### PR TITLE
Stream all payments

### DIFF
--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -464,7 +464,7 @@ func (c *Client) StreamLedgers(
 	})
 }
 
-// StreamPayments streams incoming payments. Use context.WithCancel to stop streaming or
+// StreamPayments streams incoming payments for a certain account. Use context.WithCancel to stop streaming or
 // context.Background() if you want to stream indefinitely.
 func (c *Client) StreamPayments(
 	ctx context.Context,
@@ -484,6 +484,27 @@ func (c *Client) StreamPayments(
 		return nil
 	})
 }
+
+// StreamPaymentsWithoutAccount streams incoming all incoming payments. Use context.WithCancel to stop streaming or
+// context.Background() if you want to stream indefinitely.
+func (c *Client) StreamPaymentsWithoutAccount(
+	ctx context.Context,
+	cursor *Cursor,
+	handler PaymentHandler,
+) (err error) {
+	c.fixURLOnce.Do(c.fixURL)
+	url := fmt.Sprintf("%s/payments", c.URL)
+	return c.stream(ctx, url, cursor, func(data []byte) error {
+		var payment Payment
+		err = json.Unmarshal(data, &payment)
+		if err != nil {
+			return errors.Wrap(err, "Error unmarshaling data")
+		}
+		handler(payment)
+		return nil
+	})
+}
+
 
 // StreamTransactions streams incoming transactions. Use context.WithCancel to stop streaming or
 // context.Background() if you want to stream indefinitely.

--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -485,9 +485,9 @@ func (c *Client) StreamPayments(
 	})
 }
 
-// StreamPaymentsWithoutAccount streams incoming all incoming payments. Use context.WithCancel to stop streaming or
+// StreamAllPayments streams incoming all incoming payments. Use context.WithCancel to stop streaming or
 // context.Background() if you want to stream indefinitely.
-func (c *Client) StreamPaymentsWithoutAccount(
+func (c *Client) StreamAllPayments(
 	ctx context.Context,
 	cursor *Cursor,
 	handler PaymentHandler,

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -107,7 +107,7 @@ type ClientInterface interface {
 	SequenceForAccount(accountID string) (xdr.SequenceNumber, error)
 	StreamLedgers(ctx context.Context, cursor *Cursor, handler LedgerHandler) error
 	StreamPayments(ctx context.Context, accountID string, cursor *Cursor, handler PaymentHandler) error
-	StreamPaymentsWithoutAccount(ctx context.Context, cursor *Cursor, handler PaymentHandler) error
+	StreamAllPayments(ctx context.Context, cursor *Cursor, handler PaymentHandler) error
 	StreamTransactions(ctx context.Context, accountID string, cursor *Cursor, handler TransactionHandler) error
 	SubmitTransaction(txeBase64 string) (TransactionSuccess, error)
 }

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -107,6 +107,7 @@ type ClientInterface interface {
 	SequenceForAccount(accountID string) (xdr.SequenceNumber, error)
 	StreamLedgers(ctx context.Context, cursor *Cursor, handler LedgerHandler) error
 	StreamPayments(ctx context.Context, accountID string, cursor *Cursor, handler PaymentHandler) error
+	StreamPaymentsWithoutAccount(ctx context.Context, cursor *Cursor, handler PaymentHandler) error
 	StreamTransactions(ctx context.Context, accountID string, cursor *Cursor, handler TransactionHandler) error
 	SubmitTransaction(txeBase64 string) (TransactionSuccess, error)
 }

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -134,6 +134,16 @@ func (m *MockClient) StreamPayments(
 	return a.Error(0)
 }
 
+// StreamPaymentsWithoutAccount is a mocking a method
+func (m *MockClient) StreamPayments(
+	ctx context.Context,
+	cursor *Cursor,
+	handler PaymentHandler,
+) error {
+	a := m.Called(ctx, cursor, handler)
+	return a.Error(0)
+}
+
 // StreamTransactions is a mocking a method
 func (m *MockClient) StreamTransactions(
 	ctx context.Context,

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -135,7 +135,7 @@ func (m *MockClient) StreamPayments(
 }
 
 // StreamPaymentsWithoutAccount is a mocking a method
-func (m *MockClient) StreamPayments(
+func (m *MockClient) StreamPaymentsWithoutAccount(
 	ctx context.Context,
 	cursor *Cursor,
 	handler PaymentHandler,

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -134,8 +134,8 @@ func (m *MockClient) StreamPayments(
 	return a.Error(0)
 }
 
-// StreamPaymentsWithoutAccount is a mocking a method
-func (m *MockClient) StreamPaymentsWithoutAccount(
+// StreamAllPayments is a mocking a method
+func (m *MockClient) StreamAllPayments(
 	ctx context.Context,
 	cursor *Cursor,
 	handler PaymentHandler,


### PR DESCRIPTION
Adds a method to horizon clients which enables to stream
all payments and not only those for a certain account ID.