### PR TITLE
Removed duplicate text for 'Endpoints -> All Transactions' API reference

### DIFF
--- a/services/horizon/internal/docs/reference/endpoints/transactions-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/transactions-all.md
@@ -6,7 +6,6 @@ clientData:
 
 This endpoint represents all validated [transactions](../resources/transaction.md).
 This endpoint can also be used in [streaming](../responses.md#streaming) mode. This makes it possible to use it to listen for new transactions as they get made in the Stellar network.
-If called in streaming mode Horizon will start at the earliest known transaction unless a cursor is set. In that case it will start from the cursor.
 If called in streaming mode Horizon will start at the earliest known transaction unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream transaction created since your request time.
 
 ## Request


### PR DESCRIPTION
Kept text with highlighting.