### PR TITLE
Ingestion performance fixes

### DIFF
--- a/services/horizon/internal/db2/history/account.go
+++ b/services/horizon/internal/db2/history/account.go
@@ -47,6 +47,26 @@ func (q *AccountsQ) Select(dest interface{}) error {
 	return q.Err
 }
 
+// AccountsByAddresses loads a rows from `history_accounts`, by addresses
+func (q *Q) AccountsByAddresses(dest interface{}, addresses []string) error {
+	sql := selectAccount.Where(map[string]interface{}{
+		"ha.address": addresses, // ha.address IN (...)
+	})
+	return q.Select(dest, sql)
+}
+
+// CreateAccounts creates rows for addresses in history_accounts table and
+// put
+func (q *Q) CreateAccounts(dest interface{}, addresses []string) error {
+	sql := sq.Insert("history_accounts").Columns("address")
+	for _, address := range addresses {
+		sql = sql.Values(address)
+	}
+	sql = sql.Suffix("RETURNING *")
+
+	return q.Select(dest, sql)
+}
+
 // Return id for account. If account doesn't exist, it will be created and the new id returned.
 func (q *Q) GetCreateAccountID(
 	aid xdr.AccountId,

--- a/services/horizon/internal/ingest/asset_stat.go
+++ b/services/horizon/internal/ingest/asset_stat.go
@@ -84,7 +84,7 @@ func (assetsModified AssetsModified) UpdateAssetStats(is *Session) {
 
 		if assetStat != nil {
 			hasValue = true
-			is.Ingestion.assetStats = is.Ingestion.assetStats.Values(
+			is.Ingestion.builders[AssetStatsTableName].Values(
 				assetStat.ID,
 				assetStat.Amount,
 				assetStat.NumAccounts,
@@ -104,7 +104,7 @@ func (assetsModified AssetsModified) UpdateAssetStats(is *Session) {
 		// can perform a direct upsert if postgres > 9.4
 		// is.Ingestion.assetStats = is.Ingestion.assetStats.
 		// 	Suffix("ON CONFLICT (id) DO UPDATE SET (amount, num_accounts, flags, toml) = (excluded.amount, excluded.num_accounts, excluded.flags, excluded.toml)")
-		_, is.Err = is.Ingestion.DB.Exec(is.Ingestion.assetStats)
+		is.Err = is.Ingestion.builders[AssetStatsTableName].Exec(is.Ingestion.DB)
 	}
 }
 

--- a/services/horizon/internal/ingest/batch_insert_builder.go
+++ b/services/horizon/internal/ingest/batch_insert_builder.go
@@ -1,0 +1,75 @@
+package ingest
+
+import (
+	"fmt"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/support/errors"
+)
+
+func (b *BatchInsertBuilder) init() {
+	b.rows = make([][]interface{}, 0)
+}
+
+func (b *BatchInsertBuilder) createInsertBuilder() {
+	b.insertBuilder = sq.Insert(string(b.TableName)).Columns(b.Columns...)
+}
+
+func (b *BatchInsertBuilder) GetAddresses() (adds []Address) {
+	for _, row := range b.rows {
+		for _, param := range row {
+			if address, ok := param.(Address); ok {
+				adds = append(adds, address)
+			}
+		}
+	}
+	return
+}
+
+func (b *BatchInsertBuilder) ReplaceAddressesWithIDs(mapping map[Address]int64) {
+	for i := range b.rows {
+		for j := range b.rows[i] {
+			if address, ok := b.rows[i][j].(Address); ok {
+				b.rows[i][j] = mapping[address]
+			}
+		}
+	}
+}
+
+func (b *BatchInsertBuilder) Values(params ...interface{}) {
+	b.initOnce.Do(b.init)
+	b.rows = append(b.rows, params)
+}
+
+func (b *BatchInsertBuilder) Exec(DB *db.Session) error {
+	b.initOnce.Do(b.init)
+	b.createInsertBuilder()
+	paramsCount := 0
+
+	for _, row := range b.rows {
+		b.insertBuilder = b.insertBuilder.Values(row...)
+		paramsCount += len(row)
+
+		// PostgreSQL supports up to 65535 parameters.
+		if paramsCount > 65000 {
+			_, err := DB.Exec(b.insertBuilder)
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("Error adding values while inserting to %s", b.TableName))
+			}
+			paramsCount = 0
+			b.createInsertBuilder()
+		}
+	}
+
+	if paramsCount > 0 {
+		_, err := DB.Exec(b.insertBuilder)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Error adding values while inserting to %s", b.TableName))
+		}
+	}
+
+	// Empty rows slice
+	b.rows = make([][]interface{}, 0)
+	return nil
+}

--- a/services/horizon/internal/ingest/effect_ingestion.go
+++ b/services/horizon/internal/ingest/effect_ingestion.go
@@ -8,21 +8,13 @@ import (
 // Add writes an effect to the database while automatically tracking the index
 // to use.
 func (ei *EffectIngestion) Add(aid xdr.AccountId, typ history.EffectType, details interface{}) bool {
-	q := history.Q{Session: ei.parent.DB}
-
 	if ei.err != nil {
 		return false
 	}
 
 	ei.added++
-	var haid int64
 
-	haid, ei.err = q.GetCreateAccountID(aid)
-	if ei.err != nil {
-		return false
-	}
-
-	ei.err = ei.Dest.Effect(haid, ei.OperationID, ei.added, typ, details)
+	ei.err = ei.Dest.Effect(Address(aid.Address()), ei.OperationID, ei.added, typ, details)
 	if ei.err != nil {
 		return false
 	}

--- a/services/horizon/internal/ingest/ingestion_test.go
+++ b/services/horizon/internal/ingest/ingestion_test.go
@@ -40,13 +40,10 @@ func TestEmptySignature(t *testing.T) {
 
 	transactionFee := &core.TransactionFee{}
 
-	builder := ingestion.transactionInsertBuilder(1, transaction, transactionFee)
-	sql, args, err := builder.ToSql()
-	assert.Equal(t, "INSERT INTO history_transactions (id,transaction_hash,ledger_sequence,application_order,account,account_sequence,fee_paid,operation_count,tx_envelope,tx_result,tx_meta,tx_fee_meta,signatures,time_bounds,memo_type,memo,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?::character varying[],?,?,?,?,?)", sql)
-	assert.Equal(t, `{"8qkkeKaKfsbgInyIkzXJhqJE5/Ufxri2LdxmyKkgkT6I3sPmvrs5cPWQSzEQyhV750IW2ds97xTHqTpOfuZCAg==",""}`, args[12])
-	assert.NoError(t, err)
+	ingestion.Transaction(1, transaction, transactionFee)
+	assert.Equal(t, 1, len(ingestion.builders[TransactionsTableName].rows))
 
-	err = ingestion.Transaction(1, transaction, transactionFee)
+	err := ingestion.Flush()
 	assert.NoError(t, err)
 
 	err = ingestion.Close()

--- a/services/horizon/internal/ingest/session.go
+++ b/services/horizon/internal/ingest/session.go
@@ -320,16 +320,12 @@ func (is *Session) ingestLedger() {
 	}
 
 	start := time.Now()
-	is.Err = is.Ingestion.Ledger(
+	is.Ingestion.Ledger(
 		is.Cursor.LedgerID(),
 		is.Cursor.Ledger(),
 		is.Cursor.SuccessfulTransactionCount(),
 		is.Cursor.SuccessfulLedgerOperationCount(),
 	)
-
-	if is.Err != nil {
-		return
-	}
 
 	for is.Cursor.NextTx() {
 		is.ingestTransaction()
@@ -386,10 +382,7 @@ func (is *Session) ingestOperationParticipants() {
 		return
 	}
 
-	is.Err = is.Ingestion.OperationParticipants(is.Cursor.OperationID(), p)
-	if is.Err != nil {
-		return
-	}
+	is.Ingestion.OperationParticipants(is.Cursor.OperationID(), p)
 }
 
 func (is *Session) ingestSignerEffects(effects *EffectIngestion, op xdr.SetOptionsOp) {
@@ -551,14 +544,11 @@ func (is *Session) ingestTransaction() {
 	if !is.Cursor.Transaction().IsSuccessful() {
 		return
 	}
-	is.Err = is.Ingestion.Transaction(
+	is.Ingestion.Transaction(
 		is.Cursor.TransactionID(),
 		is.Cursor.Transaction(),
 		is.Cursor.TransactionFee(),
 	)
-	if is.Err != nil {
-		return
-	}
 
 	for is.Cursor.NextOp() {
 		is.ingestOperation()
@@ -583,11 +573,7 @@ func (is *Session) ingestTransactionParticipants() {
 		return
 	}
 
-	is.Err = is.Ingestion.TransactionParticipants(is.Cursor.TransactionID(), p)
-	if is.Err != nil {
-		return
-	}
-
+	is.Ingestion.TransactionParticipants(is.Cursor.TransactionID(), p)
 }
 
 // assetDetails sets the details for `a` on `result` using keys with `prefix`


### PR DESCRIPTION
For a discussion please check: https://github.com/stellar/go/pull/316 Unfortunately I closed it by accident by force-pushing a `master` branch to it. Cannot recover from this on GitHub.

---
Ingestion code is making too many DB requests:
* It inserts each effect, operation, etc. in a separate query.
* It `GetCreateAccountID` is executed multiple times when checking row ID for a given `AccountID`.

Because of so many requests, ingesting a single transaction with 100 payment operations takes 200-500 ms. It can grow to 20 seconds per ledger causing delays in ingestion.

This PR introduces the following changes:
* It batches `INSERT`s to the database.
* It gets all the accounts participating in the ledger and then batch gets / creates them.

After implementing this changes ledger with 50 txs / 5000 operations is ingested in 3-5 seconds, ledger with 500 operations is ingested in 0.5 second.