### PR TITLE
exp/client/horizon: support fee_stats and account offers

### DIFF
--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -113,3 +113,26 @@ func (c *Client) Metrics() (metrics hProtocol.Metrics, err error) {
 	err = c.sendRequest(request, &metrics)
 	return
 }
+
+// FeeStats returns information about fees in the last 5 ledgers.
+// See https://www.stellar.org/developers/horizon/reference/endpoints/fee-stats.html
+func (c *Client) FeeStats() (feestats hProtocol.FeeStats, err error) {
+	request := feeStatsRequest{endpoint: "fee_stats"}
+	err = c.sendRequest(request, &feestats)
+	return
+}
+
+// AccountOffers returns information about offers made by an account on the SDEX
+// See https://www.stellar.org/developers/horizon/reference/endpoints/offers-for-account.html
+func (c *Client) AccountOffers(request OfferRequest) (offers hProtocol.OffersPage, err error) {
+	if request.ForAccount == "" {
+		err = errors.New("`ForAccount` parameter required")
+	}
+
+	if err != nil {
+		return
+	}
+
+	err = c.sendRequest(request, &offers)
+	return
+}

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -122,9 +122,9 @@ func (c *Client) FeeStats() (feestats hProtocol.FeeStats, err error) {
 	return
 }
 
-// AccountOffers returns information about offers made by an account on the SDEX
+// Offers returns information about offers made on the SDEX.
 // See https://www.stellar.org/developers/horizon/reference/endpoints/offers-for-account.html
-func (c *Client) AccountOffers(request OfferRequest) (offers hProtocol.OffersPage, err error) {
+func (c *Client) Offers(request OfferRequest) (offers hProtocol.OffersPage, err error) {
 	if request.ForAccount == "" {
 		err = errors.New("`ForAccount` parameter required")
 	}

--- a/exp/clients/horizon/fee_stats_request.go
+++ b/exp/clients/horizon/fee_stats_request.go
@@ -1,0 +1,13 @@
+package horizonclient
+
+import "github.com/stellar/go/support/errors"
+
+// BuildUrl returns the url for getting fee stats about a running horizon instance
+func (fr feeStatsRequest) BuildUrl() (endpoint string, err error) {
+	endpoint = fr.endpoint
+	if endpoint == "" {
+		err = errors.New("Invalid request. Too few parameters")
+	}
+
+	return
+}

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -78,7 +78,7 @@ type ClientInterface interface {
 	Metrics() (hProtocol.Metrics, error)
 	Stream(ctx context.Context, request StreamRequest, handler func(interface{})) error
 	FeeStats() (hProtocol.FeeStats, error)
-	AccountOffers(request OfferRequest) (hProtocol.OffersPage, error)
+	Offers(request OfferRequest) (hProtocol.OffersPage, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -77,6 +77,8 @@ type ClientInterface interface {
 	LedgerDetail(sequence uint32) (hProtocol.Ledger, error)
 	Metrics() (hProtocol.Metrics, error)
 	Stream(ctx context.Context, request StreamRequest, handler func(interface{})) error
+	FeeStats() (hProtocol.FeeStats, error)
+	AccountOffers(request OfferRequest) (hProtocol.OffersPage, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network
@@ -139,4 +141,16 @@ type LedgerRequest struct {
 
 type metricsRequest struct {
 	endpoint string
+}
+
+type feeStatsRequest struct {
+	endpoint string
+}
+
+// OfferRequest struct contains data for getting offers made by an account from an horizon server
+type OfferRequest struct {
+	ForAccount string
+	Order      Order
+	Cursor     Cursor
+	Limit      Limit
 }

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -126,6 +126,31 @@ func ExampleClient_Metrics() {
 
 }
 
+func ExampleClient_FeeStats() {
+
+	client := DefaultPublicNetClient
+	// horizon fees
+	fees, err := client.FeeStats()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(fees)
+
+}
+
+func ExampleClient_AccountOffers() {
+
+	client := DefaultPublicNetClient
+	offerRequest := OfferRequest{ForAccount: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU", Cursor: "now", Order: OrderDesc}
+	offers, err := client.AccountOffers(offerRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(offers)
+}
+
 func TestAccountDetail(t *testing.T) {
 	hmock := httptest.NewClient()
 	client := &Client{
@@ -450,6 +475,84 @@ func TestMetrics(t *testing.T) {
 		_, ok := err.(*Error)
 		assert.Equal(t, ok, false)
 	}
+}
+
+func TestFeeStats(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	// happy path
+	hmock.On(
+		"GET",
+		"https://localhost/fee_stats",
+	).ReturnString(200, feesResponse)
+
+	fees, err := client.FeeStats()
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, fees.LastLedger, 22606298)
+		assert.Equal(t, fees.LastLedgerBaseFee, 100)
+		assert.Equal(t, fees.LedgerCapacityUsage, 0.97)
+		assert.Equal(t, fees.MinAcceptedFee, 100)
+		assert.Equal(t, fees.ModeAcceptedFee, 250)
+		assert.Equal(t, fees.P10AcceptedFee, 100)
+		assert.Equal(t, fees.P20AcceptedFee, 100)
+		assert.Equal(t, fees.P30AcceptedFee, 250)
+		assert.Equal(t, fees.P40AcceptedFee, 250)
+		assert.Equal(t, fees.P50AcceptedFee, 250)
+		assert.Equal(t, fees.P60AcceptedFee, 1210)
+		assert.Equal(t, fees.P70AcceptedFee, 1221)
+		assert.Equal(t, fees.P80AcceptedFee, 1225)
+		assert.Equal(t, fees.P90AcceptedFee, 1225)
+		assert.Equal(t, fees.P95AcceptedFee, 1225)
+		assert.Equal(t, fees.P99AcceptedFee, 8000)
+
+	}
+
+	// connection error
+	hmock.On(
+		"GET",
+		"https://localhost/metrics",
+	).ReturnError("http.Client error")
+
+	_, err = client.Metrics()
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "http.Client error")
+		_, ok := err.(*Error)
+		assert.Equal(t, ok, false)
+	}
+}
+
+func TestOfferRequest(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	offersRequest := OfferRequest{ForAccount: "GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F"}
+
+	// account offers
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F/offers",
+	).ReturnString(200, offersResponse)
+
+	offers, err := client.AccountOffers(offersRequest)
+	if assert.NoError(t, err) {
+		assert.IsType(t, offers, hProtocol.OffersPage{})
+		record := offers.Embedded.Records[0]
+		assert.Equal(t, record.ID, int64(432323))
+		assert.Equal(t, record.Seller, "GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F")
+		assert.Equal(t, record.PT, "432323")
+		assert.Equal(t, record.Selling.Code, "ABC")
+		assert.Equal(t, record.Amount, "1999979.8700000")
+		assert.Equal(t, record.LastModifiedLedger, int32(103307))
+	}
+
 }
 
 var accountResponse = `{
@@ -845,5 +948,71 @@ var metricsResponse = `{
     "median": 18950996.5,
     "min": 3156355,
     "stddev": 79193338.90936844
+  }
+}`
+
+var feesResponse = `{
+  "last_ledger": "22606298",
+  "last_ledger_base_fee": "100",
+  "ledger_capacity_usage": "0.97",
+  "min_accepted_fee": "100",
+  "mode_accepted_fee": "250",
+  "p10_accepted_fee": "100",
+  "p20_accepted_fee": "100",
+  "p30_accepted_fee": "250",
+  "p40_accepted_fee": "250",
+  "p50_accepted_fee": "250",
+  "p60_accepted_fee": "1210",
+  "p70_accepted_fee": "1221",
+  "p80_accepted_fee": "1225",
+  "p90_accepted_fee": "1225",
+  "p95_accepted_fee": "1225",
+  "p99_accepted_fee": "8000"
+}`
+
+var offersResponse = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F/offers?cursor=&limit=10&order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F/offers?cursor=432323&limit=10&order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F/offers?cursor=432323&limit=10&order=desc"
+    }
+  },
+  "_embedded": {
+    "records": [
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/offers/432323"
+          },
+          "offer_maker": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F"
+          }
+        },
+        "id": 432323,
+        "paging_token": "432323",
+        "seller": "GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F",
+        "selling": {
+          "asset_type": "credit_alphanum4",
+          "asset_code": "ABC",
+          "asset_issuer": "GDP6QEA4A5CRNGUIGYHHFETDPNEESIZFW53RVISXGSALI7KXNUC4YBWD"
+        },
+        "buying": {
+          "asset_type": "native"
+        },
+        "amount": "1999979.8700000",
+        "price_r": {
+          "n": 100,
+          "d": 1
+        },
+        "price": "100.0000000",
+        "last_modified_ledger": 103307,
+        "last_modified_time": "2019-03-05T13:23:50Z"
+      }
+    ]
   }
 }`

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -139,11 +139,11 @@ func ExampleClient_FeeStats() {
 
 }
 
-func ExampleClient_AccountOffers() {
+func ExampleClient_Offers() {
 
 	client := DefaultPublicNetClient
 	offerRequest := OfferRequest{ForAccount: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU", Cursor: "now", Order: OrderDesc}
-	offers, err := client.AccountOffers(offerRequest)
+	offers, err := client.Offers(offerRequest)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -496,20 +496,19 @@ func TestFeeStats(t *testing.T) {
 		assert.Equal(t, fees.LastLedger, 22606298)
 		assert.Equal(t, fees.LastLedgerBaseFee, 100)
 		assert.Equal(t, fees.LedgerCapacityUsage, 0.97)
-		assert.Equal(t, fees.MinAcceptedFee, 100)
+		assert.Equal(t, fees.MinAcceptedFee, 130)
 		assert.Equal(t, fees.ModeAcceptedFee, 250)
-		assert.Equal(t, fees.P10AcceptedFee, 100)
-		assert.Equal(t, fees.P20AcceptedFee, 100)
-		assert.Equal(t, fees.P30AcceptedFee, 250)
-		assert.Equal(t, fees.P40AcceptedFee, 250)
-		assert.Equal(t, fees.P50AcceptedFee, 250)
-		assert.Equal(t, fees.P60AcceptedFee, 1210)
-		assert.Equal(t, fees.P70AcceptedFee, 1221)
-		assert.Equal(t, fees.P80AcceptedFee, 1225)
-		assert.Equal(t, fees.P90AcceptedFee, 1225)
-		assert.Equal(t, fees.P95AcceptedFee, 1225)
+		assert.Equal(t, fees.P10AcceptedFee, 150)
+		assert.Equal(t, fees.P20AcceptedFee, 200)
+		assert.Equal(t, fees.P30AcceptedFee, 300)
+		assert.Equal(t, fees.P40AcceptedFee, 400)
+		assert.Equal(t, fees.P50AcceptedFee, 500)
+		assert.Equal(t, fees.P60AcceptedFee, 1000)
+		assert.Equal(t, fees.P70AcceptedFee, 2000)
+		assert.Equal(t, fees.P80AcceptedFee, 3000)
+		assert.Equal(t, fees.P90AcceptedFee, 4000)
+		assert.Equal(t, fees.P95AcceptedFee, 5000)
 		assert.Equal(t, fees.P99AcceptedFee, 8000)
-
 	}
 
 	// connection error
@@ -541,7 +540,7 @@ func TestOfferRequest(t *testing.T) {
 		"https://localhost/accounts/GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F/offers",
 	).ReturnString(200, offersResponse)
 
-	offers, err := client.AccountOffers(offersRequest)
+	offers, err := client.Offers(offersRequest)
 	if assert.NoError(t, err) {
 		assert.IsType(t, offers, hProtocol.OffersPage{})
 		record := offers.Embedded.Records[0]
@@ -552,7 +551,6 @@ func TestOfferRequest(t *testing.T) {
 		assert.Equal(t, record.Amount, "1999979.8700000")
 		assert.Equal(t, record.LastModifiedLedger, int32(103307))
 	}
-
 }
 
 var accountResponse = `{
@@ -955,18 +953,18 @@ var feesResponse = `{
   "last_ledger": "22606298",
   "last_ledger_base_fee": "100",
   "ledger_capacity_usage": "0.97",
-  "min_accepted_fee": "100",
+  "min_accepted_fee": "130",
   "mode_accepted_fee": "250",
-  "p10_accepted_fee": "100",
-  "p20_accepted_fee": "100",
-  "p30_accepted_fee": "250",
-  "p40_accepted_fee": "250",
-  "p50_accepted_fee": "250",
-  "p60_accepted_fee": "1210",
-  "p70_accepted_fee": "1221",
-  "p80_accepted_fee": "1225",
-  "p90_accepted_fee": "1225",
-  "p95_accepted_fee": "1225",
+  "p10_accepted_fee": "150",
+  "p20_accepted_fee": "200",
+  "p30_accepted_fee": "300",
+  "p40_accepted_fee": "400",
+  "p50_accepted_fee": "500",
+  "p60_accepted_fee": "1000",
+  "p70_accepted_fee": "2000",
+  "p80_accepted_fee": "3000",
+  "p90_accepted_fee": "4000",
+  "p95_accepted_fee": "5000",
   "p99_accepted_fee": "8000"
 }`
 

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -64,7 +64,7 @@ func (m *MockClient) FeeStats() (hProtocol.FeeStats, error) {
 	return a.Get(0).(hProtocol.FeeStats), a.Error(1)
 }
 
-func (m *MockClient) AccountOffers(request OfferRequest) (hProtocol.OffersPage, error) {
+func (m *MockClient) Offers(request OfferRequest) (hProtocol.OffersPage, error) {
 	a := m.Called(request)
 	return a.Get(0).(hProtocol.OffersPage), a.Error(1)
 }

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -59,5 +59,15 @@ func (m *MockClient) Metrics() (hProtocol.Metrics, error) {
 	return a.Get(0).(hProtocol.Metrics), a.Error(1)
 }
 
+func (m *MockClient) FeeStats() (hProtocol.FeeStats, error) {
+	a := m.Called()
+	return a.Get(0).(hProtocol.FeeStats), a.Error(1)
+}
+
+func (m *MockClient) AccountOffers(request OfferRequest) (hProtocol.OffersPage, error) {
+	a := m.Called(request)
+	return a.Get(0).(hProtocol.OffersPage), a.Error(1)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}

--- a/exp/clients/horizon/offer_request.go
+++ b/exp/clients/horizon/offer_request.go
@@ -1,0 +1,32 @@
+package horizonclient
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/stellar/go/support/errors"
+)
+
+// BuildUrl creates the endpoint to be queried based on the data in the OfferRequest struct.
+func (or OfferRequest) BuildUrl() (endpoint string, err error) {
+	endpoint = fmt.Sprintf(
+		"accounts/%s/offers",
+		or.ForAccount,
+	)
+
+	queryParams := addQueryParams(or.Cursor, or.Limit, or.Order)
+	if queryParams != "" {
+		endpoint = fmt.Sprintf(
+			"%s?%s",
+			endpoint,
+			queryParams,
+		)
+	}
+
+	_, err = url.Parse(endpoint)
+	if err != nil {
+		err = errors.Wrap(err, "failed to parse endpoint")
+	}
+
+	return endpoint, err
+}

--- a/exp/clients/horizon/offer_request_test.go
+++ b/exp/clients/horizon/offer_request_test.go
@@ -1,0 +1,25 @@
+package horizonclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOfferRequestBuildUrl(t *testing.T) {
+
+	er := OfferRequest{ForAccount: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
+	endpoint, err := er.BuildUrl()
+
+	// It should return valid offers endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/offers", endpoint)
+
+	er = OfferRequest{ForAccount: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU", Cursor: "now", Order: OrderDesc}
+	endpoint, err = er.BuildUrl()
+
+	// It should return valid offers endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/offers?cursor=now&order=desc", endpoint)
+}

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -582,3 +582,24 @@ type Metrics struct {
 	TxsubSucceeded         LogMetric      `json:"txsub.succeeded"`
 	TxsubTotal             LogTotalMetric `json:"txsub.total"`
 }
+
+// FeeStats represents a response of fees from horizon
+// To do: implement fee suggestions if agreement is reached in https://github.com/stellar/go/issues/926
+type FeeStats struct {
+	LastLedger          int     `json:"last_ledger,string"`
+	LastLedgerBaseFee   int     `json:"last_ledger_base_fee,string"`
+	LedgerCapacityUsage float64 `json:"ledger_capacity_usage,string"`
+	MinAcceptedFee      int     `json:"min_accepted_fee,string"`
+	ModeAcceptedFee     int     `json:"mode_accepted_fee,string"`
+	P10AcceptedFee      int     `json:"p10_accepted_fee,string"`
+	P20AcceptedFee      int     `json:"p20_accepted_fee,string"`
+	P30AcceptedFee      int     `json:"p30_accepted_fee,string"`
+	P40AcceptedFee      int     `json:"p40_accepted_fee,string"`
+	P50AcceptedFee      int     `json:"p50_accepted_fee,string"`
+	P60AcceptedFee      int     `json:"p60_accepted_fee,string"`
+	P70AcceptedFee      int     `json:"p70_accepted_fee,string"`
+	P80AcceptedFee      int     `json:"p80_accepted_fee,string"`
+	P90AcceptedFee      int     `json:"p90_accepted_fee,string"`
+	P95AcceptedFee      int     `json:"p95_accepted_fee,string"`
+	P99AcceptedFee      int     `json:"p99_accepted_fee,string"`
+}


### PR DESCRIPTION
This PR  adds support for getting fee_stats and getting offers made by an account from horizon.
This closes #954 