### PR TITLE
Require migration to run Horizon version successfully (fixes #778)

### DIFF
--- a/services/horizon/internal/db2/schema/main.go
+++ b/services/horizon/internal/db2/schema/main.go
@@ -93,7 +93,7 @@ func GetMigrationsUp(dbUrl string) (migrationIds []string) {
 	return migrationIds
 }
 
-// GetMigrationsDown returns the number of migrations to apply in the
+// GetNumMigrationsDown returns the number of migrations to apply in the
 // "down" direction to return to the older schema version expected by this
 // version of Horizon. To keep the code simple, it does not provide a list of
 // migration names.

--- a/services/horizon/internal/db2/schema/main.go
+++ b/services/horizon/internal/db2/schema/main.go
@@ -70,18 +70,9 @@ func Migrate(db *sql.DB, dir MigrateDir, count int) (int, error) {
 	}
 }
 
-// GetMigrations, finds the names of any migrations needed in the "up" or "down" directions.
-// The differencing step is necessary to handle the "down" case correctly.
-func GetMigrations(dbUrl, dirStr string) (result []string) {
-	// Migrations can be either to later schema versions (up) or earlier (down)
-	directions := map[string]migrate.MigrationDirection{
-		"up":   migrate.Up,
-		"down": migrate.Down,
-	}
-
-	if _, ok := directions[dirStr]; !ok {
-		stdLog.Fatalf(`Invalid migration direction "%v": must be "up" or "down"`, dirStr)
-	}
+// GetMigrationsUp returns a list of names of any migrations needed in the
+// "up" direction (more recent schema versions).
+func GetMigrationsUp(dbUrl string) (migrationNames []string) {
 
 	// Get a DB handle
 	db, dbErr := sql.Open("postgres", dbUrl)
@@ -89,17 +80,30 @@ func GetMigrations(dbUrl, dirStr string) (result []string) {
 		stdLog.Fatal(dbErr)
 	}
 
-	// Get the possible migrations in the given direction
-	dir := directions[dirStr]
-	possibleMigrations, _, migrateErr := migrate.PlanMigration(db, "postgres", Migrations, dir, 0)
+	// Get the possible migrations
+	possibleMigrations, _, migrateErr := migrate.PlanMigration(db, "postgres", Migrations, migrate.Up, 0)
 	if migrateErr != nil {
 		stdLog.Fatal(migrateErr)
 	}
 
 	// Extract a list of the possible migration names
-	var possibleIds []string
 	for _, m := range possibleMigrations {
-		possibleIds = append(possibleIds, m.Id)
+		migrationNames = append(migrationNames, m.Id)
+	}
+
+	return migrationNames
+}
+
+// GetMigrationsDown returns the number of migrations to apply in the
+// "down" direction  to return to the older schema version expected by this
+// version of Horizon. To keep the code simple, it does not provide a list of
+// migration names.
+func GetMigrationsDown(dbUrl string) (nMigrations int) {
+
+	// Get a DB handle
+	db, dbErr := sql.Open("postgres", dbUrl)
+	if dbErr != nil {
+		stdLog.Fatal(dbErr)
 	}
 
 	// Get the set of migrations recorded in the database
@@ -108,30 +112,12 @@ func GetMigrations(dbUrl, dirStr string) (result []string) {
 		stdLog.Fatal(recordErr)
 	}
 
-	// Extract a list of names of the previously applied migrations
-	var migrationRecordIds []string
-	for _, m := range migrationRecords {
-		migrationRecordIds = append(migrationRecordIds, (*m).Id)
+	// Get the list of migrations needed by this version of Horizon
+	allNeededMigrations, _, migrateErr := migrate.PlanMigration(db, "postgres", Migrations, migrate.Down, 0)
+	if migrateErr != nil {
+		stdLog.Fatal(migrateErr)
 	}
 
-	// Find any migrations that need to be applied in this direction
-	// migrationsToApply := difference(possibleIds, migrationRecordIds)
-	migrationsToApply := migrationRecordIds[len(possibleIds):]
-
-	return migrationsToApply
-}
-
-// Return the elements in a that aren't in b
-func difference(a, b []string) []string {
-	mb := map[string]bool{}
-	for _, x := range b {
-		mb[x] = true
-	}
-	ab := []string{}
-	for _, x := range a {
-		if _, ok := mb[x]; !ok {
-			ab = append(ab, x)
-		}
-	}
-	return ab
+	// Return the size difference between the two sets of migrations
+	return len(migrationRecords) - len(allNeededMigrations)
 }

--- a/services/horizon/internal/db2/schema/main.go
+++ b/services/horizon/internal/db2/schema/main.go
@@ -70,7 +70,8 @@ func Migrate(db *sql.DB, dir MigrateDir, count int) (int, error) {
 	}
 }
 
-// Return the direction of migration, and an array of any necessary migrations
+// Find the names of any migrations needed in the "up" or "down" directions
+// The differencing step is necessary to handle the "down" case correctly
 func GetMigrations(dbUrl, dirStr string) (result []string) {
 	// Migrations can be either to later schema versions (up) or earlier (down)
 	directions := map[string]migrate.MigrationDirection{
@@ -88,20 +89,16 @@ func GetMigrations(dbUrl, dirStr string) (result []string) {
 		stdLog.Fatal(dbErr)
 	}
 
-	dir := directions[dirStr]
 	// Get the possible migrations in the given direction
+	dir := directions[dirStr]
 	possibleMigrations, _, migrateErr := migrate.PlanMigration(db, "postgres", Migrations, dir, 0)
 	if migrateErr != nil {
 		stdLog.Fatal(migrateErr)
 	}
-	stdLog.Println("dirStr, dir", dirStr, dir)
-	stdLog.Println("len(result)", len(possibleMigrations))
 
 	// Extract a list of the possible migration names
 	var possibleIds []string
-	for i, m := range possibleMigrations {
-		stdLog.Println(i)
-		stdLog.Println("bbbbbb", (*m).Id)
+	for _, m := range possibleMigrations {
 		possibleIds = append(possibleIds, (*m).Id)
 	}
 
@@ -110,13 +107,10 @@ func GetMigrations(dbUrl, dirStr string) (result []string) {
 	if recordErr != nil {
 		stdLog.Fatal(recordErr)
 	}
-	stdLog.Println("len(records)", len(migrationRecords))
 
 	// Extract a list of names of the previously applied migrations
 	var migrationRecordIds []string
-	for i, m := range migrationRecords {
-		stdLog.Println(i)
-		stdLog.Println("mmmmm", (*m).Id)
+	for _, m := range migrationRecords {
 		migrationRecordIds = append(migrationRecordIds, (*m).Id)
 	}
 

--- a/services/horizon/internal/db2/schema/main.go
+++ b/services/horizon/internal/db2/schema/main.go
@@ -83,6 +83,23 @@ func GetMigrations(dbUrl string) (dirStr string, result []*migrate.PlannedMigrat
 	}
 	for dirStr, dir := range directions {
 		result, _, migrateErr := migrate.PlanMigration(db, "postgres", Migrations, dir, 0)
+		stdLog.Println("dirStr, dir", dirStr, dir)
+		stdLog.Println("len(result)", len(result))
+		for i, m := range result {
+			var a = *m
+			var b = a.Id
+			stdLog.Println(i)
+			stdLog.Println("bbbbbb", b)
+		}
+
+		records, err2 := migrate.GetMigrationRecords(db, "postgres")
+		stdLog.Println(err2)
+		stdLog.Println("len(records)", len(records))
+		for i, m := range records {
+			stdLog.Println(i)
+			stdLog.Println("mmmmm", *m)
+		}
+
 		if migrateErr != nil {
 			stdLog.Fatal(migrateErr)
 		}

--- a/services/horizon/internal/db2/schema/main.go
+++ b/services/horizon/internal/db2/schema/main.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"database/sql"
 	"errors"
+	stdLog "log"
 
 	migrate "github.com/rubenv/sql-migrate"
 	"github.com/stellar/go/support/db"
@@ -67,4 +68,28 @@ func Migrate(db *sql.DB, dir MigrateDir, count int) (int, error) {
 	default:
 		return 0, errors.New("Invalid migration direction")
 	}
+}
+
+// Return the direction of migration, and an array of any necessary migrations
+func GetMigrations(dbUrl string) (dirStr string, result []*migrate.PlannedMigration) {
+	db, err := sql.Open("postgres", dbUrl)
+	if err != nil {
+		stdLog.Fatal(err)
+	}
+
+	directions := map[string]migrate.MigrationDirection{
+		"up":   migrate.Up,
+		"down": migrate.Down,
+	}
+	for dirStr, dir := range directions {
+		result, _, migrateErr := migrate.PlanMigration(db, "postgres", Migrations, dir, 0)
+		if migrateErr != nil {
+			stdLog.Fatal(migrateErr)
+		}
+
+		if len(result) > 0 {
+			return dirStr, result
+		}
+	}
+	return "none", result
 }

--- a/services/horizon/internal/db2/schema/main.go
+++ b/services/horizon/internal/db2/schema/main.go
@@ -72,8 +72,7 @@ func Migrate(db *sql.DB, dir MigrateDir, count int) (int, error) {
 
 // GetMigrationsUp returns a list of names of any migrations needed in the
 // "up" direction (more recent schema versions).
-func GetMigrationsUp(dbUrl string) (migrationNames []string) {
-
+func GetMigrationsUp(dbUrl string) (migrationIds []string) {
 	// Get a DB handle
 	db, dbErr := sql.Open("postgres", dbUrl)
 	if dbErr != nil {
@@ -88,18 +87,17 @@ func GetMigrationsUp(dbUrl string) (migrationNames []string) {
 
 	// Extract a list of the possible migration names
 	for _, m := range possibleMigrations {
-		migrationNames = append(migrationNames, m.Id)
+		migrationIds = append(migrationIds, m.Id)
 	}
 
-	return migrationNames
+	return migrationIds
 }
 
 // GetMigrationsDown returns the number of migrations to apply in the
-// "down" direction  to return to the older schema version expected by this
+// "down" direction to return to the older schema version expected by this
 // version of Horizon. To keep the code simple, it does not provide a list of
 // migration names.
-func GetMigrationsDown(dbUrl string) (nMigrations int) {
-
+func GetNumMigrationsDown(dbUrl string) (nMigrations int) {
 	// Get a DB handle
 	db, dbErr := sql.Open("postgres", dbUrl)
 	if dbErr != nil {

--- a/services/horizon/internal/db2/schema/main.go
+++ b/services/horizon/internal/db2/schema/main.go
@@ -71,42 +71,72 @@ func Migrate(db *sql.DB, dir MigrateDir, count int) (int, error) {
 }
 
 // Return the direction of migration, and an array of any necessary migrations
-func GetMigrations(dbUrl string) (dirStr string, result []*migrate.PlannedMigration) {
-	db, err := sql.Open("postgres", dbUrl)
-	if err != nil {
-		stdLog.Fatal(err)
-	}
-
+func GetMigrations(dbUrl, dirStr string) (result []string) {
+	// Migrations can be either to later schema versions (up) or earlier (down)
 	directions := map[string]migrate.MigrationDirection{
 		"up":   migrate.Up,
 		"down": migrate.Down,
 	}
-	for dirStr, dir := range directions {
-		result, _, migrateErr := migrate.PlanMigration(db, "postgres", Migrations, dir, 0)
-		stdLog.Println("dirStr, dir", dirStr, dir)
-		stdLog.Println("len(result)", len(result))
-		for i, m := range result {
-			var a = *m
-			var b = a.Id
-			stdLog.Println(i)
-			stdLog.Println("bbbbbb", b)
-		}
 
-		records, err2 := migrate.GetMigrationRecords(db, "postgres")
-		stdLog.Println(err2)
-		stdLog.Println("len(records)", len(records))
-		for i, m := range records {
-			stdLog.Println(i)
-			stdLog.Println("mmmmm", *m)
-		}
+	if _, ok := directions[dirStr]; !ok {
+		stdLog.Fatalf("Invalid migration direction \"%v\": must be \"up\" or \"down\"", dirStr)
+	}
 
-		if migrateErr != nil {
-			stdLog.Fatal(migrateErr)
-		}
+	// Get a DB handle
+	db, dbErr := sql.Open("postgres", dbUrl)
+	if dbErr != nil {
+		stdLog.Fatal(dbErr)
+	}
 
-		if len(result) > 0 {
-			return dirStr, result
+	dir := directions[dirStr]
+	// Get the possible migrations in the given direction
+	possibleMigrations, _, migrateErr := migrate.PlanMigration(db, "postgres", Migrations, dir, 0)
+	if migrateErr != nil {
+		stdLog.Fatal(migrateErr)
+	}
+	stdLog.Println("dirStr, dir", dirStr, dir)
+	stdLog.Println("len(result)", len(possibleMigrations))
+
+	// Extract a list of the possible migration names
+	var possibleIds []string
+	for i, m := range possibleMigrations {
+		stdLog.Println(i)
+		stdLog.Println("bbbbbb", (*m).Id)
+		possibleIds = append(possibleIds, (*m).Id)
+	}
+
+	// Get the set of migrations recorded in the database
+	migrationRecords, recordErr := migrate.GetMigrationRecords(db, "postgres")
+	if recordErr != nil {
+		stdLog.Fatal(recordErr)
+	}
+	stdLog.Println("len(records)", len(migrationRecords))
+
+	// Extract a list of names of the previously applied migrations
+	var migrationRecordIds []string
+	for i, m := range migrationRecords {
+		stdLog.Println(i)
+		stdLog.Println("mmmmm", (*m).Id)
+		migrationRecordIds = append(migrationRecordIds, (*m).Id)
+	}
+
+	// Find any migrations that need to be applied in this direction
+	migrationsToApply := difference(possibleIds, migrationRecordIds)
+
+	return migrationsToApply
+}
+
+// Return the elements in a that aren't in b
+func difference(a, b []string) []string {
+	mb := map[string]bool{}
+	for _, x := range b {
+		mb[x] = true
+	}
+	ab := []string{}
+	for _, x := range a {
+		if _, ok := mb[x]; !ok {
+			ab = append(ab, x)
 		}
 	}
-	return "none", result
+	return ab
 }

--- a/services/horizon/internal/db2/schema/main.go
+++ b/services/horizon/internal/db2/schema/main.go
@@ -70,8 +70,8 @@ func Migrate(db *sql.DB, dir MigrateDir, count int) (int, error) {
 	}
 }
 
-// Find the names of any migrations needed in the "up" or "down" directions
-// The differencing step is necessary to handle the "down" case correctly
+// GetMigrations, finds the names of any migrations needed in the "up" or "down" directions.
+// The differencing step is necessary to handle the "down" case correctly.
 func GetMigrations(dbUrl, dirStr string) (result []string) {
 	// Migrations can be either to later schema versions (up) or earlier (down)
 	directions := map[string]migrate.MigrationDirection{
@@ -80,7 +80,7 @@ func GetMigrations(dbUrl, dirStr string) (result []string) {
 	}
 
 	if _, ok := directions[dirStr]; !ok {
-		stdLog.Fatalf("Invalid migration direction \"%v\": must be \"up\" or \"down\"", dirStr)
+		stdLog.Fatalf(`Invalid migration direction "%v": must be "up" or "down"`, dirStr)
 	}
 
 	// Get a DB handle
@@ -99,7 +99,7 @@ func GetMigrations(dbUrl, dirStr string) (result []string) {
 	// Extract a list of the possible migration names
 	var possibleIds []string
 	for _, m := range possibleMigrations {
-		possibleIds = append(possibleIds, (*m).Id)
+		possibleIds = append(possibleIds, m.Id)
 	}
 
 	// Get the set of migrations recorded in the database
@@ -115,7 +115,8 @@ func GetMigrations(dbUrl, dirStr string) (result []string) {
 	}
 
 	// Find any migrations that need to be applied in this direction
-	migrationsToApply := difference(possibleIds, migrationRecordIds)
+	// migrationsToApply := difference(possibleIds, migrationRecordIds)
+	migrationsToApply := migrationRecordIds[len(possibleIds):]
 
 	return migrationsToApply
 }

--- a/services/horizon/main.go
+++ b/services/horizon/main.go
@@ -241,10 +241,22 @@ func initConfig() {
 		stdLog.Fatal("Invalid config: stellar-core-url is blank.  Please specify --stellar-core-url on the command line or set the STELLAR_CORE_URL environment variable.")
 	}
 
-	migrationDir, migrations := schema.GetMigrations(viper.GetString("db-url"))
-	if len(migrations) > 0 {
-		stdLog.Fatalf("A database migration is required to run this version (%v) of Horizon. Run \"horizon db migrate %v\" to update your DB. Consult the Changelog (https://github.com/stellar/horizon/blob/master/CHANGELOG.md) for more information.", apkg.Version(), migrationDir)
+	migrationNeeded := false
+	for _, migrationDir := range []string{"up", "down"} {
+		migrationsToApply := schema.GetMigrations(viper.GetString("db-url"), migrationDir)
+		if len(migrationsToApply) > 0 {
+			migrationNeeded = true
+			stdLog.Printf("There are %v migrations to apply in the \"%v\" direction", len(migrationsToApply), migrationDir)
+			stdLog.Printf("The necessary migrations are:")
+			for _, migrationName := range migrationsToApply {
+				stdLog.Printf("    %v", migrationName)
+			}
+		}
 	}
+	if migrationNeeded {
+		stdLog.Fatalf("A database migration is required to run this version (%v) of Horizon. Run \"horizon db migrate DIRECTION\" to update your DB. Consult the Changelog (https://github.com/stellar/horizon/blob/master/CHANGELOG.md) for more information.", apkg.Version())
+	}
+
 	stdLog.Fatal("Bye bye")
 
 	ll, err := logrus.ParseLevel(viper.GetString("log-level"))

--- a/services/horizon/main.go
+++ b/services/horizon/main.go
@@ -241,21 +241,22 @@ func initConfig() {
 		stdLog.Fatal("Invalid config: stellar-core-url is blank.  Please specify --stellar-core-url on the command line or set the STELLAR_CORE_URL environment variable.")
 	}
 
-	for _, migrationDir := range []string{"up", "down"} {
-		migrationsToApply := schema.GetMigrations(viper.GetString("db-url"), migrationDir)
-		nMigrations := len(migrationsToApply)
-		if nMigrations > 0 {
-			stdLog.Printf("A database migration is required to run this version (%v) of Horizon. Run \"horizon db migrate DIRECTION\" to update your DB. Consult the Changelog (https://github.com/stellar/horizon/blob/master/CHANGELOG.md) for more information.", apkg.Version())
-			stdLog.Printf("There are %v migrations to apply in the \"%v\" direction", nMigrations, migrationDir)
-			stdLog.Printf("The necessary migrations are:")
-			for _, migrationName := range migrationsToApply {
-				stdLog.Printf("    %v", migrationName)
-			}
-			if migrationDir == "down" {
-				stdLog.Printf("In order to migrate the database down, using the HIGHEST version of Horizon you have installed, run \"horizon db migrate down %v\"", nMigrations)
-			}
-			os.Exit(1)
+	migrationsToApplyUp := schema.GetMigrationsUp(viper.GetString("db-url"))
+	if len(migrationsToApplyUp) > 0 {
+		stdLog.Printf("There are %v migrations to apply in the \"up\" direction.", len(migrationsToApplyUp))
+		stdLog.Printf("The necessary migrations are:")
+		for _, migrationName := range migrationsToApplyUp {
+			stdLog.Printf("    %v", migrationName)
 		}
+		stdLog.Printf("A database migration is required to run this version (%v) of Horizon. Run \"horizon db migrate up\" to update your DB. Consult the Changelog (https://github.com/stellar/horizon/blob/master/CHANGELOG.md) for more information.", apkg.Version())
+		os.Exit(1)
+	}
+
+	nMigrationsDown := schema.GetMigrationsDown(viper.GetString("db-url"))
+	if nMigrationsDown > 0 {
+		stdLog.Printf("A database migration DOWN to an earlier version of the schema is required to run this version (%v) of Horizon. Consult the Changelog (https://github.com/stellar/horizon/blob/master/CHANGELOG.md) for more information.", apkg.Version())
+		stdLog.Printf("In order to migrate the database DOWN, using the HIGHEST version number of Horizon you have installed (not this binary), run \"horizon db migrate down %v\".", nMigrationsDown)
+		os.Exit(1)
 	}
 
 	ll, err := logrus.ParseLevel(viper.GetString("log-level"))

--- a/services/horizon/main.go
+++ b/services/horizon/main.go
@@ -9,7 +9,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/stellar/go/services/horizon/internal"
+	horizon "github.com/stellar/go/services/horizon/internal"
+	"github.com/stellar/go/services/horizon/internal/db2/schema"
+	apkg "github.com/stellar/go/support/app"
 	"github.com/stellar/go/support/log"
 	"github.com/throttled/throttled"
 )
@@ -238,6 +240,12 @@ func initConfig() {
 	if viper.GetString("stellar-core-url") == "" {
 		stdLog.Fatal("Invalid config: stellar-core-url is blank.  Please specify --stellar-core-url on the command line or set the STELLAR_CORE_URL environment variable.")
 	}
+
+	migrationDir, migrations := schema.GetMigrations(viper.GetString("db-url"))
+	if len(migrations) > 0 {
+		stdLog.Fatalf("A database migration is required to run this version (%v) of Horizon. Run \"horizon db migrate %v\" to update your DB. Consult the Changelog (https://github.com/stellar/horizon/blob/master/CHANGELOG.md) for more information.", apkg.Version(), migrationDir)
+	}
+	stdLog.Fatal("Bye bye")
 
 	ll, err := logrus.ParseLevel(viper.GetString("log-level"))
 

--- a/services/horizon/main.go
+++ b/services/horizon/main.go
@@ -243,12 +243,16 @@ func initConfig() {
 
 	for _, migrationDir := range []string{"up", "down"} {
 		migrationsToApply := schema.GetMigrations(viper.GetString("db-url"), migrationDir)
-		if len(migrationsToApply) > 0 {
+		nMigrations := len(migrationsToApply)
+		if nMigrations > 0 {
 			stdLog.Printf("A database migration is required to run this version (%v) of Horizon. Run \"horizon db migrate DIRECTION\" to update your DB. Consult the Changelog (https://github.com/stellar/horizon/blob/master/CHANGELOG.md) for more information.", apkg.Version())
-			stdLog.Printf("There are %v migrations to apply in the \"%v\" direction", len(migrationsToApply), migrationDir)
+			stdLog.Printf("There are %v migrations to apply in the \"%v\" direction", nMigrations, migrationDir)
 			stdLog.Printf("The necessary migrations are:")
 			for _, migrationName := range migrationsToApply {
 				stdLog.Printf("    %v", migrationName)
+			}
+			if migrationDir == "down" {
+				stdLog.Printf("In order to migrate the database down, using the HIGHEST version of Horizon you have installed, run \"horizon db migrate down %v\"", nMigrations)
 			}
 			os.Exit(1)
 		}

--- a/services/horizon/main.go
+++ b/services/horizon/main.go
@@ -9,10 +9,10 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/stellar/go/network"
 	horizon "github.com/stellar/go/services/horizon/internal"
 	"github.com/stellar/go/services/horizon/internal/db2/schema"
 	apkg "github.com/stellar/go/support/app"
-	"github.com/stellar/go/network"
 	"github.com/stellar/go/support/log"
 	"github.com/throttled/throttled"
 )
@@ -242,9 +242,9 @@ func initConfig() {
 		stdLog.Fatal("Invalid config: stellar-core-url is blank.  Please specify --stellar-core-url on the command line or set the STELLAR_CORE_URL environment variable.")
 	}
 
-  if viper.GetString("network-passphrase") == "" {
+	if viper.GetString("network-passphrase") == "" {
 		stdLog.Fatal("Invalid config: network-passphrase is blank.  Please specify --network-passphrase on the command line or set the NETWORK_PASSPHRASE environment variable.")
-  }
+	}
 
 	migrationsToApplyUp := schema.GetMigrationsUp(viper.GetString("db-url"))
 	if len(migrationsToApplyUp) > 0 {

--- a/services/horizon/main.go
+++ b/services/horizon/main.go
@@ -241,23 +241,18 @@ func initConfig() {
 		stdLog.Fatal("Invalid config: stellar-core-url is blank.  Please specify --stellar-core-url on the command line or set the STELLAR_CORE_URL environment variable.")
 	}
 
-	migrationNeeded := false
 	for _, migrationDir := range []string{"up", "down"} {
 		migrationsToApply := schema.GetMigrations(viper.GetString("db-url"), migrationDir)
 		if len(migrationsToApply) > 0 {
-			migrationNeeded = true
+			stdLog.Printf("A database migration is required to run this version (%v) of Horizon. Run \"horizon db migrate DIRECTION\" to update your DB. Consult the Changelog (https://github.com/stellar/horizon/blob/master/CHANGELOG.md) for more information.", apkg.Version())
 			stdLog.Printf("There are %v migrations to apply in the \"%v\" direction", len(migrationsToApply), migrationDir)
 			stdLog.Printf("The necessary migrations are:")
 			for _, migrationName := range migrationsToApply {
 				stdLog.Printf("    %v", migrationName)
 			}
+			os.Exit(1)
 		}
 	}
-	if migrationNeeded {
-		stdLog.Fatalf("A database migration is required to run this version (%v) of Horizon. Run \"horizon db migrate DIRECTION\" to update your DB. Consult the Changelog (https://github.com/stellar/horizon/blob/master/CHANGELOG.md) for more information.", apkg.Version())
-	}
-
-	stdLog.Fatal("Bye bye")
 
 	ll, err := logrus.ParseLevel(viper.GetString("log-level"))
 

--- a/services/horizon/main.go
+++ b/services/horizon/main.go
@@ -243,16 +243,13 @@ func initConfig() {
 
 	migrationsToApplyUp := schema.GetMigrationsUp(viper.GetString("db-url"))
 	if len(migrationsToApplyUp) > 0 {
-		stdLog.Printf("There are %v migrations to apply in the \"up\" direction.", len(migrationsToApplyUp))
-		stdLog.Printf("The necessary migrations are:")
-		for _, migrationName := range migrationsToApplyUp {
-			stdLog.Printf("    %v", migrationName)
-		}
+		stdLog.Printf(`There are %v migrations to apply in the "up" direction.`, len(migrationsToApplyUp))
+		stdLog.Printf("The necessary migrations are: %v", migrationsToApplyUp)
 		stdLog.Printf("A database migration is required to run this version (%v) of Horizon. Run \"horizon db migrate up\" to update your DB. Consult the Changelog (https://github.com/stellar/horizon/blob/master/CHANGELOG.md) for more information.", apkg.Version())
 		os.Exit(1)
 	}
 
-	nMigrationsDown := schema.GetMigrationsDown(viper.GetString("db-url"))
+	nMigrationsDown := schema.GetNumMigrationsDown(viper.GetString("db-url"))
 	if nMigrationsDown > 0 {
 		stdLog.Printf("A database migration DOWN to an earlier version of the schema is required to run this version (%v) of Horizon. Consult the Changelog (https://github.com/stellar/horizon/blob/master/CHANGELOG.md) for more information.", apkg.Version())
 		stdLog.Printf("In order to migrate the database DOWN, using the HIGHEST version number of Horizon you have installed (not this binary), run \"horizon db migrate down %v\".", nMigrationsDown)


### PR DESCRIPTION
When a user runs a newer or older version of Horizon that is incompatible with the current DB state, Horizon should fail with a descriptive error message indicating the migration(s) that need to be performed, and their direction. This avoids the situation described in #778, where Horizon may run in a broken way without alerting the user.

We do not run the migration automatically, since the user should understand what is happening, and take responsibility for backing up their data if necessary.

Example command line output when a new migration is detected:

```
$horizon --db-url="postgres://localhost/horizon_schema" --stellar-core-db-url="postgres://stellar:postgres@localhost:8002/core" --stellar-core-url="http://localhost:11626" --port 8001 --network-passphrase "Test SDF Network ; September 2015" --ingest
2019/01/11 16:39:11 A database migration is required to run this version (devel) of Horizon. Run "horizon db migrate DIRECTION" to update your DB. Consult the Changelog (https://github.com/stellar/horizon/blob/master/CHANGELOG.md) for more information.
2019/01/11 16:39:11 There are 1 migrations to apply in the "up" direction
2019/01/11 16:39:11 The necessary migrations are:
2019/01/11 16:39:11     15_made_up_stuff.sql
```