### PR TITLE
Fix name of `price` field on Trade

### DIFF
--- a/services/horizon/internal/docs/reference/resources/trade.md
+++ b/services/horizon/internal/docs/reference/resources/trade.md
@@ -34,11 +34,11 @@ A trade occurs between two parties - `base` and `counter`. Which is which is eit
 | counter_asset_type | string | type of counter asset|
 | counter_asset_code | string | code of counter asset|
 | counter_asset_issuer | string | issuer of counter asset|
-| price_r | object | original offer price, expressed as a rational number. example: {N:7, D:3}
+| price | object | original offer price, expressed as a rational number. example: {n:7, d:3}
 | base_is_seller | boolean | indicates which party of the trade made the sell offer|
 
-#### Price_r Object
-Price_r is a more precise representation of a bid/ask offer.
+#### Price Object
+Price is a precise representation of a bid/ask offer.
 
 |    Attribute     |  Type  |                                                                                                                                |
 | ---------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
Other resources like Offer do have both `price` (float) and `price_r` (rational number). 

However for Trade, there is just `price`, and is the rational number version.
See:
https://github.com/stellar/go/blob/4791a38ef2611994db9b841f0d2181f5ed4a20ca/protocols/horizon/main.go#L290