### PR TITLE
Fix memory leak in stream

### DIFF
--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -117,7 +117,10 @@ func (base *Base) Execute(action interface{}) {
 				return
 			}
 
-			newLedgers := make(chan bool)
+			// Make sure this is buffered channel of size 1. Otherwise, the go routine below
+			// will never return if `newLedgers` channel is not read. From Effective Go:
+			// > If the channel is unbuffered, the sender blocks until the receiver has received the value.
+			newLedgers := make(chan bool, 1)
 			go func() {
 				for {
 					time.Sleep(base.sseUpdateFrequency)


### PR DESCRIPTION
I misunderstood how unbuffered channels work in Go (from [Effective Go](https://golang.org/doc/effective_go.html#channels)):
> Receivers always block until there is data to receive. If the channel is unbuffered, the sender blocks until the receiver has received the value. If the channel has a buffer, the sender blocks only until the value has been copied to the buffer; if the buffer is full, this means waiting until some receiver has retrieved a value.

The fix is to change unbuffered channel to a buffered channel of size `1`.