### PR TITLE
Fix validating optional structs

### DIFF
--- a/services/compliance/main.go
+++ b/services/compliance/main.go
@@ -29,10 +29,7 @@ type Config struct {
 		AskUser     string `valid:"url,optional" toml:"ask_user"`
 		GetUserData string `valid:"url,optional" toml:"get_user_data"`
 	} `valid:"optional"`
-	TLS struct {
-		CertificateFile string `valid:"required" toml:"certificate_file"`
-		PrivateKeyFile  string `valid:"required" toml:"private_key_file"`
-	} `valid:"required"`
+	TLS *config.TLS `valid:"optional"`
 }
 
 func main() {
@@ -76,8 +73,7 @@ func run(cmd *cobra.Command, args []string) {
 	http.Run(http.Config{
 		ListenAddr: addr,
 		Handler:    mux,
-		TLSCert:    cfg.TLS.CertificateFile,
-		TLSKey:     cfg.TLS.PrivateKeyFile,
+		TLS:        cfg.TLS,
 		OnStarting: func() {
 			log.Infof("starting compliance server - %s", app.Version())
 			log.Infof("listening on %s", addr)

--- a/services/federation/main.go
+++ b/services/federation/main.go
@@ -26,7 +26,7 @@ type Config struct {
 		Federation        string `valid:"required"`
 		ReverseFederation string `toml:"reverse-federation" valid:"optional"`
 	} `valid:"required"`
-	TLS config.TLS `valid:"optional"`
+	TLS *config.TLS `valid:"optional"`
 }
 
 func main() {
@@ -76,8 +76,7 @@ func run(cmd *cobra.Command, args []string) {
 	http.Run(http.Config{
 		ListenAddr: addr,
 		Handler:    mux,
-		TLSCert:    cfg.TLS.CertificateFile,
-		TLSKey:     cfg.TLS.PrivateKeyFile,
+		TLS:        cfg.TLS,
 		OnStarting: func() {
 			log.Infof("starting federation server - %s", app.Version())
 			log.Infof("listening on %s", addr)

--- a/services/friendbot/main.go
+++ b/services/friendbot/main.go
@@ -19,12 +19,12 @@ import (
 
 // Config represents the configuration of a friendbot server
 type Config struct {
-	Port              int        `toml:"port" valid:"required"`
-	FriendbotSecret   string     `toml:"friendbot_secret" valid:"required"`
-	NetworkPassphrase string     `toml:"network_passphrase" valid:"required"`
-	HorizonURL        string     `toml:"horizon_url" valid:"required"`
-	StartingBalance   string     `toml:"starting_balance" valid:"required"`
-	TLS               config.TLS `valid:"optional"`
+	Port              int         `toml:"port" valid:"required"`
+	FriendbotSecret   string      `toml:"friendbot_secret" valid:"required"`
+	NetworkPassphrase string      `toml:"network_passphrase" valid:"required"`
+	HorizonURL        string      `toml:"horizon_url" valid:"required"`
+	StartingBalance   string      `toml:"starting_balance" valid:"required"`
+	TLS               *config.TLS `valid:"optional"`
 }
 
 func main() {
@@ -67,8 +67,7 @@ func run(cmd *cobra.Command, args []string) {
 	http.Run(http.Config{
 		ListenAddr: addr,
 		Handler:    router,
-		TLSCert:    cfg.TLS.CertificateFile,
-		TLSKey:     cfg.TLS.PrivateKeyFile,
+		TLS:        cfg.TLS,
 		OnStarting: func() {
 			log.Infof("starting friendbot server - %s", app.Version())
 			log.Infof("listening on %s", addr)

--- a/support/http/main.go
+++ b/support/http/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/stellar/go/support/config"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
 	"golang.org/x/net/http2"
@@ -36,8 +37,7 @@ const DefaultShutdownGracePeriod = 10 * time.Second
 type Config struct {
 	Handler             stdhttp.Handler
 	ListenAddr          string
-	TLSCert             string
-	TLSKey              string
+	TLS                 *config.TLS
 	ShutdownGracePeriod time.Duration
 	OnStarting          func()
 	OnStopping          func()
@@ -59,8 +59,8 @@ func Run(conf Config) {
 	}
 
 	var err error
-	if conf.TLSCert != "" {
-		err = srv.ListenAndServeTLS(conf.TLSCert, conf.TLSKey)
+	if conf.TLS != nil {
+		err = srv.ListenAndServeTLS(conf.TLS.CertificateFile, conf.TLS.PrivateKeyFile)
 	} else {
 		err = srv.ListenAndServe()
 	}


### PR DESCRIPTION
Validating optional structs like this:
```go
 type Config struct {
	TLS config.TLS `valid:"optional"`
 }
```
is broken after merging: https://github.com/stellar/go/pull/484. It reports errors:
```
ERRO[0000] config file: invalid fields: PrivateKeyFile,CertificateFile  pid=60167
```
even when there is no `[tls]` section in a config file.

I tried to check [diff](https://github.com/stellar/govalidator/compare/f0666aa80d7dcf75bd564ae8717b952d74a29d6a...asaskevich:7d2e70ef918f16bd6455529af38304d6d025c952) between our fork and `asaskevich/govalidator` master branch but couldn't find anything related. Instead, I changed all `config.TLS` to pointers: `*config.TLS`. Also changed `http.Config` so no `nil` checks are needed when using it.