### PR TITLE
Initial support for query building

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -175,7 +175,7 @@ imports:
 - name: github.com/valyala/bytebufferpool
   version: e746df99fe4a3986f4d4f79e13c1e0117ce9c2f7
 - name: github.com/valyala/fasthttp
-  version: a0f498b65b5690efc4b39a12c9e0555e80d95456
+  version: 0a7f0a797cd66b89588d0a7fdd670b706579a621
   subpackages:
   - fasthttputil
 - name: github.com/visionmedia/go-debug
@@ -217,7 +217,7 @@ imports:
   subpackages:
   - unix
 - name: gopkg.in/gavv/httpexpect.v1
-  version: dc339328a5b3638045ba972e16b5ac6c0f46c796
+  version: 40724cf1e4a08b670b14a02deff693a91f3aa9a0
 - name: gopkg.in/tylerb/graceful.v1
   version: 50a48b6e73fcc75b45e22c05b79629a67c79e938
 testImports:

--- a/glide.lock
+++ b/glide.lock
@@ -6,42 +6,42 @@ imports:
   subpackages:
   - edwards25519
 - name: github.com/ajg/form
-  version: cc2954064ec9ea8d93917f0f87456e11d7b881ad
+  version: 523a5da1a92f01b01f840b61689c0340a0243532
 - name: github.com/asaskevich/govalidator
   version: f0666aa80d7dcf75bd564ae8717b952d74a29d6a
   repo: https://github.com/stellar/govalidator.git
 - name: github.com/aws/aws-sdk-go
-  version: 35c21ff262580265c1d77095d6f712605fd0c3f4
+  version: d3e3f4281292478e8095bea047e2297e005152da
   subpackages:
   - aws
-  - aws/session
-  - service/s3
   - aws/awserr
-  - aws/credentials
-  - aws/client
-  - aws/corehandlers
-  - aws/credentials/stscreds
-  - aws/defaults
-  - aws/request
-  - private/endpoints
   - aws/awsutil
+  - aws/client
   - aws/client/metadata
-  - aws/signer/v4
-  - private/protocol
-  - private/protocol/restxml
-  - private/waiter
-  - service/sts
+  - aws/corehandlers
+  - aws/credentials
   - aws/credentials/ec2rolecreds
   - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/defaults
   - aws/ec2metadata
-  - private/protocol/rest
+  - aws/request
+  - aws/session
+  - aws/signer/v4
+  - private/endpoints
+  - private/protocol
   - private/protocol/query
-  - private/protocol/xml/xmlutil
   - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/restxml
+  - private/protocol/xml/xmlutil
+  - private/waiter
+  - service/s3
+  - service/sts
 - name: github.com/BurntSushi/toml
   version: 99064174e013895bbd9b025c31100bd1d9b590ca
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/fatih/structs
@@ -55,7 +55,7 @@ imports:
 - name: github.com/getsentry/raven-go
   version: c9d3cc542ad199f62c0264286be537f9bce6063c
 - name: github.com/go-ini/ini
-  version: a2610b3a793cfa7fdf0b07038068af5ddc12aba1
+  version: 6e4869b434bd001f6983749881c7ead3545887d8
 - name: github.com/go-sql-driver/mysql
   version: 0b58b37b664c21f3010e836f1b931e1d0b0b0685
 - name: github.com/google/go-querystring
@@ -63,7 +63,7 @@ imports:
   subpackages:
   - query
 - name: github.com/howeyc/gopass
-  version: b63a7d07e65df376d14e2d72907a93d4847dffe4
+  version: f5387c492211eb133053880d23dfae62aa14123d
 - name: github.com/imkira/go-interpol
   version: b9781c93ae51c8b4fc3af1b1426909721af0a624
 - name: github.com/inconshreveable/mousetrap
@@ -73,11 +73,11 @@ imports:
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/jmoiron/sqlx
-  version: 7396209bbeada6a4fcc28aa9408f89b2e71cac39
+  version: 05b81a7d5d38058e42148dc01f17daf4acba4640
   subpackages:
   - reflectx
 - name: github.com/klauspost/compress
-  version: 14eb9c4951195779ecfbec34431a976de7335b0a
+  version: 08fe86a420401e830c24114bdf9f1ba91331407a
   subpackages:
   - flate
   - gzip
@@ -90,16 +90,16 @@ imports:
   version: f22ce00fd9394014049dad11c244859432bd6820
 - name: github.com/lann/ps
   version: 62de8c46ede02a7675c4c79c84883eb164cb71e3
-- name: github.com/lann/squirrel
-  version: caff2d522d550f0998629c85898ad35e8a603328
 - name: github.com/lib/pq
-  version: 80f8150043c80fb52dee6bc863a709cdac7ec8f8
+  version: 50761b0867bd1d9d069276790bcd4a3bccf2324a
   subpackages:
   - oid
 - name: github.com/manucorporat/sse
   version: ee05b128a739a0fb76c7ebd3ae4810c1de808d6d
+- name: github.com/Masterminds/squirrel
+  version: cb03830e33a9c086b3f9051548a81d299e190939
 - name: github.com/mattn/go-sqlite3
-  version: c3e9588849195eefa783417c3a53d092f6e93526
+  version: 4b0af852c17164dce48e6754e3094c55192e4934
 - name: github.com/moul/http2curl
   version: b1479103caacaa39319f75e7f57fc545287fca0d
 - name: github.com/nullstyle/go-xdr
@@ -107,39 +107,41 @@ imports:
   subpackages:
   - xdr3
 - name: github.com/onsi/ginkgo
-  version: 43e2af1f01ace55adbb6d7d0f30416476db1baae
+  version: c07a44f02cf4a895e331f4f473c0943ee116c668
   subpackages:
-  - extensions/table
   - config
+  - extensions/table
   - internal/codelocation
+  - internal/containernode
   - internal/failer
+  - internal/leafnodes
   - internal/remote
+  - internal/spec
+  - internal/specrunner
   - internal/suite
   - internal/testingtproxy
   - internal/writer
   - reporters
   - reporters/stenographer
+  - reporters/stenographer/support/go-colorable
+  - reporters/stenographer/support/go-isatty
   - types
-  - internal/containernode
-  - internal/leafnodes
-  - internal/spec
-  - internal/specrunner
 - name: github.com/onsi/gomega
-  version: b48c9a8b2644326d0a44eaaacc8d83e35174a05d
+  version: ff4bc6b6f9f5affa66635cd04d31d2a7ee21ffd6
   subpackages:
-  - types
+  - format
   - internal/assertion
   - internal/asyncassertion
+  - internal/oraclematcher
   - internal/testingtsupport
   - matchers
-  - internal/oraclematcher
-  - format
   - matchers/support/goraph/bipartitegraph
   - matchers/support/goraph/edge
   - matchers/support/goraph/node
   - matchers/support/goraph/util
+  - types
 - name: github.com/pkg/errors
-  version: 17b591df37844cde689f4d5813e5cea0927d8dd2
+  version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -155,23 +157,25 @@ imports:
   subpackages:
   - diffmatchpatch
 - name: github.com/Sirupsen/logrus
-  version: a283a10442df8dc09befd873fab202bf8a253d6a
+  version: 3ec0642a7fb6488f65b06f9040adc67e3990296a
+  subpackages:
+  - hooks/test
 - name: github.com/spf13/cobra
-  version: 7c674d9e72017ed25f6d2b5e497a1368086b6a6f
+  version: 9c28e4bbd74e5c3ed7aacbc552b2cab7cfdfe744
 - name: github.com/spf13/pflag
-  version: f676131e2660dc8cd88de99f7486d34aa8172635
+  version: 4bd69631f4750a9df249ee317f4536e02cbc3c65
 - name: github.com/stretchr/objx
   version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
+  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
   subpackages:
   - mock
   - assert
   - require
 - name: github.com/valyala/bytebufferpool
-  version: 8ebd0474e5a2f0a5c7a74ad2bf421a1d1a90264f
+  version: e746df99fe4a3986f4d4f79e13c1e0117ce9c2f7
 - name: github.com/valyala/fasthttp
-  version: 0a7f0a797cd66b89588d0a7fdd670b706579a621
+  version: a0f498b65b5690efc4b39a12c9e0555e80d95456
   subpackages:
   - fasthttputil
 - name: github.com/visionmedia/go-debug
@@ -182,6 +186,8 @@ imports:
   version: e02fc20de94c78484cd5ffb007f8af96be030a45
 - name: github.com/xeipuuv/gojsonschema
   version: 4f624f6197547606054e042e7903db103585e151
+- name: github.com/y0ssar1an/q
+  version: 2db904a96a52a061170a3c0d8db384d388315af6
 - name: github.com/yalp/jsonpath
   version: 31a79c7593bb93eb10b163650d4a3e6ca190e4dc
 - name: github.com/yudai/gojsondiff
@@ -195,11 +201,11 @@ imports:
   - internal
   - pattern
 - name: golang.org/x/crypto
-  version: 595bbbd7f5f308415a544d3c55743c91427c8d99
+  version: 7682e7e3945130cf3cde089834664f68afdd1523
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: 075e191f18186a8ff2becaf64478e30f4545cdad
+  version: 9bc2a3340c92c17a20edcd0080e93851ed58f5d5
   subpackages:
   - context
   - http2
@@ -207,13 +213,18 @@ imports:
   - lex/httplex
   - publicsuffix
 - name: golang.org/x/sys
-  version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
+  version: 1f5e250e1174502017917628cc48b52fdc25b531
   subpackages:
   - unix
 - name: gopkg.in/gavv/httpexpect.v1
-  version: 40724cf1e4a08b670b14a02deff693a91f3aa9a0
+  version: dc339328a5b3638045ba972e16b5ac6c0f46c796
 - name: gopkg.in/tylerb/graceful.v1
-  version: c838c13b2beeea4f4f54496da96a3a6ae567c37a
+  version: 50a48b6e73fcc75b45e22c05b79629a67c79e938
 testImports:
+- name: github.com/kr/pretty
+  version: cfb55aafdaf3ec08f0db22699ab822c50091b1c4
+  repo: https://github.com/kr/pretty
+- name: github.com/kr/text
+  version: 7cafcd837844e784b526369c9bce262804aebc60
 - name: gopkg.in/yaml.v2
-  version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
+  version: a5b47d31c556af34a302ce5d659e6fea44d90de0

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,7 +13,6 @@ import:
   - http2
 - package: github.com/stretchr/testify
 - package: github.com/jmoiron/sqlx
-- package: github.com/lann/squirrel
 - package: github.com/lib/pq
 - package: github.com/go-sql-driver/mysql
 - package: github.com/mattn/go-sqlite3
@@ -34,3 +33,6 @@ import:
   - aws
 - package: github.com/jarcoal/httpmock
 - package: github.com/manucorporat/sse
+- package: github.com/y0ssar1an/q
+  version: ^1.0.0
+- package: github.com/Masterminds/squirrel

--- a/handlers/federation/main.go
+++ b/handlers/federation/main.go
@@ -101,7 +101,7 @@ type SQLDriver struct {
 	LookupRecordQuery string
 
 	init sync.Once
-	db   *db.Repo
+	db   *db.Session
 }
 
 // SuccessResponse represents the successful JSON response that will be

--- a/support/db/delete_builder.go
+++ b/support/db/delete_builder.go
@@ -1,0 +1,27 @@
+package db
+
+import (
+	"database/sql"
+
+	"github.com/pkg/errors"
+)
+
+// Exec executes the query represented by the builder, deleting any rows that
+// match the queries where clauses.
+func (delb *DeleteBuilder) Exec() (sql.Result, error) {
+	r, err := delb.Table.Session.Exec(delb.sql)
+	if err != nil {
+		return nil, errors.Wrap(err, "delete failed")
+	}
+	return r, nil
+}
+
+// Where is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#DeleteBuilder.Where
+func (delb *DeleteBuilder) Where(
+	pred interface{},
+	args ...interface{},
+) *DeleteBuilder {
+	delb.sql = delb.sql.Where(pred, args...)
+	return delb
+}

--- a/support/db/delete_builder_test.go
+++ b/support/db/delete_builder_test.go
@@ -1,0 +1,30 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stellar/go/support/db/dbtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteBuilder_Exec(t *testing.T) {
+	db := dbtest.Postgres(t).Load(testSchema)
+	defer db.Close()
+	sess := &Session{DB: db.Open()}
+	defer sess.DB.Close()
+
+	tbl := sess.GetTable("people")
+	r, err := tbl.Delete("name = ?", "scott").Exec()
+
+	if assert.NoError(t, err, "query error") {
+		actual, err := r.RowsAffected()
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), actual)
+
+		var found int
+		err = sess.GetRaw(&found, "SELECT COUNT(*) FROM people WHERE name = ?", "scott")
+		require.NoError(t, err)
+		assert.Equal(t, 0, found)
+	}
+}

--- a/support/db/errors.go
+++ b/support/db/errors.go
@@ -1,0 +1,12 @@
+package db
+
+// NoRowsError is returned when an insert is attempted without providing any
+// values to insert.
+type NoRowsError struct {
+}
+
+func (err *NoRowsError) Error() string {
+	return "no rows provided to insert"
+}
+
+var _ error = &NoRowsError{}

--- a/support/db/get_builder.go
+++ b/support/db/get_builder.go
@@ -10,32 +10,45 @@ import (
 func (gb *GetBuilder) Exec() error {
 	err := gb.Table.Session.Get(gb.dest, gb.sql)
 	if err != nil {
-		return errors.Wrap(err, "select failed")
+		return errors.Wrap(err, "get failed")
 	}
 
 	return nil
 }
 
-// Limit is a passthrough call to the squirrel.  See
-// https://godoc.org/github.com/Masterminds/squirrel#GetBuilder.Limit
-func (gb *GetBuilder) Limit(limit uint64) *GetBuilder {
-	gb.sql = gb.sql.Limit(limit)
-	return gb
-}
-
 // Offset is a passthrough call to the squirrel.  See
-// https://godoc.org/github.com/Masterminds/squirrel#GetBuilder.Offset
+// https://godoc.org/github.com/Masterminds/squirrel#SelectBuilder.Offset
 func (gb *GetBuilder) Offset(offset uint64) *GetBuilder {
 	gb.sql = gb.sql.Offset(offset)
 	return gb
 }
 
 // OrderBy is a passthrough call to the squirrel.  See
-// https://godoc.org/github.com/Masterminds/squirrel#GetBuilder.OrderBy
+// https://godoc.org/github.com/Masterminds/squirrel#SelectBuilder.OrderBy
 func (gb *GetBuilder) OrderBy(
 	orderBys ...string,
 ) *GetBuilder {
 	gb.sql = gb.sql.OrderBy(orderBys...)
+	return gb
+}
+
+// Prefix is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#SelectBuilder.Prefix
+func (gb *GetBuilder) Prefix(
+	sql string,
+	args ...interface{},
+) *GetBuilder {
+	gb.sql = gb.sql.Prefix(sql, args...)
+	return gb
+}
+
+// Suffix is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#SelectBuilder.Suffix
+func (gb *GetBuilder) Suffix(
+	sql string,
+	args ...interface{},
+) *GetBuilder {
+	gb.sql = gb.sql.Suffix(sql, args...)
 	return gb
 }
 

--- a/support/db/get_builder.go
+++ b/support/db/get_builder.go
@@ -1,0 +1,50 @@
+package db
+
+import (
+	"github.com/stellar/go/support/errors"
+)
+
+// Exec executes the query represented by the builder, populating the
+// destination with the results returned by running the query against the
+// current database session.
+func (gb *GetBuilder) Exec() error {
+	err := gb.Table.Session.Get(gb.dest, gb.sql)
+	if err != nil {
+		return errors.Wrap(err, "select failed")
+	}
+
+	return nil
+}
+
+// Limit is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#GetBuilder.Limit
+func (gb *GetBuilder) Limit(limit uint64) *GetBuilder {
+	gb.sql = gb.sql.Limit(limit)
+	return gb
+}
+
+// Offset is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#GetBuilder.Offset
+func (gb *GetBuilder) Offset(offset uint64) *GetBuilder {
+	gb.sql = gb.sql.Offset(offset)
+	return gb
+}
+
+// OrderBy is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#GetBuilder.OrderBy
+func (gb *GetBuilder) OrderBy(
+	orderBys ...string,
+) *GetBuilder {
+	gb.sql = gb.sql.OrderBy(orderBys...)
+	return gb
+}
+
+// Where is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#GetBuilder.Where
+func (gb *GetBuilder) Where(
+	pred interface{},
+	args ...interface{},
+) *GetBuilder {
+	gb.sql = gb.sql.Where(pred, args...)
+	return gb
+}

--- a/support/db/get_builder_test.go
+++ b/support/db/get_builder_test.go
@@ -1,0 +1,25 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stellar/go/support/db/dbtest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetBuilder_Exec(t *testing.T) {
+	db := dbtest.Postgres(t).Load(testSchema)
+	defer db.Close()
+	sess := &Session{DB: db.Open()}
+	defer sess.DB.Close()
+
+	var found person
+
+	tbl := sess.GetTable("people")
+	err := tbl.Get(&found, "name = ?", "scott").Exec()
+
+	if assert.NoError(t, err, "query error") {
+		assert.Equal(t, "scott", found.Name)
+		assert.Equal(t, "1000000", found.HungerLevel)
+	}
+}

--- a/support/db/insert_builder.go
+++ b/support/db/insert_builder.go
@@ -1,0 +1,47 @@
+package db
+
+import (
+	"database/sql"
+	"reflect"
+
+	"github.com/pkg/errors"
+	"github.com/y0ssar1an/q"
+)
+
+// Exec executes the query represented by the builder, inserting each val
+// provided to the builder into the database.
+func (ib *InsertBuilder) Exec() (sql.Result, error) {
+	if len(ib.rows) == 0 {
+		return nil, &NoRowsError{}
+	}
+
+	template := ib.rows[0]
+	cols := columnsForStruct(template)
+	sql := ib.sql.Columns(cols...)
+
+	for _, row := range ib.rows {
+		rrow := reflect.ValueOf(row)
+		rvals := mapper.FieldsByName(rrow, cols)
+		vals := make([]interface{}, len(cols))
+		for i, rval := range rvals {
+			vals[i] = rval.Interface()
+		}
+		q.Q(vals)
+		sql = sql.Values(vals...)
+	}
+
+	// TODO: support return inserted id
+
+	r, err := ib.Table.Session.Exec(sql)
+	if err != nil {
+		return nil, errors.Wrap(err, "insert failed")
+	}
+
+	return r, nil
+}
+
+// Rows appends more rows onto the insert statement
+func (ib *InsertBuilder) Rows(rows ...interface{}) *InsertBuilder {
+	ib.rows = append(ib.rows, rows...)
+	return ib
+}

--- a/support/db/insert_builder.go
+++ b/support/db/insert_builder.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 
 	"github.com/pkg/errors"
-	"github.com/y0ssar1an/q"
 )
 
 // Exec executes the query represented by the builder, inserting each val
@@ -19,14 +18,20 @@ func (ib *InsertBuilder) Exec() (sql.Result, error) {
 	cols := columnsForStruct(template)
 	sql := ib.sql.Columns(cols...)
 
+	// add rows onto the builder
 	for _, row := range ib.rows {
+
+		// extract field values
 		rrow := reflect.ValueOf(row)
 		rvals := mapper.FieldsByName(rrow, cols)
+
+		// convert fields values to interface{}
 		vals := make([]interface{}, len(cols))
 		for i, rval := range rvals {
 			vals[i] = rval.Interface()
 		}
-		q.Q(vals)
+
+		// append row to insert statement
 		sql = sql.Values(vals...)
 	}
 

--- a/support/db/insert_builder_test.go
+++ b/support/db/insert_builder_test.go
@@ -1,0 +1,73 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stellar/go/support/db/dbtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInsertBuilder_Exec(t *testing.T) {
+	db := dbtest.Postgres(t).Load(testSchema)
+	defer db.Close()
+	sess := &Session{DB: db.Open()}
+	defer sess.DB.Close()
+
+	tbl := sess.GetTable("people")
+
+	_, err := tbl.Insert(person{
+		Name:        "bubba",
+		HungerLevel: "120",
+	}).Exec()
+
+	if assert.NoError(t, err) {
+		var found []person
+		err := sess.SelectRaw(
+			&found,
+			"SELECT * FROM people WHERE name = ?",
+			"bubba",
+		)
+
+		require.NoError(t, err)
+
+		if assert.Len(t, found, 1) {
+			assert.Equal(t, "bubba", found[0].Name)
+			assert.Equal(t, "120", found[0].HungerLevel)
+		}
+	}
+
+	// no rows
+	_, err = tbl.Insert().Exec()
+	if assert.Error(t, err) {
+		assert.EqualError(t, err, "no rows provided to insert")
+	}
+
+	// multi rows
+	r, err := tbl.Insert(person{
+		Name:        "bubba2",
+		HungerLevel: "120",
+	}, person{
+		Name:        "bubba3",
+		HungerLevel: "120",
+	}).Exec()
+
+	if assert.NoError(t, err) {
+		count, err := r.RowsAffected()
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), count)
+	}
+
+	// invalid columns in struct
+	_, err = tbl.Insert(struct {
+		Name        string `db:"name"`
+		HungerLevel string `db:"hunger_level"`
+		NotAColumn  int    `db:"not_a_column"`
+	}{
+		Name:        "bubba2",
+		HungerLevel: "120",
+		NotAColumn:  3,
+	}).Exec()
+
+	assert.Error(t, err)
+}

--- a/support/db/insert_builder_test.go
+++ b/support/db/insert_builder_test.go
@@ -40,6 +40,7 @@ func TestInsertBuilder_Exec(t *testing.T) {
 	// no rows
 	_, err = tbl.Insert().Exec()
 	if assert.Error(t, err) {
+		assert.IsType(t, &NoRowsError{}, err)
 		assert.EqualError(t, err, "no rows provided to insert")
 	}
 

--- a/support/db/internal.go
+++ b/support/db/internal.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"reflect"
+	"sort"
 
 	"github.com/jmoiron/sqlx/reflectx"
 )
@@ -34,5 +35,9 @@ func columnsForStruct(dest interface{}) []string {
 	for k := range typmap.Names {
 		keys = append(keys, k)
 	}
+
+	// Ensure keys are sorted.
+	sort.Strings(keys)
+
 	return keys
 }

--- a/support/db/internal.go
+++ b/support/db/internal.go
@@ -36,7 +36,10 @@ func columnsForStruct(dest interface{}) []string {
 		keys = append(keys, k)
 	}
 
-	// Ensure keys are sorted.
+	// Ensure keys are sorted.  keys is populated from a map, which has no
+	// defined iteration order.  Different versions of go or different
+	// architectures may cause non-deterministic results to occur (and in our CI
+	// environment, they have).  To make testing easier, we sort the keys.
 	sort.Strings(keys)
 
 	return keys

--- a/support/db/internal.go
+++ b/support/db/internal.go
@@ -1,0 +1,38 @@
+package db
+
+import (
+	"reflect"
+
+	"github.com/jmoiron/sqlx/reflectx"
+)
+
+var mapper = reflectx.NewMapper("db")
+
+type person struct {
+	Name        string `db:"name"`
+	HungerLevel string `db:"hunger_level"`
+
+	SomethingIgnored int `db:"-"`
+}
+
+// columnsForStruct returns a slice of column names for the provided value
+// (which should be a struct, a slice of structs).
+func columnsForStruct(dest interface{}) []string {
+	typ := reflect.TypeOf(dest)
+
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+
+	if typ.Kind() == reflect.Slice {
+		typ = typ.Elem()
+	}
+
+	typmap := mapper.TypeMap(typ)
+
+	var keys []string
+	for k := range typmap.Names {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/support/db/internal_test.go
+++ b/support/db/internal_test.go
@@ -55,7 +55,7 @@ func TestColumnsForStruct(t *testing.T) {
 				Ignore string `db:"-"`
 				Age    string `db:"age"`
 			}{},
-			Expected: []string{"name", "age"},
+			Expected: []string{"age", "name"},
 		},
 		{
 			Name: "unannotated",
@@ -64,7 +64,7 @@ func TestColumnsForStruct(t *testing.T) {
 				Age   string
 				Level int `json:"level"`
 			}{},
-			Expected: []string{"name", "Age", "Level"},
+			Expected: []string{"Age", "Level", "name"},
 		},
 		{
 			Name: "private",

--- a/support/db/internal_test.go
+++ b/support/db/internal_test.go
@@ -1,0 +1,84 @@
+package db
+
+import "testing"
+import "github.com/stretchr/testify/assert"
+
+const testSchema = `
+CREATE TABLE  IF NOT EXISTS people (
+    name character varying NOT NULL,
+    hunger_level integer NOT NULL
+);
+DELETE FROM people;
+INSERT INTO people (name, hunger_level) VALUES ('scott', 1000000);
+INSERT INTO people (name, hunger_level) VALUES ('jed', 10);
+INSERT INTO people (name, hunger_level) VALUES ('bartek', 10);
+`
+
+func TestColumnsForStruct(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Struct   interface{}
+		Expected []string
+	}{
+		{
+			Name: "simple",
+			Struct: struct {
+				Name string `db:"name"`
+			}{},
+			Expected: []string{"name"},
+		},
+		{
+			Name: "simple pointer",
+			Struct: &struct {
+				Name string `db:"name"`
+			}{},
+			Expected: []string{"name"},
+		},
+		{
+			Name: "slice",
+			Struct: []struct {
+				Name string `db:"name"`
+			}{},
+			Expected: []string{"name"},
+		},
+		{
+			Name: "slice pointer",
+			Struct: &[]struct {
+				Name string `db:"name"`
+			}{},
+			Expected: []string{"name"},
+		},
+		{
+			Name: "ignored",
+			Struct: struct {
+				Name   string `db:"name"`
+				Ignore string `db:"-"`
+				Age    string `db:"age"`
+			}{},
+			Expected: []string{"name", "age"},
+		},
+		{
+			Name: "unannotated",
+			Struct: struct {
+				Name  string `db:"name"`
+				Age   string
+				Level int `json:"level"`
+			}{},
+			Expected: []string{"name", "Age", "Level"},
+		},
+		{
+			Name: "private",
+			Struct: struct {
+				Name string `db:"name"`
+				age  string
+			}{},
+			Expected: []string{"name"},
+		},
+	}
+
+	for _, kase := range cases {
+		actual := columnsForStruct(kase.Struct)
+
+		assert.Equal(t, kase.Expected, actual, "case '%s' failed", kase.Name)
+	}
+}

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -9,6 +9,7 @@ package db
 import (
 	"database/sql"
 
+	"github.com/Masterminds/squirrel"
 	"github.com/jmoiron/sqlx"
 	"github.com/stellar/go/support/errors"
 	"golang.org/x/net/context"
@@ -16,8 +17,6 @@ import (
 	// Enable mysql
 	_ "github.com/go-sql-driver/mysql"
 	// Enable postgres
-	"reflect"
-
 	_ "github.com/lib/pq"
 )
 
@@ -28,6 +27,40 @@ type Conn interface {
 	Rebind(sql string) string
 	Queryx(query string, args ...interface{}) (*sqlx.Rows, error)
 	Select(dest interface{}, query string, args ...interface{}) error
+}
+
+// DeleteBuilder is a helper struct used to construct sql queries of the DELETE
+// variety.
+type DeleteBuilder struct {
+	Table *Table
+	sql   squirrel.DeleteBuilder
+}
+
+// InsertBuilder is a helper struct used to construct sql queries of the INSERT
+// variety.
+type InsertBuilder struct {
+	Table *Table
+
+	rows []interface{}
+	sql  squirrel.InsertBuilder
+}
+
+// GetBuilder is a helper struct used to construct sql queries of the SELECT
+// variety.
+type GetBuilder struct {
+	Table *Table
+
+	dest interface{}
+	sql  squirrel.SelectBuilder
+}
+
+// SelectBuilder is a helper struct used to construct sql queries of the SELECT
+// variety.
+type SelectBuilder struct {
+	Table *Table
+
+	dest interface{}
+	sql  squirrel.SelectBuilder
 }
 
 // Session provides helper methods for making queries against `DB` and provides
@@ -46,10 +79,13 @@ type Session struct {
 	tx *sqlx.Tx
 }
 
-// Table helps to build sql queries against a given table.
+// Table helps to build sql queries against a given table.  It logically
+// represents a SQL table on the database that `Session` is connected to.
 type Table struct {
-	Name   string
-	Source reflect.Type
+	// Name is the name of the table
+	Name string
+
+	Session *Session
 }
 
 // Open the database at `dsn` and returns a new *Repo using it.

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -1,9 +1,14 @@
 // Package db is the base package for database access at stellar.  It primarily
-// exposes Repo which is a lightweight wrapper around a *sqlx.DB that provides
-// utility methods (See the repo tests for examples).
+// exposes Session which is a lightweight wrapper around a *sqlx.DB that
+// provides utility methods (See the repo tests for examples).
 //
 // In addition to the query methods, this package provides query logging and
 // stateful transaction management.
+//
+// In addition to the lower-level access facilities, this package exposes a
+// system to build queries more dynamically using the help of
+// https://github.com/Masterminds/squirrel.  These builder method are access
+// through the `Table` type.
 package db
 
 import (
@@ -88,7 +93,7 @@ type Table struct {
 	Session *Session
 }
 
-// Open the database at `dsn` and returns a new *Repo using it.
+// Open the database at `dsn` and returns a new *Session using it.
 func Open(dialect, dsn string) (*Session, error) {
 	db, err := sqlx.Connect(dialect, dsn)
 	if err != nil {
@@ -99,8 +104,8 @@ func Open(dialect, dsn string) (*Session, error) {
 }
 
 // Wrap wraps a bare *sql.DB (from the database/sql stdlib package) in a
-// *db.Repo instance.  It is meant to be used in cases where you do not control
-// the instantiation of the database connection, but would still like to
+// *db.Session instance.  It is meant to be used in cases where you do not
+// control the instantiation of the database connection, but would still like to
 // leverage the facilities provided in Session.
 func Wrap(base *sql.DB, dialect string) *Session {
 	return &Session{DB: sqlx.NewDb(base, dialect)}

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -68,6 +68,15 @@ type SelectBuilder struct {
 	sql  squirrel.SelectBuilder
 }
 
+// UpdateBuilder is a helper struct used to construct sql queries of the UPDATE
+// variety.
+type UpdateBuilder struct {
+	Table *Table
+
+	source interface{}
+	sql    squirrel.UpdateBuilder
+}
+
 // Session provides helper methods for making queries against `DB` and provides
 // utilities such as automatic query logging and transaction management.  NOTE:
 // A Session is designed to be lightweight and temporarily lived (usually

--- a/support/db/main_test.go
+++ b/support/db/main_test.go
@@ -1,0 +1,22 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stellar/go/support/db/dbtest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTable(t *testing.T) {
+	db := dbtest.Postgres(t).Load(testSchema)
+	defer db.Close()
+	sess := &Session{DB: db.Open()}
+	defer sess.DB.Close()
+
+	tbl := sess.GetTable("users")
+	if assert.NotNil(t, tbl) {
+		assert.Equal(t, "users", tbl.Name)
+		assert.Equal(t, sess, tbl.Session)
+	}
+
+}

--- a/support/db/select_builder.go
+++ b/support/db/select_builder.go
@@ -1,0 +1,50 @@
+package db
+
+import (
+	"github.com/stellar/go/support/errors"
+)
+
+// Exec executes the query represented by the builder, populating the
+// destination with the results returned by running the query against the
+// current database session.
+func (sb *SelectBuilder) Exec() error {
+	err := sb.Table.Session.Select(sb.dest, sb.sql)
+	if err != nil {
+		return errors.Wrap(err, "select failed")
+	}
+
+	return nil
+}
+
+// Limit is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#SelectBuilder.Limit
+func (sb *SelectBuilder) Limit(limit uint64) *SelectBuilder {
+	sb.sql = sb.sql.Limit(limit)
+	return sb
+}
+
+// Offset is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#SelectBuilder.Offset
+func (sb *SelectBuilder) Offset(offset uint64) *SelectBuilder {
+	sb.sql = sb.sql.Offset(offset)
+	return sb
+}
+
+// OrderBy is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#SelectBuilder.OrderBy
+func (sb *SelectBuilder) OrderBy(
+	orderBys ...string,
+) *SelectBuilder {
+	sb.sql = sb.sql.OrderBy(orderBys...)
+	return sb
+}
+
+// Where is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#SelectBuilder.Where
+func (sb *SelectBuilder) Where(
+	pred interface{},
+	args ...interface{},
+) *SelectBuilder {
+	sb.sql = sb.sql.Where(pred, args...)
+	return sb
+}

--- a/support/db/select_builder.go
+++ b/support/db/select_builder.go
@@ -39,6 +39,26 @@ func (sb *SelectBuilder) OrderBy(
 	return sb
 }
 
+// Prefix is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#SelectBuilder.Prefix
+func (sb *SelectBuilder) Prefix(
+	sql string,
+	args ...interface{},
+) *SelectBuilder {
+	sb.sql = sb.sql.Prefix(sql, args...)
+	return sb
+}
+
+// Suffix is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#SelectBuilder.Suffix
+func (sb *SelectBuilder) Suffix(
+	sql string,
+	args ...interface{},
+) *SelectBuilder {
+	sb.sql = sb.sql.Suffix(sql, args...)
+	return sb
+}
+
 // Where is a passthrough call to the squirrel.  See
 // https://godoc.org/github.com/Masterminds/squirrel#SelectBuilder.Where
 func (sb *SelectBuilder) Where(

--- a/support/db/select_builder_test.go
+++ b/support/db/select_builder_test.go
@@ -1,0 +1,40 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stellar/go/support/db/dbtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectBuilder_Exec(t *testing.T) {
+	db := dbtest.Postgres(t).Load(testSchema)
+	defer db.Close()
+	sess := &Session{DB: db.Open()}
+	defer sess.DB.Close()
+
+	var results []person
+
+	tbl := sess.GetTable("people")
+	sb := tbl.Select(&results, "name = ?", "scott")
+	sql, args, err := sb.sql.ToSql()
+	require.NoError(t, err)
+
+	assert.Contains(t, sql, "name")
+	assert.Contains(t, sql, "hunger_level")
+	assert.NotContains(t, sql, "-")
+
+	if assert.Len(t, args, 1) {
+		assert.Equal(t, "scott", args[0])
+	}
+
+	err = sb.Exec()
+
+	if assert.NoError(t, err, "query error") {
+		if assert.Len(t, results, 1) {
+			assert.Equal(t, "scott", results[0].Name)
+			assert.Equal(t, "1000000", results[0].HungerLevel)
+		}
+	}
+}

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"time"
 
+	sq "github.com/Masterminds/squirrel"
 	"github.com/jmoiron/sqlx"
-	sq "github.com/lann/squirrel"
 	"github.com/stellar/go/support/db/sqlutils"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
@@ -106,8 +106,12 @@ func (r *Repo) GetRaw(dest interface{}, query string, args ...interface{}) error
 	return errors.Wrap(err, "get failed")
 }
 
-func (s *Session) GetTable(typ interface{}) *Table {
-	return nil
+// GetTable translates the provided struct into a Table,
+func (s *Session) GetTable(name string) *Table {
+	return &Table{
+		Name:    name,
+		Session: s,
+	}
 }
 
 // Exec runs `query`

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -14,50 +14,52 @@ import (
 	"golang.org/x/net/context"
 )
 
-// Begin binds this repo to a new transaction.
-func (r *Repo) Begin() error {
-	if r.tx != nil {
+// Begin binds this session to a new transaction.
+func (s *Session) Begin() error {
+	if s.tx != nil {
 		return errors.New("already in transaction")
 	}
 
-	tx, err := r.DB.Beginx()
+	tx, err := s.DB.Beginx()
 	if err != nil {
 		return errors.Wrap(err, "beginx failed")
 	}
-	r.logBegin()
+	s.logBegin()
 
-	r.tx = tx
+	s.tx = tx
 	return nil
 }
 
 // Clone clones the receiver, returning a new instance backed by the same
 // context and db. The result will not be bound to any transaction that the
 // source is currently within.
-func (r *Repo) Clone() *Repo {
-	return &Repo{
-		DB:  r.DB,
-		Ctx: r.Ctx,
+func (s *Session) Clone() *Session {
+	return &Session{
+		DB:  s.DB,
+		Ctx: s.Ctx,
 	}
 }
 
 // Commit commits the current transaction
-func (r *Repo) Commit() error {
-	if r.tx == nil {
+func (s *Session) Commit() error {
+	if s.tx == nil {
 		return errors.New("not in transaction")
 	}
 
-	err := r.tx.Commit()
-	r.logCommit()
-	r.tx = nil
+	err := s.tx.Commit()
+	s.logCommit()
+	s.tx = nil
 	return err
 }
 
-// Dialect returns the SQL dialect that this repo is configured to use
-func (r *Repo) Dialect() string {
-	return r.DB.DriverName()
+// Dialect returns the SQL dialect that this session is configured to use
+func (s *Session) Dialect() string {
+	return s.DB.DriverName()
 }
 
-func (r *Repo) DeleteRange(
+// DeleteRange deletes a range of rows from a sql table between `start` and
+// `end` (exclusive).
+func (s *Session) DeleteRange(
 	start, end int64,
 	table string,
 	idCol string,
@@ -67,18 +69,18 @@ func (r *Repo) DeleteRange(
 		start,
 		end,
 	)
-	_, err := r.Exec(del)
+	_, err := s.Exec(del)
 	return err
 }
 
 // Get runs `query`, setting the first result found on `dest`, if
 // any.
-func (r *Repo) Get(dest interface{}, query sq.Sqlizer) error {
-	sql, args, err := r.build(query)
+func (s *Session) Get(dest interface{}, query sq.Sqlizer) error {
+	sql, args, err := s.build(query)
 	if err != nil {
 		return err
 	}
-	return r.GetRaw(dest, sql, args...)
+	return s.GetRaw(dest, sql, args...)
 }
 
 // GetRaw runs `query` with `args`, setting the first result found on
@@ -97,40 +99,44 @@ func (r *Repo) GetRaw(dest interface{}, query string, args ...interface{}) error
 		return nil
 	}
 
-	if r.NoRows(err) {
+	if s.NoRows(err) {
 		return err
 	}
 
 	return errors.Wrap(err, "get failed")
 }
 
+func (s *Session) GetTable(typ interface{}) *Table {
+	return nil
+}
+
 // Exec runs `query`
-func (r *Repo) Exec(query sq.Sqlizer) (sql.Result, error) {
-	sql, args, err := r.build(query)
+func (s *Session) Exec(query sq.Sqlizer) (sql.Result, error) {
+	sql, args, err := s.build(query)
 	if err != nil {
 		return nil, err
 	}
-	return r.ExecRaw(sql, args...)
+	return s.ExecRaw(sql, args...)
 }
 
 // ExecAll runs all sql commands in `script` against `r` within a single
 // transaction.
-func (r *Repo) ExecAll(script string) error {
-	err := r.Begin()
+func (s *Session) ExecAll(script string) error {
+	err := s.Begin()
 	if err != nil {
 		return err
 	}
 
-	defer r.Rollback()
+	defer s.Rollback()
 
 	for _, cmd := range sqlutils.AllStatements(script) {
-		_, err = r.ExecRaw(cmd)
+		_, err = s.ExecRaw(cmd)
 		if err != nil {
 			return err
 		}
 	}
 
-	return r.Commit()
+	return s.Commit()
 }
 
 // ExecRaw runs `query` with `args`
@@ -141,14 +147,14 @@ func (r *Repo) ExecRaw(query string, args ...interface{}) (sql.Result, error) {
 	}
 
 	start := time.Now()
-	result, err := r.conn().Exec(query, args...)
-	r.log("exec", start, query, args)
+	result, err := s.conn().Exec(query, args...)
+	s.log("exec", start, query, args)
 
 	if err == nil {
 		return result, nil
 	}
 
-	if r.NoRows(err) {
+	if s.NoRows(err) {
 		return nil, err
 	}
 
@@ -157,17 +163,17 @@ func (r *Repo) ExecRaw(query string, args ...interface{}) (sql.Result, error) {
 
 // NoRows returns true if the provided error resulted from a query that found
 // no results.
-func (r *Repo) NoRows(err error) bool {
+func (s *Session) NoRows(err error) bool {
 	return err == sql.ErrNoRows
 }
 
 // Query runs `query`, returns a *sqlx.Rows instance
-func (r *Repo) Query(query sq.Sqlizer) (*sqlx.Rows, error) {
-	sql, args, err := r.build(query)
+func (s *Session) Query(query sq.Sqlizer) (*sqlx.Rows, error) {
+	sql, args, err := s.build(query)
 	if err != nil {
 		return nil, err
 	}
-	return r.QueryRaw(sql, args...)
+	return s.QueryRaw(sql, args...)
 }
 
 // QueryRaw runs `query` with `args`
@@ -178,14 +184,14 @@ func (r *Repo) QueryRaw(query string, args ...interface{}) (*sqlx.Rows, error) {
 	}
 
 	start := time.Now()
-	result, err := r.conn().Queryx(query, args...)
-	r.log("query", start, query, args)
+	result, err := s.conn().Queryx(query, args...)
+	s.log("query", start, query, args)
 
 	if err == nil {
 		return result, nil
 	}
 
-	if r.NoRows(err) {
+	if s.NoRows(err) {
 		return nil, err
 	}
 
@@ -205,28 +211,28 @@ func (r *Repo) ReplacePlaceholders(query string) (string, error) {
 }
 
 // Rollback rolls back the current transaction
-func (r *Repo) Rollback() error {
-	if r.tx == nil {
+func (s *Session) Rollback() error {
+	if s.tx == nil {
 		return errors.New("not in transaction")
 	}
 
-	err := r.tx.Rollback()
-	r.logRollback()
-	r.tx = nil
+	err := s.tx.Rollback()
+	s.logRollback()
+	s.tx = nil
 	return err
 }
 
 // Select runs `query`, setting the results found on `dest`.
-func (r *Repo) Select(dest interface{}, query sq.Sqlizer) error {
-	sql, args, err := r.build(query)
+func (s *Session) Select(dest interface{}, query sq.Sqlizer) error {
+	sql, args, err := s.build(query)
 	if err != nil {
 		return err
 	}
-	return r.SelectRaw(dest, sql, args...)
+	return s.SelectRaw(dest, sql, args...)
 }
 
 // SelectRaw runs `query` with `args`, setting the results found on `dest`.
-func (r *Repo) SelectRaw(
+func (s *Session) SelectRaw(
 	dest interface{},
 	query string,
 	args ...interface{},
@@ -245,7 +251,7 @@ func (r *Repo) SelectRaw(
 		return nil
 	}
 
-	if r.NoRows(err) {
+	if s.NoRows(err) {
 		return err
 	}
 
@@ -254,7 +260,7 @@ func (r *Repo) SelectRaw(
 
 // build converts the provided sql builder `b` into the sql and args to execute
 // against the raw database connections.
-func (r *Repo) build(b sq.Sqlizer) (sql string, args []interface{}, err error) {
+func (s *Session) build(b sq.Sqlizer) (sql string, args []interface{}, err error) {
 	sql, args, err = b.ToSql()
 
 	if err != nil {
@@ -267,7 +273,7 @@ func (r *Repo) build(b sq.Sqlizer) (sql string, args []interface{}, err error) {
 // provided interface wraps one. In the event that `dest` is not a pointer to a
 // slice this func will fail with a warning, this allowing the forthcoming db
 // select fail more concretely due to an incompatible destination.
-func (r *Repo) clearSliceIfPossible(dest interface{}) {
+func (s *Session) clearSliceIfPossible(dest interface{}) {
 	v := reflect.ValueOf(dest)
 	vt := v.Type()
 
@@ -284,38 +290,38 @@ func (r *Repo) clearSliceIfPossible(dest interface{}) {
 	reflect.Indirect(v).SetLen(0)
 }
 
-func (r *Repo) conn() Conn {
-	if r.tx != nil {
-		return r.tx
+func (s *Session) conn() Conn {
+	if s.tx != nil {
+		return s.tx
 	}
 
-	return r.DB
+	return s.DB
 }
 
-func (r *Repo) log(typ string, start time.Time, query string, args []interface{}) {
+func (s *Session) log(typ string, start time.Time, query string, args []interface{}) {
 	log.
-		Ctx(r.logCtx()).
+		Ctx(s.logCtx()).
 		WithField("args", args).
 		WithField("sql", query).
 		WithField("dur", time.Since(start).String()).
 		Debugf("sql: %s", typ)
 }
 
-func (r *Repo) logBegin() {
-	log.Ctx(r.logCtx()).Debug("sql: begin")
+func (s *Session) logBegin() {
+	log.Ctx(s.logCtx()).Debug("sql: begin")
 }
 
-func (r *Repo) logCommit() {
-	log.Ctx(r.logCtx()).Debug("sql: commit")
+func (s *Session) logCommit() {
+	log.Ctx(s.logCtx()).Debug("sql: commit")
 }
 
-func (r *Repo) logRollback() {
-	log.Ctx(r.logCtx()).Debug("sql: rollback")
+func (s *Session) logRollback() {
+	log.Ctx(s.logCtx()).Debug("sql: rollback")
 }
 
-func (r *Repo) logCtx() context.Context {
-	if r.Ctx != nil {
-		return r.Ctx
+func (s *Session) logCtx() context.Context {
+	if s.Ctx != nil {
+		return s.Ctx
 	}
 
 	return context.Background()

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -85,15 +85,15 @@ func (s *Session) Get(dest interface{}, query sq.Sqlizer) error {
 
 // GetRaw runs `query` with `args`, setting the first result found on
 // `dest`, if any.
-func (r *Repo) GetRaw(dest interface{}, query string, args ...interface{}) error {
-	query, err := r.ReplacePlaceholders(query)
+func (s *Session) GetRaw(dest interface{}, query string, args ...interface{}) error {
+	query, err := s.ReplacePlaceholders(query)
 	if err != nil {
 		return errors.Wrap(err, "replace placeholders failed")
 	}
 
 	start := time.Now()
-	err = r.conn().Get(dest, query, args...)
-	r.log("get", start, query, args)
+	err = s.conn().Get(dest, query, args...)
+	s.log("get", start, query, args)
 
 	if err == nil {
 		return nil
@@ -144,8 +144,8 @@ func (s *Session) ExecAll(script string) error {
 }
 
 // ExecRaw runs `query` with `args`
-func (r *Repo) ExecRaw(query string, args ...interface{}) (sql.Result, error) {
-	query, err := r.ReplacePlaceholders(query)
+func (s *Session) ExecRaw(query string, args ...interface{}) (sql.Result, error) {
+	query, err := s.ReplacePlaceholders(query)
 	if err != nil {
 		return nil, errors.Wrap(err, "replace placeholders failed")
 	}
@@ -181,8 +181,8 @@ func (s *Session) Query(query sq.Sqlizer) (*sqlx.Rows, error) {
 }
 
 // QueryRaw runs `query` with `args`
-func (r *Repo) QueryRaw(query string, args ...interface{}) (*sqlx.Rows, error) {
-	query, err := r.ReplacePlaceholders(query)
+func (s *Session) QueryRaw(query string, args ...interface{}) (*sqlx.Rows, error) {
+	query, err := s.ReplacePlaceholders(query)
 	if err != nil {
 		return nil, errors.Wrap(err, "replace placeholders failed")
 	}
@@ -205,10 +205,10 @@ func (r *Repo) QueryRaw(query string, args ...interface{}) (*sqlx.Rows, error) {
 // ReplacePlaceholders replaces the '?' parameter placeholders in the provided
 // sql query with a sql dialect appropriate version. Use '??' to escape a
 // placeholder.
-func (r *Repo) ReplacePlaceholders(query string) (string, error) {
+func (s *Session) ReplacePlaceholders(query string) (string, error) {
 	var format sq.PlaceholderFormat = sq.Question
 
-	if r.DB.DriverName() == "postgres" {
+	if s.DB.DriverName() == "postgres" {
 		format = sq.Dollar
 	}
 	return format.ReplacePlaceholders(query)
@@ -241,15 +241,15 @@ func (s *Session) SelectRaw(
 	query string,
 	args ...interface{},
 ) error {
-	r.clearSliceIfPossible(dest)
-	query, err := r.ReplacePlaceholders(query)
+	s.clearSliceIfPossible(dest)
+	query, err := s.ReplacePlaceholders(query)
 	if err != nil {
 		return errors.Wrap(err, "replace placeholders failed")
 	}
 
 	start := time.Now()
-	err = r.conn().Select(dest, query, args...)
-	r.log("select", start, query, args)
+	err = s.conn().Select(dest, query, args...)
+	s.log("select", start, query, args)
 
 	if err == nil {
 		return nil

--- a/support/db/session_test.go
+++ b/support/db/session_test.go
@@ -89,14 +89,3 @@ func TestSession(t *testing.T) {
 		assert.Equal("$1 = $2 = $3 = ?", out)
 	}
 }
-
-const testSchema = `
-CREATE TABLE  IF NOT EXISTS people (
-    name character varying NOT NULL,
-    hunger_level integer NOT NULL
-);
-DELETE FROM people;
-INSERT INTO people (name, hunger_level) VALUES ('scott', 1000000);
-INSERT INTO people (name, hunger_level) VALUES ('jed', 10);
-INSERT INTO people (name, hunger_level) VALUES ('bartek', 10);
-`

--- a/support/db/session_test.go
+++ b/support/db/session_test.go
@@ -84,7 +84,7 @@ func TestSession(t *testing.T) {
 	assert.Len(names, 2)
 
 	// Test ReplacePlaceholders
-	out, err := repo.ReplacePlaceholders("? = ? = ? = ??")
+	out, err := sess.ReplacePlaceholders("? = ? = ? = ??")
 	if assert.NoError(err) {
 		assert.Equal("$1 = $2 = $3 = ?", out)
 	}

--- a/support/db/session_test.go
+++ b/support/db/session_test.go
@@ -8,28 +8,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRepo(t *testing.T) {
+func TestSession(t *testing.T) {
 	db := dbtest.Postgres(t).Load(testSchema)
 	defer db.Close()
 
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := &Repo{DB: db.Open()}
-	defer repo.DB.Close()
+	sess := &Session{DB: db.Open()}
+	defer sess.DB.Close()
 
-	assert.Equal("postgres", repo.Dialect())
+	assert.Equal("postgres", sess.Dialect())
 
 	var count int
-	err := repo.GetRaw(&count, "SELECT COUNT(*) FROM people")
+	err := sess.GetRaw(&count, "SELECT COUNT(*) FROM people")
 	assert.NoError(err)
 	assert.Equal(3, count)
 
 	var names []string
-	err = repo.SelectRaw(&names, "SELECT name FROM people")
+	err = sess.SelectRaw(&names, "SELECT name FROM people")
 	assert.NoError(err)
 	assert.Len(names, 3)
 
-	ret, err := repo.ExecRaw("DELETE FROM people")
+	ret, err := sess.ExecRaw("DELETE FROM people")
 	assert.NoError(err)
 	deleted, err := ret.RowsAffected()
 	assert.NoError(err)
@@ -39,7 +39,7 @@ func TestRepo(t *testing.T) {
 	// during execution)
 	db.Load(testSchema)
 	var name string
-	err = repo.GetRaw(
+	err = sess.GetRaw(
 		&name,
 		"SELECT name FROM people WHERE hunger_level = ? AND name != '??'",
 		1000000,
@@ -48,38 +48,38 @@ func TestRepo(t *testing.T) {
 	assert.Equal("scott", name)
 
 	// Test NoRows
-	err = repo.GetRaw(
+	err = sess.GetRaw(
 		&name,
 		"SELECT name FROM people WHERE hunger_level = ?",
 		1234,
 	)
-	assert.True(repo.NoRows(err))
+	assert.True(sess.NoRows(err))
 
 	// Test transactions
 	db.Load(testSchema)
-	require.NoError(repo.Begin(), "begin failed")
-	err = repo.GetRaw(&count, "SELECT COUNT(*) FROM people")
+	require.NoError(sess.Begin(), "begin failed")
+	err = sess.GetRaw(&count, "SELECT COUNT(*) FROM people")
 	assert.NoError(err)
 	assert.Equal(3, count)
-	_, err = repo.ExecRaw("DELETE FROM people")
+	_, err = sess.ExecRaw("DELETE FROM people")
 	assert.NoError(err)
-	err = repo.GetRaw(&count, "SELECT COUNT(*) FROM people")
+	err = sess.GetRaw(&count, "SELECT COUNT(*) FROM people")
 	assert.NoError(err)
 	assert.Equal(0, count, "people did not appear deleted inside transaction")
-	assert.NoError(repo.Rollback(), "rollback failed")
+	assert.NoError(sess.Rollback(), "rollback failed")
 
 	// Ensure commit works
-	require.NoError(repo.Begin(), "begin failed")
-	repo.ExecRaw("DELETE FROM people")
-	assert.NoError(repo.Commit(), "commit failed")
-	err = repo.GetRaw(&count, "SELECT COUNT(*) FROM people")
+	require.NoError(sess.Begin(), "begin failed")
+	sess.ExecRaw("DELETE FROM people")
+	assert.NoError(sess.Commit(), "commit failed")
+	err = sess.GetRaw(&count, "SELECT COUNT(*) FROM people")
 	assert.NoError(err)
 	assert.Equal(0, count)
 
 	// ensure that selecting into a populated slice clears the slice first
 	db.Load(testSchema)
 	require.Len(names, 3, "ids slice was not preloaded with data")
-	err = repo.SelectRaw(&names, "SELECT name FROM people limit 2")
+	err = sess.SelectRaw(&names, "SELECT name FROM people limit 2")
 	assert.NoError(err)
 	assert.Len(names, 2)
 

--- a/support/db/table.go
+++ b/support/db/table.go
@@ -16,6 +16,9 @@ func (tbl *Table) Delete(
 
 // Get returns a new query builder configured to select into the provided
 // `dest`.
+//
+// Get behaves the same was as Select, but automatically limits the query
+// generated to a single value and only populates a single struct.
 func (tbl *Table) Get(
 	dest interface{},
 	pred interface{},
@@ -34,6 +37,21 @@ func (tbl *Table) Get(
 
 // Insert returns a new query builder configured to insert structs into the
 // table.
+//
+// Insert takes one or more struct (or pointer to struct) values, each of which
+// represents a single row to be created in the table.  The first value provided
+// in a call to this function will operate as the template for the insert and
+// will determine what columns are populated in the query.   For this reason, it
+// is highly recommmended that you always use the same struct type for any
+// single call this function.
+//
+// An InsertBuilder uses the "db" struct tag to determine the column names that
+// a given struct should be mapped to, and by default the unmofdified name of
+// the field will be used.  Similar to other struct tags, the value "-" will
+// cause the field to be skipped.
+//
+// NOTE:  using the omitempty option, such as used with json struct tags, is not
+// supported.
 func (tbl *Table) Insert(rows ...interface{}) *InsertBuilder {
 	return &InsertBuilder{
 		Table: tbl,

--- a/support/db/table.go
+++ b/support/db/table.go
@@ -2,8 +2,8 @@ package db
 
 import sq "github.com/Masterminds/squirrel"
 
-// Insert returns a new query builder configured to insert structs into the
-// table
+// Delete returns a new query builder configured to delete rows from the table.
+//
 func (tbl *Table) Delete(
 	pred interface{},
 	args ...interface{},

--- a/support/db/table.go
+++ b/support/db/table.go
@@ -1,0 +1,61 @@
+package db
+
+import sq "github.com/Masterminds/squirrel"
+
+// Insert returns a new query builder configured to insert structs into the
+// table
+func (tbl *Table) Delete(
+	pred interface{},
+	args ...interface{},
+) *DeleteBuilder {
+	return &DeleteBuilder{
+		Table: tbl,
+		sql:   sq.Delete(tbl.Name).Where(pred, args...),
+	}
+}
+
+// Get returns a new query builder configured to select into the provided
+// `dest`.
+func (tbl *Table) Get(
+	dest interface{},
+	pred interface{},
+	args ...interface{},
+) *GetBuilder {
+
+	cols := columnsForStruct(dest)
+	sql := sq.Select(cols...).From(tbl.Name).Where(pred, args...).Limit(1)
+
+	return &GetBuilder{
+		Table: tbl,
+		dest:  dest,
+		sql:   sql,
+	}
+}
+
+// Insert returns a new query builder configured to insert structs into the
+// table.
+func (tbl *Table) Insert(rows ...interface{}) *InsertBuilder {
+	return &InsertBuilder{
+		Table: tbl,
+		sql:   sq.Insert(tbl.Name),
+		rows:  rows,
+	}
+}
+
+// Select returns a new query builder configured to select into the provided
+// `dest`.
+func (tbl *Table) Select(
+	dest interface{},
+	pred interface{},
+	args ...interface{},
+) *SelectBuilder {
+
+	cols := columnsForStruct(dest)
+	sql := sq.Select(cols...).From(tbl.Name).Where(pred, args...)
+
+	return &SelectBuilder{
+		Table: tbl,
+		dest:  dest,
+		sql:   sql,
+	}
+}

--- a/support/db/table.go
+++ b/support/db/table.go
@@ -77,3 +77,21 @@ func (tbl *Table) Select(
 		sql:   sql,
 	}
 }
+
+// Update returns a new query builder configured to update rows that match the
+// predicate with the values of the provided source struct.  See docs for
+// `UpdateBuildeExec` for more documentation.
+func (tbl *Table) Update(
+	source interface{},
+	pred interface{},
+	args ...interface{},
+) *UpdateBuilder {
+
+	sql := sq.Update(tbl.Name).Where(pred, args...)
+
+	return &UpdateBuilder{
+		Table:  tbl,
+		source: source,
+		sql:    sql,
+	}
+}

--- a/support/db/update_builder.go
+++ b/support/db/update_builder.go
@@ -1,0 +1,85 @@
+package db
+
+import (
+	"database/sql"
+
+	"github.com/stellar/go/support/errors"
+)
+
+// Exec executes the query that has been previously configured on the
+// UpdateBuilder.
+func (ub *UpdateBuilder) Exec() (sql.Result, error) {
+	r, err := ub.Table.Session.Exec(ub.sql)
+	if err != nil {
+		return nil, errors.Wrap(err, "select failed")
+	}
+
+	return r, nil
+}
+
+// Limit is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#UpdateBuilder.Limit
+func (ub *UpdateBuilder) Limit(limit uint64) *UpdateBuilder {
+	ub.sql = ub.sql.Limit(limit)
+	return ub
+}
+
+// Offset is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#UpdateBuilder.Offset
+func (ub *UpdateBuilder) Offset(offset uint64) *UpdateBuilder {
+	ub.sql = ub.sql.Offset(offset)
+	return ub
+}
+
+// OrderBy is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#UpdateBuilder.OrderBy
+func (ub *UpdateBuilder) OrderBy(
+	orderBys ...string,
+) *UpdateBuilder {
+	ub.sql = ub.sql.OrderBy(orderBys...)
+	return ub
+}
+
+// Prefix is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#UpdateBuilder.Prefix
+func (ub *UpdateBuilder) Prefix(
+	sql string,
+	args ...interface{},
+) *UpdateBuilder {
+	ub.sql = ub.sql.Prefix(sql, args...)
+	return ub
+}
+
+// Set is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#UpdateBuilder.Suffix
+func (ub *UpdateBuilder) Set(column string, value interface{}) *UpdateBuilder {
+	ub.sql = ub.sql.Set(column, value)
+	return ub
+}
+
+// SetMap is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#UpdateBuilder.Suffix
+func (ub *UpdateBuilder) SetMap(clauses map[string]interface{}) *UpdateBuilder {
+	ub.sql = ub.sql.SetMap(clauses)
+	return ub
+}
+
+// Suffix is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#UpdateBuilder.Suffix
+func (ub *UpdateBuilder) Suffix(
+	sql string,
+	args ...interface{},
+) *UpdateBuilder {
+	ub.sql = ub.sql.Suffix(sql, args...)
+	return ub
+}
+
+// Where is a passthrough call to the squirrel.  See
+// https://godoc.org/github.com/Masterminds/squirrel#UpdateBuilder.Where
+func (ub *UpdateBuilder) Where(
+	pred interface{},
+	args ...interface{},
+) *UpdateBuilder {
+	ub.sql = ub.sql.Where(pred, args...)
+	return ub
+}


### PR DESCRIPTION
This PR adds initial support for programmatically building sql queries.  Big changes include:

- Renamed `Repo` to `Session`
- Added the `Table` struct
- Added query builders for `Select`, `Get`, `Delete`, and `Insert`


TODO:
- [x] Document usage better
- [x] Add Update query builder