### PR TITLE
doc: setup instruction about Glide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This repo is the home for all of the public go code produced by SDF.  In additio
 
 This repository depends upon a [number of external dependencies](./glide.yaml), and we use [Glide](https://glide.sh/) to manage them.  Glide is used to populate the [vendor directory](http://glide.readthedocs.io/en/latest/vendor/), ensuring that builds are reproducible even as upstream dependencies are changed. Please see the [Glide](http://glide.sh/) website for installation instructions.
 
+You can use Glide yourself in your project and add stellar go as a vendor'd dependency, or you can just drop this repos as `$GOPATH/src/github.com/stellar/go` to import it the canonical way (you still need to run `glide install`).
+
 When creating this project, we had to decide whether or not we committed our external dependencies to the repo.  We decided that we would not, by default, do so.  This lets us avoid the diff churn associated with updating dependencies while allowing an acceptable path to get reproducible builds.  To do so, simply install glide and run `glide install` in your checkout of the code.  We realize this is a judgement call; Please feel free to open an issue if you would like to make a case that we change this policy.
 
 


### PR DESCRIPTION
For gophers who are not used to Glide, it's unclear what we should do
with the repos once fetched and all dependencies has been installed.

Make it clear that it still can be used in a classic go workspace and
users do not have to use Glide in their own projects.