### PR TITLE
Improve `build.Asset` ergonomics

### DIFF
--- a/build/asset.go
+++ b/build/asset.go
@@ -1,0 +1,46 @@
+package build
+
+import (
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+// MustXDR is the panicky version of ToXDR
+func (a Asset) MustXDR() xdr.Asset {
+	ret, err := a.ToXDR()
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+// ToXDR creates xdr.Asset object from build.Asset object
+func (a Asset) ToXDR() (xdr.Asset, error) {
+	if a.Native {
+		return xdr.NewAsset(xdr.AssetTypeAssetTypeNative, nil)
+	}
+
+	var issuer xdr.AccountId
+	err := setAccountId(a.Issuer, &issuer)
+	if err != nil {
+		return xdr.Asset{}, err
+	}
+
+	length := len(a.Code)
+	switch {
+	case length >= 1 && length <= 4:
+		var codeArray [4]byte
+		byteArray := []byte(a.Code)
+		copy(codeArray[:], byteArray[0:length])
+		asset := xdr.AssetAlphaNum4{AssetCode: codeArray, Issuer: issuer}
+		return xdr.NewAsset(xdr.AssetTypeAssetTypeCreditAlphanum4, asset)
+	case length >= 5 && length <= 12:
+		var codeArray [12]byte
+		byteArray := []byte(a.Code)
+		copy(codeArray[:], byteArray[0:length])
+		asset := xdr.AssetAlphaNum12{AssetCode: codeArray, Issuer: issuer}
+		return xdr.NewAsset(xdr.AssetTypeAssetTypeCreditAlphanum12, asset)
+	default:
+		return xdr.Asset{}, errors.New("Asset code length is invalid")
+	}
+}

--- a/build/asset_test.go
+++ b/build/asset_test.go
@@ -1,0 +1,80 @@
+package build
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsset_ToXDR(t *testing.T) {
+	var (
+		issuer        xdr.AccountId
+		issuerAddress = "GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA"
+	)
+	require.NoError(t, issuer.SetAddress(issuerAddress))
+
+	type fields struct {
+		Code   string
+		Issuer string
+		Native bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    xdr.Asset
+		wantErr bool
+	}{
+		{
+			name:   "Native",
+			fields: fields{"", "", true},
+			want:   xdr.Asset{Type: xdr.AssetTypeAssetTypeNative},
+		},
+		{
+			name: "USD",
+			fields: fields{
+				"USD",
+				issuerAddress,
+				false,
+			},
+			want: xdr.Asset{
+				Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
+				AlphaNum4: &xdr.AssetAlphaNum4{
+					AssetCode: [4]byte{0x55, 0x53, 0x44, 0x00}, //USD
+					Issuer:    issuer,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Asset{
+				Code:   tt.fields.Code,
+				Issuer: tt.fields.Issuer,
+				Native: tt.fields.Native,
+			}
+			got, err := a.ToXDR()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Asset.ToXDR() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Asset.ToXDR() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAsset_MustXDR(t *testing.T) {
+	// good
+	assert.NotPanics(t, func() {
+		NativeAsset().MustXDR()
+	})
+
+	// bad
+	assert.Panics(t, func() {
+		CreditAsset("USD", "BONK").MustXDR()
+	})
+}

--- a/build/change_trust.go
+++ b/build/change_trust.go
@@ -52,7 +52,7 @@ func (m Asset) MutateChangeTrust(o *xdr.ChangeTrustOp) (err error) {
 		return errors.New("Native asset not allowed")
 	}
 
-	o.Line, err = m.ToXdrObject()
+	o.Line, err = m.ToXDR()
 	return
 }
 

--- a/build/main.go
+++ b/build/main.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stellar/go/amount"
 	"github.com/stellar/go/network"
-	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 
@@ -50,37 +49,6 @@ type Asset struct {
 	Code   string
 	Issuer string
 	Native bool
-}
-
-// ToXdrObject creates xdr.Asset object from build.Asset object
-func (a Asset) ToXdrObject() (xdr.Asset, error) {
-	if a.Native {
-		return xdr.NewAsset(xdr.AssetTypeAssetTypeNative, nil)
-	}
-
-	var issuer xdr.AccountId
-	err := setAccountId(a.Issuer, &issuer)
-	if err != nil {
-		return xdr.Asset{}, err
-	}
-
-	length := len(a.Code)
-	switch {
-	case length >= 1 && length <= 4:
-		var codeArray [4]byte
-		byteArray := []byte(a.Code)
-		copy(codeArray[:], byteArray[0:length])
-		asset := xdr.AssetAlphaNum4{AssetCode: codeArray, Issuer: issuer}
-		return xdr.NewAsset(xdr.AssetTypeAssetTypeCreditAlphanum4, asset)
-	case length >= 5 && length <= 12:
-		var codeArray [12]byte
-		byteArray := []byte(a.Code)
-		copy(codeArray[:], byteArray[0:length])
-		asset := xdr.AssetAlphaNum12{AssetCode: codeArray, Issuer: issuer}
-		return xdr.NewAsset(xdr.AssetTypeAssetTypeCreditAlphanum12, asset)
-	default:
-		return xdr.Asset{}, errors.New("Asset code length is invalid")
-	}
 }
 
 // AllowTrustAsset is a mutator capable of setting the asset on

--- a/build/manage_offer.go
+++ b/build/manage_offer.go
@@ -104,24 +104,24 @@ func (m Rate) MutateManageOffer(o interface{}) (err error) {
 	default:
 		err = errors.New("Unexpected operation type")
 	case *xdr.ManageOfferOp:
-		o.Selling, err = m.Selling.ToXdrObject()
+		o.Selling, err = m.Selling.ToXDR()
 		if err != nil {
 			return
 		}
 
-		o.Buying, err = m.Buying.ToXdrObject()
+		o.Buying, err = m.Buying.ToXDR()
 		if err != nil {
 			return
 		}
 
 		o.Price, err = price.Parse(string(m.Price))
 	case *xdr.CreatePassiveOfferOp:
-		o.Selling, err = m.Selling.ToXdrObject()
+		o.Selling, err = m.Selling.ToXDR()
 		if err != nil {
 			return
 		}
 
-		o.Buying, err = m.Buying.ToXdrObject()
+		o.Buying, err = m.Buying.ToXDR()
 		if err != nil {
 			return
 		}

--- a/build/payment.go
+++ b/build/payment.go
@@ -139,7 +139,7 @@ func (m PayWithPath) MutatePayment(o interface{}) (err error) {
 	var xdrAsset xdr.Asset
 
 	for _, asset := range m.Path {
-		xdrAsset, err = asset.ToXdrObject()
+		xdrAsset, err = asset.ToXDR()
 		if err != nil {
 			return err
 		}
@@ -150,6 +150,6 @@ func (m PayWithPath) MutatePayment(o interface{}) (err error) {
 	pathPaymentOp.Path = path
 
 	// Asset
-	pathPaymentOp.SendAsset, err = m.Asset.ToXdrObject()
+	pathPaymentOp.SendAsset, err = m.Asset.ToXDR()
 	return
 }


### PR DESCRIPTION
This PR adds the `Asset#MustXDR()` helper, making this struct more useful for constructing xdr data in programs that are fine with panicking, such as test functions.  `Asset#ToXdrObject()` is renamed to `Asset#ToXDR()` for consistency's sake. Also some tests were written.