### PR TITLE
exp/clients/horizon: initial endpoints

### DIFF
--- a/clients/horizon/error.go
+++ b/clients/horizon/error.go
@@ -12,7 +12,7 @@ func (herr Error) Error() string {
 	return `Horizon error: "` + herr.Problem.Title + `". Check horizon.Error.Problem for more information.`
 }
 
-// ToProblem converts the Prolem to a problem.P
+// ToProblem converts the Problem to a problem.P
 func (prob Problem) ToProblem() problem.P {
 	extras := make(map[string]interface{})
 	for k, v := range prob.Extras {

--- a/exp/clients/horizon/account_request.go
+++ b/exp/clients/horizon/account_request.go
@@ -1,4 +1,4 @@
-package horizon
+package horizonclient
 
 import (
 	"fmt"
@@ -12,15 +12,13 @@ import (
 // If both AccounId and DataKey are present, then the endpoint for getting account data is returned
 func (ar AccountRequest) BuildUrl() (endpoint string, err error) {
 
-	// to do:  check if ar.accountId  is a valid public key. I wonder if this is the right place for this.
+	nParams := checkParams(ar.DataKey, ar.AccountId)
 
-	noOfParamsSet := checkParams(ar.DataKey, ar.AccountId)
-
-	if noOfParamsSet >= 1 && ar.AccountId == "" {
+	if nParams >= 1 && ar.AccountId == "" {
 		err = errors.New("Invalid request. Too few parameters")
 	}
 
-	if noOfParamsSet <= 0 {
+	if nParams <= 0 {
 		err = errors.New("Invalid request. No parameters")
 	}
 
@@ -41,40 +39,10 @@ func (ar AccountRequest) BuildUrl() (endpoint string, err error) {
 		)
 	}
 
-	query := url.Values{}
-
-	if ar.Cursor != "" {
-		query.Add("cursor", ar.Cursor)
-	}
-
-	if ar.Limit > 0 {
-		query.Add("limit", string(ar.Limit))
-	}
-
-	if ar.Order != "" {
-		query.Add("order", string(ar.Order))
-	}
-
-	endpoint = fmt.Sprintf(
-		"%s",
-		endpoint,
-	)
-
-	queryParams := query.Encode()
-
-	if queryParams != "" {
-		endpoint = fmt.Sprintf(
-			"%s?%s",
-			endpoint,
-			queryParams,
-		)
-	}
-
 	_, err = url.Parse(endpoint)
 	if err != nil {
 		err = errors.Wrap(err, "failed to parse endpoint")
 	}
 
 	return endpoint, err
-
 }

--- a/exp/clients/horizon/account_request.go
+++ b/exp/clients/horizon/account_request.go
@@ -12,7 +12,7 @@ import (
 // If both AccounId and DataKey are present, then the endpoint for getting account data is returned
 func (ar AccountRequest) BuildUrl() (endpoint string, err error) {
 
-	nParams := checkParams(ar.DataKey, ar.AccountId)
+	nParams := countParams(ar.DataKey, ar.AccountId)
 
 	if nParams >= 1 && ar.AccountId == "" {
 		err = errors.New("Invalid request. Too few parameters")

--- a/exp/clients/horizon/account_request.go
+++ b/exp/clients/horizon/account_request.go
@@ -1,0 +1,64 @@
+package horizon
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/stellar/go/support/errors"
+)
+
+func (ar AccountRequest) BuildUrl(rtype string) (endpoint string, err error) {
+
+	switch rtype {
+	case "account":
+		endpoint = fmt.Sprintf(
+			"accounts/%s",
+			ar.AccountId,
+		)
+		break
+
+	case "data":
+		endpoint = fmt.Sprintf(
+			"accounts/%s/data/%s",
+			ar.AccountId,
+			ar.DataKey,
+		)
+		break
+
+	default:
+		err = errors.Wrap(err, "Invalid request type, expected 'id' or 'data'")
+
+	}
+
+	if err != nil {
+		return endpoint, err
+	}
+
+	query := url.Values{}
+
+	if ar.Cursor != "" {
+		query.Add("cursor", ar.Cursor)
+	}
+
+	if ar.Limit > 0 {
+		query.Add("limit", string(ar.Limit))
+	}
+
+	if ar.Order != "" {
+		query.Add("order", string(ar.Order))
+	}
+
+	endpoint = fmt.Sprintf(
+		"%s?%s",
+		endpoint,
+		query.Encode(),
+	)
+
+	_, err = url.Parse(endpoint)
+	if err != nil {
+		err = errors.Wrap(err, "failed to parse endpoint")
+	}
+
+	return endpoint, err
+
+}

--- a/exp/clients/horizon/account_request.go
+++ b/exp/clients/horizon/account_request.go
@@ -15,16 +15,12 @@ func (ar AccountRequest) BuildUrl(rtype string) (endpoint string, err error) {
 			"accounts/%s",
 			ar.AccountId,
 		)
-		break
-
 	case "data":
 		endpoint = fmt.Sprintf(
 			"accounts/%s/data/%s",
 			ar.AccountId,
 			ar.DataKey,
 		)
-		break
-
 	default:
 		err = errors.Wrap(err, "Invalid request type, expected 'id' or 'data'")
 

--- a/exp/clients/horizon/account_request_test.go
+++ b/exp/clients/horizon/account_request_test.go
@@ -1,0 +1,44 @@
+package horizon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountRequestBuildUrl(t *testing.T) {
+
+	ar := AccountRequest{}
+	endpoint, err := ar.BuildUrl()
+
+	// error case: No parameters
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Invalid request. No parameters")
+	}
+
+	ar.DataKey = "test"
+	endpoint, err = ar.BuildUrl()
+
+	// error case: few parameters for building account data endpoint
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Invalid request. Too few parameters")
+	}
+
+	ar.DataKey = ""
+	ar.AccountId = "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"
+	endpoint, err = ar.BuildUrl()
+
+	// It should return valid account details endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU", endpoint)
+
+	ar.DataKey = "test"
+	ar.AccountId = "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"
+	endpoint, err = ar.BuildUrl()
+
+	// It should return valid account data endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/data/test", endpoint)
+
+}

--- a/exp/clients/horizon/account_request_test.go
+++ b/exp/clients/horizon/account_request_test.go
@@ -1,4 +1,4 @@
-package horizon
+package horizonclient
 
 import (
 	"testing"
@@ -8,7 +8,6 @@ import (
 )
 
 func TestAccountRequestBuildUrl(t *testing.T) {
-
 	ar := AccountRequest{}
 	endpoint, err := ar.BuildUrl()
 
@@ -40,5 +39,4 @@ func TestAccountRequestBuildUrl(t *testing.T) {
 	// It should return valid account data endpoint and no errors
 	require.NoError(t, err)
 	assert.Equal(t, "accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/data/test", endpoint)
-
 }

--- a/exp/clients/horizon/asset_request.go
+++ b/exp/clients/horizon/asset_request.go
@@ -1,0 +1,30 @@
+package horizonclient
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/stellar/go/support/errors"
+)
+
+// BuildUrl creates the endpoint to be queried based on the data in the AssetRequest struct.
+// If no data is set, it defaults to the build the URL for all assets
+func (ar AssetRequest) BuildUrl() (endpoint string, err error) {
+	endpoint = "assets"
+
+	queryParams := addQueryParams(ar.ForAssetCode, ar.ForAssetIssuer, ar.Cursor, ar.Limit, ar.Order)
+	if queryParams != "" {
+		endpoint = fmt.Sprintf(
+			"%s?%s",
+			endpoint,
+			queryParams,
+		)
+	}
+
+	_, err = url.Parse(endpoint)
+	if err != nil {
+		err = errors.Wrap(err, "failed to parse endpoint")
+	}
+
+	return endpoint, err
+}

--- a/exp/clients/horizon/asset_request_test.go
+++ b/exp/clients/horizon/asset_request_test.go
@@ -1,0 +1,32 @@
+package horizonclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssetRequestBuildUrl(t *testing.T) {
+	er := AssetRequest{}
+	endpoint, err := er.BuildUrl()
+
+	// It should return valid all assets endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "assets", endpoint)
+
+	er = AssetRequest{ForAssetIssuer: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
+	endpoint, err = er.BuildUrl()
+
+	// It should return valid assets endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "assets?asset_issuer=GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU", endpoint)
+
+	er = AssetRequest{ForAssetIssuer: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU", ForAssetCode: "ABC", Order: OrderDesc}
+	endpoint, err = er.BuildUrl()
+
+	// It should return valid assets endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "assets?asset_code=ABC&asset_issuer=GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU&order=desc", endpoint)
+
+}

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -16,3 +16,20 @@ func (c *Client) AccountDetail(request AccountRequest) (account Account, err err
 	return
 
 }
+
+func (c *Client) AccountData(request AccountRequest) (AccountData AccountData, err error) {
+
+	endpoint, err := request.BuildUrl("data")
+	if err != nil {
+		return
+	}
+
+	resp, err := c.HTTP.Get(c.HorizonURL + endpoint)
+	if err != nil {
+		return
+	}
+
+	err = decodeResponse(resp, &AccountData)
+	return
+
+}

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -1,4 +1,4 @@
-package horizon
+package horizonclient
 
 import (
 	"github.com/stellar/go/support/errors"

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -27,7 +27,7 @@ func (c *Client) AccountDetail(request AccountRequest) (account Account, err err
 
 }
 
-func (c *Client) AccountData(request AccountRequest) (AccountData AccountData, err error) {
+func (c *Client) AccountData(request AccountRequest) (accountData AccountData, err error) {
 
 	if request.AccountId == "" || request.DataKey == "" {
 		err = errors.New("Too few parameters")
@@ -47,7 +47,99 @@ func (c *Client) AccountData(request AccountRequest) (AccountData AccountData, e
 		return
 	}
 
-	err = decodeResponse(resp, &AccountData)
+	err = decodeResponse(resp, &accountData)
+	return
+
+}
+
+func (c *Client) AllEffects(request EffectRequest) (effects EffectsPage, err error) {
+	if request.AccountId != "" || request.LedgerId != "" || request.OperationId != "" || request.TransactionHash != "" {
+		err = errors.New("Too many parameters")
+	}
+
+	if err != nil {
+		return
+	}
+	endpoint, err := request.BuildUrl()
+	if err != nil {
+		return
+	}
+
+	resp, err := c.HTTP.Get(c.HorizonURL + endpoint)
+	if err != nil {
+		return
+	}
+
+	err = decodeResponse(resp, &effects)
+	return
+
+}
+
+func (c *Client) LedgerEffects(request EffectRequest) (effects EffectsPage, err error) {
+	if request.LedgerId == "" {
+		err = errors.New("Ledger Id is not provided.")
+	}
+
+	if err != nil {
+		return
+	}
+	endpoint, err := request.BuildUrl()
+	if err != nil {
+		return
+	}
+
+	resp, err := c.HTTP.Get(c.HorizonURL + endpoint)
+	if err != nil {
+		return
+	}
+
+	err = decodeResponse(resp, &effects)
+	return
+
+}
+
+func (c *Client) OperationEffects(request EffectRequest) (effects EffectsPage, err error) {
+	if request.OperationId == "" {
+		err = errors.New("Operation Id is not provided.")
+	}
+
+	if err != nil {
+		return
+	}
+	endpoint, err := request.BuildUrl()
+	if err != nil {
+		return
+	}
+
+	resp, err := c.HTTP.Get(c.HorizonURL + endpoint)
+	if err != nil {
+		return
+	}
+
+	err = decodeResponse(resp, &effects)
+	return
+
+}
+
+func (c *Client) TransactionEffects(request EffectRequest) (effects EffectsPage, err error) {
+	if request.TransactionHash == "" {
+		err = errors.New("Transaction Hash is not provided.")
+	}
+
+	if err != nil {
+		return
+	}
+	endpoint, err := request.BuildUrl()
+	if err != nil {
+		return
+	}
+
+	resp, err := c.HTTP.Get(c.HorizonURL + endpoint)
+	if err != nil {
+		return
+	}
+
+	err = decodeResponse(resp, &effects)
 	return
 
 }

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -1,8 +1,18 @@
 package horizon
 
+import "github.com/stellar/go/support/errors"
+
 func (c *Client) AccountDetail(request AccountRequest) (account Account, err error) {
 
-	endpoint, err := request.BuildUrl("account")
+	if request.AccountId == "" {
+		err = errors.New("No account ID provided")
+	}
+
+	if err != nil {
+		return
+	}
+
+	endpoint, err := request.BuildUrl()
 	if err != nil {
 		return
 	}
@@ -19,7 +29,15 @@ func (c *Client) AccountDetail(request AccountRequest) (account Account, err err
 
 func (c *Client) AccountData(request AccountRequest) (AccountData AccountData, err error) {
 
-	endpoint, err := request.BuildUrl("data")
+	if request.AccountId == "" || request.DataKey == "" {
+		err = errors.New("Too few parameters")
+	}
+
+	if err != nil {
+		return
+	}
+
+	endpoint, err := request.BuildUrl()
 	if err != nil {
 		return
 	}

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -1,6 +1,25 @@
 package horizon
 
-import "github.com/stellar/go/support/errors"
+import (
+	"github.com/stellar/go/support/errors"
+)
+
+func SendRequest(hr HorizonRequest, c Client, a interface{}) (err error) {
+
+	endpoint, err := hr.BuildUrl()
+	if err != nil {
+		return
+	}
+
+	resp, err := c.HTTP.Get(c.HorizonURL + endpoint)
+	if err != nil {
+
+		return
+	}
+
+	err = decodeResponse(resp, &a)
+	return
+}
 
 func (c *Client) AccountDetail(request AccountRequest) (account Account, err error) {
 
@@ -12,17 +31,7 @@ func (c *Client) AccountDetail(request AccountRequest) (account Account, err err
 		return
 	}
 
-	endpoint, err := request.BuildUrl()
-	if err != nil {
-		return
-	}
-
-	resp, err := c.HTTP.Get(c.HorizonURL + endpoint)
-	if err != nil {
-		return
-	}
-
-	err = decodeResponse(resp, &account)
+	err = SendRequest(request, *c, &account)
 	return
 
 }

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -56,3 +56,8 @@ func (c *Client) Effects(request EffectRequest) (effects EffectsPage, err error)
 	err = sendRequest(request, *c, &effects)
 	return
 }
+
+func (c *Client) Assets(request AssetRequest) (assets AssetsPage, err error) {
+	err = sendRequest(request, *c, &assets)
+	return
+}

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -20,6 +20,8 @@ func sendRequest(hr HorizonRequest, c Client, a interface{}) (err error) {
 	return
 }
 
+// AccountDetail returns information for a single account.
+// See https://www.stellar.org/developers/horizon/reference/endpoints/accounts-single.html
 func (c *Client) AccountDetail(request AccountRequest) (account Account, err error) {
 	if request.AccountId == "" {
 		err = errors.New("No account ID provided")
@@ -33,6 +35,8 @@ func (c *Client) AccountDetail(request AccountRequest) (account Account, err err
 	return
 }
 
+// AccountData returns a single data associated with a given account
+// See https://www.stellar.org/developers/horizon/reference/endpoints/data-for-account.html
 func (c *Client) AccountData(request AccountRequest) (accountData AccountData, err error) {
 	if request.AccountId == "" || request.DataKey == "" {
 		err = errors.New("Too few parameters")
@@ -46,6 +50,8 @@ func (c *Client) AccountData(request AccountRequest) (accountData AccountData, e
 	return
 }
 
+// Effects returns effects(https://www.stellar.org/developers/horizon/reference/resources/effect.html)
+// It can be used to return effects for an account, a ledger, an operation, a transaction and all effects on the network.
 func (c *Client) Effects(request EffectRequest) (effects EffectsPage, err error) {
 	err = sendRequest(request, *c, &effects)
 	return

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -1,0 +1,18 @@
+package horizon
+
+func (c *Client) AccountDetail(request AccountRequest) (account Account, err error) {
+
+	endpoint, err := request.BuildUrl("account")
+	if err != nil {
+		return
+	}
+
+	resp, err := c.HTTP.Get(c.HorizonURL + endpoint)
+	if err != nil {
+		return
+	}
+
+	err = decodeResponse(resp, &account)
+	return
+
+}

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -4,8 +4,7 @@ import (
 	"github.com/stellar/go/support/errors"
 )
 
-func SendRequest(hr HorizonRequest, c Client, a interface{}) (err error) {
-
+func sendRequest(hr HorizonRequest, c Client, a interface{}) (err error) {
 	endpoint, err := hr.BuildUrl()
 	if err != nil {
 		return
@@ -22,7 +21,6 @@ func SendRequest(hr HorizonRequest, c Client, a interface{}) (err error) {
 }
 
 func (c *Client) AccountDetail(request AccountRequest) (account Account, err error) {
-
 	if request.AccountId == "" {
 		err = errors.New("No account ID provided")
 	}
@@ -31,13 +29,11 @@ func (c *Client) AccountDetail(request AccountRequest) (account Account, err err
 		return
 	}
 
-	err = SendRequest(request, *c, &account)
+	err = sendRequest(request, *c, &account)
 	return
-
 }
 
 func (c *Client) AccountData(request AccountRequest) (accountData AccountData, err error) {
-
 	if request.AccountId == "" || request.DataKey == "" {
 		err = errors.New("Too few parameters")
 	}
@@ -46,109 +42,11 @@ func (c *Client) AccountData(request AccountRequest) (accountData AccountData, e
 		return
 	}
 
-	endpoint, err := request.BuildUrl()
-	if err != nil {
-		return
-	}
-
-	resp, err := c.HTTP.Get(c.HorizonURL + endpoint)
-	if err != nil {
-		return
-	}
-
-	err = decodeResponse(resp, &accountData)
+	err = sendRequest(request, *c, &accountData)
 	return
-
 }
 
-func (c *Client) AllEffects(request EffectRequest) (effects EffectsPage, err error) {
-	if request.AccountId != "" || request.LedgerId != "" || request.OperationId != "" || request.TransactionHash != "" {
-		err = errors.New("Too many parameters")
-	}
-
-	if err != nil {
-		return
-	}
-	endpoint, err := request.BuildUrl()
-	if err != nil {
-		return
-	}
-
-	resp, err := c.HTTP.Get(c.HorizonURL + endpoint)
-	if err != nil {
-		return
-	}
-
-	err = decodeResponse(resp, &effects)
+func (c *Client) Effects(request EffectRequest) (effects EffectsPage, err error) {
+	err = sendRequest(request, *c, &effects)
 	return
-
-}
-
-func (c *Client) LedgerEffects(request EffectRequest) (effects EffectsPage, err error) {
-	if request.LedgerId == "" {
-		err = errors.New("Ledger Id is not provided.")
-	}
-
-	if err != nil {
-		return
-	}
-	endpoint, err := request.BuildUrl()
-	if err != nil {
-		return
-	}
-
-	resp, err := c.HTTP.Get(c.HorizonURL + endpoint)
-	if err != nil {
-		return
-	}
-
-	err = decodeResponse(resp, &effects)
-	return
-
-}
-
-func (c *Client) OperationEffects(request EffectRequest) (effects EffectsPage, err error) {
-	if request.OperationId == "" {
-		err = errors.New("Operation Id is not provided.")
-	}
-
-	if err != nil {
-		return
-	}
-	endpoint, err := request.BuildUrl()
-	if err != nil {
-		return
-	}
-
-	resp, err := c.HTTP.Get(c.HorizonURL + endpoint)
-	if err != nil {
-		return
-	}
-
-	err = decodeResponse(resp, &effects)
-	return
-
-}
-
-func (c *Client) TransactionEffects(request EffectRequest) (effects EffectsPage, err error) {
-	if request.TransactionHash == "" {
-		err = errors.New("Transaction Hash is not provided.")
-	}
-
-	if err != nil {
-		return
-	}
-	endpoint, err := request.BuildUrl()
-	if err != nil {
-		return
-	}
-
-	resp, err := c.HTTP.Get(c.HorizonURL + endpoint)
-	if err != nil {
-		return
-	}
-
-	err = decodeResponse(resp, &effects)
-	return
-
 }

--- a/exp/clients/horizon/effect_request.go
+++ b/exp/clients/horizon/effect_request.go
@@ -11,9 +11,9 @@ import (
 // If no data is set, it defaults to the build the URL for all effects
 func (er EffectRequest) BuildUrl() (endpoint string, err error) {
 
-	noOfParamsSet := checkParams(er.AccountId, er.LedgerId, er.OperationId, er.TransactionHash)
+	nParams := checkParams(er.ForAccount, er.ForLedger, er.ForOperation, er.ForTransaction)
 
-	if noOfParamsSet > 1 {
+	if nParams > 1 {
 		err = errors.New("Invalid request. Too many parameters")
 	}
 
@@ -23,31 +23,31 @@ func (er EffectRequest) BuildUrl() (endpoint string, err error) {
 
 	endpoint = "effects"
 
-	if er.AccountId != "" {
+	if er.ForAccount != "" {
 		endpoint = fmt.Sprintf(
 			"accounts/%s/effects",
-			er.AccountId,
+			er.ForAccount,
 		)
 	}
 
-	if er.LedgerId != "" {
+	if er.ForLedger != "" {
 		endpoint = fmt.Sprintf(
 			"ledgers/%s/effects",
-			er.LedgerId,
+			er.ForLedger,
 		)
 	}
 
-	if er.OperationId != "" {
+	if er.ForOperation != "" {
 		endpoint = fmt.Sprintf(
 			"operations/%s/effects",
-			er.OperationId,
+			er.ForOperation,
 		)
 	}
 
-	if er.TransactionHash != "" {
+	if er.ForTransaction != "" {
 		endpoint = fmt.Sprintf(
 			"transactions/%s/effects",
-			er.TransactionHash,
+			er.ForTransaction,
 		)
 	}
 

--- a/exp/clients/horizon/effect_request.go
+++ b/exp/clients/horizon/effect_request.go
@@ -1,4 +1,4 @@
-package horizon
+package horizonclient
 
 import (
 	"fmt"

--- a/exp/clients/horizon/effect_request.go
+++ b/exp/clients/horizon/effect_request.go
@@ -1,0 +1,90 @@
+package horizon
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/stellar/go/support/errors"
+)
+
+// BuildUrl creates the endpoint to be queried based on the data in the EffectRequest struct.
+// If no data is set, it defaults to the build the URL for all effects
+func (er EffectRequest) BuildUrl() (endpoint string, err error) {
+
+	noOfParamsSet := checkParams(er.AccountId, er.LedgerId, er.OperationId, er.TransactionHash)
+
+	if noOfParamsSet > 1 {
+		err = errors.New("Invalid request. Too many parameters")
+	}
+
+	if err != nil {
+		return endpoint, err
+	}
+
+	endpoint = "effects"
+
+	if er.AccountId != "" {
+		endpoint = fmt.Sprintf(
+			"accounts/%s/effects",
+			er.AccountId,
+		)
+	}
+
+	if er.LedgerId != "" {
+		endpoint = fmt.Sprintf(
+			"ledgers/%s/effects",
+			er.LedgerId,
+		)
+	}
+
+	if er.OperationId != "" {
+		endpoint = fmt.Sprintf(
+			"operations/%s/effects",
+			er.OperationId,
+		)
+	}
+
+	if er.TransactionHash != "" {
+		endpoint = fmt.Sprintf(
+			"transactions/%s/effects",
+			er.TransactionHash,
+		)
+	}
+
+	query := url.Values{}
+
+	if er.Cursor != "" {
+		query.Add("cursor", er.Cursor)
+	}
+
+	if er.Limit > 0 {
+		query.Add("limit", string(er.Limit))
+	}
+
+	if er.Order != "" {
+		query.Add("order", string(er.Order))
+	}
+
+	endpoint = fmt.Sprintf(
+		"%s",
+		endpoint,
+	)
+
+	queryParams := query.Encode()
+
+	if queryParams != "" {
+		endpoint = fmt.Sprintf(
+			"%s?%s",
+			endpoint,
+			queryParams,
+		)
+	}
+
+	_, err = url.Parse(endpoint)
+	if err != nil {
+		err = errors.Wrap(err, "failed to parse endpoint")
+	}
+
+	return endpoint, err
+
+}

--- a/exp/clients/horizon/effect_request.go
+++ b/exp/clients/horizon/effect_request.go
@@ -11,7 +11,7 @@ import (
 // If no data is set, it defaults to the build the URL for all effects
 func (er EffectRequest) BuildUrl() (endpoint string, err error) {
 
-	nParams := checkParams(er.ForAccount, er.ForLedger, er.ForOperation, er.ForTransaction)
+	nParams := countParams(er.ForAccount, er.ForLedger, er.ForOperation, er.ForTransaction)
 
 	if nParams > 1 {
 		err = errors.New("Invalid request. Too many parameters")
@@ -51,27 +51,7 @@ func (er EffectRequest) BuildUrl() (endpoint string, err error) {
 		)
 	}
 
-	query := url.Values{}
-
-	if er.Cursor != "" {
-		query.Add("cursor", er.Cursor)
-	}
-
-	if er.Limit > 0 {
-		query.Add("limit", string(er.Limit))
-	}
-
-	if er.Order != "" {
-		query.Add("order", string(er.Order))
-	}
-
-	endpoint = fmt.Sprintf(
-		"%s",
-		endpoint,
-	)
-
-	queryParams := query.Encode()
-
+	queryParams := addQueryParams(er.Cursor, er.Limit, er.Order)
 	if queryParams != "" {
 		endpoint = fmt.Sprintf(
 			"%s?%s",
@@ -86,5 +66,4 @@ func (er EffectRequest) BuildUrl() (endpoint string, err error) {
 	}
 
 	return endpoint, err
-
 }

--- a/exp/clients/horizon/effect_request_test.go
+++ b/exp/clients/horizon/effect_request_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestEffectRequestBuildUrl(t *testing.T) {
-
 	er := EffectRequest{}
 	endpoint, err := er.BuildUrl()
 
@@ -16,33 +15,39 @@ func TestEffectRequestBuildUrl(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "effects", endpoint)
 
-	er = EffectRequest{LedgerId: "123"}
+	er = EffectRequest{ForAccount: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
+	endpoint, err = er.BuildUrl()
+
+	// It should return valid account effects endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/effects", endpoint)
+
+	er = EffectRequest{ForLedger: "123"}
 	endpoint, err = er.BuildUrl()
 
 	// It should return valid ledger effects endpoint and no errors
 	require.NoError(t, err)
 	assert.Equal(t, "ledgers/123/effects", endpoint)
 
-	er = EffectRequest{OperationId: "123"}
+	er = EffectRequest{ForOperation: "123"}
 	endpoint, err = er.BuildUrl()
 
 	// It should return valid operation effects endpoint and no errors
 	require.NoError(t, err)
 	assert.Equal(t, "operations/123/effects", endpoint)
 
-	er = EffectRequest{TransactionHash: "123"}
+	er = EffectRequest{ForTransaction: "123"}
 	endpoint, err = er.BuildUrl()
 
 	// It should return valid transaction effects endpoint and no errors
 	require.NoError(t, err)
 	assert.Equal(t, "transactions/123/effects", endpoint)
 
-	er = EffectRequest{LedgerId: "123", OperationId: "789"}
+	er = EffectRequest{ForLedger: "123", ForOperation: "789"}
 	endpoint, err = er.BuildUrl()
 
 	// error case: too many parameters for building any effect endpoint
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "Invalid request. Too many parameters")
 	}
-
 }

--- a/exp/clients/horizon/effect_request_test.go
+++ b/exp/clients/horizon/effect_request_test.go
@@ -1,4 +1,4 @@
-package horizon
+package horizonclient
 
 import (
 	"testing"

--- a/exp/clients/horizon/effect_request_test.go
+++ b/exp/clients/horizon/effect_request_test.go
@@ -1,0 +1,48 @@
+package horizon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEffectRequestBuildUrl(t *testing.T) {
+
+	er := EffectRequest{}
+	endpoint, err := er.BuildUrl()
+
+	// It should return valid all effects endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "effects", endpoint)
+
+	er = EffectRequest{LedgerId: "123"}
+	endpoint, err = er.BuildUrl()
+
+	// It should return valid ledger effects endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "ledgers/123/effects", endpoint)
+
+	er = EffectRequest{OperationId: "123"}
+	endpoint, err = er.BuildUrl()
+
+	// It should return valid operation effects endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "operations/123/effects", endpoint)
+
+	er = EffectRequest{TransactionHash: "123"}
+	endpoint, err = er.BuildUrl()
+
+	// It should return valid transaction effects endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "transactions/123/effects", endpoint)
+
+	er = EffectRequest{LedgerId: "123", OperationId: "789"}
+	endpoint, err = er.BuildUrl()
+
+	// error case: too many parameters for building any effect endpoint
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Invalid request. Too many parameters")
+	}
+
+}

--- a/exp/clients/horizon/effect_request_test.go
+++ b/exp/clients/horizon/effect_request_test.go
@@ -50,4 +50,11 @@ func TestEffectRequestBuildUrl(t *testing.T) {
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "Invalid request. Too many parameters")
 	}
+
+	er = EffectRequest{Cursor: "123456", Limit: 30, Order: OrderAsc}
+	endpoint, err = er.BuildUrl()
+	// It should return valid all effects endpoint with query params and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "effects?cursor=123456&limit=30&order=asc", endpoint)
+
 }

--- a/exp/clients/horizon/error.go
+++ b/exp/clients/horizon/error.go
@@ -1,0 +1,88 @@
+package horizon
+
+import (
+	"encoding/json"
+
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/render/problem"
+	"github.com/stellar/go/xdr"
+)
+
+func (herr Error) Error() string {
+	return `Horizon error: "` + herr.Problem.Title + `". Check horizon.Error.Problem for more information.`
+}
+
+// ToProblem converts the Prolem to a problem.P
+func (prob Problem) ToProblem() problem.P {
+	extras := make(map[string]interface{})
+	for k, v := range prob.Extras {
+		extras[k] = v
+	}
+
+	return problem.P{
+		Type:     prob.Type,
+		Title:    prob.Title,
+		Status:   prob.Status,
+		Detail:   prob.Detail,
+		Instance: prob.Instance,
+		Extras:   extras,
+	}
+}
+
+// Envelope extracts the transaction envelope that triggered this error from the
+// extra fields.
+func (herr *Error) Envelope() (*xdr.TransactionEnvelope, error) {
+	raw, ok := herr.Problem.Extras["envelope_xdr"]
+	if !ok {
+		return nil, ErrEnvelopeNotPopulated
+	}
+
+	var b64 string
+	var result xdr.TransactionEnvelope
+
+	err := json.Unmarshal(raw, &b64)
+	if err != nil {
+		return nil, errors.Wrap(err, "json decode failed")
+	}
+
+	err = xdr.SafeUnmarshalBase64(b64, &result)
+	if err != nil {
+		return nil, errors.Wrap(err, "xdr decode failed")
+	}
+
+	return &result, nil
+}
+
+// ResultString extracts the transaction result as a string.
+func (herr *Error) ResultString() (string, error) {
+	raw, ok := herr.Problem.Extras["result_xdr"]
+	if !ok {
+		return "", ErrResultNotPopulated
+	}
+
+	var b64 string
+
+	err := json.Unmarshal(raw, &b64)
+	if err != nil {
+		return "", errors.Wrap(err, "json decode failed")
+	}
+
+	return b64, nil
+}
+
+// ResultCodes extracts a result code summary from the error, if possible.
+func (herr *Error) ResultCodes() (*TransactionResultCodes, error) {
+
+	raw, ok := herr.Problem.Extras["result_codes"]
+	if !ok {
+		return nil, ErrResultCodesNotPopulated
+	}
+
+	var result TransactionResultCodes
+	err := json.Unmarshal(raw, &result)
+	if err != nil {
+		return nil, errors.Wrap(err, "json decode failed")
+	}
+
+	return &result, nil
+}

--- a/exp/clients/horizon/error.go
+++ b/exp/clients/horizon/error.go
@@ -1,4 +1,4 @@
-package horizon
+package horizonclient
 
 import (
 	"encoding/json"

--- a/exp/clients/horizon/internal.go
+++ b/exp/clients/horizon/internal.go
@@ -1,0 +1,39 @@
+package horizon
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/stellar/go/support/errors"
+)
+
+func decodeResponse(resp *http.Response, object interface{}) (err error) {
+	defer resp.Body.Close()
+	decoder := json.NewDecoder(resp.Body)
+
+	if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
+		horizonError := &Error{
+			Response: resp,
+		}
+		decodeError := decoder.Decode(&horizonError.Problem)
+		if decodeError != nil {
+			return errors.Wrap(decodeError, "error decoding horizon.Problem")
+		}
+		return horizonError
+	}
+
+	err = decoder.Decode(&object)
+	if err != nil {
+		return
+	}
+	return
+}
+
+func loadMemo(p *Payment) error {
+	res, err := http.Get(p.Links.Transaction.Href)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	return json.NewDecoder(res.Body).Decode(&p.Memo)
+}

--- a/exp/clients/horizon/internal.go
+++ b/exp/clients/horizon/internal.go
@@ -67,6 +67,14 @@ func addQueryParams(params ...interface{}) string {
 			if param != 0 {
 				query.Add("limit", strconv.Itoa(int(param)))
 			}
+		case AssetCode:
+			if param != "" {
+				query.Add("asset_code", string(param))
+			}
+		case AssetIssuer:
+			if param != "" {
+				query.Add("asset_issuer", string(param))
+			}
 		default:
 		}
 	}

--- a/exp/clients/horizon/internal.go
+++ b/exp/clients/horizon/internal.go
@@ -1,4 +1,4 @@
-package horizon
+package horizonclient
 
 import (
 	"encoding/json"

--- a/exp/clients/horizon/internal.go
+++ b/exp/clients/horizon/internal.go
@@ -37,3 +37,15 @@ func loadMemo(p *Payment) error {
 	defer res.Body.Close()
 	return json.NewDecoder(res.Body).Decode(&p.Memo)
 }
+
+func checkParams(params ...interface{}) int {
+	counter := 0
+
+	for _, param := range params {
+		if param != "" {
+			counter++
+		}
+	}
+
+	return counter
+}

--- a/exp/clients/horizon/internal.go
+++ b/exp/clients/horizon/internal.go
@@ -31,6 +31,7 @@ func decodeResponse(resp *http.Response, object interface{}) (err error) {
 	return
 }
 
+// deprecated. To do: remove from new client package
 func loadMemo(p *Payment) error {
 	res, err := http.Get(p.Links.Transaction.Href)
 	if err != nil {

--- a/exp/clients/horizon/internal.go
+++ b/exp/clients/horizon/internal.go
@@ -3,6 +3,8 @@ package horizonclient
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
+	"strconv"
 
 	"github.com/stellar/go/support/errors"
 )
@@ -38,14 +40,36 @@ func loadMemo(p *Payment) error {
 	return json.NewDecoder(res.Body).Decode(&p.Memo)
 }
 
-func checkParams(params ...interface{}) int {
+func countParams(params ...interface{}) int {
 	counter := 0
-
 	for _, param := range params {
 		if param != "" {
 			counter++
 		}
 	}
-
 	return counter
+}
+
+func addQueryParams(params ...interface{}) string {
+	query := url.Values{}
+
+	for _, param := range params {
+		switch param := param.(type) {
+		case Cursor:
+			if param != "" {
+				query.Add("cursor", string(param))
+			}
+		case Order:
+			if param != "" {
+				query.Add("order", string(param))
+			}
+		case Limit:
+			if param != 0 {
+				query.Add("limit", strconv.Itoa(int(param)))
+			}
+		default:
+		}
+	}
+
+	return query.Encode()
 }

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -54,10 +54,7 @@ type Client struct {
 type ClientInterface interface {
 	AccountDetail(request AccountRequest) (Account, error)
 	AccountData(request AccountRequest) (AccountData, error)
-	AllEffects(request EffectRequest) (EffectsPage, error)
-	LedgerEffects(request EffectRequest) (EffectsPage, error)
-	OperationEffects(request EffectRequest) (EffectsPage, error)
-	TransactionEffects(request EffectRequest) (EffectsPage, error)
+	Effects(request EffectRequest) (EffectsPage, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network
@@ -83,11 +80,11 @@ type AccountRequest struct {
 }
 
 type EffectRequest struct {
-	AccountId       string
-	LedgerId        string
-	OperationId     string
-	TransactionHash string
-	Order           Order
-	Cursor          string
-	Limit           int
+	ForAccount     string
+	ForLedger      string
+	ForOperation   string
+	ForTransaction string
+	Order          Order
+	Cursor         string
+	Limit          int
 }

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -1,5 +1,5 @@
-// package horizon is an experimental horizon client that provides access to the horizon server
-package horizon
+// package horizonclient is an experimental horizon client that provides access to the horizon server
+package horizonclient
 
 import (
 	"errors"
@@ -80,10 +80,6 @@ type HorizonRequest interface {
 type AccountRequest struct {
 	AccountId string
 	DataKey   string
-
-	Order  Order
-	Cursor string
-	Limit  int
 }
 
 type EffectRequest struct {
@@ -91,8 +87,7 @@ type EffectRequest struct {
 	LedgerId        string
 	OperationId     string
 	TransactionHash string
-
-	Order  Order
-	Cursor string
-	Limit  int
+	Order           Order
+	Cursor          string
+	Limit           int
 }

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -54,6 +54,10 @@ type Client struct {
 type ClientInterface interface {
 	AccountDetail(request AccountRequest) (Account, error)
 	AccountData(request AccountRequest) (AccountData, error)
+	AllEffects(request EffectRequest) (EffectsPage, error)
+	LedgerEffects(request EffectRequest) (EffectsPage, error)
+	OperationEffects(request EffectRequest) (EffectsPage, error)
+	TransactionEffects(request EffectRequest) (EffectsPage, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network
@@ -76,6 +80,17 @@ type HorizonRequest interface {
 type AccountRequest struct {
 	AccountId string
 	DataKey   string
+
+	Order  Order
+	Cursor string
+	Limit  int
+}
+
+type EffectRequest struct {
+	AccountId       string
+	LedgerId        string
+	OperationId     string
+	TransactionHash string
 
 	Order  Order
 	Cursor string

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -16,6 +16,12 @@ type Limit uint
 // Order represents `order` param in queries
 type Order string
 
+// AssetCode represets `asset_code` param in queries
+type AssetCode string
+
+// AssetIssuer represents `asset_issuer` param in queries
+type AssetIssuer string
+
 const (
 	OrderAsc  Order = "asc"
 	OrderDesc Order = "desc"
@@ -62,6 +68,7 @@ type ClientInterface interface {
 	AccountDetail(request AccountRequest) (Account, error)
 	AccountData(request AccountRequest) (AccountData, error)
 	Effects(request EffectRequest) (EffectsPage, error)
+	Assets(request AssetRequest) (AssetsPage, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network
@@ -94,6 +101,14 @@ type EffectRequest struct {
 	ForLedger      string
 	ForOperation   string
 	ForTransaction string
+	Order          Order
+	Cursor         Cursor
+	Limit          Limit
+}
+
+type AssetRequest struct {
+	ForAssetCode   AssetCode
+	ForAssetIssuer AssetIssuer
 	Order          Order
 	Cursor         Cursor
 	Limit          Limit

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -44,11 +44,13 @@ type HTTP interface {
 	PostForm(url string, data url.Values) (resp *http.Response, err error)
 }
 
+// Client struct contains data for creating an horizon client that connects to the stellar network
 type Client struct {
 	HorizonURL string
 	HTTP       HTTP
 }
 
+// ClientInterface contains methods implemented by the horizon client
 type ClientInterface interface {
 	AccountDetail(request AccountRequest) (Account, error)
 	AccountData(request AccountRequest) (AccountData, error)
@@ -70,6 +72,7 @@ type HorizonRequest interface {
 	BuildUrl(requestType string) (string error)
 }
 
+// AccountRequest struct contains data for making requests to the accounts endpoint of an horizon server
 type AccountRequest struct {
 	AccountId string
 	DataKey   string

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -7,6 +7,13 @@ import (
 	"net/url"
 )
 
+// Cursor represents `cursor` param in queries
+type Cursor string
+
+// Limit represents `limit` param in queries
+type Limit uint
+
+// Order represents `order` param in queries
 type Order string
 
 const (
@@ -79,12 +86,15 @@ type AccountRequest struct {
 	DataKey   string
 }
 
+// EffectRequest struct contains data for getting effects from an horizon server.
+// ForAccount, ForLedger, ForOperation and ForTransaction: Not more than one of these can be set at a time. If none are set, the default is to return all effects.
+// The query parameters (Order, Cursor and Limit) can all be set at the same time
 type EffectRequest struct {
 	ForAccount     string
 	ForLedger      string
 	ForOperation   string
 	ForTransaction string
 	Order          Order
-	Cursor         string
-	Limit          int
+	Cursor         Cursor
+	Limit          Limit
 }

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -73,7 +73,7 @@ var DefaultPublicNetClient = &Client{
 }
 
 type HorizonRequest interface {
-	BuildUrl(requestType string) (string error)
+	BuildUrl() (string, error)
 }
 
 // AccountRequest struct contains data for making requests to the accounts endpoint of an horizon server

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -1,0 +1,80 @@
+// package horizon is an experimental horizon client that provides access to the horizon server
+package horizon
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+)
+
+type Order string
+
+const (
+	OrderAsc  Order = "asc"
+	OrderDesc Order = "desc"
+)
+
+// Error struct contains the problem returned by Horizon
+type Error struct {
+	Response *http.Response
+	Problem  Problem
+}
+
+var (
+	// ErrResultCodesNotPopulated is the error returned from a call to
+	// ResultCodes() against a `Problem` value that doesn't have the
+	// "result_codes" extra field populated when it is expected to be.
+	ErrResultCodesNotPopulated = errors.New("result_codes not populated")
+
+	// ErrEnvelopeNotPopulated is the error returned from a call to
+	// Envelope() against a `Problem` value that doesn't have the
+	// "envelope_xdr" extra field populated when it is expected to be.
+	ErrEnvelopeNotPopulated = errors.New("envelope_xdr not populated")
+
+	// ErrResultNotPopulated is the error returned from a call to
+	// Result() against a `Problem` value that doesn't have the
+	// "result_xdr" extra field populated when it is expected to be.
+	ErrResultNotPopulated = errors.New("result_xdr not populated")
+)
+
+// HTTP represents the HTTP client that a horizon client uses to communicate
+type HTTP interface {
+	Do(req *http.Request) (resp *http.Response, err error)
+	Get(url string) (resp *http.Response, err error)
+	PostForm(url string, data url.Values) (resp *http.Response, err error)
+}
+
+type Client struct {
+	HorizonURL string
+	HTTP       HTTP
+}
+
+type ClientInterface interface {
+	AccountDetail(request AccountRequest) (Account, error)
+	AccountData(request AccountRequest) (Account, error)
+}
+
+// DefaultTestNetClient is a default client to connect to test network
+var DefaultTestNetClient = &Client{
+	HorizonURL: "https://horizon-testnet.stellar.org",
+	HTTP:       http.DefaultClient,
+}
+
+// DefaultPublicNetClient is a default client to connect to public network
+var DefaultPublicNetClient = &Client{
+	HorizonURL: "https://horizon.stellar.org",
+	HTTP:       http.DefaultClient,
+}
+
+type HorizonRequest interface {
+	BuildUrl(requestType string) (string error)
+}
+
+type AccountRequest struct {
+	AccountId string
+	DataKey   string
+
+	Order  Order
+	Cursor string
+	Limit  int
+}

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -51,7 +51,7 @@ type Client struct {
 
 type ClientInterface interface {
 	AccountDetail(request AccountRequest) (Account, error)
-	AccountData(request AccountRequest) (Account, error)
+	AccountData(request AccountRequest) (AccountData, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -14,85 +14,115 @@ func TestAccountDetail(t *testing.T) {
 		HTTP:       hmock,
 	}
 
-	accountRequest := AccountRequest{AccountId: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"}
+	accountRequest := AccountRequest{AccountId: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
 
 	// happy path
 	hmock.On(
 		"GET",
-		"https://localhost/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+		"https://localhost/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
 	).ReturnString(200, accountResponse)
 
 	account, err := client.AccountDetail(accountRequest)
 	if assert.NoError(t, err) {
-		assert.Equal(t, account.ID, "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+		assert.Equal(t, account.ID, "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU")
 		assert.Equal(t, account.PT, "1")
-		assert.Equal(t, account.Signers[0].Key, "XBT5HNPK6DAL6222MAWTLHNOZSDKPJ2AKNEQ5Q324CHHCNQFQ7EHBHZN")
-		assert.Equal(t, account.Signers[0].Type, "sha256_hash")
-		assert.Equal(t, account.Data["test"], "R0NCVkwzU1FGRVZLUkxQNkFKNDdVS0tXWUVCWTQ1V0hBSkhDRVpLVldNVEdNQ1Q0SDROS1FZTEg=")
+		assert.Equal(t, account.Signers[0].Key, "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU")
+		assert.Equal(t, account.Signers[0].Type, "ed25519_public_key")
+		assert.Equal(t, account.Data["test"], "dGVzdA==")
 		balance, err := account.GetNativeBalance()
 		assert.Nil(t, err)
-		assert.Equal(t, balance, "948522307.6146000")
+		assert.Equal(t, balance, "9999.9999900")
 	}
 
 	// failure response
-	// hmock.On(
-	// 	"GET",
-	// 	"https://localhost/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
-	// ).ReturnString(404, notFoundResponse)
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+	).ReturnString(404, notFoundResponse)
 
-	// _, err = client.LoadAccount("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
-	// if assert.Error(t, err) {
-	// 	assert.Contains(t, err.Error(), "Horizon error")
-	// 	horizonError, ok := err.(*Error)
-	// 	assert.Equal(t, ok, true)
-	// 	assert.Equal(t, horizonError.Problem.Title, "Resource Missing")
-	// }
+	_, err = client.AccountDetail(accountRequest)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Horizon error")
+		horizonError, ok := err.(*Error)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, horizonError.Problem.Title, "Resource Missing")
+	}
 
 	// connection error
-	// hmock.On(
-	// 	"GET",
-	// 	"https://localhost/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
-	// ).ReturnError("http.Client error")
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+	).ReturnError("http.Client error")
 
-	// _, err = client.LoadAccount("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
-	// if assert.Error(t, err) {
-	// 	assert.Contains(t, err.Error(), "http.Client error")
-	// 	_, ok := err.(*Error)
-	// 	assert.Equal(t, ok, false)
-	// }
+	_, err = client.AccountDetail(accountRequest)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "http.Client error")
+		_, ok := err.(*Error)
+		assert.Equal(t, ok, false)
+	}
+}
+
+func TestAccountData(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	accountRequest := AccountRequest{AccountId: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU", DataKey: "test"}
+
+	// happy path
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/data/test",
+	).ReturnString(200, accountData)
+
+	data, err := client.AccountData(accountRequest)
+	if assert.NoError(t, err) {
+		assert.Equal(t, data.Value, "dGVzdA==")
+	}
+
 }
 
 var accountResponse = `{
   "_links": {
     "self": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
+      "href": "https://horizon-testnet.stellar.org/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"
     },
     "transactions": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H/transactions{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/transactions{?cursor,limit,order}",
       "templated": true
     },
     "operations": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H/operations{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/operations{?cursor,limit,order}",
       "templated": true
     },
     "payments": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H/payments{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/payments{?cursor,limit,order}",
       "templated": true
     },
     "effects": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H/effects{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/effects{?cursor,limit,order}",
       "templated": true
     },
     "offers": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H/Offers{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/offers{?cursor,limit,order}",
+      "templated": true
+    },
+    "trades": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/trades{?cursor,limit,order}",
+      "templated": true
+    },
+    "data": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/data/{key}",
       "templated": true
     }
   },
-  "id": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+  "id": "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
   "paging_token": "1",
-  "account_id": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
-  "sequence": "7384",
-  "subentry_count": 0,
+  "account_id": "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+  "sequence": "9865509814140929",
+  "subentry_count": 1,
   "thresholds": {
     "low_threshold": 0,
     "med_threshold": 0,
@@ -100,30 +130,27 @@ var accountResponse = `{
   },
   "flags": {
     "auth_required": false,
-    "auth_revocable": false
+    "auth_revocable": false,
+    "auth_immutable": false
   },
   "balances": [
     {
-      "balance": "948522307.6146000",
+      "balance": "9999.9999900",
+      "buying_liabilities": "0.0000000",
+      "selling_liabilities": "0.0000000",
       "asset_type": "native"
     }
   ],
   "signers": [
     {
-      "public_key": "XBT5HNPK6DAL6222MAWTLHNOZSDKPJ2AKNEQ5Q324CHHCNQFQ7EHBHZN",
+      "public_key": "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
       "weight": 1,
-      "key": "XBT5HNPK6DAL6222MAWTLHNOZSDKPJ2AKNEQ5Q324CHHCNQFQ7EHBHZN",
-      "type": "sha256_hash"
-    },
-    {
-      "public_key": "GDQHKHMFW5ICTQYM3QWCXMSZ56BNHMQG6NH6SGV3ZNZ72KRHYV5XINCE",
-      "weight": 1,
-      "key": "GDQHKHMFW5ICTQYM3QWCXMSZ56BNHMQG6NH6SGV3ZNZ72KRHYV5XINCE",
+      "key": "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
       "type": "ed25519_public_key"
     }
   ],
   "data": {
-    "test": "R0NCVkwzU1FGRVZLUkxQNkFKNDdVS0tXWUVCWTQ1V0hBSkhDRVpLVldNVEdNQ1Q0SDROS1FZTEg="
+    "test": "dGVzdA=="
   }
 }`
 
@@ -133,4 +160,8 @@ var notFoundResponse = `{
   "status": 404,
   "detail": "The resource at the url requested was not found.  This is usually occurs for one of two reasons:  The url requested is not valid, or no data in our database could be found with the parameters provided.",
   "instance": "horizon-live-001/61KdRW8tKi-18408110"
+}`
+
+var accountData = `{
+  "value": "dGVzdA=="
 }`

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -1,4 +1,4 @@
-package horizon
+package horizonclient
 
 import (
 	"fmt"

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -1,0 +1,136 @@
+package horizon
+
+import (
+	"testing"
+
+	"github.com/stellar/go/support/http/httptest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccountDetail(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	accountRequest := AccountRequest{AccountId: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"}
+
+	// happy path
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+	).ReturnString(200, accountResponse)
+
+	account, err := client.AccountDetail(accountRequest)
+	if assert.NoError(t, err) {
+		assert.Equal(t, account.ID, "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+		assert.Equal(t, account.PT, "1")
+		assert.Equal(t, account.Signers[0].Key, "XBT5HNPK6DAL6222MAWTLHNOZSDKPJ2AKNEQ5Q324CHHCNQFQ7EHBHZN")
+		assert.Equal(t, account.Signers[0].Type, "sha256_hash")
+		assert.Equal(t, account.Data["test"], "R0NCVkwzU1FGRVZLUkxQNkFKNDdVS0tXWUVCWTQ1V0hBSkhDRVpLVldNVEdNQ1Q0SDROS1FZTEg=")
+		balance, err := account.GetNativeBalance()
+		assert.Nil(t, err)
+		assert.Equal(t, balance, "948522307.6146000")
+	}
+
+	// failure response
+	// hmock.On(
+	// 	"GET",
+	// 	"https://localhost/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+	// ).ReturnString(404, notFoundResponse)
+
+	// _, err = client.LoadAccount("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	// if assert.Error(t, err) {
+	// 	assert.Contains(t, err.Error(), "Horizon error")
+	// 	horizonError, ok := err.(*Error)
+	// 	assert.Equal(t, ok, true)
+	// 	assert.Equal(t, horizonError.Problem.Title, "Resource Missing")
+	// }
+
+	// connection error
+	// hmock.On(
+	// 	"GET",
+	// 	"https://localhost/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+	// ).ReturnError("http.Client error")
+
+	// _, err = client.LoadAccount("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	// if assert.Error(t, err) {
+	// 	assert.Contains(t, err.Error(), "http.Client error")
+	// 	_, ok := err.(*Error)
+	// 	assert.Equal(t, ok, false)
+	// }
+}
+
+var accountResponse = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
+    },
+    "transactions": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H/transactions{?cursor,limit,order}",
+      "templated": true
+    },
+    "operations": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H/operations{?cursor,limit,order}",
+      "templated": true
+    },
+    "payments": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H/payments{?cursor,limit,order}",
+      "templated": true
+    },
+    "effects": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H/effects{?cursor,limit,order}",
+      "templated": true
+    },
+    "offers": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H/Offers{?cursor,limit,order}",
+      "templated": true
+    }
+  },
+  "id": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+  "paging_token": "1",
+  "account_id": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+  "sequence": "7384",
+  "subentry_count": 0,
+  "thresholds": {
+    "low_threshold": 0,
+    "med_threshold": 0,
+    "high_threshold": 0
+  },
+  "flags": {
+    "auth_required": false,
+    "auth_revocable": false
+  },
+  "balances": [
+    {
+      "balance": "948522307.6146000",
+      "asset_type": "native"
+    }
+  ],
+  "signers": [
+    {
+      "public_key": "XBT5HNPK6DAL6222MAWTLHNOZSDKPJ2AKNEQ5Q324CHHCNQFQ7EHBHZN",
+      "weight": 1,
+      "key": "XBT5HNPK6DAL6222MAWTLHNOZSDKPJ2AKNEQ5Q324CHHCNQFQ7EHBHZN",
+      "type": "sha256_hash"
+    },
+    {
+      "public_key": "GDQHKHMFW5ICTQYM3QWCXMSZ56BNHMQG6NH6SGV3ZNZ72KRHYV5XINCE",
+      "weight": 1,
+      "key": "GDQHKHMFW5ICTQYM3QWCXMSZ56BNHMQG6NH6SGV3ZNZ72KRHYV5XINCE",
+      "type": "ed25519_public_key"
+    }
+  ],
+  "data": {
+    "test": "R0NCVkwzU1FGRVZLUkxQNkFKNDdVS0tXWUVCWTQ1V0hBSkhDRVpLVldNVEdNQ1Q0SDROS1FZTEg="
+  }
+}`
+
+var notFoundResponse = `{
+  "type": "https://stellar.org/horizon-errors/not_found",
+  "title": "Resource Missing",
+  "status": 404,
+  "detail": "The resource at the url requested was not found.  This is usually occurs for one of two reasons:  The url requested is not valid, or no data in our database could be found with the parameters provided.",
+  "instance": "horizon-live-001/61KdRW8tKi-18408110"
+}`

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -65,6 +65,7 @@ func TestAccountDetail(t *testing.T) {
 	).ReturnString(200, accountResponse)
 
 	account, err := client.AccountDetail(accountRequest)
+
 	if assert.NoError(t, err) {
 		assert.Equal(t, account.ID, "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU")
 		assert.Equal(t, account.PT, "1")
@@ -82,7 +83,7 @@ func TestAccountDetail(t *testing.T) {
 		"https://localhost/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
 	).ReturnString(404, notFoundResponse)
 
-	_, err = client.AccountDetail(accountRequest)
+	account, err = client.AccountDetail(accountRequest)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "Horizon error")
 		horizonError, ok := err.(*Error)

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -20,7 +20,28 @@ func ExampleClient_AccountDetail() {
 	}
 
 	fmt.Print(account)
+}
 
+func ExampleClient_Effects() {
+
+	client := DefaultPublicNetClient
+	// effects for an account
+	effectRequest := EffectRequest{ForAccount: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
+	effect, err := client.Effects(effectRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(effect)
+
+	// all effects
+	effectRequest = EffectRequest{}
+	effect, err = client.Effects(effectRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(effect)
 }
 
 func TestAccountDetail(t *testing.T) {

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -152,6 +152,42 @@ func TestAccountData(t *testing.T) {
 
 }
 
+func TestEffectsRequest(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	effectRequest := EffectRequest{}
+
+	// all effects
+	hmock.On(
+		"GET",
+		"https://localhost/effects",
+	).ReturnString(200, effectsResponse)
+
+	effects, err := client.AllEffects(effectRequest)
+	if assert.NoError(t, err) {
+		assert.IsType(t, effects, EffectsPage{})
+
+	}
+
+	// wrong parameters
+	effectRequest = EffectRequest{AccountId: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
+	hmock.On(
+		"GET",
+		"https://localhost/effects",
+	).ReturnString(200, effectsResponse)
+
+	_, err = client.AllEffects(effectRequest)
+	// error case: few parameters
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Too many parameters")
+	}
+
+}
+
 var accountResponse = `{
   "_links": {
     "self": {
@@ -232,4 +268,83 @@ var notFoundResponse = `{
 
 var accountData = `{
   "value": "dGVzdA=="
+}`
+
+var effectsResponse = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/operations/43989725060534273/effects?cursor=&limit=10&order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/operations/43989725060534273/effects?cursor=43989725060534273-3&limit=10&order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/operations/43989725060534273/effects?cursor=43989725060534273-1&limit=10&order=desc"
+    }
+  },
+  "_embedded": {
+    "records": [
+      {
+        "_links": {
+          "operation": {
+            "href": "https://horizon-testnet.stellar.org/operations/43989725060534273"
+          },
+          "succeeds": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc&cursor=43989725060534273-1"
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc&cursor=43989725060534273-1"
+          }
+        },
+        "id": "0043989725060534273-0000000001",
+        "paging_token": "43989725060534273-1",
+        "account": "GANHAS5OMPLKD6VYU4LK7MBHSHB2Q37ZHAYWOBJRUXGDHMPJF3XNT45Y",
+        "type": "account_debited",
+        "type_i": 3,
+        "created_at": "2018-07-27T21:00:12Z",
+        "asset_type": "native",
+        "amount": "9999.9999900"
+      },
+      {
+        "_links": {
+          "operation": {
+            "href": "https://horizon-testnet.stellar.org/operations/43989725060534273"
+          },
+          "succeeds": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc&cursor=43989725060534273-2"
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc&cursor=43989725060534273-2"
+          }
+        },
+        "id": "0043989725060534273-0000000002",
+        "paging_token": "43989725060534273-2",
+        "account": "GBO7LQUWCC7M237TU2PAXVPOLLYNHYCYYFCLVMX3RBJCML4WA742X3UB",
+        "type": "account_credited",
+        "type_i": 2,
+        "created_at": "2018-07-27T21:00:12Z",
+        "asset_type": "native",
+        "amount": "9999.9999900"
+      },
+      {
+        "_links": {
+          "operation": {
+            "href": "https://horizon-testnet.stellar.org/operations/43989725060534273"
+          },
+          "succeeds": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc&cursor=43989725060534273-3"
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc&cursor=43989725060534273-3"
+          }
+        },
+        "id": "0043989725060534273-0000000003",
+        "paging_token": "43989725060534273-3",
+        "account": "GANHAS5OMPLKD6VYU4LK7MBHSHB2Q37ZHAYWOBJRUXGDHMPJF3XNT45Y",
+        "type": "account_removed",
+        "type_i": 1,
+        "created_at": "2018-07-27T21:00:12Z"
+      }
+    ]
+  }
 }`

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -168,21 +168,32 @@ func TestEffectsRequest(t *testing.T) {
 		"https://localhost/effects",
 	).ReturnString(200, effectsResponse)
 
-	effects, err := client.AllEffects(effectRequest)
+	effects, err := client.Effects(effectRequest)
 	if assert.NoError(t, err) {
 		assert.IsType(t, effects, EffectsPage{})
 
 	}
 
-	// wrong parameters
-	effectRequest = EffectRequest{AccountId: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
+	effectRequest = EffectRequest{ForAccount: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/effects",
+	).ReturnString(200, effectsResponse)
+
+	effects, err = client.Effects(effectRequest)
+	if assert.NoError(t, err) {
+		assert.IsType(t, effects, EffectsPage{})
+	}
+
+	// too many parameters
+	effectRequest = EffectRequest{ForAccount: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU", ForLedger: "123"}
 	hmock.On(
 		"GET",
 		"https://localhost/effects",
 	).ReturnString(200, effectsResponse)
 
-	_, err = client.AllEffects(effectRequest)
-	// error case: few parameters
+	_, err = client.Effects(effectRequest)
+	// error case
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "Too many parameters")
 	}

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -1,11 +1,27 @@
 package horizon
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stellar/go/support/http/httptest"
 	"github.com/stretchr/testify/assert"
 )
+
+func ExampleClient_AccountDetail() {
+
+	client := DefaultPublicNetClient
+	accountRequest := AccountRequest{AccountId: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
+
+	account, err := client.AccountDetail(accountRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Print(account)
+
+}
 
 func TestAccountDetail(t *testing.T) {
 	hmock := httptest.NewClient()
@@ -14,7 +30,33 @@ func TestAccountDetail(t *testing.T) {
 		HTTP:       hmock,
 	}
 
-	accountRequest := AccountRequest{AccountId: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
+	// no parameters
+	accountRequest := AccountRequest{}
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+	).ReturnString(200, accountResponse)
+
+	_, err := client.AccountDetail(accountRequest)
+	// error case: no account id
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "No account ID provided")
+	}
+
+	// wrong parameters
+	accountRequest = AccountRequest{DataKey: "test"}
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+	).ReturnString(200, accountResponse)
+
+	_, err = client.AccountDetail(accountRequest)
+	// error case: no account id
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "No account ID provided")
+	}
+
+	accountRequest = AccountRequest{AccountId: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
 
 	// happy path
 	hmock.On(
@@ -69,7 +111,33 @@ func TestAccountData(t *testing.T) {
 		HTTP:       hmock,
 	}
 
-	accountRequest := AccountRequest{AccountId: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU", DataKey: "test"}
+	// no parameters
+	accountRequest := AccountRequest{}
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/data/test",
+	).ReturnString(200, accountResponse)
+
+	_, err := client.AccountData(accountRequest)
+	// error case: few parameters
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Too few parameters")
+	}
+
+	// wrong parameters
+	accountRequest = AccountRequest{AccountId: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/data/test",
+	).ReturnString(200, accountResponse)
+
+	_, err = client.AccountData(accountRequest)
+	// error case: few parameters
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Too few parameters")
+	}
+
+	accountRequest = AccountRequest{AccountId: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU", DataKey: "test"}
 
 	// happy path
 	hmock.On(

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -1,0 +1,25 @@
+package horizon
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+// MockClient is a mockable horizon client.
+type MockClient struct {
+	mock.Mock
+}
+
+// AccountDetail is a mocking method
+func (m *MockClient) AccountDetail(request AccountRequest) (Account, error) {
+	a := m.Called(request)
+	return a.Get(0).(Account), a.Error(1)
+}
+
+// AccountData is a mocking method
+func (m *MockClient) AccountData(request AccountRequest) (Account, error) {
+	a := m.Called(request)
+	return a.Get(0).(Account), a.Error(1)
+}
+
+// ensure that the MockClient implements ClientInterface
+var _ ClientInterface = &MockClient{}

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -16,9 +16,9 @@ func (m *MockClient) AccountDetail(request AccountRequest) (Account, error) {
 }
 
 // AccountData is a mocking method
-func (m *MockClient) AccountData(request AccountRequest) (Account, error) {
+func (m *MockClient) AccountData(request AccountRequest) (AccountData, error) {
 	a := m.Called(request)
-	return a.Get(0).(Account), a.Error(1)
+	return a.Get(0).(AccountData), a.Error(1)
 }
 
 // ensure that the MockClient implements ClientInterface

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -1,4 +1,4 @@
-package horizon
+package horizonclient
 
 import (
 	"github.com/stretchr/testify/mock"

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -27,5 +27,11 @@ func (m *MockClient) Effects(request EffectRequest) (EffectsPage, error) {
 	return a.Get(0).(EffectsPage), a.Error(1)
 }
 
+// Assets is a mocking method
+func (m *MockClient) Assets(request AssetRequest) (AssetsPage, error) {
+	a := m.Called(request)
+	return a.Get(0).(AssetsPage), a.Error(1)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -21,5 +21,29 @@ func (m *MockClient) AccountData(request AccountRequest) (AccountData, error) {
 	return a.Get(0).(AccountData), a.Error(1)
 }
 
+// AllEffects is a mocking method
+func (m *MockClient) AllEffects(request EffectRequest) (EffectsPage, error) {
+	a := m.Called(request)
+	return a.Get(0).(EffectsPage), a.Error(1)
+}
+
+// LedgerEffects is a mocking method
+func (m *MockClient) LedgerEffects(request EffectRequest) (EffectsPage, error) {
+	a := m.Called(request)
+	return a.Get(0).(EffectsPage), a.Error(1)
+}
+
+// OperationEffects is a mocking method
+func (m *MockClient) OperationEffects(request EffectRequest) (EffectsPage, error) {
+	a := m.Called(request)
+	return a.Get(0).(EffectsPage), a.Error(1)
+}
+
+// TransactionEffects is a mocking method
+func (m *MockClient) TransactionEffects(request EffectRequest) (EffectsPage, error) {
+	a := m.Called(request)
+	return a.Get(0).(EffectsPage), a.Error(1)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -21,26 +21,8 @@ func (m *MockClient) AccountData(request AccountRequest) (AccountData, error) {
 	return a.Get(0).(AccountData), a.Error(1)
 }
 
-// AllEffects is a mocking method
-func (m *MockClient) AllEffects(request EffectRequest) (EffectsPage, error) {
-	a := m.Called(request)
-	return a.Get(0).(EffectsPage), a.Error(1)
-}
-
-// LedgerEffects is a mocking method
-func (m *MockClient) LedgerEffects(request EffectRequest) (EffectsPage, error) {
-	a := m.Called(request)
-	return a.Get(0).(EffectsPage), a.Error(1)
-}
-
-// OperationEffects is a mocking method
-func (m *MockClient) OperationEffects(request EffectRequest) (EffectsPage, error) {
-	a := m.Called(request)
-	return a.Get(0).(EffectsPage), a.Error(1)
-}
-
-// TransactionEffects is a mocking method
-func (m *MockClient) TransactionEffects(request EffectRequest) (EffectsPage, error) {
+// Effects is a mocking method
+func (m *MockClient) Effects(request EffectRequest) (EffectsPage, error) {
 	a := m.Called(request)
 	return a.Get(0).(EffectsPage), a.Error(1)
 }

--- a/exp/clients/horizon/responses.go
+++ b/exp/clients/horizon/responses.go
@@ -1,4 +1,4 @@
-package horizon
+package horizonclient
 
 import (
 	"encoding/json"

--- a/exp/clients/horizon/responses.go
+++ b/exp/clients/horizon/responses.go
@@ -155,3 +155,7 @@ type PriceLevel = hProtocol.PriceLevel
 
 // Deprecated: use protocols/horizon instead
 type Transaction = hProtocol.Transaction
+
+type AccountData struct {
+	Value string `json:"value"`
+}

--- a/exp/clients/horizon/responses.go
+++ b/exp/clients/horizon/responses.go
@@ -1,0 +1,157 @@
+package horizon
+
+import (
+	"encoding/json"
+
+	hProtocol "github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/support/render/hal"
+)
+
+// Deprecated: use protocols/horizon instead
+type Problem struct {
+	Type     string                     `json:"type"`
+	Title    string                     `json:"title"`
+	Status   int                        `json:"status"`
+	Detail   string                     `json:"detail,omitempty"`
+	Instance string                     `json:"instance,omitempty"`
+	Extras   map[string]json.RawMessage `json:"extras,omitempty"`
+}
+
+// Deprecated: use protocols/horizon instead
+type Root = hProtocol.Root
+
+// Deprecated: use protocols/horizon instead
+type Account = hProtocol.Account
+
+// Deprecated: use protocols/horizon instead
+type AccountFlags = hProtocol.AccountFlags
+
+// Deprecated: use protocols/horizon instead
+type AccountThresholds = hProtocol.AccountThresholds
+
+// Deprecated: use protocols/horizon instead
+type Asset = hProtocol.Asset
+
+// Deprecated: use protocols/horizon instead
+type Balance = hProtocol.Balance
+
+// Deprecated: use protocols/horizon instead
+type HistoryAccount = hProtocol.HistoryAccount
+
+// Deprecated: use protocols/horizon instead
+type Ledger = hProtocol.Ledger
+
+// Deprecated: use render/hal instead
+type Link = hal.Link
+
+// Deprecated: use protocols/horizon instead
+type Offer = hProtocol.Offer
+
+// EffectsPageResponse contains page of effects returned by Horizon.
+// Currently used by LoadAccountMergeAmount only.
+type EffectsPage struct {
+	Embedded struct {
+		Records []Effect
+	} `json:"_embedded"`
+}
+
+// EffectResponse contains effect data returned by Horizon.
+// Currently used by LoadAccountMergeAmount only.
+type Effect struct {
+	Type   string `json:"type"`
+	Amount string `json:"amount"`
+}
+
+// TradeAggregationsPage returns a list of aggregated trade records, aggregated by resolution
+type TradeAggregationsPage struct {
+	Links    hal.Links `json:"_links"`
+	Embedded struct {
+		Records []TradeAggregation `json:"records"`
+	} `json:"_embedded"`
+}
+
+// Deprecated: use protocols/horizon instead
+type TradeAggregation = hProtocol.TradeAggregation
+
+// TradesPage returns a list of trade records
+type TradesPage struct {
+	Links    hal.Links `json:"_links"`
+	Embedded struct {
+		Records []Trade `json:"records"`
+	} `json:"_embedded"`
+}
+
+// Deprecated: use protocols/horizon instead
+type Trade = hProtocol.Trade
+
+// Deprecated: use protocols/horizon instead
+type OrderBookSummary = hProtocol.OrderBookSummary
+
+// Deprecated: use protocols/horizon instead
+type TransactionSuccess = hProtocol.TransactionSuccess
+
+// Deprecated: use protocols/horizon instead
+type TransactionResultCodes = hProtocol.TransactionResultCodes
+
+// Deprecated: use protocols/horizon instead
+type Signer = hProtocol.Signer
+
+// OffersPage returns a list of offers
+type OffersPage struct {
+	Links    hal.Links `json:"_links"`
+	Embedded struct {
+		Records []Offer `json:"records"`
+	} `json:"_embedded"`
+}
+
+type Payment struct {
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	PagingToken string `json:"paging_token"`
+
+	Links struct {
+		Effects struct {
+			Href string `json:"href"`
+		} `json:"effects"`
+		Transaction struct {
+			Href string `json:"href"`
+		} `json:"transaction"`
+	} `json:"_links"`
+
+	SourceAccount string `json:"source_account"`
+	CreatedAt     string `json:"created_at"`
+
+	// create_account and account_merge field
+	Account string `json:"account"`
+
+	// create_account fields
+	Funder          string `json:"funder"`
+	StartingBalance string `json:"starting_balance"`
+
+	// account_merge fields
+	Into string `json:"into"`
+
+	// payment/path_payment fields
+	From        string `json:"from"`
+	To          string `json:"to"`
+	AssetType   string `json:"asset_type"`
+	AssetCode   string `json:"asset_code"`
+	AssetIssuer string `json:"asset_issuer"`
+	Amount      string `json:"amount"`
+
+	// transaction fields
+	TransactionHash string `json:"transaction_hash"`
+	Memo            struct {
+		Type  string `json:"memo_type"`
+		Value string `json:"memo"`
+	}
+}
+
+// Deprecated: use protocols/horizon instead
+type Price = hProtocol.Price
+
+// Deprecated: use protocols/horizon instead
+type PriceLevel = hProtocol.PriceLevel
+
+// Deprecated: use protocols/horizon instead
+type Transaction = hProtocol.Transaction

--- a/exp/clients/horizon/responses.go
+++ b/exp/clients/horizon/responses.go
@@ -159,3 +159,13 @@ type Transaction = hProtocol.Transaction
 type AccountData struct {
 	Value string `json:"value"`
 }
+
+// Deprecated: use protocols/horizon instead
+type AssetStat = hProtocol.AssetStat
+
+// AssetsPage contains page of assets returned by Horizon.
+type AssetsPage struct {
+	Embedded struct {
+		Records []AssetStat
+	} `json:"_embedded"`
+}


### PR DESCRIPTION
This is the first attempt in redesigning the `horizon client` of the Go SDK as described in #844. The idea is to implement the proposed pattern for a few endpoints, review, then implement for the others.
The endpoints implemented here are for getting account details and effects from horizon.

I have tried to maintain the same file structure as the current `horizon` client so that it might be easier to just copy this experimental package over when the time is right.

`responses.go` still maps `protocols\horizon`. Any new response `structs` are created in this file.

Because horizon server API usually require just one parameter e.g: `/accounts/{account}/effects` the requests structs can usually only have one parameter set when building a url to be queried.

There are some exceptions to this though. See `AccountRequest.AccountData()` 

There are still some things that need clean up, for example, more tests and comments needed,  there is duplicated code when submitting the endpoints for queries to horizon. See `clients.go` file. 
This PR is to gather feedback on the pattern chosen before expanding it to other endpoints.
It closes #932 



