### PR TITLE
support/db/dbtest: integrate test assertions

### DIFF
--- a/handlers/federation/handler_test.go
+++ b/handlers/federation/handler_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestHandler(t *testing.T) {
-	db := dbtest.Postgres().Load(`
+	db := dbtest.Postgres(t).Load(`
     CREATE TABLE people (id character varying, name character varying, domain character varying);
     INSERT INTO people (id, name, domain) VALUES 
       ('GD2GJPL3UOK5LX7TWXOACK2ZPWPFSLBNKL3GTGH6BLBNISK4BGWMFBBG', 'scott', 'stellar.org'),
@@ -138,7 +138,7 @@ func TestHandler(t *testing.T) {
 }
 
 func TestForwardOnlyHandler(t *testing.T) {
-	db := dbtest.Postgres().Load(`
+	db := dbtest.Postgres(t).Load(`
     CREATE TABLE people (id character varying, name character varying, domain character varying);
     INSERT INTO people (id, name, domain) VALUES 
       ('GD2GJPL3UOK5LX7TWXOACK2ZPWPFSLBNKL3GTGH6BLBNISK4BGWMFBBG', 'scott', 'stellar.org'),

--- a/support/db/dbtest/db.go
+++ b/support/db/dbtest/db.go
@@ -2,8 +2,8 @@ package dbtest
 
 import (
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
 	"github.com/stellar/go/support/db/sqlutils"
+	"github.com/stretchr/testify/require"
 )
 
 // Close closes and deletes the database represented by `db`
@@ -24,26 +24,17 @@ func (db *DB) Load(sql string) *DB {
 	defer conn.Close()
 
 	tx, err := conn.Begin()
-	if err != nil {
-		err = errors.Wrap(err, "begin failed")
-		panic(err)
-	}
+	require.NoError(db.t, err)
 
 	defer tx.Rollback()
 
 	for i, cmd := range sqlutils.AllStatements(sql) {
 		_, err = tx.Exec(cmd)
-		if err != nil {
-			err = errors.Wrapf(err, "failed execing statement: %d", i)
-			panic(err)
-		}
+		require.NoError(db.t, err, "failed execing statement: %d", i)
 	}
 
 	err = tx.Commit()
-	if err != nil {
-		err = errors.Wrap(err, "commit failed")
-		panic(err)
-	}
+	require.NoError(db.t, err)
 
 	return db
 }
@@ -51,10 +42,7 @@ func (db *DB) Load(sql string) *DB {
 // Open opens a sqlx connection to the db.
 func (db *DB) Open() *sqlx.DB {
 	conn, err := sqlx.Open(db.Dialect, db.DSN)
-	if err != nil {
-		err = errors.Wrap(err, "open failed")
-		panic(err)
-	}
+	require.NoError(db.t, err)
 
 	return conn
 }

--- a/support/db/dbtest/main.go
+++ b/support/db/dbtest/main.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"testing"
 
 	"github.com/stellar/go/support/errors"
 )
@@ -16,6 +17,7 @@ import (
 type DB struct {
 	Dialect string
 	DSN     string
+	t       *testing.T
 	closer  func()
 	closed  bool
 }

--- a/support/db/dbtest/mysql.go
+++ b/support/db/dbtest/mysql.go
@@ -3,34 +3,29 @@ package dbtest
 import (
 	"fmt"
 	"os/exec"
+	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/stellar/go/support/errors"
+	"github.com/stretchr/testify/require"
 )
 
 // Mysql provisions a new, blank database with a random name on the localhost of
 // the running process.  It assumes that you have mysql running and that the
 // root user has access with no password.  It panics on
 // the event of a failure.
-func Mysql() *DB {
+func Mysql(t *testing.T) *DB {
 	var result DB
 	name := randomName()
 	result.Dialect = "mysql"
 	result.DSN = fmt.Sprintf("root@/%s", name)
-
+	result.t = t
 	// create the db
 	err := exec.Command("mysql", "-e", fmt.Sprintf("CREATE DATABASE %s;", name)).Run()
-	if err != nil {
-		err = errors.Wrap(err, "createdb failed")
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	result.closer = func() {
 		err := exec.Command("mysql", "-e", fmt.Sprintf("DROP DATABASE %s;", name)).Run()
-		if err != nil {
-			err = errors.Wrap(err, "dropdb failed")
-			panic(err)
-		}
+		require.NoError(t, err)
 	}
 
 	return &result

--- a/support/db/dbtest/mysql_test.go
+++ b/support/db/dbtest/mysql_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMysql(t *testing.T) {
-	db := Mysql()
+	db := Mysql(t)
 	t.Log("tempdb url", db.DSN)
 
 	conn, err := sqlx.Open("mysql", db.DSN)

--- a/support/db/dbtest/postgres.go
+++ b/support/db/dbtest/postgres.go
@@ -3,34 +3,30 @@ package dbtest
 import (
 	"fmt"
 	"os/exec"
+	"testing"
 
 	_ "github.com/lib/pq"
-	"github.com/stellar/go/support/errors"
+	"github.com/stretchr/testify/require"
 )
 
 // Postgres provisions a new, blank database with a random name on the localhost
 // of the running process.  It assumes that you have postgres running on the
 // default port, have the command line postgres tools installed, and that the
 // current user has access to the server.  It panics on the event of a failure.
-func Postgres() *DB {
+func Postgres(t *testing.T) *DB {
 	var result DB
 	name := randomName()
 	result.Dialect = "postgres"
 	result.DSN = fmt.Sprintf("postgres://localhost/%s?sslmode=disable", name)
+	result.t = t
 
 	// create the db
 	err := exec.Command("createdb", name).Run()
-	if err != nil {
-		err = errors.Wrap(err, "createdb failed")
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	result.closer = func() {
 		err := exec.Command("dropdb", name).Run()
-		if err != nil {
-			err = errors.Wrap(err, "dropdb failed")
-			panic(err)
-		}
+		require.NoError(t, err)
 	}
 
 	return &result

--- a/support/db/dbtest/postgres_test.go
+++ b/support/db/dbtest/postgres_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestPostgres(t *testing.T) {
-	db := Postgres()
+	db := Postgres(t)
 	t.Log("tempdb url", db.DSN)
 
 	err := exec.Command("psql", db.DSN, "-c", "SELECT 1").Run()

--- a/support/db/dbtest/sqlite.go
+++ b/support/db/dbtest/sqlite.go
@@ -5,37 +5,31 @@ package dbtest
 import (
 	"io/ioutil"
 	"os"
+	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
-// Sqlite provisions a new, blank database sqlite database.  It panics on the event of a failure.
-func Sqlite() *DB {
+// Sqlite provisions a new, blank database sqlite database.  It panics on the
+// event of a failure.
+func Sqlite(t *testing.T) *DB {
 	var result DB
 
 	tmpfile, err := ioutil.TempFile("", "test.sqlite")
-	if err != nil {
-		err = errors.Wrap(err, "create temp file failed")
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	tmpfile.Close()
 	err = os.Remove(tmpfile.Name())
-
-	if err != nil {
-		err = errors.Wrap(err, "remove first temp file failed")
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	result.Dialect = "sqlite3"
 	result.DSN = tmpfile.Name()
+	result.t = t
+
 	result.closer = func() {
 		err := os.Remove(tmpfile.Name())
-		if err != nil {
-			err = errors.Wrap(err, "remove db file failed")
-			panic(err)
-		}
+		require.NoError(t, err)
 	}
 
 	return &result

--- a/support/db/dbtest/sqlite_test.go
+++ b/support/db/dbtest/sqlite_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSqlite(t *testing.T) {
-	tdb := Sqlite()
+	tdb := Sqlite(t)
 	t.Log(tdb.DSN)
 
 	db, err := sqlx.Open("sqlite3", tdb.DSN)

--- a/support/db/repo_test.go
+++ b/support/db/repo_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRepo(t *testing.T) {
-	db := dbtest.Postgres().Load(testSchema)
+	db := dbtest.Postgres(t).Load(testSchema)
 	defer db.Close()
 
 	assert := assert.New(t)


### PR DESCRIPTION
This PR updates the dbtest library to use test assertions instead of panics for handling errors when creating test databases.  This standardizes the package with way we handle test setup errors and simplifies the code.