### PR TITLE
Updating SSE to utilize  as opposed to  which follows W3C spec: https…

### DIFF
--- a/services/horizon/internal/render/sse/main.go
+++ b/services/horizon/internal/render/sse/main.go
@@ -56,7 +56,7 @@ func WritePreamble(ctx context.Context, w http.ResponseWriter) bool {
 // sending it over the provided ResponseWriter and flushing.
 func WriteEvent(ctx context.Context, w http.ResponseWriter, e Event) {
 	if e.Error != nil {
-		fmt.Fprint(w, "event: err\n")
+		fmt.Fprint(w, "event: error\n")
 		fmt.Fprintf(w, "data: %s\n\n", e.Error.Error())
 		w.(http.Flusher).Flush()
 		return

--- a/services/horizon/internal/render/sse/main_test.go
+++ b/services/horizon/internal/render/sse/main_test.go
@@ -19,7 +19,7 @@ func TestWriteEventOutput(t *testing.T) {
 		{Event{Data: "test"}, "data: \"test\"\n\n"},
 		{Event{ID: "1", Data: "test"}, "id: 1\n"},
 		{Event{Retry: 1000, Data: "test"}, "retry: 1000\n"},
-		{Event{Error: errors.New("busted")}, "event: err\ndata: busted\n\n"},
+		{Event{Error: errors.New("busted")}, "event: error\ndata: busted\n\n"},
 		{Event{Event: "test", Data: "test"}, "event: test\ndata: \"test\"\n\n"},
 	}
 

--- a/services/horizon/internal/render/sse/stream_test.go
+++ b/services/horizon/internal/render/sse/stream_test.go
@@ -67,7 +67,7 @@ func (suite *StreamTestSuite) TestStream_Err() {
 	suite.stream.sent++
 	suite.stream.Err(err)
 	suite.checkHeadersAndPreamble()
-	assert.Contains(suite.T(), suite.w.Body.String(), "event: err\ndata: Unexpected stream error\n\n")
+	assert.Contains(suite.T(), suite.w.Body.String(), "event: error\ndata: Unexpected stream error\n\n")
 	assert.True(suite.T(), suite.stream.IsDone())
 }
 


### PR DESCRIPTION
Client libraries don't appropriately know about `err` events.

W3C spec for EventSource:
https://www.w3.org/TR/2009/WD-eventsource-20090421