### PR TITLE
Fix trimming of newlines on windows

### DIFF
--- a/tools/stellar-hd-wallet/commands/io.go
+++ b/tools/stellar-hd-wallet/commands/io.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -15,6 +16,9 @@ var out io.Writer = os.Stdout
 
 func readString() string {
 	line, _ := reader.ReadString('\n')
+	if os := runtime.GOOS; os == "windows" {
+		return strings.TrimRight(line, "\r\n")
+	}
 	return strings.TrimRight(line, "\n")
 }
 

--- a/tools/stellar-hd-wallet/commands/io.go
+++ b/tools/stellar-hd-wallet/commands/io.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 )
@@ -16,10 +15,7 @@ var out io.Writer = os.Stdout
 
 func readString() string {
 	line, _ := reader.ReadString('\n')
-	if os := runtime.GOOS; os == "windows" {
-		return strings.TrimRight(line, "\r\n")
-	}
-	return strings.TrimRight(line, "\n")
+	return strings.TrimRight(line, "\r\n")
 }
 
 func readUint() uint32 {


### PR DESCRIPTION
This is a fix for issue #334.

This fixes the incorrect trimming of newlines on windows machines and now allows functionality of the "accounts" command. Attached is a screenshot of it properly handling individual inputs and giving appropriate error messages for invalid entries. I have now been able to go through the full process and generate the keys.

![wallet-fixed](https://user-images.githubusercontent.com/2281043/36952036-881690da-1fd8-11e8-880c-e61134b340cb.png)
