### PR TITLE
Add percentiles to /operation_fee_stats

### DIFF
--- a/services/horizon/internal/actions_operation_fee_stats.go
+++ b/services/horizon/internal/actions_operation_fee_stats.go
@@ -20,6 +20,17 @@ type OperationFeeStatsAction struct {
 	Action
 	Min         int64
 	Mode        int64
+	P10         int64
+	P20         int64
+	P30         int64
+	P40         int64
+	P50         int64
+	P60         int64
+	P70         int64
+	P80         int64
+	P90         int64
+	P95         int64
+	P99         int64
 	LastBaseFee int64
 	LastLedger  int64
 }
@@ -32,6 +43,17 @@ func (action *OperationFeeStatsAction) JSON() error {
 			hal.Render(action.W, map[string]string{
 				"min_accepted_fee":     fmt.Sprint(action.Min),
 				"mode_accepted_fee":    fmt.Sprint(action.Mode),
+				"p10_accepted_fee":     fmt.Sprint(action.P10),
+				"p20_accepted_fee":     fmt.Sprint(action.P20),
+				"p30_accepted_fee":     fmt.Sprint(action.P30),
+				"p40_accepted_fee":     fmt.Sprint(action.P40),
+				"p50_accepted_fee":     fmt.Sprint(action.P50),
+				"p60_accepted_fee":     fmt.Sprint(action.P60),
+				"p70_accepted_fee":     fmt.Sprint(action.P70),
+				"p80_accepted_fee":     fmt.Sprint(action.P80),
+				"p90_accepted_fee":     fmt.Sprint(action.P90),
+				"p95_accepted_fee":     fmt.Sprint(action.P95),
+				"p99_accepted_fee":     fmt.Sprint(action.P99),
 				"last_ledger_base_fee": fmt.Sprint(action.LastBaseFee),
 				"last_ledger":          fmt.Sprint(action.LastLedger),
 			})
@@ -46,4 +68,15 @@ func (action *OperationFeeStatsAction) loadRecords() {
 	action.Mode = cur.Mode
 	action.LastBaseFee = cur.LastBaseFee
 	action.LastLedger = cur.LastLedger
+	action.P10 = cur.P10
+	action.P20 = cur.P20
+	action.P30 = cur.P30
+	action.P40 = cur.P40
+	action.P50 = cur.P50
+	action.P60 = cur.P60
+	action.P70 = cur.P70
+	action.P80 = cur.P80
+	action.P90 = cur.P90
+	action.P95 = cur.P95
+	action.P99 = cur.P99
 }

--- a/services/horizon/internal/actions_operation_fee_stats_test.go
+++ b/services/horizon/internal/actions_operation_fee_stats_test.go
@@ -9,13 +9,35 @@ func TestOperationFeeTestsActions_Show(t *testing.T) {
 
 	testCases := []struct {
 		scenario    string
+		lastbasefee string
 		min         string
 		mode        string
-		lastbasefee string
+		p10         string
+		p20         string
+		p30         string
+		p40         string
+		p50         string
+		p60         string
+		p70         string
+		p80         string
+		p90         string
+		p95         string
+		p99         string
 	}{
 		// happy path
 		{
 			"operation_fee_stats_1",
+			"100",
+			"100",
+			"100",
+			"100",
+			"100",
+			"100",
+			"100",
+			"100",
+			"100",
+			"100",
+			"100",
 			"100",
 			"100",
 			"100",
@@ -26,13 +48,35 @@ func TestOperationFeeTestsActions_Show(t *testing.T) {
 			"100",
 			"100",
 			"100",
+			"100",
+			"100",
+			"100",
+			"100",
+			"100",
+			"100",
+			"100",
+			"100",
+			"100",
+			"100",
+			"100",
 		},
 		// transactions with varying fees
 		{
 			"operation_fee_stats_3",
+			"100",
 			"200",
 			"400",
-			"100",
+			"260", // p10
+			"320",
+			"380",
+			"400",
+			"400",
+			"400",
+			"400",
+			"400",
+			"400",
+			"400",
+			"400",
 		},
 	}
 
@@ -41,15 +85,28 @@ func TestOperationFeeTestsActions_Show(t *testing.T) {
 			ht := StartHTTPTest(t, kase.scenario)
 			defer ht.Finish()
 
+			ht.App.UpdateOperationFeeStatsState()
+
 			w := ht.Get("/operation_fee_stats")
 
 			if ht.Assert.Equal(200, w.Code) {
 				var result map[string]string
 				err := json.Unmarshal(w.Body.Bytes(), &result)
 				ht.Require.NoError(err)
-				ht.Assert.Equal(kase.min, result["min_accepted_fee"])
-				ht.Assert.Equal(kase.mode, result["mode_accepted_fee"])
-				ht.Assert.Equal(kase.lastbasefee, result["last_ledger_base_fee"])
+				ht.Assert.Equal(kase.min, result["min_accepted_fee"], "min")
+				ht.Assert.Equal(kase.mode, result["mode_accepted_fee"], "mode")
+				ht.Assert.Equal(kase.lastbasefee, result["last_ledger_base_fee"], "base_fee")
+				ht.Assert.Equal(kase.p10, result["p10_accepted_fee"], "p10")
+				ht.Assert.Equal(kase.p20, result["p20_accepted_fee"], "p20")
+				ht.Assert.Equal(kase.p30, result["p30_accepted_fee"], "p30")
+				ht.Assert.Equal(kase.p40, result["p40_accepted_fee"], "p40")
+				ht.Assert.Equal(kase.p50, result["p50_accepted_fee"], "p50")
+				ht.Assert.Equal(kase.p60, result["p60_accepted_fee"], "p60")
+				ht.Assert.Equal(kase.p70, result["p70_accepted_fee"], "p70")
+				ht.Assert.Equal(kase.p80, result["p80_accepted_fee"], "p80")
+				ht.Assert.Equal(kase.p90, result["p90_accepted_fee"], "p90")
+				ht.Assert.Equal(kase.p95, result["p95_accepted_fee"], "p95")
+				ht.Assert.Equal(kase.p99, result["p99_accepted_fee"], "p99")
 			}
 		})
 	}

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -227,9 +227,31 @@ func (a *App) UpdateOperationFeeStatsState() {
 	if !feeStats.Mode.Valid && !feeStats.Min.Valid {
 		next.Min = next.LastBaseFee
 		next.Mode = next.LastBaseFee
+		next.P10 = next.LastBaseFee
+		next.P20 = next.LastBaseFee
+		next.P30 = next.LastBaseFee
+		next.P40 = next.LastBaseFee
+		next.P50 = next.LastBaseFee
+		next.P60 = next.LastBaseFee
+		next.P70 = next.LastBaseFee
+		next.P80 = next.LastBaseFee
+		next.P90 = next.LastBaseFee
+		next.P95 = next.LastBaseFee
+		next.P99 = next.LastBaseFee
 	} else {
 		next.Min = feeStats.Min.Int64
 		next.Mode = feeStats.Mode.Int64
+		next.P10 = feeStats.P10.Int64
+		next.P20 = feeStats.P20.Int64
+		next.P30 = feeStats.P30.Int64
+		next.P40 = feeStats.P40.Int64
+		next.P50 = feeStats.P50.Int64
+		next.P60 = feeStats.P60.Int64
+		next.P70 = feeStats.P70.Int64
+		next.P80 = feeStats.P80.Int64
+		next.P90 = feeStats.P90.Int64
+		next.P95 = feeStats.P95.Int64
+		next.P99 = feeStats.P99.Int64
 	}
 
 	operationfeestats.SetState(next)

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -164,6 +164,17 @@ type EffectType int
 type FeeStats struct {
 	Min  null.Int `db:"min"`
 	Mode null.Int `db:"mode"`
+	P10  null.Int `db:"p10"`
+	P20  null.Int `db:"p20"`
+	P30  null.Int `db:"p30"`
+	P40  null.Int `db:"p40"`
+	P50  null.Int `db:"p50"`
+	P60  null.Int `db:"p60"`
+	P70  null.Int `db:"p70"`
+	P80  null.Int `db:"p80"`
+	P90  null.Int `db:"p90"`
+	P95  null.Int `db:"p95"`
+	P99  null.Int `db:"p99"`
 }
 
 // LatestLedger represents a response from the raw LatestLedgerBaseFeeAndSequence

--- a/services/horizon/internal/db2/history/transaction.go
+++ b/services/horizon/internal/db2/history/transaction.go
@@ -21,7 +21,20 @@ func (q *Q) TransactionByHash(dest interface{}, hash string) error {
 // future this may be configurable.
 func (q *Q) TransactionsForLastXLedgers(currentSeq int32, dest interface{}) error {
 	return q.GetRaw(dest, `
-		SELECT min(fee_paid/operation_count),  mode() within group (order by fee_paid/operation_count)
+		SELECT
+			min(fee_paid/operation_count),
+			mode() within group (order by fee_paid/operation_count),
+			percentile_cont(0.10) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p10",
+			percentile_cont(0.20) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p20",
+			percentile_cont(0.30) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p30",
+			percentile_cont(0.40) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p40",
+			percentile_cont(0.50) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p50",
+			percentile_cont(0.60) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p60",
+			percentile_cont(0.70) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p70",
+			percentile_cont(0.80) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p80",
+			percentile_cont(0.90) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p90",
+			percentile_cont(0.95) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p95",
+			percentile_cont(0.99) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p99"
 		FROM history_transactions
 		WHERE ledger_sequence > $1 AND ledger_sequence <= $2
 	`, currentSeq-5, currentSeq)

--- a/services/horizon/internal/operationfeestats/main.go
+++ b/services/horizon/internal/operationfeestats/main.go
@@ -14,6 +14,17 @@ import (
 type State struct {
 	Min         int64
 	Mode        int64
+	P10         int64
+	P20         int64
+	P30         int64
+	P40         int64
+	P50         int64
+	P60         int64
+	P70         int64
+	P80         int64
+	P90         int64
+	P95         int64
+	P99         int64
 	LastBaseFee int64
 	LastLedger  int64
 }

--- a/services/horizon/internal/test/t.go
+++ b/services/horizon/internal/test/t.go
@@ -5,7 +5,6 @@ import (
 
 	"encoding/json"
 
-	"github.com/guregu/null"
 	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/operationfeestats"
 	"github.com/stellar/go/support/db"
@@ -46,7 +45,6 @@ func (t *T) HorizonSession() *db.Session {
 func (t *T) Scenario(name string) *T {
 	LoadScenario(name)
 	t.UpdateLedgerState()
-	t.UpdateOperationFeeStatsState()
 	return t
 }
 
@@ -54,7 +52,6 @@ func (t *T) Scenario(name string) *T {
 func (t *T) ScenarioWithoutHorizon(name string) *T {
 	LoadScenarioWithoutHorizon(name)
 	t.UpdateLedgerState()
-	t.UpdateOperationFeeStatsState()
 	return t
 }
 
@@ -133,62 +130,5 @@ func (t *T) UpdateLedgerState() {
 	}
 
 	ledger.SetState(next)
-	return
-}
-
-// UpdateOperationFeeStatsState updates the cached operation fees state
-// or panics on failure.
-func (t *T) UpdateOperationFeeStatsState() {
-	var err error
-	var next operationfeestats.State
-
-	var latest struct {
-		BaseFee  int32 `db:"base_fee"`
-		Sequence int32 `db:"sequence"`
-	}
-	var feeStats struct {
-		Min  null.Int `db:"min"`
-		Mode null.Int `db:"mode"`
-	}
-
-	cur := operationfeestats.CurrentState()
-
-	err = t.HorizonSession().GetRaw(&latest, `
-		SELECT base_fee, sequence
-		FROM history_ledgers
-		WHERE sequence = (SELECT COALESCE(MAX(sequence), 0) FROM history_ledgers)
-	`)
-	if err != nil {
-		return
-	}
-
-	next.LastBaseFee = int64(latest.BaseFee)
-	next.LastLedger = int64(latest.Sequence)
-
-	// finish early if no new ledgers
-	if cur.LastLedger == int64(latest.Sequence) {
-		return
-	}
-
-	err = t.HorizonSession().GetRaw(&feeStats, `
-		SELECT min(fee_paid/operation_count),  mode() within group (order by fee_paid/operation_count)
-		FROM history_transactions
-		WHERE ledger_sequence > $1 AND ledger_sequence <= $2
-	`, latest.Sequence-5, latest.Sequence)
-	if err != nil {
-		return
-	}
-
-	// if no transactions in last X ledgers, return
-	// latest ledger's base fee for all
-	if !feeStats.Mode.Valid && !feeStats.Min.Valid {
-		next.Min = next.LastBaseFee
-		next.Mode = next.LastBaseFee
-	} else {
-		next.Min = feeStats.Min.Int64
-		next.Mode = feeStats.Mode.Int64
-	}
-
-	operationfeestats.SetState(next)
 	return
 }


### PR DESCRIPTION
It seems that percentile stats are much better for estimating the required fee. Would be great to release it in the next version.