### PR TITLE
Fix query checking

### DIFF
--- a/services/horizon/internal/actions/helpers_test.go
+++ b/services/horizon/internal/actions/helpers_test.go
@@ -279,7 +279,7 @@ func TestGetPageQuery(t *testing.T) {
 	// happy path
 	pq := action.GetPageQuery()
 	tt.Assert.NoError(action.Err)
-	tt.Assert.Equal("hello", pq.Cursor)
+	tt.Assert.Equal("123456", pq.Cursor)
 	tt.Assert.Equal(uint64(2), pq.Limit)
 	tt.Assert.Equal("asc", pq.Order)
 
@@ -302,7 +302,7 @@ func TestGetString(t *testing.T) {
 	defer tt.Finish()
 	action := makeTestAction()
 
-	tt.Assert.Equal("hello", action.GetString("cursor"))
+	tt.Assert.Equal("123456", action.GetString("cursor"))
 	action.R.Form = url.Values{
 		"cursor": {"goodbye"},
 	}
@@ -338,7 +338,7 @@ func TestGetURLParam(t *testing.T) {
 }
 
 func makeTestAction() *Base {
-	return makeAction("/foo-bar/blah?limit=2&cursor=hello", testURLParams())
+	return makeAction("/foo-bar/blah?limit=2&cursor=123456", testURLParams())
 }
 
 func makeAction(path string, body map[string]string) *Base {

--- a/services/horizon/internal/actions_assets.go
+++ b/services/horizon/internal/actions_assets.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/assets"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
@@ -52,7 +53,7 @@ func (action *AssetsAction) loadParams() {
 		}
 		action.AssetIssuer = issuerAccount.Address()
 	}
-	action.PagingParams = action.GetPageQuery()
+	action.PagingParams = action.GetPageQuery(actions.DisableCursorValidation)
 }
 
 func (action *AssetsAction) loadRecords() {

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -1,15 +1,15 @@
 package horizon
 
 import (
-	"errors"
-	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"strconv"
 	gTime "time"
 
 	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"
 	"github.com/stellar/go/support/time"
 	"github.com/stellar/go/xdr"

--- a/services/horizon/internal/db2/core/offer_test.go
+++ b/services/horizon/internal/db2/core/offer_test.go
@@ -16,7 +16,7 @@ func TestOffersByAddress(t *testing.T) {
 
 	load := func(addy, cursor, order string, limit uint64) bool {
 		offers = []Offer{}
-		pq, err := db2.NewPageQuery(cursor, order, limit)
+		pq, err := db2.NewPageQuery(cursor, true, order, limit)
 		if !tt.Assert.NoError(err) {
 			return false
 		}

--- a/services/horizon/internal/db2/history/trade_test.go
+++ b/services/horizon/internal/db2/history/trade_test.go
@@ -16,13 +16,13 @@ func TestTradeQueries(t *testing.T) {
 	var trades []Trade
 
 	// All trades
-	err := q.Trades().Page(db2.MustPageQuery("", "asc", 100)).Select(&trades)
+	err := q.Trades().Page(db2.MustPageQuery("", false, "asc", 100)).Select(&trades)
 	if tt.Assert.NoError(err) {
 		tt.Assert.Len(trades, 4)
 	}
 
 	// Paging
-	pq := db2.MustPageQuery(trades[0].PagingToken(), "asc", 1)
+	pq := db2.MustPageQuery(trades[0].PagingToken(), false, "asc", 1)
 	var pt []Trade
 
 	err = q.Trades().Page(pq).Select(&pt)
@@ -33,7 +33,7 @@ func TestTradeQueries(t *testing.T) {
 	}
 
 	// Cursor bounds checking
-	pq = db2.MustPageQuery("", "desc", 1)
+	pq = db2.MustPageQuery("", false, "desc", 1)
 	err = q.Trades().Page(pq).Select(&pt)
 	tt.Require.NoError(err)
 

--- a/services/horizon/internal/db2/page_query.go
+++ b/services/horizon/internal/db2/page_query.go
@@ -216,6 +216,7 @@ func (p PageQuery) CursorInt64Pair(sep string) (l int64, r int64, err error) {
 // cursor are set to the appropriate defaults and are valid.
 func NewPageQuery(
 	cursor string,
+	validateCursor bool,
 	order string,
 	limit uint64,
 ) (result PageQuery, err error) {
@@ -233,10 +234,12 @@ func NewPageQuery(
 
 	// Set cursor
 	result.Cursor = cursor
-	_, _, err = result.CursorInt64Pair(DefaultPairSep)
-	if err != nil {
-		err = ErrInvalidCursor
-		return
+	if validateCursor {
+		_, _, err = result.CursorInt64Pair(DefaultPairSep)
+		if err != nil {
+			err = ErrInvalidCursor
+			return
+		}
 	}
 
 	// Set limit
@@ -255,8 +258,8 @@ func NewPageQuery(
 }
 
 // MustPageQuery behaves as NewPageQuery, but panics upon error
-func MustPageQuery(cursor string, order string, limit uint64) PageQuery {
-	r, err := NewPageQuery(cursor, order, limit)
+func MustPageQuery(cursor string, validateCursor bool, order string, limit uint64) PageQuery {
+	r, err := NewPageQuery(cursor, validateCursor, order, limit)
 	if err != nil {
 		panic(err)
 	}

--- a/services/horizon/internal/db2/page_query_test.go
+++ b/services/horizon/internal/db2/page_query_test.go
@@ -15,36 +15,36 @@ func TestPageQuery(t *testing.T) {
 	var p PageQuery
 	var err error
 
-	p, err = NewPageQuery("10", "desc", 15)
+	p, err = NewPageQuery("10", true, "desc", 15)
 	require.NoError(err)
 	assert.Equal("10", p.Cursor)
 	assert.Equal("desc", p.Order)
 	assert.Equal(uint64(15), p.Limit)
 
 	// Defaults
-	p, err = NewPageQuery("", "", 1)
+	p, err = NewPageQuery("", true, "", 1)
 	require.NoError(err)
 	assert.Equal("asc", p.Order)
 	c, err := p.CursorInt64()
 	require.NoError(err)
 	assert.Equal(int64(0), c)
 	assert.Equal(uint64(1), p.Limit)
-	p, err = NewPageQuery("", "desc", 1)
+	p, err = NewPageQuery("", true, "desc", 1)
 	require.NoError(err)
 	c, err = p.CursorInt64()
 	require.NoError(err)
 	assert.Equal(int64(9223372036854775807), c)
 
 	// Max
-	p, err = NewPageQuery("", "", 200)
+	p, err = NewPageQuery("", true, "", 200)
 	require.NoError(err)
 
 	// Error states
-	_, err = NewPageQuery("", "foo", 1)
+	_, err = NewPageQuery("", true, "foo", 1)
 	assert.Error(err)
-	_, err = NewPageQuery("", "", 0)
+	_, err = NewPageQuery("", true, "", 0)
 	assert.Error(err)
-	_, err = NewPageQuery("", "", 201)
+	_, err = NewPageQuery("", true, "", 201)
 	assert.Error(err)
 
 }
@@ -56,44 +56,44 @@ func TestPageQuery_CursorInt64(t *testing.T) {
 	var p PageQuery
 	var err error
 
-	p = MustPageQuery("1231-4456", "asc", 1)
+	p = MustPageQuery("1231-4456", false, "asc", 1)
 	l, r, err := p.CursorInt64Pair("-")
 	require.NoError(err)
 	assert.Equal(int64(1231), l)
 	assert.Equal(int64(4456), r)
 
 	// Defaults
-	p = MustPageQuery("", "asc", 1)
+	p = MustPageQuery("", false, "asc", 1)
 	l, r, err = p.CursorInt64Pair("-")
 	require.NoError(err)
 	assert.Equal(int64(0), l)
 	assert.Equal(int64(0), r)
-	p = MustPageQuery("", "desc", 1)
+	p = MustPageQuery("", false, "desc", 1)
 	l, r, err = p.CursorInt64Pair("-")
 	require.NoError(err)
 	assert.Equal(int64(math.MaxInt64), l)
 	assert.Equal(int64(math.MaxInt64), r)
-	p = MustPageQuery("0", "", 1)
+	p = MustPageQuery("0", false, "", 1)
 	_, r, err = p.CursorInt64Pair("-")
 	require.NoError(err)
 	assert.Equal(int64(math.MaxInt64), r)
 
 	// Errors
-	p = MustPageQuery("123-foo", "", 1)
+	p = MustPageQuery("123-foo", false, "", 1)
 	_, _, err = p.CursorInt64Pair("-")
 	assert.Error(err)
-	p = MustPageQuery("foo-123", "", 1)
+	p = MustPageQuery("foo-123", false, "", 1)
 	_, _, err = p.CursorInt64Pair("-")
 	assert.Error(err)
-	p = MustPageQuery("-1:123", "", 1)
+	p = MustPageQuery("-1:123", false, "", 1)
 	_, _, err = p.CursorInt64Pair("-")
 	assert.Error(err)
-	p = MustPageQuery("111:-123", "", 1)
+	p = MustPageQuery("111:-123", false, "", 1)
 	_, _, err = p.CursorInt64Pair("-")
 	assert.Error(err)
 
 	// Regression: -23667108046966785
-	p = MustPageQuery("-23667108046966785", "asc", 100)
+	p = MustPageQuery("-23667108046966785", false, "asc", 100)
 	_, err = p.CursorInt64()
 	assert.Error(err)
 }

--- a/services/horizon/internal/ingest/session_test.go
+++ b/services/horizon/internal/ingest/session_test.go
@@ -51,7 +51,7 @@ func Test_ingestOperationEffects(t *testing.T) {
 	tt.ScenarioWithoutHorizon("kahuna")
 	s = ingest(tt, false)
 	tt.Require.NoError(s.Err)
-	pq, err := db2.NewPageQuery("", "asc", 200)
+	pq, err := db2.NewPageQuery("", true, "asc", 200)
 	tt.Require.NoError(err)
 
 	// ensure payments get the payment effects


### PR DESCRIPTION
Fixed multiple issues in query checking code:
* Invalid `cursor` no longer generate `ERROR` level logs.
* Internal errors (like `strconv.ParseInt`, `amount.Parse` errors) are
no longer sent with an error response.