### PR TITLE
clients/horizon: return error on bad http status

### DIFF
--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -373,6 +373,9 @@ func (c *Client) stream(
 		if err != nil {
 			return errors.Wrap(err, "Error sending HTTP request")
 		}
+		if resp.StatusCode/100 != 2 {
+			return fmt.Errorf("Got bad HTTP status code %d", resp.StatusCode)
+		}
 		defer resp.Body.Close()
 
 		reader := bufio.NewReader(resp.Body)


### PR DESCRIPTION
Fixes a bug where requests exceeded the rate-limit but wouldn't return errors, so `stream` would continue reading data, blocking the calling function from being able to back off and retry and avoid continual rate-limiting.