### PR TITLE
Add missing effects for the path_payment operation

### DIFF
--- a/services/horizon/internal/ingest/session_test.go
+++ b/services/horizon/internal/ingest/session_test.go
@@ -44,3 +44,70 @@ func Test_ingestOperationEffects(t *testing.T) {
 		tt.Assert.Equal(history.EffectAccountInflationDestinationUpdated, effects[0].Type)
 	}
 }
+
+func Test_ingestPathPaymentExportsCorrectEffects(t *testing.T) {
+	tt := test.Start(t).ScenarioWithoutHorizon("pathed_payment")
+	defer tt.Finish()
+
+	s := ingest(tt)
+	tt.Require.NoError(s.Err)
+
+	q := &history.Q{Session: tt.HorizonSession()}
+	var effects []history.Effect
+	err := q.Effects().ForOperation(25769807873).Select(&effects)
+	tt.Require.NoError(err)
+
+	if tt.Assert.Len(effects, 3) {
+		tradeEffect := false
+		accountCreditEffect := false
+		accountDebitEffect := false
+
+		for _, effect := range effects {
+			if effect.Type == history.EffectTrade &&
+				effect.Account == "GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON" {
+				var details map[string]interface{}
+				effect.UnmarshalDetails(&details)
+				tt.Assert.Equal("GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
+					details["seller"])
+				tt.Assert.Equal("10.0000000", details["sold_amount"])
+				tt.Assert.Equal("10.0000000", details["bought_amount"])
+				tt.Assert.Equal("credit_alphanum4", details["sold_asset_type"])
+				tt.Assert.Equal("GCQPYGH4K57XBDENKKX55KDTWOTK5WDWRQOH2LHEDX3EKVIQRLMESGBG",
+					details["sold_asset_issuer"])
+				tt.Assert.Equal("EUR", details["sold_asset_code"])
+				tt.Assert.Equal("credit_alphanum4", details["bought_asset_type"])
+				tt.Assert.Equal("GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4",
+					details["bought_asset_issuer"])
+				tt.Assert.Equal("USD", details["bought_asset_code"])
+				tradeEffect = true
+			}
+			if effect.Type == history.EffectAccountCredited {
+				tt.Assert.Equal("GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+					effect.Account)
+				var details map[string]interface{}
+				effect.UnmarshalDetails(&details)
+				tt.Assert.Equal("10.0000000", details["amount"])
+				tt.Assert.Equal("credit_alphanum4", details["asset_type"])
+				tt.Assert.Equal("GCQPYGH4K57XBDENKKX55KDTWOTK5WDWRQOH2LHEDX3EKVIQRLMESGBG",
+					details["asset_issuer"])
+				tt.Assert.Equal("EUR", details["asset_code"])
+				accountCreditEffect = true
+			}
+			if effect.Type == history.EffectAccountDebited {
+				tt.Assert.Equal("GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
+					effect.Account)
+				var details map[string]interface{}
+				effect.UnmarshalDetails(&details)
+				tt.Assert.Equal("10.0000000", details["amount"])
+				tt.Assert.Equal("credit_alphanum4", details["asset_type"])
+				tt.Assert.Equal("GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4",
+					details["asset_issuer"])
+				tt.Assert.Equal("USD", details["asset_code"])
+				accountDebitEffect = true
+			}
+		}
+		tt.Assert.True(tradeEffect)
+		tt.Assert.True(accountCreditEffect)
+		tt.Assert.True(accountDebitEffect)
+	}
+}


### PR DESCRIPTION
The `path_payment` now generates the following effects:
 - An `AccountDebited` effect for the source account. This account debited is for the source asset and the amount is based on the amount of the asset that was traded.
 - An `AccountCredited` effect for the destination account. This effect applies the amount of the payment for the payment's destination asset.
 - A `Trade` effect for each of the offers that were used in the `path_payment`. The trade effect is only generated for the seller side of the offer as the buying side never gets the asset traded.

Resolves #268 