### PR TITLE
Add overwrite: true to nightly deploy spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ deploy:
     file_glob: true
     name: Nightlies
     prerelease: true
+    overwrite: true
     on:
       repo: stellar/go
       branch: master


### PR DESCRIPTION
Continued work on automated nightly builds.  If this doesn't work I'll need to automate updating a `nightly` tag to build and release from.