### PR TITLE
fix offers for account timestamps

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -151,15 +151,16 @@ type Offer struct {
 		OfferMaker hal.Link `json:"offer_maker"`
 	} `json:"_links"`
 
-	ID           int64     `json:"id"`
-	PT           string    `json:"paging_token"`
-	Seller       string    `json:"seller"`
-	Selling      Asset     `json:"selling"`
-	Buying       Asset     `json:"buying"`
-	Amount       string    `json:"amount"`
-	PriceR       Price     `json:"price_r"`
-	Price        string    `json:"price"`
-	LastModified time.Time `json:"last_modified"`
+	ID                 int64     `json:"id"`
+	PT                 string    `json:"paging_token"`
+	Seller             string    `json:"seller"`
+	Selling            Asset     `json:"selling"`
+	Buying             Asset     `json:"buying"`
+	Amount             string    `json:"amount"`
+	PriceR             Price     `json:"price_r"`
+	Price              string    `json:"price"`
+	LastModifiedLedger int32     `json:"last_modified_ledger"`
+	LastModifiedTime   time.Time `json:"last_modified_time"`
 }
 
 func (this Offer) PagingToken() string {

--- a/services/horizon/internal/actions_offer.go
+++ b/services/horizon/internal/actions_offer.go
@@ -1,12 +1,15 @@
 package horizon
 
 import (
+	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
-	"github.com/stellar/go/services/horizon/internal/resourceadapter"
-	"github.com/stellar/go/protocols/horizon"
-	"github.com/stellar/go/support/render/hal"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
+	"github.com/stellar/go/services/horizon/internal/resourceadapter"
+	"github.com/stellar/go/support/render/hal"
+	"fmt"
+	"errors"
 )
 
 // This file contains the actions:
@@ -19,6 +22,7 @@ type OffersByAccountAction struct {
 	Address   string
 	PageQuery db2.PageQuery
 	Records   []core.Offer
+	Ledgers   history.LedgerCache
 	Page      hal.Page
 }
 
@@ -27,6 +31,7 @@ func (action *OffersByAccountAction) JSON() {
 	action.Do(
 		action.loadParams,
 		action.loadRecords,
+		action.loadLedgers,
 		action.loadPage,
 		func() {
 			hal.Render(action.W, action.Page)
@@ -42,8 +47,14 @@ func (action *OffersByAccountAction) SSE(stream sse.Stream) {
 		func() {
 			stream.SetLimit(int(action.PageQuery.Limit))
 			for _, record := range action.Records[stream.SentCount():] {
+				ledger, found := action.Ledgers.Records[record.Lastmodified]
+				if !found {
+					msg := fmt.Sprintf("could not find ledger data for sequence %d", record.Lastmodified)
+					stream.Err(errors.New(msg))
+					return
+				}
 				var res horizon.Offer
-				resourceadapter.PopulateOffer(action.R.Context(), &res, record)
+				resourceadapter.PopulateOffer(action.R.Context(), &res, record, ledger)
 				stream.Send(sse.Event{ID: res.PagingToken(), Data: res})
 			}
 		},
@@ -53,6 +64,14 @@ func (action *OffersByAccountAction) SSE(stream sse.Stream) {
 func (action *OffersByAccountAction) loadParams() {
 	action.PageQuery = action.GetPageQuery()
 	action.Address = action.GetString("account_id")
+}
+
+// loadLedgers populates the ledger cache for this action
+func (action *OffersByAccountAction) loadLedgers() {
+	for _, offer := range action.Records {
+		action.Ledgers.Queue(offer.Lastmodified)
+	}
+	action.Err = action.Ledgers.Load(action.HistoryQ())
 }
 
 func (action *OffersByAccountAction) loadRecords() {
@@ -65,8 +84,15 @@ func (action *OffersByAccountAction) loadRecords() {
 
 func (action *OffersByAccountAction) loadPage() {
 	for _, record := range action.Records {
+		ledger, found := action.Ledgers.Records[record.Lastmodified]
+		if !found {
+			msg := fmt.Sprintf("could not find ledger data for sequence %d", record.Lastmodified)
+			action.Err = errors.New(msg)
+			return
+		}
+
 		var res horizon.Offer
-		resourceadapter.PopulateOffer(action.R.Context(), &res, record)
+		resourceadapter.PopulateOffer(action.R.Context(), &res, record, ledger)
 		action.Page.Add(res)
 	}
 

--- a/services/horizon/internal/actions_offer_test.go
+++ b/services/horizon/internal/actions_offer_test.go
@@ -18,6 +18,7 @@ func TestOfferActions_Index(t *testing.T) {
 		//test last modified timestamp
 		var records []map[string]interface{}
 		ht.UnmarshalPage(w.Body, &records)
-		ht.Assert.Equal("1970-01-01T00:00:05Z", records[2]["last_modified"])
+		ht.Assert.Equal("2018-06-01T17:10:08Z", records[2]["last_modified_time"])
+		ht.Assert.EqualValues(5, records[2]["last_modified_ledger"])
 	}
 }

--- a/services/horizon/internal/docs/reference/resources/offer.md
+++ b/services/horizon/internal/docs/reference/resources/offer.md
@@ -17,7 +17,8 @@ Horizon only returns offers that belong to a particular account.  When it does, 
 | amount | string | The amount of `selling` the account making this offer is willing to sell.|
 | price_r | object | An object of a number numerator and number denominator that represent the buy and sell price of the currencies on offer.|
 | price| string | How many units of `buying` it takes to get 1 unit of `selling`. A number representing the decimal form of `price_r`.|
-| last_modified| string | An ISO 8601 formatted string of last modification time||
+| last_modified_ledger| integer | sequence number for the latest ledger in which this offer was modified.||
+| last_modified_time| string | An ISO 8601 formatted string of last modification time.||
 
 ## Links
 | rel          | Example                                                                                           | Description                                                | `templated` |

--- a/services/horizon/internal/resourceadapter/offer.go
+++ b/services/horizon/internal/resourceadapter/offer.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stellar/go/services/horizon/internal/httpx"
 	. "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/render/hal"
-	"time"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
 )
 
-func PopulateOffer(ctx context.Context, dest *Offer, row core.Offer) {
+func PopulateOffer(ctx context.Context, dest *Offer, row core.Offer, ledger history.Ledger) {
 	dest.ID = row.OfferID
 	dest.PT = row.PagingToken()
 	dest.Seller = row.SellerID
@@ -30,7 +30,8 @@ func PopulateOffer(ctx context.Context, dest *Offer, row core.Offer) {
 		Code:   row.SellingAssetCode.String,
 		Issuer: row.SellingIssuer.String,
 	}
-	dest.LastModified = time.Unix(int64(row.Lastmodified), 0).UTC()
+	dest.LastModifiedLedger = row.Lastmodified
+	dest.LastModifiedTime = ledger.ClosedAt
 	lb := hal.LinkBuilder{httpx.BaseURL(ctx)}
 	dest.Links.Self = lb.Linkf("/offers/%d", row.OfferID)
 	dest.Links.OfferMaker = lb.Linkf("/accounts/%s", row.SellerID)


### PR DESCRIPTION
Add a `LedgerCache` to `OffersByAccountAction` and populate the offer resource with ledger sequence number and `closed_at` time.  

closes #478