### PR TITLE
Stellar core Info and cursor fixes

### DIFF
--- a/services/horizon/internal/actions_payment_test.go
+++ b/services/horizon/internal/actions_payment_test.go
@@ -47,6 +47,10 @@ func TestPaymentActions(t *testing.T) {
 	if ht.Assert.Equal(200, w.Code) {
 		ht.Assert.PageOf(1, w.Body)
 	}
+
+	// Regression: negative cursor
+	w = ht.Get("/accounts/GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2/payments?cursor=-23667108046966785&order=asc&limit=100")
+	ht.Assert.Equal(400, w.Code)
 }
 
 func TestPayment_CreatedAt(t *testing.T) {

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -96,7 +96,7 @@ func (a *App) Serve() {
 
 	http2.ConfigureServer(srv.Server, nil)
 
-	log.Infof("Starting horizon on %s", addr)
+	log.Infof("Starting horizon on %s (ingest: %v)", addr, a.config.Ingest)
 
 	go a.run()
 

--- a/services/horizon/internal/db2/page_query.go
+++ b/services/horizon/internal/db2/page_query.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	sq "github.com/Masterminds/squirrel"
-	"github.com/go-errors/errors"
+	"github.com/stellar/go/support/errors"
 )
 
 const (
@@ -109,12 +109,12 @@ func (p PageQuery) GetContinuations(records interface{}) (next PageQuery, prev P
 
 	first, ok := rv.Index(0).Interface().(Pageable)
 	if !ok {
-		err = errors.New(ErrNotPageable)
+		err = ErrNotPageable
 	}
 
 	last, ok := rv.Index(l - 1).Interface().(Pageable)
 	if !ok {
-		err = errors.New(ErrNotPageable)
+		err = ErrNotPageable
 	}
 
 	next.Cursor = last.PagingToken()
@@ -132,18 +132,18 @@ func (p PageQuery) CursorInt64() (int64, error) {
 		case OrderDescending:
 			return math.MaxInt64, nil
 		default:
-			return 0, errors.New(ErrInvalidOrder)
+			return 0, ErrInvalidOrder
 		}
 	}
 
 	i, err := strconv.ParseInt(p.Cursor, 10, 64)
 
 	if err != nil {
-		return 0, errors.New(ErrInvalidCursor)
+		return 0, ErrInvalidCursor
 	}
 
 	if i < 0 {
-		return 0, errors.New(ErrInvalidCursor)
+		return 0, ErrInvalidCursor
 	}
 
 	return i, nil
@@ -162,7 +162,7 @@ func (p PageQuery) CursorInt64Pair(sep string) (l int64, r int64, err error) {
 			l = math.MaxInt64
 			r = math.MaxInt64
 		default:
-			err = errors.New(ErrInvalidOrder)
+			err = ErrInvalidOrder
 		}
 		return
 	}
@@ -187,18 +187,18 @@ func (p PageQuery) CursorInt64Pair(sep string) (l int64, r int64, err error) {
 
 	l, err = strconv.ParseInt(parts[0], 10, 64)
 	if err != nil {
-		err = errors.Wrap(err, 1)
+		err = errors.Wrap(err, "first component unparseable")
 		return
 	}
 
 	r, err = strconv.ParseInt(parts[1], 10, 64)
 	if err != nil {
-		err = errors.Wrap(err, 1)
+		err = errors.Wrap(err, "second component unparseable")
 		return
 	}
 
 	if l < 0 || r < 0 {
-		err = errors.New(ErrInvalidCursor)
+		err = ErrInvalidCursor
 	}
 
 	return
@@ -219,7 +219,7 @@ func NewPageQuery(
 	case OrderAscending, OrderDescending:
 		result.Order = order
 	default:
-		err = errors.New(ErrInvalidOrder)
+		err = ErrInvalidOrder
 		return
 	}
 
@@ -228,10 +228,10 @@ func NewPageQuery(
 	// Set limit
 	switch {
 	case limit <= 0:
-		err = errors.New(ErrInvalidLimit)
+		err = ErrInvalidLimit
 		return
 	case limit > MaxPageSize:
-		err = errors.New(ErrInvalidLimit)
+		err = ErrInvalidLimit
 		return
 	default:
 		result.Limit = limit

--- a/services/horizon/internal/db2/page_query_test.go
+++ b/services/horizon/internal/db2/page_query_test.go
@@ -92,4 +92,8 @@ func TestPageQuery_CursorInt64(t *testing.T) {
 	_, _, err = p.CursorInt64Pair("-")
 	assert.Error(err)
 
+	// Regression: -23667108046966785
+	p = MustPageQuery("-23667108046966785", "asc", 100)
+	_, err = p.CursorInt64()
+	assert.Error(err)
 }

--- a/services/horizon/internal/init_web.go
+++ b/services/horizon/internal/init_web.go
@@ -10,6 +10,7 @@ import (
 	metrics "github.com/rcrowley/go-metrics"
 	"github.com/rs/cors"
 	"github.com/sebest/xff"
+	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/services/horizon/internal/txsub/sequence"
 	"github.com/zenazn/goji/web"
@@ -39,6 +40,9 @@ func initWeb(app *App) {
 	// register problems
 	problem.RegisterError(sql.ErrNoRows, problem.NotFound)
 	problem.RegisterError(sequence.ErrNoMoreRoom, problem.ServerOverCapacity)
+	problem.RegisterError(db2.ErrInvalidCursor, problem.BadRequest)
+	problem.RegisterError(db2.ErrInvalidLimit, problem.BadRequest)
+	problem.RegisterError(db2.ErrInvalidOrder, problem.BadRequest)
 }
 
 // initWebMiddleware installs the middleware stack used for horizon onto the


### PR DESCRIPTION
This PR includes a grab bag of simple fixes for horizon:

- prevent panics when clients pass invalid paging info
- add a info message at horizon startup to display ingestion config
- fix bug preventing connection to stellar core when the config value contains a trailing slash