### PR TITLE
Feature flag to disable asset stats

### DIFF
--- a/services/horizon/db.go
+++ b/services/horizon/db.go
@@ -28,7 +28,7 @@ var dbBackfillCmd = &cobra.Command{
 		initConfig()
 		hlog.DefaultLogger.Logger.Level = config.LogLevel
 
-		i := ingestSystem()
+		i := ingestSystem(ingest.Config{})
 		i.SkipCursorUpdate = true
 		parsed, err := strconv.ParseUint(args[0], 10, 32)
 		if err != nil {
@@ -49,7 +49,7 @@ var dbClearCmd = &cobra.Command{
 		initConfig()
 		hlog.DefaultLogger.Logger.Level = config.LogLevel
 
-		i := ingestSystem()
+		i := ingestSystem(ingest.Config{})
 		err := i.ClearAll()
 		if err != nil {
 			hlog.Error(err)
@@ -138,7 +138,7 @@ var dbRebaseCmd = &cobra.Command{
 		initConfig()
 		hlog.DefaultLogger.Logger.Level = config.LogLevel
 
-		i := ingestSystem()
+		i := ingestSystem(ingest.Config{})
 		i.SkipCursorUpdate = true
 
 		err := i.RebaseHistory()
@@ -156,7 +156,7 @@ var dbReingestCmd = &cobra.Command{
 		initConfig()
 		hlog.DefaultLogger.Logger.Level = config.LogLevel
 
-		i := ingestSystem()
+		i := ingestSystem(ingest.Config{})
 		i.SkipCursorUpdate = true
 		logStatus := func(stage string) {
 			count := i.Metrics.IngestLedgerTimer.Count()
@@ -207,7 +207,7 @@ func init() {
 	dbCmd.AddCommand(dbRebaseCmd)
 }
 
-func ingestSystem() *ingest.System {
+func ingestSystem(ingestConfig ingest.Config) *ingest.System {
 	hdb, err := db.Open("postgres", config.DatabaseURL)
 	if err != nil {
 		log.Fatal(err)
@@ -223,7 +223,7 @@ func ingestSystem() *ingest.System {
 		log.Fatal("network-passphrase is blank: reingestion requires manually setting passphrase")
 	}
 
-	i := ingest.New(passphrase, config.StellarCoreURL, cdb, hdb)
+	i := ingest.New(passphrase, config.StellarCoreURL, cdb, hdb, ingestConfig)
 	return i
 }
 

--- a/services/horizon/internal/actions_assets_test.go
+++ b/services/horizon/internal/actions_assets_test.go
@@ -3,8 +3,9 @@ package horizon
 import (
 	"testing"
 
-	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/protocols/horizon/base"
+	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/support/render/hal"
 )
 
@@ -270,4 +271,21 @@ func TestInvalidAssetIssuer(t *testing.T) {
 
 	w = ht.Get("/assets?asset_issuer=invalid")
 	ht.Assert.Equal(400, w.Code)
+}
+
+func TestAssetStatsDisabled(t *testing.T) {
+	ht := StartHTTPTest(t, "ingest_asset_stats")
+	defer ht.Finish()
+
+	// Ugly but saves us time needed to change each `StartHTTPTest` occurence.
+	appConfig := NewTestConfig()
+	appConfig.DisableAssetStats = true
+
+	var err error
+	ht.App, err = NewApp(appConfig)
+	ht.Assert.Nil(err)
+	ht.RH = test.NewRequestHelper(ht.App.web.router)
+
+	w := ht.Get("/assets?asset_issuer=GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4")
+	ht.Assert.Equal(404, w.Code)
 }

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -33,13 +33,16 @@ type Config struct {
 	// determining a "retention duration", each ledger roughly corresponds to 10
 	// seconds of real time.
 	HistoryRetentionCount uint
-
 	// StaleThreshold represents the number of ledgers a history database may be
 	// out-of-date by before horizon begins to respond with an error to history
 	// requests.
 	StaleThreshold uint
-
 	// SkipCursorUpdate causes the ingestor to skip reporting the "last imported
 	// ledger" state to stellar-core.
 	SkipCursorUpdate bool
+	// DisableAssetStats is a feature flag that determines whether to calculate
+	// asset stats during the ingestion and expose `/assets` endpoint.
+	// Disabling it will save CPU when ingesting ledgers full of many different
+	// assets related operations.
+	DisableAssetStats bool
 }

--- a/services/horizon/internal/ingest/main_test.go
+++ b/services/horizon/internal/ingest/main_test.go
@@ -13,7 +13,7 @@ func TestIngest_Kahuna1(t *testing.T) {
 	tt := test.Start(t).ScenarioWithoutHorizon("kahuna")
 	defer tt.Finish()
 
-	s := ingest(tt)
+	s := ingest(tt, false)
 
 	tt.Require.NoError(s.Err)
 	tt.Assert.Equal(62, s.Ingested)
@@ -34,7 +34,7 @@ func TestIngest_Kahuna2(t *testing.T) {
 	tt := test.Start(t).ScenarioWithoutHorizon("kahuna-2")
 	defer tt.Finish()
 
-	s := ingest(tt)
+	s := ingest(tt, false)
 
 	tt.Require.NoError(s.Err)
 	tt.Assert.Equal(6, s.Ingested)
@@ -52,7 +52,7 @@ func TestIngest_Kahuna2(t *testing.T) {
 func TestTick(t *testing.T) {
 	tt := test.Start(t).ScenarioWithoutHorizon("base")
 	defer tt.Finish()
-	sys := sys(tt)
+	sys := sys(tt, false)
 
 	// ingest by tick
 	s := sys.Tick()
@@ -65,8 +65,8 @@ func TestTick(t *testing.T) {
 	tt.Require.NoError(s.Err)
 }
 
-func ingest(tt *test.T) *Session {
-	sys := sys(tt)
+func ingest(tt *test.T, disableAssetStats bool) *Session {
+	sys := sys(tt, disableAssetStats)
 	s := NewSession(sys)
 	s.Cursor = NewCursor(1, ledger.CurrentState().CoreLatest, sys)
 	s.Run()
@@ -74,11 +74,12 @@ func ingest(tt *test.T) *Session {
 	return s
 }
 
-func sys(tt *test.T) *System {
+func sys(tt *test.T, disableAssetStats bool) *System {
 	return New(
 		network.TestNetworkPassphrase,
 		"",
 		tt.CoreSession(),
 		tt.HorizonSession(),
+		Config{DisableAssetStats: disableAssetStats},
 	)
 }

--- a/services/horizon/internal/ingest/session.go
+++ b/services/horizon/internal/ingest/session.go
@@ -46,7 +46,10 @@ func (is *Session) Run() {
 			break
 		}
 	}
-	is.Cursor.AssetsModified.UpdateAssetStats(is)
+
+	if !is.Config.DisableAssetStats {
+		is.Cursor.AssetsModified.UpdateAssetStats(is)
+	}
 
 	if is.Err != nil {
 		is.Ingestion.Rollback()

--- a/services/horizon/internal/ingest/session_test.go
+++ b/services/horizon/internal/ingest/session_test.go
@@ -13,7 +13,7 @@ func Test_ingestSignerEffects(t *testing.T) {
 	tt := test.Start(t).ScenarioWithoutHorizon("set_options")
 	defer tt.Finish()
 
-	s := ingest(tt)
+	s := ingest(tt, false)
 	tt.Require.NoError(s.Err)
 
 	q := &history.Q{Session: tt.HorizonSession()}
@@ -33,7 +33,7 @@ func Test_ingestOperationEffects(t *testing.T) {
 	tt := test.Start(t).ScenarioWithoutHorizon("set_options")
 	defer tt.Finish()
 
-	s := ingest(tt)
+	s := ingest(tt, false)
 	tt.Require.NoError(s.Err)
 
 	q := &history.Q{Session: tt.HorizonSession()}
@@ -49,7 +49,7 @@ func Test_ingestOperationEffects(t *testing.T) {
 
 	// HACK(scott): switch to kahuna recipe mid-stream.  We need to integrate our test scenario loader to be compatible with go subtests/
 	tt.ScenarioWithoutHorizon("kahuna")
-	s = ingest(tt)
+	s = ingest(tt, false)
 	tt.Require.NoError(s.Err)
 	pq, err := db2.NewPageQuery("", "asc", 200)
 	tt.Require.NoError(err)
@@ -80,7 +80,7 @@ func Test_ingestBumpSeq(t *testing.T) {
 	tt := test.Start(t).ScenarioWithoutHorizon("kahuna")
 	defer tt.Finish()
 
-	s := ingest(tt)
+	s := ingest(tt, false)
 	tt.Require.NoError(s.Err)
 
 	q := &history.Q{Session: tt.HorizonSession()}

--- a/services/horizon/internal/ingest/system_test.go
+++ b/services/horizon/internal/ingest/system_test.go
@@ -10,7 +10,7 @@ import (
 func TestBackfill(t *testing.T) {
 	tt := test.Start(t).ScenarioWithoutHorizon("kahuna")
 	defer tt.Finish()
-	is := sys(tt)
+	is := sys(tt, false)
 
 	err := is.ReingestSingle(10)
 	tt.Require.NoError(err)
@@ -34,7 +34,7 @@ func TestBackfill(t *testing.T) {
 func TestClearAll(t *testing.T) {
 	tt := test.Start(t).Scenario("kahuna")
 	defer tt.Finish()
-	is := sys(tt)
+	is := sys(tt, false)
 
 	err := is.ClearAll()
 
@@ -51,7 +51,7 @@ func TestValidation(t *testing.T) {
 	tt := test.Start(t).Scenario("kahuna")
 	defer tt.Finish()
 
-	sys := New(network.TestNetworkPassphrase, "", tt.CoreSession(), tt.HorizonSession())
+	sys := New(network.TestNetworkPassphrase, "", tt.CoreSession(), tt.HorizonSession(), Config{})
 
 	// intact chain
 	for i := int32(2); i <= 57; i++ {

--- a/services/horizon/internal/init_ingester.go
+++ b/services/horizon/internal/init_ingester.go
@@ -20,6 +20,9 @@ func initIngester(app *App) {
 		app.config.StellarCoreURL,
 		app.CoreSession(nil),
 		app.HorizonSession(nil),
+		ingest.Config{
+			DisableAssetStats: app.config.DisableAssetStats,
+		},
 	)
 
 	app.ingester.SkipCursorUpdate = app.config.SkipCursorUpdate

--- a/services/horizon/internal/init_web.go
+++ b/services/horizon/internal/init_web.go
@@ -143,8 +143,11 @@ func initWebActions(app *App) {
 	r.Post("/transactions", TransactionCreateAction{}.Handle)
 	r.Get("/paths", PathIndexAction{}.Handle)
 
-	// Asset related endpoints
-	r.Get("/assets", AssetsAction{}.Handle)
+	if !app.config.DisableAssetStats {
+		// Asset related endpoints
+		r.Get("/assets", AssetsAction{}.Handle)
+	}
+
 	// friendbot
 	if app.config.FriendbotURL != nil {
 		redirectFriendbot := func(w http.ResponseWriter, r *http.Request) {

--- a/services/horizon/main.go
+++ b/services/horizon/main.go
@@ -44,6 +44,7 @@ func init() {
 	viper.BindEnv("history-retention-count", "HISTORY_RETENTION_COUNT")
 	viper.BindEnv("history-stale-threshold", "HISTORY_STALE_THRESHOLD")
 	viper.BindEnv("skip-cursor-update", "SKIP_CURSOR_UPDATE")
+	viper.BindEnv("disable-asset-stats", "DISABLE_ASSET_STATS")
 
 	rootCmd = &cobra.Command{
 		Use:   "horizon",
@@ -230,5 +231,6 @@ func initConfig() {
 		HistoryRetentionCount:  uint(viper.GetInt("history-retention-count")),
 		StaleThreshold:         uint(viper.GetInt("history-stale-threshold")),
 		SkipCursorUpdate:       viper.GetBool("skip-cursor-update"),
+		DisableAssetStats:      viper.GetBool("disable-asset-stats"),
 	}
 }


### PR DESCRIPTION
Asset stats calculations have become very CPU intensive with the recent growth of operations per ledger and assets in, both, public and test networks. Because it's part of the ingestion session it sometimes caused delays in ingesting new ledgers but also slows down connected stellar-core DB (calculations are done in core DB).

The original plan I discussed with @MonsieurNicolas was to extract asset stats calculations outside ingestion and make it run every X seconds, independently of ingestion. The problem is that it's a huge architectural change and requires much more work than I expected to make it right and test it properly. Given all the arguments above and the fact that it's already causing operational issues for some organizations I think we should design it along with the upcoming big architectural change in Horizon and `ingest` package and have a _quickfix_ now.

This PR introduces a feature flag that can be set using environment variable or command line param. When `DISABLE_ASSET_STATS=true` assets stats calculation are turned off during ingestion and `/assets` endpoint is not present. This is not a breaking change as the default value is `false`. It can be released in 0.14.1 patch release.