### PR TITLE
Fix incorrect detail message in /order_book

### DIFF
--- a/services/horizon/internal/actions_order_book.go
+++ b/services/horizon/internal/actions_order_book.go
@@ -35,8 +35,8 @@ func (action *OrderBookShowAction) LoadQuery() {
 			Detail: "The parameters that specify what order book to view are invalid in some way. " +
 				"Please ensure that your type parameters (selling_asset_type and buying_asset_type) are one the " +
 				"following valid values: native, credit_alphanum4, credit_alphanum12.  Also ensure that you " +
-				"have specified selling_asset_code and selling_issuer if selling_asset_type is not 'native', as well " +
-				"as buying_asset_code and buying_issuer if buying_asset_type is not 'native'",
+				"have specified selling_asset_code and selling_asset_issuer if selling_asset_type is not 'native', as well " +
+				"as buying_asset_code and buying_asset_issuer if buying_asset_type is not 'native'",
 		}
 	}
 }


### PR DESCRIPTION
*_issuer -> *_asset_issuer

While using the endpoint, I found that the detailed message had incorrectly specified the params