### PR TITLE
horizon: delete /friendbot redirecting routes

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -15,6 +15,7 @@ bumps.  A breaking change will get clearly notified in this log.
 ### Changes
 
 - dropped support for go1.8 since we need big.IsInt64 from math/big in our findpaths calculations
+- removed `/friendbot` redirect routes in favor of using the FriendBot URL provided in the root resource. Note that this field is not visible unless Horizon is configured with a Friendbot URL.
 
 ## v0.13.3 - 2018-08-23
 

--- a/services/horizon/internal/init_web.go
+++ b/services/horizon/internal/init_web.go
@@ -145,13 +145,6 @@ func initWebActions(app *App) {
 
 	// Asset related endpoints
 	r.Get("/assets", AssetsAction{}.Handle)
-	// friendbot
-	redirectFriendbot := func(w http.ResponseWriter, r *http.Request) {
-		redirectURL := app.config.FriendbotURL.String() + "?" + r.URL.RawQuery
-		http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
-	}
-	r.Post("/friendbot", redirectFriendbot)
-	r.Get("/friendbot", redirectFriendbot)
 
 	r.NotFound(NotFoundAction{}.Handle)
 }


### PR DESCRIPTION
We prefer to host friendbot on its own subdomain, and this domain is accessible to clients at the root resource of horizon. This redirect is no longer necessary as clients can discover for themselves where to find friendbot.