### PR TITLE
horizon/actions: remove JSON from SingleObjectStreamer

### DIFF
--- a/services/horizon/internal/actions/responders.go
+++ b/services/horizon/internal/actions/responders.go
@@ -20,7 +20,9 @@ type SSE interface {
 	SSE(sse.Stream)
 }
 
+// SingleObjectStreamer implementors can respond to a request whose response
+// type was negotiated to be MimeEventStream. A SingleObjectStreamer loads an
+// object whenever a ledger is closed.
 type SingleObjectStreamer interface {
-	JSON
 	LoadEvent() sse.Event
 }


### PR DESCRIPTION
Although every single object streamer has `JSON()`, we might have a single object streamer who doesn't have `JSON()` in the future. Keeping the interface minimal makes it easier for future developers to make changes.

Details: https://github.com/stellar/go/pull/828#discussion_r251932368