### PR TITLE
Add horizon-cmp command

### DIFF
--- a/tools/horizon-cmp/internal/response.go
+++ b/tools/horizon-cmp/internal/response.go
@@ -10,6 +10,11 @@ import (
 )
 
 var findResultMetaXDR = regexp.MustCompile(`"result_meta_xdr": "(.*)",`)
+var succ1 = regexp.MustCompile(`\s*"transaction_successful": true,`)
+var succ2 = regexp.MustCompile(`\s*"successful": true,`)
+var succ3 = regexp.MustCompile(`\s*"transaction_count": [0-9]+,`)
+var succ4 = regexp.MustCompile(`\s*"last_modified_ledger": [0-9]+,`)
+var succ5 = regexp.MustCompile(`\s*"public_key": "G.*",`)
 
 type Response struct {
 	Domain string
@@ -49,6 +54,12 @@ func NewResponse(domain, path string) *Response {
 	normalizedBody = findResultMetaXDR.ReplaceAllString(normalizedBody, "")
 	// Remove Horizon URL from the _links
 	normalizedBody = strings.Replace(normalizedBody, domain, "", -1)
+
+	normalizedBody = succ1.ReplaceAllString(normalizedBody, "")
+	normalizedBody = succ2.ReplaceAllString(normalizedBody, "")
+	normalizedBody = succ3.ReplaceAllString(normalizedBody, "")
+	normalizedBody = succ4.ReplaceAllString(normalizedBody, "")
+	normalizedBody = succ5.ReplaceAllString(normalizedBody, "")
 
 	response.NormalizedBody = normalizedBody
 	return response

--- a/tools/horizon-cmp/internal/response.go
+++ b/tools/horizon-cmp/internal/response.go
@@ -1,0 +1,117 @@
+package cmp
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+var findResultMetaXDR = regexp.MustCompile(`"result_meta_xdr": "(.*)",`)
+
+type Response struct {
+	Domain string
+	Path   string
+
+	Body string
+	// NormalizedBody is body without parts that identify a single
+	// server (ex. domain) and fields known to be different between
+	// instances (ex. `result_meta_xdr`).
+	NormalizedBody string
+}
+
+func NewResponse(domain, path string) *Response {
+	response := &Response{
+		Domain: domain,
+		Path:   path,
+	}
+
+	resp, err := http.Get(domain + path)
+	if err != nil {
+		panic(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		panic(resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+
+	response.Body = string(body)
+
+	normalizedBody := response.Body
+	// `result_meta_xdr` can differ between core instances (confirmed this with core team)
+	normalizedBody = findResultMetaXDR.ReplaceAllString(normalizedBody, "")
+	// Remove Horizon URL from the _links
+	normalizedBody = strings.Replace(normalizedBody, domain, "", -1)
+
+	response.NormalizedBody = normalizedBody
+	return response
+}
+
+func (r *Response) Equal(other *Response) bool {
+	return r.NormalizedBody == other.NormalizedBody
+}
+
+func (r *Response) SaveDiff(outputDir string, other *Response) {
+	if r.Path != other.Path {
+		panic("Paths are different")
+	}
+
+	fileName := pathToFileName(r.Path)
+
+	fileA := fmt.Sprintf("%s/%s.old", outputDir, fileName)
+	fileB := fmt.Sprintf("%s/%s.new", outputDir, fileName)
+	fileDiff := fmt.Sprintf("%s/%s.diff", outputDir, fileName)
+
+	err := ioutil.WriteFile(fileA, []byte(r.Body), 0744)
+	if err != nil {
+		panic(err)
+	}
+
+	err = ioutil.WriteFile(fileB, []byte(other.Body), 0744)
+	if err != nil {
+		panic(err)
+	}
+
+	out, err := exec.Command("diff", fileA, fileB).Output()
+	if err != nil {
+		// Ignore, user will generate diff manually
+	}
+
+	if len(out) != 0 {
+		err = ioutil.WriteFile(fileDiff, out, 0744)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+// GetPaths finds all URLs in the response body and returns paths
+// (without domain).
+func (r *Response) GetPaths() []string {
+	// escapedDomain := strings.Replace(r.Domain, `\`, `\\`, -1)
+	var linksRegexp = regexp.MustCompile(`"` + r.Domain + `(.*?)["{]`)
+	found := linksRegexp.FindAllSubmatch([]byte(r.Body), -1)
+	links := make([]string, 0, len(found))
+
+	for _, link := range found {
+		l := strings.Replace(string(link[1]), "\\u0026", "&", -1)
+		links = append(links, l)
+	}
+
+	return links
+}
+
+func pathToFileName(path string) string {
+	path = strings.Replace(path, "/", "_", -1)
+	path = strings.Replace(path, "?", "_", -1)
+	path = strings.Replace(path, "&", "_", -1)
+	path = strings.Replace(path, "=", "_", -1)
+	return path
+}

--- a/tools/horizon-cmp/internal/response.go
+++ b/tools/horizon-cmp/internal/response.go
@@ -33,7 +33,7 @@ func NewResponse(domain, path string) *Response {
 		panic(err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
 		panic(resp.StatusCode)
 	}
 

--- a/tools/horizon-cmp/internal/response.go
+++ b/tools/horizon-cmp/internal/response.go
@@ -10,11 +10,13 @@ import (
 )
 
 var findResultMetaXDR = regexp.MustCompile(`"result_meta_xdr": "(.*)",`)
-var succ1 = regexp.MustCompile(`\s*"transaction_successful": true,`)
-var succ2 = regexp.MustCompile(`\s*"successful": true,`)
-var succ3 = regexp.MustCompile(`\s*"transaction_count": [0-9]+,`)
-var succ4 = regexp.MustCompile(`\s*"last_modified_ledger": [0-9]+,`)
-var succ5 = regexp.MustCompile(`\s*"public_key": "G.*",`)
+
+// Horizon 0.16.x vs 0.17.0:
+// var succ1 = regexp.MustCompile(`\s*"transaction_successful": true,`)
+// var succ2 = regexp.MustCompile(`\s*"successful": true,`)
+// var succ3 = regexp.MustCompile(`\s*"transaction_count": [0-9]+,`)
+// var succ4 = regexp.MustCompile(`\s*"last_modified_ledger": [0-9]+,`)
+// var succ5 = regexp.MustCompile(`\s*"public_key": "G.*",`)
 
 type Response struct {
 	Domain string
@@ -55,11 +57,11 @@ func NewResponse(domain, path string) *Response {
 	// Remove Horizon URL from the _links
 	normalizedBody = strings.Replace(normalizedBody, domain, "", -1)
 
-	normalizedBody = succ1.ReplaceAllString(normalizedBody, "")
-	normalizedBody = succ2.ReplaceAllString(normalizedBody, "")
-	normalizedBody = succ3.ReplaceAllString(normalizedBody, "")
-	normalizedBody = succ4.ReplaceAllString(normalizedBody, "")
-	normalizedBody = succ5.ReplaceAllString(normalizedBody, "")
+	// normalizedBody = succ1.ReplaceAllString(normalizedBody, "")
+	// normalizedBody = succ2.ReplaceAllString(normalizedBody, "")
+	// normalizedBody = succ3.ReplaceAllString(normalizedBody, "")
+	// normalizedBody = succ4.ReplaceAllString(normalizedBody, "")
+	// normalizedBody = succ5.ReplaceAllString(normalizedBody, "")
 
 	response.NormalizedBody = normalizedBody
 	return response
@@ -76,16 +78,20 @@ func (r *Response) SaveDiff(outputDir string, other *Response) {
 
 	fileName := pathToFileName(r.Path)
 
+	if len(fileName) > 100 {
+		fileName = fileName[0:100]
+	}
+
 	fileA := fmt.Sprintf("%s/%s.old", outputDir, fileName)
 	fileB := fmt.Sprintf("%s/%s.new", outputDir, fileName)
 	fileDiff := fmt.Sprintf("%s/%s.diff", outputDir, fileName)
 
-	err := ioutil.WriteFile(fileA, []byte(r.Body), 0744)
+	err := ioutil.WriteFile(fileA, []byte(r.Path+"\n\n"+r.Body), 0744)
 	if err != nil {
 		panic(err)
 	}
 
-	err = ioutil.WriteFile(fileB, []byte(other.Body), 0744)
+	err = ioutil.WriteFile(fileB, []byte(other.Path+"\n\n"+other.Body), 0744)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/horizon-cmp/internal/response.go
+++ b/tools/horizon-cmp/internal/response.go
@@ -21,11 +21,12 @@ var findResultMetaXDR = regexp.MustCompile(`"result_meta_xdr": "(.*)",`)
 // `is_authorized` on account balances list. You want to remove this
 // field so it's not reported for each `/accounts/{id}` response.
 var removeRegexps = []*regexp.Regexp{
-	regexp.MustCompile(`\s*"transaction_successful": true,`),
-	regexp.MustCompile(`\s*"successful": true,`),
-	regexp.MustCompile(`\s*"transaction_count": [0-9]+,`),
-	regexp.MustCompile(`\s*"last_modified_ledger": [0-9]+,`),
-	regexp.MustCompile(`\s*"public_key": "G.*",`),
+	// regexp.MustCompile(`\s*"is_authorized": true,`),
+	// regexp.MustCompile(`\s*"is_authorized": false,`),
+	// regexp.MustCompile(`\s*"successful": true,`),
+	// regexp.MustCompile(`\s*"transaction_count": [0-9]+,`),
+	// regexp.MustCompile(`\s*"last_modified_ledger": [0-9]+,`),
+	// regexp.MustCompile(`\s*"public_key": "G.*",`),
 }
 
 type Response struct {

--- a/tools/horizon-cmp/internal/response.go
+++ b/tools/horizon-cmp/internal/response.go
@@ -9,14 +9,24 @@ import (
 	"strings"
 )
 
+const fileLengthLimit = 100
+
 var findResultMetaXDR = regexp.MustCompile(`"result_meta_xdr": "(.*)",`)
 
-// Horizon 0.16.x vs 0.17.0:
-// var succ1 = regexp.MustCompile(`\s*"transaction_successful": true,`)
-// var succ2 = regexp.MustCompile(`\s*"successful": true,`)
-// var succ3 = regexp.MustCompile(`\s*"transaction_count": [0-9]+,`)
-// var succ4 = regexp.MustCompile(`\s*"last_modified_ledger": [0-9]+,`)
-// var succ5 = regexp.MustCompile(`\s*"public_key": "G.*",`)
+// removeRegexps contains a list of regular expressions that, when matched,
+// will be changed to an empty string. This is done to exclude known
+// differences in responses between two Horizon version.
+//
+// Let's say that next Horizon version adds a new bool field:
+// `is_authorized` on account balances list. You want to remove this
+// field so it's not reported for each `/accounts/{id}` response.
+var removeRegexps = []*regexp.Regexp{
+	regexp.MustCompile(`\s*"transaction_successful": true,`),
+	regexp.MustCompile(`\s*"successful": true,`),
+	regexp.MustCompile(`\s*"transaction_count": [0-9]+,`),
+	regexp.MustCompile(`\s*"last_modified_ledger": [0-9]+,`),
+	regexp.MustCompile(`\s*"public_key": "G.*",`),
+}
 
 type Response struct {
 	Domain string
@@ -57,11 +67,9 @@ func NewResponse(domain, path string) *Response {
 	// Remove Horizon URL from the _links
 	normalizedBody = strings.Replace(normalizedBody, domain, "", -1)
 
-	// normalizedBody = succ1.ReplaceAllString(normalizedBody, "")
-	// normalizedBody = succ2.ReplaceAllString(normalizedBody, "")
-	// normalizedBody = succ3.ReplaceAllString(normalizedBody, "")
-	// normalizedBody = succ4.ReplaceAllString(normalizedBody, "")
-	// normalizedBody = succ5.ReplaceAllString(normalizedBody, "")
+	for _, reg := range removeRegexps {
+		normalizedBody = reg.ReplaceAllString(normalizedBody, "")
+	}
 
 	response.NormalizedBody = normalizedBody
 	return response
@@ -78,8 +86,8 @@ func (r *Response) SaveDiff(outputDir string, other *Response) {
 
 	fileName := pathToFileName(r.Path)
 
-	if len(fileName) > 100 {
-		fileName = fileName[0:100]
+	if len(fileName) > fileLengthLimit {
+		fileName = fileName[0:fileLengthLimit]
 	}
 
 	fileA := fmt.Sprintf("%s/%s.old", outputDir, fileName)
@@ -96,10 +104,8 @@ func (r *Response) SaveDiff(outputDir string, other *Response) {
 		panic(err)
 	}
 
-	out, err := exec.Command("diff", fileA, fileB).Output()
-	if err != nil {
-		// Ignore, user will generate diff manually
-	}
+	// Ignore `err`, user will generate diff manually
+	out, _ := exec.Command("diff", fileA, fileB).Output()
 
 	if len(out) != 0 {
 		err = ioutil.WriteFile(fileDiff, out, 0744)

--- a/tools/horizon-cmp/main.go
+++ b/tools/horizon-cmp/main.go
@@ -14,8 +14,8 @@ import (
 	cmp "github.com/stellar/go/tools/horizon-cmp/internal"
 )
 
-const HorizonOld = "https://horizon.stellar.org"
-const HorizonNew = "https://horizon-dev-pubnet.stellar.org"
+const HorizonOld = "http://localhost:8000"
+const HorizonNew = "http://localhost:8001"
 
 const MaxLevels = 3
 
@@ -38,8 +38,17 @@ var paths []PathWithLevel = []PathWithLevel{
 	PathWithLevel{"/ledgers?order=desc", 0},
 	PathWithLevel{"/effects?order=desc", 0},
 	PathWithLevel{"/trades?order=desc", 0},
-	PathWithLevel{"/assets", 0},
+	// PathWithLevel{"/assets", 0},
 	PathWithLevel{"/fee_stats", 0},
+
+	// Pubnet markets
+	PathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=LTC&buying_asset_issuer=GCSTRLTC73UVXIYPHYTTQUUSDTQU2KQW5VKCE4YCMEHWF44JKDMQAL23", 0},
+	PathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=XRP&buying_asset_issuer=GCSTRLTC73UVXIYPHYTTQUUSDTQU2KQW5VKCE4YCMEHWF44JKDMQAL23", 0},
+	PathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=BTC&buying_asset_issuer=GCSTRLTC73UVXIYPHYTTQUUSDTQU2KQW5VKCE4YCMEHWF44JKDMQAL23", 0},
+	PathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=USD&buying_asset_issuer=GBSTRUSD7IRX73RQZBL3RQUH6KS3O4NYFY3QCALDLZD77XMZOPWAVTUK", 0},
+	PathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=SLT&buying_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP", 0},
+
+	PathWithLevel{"/trade_aggregations?base_asset_type=native&counter_asset_code=USD&counter_asset_issuer=GBSTRUSD7IRX73RQZBL3RQUH6KS3O4NYFY3QCALDLZD77XMZOPWAVTUK&counter_asset_type=credit_alphanum4&end_time=1551866400000&limit=200&order=desc&resolution=900000&start_time=1514764800", 0},
 }
 
 var visitedPaths map[string]bool
@@ -92,6 +101,8 @@ func main() {
 
 		visitedPaths[p] = true
 
+		fmt.Printf("%s ", p)
+
 		p = getPathWithCursor(p, cursor)
 
 		a := cmp.NewResponse(HorizonOld, p)
@@ -105,7 +116,7 @@ func main() {
 		} else {
 			status = "diff"
 		}
-		fmt.Println(status, p)
+		fmt.Println(status)
 		if status == "diff" {
 			a.SaveDiff(outputDir, b)
 		}
@@ -114,7 +125,7 @@ func main() {
 		for _, newPath := range newPaths {
 			// Such links can get recent ledgers data that may be different
 			// if Horizon nodes are not at the same ledger.
-			if strings.Contains(newPath, "desc=asc") {
+			if strings.Contains(newPath, "order=asc") {
 				continue
 			}
 

--- a/tools/horizon-cmp/main.go
+++ b/tools/horizon-cmp/main.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+var paths []string = []string{
+	"/payments?order=desc&limit=200&include_failed=true&cursor=97761976872132608",
+	"/payments?order=desc&limit=200&include_failed=false&cursor=97761976872132608",
+	"/payments?order=desc&limit=200&cursor=97761976872132608",
+
+	"/operations?order=desc&limit=200&include_failed=true&cursor=97761976872132608",
+	"/operations?order=desc&limit=200&include_failed=false&cursor=97761976872132608",
+	"/operations?order=desc&limit=200&cursor=97761976872132608",
+
+	"/accounts/GBXY56UJJH4MSEHTP35VX7B5JSLKD72XWLXK4JROQBYRASOXNDIMIL2D/payments?order=desc&limit=200&include_failed=true&cursor=97761976872132608",
+	"/accounts/GBXY56UJJH4MSEHTP35VX7B5JSLKD72XWLXK4JROQBYRASOXNDIMIL2D/operations?order=desc&limit=200&include_failed=true&cursor=97761976872132608",
+	"/accounts/GBXY56UJJH4MSEHTP35VX7B5JSLKD72XWLXK4JROQBYRASOXNDIMIL2D/transactions?order=desc&limit=200&include_failed=true&cursor=97761976872132608",
+
+	"/accounts/GBXY56UJJH4MSEHTP35VX7B5JSLKD72XWLXK4JROQBYRASOXNDIMIL2D/payments?order=desc&limit=2&cursor=97761976872132608",
+	"/accounts/GBXY56UJJH4MSEHTP35VX7B5JSLKD72XWLXK4JROQBYRASOXNDIMIL2D/operations?order=desc&limit=2&cursor=97761976872132608",
+	"/accounts/GBXY56UJJH4MSEHTP35VX7B5JSLKD72XWLXK4JROQBYRASOXNDIMIL2D/transactions?order=desc&limit=2&cursor=97761976872132608",
+
+	"/accounts/GB3BVRX2D2WBTUYPXOB6S25VTFK36LDCII2AILMMLIJT3SWG66CCS5AK/transactions?order=desc&cursor=97762191620468736",
+	"/accounts/GB3BVRX2D2WBTUYPXOB6S25VTFK36LDCII2AILMMLIJT3SWG66CCS5AK/transactions?order=desc&include_failed=true&cursor=97762191620468736",
+	"/accounts/GB3BVRX2D2WBTUYPXOB6S25VTFK36LDCII2AILMMLIJT3SWG66CCS5AK/transactions?order=desc&include_failed=false&cursor=97762191620468736",
+
+	"/accounts/GB3BVRX2D2WBTUYPXOB6S25VTFK36LDCII2AILMMLIJT3SWG66CCS5AK/transactions?order=desc&include_failed=true&limit=50&cursor=97696238102654976",
+	"/accounts/GB3BVRX2D2WBTUYPXOB6S25VTFK36LDCII2AILMMLIJT3SWG66CCS5AK/transactions?order=desc&include_failed=false&limit=50&cursor=97696238102654976",
+
+	"/ledgers/22764327/operations?limit=200",
+	"/ledgers/22764327/operations?limit=200&include_failed=true",
+	"/ledgers/22764327/payments?limit=200",
+	"/ledgers/22764327/payments?limit=200&include_failed=true",
+	"/ledgers/22764327/transactions?limit=200",
+	"/ledgers/22764327/transactions?limit=200&include_failed=true",
+	"/ledgers/22764327/effects?limit=200",
+	"/ledgers/22764327/effects?limit=200&include_failed=true",
+
+	"/ledgers/22762425/operations?limit=200",
+	"/ledgers/22762425/operations?limit=200&include_failed=true",
+	"/ledgers/22762425/payments?limit=200",
+	"/ledgers/22762425/payments?limit=200&include_failed=true",
+	"/ledgers/22762425/transactions?limit=200",
+	"/ledgers/22762425/transactions?limit=200&include_failed=true",
+	"/ledgers/22762425/effects?limit=200",
+	"/ledgers/22762425/effects?limit=200&include_failed=true",
+
+	"/payments?limit=200&cursor=97774668500484098",
+	"/payments?limit=200&cursor=97774668500484098&include_failed=false",
+	"/payments?limit=200&cursor=97774668500484098&include_failed=true",
+
+	"/operations/97774668500484098",
+	"/operations/97774689975341057",
+
+	"/operations?limit=200&cursor=97774668500484098",
+	"/operations?limit=200&cursor=97774668500484098&include_failed=false",
+	"/operations?limit=200&cursor=97774668500484098&include_failed=true",
+
+	"/transactions?limit=200&cursor=97774668500484098",
+	"/transactions?limit=200&cursor=97774668500484098&include_failed=false",
+	"/transactions?limit=200&cursor=97774668500484098&include_failed=true",
+
+	// failed
+	"/transactions/96583f831cefcc5dbab65f918e1818468ed7102f9da1a35159b40c37253ef4a3",
+	"/transactions/96583f831cefcc5dbab65f918e1818468ed7102f9da1a35159b40c37253ef4a3/operations",
+	"/transactions/96583f831cefcc5dbab65f918e1818468ed7102f9da1a35159b40c37253ef4a3/payments",
+	"/transactions/96583f831cefcc5dbab65f918e1818468ed7102f9da1a35159b40c37253ef4a3/effects",
+
+	// succ
+	"/transactions/702cbb5fead49b16d64b55a3bfcbabc7d4674a6d5a9e4012caf422ab87db3010",
+	"/transactions/702cbb5fead49b16d64b55a3bfcbabc7d4674a6d5a9e4012caf422ab87db3010/operations",
+	"/transactions/702cbb5fead49b16d64b55a3bfcbabc7d4674a6d5a9e4012caf422ab87db3010/payments",
+	"/transactions/702cbb5fead49b16d64b55a3bfcbabc7d4674a6d5a9e4012caf422ab87db3010/effects",
+}
+
+var removeMeta = regexp.MustCompile(`"result_meta_xdr": "(.*)"`)
+
+func main() {
+	for _, p := range paths {
+		a := getResponse("https://horizon.stellar.org", p)
+		fmt.Print(".")
+		b := getResponse("https://horizon-dev-pubnet.stellar.org", p)
+		fmt.Print(".")
+
+		status := ""
+		if a == b {
+			status = "ok"
+		} else {
+			status = "fail"
+		}
+		fmt.Println(status, p)
+		if status == "fail" {
+			fmt.Println(a)
+			fmt.Println(b)
+			return
+		}
+	}
+}
+
+func getResponse(domain, url string) string {
+	resp, err := http.Get(domain + url)
+	if err != nil {
+		panic(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		panic(resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+
+	bodyString := string(body)
+	// `result_meta_xdr` can differ between core instances (confirmed this with core team)
+	bodyString = removeMeta.ReplaceAllString(bodyString, "")
+	// Remove Horizon URL from the _links
+	bodyString = strings.Replace(bodyString, domain, "", -1)
+
+	return bodyString
+}

--- a/tools/horizon-cmp/main.go
+++ b/tools/horizon-cmp/main.go
@@ -27,13 +27,13 @@ type PathWithLevel struct {
 // Starting corpus of paths to test
 var paths []PathWithLevel = []PathWithLevel{
 	PathWithLevel{"/transactions?order=desc", 0},
-	PathWithLevel{"/transactions?order=desc&include_failed=true", 0},
+	// PathWithLevel{"/transactions?order=desc&include_failed=true", 0},
 
 	PathWithLevel{"/operations?order=desc", 0},
-	PathWithLevel{"/operations?order=desc&include_failed=true", 0},
+	// PathWithLevel{"/operations?order=desc&include_failed=true", 0},
 
 	PathWithLevel{"/payments?order=desc", 0},
-	PathWithLevel{"/payments?order=desc&include_failed=true", 0},
+	// PathWithLevel{"/payments?order=desc&include_failed=true", 0},
 
 	PathWithLevel{"/ledgers?order=desc", 0},
 	PathWithLevel{"/effects?order=desc", 0},
@@ -49,6 +49,8 @@ var paths []PathWithLevel = []PathWithLevel{
 	PathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=SLT&buying_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP", 0},
 
 	PathWithLevel{"/trade_aggregations?base_asset_type=native&counter_asset_code=USD&counter_asset_issuer=GBSTRUSD7IRX73RQZBL3RQUH6KS3O4NYFY3QCALDLZD77XMZOPWAVTUK&counter_asset_type=credit_alphanum4&end_time=1551866400000&limit=200&order=desc&resolution=900000&start_time=1514764800", 0},
+
+	PathWithLevel{"/metrics", 0},
 }
 
 var visitedPaths map[string]bool

--- a/tools/horizon-cmp/main.go
+++ b/tools/horizon-cmp/main.go
@@ -14,7 +14,7 @@ import (
 	cmp "github.com/stellar/go/tools/horizon-cmp/internal"
 )
 
-const HorizonOld = "http://localhost:8000"
+const HorizonOld = "https://horizon.stellar.org"
 const HorizonNew = "http://localhost:8001"
 
 const MaxLevels = 3
@@ -27,19 +27,37 @@ type PathWithLevel struct {
 // Starting corpus of paths to test
 var paths []PathWithLevel = []PathWithLevel{
 	PathWithLevel{"/transactions?order=desc", 0},
-	// PathWithLevel{"/transactions?order=desc&include_failed=true", 0},
+	PathWithLevel{"/transactions?order=desc&include_failed=false", 0},
+	PathWithLevel{"/transactions?order=desc&include_failed=true", 0},
 
 	PathWithLevel{"/operations?order=desc", 0},
-	// PathWithLevel{"/operations?order=desc&include_failed=true", 0},
+	PathWithLevel{"/operations?order=desc&include_failed=false", 0},
+	PathWithLevel{"/operations?order=desc&include_failed=true", 0},
 
 	PathWithLevel{"/payments?order=desc", 0},
-	// PathWithLevel{"/payments?order=desc&include_failed=true", 0},
+	PathWithLevel{"/payments?order=desc&include_failed=false", 0},
+	PathWithLevel{"/payments?order=desc&include_failed=true", 0},
 
 	PathWithLevel{"/ledgers?order=desc", 0},
 	PathWithLevel{"/effects?order=desc", 0},
 	PathWithLevel{"/trades?order=desc", 0},
-	// PathWithLevel{"/assets", 0},
-	PathWithLevel{"/fee_stats", 0},
+
+	PathWithLevel{"/ledgers/22923641", 0},
+	PathWithLevel{"/ledgers/22923641/transactions?limit=200", 0},
+	PathWithLevel{"/ledgers/22923641/operations?limit=200", 0},
+	PathWithLevel{"/ledgers/22923641/payments?limit=200", 0},
+	PathWithLevel{"/ledgers/22923641/effects?limit=200", 0},
+
+	PathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/transactions?limit=200", 0},
+	PathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/transactions?limit=200&include_failed=false", 0},
+	PathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/transactions?limit=200&include_failed=true", 0},
+
+	PathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/operations?limit=200", 0},
+	PathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/payments?limit=200", 0},
+	PathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/effects?limit=200", 0},
+
+	PathWithLevel{"/accounts/GC2ZV6KGGFLQIMDVDWBWCP6LTODUDXYBLUPTUZCFHIMDCWHR43ULZITJ/trades?limit=200", 0},
+	PathWithLevel{"/accounts/GC2ZV6KGGFLQIMDVDWBWCP6LTODUDXYBLUPTUZCFHIMDCWHR43ULZITJ/offers?limit=200", 0},
 
 	// Pubnet markets
 	PathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=LTC&buying_asset_issuer=GCSTRLTC73UVXIYPHYTTQUUSDTQU2KQW5VKCE4YCMEHWF44JKDMQAL23", 0},
@@ -49,8 +67,6 @@ var paths []PathWithLevel = []PathWithLevel{
 	PathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=SLT&buying_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP", 0},
 
 	PathWithLevel{"/trade_aggregations?base_asset_type=native&counter_asset_code=USD&counter_asset_issuer=GBSTRUSD7IRX73RQZBL3RQUH6KS3O4NYFY3QCALDLZD77XMZOPWAVTUK&counter_asset_type=credit_alphanum4&end_time=1551866400000&limit=200&order=desc&resolution=900000&start_time=1514764800", 0},
-
-	PathWithLevel{"/metrics", 0},
 }
 
 var visitedPaths map[string]bool
@@ -128,6 +144,19 @@ func main() {
 			// Such links can get recent ledgers data that may be different
 			// if Horizon nodes are not at the same ledger.
 			if strings.Contains(newPath, "order=asc") {
+				continue
+			}
+
+			if (strings.Contains(newPath, "/transactions") ||
+				strings.Contains(newPath, "/operations") ||
+				strings.Contains(newPath, "/payments")) && !strings.Contains(newPath, "include_failed") {
+				prefix := "?"
+				if strings.Contains(newPath, "?") {
+					prefix = "&"
+				}
+
+				paths = append(paths, PathWithLevel{newPath + prefix + "include_failed=false", level + 1})
+				paths = append(paths, PathWithLevel{newPath + prefix + "include_failed=true", level + 1})
 				continue
 			}
 

--- a/tools/horizon-cmp/main.go
+++ b/tools/horizon-cmp/main.go
@@ -1,109 +1,136 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"regexp"
+	"net/url"
+	"os"
 	"strings"
+	"time"
+
+	protocol "github.com/stellar/go/protocols/horizon"
+	cmp "github.com/stellar/go/tools/horizon-cmp/internal"
 )
 
-var paths []string = []string{
-	"/payments?order=desc&limit=200&include_failed=true&cursor=97761976872132608",
-	"/payments?order=desc&limit=200&include_failed=false&cursor=97761976872132608",
-	"/payments?order=desc&limit=200&cursor=97761976872132608",
+const HorizonOld = "https://horizon.stellar.org"
+const HorizonNew = "https://horizon-dev-pubnet.stellar.org"
 
-	"/operations?order=desc&limit=200&include_failed=true&cursor=97761976872132608",
-	"/operations?order=desc&limit=200&include_failed=false&cursor=97761976872132608",
-	"/operations?order=desc&limit=200&cursor=97761976872132608",
+const MaxLevels = 3
 
-	"/accounts/GBXY56UJJH4MSEHTP35VX7B5JSLKD72XWLXK4JROQBYRASOXNDIMIL2D/payments?order=desc&limit=200&include_failed=true&cursor=97761976872132608",
-	"/accounts/GBXY56UJJH4MSEHTP35VX7B5JSLKD72XWLXK4JROQBYRASOXNDIMIL2D/operations?order=desc&limit=200&include_failed=true&cursor=97761976872132608",
-	"/accounts/GBXY56UJJH4MSEHTP35VX7B5JSLKD72XWLXK4JROQBYRASOXNDIMIL2D/transactions?order=desc&limit=200&include_failed=true&cursor=97761976872132608",
-
-	"/accounts/GBXY56UJJH4MSEHTP35VX7B5JSLKD72XWLXK4JROQBYRASOXNDIMIL2D/payments?order=desc&limit=2&cursor=97761976872132608",
-	"/accounts/GBXY56UJJH4MSEHTP35VX7B5JSLKD72XWLXK4JROQBYRASOXNDIMIL2D/operations?order=desc&limit=2&cursor=97761976872132608",
-	"/accounts/GBXY56UJJH4MSEHTP35VX7B5JSLKD72XWLXK4JROQBYRASOXNDIMIL2D/transactions?order=desc&limit=2&cursor=97761976872132608",
-
-	"/accounts/GB3BVRX2D2WBTUYPXOB6S25VTFK36LDCII2AILMMLIJT3SWG66CCS5AK/transactions?order=desc&cursor=97762191620468736",
-	"/accounts/GB3BVRX2D2WBTUYPXOB6S25VTFK36LDCII2AILMMLIJT3SWG66CCS5AK/transactions?order=desc&include_failed=true&cursor=97762191620468736",
-	"/accounts/GB3BVRX2D2WBTUYPXOB6S25VTFK36LDCII2AILMMLIJT3SWG66CCS5AK/transactions?order=desc&include_failed=false&cursor=97762191620468736",
-
-	"/accounts/GB3BVRX2D2WBTUYPXOB6S25VTFK36LDCII2AILMMLIJT3SWG66CCS5AK/transactions?order=desc&include_failed=true&limit=50&cursor=97696238102654976",
-	"/accounts/GB3BVRX2D2WBTUYPXOB6S25VTFK36LDCII2AILMMLIJT3SWG66CCS5AK/transactions?order=desc&include_failed=false&limit=50&cursor=97696238102654976",
-
-	"/ledgers/22764327/operations?limit=200",
-	"/ledgers/22764327/operations?limit=200&include_failed=true",
-	"/ledgers/22764327/payments?limit=200",
-	"/ledgers/22764327/payments?limit=200&include_failed=true",
-	"/ledgers/22764327/transactions?limit=200",
-	"/ledgers/22764327/transactions?limit=200&include_failed=true",
-	"/ledgers/22764327/effects?limit=200",
-	"/ledgers/22764327/effects?limit=200&include_failed=true",
-
-	"/ledgers/22762425/operations?limit=200",
-	"/ledgers/22762425/operations?limit=200&include_failed=true",
-	"/ledgers/22762425/payments?limit=200",
-	"/ledgers/22762425/payments?limit=200&include_failed=true",
-	"/ledgers/22762425/transactions?limit=200",
-	"/ledgers/22762425/transactions?limit=200&include_failed=true",
-	"/ledgers/22762425/effects?limit=200",
-	"/ledgers/22762425/effects?limit=200&include_failed=true",
-
-	"/payments?limit=200&cursor=97774668500484098",
-	"/payments?limit=200&cursor=97774668500484098&include_failed=false",
-	"/payments?limit=200&cursor=97774668500484098&include_failed=true",
-
-	"/operations/97774668500484098",
-	"/operations/97774689975341057",
-
-	"/operations?limit=200&cursor=97774668500484098",
-	"/operations?limit=200&cursor=97774668500484098&include_failed=false",
-	"/operations?limit=200&cursor=97774668500484098&include_failed=true",
-
-	"/transactions?limit=200&cursor=97774668500484098",
-	"/transactions?limit=200&cursor=97774668500484098&include_failed=false",
-	"/transactions?limit=200&cursor=97774668500484098&include_failed=true",
-
-	// failed
-	"/transactions/96583f831cefcc5dbab65f918e1818468ed7102f9da1a35159b40c37253ef4a3",
-	"/transactions/96583f831cefcc5dbab65f918e1818468ed7102f9da1a35159b40c37253ef4a3/operations",
-	"/transactions/96583f831cefcc5dbab65f918e1818468ed7102f9da1a35159b40c37253ef4a3/payments",
-	"/transactions/96583f831cefcc5dbab65f918e1818468ed7102f9da1a35159b40c37253ef4a3/effects",
-
-	// succ
-	"/transactions/702cbb5fead49b16d64b55a3bfcbabc7d4674a6d5a9e4012caf422ab87db3010",
-	"/transactions/702cbb5fead49b16d64b55a3bfcbabc7d4674a6d5a9e4012caf422ab87db3010/operations",
-	"/transactions/702cbb5fead49b16d64b55a3bfcbabc7d4674a6d5a9e4012caf422ab87db3010/payments",
-	"/transactions/702cbb5fead49b16d64b55a3bfcbabc7d4674a6d5a9e4012caf422ab87db3010/effects",
+type PathWithLevel struct {
+	Path  string
+	Level int
 }
 
-var removeMeta = regexp.MustCompile(`"result_meta_xdr": "(.*)"`)
+// Starting corpus of paths to test
+var paths []PathWithLevel = []PathWithLevel{
+	PathWithLevel{"/transactions?order=desc", 0},
+	PathWithLevel{"/transactions?order=desc&include_failed=true", 0},
+
+	PathWithLevel{"/operations?order=desc", 0},
+	PathWithLevel{"/operations?order=desc&include_failed=true", 0},
+
+	PathWithLevel{"/payments?order=desc", 0},
+	PathWithLevel{"/payments?order=desc&include_failed=true", 0},
+
+	PathWithLevel{"/ledgers?order=desc", 0},
+	PathWithLevel{"/effects?order=desc", 0},
+	PathWithLevel{"/trades?order=desc", 0},
+	PathWithLevel{"/assets", 0},
+	PathWithLevel{"/fee_stats", 0},
+}
+
+var visitedPaths map[string]bool
+
+func init() {
+	visitedPaths = make(map[string]bool)
+}
 
 func main() {
-	for _, p := range paths {
-		a := getResponse("https://horizon.stellar.org", p)
+	// Get latest ledger and operate on it's cursor to get responses at a given ledger.
+	ledger := getLatestLedger()
+	cursor := ledger.PagingToken()
+
+	// Sleep for a few sec to make sure second Horizon is up to speed
+	time.Sleep(2 * time.Second)
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	outputDir := fmt.Sprintf("%s/horizon-cmp-diff/%d", pwd, time.Now().Unix())
+
+	fmt.Println("Comparing:")
+	fmt.Printf("%s vs %s\n", HorizonOld, HorizonNew)
+	fmt.Printf("[ledger=%d cursor=%s outputDir=%s]\n\n", ledger.Sequence, cursor, outputDir)
+
+	err = os.MkdirAll(outputDir, 0744)
+	if err != nil {
+		panic(err)
+	}
+
+	for {
+		if len(paths) == 0 {
+			return
+		}
+
+		var pl PathWithLevel
+		pl, paths = paths[0], paths[1:]
+
+		p := pl.Path
+		level := pl.Level
+
+		if level > MaxLevels {
+			continue
+		}
+
+		if visitedPaths[p] {
+			continue
+		}
+
+		visitedPaths[p] = true
+
+		p = getPathWithCursor(p, cursor)
+
+		a := cmp.NewResponse(HorizonOld, p)
 		fmt.Print(".")
-		b := getResponse("https://horizon-dev-pubnet.stellar.org", p)
+		b := cmp.NewResponse(HorizonNew, p)
 		fmt.Print(".")
 
 		status := ""
-		if a == b {
+		if a.Equal(b) {
 			status = "ok"
 		} else {
-			status = "fail"
+			status = "diff"
 		}
 		fmt.Println(status, p)
-		if status == "fail" {
-			fmt.Println(a)
-			fmt.Println(b)
-			return
+		if status == "diff" {
+			a.SaveDiff(outputDir, b)
+		}
+
+		newPaths := a.GetPaths()
+		for _, newPath := range newPaths {
+			// Such links can get recent ledgers data that may be different
+			// if Horizon nodes are not at the same ledger.
+			if strings.Contains(newPath, "desc=asc") {
+				continue
+			}
+
+			paths = append(paths, PathWithLevel{newPath, level + 1})
 		}
 	}
 }
 
-func getResponse(domain, url string) string {
-	resp, err := http.Get(domain + url)
+func getLatestLedger() protocol.Ledger {
+	ledgersResponse := struct {
+		Embedded struct {
+			Records []protocol.Ledger `json:"records"`
+		} `json:"_embedded"`
+	}{}
+
+	resp, err := http.Get(HorizonOld + "/ledgers?order=desc&limit=1")
 	if err != nil {
 		panic(err)
 	}
@@ -117,11 +144,26 @@ func getResponse(domain, url string) string {
 		panic(err)
 	}
 
-	bodyString := string(body)
-	// `result_meta_xdr` can differ between core instances (confirmed this with core team)
-	bodyString = removeMeta.ReplaceAllString(bodyString, "")
-	// Remove Horizon URL from the _links
-	bodyString = strings.Replace(bodyString, domain, "", -1)
+	err = json.Unmarshal(body, &ledgersResponse)
+	if err != nil {
+		panic(err)
+	}
 
-	return bodyString
+	return ledgersResponse.Embedded.Records[0]
+}
+
+func getPathWithCursor(path, cursor string) string {
+	urlObj, err := url.Parse(path)
+	if err != nil {
+		panic(err)
+	}
+
+	// Add cursor if not present
+	q := urlObj.Query()
+	if q.Get("cursor") == "" {
+		q.Set("cursor", cursor)
+	}
+
+	urlObj.RawQuery = q.Encode()
+	return urlObj.String()
 }

--- a/tools/horizon-cmp/main.go
+++ b/tools/horizon-cmp/main.go
@@ -1,72 +1,71 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"time"
 
+	client "github.com/stellar/go/exp/clients/horizon"
 	protocol "github.com/stellar/go/protocols/horizon"
 	cmp "github.com/stellar/go/tools/horizon-cmp/internal"
 )
 
-const HorizonOld = "https://horizon.stellar.org"
-const HorizonNew = "http://localhost:8001"
+const horizonOld = "https://horizon.stellar.org"
+const horizonNew = "http://localhost:8000"
 
-const MaxLevels = 3
+// maxLevels defines the maximum number of levels deep the crawler
+// should go. Here's an example crawl stack:
+// Level 1 = /ledgers?order=desc (finds a link to tx details)
+// Level 2 = /transactions/abcdef (finds a link to a list of operations)
+// Level 3 = /transactions/abcdef/operations (will not follow any links - at level 3)
+const maxLevels = 3
 
-type PathWithLevel struct {
+type pathWithLevel struct {
 	Path  string
 	Level int
 }
 
-// Starting corpus of paths to test
-var paths []PathWithLevel = []PathWithLevel{
-	PathWithLevel{"/transactions?order=desc", 0},
-	PathWithLevel{"/transactions?order=desc&include_failed=false", 0},
-	PathWithLevel{"/transactions?order=desc&include_failed=true", 0},
+// Starting corpus of paths to test. You may want to extend this with a list of
+// paths that you want to ensure are tested.
+var paths []pathWithLevel = []pathWithLevel{
+	pathWithLevel{"/transactions?order=desc", 0},
+	pathWithLevel{"/transactions?order=desc&include_failed=false", 0},
+	pathWithLevel{"/transactions?order=desc&include_failed=true", 0},
 
-	PathWithLevel{"/operations?order=desc", 0},
-	PathWithLevel{"/operations?order=desc&include_failed=false", 0},
-	PathWithLevel{"/operations?order=desc&include_failed=true", 0},
+	pathWithLevel{"/operations?order=desc", 0},
+	pathWithLevel{"/operations?order=desc&include_failed=false", 0},
+	pathWithLevel{"/operations?order=desc&include_failed=true", 0},
 
-	PathWithLevel{"/payments?order=desc", 0},
-	PathWithLevel{"/payments?order=desc&include_failed=false", 0},
-	PathWithLevel{"/payments?order=desc&include_failed=true", 0},
+	pathWithLevel{"/payments?order=desc", 0},
+	pathWithLevel{"/payments?order=desc&include_failed=false", 0},
+	pathWithLevel{"/payments?order=desc&include_failed=true", 0},
 
-	PathWithLevel{"/ledgers?order=desc", 0},
-	PathWithLevel{"/effects?order=desc", 0},
-	PathWithLevel{"/trades?order=desc", 0},
+	pathWithLevel{"/ledgers?order=desc", 0},
+	pathWithLevel{"/effects?order=desc", 0},
+	pathWithLevel{"/trades?order=desc", 0},
 
-	PathWithLevel{"/ledgers/22923641", 0},
-	PathWithLevel{"/ledgers/22923641/transactions?limit=200", 0},
-	PathWithLevel{"/ledgers/22923641/operations?limit=200", 0},
-	PathWithLevel{"/ledgers/22923641/payments?limit=200", 0},
-	PathWithLevel{"/ledgers/22923641/effects?limit=200", 0},
+	pathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/transactions?limit=200", 0},
+	pathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/transactions?limit=200&include_failed=false", 0},
+	pathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/transactions?limit=200&include_failed=true", 0},
 
-	PathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/transactions?limit=200", 0},
-	PathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/transactions?limit=200&include_failed=false", 0},
-	PathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/transactions?limit=200&include_failed=true", 0},
+	pathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/operations?limit=200", 0},
+	pathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/payments?limit=200", 0},
+	pathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/effects?limit=200", 0},
 
-	PathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/operations?limit=200", 0},
-	PathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/payments?limit=200", 0},
-	PathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/effects?limit=200", 0},
-
-	PathWithLevel{"/accounts/GC2ZV6KGGFLQIMDVDWBWCP6LTODUDXYBLUPTUZCFHIMDCWHR43ULZITJ/trades?limit=200", 0},
-	PathWithLevel{"/accounts/GC2ZV6KGGFLQIMDVDWBWCP6LTODUDXYBLUPTUZCFHIMDCWHR43ULZITJ/offers?limit=200", 0},
+	pathWithLevel{"/accounts/GC2ZV6KGGFLQIMDVDWBWCP6LTODUDXYBLUPTUZCFHIMDCWHR43ULZITJ/trades?limit=200", 0},
+	pathWithLevel{"/accounts/GC2ZV6KGGFLQIMDVDWBWCP6LTODUDXYBLUPTUZCFHIMDCWHR43ULZITJ/offers?limit=200", 0},
 
 	// Pubnet markets
-	PathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=LTC&buying_asset_issuer=GCSTRLTC73UVXIYPHYTTQUUSDTQU2KQW5VKCE4YCMEHWF44JKDMQAL23", 0},
-	PathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=XRP&buying_asset_issuer=GCSTRLTC73UVXIYPHYTTQUUSDTQU2KQW5VKCE4YCMEHWF44JKDMQAL23", 0},
-	PathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=BTC&buying_asset_issuer=GCSTRLTC73UVXIYPHYTTQUUSDTQU2KQW5VKCE4YCMEHWF44JKDMQAL23", 0},
-	PathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=USD&buying_asset_issuer=GBSTRUSD7IRX73RQZBL3RQUH6KS3O4NYFY3QCALDLZD77XMZOPWAVTUK", 0},
-	PathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=SLT&buying_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP", 0},
+	pathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=LTC&buying_asset_issuer=GCSTRLTC73UVXIYPHYTTQUUSDTQU2KQW5VKCE4YCMEHWF44JKDMQAL23", 0},
+	pathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=XRP&buying_asset_issuer=GCSTRLTC73UVXIYPHYTTQUUSDTQU2KQW5VKCE4YCMEHWF44JKDMQAL23", 0},
+	pathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=BTC&buying_asset_issuer=GCSTRLTC73UVXIYPHYTTQUUSDTQU2KQW5VKCE4YCMEHWF44JKDMQAL23", 0},
+	pathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=USD&buying_asset_issuer=GBSTRUSD7IRX73RQZBL3RQUH6KS3O4NYFY3QCALDLZD77XMZOPWAVTUK", 0},
+	pathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=SLT&buying_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP", 0},
 
-	PathWithLevel{"/trade_aggregations?base_asset_type=native&counter_asset_code=USD&counter_asset_issuer=GBSTRUSD7IRX73RQZBL3RQUH6KS3O4NYFY3QCALDLZD77XMZOPWAVTUK&counter_asset_type=credit_alphanum4&end_time=1551866400000&limit=200&order=desc&resolution=900000&start_time=1514764800", 0},
+	pathWithLevel{"/trade_aggregations?base_asset_type=native&counter_asset_code=USD&counter_asset_issuer=GBSTRUSD7IRX73RQZBL3RQUH6KS3O4NYFY3QCALDLZD77XMZOPWAVTUK&counter_asset_type=credit_alphanum4&end_time=1551866400000&limit=200&order=desc&resolution=900000&start_time=1514764800", 0},
 }
 
 var visitedPaths map[string]bool
@@ -90,7 +89,7 @@ func main() {
 	outputDir := fmt.Sprintf("%s/horizon-cmp-diff/%d", pwd, time.Now().Unix())
 
 	fmt.Println("Comparing:")
-	fmt.Printf("%s vs %s\n", HorizonOld, HorizonNew)
+	fmt.Printf("%s vs %s\n", horizonOld, horizonNew)
 	fmt.Printf("[ledger=%d cursor=%s outputDir=%s]\n\n", ledger.Sequence, cursor, outputDir)
 
 	err = os.MkdirAll(outputDir, 0744)
@@ -103,13 +102,13 @@ func main() {
 			return
 		}
 
-		var pl PathWithLevel
+		var pl pathWithLevel
 		pl, paths = paths[0], paths[1:]
 
 		p := pl.Path
 		level := pl.Level
 
-		if level > MaxLevels {
+		if level > maxLevels {
 			continue
 		}
 
@@ -123,9 +122,9 @@ func main() {
 
 		p = getPathWithCursor(p, cursor)
 
-		a := cmp.NewResponse(HorizonOld, p)
+		a := cmp.NewResponse(horizonOld, p)
 		fmt.Print(".")
-		b := cmp.NewResponse(HorizonNew, p)
+		b := cmp.NewResponse(horizonNew, p)
 		fmt.Print(".")
 
 		status := ""
@@ -155,43 +154,32 @@ func main() {
 					prefix = "&"
 				}
 
-				paths = append(paths, PathWithLevel{newPath + prefix + "include_failed=false", level + 1})
-				paths = append(paths, PathWithLevel{newPath + prefix + "include_failed=true", level + 1})
+				paths = append(paths, pathWithLevel{newPath + prefix + "include_failed=false", level + 1})
+				paths = append(paths, pathWithLevel{newPath + prefix + "include_failed=true", level + 1})
 				continue
 			}
 
-			paths = append(paths, PathWithLevel{newPath, level + 1})
+			paths = append(paths, pathWithLevel{newPath, level + 1})
 		}
 	}
 }
 
 func getLatestLedger() protocol.Ledger {
-	ledgersResponse := struct {
-		Embedded struct {
-			Records []protocol.Ledger `json:"records"`
-		} `json:"_embedded"`
-	}{}
+	horizon := client.Client{
+		HorizonURL: horizonOld,
+		HTTP:       http.DefaultClient,
+	}
 
-	resp, err := http.Get(HorizonOld + "/ledgers?order=desc&limit=1")
+	ledgers, err := horizon.Ledgers(client.LedgerRequest{
+		Order: client.OrderDesc,
+		Limit: 1,
+	})
+
 	if err != nil {
 		panic(err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		panic(resp.StatusCode)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		panic(err)
-	}
-
-	err = json.Unmarshal(body, &ledgersResponse)
-	if err != nil {
-		panic(err)
-	}
-
-	return ledgersResponse.Embedded.Records[0]
+	return ledgers.Embedded.Records[0]
 }
 
 func getPathWithCursor(path, cursor string) string {

--- a/tools/horizon-cmp/main.go
+++ b/tools/horizon-cmp/main.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	client "github.com/stellar/go/exp/clients/horizon"
+	client "github.com/stellar/go/clients/horizonclient"
 	protocol "github.com/stellar/go/protocols/horizon"
 	cmp "github.com/stellar/go/tools/horizon-cmp/internal"
 )

--- a/tools/horizon-cmp/main.go
+++ b/tools/horizon-cmp/main.go
@@ -13,7 +13,7 @@ import (
 	cmp "github.com/stellar/go/tools/horizon-cmp/internal"
 )
 
-const horizonOld = "https://horizon.stellar.org"
+const horizonOld = "http://localhost:8001"
 const horizonNew = "http://localhost:8000"
 
 // maxLevels defines the maximum number of levels deep the crawler
@@ -79,7 +79,7 @@ func main() {
 	ledger := getLatestLedger()
 	cursor := ledger.PagingToken()
 
-	// Sleep for a few sec to make sure second Horizon is up to speed
+	// Sleep for a few seconds to make sure the second Horizon is up to speed
 	time.Sleep(2 * time.Second)
 
 	pwd, err := os.Getwd()

--- a/tools/horizon-verify/main.go
+++ b/tools/horizon-verify/main.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"sync"
+
+	"github.com/stellar/go/xdr"
+)
+
+type Operation struct {
+	TransactionSuccessful bool `json:"transaction_successful"`
+}
+
+type OperationsPage struct {
+	Embedded struct {
+		Records []Operation
+	} `json:"_embedded"`
+}
+
+type Transaction struct {
+	Successful     bool   `json:"successful"`
+	TxResult       string `json:"result_xdr"`
+	OperationCount int    `json:"operation_count"`
+	Hash           string `json:"hash"`
+}
+
+type TransactionsPage struct {
+	Embedded struct {
+		Records []Transaction
+	} `json:"_embedded"`
+}
+
+type Ledger struct {
+	Sequence                   int    `json:"sequence"`
+	PagingToken                string `json:"paging_token"`
+	SuccessfulTransactionCount int    `json:"successful_transaction_count"`
+	FailedTransactionCount     int    `json:"failed_transaction_count"`
+}
+
+type LedgersPage struct {
+	Embedded struct {
+		Records []Ledger
+	} `json:"_embedded"`
+}
+
+func main() {
+	ledgerCursor := ""
+
+	HorizonURL := os.Args[1]
+
+	for {
+		body := getBody(HorizonURL + fmt.Sprintf("/ledgers?order=desc&limit=200&cursor=%s", ledgerCursor))
+
+		ledgersPage := LedgersPage{}
+		err := json.Unmarshal(body, &ledgersPage)
+		if err != nil {
+			panic(err)
+		}
+
+		if len(ledgersPage.Embedded.Records) == 0 {
+			fmt.Println("Done")
+			return
+		}
+
+		for _, ledger := range ledgersPage.Embedded.Records {
+			fmt.Printf("Checking ledger: %d (successful=%d failed=%d)\n", ledger.Sequence, ledger.SuccessfulTransactionCount, ledger.FailedTransactionCount)
+
+			ledgerCursor = ledger.PagingToken
+
+			body := getBody(HorizonURL + fmt.Sprintf("/ledgers/%d/transactions?limit=200&include_failed=true", ledger.Sequence))
+			transactionsPage := TransactionsPage{}
+			err = json.Unmarshal(body, &transactionsPage)
+			if err != nil {
+				panic(err)
+			}
+
+			var wg sync.WaitGroup
+
+			successful := 0
+			failed := 0
+
+			for _, transaction := range transactionsPage.Embedded.Records {
+				wg.Add(1)
+
+				if transaction.Successful {
+					successful++
+				} else {
+					failed++
+				}
+
+				go func(transaction Transaction) {
+					defer wg.Done()
+
+					var resultXDR xdr.TransactionResult
+					err = xdr.SafeUnmarshalBase64(transaction.TxResult, &resultXDR)
+					if err != nil {
+						return
+					}
+
+					if transaction.Successful && resultXDR.Result.Code != xdr.TransactionResultCodeTxSuccess {
+						panic(fmt.Sprintf("Corrupted data! %s %s", transaction.Hash, transaction.TxResult))
+						return
+					}
+
+					if !transaction.Successful && resultXDR.Result.Code == xdr.TransactionResultCodeTxSuccess {
+						panic(fmt.Sprintf("Corrupted data! %s %s", transaction.Hash, transaction.TxResult))
+						return
+					}
+
+					body := getBody(HorizonURL + fmt.Sprintf("/transactions/%s/operations?limit=200", transaction.Hash))
+					operationsPage := OperationsPage{}
+					err = json.Unmarshal(body, &operationsPage)
+					if err != nil {
+						panic(err)
+					}
+
+					if len(operationsPage.Embedded.Records) != transaction.OperationCount {
+						panic(fmt.Sprintf("Corrupted data! %s operations count %d vs %d (body=%s)", transaction.Hash, len(operationsPage.Embedded.Records), transaction.OperationCount, string(body)))
+					}
+				}(transaction)
+			}
+
+			wg.Wait()
+
+			if successful != ledger.SuccessfulTransactionCount || failed != ledger.FailedTransactionCount {
+				panic(fmt.Sprintf("Invalid ledger counters %d", ledger.Sequence))
+			}
+		}
+	}
+}
+
+func getBody(url string) []byte {
+	resp, err := http.Get(url)
+	if err != nil {
+		panic(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		panic(fmt.Sprintf("%d response for %s", resp.StatusCode, url))
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+
+	return body
+}

--- a/tools/horizon-verify/main.go
+++ b/tools/horizon-verify/main.go
@@ -86,6 +86,8 @@ var rootCmd = &cobra.Command{
 			ledgerCursor = ledger.PagingToken()
 		}
 
+		fmt.Printf("%s: Checking %d ledgers starting from cursor \"%s\"\n\n", horizonURL, count, ledgerCursor)
+
 		for {
 			ledgersPage, err := client.Ledgers(horizonclient.LedgerRequest{
 				Limit:  200,
@@ -103,7 +105,7 @@ var rootCmd = &cobra.Command{
 			}
 
 			for _, ledger := range ledgersPage.Embedded.Records {
-				fmt.Printf("Checking ledger: %d (successful=%d failed=%d)\n", ledger.Sequence, ledger.SuccessfulTransactionCount, ledger.FailedTransactionCount)
+				fmt.Printf("Checking ledger: %d (successful=%d failed=%d)\n", ledger.Sequence, ledger.SuccessfulTransactionCount, *ledger.FailedTransactionCount)
 
 				ledgerCursor = ledger.PagingToken()
 

--- a/tools/horizon-verify/main.go
+++ b/tools/horizon-verify/main.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	"github.com/spf13/cobra"
-	"github.com/stellar/go/exp/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
 	protocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/xdr"
 )

--- a/tools/horizon-verify/main.go
+++ b/tools/horizon-verify/main.go
@@ -19,7 +19,7 @@ var count uint
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&horizonURL, "url", "u", "", "Horizon server URL")
-	rootCmd.PersistentFlags().Uint32VarP(&startSequence, "start", "s", 0, "Sequence number of a start ledger (follows descending order, defaults to the latest ledger)")
+	rootCmd.PersistentFlags().Uint32VarP(&startSequence, "start", "s", 0, "Sequence number of the ledger to start with (follows descending order, defaults to the latest ledger)")
 	rootCmd.PersistentFlags().UintVarP(&count, "count", "c", 10000, "Number of ledgers to check")
 }
 
@@ -83,9 +83,10 @@ var rootCmd = &cobra.Command{
 					panic(err)
 				}
 
-				var wg sync.WaitGroup
-
-				var successful, failed int32
+				var (
+					wg                 sync.WaitGroup
+					successful, failed int32
+				)
 
 				for _, transaction := range transactionsPage.Embedded.Records {
 					wg.Add(1)
@@ -102,17 +103,12 @@ var rootCmd = &cobra.Command{
 						var resultXDR xdr.TransactionResult
 						err = xdr.SafeUnmarshalBase64(transaction.ResultXdr, &resultXDR)
 						if err != nil {
-							return
+							panic(err)
 						}
 
-						if transaction.Successful && resultXDR.Result.Code != xdr.TransactionResultCodeTxSuccess {
+						if (transaction.Successful && resultXDR.Result.Code != xdr.TransactionResultCodeTxSuccess) ||
+							(!transaction.Successful && resultXDR.Result.Code == xdr.TransactionResultCodeTxSuccess) {
 							panic(fmt.Sprintf("Corrupted data! %s %s", transaction.Hash, transaction.ResultXdr))
-							return
-						}
-
-						if !transaction.Successful && resultXDR.Result.Code == xdr.TransactionResultCodeTxSuccess {
-							panic(fmt.Sprintf("Corrupted data! %s %s", transaction.Hash, transaction.ResultXdr))
-							return
 						}
 
 						operationsPage, err := client.Operations(horizonclient.OperationRequest{

--- a/tools/horizon-verify/main.go
+++ b/tools/horizon-verify/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -10,44 +9,9 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/exp/clients/horizon"
+	protocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/xdr"
 )
-
-type Operation struct {
-	TransactionSuccessful bool `json:"transaction_successful"`
-}
-
-type OperationsPage struct {
-	Embedded struct {
-		Records []Operation
-	} `json:"_embedded"`
-}
-
-type Transaction struct {
-	Successful     bool   `json:"successful"`
-	TxResult       string `json:"result_xdr"`
-	OperationCount int    `json:"operation_count"`
-	Hash           string `json:"hash"`
-}
-
-type TransactionsPage struct {
-	Embedded struct {
-		Records []Transaction
-	} `json:"_embedded"`
-}
-
-type Ledger struct {
-	Sequence                   int    `json:"sequence"`
-	PagingToken                string `json:"paging_token"`
-	SuccessfulTransactionCount int    `json:"successful_transaction_count"`
-	FailedTransactionCount     int    `json:"failed_transaction_count"`
-}
-
-type LedgersPage struct {
-	Embedded struct {
-		Records []Ledger
-	} `json:"_embedded"`
-}
 
 var horizonURL string
 var startSequence uint32
@@ -109,9 +73,12 @@ var rootCmd = &cobra.Command{
 
 				ledgerCursor = ledger.PagingToken()
 
-				body := getBody(horizonURL + fmt.Sprintf("/ledgers/%d/transactions?limit=200&include_failed=true", ledger.Sequence))
-				transactionsPage := TransactionsPage{}
-				err = json.Unmarshal(body, &transactionsPage)
+				transactionsPage, err := client.Transactions(horizonclient.TransactionRequest{
+					ForLedger:     uint(ledger.Sequence),
+					Limit:         200,
+					IncludeFailed: true,
+				})
+
 				if err != nil {
 					panic(err)
 				}
@@ -129,34 +96,36 @@ var rootCmd = &cobra.Command{
 						failed++
 					}
 
-					go func(transaction Transaction) {
+					go func(transaction protocol.Transaction) {
 						defer wg.Done()
 
 						var resultXDR xdr.TransactionResult
-						err = xdr.SafeUnmarshalBase64(transaction.TxResult, &resultXDR)
+						err = xdr.SafeUnmarshalBase64(transaction.ResultXdr, &resultXDR)
 						if err != nil {
 							return
 						}
 
 						if transaction.Successful && resultXDR.Result.Code != xdr.TransactionResultCodeTxSuccess {
-							panic(fmt.Sprintf("Corrupted data! %s %s", transaction.Hash, transaction.TxResult))
+							panic(fmt.Sprintf("Corrupted data! %s %s", transaction.Hash, transaction.ResultXdr))
 							return
 						}
 
 						if !transaction.Successful && resultXDR.Result.Code == xdr.TransactionResultCodeTxSuccess {
-							panic(fmt.Sprintf("Corrupted data! %s %s", transaction.Hash, transaction.TxResult))
+							panic(fmt.Sprintf("Corrupted data! %s %s", transaction.Hash, transaction.ResultXdr))
 							return
 						}
 
-						body := getBody(horizonURL + fmt.Sprintf("/transactions/%s/operations?limit=200", transaction.Hash))
-						operationsPage := OperationsPage{}
-						err = json.Unmarshal(body, &operationsPage)
+						operationsPage, err := client.Operations(horizonclient.OperationRequest{
+							ForTransaction: transaction.Hash,
+							Limit:          200,
+						})
+
 						if err != nil {
 							panic(err)
 						}
 
-						if len(operationsPage.Embedded.Records) != transaction.OperationCount {
-							panic(fmt.Sprintf("Corrupted data! %s operations count %d vs %d (body=%s)", transaction.Hash, len(operationsPage.Embedded.Records), transaction.OperationCount, string(body)))
+						if len(operationsPage.Embedded.Records) != int(transaction.OperationCount) {
+							panic(fmt.Sprintf("Corrupted data! %s operations count %d vs %d", transaction.Hash, len(operationsPage.Embedded.Records), transaction.OperationCount))
 						}
 					}(transaction)
 				}


### PR DESCRIPTION
Adds a simple command to compare responses of two horizon servers. Can be used to check differences between the latest stable version and release candidate.

EDIT: forgot about "Work in Progress" option in GH, can't change the status once PR is added.

TODO:
- [x] Add more paths to the test corpus (can also add code that generates relevant paths).
- [x] Print diff instead of full body when responses differ.
- [x] ~Setting params via CLI.~ #1183
- [x] ~Test streaming.~ #1184
- [x] ~Run in CI and add diffs to PRs.~ #1185