### PR TITLE
Re-enable account trades and offer trades endpoints

### DIFF
--- a/services/horizon/internal/actions_trade_test.go
+++ b/services/horizon/internal/actions_trade_test.go
@@ -34,7 +34,6 @@ func TestTradeActions_Index(t *testing.T) {
 
 	ht.Assert.WithinDuration(l.ClosedAt, records[0].LedgerCloseTime, 1*time.Second)
 
-	//
 	var q = make(url.Values)
 	q.Add("base_asset_type", "credit_alphanum4")
 	q.Add("base_asset_code", "USD")
@@ -71,6 +70,28 @@ func TestTradeActions_Index(t *testing.T) {
 
 		ht.Assert.Contains(records[0], "base_amount")
 		ht.Assert.Contains(records[0], "counter_amount")
+	}
+
+	// For offer
+	w = ht.Get("/offers/1/trades")
+	if ht.Assert.Equal(200, w.Code) {
+		ht.Assert.PageOf(1, w.Body)
+	}
+
+	w = ht.Get("/offers/2/trades")
+	if ht.Assert.Equal(200, w.Code) {
+		ht.Assert.PageOf(0, w.Body)
+	}
+
+	// for an account
+	w = ht.Get("/accounts/GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2/trades")
+	if ht.Assert.Equal(200, w.Code) {
+		ht.Assert.PageOf(1, w.Body)
+	}
+
+	w = ht.Get("/accounts/GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU/trades")
+	if ht.Assert.Equal(200, w.Code) {
+		ht.Assert.PageOf(1, w.Body)
 	}
 }
 

--- a/services/horizon/internal/db2/history/trade.go
+++ b/services/horizon/internal/db2/history/trade.go
@@ -49,6 +49,12 @@ func (q *Q) TradesForAssetPair(baseAssetId int64, counterAssetId int64) *TradesQ
 	return trades.forAssetPair(baseAssetId, counterAssetId)
 }
 
+// ForOffer filters the query results by the offer id.
+func (q *TradesQ) ForOffer(id int64) *TradesQ {
+	q.sql = q.sql.Where("htrd.offer_id = ?", id)
+	return q
+}
+
 //Filter by asset pair. This function is private to ensure that correct order and proper select statement are coupled
 func (q *TradesQ) forAssetPair(baseAssetId int64, counterAssetId int64) *TradesQ {
 	q.sql = q.sql.Where(sq.Eq{"base_asset_id": baseAssetId, "counter_asset_id": counterAssetId})

--- a/services/horizon/internal/ingest/system.go
+++ b/services/horizon/internal/ingest/system.go
@@ -254,8 +254,7 @@ func (i *System) runOnce() {
 
 	cursor, err := i.newCursor()
 	if err != nil {
-		log.
-			Errorf("failed to create ingestion cursor: %s", err)
+		log.Errorf("failed to create ingestion cursor: %s", err)
 		return
 	}
 	is.Cursor = cursor

--- a/services/horizon/internal/init_web.go
+++ b/services/horizon/internal/init_web.go
@@ -88,7 +88,7 @@ func initWebActions(app *App) {
 	r.Get("/accounts/:account_id/payments", &PaymentsIndexAction{})
 	r.Get("/accounts/:account_id/effects", &EffectIndexAction{})
 	r.Get("/accounts/:account_id/offers", &OffersByAccountAction{})
-	r.Get("/accounts/:account_id/trades", &NotImplementedAction{})
+	r.Get("/accounts/:account_id/trades", &TradeEffectIndexAction{})
 	r.Get("/accounts/:account_id/data/:key", &DataShowAction{})
 
 	// transaction history actions
@@ -110,9 +110,8 @@ func initWebActions(app *App) {
 	r.Get("/trades", &TradeIndexAction{})
 	r.Get("/trade_aggregations", &TradeAggregateIndexAction{})
 	r.Get("/offers/:id", &NotImplementedAction{})
-	r.Get("/offers/:offer_id/", &NotImplementedAction{})
+	r.Get("/offers/:offer_id/trades", &TradeIndexAction{})
 	r.Get("/order_book", &OrderBookShowAction{})
-	r.Get("/order_book/trades", &TradeIndexAction{})
 
 	// Transaction submission API
 	r.Post("/transactions", &TransactionCreateAction{})

--- a/services/horizon/internal/main_generated.go
+++ b/services/horizon/internal/main_generated.go
@@ -1,9 +1,8 @@
 package horizon
 
 import (
-	"net/http"
-
 	"github.com/zenazn/goji/web"
+	"net/http"
 )
 
 // ServeHTTPC is a method for web.Handler
@@ -127,6 +126,13 @@ func (action RootAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Requ
 
 // ServeHTTPC is a method for web.Handler
 func (action TradeAggregateIndexAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
+	ap := &action.Action
+	ap.Prepare(c, w, r)
+	ap.Execute(&action)
+}
+
+// ServeHTTPC is a method for web.Handler
+func (action TradeEffectIndexAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
 	ap := &action.Action
 	ap.Prepare(c, w, r)
 	ap.Execute(&action)

--- a/services/horizon/internal/resource/main.go
+++ b/services/horizon/internal/resource/main.go
@@ -224,6 +224,34 @@ type Trade struct {
 	BaseIsSeller       bool      `json:"base_is_seller"`
 }
 
+// TradeEffect represents a trade effect resource.  NOTE (scott, 2017-12-08):
+// this resource is being added back in temporarily to deal with a deploy snafu.
+// I didn't properly message the community that we were changing the response
+// format, and so we're adding this back in to allow transition.
+type TradeEffect struct {
+	Links struct {
+		Self      hal.Link `json:"self"`
+		Seller    hal.Link `json:"seller"`
+		Buyer     hal.Link `json:"buyer"`
+		Operation hal.Link `json:"operation"`
+	} `json:"_links"`
+
+	ID                string    `json:"id"`
+	PT                string    `json:"paging_token"`
+	OfferID           string    `json:"offer_id"`
+	Seller            string    `json:"seller"`
+	SoldAmount        string    `json:"sold_amount"`
+	SoldAssetType     string    `json:"sold_asset_type"`
+	SoldAssetCode     string    `json:"sold_asset_code,omitempty"`
+	SoldAssetIssuer   string    `json:"sold_asset_issuer,omitempty"`
+	Buyer             string    `json:"buyer"`
+	BoughtAmount      string    `json:"bought_amount"`
+	BoughtAssetType   string    `json:"bought_asset_type"`
+	BoughtAssetCode   string    `json:"bought_asset_code,omitempty"`
+	BoughtAssetIssuer string    `json:"bought_asset_issuer,omitempty"`
+	LedgerCloseTime   time.Time `json:"created_at"`
+}
+
 // Transaction represents trade data aggregation over a period of time
 type TradeAggregation struct {
 	Timestamp     int64  `json:"timestamp"`

--- a/services/horizon/internal/resource/trade.go
+++ b/services/horizon/internal/resource/trade.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/stellar/go/amount"
-	"github.com/stellar/go/price"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/httpx"
 	"github.com/stellar/go/services/horizon/internal/render/hal"
@@ -52,27 +51,4 @@ func (res *Trade) populateLinks(
 		"/operations",
 		fmt.Sprintf("%d", opid),
 	)
-}
-
-// Populate fills out the details of a trade using a row from the history_trades
-// table.
-func (res *TradeAggregation) Populate(
-	ctx context.Context,
-	row history.TradeAggregation,
-) (err error) {
-	res.Timestamp = row.Timestamp
-	res.TradeCount = row.TradeCount
-	res.BaseVolume = amount.StringFromInt64(row.BaseVolume)
-	res.CounterVolume = amount.StringFromInt64(row.CounterVolume)
-	res.Average = price.StringFromFloat64(row.Average)
-	res.High = price.StringFromFloat64(row.High)
-	res.Low = price.StringFromFloat64(row.Low)
-	res.Open = price.StringFromFloat64(row.Open)
-	res.Close = price.StringFromFloat64(row.Close)
-	return
-}
-
-// PagingToken implementation for hal.Pageable. Not actually used
-func (res TradeAggregation) PagingToken() string {
-	return string(res.Timestamp)
 }

--- a/services/horizon/internal/resource/trade_aggregation.go
+++ b/services/horizon/internal/resource/trade_aggregation.go
@@ -1,0 +1,31 @@
+package resource
+
+import (
+	"github.com/stellar/go/amount"
+	"github.com/stellar/go/price"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"golang.org/x/net/context"
+)
+
+// Populate fills out the details of a trade using a row from the history_trades
+// table.
+func (res *TradeAggregation) Populate(
+	ctx context.Context,
+	row history.TradeAggregation,
+) (err error) {
+	res.Timestamp = row.Timestamp
+	res.TradeCount = row.TradeCount
+	res.BaseVolume = amount.StringFromInt64(row.BaseVolume)
+	res.CounterVolume = amount.StringFromInt64(row.CounterVolume)
+	res.Average = price.StringFromFloat64(row.Average)
+	res.High = price.StringFromFloat64(row.High)
+	res.Low = price.StringFromFloat64(row.Low)
+	res.Open = price.StringFromFloat64(row.Open)
+	res.Close = price.StringFromFloat64(row.Close)
+	return
+}
+
+// PagingToken implementation for hal.Pageable. Not actually used
+func (res TradeAggregation) PagingToken() string {
+	return string(res.Timestamp)
+}

--- a/services/horizon/internal/resource/trade_effect.go
+++ b/services/horizon/internal/resource/trade_effect.go
@@ -1,0 +1,58 @@
+package resource
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/httpx"
+	"github.com/stellar/go/services/horizon/internal/render/hal"
+	"golang.org/x/net/context"
+)
+
+// PopulateFromEffect fills out the details of a trade resource from a
+// history.Effect row.
+func (res *TradeEffect) PopulateFromEffect(
+	ctx context.Context,
+	row history.Effect,
+	ledger history.Ledger,
+) (err error) {
+	if row.Type != history.EffectTrade {
+		err = errors.New("invalid effect; not a trade")
+		return
+	}
+
+	if row.LedgerSequence() != ledger.Sequence {
+		err = errors.New("invalid ledger; different sequence than trade")
+		return
+	}
+
+	row.UnmarshalDetails(res)
+	res.ID = row.PagingToken()
+	res.PT = row.PagingToken()
+	res.Buyer = row.Account
+	res.LedgerCloseTime = ledger.ClosedAt
+	res.populateLinks(ctx, res.Seller, res.Buyer, row.HistoryOperationID)
+
+	return
+}
+
+// PagingToken implementation for hal.Pageable
+func (res TradeEffect) PagingToken() string {
+	return res.PT
+}
+
+func (res *TradeEffect) populateLinks(
+	ctx context.Context,
+	seller string,
+	buyer string,
+	opid int64,
+) {
+	lb := hal.LinkBuilder{Base: httpx.BaseURL(ctx)}
+	res.Links.Seller = lb.Link("/accounts", res.Seller)
+	res.Links.Buyer = lb.Link("/accounts", res.Buyer)
+	res.Links.Operation = lb.Link(
+		"/operations",
+		fmt.Sprintf("%d", opid),
+	)
+}

--- a/support/scripts/run_tests
+++ b/support/scripts/run_tests
@@ -3,9 +3,14 @@ set -e
 
 TESTS=$(glide novendor | sed 's/^\./github.com\/stellar\/go/g')
 
-if [ "$CGO_ENABLED" = "1" ] 
-then
-  exec go test -race $TESTS
-else
-  exec go test $TESTS
-fi
+for TEST in $TESTS; do
+
+  if [ "$CGO_ENABLED" = "1" ] 
+  then
+    go test -race $TEST
+  else
+    go test $TEST
+  fi
+
+done
+


### PR DESCRIPTION
- Adds the `/accounts/:id/trades` endpoint
- Adds the `/offers/:id/trades` endpoint
- Split test run up, running one invocation of `go test` per subtree of the monorepo
- Remove `order_book/trades` endpoint