### PR TITLE
Add LoadTransaction to horizon client interface

### DIFF
--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -103,6 +103,7 @@ type ClientInterface interface {
 	LoadMemo(p *Payment) error
 	LoadOperation(operationID string) (payment Payment, err error)
 	LoadOrderBook(selling Asset, buying Asset, params ...interface{}) (orderBook OrderBookSummary, err error)
+	LoadTransaction(transactionID string) (transaction Transaction, err error)
 	SequenceForAccount(accountID string) (xdr.SequenceNumber, error)
 	StreamLedgers(ctx context.Context, cursor *Cursor, handler LedgerHandler) error
 	StreamPayments(ctx context.Context, accountID string, cursor *Cursor, handler PaymentHandler) error

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -101,6 +101,12 @@ func (m *MockClient) LoadOrderBook(
 	return a.Get(0).(OrderBookSummary), a.Error(1)
 }
 
+// LoadTransaction is a mocking a method
+func (m *MockClient) LoadTransaction(transactionID string) (transaction Transaction, err error) {
+	a := m.Called(transactionID)
+	return a.Get(0).(Transaction), a.Error(1)
+}
+
 // SequenceForAccount is a mocking a method
 func (m *MockClient) SequenceForAccount(accountID string) (xdr.SequenceNumber, error) {
 	a := m.Called(accountID)


### PR DESCRIPTION
When I added the `LoadTransaction` method to the horizon client, I forgot to add it to the interface.