### PR TITLE
Fix empty memo field in JSON when memo_type is text

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -373,6 +373,9 @@ type Transaction struct {
 	ValidBefore     string    `json:"valid_before,omitempty"`
 }
 
+// MarshalJSON implements a custom marshaler for Transaction.
+// The memo field should be omitted if and only if the
+// memo_type is "none".
 func (t Transaction) MarshalJSON() ([]byte, error) {
 	type Alias Transaction
 	v := &struct {

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"encoding/base64"
+	"encoding/json"
 
 	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stellar/go/strkey"
@@ -370,6 +371,28 @@ type Transaction struct {
 	Signatures      []string  `json:"signatures"`
 	ValidAfter      string    `json:"valid_after,omitempty"`
 	ValidBefore     string    `json:"valid_before,omitempty"`
+}
+
+func (t Transaction) MarshalJSON() ([]byte, error) {
+	type Alias Transaction
+	switch t.MemoType {
+	case "none":
+		return json.Marshal(&struct {
+			Memo *string `json:"memo"`
+			*Alias
+		}{
+			Memo:  nil,
+			Alias: (*Alias)(&t),
+		})
+	default:
+		return json.Marshal(&struct {
+			Memo *string `json:"memo"`
+			*Alias
+		}{
+			Memo:  &t.Memo,
+			Alias: (*Alias)(&t),
+		})
+	}
 }
 
 // PagingToken implementation for hal.Pageable

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -375,24 +375,16 @@ type Transaction struct {
 
 func (t Transaction) MarshalJSON() ([]byte, error) {
 	type Alias Transaction
-	switch t.MemoType {
-	case "none":
-		return json.Marshal(&struct {
-			Memo *string `json:"memo"`
-			*Alias
-		}{
-			Memo:  nil,
-			Alias: (*Alias)(&t),
-		})
-	default:
-		return json.Marshal(&struct {
-			Memo *string `json:"memo"`
-			*Alias
-		}{
-			Memo:  &t.Memo,
-			Alias: (*Alias)(&t),
-		})
+	v := &struct {
+		Memo *string `json:"memo,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(&t),
 	}
+	if t.MemoType != "none" {
+		v.Memo = &t.Memo
+	}
+	return json.Marshal(v)
 }
 
 // PagingToken implementation for hal.Pageable

--- a/protocols/horizon/main_test.go
+++ b/protocols/horizon/main_test.go
@@ -2,8 +2,9 @@ package horizon
 
 import (
 	"encoding/json"
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestAccount(t *testing.T) {

--- a/protocols/horizon/main_test.go
+++ b/protocols/horizon/main_test.go
@@ -2,6 +2,7 @@ package horizon
 
 import (
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -51,49 +52,47 @@ func TestAccount(t *testing.T) {
 	})
 }
 
+//After marshalling and unmarshalling, the resulting struct should be the exact same as the original
 func TestTransactionJSONMarshal(t *testing.T) {
-	Convey("After marshalling and unmarshalling, the resulting struct should be the exact same as the original", t, func() {
-		transaction := Transaction{
-			ID:       "12345",
-			FeePaid:  10,
-			MemoType: "text",
-			Memo:     "",
-		}
-		marshaledTransaction, marshalErr := json.Marshal(transaction)
-		So(marshalErr, ShouldBeNil)
-		var result Transaction
-		json.Unmarshal(marshaledTransaction, &result)
-		So(result, ShouldResemble, transaction)
-	})
+	transaction := Transaction{
+		ID:       "12345",
+		FeePaid:  10,
+		MemoType: "text",
+		Memo:     "",
+	}
+	marshaledTransaction, marshalErr := json.Marshal(transaction)
+	assert.Nil(t, marshalErr)
+	var result Transaction
+	json.Unmarshal(marshaledTransaction, &result)
+	assert.Equal(t, result, transaction)
+}
 
-	Convey("For text memos, even if memo is an empty string, the resulting JSON should still include memo as a field", t, func() {
-		transaction := Transaction{
-			MemoType: "text",
-			Memo:     "",
-		}
-		marshaledTransaction, marshalErr := json.Marshal(transaction)
-		So(marshalErr, ShouldBeNil)
-		var result struct {
-			Memo *string
-		}
-		json.Unmarshal(marshaledTransaction, &result)
-		if result.Memo == nil {
-			t.Errorf("Memo field is nil")
-		}
-	})
+//For text memos, even if memo is an empty string, the resulting JSON should
+// still include memo as a field
+func TestTransactionEmptyMemoText(t *testing.T) {
+	transaction := Transaction{
+		MemoType: "text",
+		Memo:     "",
+	}
+	marshaledTransaction, marshalErr := json.Marshal(transaction)
+	assert.Nil(t, marshalErr)
+	var result struct {
+		Memo *string
+	}
+	json.Unmarshal(marshaledTransaction, &result)
+	assert.NotNil(t, result.Memo)
+}
 
-	Convey("If the memo type is None, then memo field should be nil", t, func() {
-		transaction := Transaction{
-			MemoType: "none",
-		}
-		marshaledTransaction, marshalErr := json.Marshal(transaction)
-		So(marshalErr, ShouldBeNil)
-		var result struct {
-			Memo *string
-		}
-		json.Unmarshal(marshaledTransaction, &result)
-		if result.Memo != nil {
-			t.Errorf("MemoType is none, but memo is not nil")
-		}
-	})
+// If a transaction's memo type is None, then memo field should be nil in JSON
+func TestTransactionMemoTypeNone(t *testing.T) {
+	transaction := Transaction{
+		MemoType: "none",
+	}
+	marshaledTransaction, marshalErr := json.Marshal(transaction)
+	assert.Nil(t, marshalErr)
+	var result struct {
+		Memo *string
+	}
+	json.Unmarshal(marshaledTransaction, &result)
+	assert.Nil(t, result.Memo)
 }

--- a/protocols/horizon/main_test.go
+++ b/protocols/horizon/main_test.go
@@ -1,9 +1,9 @@
 package horizon
 
 import (
-	"testing"
-
+	"encoding/json"
 	. "github.com/smartystreets/goconvey/convey"
+	"testing"
 )
 
 func TestAccount(t *testing.T) {
@@ -47,5 +47,52 @@ func TestAccount(t *testing.T) {
 		Convey("Returns error slice if value is invalid", func() {
 			So(func() { account.MustGetData("invalid") }, ShouldPanic)
 		})
+	})
+}
+
+func TestTransactionJSONMarshal(t *testing.T) {
+	Convey("After marshalling and unmarshalling, the resulting struct should be the exact same as the original", t, func() {
+		transaction := Transaction{
+			ID:       "12345",
+			FeePaid:  10,
+			MemoType: "text",
+			Memo:     "",
+		}
+		marshaledTransaction, marshalErr := json.Marshal(transaction)
+		So(marshalErr, ShouldBeNil)
+		var result Transaction
+		json.Unmarshal(marshaledTransaction, &result)
+		So(result, ShouldResemble, transaction)
+	})
+
+	Convey("For text memos, even if memo is an empty string, the resulting JSON should still include memo as a field", t, func() {
+		transaction := Transaction{
+			MemoType: "text",
+			Memo:     "",
+		}
+		marshaledTransaction, marshalErr := json.Marshal(transaction)
+		So(marshalErr, ShouldBeNil)
+		var result struct {
+			Memo *string
+		}
+		json.Unmarshal(marshaledTransaction, &result)
+		if result.Memo == nil {
+			t.Errorf("Memo field is nil")
+		}
+	})
+
+	Convey("If the memo type is None, then memo field should be nil", t, func() {
+		transaction := Transaction{
+			MemoType: "none",
+		}
+		marshaledTransaction, marshalErr := json.Marshal(transaction)
+		So(marshalErr, ShouldBeNil)
+		var result struct {
+			Memo *string
+		}
+		json.Unmarshal(marshaledTransaction, &result)
+		if result.Memo != nil {
+			t.Errorf("MemoType is none, but memo is not nil")
+		}
 	})
 }

--- a/protocols/horizon/main_test.go
+++ b/protocols/horizon/main_test.go
@@ -83,7 +83,7 @@ func TestTransactionEmptyMemoText(t *testing.T) {
 	assert.NotNil(t, result.Memo)
 }
 
-// If a transaction's memo type is None, then memo field should be nil in JSON
+// If a transaction's memo type is None, then the memo field should be omitted from JSON
 func TestTransactionMemoTypeNone(t *testing.T) {
 	transaction := Transaction{
 		MemoType: "none",


### PR DESCRIPTION
- resolves #149, where the "memo" field does not exist in the JSON response for a transaction whose memo_type is text and the memo happens to be an empty string.
- Fix is to define a custom JSON marshaler that converts the Memo field to be a string pointer. That way if the memo_type is none, it can be set to nil and the resulting JSON response doesn't have a memo field. In all other cases, it points to a string (possibly the empty string), which would cause the JSON response to include "memo" as a field.
- Add some test cases to ensure this behavior, and also make sure that the default marshalling and unmarshalling of Transactions still work.