### PR TITLE
horizon/cmd: fix configuring logging level

### DIFF
--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -91,7 +91,6 @@ var dbClearCmd = &cobra.Command{
 	Use:   "clear",
 	Short: "clears all imported historical data",
 	Run: func(cmd *cobra.Command, args []string) {
-		hlog.DefaultLogger.Logger.Level = config.LogLevel
 		initConfig()
 
 		err := ingestSystem(ingest.Config{
@@ -175,7 +174,6 @@ var dbRebaseCmd = &cobra.Command{
 	Short: "rebases clears the horizon db and ingests the latest ledger segment from stellar-core",
 	Long:  "...",
 	Run: func(cmd *cobra.Command, args []string) {
-		hlog.DefaultLogger.Logger.Level = config.LogLevel
 		initConfig()
 
 		i := ingestSystem(ingest.Config{
@@ -195,7 +193,6 @@ var dbReingestCmd = &cobra.Command{
 	Short: "imports all data",
 	Long:  "reingest runs the ingestion pipeline over every ledger",
 	Run: func(cmd *cobra.Command, args []string) {
-		hlog.DefaultLogger.Logger.Level = config.LogLevel
 		initConfig()
 
 		i := ingestSystem(ingest.Config{

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -300,7 +300,7 @@ func initConfig() {
 	}
 
 	// Configure log level
-	log.DefaultLogger.Level = config.LogLevel
+	log.DefaultLogger.Logger.SetLevel(config.LogLevel)
 }
 
 func Execute() {

--- a/services/horizon/internal/ingest/system.go
+++ b/services/horizon/internal/ingest/system.go
@@ -122,7 +122,6 @@ func (i *System) ReingestAll() (int, error) {
 
 // ReingestOutdated finds old ledgers and reimports them.
 func (i *System) ReingestOutdated() (n int, err error) {
-
 	q := history.Q{Session: i.HorizonDB}
 
 	// NOTE: this loop will never terminate if some bug were cause a ledger


### PR DESCRIPTION
This issue is caused by reverting a PR on the release branch for quickly unblocking, not caused by the `logrus` library update. That temporary PR was brought back to `master` after we published the release, and the PR reverting the revert didn't clean it up everything properly. Thus we ended up in this state.

This PR uses `Logger.SetLevel` to properly set the level of the logger in an `Entry`.

Close #966 