### PR TITLE
Fix ingestion issues

### DIFF
--- a/clients/stellarcore/client.go
+++ b/clients/stellarcore/client.go
@@ -1,0 +1,87 @@
+package stellarcore
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/stellar/go/support/errors"
+)
+
+// Client represents a client that is capable of communicating with a
+// stellar-core server using HTTP
+type Client struct {
+	// HTTP is the client to use when communicating with stellar-core.  If nil,
+	// http.DefaultClient will be used.
+	HTTP HTTP
+
+	// URL of Stellar Core server to connect.
+	URL string
+}
+
+// Info returns
+func (c *Client) Info(ctx context.Context) (resp *InfoResponse, err error) {
+	var hresp *http.Response
+
+	req, err := http.NewRequest(http.MethodGet, c.URL+"/info", nil)
+	if err != nil {
+		err = errors.Wrap(err, "failed to create request")
+		return
+	}
+
+	req = req.WithContext(ctx)
+
+	hresp, err = c.http().Do(req)
+	if err != nil {
+		err = errors.Wrap(err, "http request errored")
+		return
+	}
+	defer hresp.Body.Close()
+
+	if !(hresp.StatusCode >= 200 && hresp.StatusCode < 300) {
+		err = errors.New("http request failed with non-200 status code")
+		return
+	}
+
+	err = json.NewDecoder(hresp.Body).Decode(&resp)
+
+	if err != nil {
+		err = errors.Wrap(err, "json decode failed")
+		return
+	}
+
+	return
+}
+
+// WaitForNetworkSync continually polls the connected stellar-core until it
+// receives a response that indicated the node has synced with the network
+func (c *Client) WaitForNetworkSync(ctx context.Context) error {
+	for {
+		info, err := c.Info(ctx)
+
+		if err != nil {
+			return errors.Wrap(err, "info request failed")
+		}
+
+		if info.IsSynced() {
+			return nil
+		}
+
+		// wait for next attempt or error if canceled while waiting
+		select {
+		case <-ctx.Done():
+			return errors.New("canceled")
+		case <-time.After(5 * time.Second):
+			continue
+		}
+	}
+}
+
+func (c *Client) http() HTTP {
+	if c.HTTP == nil {
+		return http.DefaultClient
+	}
+
+	return c.HTTP
+}

--- a/clients/stellarcore/info_response.go
+++ b/clients/stellarcore/info_response.go
@@ -1,0 +1,20 @@
+package stellarcore
+
+// InfoResponse is the json response returned from stellar-core's /info
+// endpoint.
+type InfoResponse struct {
+	Info struct {
+		Build           string `json:"build"`
+		Network         string `json:"network"`
+		ProtocolVersion int    `json:"protocol_version"`
+		State           string `json:"state"`
+
+		// TODO: all the other fields
+	}
+}
+
+// IsSynced returns a boolean indicating whether stellarcore is synced with the
+// network.
+func (resp *InfoResponse) IsSynced() bool {
+	return resp.Info.State == "Synced!"
+}

--- a/clients/stellarcore/info_response_test.go
+++ b/clients/stellarcore/info_response_test.go
@@ -1,0 +1,75 @@
+package stellarcore
+
+import "testing"
+import "encoding/json"
+import "github.com/stretchr/testify/require"
+import "github.com/stretchr/testify/assert"
+
+func TestInfoResponse_IsSynced(t *testing.T) {
+	cases := []struct {
+		Name     string
+		JSON     string
+		Expected bool
+	}{
+		{
+			Name: "synced",
+			JSON: `{
+				"info": {
+						"UNSAFE_QUORUM": "UNSAFE QUORUM ALLOWED",
+						"build": "v0.6.4",
+						"ledger": {
+								"age": 0,
+								"closeTime": 1512512956,
+								"hash": "a0035988ef68f225df4fb37b4639b8648c2d77dc4b3b1b0f5cd3bfa385fb4cc3",
+								"num": 5787995
+						},
+						"network": "Test SDF Network ; September 2015",
+						"numPeers": 6,
+						"protocol_version": 8,
+						"quorum": {
+								"5787994": {
+										"agree": 3,
+										"disagree": 0,
+										"fail_at": 2,
+										"hash": "273af2",
+										"missing": 0,
+										"phase": "EXTERNALIZE"
+								}
+						},
+						"state": "Synced!"
+				}
+			}`,
+			Expected: true,
+		},
+		{
+			Name: "joining scp",
+			JSON: `{
+				"info": {
+						"UNSAFE_QUORUM": "UNSAFE QUORUM ALLOWED",
+						"build": "v0.6.4",
+						"ledger": {
+								"age": 17,
+								"closeTime": 1512520421,
+								"hash": "263c1e575422e960cb1b51a38feac8f54947d1cd6ba8c7f1da5302b063ad7045",
+								"num": 5789919
+						},
+						"network": "Test SDF Network ; September 2015",
+						"numPeers": 0,
+						"protocol_version": 8,
+						"state": "Joining SCP"
+				}
+			}`,
+			Expected: false,
+		},
+	}
+
+	for _, kase := range cases {
+		t.Run(kase.Name, func(t *testing.T) {
+			var resp InfoResponse
+			err := json.Unmarshal([]byte(kase.JSON), &resp)
+			require.NoError(t, err)
+
+			assert.True(t, kase.Expected == resp.IsSynced(), "sync state is unexpected")
+		})
+	}
+}

--- a/clients/stellarcore/main.go
+++ b/clients/stellarcore/main.go
@@ -4,6 +4,10 @@ package stellarcore
 
 import "net/http"
 
+// SetCursorDone is the success message returned by stellar-core when a cursor
+// update succeeds.
+const SetCursorDone = "Done"
+
 // HTTP represents the http client that a stellarcore client uses to make http
 // requests.
 type HTTP interface {

--- a/clients/stellarcore/main.go
+++ b/clients/stellarcore/main.go
@@ -1,0 +1,14 @@
+// Package stellarcore is a client library for communicating with an
+// instance of stellar-core using through the server's HTTP port.
+package stellarcore
+
+import "net/http"
+
+// HTTP represents the http client that a stellarcore client uses to make http
+// requests.
+type HTTP interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// confirm interface conformity
+var _ HTTP = http.DefaultClient

--- a/clients/stellarcore/main_test.go
+++ b/clients/stellarcore/main_test.go
@@ -1,0 +1,18 @@
+package stellarcore
+
+import (
+	"context"
+	"fmt"
+)
+
+func ExampleClient_Info() {
+	client := &Client{URL: "http://localhost:11626"}
+
+	info, err := client.Info(context.Background())
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("synced: %v", info.IsSynced())
+}

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -56,7 +56,6 @@ type App struct {
 	historyElderLedgerGauge  metrics.Gauge
 	horizonConnGauge         metrics.Gauge
 	coreLatestLedgerGauge    metrics.Gauge
-	coreElderLedgerGauge     metrics.Gauge
 	coreConnGauge            metrics.Gauge
 	goroutineGauge           metrics.Gauge
 }
@@ -170,11 +169,6 @@ func (a *App) UpdateLedgerState() {
 		goto Failed
 	}
 
-	err = a.CoreQ().ElderLedger(&next.CoreElder)
-	if err != nil {
-		goto Failed
-	}
-
 	err = a.HistoryQ().LatestLedger(&next.HistoryLatest)
 	if err != nil {
 		goto Failed
@@ -248,7 +242,6 @@ func (a *App) UpdateMetrics() {
 	a.historyLatestLedgerGauge.Update(int64(ls.HistoryLatest))
 	a.historyElderLedgerGauge.Update(int64(ls.HistoryElder))
 	a.coreLatestLedgerGauge.Update(int64(ls.CoreLatest))
-	a.coreElderLedgerGauge.Update(int64(ls.CoreElder))
 
 	a.horizonConnGauge.Update(int64(a.historyQ.Session.DB.Stats().OpenConnections))
 	a.coreConnGauge.Update(int64(a.coreQ.Session.DB.Stats().OpenConnections))

--- a/services/horizon/internal/app_test.go
+++ b/services/horizon/internal/app_test.go
@@ -56,12 +56,10 @@ func TestMetrics(t *testing.T) {
 	hl := ht.App.historyLatestLedgerGauge
 	he := ht.App.historyElderLedgerGauge
 	cl := ht.App.coreLatestLedgerGauge
-	ce := ht.App.coreElderLedgerGauge
 
 	ht.Require.EqualValues(0, hl.Value())
 	ht.Require.EqualValues(0, he.Value())
 	ht.Require.EqualValues(0, cl.Value())
-	ht.Require.EqualValues(0, ce.Value())
 
 	ht.App.UpdateLedgerState()
 	ht.App.UpdateMetrics()
@@ -69,7 +67,6 @@ func TestMetrics(t *testing.T) {
 	ht.Require.EqualValues(3, hl.Value())
 	ht.Require.EqualValues(1, he.Value())
 	ht.Require.EqualValues(3, cl.Value())
-	ht.Require.EqualValues(1, ce.Value())
 }
 
 func TestTick(t *testing.T) {

--- a/services/horizon/internal/db2/core/main.go
+++ b/services/horizon/internal/db2/core/main.go
@@ -179,7 +179,8 @@ func AssetFromDB(typ xdr.AssetType, code string, issuer string) (result xdr.Asse
 // stellar-core database this ingestion system is communicating with.  Horizon,
 // which wants to operate on a contiguous range of ledger data (i.e. free from
 // gaps) uses the elder ledger to start importing in the case of an empty
-// database.
+// database.  NOTE:  This current query used is correct, but slow.  Please keep
+// this query out of latency sensitive or frequently trafficked code paths.
 func (q *Q) ElderLedger(dest *int32) error {
 	err := q.GetRaw(dest, `
 		SELECT COALESCE(ledgerseq, 0)

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -179,21 +179,24 @@ func New(network string, coreURL string, core, horizon *db.Session) *System {
 	return i
 }
 
-// NewSession initialize a new ingestion session, from `first` to `last` using
-// `i`.
-func NewSession(first, last int32, i *System) *Session {
+// NewCursor initializes a new ingestion cursor
+func NewCursor(first, last int32, i *System) *Cursor {
+	return &Cursor{
+		FirstLedger:    first,
+		LastLedger:     last,
+		DB:             i.CoreDB,
+		Metrics:        &i.Metrics,
+		AssetsModified: AssetsModified(make(map[string]xdr.Asset)),
+	}
+}
+
+// NewSession initialize a new ingestion session
+func NewSession(i *System) *Session {
 	hdb := i.HorizonDB.Clone()
 
 	return &Session{
 		Ingestion: &Ingestion{
 			DB: hdb,
-		},
-		Cursor: &Cursor{
-			FirstLedger:    first,
-			LastLedger:     last,
-			DB:             i.CoreDB,
-			Metrics:        &i.Metrics,
-			AssetsModified: AssetsModified(make(map[string]xdr.Asset)),
 		},
 		Network:          i.Network,
 		StellarCoreURL:   i.StellarCoreURL,

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -91,10 +91,10 @@ type System struct {
 	// stellar-core
 	SkipCursorUpdate bool
 
-	// LedgerRetentionCount is the desired minimum number of ledgers to
+	// HistoryRetentionCount is the desired minimum number of ledgers to
 	// keep in the history database, working backwards from the latest core
 	// ledger.  0 represents "all ledgers".
-	LedgerRetentionCount uint
+	HistoryRetentionCount uint
 
 	lock    sync.Mutex
 	current *Session

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -91,6 +91,11 @@ type System struct {
 	// stellar-core
 	SkipCursorUpdate bool
 
+	// LedgerRetentionCount is the desired minimum number of ledgers to
+	// keep in the history database, working backwards from the latest core
+	// ledger.  0 represents "all ledgers".
+	LedgerRetentionCount uint
+
 	lock    sync.Mutex
 	current *Session
 }

--- a/services/horizon/internal/ingest/session.go
+++ b/services/horizon/internal/ingest/session.go
@@ -1,14 +1,12 @@
 package ingest
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/url"
-	"path"
-	"strings"
 	"time"
+
+	"github.com/stellar/go/clients/stellarcore"
 
 	"github.com/stellar/go/amount"
 	"github.com/stellar/go/keypair"
@@ -16,6 +14,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/ingest/participants"
+	"github.com/stellar/go/support/errors"
 	sTime "github.com/stellar/go/support/time"
 	"github.com/stellar/go/xdr"
 )
@@ -759,42 +758,16 @@ func (is *Session) operationFlagDetails(result map[string]interface{}, f int32, 
 // allows stellar-core to free that storage when next it runs its own
 // maintenance.
 func (is *Session) reportCursorState() error {
-	// TODO(scott): with the introduction of
-	// SkipCursorUpdate, this should probably be removed.
-	if is.StellarCoreURL == "" {
-		return nil
-	}
-
 	if is.SkipCursorUpdate {
 		return nil
 	}
 
-	u, err := url.Parse(is.StellarCoreURL)
+	core := &stellarcore.Client{URL: is.StellarCoreURL}
+
+	err := core.SetCursor(context.Background(), "HORIZON", is.Cursor.LastLedger)
+
 	if err != nil {
-		return err
-	}
-
-	u.Path = path.Join(u.Path, "setcursor")
-	q := u.Query()
-	q.Set("id", "HORIZON")
-	q.Set("cursor", fmt.Sprintf("%d", is.Cursor.LastLedger))
-	u.RawQuery = q.Encode()
-	url := u.String()
-
-	resp, err := http.Get(url)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	raw, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	body := strings.TrimSpace(string(raw))
-	if body != "Done" {
-		return fmt.Errorf("failed to set cursor on stellar-core: %s", body)
+		return errors.Wrap(err, "SetCursor failed")
 	}
 
 	return nil

--- a/services/horizon/internal/ingest/session.go
+++ b/services/horizon/internal/ingest/session.go
@@ -22,6 +22,11 @@ import (
 // Run starts an attempt to ingest the range of ledgers specified in this
 // session.
 func (is *Session) Run() {
+	if is.Cursor == nil {
+		is.Err = errors.New("no cursor set on session")
+		return
+	}
+
 	is.Err = is.Ingestion.Start()
 	if is.Err != nil {
 		return
@@ -758,6 +763,10 @@ func (is *Session) operationFlagDetails(result map[string]interface{}, f int32, 
 // allows stellar-core to free that storage when next it runs its own
 // maintenance.
 func (is *Session) reportCursorState() error {
+	if is.StellarCoreURL == "" {
+		return nil
+	}
+
 	if is.SkipCursorUpdate {
 		return nil
 	}

--- a/services/horizon/internal/ingest/system.go
+++ b/services/horizon/internal/ingest/system.go
@@ -197,11 +197,11 @@ func (i *System) newTickSession() (*Session, error) {
 
 	// If horizon is configured to only retain a certain number of ledgers, use
 	// that retention number to guess at the new start point.
-	if i.LedgerRetentionCount > 0 {
+	if i.HistoryRetentionCount > 0 {
 		var start int32
 		err := i.CoreDB.GetRaw(&start, `
 			SELECT ledgerseq FROM ledgerheaders WHERE ledgerseq > ?
-		`, ls.CoreLatest-int32(i.LedgerRetentionCount))
+		`, ls.CoreLatest-int32(i.HistoryRetentionCount))
 
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to find session start")

--- a/services/horizon/internal/ingest/system.go
+++ b/services/horizon/internal/ingest/system.go
@@ -258,7 +258,7 @@ func (i *System) runOnce() {
 	}
 
 	if is.Cursor.FirstLedger > is.Cursor.LastLedger {
-		log.Warn("ingest: runOnce ran with an inverted Cursor")
+		// NOTE: this occurs when horizon is synced with the connected stellar-core
 		return
 	}
 
@@ -338,7 +338,7 @@ func (i *System) validateLedgerChain(seq int32) error {
 		prev core.LedgerHeader
 	)
 
-	q := &core.Q{i.CoreDB}
+	q := &core.Q{Session: i.CoreDB}
 
 	err := q.LedgerHeaderBySequence(&cur, seq)
 	if err != nil {

--- a/services/horizon/internal/ingest/system_test.go
+++ b/services/horizon/internal/ingest/system_test.go
@@ -60,27 +60,27 @@ func TestValidation(t *testing.T) {
 	tt.Assert.Contains(err.Error(), "cur and prev ledger hashes don't match")
 }
 
-// TestSystem_newTickSession tests the ledger that newTickSession picks to start
+// TestSystem_newCursor tests the ledger that newCursor picks to start
 // ingestion from in various scenarios.
-func TestSystem_newTickSession(t *testing.T) {
+func TestSystem_newCursor(t *testing.T) {
 	tt := test.Start(t).ScenarioWithoutHorizon("kahuna")
 	defer tt.Finish()
 
 	sys := New(network.TestNetworkPassphrase, "", tt.CoreSession(), tt.HorizonSession())
 
-	sess, err := sys.newTickSession()
+	cursor, err := sys.newCursor()
 	if tt.Assert.NoError(err) {
-		tt.Assert.Equal(int32(1), sess.Cursor.FirstLedger)
-		tt.Assert.Equal(int32(57), sess.Cursor.LastLedger)
+		tt.Assert.Equal(int32(1), cursor.FirstLedger)
+		tt.Assert.Equal(int32(57), cursor.LastLedger)
 	}
 
 	// when HistoryRetentionCount is set, start with the first importable ledger
 	sys.HistoryRetentionCount = 10
 
-	sess, err = sys.newTickSession()
+	cursor, err = sys.newCursor()
 	if tt.Assert.NoError(err) {
-		tt.Assert.Equal(int32(48), sess.Cursor.FirstLedger)
-		tt.Assert.Equal(int32(57), sess.Cursor.LastLedger)
+		tt.Assert.Equal(int32(48), cursor.FirstLedger)
+		tt.Assert.Equal(int32(57), cursor.LastLedger)
 	}
 
 	// when a gap exists where the first importable ledger should be, pick the
@@ -90,22 +90,22 @@ func TestSystem_newTickSession(t *testing.T) {
 		WHERE ledgerseq BETWEEN 35 AND 50`)
 	tt.Require.NoError(err)
 
-	sess, err = sys.newTickSession()
+	cursor, err = sys.newCursor()
 	if tt.Assert.NoError(err) {
-		tt.Assert.Equal(int32(51), sess.Cursor.FirstLedger)
-		tt.Assert.Equal(int32(57), sess.Cursor.LastLedger)
+		tt.Assert.Equal(int32(51), cursor.FirstLedger)
+		tt.Assert.Equal(int32(57), cursor.LastLedger)
 	}
 
 	// when the history database is populated, start after the end of ingested
 	// history
-	sess = sys.Tick()
+	sess := sys.Tick()
 	tt.Require.NoError(sess.Err)
 	tt.UpdateLedgerState()
 
-	sess, err = sys.newTickSession()
+	cursor, err = sys.newCursor()
 	if tt.Assert.NoError(err) {
-		tt.Assert.Equal(int32(58), sess.Cursor.FirstLedger)
-		tt.Assert.Equal(int32(57), sess.Cursor.LastLedger)
+		tt.Assert.Equal(int32(58), cursor.FirstLedger)
+		tt.Assert.Equal(int32(57), cursor.LastLedger)
 	}
 
 	// sanity test: ensure no error when re-ticking with a synced horizon db.
@@ -122,9 +122,9 @@ func TestSystem_newTickSession(t *testing.T) {
 	tt.Require.NoError(err)
 	tt.UpdateLedgerState()
 
-	sess, err = sys.newTickSession()
+	cursor, err = sys.newCursor()
 	if tt.Assert.NoError(err) {
-		tt.Assert.Equal(int32(53), sess.Cursor.FirstLedger)
-		tt.Assert.Equal(int32(57), sess.Cursor.LastLedger)
+		tt.Assert.Equal(int32(53), cursor.FirstLedger)
+		tt.Assert.Equal(int32(57), cursor.LastLedger)
 	}
 }

--- a/services/horizon/internal/ingest/system_test.go
+++ b/services/horizon/internal/ingest/system_test.go
@@ -69,9 +69,9 @@ func TestSessionStart(t *testing.T) {
 	sys := New(network.TestNetworkPassphrase, "", tt.CoreSession(), tt.HorizonSession())
 
 	_ = sys
-	// when history database is empty and no LedgerRetentionCount is set, start importing from ledger 1
+	// when history database is empty and no HistoryRetentionCount is set, start importing from ledger 1
 
-	// when LedgerRetentionCount is set, start with the first importable ledger
+	// when HistoryRetentionCount is set, start with the first importable ledger
 
 	// when the history database is populated, start at the end of ingested history
 }

--- a/services/horizon/internal/ingest/system_test.go
+++ b/services/horizon/internal/ingest/system_test.go
@@ -96,7 +96,7 @@ func TestSystem_newTickSession(t *testing.T) {
 		tt.Assert.Equal(int32(57), sess.Cursor.LastLedger)
 	}
 
-	// when the history database is populated, start at the end of ingested
+	// when the history database is populated, start after the end of ingested
 	// history
 	sess = sys.Tick()
 	tt.Require.NoError(sess.Err)
@@ -104,7 +104,7 @@ func TestSystem_newTickSession(t *testing.T) {
 
 	sess, err = sys.newTickSession()
 	if tt.Assert.NoError(err) {
-		tt.Assert.Equal(int32(57), sess.Cursor.FirstLedger)
+		tt.Assert.Equal(int32(58), sess.Cursor.FirstLedger)
 		tt.Assert.Equal(int32(57), sess.Cursor.LastLedger)
 	}
 

--- a/services/horizon/internal/ingest/system_test.go
+++ b/services/horizon/internal/ingest/system_test.go
@@ -59,3 +59,19 @@ func TestValidation(t *testing.T) {
 	tt.Assert.Error(err)
 	tt.Assert.Contains(err.Error(), "cur and prev ledger hashes don't match")
 }
+
+// TestSessionStart tests the ledger that newTickSession picks to start
+// ingestion from in various scenarios.
+func TestSessionStart(t *testing.T) {
+	tt := test.Start(t).ScenarioWithoutHorizon("kahuna")
+	defer tt.Finish()
+
+	sys := New(network.TestNetworkPassphrase, "", tt.CoreSession(), tt.HorizonSession())
+
+	_ = sys
+	// when history database is empty and no LedgerRetentionCount is set, start importing from ledger 1
+
+	// when LedgerRetentionCount is set, start with the first importable ledger
+
+	// when the history database is populated, start at the end of ingested history
+}

--- a/services/horizon/internal/init_ingester.go
+++ b/services/horizon/internal/init_ingester.go
@@ -23,7 +23,7 @@ func initIngester(app *App) {
 	)
 
 	app.ingester.SkipCursorUpdate = app.config.SkipCursorUpdate
-	app.ingester.LedgerRetentionCount = app.config.HistoryRetentionCount
+	app.ingester.HistoryRetentionCount = app.config.HistoryRetentionCount
 }
 
 func init() {

--- a/services/horizon/internal/init_ingester.go
+++ b/services/horizon/internal/init_ingester.go
@@ -23,6 +23,7 @@ func initIngester(app *App) {
 	)
 
 	app.ingester.SkipCursorUpdate = app.config.SkipCursorUpdate
+	app.ingester.LedgerRetentionCount = app.config.HistoryRetentionCount
 }
 
 func init() {

--- a/services/horizon/internal/init_metrics.go
+++ b/services/horizon/internal/init_metrics.go
@@ -15,7 +15,6 @@ func initDbMetrics(app *App) {
 	app.historyLatestLedgerGauge = metrics.NewGauge()
 	app.historyElderLedgerGauge = metrics.NewGauge()
 	app.coreLatestLedgerGauge = metrics.NewGauge()
-	app.coreElderLedgerGauge = metrics.NewGauge()
 
 	app.horizonConnGauge = metrics.NewGauge()
 	app.coreConnGauge = metrics.NewGauge()
@@ -23,7 +22,6 @@ func initDbMetrics(app *App) {
 	app.metrics.Register("history.latest_ledger", app.historyLatestLedgerGauge)
 	app.metrics.Register("history.elder_ledger", app.historyElderLedgerGauge)
 	app.metrics.Register("stellar_core.latest_ledger", app.coreLatestLedgerGauge)
-	app.metrics.Register("stellar_core.elder_ledger", app.coreElderLedgerGauge)
 	app.metrics.Register("history.open_connections", app.horizonConnGauge)
 	app.metrics.Register("stellar_core.open_connections", app.coreConnGauge)
 	app.metrics.Register("goroutines", app.goroutineGauge)

--- a/services/horizon/internal/ledger/main.go
+++ b/services/horizon/internal/ledger/main.go
@@ -1,6 +1,6 @@
 // Package ledger provides useful utilities concerning ledgers within stellar,
-// specifically a central location to store a cached snapshot of the state of
-// both horizon's and stellar-core's view of the ledger.  This package is
+// specifically as a central location to store a cached snapshot of the state of
+// both horizon's and stellar-core's views of the ledger.  This package is
 // intended to be at the lowest levels of horizon's dependency tree, please keep
 // it free of dependencies to other horizon packages.
 package ledger
@@ -13,7 +13,6 @@ import (
 // ledger.
 type State struct {
 	CoreLatest    int32 `db:"core_latest"`
-	CoreElder     int32 `db:"core_elder"`
 	HistoryLatest int32 `db:"history_latest"`
 	HistoryElder  int32 `db:"history_elder"`
 }

--- a/services/horizon/internal/resource/main.go
+++ b/services/horizon/internal/resource/main.go
@@ -186,7 +186,6 @@ type Root struct {
 	HorizonSequence      int32  `json:"history_latest_ledger"`
 	HistoryElderSequence int32  `json:"history_elder_ledger"`
 	CoreSequence         int32  `json:"core_latest_ledger"`
-	CoreElderSequence    int32  `json:"core_elder_ledger"`
 	NetworkPassphrase    string `json:"network_passphrase"`
 	ProtocolVersion      int32  `json:"protocol_version"`
 }

--- a/services/horizon/internal/resource/root.go
+++ b/services/horizon/internal/resource/root.go
@@ -18,7 +18,6 @@ func (res *Root) Populate(
 	res.HorizonSequence = ledgerState.HistoryLatest
 	res.HistoryElderSequence = ledgerState.HistoryElder
 	res.CoreSequence = ledgerState.CoreLatest
-	res.CoreElderSequence = ledgerState.CoreElder
 	res.HorizonVersion = hVersion
 	res.StellarCoreVersion = cVersion
 	res.NetworkPassphrase = passphrase

--- a/services/horizon/internal/test/t.go
+++ b/services/horizon/internal/test/t.go
@@ -96,7 +96,6 @@ func (t *T) UpdateLedgerState() {
 
 	err := t.CoreSession().GetRaw(&next, `
 		SELECT
-			COALESCE(MIN(ledgerseq), 0) as core_elder,
 			COALESCE(MAX(ledgerseq), 0) as core_latest
 		FROM ledgerheaders
 	`)


### PR DESCRIPTION
This PR removes the notion of the "Core Elder Ledger" from the API and from the history ingestion system.  Unfortunately the query is too slow for a large horizon database.

## Operational tasks after merge 

- Test "reingestion re-establishment"  on testnet

- Clear testnet and start from scratch

- Pubnet has _not_ had maintenance run on it, so we are going to be re-ingesting a lot of old data.  Someone should start a screen session on one of those boxes and run a full reingestion using `horizon db reingest outdated` after deploying this code.

