### PR TITLE
Fix support/time.Milis.ToTime

### DIFF
--- a/support/time/main.go
+++ b/support/time/main.go
@@ -20,7 +20,7 @@ func MillisFromInt64(millis int64) Millis {
 }
 
 func (t Millis) increment(millisToAdd int64) Millis {
-	return Millis(int64(t)+ millisToAdd)
+	return Millis(int64(t) + millisToAdd)
 }
 
 //IsNil returns true if the timeMillis has not been initialized to a date other then 0 from epoch
@@ -49,7 +49,11 @@ func (t Millis) ToInt64() int64 {
 
 //ToTime returns a go time.Time timestamp, UTC adjusted
 func (t Millis) ToTime() goTime.Time {
-	return goTime.Unix(int64(t)/1000, 0).UTC()
+	// Milliseconds   1510831636149
+	// Nanoseconds    1510831636149000000
+	// Unix sec arg   1510831636
+	// Unix nsec arg            149000000
+	return goTime.Unix(int64(t)/1000, int64(t)%1000*int64(goTime.Millisecond)).UTC()
 }
 
 //Now returns current time in millis

--- a/support/time/main_test.go
+++ b/support/time/main_test.go
@@ -21,3 +21,7 @@ func TestMillisParsing(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, actual, expected)
 }
+
+func TestMillisToTime(t *testing.T) {
+	assert.Equal(t, int64(1510831636149000000), Millis(1510831636149).ToTime().UnixNano())
+}


### PR DESCRIPTION
@tomerweller looks like we were both wrong when it comes to `time.Unix()` in https://github.com/stellar/go/pull/144#discussion_r151078044. You were close (`%100` instead of `%1000`) and I completely misunderstood how `time.Unix()` works, apologies!