### PR TITLE
Fix `horizon db backfill` command

### DIFF
--- a/services/horizon/db.go
+++ b/services/horizon/db.go
@@ -25,10 +25,12 @@ var dbBackfillCmd = &cobra.Command{
 	Use:   "backfill [COUNT]",
 	Short: "backfills horizon history for COUNT ledgers",
 	Run: func(cmd *cobra.Command, args []string) {
-		initConfig()
+		app := initApp(cmd, args)
+		app.UpdateLedgerState()
+
 		hlog.DefaultLogger.Logger.Level = config.LogLevel
 
-		i := ingestSystem(ingest.Config{})
+		i := ingestSystem(ingest.Config{DisableAssetStats: true})
 		i.SkipCursorUpdate = true
 		parsed, err := strconv.ParseUint(args[0], 10, 32)
 		if err != nil {

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -10,8 +10,11 @@ import (
 	metrics "github.com/rcrowley/go-metrics"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/support/db"
+	ilog "github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 )
+
+var log = ilog.DefaultLogger.WithField("service", "ingest")
 
 const (
 	// CurrentVersion reflects the latest version of the ingestion

--- a/services/horizon/internal/ingest/system.go
+++ b/services/horizon/internal/ingest/system.go
@@ -12,18 +12,22 @@ import (
 	ilog "github.com/stellar/go/support/log"
 )
 
-var log = ilog.DefaultLogger.WithField("service", "ingest")
-
 // Backfill ingests history in reverse chronological order, from the current
 // horizon elder query for `n` ledgers
 func (i *System) Backfill(n uint) error {
-	start := ledger.CurrentState().HistoryElder
-	end := start - int32(n)
+	start := ledger.CurrentState().HistoryElder - 1
+	end := start - int32(n) + 1
 	is := NewSession(i)
 	is.Cursor = NewCursor(start, end, i)
-	is.ClearExisting = true
+
+	log.WithField("start", start).
+		WithField("end", end).
+		WithField("err", is.Err).
+		WithField("ingested", is.Ingested).
+		Info("ingest: backfill start")
 
 	is.Run()
+
 	log.WithField("start", start).
 		WithField("end", end).
 		WithField("err", is.Err).

--- a/services/horizon/main.go
+++ b/services/horizon/main.go
@@ -172,7 +172,7 @@ func init() {
 	viper.BindPFlags(rootCmd.PersistentFlags())
 }
 
-func initApp(cmd *cobra.Command, args []string) {
+func initApp(cmd *cobra.Command, args []string) *horizon.App {
 	initConfig()
 
 	var err error
@@ -181,6 +181,8 @@ func initApp(cmd *cobra.Command, args []string) {
 	if err != nil {
 		stdLog.Fatal(err.Error())
 	}
+
+	return app
 }
 
 func initConfig() {


### PR DESCRIPTION
`horizon db backfill` command was not working because the global ledger
state (`ledger` package) was not updated before starting the ledger
backfill process.

Fix #718
CC @lechengfan