### PR TITLE
Mocking improvements

### DIFF
--- a/clients/federation/client_test.go
+++ b/clients/federation/client_test.go
@@ -1,19 +1,68 @@
 package federation
 
 import (
+	"errors"
+	"net/http"
 	"testing"
 
+	"github.com/stellar/go/clients/stellartoml"
+	"github.com/stellar/go/support/http/httptest"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLookupByName(t *testing.T) {
-	// HACK: until we improve our mocking scenario, this is just a smoke test
-	// against a known federation server.  When/if it breaks, please write this
-	// test correctly.
+func TestLookupByAddress(t *testing.T) {
+	hmock := httptest.NewClient()
+	tomlmock := &stellartoml.MockClient{}
+	c := &Client{StellarTOML: tomlmock, HTTP: hmock}
 
-	r, err := DefaultPublicNetClient.LookupByAddress("nullstyle*codetip.io")
-	assert.NoError(t, err)
-	assert.Equal(t, "GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C", r.AccountID)
+	// happy path
+	tomlmock.On("GetStellarToml", "stellar.org").Return(&stellartoml.Response{
+		FederationServer: "https://stellar.org/federation",
+	}, nil)
+	hmock.On("GET", "https://stellar.org/federation").
+		ReturnJSON(http.StatusOK, map[string]string{
+			"stellar_address": "scott*stellar.org",
+			"account_id":      "GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C",
+			"memo_type":       "id",
+			"memo":            "123",
+		})
+	resp, err := c.LookupByAddress("scott*stellar.org")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, "GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C", resp.AccountID)
+		assert.Equal(t, "id", resp.MemoType)
+		assert.Equal(t, "123", resp.Memo)
+	}
+
+	// failed toml resolution
+	tomlmock.On("GetStellarToml", "missing.org").Return(
+		(*stellartoml.Response)(nil),
+		errors.New("toml failed"),
+	)
+	resp, err = c.LookupByAddress("scott*missing.org")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "toml failed")
+	}
+
+	// 404 federation response
+	tomlmock.On("GetStellarToml", "404.org").Return(&stellartoml.Response{
+		FederationServer: "https://404.org/federation",
+	}, nil)
+	hmock.On("GET", "https://404.org/federation").ReturnNotFound()
+	resp, err = c.LookupByAddress("scott*404.org")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "failed with (404)")
+	}
+
+	// connection error on federation response
+	tomlmock.On("GetStellarToml", "error.org").Return(&stellartoml.Response{
+		FederationServer: "https://error.org/federation",
+	}, nil)
+	hmock.On("GET", "https://error.org/federation").ReturnError("kaboom!")
+	resp, err = c.LookupByAddress("scott*error.org")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "kaboom!")
+	}
 }
 
 func TestLookupByID(t *testing.T) {

--- a/clients/stellartoml/client.go
+++ b/clients/stellartoml/client.go
@@ -12,11 +12,11 @@ import (
 // GetStellarToml returns stellar.toml file for a given domain
 func (c *Client) GetStellarToml(domain string) (resp *Response, err error) {
 	var hresp *http.Response
-	hresp, err = http.Get(c.url(domain))
+	hresp, err = c.HTTP.Get(c.url(domain))
 	if err != nil {
 		err = errors.Wrap(err, "http request errored")
+		return
 	}
-
 	defer hresp.Body.Close()
 
 	if !(hresp.StatusCode >= 200 && hresp.StatusCode < 300) {
@@ -27,6 +27,7 @@ func (c *Client) GetStellarToml(domain string) (resp *Response, err error) {
 	_, err = toml.DecodeReader(hresp.Body, &resp)
 	if err != nil {
 		err = errors.Wrap(err, "toml decode failed")
+		return
 	}
 
 	return

--- a/clients/stellartoml/client_test.go
+++ b/clients/stellartoml/client_test.go
@@ -1,9 +1,12 @@
 package stellartoml
 
 import (
+	"net/http"
 	"testing"
 
+	"github.com/stellar/go/support/http/httptest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClientURL(t *testing.T) {
@@ -15,4 +18,36 @@ func TestClientURL(t *testing.T) {
 
 	c = &Client{UseHTTP: true}
 	assert.Equal(t, "http://www.stellar.org/.well-known/stellar.toml", c.url("stellar.org"))
+}
+
+func TestClient(t *testing.T) {
+	h := httptest.NewClient()
+	c := &Client{HTTP: h}
+
+	// happy path
+	h.
+		On("GET", "https://www.stellar.org/.well-known/stellar.toml").
+		ReturnString(http.StatusOK,
+			`FEDERATION_SERVER="https://localhost/federation"`,
+		)
+	stoml, err := c.GetStellarToml("stellar.org")
+	require.NoError(t, err)
+	assert.Equal(t, "https://localhost/federation", stoml.FederationServer)
+
+	// not found
+	h.
+		On("GET", "https://www.missing.org/.well-known/stellar.toml").
+		ReturnNotFound()
+	stoml, err = c.GetStellarToml("missing.org")
+	assert.EqualError(t, err, "http request failed with non-200 status code")
+
+	// invalid toml
+	h.
+		On("GET", "https://www.json.org/.well-known/stellar.toml").
+		ReturnJSON(http.StatusOK, map[string]string{"hello": "world"})
+	stoml, err = c.GetStellarToml("json.org")
+
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "toml decode failed")
+	}
 }

--- a/clients/stellartoml/mocks.go
+++ b/clients/stellartoml/mocks.go
@@ -1,0 +1,20 @@
+package stellartoml
+
+import "github.com/stretchr/testify/mock"
+
+// MockClient is a mockable stellartoml client.
+type MockClient struct {
+	mock.Mock
+}
+
+// GetStellarToml is a mocking a method
+func (m *MockClient) GetStellarToml(domain string) (*Response, error) {
+	a := m.Called(domain)
+	return a.Get(0).(*Response), a.Error(1)
+}
+
+// GetStellarTomlByAddress is a mocking a method
+func (m *MockClient) GetStellarTomlByAddress(address string) (*Response, error) {
+	a := m.Called(address)
+	return a.Get(0).(*Response), a.Error(1)
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,12 @@
 hash: 1a2c587152ba60cb7753d309dc265f9a492eaf00283a78cf7a4f4e906415ba24
-updated: 2016-08-29T16:03:57.881898614-07:00
+updated: 2016-08-30T11:38:19.015089322-07:00
 imports:
 - name: github.com/agl/ed25519
   version: 278e1ec8e8a6e017cd07577924d6766039146ced
   subpackages:
   - edwards25519
+- name: github.com/ajg/form
+  version: cc2954064ec9ea8d93917f0f87456e11d7b881ad
 - name: github.com/asaskevich/govalidator
   version: 593d64559f7600f29581a3ee42177f5dbded27a9
 - name: github.com/aws/aws-sdk-go
@@ -41,14 +43,28 @@ imports:
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
+- name: github.com/fatih/structs
+  version: dc3312cb1a4513a366c4c9e622ad55c32df12ed3
+- name: github.com/gavv/gojsondiff
+  version: 36046c6e558e7f854ebd3fd97d1e9812ebe8709b
+  subpackages:
+  - formatter
+- name: github.com/gavv/monotime
+  version: 259cd7b345f5aa080eff16f21d7866ef7dea9528
 - name: github.com/getsentry/raven-go
   version: c9d3cc542ad199f62c0264286be537f9bce6063c
 - name: github.com/go-ini/ini
   version: a2610b3a793cfa7fdf0b07038068af5ddc12aba1
 - name: github.com/go-sql-driver/mysql
   version: 0b58b37b664c21f3010e836f1b931e1d0b0b0685
+- name: github.com/google/go-querystring
+  version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
+  subpackages:
+  - query
 - name: github.com/howeyc/gopass
   version: b63a7d07e65df376d14e2d72907a93d4847dffe4
+- name: github.com/imkira/go-interpol
+  version: b9781c93ae51c8b4fc3af1b1426909721af0a624
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jarcoal/httpmock
@@ -59,6 +75,16 @@ imports:
   version: 7396209bbeada6a4fcc28aa9408f89b2e71cac39
   subpackages:
   - reflectx
+- name: github.com/klauspost/compress
+  version: 14eb9c4951195779ecfbec34431a976de7335b0a
+  subpackages:
+  - flate
+  - gzip
+  - zlib
+- name: github.com/klauspost/cpuid
+  version: 09cded8978dc9e80714c4d85b0322337b0a1e5e0
+- name: github.com/klauspost/crc32
+  version: 19b0b332c9e4516a6370a0456e6182c3b5036720
 - name: github.com/lann/builder
   version: f22ce00fd9394014049dad11c244859432bd6820
 - name: github.com/lann/ps
@@ -71,6 +97,8 @@ imports:
   - oid
 - name: github.com/mattn/go-sqlite3
   version: c3e9588849195eefa783417c3a53d092f6e93526
+- name: github.com/moul/http2curl
+  version: b1479103caacaa39319f75e7f57fc545287fca0d
 - name: github.com/nullstyle/go-xdr
   version: 8bf8a5d05c8612d4039a7f67ddce3d49ee61b398
   subpackages:
@@ -119,6 +147,10 @@ imports:
   version: ed27b6fd65218132ee50cd95f38474a3d8a2cd12
 - name: github.com/segmentio/go-loggly
   version: e78f6971ebca5835614673e2f5f6a47ca5f13501
+- name: github.com/sergi/go-diff
+  version: 97b2266dfe4bd4ea1b81a463322f04f8b724801e
+  subpackages:
+  - diffmatchpatch
 - name: github.com/Sirupsen/logrus
   version: a283a10442df8dc09befd873fab202bf8a253d6a
 - name: github.com/spf13/cobra
@@ -133,8 +165,24 @@ imports:
   - mock
   - assert
   - require
+- name: github.com/valyala/bytebufferpool
+  version: 8ebd0474e5a2f0a5c7a74ad2bf421a1d1a90264f
+- name: github.com/valyala/fasthttp
+  version: 45697fe30a130ec6a54426a069c82f3abe76b63d
+  subpackages:
+  - fasthttputil
 - name: github.com/visionmedia/go-debug
   version: ff4a55a20a86994118644bbddc6a216da193cc13
+- name: github.com/xeipuuv/gojsonpointer
+  version: e0fe6f68307607d540ed8eac07a342c33fa1b54a
+- name: github.com/xeipuuv/gojsonreference
+  version: e02fc20de94c78484cd5ffb007f8af96be030a45
+- name: github.com/xeipuuv/gojsonschema
+  version: 4f624f6197547606054e042e7903db103585e151
+- name: github.com/yalp/jsonpath
+  version: 31a79c7593bb93eb10b163650d4a3e6ca190e4dc
+- name: github.com/yudai/golcs
+  version: d1c525dea8ce39ea9a783d33cf08932305373f2c
 - name: goji.io
   version: e355964ac565b94cf0fc7f218346626529125086
   subpackages:
@@ -152,6 +200,7 @@ imports:
   - http2
   - http2/hpack
   - lex/httplex
+  - publicsuffix
 - name: golang.org/x/sys
   version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,10 @@
-hash: 9c1652a73f35bbad40c76ccfd9a7460bdf9cbecf9a54bc849bbfde8dd5d52011
-updated: 2016-08-17T08:31:13.332086432-07:00
+hash: 1a2c587152ba60cb7753d309dc265f9a492eaf00283a78cf7a4f4e906415ba24
+updated: 2016-08-29T16:03:57.881898614-07:00
 imports:
 - name: github.com/agl/ed25519
   version: 278e1ec8e8a6e017cd07577924d6766039146ced
   subpackages:
   - edwards25519
-- name: github.com/ajg/form
-  version: cc2954064ec9ea8d93917f0f87456e11d7b881ad
 - name: github.com/asaskevich/govalidator
   version: 593d64559f7600f29581a3ee42177f5dbded27a9
 - name: github.com/aws/aws-sdk-go
@@ -43,46 +41,24 @@ imports:
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
-- name: github.com/fatih/structs
-  version: dc3312cb1a4513a366c4c9e622ad55c32df12ed3
-- name: github.com/gavv/gojsondiff
-  version: 36046c6e558e7f854ebd3fd97d1e9812ebe8709b
-  subpackages:
-  - formatter
-- name: github.com/gavv/monotime
-  version: 259cd7b345f5aa080eff16f21d7866ef7dea9528
 - name: github.com/getsentry/raven-go
   version: c9d3cc542ad199f62c0264286be537f9bce6063c
 - name: github.com/go-ini/ini
   version: a2610b3a793cfa7fdf0b07038068af5ddc12aba1
 - name: github.com/go-sql-driver/mysql
   version: 0b58b37b664c21f3010e836f1b931e1d0b0b0685
-- name: github.com/google/go-querystring
-  version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
-  subpackages:
-  - query
 - name: github.com/howeyc/gopass
   version: b63a7d07e65df376d14e2d72907a93d4847dffe4
-- name: github.com/imkira/go-interpol
-  version: b9781c93ae51c8b4fc3af1b1426909721af0a624
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/jarcoal/httpmock
+  version: 145b10d659265440f062c31ea15326166bae56ee
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/jmoiron/sqlx
   version: 7396209bbeada6a4fcc28aa9408f89b2e71cac39
   subpackages:
   - reflectx
-- name: github.com/klauspost/compress
-  version: 14eb9c4951195779ecfbec34431a976de7335b0a
-  subpackages:
-  - flate
-  - gzip
-  - zlib
-- name: github.com/klauspost/cpuid
-  version: 09cded8978dc9e80714c4d85b0322337b0a1e5e0
-- name: github.com/klauspost/crc32
-  version: 19b0b332c9e4516a6370a0456e6182c3b5036720
 - name: github.com/lann/builder
   version: f22ce00fd9394014049dad11c244859432bd6820
 - name: github.com/lann/ps
@@ -95,14 +71,12 @@ imports:
   - oid
 - name: github.com/mattn/go-sqlite3
   version: c3e9588849195eefa783417c3a53d092f6e93526
-- name: github.com/moul/http2curl
-  version: b1479103caacaa39319f75e7f57fc545287fca0d
 - name: github.com/nullstyle/go-xdr
   version: 8bf8a5d05c8612d4039a7f67ddce3d49ee61b398
   subpackages:
   - xdr3
 - name: github.com/onsi/ginkgo
-  version: 120efcfd33906beedc53369a8659c41cc9190e81
+  version: 43e2af1f01ace55adbb6d7d0f30416476db1baae
   subpackages:
   - extensions/table
   - config
@@ -120,7 +94,7 @@ imports:
   - internal/spec
   - internal/specrunner
 - name: github.com/onsi/gomega
-  version: 9ed8da19f2156b87a803a8fdf6d126f627a12db1
+  version: b48c9a8b2644326d0a44eaaacc8d83e35174a05d
   subpackages:
   - types
   - internal/assertion
@@ -134,7 +108,7 @@ imports:
   - matchers/support/goraph/node
   - matchers/support/goraph/util
 - name: github.com/pkg/errors
-  version: 01fa4104b9c248c8945d14d9f128454d5b28d595
+  version: 17b591df37844cde689f4d5813e5cea0927d8dd2
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -145,39 +119,22 @@ imports:
   version: ed27b6fd65218132ee50cd95f38474a3d8a2cd12
 - name: github.com/segmentio/go-loggly
   version: e78f6971ebca5835614673e2f5f6a47ca5f13501
-- name: github.com/sergi/go-diff
-  version: 97b2266dfe4bd4ea1b81a463322f04f8b724801e
-  subpackages:
-  - diffmatchpatch
 - name: github.com/Sirupsen/logrus
   version: a283a10442df8dc09befd873fab202bf8a253d6a
 - name: github.com/spf13/cobra
   version: 7c674d9e72017ed25f6d2b5e497a1368086b6a6f
 - name: github.com/spf13/pflag
   version: f676131e2660dc8cd88de99f7486d34aa8172635
+- name: github.com/stretchr/objx
+  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
   version: d77da356e56a7428ad25149ca77381849a6a5232
   subpackages:
+  - mock
   - assert
   - require
-- name: github.com/valyala/bytebufferpool
-  version: 8ebd0474e5a2f0a5c7a74ad2bf421a1d1a90264f
-- name: github.com/valyala/fasthttp
-  version: 45697fe30a130ec6a54426a069c82f3abe76b63d
-  subpackages:
-  - fasthttputil
 - name: github.com/visionmedia/go-debug
   version: ff4a55a20a86994118644bbddc6a216da193cc13
-- name: github.com/xeipuuv/gojsonpointer
-  version: e0fe6f68307607d540ed8eac07a342c33fa1b54a
-- name: github.com/xeipuuv/gojsonreference
-  version: e02fc20de94c78484cd5ffb007f8af96be030a45
-- name: github.com/xeipuuv/gojsonschema
-  version: 4f624f6197547606054e042e7903db103585e151
-- name: github.com/yalp/jsonpath
-  version: 31a79c7593bb93eb10b163650d4a3e6ca190e4dc
-- name: github.com/yudai/golcs
-  version: d1c525dea8ce39ea9a783d33cf08932305373f2c
 - name: goji.io
   version: e355964ac565b94cf0fc7f218346626529125086
   subpackages:
@@ -195,7 +152,6 @@ imports:
   - http2
   - http2/hpack
   - lex/httplex
-  - publicsuffix
 - name: golang.org/x/sys
   version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,8 +7,10 @@ import:
   version: ^0.7.0
 - package: github.com/getsentry/raven-go
 - package: github.com/segmentio/go-loggly
-- package: golang.org/x/net/context
-- package: golang.org/x/net/http2
+- package: golang.org/x/net
+  subpackages:
+  - context
+  - http2
 - package: github.com/stretchr/testify
 - package: github.com/jmoiron/sqlx
 - package: github.com/lann/squirrel
@@ -26,4 +28,7 @@ import:
   version: master
 - package: github.com/onsi/gomega
   version: master
-- package: github.com/aws/aws-sdk-go/aws
+- package: github.com/aws/aws-sdk-go
+  subpackages:
+  - aws
+- package: github.com/jarcoal/httpmock

--- a/support/http/httptest/client.go
+++ b/support/http/httptest/client.go
@@ -1,0 +1,10 @@
+package httptest
+
+// On is the entrypoint method into this packages "client" mocking system.
+func (c *Client) On(method string, url string) *ClientExpectation {
+	return &ClientExpectation{
+		Method: method,
+		URL:    url,
+		Client: c,
+	}
+}

--- a/support/http/httptest/client_expectation.go
+++ b/support/http/httptest/client_expectation.go
@@ -1,0 +1,52 @@
+package httptest
+
+import (
+	"net/http"
+
+	"github.com/jarcoal/httpmock"
+)
+
+// Return specifies the response for a ClientExpectation, which is then
+// committed to the connected mock client.
+func (ce *ClientExpectation) Return(r httpmock.Responder) *ClientExpectation {
+	ce.Client.MockTransport.RegisterResponder(
+		ce.Method,
+		ce.URL,
+		r,
+	)
+	return ce
+}
+
+// ReturnString causes this expectation to resolve to a string-based body with
+// the provided status code.
+func (ce *ClientExpectation) ReturnString(
+	status int,
+	body string,
+) *ClientExpectation {
+	return ce.Return(
+		httpmock.NewStringResponder(status, body),
+	)
+}
+
+// ReturnText causes this expectation to resolve to a json-based body with the
+// provided status code.  Panics when the provided body cannot be encoded to
+// JSON.
+func (ce *ClientExpectation) ReturnJSON(
+	status int,
+	body interface{},
+) *ClientExpectation {
+
+	r, err := httpmock.NewJsonResponder(status, body)
+	if err != nil {
+		panic(err)
+	}
+
+	return ce.Return(r)
+}
+
+// ReturnNotFound is a simple helper that causes this expectation to resolve to
+// a 404 error.  If a customized body is needed, use something like
+// `ReturnString`` instead.
+func (ce *ClientExpectation) ReturnNotFound() *ClientExpectation {
+	return ce.ReturnString(http.StatusNotFound, "not found")
+}

--- a/support/http/httptest/client_expectation.go
+++ b/support/http/httptest/client_expectation.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/jarcoal/httpmock"
+	"github.com/stellar/go/support/errors"
 )
 
 // Return specifies the response for a ClientExpectation, which is then
@@ -15,6 +16,13 @@ func (ce *ClientExpectation) Return(r httpmock.Responder) *ClientExpectation {
 		r,
 	)
 	return ce
+}
+
+// ReturnError causes this expectation to resolve to an error.
+func (ce *ClientExpectation) ReturnError(msg string) *ClientExpectation {
+	return ce.Return(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New(msg)
+	})
 }
 
 // ReturnString causes this expectation to resolve to a string-based body with

--- a/support/http/httptest/main.go
+++ b/support/http/httptest/main.go
@@ -1,6 +1,21 @@
 // Package httptest enhances the stdlib net/http/httptest package by integrating
 // it with gopkg.in/gavv/httpexpect.v1, reducing the boilerplate needed for http
-// tests
+// tests.  In addition to the functions that make it easier to stand up a test
+// server, this package also provides a set of tools to make it easier to mock
+// out http client responses.
+//
+// Test Servers vs. Client mocking
+//
+// When building a testing fixture for HTTP, you can approach the problem in two
+// ways:  Use a mocked server and make real http requests to the server, or use
+// a mocked client and have _no_ server.  While this package provides facilities
+// for both, we recommend that you follow the conventions for decided which to
+// use in your tests.
+//
+// The test server system should be used when the object under test is our own
+// server code; usually that means our own http.Handler implementations.  The
+// mocked client system should be used when the object under test is making http
+// requests.
 package httptest
 
 import (
@@ -8,14 +23,43 @@ import (
 	stdtest "net/http/httptest"
 	"testing"
 
+	"github.com/jarcoal/httpmock"
 	"gopkg.in/gavv/httpexpect.v1"
 )
+
+// Client represents an easier way to mock http client behavior.  It assumes
+// that your packages use interfaces to store an http client instead of a
+// concrete *http.Client.
+type Client struct {
+	*http.Client
+	*httpmock.MockTransport
+}
+
+// ClientExpectation represents a in-process-of-being-built http client mocking
+// operation.  The `On` method of `Client` returns an instance of this struct
+// upon which you can call further methods to customize the response.
+type ClientExpectation struct {
+	Method string
+	URL    string
+	Client *Client
+}
 
 type Server struct {
 	*httpexpect.Expect
 	*stdtest.Server
 }
 
+// NewClient returns a new mocked http client.  A value being tested can be
+// configured to use this http client allowing the tester to control the server
+// responses without needing to run an actual server.
+func NewClient() *Client {
+	var result Client
+	result.MockTransport = httpmock.NewMockTransport()
+	result.Client = &http.Client{Transport: result.MockTransport}
+	return &result
+}
+
+// NewServer returns a new test server instance using the provided handler.
 func NewServer(t *testing.T, handler http.Handler) *Server {
 	server := stdtest.NewServer(handler)
 	return &Server{


### PR DESCRIPTION
This PR adds a number of improvements to mocking, while fixing some small errors.

The `httptest` package gained the `Client` type that allows for mocked http clients in tests, and the `clients/stellartoml` package got a `MockClient` that consumers of the package can use in their tests.