### PR TITLE
Marshalling Memo type should always result in string

### DIFF
--- a/handlers/federation/handler_test.go
+++ b/handlers/federation/handler_test.go
@@ -222,7 +222,7 @@ func TestForwardHandler(t *testing.T) {
 		ContainsKey("memo_type").
 		ValueEqual("memo_type", "id").
 		ContainsKey("memo").
-		ValueEqual("memo", 1)
+		ValueEqual("memo", "1")
 
 		// Good forward request
 	server.GET("/federation").

--- a/protocols/federation/main.go
+++ b/protocols/federation/main.go
@@ -26,17 +26,12 @@ type Memo struct {
 }
 
 func (m Memo) MarshalJSON() ([]byte, error) {
-	// Attempt to ParseUint. If this marshal m.Value
-	// and return JSON string.
-	_, err := strconv.ParseUint(m.Value, 10, 64)
+	// Memo after marshalling should always be a string
+	value, err := json.Marshal(m.Value)
 	if err != nil {
-		jsonString, err := json.Marshal(m.Value)
-		if err != nil {
-			return []byte{}, err
-		}
-		return jsonString, nil
+		return []byte{}, err
 	}
-	return []byte(m.Value), nil
+	return value, nil
 }
 
 func (m *Memo) UnmarshalJSON(value []byte) error {

--- a/protocols/federation/main_test.go
+++ b/protocols/federation/main_test.go
@@ -13,12 +13,21 @@ func TestMarshal(t *testing.T) {
 	m = Memo{"123"}
 	value, err := json.Marshal(m)
 	assert.NoError(t, err)
-	assert.Equal(t, "123", string(value))
+	assert.Equal(t, `"123"`, string(value))
 
 	m = Memo{"Test"}
 	value, err = json.Marshal(m)
 	assert.NoError(t, err)
 	assert.Equal(t, `"Test"`, string(value))
+
+	resp := NameResponse{
+		AccountID: "GCQ4MQ4ZOS6P6RON4HH6FNWNABCLZUCNBSDE3QXFZOX5VYJDDKRQDQOJ",
+		MemoType:  "id",
+		Memo:      Memo{"123"},
+	}
+	value, err = json.Marshal(resp)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"account_id":"GCQ4MQ4ZOS6P6RON4HH6FNWNABCLZUCNBSDE3QXFZOX5VYJDDKRQDQOJ","memo_type":"id","memo":"123"}`, string(value))
 }
 
 func TestUnmarshal(t *testing.T) {


### PR DESCRIPTION
Not sure why `Memo.MarshalJSON()` is returning integer for integer values since https://github.com/stellar/go/pull/40. We agreed that `Memo.MarshalJSON()` should always return strings and `Memo.UnmarshalJSON()` allows both integers in strings for integer values because we can parse both values correctly in Go (Slack: [[1]](https://stellarfoundation.slack.com/archives/C02B04RMK/p1488913219000732) [[2]](https://stellarfoundation.slack.com/archives/C02B04RMK/p1488923785000757)).