### PR TITLE
Timebounds On Transactions

### DIFF
--- a/build/main.go
+++ b/build/main.go
@@ -217,6 +217,11 @@ type Thresholds struct {
 	High   *uint32
 }
 
+type Timebounds struct {
+    Mintime uint64
+    Maxtime uint64
+}
+
 // Trustor is a mutator capable of setting the trustor on
 // allow_trust operation.
 type Trustor struct {

--- a/build/main.go
+++ b/build/main.go
@@ -218,8 +218,8 @@ type Thresholds struct {
 }
 
 type Timebounds struct {
-    Mintime uint64
-    Maxtime uint64
+    MinTime uint64
+    MaxTime uint64
 }
 
 // Trustor is a mutator capable of setting the trustor on

--- a/build/transaction.go
+++ b/build/transaction.go
@@ -257,8 +257,7 @@ func (m MemoText) MutateTransaction(o *TransactionBuilder) (err error) {
 }
 
 func (m Timebounds) MutateTransaction(o *TransactionBuilder) error {
-    o.TX.TimeBounds.MinTime = m.Mintime
-    o.TX.TimeBounds.MaxTime = m.Maxtime
+    o.TX.TimeBounds = &xdr.TimeBounds{MinTime: xdr.Uint64(m.Mintime), MaxTime: xdr.Uint64(m.Maxtime)}
     return nil
 }
 

--- a/build/transaction.go
+++ b/build/transaction.go
@@ -256,14 +256,10 @@ func (m MemoText) MutateTransaction(o *TransactionBuilder) (err error) {
 	return
 }
 
-func (m MinTimeBound) MutateTransaction(o *TransactionBuilder) (err error) {
-    o.TX.MinTime, err = xdr.NewTimeBound(xdr.MinTime, m.Value)
-    return
-}
-
-func (m MaxTimeBound) MutateTransaction(o *TransactionBuilder) (err error) {
-    o.TX.MaxTime, err = xdr.NewTimeBound(xdr.MaxTime, m.Value)
-    return
+func (m Timebounds) MutateTransaction(o *TransactionBuilder) error {
+    o.TX.TimeBounds.MinTime = m.Mintime
+    o.TX.TimeBounds.MaxTime = m.Maxtime
+    return nil
 }
 
 // MutateTransaction for Network sets the Network ID to use when signing this transaction

--- a/build/transaction.go
+++ b/build/transaction.go
@@ -257,7 +257,7 @@ func (m MemoText) MutateTransaction(o *TransactionBuilder) (err error) {
 }
 
 func (m Timebounds) MutateTransaction(o *TransactionBuilder) error {
-    o.TX.TimeBounds = &xdr.TimeBounds{MinTime: xdr.Uint64(m.Mintime), MaxTime: xdr.Uint64(m.Maxtime)}
+    o.TX.TimeBounds = &xdr.TimeBounds{MinTime: xdr.Uint64(m.MinTime), MaxTime: xdr.Uint64(m.MaxTime)}
     return nil
 }
 

--- a/build/transaction.go
+++ b/build/transaction.go
@@ -256,6 +256,16 @@ func (m MemoText) MutateTransaction(o *TransactionBuilder) (err error) {
 	return
 }
 
+func (m MinTimeBound) MutateTransaction(o *TransactionBuilder) (err error) {
+    o.TX.MinTime, err = xdr.NewTimeBound(xdr.MinTime, m.Value)
+    return
+}
+
+func (m MaxTimeBound) MutateTransaction(o *TransactionBuilder) (err error) {
+    o.TX.MaxTime, err = xdr.NewTimeBound(xdr.MaxTime, m.Value)
+    return
+}
+
 // MutateTransaction for Network sets the Network ID to use when signing this transaction
 func (m Network) MutateTransaction(o *TransactionBuilder) error {
 	o.NetworkPassphrase = m.Passphrase

--- a/build/transaction_test.go
+++ b/build/transaction_test.go
@@ -115,8 +115,8 @@ var _ = Describe("Transaction Mutators:", func() {
         BeforeEach(func() { mut = Timebounds{1521056118, 1521056298} })
         It("succeeds", func() { Expect(err).NotTo(HaveOccurred()) })
         It("sets an minimum and maximum timebound on the transaction", func() {
-            Expect(subject.TX.TimeBounds.MinTime).To(BeEquivalentTo(xdr.Uint64(1521056118)))
-            Expect(subject.TX.TimeBounds.MaxTime).To(BeEquivalentTo(xdr.Uint64(1521056298)))
+            Expect(subject.TX.TimeBounds.MinTime).To(Equal(xdr.Uint64(1521056118)))
+            Expect(subject.TX.TimeBounds.MaxTime).To(Equal(xdr.Uint64(1521056298)))
         })
     })
 

--- a/build/transaction_test.go
+++ b/build/transaction_test.go
@@ -113,9 +113,10 @@ var _ = Describe("Transaction Mutators:", func() {
 
     Describe("Timebounds", func() {
         BeforeEach(func() { mut = Timebounds{1521056118, 1521056298} })
+        It("succeeds", func() { Expect(err).NotTo(HaveOccurred()) })
         It("sets an minimum and maximum timebound on the transaction", func() {
-            Expect(subject.TX.TimeBounds.MinTime).To(BeAssignableToTypeOf(xdr.TimeBounds.MinTime))
-            Expect(subject.TX.TimeBounds.MaxTime).To(BeAssignableToTypeOf(xdr.TimeBounds.MaxTime))
+            Expect(subject.TX.TimeBounds.MinTime).To(BeEquivalentTo(xdr.Uint64(1521056118)))
+            Expect(subject.TX.TimeBounds.MaxTime).To(BeEquivalentTo(xdr.Uint64(1521056298)))
         })
     })
 

--- a/build/transaction_test.go
+++ b/build/transaction_test.go
@@ -111,6 +111,14 @@ var _ = Describe("Transaction Mutators:", func() {
 		})
 	})
 
+    Describe("Timebounds", func() {
+        BeforeEach(func() { mut = Timebounds{1521056118, 1521056298} })
+        It("sets an minimum and maximum timebound on the transaction", func() {
+            Expect(subject.TX.TimeBounds.MinTime).To(BeAssignableToTypeOf(xdr.TimeBounds.MinTime))
+            Expect(subject.TX.TimeBounds.MaxTime).To(BeAssignableToTypeOf(xdr.TimeBounds.MaxTime))
+        })
+    })
+
 	Describe("AllowTrustBuilder", func() {
 		BeforeEach(func() { mut = AllowTrust() })
 		It("adds itself to the tx's operations", func() {


### PR DESCRIPTION
This PR solves the following issue: https://github.com/stellar/go/issues/350

Basically, passing a lower and upper timebounds on a Transaction in `build` package.