### PR TITLE
include lastModified field in account balances

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -42,6 +42,7 @@ type Account struct {
 	SubentryCount        int32             `json:"subentry_count"`
 	InflationDestination string            `json:"inflation_destination,omitempty"`
 	HomeDomain           string            `json:"home_domain,omitempty"`
+	LastModifiedLedger   uint32            `json:"last_modified_ledger"`
 	Thresholds           AccountThresholds `json:"thresholds"`
 	Flags                AccountFlags      `json:"flags"`
 	Balances             []Balance         `json:"balances"`
@@ -130,7 +131,7 @@ type Balance struct {
 	Limit              string `json:"limit,omitempty"`
 	BuyingLiabilities  string `json:"buying_liabilities"`
 	SellingLiabilities string `json:"selling_liabilities"`
-	LastModifiedLedger uint32 `json:"last_modified_ledger"`
+	LastModifiedLedger uint32 `json:"last_modified_ledger,omitempty"`
 	base.Asset
 }
 

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -130,6 +130,7 @@ type Balance struct {
 	Limit              string `json:"limit,omitempty"`
 	BuyingLiabilities  string `json:"buying_liabilities"`
 	SellingLiabilities string `json:"selling_liabilities"`
+	LastModified       uint32 `json:"last_modified"`
 	base.Asset
 }
 

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -130,7 +130,7 @@ type Balance struct {
 	Limit              string `json:"limit,omitempty"`
 	BuyingLiabilities  string `json:"buying_liabilities"`
 	SellingLiabilities string `json:"selling_liabilities"`
-	LastModified       uint32 `json:"last_modified"`
+	LastModifiedLedger uint32 `json:"last_modified_ledger"`
 	base.Asset
 }
 

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,6 +6,16 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## Unreleased
+
+### Deprecations
+
+### Breaking changes
+
+### Changes
+
+* Account detail endpoint (/accounts/:account-id) includes `last_modified_ledger` field for each asset's balance.
+
 ## v0.17.0 - 2019-02-26
 
 ### Upgrade notes

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -14,7 +14,7 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ### Changes
 
-* Account detail endpoint (/accounts/:account-id) includes `last_modified_ledger` field for each asset's balance.
+* Account detail endpoint (/accounts/:account-id) includes `last_modified_ledger` field for account and for each non-native asset balance.
 
 ## v0.17.0 - 2019-02-26
 

--- a/services/horizon/internal/actions_account_test.go
+++ b/services/horizon/internal/actions_account_test.go
@@ -16,11 +16,13 @@ func TestAccountActions_Show(t *testing.T) {
 		"/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 	)
 	if ht.Assert.Equal(200, w.Code) {
-
 		var result horizon.Account
 		err := json.Unmarshal(w.Body.Bytes(), &result)
 		ht.Require.NoError(err)
 		ht.Assert.Equal("3", result.Sequence)
+		for _, balance := range result.Balances {
+			ht.Assert.NotEqual(0, balance.LastModifiedLedger)
+		}
 	}
 
 	// missing account

--- a/services/horizon/internal/actions_account_test.go
+++ b/services/horizon/internal/actions_account_test.go
@@ -8,18 +8,18 @@ import (
 )
 
 func TestAccountActions_Show(t *testing.T) {
-	ht := StartHTTPTest(t, "base")
+	ht := StartHTTPTest(t, "allow_trust")
 	defer ht.Finish()
 
 	// existing account
 	w := ht.Get(
-		"/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+		"/accounts/GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
 	)
 	if ht.Assert.Equal(200, w.Code) {
 		var result horizon.Account
 		err := json.Unmarshal(w.Body.Bytes(), &result)
 		ht.Require.NoError(err)
-		ht.Assert.Equal("3", result.Sequence)
+		ht.Assert.Equal("8589934593", result.Sequence)
 
 		ht.Assert.NotEqual(0, result.LastModifiedLedger)
 		for _, balance := range result.Balances {

--- a/services/horizon/internal/actions_account_test.go
+++ b/services/horizon/internal/actions_account_test.go
@@ -20,8 +20,14 @@ func TestAccountActions_Show(t *testing.T) {
 		err := json.Unmarshal(w.Body.Bytes(), &result)
 		ht.Require.NoError(err)
 		ht.Assert.Equal("3", result.Sequence)
+
+		ht.Assert.NotEqual(0, result.LastModifiedLedger)
 		for _, balance := range result.Balances {
-			ht.Assert.NotEqual(0, balance.LastModifiedLedger)
+			if balance.Type == "native" {
+				ht.Assert.Equal(uint32(0), balance.LastModifiedLedger)
+			} else {
+				ht.Assert.NotEqual(uint32(0), balance.LastModifiedLedger)
+			}
 		}
 	}
 

--- a/services/horizon/internal/db2/core/account.go
+++ b/services/horizon/internal/db2/core/account.go
@@ -95,6 +95,7 @@ var selectAccount = sq.Select(
 	"a.homedomain",
 	"a.thresholds",
 	"a.flags",
+	"a.lastmodified",
 	// Liabilities can be NULL so can error without `coalesce`:
 	// `Invalid value for xdr.Int64`
 	"coalesce(a.buyingliabilities, 0) as buyingliabilities",

--- a/services/horizon/internal/db2/core/main.go
+++ b/services/horizon/internal/db2/core/main.go
@@ -22,6 +22,7 @@ type Account struct {
 	HomeDomain         null.String
 	Thresholds         xdr.Thresholds
 	Flags              xdr.AccountFlags
+	LastModified       uint32
 	BuyingLiabilities  xdr.Int64 `db:"buyingliabilities"`
 	SellingLiabilities xdr.Int64 `db:"sellingliabilities"`
 }
@@ -129,6 +130,7 @@ type Trustline struct {
 	Tlimit             xdr.Int64
 	Balance            xdr.Int64
 	Flags              int32
+	LastModified       uint32
 	BuyingLiabilities  xdr.Int64 `db:"buyingliabilities"`
 	SellingLiabilities xdr.Int64 `db:"sellingliabilities"`
 }

--- a/services/horizon/internal/db2/core/trustline.go
+++ b/services/horizon/internal/db2/core/trustline.go
@@ -103,6 +103,7 @@ var selectTrustline = sq.Select(
 	"tl.tlimit",
 	"tl.balance",
 	"tl.flags",
+	"tl.lastmodified",
 	// Liabilities can be NULL so can error without `coalesce`:
 	// `Invalid value for xdr.Int64`
 	"coalesce(tl.buyingliabilities, 0) as buyingliabilities",

--- a/services/horizon/internal/resourceadapter/account.go
+++ b/services/horizon/internal/resourceadapter/account.go
@@ -27,6 +27,7 @@ func PopulateAccount(
 	dest.SubentryCount = ca.Numsubentries
 	dest.InflationDestination = ca.Inflationdest.String
 	dest.HomeDomain = ca.HomeDomain.String
+	dest.LastModifiedLedger = ca.LastModified
 
 	PopulateAccountFlags(&dest.Flags, ca)
 	PopulateAccountThresholds(&dest.Thresholds, ca)
@@ -41,7 +42,7 @@ func PopulateAccount(
 	}
 
 	// add native balance
-	err = PopulateNativeBalance(&dest.Balances[len(dest.Balances)-1], ca.Balance, ca.BuyingLiabilities, ca.SellingLiabilities, ca.LastModified)
+	err = PopulateNativeBalance(&dest.Balances[len(dest.Balances)-1], ca.Balance, ca.BuyingLiabilities, ca.SellingLiabilities)
 	if err != nil {
 		return
 	}

--- a/services/horizon/internal/resourceadapter/account.go
+++ b/services/horizon/internal/resourceadapter/account.go
@@ -41,7 +41,7 @@ func PopulateAccount(
 	}
 
 	// add native balance
-	err = PopulateNativeBalance(&dest.Balances[len(dest.Balances)-1], ca.Balance, ca.BuyingLiabilities, ca.SellingLiabilities)
+	err = PopulateNativeBalance(&dest.Balances[len(dest.Balances)-1], ca.Balance, ca.BuyingLiabilities, ca.SellingLiabilities, ca.LastModified)
 	if err != nil {
 		return
 	}

--- a/services/horizon/internal/resourceadapter/balance.go
+++ b/services/horizon/internal/resourceadapter/balance.go
@@ -22,7 +22,7 @@ func PopulateBalance(ctx context.Context, dest *Balance, row core.Trustline) (er
 	dest.Limit = amount.String(row.Tlimit)
 	dest.Issuer = row.Issuer
 	dest.Code = row.Assetcode
-	dest.LastModified = row.LastModified
+	dest.LastModifiedLedger = row.LastModified
 	return
 }
 
@@ -35,7 +35,7 @@ func PopulateNativeBalance(dest *Balance, stroops, buyingLiabilities, sellingLia
 	dest.Balance = amount.String(stroops)
 	dest.BuyingLiabilities = amount.String(buyingLiabilities)
 	dest.SellingLiabilities = amount.String(sellingLiabilities)
-	dest.LastModified = lastModified
+	dest.LastModifiedLedger = lastModified
 	dest.Limit = ""
 	dest.Issuer = ""
 	dest.Code = ""

--- a/services/horizon/internal/resourceadapter/balance.go
+++ b/services/horizon/internal/resourceadapter/balance.go
@@ -22,10 +22,11 @@ func PopulateBalance(ctx context.Context, dest *Balance, row core.Trustline) (er
 	dest.Limit = amount.String(row.Tlimit)
 	dest.Issuer = row.Issuer
 	dest.Code = row.Assetcode
+	dest.LastModified = row.LastModified
 	return
 }
 
-func PopulateNativeBalance(dest *Balance, stroops, buyingLiabilities, sellingLiabilities xdr.Int64) (err error) {
+func PopulateNativeBalance(dest *Balance, stroops, buyingLiabilities, sellingLiabilities xdr.Int64, lastModified uint32) (err error) {
 	dest.Type, err = assets.String(xdr.AssetTypeAssetTypeNative)
 	if err != nil {
 		return
@@ -34,6 +35,7 @@ func PopulateNativeBalance(dest *Balance, stroops, buyingLiabilities, sellingLia
 	dest.Balance = amount.String(stroops)
 	dest.BuyingLiabilities = amount.String(buyingLiabilities)
 	dest.SellingLiabilities = amount.String(sellingLiabilities)
+	dest.LastModified = lastModified
 	dest.Limit = ""
 	dest.Issuer = ""
 	dest.Code = ""

--- a/services/horizon/internal/resourceadapter/balance.go
+++ b/services/horizon/internal/resourceadapter/balance.go
@@ -26,7 +26,7 @@ func PopulateBalance(ctx context.Context, dest *Balance, row core.Trustline) (er
 	return
 }
 
-func PopulateNativeBalance(dest *Balance, stroops, buyingLiabilities, sellingLiabilities xdr.Int64, lastModified uint32) (err error) {
+func PopulateNativeBalance(dest *Balance, stroops, buyingLiabilities, sellingLiabilities xdr.Int64) (err error) {
 	dest.Type, err = assets.String(xdr.AssetTypeAssetTypeNative)
 	if err != nil {
 		return
@@ -35,7 +35,7 @@ func PopulateNativeBalance(dest *Balance, stroops, buyingLiabilities, sellingLia
 	dest.Balance = amount.String(stroops)
 	dest.BuyingLiabilities = amount.String(buyingLiabilities)
 	dest.SellingLiabilities = amount.String(sellingLiabilities)
-	dest.LastModifiedLedger = lastModified
+	dest.LastModifiedLedger = 0
 	dest.Limit = ""
 	dest.Issuer = ""
 	dest.Code = ""


### PR DESCRIPTION
this PR exposes the `lastModified` field on an account (native balance) and on trustlines (non-native balance).

This allows us to easily get the ledger number when an account's balance was last modified.