### PR TITLE
horizon/actions: fix slice looping for offers in an account

### DIFF
--- a/services/horizon/internal/actions_offer.go
+++ b/services/horizon/internal/actions_offer.go
@@ -39,6 +39,8 @@ func (action *OffersByAccountAction) JSON() {
 
 // SSE is a method for actions.SSE
 func (action *OffersByAccountAction) SSE(stream sse.Stream) {
+	// Load the page query params the first time SSE() is called. We update
+	// the pagination cursor below before sending each event to the stream.
 	if action.PageQuery.Cursor == "" {
 		action.loadParams()
 		if action.Err != nil {

--- a/services/horizon/internal/actions_offer.go
+++ b/services/horizon/internal/actions_offer.go
@@ -53,6 +53,7 @@ func (action *OffersByAccountAction) SSE(stream sse.Stream) {
 				}
 				var res horizon.Offer
 				resourceadapter.PopulateOffer(action.R.Context(), &res, record, ledgerPtr)
+				action.PageQuery.Cursor = res.PagingToken()
 				stream.Send(sse.Event{ID: res.PagingToken(), Data: res})
 			}
 		},
@@ -60,7 +61,9 @@ func (action *OffersByAccountAction) SSE(stream sse.Stream) {
 }
 
 func (action *OffersByAccountAction) loadParams() {
-	action.PageQuery = action.GetPageQuery()
+	if action.PageQuery.Cursor == "" {
+		action.PageQuery = action.GetPageQuery()
+	}
 	action.Address = action.GetAddress("account_id")
 }
 

--- a/services/horizon/internal/actions_offer.go
+++ b/services/horizon/internal/actions_offer.go
@@ -45,7 +45,7 @@ func (action *OffersByAccountAction) SSE(stream sse.Stream) {
 		action.loadLedgers,
 		func() {
 			stream.SetLimit(int(action.PageQuery.Limit))
-			for _, record := range action.Records[stream.SentCount():] {
+			for _, record := range action.Records {
 				ledger, found := action.Ledgers.Records[record.Lastmodified]
 				ledgerPtr := &ledger
 				if !found {

--- a/services/horizon/internal/actions_offer.go
+++ b/services/horizon/internal/actions_offer.go
@@ -39,8 +39,14 @@ func (action *OffersByAccountAction) JSON() {
 
 // SSE is a method for actions.SSE
 func (action *OffersByAccountAction) SSE(stream sse.Stream) {
+	if action.PageQuery.Cursor == "" {
+		action.loadParams()
+		if action.Err != nil {
+			return
+		}
+	}
+
 	action.Do(
-		action.loadParams,
 		action.loadRecords,
 		action.loadLedgers,
 		func() {
@@ -61,9 +67,7 @@ func (action *OffersByAccountAction) SSE(stream sse.Stream) {
 }
 
 func (action *OffersByAccountAction) loadParams() {
-	if action.PageQuery.Cursor == "" {
-		action.PageQuery = action.GetPageQuery()
-	}
+	action.PageQuery = action.GetPageQuery()
 	action.Address = action.GetAddress("account_id")
 }
 

--- a/services/horizon/internal/actions_offer_test.go
+++ b/services/horizon/internal/actions_offer_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-chi/chi"
-	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/test"
 )
@@ -64,11 +62,7 @@ func TestOfferActions_SSE(t *testing.T) {
 
 	ctx := context.Background()
 	stream := sse.NewStream(ctx, httptest.NewRecorder())
-	oa := OffersByAccountAction{}
-	oa.App = NewTestApp()
-	oa.Base = actions.Base{
-		R: httptest.NewRequest("GET", "/foo/bar?account_id=GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2", nil).WithContext(context.WithValue(ctx, chi.RouteCtxKey, chi.NewRouteContext())),
-	}
+	oa := OffersByAccountAction{Action: *NewTestAction(ctx, "/foo/bar?account_id=GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2")}
 
 	oa.SSE(stream)
 	tt.Require.NoError(oa.Err)

--- a/services/horizon/internal/actions_offer_test.go
+++ b/services/horizon/internal/actions_offer_test.go
@@ -1,8 +1,15 @@
 package horizon
 
 import (
+	"context"
+	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/stellar/go/services/horizon/internal/actions"
+	"github.com/stellar/go/services/horizon/internal/render/sse"
+	"github.com/stellar/go/services/horizon/internal/test"
 )
 
 func TestOfferActions_Index(t *testing.T) {
@@ -49,4 +56,29 @@ func TestOfferActions_IndexNoLedgerData(t *testing.T) {
 		ht.Assert.NotEmpty(records[2]["last_modified_ledger"])
 		ht.Assert.Nil(records[2]["last_modified_time"])
 	}
+}
+
+func TestOfferActions_SSE(t *testing.T) {
+	tt := test.Start(t).Scenario("trades")
+	defer tt.Finish()
+
+	ctx := context.Background()
+	stream := sse.NewStream(ctx, httptest.NewRecorder())
+	oa := OffersByAccountAction{}
+	oa.App = NewTestApp()
+	oa.Base = actions.Base{
+		R: httptest.NewRequest("GET", "/foo/bar?account_id=GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2", nil).WithContext(context.WithValue(ctx, chi.RouteCtxKey, chi.NewRouteContext())),
+	}
+
+	oa.SSE(stream)
+	tt.Require.NoError(oa.Err)
+
+	_, err := tt.CoreSession().ExecRaw(
+		`DELETE FROM offers WHERE sellerid = ?`,
+		"GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+	)
+	tt.Require.NoError(err)
+
+	oa.SSE(stream)
+	tt.Require.NoError(oa.Err)
 }

--- a/services/horizon/internal/helpers_test.go
+++ b/services/horizon/internal/helpers_test.go
@@ -2,12 +2,16 @@ package horizon
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http/httptest"
 	"time"
 
+	"github.com/go-chi/chi"
 	"github.com/stellar/go/network"
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/test"
 	supportLog "github.com/stellar/go/support/log"
 	"github.com/throttled/throttled"
@@ -15,7 +19,6 @@ import (
 
 func NewTestApp() *App {
 	app, err := NewApp(NewTestConfig())
-
 	if err != nil {
 		log.Panic(err)
 	}
@@ -47,28 +50,33 @@ func ShouldBePageOf(actual interface{}, options ...interface{}) string {
 
 	var result map[string]interface{}
 	err := json.Unmarshal(body.Bytes(), &result)
-
 	if err != nil {
 		return fmt.Sprintf("Could not unmarshal json:\n%s\n", body.String())
 	}
 
 	embedded, ok := result["_embedded"]
-
 	if !ok {
 		return "No _embedded key in response"
 	}
 
 	records, ok := embedded.(map[string]interface{})["records"]
-
 	if !ok {
 		return "No records key in _embedded"
 	}
 
 	length := len(records.([]interface{}))
-
 	if length != expected {
 		return fmt.Sprintf("Expected %d records in page, got %d", expected, length)
 	}
 
 	return ""
+}
+
+func NewTestAction(ctx context.Context, path string) *Action {
+	return &Action{
+		App: NewTestApp(),
+		Base: actions.Base{
+			R: httptest.NewRequest("GET", path, nil).WithContext(context.WithValue(ctx, chi.RouteCtxKey, chi.NewRouteContext())),
+		},
+	}
 }


### PR DESCRIPTION
We used to load `action.Records` per `SSE()` call with the same cursor and use `SentCount()` to paginate for the next call. It is problematic if an offer gets added or dropped. This PR sets the cursor every time we send an event back so that we don't rely on `SentCount()`.

Close #637