### PR TITLE
horizon: remove redundant field App in the rate limiter

### DIFF
--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -115,7 +115,7 @@ var configOpts = []*support.ConfigOption{
 	},
 	&support.ConfigOption{
 		Name:        "per-hour-rate-limit",
-		ConfigKey:   &config.RateLimitQuota,
+		ConfigKey:   &config.RateQuota,
 		OptType:     types.Int,
 		FlagDefault: 3600,
 		CustomSetValue: func(co *support.ConfigOption) {

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -115,7 +115,7 @@ var configOpts = []*support.ConfigOption{
 	},
 	&support.ConfigOption{
 		Name:        "per-hour-rate-limit",
-		ConfigKey:   &config.RateLimit,
+		ConfigKey:   &config.RateLimitQuota,
 		OptType:     types.Int,
 		FlagDefault: 3600,
 		CustomSetValue: func(co *support.ConfigOption) {

--- a/services/horizon/internal/actions_rate_limit_exceeded.go
+++ b/services/horizon/internal/actions_rate_limit_exceeded.go
@@ -10,12 +10,10 @@ import (
 // RateLimitExceededAction renders a 429 response
 type RateLimitExceededAction struct {
 	Action
-	App *App
 }
 
 func (action RateLimitExceededAction) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ap := &action.Action
 	ap.Prepare(w, r)
-	ap.App = action.App
 	problem.Render(action.R.Context(), action.W, hProblem.RateLimitExceeded)
 }

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -398,7 +398,7 @@ func (a *App) init() {
 	initWeb(a)
 
 	// web.rate-limiter
-	a.web.rateLimiter = initWebRateLimiter(a.config.RateLimitQuota)
+	a.web.rateLimiter = maybeInitWebRateLimiter(a.config.RateLimitQuota)
 
 	// web.middleware
 	initWebMiddleware(a)

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -398,7 +398,7 @@ func (a *App) init() {
 	initWeb(a)
 
 	// web.rate-limiter
-	a.web.rateLimiter = maybeInitWebRateLimiter(a.config.RateLimitQuota)
+	a.web.rateLimiter = maybeInitWebRateLimiter(a.config.RateQuota)
 
 	// web.middleware
 	initWebMiddleware(a)

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -398,7 +398,7 @@ func (a *App) init() {
 	initWeb(a)
 
 	// web.rate-limiter
-	a.web.rateLimiter = initWebRateLimiter(a.config.RateLimit)
+	a.web.rateLimiter = initWebRateLimiter(a.config.RateLimitQuota)
 
 	// web.middleware
 	initWebMiddleware(a)

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -398,7 +398,7 @@ func (a *App) init() {
 	initWeb(a)
 
 	// web.rate-limiter
-	initWebRateLimiter(a)
+	a.web.rateLimiter = initWebRateLimiter(a.config.RateLimit)
 
 	// web.middleware
 	initWebMiddleware(a)

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	MaxDBConnections       int
 	SSEUpdateFrequency     time.Duration
 	ConnectionTimeout      time.Duration
-	RateLimitQuota         *throttled.RateQuota
+	RateQuota              *throttled.RateQuota
 	RateLimitRedisKey      string
 	RedisURL               string
 	FriendbotURL           *url.URL

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	MaxDBConnections       int
 	SSEUpdateFrequency     time.Duration
 	ConnectionTimeout      time.Duration
-	RateLimit              *throttled.RateQuota
+	RateLimitQuota         *throttled.RateQuota
 	RateLimitRedisKey      string
 	RedisURL               string
 	FriendbotURL           *url.URL

--- a/services/horizon/internal/helpers_test.go
+++ b/services/horizon/internal/helpers_test.go
@@ -24,7 +24,7 @@ func NewTestConfig() Config {
 	return Config{
 		DatabaseURL:            test.DatabaseURL(),
 		StellarCoreDatabaseURL: test.StellarCoreDatabaseURL(),
-		RateLimit: &throttled.RateQuota{
+		RateLimitQuota: &throttled.RateQuota{
 			MaxRate:  throttled.PerHour(1000),
 			MaxBurst: 100,
 		},

--- a/services/horizon/internal/helpers_test.go
+++ b/services/horizon/internal/helpers_test.go
@@ -24,7 +24,7 @@ func NewTestConfig() Config {
 	return Config{
 		DatabaseURL:            test.DatabaseURL(),
 		StellarCoreDatabaseURL: test.StellarCoreDatabaseURL(),
-		RateLimitQuota: &throttled.RateQuota{
+		RateQuota: &throttled.RateQuota{
 			MaxRate:  throttled.PerHour(1000),
 			MaxBurst: 100,
 		},

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -24,7 +24,7 @@ func (suite *RateLimitMiddlewareTestSuite) SetupSuite() {
 
 func (suite *RateLimitMiddlewareTestSuite) SetupTest() {
 	suite.c = NewTestConfig()
-	suite.c.RateLimitQuota = &throttled.RateQuota{
+	suite.c.RateQuota = &throttled.RateQuota{
 		MaxRate:  throttled.PerHour(10),
 		MaxBurst: 9,
 	}
@@ -118,7 +118,7 @@ func TestRateLimit_Redis(t *testing.T) {
 	ht := StartHTTPTest(t, "base")
 	defer ht.Finish()
 	c := NewTestConfig()
-	c.RateLimitQuota = &throttled.RateQuota{
+	c.RateQuota = &throttled.RateQuota{
 		MaxRate:  throttled.PerHour(10),
 		MaxBurst: 9,
 	}

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -24,7 +24,7 @@ func (suite *RateLimitMiddlewareTestSuite) SetupSuite() {
 
 func (suite *RateLimitMiddlewareTestSuite) SetupTest() {
 	suite.c = NewTestConfig()
-	suite.c.RateLimit = &throttled.RateQuota{
+	suite.c.RateLimitQuota = &throttled.RateQuota{
 		MaxRate:  throttled.PerHour(10),
 		MaxBurst: 9,
 	}
@@ -118,7 +118,7 @@ func TestRateLimit_Redis(t *testing.T) {
 	ht := StartHTTPTest(t, "base")
 	defer ht.Finish()
 	c := NewTestConfig()
-	c.RateLimit = &throttled.RateQuota{
+	c.RateLimitQuota = &throttled.RateQuota{
 		MaxRate:  throttled.PerHour(10),
 		MaxBurst: 9,
 	}

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -179,12 +179,11 @@ func maybeInitWebRateLimiter(rateQuota *throttled.RateQuota) *throttled.HTTPRate
 		log.Fatalf("unable to create RateLimiter: %v", err)
 	}
 
-	httpRateLimiter := throttled.HTTPRateLimiter{
+	return &throttled.HTTPRateLimiter{
 		RateLimiter:   rateLimiter,
 		DeniedHandler: &RateLimitExceededAction{Action{}},
+		VaryBy:        VaryByRemoteIP{},
 	}
-	httpRateLimiter.VaryBy = VaryByRemoteIP{}
-	return &httpRateLimiter
 }
 
 type VaryByRemoteIP struct{}

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -3,7 +3,6 @@ package horizon
 import (
 	"compress/flate"
 	"database/sql"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -16,6 +15,7 @@ import (
 	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/txsub/sequence"
+	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/problem"
 	"github.com/throttled/throttled"
 )
@@ -168,23 +168,23 @@ func initWebActions(app *App) {
 	r.NotFound(NotFoundAction{}.Handle)
 }
 
-func initWebRateLimiter(app *App) {
+func initWebRateLimiter(rateQuota *throttled.RateQuota) *throttled.HTTPRateLimiter {
 	// Disabled
-	if app.config.RateLimit == nil {
-		return
+	if rateQuota == nil {
+		return nil
 	}
 
-	rateLimiter, err := throttled.NewGCRARateLimiter(50000, *app.config.RateLimit)
+	rateLimiter, err := throttled.NewGCRARateLimiter(50000, *rateQuota)
 	if err != nil {
-		panic(fmt.Errorf("unable to create RateLimiter"))
+		log.Fatalf("unable to create RateLimiter: %v", err)
 	}
 
 	httpRateLimiter := throttled.HTTPRateLimiter{
 		RateLimiter:   rateLimiter,
-		DeniedHandler: &RateLimitExceededAction{App: app, Action: Action{}},
+		DeniedHandler: &RateLimitExceededAction{Action{}},
 	}
 	httpRateLimiter.VaryBy = VaryByRemoteIP{}
-	app.web.rateLimiter = &httpRateLimiter
+	return &httpRateLimiter
 }
 
 type VaryByRemoteIP struct{}

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -20,6 +20,8 @@ import (
 	"github.com/throttled/throttled"
 )
 
+const LRUCacheSize = 50000
+
 // Web contains the http server related fields for horizon: the router,
 // rate limiter, etc.
 type Web struct {
@@ -174,7 +176,7 @@ func maybeInitWebRateLimiter(rateQuota *throttled.RateQuota) *throttled.HTTPRate
 		return nil
 	}
 
-	rateLimiter, err := throttled.NewGCRARateLimiter(50000, *rateQuota)
+	rateLimiter, err := throttled.NewGCRARateLimiter(LRUCacheSize, *rateQuota)
 	if err != nil {
 		log.Fatalf("unable to create RateLimiter: %v", err)
 	}

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -168,7 +168,7 @@ func initWebActions(app *App) {
 	r.NotFound(NotFoundAction{}.Handle)
 }
 
-func initWebRateLimiter(rateQuota *throttled.RateQuota) *throttled.HTTPRateLimiter {
+func maybeInitWebRateLimiter(rateQuota *throttled.RateQuota) *throttled.HTTPRateLimiter {
 	// Disabled
 	if rateQuota == nil {
 		return nil


### PR DESCRIPTION
Action.Prepare method has already assigned the app in the context to the
action, which makes This `App` field redundant.

This PR also renames `config.RateLimit` to `config.RateLimitQuota` to be specific.