### PR TITLE
horizon: Use redirect routes in cases where friendbot is configured

### DIFF
--- a/services/horizon/internal/init_web.go
+++ b/services/horizon/internal/init_web.go
@@ -146,12 +146,14 @@ func initWebActions(app *App) {
 	// Asset related endpoints
 	r.Get("/assets", AssetsAction{}.Handle)
 	// friendbot
-	redirectFriendbot := func(w http.ResponseWriter, r *http.Request) {
-		redirectURL := app.config.FriendbotURL.String() + "?" + r.URL.RawQuery
-		http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
+	if app.config.FriendbotURL != nil {
+		redirectFriendbot := func(w http.ResponseWriter, r *http.Request) {
+			redirectURL := app.config.FriendbotURL.String() + "?" + r.URL.RawQuery
+			http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
+		}
+		r.Post("/friendbot", redirectFriendbot)
+		r.Get("/friendbot", redirectFriendbot)
 	}
-	r.Post("/friendbot", redirectFriendbot)
-	r.Get("/friendbot", redirectFriendbot)
 
 	r.NotFound(NotFoundAction{}.Handle)
 }


### PR DESCRIPTION
There's no correct redirect route available when no friendbot URL is specified, we must 404.