### PR TITLE
AllowOverInt64 in amount.IntStringToAmount

### DIFF
--- a/amount/main.go
+++ b/amount/main.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
@@ -24,12 +25,6 @@ const (
 	One = 10000000
 )
 
-type Option byte
-
-const (
-	AllowOverInt64 Option = iota
-)
-
 var (
 	bigOne = big.NewRat(One, 1)
 	// validAmountSimple is a simple regular expression checking if a string looks like
@@ -38,7 +33,8 @@ var (
 	// to `big.Rat.SetString` triggering long calculations.
 	// Note: {1,20} because the biggest amount you can use in Stellar is:
 	// len("922337203685.4775807") = 20.
-	validAmountSimple = regexp.MustCompile("^-?[.0-9]{1,20}$")
+	validAmountSimple          = regexp.MustCompile("^-?[.0-9]{1,20}$")
+	negativePositiveNumberOnly = regexp.MustCompile("^-?[0-9]+$")
 )
 
 // MustParse is the panicking version of Parse.
@@ -90,33 +86,30 @@ func ParseInt64(v string) (int64, error) {
 // "amount". In other words, it divides the given string integer value by 10^7
 // and returns the string representation of that number.
 // It is safe to use with values exceeding int64 limits.
-//
-// Pass AllowOverInt64 as an option to allow v values over int64. Please note
-// that computations may take much more time.
-//
-// Note: this can be rewritten to not use big.Rat. We should do it if there are
-// serious performance issues.
-func IntStringToAmount(v string, opts ...Option) (string, error) {
-	allowOverInt64 := false
-	for _, opt := range opts {
-		switch opt {
-		case AllowOverInt64:
-			allowOverInt64 = true
-		}
-	}
-
-	if !allowOverInt64 && !validAmountSimple.MatchString(v) {
+func IntStringToAmount(v string) (string, error) {
+	if !negativePositiveNumberOnly.MatchString(v) {
 		return "", errors.Errorf("invalid amount format: %s", v)
 	}
 
-	r := &big.Rat{}
-	if _, ok := r.SetString(v); !ok {
-		return "", errors.Errorf("cannot parse amount: %s", v)
+	negative := false
+	if v[0] == '-' {
+		negative = true
+		v = v[1:]
 	}
 
-	r.Quo(r, bigOne)
+	l := len(v)
+	var r string
+	if l <= 7 {
+		r = "0." + strings.Repeat("0", 7-l) + v
+	} else {
+		r = v[0:l-7] + "." + v[l-7:l]
+	}
 
-	return r.FloatString(7), nil
+	if negative {
+		r = "-" + r
+	}
+
+	return r, nil
 }
 
 // String returns an "amount string" from the provided raw xdr.Int64 value `v`.

--- a/amount/main.go
+++ b/amount/main.go
@@ -24,6 +24,12 @@ const (
 	One = 10000000
 )
 
+type Option byte
+
+const (
+	AllowOverInt64 Option = iota
+)
+
 var (
 	bigOne = big.NewRat(One, 1)
 	// validAmountSimple is a simple regular expression checking if a string looks like
@@ -84,8 +90,22 @@ func ParseInt64(v string) (int64, error) {
 // "amount". In other words, it divides the given string integer value by 10^7
 // and returns the string representation of that number.
 // It is safe to use with values exceeding int64 limits.
-func IntStringToAmount(v string) (string, error) {
-	if !validAmountSimple.MatchString(v) {
+//
+// Pass AllowOverInt64 as an option to allow v values over int64. Please note
+// that computations may take much more time.
+//
+// Note: this can be rewritten to not use big.Rat. We should do it if there are
+// serious performance issues.
+func IntStringToAmount(v string, opts ...Option) (string, error) {
+	allowOverInt64 := false
+	for _, opt := range opts {
+		switch opt {
+		case AllowOverInt64:
+			allowOverInt64 = true
+		}
+	}
+
+	if !allowOverInt64 && !validAmountSimple.MatchString(v) {
 		return "", errors.Errorf("invalid amount format: %s", v)
 	}
 

--- a/amount/main_test.go
+++ b/amount/main_test.go
@@ -71,37 +71,39 @@ func TestString(t *testing.T) {
 
 func TestIntStringToAmount(t *testing.T) {
 	var testCases = []struct {
-		Output  string
-		Input   string
-		Options []amount.Option
-		Valid   bool
+		Output string
+		Input  string
+		Valid  bool
 	}{
-		{"100.0000000", "1000000000", []amount.Option{}, true},
-		{"-100.0000000", "-1000000000", []amount.Option{}, true},
-		{"100.0000001", "1000000001", []amount.Option{}, true},
-		{"123.0000001", "1230000001", []amount.Option{}, true},
-		{"922337203685.4775807", "9223372036854775807", []amount.Option{}, true},
-		{"922337203685.4775808", "9223372036854775808", []amount.Option{}, true},
-		{"92233.7203686", "922337203686", []amount.Option{}, true},
-		{"-922337203685.4775808", "-9223372036854775808", []amount.Option{}, true},
-		{"-922337203685.4775809", "-9223372036854775809", []amount.Option{}, true},
-		{"-92233.7203686", "-922337203686", []amount.Option{}, true},
-		{"1000000000000.0000000", "10000000000000000000", []amount.Option{}, true},
-		{"0.0000000", "0", []amount.Option{}, true},
-		{"", "nan", []amount.Option{}, false},
-		// Expensive inputs:
-		{"", strings.Repeat("1", 1000000), []amount.Option{}, false},
-		{"", "1E9223372036854775807", []amount.Option{}, false},
-		{"", "1e9223372036854775807", []amount.Option{}, false},
-		{"", "Inf", []amount.Option{}, false},
-		// Expensive input but AllowOverInt64:
-		{"10000000000000.0000000", "1" + strings.Repeat("0", 20), []amount.Option{amount.AllowOverInt64}, true},
-		{"1" + strings.Repeat("0", 1000-7) + ".0000000", "1" + strings.Repeat("0", 1000), []amount.Option{amount.AllowOverInt64}, true},
+		{"100.0000000", "1000000000", true},
+		{"-100.0000000", "-1000000000", true},
+		{"100.0000001", "1000000001", true},
+		{"123.0000001", "1230000001", true},
+		{"922337203685.4775807", "9223372036854775807", true},
+		{"922337203685.4775808", "9223372036854775808", true},
+		{"92233.7203686", "922337203686", true},
+		{"-922337203685.4775808", "-9223372036854775808", true},
+		{"-922337203685.4775809", "-9223372036854775809", true},
+		{"-92233.7203686", "-922337203686", true},
+		{"1000000000000.0000000", "10000000000000000000", true},
+		{"0.0000000", "0", true},
+		// Expensive inputs when using big.Rat:
+		{"10000000000000.0000000", "1" + strings.Repeat("0", 20), true},
+		{"-10000000000000.0000000", "-1" + strings.Repeat("0", 20), true},
+		{"1" + strings.Repeat("0", 1000-7) + ".0000000", "1" + strings.Repeat("0", 1000), true},
+		{"1" + strings.Repeat("0", 1000000-7) + ".0000000", "1" + strings.Repeat("0", 1000000), true},
+		// Invalid inputs
+		{"", "nan", false},
+		{"", "", false},
+		{"", "-", false},
+		{"", "1E9223372036854775807", false},
+		{"", "1e9223372036854775807", false},
+		{"", "Inf", false},
 	}
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s to %s (valid = %t)", tc.Input, tc.Output, tc.Valid), func(t *testing.T) {
-			o, err := amount.IntStringToAmount(tc.Input, tc.Options...)
+			o, err := amount.IntStringToAmount(tc.Input)
 
 			if !tc.Valid && err == nil {
 				t.Errorf("expected err for input %s (output: %s)", tc.Input, tc.Output)

--- a/amount/main_test.go
+++ b/amount/main_test.go
@@ -71,33 +71,37 @@ func TestString(t *testing.T) {
 
 func TestIntStringToAmount(t *testing.T) {
 	var testCases = []struct {
-		Output string
-		Input  string
-		Valid  bool
+		Output  string
+		Input   string
+		Options []amount.Option
+		Valid   bool
 	}{
-		{"100.0000000", "1000000000", true},
-		{"-100.0000000", "-1000000000", true},
-		{"100.0000001", "1000000001", true},
-		{"123.0000001", "1230000001", true},
-		{"922337203685.4775807", "9223372036854775807", true},
-		{"922337203685.4775808", "9223372036854775808", true},
-		{"92233.7203686", "922337203686", true},
-		{"-922337203685.4775808", "-9223372036854775808", true},
-		{"-922337203685.4775809", "-9223372036854775809", true},
-		{"-92233.7203686", "-922337203686", true},
-		{"1000000000000.0000000", "10000000000000000000", true},
-		{"0.0000000", "0", true},
-		{"", "nan", false},
+		{"100.0000000", "1000000000", []amount.Option{}, true},
+		{"-100.0000000", "-1000000000", []amount.Option{}, true},
+		{"100.0000001", "1000000001", []amount.Option{}, true},
+		{"123.0000001", "1230000001", []amount.Option{}, true},
+		{"922337203685.4775807", "9223372036854775807", []amount.Option{}, true},
+		{"922337203685.4775808", "9223372036854775808", []amount.Option{}, true},
+		{"92233.7203686", "922337203686", []amount.Option{}, true},
+		{"-922337203685.4775808", "-9223372036854775808", []amount.Option{}, true},
+		{"-922337203685.4775809", "-9223372036854775809", []amount.Option{}, true},
+		{"-92233.7203686", "-922337203686", []amount.Option{}, true},
+		{"1000000000000.0000000", "10000000000000000000", []amount.Option{}, true},
+		{"0.0000000", "0", []amount.Option{}, true},
+		{"", "nan", []amount.Option{}, false},
 		// Expensive inputs:
-		{"", strings.Repeat("1", 1000000), false},
-		{"", "1E9223372036854775807", false},
-		{"", "1e9223372036854775807", false},
-		{"", "Inf", false},
+		{"", strings.Repeat("1", 1000000), []amount.Option{}, false},
+		{"", "1E9223372036854775807", []amount.Option{}, false},
+		{"", "1e9223372036854775807", []amount.Option{}, false},
+		{"", "Inf", []amount.Option{}, false},
+		// Expensive input but AllowOverInt64:
+		{"10000000000000.0000000", "1" + strings.Repeat("0", 20), []amount.Option{amount.AllowOverInt64}, true},
+		{"1" + strings.Repeat("0", 1000-7) + ".0000000", "1" + strings.Repeat("0", 1000), []amount.Option{amount.AllowOverInt64}, true},
 	}
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s to %s (valid = %t)", tc.Input, tc.Output, tc.Valid), func(t *testing.T) {
-			o, err := amount.IntStringToAmount(tc.Input)
+			o, err := amount.IntStringToAmount(tc.Input, tc.Options...)
 
 			if !tc.Valid && err == nil {
 				t.Errorf("expected err for input %s (output: %s)", tc.Input, tc.Output)

--- a/services/horizon/internal/actions_assets.go
+++ b/services/horizon/internal/actions_assets.go
@@ -3,10 +3,10 @@ package horizon
 import (
 	"fmt"
 
+	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/assets"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
-	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/render/hal"
 )
 
@@ -71,7 +71,11 @@ func (action *AssetsAction) loadRecords() {
 func (action *AssetsAction) loadPage() {
 	for _, record := range action.Records {
 		var res horizon.AssetStat
-		resourceadapter.PopulateAssetStat(action.R.Context(), &res, record)
+		err := resourceadapter.PopulateAssetStat(action.R.Context(), &res, record)
+		if err != nil {
+			action.Err = err
+			return
+		}
 		action.Page.Add(res)
 	}
 

--- a/services/horizon/internal/resourceadapter/asset_stat.go
+++ b/services/horizon/internal/resourceadapter/asset_stat.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	"github.com/stellar/go/amount"
-	"github.com/stellar/go/services/horizon/internal/db2/assets"
-	"github.com/stellar/go/xdr"
 	. "github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/db2/assets"
 	"github.com/stellar/go/support/render/hal"
+	"github.com/stellar/go/xdr"
 )
 
 // PopulateAssetStat fills out the details
@@ -17,11 +17,10 @@ func PopulateAssetStat(
 	res *AssetStat,
 	row assets.AssetStatsR,
 ) (err error) {
-
 	res.Asset.Type = row.Type
 	res.Asset.Code = row.Code
 	res.Asset.Issuer = row.Issuer
-	res.Amount, err = amount.IntStringToAmount(row.Amount)
+	res.Amount, err = amount.IntStringToAmount(row.Amount, amount.AllowOverInt64)
 	if err != nil {
 		return err
 	}

--- a/services/horizon/internal/resourceadapter/asset_stat.go
+++ b/services/horizon/internal/resourceadapter/asset_stat.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stellar/go/amount"
 	. "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2/assets"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"
 	"github.com/stellar/go/xdr"
 )
@@ -20,9 +21,9 @@ func PopulateAssetStat(
 	res.Asset.Type = row.Type
 	res.Asset.Code = row.Code
 	res.Asset.Issuer = row.Issuer
-	res.Amount, err = amount.IntStringToAmount(row.Amount, amount.AllowOverInt64)
+	res.Amount, err = amount.IntStringToAmount(row.Amount)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Invalid amount in PopulateAssetStat")
 	}
 	res.NumAccounts = row.NumAccounts
 	res.Flags = AccountFlags{

--- a/services/horizon/internal/resourceadapter/asset_stat_test.go
+++ b/services/horizon/internal/resourceadapter/asset_stat_test.go
@@ -1,0 +1,33 @@
+package resourceadapter
+
+import (
+	"context"
+	"testing"
+
+	protocol "github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/db2/assets"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLargeAmount(t *testing.T) {
+	row := assets.AssetStatsR{
+		SortKey:     "",
+		Type:        "credit_alphanum4",
+		Code:        "XIM",
+		Issuer:      "GBZ35ZJRIKJGYH5PBKLKOZ5L6EXCNTO7BKIL7DAVVDFQ2ODJEEHHJXIM",
+		Amount:      "100000000000000000000", // 10T
+		NumAccounts: 429,
+		Flags:       0,
+		Toml:        "https://xim.com/.well-known/stellar.toml",
+	}
+	var res protocol.AssetStat
+	err := PopulateAssetStat(context.Background(), &res, row)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "credit_alphanum4", res.Type)
+	assert.Equal(t, "XIM", res.Code)
+	assert.Equal(t, "GBZ35ZJRIKJGYH5PBKLKOZ5L6EXCNTO7BKIL7DAVVDFQ2ODJEEHHJXIM", res.Issuer)
+	assert.Equal(t, "10000000000000.0000000", res.Amount)
+	assert.Equal(t, int32(429), res.NumAccounts)
+	assert.Equal(t, "https://xim.com/.well-known/stellar.toml", res.Links.Toml.Href)
+}


### PR DESCRIPTION
This change allows parsing string integers larger than `int64` in `amount.IntStringToAmount`. This function is used in `/assets` endpoint and currently does not work for larger amounts. The bug was introduced in https://github.com/stellar/go/commit/5bf53ca1550b70f00e6294589d4fcb2497264b31.

This also adds error check in `AssetsAction.loadPage` (that's why it hasn't been caught earler).

Close #606.