### PR TITLE
Temp fix LoadOperation w/ correct return type and test coverage

### DIFF
--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/manucorporat/sse"
+	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -246,14 +247,14 @@ func addAssetToQuery(v map[string][]string, assetPrefix string, asset Asset) {
 }
 
 // LoadOperation loads a single operation from Horizon server
-func (c *Client) LoadOperation(operationID string) (payment Payment, err error) {
+func (c *Client) LoadOperation(operationID string) (operation operations.Base, err error) {
 	c.fixURLOnce.Do(c.fixURL)
 	resp, err := c.HTTP.Get(c.URL + "/operations/" + operationID)
 	if err != nil {
 		return
 	}
 
-	err = decodeResponse(resp, &payment)
+	err = decodeResponse(resp, &operation)
 	return
 }
 

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/stellar/go/build"
+	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -101,7 +102,7 @@ type ClientInterface interface {
 	) (tradesPage TradesPage, err error)
 	LoadAccountMergeAmount(p *Payment) error
 	LoadMemo(p *Payment) error
-	LoadOperation(operationID string) (payment Payment, err error)
+	LoadOperation(operationID string) (operation operations.Base, err error)
 	LoadOrderBook(selling Asset, buying Asset, params ...interface{}) (orderBook OrderBookSummary, err error)
 	LoadTransaction(transactionID string) (transaction Transaction, err error)
 	SequenceForAccount(accountID string) (xdr.SequenceNumber, error)

--- a/clients/horizon/main_test.go
+++ b/clients/horizon/main_test.go
@@ -355,6 +355,57 @@ func TestLoadOrderBook(t *testing.T) {
 
 }
 
+func TestLoadOperation(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		URL:  "https://localhost",
+		HTTP: hmock,
+	}
+
+	// happy path
+	hmock.On(
+		"GET",
+		"https://localhost/operations/123",
+	).ReturnString(200, operationResponse)
+
+	operation, err := client.LoadOperation("123")
+	if assert.NoError(t, err) {
+		assert.Equal(t, operation.ID, "123")
+		assert.Equal(t, operation.PT, "123")
+		assert.Equal(t, operation.Type, "create_account")
+		assert.Equal(t, operation.TypeI, int32(0))
+		assert.Equal(t, operation.TransactionHash, "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a")
+
+	}
+
+	// failure response
+	hmock.On(
+		"GET",
+		"https://localhost/operations/123",
+	).ReturnString(404, notFoundResponse)
+
+	_, err = client.LoadOperation("123")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Horizon error")
+		horizonError, ok := err.(*Error)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, horizonError.Problem.Title, "Resource Missing")
+	}
+
+	// connection error
+	hmock.On(
+		"GET",
+		"https://localhost/operations/123",
+	).ReturnError("http.Client error")
+
+	_, err = client.LoadOperation("123")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "http.Client error")
+		_, ok := err.(*Error)
+		assert.Equal(t, ok, false)
+	}
+}
+
 func TestSubmitTransaction(t *testing.T) {
 	hmock := httptest.NewClient()
 	client := &Client{
@@ -700,6 +751,35 @@ var accountOffersResponse = `{
       }
     ]
   }
+}`
+
+var operationResponse = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/operations/123"
+    },
+    "transaction": {
+      "href": "https://horizon-testnet.stellar.org/transactions/17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a"
+    },
+    "effects": {
+      "href": "https://horizon-testnet.stellar.org/operations/123/effects"
+    },
+    "succeeds": {
+      "href": "https://horizon-testnet.stellar.org/effects?order=desc&cursor=10157597659137"
+    },
+    "precedes": {
+      "href": "https://horizon-testnet.stellar.org/effects?order=asc&cursor=10157597659137"
+    }
+  },
+  "id": "123",
+  "paging_token": "123",
+  "source_account": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+  "type": "create_account",
+  "type_i": 0,
+  "transaction_hash": "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a",
+  "starting_balance": "50000000.0000000",
+  "funder": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+  "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K"
 }`
 
 var transactionResponse = `{

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -3,6 +3,7 @@ package horizon
 import (
 	"context"
 
+	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/mock"
 )
@@ -86,9 +87,9 @@ func (m *MockClient) LoadMemo(p *Payment) error {
 }
 
 // LoadMemo is a mocking a method
-func (m *MockClient) LoadOperation(operationID string) (payment Payment, err error) {
+func (m *MockClient) LoadOperation(operationID string) (operation operations.Base, err error) {
 	a := m.Called(operationID)
-	return a.Get(0).(Payment), a.Error(1)
+	return a.Get(0).(operations.Base), a.Error(1)
 }
 
 // LoadOrderBook is a mocking a method


### PR DESCRIPTION
So this is clearly not a permanent fix -- ultimately we want to return the correct `Operation`, not just the `Base` type.

However, this is an improvement over the current code since the current code:
* doesn't return the correct type
* has no test coverage

With this, repo test coverage is now up to 40%

Closes #557 