### PR TITLE
Display empty values when base_offer_id or counter_offer_id are null

### DIFF
--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -249,13 +249,13 @@ type Trade struct {
 	Order              int32     `db:"order"`
 	LedgerCloseTime    time.Time `db:"ledger_closed_at"`
 	OfferID            int64     `db:"offer_id"`
-	BaseOfferID        int64     `db:"base_offer_id"`
+	BaseOfferID        *int64    `db:"base_offer_id"`
 	BaseAccount        string    `db:"base_account"`
 	BaseAssetType      string    `db:"base_asset_type"`
 	BaseAssetCode      string    `db:"base_asset_code"`
 	BaseAssetIssuer    string    `db:"base_asset_issuer"`
 	BaseAmount         xdr.Int64 `db:"base_amount"`
-	CounterOfferID     int64     `db:"counter_offer_id"`
+	CounterOfferID     *int64    `db:"counter_offer_id"`
 	CounterAccount     string    `db:"counter_account"`
 	CounterAssetType   string    `db:"counter_asset_type"`
 	CounterAssetCode   string    `db:"counter_asset_code"`

--- a/services/horizon/internal/resourceadapter/trade.go
+++ b/services/horizon/internal/resourceadapter/trade.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 
 	"github.com/stellar/go/amount"
+	. "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/httpx"
 	"github.com/stellar/go/support/render/hal"
-	. "github.com/stellar/go/protocols/horizon"
-
 )
 
 // Populate fills out the details of a trade using a row from the history_trades
@@ -22,13 +21,19 @@ func PopulateTrade(
 	dest.ID = row.PagingToken()
 	dest.PT = row.PagingToken()
 	dest.OfferID = fmt.Sprintf("%d", row.OfferID)
-	dest.BaseOfferID = fmt.Sprintf("%d", row.BaseOfferID)
+	dest.BaseOfferID = ""
+	if row.BaseOfferID != nil {
+		dest.BaseOfferID = fmt.Sprintf("%d", row.BaseOfferID)
+	}
 	dest.BaseAccount = row.BaseAccount
 	dest.BaseAssetType = row.BaseAssetType
 	dest.BaseAssetCode = row.BaseAssetCode
 	dest.BaseAssetIssuer = row.BaseAssetIssuer
 	dest.BaseAmount = amount.String(row.BaseAmount)
-	dest.CounterOfferID = fmt.Sprintf("%d", row.CounterOfferID)
+	dest.CounterOfferID = ""
+	if row.CounterOfferID != nil {
+		dest.CounterOfferID = fmt.Sprintf("%d", row.CounterOfferID)
+	}
 	dest.CounterAccount = row.CounterAccount
 	dest.CounterAssetType = row.CounterAssetType
 	dest.CounterAssetCode = row.CounterAssetCode
@@ -47,7 +52,6 @@ func PopulateTrade(
 	populateTradeLinks(ctx, dest, row.HistoryOperationID)
 	return
 }
-
 
 func populateTradeLinks(
 	ctx context.Context,

--- a/services/horizon/internal/resourceadapter/trade.go
+++ b/services/horizon/internal/resourceadapter/trade.go
@@ -23,7 +23,7 @@ func PopulateTrade(
 	dest.OfferID = fmt.Sprintf("%d", row.OfferID)
 	dest.BaseOfferID = ""
 	if row.BaseOfferID != nil {
-		dest.BaseOfferID = fmt.Sprintf("%d", row.BaseOfferID)
+		dest.BaseOfferID = fmt.Sprintf("%d", *row.BaseOfferID)
 	}
 	dest.BaseAccount = row.BaseAccount
 	dest.BaseAssetType = row.BaseAssetType
@@ -32,7 +32,7 @@ func PopulateTrade(
 	dest.BaseAmount = amount.String(row.BaseAmount)
 	dest.CounterOfferID = ""
 	if row.CounterOfferID != nil {
-		dest.CounterOfferID = fmt.Sprintf("%d", row.CounterOfferID)
+		dest.CounterOfferID = fmt.Sprintf("%d", *row.CounterOfferID)
 	}
 	dest.CounterAccount = row.CounterAccount
 	dest.CounterAssetType = row.CounterAssetType


### PR DESCRIPTION
This can happen requesting `/trades` with `base_offer_id` or `counter_offer_id` equal `null` (if data has not been or is still being reingestested):
```
select failed: sql: Scan error on column index 4: converting driver.Value type <nil> ("<nil>") to a int64: invalid syntax
```