### PR TITLE
Use the updated ledger state in ingest

### DIFF
--- a/services/horizon/internal/ingest/system.go
+++ b/services/horizon/internal/ingest/system.go
@@ -240,7 +240,7 @@ func (i *System) runOnce() {
 	i.lock.Unlock()
 
 	// Warning: do not check the current ledger state using ledger.CurrentState()! It is updated
-	// in another go routine and can return the same data for two different ingesiton sessions.
+	// in another go routine and can return the same data for two different ingestion sessions.
 	var coreLatest, historyLatest int32
 
 	coreQ := core.Q{Session: i.CoreDB}


### PR DESCRIPTION
This PR fixes random DB constraint errors like (and similar):
```
import session failed: Ingestion.Flush error: Error adding values while inserting to history_effects: Error adding values while inserting to history_effects: exec failed: pq: duplicate key value violates unique constraint "hist_e_by_order"
```
The reason is a synchronization issue between `App.UpdateLedgerState` and `ingest.System.runOnce` go routines. Both go routines are executed every second by the application ticker. The following sequence of events is possible:

Time | Tick1 | Tick2
-|-|-
1 | `UpdateLedgerState` result = `[horizon ledger = 10, core ledger = 11]` |
2 | Start ingest session `ledgers: [11, 11]` |
3 | | `UpdateLedgerState` result = `[horizon ledger = 10, core ledger = 11]`
4 | Finish ingest session `ledgers: [11, 11]` |
5 | | Start ingest session `ledgers: [11, 11]`
6 | | Error in ingest session `ledgers: [11, 11]` (because already saved in t=4)

So it is possible that `ingest.System.runOnce` reads the stale state of ledgers. The simple fix in this PR moves loading the state to `ingest.System.runOnce`. The long-term fix, in my opinion, should remove synchronization requirement in `ingest` package (use internal state only, use infinite `for` instead of ticker etc.).

Close #513.

PS. I've been searching for this for so long! It feels good! 🤓