### PR TITLE
Pass ErrorResponse errors from FederationDriver to end user

### DIFF
--- a/handlers/federation/handler.go
+++ b/handlers/federation/handler.go
@@ -156,5 +156,11 @@ func (h *Handler) writeJSON(
 
 func (h *Handler) writeError(w http.ResponseWriter, err error) {
 	log.Error(err)
-	http.Error(w, "An internal error occurred", http.StatusInternalServerError)
+
+	switch err := errors.Cause(err).(type) {
+	case ErrorResponse:
+		h.writeJSON(w, err, err.StatusCode)
+	default:
+		http.Error(w, "An internal error occurred", http.StatusInternalServerError)
+	}
 }

--- a/handlers/federation/main.go
+++ b/handlers/federation/main.go
@@ -29,10 +29,16 @@ type Driver interface {
 }
 
 // ErrorResponse represents the JSON response sent to a client when the request
-// triggered an error.
+// triggered an error. FederationDriver methods can return this as an error and
+// it will be passed to end user.
 type ErrorResponse struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
+	StatusCode int    `json:"-"`
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+}
+
+func (response ErrorResponse) Error() string {
+	return response.Message
 }
 
 // Handler represents an http handler that can service http requests that


### PR DESCRIPTION
Currently when `FederationDriver` methods return error
`federation.Handler` always sends "An internal error occurred" error
message. It is impossible to send another response, for example:
containing information about why request was invalid.

To solve this we make `ErrorResponse` implement error interface. By
doing this `FederationDriver` implementations can return `ErrorResponse`
as an error that will be passed to end user.