### PR TITLE
horizon/actions: fix a bug in `GetPageQuery`

### DIFF
--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -194,29 +194,25 @@ func (base *Base) GetLimit(name string, def uint64, max uint64) uint64 {
 // GetPageQuery is a helper that returns a new db.PageQuery struct initialized
 // using the results from a call to GetPagingParams()
 func (base *Base) GetPageQuery(opts ...Opt) db2.PageQuery {
-	disableCursorValidation := false
-
-	for opt := range opts {
-		switch Opt(opt) {
-		case DisableCursorValidation:
-			disableCursorValidation = true
-		}
-	}
-
 	if base.Err != nil {
 		return db2.PageQuery{}
+	}
+
+	disableCursorValidation := false
+	for _, opt := range opts {
+		if opt == DisableCursorValidation {
+			disableCursorValidation = true
+		}
 	}
 
 	cursor := base.GetCursor(ParamCursor)
 	order := base.GetString(ParamOrder)
 	limit := base.GetLimit(ParamLimit, db2.DefaultPageSize, db2.MaxPageSize)
-
 	if base.Err != nil {
 		return db2.PageQuery{}
 	}
 
 	r, err := db2.NewPageQuery(cursor, !disableCursorValidation, order, limit)
-
 	if err != nil {
 		if invalidFieldError, ok := err.(*db2.InvalidFieldError); ok {
 			base.SetInvalidField(invalidFieldError.Name, err)


### PR DESCRIPTION
The `for opt := range opts` loop is wrong because `opt` is actually the index number starting from `0`. The PR also moves the first error check to the beginning as the none of operations before the first error check would set `base.Err`.