### PR TITLE
horizon: hide is_authorized flag for native asset

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -147,7 +147,7 @@ type Balance struct {
 	BuyingLiabilities  string `json:"buying_liabilities"`
 	SellingLiabilities string `json:"selling_liabilities"`
 	LastModifiedLedger uint32 `json:"last_modified_ledger,omitempty"`
-	IsAuthorized       bool   `json:"is_authorized,omitempty"`
+	IsAuthorized       *bool  `json:"is_authorized,omitempty"`
 	base.Asset
 }
 

--- a/services/horizon/internal/actions_account_test.go
+++ b/services/horizon/internal/actions_account_test.go
@@ -25,6 +25,7 @@ func TestAccountActions_Show(t *testing.T) {
 		for _, balance := range result.Balances {
 			if balance.Type == "native" {
 				ht.Assert.Equal(uint32(0), balance.LastModifiedLedger)
+				ht.Assert.Nil(balance.IsAuthorized)
 			} else {
 				ht.Assert.NotEqual(uint32(0), balance.LastModifiedLedger)
 			}

--- a/services/horizon/internal/resourceadapter/balance.go
+++ b/services/horizon/internal/resourceadapter/balance.go
@@ -21,9 +21,8 @@ func PopulateBalance(dest *Balance, row core.Trustline) (err error) {
 	dest.Issuer = row.Issuer
 	dest.Code = row.Assetcode
 	dest.LastModifiedLedger = row.LastModified
-	if row.IsAuthorized() {
-		dest.IsAuthorized = true
-	}
+	isAuthorized := row.IsAuthorized()
+	dest.IsAuthorized = &isAuthorized
 	return
 }
 
@@ -40,6 +39,6 @@ func PopulateNativeBalance(dest *Balance, stroops, buyingLiabilities, sellingLia
 	dest.Limit = ""
 	dest.Issuer = ""
 	dest.Code = ""
-	dest.IsAuthorized = true
+	dest.IsAuthorized = nil
 	return
 }

--- a/services/horizon/internal/resourceadapter/balance_test.go
+++ b/services/horizon/internal/resourceadapter/balance_test.go
@@ -39,7 +39,8 @@ func TestPopulateBalance(t *testing.T) {
 	assert.Equal(t, "0.0000100", want.Limit)
 	assert.Equal(t, "", want.Issuer)
 	assert.Equal(t, testAssetCode1, want.Code)
-	assert.Equal(t, true, want.IsAuthorized)
+	vTrue := true
+	assert.Equal(t, &vTrue, want.IsAuthorized)
 
 	want = Balance{}
 	err = PopulateBalance(&want, unauthorizedTrustline)
@@ -49,7 +50,8 @@ func TestPopulateBalance(t *testing.T) {
 	assert.Equal(t, "0.0000100", want.Limit)
 	assert.Equal(t, "", want.Issuer)
 	assert.Equal(t, testAssetCode2, want.Code)
-	assert.Equal(t, false, want.IsAuthorized)
+	vFalse := false
+	assert.Equal(t, &vFalse, want.IsAuthorized)
 }
 
 func TestPopulateNativeBalance(t *testing.T) {
@@ -63,5 +65,5 @@ func TestPopulateNativeBalance(t *testing.T) {
 	assert.Equal(t, "", want.Limit)
 	assert.Equal(t, "", want.Issuer)
 	assert.Equal(t, "", want.Code)
-	assert.Equal(t, true, want.IsAuthorized)
+	assert.Nil(t, want.IsAuthorized)
 }


### PR DESCRIPTION
We don't want to show the flag for XLM.