### PR TITLE
Return errors in builder functions

### DIFF
--- a/build/account_merge.go
+++ b/build/account_merge.go
@@ -40,7 +40,7 @@ func (b *AccountMergeBuilder) Mutate(muts ...interface{}) {
 		}
 
 		if err != nil {
-			b.Err = err
+			b.Err = errors.Wrap(err, "AccountMergeBuilder error")
 			return
 		}
 	}

--- a/build/allow_trust.go
+++ b/build/allow_trust.go
@@ -39,7 +39,7 @@ func (b *AllowTrustBuilder) Mutate(muts ...interface{}) {
 		}
 
 		if err != nil {
-			b.Err = err
+			b.Err = errors.Wrap(err, "AllowTrustBuilder error")
 			return
 		}
 	}

--- a/build/allow_trust_test.go
+++ b/build/allow_trust_test.go
@@ -95,7 +95,7 @@ var _ = Describe("AllowTrustBuilder Mutators", func() {
 				})
 
 				It("failed", func() {
-					Expect(subject.Err).To(MatchError("Asset code length is invalid"))
+					Expect(subject.Err.Error()).To(ContainSubstring("Asset code length is invalid"))
 				})
 			})
 
@@ -105,7 +105,7 @@ var _ = Describe("AllowTrustBuilder Mutators", func() {
 				})
 
 				It("failed", func() {
-					Expect(subject.Err).To(MatchError("Asset code length is invalid"))
+					Expect(subject.Err.Error()).To(ContainSubstring("Asset code length is invalid"))
 				})
 			})
 		})

--- a/build/change_trust.go
+++ b/build/change_trust.go
@@ -40,7 +40,7 @@ func (b *ChangeTrustBuilder) Mutate(muts ...interface{}) {
 		}
 
 		if err != nil {
-			b.Err = err
+			b.Err = errors.Wrap(err, "ChangeTrustBuilder error")
 			return
 		}
 	}

--- a/build/change_trust_test.go
+++ b/build/change_trust_test.go
@@ -74,7 +74,7 @@ var _ = Describe("ChangeTrustBuilder Mutators", func() {
 				})
 
 				It("failed", func() {
-					Expect(subject.Err).To(MatchError("Native asset not allowed"))
+					Expect(subject.Err.Error()).To(ContainSubstring("Native asset not allowed"))
 				})
 			})
 
@@ -84,7 +84,7 @@ var _ = Describe("ChangeTrustBuilder Mutators", func() {
 				})
 
 				It("failed", func() {
-					Expect(subject.Err).To(MatchError("Asset code length is invalid"))
+					Expect(subject.Err.Error()).To(ContainSubstring("Asset code length is invalid"))
 				})
 			})
 
@@ -94,7 +94,7 @@ var _ = Describe("ChangeTrustBuilder Mutators", func() {
 				})
 
 				It("failed", func() {
-					Expect(subject.Err).To(MatchError("Asset code length is invalid"))
+					Expect(subject.Err.Error()).To(ContainSubstring("Asset code length is invalid"))
 				})
 			})
 		})

--- a/build/create_account.go
+++ b/build/create_account.go
@@ -41,7 +41,7 @@ func (b *CreateAccountBuilder) Mutate(muts ...interface{}) {
 		}
 
 		if err != nil {
-			b.Err = err
+			b.Err = errors.Wrap(err, "CreateAccountBuilder error")
 			return
 		}
 	}

--- a/build/inflation.go
+++ b/build/inflation.go
@@ -29,7 +29,7 @@ func (b *InflationBuilder) Mutate(muts ...interface{}) {
 		}
 
 		if err != nil {
-			b.Err = err
+			b.Err = errors.Wrap(err, "InflationBuilder error")
 			return
 		}
 	}

--- a/build/main_test.go
+++ b/build/main_test.go
@@ -19,7 +19,7 @@ func TestBuild(t *testing.T) {
 // It uses the transaction builder system
 func ExampleTransactionBuilder() {
 	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
-	tx := Transaction(
+	tx, err := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
 		TestNetwork,
@@ -29,8 +29,23 @@ func ExampleTransactionBuilder() {
 		),
 	)
 
-	txe := tx.Sign(seed)
-	txeB64, _ := txe.Base64()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txe, err := tx.Sign(seed)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txeB64, err := txe.Base64()
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
 	fmt.Printf("tx base64: %s", txeB64)
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAALSRpLtCLv2eboZlEiHDSGR6Hb+zZL92fbSdNpObeE0EAAAAAAAAAAB3NZQAAAAAAAAAAARtDMfAAAABA2oIeQxoJl53RMRWFeLB865zcky39f2gf2PmUubCuJYccEePRSrTC8QQrMOgGwD8a6oe8dgltvezdDsmmXBPyBw==
@@ -40,7 +55,7 @@ func ExampleTransactionBuilder() {
 // encodes it into a base64 string capable of being submitted to stellar-core.
 func ExamplePathPayment() {
 	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
-	tx := Transaction(
+	tx, err := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
 		TestNetwork,
@@ -53,8 +68,23 @@ func ExamplePathPayment() {
 		),
 	)
 
-	txe := tx.Sign(seed)
-	txeB64, _ := txe.Base64()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txe, err := tx.Sign(seed)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txeB64, err := txe.Base64()
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
 	fmt.Printf("tx base64: %s", txeB64)
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAIAAAABRVVSAAAAAACflO2Jhs1DJkFfo7YvGZeKqpze+F4ENZde22bePZeubwAAAAA7msoAAAAAAEc9q5pbnyO0BDkT4FXgGhPGAj7kCKVbS4PDJS8D1pVCAAAAAVVTRAAAAAAALSRpLtCLv2eboZlEiHDSGR6Hb+zZL92fbSdNpObeE0EAAAAAHc1lAAAAAAIAAAAAAAAAAUJUQwAAAAAADpyeqirBMAJpPzwvuVrLqxHz5shND7/OFUvopGIhupYAAAAAAAAAARtDMfAAAABA5xuIJu/KGKQRuDrdkzNsR4HjT6wX464SHZ/yvYwVb/AkAyyfeMLDNhgKbBxQMWc3Uo5fTst1UHldC+jYNeAhCQ==
@@ -64,7 +94,7 @@ func ExamplePathPayment() {
 // encodes it into a base64 string capable of being submitted to stellar-core.
 func ExampleSetOptions() {
 	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
-	tx := Transaction(
+	tx, err := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
 		TestNetwork,
@@ -83,8 +113,23 @@ func ExampleSetOptions() {
 		),
 	)
 
-	txe := tx.Sign(seed)
-	txeB64, _ := txe.Base64()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txe, err := tx.Sign(seed)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txeB64, err := txe.Base64()
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
 	fmt.Printf("tx base64: %s", txeB64)
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAUAAAABAAAAAKf5dCD2RflX5jEYTCZ2cHEwuB+QuJJh/0AIM3zwaiyoAAAAAQAAAAcAAAABAAAABwAAAAEAAAABAAAAAQAAAAIAAAABAAAAAwAAAAEAAAAEAAAAAQAAAAtzdGVsbGFyLm9yZwAAAAABAAAAALwxmfetrj7X13WT+tJjwj9VPrqIE2DUJ48+59etBKjTAAAABQAAAAAAAAABG0Mx8AAAAECZF17pOfZcyc7YJXMyx++PMydIvL6g2yZcPDY8h4+tmlz+3rsE6uuX0R6xfgNnuMntvK4YMmaOvp4DvaZMMNoA
@@ -94,7 +139,7 @@ func ExampleSetOptions() {
 // encodes it into a base64 string capable of being submitted to stellar-core.
 func ExampleSetOptions_manyOperations() {
 	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
-	tx := Transaction(
+	tx, err := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
 		TestNetwork,
@@ -111,8 +156,23 @@ func ExampleSetOptions_manyOperations() {
 		RemoveSigner("GC6DDGPXVWXD5V6XOWJ7VUTDYI7VKPV2RAJWBVBHR47OPV5NASUNHTJW"),
 	)
 
-	txe := tx.Sign(seed)
-	txeB64, _ := txe.Base64()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txe, err := tx.Sign(seed)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txeB64, err := txe.Base64()
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
 	fmt.Printf("tx base64: %s", txeB64)
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAETAAAAAAAAAABAAAAAAAAAAAAAAALAAAAAAAAAAUAAAABAAAAAKf5dCD2RflX5jEYTCZ2cHEwuB+QuJJh/0AIM3zwaiyoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAAAAAAAAQAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAAAAAAAAQAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAABAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAABAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAABAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAgAAAAEAAAADAAAAAQAAAAQAAAAAAAAAAAAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAALc3RlbGxhci5vcmcAAAAAAAAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAALwxmfetrj7X13WT+tJjwj9VPrqIE2DUJ48+59etBKjTAAAAAAAAAAAAAAABG0Mx8AAAAEAOXsLbFo3e8fpqyeZEHGP9o/IrQDQRyof+DA1EeUkvUGbNhy57xXcpMhZpRtwXThWBYx4za4q+TRrnoZQtezgN
@@ -122,15 +182,30 @@ func ExampleSetOptions_manyOperations() {
 // encodes it into a base64 string capable of being submitted to stellar-core.
 func ExampleChangeTrust() {
 	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
-	tx := Transaction(
+	tx, err := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
 		TestNetwork,
 		Trust("USD", "GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA", Limit("100.25")),
 	)
 
-	txe := tx.Sign(seed)
-	txeB64, _ := txe.Base64()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txe, err := tx.Sign(seed)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txeB64, err := txe.Base64()
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
 	fmt.Printf("tx base64: %s", txeB64)
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABVVNEAAAAAAAtJGku0Iu/Z5uhmUSIcNIZHodv7Nkv3Z9tJ02k5t4TQQAAAAA7wO+gAAAAAAAAAAEbQzHwAAAAQOIy19X38Y3jcFzvhDsmXu6iDzrzb4iwfS2NAq9GGAFiRJUGoFX85vKtlNcXzQppF4X8oIMNPEb74fuZE/N+GAE=
@@ -140,15 +215,30 @@ func ExampleChangeTrust() {
 // encodes it into a base64 string capable of being submitted to stellar-core.
 func ExampleChangeTrust_maxLimit() {
 	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
-	tx := Transaction(
+	tx, err := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
 		TestNetwork,
 		Trust("USD", "GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA"),
 	)
 
-	txe := tx.Sign(seed)
-	txeB64, _ := txe.Base64()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txe, err := tx.Sign(seed)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txeB64, err := txe.Base64()
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
 	fmt.Printf("tx base64: %s", txeB64)
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABVVNEAAAAAAAtJGku0Iu/Z5uhmUSIcNIZHodv7Nkv3Z9tJ02k5t4TQX//////////AAAAAAAAAAEbQzHwAAAAQJQC6R3RqNaw5rOmaxqpAE0lD5onM/njn9I2RVlhtS2SGi2Z7xm65USYVWXTJFVqTCfTwwu+QXFcOuqgJjVtHAk=
@@ -159,7 +249,7 @@ func ExampleChangeTrust_maxLimit() {
 func ExampleRemoveTrust() {
 	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
 	operationSource := "GCVJCNUHSGKOTBBSXZJ7JJZNOSE2YDNGRLIDPMQDUEQWJQSE6QZSDPNU"
-	tx := Transaction(
+	tx, err := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
 		TestNetwork,
@@ -170,8 +260,23 @@ func ExampleRemoveTrust() {
 		),
 	)
 
-	txe := tx.Sign(seed)
-	txeB64, _ := txe.Base64()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txe, err := tx.Sign(seed)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txeB64, err := txe.Base64()
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
 	fmt.Printf("tx base64: %s", txeB64)
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAQAAAACqkTaHkZTphDK+U/SnLXSJrA2mitA3sgOhIWTCRPQzIQAAAAYAAAABVVNEAAAAAAAtJGku0Iu/Z5uhmUSIcNIZHodv7Nkv3Z9tJ02k5t4TQQAAAAAAAAAAAAAAAAAAAAEbQzHwAAAAQD5FeGBEwJyeauK+WKfcxYBeKw62EtCqvC0p9Z+1cY32fKQ+5Jz9uE1LaDsHW5NurtStKcUTiG5j2qNDf1QpYgw=
@@ -187,7 +292,7 @@ func ExampleManageOffer() {
 	}
 
 	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
-	tx := Transaction(
+	tx, err := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
 		TestNetwork,
@@ -196,8 +301,23 @@ func ExampleManageOffer() {
 		DeleteOffer(rate, OfferID(1)),
 	)
 
-	txe := tx.Sign(seed)
-	txeB64, _ := txe.Base64()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txe, err := tx.Sign(seed)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txeB64, err := txe.Base64()
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
 	fmt.Printf("tx base64: %s", txeB64)
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAABLAAAAAAAAAABAAAAAAAAAAAAAAADAAAAAAAAAAMAAAAAAAAAAVVTRAAAAAAALSRpLtCLv2eboZlEiHDSGR6Hb+zZL92fbSdNpObeE0EAAAAAC+vCAAAADDgAAAAZAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAABVVNEAAAAAAAtJGku0Iu/Z5uhmUSIcNIZHodv7Nkv3Z9tJ02k5t4TQQAAAAAX14QAAAAMOAAAABkAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAFVU0QAAAAAAC0kaS7Qi79nm6GZRIhw0hkeh2/s2S/dn20nTaTm3hNBAAAAAAAAAAAAAAw4AAAAGQAAAAAAAAABAAAAAAAAAAEbQzHwAAAAQBfosk+t8qpULHP4ppNX2xVPih8lmnbHFZdeuxSP6pgpCCX05S7zZ4PsjVQY2nOnLru6mBTc1r8So+vxHs3FXAc=
@@ -213,15 +333,30 @@ func ExampleCreatePassiveOffer() {
 	}
 
 	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
-	tx := Transaction(
+	tx, err := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
 		TestNetwork,
 		CreatePassiveOffer(rate, "20"),
 	)
 
-	txe := tx.Sign(seed)
-	txeB64, _ := txe.Base64()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txe, err := tx.Sign(seed)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txeB64, err := txe.Base64()
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
 	fmt.Printf("tx base64: %s", txeB64)
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAQAAAAAAAAAAVVTRAAAAAAALSRpLtCLv2eboZlEiHDSGR6Hb+zZL92fbSdNpObeE0EAAAAAC+vCAAAADDgAAAAZAAAAAAAAAAEbQzHwAAAAQHv/1xLn+ArfIUoWjn3V0zVka6tulqMYx4zJZhGqdmTw8iCXY0ZtHS+y+7YGgR3vM1DpKOdvWTmhee+sCXIppQA=
@@ -231,7 +366,7 @@ func ExampleCreatePassiveOffer() {
 // encodes it into a base64 string capable of being submitted to stellar-core.
 func ExampleAccountMerge() {
 	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
-	tx := Transaction(
+	tx, err := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
 		TestNetwork,
@@ -240,8 +375,23 @@ func ExampleAccountMerge() {
 		),
 	)
 
-	txe := tx.Sign(seed)
-	txeB64, _ := txe.Base64()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txe, err := tx.Sign(seed)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txeB64, err := txe.Base64()
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
 	fmt.Printf("tx base64: %s", txeB64)
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAgAAAAARz2rmlufI7QEORPgVeAaE8YCPuQIpVtLg8MlLwPWlUIAAAAAAAAAARtDMfAAAABAh3qZrP5T9Xg0LdzwOLx/eA/B7bzj+8j+s9eXNuu7/Ldch7I6kW5iYz6Vfy32FVnKNtoykToB7nQY2o2vo1tqAw==
@@ -251,15 +401,30 @@ func ExampleAccountMerge() {
 // encodes it into a base64 string capable of being submitted to stellar-core.
 func ExampleInflation() {
 	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
-	tx := Transaction(
+	tx, err := Transaction(
 		SourceAccount{seed},
 		Sequence{1},
 		TestNetwork,
 		Inflation(),
 	)
 
-	txe := tx.Sign(seed)
-	txeB64, _ := txe.Base64()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txe, err := tx.Sign(seed)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txeB64, err := txe.Base64()
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
 	fmt.Printf("tx base64: %s", txeB64)
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAkAAAAAAAAAARtDMfAAAABAzzDG4V7KzynWY0ER/V4HH0WgDvl3hrIizDcKW3qEQY4Ib3yXufVvdbzsET/Dj5js5dgDkcYgikHwRCpqi/J8BQ==

--- a/build/manage_data.go
+++ b/build/manage_data.go
@@ -45,7 +45,7 @@ func (b *ManageDataBuilder) Mutate(muts ...interface{}) {
 		}
 
 		if err != nil {
-			b.Err = err
+			b.Err = errors.Wrap(err, "ManageDataBuilder error")
 			return
 		}
 	}

--- a/build/manage_offer.go
+++ b/build/manage_offer.go
@@ -68,7 +68,7 @@ func (b *ManageOfferBuilder) Mutate(muts ...interface{}) {
 		}
 
 		if err != nil {
-			b.Err = err
+			b.Err = errors.Wrap(err, "ManageOfferBuilder error")
 			return
 		}
 	}

--- a/build/payment.go
+++ b/build/payment.go
@@ -53,7 +53,7 @@ func (b *PaymentBuilder) Mutate(muts ...interface{}) {
 		}
 
 		if err != nil {
-			b.Err = err
+			b.Err = errors.Wrap(err, "PaymentBuilder error")
 			return
 		}
 	}

--- a/build/payment_test.go
+++ b/build/payment_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Payment Mutators", func() {
 					})
 
 					It("failed", func() {
-						Expect(subject.Err).To(MatchError("Asset code length is invalid"))
+						Expect(subject.Err.Error()).To(ContainSubstring("Asset code length is invalid"))
 					})
 				})
 
@@ -96,7 +96,7 @@ var _ = Describe("Payment Mutators", func() {
 					})
 
 					It("failed", func() {
-						Expect(subject.Err).To(MatchError("Asset code length is invalid"))
+						Expect(subject.Err.Error()).To(ContainSubstring("Asset code length is invalid"))
 					})
 				})
 			})
@@ -265,7 +265,7 @@ var _ = Describe("Payment Mutators", func() {
 					})
 
 					It("failed", func() {
-						Expect(subject.Err).To(MatchError("Asset code length is invalid"))
+						Expect(subject.Err.Error()).To(ContainSubstring("Asset code length is invalid"))
 					})
 				})
 
@@ -275,7 +275,7 @@ var _ = Describe("Payment Mutators", func() {
 					})
 
 					It("failed", func() {
-						Expect(subject.Err).To(MatchError("Asset code length is invalid"))
+						Expect(subject.Err.Error()).To(ContainSubstring("Asset code length is invalid"))
 					})
 				})
 			})

--- a/build/set_options.go
+++ b/build/set_options.go
@@ -39,7 +39,7 @@ func (b *SetOptionsBuilder) Mutate(muts ...interface{}) {
 		}
 
 		if err != nil {
-			b.Err = err
+			b.Err = errors.Wrap(err, "SetOptionsBuilder error")
 			return
 		}
 	}

--- a/build/transaction_envelope_test.go
+++ b/build/transaction_envelope_test.go
@@ -3,7 +3,6 @@ package build
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/stellar/go/support/errors"
 )
 
 var _ = Describe("TransactionEnvelope Mutators:", func() {
@@ -11,27 +10,22 @@ var _ = Describe("TransactionEnvelope Mutators:", func() {
 	var (
 		subject TransactionEnvelopeBuilder
 		mut     TransactionEnvelopeMutator
+		err     error
 	)
 
 	BeforeEach(func() { subject = TransactionEnvelopeBuilder{} })
-	JustBeforeEach(func() { subject.Mutate(mut) })
+	JustBeforeEach(func() { err = subject.Mutate(mut) })
 
 	Describe("TransactionBuilder", func() {
 		Context("that is valid", func() {
-			BeforeEach(func() { mut = Transaction(Sequence{10}) })
-			It("succeeds", func() { Expect(subject.Err).NotTo(HaveOccurred()) })
+			BeforeEach(func() {
+				var err error
+				mut, err = Transaction(Sequence{10})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("succeeds", func() { Expect(err).NotTo(HaveOccurred()) })
 			It("sets the TX", func() { Expect(subject.E.Tx.SeqNum).To(BeEquivalentTo(10)) })
 		})
-
-		Context("with an error set on it", func() {
-			err := errors.New("busted!")
-			BeforeEach(func() { mut = &TransactionBuilder{Err: err} })
-			It("propagates the error upwards", func() {
-				Expect(subject.Err).To(HaveOccurred())
-				Expect(subject.Err.Error()).To(ContainSubstring("busted!"))
-			})
-		})
-
 	})
 
 	Describe("Sign", func() {
@@ -41,7 +35,7 @@ var _ = Describe("TransactionEnvelope Mutators:", func() {
 				mut = Sign{"SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"}
 			})
 
-			It("succeeds", func() { Expect(subject.Err).NotTo(HaveOccurred()) })
+			It("succeeds", func() { Expect(err).NotTo(HaveOccurred()) })
 			It("adds a signature to the envelope", func() {
 				Expect(subject.E.Signatures).To(HaveLen(1))
 			})
@@ -51,7 +45,7 @@ var _ = Describe("TransactionEnvelope Mutators:", func() {
 			BeforeEach(func() { mut = Sign{""} })
 
 			It("fails", func() {
-				Expect(subject.Err).To(HaveOccurred())
+				Expect(err).To(HaveOccurred())
 			})
 		})
 	})

--- a/build/transaction_test.go
+++ b/build/transaction_test.go
@@ -11,10 +11,11 @@ var _ = Describe("Transaction Mutators:", func() {
 	var (
 		subject *TransactionBuilder
 		mut     TransactionMutator
+		err     error
 	)
 
 	BeforeEach(func() { subject = &TransactionBuilder{} })
-	JustBeforeEach(func() { subject.Mutate(mut) })
+	JustBeforeEach(func() { err = subject.Mutate(mut) })
 
 	Describe("Defaults", func() {
 		BeforeEach(func() {
@@ -105,7 +106,7 @@ var _ = Describe("Transaction Mutators:", func() {
 		Context("a string longer than 28 bytes", func() {
 			BeforeEach(func() { mut = MemoText{"12345678901234567890123456789"} })
 			It("sets an error", func() {
-				Expect(subject.Err).ToNot(BeNil())
+				Expect(err).ToNot(BeNil())
 			})
 		})
 	})
@@ -137,13 +138,13 @@ var _ = Describe("Transaction Mutators:", func() {
 
 		Context("with bad address", func() {
 			BeforeEach(func() { mut = SourceAccount{"foo"} })
-			It("fails", func() { Expect(subject.Err).To(HaveOccurred()) })
+			It("fails", func() { Expect(err).To(HaveOccurred()) })
 		})
 	})
 
 	Describe("Sequence", func() {
 		BeforeEach(func() { mut = Sequence{12345} })
-		It("succeeds", func() { Expect(subject.Err).NotTo(HaveOccurred()) })
+		It("succeeds", func() { Expect(err).NotTo(HaveOccurred()) })
 		It("sets the sequence", func() { Expect(subject.TX.SeqNum).To(BeEquivalentTo(12345)) })
 	})
 
@@ -159,7 +160,7 @@ var _ = Describe("Transaction Mutators:", func() {
 		})
 
 		Context("with no source account set", func() {
-			It("fails", func() { Expect(subject.Err).To(HaveOccurred()) })
+			It("fails", func() { Expect(err).To(HaveOccurred()) })
 		})
 
 		Context("with a source account set", func() {
@@ -169,7 +170,7 @@ var _ = Describe("Transaction Mutators:", func() {
 				})
 			})
 
-			It("succeeds", func() { Expect(subject.Err).NotTo(HaveOccurred()) })
+			It("succeeds", func() { Expect(err).NotTo(HaveOccurred()) })
 			It("sets the sequence", func() { Expect(subject.TX.SeqNum).To(BeEquivalentTo(3)) })
 		})
 	})

--- a/clients/federation/client_test.go
+++ b/clients/federation/client_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/clients/stellartoml"
 	"github.com/stellar/go/support/http/httptest"
 	"github.com/stretchr/testify/assert"
@@ -121,14 +122,16 @@ func TestLookupByAddress(t *testing.T) {
 }
 
 func TestLookupByID(t *testing.T) {
-	// HACK: until we improve our mocking scenario, this is just a smoke test.
-	// When/if it breaks, please write this test correctly.  That, or curse
-	// scott's name aloud.
+	horizonMock := &horizon.MockClient{}
+	client := &Client{Horizon: horizonMock}
+
+	horizonMock.On("HomeDomainForAccount", "GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C").
+		Return("", errors.New("homedomain not set"))
 
 	// an account without a homedomain set fails
-	_, err := DefaultPublicNetClient.LookupByAccountID("GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C")
+	_, err := client.LookupByAccountID("GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C")
 	assert.Error(t, err)
-	assert.Equal(t, "homedomain not set", err.Error())
+	assert.Equal(t, "get homedomain failed: homedomain not set", err.Error())
 }
 
 func Test_url(t *testing.T) {

--- a/clients/federation/main.go
+++ b/clients/federation/main.go
@@ -17,7 +17,7 @@ var DefaultTestNetClient = &Client{
 	StellarTOML: stellartoml.DefaultClient,
 }
 
-// DefaultPublicNetClient is a default federation client for oubnet
+// DefaultPublicNetClient is a default federation client for pubnet
 var DefaultPublicNetClient = &Client{
 	HTTP:        http.DefaultClient,
 	Horizon:     horizon.DefaultPublicNetClient,
@@ -29,14 +29,8 @@ var DefaultPublicNetClient = &Client{
 type Client struct {
 	StellarTOML StellarTOML
 	HTTP        HTTP
-	Horizon     Horizon
+	Horizon     horizon.ClientInterface
 	AllowHTTP   bool
-}
-
-// Horizon represents a horizon client that can be consulted for data when
-// needed as part of the federation protocol
-type Horizon interface {
-	HomeDomainForAccount(aid string) (string, error)
 }
 
 // HTTP represents the http client that a federation client uses to make http
@@ -55,4 +49,3 @@ type StellarTOML interface {
 // confirm interface conformity
 var _ StellarTOML = stellartoml.DefaultClient
 var _ HTTP = http.DefaultClient
-var _ Horizon = horizon.DefaultTestNetClient

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -71,6 +71,7 @@ type Client struct {
 
 type ClientInterface interface {
 	Root() (Root, error)
+	HomeDomainForAccount(aid string) (string, error)
 	LoadAccount(accountID string) (Account, error)
 	LoadAccountOffers(accountID string, params ...interface{}) (offers OffersPage, err error)
 	LoadMemo(p *Payment) error

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -16,6 +16,12 @@ func (m *MockClient) Root() (Root, error) {
 	return a.Get(0).(Root), a.Error(1)
 }
 
+// HomeDomainForAccount is a mocking a method
+func (m *MockClient) HomeDomainForAccount(aid string) (string, error) {
+	a := m.Called(aid)
+	return a.Get(0).(string), a.Error(1)
+}
+
 // LoadAccount is a mocking a method
 func (m *MockClient) LoadAccount(accountID string) (Account, error) {
 	a := m.Called(accountID)

--- a/examples/build_transaction/main.go
+++ b/examples/build_transaction/main.go
@@ -14,7 +14,7 @@ func main() {
 	// seed: SDLJZXOSOMKPWAK4OCWNNVOYUEYEESPGCWK53PT7QMG4J4KGDAUIL5LG
 	to := "GA3A7AD7ZR4PIYW6A52SP6IK7UISESICPMMZVJGNUTVIZ5OUYOPBTK6X"
 
-	tx := b.Transaction(
+	tx, err := b.Transaction(
 		b.SourceAccount{from},
 		b.AutoSequence{horizon.DefaultTestNetClient},
 		b.Payment(
@@ -23,8 +23,19 @@ func main() {
 		),
 	)
 
-	txe := tx.Sign(from)
+	if err != nil {
+		panic(err)
+	}
+
+	txe, err := tx.Sign(from)
+	if err != nil {
+		panic(err)
+	}
+
 	txeB64, err := txe.Base64()
+	if err != nil {
+		panic(err)
+	}
 
 	if err != nil {
 		panic(err)

--- a/main_test.go
+++ b/main_test.go
@@ -40,7 +40,7 @@ func ExampleDecodeTransaction() {
 // intuitive to configure and sign a transaction.
 func ExampleBuildTransaction() {
 	source := "SA26PHIKZM6CXDGR472SSGUQQRYXM6S437ZNHZGRM6QA4FOPLLLFRGDX"
-	tx := b.Transaction(
+	tx, err := b.Transaction(
 		b.SourceAccount{source},
 		b.Sequence{1},
 		b.Payment(
@@ -48,10 +48,16 @@ func ExampleBuildTransaction() {
 			b.NativeAmount{"50.0"},
 		),
 	)
+	if err != nil {
+		panic(err)
+	}
 
-	txe := tx.Sign(source)
+	txe, err := tx.Sign(source)
+	if err != nil {
+		panic(err)
+	}
+
 	txeB64, err := txe.Base64()
-
 	if err != nil {
 		panic(err)
 	}

--- a/protocols/compliance/auth_request_test.go
+++ b/protocols/compliance/auth_request_test.go
@@ -56,7 +56,7 @@ func TestValidateSuccess(t *testing.T) {
 	attachMarshalled, err := attachment.Marshal()
 	require.NoError(t, err)
 
-	txBuilder := build.Transaction(
+	txBuilder, err := build.Transaction(
 		build.SourceAccount{"GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD"},
 		build.Sequence{0},
 		build.TestNetwork,
@@ -66,6 +66,7 @@ func TestValidateSuccess(t *testing.T) {
 			build.CreditAmount{"USD", "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE", "20"},
 		),
 	)
+	require.NoError(t, err)
 
 	txB64, err := xdr.MarshalBase64(txBuilder.TX)
 	require.NoError(t, err)

--- a/services/bifrost/stellar/transactions.go
+++ b/services/bifrost/stellar/transactions.go
@@ -98,8 +98,14 @@ func (ac *AccountConfigurator) buildTransaction(mutators ...build.TransactionMut
 		build.Network{ac.NetworkPassphrase},
 	}
 	muts = append(muts, mutators...)
-	tx := build.Transaction(muts...)
-	txe := tx.Sign(ac.SignerSecretKey)
+	tx, err := build.Transaction(muts...)
+	if err != nil {
+		return "", err
+	}
+	txe, err := tx.Sign(ac.SignerSecretKey)
+	if err != nil {
+		return "", err
+	}
 	return txe.Base64()
 }
 

--- a/services/bifrost/stress/users.go
+++ b/services/bifrost/stress/users.go
@@ -139,14 +139,22 @@ func (u *Users) newUser(kp *keypair.Full) server.GenerateAddressResponse {
 
 		// Create trust lines
 		sequence++
-		tx := build.Transaction(
+		tx, err := build.Transaction(
 			build.SourceAccount{kp.Address()},
 			build.Sequence{sequence},
 			build.Network{u.NetworkPassphrase},
 			build.Trust("BTC", u.IssuerPublicKey),
 			build.Trust("ETH", u.IssuerPublicKey),
 		)
-		txe := tx.Sign(kp.Seed())
+		if err != nil {
+			panic(err)
+		}
+
+		txe, err := tx.Sign(kp.Seed())
+		if err != nil {
+			panic(err)
+		}
+
 		txeB64, err := txe.Base64()
 		if err != nil {
 			panic(err)
@@ -197,7 +205,7 @@ func (u *Users) newUser(kp *keypair.Full) server.GenerateAddressResponse {
 
 		// Merge account so we don't need to fund issuing account over and over again.
 		sequence++
-		tx = build.Transaction(
+		tx, err = build.Transaction(
 			build.SourceAccount{kp.Address()},
 			build.Sequence{sequence},
 			build.Network{u.NetworkPassphrase},
@@ -215,7 +223,15 @@ func (u *Users) newUser(kp *keypair.Full) server.GenerateAddressResponse {
 				build.Destination{u.IssuerPublicKey},
 			),
 		)
-		txe = tx.Sign(kp.Seed())
+		if err != nil {
+			panic(err)
+		}
+
+		txe, err = tx.Sign(kp.Seed())
+		if err != nil {
+			panic(err)
+		}
+
 		txeB64, err = txe.Base64()
 		if err != nil {
 			panic(err)

--- a/services/horizon/internal/friendbot/main.go
+++ b/services/horizon/internal/friendbot/main.go
@@ -54,7 +54,7 @@ func (bot *Bot) makeTx(address string) (string, error) {
 	bot.lock.Lock()
 	defer bot.lock.Unlock()
 
-	tx := Transaction(
+	tx, err := Transaction(
 		SourceAccount{bot.Secret},
 		Sequence{bot.sequence + 1},
 		Network{bot.Network},
@@ -64,13 +64,16 @@ func (bot *Bot) makeTx(address string) (string, error) {
 		),
 	)
 
-	if tx.Err != nil {
-		return "", tx.Err
+	if err != nil {
+		return "", err
 	}
 
 	bot.sequence++
 
-	txe := tx.Sign(bot.Secret)
+	txe, err := tx.Sign(bot.Secret)
+	if err != nil {
+		return "", err
+	}
 
 	return txe.Base64()
 }

--- a/tools/stellar-sign/main.go
+++ b/tools/stellar-sign/main.go
@@ -77,10 +77,13 @@ func main() {
 	// sign the transaction
 	b := &build.TransactionEnvelopeBuilder{E: &txe}
 	b.Init()
-	b.MutateTX(build.PublicNetwork)
-	b.Mutate(build.Sign{seed})
-	if b.Err != nil {
-		log.Fatal(b.Err)
+	err = b.MutateTX(build.PublicNetwork)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = b.Mutate(build.Sign{seed})
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	newEnv, err := xdr.MarshalBase64(b.E)


### PR DESCRIPTION
There are issues (examples in https://github.com/stellar/go/issues/79 https://github.com/stellar/go/issues/243) in which developers are not checking `Err` field on builder structs (`TransactionBuilder`, `TransactionEnvelopeBuilder`). This make errors pop up later in unexpected moments like calling another function with a builder as a parameter. This PR changes `Transaction`, `TransactionBuilder.Sign` and `Mutate` functions to return error instead of setting it in a builder struct `Err` field.

In my opinion the only disadvantage of this change is that developers can no longer call multiple `Mutate` functions and check the error later, like:
```go
b := &build.TransactionEnvelopeBuilder{E: &txe}
b.Init()
b.MutateTX(build.PublicNetwork)
b.Mutate(build.Sign{seed})
if b.Err != nil {
	log.Fatal(b.Err)
}
```
Instead they need to check for errors after each `Mutate` call. However this change will require developers to check errors early (and always) what should improve the code and make it more predictable.

This PR also adds a code to wrap errors returned by operation builders to help understand what is the reason of an error.

Close https://github.com/stellar/go/issues/79.