### PR TITLE
Add seperate streaming page to api reference w/ endpoints list

### DIFF
--- a/services/horizon/internal/docs/reference/endpoints/effects-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/effects-all.md
@@ -6,7 +6,7 @@ clientData:
 
 This endpoint represents all [effects](../resources/effect.md).
 
-This endpoint can also be used in [streaming](../responses.md#streaming) mode so it is possible to use it to listen for new effects as transactions happen in the Stellar network.
+This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to listen for new effects as transactions happen in the Stellar network.
 If called in streaming mode Horizon will start at the earliest known effect unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream effects created since your request time.
 
 ## Request

--- a/services/horizon/internal/docs/reference/endpoints/effects-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/effects-for-account.md
@@ -6,7 +6,7 @@ clientData:
 
 This endpoint represents all [effects](../resources/effect.md) that changed a given [account](../resources/account.md). It will return relevant effects from the creation of the account to the current ledger.
 
-This endpoint can also be used in [streaming](../responses.md#streaming) mode so it is possible to use it to listen for new effects as transactions happen in the Stellar network.
+This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to listen for new effects as transactions happen in the Stellar network.
 If called in streaming mode Horizon will start at the earliest known effect unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream effects created since your request time.
 
 ## Request

--- a/services/horizon/internal/docs/reference/endpoints/ledgers-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/ledgers-all.md
@@ -5,7 +5,7 @@ clientData:
 ---
 
 This endpoint represents all [ledgers](../resources/ledger.md).
-This endpoint can also be used in [streaming](../responses.md#streaming) mode so it is possible to use it to get notifications as ledgers are closed by the Stellar network.
+This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to get notifications as ledgers are closed by the Stellar network.
 If called in streaming mode Horizon will start at the earliest known ledger unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream ledgers created since your request time.
 
 ## Request

--- a/services/horizon/internal/docs/reference/endpoints/offers-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/offers-for-account.md
@@ -5,7 +5,8 @@ clientData:
 ---
 
 People on the Stellar network can make [offers](../resources/offer.md) to buy or sell assets.  This endpoint represents all the offers a particular account makes.
-
+This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to listen as offers are processed in the Stellar network.
+If called in streaming mode Horizon will start at the earliest known offer unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream offers created since your request time.
 
 ## Request
 

--- a/services/horizon/internal/docs/reference/endpoints/operations-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/operations-all.md
@@ -5,7 +5,7 @@ clientData:
 ---
 
 This endpoint represents all [operations](../resources/operation.md) that are part of validated [transactions](../resources/transaction.md).
-This endpoint can also be used in [streaming](../responses.md#streaming) mode so it is possible to use it to listen as operations are processed in the Stellar network.
+This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to listen as operations are processed in the Stellar network.
 If called in streaming mode Horizon will start at the earliest known operation unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream operations created since your request time.
 
 ## Request

--- a/services/horizon/internal/docs/reference/endpoints/operations-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/operations-for-account.md
@@ -6,7 +6,7 @@ clientData:
 
 This endpoint represents all [operations](../resources/operation.md) that were included in valid [transactions](../resources/transaction.md) that affected a particular [account](../resources/account.md).
 
-This endpoint can also be used in [streaming](../responses.md#streaming) mode so it is possible to use it to listen for new operations that affect a given account as they happen.
+This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to listen for new operations that affect a given account as they happen.
 If called in streaming mode Horizon will start at the earliest known operation unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream operations created since your request time.
 
 ## Request

--- a/services/horizon/internal/docs/reference/endpoints/orderbook-details.md
+++ b/services/horizon/internal/docs/reference/endpoints/orderbook-details.md
@@ -8,6 +8,9 @@ People on the Stellar network can make [offers](../resources/offer.md) to buy or
 
 Horizon will return, for each orderbook, a summary of the orderbook and the bids and asks associated with that orderbook.
 
+This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to listen as offers are processed in the Stellar network.
+If called in streaming mode Horizon will start at the earliest known offer unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream offers created since your request time.
+
 ## Request
 
 ```

--- a/services/horizon/internal/docs/reference/endpoints/payments-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/payments-all.md
@@ -4,7 +4,7 @@ clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=payments&endpoint=all
 ---
 
-This endpoint represents all payment [operations](../resources/operation.md) that are part of validated [transactions](../resources/transaction.md). This endpoint can also be used in [streaming](../responses.md#streaming) mode so it is possible to use it to listen for new payments as they get made in the Stellar network.
+This endpoint represents all payment [operations](../resources/operation.md) that are part of validated [transactions](../resources/transaction.md). This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to listen for new payments as they get made in the Stellar network.
 If called in streaming mode Horizon will start at the earliest known payment unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream payments created since your request time.
 
 ## Request

--- a/services/horizon/internal/docs/reference/endpoints/payments-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/payments-for-account.md
@@ -6,7 +6,7 @@ clientData:
 
 This endpoint responds with a collection of [Payment operations](../resources/operation.md) where the given [account](../resources/account.md) was either the sender or receiver.
 
-This endpoint can also be used in [streaming](../responses.md#streaming) mode so it is possible to use it to listen for new payments to or from an account as they get made in the Stellar network.
+This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to listen for new payments to or from an account as they get made in the Stellar network.
 If called in streaming mode Horizon will start at the earliest known payment unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream payments created since your request time.
 
 ## Request

--- a/services/horizon/internal/docs/reference/endpoints/transactions-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/transactions-all.md
@@ -5,7 +5,7 @@ clientData:
 ---
 
 This endpoint represents all validated [transactions](../resources/transaction.md).
-This endpoint can also be used in [streaming](../responses.md#streaming) mode. This makes it possible to use it to listen for new transactions as they get made in the Stellar network.
+This endpoint can also be used in [streaming](../streaming.md) mode. This makes it possible to use it to listen for new transactions as they get made in the Stellar network.
 If called in streaming mode Horizon will start at the earliest known transaction unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream transaction created since your request time.
 
 ## Request

--- a/services/horizon/internal/docs/reference/endpoints/transactions-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/transactions-for-account.md
@@ -5,7 +5,7 @@ clientData:
 ---
 
 This endpoint represents all [transactions](../resources/transaction.md) that affected a given [account](../resources/account.md).
-This endpoint can also be used in [streaming](../responses.md#streaming) mode so it is possible to use it to listen for new transactions as that affect a given account as they get made in the Stellar network.
+This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to listen for new transactions as that affect a given account as they get made in the Stellar network.
 If called in streaming mode Horizon will start at the earliest known transaction unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream transaction created since your request time.
 
 ## Request

--- a/services/horizon/internal/docs/reference/responses.md
+++ b/services/horizon/internal/docs/reference/responses.md
@@ -73,7 +73,3 @@ Read more about paging in following docs:
 - [Page](../reference/resources/page.md)
 - [Paging](./paging.md)
 
-## Streaming
-
-Certain endpoints in Horizon can be called in streaming mode using Server-Sent Events. This mode will keep the connection to horizon open and horizon will continue to return responses as ledgers close. All parameters for the endpoints that allow this mode are the same. The way a caller initiates this mode is by setting `Accept: text/event-stream` in the HTTP header when you make the request.
-You can read an example of using the streaming mode in the [Follow Received Payments](./tutorials/follow-received-payments.md) tutorial.

--- a/services/horizon/internal/docs/reference/streaming.md
+++ b/services/horizon/internal/docs/reference/streaming.md
@@ -1,0 +1,17 @@
+---
+title: Streaming
+---
+
+## Streaming
+
+Certain endpoints in Horizon can be called in streaming mode using Server-Sent Events. This mode will keep the connection to horizon open and horizon will continue to return responses as ledgers close. All parameters for the endpoints that allow this mode are the same. The way a caller initiates this mode is by setting `Accept: text/event-stream` in the HTTP header when you make the request.
+You can read an example of using the streaming mode in the [Follow Received Payments](./tutorials/follow-received-payments.md) tutorial.
+
+Endpoints that currently support streaming:
+* [Effects](./endpoints/effects-all.md)
+* [Ledgers](./endpoints/ledgers-all.md)
+* [Offers](./endpoints/offers-for-account.md)
+* [Operations](./endpoints/operations-all.md)
+* [Orderbook](./endpoints/orderbook-details.md)
+* [Payments](./endpoints/payments-all.md)
+* [Transactions](./endpoints/transactions-all.md)


### PR DESCRIPTION
Closes #362 

I created a completely new streaming page where I copy-pasta what we had before and then add a bullet-list of endpoints that support streaming.

This may break some links/references that refer to the old streaming paragraph in the response.md. I found all those references within the horizon docs (and docs within the monorepo).

Besides those, these are the only known links that will break that I have found so far:  
* [Reference in JS SDK](https://github.com/stellar/js-stellar-sdk/blob/6fc33fc6f2e9b93818c69046c99a41d454331836/docs/reference/readme.md
)