### PR TITLE
[Trade API] If one of asset_type is missing, return 400 instead of 500

### DIFF
--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -59,7 +59,18 @@ func (action *TradeIndexAction) loadRecords() {
 
 	// If both assets are provided, or no assets are provided, the API call should work
 	if (action.HasBaseAssetFilter != action.HasCounterAssetFilter) {
-		action.SetInvalidField("asset_type", errors.New("this endpoint supports asset pairs but only one asset supplied"))
+		if (!action.HasBaseAssetFilter) {
+			action.SetInvalidField(
+			"base_asset_type", errors.New("invalid asset type: was not one of 'native', 'credit_alphanum4', 'credit_alphanum12'"),
+			);
+		}
+
+		if (!action.HasCounterAssetFilter) {
+			action.SetInvalidField(
+				"counter_asset_type", errors.New("invalid asset type: was not one of 'native', 'credit_alphanum4', 'credit_alphanum12'"),
+			);
+		}
+
 		return
 	}
 

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -57,6 +57,12 @@ func (action *TradeIndexAction) loadRecords() {
 		trades.ForAccount(action.AccountFilter)
 	}
 
+	if (action.HasBaseAssetFilter != action.HasCounterAssetFilter) {
+		action.SetInvalidField("asset_type", errors.New("this endpoint supports asset pairs but only one asset supplied"))
+		//action.Err = errors.New("this endpoint supports asset pairs but only one asset supplied")
+		return
+	}
+
 	if action.HasBaseAssetFilter {
 
 		baseAssetId, err := action.HistoryQ().GetAssetID(action.BaseAssetFilter)
@@ -73,9 +79,6 @@ func (action *TradeIndexAction) loadRecords() {
 				return
 			}
 			trades = action.HistoryQ().TradesForAssetPair(baseAssetId, counterAssetId)
-		} else {
-			action.Err = errors.New("this endpoint supports asset pairs but only one asset supplied")
-			return
 		}
 	}
 

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -57,7 +57,7 @@ func (action *TradeIndexAction) loadRecords() {
 		trades.ForAccount(action.AccountFilter)
 	}
 
-	// If both assets are provided, or no assets are provided, the API call should work
+	// If only one of the asset pair is provided, invalid parameter for request
 	if (action.HasBaseAssetFilter != action.HasCounterAssetFilter) {
 		if (!action.HasBaseAssetFilter) {
 			action.SetInvalidField(
@@ -74,6 +74,8 @@ func (action *TradeIndexAction) loadRecords() {
 		return
 	}
 
+	// For Trades endpoint, both assets should be provided
+	// For All Trades endpoint, none of the assets are needed
 	if action.HasBaseAssetFilter {
 
 		baseAssetId, err := action.HistoryQ().GetAssetID(action.BaseAssetFilter)

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -57,9 +57,9 @@ func (action *TradeIndexAction) loadRecords() {
 		trades.ForAccount(action.AccountFilter)
 	}
 
+	// If both assets are provided, or no assets are provided, the API call should work
 	if (action.HasBaseAssetFilter != action.HasCounterAssetFilter) {
 		action.SetInvalidField("asset_type", errors.New("this endpoint supports asset pairs but only one asset supplied"))
-		//action.Err = errors.New("this endpoint supports asset pairs but only one asset supplied")
 		return
 	}
 

--- a/services/horizon/internal/actions_trade_test.go
+++ b/services/horizon/internal/actions_trade_test.go
@@ -336,6 +336,19 @@ func TestTradeActions_IndexRegressions(t *testing.T) {
 		w = ht.Get("/trades")
 		ht.Assert.Equal(200, w.Code, "nil-price trades failed")
 	})
+
+	t.Run("Regression for https://github.com/stellar/go/issues/466", func(t *testing.T) {
+		ht := StartHTTPTest(t, "trades")
+		defer ht.Finish()
+
+		var q = make(url.Values)
+		q.Add("base_asset_code", "EUR")
+		q.Add("base_asset_issuer", "GCQPYGH4K57XBDENKKX55KDTWOTK5WDWRQOH2LHEDX3EKVIQRLMESGBG")
+		q.Add("counter_asset_type", "native")
+
+		w := ht.Get("/trades?" + q.Encode())
+		ht.Assert.Equal(400, w.Code)
+	})
 }
 
 // TestTradeActions_AggregationOrdering checks that open/close aggregation


### PR DESCRIPTION
http://localhost:8000/trades?base_asset_type=native&counter_asset_code=CMA&counter_asset_issuer=GBWZHAVWY23QKKDJW7TXLSIHY5EX4NIB37O4NMRKN2SKNWOSE5TEPCY3&start_time=1525444269552&end_time=1526308269552&resolution=300000

Or 

http://localhost:8000/trades?counter_asset_type=native&base_asset_code=CMA&base_asset_issuer=GBWZHAVWY23QKKDJW7TXLSIHY5EX4NIB37O4NMRKN2SKNWOSE5TEPCY3&start_time=1525444269552&end_time=1526308269552&resolution=300000

```
{
  "type": "https://stellar.org/horizon-errors/server_error",
  "title": "Internal Server Error",
  "status": 500,
  "detail": "An error occurred while processing this request.  This is usually due to a bug within the server software.  Trying this request again may succeed if the bug is transient, otherwise please report this issue to the issue tracker at: https://github.com/stellar/go/services/horizon/internal/issues. Please include this response in your issue."
}
```

After code change:

```
{
  "type": "https://stellar.org/horizon-errors/bad_request",
  "title": "Bad Request",
  "status": 400,
  "detail": "The request you sent was invalid in some way",
  "extras": {
    "invalid_field": "asset_type",
    "reason": "this endpoint supports asset pairs but only one asset supplied"
  }
}
```

This will always return correctly:
http://localhost:8000/trades?base_asset_type=native&counter_asset_type=credit_alphanum4&counter_asset_code=CMA&counter_asset_issuer=GBWZHAVWY23QKKDJW7TXLSIHY5EX4NIB37O4NMRKN2SKNWOSE5TEPCY3&start_time=1525444269552&end_time=1526308269552&resolution=300000

Close #466 