### PR TITLE
Return correct status for resubmitting old, failed transactions

### DIFF
--- a/services/horizon/internal/actions_transaction_test.go
+++ b/services/horizon/internal/actions_transaction_test.go
@@ -192,3 +192,14 @@ func TestTransactionActions_Post(t *testing.T) {
 	w = ht.Post("/transactions", form)
 	ht.Assert.Equal(503, w.Code)
 }
+
+func TestTransactionActions_PostFailed(t *testing.T) {
+	ht := StartHTTPTest(t, "failed_transactions")
+	defer ht.Finish()
+
+	// aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf
+	form := url.Values{"tx": []string{"AAAAAG5oJtVdnYOVdZqtXpTHBtbcY0mCmfcBIKEgWnlvFIhaAAAAZAAAAAIAAAACAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAO2C/AO45YBD3tHVFO1R3A0MekP8JR6nN1A9eWidyItUAAAABVVNEAAAAAACuo3ot45qCPExpQ/3oHN+z17Ryis1lfMFYmQWgruS+TAAAAAB3NZQAAAAAAAAAAAFvFIhaAAAAQKcGS9OsVnVHCVIH04C9ZKzzKYBRdCmy+Jwmzld7QcALOxZUcAgkuGfoSdvXpH38mNvrqQiaMsSNmTJWYRzHvgo="}}
+
+	w := ht.Post("/transactions", form)
+	ht.Assert.Equal(400, w.Code)
+}

--- a/services/horizon/internal/actions_transaction_test.go
+++ b/services/horizon/internal/actions_transaction_test.go
@@ -193,6 +193,18 @@ func TestTransactionActions_Post(t *testing.T) {
 	ht.Assert.Equal(503, w.Code)
 }
 
+func TestTransactionActions_PostSuccessful(t *testing.T) {
+	ht := StartHTTPTest(t, "failed_transactions")
+	defer ht.Finish()
+
+	// 56e3216045d579bea40f2d35a09406de3a894ecb5be70dbda5ec9c0427a0d5a1
+	form := url.Values{"tx": []string{"AAAAAK6jei3jmoI8TGlD/egc37PXtHKKzWV8wViZBaCu5L5MAAAAZAAAAAIAAAABAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAbmgm1V2dg5V1mq1elMcG1txjSYKZ9wEgoSBaeW8UiFoAAAABVVNEAAAAAACuo3ot45qCPExpQ/3oHN+z17Ryis1lfMFYmQWgruS+TAAAAAA7msoAAAAAAAAAAAGu5L5MAAAAQEnKDbDYvKkJjYK0arvhFln+GK0+7Ay6g0a+1hjRRelEAe4wmjeqNcRg2m4Cn7t4AjJzAsDQI0iXahGboJPINAw="}}
+
+	w := ht.Post("/transactions", form)
+	ht.Assert.Equal(200, w.Code)
+	ht.Assert.Contains(string(w.Body.Bytes()), `"result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA="`)
+}
+
 func TestTransactionActions_PostFailed(t *testing.T) {
 	ht := StartHTTPTest(t, "failed_transactions")
 	defer ht.Finish()
@@ -203,5 +215,5 @@ func TestTransactionActions_PostFailed(t *testing.T) {
 	w := ht.Post("/transactions", form)
 	ht.Assert.Equal(400, w.Code)
 	ht.Assert.Contains(string(w.Body.Bytes()), "op_underfunded")
-	ht.Assert.Contains(string(w.Body.Bytes()), "AAAAAAAAAGT/////AAAAAQAAAAAAAAAB/////gAAAAA=")
+	ht.Assert.Contains(string(w.Body.Bytes()), `"result_xdr": "AAAAAAAAAGT/////AAAAAQAAAAAAAAAB/////gAAAAA="`)
 }

--- a/services/horizon/internal/actions_transaction_test.go
+++ b/services/horizon/internal/actions_transaction_test.go
@@ -202,4 +202,6 @@ func TestTransactionActions_PostFailed(t *testing.T) {
 
 	w := ht.Post("/transactions", form)
 	ht.Assert.Equal(400, w.Code)
+	ht.Assert.Contains(string(w.Body.Bytes()), "op_underfunded")
+	ht.Assert.Contains(string(w.Body.Bytes()), "AAAAAAAAAGT/////AAAAAQAAAAAAAAAB/////gAAAAA=")
 }

--- a/services/horizon/internal/txsub/results/db/main.go
+++ b/services/horizon/internal/txsub/results/db/main.go
@@ -65,7 +65,18 @@ func (rp *DB) ResultByHash(ctx context.Context, hash string) txsub.Result {
 }
 
 func txResultFromHistory(tx history.Transaction) txsub.Result {
+	var txResult xdr.TransactionResult
+	err := xdr.SafeUnmarshalBase64(tx.TxResult, &txResult)
+	if err == nil {
+		if txResult.Result.Code != xdr.TransactionResultCodeTxSuccess {
+			err = &txsub.FailedTransactionError{
+				ResultXDR: tx.TxResult,
+			}
+		}
+	}
+
 	return txsub.Result{
+		Err:            err,
 		Hash:           tx.TransactionHash,
 		LedgerSequence: tx.LedgerSequence,
 		EnvelopeXDR:    tx.TxEnvelope,

--- a/services/horizon/internal/txsub/results/db/main_test.go
+++ b/services/horizon/internal/txsub/results/db/main_test.go
@@ -6,10 +6,11 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/services/horizon/internal/txsub"
 )
 
 func TestResultProvider(t *testing.T) {
-	tt := test.Start(t).ScenarioWithoutHorizon("base")
+	tt := test.Start(t).Scenario("base")
 	defer tt.Finish()
 
 	rp := &DB{
@@ -23,5 +24,30 @@ func TestResultProvider(t *testing.T) {
 	ret := rp.ResultByHash(tt.Ctx, hash)
 
 	tt.Require.NoError(ret.Err)
+	tt.Assert.Equal(hash, ret.Hash)
+}
+
+func TestResultFailed(t *testing.T) {
+	tt := test.Start(t).Scenario("failed_transactions")
+	defer tt.Finish()
+
+	rp := &DB{
+		Core:    &core.Q{Session: tt.CoreSession()},
+		History: &history.Q{Session: tt.HorizonSession()},
+	}
+
+	hash := "aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf"
+
+	// Ignore core db results
+	_, err := tt.CoreSession().ExecRaw(
+		`DELETE FROM txhistory WHERE txid = ?`,
+		hash,
+	)
+	tt.Require.NoError(err)
+
+	ret := rp.ResultByHash(tt.Ctx, hash)
+
+	tt.Require.Error(ret.Err)
+	tt.Assert.Equal("AAAAAAAAAGT/////AAAAAQAAAAAAAAAB/////gAAAAA=", ret.Err.(*txsub.FailedTransactionError).ResultXDR)
 	tt.Assert.Equal(hash, ret.Hash)
 }


### PR DESCRIPTION
Since #875 `POST /transactions` returned `200 OK` status for old, failed transactions (that are not present in core DB) if a node was ingesting failed transactions. This PR fixes the code responsible for checking the transaction status and returns correct HTTP code and response.