### PR TITLE
findpaths: clean up path.go and add caching to cost for pathNode

### DIFF
--- a/services/horizon/internal/paths/dummy_finder.go
+++ b/services/horizon/internal/paths/dummy_finder.go
@@ -36,7 +36,11 @@ type DummyPath struct {
 	path        []xdr.Asset
 }
 
+// check interface compatibility
+var _ Path = DummyPath{}
+
 func (d DummyPath) Source() xdr.Asset                        { return d.source }
 func (d DummyPath) Destination() xdr.Asset                   { return d.destination }
 func (d DummyPath) Path() []xdr.Asset                        { return d.path }
 func (d DummyPath) Cost(amount xdr.Int64) (xdr.Int64, error) { return amount, nil }
+func (d DummyPath) CachedCost(amount xdr.Int64) *xdr.Int64   { return nil }

--- a/services/horizon/internal/paths/main.go
+++ b/services/horizon/internal/paths/main.go
@@ -21,6 +21,8 @@ type Path interface {
 	// Cost returns an amount (which may be estimated), delimited in the Source assets
 	// that is suitable for use as the `sendMax` field for a `PathPaymentOp` struct.
 	Cost(amount xdr.Int64) (xdr.Int64, error)
+	// returns a cached version of the cost, return nil if not cached for the amount
+	CachedCost(amount xdr.Int64) *xdr.Int64
 }
 
 // Finder finds paths.

--- a/services/horizon/internal/simplepath/path.go
+++ b/services/horizon/internal/simplepath/path.go
@@ -67,15 +67,14 @@ func (p *pathNode) Path() []xdr.Asset {
 	return path[1 : len(path)-1]
 }
 
+func (p *pathNode) init() {
+	p.costCache = make(map[xdr.Int64]xdr.Int64)
+}
+
 // Cost implements the paths.Path.Cost interface method
 func (p *pathNode) Cost(amount xdr.Int64) (xdr.Int64, error) {
 	if p.costCache == nil {
-		p.costCache = make(map[xdr.Int64]xdr.Int64)
-	}
-
-	if p.Tail == nil {
-		p.costCache[amount] = amount
-		return amount, nil
+		p.init()
 	}
 
 	result := amount

--- a/services/horizon/internal/simplepath/path.go
+++ b/services/horizon/internal/simplepath/path.go
@@ -67,51 +67,45 @@ func (p *pathNode) Path() []xdr.Asset {
 }
 
 // Cost implements the paths.Path.Cost interface method
-func (p *pathNode) Cost(amount xdr.Int64) (result xdr.Int64, err error) {
-	result = amount
-
+func (p *pathNode) Cost(amount xdr.Int64) (xdr.Int64, error) {
 	if p.Tail == nil {
-		return
+		return amount, nil
 	}
 
+	result := amount
+	var err error
 	cur := p
-
 	for cur.Tail != nil {
 		ob := cur.OrderBook()
 		result, err = ob.CostToConsumeLiquidity(result)
 		if err != nil {
-			return
+			return result, err
 		}
 		cur = cur.Tail
 	}
-
-	return
+	return result, nil
 }
 
 // Depth returns the length of the list
 func (p *pathNode) Depth() int {
 	depth := 0
 	cur := p
-	for {
-		if cur == nil {
-			return depth
-		}
+	for cur != nil {
 		cur = cur.Tail
 		depth++
 	}
+	return depth
 }
 
 // Flatten walks the list and returns a slice of assets
-func (p *pathNode) Flatten() (result []xdr.Asset) {
+func (p *pathNode) Flatten() []xdr.Asset {
+	result := []xdr.Asset{}
 	cur := p
-
-	for {
-		if cur == nil {
-			return
-		}
+	for cur != nil {
 		result = append(result, cur.Asset)
 		cur = cur.Tail
 	}
+	return result
 }
 
 func (p *pathNode) OrderBook() *orderBook {

--- a/services/horizon/internal/simplepath/path_test.go
+++ b/services/horizon/internal/simplepath/path_test.go
@@ -1,0 +1,45 @@
+package simplepath
+
+import (
+	"testing"
+
+	"github.com/stellar/go/services/horizon/internal/db2/core"
+	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/xdr"
+)
+
+func TestCachedCost(t *testing.T) {
+	tt := test.Start(t).Scenario("paths")
+	defer tt.Finish()
+
+	eur := makeAsset(
+		xdr.AssetTypeAssetTypeCreditAlphanum4,
+		"EUR",
+		"GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+	)
+
+	p := pathNode{
+		Asset: eur,
+		Tail:  nil,
+		Q:     &core.Q{Session: tt.CoreSession()},
+	}
+	p.init()
+
+	// when we first run there should be no value
+	if !tt.Assert.Nil(p.CachedCost(xdr.Int64(100))) {
+		return
+	}
+
+	// run the cost function
+	cost, err := p.Cost(xdr.Int64(100))
+	if !tt.Assert.Nil(err) {
+		return
+	}
+	tt.Assert.Equal(xdr.Int64(100), cost)
+
+	// now the same CachedCost call should yield a result
+	cachedCost := p.CachedCost(xdr.Int64(100))
+	if tt.Assert.NotNil(cachedCost) {
+		tt.Assert.Equal(xdr.Int64(100), *cachedCost)
+	}
+}

--- a/services/horizon/internal/simplepath/search.go
+++ b/services/horizon/internal/simplepath/search.go
@@ -95,9 +95,9 @@ func (s *search) isTarget(id string) bool {
 	return found
 }
 
-// visit returns true if the asset id provided has not been
+// shouldVisit returns true if the asset id provided has not been
 // visited on this search, after marking the id as visited
-func (s *search) visit(id string) bool {
+func (s *search) shouldVisit(id string) bool {
 	if _, found := s.visited[id]; found {
 		return false
 	}
@@ -116,7 +116,7 @@ func (s *search) runOnce() {
 		s.Results = append(s.Results, cur)
 	}
 
-	if !s.visit(id) {
+	if !s.shouldVisit(id) {
 		return
 	}
 


### PR DESCRIPTION
we were running Cost() twice, once when finding the paths and again when we wanted to compute the actual costs of the path -- this needs to be run only once. I've added a CachedCost() function to the Path API to facilitate this.