### PR TITLE
Add rate limiting to stream requests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -40,16 +40,6 @@
   revision = "20f192218cf52a73397fa2df45bdda720f3e47c8"
 
 [[projects]]
-  digest = "1:409c6b044ddccdcb281f06d461ec8fe440ff47cd0e2e0235374057dd5cd38523"
-  name = "github.com/PuerkitoBio/throttled"
-  packages = [
-    ".",
-    "store",
-  ]
-  pruneopts = "T"
-  revision = "1c8297c643b774435df8df65f7502b37d014fb6b"
-
-[[projects]]
   digest = "1:99851d69cfb33fc9e027ae5190748dfca08457942386a3359abd42ef0d73d20f"
   name = "github.com/agl/ed25519"
   packages = [
@@ -211,16 +201,6 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:1dba21b5c876bf139d415909c3e20cbd754b7fd6e35d1775023502c971600780"
-  name = "github.com/garyburd/redigo"
-  packages = [
-    "internal",
-    "redis",
-  ]
-  pruneopts = "T"
-  revision = "8b1d80a45a732e6d95e22dcc2e067312c664936c"
-
-[[projects]]
   digest = "1:3cffcaa76937c4207f2b0e7d2a9c5ed452e1062e6f07dd288808cdb03ed64d0d"
   name = "github.com/gavv/monotime"
   packages = ["."]
@@ -284,11 +264,15 @@
   revision = "2da839ab0f4df05a6db5eb277995589dadbd4fb9"
 
 [[projects]]
-  digest = "1:d7491e1f92e84bfe31dc29bc276bf7d55f9cb02927ed82cab56a198ec839bc29"
-  name = "github.com/golang/groupcache"
-  packages = ["lru"]
+  digest = "1:eca5b59a68125905e4f62d6f5072f01740a7648a808e93f6d76c5334ff948601"
+  name = "github.com/gomodule/redigo"
+  packages = [
+    "internal",
+    "redis",
+  ]
   pruneopts = "T"
-  revision = "604ed5785183e59ae2789449d89e73f3a2a77987"
+  revision = "9c11da706d9b7902c6da69c592f75637793fe121"
+  version = "v2.0.0"
 
 [[projects]]
   digest = "1:d9ddf73f04fe521d71675d2c11c0694d138ad08a58d730e7c32fb387abafabbe"
@@ -314,6 +298,17 @@
   ]
   pruneopts = "T"
   revision = "572209b26df66a638573023571b5ce80983214eb"
+
+[[projects]]
+  digest = "1:8ec8d88c248041a6df5f6574b87bc00e7e0b493881dad2e7ef47b11dc69093b5"
+  name = "github.com/hashicorp/golang-lru"
+  packages = [
+    ".",
+    "simplelru",
+  ]
+  pruneopts = "T"
+  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
+  version = "v0.5.0"
 
 [[projects]]
   branch = "master"
@@ -665,6 +660,18 @@
   revision = "976c720a22c8eb4eb6a0b4348ad85ad12491a506"
 
 [[projects]]
+  digest = "1:513b53b1a9d42d32d2bbf1e67701ed384c74c020a5a701e8da2d4dc751192876"
+  name = "github.com/throttled/throttled"
+  packages = [
+    ".",
+    "store/memstore",
+    "store/redigostore",
+  ]
+  pruneopts = "T"
+  revision = "ee00e877b953e232c5b0fff46f75cdc56b984524"
+  version = "v2.2.2"
+
+[[projects]]
   branch = "master"
   digest = "1:ec528a786fa75556deed44de7118a74ced456360e782786a20aed292a03955a5"
   name = "github.com/tyler-smith/go-bip32"
@@ -865,8 +872,6 @@
     "bitbucket.org/ww/goautoneg",
     "github.com/BurntSushi/toml",
     "github.com/Masterminds/squirrel",
-    "github.com/PuerkitoBio/throttled",
-    "github.com/PuerkitoBio/throttled/store",
     "github.com/agl/ed25519",
     "github.com/asaskevich/govalidator",
     "github.com/aws/aws-sdk-go/aws",
@@ -883,13 +888,13 @@
     "github.com/ethereum/go-ethereum/crypto",
     "github.com/ethereum/go-ethereum/ethclient",
     "github.com/facebookgo/inject",
-    "github.com/garyburd/redigo/redis",
     "github.com/getsentry/raven-go",
     "github.com/go-chi/chi",
     "github.com/go-chi/chi/middleware",
     "github.com/go-errors/errors",
     "github.com/go-sql-driver/mysql",
     "github.com/goji/httpauth",
+    "github.com/gomodule/redigo/redis",
     "github.com/guregu/null",
     "github.com/haltingstate/secp256k1-go",
     "github.com/howeyc/gopass",
@@ -919,6 +924,9 @@
     "github.com/stretchr/testify/mock",
     "github.com/stretchr/testify/require",
     "github.com/stretchr/testify/suite",
+    "github.com/throttled/throttled",
+    "github.com/throttled/throttled/store/memstore",
+    "github.com/throttled/throttled/store/redigostore",
     "github.com/tyler-smith/go-bip32",
     "github.com/tyler-smith/go-bip39",
     "golang.org/x/net/http2",

--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -2,8 +2,8 @@ package actions
 
 import (
 	"database/sql"
-	"github.com/stellar/go/services/horizon/internal"
 	"net/http"
+	"strings"
 
 	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/render"
@@ -67,7 +67,8 @@ func (base *Base) Execute(action interface{}) {
 			// Rate limit the request if it's a call to stream since it queries the DB every second. See
 			// https://github.com/stellar/go/issues/715 for more details.
 			app := base.R.Context().Value(&horizonContext.AppContextKey)
-			limited, _, err := app.(RateLimiterProvider).GetRateLimiter().RateLimiter.RateLimit(horizon.RemoteAddrIP(base.R), 1)
+			key := strings.SplitN(base.R.RemoteAddr, ":", 2)[0]
+			limited, _, err := app.(RateLimiterProvider).GetRateLimiter().RateLimiter.RateLimit(key, 1)
 			if limited || err != nil {
 				stream.Err(errors.New("rate limit exceeded"))
 				return

--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -2,9 +2,10 @@ package actions
 
 import (
 	"database/sql"
+	"github.com/stellar/go/services/horizon/internal"
 	"net/http"
 
-	"github.com/stellar/go/services/horizon/internal"
+	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/render"
 	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
@@ -65,9 +66,12 @@ func (base *Base) Execute(action interface{}) {
 		for {
 			// Rate limit the request if it's a call to stream since it queries the DB every second. See
 			// https://github.com/stellar/go/issues/715 for more details.
-			app := horizon.AppFromContext(base.R.Context())
-			r := app.GetRateLimiter()
-			r.RateLimiter.RateLimit(horizon.RemoteAddrIP(base.R), 1)
+			app := base.R.Context().Value(&horizonContext.AppContextKey)
+			limited, _, err := app.(RateLimiterProvider).GetRateLimiter().RateLimiter.RateLimit(horizon.RemoteAddrIP(base.R), 1)
+			if limited || err != nil {
+				stream.Err(errors.New("rate limit exceeded"))
+				return
+			}
 
 			action.SSE(stream)
 

--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -3,7 +3,6 @@ package actions
 import (
 	"database/sql"
 	"net/http"
-	"strings"
 
 	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/render"
@@ -67,9 +66,14 @@ func (base *Base) Execute(action interface{}) {
 			// Rate limit the request if it's a call to stream since it queries the DB every second. See
 			// https://github.com/stellar/go/issues/715 for more details.
 			app := base.R.Context().Value(&horizonContext.AppContextKey)
-			key := strings.SplitN(base.R.RemoteAddr, ":", 2)[0]
-			limited, _, err := app.(RateLimiterProvider).GetRateLimiter().RateLimiter.RateLimit(key, 1)
-			if limited || err != nil {
+			rateLimiter := app.(RateLimiterProvider).GetRateLimiter()
+			limited, _, err := rateLimiter.RateLimiter.RateLimit(rateLimiter.VaryBy.Key(base.R), 1)
+			if err != nil {
+				log.Ctx(ctx).Error(errors.Wrap(err, "RateLimiter error"))
+				stream.Err(errors.New("Unexpected stream error"))
+				return
+			}
+			if limited {
 				stream.Err(errors.New("rate limit exceeded"))
 				return
 			}

--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -2,9 +2,9 @@ package actions
 
 import (
 	"database/sql"
-	"github.com/stellar/go/services/horizon/internal"
 	"net/http"
 
+	"github.com/stellar/go/services/horizon/internal"
 	"github.com/stellar/go/services/horizon/internal/render"
 	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
@@ -68,7 +68,7 @@ func (base *Base) Execute(action interface{}) {
 			app := horizon.AppFromContext(base.R.Context())
 			r := app.GetRateLimiter()
 			r.RateLimiter.RateLimit(horizon.RemoteAddrIP(base.R), 1)
-			
+
 			action.SSE(stream)
 
 			if base.Err != nil {

--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"database/sql"
+	"github.com/stellar/go/services/horizon/internal"
 	"net/http"
 
 	"github.com/stellar/go/services/horizon/internal/render"
@@ -62,6 +63,12 @@ func (base *Base) Execute(action interface{}) {
 		stream := sse.NewStream(ctx, base.W)
 
 		for {
+			// Rate limit the request if it's a call to stream since it queries the DB every second. See
+			// https://github.com/stellar/go/issues/715 for more details.
+			app := horizon.AppFromContext(base.R.Context())
+			r := app.GetRateLimiter()
+			r.RateLimiter.RateLimit(horizon.RemoteAddrIP(base.R), 1)
+			
 			action.SSE(stream)
 
 			if base.Err != nil {

--- a/services/horizon/internal/actions/rate_limiter_provider.go
+++ b/services/horizon/internal/actions/rate_limiter_provider.go
@@ -2,6 +2,7 @@ package actions
 
 import "github.com/throttled/throttled"
 
+// RateLimiterProvider is an interface that provides access to the type's HTTPRateLimiter.
 type RateLimiterProvider interface {
 	GetRateLimiter() *throttled.HTTPRateLimiter
 }

--- a/services/horizon/internal/actions/rate_limiter_provider.go
+++ b/services/horizon/internal/actions/rate_limiter_provider.go
@@ -1,0 +1,7 @@
+package actions
+
+import "github.com/throttled/throttled"
+
+type RateLimiterProvider interface {
+	GetRateLimiter() *throttled.HTTPRateLimiter
+}

--- a/services/horizon/internal/actions_account.go
+++ b/services/horizon/internal/actions_account.go
@@ -39,6 +39,7 @@ func (action *AccountShowAction) JSON() {
 
 // SSE is a method for actions.SSE
 func (action *AccountShowAction) SSE(stream sse.Stream) {
+
 	action.Do(
 		action.loadParams,
 		action.loadRecord,

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -3,7 +3,6 @@ package horizon
 import (
 	"context"
 	"fmt"
-	"github.com/throttled/throttled"
 	"net/http"
 	"runtime"
 	"sync"
@@ -13,6 +12,7 @@ import (
 	"github.com/rcrowley/go-metrics"
 	"github.com/stellar/go/build"
 	"github.com/stellar/go/clients/stellarcore"
+	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/ingest"
@@ -25,6 +25,7 @@ import (
 	"github.com/stellar/go/support/app"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/log"
+	"github.com/throttled/throttled"
 	"golang.org/x/net/http2"
 	"gopkg.in/tylerb/graceful.v1"
 )
@@ -328,11 +329,9 @@ func (a *App) run() {
 	}
 }
 
-var appkey = 0
-
 // Context create a context on from the App type.
 func (a *App) Context(ctx context.Context) context.Context {
-	return context.WithValue(ctx, &appkey, a)
+	return context.WithValue(ctx, &horizonContext.AppContextKey, a)
 }
 
 // GetRateLimiter returns the HTTPRateLimiter of the App.
@@ -347,7 +346,7 @@ func AppFromContext(ctx context.Context) *App {
 		return nil
 	}
 
-	val := ctx.Value(&appkey)
+	val := ctx.Value(&horizonContext.AppContextKey)
 	if val == nil {
 		return nil
 	}

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -3,13 +3,14 @@ package horizon
 import (
 	"context"
 	"fmt"
+	"github.com/throttled/throttled"
 	"net/http"
 	"runtime"
 	"sync"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
-	metrics "github.com/rcrowley/go-metrics"
+	"github.com/gomodule/redigo/redis"
+	"github.com/rcrowley/go-metrics"
 	"github.com/stellar/go/build"
 	"github.com/stellar/go/clients/stellarcore"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
@@ -25,7 +26,7 @@ import (
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/log"
 	"golang.org/x/net/http2"
-	graceful "gopkg.in/tylerb/graceful.v1"
+	"gopkg.in/tylerb/graceful.v1"
 )
 
 // App represents the root of the state of a horizon instance.
@@ -332,6 +333,11 @@ var appkey = 0
 // Context create a context on from the App type.
 func (a *App) Context(ctx context.Context) context.Context {
 	return context.WithValue(ctx, &appkey, a)
+}
+
+// GetRateLimiter returns the HTTPRateLimiter of the App.
+func (a *App) GetRateLimiter() *throttled.HTTPRateLimiter {
+	return a.web.rateLimiter
 }
 
 // AppFromContext returns the set app, if one has been set, from the

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -3,8 +3,8 @@ package horizon
 import (
 	"net/url"
 
-	"github.com/PuerkitoBio/throttled"
 	"github.com/sirupsen/logrus"
+	"github.com/throttled/throttled"
 )
 
 // Config is the configuration for horizon.  It get's populated by the
@@ -14,7 +14,7 @@ type Config struct {
 	StellarCoreDatabaseURL string
 	StellarCoreURL         string
 	Port                   int
-	RateLimit              throttled.Quota
+	RateLimit              throttled.RateQuota
 	RedisURL               string
 	FriendbotURL           *url.URL
 	LogLevel               logrus.Level

--- a/services/horizon/internal/context/context_key.go
+++ b/services/horizon/internal/context/context_key.go
@@ -1,0 +1,7 @@
+package context
+
+type CtxKey string
+
+var AppContextKey = CtxKey("app")
+var RequestContextKey = CtxKey("request")
+var ClientContextKey = CtxKey("client")

--- a/services/horizon/internal/helpers_test.go
+++ b/services/horizon/internal/helpers_test.go
@@ -26,7 +26,7 @@ func NewTestConfig() Config {
 		DatabaseURL:            test.DatabaseURL(),
 		StellarCoreDatabaseURL: test.StellarCoreDatabaseURL(),
 		RateLimit:              throttled.RateQuota{
-			MaxRate: throttled.PerHour(10),
+			MaxRate: throttled.PerHour(1000),
 		},
 		LogLevel:               supportLog.InfoLevel,
 	}

--- a/services/horizon/internal/helpers_test.go
+++ b/services/horizon/internal/helpers_test.go
@@ -27,6 +27,7 @@ func NewTestConfig() Config {
 		StellarCoreDatabaseURL: test.StellarCoreDatabaseURL(),
 		RateLimit:              throttled.RateQuota{
 			MaxRate: throttled.PerHour(1000),
+			MaxBurst: 100,
 		},
 		LogLevel:               supportLog.InfoLevel,
 	}

--- a/services/horizon/internal/helpers_test.go
+++ b/services/horizon/internal/helpers_test.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/PuerkitoBio/throttled"
 	"github.com/stellar/go/services/horizon/internal/test"
 	supportLog "github.com/stellar/go/support/log"
+	"github.com/throttled/throttled"
 )
 
 func NewTestApp() *App {
@@ -25,7 +25,9 @@ func NewTestConfig() Config {
 	return Config{
 		DatabaseURL:            test.DatabaseURL(),
 		StellarCoreDatabaseURL: test.StellarCoreDatabaseURL(),
-		RateLimit:              throttled.PerHour(1000),
+		RateLimit:              throttled.RateQuota{
+			MaxRate: throttled.PerHour(10),
+		},
 		LogLevel:               supportLog.InfoLevel,
 	}
 }

--- a/services/horizon/internal/httpx/client.go
+++ b/services/horizon/internal/httpx/client.go
@@ -3,16 +3,17 @@ package httpx
 import (
 	"context"
 	"net/http"
+
+	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 )
 
-var clientContextKey = 0
 var defaultClient = &http.Client{}
 
 // ClientFromContext retrieves a http.Client that has been bound to this context
 // previously by a call to httpx.ClientContext, defaulting to a default Client
 // if none has been bound
 func ClientFromContext(ctx context.Context) *http.Client {
-	found := ctx.Value(&clientContextKey)
+	found := ctx.Value(&horizonContext.ClientContextKey)
 
 	if found == nil {
 		return defaultClient
@@ -29,5 +30,5 @@ func ClientContext(parent context.Context, client *http.Client) context.Context 
 		panic("Cannot bind nil *http.Client to context tree")
 	}
 
-	return context.WithValue(parent, &clientContextKey, client)
+	return context.WithValue(parent, &horizonContext.ClientContextKey, client)
 }

--- a/services/horizon/internal/httpx/request.go
+++ b/services/horizon/internal/httpx/request.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"net/http"
 
+	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/support/log"
 )
 
-var requestContextKey = 0
-
 func RequestFromContext(ctx context.Context) *http.Request {
-	found := ctx.Value(&requestContextKey)
+	found := ctx.Value(&horizonContext.RequestContextKey)
 
 	if found == nil {
 		return nil
@@ -38,7 +37,7 @@ func RequestContext(parent context.Context, w http.ResponseWriter, r *http.Reque
 		closedByClient = make(chan bool)
 	}
 
-	// listen for the connection to close, trigger cancelation
+	// listen for the connection to close, trigger cancellation
 	go func() {
 		select {
 		case <-closedByClient:
@@ -49,5 +48,5 @@ func RequestContext(parent context.Context, w http.ResponseWriter, r *http.Reque
 		}
 	}()
 
-	return context.WithValue(ctx, &requestContextKey, r), cancel
+	return context.WithValue(ctx, &horizonContext.RequestContextKey, r), cancel
 }

--- a/services/horizon/internal/init_redis.go
+++ b/services/horizon/internal/init_redis.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/stellar/go/support/log"
 )
 

--- a/services/horizon/internal/init_redis_test.go
+++ b/services/horizon/internal/init_redis_test.go
@@ -3,7 +3,7 @@ package horizon
 import (
 	"testing"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/services/horizon/internal/init_web.go
+++ b/services/horizon/internal/init_web.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/PuerkitoBio/throttled"
-	"github.com/PuerkitoBio/throttled/store"
 	"github.com/go-chi/chi"
 	chimiddleware "github.com/go-chi/chi/middleware"
 	metrics "github.com/rcrowley/go-metrics"
@@ -17,13 +15,16 @@ import (
 	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/services/horizon/internal/txsub/sequence"
 	"github.com/stellar/go/support/render/problem"
+	"github.com/throttled/throttled"
+	"github.com/throttled/throttled/store/memstore"
+	"github.com/throttled/throttled/store/redigostore"
 )
 
 // Web contains the http server related fields for horizon: the router,
 // rate limiter, etc.
 type Web struct {
 	router      *chi.Mux
-	rateLimiter *throttled.Throttler
+	rateLimiter *throttled.HTTPRateLimiter
 
 	requestTimer metrics.Timer
 	failureMeter metrics.Meter
@@ -165,23 +166,28 @@ func initWebActions(app *App) {
 }
 
 func initWebRateLimiter(app *App) {
-	rateLimitStore := store.NewMemStore(1000)
+	var rateLimitStore throttled.GCRAStore
+	rateLimitStore, _ = memstore.New(1000)
 
 	if app.redis != nil {
-		rateLimitStore = store.NewRedisStore(app.redis, "throttle:", 0)
+		rateLimitStore, _ = redigostore.New(app.redis, "throttle:", 0)
 	}
 
-	rateLimiter := throttled.RateLimit(
-		app.config.RateLimit,
-		&throttled.VaryBy{Custom: remoteAddrIP},
-		rateLimitStore,
-	)
-
-	rateLimiter.DeniedHandler = &RateLimitExceededAction{App: app, Action: Action{}}
-	app.web.rateLimiter = rateLimiter
+	rateLimiter, _ := throttled.NewGCRARateLimiter(rateLimitStore, app.config.RateLimit)
+	httpRateLimiter := throttled.HTTPRateLimiter{
+		RateLimiter:   rateLimiter,
+		DeniedHandler: &RateLimitExceededAction{App: app, Action: Action{}},
+	}
+	httpRateLimiter.VaryBy = VaryByRemoteIP{}
+	app.web.rateLimiter = &httpRateLimiter
 }
 
-func remoteAddrIP(r *http.Request) string {
+type VaryByRemoteIP struct{}
+func (v VaryByRemoteIP) Key(r *http.Request) string{
+	return RemoteAddrIP(r)
+}
+
+func RemoteAddrIP(r *http.Request) string {
 	ip := strings.SplitN(r.RemoteAddr, ":", 2)[0]
 	return ip
 }

--- a/services/horizon/internal/init_web.go
+++ b/services/horizon/internal/init_web.go
@@ -3,12 +3,13 @@ package horizon
 import (
 	"compress/flate"
 	"database/sql"
+	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/go-chi/chi"
 	chimiddleware "github.com/go-chi/chi/middleware"
-	metrics "github.com/rcrowley/go-metrics"
+	"github.com/rcrowley/go-metrics"
 	"github.com/rs/cors"
 	"github.com/sebest/xff"
 	"github.com/stellar/go/services/horizon/internal/db2"
@@ -167,13 +168,21 @@ func initWebActions(app *App) {
 
 func initWebRateLimiter(app *App) {
 	var rateLimitStore throttled.GCRAStore
-	rateLimitStore, _ = memstore.New(1000)
+	rateLimitStore, err := memstore.New(1000)
 
 	if app.redis != nil {
-		rateLimitStore, _ = redigostore.New(app.redis, "throttle:", 0)
+		rateLimitStore, err = redigostore.New(app.redis, "throttle:", 0)
 	}
 
-	rateLimiter, _ := throttled.NewGCRARateLimiter(rateLimitStore, app.config.RateLimit)
+	if err != nil {
+		panic(fmt.Errorf("unable to initialize store for RateLimiter"))
+	}
+
+	rateLimiter, err := throttled.NewGCRARateLimiter(rateLimitStore, app.config.RateLimit)
+	if err != nil {
+		panic(fmt.Errorf("unable to create RateLimiter"))
+	}
+
 	httpRateLimiter := throttled.HTTPRateLimiter{
 		RateLimiter:   rateLimiter,
 		DeniedHandler: &RateLimitExceededAction{App: app, Action: Action{}},

--- a/services/horizon/internal/init_web.go
+++ b/services/horizon/internal/init_web.go
@@ -184,10 +184,10 @@ func initWebRateLimiter(app *App) {
 
 type VaryByRemoteIP struct{}
 func (v VaryByRemoteIP) Key(r *http.Request) string{
-	return RemoteAddrIP(r)
+	return remoteAddrIP(r)
 }
 
-func RemoteAddrIP(r *http.Request) string {
+func remoteAddrIP(r *http.Request) string {
 	ip := strings.SplitN(r.RemoteAddr, ":", 2)[0]
 	return ip
 }

--- a/services/horizon/internal/middleware_logger.go
+++ b/services/horizon/internal/middleware_logger.go
@@ -43,7 +43,7 @@ func logStartOfRequest(ctx context.Context, r *http.Request) {
 	log.Ctx(ctx).WithFields(log.F{
 		"path":         r.URL.String(),
 		"method":       r.Method,
-		"ip":           remoteAddrIP(r),
+		"ip":           RemoteAddrIP(r),
 		"ip_port":      r.RemoteAddr,
 		"forwarded_ip": firstXForwardedFor(r),
 		"host":         r.Host,
@@ -55,7 +55,7 @@ func logEndOfRequest(ctx context.Context, r *http.Request, duration time.Duratio
 		"path":         r.URL.String(),
 		"route":        chi.RouteContext(r.Context()).RoutePattern(),
 		"method":       r.Method,
-		"ip":           remoteAddrIP(r),
+		"ip":           RemoteAddrIP(r),
 		"ip_port":      r.RemoteAddr,
 		"forwarded_ip": firstXForwardedFor(r),
 		"host":         r.Host,

--- a/services/horizon/internal/middleware_logger.go
+++ b/services/horizon/internal/middleware_logger.go
@@ -43,7 +43,7 @@ func logStartOfRequest(ctx context.Context, r *http.Request) {
 	log.Ctx(ctx).WithFields(log.F{
 		"path":         r.URL.String(),
 		"method":       r.Method,
-		"ip":           RemoteAddrIP(r),
+		"ip":           remoteAddrIP(r),
 		"ip_port":      r.RemoteAddr,
 		"forwarded_ip": firstXForwardedFor(r),
 		"host":         r.Host,
@@ -55,7 +55,7 @@ func logEndOfRequest(ctx context.Context, r *http.Request, duration time.Duratio
 		"path":         r.URL.String(),
 		"route":        chi.RouteContext(r.Context()).RoutePattern(),
 		"method":       r.Method,
-		"ip":           RemoteAddrIP(r),
+		"ip":           remoteAddrIP(r),
 		"ip_port":      r.RemoteAddr,
 		"forwarded_ip": firstXForwardedFor(r),
 		"host":         r.Host,

--- a/services/horizon/internal/middleware_rate_limit.go
+++ b/services/horizon/internal/middleware_rate_limit.go
@@ -5,5 +5,5 @@ import (
 )
 
 func (web *Web) RateLimitMiddleware(next http.Handler) http.Handler {
-	return web.rateLimiter.Throttle(next)
+	return web.rateLimiter.RateLimit(next)
 }

--- a/services/horizon/internal/middleware_rate_limit_test.go
+++ b/services/horizon/internal/middleware_rate_limit_test.go
@@ -4,10 +4,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/PuerkitoBio/throttled"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"github.com/throttled/throttled"
 )
 
 type RateLimitMiddlewareTestSuite struct {
@@ -24,7 +24,10 @@ func (suite *RateLimitMiddlewareTestSuite) SetupSuite() {
 
 func (suite *RateLimitMiddlewareTestSuite) SetupTest() {
 	suite.c = NewTestConfig()
-	suite.c.RateLimit = throttled.PerHour(10)
+	suite.c.RateLimit = throttled.RateQuota{
+		MaxRate: throttled.PerHour(10),
+		MaxBurst: 9,
+	}
 	suite.app, _ = NewApp(suite.c)
 	suite.rh = NewRequestHelper(suite.app)
 }
@@ -62,7 +65,7 @@ func (suite *RateLimitMiddlewareTestSuite) TestRateLimit_RemainingHeaders() {
 // Sets X-RateLimit-Reset header correctly.
 func (suite *RateLimitMiddlewareTestSuite) TestRateLimit_ResetHeaders() {
 	w := suite.rh.Get("/")
-	assert.Equal(suite.T(), "3599", w.Header().Get("X-RateLimit-Reset"))
+	assert.Equal(suite.T(), "360", w.Header().Get("X-RateLimit-Reset"))
 }
 
 // Restricts based on RemoteAddr IP after too many requests.
@@ -115,7 +118,10 @@ func TestRateLimit_Redis(t *testing.T) {
 	ht := StartHTTPTest(t, "base")
 	defer ht.Finish()
 	c := NewTestConfig()
-	c.RateLimit = throttled.PerHour(10)
+	c.RateLimit = throttled.RateQuota{
+		MaxRate: throttled.PerHour(10),
+		MaxBurst: 9,
+	}
 	c.RedisURL = "redis://127.0.0.1:6379/"
 	app, _ := NewApp(c)
 	defer app.Close()

--- a/services/horizon/internal/middleware_rate_limit_test.go
+++ b/services/horizon/internal/middleware_rate_limit_test.go
@@ -62,7 +62,7 @@ func (suite *RateLimitMiddlewareTestSuite) TestRateLimit_RemainingHeaders() {
 	}
 }
 
-// Sets X-RateLimit-Reset header correctly.
+// Sets X-RateLimit-Reset header correctly. Should reset after 360 seconds since it's limited to 10 requests/hour.
 func (suite *RateLimitMiddlewareTestSuite) TestRateLimit_ResetHeaders() {
 	w := suite.rh.Get("/")
 	assert.Equal(suite.T(), "360", w.Header().Get("X-RateLimit-Reset"))

--- a/services/horizon/main.go
+++ b/services/horizon/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"github.com/throttled/throttled"
 	stdLog "log"
 	"net/url"
 	"os"
 
-	"github.com/PuerkitoBio/throttled"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -240,11 +240,14 @@ func initConfig() {
 	}
 
 	config = horizon.Config{
-		DatabaseURL:                   viper.GetString("db-url"),
-		StellarCoreDatabaseURL:        viper.GetString("stellar-core-db-url"),
-		StellarCoreURL:                viper.GetString("stellar-core-url"),
-		Port:                          viper.GetInt("port"),
-		RateLimit:                     throttled.PerHour(viper.GetInt("per-hour-rate-limit")),
+		DatabaseURL:            viper.GetString("db-url"),
+		StellarCoreDatabaseURL: viper.GetString("stellar-core-db-url"),
+		StellarCoreURL:         viper.GetString("stellar-core-url"),
+		Port:                   viper.GetInt("port"),
+		RateLimit: throttled.RateQuota{
+			MaxRate:  throttled.PerHour(viper.GetInt("per-hour-rate-limit")),
+			MaxBurst: 100,
+		},
 		RedisURL:                      viper.GetString("redis-url"),
 		FriendbotURL:                  friendbotURL,
 		LogLevel:                      ll,

--- a/services/horizon/main.go
+++ b/services/horizon/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/throttled/throttled"
 	stdLog "log"
 	"net/url"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stellar/go/services/horizon/internal"
 	"github.com/stellar/go/support/log"
+	"github.com/throttled/throttled"
 )
 
 var app *horizon.App


### PR DESCRIPTION
* fixes #715 @bartekn 
* Add an extra rate limit call for every call to stream.SSE in base.go so that clients are rate limited based on their DB queries
* Upgrade throttled package and refactor all the deprecated methods