### PR TITLE
Fixes `ElderLedger` query

### DIFF
--- a/services/horizon/internal/db2/core/main_test.go
+++ b/services/horizon/internal/db2/core/main_test.go
@@ -50,7 +50,7 @@ func TestElderLedger(t *testing.T) {
 		tt.Assert.Equal(elder, int32(10))
 	}
 
-	// a second gap is not considered for determining the elder ledger
+	// only the latest gap is considered for determining the elder ledger
 	_, err = tt.CoreDB.Exec(`
 		DELETE FROM ledgerheaders WHERE ledgerseq > 15 AND ledgerseq < 20
 	`)
@@ -58,6 +58,6 @@ func TestElderLedger(t *testing.T) {
 
 	err = q.ElderLedger(&elder)
 	if tt.Assert.NoError(err) {
-		tt.Assert.Equal(elder, int32(10))
+		tt.Assert.Equal(elder, int32(20))
 	}
 }


### PR DESCRIPTION
This PR fixes a misconception that horizon was making about the behavior of the SQL database managed by stellar-core.  Prior to this PR, horizon behaved as though stellar-core would not create gaps in the `ledgerheaders` table when `CATCHUP_RECENT` was configured, which is not how stellar-core actually behaves.  Instead, multiple gaps can be created regardless of the catchup config.

This PR amends the notion of the "Elder" ledger that horizon tracks.  It is now defined as the oldest ledger in the youngest contiguous range of ledgers whose headers are found in the core sql db.