### PR TITLE
horizon/actions: fix stream logging

### DIFF
--- a/services/horizon/internal/init_web.go
+++ b/services/horizon/internal/init_web.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sebest/xff"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
+	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/txsub/sequence"
 	"github.com/stellar/go/support/render/problem"
 	"github.com/throttled/throttled"
@@ -45,6 +46,7 @@ func initWeb(app *App) {
 	problem.RegisterError(db2.ErrInvalidCursor, problem.BadRequest)
 	problem.RegisterError(db2.ErrInvalidLimit, problem.BadRequest)
 	problem.RegisterError(db2.ErrInvalidOrder, problem.BadRequest)
+	problem.RegisterError(sse.ErrRateLimited, hProblem.RateLimitExceeded)
 }
 
 // initWebMiddleware installs the middleware stack used for horizon onto the

--- a/services/horizon/internal/render/sse/stream.go
+++ b/services/horizon/internal/render/sse/stream.go
@@ -105,23 +105,21 @@ func (s *Stream) Err(err error) {
 	defer s.mu.Unlock()
 
 	rootErr := errors.Cause(err)
-	if rootErr != ErrRateLimited {
-		// If we haven't sent an event, we should simply return the normal HTTP
-		// error because it means that we haven't sent the preamble.
-		if s.sent == 0 {
-			problem.Render(s.ctx, s.w, err)
-			return
-		}
+	// If we haven't sent an event, we should simply return the normal HTTP
+	// error because it means that we haven't sent the preamble.
+	if s.sent == 0 {
+		problem.Render(s.ctx, s.w, err)
+		return
+	}
 
-		if rootErr == sql.ErrNoRows {
-			err = errNoObject
-		}
+	if rootErr == sql.ErrNoRows {
+		err = errNoObject
+	}
 
-		_, ok := knownErrors[rootErr]
-		if !ok {
-			log.Ctx(s.ctx).Error(err)
-			err = errBadStream
-		}
+	_, ok := knownErrors[rootErr]
+	if !ok {
+		log.Ctx(s.ctx).Error(err)
+		err = errBadStream
 	}
 
 	s.Init()

--- a/services/horizon/internal/render/sse/stream.go
+++ b/services/horizon/internal/render/sse/stream.go
@@ -104,21 +104,24 @@ func (s *Stream) Err(err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// If we haven't sent an event, we should simply return the normal HTTP
-	// error because it means that we haven't sent the preamble.
-	if s.sent == 0 {
-		problem.Render(s.ctx, s.w, err)
-		return
-	}
+	rootErr := errors.Cause(err)
+	if rootErr != ErrRateLimited {
+		// If we haven't sent an event, we should simply return the normal HTTP
+		// error because it means that we haven't sent the preamble.
+		if s.sent == 0 {
+			problem.Render(s.ctx, s.w, err)
+			return
+		}
 
-	if errors.Cause(err) == sql.ErrNoRows {
-		err = errNoObject
-	}
+		if rootErr == sql.ErrNoRows {
+			err = errNoObject
+		}
 
-	_, ok := knownErrors[errors.Cause(err)]
-	if !ok {
-		log.Ctx(s.ctx).Error(err)
-		err = errBadStream
+		_, ok := knownErrors[rootErr]
+		if !ok {
+			log.Ctx(s.ctx).Error(err)
+			err = errBadStream
+		}
 	}
 
 	s.Init()


### PR DESCRIPTION
The `ErrRateLimited` error was returned with `WriteEvent` not through `problem.Render` before https://github.com/stellar/go/pull/856/. The problem was that we didn't register `sse.ErrRateLimited` in `errToProblemMap` and when `sent count` is zero, we used `problem.Render` to process the error. Hence, we were logging `ErrRateLimited` in the last deploy.

Close #908 