### PR TITLE
Fix complie error in method Entry.StartTest

### DIFF
--- a/support/log/entry.go
+++ b/support/log/entry.go
@@ -145,7 +145,7 @@ func (e *Entry) StartTest(level logrus.Level) func() []*logrus.Entry {
 		e.Logger.Out = old
 		e.removeHook(hook)
 		e.isTesting = false
-		return hook.Entries
+		return hook.AllEntries()
 	}
 }
 


### PR DESCRIPTION
the type of hook.Entries is []logrus.Entry, but the return reuqire []*logrus.Entry