### PR TITLE
findpaths rounding fix: renamed order_book#mul to convertToBuyingUnits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
 addons:
   postgresql: '9.4'
 go:
-- '1.8'
 - '1.9'
 - '1.10'
 - tip

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -17,6 +17,7 @@ bumps.  A breaking change will get clearly notified in this log.
 - BREAKING CHANGE: Streaming connections will no longer wait until the first SSE message before sending the SSE preamble and establishing the streaming connection.
 - BREAKING CHANGE: SSE requests will no longer respond with regular HTTP error (i.e. a non-200 status) if the error occurred prior to sending the first SSE message.
 - Above changes have been reverted in [#446](https://github.com/stellar/go/pull/446).
+- dropped support for go1.8 since we need big.IsInt64 from math/big in our findpaths calculations
 
 ## v0.12.3 - 2017-03-20
 

--- a/services/horizon/README.md
+++ b/services/horizon/README.md
@@ -19,7 +19,7 @@ Alternatively, you can [build](#building) the binary yourself.
 
 ## Dependencies
 
-Horizon requires go 1.8 or higher to build. See (https://golang.org/doc/install) for installation instructions.
+Horizon requires go 1.9 or higher to build. See (https://golang.org/doc/install) for installation instructions.
 
 ## Building
 

--- a/services/horizon/internal/simplepath/order_book_test.go
+++ b/services/horizon/internal/simplepath/order_book_test.go
@@ -110,3 +110,26 @@ func TestConvertToBuyingUnits(t *testing.T) {
 		})
 	}
 }
+
+func TestWillAddOverflow(t *testing.T) {
+	testCases := []struct {
+		a                int64
+		b                int64
+		wantWillOverflow bool
+	}{
+		{1, 2, false},
+		{0, 1, false},
+		{math.MaxInt64, 0, false},
+		{math.MaxInt64 - 1, 1, false},
+		{math.MaxInt64, 1, true},
+		{math.MaxInt64 - 1, 2, true},
+		{math.MaxInt64 - 1, math.MaxInt64, true},
+		{math.MaxInt64, math.MaxInt64, true},
+	}
+	for _, kase := range testCases {
+		t.Run(t.Name(), func(t *testing.T) {
+			r := willAddOverflow(kase.a, kase.b)
+			assert.Equal(t, kase.wantWillOverflow, r)
+		})
+	}
+}

--- a/services/horizon/internal/simplepath/order_book_test.go
+++ b/services/horizon/internal/simplepath/order_book_test.go
@@ -1,6 +1,7 @@
 package simplepath
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,19 +80,30 @@ func TestOrderBook_BadCost(t *testing.T) {
 
 func TestConvertToBuyingUnits(t *testing.T) {
 	testCases := []struct {
-		sellingUnits    int64
-		pricen          int64
-		priced          int64
-		wantBuyingUnits int64
+		sellingOfferAmount int64
+		sellingUnitsNeeded int64
+		pricen             int64
+		priced             int64
+		wantBuyingUnits    int64
+		wantSellingUnits   int64
 	}{
-		{20, 1, 4, 5},
-		{20, 7, 11, 13},
-		{20, 11, 7, 32},
+		{7, 2, 3, 7, 1, 2},
+		{math.MaxInt64, 2, 3, 7, 1, 2},
+		{20, 20, 1, 4, 5, 20},
+		{20, 100, 1, 4, 5, 20},
+		{20, 20, 7, 11, 13, 19},
+		{20, 20, 11, 7, 32, 20},
+		{20, 100, 7, 11, 13, 19},
+		{20, 100, 11, 7, 32, 20},
+		{1, 0, 3, 7, 0, 0},
+		{1, 0, 7, 3, 0, 0},
+		{math.MaxInt64, 0, 3, 7, 0, 0},
 	}
 	for _, kase := range testCases {
 		t.Run(t.Name(), func(t *testing.T) {
-			r := convertToBuyingUnits(kase.sellingUnits, kase.pricen, kase.priced)
-			assert.Equal(t, kase.wantBuyingUnits, r)
+			buyingUnits, sellingUnits := convertToBuyingUnits(kase.sellingOfferAmount, kase.sellingUnitsNeeded, kase.pricen, kase.priced)
+			assert.Equal(t, kase.wantBuyingUnits, buyingUnits)
+			assert.Equal(t, kase.wantSellingUnits, sellingUnits)
 		})
 	}
 }

--- a/services/horizon/internal/simplepath/order_book_test.go
+++ b/services/horizon/internal/simplepath/order_book_test.go
@@ -3,6 +3,8 @@ package simplepath
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/xdr"
@@ -72,5 +74,24 @@ func TestOrderBook_BadCost(t *testing.T) {
 	r, err := ob.CostToConsumeLiquidity(2000000000)
 	if tt.Assert.NoError(err) {
 		tt.Assert.Equal(xdr.Int64(10000000), r)
+	}
+}
+
+func TestConvertToBuyingUnits(t *testing.T) {
+	testCases := []struct {
+		sellingUnits    int64
+		pricen          int64
+		priced          int64
+		wantBuyingUnits int64
+	}{
+		{20, 1, 4, 5},
+		{20, 7, 11, 13},
+		{20, 11, 7, 32},
+	}
+	for _, kase := range testCases {
+		t.Run(t.Name(), func(t *testing.T) {
+			r := convertToBuyingUnits(kase.sellingUnits, kase.pricen, kase.priced)
+			assert.Equal(t, kase.wantBuyingUnits, r)
+		})
 	}
 }

--- a/services/horizon/internal/simplepath/order_book_test.go
+++ b/services/horizon/internal/simplepath/order_book_test.go
@@ -101,7 +101,10 @@ func TestConvertToBuyingUnits(t *testing.T) {
 	}
 	for _, kase := range testCases {
 		t.Run(t.Name(), func(t *testing.T) {
-			buyingUnits, sellingUnits := convertToBuyingUnits(kase.sellingOfferAmount, kase.sellingUnitsNeeded, kase.pricen, kase.priced)
+			buyingUnits, sellingUnits, e := convertToBuyingUnits(kase.sellingOfferAmount, kase.sellingUnitsNeeded, kase.pricen, kase.priced)
+			if !assert.Nil(t, e) {
+				return
+			}
 			assert.Equal(t, kase.wantBuyingUnits, buyingUnits)
 			assert.Equal(t, kase.wantSellingUnits, sellingUnits)
 		})


### PR DESCRIPTION
updated the multiplication logic for findpaths which now uses the rounding formula specified in the orderbook doc.

included test for this function