### PR TITLE
exp/clients/horizonclient: assets and streaming

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,6 +64,10 @@
   revision = "7f87c0fbb88b590338857bcb720678c2583d4dea"
 
 [[override]]
+  name = "gopkg.in/fsnotify.v1"
+  source = "gopkg.in/fsnotify/fsnotify.v1"  
+
+[[override]]
   name = "golang.org/x/sys"
   revision = "cc5685c2db1239775905f3911f0067c0fa74762f"
 

--- a/exp/clients/horizon/asset_request.go
+++ b/exp/clients/horizon/asset_request.go
@@ -11,7 +11,6 @@ import (
 // If no data is set, it defaults to the build the URL for all assets
 func (ar AssetRequest) BuildUrl() (endpoint string, err error) {
 	endpoint = "assets"
-
 	queryParams := addQueryParams(ar.ForAssetCode, ar.ForAssetIssuer, ar.Cursor, ar.Limit, ar.Order)
 	if queryParams != "" {
 		endpoint = fmt.Sprintf(

--- a/exp/clients/horizon/asset_request_test.go
+++ b/exp/clients/horizon/asset_request_test.go
@@ -28,5 +28,4 @@ func TestAssetRequestBuildUrl(t *testing.T) {
 	// It should return valid assets endpoint and no errors
 	require.NoError(t, err)
 	assert.Equal(t, "assets?asset_code=ABC&asset_issuer=GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU&order=desc", endpoint)
-
 }

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stellar/go/support/errors"
 )
 
-func sendRequest(hr HorizonRequest, c Client, a interface{}) (err error) {
+func (c *Client) sendRequest(hr HorizonRequest, a interface{}) (err error) {
 	endpoint, err := hr.BuildUrl()
 	if err != nil {
 		return
@@ -19,8 +19,6 @@ func sendRequest(hr HorizonRequest, c Client, a interface{}) (err error) {
 		return errors.Wrap(err, "Error creating HTTP request")
 	}
 	req.Header.Set("X-Client-Name", "go-stellar-sdk")
-	// to do: Confirm if there is a different way to set version. Not sure about this, since we dont build the sdk into an executable file.
-	// Do we currently track sdk versions differently?
 	req.Header.Set("X-Client-Version", app.Version())
 
 	resp, err := c.HTTP.Do(req)
@@ -43,7 +41,7 @@ func (c *Client) AccountDetail(request AccountRequest) (account Account, err err
 		return
 	}
 
-	err = sendRequest(request, *c, &account)
+	err = c.sendRequest(request, &account)
 	return
 }
 
@@ -58,44 +56,44 @@ func (c *Client) AccountData(request AccountRequest) (accountData AccountData, e
 		return
 	}
 
-	err = sendRequest(request, *c, &accountData)
+	err = c.sendRequest(request, &accountData)
 	return
 }
 
 // Effects returns effects(https://www.stellar.org/developers/horizon/reference/resources/effect.html)
 // It can be used to return effects for an account, a ledger, an operation, a transaction and all effects on the network.
 func (c *Client) Effects(request EffectRequest) (effects EffectsPage, err error) {
-	err = sendRequest(request, *c, &effects)
+	err = c.sendRequest(request, &effects)
 	return
 }
 
 // Assets returns asset information.
 // See https://www.stellar.org/developers/horizon/reference/endpoints/assets-all.html
 func (c *Client) Assets(request AssetRequest) (assets AssetsPage, err error) {
-	err = sendRequest(request, *c, &assets)
+	err = c.sendRequest(request, &assets)
 	return
 }
 
-func (c *Client) Stream(request StreamRequest, ctx context.Context, handler func(interface{})) (err error) {
+func (c *Client) Stream(ctx context.Context, request StreamRequest, handler func(interface{})) (err error) {
 
-	err = request.Stream(c.HorizonURL, ctx, handler)
+	err = request.Stream(ctx, c.HorizonURL, handler)
 	return
 }
 
 func (c *Client) Ledgers(request LedgerRequest) (ledgers LedgersPage, err error) {
-	err = sendRequest(request, *c, &ledgers)
+	err = c.sendRequest(request, &ledgers)
 	return
 }
 
 func (c *Client) LedgerDetail(request LedgerRequest) (ledger Ledger, err error) {
-	if request.ForSequence == "" {
-		err = errors.New("No sequence number provided")
+	if request.ForSequence <= 0 {
+		err = errors.New("Invalid sequence number provided")
 	}
 
 	if err != nil {
 		return
 	}
 
-	err = sendRequest(request, *c, &ledger)
+	err = c.sendRequest(request, &ledger)
 	return
 }

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -1,6 +1,10 @@
 package horizonclient
 
 import (
+	"context"
+	"net/http"
+
+	"github.com/stellar/go/support/app"
 	"github.com/stellar/go/support/errors"
 )
 
@@ -10,9 +14,17 @@ func sendRequest(hr HorizonRequest, c Client, a interface{}) (err error) {
 		return
 	}
 
-	resp, err := c.HTTP.Get(c.HorizonURL + endpoint)
+	req, err := http.NewRequest("GET", c.HorizonURL+endpoint, nil)
 	if err != nil {
+		return errors.Wrap(err, "Error creating HTTP request")
+	}
+	req.Header.Set("X-Client-Name", "go-stellar-sdk")
+	// to do: Confirm if there is a different way to set version. Not sure about this, since we dont build the sdk into an executable file.
+	// Do we currently track sdk versions differently?
+	req.Header.Set("X-Client-Version", app.Version())
 
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
 		return
 	}
 
@@ -57,7 +69,15 @@ func (c *Client) Effects(request EffectRequest) (effects EffectsPage, err error)
 	return
 }
 
+// Assets returns asset information.
+// See https://www.stellar.org/developers/horizon/reference/endpoints/assets-all.html
 func (c *Client) Assets(request AssetRequest) (assets AssetsPage, err error) {
 	err = sendRequest(request, *c, &assets)
+	return
+}
+
+func (c *Client) Stream(request StreamRequest, ctx context.Context, handler func(interface{})) (err error) {
+
+	err = request.Stream(c.HorizonURL, ctx, handler)
 	return
 }

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -81,3 +81,21 @@ func (c *Client) Stream(request StreamRequest, ctx context.Context, handler func
 	err = request.Stream(c.HorizonURL, ctx, handler)
 	return
 }
+
+func (c *Client) Legders(request LedgerRequest) (ledgers LedgersPage, err error) {
+	err = sendRequest(request, *c, &ledgers)
+	return
+}
+
+func (c *Client) LegderDetail(request LedgerRequest) (ledger Ledger, err error) {
+	if request.ForSequence == "" {
+		err = errors.New("No sequence number provided")
+	}
+
+	if err != nil {
+		return
+	}
+
+	err = sendRequest(request, *c, &ledger)
+	return
+}

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -74,17 +74,22 @@ func (c *Client) Assets(request AssetRequest) (assets AssetsPage, err error) {
 	return
 }
 
+// Stream is for endpoints that support streaming
 func (c *Client) Stream(ctx context.Context, request StreamRequest, handler func(interface{})) (err error) {
 
 	err = request.Stream(ctx, c.HorizonURL, handler)
 	return
 }
 
+// Ledgers returns information about all ledgers.
+// See https://www.stellar.org/developers/horizon/reference/endpoints/ledgers-all.html
 func (c *Client) Ledgers(request LedgerRequest) (ledgers LedgersPage, err error) {
 	err = c.sendRequest(request, &ledgers)
 	return
 }
 
+// LedgerDetails returns information about a particular ledger
+// See https://www.stellar.org/developers/horizon/reference/endpoints/ledgers-single.html
 func (c *Client) LedgerDetail(request LedgerRequest) (ledger Ledger, err error) {
 	if request.ForSequence <= 0 {
 		err = errors.New("Invalid sequence number provided")

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -82,12 +82,12 @@ func (c *Client) Stream(request StreamRequest, ctx context.Context, handler func
 	return
 }
 
-func (c *Client) Legders(request LedgerRequest) (ledgers LedgersPage, err error) {
+func (c *Client) Ledgers(request LedgerRequest) (ledgers LedgersPage, err error) {
 	err = sendRequest(request, *c, &ledgers)
 	return
 }
 
-func (c *Client) LegderDetail(request LedgerRequest) (ledger Ledger, err error) {
+func (c *Client) LedgerDetail(request LedgerRequest) (ledger Ledger, err error) {
 	if request.ForSequence == "" {
 		err = errors.New("No sequence number provided")
 	}

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -88,16 +88,18 @@ func (c *Client) Ledgers(request LedgerRequest) (ledgers LedgersPage, err error)
 	return
 }
 
-// LedgerDetails returns information about a particular ledger
+// LedgerDetails returns information about a particular ledger for a given sequence number
 // See https://www.stellar.org/developers/horizon/reference/endpoints/ledgers-single.html
-func (c *Client) LedgerDetail(request LedgerRequest) (ledger Ledger, err error) {
-	if request.ForSequence <= 0 {
+func (c *Client) LedgerDetail(sequence uint32) (ledger Ledger, err error) {
+	if sequence <= 0 {
 		err = errors.New("Invalid sequence number provided")
 	}
 
 	if err != nil {
 		return
 	}
+
+	request := LedgerRequest{forSequence: sequence}
 
 	err = c.sendRequest(request, &ledger)
 	return

--- a/exp/clients/horizon/effect_request.go
+++ b/exp/clients/horizon/effect_request.go
@@ -1,11 +1,23 @@
 package horizonclient
 
 import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
+	"strings"
 
+	"github.com/manucorporat/sse"
+	"github.com/stellar/go/support/app"
 	"github.com/stellar/go/support/errors"
 )
+
+// EffectHandler is a function that is called when a new effect is received
+type EffectHandler func(Effect)
 
 // BuildUrl creates the endpoint to be queried based on the data in the EffectRequest struct.
 // If no data is set, it defaults to the build the URL for all effects
@@ -66,4 +78,147 @@ func (er EffectRequest) BuildUrl() (endpoint string, err error) {
 	}
 
 	return endpoint, err
+}
+
+// To do: move this from here
+func stream(
+	ctx context.Context,
+	baseURL string,
+	cursor *Cursor,
+	handler func(data []byte) error,
+) error {
+	query := url.Values{}
+	if cursor != nil {
+		query.Set("cursor", string(*cursor))
+	}
+
+	client := http.Client{}
+
+	for {
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s?%s", baseURL, query.Encode()), nil)
+		if err != nil {
+			return errors.Wrap(err, "Error creating HTTP request")
+		}
+		req.Header.Set("Accept", "text/event-stream")
+		// to do: confirm name and version
+		req.Header.Set("X-Client-Name", "go-stellar-sdk")
+		req.Header.Set("X-Client-Version", app.Version())
+
+		// Make sure we don't use c.HTTP that can have Timeout set.
+		resp, err := client.Do(req)
+		if err != nil {
+			return errors.Wrap(err, "Error sending HTTP request")
+		}
+
+		// To do: Why not just check if StatusCode != 200 ? Was there a reason why it was implemented like this?
+		if resp.StatusCode/100 != 2 {
+			return fmt.Errorf("Got bad HTTP status code %d", resp.StatusCode)
+		}
+		defer resp.Body.Close()
+
+		reader := bufio.NewReader(resp.Body)
+
+		// Read events one by one. Break this loop when there is no more data to be
+		// read from resp.Body (io.EOF).
+	Events:
+		for {
+			// Read until empty line = event delimiter. The perfect solution would be to read
+			// as many bytes as possible and forward them to sse.Decode. However this
+			// requires much more complicated code.
+			// We could also write our own `sse` package that works fine with streams directly
+			// (github.com/manucorporat/sse is just using io/ioutils.ReadAll).
+			var buffer bytes.Buffer
+			nonEmptylinesRead := 0
+			for {
+				// Check if ctx is not cancelled
+				select {
+				case <-ctx.Done():
+					return nil
+				default:
+					// Continue
+				}
+
+				line, err := reader.ReadString('\n')
+				if err != nil {
+					if err == io.EOF || err == io.ErrUnexpectedEOF {
+						// We catch EOF errors to handle two possible situations:
+						// - The last line before closing the stream was not empty. This should never
+						//   happen in Horizon as it always sends an empty line after each event.
+						// - The stream was closed by the server/proxy because the connection was idle.
+						//
+						// In the former case, that (again) should never happen in Horizon, we need to
+						// check if there are any events we need to decode. We do this in the `if`
+						// statement below just in case if Horizon behaviour changes in a future.
+						//
+						// From spec:
+						// > Once the end of the file is reached, the user agent must dispatch the
+						// > event one final time, as defined below.
+						if nonEmptylinesRead == 0 {
+							break Events
+						}
+					} else {
+						return errors.Wrap(err, "Error reading line")
+					}
+				}
+
+				buffer.WriteString(line)
+
+				if strings.TrimRight(line, "\n\r") == "" {
+					break
+				}
+
+				nonEmptylinesRead++
+			}
+
+			events, err := sse.Decode(strings.NewReader(buffer.String()))
+			if err != nil {
+				return errors.Wrap(err, "Error decoding event")
+			}
+
+			// Right now len(events) should always be 1. This loop will be helpful after writing
+			// new SSE decoder that can handle io.Reader without using ioutils.ReadAll().
+			for _, event := range events {
+				if event.Event != "message" {
+					continue
+				}
+
+				// Update cursor with event ID
+				if event.Id != "" {
+					query.Set("cursor", event.Id)
+				}
+
+				switch data := event.Data.(type) {
+				case string:
+					err = handler([]byte(data))
+					err = errors.Wrap(err, "Handler error")
+				case []byte:
+					err = handler(data)
+					err = errors.Wrap(err, "Handler error")
+				default:
+					err = errors.New("Invalid event.Data type")
+				}
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+func (er EffectRequest) Stream(
+	horizonURL string,
+	ctx context.Context,
+	handler func(interface{}),
+) (err error) {
+
+	url := fmt.Sprintf("%s/effects", horizonURL)
+	return stream(ctx, url, &er.Cursor, func(data []byte) error {
+		var effect Effect
+		err = json.Unmarshal(data, &effect)
+		if err != nil {
+			return errors.Wrap(err, "Error unmarshaling data")
+		}
+		handler(effect)
+		return nil
+	})
 }

--- a/exp/clients/horizon/effect_request.go
+++ b/exp/clients/horizon/effect_request.go
@@ -110,8 +110,8 @@ func stream(
 			return errors.Wrap(err, "Error sending HTTP request")
 		}
 
-		// To do: Why not just check if StatusCode != 200 ? Was there a reason why it was implemented like this?
-		if resp.StatusCode/100 != 2 {
+		// Expected statusCode are 200-299
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 			return fmt.Errorf("Got bad HTTP status code %d", resp.StatusCode)
 		}
 		defer resp.Body.Close()
@@ -206,8 +206,8 @@ func stream(
 }
 
 func (er EffectRequest) Stream(
-	horizonURL string,
 	ctx context.Context,
+	horizonURL string,
 	handler func(interface{}),
 ) (err error) {
 

--- a/exp/clients/horizon/ledger_request.go
+++ b/exp/clients/horizon/ledger_request.go
@@ -12,15 +12,13 @@ import (
 func (lr LedgerRequest) BuildUrl() (endpoint string, err error) {
 	endpoint = "ledgers"
 
-	if lr.ForSequence != "" {
+	if lr.ForSequence != 0 {
 		endpoint = fmt.Sprintf(
-			"%s/%s",
+			"%s/%d",
 			endpoint,
 			lr.ForSequence,
 		)
-	}
-
-	if lr.ForSequence == "" {
+	} else {
 		queryParams := addQueryParams(lr.Cursor, lr.Limit, lr.Order)
 		if queryParams != "" {
 			endpoint = fmt.Sprintf(

--- a/exp/clients/horizon/ledger_request.go
+++ b/exp/clients/horizon/ledger_request.go
@@ -1,0 +1,40 @@
+package horizonclient
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/stellar/go/support/errors"
+)
+
+// BuildUrl creates the endpoint to be queried based on the data in the LedgerRequest struct.
+// If no data is set, it defaults to the build the URL for all ledgers
+func (lr LedgerRequest) BuildUrl() (endpoint string, err error) {
+	endpoint = "ledgers"
+
+	if lr.ForSequence != "" {
+		endpoint = fmt.Sprintf(
+			"%s/%s",
+			endpoint,
+			lr.ForSequence,
+		)
+	}
+
+	if lr.ForSequence == "" {
+		queryParams := addQueryParams(lr.Cursor, lr.Limit, lr.Order)
+		if queryParams != "" {
+			endpoint = fmt.Sprintf(
+				"%s?%s",
+				endpoint,
+				queryParams,
+			)
+		}
+	}
+
+	_, err = url.Parse(endpoint)
+	if err != nil {
+		err = errors.Wrap(err, "failed to parse endpoint")
+	}
+
+	return endpoint, err
+}

--- a/exp/clients/horizon/ledger_request.go
+++ b/exp/clients/horizon/ledger_request.go
@@ -12,11 +12,11 @@ import (
 func (lr LedgerRequest) BuildUrl() (endpoint string, err error) {
 	endpoint = "ledgers"
 
-	if lr.ForSequence != 0 {
+	if lr.forSequence != 0 {
 		endpoint = fmt.Sprintf(
 			"%s/%d",
 			endpoint,
-			lr.ForSequence,
+			lr.forSequence,
 		)
 	} else {
 		queryParams := addQueryParams(lr.Cursor, lr.Limit, lr.Order)

--- a/exp/clients/horizon/ledger_request_test.go
+++ b/exp/clients/horizon/ledger_request_test.go
@@ -15,14 +15,14 @@ func TestLedgerRequestBuildUrl(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ledgers", endpoint)
 
-	lr = LedgerRequest{ForSequence: "123"}
+	lr = LedgerRequest{ForSequence: 123}
 	endpoint, err = lr.BuildUrl()
 
 	// It should return valid ledger detail endpoint and no errors
 	require.NoError(t, err)
 	assert.Equal(t, "ledgers/123", endpoint)
 
-	lr = LedgerRequest{ForSequence: "123", Cursor: "now", Order: OrderDesc}
+	lr = LedgerRequest{ForSequence: 123, Cursor: "now", Order: OrderDesc}
 	endpoint, err = lr.BuildUrl()
 
 	// It should return valid ledger detail endpoint, with no cursor or order

--- a/exp/clients/horizon/ledger_request_test.go
+++ b/exp/clients/horizon/ledger_request_test.go
@@ -1,0 +1,38 @@
+package horizonclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLedgerRequestBuildUrl(t *testing.T) {
+	lr := LedgerRequest{}
+	endpoint, err := lr.BuildUrl()
+
+	// It should return valid all ledgers endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "ledgers", endpoint)
+
+	lr = LedgerRequest{ForSequence: "123"}
+	endpoint, err = lr.BuildUrl()
+
+	// It should return valid ledger detail endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "ledgers/123", endpoint)
+
+	lr = LedgerRequest{ForSequence: "123", Cursor: "now", Order: OrderDesc}
+	endpoint, err = lr.BuildUrl()
+
+	// It should return valid ledger detail endpoint, with no cursor or order
+	require.NoError(t, err)
+	assert.Equal(t, "ledgers/123", endpoint)
+
+	lr = LedgerRequest{Cursor: "now", Order: OrderDesc}
+	endpoint, err = lr.BuildUrl()
+
+	// It should return valid ledgers endpoint, with cursor and order
+	require.NoError(t, err)
+	assert.Equal(t, "ledgers?cursor=now&order=desc", endpoint)
+}

--- a/exp/clients/horizon/ledger_request_test.go
+++ b/exp/clients/horizon/ledger_request_test.go
@@ -15,14 +15,14 @@ func TestLedgerRequestBuildUrl(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ledgers", endpoint)
 
-	lr = LedgerRequest{ForSequence: 123}
+	lr = LedgerRequest{forSequence: 123}
 	endpoint, err = lr.BuildUrl()
 
 	// It should return valid ledger detail endpoint and no errors
 	require.NoError(t, err)
 	assert.Equal(t, "ledgers/123", endpoint)
 
-	lr = LedgerRequest{ForSequence: 123, Cursor: "now", Order: OrderDesc}
+	lr = LedgerRequest{forSequence: 123, Cursor: "now", Order: OrderDesc}
 	endpoint, err = lr.BuildUrl()
 
 	// It should return valid ledger detail endpoint, with no cursor or order

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -72,7 +72,7 @@ type ClientInterface interface {
 	Assets(request AssetRequest) (AssetsPage, error)
 	Ledgers(request LedgerRequest) (LedgersPage, error)
 	LedgerDetail(request LedgerRequest) (Ledger, error)
-	Stream(request StreamRequest, ctx context.Context, handler func(interface{})) error
+	Stream(ctx context.Context, request StreamRequest, handler func(interface{})) error
 }
 
 // DefaultTestNetClient is a default client to connect to test network
@@ -87,12 +87,14 @@ var DefaultPublicNetClient = &Client{
 	HTTP:       http.DefaultClient,
 }
 
+// HorizonRequest contains methods implemented by request structs for horizon endpoints
 type HorizonRequest interface {
 	BuildUrl() (string, error)
 }
 
+// HorizonRequest contains methods implemented by request structs for endpoints that support streaming
 type StreamRequest interface {
-	Stream(horizonURL string, ctx context.Context, handler func(interface{})) error
+	Stream(ctx context.Context, horizonURL string, handler func(interface{})) error
 }
 
 // AccountRequest struct contains data for making requests to the accounts endpoint of an horizon server
@@ -123,8 +125,9 @@ type AssetRequest struct {
 	Limit          Limit
 }
 
+// LedgerRequest struct contains data for getting ledger details from an horizon server.
 type LedgerRequest struct {
-	ForSequence string
+	ForSequence uint
 	Order       Order
 	Cursor      Cursor
 	Limit       Limit

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -2,6 +2,7 @@
 package horizonclient
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/url"
@@ -69,6 +70,7 @@ type ClientInterface interface {
 	AccountData(request AccountRequest) (AccountData, error)
 	Effects(request EffectRequest) (EffectsPage, error)
 	Assets(request AssetRequest) (AssetsPage, error)
+	Stream(request StreamRequest, ctx context.Context, handler func(interface{})) error
 }
 
 // DefaultTestNetClient is a default client to connect to test network
@@ -85,6 +87,10 @@ var DefaultPublicNetClient = &Client{
 
 type HorizonRequest interface {
 	BuildUrl() (string, error)
+}
+
+type StreamRequest interface {
+	Stream(horizonURL string, ctx context.Context, handler func(interface{})) error
 }
 
 // AccountRequest struct contains data for making requests to the accounts endpoint of an horizon server
@@ -106,6 +112,7 @@ type EffectRequest struct {
 	Limit          Limit
 }
 
+// AssetRequest struct contains data for getting asset details from an horizon server.
 type AssetRequest struct {
 	ForAssetCode   AssetCode
 	ForAssetIssuer AssetIssuer

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -70,6 +70,8 @@ type ClientInterface interface {
 	AccountData(request AccountRequest) (AccountData, error)
 	Effects(request EffectRequest) (EffectsPage, error)
 	Assets(request AssetRequest) (AssetsPage, error)
+	Ledgers(request LedgerRequest) (LedgersPage, error)
+	LedgerDetail(request LedgerRequest) (Ledger, error)
 	Stream(request StreamRequest, ctx context.Context, handler func(interface{})) error
 }
 
@@ -119,4 +121,11 @@ type AssetRequest struct {
 	Order          Order
 	Cursor         Cursor
 	Limit          Limit
+}
+
+type LedgerRequest struct {
+	ForSequence string
+	Order       Order
+	Cursor      Cursor
+	Limit       Limit
 }

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -71,7 +71,7 @@ type ClientInterface interface {
 	Effects(request EffectRequest) (EffectsPage, error)
 	Assets(request AssetRequest) (AssetsPage, error)
 	Ledgers(request LedgerRequest) (LedgersPage, error)
-	LedgerDetail(request LedgerRequest) (Ledger, error)
+	LedgerDetail(sequence uint32) (Ledger, error)
 	Stream(ctx context.Context, request StreamRequest, handler func(interface{})) error
 }
 
@@ -127,8 +127,8 @@ type AssetRequest struct {
 
 // LedgerRequest struct contains data for getting ledger details from an horizon server.
 type LedgerRequest struct {
-	ForSequence uint
 	Order       Order
 	Cursor      Cursor
 	Limit       Limit
+	forSequence uint32
 }

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -1,8 +1,10 @@
 package horizonclient
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stellar/go/support/http/httptest"
 	"github.com/stretchr/testify/assert"
@@ -64,6 +66,36 @@ func ExampleClient_Assets() {
 		return
 	}
 	fmt.Print(asset)
+}
+
+func ExampleClient_Stream() {
+	// stream effects
+
+	client := DefaultPublicNetClient
+	effectRequest := EffectRequest{Cursor: "now"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		// Stop streaming after 60 seconds.
+		time.Sleep(60 * time.Second)
+		cancel()
+	}()
+
+	// to do: can `e interface{}` be `e Effect` ?? Then we won't have type assertion.
+	//
+	err := client.Stream(effectRequest, ctx, func(e interface{}) {
+
+		resp, ok := e.(Effect)
+		if ok {
+			fmt.Println(resp.Type)
+		}
+
+	})
+
+	if err != nil {
+		fmt.Println(err)
+	}
 }
 
 func TestAccountDetail(t *testing.T) {

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -84,7 +84,7 @@ func ExampleClient_Stream() {
 
 	// to do: can `e interface{}` be `e Effect` ?? Then we won't have type assertion.
 	//
-	err := client.Stream(effectRequest, ctx, func(e interface{}) {
+	err := client.Stream(ctx, effectRequest, func(e interface{}) {
 
 		resp, ok := e.(Effect)
 		if ok {
@@ -102,7 +102,8 @@ func ExampleClient_LedgerDetail() {
 
 	client := DefaultPublicNetClient
 	// details for a ledger
-	ledgerRequest := LedgerRequest{ForSequence: "12345"}
+	// No need to initialise the complete struct
+	ledgerRequest := LedgerRequest{ForSequence: 12345}
 	ledger, err := client.LedgerDetail(ledgerRequest)
 	if err != nil {
 		fmt.Println(err)
@@ -320,6 +321,73 @@ func TestAssetsRequest(t *testing.T) {
 
 }
 
+func TestLedgerDetail(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	// no parameters
+	ledgerRequest := LedgerRequest{}
+	hmock.On(
+		"GET",
+		"https://localhost/ledgers/",
+	).ReturnString(200, ledgerResponse)
+
+	_, err := client.LedgerDetail(ledgerRequest)
+	// error case: invlaid sequence
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Invalid sequence number provided")
+	}
+
+	// happy path
+	hmock.On(
+		"GET",
+		"https://localhost/ledgers/69859",
+	).ReturnString(200, ledgerResponse)
+
+	ledgerRequest = LedgerRequest{ForSequence: 69859}
+	ledger, err := client.LedgerDetail(ledgerRequest)
+	ftc := int32(1)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, ledger.ID, "71a40c0581d8d7c1158e1d9368024c5f9fd70de17a8d277cdd96781590cc10fb")
+		assert.Equal(t, ledger.PT, "300042120331264")
+		assert.Equal(t, ledger.Sequence, int32(69859))
+		// to do: Why is Ledger.FailedTransactionCount a pointer in protocols/horizon ??
+		assert.Equal(t, ledger.FailedTransactionCount, &ftc)
+
+	}
+
+	// failure response
+	hmock.On(
+		"GET",
+		"https://localhost/ledgers/69859",
+	).ReturnString(404, notFoundResponse)
+
+	_, err = client.LedgerDetail(ledgerRequest)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Horizon error")
+		horizonError, ok := err.(*Error)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, horizonError.Problem.Title, "Resource Missing")
+	}
+
+	// connection error
+	hmock.On(
+		"GET",
+		"https://localhost/ledgers/69859",
+	).ReturnError("http.Client error")
+
+	_, err = client.LedgerDetail(ledgerRequest)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "http.Client error")
+		_, ok := err.(*Error)
+		assert.Equal(t, ok, false)
+	}
+}
+
 var accountResponse = `{
   "_links": {
     "self": {
@@ -515,4 +583,44 @@ var assetsResponse = `{
             }
         ]
     }
+}`
+
+var ledgerResponse = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/69859"
+    },
+    "transactions": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/69859/transactions{?cursor,limit,order}",
+      "templated": true
+    },
+    "operations": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/69859/operations{?cursor,limit,order}",
+      "templated": true
+    },
+    "payments": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/69859/payments{?cursor,limit,order}",
+      "templated": true
+    },
+    "effects": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/69859/effects{?cursor,limit,order}",
+      "templated": true
+    }
+  },
+  "id": "71a40c0581d8d7c1158e1d9368024c5f9fd70de17a8d277cdd96781590cc10fb",
+  "paging_token": "300042120331264",
+  "hash": "71a40c0581d8d7c1158e1d9368024c5f9fd70de17a8d277cdd96781590cc10fb",
+  "prev_hash": "78979bed15463bfc3b0c1915acc6aec866565d360ba6565d26ffbb3dc484f18c",
+  "sequence": 69859,
+  "successful_transaction_count": 0,
+  "failed_transaction_count": 1,
+  "operation_count": 0,
+  "closed_at": "2019-03-03T13:38:16Z",
+  "total_coins": "100000000000.0000000",
+  "fee_pool": "10.7338093",
+  "base_fee_in_stroops": 100,
+  "base_reserve_in_stroops": 5000000,
+  "max_tx_set_size": 100,
+  "protocol_version": 10,
+  "header_xdr": "AAAACniXm+0VRjv8OwwZFazGrshmVl02C6ZWXSb/uz3EhPGMLuFhI0sVqAG57WnGMUKmOUk/J8TAktUB97VgrgEsZuEAAAAAXHvYyAAAAAAAAAAAcvWzXsmT72oXZ7QPC1nZLJei+lFwYRXF4FIz/PQguubMDKGRJrT/0ofTHlZjWAMWjABeGgup7zhfZkm0xrthCAABEOMN4Lazp2QAAAAAAAAGZdltAAAAAAAAAAAABOqvAAAAZABMS0AAAABk4Vse3u3dDM9UWfoH9ooQLLSXYEee8xiHu/k9p6YLlWR2KT4hYGehoHGmp04rhMRMAEp+GHE+KXv0UUxAPmmNmwGYK2HFCnl5a931YmTQYrHQzEeCHx+aI4+TLjTlFjMqAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 }`

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -98,6 +98,20 @@ func ExampleClient_Stream() {
 	}
 }
 
+func ExampleClient_LedgerDetail() {
+
+	client := DefaultPublicNetClient
+	// details for a ledger
+	ledgerRequest := LedgerRequest{ForSequence: "12345"}
+	ledger, err := client.LedgerDetail(ledgerRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(ledger)
+
+}
+
 func TestAccountDetail(t *testing.T) {
 	hmock := httptest.NewClient()
 	client := &Client{

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -334,7 +334,7 @@ func TestLedgerDetail(t *testing.T) {
 	).ReturnString(200, ledgerResponse)
 
 	_, err := client.LedgerDetail(sequence)
-	// error case: invlaid sequence
+	// error case: invalid sequence
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "Invalid sequence number provided")
 	}
@@ -353,9 +353,7 @@ func TestLedgerDetail(t *testing.T) {
 		assert.Equal(t, ledger.ID, "71a40c0581d8d7c1158e1d9368024c5f9fd70de17a8d277cdd96781590cc10fb")
 		assert.Equal(t, ledger.PT, "300042120331264")
 		assert.Equal(t, ledger.Sequence, int32(69859))
-		// to do: Why is Ledger.FailedTransactionCount a pointer in protocols/horizon ??
 		assert.Equal(t, ledger.FailedTransactionCount, &ftc)
-
 	}
 
 	// failure response

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -83,7 +83,6 @@ func ExampleClient_Stream() {
 	}()
 
 	// to do: can `e interface{}` be `e Effect` ?? Then we won't have type assertion.
-	//
 	err := client.Stream(ctx, effectRequest, func(e interface{}) {
 
 		resp, ok := e.(Effect)
@@ -102,9 +101,8 @@ func ExampleClient_LedgerDetail() {
 
 	client := DefaultPublicNetClient
 	// details for a ledger
-	// No need to initialise the complete struct
-	ledgerRequest := LedgerRequest{ForSequence: 12345}
-	ledger, err := client.LedgerDetail(ledgerRequest)
+	sequence := uint32(12345)
+	ledger, err := client.LedgerDetail(sequence)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -328,14 +326,14 @@ func TestLedgerDetail(t *testing.T) {
 		HTTP:       hmock,
 	}
 
-	// no parameters
-	ledgerRequest := LedgerRequest{}
+	// invalid parameters
+	var sequence uint32 = 0
 	hmock.On(
 		"GET",
 		"https://localhost/ledgers/",
 	).ReturnString(200, ledgerResponse)
 
-	_, err := client.LedgerDetail(ledgerRequest)
+	_, err := client.LedgerDetail(sequence)
 	// error case: invlaid sequence
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "Invalid sequence number provided")
@@ -347,8 +345,8 @@ func TestLedgerDetail(t *testing.T) {
 		"https://localhost/ledgers/69859",
 	).ReturnString(200, ledgerResponse)
 
-	ledgerRequest = LedgerRequest{ForSequence: 69859}
-	ledger, err := client.LedgerDetail(ledgerRequest)
+	sequence = 69859
+	ledger, err := client.LedgerDetail(sequence)
 	ftc := int32(1)
 
 	if assert.NoError(t, err) {
@@ -366,7 +364,7 @@ func TestLedgerDetail(t *testing.T) {
 		"https://localhost/ledgers/69859",
 	).ReturnString(404, notFoundResponse)
 
-	_, err = client.LedgerDetail(ledgerRequest)
+	_, err = client.LedgerDetail(sequence)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "Horizon error")
 		horizonError, ok := err.(*Error)
@@ -380,7 +378,7 @@ func TestLedgerDetail(t *testing.T) {
 		"https://localhost/ledgers/69859",
 	).ReturnError("http.Client error")
 
-	_, err = client.LedgerDetail(ledgerRequest)
+	_, err = client.LedgerDetail(sequence)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "http.Client error")
 		_, ok := err.(*Error)

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -1,6 +1,8 @@
 package horizonclient
 
 import (
+	"context"
+
 	"github.com/stretchr/testify/mock"
 )
 
@@ -31,6 +33,14 @@ func (m *MockClient) Effects(request EffectRequest) (EffectsPage, error) {
 func (m *MockClient) Assets(request AssetRequest) (AssetsPage, error) {
 	a := m.Called(request)
 	return a.Get(0).(AssetsPage), a.Error(1)
+}
+
+func (m *MockClient) Stream(
+	request StreamRequest, ctx context.Context,
+	handler func(interface{}),
+) error {
+	a := m.Called(request, ctx, handler)
+	return a.Error(0)
 }
 
 // ensure that the MockClient implements ClientInterface

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -43,5 +43,15 @@ func (m *MockClient) Stream(
 	return a.Error(0)
 }
 
+func (m *MockClient) Ledgers(request LedgerRequest) (LedgersPage, error) {
+	a := m.Called(request)
+	return a.Get(0).(LedgersPage), a.Error(1)
+}
+
+func (m *MockClient) LedgerDetail(request LedgerRequest) (Ledger, error) {
+	a := m.Called(request)
+	return a.Get(0).(Ledger), a.Error(1)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -35,8 +35,8 @@ func (m *MockClient) Assets(request AssetRequest) (AssetsPage, error) {
 	return a.Get(0).(AssetsPage), a.Error(1)
 }
 
-func (m *MockClient) Stream(
-	request StreamRequest, ctx context.Context,
+func (m *MockClient) Stream(ctx context.Context,
+	request StreamRequest,
 	handler func(interface{}),
 ) error {
 	a := m.Called(request, ctx, handler)

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -48,8 +48,8 @@ func (m *MockClient) Ledgers(request LedgerRequest) (LedgersPage, error) {
 	return a.Get(0).(LedgersPage), a.Error(1)
 }
 
-func (m *MockClient) LedgerDetail(request LedgerRequest) (Ledger, error) {
-	a := m.Called(request)
+func (m *MockClient) LedgerDetail(sequence uint32) (Ledger, error) {
+	a := m.Called(sequence)
 	return a.Get(0).(Ledger), a.Error(1)
 }
 

--- a/exp/clients/horizon/responses.go
+++ b/exp/clients/horizon/responses.go
@@ -57,6 +57,7 @@ type EffectsPage struct {
 
 // EffectResponse contains effect data returned by Horizon.
 // Currently used by LoadAccountMergeAmount only.
+// To Do: Have a more generic Effect struct that supports all effects
 type Effect struct {
 	Type   string `json:"type"`
 	Amount string `json:"amount"`

--- a/exp/clients/horizon/responses.go
+++ b/exp/clients/horizon/responses.go
@@ -170,3 +170,9 @@ type AssetsPage struct {
 		Records []AssetStat
 	} `json:"_embedded"`
 }
+
+type LedgersPage struct {
+	Embedded struct {
+		Records []Ledger
+	} `json:"_embedded"`
+}

--- a/exp/clients/horizon/responses.go
+++ b/exp/clients/horizon/responses.go
@@ -166,12 +166,15 @@ type AssetStat = hProtocol.AssetStat
 
 // AssetsPage contains page of assets returned by Horizon.
 type AssetsPage struct {
+	Links    hal.Links `json:"_links"`
 	Embedded struct {
 		Records []AssetStat
 	} `json:"_embedded"`
 }
 
+// LedgersPage contains page of ledger information returned by Horizon
 type LedgersPage struct {
+	Links    hal.Links `json:"_links"`
 	Embedded struct {
 		Records []Ledger
 	} `json:"_embedded"`


### PR DESCRIPTION
Still building out the horizon client.
This PR add /assets endpoint, adds sdk identifiers to requests which closes #962 and implements streaming on the /effects endpoint.

Will appreciate some feedback especially on the streaming implementation.