### PR TITLE
horizon/actions: have JSON() and Raw() return an error

### DIFF
--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -62,7 +62,7 @@ func (base *Base) Execute(action interface{}) {
 
 	case render.MimeEventStream:
 		switch action.(type) {
-		case SSE, SingleObjectStreamer:
+		case EventStreamer, SingleObjectStreamer:
 		default:
 			goto NotAcceptable
 		}
@@ -90,7 +90,7 @@ func (base *Base) Execute(action interface{}) {
 			}
 
 			switch ac := action.(type) {
-			case SSE:
+			case EventStreamer:
 				err := ac.SSE(stream)
 				if err != nil {
 					stream.Err(err)
@@ -154,7 +154,7 @@ func (base *Base) Execute(action interface{}) {
 			return
 		}
 	case render.MimeRaw:
-		action, ok := action.(Rawer)
+		action, ok := action.(RawDataResponder)
 		if !ok {
 			goto NotAcceptable
 		}

--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -49,7 +49,7 @@ func (base *Base) Execute(action interface{}) {
 
 	switch contentType {
 	case render.MimeHal, render.MimeJSON:
-		action, ok := action.(JSON)
+		action, ok := action.(JSONer)
 		if !ok {
 			goto NotAcceptable
 		}

--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -154,15 +154,14 @@ func (base *Base) Execute(action interface{}) {
 			return
 		}
 	case render.MimeRaw:
-		action, ok := action.(Raw)
+		action, ok := action.(Rawer)
 		if !ok {
 			goto NotAcceptable
 		}
 
-		action.Raw()
-
-		if base.Err != nil {
-			problem.Render(ctx, base.W, base.Err)
+		err := action.Raw()
+		if err != nil {
+			problem.Render(ctx, base.W, err)
 			return
 		}
 	default:

--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -54,10 +54,9 @@ func (base *Base) Execute(action interface{}) {
 			goto NotAcceptable
 		}
 
-		action.JSON()
-
-		if base.Err != nil {
-			problem.Render(ctx, base.W, base.Err)
+		err := action.JSON()
+		if err != nil {
+			problem.Render(ctx, base.W, err)
 			return
 		}
 

--- a/services/horizon/internal/actions/responders.go
+++ b/services/horizon/internal/actions/responders.go
@@ -5,7 +5,7 @@ import "github.com/stellar/go/services/horizon/internal/render/sse"
 // JSON implementors can respond to a request whose response type was negotiated
 // to be MimeHal or MimeJSON.
 type JSON interface {
-	JSON()
+	JSON() error
 }
 
 // Raw implementors can respond to a request whose response type was negotiated

--- a/services/horizon/internal/actions/responders.go
+++ b/services/horizon/internal/actions/responders.go
@@ -8,15 +8,15 @@ type JSONer interface {
 	JSON() error
 }
 
-// Rawer implementors can respond to a request whose response type was negotiated
+// RawDataResponder implementors can respond to a request whose response type was negotiated
 // to be MimeRaw.
-type Rawer interface {
+type RawDataResponder interface {
 	Raw() error
 }
 
-// SSE implementors can respond to a request whose response type was negotiated
+// EventStreamer implementors can respond to a request whose response type was negotiated
 // to be MimeEventStream.
-type SSE interface {
+type EventStreamer interface {
 	SSE(*sse.Stream) error
 }
 

--- a/services/horizon/internal/actions/responders.go
+++ b/services/horizon/internal/actions/responders.go
@@ -2,9 +2,9 @@ package actions
 
 import "github.com/stellar/go/services/horizon/internal/render/sse"
 
-// JSON implementors can respond to a request whose response type was negotiated
+// JSONer implementors can respond to a request whose response type was negotiated
 // to be MimeHal or MimeJSON.
-type JSON interface {
+type JSONer interface {
 	JSON() error
 }
 

--- a/services/horizon/internal/actions/responders.go
+++ b/services/horizon/internal/actions/responders.go
@@ -8,10 +8,10 @@ type JSONer interface {
 	JSON() error
 }
 
-// Raw implementors can respond to a request whose response type was negotiated
+// Rawer implementors can respond to a request whose response type was negotiated
 // to be MimeRaw.
-type Raw interface {
-	Raw()
+type Rawer interface {
+	Raw() error
 }
 
 // SSE implementors can respond to a request whose response type was negotiated

--- a/services/horizon/internal/actions_account.go
+++ b/services/horizon/internal/actions_account.go
@@ -15,7 +15,7 @@ import (
 // AccountShowAction: details for single account (including stellar-core state)
 
 // Interface verifications
-var _ actions.JSON = (*AccountShowAction)(nil)
+var _ actions.JSONer = (*AccountShowAction)(nil)
 var _ actions.SingleObjectStreamer = (*AccountShowAction)(nil)
 
 // AccountShowAction renders a account summary found by its address.

--- a/services/horizon/internal/actions_account.go
+++ b/services/horizon/internal/actions_account.go
@@ -15,6 +15,7 @@ import (
 // AccountShowAction: details for single account (including stellar-core state)
 
 // Interface verifications
+var _ actions.JSON = (*AccountShowAction)(nil)
 var _ actions.SingleObjectStreamer = (*AccountShowAction)(nil)
 
 // AccountShowAction renders a account summary found by its address.
@@ -30,15 +31,14 @@ type AccountShowAction struct {
 }
 
 // JSON is a method for actions.JSON
-func (action *AccountShowAction) JSON() {
+func (action *AccountShowAction) JSON() error {
 	action.Do(
 		action.loadParams,
 		action.loadRecord,
 		action.loadResource,
-		func() {
-			hal.Render(action.W, action.Resource)
-		},
+		func() { hal.Render(action.W, action.Resource) },
 	)
+	return action.Err
 }
 
 func (action *AccountShowAction) LoadEvent() (sse.Event, error) {
@@ -54,41 +54,31 @@ func (action *AccountShowAction) loadRecord() {
 	app := AppFromContext(action.R.Context())
 	protocolVersion := app.coreSupportedProtocolVersion
 
-	action.Err = action.CoreQ().
-		AccountByAddress(&action.CoreRecord, action.Address, protocolVersion)
+	action.Err = action.CoreQ().AccountByAddress(&action.CoreRecord, action.Address, protocolVersion)
 	if action.Err != nil {
 		return
 	}
 
-	action.Err = action.CoreQ().
-		AllDataByAddress(&action.CoreData, action.Address)
+	action.Err = action.CoreQ().AllDataByAddress(&action.CoreData, action.Address)
 	if action.Err != nil {
 		return
 	}
 
-	action.Err = action.CoreQ().
-		SignersByAddress(&action.CoreSigners, action.Address)
+	action.Err = action.CoreQ().SignersByAddress(&action.CoreSigners, action.Address)
 	if action.Err != nil {
 		return
 	}
 
-	action.Err = action.CoreQ().
-		TrustlinesByAddress(&action.CoreTrustlines, action.Address, protocolVersion)
+	action.Err = action.CoreQ().TrustlinesByAddress(&action.CoreTrustlines, action.Address, protocolVersion)
 	if action.Err != nil {
 		return
 	}
 
-	action.Err = action.HistoryQ().
-		AccountByAddress(&action.HistoryRecord, action.Address)
-
+	action.Err = action.HistoryQ().AccountByAddress(&action.HistoryRecord, action.Address)
 	// Do not fail when we cannot find the history record... it probably just
 	// means that the account was created outside of our known history range.
 	if action.HistoryQ().NoRows(action.Err) {
 		action.Err = nil
-	}
-
-	if action.Err != nil {
-		return
 	}
 }
 

--- a/services/horizon/internal/actions_assets.go
+++ b/services/horizon/internal/actions_assets.go
@@ -15,6 +15,9 @@ import (
 //
 // AssetsAction: pages of assets
 
+// Interface verification
+var _ actions.JSON = (*AssetsAction)(nil)
+
 // AssetsAction renders a page of Assets
 type AssetsAction struct {
 	Action
@@ -28,15 +31,14 @@ type AssetsAction struct {
 const maxAssetCodeLength = 12
 
 // JSON is a method for actions.JSON
-func (action *AssetsAction) JSON() {
+func (action *AssetsAction) JSON() error {
 	action.Do(
 		action.loadParams,
 		action.loadRecords,
 		action.loadPage,
-		func() {
-			hal.Render(action.W, action.Page)
-		},
+		func() { hal.Render(action.W, action.Page) },
 	)
+	return action.Err
 }
 
 func (action *AssetsAction) loadParams() {

--- a/services/horizon/internal/actions_assets.go
+++ b/services/horizon/internal/actions_assets.go
@@ -16,7 +16,7 @@ import (
 // AssetsAction: pages of assets
 
 // Interface verification
-var _ actions.JSON = (*AssetsAction)(nil)
+var _ actions.JSONer = (*AssetsAction)(nil)
 
 // AssetsAction renders a page of Assets
 type AssetsAction struct {

--- a/services/horizon/internal/actions_data.go
+++ b/services/horizon/internal/actions_data.go
@@ -9,6 +9,7 @@ import (
 
 // Interface verifications
 var _ actions.JSONer = (*DataShowAction)(nil)
+var _ actions.Rawer = (*DataShowAction)(nil)
 var _ actions.SSE = (*DataShowAction)(nil)
 
 // DataShowAction renders a account summary found by its address.
@@ -34,7 +35,7 @@ func (action *DataShowAction) JSON() error {
 }
 
 // Raw is a method for actions.Raw
-func (action *DataShowAction) Raw() {
+func (action *DataShowAction) Raw() error {
 	action.Do(
 		action.loadParams,
 		action.loadRecord,
@@ -48,6 +49,7 @@ func (action *DataShowAction) Raw() {
 			action.W.Write(raw)
 		},
 	)
+	return action.Err
 }
 
 // SSE is a method for actions.SSE

--- a/services/horizon/internal/actions_data.go
+++ b/services/horizon/internal/actions_data.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Interface verifications
-var _ actions.JSON = (*DataShowAction)(nil)
+var _ actions.JSONer = (*DataShowAction)(nil)
 var _ actions.SSE = (*DataShowAction)(nil)
 
 // DataShowAction renders a account summary found by its address.

--- a/services/horizon/internal/actions_data.go
+++ b/services/horizon/internal/actions_data.go
@@ -8,6 +8,7 @@ import (
 )
 
 // Interface verifications
+var _ actions.JSON = (*DataShowAction)(nil)
 var _ actions.SSE = (*DataShowAction)(nil)
 
 // DataShowAction renders a account summary found by its address.
@@ -19,17 +20,17 @@ type DataShowAction struct {
 }
 
 // JSON is a method for actions.JSON
-func (action *DataShowAction) JSON() {
+func (action *DataShowAction) JSON() error {
 	action.Do(
 		action.loadParams,
 		action.loadRecord,
 		func() {
-
 			hal.Render(action.W, map[string]string{
 				"value": action.Data.Value,
 			})
 		},
 	)
+	return action.Err
 }
 
 // Raw is a method for actions.Raw
@@ -58,7 +59,6 @@ func (action *DataShowAction) SSE(stream *sse.Stream) error {
 			stream.Send(sse.Event{Data: action.Data.Value})
 		},
 	)
-
 	return action.Err
 }
 
@@ -68,9 +68,5 @@ func (action *DataShowAction) loadParams() {
 }
 
 func (action *DataShowAction) loadRecord() {
-	action.Err = action.CoreQ().
-		AccountDataByKey(&action.Data, action.Address, action.Key)
-	if action.Err != nil {
-		return
-	}
+	action.Err = action.CoreQ().AccountDataByKey(&action.Data, action.Address, action.Key)
 }

--- a/services/horizon/internal/actions_data.go
+++ b/services/horizon/internal/actions_data.go
@@ -9,8 +9,8 @@ import (
 
 // Interface verifications
 var _ actions.JSONer = (*DataShowAction)(nil)
-var _ actions.Rawer = (*DataShowAction)(nil)
-var _ actions.SSE = (*DataShowAction)(nil)
+var _ actions.RawDataResponder = (*DataShowAction)(nil)
+var _ actions.EventStreamer = (*DataShowAction)(nil)
 
 // DataShowAction renders a account summary found by its address.
 type DataShowAction struct {

--- a/services/horizon/internal/actions_effects.go
+++ b/services/horizon/internal/actions_effects.go
@@ -19,7 +19,7 @@ import (
 
 // Interface verifications
 var _ actions.JSONer = (*EffectIndexAction)(nil)
-var _ actions.SSE = (*EffectIndexAction)(nil)
+var _ actions.EventStreamer = (*EffectIndexAction)(nil)
 
 // EffectIndexAction renders a page of effect resources, identified by
 // a normal page query and optionally filtered by an account, ledger,

--- a/services/horizon/internal/actions_effects.go
+++ b/services/horizon/internal/actions_effects.go
@@ -18,6 +18,7 @@ import (
 // EffectIndexAction: pages of effects
 
 // Interface verifications
+var _ actions.JSON = (*EffectIndexAction)(nil)
 var _ actions.SSE = (*EffectIndexAction)(nil)
 
 // EffectIndexAction renders a page of effect resources, identified by
@@ -37,7 +38,7 @@ type EffectIndexAction struct {
 }
 
 // JSON is a method for actions.JSON
-func (action *EffectIndexAction) JSON() {
+func (action *EffectIndexAction) JSON() error {
 	action.Do(
 		action.EnsureHistoryFreshness,
 		action.loadParams,
@@ -45,11 +46,9 @@ func (action *EffectIndexAction) JSON() {
 		action.loadRecords,
 		action.loadLedgers,
 		action.loadPage,
+		func() { hal.Render(action.W, action.Page) },
 	)
-
-	action.Do(func() {
-		hal.Render(action.W, action.Page)
-	})
+	return action.Err
 }
 
 // SSE is a method for actions.SSE
@@ -132,7 +131,6 @@ func (action *EffectIndexAction) loadRecords() {
 // loadPage populates action.Page
 func (action *EffectIndexAction) loadPage() {
 	for _, record := range action.Records {
-
 		ledger, found := action.Ledgers.Records[record.LedgerSequence()]
 		if !found {
 			msg := fmt.Sprintf("could not find ledger data for sequence %d", record.LedgerSequence())
@@ -160,7 +158,6 @@ func (action *EffectIndexAction) loadPage() {
 // represents the the cursor directly after the last closed ledger
 func (action *EffectIndexAction) ValidateCursor() {
 	c := action.GetString("cursor")
-
 	if c == "" {
 		return
 	}
@@ -173,8 +170,5 @@ func (action *EffectIndexAction) ValidateCursor() {
 
 	if !ok {
 		action.SetInvalidField("cursor", errors.New("invalid format"))
-		return
 	}
-
-	return
 }

--- a/services/horizon/internal/actions_effects.go
+++ b/services/horizon/internal/actions_effects.go
@@ -18,7 +18,7 @@ import (
 // EffectIndexAction: pages of effects
 
 // Interface verifications
-var _ actions.JSON = (*EffectIndexAction)(nil)
+var _ actions.JSONer = (*EffectIndexAction)(nil)
 var _ actions.SSE = (*EffectIndexAction)(nil)
 
 // EffectIndexAction renders a page of effect resources, identified by

--- a/services/horizon/internal/actions_ledger.go
+++ b/services/horizon/internal/actions_ledger.go
@@ -18,7 +18,7 @@ import (
 // LedgerShowAction: single ledger by sequence
 
 // Interface verifications
-var _ actions.JSON = (*LedgerIndexAction)(nil)
+var _ actions.JSONer = (*LedgerIndexAction)(nil)
 var _ actions.SSE = (*LedgerIndexAction)(nil)
 
 // LedgerIndexAction renders a page of ledger resources, identified by
@@ -90,7 +90,7 @@ func (action *LedgerIndexAction) loadPage() {
 }
 
 // Interface verification
-var _ actions.JSON = (*LedgerShowAction)(nil)
+var _ actions.JSONer = (*LedgerShowAction)(nil)
 
 // LedgerShowAction renders a ledger found by its sequence number.
 type LedgerShowAction struct {

--- a/services/horizon/internal/actions_ledger.go
+++ b/services/horizon/internal/actions_ledger.go
@@ -19,7 +19,7 @@ import (
 
 // Interface verifications
 var _ actions.JSONer = (*LedgerIndexAction)(nil)
-var _ actions.SSE = (*LedgerIndexAction)(nil)
+var _ actions.EventStreamer = (*LedgerIndexAction)(nil)
 
 // LedgerIndexAction renders a page of ledger resources, identified by
 // a normal page query.

--- a/services/horizon/internal/actions_ledger.go
+++ b/services/horizon/internal/actions_ledger.go
@@ -18,6 +18,7 @@ import (
 // LedgerShowAction: single ledger by sequence
 
 // Interface verifications
+var _ actions.JSON = (*LedgerIndexAction)(nil)
 var _ actions.SSE = (*LedgerIndexAction)(nil)
 
 // LedgerIndexAction renders a page of ledger resources, identified by
@@ -30,7 +31,7 @@ type LedgerIndexAction struct {
 }
 
 // JSON is a method for actions.JSON
-func (action *LedgerIndexAction) JSON() {
+func (action *LedgerIndexAction) JSON() error {
 	action.Do(
 		action.EnsureHistoryFreshness,
 		action.loadParams,
@@ -39,6 +40,7 @@ func (action *LedgerIndexAction) JSON() {
 		action.loadPage,
 		func() { hal.Render(action.W, action.Page) },
 	)
+	return action.Err
 }
 
 // SSE is a method for actions.SSE
@@ -53,7 +55,6 @@ func (action *LedgerIndexAction) SSE(stream *sse.Stream) error {
 		func() {
 			stream.SetLimit(int(action.PagingParams.Limit))
 			records := action.Records[stream.SentCount():]
-
 			for _, record := range records {
 				var res horizon.Ledger
 				resourceadapter.PopulateLedger(action.R.Context(), &res, record)
@@ -71,9 +72,7 @@ func (action *LedgerIndexAction) loadParams() {
 }
 
 func (action *LedgerIndexAction) loadRecords() {
-	action.Err = action.HistoryQ().Ledgers().
-		Page(action.PagingParams).
-		Select(&action.Records)
+	action.Err = action.HistoryQ().Ledgers().Page(action.PagingParams).Select(&action.Records)
 }
 
 func (action *LedgerIndexAction) loadPage() {
@@ -90,6 +89,9 @@ func (action *LedgerIndexAction) loadPage() {
 	action.Page.PopulateLinks()
 }
 
+// Interface verification
+var _ actions.JSON = (*LedgerShowAction)(nil)
+
 // LedgerShowAction renders a ledger found by its sequence number.
 type LedgerShowAction struct {
 	Action
@@ -98,7 +100,7 @@ type LedgerShowAction struct {
 }
 
 // JSON is a method for actions.JSON
-func (action *LedgerShowAction) JSON() {
+func (action *LedgerShowAction) JSON() error {
 	action.Do(
 		action.EnsureHistoryFreshness,
 		action.loadParams,
@@ -110,6 +112,7 @@ func (action *LedgerShowAction) JSON() {
 			hal.Render(action.W, res)
 		},
 	)
+	return action.Err
 }
 
 func (action *LedgerShowAction) loadParams() {
@@ -117,8 +120,7 @@ func (action *LedgerShowAction) loadParams() {
 }
 
 func (action *LedgerShowAction) loadRecord() {
-	action.Err = action.HistoryQ().
-		LedgerBySequence(&action.Record, action.Sequence)
+	action.Err = action.HistoryQ().LedgerBySequence(&action.Record, action.Sequence)
 }
 
 func (action *LedgerShowAction) verifyWithinHistory() {

--- a/services/horizon/internal/actions_metrics.go
+++ b/services/horizon/internal/actions_metrics.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Interface verification
-var _ actions.JSON = (*MetricsAction)(nil)
+var _ actions.JSONer = (*MetricsAction)(nil)
 
 // MetricsAction collects and renders a snapshot from the metrics system that
 // will inlude any previously registered metrics.

--- a/services/horizon/internal/actions_metrics.go
+++ b/services/horizon/internal/actions_metrics.go
@@ -1,9 +1,13 @@
 package horizon
 
 import (
-	"github.com/rcrowley/go-metrics"
+	metrics "github.com/rcrowley/go-metrics"
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/support/render/hal"
 )
+
+// Interface verification
+var _ actions.JSON = (*MetricsAction)(nil)
 
 // MetricsAction collects and renders a snapshot from the metrics system that
 // will inlude any previously registered metrics.
@@ -13,20 +17,20 @@ type MetricsAction struct {
 }
 
 // JSON is a method for actions.JSON
-func (action *MetricsAction) JSON() {
+func (action *MetricsAction) JSON() error {
 	action.LoadSnapshot()
 	action.Snapshot["_links"] = map[string]interface{}{
 		"self": hal.NewLink("/metrics"),
 	}
 
 	hal.Render(action.W, action.Snapshot)
+	return action.Err
 }
 
 // LoadSnapshot populates action.Snapshot
 //
 // Original code copied from github.com/rcrowley/go-metrics MarshalJSON
 func (action *MetricsAction) LoadSnapshot() {
-
 	action.Snapshot = make(map[string]interface{})
 
 	action.App.metrics.Each(func(name string, i interface{}) {
@@ -84,5 +88,4 @@ func (action *MetricsAction) LoadSnapshot() {
 		}
 		action.Snapshot[name] = values
 	})
-
 }

--- a/services/horizon/internal/actions_not_found.go
+++ b/services/horizon/internal/actions_not_found.go
@@ -1,8 +1,12 @@
 package horizon
 
 import (
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/support/render/problem"
 )
+
+// Interface verification
+var _ actions.JSON = (*NotFoundAction)(nil)
 
 // NotFoundAction renders a 404 response
 type NotFoundAction struct {
@@ -10,6 +14,7 @@ type NotFoundAction struct {
 }
 
 // JSON is a method for actions.JSON
-func (action *NotFoundAction) JSON() {
+func (action *NotFoundAction) JSON() error {
 	problem.Render(action.R.Context(), action.W, problem.NotFound)
+	return action.Err
 }

--- a/services/horizon/internal/actions_not_found.go
+++ b/services/horizon/internal/actions_not_found.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Interface verification
-var _ actions.JSON = (*NotFoundAction)(nil)
+var _ actions.JSONer = (*NotFoundAction)(nil)
 
 // NotFoundAction renders a 404 response
 type NotFoundAction struct {

--- a/services/horizon/internal/actions_not_implemented.go
+++ b/services/horizon/internal/actions_not_implemented.go
@@ -1,9 +1,13 @@
 package horizon
 
 import (
+	"github.com/stellar/go/services/horizon/internal/actions"
 	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/support/render/problem"
 )
+
+// Interface verification
+var _ actions.JSON = (*NotImplementedAction)(nil)
 
 // NotImplementedAction renders a NotImplemented prblem
 type NotImplementedAction struct {
@@ -11,6 +15,7 @@ type NotImplementedAction struct {
 }
 
 // JSON is a method for actions.JSON
-func (action *NotImplementedAction) JSON() {
+func (action *NotImplementedAction) JSON() error {
 	problem.Render(action.R.Context(), action.W, hProblem.NotImplemented)
+	return action.Err
 }

--- a/services/horizon/internal/actions_not_implemented.go
+++ b/services/horizon/internal/actions_not_implemented.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Interface verification
-var _ actions.JSON = (*NotImplementedAction)(nil)
+var _ actions.JSONer = (*NotImplementedAction)(nil)
 
 // NotImplementedAction renders a NotImplemented prblem
 type NotImplementedAction struct {

--- a/services/horizon/internal/actions_offer.go
+++ b/services/horizon/internal/actions_offer.go
@@ -14,7 +14,7 @@ import (
 // This file contains the actions:
 
 // Interface verifications
-var _ actions.JSON = (*OffersByAccountAction)(nil)
+var _ actions.JSONer = (*OffersByAccountAction)(nil)
 var _ actions.SSE = (*OffersByAccountAction)(nil)
 
 // OffersByAccountAction renders a page of offer resources, for a given

--- a/services/horizon/internal/actions_offer.go
+++ b/services/horizon/internal/actions_offer.go
@@ -14,6 +14,7 @@ import (
 // This file contains the actions:
 
 // Interface verifications
+var _ actions.JSON = (*OffersByAccountAction)(nil)
 var _ actions.SSE = (*OffersByAccountAction)(nil)
 
 // OffersByAccountAction renders a page of offer resources, for a given
@@ -29,16 +30,15 @@ type OffersByAccountAction struct {
 }
 
 // JSON is a method for actions.JSON
-func (action *OffersByAccountAction) JSON() {
+func (action *OffersByAccountAction) JSON() error {
 	action.Do(
 		action.loadParams,
 		action.loadRecords,
 		action.loadLedgers,
 		action.loadPage,
-		func() {
-			hal.Render(action.W, action.Page)
-		},
+		func() { hal.Render(action.W, action.Page) },
 	)
+	return action.Err
 }
 
 // SSE is a method for actions.SSE

--- a/services/horizon/internal/actions_offer.go
+++ b/services/horizon/internal/actions_offer.go
@@ -15,7 +15,7 @@ import (
 
 // Interface verifications
 var _ actions.JSONer = (*OffersByAccountAction)(nil)
-var _ actions.SSE = (*OffersByAccountAction)(nil)
+var _ actions.EventStreamer = (*OffersByAccountAction)(nil)
 
 // OffersByAccountAction renders a page of offer resources, for a given
 // account.  These offers are present in the ledger as of the latest validated

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -21,7 +21,7 @@ import (
 // OperationShowAction: single operation by id
 
 // Interface verifications
-var _ actions.JSON = (*OperationIndexAction)(nil)
+var _ actions.JSONer = (*OperationIndexAction)(nil)
 var _ actions.SSE = (*OperationIndexAction)(nil)
 
 // OperationIndexAction renders a page of operations resources, identified by
@@ -147,7 +147,7 @@ func (action *OperationIndexAction) loadPage() {
 }
 
 // Interface verification
-var _ actions.JSON = (*OperationShowAction)(nil)
+var _ actions.JSONer = (*OperationShowAction)(nil)
 
 // OperationShowAction renders a ledger found by its sequence number.
 type OperationShowAction struct {

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -22,7 +22,7 @@ import (
 
 // Interface verifications
 var _ actions.JSONer = (*OperationIndexAction)(nil)
-var _ actions.SSE = (*OperationIndexAction)(nil)
+var _ actions.EventStreamer = (*OperationIndexAction)(nil)
 
 // OperationIndexAction renders a page of operations resources, identified by
 // a normal page query and optionally filtered by an account, ledger, or

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -21,6 +21,7 @@ import (
 // OperationShowAction: single operation by id
 
 // Interface verifications
+var _ actions.JSON = (*OperationIndexAction)(nil)
 var _ actions.SSE = (*OperationIndexAction)(nil)
 
 // OperationIndexAction renders a page of operations resources, identified by
@@ -38,17 +39,17 @@ type OperationIndexAction struct {
 }
 
 // JSON is a method for actions.JSON
-func (action *OperationIndexAction) JSON() {
+func (action *OperationIndexAction) JSON() error {
 	action.Do(
 		action.EnsureHistoryFreshness,
 		action.loadParams,
 		action.ValidateCursorWithinHistory,
 		action.loadRecords,
 		action.loadLedgers,
-		action.loadPage)
-	action.Do(func() {
-		hal.Render(action.W, action.Page)
-	})
+		action.loadPage,
+		func() { hal.Render(action.W, action.Page) },
+	)
+	return action.Err
 }
 
 // SSE is a method for actions.SSE
@@ -64,7 +65,6 @@ func (action *OperationIndexAction) SSE(stream *sse.Stream) error {
 		func() {
 			stream.SetLimit(int(action.PagingParams.Limit))
 			records := action.Records[stream.SentCount():]
-
 			for _, record := range records {
 				ledger, found := action.Ledgers.Records[record.LedgerSequence()]
 				if !found {
@@ -116,17 +116,14 @@ func (action *OperationIndexAction) loadRecords() {
 // loadLedgers populates the ledger cache for this action
 func (action *OperationIndexAction) loadLedgers() {
 	action.Ledgers = &history.LedgerCache{}
-
 	for _, op := range action.Records {
 		action.Ledgers.Queue(op.LedgerSequence())
 	}
-
 	action.Err = action.Ledgers.Load(action.HistoryQ())
 }
 
 func (action *OperationIndexAction) loadPage() {
 	for _, record := range action.Records {
-
 		ledger, found := action.Ledgers.Records[record.LedgerSequence()]
 		if !found {
 			msg := fmt.Sprintf("could not find ledger data for sequence %d", record.LedgerSequence())
@@ -148,6 +145,9 @@ func (action *OperationIndexAction) loadPage() {
 	action.Page.Order = action.PagingParams.Order
 	action.Page.PopulateLinks()
 }
+
+// Interface verification
+var _ actions.JSON = (*OperationShowAction)(nil)
 
 // OperationShowAction renders a ledger found by its sequence number.
 type OperationShowAction struct {
@@ -175,7 +175,7 @@ func (action *OperationShowAction) loadResource() {
 }
 
 // JSON is a method for actions.JSON
-func (action *OperationShowAction) JSON() {
+func (action *OperationShowAction) JSON() error {
 	action.Do(
 		action.EnsureHistoryFreshness,
 		action.loadParams,
@@ -183,10 +183,9 @@ func (action *OperationShowAction) JSON() {
 		action.loadRecord,
 		action.loadLedger,
 		action.loadResource,
+		func() { hal.Render(action.W, action.Resource) },
 	)
-	action.Do(func() {
-		hal.Render(action.W, action.Resource)
-	})
+	return action.Err
 }
 
 func (action *OperationShowAction) verifyWithinHistory() {

--- a/services/horizon/internal/actions_operation_fee_stats.go
+++ b/services/horizon/internal/actions_operation_fee_stats.go
@@ -3,6 +3,7 @@ package horizon
 import (
 	"fmt"
 
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/operationfeestats"
 	"github.com/stellar/go/support/render/hal"
 )
@@ -10,6 +11,8 @@ import (
 // This file contains the actions:
 //
 // OperationFeeStatsAction: stats representing current state of network fees
+
+var _ actions.JSON = (*OperationFeeStatsAction)(nil)
 
 // OperationFeeStatsAction renders a few useful statistics that describe the
 // current state of operation fees on the network.
@@ -22,7 +25,7 @@ type OperationFeeStatsAction struct {
 }
 
 // JSON is a method for actions.JSON
-func (action *OperationFeeStatsAction) JSON() {
+func (action *OperationFeeStatsAction) JSON() error {
 	action.Do(
 		action.loadRecords,
 		func() {
@@ -34,11 +37,11 @@ func (action *OperationFeeStatsAction) JSON() {
 			})
 		},
 	)
+	return action.Err
 }
 
 func (action *OperationFeeStatsAction) loadRecords() {
 	cur := operationfeestats.CurrentState()
-
 	action.Min = cur.Min
 	action.Mode = cur.Mode
 	action.LastBaseFee = cur.LastBaseFee

--- a/services/horizon/internal/actions_operation_fee_stats.go
+++ b/services/horizon/internal/actions_operation_fee_stats.go
@@ -12,7 +12,7 @@ import (
 //
 // OperationFeeStatsAction: stats representing current state of network fees
 
-var _ actions.JSON = (*OperationFeeStatsAction)(nil)
+var _ actions.JSONer = (*OperationFeeStatsAction)(nil)
 
 // OperationFeeStatsAction renders a few useful statistics that describe the
 // current state of operation fees on the network.

--- a/services/horizon/internal/actions_order_book.go
+++ b/services/horizon/internal/actions_order_book.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Interface verifications
-var _ actions.JSON = (*OrderBookShowAction)(nil)
+var _ actions.JSONer = (*OrderBookShowAction)(nil)
 var _ actions.SingleObjectStreamer = (*OrderBookShowAction)(nil)
 
 // OrderBookShowAction renders a account summary found by its address.

--- a/services/horizon/internal/actions_order_book.go
+++ b/services/horizon/internal/actions_order_book.go
@@ -14,6 +14,7 @@ import (
 )
 
 // Interface verifications
+var _ actions.JSON = (*OrderBookShowAction)(nil)
 var _ actions.SingleObjectStreamer = (*OrderBookShowAction)(nil)
 
 // OrderBookShowAction renders a account summary found by its address.
@@ -68,12 +69,14 @@ func (action *OrderBookShowAction) LoadResource() {
 }
 
 // JSON is a method for actions.JSON
-func (action *OrderBookShowAction) JSON() {
-	action.Do(action.LoadQuery, action.LoadRecord, action.LoadResource)
-
-	action.Do(func() {
-		hal.Render(action.W, action.Resource)
-	})
+func (action *OrderBookShowAction) JSON() error {
+	action.Do(
+		action.LoadQuery,
+		action.LoadRecord,
+		action.LoadResource,
+		func() { hal.Render(action.W, action.Resource) },
+	)
+	return action.Err
 }
 
 func (action *OrderBookShowAction) LoadEvent() (sse.Event, error) {

--- a/services/horizon/internal/actions_path.go
+++ b/services/horizon/internal/actions_path.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Interface verification
-var _ actions.JSON = (*PathIndexAction)(nil)
+var _ actions.JSONer = (*PathIndexAction)(nil)
 
 // PathIndexAction provides path finding
 type PathIndexAction struct {

--- a/services/horizon/internal/actions_path.go
+++ b/services/horizon/internal/actions_path.go
@@ -8,6 +8,9 @@ import (
 	"github.com/stellar/go/support/render/hal"
 )
 
+// Interface verification
+var _ actions.JSON = (*PathIndexAction)(nil)
+
 // PathIndexAction provides path finding
 type PathIndexAction struct {
 	Action
@@ -17,16 +20,15 @@ type PathIndexAction struct {
 }
 
 // JSON implements actions.JSON
-func (action *PathIndexAction) JSON() {
+func (action *PathIndexAction) JSON() error {
 	action.Do(
 		action.loadQuery,
 		action.loadSourceAssets,
 		action.loadRecords,
 		action.loadPage,
-		func() {
-			hal.Render(action.W, action.Page)
-		},
+		func() { hal.Render(action.W, action.Page) },
 	)
+	return action.Err
 }
 
 func (action *PathIndexAction) loadQuery() {

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -13,6 +13,7 @@ import (
 )
 
 // Interface verifications
+var _ actions.JSON = (*PaymentsIndexAction)(nil)
 var _ actions.SSE = (*PaymentsIndexAction)(nil)
 
 // PaymentsIndexAction returns a paged slice of payments based upon the provided
@@ -29,7 +30,7 @@ type PaymentsIndexAction struct {
 }
 
 // JSON is a method for actions.JSON
-func (action *PaymentsIndexAction) JSON() {
+func (action *PaymentsIndexAction) JSON() error {
 	action.Do(
 		action.EnsureHistoryFreshness,
 		action.loadParams,
@@ -37,10 +38,9 @@ func (action *PaymentsIndexAction) JSON() {
 		action.loadRecords,
 		action.loadLedgers,
 		action.loadPage,
+		func() { hal.Render(action.W, action.Page) },
 	)
-	action.Do(func() {
-		hal.Render(action.W, action.Page)
-	})
+	return action.Err
 }
 
 // SSE is a method for actions.SSE

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -14,7 +14,7 @@ import (
 
 // Interface verifications
 var _ actions.JSONer = (*PaymentsIndexAction)(nil)
-var _ actions.SSE = (*PaymentsIndexAction)(nil)
+var _ actions.EventStreamer = (*PaymentsIndexAction)(nil)
 
 // PaymentsIndexAction returns a paged slice of payments based upon the provided
 // filters

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Interface verifications
-var _ actions.JSON = (*PaymentsIndexAction)(nil)
+var _ actions.JSONer = (*PaymentsIndexAction)(nil)
 var _ actions.SSE = (*PaymentsIndexAction)(nil)
 
 // PaymentsIndexAction returns a paged slice of payments based upon the provided

--- a/services/horizon/internal/actions_root.go
+++ b/services/horizon/internal/actions_root.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Interface verification
-var _ actions.JSON = (*RootAction)(nil)
+var _ actions.JSONer = (*RootAction)(nil)
 
 // RootAction provides a summary of the horizon instance and links to various
 // useful endpoints

--- a/services/horizon/internal/actions_root.go
+++ b/services/horizon/internal/actions_root.go
@@ -2,10 +2,14 @@ package horizon
 
 import (
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 	"github.com/stellar/go/support/render/hal"
 )
+
+// Interface verification
+var _ actions.JSON = (*RootAction)(nil)
 
 // RootAction provides a summary of the horizon instance and links to various
 // useful endpoints
@@ -14,7 +18,7 @@ type RootAction struct {
 }
 
 // JSON renders the json response for RootAction
-func (action *RootAction) JSON() {
+func (action *RootAction) JSON() error {
 	var res horizon.Root
 	resourceadapter.PopulateRoot(
 		action.R.Context(),
@@ -29,4 +33,5 @@ func (action *RootAction) JSON() {
 	)
 
 	hal.Render(action.W, res)
+	return action.Err
 }

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Interface verifications
-var _ actions.JSON = (*TradeIndexAction)(nil)
+var _ actions.JSONer = (*TradeIndexAction)(nil)
 var _ actions.SSE = (*TradeIndexAction)(nil)
 
 type TradeIndexAction struct {
@@ -138,7 +138,7 @@ func (action *TradeIndexAction) loadPage() {
 }
 
 // Interface verification
-var _ actions.JSON = (*TradeAggregateIndexAction)(nil)
+var _ actions.JSONer = (*TradeAggregateIndexAction)(nil)
 
 type TradeAggregateIndexAction struct {
 	Action

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -17,6 +17,7 @@ import (
 )
 
 // Interface verifications
+var _ actions.JSON = (*TradeIndexAction)(nil)
 var _ actions.SSE = (*TradeIndexAction)(nil)
 
 type TradeIndexAction struct {
@@ -33,16 +34,15 @@ type TradeIndexAction struct {
 }
 
 // JSON is a method for actions.JSON
-func (action *TradeIndexAction) JSON() {
+func (action *TradeIndexAction) JSON() error {
 	action.Do(
 		action.EnsureHistoryFreshness,
 		action.loadParams,
 		action.loadRecords,
 		action.loadPage,
-		func() {
-			hal.Render(action.W, action.Page)
-		},
+		func() { hal.Render(action.W, action.Page) },
 	)
+	return action.Err
 }
 
 // SSE is a method for actions.SSE
@@ -137,6 +137,9 @@ func (action *TradeIndexAction) loadPage() {
 	action.Page.PopulateLinks()
 }
 
+// Interface verification
+var _ actions.JSON = (*TradeAggregateIndexAction)(nil)
+
 type TradeAggregateIndexAction struct {
 	Action
 	BaseAssetFilter    xdr.Asset
@@ -151,16 +154,15 @@ type TradeAggregateIndexAction struct {
 }
 
 // JSON is a method for actions.JSON
-func (action *TradeAggregateIndexAction) JSON() {
+func (action *TradeAggregateIndexAction) JSON() error {
 	action.Do(
 		action.EnsureHistoryFreshness,
 		action.loadParams,
 		action.loadRecords,
 		action.loadPage,
-		func() {
-			hal.Render(action.W, action.Page)
-		},
+		func() { hal.Render(action.W, action.Page) },
 	)
+	return action.Err
 }
 
 func (action *TradeAggregateIndexAction) loadParams() {
@@ -208,7 +210,6 @@ func (action *TradeAggregateIndexAction) loadRecords() {
 	//initialize the query builder with required params
 	tradeAggregationsQ, err := historyQ.GetTradeAggregationsQ(
 		baseAssetId, counterAssetId, action.ResolutionFilter, action.OffsetFilter, action.PagingParams)
-
 	if err != nil {
 		action.Err = err
 		return
@@ -241,7 +242,6 @@ func (action *TradeAggregateIndexAction) loadPage() {
 		var res horizon.TradeAggregation
 
 		action.Err = resourceadapter.PopulateTradeAggregation(action.R.Context(), &res, record)
-
 		if action.Err != nil {
 			return
 		}

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -18,7 +18,7 @@ import (
 
 // Interface verifications
 var _ actions.JSONer = (*TradeIndexAction)(nil)
-var _ actions.SSE = (*TradeIndexAction)(nil)
+var _ actions.EventStreamer = (*TradeIndexAction)(nil)
 
 type TradeIndexAction struct {
 	Action

--- a/services/horizon/internal/actions_transaction.go
+++ b/services/horizon/internal/actions_transaction.go
@@ -21,7 +21,7 @@ import (
 // TransactionShowAction: single transaction by sequence, by hash or id
 
 // Interface verifications
-var _ actions.JSON = (*TransactionIndexAction)(nil)
+var _ actions.JSONer = (*TransactionIndexAction)(nil)
 var _ actions.SSE = (*TransactionIndexAction)(nil)
 
 // TransactionIndexAction renders a page of ledger resources, identified by
@@ -108,7 +108,7 @@ func (action *TransactionIndexAction) loadPage() {
 }
 
 // Interface verification
-var _ actions.JSON = (*TransactionShowAction)(nil)
+var _ actions.JSONer = (*TransactionShowAction)(nil)
 
 // TransactionShowAction renders a ledger found by its sequence number.
 type TransactionShowAction struct {
@@ -143,7 +143,7 @@ func (action *TransactionShowAction) JSON() error {
 }
 
 // Interface verification
-var _ actions.JSON = (*TransactionCreateAction)(nil)
+var _ actions.JSONer = (*TransactionCreateAction)(nil)
 
 // TransactionCreateAction submits a transaction to the stellar-core network
 // on behalf of the requesting client.

--- a/services/horizon/internal/actions_transaction.go
+++ b/services/horizon/internal/actions_transaction.go
@@ -22,7 +22,7 @@ import (
 
 // Interface verifications
 var _ actions.JSONer = (*TransactionIndexAction)(nil)
-var _ actions.SSE = (*TransactionIndexAction)(nil)
+var _ actions.EventStreamer = (*TransactionIndexAction)(nil)
 
 // TransactionIndexAction renders a page of ledger resources, identified by
 // a normal page query.

--- a/services/horizon/internal/actions_transaction.go
+++ b/services/horizon/internal/actions_transaction.go
@@ -21,6 +21,7 @@ import (
 // TransactionShowAction: single transaction by sequence, by hash or id
 
 // Interface verifications
+var _ actions.JSON = (*TransactionIndexAction)(nil)
 var _ actions.SSE = (*TransactionIndexAction)(nil)
 
 // TransactionIndexAction renders a page of ledger resources, identified by
@@ -35,17 +36,16 @@ type TransactionIndexAction struct {
 }
 
 // JSON is a method for actions.JSON
-func (action *TransactionIndexAction) JSON() {
+func (action *TransactionIndexAction) JSON() error {
 	action.Do(
 		action.EnsureHistoryFreshness,
 		action.loadParams,
 		action.ValidateCursorWithinHistory,
 		action.loadRecords,
 		action.loadPage,
-		func() {
-			hal.Render(action.W, action.Page)
-		},
+		func() { hal.Render(action.W, action.Page) },
 	)
+	return action.Err
 }
 
 // SSE is a method for actions.SSE
@@ -107,6 +107,9 @@ func (action *TransactionIndexAction) loadPage() {
 	action.Page.PopulateLinks()
 }
 
+// Interface verification
+var _ actions.JSON = (*TransactionShowAction)(nil)
+
 // TransactionShowAction renders a ledger found by its sequence number.
 type TransactionShowAction struct {
 	Action
@@ -128,7 +131,7 @@ func (action *TransactionShowAction) loadResource() {
 }
 
 // JSON is a method for actions.JSON
-func (action *TransactionShowAction) JSON() {
+func (action *TransactionShowAction) JSON() error {
 	action.Do(
 		action.EnsureHistoryFreshness,
 		action.loadParams,
@@ -136,7 +139,11 @@ func (action *TransactionShowAction) JSON() {
 		action.loadResource,
 		func() { hal.Render(action.W, action.Resource) },
 	)
+	return action.Err
 }
+
+// Interface verification
+var _ actions.JSON = (*TransactionCreateAction)(nil)
 
 // TransactionCreateAction submits a transaction to the stellar-core network
 // on behalf of the requesting client.
@@ -148,15 +155,14 @@ type TransactionCreateAction struct {
 }
 
 // JSON format action handler
-func (action *TransactionCreateAction) JSON() {
+func (action *TransactionCreateAction) JSON() error {
 	action.Do(
 		action.loadTX,
 		action.loadResult,
 		action.loadResource,
-
-		func() {
-			hal.Render(action.W, action.Resource)
-		})
+		func() { hal.Render(action.W, action.Resource) },
+	)
+	return action.Err
 }
 
 func (action *TransactionCreateAction) loadTX() {

--- a/services/horizon/internal/render/sse/stream_test.go
+++ b/services/horizon/internal/render/sse/stream_test.go
@@ -61,7 +61,7 @@ func (suite *StreamTestSuite) TestStream_Err() {
 	suite.stream.Err(err)
 	suite.checkHeadersAndPreamble()
 
-	// Reset the tream to test the scenario where an event has been sent.
+	// Reset the stream to test the scenario where an event has been sent.
 	suite.w = httptest.NewRecorder()
 	suite.stream = NewStream(suite.ctx, suite.w)
 	suite.stream.sent++

--- a/support/render/hal/main.go
+++ b/support/render/hal/main.go
@@ -17,7 +17,6 @@ func RenderToString(data interface{}, pretty bool) ([]byte, error) {
 // Render write data to w, after marshalling to json
 func Render(w http.ResponseWriter, data interface{}) {
 	js, err := RenderToString(data, true)
-
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
This PR does the following:
1. Renames `JSON`, `Raw`, and `SSE` responder to `JSONer`, `RawDataResponder`, and `EventStreamer` respectively.
2. Has JSON() and Raw() return an error
3. Adds the corresponding interface verifications

Close #870 