### PR TITLE
horizon: Ceil() operation fee stats

### DIFF
--- a/services/horizon/internal/db2/history/transaction.go
+++ b/services/horizon/internal/db2/history/transaction.go
@@ -22,19 +22,19 @@ func (q *Q) TransactionByHash(dest interface{}, hash string) error {
 func (q *Q) TransactionsForLastXLedgers(currentSeq int32, dest interface{}) error {
 	return q.GetRaw(dest, `
 		SELECT
-			round(min(fee_paid/operation_count)) as "min",
-			round(mode() within group (order by fee_paid/operation_count)) as "mode",
-			round(percentile_cont(0.10) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p10",
-			round(percentile_cont(0.20) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p20",
-			round(percentile_cont(0.30) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p30",
-			round(percentile_cont(0.40) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p40",
-			round(percentile_cont(0.50) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p50",
-			round(percentile_cont(0.60) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p60",
-			round(percentile_cont(0.70) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p70",
-			round(percentile_cont(0.80) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p80",
-			round(percentile_cont(0.90) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p90",
-			round(percentile_cont(0.95) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p95",
-			round(percentile_cont(0.99) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p99"
+			ceil(min(fee_paid/operation_count)) AS "min",
+			ceil(mode() within group (order by fee_paid/operation_count)) AS "mode",
+			ceil(percentile_cont(0.10) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p10",
+			ceil(percentile_cont(0.20) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p20",
+			ceil(percentile_cont(0.30) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p30",
+			ceil(percentile_cont(0.40) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p40",
+			ceil(percentile_cont(0.50) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p50",
+			ceil(percentile_cont(0.60) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p60",
+			ceil(percentile_cont(0.70) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p70",
+			ceil(percentile_cont(0.80) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p80",
+			ceil(percentile_cont(0.90) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p90",
+			ceil(percentile_cont(0.95) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p95",
+			ceil(percentile_cont(0.99) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p99"
 		FROM history_transactions
 		WHERE ledger_sequence > $1 AND ledger_sequence <= $2
 	`, currentSeq-5, currentSeq)

--- a/services/horizon/internal/db2/history/transaction.go
+++ b/services/horizon/internal/db2/history/transaction.go
@@ -22,19 +22,19 @@ func (q *Q) TransactionByHash(dest interface{}, hash string) error {
 func (q *Q) TransactionsForLastXLedgers(currentSeq int32, dest interface{}) error {
 	return q.GetRaw(dest, `
 		SELECT
-			min(fee_paid/operation_count),
-			mode() within group (order by fee_paid/operation_count),
-			percentile_cont(0.10) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p10",
-			percentile_cont(0.20) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p20",
-			percentile_cont(0.30) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p30",
-			percentile_cont(0.40) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p40",
-			percentile_cont(0.50) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p50",
-			percentile_cont(0.60) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p60",
-			percentile_cont(0.70) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p70",
-			percentile_cont(0.80) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p80",
-			percentile_cont(0.90) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p90",
-			percentile_cont(0.95) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p95",
-			percentile_cont(0.99) WITHIN GROUP (ORDER BY fee_paid/operation_count) AS "p99"
+			round(min(fee_paid/operation_count)) as "min",
+			round(mode() within group (order by fee_paid/operation_count)) as "mode",
+			round(percentile_cont(0.10) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p10",
+			round(percentile_cont(0.20) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p20",
+			round(percentile_cont(0.30) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p30",
+			round(percentile_cont(0.40) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p40",
+			round(percentile_cont(0.50) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p50",
+			round(percentile_cont(0.60) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p60",
+			round(percentile_cont(0.70) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p70",
+			round(percentile_cont(0.80) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p80",
+			round(percentile_cont(0.90) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p90",
+			round(percentile_cont(0.95) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p95",
+			round(percentile_cont(0.99) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p99"
 		FROM history_transactions
 		WHERE ledger_sequence > $1 AND ledger_sequence <= $2
 	`, currentSeq-5, currentSeq)


### PR DESCRIPTION
It's possible that for some fee distribution returned values are floats, we want to return ints.