### PR TITLE
Add support to stream effects and operations

### DIFF
--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -444,6 +444,26 @@ func (c *Client) stream(
 	}
 }
 
+// StreamEffects streams incoming effects. Use context.WithCancel to stop streaming or
+// context.Background() if you want to stream indefinitely.
+func (c *Client) StreamEffects(
+	ctx context.Context,
+	cursor *Cursor,
+	handler EffectHandler,
+) (err error) {
+	c.fixURLOnce.Do(c.fixURL)
+	url := fmt.Sprintf("%s/effects", c.URL)
+	return c.stream(ctx, url, cursor, func(data []byte) error {
+		var effect Effect
+		err = json.Unmarshal(data, &effect)
+		if err != nil {
+			return errors.Wrap(err, "Error unmarshaling data")
+		}
+		handler(effect)
+		return nil
+	})
+}
+
 // StreamLedgers streams incoming ledgers. Use context.WithCancel to stop streaming or
 // context.Background() if you want to stream indefinitely.
 func (c *Client) StreamLedgers(

--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -454,7 +455,7 @@ func (c *Client) StreamEffects(
 	c.fixURLOnce.Do(c.fixURL)
 	url := fmt.Sprintf("%s/effects", c.URL)
 	return c.stream(ctx, url, cursor, func(data []byte) error {
-		var effect Effect
+		var effect horizon.Effect
 		err = json.Unmarshal(data, &effect)
 		if err != nil {
 			return errors.Wrap(err, "Error unmarshaling data")

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -105,6 +105,7 @@ type ClientInterface interface {
 	LoadOrderBook(selling Asset, buying Asset, params ...interface{}) (orderBook OrderBookSummary, err error)
 	LoadTransaction(transactionID string) (transaction Transaction, err error)
 	SequenceForAccount(accountID string) (xdr.SequenceNumber, error)
+	StreamEffects(ctx context.Context, cursor *Cursor, handler EffectHandler) error
 	StreamLedgers(ctx context.Context, cursor *Cursor, handler LedgerHandler) error
 	StreamPayments(ctx context.Context, accountID string, cursor *Cursor, handler PaymentHandler) error
 	StreamTransactions(ctx context.Context, accountID string, cursor *Cursor, handler TransactionHandler) error
@@ -123,6 +124,9 @@ type HTTP interface {
 	Get(url string) (resp *http.Response, err error)
 	PostForm(url string, data url.Values) (resp *http.Response, err error)
 }
+
+// EffectHandler is a function that is called when a new effect is received
+type EffectHandler func(Effect)
 
 // LedgerHandler is a function that is called when a new ledger is received
 type LedgerHandler func(Ledger)

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/stellar/go/build"
+	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -126,7 +127,7 @@ type HTTP interface {
 }
 
 // EffectHandler is a function that is called when a new effect is received
-type EffectHandler func(Effect)
+type EffectHandler func(horizon.Effect)
 
 // LedgerHandler is a function that is called when a new ledger is received
 type LedgerHandler func(Ledger)

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -113,6 +113,12 @@ func (m *MockClient) SequenceForAccount(accountID string) (xdr.SequenceNumber, e
 	return a.Get(0).(xdr.SequenceNumber), a.Error(1)
 }
 
+// StreamEffects is a mocking a method
+func (m *MockClient) StreamEffects(ctx context.Context, cursor *Cursor, handler EffectHandler) error {
+	a := m.Called(ctx, cursor, handler)
+	return a.Error(0)
+}
+
 // StreamLedgers is a mocking a method
 func (m *MockClient) StreamLedgers(
 	ctx context.Context,

--- a/clients/horizon/responses.go
+++ b/clients/horizon/responses.go
@@ -54,16 +54,26 @@ type EffectsPage struct {
 	} `json:"_embedded"`
 }
 
-// EffectResponse contains effect data returned by Horizon.
-// Currently used by LoadAccountMergeAmount only.
 type Effect struct {
-	Type   string `json:"type"`
-	Amount string `json:"amount"`
+	Links struct {
+		Operation Link `json:"operation"`
+		Succeeds  Link `json:"succeeds"`
+		Precedes  Link `json:"precedes"`
+	} `json:"_links"`
+	ID              string `json:"id"`
+	PT              string `json:"paging_token"`
+	Account         string `json:"account"`
+	Amount          string `json:"amount"`
+	Type            string `json:"type"`
+	TypeI           int32  `json:"type_i"`
+	StartingBalance string `json:"starting_balance"`
+	Balance
+	Signer
 }
 
 // TradeAggregationsPage returns a list of aggregated trade records, aggregated by resolution
 type TradeAggregationsPage struct {
-	Links hal.Links `json:"_links"`
+	Links    hal.Links `json:"_links"`
 	Embedded struct {
 		Records []TradeAggregation `json:"records"`
 	} `json:"_embedded"`
@@ -74,7 +84,7 @@ type TradeAggregation = hProtocol.TradeAggregation
 
 // TradesPage returns a list of trade records
 type TradesPage struct {
-	Links hal.Links `json:"_links"`
+	Links    hal.Links `json:"_links"`
 	Embedded struct {
 		Records []Trade `json:"records"`
 	} `json:"_embedded"`
@@ -97,7 +107,7 @@ type Signer = hProtocol.Signer
 
 // OffersPage returns a list of offers
 type OffersPage struct {
-	Links hal.Links `json:"_links"`
+	Links    hal.Links `json:"_links"`
 	Embedded struct {
 		Records []Offer `json:"records"`
 	} `json:"_embedded"`

--- a/clients/horizon/responses.go
+++ b/clients/horizon/responses.go
@@ -50,25 +50,8 @@ type Offer = hProtocol.Offer
 // Currently used by LoadAccountMergeAmount only.
 type EffectsPage struct {
 	Embedded struct {
-		Records []Effect
+		Records []hProtocol.Effect
 	} `json:"_embedded"`
-}
-
-type Effect struct {
-	Links struct {
-		Operation Link `json:"operation"`
-		Succeeds  Link `json:"succeeds"`
-		Precedes  Link `json:"precedes"`
-	} `json:"_links"`
-	ID              string `json:"id"`
-	PT              string `json:"paging_token"`
-	Account         string `json:"account"`
-	Amount          string `json:"amount"`
-	Type            string `json:"type"`
-	TypeI           int32  `json:"type_i"`
-	StartingBalance string `json:"starting_balance"`
-	Balance
-	Signer
 }
 
 // TradeAggregationsPage returns a list of aggregated trade records, aggregated by resolution

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -48,7 +48,7 @@ type Account struct {
 }
 
 // GetNativeBalance returns the native balance of the account
-func (a Account) GetNativeBalance() (string, error){
+func (a Account) GetNativeBalance() (string, error) {
 	for _, balance := range a.Balances {
 		if balance.Asset.Type == "native" {
 			return balance.Balance, nil
@@ -126,6 +126,23 @@ type Balance struct {
 	Balance string `json:"balance"`
 	Limit   string `json:"limit,omitempty"`
 	base.Asset
+}
+
+type Effect struct {
+	Links struct {
+		Operation hal.Link `json:"operation"`
+		Succeeds  hal.Link `json:"succeeds"`
+		Precedes  hal.Link `json:"precedes"`
+	} `json:"_links"`
+	ID              string `json:"id"`
+	PT              string `json:"paging_token"`
+	Account         string `json:"account"`
+	Amount          string `json:"amount"`
+	Type            string `json:"type"`
+	TypeI           int32  `json:"type_i"`
+	StartingBalance string `json:"starting_balance"`
+	Balance
+	Signer
 }
 
 // HistoryAccount is a simple resource, used for the account collection actions.


### PR DESCRIPTION
This is an attemt to bring support to stream `/effects` to the Golang SDK.

Unlike in the JavaScript SDK this is not yet supported by the Go SDK (if I understood correctly).

Feedback welcome, especially concerning the `Effect` struct - I'm not sure whether I catched all properties, and wasn't sure where to get a complete list of them. I assembled them looking at a test file in the JS-JDK.

Code snipped to stream `/effects`:

```golang
package main

import (
	"fmt"
	"github.com/stellar/go/clients/horizon"
	"golang.org/x/net/context"
	"log"
)

func main() {
	client := horizon.DefaultTestNetClient
	cursor := horizon.Cursor("now")
	ctx := context.Background() // Stream indefinitly

	err := client.StreamEffects(ctx, &cursor, func(l horizon.Effect) {
			fmt.Printf("%+v", l)
	})

	if err != nil {
		log.Fatal(err)
	}
}
```