### PR TITLE
horizon/cmd: require at least one argument for rootCmd

### DIFF
--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -92,7 +92,6 @@ var dbClearCmd = &cobra.Command{
 	Use:   "clear",
 	Short: "clears all imported historical data",
 	Run: func(cmd *cobra.Command, args []string) {
-		initConfig()
 		hlog.DefaultLogger.Logger.Level = config.LogLevel
 
 		i := ingestSystem(ingest.Config{})
@@ -179,7 +178,6 @@ var dbRebaseCmd = &cobra.Command{
 	Short: "rebases clears the horizon db and ingests the latest ledger segment from stellar-core",
 	Long:  "...",
 	Run: func(cmd *cobra.Command, args []string) {
-		initConfig()
 		hlog.DefaultLogger.Logger.Level = config.LogLevel
 
 		i := ingestSystem(ingest.Config{})
@@ -197,7 +195,6 @@ var dbReingestCmd = &cobra.Command{
 	Short: "imports all data",
 	Long:  "reingest runs the ingestion pipeline over every ledger",
 	Run: func(cmd *cobra.Command, args []string) {
-		initConfig()
 		hlog.DefaultLogger.Logger.Level = config.LogLevel
 
 		i := ingestSystem(ingest.Config{})
@@ -208,9 +205,7 @@ var dbReingestCmd = &cobra.Command{
 			loadMean := time.Duration(i.Metrics.LoadLedgerTimer.Mean())
 			ingestMean := time.Duration(i.Metrics.IngestLedgerTimer.Mean())
 			clearMean := time.Duration(i.Metrics.IngestLedgerTimer.Mean())
-			hlog.
-				WithField("count", count).
-				WithField("rate", rate).
+			hlog.WithField("count", count).WithField("rate", rate).
 				WithField("means", fmt.Sprintf("load: %s clear: %s ingest: %s", loadMean, clearMean, ingestMean)).
 				Infof("reingest: %s", stage)
 		}
@@ -262,19 +257,16 @@ func ingestSystem(ingestConfig ingest.Config) *ingest.System {
 		log.Fatal("network-passphrase is blank: reingestion requires manually setting passphrase")
 	}
 
-	i := ingest.New(passphrase, config.StellarCoreURL, cdb, hdb, ingestConfig)
-	return i
+	return ingest.New(passphrase, config.StellarCoreURL, cdb, hdb, ingestConfig)
 }
 
 func reingest(i *ingest.System, args []string) (int, error) {
 	if len(args) == 0 {
-		count, err := i.ReingestAll()
-		return count, err
+		return i.ReingestAll()
 	}
 
 	if len(args) == 1 && args[0] == "outdated" {
-		count, err := i.ReingestOutdated()
-		return count, err
+		return i.ReingestOutdated()
 	}
 
 	for idx, arg := range args {

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -30,10 +30,9 @@ var dbBackfillCmd = &cobra.Command{
 			return
 		}
 
-		app := initApp()
-		app.UpdateLedgerState()
-
 		hlog.DefaultLogger.Logger.Level = config.LogLevel
+
+		initApp().UpdateLedgerState()
 
 		i := ingestSystem(ingest.Config{})
 		i.SkipCursorUpdate = true
@@ -94,8 +93,7 @@ var dbClearCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		hlog.DefaultLogger.Logger.Level = config.LogLevel
 
-		i := ingestSystem(ingest.Config{})
-		err := i.ClearAll()
+		err := ingestSystem(ingest.Config{}).ClearAll()
 		if err != nil {
 			hlog.Error(err)
 			os.Exit(1)
@@ -165,8 +163,7 @@ var dbReapCmd = &cobra.Command{
 	Short: "reaps (i.e. removes) any reapable history data",
 	Long:  "reap removes any historical data that is earlier than the configured retention cutoff",
 	Run: func(cmd *cobra.Command, args []string) {
-		app := initApp()
-		err := app.DeleteUnretainedHistory()
+		err := initApp().DeleteUnretainedHistory()
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -205,7 +202,8 @@ var dbReingestCmd = &cobra.Command{
 			loadMean := time.Duration(i.Metrics.LoadLedgerTimer.Mean())
 			ingestMean := time.Duration(i.Metrics.IngestLedgerTimer.Mean())
 			clearMean := time.Duration(i.Metrics.IngestLedgerTimer.Mean())
-			hlog.WithField("count", count).WithField("rate", rate).
+			hlog.WithField("count", count).
+				WithField("rate", rate).
 				WithField("means", fmt.Sprintf("load: %s clear: %s ingest: %s", loadMean, clearMean, ingestMean)).
 				Infof("reingest: %s", stage)
 		}

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -236,7 +236,16 @@ var dbReingestCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(dbCmd)
-	dbCmd.AddCommand(dbInitCmd, dbInitAssetStatsCmd, dbBackfillCmd, dbClearCmd, dbMigrateCmd, dbReapCmd, dbReingestCmd, dbRebaseCmd)
+	dbCmd.AddCommand(
+		dbInitCmd,
+		dbInitAssetStatsCmd,
+		dbBackfillCmd,
+		dbClearCmd,
+		dbMigrateCmd,
+		dbReapCmd,
+		dbReingestCmd,
+		dbRebaseCmd,
+	)
 }
 
 func ingestSystem(ingestConfig ingest.Config) *ingest.System {

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -128,7 +128,6 @@ var dbMigrateCmd = &cobra.Command{
 	Short: "migrate schema",
 	Long:  "performs a schema migration command",
 	Run: func(cmd *cobra.Command, args []string) {
-
 		// Allow invokations with 1 or 2 args.  All other args counts are erroneous.
 		if len(args) < 1 || len(args) > 2 {
 			cmd.Usage()
@@ -244,14 +243,7 @@ var dbReingestCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(dbCmd)
-	dbCmd.AddCommand(dbInitCmd)
-	dbCmd.AddCommand(dbInitAssetStatsCmd)
-	dbCmd.AddCommand(dbBackfillCmd)
-	dbCmd.AddCommand(dbClearCmd)
-	dbCmd.AddCommand(dbMigrateCmd)
-	dbCmd.AddCommand(dbReapCmd)
-	dbCmd.AddCommand(dbReingestCmd)
-	dbCmd.AddCommand(dbRebaseCmd)
+	dbCmd.AddCommand(dbInitCmd, dbInitAssetStatsCmd, dbBackfillCmd, dbClearCmd, dbMigrateCmd, dbReapCmd, dbReingestCmd, dbRebaseCmd)
 }
 
 func ingestSystem(ingestConfig ingest.Config) *ingest.System {

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -20,22 +20,24 @@ import (
 var config horizon.Config
 
 var rootCmd = &cobra.Command{
-	Use:   "horizon",
+	Use:   "horizon [db|serve|version]",
 	Short: "client-facing api server for the stellar network",
-	Long:  "client-facing api server for the stellar network",
+	Long:  "client-facing api server for the stellar network. It acts as the interface between Stellar Core and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.",
 	Run: func(cmd *cobra.Command, args []string) {
-		app := initApp()
-		app.Serve()
+		if len(args) < 1 {
+			cmd.Usage()
+			os.Exit(1)
+		}
 	},
 }
 
 // validateBothOrNeither ensures that both options are provided, if either is provided
 func validateBothOrNeither(option1, option2 string) {
 	arg1, arg2 := viper.GetString(option1), viper.GetString(option2)
-	switch {
-	case arg1 != "" && arg2 == "":
+	if arg1 != "" && arg2 == "" {
 		stdLog.Fatalf("Invalid config: %s = %s, but corresponding option %s is not configured", option1, arg1, option2)
-	case arg1 == "" && arg2 != "":
+	}
+	if arg1 == "" && arg2 != "" {
 		stdLog.Fatalf("Invalid config: %s = %s, but corresponding option %s is not configured", option2, arg2, option1)
 	}
 }

--- a/services/horizon/cmd/serve.go
+++ b/services/horizon/cmd/serve.go
@@ -9,8 +9,7 @@ var serveCmd = &cobra.Command{
 	Short: "run horizon server",
 	Long:  "serve initializes then starts the horizon HTTP server",
 	Run: func(cmd *cobra.Command, args []string) {
-		app := initApp()
-		app.Serve()
+		initApp().Serve()
 	},
 }
 

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -164,32 +164,33 @@ func (a *App) IsHistoryStale() bool {
 // UpdateLedgerState triggers a refresh of several metrics gauges, such as open
 // db connections and ledger state
 func (a *App) UpdateLedgerState() {
-	var err error
 	var next ledger.State
 
-	err = a.CoreQ().LatestLedger(&next.CoreLatest)
+	err := a.CoreQ().LatestLedger(&next.CoreLatest)
 	if err != nil {
-		goto Failed
+		log.WithStack(err).
+			WithField("err", err.Error()).
+			Error("failed to load the latest known ledger state from core DB")
+		return
 	}
 
 	err = a.HistoryQ().LatestLedger(&next.HistoryLatest)
 	if err != nil {
-		goto Failed
+		log.WithStack(err).
+			WithField("err", err.Error()).
+			Error("failed to load the latest known ledger state from history DB")
+		return
 	}
 
 	err = a.HistoryQ().ElderLedger(&next.HistoryElder)
 	if err != nil {
-		goto Failed
+		log.WithStack(err).
+			WithField("err", err.Error()).
+			Error("failed to load the oldest known ledger state from history DB")
+		return
 	}
 
 	ledger.SetState(next)
-	return
-
-Failed:
-	log.WithStack(err).
-		WithField("err", err.Error()).
-		Error("failed to load ledger state")
-
 }
 
 // UpdateOperationFeeStatsState triggers a refresh of several operation fee metrics

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -166,27 +166,25 @@ func (a *App) IsHistoryStale() bool {
 func (a *App) UpdateLedgerState() {
 	var next ledger.State
 
+	logErr := func(err error, msg string) {
+		log.WithStack(err).WithField("err", err.Error()).Error(msg)
+	}
+
 	err := a.CoreQ().LatestLedger(&next.CoreLatest)
 	if err != nil {
-		log.WithStack(err).
-			WithField("err", err.Error()).
-			Error("failed to load the latest known ledger state from core DB")
+		logErr(err, "failed to load the latest known ledger state from core DB")
 		return
 	}
 
 	err = a.HistoryQ().LatestLedger(&next.HistoryLatest)
 	if err != nil {
-		log.WithStack(err).
-			WithField("err", err.Error()).
-			Error("failed to load the latest known ledger state from history DB")
+		logErr(err, "failed to load the latest known ledger state from history DB")
 		return
 	}
 
 	err = a.HistoryQ().ElderLedger(&next.HistoryElder)
 	if err != nil {
-		log.WithStack(err).
-			WithField("err", err.Error()).
-			Error("failed to load the oldest known ledger state from history DB")
+		logErr(err, "failed to load the oldest known ledger state from history DB")
 		return
 	}
 


### PR DESCRIPTION
Previously, `horizon` worked the same as `horizon serve`. I don't see much benefit for this shortcut, and this is a little unexpected as a horizon user. This PR also piggybacks some of the code cleanup.