### PR TITLE
Remove GoConvey dependency in services/horizon/internal/logmetrics

### DIFF
--- a/services/horizon/internal/logmetrics/main_test.go
+++ b/services/horizon/internal/logmetrics/main_test.go
@@ -5,32 +5,29 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestLogPackage(t *testing.T) {
-	Convey("Metrics", t, func() {
-		output := new(bytes.Buffer)
-		l, m := New()
-		l.Logger.Formatter.(*logrus.TextFormatter).DisableColors = true
-		l.Logger.Level = logrus.DebugLevel
-		l.Logger.Out = output
+func TestLogPackageMetrics(t *testing.T) {
+	output := new(bytes.Buffer)
+	l, m := New()
+	l.Logger.Formatter.(*logrus.TextFormatter).DisableColors = true
+	l.Logger.Level = logrus.DebugLevel
+	l.Logger.Out = output
 
-		for _, meter := range *m {
-			So(meter.Count(), ShouldEqual, 0)
-		}
+	for _, meter := range *m {
+		assert.Equal(t, int64(0), meter.Count())
+	}
 
-		l.Debug("foo")
-		l.Info("foo")
-		l.Warn("foo")
-		l.Error("foo")
-		So(func() {
-			l.Panic("foo")
-		}, ShouldPanic)
-
-		for _, meter := range *m {
-			So(meter.Count(), ShouldEqual, 1)
-		}
+	l.Debug("foo")
+	l.Info("foo")
+	l.Warn("foo")
+	l.Error("foo")
+	assert.Panics(t, func() {
+		l.Panic("foo")
 	})
 
+	for _, meter := range *m {
+		assert.Equal(t, int64(1), meter.Count())
+	}
 }


### PR DESCRIPTION
- Addresses #638 to remove GoConvey in services/horizon/internal/logmetrics