### PR TITLE
Minor updates

### DIFF
--- a/support/config/broken_test.go
+++ b/support/config/broken_test.go
@@ -1,0 +1,27 @@
+// +build brokentests
+
+package config
+
+import (
+	"testing"
+
+	"github.com/asaskevich/govalidator"
+	"github.com/stretchr/testify/assert"
+)
+
+// NOTE: this test is presently failing because govalidator doesn't support
+// optional fields that also use a custom validator.  We'll remove the build tag
+// above that disabled it from running during tests when we fix upstream.
+func TestOptionalStellarFields(t *testing.T) {
+	var val struct {
+		F1 string `valid:"stellar_accountid,optional"`
+		F2 string `valid:"optional,stellar_accountid"`
+		F3 string `valid:"stellar_seed,optional"`
+		F4 string `valid:"optional,stellar_accountid"`
+	}
+
+	// run the validation
+	ok, err := govalidator.ValidateStruct(val)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+}

--- a/support/db/repo.go
+++ b/support/db/repo.go
@@ -52,6 +52,11 @@ func (r *Repo) Commit() error {
 	return err
 }
 
+// Dialect returns the SQL dialect that this repo is configured to use
+func (r *Repo) Dialect() string {
+	return r.DB.DriverName()
+}
+
 func (r *Repo) DeleteRange(
 	start, end int64,
 	table string,

--- a/support/db/repo_test.go
+++ b/support/db/repo_test.go
@@ -17,6 +17,8 @@ func TestRepo(t *testing.T) {
 	repo := &Repo{DB: db.Open()}
 	defer repo.DB.Close()
 
+	assert.Equal("postgres", repo.Dialect())
+
 	var count int
 	err := repo.GetRaw(&count, "SELECT COUNT(*) FROM people")
 	assert.NoError(err)


### PR DESCRIPTION
- Adds expectedly broken test illustrating upstream govalidator bug.
- Add `Dialect()` helper method to db.Repo