### PR TITLE
Examples Update and Signer public_key deprecation note

### DIFF
--- a/services/horizon/internal/docs/reference/endpoints/accounts-single.md
+++ b/services/horizon/internal/docs/reference/endpoints/accounts-single.md
@@ -18,22 +18,22 @@ GET /accounts/{account}
 
 | name | notes | description | example |
 | ---- | ----- | ----------- | ------- |
-| `account` | required, string | Account ID | GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36 |
+| `account` | required, string | Account ID | GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW  |
 
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/accounts/GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ"
+curl "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW "
 ```
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.accounts()
-  .accountId("GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ")
+  .accountId("GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW ")
   .call()
   .then(function (accountResult) {
     console.log(accountResult);
@@ -52,34 +52,42 @@ This endpoint responds with the details of a single account for a given ID. See 
 {
   "_links": {
     "self": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB"
+      "href": "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW"
     },
     "transactions": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB/transactions{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW/transactions{?cursor,limit,order}",
       "templated": true
     },
     "operations": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB/operations{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW/operations{?cursor,limit,order}",
       "templated": true
     },
     "payments": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB/payments{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW/payments{?cursor,limit,order}",
       "templated": true
     },
     "effects": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB/effects{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW/effects{?cursor,limit,order}",
       "templated": true
     },
     "offers": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB/offers{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW/offers{?cursor,limit,order}",
+      "templated": true
+    },
+    "trades": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW/trades{?cursor,limit,order}",
+      "templated": true
+    },
+    "data": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW/data/{key}",
       "templated": true
     }
   },
-  "id": "GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB",
-  "paging_token": "7275146318450689",
-  "account_id": "GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB",
-  "sequence": 7275146318446606,
-  "subentry_count": 5,
+  "id": "GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW",
+  "paging_token": "",
+  "account_id": "GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW",
+  "sequence": "43692723777044483",
+  "subentry_count": 3,
   "thresholds": {
     "low_threshold": 0,
     "med_threshold": 0,
@@ -91,32 +99,38 @@ This endpoint responds with the details of a single account for a given ID. See 
   },
   "balances": [
     {
-      "balance": "126.8107491",
-      "limit": "5000.0000000",
-      "asset_type": "credit_alphanum4",
-      "asset_code": "BAR",
-      "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
-    },
-    {
-      "balance": "294.0000000",
-      "limit": "922337203685.4775807",
-      "asset_type": "credit_alphanum4",
-      "asset_code": "FOO",
-      "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
-    },
-    {
-      "balance": "9997.6802725",
+      "balance": "9999.9999700",
       "asset_type": "native"
     }
   ],
   "signers": [
     {
-      "public_key": "GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB",
-      "weight": 1
+      "public_key": "GDLEPBJBC2VSKJCLJB264F2WDK63X4NKOG774A3QWVH2U6PERGDPUCS4",
+      "weight": 1,
+      "key": "GDLEPBJBC2VSKJCLJB264F2WDK63X4NKOG774A3QWVH2U6PERGDPUCS4",
+      "type": "ed25519_public_key"
+    },
+    {
+      "public_key": "XCPNCUKYDHPMMH6TMHK73K5VP5A6ZTQ2L7Q74JR3TDANNFB3TMRS5OKG",
+      "weight": 1,
+      "key": "XCPNCUKYDHPMMH6TMHK73K5VP5A6ZTQ2L7Q74JR3TDANNFB3TMRS5OKG",
+      "type": "sha256_hash"
+    },
+    {
+      "public_key": "TABGGIW6EXOVOSNJ2O27U2DUX7RWHSRBGOKQLGYDTOXPANEX6LXBX7O7",
+      "weight": 1,
+      "key": "TABGGIW6EXOVOSNJ2O27U2DUX7RWHSRBGOKQLGYDTOXPANEX6LXBX7O7",
+      "type": "preauth_tx"
+    },
+    {
+      "public_key": "GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW",
+      "weight": 1,
+      "key": "GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW",
+      "type": "ed25519_public_key"
     }
   ],
   "data": {
-    "club": "MTAw"
+    
   }
 }
 ```

--- a/services/horizon/internal/docs/reference/endpoints/assets-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/assets-all.md
@@ -33,6 +33,23 @@ GET /assets{?asset_code,asset_issuer,cursor,limit,order}
 curl "https://horizon-testnet.stellar.org/assets?limit=200&order=desc"
 ```
 
+### JavaScript Example Request
+
+```javascript
+var StellarSdk = require('stellar-sdk');
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+server.assets()
+  .call()
+  .then(function (result) {
+    console.log(result.records);
+  })
+  .catch(function (err) {
+    console.log(err)
+  })
+```
+
+
 ## Response
 
 If called normally this endpoint responds with a [page](../resources/page.md) of assets.

--- a/services/horizon/internal/docs/reference/endpoints/data-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/data-for-account.md
@@ -21,17 +21,17 @@ GET /accounts/{account}/data/{key}
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/data/user-id"
+curl "https://horizon-testnet.stellar.org/accounts/GCY3SMRZV3R7SNJKFZQHHZEPU4TUJULHSIPMJGKA6APL6O5F5RWCRZCM/data/user-id"
 ```
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.accounts()
-  .accountId("GAKLBGHNHFQ3BMUYG5KU4BEWO6EYQHZHAXEWC33W34PH2RBHZDSQBD75")
+  .accountId("GCY3SMRZV3R7SNJKFZQHHZEPU4TUJULHSIPMJGKA6APL6O5F5RWCRZCM")
   .call()
   .then(function (account) {
     return account.data({key: 'user-id'})
@@ -52,7 +52,7 @@ This endpoint responds with a value of the data field for the given account. See
 
 ```json
 {
-  "value": "MTAw"
+  "value": "MTIz"
 }
 ```
 

--- a/services/horizon/internal/docs/reference/endpoints/effects-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/effects-all.md
@@ -44,7 +44,22 @@ server.effects()
   .catch(function (err) {
     console.log(err)
   })
+```
 
+### JavaScript Streaming Example
+
+```javascript
+var StellarSdk = require('stellar-sdk')
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+var effectHandler = function (effectResponse) {
+    console.log(effectResponse);
+};
+
+var es = server.effects()
+    .stream({
+        onmessage: effectHandler
+    })
 ```
 
 ## Response

--- a/services/horizon/internal/docs/reference/endpoints/effects-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/effects-for-account.md
@@ -27,7 +27,7 @@ GET /accounts/{account}/effects{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/effects"
+curl "https://horizon-testnet.stellar.org/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/effects?limit=1"
 ```
 
 ### JavaScript Example Request
@@ -37,7 +37,7 @@ var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.effects()
-  .forAccount("GD6VWBXI6NY3AOOR55RLVQ4MNIDSXE5JSAVXUTF35FRRI72LYPI3WL6Z")
+  .forAccount("GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36")
   .call()
   .then(function (effectResults) {
     //page 1
@@ -49,6 +49,23 @@ server.effects()
 
 ```
 
+### JavaScript Streaming Example
+
+```javascript
+var StellarSdk = require('stellar-sdk')
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+var effectHandler = function (effectResponse) {
+    console.log(effectResponse);
+};
+
+var es = server.effects()
+    .forAccount("GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36")
+    .stream({
+        onmessage: effectHandler
+    })
+```
+
 ## Response
 
 The list of effects.
@@ -57,57 +74,40 @@ The list of effects.
 
 ```json
 {
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/effects?cursor=\u0026limit=1\u0026order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/effects?cursor=34517561236262913-1\u0026limit=1\u0026order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/effects?cursor=34517561236262913-1\u0026limit=1\u0026order=desc"
+    }
+  },
   "_embedded": {
     "records": [
       {
         "_links": {
           "operation": {
-            "href": "/operations/214748368897"
-          },
-          "precedes": {
-            "href": "/effects?cursor=214748368897-1\u0026order=asc"
+            "href": "https://horizon-testnet.stellar.org/operations/34517561236262913"
           },
           "succeeds": {
-            "href": "/effects?cursor=214748368897-1\u0026order=desc"
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=34517561236262913-1"
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=34517561236262913-1"
           }
         },
-        "account": "GC6NFQDTVH2YMVZSXJIVLCRHLFAOVOT32JMDFZJZ34QFSSVT7M5G2XFK",
-        "paging_token": "214748368897-1",
-        "starting_balance": "100.0",
+        "id": "0034517561236262913-0000000001",
+        "paging_token": "34517561236262913-1",
+        "account": "GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36",
+        "type": "account_created",
         "type_i": 0,
-        "type": "account_created"
-      },
-      {
-        "_links": {
-          "operation": {
-            "href": "/operations/214748368897"
-          },
-          "precedes": {
-            "href": "/effects?cursor=214748368897-3\u0026order=asc"
-          },
-          "succeeds": {
-            "href": "/effects?cursor=214748368897-3\u0026order=desc"
-          }
-        },
-        "account": "GC6NFQDTVH2YMVZSXJIVLCRHLFAOVOT32JMDFZJZ34QFSSVT7M5G2XFK",
-        "paging_token": "214748368897-3",
-        "public_key": "GC6NFQDTVH2YMVZSXJIVLCRHLFAOVOT32JMDFZJZ34QFSSVT7M5G2XFK",
-        "type_i": 10,
-        "type": "signer_created",
-        "weight": 2
+        "created_at": "2018-03-22T02:46:34Z",
+        "starting_balance": "10000.0000000"
       }
     ]
-  },
-  "_links": {
-    "next": {
-      "href": "/accounts/GC6NFQDTVH2YMVZSXJIVLCRHLFAOVOT32JMDFZJZ34QFSSVT7M5G2XFK/effects?order=asc\u0026limit=10\u0026cursor=214748368897-3"
-    },
-    "prev": {
-      "href": "/accounts/GC6NFQDTVH2YMVZSXJIVLCRHLFAOVOT32JMDFZJZ34QFSSVT7M5G2XFK/effects?order=desc\u0026limit=10\u0026cursor=214748368897-1"
-    },
-    "self": {
-      "href": "/accounts/GC6NFQDTVH2YMVZSXJIVLCRHLFAOVOT32JMDFZJZ34QFSSVT7M5G2XFK/effects?order=asc\u0026limit=10\u0026cursor="
-    }
   }
 }
 ```

--- a/services/horizon/internal/docs/reference/endpoints/effects-for-ledger.md
+++ b/services/horizon/internal/docs/reference/endpoints/effects-for-ledger.md
@@ -18,7 +18,7 @@ GET /ledgers/{id}/effects{?cursor,limit,order}
 
 | name     | notes                          | description                                                      | example      |
 | ------   | -------                        | -----------                                                      | -------      |
-| `id`     | required, number               | Ledger ID                                                        | `69859`      |
+| `id`     | required, number               | Ledger ID                                                        | `10085921`   |
 | `?cursor`| optional, default _null_       | A paging token, specifying where to start returning records from.| `12884905984`|
 | `?order` | optional, string, default `asc`| The order in which to return rows, "asc" or "desc".              | `asc`        |
 | `?limit` | optional, number, default `10` | Maximum number of records to return.                             | `200`        |
@@ -26,7 +26,7 @@ GET /ledgers/{id}/effects{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/ledgers/69859/effects"
+curl "https://horizon-testnet.stellar.org/ledgers/10085921/effects?limit=1"
 ```
 
 ### JavaScript Example Request
@@ -36,7 +36,7 @@ var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.effects()
-  .forLedger("2")
+  .forLedger("10085921")
   .call()
   .then(function (effectResults) {
     //page 1
@@ -56,76 +56,43 @@ This endpoint responds with a list of effects that occurred in the ledger. See [
 
 ```json
 {
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/10085921/effects?cursor=\u0026limit=1\u0026order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/10085921/effects?cursor=43318700845043713-1\u0026limit=1\u0026order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/10085921/effects?cursor=43318700845043713-1\u0026limit=1\u0026order=desc"
+    }
+  },
   "_embedded": {
     "records": [
       {
         "_links": {
           "operation": {
-            "href": "/operations/141733924865"
-          },
-          "precedes": {
-            "href": "/effects?cursor=141733924865-1\u0026order=asc"
+            "href": "https://horizon-testnet.stellar.org/operations/43318700845043713"
           },
           "succeeds": {
-            "href": "/effects?cursor=141733924865-1\u0026order=desc"
-          }
-        },
-        "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
-        "paging_token": "141733924865-1",
-        "starting_balance": "10000000.0",
-        "type_i": 0,
-        "type": "account_created"
-      },
-      {
-        "_links": {
-          "operation": {
-            "href": "/operations/141733924865"
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=43318700845043713-1"
           },
           "precedes": {
-            "href": "/effects?cursor=141733924865-2\u0026order=asc"
-          },
-          "succeeds": {
-            "href": "/effects?cursor=141733924865-2\u0026order=desc"
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=43318700845043713-1"
           }
         },
-        "account": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
-        "amount": "10000000.0",
-        "asset_type": "native",
-        "paging_token": "141733924865-2",
-        "type_i": 3,
-        "type": "account_debited"
-      },
-      {
-        "_links": {
-          "operation": {
-            "href": "/operations/141733924865"
-          },
-          "precedes": {
-            "href": "/effects?cursor=141733924865-3\u0026order=asc"
-          },
-          "succeeds": {
-            "href": "/effects?cursor=141733924865-3\u0026order=desc"
-          }
-        },
-        "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
-        "paging_token": "141733924865-3",
-        "public_key": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
-        "type_i": 10,
-        "type": "signer_created",
-        "weight": 2
+        "id": "0043318700845043713-0000000001",
+        "paging_token": "43318700845043713-1",
+        "account": "GB4OMVGHXSZRVT6KTXV22LPWIVYZES7B43RQ3P54BKIH3U36GOPS645Y",
+        "type": "account_credited",
+        "type_i": 2,
+        "created_at": "2018-07-18T19:39:00Z",
+        "asset_type": "credit_alphanum12",
+        "asset_code": "nCntGameCoin",
+        "asset_issuer": "GDLMDXI6EVVUIXWRU4S2YVZRMELHUEX3WKOX6XFW77QQC6KZJ4CZ7NRB",
+        "amount": "1.0000000"
       }
     ]
-  },
-  "_links": {
-    "next": {
-      "href": "/ledgers/33/effects?order=asc\u0026limit=10\u0026cursor=141733924865-3"
-    },
-    "prev": {
-      "href": "/ledgers/33/effects?order=desc\u0026limit=10\u0026cursor=141733924865-1"
-    },
-    "self": {
-      "href": "/ledgers/33/effects?order=asc\u0026limit=10\u0026cursor="
-    }
   }
 }
 ```

--- a/services/horizon/internal/docs/reference/endpoints/effects-for-operation.md
+++ b/services/horizon/internal/docs/reference/endpoints/effects-for-operation.md
@@ -16,7 +16,7 @@ GET /operations/{id}/effects{?cursor,limit,order}
 
 | name     | notes                          | description                                                      | example      |
 | ------   | -------                        | -----------                                                      | -------      |
-| `id`     | required, number               | An operation ID                                                  | `77309415424`|
+| `id`     | required, number               | An operation ID                                                  | `10157597659137`|
 | `?cursor`| optional, default _null_       | A paging token, specifying where to start returning records from.| `12884905984`|
 | `?order` | optional, string, default `asc`| The order in which to return rows, "asc" or "desc".              | `asc`        |
 | `?limit` | optional, number, default `10` | Maximum number of records to return.                             | `200`        |
@@ -24,7 +24,7 @@ GET /operations/{id}/effects{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/operations/77309415424/effects"
+curl "https://horizon-testnet.stellar.org/operations/10157597659137/effects"
 ```
 
 ### JavaScript Example Request
@@ -34,7 +34,7 @@ var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.effects()
-  .forOperation("141733924865")
+  .forOperation("10157597659137")
   .call()
   .then(function (effectResults) {
     //page 1
@@ -54,76 +54,83 @@ This endpoint responds with a list of effects on the ledger as a result of a giv
 
 ```json
 {
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/operations/10157597659137/effects?cursor=&limit=10&order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/operations/10157597659137/effects?cursor=10157597659137-3&limit=10&order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/operations/10157597659137/effects?cursor=10157597659137-1&limit=10&order=desc"
+    }
+  },
   "_embedded": {
     "records": [
       {
         "_links": {
           "operation": {
-            "href": "/operations/141733924865"
-          },
-          "precedes": {
-            "href": "/effects?cursor=141733924865-1\u0026order=asc"
+            "href": "https://horizon-testnet.stellar.org/operations/10157597659137"
           },
           "succeeds": {
-            "href": "/effects?cursor=141733924865-1\u0026order=desc"
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc&cursor=10157597659137-1"
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc&cursor=10157597659137-1"
           }
         },
+        "id": "0000010157597659137-0000000001",
+        "paging_token": "10157597659137-1",
         "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
-        "paging_token": "141733924865-1",
-        "starting_balance": "10000000.0",
+        "type": "account_created",
         "type_i": 0,
-        "type": "account_created"
+        "created_at": "2017-03-20T19:50:52Z",
+        "starting_balance": "50000000.0000000"
       },
       {
         "_links": {
           "operation": {
-            "href": "/operations/141733924865"
-          },
-          "precedes": {
-            "href": "/effects?cursor=141733924865-2\u0026order=asc"
+            "href": "https://horizon-testnet.stellar.org/operations/10157597659137"
           },
           "succeeds": {
-            "href": "/effects?cursor=141733924865-2\u0026order=desc"
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc&cursor=10157597659137-2"
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc&cursor=10157597659137-2"
           }
         },
+        "id": "0000010157597659137-0000000002",
+        "paging_token": "10157597659137-2",
         "account": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
-        "amount": "10000000.0",
-        "asset_type": "native",
-        "paging_token": "141733924865-2",
+        "type": "account_debited",
         "type_i": 3,
-        "type": "account_debited"
+        "created_at": "2017-03-20T19:50:52Z",
+        "asset_type": "native",
+        "amount": "50000000.0000000"
       },
       {
         "_links": {
           "operation": {
-            "href": "/operations/141733924865"
-          },
-          "precedes": {
-            "href": "/effects?cursor=141733924865-3\u0026order=asc"
+            "href": "https://horizon-testnet.stellar.org/operations/10157597659137"
           },
           "succeeds": {
-            "href": "/effects?cursor=141733924865-3\u0026order=desc"
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc&cursor=10157597659137-3"
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc&cursor=10157597659137-3"
           }
         },
+        "id": "0000010157597659137-0000000003",
+        "paging_token": "10157597659137-3",
         "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
-        "paging_token": "141733924865-3",
-        "public_key": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
-        "type_i": 10,
         "type": "signer_created",
-        "weight": 2
+        "type_i": 10,
+        "created_at": "2017-03-20T19:50:52Z",
+        "weight": 1,
+        "public_key": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
+        "key": ""
       }
     ]
-  },
-  "_links": {
-    "next": {
-      "href": "/operations/141733924865/effects?order=asc\u0026limit=10\u0026cursor=141733924865-3"
-    },
-    "prev": {
-      "href": "/operations/141733924865/effects?order=desc\u0026limit=10\u0026cursor=141733924865-1"
-    },
-    "self": {
-      "href": "/operations/141733924865/effects?order=asc\u0026limit=10\u0026cursor="
-    }
   }
 }
 ```

--- a/services/horizon/internal/docs/reference/endpoints/effects-for-transaction.md
+++ b/services/horizon/internal/docs/reference/endpoints/effects-for-transaction.md
@@ -16,7 +16,7 @@ GET /transactions/{hash}/effects{?cursor,limit,order}
 
 | name     | notes                          | description                                                      | example                                                           |
 | ------   | -------                        | -----------                                                      | -------                                                           |
-| `hash`   | required, string               | A transaction hash, hex-encoded                                  | `6391dd190f15f7d1665ba53c63842e368f485651a53d8d852ed442a446d1c69a`|
+| `hash`   | required, string               | A transaction hash, hex-encoded                                  | `17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a`|
 | `?cursor`| optional, default _null_       | A paging token, specifying where to start returning records from.| `12884905984`                                                     |
 | `?order` | optional, string, default `asc`| The order in which to return rows, "asc" or "desc".              | `asc`                                                             |
 | `?limit` | optional, number, default `10` | Maximum number of records to return.                             | `200`                                                             |
@@ -24,7 +24,7 @@ GET /transactions/{hash}/effects{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/transactions/6391dd190f15f7d1665ba53c63842e368f485651a53d8d852ed442a446d1c69a/effects"
+curl "https://horizon-testnet.stellar.org/transactions/17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a/effects?limit=1"
 ```
 
 ### JavaScript Example Request
@@ -34,7 +34,7 @@ var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.effects()
-  .forTransaction("2ca4cb42fda85f4f0b4bc0a0dc6517a7f109761d0da784cb7c38fb6ee378b1b5")
+  .forTransaction("17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a")
   .call()
   .then(function (effectResults) {
     //page 1
@@ -54,76 +54,40 @@ This endpoint responds with a list of effects on the ledger as a result of a giv
 
 ```json
 {
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/transactions/17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a/effects?cursor=&limit=1&order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/transactions/17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a/effects?cursor=10157597659137-1&limit=1&order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/transactions/17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a/effects?cursor=10157597659137-1&limit=1&order=desc"
+    }
+  },
   "_embedded": {
     "records": [
       {
         "_links": {
           "operation": {
-            "href": "/operations/141733924865"
-          },
-          "precedes": {
-            "href": "/effects?cursor=141733924865-1\u0026order=asc"
+            "href": "https://horizon-testnet.stellar.org/operations/10157597659137"
           },
           "succeeds": {
-            "href": "/effects?cursor=141733924865-1\u0026order=desc"
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc&cursor=10157597659137-1"
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc&cursor=10157597659137-1"
           }
         },
+        "id": "0000010157597659137-0000000001",
+        "paging_token": "10157597659137-1",
         "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
-        "paging_token": "141733924865-1",
-        "starting_balance": "10000000.0",
+        "type": "account_created",
         "type_i": 0,
-        "type": "account_created"
-      },
-      {
-        "_links": {
-          "operation": {
-            "href": "/operations/141733924865"
-          },
-          "precedes": {
-            "href": "/effects?cursor=141733924865-2\u0026order=asc"
-          },
-          "succeeds": {
-            "href": "/effects?cursor=141733924865-2\u0026order=desc"
-          }
-        },
-        "account": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
-        "amount": "10000000.0",
-        "asset_type": "native",
-        "paging_token": "141733924865-2",
-        "type_i": 3,
-        "type": "account_debited"
-      },
-      {
-        "_links": {
-          "operation": {
-            "href": "/operations/141733924865"
-          },
-          "precedes": {
-            "href": "/effects?cursor=141733924865-3\u0026order=asc"
-          },
-          "succeeds": {
-            "href": "/effects?cursor=141733924865-3\u0026order=desc"
-          }
-        },
-        "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
-        "paging_token": "141733924865-3",
-        "public_key": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
-        "type_i": 10,
-        "type": "signer_created",
-        "weight": 2
+        "created_at": "2017-03-20T19:50:52Z",
+        "starting_balance": "50000000.0000000"
       }
     ]
-  },
-  "_links": {
-    "next": {
-      "href": "/transactions/2a2beb163e2c68bd2377aab243d68225626d70263444a85556ec7271d4e46e03/effects?order=asc\u0026limit=10\u0026cursor=141733924865-3"
-    },
-    "prev": {
-      "href": "/transactions/2a2beb163e2c68bd2377aab243d68225626d70263444a85556ec7271d4e46e03/effects?order=desc\u0026limit=10\u0026cursor=141733924865-1"
-    },
-    "self": {
-      "href": "/transactions/2a2beb163e2c68bd2377aab243d68225626d70263444a85556ec7271d4e46e03/effects?order=asc\u0026limit=10\u0026cursor="
-    }
   }
 }
 ```

--- a/services/horizon/internal/docs/reference/endpoints/ledgers-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/ledgers-all.md
@@ -31,7 +31,7 @@ curl "https://horizon-testnet.stellar.org/ledgers?limit=200&order=desc"
 
 ### JavaScript Example Request
 
-```js
+```javascript
 server.ledgers()
   .call()
   .then(function (ledgerResult) {
@@ -47,6 +47,24 @@ server.ledgers()
     console.log(err)
   })
 ```
+
+
+### JavaScript Streaming Example
+
+```javascript
+var StellarSdk = require('stellar-sdk')
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+var ledgerHandler = function (ledgerResponse) {
+    console.log(ledgerResponse);
+};
+
+var es = server.ledgers()
+    .stream({
+        onmessage: ledgerHandler
+    })
+```
+
 ## Response
 
 This endpoint responds with a list of ledgers.  See [ledger resource](../resources/ledger.md) for reference.

--- a/services/horizon/internal/docs/reference/endpoints/offers-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/offers-for-account.md
@@ -18,7 +18,7 @@ GET /accounts/{account}/offers{?cursor,limit,order}
 
 | name | notes | description | example |
 | ---- | ----- | ----------- | ------- |
-| `account` | required, string | Account ID | `GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36` |
+| `account` | required, string | Account ID | `GBYTR4MC5JAX4ALGUBJD7EIKZVM7CUGWKXIUJMRSMK573XH2O7VAK3SR` |
 | `?cursor` | optional, any, default _null_ | A paging token, specifying where to start returning records from. | `12884905984` |
 | `?order`  | optional, string, default `asc` | The order in which to return rows, "asc" or "desc". | `asc` |
 | `?limit`  | optional, number, default: `10` | Maximum number of records to return. | `200` |
@@ -26,16 +26,16 @@ GET /accounts/{account}/offers{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4/offers"
+curl "https://horizon-testnet.stellar.org/accounts/GBYTR4MC5JAX4ALGUBJD7EIKZVM7CUGWKXIUJMRSMK573XH2O7VAK3SR/offers"
 ```
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
-server.offers('accounts', 'GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4')
+server.offers('accounts', 'GBYTR4MC5JAX4ALGUBJD7EIKZVM7CUGWKXIUJMRSMK573XH2O7VAK3SR')
   .call()
   .then(function (offerResult) {
     console.log(offerResult);
@@ -43,6 +43,22 @@ server.offers('accounts', 'GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVG
   .catch(function (err) {
     console.error(err);
   })
+```
+
+### JavaScript Streaming Example
+
+```javascript
+var StellarSdk = require('stellar-sdk')
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+var offerHandler = function (offerResponse) {
+    console.log(offerResponse);
+};
+
+var es = server.offers('accounts', 'GBYTR4MC5JAX4ALGUBJD7EIKZVM7CUGWKXIUJMRSMK573XH2O7VAK3SR')
+    .stream({
+        onmessage: offerHandler
+    })
 ```
 
 ## Response
@@ -55,13 +71,13 @@ The list of offers.
 {
   "_links": {
     "self": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4/offers?order=asc&limit=10&cursor="
+      "href": "https://horizon-testnet.stellar.org/accounts/GBYTR4MC5JAX4ALGUBJD7EIKZVM7CUGWKXIUJMRSMK573XH2O7VAK3SR/offers?cursor=\u0026limit=10\u0026order=asc"
     },
     "next": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4/offers?order=asc&limit=10&cursor=122"
+      "href": "https://horizon-testnet.stellar.org/accounts/GBYTR4MC5JAX4ALGUBJD7EIKZVM7CUGWKXIUJMRSMK573XH2O7VAK3SR/offers?cursor=8\u0026limit=10\u0026order=asc"
     },
     "prev": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4/offers?order=desc&limit=10&cursor=121"
+      "href": "https://horizon-testnet.stellar.org/accounts/GBYTR4MC5JAX4ALGUBJD7EIKZVM7CUGWKXIUJMRSMK573XH2O7VAK3SR/offers?cursor=8\u0026limit=10\u0026order=desc"
     }
   },
   "_embedded": {
@@ -69,62 +85,29 @@ The list of offers.
       {
         "_links": {
           "self": {
-            "href": "https://horizon-testnet.stellar.org/offers/121"
+            "href": "https://horizon-testnet.stellar.org/offers/8"
           },
           "offer_maker": {
-            "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4"
+            "href": "https://horizon-testnet.stellar.org/accounts/GBYTR4MC5JAX4ALGUBJD7EIKZVM7CUGWKXIUJMRSMK573XH2O7VAK3SR"
           }
         },
-        "id": 121,
-        "paging_token": "121",
-        "seller": "GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4",
+        "id": 8,
+        "paging_token": "8",
+        "seller": "GBYTR4MC5JAX4ALGUBJD7EIKZVM7CUGWKXIUJMRSMK573XH2O7VAK3SR",
         "selling": {
           "asset_type": "credit_alphanum4",
-          "asset_code": "BAR",
-          "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
+          "asset_code": "BTC",
+          "asset_issuer": "GB6FN4C7ZLWKENAOZDLZOQHNIOK4RDMV6EKLR53LWCHEBR6LVXOEKDZH"
         },
         "buying": {
-          "asset_type": "credit_alphanum4",
-          "asset_code": "FOO",
-          "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
+          "asset_type": "native"
         },
-        "amount": "23.6692509",
+        "amount": "8.0000000",
         "price_r": {
-          "n": 387,
-          "d": 50
+          "n": 1,
+          "d": 1
         },
-        "price": "7.7400000",
-        "last_modified": "1970-01-01T00:00:05Z"
-      },
-      {
-        "_links": {
-          "self": {
-            "href": "https://horizon-testnet.stellar.org/offers/122"
-          },
-          "offer_maker": {
-            "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4"
-          }
-        },
-        "id": 122,
-        "paging_token": "122",
-        "seller": "GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4",
-        "selling": {
-          "asset_type": "credit_alphanum4",
-          "asset_code": "BAR",
-          "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
-        },
-        "buying": {
-          "asset_type": "credit_alphanum4",
-          "asset_code": "FOO",
-          "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
-        },
-        "amount": "72.0000000",
-        "price_r": {
-          "n": 779,
-          "d": 100
-        },
-        "price": "7.7900000",
-        "last_modified": "1970-01-01T00:00:06Z"
+        "price": "1.0000000"
       }
     ]
   }

--- a/services/horizon/internal/docs/reference/endpoints/operations-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/operations-all.md
@@ -50,6 +50,22 @@ server.operations()
   })
 ```
 
+### JavaScript Streaming Example
+
+```javascript
+var StellarSdk = require('stellar-sdk')
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+var operationHandler = function (operationResponse) {
+    console.log(operationResponse);
+};
+
+var es = server.operations()
+    .stream({
+        onmessage: operationHandler
+    })
+```
+
 ## Response
 
 This endpoint responds with a list of operations. See [operation resource](../resources/operation.md) for reference.

--- a/services/horizon/internal/docs/reference/endpoints/operations-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/operations-for-account.md
@@ -47,6 +47,23 @@ server.operations()
   })
 ```
 
+### JavaScript Streaming Example
+
+```javascript
+var StellarSdk = require('stellar-sdk')
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+var operationHandler = function (operationResponse) {
+    console.log(operationResponse);
+};
+
+var es = server.operations()
+    .forAccount("GAKLBGHNHFQ3BMUYG5KU4BEWO6EYQHZHAXEWC33W34PH2RBHZDSQBD75")
+    .stream({
+        onmessage: operationHandler
+    })
+```
+
 ## Response
 
 This endpoint responds with a list of operations that affected the given account. See [operation resource](../resources/operation.md) for reference.

--- a/services/horizon/internal/docs/reference/endpoints/operations-for-ledger.md
+++ b/services/horizon/internal/docs/reference/endpoints/operations-for-ledger.md
@@ -16,7 +16,7 @@ GET /ledgers/{id}/operations{?cursor,limit,order}
 
 | name     | notes                          | description                                                      | example      |
 | ------   | -------                        | -----------                                                      | -------      |
-| `id`     | required, number               | Ledger ID                                                        | `69859`      |
+| `id`     | required, number               | Ledger ID                                                        | `6985922`    |
 | `?cursor`| optional, default _null_       | A paging token, specifying where to start returning records from.| `12884905984`|
 | `?order` | optional, string, default `asc`| The order in which to return rows, "asc" or "desc".              | `asc`        |
 | `?limit` | optional, number, default `10` | Maximum number of records to return.                             | `200`        |
@@ -24,17 +24,17 @@ GET /ledgers/{id}/operations{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/ledgers/69859/operations"
+curl "https://horizon-testnet.stellar.org/ledgers/6985922/operations?limit=1"
 ```
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.operations()
-  .forLedger("10866")
+  .forLedger("6985922")
   .call()
   .then(function (operationsResult) {
     console.log(operationsResult.records);
@@ -52,47 +52,57 @@ This endpoint responds with a list of operations in a given ledger.  See [operat
 
 ```json
 {
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/6985922/operations?cursor=\u0026limit=1\u0026order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/6985922/operations?cursor=30004306522411009\u0026limit=1\u0026order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/6985922/operations?cursor=30004306522411009\u0026limit=1\u0026order=desc"
+    }
+  },
   "_embedded": {
     "records": [
       {
         "_links": {
-          "effects": {
-            "href": "/operations/77309415424/effects/{?cursor,limit,order}",
-            "templated": true
-          },
-          "precedes": {
-            "href": "/operations?cursor=77309415424&order=asc"
-          },
           "self": {
-            "href": "/operations/77309415424"
+            "href": "https://horizon-testnet.stellar.org/operations/30004306522411009"
+          },
+          "transaction": {
+            "href": "https://horizon-testnet.stellar.org/transactions/ca375ca4c5f084c9654459fd5c84cfa58c627adad6a91ffb848585a7989be044"
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/operations/30004306522411009/effects"
           },
           "succeeds": {
-            "href": "/operations?cursor=77309415424&order=desc"
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=30004306522411009"
           },
-          "transactions": {
-            "href": "/transactions/77309415424"
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=30004306522411009"
           }
         },
-        "account": "GBIA4FH6TV64KSPDAJCNUQSM7PFL4ILGUVJDPCLUOPJ7ONMKBBVUQHRO",
-        "funder": "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ",
-        "id": 77309415424,
-        "paging_token": "77309415424",
-        "starting_balance": 1e+14,
-        "type_i": 0,
-        "type": "create_account"
+        "id": "30004306522411009",
+        "paging_token": "30004306522411009",
+        "source_account": "GBLMPWYW2R7ICYRM62GSLW5B567ETK5O64N34VPT4RWH6PMWPMIG3FHT",
+        "type": "manage_offer",
+        "type_i": 3,
+        "created_at": "2018-01-29T02:39:49Z",
+        "transaction_hash": "ca375ca4c5f084c9654459fd5c84cfa58c627adad6a91ffb848585a7989be044",
+        "amount": "0.0999454",
+        "price": "19776.0950519",
+        "price_r": {
+          "n": 703020403,
+          "d": 35549
+        },
+        "buying_asset_type": "native",
+        "selling_asset_type": "credit_alphanum4",
+        "selling_asset_code": "BTC",
+        "selling_asset_issuer": "GCNSGHUCG5VMGLT5RIYYZSO7VQULQKAJ62QA33DBC5PPBSO57LFWVV6P",
+        "offer_id": 81843
       }
     ]
-  },
-  "_links": {
-    "next": {
-      "href": "/ledgers/18/operations?order=asc&limit=10&cursor=77309415424"
-    },
-    "prev": {
-      "href": "/ledgers/18/operations?order=desc&limit=10&cursor=77309415424"
-    },
-    "self": {
-      "href": "/ledgers/18/operations?order=asc&limit=10&cursor="
-    }
   }
 }
 ```

--- a/services/horizon/internal/docs/reference/endpoints/operations-for-transaction.md
+++ b/services/horizon/internal/docs/reference/endpoints/operations-for-transaction.md
@@ -16,7 +16,7 @@ GET /transactions/{hash}/operations{?cursor,limit,order}
 
 | name     | notes                          | description                                                      | example                                                           |
 | ------   | -------                        | -----------                                                      | -------                                                           |
-| `hash`   | required, string               | A transaction hash, hex-encoded                                  | `6391dd190f15f7d1665ba53c63842e368f485651a53d8d852ed442a446d1c69a`|
+| `hash`   | required, string               | A transaction hash, hex-encoded                                  | `17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a`|
 | `?cursor`| optional, default _null_       | A paging token, specifying where to start returning records from.| `12884905984`                                                     |
 | `?order` | optional, string, default `asc`| The order in which to return rows, "asc" or "desc".              | `asc`                                                             |
 | `?limit` | optional, number, default `10` | Maximum number of records to return.                             | `200`                                                             |
@@ -24,17 +24,17 @@ GET /transactions/{hash}/operations{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/transactions/6391dd190f15f7d1665ba53c63842e368f485651a53d8d852ed442a446d1c69a/operations"
+curl "https://horizon-testnet.stellar.org/transactions/17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a/operations?limit=1"
 ```
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.operations()
-  .forTransaction("3c8ef808df9d5d240ba0d495629df9da5653b1be2daf05d43b49c5bcbfe099bd")
+  .forTransaction("17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a")
   .call()
   .then(function (operationsResult) {
     console.log(operationsResult.records);
@@ -52,47 +52,49 @@ This endpoint responds with a list of operations that are part of a given transa
 
 ```json
 {
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/transactions/17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a/operations?cursor=&limit=1&order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/transactions/17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a/operations?cursor=10157597659137&limit=1&order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/transactions/17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a/operations?cursor=10157597659137&limit=1&order=desc"
+    }
+  },
   "_embedded": {
     "records": [
       {
         "_links": {
-          "effects": {
-            "href": "/operations/352573865332736/effects/{?cursor,limit,order}",
-            "templated": true
-          },
-          "precedes": {
-            "href": "/operations?cursor=352573865332736&order=asc"
-          },
           "self": {
-            "href": "/operations/352573865332736"
+            "href": "https://horizon-testnet.stellar.org/operations/10157597659137"
+          },
+          "transaction": {
+            "href": "https://horizon-testnet.stellar.org/transactions/17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a"
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/operations/10157597659137/effects"
           },
           "succeeds": {
-            "href": "/operations?cursor=352573865332736&order=desc"
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc&cursor=10157597659137"
           },
-          "transactions": {
-            "href": "/transactions/352573865332736"
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc&cursor=10157597659137"
           }
         },
-        "account": "GBU3FDYZK5VTU7A3SIGC443E5OV6MXUI5DXOI22SPT3OPK7AGIIWOZLF",
-        "funder": "GBIA4FH6TV64KSPDAJCNUQSM7PFL4ILGUVJDPCLUOPJ7ONMKBBVUQHRO",
-        "id": 352573865332736,
-        "paging_token": "352573865332736",
-        "starting_balance": 1e+09,
+        "id": "10157597659137",
+        "paging_token": "10157597659137",
+        "source_account": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+        "type": "create_account",
         "type_i": 0,
-        "type": "create_account"
+        "created_at": "2017-03-20T19:50:52Z",
+        "transaction_hash": "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a",
+        "starting_balance": "50000000.0000000",
+        "funder": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+        "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K"
       }
     ]
-  },
-  "_links": {
-    "next": {
-      "href": "/transactions/e648b8f9b00c6a04267b3d204c97d08181a13a9b8f3dce8ba28e96b03114b149/operations?order=asc&limit=10&cursor=352573865332736"
-    },
-    "prev": {
-      "href": "/transactions/e648b8f9b00c6a04267b3d204c97d08181a13a9b8f3dce8ba28e96b03114b149/operations?order=desc&limit=10&cursor=352573865332736"
-    },
-    "self": {
-      "href": "/transactions/e648b8f9b00c6a04267b3d204c97d08181a13a9b8f3dce8ba28e96b03114b149/operations?order=asc&limit=10&cursor="
-    }
   }
 }
 ```

--- a/services/horizon/internal/docs/reference/endpoints/operations-single.md
+++ b/services/horizon/internal/docs/reference/endpoints/operations-single.md
@@ -16,22 +16,22 @@ GET /operations/{id}
 
 |  name  |  notes  | description | example |
 | ------ | ------- | ----------- | ------- |
-| `id` | required, number | An operation ID. | 77309415424 |
+| `id` | required, number | An operation ID. | 43685160339648551 |
 
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/operations/77309415424
+curl https://horizon-testnet.stellar.org/operations/43685160339648551
 ```
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.operations()
-  .operation('77309415424')
+  .operation('43685160339648551')
   .call()
   .then(function (operationsResult) {
     console.log(operationsResult)
@@ -52,30 +52,40 @@ This endpoint responds with a single Operation.  See [operation resource](../res
 ```json
 {
   "_links": {
-    "effects": {
-      "href": "/operations/77309415424/effects/{?cursor,limit,order}",
-      "templated": true
-    },
-    "precedes": {
-      "href": "/operations?cursor=77309415424&order=asc"
-    },
     "self": {
-      "href": "/operations/77309415424"
+      "href": "https://horizon-testnet.stellar.org/operations/43685160339648551"
+    },
+    "transaction": {
+      "href": "https://horizon-testnet.stellar.org/transactions/3d13f059842c775096a20d7132bf4ac6c962811cb0313ff43c7c4881ee9119f3"
+    },
+    "effects": {
+      "href": "https://horizon-testnet.stellar.org/operations/43685160339648551/effects"
     },
     "succeeds": {
-      "href": "/operations?cursor=77309415424&order=desc"
+      "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=43685160339648551"
     },
-    "transactions": {
-      "href": "/transactions/77309415424"
+    "precedes": {
+      "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=43685160339648551"
     }
   },
-  "account": "GBIA4FH6TV64KSPDAJCNUQSM7PFL4ILGUVJDPCLUOPJ7ONMKBBVUQHRO",
-  "funder": "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ",
-  "id": 77309415424,
-  "paging_token": "77309415424",
-  "starting_balance": 1e+14,
-  "type_i": 0,
-  "type": "create_account"
+  "id": "43685160339648551",
+  "paging_token": "43685160339648551",
+  "source_account": "GDWGJSTUVRNFTR7STPUUHFWQYAN6KBVWCZT2YN7MY276GCSSXSWPS6JY",
+  "type": "manage_offer",
+  "type_i": 3,
+  "created_at": "2018-07-23T18:14:46Z",
+  "transaction_hash": "3d13f059842c775096a20d7132bf4ac6c962811cb0313ff43c7c4881ee9119f3",
+  "amount": "828.3700000",
+  "price": "0.2898700",
+  "price_r": {
+    "n": 28987,
+    "d": 100000
+  },
+  "buying_asset_type": "credit_alphanum4",
+  "buying_asset_code": "USD",
+  "buying_asset_issuer": "GA7RXKBZOUA3FCUUS65JRLU5SZD3XBQUGRWL7NVQWU5QOXQW2LUZNBFZ",
+  "selling_asset_type": "native",
+  "offer_id": 526476
 }
 ```
 

--- a/services/horizon/internal/docs/reference/endpoints/orderbook-details.md
+++ b/services/horizon/internal/docs/reference/endpoints/orderbook-details.md
@@ -37,14 +37,34 @@ curl "https://horizon-testnet.stellar.org/order_book?selling_asset_type=native&b
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.orderbook(new StellarSdk.Asset.native(), new StellarSdk.Asset('FOO', 'GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG'))
   .call()
-  .then(function(resp) { console.log(resp); })
-  .catch(function(err) { console.log(err); })
+  .then(function(resp) { 
+  	console.log(resp); 
+  })
+  .catch(function(err) { 
+  	console.log(err); 
+  })
+```
+
+### JavaScript Streaming Example
+
+```javascript
+var StellarSdk = require('stellar-sdk')
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+var orderbookHandler = function (orderbookResponse) {
+    console.log(orderbookResponse);
+};
+
+var es = server.orderbook(new StellarSdk.Asset.native(), new StellarSdk.Asset('FOO', 'GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG'))
+    .stream({
+        onmessage: orderbookHandler
+    })
 ```
 
 ## Response

--- a/services/horizon/internal/docs/reference/endpoints/path-finding.md
+++ b/services/horizon/internal/docs/reference/endpoints/path-finding.md
@@ -36,7 +36,29 @@ GET /paths?destination_account={da}&source_account={sa}&destination_asset_type={
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/paths?destination_account=GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V&source_account=GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP&destination_asset_type=credit_alphanum4&destination_asset_code=EUR&destination_asset_issuer=GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN&destination_amount=20"
+curl "https://horizon-testnet.stellar.org/paths?destination_account=GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V&source_account=GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP&destination_asset_type=native&destination_amount=20"
+```
+
+### JavaScript Example Request
+
+```javascript
+var StellarSdk = require('stellar-sdk');
+var StellarSdk = require('stellar-sdk')
+StellarSdk.Network.useTestNetwork();
+
+var source_account = "GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP";
+var destination_account = "GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V";
+var destination_asset = StellarSdk.Asset.native();
+var destination_amount = "20";
+
+server.paths(source_account, destination_account, destination_asset, destination_amount)
+    .call()
+    .then(function (pathResult) {
+        console.log(pathResult.records);
+    })
+    .catch(function (err) {
+        console.log(err)
+    })
 ```
 
 ## Response
@@ -50,61 +72,39 @@ This endpoint responds with a page of path resources.  See [path resource](../re
   "_embedded": {
     "records": [
       {
+        "source_asset_type": "native",
+        "source_amount": "20.0000000",
+        "destination_asset_type": "native",
         "destination_amount": "20.0000000",
-        "destination_asset_code": "EUR",
-        "destination_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-        "destination_asset_type": "credit_alphanum4",
-        "path": [],
-        "source_amount": "30.0000000",
-        "source_asset_code": "USD",
-        "source_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-        "source_asset_type": "credit_alphanum4"
+        "path": []
       },
       {
+        "source_asset_type": "native",
+        "source_amount": "20.1161232",
+        "destination_asset_type": "native",
         "destination_amount": "20.0000000",
-        "destination_asset_code": "EUR",
-        "destination_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-        "destination_asset_type": "credit_alphanum4",
         "path": [
           {
-            "asset_code": "1",
-            "asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-            "asset_type": "credit_alphanum4"
+            "asset_type": "credit_alphanum4",
+            "asset_code": "ALL",
+            "asset_issuer": "GBANKHXFXNOST75HZRTJGNJWB7QYQ6WWK3PVJKD6VD6ZXPCX3HNNTLLK"
           }
-        ],
-        "source_amount": "20.0000000",
-        "source_asset_code": "USD",
-        "source_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-        "source_asset_type": "credit_alphanum4"
+        ]
       },
       {
+        "source_asset_type": "native",
+        "source_amount": "21.5280000",
+        "destination_asset_type": "native",
         "destination_amount": "20.0000000",
-        "destination_asset_code": "EUR",
-        "destination_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-        "destination_asset_type": "credit_alphanum4",
         "path": [
           {
-            "asset_code": "21",
-            "asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-            "asset_type": "credit_alphanum4"
-          },
-          {
-            "asset_code": "22",
-            "asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-            "asset_type": "credit_alphanum4"
+            "asset_type": "credit_alphanum4",
+            "asset_code": "ICBC",
+            "asset_issuer": "GCTS32RGWRH6RJM62UVZ4UT5ZN5L6B2D3LPGO6Z2NM2EOGVQA7TA6SKO"
           }
-        ],
-        "source_amount": "20.0000000",
-        "source_asset_code": "USD",
-        "source_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-        "source_asset_type": "credit_alphanum4"
+        ]
       }
     ]
-  },
-  "_links": {
-    "self": {
-      "href": "/paths"
-    }
   }
 }
 ```

--- a/services/horizon/internal/docs/reference/endpoints/payments-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/payments-all.md
@@ -42,7 +42,7 @@ curl "https://horizon-testnet.stellar.org/payments?cursor=1234&order=desc"
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
@@ -55,6 +55,23 @@ server.payments()
     console.log(err)
   })
 ```
+
+### JavaScript Streaming Example
+
+```javascript
+var StellarSdk = require('stellar-sdk')
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+var paymentHandler = function (paymentResponse) {
+    console.log(paymentResponse);
+};
+
+var es = server.payments()
+    .stream({
+        onmessage: paymentHandler
+    })
+```
+
 ## Response
 
 This endpoint responds with a list of payments. See [operation resource](../resources/operation.md) for more information about operations (and payment operations).

--- a/services/horizon/internal/docs/reference/endpoints/payments-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/payments-for-account.md
@@ -39,7 +39,7 @@ curl "https://horizon-testnet.stellar.org/accounts/GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
@@ -53,6 +53,24 @@ server.payments()
     console.error(err);
   })
 ```
+
+### JavaScript Streaming Example
+
+```javascript
+var StellarSdk = require('stellar-sdk')
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+var paymentHandler = function (paymentResponse) {
+    console.log(paymentResponse);
+};
+
+var es = server.payments()
+    .forAccount("GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ")
+    .stream({
+        onmessage: paymentHandler
+    })
+```
+
 ## Response
 
 This endpoint responds with a [page](../resources/page.md) of [payment operations](../resources/operation.md).

--- a/services/horizon/internal/docs/reference/endpoints/payments-for-ledger.md
+++ b/services/horizon/internal/docs/reference/endpoints/payments-for-ledger.md
@@ -22,7 +22,7 @@ GET /ledgers/{id}/payments{?cursor,limit,order}
 
 |  name  |  notes  | description | example |
 | ------ | ------- | ----------- | ------- |
-| `id` | required, number | Ledger ID | `69859` |
+| `id` | required, number | Ledger ID | `10009866` |
 | `?cursor` | optional, default _null_ | A paging token, specifying where to start returning records from. | `12884905984` |
 | `?order`  | optional, string, default `asc` | The order in which to return rows, "asc" or "desc". | `asc` |
 | `?limit`  | optional, number, default `10` | Maximum number of records to return. | `200` |
@@ -30,17 +30,17 @@ GET /ledgers/{id}/payments{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/ledgers/69859/payments"
+curl "https://horizon-testnet.stellar.org/ledgers/10009866/payments?limit=1"
 ```
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk')
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.payments()
-  .forLedger("10866")
+  .forLedger("10009866")
   .call()
   .then(function (paymentResult) {
     console.log(paymentResult)
@@ -58,47 +58,52 @@ This endpoint responds with a list of payment operations in a given ledger.  See
 
 ```json
 {
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/10009866/payments?cursor=\u0026limit=1\u0026order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/10009866/payments?cursor=42992047107346433\u0026limit=1\u0026order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/10009866/payments?cursor=42992047107346433\u0026limit=1\u0026order=desc"
+    }
+  },
   "_embedded": {
     "records": [
       {
         "_links": {
-          "effects": {
-            "href": "/operations/77309415424/effects/{?cursor,limit,order}",
-            "templated": true
-          },
-          "precedes": {
-            "href": "/operations?cursor=77309415424&order=asc"
-          },
           "self": {
-            "href": "/operations/77309415424"
+            "href": "https://horizon-testnet.stellar.org/operations/42992047107346433"
+          },
+          "transaction": {
+            "href": "https://horizon-testnet.stellar.org/transactions/e235cf90e6cc5c84ec6912dc3cbd13b627f43eca8ac59eae34872c224c5a728c"
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/operations/42992047107346433/effects"
           },
           "succeeds": {
-            "href": "/operations?cursor=77309415424&order=desc"
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=42992047107346433"
           },
-          "transactions": {
-            "href": "/transactions/77309415424"
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=42992047107346433"
           }
         },
-        "account": "GBIA4FH6TV64KSPDAJCNUQSM7PFL4ILGUVJDPCLUOPJ7ONMKBBVUQHRO",
-        "funder": "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ",
-        "id": 77309415424,
-        "paging_token": "77309415424",
-        "starting_balance": 1e+14,
-        "type_i": 0,
-        "type": "create_account"
+        "id": "42992047107346433",
+        "paging_token": "42992047107346433",
+        "source_account": "GCANEDZUIL7MBBWWCTQ25534UMCOIQLEH3IPOCU7W7H6LK7I35WAE7BI",
+        "type": "payment",
+        "type_i": 1,
+        "created_at": "2018-07-14T09:59:20Z",
+        "transaction_hash": "e235cf90e6cc5c84ec6912dc3cbd13b627f43eca8ac59eae34872c224c5a728c",
+        "asset_type": "credit_alphanum12",
+        "asset_code": "nCntGameCoin",
+        "asset_issuer": "GDLMDXI6EVVUIXWRU4S2YVZRMELHUEX3WKOX6XFW77QQC6KZJ4CZ7NRB",
+        "from": "GCANEDZUIL7MBBWWCTQ25534UMCOIQLEH3IPOCU7W7H6LK7I35WAE7BI",
+        "to": "GC25MF2YFV2KTBVVVL7HT3PHAMGV7N46DVL75MJU4IVXSXVTAOIIHKCM",
+        "amount": "1.0000000"
       }
     ]
-  },
-  "_links": {
-    "next": {
-      "href": "?order=asc&limit=10&cursor=77309415424"
-    },
-    "prev": {
-      "href": "?order=desc&limit=10&cursor=77309415424"
-    },
-    "self": {
-      "href": "?order=asc&limit=10&cursor="
-    }
   }
 }
 ```

--- a/services/horizon/internal/docs/reference/endpoints/payments-for-transaction.md
+++ b/services/horizon/internal/docs/reference/endpoints/payments-for-transaction.md
@@ -30,17 +30,17 @@ GET /transactions/{hash}/payments{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/transactions/3c8ef808df9d5d240ba0d495629df9da5653b1be2daf05d43b49c5bcbfe099bd/payments"
+curl "https://horizon-testnet.stellar.org/transactions/622d566df3ee61848be3c3211f614310082f4a09c959cbee7be6990b0dccdba8/payments"
 ```
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.payments()
-  .forTransaction("3c8ef808df9d5d240ba0d495629df9da5653b1be2daf05d43b49c5bcbfe099bd")
+  .forTransaction("622d566df3ee61848be3c3211f614310082f4a09c959cbee7be6990b0dccdba8")
   .call()
   .then(function (paymentResult) {
     console.log(paymentResult.records);
@@ -49,6 +49,7 @@ server.payments()
     console.log(err);
   })
 ```
+
 ## Response
 
 This endpoint responds with a list of payments operations that are part of a given transaction. See [operation resource](../resources/operation.md) for more information about operations (and payment operations).
@@ -57,47 +58,52 @@ This endpoint responds with a list of payments operations that are part of a giv
 
 ```json
 {
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/transactions/622d566df3ee61848be3c3211f614310082f4a09c959cbee7be6990b0dccdba8/payments?cursor=\u0026limit=10\u0026order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/transactions/622d566df3ee61848be3c3211f614310082f4a09c959cbee7be6990b0dccdba8/payments?cursor=43456504870744065\u0026limit=10\u0026order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/transactions/622d566df3ee61848be3c3211f614310082f4a09c959cbee7be6990b0dccdba8/payments?cursor=43456504870744065\u0026limit=10\u0026order=desc"
+    }
+  },
   "_embedded": {
     "records": [
       {
         "_links": {
-          "effects": {
-            "href": "/operations/46428596473856/effects/{?cursor,limit,order}",
-            "templated": true
-          },
-          "precedes": {
-            "href": "/operations?cursor=46428596473856&order=asc"
-          },
           "self": {
-            "href": "/operations/46428596473856"
+            "href": "https://horizon-testnet.stellar.org/operations/43456504870744065"
+          },
+          "transaction": {
+            "href": "https://horizon-testnet.stellar.org/transactions/622d566df3ee61848be3c3211f614310082f4a09c959cbee7be6990b0dccdba8"
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/operations/43456504870744065/effects"
           },
           "succeeds": {
-            "href": "/operations?cursor=46428596473856&order=desc"
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=43456504870744065"
           },
-          "transactions": {
-            "href": "/transactions/46428596473856"
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=43456504870744065"
           }
         },
-        "account": "GAKLBGHNHFQ3BMUYG5KU4BEWO6EYQHZHAXEWC33W34PH2RBHZDSQBD75",
-        "funder": "GBIA4FH6TV64KSPDAJCNUQSM7PFL4ILGUVJDPCLUOPJ7ONMKBBVUQHRO",
-        "id": 46428596473856,
-        "paging_token": "46428596473856",
-        "starting_balance": 1e+09,
-        "type_i": 0,
-        "type": "create_account"
+        "id": "43456504870744065",
+        "paging_token": "43456504870744065",
+        "source_account": "GCEDON5M2HFQ5P5MVWYGKH3K4S3ZKQFZ5AYLWNXPSGVOHLJUXQRYL35Z",
+        "type": "payment",
+        "type_i": 1,
+        "created_at": "2018-07-20T16:12:46Z",
+        "transaction_hash": "622d566df3ee61848be3c3211f614310082f4a09c959cbee7be6990b0dccdba8",
+        "asset_type": "credit_alphanum12",
+        "asset_code": "nCntGameCoin",
+        "asset_issuer": "GDLMDXI6EVVUIXWRU4S2YVZRMELHUEX3WKOX6XFW77QQC6KZJ4CZ7NRB",
+        "from": "GCEDON5M2HFQ5P5MVWYGKH3K4S3ZKQFZ5AYLWNXPSGVOHLJUXQRYL35Z",
+        "to": "GAWHFIIG2LTBO4Q5ZCTMPGYVV3FSQE4TCXPFTL44V5BN5FLR3GRGJB5G",
+        "amount": "1.0000000"
       }
     ]
-  },
-  "_links": {
-    "next": {
-      "href": "?order=asc&limit=10&cursor=46428596473856"
-    },
-    "prev": {
-      "href": "?order=desc&limit=10&cursor=46428596473856"
-    },
-    "self": {
-      "href": "?order=asc&limit=10&cursor="
-    }
   }
 }
 ```

--- a/services/horizon/internal/docs/reference/endpoints/trade_aggregations.md
+++ b/services/horizon/internal/docs/reference/endpoints/trade_aggregations.md
@@ -32,13 +32,35 @@ GET /trade_aggregations?base_asset_type={base_asset_type}&base_asset_code={base_
 curl https://horizon.stellar.org/trade_aggregations?base_asset_type=native&counter_asset_code=SLT&counter_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP&counter_asset_type=credit_alphanum4&limit=200&order=asc&resolution=3600000&start_time=1517521726000&end_time=1517532526000
 ```
 
+### JavaScript Example Request
+
+```javascript
+var StellarSdk = require('stellar-sdk');
+var server = new StellarSdk.Server('https://horizon.stellar.org');
+
+var base = new StellarSdk.Asset.native();
+var counter = new StellarSdk.Asset("SLT", "GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP");
+var startTime = 1517521726000;
+var endTime = 1517532526000;
+var resolution = 3600000;
+
+server.tradeAggregation(base, counter, startTime, endTime, resolution)
+  .call()
+  .then(function (tradeAggregation) {
+    console.log(tradeAggregation);
+  })
+  .catch(function (err) {
+    console.log(err);
+  })
+```
+
 ## Response
 
 A list of collected trade aggregations.
 
 Note
 - Segments that fit into the time range but have 0 trades in them, will not be included.
-- Partial segments, in the beginning and end of the time range, will not be included.
+- Partial segments, in the beginning and end of the time range, will not be included. Thus if your start time is noon Wednesday, your end time is noon Thursday, and your resolution is one day, you will not receive back any data. Instead, you would want to either start at midnight Wednesday and midnight Thursday, or shorten the resolution interval to better cover your time frame. 
 
 ### Example Response
 ```json

--- a/services/horizon/internal/docs/reference/endpoints/trades-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/trades-for-account.md
@@ -29,12 +29,12 @@ curl "https://horizon-testnet.stellar.org/accounts/GBYTR4MC5JAX4ALGUBJD7EIKZVM7C
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.trades()
-  .forAccount("GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ")
+  .forAccount("GBYTR4MC5JAX4ALGUBJD7EIKZVM7CUGWKXIUJMRSMK573XH2O7VAK3SR")
   .call()
   .then(function (accountResult) {
     console.log(accountResult);

--- a/services/horizon/internal/docs/reference/endpoints/trades.md
+++ b/services/horizon/internal/docs/reference/endpoints/trades.md
@@ -4,7 +4,7 @@ title: Trades
 
 People on the Stellar network can make [offers](../resources/offer.md) to buy or sell assets. When an offer is fully or partially fulfilled, a [trade](../resources/trade.md) happens.
 
-Trades can be filtered for specific orderbook, defined by an asset pair: `base` and `counter`. 
+Trades can be filtered for a specific orderbook, defined by an asset pair: `base` and `counter`. 
 
 ## Request
 
@@ -30,6 +30,22 @@ GET /trades?base_asset_type={base_asset_type}&base_asset_code={base_asset_code}&
 ### curl Example Request
 ```sh 
 curl https://horizon.stellar.org/trades?base_asset_type=native&counter_asset_code=SLT&counter_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP&counter_asset_type=credit_alphanum4&limit=2&order=desc
+```
+
+### JavaScript Example Request
+
+```javascript
+var StellarSdk = require('stellar-sdk');
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+server.trades()
+  .call()
+  .then(function (tradesResult) {
+    console.log(tradesResult.records);
+  })
+  .catch(function (err) {
+    console.log(err)
+  })
 ```
 
 ## Response

--- a/services/horizon/internal/docs/reference/endpoints/transactions-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/transactions-all.md
@@ -31,7 +31,7 @@ curl "https://horizon-testnet.stellar.org/transactions?limit=200&order=desc"
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
@@ -48,6 +48,22 @@ server.transactions()
   .catch(function (err) {
     console.log(err)
   })
+```
+
+### JavaScript Streaming Example
+
+```javascript
+var StellarSdk = require('stellar-sdk')
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+var txHandler = function (txResponse) {
+    console.log(txResponse);
+};
+
+var es = server.transactions()
+    .stream({
+        onmessage: txHandler
+    })
 ```
 
 ## Response

--- a/services/horizon/internal/docs/reference/endpoints/transactions-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/transactions-for-account.md
@@ -18,7 +18,7 @@ GET /accounts/{account_id}/transactions{?cursor,limit,order}
 
 | name | notes | description | example |
 | ---- | ----- | ----------- | ------- |
-| `account_id` | required, string | ID of an account | GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ |
+| `account_id` | required, string | ID of an account | GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K |
 | `?cursor` | optional, any, default _null_ | A paging token, specifying where to start returning records from. When streaming this can be set to `now` to stream object created since your request time. | 12884905984 |
 | `?order`  | optional, string, default `asc` | The order in which to return rows, "asc" or "desc". | `asc` |
 | `?limit`  | optional, number, default: `10` | Maximum number of records to return. | `200` |
@@ -26,17 +26,17 @@ GET /accounts/{account_id}/transactions{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/accounts/GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ/transactions?limit=1"
+curl "https://horizon-testnet.stellar.org/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K/transactions?limit=1"
 ```
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.transactions()
-  .forAccount("GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ")
+  .forAccount("GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K")
   .call()
   .then(function (accountResult) {
     console.log(accountResult);
@@ -46,6 +46,23 @@ server.transactions()
   })
 ```
 
+### JavaScript Streaming Example
+
+```javascript
+var StellarSdk = require('stellar-sdk')
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+var txHandler = function (txResponse) {
+    console.log(txResponse);
+};
+
+var es = server.transactions()
+    .forAccount("GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K")
+    .stream({
+        onmessage: txHandler
+    })
+```
+
 ## Response
 
 This endpoint responds with a list of transactions that changed a given account's state. See [transaction resource](../resources/transaction.md) for reference.
@@ -53,60 +70,64 @@ This endpoint responds with a list of transactions that changed a given account'
 ### Example Response
 ```json
 {
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ/transactions?cursor=&limit=1&order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ/transactions?cursor=25731149074432&limit=1&order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ/transactions?cursor=25731149074432&limit=1&order=desc"
+    }
+  },
   "_embedded": {
     "records": [
       {
         "_links": {
-          "account": {
-            "href": "/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/transactions/d486852ab6f96ec9f16d8972ef11199947a2c22132ac47f4bc645a186dc518c8"
           },
-          "effects": {
-            "href": "/transactions/2a2beb163e2c68bd2377aab243d68225626d70263444a85556ec7271d4e46e03/effects{?cursor,limit,order}",
-            "templated": true
+          "account": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K"
           },
           "ledger": {
-            "href": "/ledgers/33"
+            "href": "https://horizon-testnet.stellar.org/ledgers/5991"
           },
           "operations": {
-            "href": "/transactions/2a2beb163e2c68bd2377aab243d68225626d70263444a85556ec7271d4e46e03/operations{?cursor,limit,order}",
+            "href": "https://horizon-testnet.stellar.org/transactions/d486852ab6f96ec9f16d8972ef11199947a2c22132ac47f4bc645a186dc518c8/operations{?cursor,limit,order}",
+            "templated": true
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/transactions/d486852ab6f96ec9f16d8972ef11199947a2c22132ac47f4bc645a186dc518c8/effects{?cursor,limit,order}",
             "templated": true
           },
           "precedes": {
-            "href": "/transactions?cursor=141733924864&order=asc"
-          },
-          "self": {
-            "href": "/transactions/2a2beb163e2c68bd2377aab243d68225626d70263444a85556ec7271d4e46e03"
+            "href": "https://horizon-testnet.stellar.org/transactions?order=asc&cursor=25731149074432"
           },
           "succeeds": {
-            "href": "/transactions?cursor=141733924864&order=desc"
+            "href": "https://horizon-testnet.stellar.org/transactions?order=desc&cursor=25731149074432"
           }
         },
-        "id": "2a2beb163e2c68bd2377aab243d68225626d70263444a85556ec7271d4e46e03",
-        "paging_token": "141733924864",
-        "hash": "2a2beb163e2c68bd2377aab243d68225626d70263444a85556ec7271d4e46e03",
-        "ledger": 33,
-        "created_at": "2015-09-09T02:46:44Z",
-        "account": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
-        "account_sequence": 1,
-        "max_fee": 0,
-        "fee_paid": 0,
+        "id": "d486852ab6f96ec9f16d8972ef11199947a2c22132ac47f4bc645a186dc518c8",
+        "paging_token": "25731149074432",
+        "hash": "d486852ab6f96ec9f16d8972ef11199947a2c22132ac47f4bc645a186dc518c8",
+        "ledger": 5991,
+        "created_at": "2017-03-20T23:39:43Z",
+        "source_account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
+        "source_account_sequence": "10157597655056",
+        "fee_paid": 100,
         "operation_count": 1,
-        "envelope_xdr": "AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAACgAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAZc2EuuEa2W1PAKmaqVquHuzUMHaEiRs//+ODOfgWiz8AAFrzEHpAAAAAAAAAAAABVvwF9wAAAEAhwIlmkDnlvOaUnj5NMyGlu7XlGLUqUoigWbbMwLS0Em99ZrEh/Gd85pz7hGtAxNMj335utvGDUOAm9WAewEYE",
-        "result_xdr": "KivrFj4saL0jd6qyQ9aCJWJtcCY0RKhVVuxycdTkbgMAAAAAAAAACgAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==",
-        "result_meta_xdr": "AAAAAAAAAAEAAAABAAAAIQAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcBY0V4XYn/9gAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAgAAAAAAAAAhAAAAAAAAAABlzYS64RrZbU8AqZqpWq4e7NQwdoSJGz//44M5+BaLPwAAWvMQekAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAAhAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wFi6oVND7/2AAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        "envelope_xdr": "AAAAAGXNhLrhGtltTwCpmqlarh7s1DB2hIkbP//jgzn4Fos/AAAAZAAACT0AAAAQAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAiZsoQO1WNsVt3F8Usjl1958bojiNJpTkxW7N3clg5e8AAAAXSHboAAAAAAAAAAAB+BaLPwAAAEColV/6xTnefW6UqmMpu/Nn4flKsMxvlmQNSV6eBITUXonKWI5GhCC/HW1CRcnxmVR7NftBzkbBatnGgtWPraUH",
+        "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+        "result_meta_xdr": "AAAAAAAAAAEAAAACAAAAAAAAF2cAAAAAAAAAAImbKEDtVjbFbdxfFLI5dfefG6I4jSaU5MVuzd3JYOXvAAAAF0h26AAAABdnAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQAAF2cAAAAAAAAAAGXNhLrhGtltTwCpmqlarh7s1DB2hIkbP//jgzn4Fos/AAHFSsr0ucAAAAk9AAAAEAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAA",
+        "fee_meta_xdr": "AAAAAgAAAAMAABMBAAAAAAAAAABlzYS64RrZbU8AqZqpWq4e7NQwdoSJGz//44M5+BaLPwABxWITa6IkAAAJPQAAAA8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAABdnAAAAAAAAAABlzYS64RrZbU8AqZqpWq4e7NQwdoSJGz//44M5+BaLPwABxWITa6HAAAAJPQAAABAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+        "memo_type": "none",
+        "signatures": [
+          "qJVf+sU53n1ulKpjKbvzZ+H5SrDMb5ZkDUlengSE1F6JyliORoQgvx1tQkXJ8ZlUezX7Qc5GwWrZxoLVj62lBw=="
+        ]
       }
     ]
-  },
-  "_links": {
-    "next": {
-      "href": "/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K/transactions?order=asc&limit=1&cursor=141733924864"
-    },
-    "prev": {
-      "href": "/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K/transactions?order=desc&limit=1&cursor=141733924864"
-    },
-    "self": {
-      "href": "/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K/transactions?order=asc&limit=1&cursor="
-    }
   }
 }
 ```

--- a/services/horizon/internal/docs/reference/endpoints/transactions-for-ledger.md
+++ b/services/horizon/internal/docs/reference/endpoints/transactions-for-ledger.md
@@ -16,7 +16,7 @@ GET /ledgers/{id}/transactions{?cursor,limit,order}
 
 |  name  |  notes  | description | example |
 | ------ | ------- | ----------- | ------- |
-| `id` | required, number | Ledger ID | `69859` |
+| `id` | required, number | Ledger ID | `9000000` |
 | `?cursor` | optional, default _null_ | A paging token, specifying where to start returning records from. | `12884905984` |
 | `?order`  | optional, string, default `asc` | The order in which to return rows, "asc" or "desc". | `asc` |
 | `?limit`  | optional, number, default `10` | Maximum number of records to return. | `200` |
@@ -24,17 +24,18 @@ GET /ledgers/{id}/transactions{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/ledgers/69859/transactions"
+curl "https://horizon-testnet.stellar.org/ledgers/9000000/transactions?limit=1"
 ```
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.transactions()
-  .forLedger("8365")
+  .forLedger("9000000")
+  .limit("1")
   .call()
   .then(function (accountResults) {
     console.log(accountResults.records)
@@ -52,60 +53,65 @@ This endpoint responds with a list of transactions in a given ledger.  See [tran
 
 ```json
 {
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/9000000/transactions?cursor=\u0026limit=1\u0026order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/9000000/transactions?cursor=38654705664004096\u0026limit=1\u0026order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/9000000/transactions?cursor=38654705664004096\u0026limit=1\u0026order=desc"
+    }
+  },
   "_embedded": {
     "records": [
       {
         "_links": {
-          "account": {
-            "href": "/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K"
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/transactions/2b5742600b45f2051d9e4d85d900e271d11c46ec1fccfb54469b1e5d3326585e"
           },
-          "effects": {
-            "href": "/transactions/fa78cb43d72171fdb2c6376be12d57daa787b1fa1a9fdd0e9453e1f41ee5f15a/effects{?cursor,limit,order}",
-            "templated": true
+          "account": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GBBPUGFZQCQX4MCU5SJZECQZCAISVI6EQXQSW2MNJXPCK3QVSWGYYAA7"
           },
           "ledger": {
-            "href": "/ledgers/146970"
+            "href": "https://horizon-testnet.stellar.org/ledgers/9000000"
           },
           "operations": {
-            "href": "/transactions/fa78cb43d72171fdb2c6376be12d57daa787b1fa1a9fdd0e9453e1f41ee5f15a/operations{?cursor,limit,order}",
+            "href": "https://horizon-testnet.stellar.org/transactions/2b5742600b45f2051d9e4d85d900e271d11c46ec1fccfb54469b1e5d3326585e/operations{?cursor,limit,order}",
+            "templated": true
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/transactions/2b5742600b45f2051d9e4d85d900e271d11c46ec1fccfb54469b1e5d3326585e/effects{?cursor,limit,order}",
             "templated": true
           },
           "precedes": {
-            "href": "/transactions?cursor=631231343497216\u0026order=asc"
-          },
-          "self": {
-            "href": "/transactions/fa78cb43d72171fdb2c6376be12d57daa787b1fa1a9fdd0e9453e1f41ee5f15a"
+            "href": "https://horizon-testnet.stellar.org/transactions?order=asc\u0026cursor=38654705664004096"
           },
           "succeeds": {
-            "href": "/transactions?cursor=631231343497216\u0026order=desc"
+            "href": "https://horizon-testnet.stellar.org/transactions?order=desc\u0026cursor=38654705664004096"
           }
         },
-        "id": "fa78cb43d72171fdb2c6376be12d57daa787b1fa1a9fdd0e9453e1f41ee5f15a",
-        "paging_token": "631231343497216",
-        "hash": "fa78cb43d72171fdb2c6376be12d57daa787b1fa1a9fdd0e9453e1f41ee5f15a",
-        "ledger": 146970,
-        "created_at": "2015-09-24T10:07:09Z",
-        "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
-        "account_sequence": 279172874343,
-        "max_fee": 0,
-        "fee_paid": 0,
+        "id": "2b5742600b45f2051d9e4d85d900e271d11c46ec1fccfb54469b1e5d3326585e",
+        "paging_token": "38654705664004096",
+        "hash": "2b5742600b45f2051d9e4d85d900e271d11c46ec1fccfb54469b1e5d3326585e",
+        "ledger": 9000000,
+        "created_at": "2018-05-16T20:39:57Z",
+        "source_account": "GBBPUGFZQCQX4MCU5SJZECQZCAISVI6EQXQSW2MNJXPCK3QVSWGYYAA7",
+        "source_account_sequence": "26088580543780806",
+        "fee_paid": 100,
         "operation_count": 1,
-        "envelope_xdr": "AAAAAGXNhLrhGtltTwCpmqlarh7s1DB2hIkbP//jgzn4Fos/AAAACgAAAEEAAABnAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA2ddmTOFAgr21Crs2RXRGLhiAKxicZb/IERyEZL/Y2kUAAAAXSHboAAAAAAAAAAAB+BaLPwAAAECDEEZmzbgBr5fc3mfJsCjWPDtL6H8/vf16me121CC09ONyWJZnw0PUvp4qusmRwC6ZKfLDdk8F3Rq41s+yOgQD",
-        "result_xdr": "AAAAAAAAAAoAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
-        "result_meta_xdr": "AAAAAAAAAAEAAAACAAAAAAACPhoAAAAAAAAAANnXZkzhQIK9tQq7NkV0Ri4YgCsYnGW/yBEchGS/2NpFAAAAF0h26AAAAj4aAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQACPhoAAAAAAAAAAGXNhLrhGtltTwCpmqlarh7s1DB2hIkbP//jgzn4Fos/AABT8kS2c/oAAABBAAAAZwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAA"
+        "envelope_xdr": "AAAAAEL6GLmAoX4wVOyTkgoZEBEqo8SF4StpjU3eJW4VlY2MAAAAZABcr20AAZfGAAAAAAAAAAEAAAAUUDowLjc1MTA4NjY5OTkyODg2MjYAAAABAAAAAAAAAAEAAAAAOTWBGXr2eMo9a57pGIn+2nsIC5m6m9n68vTStJnCP7wAAAACWmlmQ29pbgAAAAAAAAAAAEL6GLmAoX4wVOyTkgoZEBEqo8SF4StpjU3eJW4VlY2MAAAAAAABhqAAAAAAAAAAARWVjYwAAABA4yDYtVvMiSuHkh0syb43MedFwsjHgqmFtA618Z5e/dZ3zobWMY3SPvY81mNw8fbSpHLg0lYzIjHNo5dbAvCaAw==",
+        "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+        "result_meta_xdr": "AAAAAAAAAAEAAAACAAAAAwCJVD4AAAABAAAAADk1gRl69njKPWue6RiJ/tp7CAuZupvZ+vL00rSZwj+8AAAAAlppZkNvaW4AAAAAAAAAAABC+hi5gKF+MFTsk5IKGRARKqPEheEraY1N3iVuFZWNjAAAAAACAjigf/////////8AAAABAAAAAAAAAAAAAAABAIlUQAAAAAEAAAAAOTWBGXr2eMo9a57pGIn+2nsIC5m6m9n68vTStJnCP7wAAAACWmlmQ29pbgAAAAAAAAAAAEL6GLmAoX4wVOyTkgoZEBEqo8SF4StpjU3eJW4VlY2MAAAAAAIDv0B//////////wAAAAEAAAAAAAAAAA==",
+        "fee_meta_xdr": "AAAAAgAAAAMAiVQ+AAAAAAAAAABC+hi5gKF+MFTsk5IKGRARKqPEheEraY1N3iVuFZWNjAAADSzkRrSMAFyvbQABl8UAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAiVRAAAAAAAAAAABC+hi5gKF+MFTsk5IKGRARKqPEheEraY1N3iVuFZWNjAAADSzkRrQoAFyvbQABl8YAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+        "memo_type": "text",
+        "memo": "P:0.7510866999288626",
+        "signatures": [
+          "4yDYtVvMiSuHkh0syb43MedFwsjHgqmFtA618Z5e/dZ3zobWMY3SPvY81mNw8fbSpHLg0lYzIjHNo5dbAvCaAw=="
+        ]
       }
     ]
-  },
-  "_links": {
-    "next": {
-      "href": "/ledgers/146970/transactions?order=asc\u0026limit=10\u0026cursor=631231343497216"
-    },
-    "prev": {
-      "href": "/ledgers/146970/transactions?order=desc\u0026limit=10\u0026cursor=631231343497216"
-    },
-    "self": {
-      "href": "/ledgers/146970/transactions?order=asc\u0026limit=10\u0026cursor="
-    }
   }
 }
 ```

--- a/services/horizon/internal/docs/reference/endpoints/transactions-single.md
+++ b/services/horizon/internal/docs/reference/endpoints/transactions-single.md
@@ -16,22 +16,22 @@ GET /transactions/{hash}
 
 |  name  |  notes  | description | example |
 | ------ | ------- | ----------- | ------- |
-| `hash` | required, string | A transaction hash, hex-encoded. | 6391dd190f15f7d1665ba53c63842e368f485651a53d8d852ed442a446d1c69a |
+| `hash` | required, string | A transaction hash, hex-encoded. | 85b0084a82a055dc1b3c9312277c97b13baca5377d23d4b4fde36c01467edf9c |
 
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/transactions/6391dd190f15f7d1665ba53c63842e368f485651a53d8d852ed442a446d1c69a"
+curl "https://horizon-testnet.stellar.org/transactions/85b0084a82a055dc1b3c9312277c97b13baca5377d23d4b4fde36c01467edf9c"
 ```
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.transactions()
-  .transaction("3c8ef808df9d5d240ba0d495629df9da5653b1be2daf05d43b49c5bcbfe099bd")
+  .transaction("85b0084a82a055dc1b3c9312277c97b13baca5377d23d4b4fde36c01467edf9c")
   .call()
   .then(function (transactionResult) {
     console.log(transactionResult)
@@ -50,43 +50,47 @@ This endpoint responds with a single Transaction.  See [transaction resource](..
 ```json
 {
   "_links": {
-    "account": {
-      "href": "/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K"
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/transactions/85b0084a82a055dc1b3c9312277c97b13baca5377d23d4b4fde36c01467edf9c"
     },
-    "effects": {
-      "href": "/transactions/fa78cb43d72171fdb2c6376be12d57daa787b1fa1a9fdd0e9453e1f41ee5f15a/effects{?cursor,limit,order}",
-      "templated": true
+    "account": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GBALEQDXK5F77ZSQEQG6QOOWJVDVVWKOZN2IAKALKXIS34DA5K6OAQW7"
     },
     "ledger": {
-      "href": "/ledgers/146970"
+      "href": "https://horizon-testnet.stellar.org/ledgers/10106016"
     },
     "operations": {
-      "href": "/transactions/fa78cb43d72171fdb2c6376be12d57daa787b1fa1a9fdd0e9453e1f41ee5f15a/operations{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/transactions/85b0084a82a055dc1b3c9312277c97b13baca5377d23d4b4fde36c01467edf9c/operations{?cursor,limit,order}",
+      "templated": true
+    },
+    "effects": {
+      "href": "https://horizon-testnet.stellar.org/transactions/85b0084a82a055dc1b3c9312277c97b13baca5377d23d4b4fde36c01467edf9c/effects{?cursor,limit,order}",
       "templated": true
     },
     "precedes": {
-      "href": "/transactions?cursor=631231343497216\u0026order=asc"
-    },
-    "self": {
-      "href": "/transactions/fa78cb43d72171fdb2c6376be12d57daa787b1fa1a9fdd0e9453e1f41ee5f15a"
+      "href": "https://horizon-testnet.stellar.org/transactions?order=asc&cursor=43405008212856832"
     },
     "succeeds": {
-      "href": "/transactions?cursor=631231343497216\u0026order=desc"
+      "href": "https://horizon-testnet.stellar.org/transactions?order=desc&cursor=43405008212856832"
     }
   },
-  "id": "fa78cb43d72171fdb2c6376be12d57daa787b1fa1a9fdd0e9453e1f41ee5f15a",
-  "paging_token": "631231343497216",
-  "hash": "fa78cb43d72171fdb2c6376be12d57daa787b1fa1a9fdd0e9453e1f41ee5f15a",
-  "ledger": 146970,
-  "created_at": "2015-09-24T10:07:09Z",
-  "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
-  "account_sequence": 279172874343,
-  "max_fee": 0,
-  "fee_paid": 0,
+  "id": "85b0084a82a055dc1b3c9312277c97b13baca5377d23d4b4fde36c01467edf9c",
+  "paging_token": "43405008212856832",
+  "hash": "85b0084a82a055dc1b3c9312277c97b13baca5377d23d4b4fde36c01467edf9c",
+  "ledger": 10106016,
+  "created_at": "2018-07-19T23:33:35Z",
+  "source_account": "GBALEQDXK5F77ZSQEQG6QOOWJVDVVWKOZN2IAKALKXIS34DA5K6OAQW7",
+  "source_account_sequence": "37676552632212983",
+  "fee_paid": 100,
   "operation_count": 1,
-  "envelope_xdr": "AAAAAGXNhLrhGtltTwCpmqlarh7s1DB2hIkbP//jgzn4Fos/AAAACgAAAEEAAABnAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA2ddmTOFAgr21Crs2RXRGLhiAKxicZb/IERyEZL/Y2kUAAAAXSHboAAAAAAAAAAAB+BaLPwAAAECDEEZmzbgBr5fc3mfJsCjWPDtL6H8/vf16me121CC09ONyWJZnw0PUvp4qusmRwC6ZKfLDdk8F3Rq41s+yOgQD",
-  "result_xdr": "AAAAAAAAAAoAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
-  "result_meta_xdr": "AAAAAAAAAAEAAAACAAAAAAACPhoAAAAAAAAAANnXZkzhQIK9tQq7NkV0Ri4YgCsYnGW/yBEchGS/2NpFAAAAF0h26AAAAj4aAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQACPhoAAAAAAAAAAGXNhLrhGtltTwCpmqlarh7s1DB2hIkbP//jgzn4Fos/AABT8kS2c/oAAABBAAAAZwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAA"
+  "envelope_xdr": "AAAAAECyQHdXS//mUCQN6DnWTUda2U7LdIAoC1XRLfBg6rzgAAAAZACF2qAAAR33AAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAeOZUx7yzGs/KneutLfZFcZJL4ebjDb+8CpB9034zny8AAAACbkNudEdhbWVDb2luAAAAANbB3R4la0Re0aclrFcxYRZ6EvuynX9ctv/hAXlZTwWfAAAAAACYloAAAAAAAAAAAWDqvOAAAABAw/3HdgLG9+9ScBjSDi0htbmOruoaZaQKbCrVIaucQde7zJmexofgt+nnSzx+Sr2+uiEugt0J5hnIQq1kICitCg==",
+  "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+  "result_meta_xdr": "AAAAAAAAAAEAAAAEAAAAAwCaNJQAAAABAAAAAECyQHdXS//mUCQN6DnWTUda2U7LdIAoC1XRLfBg6rzgAAAAAm5DbnRHYW1lQ29pbgAAAADWwd0eJWtEXtGnJaxXMWEWehL7sp1/XLb/4QF5WU8FnwAABsf9bG0Af/////////8AAAABAAAAAAAAAAAAAAABAJo0oAAAAAEAAAAAQLJAd1dL/+ZQJA3oOdZNR1rZTst0gCgLVdEt8GDqvOAAAAACbkNudEdhbWVDb2luAAAAANbB3R4la0Re0aclrFcxYRZ6EvuynX9ctv/hAXlZTwWfAAAGx/zT1oB//////////wAAAAEAAAAAAAAAAAAAAAMAmjSfAAAAAQAAAAB45lTHvLMaz8qd660t9kVxkkvh5uMNv7wKkH3TfjOfLwAAAAJuQ250R2FtZUNvaW4AAAAA1sHdHiVrRF7RpyWsVzFhFnoS+7Kdf1y2/+EBeVlPBZ8AAAbSqRq6gH//////////AAAAAQAAAAAAAAAAAAAAAQCaNKAAAAABAAAAAHjmVMe8sxrPyp3rrS32RXGSS+Hm4w2/vAqQfdN+M58vAAAAAm5DbnRHYW1lQ29pbgAAAADWwd0eJWtEXtGnJaxXMWEWehL7sp1/XLb/4QF5WU8FnwAABtKps1EAf/////////8AAAABAAAAAAAAAAA=",
+  "fee_meta_xdr": "AAAAAgAAAAMAmjSIAAAAAAAAAABAskB3V0v/5lAkDeg51k1HWtlOy3SAKAtV0S3wYOq84AAAABdIBzPoAIXaoAABHfYAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAmjSgAAAAAAAAAABAskB3V0v/5lAkDeg51k1HWtlOy3SAKAtV0S3wYOq84AAAABdIBzOEAIXaoAABHfcAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+  "memo_type": "none",
+  "signatures": [
+    "w/3HdgLG9+9ScBjSDi0htbmOruoaZaQKbCrVIaucQde7zJmexofgt+nnSzx+Sr2+uiEugt0J5hnIQq1kICitCg=="
+  ]
 }
 ```
 

--- a/services/horizon/internal/docs/reference/resources/account.md
+++ b/services/horizon/internal/docs/reference/resources/account.md
@@ -17,7 +17,7 @@ When horizon returns information about an account it uses the following format:
 | subentry_count     | number           | The number of [account subentries](https://www.stellar.org/developers/guides/concepts/ledger.html#ledger-entries). |
 | balances     | array of objects | An array of the native asset or credits this account holds.                                                          |
 | thresholds     | object | An object of account flags. |
-| signers     | array of objects | An array of account signers with their weights. |
+| signers     | array of objects | An array of [account signers](https://www.stellar.org/developers/guides/concepts/multi-sig.html#additional-signing-keys) with their weights. *Note: `public_key` attribute for signer is [deprecated](https://github.com/stellar/go/blob/master/services/horizon/CHANGELOG.md#deprecated), use `key` attribute.* |
 | data     | object | An array of account data fields. |
 
 ## Links
@@ -38,42 +38,42 @@ When horizon returns information about an account it uses the following format:
 {
   "_links": {
     "self": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GBRTWTVW65NO4AER7W6G5CTVWGZCLQJIKJTAX523Q5GPU6TNJONXOR23"
+      "href": "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW"
     },
     "transactions": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GBRTWTVW65NO4AER7W6G5CTVWGZCLQJIKJTAX523Q5GPU6TNJONXOR23/transactions{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW/transactions{?cursor,limit,order}",
       "templated": true
     },
     "operations": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GBRTWTVW65NO4AER7W6G5CTVWGZCLQJIKJTAX523Q5GPU6TNJONXOR23/operations{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW/operations{?cursor,limit,order}",
       "templated": true
     },
     "payments": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GBRTWTVW65NO4AER7W6G5CTVWGZCLQJIKJTAX523Q5GPU6TNJONXOR23/payments{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW/payments{?cursor,limit,order}",
       "templated": true
     },
     "effects": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GBRTWTVW65NO4AER7W6G5CTVWGZCLQJIKJTAX523Q5GPU6TNJONXOR23/effects{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW/effects{?cursor,limit,order}",
       "templated": true
     },
     "offers": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GBRTWTVW65NO4AER7W6G5CTVWGZCLQJIKJTAX523Q5GPU6TNJONXOR23/offers{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW/offers{?cursor,limit,order}",
       "templated": true
     },
     "trades": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GBRTWTVW65NO4AER7W6G5CTVWGZCLQJIKJTAX523Q5GPU6TNJONXOR23/trades{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW/trades{?cursor,limit,order}",
       "templated": true
     },
     "data": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GBRTWTVW65NO4AER7W6G5CTVWGZCLQJIKJTAX523Q5GPU6TNJONXOR23/data/{key}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW/data/{key}",
       "templated": true
     }
   },
-  "id": "GBRTWTVW65NO4AER7W6G5CTVWGZCLQJIKJTAX523Q5GPU6TNJONXOR23",
+  "id": "GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW",
   "paging_token": "",
-  "account_id": "GBRTWTVW65NO4AER7W6G5CTVWGZCLQJIKJTAX523Q5GPU6TNJONXOR23",
-  "sequence": "26509955490119684",
-  "subentry_count": 1,
+  "account_id": "GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW",
+  "sequence": "43692723777044483",
+  "subentry_count": 3,
   "thresholds": {
     "low_threshold": 0,
     "med_threshold": 0,
@@ -85,18 +85,38 @@ When horizon returns information about an account it uses the following format:
   },
   "balances": [
     {
-      "balance": "9999.9999600",
+      "balance": "9999.9999700",
       "asset_type": "native"
     }
   ],
   "signers": [
     {
-      "public_key": "GBRTWTVW65NO4AER7W6G5CTVWGZCLQJIKJTAX523Q5GPU6TNJONXOR23",
-      "weight": 1
+      "public_key": "GDLEPBJBC2VSKJCLJB264F2WDK63X4NKOG774A3QWVH2U6PERGDPUCS4",
+      "weight": 1,
+      "key": "GDLEPBJBC2VSKJCLJB264F2WDK63X4NKOG774A3QWVH2U6PERGDPUCS4",
+      "type": "ed25519_public_key"
+    },
+    {
+      "public_key": "XCPNCUKYDHPMMH6TMHK73K5VP5A6ZTQ2L7Q74JR3TDANNFB3TMRS5OKG",
+      "weight": 1,
+      "key": "XCPNCUKYDHPMMH6TMHK73K5VP5A6ZTQ2L7Q74JR3TDANNFB3TMRS5OKG",
+      "type": "sha256_hash"
+    },
+    {
+      "public_key": "TABGGIW6EXOVOSNJ2O27U2DUX7RWHSRBGOKQLGYDTOXPANEX6LXBX7O7",
+      "weight": 1,
+      "key": "TABGGIW6EXOVOSNJ2O27U2DUX7RWHSRBGOKQLGYDTOXPANEX6LXBX7O7",
+      "type": "preauth_tx"
+    },
+    {
+      "public_key": "GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW",
+      "weight": 1,
+      "key": "GBWRID7MPYUDBTNQPEHUN4XOBVVDPJOHYXAVW3UTOD2RG7BDAY6O3PHW",
+      "type": "ed25519_public_key"
     }
   ],
   "data": {
-    "club": "MTAw"
+    
   }
 }
 ```


### PR DESCRIPTION
Doc fixes:
* confirmed all code examples are up to date for horizon endpoints
* added javascript streaming examples
* added note about deprecation of `public_key`

Closes #536 
Closes #544