### PR TITLE
only run go fmt on one Go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ go:
 - '1.9'
 - '1.10'
 - '1.11'
+- '1.12'
 - tip
 go_import_path: github.com/stellar/go
 before_install:
@@ -23,7 +24,7 @@ before_install:
   fi
 - |
   # Only run format checks on the recommended developer version of Go
-  DEVEL_GO_VERSION='1.11'
+  DEVEL_GO_VERSION='1.12'
   if [ "$TRAVIS_GO_VERSION" != "$DEVEL_GO_VERSION" ]; then
     echo "Skipping gofmt checks for this version of Go..."
   else

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,14 @@ before_install:
     echo "Searching for deprecated values in Horizon..."
     ! egrep -irn -A 1 --include=*.go "Deprecated.+-.+remove.+in:.+$TRAVIS_TAG" ./services/horizon/ ./protocols/horizon/
   fi
-- ./gofmt.sh
+- |
+  # Only run format checks on the recommended developer version of Go
+  DEVEL_GO_VERSION='1.11'
+  if [ "$TRAVIS_GO_VERSION" != "$DEVEL_GO_VERSION" ]; then
+    echo "Skipping gofmt checks for this version of Go..."
+  else
+    ./gofmt.sh
+  fi
 - ./govet.sh
 install:
 - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh

--- a/exp/txnbuild/transaction.go
+++ b/exp/txnbuild/transaction.go
@@ -5,7 +5,7 @@ TODO: More explanation + links here
 package txnbuild
 
 import (
-	"bytes"
+			"bytes"
 	"encoding/base64"
 	"fmt"
 

--- a/exp/txnbuild/transaction.go
+++ b/exp/txnbuild/transaction.go
@@ -5,7 +5,7 @@ TODO: More explanation + links here
 package txnbuild
 
 import (
-			"bytes"
+	"bytes"
 	"encoding/base64"
 	"fmt"
 

--- a/gofmt.sh
+++ b/gofmt.sh
@@ -1,14 +1,13 @@
 #! /bin/bash
 set -e
 
-printf "Is this thing on?\n"
-echo "Hello"
 # Only run format checks on the recommended developer version of Go
 if [ "$TRAVIS_GO_VERSION" != '1.11' ]; then
     printf "Skipping gofmt checks for this version of Go...\n"
     exit 0
 fi
 
+printf "Running gofmt checks...\n"
 OUTPUT=$(ls -d */ \
   | egrep -v '^vendor|^docs' \
   | xargs -I {} -P 4 gofmt -l {})

--- a/gofmt.sh
+++ b/gofmt.sh
@@ -1,8 +1,10 @@
 #! /bin/bash
 set -e
 
+DEVEL_GO_VERSION='1.11'
+
 # Only run format checks on the recommended developer version of Go
-if [ "$TRAVIS_GO_VERSION" != '1.11' ]; then
+if [ "$TRAVIS_GO_VERSION" != "$DEVEL_GO_VERSION" ]; then
     printf "Skipping gofmt checks for this version of Go...\n"
     exit 0
 fi

--- a/gofmt.sh
+++ b/gofmt.sh
@@ -10,7 +10,7 @@ fi
 printf "Running gofmt checks...\n"
 OUTPUT=$(ls -d */ \
   | egrep -v '^vendor|^docs' \
-  | xargs -I {} -P 4 gofmt -l {})
+  | xargs -I {} -P 4 gofmt -d {})
 
 if [[ $OUTPUT ]]; then
   printf "gofmt found unformatted files:\n\n"

--- a/gofmt.sh
+++ b/gofmt.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
 set -e
 
+printf "Is this thing on?"
 # Only run format checks on the recommended developer version of Go
 if [ $TRAVIS_GO_VERSION != '1.11' ]; then
     printf "Skipping gofmt checks for this version of Go..."

--- a/gofmt.sh
+++ b/gofmt.sh
@@ -3,6 +3,7 @@ set -e
 
 # Only run format checks on the recommended developer version of Go
 if [ $TRAVIS_GO_VERSION != '1.11' ]; then
+    printf "Skipping gofmt checks for this version of Go..."
     exit 0
 fi
 

--- a/gofmt.sh
+++ b/gofmt.sh
@@ -1,10 +1,11 @@
 #! /bin/bash
 set -e
 
-printf "Is this thing on?"
+printf "Is this thing on?\n"
+echo "Hello"
 # Only run format checks on the recommended developer version of Go
-if [ $TRAVIS_GO_VERSION != '1.11' ]; then
-    printf "Skipping gofmt checks for this version of Go..."
+if [ "$TRAVIS_GO_VERSION" != '1.11' ]; then
+    printf "Skipping gofmt checks for this version of Go...\n"
     exit 0
 fi
 

--- a/gofmt.sh
+++ b/gofmt.sh
@@ -1,6 +1,11 @@
 #! /bin/bash
 set -e
 
+# Only run format checks on the recommended developer version of Go
+if [ $TRAVIS_GO_VERSION != '1.11' ]; then
+    exit 0
+fi
+
 OUTPUT=$(ls -d */ \
   | egrep -v '^vendor|^docs' \
   | xargs -I {} -P 4 gofmt -l {})

--- a/gofmt.sh
+++ b/gofmt.sh
@@ -1,14 +1,6 @@
 #! /bin/bash
 set -e
 
-DEVEL_GO_VERSION='1.11'
-
-# Only run format checks on the recommended developer version of Go
-if [ "$TRAVIS_GO_VERSION" != "$DEVEL_GO_VERSION" ]; then
-    printf "Skipping gofmt checks for this version of Go...\n"
-    exit 0
-fi
-
 printf "Running gofmt checks...\n"
 OUTPUT=$(ls -d */ \
   | egrep -v '^vendor|^docs' \

--- a/govet.sh
+++ b/govet.sh
@@ -6,11 +6,12 @@ set -e
 # For now we just skip the shadow checking for Go 1.12+
 if [ "$TRAVIS_GO_VERSION" = '1.9' ] || [ "$TRAVIS_GO_VERSION" = '1.10' ] || [ "$TRAVIS_GO_VERSION" = '1.11' ]; then
 GOVET_SHADOW='-shadow'
+GOVET_TOOL='tool'
 fi
 
 OUTPUT=$(ls -d */ \
   | egrep -v '^vendor|^docs' \
-  | xargs -I {} -P 4 go tool vet -all -composites=false -unreachable=false -tests=false $GOVET_SHADOW {})
+  | xargs -I {} -P 4 go $GOVET_TOOL vet -all -composites=false -unreachable=false -tests=false $GOVET_SHADOW {})
 
 if [[ $OUTPUT ]]; then
   printf "govet found some issues:\n\n"

--- a/govet.sh
+++ b/govet.sh
@@ -1,17 +1,21 @@
 #! /bin/bash
 set -e
 
-# TODO: Build and install shadow analyzer for go vet in 1.12+
+# TODO: 1) Build and install shadow analyzer for go vet in 1.12+
 # See https://github.com/golang/go/issues/29260
+# https://golang.org/doc/go1.12#vet
 # For now we just skip the shadow checking for Go 1.12+
+# TODO: 2) Not triggering on shadowed vars (output not stdout?)
+# TODO: 3) Fix syntax for Go 1.12+ (go tool vet -> go vet, but fails to find packages?)
 if [ "$TRAVIS_GO_VERSION" = '1.9' ] || [ "$TRAVIS_GO_VERSION" = '1.10' ] || [ "$TRAVIS_GO_VERSION" = '1.11' ]; then
-GOVET_SHADOW='-shadow'
-GOVET_TOOL='tool'
-fi
-
+    echo "Running go vet checks..."
 OUTPUT=$(ls -d */ \
   | egrep -v '^vendor|^docs' \
-  | xargs -I {} -P 4 go $GOVET_TOOL vet -all -composites=false -unreachable=false -tests=false $GOVET_SHADOW {})
+  | xargs -I {} -P 4 go tool vet -all -composites=false -unreachable=false -tests=false -shadow {})
+else
+    echo "Skipping go vet checks for this version of Go..."
+fi
+
 
 if [[ $OUTPUT ]]; then
   printf "govet found some issues:\n\n"

--- a/govet.sh
+++ b/govet.sh
@@ -1,9 +1,16 @@
 #! /bin/bash
 set -e
 
+# TODO: Build and install shadow analyzer for go vet in 1.12+
+# See https://github.com/golang/go/issues/29260
+# For now we just skip the shadow checking for Go 1.12+
+if [ "$TRAVIS_GO_VERSION" = '1.9' ] || [ "$TRAVIS_GO_VERSION" = '1.10' ] || [ "$TRAVIS_GO_VERSION" = '1.11' ]; then
+GOVET_SHADOW='-shadow'
+fi
+
 OUTPUT=$(ls -d */ \
   | egrep -v '^vendor|^docs' \
-  | xargs -I {} -P 4 go tool vet -all -composites=false -unreachable=false -tests=false -shadow {})
+  | xargs -I {} -P 4 go tool vet -all -composites=false -unreachable=false -tests=false $GOVET_SHADOW {})
 
 if [[ $OUTPUT ]]; then
   printf "govet found some issues:\n\n"


### PR DESCRIPTION
Addresses the problem of `go fmt` changes between versions of go described in #1030 by only running `gofmt` on the recommended developer version (currently 1.11).

This PR also changes the output of `gofmt` to `-d` to provide more context for failing format checks. This is important information since the developer may potentially have the wrong version of the `gofmt` binary in their devel environment and be unable to reproduce.