### PR TITLE
Update Horizon API compatibility table with Java SDK 0.2.1

### DIFF
--- a/protocols/horizon/README.md
+++ b/protocols/horizon/README.md
@@ -14,7 +14,7 @@ For each new version we will only track changes from the previous version.
 | Resource                                      | Changes                                      | Go SDK <sup>1</sup>            | JS SDK             | Java SDK                                          |
 |:----------------------------------------------|:---------------------------------------------|:-------------------------------|:-------------------|:--------------------------------------------------|
 | **0.12.3**                                    |                                              |                                |                    |                                                   |
-| `GET /`                                       |                                              | +<br />(some `_links` missing) | -                  | -                                                 |
+| `GET /`                                       |                                              | +<br />(some `_links` missing) | -                  | 0.2.1                                             |
 | `GET /metrics`                                |                                              | -                              | -                  | -                                                 |
 | `GET /ledgers`                                |                                              | -                              | 0.8.2              | 0.2.0                                             |
 | `GET /ledgers` SSE                            |                                              | +                              | 0.8.2              | 0.2.0                                             |
@@ -22,7 +22,7 @@ For each new version we will only track changes from the previous version.
 | `GET /ledgers/{ledger_id}/transactions`       |                                              | -                              | 0.8.2              | 0.2.0                                             |
 | `GET /ledgers/{ledger_id}/transactions` SSE   |                                              | -                              | 0.8.2              | 0.2.0                                             |
 | `GET /ledgers/{ledger_id}/operations`         |                                              | -                              | 0.8.2              | 0.2.0                                             |
-| `GET /ledgers/{ledger_id}/operations` SSE     |                                              | -                              | 0.8.2              | -                                                 |
+| `GET /ledgers/{ledger_id}/operations` SSE     |                                              | -                              | 0.8.2              | 0.2.1                                             |
 | `GET /ledgers/{ledger_id}/payments`           |                                              | -                              | 0.8.2              | 0.2.0                                             |
 | `GET /ledgers/{ledger_id}/payments` SSE       |                                              | -                              | 0.8.2              | 0.2.0                                             |
 | `GET /ledgers/{ledger_id}/effects`            |                                              | -                              | 0.8.2              | 0.2.0<br />(no support for data, inflation types) |
@@ -31,25 +31,25 @@ For each new version we will only track changes from the previous version.
 | `GET /accounts/{account_id}/transactions`     |                                              | -                              | 0.8.2              | 0.2.0                                             |
 | `GET /accounts/{account_id}/transactions` SSE |                                              | -                              | 0.8.2              | 0.2.0                                             |
 | `GET /accounts/{account_id}/operations`       |                                              | -                              | 0.8.2              | 0.2.0                                             |
-| `GET /accounts/{account_id}/operations` SSE   |                                              | -                              | 0.8.2              | -                                                 |
+| `GET /accounts/{account_id}/operations` SSE   |                                              | -                              | 0.8.2              | 0.2.1                                             |
 | `GET /accounts/{account_id}/payments`         |                                              | -                              | 0.8.2              | 0.2.0                                             |
 | `GET /accounts/{account_id}/payments` SSE     |                                              | -                              | 0.8.2              | 0.2.0                                             |
 | `GET /accounts/{account_id}/effects`          |                                              | -                              | 0.8.2              | 0.2.0<br />(no support for data, inflation types) |
 | `GET /accounts/{account_id}/effects` SSE      |                                              | -                              | 0.8.2              | 0.2.0<br />(no support for data, inflation types) |
 | `GET /accounts/{account_id}/offers`           |                                              | +                              | -                  | 0.2.0                                             |
-| `GET /accounts/{account_id}/trades`           |                                              | -                              | 0.8.2              | -                                                 |
+| `GET /accounts/{account_id}/trades`           |                                              | -                              | 0.8.2              | 0.2.1                                             |
 | `GET /accounts/{account_id}/data/{key}`       |                                              | -                              | -                  | -                                                 |
 | `POST /transactions`                          |                                              | -                              | 0.8.2              | 0.2.0                                             |
 | `GET /transactions`                           |                                              | +                              | 0.8.2              | 0.2.0                                             |
 | `GET /transactions` SSE                       |                                              | +                              | 0.8.2              | 0.2.0                                             |
 | `GET /transactions/{tx_id}`                   |                                              | +                              | 0.8.2              | 0.2.0                                             |
 | `GET /transactions/{tx_id}/operations`        |                                              | -                              | 0.8.2              | 0.2.0                                             |
-| `GET /transactions/{tx_id}/operations` SSE    |                                              | -                              | 0.8.2              | -                                                 |
+| `GET /transactions/{tx_id}/operations` SSE    |                                              | -                              | 0.8.2              | 0.2.1                                             |
 | `GET /transactions/{tx_id}/payments`          |                                              | -                              | 0.8.2              | 0.2.0                                             |
 | `GET /transactions/{tx_id}/effects`           |                                              | -                              | 0.8.2              | 0.2.0<br />(no support for data, inflation types) |
 | `GET /transactions/{tx_id}/effects` SSE       |                                              | -                              | 0.8.2              | 0.2.0<br />(no support for data, inflation types) |
 | `GET /operations`                             |                                              | -                              | 0.8.2              | 0.2.0                                             |
-| `GET /operations` SSE                         |                                              | -                              | 0.8.2              | -                                                 |
+| `GET /operations` SSE                         |                                              | -                              | 0.8.2              | 0.2.1                                             |
 | `GET /operations/{op_id}`                     |                                              | -                              | 0.8.2              | 0.2.0                                             |
 | `GET /operations/{op_id}/effects`             |                                              | -                              | 0.8.2              | 0.2.0<br />(no support for data, inflation types) |
 | `GET /operations/{op_id}/effects` SSE         |                                              | -                              | 0.8.2              | 0.2.0<br />(no support for data, inflation types) |
@@ -59,23 +59,23 @@ For each new version we will only track changes from the previous version.
 | `GET /effects` SSE                            |                                              | -                              | 0.8.2              | 0.2.0<br />(no support for data, inflation types) |
 | `GET /trades`                                 |                                              | +                              | 0.8.2              | 0.2.0<br />(no `price` field)                     |
 | `GET /trades_aggregations`                    |                                              | +                              | 0.8.2              | 0.2.0                                             |
-| `GET /offers/{offer_id}/trades`               |                                              | -                              | 0.8.2              | -                                                 |
+| `GET /offers/{offer_id}/trades`               |                                              | -                              | 0.8.2              | 0.2.1                                             |
 | `GET /order_book`                             |                                              | +                              | 0.8.2              | 0.2.0                                             |
-| `GET /order_book` SSE                         |                                              | -                              | 0.8.2              | -                                                 |
+| `GET /order_book` SSE                         |                                              | -                              | 0.8.2              | 0.2.1                                             |
 | `GET /paths`                                  |                                              | -                              | 0.8.2              | 0.2.0                                             |
 | `GET /assets`                                 |                                              | -                              | 0.8.2              | 0.2.0                                             |
 | [**0.13.0**](#0130) (changes only)            |                                              |                                |                    |                                                   |
 | `GET /assets`                                 | `amount` can be larger than `MAX_INT64`/10^7 | +                              | 0.8.2 <sup>2</sup> | 0.2.0                                             |
-| `GET /ledgers/{ledger_id}/effects`            | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | -                                                 |
-| `GET /ledgers/{ledger_id}/effects` SSE        | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | -                                                 |
-| `GET /accounts/{account_id}/effects`          | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | -                                                 |
-| `GET /accounts/{account_id}/effects` SSE      | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | -                                                 |
-| `GET /transactions/{tx_id}/effects`           | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | -                                                 |
-| `GET /transactions/{tx_id}/effects` SSE       | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | -                                                 |
-| `GET /operations/{op_id}/effects`             | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | -                                                 |
-| `GET /operations/{op_id}/effects` SSE         | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | -                                                 |
-| `GET /effects`                                | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | -                                                 |
-| `GET /effects` SSE                            | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | -                                                 |
+| `GET /ledgers/{ledger_id}/effects`            | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | 0.2.1                                             |
+| `GET /ledgers/{ledger_id}/effects` SSE        | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | 0.2.1                                             |
+| `GET /accounts/{account_id}/effects`          | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | 0.2.1                                             |
+| `GET /accounts/{account_id}/effects` SSE      | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | 0.2.1                                             |
+| `GET /transactions/{tx_id}/effects`           | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | 0.2.1                                             |
+| `GET /transactions/{tx_id}/effects` SSE       | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | 0.2.1                                             |
+| `GET /operations/{op_id}/effects`             | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | 0.2.1                                             |
+| `GET /operations/{op_id}/effects` SSE         | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | 0.2.1                                             |
+| `GET /effects`                                | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | 0.2.1                                             |
+| `GET /effects` SSE                            | `created_at` field added                     | +                              | 0.8.2 <sup>2</sup> | 0.2.1                                             |
 
 <sup>1</sup> We don't do proper versioning for GO SDK yet. `+` means implemented in `master` branch.
 


### PR DESCRIPTION
Java SDK 0.2.1 released today: https://github.com/stellar/java-stellar-sdk/releases/tag/0.2.1