### PR TITLE
Support integer memo

### DIFF
--- a/clients/federation/client.go
+++ b/clients/federation/client.go
@@ -36,7 +36,7 @@ func (c *Client) LookupByAddress(addy string) (*proto.NameResponse, error) {
 		return nil, errors.Wrap(err, "get federation failed")
 	}
 
-	if resp.MemoType != "" && resp.Memo == "" {
+	if resp.MemoType != "" && resp.Memo.String() == "" {
 		return nil, errors.New("Invalid federation response (memo)")
 	}
 

--- a/clients/federation/client_test.go
+++ b/clients/federation/client_test.go
@@ -32,7 +32,7 @@ func TestLookupByAddress(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, "GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C", resp.AccountID)
 		assert.Equal(t, "id", resp.MemoType)
-		assert.Equal(t, "123", string(resp.Memo))
+		assert.Equal(t, "123", resp.Memo.String())
 	}
 
 	// happy path - integer
@@ -51,7 +51,7 @@ func TestLookupByAddress(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, "GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C", resp.AccountID)
 		assert.Equal(t, "id", resp.MemoType)
-		assert.Equal(t, "123", string(resp.Memo))
+		assert.Equal(t, "123", resp.Memo.String())
 	}
 
 	// happy path - string
@@ -70,7 +70,7 @@ func TestLookupByAddress(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, "GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C", resp.AccountID)
 		assert.Equal(t, "text", resp.MemoType)
-		assert.Equal(t, "testing", string(resp.Memo))
+		assert.Equal(t, "testing", resp.Memo.String())
 	}
 
 	// response exceeds limit

--- a/clients/federation/client_test.go
+++ b/clients/federation/client_test.go
@@ -16,7 +16,7 @@ func TestLookupByAddress(t *testing.T) {
 	tomlmock := &stellartoml.MockClient{}
 	c := &Client{StellarTOML: tomlmock, HTTP: hmock}
 
-	// happy path
+	// happy path - string integer
 	tomlmock.On("GetStellarToml", "stellar.org").Return(&stellartoml.Response{
 		FederationServer: "https://stellar.org/federation",
 	}, nil)
@@ -32,7 +32,45 @@ func TestLookupByAddress(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, "GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C", resp.AccountID)
 		assert.Equal(t, "id", resp.MemoType)
-		assert.Equal(t, "123", resp.Memo)
+		assert.Equal(t, "123", string(resp.Memo))
+	}
+
+	// happy path - integer
+	tomlmock.On("GetStellarToml", "stellar.org").Return(&stellartoml.Response{
+		FederationServer: "https://stellar.org/federation",
+	}, nil)
+	hmock.On("GET", "https://stellar.org/federation").
+		ReturnJSON(http.StatusOK, map[string]interface{}{
+			"stellar_address": "scott*stellar.org",
+			"account_id":      "GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C",
+			"memo_type":       "id",
+			"memo":            123,
+		})
+	resp, err = c.LookupByAddress("scott*stellar.org")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, "GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C", resp.AccountID)
+		assert.Equal(t, "id", resp.MemoType)
+		assert.Equal(t, "123", string(resp.Memo))
+	}
+
+	// happy path - string
+	tomlmock.On("GetStellarToml", "stellar.org").Return(&stellartoml.Response{
+		FederationServer: "https://stellar.org/federation",
+	}, nil)
+	hmock.On("GET", "https://stellar.org/federation").
+		ReturnJSON(http.StatusOK, map[string]interface{}{
+			"stellar_address": "scott*stellar.org",
+			"account_id":      "GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C",
+			"memo_type":       "text",
+			"memo":            "testing",
+		})
+	resp, err = c.LookupByAddress("scott*stellar.org")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, "GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C", resp.AccountID)
+		assert.Equal(t, "text", resp.MemoType)
+		assert.Equal(t, "testing", string(resp.Memo))
 	}
 
 	// response exceeds limit

--- a/handlers/federation/handler.go
+++ b/handlers/federation/handler.go
@@ -103,7 +103,7 @@ func (h *Handler) lookupByName(w http.ResponseWriter, q string) {
 
 	h.writeJSON(w, proto.NameResponse{
 		AccountID: rec.AccountID,
-		Memo:      rec.Memo,
+		Memo:      proto.Memo{rec.Memo},
 		MemoType:  rec.MemoType,
 	}, http.StatusOK)
 }
@@ -128,7 +128,7 @@ func (h *Handler) lookupByForward(w http.ResponseWriter, query url.Values) {
 
 	h.writeJSON(w, proto.NameResponse{
 		AccountID: rec.AccountID,
-		Memo:      rec.Memo,
+		Memo:      proto.Memo{rec.Memo},
 		MemoType:  rec.MemoType,
 	}, http.StatusOK)
 }

--- a/handlers/federation/handler_test.go
+++ b/handlers/federation/handler_test.go
@@ -189,6 +189,12 @@ func (fd ForwardTestDriver) LookupForwardingRecord(query url.Values) (*Record, e
 			MemoType:  "id",
 			Memo:      "1",
 		}, nil
+	} else if query.Get("acct") == "4321" {
+		return &Record{
+			AccountID: "GD2GJPL3UOK5LX7TWXOACK2ZPWPFSLBNKL3GTGH6BLBNISK4BGWMFBBG",
+			MemoType:  "text",
+			Memo:      "test",
+		}, nil
 	} else {
 		return nil, nil
 	}
@@ -216,7 +222,22 @@ func TestForwardHandler(t *testing.T) {
 		ContainsKey("memo_type").
 		ValueEqual("memo_type", "id").
 		ContainsKey("memo").
-		ValueEqual("memo", "1")
+		ValueEqual("memo", 1)
+
+		// Good forward request
+	server.GET("/federation").
+		WithQuery("type", "forward").
+		WithQuery("forward_type", "bank_account").
+		WithQuery("acct", "4321").
+		Expect().
+		Status(http.StatusOK).
+		JSON().Object().
+		ContainsKey("account_id").
+		ValueEqual("account_id", "GD2GJPL3UOK5LX7TWXOACK2ZPWPFSLBNKL3GTGH6BLBNISK4BGWMFBBG").
+		ContainsKey("memo_type").
+		ValueEqual("memo_type", "text").
+		ContainsKey("memo").
+		ValueEqual("memo", "test")
 
 	// Not Found forward request
 	server.GET("/federation").

--- a/protocols/federation/main.go
+++ b/protocols/federation/main.go
@@ -1,11 +1,18 @@
 package federation
 
+import (
+	"encoding/json"
+)
+
 // NameResponse represents the result of a federation request
 // for `name` and `forward` requests.
 type NameResponse struct {
 	AccountID string `json:"account_id"`
 	MemoType  string `json:"memo_type,omitempty"`
-	Memo      string `json:"memo,omitempty"`
+	// We are using json.Number to support unmarshalling integer
+	// values into `memo` field. This will contain string value of
+	// numeric `memo` (123/"123") but also normal string values.
+	Memo json.Number `json:"memo,omitempty"`
 }
 
 // IDResponse represents the result of a federation request

--- a/protocols/federation/main.go
+++ b/protocols/federation/main.go
@@ -2,6 +2,7 @@ package federation
 
 import (
 	"encoding/json"
+	"strconv"
 )
 
 // NameResponse represents the result of a federation request
@@ -9,14 +10,51 @@ import (
 type NameResponse struct {
 	AccountID string `json:"account_id"`
 	MemoType  string `json:"memo_type,omitempty"`
-	// We are using json.Number to support unmarshalling integer
-	// values into `memo` field. This will contain string value of
-	// numeric `memo` (123/"123") but also normal string values.
-	Memo json.Number `json:"memo,omitempty"`
+	Memo      Memo   `json:"memo,omitempty"`
 }
 
 // IDResponse represents the result of a federation request
 // for `id` request.
 type IDResponse struct {
 	Address string `json:"stellar_address"`
+}
+
+// Memo value can be either integer or string in JSON. This struct
+// allows marshaling and unmarshaling both types.
+type Memo struct {
+	Value string
+}
+
+func (m Memo) MarshalJSON() ([]byte, error) {
+	// Attempt to ParseUint. If this marshal m.Value
+	// and return JSON string.
+	_, err := strconv.ParseUint(m.Value, 10, 64)
+	if err != nil {
+		jsonString, err := json.Marshal(m.Value)
+		if err != nil {
+			return []byte{}, err
+		}
+		return jsonString, nil
+	}
+	return []byte(m.Value), nil
+}
+
+func (m *Memo) UnmarshalJSON(value []byte) error {
+	// Try to unmarshal value into uint64. If that fails
+	// unmarshal into string.
+	var uintValue uint64
+	err := json.Unmarshal(value, &uintValue)
+	if err == nil {
+		m.Value = strconv.FormatUint(uintValue, 10)
+		return nil
+	}
+	err = json.Unmarshal(value, &m.Value)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Memo) String() string {
+	return m.Value
 }

--- a/protocols/federation/main_test.go
+++ b/protocols/federation/main_test.go
@@ -1,0 +1,41 @@
+package federation
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshal(t *testing.T) {
+	var m Memo
+
+	m = Memo{"123"}
+	value, err := json.Marshal(m)
+	assert.NoError(t, err)
+	assert.Equal(t, "123", string(value))
+
+	m = Memo{"Test"}
+	value, err = json.Marshal(m)
+	assert.NoError(t, err)
+	assert.Equal(t, `"Test"`, string(value))
+}
+
+func TestUnmarshal(t *testing.T) {
+	var m Memo
+
+	err := json.Unmarshal([]byte("123"), &m)
+	assert.NoError(t, err)
+	assert.Equal(t, "123", m.Value)
+
+	err = json.Unmarshal([]byte(`"123"`), &m)
+	assert.NoError(t, err)
+	assert.Equal(t, "123", m.Value)
+
+	err = json.Unmarshal([]byte(`"Test"`), &m)
+	assert.NoError(t, err)
+	assert.Equal(t, "Test", m.Value)
+
+	err = json.Unmarshal([]byte("-123"), &m)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Unmarshalling integer values (`"memo": 123`) was returning an error:
```
json: cannot unmarshal number into Go struct field NameResponse.memo of type string
```