### PR TITLE
fix param type uint64 not binInt

### DIFF
--- a/services/bifrost/stress/ethereum.go
+++ b/services/bifrost/stress/ethereum.go
@@ -70,7 +70,7 @@ func (g *RandomEthereumClient) generateBlocks() {
 				uint64(i),
 				g.randomAddress(),
 				g.randomAmount(),
-				big.NewInt(1),
+				1,
 				big.NewInt(2),
 				[]byte{0, 0, 0, 0},
 			)


### PR DESCRIPTION
Build bifrost failed due to error: cannot use big.NewInt(1) (type *big.Int) as type uint64 in argument to types.NewTransaction. fix by use "1" not  big.NewInt(1) 