### PR TITLE
Horizon client updates

### DIFF
--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -1,0 +1,141 @@
+package horizon
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/stellar/go/xdr"
+)
+
+// HomeDomainForAccount returns the home domain for the provided strkey-encoded
+// account id.
+func (c *Client) HomeDomainForAccount(aid string) (string, error) {
+	a, err := c.LoadAccount(aid)
+	if err != nil {
+		return "", errors.Wrap(err, "load account failed")
+	}
+	return a.HomeDomain, nil
+}
+
+// LoadAccount loads the account state from horizon. err can be either error
+// object or horizon.Error object.
+func (c *Client) LoadAccount(accountID string) (account Account, err error) {
+	resp, err := c.HTTP.Get(c.URL + "/accounts/" + accountID)
+	if err != nil {
+		return
+	}
+
+	err = decodeResponse(resp, &account)
+	return
+}
+
+// LoadMemo loads memo for a transaction in PaymentResponse
+func (c *Client) LoadMemo(p *PaymentResponse) (err error) {
+	res, err := c.HTTP.Get(p.Links.Transaction.Href)
+	if err != nil {
+		return errors.Wrap(err, "load transaciton failed")
+	}
+	defer res.Body.Close()
+	return json.NewDecoder(res.Body).Decode(&p.Memo)
+}
+
+// SequenceForAccount implements build.SequenceProvider
+func (c *Client) SequenceForAccount(
+	accountID string,
+) (xdr.SequenceNumber, error) {
+
+	a, err := c.LoadAccount(accountID)
+	if err != nil {
+		return 0, errors.Wrap(err, "load account failed")
+	}
+
+	seq, err := strconv.ParseUint(a.Sequence, 10, 64)
+	if err != nil {
+		return 0, errors.Wrap(err, "parse sequence failed")
+	}
+
+	return xdr.SequenceNumber(seq), nil
+}
+
+// StreamPayments streams incoming payments
+func (c *Client) StreamPayments(accountID string, cursor *string, onPaymentHandler PaymentHandler) (err error) {
+	url := c.URL + "/accounts/" + accountID + "/payments"
+	if cursor != nil {
+		url += "?cursor=" + *cursor
+	}
+
+	req, _ := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Split(splitSSE)
+
+	for scanner.Scan() {
+		if len(scanner.Bytes()) == 0 {
+			continue
+		}
+
+		ev, err := parseEvent(scanner.Bytes())
+		if err != nil {
+			return err
+		}
+
+		if ev.Event != "message" {
+			continue
+		}
+
+		var payment PaymentResponse
+		data := ev.Data.(string)
+		err = json.Unmarshal([]byte(data), &payment)
+		if err != nil {
+			return err
+		}
+
+		onPaymentHandler(payment)
+	}
+
+	err = scanner.Err()
+	if err == io.ErrUnexpectedEOF {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SubmitTransaction submits a transaction to the network. err can be either error object or horizon.Error object.
+func (c *Client) SubmitTransaction(
+	transactionEnvelopeXdr string,
+) (response TransactionSuccess, err error) {
+	v := url.Values{}
+	v.Set("tx", transactionEnvelopeXdr)
+
+	resp, err := c.HTTP.PostForm(c.URL+"/transactions", v)
+	if err != nil {
+		err = errors.Wrap(err, "http post failed")
+		return
+	}
+
+	err = decodeResponse(resp, &response)
+	if err != nil {
+		err = errors.Wrap(err, "decode response failed")
+		return
+	}
+
+	return
+}

--- a/clients/horizon/error.go
+++ b/clients/horizon/error.go
@@ -1,0 +1,6 @@
+package horizon
+
+func (err *Error) Error() string {
+	// TODO: use the attached problem to provide a better error message
+	return "Horizon error"
+}

--- a/clients/horizon/internal.go
+++ b/clients/horizon/internal.go
@@ -1,0 +1,72 @@
+package horizon
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"github.com/manucorporat/sse"
+)
+
+var endEvent = regexp.MustCompile("(\r\n|\r|\n){2}")
+
+func decodeResponse(resp *http.Response, object interface{}) (err error) {
+	defer resp.Body.Close()
+	decoder := json.NewDecoder(resp.Body)
+
+	if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
+		horizonError := &Error{
+			Response: resp,
+		}
+		decodeError := decoder.Decode(&horizonError.Problem)
+		if decodeError != nil {
+			return decodeError
+		}
+		return horizonError
+	}
+
+	err = decoder.Decode(&object)
+	if err != nil {
+		return
+	}
+	return
+}
+
+func loadMemo(p *PaymentResponse) error {
+	res, err := http.Get(p.Links.Transaction.Href)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	return json.NewDecoder(res.Body).Decode(&p.Memo)
+}
+
+func parseEvent(data []byte) (result sse.Event, err error) {
+	r := bytes.NewReader(data)
+	events, err := sse.Decode(r)
+	if err != nil {
+		return
+	}
+
+	if len(events) != 1 {
+		err = fmt.Errorf("only expected 1 event, got: %d", len(events))
+		return
+	}
+
+	result = events[0]
+	return
+}
+
+func splitSSE(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF {
+		return 0, nil, nil
+	}
+
+	if loc := endEvent.FindIndex(data); loc != nil {
+		return loc[1], data[0:loc[1]], nil
+	}
+
+	return 0, nil, nil
+}

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -7,21 +7,32 @@
 package horizon
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/url"
-	"strconv"
-	"sync"
 
-	"github.com/stellar/go/support/errors"
-	"github.com/stellar/go/xdr"
+	"github.com/stellar/go/build"
 )
 
 // DefaultTestNetClient is a default client to connect to test network
-var DefaultTestNetClient = &Client{URL: "https://horizon-testnet.stellar.org"}
+var DefaultTestNetClient = &Client{
+	URL:  "https://horizon-testnet.stellar.org",
+	HTTP: http.DefaultClient,
+}
 
 // DefaultPublicNetClient is a default client to connect to public network
-var DefaultPublicNetClient = &Client{URL: "https://horizon.stellar.org"}
+var DefaultPublicNetClient = &Client{
+	URL:  "https://horizon.stellar.org",
+	HTTP: http.DefaultClient,
+}
+
+// Client struct contains data required to connect to Horizon instance
+type Client struct {
+	// URL of Horizon server to connect
+	URL string
+
+	// HTTP client to make requests with
+	HTTP HTTP
+}
 
 // Error struct contains the problem returned by Horizon
 type Error struct {
@@ -29,107 +40,15 @@ type Error struct {
 	Problem  Problem
 }
 
-func (herror *Error) Error() string {
-	return "Horizon error"
-}
-
-type HorizonHttpClient interface {
+// HTTP represents the HTTP client that a horizon client uses to communicate
+type HTTP interface {
+	Do(req *http.Request) (resp *http.Response, err error)
 	Get(url string) (resp *http.Response, err error)
 	PostForm(url string, data url.Values) (resp *http.Response, err error)
 }
 
-// Client struct contains data required to connect to Horizon instance
-type Client struct {
-	// URL of Horizon server to connect
-	URL string
-	// Will be populated with &http.Client when nil. If you want to configure your http.Client make sure Timeout is at least 10 seconds.
-	Client HorizonHttpClient
-	// clientInit initializes http client once
-	clientInit sync.Once
-}
+// PaymentHandler is a function that is called when a new payment is received
+type PaymentHandler func(PaymentResponse)
 
-// HomeDomainForAccount returns the home domain for the provided strkey-encoded
-// account id.
-func (c *Client) HomeDomainForAccount(aid string) (string, error) {
-	a, err := c.LoadAccount(aid)
-	if err != nil {
-		return "", errors.Wrap(err, "load account failed")
-	}
-	return a.HomeDomain, nil
-}
-
-// LoadAccount loads the account state from horizon. err can be either error
-// object or horizon.Error object.
-func (c *Client) LoadAccount(accountID string) (account Account, err error) {
-	c.initHttpClient()
-	resp, err := c.Client.Get(c.URL + "/accounts/" + accountID)
-	if err != nil {
-		return
-	}
-
-	err = decodeResponse(resp, &account)
-	return
-}
-
-// SequenceForAccount implements build.SequenceProvider
-func (c *Client) SequenceForAccount(
-	accountID string,
-) (xdr.SequenceNumber, error) {
-
-	a, err := c.LoadAccount(accountID)
-	if err != nil {
-		return 0, err
-	}
-
-	seq, err := strconv.ParseUint(a.Sequence, 10, 64)
-	if err != nil {
-		return 0, err
-	}
-
-	return xdr.SequenceNumber(seq), nil
-}
-
-// SubmitTransaction submits a transaction to the network. err can be either error object or horizon.Error object.
-func (c *Client) SubmitTransaction(transactionEnvelopeXdr string) (response TransactionSuccess, err error) {
-	v := url.Values{}
-	v.Set("tx", transactionEnvelopeXdr)
-
-	c.initHttpClient()
-	resp, err := c.Client.PostForm(c.URL+"/transactions", v)
-	if err != nil {
-		return
-	}
-
-	err = decodeResponse(resp, &response)
-	return
-}
-
-func (c *Client) initHttpClient() {
-	c.clientInit.Do(func() {
-		if c.Client == nil {
-			c.Client = &http.Client{}
-		}
-	})
-}
-
-func decodeResponse(resp *http.Response, object interface{}) (err error) {
-	defer resp.Body.Close()
-	decoder := json.NewDecoder(resp.Body)
-
-	if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
-		horizonError := &Error{
-			Response: resp,
-		}
-		decodeError := decoder.Decode(&horizonError.Problem)
-		if decodeError != nil {
-			return decodeError
-		}
-		return horizonError
-	}
-
-	err = decoder.Decode(&object)
-	if err != nil {
-		return
-	}
-	return
-}
+// ensure that the horizon client can be used as a SequenceProvider
+var _ build.SequenceProvider = &Client{}

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -1,0 +1,32 @@
+package horizon
+
+import "github.com/stretchr/testify/mock"
+
+// MockClient is a mockable horizon client.
+type MockClient struct {
+	mock.Mock
+}
+
+// LoadAccount is a mocking a method
+func (m *MockClient) LoadAccount(accountID string) (Account, error) {
+	a := m.Called(accountID)
+	return a.Get(0).(Account), a.Error(1)
+}
+
+// LoadMemo is a mocking a method
+func (m *MockClient) LoadMemo(p *PaymentResponse) error {
+	a := m.Called(p)
+	return a.Error(0)
+}
+
+// StreamPayments is a mocking a method
+func (m *MockClient) StreamPayments(accountID string, cursor *string, onPaymentHandler PaymentHandler) error {
+	a := m.Called(accountID, cursor, onPaymentHandler)
+	return a.Error(0)
+}
+
+// SubmitTransaction is a mocking a method
+func (m *MockClient) SubmitTransaction(txeBase64 string) (TransactionSuccess, error) {
+	a := m.Called(txeBase64)
+	return a.Get(0).(TransactionSuccess), a.Error(1)
+}

--- a/clients/horizon/responses.go
+++ b/clients/horizon/responses.go
@@ -74,6 +74,7 @@ type Link struct {
 	Templated bool   `json:"templated,omitempty"`
 }
 
+
 type TransactionSuccess struct {
 	Links struct {
 		Transaction Link `json:"transaction"`
@@ -88,4 +89,30 @@ type TransactionSuccess struct {
 type Signer struct {
 	PublicKey string `json:"public_key"`
 	Weight    int32  `json:"weight"`
+}
+
+type PaymentResponse struct {
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	PagingToken string `json:"paging_token"`
+
+	Links struct {
+		Transaction struct {
+			Href string `json:"href"`
+		} `json:"transaction"`
+	} `json:"_links"`
+
+	// payment/path_payment fields
+	From        string `json:"from"`
+	To          string `json:"to"`
+	AssetType   string `json:"asset_type"`
+	AssetCode   string `json:"asset_code"`
+	AssetIssuer string `json:"asset_issuer"`
+	Amount      string `json:"amount"`
+
+	// transaction fields
+	Memo struct {
+		Type  string `json:"memo_type"`
+		Value string `json:"memo"`
+	}
 }

--- a/clients/stellartoml/main.go
+++ b/clients/stellartoml/main.go
@@ -33,3 +33,14 @@ type Response struct {
 	EncryptionKey    string `toml:"ENCRYPTION_KEY"`
 	SigningKey       string `toml:"SIGNING_KEY"`
 }
+
+// GetStellarToml returns stellar.toml file for a given domain
+func GetStellarToml(domain string) (*Response, error) {
+	return DefaultClient.GetStellarToml(domain)
+}
+
+// GetStellarTomlByAddress returns stellar.toml file of a domain fetched from a
+// given address
+func GetStellarTomlByAddress(addy string) (*Response, error) {
+	return DefaultClient.GetStellarTomlByAddress(addy)
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 1a2c587152ba60cb7753d309dc265f9a492eaf00283a78cf7a4f4e906415ba24
-updated: 2016-08-30T11:38:19.015089322-07:00
+hash: 16fe0b731a9a76e736f87e7f34179ad3ccd2dc577a95067f5c39f035ee350e79
+updated: 2016-08-30T14:06:41.303176771-07:00
 imports:
 - name: github.com/agl/ed25519
   version: 278e1ec8e8a6e017cd07577924d6766039146ced
@@ -95,6 +95,8 @@ imports:
   version: 80f8150043c80fb52dee6bc863a709cdac7ec8f8
   subpackages:
   - oid
+- name: github.com/manucorporat/sse
+  version: ee05b128a739a0fb76c7ebd3ae4810c1de808d6d
 - name: github.com/mattn/go-sqlite3
   version: c3e9588849195eefa783417c3a53d092f6e93526
 - name: github.com/moul/http2curl

--- a/glide.yaml
+++ b/glide.yaml
@@ -32,3 +32,4 @@ import:
   subpackages:
   - aws
 - package: github.com/jarcoal/httpmock
+- package: github.com/manucorporat/sse


### PR DESCRIPTION
This PR brings in some of the added features (such as streaming payments) from the bridge-server horizon client.  In addition:

- I've improved some of the error handling using our support package
- Changed member names to be the same as our other clients
- Fixed some random re-creations of http clients
- Removing logging statements that are better surfaced elsewhere
- Updated the tests to use our http client mocking system
- Added a mock client for use in other packages' tests
