### PR TITLE
horizon/actions: improve streaming error handling

### DIFF
--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"database/sql"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -15,11 +14,8 @@ import (
 	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/support/errors"
-	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/problem"
 )
-
-var errBadStream = errors.New("Unexpected stream error")
 
 // Base is a helper struct you can use as part of a custom action via
 // composition.
@@ -85,29 +81,32 @@ func (base *Base) Execute(action interface{}) {
 			if rateLimiter != nil {
 				limited, _, err := rateLimiter.RateLimiter.RateLimit(rateLimiter.VaryBy.Key(base.R), 1)
 				if err != nil {
-					log.Ctx(ctx).Error(errors.Wrap(err, "RateLimiter error"))
-					stream.Err(errBadStream)
+					stream.Err(errors.Wrap(err, "RateLimiter error"))
 					return
 				}
 				if limited {
-					stream.Err(errors.New("rate limit exceeded"))
+					stream.Err(sse.ErrRateLimited)
 					return
 				}
 			}
 
 			switch ac := action.(type) {
 			case SSE:
-				ac.SSE(stream)
+				err := ac.SSE(stream)
+				if err != nil {
+					stream.Err(err)
+					return
+				}
 
 			case SingleObjectStreamer:
 				newEvent, err := ac.LoadEvent()
 				if err != nil {
-					break
+					stream.Err(err)
+					return
 				}
 				resource, err := json.Marshal(newEvent.Data)
 				if err != nil {
-					log.Ctx(ctx).Error(errors.Wrap(err, "unable to marshal next action resource"))
-					stream.Err(errBadStream)
+					stream.Err(errors.Wrap(err, "unable to marshal next action resource"))
 					return
 				}
 
@@ -119,26 +118,6 @@ func (base *Base) Execute(action interface{}) {
 				oldHash = nextHash
 				stream.SetLimit(10)
 				stream.Send(newEvent)
-			}
-			// TODO: better error handling. We should probably handle the error immediately in the error case above
-			// instead of breaking out from the switch statement.
-			if base.Err != nil {
-				// If we haven't sent an event, we should simply return the normal HTTP
-				// error because it means that we haven't sent the preamble.
-				if stream.SentCount() == 0 {
-					problem.Render(ctx, base.W, base.Err)
-					return
-				}
-
-				if errors.Cause(base.Err) == sql.ErrNoRows {
-					base.Err = errors.New("Object not found")
-				} else {
-					log.Ctx(ctx).Error(base.Err)
-					base.Err = errBadStream
-				}
-
-				// Send errors through the stream and then close the stream.
-				stream.Err(base.Err)
 			}
 
 			// Manually send the preamble in case there are no data events in SSE to trigger a stream.Send call.

--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -98,8 +98,8 @@ func (base *Base) Execute(action interface{}) {
 				ac.SSE(stream)
 
 			case SingleObjectStreamer:
-				newEvent := ac.LoadEvent()
-				if base.Err != nil {
+				newEvent, err := ac.LoadEvent()
+				if err != nil {
 					break
 				}
 				resource, err := json.Marshal(newEvent.Data)

--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -19,6 +19,8 @@ import (
 	"github.com/stellar/go/support/render/problem"
 )
 
+var errBadStream = errors.New("Unexpected stream error")
+
 // Base is a helper struct you can use as part of a custom action via
 // composition.
 //
@@ -84,7 +86,7 @@ func (base *Base) Execute(action interface{}) {
 				limited, _, err := rateLimiter.RateLimiter.RateLimit(rateLimiter.VaryBy.Key(base.R), 1)
 				if err != nil {
 					log.Ctx(ctx).Error(errors.Wrap(err, "RateLimiter error"))
-					stream.Err(errors.New("Unexpected stream error"))
+					stream.Err(errBadStream)
 					return
 				}
 				if limited {
@@ -105,7 +107,7 @@ func (base *Base) Execute(action interface{}) {
 				resource, err := json.Marshal(newEvent.Data)
 				if err != nil {
 					log.Ctx(ctx).Error(errors.Wrap(err, "unable to marshal next action resource"))
-					stream.Err(errors.New("Unexpected stream error"))
+					stream.Err(errBadStream)
 					return
 				}
 
@@ -132,7 +134,7 @@ func (base *Base) Execute(action interface{}) {
 					base.Err = errors.New("Object not found")
 				} else {
 					log.Ctx(ctx).Error(base.Err)
-					base.Err = errors.New("Unexpected stream error")
+					base.Err = errBadStream
 				}
 
 				// Send errors through the stream and then close the stream.

--- a/services/horizon/internal/actions/responders.go
+++ b/services/horizon/internal/actions/responders.go
@@ -17,7 +17,7 @@ type Raw interface {
 // SSE implementors can respond to a request whose response type was negotiated
 // to be MimeEventStream.
 type SSE interface {
-	SSE(sse.Stream)
+	SSE(*sse.Stream)
 }
 
 // SingleObjectStreamer implementors can respond to a request whose response

--- a/services/horizon/internal/actions/responders.go
+++ b/services/horizon/internal/actions/responders.go
@@ -24,5 +24,5 @@ type SSE interface {
 // type was negotiated to be MimeEventStream. A SingleObjectStreamer loads an
 // object whenever a ledger is closed.
 type SingleObjectStreamer interface {
-	LoadEvent() sse.Event
+	LoadEvent() (sse.Event, error)
 }

--- a/services/horizon/internal/actions/responders.go
+++ b/services/horizon/internal/actions/responders.go
@@ -17,7 +17,7 @@ type Raw interface {
 // SSE implementors can respond to a request whose response type was negotiated
 // to be MimeEventStream.
 type SSE interface {
-	SSE(*sse.Stream)
+	SSE(*sse.Stream) error
 }
 
 // SingleObjectStreamer implementors can respond to a request whose response

--- a/services/horizon/internal/actions_account.go
+++ b/services/horizon/internal/actions_account.go
@@ -38,9 +38,9 @@ func (action *AccountShowAction) JSON() {
 	)
 }
 
-func (action *AccountShowAction) LoadEvent() sse.Event {
+func (action *AccountShowAction) LoadEvent() (sse.Event, error) {
 	action.Do(action.loadParams, action.loadRecord, action.loadResource)
-	return sse.Event{Data: action.Resource}
+	return sse.Event{Data: action.Resource}, action.Err
 }
 
 func (action *AccountShowAction) loadParams() {

--- a/services/horizon/internal/actions_account.go
+++ b/services/horizon/internal/actions_account.go
@@ -14,6 +14,9 @@ import (
 //
 // AccountShowAction: details for single account (including stellar-core state)
 
+// Interface verifications
+var _ actions.SingleObjectStreamer = (*AccountShowAction)(nil)
+
 // AccountShowAction renders a account summary found by its address.
 type AccountShowAction struct {
 	Action

--- a/services/horizon/internal/actions_data.go
+++ b/services/horizon/internal/actions_data.go
@@ -47,7 +47,7 @@ func (action *DataShowAction) Raw() {
 }
 
 // SSE is a method for actions.SSE
-func (action *DataShowAction) SSE(stream sse.Stream) {
+func (action *DataShowAction) SSE(stream *sse.Stream) error {
 	action.Do(
 		action.loadParams,
 		action.loadRecord,
@@ -55,6 +55,8 @@ func (action *DataShowAction) SSE(stream sse.Stream) {
 			stream.Send(sse.Event{Data: action.Data.Value})
 		},
 	)
+
+	return action.Err
 }
 
 func (action *DataShowAction) loadParams() {

--- a/services/horizon/internal/actions_data.go
+++ b/services/horizon/internal/actions_data.go
@@ -7,6 +7,9 @@ import (
 	"github.com/stellar/go/support/render/hal"
 )
 
+// Interface verifications
+var _ actions.SSE = (*DataShowAction)(nil)
+
 // DataShowAction renders a account summary found by its address.
 type DataShowAction struct {
 	Action

--- a/services/horizon/internal/actions_effects.go
+++ b/services/horizon/internal/actions_effects.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
@@ -15,6 +16,9 @@ import (
 // This file contains the actions:
 //
 // EffectIndexAction: pages of effects
+
+// Interface verifications
+var _ actions.SSE = (*EffectIndexAction)(nil)
 
 // EffectIndexAction renders a page of effect resources, identified by
 // a normal page query and optionally filtered by an account, ledger,

--- a/services/horizon/internal/actions_effects.go
+++ b/services/horizon/internal/actions_effects.go
@@ -67,11 +67,13 @@ func (action *EffectIndexAction) SSE(stream *sse.Stream) error {
 				ledger, found := action.Ledgers.Records[record.LedgerSequence()]
 				if !found {
 					action.Err = errors.New(fmt.Sprintf("could not find ledger data for sequence %d", record.LedgerSequence()))
+					return
 				}
 
 				res, err := resourceadapter.NewEffect(action.R.Context(), record, ledger)
 				if err != nil {
 					action.Err = err
+					return
 				}
 
 				stream.Send(sse.Event{

--- a/services/horizon/internal/actions_effects.go
+++ b/services/horizon/internal/actions_effects.go
@@ -49,7 +49,7 @@ func (action *EffectIndexAction) JSON() {
 }
 
 // SSE is a method for actions.SSE
-func (action *EffectIndexAction) SSE(stream sse.Stream) {
+func (action *EffectIndexAction) SSE(stream *sse.Stream) error {
 	action.Setup(
 		action.EnsureHistoryFreshness,
 		action.loadParams,
@@ -66,16 +66,12 @@ func (action *EffectIndexAction) SSE(stream sse.Stream) {
 			for _, record := range records {
 				ledger, found := action.Ledgers.Records[record.LedgerSequence()]
 				if !found {
-					msg := fmt.Sprintf("could not find ledger data for sequence %d", record.LedgerSequence())
-					action.Err = errors.New(msg)
-					return
+					action.Err = errors.New(fmt.Sprintf("could not find ledger data for sequence %d", record.LedgerSequence()))
 				}
 
 				res, err := resourceadapter.NewEffect(action.R.Context(), record, ledger)
-
 				if err != nil {
 					action.Err = err
-					return
 				}
 
 				stream.Send(sse.Event{
@@ -85,6 +81,8 @@ func (action *EffectIndexAction) SSE(stream sse.Stream) {
 			}
 		},
 	)
+
+	return action.Err
 }
 
 // loadLedgers populates the ledger cache for this action

--- a/services/horizon/internal/actions_ledger.go
+++ b/services/horizon/internal/actions_ledger.go
@@ -2,6 +2,7 @@ package horizon
 
 import (
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/ledger"
@@ -15,6 +16,9 @@ import (
 //
 // LedgerIndexAction: pages of ledgers
 // LedgerShowAction: single ledger by sequence
+
+// Interface verifications
+var _ actions.SSE = (*LedgerIndexAction)(nil)
 
 // LedgerIndexAction renders a page of ledger resources, identified by
 // a normal page query.

--- a/services/horizon/internal/actions_ledger.go
+++ b/services/horizon/internal/actions_ledger.go
@@ -38,7 +38,7 @@ func (action *LedgerIndexAction) JSON() {
 }
 
 // SSE is a method for actions.SSE
-func (action *LedgerIndexAction) SSE(stream sse.Stream) {
+func (action *LedgerIndexAction) SSE(stream *sse.Stream) error {
 	action.Setup(
 		action.EnsureHistoryFreshness,
 		action.loadParams,
@@ -57,6 +57,8 @@ func (action *LedgerIndexAction) SSE(stream sse.Stream) {
 			}
 		},
 	)
+
+	return action.Err
 }
 
 func (action *LedgerIndexAction) loadParams() {

--- a/services/horizon/internal/actions_offer.go
+++ b/services/horizon/internal/actions_offer.go
@@ -2,6 +2,7 @@ package horizon
 
 import (
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -11,6 +12,9 @@ import (
 )
 
 // This file contains the actions:
+
+// Interface verifications
+var _ actions.SSE = (*OffersByAccountAction)(nil)
 
 // OffersByAccountAction renders a page of offer resources, for a given
 // account.  These offers are present in the ledger as of the latest validated

--- a/services/horizon/internal/actions_offer.go
+++ b/services/horizon/internal/actions_offer.go
@@ -38,13 +38,13 @@ func (action *OffersByAccountAction) JSON() {
 }
 
 // SSE is a method for actions.SSE
-func (action *OffersByAccountAction) SSE(stream sse.Stream) {
+func (action *OffersByAccountAction) SSE(stream *sse.Stream) error {
 	// Load the page query params the first time SSE() is called. We update
 	// the pagination cursor below before sending each event to the stream.
 	if action.PageQuery.Cursor == "" {
 		action.loadParams()
 		if action.Err != nil {
-			return
+			return action.Err
 		}
 	}
 
@@ -66,6 +66,8 @@ func (action *OffersByAccountAction) SSE(stream sse.Stream) {
 			}
 		},
 	)
+
+	return action.Err
 }
 
 func (action *OffersByAccountAction) loadParams() {

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/ledger"
@@ -18,6 +19,9 @@ import (
 //
 // OperationIndexAction: pages of operations
 // OperationShowAction: single operation by id
+
+// Interface verifications
+var _ actions.SSE = (*OperationIndexAction)(nil)
 
 // OperationIndexAction renders a page of operations resources, identified by
 // a normal page query and optionally filtered by an account, ledger, or

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -48,7 +48,7 @@ func (action *OperationIndexAction) JSON() {
 }
 
 // SSE is a method for actions.SSE
-func (action *OperationIndexAction) SSE(stream sse.Stream) {
+func (action *OperationIndexAction) SSE(stream *sse.Stream) error {
 	action.Setup(
 		action.EnsureHistoryFreshness,
 		action.loadParams,
@@ -64,16 +64,13 @@ func (action *OperationIndexAction) SSE(stream sse.Stream) {
 			for _, record := range records {
 				ledger, found := action.Ledgers.Records[record.LedgerSequence()]
 				if !found {
-					msg := fmt.Sprintf("could not find ledger data for sequence %d", record.LedgerSequence())
-					action.Err = errors.New(msg)
-					return
+					action.Err = errors.New(fmt.Sprintf("could not find ledger data for sequence %d", record.LedgerSequence()))
 				}
 
 				res, err := resourceadapter.NewOperation(action.R.Context(), record, ledger)
 
 				if err != nil {
 					action.Err = err
-					return
 				}
 
 				stream.Send(sse.Event{
@@ -81,8 +78,10 @@ func (action *OperationIndexAction) SSE(stream sse.Stream) {
 					Data: res,
 				})
 			}
-		})
+		},
+	)
 
+	return action.Err
 }
 
 func (action *OperationIndexAction) loadParams() {

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -65,12 +65,13 @@ func (action *OperationIndexAction) SSE(stream *sse.Stream) error {
 				ledger, found := action.Ledgers.Records[record.LedgerSequence()]
 				if !found {
 					action.Err = errors.New(fmt.Sprintf("could not find ledger data for sequence %d", record.LedgerSequence()))
+					return
 				}
 
 				res, err := resourceadapter.NewOperation(action.R.Context(), record, ledger)
-
 				if err != nil {
 					action.Err = err
+					return
 				}
 
 				stream.Send(sse.Event{

--- a/services/horizon/internal/actions_order_book.go
+++ b/services/horizon/internal/actions_order_book.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
@@ -11,6 +12,9 @@ import (
 	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/xdr"
 )
+
+// Interface verifications
+var _ actions.SingleObjectStreamer = (*OrderBookShowAction)(nil)
 
 // OrderBookShowAction renders a account summary found by its address.
 type OrderBookShowAction struct {

--- a/services/horizon/internal/actions_order_book.go
+++ b/services/horizon/internal/actions_order_book.go
@@ -72,7 +72,7 @@ func (action *OrderBookShowAction) JSON() {
 	})
 }
 
-func (action *OrderBookShowAction) LoadEvent() sse.Event {
+func (action *OrderBookShowAction) LoadEvent() (sse.Event, error) {
 	action.Do(action.LoadQuery, action.LoadRecord, action.LoadResource)
-	return sse.Event{Data: action.Resource}
+	return sse.Event{Data: action.Resource}, action.Err
 }

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -40,7 +40,7 @@ func (action *PaymentsIndexAction) JSON() {
 }
 
 // SSE is a method for actions.SSE
-func (action *PaymentsIndexAction) SSE(stream sse.Stream) {
+func (action *PaymentsIndexAction) SSE(stream *sse.Stream) error {
 	action.Setup(
 		action.EnsureHistoryFreshness,
 		action.loadParams,
@@ -56,16 +56,12 @@ func (action *PaymentsIndexAction) SSE(stream sse.Stream) {
 			for _, record := range records {
 				ledger, found := action.Ledgers.Records[record.LedgerSequence()]
 				if !found {
-					msg := fmt.Sprintf("could not find ledger data for sequence %d", record.LedgerSequence())
-					action.Err = errors.New(msg)
-					return
+					action.Err = errors.New(fmt.Sprintf("could not find ledger data for sequence %d", record.LedgerSequence()))
 				}
 
 				res, err := resourceadapter.NewOperation(action.R.Context(), record, ledger)
-
 				if err != nil {
 					action.Err = err
-					return
 				}
 
 				stream.Send(sse.Event{
@@ -73,7 +69,10 @@ func (action *PaymentsIndexAction) SSE(stream sse.Stream) {
 					Data: res,
 				})
 			}
-		})
+		},
+	)
+
+	return action.Err
 }
 
 func (action *PaymentsIndexAction) loadParams() {

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -4,12 +4,16 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 	"github.com/stellar/go/support/render/hal"
 )
+
+// Interface verifications
+var _ actions.SSE = (*PaymentsIndexAction)(nil)
 
 // PaymentsIndexAction returns a paged slice of payments based upon the provided
 // filters

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -57,11 +57,13 @@ func (action *PaymentsIndexAction) SSE(stream *sse.Stream) error {
 				ledger, found := action.Ledgers.Records[record.LedgerSequence()]
 				if !found {
 					action.Err = errors.New(fmt.Sprintf("could not find ledger data for sequence %d", record.LedgerSequence()))
+					return
 				}
 
 				res, err := resourceadapter.NewOperation(action.R.Context(), record, ledger)
 				if err != nil {
 					action.Err = err
+					return
 				}
 
 				stream.Send(sse.Event{

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -5,6 +5,7 @@ import (
 	gTime "time"
 
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
@@ -14,6 +15,9 @@ import (
 	"github.com/stellar/go/support/time"
 	"github.com/stellar/go/xdr"
 )
+
+// Interface verifications
+var _ actions.SSE = (*TradeIndexAction)(nil)
 
 type TradeIndexAction struct {
 	Action

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -42,7 +42,7 @@ func (action *TradeIndexAction) JSON() {
 }
 
 // SSE is a method for actions.SSE
-func (action *TradeIndexAction) SSE(stream sse.Stream) {
+func (action *TradeIndexAction) SSE(stream *sse.Stream) error {
 	action.Setup(
 		action.EnsureHistoryFreshness,
 		action.loadParams,
@@ -56,10 +56,8 @@ func (action *TradeIndexAction) SSE(stream sse.Stream) {
 			for _, record := range records {
 				var res horizon.Trade
 				err := resourceadapter.PopulateTrade(action.R.Context(), &res, record)
-
 				if err != nil {
 					action.Err = err
-					return
 				}
 
 				stream.Send(sse.Event{
@@ -69,6 +67,8 @@ func (action *TradeIndexAction) SSE(stream sse.Stream) {
 			}
 		},
 	)
+
+	return action.Err
 }
 
 // loadParams sets action.Query from the request params

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -55,11 +55,7 @@ func (action *TradeIndexAction) SSE(stream *sse.Stream) error {
 
 			for _, record := range records {
 				var res horizon.Trade
-				err := resourceadapter.PopulateTrade(action.R.Context(), &res, record)
-				if err != nil {
-					action.Err = err
-				}
-
+				resourceadapter.PopulateTrade(action.R.Context(), &res, record)
 				stream.Send(sse.Event{
 					ID:   res.PagingToken(),
 					Data: res,
@@ -126,13 +122,7 @@ func (action *TradeIndexAction) loadRecords() {
 func (action *TradeIndexAction) loadPage() {
 	for _, record := range action.Records {
 		var res horizon.Trade
-
-		action.Err = resourceadapter.PopulateTrade(action.R.Context(), &res, record)
-
-		if action.Err != nil {
-			return
-		}
-
+		resourceadapter.PopulateTrade(action.R.Context(), &res, record)
 		action.Page.Add(res)
 	}
 

--- a/services/horizon/internal/actions_transaction.go
+++ b/services/horizon/internal/actions_transaction.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
@@ -18,6 +19,9 @@ import (
 //
 // TransactionIndexAction: pages of transactions
 // TransactionShowAction: single transaction by sequence, by hash or id
+
+// Interface verifications
+var _ actions.SSE = (*TransactionIndexAction)(nil)
 
 // TransactionIndexAction renders a page of ledger resources, identified by
 // a normal page query.

--- a/services/horizon/internal/actions_transaction.go
+++ b/services/horizon/internal/actions_transaction.go
@@ -45,7 +45,7 @@ func (action *TransactionIndexAction) JSON() {
 }
 
 // SSE is a method for actions.SSE
-func (action *TransactionIndexAction) SSE(stream sse.Stream) {
+func (action *TransactionIndexAction) SSE(stream *sse.Stream) error {
 	action.Setup(
 		action.EnsureHistoryFreshness,
 		action.loadParams,
@@ -64,6 +64,8 @@ func (action *TransactionIndexAction) SSE(stream sse.Stream) {
 			}
 		},
 	)
+
+	return action.Err
 }
 
 func (action *TransactionIndexAction) loadParams() {

--- a/services/horizon/internal/assets/main.go
+++ b/services/horizon/internal/assets/main.go
@@ -22,9 +22,7 @@ var AssetTypeMap = map[string]xdr.AssetType{
 
 //Parse creates an asset from the provided strings.  See AssetTypeMap for valid strings for aType.
 func Parse(aType string) (result xdr.AssetType, err error) {
-
 	result, ok := AssetTypeMap[aType]
-
 	if !ok {
 		err = errors.New(ErrInvalidString)
 	}

--- a/services/horizon/internal/render/sse/main.go
+++ b/services/horizon/internal/render/sse/main.go
@@ -31,12 +31,10 @@ type Eventable interface {
 }
 
 // WritePreamble prepares this http connection for streaming using Server Sent
-// Events.  It sends the initial http response with the appropriate headers to
+// Events. It sends the initial http response with the appropriate headers to
 // do so.
 func WritePreamble(ctx context.Context, w http.ResponseWriter) bool {
-
 	_, flushable := w.(http.Flusher)
-
 	if !flushable {
 		//TODO: render a problem struct instead of simple string
 		http.Error(w, "Streaming Not Supported", http.StatusBadRequest)

--- a/services/horizon/internal/render/sse/stream.go
+++ b/services/horizon/internal/render/sse/stream.go
@@ -2,9 +2,28 @@ package sse
 
 import (
 	"context"
+	"database/sql"
 	"net/http"
 	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/go/support/render/problem"
 )
+
+var (
+	// default error
+	errBadStream = errors.New("Unexpected stream error")
+
+	// known error
+	errNoObject    = errors.New("Object not found")
+	ErrRateLimited = errors.New("Rate limit exceeded")
+)
+
+var errorMap = map[error]struct{}{
+	errNoObject:    struct{}{},
+	ErrRateLimited: struct{}{},
+}
 
 type Stream struct {
 	ctx      context.Context
@@ -84,6 +103,24 @@ func (s *Stream) IsDone() bool {
 func (s *Stream) Err(err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// If we haven't sent an event, we should simply return the normal HTTP
+	// error because it means that we haven't sent the preamble.
+	if s.sent == 0 {
+		problem.Render(s.ctx, s.w, err)
+		return
+	}
+
+	if errors.Cause(err) == sql.ErrNoRows {
+		err = errNoObject
+	}
+
+	_, ok := errorMap[err]
+	if !ok {
+		log.Ctx(s.ctx).Error(err)
+		err = errBadStream
+	}
+
 	s.Init()
 	WriteEvent(s.ctx, s.w, Event{Error: err})
 	s.done = true

--- a/services/horizon/internal/render/sse/stream.go
+++ b/services/horizon/internal/render/sse/stream.go
@@ -6,29 +6,8 @@ import (
 	"sync"
 )
 
-// Stream represents an output stream that data can be written to.
-// Its methods must be safe to call concurrently.
-type Stream interface {
-	Init()
-	Send(Event)
-	SentCount() int
-	Done()
-	SetLimit(limit int)
-	IsDone() bool
-	Err(error)
-}
-
-// NewStream creates a new stream against the provided response writer.
-func NewStream(ctx context.Context, w http.ResponseWriter) *stream {
-	return &stream{
-		ctx: ctx,
-		w:   w,
-	}
-}
-
-type stream struct {
-	ctx context.Context
-
+type Stream struct {
+	ctx      context.Context
 	initSync sync.Once  // Variable to ensure that Init only writes the preamble once.
 	mu       sync.Mutex // Mutex protects the following fields
 	w        http.ResponseWriter
@@ -37,10 +16,18 @@ type stream struct {
 	limit    int
 }
 
+// NewStream creates a new stream against the provided response writer.
+func NewStream(ctx context.Context, w http.ResponseWriter) *Stream {
+	return &Stream{
+		ctx: ctx,
+		w:   w,
+	}
+}
+
 // Init function is only executed once. It writes the preamble event which includes the HTTP response code and a
 // hello message. This should be called before any method that writes to the client to ensure that the preamble
 // has been sent first.
-func (s *stream) Init() {
+func (s *Stream) Init() {
 	s.initSync.Do(func() {
 		ok := WritePreamble(s.ctx, s.w)
 		if !ok {
@@ -49,7 +36,7 @@ func (s *stream) Init() {
 	})
 }
 
-func (s *stream) Send(e Event) {
+func (s *Stream) Send(e Event) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.Init()
@@ -57,19 +44,19 @@ func (s *stream) Send(e Event) {
 	s.sent++
 }
 
-func (s *stream) SentCount() int {
+func (s *Stream) SentCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.sent
 }
 
-func (s *stream) SetLimit(limit int) {
+func (s *Stream) SetLimit(limit int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.limit = limit
 }
 
-func (s *stream) Done() {
+func (s *Stream) Done() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.Init()
@@ -79,7 +66,7 @@ func (s *stream) Done() {
 
 // isDone checks to see if the stream is done. Not safe to call concurrently
 // and meant for internal use.
-func (s *stream) isDone() bool {
+func (s *Stream) isDone() bool {
 	if s.limit == 0 {
 		return s.done
 	}
@@ -88,13 +75,13 @@ func (s *stream) isDone() bool {
 }
 
 // IsDone is safe to call concurrently and is exported.
-func (s *stream) IsDone() bool {
+func (s *Stream) IsDone() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.isDone()
 }
 
-func (s *stream) Err(err error) {
+func (s *Stream) Err(err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.Init()

--- a/services/horizon/internal/render/sse/stream.go
+++ b/services/horizon/internal/render/sse/stream.go
@@ -15,12 +15,12 @@ var (
 	// default error
 	errBadStream = errors.New("Unexpected stream error")
 
-	// known error
+	// known errors
 	errNoObject    = errors.New("Object not found")
 	ErrRateLimited = errors.New("Rate limit exceeded")
 )
 
-var errorMap = map[error]struct{}{
+var knownErrors = map[error]struct{}{
 	errNoObject:    struct{}{},
 	ErrRateLimited: struct{}{},
 }
@@ -115,7 +115,7 @@ func (s *Stream) Err(err error) {
 		err = errNoObject
 	}
 
-	_, ok := errorMap[err]
+	_, ok := knownErrors[errors.Cause(err)]
 	if !ok {
 		log.Ctx(s.ctx).Error(err)
 		err = errBadStream

--- a/services/horizon/internal/render/sse/stream.go
+++ b/services/horizon/internal/render/sse/stream.go
@@ -19,13 +19,11 @@ type Stream interface {
 }
 
 // NewStream creates a new stream against the provided response writer.
-func NewStream(ctx context.Context, w http.ResponseWriter) Stream {
-	result := &stream{
+func NewStream(ctx context.Context, w http.ResponseWriter) *stream {
+	return &stream{
 		ctx: ctx,
 		w:   w,
 	}
-
-	return result
 }
 
 type stream struct {

--- a/services/horizon/internal/resourceadapter/trade.go
+++ b/services/horizon/internal/resourceadapter/trade.go
@@ -17,7 +17,7 @@ func PopulateTrade(
 	ctx context.Context,
 	dest *Trade,
 	row history.Trade,
-) (err error) {
+) {
 	dest.ID = row.PagingToken()
 	dest.PT = row.PagingToken()
 	dest.OfferID = fmt.Sprintf("%d", row.OfferID)
@@ -50,7 +50,6 @@ func PopulateTrade(
 	}
 
 	populateTradeLinks(ctx, dest, row.HistoryOperationID)
-	return
 }
 
 func populateTradeLinks(

--- a/services/horizon/internal/resourceadapter/transaction.go
+++ b/services/horizon/internal/resourceadapter/transaction.go
@@ -18,8 +18,7 @@ func PopulateTransaction(
 	ctx context.Context,
 	dest *Transaction,
 	row history.Transaction,
-) (err error) {
-
+) {
 	dest.ID = row.TransactionHash
 	dest.PT = row.PagingToken()
 	dest.Hash = row.TransactionHash
@@ -47,7 +46,6 @@ func PopulateTransaction(
 	dest.Links.Self = lb.Link("/transactions", dest.ID)
 	dest.Links.Succeeds = lb.Linkf("/transactions?order=desc&cursor=%s", dest.PT)
 	dest.Links.Precedes = lb.Linkf("/transactions?order=asc&cursor=%s", dest.PT)
-	return
 }
 
 func timeString(res *Transaction, in null.Int) string {


### PR DESCRIPTION
This PR does the following:
1. removes unnecessary empty lines.
2. removes `Stream` interface and exports `stream` struct.
3. makes both `SSE()` and `LoadEvent` return an error directly.
4. consolidates errors returned when streaming into `sse/stream.go`.
5. fixes `TestStream_Err()` so that we don't send preamble when encountering an error before sending an event.