### PR TITLE
txnbuild allow trust (#982)

### DIFF
--- a/exp/txnbuild/allow_trust.go
+++ b/exp/txnbuild/allow_trust.go
@@ -1,0 +1,48 @@
+package txnbuild
+
+import (
+	"github.com/stellar/go/amount"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+// AllowTrust represents the Stellar allow trust operation. See
+// https://www.stellar.org/developers/guides/concepts/list-of-operations.html
+type AllowTrust struct {
+	Trustor   string
+	Type      *Asset
+	Authorize bool
+	xdrOp     xdr.AllowTrustOp
+}
+
+// BuildXDR for AllowTrust returns a fully configured XDR Operation.
+func (at *AllowTrust) BuildXDR() (xdr.Operation, error) {
+	var err error
+	err = at.xdrOp.Trustor.SetAddress(at.Trustor)
+	if err != nil {
+		return xdr.Operation{}, errors.Wrap(err, "Failed to set trustor address")
+	}
+
+	if at.Type.IsNative() {
+		return xdr.Operation{}, errors.New("Trustline doesn't exist for a native (XLM) asset")
+	}
+
+	// TODO: AllowTrust has a special asset op type. Need to map to it
+	at.xdrOp.Asset, err = ct.Line.ToXDR()
+	if err != nil {
+		return xdr.Operation{}, errors.Wrap(err, "Can't convert asset for trustline to XDR")
+	}
+
+	ct.xdrOp.Limit, err = amount.Parse(ct.Limit)
+	if err != nil {
+		return xdr.Operation{}, errors.Wrap(err, "Failed to parse limit amount")
+	}
+
+	opType := xdr.OperationTypeChangeTrust
+	body, err := xdr.NewOperationBody(opType, ct.xdrOp)
+	if err != nil {
+		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
+	}
+
+	return xdr.Operation{Body: body}, nil
+}

--- a/exp/txnbuild/asset.go
+++ b/exp/txnbuild/asset.go
@@ -57,3 +57,25 @@ func (a *Asset) ToXDR() (xdr.Asset, error) {
 
 	return xdrAsset, nil
 }
+
+// ToXDRAllowTrustOpAsset for Asset produces a corresponding XDR "allow trust" asset, used by the
+// XDR allow trust operation.
+func (a *Asset) ToXDRAllowTrustOpAsset() (xdr.AllowTrustOpAsset, error) {
+	length := len(a.Code)
+
+	// TODO: This code could be moved to XDR library as is done with xdr.Asset()
+	switch {
+	case length >= 1 && length <= 4:
+		var code [4]byte
+		byteArray := []byte(a.Code)
+		copy(code[:], byteArray[0:length])
+		return xdr.NewAllowTrustOpAsset(xdr.AssetTypeAssetTypeCreditAlphanum4, code)
+	case length >= 5 && length <= 12:
+		var code [12]byte
+		byteArray := []byte(a.Code)
+		copy(code[:], byteArray[0:length])
+		return xdr.NewAllowTrustOpAsset(xdr.AssetTypeAssetTypeCreditAlphanum12, code)
+	default:
+		return xdr.AllowTrustOpAsset{}, errors.New("Asset code length is invalid")
+	}
+}

--- a/exp/txnbuild/transaction_test.go
+++ b/exp/txnbuild/transaction_test.go
@@ -462,3 +462,30 @@ func TestChangeTrustDeleteTrustline(t *testing.T) {
 	expected := "AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAAJLsAAABDAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABQUJDRAAAAAAlyvHaD8duz+iEXkJUUbsHkklIlH46oMrMMYrt0odkfgAAAAAAAAAAAAAAAAAAAAHqLnLFAAAAQEop/qQ5+2GTSQxZWzL4BPKsAi47VVNxnbtWgSAZvJOqz0yG0GJaTpUUYskuEo1haBg0UDbQF4M0PIK4l0Pzegg="
 	assert.Equal(t, expected, received, "Base 64 XDR should match")
 }
+
+func TestAllowTrust(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+
+	sourceAccount := Account{
+		ID:             kp0.Address(),
+		SequenceNumber: 40385577484366,
+	}
+
+	issuedAsset := NewAsset("ABCD", kp1.Address())
+	allowTrust := AllowTrust{
+		Trustor:   kp1.Address(),
+		Type:      issuedAsset,
+		Authorize: true,
+	}
+
+	tx := Transaction{
+		SourceAccount: sourceAccount,
+		Operations:    []Operation{&allowTrust},
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	received := buildSignEncode(tx, kp0, t)
+	expected := "AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAAJLsAAABPAAAAAAAAAAAAAAABAAAAAAAAAAcAAAAAJcrx2g/Hbs/ohF5CVFG7B5JJSJR+OqDKzDGK7dKHZH4AAAABQUJDRAAAAAEAAAAAAAAAAeoucsUAAABAlP4A5hdKUQU18MY6wmf4GugGNnCUklsV9/aRoTv8Q2yw7skm5nkFExnjhgEya6AM7iCR6oaf2C0VhrU4oEEODQ=="
+	assert.Equal(t, expected, received, "Base 64 XDR should match")
+}


### PR DESCRIPTION
Adds allow trust operation to `txnbuild`. Verified by running operation manually and inspecting returned XDR for flag change.

As usual, feel free to skip scratchpad code in `/txnbuild_examples/main.go`.

This closes #982.