### PR TITLE
Enable SSL on the bifrost ethereum rpc

### DIFF
--- a/services/bifrost/bifrost.cfg
+++ b/services/bifrost/bifrost.cfg
@@ -14,6 +14,7 @@ token_price = "1"
 [ethereum]
 master_public_key = "xpub6DxSCdWu6jKqr4isjo7bsPeDD6s3J4YVQV1JSHZg12Eagdqnf7XX4fxqyW2sLhUoFWutL7tAELU2LiGZrEXtjVbvYptvTX5Eoa4Mamdjm9u"
 rpc_server = "localhost:8545"
+rpc_ssl = false
 network_id = "3"
 minimum_value_eth = "0.00001"
 token_price = "1"

--- a/services/bifrost/config/main.go
+++ b/services/bifrost/config/main.go
@@ -66,7 +66,8 @@ type ethereumConfig struct {
 	// TokenPrice is a price of one token in ETH
 	TokenPrice string `valid:"required" toml:"token_price"`
 	// Host only
-	RpcServer string `valid:"required" toml:"rpc_server"`
+	RpcServer     string `valid:"required" toml:"rpc_server"`
+	RpcSsl        bool   `valid:"required" toml:"rpc_ssl" `
 }
 
 func (c Config) SignerPublicKey() string {

--- a/services/bifrost/main.go
+++ b/services/bifrost/main.go
@@ -340,7 +340,11 @@ func createServer(cfg config.Config, stressTest bool) *server.Server {
 		}
 
 		if cfg.Ethereum != nil {
-			ethereumClient, err = ethclient.Dial("http://" + cfg.Ethereum.RpcServer)
+			var ethereumRpcAddress = "http://" + cfg.Ethereum.RpcServer
+			if cfg.Ethereum.RpcSsl {
+				ethereumRpcAddress = "https://" + cfg.Ethereum.RpcServer
+			}
+			ethereumClient, err = ethclient.Dial(ethereumRpcAddress)
 			if err != nil {
 				log.WithField("err", err).Error("Error connecting to geth")
 				os.Exit(-1)


### PR DESCRIPTION
Since it's possible to run the ethereum rpc trough ssl it would be nice if we can configure it that way. This also allows you to connect to public rpc endpoints for testing purposes (eg. infura, or myetherwallet rpc's)