### PR TITLE
Trade ingestion timestamp fix

### DIFF
--- a/services/horizon/internal/db2/history/trade.go
+++ b/services/horizon/internal/db2/history/trade.go
@@ -182,7 +182,7 @@ func (q *Q) InsertTrade(
 	order int32,
 	buyer xdr.AccountId,
 	trade xdr.ClaimOfferAtom,
-	ledgerClosedAt int64,
+	ledgerClosedAt time.Millis,
 ) error {
 	sellerAccountId, err := q.GetCreateAccountID(trade.SellerId)
 	if err != nil {
@@ -219,7 +219,7 @@ func (q *Q) InsertTrade(
 	sql := tradesInsert.Values(
 		opid,
 		order,
-		time.MillisFromInt64(ledgerClosedAt).ToTime(),
+		ledgerClosedAt.ToTime(),
 		trade.OfferId,
 		baseAccountId,
 		baseAssetId,

--- a/services/horizon/internal/ingest/ingestion_test.go
+++ b/services/horizon/internal/ingest/ingestion_test.go
@@ -74,8 +74,8 @@ func TestAssetIngest(t *testing.T) {
 }
 
 func TestTradeIngestTimestamp(t *testing.T) {
-	//ingest trade scenario and make verify that the trade
-	//timestamp matches the appropriate ledger's timestamp
+	//ingest trade scenario and verify that the trade timestamp
+	//matches the appropriate ledger's timestamp
 	tt := test.Start(t).ScenarioWithoutHorizon("trades")
 	defer tt.Finish()
 	s := ingest(tt)

--- a/services/horizon/internal/ingest/ingestion_test.go
+++ b/services/horizon/internal/ingest/ingestion_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stretchr/testify/assert"
-	"fmt"
 )
 
 func TestEmptySignature(t *testing.T) {
@@ -75,13 +74,12 @@ func TestAssetIngest(t *testing.T) {
 }
 
 func TestTradeIngestTimestamp(t *testing.T) {
-	//ingest trade scenario and make sure the trade timestamps matches
-	//the appropriate ledger's timestamp
+	//ingest trade scenario and make verify that the trade
+	//timestamp matches the appropriate ledger's timestamp
 	tt := test.Start(t).ScenarioWithoutHorizon("trades")
 	defer tt.Finish()
 	s := ingest(tt)
 	q := history.Q{Session: s.Ingestion.DB}
-	fmt.Println(s.Ingestion.DB.DB.DB)
 
 	var ledgers []history.Ledger
 	err := q.Ledgers().Select(&ledgers)

--- a/services/horizon/internal/ingest/session.go
+++ b/services/horizon/internal/ingest/session.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"strings"
 	"time"
-
+	sTime "github.com/stellar/go/support/time"
 	"github.com/stellar/go/amount"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/meta"
@@ -468,7 +468,7 @@ func (is *Session) ingestTrades() {
 			int32(i),
 			buyer,
 			trade,
-			is.Cursor.Ledger().CloseTime,
+			sTime.MillisFromSeconds(is.Cursor.Ledger().CloseTime),
 		)
 		if is.Err != nil {
 			return

--- a/services/horizon/internal/test/trades/main.go
+++ b/services/horizon/internal/test/trades/main.go
@@ -4,6 +4,7 @@ package trades
 import (
 	. "github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/xdr"
+	"github.com/stellar/go/support/time"
 )
 
 //getTestAsset generates an issuer on the fly and creates a CreditAlphanum4 Asset with given code
@@ -30,7 +31,7 @@ func ingestTestTrade(
 	buyer xdr.AccountId,
 	amountSold int64,
 	amountBought int64,
-	timestamp int64,
+	timestamp time.Millis,
 	opCounter int64) error {
 
 	trade := xdr.ClaimOfferAtom{}
@@ -52,8 +53,9 @@ func PopulateTestTrades(q *Q, startTs int64, numOfTrades int, delta int64) (err 
 	ass2 = getTestAsset("euro", 4)
 
 	for i := 1; i <= numOfTrades; i++ {
+		timestamp := time.MillisFromInt64(startTs+(delta*int64(i-1)))
 		err = ingestTestTrade(
-			q, ass1, ass2, acc1, acc2, int64(i*100), int64(i*100)*int64(i), startTs+(delta*int64(i-1)),int64(i))
+			q, ass1, ass2, acc1, acc2, int64(i*100), int64(i*100)*int64(i), timestamp, int64(i))
 		//tt.Assert.NoError(err)
 		if err != nil {
 			return

--- a/support/time/main.go
+++ b/support/time/main.go
@@ -5,18 +5,23 @@ import (
 	goTime "time"
 )
 
-//ToInt64 represents time as milliseconds since epoch without any timezone adjustments
+//Millis represents time as milliseconds since epoch without any timezone adjustments
 type Millis int64
 
-//MillisFromString generates a ToInt64 struct from a string representing an int64
+//MillisFromString generates a Millis struct from a string representing an int64
 func MillisFromString(s string) (Millis, error) {
 	millis, err := strconv.ParseInt(s, 10, 64)
 	return Millis(int64(millis)), err
 }
 
-//MillisFromInt64 generates a ToInt64 struct from given millis int64
+//MillisFromInt64 generates a Millis struct from given millis int64
 func MillisFromInt64(millis int64) Millis {
 	return Millis(millis)
+}
+
+//MillisFromSeconds generates a Millis struct from given seconds int64
+func MillisFromSeconds(seconds int64) Millis {
+	return Millis(seconds*1000)
 }
 
 func (t Millis) increment(millisToAdd int64) Millis {
@@ -28,7 +33,7 @@ func (t Millis) IsNil() bool {
 	return t == 0
 }
 
-//RoundUp returns a new ToInt64 instance with a rounded up to d millis
+//RoundUp returns a new Millis instance with a rounded up to d millis
 func (t Millis) RoundUp(d int64) Millis {
 	if int64(t)%d != 0 {
 		return t.RoundDown(d).increment(d)


### PR DESCRIPTION
Modify trade ingestion to use `Millis` instead of `int64`.
Fixes a bug where trade ingestion treated the ledger close time as millis since epoch, when it was in fact seconds since epoch. 
Added a test. 