### PR TITLE
Check if multiple filters are set

### DIFF
--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -75,6 +75,27 @@ func (base *Base) checkUTF8(name, value string) {
 	}
 }
 
+// GetStringFromURLParam retrieves a string from the URLParams.
+func (base *Base) GetStringFromURLParam(name string) string {
+	if base.Err != nil {
+		return ""
+	}
+
+	fromURL, ok := base.GetURLParam(name)
+	if ok {
+		ret, err := url.PathUnescape(fromURL)
+		if err != nil {
+			base.SetInvalidField(name, err)
+			return ""
+		}
+
+		base.checkUTF8(name, ret)
+		return ret
+	}
+
+	return ""
+}
+
 // GetString retrieves a string from either the URLParams, form or query string.
 // This method uses the priority (URLParams, Form, Query).
 func (base *Base) GetString(name string) string {
@@ -147,7 +168,7 @@ func (base *Base) GetInt32(name string) int32 {
 	return int32(asI64)
 }
 
-// GetBool retrieves a bool from the action parameter of the given name.
+// GetBool retrieves a bool from the query parameter for the given name.
 // Populates err if the value is not a valid bool.
 // Defaults to `false` in case of an empty string. WARNING, do not change
 // this behaviour without checking other modules, ex. this is critical
@@ -157,7 +178,7 @@ func (base *Base) GetBool(name string) bool {
 		return false
 	}
 
-	asStr := base.GetString(name)
+	asStr := base.R.URL.Query().Get(name)
 	if asStr == "" {
 		return false
 	}

--- a/services/horizon/internal/actions_effects.go
+++ b/services/horizon/internal/actions_effects.go
@@ -109,33 +109,38 @@ func (action *EffectIndexAction) loadParams() {
 	action.LedgerFilter = action.GetInt32("ledger_id")
 	action.TransactionFilter = action.GetString("tx_id")
 	action.OperationFilter = action.GetInt64("op_id")
+
+	filters, err := countNonEmpty(
+		action.AccountFilter,
+		action.LedgerFilter,
+		action.TransactionFilter,
+		action.OperationFilter,
+	)
+
+	if err != nil {
+		action.Err = errors.Wrap(err, "Error in countNonEmpty")
+		return
+	}
+
+	if filters > 1 {
+		action.Err = supportProblem.BadRequest
+		return
+	}
 }
 
 // loadRecords populates action.Records
 func (action *EffectIndexAction) loadRecords() {
 	effects := action.HistoryQ().Effects()
 
-	filters := 0
-	if action.AccountFilter != "" {
+	switch {
+	case action.AccountFilter != "":
 		effects.ForAccount(action.AccountFilter)
-		filters++
-	}
-	if action.LedgerFilter > 0 {
+	case action.LedgerFilter > 0:
 		effects.ForLedger(action.LedgerFilter)
-		filters++
-	}
-	if action.OperationFilter > 0 {
+	case action.OperationFilter > 0:
 		effects.ForOperation(action.OperationFilter)
-		filters++
-	}
-	if action.TransactionFilter != "" {
+	case action.TransactionFilter != "":
 		effects.ForTransaction(action.TransactionFilter)
-		filters++
-	}
-
-	if filters > 1 {
-		action.Err = problem.BadRequest
-		return
 	}
 
 	action.Err = effects.Page(action.PagingParams).Select(&action.Records)

--- a/services/horizon/internal/actions_effects.go
+++ b/services/horizon/internal/actions_effects.go
@@ -123,7 +123,7 @@ func (action *EffectIndexAction) loadParams() {
 	}
 
 	if filters > 1 {
-		action.Err = supportProblem.BadRequest
+		action.Err = problem.BadRequest
 		return
 	}
 }

--- a/services/horizon/internal/actions_effects_test.go
+++ b/services/horizon/internal/actions_effects_test.go
@@ -68,6 +68,12 @@ func TestEffectActions_Index(t *testing.T) {
 			ht.Assert.PageOf(3, w.Body)
 		}
 
+		// Check extra params
+		w = ht.Get("/ledgers/100/effects?account_id=GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+		ht.Assert.Equal(400, w.Code)
+		w = ht.Get("/accounts/GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU/effects?ledger_id=5")
+		ht.Assert.Equal(400, w.Code)
+
 		// before history
 		ht.ReapHistory(1)
 		w = ht.Get("/effects?order=desc&cursor=8589938689-1")

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -116,6 +116,12 @@ func (action *OperationIndexAction) loadParams() {
 		return
 	}
 
+	// Double check TransactionFilter as it's used to determine if failed txs should be returned
+	if action.TransactionFilter != "" && !isValidTransactionHash(action.TransactionFilter) {
+		action.Err = supportProblem.MakeInvalidFieldProblem("tx_id", errors.New("Invalid transaction hash"))
+		return
+	}
+
 	if action.IncludeFailed == true && !action.App.config.IngestFailedTransactions {
 		err := errors.New("`include_failed` parameter is unavailable when Horizon is not ingesting failed " +
 			"transactions. Set `INGEST_FAILED_TRANSACTIONS=true` to start ingesting them.")

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -100,6 +100,22 @@ func (action *OperationIndexAction) loadParams() {
 	action.PagingParams = action.GetPageQuery()
 	action.IncludeFailed = action.GetBool("include_failed")
 
+	filters, err := countNonEmpty(
+		action.AccountFilter,
+		action.LedgerFilter,
+		action.TransactionFilter,
+	)
+
+	if err != nil {
+		action.Err = errors.Wrap(err, "Error in countNonEmpty")
+		return
+	}
+
+	if filters > 1 {
+		action.Err = supportProblem.BadRequest
+		return
+	}
+
 	if action.IncludeFailed == true && !action.App.config.IngestFailedTransactions {
 		err := errors.New("`include_failed` parameter is unavailable when Horizon is not ingesting failed " +
 			"transactions. Set `INGEST_FAILED_TRANSACTIONS=true` to start ingesting them.")
@@ -112,23 +128,13 @@ func (action *OperationIndexAction) loadRecords() {
 	q := action.HistoryQ()
 	ops := q.Operations()
 
-	filters := 0
-	if action.AccountFilter != "" {
+	switch {
+	case action.AccountFilter != "":
 		ops.ForAccount(action.AccountFilter)
-		filters++
-	}
-	if action.LedgerFilter > 0 {
+	case action.LedgerFilter > 0:
 		ops.ForLedger(action.LedgerFilter)
-		filters++
-	}
-	if action.TransactionFilter != "" {
+	case action.TransactionFilter != "":
 		ops.ForTransaction(action.TransactionFilter)
-		filters++
-	}
-
-	if filters > 1 {
-		action.Err = supportProblem.BadRequest
-		return
 	}
 
 	// When querying operations for transaction return both successful

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -63,6 +63,19 @@ func TestOperationActions_Index(t *testing.T) {
 		ht.Assert.PageOf(1, w.Body)
 	}
 
+	// 400 for invalid tx hash
+	w = ht.Get("/transactions/ /operations")
+	ht.Assert.Equal(400, w.Code)
+
+	w = ht.Get("/transactions/invalid/operations")
+	ht.Assert.Equal(400, w.Code)
+
+	w = ht.Get("/transactions/1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc29/operations")
+	ht.Assert.Equal(400, w.Code)
+
+	w = ht.Get("/transactions/1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc29222/operations")
+	ht.Assert.Equal(400, w.Code)
+
 	// filtered by ledger
 	w = ht.Get("/ledgers/3/operations")
 	if ht.Assert.Equal(200, w.Code) {

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -88,7 +88,7 @@ func (action *PaymentsIndexAction) loadParams() {
 	action.ValidateCursorAsDefault()
 	action.AccountFilter = action.GetAddress("account_id")
 	action.LedgerFilter = action.GetInt32("ledger_id")
-	action.TransactionFilter = action.GetString("tx_id")
+	action.TransactionFilter = action.GetStringFromURLParam("tx_id")
 	action.PagingParams = action.GetPageQuery()
 	action.IncludeFailed = action.GetBool("include_failed")
 
@@ -104,13 +104,23 @@ func (action *PaymentsIndexAction) loadRecords() {
 	q := action.HistoryQ()
 	ops := q.Operations().OnlyPayments()
 
-	switch {
-	case action.AccountFilter != "":
+	filters := 0
+	if action.AccountFilter != "" {
 		ops.ForAccount(action.AccountFilter)
-	case action.LedgerFilter > 0:
+		filters++
+	}
+	if action.LedgerFilter > 0 {
 		ops.ForLedger(action.LedgerFilter)
-	case action.TransactionFilter != "":
+		filters++
+	}
+	if action.TransactionFilter != "" {
 		ops.ForTransaction(action.TransactionFilter)
+		filters++
+	}
+
+	if filters > 1 {
+		action.Err = supportProblem.BadRequest
+		return
 	}
 
 	// When querying operations for transaction return both successful

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -92,6 +92,22 @@ func (action *PaymentsIndexAction) loadParams() {
 	action.PagingParams = action.GetPageQuery()
 	action.IncludeFailed = action.GetBool("include_failed")
 
+	filters, err := countNonEmpty(
+		action.AccountFilter,
+		action.LedgerFilter,
+		action.TransactionFilter,
+	)
+
+	if err != nil {
+		action.Err = errors.Wrap(err, "Error in countNonEmpty")
+		return
+	}
+
+	if filters > 1 {
+		action.Err = supportProblem.BadRequest
+		return
+	}
+
 	if action.IncludeFailed == true && !action.App.config.IngestFailedTransactions {
 		err := errors.New("`include_failed` parameter is unavailable when Horizon is not ingesting failed " +
 			"transactions. Set `INGEST_FAILED_TRANSACTIONS=true` to start ingesting them.")
@@ -104,23 +120,13 @@ func (action *PaymentsIndexAction) loadRecords() {
 	q := action.HistoryQ()
 	ops := q.Operations().OnlyPayments()
 
-	filters := 0
-	if action.AccountFilter != "" {
+	switch {
+	case action.AccountFilter != "":
 		ops.ForAccount(action.AccountFilter)
-		filters++
-	}
-	if action.LedgerFilter > 0 {
+	case action.LedgerFilter > 0:
 		ops.ForLedger(action.LedgerFilter)
-		filters++
-	}
-	if action.TransactionFilter != "" {
+	case action.TransactionFilter != "":
 		ops.ForTransaction(action.TransactionFilter)
-		filters++
-	}
-
-	if filters > 1 {
-		action.Err = supportProblem.BadRequest
-		return
 	}
 
 	// When querying operations for transaction return both successful

--- a/services/horizon/internal/actions_payment.go
+++ b/services/horizon/internal/actions_payment.go
@@ -108,6 +108,12 @@ func (action *PaymentsIndexAction) loadParams() {
 		return
 	}
 
+	// Double check TransactionFilter as it's used to determine if failed txs should be returned
+	if action.TransactionFilter != "" && !isValidTransactionHash(action.TransactionFilter) {
+		action.Err = supportProblem.MakeInvalidFieldProblem("tx_id", errors.New("Invalid transaction hash"))
+		return
+	}
+
 	if action.IncludeFailed == true && !action.App.config.IngestFailedTransactions {
 		err := errors.New("`include_failed` parameter is unavailable when Horizon is not ingesting failed " +
 			"transactions. Set `INGEST_FAILED_TRANSACTIONS=true` to start ingesting them.")

--- a/services/horizon/internal/actions_payment_test.go
+++ b/services/horizon/internal/actions_payment_test.go
@@ -164,3 +164,32 @@ func TestPayment_CreatedAt(t *testing.T) {
 
 	ht.Assert.WithinDuration(l.ClosedAt, records[0].LedgerCloseTime, 1*time.Second)
 }
+
+// TestPaymentActions_Show_Extra_TxID tests if failed transactions are not returned
+// when `tx_id` GET param is present. This was happening because `base.GetString()`
+// method retuns values from the query when URL param is not present.
+func TestPaymentActions_Show_Extra_TxID(t *testing.T) {
+	ht := StartHTTPTest(t, "failed_transactions")
+	defer ht.Finish()
+
+	w := ht.Get("/accounts/GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON/payments?limit=200&tx_id=abc")
+
+	if ht.Assert.Equal(200, w.Code) {
+		records := []operations.Base{}
+		ht.UnmarshalPage(w.Body, &records)
+
+		successful := 0
+		failed := 0
+
+		for _, op := range records {
+			if op.TransactionSuccessful {
+				successful++
+			} else {
+				failed++
+			}
+		}
+
+		ht.Assert.Equal(2, successful)
+		ht.Assert.Equal(0, failed)
+	}
+}

--- a/services/horizon/internal/actions_payment_test.go
+++ b/services/horizon/internal/actions_payment_test.go
@@ -43,6 +43,19 @@ func TestPaymentActions(t *testing.T) {
 		ht.Assert.PageOf(0, w.Body)
 	}
 
+	// 400 for invalid tx hash
+	w = ht.Get("/transactions/ /payments")
+	ht.Assert.Equal(400, w.Code)
+
+	w = ht.Get("/transactions/invalid/payments")
+	ht.Assert.Equal(400, w.Code)
+
+	w = ht.Get("/transactions/1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc29/payments")
+	ht.Assert.Equal(400, w.Code)
+
+	w = ht.Get("/transactions/1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc29222/payments")
+	ht.Assert.Equal(400, w.Code)
+
 	w = ht.Get("/transactions/1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc292/payments")
 	if ht.Assert.Equal(200, w.Code) {
 		ht.Assert.PageOf(1, w.Body)

--- a/services/horizon/internal/actions_transaction.go
+++ b/services/horizon/internal/actions_transaction.go
@@ -94,11 +94,19 @@ func (action *TransactionIndexAction) loadRecords() {
 	q := action.HistoryQ()
 	txs := q.Transactions()
 
-	switch {
-	case action.AccountFilter != "":
+	filters := 0
+	if action.AccountFilter != "" {
 		txs.ForAccount(action.AccountFilter)
-	case action.LedgerFilter > 0:
+		filters++
+	}
+	if action.LedgerFilter > 0 {
 		txs.ForLedger(action.LedgerFilter)
+		filters++
+	}
+
+	if filters > 1 {
+		action.Err = problem.BadRequest
+		return
 	}
 
 	if action.IncludeFailed {

--- a/services/horizon/internal/actions_transaction.go
+++ b/services/horizon/internal/actions_transaction.go
@@ -82,6 +82,21 @@ func (action *TransactionIndexAction) loadParams() {
 	action.PagingParams = action.GetPageQuery()
 	action.IncludeFailed = action.GetBool("include_failed")
 
+	filters, err := countNonEmpty(
+		action.AccountFilter,
+		action.LedgerFilter,
+	)
+
+	if err != nil {
+		action.Err = errors.Wrap(err, "Error in countNonEmpty")
+		return
+	}
+
+	if filters > 1 {
+		action.Err = problem.BadRequest
+		return
+	}
+
 	if action.IncludeFailed == true && !action.App.config.IngestFailedTransactions {
 		err := errors.New("`include_failed` parameter is unavailable when Horizon is not ingesting failed " +
 			"transactions. Set `INGEST_FAILED_TRANSACTIONS=true` to start ingesting them.")
@@ -94,19 +109,11 @@ func (action *TransactionIndexAction) loadRecords() {
 	q := action.HistoryQ()
 	txs := q.Transactions()
 
-	filters := 0
-	if action.AccountFilter != "" {
+	switch {
+	case action.AccountFilter != "":
 		txs.ForAccount(action.AccountFilter)
-		filters++
-	}
-	if action.LedgerFilter > 0 {
+	case action.LedgerFilter > 0:
 		txs.ForLedger(action.LedgerFilter)
-		filters++
-	}
-
-	if filters > 1 {
-		action.Err = problem.BadRequest
-		return
 	}
 
 	if action.IncludeFailed {

--- a/services/horizon/internal/actions_transaction_test.go
+++ b/services/horizon/internal/actions_transaction_test.go
@@ -195,6 +195,12 @@ func TestTransactionActions_Index(t *testing.T) {
 		ht.Assert.PageOf(2, w.Body)
 	}
 
+	// Check extra params
+	w = ht.Get("/ledgers/100/transactions?account_id=GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	ht.Assert.Equal(400, w.Code)
+	w = ht.Get("/accounts/GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU/transactions?ledger_id=5")
+	ht.Assert.Equal(400, w.Code)
+
 	// regression: https://github.com/stellar/go/services/horizon/internal/issues/365
 	w = ht.Get("/transactions?limit=200")
 	ht.Require.Equal(200, w.Code)

--- a/services/horizon/internal/helpers.go
+++ b/services/horizon/internal/helpers.go
@@ -1,6 +1,8 @@
 package horizon
 
 import (
+	"encoding/hex"
+
 	"github.com/stellar/go/support/errors"
 )
 
@@ -27,4 +29,13 @@ func countNonEmpty(params ...interface{}) (int, error) {
 	}
 
 	return count, nil
+}
+
+func isValidTransactionHash(hash string) bool {
+	decoded, err := hex.DecodeString(hash)
+	if err != nil {
+		return false
+	}
+
+	return len(decoded) == 32
 }

--- a/services/horizon/internal/helpers.go
+++ b/services/horizon/internal/helpers.go
@@ -12,7 +12,11 @@ func countNonEmpty(params ...interface{}) (int, error) {
 		default:
 			return 0, errors.Errorf("unexpected type %T", param)
 		case int32:
-			if param != 0 {
+			if param != int32(0) {
+				count++
+			}
+		case int64:
+			if param != int64(0) {
 				count++
 			}
 		case string:

--- a/services/horizon/internal/helpers.go
+++ b/services/horizon/internal/helpers.go
@@ -1,0 +1,26 @@
+package horizon
+
+import (
+	"github.com/stellar/go/support/errors"
+)
+
+func countNonEmpty(params ...interface{}) (int, error) {
+	count := 0
+
+	for _, param := range params {
+		switch param := param.(type) {
+		default:
+			return 0, errors.Errorf("unexpected type %T", param)
+		case int32:
+			if param != 0 {
+				count++
+			}
+		case string:
+			if param != "" {
+				count++
+			}
+		}
+	}
+
+	return count, nil
+}


### PR DESCRIPTION
This commit fixes multiple issues with parameter handling in actions. The main problem was connected to `base.GetString` method that gets values from the URLParams, form or query string (in this order). It was possible that extra GET parameter changed the internal query. For example:
```
/ledgers/100/effects?account_id=GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H
```
doesn't return effects for ledger 100 but for a given account ID because if `account_id` is set the rest of the parameters are ignored (`switch`). Obviously, this is not how the actions should be used but for extra security I think this should be fixed.

To solve this issue:
* We count applied filters, if it's larger than 1 we return `400 Bad Request` response.
* We ensure that `tx_id` parameter is only checked in URL params. Additionally, we ensure that transaction hash is valid (if passed).
* We ensure that `include_failed` parameter is only checked in GET params.

This commit doesn't fix all the issues, for example such query is still returning invalid results:
```
/payments?account_id=GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H
```
but checking all the parameters require a larger set of changes and it would be good to release the most urgent changes in 0.17.4.