### PR TITLE
[WIP] macOS Getting Started README to ease development

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,23 @@ cd "$GOPATH/src/github.com/stellar/go"
 go test -run "\(\(\?\!mysql\).\)*" ./... -p 8
 ```
 
+To build the underlying executables:
+
+```
+# From the repository directory
+CGO_ENABLED=1 go run ./support/scripts/build_release_artifacts/main.go -os darwin
+```
+
+This will place distributions in the `dist/` directory. Extract one, like Horizon, and execute it:
+
+```sh
+cd dist
+tar -xvf horizon-snapshot-darwin-amd64.tar.gz
+./horizon-snapshot-darwin-amd64/horizon --help
+```
+
+These command line arguments correspond to the `main.go` entry point of the respective binary's source tree. For horizon, this file would be located at `services/horizon/main.go`.
+
 ## Dependencies
 
 This repository depends upon a [number of external dependencies](./Gopkg.lock), and we use [dep](https://golang.github.io/dep/) to manage them.  Dep is used to populate the [vendor directory](https://golang.github.io/dep/docs/ensure-mechanics.html), ensuring that builds are reproducible even as upstream dependencies are changed. Please see the [dep](https://golang.github.io/dep/) website for installation instructions.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ cd "$GOPATH/src/github.com/stellar/go"
 dep ensure -v
 ```
 
+Your `GOPATH` variable will need to be exported with `export GOPATH=path/to/directory/chosen/above` in every shell. There is no consensus whether a `GOPATH` should exist for an entire single machine, user or logical group of projects. Since the group of projects convention is used here, think of this `GOPATH` variable as the equivalent `source venv/bin/activate`, `rbenv ...`, or `./gradlew ...` "set up" command for a Go environment for this repository's development. It would not necessarily be appropriate to export this `GOPATH` inside a `.bashrc` or `.zshrc` as documented elsewhere.
+
 JetBrain's **GoLand** is a well-supported commercial IDE for Go. Open the `$GOPATH/src/github.com/stellar/go` directory with it. Then in the application's Preferences, open the Go configuration tree, and:
 
  1. Visit GOROOT, and set the GOROOT to the `brew` installed location. The dropdown will locate it automatically.


### PR DESCRIPTION
These documentation changes help a `macOS` user get started with development on this repository from absolute zero. Tries to address #30, your most ancient bug.

This documents my experience getting a decent editing setup on macOS. Specifically:

 - How to get a conventional, non-globally-polluting GO environment.
 - A suggestion for a productivity-friendly editor.
 - How to run tests.
 - How to build executables
 - Where to find application entry points.