### PR TITLE
Fix graceful shutdown

### DIFF
--- a/services/horizon/internal/action.go
+++ b/services/horizon/internal/action.go
@@ -54,7 +54,7 @@ func (action *Action) HistoryQ() *history.Q {
 func (action *Action) Prepare(w http.ResponseWriter, r *http.Request) {
 	base := &action.Base
 	action.App = AppFromContext(r.Context())
-	base.Prepare(w, r, action.App.config.SSEUpdateFrequency)
+	base.Prepare(w, r, action.App.ctx, action.App.config.SSEUpdateFrequency)
 	if action.R.Context() != nil {
 		action.Log = log.Ctx(action.R.Context())
 	} else {

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -110,6 +110,9 @@ func (a *App) Serve() {
 		log.Panic(err)
 	}
 
+	a.historyQ.Session.DB.Close()
+	a.coreQ.Session.DB.Close()
+
 	log.Info("stopped")
 }
 
@@ -117,9 +120,6 @@ func (a *App) Serve() {
 func (a *App) Close() {
 	a.cancel()
 	a.ticks.Stop()
-
-	a.historyQ.Session.DB.Close()
-	a.coreQ.Session.DB.Close()
 }
 
 // HistoryQ returns a helper object for performing sql queries against the

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -110,16 +110,21 @@ func (a *App) Serve() {
 		log.Panic(err)
 	}
 
-	a.historyQ.Session.DB.Close()
-	a.coreQ.Session.DB.Close()
+	a.CloseDB()
 
 	log.Info("stopped")
 }
 
-// Close cancels the app and forces the closure of db connections
+// Close cancels the app. It does not close DB connections - use App.CloseDB().
 func (a *App) Close() {
 	a.cancel()
 	a.ticks.Stop()
+}
+
+// CloseDB closes DB connections.
+func (a *App) CloseDB() {
+	a.historyQ.Session.DB.Close()
+	a.coreQ.Session.DB.Close()
 }
 
 // HistoryQ returns a helper object for performing sql queries against the

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -121,7 +121,9 @@ func (a *App) Close() {
 	a.ticks.Stop()
 }
 
-// CloseDB closes DB connections.
+// CloseDB closes DB connections. When using during web server shut down make
+// sure all requests are first properly finished to avoid "sql: database is
+// closed" errors.
 func (a *App) CloseDB() {
 	a.historyQ.Session.DB.Close()
 	a.coreQ.Session.DB.Close()


### PR DESCRIPTION
This commit fixes two issues connected to graceful shutdown in Horizon. First, application context was not correctly handled in actions. Because of this, streaming connections were not closed gracefully.

Streaming body during shutdown before the change:

```
retry: 1000
event: open
data: "hello"

curl: (18) transfer closed with outstanding read data remaining
```

Streaming body during shutdown after the change:

```
retry: 1000
event: open
data: "hello"

retry: 10
event: close
data: "byebye"
```

Second, DB connections were closed before requests handling was finished. This caused generation of `ERROR`-level log entries like `sql: database is closed` during shutdown. This commit runs the code that closes DB connections after the requests are properly closed.

Close #777.