### PR TITLE
Remove extra `for` loop in clients/horizon/client.go

### DIFF
--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -361,26 +361,25 @@ func (c *Client) stream(
 
 	client := http.Client{}
 
-		req, err := http.NewRequest("GET", fmt.Sprintf("%s?%s", baseURL, query.Encode()), nil)
-		if err != nil {
-			return errors.Wrap(err, "Error creating HTTP request")
-		}
-		req.Header.Set("Accept", "text/event-stream")
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s?%s", baseURL, query.Encode()), nil)
+	if err != nil {
+		return errors.Wrap(err, "Error creating HTTP request")
+	}
+	req.Header.Set("Accept", "text/event-stream")
 
-		// Make sure we don't use c.HTTP that can have Timeout set.
-		resp, err := client.Do(req)
-		if err != nil {
-			return errors.Wrap(err, "Error sending HTTP request")
-		}
-		if resp.StatusCode/100 != 2 {
-			return fmt.Errorf("Got bad HTTP status code %d", resp.StatusCode)
-		}
-		defer resp.Body.Close()
+	// Make sure we don't use c.HTTP that can have Timeout set.
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "Error sending HTTP request")
+	}
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("Got bad HTTP status code %d", resp.StatusCode)
+	}
+	defer resp.Body.Close()
 
-		reader := bufio.NewReader(resp.Body)
+	reader := bufio.NewReader(resp.Body)
 
-		for {
-
+	for {
 		// Read events one by one. Break this loop when there is no more data to be
 		// read from resp.Body (io.EOF).
 	Events:

--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -464,7 +464,7 @@ func (c *Client) stream(
 				}
 			}
 		}
-	} 
+	}
 }
 
 // StreamLedgers streams incoming ledgers. Use context.WithCancel to stop streaming or

--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -361,7 +361,6 @@ func (c *Client) stream(
 
 	client := http.Client{}
 
-	for {
 		req, err := http.NewRequest("GET", fmt.Sprintf("%s?%s", baseURL, query.Encode()), nil)
 		if err != nil {
 			return errors.Wrap(err, "Error creating HTTP request")
@@ -464,7 +463,7 @@ func (c *Client) stream(
 				}
 			}
 		}
-	}
+		return nil
 }
 
 // StreamLedgers streams incoming ledgers. Use context.WithCancel to stop streaming or

--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -379,6 +379,8 @@ func (c *Client) stream(
 
 		reader := bufio.NewReader(resp.Body)
 
+		for {
+
 		// Read events one by one. Break this loop when there is no more data to be
 		// read from resp.Body (io.EOF).
 	Events:
@@ -463,7 +465,7 @@ func (c *Client) stream(
 				}
 			}
 		}
-		return nil
+	} 
 }
 
 // StreamLedgers streams incoming ledgers. Use context.WithCancel to stop streaming or


### PR DESCRIPTION
This PR stops the infinite loop documented in issue https://github.com/stellar/go/issues/895. When run this way the request is still sent 10 times instead of once; I'm not sure why. Way better than an infinite loop though.