### PR TITLE
Add Order field to Horizon resources

### DIFF
--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -10,9 +10,10 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
-	"golang.org/x/net/context"
 )
 
 // HomeDomainForAccount returns the home domain for the provided strkey-encoded
@@ -116,10 +117,7 @@ func (c *Client) LoadMemo(p *Payment) (err error) {
 }
 
 // SequenceForAccount implements build.SequenceProvider
-func (c *Client) SequenceForAccount(
-	accountID string,
-) (xdr.SequenceNumber, error) {
-
+func (c *Client) SequenceForAccount(accountID string) (xdr.SequenceNumber, error) {
 	a, err := c.LoadAccount(accountID)
 	if err != nil {
 		return 0, errors.Wrap(err, "load account failed")

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -11,9 +11,10 @@ import (
 	"net/url"
 	"sync"
 
+	"golang.org/x/net/context"
+
 	"github.com/stellar/go/build"
 	"github.com/stellar/go/support/errors"
-	"golang.org/x/net/context"
 )
 
 // DefaultTestNetClient is a default client to connect to test network

--- a/clients/horizon/responses.go
+++ b/clients/horizon/responses.go
@@ -133,6 +133,7 @@ type Ledger struct {
 		Payments     Link `json:"payments"`
 		Effects      Link `json:"effects"`
 	} `json:"_links"`
+
 	ID               string    `json:"id"`
 	PT               string    `json:"paging_token"`
 	Hash             string    `json:"hash"`
@@ -181,6 +182,7 @@ type TransactionSuccess struct {
 	Links struct {
 		Transaction Link `json:"transaction"`
 	} `json:"_links"`
+
 	Hash   string `json:"hash"`
 	Ledger int32  `json:"ledger"`
 	Env    string `json:"envelope_xdr"`
@@ -208,21 +210,22 @@ type OffersPage struct {
 		Next Link `json:"next"`
 		Prev Link `json:"prev"`
 	} `json:"_links"`
+
 	Embedded struct {
 		Records []Offer `json:"records"`
 	} `json:"_embedded"`
 }
 
 type Payment struct {
-	ID          string `json:"id"`
-	Type        string `json:"type"`
-	PagingToken string `json:"paging_token"`
-
 	Links struct {
 		Transaction struct {
 			Href string `json:"href"`
 		} `json:"transaction"`
 	} `json:"_links"`
+
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	PagingToken string `json:"paging_token"`
 
 	// create_account fields
 	Account         string `json:"account"`
@@ -273,4 +276,5 @@ type Transaction struct {
 	Signatures      []string  `json:"signatures"`
 	ValidAfter      string    `json:"valid_after,omitempty"`
 	ValidBefore     string    `json:"valid_before,omitempty"`
+	Order           int32     `json:"order"`
 }

--- a/services/horizon/internal/resource/effects/base.go
+++ b/services/horizon/internal/resource/effects/base.go
@@ -1,36 +1,41 @@
 package effects
 
 import (
+	"strconv"
+
+	"golang.org/x/net/context"
+
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/httpx"
 	"github.com/stellar/go/services/horizon/internal/render/hal"
-	"golang.org/x/net/context"
 )
 
 // PagingToken implements `hal.Pageable`
-func (this Base) PagingToken() string {
-	return this.PT
+func (b Base) PagingToken() string {
+	return b.PT
 }
 
-// Populate loads this resource from `row`
-func (this *Base) Populate(ctx context.Context, row history.Effect) {
-	this.ID = row.ID()
-	this.PT = row.PagingToken()
-	this.Account = row.Account
-	this.populateType(row)
+// Populate loads b resource from `row`
+func (b *Base) Populate(ctx context.Context, row history.Effect) {
+	b.ID = row.ID()
+	b.PT = row.PagingToken()
+	b.Account = row.Account
+	b.populateType(row)
+	b.OperationID = strconv.FormatInt(row.HistoryOperationID, 10)
+	b.Order = row.Order
 
-	lb := hal.LinkBuilder{httpx.BaseURL(ctx)}
-	this.Links.Operation = lb.Linkf("/operations/%d", row.HistoryOperationID)
-	this.Links.Succeeds = lb.Linkf("/effects?order=desc&cursor=%s", this.PT)
-	this.Links.Precedes = lb.Linkf("/effects?order=asc&cursor=%s", this.PT)
+	lb := hal.LinkBuilder{Base: httpx.BaseURL(ctx)}
+	b.Links.Operation = lb.Linkf("/operations/%d", row.HistoryOperationID)
+	b.Links.Succeeds = lb.Linkf("/effects?order=desc&cursor=%s", b.PT)
+	b.Links.Precedes = lb.Linkf("/effects?order=asc&cursor=%s", b.PT)
 }
 
-func (this *Base) populateType(row history.Effect) {
+func (b *Base) populateType(row history.Effect) {
 	var ok bool
-	this.TypeI = int32(row.Type)
-	this.Type, ok = TypeNames[row.Type]
+	b.TypeI = int32(row.Type)
+	b.Type, ok = TypeNames[row.Type]
 
 	if !ok {
-		this.Type = "unknown"
+		b.Type = "unknown"
 	}
 }

--- a/services/horizon/internal/resource/effects/main.go
+++ b/services/horizon/internal/resource/effects/main.go
@@ -1,10 +1,11 @@
 package effects
 
 import (
+	"golang.org/x/net/context"
+
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/render/hal"
 	"github.com/stellar/go/services/horizon/internal/resource/base"
-	"golang.org/x/net/context"
 )
 
 var TypeNames = map[history.EffectType]string{
@@ -39,7 +40,6 @@ func New(
 	ctx context.Context,
 	row history.Effect,
 ) (result hal.Pageable, err error) {
-
 	basev := Base{}
 	basev.Populate(ctx, row)
 
@@ -129,11 +129,13 @@ type Base struct {
 		Precedes  hal.Link `json:"precedes"`
 	} `json:"_links"`
 
-	ID      string `json:"id"`
-	PT      string `json:"paging_token"`
-	Account string `json:"account"`
-	Type    string `json:"type"`
-	TypeI   int32  `json:"type_i"`
+	ID          string `json:"id"`
+	PT          string `json:"paging_token"`
+	Account     string `json:"account"`
+	Type        string `json:"type"`
+	TypeI       int32  `json:"type_i"`
+	OperationID string `json:"operation_id"`
+	Order       int32  `json:"order"`
 }
 
 type AccountCreated struct {

--- a/services/horizon/internal/resource/main.go
+++ b/services/horizon/internal/resource/main.go
@@ -5,15 +5,16 @@ package resource
 import (
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/render/hal"
 	"github.com/stellar/go/services/horizon/internal/resource/base"
 	"github.com/stellar/go/services/horizon/internal/resource/effects"
 	"github.com/stellar/go/services/horizon/internal/resource/operations"
-	"github.com/stellar/go/services/horizon/internal/render/hal"
 	"github.com/stellar/go/strkey"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
-	"golang.org/x/net/context"
 )
 
 // KeyTypeNames maps from strkey version bytes into json string values to use in
@@ -255,7 +256,7 @@ type TradeEffect struct {
 	LedgerCloseTime   time.Time `json:"created_at"`
 }
 
-// Transaction represents trade data aggregation over a period of time
+// TradeAggregation represents trade data aggregation over a period of time
 type TradeAggregation struct {
 	Timestamp     int64     `json:"timestamp"`
 	TradeCount    int64     `json:"trade_count"`
@@ -301,6 +302,7 @@ type Transaction struct {
 	Signatures      []string  `json:"signatures"`
 	ValidAfter      string    `json:"valid_after,omitempty"`
 	ValidBefore     string    `json:"valid_before,omitempty"`
+	Order           int32     `json:"order"`
 }
 
 // TransactionResultCodes represent a summary of result codes returned from

--- a/services/horizon/internal/resource/operations/main.go
+++ b/services/horizon/internal/resource/operations/main.go
@@ -3,11 +3,12 @@ package operations
 import (
 	"time"
 
-	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/services/horizon/internal/resource/base"
-	"github.com/stellar/go/services/horizon/internal/render/hal"
-	"github.com/stellar/go/xdr"
 	"golang.org/x/net/context"
+
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/render/hal"
+	"github.com/stellar/go/services/horizon/internal/resource/base"
+	"github.com/stellar/go/xdr"
 )
 
 // TypeNames maps from operation type to the string used to represent that type
@@ -33,7 +34,6 @@ func New(
 	row history.Operation,
 	ledger history.Ledger,
 ) (result hal.Pageable, err error) {
-
 	base := Base{}
 	base.Populate(ctx, row, ledger)
 
@@ -108,6 +108,7 @@ type Base struct {
 	TypeI           int32     `json:"type_i"`
 	LedgerCloseTime time.Time `json:"created_at"`
 	TransactionHash string    `json:"transaction_hash"`
+	Order           int32     `json:"order"`
 }
 
 // CreateAccount is the json resource representing a single operation whose type

--- a/services/horizon/internal/resource/transaction.go
+++ b/services/horizon/internal/resource/transaction.go
@@ -6,53 +6,55 @@ import (
 	"time"
 
 	"github.com/guregu/null"
+	"golang.org/x/net/context"
+
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/httpx"
 	"github.com/stellar/go/services/horizon/internal/render/hal"
-	"golang.org/x/net/context"
 )
 
 // Populate fills out the details
-func (res *Transaction) Populate(
+func (t *Transaction) Populate(
 	ctx context.Context,
 	row history.Transaction,
 ) (err error) {
-
-	res.ID = row.TransactionHash
-	res.PT = row.PagingToken()
-	res.Hash = row.TransactionHash
-	res.Ledger = row.LedgerSequence
-	res.LedgerCloseTime = row.LedgerCloseTime
-	res.Account = row.Account
-	res.AccountSequence = row.AccountSequence
-	res.FeePaid = row.FeePaid
-	res.OperationCount = row.OperationCount
-	res.EnvelopeXdr = row.TxEnvelope
-	res.ResultXdr = row.TxResult
-	res.ResultMetaXdr = row.TxMeta
-	res.FeeMetaXdr = row.TxFeeMeta
-	res.MemoType = row.MemoType
-	res.Memo = row.Memo.String
-	res.Signatures = strings.Split(row.SignatureString, ",")
-	res.ValidBefore = res.timeString(row.ValidBefore)
-	res.ValidAfter = res.timeString(row.ValidAfter)
+	t.ID = row.TransactionHash
+	t.PT = row.PagingToken()
+	t.Hash = row.TransactionHash
+	t.Ledger = row.LedgerSequence
+	t.LedgerCloseTime = row.LedgerCloseTime
+	t.Account = row.Account
+	t.AccountSequence = row.AccountSequence
+	t.FeePaid = row.FeePaid
+	t.OperationCount = row.OperationCount
+	t.EnvelopeXdr = row.TxEnvelope
+	t.ResultXdr = row.TxResult
+	t.ResultMetaXdr = row.TxMeta
+	t.FeeMetaXdr = row.TxFeeMeta
+	t.MemoType = row.MemoType
+	t.Memo = row.Memo.String
+	t.Signatures = strings.Split(row.SignatureString, ",")
+	t.ValidBefore = t.timeString(row.ValidBefore)
+	t.ValidAfter = t.timeString(row.ValidAfter)
+	t.Order = row.ApplicationOrder
 
 	lb := hal.LinkBuilder{Base: httpx.BaseURL(ctx)}
-	res.Links.Account = lb.Link("/accounts", res.Account)
-	res.Links.Ledger = lb.Link("/ledgers", fmt.Sprintf("%d", res.Ledger))
-	res.Links.Operations = lb.PagedLink("/transactions", res.ID, "operations")
-	res.Links.Effects = lb.PagedLink("/transactions", res.ID, "effects")
-	res.Links.Self = lb.Link("/transactions", res.ID)
-	res.Links.Succeeds = lb.Linkf("/transactions?order=desc&cursor=%s", res.PT)
-	res.Links.Precedes = lb.Linkf("/transactions?order=asc&cursor=%s", res.PT)
+	t.Links.Account = lb.Link("/accounts", t.Account)
+	t.Links.Ledger = lb.Link("/ledgers", fmt.Sprintf("%d", t.Ledger))
+	t.Links.Operations = lb.PagedLink("/transactions", t.ID, "operations")
+	t.Links.Effects = lb.PagedLink("/transactions", t.ID, "effects")
+	t.Links.Self = lb.Link("/transactions", t.ID)
+	t.Links.Succeeds = lb.Linkf("/transactions?order=desc&cursor=%s", t.PT)
+	t.Links.Precedes = lb.Linkf("/transactions?order=asc&cursor=%s", t.PT)
 	return
 }
 
 // PagingToken implementation for hal.Pageable
-func (res Transaction) PagingToken() string {
-	return res.PT
+func (t Transaction) PagingToken() string {
+	return t.PT
 }
-func (res *Transaction) timeString(in null.Int) string {
+
+func (t *Transaction) timeString(in null.Int) string {
 	if !in.Valid {
 		return ""
 	}


### PR DESCRIPTION
Hey folks, I noticed that the Horizon api doesn't actually return the order of the transactions, operations, or effects. This piece of information can be important if you have use cases that require validation for example.

After having a look around the code I realised that the IDs of the operations and effects use the total order ID scheme so it is possible to parse out the order client side, however I find this quite opaque and undocumented (as far as I can tell). In any case the transaction ID is not returned so this method would not have worked for transactions.

To help remedy this, I made this PR to include the `Order` field to all three resources which is the 1-based index of the resource's position within their respective parent resource. The values are taken directly from the order fields from the history table rows.

I also added `OperationID` to the effects resource so that the foreign key to its parent is obvious (as opposed to being parsed from its ID).