### PR TITLE
More fixes for reingestion

### DIFF
--- a/services/horizon/internal/ingest/asset_stat.go
+++ b/services/horizon/internal/ingest/asset_stat.go
@@ -179,7 +179,7 @@ func computeAssetStat(is *Session, asset *xdr.Asset) *history.AssetStat {
 		return nil
 	}
 
-	coreQ := &core.Q{Session: is.Cursor.DB}
+	coreQ := &core.Q{Session: is.Cursor.CoreDB}
 
 	numAccounts, amount, err := statTrustlinesInfo(coreQ, assetType, assetCode, assetIssuer)
 	if err != nil {

--- a/services/horizon/internal/ingest/cursor.go
+++ b/services/horizon/internal/ingest/cursor.go
@@ -90,7 +90,7 @@ func (c *Cursor) NextLedger() bool {
 
 	c.data = &LedgerBundle{Sequence: c.lg}
 	start := time.Now()
-	c.Err = c.data.Load(c.DB)
+	c.Err = c.data.Load(c.CoreDB)
 	if c.Err != nil {
 		return false
 	}

--- a/services/horizon/internal/ingest/cursor_test.go
+++ b/services/horizon/internal/ingest/cursor_test.go
@@ -14,7 +14,7 @@ func TestCursor(t *testing.T) {
 	c := Cursor{
 		FirstLedger: 7,
 		LastLedger:  10,
-		DB:          tt.CoreSession(),
+		CoreDB:      tt.CoreSession(),
 	}
 
 	// Ledger 7
@@ -61,7 +61,7 @@ func TestCursor(t *testing.T) {
 	c = Cursor{
 		FirstLedger: 10,
 		LastLedger:  7,
-		DB:          tt.CoreSession(),
+		CoreDB:      tt.CoreSession(),
 	}
 
 	tt.Require.True(c.NextLedger())

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -22,7 +22,7 @@ const (
 	// Scripts, that have yet to be ported to this codebase can then be leveraged
 	// to re-ingest old data with the new algorithm, providing a seamless
 	// transition when the ingested data's structure changes.
-	CurrentVersion = 11
+	CurrentVersion = 12
 )
 
 // Address is a type of a param provided to BatchInsertBuilder that gets exchanged

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -50,8 +50,9 @@ type Cursor struct {
 	// LastLedger is the end of the range of ledgers (inclusive) that will
 	// attempt to be ingested in this session.
 	LastLedger int32
-	// DB is the stellar-core db that data is ingested from.
-	DB *db.Session
+
+	// CoreDB is the stellar-core db that data is ingested from.
+	CoreDB *db.Session
 
 	Metrics        *IngesterMetrics
 	AssetsModified AssetsModified
@@ -203,7 +204,7 @@ func NewCursor(first, last int32, i *System) *Cursor {
 	return &Cursor{
 		FirstLedger:    first,
 		LastLedger:     last,
-		DB:             i.CoreDB,
+		CoreDB:         i.CoreDB,
 		Metrics:        &i.Metrics,
 		AssetsModified: AssetsModified(make(map[string]xdr.Asset)),
 	}

--- a/services/horizon/internal/ingest/system.go
+++ b/services/horizon/internal/ingest/system.go
@@ -78,7 +78,7 @@ func (i *System) ReingestAll() (int, error) {
 
 	var elder int32
 	var latest int32
-	q := history.Q{Session: i.CoreDB}
+	q := history.Q{Session: i.HorizonDB}
 
 	err := q.ElderLedger(&elder)
 	if err != nil {


### PR DESCRIPTION
Most importantly, this revs the ingester version so we can get a clean up to date reingestion happening on testnet.  Additionally, I've renamed `DB` to `CoreDB` in the ingestion cursor:  this change is preparing for a reingestion mode that loads a `LedgerBundle` from the history database instead of core, allowing us to reingest the history database even if stellar-core has purged its old records.

Finally, this commit removes the trimming of abandoned ledgers from reingestion... IMO it's dangerous to delete rows when it isn't expected.

