### PR TITLE
Document concurrency contract for horizon Client

### DIFF
--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -71,6 +71,8 @@ var (
 )
 
 // Client struct contains data required to connect to Horizon instance
+// It is okay to call methods on Client concurrently.
+// A Client must not be copied after first use.
 type Client struct {
 	// URL of Horizon server to connect
 	URL string


### PR DESCRIPTION
Go's convention is that types are assumed not to be safe to
operate on concurrently unless they're documented to be safe.
This type is meant to be concurrency-safe, so document that.

Also, this struct contains a mutex, which is not okay to copy.
So document that as well.