### PR TITLE
Validate UTF-8 strings in params

### DIFF
--- a/services/horizon/internal/actions_account.go
+++ b/services/horizon/internal/actions_account.go
@@ -2,6 +2,7 @@ package horizon
 
 import (
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
@@ -52,7 +53,7 @@ func (action *AccountShowAction) SSE(stream sse.Stream) {
 }
 
 func (action *AccountShowAction) loadParams() {
-	action.Address = action.GetAddress("account_id")
+	action.Address = action.GetAddress("account_id", actions.RequiredParam)
 }
 
 func (action *AccountShowAction) loadRecord() {

--- a/services/horizon/internal/actions_data.go
+++ b/services/horizon/internal/actions_data.go
@@ -1,6 +1,7 @@
 package horizon
 
 import (
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/support/render/hal"
@@ -57,7 +58,7 @@ func (action *DataShowAction) SSE(stream sse.Stream) {
 }
 
 func (action *DataShowAction) loadParams() {
-	action.Address = action.GetAddress("account_id")
+	action.Address = action.GetAddress("account_id", actions.RequiredParam)
 	action.Key = action.GetString("key")
 }
 

--- a/services/horizon/internal/actions_data.go
+++ b/services/horizon/internal/actions_data.go
@@ -57,7 +57,7 @@ func (action *DataShowAction) SSE(stream sse.Stream) {
 }
 
 func (action *DataShowAction) loadParams() {
-	action.Address = action.GetString("account_id")
+	action.Address = action.GetAddress("account_id")
 	action.Key = action.GetString("key")
 }
 

--- a/services/horizon/internal/actions_effects.go
+++ b/services/horizon/internal/actions_effects.go
@@ -99,7 +99,7 @@ func (action *EffectIndexAction) loadLedgers() {
 func (action *EffectIndexAction) loadParams() {
 	action.ValidateCursor()
 	action.PagingParams = action.GetPageQuery()
-	action.AccountFilter = action.GetString("account_id")
+	action.AccountFilter = action.GetAddress("account_id")
 	action.LedgerFilter = action.GetInt32("ledger_id")
 	action.TransactionFilter = action.GetString("tx_id")
 	action.OperationFilter = action.GetInt64("op_id")

--- a/services/horizon/internal/actions_offer.go
+++ b/services/horizon/internal/actions_offer.go
@@ -61,7 +61,7 @@ func (action *OffersByAccountAction) SSE(stream sse.Stream) {
 
 func (action *OffersByAccountAction) loadParams() {
 	action.PageQuery = action.GetPageQuery()
-	action.Address = action.GetString("account_id")
+	action.Address = action.GetAddress("account_id")
 }
 
 // loadLedgers populates the ledger cache for this action

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -87,7 +87,7 @@ func (action *OperationIndexAction) SSE(stream sse.Stream) {
 
 func (action *OperationIndexAction) loadParams() {
 	action.ValidateCursorAsDefault()
-	action.AccountFilter = action.GetString("account_id")
+	action.AccountFilter = action.GetAddress("account_id")
 	action.LedgerFilter = action.GetInt32("ledger_id")
 	action.TransactionFilter = action.GetString("tx_id")
 	action.PagingParams = action.GetPageQuery()

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -104,7 +104,7 @@ func TestOperationActions_Regressions(t *testing.T) {
 
 	// ensure that trying to stream ops from an account that doesn't exist
 	// fails before streaming the hello message.  Regression test for #285
-	w := ht.Get("/accounts/foo/operations?limit=1", test.RequestHelperStreaming)
+	w := ht.Get("/accounts/GAS2FZOQRFVHIDY35TUSBWFGCROPLWPZVFRN5JZEOUUVRGDRZGHPBLYZ/operations?limit=1", test.RequestHelperStreaming)
 	if ht.Assert.Equal(404, w.Code) {
 		ht.Assert.ProblemType(w.Body, "not_found")
 	}

--- a/services/horizon/internal/actions_path.go
+++ b/services/horizon/internal/actions_path.go
@@ -2,6 +2,7 @@ package horizon
 
 import (
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/paths"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 	"github.com/stellar/go/support/render/hal"
@@ -30,7 +31,7 @@ func (action *PathIndexAction) JSON() {
 
 func (action *PathIndexAction) loadQuery() {
 	action.Query.DestinationAmount = action.GetPositiveAmount("destination_amount")
-	action.Query.DestinationAddress = action.GetAddress("destination_account")
+	action.Query.DestinationAddress = action.GetAddress("destination_account", actions.RequiredParam)
 	action.Query.DestinationAsset = action.GetAsset("destination_")
 }
 

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -78,7 +78,7 @@ func (action *PaymentsIndexAction) SSE(stream sse.Stream) {
 
 func (action *PaymentsIndexAction) loadParams() {
 	action.ValidateCursorAsDefault()
-	action.AccountFilter = action.GetString("account_id")
+	action.AccountFilter = action.GetAddress("account_id")
 	action.LedgerFilter = action.GetInt32("ledger_id")
 	action.TransactionFilter = action.GetString("tx_id")
 	action.PagingParams = action.GetPageQuery()

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -77,7 +77,7 @@ func (action *TradeIndexAction) loadParams() {
 	action.BaseAssetFilter, action.HasBaseAssetFilter = action.MaybeGetAsset("base_")
 	action.CounterAssetFilter, action.HasCounterAssetFilter = action.MaybeGetAsset("counter_")
 	action.OfferFilter = action.GetInt64("offer_id")
-	action.AccountFilter = action.GetString("account_id")
+	action.AccountFilter = action.GetAddress("account_id")
 
 	if (!action.HasBaseAssetFilter && action.HasCounterAssetFilter) ||
 		(action.HasBaseAssetFilter && !action.HasCounterAssetFilter) {

--- a/services/horizon/internal/actions_transaction.go
+++ b/services/horizon/internal/actions_transaction.go
@@ -3,15 +3,15 @@ package horizon
 import (
 	"net/http"
 
+	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
-	"github.com/stellar/go/services/horizon/internal/txsub"
-	"github.com/stellar/go/support/render/problem"
-	"github.com/stellar/go/protocols/horizon"
-	"github.com/stellar/go/support/render/hal"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
+	"github.com/stellar/go/services/horizon/internal/resourceadapter"
+	"github.com/stellar/go/services/horizon/internal/txsub"
+	"github.com/stellar/go/support/render/hal"
+	"github.com/stellar/go/support/render/problem"
 )
 
 // This file contains the actions:
@@ -68,7 +68,7 @@ func (action *TransactionIndexAction) SSE(stream sse.Stream) {
 
 func (action *TransactionIndexAction) loadParams() {
 	action.ValidateCursorAsDefault()
-	action.AccountFilter = action.GetString("account_id")
+	action.AccountFilter = action.GetAddress("account_id")
 	action.LedgerFilter = action.GetInt32("ledger_id")
 	action.PagingParams = action.GetPageQuery()
 }


### PR DESCRIPTION
Invalid UTF-8 byte sequence passed to Postgres triggers errors like:
```
invalid byte sequence for encoding "UTF8"
```