### PR TITLE
horizon: remove redundant return param from NewApp()

### DIFF
--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -268,12 +268,7 @@ func init() {
 }
 
 func initApp() *horizon.App {
-	app, err := horizon.NewApp(config)
-	if err != nil {
-		stdLog.Fatal(err.Error())
-	}
-
-	return app
+	return horizon.NewApp(config)
 }
 
 func initConfig() {

--- a/services/horizon/internal/actions_assets_test.go
+++ b/services/horizon/internal/actions_assets_test.go
@@ -236,9 +236,7 @@ func TestAssetsActions(t *testing.T) {
 			appConfig := NewTestConfig()
 			appConfig.EnableAssetStats = true
 
-			var err error
-			ht.App, err = NewApp(appConfig)
-			ht.Assert.Nil(err)
+			ht.App = NewApp(appConfig)
 			ht.RH = test.NewRequestHelper(ht.App.web.router)
 
 			w := ht.Get(kase.path)
@@ -268,9 +266,7 @@ func TestInvalidAssetCode(t *testing.T) {
 	appConfig := NewTestConfig()
 	appConfig.EnableAssetStats = true
 
-	var err error
-	ht.App, err = NewApp(appConfig)
-	ht.Assert.Nil(err)
+	ht.App = NewApp(appConfig)
 	ht.RH = test.NewRequestHelper(ht.App.web.router)
 
 	w := ht.Get("/assets?asset_code=ABCDEFGHIJKL")
@@ -288,9 +284,7 @@ func TestInvalidAssetIssuer(t *testing.T) {
 	appConfig := NewTestConfig()
 	appConfig.EnableAssetStats = true
 
-	var err error
-	ht.App, err = NewApp(appConfig)
-	ht.Assert.Nil(err)
+	ht.App = NewApp(appConfig)
 	ht.RH = test.NewRequestHelper(ht.App.web.router)
 
 	w := ht.Get("/assets?asset_issuer=GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4")

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -60,12 +60,15 @@ type App struct {
 }
 
 // NewApp constructs an new App instance from the provided config.
-func NewApp(config Config) (*App, error) {
-	result := &App{config: config}
-	result.horizonVersion = app.Version()
-	result.ticks = time.NewTicker(1 * time.Second)
-	result.init()
-	return result, nil
+func NewApp(config Config) *App {
+	a := &App{
+		config:         config,
+		horizonVersion: app.Version(),
+		ticks:          time.NewTicker(1 * time.Second),
+	}
+
+	a.init()
+	return a
 }
 
 // Serve starts the horizon web server, binding it to a socket, setting up

--- a/services/horizon/internal/app_test.go
+++ b/services/horizon/internal/app_test.go
@@ -15,8 +15,7 @@ func TestNewApp(t *testing.T) {
 	config.SentryDSN = "Not a url"
 
 	tt.Assert.Panics(func() {
-		app, _ := NewApp(config)
-		app.Close()
+		NewApp(config).Close()
 	})
 }
 

--- a/services/horizon/internal/helpers_test.go
+++ b/services/horizon/internal/helpers_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http/httptest"
 	"time"
 
@@ -18,12 +17,7 @@ import (
 )
 
 func NewTestApp() *App {
-	app, err := NewApp(NewTestConfig())
-	if err != nil {
-		log.Panic(err)
-	}
-
-	return app
+	return NewApp(NewTestConfig())
 }
 
 func NewTestConfig() Config {

--- a/services/horizon/internal/init_redis_test.go
+++ b/services/horizon/internal/init_redis_test.go
@@ -8,18 +8,17 @@ import (
 )
 
 func TestRedis_Config(t *testing.T) {
-
 	c := NewTestConfig()
 
 	// app.redis is nil when no RedisURL is set
 	c.RedisURL = ""
-	app, _ := NewApp(c)
+	app := NewApp(c)
 	assert.Nil(t, app.redis)
 	app.Close()
 
 	// app.redis gets set when RedisURL is set
 	c.RedisURL = "redis://127.0.0.1:6379/"
-	app, _ = NewApp(c)
+	app = NewApp(c)
 	assert.NotNil(t, app.redis)
 
 	// redis connection works

--- a/services/horizon/internal/init_web.go
+++ b/services/horizon/internal/init_web.go
@@ -49,6 +49,7 @@ func initWeb(app *App) {
 
 // initWebMiddleware installs the middleware stack used for horizon onto the
 // provided app.
+// Note that a request will go through the middlewares from top to bottom.
 func initWebMiddleware(app *App) {
 	r := app.web.router
 	r.Use(chimiddleware.Timeout(app.config.ConnectionTimeout))

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -28,7 +28,7 @@ func (suite *RateLimitMiddlewareTestSuite) SetupTest() {
 		MaxRate:  throttled.PerHour(10),
 		MaxBurst: 9,
 	}
-	suite.app, _ = NewApp(suite.c)
+	suite.app = NewApp(suite.c)
 	suite.rh = NewRequestHelper(suite.app)
 }
 
@@ -123,7 +123,7 @@ func TestRateLimit_Redis(t *testing.T) {
 		MaxBurst: 9,
 	}
 	c.RedisURL = "redis://127.0.0.1:6379/"
-	app, _ := NewApp(c)
+	app := NewApp(c)
 	defer app.Close()
 	rh := NewRequestHelper(app)
 


### PR DESCRIPTION
We always return `nil` in this function.