### PR TITLE
Add offset parameter to trade aggregations

### DIFF
--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -226,7 +226,6 @@ func (action *TradeAggregateIndexAction) loadRecords() {
 		if err != nil {
 			action.SetInvalidField("start_time", errors.New("illegal start time. adjusted start time must "+
 				"be less than the provided end time if the end time is greater than 0"))
-			action.Err = err
 			return
 		}
 	}
@@ -235,7 +234,6 @@ func (action *TradeAggregateIndexAction) loadRecords() {
 		if err != nil {
 			action.SetInvalidField("end_time", errors.New("illegal end time. adjusted end time "+
 				"must be greater than the offset and greater than the provided start time"))
-			action.Err = err
 			return
 		}
 	}

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -187,6 +187,12 @@ func (action *TradeAggregateIndexAction) loadParams() {
 				"1 day (86400000) and 1 week (604800000)"))
 		}
 	}
+	// check if offset is legal
+	offsetDuration := gTime.Duration(action.OffsetFilter) * gTime.Millisecond
+	if offsetDuration%gTime.Hour != 0 || offsetDuration >= gTime.Hour*24 || offsetDuration > resolutionDuration {
+		action.SetInvalidField("offset", errors.New("illegal or missing offset. offset must be a multiple of an"+
+			" hour, less than or equal to the resolution, and less than 24 hours"))
+	}
 }
 
 // loadRecords populates action.Records
@@ -207,21 +213,31 @@ func (action *TradeAggregateIndexAction) loadRecords() {
 
 	//initialize the query builder with required params
 	tradeAggregationsQ, err := historyQ.GetTradeAggregationsQ(
-		baseAssetId, counterAssetId, action.ResolutionFilter, action.PagingParams)
+		baseAssetId, counterAssetId, action.ResolutionFilter, action.OffsetFilter, action.PagingParams)
 
 	if err != nil {
 		action.Err = err
 		return
 	}
 
-	tradeAggregationsQ.WithOffset(action.OffsetFilter)
-
 	//set time range if supplied
 	if !action.StartTimeFilter.IsNil() {
-		tradeAggregationsQ.WithStartTime(action.StartTimeFilter)
+		tradeAggregationsQ, err = tradeAggregationsQ.WithStartTime(action.StartTimeFilter)
+		if err != nil {
+			action.SetInvalidField("start_time", errors.New("illegal start time. adjusted start time must "+
+				"be less than the provided end time if the end time is greater than 0"))
+			action.Err = err
+			return
+		}
 	}
 	if !action.EndTimeFilter.IsNil() {
-		tradeAggregationsQ.WithEndTime(action.EndTimeFilter)
+		tradeAggregationsQ, err = tradeAggregationsQ.WithEndTime(action.EndTimeFilter)
+		if err != nil {
+			action.SetInvalidField("end_time", errors.New("illegal end time. adjusted end time "+
+				"must be greater than the offset and greater than the provided start time"))
+			action.Err = err
+			return
+		}
 	}
 
 	action.Err = historyQ.Select(&action.Records, tradeAggregationsQ.GetSql())

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -147,9 +147,9 @@ type TradeAggregateIndexAction struct {
 	Action
 	BaseAssetFilter    xdr.Asset
 	CounterAssetFilter xdr.Asset
-	OffsetFilter       time.Millis
 	StartTimeFilter    time.Millis
 	EndTimeFilter      time.Millis
+	OffsetFilter       int64
 	ResolutionFilter   int64
 	PagingParams       db2.PageQuery
 	Records            []history.TradeAggregation
@@ -173,7 +173,7 @@ func (action *TradeAggregateIndexAction) loadParams() {
 	action.PagingParams = action.GetPageQuery()
 	action.BaseAssetFilter = action.GetAsset("base_")
 	action.CounterAssetFilter = action.GetAsset("counter_")
-	action.OffsetFilter = action.GetTimeMillis("offset")
+	action.OffsetFilter = action.GetInt64("offset")
 	action.StartTimeFilter = action.GetTimeMillis("start_time")
 	action.EndTimeFilter = action.GetTimeMillis("end_time")
 	action.ResolutionFilter = action.GetInt64("resolution")
@@ -214,11 +214,9 @@ func (action *TradeAggregateIndexAction) loadRecords() {
 		return
 	}
 
-	//set time range if supplied
-	if !action.OffsetFilter.IsNil() {
-		tradeAggregationsQ.WithOffset(action.OffsetFilter)
-	}
+	tradeAggregationsQ.WithOffset(action.OffsetFilter)
 
+	//set time range if supplied
 	if !action.StartTimeFilter.IsNil() {
 		tradeAggregationsQ.WithStartTime(action.StartTimeFilter)
 	}

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -147,6 +147,7 @@ type TradeAggregateIndexAction struct {
 	Action
 	BaseAssetFilter    xdr.Asset
 	CounterAssetFilter xdr.Asset
+	OffsetFilter       time.Millis
 	StartTimeFilter    time.Millis
 	EndTimeFilter      time.Millis
 	ResolutionFilter   int64
@@ -172,6 +173,7 @@ func (action *TradeAggregateIndexAction) loadParams() {
 	action.PagingParams = action.GetPageQuery()
 	action.BaseAssetFilter = action.GetAsset("base_")
 	action.CounterAssetFilter = action.GetAsset("counter_")
+	action.OffsetFilter = action.GetTimeMillis("offset")
 	action.StartTimeFilter = action.GetTimeMillis("start_time")
 	action.EndTimeFilter = action.GetTimeMillis("end_time")
 	action.ResolutionFilter = action.GetInt64("resolution")
@@ -213,6 +215,10 @@ func (action *TradeAggregateIndexAction) loadRecords() {
 	}
 
 	//set time range if supplied
+	if !action.OffsetFilter.IsNil() {
+		tradeAggregationsQ.WithOffset(action.OffsetFilter)
+	}
+
 	if !action.StartTimeFilter.IsNil() {
 		tradeAggregationsQ.WithStartTime(action.StartTimeFilter)
 	}

--- a/services/horizon/internal/actions_trade_test.go
+++ b/services/horizon/internal/actions_trade_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	. "github.com/stellar/go/services/horizon/internal/db2/history"
 	. "github.com/stellar/go/services/horizon/internal/test/trades"
-	"github.com/stellar/go/xdr"
 	"github.com/stellar/go/support/render/hal"
+	"github.com/stellar/go/xdr"
 )
 
 func TestTradeActions_Index(t *testing.T) {
@@ -203,7 +203,6 @@ func TestTradeActions_Aggregation(t *testing.T) {
 	q.Add("end_time", strconv.FormatInt(start+hour, 10))
 	q.Add("order", "asc")
 
-
 	//test no resolution provided
 	w := ht.GetWithParams(aggregationPath, q)
 	println(w.Body.String())
@@ -249,6 +248,16 @@ func TestTradeActions_Aggregation(t *testing.T) {
 			ht.Assert.Equal("1.0000000", records[0].Average)
 		}
 	}
+
+	// Test that offset works by shifting the start time to the half range.
+	// Half of the results are expected.
+	offset := (numOfTrades / 2) * minute
+	q.Add("offset", strconv.Itoa(offset))
+	w = ht.GetWithParams(aggregationPath, q)
+	if ht.Assert.Equal(200, w.Code) {
+		ht.Assert.PageOf(numOfTrades/2, w.Body)
+	}
+	q.Del("offset")
 
 	//test partial range by modifying endTime to be one minute above half range.
 	//half of the results are expected

--- a/services/horizon/internal/actions_trade_test.go
+++ b/services/horizon/internal/actions_trade_test.go
@@ -170,11 +170,10 @@ func testTradeAggregationPrices(t *HTTPT, record horizon.TradeAggregation) {
 	testPrice(t, record.Close, record.CloseR)
 }
 
-const second = int64(1000)
-const minute = int64(60 * second)
-const hour = int64(minute * 60)
-const day = int64(24 * hour)
-const week = int64(7 * day)
+const minute = int64(time.Minute / time.Millisecond)
+const hour = int64(time.Hour / time.Millisecond)
+const day = int64(24 * time.Hour / time.Millisecond)
+const week = int64(7 * 24 * time.Hour / time.Millisecond)
 const aggregationPath = "/trade_aggregations"
 
 func TestTradeActions_Aggregation(t *testing.T) {
@@ -461,7 +460,7 @@ func TestTradeActions_AggregationOffset(t *testing.T) {
 			}
 			w := ht.GetWithParams(aggregationPath, q)
 			if ht.Assert.Equal(200, w.Code) {
-				//ht.Assert.PageOf(len(tc.expectedTimestamps), w.Body)
+				ht.Assert.PageOf(len(tc.expectedTimestamps), w.Body)
 				var records []horizon.TradeAggregation
 				ht.UnmarshalPage(w.Body, &records)
 				if len(records) > 0 {

--- a/services/horizon/internal/actions_trade_test.go
+++ b/services/horizon/internal/actions_trade_test.go
@@ -1,6 +1,7 @@
 package horizon
 
 import (
+	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
@@ -169,19 +170,22 @@ func testTradeAggregationPrices(t *HTTPT, record horizon.TradeAggregation) {
 	testPrice(t, record.Close, record.CloseR)
 }
 
+const second = int64(1000)
+const minute = int64(60 * second)
+const hour = int64(minute * 60)
+const day = int64(24 * hour)
+const week = int64(7 * day)
+const aggregationPath = "/trade_aggregations"
+
 func TestTradeActions_Aggregation(t *testing.T) {
 	ht := StartHTTPTest(t, "base")
 	defer ht.Finish()
 
-	const aggregationPath = "/trade_aggregations"
 	const numOfTrades = 10
-	const second = 1000
-	const minute = 60 * second
-	const hour = minute * 60
 
 	//a realistic millis (since epoch) value to start the test from
 	//it represents a round hour and is bigger than a max int32
-	const start = 1510693200000
+	const start = int64(1510693200000)
 
 	dbQ := &Q{ht.HorizonSession()}
 	ass1, ass2, err := PopulateTestTrades(dbQ, start, numOfTrades, minute, 0)
@@ -205,7 +209,6 @@ func TestTradeActions_Aggregation(t *testing.T) {
 
 	//test no resolution provided
 	w := ht.GetWithParams(aggregationPath, q)
-	println(w.Body.String())
 	ht.Assert.Equal(400, w.Code)
 
 	//test illegal resolution
@@ -249,20 +252,10 @@ func TestTradeActions_Aggregation(t *testing.T) {
 		}
 	}
 
-	// Test that offset works by shifting the start time to the half range.
-	// Half of the results are expected.
-	offset := (numOfTrades / 2) * minute
-	q.Add("offset", strconv.Itoa(offset))
-	w = ht.GetWithParams(aggregationPath, q)
-	if ht.Assert.Equal(200, w.Code) {
-		ht.Assert.PageOf(numOfTrades/2, w.Body)
-	}
-	q.Del("offset")
-
 	//test partial range by modifying endTime to be one minute above half range.
 	//half of the results are expected
 	endTime := start + (numOfTrades/2)*minute
-	q.Set("end_time", strconv.Itoa(endTime))
+	q.Set("end_time", strconv.FormatInt(endTime, 10))
 	w = ht.GetWithParams(aggregationPath, q)
 	if ht.Assert.Equal(200, w.Code) {
 		ht.Assert.PageOf(numOfTrades/2, w.Body)
@@ -286,7 +279,7 @@ func TestTradeActions_Aggregation(t *testing.T) {
 		ht.Assert.PageOf(numOfTrades/2-limit, w.Body)
 		ht.UnmarshalPage(w.Body, &records)
 		//test for expected value on timestamp of first record on next page
-		ht.Assert.Equal(int64(start+limit*minute), records[0].Timestamp)
+		ht.Assert.Equal(start+int64(limit)*minute, records[0].Timestamp)
 	}
 
 	//test direction (desc)
@@ -381,5 +374,103 @@ func TestTradeActions_AggregationOrdering(t *testing.T) {
 		ht.UnmarshalPage(w.Body, &records)
 		ht.Assert.Equal("1.0000000", records[0].Open)
 		ht.Assert.Equal("3.0000000", records[0].Close)
+	}
+}
+
+func TestTradeActions_AggregationInvalidOffset(t *testing.T) {
+	ht := StartHTTPTest(t, "base")
+	defer ht.Finish()
+	dbQ := &Q{ht.HorizonSession()}
+	ass1, ass2, err := PopulateTestTrades(dbQ, 0, 100, hour, 1)
+	ht.Require.NoError(err)
+
+	q := make(url.Values)
+	setAssetQuery(&q, "base_", ass1)
+	setAssetQuery(&q, "counter_", ass2)
+	q.Add("order", "asc")
+
+	testCases := []struct {
+		offset     int64
+		resolution int64
+		startTime  int64
+		endTime    int64
+	}{
+		{offset: minute, resolution: hour},                                            // Test invalid offset value that's not hour aligned
+		{offset: 25 * hour, resolution: week},                                         // Test invalid offset value that's greater than 24 hours
+		{offset: 3 * hour, resolution: hour},                                          // Test invalid offset value that's greater than the resolution
+		{offset: 3 * hour, startTime: 28 * hour, endTime: 26 * hour, resolution: day}, // Test invalid end time that's less than the start time
+		{offset: 3 * hour, startTime: 6 * hour, endTime: 26 * hour, resolution: day},  // Test invalid end time that's less than the offset-adjusted start time
+		{offset: 1 * hour, startTime: 5 * hour, endTime: 3 * hour, resolution: day},   // Test invalid end time that's less than the offset-adjusted start time
+		{offset: 3 * hour, endTime: 1 * hour, resolution: day},                        // Test invalid end time that's less than the offset
+		{startTime: 3 * minute, endTime: 1 * minute, resolution: minute},              // Test invalid end time that's less than the start time (no offset)
+	}
+
+	for _, tc := range testCases {
+		t.Run("Testing invalid offset parameters", func(t *testing.T) {
+			q.Add("offset", strconv.FormatInt(tc.offset, 10))
+			q.Add("resolution", strconv.FormatInt(tc.resolution, 10))
+			q.Add("start_time", strconv.FormatInt(tc.startTime, 10))
+			if tc.endTime != 0 {
+				q.Add("end_time", strconv.FormatInt(tc.endTime, 10))
+			}
+			w := ht.GetWithParams(aggregationPath, q)
+			ht.Assert.Equal(400, w.Code)
+		})
+	}
+}
+
+func TestTradeActions_AggregationOffset(t *testing.T) {
+	ht := StartHTTPTest(t, "base")
+	defer ht.Finish()
+	dbQ := &Q{ht.HorizonSession()}
+	// One trade every hour
+	ass1, ass2, err := PopulateTestTrades(dbQ, 0, 100, hour, 1)
+	ht.Require.NoError(err)
+
+	q := make(url.Values)
+	setAssetQuery(&q, "base_", ass1)
+	setAssetQuery(&q, "counter_", ass2)
+	q.Add("order", "asc")
+
+	q.Set("resolution", strconv.FormatInt(day, 10))
+	testCases := []struct {
+		offset             int64
+		startTime          int64
+		endTime            int64
+		expectedTimestamps []int64
+	}{
+		{offset: 2 * hour, expectedTimestamps: []int64{2 * hour, 26 * hour, 50 * hour, 74 * hour, 98 * hour}}, //Test with no start time
+		{offset: 1 * hour, startTime: 25 * hour, expectedTimestamps: []int64{25 * hour, 49 * hour, 73 * hour, 97 * hour}},
+		{offset: 3 * hour, startTime: 10 * hour, expectedTimestamps: []int64{27 * hour, 51 * hour, 75 * hour, 99 * hour}},
+		{offset: 6 * hour, startTime: 1 * hour, expectedTimestamps: []int64{6 * hour, 30 * hour, 54 * hour, 78 * hour}},
+		{offset: 18 * hour, startTime: 30 * hour, expectedTimestamps: []int64{42 * hour, 66 * hour, 90 * hour}},
+		{offset: 10 * hour, startTime: 35 * hour, expectedTimestamps: []int64{58 * hour, 82 * hour}},
+		{offset: 18 * hour, startTime: 96 * hour, expectedTimestamps: []int64{}}, // No results since last timestamp is at 100
+		{offset: 1 * hour, startTime: 5 * hour, endTime: 95 * hour, expectedTimestamps: []int64{25 * hour, 49 * hour}},
+		{offset: 1 * hour, startTime: 5 * hour, endTime: 26 * hour, expectedTimestamps: []int64{}}, // end time and start time should both be at 25 hours
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing trade aggregations bucket with offset %d (hour) start time %d (hour)",
+			tc.offset/hour, tc.startTime/hour), func(t *testing.T) {
+			q.Set("offset", strconv.FormatInt(tc.offset, 10))
+			if tc.startTime != 0 {
+				q.Set("start_time", strconv.FormatInt(tc.startTime, 10))
+			}
+			if tc.endTime != 0 {
+				q.Set("end_time", strconv.FormatInt(tc.endTime, 10))
+			}
+			w := ht.GetWithParams(aggregationPath, q)
+			if ht.Assert.Equal(200, w.Code) {
+				//ht.Assert.PageOf(len(tc.expectedTimestamps), w.Body)
+				var records []horizon.TradeAggregation
+				ht.UnmarshalPage(w.Body, &records)
+				if len(records) > 0 {
+					for i, record := range records {
+						println(record.Timestamp / hour)
+						ht.Assert.Equal(tc.expectedTimestamps[i], record.Timestamp)
+					}
+				}
+			}
+		})
 	}
 }

--- a/services/horizon/internal/actions_trade_test.go
+++ b/services/horizon/internal/actions_trade_test.go
@@ -466,7 +466,6 @@ func TestTradeActions_AggregationOffset(t *testing.T) {
 				ht.UnmarshalPage(w.Body, &records)
 				if len(records) > 0 {
 					for i, record := range records {
-						println(record.Timestamp / hour)
 						ht.Assert.Equal(tc.expectedTimestamps[i], record.Timestamp)
 					}
 				}

--- a/services/horizon/internal/db2/history/trade_aggregation.go
+++ b/services/horizon/internal/db2/history/trade_aggregation.go
@@ -45,17 +45,19 @@ type TradeAggregationsQ struct {
 	baseAssetID    int64
 	counterAssetID int64
 	resolution     int64
-	offset		   int64
+	offset         int64
 	startTime      strtime.Millis
 	endTime        strtime.Millis
 	pagingParams   db2.PageQuery
 }
 
 // GetTradeAggregationsQ initializes a TradeAggregationsQ query builder based on the required parameters
-func (q Q) GetTradeAggregationsQ(baseAssetID int64, counterAssetID int64, resolution int64, pagingParams db2.PageQuery) (*TradeAggregationsQ, error) {
+func (q Q) GetTradeAggregationsQ(baseAssetID int64, counterAssetID int64, resolution int64,
+	offset int64, pagingParams db2.PageQuery) (*TradeAggregationsQ, error) {
 
 	//convert resolution to a duration struct
 	resolutionDuration := time.Duration(resolution) * time.Millisecond
+	offsetDuration := time.Duration(offset) * time.Millisecond
 
 	//check if resolution allowed
 	if StrictResolutionFiltering {
@@ -63,33 +65,56 @@ func (q Q) GetTradeAggregationsQ(baseAssetID int64, counterAssetID int64, resolu
 			return &TradeAggregationsQ{}, errors.New("resolution is not allowed")
 		}
 	}
+	// check if offset is allowed. Offset must be 1) a multiple of an hour 2) less than the resolution and 3)
+	// less than 24 hours
+	if offsetDuration%time.Hour != 0 || offsetDuration >= time.Hour*24 || offsetDuration > resolutionDuration {
+		return &TradeAggregationsQ{}, errors.New("offset is not allowed.")
+	}
 
 	return &TradeAggregationsQ{
 		baseAssetID:    baseAssetID,
 		counterAssetID: counterAssetID,
 		resolution:     resolution,
+		offset:         offset,
 		pagingParams:   pagingParams,
 	}, nil
 }
 
-// WithOffset adds an optional time offset to apply to the start time (after rounding it to the nearest resolution).
-func (q *TradeAggregationsQ) WithOffset(offset int64) *TradeAggregationsQ {
-	q.offset = offset
-	return q
-}
-
 // WithStartTime adds an optional lower time boundary filter to the trades being aggregated.
-func (q *TradeAggregationsQ) WithStartTime(startTime strtime.Millis) *TradeAggregationsQ {
-	// Round lower boundary up, if start time is in the middle of a bucket
-	q.startTime = startTime.RoundUp(q.resolution)
-	return q
+func (q *TradeAggregationsQ) WithStartTime(startTime strtime.Millis) (*TradeAggregationsQ, error) {
+	offsetMillis := strtime.MillisFromInt64(q.offset)
+	var adjustedStartTime strtime.Millis
+	// Round up to offset if the provided start time is less than the offset.
+	if startTime < offsetMillis {
+		adjustedStartTime = offsetMillis
+	} else {
+		adjustedStartTime = (startTime - offsetMillis).RoundUp(q.resolution) + offsetMillis
+	}
+	if !q.endTime.IsNil() && adjustedStartTime > q.endTime {
+		return &TradeAggregationsQ{}, errors.New("start time is not allowed")
+	} else {
+		q.startTime = adjustedStartTime
+		return q, nil
+	}
 }
 
-// WithEndTime adds an upper optional time boundary filter to the trades being aggregated
-func (q *TradeAggregationsQ) WithEndTime(endTime strtime.Millis) *TradeAggregationsQ {
+// WithEndTime adds an upper optional time boundary filter to the trades being aggregated.
+func (q *TradeAggregationsQ) WithEndTime(endTime strtime.Millis) (*TradeAggregationsQ, error) {
 	// Round upper boundary down, to not deliver partial bucket
-	q.endTime = endTime.RoundDown(q.resolution)
-	return q
+	offsetMillis := strtime.MillisFromInt64(q.offset)
+	var adjustedEndTime strtime.Millis
+	// the end time isn't allowed to be less than the offset
+	if endTime < offsetMillis {
+		return &TradeAggregationsQ{}, errors.New("end time is not allowed")
+	} else {
+		adjustedEndTime = (endTime - offsetMillis).RoundDown(q.resolution) + offsetMillis
+	}
+	if adjustedEndTime < q.startTime {
+		return &TradeAggregationsQ{}, errors.New("end time is not allowed")
+	} else {
+		q.endTime = adjustedEndTime
+		return q, nil
+	}
 }
 
 // GetSql generates a sql statement to aggregate Trades based on given parameters
@@ -99,9 +124,9 @@ func (q *TradeAggregationsQ) GetSql() sq.SelectBuilder {
 
 	var bucketSQL sq.SelectBuilder
 	if orderPreserved {
-		bucketSQL = bucketTrades(q.resolution)
+		bucketSQL = bucketTrades(q.resolution, q.offset)
 	} else {
-		bucketSQL = reverseBucketTrades(q.resolution)
+		bucketSQL = reverseBucketTrades(q.resolution, q.offset)
 	}
 
 	bucketSQL = bucketSQL.From("history_trades").
@@ -134,16 +159,18 @@ func (q *TradeAggregationsQ) GetSql() sq.SelectBuilder {
 }
 
 // formatBucketTimestampSelect formats a sql select clause for a bucketed timestamp, based on given resolution
-func formatBucketTimestampSelect(resolution int64) string {
-	return fmt.Sprintf("div(cast((extract(epoch from ledger_closed_at) * 1000 ) as bigint), %d)*%d as timestamp",
-		resolution, resolution)
+// and the offset. Given a time t, it gives it a timestamp defined by
+// f(t) = ((t - offset)/resolution)*resolution + offset.
+func formatBucketTimestampSelect(resolution int64, offset int64) string {
+	return fmt.Sprintf("div((cast((extract(epoch from ledger_closed_at) * 1000 ) as bigint) - %d), %d)*%d + %d as timestamp",
+		offset, resolution, resolution, offset)
 }
 
 // bucketTrades generates a select statement to filter rows from the `history_trades` table in
 // a compact form, with a timestamp rounded to resolution and reversed base/counter.
-func bucketTrades(resolution int64) sq.SelectBuilder {
+func bucketTrades(resolution int64, offset int64) sq.SelectBuilder {
 	return sq.Select(
-		formatBucketTimestampSelect(resolution),
+		formatBucketTimestampSelect(resolution, offset),
 		"history_operation_id",
 		"\"order\"",
 		"base_asset_id",
@@ -156,9 +183,9 @@ func bucketTrades(resolution int64) sq.SelectBuilder {
 
 // reverseBucketTrades generates a select statement to filter rows from the `history_trades` table in
 // a compact form, with a timestamp rounded to resolution and reversed base/counter.
-func reverseBucketTrades(resolution int64) sq.SelectBuilder {
+func reverseBucketTrades(resolution int64, offset int64) sq.SelectBuilder {
 	return sq.Select(
-		formatBucketTimestampSelect(resolution),
+		formatBucketTimestampSelect(resolution, offset),
 		"history_operation_id",
 		"\"order\"",
 		"counter_asset_id as base_asset_id",

--- a/services/horizon/internal/db2/history/trade_aggregation.go
+++ b/services/horizon/internal/db2/history/trade_aggregation.go
@@ -45,7 +45,7 @@ type TradeAggregationsQ struct {
 	baseAssetID    int64
 	counterAssetID int64
 	resolution     int64
-	offset		   strtime.Millis
+	offset		   int64
 	startTime      strtime.Millis
 	endTime        strtime.Millis
 	pagingParams   db2.PageQuery
@@ -73,7 +73,7 @@ func (q Q) GetTradeAggregationsQ(baseAssetID int64, counterAssetID int64, resolu
 }
 
 // WithOffset adds an optional time offset to apply to the start time (after rounding it to the nearest resolution).
-func (q *TradeAggregationsQ) WithOffset(offset strtime.Millis) *TradeAggregationsQ {
+func (q *TradeAggregationsQ) WithOffset(offset int64) *TradeAggregationsQ {
 	q.offset = offset
 	return q
 }
@@ -108,7 +108,7 @@ func (q *TradeAggregationsQ) GetSql() sq.SelectBuilder {
 		Where(sq.Eq{"base_asset_id": q.baseAssetID, "counter_asset_id": q.counterAssetID})
 
 	//adjust time range and apply time filters
-	bucketSQL = bucketSQL.Where(sq.GtOrEq{"ledger_closed_at": (q.startTime + q.offset).ToTime()})
+	bucketSQL = bucketSQL.Where(sq.GtOrEq{"ledger_closed_at": q.startTime.ToTime()})
 	if !q.endTime.IsNil() {
 		bucketSQL = bucketSQL.Where(sq.Lt{"ledger_closed_at": q.endTime.ToTime()})
 	}

--- a/services/horizon/internal/db2/history/trade_aggregation.go
+++ b/services/horizon/internal/db2/history/trade_aggregation.go
@@ -45,6 +45,7 @@ type TradeAggregationsQ struct {
 	baseAssetID    int64
 	counterAssetID int64
 	resolution     int64
+	offset		   strtime.Millis
 	startTime      strtime.Millis
 	endTime        strtime.Millis
 	pagingParams   db2.PageQuery
@@ -71,7 +72,13 @@ func (q Q) GetTradeAggregationsQ(baseAssetID int64, counterAssetID int64, resolu
 	}, nil
 }
 
-// WithStartTime adds an optional lower time boundary filter to the trades being aggregated
+// WithOffset adds an optional time offset to apply to the start time (after rounding it to the nearest resolution).
+func (q *TradeAggregationsQ) WithOffset(offset strtime.Millis) *TradeAggregationsQ {
+	q.offset = offset
+	return q
+}
+
+// WithStartTime adds an optional lower time boundary filter to the trades being aggregated.
 func (q *TradeAggregationsQ) WithStartTime(startTime strtime.Millis) *TradeAggregationsQ {
 	// Round lower boundary up, if start time is in the middle of a bucket
 	q.startTime = startTime.RoundUp(q.resolution)
@@ -101,7 +108,7 @@ func (q *TradeAggregationsQ) GetSql() sq.SelectBuilder {
 		Where(sq.Eq{"base_asset_id": q.baseAssetID, "counter_asset_id": q.counterAssetID})
 
 	//adjust time range and apply time filters
-	bucketSQL = bucketSQL.Where(sq.GtOrEq{"ledger_closed_at": q.startTime.ToTime()})
+	bucketSQL = bucketSQL.Where(sq.GtOrEq{"ledger_closed_at": (q.startTime + q.offset).ToTime()})
 	if !q.endTime.IsNil() {
 		bucketSQL = bucketSQL.Where(sq.Lt{"ledger_closed_at": q.endTime.ToTime()})
 	}


### PR DESCRIPTION
- Closes #545 
- Adds an offset parameter to TradeAggregationsQ and a WithOffset method.
- Change actions_trade.go so that an offset filter can be created and used.
- Add test