### PR TITLE
Fix config

### DIFF
--- a/services/federation/main.go
+++ b/services/federation/main.go
@@ -30,8 +30,8 @@ type Config struct {
 		ReverseFederation string `toml:"reverse-federation" valid:"optional"`
 	} `valid:"required"`
 	TLS struct {
-		CertificateFile string `toml:"certificate-file"`
-		PrivateKeyFile  string `toml:"private-key-file"`
+		CertificateFile string `toml:"certificate-file" valid:"optional"`
+		PrivateKeyFile  string `toml:"private-key-file" valid:"optional"`
 	} `valid:"optional"`
 }
 

--- a/support/config/main_test.go
+++ b/support/config/main_test.go
@@ -83,3 +83,42 @@ func TestSeedValidator(t *testing.T) {
 	_, ok = fields["WrongType"]
 	assert.True(t, ok, "WrongType is not an invalid field")
 }
+
+func TestUndecoded(t *testing.T) {
+	var val struct {
+		Test string `toml:"test" valid:"optional"`
+		TLS  struct {
+			CertificateFile string `toml:"certificate-file" valid:"optional"`
+			PrivateKeyFile  string `toml:"private-key-file" valid:"optional"`
+		} `valid:"optional"`
+	}
+
+	// Notice _ in certificate_file
+	toml := `test="abc"
+[tls]
+certificate_file="hello"
+private-key-file="world"`
+
+	err := decode(toml, &val)
+	require.Error(t, err)
+	assert.Equal(t, "Unknown fields: [tls.certificate_file]", err.Error())
+}
+
+func TestCorrect(t *testing.T) {
+	var val struct {
+		Test string `toml:"test" valid:"optional"`
+		TLS  struct {
+			CertificateFile string `toml:"certificate-file" valid:"optional"`
+			PrivateKeyFile  string `toml:"private-key-file" valid:"optional"`
+		} `valid:"optional"`
+	}
+
+	// Notice _ in certificate_file
+	toml := `test="abc"
+[tls]
+certificate-file="hello"
+private-key-file="world"`
+
+	err := decode(toml, &val)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This PR contains two commits:
1. 4491b16 fixing federation server config file. Some fields didn't have `valid:"optional"` tag but govalidator requires all fields to have `valid` tags.
2. b45f11d close https://github.com/stellar/go/issues/36.