### PR TITLE
update ruby bundle dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/stellar/stellar_core_commander.git
-  revision: b54494191507a3cdfe28f7dc9a9aa2ef7713cb51
+  revision: 154c81daae1ae9acd41e81e1740e8e961124d8bd
   branch: master
   specs:
     stellar_core_commander (0.0.13)
@@ -12,13 +12,13 @@ GIT
       pry (~> 0.11.3)
       sequel (~> 5.5.0)
       slop (~> 3.6.0)
-      stellar-base (>= 0.16.0)
+      stellar-base (>= 0.17.0)
       stellar-sdk (>= 0.5.0)
       typhoeus (~> 0.8.0)
 
 GIT
   remote: https://github.com/stellar/xdrgen.git
-  revision: c683684abb3cb2c8b8c3dc12dc7c6cc9bf1e3b60
+  revision: c56e3ff84b325e2c28b3668a8c98be89886adf2a
   branch: master
   specs:
     xdrgen (0.0.1)
@@ -30,9 +30,9 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.0)
-      activesupport (= 5.2.0)
-    activesupport (5.2.0)
+    activemodel (5.2.1)
+      activesupport (= 5.2.1)
+    activesupport (5.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -65,7 +65,7 @@ GEM
       faraday_middleware
       net-http-digest_auth
       uri_template
-    i18n (1.0.1)
+    i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     memoist (0.11.0)
     method_source (0.9.0)
@@ -73,14 +73,14 @@ GEM
     multipart-post (2.0.0)
     net-http-digest_auth (1.4.1)
     netrc (0.11.0)
-    octokit (4.8.0)
+    octokit (4.12.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     pg (0.18.4)
     polyglot (0.3.5)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (3.0.2)
+    public_suffix (3.0.3)
     rake (12.3.1)
     rbnacl (5.0.0)
       ffi
@@ -91,7 +91,7 @@ GEM
       faraday (~> 0.8, < 1.0)
     sequel (5.5.0)
     slop (3.6.0)
-    stellar-base (0.16.0)
+    stellar-base (0.17.0)
       activesupport (>= 5.2.0)
       base32
       digest-crc
@@ -106,7 +106,7 @@ GEM
       stellar-base (>= 0.16.0)
       toml-rb (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
-    toml-rb (1.1.1)
+    toml-rb (1.1.2)
       citrus (~> 3.0, > 3.0)
     treetop (1.5.3)
       polyglot (~> 0.3)
@@ -131,4 +131,4 @@ DEPENDENCIES
   xdrgen!
 
 BUNDLED WITH
-   1.16.2
+   1.16.5


### PR DESCRIPTION
Most importantly, the current `stellar-base` version, 0.16.0, is not sufficient for building all test scenarios.