### PR TITLE
Improve performance of transaction result lookup

### DIFF
--- a/services/horizon/internal/db2/core/transaction.go
+++ b/services/horizon/internal/db2/core/transaction.go
@@ -127,12 +127,17 @@ func (tx *Transaction) SourceAddress() string {
 	return strkey.MustEncode(strkey.VersionByteAccountID, raw)
 }
 
-// TransactionByHash is a query that loads a single row from the `txhistory`.
-func (q *Q) TransactionByHash(dest interface{}, hash string) error {
+// TransactionByHashAfterLedger is a query that loads a single row from the `txhistory`.
+func (q *Q) TransactionByHashAfterLedger(
+	dest interface{},
+	hash string,
+	ledger int32,
+) error {
 	sql := sq.Select("ctxh.*").
 		From("txhistory ctxh").
 		Limit(1).
-		Where("ctxh.txid = ?", hash)
+		Where("ctxh.txid = ?", hash).
+		Where("ctxh.ledgerseq > ?", ledger)
 
 	return q.Get(dest, sql)
 }

--- a/services/horizon/internal/db2/core/transaction_test.go
+++ b/services/horizon/internal/db2/core/transaction_test.go
@@ -20,12 +20,18 @@ func TestTransactionsQueries(t *testing.T) {
 		tt.Assert.Len(txs, 3)
 	}
 
-	// Test TransactionByHash
+	// Test TransactionByHashAfterLedger
 	var tx Transaction
-	err = q.TransactionByHash(&tx, "cebb875a00ff6e1383aef0fd251a76f22c1f9ab2a2dffcb077855736ade2659a")
+	err = q.TransactionByHashAfterLedger(&tx, "cebb875a00ff6e1383aef0fd251a76f22c1f9ab2a2dffcb077855736ade2659a", 2)
 
 	if tt.Assert.NoError(err) {
 		tt.Assert.Equal(int32(3), tx.LedgerSequence)
+	}
+
+	err = q.TransactionByHashAfterLedger(&tx, "cebb875a00ff6e1383aef0fd251a76f22c1f9ab2a2dffcb077855736ade2659a", 3)
+
+	if tt.Assert.Error(err) {
+		tt.Assert.True(q.NoRows(err))
 	}
 }
 

--- a/services/horizon/internal/txsub/internal.go
+++ b/services/horizon/internal/txsub/internal.go
@@ -1,10 +1,11 @@
 package txsub
 
 import (
+	"context"
+
 	"github.com/stellar/go/build"
 	"github.com/stellar/go/strkey"
 	"github.com/stellar/go/xdr"
-	"golang.org/x/net/context"
 )
 
 type envelopeInfo struct {

--- a/services/horizon/internal/txsub/main.go
+++ b/services/horizon/internal/txsub/main.go
@@ -3,8 +3,9 @@ package txsub
 import (
 	"time"
 
+	"context"
+
 	"github.com/stellar/go/xdr"
-	"golang.org/x/net/context"
 )
 
 // ResultProvider represents an abstract store that can lookup Result objects

--- a/services/horizon/internal/txsub/open_submission_list.go
+++ b/services/horizon/internal/txsub/open_submission_list.go
@@ -1,11 +1,11 @@
 package txsub
 
 import (
+	"context"
 	"sync"
 	"time"
 
 	"github.com/go-errors/errors"
-	"golang.org/x/net/context"
 )
 
 // NewDefaultSubmissionList returns a list that manages open submissions purely

--- a/services/horizon/internal/txsub/submitter.go
+++ b/services/horizon/internal/txsub/submitter.go
@@ -1,13 +1,13 @@
 package txsub
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/go-errors/errors"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/services/horizon/internal/txsub/system.go
+++ b/services/horizon/internal/txsub/system.go
@@ -1,13 +1,13 @@
 package txsub
 
 import (
+	"context"
 	"sync"
 	"time"
 
 	"github.com/rcrowley/go-metrics"
 	"github.com/stellar/go/services/horizon/internal/log"
 	"github.com/stellar/go/services/horizon/internal/txsub/sequence"
-	"golang.org/x/net/context"
 )
 
 // System represents a completely configured transaction submission system.

--- a/services/horizon/internal/txsub/test_helpers.go
+++ b/services/horizon/internal/txsub/test_helpers.go
@@ -7,7 +7,7 @@ package txsub
 // txsub and use these mocks in their own tests
 
 import (
-	"golang.org/x/net/context"
+	"context"
 )
 
 // MockSubmitter is a test helper that simplements the Submitter interface


### PR DESCRIPTION
This PR modifies how horizon queries the stellar core database for transaction results to reduce complexity.  By filtering the `txhistory` table by `ledgerseq` we reduce the search space for a result significantly.