### PR TITLE
Restart and cancel streaming

### DIFF
--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -134,14 +134,14 @@ func (c *Client) LoadOrderBook(selling Asset, buying Asset) (orderBook OrderBook
 	return
 }
 
-func (c *Client) stream(ctx context.Context, url string, cursor *Cursor, handler func(data []byte) error) error {
-	currentURL := url
+func (c *Client) stream(ctx context.Context, baseURL string, cursor *Cursor, handler func(data []byte) error) error {
+	query := url.Values{}
 	if cursor != nil {
-		currentURL += "?cursor=" + string(*cursor)
+		query.Set("cursor", string(*cursor))
 	}
 
 	for {
-		req, err := http.NewRequest("GET", currentURL, nil)
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s?%s", baseURL, query.Encode()), nil)
 		if err != nil {
 			return err
 		}
@@ -210,7 +210,7 @@ func (c *Client) stream(ctx context.Context, url string, cursor *Cursor, handler
 			}
 
 			if object.PT != "" {
-				currentURL = url + "?cursor=" + object.PT
+				query.Set("cursor", object.PT)
 			} else {
 				return errors.New("no paging_token in object: cannot continue")
 			}

--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -2,7 +2,6 @@ package horizon
 
 import (
 	"bufio"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
+	"golang.org/x/net/context"
 )
 
 // HomeDomainForAccount returns the home domain for the provided strkey-encoded

--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -2,6 +2,7 @@ package horizon
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -133,67 +134,102 @@ func (c *Client) LoadOrderBook(selling Asset, buying Asset) (orderBook OrderBook
 	return
 }
 
-func (c *Client) stream(url string, cursor *Cursor, handler func(data []byte) error) (err error) {
+func (c *Client) stream(ctx context.Context, url string, cursor *Cursor, handler func(data []byte) error) error {
+	currentURL := url
 	if cursor != nil {
-		url += "?cursor=" + string(*cursor)
+		currentURL += "?cursor=" + string(*cursor)
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return
-	}
-	req.Header.Set("Accept", "text/event-stream")
-
-	resp, err := c.HTTP.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	scanner := bufio.NewScanner(resp.Body)
-	scanner.Split(splitSSE)
-
-	for scanner.Scan() {
-		if len(scanner.Bytes()) == 0 {
-			continue
-		}
-
-		ev, err := parseEvent(scanner.Bytes())
+	for {
+		req, err := http.NewRequest("GET", currentURL, nil)
 		if err != nil {
 			return err
 		}
+		req.Header.Set("Accept", "text/event-stream")
 
-		if ev.Event != "message" {
-			continue
-		}
-
-		switch data := ev.Data.(type) {
-		case string:
-			err = handler([]byte(data))
-		case []byte:
-			err = handler(data)
-		default:
-			err = errors.New("Invalid ev.Data type")
-		}
+		resp, err := c.HTTP.Do(req)
 		if err != nil {
 			return err
 		}
-	}
+		defer resp.Body.Close()
+		scanner := bufio.NewScanner(resp.Body)
+		scanner.Split(splitSSE)
 
-	err = scanner.Err()
-	if err == io.ErrUnexpectedEOF {
-		return nil
-	}
-	if err != nil {
-		return err
+		var objectBytes []byte
+
+		for scanner.Scan() {
+			// Check if ctx is not cancelled
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+				// Continue streaming
+			}
+
+			if len(scanner.Bytes()) == 0 {
+				continue
+			}
+
+			ev, err := parseEvent(scanner.Bytes())
+			if err != nil {
+				return err
+			}
+
+			if ev.Event != "message" {
+				continue
+			}
+
+			switch data := ev.Data.(type) {
+			case string:
+				err = handler([]byte(data))
+				objectBytes = []byte(data)
+			case []byte:
+				err = handler(data)
+				objectBytes = data
+			default:
+				err = errors.New("Invalid ev.Data type")
+			}
+			if err != nil {
+				return err
+			}
+		}
+
+		err = scanner.Err()
+
+		// Start streaming from the next object:
+		// - if there was no error OR
+		// - if connection was lost
+		if err == nil || err == io.ErrUnexpectedEOF {
+			object := struct {
+				PT string `json:"paging_token"`
+			}{}
+
+			err := json.Unmarshal(objectBytes, &object)
+			if err != nil {
+				return errors.Wrap(err, "Error unmarshaling objectBytes")
+			}
+
+			if object.PT != "" {
+				currentURL = url + "?cursor=" + object.PT
+			} else {
+				return errors.New("no paging_token in object: cannot continue")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-// StreamLedgers streams incoming ledgers
-func (c *Client) StreamLedgers(cursor *Cursor, handler LedgerHandler) (err error) {
+// StreamLedgers streams incoming ledgers. Use context.WithCancel to stop streaming.
+func (c *Client) StreamLedgers(ctx context.Context, cursor *Cursor, handler LedgerHandler) (err error) {
 	url := fmt.Sprintf("%s/ledgers", c.URL)
-	return c.stream(url, cursor, func(data []byte) error {
+	return c.stream(ctx, url, cursor, func(data []byte) error {
 		var ledger Ledger
 		err = json.Unmarshal(data, &ledger)
 		if err != nil {
@@ -204,10 +240,10 @@ func (c *Client) StreamLedgers(cursor *Cursor, handler LedgerHandler) (err error
 	})
 }
 
-// StreamPayments streams incoming payments
-func (c *Client) StreamPayments(accountID string, cursor *Cursor, handler PaymentHandler) (err error) {
+// StreamPayments streams incoming payments. Use context.WithCancel to stop streaming.
+func (c *Client) StreamPayments(ctx context.Context, accountID string, cursor *Cursor, handler PaymentHandler) (err error) {
 	url := fmt.Sprintf("%s/accounts/%s/payments", c.URL, accountID)
-	return c.stream(url, cursor, func(data []byte) error {
+	return c.stream(ctx, url, cursor, func(data []byte) error {
 		var payment Payment
 		err = json.Unmarshal(data, &payment)
 		if err != nil {
@@ -218,10 +254,10 @@ func (c *Client) StreamPayments(accountID string, cursor *Cursor, handler Paymen
 	})
 }
 
-// StreamTransactions streams incoming transactions
-func (c *Client) StreamTransactions(accountID string, cursor *Cursor, handler TransactionHandler) (err error) {
+// StreamTransactions streams incoming transactions. Use context.WithCancel to stop streaming.
+func (c *Client) StreamTransactions(ctx context.Context, accountID string, cursor *Cursor, handler TransactionHandler) (err error) {
 	url := fmt.Sprintf("%s/accounts/%s/transactions", c.URL, accountID)
-	return c.stream(url, cursor, func(data []byte) error {
+	return c.stream(ctx, url, cursor, func(data []byte) error {
 		var transaction Transaction
 		err = json.Unmarshal(data, &transaction)
 		if err != nil {

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -7,6 +7,7 @@
 package horizon
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 
@@ -74,9 +75,9 @@ type ClientInterface interface {
 	LoadAccountOffers(accountID string, params ...interface{}) (offers OffersPage, err error)
 	LoadMemo(p *Payment) error
 	LoadOrderBook(selling Asset, buying Asset) (orderBook OrderBookSummary, err error)
-	StreamLedgers(cursor *Cursor, handler LedgerHandler) error
-	StreamPayments(accountID string, cursor *Cursor, handler PaymentHandler) error
-	StreamTransactions(accountID string, cursor *Cursor, handler TransactionHandler) error
+	StreamLedgers(ctx context.Context, cursor *Cursor, handler LedgerHandler) error
+	StreamPayments(ctx context.Context, accountID string, cursor *Cursor, handler PaymentHandler) error
+	StreamTransactions(ctx context.Context, accountID string, cursor *Cursor, handler TransactionHandler) error
 	SubmitTransaction(txeBase64 string) (TransactionSuccess, error)
 }
 

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -7,12 +7,12 @@
 package horizon
 
 import (
-	"context"
 	"net/http"
 	"net/url"
 
 	"github.com/stellar/go/build"
 	"github.com/stellar/go/support/errors"
+	"golang.org/x/net/context"
 )
 
 // DefaultTestNetClient is a default client to connect to test network

--- a/clients/horizon/main_test.go
+++ b/clients/horizon/main_test.go
@@ -1,13 +1,37 @@
 package horizon
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/http/httptest"
 )
+
+func ExampleStream() {
+	client := DefaultPublicNetClient
+	cursor := Cursor("now")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		// Stop streaming after 60 seconds.
+		time.Sleep(60 * time.Second)
+		cancel()
+	}()
+
+	err := client.StreamLedgers(ctx, &cursor, func(l Ledger) {
+		fmt.Println(l.Sequence)
+	})
+
+	if err != nil {
+		fmt.Println(err)
+	}
+}
 
 func TestHorizon(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/clients/horizon/main_test.go
+++ b/clients/horizon/main_test.go
@@ -1,7 +1,6 @@
 package horizon
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -10,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/http/httptest"
+	"golang.org/x/net/context"
 )
 
 func ExampleStream() {

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -1,9 +1,8 @@
 package horizon
 
 import (
-	"context"
-
 	"github.com/stretchr/testify/mock"
+	"golang.org/x/net/context"
 )
 
 // MockClient is a mockable horizon client.

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -1,6 +1,10 @@
 package horizon
 
-import "github.com/stretchr/testify/mock"
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
 
 // MockClient is a mockable horizon client.
 type MockClient struct {
@@ -41,20 +45,20 @@ func (m *MockClient) LoadOrderBook(selling Asset, buying Asset) (orderBook Order
 }
 
 // StreamLedgers is a mocking a method
-func (m *MockClient) StreamLedgers(cursor *Cursor, handler LedgerHandler) error {
-	a := m.Called(cursor, handler)
+func (m *MockClient) StreamLedgers(ctx context.Context, cursor *Cursor, handler LedgerHandler) error {
+	a := m.Called(ctx, cursor, handler)
 	return a.Error(0)
 }
 
 // StreamPayments is a mocking a method
-func (m *MockClient) StreamPayments(accountID string, cursor *Cursor, handler PaymentHandler) error {
-	a := m.Called(accountID, cursor, handler)
+func (m *MockClient) StreamPayments(ctx context.Context, accountID string, cursor *Cursor, handler PaymentHandler) error {
+	a := m.Called(ctx, accountID, cursor, handler)
 	return a.Error(0)
 }
 
 // StreamTransactions is a mocking a method
-func (m *MockClient) StreamTransactions(accountID string, cursor *Cursor, handler TransactionHandler) error {
-	a := m.Called(accountID, cursor, handler)
+func (m *MockClient) StreamTransactions(ctx context.Context, accountID string, cursor *Cursor, handler TransactionHandler) error {
+	a := m.Called(ctx, accountID, cursor, handler)
 	return a.Error(0)
 }
 


### PR DESCRIPTION
All streaming methods have been updated to restart in case of
recoverable errors or when horizon disconnects. They now also accept
context.Context as a first argument to allow cancelling streaming.

Close https://github.com/stellar/go/issues/43

Example:
```go
package main

import (
	"context"
	"fmt"
	"time"

	"github.com/stellar/go/clients/horizon"
)

func main() {
	client := horizon.DefaultPublicNetClient
	cursor := horizon.Cursor("now")

	ctx, cancel := context.WithCancel(context.Background())
	defer cancel()

	go func() {
		time.Sleep(60 * time.Second)
		cancel()
	}()

	err := client.StreamLedgers(ctx, &cursor, func(l horizon.Ledger) {
		fmt.Println(l.Sequence)
	})

	if err != nil {
		fmt.Println(err)
	}
}

```