### PR TITLE
replace LogglyHost with LogglyTag

### DIFF
--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	FriendbotURL           string
 	LogLevel               logrus.Level
 	SentryDSN              string
-	LogglyHost             string
+	LogglyTag              string
 	LogglyToken            string
 	// TLSCert is a path to a certificate file to use for horizon's TLS config
 	TLSCert string

--- a/services/horizon/internal/init_log.go
+++ b/services/horizon/internal/init_log.go
@@ -34,10 +34,10 @@ func initLogglyLog(app *App) {
 
 	log.WithFields(log.F{
 		"token":       app.config.LogglyToken,
-		"loggly_host": app.config.LogglyHost,
+		"tag": app.config.LogglyTag,
 	}).Info("Initializing loggly hook")
 
-	hook := log.NewLogglyHook(app.config.LogglyToken)
+	hook := log.NewLogglyHook(app.config.LogglyToken, app.config.LogglyTag)
 	log.DefaultLogger.Logger.Hooks.Add(hook)
 
 	go func() {

--- a/services/horizon/internal/log/loggly_hook.go
+++ b/services/horizon/internal/log/loggly_hook.go
@@ -16,8 +16,8 @@ type LogglyHook struct {
 }
 
 // NewLogglyHook creates a new hook
-func NewLogglyHook(token string) *LogglyHook {
-	client := loggly.New(token, "horizon")
+func NewLogglyHook(token, tag string) *LogglyHook {
+	client := loggly.New(token, tag)
 	host, err := os.Hostname()
 
 	if err != nil {

--- a/services/horizon/main.go
+++ b/services/horizon/main.go
@@ -35,7 +35,7 @@ func init() {
 	viper.BindEnv("log-level", "LOG_LEVEL")
 	viper.BindEnv("sentry-dsn", "SENTRY_DSN")
 	viper.BindEnv("loggly-token", "LOGGLY_TOKEN")
-	viper.BindEnv("loggly-host", "LOGGLY_HOST")
+	viper.BindEnv("loggly-tag", "LOGGLY_TAG")
 	viper.BindEnv("tls-cert", "TLS_CERT")
 	viper.BindEnv("tls-key", "TLS_KEY")
 	viper.BindEnv("ingest", "INGEST")
@@ -115,9 +115,9 @@ func init() {
 	)
 
 	rootCmd.PersistentFlags().String(
-		"loggly-host",
-		"",
-		"Hostname to be added to every loggly log event",
+		"loggly-tag",
+		"horizon",
+		"Tag to be added to every loggly log event",
 	)
 
 	rootCmd.PersistentFlags().String(
@@ -213,7 +213,7 @@ func initConfig() {
 		LogLevel:               ll,
 		SentryDSN:              viper.GetString("sentry-dsn"),
 		LogglyToken:            viper.GetString("loggly-token"),
-		LogglyHost:             viper.GetString("loggly-host"),
+		LogglyTag:              viper.GetString("loggly-tag"),
 		TLSCert:                cert,
 		TLSKey:                 key,
 		Ingest:                 viper.GetBool("ingest"),

--- a/support/log/loggly_hook.go
+++ b/support/log/loggly_hook.go
@@ -9,8 +9,8 @@ import (
 )
 
 // NewLogglyHook creates a new hook
-func NewLogglyHook(token string) *LogglyHook {
-	client := loggly.New(token, "horizon")
+func NewLogglyHook(token, tag string) *LogglyHook {
+	client := loggly.New(token, tag)
 	host, err := os.Hostname()
 
 	if err != nil {


### PR DESCRIPTION
LOGGLY_HOST, is defined but never used, Horizon defaults to using the Operating System hostname.

In this PR I suggest replacing the currrently unused LOGGLY_HOST parameter with LOGGLY_TAG, in order to help separating out different log streams as currently all Loggly streams are sent with the `horizon` tag.

`
LOGGLY_TAG='horizon-testnet'
`

Default behaviour is to continue using `horizon` as the Loggly tag.