### PR TITLE
all: cache go dependency in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ install:
 - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 script:
 - dep ensure -v && ./support/scripts/run_tests
+cache:
+  directories:
+    - pkg/dep # cache dep downloaded dependencies
 before_deploy:
 - go run ./support/scripts/build_release_artifacts/main.go
 - ./support/scripts/push_snapshots_tag.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
 - dep ensure -v && ./support/scripts/run_tests
 cache:
   directories:
-    - pkg/dep # cache dep downloaded dependencies
+    - $GOPATH/pkg/dep # cache dep downloaded dependencies
 before_deploy:
 - go run ./support/scripts/build_release_artifacts/main.go
 - ./support/scripts/push_snapshots_tag.sh


### PR DESCRIPTION
It looks like build times are comparable vs. not using caching because some updates have been happening to the builds for the first few times. If these settle down, the caching will be about 40 secs faster per build. In addition the caching approach may be more redundant to network outages like the one we saw yesterday.