### PR TITLE
Improve queries getting failed objects

### DIFF
--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -123,8 +123,8 @@ func (action *OperationIndexAction) loadRecords() {
 	// When querying operations for transaction return both successful
 	// and failed operations. We asume that because user is querying
 	// this specific transactions, she knows it's status.
-	if action.TransactionFilter == "" && !action.IncludeFailed {
-		ops.SuccessfulOnly()
+	if action.TransactionFilter == "" && action.IncludeFailed {
+		ops.IncludeFailed()
 	}
 
 	action.Err = ops.Page(action.PagingParams).Select(&action.Records)

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -122,7 +122,7 @@ func (action *OperationIndexAction) loadRecords() {
 	}
 
 	// When querying operations for transaction return both successful
-	// and failed operations. We asume that because user is querying
+	// and failed operations. We assume that because user is querying
 	// this specific transactions, she knows it's status.
 	if action.TransactionFilter != "" || action.IncludeFailed {
 		ops.IncludeFailed()

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -123,7 +123,7 @@ func (action *OperationIndexAction) loadRecords() {
 	// When querying operations for transaction return both successful
 	// and failed operations. We asume that because user is querying
 	// this specific transactions, she knows it's status.
-	if action.TransactionFilter == "" && action.IncludeFailed {
+	if action.TransactionFilter != "" || action.IncludeFailed {
 		ops.IncludeFailed()
 	}
 

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -128,8 +128,10 @@ func TestOperationActions_Show_Failed(t *testing.T) {
 		records := []operations.Base{}
 		ht.UnmarshalPage(w.Body, &records)
 
+		ht.Assert.Equal(1, len(records))
 		for _, op := range records {
 			ht.Assert.False(op.TransactionSuccessful)
+			ht.Assert.Equal("aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf", op.TransactionHash)
 		}
 	}
 
@@ -139,6 +141,7 @@ func TestOperationActions_Show_Failed(t *testing.T) {
 		records := []operations.Base{}
 		ht.UnmarshalPage(w.Body, &records)
 
+		ht.Assert.Equal(1, len(records))
 		for _, op := range records {
 			ht.Assert.True(op.TransactionSuccessful)
 		}
@@ -157,6 +160,7 @@ func TestOperationActions_Show_Failed(t *testing.T) {
 		records := []operations.Base{}
 		ht.UnmarshalPage(w.Body, &records)
 
+		ht.Assert.Equal(1, len(records))
 		for _, op := range records {
 			ht.Assert.True(op.TransactionSuccessful)
 		}

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -115,8 +115,8 @@ func (action *PaymentsIndexAction) loadRecords() {
 	// When querying operations for transaction return both successful
 	// and failed operations. We asume that because user is querying
 	// this specific transactions, she knows it's status.
-	if action.TransactionFilter == "" && !action.IncludeFailed {
-		ops.SuccessfulOnly()
+	if action.TransactionFilter == "" && action.IncludeFailed {
+		ops.IncludeFailed()
 	}
 
 	action.Err = ops.Page(action.PagingParams).Select(&action.Records)

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -1,7 +1,6 @@
 package horizon
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/stellar/go/services/horizon/internal/actions"
@@ -9,8 +8,10 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"
 	supportProblem "github.com/stellar/go/support/render/problem"
+	"github.com/stellar/go/xdr"
 )
 
 // Interface verifications
@@ -120,6 +121,27 @@ func (action *PaymentsIndexAction) loadRecords() {
 	}
 
 	action.Err = ops.Page(action.PagingParams).Select(&action.Records)
+	if action.Err == nil {
+		for _, o := range action.Records {
+			if !action.IncludeFailed && action.TransactionFilter == "" {
+				if o.TransactionSuccessful != nil && *o.TransactionSuccessful == false {
+					action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction in /payments is failed: %s", o.TransactionHash)
+					return
+				}
+
+				var resultXDR xdr.TransactionResult
+				action.Err = xdr.SafeUnmarshalBase64(o.TxResult, &resultXDR)
+				if action.Err != nil {
+					return
+				}
+
+				if resultXDR.Result.Code != xdr.TransactionResultCodeTxSuccess {
+					action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction /payments is failed: %s %s", o.TransactionHash, o.TxResult)
+					return
+				}
+			}
+		}
+	}
 }
 
 // loadLedgers populates the ledger cache for this action

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -121,24 +121,26 @@ func (action *PaymentsIndexAction) loadRecords() {
 	}
 
 	action.Err = ops.Page(action.PagingParams).Select(&action.Records)
-	if action.Err == nil {
-		for _, o := range action.Records {
-			if !action.IncludeFailed && action.TransactionFilter == "" {
-				if o.TransactionSuccessful != nil && *o.TransactionSuccessful == false {
-					action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction in /payments is failed: %s", o.TransactionHash)
-					return
-				}
+	if action.Err != nil {
+		return
+	}
 
-				var resultXDR xdr.TransactionResult
-				action.Err = xdr.SafeUnmarshalBase64(o.TxResult, &resultXDR)
-				if action.Err != nil {
-					return
-				}
+	for _, o := range action.Records {
+		if !action.IncludeFailed && action.TransactionFilter == "" {
+			if !o.IsTransactionSuccessful() {
+				action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction in /payments is failed: %s", o.TransactionHash)
+				return
+			}
 
-				if resultXDR.Result.Code != xdr.TransactionResultCodeTxSuccess {
-					action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction /payments is failed: %s %s", o.TransactionHash, o.TxResult)
-					return
-				}
+			var resultXDR xdr.TransactionResult
+			action.Err = xdr.SafeUnmarshalBase64(o.TxResult, &resultXDR)
+			if action.Err != nil {
+				return
+			}
+
+			if resultXDR.Result.Code != xdr.TransactionResultCodeTxSuccess {
+				action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction /payments is failed: %s %s", o.TransactionHash, o.TxResult)
+				return
 			}
 		}
 	}

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -115,7 +115,7 @@ func (action *PaymentsIndexAction) loadRecords() {
 	// When querying operations for transaction return both successful
 	// and failed operations. We asume that because user is querying
 	// this specific transactions, she knows it's status.
-	if action.TransactionFilter == "" && action.IncludeFailed {
+	if action.TransactionFilter != "" || action.IncludeFailed {
 		ops.IncludeFailed()
 	}
 

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -114,7 +114,7 @@ func (action *PaymentsIndexAction) loadRecords() {
 	}
 
 	// When querying operations for transaction return both successful
-	// and failed operations. We asume that because user is querying
+	// and failed operations. We assume that because user is querying
 	// this specific transactions, she knows it's status.
 	if action.TransactionFilter != "" || action.IncludeFailed {
 		ops.IncludeFailed()

--- a/services/horizon/internal/actions_payment_test.go
+++ b/services/horizon/internal/actions_payment_test.go
@@ -58,6 +58,95 @@ func TestPaymentActions(t *testing.T) {
 	ht.Assert.Equal(400, w.Code)
 }
 
+func TestPaymentActions_Show_Failed(t *testing.T) {
+	ht := StartHTTPTest(t, "failed_transactions")
+	defer ht.Finish()
+
+	// Should show successful transactions only
+	w := ht.Get("/payments?limit=200")
+
+	if ht.Assert.Equal(200, w.Code) {
+		records := []operations.Base{}
+		ht.UnmarshalPage(w.Body, &records)
+
+		successful := 0
+		failed := 0
+
+		for _, op := range records {
+			if op.TransactionSuccessful {
+				successful++
+			} else {
+				failed++
+			}
+		}
+
+		ht.Assert.Equal(5, successful)
+		ht.Assert.Equal(0, failed)
+	}
+
+	// Should show all transactions: both successful and failed
+	w = ht.Get("/payments?limit=200&include_failed=true")
+
+	if ht.Assert.Equal(200, w.Code) {
+		records := []operations.Base{}
+		ht.UnmarshalPage(w.Body, &records)
+
+		successful := 0
+		failed := 0
+
+		for _, op := range records {
+			if op.TransactionSuccessful {
+				successful++
+			} else {
+				failed++
+			}
+		}
+
+		ht.Assert.Equal(5, successful)
+		ht.Assert.Equal(1, failed)
+	}
+
+	w = ht.Get("/transactions/aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf/payments")
+
+	if ht.Assert.Equal(200, w.Code) {
+		records := []operations.Base{}
+		ht.UnmarshalPage(w.Body, &records)
+
+		for _, op := range records {
+			ht.Assert.False(op.TransactionSuccessful)
+		}
+	}
+
+	w = ht.Get("/transactions/56e3216045d579bea40f2d35a09406de3a894ecb5be70dbda5ec9c0427a0d5a1/payments")
+
+	if ht.Assert.Equal(200, w.Code) {
+		records := []operations.Base{}
+		ht.UnmarshalPage(w.Body, &records)
+
+		for _, op := range records {
+			ht.Assert.True(op.TransactionSuccessful)
+		}
+	}
+
+	// NULL value
+	_, err := ht.HorizonSession().ExecRaw(
+		`UPDATE history_transactions SET successful = NULL WHERE transaction_hash = ?`,
+		"56e3216045d579bea40f2d35a09406de3a894ecb5be70dbda5ec9c0427a0d5a1",
+	)
+	ht.Require.NoError(err)
+
+	w = ht.Get("/transactions/56e3216045d579bea40f2d35a09406de3a894ecb5be70dbda5ec9c0427a0d5a1/payments")
+
+	if ht.Assert.Equal(200, w.Code) {
+		records := []operations.Base{}
+		ht.UnmarshalPage(w.Body, &records)
+
+		for _, op := range records {
+			ht.Assert.True(op.TransactionSuccessful)
+		}
+	}
+}
+
 func TestPayment_CreatedAt(t *testing.T) {
 	ht := StartHTTPTest(t, "base")
 	defer ht.Finish()

--- a/services/horizon/internal/actions_payment_test.go
+++ b/services/horizon/internal/actions_payment_test.go
@@ -112,6 +112,7 @@ func TestPaymentActions_Show_Failed(t *testing.T) {
 		records := []operations.Base{}
 		ht.UnmarshalPage(w.Body, &records)
 
+		ht.Assert.Equal(1, len(records))
 		for _, op := range records {
 			ht.Assert.False(op.TransactionSuccessful)
 		}
@@ -123,6 +124,7 @@ func TestPaymentActions_Show_Failed(t *testing.T) {
 		records := []operations.Base{}
 		ht.UnmarshalPage(w.Body, &records)
 
+		ht.Assert.Equal(1, len(records))
 		for _, op := range records {
 			ht.Assert.True(op.TransactionSuccessful)
 		}
@@ -141,6 +143,7 @@ func TestPaymentActions_Show_Failed(t *testing.T) {
 		records := []operations.Base{}
 		ht.UnmarshalPage(w.Body, &records)
 
+		ht.Assert.Equal(1, len(records))
 		for _, op := range records {
 			ht.Assert.True(op.TransactionSuccessful)
 		}

--- a/services/horizon/internal/actions_transaction.go
+++ b/services/horizon/internal/actions_transaction.go
@@ -106,24 +106,26 @@ func (action *TransactionIndexAction) loadRecords() {
 	}
 
 	action.Err = txs.Page(action.PagingParams).Select(&action.Records)
-	if action.Err == nil {
-		for _, t := range action.Records {
-			if !action.IncludeFailed {
-				if t.Successful != nil && *t.Successful == false {
-					action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction is failed: %s", t.TransactionHash)
-					return
-				}
+	if action.Err != nil {
+		return
+	}
 
-				var resultXDR xdr.TransactionResult
-				action.Err = xdr.SafeUnmarshalBase64(t.TxResult, &resultXDR)
-				if action.Err != nil {
-					return
-				}
+	for _, t := range action.Records {
+		if !action.IncludeFailed {
+			if !t.IsSuccessful() {
+				action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction is failed: %s", t.TransactionHash)
+				return
+			}
 
-				if resultXDR.Result.Code != xdr.TransactionResultCodeTxSuccess {
-					action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction is failed: %s %s", t.TransactionHash, t.TxResult)
-					return
-				}
+			var resultXDR xdr.TransactionResult
+			action.Err = xdr.SafeUnmarshalBase64(t.TxResult, &resultXDR)
+			if action.Err != nil {
+				return
+			}
+
+			if resultXDR.Result.Code != xdr.TransactionResultCodeTxSuccess {
+				action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction is failed: %s %s", t.TransactionHash, t.TxResult)
+				return
 			}
 		}
 	}

--- a/services/horizon/internal/actions_transaction.go
+++ b/services/horizon/internal/actions_transaction.go
@@ -100,8 +100,8 @@ func (action *TransactionIndexAction) loadRecords() {
 		txs.ForLedger(action.LedgerFilter)
 	}
 
-	if !action.IncludeFailed {
-		txs.SuccessfulOnly()
+	if action.IncludeFailed {
+		txs.IncludeFailed()
 	}
 
 	action.Err = txs.Page(action.PagingParams).Select(&action.Records)

--- a/services/horizon/internal/actions_transaction.go
+++ b/services/horizon/internal/actions_transaction.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"
 	"github.com/stellar/go/support/render/problem"
+	"github.com/stellar/go/xdr"
 )
 
 // This file contains the actions:
@@ -105,6 +106,27 @@ func (action *TransactionIndexAction) loadRecords() {
 	}
 
 	action.Err = txs.Page(action.PagingParams).Select(&action.Records)
+	if action.Err == nil {
+		for _, t := range action.Records {
+			if !action.IncludeFailed {
+				if t.Successful != nil && *t.Successful == false {
+					action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction is failed: %s", t.TransactionHash)
+					return
+				}
+
+				var resultXDR xdr.TransactionResult
+				action.Err = xdr.SafeUnmarshalBase64(t.TxResult, &resultXDR)
+				if action.Err != nil {
+					return
+				}
+
+				if resultXDR.Result.Code != xdr.TransactionResultCodeTxSuccess {
+					action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction is failed: %s %s", t.TransactionHash, t.TxResult)
+					return
+				}
+			}
+		}
+	}
 }
 
 func (action *TransactionIndexAction) loadPage() {

--- a/services/horizon/internal/actions_transaction_test.go
+++ b/services/horizon/internal/actions_transaction_test.go
@@ -36,8 +36,40 @@ func TestTransactionActions_Show_Failed(t *testing.T) {
 	ht := StartHTTPTest(t, "failed_transactions")
 	defer ht.Finish()
 
+	// Failed single
+	w := ht.Get("/transactions/aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf")
+
+	if ht.Assert.Equal(200, w.Code) {
+		var actual horizon.Transaction
+		err := json.Unmarshal(w.Body.Bytes(), &actual)
+		ht.Require.NoError(err)
+
+		ht.Assert.Equal(
+			"aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf",
+			actual.Hash,
+		)
+
+		ht.Assert.False(actual.Successful)
+	}
+
+	// Successful single
+	w = ht.Get("/transactions/56e3216045d579bea40f2d35a09406de3a894ecb5be70dbda5ec9c0427a0d5a1")
+
+	if ht.Assert.Equal(200, w.Code) {
+		var actual horizon.Transaction
+		err := json.Unmarshal(w.Body.Bytes(), &actual)
+		ht.Require.NoError(err)
+
+		ht.Assert.Equal(
+			"56e3216045d579bea40f2d35a09406de3a894ecb5be70dbda5ec9c0427a0d5a1",
+			actual.Hash,
+		)
+
+		ht.Assert.True(actual.Successful)
+	}
+
 	// Should show successful transactions only
-	w := ht.Get("/transactions?limit=200")
+	w = ht.Get("/transactions?limit=200")
 
 	if ht.Assert.Equal(200, w.Code) {
 		records := []horizon.Transaction{}

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -244,13 +244,12 @@ type Operation struct {
 
 // OperationsQ is a helper struct to aid in configuring queries that loads
 // slices of Operation structs.
-// WARNING: returns successful and failed operations! Use `SuccessfulOnly`
-// to return successful transactions only.
 type OperationsQ struct {
-	Err     error
-	parent  *Q
-	sql     sq.SelectBuilder
-	opIdCol string
+	Err           error
+	parent        *Q
+	sql           sq.SelectBuilder
+	opIdCol       string
+	includeFailed bool
 }
 
 // Q is a helper struct on which to hang common_trades queries against a history
@@ -329,12 +328,11 @@ type Transaction struct {
 
 // TransactionsQ is a helper struct to aid in configuring queries that loads
 // slices of transaction structs.
-// WARNING: returns successful and failed transactions! Use `SuccessfulOnly`
-// to return successful transactions only.
 type TransactionsQ struct {
-	Err    error
-	parent *Q
-	sql    sq.SelectBuilder
+	Err           error
+	parent        *Q
+	sql           sq.SelectBuilder
+	includeFailed bool
 }
 
 // ElderLedger loads the oldest ledger known to the history database

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -234,6 +234,7 @@ type Operation struct {
 	TotalOrderID
 	TransactionID    int64             `db:"transaction_id"`
 	TransactionHash  string            `db:"transaction_hash"`
+	TxResult         string            `db:"tx_result"`
 	ApplicationOrder int32             `db:"application_order"`
 	Type             xdr.OperationType `db:"type"`
 	DetailsString    null.String       `db:"details"`

--- a/services/horizon/internal/db2/history/operation.go
+++ b/services/horizon/internal/db2/history/operation.go
@@ -10,6 +10,14 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
+func (t *Operation) IsTransactionSuccessful() bool {
+	if t.TransactionSuccessful == nil {
+		return true
+	}
+
+	return *t.TransactionSuccessful
+}
+
 // LedgerSequence return the ledger in which the effect occurred.
 func (r *Operation) LedgerSequence() int32 {
 	id := toid.Parse(r.ID)
@@ -185,20 +193,29 @@ func (q *OperationsQ) Select(dest interface{}) error {
 	}
 
 	for _, o := range *operations {
-		if !q.includeFailed {
-			if o.TransactionSuccessful != nil && *o.TransactionSuccessful == false {
-				return errors.Errorf("Corrupted data! `include_failed=false` but returned transaction is failed: %s", o.TransactionHash)
-			}
+		var resultXDR xdr.TransactionResult
+		err := xdr.SafeUnmarshalBase64(o.TxResult, &resultXDR)
+		if err != nil {
+			return err
+		}
 
-			var resultXDR xdr.TransactionResult
-			err := xdr.SafeUnmarshalBase64(o.TxResult, &resultXDR)
-			if err != nil {
-				return err
+		if !q.includeFailed {
+			if !o.IsTransactionSuccessful() {
+				return errors.Errorf("Corrupted data! `include_failed=false` but returned transaction is failed: %s", o.TransactionHash)
 			}
 
 			if resultXDR.Result.Code != xdr.TransactionResultCodeTxSuccess {
 				return errors.Errorf("Corrupted data! `include_failed=false` but returned transaction is failed: %s %s", o.TransactionHash, o.TxResult)
 			}
+		}
+
+		// Check if `successful` equals resultXDR
+		if o.IsTransactionSuccessful() && resultXDR.Result.Code != xdr.TransactionResultCodeTxSuccess {
+			return errors.Errorf("Corrupted data! `successful=true` but returned transaction is not success: %s %s", o.TransactionHash, o.TxResult)
+		}
+
+		if !o.IsTransactionSuccessful() && resultXDR.Result.Code == xdr.TransactionResultCodeTxSuccess {
+			return errors.Errorf("Corrupted data! `successful=false` but returned transaction is success: %s %s", o.TransactionHash, o.TxResult)
 		}
 	}
 

--- a/services/horizon/internal/db2/history/operation_test.go
+++ b/services/horizon/internal/db2/history/operation_test.go
@@ -71,7 +71,7 @@ func TestOperationQueryBuilder(t *testing.T) {
 	tt.Assert.NoError(err)
 
 	// Operations for account queries will use hopp.history_operation_id in their predicates.
-	want := "SELECT hop.id, hop.transaction_id, hop.application_order, hop.type, hop.details, hop.source_account, ht.transaction_hash, ht.successful as transaction_successful FROM history_operations hop LEFT JOIN history_transactions ht ON ht.id = hop.transaction_id JOIN history_operation_participants hopp ON hopp.history_operation_id = hop.id WHERE hopp.history_account_id = ? AND hopp.history_operation_id > ? ORDER BY hopp.history_operation_id asc LIMIT 10"
+	want := "SELECT hop.id, hop.transaction_id, hop.application_order, hop.type, hop.details, hop.source_account, ht.transaction_hash, ht.tx_result, ht.successful as transaction_successful FROM history_operations hop LEFT JOIN history_transactions ht ON ht.id = hop.transaction_id JOIN history_operation_participants hopp ON hopp.history_operation_id = hop.id WHERE hopp.history_account_id = ? AND hopp.history_operation_id > ? ORDER BY hopp.history_operation_id asc LIMIT 10"
 	tt.Assert.EqualValues(want, got)
 
 	opsQ = q.Operations().ForLedger(2).Page(db2.PageQuery{Cursor: "8589938689", Order: "asc", Limit: 10})
@@ -80,7 +80,7 @@ func TestOperationQueryBuilder(t *testing.T) {
 	tt.Assert.NoError(err)
 
 	// Other operation queries will use hop.id in their predicates.
-	want = "SELECT hop.id, hop.transaction_id, hop.application_order, hop.type, hop.details, hop.source_account, ht.transaction_hash, ht.successful as transaction_successful FROM history_operations hop LEFT JOIN history_transactions ht ON ht.id = hop.transaction_id WHERE hop.id >= ? AND hop.id < ? AND hop.id > ? ORDER BY hop.id asc LIMIT 10"
+	want = "SELECT hop.id, hop.transaction_id, hop.application_order, hop.type, hop.details, hop.source_account, ht.transaction_hash, ht.tx_result, ht.successful as transaction_successful FROM history_operations hop LEFT JOIN history_transactions ht ON ht.id = hop.transaction_id WHERE hop.id >= ? AND hop.id < ? AND hop.id > ? ORDER BY hop.id asc LIMIT 10"
 	tt.Assert.EqualValues(want, got)
 }
 
@@ -142,7 +142,7 @@ func TestOperationIncludeFailed(t *testing.T) {
 
 	sql, _, err := query.sql.ToSql()
 	tt.Assert.NoError(err)
-	tt.Assert.Equal("SELECT hop.id, hop.transaction_id, hop.application_order, hop.type, hop.details, hop.source_account, ht.transaction_hash, ht.successful as transaction_successful FROM history_operations hop LEFT JOIN history_transactions ht ON ht.id = hop.transaction_id JOIN history_operation_participants hopp ON hopp.history_operation_id = hop.id WHERE hopp.history_account_id = ?", sql)
+	tt.Assert.Equal("SELECT hop.id, hop.transaction_id, hop.application_order, hop.type, hop.details, hop.source_account, ht.transaction_hash, ht.tx_result, ht.successful as transaction_successful FROM history_operations hop LEFT JOIN history_transactions ht ON ht.id = hop.transaction_id JOIN history_operation_participants hopp ON hopp.history_operation_id = hop.id WHERE hopp.history_account_id = ?", sql)
 }
 
 // TestPaymentsSuccessfulOnly tests if default query returns payments in
@@ -205,5 +205,5 @@ func TestPaymentsIncludeFailed(t *testing.T) {
 
 	sql, _, err := query.sql.ToSql()
 	tt.Assert.NoError(err)
-	tt.Assert.Equal("SELECT hop.id, hop.transaction_id, hop.application_order, hop.type, hop.details, hop.source_account, ht.transaction_hash, ht.successful as transaction_successful FROM history_operations hop LEFT JOIN history_transactions ht ON ht.id = hop.transaction_id JOIN history_operation_participants hopp ON hopp.history_operation_id = hop.id WHERE hop.type IN (?,?,?,?) AND hopp.history_account_id = ?", sql)
+	tt.Assert.Equal("SELECT hop.id, hop.transaction_id, hop.application_order, hop.type, hop.details, hop.source_account, ht.transaction_hash, ht.tx_result, ht.successful as transaction_successful FROM history_operations hop LEFT JOIN history_transactions ht ON ht.id = hop.transaction_id JOIN history_operation_participants hopp ON hopp.history_operation_id = hop.id WHERE hop.type IN (?,?,?,?) AND hopp.history_account_id = ?", sql)
 }

--- a/services/horizon/internal/db2/history/transaction_test.go
+++ b/services/horizon/internal/db2/history/transaction_test.go
@@ -83,3 +83,47 @@ func TestTransactionIncludeFailed(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.Equal("SELECT ht.id, ht.transaction_hash, ht.ledger_sequence, ht.application_order, ht.account, ht.account_sequence, ht.fee_paid, ht.operation_count, ht.tx_envelope, ht.tx_result, ht.tx_meta, ht.tx_fee_meta, ht.created_at, ht.updated_at, ht.successful, array_to_string(ht.signatures, ',') AS signatures, ht.memo_type, ht.memo, lower(ht.time_bounds) AS valid_after, upper(ht.time_bounds) AS valid_before, hl.closed_at AS ledger_close_time FROM history_transactions ht LEFT JOIN history_ledgers hl ON ht.ledger_sequence = hl.sequence JOIN history_transaction_participants htp ON htp.history_transaction_id = ht.id WHERE htp.history_account_id = ?", sql)
 }
+
+func TestExtraChecksTransactionSuccessfulTrueResultFalse(t *testing.T) {
+	tt := test.Start(t).Scenario("failed_transactions")
+	defer tt.Finish()
+
+	// successful `true` but tx result `false`
+	_, err := tt.HorizonDB.Exec(
+		`UPDATE history_transactions SET successful = true WHERE transaction_hash = 'aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf'`,
+	)
+	tt.Require.NoError(err)
+
+	var transactions []Transaction
+
+	q := &Q{tt.HorizonSession()}
+	query := q.Transactions().
+		ForAccount("GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2").
+		IncludeFailed()
+
+	err = query.Select(&transactions)
+	tt.Assert.Error(err)
+	tt.Assert.Contains(err.Error(), "Corrupted data! `successful=true` but returned transaction is not success")
+}
+
+func TestExtraChecksTransactionSuccessfulFalseResultTrue(t *testing.T) {
+	tt := test.Start(t).Scenario("failed_transactions")
+	defer tt.Finish()
+
+	// successful `false` but tx result `true`
+	_, err := tt.HorizonDB.Exec(
+		`UPDATE history_transactions SET successful = false WHERE transaction_hash = 'a2dabf4e9d1642722602272e178a37c973c9177b957da86192a99b3e9f3a9aa4'`,
+	)
+	tt.Require.NoError(err)
+
+	var transactions []Transaction
+
+	q := &Q{tt.HorizonSession()}
+	query := q.Transactions().
+		ForAccount("GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON").
+		IncludeFailed()
+
+	err = query.Select(&transactions)
+	tt.Assert.Error(err)
+	tt.Assert.Contains(err.Error(), "Corrupted data! `successful=false` but returned transaction is success")
+}

--- a/services/horizon/internal/db2/history/transaction_test.go
+++ b/services/horizon/internal/db2/history/transaction_test.go
@@ -23,21 +23,63 @@ func TestTransactionQueries(t *testing.T) {
 	tt.Assert.Equal(err, sql.ErrNoRows)
 }
 
-// TestTransactionSuccessfulOnly tests SuccessfulOnly() method. It specifically
-// tests the `successful = true OR successful IS NULL` condition in a query.
+// TestTransactionSuccessfulOnly tests if default query returns successful
+// transactions only.
 // If it's not enclosed in brackets, it may return incorrect result when mixed
 // with `ForAccount` or `ForLedger` filters.
 func TestTransactionSuccessfulOnly(t *testing.T) {
 	tt := test.Start(t).Scenario("failed_transactions")
 	defer tt.Finish()
 
+	var transactions []Transaction
+
 	q := &Q{tt.HorizonSession()}
 	query := q.Transactions().
-		ForAccount("GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU").
-		SuccessfulOnly()
+		ForAccount("GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2")
+
+	err := query.Select(&transactions)
+	tt.Assert.NoError(err)
+
+	tt.Assert.Equal(3, len(transactions))
+
+	for _, transaction := range transactions {
+		tt.Assert.True(*transaction.Successful)
+	}
 
 	sql, _, err := query.sql.ToSql()
 	tt.Assert.NoError(err)
 	// Note: brackets around `(ht.successful = true OR ht.successful IS NULL)` are critical!
 	tt.Assert.Contains(sql, "WHERE htp.history_account_id = ? AND (ht.successful = true OR ht.successful IS NULL)")
+}
+
+// TestTransactionIncludeFailed tests `IncludeFailed` method.
+func TestTransactionIncludeFailed(t *testing.T) {
+	tt := test.Start(t).Scenario("failed_transactions")
+	defer tt.Finish()
+
+	var transactions []Transaction
+
+	q := &Q{tt.HorizonSession()}
+	query := q.Transactions().
+		ForAccount("GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2").
+		IncludeFailed()
+
+	err := query.Select(&transactions)
+	tt.Assert.NoError(err)
+
+	var failed, successful int
+	for _, transaction := range transactions {
+		if *transaction.Successful {
+			successful++
+		} else {
+			failed++
+		}
+	}
+
+	tt.Assert.Equal(3, successful)
+	tt.Assert.Equal(1, failed)
+
+	sql, _, err := query.sql.ToSql()
+	tt.Assert.NoError(err)
+	tt.Assert.Equal("SELECT ht.id, ht.transaction_hash, ht.ledger_sequence, ht.application_order, ht.account, ht.account_sequence, ht.fee_paid, ht.operation_count, ht.tx_envelope, ht.tx_result, ht.tx_meta, ht.tx_fee_meta, ht.created_at, ht.updated_at, ht.successful, array_to_string(ht.signatures, ',') AS signatures, ht.memo_type, ht.memo, lower(ht.time_bounds) AS valid_after, upper(ht.time_bounds) AS valid_before, hl.closed_at AS ledger_close_time FROM history_transactions ht LEFT JOIN history_ledgers hl ON ht.ledger_sequence = hl.sequence JOIN history_transaction_participants htp ON htp.history_transaction_id = ht.id WHERE htp.history_account_id = ?", sql)
 }

--- a/services/horizon/internal/test/scenarios/failed_transactions.rb
+++ b/services/horizon/internal/test/scenarios/failed_transactions.rb
@@ -27,6 +27,7 @@ offer :anchor, {buy:["USD", :anchor], with: :native}, "200.0", "2.0"
 
 close_ledger
 
+# this should fail
 payment :user1, :user2,
   ["USD", :anchor, "200.0"],
   path:[:native]


### PR DESCRIPTION
As proved by 2cf045bc11febe413feb1af03c7493e955c9f792 the code in #875 was not safe. The default queries for `TransactionsQ` and `OperationsQ` were retuning both successful and failed objects. This is not how a default query should behave as it can have a critical implications when `SuccessfulOnly()` method is not called.

This PR changes the default query to return successful objects only and adds `IncludeFailed()` method to include failed objects. It also adds extra checks in query structs and actions to check if objects are correct and tests for `/payments` endpoint.

**Please do not merge without extensive check of the code.**