### PR TITLE
fix trade aggregation asset filters

### DIFF
--- a/services/horizon/internal/actions_trade_test.go
+++ b/services/horizon/internal/actions_trade_test.go
@@ -98,11 +98,11 @@ func TestTradeActions_Aggregation(t *testing.T) {
 	const start = 1510693200000
 
 	dbQ := &Q{ht.HorizonSession()}
-	err, ass1, ass2 := PopulateTestTrades(dbQ, start, numOfTrades, minute, 0)
+	ass1, ass2, err := PopulateTestTrades(dbQ, start, numOfTrades, minute, 0)
 	ht.Require.NoError(err)
 
 	//add other trades as noise, to ensure asset filtering is working
-	err, _, _ = PopulateTestTrades(dbQ, start, numOfTrades, minute, numOfTrades)
+	_, _, err = PopulateTestTrades(dbQ, start, numOfTrades, minute, numOfTrades)
 	ht.Require.NoError(err)
 
 	var records []resource.TradeAggregation

--- a/services/horizon/internal/actions_trade_test.go
+++ b/services/horizon/internal/actions_trade_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stellar/go/xdr"
 	"strconv"
 	"strings"
+	"fmt"
 )
 
 func TestTradeActions_Index(t *testing.T) {
@@ -98,8 +99,12 @@ func TestTradeActions_Aggregation(t *testing.T) {
 	const start = 1510693200000
 
 	dbQ := &Q{ht.HorizonSession()}
-	err, ass1, ass2 := PopulateTestTrades(dbQ, start, numOfTrades, minute)
+	fmt.Println(dbQ.DB.DB)
+	err, ass1, ass2 := PopulateTestTrades(dbQ, start, numOfTrades, minute, 0)
+	ht.Require.NoError(err)
 
+	//add other trades as noise, to ensure asset filtering is working
+	err, _, _ = PopulateTestTrades(dbQ, start, numOfTrades, minute, numOfTrades)
 	ht.Require.NoError(err)
 
 	var records []resource.TradeAggregation

--- a/services/horizon/internal/actions_trade_test.go
+++ b/services/horizon/internal/actions_trade_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stellar/go/xdr"
 	"strconv"
 	"strings"
-	"fmt"
 )
 
 func TestTradeActions_Index(t *testing.T) {
@@ -99,7 +98,6 @@ func TestTradeActions_Aggregation(t *testing.T) {
 	const start = 1510693200000
 
 	dbQ := &Q{ht.HorizonSession()}
-	fmt.Println(dbQ.DB.DB)
 	err, ass1, ass2 := PopulateTestTrades(dbQ, start, numOfTrades, minute, 0)
 	ht.Require.NoError(err)
 

--- a/services/horizon/internal/db2/history/trade_aggregation.go
+++ b/services/horizon/internal/db2/history/trade_aggregation.go
@@ -66,7 +66,9 @@ func (q *TradeAggregationsQ) GetSql() sq.SelectBuilder {
 	} else {
 		bucketSql = reverseBucketTrades(q.resolution)
 	}
-	bucketSql = bucketSql.From("history_trades")
+
+	bucketSql = bucketSql.From("history_trades").
+		Where(sq.Eq{"base_asset_id": q.baseAssetId, "counter_asset_id": q.counterAssetId})
 
 	//adjust time range and apply time filters
 	bucketSql = bucketSql.Where(sq.GtOrEq{"ledger_closed_at": q.startTime.ToTime()})

--- a/services/horizon/internal/test/trades/main.go
+++ b/services/horizon/internal/test/trades/main.go
@@ -53,7 +53,7 @@ func PopulateTestTrades(
 	startTs int64,
 	numOfTrades int,
 	delta int64,
-	opStart int64) (err error, ass1 xdr.Asset, ass2 xdr.Asset) {
+	opStart int64) (ass1 xdr.Asset, ass2 xdr.Asset, err error) {
 
 	acc1 := getTestAccount()
 	acc2 := getTestAccount()

--- a/services/horizon/internal/test/trades/main.go
+++ b/services/horizon/internal/test/trades/main.go
@@ -2,23 +2,26 @@
 package trades
 
 import (
+	"github.com/stellar/go/keypair"
 	. "github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/xdr"
 	"github.com/stellar/go/support/time"
+	"github.com/stellar/go/xdr"
 )
 
 //getTestAsset generates an issuer on the fly and creates a CreditAlphanum4 Asset with given code
-func getTestAsset(code string, accountNumber byte) xdr.Asset {
+func getTestAsset(code string) xdr.Asset {
 	var codeBytes [4]byte
 	copy(codeBytes[:], []byte(code))
-	ca4 := xdr.AssetAlphaNum4{Issuer: getTestAccount(accountNumber), AssetCode: codeBytes}
+	ca4 := xdr.AssetAlphaNum4{Issuer: getTestAccount(), AssetCode: codeBytes}
 	return xdr.Asset{Type: xdr.AssetTypeAssetTypeCreditAlphanum4, AlphaNum4: &ca4, AlphaNum12: nil}
 }
 
 //Get generates and returns an account on the fly
-func getTestAccount(accountNumber byte) xdr.AccountId {
-	accountNumber++
-	acc, _ := xdr.NewAccountId(xdr.PublicKeyTypePublicKeyTypeEd25519, xdr.Uint256{accountNumber})
+func getTestAccount() xdr.AccountId {
+	var key xdr.Uint256
+	kp, _ := keypair.Random()
+	copy(key[:], kp.Address())
+	acc, _ := xdr.NewAccountId(xdr.PublicKeyTypePublicKeyTypeEd25519, key)
 	return acc
 }
 
@@ -41,21 +44,25 @@ func ingestTestTrade(
 	trade.AssetBought = assetBought
 	trade.AssetSold = assetSold
 
-	opCounter++
 	return q.InsertTrade(opCounter, 0, buyer, trade, timestamp)
 }
 
 //PopulateTestTrades generates and ingests trades between two assets according to given parameters
-func PopulateTestTrades(q *Q, startTs int64, numOfTrades int, delta int64) (err error, ass1 xdr.Asset, ass2 xdr.Asset) {
-	acc1 := getTestAccount(1)
-	acc2 := getTestAccount(2)
-	ass1 = getTestAsset("usd", 3)
-	ass2 = getTestAsset("euro", 4)
+func PopulateTestTrades(
+	q *Q,
+	startTs int64,
+	numOfTrades int,
+	delta int64,
+	opStart int64) (err error, ass1 xdr.Asset, ass2 xdr.Asset) {
 
+	acc1 := getTestAccount()
+	acc2 := getTestAccount()
+	ass1 = getTestAsset("usd")
+	ass2 = getTestAsset("euro")
 	for i := 1; i <= numOfTrades; i++ {
-		timestamp := time.MillisFromInt64(startTs+(delta*int64(i-1)))
+		timestamp := time.MillisFromInt64(startTs + (delta * int64(i-1)))
 		err = ingestTestTrade(
-			q, ass1, ass2, acc1, acc2, int64(i*100), int64(i*100)*int64(i), timestamp, int64(i))
+			q, ass1, ass2, acc1, acc2, int64(i*100), int64(i*100)*int64(i), timestamp, opStart+int64(i))
 		//tt.Assert.NoError(err)
 		if err != nil {
 			return


### PR DESCRIPTION
Reinstate the asset filters that were accidentally ignored after the query refactoring. 
Modify tests to spot filtering issues.