### PR TITLE
Rewrite horizon.Client.stream() to use bufio.Reader

### DIFF
--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -2,6 +2,7 @@ package horizon
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -385,7 +386,7 @@ func (c *Client) stream(
 			// requires much more complicated code.
 			// We could also write our own `sse` package that works fine with streams directly
 			// (github.com/manucorporat/sse is just using io/ioutils.ReadAll).
-			var sb strings.Builder
+			var buffer bytes.Buffer
 			nonEmptylinesRead := 0
 			for {
 				// Check if ctx is not cancelled
@@ -412,7 +413,7 @@ func (c *Client) stream(
 					}
 				}
 
-				sb.WriteString(line)
+				buffer.WriteString(line)
 
 				if strings.TrimRight(line, "\n\r") == "" {
 					break
@@ -421,7 +422,7 @@ func (c *Client) stream(
 				nonEmptylinesRead++
 			}
 
-			events, err := sse.Decode(strings.NewReader(sb.String()))
+			events, err := sse.Decode(strings.NewReader(buffer.String()))
 			if err != nil {
 				return err
 			}

--- a/clients/horizon/internal.go
+++ b/clients/horizon/internal.go
@@ -1,17 +1,11 @@
 package horizon
 
 import (
-	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"regexp"
 
-	"github.com/manucorporat/sse"
 	"github.com/stellar/go/support/errors"
 )
-
-var endEvent = regexp.MustCompile("(\r\n|\r|\n){2}")
 
 func decodeResponse(resp *http.Response, object interface{}) (err error) {
 	defer resp.Body.Close()
@@ -42,32 +36,4 @@ func loadMemo(p *Payment) error {
 	}
 	defer res.Body.Close()
 	return json.NewDecoder(res.Body).Decode(&p.Memo)
-}
-
-func parseEvent(data []byte) (result sse.Event, err error) {
-	r := bytes.NewReader(data)
-	events, err := sse.Decode(r)
-	if err != nil {
-		return
-	}
-
-	if len(events) != 1 {
-		err = fmt.Errorf("only expected 1 event, got: %d", len(events))
-		return
-	}
-
-	result = events[0]
-	return
-}
-
-func splitSSE(data []byte, atEOF bool) (advance int, token []byte, err error) {
-	if atEOF {
-		return 0, nil, nil
-	}
-
-	if loc := endEvent.FindIndex(data); loc != nil {
-		return loc[1], data[0:loc[1]], nil
-	}
-
-	return 0, nil, nil
 }


### PR DESCRIPTION
Rewrite `horizon.Client.stream()` to use `bufio.Reader` (fix #548). I'm not super proud of this solution because it requires 2 additional loops:
* Main loop to read events until `io.EOF` error is returned by `reader.ReadString`.
* Internal loop to read lines until an empty line (SSE event delimiter) is found.

This basically duplicates code in `github.com/manucorporat/sse.decode` but is required because `sse.decode` is [using](https://github.com/manucorporat/sse/blob/master/sse-decoder.go#L40) `ioutils.ReadAll` for `io.Reader` provided in the `sse.decode` method argument.

Without doing this streaming method would wait until all events in the current streaming request are sent instead of dispatching them one by one as they arrive (what happens in most cases for `cursor=now`).

The ideal solution would be to analyze the stream content as new bytes are written to it. This requires writing our own SSE event decoder or making a PR to `github.com/manucorporat/sse` and it's much more complicated.

We also start utilizing `event.ID` and use it later as `cursor` instead of parsing `event.Data` for `paging_token` (no need to call `json.Unmarshal`).

Should also fix #542.