### PR TITLE
horizon: remove unused param in populating account

### DIFF
--- a/services/horizon/internal/actions_account.go
+++ b/services/horizon/internal/actions_account.go
@@ -4,7 +4,6 @@ import (
 	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
-	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 	"github.com/stellar/go/support/render/hal"
@@ -22,7 +21,6 @@ var _ actions.SingleObjectStreamer = (*AccountShowAction)(nil)
 type AccountShowAction struct {
 	Action
 	Address        string
-	HistoryRecord  history.Account
 	CoreData       []core.AccountData
 	CoreRecord     core.Account
 	CoreSigners    []core.Signer
@@ -67,16 +65,6 @@ func (action *AccountShowAction) loadRecord() {
 	}
 
 	action.Err = action.CoreQ().TrustlinesByAddress(&action.CoreTrustlines, action.Address)
-	if action.Err != nil {
-		return
-	}
-
-	action.Err = action.HistoryQ().AccountByAddress(&action.HistoryRecord, action.Address)
-	// Do not fail when we cannot find the history record... it probably just
-	// means that the account was created outside of our known history range.
-	if action.HistoryQ().NoRows(action.Err) {
-		action.Err = nil
-	}
 }
 
 func (action *AccountShowAction) loadResource() {
@@ -87,6 +75,5 @@ func (action *AccountShowAction) loadResource() {
 		action.CoreData,
 		action.CoreSigners,
 		action.CoreTrustlines,
-		action.HistoryRecord,
 	)
 }

--- a/services/horizon/internal/resourceadapter/account.go
+++ b/services/horizon/internal/resourceadapter/account.go
@@ -6,8 +6,8 @@ import (
 
 	. "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
-	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/httpx"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"
 )
 
@@ -19,8 +19,7 @@ func PopulateAccount(
 	cd []core.AccountData,
 	cs []core.Signer,
 	ct []core.Trustline,
-	ha history.Account,
-) (err error) {
+) error {
 	dest.ID = ca.Accountid
 	dest.AccountID = ca.Accountid
 	dest.Sequence = ca.Seqnum
@@ -35,16 +34,16 @@ func PopulateAccount(
 	// populate balances
 	dest.Balances = make([]Balance, len(ct)+1)
 	for i, tl := range ct {
-		err = PopulateBalance(&dest.Balances[i], tl)
+		err := PopulateBalance(&dest.Balances[i], tl)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "populating balance")
 		}
 	}
 
 	// add native balance
-	err = PopulateNativeBalance(&dest.Balances[len(dest.Balances)-1], ca.Balance, ca.BuyingLiabilities, ca.SellingLiabilities)
+	err := PopulateNativeBalance(&dest.Balances[len(dest.Balances)-1], ca.Balance, ca.BuyingLiabilities, ca.SellingLiabilities)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "populating native balance")
 	}
 
 	// populate data

--- a/services/horizon/internal/resourceadapter/balance.go
+++ b/services/horizon/internal/resourceadapter/balance.go
@@ -5,13 +5,14 @@ import (
 	. "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/assets"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 
 func PopulateBalance(dest *Balance, row core.Trustline) (err error) {
 	dest.Type, err = assets.String(row.Assettype)
 	if err != nil {
-		return
+		return errors.Wrap(err, "getting the string representation from the provided xdr asset type")
 	}
 
 	dest.Balance = amount.String(row.Balance)
@@ -29,7 +30,7 @@ func PopulateBalance(dest *Balance, row core.Trustline) (err error) {
 func PopulateNativeBalance(dest *Balance, stroops, buyingLiabilities, sellingLiabilities xdr.Int64) (err error) {
 	dest.Type, err = assets.String(xdr.AssetTypeAssetTypeNative)
 	if err != nil {
-		return
+		return errors.Wrap(err, "getting the string representation from the provided xdr asset type")
 	}
 
 	dest.Balance = amount.String(stroops)

--- a/services/horizon/internal/resourceadapter/balance_test.go
+++ b/services/horizon/internal/resourceadapter/balance_test.go
@@ -39,8 +39,7 @@ func TestPopulateBalance(t *testing.T) {
 	assert.Equal(t, "0.0000100", want.Limit)
 	assert.Equal(t, "", want.Issuer)
 	assert.Equal(t, testAssetCode1, want.Code)
-	vTrue := true
-	assert.Equal(t, &vTrue, want.IsAuthorized)
+	assert.Equal(t, true, *want.IsAuthorized)
 
 	want = Balance{}
 	err = PopulateBalance(&want, unauthorizedTrustline)
@@ -50,8 +49,7 @@ func TestPopulateBalance(t *testing.T) {
 	assert.Equal(t, "0.0000100", want.Limit)
 	assert.Equal(t, "", want.Issuer)
 	assert.Equal(t, testAssetCode2, want.Code)
-	vFalse := false
-	assert.Equal(t, &vFalse, want.IsAuthorized)
+	assert.Equal(t, false, *want.IsAuthorized)
 }
 
 func TestPopulateNativeBalance(t *testing.T) {


### PR DESCRIPTION
This PR removes the `history.Account` from AccountShowAction since it's
not used. It also wraps the errors we return in some associated functions.