### PR TITLE
Fix and improve `txsub` package

### DIFF
--- a/services/horizon/internal/db2/core/transaction.go
+++ b/services/horizon/internal/db2/core/transaction.go
@@ -128,16 +128,14 @@ func (tx *Transaction) SourceAddress() string {
 }
 
 // TransactionByHashAfterLedger is a query that loads a single row from the `txhistory`.
-func (q *Q) TransactionByHashAfterLedger(
+func (q *Q) TransactionByHash(
 	dest interface{},
 	hash string,
-	ledger int32,
 ) error {
 	sql := sq.Select("ctxh.*").
 		From("txhistory ctxh").
 		Limit(1).
-		Where("ctxh.txid = ?", hash).
-		Where("ctxh.ledgerseq > ?", ledger)
+		Where("ctxh.txid = ?", hash)
 
 	return q.Get(dest, sql)
 }

--- a/services/horizon/internal/db2/core/transaction_test.go
+++ b/services/horizon/internal/db2/core/transaction_test.go
@@ -22,13 +22,13 @@ func TestTransactionsQueries(t *testing.T) {
 
 	// Test TransactionByHashAfterLedger
 	var tx Transaction
-	err = q.TransactionByHashAfterLedger(&tx, "cebb875a00ff6e1383aef0fd251a76f22c1f9ab2a2dffcb077855736ade2659a", 2)
+	err = q.TransactionByHash(&tx, "cebb875a00ff6e1383aef0fd251a76f22c1f9ab2a2dffcb077855736ade2659a")
 
 	if tt.Assert.NoError(err) {
 		tt.Assert.Equal(int32(3), tx.LedgerSequence)
 	}
 
-	err = q.TransactionByHashAfterLedger(&tx, "cebb875a00ff6e1383aef0fd251a76f22c1f9ab2a2dffcb077855736ade2659a", 3)
+	err = q.TransactionByHash(&tx, "e91b62146d6615473998408ce45e44f4a2929d2a0a2e3f2557e656a24df69d6d")
 
 	if tt.Assert.Error(err) {
 		tt.Assert.True(q.NoRows(err))

--- a/services/horizon/internal/httpx/request.go
+++ b/services/horizon/internal/httpx/request.go
@@ -3,6 +3,8 @@ package httpx
 import (
 	"context"
 	"net/http"
+
+	"github.com/stellar/go/support/log"
 )
 
 var requestContextKey = 0
@@ -40,6 +42,7 @@ func RequestContext(parent context.Context, w http.ResponseWriter, r *http.Reque
 	go func() {
 		select {
 		case <-closedByClient:
+			log.Ctx(parent).Info("Request closed by client")
 			cancel()
 		case <-ctx.Done():
 			return

--- a/services/horizon/internal/render/problem/main.go
+++ b/services/horizon/internal/render/problem/main.go
@@ -66,7 +66,8 @@ var (
 		Title:  "Timeout",
 		Status: http.StatusGatewayTimeout,
 		Detail: "Your request timed out before completing.  Please try your " +
-			"request again.",
+			"request again. If you are submitting a transaction make sure you are " +
+			"sending exactly the same transaction (with the same sequence number).",
 	}
 
 	// UnsupportedMediaType is a well-known problem type.  Use it as a shortcut

--- a/support/log/entry.go
+++ b/support/log/entry.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 
@@ -9,6 +10,28 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stellar/go/support/errors"
 )
+
+// Ctx appends all fields from `e` to the new logger created from `ctx`
+// logger and returns it.
+func (e *Entry) Ctx(ctx context.Context) *Entry {
+	if ctx == nil {
+		return e
+	}
+
+	found := ctx.Value(&loggerContextKey)
+	if found == nil {
+		return e
+	}
+
+	entry := found.(*Entry)
+
+	// Copy all fields from e to entry
+	for key, value := range e.Data {
+		entry = entry.WithField(key, value)
+	}
+
+	return entry
+}
 
 func (e *Entry) SetLevel(level logrus.Level) {
 	e.Logger.Level = level


### PR DESCRIPTION
This commit fixes an issue that caused sending `Timeout` responses to client submitting transactions. The problem was present in `TransactionByHashAfterLedger` function: it was checking the result of the transaction in History DB and, when it was not found, in Core DB but with ledger sequence after the latest ingested ledger. Given the fact that Horizon ingests only successful transactions it was impossible to find results for some of the failed transactions (especially those failed at the consensus level that require more time to process).

`SubmissionTimeout` was changed to 30 seconds because HTTP clients in SDKs usually timeout in 60 seconds. We want `SubmissionTimeout`
to be lower than that to make sure that they read the response before the client timeout and 30 seconds is 6 ledgers (with avg. close time = 5 sec), enough for stellar-core to drop the transaction if not added to the ledger and ask client to try again by sending a `Timeout` response.

It also contains improved logging in `txsub` package.