### PR TITLE
fixed race condition in friendbot test

### DIFF
--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -28,7 +28,8 @@ func initFriendbot(
 			URL:  horizonURL,
 			HTTP: http.DefaultClient,
 		},
-		Network:         networkPassphrase,
-		StartingBalance: startingBalance,
+		Network:           networkPassphrase,
+		StartingBalance:   startingBalance,
+		SubmitTransaction: internal.AsyncSubmitTransaction,
 	}
 }

--- a/services/friendbot/internal/friendbot.go
+++ b/services/friendbot/internal/friendbot.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"fmt"
 	"strconv"
 	"sync"
 
@@ -11,13 +10,19 @@ import (
 	"github.com/stellar/go/support/errors"
 )
 
+// TxResult is the result from the asynchronous submit transaction method over a channel
+type TxResult struct {
+	maybeTransactionSuccess *horizon.TransactionSuccess
+	maybeErr                error
+}
+
 // Bot represents the friendbot subsystem.
 type Bot struct {
 	Horizon           *horizon.Client
 	Secret            string
 	Network           string
 	StartingBalance   string
-	SubmitTransaction func(bot *Bot, channel chan interface{}, signed string)
+	SubmitTransaction func(bot *Bot, channel chan TxResult, signed string)
 
 	// uninitialized
 	sequence             uint64
@@ -27,24 +32,17 @@ type Bot struct {
 
 // Pay funds the account at `destAddress`
 func (bot *Bot) Pay(destAddress string) (*horizon.TransactionSuccess, error) {
-	channel := make(chan interface{})
+	channel := make(chan TxResult)
 	err := bot.lockedPay(channel, destAddress)
 	if err != nil {
 		return nil, err
 	}
 
 	v := <-channel
-	switch tv := v.(type) {
-	case horizon.TransactionSuccess:
-		return &tv, nil
-	case error:
-		return nil, tv
-	default:
-		return nil, fmt.Errorf("failed to submit async txn")
-	}
+	return v.maybeTransactionSuccess, v.maybeErr
 }
 
-func (bot *Bot) lockedPay(channel chan interface{}, destAddress string) error {
+func (bot *Bot) lockedPay(channel chan TxResult, destAddress string) error {
 	bot.lock.Lock()
 	defer bot.lock.Unlock()
 
@@ -63,7 +61,7 @@ func (bot *Bot) lockedPay(channel chan interface{}, destAddress string) error {
 }
 
 // AsyncSubmitTransaction should be passed into the bot
-func AsyncSubmitTransaction(bot *Bot, channel chan interface{}, signed string) {
+func AsyncSubmitTransaction(bot *Bot, channel chan TxResult, signed string) {
 	result, err := bot.Horizon.SubmitTransaction(signed)
 	if err != nil {
 		switch e := err.(type) {
@@ -71,9 +69,15 @@ func AsyncSubmitTransaction(bot *Bot, channel chan interface{}, signed string) {
 			bot.checkHandleBadSequence(e)
 		}
 
-		channel <- err
+		channel <- TxResult{
+			maybeTransactionSuccess: nil,
+			maybeErr:                err,
+		}
 	} else {
-		channel <- result
+		channel <- TxResult{
+			maybeTransactionSuccess: &result,
+			maybeErr:                nil,
+		}
 	}
 }
 

--- a/services/friendbot/internal/friendbot.go
+++ b/services/friendbot/internal/friendbot.go
@@ -13,10 +13,11 @@ import (
 
 // Bot represents the friendbot subsystem.
 type Bot struct {
-	Horizon         *horizon.Client
-	Secret          string
-	Network         string
-	StartingBalance string
+	Horizon           *horizon.Client
+	Secret            string
+	Network           string
+	StartingBalance   string
+	SubmitTransaction func(bot *Bot, channel chan interface{}, signed string)
 
 	// uninitialized
 	sequence             uint64
@@ -27,9 +28,9 @@ type Bot struct {
 // Pay funds the account at `destAddress`
 func (bot *Bot) Pay(destAddress string) (*horizon.TransactionSuccess, error) {
 	channel := make(chan interface{})
-	shouldReadChannel, result, err := bot.lockedPay(channel, destAddress)
-	if !shouldReadChannel {
-		return result, err
+	err := bot.lockedPay(channel, destAddress)
+	if err != nil {
+		return nil, err
 	}
 
 	v := <-channel
@@ -43,25 +44,26 @@ func (bot *Bot) Pay(destAddress string) (*horizon.TransactionSuccess, error) {
 	}
 }
 
-func (bot *Bot) lockedPay(channel chan interface{}, destAddress string) (bool, *horizon.TransactionSuccess, error) {
+func (bot *Bot) lockedPay(channel chan interface{}, destAddress string) error {
 	bot.lock.Lock()
 	defer bot.lock.Unlock()
 
 	err := bot.checkSequenceRefresh()
 	if err != nil {
-		return false, nil, err
+		return err
 	}
 
 	signed, err := bot.makeTx(destAddress)
 	if err != nil {
-		return false, nil, err
+		return err
 	}
 
-	go bot.asyncSubmitTransaction(channel, signed)
-	return true, nil, nil
+	go bot.SubmitTransaction(bot, channel, signed)
+	return nil
 }
 
-func (bot *Bot) asyncSubmitTransaction(channel chan interface{}, signed string) {
+// AsyncSubmitTransaction should be passed into the bot
+func AsyncSubmitTransaction(bot *Bot, channel chan interface{}, signed string) {
 	result, err := bot.Horizon.SubmitTransaction(signed)
 	if err != nil {
 		switch e := err.(type) {

--- a/services/friendbot/internal/friendbot_test.go
+++ b/services/friendbot/internal/friendbot_test.go
@@ -3,39 +3,47 @@ package internal
 import (
 	"testing"
 
+	"github.com/stellar/go/clients/horizon"
 	"github.com/stretchr/testify/assert"
 
 	"sync"
 )
 
-// REGRESSION:  ensure that we can craft a transaction
-func TestFriendbot_makeTx(t *testing.T) {
-	fb := &Bot{
-		Secret:          "SAQWC7EPIYF3XGILYVJM4LVAVSLZKT27CTEI3AFBHU2VRCMQ3P3INPG5",
-		Network:         "Test SDF Network ; September 2015",
-		StartingBalance: "100.00",
-		sequence:        2,
+func TestFriendbot_Pay(t *testing.T) {
+	mockSubmitTransaction := func(bot *Bot, channel chan interface{}, signed string) {
+		txSuccess := horizon.TransactionSuccess{Env: signed}
+		// we don't want to actually submit the tx here but emulate a success instead
+		channel <- txSuccess
 	}
 
-	txn, err := fb.makeTx("GDJIN6W6PLTPKLLM57UW65ZH4BITUXUMYQHIMAZFYXF45PZVAWDBI77Z")
+	fb := &Bot{
+		Secret:            "SAQWC7EPIYF3XGILYVJM4LVAVSLZKT27CTEI3AFBHU2VRCMQ3P3INPG5",
+		Network:           "Test SDF Network ; September 2015",
+		StartingBalance:   "100.00",
+		SubmitTransaction: mockSubmitTransaction,
+		sequence:          2,
+	}
+
+	txSuccess, err := fb.Pay("GDJIN6W6PLTPKLLM57UW65ZH4BITUXUMYQHIMAZFYXF45PZVAWDBI77Z")
 	if !assert.NoError(t, err) {
 		return
 	}
 	expectedTxn := "AAAAAPuYf7x7KGvFX9fjCR9WIaoTX3yHJYwX6ZSx6w76HPjEAAAAZAAAAAAAAAADAAAAAAAAAAAAAAAB" +
 		"AAAAAAAAAAAAAAAA0ob63nrm9S1s7+lvdyfgUTpejMQOhgMlxcvOvzUFhhQAAAAAO5rKAAAAAAAAAAAB+hz4xAAAAEC" +
 		"zNV2yXevMYKzm7OhXX2gYwmLZ5V37yeRHUX3Vhb6eT8wkUtpj2vJsUwzLWjdKMyGonFCPkaG4twRFUVqBRLEH"
-	assert.Equal(t, expectedTxn, txn)
+	assert.Equal(t, expectedTxn, txSuccess.Env)
 
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		_, err := fb.makeTx("GDJIN6W6PLTPKLLM57UW65ZH4BITUXUMYQHIMAZFYXF45PZVAWDBI77Z")
+		_, err := fb.Pay("GDJIN6W6PLTPKLLM57UW65ZH4BITUXUMYQHIMAZFYXF45PZVAWDBI77Z")
 		// don't assert on the txn value here because the ordering is not guaranteed between these 2 goroutines
 		assert.NoError(t, err)
 		wg.Done()
 	}()
 	go func() {
-		_, err := fb.makeTx("GDJIN6W6PLTPKLLM57UW65ZH4BITUXUMYQHIMAZFYXF45PZVAWDBI77Z")
+		_, err := fb.Pay("GDJIN6W6PLTPKLLM57UW65ZH4BITUXUMYQHIMAZFYXF45PZVAWDBI77Z")
+		// don't assert on the txn value here because the ordering is not guaranteed between these 2 goroutines
 		assert.NoError(t, err)
 		wg.Done()
 	}()

--- a/services/friendbot/internal/friendbot_test.go
+++ b/services/friendbot/internal/friendbot_test.go
@@ -10,10 +10,13 @@ import (
 )
 
 func TestFriendbot_Pay(t *testing.T) {
-	mockSubmitTransaction := func(bot *Bot, channel chan interface{}, signed string) {
+	mockSubmitTransaction := func(bot *Bot, channel chan TxResult, signed string) {
 		txSuccess := horizon.TransactionSuccess{Env: signed}
 		// we don't want to actually submit the tx here but emulate a success instead
-		channel <- txSuccess
+		channel <- TxResult{
+			maybeTransactionSuccess: &txSuccess,
+			maybeErr:                nil,
+		}
 	}
 
 	fb := &Bot{


### PR DESCRIPTION
We should really be testing the `Pay` function so I changed to use that so we can take advantage of the locking (which will prevent race conditions).

Test works now when run in with the `race` flag enabled.