### PR TITLE
Send Cache-Control header

### DIFF
--- a/services/horizon/internal/init_web.go
+++ b/services/horizon/internal/init_web.go
@@ -54,6 +54,7 @@ func initWebMiddleware(app *App) {
 	r := app.web.router
 	r.Use(chimiddleware.StripSlashes)
 	r.Use(app.Middleware)
+	r.Use(requestCacheHeadersMiddleware)
 	r.Use(chimiddleware.RequestID)
 	r.Use(contextMiddleware(app.ctx))
 	r.Use(xff.Handler)

--- a/services/horizon/internal/middleware_cache_headers.go
+++ b/services/horizon/internal/middleware_cache_headers.go
@@ -1,0 +1,16 @@
+package horizon
+
+import (
+	"net/http"
+)
+
+// requestCacheHeadersMiddleware adds caching headers to each response.
+func requestCacheHeadersMiddleware(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Before changing this read Stack Overflow answer about staled request
+		// in older versions of Chrome:
+		// https://stackoverflow.com/questions/27513994/chrome-stalls-when-making-multiple-requests-to-same-resource
+		w.Header().Set("Cache-Control", "no-cache, no-store, max-age=0")
+		h.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
In JS SDK we're adding random values to URL because of an older Chrome versions issue: https://github.com/stellar/js-stellar-sdk/issues/15. With correct `Cache-Control` headers it's not needed anymore.

This is a fix for browser based requests. In a future caching strategy should be more sophisticated so that Horizon responses can be cached at the proxy level (ex. `/transactions/{id}` will never change, unless we change response struct).