### PR TITLE
[Client] Introducing `StreamAllTransactions` to stream from the /transactions endpoint

### DIFF
--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -452,6 +452,22 @@ func (c *Client) StreamTransactions(
 	})
 }
 
+// StreamAllTransactions streams all incoming transactions. Use context.WithCancel to stop streaming or
+// context.Background() if you want to stream indefinitely.
+func (c *Client) StreamAllTransactions(ctx context.Context, cursor *Cursor, handler TransactionHandler) (err error) {
+	c.fixURLOnce.Do(c.fixURL)
+	url := fmt.Sprintf("%s/transactions", c.URL)
+	return c.stream(ctx, url, cursor, func(data []byte) error {
+		var transaction Transaction
+		err = json.Unmarshal(data, &transaction)
+		if err != nil {
+			return errors.Wrap(err, "Error unmarshaling data")
+		}
+		handler(transaction)
+		return nil
+	})
+}
+
 // SubmitTransaction submits a transaction to the network. err can be either error object or horizon.Error object.
 func (c *Client) SubmitTransaction(
 	transactionEnvelopeXdr string,

--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -222,12 +222,12 @@ func (c *Client) LoadTrades(
 }
 
 func addAssetToQuery(v map[string][]string, assetPrefix string, asset Asset) {
-	if (asset.Type == "native") {
-		v[assetPrefix+"_asset_type"] = []string{asset.Type};
+	if asset.Type == "native" {
+		v[assetPrefix+"_asset_type"] = []string{asset.Type}
 	} else {
-		v[assetPrefix+"_asset_type"] = []string{asset.Type};
-		v[assetPrefix+"_asset_code"] = []string{asset.Code};
-		v[assetPrefix+"_asset_issuer"] = []string{asset.Issuer};
+		v[assetPrefix+"_asset_type"] = []string{asset.Type}
+		v[assetPrefix+"_asset_code"] = []string{asset.Code}
+		v[assetPrefix+"_asset_issuer"] = []string{asset.Issuer}
 	}
 }
 

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -99,6 +99,7 @@ type ClientInterface interface {
 	SequenceForAccount(accountID string) (xdr.SequenceNumber, error)
 	StreamLedgers(ctx context.Context, cursor *Cursor, handler LedgerHandler) error
 	StreamPayments(ctx context.Context, accountID string, cursor *Cursor, handler PaymentHandler) error
+	StreamAllTransactions(ctx context.Context, cursor *Cursor, handler TransactionHandler) error
 	StreamTransactions(ctx context.Context, accountID string, cursor *Cursor, handler TransactionHandler) error
 	SubmitTransaction(txeBase64 string) (TransactionSuccess, error)
 }

--- a/clients/horizon/main_test.go
+++ b/clients/horizon/main_test.go
@@ -32,6 +32,27 @@ func ExampleClient_StreamLedgers() {
 	}
 }
 
+func ExampleClient_StreamAllTransactions() {
+	client := DefaultPublicNetClient
+	cursor := Cursor("now")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		// Stop streaming after 60 seconds.
+		time.Sleep(20 * time.Second)
+		cancel()
+	}()
+
+	err := client.StreamAllTransactions(ctx, &cursor, func(transaction Transaction) {
+		fmt.Println(transaction.ID)
+	})
+
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
 func ExampleClient_SubmitTransaction() {
 	client := DefaultPublicNetClient
 	transactionEnvelopeXdr := "AAAAABSxFjMo7qcQlJBlrZQypSqYsHA5hHaYxk5hFXwiehh6AAAAZAAIdakAAABZAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAFLEWMyjupxCUkGWtlDKlKpiwcDmEdpjGTmEVfCJ6GHoAAAAAAAAAAACYloAAAAAAAAAAASJ6GHoAAABAp0FnKOQ9lJPDXPTh/a91xoZ8BaznwLj59sdDGK94eGzCOk7oetw7Yw50yOSZg2mqXAST6Agc9Ao/f5T9gB+GCw=="

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -116,6 +116,16 @@ func (m *MockClient) StreamPayments(
 	return a.Error(0)
 }
 
+// StreamAllTransactions is a mocking a method
+func (m *MockClient) StreamAllTransactions(
+	ctx context.Context,
+	cursor *Cursor,
+	handler TransactionHandler,
+) error {
+	a := m.Called(ctx, cursor, handler)
+	return a.Error(0)
+}
+
 // StreamTransactions is a mocking a method
 func (m *MockClient) StreamTransactions(
 	ctx context.Context,


### PR DESCRIPTION
I am not sure if that's the right approach, or if the API naming was intended by the community,  but there is a misalignment with the naming of `StreamTransactions` & `account_transactions` according to the root endpoint [1].

In my case I's looking for a native call that can stream the transactions that are taking place in the network. But the `StreamTransactions` seems to be implementing the `account_transactions ` [2] endpoint. Leaving me with the option to propose an implementation of `StreamAllTransactions` method, with which we can achieve a generic stream of the network [3].

If I'm missing another call/way that the library is already implementing this, then please ignore & close this PR :)

Example of use;

```
var ctx, _ = context.WithCancel(context.Background())
var cursor = horizon.Cursor("now")
var horizonNetwork = horizon.DefaultTestNetClient

horizonNetwork.StreamAllTransactions(ctx, &cursor, func(t horizon.Transaction) {
	fmt.Println("Transaction", t)
})
```

Thanks

[1] https://horizon.stellar.org/
[2] https://horizon.stellar.org/accounts/{account_id}/transactions
[3] https://horizon.stellar.org/transactions