### PR TITLE
New horizon.Client methods

### DIFF
--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -35,11 +35,44 @@ func (c *Client) LoadAccount(accountID string) (account Account, err error) {
 	return
 }
 
+// LoadAccountOffers loads the account state from horizon. err can be either error
+// object or horizon.Error object.
+func (c *Client) LoadAccountOffers(accountID string, params ...interface{}) (offers OffersPage, err error) {
+	query := url.Values{}
+	for _, param := range params {
+		switch param := param.(type) {
+		case Limit:
+			query.Add("limit", strconv.Itoa(int(param)))
+		case Order:
+			query.Add("order", string(param))
+		case Cursor:
+			query.Add("cursor", string(param))
+		default:
+			err = fmt.Errorf("Undefined parameter: %+v", param)
+			return
+		}
+	}
+
+	var q string
+	if len(query) > 0 {
+		q = "?" + query.Encode()
+	}
+
+	url := fmt.Sprintf("%s/accounts/%s/offers%s", c.URL, accountID, q)
+	resp, err := c.HTTP.Get(url)
+	if err != nil {
+		return
+	}
+
+	err = decodeResponse(resp, &offers)
+	return
+}
+
 // LoadMemo loads memo for a transaction in Payment
 func (c *Client) LoadMemo(p *Payment) (err error) {
 	res, err := c.HTTP.Get(p.Links.Transaction.Href)
 	if err != nil {
-		return errors.Wrap(err, "load transaciton failed")
+		return errors.Wrap(err, "load transaction failed")
 	}
 	defer res.Body.Close()
 	return json.NewDecoder(res.Body).Decode(&p.Memo)
@@ -63,9 +96,30 @@ func (c *Client) SequenceForAccount(
 	return xdr.SequenceNumber(seq), nil
 }
 
-func (c *Client) stream(url string, cursor *string, handler func(data []byte) error) (err error) {
+// LoadOrderBook loads order book for given selling and buying assets.
+func (c *Client) LoadOrderBook(selling Asset, buying Asset) (orderBook OrderBookSummary, err error) {
+	query := url.Values{}
+
+	query.Add("selling_asset_type", selling.Type)
+	query.Add("selling_asset_code", selling.Code)
+	query.Add("selling_asset_issuer", selling.Issuer)
+
+	query.Add("buying_asset_type", buying.Type)
+	query.Add("buying_asset_code", buying.Code)
+	query.Add("buying_asset_issuer", buying.Issuer)
+
+	resp, err := c.HTTP.Get(c.URL + "/order_book?" + query.Encode())
+	if err != nil {
+		return
+	}
+
+	err = decodeResponse(resp, &orderBook)
+	return
+}
+
+func (c *Client) stream(url string, cursor *Cursor, handler func(data []byte) error) (err error) {
 	if cursor != nil {
-		url += "?cursor=" + *cursor
+		url += "?cursor=" + string(*cursor)
 	}
 
 	req, err := http.NewRequest("GET", url, nil)
@@ -120,8 +174,22 @@ func (c *Client) stream(url string, cursor *string, handler func(data []byte) er
 	return nil
 }
 
+// StreamLedgers streams incoming ledgers
+func (c *Client) StreamLedgers(cursor *Cursor, handler LedgerHandler) (err error) {
+	url := fmt.Sprintf("%s/ledgers", c.URL)
+	return c.stream(url, cursor, func(data []byte) error {
+		var ledger Ledger
+		err = json.Unmarshal(data, &ledger)
+		if err != nil {
+			return errors.Wrap(err, "Error unmarshaling data")
+		}
+		handler(ledger)
+		return nil
+	})
+}
+
 // StreamPayments streams incoming payments
-func (c *Client) StreamPayments(accountID string, cursor *string, handler PaymentHandler) (err error) {
+func (c *Client) StreamPayments(accountID string, cursor *Cursor, handler PaymentHandler) (err error) {
 	url := fmt.Sprintf("%s/accounts/%s/payments", c.URL, accountID)
 	return c.stream(url, cursor, func(data []byte) error {
 		var payment Payment
@@ -135,7 +203,7 @@ func (c *Client) StreamPayments(accountID string, cursor *string, handler Paymen
 }
 
 // StreamTransactions streams incoming transactions
-func (c *Client) StreamTransactions(accountID string, cursor *string, handler TransactionHandler) (err error) {
+func (c *Client) StreamTransactions(accountID string, cursor *Cursor, handler TransactionHandler) (err error) {
 	url := fmt.Sprintf("%s/accounts/%s/transactions", c.URL, accountID)
 	return c.stream(url, cursor, func(data []byte) error {
 		var transaction Transaction

--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -35,7 +35,7 @@ func (c *Client) LoadAccount(accountID string) (account Account, err error) {
 	return
 }
 
-// LoadAccountOffers loads the account state from horizon. err can be either error
+// LoadAccountOffers loads the account offers from horizon. err can be either error
 // object or horizon.Error object.
 func (c *Client) LoadAccountOffers(accountID string, params ...interface{}) (offers OffersPage, err error) {
 	query := url.Values{}

--- a/clients/horizon/main_test.go
+++ b/clients/horizon/main_test.go
@@ -73,6 +73,108 @@ var _ = Describe("Horizon", func() {
 		})
 	})
 
+	Describe("LoadAccountOffers", func() {
+		It("success response", func() {
+			hmock.On(
+				"GET",
+				"https://localhost/accounts/GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK/offers?cursor=a&limit=50&order=desc",
+			).ReturnString(200, accountOffersResponse)
+
+			offers, err := client.LoadAccountOffers("GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK", Cursor("a"), Limit(50), OrderDesc)
+			Expect(err).To(BeNil())
+			Expect(len(offers.Embedded.Records)).To(Equal(2))
+			Expect(offers.Embedded.Records[0].ID).To(Equal(int64(161)))
+			Expect(offers.Embedded.Records[0].Seller).To(Equal("GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK"))
+			Expect(offers.Embedded.Records[0].Price).To(Equal("450000.0000000"))
+			Expect(offers.Embedded.Records[0].Buying.Type).To(Equal("native"))
+			Expect(offers.Embedded.Records[0].Selling.Type).To(Equal("credit_alphanum4"))
+			Expect(offers.Embedded.Records[0].Selling.Code).To(Equal("XBT"))
+			Expect(offers.Embedded.Records[0].Selling.Issuer).To(Equal("GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U"))
+		})
+
+		It("failure response", func() {
+			hmock.On(
+				"GET",
+				"https://localhost/accounts/GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK/offers",
+			).ReturnString(404, notFoundResponse)
+
+			_, err := client.LoadAccountOffers("GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK")
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(Equal("Horizon error"))
+			horizonError, ok := err.(*Error)
+			Expect(ok).To(BeTrue())
+			Expect(horizonError.Problem.Title).To(Equal("Resource Missing"))
+		})
+
+		It("connection error", func() {
+			hmock.On(
+				"GET",
+				"https://localhost/accounts/GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK/offers",
+			).ReturnError("http.Client error")
+
+			_, err := client.LoadAccountOffers("GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK")
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(ContainSubstring("http.Client error"))
+			_, ok := err.(*Error)
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Describe("LoadOrderBook", func() {
+		It("success response", func() {
+			hmock.On(
+				"GET",
+				"https://localhost/order_book?buying_asset_code=DEMO&buying_asset_issuer=GBAMBOOZDWZPVV52RCLJQYMQNXOBLOXWNQAY2IF2FREV2WL46DBCH3BE&buying_asset_type=credit_alphanum4&selling_asset_code=&selling_asset_issuer=&selling_asset_type=native",
+			).ReturnString(200, orderBookResponse)
+
+			orderBook, err := client.LoadOrderBook(Asset{Type: "native"}, Asset{"credit_alphanum4", "DEMO", "GBAMBOOZDWZPVV52RCLJQYMQNXOBLOXWNQAY2IF2FREV2WL46DBCH3BE"})
+			Expect(err).To(BeNil())
+			Expect(orderBook.Selling.Type).To(Equal("native"))
+			Expect(orderBook.Buying.Type).To(Equal("credit_alphanum4"))
+			Expect(orderBook.Buying.Code).To(Equal("DEMO"))
+			Expect(orderBook.Buying.Issuer).To(Equal("GBAMBOOZDWZPVV52RCLJQYMQNXOBLOXWNQAY2IF2FREV2WL46DBCH3BE"))
+
+			Expect(len(orderBook.Bids)).To(Equal(20))
+			Expect(orderBook.Bids[0].Price).To(Equal("0.0024937"))
+			Expect(orderBook.Bids[0].Amount).To(Equal("0.4363975"))
+			Expect(orderBook.Bids[0].PriceR.N).To(Equal(int32(24937)))
+			Expect(orderBook.Bids[0].PriceR.D).To(Equal(int32(10000000)))
+
+			Expect(len(orderBook.Asks)).To(Equal(20))
+			Expect(orderBook.Asks[0].Price).To(Equal("0.0025093"))
+			Expect(orderBook.Asks[0].Amount).To(Equal("1248.9663104"))
+			Expect(orderBook.Asks[0].PriceR.N).To(Equal(int32(2017413)))
+			Expect(orderBook.Asks[0].PriceR.D).To(Equal(int32(803984111)))
+		})
+
+		It("failure response", func() {
+			hmock.On(
+				"GET",
+				"https://localhost/order_book?buying_asset_code=DEMO&buying_asset_issuer=GBAMBOOZDWZPVV52RCLJQYMQNXOBLOXWNQAY2IF2FREV2WL46DBCH3BE&buying_asset_type=credit_alphanum4&selling_asset_code=&selling_asset_issuer=&selling_asset_type=native",
+			).ReturnString(404, notFoundResponse)
+
+			_, err := client.LoadOrderBook(Asset{Type: "native"}, Asset{"credit_alphanum4", "DEMO", "GBAMBOOZDWZPVV52RCLJQYMQNXOBLOXWNQAY2IF2FREV2WL46DBCH3BE"})
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(Equal("Horizon error"))
+			horizonError, ok := err.(*Error)
+			Expect(ok).To(BeTrue())
+			Expect(horizonError.Problem.Title).To(Equal("Resource Missing"))
+		})
+
+		It("connection error", func() {
+			hmock.On(
+				"GET",
+				"https://localhost/order_book?buying_asset_code=DEMO&buying_asset_issuer=GBAMBOOZDWZPVV52RCLJQYMQNXOBLOXWNQAY2IF2FREV2WL46DBCH3BE&buying_asset_type=credit_alphanum4&selling_asset_code=&selling_asset_issuer=&selling_asset_type=native",
+			).ReturnError("http.Client error")
+
+			_, err := client.LoadOrderBook(Asset{Type: "native"}, Asset{"credit_alphanum4", "DEMO", "GBAMBOOZDWZPVV52RCLJQYMQNXOBLOXWNQAY2IF2FREV2WL46DBCH3BE"})
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(ContainSubstring("http.Client error"))
+			_, ok := err.(*Error)
+			Expect(ok).To(BeFalse())
+		})
+	})
+
 	Describe("SubmitTransaction", func() {
 		var tx = "AAAAADSMMRmQGDH6EJzkgi/7PoKhphMHyNGQgDp2tlS/dhGXAAAAZAAT3TUAAAAwAAAAAAAAAAAAAAABAAAAAAAAAAMAAAABSU5SAAAAAAA0jDEZkBgx+hCc5IIv+z6CoaYTB8jRkIA6drZUv3YRlwAAAAFVU0QAAAAAADSMMRmQGDH6EJzkgi/7PoKhphMHyNGQgDp2tlS/dhGXAAAAAAX14QAAAAAKAAAAAQAAAAAAAAAAAAAAAAAAAAG/dhGXAAAAQLuStfImg0OeeGAQmvLkJSZ1MPSkCzCYNbGqX5oYNuuOqZ5SmWhEsC7uOD9ha4V7KengiwNlc0oMNqBVo22S7gk="
 
@@ -175,6 +277,413 @@ var accountResponse = `{
   ],
   "data": {
     "test": "R0NCVkwzU1FGRVZLUkxQNkFKNDdVS0tXWUVCWTQ1V0hBSkhDRVpLVldNVEdNQ1Q0SDROS1FZTEg="
+  }
+}`
+
+var accountOffersResponse = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon.stellar.org/accounts/GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK/offers?order=asc\u0026limit=10\u0026cursor="
+    },
+    "next": {
+      "href": "https://horizon.stellar.org/accounts/GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK/offers?order=asc\u0026limit=10\u0026cursor=2539"
+    },
+    "prev": {
+      "href": "https://horizon.stellar.org/accounts/GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK/offers?order=desc\u0026limit=10\u0026cursor=161"
+    }
+  },
+  "_embedded": {
+    "records": [
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon.stellar.org/offers/161"
+          },
+          "offer_maker": {
+            "href": "https://horizon.stellar.org/accounts/GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK"
+          }
+        },
+        "id": 161,
+        "paging_token": "161",
+        "seller": "GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK",
+        "selling": {
+          "asset_type": "credit_alphanum4",
+          "asset_code": "XBT",
+          "asset_issuer": "GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U"
+        },
+        "buying": {
+          "asset_type": "native"
+        },
+        "amount": "0.0000100",
+        "price_r": {
+          "n": 450000,
+          "d": 1
+        },
+        "price": "450000.0000000"
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon.stellar.org/offers/2539"
+          },
+          "offer_maker": {
+            "href": "https://horizon.stellar.org/accounts/GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK"
+          }
+        },
+        "id": 2539,
+        "paging_token": "2539",
+        "seller": "GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK",
+        "selling": {
+          "asset_type": "credit_alphanum4",
+          "asset_code": "EUR",
+          "asset_issuer": "GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U"
+        },
+        "buying": {
+          "asset_type": "native"
+        },
+        "amount": "4.9129252",
+        "price_r": {
+          "n": 588,
+          "d": 1
+        },
+        "price": "588.0000000"
+      }
+    ]
+  }
+}`
+
+var orderBookResponse = `{
+  "bids": [
+    {
+      "price_r": {
+        "n": 24937,
+        "d": 10000000
+      },
+      "price": "0.0024937",
+      "amount": "0.4363975"
+    },
+    {
+      "price_r": {
+        "n": 24817,
+        "d": 10000000
+      },
+      "price": "0.0024817",
+      "amount": "0.6800000"
+    },
+    {
+      "price_r": {
+        "n": 1787762,
+        "d": 737341097
+      },
+      "price": "0.0024246",
+      "amount": "0.7078008"
+    },
+    {
+      "price_r": {
+        "n": 4638606,
+        "d": 1914900241
+      },
+      "price": "0.0024224",
+      "amount": "32.0067435"
+    },
+    {
+      "price_r": {
+        "n": 2048926,
+        "d": 845926319
+      },
+      "price": "0.0024221",
+      "amount": "5.9303650"
+    },
+    {
+      "price_r": {
+        "n": 4315154,
+        "d": 1782416791
+      },
+      "price": "0.0024210",
+      "amount": "2.6341583"
+    },
+    {
+      "price_r": {
+        "n": 3360181,
+        "d": 1397479136
+      },
+      "price": "0.0024045",
+      "amount": "5.9948532"
+    },
+    {
+      "price_r": {
+        "n": 2367836,
+        "d": 985908229
+      },
+      "price": "0.0024017",
+      "amount": "3.8896537"
+    },
+    {
+      "price_r": {
+        "n": 4687363,
+        "d": 1952976585
+      },
+      "price": "0.0024001",
+      "amount": "1.5747618"
+    },
+    {
+      "price_r": {
+        "n": 903753,
+        "d": 380636870
+      },
+      "price": "0.0023743",
+      "amount": "1.6182054"
+    },
+    {
+      "price_r": {
+        "n": 2562439,
+        "d": 1081514977
+      },
+      "price": "0.0023693",
+      "amount": "15.1310429"
+    },
+    {
+      "price_r": {
+        "n": 2588843,
+        "d": 1129671233
+      },
+      "price": "0.0022917",
+      "amount": "2.7172038"
+    },
+    {
+      "price_r": {
+        "n": 3249035,
+        "d": 1425861493
+      },
+      "price": "0.0022786",
+      "amount": "6.7610234"
+    },
+    {
+      "price_r": {
+        "n": 629489,
+        "d": 284529942
+      },
+      "price": "0.0022124",
+      "amount": "8.6216043"
+    },
+    {
+      "price_r": {
+        "n": 1428194,
+        "d": 664535371
+      },
+      "price": "0.0021492",
+      "amount": "11.0263350"
+    },
+    {
+      "price_r": {
+        "n": 1653667,
+        "d": 771446377
+      },
+      "price": "0.0021436",
+      "amount": "26.0527506"
+    },
+    {
+      "price_r": {
+        "n": 3613348,
+        "d": 1709911165
+      },
+      "price": "0.0021132",
+      "amount": "1.6923954"
+    },
+    {
+      "price_r": {
+        "n": 2674223,
+        "d": 1280335392
+      },
+      "price": "0.0020887",
+      "amount": "0.9882259"
+    },
+    {
+      "price_r": {
+        "n": 3594842,
+        "d": 1769335169
+      },
+      "price": "0.0020317",
+      "amount": "6.6846233"
+    },
+    {
+      "price_r": {
+        "n": 1526497,
+        "d": 751849545
+      },
+      "price": "0.0020303",
+      "amount": "3.5964310"
+    }
+  ],
+  "asks": [
+    {
+      "price_r": {
+        "n": 2017413,
+        "d": 803984111
+      },
+      "price": "0.0025093",
+      "amount": "1248.9663104"
+    },
+    {
+      "price_r": {
+        "n": 2687972,
+        "d": 1067615183
+      },
+      "price": "0.0025177",
+      "amount": "6286.5014925"
+    },
+    {
+      "price_r": {
+        "n": 845303,
+        "d": 332925720
+      },
+      "price": "0.0025390",
+      "amount": "1203.8364195"
+    },
+    {
+      "price_r": {
+        "n": 5147713,
+        "d": 2017340695
+      },
+      "price": "0.0025517",
+      "amount": "668.0464888"
+    },
+    {
+      "price_r": {
+        "n": 2372938,
+        "d": 877879233
+      },
+      "price": "0.0027030",
+      "amount": "4953.5042925"
+    },
+    {
+      "price_r": {
+        "n": 5177131,
+        "d": 1895808254
+      },
+      "price": "0.0027308",
+      "amount": "3691.8772552"
+    },
+    {
+      "price_r": {
+        "n": 2219932,
+        "d": 812231813
+      },
+      "price": "0.0027331",
+      "amount": "1948.1788496"
+    },
+    {
+      "price_r": {
+        "n": 4285123,
+        "d": 1556796383
+      },
+      "price": "0.0027525",
+      "amount": "5274.3733332"
+    },
+    {
+      "price_r": {
+        "n": 3945179,
+        "d": 1402780548
+      },
+      "price": "0.0028124",
+      "amount": "1361.9590574"
+    },
+    {
+      "price_r": {
+        "n": 4683683,
+        "d": 1664729678
+      },
+      "price": "0.0028135",
+      "amount": "5076.0909147"
+    },
+    {
+      "price_r": {
+        "n": 1489326,
+        "d": 524639179
+      },
+      "price": "0.0028388",
+      "amount": "2303.2370107"
+    },
+    {
+      "price_r": {
+        "n": 3365104,
+        "d": 1176168157
+      },
+      "price": "0.0028611",
+      "amount": "8080.5751770"
+    },
+    {
+      "price_r": {
+        "n": 2580607,
+        "d": 899476885
+      },
+      "price": "0.0028690",
+      "amount": "3733.5054174"
+    },
+    {
+      "price_r": {
+        "n": 5213871,
+        "d": 1788590825
+      },
+      "price": "0.0029151",
+      "amount": "485.7370041"
+    },
+    {
+      "price_r": {
+        "n": 4234565,
+        "d": 1447134374
+      },
+      "price": "0.0029262",
+      "amount": "7936.6430110"
+    },
+    {
+      "price_r": {
+        "n": 674413,
+        "d": 230022877
+      },
+      "price": "0.0029319",
+      "amount": "101.5325328"
+    },
+    {
+      "price_r": {
+        "n": 1554515,
+        "d": 514487004
+      },
+      "price": "0.0030215",
+      "amount": "5407.8562112"
+    },
+    {
+      "price_r": {
+        "n": 5638983,
+        "d": 1850050675
+      },
+      "price": "0.0030480",
+      "amount": "3024.9341116"
+    },
+    {
+      "price_r": {
+        "n": 31027,
+        "d": 10000000
+      },
+      "price": "0.0031027",
+      "amount": "18911.2836169"
+    },
+    {
+      "price_r": {
+        "n": 15899,
+        "d": 5000000
+      },
+      "price": "0.0031798",
+      "amount": "3767.4827430"
+    }
+  ],
+  "base": {
+    "asset_type": "native"
+  },
+  "counter": {
+    "asset_type": "credit_alphanum4",
+    "asset_code": "DEMO",
+    "asset_issuer": "GBAMBOOZDWZPVV52RCLJQYMQNXOBLOXWNQAY2IF2FREV2WL46DBCH3BE"
   }
 }`
 

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -13,20 +13,47 @@ func (m *MockClient) LoadAccount(accountID string) (Account, error) {
 	return a.Get(0).(Account), a.Error(1)
 }
 
+// LoadAccountOffers is a mocking a method
+func (m *MockClient) LoadAccountOffers(accountID string, params ...interface{}) (offers OffersPage, err error) {
+	// There is no way to simply call:
+	//
+	// a := m.Called(accountID, params...)
+	//
+	// Go errors with: "too many arguments in call to m.Mock.Called"
+	args := []interface{}{accountID}
+	for _, param := range params {
+		args = append(args, param)
+	}
+	a := m.Called(args...)
+	return a.Get(0).(OffersPage), a.Error(1)
+}
+
 // LoadMemo is a mocking a method
 func (m *MockClient) LoadMemo(p *Payment) error {
 	a := m.Called(p)
 	return a.Error(0)
 }
 
+// LoadOrderBook is a mocking a method
+func (m *MockClient) LoadOrderBook(selling Asset, buying Asset) (orderBook OrderBookSummary, err error) {
+	a := m.Called(selling, buying)
+	return a.Get(0).(OrderBookSummary), a.Error(1)
+}
+
+// StreamLedgers is a mocking a method
+func (m *MockClient) StreamLedgers(cursor *Cursor, handler LedgerHandler) error {
+	a := m.Called(cursor, handler)
+	return a.Error(0)
+}
+
 // StreamPayments is a mocking a method
-func (m *MockClient) StreamPayments(accountID string, cursor *string, handler PaymentHandler) error {
+func (m *MockClient) StreamPayments(accountID string, cursor *Cursor, handler PaymentHandler) error {
 	a := m.Called(accountID, cursor, handler)
 	return a.Error(0)
 }
 
 // StreamTransactions is a mocking a method
-func (m *MockClient) StreamTransactions(accountID string, cursor *string, handler TransactionHandler) error {
+func (m *MockClient) StreamTransactions(accountID string, cursor *Cursor, handler TransactionHandler) error {
 	a := m.Called(accountID, cursor, handler)
 	return a.Error(0)
 }
@@ -36,3 +63,6 @@ func (m *MockClient) SubmitTransaction(txeBase64 string) (TransactionSuccess, er
 	a := m.Called(txeBase64)
 	return a.Get(0).(TransactionSuccess), a.Error(1)
 }
+
+// ensure that the MockClient implements ClientInterface
+var _ ClientInterface = &MockClient{}

--- a/clients/horizon/responses.go
+++ b/clients/horizon/responses.go
@@ -93,9 +93,56 @@ type HistoryAccount struct {
 	AccountID string `json:"account_id"`
 }
 
+type Ledger struct {
+	Links struct {
+		Self         Link `json:"self"`
+		Transactions Link `json:"transactions"`
+		Operations   Link `json:"operations"`
+		Payments     Link `json:"payments"`
+		Effects      Link `json:"effects"`
+	} `json:"_links"`
+	ID               string    `json:"id"`
+	PT               string    `json:"paging_token"`
+	Hash             string    `json:"hash"`
+	PrevHash         string    `json:"prev_hash,omitempty"`
+	Sequence         int32     `json:"sequence"`
+	TransactionCount int32     `json:"transaction_count"`
+	OperationCount   int32     `json:"operation_count"`
+	ClosedAt         time.Time `json:"closed_at"`
+	TotalCoins       string    `json:"total_coins"`
+	FeePool          string    `json:"fee_pool"`
+	BaseFee          int32     `json:"base_fee"`
+	BaseReserve      string    `json:"base_reserve"`
+	MaxTxSetSize     int32     `json:"max_tx_set_size"`
+	ProtocolVersion  int32     `json:"protocol_version"`
+}
+
 type Link struct {
 	Href      string `json:"href"`
 	Templated bool   `json:"templated,omitempty"`
+}
+
+type Offer struct {
+	Links struct {
+		Self       Link `json:"self"`
+		OfferMaker Link `json:"offer_maker"`
+	} `json:"_links"`
+
+	ID      int64  `json:"id"`
+	PT      string `json:"paging_token"`
+	Seller  string `json:"seller"`
+	Selling Asset  `json:"selling"`
+	Buying  Asset  `json:"buying"`
+	Amount  string `json:"amount"`
+	PriceR  Price  `json:"price_r"`
+	Price   string `json:"price"`
+}
+
+type OrderBookSummary struct {
+	Bids    []PriceLevel `json:"bids"`
+	Asks    []PriceLevel `json:"asks"`
+	Selling Asset        `json:"base"`
+	Buying  Asset        `json:"counter"`
 }
 
 type TransactionSuccess struct {
@@ -123,6 +170,17 @@ type Signer struct {
 	Type      string `json:"type"`
 }
 
+type OffersPage struct {
+	Links struct {
+		Self Link `json:"self"`
+		Next Link `json:"next"`
+		Prev Link `json:"prev"`
+	} `json:"_links"`
+	Embedded struct {
+		Records []Offer `json:"records"`
+	} `json:"_embedded"`
+}
+
 type Payment struct {
 	ID          string `json:"id"`
 	Type        string `json:"type"`
@@ -147,6 +205,17 @@ type Payment struct {
 		Type  string `json:"memo_type"`
 		Value string `json:"memo"`
 	}
+}
+
+type Price struct {
+	N int32 `json:"n"`
+	D int32 `json:"d"`
+}
+
+type PriceLevel struct {
+	PriceR Price  `json:"price_r"`
+	Price  string `json:"price"`
+	Amount string `json:"amount"`
 }
 
 type Transaction struct {


### PR DESCRIPTION
Added three requested methods:
```go
LoadAccountOffers(accountID string, params ...interface{}) (offers OffersPage, err error)
LoadOrderBook(selling Asset, buying Asset) (orderBook OrderBookSummary, err error)
StreamLedgers(cursor *Cursor, handler LedgerHandler) error
```

Additionally created `ClientInterface` to ensure both `Client` and `MockClient` implement the same methods.

Close #44 
Close #45 
Close #46 