### PR TITLE
Removed goji from glide.yaml+glide.lock

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -131,9 +131,6 @@ imports:
   repo: https://github.com/go-sql-driver/mysql
 - name: github.com/go-stack/stack
   version: 817915b46b97fd7bb80e8ab6b69f01a53ac3eebf
-- name: github.com/goji/context
-  version: cc5d214cefa9d50beb2cdbf2344eb8c4bd14709b
-  repo: https://github.com/goji/context
 - name: github.com/golang/groupcache
   version: 604ed5785183e59ae2789449d89e73f3a2a77987
   repo: https://github.com/golang/groupcache
@@ -382,22 +379,6 @@ imports:
 - name: github.com/yudai/golcs
   version: d1c525dea8ce39ea9a783d33cf08932305373f2c
   repo: https://github.com/yudai/golcs
-- name: github.com/zenazn/goji
-  version: bf843a174a08e846246b8945f8a9a853d84a256a
-  repo: https://github.com/zenazn/goji
-  subpackages:
-  - bind
-  - graceful
-  - web
-  - web/middleware
-  - web/mutil
-- name: goji.io
-  version: e355964ac565b94cf0fc7f218346626529125086
-  repo: https://github.com/goji/goji
-  subpackages:
-  - internal
-  - pat
-  - pattern
 - name: golang.org/x/crypto
   version: 1f22c0103821b9390939b6776727195525381532
   repo: https://go.googlesource.com/crypto

--- a/glide.yaml
+++ b/glide.yaml
@@ -52,9 +52,6 @@ import:
 - package: github.com/rs/cors
   version: a62a804a8a009876ca59105f7899938a1349f4b3
   repo: https://github.com/rs/cors
-- package: goji.io
-  version: e355964ac565b94cf0fc7f218346626529125086
-  repo: https://github.com/goji/goji
 - package: github.com/asaskevich/govalidator
   repo: https://github.com/stellar/govalidator.git
 - package: github.com/BurntSushi/toml
@@ -129,9 +126,6 @@ import:
 - package: github.com/go-ini/ini
   version: 6f66b0e091edb3c7b380f7c4f0f884274d550b67
   repo: https://github.com/go-ini/ini
-- package: github.com/goji/context
-  version: cc5d214cefa9d50beb2cdbf2344eb8c4bd14709b
-  repo: https://github.com/goji/context
 - package: github.com/golang/groupcache
   version: 604ed5785183e59ae2789449d89e73f3a2a77987
   repo: https://github.com/golang/groupcache
@@ -260,15 +254,6 @@ import:
 - package: github.com/yudai/golcs
   version: d1c525dea8ce39ea9a783d33cf08932305373f2c
   repo: https://github.com/yudai/golcs
-- package: github.com/zenazn/goji
-  version: bf843a174a08e846246b8945f8a9a853d84a256a
-  repo: https://github.com/zenazn/goji
-  subpackages:
-  - bind
-  - graceful
-  - web
-  - web/middleware
-  - web/mutil
 - package: golang.org/x/crypto
   version: 1f22c0103821b9390939b6776727195525381532
   repo: https://go.googlesource.com/crypto


### PR DESCRIPTION
Did a search through the repo and saw `goji` is no longer used anywhere, so I removed it from the glide.yaml and glide.lock.

`Good bye goji, you will be missed `