### PR TITLE
Update base fee and reserve attributes on ledger resource

### DIFF
--- a/clients/horizon/responses.go
+++ b/clients/horizon/responses.go
@@ -143,8 +143,8 @@ type Ledger struct {
 	ClosedAt         time.Time `json:"closed_at"`
 	TotalCoins       string    `json:"total_coins"`
 	FeePool          string    `json:"fee_pool"`
-	BaseFee          int32     `json:"base_fee"`
-	BaseReserve      string    `json:"base_reserve"`
+	BaseFee          int32     `json:"base_fee_in_stroops"`
+	BaseReserve      int32     `json:"base_reserve_in_stroops"`
 	MaxTxSetSize     int32     `json:"max_tx_set_size"`
 	ProtocolVersion  int32     `json:"protocol_version"`
 }

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -12,6 +12,11 @@ bumps.  A breaking change will get clearly notified in this log.
 
 - Operation and payment resources were changed to add a `transaction_hash` property.
 
+### Changed
+
+- BREAKING CHANGE: The `base_fee` property of the ledger resource has been renamed to `base_fee_in_stroops` 
+- BREAKING CHANGE: The `base_reserve` property of the ledger resource has been renamed to `base_reserve_in_stroops` and is now expressed in stroops (rather than lumens) and as a JSON number. 
+
 ## [v0.11.0] - 2017-08-15
 
 ### Bug fixes

--- a/services/horizon/internal/docs/reference/endpoints/ledgers-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/ledgers-all.md
@@ -84,8 +84,8 @@ This endpoint responds with a list of ledgers.  See [ledger resource](../resourc
         "closed_at": "1970-01-01T00:00:00Z",
         "total_coins": "100000000000.0000000",
         "fee_pool": "0.0000000",
-        "base_fee": 100,
-        "base_reserve": "10.0000000",
+        "base_fee_in_stroops": 100,
+        "base_reserve_in_stroops": 100000000,
         "max_tx_set_size": 50
       },
       {
@@ -116,8 +116,8 @@ This endpoint responds with a list of ledgers.  See [ledger resource](../resourc
         "closed_at": "2015-07-16T23:49:00Z",
         "total_coins": "100000000000.0000000",
         "fee_pool": "0.0000000",
-        "base_fee": 100,
-        "base_reserve": "10.0000000",
+        "base_fee_in_stroops": 100,
+        "base_reserve_in_stroops": 100000000,
         "max_tx_set_size": 100
       }
     ]
@@ -167,8 +167,8 @@ This endpoint responds with a list of ledgers.  See [ledger resource](../resourc
   "closed_at": "2015-07-20T15:51:52Z",
   "total_coins": "100000000000.0000000",
   "fee_pool": "0.0025600",
-  "base_fee": 100,
-  "base_reserve": "10.0000000",
+  "base_fee_in_stroops": 100,
+  "base_reserve_in_stroops": "100000000,
   "max_tx_set_size": 50
 }
 ```

--- a/services/horizon/internal/docs/reference/endpoints/ledgers-single.md
+++ b/services/horizon/internal/docs/reference/endpoints/ledgers-single.md
@@ -76,8 +76,8 @@ This endpoint responds with a single Ledger.  See [ledger resource](../resources
   "closed_at": "2015-07-20T15:51:52Z",
   "total_coins": "100000000000.0000000",
   "fee_pool": "0.0025600",
-  "base_fee": 100,
-  "base_reserve": "10.0000000",
+  "base_fee_in_stroops": 100,
+  "base_reserve_in_stroops": 100000000,
   "max_tx_set_size": 50
 }
 ```

--- a/services/horizon/internal/docs/reference/resources/ledger.md
+++ b/services/horizon/internal/docs/reference/resources/ledger.md
@@ -7,21 +7,21 @@ A **ledger** resource contains information about a given ledger.
 To learn more about the concept of ledgers in the Stellar network, take a look at the [Stellar ledger concept guide](https://www.stellar.org/developers/learn/concepts/ledger.html).
 
 ## Attributes
-| Attribute         | Type   |                                                                                                                               |
-|-------------------|--------|-------------------------------------------------------------------------------------------------------------------------------|
-| id                | string | The id is a unique identifier for this ledger.                                                                                |
-| paging_token      | number | A [paging token](./page.md) suitable for use as a `cursor` parameter.                                                         |
-| hash              | string | A hex-encoded SHA-256 hash of the ledger's [XDR](../../learn/xdr.md)-encoded form.                                            |
-| prev_hash         | string | The hash of the ledger that chronologically came before this one.                                                             |
-| sequence          | number | Sequence number of this ledger, suitable for use as the as the :id parameter for url templates that require a ledger number.  |
-| transaction_count | number | The number of transactions in this ledger.                                                                                    |
-| operation_count   | number | The number of operations in this ledger.                                                                                      |
-| closed_at         | string | An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formatted string of when this ledger was closed.                        |
-| total_coins       | string | The total number of lumens in circulation.                                                                                    |
-| fee_pool          | string | The sum of all transaction fees *(in lumens)* since the last inflation operation. They are redistributed during [inflation].  |
-| base_fee          | number | The [fee] the network charges per operation in a transaction.                                                                 |
-| base_reserve      | string | The [reserve][fee] the network uses when calculating an account's minimum balance.                                            |
-| max_tx_set_size   | number | The maximum number of transactions validators have agreed to process in a given ledger.                                       |
+| Attribute               | Type   |                                                                                                                               |
+|-------------------------|--------|-------------------------------------------------------------------------------------------------------------------------------|
+| id                      | string | The id is a unique identifier for this ledger.                                                                                |
+| paging_token            | number | A [paging token](./page.md) suitable for use as a `cursor` parameter.                                                         |
+| hash                    | string | A hex-encoded SHA-256 hash of the ledger's [XDR](../../learn/xdr.md)-encoded form.                                            |
+| prev_hash               | string | The hash of the ledger that chronologically came before this one.                                                             |
+| sequence                | number | Sequence number of this ledger, suitable for use as the as the :id parameter for url templates that require a ledger number.  |
+| transaction_count       | number | The number of transactions in this ledger.                                                                                    |
+| operation_count         | number | The number of operations in this ledger.                                                                                      |
+| closed_at               | string | An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formatted string of when this ledger was closed.                        |
+| total_coins             | string | The total number of lumens in circulation.                                                                                    |
+| fee_pool                | string | The sum of all transaction fees *(in lumens)* since the last inflation operation. They are redistributed during [inflation].  |
+| base_fee_in_stroops     | number | The [fee] the network charges per operation in a transaction.  Expressed in stroops.                                          |
+| base_reserve_in_stroops | number | The [reserve][fee] the network uses when calculating an account's minimum balance. Expressed in stroops.                      |
+| max_tx_set_size         | number | The maximum number of transactions validators have agreed to process in a given ledger.                                       |
 
 ## Links
 |              | Example                                           | Relation                        | templated |
@@ -63,8 +63,8 @@ To learn more about the concept of ledgers in the Stellar network, take a look a
   "closed_at": "2015-07-09T21:39:28Z",
   "total_coins": "100000000000.0000000",
   "fee_pool": "0.0025600",
-  "base_fee": 100,
-  "base_reserve": "10.0000000",
+  "base_fee_in_stroops": 100,
+  "base_reserve_in_stroops": 100000000,
   "max_tx_set_size": 50
 }
 ```

--- a/services/horizon/internal/docs/reference/responses.md
+++ b/services/horizon/internal/docs/reference/responses.md
@@ -41,8 +41,8 @@ links between documents.  Let's look at a simple example:
   "closed_at": "0001-01-01T00:00:00Z",
   "total_coins": "100000000000.0000000",
   "fee_pool": "0.0000000",
-  "base_fee": 100,
-  "base_reserve": "10.0000000",
+  "base_fee_in_stroops": 100,
+  "base_reserve_in_stroops": 100000000,
   "max_tx_set_size": 50
 }
 ```

--- a/services/horizon/internal/resource/ledger.go
+++ b/services/horizon/internal/resource/ledger.go
@@ -23,7 +23,7 @@ func (this *Ledger) Populate(ctx context.Context, row history.Ledger) {
 	this.TotalCoins = amount.String(xdr.Int64(row.TotalCoins))
 	this.FeePool = amount.String(xdr.Int64(row.FeePool))
 	this.BaseFee = row.BaseFee
-	this.BaseReserve = amount.String(xdr.Int64(row.BaseReserve))
+	this.BaseReserve = row.BaseReserve
 	this.MaxTxSetSize = row.MaxTxSetSize
 	this.ProtocolVersion = row.ProtocolVersion
 

--- a/services/horizon/internal/resource/main.go
+++ b/services/horizon/internal/resource/main.go
@@ -113,8 +113,8 @@ type Ledger struct {
 	ClosedAt         time.Time `json:"closed_at"`
 	TotalCoins       string    `json:"total_coins"`
 	FeePool          string    `json:"fee_pool"`
-	BaseFee          int32     `json:"base_fee"`
-	BaseReserve      string    `json:"base_reserve"`
+	BaseFee          int32     `json:"base_fee_in_stroops"`
+	BaseReserve      int32     `json:"base_reserve_in_stroops"`
 	MaxTxSetSize     int32     `json:"max_tx_set_size"`
 	ProtocolVersion  int32     `json:"protocol_version"`
 }


### PR DESCRIPTION
This PR updates our representation of "base fee" and "base reserve" in horizon.  In renames attributes to make it clearer what the number represents.