### PR TITLE
bridge: use nginx-safe header for MAC auth

### DIFF
--- a/services/bridge/CHANGELOG.md
+++ b/services/bridge/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 As this project is pre 1.0, breaking changes may happen for minor version bumps. A breaking change will get clearly notified in this log.
 
+## Unreleased
+
+## Changes
+* Payload MAC authentication uses `X-Payload-Mac` header (old `X_PAYLOAD_MAC` header is still provided for backward compatibility, but it is deprecated and will be removed in future versions).
+
 ## 0.0.31
 
 ### Breaking changes

--- a/services/bridge/README.md
+++ b/services/bridge/README.md
@@ -436,7 +436,7 @@ Respond with `200 OK` when processing succeeded. Any other status code will be c
 
 #### Payload Authentication
 
-When the `mac_key` configuration value is set, the bridge server will attach HTTP headers to each payment notification that allow the receiver to verify that the notification is not forged.  A header named `X_PAYLOAD_MAC` that contains a base64-encoded MAC value will be included. This MAC is derived by calculating the HMAC-SHA256 of the raw request body using the decoded value of the `mac_key` configuration option as the key.
+When the `mac_key` configuration value is set, the bridge server will attach HTTP headers to each payment notification that allow the receiver to verify that the notification is not forged.  A header named `X-Payload-Mac` that contains a base64-encoded MAC value will be included. This MAC is derived by calculating the HMAC-SHA256 of the raw request body using the decoded value of the `mac_key` configuration option as the key.
 
 This MAC can be used on the receiving side of the notification to verify that the payment notifications was generated from the bridge server, rather than from some other actor, to increase security.
 

--- a/services/bridge/internal/listener/payment_listener.go
+++ b/services/bridge/internal/listener/payment_listener.go
@@ -355,6 +355,7 @@ func (pl *PaymentListener) postForm(
 
 		encMAC := base64.StdEncoding.EncodeToString(rawMAC)
 		req.Header.Set("X_PAYLOAD_MAC", encMAC)
+		req.Header.Set("X-Payload-Mac", encMAC)
 	}
 
 	resp, err := pl.client.Do(req)


### PR DESCRIPTION
Bridge server currently  uses `HTTP_PAYLOAD_MAC` header to sign the callback requests, which can be troublesome because Nginx by default [marks such headers as invalid](http://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers) and silently drops them. This can become especially tricky in environments like AWS ElasticBeanstalk, which use Nginx under the hood, but don't provide easy access to its configuration.

This PR leaves the old header in place for backward compatibility, and duplicates MAC signature  into `X-Payload-Mac` header, which follows the (now deprecated) convention for application-level custom headers and shouldn't cause any issues in most popular web servers.

Although this provides a quick and easy fix for the problem, I think in the long run it would be better to use some kind of (semi-)standardised solution, like this draft for HTTP request signing: https://tools.ietf.org/html/draft-cavage-http-signatures-10#section-4. Any thoughts?

/cc @bartekn 