### PR TITLE
Fix sending CORS headers in support/http

### DIFF
--- a/support/http/mux.go
+++ b/support/http/mux.go
@@ -30,7 +30,7 @@ func NewAPIMux(behindProxy bool) *chi.Mux {
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},
 		AllowedHeaders: []string{"*"},
-		AllowedMethods: []string{"*"},
+		AllowedMethods: []string{"GET", "PUT", "POST", "PATCH", "DELETE", "HEAD", "OPTIONS"},
 	})
 
 	mux.Use(c.Handler)


### PR DESCRIPTION
Previous version was using `*` value for `AllowedMethods` on github.com/rs/cors package. However, this property does not allow wildcard values. This commit changes the values passed to `AllowedMethods` to `GET`, `POST` and `HEAD`.

---
Before, `friendbot` service (`Access-Control-Allow-Origin` header not present):
```
curl -H "Origin: https://www.stellar.org/laboratory" -v localhost:8000
* Rebuilt URL to: localhost:8000/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8000 (#0)
> GET / HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.54.0
> Accept: */*
> Origin: https://www.stellar.org/laboratory
> 
< HTTP/1.1 400 Bad Request
< Content-Type: application/problem+json; charset=utf-8
< Vary: Origin
< Date: Wed, 23 May 2018 13:42:01 GMT
< Content-Length: 281
```
After:
```
curl -H "Origin: https://www.stellar.org/laboratory" -v localhost:8000
* Rebuilt URL to: localhost:8000/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8000 (#0)
> GET / HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.54.0
> Accept: */*
> Origin: https://www.stellar.org/laboratory
> 
< HTTP/1.1 200 OK
< Access-Control-Allow-Origin: https://www.stellar.org/laboratory
< Content-Disposition: inline
< Content-Type: application/hal+json; charset=utf-8
< Vary: Origin
< X-Ratelimit-Limit: 3600
< X-Ratelimit-Remaining: 3599
< X-Ratelimit-Reset: 3599
< Date: Wed, 23 May 2018 13:42:26 GMT
< Content-Length: 1350
```