### PR TITLE
findpaths: simplify simplepath/order_book.go and fix order_book_test.go

### DIFF
--- a/services/horizon/internal/simplepath/order_book_test.go
+++ b/services/horizon/internal/simplepath/order_book_test.go
@@ -24,32 +24,33 @@ func TestOrderBook(t *testing.T) {
 		Q: &core.Q{Session: tt.CoreSession()},
 	}
 
-	r, err := ob.Cost(ob.Buying, 10000000)
-	if tt.Assert.NoError(err) {
-		tt.Assert.Equal(xdr.Int64(10000000), r)
+	testCases := []struct {
+		scenario    string
+		eur         int64
+		wantCostUSD int64
+	}{
+		{"first unit", 2, 1},                                // taking from the first offer, where the price is 0.25 (i.e. offer to sell 4 EUR for 1 USD)
+		{"first full offer", 100000000, 50000000},           // taking all from first offer (p=0.25)
+		{"first full offer + 1", 100000002, 50000001},       // taking all from first offer (p=0.25), and first full unit of second offer (p=0.5)
+		{"first two full offers", 200000000, 100000000},     // taking all from first two offers (p=0.25, p=0.5)
+		{"first two full offers + 1", 200000001, 100000001}, // taking all from first two offers (p=0.25, p=0.5), and first full unit of third offer (p=1.0)
+		{"first three full offers", 300000000, 200000000},   // taking all from first three offers (p=0.25, p=0.5, p = 1.0)
 	}
 
-	// this cost should consume the entire lowest priced order, whose price
-	// is 1.0, thus the output should be the same
-	r, err = ob.Cost(ob.Buying, 100000000)
-	if tt.Assert.NoError(err) {
-		tt.Assert.Equal(xdr.Int64(100000000), r)
+	for _, kase := range testCases {
+		t.Run(kase.scenario, func(t *testing.T) {
+			r, err := ob.CostToConsumeLiquidity(xdr.Int64(kase.eur))
+			if tt.Assert.NoError(err) {
+				tt.Assert.Equal(xdr.Int64(kase.wantCostUSD), r)
+			}
+		})
 	}
 
-	// now we are taking from the next offer, where the price is 2.0
-	r, err = ob.Cost(ob.Buying, 100000001)
-	if tt.Assert.NoError(err) {
-		tt.Assert.Equal(xdr.Int64(100000002), r)
-	}
-
-	r, err = ob.Cost(ob.Buying, 500000000)
-	if tt.Assert.NoError(err) {
-		tt.Assert.Equal(xdr.Int64(900000000), r)
-	}
-
-	_, err = ob.Cost(ob.Buying, 500000001)
-	tt.Assert.Error(err)
-
+	// taking 1 more than there is available
+	t.Run("one more than available liquidity", func(t *testing.T) {
+		_, err := ob.CostToConsumeLiquidity(xdr.Int64(300000001))
+		tt.Assert.Error(err)
+	})
 }
 
 func TestOrderBook_BadCost(t *testing.T) {
@@ -68,8 +69,8 @@ func TestOrderBook_BadCost(t *testing.T) {
 		Q: &core.Q{Session: tt.CoreSession()},
 	}
 
-	r, err := ob.Cost(ob.Buying, 10000000)
+	r, err := ob.CostToConsumeLiquidity(2000000000)
 	if tt.Assert.NoError(err) {
-		tt.Assert.Equal(xdr.Int64(2000000000), r)
+		tt.Assert.Equal(xdr.Int64(10000000), r)
 	}
 }

--- a/services/horizon/internal/simplepath/path.go
+++ b/services/horizon/internal/simplepath/path.go
@@ -78,7 +78,7 @@ func (p *pathNode) Cost(amount xdr.Int64) (result xdr.Int64, err error) {
 
 	for cur.Tail != nil {
 		ob := cur.OrderBook()
-		result, err = ob.Cost(cur.Tail.Asset, result)
+		result, err = ob.CostToConsumeLiquidity(result)
 		if err != nil {
 			return
 		}
@@ -120,8 +120,8 @@ func (p *pathNode) OrderBook() *orderBook {
 	}
 
 	return &orderBook{
-		Selling: p.Tail.Asset,
-		Buying:  p.Asset,
+		Selling: p.Tail.Asset, // offer is selling this asset
+		Buying:  p.Asset,      // offer is buying this asset
 		Q:       p.Q,
 	}
 }


### PR DESCRIPTION
order_book.go was very confusing as it was not very clear as to what it did.

That orderbook struct is essentially a one-way orderbook that is selling an asset to you. I've updated the struct and functions to represent that --it's also the only way we use it in production.
The test was not testing that codepath, now it does.

The name for the function has changed from `Cost` to `CostToConsumeLiquidity` along with clear explanations of what it does. The tests have also been updated to use the case based approach with subtests.