### PR TITLE
exp/txnbuild: user-facing function to wrap delete trustline functionality

### DIFF
--- a/exp/txnbuild/change_trust.go
+++ b/exp/txnbuild/change_trust.go
@@ -14,8 +14,9 @@ type ChangeTrust struct {
 	xdrOp xdr.ChangeTrustOp
 }
 
-// NewRemoveTrust returns a ChangeTrust operation to remove the trustline of the described asset.
-func NewRemoveTrust(issuedAsset *Asset) ChangeTrust {
+// NewRemoveTrustlineOp returns a ChangeTrust operation to remove the trustline of the described asset,
+// by setting the limit to "0".
+func NewRemoveTrustlineOp(issuedAsset *Asset) ChangeTrust {
 	return ChangeTrust{
 		Line:  issuedAsset,
 		Limit: "0",

--- a/exp/txnbuild/change_trust.go
+++ b/exp/txnbuild/change_trust.go
@@ -14,6 +14,14 @@ type ChangeTrust struct {
 	xdrOp xdr.ChangeTrustOp
 }
 
+// NewRemoveTrust returns a ChangeTrust operation to remove the trustline of the described asset.
+func NewRemoveTrust(issuedAsset *Asset) ChangeTrust {
+	return ChangeTrust{
+		Line:  issuedAsset,
+		Limit: "0",
+	}
+}
+
 // BuildXDR for ChangeTrust returns a fully configured XDR Operation.
 func (ct *ChangeTrust) BuildXDR() (xdr.Operation, error) {
 	var err error

--- a/exp/txnbuild/cmd/txnbuild_examples/main.go
+++ b/exp/txnbuild/cmd/txnbuild_examples/main.go
@@ -98,7 +98,7 @@ func exampleChangeTrustDeleteTrustline(client *horizon.Client, mock bool) horizo
 	sourceAccount := mapAccounts(horizonSourceAccount)
 
 	issuedAsset := txnbuild.NewAsset("ABCD", keys[1].Address)
-	removeTrust := txnbuild.NewRemoveTrust(issuedAsset)
+	removeTrust := txnbuild.NewRemoveTrustlineOp(issuedAsset)
 
 	tx := txnbuild.Transaction{
 		SourceAccount: sourceAccount,
@@ -166,8 +166,7 @@ func exampleManageDataRemoveDataEntry(client *horizon.Client, mock bool) horizon
 	txeBase64 := buildSignEncode(tx, keys[0].Keypair)
 	log.Println("Base 64 TX: ", txeBase64)
 
-	resp := submit(client, txeBase64, mock)
-	return resp
+	return submit(client, txeBase64, mock)
 }
 
 func exampleManageData(client *horizon.Client, mock bool) horizon.TransactionSuccess {
@@ -191,8 +190,7 @@ func exampleManageData(client *horizon.Client, mock bool) horizon.TransactionSuc
 	txeBase64 := buildSignEncode(tx, keys[0].Keypair)
 	log.Println("Base 64 TX: ", txeBase64)
 
-	resp := submit(client, txeBase64, mock)
-	return resp
+	return submit(client, txeBase64, mock)
 }
 
 func exampleAccountMerge(client *horizon.Client, mock bool) horizon.TransactionSuccess {
@@ -215,8 +213,7 @@ func exampleAccountMerge(client *horizon.Client, mock bool) horizon.TransactionS
 	txeBase64 := buildSignEncode(tx, keys[0].Keypair)
 	log.Println("Base 64 TX: ", txeBase64)
 
-	resp := submit(client, txeBase64, mock)
-	return resp
+	return submit(client, txeBase64, mock)
 }
 
 func exampleBumpSequence(client *horizon.Client, mock bool) horizon.TransactionSuccess {
@@ -240,8 +237,7 @@ func exampleBumpSequence(client *horizon.Client, mock bool) horizon.TransactionS
 	txeBase64 := buildSignEncode(tx, keys[1].Keypair)
 	log.Println("Base 64 TX: ", txeBase64)
 
-	resp := submit(client, txeBase64, mock)
-	return resp
+	return submit(client, txeBase64, mock)
 }
 
 func exampleSendNonNative(client *horizon.Client, mock bool) horizon.TransactionSuccess {
@@ -265,9 +261,7 @@ func exampleSendNonNative(client *horizon.Client, mock bool) horizon.Transaction
 	txeBase64 := buildSignEncode(tx, keys[0].Keypair)
 	log.Println("Base 64 TX: ", txeBase64)
 
-	resp := submit(client, txeBase64, mock)
-
-	return resp
+	return submit(client, txeBase64, mock)
 }
 
 func exampleSendLumens(client *horizon.Client, mock bool) horizon.TransactionSuccess {
@@ -290,9 +284,7 @@ func exampleSendLumens(client *horizon.Client, mock bool) horizon.TransactionSuc
 	txeBase64 := buildSignEncode(tx, keys[0].Keypair)
 	log.Println("Base 64 TX: ", txeBase64)
 
-	resp := submit(client, txeBase64, mock)
-
-	return resp
+	return submit(client, txeBase64, mock)
 }
 
 func exampleCreateAccount(client *horizon.Client, mock bool) horizon.TransactionSuccess {
@@ -317,9 +309,7 @@ func exampleCreateAccount(client *horizon.Client, mock bool) horizon.Transaction
 	txeBase64 := buildSignEncode(tx, keys[0].Keypair)
 	log.Println("Base 64 TX: ", txeBase64)
 
-	resp := submit(client, txeBase64, mock)
-
-	return resp
+	return submit(client, txeBase64, mock)
 }
 
 func submit(client *horizon.Client, txeBase64 string, mock bool) (resp horizon.TransactionSuccess) {
@@ -359,9 +349,7 @@ func dieIfError(desc string, err error) {
 }
 
 func mockSuccess() horizon.TransactionSuccess {
-	resp := horizon.TransactionSuccess{}
-
-	return resp
+	return horizon.TransactionSuccess{}
 }
 
 func verify(received string) {

--- a/exp/txnbuild/cmd/txnbuild_examples/main.go
+++ b/exp/txnbuild/cmd/txnbuild_examples/main.go
@@ -60,7 +60,8 @@ func main() {
 	// resp := exampleManageData(client, false)
 	// resp := exampleManageDataRemoveDataEntry(client, false)
 	// resp := exampleSetOptions(client, true)
-	resp := exampleChangeTrust(client, true)
+	// resp := exampleChangeTrust(client, false)
+	resp := exampleChangeTrustDeleteTrustline(client, true)
 	fmt.Println(resp.TransactionSuccessToString())
 }
 
@@ -79,6 +80,29 @@ func exampleChangeTrust(client *horizon.Client, mock bool) horizon.TransactionSu
 	tx := txnbuild.Transaction{
 		SourceAccount: sourceAccount,
 		Operations:    []txnbuild.Operation{&changeTrust},
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	txeBase64 := buildSignEncode(tx, keys[0].Keypair)
+	log.Println("Base 64 TX: ", txeBase64)
+
+	resp := submit(client, txeBase64, mock)
+
+	return resp
+}
+
+func exampleChangeTrustDeleteTrustline(client *horizon.Client, mock bool) horizon.TransactionSuccess {
+	keys := initKeys()
+	horizonSourceAccount, err := client.LoadAccount(keys[0].Address)
+	dieIfError("loadaccount", err)
+	sourceAccount := mapAccounts(horizonSourceAccount)
+
+	issuedAsset := txnbuild.NewAsset("ABCD", keys[1].Address)
+	removeTrust := txnbuild.NewRemoveTrust(issuedAsset)
+
+	tx := txnbuild.Transaction{
+		SourceAccount: sourceAccount,
+		Operations:    []txnbuild.Operation{&removeTrust},
 		Network:       network.TestNetworkPassphrase,
 	}
 

--- a/exp/txnbuild/transaction_test.go
+++ b/exp/txnbuild/transaction_test.go
@@ -400,9 +400,9 @@ func TestChangeTrust(t *testing.T) {
 		SequenceNumber: 40385577484348,
 	}
 
-	issuerAsset := NewAsset("ABCD", kp1.Address())
+	issuedAsset := NewAsset("ABCD", kp1.Address())
 	changeTrust := ChangeTrust{
-		Line:  issuerAsset,
+		Line:  issuedAsset,
 		Limit: "10",
 	}
 
@@ -425,9 +425,9 @@ func TestChangeTrustNativeAssetNotAllowed(t *testing.T) {
 		SequenceNumber: 40385577484348,
 	}
 
-	issuerAsset := NewNativeAsset()
+	issuedAsset := NewNativeAsset()
 	changeTrust := ChangeTrust{
-		Line:  issuerAsset,
+		Line:  issuedAsset,
 		Limit: "10",
 	}
 
@@ -440,4 +440,27 @@ func TestChangeTrustNativeAssetNotAllowed(t *testing.T) {
 	err := tx.Build()
 	expectedErrMsg := "Failed to build operation *txnbuild.ChangeTrust: Trustline cannot be extended to a native (XLM) asset"
 	require.EqualError(t, err, expectedErrMsg, "No trustlines for native assets")
+}
+
+func TestChangeTrustDeleteTrustline(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+
+	sourceAccount := Account{
+		ID:             kp0.Address(),
+		SequenceNumber: 40385577484354,
+	}
+
+	issuedAsset := NewAsset("ABCD", kp1.Address())
+	removeTrust := NewRemoveTrust(issuedAsset)
+
+	tx := Transaction{
+		SourceAccount: sourceAccount,
+		Operations:    []Operation{&removeTrust},
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	received := buildSignEncode(tx, kp0, t)
+	expected := "AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAAJLsAAABDAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABQUJDRAAAAAAlyvHaD8duz+iEXkJUUbsHkklIlH46oMrMMYrt0odkfgAAAAAAAAAAAAAAAAAAAAHqLnLFAAAAQEop/qQ5+2GTSQxZWzL4BPKsAi47VVNxnbtWgSAZvJOqz0yG0GJaTpUUYskuEo1haBg0UDbQF4M0PIK4l0Pzegg="
+	assert.Equal(t, expected, received, "Base 64 XDR should match")
 }

--- a/exp/txnbuild/transaction_test.go
+++ b/exp/txnbuild/transaction_test.go
@@ -400,9 +400,8 @@ func TestChangeTrust(t *testing.T) {
 		SequenceNumber: 40385577484348,
 	}
 
-	issuedAsset := NewAsset("ABCD", kp1.Address())
 	changeTrust := ChangeTrust{
-		Line:  issuedAsset,
+		Line:  NewAsset("ABCD", kp1.Address()),
 		Limit: "10",
 	}
 
@@ -425,9 +424,8 @@ func TestChangeTrustNativeAssetNotAllowed(t *testing.T) {
 		SequenceNumber: 40385577484348,
 	}
 
-	issuedAsset := NewNativeAsset()
 	changeTrust := ChangeTrust{
-		Line:  issuedAsset,
+		Line:  NewNativeAsset(),
 		Limit: "10",
 	}
 
@@ -452,7 +450,7 @@ func TestChangeTrustDeleteTrustline(t *testing.T) {
 	}
 
 	issuedAsset := NewAsset("ABCD", kp1.Address())
-	removeTrust := NewRemoveTrust(issuedAsset)
+	removeTrust := NewRemoveTrustlineOp(issuedAsset)
 
 	tx := Transaction{
 		SourceAccount: sourceAccount,


### PR DESCRIPTION
Very small PR to abstract the details of how you delete trustlines. Part of #982.