### PR TITLE
Add HTTP 400 message in case of negative cursors

### DIFF
--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -36,7 +36,7 @@ func (base *Base) Prepare(c web.C, w http.ResponseWriter, r *http.Request) {
 	base.R = r
 }
 
-// Execute trigger content negottion and the actual execution of one of the
+// Execute trigger content negotiation and the actual execution of one of the
 // action's handlers.
 func (base *Base) Execute(action interface{}) {
 	contentType := render.Negotiate(base.Ctx, base.R)

--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -47,9 +47,9 @@ func (base *Base) GetCursor(name string) string {
 	}
 
 	// In case cursor is negative value, return InvalidField error
-	cursorInt, _ := strconv.Atoi(cursor)
-	if cursorInt < 0 {
-		msg := fmt.Sprintf("the cursor could not be negative %d", cursorInt)
+	cursorInt, err := strconv.Atoi(cursor)
+	if err == nil && cursorInt < 0 {
+		msg := fmt.Sprintf("the cursor %d is a negative number: ", cursorInt)
 		base.SetInvalidField("cursor", errors.New(msg))
 	}
 

--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/support/time"
 	"github.com/stellar/go/xdr"
+	"fmt"
 )
 
 const (
@@ -45,9 +46,14 @@ func (base *Base) GetCursor(name string) string {
 		cursor = lei
 	}
 
-	// if cursor is a negative number, the base.GetInt64() function will return 0
-	cursorInt := base.GetInt64(cursor)
-	return strconv.FormatInt(cursorInt, 10)
+	// In case cursor is negative value, return InvalidField error
+	cursorInt, _ := strconv.Atoi(cursor)
+	if cursorInt < 0 {
+		msg := fmt.Sprintf("the cursor could not be negative %d", cursorInt)
+		base.SetInvalidField("cursor", errors.New(msg))
+	}
+
+	return cursor
 }
 
 // GetString retrieves a string from either the URLParams, form or query string.

--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -45,7 +45,9 @@ func (base *Base) GetCursor(name string) string {
 		cursor = lei
 	}
 
-	return cursor
+	// if cursor is a negative number, the base.GetInt64() function will return 0
+	cursorInt := base.GetInt64(cursor)
+	return strconv.FormatInt(cursorInt, 10)
 }
 
 // GetString retrieves a string from either the URLParams, form or query string.

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -2,7 +2,7 @@ package horizon
 
 import (
 	"errors"
-	"fmt"
+	fmt "fmt"
 
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -87,7 +87,7 @@ func (action *PaymentsIndexAction) loadParams() {
 	action.PagingParams = action.GetPageQuery()
 
 	cursorInt, _ := strconv.Atoi(action.PagingParams.Cursor)
-	if (cursorInt < 0) {
+	if cursorInt < 0 {
 		msg := fmt.Sprintf("the cursor could not be negative %d", cursorInt)
 		action.Err = problem.P{
 			Type:   "invalid_parameters",

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -2,7 +2,7 @@ package horizon
 
 import (
 	"errors"
-	fmt "fmt"
+	"fmt"
 
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -10,8 +10,6 @@ import (
 	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/resource"
 	halRender "github.com/stellar/go/support/render/hal"
-	"strconv"
-	"github.com/stellar/go/support/render/problem"
 )
 
 // PaymentsIndexAction returns a paged slice of payments based upon the provided
@@ -85,17 +83,6 @@ func (action *PaymentsIndexAction) loadParams() {
 	action.LedgerFilter = action.GetInt32("ledger_id")
 	action.TransactionFilter = action.GetString("tx_id")
 	action.PagingParams = action.GetPageQuery()
-
-	cursorInt, _ := strconv.Atoi(action.PagingParams.Cursor)
-	if cursorInt < 0 {
-		msg := fmt.Sprintf("the cursor could not be negative %d", cursorInt)
-		action.Err = problem.P{
-			Type:   "invalid_parameters",
-			Title:  "Invalid Cursor Number",
-			Status: 400,
-			Detail: msg,
-		}
-	}
 }
 
 func (action *PaymentsIndexAction) loadRecords() {

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/resource"
 	halRender "github.com/stellar/go/support/render/hal"
+	"strconv"
+	"github.com/stellar/go/support/render/problem"
 )
 
 // PaymentsIndexAction returns a paged slice of payments based upon the provided
@@ -83,6 +85,17 @@ func (action *PaymentsIndexAction) loadParams() {
 	action.LedgerFilter = action.GetInt32("ledger_id")
 	action.TransactionFilter = action.GetString("tx_id")
 	action.PagingParams = action.GetPageQuery()
+
+	cursorInt, _ := strconv.Atoi(action.PagingParams.Cursor)
+	if (cursorInt < 0) {
+		msg := fmt.Sprintf("the cursor could not be negative %d", cursorInt)
+		action.Err = problem.P{
+			Type:   "invalid_parameters",
+			Title:  "Invalid Cursor Number",
+			Status: 400,
+			Detail: msg,
+		}
+	}
 }
 
 func (action *PaymentsIndexAction) loadRecords() {


### PR DESCRIPTION
For https://github.com/stellar/go/issues/193, if we pass in negative cursor to account payment API, the endpoint would fail will HTTP 400. However, there's NO detailed message explaining why the API request failed. 

This PR adds that error message. 

For testing, I ran **stellar-core** on http://localhost:11626/ and **Horizon** on http://localhost:8000/

Now, access this endpoint: 
http://localhost:8000/accounts/GBTYBQW5GLRSYMT4OJQGVAIH5KBIE5ITEWIVDZHVHIZT7XSKU6DLB6QI/payments?cursor=-1&order=asc&limit=6

Before code change

```
{
  "type": "https://stellar.org/horizon-errors/bad_request",
  "title": "Bad Request",
  "status": 400,
  "detail": "The request you sent was invalid in some way"
}
```

After code change:

```
{
  "type": "https://stellar.org/horizon-errors/invalid_parameters",
  "title": "Invalid Cursor Number",
  "status": 400,
  "detail": "the cursor could not be negative -1"
}
```