### PR TITLE
clients/horizon: Add `Envelope()` and `ResultCodes()` to `Error`

### DIFF
--- a/clients/horizon/error.go
+++ b/clients/horizon/error.go
@@ -37,8 +37,6 @@ func (herr *Error) Envelope() (*xdr.TransactionEnvelope, error) {
 }
 
 // ResultCodes extracts a result code summary from the error, if possible.
-// NOTE: this method will panic if the input that was received from horizon is
-// invalid.
 func (herr *Error) ResultCodes() (*TransactionResultCodes, error) {
 	if herr.Problem.Type != "transaction_failed" {
 		return nil, ErrTransactionNotFailed

--- a/clients/horizon/error.go
+++ b/clients/horizon/error.go
@@ -1,6 +1,59 @@
 package horizon
 
-func (err *Error) Error() string {
+import (
+	"encoding/json"
+
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+func (herr *Error) Error() string {
 	// TODO: use the attached problem to provide a better error message
 	return "Horizon error"
+}
+
+// Envelope extracts the transaction envelope that triggered this error from the
+// extra fields.
+func (herr *Error) Envelope() (*xdr.TransactionEnvelope, error) {
+	raw, ok := herr.Problem.Extras["envelope_xdr"]
+	if !ok {
+		return nil, ErrEnvelopeNotPopulated
+	}
+
+	var b64 string
+	var result xdr.TransactionEnvelope
+
+	err := json.Unmarshal(raw, &b64)
+	if err != nil {
+		return nil, errors.Wrap(err, "json decode failed")
+	}
+
+	err = xdr.SafeUnmarshalBase64(b64, &result)
+	if err != nil {
+		return nil, errors.Wrap(err, "xdr decode failed")
+	}
+
+	return &result, nil
+}
+
+// ResultCodes extracts a result code summary from the error, if possible.
+// NOTE: this method will panic if the input that was received from horizon is
+// invalid.
+func (herr *Error) ResultCodes() (*TransactionResultCodes, error) {
+	if herr.Problem.Type != "transaction_failed" {
+		return nil, ErrTransactionNotFailed
+	}
+
+	raw, ok := herr.Problem.Extras["result_codes"]
+	if !ok {
+		return nil, ErrResultCodesNotPopulated
+	}
+
+	var result TransactionResultCodes
+	err := json.Unmarshal(raw, &result)
+	if err != nil {
+		return nil, errors.Wrap(err, "json decode failed")
+	}
+
+	return &result, nil
 }

--- a/clients/horizon/error_test.go
+++ b/clients/horizon/error_test.go
@@ -1,0 +1,71 @@
+package horizon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestError_ResultCodes(t *testing.T) {
+	var herr Error
+
+	// happy path: transaction_failed with the appropriate extra fields
+	herr.Problem.Type = "transaction_failed"
+	herr.Problem.Extras = make(map[string]json.RawMessage)
+	herr.Problem.Extras["result_codes"] = json.RawMessage(`{
+    "transaction": "tx_failed",
+    "operations": ["op_underfunded"]
+  }`)
+
+	trc, err := herr.ResultCodes()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "tx_failed", trc.TransactionCode)
+
+		if assert.Len(t, trc.OperationCodes, 1) {
+			assert.Equal(t, "op_underfunded", trc.OperationCodes[0])
+		}
+	}
+
+	// sad path: !transaction_failed
+	herr.Problem.Type = "transaction_success"
+	herr.Problem.Extras = make(map[string]json.RawMessage)
+	_, err = herr.ResultCodes()
+	assert.Equal(t, ErrTransactionNotFailed, err)
+
+	// sad path: missing result_codes extra
+	herr.Problem.Type = "transaction_failed"
+	herr.Problem.Extras = make(map[string]json.RawMessage)
+	_, err = herr.ResultCodes()
+	assert.Equal(t, ErrResultCodesNotPopulated, err)
+
+	// sad path: unparseable result_codes extra
+	herr.Problem.Type = "transaction_failed"
+	herr.Problem.Extras = make(map[string]json.RawMessage)
+	herr.Problem.Extras["result_codes"] = json.RawMessage(`kaboom`)
+	_, err = herr.ResultCodes()
+	assert.Error(t, err)
+}
+
+func TestError_Envelope(t *testing.T) {
+	var herr Error
+
+	// happy path: transaction_failed with the appropriate extra fields
+	herr.Problem.Type = "transaction_failed"
+	herr.Problem.Extras = make(map[string]json.RawMessage)
+	herr.Problem.Extras["envelope_xdr"] = json.RawMessage(`"AAAAADSMMRmQGDH6EJzkgi/7PoKhphMHyNGQgDp2tlS/dhGXAAAAZAAT3TUAAAAwAAAAAAAAAAAAAAABAAAAAAAAAAMAAAABSU5SAAAAAAA0jDEZkBgx+hCc5IIv+z6CoaYTB8jRkIA6drZUv3YRlwAAAAFVU0QAAAAAADSMMRmQGDH6EJzkgi/7PoKhphMHyNGQgDp2tlS/dhGXAAAAAAX14QAAAAAKAAAAAQAAAAAAAAAAAAAAAAAAAAG/dhGXAAAAQLuStfImg0OeeGAQmvLkJSZ1MPSkCzCYNbGqX5oYNuuOqZ5SmWhEsC7uOD9ha4V7KengiwNlc0oMNqBVo22S7gk="`)
+
+	_, err := herr.Envelope()
+	assert.NoError(t, err)
+
+	// sad path: missing envelope_xdr extra
+	herr.Problem.Extras = make(map[string]json.RawMessage)
+	_, err = herr.Envelope()
+	assert.Equal(t, ErrEnvelopeNotPopulated, err)
+
+	// sad path: unparseable envelope_xdr extra
+	herr.Problem.Extras = make(map[string]json.RawMessage)
+	herr.Problem.Extras["envelope+xdr"] = json.RawMessage(`"AAAAADSMMRmQGDH6EJzkgi"`)
+	_, err = herr.Envelope()
+	assert.Error(t, err)
+}

--- a/clients/horizon/error_test.go
+++ b/clients/horizon/error_test.go
@@ -65,7 +65,9 @@ func TestError_Envelope(t *testing.T) {
 
 	// sad path: unparseable envelope_xdr extra
 	herr.Problem.Extras = make(map[string]json.RawMessage)
-	herr.Problem.Extras["envelope+xdr"] = json.RawMessage(`"AAAAADSMMRmQGDH6EJzkgi"`)
+	herr.Problem.Extras["envelope_xdr"] = json.RawMessage(`"AAAAADSMMRmQGDH6EJzkgi"`)
 	_, err = herr.Envelope()
-	assert.Error(t, err)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "xdr decode")
+	}
 }

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 
 	"github.com/stellar/go/build"
+	"github.com/stellar/go/support/errors"
 )
 
 // DefaultTestNetClient is a default client to connect to test network
@@ -24,6 +25,22 @@ var DefaultPublicNetClient = &Client{
 	URL:  "https://horizon.stellar.org",
 	HTTP: http.DefaultClient,
 }
+
+var (
+	// ErrTransactionNotFailed is the error returned from a call to ResultCodes()
+	// against a `Problem` value that is not of type "transaction_failed".
+	ErrTransactionNotFailed = errors.New("cannot get result codes from transaction that did not fail")
+
+	// ErrResultCodesNotPopulated is the error returned from a call to
+	// ResultCodes() against a `Problem` value that doesn't have the
+	// "result_codes" extra field populated when it is expected to be.
+	ErrResultCodesNotPopulated = errors.New("result_codes not populated")
+
+	// ErrEnvelopeNotPopulated is the error returned from a call to
+	// Envelope() against a `Problem` value that doesn't have the
+	// "envelope_xdr" extra field populated when it is expected to be.
+	ErrEnvelopeNotPopulated = errors.New("envelope_xdr not populated")
+)
 
 // Client struct contains data required to connect to Horizon instance
 type Client struct {

--- a/clients/horizon/responses.go
+++ b/clients/horizon/responses.go
@@ -1,12 +1,14 @@
 package horizon
 
+import "encoding/json"
+
 type Problem struct {
-	Type     string                 `json:"type"`
-	Title    string                 `json:"title"`
-	Status   int                    `json:"status"`
-	Detail   string                 `json:"detail,omitempty"`
-	Instance string                 `json:"instance,omitempty"`
-	Extras   map[string]interface{} `json:"extras,omitempty"`
+	Type     string                     `json:"type"`
+	Title    string                     `json:"title"`
+	Status   int                        `json:"status"`
+	Detail   string                     `json:"detail,omitempty"`
+	Instance string                     `json:"instance,omitempty"`
+	Extras   map[string]json.RawMessage `json:"extras,omitempty"`
 }
 
 type Account struct {
@@ -74,7 +76,6 @@ type Link struct {
 	Templated bool   `json:"templated,omitempty"`
 }
 
-
 type TransactionSuccess struct {
 	Links struct {
 		Transaction Link `json:"transaction"`
@@ -84,6 +85,13 @@ type TransactionSuccess struct {
 	Env    string `json:"envelope_xdr"`
 	Result string `json:"result_xdr"`
 	Meta   string `json:"result_meta_xdr"`
+}
+
+// TransactionResultCodes represent a summary of result codes returned from
+// a single xdr TransactionResult
+type TransactionResultCodes struct {
+	TransactionCode string   `json:"transaction"`
+	OperationCodes  []string `json:"operations,omitempty"`
 }
 
 type Signer struct {


### PR DESCRIPTION
This PR adds some helper methods to get details about a `*horizon.Error` that was returned in response to a transaction posted to horizon. 