### PR TITLE
[Documentation] Update horizon guide, use 'go get' instead of 'git clone'

### DIFF
--- a/services/horizon/internal/docs/reference/admin.md
+++ b/services/horizon/internal/docs/reference/admin.md
@@ -41,11 +41,11 @@ Should you decide not to use one of our prebuilt releases, you may instead build
 
 Provided your workstation satisfies the requirements above, follow the steps below:
 
-1. Clone horizon's source:  `git clone https://github.com/stellar/go.git && cd go`
-2. Download external dependencies: `glide install`
-3. Build the binary: `go install github.com/stellar/go/services/horizon`
+1. Clone horizon's source:  `go get github.com/stellar/go && cd $GOPATH/src/github.com/stellar/go/`
+2. Under the project folder, download external dependencies: `glide install`
+3. Build the binary: `go install /services/horizon`
 
-After running the above commands have succeeded, the built horizon will have be written into the `bin` subdirectory of the current directory.
+After running the above commands have succeeded, the built horizon will have be written into the `bin` subdirectory of your $GOPATH.
 
 Note:  Building directly on windows is not supported.
 


### PR DESCRIPTION
I was doing a fresh setup of Horizon on my home laptop. I found out that 'git clone' doesn't always guarantee putting the code in the correct directory. 

Instead, I use 'go get' and made it work. 

Additionally, we should mention $GOPATH in the documentation, indicating where the stellar/go directory should reside. 