### PR TITLE
Add Init method to stream

### DIFF
--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -83,12 +83,16 @@ func (base *Base) Execute(action interface{}) {
 				stream.Err(base.Err)
 			}
 
+			// Manually send the preamble in case there are no data events in SSE to trigger a stream.Send call
+			stream.Init()
+
 			if stream.IsDone() {
 				return
 			}
 
 			select {
 			case <-ctx.Done():
+				stream.Done()
 				return
 			case <-sse.Pumped():
 				//no-op, continue onto the next iteration

--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -65,8 +65,8 @@ func (base *Base) Execute(action interface{}) {
 			action.SSE(stream)
 
 			if base.Err != nil {
-				// in the case that we haven't yet sent an event, is also means we
-				// havent sent the preamble, meaning we should simply return the normal
+				// In the case that we haven't yet sent an event, is also means we
+				// haven't sent the preamble, meaning we should simply return the normal HTTP
 				// error.
 				if stream.SentCount() == 0 {
 					problem.Render(ctx, base.W, base.Err)
@@ -80,10 +80,13 @@ func (base *Base) Execute(action interface{}) {
 					base.Err = errors.New("Unexpected stream error")
 				}
 
+				// Send errors through the stream and then close the stream.
 				stream.Err(base.Err)
 			}
 
-			// Manually send the preamble in case there are no data events in SSE to trigger a stream.Send call
+			// Manually send the preamble in case there are no data events in SSE to trigger a stream.Send call.
+			// This method is called every iteration of the loop, but is protected by a sync.Once variable so it's
+			// only executed once.
 			stream.Init()
 
 			if stream.IsDone() {

--- a/services/horizon/internal/actions_offer.go
+++ b/services/horizon/internal/actions_offer.go
@@ -63,7 +63,7 @@ func (action *OffersByAccountAction) SSE(stream sse.Stream) {
 						// In other words, it is expected to happen, especially for
 						// recently changed offers.
 						log.Ctx(action.R.Context()).Warn(err)
-						stream.Err(err)
+						action.Err = err
 						return
 					}
 				}

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -58,7 +58,7 @@ func (action *TradeIndexAction) SSE(stream sse.Stream) {
 				err := resourceadapter.PopulateTrade(action.R.Context(), &res, record)
 
 				if err != nil {
-					stream.Err(err)
+					action.Err = err
 					return
 				}
 

--- a/services/horizon/internal/render/sse/stream.go
+++ b/services/horizon/internal/render/sse/stream.go
@@ -9,6 +9,7 @@ import (
 // Stream represents an output stream that data can be written to.
 // Its methods must be safe to call concurrently.
 type Stream interface {
+	Init()
 	Send(Event)
 	SentCount() int
 	Done()
@@ -27,6 +28,7 @@ func NewStream(ctx context.Context, w http.ResponseWriter, r *http.Request) Stre
 		sent:  0,
 		limit: 0,
 	}
+
 	return result
 }
 
@@ -34,26 +36,32 @@ type stream struct {
 	ctx context.Context
 	r   *http.Request
 
-	mu    sync.Mutex // Mutex protects the following fields
-	w     http.ResponseWriter
-	done  bool
-	sent  int
-	limit int
+	initSync sync.Once  // Variable to ensure that Init is only called once
+	mu       sync.Mutex // Mutex protects the following fields
+	w        http.ResponseWriter
+	done     bool
+	sent     int
+	limit    int
+}
+
+// Init function is only called once. It writes the preamble event which includes the HTTP response code and a
+// hello message.
+func (s *stream) Init() {
+	s.initSync.Do(func() {
+		ok := WritePreamble(s.ctx, s.w)
+		if !ok {
+			s.done = true
+		}
+		// Add heartbeat routine here
+	})
 }
 
 func (s *stream) Send(e Event) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.sent == 0 {
-		ok := WritePreamble(s.ctx, s.w)
-		if !ok {
-			s.done = true
-			return
-		}
-	}
-
+	s.Init()
 	WriteEvent(s.ctx, s.w, e)
 	s.sent++
+	s.mu.Unlock()
 }
 
 func (s *stream) SentCount() int {

--- a/services/horizon/internal/render/sse/stream.go
+++ b/services/horizon/internal/render/sse/stream.go
@@ -36,7 +36,7 @@ type stream struct {
 	ctx context.Context
 	r   *http.Request
 
-	initSync sync.Once  // Variable to ensure that Init is only called once
+	initSync sync.Once  // Variable to ensure that Init only writes the preamble once.
 	mu       sync.Mutex // Mutex protects the following fields
 	w        http.ResponseWriter
 	done     bool
@@ -44,8 +44,9 @@ type stream struct {
 	limit    int
 }
 
-// Init function is only called once. It writes the preamble event which includes the HTTP response code and a
-// hello message.
+// Init function is only executed once. It writes the preamble event which includes the HTTP response code and a
+// hello message. This should be called before any method that writes to the client to ensure that the preamble
+// has been sent first.
 func (s *stream) Init() {
 	s.initSync.Do(func() {
 		ok := WritePreamble(s.ctx, s.w)
@@ -58,10 +59,10 @@ func (s *stream) Init() {
 
 func (s *stream) Send(e Event) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.Init()
 	WriteEvent(s.ctx, s.w, e)
 	s.sent++
-	s.mu.Unlock()
 }
 
 func (s *stream) SentCount() int {
@@ -79,6 +80,7 @@ func (s *stream) SetLimit(limit int) {
 func (s *stream) Done() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.Init()
 	WriteEvent(s.ctx, s.w, goodbyeEvent)
 	s.done = true
 }
@@ -96,6 +98,7 @@ func (s *stream) IsDone() bool {
 func (s *stream) Err(err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.Init()
 	WriteEvent(s.ctx, s.w, Event{Error: err})
 	s.done = true
 }


### PR DESCRIPTION
- Addresses the alternate solution laid out by Bartek in #687 
- This PR adds an Init method to stream that sends the preamble message.
- If there were any initial errors in validating the SSE request, base.execute will render a HTTP error code as the response
- Otherwise (upon success) it will send the preamble right away