### PR TITLE
Add `db reingest range` command

### DIFF
--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -291,6 +291,20 @@ func reingest(i *ingest.System, args []string) (int, error) {
 		return count, err
 	}
 
+	if len(args) >= 1 && args[0] == "range" {
+		from, err := strconv.Atoi(args[1])
+		if err != nil {
+			return 0, err
+		}
+
+		to, err := strconv.Atoi(args[2])
+		if err != nil {
+			return 0, err
+		}
+
+		return i.ReingestRange(int32(from), int32(to))
+	}
+
 	for idx, arg := range args {
 		seq, err := strconv.Atoi(arg)
 		if err != nil {


### PR DESCRIPTION
Simple command to support ledger range reingestion. Can be used to distribute reingestion of ledgers across multiple machines:
```
horizon1> horizon db reingest range 1 10000
horizon2> horizon db reingest range 10001 20000
horizon3> horizon db reingest range 20001 30000
...
```