### PR TITLE
Report right protocol version in horizon root path

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -252,7 +252,10 @@ type Root struct {
 	HistoryElderSequence int32  `json:"history_elder_ledger"`
 	CoreSequence         int32  `json:"core_latest_ledger"`
 	NetworkPassphrase    string `json:"network_passphrase"`
-	ProtocolVersion      int32  `json:"protocol_version"`
+	// Deprecated - remove in: horizon-v0.17.0
+	ProtocolVersion              int32 `json:"protocol_version"`
+	CurrentProtocolVersion       int32 `json:"current_protocol_version"`
+	CoreSupportedProtocolVersion int32 `json:"core_supported_protocol_version"`
 }
 
 // Signer represents one of an account's signers.

--- a/protocols/stellarcore/info_response.go
+++ b/protocols/stellarcore/info_response.go
@@ -4,13 +4,27 @@ package stellarcore
 // endpoint.
 type InfoResponse struct {
 	Info struct {
-		Build           string `json:"build"`
-		Network         string `json:"network"`
-		ProtocolVersion int    `json:"protocol_version"`
-		State           string `json:"state"`
+		Build           string     `json:"build"`
+		Network         string     `json:"network"`
+		ProtocolVersion int        `json:"protocol_version"`
+		State           string     `json:"state"`
+		Ledger          LedgerInfo `json:"ledger"`
 
 		// TODO: all the other fields
 	}
+}
+
+// LedgerInfo is the part of the stellar-core's info json response.
+// It's returned under `ledger` key
+type LedgerInfo struct {
+	Age          int    `json:"age"`
+	BaseFee      int    `json:"baseFee"`
+	BaseReserve  int    `json:"baseReserve"`
+	CloseTime    int    `json:"closeTime"`
+	Hash         string `json:"hash"`
+	MaxTxSetSize int    `json:"maxTxSetSize"`
+	Num          int    `json:"num"`
+	Version      int    `json:"version"`
 }
 
 // IsSynced returns a boolean indicating whether stellarcore is synced with the

--- a/services/horizon/internal/actions_account.go
+++ b/services/horizon/internal/actions_account.go
@@ -58,7 +58,7 @@ func (action *AccountShowAction) loadParams() {
 
 func (action *AccountShowAction) loadRecord() {
 	app := AppFromContext(action.R.Context())
-	protocolVersion := app.protocolVersion
+	protocolVersion := app.currentProtocolVersion
 
 	action.Err = action.CoreQ().
 		AccountByAddress(&action.CoreRecord, action.Address, protocolVersion)

--- a/services/horizon/internal/actions_account.go
+++ b/services/horizon/internal/actions_account.go
@@ -58,7 +58,7 @@ func (action *AccountShowAction) loadParams() {
 
 func (action *AccountShowAction) loadRecord() {
 	app := AppFromContext(action.R.Context())
-	protocolVersion := app.currentProtocolVersion
+	protocolVersion := app.coreSupportedProtocolVersion
 
 	action.Err = action.CoreQ().
 		AccountByAddress(&action.CoreRecord, action.Address, protocolVersion)

--- a/services/horizon/internal/actions_path.go
+++ b/services/horizon/internal/actions_path.go
@@ -37,7 +37,7 @@ func (action *PathIndexAction) loadQuery() {
 
 func (action *PathIndexAction) loadSourceAssets() {
 	app := AppFromContext(action.R.Context())
-	protocolVersion := app.protocolVersion
+	protocolVersion := app.currentProtocolVersion
 
 	action.Err = action.CoreQ().AssetsForAddress(
 		&action.Query.SourceAssets,

--- a/services/horizon/internal/actions_path.go
+++ b/services/horizon/internal/actions_path.go
@@ -37,7 +37,7 @@ func (action *PathIndexAction) loadQuery() {
 
 func (action *PathIndexAction) loadSourceAssets() {
 	app := AppFromContext(action.R.Context())
-	protocolVersion := app.currentProtocolVersion
+	protocolVersion := app.coreSupportedProtocolVersion
 
 	action.Err = action.CoreQ().AssetsForAddress(
 		&action.Query.SourceAssets,

--- a/services/horizon/internal/actions_root.go
+++ b/services/horizon/internal/actions_root.go
@@ -23,7 +23,8 @@ func (action *RootAction) JSON() {
 		action.App.horizonVersion,
 		action.App.coreVersion,
 		action.App.config.NetworkPassphrase,
-		action.App.protocolVersion,
+		action.App.currentProtocolVersion,
+		action.App.coreSupportedProtocolVersion,
 		action.App.config.FriendbotURL,
 	)
 

--- a/services/horizon/internal/actions_root_test.go
+++ b/services/horizon/internal/actions_root_test.go
@@ -30,6 +30,7 @@ func TestRootAction(t *testing.T) {
 	ht.App.UpdateStellarCoreInfo()
 
 	w := ht.Get("/")
+
 	if ht.Assert.Equal(200, w.Code) {
 		var actual horizon.Root
 		err := json.Unmarshal(w.Body.Bytes(), &actual)
@@ -37,5 +38,7 @@ func TestRootAction(t *testing.T) {
 		ht.Assert.Equal("test-horizon", actual.HorizonVersion)
 		ht.Assert.Equal("test-core", actual.StellarCoreVersion)
 		ht.Assert.Equal(int32(3), actual.ProtocolVersion)
+		ht.Assert.Equal(int32(4), actual.CoreSupportedProtocolVersion)
+		ht.Assert.Equal(int32(3), actual.CurrentProtocolVersion)
 	}
 }

--- a/services/horizon/internal/actions_root_test.go
+++ b/services/horizon/internal/actions_root_test.go
@@ -16,6 +16,9 @@ func TestRootAction(t *testing.T) {
 			"info": {
 				"network": "test",
 				"build": "test-core",
+				"ledger": {
+					"version": 3
+				},
 				"protocol_version": 4
 			}
 		}`)
@@ -33,5 +36,6 @@ func TestRootAction(t *testing.T) {
 		ht.Require.NoError(err)
 		ht.Assert.Equal("test-horizon", actual.HorizonVersion)
 		ht.Assert.Equal("test-core", actual.StellarCoreVersion)
+		ht.Assert.Equal(int32(3), actual.ProtocolVersion)
 	}
 }

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -280,7 +280,7 @@ func (a *App) UpdateStellarCoreInfo() {
 	}
 
 	a.coreVersion = resp.Info.Build
-	a.protocolVersion = int32(resp.Info.ProtocolVersion)
+	a.protocolVersion = int32(resp.Info.Ledger.Version)
 }
 
 // UpdateMetrics triggers a refresh of several metrics gauges, such as open

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -32,21 +32,22 @@ import (
 
 // App represents the root of the state of a horizon instance.
 type App struct {
-	config          Config
-	web             *Web
-	historyQ        *history.Q
-	coreQ           *core.Q
-	ctx             context.Context
-	cancel          func()
-	redis           *redis.Pool
-	coreVersion     string
-	horizonVersion  string
-	protocolVersion int32
-	submitter       *txsub.System
-	paths           paths.Finder
-	ingester        *ingest.System
-	reaper          *reap.System
-	ticks           *time.Ticker
+	config                       Config
+	web                          *Web
+	historyQ                     *history.Q
+	coreQ                        *core.Q
+	ctx                          context.Context
+	cancel                       func()
+	redis                        *redis.Pool
+	coreVersion                  string
+	horizonVersion               string
+	currentProtocolVersion       int32
+	coreSupportedProtocolVersion int32
+	submitter                    *txsub.System
+	paths                        paths.Finder
+	ingester                     *ingest.System
+	reaper                       *reap.System
+	ticks                        *time.Ticker
 
 	// metrics
 	metrics                  metrics.Registry
@@ -280,7 +281,9 @@ func (a *App) UpdateStellarCoreInfo() {
 	}
 
 	a.coreVersion = resp.Info.Build
-	a.protocolVersion = int32(resp.Info.Ledger.Version)
+
+	a.currentProtocolVersion = int32(resp.Info.Ledger.Version)
+	a.coreSupportedProtocolVersion = int32(resp.Info.ProtocolVersion)
 }
 
 // UpdateMetrics triggers a refresh of several metrics gauges, such as open

--- a/services/horizon/internal/resourceadapter/root.go
+++ b/services/horizon/internal/resourceadapter/root.go
@@ -18,6 +18,7 @@ func PopulateRoot(
 	hVersion, cVersion string,
 	passphrase string,
 	pVersion int32,
+	coreSupportedProtocolVersion int32,
 	friendBotURL *url.URL,
 ) {
 	dest.HorizonSequence = ledgerState.HistoryLatest
@@ -27,6 +28,8 @@ func PopulateRoot(
 	dest.StellarCoreVersion = cVersion
 	dest.NetworkPassphrase = passphrase
 	dest.ProtocolVersion = pVersion
+	dest.CurrentProtocolVersion = pVersion
+	dest.CoreSupportedProtocolVersion = coreSupportedProtocolVersion
 
 	lb := hal.LinkBuilder{Base: httpx.BaseURL(ctx)}
 	if friendBotURL != nil {

--- a/services/horizon/internal/resourceadapter/root.go
+++ b/services/horizon/internal/resourceadapter/root.go
@@ -17,7 +17,7 @@ func PopulateRoot(
 	ledgerState ledger.State,
 	hVersion, cVersion string,
 	passphrase string,
-	pVersion int32,
+	currentProtocolVersion int32,
 	coreSupportedProtocolVersion int32,
 	friendBotURL *url.URL,
 ) {
@@ -27,8 +27,8 @@ func PopulateRoot(
 	dest.HorizonVersion = hVersion
 	dest.StellarCoreVersion = cVersion
 	dest.NetworkPassphrase = passphrase
-	dest.ProtocolVersion = pVersion
-	dest.CurrentProtocolVersion = pVersion
+	dest.ProtocolVersion = currentProtocolVersion
+	dest.CurrentProtocolVersion = currentProtocolVersion
 	dest.CoreSupportedProtocolVersion = coreSupportedProtocolVersion
 
 	lb := hal.LinkBuilder{Base: httpx.BaseURL(ctx)}

--- a/services/horizon/internal/resourceadapter/root_test.go
+++ b/services/horizon/internal/resourceadapter/root_test.go
@@ -19,6 +19,7 @@ func TestPopulateRoot(t *testing.T) {
 		"cVersion",
 		"passphrase",
 		100,
+		101,
 		urlMustParse(t, "https://friendbot.example.com"))
 
 	assert.Equal(t, int32(1), res.CoreSequence)
@@ -38,6 +39,7 @@ func TestPopulateRoot(t *testing.T) {
 		"cVersion",
 		"passphrase",
 		100,
+		101,
 		nil)
 
 	assert.Equal(t, int32(1), res.CoreSequence)


### PR DESCRIPTION
Addresses #580 

As stated in https://github.com/stellar/stellar-core/issues/1740, I take here current protocol version from the `ledger.version` attribute of stellar-core info command response

I am a quite newbie in both Stellar and Go, so I will appreciate any comments, which help me improve this PR 🙏 