### PR TITLE
Cast fee stats to bigint

### DIFF
--- a/services/horizon/internal/db2/history/operation.go
+++ b/services/horizon/internal/db2/history/operation.go
@@ -36,19 +36,19 @@ func (r *Operation) UnmarshalDetails(dest interface{}) error {
 func (q *Q) OperationFeeStats(currentSeq int32, dest *FeeStats) error {
 	return q.GetRaw(dest, `
 		SELECT
-			ceil(min(fee_paid/operation_count)) :: bigint AS "min",
-			ceil(mode() within group (order by fee_paid/operation_count)) :: bigint AS "mode",
-			ceil(percentile_cont(0.10) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p10",
-			ceil(percentile_cont(0.20) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p20",
-			ceil(percentile_cont(0.30) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p30",
-			ceil(percentile_cont(0.40) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p40",
-			ceil(percentile_cont(0.50) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p50",
-			ceil(percentile_cont(0.60) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p60",
-			ceil(percentile_cont(0.70) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p70",
-			ceil(percentile_cont(0.80) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p80",
-			ceil(percentile_cont(0.90) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p90",
-			ceil(percentile_cont(0.95) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p95",
-			ceil(percentile_cont(0.99) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p99"
+			ceil(min(fee_paid/operation_count))::bigint AS "min",
+			ceil(mode() within group (order by fee_paid/operation_count))::bigint AS "mode",
+			ceil(percentile_cont(0.10) WITHIN GROUP (ORDER BY fee_paid/operation_count))::bigint AS "p10",
+			ceil(percentile_cont(0.20) WITHIN GROUP (ORDER BY fee_paid/operation_count))::bigint AS "p20",
+			ceil(percentile_cont(0.30) WITHIN GROUP (ORDER BY fee_paid/operation_count))::bigint AS "p30",
+			ceil(percentile_cont(0.40) WITHIN GROUP (ORDER BY fee_paid/operation_count))::bigint AS "p40",
+			ceil(percentile_cont(0.50) WITHIN GROUP (ORDER BY fee_paid/operation_count))::bigint AS "p50",
+			ceil(percentile_cont(0.60) WITHIN GROUP (ORDER BY fee_paid/operation_count))::bigint AS "p60",
+			ceil(percentile_cont(0.70) WITHIN GROUP (ORDER BY fee_paid/operation_count))::bigint AS "p70",
+			ceil(percentile_cont(0.80) WITHIN GROUP (ORDER BY fee_paid/operation_count))::bigint AS "p80",
+			ceil(percentile_cont(0.90) WITHIN GROUP (ORDER BY fee_paid/operation_count))::bigint AS "p90",
+			ceil(percentile_cont(0.95) WITHIN GROUP (ORDER BY fee_paid/operation_count))::bigint AS "p95",
+			ceil(percentile_cont(0.99) WITHIN GROUP (ORDER BY fee_paid/operation_count))::bigint AS "p99"
 		FROM history_transactions
 		WHERE ledger_sequence > $1 AND ledger_sequence <= $2
 	`, currentSeq-5, currentSeq)

--- a/services/horizon/internal/db2/history/operation.go
+++ b/services/horizon/internal/db2/history/operation.go
@@ -36,19 +36,19 @@ func (r *Operation) UnmarshalDetails(dest interface{}) error {
 func (q *Q) OperationFeeStats(currentSeq int32, dest *FeeStats) error {
 	return q.GetRaw(dest, `
 		SELECT
-			ceil(min(fee_paid/operation_count) :: bigint) AS "min",
-			ceil(mode() within group (order by fee_paid/operation_count) :: bigint) AS "mode",
-			ceil(percentile_cont(0.10) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p10",
-			ceil(percentile_cont(0.20) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p20",
-			ceil(percentile_cont(0.30) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p30",
-			ceil(percentile_cont(0.40) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p40",
-			ceil(percentile_cont(0.50) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p50",
-			ceil(percentile_cont(0.60) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p60",
-			ceil(percentile_cont(0.70) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p70",
-			ceil(percentile_cont(0.80) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p80",
-			ceil(percentile_cont(0.90) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p90",
-			ceil(percentile_cont(0.95) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p95",
-			ceil(percentile_cont(0.99) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p99"
+			ceil(min(fee_paid/operation_count)) :: bigint AS "min",
+			ceil(mode() within group (order by fee_paid/operation_count)) :: bigint AS "mode",
+			ceil(percentile_cont(0.10) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p10",
+			ceil(percentile_cont(0.20) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p20",
+			ceil(percentile_cont(0.30) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p30",
+			ceil(percentile_cont(0.40) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p40",
+			ceil(percentile_cont(0.50) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p50",
+			ceil(percentile_cont(0.60) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p60",
+			ceil(percentile_cont(0.70) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p70",
+			ceil(percentile_cont(0.80) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p80",
+			ceil(percentile_cont(0.90) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p90",
+			ceil(percentile_cont(0.95) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p95",
+			ceil(percentile_cont(0.99) WITHIN GROUP (ORDER BY fee_paid/operation_count)) :: bigint AS "p99"
 		FROM history_transactions
 		WHERE ledger_sequence > $1 AND ledger_sequence <= $2
 	`, currentSeq-5, currentSeq)

--- a/services/horizon/internal/db2/history/operation.go
+++ b/services/horizon/internal/db2/history/operation.go
@@ -36,19 +36,19 @@ func (r *Operation) UnmarshalDetails(dest interface{}) error {
 func (q *Q) OperationFeeStats(currentSeq int32, dest *FeeStats) error {
 	return q.GetRaw(dest, `
 		SELECT
-			ceil(min(fee_paid/operation_count)) AS "min",
-			ceil(mode() within group (order by fee_paid/operation_count)) AS "mode",
-			ceil(percentile_cont(0.10) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p10",
-			ceil(percentile_cont(0.20) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p20",
-			ceil(percentile_cont(0.30) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p30",
-			ceil(percentile_cont(0.40) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p40",
-			ceil(percentile_cont(0.50) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p50",
-			ceil(percentile_cont(0.60) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p60",
-			ceil(percentile_cont(0.70) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p70",
-			ceil(percentile_cont(0.80) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p80",
-			ceil(percentile_cont(0.90) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p90",
-			ceil(percentile_cont(0.95) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p95",
-			ceil(percentile_cont(0.99) WITHIN GROUP (ORDER BY fee_paid/operation_count)) AS "p99"
+			ceil(min(fee_paid/operation_count) :: bigint) AS "min",
+			ceil(mode() within group (order by fee_paid/operation_count) :: bigint) AS "mode",
+			ceil(percentile_cont(0.10) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p10",
+			ceil(percentile_cont(0.20) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p20",
+			ceil(percentile_cont(0.30) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p30",
+			ceil(percentile_cont(0.40) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p40",
+			ceil(percentile_cont(0.50) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p50",
+			ceil(percentile_cont(0.60) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p60",
+			ceil(percentile_cont(0.70) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p70",
+			ceil(percentile_cont(0.80) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p80",
+			ceil(percentile_cont(0.90) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p90",
+			ceil(percentile_cont(0.95) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p95",
+			ceil(percentile_cont(0.99) WITHIN GROUP (ORDER BY fee_paid/operation_count) :: bigint) AS "p99"
 		FROM history_transactions
 		WHERE ledger_sequence > $1 AND ledger_sequence <= $2
 	`, currentSeq-5, currentSeq)


### PR DESCRIPTION
`ceil()` function in PostgreSQL returns the same type as input. It's possible that percentile value will be returned in e-notation (like `2.000081e+06`) and Go drivers have problems with converting such values into `int` returning an error:
```
sql: Scan error on column index 10, name "p90": converting driver.Value type float64 ("2.000081e+06") to a int64: invalid syntax
```
We cast values to `bigint` to prevent such errors.