### PR TITLE
Support amounts that exceed int64 max in order book

### DIFF
--- a/services/horizon/internal/db2/core/main.go
+++ b/services/horizon/internal/db2/core/main.go
@@ -103,7 +103,7 @@ type PriceLevel struct {
 	Pricen int32   `db:"pricen"`
 	Priced int32   `db:"priced"`
 	Pricef float64 `db:"pricef"`
-	Amount int64   `db:"amount"`
+	Amount string  `db:"amount"`
 }
 
 // SequenceProvider implements `txsub.SequenceProvider`

--- a/services/horizon/internal/db2/core/main_test.go
+++ b/services/horizon/internal/db2/core/main_test.go
@@ -151,7 +151,7 @@ func TestSchemaVersion8(t *testing.T) {
 	}
 }
 
-func checkOrderBookRow(tt *test.T, row OrderBookSummaryPriceLevel, typ string, pricen, priced int32, pricef float64, amount int64) {
+func checkOrderBookRow(tt *test.T, row OrderBookSummaryPriceLevel, typ string, pricen, priced int32, pricef float64, amount string) {
 	tt.Assert.Equal(typ, row.Type)
 	tt.Assert.Equal(pricen, row.Pricen)
 	tt.Assert.Equal(priced, row.Priced)

--- a/services/horizon/internal/db2/core/main_test.go
+++ b/services/horizon/internal/db2/core/main_test.go
@@ -143,11 +143,11 @@ func TestSchemaVersion8(t *testing.T) {
 	var orderbookSummary OrderBookSummary
 	err = q.GetOrderBookSummary(&orderbookSummary, xdr.MustNewNativeAsset(), xdr.MustNewCreditAsset("USD", "GB2QIYT2IAUFMRXKLSLLPRECC6OCOGJMADSPTRK7TGNT2SFR2YGWDARD"), 10)
 	if tt.Assert.NoError(err) {
-		checkOrderBookRow(tt, orderbookSummary[0], "ask", int32(1), int32(1), float64(1), 300000000)
-		checkOrderBookRow(tt, orderbookSummary[1], "ask", int32(3), int32(1), float64(3), 400000000)
+		checkOrderBookRow(tt, orderbookSummary[0], "ask", int32(1), int32(1), float64(1), "300000000")
+		checkOrderBookRow(tt, orderbookSummary[1], "ask", int32(3), int32(1), float64(3), "400000000")
 
-		checkOrderBookRow(tt, orderbookSummary[2], "bid", int32(1), int32(2), float64(0.5), 200000000)
-		checkOrderBookRow(tt, orderbookSummary[3], "bid", int32(1), int32(1), float64(1), 100000000)
+		checkOrderBookRow(tt, orderbookSummary[2], "bid", int32(1), int32(2), float64(0.5), "200000000")
+		checkOrderBookRow(tt, orderbookSummary[3], "bid", int32(1), int32(1), float64(1), "100000000")
 	}
 }
 
@@ -263,10 +263,10 @@ func TestSchemaVersion9(t *testing.T) {
 	var orderbookSummary OrderBookSummary
 	err = q.GetOrderBookSummary(&orderbookSummary, xdr.MustNewNativeAsset(), xdr.MustNewCreditAsset("USD", "GB2QIYT2IAUFMRXKLSLLPRECC6OCOGJMADSPTRK7TGNT2SFR2YGWDARD"), 10)
 	if tt.Assert.NoError(err) {
-		checkOrderBookRow(tt, orderbookSummary[0], "ask", int32(1), int32(1), float64(1), 300000000)
-		checkOrderBookRow(tt, orderbookSummary[1], "ask", int32(3), int32(1), float64(3), 400000000)
+		checkOrderBookRow(tt, orderbookSummary[0], "ask", int32(1), int32(1), float64(1), "300000000")
+		checkOrderBookRow(tt, orderbookSummary[1], "ask", int32(3), int32(1), float64(3), "400000000")
 
-		checkOrderBookRow(tt, orderbookSummary[2], "bid", int32(1), int32(2), float64(0.5), 200000000)
-		checkOrderBookRow(tt, orderbookSummary[3], "bid", int32(1), int32(1), float64(1), 100000000)
+		checkOrderBookRow(tt, orderbookSummary[2], "bid", int32(1), int32(2), float64(0.5), "200000000")
+		checkOrderBookRow(tt, orderbookSummary[3], "bid", int32(1), int32(1), float64(1), "100000000")
 	}
 }

--- a/services/horizon/internal/db2/core/order_book_summary_test.go
+++ b/services/horizon/internal/db2/core/order_book_summary_test.go
@@ -31,27 +31,27 @@ func TestGetOrderBookSummary(t *testing.T) {
 	ibids := inverted.Bids()
 
 	// Check that summary was loaded correct
-	tt.Assert.Equal(int64(100000000), asks[0].Amount)
+	tt.Assert.Equal("100000000", asks[0].Amount)
 	tt.Assert.Equal(int32(15), asks[0].Pricen)
 	tt.Assert.Equal(int32(1), asks[0].Priced)
 
-	tt.Assert.Equal(int64(1000000000), asks[1].Amount)
+	tt.Assert.Equal("1000000000", asks[1].Amount)
 	tt.Assert.Equal(int32(20), asks[1].Pricen)
 	tt.Assert.Equal(int32(1), asks[1].Priced)
 
-	tt.Assert.Equal(int64(10000000000), asks[2].Amount)
+	tt.Assert.Equal("10000000000", asks[2].Amount)
 	tt.Assert.Equal(int32(50), asks[2].Pricen)
 	tt.Assert.Equal(int32(1), asks[2].Priced)
 
-	tt.Assert.Equal(int64(1000000000), bids[0].Amount)
+	tt.Assert.Equal("1000000000", bids[0].Amount)
 	tt.Assert.Equal(int32(10), bids[0].Pricen)
 	tt.Assert.Equal(int32(1), bids[0].Priced)
 
-	tt.Assert.Equal(int64(9000000000), bids[1].Amount)
+	tt.Assert.Equal("9000000000", bids[1].Amount)
 	tt.Assert.Equal(int32(9), bids[1].Pricen)
 	tt.Assert.Equal(int32(1), bids[1].Priced)
 
-	tt.Assert.Equal(int64(50000000000), bids[2].Amount)
+	tt.Assert.Equal("50000000000", bids[2].Amount)
 	tt.Assert.Equal(int32(5), bids[2].Pricen)
 	tt.Assert.Equal(int32(1), bids[2].Priced)
 

--- a/services/horizon/internal/db2/core/price_level.go
+++ b/services/horizon/internal/db2/core/price_level.go
@@ -4,7 +4,6 @@ import (
 	"math/big"
 
 	"github.com/stellar/go/amount"
-	"github.com/stellar/go/xdr"
 )
 
 // InvertPricef returns the inverted price of the price-level, i.e. what the price would be if you were
@@ -20,6 +19,6 @@ func (p *PriceLevel) PriceAsString() string {
 
 // AmountAsString returns the amount as a string, formatted using
 // the amount.String() utility from github.com/stellar/go.
-func (p *PriceLevel) AmountAsString() string {
-	return amount.String(xdr.Int64(p.Amount))
+func (p *PriceLevel) AmountAsString() (string, error) {
+	return amount.IntStringToAmount(p.Amount)
 }


### PR DESCRIPTION
It's possible that sum of ask/bid offers at a given price level in the order book summary exceeds `INT64_MAX` as issuers can send `INT64_MAX` of the asset to each trust line. In such cases, Horizon was logging errors like:
```
select failed: sql: Scan error on column index 3, name \"amount\": converting driver.Value type []uint8 (\"10700325238000000000\") to a int64: value out of range
```
To support this, `PriceLevel.Amount` field type was changed from `int64` to `string`.