### PR TITLE
fix paging

### DIFF
--- a/services/horizon/internal/action.go
+++ b/services/horizon/internal/action.go
@@ -140,18 +140,16 @@ func (action *Action) EnsureHistoryFreshness() {
 	}
 }
 
-// BaseURL returns the base url for this requestion, defined as a url containing
-// the Host and Scheme portions of the request uri.
-func (action *Action) BaseURL() *url.URL {
-	result := httpx.BaseURL(action.Ctx)
+// FullURL returns the full url for this request
+func (action *Action) FullURL() *url.URL {
+	result := action.BaseURL()
 	result.Path = action.R.URL.Path
 	result.RawQuery = action.R.URL.RawQuery
 	return result
 }
 
-//func (action *Action) FullURL() *url.URL {
-//	result := httpx.BaseURL(action.Ctx)
-//	result.Path = action.R.URL.Path
-//	result.RawQuery = action.R.URL.RawQuery
-//	return result
-//}
+// BaseURL returns the base url for this request, defined as a url containing
+// the Host and Scheme portions of the request uri.
+func (action *Action) BaseURL() *url.URL {
+	return httpx.BaseURL(action.Ctx)
+}

--- a/services/horizon/internal/action.go
+++ b/services/horizon/internal/action.go
@@ -148,7 +148,7 @@ func (action *Action) FullURL() *url.URL {
 	return result
 }
 
-// BaseURL returns the base url for this request, defined as a url containing
+// baseURL returns the base url for this request, defined as a url containing
 // the Host and Scheme portions of the request uri.
 func (action *Action) baseURL() *url.URL {
 	return httpx.BaseURL(action.Ctx)

--- a/services/horizon/internal/action.go
+++ b/services/horizon/internal/action.go
@@ -142,7 +142,7 @@ func (action *Action) EnsureHistoryFreshness() {
 
 // FullURL returns the full url for this request
 func (action *Action) FullURL() *url.URL {
-	result := action.BaseURL()
+	result := action.baseURL()
 	result.Path = action.R.URL.Path
 	result.RawQuery = action.R.URL.RawQuery
 	return result
@@ -150,6 +150,6 @@ func (action *Action) FullURL() *url.URL {
 
 // BaseURL returns the base url for this request, defined as a url containing
 // the Host and Scheme portions of the request uri.
-func (action *Action) BaseURL() *url.URL {
+func (action *Action) baseURL() *url.URL {
 	return httpx.BaseURL(action.Ctx)
 }

--- a/services/horizon/internal/action.go
+++ b/services/horizon/internal/action.go
@@ -143,5 +143,15 @@ func (action *Action) EnsureHistoryFreshness() {
 // BaseURL returns the base url for this requestion, defined as a url containing
 // the Host and Scheme portions of the request uri.
 func (action *Action) BaseURL() *url.URL {
-	return httpx.BaseURL(action.Ctx)
+	result := httpx.BaseURL(action.Ctx)
+	result.Path = action.R.URL.Path
+	result.RawQuery = action.R.URL.RawQuery
+	return result
 }
+
+//func (action *Action) FullURL() *url.URL {
+//	result := httpx.BaseURL(action.Ctx)
+//	result.Path = action.R.URL.Path
+//	result.RawQuery = action.R.URL.RawQuery
+//	return result
+//}

--- a/services/horizon/internal/actions_assets.go
+++ b/services/horizon/internal/actions_assets.go
@@ -75,8 +75,7 @@ func (action *AssetsAction) loadPage() {
 		action.Page.Add(res)
 	}
 
-	action.Page.BaseURL = action.BaseURL()
-	action.Page.BasePath = action.Path()
+	action.Page.FullURL = action.FullURL()
 	action.Page.Limit = action.PagingParams.Limit
 	action.Page.Cursor = action.PagingParams.Cursor
 	action.Page.Order = action.PagingParams.Order

--- a/services/horizon/internal/actions_assets.go
+++ b/services/horizon/internal/actions_assets.go
@@ -2,7 +2,6 @@ package horizon
 
 import (
 	"fmt"
-	"net/url"
 
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/assets"
@@ -79,13 +78,5 @@ func (action *AssetsAction) loadPage() {
 	action.Page.Limit = action.PagingParams.Limit
 	action.Page.Cursor = action.PagingParams.Cursor
 	action.Page.Order = action.PagingParams.Order
-
-	linkParams := url.Values{}
-	if action.AssetCode != "" {
-		linkParams.Set("asset_code", action.AssetCode)
-	}
-	if action.AssetIssuer != "" {
-		linkParams.Set("asset_issuer", action.AssetIssuer)
-	}
 	action.Page.PopulateLinks()
 }

--- a/services/horizon/internal/actions_assets.go
+++ b/services/horizon/internal/actions_assets.go
@@ -88,5 +88,5 @@ func (action *AssetsAction) loadPage() {
 	if action.AssetIssuer != "" {
 		linkParams.Set("asset_issuer", action.AssetIssuer)
 	}
-	action.Page.PopulateLinksWithParams(linkParams)
+	action.Page.PopulateLinks()
 }

--- a/services/horizon/internal/actions_assets_test.go
+++ b/services/horizon/internal/actions_assets_test.go
@@ -243,9 +243,9 @@ func TestAssetsActions(t *testing.T) {
 				}
 			}
 
-			ht.Assert.Equal(("http://localhost" + kase.wantSelf), links.Self.Href)
-			ht.Assert.Equal(("http://localhost" + kase.wantPrevious), links.Prev.Href)
-			ht.Assert.Equal(("http://localhost" + kase.wantNext), links.Next.Href)
+			ht.Assert.EqualUrlStrings("http://localhost" + kase.wantSelf, links.Self.Href)
+			ht.Assert.EqualUrlStrings("http://localhost" + kase.wantPrevious, links.Prev.Href)
+			ht.Assert.EqualUrlStrings("http://localhost" + kase.wantNext, links.Next.Href)
 		})
 	}
 }

--- a/services/horizon/internal/actions_assets_test.go
+++ b/services/horizon/internal/actions_assets_test.go
@@ -243,9 +243,9 @@ func TestAssetsActions(t *testing.T) {
 				}
 			}
 
-			ht.Assert.EqualUrlStrings("http://localhost" + kase.wantSelf, links.Self.Href)
-			ht.Assert.EqualUrlStrings("http://localhost" + kase.wantPrevious, links.Prev.Href)
-			ht.Assert.EqualUrlStrings("http://localhost" + kase.wantNext, links.Next.Href)
+			ht.Assert.EqualUrlStrings("http://localhost"+kase.wantSelf, links.Self.Href)
+			ht.Assert.EqualUrlStrings("http://localhost"+kase.wantPrevious, links.Prev.Href)
+			ht.Assert.EqualUrlStrings("http://localhost"+kase.wantNext, links.Next.Href)
 		})
 	}
 }

--- a/services/horizon/internal/actions_effects.go
+++ b/services/horizon/internal/actions_effects.go
@@ -114,8 +114,7 @@ func (action *EffectIndexAction) loadPage() {
 		action.Page.Add(res)
 	}
 
-	action.Page.BaseURL = action.BaseURL()
-	action.Page.BasePath = action.Path()
+	action.Page.FullURL = action.FullURL()
 	action.Page.Limit = action.PagingParams.Limit
 	action.Page.Cursor = action.PagingParams.Cursor
 	action.Page.Order = action.PagingParams.Order

--- a/services/horizon/internal/actions_ledger.go
+++ b/services/horizon/internal/actions_ledger.go
@@ -76,8 +76,7 @@ func (action *LedgerIndexAction) loadPage() {
 		action.Page.Add(res)
 	}
 
-	action.Page.BaseURL = action.BaseURL()
-	action.Page.BasePath = action.Path()
+	action.Page.FullURL = action.FullURL()
 	action.Page.Limit = action.PagingParams.Limit
 	action.Page.Cursor = action.PagingParams.Cursor
 	action.Page.Order = action.PagingParams.Order

--- a/services/horizon/internal/actions_offer.go
+++ b/services/horizon/internal/actions_offer.go
@@ -69,8 +69,7 @@ func (action *OffersByAccountAction) loadPage() {
 		action.Page.Add(res)
 	}
 
-	action.Page.BaseURL = action.BaseURL()
-	action.Page.BasePath = action.Path()
+	action.Page.FullURL = action.FullURL()
 	action.Page.Limit = action.PageQuery.Limit
 	action.Page.Cursor = action.PageQuery.Cursor
 	action.Page.Order = action.PageQuery.Order

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -136,8 +136,7 @@ func (action *OperationIndexAction) loadPage() {
 		action.Page.Add(res)
 	}
 
-	action.Page.BaseURL = action.BaseURL()
-	action.Page.BasePath = action.Path()
+	action.Page.FullURL = action.FullURL()
 	action.Page.Limit = action.PagingParams.Limit
 	action.Page.Cursor = action.PagingParams.Cursor
 	action.Page.Order = action.PagingParams.Order

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -127,8 +127,7 @@ func (action *PaymentsIndexAction) loadPage() {
 		action.Page.Add(res)
 	}
 
-	action.Page.BaseURL = action.BaseURL()
-	action.Page.BasePath = action.Path()
+	action.Page.FullURL = action.FullURL()
 	action.Page.Limit = action.PagingParams.Limit
 	action.Page.Cursor = action.PagingParams.Cursor
 	action.Page.Order = action.PagingParams.Order

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -84,8 +84,7 @@ func (action *TradeIndexAction) loadPage() {
 		action.Page.Add(res)
 	}
 
-	action.Page.BaseURL = action.BaseURL()
-	action.Page.BasePath = action.Path()
+	action.Page.FullURL = action.FullURL()
 	action.Page.Limit = action.PagingParams.Limit
 	action.Page.Cursor = action.PagingParams.Cursor
 	action.Page.Order = action.PagingParams.Order
@@ -172,9 +171,7 @@ func (action *TradeAggregateIndexAction) loadPage() {
 	action.Page.Limit = action.PagingParams.Limit
 	action.Page.Order = action.PagingParams.Order
 
-	newUrl := action.BaseURL()              // preserve scheme and host for the new url links
-	newUrl.RawQuery = action.R.URL.RawQuery //preserve query parameters
-	newUrl.Path = action.Path()             //preserve path
+	newUrl := action.FullURL()              // preserve scheme and host for the new url links
 	q := newUrl.Query()
 
 	action.Page.Links.Self = hal.NewLink(newUrl.String())

--- a/services/horizon/internal/actions_transaction.go
+++ b/services/horizon/internal/actions_transaction.go
@@ -92,8 +92,7 @@ func (action *TransactionIndexAction) loadPage() {
 		action.Page.Add(res)
 	}
 
-	action.Page.BaseURL = action.BaseURL()
-	action.Page.BasePath = action.Path()
+	action.Page.FullURL = action.FullURL()
 	action.Page.Limit = action.PagingParams.Limit
 	action.Page.Cursor = action.PagingParams.Cursor
 	action.Page.Order = action.PagingParams.Order

--- a/services/horizon/internal/assertions_test.go
+++ b/services/horizon/internal/assertions_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stretchr/testify/assert"
+	"net/url"
 )
 
 // Assertions provides an assertions helper.  Custom assertions for this package
@@ -71,4 +72,26 @@ func (a *Assertions) ProblemType(body *bytes.Buffer, typ string) bool {
 	}
 
 	return a.Problem(body, problem.P{Type: typ})
+}
+
+// EqualUrlStrings asserts for equality between url strings, regardless of query params ordering
+func (a *Assertions) EqualUrlStrings(expected string, actual string) bool {
+
+	// this function generates a golang URL struct from
+	// each string and re-encodes the query params,
+	// which sorts and allows for a simple equality check
+
+	expectedU, err := url.Parse(expected)
+	if !a.NoError(err) {
+		return false
+	}
+	expectedU.RawQuery = expectedU.Query().Encode()
+
+	actualU, err := url.Parse(actual)
+	if !a.NoError(err) {
+		return false
+	}
+	actualU.RawQuery = actualU.Query().Encode()
+
+	return a.Equal(expectedU, actualU)
 }

--- a/services/horizon/internal/render/hal/page.go
+++ b/services/horizon/internal/render/hal/page.go
@@ -41,7 +41,6 @@ type Links struct {
 type Page struct {
 	Links Links `json:"_links"`
 	BasePage
-	//BasePath string `json:"-"`
 	Order    string `json:"-"`
 	Limit    uint64 `json:"-"`
 	Cursor   string `json:"-"`

--- a/services/horizon/internal/render/hal/page.go
+++ b/services/horizon/internal/render/hal/page.go
@@ -1,13 +1,16 @@
 package hal
 
 import (
+	sUrl "github.com/stellar/go/support/url"
 	"net/url"
+	"strconv"
 )
 
 // BasePage represents the simplest page: one with no links and only embedded records.
 // Can be used to build custom page-like resources
 type BasePage struct {
-	BaseURL  *url.URL `json:"-"`
+	BaseURL *url.URL `json:"-"`
+	//FullURL  *url.URL `json:"-"`
 	Embedded struct {
 		Records []Pageable `json:"records"`
 	} `json:"_embedded"`
@@ -45,31 +48,34 @@ type Page struct {
 	Cursor   string `json:"-"`
 }
 
-// PopulateLinks sets the common links for a page
+// PopulateLinks sets the common links for a page.
 func (p *Page) PopulateLinks() {
-	p.PopulateLinksWithParams(url.Values{})
-}
-
-// PopulateLinksWithParams sets the common links for a page with additional non-paging params
-func (p *Page) PopulateLinksWithParams(params url.Values) {
 	p.Init()
-	fmts := p.BasePath + "?order=%s&limit=%d&cursor=%s"
-	encodedParams := params.Encode()
-	if len(encodedParams) > 0 {
-		fmts = fmts + "&" + encodedParams
-	}
-	lb := LinkBuilder{p.BaseURL}
 
-	p.Links.Self = lb.Linkf(fmts, p.Order, p.Limit, p.Cursor)
 	rec := p.Embedded.Records
 
+	//verify paging params
+	selfUrl := sUrl.URL(*p.BaseURL).
+		SetParam("cursor", p.Cursor).
+		SetParam("order", p.Order).
+		SetParam("limit", strconv.FormatInt(int64(p.Limit), 10))
+
+	//self: re-encode existing query params
+	p.Links.Self = NewLink(selfUrl.String())
+
+	//next: update cursor to last record (if any)
+	nextUrl := selfUrl
 	if len(rec) > 0 {
-		p.Links.Next = lb.Linkf(fmts, p.Order, p.Limit, rec[len(rec)-1].PagingToken())
-		p.Links.Prev = lb.Linkf(fmts, p.InvertedOrder(), p.Limit, rec[0].PagingToken())
-	} else {
-		p.Links.Next = lb.Linkf(fmts, p.Order, p.Limit, p.Cursor)
-		p.Links.Prev = lb.Linkf(fmts, p.InvertedOrder(), p.Limit, p.Cursor)
+		nextUrl = nextUrl.SetParam("cursor", rec[len(rec)-1].PagingToken())
 	}
+	p.Links.Next = NewLink(nextUrl.String())
+
+	//prev: inverse order and update cursor to first record (if any)
+	prevUrl := selfUrl.SetParam("order", p.InvertedOrder())
+	if len(rec) > 0 {
+		prevUrl = prevUrl.SetParam("cursor", rec[0].PagingToken())
+	}
+	p.Links.Prev = NewLink(prevUrl.String())
 }
 
 // InvertedOrder returns the inversion of the page's current order. Used to

--- a/services/horizon/internal/render/hal/page.go
+++ b/services/horizon/internal/render/hal/page.go
@@ -9,8 +9,7 @@ import (
 // BasePage represents the simplest page: one with no links and only embedded records.
 // Can be used to build custom page-like resources
 type BasePage struct {
-	BaseURL *url.URL `json:"-"`
-	//FullURL  *url.URL `json:"-"`
+	FullURL *url.URL `json:"-"`
 	Embedded struct {
 		Records []Pageable `json:"records"`
 	} `json:"_embedded"`
@@ -42,7 +41,7 @@ type Links struct {
 type Page struct {
 	Links Links `json:"_links"`
 	BasePage
-	BasePath string `json:"-"`
+	//BasePath string `json:"-"`
 	Order    string `json:"-"`
 	Limit    uint64 `json:"-"`
 	Cursor   string `json:"-"`
@@ -55,7 +54,7 @@ func (p *Page) PopulateLinks() {
 	rec := p.Embedded.Records
 
 	//verify paging params
-	selfUrl := sUrl.URL(*p.BaseURL).
+	selfUrl := sUrl.URL(*p.FullURL).
 		SetParam("cursor", p.Cursor).
 		SetParam("order", p.Order).
 		SetParam("limit", strconv.FormatInt(int64(p.Limit), 10))

--- a/support/url/main.go
+++ b/support/url/main.go
@@ -4,9 +4,10 @@ import (
 	gUrl "net/url"
 )
 
+// URL wraps around the native golang URL struct to allow for custom methods
 type URL gUrl.URL
 
-// SetParam
+// SetParam returns a new URL with the given param created or modified if already exists
 func (u URL) SetParam(key string, val string) URL {
 	gu := gUrl.URL(u)
 	q := gu.Query()
@@ -16,11 +17,13 @@ func (u URL) SetParam(key string, val string) URL {
 	return URL(gu)
 }
 
+// String encodes all URL segments to a fully qualified URL string
 func (u URL) String() string {
 	gu := gUrl.URL(u)
 	return gu.String()
 }
 
+// Parse decodes a URL string. Returns error if string is not a legal
 func Parse(s string) (u URL, err error) {
 	gu, err := gUrl.Parse(s)
 	if err != nil {

--- a/support/url/main.go
+++ b/support/url/main.go
@@ -1,0 +1,30 @@
+package url
+
+import (
+	gUrl "net/url"
+)
+
+type URL gUrl.URL
+
+// SetParam
+func (u URL) SetParam(key string, val string) URL {
+	gu := gUrl.URL(u)
+	q := gu.Query()
+	q.Del(key)
+	q.Add(key, val)
+	gu.RawQuery = q.Encode()
+	return URL(gu)
+}
+
+func (u URL) String() string {
+	gu := gUrl.URL(u)
+	return gu.String()
+}
+
+func Parse(s string) (u URL, err error) {
+	gu, err := gUrl.Parse(s)
+	if err != nil {
+		return
+	}
+	return URL(*gu), nil
+}

--- a/support/url/main.go
+++ b/support/url/main.go
@@ -29,5 +29,6 @@ func Parse(s string) (u URL, err error) {
 	if err != nil {
 		return
 	}
-	return URL(*gu), nil
+	u = URL(*gu)
+	return
 }

--- a/support/url/main_test.go
+++ b/support/url/main_test.go
@@ -1,0 +1,27 @@
+package url
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSetUrlParam(t *testing.T) {
+	testCases := []struct {
+		input    string
+		key      string
+		val      string
+		expected string
+	}{
+		{"http://localhost/a", "x", "1", "http://localhost/a?x=1"},
+		{"http://localhost/a?x=1", "y", "2", "http://localhost/a?x=1&y=2"},
+		{"http://localhost/a?x=1", "x", "2", "http://localhost/a?x=2"},
+	}
+
+	for _, kase := range testCases {
+		u, err := Parse(kase.input)
+		if assert.NoError(t, err) {
+			actual := u.SetParam(kase.key, kase.val).String()
+			assert.Equal(t, kase.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
apply query filters on paging links. closes #148 

also:
- modifies the Page struct to include a full url, rather than separate base url, path and query params. 
- introduces a support/url package and a URL struct for convenient url modifications. 