### PR TITLE
Fix Example functions in tests

### DIFF
--- a/build/main_test.go
+++ b/build/main_test.go
@@ -90,9 +90,9 @@ func ExampleSetOptions() {
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAUAAAABAAAAAKf5dCD2RflX5jEYTCZ2cHEwuB+QuJJh/0AIM3zwaiyoAAAAAQAAAAcAAAABAAAABwAAAAEAAAABAAAAAQAAAAIAAAABAAAAAwAAAAEAAAAEAAAAAQAAAAtzdGVsbGFyLm9yZwAAAAABAAAAALwxmfetrj7X13WT+tJjwj9VPrqIE2DUJ48+59etBKjTAAAABQAAAAAAAAABG0Mx8AAAAECZF17pOfZcyc7YJXMyx++PMydIvL6g2yZcPDY8h4+tmlz+3rsE6uuX0R6xfgNnuMntvK4YMmaOvp4DvaZMMNoA
 }
 
-// ExampleSetOptionsOperations creates and signs a simple transaction with many SetOptions operations, and then
+// ExampleSetOptions_manyOperations creates and signs a simple transaction with many SetOptions operations, and then
 // encodes it into a base64 string capable of being submitted to stellar-core.
-func ExampleSetOptionsOperations() {
+func ExampleSetOptions_manyOperations() {
 	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
 	tx := Transaction(
 		SourceAccount{seed},
@@ -136,9 +136,9 @@ func ExampleChangeTrust() {
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABVVNEAAAAAAAtJGku0Iu/Z5uhmUSIcNIZHodv7Nkv3Z9tJ02k5t4TQQAAAAA7wO+gAAAAAAAAAAEbQzHwAAAAQOIy19X38Y3jcFzvhDsmXu6iDzrzb4iwfS2NAq9GGAFiRJUGoFX85vKtlNcXzQppF4X8oIMNPEb74fuZE/N+GAE=
 }
 
-// ExampleChangeTrustMaxLimit creates and signs a simple transaction with ChangeTrust operation (maximum limit), and then
+// ExampleChangeTrust_maxLimit creates and signs a simple transaction with ChangeTrust operation (maximum limit), and then
 // encodes it into a base64 string capable of being submitted to stellar-core.
-func ExampleChangeTrustMaxLimit() {
+func ExampleChangeTrust_maxLimit() {
 	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
 	tx := Transaction(
 		SourceAccount{seed},

--- a/clients/horizon/main_test.go
+++ b/clients/horizon/main_test.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func ExampleStream() {
+func ExampleClient_StreamLedgers() {
 	client := DefaultPublicNetClient
 	cursor := Cursor("now")
 
@@ -31,6 +31,29 @@ func ExampleStream() {
 	if err != nil {
 		fmt.Println(err)
 	}
+}
+
+func ExampleClient_SubmitTransaction() {
+	client := DefaultPublicNetClient
+	transactionEnvelopeXdr := "AAAAABSxFjMo7qcQlJBlrZQypSqYsHA5hHaYxk5hFXwiehh6AAAAZAAIdakAAABZAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAFLEWMyjupxCUkGWtlDKlKpiwcDmEdpjGTmEVfCJ6GHoAAAAAAAAAAACYloAAAAAAAAAAASJ6GHoAAABAp0FnKOQ9lJPDXPTh/a91xoZ8BaznwLj59sdDGK94eGzCOk7oetw7Yw50yOSZg2mqXAST6Agc9Ao/f5T9gB+GCw=="
+
+	response, err := client.SubmitTransaction(transactionEnvelopeXdr)
+	if err != nil {
+		fmt.Println(err)
+		herr, isHorizonError := err.(*Error)
+		if isHorizonError {
+			resultCodes, err := herr.ResultCodes()
+			if err != nil {
+				fmt.Println("failed to extract result codes from horizon response")
+				return
+			}
+			fmt.Println(resultCodes)
+		}
+		return
+	}
+
+	fmt.Println("Success")
+	fmt.Println(response)
 }
 
 func TestHorizon(t *testing.T) {

--- a/clients/stellartoml/main_test.go
+++ b/clients/stellartoml/main_test.go
@@ -3,7 +3,7 @@ package stellartoml
 import "log"
 
 // ExampleGetTOML gets the stellar.toml file for coins.asia
-func ExampleGetTOML() {
+func ExampleClient_GetStellarToml() {
 	_, err := DefaultClient.GetStellarToml("coins.asia")
 	if err != nil {
 		log.Fatal(err)

--- a/xdr/main_test.go
+++ b/xdr/main_test.go
@@ -1,11 +1,36 @@
-package xdr_test
+package xdr
 
 import (
-	. "github.com/stellar/go/xdr"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+// ExampleUnmarshal shows the lowest-level process to decode a base64
+// envelope encoded in base64.
+func ExampleUnmarshal() {
+	data := "AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAACgAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAArqN6LeOagjxMaUP96Bzfs9e0corNZXzBWJkFoK7kvkwAAAAAO5rKAAAAAAAAAAABVvwF9wAAAEAKZ7IPj/46PuWU6ZOtyMosctNAkXRNX9WCAI5RnfRk+AyxDLoDZP/9l3NvsxQtWj9juQOuoBlFLnWu8intgxQA"
+
+	rawr := strings.NewReader(data)
+	b64r := base64.NewDecoder(base64.StdEncoding, rawr)
+
+	var tx TransactionEnvelope
+	bytesRead, err := Unmarshal(b64r, &tx)
+
+	fmt.Printf("read %d bytes\n", bytesRead)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("This tx has %d operations\n", len(tx.Tx.Operations))
+	// Output: read 192 bytes
+	// This tx has 1 operations
+}
 
 var _ = Describe("xdr.SafeUnmarshal", func() {
 	var (


### PR DESCRIPTION
Example functions in tests do not follow naming conventions of testing
package: https://golang.org/pkg/testing/#hdr-Examples Because of this
examples were not rendered in go docs.