### PR TITLE
Refactor test to not use GoConvey for render/sse

### DIFF
--- a/services/horizon/internal/render/sse/main_test.go
+++ b/services/horizon/internal/render/sse/main_test.go
@@ -2,6 +2,7 @@ package sse
 
 import (
 	"errors"
+	"fmt"
 	"net/http/httptest"
 	"testing"
 
@@ -11,9 +12,9 @@ import (
 
 func TestWriteEventOutput(t *testing.T) {
 	ctx, _ := test.ContextWithLogBuffer()
-	expectations := []struct {
-		Event     Event
-		Substring string
+	testCases := []struct {
+		Event Event
+		ExpectedSubstring string
 	}{
 		{Event{Data: "test"}, "data: \"test\"\n\n"},
 		{Event{ID: "1", Data: "test"}, "id: 1\n"},
@@ -22,11 +23,13 @@ func TestWriteEventOutput(t *testing.T) {
 		{Event{Event: "test", Data: "test"}, "event: test\ndata: \"test\"\n\n"},
 	}
 
-	for _, e := range expectations {
-		w := httptest.NewRecorder()
-		WriteEvent(ctx, w, e.Event)
-		bodyString := w.Body.String()
-		assert.Contains(t, bodyString, e.Substring)
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Checking for expected substring %s", tc.ExpectedSubstring), func(t *testing.T) {
+			w := httptest.NewRecorder()
+			WriteEvent(ctx, w, tc.Event)
+			bodyString := w.Body.String()
+			assert.Contains(t, bodyString, tc.ExpectedSubstring)
+		})
 	}
 }
 

--- a/services/horizon/internal/render/sse/main_test.go
+++ b/services/horizon/internal/render/sse/main_test.go
@@ -1,27 +1,16 @@
 package sse
 
 import (
-	"bytes"
-	"context"
 	"errors"
-	"github.com/stellar/go/support/test"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stellar/go/support/test"
+	"github.com/stretchr/testify/assert"
 )
 
-type SsePackageTestSuite struct {
-	suite.Suite
-	ctx context.Context
-	log *bytes.Buffer
-}
-
-func (suite *SsePackageTestSuite) SetupTest() {
-	suite.ctx, suite.log = test.ContextWithLogBuffer()
-}
-
-func (suite *SsePackageTestSuite) TestWriteEventOutput() {
+func TestWriteEventOutput(t *testing.T) {
+	ctx, _ := test.ContextWithLogBuffer()
 	expectations := []struct {
 		Event     Event
 		Substring string
@@ -35,19 +24,16 @@ func (suite *SsePackageTestSuite) TestWriteEventOutput() {
 
 	for _, e := range expectations {
 		w := httptest.NewRecorder()
-		WriteEvent(suite.ctx, w, e.Event)
+		WriteEvent(ctx, w, e.Event)
 		bodyString := w.Body.String()
-		assert.Equal(suite.T(), e.Substring, bodyString)
+		assert.Contains(t, bodyString, e.Substring)
 	}
 }
 
-func (suite *SsePackageTestSuite) TestWriteEventLogs() {
+func TestWriteEventLogs(t *testing.T) {
+	ctx, log := test.ContextWithLogBuffer()
 	w := httptest.NewRecorder()
-	WriteEvent(suite.ctx, w, Event{Error: errors.New("busted")})
-	assert.Contains(suite.T(), suite.log.String(), "level=error")
-	assert.Contains(suite.T(), suite.log.String(), "busted")
-}
-
-func TestSsePackageTestSuite(t *testing.T) {
-	suite.Run(t, new(SsePackageTestSuite))
+	WriteEvent(ctx, w, Event{Error: errors.New("busted")})
+	assert.Contains(t, log.String(), "level=error")
+	assert.Contains(t, log.String(), "busted")
 }

--- a/services/horizon/internal/render/sse/main_test.go
+++ b/services/horizon/internal/render/sse/main_test.go
@@ -1,40 +1,53 @@
 package sse
 
 import (
+	"bytes"
+	"context"
 	"errors"
+	"github.com/stellar/go/support/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 	"net/http/httptest"
 	"testing"
-
-	. "github.com/smartystreets/goconvey/convey"
-	"github.com/stellar/go/support/test"
 )
 
-func TestSsePackage(t *testing.T) {
-	ctx, log := test.ContextWithLogBuffer()
+type SsePackageTestSuite struct {
+	suite.Suite
+	ctx context.Context
+	log *bytes.Buffer
+}
 
-	Convey("sse.WriteEvent outputs data properly", t, func() {
-		expectations := []struct {
-			Event     Event
-			Substring string
-		}{
-			{Event{Data: "test"}, "data: \"test\"\n\n"},
-			{Event{ID: "1", Data: "test"}, "id: 1\n"},
-			{Event{Retry: 1000, Data: "test"}, "retry: 1000\n"},
-			{Event{Error: errors.New("busted")}, "event: err\ndata: busted\n\n"},
-			{Event{Event: "test", Data: "test"}, "event: test\ndata: \"test\"\n\n"},
-		}
+func (suite *SsePackageTestSuite) SetupTest() {
+	suite.ctx, suite.log = test.ContextWithLogBuffer()
+}
 
-		for _, e := range expectations {
-			w := httptest.NewRecorder()
-			WriteEvent(ctx, w, e.Event)
-			So(w.Body.String(), ShouldContainSubstring, e.Substring)
-		}
-	})
+func (suite *SsePackageTestSuite) TestWriteEventOutput() {
+	expectations := []struct {
+		Event     Event
+		Substring string
+	}{
+		{Event{Data: "test"}, "data: \"test\"\n\n"},
+		{Event{ID: "1", Data: "test"}, "id: 1\n"},
+		{Event{Retry: 1000, Data: "test"}, "retry: 1000\n"},
+		{Event{Error: errors.New("busted")}, "event: err\ndata: busted\n\n"},
+		{Event{Event: "test", Data: "test"}, "event: test\ndata: \"test\"\n\n"},
+	}
 
-	Convey("sse.WriteEvent logs errors", t, func() {
+	for _, e := range expectations {
 		w := httptest.NewRecorder()
-		WriteEvent(ctx, w, Event{Error: errors.New("busted")})
-		So(log.String(), ShouldContainSubstring, "level=error")
-		So(log.String(), ShouldContainSubstring, "busted")
-	})
+		WriteEvent(suite.ctx, w, e.Event)
+		bodyString := w.Body.String()
+		assert.Equal(suite.T(), e.Substring, bodyString)
+	}
+}
+
+func (suite *SsePackageTestSuite) TestWriteEventLogs() {
+	w := httptest.NewRecorder()
+	WriteEvent(suite.ctx, w, Event{Error: errors.New("busted")})
+	assert.Contains(suite.T(), suite.log.String(), "level=error")
+	assert.Contains(suite.T(), suite.log.String(), "busted")
+}
+
+func TestSsePackageTestSuite(t *testing.T) {
+	suite.Run(t, new(SsePackageTestSuite))
 }


### PR DESCRIPTION
- Addresses #638
- Removes GoConvey as a test depedency for services/internal/horizon/render/sse