### PR TITLE
Limit bytes read from stellar.toml and federation responses

### DIFF
--- a/clients/federation/client_test.go
+++ b/clients/federation/client_test.go
@@ -3,6 +3,7 @@ package federation
 import (
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stellar/go/clients/stellartoml"
@@ -32,6 +33,22 @@ func TestLookupByAddress(t *testing.T) {
 		assert.Equal(t, "GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C", resp.AccountID)
 		assert.Equal(t, "id", resp.MemoType)
 		assert.Equal(t, "123", resp.Memo)
+	}
+
+	// response too big
+	tomlmock.On("GetStellarToml", "toobig.org").Return(&stellartoml.Response{
+		FederationServer: "https://toobig.org/federation",
+	}, nil)
+	hmock.On("GET", "https://toobig.org/federation").
+		ReturnJSON(http.StatusOK, map[string]string{
+			"stellar_address": strings.Repeat("0", FederationResponseMaxSize) + "*stellar.org",
+			"account_id":      "GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C",
+			"memo_type":       "id",
+			"memo":            "123",
+		})
+	_, err = c.LookupByAddress("response*toobig.org")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "federation response too big")
 	}
 
 	// failed toml resolution

--- a/clients/federation/client_test.go
+++ b/clients/federation/client_test.go
@@ -35,7 +35,7 @@ func TestLookupByAddress(t *testing.T) {
 		assert.Equal(t, "123", resp.Memo)
 	}
 
-	// response too big
+	// response exceeds limit
 	tomlmock.On("GetStellarToml", "toobig.org").Return(&stellartoml.Response{
 		FederationServer: "https://toobig.org/federation",
 	}, nil)
@@ -48,7 +48,7 @@ func TestLookupByAddress(t *testing.T) {
 		})
 	_, err = c.LookupByAddress("response*toobig.org")
 	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "federation response too big")
+		assert.Contains(t, err.Error(), "federation response exceeds")
 	}
 
 	// failed toml resolution

--- a/clients/federation/main.go
+++ b/clients/federation/main.go
@@ -7,6 +7,9 @@ import (
 	"github.com/stellar/go/clients/stellartoml"
 )
 
+// FederationResponseMaxSize is the maximum size of response from a federation server
+const FederationResponseMaxSize = 5 * 1024
+
 // DefaultTestNetClient is a default federation client for testnet
 var DefaultTestNetClient = &Client{
 	HTTP:        http.DefaultClient,

--- a/clients/federation/main.go
+++ b/clients/federation/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 // FederationResponseMaxSize is the maximum size of response from a federation server
-const FederationResponseMaxSize = 5 * 1024
+const FederationResponseMaxSize = 100 * 1024
 
 // DefaultTestNetClient is a default federation client for testnet
 var DefaultTestNetClient = &Client{

--- a/clients/stellartoml/client_test.go
+++ b/clients/stellartoml/client_test.go
@@ -2,6 +2,7 @@ package stellartoml
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stellar/go/support/http/httptest"
@@ -33,6 +34,15 @@ func TestClient(t *testing.T) {
 	stoml, err := c.GetStellarToml("stellar.org")
 	require.NoError(t, err)
 	assert.Equal(t, "https://localhost/federation", stoml.FederationServer)
+
+	// stellar.toml too big
+	h.
+		On("GET", "https://toobig.org/.well-known/stellar.toml").
+		ReturnString(http.StatusOK,
+			`FEDERATION_SERVER="https://localhost/federation`+strings.Repeat("0", StellarTomlMaxSize)+`"`,
+		)
+	stoml, err = c.GetStellarToml("toobig.org")
+	assert.EqualError(t, err, "stellar.toml file too big")
 
 	// not found
 	h.

--- a/clients/stellartoml/client_test.go
+++ b/clients/stellartoml/client_test.go
@@ -35,14 +35,16 @@ func TestClient(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "https://localhost/federation", stoml.FederationServer)
 
-	// stellar.toml too big
+	// stellar.toml exceeds limit
 	h.
 		On("GET", "https://toobig.org/.well-known/stellar.toml").
 		ReturnString(http.StatusOK,
 			`FEDERATION_SERVER="https://localhost/federation`+strings.Repeat("0", StellarTomlMaxSize)+`"`,
 		)
 	stoml, err = c.GetStellarToml("toobig.org")
-	assert.EqualError(t, err, "stellar.toml file too big")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "stellar.toml response exceeds")
+	}
 
 	// not found
 	h.

--- a/clients/stellartoml/main.go
+++ b/clients/stellartoml/main.go
@@ -2,6 +2,9 @@ package stellartoml
 
 import "net/http"
 
+// StellarTomlMaxSize is the maximum size of stellar.toml file
+const StellarTomlMaxSize = 5 * 1024
+
 // WellKnownPath represents the url path at which the stellar.toml file should
 // exist to conform to the federation protocol.
 const WellKnownPath = "/.well-known/stellar.toml"


### PR DESCRIPTION
Stellar.toml and Federation clients connect to untrusted servers. Responses from these servers can be a valid large toml/json that would need to be placed in memory. This can lead to out-of-memory errors and can ultimately crash the app using stellar/go.

This commit is using io.LimitReader to read no more than defined max size of stellar.toml and federation response.