### PR TITLE
Remove in-request call to stellar-core in the root resource; Fixes a stall (of up to 5 seconds).

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,6 +6,13 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## v0.12.3 - 2017-03-20
+
+### Bug fixes
+
+- Fix a service stutter caused by excessive `info` commands being issued from the root endpoint.
+
+
 ## v0.12.2 - 2017-03-14
 
 This release is a bug fix release for v0.12.1 and v0.12.2.  *Please see the upgrade notes below if you did not already migrate your db for v0.12.0*

--- a/services/horizon/internal/actions_root.go
+++ b/services/horizon/internal/actions_root.go
@@ -14,8 +14,6 @@ type RootAction struct {
 
 // JSON renders the json response for RootAction
 func (action *RootAction) JSON() {
-	action.App.UpdateStellarCoreInfo()
-
 	var res resource.Root
 	res.Populate(
 		action.Ctx,

--- a/services/horizon/internal/actions_root_test.go
+++ b/services/horizon/internal/actions_root_test.go
@@ -23,6 +23,7 @@ func TestRootAction(t *testing.T) {
 
 	ht.App.horizonVersion = "test-horizon"
 	ht.App.config.StellarCoreURL = server.URL
+	ht.App.UpdateStellarCoreInfo()
 
 	w := ht.Get("/")
 	if ht.Assert.Equal(200, w.Code) {


### PR DESCRIPTION
Also bumps the changelog to v0.12.3