### PR TITLE
Update documentation for transaction attributes

### DIFF
--- a/services/horizon/internal/docs/reference/resources/transaction.md
+++ b/services/horizon/internal/docs/reference/resources/transaction.md
@@ -19,7 +19,7 @@ To learn more about the concept of transactions in the Stellar network, take a l
 | ledger           | number | Sequence number of the ledger in which this transaction was applied.       |
 | created_at       | ISO8601 string | |
 | source_account   | string |                                                                                                                                |
-| source_account_sequence | number |                                                                                                                                |
+| source_account_sequence | string |                                                                                                                                |
 | fee_paid         | number | The fee paid by the source account of this transaction when the transaction was applied to the ledger.                         |
 | operation_count  | number | The number of operations that are contained within this transaction.                                                           |
 | envelope_xdr     | string | A base64 encoded string of the raw `TransactionEnvelope` xdr struct for this transaction                                       |
@@ -30,6 +30,7 @@ To learn more about the concept of transactions in the Stellar network, take a l
 | memo             | string | |
 | signatures | string[] | An array of signatures used to sign this transaction |
 | valid_after | ISO8601 string | |
+| valid_before | ISO8601 string | |
 
 ## Links
 

--- a/services/horizon/internal/docs/reference/resources/transaction.md
+++ b/services/horizon/internal/docs/reference/resources/transaction.md
@@ -14,70 +14,84 @@ To learn more about the concept of transactions in the Stellar network, take a l
 | ---------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------ |
 | id               | string | The canonical id of this transaction, suitable for use as the :id parameter for url templates that require a transaction's ID. |
 | paging_token     | string | A [paging token](./page.md) suitable for use as the `cursor` parameter to transaction collection resources.                   |
+| successful       | boolean | |
 | hash             | string | A hex-encoded SHA-256 hash of the transaction's [XDR](../../learn/xdr.md)-encoded form.                                                              |
 | ledger           | number | Sequence number of the ledger in which this transaction was applied.       |
-| account          | string |                                                                                                                                |
-| account_sequence | number |                                                                                                                                |
+| created_at       | ISO8601 string | |
+| source_account   | string |                                                                                                                                |
+| source_account_sequence | number |                                                                                                                                |
 | fee_paid         | number | The fee paid by the source account of this transaction when the transaction was applied to the ledger.                         |
 | operation_count  | number | The number of operations that are contained within this transaction.                                                           |
 | envelope_xdr     | string | A base64 encoded string of the raw `TransactionEnvelope` xdr struct for this transaction                                       |
 | result_xdr       | string | A base64 encoded string of the raw `TransactionResultPair` xdr struct for this transaction                                     |
 | result_meta_xdr  | string | A base64 encoded string of the raw `TransactionMeta` xdr struct for this transaction                                           |
-| fee_meta_xdr  | string | A base64 encoded string of the raw `LedgerEntryChanges` xdr struct produced by taking fees for this transaction.                                           |
+| fee_meta_xdr     | string | A base64 encoded string of the raw `LedgerEntryChanges` xdr struct produced by taking fees for this transaction.                                           |
+| memo_type        | string | |
+| memo             | string | |
+| signatures | string[] | An array of signatures used to sign this transaction |
+| valid_after | ISO8601 string | |
 
 ## Links
 
 |                   rel                    |                                           Example                                           |                             Description                          |
 | ---------------------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| self | `/transactions/6391dd190f15f7d1665ba53c63842e368f485651a53d8d852ed442a446d1c69a`|  |
-| account | `/accounts/GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ` | The source [account](../accounts-single.md) for this transaction. |
-| ledger | `/ledgers/3` | The [ledger](../ledgers-single.md) in which this transaction was applied. |
-| operations | `/transactions/6391dd190f15f7d1665ba53c63842e368f485651a53d8d852ed442a446d1c69a/operations` | [Operations](../operations-for-transaction.md) included in this transaction. |
-| effects | `/transactions/6391dd190f15f7d1665ba53c63842e368f485651a53d8d852ed442a446d1c69a/effects` | [Effects](../effects-for-transaction.md) which resulted by operations in this transaction. |
-| precedes | `/transactions?cursor=12884905984&order=asc` | A collection of transactions that occur after this transaction. |
-| succeeds | `/transactions?cursor=12884905984&order=desc` | A collection of transactions that occur before this transaction. |
+| self | `https://horizon-testnet.stellar.org/transactions/cb9a25394acb6fe0d1d9bdea5afc01cafe2c6fde59a96ddceb2564a65780a81f` |  |
+| account | `https://horizon-testnet.stellar.org/accounts/GCDLRUXOD6KA53G5ILL435TZAISNLPS4EKIHSOVY3MVD3DVJ333NO4DT` | The source [account](../accounts-single.md) for this transaction. |
+| ledger | `https://horizon-testnet.stellar.org/ledgers/2352988` | The [ledger](../ledgers-single.md) in which this transaction was applied. |
+| operations | `https://horizon-testnet.stellar.org/transactions/cb9a25394acb6fe0d1d9bdea5afc01cafe2c6fde59a96ddceb2564a65780a81f/operations{?cursor,limit,order}"` | [Operations](../operations-for-transaction.md) included in this transaction. |
+| effects | `https://horizon-testnet.stellar.org/transactions/cb9a25394acb6fe0d1d9bdea5afc01cafe2c6fde59a96ddceb2564a65780a81f/effects{?cursor,limit,order}"` | [Effects](../effects-for-transaction.md) which resulted by operations in this transaction. |
+| precedes | `https://horizon-testnet.stellar.org/transactions?order=asc&cursor=10106006507900928` | A collection of transactions that occur after this transaction. |
+| succeeds | `https://horizon-testnet.stellar.org/transactions?order=desc&cursor=10106006507900928` | A collection of transactions that occur before this transaction. |
 
 ## Example
 
 ```json
 {
   "_links": {
-    "account": {
-      "href": "/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K"
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/transactions/cb9a25394acb6fe0d1d9bdea5afc01cafe2c6fde59a96ddceb2564a65780a81f"
     },
-    "effects": {
-      "href": "/transactions/fa78cb43d72171fdb2c6376be12d57daa787b1fa1a9fdd0e9453e1f41ee5f15a/effects{?cursor,limit,order}",
-      "templated": true
+    "account": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GCDLRUXOD6KA53G5ILL435TZAISNLPS4EKIHSOVY3MVD3DVJ333NO4DT"
     },
     "ledger": {
-      "href": "/ledgers/146970"
+      "href": "https://horizon-testnet.stellar.org/ledgers/2352988"
     },
     "operations": {
-      "href": "/transactions/fa78cb43d72171fdb2c6376be12d57daa787b1fa1a9fdd0e9453e1f41ee5f15a/operations{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/transactions/cb9a25394acb6fe0d1d9bdea5afc01cafe2c6fde59a96ddceb2564a65780a81f/operations{?cursor,limit,order}",
+      "templated": true
+    },
+    "effects": {
+      "href": "https://horizon-testnet.stellar.org/transactions/cb9a25394acb6fe0d1d9bdea5afc01cafe2c6fde59a96ddceb2564a65780a81f/effects{?cursor,limit,order}",
       "templated": true
     },
     "precedes": {
-      "href": "/transactions?cursor=631231343497216\u0026order=asc"
-    },
-    "self": {
-      "href": "/transactions/fa78cb43d72171fdb2c6376be12d57daa787b1fa1a9fdd0e9453e1f41ee5f15a"
+      "href": "https://horizon-testnet.stellar.org/transactions?order=asc&cursor=10106006507900928"
     },
     "succeeds": {
-      "href": "/transactions?cursor=631231343497216\u0026order=desc"
+      "href": "https://horizon-testnet.stellar.org/transactions?order=desc&cursor=10106006507900928"
     }
   },
-  "id": "fa78cb43d72171fdb2c6376be12d57daa787b1fa1a9fdd0e9453e1f41ee5f15a",
-  "paging_token": "631231343497216",
-  "hash": "fa78cb43d72171fdb2c6376be12d57daa787b1fa1a9fdd0e9453e1f41ee5f15a",
-  "ledger": 146970,
-  "created_at": "2015-09-24T10:07:09Z",
-  "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
-  "account_sequence": 279172874343,
-  "fee_paid": 0,
+  "id": "cb9a25394acb6fe0d1d9bdea5afc01cafe2c6fde59a96ddceb2564a65780a81f",
+  "paging_token": "10106006507900928",
+  "successful": true,
+  "hash": "cb9a25394acb6fe0d1d9bdea5afc01cafe2c6fde59a96ddceb2564a65780a81f",
+  "ledger": 2352988,
+  "created_at": "2019-02-21T21:44:13Z",
+  "source_account": "GCDLRUXOD6KA53G5ILL435TZAISNLPS4EKIHSOVY3MVD3DVJ333NO4DT",
+  "source_account_sequence": "10105916313567234",
+  "fee_paid": 100,
   "operation_count": 1,
-  "envelope_xdr": "AAAAAGXNhLrhGtltTwCpmqlarh7s1DB2hIkbP//jgzn4Fos/AAAACgAAAEEAAABnAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA2ddmTOFAgr21Crs2RXRGLhiAKxicZb/IERyEZL/Y2kUAAAAXSHboAAAAAAAAAAAB+BaLPwAAAECDEEZmzbgBr5fc3mfJsCjWPDtL6H8/vf16me121CC09ONyWJZnw0PUvp4qusmRwC6ZKfLDdk8F3Rq41s+yOgQD",
-  "result_xdr": "AAAAAAAAAAoAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
-  "result_meta_xdr": "AAAAAAAAAAEAAAACAAAAAAACPhoAAAAAAAAAANnXZkzhQIK9tQq7NkV0Ri4YgCsYnGW/yBEchGS/2NpFAAAAF0h26AAAAj4aAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQACPhoAAAAAAAAAAGXNhLrhGtltTwCpmqlarh7s1DB2hIkbP//jgzn4Fos/AABT8kS2c/oAAABBAAAAZwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAA"
+  "envelope_xdr": "AAAAAIa40u4flA7s3ULXzfZ5AiTVvlwikHk6uNsqPY6p3vbXAAAAZAAj50cAAAACAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAB2Fmc2RmYXMAAAAAAQAAAAAAAAABAAAAAIa40u4flA7s3ULXzfZ5AiTVvlwikHk6uNsqPY6p3vbXAAAAAAAAAAEqBfIAAAAAAAAAAAGp3vbXAAAAQKElK3CoNo1f8fWIGeJm98lw2AaFiyVVFhx3uFok0XVW3MHV9MubtEhfA+n1iLPrxmzHtHfmZsumWk+sOEQlSwI=",
+  "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+  "result_meta_xdr": "AAAAAQAAAAIAAAADACPnXAAAAAAAAAAAhrjS7h+UDuzdQtfN9nkCJNW+XCKQeTq42yo9jqne9tcAAAAXSHbnOAAj50cAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABACPnXAAAAAAAAAAAhrjS7h+UDuzdQtfN9nkCJNW+XCKQeTq42yo9jqne9tcAAAAXSHbnOAAj50cAAAACAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAA==",
+  "fee_meta_xdr": "AAAAAgAAAAMAI+dTAAAAAAAAAACGuNLuH5QO7N1C1832eQIk1b5cIpB5OrjbKj2Oqd721wAAABdIduecACPnRwAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAI+dcAAAAAAAAAACGuNLuH5QO7N1C1832eQIk1b5cIpB5OrjbKj2Oqd721wAAABdIduc4ACPnRwAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+  "memo_type": "text",
+  "memo": "afsdfas",
+  "valid_after": "1970-01-01T00:00:00Z",
+  "signatures": [
+    "oSUrcKg2jV/x9YgZ4mb3yXDYBoWLJVUWHHe4WiTRdVbcwdX0y5u0SF8D6fWIs+vGbMe0d+Zmy6ZaT6w4RCVLAg=="
+  ]
 }
 ```
 


### PR DESCRIPTION
I noticed that `account` was no longer present in the newest responses, and while updating that, caught a couple other difference as well. 

* Links are full URLs, not just paths
* `account` -> `source_account`
* `account_sequence` -> `source_account_sequence`
* `successful`
* `signatures`
* `memo`/`memo_type`
* `valid_after`, but I'm not sure if this is always present, and I'm not sure how to note that in the table.
* `created_at`, I'm not sure if the type should just be `string`

I completely replaced the examples with a new transaction, since it seemed wrong to mix the data (even for example purposes).