### PR TITLE
refactor clients/horizon to use protocols/horizon

### DIFF
--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
+	. "github.com/stellar/go/protocols/horizon"
 )
 
 // HomeDomainForAccount returns the home domain for the provided strkey-encoded

--- a/clients/horizon/client_test.go
+++ b/clients/horizon/client_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stellar/go/support/http/httptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	. "github.com/stellar/go/protocols/horizon"
 )
 
 func TestClient(t *testing.T) {

--- a/clients/horizon/error.go
+++ b/clients/horizon/error.go
@@ -4,29 +4,13 @@ import (
 	"encoding/json"
 
 	"github.com/stellar/go/support/errors"
-	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/xdr"
+
+	. "github.com/stellar/go/protocols/horizon"
 )
 
 func (herr Error) Error() string {
 	return `Horizon error: "` + herr.Problem.Title + `". Check horizon.Error.Problem for more information.`
-}
-
-// ToProblem converts the Prolem to a problem.P
-func (prob Problem) ToProblem() problem.P {
-	extras := make(map[string]interface{})
-	for k, v := range prob.Extras {
-		extras[k] = v
-	}
-
-	return problem.P{
-		Type:     prob.Type,
-		Title:    prob.Title,
-		Status:   prob.Status,
-		Detail:   prob.Detail,
-		Instance: prob.Instance,
-		Extras:   extras,
-	}
 }
 
 // Envelope extracts the transaction envelope that triggered this error from the
@@ -40,7 +24,7 @@ func (herr *Error) Envelope() (*xdr.TransactionEnvelope, error) {
 	var b64 string
 	var result xdr.TransactionEnvelope
 
-	err := json.Unmarshal(raw, &b64)
+	err := json.Unmarshal(raw.(json.RawMessage), &b64)
 	if err != nil {
 		return nil, errors.Wrap(err, "json decode failed")
 	}
@@ -62,7 +46,7 @@ func (herr *Error) ResultCodes() (*TransactionResultCodes, error) {
 	}
 
 	var result TransactionResultCodes
-	err := json.Unmarshal(raw, &result)
+	err := json.Unmarshal(raw.(json.RawMessage), &result)
 	if err != nil {
 		return nil, errors.Wrap(err, "json decode failed")
 	}

--- a/clients/horizon/error_test.go
+++ b/clients/horizon/error_test.go
@@ -12,7 +12,7 @@ func TestError_ResultCodes(t *testing.T) {
 
 	// happy path: transaction_failed with the appropriate extra fields
 	herr.Problem.Type = "transaction_failed"
-	herr.Problem.Extras = make(map[string]json.RawMessage)
+	herr.Problem.Extras = make(map[string]interface{})
 	herr.Problem.Extras["result_codes"] = json.RawMessage(`{
     "transaction": "tx_failed",
     "operations": ["op_underfunded"]
@@ -29,13 +29,13 @@ func TestError_ResultCodes(t *testing.T) {
 
 	// sad path: missing result_codes extra
 	herr.Problem.Type = "transaction_failed"
-	herr.Problem.Extras = make(map[string]json.RawMessage)
+	herr.Problem.Extras = make(map[string]interface{})
 	_, err = herr.ResultCodes()
 	assert.Equal(t, ErrResultCodesNotPopulated, err)
 
 	// sad path: unparseable result_codes extra
 	herr.Problem.Type = "transaction_failed"
-	herr.Problem.Extras = make(map[string]json.RawMessage)
+	herr.Problem.Extras = make(map[string]interface{})
 	herr.Problem.Extras["result_codes"] = json.RawMessage(`kaboom`)
 	_, err = herr.ResultCodes()
 	assert.Error(t, err)
@@ -46,19 +46,19 @@ func TestError_Envelope(t *testing.T) {
 
 	// happy path: transaction_failed with the appropriate extra fields
 	herr.Problem.Type = "transaction_failed"
-	herr.Problem.Extras = make(map[string]json.RawMessage)
+	herr.Problem.Extras = make(map[string]interface{})
 	herr.Problem.Extras["envelope_xdr"] = json.RawMessage(`"AAAAADSMMRmQGDH6EJzkgi/7PoKhphMHyNGQgDp2tlS/dhGXAAAAZAAT3TUAAAAwAAAAAAAAAAAAAAABAAAAAAAAAAMAAAABSU5SAAAAAAA0jDEZkBgx+hCc5IIv+z6CoaYTB8jRkIA6drZUv3YRlwAAAAFVU0QAAAAAADSMMRmQGDH6EJzkgi/7PoKhphMHyNGQgDp2tlS/dhGXAAAAAAX14QAAAAAKAAAAAQAAAAAAAAAAAAAAAAAAAAG/dhGXAAAAQLuStfImg0OeeGAQmvLkJSZ1MPSkCzCYNbGqX5oYNuuOqZ5SmWhEsC7uOD9ha4V7KengiwNlc0oMNqBVo22S7gk="`)
 
 	_, err := herr.Envelope()
 	assert.NoError(t, err)
 
 	// sad path: missing envelope_xdr extra
-	herr.Problem.Extras = make(map[string]json.RawMessage)
+	herr.Problem.Extras = make(map[string]interface{})
 	_, err = herr.Envelope()
 	assert.Equal(t, ErrEnvelopeNotPopulated, err)
 
 	// sad path: unparseable envelope_xdr extra
-	herr.Problem.Extras = make(map[string]json.RawMessage)
+	herr.Problem.Extras = make(map[string]interface{})
 	herr.Problem.Extras["envelope_xdr"] = json.RawMessage(`"AAAAADSMMRmQGDH6EJzkgi"`)
 	_, err = herr.Envelope()
 	if assert.Error(t, err) {

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -15,6 +15,9 @@ import (
 	"github.com/stellar/go/build"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
+
+	. "github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/support/render/problem"
 )
 
 // DefaultTestNetClient is a default client to connect to test network
@@ -106,7 +109,7 @@ type ClientInterface interface {
 // Error struct contains the problem returned by Horizon
 type Error struct {
 	Response *http.Response
-	Problem  Problem
+	Problem  problem.P
 }
 
 // HTTP represents the HTTP client that a horizon client uses to communicate

--- a/clients/horizon/main_test.go
+++ b/clients/horizon/main_test.go
@@ -10,6 +10,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/http/httptest"
+
+	. "github.com/stellar/go/protocols/horizon"
 )
 
 func ExampleClient_StreamLedgers() {

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/mock"
+
+	. "github.com/stellar/go/protocols/horizon"
 )
 
 // MockClient is a mockable horizon client.

--- a/clients/horizon/responses.go
+++ b/clients/horizon/responses.go
@@ -7,11 +7,7 @@ import (
 
 // TradeAggregationsPage returns a list of aggregated trade records, aggregated by resolution
 type TradeAggregationsPage struct {
-	Links struct {
-		Self hal.Link `json:"self"`
-		Next hal.Link `json:"next"`
-		Prev hal.Link `json:"prev"`
-	} `json:"_links"`
+	Links hal.Links `json:"_links"`
 	Embedded struct {
 		Records []TradeAggregation `json:"records"`
 	} `json:"_embedded"`
@@ -19,22 +15,14 @@ type TradeAggregationsPage struct {
 
 // TradesPage returns a list of trade records
 type TradesPage struct {
-	Links struct {
-		Self hal.Link `json:"self"`
-		Next hal.Link `json:"next"`
-		Prev hal.Link `json:"prev"`
-	} `json:"_links"`
+	Links hal.Links `json:"_links"`
 	Embedded struct {
 		Records []Trade `json:"records"`
 	} `json:"_embedded"`
 }
 
 type OffersPage struct {
-	Links struct {
-		Self hal.Link `json:"self"`
-		Next hal.Link `json:"next"`
-		Prev hal.Link `json:"prev"`
-	} `json:"_links"`
+	Links hal.Links `json:"_links"`
 	Embedded struct {
 		Records []Offer `json:"records"`
 	} `json:"_embedded"`

--- a/clients/horizon/responses.go
+++ b/clients/horizon/responses.go
@@ -1,280 +1,39 @@
 package horizon
 
 import (
-	"encoding/base64"
-	"encoding/json"
-	"time"
+	"github.com/stellar/go/support/render/hal"
+	. "github.com/stellar/go/protocols/horizon"
 )
-
-type Problem struct {
-	Type     string                     `json:"type"`
-	Title    string                     `json:"title"`
-	Status   int                        `json:"status"`
-	Detail   string                     `json:"detail,omitempty"`
-	Instance string                     `json:"instance,omitempty"`
-	Extras   map[string]json.RawMessage `json:"extras,omitempty"`
-}
-
-type Root struct {
-	Links struct {
-		Account             Link `json:"account"`
-		AccountTransactions Link `json:"account_transactions"`
-		Friendbot           Link `json:"friendbot"`
-		Metrics             Link `json:"metrics"`
-		OrderBook           Link `json:"order_book"`
-		Self                Link `json:"self"`
-		Transaction         Link `json:"transaction"`
-		Transactions        Link `json:"transactions"`
-	} `json:"_links"`
-
-	HorizonVersion       string `json:"horizon_version"`
-	StellarCoreVersion   string `json:"core_version"`
-	HorizonSequence      int32  `json:"history_latest_ledger"`
-	HistoryElderSequence int32  `json:"history_elder_ledger"`
-	CoreSequence         int32  `json:"core_latest_ledger"`
-	CoreElderSequence    int32  `json:"core_elder_ledger"`
-	NetworkPassphrase    string `json:"network_passphrase"`
-	ProtocolVersion      int32  `json:"protocol_version"`
-}
-
-type Account struct {
-	Links struct {
-		Self         Link `json:"self"`
-		Transactions Link `json:"transactions"`
-		Operations   Link `json:"operations"`
-		Payments     Link `json:"payments"`
-		Effects      Link `json:"effects"`
-		Offers       Link `json:"offers"`
-	} `json:"_links"`
-
-	HistoryAccount
-	Sequence             string            `json:"sequence"`
-	SubentryCount        int32             `json:"subentry_count"`
-	InflationDestination string            `json:"inflation_destination,omitempty"`
-	HomeDomain           string            `json:"home_domain,omitempty"`
-	Thresholds           AccountThresholds `json:"thresholds"`
-	Flags                AccountFlags      `json:"flags"`
-	Balances             []Balance         `json:"balances"`
-	Signers              []Signer          `json:"signers"`
-	Data                 map[string]string `json:"data"`
-}
-
-func (a Account) GetNativeBalance() string {
-	for _, balance := range a.Balances {
-		if balance.Asset.Type == "native" {
-			return balance.Balance
-		}
-	}
-
-	return "0"
-}
-
-func (a Account) GetCreditBalance(code, issuer string) string {
-	for _, balance := range a.Balances {
-		if balance.Asset.Code == code && balance.Asset.Issuer == issuer {
-			return balance.Balance
-		}
-	}
-
-	return "0"
-}
-
-// MustGetData returns decoded value for a given key. If the key does
-// not exist, empty slice will be returned. If there is an error
-// decoding a value, it will panic.
-func (this *Account) MustGetData(key string) []byte {
-	bytes, err := this.GetData(key)
-	if err != nil {
-		panic(err)
-	}
-	return bytes
-}
-
-// GetData returns decoded value for a given key. If the key does
-// not exist, empty slice will be returned.
-func (this *Account) GetData(key string) ([]byte, error) {
-	return base64.StdEncoding.DecodeString(this.Data[key])
-}
-
-type AccountFlags struct {
-	AuthRequired  bool `json:"auth_required"`
-	AuthRevocable bool `json:"auth_revocable"`
-}
-
-type AccountThresholds struct {
-	LowThreshold  byte `json:"low_threshold"`
-	MedThreshold  byte `json:"med_threshold"`
-	HighThreshold byte `json:"high_threshold"`
-}
-
-type Asset struct {
-	Type   string `json:"asset_type"`
-	Code   string `json:"asset_code,omitempty"`
-	Issuer string `json:"asset_issuer,omitempty"`
-}
-
-type Balance struct {
-	Balance string `json:"balance"`
-	Limit   string `json:"limit,omitempty"`
-	Asset
-}
-
-type HistoryAccount struct {
-	ID        string `json:"id"`
-	PT        string `json:"paging_token"`
-	AccountID string `json:"account_id"`
-}
-
-type Ledger struct {
-	Links struct {
-		Self         Link `json:"self"`
-		Transactions Link `json:"transactions"`
-		Operations   Link `json:"operations"`
-		Payments     Link `json:"payments"`
-		Effects      Link `json:"effects"`
-	} `json:"_links"`
-	ID               string    `json:"id"`
-	PT               string    `json:"paging_token"`
-	Hash             string    `json:"hash"`
-	PrevHash         string    `json:"prev_hash,omitempty"`
-	Sequence         int32     `json:"sequence"`
-	TransactionCount int32     `json:"transaction_count"`
-	OperationCount   int32     `json:"operation_count"`
-	ClosedAt         time.Time `json:"closed_at"`
-	TotalCoins       string    `json:"total_coins"`
-	FeePool          string    `json:"fee_pool"`
-	BaseFee          int32     `json:"base_fee_in_stroops"`
-	BaseReserve      int32     `json:"base_reserve_in_stroops"`
-	MaxTxSetSize     int32     `json:"max_tx_set_size"`
-	ProtocolVersion  int32     `json:"protocol_version"`
-}
-
-type Link struct {
-	Href      string `json:"href"`
-	Templated bool   `json:"templated,omitempty"`
-}
-
-type Offer struct {
-	Links struct {
-		Self       Link `json:"self"`
-		OfferMaker Link `json:"offer_maker"`
-	} `json:"_links"`
-
-	ID      int64  `json:"id"`
-	PT      string `json:"paging_token"`
-	Seller  string `json:"seller"`
-	Selling Asset  `json:"selling"`
-	Buying  Asset  `json:"buying"`
-	Amount  string `json:"amount"`
-	PriceR  Price  `json:"price_r"`
-	Price   string `json:"price"`
-}
 
 // TradeAggregationsPage returns a list of aggregated trade records, aggregated by resolution
 type TradeAggregationsPage struct {
 	Links struct {
-		Self Link `json:"self"`
-		Next Link `json:"next"`
-		Prev Link `json:"prev"`
+		Self hal.Link `json:"self"`
+		Next hal.Link `json:"next"`
+		Prev hal.Link `json:"prev"`
 	} `json:"_links"`
 	Embedded struct {
 		Records []TradeAggregation `json:"records"`
 	} `json:"_embedded"`
 }
 
-// TradeAggregation represents trade data aggregation over a period of time
-type TradeAggregation struct {
-	Timestamp     int64  `json:"timestamp"`
-	TradeCount    int64  `json:"trade_count"`
-	BaseVolume    string `json:"base_volume"`
-	CounterVolume string `json:"counter_volume"`
-	Average       string `json:"avg"`
-	High          string `json:"high"`
-	HighR         Price  `json:"high_r"`
-	Low           string `json:"low"`
-	LowR          Price  `json:"low_r"`
-	Open          string `json:"open"`
-	OpenR         Price  `json:"open_r"`
-	Close         string `json:"close"`
-	CloseR        Price  `json:"close_r"`
-}
-
 // TradesPage returns a list of trade records
 type TradesPage struct {
 	Links struct {
-		Self Link `json:"self"`
-		Next Link `json:"next"`
-		Prev Link `json:"prev"`
+		Self hal.Link `json:"self"`
+		Next hal.Link `json:"next"`
+		Prev hal.Link `json:"prev"`
 	} `json:"_links"`
 	Embedded struct {
 		Records []Trade `json:"records"`
 	} `json:"_embedded"`
 }
 
-// Trade represents a horizon digested trade
-type Trade struct {
-	Links struct {
-		Self      Link `json:"self"`
-		Base      Link `json:"base"`
-		Counter   Link `json:"counter"`
-		Operation Link `json:"operation"`
-	} `json:"_links"`
-
-	ID                 string    `json:"id"`
-	PT                 string    `json:"paging_token"`
-	LedgerCloseTime    time.Time `json:"ledger_close_time"`
-	OfferID            string    `json:"offer_id"`
-	BaseAccount        string    `json:"base_account"`
-	BaseAmount         string    `json:"base_amount"`
-	BaseAssetType      string    `json:"base_asset_type"`
-	BaseAssetCode      string    `json:"base_asset_code,omitempty"`
-	BaseAssetIssuer    string    `json:"base_asset_issuer,omitempty"`
-	CounterAccount     string    `json:"counter_account"`
-	CounterAmount      string    `json:"counter_amount"`
-	CounterAssetType   string    `json:"counter_asset_type"`
-	CounterAssetCode   string    `json:"counter_asset_code,omitempty"`
-	CounterAssetIssuer string    `json:"counter_asset_issuer,omitempty"`
-	BaseIsSeller       bool      `json:"base_is_seller"`
-	Price              *Price    `json:"price"`
-}
-
-type OrderBookSummary struct {
-	Bids    []PriceLevel `json:"bids"`
-	Asks    []PriceLevel `json:"asks"`
-	Selling Asset        `json:"base"`
-	Buying  Asset        `json:"counter"`
-}
-
-type TransactionSuccess struct {
-	Links struct {
-		Transaction Link `json:"transaction"`
-	} `json:"_links"`
-	Hash   string `json:"hash"`
-	Ledger int32  `json:"ledger"`
-	Env    string `json:"envelope_xdr"`
-	Result string `json:"result_xdr"`
-	Meta   string `json:"result_meta_xdr"`
-}
-
-// TransactionResultCodes represent a summary of result codes returned from
-// a single xdr TransactionResult
-type TransactionResultCodes struct {
-	TransactionCode string   `json:"transaction"`
-	OperationCodes  []string `json:"operations,omitempty"`
-}
-
-type Signer struct {
-	PublicKey string `json:"public_key"`
-	Weight    int32  `json:"weight"`
-	Key       string `json:"key"`
-	Type      string `json:"type"`
-}
-
 type OffersPage struct {
 	Links struct {
-		Self Link `json:"self"`
-		Next Link `json:"next"`
-		Prev Link `json:"prev"`
+		Self hal.Link `json:"self"`
+		Next hal.Link `json:"next"`
+		Prev hal.Link `json:"prev"`
 	} `json:"_links"`
 	Embedded struct {
 		Records []Offer `json:"records"`
@@ -319,36 +78,4 @@ type Payment struct {
 		Type  string `json:"memo_type"`
 		Value string `json:"memo"`
 	}
-}
-
-type Price struct {
-	N int32 `json:"n"`
-	D int32 `json:"d"`
-}
-
-type PriceLevel struct {
-	PriceR Price  `json:"price_r"`
-	Price  string `json:"price"`
-	Amount string `json:"amount"`
-}
-
-type Transaction struct {
-	ID              string    `json:"id"`
-	PagingToken     string    `json:"paging_token"`
-	Hash            string    `json:"hash"`
-	Ledger          int32     `json:"ledger"`
-	LedgerCloseTime time.Time `json:"created_at"`
-	Account         string    `json:"source_account"`
-	AccountSequence string    `json:"source_account_sequence"`
-	FeePaid         int32     `json:"fee_paid"`
-	OperationCount  int32     `json:"operation_count"`
-	EnvelopeXdr     string    `json:"envelope_xdr"`
-	ResultXdr       string    `json:"result_xdr"`
-	ResultMetaXdr   string    `json:"result_meta_xdr"`
-	FeeMetaXdr      string    `json:"fee_meta_xdr"`
-	MemoType        string    `json:"memo_type"`
-	Memo            string    `json:"memo,omitempty"`
-	Signatures      []string  `json:"signatures"`
-	ValidAfter      string    `json:"valid_after,omitempty"`
-	ValidBefore     string    `json:"valid_before,omitempty"`
 }

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -47,6 +47,26 @@ type Account struct {
 	Data                 map[string]string `json:"data"`
 }
 
+func (a Account) GetNativeBalance() string {
+	for _, balance := range a.Balances {
+		if balance.Asset.Type == "native" {
+			return balance.Balance
+		}
+	}
+	panic(errors.New("account is missing native balance"))
+}
+
+
+//TODO: remove this?
+func (a Account) GetCreditBalance(code, issuer string) string {
+	for _, balance := range a.Balances {
+		if balance.Asset.Code == code && balance.Asset.Issuer == issuer {
+			return balance.Balance
+		}
+	}
+	return "0"
+}
+
 // MustGetData returns decoded value for a given key. If the key does
 // not exist, empty slice will be returned. If there is an error
 // decoding a value, it will panic.

--- a/services/bifrost/stellar/account_configurator.go
+++ b/services/bifrost/stellar/account_configurator.go
@@ -4,11 +4,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/services/bifrost/common"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
+	hClient "github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 )
 
 func (ac *AccountConfigurator) Start() error {
@@ -185,11 +186,11 @@ func (ac *AccountConfigurator) removeAccountStatus(account string) {
 	delete(ac.accountStatus, account)
 }
 
-func (ac *AccountConfigurator) getAccount(account string) (horizon.Account, bool, error) {
-	var hAccount horizon.Account
+func (ac *AccountConfigurator) getAccount(account string) (hProtocol.Account, bool, error) {
+	var hAccount hProtocol.Account
 	hAccount, err := ac.Horizon.LoadAccount(account)
 	if err != nil {
-		if err, ok := err.(*horizon.Error); ok && err.Response.StatusCode == http.StatusNotFound {
+		if err, ok := err.(*hClient.Error); ok && err.Response.StatusCode == http.StatusNotFound {
 			return hAccount, false, nil
 		}
 		return hAccount, false, err
@@ -200,7 +201,7 @@ func (ac *AccountConfigurator) getAccount(account string) (horizon.Account, bool
 
 // signerExistsOnly returns true if account has exactly one signer and it's
 // equal to `signerPublicKey`.
-func (ac *AccountConfigurator) signerExistsOnly(account horizon.Account) bool {
+func (ac *AccountConfigurator) signerExistsOnly(account hProtocol.Account) bool {
 	tempSignerFound := false
 
 	for _, signer := range account.Signers {

--- a/services/bifrost/stellar/transactions.go
+++ b/services/bifrost/stellar/transactions.go
@@ -175,7 +175,7 @@ func (ac *AccountConfigurator) submitTransaction(transaction string) error {
 	if err != nil {
 		fields := log.F{"err": err}
 		if err, ok := err.(*horizon.Error); ok {
-			fields["result"] = string(err.Problem.Extras["result_xdr"])
+			fields["result"] = err.Problem.Extras["result_xdr"]
 			ac.updateSignerSequence()
 		}
 		localLog.WithFields(fields).Error("Error submitting transaction")

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -3,9 +3,9 @@ package main
 import (
 	"net/http"
 
-	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/services/friendbot/internal"
 	"github.com/stellar/go/strkey"
+	hClient "github.com/stellar/go/clients/horizon"
 )
 
 func initFriendbot(
@@ -24,7 +24,7 @@ func initFriendbot(
 
 	return &internal.Bot{
 		Secret: friendbotSecret,
-		Horizon: &horizon.Client{
+		Horizon: hClient.Client{
 			URL:  horizonURL,
 			HTTP: http.DefaultClient,
 		},

--- a/services/friendbot/internal/friendbot_handler.go
+++ b/services/friendbot/internal/friendbot_handler.go
@@ -4,7 +4,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/stellar/go/clients/horizon"
+	hClient "github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/strkey"
 	"github.com/stellar/go/support/render/hal"
 	"github.com/stellar/go/support/render/problem"
@@ -27,7 +28,7 @@ func (handler *FriendbotHandler) Handle(w http.ResponseWriter, r *http.Request) 
 }
 
 // doHandle is just a convenience method that returns the object to be rendered
-func (handler *FriendbotHandler) doHandle(r *http.Request) (*horizon.TransactionSuccess, error) {
+func (handler *FriendbotHandler) doHandle(r *http.Request) (*hProtocol.TransactionSuccess, error) {
 	err := handler.checkEnabled()
 	if err != nil {
 		return nil, err
@@ -70,13 +71,13 @@ func (handler *FriendbotHandler) loadAddress(r *http.Request) (string, error) {
 	return unescaped, err
 }
 
-func (handler *FriendbotHandler) loadResult(address string) (*horizon.TransactionSuccess, error) {
+func (handler *FriendbotHandler) loadResult(address string) (*hProtocol.TransactionSuccess, error) {
 	result, err := handler.Friendbot.Pay(address)
 	switch e := err.(type) {
-	case horizon.Error:
-		return result, e.Problem.ToProblem()
-	case *horizon.Error:
-		return result, e.Problem.ToProblem()
+	case hClient.Error:
+		return result, e.Problem
+	case *hClient.Error:
+		return result, e.Problem
 	}
 	return result, err
 }

--- a/services/friendbot/internal/friendbot_test.go
+++ b/services/friendbot/internal/friendbot_test.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"testing"
 
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/protocols/horizon"
 	"github.com/stretchr/testify/assert"
 
 	"sync"


### PR DESCRIPTION
This is work in progress. It will break any application that currently depends on the horizon go client.
This also modifies friendbot and the compliance server to work with the new resources.

Remaining work:
- [ ] **Figure out dependency versioning**
- [ ] Replace various Page structs (`OffersPage`, `TradesPage`, etc.) with  `hal.Page`
- [ ] Get rid of `Payment` struct
- [ ] Extract `Error` struct (?)  