### PR TITLE
Fix slow trades page query

### DIFF
--- a/services/horizon/internal/db2/history/trade.go
+++ b/services/horizon/internal/db2/history/trade.go
@@ -99,20 +99,20 @@ func (q *TradesQ) Page(page db2.PageQuery) *TradesQ {
 	case "asc":
 		q.sql = q.sql.
 			Where(`(
-					 htrd.history_operation_id > ?
-				OR (
-							htrd.history_operation_id = ?
-					AND htrd.order > ?
-				))`, op, op, idx).
+					 htrd.history_operation_id >= ?
+				AND (
+					 htrd.history_operation_id > ? OR
+					(htrd.history_operation_id = ? AND htrd.order > ?)
+				))`, op, op, op, idx).
 			OrderBy("htrd.history_operation_id asc, htrd.order asc")
 	case "desc":
 		q.sql = q.sql.
 			Where(`(
-					 htrd.history_operation_id < ?
-				OR (
-							htrd.history_operation_id = ?
-					AND htrd.order < ?
-				))`, op, op, idx).
+					 htrd.history_operation_id <= ?
+				AND (
+					 htrd.history_operation_id < ? OR
+					(htrd.history_operation_id = ? AND htrd.order < ?)
+				))`, op, op, op, idx).
 			OrderBy("htrd.history_operation_id desc, htrd.order desc")
 	}
 

--- a/services/horizon/internal/db2/history/trade.go
+++ b/services/horizon/internal/db2/history/trade.go
@@ -95,6 +95,10 @@ func (q *TradesQ) Page(page db2.PageQuery) *TradesQ {
 		idx = math.MaxInt32
 	}
 
+	// NOTE: Remember to test the queries below with EXPLAIN / EXPLAIN ANALYZE
+	// before changing them.
+	// This condition is using multicolumn index and it's easy to write it in a way that
+	// DB will perform a full table scan.
 	switch page.Order {
 	case "asc":
 		q.sql = q.sql.


### PR DESCRIPTION
Exactly the same issue as in #315.

---
Old query:
```
horizon=> EXPLAIN ANALYZE SELECT history_operation_id, htrd."order", htrd.ledger_closed_at, htrd.offer_id, htrd.base_offer_id, base_accounts.address as base_account, base_assets.asset_type as base_asset_type, base_assets.asset_code as base_asset_code, base_assets.asset_issuer as base_asset_issuer, htrd.base_amount, htrd.counter_offer_id, counter_accounts.address as counter_account, counter_assets.asset_type as counter_asset_type, counter_assets.asset_code as counter_asset_code, counter_assets.asset_issuer as counter_asset_issuer, htrd.counter_amount, htrd.base_is_seller, htrd.price_n, htrd.price_d FROM history_trades htrd JOIN history_accounts base_accounts ON base_account_id = base_accounts.id JOIN history_accounts counter_accounts ON counter_account_id = counter_accounts.id JOIN history_assets base_assets ON base_asset_id = base_assets.id JOIN history_assets counter_assets ON counter_asset_id = counter_assets.id WHERE (
horizon(> htrd.history_operation_id > 91887728626503681
horizon(> OR (
horizon(> htrd.history_operation_id = 91887728626503681
horizon(> AND htrd.order > 2
horizon(> )) ORDER BY htrd.history_operation_id asc, htrd.order asc LIMIT 10;
                                                                                         QUERY PLAN                                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1.86..360.55 rows=10 width=349) (actual time=3817.761..3817.991 rows=10 loops=1)
   ->  Nested Loop  (cost=1.86..356071.44 rows=9927 width=349) (actual time=3817.760..3817.981 rows=10 loops=1)
         ->  Nested Loop  (cost=1.58..352659.26 rows=9927 width=278) (actual time=3817.752..3817.929 rows=10 loops=1)
               ->  Nested Loop  (cost=1.29..349247.07 rows=9927 width=207) (actual time=3817.741..3817.871 rows=10 loops=1)
                     ->  Nested Loop  (cost=0.86..330512.47 rows=9927 width=158) (actual time=3817.731..3817.807 rows=10 loops=1)
                           ->  Index Scan using htrd_pid on history_trades htrd  (cost=0.43..311777.86 rows=9927 width=109) (actual time=3817.715..3817.724 rows=10 loops=1)
                                 Filter: ((history_operation_id > '91887728626503681'::bigint) OR ((history_operation_id = '91887728626503681'::bigint) AND ("order" > 2)))
                                 Rows Removed by Filter: 7179118
                           ->  Index Scan using index_history_accounts_on_id on history_accounts base_accounts  (cost=0.43..1.88 rows=1 width=65) (actual time=0.006..0.006 rows=1 loops=10)
                                 Index Cond: (id = htrd.base_account_id)
                     ->  Index Scan using index_history_accounts_on_id on history_accounts counter_accounts  (cost=0.43..1.88 rows=1 width=65) (actual time=0.004..0.005 rows=1 loops=10)
                           Index Cond: (id = htrd.counter_account_id)
               ->  Index Scan using history_assets_pkey on history_assets base_assets  (cost=0.29..0.33 rows=1 width=83) (actual time=0.003..0.003 rows=1 loops=10)
                     Index Cond: (id = htrd.base_asset_id)
         ->  Index Scan using history_assets_pkey on history_assets counter_assets  (cost=0.29..0.33 rows=1 width=83) (actual time=0.003..0.003 rows=1 loops=10)
               Index Cond: (id = htrd.counter_asset_id)
 Planning time: 1.555 ms
 Execution time: 3818.085 ms
```
New query:
```
horizon=> EXPLAIN ANALYZE SELECT history_operation_id, htrd."order", htrd.ledger_closed_at, htrd.offer_id, htrd.base_offer_id, base_accounts.address as base_account, base_assets.asset_type as base_asset_type, base_assets.asset_code as base_asset_code, base_assets.asset_issuer as base_asset_issuer, htrd.base_amount, htrd.counter_offer_id, counter_accounts.address as counter_account, counter_assets.asset_type as counter_asset_type, counter_assets.asset_code as counter_asset_code, counter_assets.asset_issuer as counter_asset_issuer, htrd.counter_amount, htrd.base_is_seller, htrd.price_n, htrd.price_d FROM history_trades htrd JOIN history_accounts base_accounts ON base_account_id = base_accounts.id JOIN history_accounts counter_accounts ON counter_account_id = counter_accounts.id JOIN history_assets base_assets ON base_asset_id = base_assets.id JOIN history_assets counter_assets ON counter_asset_id = counter_assets.id WHERE (
horizon(> htrd.history_operation_id >= 91887728626503681
horizon(> AND (
horizon(> htrd.history_operation_id > 91887728626503681 OR (htrd.history_operation_id = 91887728626503681 AND htrd.order > 2)
horizon(> )) ORDER BY htrd.history_operation_id asc, htrd.order asc LIMIT 10;
                                                                                         QUERY PLAN                                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1.86..3344.32 rows=10 width=349) (actual time=0.054..0.277 rows=10 loops=1)
   ->  Nested Loop  (cost=1.86..4681.30 rows=14 width=349) (actual time=0.052..0.269 rows=10 loops=1)
         ->  Nested Loop  (cost=1.58..4650.92 rows=14 width=278) (actual time=0.048..0.210 rows=10 loops=1)
               ->  Nested Loop  (cost=1.29..4620.55 rows=14 width=207) (actual time=0.040..0.162 rows=10 loops=1)
                     ->  Nested Loop  (cost=0.86..4586.14 rows=14 width=158) (actual time=0.033..0.105 rows=10 loops=1)
                           ->  Index Scan using htrd_pid on history_trades htrd  (cost=0.43..4551.74 rows=14 width=109) (actual time=0.023..0.035 rows=10 loops=1)
                                 Index Cond: (history_operation_id >= '91887728626503681'::bigint)
                                 Filter: ((history_operation_id > '91887728626503681'::bigint) OR ((history_operation_id = '91887728626503681'::bigint) AND ("order" > 2)))
                                 Rows Removed by Filter: 3
                           ->  Index Scan using index_history_accounts_on_id on history_accounts base_accounts  (cost=0.43..2.45 rows=1 width=65) (actual time=0.005..0.005 rows=1 loops=10)
                                 Index Cond: (id = htrd.base_account_id)
                     ->  Index Scan using index_history_accounts_on_id on history_accounts counter_accounts  (cost=0.43..2.45 rows=1 width=65) (actual time=0.004..0.004 rows=1 loops=10)
                           Index Cond: (id = htrd.counter_account_id)
               ->  Index Scan using history_assets_pkey on history_assets base_assets  (cost=0.29..2.16 rows=1 width=83) (actual time=0.002..0.003 rows=1 loops=10)
                     Index Cond: (id = htrd.base_asset_id)
         ->  Index Scan using history_assets_pkey on history_assets counter_assets  (cost=0.29..2.16 rows=1 width=83) (actual time=0.004..0.004 rows=1 loops=10)
               Index Cond: (id = htrd.counter_asset_id)
 Planning time: 0.979 ms
 Execution time: 0.375 ms
```