### PR TITLE
Improve friendbot linking in root resource

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"encoding/base64"
+
 	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stellar/go/strkey"
 	"github.com/stellar/go/support/errors"
@@ -230,15 +231,15 @@ type PriceLevel struct {
 // Root is the initial map of links into the api.
 type Root struct {
 	Links struct {
-		Account             hal.Link `json:"account"`
-		AccountTransactions hal.Link `json:"account_transactions"`
-		Assets              hal.Link `json:"assets"`
-		Friendbot           hal.Link `json:"friendbot"`
-		Metrics             hal.Link `json:"metrics"`
-		OrderBook           hal.Link `json:"order_book"`
-		Self                hal.Link `json:"self"`
-		Transaction         hal.Link `json:"transaction"`
-		Transactions        hal.Link `json:"transactions"`
+		Account             hal.Link  `json:"account"`
+		AccountTransactions hal.Link  `json:"account_transactions"`
+		Assets              hal.Link  `json:"assets"`
+		Friendbot           *hal.Link `json:"friendbot,omitempty"`
+		Metrics             hal.Link  `json:"metrics"`
+		OrderBook           hal.Link  `json:"order_book"`
+		Self                hal.Link  `json:"self"`
+		Transaction         hal.Link  `json:"transaction"`
+		Transactions        hal.Link  `json:"transactions"`
 	} `json:"_links"`
 
 	HorizonVersion       string `json:"horizon_version"`

--- a/services/horizon/internal/actions_root.go
+++ b/services/horizon/internal/actions_root.go
@@ -1,9 +1,9 @@
 package horizon
 
 import (
+	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
-	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/render/hal"
 )
 

--- a/services/horizon/internal/actions_root.go
+++ b/services/horizon/internal/actions_root.go
@@ -24,6 +24,7 @@ func (action *RootAction) JSON() {
 		action.App.coreVersion,
 		action.App.networkPassphrase,
 		action.App.protocolVersion,
+		action.App.config.FriendbotURL,
 	)
 
 	hal.Render(action.W, res)

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -1,6 +1,8 @@
 package horizon
 
 import (
+	"net/url"
+
 	"github.com/PuerkitoBio/throttled"
 	"github.com/sirupsen/logrus"
 )
@@ -14,7 +16,7 @@ type Config struct {
 	Port                   int
 	RateLimit              throttled.Quota
 	RedisURL               string
-	FriendbotURL           string
+	FriendbotURL           *url.URL
 	LogLevel               logrus.Level
 	SentryDSN              string
 	LogglyTag              string

--- a/services/horizon/internal/init_web.go
+++ b/services/horizon/internal/init_web.go
@@ -146,14 +146,6 @@ func initWebActions(app *App) {
 	// Asset related endpoints
 	r.Get("/assets", AssetsAction{}.Handle)
 
-	// friendbot
-	redirectFriendbot := func(w http.ResponseWriter, r *http.Request) {
-		redirectURL := app.config.FriendbotURL + "?" + r.URL.RawQuery
-		http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
-	}
-	r.Post("/friendbot", redirectFriendbot)
-	r.Get("/friendbot", redirectFriendbot)
-
 	r.NotFound(NotFoundAction{}.Handle)
 }
 

--- a/services/horizon/internal/init_web.go
+++ b/services/horizon/internal/init_web.go
@@ -145,6 +145,13 @@ func initWebActions(app *App) {
 
 	// Asset related endpoints
 	r.Get("/assets", AssetsAction{}.Handle)
+	// friendbot
+	redirectFriendbot := func(w http.ResponseWriter, r *http.Request) {
+		redirectURL := app.config.FriendbotURL.String() + "?" + r.URL.RawQuery
+		http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
+	}
+	r.Post("/friendbot", redirectFriendbot)
+	r.Get("/friendbot", redirectFriendbot)
 
 	r.NotFound(NotFoundAction{}.Handle)
 }

--- a/services/horizon/internal/resourceadapter/root.go
+++ b/services/horizon/internal/resourceadapter/root.go
@@ -2,21 +2,23 @@ package resourceadapter
 
 import (
 	"context"
+	"net/url"
 
+	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/httpx"
 	"github.com/stellar/go/services/horizon/internal/ledger"
-	. "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/render/hal"
 )
 
 // Populate fills in the details
 func PopulateRoot(
 	ctx context.Context,
-	dest *Root,
+	dest *horizon.Root,
 	ledgerState ledger.State,
 	hVersion, cVersion string,
 	passphrase string,
 	pVersion int32,
+	friendBotURL *url.URL,
 ) {
 	dest.HorizonSequence = ledgerState.HistoryLatest
 	dest.HistoryElderSequence = ledgerState.HistoryElder
@@ -26,11 +28,16 @@ func PopulateRoot(
 	dest.NetworkPassphrase = passphrase
 	dest.ProtocolVersion = pVersion
 
-	lb := hal.LinkBuilder{httpx.BaseURL(ctx)}
+	lb := hal.LinkBuilder{Base: httpx.BaseURL(ctx)}
+	if friendBotURL != nil {
+		friendbotLinkBuild := hal.LinkBuilder{Base: friendBotURL}
+		dest.Links.Friendbot = friendbotLinkBuild.Link("/friendbot{?addr}")
+	} else {
+		panic("friendbotURL is nil")
+	}
 	dest.Links.Account = lb.Link("/accounts/{account_id}")
 	dest.Links.AccountTransactions = lb.PagedLink("/accounts/{account_id}/transactions")
 	dest.Links.Assets = lb.Link("/assets{?asset_code,asset_issuer,cursor,limit,order}")
-	dest.Links.Friendbot = lb.Link("/friendbot{?addr}")
 	dest.Links.Metrics = lb.Link("/metrics")
 	dest.Links.OrderBook = lb.Link("/order_book{?selling_asset_type,selling_asset_code,selling_issuer,buying_asset_type,buying_asset_code,buying_issuer,limit}")
 	dest.Links.Self = lb.Link("/")

--- a/services/horizon/internal/resourceadapter/root.go
+++ b/services/horizon/internal/resourceadapter/root.go
@@ -31,9 +31,7 @@ func PopulateRoot(
 	lb := hal.LinkBuilder{Base: httpx.BaseURL(ctx)}
 	if friendBotURL != nil {
 		friendbotLinkBuild := hal.LinkBuilder{Base: friendBotURL}
-		dest.Links.Friendbot = friendbotLinkBuild.Link("/friendbot{?addr}")
-	} else {
-		panic("friendbotURL is nil")
+		dest.Links.Friendbot = friendbotLinkBuild.Link("{?addr}")
 	}
 	dest.Links.Account = lb.Link("/accounts/{account_id}")
 	dest.Links.AccountTransactions = lb.PagedLink("/accounts/{account_id}/transactions")

--- a/services/horizon/internal/resourceadapter/root.go
+++ b/services/horizon/internal/resourceadapter/root.go
@@ -31,8 +31,10 @@ func PopulateRoot(
 	lb := hal.LinkBuilder{Base: httpx.BaseURL(ctx)}
 	if friendBotURL != nil {
 		friendbotLinkBuild := hal.LinkBuilder{Base: friendBotURL}
-		dest.Links.Friendbot = friendbotLinkBuild.Link("{?addr}")
+		l := friendbotLinkBuild.Link("{?addr}")
+		dest.Links.Friendbot = &l
 	}
+
 	dest.Links.Account = lb.Link("/accounts/{account_id}")
 	dest.Links.AccountTransactions = lb.PagedLink("/accounts/{account_id}/transactions")
 	dest.Links.Assets = lb.Link("/assets{?asset_code,asset_issuer,cursor,limit,order}")

--- a/services/horizon/internal/resourceadapter/root_test.go
+++ b/services/horizon/internal/resourceadapter/root_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/services/horizon/internal/ledger"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPopulateRoot(t *testing.T) {
@@ -19,27 +20,33 @@ func TestPopulateRoot(t *testing.T) {
 		"passphrase",
 		100,
 		urlMustParse(t, "https://friendbot.example.com"))
-	if res.CoreSequence != 1 {
-		t.Errorf("CoreSequence did not match expectation %d", res.CoreSequence)
-	}
-	if res.HistoryElderSequence != 2 {
-		t.Errorf("HistoryElderSequence did not match expectation %d", res.HistoryElderSequence)
-	}
-	if res.HorizonSequence != 3 {
-		t.Errorf("HorizonSequence did not match expectation %d", res.HorizonSequence)
-	}
-	if res.StellarCoreVersion != "cVersion" {
-		t.Errorf("StellarCoreVersion did not match expectation %s", res.StellarCoreVersion)
-	}
-	if res.HorizonVersion != "hVersion" {
-		t.Errorf("HorizonVersion did not match expectation %s", res.HorizonVersion)
-	}
-	if res.NetworkPassphrase != "passphrase" {
-		t.Errorf("Network passphrase did not match expectation %s", res.NetworkPassphrase)
-	}
-	if res.Links.Friendbot.Href != "https://friendbot.example.com/{?addr}" {
-		t.Errorf("Friendbot URL not set as expected %s", res.Links.Friendbot.Href)
-	}
+
+	assert.Equal(t, int32(1), res.CoreSequence)
+	assert.Equal(t, int32(2), res.HistoryElderSequence)
+	assert.Equal(t, int32(3), res.HorizonSequence)
+	assert.Equal(t, "hVersion", res.HorizonVersion)
+	assert.Equal(t, "cVersion", res.StellarCoreVersion)
+	assert.Equal(t, "passphrase", res.NetworkPassphrase)
+	assert.Equal(t, "https://friendbot.example.com/{?addr}", res.Links.Friendbot.Href)
+
+	// Without testbot
+	res = &horizon.Root{}
+	PopulateRoot(context.Background(),
+		res,
+		ledger.State{CoreLatest: 1, HistoryLatest: 3, HistoryElder: 2},
+		"hVersion",
+		"cVersion",
+		"passphrase",
+		100,
+		nil)
+
+	assert.Equal(t, int32(1), res.CoreSequence)
+	assert.Equal(t, int32(2), res.HistoryElderSequence)
+	assert.Equal(t, int32(3), res.HorizonSequence)
+	assert.Equal(t, "hVersion", res.HorizonVersion)
+	assert.Equal(t, "cVersion", res.StellarCoreVersion)
+	assert.Equal(t, "passphrase", res.NetworkPassphrase)
+	assert.Empty(t, res.Links.Friendbot)
 }
 
 func urlMustParse(t *testing.T, s string) *url.URL {

--- a/services/horizon/internal/resourceadapter/root_test.go
+++ b/services/horizon/internal/resourceadapter/root_test.go
@@ -1,0 +1,52 @@
+package resourceadapter
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/services/horizon/internal/ledger"
+)
+
+func TestPopulateRoot(t *testing.T) {
+	res := &horizon.Root{}
+	PopulateRoot(context.Background(),
+		res,
+		ledger.State{CoreLatest: 1, HistoryLatest: 3, HistoryElder: 2},
+		"hVersion",
+		"cVersion",
+		"passphrase",
+		100,
+		urlMustParse(t, "https://friendbot.example.com"))
+	if res.CoreSequence != 1 {
+		t.Errorf("CoreSequence did not match expectation %d", res.CoreSequence)
+	}
+	if res.HistoryElderSequence != 2 {
+		t.Errorf("HistoryElderSequence did not match expectation %d", res.HistoryElderSequence)
+	}
+	if res.HorizonSequence != 3 {
+		t.Errorf("HorizonSequence did not match expectation %d", res.HorizonSequence)
+	}
+	if res.StellarCoreVersion != "cVersion" {
+		t.Errorf("StellarCoreVersion did not match expectation %s", res.StellarCoreVersion)
+	}
+	if res.HorizonVersion != "hVersion" {
+		t.Errorf("HorizonVersion did not match expectation %s", res.HorizonVersion)
+	}
+	if res.NetworkPassphrase != "passphrase" {
+		t.Errorf("Network passphrase did not match expectation %s", res.NetworkPassphrase)
+	}
+	if res.Links.Friendbot.Href != "https://friendbot.example.com/{?addr}" {
+		t.Errorf("Friendbot URL not set as expected %s", res.Links.Friendbot.Href)
+	}
+}
+
+func urlMustParse(t *testing.T, s string) *url.URL {
+	if u, err := url.Parse(s); err != nil {
+		t.Fatalf("Unable to parse URL: %s/%v", s, err)
+		return nil
+	} else {
+		return u
+	}
+}

--- a/services/horizon/main.go
+++ b/services/horizon/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"net/url"
 
 	"github.com/PuerkitoBio/throttled"
 	"github.com/sirupsen/logrus"
@@ -202,6 +203,15 @@ func initConfig() {
 		log.Fatal("Invalid TLS config: cert not configured")
 	}
 
+	var friendbotURL *url.URL
+	friendbotURLString := viper.GetString("friendbot-url")
+	if friendbotURLString != "" {
+		friendbotURL, err = url.Parse(friendbotURLString)
+		if err != nil {
+			log.Fatalf("Unable to parse URL: %s/%v", friendbotURLString, err)
+		}
+	}
+
 	config = horizon.Config{
 		DatabaseURL:            viper.GetString("db-url"),
 		StellarCoreDatabaseURL: viper.GetString("stellar-core-db-url"),
@@ -209,7 +219,7 @@ func initConfig() {
 		Port:                   viper.GetInt("port"),
 		RateLimit:              throttled.PerHour(viper.GetInt("per-hour-rate-limit")),
 		RedisURL:               viper.GetString("redis-url"),
-		FriendbotURL:           viper.GetString("friendbot-url"),
+		FriendbotURL:           friendbotURL,
 		LogLevel:               ll,
 		SentryDSN:              viper.GetString("sentry-dsn"),
 		LogglyToken:            viper.GetString("loggly-token"),


### PR DESCRIPTION
Implements part of #239 

I've presented this change is several commits for clarity's sake. I'd be happy to squash it down to one before merging, if that's the custom.

The change here makes the friendbotURL show up only when it's set in the configured environment. This, to me, feels more correct than depending on a mainnet vs. testnet configuration because it's much more specific. It supposes that configuration (eg. environment variables) can be easily changed. In the issue (#239) a conventional approach for distinguishing mainnet vs testnet was alluded to but was not described - I was not able to find any code implementing a conventional approach. If that's still a strong preference, I can change this PR to match the convention.

This change also removes the redirect functionality that has been in placed since (last year)[https://github.com/stellar/go/pull/217/files/4f1708305a05c39092dede7047774a60bfb3138b#r158850670] as I don't believe it's used.