### PR TITLE
Change Route field in compliance to Route type

### DIFF
--- a/protocols/compliance/main.go
+++ b/protocols/compliance/main.go
@@ -55,7 +55,7 @@ type Attachment struct {
 // Transaction represents transaction field in Stellar attachment
 type Transaction struct {
 	SenderInfo map[string]string `json:"sender_info"`
-	Route      string            `json:"route"`
+	Route      Route             `json:"route"`
 	Note       string            `json:"note"`
 	Extra      string            `json:"extra"`
 }
@@ -65,10 +65,13 @@ type Operation struct {
 	// Overriddes Transaction field for this operation
 	SenderInfo map[string]string `json:"sender_info"`
 	// Overriddes Transaction field for this operation
-	Route string `json:"route"`
+	Route Route `json:"route"`
 	// Overriddes Transaction field for this operation
 	Note string `json:"note"`
 }
+
+// Route allows unmarshalling both integer and string types into string
+type Route string
 
 // SenderInfo is a helper structure with standardized fields that contains
 // information about the sender. Use Map() method to transform it to

--- a/protocols/compliance/route.go
+++ b/protocols/compliance/route.go
@@ -1,0 +1,24 @@
+package compliance
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+func (r *Route) UnmarshalJSON(data []byte) error {
+	var number int64
+	err := json.Unmarshal(data, &number)
+	if err == nil {
+		*r = Route(strconv.FormatInt(number, 10))
+		return nil
+	}
+
+	var str string
+	err = json.Unmarshal(data, &str)
+	if err == nil {
+		*r = Route(str)
+		return nil
+	}
+
+	return err
+}

--- a/protocols/compliance/route_test.go
+++ b/protocols/compliance/route_test.go
@@ -1,0 +1,41 @@
+package compliance
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalNumber(t *testing.T) {
+	marshalledTx := `{"route": 15, "note": "note", "extra": "extra"}`
+	var tx Transaction
+	err := json.Unmarshal([]byte(marshalledTx), &tx)
+	require.Nil(t, err)
+	assert.Equal(t, Route("15"), tx.Route)
+}
+
+func TestUnmarshalString(t *testing.T) {
+	marshalledTx := `{"route": "15", "note": "note", "extra": "extra"}`
+	var tx Transaction
+	err := json.Unmarshal([]byte(marshalledTx), &tx)
+	require.Nil(t, err)
+	assert.Equal(t, Route("15"), tx.Route)
+}
+
+func TestUnmarshalInvalid(t *testing.T) {
+	marshalledTx := `{"route": test, "note": "note", "extra": "extra"}`
+	var tx Transaction
+	err := json.Unmarshal([]byte(marshalledTx), &tx)
+	assert.NotNil(t, err)
+}
+
+func TestMarshal(t *testing.T) {
+	tx := Transaction{
+		Route: "15",
+	}
+	bytes, err := json.Marshal(tx)
+	require.Nil(t, err)
+	assert.Equal(t, `{"sender_info":null,"route":"15","note":"","extra":""}`, string(bytes))
+}


### PR DESCRIPTION
Go's encoding/json Decoder returns error when trying to unmarshal number
into Go value of type string. This commit is introducing Route type
implementing Unmarshaler interface, that allows decoding both integer
and string values.