### PR TITLE
Fix time rounding

### DIFF
--- a/support/time/main.go
+++ b/support/time/main.go
@@ -35,6 +35,9 @@ func (t Millis) IsNil() bool {
 
 //RoundUp returns a new Millis instance with a rounded up to d millis
 func (t Millis) RoundUp(d int64) Millis {
+	if d == 0 {
+		return t
+	}
 	if int64(t)%d != 0 {
 		return t.RoundDown(d).increment(d)
 	}

--- a/support/time/main_test.go
+++ b/support/time/main_test.go
@@ -27,3 +27,7 @@ func TestMillisParsing(t *testing.T) {
 func TestMillisToTime(t *testing.T) {
 	assert.Equal(t, int64(1510831636149000000), Millis(1510831636149).ToTime().UnixNano())
 }
+
+func TestMillisFromSeconds(t *testing.T) {
+	assert.Equal(t, MillisFromInt64(10000), MillisFromSeconds(10))
+}

--- a/support/time/main_test.go
+++ b/support/time/main_test.go
@@ -9,6 +9,7 @@ import (
 func TestMillisRoundUp(t *testing.T) {
 	assert.Equal(t, MillisFromInt64(20), MillisFromInt64(13).RoundUp(10))
 	assert.Equal(t, MillisFromInt64(10), MillisFromInt64(10).RoundUp(10))
+	assert.Equal(t, MillisFromInt64(15), MillisFromInt64(15).RoundUp(0))
 }
 
 func TestMillisRoundDown(t *testing.T) {


### PR DESCRIPTION
When trying to round up with 0 the original time should be returned.

Fixes https://github.com/stellar/go/issues/284