### PR TITLE
Revert "horizon/cmd: require at least one argument for rootCmd (#879)"

### DIFF
--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -30,6 +30,8 @@ var dbBackfillCmd = &cobra.Command{
 			return
 		}
 
+		hlog.DefaultLogger.Logger.Level = config.LogLevel
+
 		initApp().UpdateLedgerState()
 
 		i := ingestSystem(ingest.Config{})
@@ -90,8 +92,10 @@ var dbClearCmd = &cobra.Command{
 	Short: "clears all imported historical data",
 	Run: func(cmd *cobra.Command, args []string) {
 		initConfig()
+		hlog.DefaultLogger.Logger.Level = config.LogLevel
 
-		err := ingestSystem(ingest.Config{}).ClearAll()
+		i := ingestSystem(ingest.Config{})
+		err := i.ClearAll()
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -120,6 +124,7 @@ var dbMigrateCmd = &cobra.Command{
 	Short: "migrate schema",
 	Long:  "performs a schema migration command",
 	Run: func(cmd *cobra.Command, args []string) {
+
 		// Allow invokations with 1 or 2 args.  All other args counts are erroneous.
 		if len(args) < 1 || len(args) > 2 {
 			cmd.Usage()
@@ -158,7 +163,8 @@ var dbReapCmd = &cobra.Command{
 	Short: "reaps (i.e. removes) any reapable history data",
 	Long:  "reap removes any historical data that is earlier than the configured retention cutoff",
 	Run: func(cmd *cobra.Command, args []string) {
-		err := initApp().DeleteUnretainedHistory()
+		app := initApp()
+		err := app.DeleteUnretainedHistory()
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -171,6 +177,7 @@ var dbRebaseCmd = &cobra.Command{
 	Long:  "...",
 	Run: func(cmd *cobra.Command, args []string) {
 		initConfig()
+		hlog.DefaultLogger.Logger.Level = config.LogLevel
 
 		i := ingestSystem(ingest.Config{})
 		i.SkipCursorUpdate = true
@@ -188,6 +195,7 @@ var dbReingestCmd = &cobra.Command{
 	Long:  "reingest runs the ingestion pipeline over every ledger",
 	Run: func(cmd *cobra.Command, args []string) {
 		initConfig()
+		hlog.DefaultLogger.Logger.Level = config.LogLevel
 
 		i := ingestSystem(ingest.Config{})
 		i.SkipCursorUpdate = true
@@ -197,7 +205,8 @@ var dbReingestCmd = &cobra.Command{
 			loadMean := time.Duration(i.Metrics.LoadLedgerTimer.Mean())
 			ingestMean := time.Duration(i.Metrics.IngestLedgerTimer.Mean())
 			clearMean := time.Duration(i.Metrics.IngestLedgerTimer.Mean())
-			hlog.WithField("count", count).
+			hlog.
+				WithField("count", count).
 				WithField("rate", rate).
 				WithField("means", fmt.Sprintf("load: %s clear: %s ingest: %s", loadMean, clearMean, ingestMean)).
 				Infof("reingest: %s", stage)
@@ -231,16 +240,14 @@ var dbReingestCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(dbCmd)
-	dbCmd.AddCommand(
-		dbInitCmd,
-		dbInitAssetStatsCmd,
-		dbBackfillCmd,
-		dbClearCmd,
-		dbMigrateCmd,
-		dbReapCmd,
-		dbReingestCmd,
-		dbRebaseCmd,
-	)
+	dbCmd.AddCommand(dbInitCmd)
+	dbCmd.AddCommand(dbInitAssetStatsCmd)
+	dbCmd.AddCommand(dbBackfillCmd)
+	dbCmd.AddCommand(dbClearCmd)
+	dbCmd.AddCommand(dbMigrateCmd)
+	dbCmd.AddCommand(dbReapCmd)
+	dbCmd.AddCommand(dbReingestCmd)
+	dbCmd.AddCommand(dbRebaseCmd)
 }
 
 func ingestSystem(ingestConfig ingest.Config) *ingest.System {
@@ -259,16 +266,19 @@ func ingestSystem(ingestConfig ingest.Config) *ingest.System {
 		log.Fatal("network-passphrase is blank: reingestion requires manually setting passphrase")
 	}
 
-	return ingest.New(passphrase, config.StellarCoreURL, cdb, hdb, ingestConfig)
+	i := ingest.New(passphrase, config.StellarCoreURL, cdb, hdb, ingestConfig)
+	return i
 }
 
 func reingest(i *ingest.System, args []string) (int, error) {
 	if len(args) == 0 {
-		return i.ReingestAll()
+		count, err := i.ReingestAll()
+		return count, err
 	}
 
 	if len(args) == 1 && args[0] == "outdated" {
-		return i.ReingestOutdated()
+		count, err := i.ReingestOutdated()
+		return count, err
 	}
 
 	for idx, arg := range args {

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -20,24 +20,22 @@ import (
 var config horizon.Config
 
 var rootCmd = &cobra.Command{
-	Use:   "horizon [db|serve|version]",
+	Use:   "horizon",
 	Short: "client-facing api server for the stellar network",
-	Long:  "client-facing api server for the stellar network. It acts as the interface between Stellar Core and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.",
+	Long:  "client-facing api server for the stellar network",
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) < 1 {
-			cmd.Usage()
-			os.Exit(1)
-		}
+		app := initApp()
+		app.Serve()
 	},
 }
 
 // validateBothOrNeither ensures that both options are provided, if either is provided
 func validateBothOrNeither(option1, option2 string) {
 	arg1, arg2 := viper.GetString(option1), viper.GetString(option2)
-	if arg1 != "" && arg2 == "" {
+	switch {
+	case arg1 != "" && arg2 == "":
 		stdLog.Fatalf("Invalid config: %s = %s, but corresponding option %s is not configured", option1, arg1, option2)
-	}
-	if arg1 == "" && arg2 != "" {
+	case arg1 == "" && arg2 != "":
 		stdLog.Fatalf("Invalid config: %s = %s, but corresponding option %s is not configured", option2, arg2, option1)
 	}
 }

--- a/services/horizon/cmd/serve.go
+++ b/services/horizon/cmd/serve.go
@@ -9,7 +9,8 @@ var serveCmd = &cobra.Command{
 	Short: "run horizon server",
 	Long:  "serve initializes then starts the horizon HTTP server",
 	Run: func(cmd *cobra.Command, args []string) {
-		initApp().Serve()
+		app := initApp()
+		app.Serve()
 	},
 }
 


### PR DESCRIPTION
This reverts commit bf56ad6262e4b0f1ef0c785a9525ec2378c15440 because it was a breaking change. It was already cherry-picked to `release-horizon-v0.17.0` branch.