### PR TITLE
tools/stellar-archivist: support custom S3 endpoints

### DIFF
--- a/tools/stellar-archivist/README.md
+++ b/tools/stellar-archivist/README.md
@@ -43,6 +43,7 @@ Flags:
       --low int           first ledger to act on
       --profile           collect and serve profile locally
       --s3region string   S3 region to connect to (default "us-east-1")
+      --s3endpoint string S3 endpoint (default to AWS endpoint for selected region)
       --thorough          decode and re-encode all buckets
       --verify            verify file contents
 
@@ -67,6 +68,20 @@ archive; the advantage is that more operations are supported, and the tool can s
 archives much more quickly. This is necessary to handle bulk operations on archives with many
 thousands of files efficiently.
 
+### S3 backend
+
+`stellar-archivist` supports reading from and writing to any S3-compatible storage.
+
+The following options are specific to S3 backend:
+
+ - `--s3region string` — AWS S3 region to connect to (default "us-east-1")
+ - `--s3endpoint string` — S3-compatible endpoint (default to AWS S3 endpoint for selected region)
+
+For example, to check the current status of an archive in DigitalOcean Spaces (ams3 region):
+
+```
+$ stellar-archivist status --s3endpoint ams3.digitaloceanspaces.com s3://bucketname/prefix
+```
 
 ## Examples of use
 

--- a/tools/stellar-archivist/internal/archive_test.go
+++ b/tools/stellar-archivist/internal/archive_test.go
@@ -25,11 +25,11 @@ func GetTestS3Archive() *Archive {
 		panic(e)
 	}
 	return MustConnect(fmt.Sprintf("s3://history-stg.stellar.org/dev/archivist/test-%s", r),
-		&ConnectOptions{S3Region: "eu-west-1"})
+		ConnectOptions{S3Region: "eu-west-1"})
 }
 
 func GetTestMockArchive() *Archive {
-	return MustConnect("mock://test", nil)
+	return MustConnect("mock://test", ConnectOptions{})
 }
 
 var tmpdirs []string
@@ -44,7 +44,7 @@ func GetTestFileArchive() *Archive {
 	} else {
 		tmpdirs = append(tmpdirs, d)
 	}
-	return MustConnect("file://"+d, nil)
+	return MustConnect("file://"+d, ConnectOptions{})
 }
 
 func cleanup() {

--- a/tools/stellar-archivist/internal/fs_archive.go
+++ b/tools/stellar-archivist/internal/fs_archive.go
@@ -72,7 +72,7 @@ func (b *FsArchiveBackend) CanListFiles() bool {
 	return true
 }
 
-func MakeFsBackend(pth string, opts *ConnectOptions) ArchiveBackend {
+func MakeFsBackend(pth string, opts ConnectOptions) ArchiveBackend {
 	return &FsArchiveBackend{
 		prefix: pth,
 	}

--- a/tools/stellar-archivist/internal/http_archive.go
+++ b/tools/stellar-archivist/internal/http_archive.go
@@ -75,7 +75,7 @@ func (b *HttpArchiveBackend) CanListFiles() bool {
 	return false
 }
 
-func MakeHttpBackend(base *url.URL, opts *ConnectOptions) ArchiveBackend {
+func MakeHttpBackend(base *url.URL, opts ConnectOptions) ArchiveBackend {
 	return &HttpArchiveBackend{
 		base: *base,
 	}

--- a/tools/stellar-archivist/internal/mock_archive.go
+++ b/tools/stellar-archivist/internal/mock_archive.go
@@ -72,7 +72,7 @@ func (b *MockArchiveBackend) CanListFiles() bool {
 	return true
 }
 
-func MakeMockBackend(opts *ConnectOptions) ArchiveBackend {
+func MakeMockBackend(opts ConnectOptions) ArchiveBackend {
 	b := new(MockArchiveBackend)
 	b.files = make(map[string][]byte)
 	return b

--- a/tools/stellar-archivist/internal/s3_archive.go
+++ b/tools/stellar-archivist/internal/s3_archive.go
@@ -101,15 +101,21 @@ func (b *S3ArchiveBackend) CanListFiles() bool {
 	return true
 }
 
-func MakeS3Backend(bucket string, prefix string, opts *ConnectOptions) ArchiveBackend {
-	cfg := aws.Config{}
-	if opts != nil && opts.S3Region != "" {
-		cfg.Region = aws.String(opts.S3Region)
+func MakeS3Backend(bucket string, prefix string, opts ConnectOptions) (ArchiveBackend, error) {
+	cfg := aws.Config{
+		Region:   aws.String(opts.S3Region),
+		Endpoint: aws.String(opts.S3Endpoint),
 	}
-	sess := session.New(&cfg)
-	return &S3ArchiveBackend{
+
+	sess, err := session.NewSession(&cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	backend := S3ArchiveBackend{
 		svc:    s3.New(sess),
 		bucket: bucket,
 		prefix: prefix,
 	}
+	return &backend, nil
 }

--- a/tools/stellar-archivist/main.go
+++ b/tools/stellar-archivist/main.go
@@ -12,11 +12,11 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	archivist "github.com/stellar/go/tools/stellar-archivist/internal"
+	"github.com/stellar/go/tools/stellar-archivist/internal"
 )
 
 func status(a string, opts *Options) {
-	arch := archivist.MustConnect(a, &opts.ConnectOpts)
+	arch := archivist.MustConnect(a, opts.ConnectOpts)
 	state, e := arch.GetRootHAS()
 	if e != nil {
 		log.Fatal(e)
@@ -66,7 +66,7 @@ func (opts *Options) MaybeProfile() {
 }
 
 func scan(a string, opts *Options) {
-	arch := archivist.MustConnect(a, &opts.ConnectOpts)
+	arch := archivist.MustConnect(a, opts.ConnectOpts)
 	opts.SetRange(arch)
 	e1 := arch.Scan(&opts.CommandOpts)
 	e2 := arch.ReportMissing(&opts.CommandOpts)
@@ -83,8 +83,8 @@ func scan(a string, opts *Options) {
 }
 
 func mirror(src string, dst string, opts *Options) {
-	srcArch := archivist.MustConnect(src, &opts.ConnectOpts)
-	dstArch := archivist.MustConnect(dst, &opts.ConnectOpts)
+	srcArch := archivist.MustConnect(src, opts.ConnectOpts)
+	dstArch := archivist.MustConnect(dst, opts.ConnectOpts)
 	opts.SetRange(srcArch)
 	log.Printf("mirroring %v -> %v\n", src, dst)
 	e := archivist.Mirror(srcArch, dstArch, &opts.CommandOpts)
@@ -94,8 +94,8 @@ func mirror(src string, dst string, opts *Options) {
 }
 
 func repair(src string, dst string, opts *Options) {
-	srcArch := archivist.MustConnect(src, &opts.ConnectOpts)
-	dstArch := archivist.MustConnect(dst, &opts.ConnectOpts)
+	srcArch := archivist.MustConnect(src, opts.ConnectOpts)
+	dstArch := archivist.MustConnect(dst, opts.ConnectOpts)
 	opts.SetRange(srcArch)
 	log.Printf("repairing %v -> %v\n", src, dst)
 	e := archivist.Repair(srcArch, dstArch, &opts.CommandOpts)
@@ -151,6 +151,13 @@ func main() {
 		"s3region",
 		"us-east-1",
 		"S3 region to connect to",
+	)
+
+	rootCmd.PersistentFlags().StringVar(
+		&opts.ConnectOpts.S3Endpoint,
+		"s3endpoint",
+		"",
+		"S3 endpoint to use",
 	)
 
 	rootCmd.PersistentFlags().BoolVarP(


### PR DESCRIPTION
This PR adds custom S3 endpoint support to `stellar-archivist` tool, so that it can be used with any S3-compatible storage (like [DigitalOcean Spaces](https://www.digitalocean.com/products/spaces/)).