### PR TITLE
Add StreamOperations to Horizon Client

### DIFF
--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -531,14 +531,21 @@ func (c *Client) StreamTransactions(
 }
 
 // StreamOperations streams incoming operations. Use context.WithCancel to stop streaming or
-// context.Background() if you want to stream indefinitely.
+// context.Background() if you want to stream indefinitely. Send empty string for accountID to
+// stream every operation.
 func (c *Client) StreamOperations(
 	ctx context.Context,
+	accountID string,
 	cursor *Cursor,
 	handler OperationHandler,
 ) (err error) {
+	var url string
 	c.fixURLOnce.Do(c.fixURL)
-	url := fmt.Sprintf("%s/operations", c.URL)
+	if accountID == "" {
+		url = fmt.Sprintf("%s/operations", c.URL)
+	} else {
+		url = fmt.Sprintf("%s/accounts/%s/operations", c.URL, accountID)
+	}
 	return c.stream(ctx, url, cursor, func(data []byte) error {
 		var o operations.Base
 		err = json.Unmarshal(data, &o)

--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/manucorporat/sse"
+	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -539,7 +540,7 @@ func (c *Client) StreamOperations(
 	c.fixURLOnce.Do(c.fixURL)
 	url := fmt.Sprintf("%s/operations", c.URL)
 	return c.stream(ctx, url, cursor, func(data []byte) error {
-		var o operation.Base
+		var o operations.Base
 		err = json.Unmarshal(data, &o)
 		if err != nil {
 			return errors.Wrap(err, "Error unmarshaling data")

--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -529,6 +529,26 @@ func (c *Client) StreamTransactions(
 	})
 }
 
+// StreamOperations streams incoming operations. Use context.WithCancel to stop streaming or
+// context.Background() if you want to stream indefinitely.
+func (c *Client) StreamOperations(
+	ctx context.Context,
+	cursor *Cursor,
+	handler OperationHandler,
+) (err error) {
+	c.fixURLOnce.Do(c.fixURL)
+	url := fmt.Sprintf("%s/operations", c.URL)
+	return c.stream(ctx, url, cursor, func(data []byte) error {
+		var o operation.Base
+		err = json.Unmarshal(data, &o)
+		if err != nil {
+			return errors.Wrap(err, "Error unmarshaling data")
+		}
+		handler(o)
+		return nil
+	})
+}
+
 // SubmitTransaction submits a transaction to the network. err can be either error object or horizon.Error object.
 func (c *Client) SubmitTransaction(
 	transactionEnvelopeXdr string,

--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/manucorporat/sse"
-	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -547,7 +546,7 @@ func (c *Client) StreamOperations(
 		url = fmt.Sprintf("%s/accounts/%s/operations", c.URL, accountID)
 	}
 	return c.stream(ctx, url, cursor, func(data []byte) error {
-		var o operations.Base
+		var o interface{}
 		err = json.Unmarshal(data, &o)
 		if err != nil {
 			return errors.Wrap(err, "Error unmarshaling data")

--- a/clients/horizon/client_test.go
+++ b/clients/horizon/client_test.go
@@ -20,8 +20,8 @@ func TestClient(t *testing.T) {
 	h.
 		On("GET", "https://horizon.stellar.org/trades/?base_asset_type=native&counter_asset_code=SLT&counter_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP&counter_asset_type=credit_alphanum4&limit=3&offer_id=0&order=asc&resolution=300000").
 		ReturnString(http.StatusOK,
-		tradesNormalResponse,
-	)
+			tradesNormalResponse,
+		)
 	trades, err := horizonClient.LoadTrades(
 		Asset{Type: "native"},
 		Asset{"credit_alphanum4", "SLT", "GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP"},

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -110,7 +110,7 @@ type ClientInterface interface {
 	SequenceForAccount(accountID string) (xdr.SequenceNumber, error)
 	StreamLedgers(ctx context.Context, cursor *Cursor, handler LedgerHandler) error
 	StreamPayments(ctx context.Context, accountID string, cursor *Cursor, handler PaymentHandler) error
-	StreamOperations(ctx context.Context, cursor *Cursor, handler OperationHandler) error
+	StreamOperations(ctx context.Context, accountID string, cursor *Cursor, handler OperationHandler) error
 	StreamTransactions(ctx context.Context, accountID string, cursor *Cursor, handler TransactionHandler) error
 	SubmitTransaction(txeBase64 string) (TransactionSuccess, error)
 }

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/stellar/go/build"
+	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -109,6 +110,7 @@ type ClientInterface interface {
 	SequenceForAccount(accountID string) (xdr.SequenceNumber, error)
 	StreamLedgers(ctx context.Context, cursor *Cursor, handler LedgerHandler) error
 	StreamPayments(ctx context.Context, accountID string, cursor *Cursor, handler PaymentHandler) error
+	StreamOperations(ctx context.Context, cursor *Cursor, handler OperationHandler) error
 	StreamTransactions(ctx context.Context, accountID string, cursor *Cursor, handler TransactionHandler) error
 	SubmitTransaction(txeBase64 string) (TransactionSuccess, error)
 }
@@ -134,6 +136,9 @@ type PaymentHandler func(Payment)
 
 // TransactionHandler is a function that is called when a new transaction is received
 type TransactionHandler func(Transaction)
+
+// OperationHandler is a function that is called when a new operation is received
+type OperationHandler func(operations.Base)
 
 // ensure that the horizon client can be used as a SequenceProvider
 var _ build.SequenceProvider = &Client{}

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -138,7 +137,7 @@ type PaymentHandler func(Payment)
 type TransactionHandler func(Transaction)
 
 // OperationHandler is a function that is called when a new operation is received
-type OperationHandler func(operations.Base)
+type OperationHandler func(interface{})
 
 // ensure that the horizon client can be used as a SequenceProvider
 var _ build.SequenceProvider = &Client{}

--- a/clients/horizon/main_test.go
+++ b/clients/horizon/main_test.go
@@ -43,7 +43,7 @@ func ExampleClient_StreamOperations() {
 		time.Sleep(60 * time.Second)
 		cancel()
 	}()
-	err := client.StreamOperations(ctx, &cursor, func(o operations.Base) {
+	err := client.StreamOperations(ctx, "", &cursor, func(o operations.Base) {
 		fmt.Println(o.Type)
 	})
 	if err != nil {

--- a/clients/horizon/main_test.go
+++ b/clients/horizon/main_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/http/httptest"
 	"github.com/stretchr/testify/assert"
@@ -42,7 +43,7 @@ func ExampleClient_StreamOperations() {
 		time.Sleep(60 * time.Second)
 		cancel()
 	}()
-	err := client.StreamOperations(ctx, &cursor, func(o operation.Base) {
+	err := client.StreamOperations(ctx, &cursor, func(o operations.Base) {
 		fmt.Println(o.Type)
 	})
 	if err != nil {

--- a/clients/horizon/main_test.go
+++ b/clients/horizon/main_test.go
@@ -34,6 +34,22 @@ func ExampleClient_StreamLedgers() {
 	}
 }
 
+func ExampleClient_StreamOperations() {
+	client := DefaultPublicNetClient
+	cursor := Cursor("now")
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(60 * time.Second)
+		cancel()
+	}()
+	err := client.StreamOperations(ctx, &cursor, func(o operation.Base) {
+		fmt.Println(o.Type)
+	})
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
 func ExampleClient_SubmitTransaction() {
 	client := DefaultPublicNetClient
 	transactionEnvelopeXdr := "AAAAABSxFjMo7qcQlJBlrZQypSqYsHA5hHaYxk5hFXwiehh6AAAAZAAIdakAAABZAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAFLEWMyjupxCUkGWtlDKlKpiwcDmEdpjGTmEVfCJ6GHoAAAAAAAAAAACYloAAAAAAAAAAASJ6GHoAAABAp0FnKOQ9lJPDXPTh/a91xoZ8BaznwLj59sdDGK94eGzCOk7oetw7Yw50yOSZg2mqXAST6Agc9Ao/f5T9gB+GCw=="

--- a/clients/horizon/main_test.go
+++ b/clients/horizon/main_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/http/httptest"
 	"github.com/stretchr/testify/assert"
@@ -43,8 +42,9 @@ func ExampleClient_StreamOperations() {
 		time.Sleep(60 * time.Second)
 		cancel()
 	}()
-	err := client.StreamOperations(ctx, "", &cursor, func(o operations.Base) {
-		fmt.Println(o.Type)
+	err := client.StreamOperations(ctx, "", &cursor, func(o interface{}) {
+		fmt.Println(o)
+		// do stuff like type assertions
 	})
 	if err != nil {
 		fmt.Println(err)

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -148,10 +148,11 @@ func (m *MockClient) StreamTransactions(
 // StreamOperations is a mocking a method
 func (m *MockClient) StreamOperations(
 	ctx context.Context,
+	accountID string,
 	cursor *Cursor,
 	handler OperationHandler,
 ) error {
-	a := m.Called(ctx, cursor, handler)
+	a := m.Called(ctx, accountID, cursor, handler)
 	return a.Error(0)
 }
 

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -85,7 +85,7 @@ func (m *MockClient) LoadMemo(p *Payment) error {
 	return a.Error(0)
 }
 
-// LoadMemo is a mocking a method
+// LoadOperation is a mocking a method
 func (m *MockClient) LoadOperation(operationID string) (payment Payment, err error) {
 	a := m.Called(operationID)
 	return a.Get(0).(Payment), a.Error(1)
@@ -142,6 +142,16 @@ func (m *MockClient) StreamTransactions(
 	handler TransactionHandler,
 ) error {
 	a := m.Called(ctx, accountID, cursor, handler)
+	return a.Error(0)
+}
+
+// StreamOperations is a mocking a method
+func (m *MockClient) StreamOperations(
+	ctx context.Context,
+	cursor *Cursor,
+	handler OperationHandler,
+) error {
+	a := m.Called(ctx, cursor, handler)
 	return a.Error(0)
 }
 

--- a/clients/horizon/responses.go
+++ b/clients/horizon/responses.go
@@ -2,6 +2,7 @@ package horizon
 
 import (
 	"encoding/json"
+
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/render/hal"
 )
@@ -63,7 +64,7 @@ type Effect struct {
 
 // TradeAggregationsPage returns a list of aggregated trade records, aggregated by resolution
 type TradeAggregationsPage struct {
-	Links hal.Links `json:"_links"`
+	Links    hal.Links `json:"_links"`
 	Embedded struct {
 		Records []TradeAggregation `json:"records"`
 	} `json:"_embedded"`
@@ -74,7 +75,7 @@ type TradeAggregation = hProtocol.TradeAggregation
 
 // TradesPage returns a list of trade records
 type TradesPage struct {
-	Links hal.Links `json:"_links"`
+	Links    hal.Links `json:"_links"`
 	Embedded struct {
 		Records []Trade `json:"records"`
 	} `json:"_embedded"`
@@ -97,7 +98,7 @@ type Signer = hProtocol.Signer
 
 // OffersPage returns a list of offers
 type OffersPage struct {
-	Links hal.Links `json:"_links"`
+	Links    hal.Links `json:"_links"`
 	Embedded struct {
 		Records []Offer `json:"records"`
 	} `json:"_embedded"`


### PR DESCRIPTION
Needed streaming operations for a project I am working on. 

Original work adapted from https://github.com/stellar/go/pull/501 written by @mattlisiv

@tomerweller requested that the Operation type be switched over to the newer protocols/horizon/operations package. I simply switched the types from @mattlisiv's code.
 
@mattlisiv should receive credit. Matt, if you want, fork my updated repo and then open a PR.
