### PR TITLE
Add network passphrase to the transaction parameters

### DIFF
--- a/examples/build_transaction/main.go
+++ b/examples/build_transaction/main.go
@@ -5,6 +5,7 @@ import (
 
 	b "github.com/stellar/go/build"
 	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/network"
 )
 
 func main() {
@@ -14,7 +15,10 @@ func main() {
 	// seed: SDLJZXOSOMKPWAK4OCWNNVOYUEYEESPGCWK53PT7QMG4J4KGDAUIL5LG
 	to := "GA3A7AD7ZR4PIYW6A52SP6IK7UISESICPMMZVJGNUTVIZ5OUYOPBTK6X"
 
+	passphrase := network.TestNetworkPassphrase
+
 	tx, err := b.Transaction(
+		b.Network{passphrase},
 		b.SourceAccount{from},
 		b.AutoSequence{horizon.DefaultTestNetClient},
 		b.Payment(


### PR DESCRIPTION
Hey there,

The transaction build example is missing network phrase, so the `Sign` method returns an error. I just added the test network phrase to the parameters. 

Cheers 