### PR TITLE
horizon: Add ledger capacity stats

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -8,6 +8,10 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ## Unreleased
 
+### Deprecations
+
+* `/operation_fee_stats` is deprecated in favour of `/fee_stats`. Will be removed in v0.18.0.
+
 ### Breaking changes
 
 * This Horizon version no longer supports Core <10.0.0. Horizon can still ingest version <10 ledgers.

--- a/services/horizon/internal/actions_operation_fee_stats.go
+++ b/services/horizon/internal/actions_operation_fee_stats.go
@@ -20,21 +20,22 @@ var _ actions.JSONer = (*OperationFeeStatsAction)(nil)
 // current state of operation fees on the network.
 type OperationFeeStatsAction struct {
 	Action
-	Min         int64
-	Mode        int64
-	P10         int64
-	P20         int64
-	P30         int64
-	P40         int64
-	P50         int64
-	P60         int64
-	P70         int64
-	P80         int64
-	P90         int64
-	P95         int64
-	P99         int64
-	LastBaseFee int64
-	LastLedger  int64
+	FeeMin              int64
+	FeeMode             int64
+	FeeP10              int64
+	FeeP20              int64
+	FeeP30              int64
+	FeeP40              int64
+	FeeP50              int64
+	FeeP60              int64
+	FeeP70              int64
+	FeeP80              int64
+	FeeP90              int64
+	FeeP95              int64
+	FeeP99              int64
+	LedgerCapacityUsage string
+	LastBaseFee         int64
+	LastLedger          int64
 }
 
 // JSON is a method for actions.JSON
@@ -57,21 +58,22 @@ func (action *OperationFeeStatsAction) JSON() error {
 		action.loadRecords,
 		func() {
 			hal.Render(action.W, map[string]string{
-				"min_accepted_fee":     fmt.Sprint(action.Min),
-				"mode_accepted_fee":    fmt.Sprint(action.Mode),
-				"p10_accepted_fee":     fmt.Sprint(action.P10),
-				"p20_accepted_fee":     fmt.Sprint(action.P20),
-				"p30_accepted_fee":     fmt.Sprint(action.P30),
-				"p40_accepted_fee":     fmt.Sprint(action.P40),
-				"p50_accepted_fee":     fmt.Sprint(action.P50),
-				"p60_accepted_fee":     fmt.Sprint(action.P60),
-				"p70_accepted_fee":     fmt.Sprint(action.P70),
-				"p80_accepted_fee":     fmt.Sprint(action.P80),
-				"p90_accepted_fee":     fmt.Sprint(action.P90),
-				"p95_accepted_fee":     fmt.Sprint(action.P95),
-				"p99_accepted_fee":     fmt.Sprint(action.P99),
-				"last_ledger_base_fee": fmt.Sprint(action.LastBaseFee),
-				"last_ledger":          fmt.Sprint(action.LastLedger),
+				"min_accepted_fee":      fmt.Sprint(action.FeeMin),
+				"mode_accepted_fee":     fmt.Sprint(action.FeeMode),
+				"p10_accepted_fee":      fmt.Sprint(action.FeeP10),
+				"p20_accepted_fee":      fmt.Sprint(action.FeeP20),
+				"p30_accepted_fee":      fmt.Sprint(action.FeeP30),
+				"p40_accepted_fee":      fmt.Sprint(action.FeeP40),
+				"p50_accepted_fee":      fmt.Sprint(action.FeeP50),
+				"p60_accepted_fee":      fmt.Sprint(action.FeeP60),
+				"p70_accepted_fee":      fmt.Sprint(action.FeeP70),
+				"p80_accepted_fee":      fmt.Sprint(action.FeeP80),
+				"p90_accepted_fee":      fmt.Sprint(action.FeeP90),
+				"p95_accepted_fee":      fmt.Sprint(action.FeeP95),
+				"p99_accepted_fee":      fmt.Sprint(action.FeeP99),
+				"ledger_capacity_usage": action.LedgerCapacityUsage,
+				"last_ledger_base_fee":  fmt.Sprint(action.LastBaseFee),
+				"last_ledger":           fmt.Sprint(action.LastLedger),
 			})
 		},
 	)
@@ -80,19 +82,20 @@ func (action *OperationFeeStatsAction) JSON() error {
 
 func (action *OperationFeeStatsAction) loadRecords() {
 	cur := operationfeestats.CurrentState()
-	action.Min = cur.Min
-	action.Mode = cur.Mode
+	action.FeeMin = cur.FeeMin
+	action.FeeMode = cur.FeeMode
 	action.LastBaseFee = cur.LastBaseFee
 	action.LastLedger = cur.LastLedger
-	action.P10 = cur.P10
-	action.P20 = cur.P20
-	action.P30 = cur.P30
-	action.P40 = cur.P40
-	action.P50 = cur.P50
-	action.P60 = cur.P60
-	action.P70 = cur.P70
-	action.P80 = cur.P80
-	action.P90 = cur.P90
-	action.P95 = cur.P95
-	action.P99 = cur.P99
+	action.LedgerCapacityUsage = cur.LedgerCapacityUsage
+	action.FeeP10 = cur.FeeP10
+	action.FeeP20 = cur.FeeP20
+	action.FeeP30 = cur.FeeP30
+	action.FeeP40 = cur.FeeP40
+	action.FeeP50 = cur.FeeP50
+	action.FeeP60 = cur.FeeP60
+	action.FeeP70 = cur.FeeP70
+	action.FeeP80 = cur.FeeP80
+	action.FeeP90 = cur.FeeP90
+	action.FeeP95 = cur.FeeP95
+	action.FeeP99 = cur.FeeP99
 }

--- a/services/horizon/internal/actions_operation_fee_stats_test.go
+++ b/services/horizon/internal/actions_operation_fee_stats_test.go
@@ -8,21 +8,22 @@ import (
 func TestOperationFeeTestsActions_Show(t *testing.T) {
 
 	testCases := []struct {
-		scenario    string
-		lastbasefee string
-		min         string
-		mode        string
-		p10         string
-		p20         string
-		p30         string
-		p40         string
-		p50         string
-		p60         string
-		p70         string
-		p80         string
-		p90         string
-		p95         string
-		p99         string
+		scenario            string
+		lastbasefee         string
+		min                 string
+		mode                string
+		p10                 string
+		p20                 string
+		p30                 string
+		p40                 string
+		p50                 string
+		p60                 string
+		p70                 string
+		p80                 string
+		p90                 string
+		p95                 string
+		p99                 string
+		ledgerCapacityUsage string
 	}{
 		// happy path
 		{
@@ -41,6 +42,7 @@ func TestOperationFeeTestsActions_Show(t *testing.T) {
 			"100",
 			"100",
 			"100",
+			"0.04",
 		},
 		// no transactions in last 5 ledgers
 		{
@@ -59,6 +61,7 @@ func TestOperationFeeTestsActions_Show(t *testing.T) {
 			"100",
 			"100",
 			"100",
+			"0.00",
 		},
 		// transactions with varying fees
 		{
@@ -77,6 +80,7 @@ func TestOperationFeeTestsActions_Show(t *testing.T) {
 			"400",
 			"400",
 			"400",
+			"0.03",
 		},
 	}
 
@@ -84,6 +88,10 @@ func TestOperationFeeTestsActions_Show(t *testing.T) {
 		t.Run("/operation_fee_stats", func(t *testing.T) {
 			ht := StartHTTPTest(t, kase.scenario)
 			defer ht.Finish()
+
+			// Update max_tx_set_size on ledgers
+			_, err := ht.HorizonSession().ExecRaw("UPDATE history_ledgers SET max_tx_set_size = 50")
+			ht.Require.NoError(err)
 
 			ht.App.UpdateOperationFeeStatsState()
 
@@ -107,6 +115,7 @@ func TestOperationFeeTestsActions_Show(t *testing.T) {
 				ht.Assert.Equal(kase.p90, result["p90_accepted_fee"], "p90")
 				ht.Assert.Equal(kase.p95, result["p95_accepted_fee"], "p95")
 				ht.Assert.Equal(kase.p99, result["p99_accepted_fee"], "p99")
+				ht.Assert.Equal(kase.ledgerCapacityUsage, result["ledger_capacity_usage"], "ledger_capacity_usage")
 			}
 		})
 	}

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -202,6 +202,7 @@ func (a *App) UpdateOperationFeeStatsState() {
 
 	var latest history.LatestLedger
 	var feeStats history.FeeStats
+	var capacityStats history.LedgerCapacityUsageStats
 
 	cur := operationfeestats.CurrentState()
 
@@ -218,41 +219,48 @@ func (a *App) UpdateOperationFeeStatsState() {
 	next.LastBaseFee = int64(latest.BaseFee)
 	next.LastLedger = int64(latest.Sequence)
 
-	err = a.HistoryQ().TransactionsForLastXLedgers(latest.Sequence, &feeStats)
+	err = a.HistoryQ().OperationFeeStatsForXLedgers(latest.Sequence, &feeStats)
 	if err != nil {
 		goto Failed
 	}
 
+	err = a.HistoryQ().LedgerCapacityUsageStatsForXLedgers(latest.Sequence, &capacityStats)
+	if err != nil {
+		goto Failed
+	}
+
+	next.LedgerCapacityUsage = capacityStats.CapacityUsage.String
+
 	// if no transactions in last X ledgers, return
 	// latest ledger's base fee for all
 	if !feeStats.Mode.Valid && !feeStats.Min.Valid {
-		next.Min = next.LastBaseFee
-		next.Mode = next.LastBaseFee
-		next.P10 = next.LastBaseFee
-		next.P20 = next.LastBaseFee
-		next.P30 = next.LastBaseFee
-		next.P40 = next.LastBaseFee
-		next.P50 = next.LastBaseFee
-		next.P60 = next.LastBaseFee
-		next.P70 = next.LastBaseFee
-		next.P80 = next.LastBaseFee
-		next.P90 = next.LastBaseFee
-		next.P95 = next.LastBaseFee
-		next.P99 = next.LastBaseFee
+		next.FeeMin = next.LastBaseFee
+		next.FeeMode = next.LastBaseFee
+		next.FeeP10 = next.LastBaseFee
+		next.FeeP20 = next.LastBaseFee
+		next.FeeP30 = next.LastBaseFee
+		next.FeeP40 = next.LastBaseFee
+		next.FeeP50 = next.LastBaseFee
+		next.FeeP60 = next.LastBaseFee
+		next.FeeP70 = next.LastBaseFee
+		next.FeeP80 = next.LastBaseFee
+		next.FeeP90 = next.LastBaseFee
+		next.FeeP95 = next.LastBaseFee
+		next.FeeP99 = next.LastBaseFee
 	} else {
-		next.Min = feeStats.Min.Int64
-		next.Mode = feeStats.Mode.Int64
-		next.P10 = feeStats.P10.Int64
-		next.P20 = feeStats.P20.Int64
-		next.P30 = feeStats.P30.Int64
-		next.P40 = feeStats.P40.Int64
-		next.P50 = feeStats.P50.Int64
-		next.P60 = feeStats.P60.Int64
-		next.P70 = feeStats.P70.Int64
-		next.P80 = feeStats.P80.Int64
-		next.P90 = feeStats.P90.Int64
-		next.P95 = feeStats.P95.Int64
-		next.P99 = feeStats.P99.Int64
+		next.FeeMin = feeStats.Min.Int64
+		next.FeeMode = feeStats.Mode.Int64
+		next.FeeP10 = feeStats.P10.Int64
+		next.FeeP20 = feeStats.P20.Int64
+		next.FeeP30 = feeStats.P30.Int64
+		next.FeeP40 = feeStats.P40.Int64
+		next.FeeP50 = feeStats.P50.Int64
+		next.FeeP60 = feeStats.P60.Int64
+		next.FeeP70 = feeStats.P70.Int64
+		next.FeeP80 = feeStats.P80.Int64
+		next.FeeP90 = feeStats.P90.Int64
+		next.FeeP95 = feeStats.P95.Int64
+		next.FeeP99 = feeStats.P99.Int64
 	}
 
 	operationfeestats.SetState(next)

--- a/services/horizon/internal/db2/history/ledger.go
+++ b/services/horizon/internal/db2/history/ledger.go
@@ -44,6 +44,20 @@ func (q *Q) LedgersBySequence(dest interface{}, seqs ...int32) error {
 	return q.Select(dest, sql)
 }
 
+// LedgerCapacityUsageStatsForXLedgers returns ledger capacity stats for the last 5 ledgers.
+// Currently, we hard code the query to return the last 5 ledgers. In the future this
+// may be configurable.
+func (q *Q) LedgerCapacityUsageStatsForXLedgers(currentSeq int32, dest *LedgerCapacityUsageStats) error {
+	return q.GetRaw(dest, `
+		SELECT
+			round(avg(
+				cast(successful_transaction_count+failed_transaction_count as decimal)/max_tx_set_size
+			), 2) AS "ledger_capacity_usage"
+		FROM history_ledgers
+		WHERE sequence > $1 AND sequence <= $2
+	`, currentSeq-5, currentSeq)
+}
+
 // Page specifies the paging constraints for the query being built by `q`.
 func (q *LedgersQ) Page(page db2.PageQuery) *LedgersQ {
 	if q.Err != nil {

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -159,8 +159,8 @@ type EffectsQ struct {
 // `history_effects` table.
 type EffectType int
 
-// FeeStats is a row of data from the min, mode aggregate functions over the
-// `history_ledgers` table.
+// FeeStats is a row of data from the min, mode, percentile aggregate functions over the
+// `history_transactions` table.
 type FeeStats struct {
 	Min  null.Int `db:"min"`
 	Mode null.Int `db:"mode"`
@@ -205,6 +205,11 @@ type Ledger struct {
 	MaxTxSetSize               int32       `db:"max_tx_set_size"`
 	ProtocolVersion            int32       `db:"protocol_version"`
 	LedgerHeaderXDR            null.String `db:"ledger_header"`
+}
+
+// LedgerCapacityUsageStats contains ledgers fullness stats.
+type LedgerCapacityUsageStats struct {
+	CapacityUsage null.String `db:"ledger_capacity_usage"`
 }
 
 // LedgerCache is a helper struct to load ledger data related to a batch of

--- a/services/horizon/internal/db2/history/transaction.go
+++ b/services/horizon/internal/db2/history/transaction.go
@@ -16,30 +16,6 @@ func (q *Q) TransactionByHash(dest interface{}, hash string) error {
 	return q.Get(dest, sql)
 }
 
-// TransactionsForLastXLedgers filters the query to only the last X ledgers worth of transactions.
-// Currently, we hard code the query to return the last 5 ledgers worth of transactions. In the
-// future this may be configurable.
-func (q *Q) TransactionsForLastXLedgers(currentSeq int32, dest interface{}) error {
-	return q.GetRaw(dest, `
-		SELECT
-			ceil(min(fee_paid/operation_count)) AS "min",
-			ceil(mode() within group (order by fee_paid/operation_count)) AS "mode",
-			ceil(percentile_cont(0.10) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p10",
-			ceil(percentile_cont(0.20) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p20",
-			ceil(percentile_cont(0.30) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p30",
-			ceil(percentile_cont(0.40) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p40",
-			ceil(percentile_cont(0.50) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p50",
-			ceil(percentile_cont(0.60) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p60",
-			ceil(percentile_cont(0.70) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p70",
-			ceil(percentile_cont(0.80) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p80",
-			ceil(percentile_cont(0.90) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p90",
-			ceil(percentile_cont(0.95) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p95",
-			ceil(percentile_cont(0.99) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p99"
-		FROM history_transactions
-		WHERE ledger_sequence > $1 AND ledger_sequence <= $2
-	`, currentSeq-5, currentSeq)
-}
-
 // Transactions provides a helper to filter rows from the `history_transactions`
 // table with pre-defined filters.  See `TransactionsQ` methods for the
 // available filters.

--- a/services/horizon/internal/init_web.go
+++ b/services/horizon/internal/init_web.go
@@ -151,6 +151,8 @@ func initWebActions(app *App) {
 	}
 
 	// Network state related endpoints
+	r.Get("/fee_stats", OperationFeeStatsAction{}.Handle)
+	// Deprecated - remove in: horizon-v0.18.0
 	r.Get("/operation_fee_stats", OperationFeeStatsAction{}.Handle)
 
 	// friendbot

--- a/services/horizon/internal/operationfeestats/main.go
+++ b/services/horizon/internal/operationfeestats/main.go
@@ -12,21 +12,22 @@ import (
 // State represents a snapshot of horizon's view of the state of operation fee's
 // on the network.
 type State struct {
-	Min         int64
-	Mode        int64
-	P10         int64
-	P20         int64
-	P30         int64
-	P40         int64
-	P50         int64
-	P60         int64
-	P70         int64
-	P80         int64
-	P90         int64
-	P95         int64
-	P99         int64
-	LastBaseFee int64
-	LastLedger  int64
+	FeeMin              int64
+	FeeMode             int64
+	FeeP10              int64
+	FeeP20              int64
+	FeeP30              int64
+	FeeP40              int64
+	FeeP50              int64
+	FeeP60              int64
+	FeeP70              int64
+	FeeP80              int64
+	FeeP90              int64
+	FeeP95              int64
+	FeeP99              int64
+	LedgerCapacityUsage string
+	LastBaseFee         int64
+	LastLedger          int64
 }
 
 // CurrentState returns the cached snapshot of operation fee state


### PR DESCRIPTION
I'm wondering if we should rename `/operation_fee_stats` to simply `/fee_stats`.

Also, renamed `TransactionsForLastXLedgers` to `OperationFeeStatsForXLedgers`.

Deployed `ledger-capacity-stats` branch to: https://horizon-dev-pubnet.stellar.org/operation_fee_stats and https://horizon-testnet.stellar.org/operation_fee_stats.

Close #891.