### PR TITLE
Add assets validation to trade aggregation

### DIFF
--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -138,12 +138,19 @@ func (action *TradeAggregateIndexAction) JSON() {
 }
 
 func (action *TradeAggregateIndexAction) loadParams() {
+	var hasBaseAssetFilter, hasCounterAssetFilter bool
+
 	action.PagingParams = action.GetPageQuery()
-	action.BaseAssetFilter = action.GetAsset("base_")
-	action.CounterAssetFilter = action.GetAsset("counter_")
+	action.BaseAssetFilter, hasBaseAssetFilter = action.MaybeGetAsset("base_")
+	action.CounterAssetFilter, hasCounterAssetFilter = action.MaybeGetAsset("counter_")
 	action.StartTimeFilter = action.GetTimeMillis("start_time")
 	action.EndTimeFilter = action.GetTimeMillis("end_time")
 	action.ResolutionFilter = action.GetInt64("resolution")
+
+	if !hasBaseAssetFilter || !hasCounterAssetFilter {
+		action.SetInvalidField("base_asset_type,counter_asset_type", errors.New("this endpoint supports asset pairs but none or one asset supplied"))
+		return
+	}
 
 	//check if resolution is legal
 	resolutionDuration := gTime.Duration(action.ResolutionFilter) * gTime.Millisecond

--- a/services/horizon/internal/actions_trade_test.go
+++ b/services/horizon/internal/actions_trade_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	. "github.com/stellar/go/services/horizon/internal/db2/history"
 	. "github.com/stellar/go/services/horizon/internal/test/trades"
-	"github.com/stellar/go/xdr"
 	"github.com/stellar/go/support/render/hal"
+	"github.com/stellar/go/xdr"
 )
 
 func TestTradeActions_Index(t *testing.T) {
@@ -203,11 +203,14 @@ func TestTradeActions_Aggregation(t *testing.T) {
 	q.Add("end_time", strconv.FormatInt(start+hour, 10))
 	q.Add("order", "asc")
 
-
 	//test no resolution provided
 	w := ht.GetWithParams(aggregationPath, q)
-	println(w.Body.String())
+	extras := ht.UnmarshalExtras(w.Body)
 	ht.Assert.Equal(400, w.Code)
+	ht.Assert.Equal("resolution", extras["invalid_field"])
+	ht.Assert.Equal("illegal or missing resolution. allowed resolutions are: "+
+		"1 minute (60000), 5 minutes (300000), 15 minutes (900000), 1 hour (3600000), "+
+		"1 day (86400000) and 1 week (604800000)", extras["reason"])
 
 	//test illegal resolution
 	if history.StrictResolutionFiltering {

--- a/services/horizon/internal/actions_trade_test.go
+++ b/services/horizon/internal/actions_trade_test.go
@@ -196,16 +196,31 @@ func TestTradeActions_Aggregation(t *testing.T) {
 	var nextLink string
 
 	q := make(url.Values)
-	setAssetQuery(&q, "base_", ass1)
-	setAssetQuery(&q, "counter_", ass2)
-
 	q.Add("start_time", strconv.FormatInt(start, 10))
 	q.Add("end_time", strconv.FormatInt(start+hour, 10))
 	q.Add("order", "asc")
 
-	//test no resolution provided
+	// test no base_ and counter_ asset
 	w := ht.GetWithParams(aggregationPath, q)
 	extras := ht.UnmarshalExtras(w.Body)
+	ht.Assert.Equal(400, w.Code)
+	ht.Assert.Equal("base_asset_type,counter_asset_type", extras["invalid_field"])
+	ht.Assert.Equal("this endpoint supports asset pairs but none or one asset supplied", extras["reason"])
+
+	// test no counter_ asset
+	setAssetQuery(&q, "base_", ass1)
+
+	w = ht.GetWithParams(aggregationPath, q)
+	extras = ht.UnmarshalExtras(w.Body)
+	ht.Assert.Equal(400, w.Code)
+	ht.Assert.Equal("base_asset_type,counter_asset_type", extras["invalid_field"])
+	ht.Assert.Equal("this endpoint supports asset pairs but none or one asset supplied", extras["reason"])
+
+	setAssetQuery(&q, "counter_", ass2)
+
+	//test no resolution provided
+	w = ht.GetWithParams(aggregationPath, q)
+	extras = ht.UnmarshalExtras(w.Body)
 	ht.Assert.Equal(400, w.Code)
 	ht.Assert.Equal("resolution", extras["invalid_field"])
 	ht.Assert.Equal("illegal or missing resolution. allowed resolutions are: "+

--- a/services/horizon/internal/test/t.go
+++ b/services/horizon/internal/test/t.go
@@ -90,6 +90,18 @@ func (t *T) UnmarshalNext(r io.Reader) string {
 	return env.Links.Next.Href
 }
 
+// UnmarshalExtras extracts and returns extras content
+func (t *T) UnmarshalExtras(r io.Reader) map[string]string {
+	var resp struct {
+		Extras map[string]string `json:"extras"`
+	}
+
+	err := json.NewDecoder(r).Decode(&resp)
+	t.Require.NoError(err, "failed to decode page")
+
+	return resp.Extras
+}
+
 // UpdateLedgerState updates the cached ledger state (or panicing on failure).
 func (t *T) UpdateLedgerState() {
 	var next ledger.State


### PR DESCRIPTION
`/trade_aggretations` doesn't display correct error message when sending a request without `base_` or `counter_` assets.

Fixes https://github.com/stellar/go/issues/617