### PR TITLE
Make SSE action execution use an internal PubSub implementation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -139,6 +139,14 @@
   revision = "31079b6807923eb23992c421b114992b95131b55"
 
 [[projects]]
+  digest = "1:5bdd0581421e643e6c3163bb5da785600a2d7d0d73fec58acebaf2e693868e9d"
+  name = "github.com/cskr/pubsub"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "65166f5ae403cbf6dcdced31e1f8f8ad95485cb3"
+  version = "v1.0.2"
+
+[[projects]]
   digest = "1:33ad47e6f2f3685027d42cbf66067e0e2e75f8841d95b802bad85f5fa4c7c956"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -873,6 +881,7 @@
     "github.com/btcsuite/btcd/txscript",
     "github.com/btcsuite/btcd/wire",
     "github.com/btcsuite/btcutil",
+    "github.com/cskr/pubsub",
     "github.com/ethereum/go-ethereum/common",
     "github.com/ethereum/go-ethereum/core/types",
     "github.com/ethereum/go-ethereum/crypto",

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -98,14 +98,6 @@ var configOpts = []*support.ConfigOption{
 		Usage:       "max db connections (per DB), may need to be increased when responses are slow but DB CPU is normal",
 	},
 	&support.ConfigOption{
-		Name:           "sse-update-frequency",
-		ConfigKey:      &config.SSEUpdateFrequency,
-		OptType:        types.Int,
-		FlagDefault:    5,
-		CustomSetValue: support.SetDuration,
-		Usage:          "defines how often streams should check if there's a new ledger (in seconds), may need to increase in case of big number of streams",
-	},
-	&support.ConfigOption{
 		Name:           "connection-timeout",
 		ConfigKey:      &config.ConnectionTimeout,
 		OptType:        types.Int,

--- a/services/horizon/internal/action.go
+++ b/services/horizon/internal/action.go
@@ -54,7 +54,7 @@ func (action *Action) HistoryQ() *history.Q {
 func (action *Action) Prepare(w http.ResponseWriter, r *http.Request) {
 	base := &action.Base
 	action.App = AppFromContext(r.Context())
-	base.Prepare(w, r, action.App.ctx, action.App.config.SSEUpdateFrequency)
+	base.Prepare(w, r, action.App.ctx)
 	if action.R.Context() != nil {
 		action.Log = log.Ctx(action.R.Context())
 	} else {

--- a/services/horizon/internal/actions/responders.go
+++ b/services/horizon/internal/actions/responders.go
@@ -18,6 +18,7 @@ type RawDataResponder interface {
 // to be MimeEventStream.
 type EventStreamer interface {
 	SSE(*sse.Stream) error
+	GetPubsubTopic() string
 }
 
 // SingleObjectStreamer implementors can respond to a request whose response

--- a/services/horizon/internal/actions_data.go
+++ b/services/horizon/internal/actions_data.go
@@ -64,6 +64,14 @@ func (action *DataShowAction) SSE(stream *sse.Stream) error {
 	return action.Err
 }
 
+// GetPubsubTopic is a method for actions.SSE
+//
+// There is no value in this action for specific account_id, so registration topic is a general
+// change in the ledger.
+func (action *DataShowAction) GetPubsubTopic() string {
+	return action.GetString("account_id")
+}
+
 func (action *DataShowAction) loadParams() {
 	action.Address = action.GetAddress("account_id", actions.RequiredParam)
 	action.Key = action.GetString("key")

--- a/services/horizon/internal/actions_effects.go
+++ b/services/horizon/internal/actions_effects.go
@@ -90,6 +90,23 @@ func (action *EffectIndexAction) SSE(stream *sse.Stream) error {
 	return action.Err
 }
 
+// GetPubsubTopic is a method for actions.SSE
+func (action *EffectIndexAction) GetPubsubTopic() string {
+	if res := action.GetString("account_id"); res != "" {
+		return res
+	}
+	if res := action.GetString("ledger_id"); res != "" {
+		return res
+	}
+	if res := action.GetString("tx_id"); res != "" {
+		return res
+	}
+	if res := action.GetString("op_id"); res != "" {
+		return res
+	}
+	return ""
+}
+
 // loadLedgers populates the ledger cache for this action
 func (action *EffectIndexAction) loadLedgers() {
 	action.Ledgers = &history.LedgerCache{}

--- a/services/horizon/internal/actions_ledger.go
+++ b/services/horizon/internal/actions_ledger.go
@@ -66,6 +66,14 @@ func (action *LedgerIndexAction) SSE(stream *sse.Stream) error {
 	return action.Err
 }
 
+// GetPubsubTopic is a method for actions.SSE
+//
+// There is no value in this action for specific ledger_id, so registration topic is a general
+// change in the ledger.
+func (action *LedgerIndexAction) GetPubsubTopic() string {
+	return "ledger"
+}
+
 func (action *LedgerIndexAction) loadParams() {
 	action.ValidateCursorAsDefault()
 	action.PagingParams = action.GetPageQuery()

--- a/services/horizon/internal/actions_offer.go
+++ b/services/horizon/internal/actions_offer.go
@@ -74,6 +74,14 @@ func (action *OffersByAccountAction) SSE(stream *sse.Stream) error {
 	return action.Err
 }
 
+// GetPubsubTopic is a method for actions.SSE
+//
+// There is no value in this action for specific account_id, so registration topic is a general
+// change in the ledger.
+func (action *OffersByAccountAction) GetPubsubTopic() string {
+	return action.GetString("account_id")
+}
+
 func (action *OffersByAccountAction) loadParams() {
 	action.PageQuery = action.GetPageQuery()
 	action.Address = action.GetAddress("account_id")

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -89,6 +89,20 @@ func (action *OperationIndexAction) SSE(stream *sse.Stream) error {
 	return action.Err
 }
 
+// GetPubsubTopic is a method for actions.SSE
+func (action *OperationIndexAction) GetPubsubTopic() string {
+	if res := action.GetString("account_id"); res != "" {
+		return res
+	}
+	if res := action.GetString("ledger_id"); res != "" {
+		return res
+	}
+	if res := action.GetString("tx_id"); res != "" {
+		return res
+	}
+	return ""
+}
+
 func (action *OperationIndexAction) loadParams() {
 	action.ValidateCursorAsDefault()
 	action.AccountFilter = action.GetAddress("account_id")

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -81,6 +81,20 @@ func (action *PaymentsIndexAction) SSE(stream *sse.Stream) error {
 	return action.Err
 }
 
+// GetPubsubTopic is a method for actions.SSE
+func (action *PaymentsIndexAction) GetPubsubTopic() string {
+	if res := action.GetString("account_id"); res != "" {
+		return res
+	}
+	if res := action.GetString("ledger_id"); res != "" {
+		return res
+	}
+	if res := action.GetString("tx_id"); res != "" {
+		return res
+	}
+	return ""
+}
+
 func (action *PaymentsIndexAction) loadParams() {
 	action.ValidateCursorAsDefault()
 	action.AccountFilter = action.GetAddress("account_id")

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -71,6 +71,17 @@ func (action *TradeIndexAction) SSE(stream *sse.Stream) error {
 	return action.Err
 }
 
+// GetPubsubTopic is a method for actions.SSE
+func (action *TradeIndexAction) GetPubsubTopic() string {
+	if res := action.GetString("offer_id"); res != "" {
+		return res
+	}
+	if res := action.GetString("account_id"); res != "" {
+		return res
+	}
+	return ""
+}
+
 // loadParams sets action.Query from the request params
 func (action *TradeIndexAction) loadParams() {
 	action.PagingParams = action.GetPageQuery()

--- a/services/horizon/internal/actions_transaction.go
+++ b/services/horizon/internal/actions_transaction.go
@@ -72,6 +72,17 @@ func (action *TransactionIndexAction) SSE(stream *sse.Stream) error {
 	return action.Err
 }
 
+// GetPubsubTopic is a method for actions.SSE
+func (action *TransactionIndexAction) GetPubsubTopic() string {
+	if res := action.GetString("account_id"); res != "" {
+		return res
+	}
+	if res := action.GetString("ledger_id"); res != "" {
+		return res
+	}
+	return "transactions"
+}
+
 func (action *TransactionIndexAction) loadParams() {
 	action.ValidateCursorAsDefault()
 	action.AccountFilter = action.GetAddress("account_id")

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -16,7 +16,6 @@ type Config struct {
 	StellarCoreURL         string
 	Port                   uint
 	MaxDBConnections       int
-	SSEUpdateFrequency     time.Duration
 	ConnectionTimeout      time.Duration
 	RateLimit              *throttled.RateQuota
 	RateLimitRedisKey      string

--- a/services/horizon/internal/render/sse/stream.go
+++ b/services/horizon/internal/render/sse/stream.go
@@ -104,7 +104,6 @@ func (s *Stream) Err(err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	rootErr := errors.Cause(err)
 	// If we haven't sent an event, we should simply return the normal HTTP
 	// error because it means that we haven't sent the preamble.
 	if s.sent == 0 {
@@ -112,11 +111,11 @@ func (s *Stream) Err(err error) {
 		return
 	}
 
-	if rootErr == sql.ErrNoRows {
+	if errors.Cause(err) == sql.ErrNoRows {
 		err = errNoObject
 	}
 
-	_, ok := knownErrors[rootErr]
+	_, ok := knownErrors[errors.Cause(err)]
 	if !ok {
 		log.Ctx(s.ctx).Error(err)
 		err = errBadStream

--- a/services/horizon/internal/sse_test.go
+++ b/services/horizon/internal/sse_test.go
@@ -1,0 +1,236 @@
+package horizon
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/services/horizon/internal/actions"
+	"github.com/stellar/go/services/horizon/internal/ingest"
+	"github.com/stellar/go/services/horizon/internal/ledger"
+	"github.com/stellar/go/services/horizon/internal/render/sse"
+	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test 2 subscriptions to different topics. Make sure that one topic doesnt
+// raise both channels.
+func TestSSEPubsubMultipleChannels(t *testing.T) {
+	ht := StartHTTPTest(t, "base")
+	defer ht.Finish()
+
+	ht.App.ticks.Stop()
+
+	subA := sse.Subscribe("a")
+	subB := sse.Subscribe("b")
+	defer sse.Unsubscribe(subA, "a")
+	defer sse.Unsubscribe(subB, "b")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(subA chan interface{}, subB chan interface{}, wg *sync.WaitGroup) {
+		defer wg.Done()
+
+		select {
+		case <-subA: // no-op. Success!
+		case <-subB:
+			t.Fatal("subscription B shouldn't trigger")
+		case <-time.After(2 * time.Second):
+			t.Fatal("subscription A did not trigger")
+		}
+
+		select {
+		case <-subA:
+			t.Fatal("subscription A shouldn't trigger")
+		case <-subB:
+			t.Fatal("subscription B shouldn't trigger")
+		case <-time.After(2 * time.Second): // no-op. Success!
+		}
+	}(subA, subB, &wg)
+	sse.Publish("a", true)
+	wg.Wait()
+}
+
+// Test multiple number of topics handled
+func TestSSEPubsubManyTopics(t *testing.T) {
+	ht := StartHTTPTest(t, "base")
+	defer ht.Finish()
+
+	ht.App.ticks.Stop()
+
+	var wg sync.WaitGroup
+	wg.Add(100)
+	subscriptions := make([]chan interface{}, 100)
+
+	for i := 0; i < 100; i++ {
+		subscriptions[i] = sse.Subscribe(strconv.Itoa(i))
+		defer sse.Unsubscribe(subscriptions[i], strconv.Itoa(i))
+
+		go func(subscription chan interface{}, wg *sync.WaitGroup) {
+			defer wg.Done()
+			select {
+			case <-subscription:
+				return
+			case <-time.After(10 * time.Second):
+				t.Fatal("Subscription did not trigger within 2 seconds")
+			}
+		}(subscriptions[i], &wg)
+	}
+
+	for i := 0; i < 100; i++ {
+		sse.Publish(strconv.Itoa(i), true)
+	}
+
+	wg.Wait()
+}
+
+// Test multiple subscriptions to the same topic.
+func TestSSEPubsubManySubscribers(t *testing.T) {
+	ht := StartHTTPTest(t, "base")
+	defer ht.Finish()
+
+	ht.App.ticks.Stop()
+
+	var wg sync.WaitGroup
+	wg.Add(100)
+	subscriptions := make([]chan interface{}, 100)
+	for i := 0; i < 100; i++ {
+		subscriptions[i] = sse.Subscribe("a")
+		defer sse.Unsubscribe(subscriptions[i], "a")
+
+		go func(subscription chan interface{}, wg *sync.WaitGroup) {
+			defer wg.Done()
+			select {
+			case <-subscription:
+				return
+			case <-time.After(10 * time.Second):
+				t.Fatal("Subscription did not trigger within 2 seconds")
+			}
+		}(subscriptions[i], &wg)
+	}
+	sse.Publish("a", true)
+
+	wg.Wait()
+}
+
+// Test Actions which implement actions.EventStreamer return the correct URL path parameter value
+// which is used for SSE PubSub subscription.
+//
+// Actions and parameters are defined in services/horizon/internal/init_web.go
+func TestSSEPubsubTopic(t *testing.T) {
+	for _, tt := range []struct {
+		path,
+		paramKey,
+		paramValue string
+		streamEventType actions.EventStreamer
+	}{
+		// Constructs a URL using the structure as in init_web.go
+		// e.g. "/accounts/{account_id=12345}" ==> GetTopic() should return "12345"
+
+		// Unspecific topics.
+		{"/ledgers/", "ledger", "ledger", &LedgerIndexAction{}},
+		{"/order_book/", "order_book", "order_book", &OrderBookShowAction{}},
+
+		// Topics using a specific parameter e.g. and account address.
+		//
+		// NOTE the parameter we compare (e.g. the account address) doesn't have to be a valid
+		// address for the purpose of this test. We only care the SSE PubSub implementation fetches
+		// the correct parameter. The validity is already checked elsewhere and is out of the scope
+		// of SSE handling in general.
+		{"/accounts/", "account_id", "1", &AccountShowAction{}},
+		{"/transactions/", "account_id", "2", &TransactionIndexAction{}},
+		{"/operations/", "account_id", "3", &OperationIndexAction{}},
+		{"/payments/", "account_id", "4", &PaymentsIndexAction{}},
+		{"/effects/", "account_id", "5", &EffectIndexAction{}},
+		{"/offers/", "account_id", "6", &OffersByAccountAction{}},
+		{"/trades/", "account_id", "7", &TradeIndexAction{}},
+
+		// "2nd-level" parameters e.g. /accounts/{account_id}/data/{key}
+		{"/data/", "account_id", "8", &DataShowAction{}},
+	} {
+		// Initialize the Action implemented by the current actions.EventStreamer
+		action := reflect.ValueOf(tt.streamEventType).Elem()
+		base := action.FieldByName("Base")
+		require.True(t, base.IsValid()) // Sanity check: Base should be a struct member of action
+		base.Set(reflect.ValueOf(*makeAction(tt.path, map[string]string{tt.paramKey: tt.paramValue})))
+
+		// Test that it's EventStreamer.GetTopic() returns the correct expected PubSub topic
+		assert.Equal(t, tt.paramValue, tt.streamEventType.GetPubsubTopic(), "Path: %s/%s", tt.path, "/", tt.paramValue)
+	}
+}
+
+// Test various SSE subscriptions to various topics receive notifications when an ingestion
+// that relates to these topics occur.
+func TestSSEPubsubSubscribeToTopics(t *testing.T) {
+	SCENARIO_NAME := "kahuna"
+
+	tt := test.Start(t).ScenarioWithoutHorizon(SCENARIO_NAME)
+	defer tt.Finish()
+
+	var wg sync.WaitGroup
+	for _, topic := range []string{
+		"transactions",
+		// account in "kahuna" memo test
+		"GA46VRKBCLI2X6DXLX7AIEVRFLH3UA7XBE3NGNP6O74HQ5LXHMGTV2JB",
+	} {
+		subscription := sse.Subscribe(topic)
+		defer sse.Unsubscribe(subscription, topic)
+
+		wg.Add(1)
+		go func(topic string, subscription chan interface{}, wg *sync.WaitGroup) {
+			defer wg.Done()
+
+			select {
+			case <-subscription:
+			case <-time.After(10 * time.Second):
+				t.Fatalf("subscription did not trigger within 10s for topic \"%s\"", topic)
+			}
+		}(topic, subscription, &wg)
+	}
+
+	ingestHorizon(tt)
+
+	wg.Wait()
+}
+
+// Helpers from actions/helpers_test.go and ingest/main_test.go
+
+func ingestHorizon(tt *test.T) *ingest.Session {
+	sys := sys(tt)
+	s := ingest.NewSession(sys)
+	s.Cursor = ingest.NewCursor(1, ledger.CurrentState().CoreLatest, sys)
+	s.Run()
+
+	return s
+}
+
+func sys(tt *test.T) *ingest.System {
+	return ingest.New(
+		network.TestNetworkPassphrase,
+		"",
+		tt.CoreSession(),
+		tt.HorizonSession(),
+		ingest.Config{},
+	)
+}
+
+func makeAction(path string, body map[string]string) *actions.Base {
+	rctx := chi.NewRouteContext()
+	for k, v := range body {
+		rctx.URLParams.Add(k, v)
+	}
+
+	r, _ := http.NewRequest("GET", path, nil)
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+	action := &actions.Base{
+		R: r,
+	}
+	return action
+}


### PR DESCRIPTION
The mechanism introducted in this commit causes ingested ledgers to notify SSE action handlers, letting them know they should query the database for new related information. This causes every SSE connection to query the history database only when a ledger was ingested that contains explicit information related to that SSE request. This is in contrast to the current way it's done - where every SSE action handler queries the database in a periodic manner e.g. every 5s, regardless of that ledger's contents.

For example `/accounts/{account_id}/transactions` will query the history database only when a ledger containing a transaction affecting that specific `{account_id}` is ingested.

This greatly reduces the performance load on the history database belonging to Horizons handling a large number of SSE connections.

In addition:

- Add a new `GetPubsubTopic()` function to `actions.EventStreamer` interface.
  It returns the specific URL parameter used to notify on related ledger ingestions.
- Remove `sse-update-frequency` command line argument, since the feature introduced in this commit makes it obsolete.
- Added new `services/horizon/internal/sse_test.go` with related unit tests.