### PR TITLE
set stellar-core ingestion cursor name

### DIFF
--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -230,6 +230,14 @@ var configOpts = []*support.ConfigOption{
 		Usage:       "causes this horizon process to ingest failed transactions data",
 	},
 	&support.ConfigOption{
+		Name:        "cursor-name",
+		EnvVar:      "CURSOR_NAME",
+		ConfigKey:   &config.CursorName,
+		OptType:     types.String,
+		FlagDefault: "HORIZON",
+		Usage:       "ingestor cursor used by horizon to ingest from stellar core. must be uppercase and unique for each horizon instance ingesting from that core instance.",
+	},
+	&support.ConfigOption{
 		Name:        "history-retention-count",
 		ConfigKey:   &config.HistoryRetentionCount,
 		OptType:     types.Uint,

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -38,6 +38,11 @@ type Config struct {
 	Ingest bool
 	// IngestFailedTransactions toggles whether to ingest failed transactions
 	IngestFailedTransactions bool
+	// CursorName is the cursor used for ingesting from stellar-core.
+	// Setting multiple cursors in different Horizon instances allows multiple
+	// Horizons to ingest from the same stellar-core instance without cursor
+	// collisions.
+	CursorName string
 	// HistoryRetentionCount represents the minimum number of ledgers worth of
 	// history data to retain in the horizon database. For the purposes of
 	// determining a "retention duration", each ledger roughly corresponds to 10

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -63,6 +63,9 @@ type Cursor struct {
 	// Err is the error that caused this iteration to fail, if any.
 	Err error
 
+	// Name is a unique identifier tracking the latest ingested ledger on stellar-core
+	Name string
+
 	lg   int32
 	tx   int
 	op   int
@@ -77,6 +80,11 @@ type Config struct {
 	// IngestFailedTransactions is a feature flag that determines if system
 	// should ingest failed transactions.
 	IngestFailedTransactions bool
+	// CursorName is the cursor used for ingesting from stellar-core.
+	// Setting multiple cursors in different Horizon instances allows multiple
+	// Horizons to ingest from the same stellar-core instance without cursor
+	// collisions.
+	CursorName string
 }
 
 // EffectIngestion is a helper struct to smooth the ingestion of effects.  this
@@ -223,6 +231,7 @@ func NewCursor(first, last int32, i *System) *Cursor {
 		FirstLedger: first,
 		LastLedger:  last,
 		CoreDB:      i.CoreDB,
+		Name:        i.Config.CursorName,
 		Metrics:     &i.Metrics,
 	}
 }

--- a/services/horizon/internal/ingest/main_test.go
+++ b/services/horizon/internal/ingest/main_test.go
@@ -52,7 +52,7 @@ func TestIngest_Kahuna2(t *testing.T) {
 func TestTick(t *testing.T) {
 	tt := test.Start(t).ScenarioWithoutHorizon("base")
 	defer tt.Finish()
-	sys := sys(tt, Config{EnableAssetStats: false})
+	sys := sys(tt, Config{EnableAssetStats: false, CursorName: "HORIZON"})
 
 	// ingest by tick
 	s := sys.Tick()

--- a/services/horizon/internal/ingest/session.go
+++ b/services/horizon/internal/ingest/session.go
@@ -886,7 +886,7 @@ func (is *Session) reportCursorState() error {
 
 	core := &stellarcore.Client{URL: is.StellarCoreURL}
 
-	err := core.SetCursor(context.Background(), "HORIZON", is.Cursor.LastLedger)
+	err := core.SetCursor(context.Background(), is.Cursor.Name, is.Cursor.LastLedger)
 
 	if err != nil {
 		return errors.Wrap(err, "SetCursor failed")

--- a/services/horizon/internal/ingest/system_test.go
+++ b/services/horizon/internal/ingest/system_test.go
@@ -10,7 +10,7 @@ import (
 func TestBackfill(t *testing.T) {
 	tt := test.Start(t).ScenarioWithoutHorizon("kahuna")
 	defer tt.Finish()
-	is := sys(tt, Config{EnableAssetStats: false})
+	is := sys(tt, Config{EnableAssetStats: false, CursorName: "HORIZON"})
 
 	err := is.ReingestSingle(10)
 	tt.Require.NoError(err)
@@ -34,7 +34,7 @@ func TestBackfill(t *testing.T) {
 func TestClearAll(t *testing.T) {
 	tt := test.Start(t).Scenario("kahuna")
 	defer tt.Finish()
-	is := sys(tt, Config{EnableAssetStats: false})
+	is := sys(tt, Config{EnableAssetStats: false, CursorName: "HORIZON"})
 
 	err := is.ClearAll()
 

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -61,6 +61,7 @@ func initIngester(app *App) {
 		ingest.Config{
 			EnableAssetStats:         app.config.EnableAssetStats,
 			IngestFailedTransactions: app.config.IngestFailedTransactions,
+			CursorName:               app.config.CursorName,
 		},
 	)
 


### PR DESCRIPTION
fixes #194, and also relates to #183 but DOES NOT fix that issue

you can now override the default cursor name used by horizon
to ingest new ledgers from stellar-core database.

default value is "HORIZON" for backwards compatibility

we have been using this for scaling horizon horizontally (accidental pun i swear :) ) - using multiple horizons to ingest from a single core instance, some used for "read" operations such as SSE requests and some for "write" i.e. submitting transactions.