### PR TITLE
horizon: improve logging for update operation fee stats

### DIFF
--- a/services/horizon/internal/actions_operation_fee_stats_test.go
+++ b/services/horizon/internal/actions_operation_fee_stats_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 func TestOperationFeeTestsActions_Show(t *testing.T) {
-
 	testCases := []struct {
 		scenario            string
 		lastbasefee         string

--- a/services/horizon/internal/db2/history/ledger.go
+++ b/services/horizon/internal/db2/history/ledger.go
@@ -44,10 +44,10 @@ func (q *Q) LedgersBySequence(dest interface{}, seqs ...int32) error {
 	return q.Select(dest, sql)
 }
 
-// LedgerCapacityUsageStatsForXLedgers returns ledger capacity stats for the last 5 ledgers.
-// Currently, we hard code the query to return the last 5 ledgers. In the future this
-// may be configurable.
-func (q *Q) LedgerCapacityUsageStatsForXLedgers(currentSeq int32, dest *LedgerCapacityUsageStats) error {
+// LedgerCapacityUsageStats returns ledger capacity stats for the last 5 ledgers.
+// Currently, we hard code the query to return the last 5 ledgers.
+// TODO: make the number of ledgers configurable.
+func (q *Q) LedgerCapacityUsageStats(currentSeq int32, dest *LedgerCapacityUsageStats) error {
 	return q.GetRaw(dest, `
 		SELECT
 			round(avg(

--- a/services/horizon/internal/db2/history/operation.go
+++ b/services/horizon/internal/db2/history/operation.go
@@ -30,10 +30,10 @@ func (r *Operation) UnmarshalDetails(dest interface{}) error {
 	return err
 }
 
-// OperationFeeStatsForXLedgers returns operation fee stats for the last 5 ledgers.
-// Currently, we hard code the query to return the last 5 ledgers worth of transactions. In the
-// future this may be configurable.
-func (q *Q) OperationFeeStatsForXLedgers(currentSeq int32, dest *FeeStats) error {
+// OperationFeeStats returns operation fee stats for the last 5 ledgers.
+// Currently, we hard code the query to return the last 5 ledgers worth of transactions.
+// TODO: make the number of ledgers configurable.
+func (q *Q) OperationFeeStats(currentSeq int32, dest *FeeStats) error {
 	return q.GetRaw(dest, `
 		SELECT
 			ceil(min(fee_paid/operation_count)) AS "min",

--- a/services/horizon/internal/operationfeestats/main.go
+++ b/services/horizon/internal/operationfeestats/main.go
@@ -12,22 +12,23 @@ import (
 // State represents a snapshot of horizon's view of the state of operation fee's
 // on the network.
 type State struct {
-	FeeMin              int64
-	FeeMode             int64
-	FeeP10              int64
-	FeeP20              int64
-	FeeP30              int64
-	FeeP40              int64
-	FeeP50              int64
-	FeeP60              int64
-	FeeP70              int64
-	FeeP80              int64
-	FeeP90              int64
-	FeeP95              int64
-	FeeP99              int64
+	FeeMin      int64
+	FeeMode     int64
+	FeeP10      int64
+	FeeP20      int64
+	FeeP30      int64
+	FeeP40      int64
+	FeeP50      int64
+	FeeP60      int64
+	FeeP70      int64
+	FeeP80      int64
+	FeeP90      int64
+	FeeP95      int64
+	FeeP99      int64
+	LastBaseFee int64
+	LastLedger  int64
+
 	LedgerCapacityUsage string
-	LastBaseFee         int64
-	LastLedger          int64
 }
 
 // CurrentState returns the cached snapshot of operation fee state


### PR DESCRIPTION
We need to log what went wrong more clearly in order to have an easier life for debugging.