### PR TITLE
Remove default network, plus some refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,8 @@ NOTE:  this changelog represents the changes that are associated with the librar
 
 - network:  Added the `HashTransaction` helper func to get the hash of a transaction targetted to a specific stellar network.
 
+### Changed:
+
+- build: _BREAKING CHANGE_:  A transaction built and signed using the `build` package no longer default to the test network.
+
 [Unreleased]: https://github.com/stellar/go/commits/master

--- a/build/account_merge.go
+++ b/build/account_merge.go
@@ -1,12 +1,12 @@
 package build
 
 import (
-	"errors"
-
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 
-// AccountMerge groups the creation of a new AccountMergeBuilder with a call to Mutate.
+// AccountMerge groups the creation of a new AccountMergeBuilder with a call to
+// Mutate.
 func AccountMerge(muts ...interface{}) (result AccountMergeBuilder) {
 	result.Mutate(muts...)
 	return

--- a/build/allow_trust.go
+++ b/build/allow_trust.go
@@ -1,8 +1,7 @@
 package build
 
 import (
-	"errors"
-
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 

--- a/build/change_trust.go
+++ b/build/change_trust.go
@@ -1,9 +1,8 @@
 package build
 
 import (
-	"errors"
-
 	"github.com/stellar/go/amount"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 

--- a/build/create_account.go
+++ b/build/create_account.go
@@ -1,9 +1,8 @@
 package build
 
 import (
-	"errors"
-
 	"github.com/stellar/go/amount"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 

--- a/build/inflation.go
+++ b/build/inflation.go
@@ -1,8 +1,7 @@
 package build
 
 import (
-	"errors"
-
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 

--- a/build/main.go
+++ b/build/main.go
@@ -1,18 +1,19 @@
-// Package build provides a builder system for constructing various xdr
-// structures used by the stellar network.
+// Package build implements a builder system for constructing various xdr
+// structures used by the stellar network, most importanly transactions.
 //
 // At the core of this package is the *Builder and *Mutator types.  A Builder
 // object (ex. PaymentBuilder, TransactionBuilder) contain an underlying xdr
 // struct that is being iteratively built by having zero or more Mutator structs
 // applied to it. See ExampleTransactionBuilder in main_test.go for an example.
+//
 package build
 
 import (
-	"errors"
 	"math"
 
 	"github.com/stellar/go/amount"
 	"github.com/stellar/go/network"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 
@@ -31,11 +32,14 @@ var (
 	// to the test stellar network (often called testnet).
 	TestNetwork = Network{network.TestNetworkPassphrase}
 
-	// DefaultNetwork is a mutator that configures the transaction for submission
-	// to the default stellar network.  Integrators may change this value to
-	// another `Network` mutator if they would like to effect the default in a
-	// process-global manner.
-	DefaultNetwork = TestNetwork
+	// DefaultNetwork is a mutator that configures the
+	// transaction for submission to the default stellar
+	// network.  Integrators may change this value to
+	// another `Network` mutator if they would like to
+	// effect the default in a process-global manner.
+	// Replace or set your own custom passphrase on this
+	// var to set the default network for the process.
+	DefaultNetwork = Network{}
 )
 
 // Amount is a mutator capable of setting the amount
@@ -66,13 +70,13 @@ func (a Asset) ToXdrObject() (xdr.Asset, error) {
 		var codeArray [4]byte
 		byteArray := []byte(a.Code)
 		copy(codeArray[:], byteArray[0:length])
-		asset := xdr.AssetAlphaNum4{codeArray, issuer}
+		asset := xdr.AssetAlphaNum4{AssetCode: codeArray, Issuer: issuer}
 		return xdr.NewAsset(xdr.AssetTypeAssetTypeCreditAlphanum4, asset)
 	case length >= 5 && length <= 12:
 		var codeArray [12]byte
 		byteArray := []byte(a.Code)
 		copy(codeArray[:], byteArray[0:length])
-		asset := xdr.AssetAlphaNum12{codeArray, issuer}
+		asset := xdr.AssetAlphaNum12{AssetCode: codeArray, Issuer: issuer}
 		return xdr.NewAsset(xdr.AssetTypeAssetTypeCreditAlphanum12, asset)
 	default:
 		return xdr.Asset{}, errors.New("Asset code length is invalid")

--- a/build/main_test.go
+++ b/build/main_test.go
@@ -22,6 +22,7 @@ func ExampleTransactionBuilder() {
 	tx := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
+		TestNetwork,
 		Payment(
 			Destination{"GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA"},
 			NativeAmount{"50"},
@@ -42,6 +43,7 @@ func ExamplePathPayment() {
 	tx := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
+		TestNetwork,
 		Payment(
 			Destination{"GBDT3K42LOPSHNAEHEJ6AVPADIJ4MAR64QEKKW2LQPBSKLYD22KUEH4P"},
 			CreditAmount{"USD", "GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA", "50"},
@@ -65,6 +67,7 @@ func ExampleSetOptions() {
 	tx := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
+		TestNetwork,
 		SetOptions(
 			InflationDest("GCT7S5BA6ZC7SV7GGEMEYJTWOBYTBOA7SC4JEYP7IAEDG7HQNIWKRJ4G"),
 			SetAuthRequired(),
@@ -94,6 +97,7 @@ func ExampleSetOptionsOperations() {
 	tx := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
+		TestNetwork,
 		InflationDest("GCT7S5BA6ZC7SV7GGEMEYJTWOBYTBOA7SC4JEYP7IAEDG7HQNIWKRJ4G"),
 		SetAuthRequired(),
 		SetAuthRevocable(),
@@ -121,6 +125,7 @@ func ExampleChangeTrust() {
 	tx := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
+		TestNetwork,
 		Trust("USD", "GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA", Limit("100.25")),
 	)
 
@@ -138,6 +143,7 @@ func ExampleChangeTrustMaxLimit() {
 	tx := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
+		TestNetwork,
 		Trust("USD", "GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA"),
 	)
 
@@ -156,6 +162,7 @@ func ExampleRemoveTrust() {
 	tx := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
+		TestNetwork,
 		RemoveTrust(
 			"USD",
 			"GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA",
@@ -183,6 +190,7 @@ func ExampleManageOffer() {
 	tx := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
+		TestNetwork,
 		CreateOffer(rate, "20"),
 		UpdateOffer(rate, "40", OfferID(2)),
 		DeleteOffer(rate, OfferID(1)),
@@ -208,6 +216,7 @@ func ExampleCreatePassiveOffer() {
 	tx := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
+		TestNetwork,
 		CreatePassiveOffer(rate, "20"),
 	)
 
@@ -225,6 +234,7 @@ func ExampleAccountMerge() {
 	tx := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
+		TestNetwork,
 		AccountMerge(
 			Destination{"GBDT3K42LOPSHNAEHEJ6AVPADIJ4MAR64QEKKW2LQPBSKLYD22KUEH4P"},
 		),
@@ -244,6 +254,7 @@ func ExampleInflation() {
 	tx := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
+		TestNetwork,
 		Inflation(),
 	)
 

--- a/build/manage_data.go
+++ b/build/manage_data.go
@@ -1,8 +1,7 @@
 package build
 
 import (
-	"errors"
-
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 

--- a/build/manage_offer.go
+++ b/build/manage_offer.go
@@ -1,10 +1,9 @@
 package build
 
 import (
-	"errors"
-
 	"github.com/stellar/go/amount"
 	"github.com/stellar/go/price"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 

--- a/build/payment.go
+++ b/build/payment.go
@@ -1,9 +1,8 @@
 package build
 
 import (
-	"errors"
-
 	"github.com/stellar/go/amount"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 

--- a/build/set_options.go
+++ b/build/set_options.go
@@ -1,8 +1,7 @@
 package build
 
 import (
-	"errors"
-
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 

--- a/build/transaction.go
+++ b/build/transaction.go
@@ -2,10 +2,10 @@ package build
 
 import (
 	"encoding/hex"
-	"errors"
 
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/xdr"
+	"github.com/stellar/go/support/errors"
 )
 
 // Transaction groups the creation of a new TransactionBuilder with a call

--- a/build/transaction_envelope_test.go
+++ b/build/transaction_envelope_test.go
@@ -1,9 +1,9 @@
 package build
 
 import (
-	"errors"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/stellar/go/support/errors"
 )
 
 var _ = Describe("TransactionEnvelope Mutators:", func() {
@@ -26,7 +26,10 @@ var _ = Describe("TransactionEnvelope Mutators:", func() {
 		Context("with an error set on it", func() {
 			err := errors.New("busted!")
 			BeforeEach(func() { mut = &TransactionBuilder{Err: err} })
-			It("propagates the error upwards", func() { Expect(subject.Err).To(Equal(err)) })
+			It("propagates the error upwards", func() {
+				Expect(subject.Err).To(HaveOccurred())
+				Expect(subject.Err.Error()).To(ContainSubstring("busted!"))
+			})
 		})
 
 	})
@@ -34,7 +37,7 @@ var _ = Describe("TransactionEnvelope Mutators:", func() {
 	Describe("Sign", func() {
 		Context("with a valid key", func() {
 			BeforeEach(func() {
-				subject.MutateTX(SourceAccount{"SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"})
+				subject.MutateTX(SourceAccount{"SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"}, TestNetwork)
 				mut = Sign{"SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"}
 			})
 
@@ -46,6 +49,7 @@ var _ = Describe("TransactionEnvelope Mutators:", func() {
 
 		Context("with an invalid key", func() {
 			BeforeEach(func() { mut = Sign{""} })
+
 			It("fails", func() {
 				Expect(subject.Err).To(HaveOccurred())
 			})

--- a/build/util.go
+++ b/build/util.go
@@ -1,9 +1,8 @@
 package build
 
 import (
-	"errors"
-
 	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 
@@ -33,13 +32,13 @@ func createAlphaNumAsset(code, issuerAccountId string) (xdr.Asset, error) {
 		var codeArray [4]byte
 		byteArray := []byte(code)
 		copy(codeArray[:], byteArray[0:length])
-		asset := xdr.AssetAlphaNum4{codeArray, issuer}
+		asset := xdr.AssetAlphaNum4{AssetCode: codeArray, Issuer: issuer}
 		return xdr.NewAsset(xdr.AssetTypeAssetTypeCreditAlphanum4, asset)
 	case length >= 5 && length <= 12:
 		var codeArray [12]byte
 		byteArray := []byte(code)
 		copy(codeArray[:], byteArray[0:length])
-		asset := xdr.AssetAlphaNum12{codeArray, issuer}
+		asset := xdr.AssetAlphaNum12{AssetCode: codeArray, Issuer: issuer}
 		return xdr.NewAsset(xdr.AssetTypeAssetTypeCreditAlphanum12, asset)
 	default:
 		return xdr.Asset{}, errors.New("Asset code length is invalid")

--- a/network/main.go
+++ b/network/main.go
@@ -6,6 +6,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"strings"
+
 	"github.com/stellar/go/hash"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
@@ -31,6 +33,10 @@ func ID(passphrase string) [32]byte {
 // authorize the transaction identified by the hash to stellar validators.
 func HashTransaction(tx *xdr.Transaction, passphrase string) ([32]byte, error) {
 	var txBytes bytes.Buffer
+
+	if strings.TrimSpace(passphrase) == "" {
+		return [32]byte{}, errors.New("empty network passphrase")
+	}
 
 	_, err := fmt.Fprintf(&txBytes, "%s", ID(passphrase))
 	if err != nil {

--- a/network/main_test.go
+++ b/network/main_test.go
@@ -26,4 +26,10 @@ func TestHashTransaction(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, expected, actual)
 	}
+
+	// sadpath: empty passphrase
+	_, err = HashTransaction(&txe.Tx, "")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "empty network passphrase")
+	}
 }


### PR DESCRIPTION
This PR removes the behavior where the build package defaults to signing transactions for the test network.  Unless a developer explicitly sets `DefaultNetwork.Passphrase`, an error will now be returned when building transactions.

Additionally, I took the opportunity to make 30 minutes of progress on unifying our error handling with the `stellar/go/support/errors` package.