### PR TITLE
horizon/cmd: fix migration checks

### DIFF
--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -30,8 +30,6 @@ var dbBackfillCmd = &cobra.Command{
 			return
 		}
 
-		hlog.DefaultLogger.Logger.Level = config.LogLevel
-
 		initApp().UpdateLedgerState()
 
 		i := ingestSystem(ingest.Config{})
@@ -52,7 +50,7 @@ var dbInitAssetStatsCmd = &cobra.Command{
 	Use:   "init-asset-stats",
 	Short: "initializes values for assets stats",
 	Run: func(cmd *cobra.Command, args []string) {
-		hlog.DefaultLogger.Logger.Level = config.LogLevel
+		initConfig()
 
 		hdb, err := db.Open("postgres", config.DatabaseURL)
 		if err != nil {
@@ -91,12 +89,11 @@ var dbClearCmd = &cobra.Command{
 	Use:   "clear",
 	Short: "clears all imported historical data",
 	Run: func(cmd *cobra.Command, args []string) {
-		hlog.DefaultLogger.Logger.Level = config.LogLevel
+		initConfig()
 
 		err := ingestSystem(ingest.Config{}).ClearAll()
 		if err != nil {
-			hlog.Error(err)
-			os.Exit(1)
+			log.Fatal(err)
 		}
 	},
 }
@@ -108,14 +105,12 @@ var dbInitCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		dbConn, err := db.Open("postgres", viper.GetString("db-url"))
 		if err != nil {
-			hlog.Error(err)
-			os.Exit(1)
+			log.Fatal(err)
 		}
 
 		err = schema.Init(dbConn)
 		if err != nil {
-			hlog.Error(err)
-			os.Exit(1)
+			log.Fatal(err)
 		}
 	},
 }
@@ -175,7 +170,7 @@ var dbRebaseCmd = &cobra.Command{
 	Short: "rebases clears the horizon db and ingests the latest ledger segment from stellar-core",
 	Long:  "...",
 	Run: func(cmd *cobra.Command, args []string) {
-		hlog.DefaultLogger.Logger.Level = config.LogLevel
+		initConfig()
 
 		i := ingestSystem(ingest.Config{})
 		i.SkipCursorUpdate = true
@@ -192,7 +187,7 @@ var dbReingestCmd = &cobra.Command{
 	Short: "imports all data",
 	Long:  "reingest runs the ingestion pipeline over every ledger",
 	Run: func(cmd *cobra.Command, args []string) {
-		hlog.DefaultLogger.Logger.Level = config.LogLevel
+		initConfig()
 
 		i := ingestSystem(ingest.Config{})
 		i.SkipCursorUpdate = true

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -256,7 +256,6 @@ var configOpts = []*support.ConfigOption{
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
 	for _, co := range configOpts {
 		err := co.Init(rootCmd)
 		if err != nil {
@@ -268,6 +267,7 @@ func init() {
 }
 
 func initApp() *horizon.App {
+	initConfig()
 	return horizon.NewApp(config)
 }
 


### PR DESCRIPTION
We can't run the migration checks on every single command like `horizon db init` and `horizon db migrate` themselves. This PR removes `cobra.OnInitialize()` and places `initConfig()` at commands where we need it.