### PR TITLE
fix wrong effect of a circular path payment

### DIFF
--- a/services/horizon/internal/db2/history/effect.go
+++ b/services/horizon/internal/db2/history/effect.go
@@ -18,12 +18,7 @@ func (r *Effect) UnmarshalDetails(dest interface{}) error {
 		return nil
 	}
 
-	err := json.Unmarshal([]byte(r.DetailsString.String), &dest)
-	if err != nil {
-		err = errors.Wrap(err, "unmarshal failed")
-	}
-
-	return err
+	return errors.Wrap(json.Unmarshal([]byte(r.DetailsString.String), &dest), "unmarshal effect details failed")
 }
 
 // ID returns a lexically ordered id for this effect record

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -25,7 +25,7 @@ const (
 	// Scripts, that have yet to be ported to this codebase can then be leveraged
 	// to re-ingest old data with the new algorithm, providing a seamless
 	// transition when the ingested data's structure changes.
-	CurrentVersion = 14
+	CurrentVersion = 15
 )
 
 // Address is a type of a param provided to BatchInsertBuilder that gets exchanged

--- a/services/horizon/internal/ingest/session.go
+++ b/services/horizon/internal/ingest/session.go
@@ -185,17 +185,18 @@ func (is *Session) ingestEffects() {
 
 	case xdr.OperationTypePathPayment:
 		op := opbody.MustPathPaymentOp()
-		result := is.Cursor.OperationResult().MustPathPaymentResult().MustSuccess()
+		resultSuccess := is.Cursor.OperationResult().MustPathPaymentResult().MustSuccess()
 
 		dets := map[string]interface{}{"amount": amount.String(op.DestAmount)}
 		is.assetDetails(dets, op.DestAsset, "")
 		effects.Add(op.Destination, history.EffectAccountCredited, dets)
 
-		dets = map[string]interface{}{"amount": amount.String(result.Last.Amount)}
+		result := is.Cursor.OperationResult().MustPathPaymentResult()
+		dets = map[string]interface{}{"amount": amount.String(result.SendAmount())}
 		is.assetDetails(dets, op.SendAsset, "")
 		effects.Add(source, history.EffectAccountDebited, dets)
 
-		is.ingestTradeEffects(effects, source, result.Offers)
+		is.ingestTradeEffects(effects, source, resultSuccess.Offers)
 	case xdr.OperationTypeManageOffer:
 		result := is.Cursor.OperationResult().MustManageOfferResult().MustSuccess()
 		is.ingestTradeEffects(effects, source, result.OffersClaimed)

--- a/services/horizon/internal/ingest/session_test.go
+++ b/services/horizon/internal/ingest/session_test.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"testing"
 
+	protocolEffects "github.com/stellar/go/protocols/horizon/effects"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/test"
@@ -74,16 +75,13 @@ func Test_ingestOperationEffects(t *testing.T) {
 		tt.Assert.Equal(history.EffectTrade, effects[3].Type)
 	}
 
-	var details struct {
-		Amount float64 `json:"amount,string"`
-	}
-	err = effects[1].UnmarshalDetails(&details)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if details.Amount != 100 {
-		t.Errorf("got: %v, want: 100, details: %s", details.Amount, effects[1].DetailsString.String)
-	}
+	err = q.Effects().ForOperation(81604382721).Page(pq).Select(&effects)
+	tt.Require.NoError(err)
+
+	var ad protocolEffects.AccountDebited
+	err = effects[1].UnmarshalDetails(&ad)
+	tt.Require.NoError(err)
+	tt.Assert.Equal("100.0000000", ad.Amount)
 }
 
 func Test_ingestBumpSeq(t *testing.T) {

--- a/services/horizon/internal/ingest/session_test.go
+++ b/services/horizon/internal/ingest/session_test.go
@@ -1,7 +1,6 @@
 package ingest
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stellar/go/services/horizon/internal/db2"
@@ -78,7 +77,7 @@ func Test_ingestOperationEffects(t *testing.T) {
 	var details struct {
 		Amount float64 `json:"amount,string"`
 	}
-	err = json.Unmarshal([]byte(effects[1].DetailsString.String), &details)
+	err = effects[1].UnmarshalDetails(&details)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/services/horizon/internal/ingest/session_test.go
+++ b/services/horizon/internal/ingest/session_test.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stellar/go/services/horizon/internal/db2"
@@ -74,6 +75,16 @@ func Test_ingestOperationEffects(t *testing.T) {
 		tt.Assert.Equal(history.EffectTrade, effects[3].Type)
 	}
 
+	var details struct {
+		Amount float64 `json:"amount,string"`
+	}
+	err = json.Unmarshal([]byte(effects[1].DetailsString.String), &details)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if details.Amount != 100 {
+		t.Errorf("got: %v, want: 100, details: %s", details.Amount, effects[1].DetailsString.String)
+	}
 }
 
 func Test_ingestBumpSeq(t *testing.T) {


### PR DESCRIPTION
`account_debited` should indicate the `source_amount` instead.

Close #744