### PR TITLE
DomainKeys Identified Federation (DKIF) support to federation service

### DIFF
--- a/handlers/federation/handler.go
+++ b/handlers/federation/handler.go
@@ -76,17 +76,9 @@ func (h *Handler) lookupByID(w http.ResponseWriter, q string) {
 		return
 	}
 
-	resp := proto.IDResponse{
+	h.writeJSON(w, proto.IDResponse{
 		Address: address.New(rec.Name, rec.Domain),
-	}
-
-	if rec.Signature != "" {
-		resp.AccountID = q
-		resp.Signature = rec.Signature
-	}
-
-	h.writeJSON(w, resp, http.StatusOK)
-
+	}, http.StatusOK)
 }
 
 func (h *Handler) lookupByName(w http.ResponseWriter, q string) {

--- a/handlers/federation/handler.go
+++ b/handlers/federation/handler.go
@@ -76,9 +76,17 @@ func (h *Handler) lookupByID(w http.ResponseWriter, q string) {
 		return
 	}
 
-	h.writeJSON(w, proto.IDResponse{
+	resp := proto.IDResponse{
 		Address: address.New(rec.Name, rec.Domain),
-	}, http.StatusOK)
+	}
+
+	if rec.Signature != "" {
+		resp.AccountID = q
+		resp.Signature = rec.Signature
+	}
+
+	h.writeJSON(w, resp, http.StatusOK)
+
 }
 
 func (h *Handler) lookupByName(w http.ResponseWriter, q string) {
@@ -101,11 +109,19 @@ func (h *Handler) lookupByName(w http.ResponseWriter, q string) {
 		return
 	}
 
-	h.writeJSON(w, proto.NameResponse{
+	resp := proto.NameResponse{
 		AccountID: rec.AccountID,
 		Memo:      proto.Memo{rec.Memo},
 		MemoType:  rec.MemoType,
-	}, http.StatusOK)
+	}
+
+	if rec.Signature != "" {
+		resp.Address = address.New(name, domain)
+		resp.Signature = rec.Signature
+	}
+
+	h.writeJSON(w, resp, http.StatusOK)
+
 }
 
 func (h *Handler) lookupByForward(w http.ResponseWriter, query url.Values) {
@@ -126,11 +142,19 @@ func (h *Handler) lookupByForward(w http.ResponseWriter, query url.Values) {
 		return
 	}
 
-	h.writeJSON(w, proto.NameResponse{
+	resp := proto.NameResponse{
 		AccountID: rec.AccountID,
 		Memo:      proto.Memo{rec.Memo},
 		MemoType:  rec.MemoType,
-	}, http.StatusOK)
+	}
+
+	if rec.Signature != "" {
+		resp.Address = address.New(rec.Name, rec.Domain)
+		resp.Signature = rec.Signature
+	}
+
+	h.writeJSON(w, resp, http.StatusOK)
+
 }
 
 func (h *Handler) writeJSON(

--- a/handlers/federation/handler_test.go
+++ b/handlers/federation/handler_test.go
@@ -138,6 +138,88 @@ func TestHandler(t *testing.T) {
 
 }
 
+func TestHandlerWithSignature(t *testing.T) {
+	db := dbtest.Postgres(t).Load(`
+    CREATE TABLE people (id character varying, name character varying, domain character varying, memo character varying, signature character varying, signature_rev character varying);
+    INSERT INTO people (id, name, domain, memo, signature, signature_rev) VALUES
+      ('GD2GJPL3UOK5LX7TWXOACK2ZPWPFSLBNKL3GTGH6BLBNISK4BGWMFBBG', 'scott', 'stellar.org', 'scottsmemo', 'scottssignature', 'scottssignaturerev'),
+      ('GCYMGWPZ6NC2U7SO6SMXOP5ZLXOEC5SYPKITDMVEONLCHFSCCQR2J4S3', 'bartek', 'stellar.org', 'barteksmemo', '', '');
+  `)
+	defer db.Close()
+
+	driver := &ReverseSQLDriver{
+		SQLDriver: SQLDriver{
+			DB:                db.Open().DB,
+			Dialect:           db.Dialect,
+			LookupRecordQuery: "SELECT id, memo, 'text' as memo_type, signature FROM people WHERE name = ? AND domain = ?",
+		},
+		LookupReverseRecordQuery: "SELECT name, domain, signature_rev as signature FROM people WHERE id = ?",
+	}
+
+	defer driver.DB.Close()
+
+	handler := &Handler{driver}
+	server := httptest.NewServer(t, handler)
+	defer server.Close()
+
+	// Good name request and respond with signature
+	server.GET("/federation").
+		WithQuery("type", "name").
+		WithQuery("q", "scott*stellar.org").
+		Expect().
+		Status(http.StatusOK).
+		JSON().Object().
+		ContainsKey("account_id").
+		ValueEqual("account_id", "GD2GJPL3UOK5LX7TWXOACK2ZPWPFSLBNKL3GTGH6BLBNISK4BGWMFBBG").
+		ContainsKey("stellar_address").
+		ValueEqual("stellar_address", "scott*stellar.org").
+		ContainsKey("memo").
+		ValueEqual("memo", "scottsmemo").
+		ContainsKey("signature").
+		ValueEqual("signature", "scottssignature")
+
+	// Good name request and respond without signature
+	server.GET("/federation").
+		WithQuery("type", "name").
+		WithQuery("q", "bartek*stellar.org").
+		Expect().
+		Status(http.StatusOK).
+		JSON().Object().
+		ContainsKey("account_id").
+		ValueEqual("account_id", "GCYMGWPZ6NC2U7SO6SMXOP5ZLXOEC5SYPKITDMVEONLCHFSCCQR2J4S3").
+		NotContainsKey("stellar_address").
+		ContainsKey("memo").
+		ValueEqual("memo", "barteksmemo").
+		NotContainsKey("signature")
+
+	// Good reverse request and response with signature
+	server.GET("/federation").
+		WithQuery("type", "id").
+		WithQuery("q", "GD2GJPL3UOK5LX7TWXOACK2ZPWPFSLBNKL3GTGH6BLBNISK4BGWMFBBG").
+		Expect().
+		Status(http.StatusOK).
+		JSON().Object().
+		ContainsKey("account_id").
+		ValueEqual("account_id", "GD2GJPL3UOK5LX7TWXOACK2ZPWPFSLBNKL3GTGH6BLBNISK4BGWMFBBG").
+		ContainsKey("stellar_address").
+		ValueEqual("stellar_address", "scott*stellar.org").
+		ContainsKey("signature").
+		ValueEqual("signature", "scottssignaturerev")
+
+	// Good reverse request and response without signature
+	server.GET("/federation").
+		WithQuery("type", "id").
+		WithQuery("q", "GCYMGWPZ6NC2U7SO6SMXOP5ZLXOEC5SYPKITDMVEONLCHFSCCQR2J4S3").
+		Expect().
+		Status(http.StatusOK).
+		JSON().Object().
+		NotContainsKey("account_id").
+		ContainsKey("stellar_address").
+		ValueEqual("stellar_address", "bartek*stellar.org").
+		NotContainsKey("signature")
+
+}
+
 func TestNameHandler(t *testing.T) {
 	db := dbtest.Postgres(t).Load(`
     CREATE TABLE people (id character varying, name character varying, domain character varying);

--- a/handlers/federation/main.go
+++ b/handlers/federation/main.go
@@ -53,9 +53,12 @@ type Handler struct {
 // Record represents the result from the database when performing a
 // federation request.
 type Record struct {
+	Name      string `db:"name"`
+	Domain    string `db:"domain"`
 	AccountID string `db:"id"`
 	MemoType  string `db:"memo_type"`
 	Memo      string `db:"memo"`
+	Signature string `db:"signature"`
 }
 
 // ReverseDriver represents a data source against which federation queries can
@@ -82,8 +85,10 @@ type ForwardDriver interface {
 // ReverseRecord represents the result from performing a "Reverse federation"
 // lookup, in which an Account ID is used to lookup an associated address.
 type ReverseRecord struct {
-	Name   string `db:"name"`
-	Domain string `db:"domain"`
+	Name      string `db:"name"`
+	Domain    string `db:"domain"`
+	AccountID string `db:"id"`
+	Signature string `db:"signature"`
 }
 
 // ReverseSQLDriver provides a `ReverseDriver` implementation based upon a SQL

--- a/handlers/federation/main.go
+++ b/handlers/federation/main.go
@@ -85,10 +85,8 @@ type ForwardDriver interface {
 // ReverseRecord represents the result from performing a "Reverse federation"
 // lookup, in which an Account ID is used to lookup an associated address.
 type ReverseRecord struct {
-	Name      string `db:"name"`
-	Domain    string `db:"domain"`
-	AccountID string `db:"id"`
-	Signature string `db:"signature"`
+	Name   string `db:"name"`
+	Domain string `db:"domain"`
 }
 
 // ReverseSQLDriver provides a `ReverseDriver` implementation based upon a SQL

--- a/protocols/federation/main.go
+++ b/protocols/federation/main.go
@@ -18,9 +18,7 @@ type NameResponse struct {
 // IDResponse represents the result of a federation request
 // for `id` request.
 type IDResponse struct {
-	Address   string `json:"stellar_address"`
-	AccountID string `json:"account_id,omitempty"`
-	Signature string `json:"signature,omitempty"`
+	Address string `json:"stellar_address"`
 }
 
 // Memo value can be either integer or string in JSON. This struct

--- a/protocols/federation/main.go
+++ b/protocols/federation/main.go
@@ -8,15 +8,19 @@ import (
 // NameResponse represents the result of a federation request
 // for `name` and `forward` requests.
 type NameResponse struct {
+	Address   string `json:"stellar_address,omitempty"`
 	AccountID string `json:"account_id"`
 	MemoType  string `json:"memo_type,omitempty"`
 	Memo      Memo   `json:"memo,omitempty"`
+	Signature string `json:"signature,omitempty"`
 }
 
 // IDResponse represents the result of a federation request
 // for `id` request.
 type IDResponse struct {
-	Address string `json:"stellar_address"`
+	Address   string `json:"stellar_address"`
+	AccountID string `json:"account_id,omitempty"`
+	Signature string `json:"signature,omitempty"`
 }
 
 // Memo value can be either integer or string in JSON. This struct

--- a/protocols/federation/main_test.go
+++ b/protocols/federation/main_test.go
@@ -28,6 +28,17 @@ func TestMarshal(t *testing.T) {
 	value, err = json.Marshal(resp)
 	assert.NoError(t, err)
 	assert.Equal(t, `{"account_id":"GCQ4MQ4ZOS6P6RON4HH6FNWNABCLZUCNBSDE3QXFZOX5VYJDDKRQDQOJ","memo_type":"id","memo":"123"}`, string(value))
+
+	respWithSig := NameResponse{
+		Address:   "john*stellar.org",
+		AccountID: "GCQ4MQ4ZOS6P6RON4HH6FNWNABCLZUCNBSDE3QXFZOX5VYJDDKRQDQOJ",
+		MemoType:  "id",
+		Memo:      Memo{"123"},
+		Signature: "h=stellar_address:account_id:memo_type:memo;b=dGhpc2lzYXNpZ25hdHVyZQ==",
+	}
+	value, err = json.Marshal(respWithSig)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"stellar_address":"john*stellar.org","account_id":"GCQ4MQ4ZOS6P6RON4HH6FNWNABCLZUCNBSDE3QXFZOX5VYJDDKRQDQOJ","memo_type":"id","memo":"123","signature":"h=stellar_address:account_id:memo_type:memo;b=dGhpc2lzYXNpZ25hdHVyZQ=="}`, string(value))
 }
 
 func TestUnmarshal(t *testing.T) {

--- a/protocols/federation/main_test.go
+++ b/protocols/federation/main_test.go
@@ -34,11 +34,11 @@ func TestMarshal(t *testing.T) {
 		AccountID: "GCQ4MQ4ZOS6P6RON4HH6FNWNABCLZUCNBSDE3QXFZOX5VYJDDKRQDQOJ",
 		MemoType:  "id",
 		Memo:      Memo{"123"},
-		Signature: "h=stellar_address:account_id:memo_type:memo;b=dGhpc2lzYXNpZ25hdHVyZQ==",
+		Signature: "uUq9eNXRWb6gV0mStLf8WJA5RlUI2grVCD+D+LcrASzURWfmlAxqE2TPp2zGJSyiVqC8UCNkALHr3+ZZRvQoBg==",
 	}
 	value, err = json.Marshal(respWithSig)
 	assert.NoError(t, err)
-	assert.Equal(t, `{"stellar_address":"john*stellar.org","account_id":"GCQ4MQ4ZOS6P6RON4HH6FNWNABCLZUCNBSDE3QXFZOX5VYJDDKRQDQOJ","memo_type":"id","memo":"123","signature":"h=stellar_address:account_id:memo_type:memo;b=dGhpc2lzYXNpZ25hdHVyZQ=="}`, string(value))
+	assert.Equal(t, `{"stellar_address":"john*stellar.org","account_id":"GCQ4MQ4ZOS6P6RON4HH6FNWNABCLZUCNBSDE3QXFZOX5VYJDDKRQDQOJ","memo_type":"id","memo":"123","signature":"uUq9eNXRWb6gV0mStLf8WJA5RlUI2grVCD+D+LcrASzURWfmlAxqE2TPp2zGJSyiVqC8UCNkALHr3+ZZRvQoBg=="}`, string(value))
 }
 
 func TestUnmarshal(t *testing.T) {


### PR DESCRIPTION
Hi Guys,

This PR contains simple changes to extend the capabilities of the federation service to support [DomainKeys Identified Federation](https://galactictalk.org/d/789-domainkeys-identified-federation-dkif).
The changes are backwards compatible and include tests as well.

In short the changes are: In case the database contain signatures for federation records the federation server will return them back in its response. If the signatures were not there or were empty behave the same way like before.

Please take a look and let us know your opinion.

Thanks,
Balazs