### PR TITLE
WIP clients/horizon: redesign

### DIFF
--- a/clients/horizon/account_call_builder.go
+++ b/clients/horizon/account_call_builder.go
@@ -1,0 +1,42 @@
+package horizon
+
+func (ac *AccountCallBuilder) LoadAccount(accountID string) (Account, error) {
+
+	ac.addEndpoint("/accounts/" + accountID)
+
+	resp, err := ac.Call()
+	if err != nil {
+		return Account{}, err
+	}
+
+	// fmt.Print("resp b4 type assert: ", resp)
+
+	// acc, ok := resp.(Account)
+	// if !ok {
+	// 	return Account{}, errors.New("could not assert type")
+	// }
+
+	return resp, nil
+
+}
+
+func (ac *AccountCallBuilder) Call() (acc Account, err error) {
+
+	endpoint, err := ac.buildUrl()
+	if err != nil {
+		return acc, err
+	}
+
+	resp, err := ac.HTTP.Get(endpoint)
+	if err != nil {
+		return acc, err
+	}
+
+	err = decodeResponse(resp, &acc)
+	if err != nil {
+		return acc, err
+	}
+
+	return acc, nil
+
+}

--- a/clients/horizon/call_builder.go
+++ b/clients/horizon/call_builder.go
@@ -1,0 +1,72 @@
+package horizon
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/poliha/go/support/errors"
+)
+
+func (c *CallBuilder) Call() (interface{}, error) {
+
+	endpoint, err := c.buildUrl()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.HTTP.Get(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	err = decodeResponse(resp, &c.HorizonResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.HorizonResponse, nil
+
+}
+
+func (c *CallBuilder) fixURL() {
+	c.URL = strings.TrimRight(c.URL, "/")
+}
+
+func (c *CallBuilder) addEndpoint(endpoint string) {
+	c.endpoint = endpoint
+}
+
+func (c *CallBuilder) addParam(key string, value string) {
+	c.params[key] = value
+}
+
+func (c *CallBuilder) Cursor(cursor string) {
+	c.addParam("cursor", cursor)
+}
+
+func (c *CallBuilder) buildUrl() (endpoint string, err error) {
+	endpoint = ""
+	query := url.Values{}
+
+	for key, val := range c.params {
+		query.Add(key, val)
+	}
+	c.fixURLOnce.Do(c.fixURL)
+	if endpoint == "" {
+		endpoint = fmt.Sprintf(
+			"%s%s?%s",
+			c.URL,
+			c.endpoint,
+			query.Encode(),
+		)
+	}
+
+	_, err = url.Parse(endpoint)
+	if err != nil {
+		err = errors.Wrap(err, "failed to parse endpoint")
+	}
+
+	return endpoint, err
+
+}

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -140,3 +140,43 @@ var _ build.SequenceProvider = &Client{}
 
 // ensure that the horizon client implements ClientInterface
 var _ ClientInterface = &Client{}
+
+// ClientX is an experimental horizon client that uses call builder pattern
+type ClientX struct {
+	// URL of Horizon server to connect
+	URL string
+	*AccountCallBuilder
+}
+
+type CallBuilder struct {
+	URL             string
+	HTTP            HTTP
+	endpoint        string
+	params          map[string]string
+	fixURLOnce      sync.Once
+	HorizonResponse interface{}
+}
+
+type CallBuilderInterface interface {
+	addEndpoint(endpoint string)
+	addParam(key string, value string)
+	buildUrl()
+	Call() (interface{}, error)
+	Cursor(cursor string)
+}
+
+type AccountCallBuilder struct {
+	*CallBuilder
+}
+
+type OperationCallBuilder struct {
+	*CallBuilder
+}
+
+type AccountCallBuilderInterface interface {
+	LoadAccount(accountID string) (interface{}, error)
+}
+
+type OperationCallBuilderInterface interface {
+	ForId(operationID string) (interface{}, error)
+}

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -146,6 +146,7 @@ type ClientX struct {
 	// URL of Horizon server to connect
 	URL string
 	*AccountCallBuilder
+	*OperationCallBuilder
 }
 
 type CallBuilder struct {

--- a/clients/horizon/main_test.go
+++ b/clients/horizon/main_test.go
@@ -57,6 +57,65 @@ func ExampleClient_SubmitTransaction() {
 	fmt.Println(response)
 }
 
+func TestClientXLoadAccount(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &ClientX{
+		URL: "https://localhost",
+		AccountCallBuilder: &AccountCallBuilder{
+			CallBuilder: &CallBuilder{
+				URL: "https://localhost", HTTP: hmock},
+		},
+	}
+
+	// happy path
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+	).ReturnString(200, accountResponse)
+
+	account, err := client.LoadAccount("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+
+	// log.Print(account)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, account.ID, "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+		assert.Equal(t, account.PT, "1")
+		assert.Equal(t, account.Signers[0].Key, "XBT5HNPK6DAL6222MAWTLHNOZSDKPJ2AKNEQ5Q324CHHCNQFQ7EHBHZN")
+		assert.Equal(t, account.Signers[0].Type, "sha256_hash")
+		assert.Equal(t, account.Data["test"], "R0NCVkwzU1FGRVZLUkxQNkFKNDdVS0tXWUVCWTQ1V0hBSkhDRVpLVldNVEdNQ1Q0SDROS1FZTEg=")
+		balance, err := account.GetNativeBalance()
+		assert.Nil(t, err)
+		assert.Equal(t, balance, "948522307.6146000")
+	}
+
+	// failure response
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+	).ReturnString(404, notFoundResponse)
+
+	_, err = client.LoadAccount("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Horizon error")
+		horizonError, ok := err.(*Error)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, horizonError.Problem.Title, "Resource Missing")
+	}
+
+	// connection error
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+	).ReturnError("http.Client error")
+
+	_, err = client.LoadAccount("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "http.Client error")
+		_, ok := err.(*Error)
+		assert.Equal(t, ok, false)
+	}
+}
+
 func TestLoadAccount(t *testing.T) {
 	hmock := httptest.NewClient()
 	client := &Client{

--- a/clients/horizon/main_test.go
+++ b/clients/horizon/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"testing"
 	"time"
 
@@ -57,9 +58,36 @@ func ExampleClient_SubmitTransaction() {
 	fmt.Println(response)
 }
 
+func TestClientXLoadOperation(t *testing.T) {
+	hmock := httptest.NewClient()
+	clientx := &ClientX{
+		URL: "https://localhost",
+		OperationCallBuilder: &OperationCallBuilder{
+			CallBuilder: &CallBuilder{
+				URL: "https://localhost", HTTP: hmock},
+		},
+	}
+
+	// payment operation
+	hmock.On(
+		"GET",
+		"https://localhost/operations/96422947803136001",
+	).ReturnString(200, paymentResponse)
+
+	clientx.OperationCallBuilder.ForId("96422947803136001")
+	operation, err := clientx.OperationCallBuilder.Call()
+	if err != nil {
+		log.Print("op err: ", err)
+	}
+	// to do:
+	// assert types based on operation types?
+	log.Print(operation)
+
+}
+
 func TestClientXLoadAccount(t *testing.T) {
 	hmock := httptest.NewClient()
-	client := &ClientX{
+	clientx := &ClientX{
 		URL: "https://localhost",
 		AccountCallBuilder: &AccountCallBuilder{
 			CallBuilder: &CallBuilder{
@@ -73,7 +101,7 @@ func TestClientXLoadAccount(t *testing.T) {
 		"https://localhost/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 	).ReturnString(200, accountResponse)
 
-	account, err := client.LoadAccount("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	account, err := clientx.LoadAccount("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
 
 	// log.Print(account)
 
@@ -94,7 +122,7 @@ func TestClientXLoadAccount(t *testing.T) {
 		"https://localhost/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 	).ReturnString(404, notFoundResponse)
 
-	_, err = client.LoadAccount("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	_, err = clientx.LoadAccount("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "Horizon error")
 		horizonError, ok := err.(*Error)
@@ -108,7 +136,7 @@ func TestClientXLoadAccount(t *testing.T) {
 		"https://localhost/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 	).ReturnError("http.Client error")
 
-	_, err = client.LoadAccount("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	_, err = clientx.LoadAccount("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "http.Client error")
 		_, ok := err.(*Error)
@@ -1183,4 +1211,35 @@ var internalServerError = `{
   "status":   500,
   "details":  "Horizon unavailible",
   "instance": "d3465740-ec3a-4a0b-9d4a-c9ea734ce58a"
+}`
+
+var paymentResponse = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon.stellar.org/operations/96422947803136001"
+    },
+    "transaction": {
+      "href": "https://horizon.stellar.org/transactions/618cac7ae4a9ab4d4e1791ed281044527295a1181bd9723270deb8062f7e19ab"
+    },
+    "effects": {
+      "href": "https://horizon.stellar.org/operations/96422947803136001/effects"
+    },
+    "succeeds": {
+      "href": "https://horizon.stellar.org/effects?order=desc&cursor=96422947803136001"
+    },
+    "precedes": {
+      "href": "https://horizon.stellar.org/effects?order=asc&cursor=96422947803136001"
+    }
+  },
+  "id": "96422947803136001",
+  "paging_token": "96422947803136001",
+  "source_account": "GA5XIGA5C7QTPTWXQHY6MCJRMTRZDOSHR6EFIBNDQTCQHG262N4GGKTM",
+  "type": "payment",
+  "type_i": 1,
+  "created_at": "2019-02-12T18:37:50Z",
+  "transaction_hash": "618cac7ae4a9ab4d4e1791ed281044527295a1181bd9723270deb8062f7e19ab",
+  "asset_type": "native",
+  "from": "GA5XIGA5C7QTPTWXQHY6MCJRMTRZDOSHR6EFIBNDQTCQHG262N4GGKTM",
+  "to": "GDDVZO3LXDD4AZSSDADHYZEZJKYNUSGO6DFOQTJAJGBUGOYUQ5JDXXMM",
+  "amount": "124.9999800"
 }`

--- a/clients/horizon/operation_call_builder.go
+++ b/clients/horizon/operation_call_builder.go
@@ -1,0 +1,6 @@
+package horizon
+
+func (op *OperationCallBuilder) ForId(operationId string) {
+
+	op.addEndpoint("/operations/" + operationId)
+}

--- a/clients/horizon/operation_call_builder.go
+++ b/clients/horizon/operation_call_builder.go
@@ -4,3 +4,24 @@ func (op *OperationCallBuilder) ForId(operationId string) {
 
 	op.addEndpoint("/operations/" + operationId)
 }
+
+func (opc *OperationCallBuilder) Call() (op interface{}, err error) {
+
+	endpoint, err := opc.buildUrl()
+	if err != nil {
+		return op, err
+	}
+
+	resp, err := opc.HTTP.Get(endpoint)
+	if err != nil {
+		return op, err
+	}
+
+	err = decodeResponse(resp, &op)
+	if err != nil {
+		return op, err
+	}
+
+	return op, nil
+
+}


### PR DESCRIPTION
So I have been experimenting on a builder pattern for `clients/horizon`. This PR is just to make it easier to see the changes to the codebase. Please **DO NOT MERGE.**

So far, It seems like it might be fairly straightforward to get the details when you know the type to be returned by horizon endpoint. 
It is a bit more tricky when returning operations because its hard to know which struct to decode the response to as we don't know the operation type ahead of time. 

An option is to return `interface{}` for operations, but this might mean we lose type assertions. 

Another idea is to decode the response into a temporary `map`, loop through this to get the `type_i` field which can be used to determine the operating type. Once we have this field, we can then decode the response to the actual operation struct.

@bartekn  and @ire-and-curses when you get a chance, will like to get some thoughts on work so far. Thanks
