### PR TITLE
remove unsupported parameters start_time and end_time from the /trades request documentation

### DIFF
--- a/services/horizon/internal/docs/reference/endpoints/trades.md
+++ b/services/horizon/internal/docs/reference/endpoints/trades.md
@@ -9,7 +9,7 @@ Trades can be filtered for specific orderbook, defined by an asset pair: `base` 
 ## Request
 
 ```
-GET /trades?base_asset_type={base_asset_type}&base_asset_code={base_asset_code}&base_asset_issuer={base_asset_issuer}&counter_asset_type={counter_asset_type}&counter_asset_code={counter_asset_code}&counter_asset_issuer={counter_asset_issuer}&resolution={resolution}&start_time={start_time}&end_time={end_time}
+GET /trades?base_asset_type={base_asset_type}&base_asset_code={base_asset_code}&base_asset_issuer={base_asset_issuer}&counter_asset_type={counter_asset_type}&counter_asset_code={counter_asset_code}&counter_asset_issuer={counter_asset_issuer}&resolution={resolution}
 ```
 
 ### Arguments


### PR DESCRIPTION
it appears these are implemented for /trade_aggregation but not /trades so removing them from the request example.