### PR TITLE
errors.Wrap errors in ingest package

### DIFF
--- a/services/horizon/internal/ingest/asset_stat.go
+++ b/services/horizon/internal/ingest/asset_stat.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 
@@ -96,7 +97,7 @@ func (assetsModified AssetsModified) UpdateAssetStats(is *Session) {
 
 	if hasValue {
 		// perform a delete first since upsert is not supported if postgres < 9.5
-		is.Err = assetsModified.deleteRows(is.Ingestion.DB)
+		is.Err = errors.Wrap(assetsModified.deleteRows(is.Ingestion.DB), "Error deleting asset_stats row")
 		if is.Err != nil {
 			return
 		}
@@ -104,7 +105,7 @@ func (assetsModified AssetsModified) UpdateAssetStats(is *Session) {
 		// can perform a direct upsert if postgres > 9.4
 		// is.Ingestion.assetStats = is.Ingestion.assetStats.
 		// 	Suffix("ON CONFLICT (id) DO UPDATE SET (amount, num_accounts, flags, toml) = (excluded.amount, excluded.num_accounts, excluded.flags, excluded.toml)")
-		is.Err = is.Ingestion.builders[AssetStatsTableName].Exec(is.Ingestion.DB)
+		is.Err = errors.Wrap(is.Ingestion.builders[AssetStatsTableName].Exec(is.Ingestion.DB), "Error inserting asset_stats row")
 	}
 }
 
@@ -167,7 +168,7 @@ func computeAssetStat(is *Session, asset *xdr.Asset) *history.AssetStat {
 	historyQ := history.Q{Session: is.Ingestion.DB}
 	assetID, err := historyQ.GetCreateAssetID(*asset)
 	if err != nil {
-		is.Err = err
+		is.Err = errors.Wrap(err, "historyQ.GetCreateAssetID error")
 		return nil
 	}
 
@@ -175,7 +176,7 @@ func computeAssetStat(is *Session, asset *xdr.Asset) *history.AssetStat {
 	var assetCode, assetIssuer string
 	err = asset.Extract(&assetType, &assetCode, &assetIssuer)
 	if err != nil {
-		is.Err = err
+		is.Err = errors.Wrap(err, "asset.Extract error")
 		return nil
 	}
 
@@ -183,13 +184,13 @@ func computeAssetStat(is *Session, asset *xdr.Asset) *history.AssetStat {
 
 	numAccounts, amount, err := statTrustlinesInfo(coreQ, assetType, assetCode, assetIssuer)
 	if err != nil {
-		is.Err = err
+		is.Err = errors.Wrap(err, "statTrustlinesInfo error")
 		return nil
 	}
 
 	flags, toml, err := statAccountInfo(coreQ, assetIssuer)
 	if err != nil {
-		is.Err = err
+		is.Err = errors.Wrap(err, "statAccountInfo error")
 		return nil
 	}
 
@@ -212,7 +213,7 @@ func statAccountInfo(coreQ *core.Q, accountID string) (int8, string, error) {
 	var account core.Account
 	err := coreQ.AccountByAddress(&account, accountID)
 	if err != nil {
-		return -1, "", err
+		return -1, "", errors.Wrap(err, "coreQ.AccountByAddress error")
 	}
 
 	var toml string

--- a/services/horizon/internal/ingest/ingestion.go
+++ b/services/horizon/internal/ingest/ingestion.go
@@ -28,35 +28,35 @@ func (ingest *Ingestion) Clear(start int64, end int64) error {
 
 	err := clear(start, end, "history_effects", "history_operation_id")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Error clearing history_effects")
 	}
 	err = clear(start, end, "history_operation_participants", "history_operation_id")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Error clearing history_operation_participants")
 	}
 	err = clear(start, end, "history_operations", "id")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Error clearing history_operations")
 	}
 	err = clear(start, end, "history_transaction_participants", "history_transaction_id")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Error clearing history_transaction_participants")
 	}
 	err = clear(start, end, "history_transactions", "id")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Error clearing history_transactions")
 	}
 	err = clear(start, end, "history_ledgers", "id")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Error clearing history_ledgers")
 	}
 	err = clear(start, end, "history_trades", "history_operation_id")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Error clearing history_trades")
 	}
 	err = clear(start, end, "asset_stats", "id")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Error clearing asset_stats")
 	}
 
 	return nil
@@ -71,7 +71,7 @@ func (ingest *Ingestion) Close() error {
 func (ingest *Ingestion) Effect(address Address, opid int64, order int, typ history.EffectType, details interface{}) error {
 	djson, err := json.Marshal(details)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Error marshaling details")
 	}
 
 	ingest.builders[EffectsTableName].Values(address, opid, order, typ, djson)
@@ -105,7 +105,7 @@ func (ingest *Ingestion) Flush() error {
 
 	err = ingest.commit()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "ingest.commit error")
 	}
 
 	return ingest.Start()
@@ -137,7 +137,7 @@ func (ingest *Ingestion) UpdateAccountIDs(tables []TableName) error {
 	dbAccounts := make([]history.Account, 0, len(addresses))
 	err := q.AccountsByAddresses(&dbAccounts, addresses)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "q.AccountsByAddresses error")
 	}
 
 	for _, row := range dbAccounts {
@@ -157,7 +157,7 @@ func (ingest *Ingestion) UpdateAccountIDs(tables []TableName) error {
 		dbAccounts = make([]history.Account, 0, len(addresses))
 		err = q.CreateAccounts(&dbAccounts, addresses)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "q.CreateAccounts error")
 		}
 
 		for _, row := range dbAccounts {
@@ -214,7 +214,7 @@ func (ingest *Ingestion) Operation(
 ) error {
 	djson, err := json.Marshal(details)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Error marshaling details")
 	}
 
 	ingest.builders[OperationsTableName].Values(id, txid, order, source.Address(), typ, djson)

--- a/services/horizon/internal/ingest/session.go
+++ b/services/horizon/internal/ingest/session.go
@@ -30,6 +30,7 @@ func (is *Session) Run() {
 
 	is.Err = is.Ingestion.Start()
 	if is.Err != nil {
+		is.Err = errors.Wrap(is.Err, "Ingestion.Start error")
 		return
 	}
 
@@ -59,10 +60,11 @@ func (is *Session) Run() {
 
 	is.Err = is.Ingestion.Close()
 	if is.Err != nil {
+		is.Err = errors.Wrap(is.Err, "Ingestion.Close error")
 		return
 	}
 
-	is.Err = is.reportCursorState()
+	is.Err = errors.Wrap(is.reportCursorState(), "reportCursorState error")
 }
 
 func (is *Session) clearLedger() {
@@ -75,6 +77,10 @@ func (is *Session) clearLedger() {
 	}
 	start := time.Now()
 	is.Err = is.Ingestion.Clear(is.Cursor.LedgerRange())
+	if is.Err != nil {
+		is.Err = errors.Wrap(is.Err, "Ingestion.Clear error")
+	}
+
 	if is.Metrics != nil {
 		is.Metrics.ClearLedgerTimer.Update(time.Since(start))
 	}
@@ -101,6 +107,9 @@ func (is *Session) flush() {
 		return
 	}
 	is.Err = is.Ingestion.Flush()
+	if is.Err != nil {
+		is.Err = errors.Wrap(is.Err, "Ingestion.Flush error")
+	}
 }
 
 func (is *Session) ingestEffects() {
@@ -232,7 +241,7 @@ func (is *Session) ingestEffects() {
 		}
 
 		if err != nil {
-			is.Err = err
+			is.Err = errors.Wrap(err, "is.Cursor.BeforeAndAfter error")
 			return
 		}
 
@@ -292,7 +301,7 @@ func (is *Session) ingestEffects() {
 
 		before, after, err := is.Cursor.BeforeAndAfter(key)
 		if err != nil {
-			is.Err = err
+			is.Err = errors.Wrap(err, "is.Cursor.BeforeAndAfter error")
 			return
 		}
 
@@ -320,6 +329,9 @@ func (is *Session) ingestEffects() {
 	}
 
 	is.Err = effects.Finish()
+	if is.Err != nil {
+		is.Err = errors.Wrap(is.Err, "effects.Finish error")
+	}
 }
 
 // ingestLedger ingests the current ledger
@@ -362,6 +374,7 @@ func (is *Session) ingestOperation() {
 		is.operationDetails(),
 	)
 	if is.Err != nil {
+		is.Err = errors.Wrap(is.Err, "Ingestion.Operation error")
 		return
 	}
 
@@ -374,6 +387,11 @@ func (is *Session) ingestOperation() {
 		&is.Cursor.Transaction().Envelope.Tx.SourceAccount,
 		&core.Q{Session: is.Ingestion.DB},
 	)
+
+	if is.Err != nil {
+		is.Err = errors.Wrap(is.Err, "Cursor.AssetsModified.IngestOperation error")
+		return
+	}
 }
 
 func (is *Session) ingestOperationParticipants() {
@@ -388,6 +406,7 @@ func (is *Session) ingestOperationParticipants() {
 		is.Cursor.Operation(),
 	)
 	if is.Err != nil {
+		is.Err = errors.Wrap(is.Err, "participants.ForOperation error")
 		return
 	}
 
@@ -399,7 +418,7 @@ func (is *Session) ingestSignerEffects(effects *EffectIngestion, op xdr.SetOptio
 
 	be, ae, err := is.Cursor.BeforeAndAfter(source.LedgerKey())
 	if err != nil {
-		is.Err = err
+		is.Err = errors.Wrap(is.Err, "Cursor.BeforeAndAfter error")
 		return
 	}
 
@@ -496,7 +515,7 @@ func (is *Session) ingestTrades() {
 		key.SetOffer(trade.SellerId, uint64(trade.OfferId))
 		before, _, err := is.Cursor.BeforeAndAfter(key)
 		if err != nil {
-			is.Err = err
+			is.Err = errors.Wrap(is.Err, "Cursor.BeforeAndAfter error")
 			return
 		}
 		offerPrice := before.Data.Offer.Price
@@ -510,6 +529,7 @@ func (is *Session) ingestTrades() {
 			sTime.MillisFromSeconds(is.Cursor.Ledger().CloseTime),
 		)
 		if is.Err != nil {
+			is.Err = errors.Wrap(is.Err, "q.InsertTrade error")
 			return
 		}
 	}
@@ -585,6 +605,7 @@ func (is *Session) ingestTransactionParticipants() {
 		&is.Cursor.TransactionFee().Changes,
 	)
 	if is.Err != nil {
+		is.Err = errors.Wrap(is.Err, "participants.ForTransaction error")
 		return
 	}
 
@@ -600,6 +621,7 @@ func (is *Session) assetDetails(result map[string]interface{}, a xdr.Asset, pref
 	)
 	err := a.Extract(&t, &code, &i)
 	if err != nil {
+		err = errors.Wrap(err, "xdr.Asset.Extract error")
 		return err
 	}
 	result[prefix+"asset_type"] = t


### PR DESCRIPTION
All errors in `ingest` package are now wrapped (`errors.Wrap`) to make them easier to track and find functions where the error occurred.