### PR TITLE
Init asset stats command

### DIFF
--- a/services/horizon/db.go
+++ b/services/horizon/db.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/stellar/go/services/horizon/internal/db2/core"
-	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/db2/schema"
 	"github.com/stellar/go/services/horizon/internal/ingest"
 	"github.com/stellar/go/support/db"
@@ -66,8 +64,8 @@ var dbInitAssetStatsCmd = &cobra.Command{
 		}
 
 		assetStats := ingest.AssetStats{
-			CoreQ:    &core.Q{Session: cdb},
-			HistoryQ: &history.Q{Session: hdb},
+			CoreSession:    cdb,
+			HistorySession: hdb,
 		}
 
 		log.Println("Getting assets from core DB...")

--- a/services/horizon/internal/ingest/asset_stat.go
+++ b/services/horizon/internal/ingest/asset_stat.go
@@ -11,12 +11,27 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-func (assetsModified AssetsModified) handlePaymentOp(paymentOp *xdr.PaymentOp, sourceAccount *xdr.AccountId) error {
-	err := assetsModified.updateIfAssetIssuerInvolved(paymentOp.Asset, *sourceAccount)
+func (assetStats *AssetStats) init() {
+	assetStats.batchInsertBuilder = &BatchInsertBuilder{
+		TableName: AssetStatsTableName,
+		Columns: []string{
+			"id",
+			"amount",
+			"num_accounts",
+			"flags",
+			"toml",
+		},
+	}
+
+	assetStats.toUpdate = make(map[string]xdr.Asset)
+}
+
+func (assetStats *AssetStats) handlePaymentOp(paymentOp *xdr.PaymentOp, sourceAccount *xdr.AccountId) error {
+	err := assetStats.updateIfAssetIssuerInvolved(paymentOp.Asset, *sourceAccount)
 	if err != nil {
 		return err
 	}
-	return assetsModified.updateIfAssetIssuerInvolved(paymentOp.Asset, paymentOp.Destination)
+	return assetStats.updateIfAssetIssuerInvolved(paymentOp.Asset, paymentOp.Destination)
 }
 
 func defaultSourceAccount(sourceAccount *xdr.AccountId, defaultAccount *xdr.AccountId) *xdr.AccountId {
@@ -26,66 +41,79 @@ func defaultSourceAccount(sourceAccount *xdr.AccountId, defaultAccount *xdr.Acco
 	return defaultAccount
 }
 
-func (assetsModified AssetsModified) add(asset xdr.Asset) {
-	assetsModified[asset.String()] = asset
+// AddAllAssets adds all assets to update list. Used in initialization of stats.
+func (assetStats *AssetStats) AddAllAssetsFromCore() (int, error) {
+	assetStats.initOnce.Do(assetStats.init)
+
+	var assets []xdr.Asset
+	err := assetStats.CoreQ.AllAssets(&assets)
+	if err != nil {
+		return 0, errors.Wrap(err, "Error getting all assets")
+	}
+
+	for _, asset := range assets {
+		assetStats.add(asset)
+	}
+
+	return len(assets), nil
+}
+
+func (assetStats *AssetStats) add(asset xdr.Asset) {
+	assetStats.toUpdate[asset.String()] = asset
 }
 
 // IngestOperation updates the assetsModified using the passed in operation
-func (assetsModified AssetsModified) IngestOperation(err error, op *xdr.Operation, source *xdr.AccountId, coreQ *core.Q) error {
-	if err != nil {
-		return err
-	}
+func (assetStats *AssetStats) IngestOperation(op *xdr.Operation, source *xdr.AccountId) error {
+	assetStats.initOnce.Do(assetStats.init)
 
 	body := op.Body
 	sourceAccount := defaultSourceAccount(op.SourceAccount, source)
 	switch body.Type {
 	// TODO NNS 2 need to fix GetCreateAssetID call when adding assets from account
 	// case xdr.OperationTypeSetOptions:
-	// 	assetsModified.addAssetsFromAccount(coreQ, sourceAccount)
+	// 	assetStats.addAssetsFromAccount(coreQ, sourceAccount)
 	case xdr.OperationTypePayment:
 		// payments is the only operation where we currently perform the optimization of checking against the issuer
-		return assetsModified.handlePaymentOp(body.PaymentOp, sourceAccount)
+		return assetStats.handlePaymentOp(body.PaymentOp, sourceAccount)
 	case xdr.OperationTypePathPayment:
 		// if this gets expensive then we can limit it to only include those assets that includes the issuer
-		assetsModified.add(body.PathPaymentOp.DestAsset)
-		assetsModified.add(body.PathPaymentOp.SendAsset)
+		assetStats.add(body.PathPaymentOp.DestAsset)
+		assetStats.add(body.PathPaymentOp.SendAsset)
 		for _, asset := range body.PathPaymentOp.Path {
-			assetsModified.add(asset)
+			assetStats.add(asset)
 		}
 	case xdr.OperationTypeManageOffer:
 		// if this gets expensive then we can limit it to only include those assets that includes the issuer
-		assetsModified.add(body.ManageOfferOp.Buying)
-		assetsModified.add(body.ManageOfferOp.Selling)
+		assetStats.add(body.ManageOfferOp.Buying)
+		assetStats.add(body.ManageOfferOp.Selling)
 	case xdr.OperationTypeCreatePassiveOffer:
 		// if this gets expensive then we can limit it to only include those assets that includes the issuer
-		assetsModified.add(body.CreatePassiveOfferOp.Buying)
-		assetsModified.add(body.CreatePassiveOfferOp.Selling)
+		assetStats.add(body.CreatePassiveOfferOp.Buying)
+		assetStats.add(body.CreatePassiveOfferOp.Selling)
 	case xdr.OperationTypeChangeTrust:
-		assetsModified.add(body.ChangeTrustOp.Line)
+		assetStats.add(body.ChangeTrustOp.Line)
 	case xdr.OperationTypeAllowTrust:
 		asset := body.AllowTrustOp.Asset.ToAsset(*sourceAccount)
-		assetsModified.add(asset)
+		assetStats.add(asset)
 	}
 
 	return nil
 }
 
 // UpdateAssetStats updates the db with the latest asset stats for the assets that were modified
-func (assetsModified AssetsModified) UpdateAssetStats(is *Session) {
-	if is.Err != nil {
-		return
-	}
+func (assetStats *AssetStats) UpdateAssetStats() error {
+	assetStats.initOnce.Do(assetStats.init)
 
 	hasValue := false
-	for _, asset := range assetsModified {
-		assetStat := computeAssetStat(is, &asset)
-		if is.Err != nil {
-			return
+	for _, asset := range assetStats.toUpdate {
+		assetStat, err := assetStats.computeAssetStat(&asset)
+		if err != nil {
+			return err
 		}
 
 		if assetStat != nil {
 			hasValue = true
-			is.Ingestion.builders[AssetStatsTableName].Values(
+			assetStats.batchInsertBuilder.Values(
 				assetStat.ID,
 				assetStat.Amount,
 				assetStat.NumAccounts,
@@ -97,19 +125,21 @@ func (assetsModified AssetsModified) UpdateAssetStats(is *Session) {
 
 	if hasValue {
 		// perform a delete first since upsert is not supported if postgres < 9.5
-		is.Err = errors.Wrap(assetsModified.deleteRows(is.Ingestion.DB), "Error deleting asset_stats row")
-		if is.Err != nil {
-			return
+		err := errors.Wrap(assetStats.deleteRows(assetStats.HistoryQ.Session), "Error deleting asset_stats row")
+		if err != nil {
+			return err
 		}
 
 		// can perform a direct upsert if postgres > 9.4
 		// is.Ingestion.assetStats = is.Ingestion.assetStats.
 		// 	Suffix("ON CONFLICT (id) DO UPDATE SET (amount, num_accounts, flags, toml) = (excluded.amount, excluded.num_accounts, excluded.flags, excluded.toml)")
-		is.Err = errors.Wrap(is.Ingestion.builders[AssetStatsTableName].Exec(is.Ingestion.DB), "Error inserting asset_stats row")
+		return errors.Wrap(assetStats.batchInsertBuilder.Exec(assetStats.HistoryQ.Session), "Error inserting asset_stats row")
 	}
+
+	return nil
 }
 
-// func (assetsModified AssetsModified) addAssetsFromAccount(coreQ *core.Q, account *xdr.AccountId) {
+// func (assetStats *AssetStats) addAssetsFromAccount(coreQ *core.Q, account *xdr.AccountId) {
 // 	if account == nil {
 // 		return
 // 	}
@@ -119,22 +149,21 @@ func (assetsModified AssetsModified) UpdateAssetStats(is *Session) {
 
 // 	for _, asset := range assets {
 // 		if asset.Type != xdr.AssetTypeAssetTypeNative {
-// 			assetsModified.add(asset)
+// 			assetStats.add(asset)
 // 		}
 // 	}
 // }
 
-func (assetsModified AssetsModified) deleteRows(session *db.Session) error {
-	if len(assetsModified) == 0 {
+func (assetStats *AssetStats) deleteRows(session *db.Session) error {
+	if len(assetStats.toUpdate) == 0 {
 		return nil
 	}
 
-	assets := make([]xdr.Asset, 0, len(assetsModified))
-	for _, asset := range assetsModified {
+	assets := make([]xdr.Asset, 0, len(assetStats.toUpdate))
+	for _, asset := range assetStats.toUpdate {
 		assets = append(assets, asset)
 	}
-	historyQ := history.Q{Session: session}
-	ids, err := historyQ.GetAssetIDs(assets)
+	ids, err := assetStats.HistoryQ.GetAssetIDs(assets)
 	if err != nil {
 		return err
 	}
@@ -147,7 +176,7 @@ func (assetsModified AssetsModified) deleteRows(session *db.Session) error {
 	return err
 }
 
-func (assetsModified AssetsModified) updateIfAssetIssuerInvolved(asset xdr.Asset, account xdr.AccountId) error {
+func (assetStats *AssetStats) updateIfAssetIssuerInvolved(asset xdr.Asset, account xdr.AccountId) error {
 	var assetType, assetCode, assetIssuer string
 	err := asset.Extract(&assetType, &assetCode, &assetIssuer)
 	if err != nil {
@@ -155,43 +184,36 @@ func (assetsModified AssetsModified) updateIfAssetIssuerInvolved(asset xdr.Asset
 	}
 
 	if assetIssuer == account.Address() {
-		assetsModified.add(asset)
+		assetStats.add(asset)
 	}
 	return nil
 }
 
-func computeAssetStat(is *Session, asset *xdr.Asset) *history.AssetStat {
+func (assetStats *AssetStats) computeAssetStat(asset *xdr.Asset) (*history.AssetStat, error) {
 	if asset.Type == xdr.AssetTypeAssetTypeNative {
-		return nil
+		return nil, nil
 	}
 
-	historyQ := history.Q{Session: is.Ingestion.DB}
-	assetID, err := historyQ.GetCreateAssetID(*asset)
+	assetID, err := assetStats.HistoryQ.GetCreateAssetID(*asset)
 	if err != nil {
-		is.Err = errors.Wrap(err, "historyQ.GetCreateAssetID error")
-		return nil
+		return nil, errors.Wrap(err, "historyQ.GetCreateAssetID error")
 	}
 
 	var assetType xdr.AssetType
 	var assetCode, assetIssuer string
 	err = asset.Extract(&assetType, &assetCode, &assetIssuer)
 	if err != nil {
-		is.Err = errors.Wrap(err, "asset.Extract error")
-		return nil
+		return nil, errors.Wrap(err, "asset.Extract error")
 	}
 
-	coreQ := &core.Q{Session: is.Cursor.CoreDB}
-
-	numAccounts, amount, err := statTrustlinesInfo(coreQ, assetType, assetCode, assetIssuer)
+	numAccounts, amount, err := statTrustlinesInfo(assetStats.CoreQ, assetType, assetCode, assetIssuer)
 	if err != nil {
-		is.Err = errors.Wrap(err, "statTrustlinesInfo error")
-		return nil
+		return nil, errors.Wrap(err, "statTrustlinesInfo error")
 	}
 
-	flags, toml, err := statAccountInfo(coreQ, assetIssuer)
+	flags, toml, err := statAccountInfo(assetStats.CoreQ, assetIssuer)
 	if err != nil {
-		is.Err = errors.Wrap(err, "statAccountInfo error")
-		return nil
+		return nil, errors.Wrap(err, "statAccountInfo error")
 	}
 
 	return &history.AssetStat{
@@ -200,7 +222,7 @@ func computeAssetStat(is *Session, asset *xdr.Asset) *history.AssetStat {
 		NumAccounts: numAccounts,
 		Flags:       flags,
 		Toml:        toml,
-	}
+	}, nil
 }
 
 // statTrustlinesInfo fetches all the stats from the trustlines table

--- a/services/horizon/internal/ingest/asset_stat_test.go
+++ b/services/horizon/internal/ingest/asset_stat_test.go
@@ -357,16 +357,14 @@ func TestAssetModified(t *testing.T) {
 				coreQ = &core.Q{Session: session}
 			}
 
-			assetsModified := AssetsModified(make(map[string]xdr.Asset))
-			assetsModified.IngestOperation(
-				nil,
+			assetsStats := AssetStats{CoreQ: coreQ}
+			assetsStats.IngestOperation(
 				&xdr.Operation{
 					SourceAccount: &sourceAccount,
 					Body:          kase.opBody,
 				},
-				&sourceAccount,
-				coreQ)
-			assert.Equal(t, kase.wantAssets, extractKeys(assetsModified))
+				&sourceAccount)
+			assert.Equal(t, kase.wantAssets, extractKeys(assetsStats.toUpdate))
 		})
 	}
 }
@@ -387,17 +385,15 @@ func TestSourceAccountForAllowTrust(t *testing.T) {
 	})
 	wantAssets := []string{"credit_alphanum4/CAT/GCYLTPOU7IVYHHA3XKQF4YB4W4ZWHFERMOQ7K47IWANKNBFBNJJNEOG5"} // issued by anotherAccount
 
-	assetsModified := AssetsModified(make(map[string]xdr.Asset))
-	assetsModified.IngestOperation(
-		nil,
+	assetsStats := AssetStats{}
+	assetsStats.IngestOperation(
 		&xdr.Operation{
 			// this is the difference between this test and the table-driven case above
 			SourceAccount: nil,
 			Body:          opBody,
 		},
-		&sourceAccount,
-		nil)
-	assert.Equal(t, wantAssets, extractKeys(assetsModified))
+		&sourceAccount)
+	assert.Equal(t, wantAssets, extractKeys(assetsStats.toUpdate))
 }
 
 func makeAccount(secret string, code string) (xdr.AccountId, xdr.Asset) {

--- a/services/horizon/internal/ingest/ingestion.go
+++ b/services/horizon/internal/ingest/ingestion.go
@@ -54,10 +54,6 @@ func (ingest *Ingestion) Clear(start int64, end int64) error {
 	if err != nil {
 		return errors.Wrap(err, "Error clearing history_trades")
 	}
-	err = clear(start, end, "asset_stats", "id")
-	if err != nil {
-		return errors.Wrap(err, "Error clearing asset_stats")
-	}
 
 	return nil
 }
@@ -450,17 +446,6 @@ func (ingest *Ingestion) createInsertBuilders() {
 			"counter_asset_id",
 			"counter_amount",
 			"base_is_seller",
-		},
-	}
-
-	ingest.builders[AssetStatsTableName] = &BatchInsertBuilder{
-		TableName: AssetStatsTableName,
-		Columns: []string{
-			"id",
-			"amount",
-			"num_accounts",
-			"flags",
-			"toml",
 		},
 	}
 }

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -9,7 +9,6 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	metrics "github.com/rcrowley/go-metrics"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
-	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/db"
 	ilog "github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
@@ -145,8 +144,8 @@ type BatchInsertBuilder struct {
 
 // AssetStats tracks and updates all the assets modified during a cycle of ingestion.
 type AssetStats struct {
-	CoreQ    *core.Q
-	HistoryQ *history.Q
+	CoreSession    *db.Session
+	HistorySession *db.Session
 
 	batchInsertBuilder *BatchInsertBuilder
 	toUpdate           map[string]xdr.Asset
@@ -238,8 +237,8 @@ func NewSession(i *System) *Session {
 		SkipCursorUpdate: i.SkipCursorUpdate,
 		Metrics:          &i.Metrics,
 		AssetStats: &AssetStats{
-			CoreQ:    &core.Q{Session: cdb},
-			HistoryQ: &history.Q{Session: hdb},
+			CoreSession:    cdb,
+			HistorySession: hdb,
 		},
 	}
 }

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -9,6 +9,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	metrics "github.com/rcrowley/go-metrics"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/db"
 	ilog "github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
@@ -57,8 +58,8 @@ type Cursor struct {
 	// CoreDB is the stellar-core db that data is ingested from.
 	CoreDB *db.Session
 
-	Metrics        *IngesterMetrics
-	AssetsModified AssetsModified
+	Metrics    *IngesterMetrics
+	AssetStats *AssetStats
 
 	// Err is the error that caused this iteration to fail, if any.
 	Err error
@@ -142,8 +143,15 @@ type BatchInsertBuilder struct {
 	insertBuilder sq.InsertBuilder
 }
 
-// AssetsModified tracks all the assets modified during a cycle of ingestion
-type AssetsModified map[string]xdr.Asset
+// AssetStats tracks and updates all the assets modified during a cycle of ingestion.
+type AssetStats struct {
+	CoreQ    *core.Q
+	HistoryQ *history.Q
+
+	batchInsertBuilder *BatchInsertBuilder
+	toUpdate           map[string]xdr.Asset
+	initOnce           sync.Once
+}
 
 // Ingestion receives write requests from a Session
 type Ingestion struct {
@@ -174,6 +182,8 @@ type Session struct {
 	SkipCursorUpdate bool
 	// Metrics is a reference to where the session should record its metric information
 	Metrics *IngesterMetrics
+	// AssetStats calculates asset stats
+	AssetStats *AssetStats
 
 	//
 	// Results fields
@@ -206,16 +216,16 @@ func New(network string, coreURL string, core, horizon *db.Session, config Confi
 // NewCursor initializes a new ingestion cursor
 func NewCursor(first, last int32, i *System) *Cursor {
 	return &Cursor{
-		FirstLedger:    first,
-		LastLedger:     last,
-		CoreDB:         i.CoreDB,
-		Metrics:        &i.Metrics,
-		AssetsModified: AssetsModified(make(map[string]xdr.Asset)),
+		FirstLedger: first,
+		LastLedger:  last,
+		CoreDB:      i.CoreDB,
+		Metrics:     &i.Metrics,
 	}
 }
 
 // NewSession initialize a new ingestion session
 func NewSession(i *System) *Session {
+	cdb := i.CoreDB.Clone()
 	hdb := i.HorizonDB.Clone()
 
 	return &Session{
@@ -227,5 +237,9 @@ func NewSession(i *System) *Session {
 		StellarCoreURL:   i.StellarCoreURL,
 		SkipCursorUpdate: i.SkipCursorUpdate,
 		Metrics:          &i.Metrics,
+		AssetStats: &AssetStats{
+			CoreQ:    &core.Q{Session: cdb},
+			HistoryQ: &history.Q{Session: hdb},
+		},
 	}
 }


### PR DESCRIPTION
Something we discussed in https://github.com/stellar/go/pull/147 but never implemented.

Adds a command `horizon db init-asset-stats` that calculates the stats from the current state of core DB. To achieve this I refactored `AssetsModified` to remove dependency on `ingest.Session` struct and to allow to use it outside ingestion context.