### PR TITLE
horizon/cmd: remove the requirement of specifying "serve"

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -10,8 +10,6 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ### Breaking changes
 
-* horizon command now requires at least one argument. As a result, users will have to do `horizon serve` to launch horizon.
-
 ### Changes
 
 * Fixed a bug causing slice bounds out of range at offer-by-account endpoint during streaming.

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -24,10 +24,7 @@ var rootCmd = &cobra.Command{
 	Short: "client-facing api server for the stellar network",
 	Long:  "client-facing api server for the stellar network. It acts as the interface between Stellar Core and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.",
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) < 1 {
-			cmd.Usage()
-			os.Exit(1)
-		}
+		initApp().Serve()
 	},
 }
 


### PR DESCRIPTION
A lot of scripts are using `horizon` without specifying `serve` explicitly. This PR removes the requirement.