### PR TITLE
Update docs for horizon client StreamPayments func

### DIFF
--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -475,8 +475,8 @@ func (c *Client) StreamLedgers(
 	})
 }
 
-// StreamPayments streams incoming payments. Use context.WithCancel to stop streaming or
-// context.Background() if you want to stream indefinitely.
+// StreamPayments streams payments, for which the given `accountID` was either the sender or receiver.
+// Use context.WithCancel to stop streaming or context.Background() if you want to stream indefinitely.
 func (c *Client) StreamPayments(
 	ctx context.Context,
 	accountID string,


### PR DESCRIPTION
Now it's misleading saying that only incoming payments are streamed