### PR TITLE
Send initial errors while streaming

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -16,6 +16,7 @@ bumps.  A breaking change will get clearly notified in this log.
 
 - BREAKING CHANGE: Streaming connections will no longer wait until the first SSE message before sending the SSE preamble and establishing the streaming connection.
 - BREAKING CHANGE: SSE requests will no longer respond with regular HTTP error (i.e. a non-200 status) if the error occurred prior to sending the first SSE message.
+- Above changes have been reverted in [#446](https://github.com/stellar/go/pull/446).
 
 ## v0.12.3 - 2017-03-20
 

--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -68,7 +68,12 @@ func (base *Base) Execute(action interface{}) {
 			action.SSE(stream)
 
 			if base.Err != nil {
-				stream.Err(base.Err)
+				if stream.SentCount() == 0 {
+					problem.Render(base.Ctx, base.W, base.Err)
+					return
+				} else {
+					stream.Err(base.Err)
+				}
 			}
 
 			if stream.IsDone() {


### PR DESCRIPTION
Initial errors in streaming endpoints (ex. streaming payments for non-existent account) are now sent before sending SSE preamble with `200 OK` status code what made clients to reconnect to the stream over and over again.

Preamble is sent just before the first message or comment.

Partial fix for https://github.com/stellar/go/issues/445 to allow us to start testing a new code in `master` in testnet.