### PR TITLE
doc: Add examples for `build.Payment` and `build.CreateAccount`

### DIFF
--- a/build/create_account.go
+++ b/build/create_account.go
@@ -7,7 +7,7 @@ import (
 )
 
 // CreateAccount groups the creation of a new CreateAccountBuilder with a call
-// to Mutate.
+// to Mutate. Requires the Destination and NativeAmount mutators to be set.
 func CreateAccount(muts ...interface{}) (result CreateAccountBuilder) {
 	result.Mutate(muts...)
 	return

--- a/build/main_test.go
+++ b/build/main_test.go
@@ -51,6 +51,79 @@ func ExampleTransactionBuilder() {
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAALSRpLtCLv2eboZlEiHDSGR6Hb+zZL92fbSdNpObeE0EAAAAAAAAAAB3NZQAAAAAAAAAAARtDMfAAAABA2oIeQxoJl53RMRWFeLB865zcky39f2gf2PmUubCuJYccEePRSrTC8QQrMOgGwD8a6oe8dgltvezdDsmmXBPyBw==
 }
 
+// ExampleCreateAccount creates a transaction to fund a new stallar account with a balance. It then
+// encodes the transaction into a base64 string capable of being submitted to stellar-core. It uses
+// the transaction builder system.
+func ExampleCreateAccount() {
+	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
+	tx, err := Transaction(
+		SourceAccount{seed},
+		Sequence{1},
+		TestNetwork,
+		CreateAccount(
+			Destination{"GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA"},
+			NativeAmount{"50"},
+		),
+	)
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txe, err := tx.Sign(seed)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txeB64, err := txe.Base64()
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Printf("tx base64: %s", txeB64)
+	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAALSRpLtCLv2eboZlEiHDSGR6Hb+zZL92fbSdNpObeE0EAAAAAHc1lAAAAAAAAAAABG0Mx8AAAAEDiHQEurLITX87zmkEi8Rrcf5wGp1JrLnSDoTJiN+yNjJZVF3WcBJgoGyIJ3NJo+tNmTqALVrJziiiZGdoukxcN
+}
+
+// ExamplePayment creates and signs a native-asset Payment, encodes it into a base64 string capable of
+// being submitted to stellar-core. It uses the transaction builder system.
+func ExamplePayment() {
+	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
+	tx, err := Transaction(
+		SourceAccount{seed},
+		Sequence{1},
+		TestNetwork,
+		Payment(
+			Destination{"GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA"},
+			NativeAmount{"50"},
+		),
+	)
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txe, err := tx.Sign(seed)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	txeB64, err := txe.Base64()
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Printf("tx base64: %s", txeB64)
+	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAALSRpLtCLv2eboZlEiHDSGR6Hb+zZL92fbSdNpObeE0EAAAAAAAAAAB3NZQAAAAAAAAAAARtDMfAAAABA2oIeQxoJl53RMRWFeLB865zcky39f2gf2PmUubCuJYccEePRSrTC8QQrMOgGwD8a6oe8dgltvezdDsmmXBPyBw==
+}
+
 // ExamplePathPayment creates and signs a simple transaction with PathPayment operation, and then
 // encodes it into a base64 string capable of being submitted to stellar-core.
 func ExamplePathPayment() {

--- a/build/payment.go
+++ b/build/payment.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Payment groups the creation of a new PaymentBuilder with a call to Mutate.
+// Requires the Destination and NativeAmount mutators to be set.
 func Payment(muts ...interface{}) (result PaymentBuilder) {
 	result.Mutate(muts...)
 	return


### PR DESCRIPTION
Addresses #336.

This is just a doc and test change. Includes working examples for funding a new account, and making a payment (the latter was just a copy of the `Transaction` example.)

(First PR: I signed the contributor license agreement.)