### PR TITLE
Improve stream error reporting

### DIFF
--- a/services/horizon/internal/actions_effects.go
+++ b/services/horizon/internal/actions_effects.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/support/errors"
-	"github.com/stellar/go/support/render/hal"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/render/hal"
 )
 
 // This file contains the actions:
@@ -67,14 +67,14 @@ func (action *EffectIndexAction) SSE(stream sse.Stream) {
 				ledger, found := action.Ledgers.Records[record.LedgerSequence()]
 				if !found {
 					msg := fmt.Sprintf("could not find ledger data for sequence %d", record.LedgerSequence())
-					stream.Err(errors.New(msg))
+					action.Err = errors.New(msg)
 					return
 				}
 
 				res, err := resourceadapter.NewEffect(action.R.Context(), record, ledger)
 
 				if err != nil {
-					stream.Err(action.Err)
+					action.Err = err
 					return
 				}
 

--- a/services/horizon/internal/actions_offer.go
+++ b/services/horizon/internal/actions_offer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
+	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/hal"
 )
 
@@ -56,7 +57,13 @@ func (action *OffersByAccountAction) SSE(stream sse.Stream) {
 						ledgerPtr = nil
 					} else {
 						msg := fmt.Sprintf("could not find ledger data for sequence %d", record.Lastmodified)
-						stream.Err(errors.New(msg))
+						err := errors.New(msg)
+						// Warn not Error because it can happen quite often because
+						// offer data is taken directly from stellar-core db.
+						// In other words, it is expected to happen, especially for
+						// recently changed offers.
+						log.Ctx(action.R.Context()).Warn(err)
+						stream.Err(err)
 						return
 					}
 				}

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/ledger"
-	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/render/problem"
-	"github.com/stellar/go/services/horizon/internal/toid"
+	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
+	"github.com/stellar/go/services/horizon/internal/toid"
 	"github.com/stellar/go/support/render/hal"
 )
 
@@ -65,14 +65,14 @@ func (action *OperationIndexAction) SSE(stream sse.Stream) {
 				ledger, found := action.Ledgers.Records[record.LedgerSequence()]
 				if !found {
 					msg := fmt.Sprintf("could not find ledger data for sequence %d", record.LedgerSequence())
-					stream.Err(errors.New(msg))
+					action.Err = errors.New(msg)
 					return
 				}
 
 				res, err := resourceadapter.NewOperation(action.R.Context(), record, ledger)
 
 				if err != nil {
-					stream.Err(err)
+					action.Err = err
 					return
 				}
 

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/support/render/hal"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
+	"github.com/stellar/go/support/render/hal"
 )
 
 // PaymentsIndexAction returns a paged slice of payments based upon the provided
@@ -57,14 +57,14 @@ func (action *PaymentsIndexAction) SSE(stream sse.Stream) {
 				ledger, found := action.Ledgers.Records[record.LedgerSequence()]
 				if !found {
 					msg := fmt.Sprintf("could not find ledger data for sequence %d", record.LedgerSequence())
-					stream.Err(errors.New(msg))
+					action.Err = errors.New(msg)
 					return
 				}
 
 				res, err := resourceadapter.NewOperation(action.R.Context(), record, ledger)
 
 				if err != nil {
-					stream.Err(err)
+					action.Err = err
 					return
 				}
 

--- a/services/horizon/internal/render/sse/main.go
+++ b/services/horizon/internal/render/sse/main.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
-
-	"github.com/stellar/go/support/log"
 )
 
 // Event is the packet of data that gets sent over the wire to a connected
@@ -81,7 +79,6 @@ func WriteEvent(ctx context.Context, w http.ResponseWriter, e Event) {
 		fmt.Fprint(w, "event: err\n")
 		fmt.Fprintf(w, "data: %s\n\n", e.Error.Error())
 		w.(http.Flusher).Flush()
-		log.Ctx(ctx).Error(e.Error)
 		return
 	}
 
@@ -122,7 +119,7 @@ var helloEvent = Event{
 }
 
 var (
-	lock sync.Mutex
+	lock     sync.Mutex
 	nextTick = make(chan struct{})
 )
 

--- a/services/horizon/internal/render/sse/main_test.go
+++ b/services/horizon/internal/render/sse/main_test.go
@@ -13,7 +13,7 @@ import (
 func TestWriteEventOutput(t *testing.T) {
 	ctx, _ := test.ContextWithLogBuffer()
 	testCases := []struct {
-		Event Event
+		Event             Event
 		ExpectedSubstring string
 	}{
 		{Event{Data: "test"}, "data: \"test\"\n\n"},
@@ -37,6 +37,6 @@ func TestWriteEventLogs(t *testing.T) {
 	ctx, log := test.ContextWithLogBuffer()
 	w := httptest.NewRecorder()
 	WriteEvent(ctx, w, Event{Error: errors.New("busted")})
-	assert.Contains(t, log.String(), "level=error")
-	assert.Contains(t, log.String(), "busted")
+	assert.NotContains(t, log.String(), "level=error")
+	assert.NotContains(t, log.String(), "busted")
 }


### PR DESCRIPTION
Errors sent to clients via SSE stream are not necessarily the same level at the system layer. Currently every error passed to `stream.Err` is logged with `level=error`. Because of this we can often see `level=error` entries like: `sql: no rows in result set` in the logs, for example when streamed account has been removed.

This commit removes logging in `render/sse` package and reports errors in `actions_*.go` files. It also changes `actions.Base` to hide internal errors from the client: it returns "Object not found" for `sql.ErrNoRows` errors and "Unexpected stream error" for others. All occurrences of `stream.Err` have been updated with log reporting.