### PR TITLE
Update /payments endpoints with operations

### DIFF
--- a/services/horizon/internal/docs/reference/endpoints/payments-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/payments-all.md
@@ -4,8 +4,14 @@ clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=payments&endpoint=all
 ---
 
-This endpoint represents all payment [operations](../resources/operation.md) that are part of validated [transactions](../resources/transaction.md). This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to listen for new payments as they get made in the Stellar network.
+This endpoint represents all payment-related [operations](../resources/operation.md) that are part of validated [transactions](../resources/transaction.md). This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to listen for new payments as they get made in the Stellar network.
 If called in streaming mode Horizon will start at the earliest known payment unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream payments created since your request time.
+
+The operations that can be returned in by this endpoint are:
+- `create_account`
+- `payment`
+- `path_payment`
+- `account_merge`
 
 ## Request
 

--- a/services/horizon/internal/docs/reference/endpoints/payments-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/payments-for-account.md
@@ -4,10 +4,16 @@ clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=payments&endpoint=for_account
 ---
 
-This endpoint responds with a collection of [Payment operations](../resources/operation.md) where the given [account](../resources/account.md) was either the sender or receiver.
+This endpoint responds with a collection of payment-releated operations where the given [account](../resources/account.md) was either the sender or receiver.
 
 This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to listen for new payments to or from an account as they get made in the Stellar network.
 If called in streaming mode Horizon will start at the earliest known payment unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream payments created since your request time.
+
+The operations that can be returned in by this endpoint are:
+- `create_account`
+- `payment`
+- `path_payment`
+- `account_merge`
 
 ## Request
 

--- a/services/horizon/internal/docs/reference/endpoints/payments-for-ledger.md
+++ b/services/horizon/internal/docs/reference/endpoints/payments-for-ledger.md
@@ -4,7 +4,13 @@ clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=payments&endpoint=for_ledger
 ---
 
-This endpoint represents all payment [operations](../resources/operation.md) that are part of a valid [transactions](../resources/transaction.md) in a given [ledger](../resources/ledger.md).
+This endpoint represents all payment-releated [operations](../resources/operation.md) that are part of a valid [transactions](../resources/transaction.md) in a given [ledger](../resources/ledger.md).
+
+The operations that can be returned in by this endpoint are:
+- `create_account`
+- `payment`
+- `path_payment`
+- `account_merge`
 
 ## Request
 

--- a/services/horizon/internal/docs/reference/endpoints/payments-for-transaction.md
+++ b/services/horizon/internal/docs/reference/endpoints/payments-for-transaction.md
@@ -4,7 +4,13 @@ clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=payments&endpoint=for_transaction
 ---
 
-This endpoint represents all payment [operations](../resources/operation.md) that are part of a given [transaction](../resources/transaction.md).
+This endpoint represents all payment-related [operations](../resources/operation.md) that are part of a given [transaction](../resources/transaction.md).
+
+The operations that can be returned in by this endpoint are:
+- `create_account`
+- `payment`
+- `path_payment`
+- `account_merge`
 
 ## Request
 


### PR DESCRIPTION
It's not clear that `/payments` endpoint can return operations like `create_account` or `account_merge`.

Releated: https://github.com/stellar/js-stellar-sdk/issues/182