### PR TITLE
wrap offerId around CreatePassiveOffer to make a ManageOffer

### DIFF
--- a/services/horizon/resource/operations/main.go
+++ b/services/horizon/resource/operations/main.go
@@ -52,12 +52,12 @@ func New(
 		err = row.UnmarshalDetails(&e)
 		result = e
 	case xdr.OperationTypeManageOffer:
-		e := ManageOffer{Base: base}
+		e := ManageOffer{}
+		e.CreatePassiveOffer.Base = base
 		err = row.UnmarshalDetails(&e)
 		result = e
 	case xdr.OperationTypeCreatePassiveOffer:
-		e := CreatePassiveOffer{}
-		e.ManageOffer.Base = base
+		e := CreatePassiveOffer{Base: base}
 		err = row.UnmarshalDetails(&e)
 		result = e
 	case xdr.OperationTypeSetOptions:
@@ -148,11 +148,10 @@ type ManageData struct {
 	Value string `json:"value"`
 }
 
-// ManageOffer is the json resource representing a single operation whose type
-// is ManageOffer.
-type ManageOffer struct {
+// CreatePassiveOffer is the json resource representing a single operation whose
+// type is CreatePassiveOffer.
+type CreatePassiveOffer struct {
 	Base
-	OfferID            int64      `json:"offer_id"`
 	Amount             string     `json:"amount"`
 	Price              string     `json:"price"`
 	PriceR             base.Price `json:"price_r"`
@@ -164,10 +163,11 @@ type ManageOffer struct {
 	SellingAssetIssuer string     `json:"selling_asset_issuer,omitempty"`
 }
 
-// CreatePassiveOffer is the json resource representing a single operation whose
-// type is CreatePassiveOffer.
-type CreatePassiveOffer struct {
-	ManageOffer
+// ManageOffer is the json resource representing a single operation whose type
+// is ManageOffer.
+type ManageOffer struct {
+	CreatePassiveOffer
+	OfferID            int64      `json:"offer_id"`
 }
 
 // SetOptions is the json resource representing a single operation whose type is


### PR DESCRIPTION
no more planned changes, this closes https://github.com/stellar/horizon/issues/404

before the change:
![screen shot 2017-10-11 at 10 11 50 am](https://user-images.githubusercontent.com/1028334/31455638-2c168128-ae6d-11e7-9024-39f3001bbf06.png)

after the change (notice that offer_id field is no longer there, before the amount field):
![screen shot 2017-10-11 at 10 12 50 am](https://user-images.githubusercontent.com/1028334/31455664-3f7e9570-ae6d-11e7-96d0-518b30fcbe40.png)
