### PR TITLE
support/log: add log fatal functions

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -379,8 +379,8 @@ func (a *App) init() {
 	a.UpdateStellarCoreInfo()
 
 	// horizon-db and core-db
-	initHorizonDb(a)
-	initCoreDb(a)
+	mustInitHorizonDB(a)
+	mustInitCoreDB(a)
 
 	// ingester
 	initIngester(a)

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -77,7 +77,7 @@ func initSentry(app *App) {
 	log.WithField("dsn", app.config.SentryDSN).Info("Initializing sentry")
 	err := raven.SetDSN(app.config.SentryDSN)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 }
 

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -3,7 +3,6 @@ package horizon
 import (
 	"net/http"
 	"net/url"
-	"os"
 	"time"
 
 	raven "github.com/getsentry/raven-go"
@@ -19,10 +18,10 @@ import (
 	"github.com/stellar/go/support/log"
 )
 
-func initHorizonDb(app *App) {
+func mustInitHorizonDB(app *App) {
 	session, err := db.Open("postgres", app.config.DatabaseURL)
 	if err != nil {
-		log.Panic(err)
+		log.Fatalf("cannot open Horizon DB due to error %v", err)
 	}
 
 	// Make sure MaxIdleConns is equal MaxOpenConns. In case of high variance
@@ -32,10 +31,10 @@ func initHorizonDb(app *App) {
 	app.historyQ = &history.Q{session}
 }
 
-func initCoreDb(app *App) {
+func mustInitCoreDB(app *App) {
 	session, err := db.Open("postgres", app.config.StellarCoreDatabaseURL)
 	if err != nil {
-		log.Panic(err)
+		log.Fatalf("cannot open core DB due to error %v", err)
 	}
 
 	// Make sure MaxIdleConns is equal MaxOpenConns. In case of high variance
@@ -51,8 +50,7 @@ func initIngester(app *App) {
 	}
 
 	if app.config.NetworkPassphrase == "" {
-		log.Error("Cannot start ingestion without network passphrase. Please confirm connectivity with stellar-core.")
-		os.Exit(1)
+		log.Fatal("Cannot start ingestion without network passphrase. Please confirm connectivity with stellar-core.")
 	}
 
 	app.ingester = ingest.New(
@@ -79,7 +77,7 @@ func initSentry(app *App) {
 	log.WithField("dsn", app.config.SentryDSN).Info("Initializing sentry")
 	err := raven.SetDSN(app.config.SentryDSN)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 }
 
@@ -152,7 +150,7 @@ func initRedis(app *App) {
 
 	redisURL, err := url.Parse(app.config.RedisURL)
 	if err != nil {
-		log.Panic(err)
+		log.Fatal(err)
 	}
 
 	app.redis = &redis.Pool{
@@ -171,7 +169,7 @@ func initRedis(app *App) {
 
 	_, err = c.Do("PING")
 	if err != nil {
-		log.Panic(err)
+		log.Fatal(err)
 	}
 }
 

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -21,7 +21,7 @@ import (
 func mustInitHorizonDB(app *App) {
 	session, err := db.Open("postgres", app.config.DatabaseURL)
 	if err != nil {
-		log.Fatalf("cannot open Horizon DB due to error %v", err)
+		log.Fatalf("cannot open Horizon DB: %v", err)
 	}
 
 	// Make sure MaxIdleConns is equal MaxOpenConns. In case of high variance
@@ -34,7 +34,7 @@ func mustInitHorizonDB(app *App) {
 func mustInitCoreDB(app *App) {
 	session, err := db.Open("postgres", app.config.StellarCoreDatabaseURL)
 	if err != nil {
-		log.Fatalf("cannot open core DB due to error %v", err)
+		log.Fatalf("cannot open Core DB: %v", err)
 	}
 
 	// Make sure MaxIdleConns is equal MaxOpenConns. In case of high variance

--- a/support/log/entry.go
+++ b/support/log/entry.go
@@ -110,6 +110,16 @@ func (e *Entry) Error(args ...interface{}) {
 	e.Entry.Error(args...)
 }
 
+// Fatalf logs a message at the Fatal severity.
+func (e *Entry) Fatalf(format string, args ...interface{}) {
+	e.Entry.Fatalf(format, args...)
+}
+
+// Fatal logs a message at the Fatal severity.
+func (e *Entry) Fatal(args ...interface{}) {
+	e.Entry.Fatal(args...)
+}
+
 // Panicf logs a message at the Panic severity.
 func (e *Entry) Panicf(format string, args ...interface{}) {
 	e.Entry.Panicf(format, args...)

--- a/support/log/main.go
+++ b/support/log/main.go
@@ -135,6 +135,16 @@ func Error(args ...interface{}) {
 	DefaultLogger.Error(args...)
 }
 
+// Fatalf logs a message at the Fatal severity.
+func Fatalf(format string, args ...interface{}) {
+	DefaultLogger.Fatalf(format, args...)
+}
+
+// Fatal logs a message at the Fatal severity.
+func Fatal(args ...interface{}) {
+	DefaultLogger.Fatal(args...)
+}
+
 // Panicf logs a message at the Panic severity.
 func Panicf(format string, args ...interface{}) {
 	DefaultLogger.Panicf(format, args...)


### PR DESCRIPTION
We've been using `log.Panic` for initialization. Panic should be used on
unexpected things. In our case, it is likely that the user doesn't have
the right configs to spin up our server.