### PR TITLE
Add `horizon db rebase` subcommand

### DIFF
--- a/services/horizon/db.go
+++ b/services/horizon/db.go
@@ -109,6 +109,29 @@ var dbReapCmd = &cobra.Command{
 	},
 }
 
+var dbRebaseCmd = &cobra.Command{
+	Use:   "rebase [SEQUENCE]",
+	Short: "rebases horizon history at ledger SEQUENCE",
+	Long:  "rebases clears the horizon history db and ingests the ledger at SEQUENCE",
+	Run: func(cmd *cobra.Command, args []string) {
+		initConfig()
+		hlog.DefaultLogger.Logger.Level = config.LogLevel
+
+		i := ingestSystem()
+		i.SkipCursorUpdate = true
+
+		parsed, err := strconv.ParseInt(args[0], 10, 32)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = i.RebaseHistory(int32(parsed))
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
 var dbReingestCmd = &cobra.Command{
 	Use:   "reingest",
 	Short: "imports all data",
@@ -164,6 +187,7 @@ func init() {
 	dbCmd.AddCommand(dbMigrateCmd)
 	dbCmd.AddCommand(dbReapCmd)
 	dbCmd.AddCommand(dbReingestCmd)
+	dbCmd.AddCommand(dbRebaseCmd)
 }
 
 func ingestSystem() *ingest.System {

--- a/services/horizon/internal/ingest/system.go
+++ b/services/horizon/internal/ingest/system.go
@@ -38,6 +38,23 @@ func (i *System) ClearAll() error {
 	return nil
 }
 
+// RebaseHistory re-establishes horizon's history database using the provided
+// sequence as a starting point.
+func (i *System) RebaseHistory(sequence int32) error {
+
+	err := i.ClearAll()
+	if err != nil {
+		return errors.Wrap(err, "failed to  clear db")
+	}
+
+	err = i.ReingestSingle(sequence)
+	if err != nil {
+		return errors.Wrap(err, "failed to reingest new base")
+	}
+
+	return nil
+}
+
 // ReingestAll re-ingests all ledgers
 func (i *System) ReingestAll() (int, error) {
 


### PR DESCRIPTION
This PR adds an administrative command to horizon allowing an operator to clear the horizon database and re-establish the ledger from which history ingestion will begin.