### PR TITLE
Improve test coverage for TradeIndexAction

### DIFF
--- a/services/horizon/internal/actions_trade_test.go
+++ b/services/horizon/internal/actions_trade_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	. "github.com/stellar/go/services/horizon/internal/db2/history"
 	. "github.com/stellar/go/services/horizon/internal/test/trades"
-	"github.com/stellar/go/xdr"
 	"github.com/stellar/go/support/render/hal"
+	"github.com/stellar/go/xdr"
 )
 
 func TestTradeActions_Index(t *testing.T) {
@@ -203,7 +203,6 @@ func TestTradeActions_Aggregation(t *testing.T) {
 	q.Add("end_time", strconv.FormatInt(start+hour, 10))
 	q.Add("order", "asc")
 
-
 	//test no resolution provided
 	w := ht.GetWithParams(aggregationPath, q)
 	println(w.Body.String())
@@ -373,4 +372,19 @@ func TestTradeActions_AggregationOrdering(t *testing.T) {
 		ht.Assert.Equal("1.0000000", records[0].Open)
 		ht.Assert.Equal("3.0000000", records[0].Close)
 	}
+}
+
+func TestTradeActions_AssetValidation(t *testing.T) {
+	ht := StartHTTPTest(t, "trades")
+	defer ht.Finish()
+
+	var q = make(url.Values)
+	q.Add("base_asset_type", "native")
+
+	w := ht.GetWithParams("/trades", q)
+	ht.Assert.Equal(400, w.Code)
+
+	extras := ht.UnmarshalExtras(w.Body)
+	ht.Assert.Equal("base_asset_type,counter_asset_type", extras["invalid_field"])
+	ht.Assert.Equal("this endpoint supports asset pairs but only one asset supplied", extras["reason"])
 }

--- a/services/horizon/internal/test/t.go
+++ b/services/horizon/internal/test/t.go
@@ -90,6 +90,18 @@ func (t *T) UnmarshalNext(r io.Reader) string {
 	return env.Links.Next.Href
 }
 
+// UnmarshalExtras extracts and returns extras content
+func (t *T) UnmarshalExtras(r io.Reader) map[string]string {
+	var resp struct {
+		Extras map[string]string `json:"extras"`
+	}
+
+	err := json.NewDecoder(r).Decode(&resp)
+	t.Require.NoError(err, "failed to decode page")
+
+	return resp.Extras
+}
+
 // UpdateLedgerState updates the cached ledger state (or panicing on failure).
 func (t *T) UpdateLedgerState() {
 	var next ledger.State


### PR DESCRIPTION
I started investigating https://github.com/stellar/go/issues/615 and I've found it was actually fixed by https://github.com/stellar/go/pull/654 but couldn't find any test that covers the problem described in the issue.

I've added a test to assert that error messages are returned as expected in the JSON response.
