### PR TITLE
protocols/horizon: Add PaymentsPage

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -531,7 +531,7 @@ type LedgersPage struct {
 }
 
 // PaymentsPage returns a list of payments
-type OffersPage struct {
+type PaymentsPage struct {
 	Links    hal.Links `json:"_links"`
 	Embedded struct {
 		Records []Payment `json:"records"`

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -530,6 +530,14 @@ type LedgersPage struct {
 	} `json:"_embedded"`
 }
 
+// PaymentsPage returns a list of payments
+type OffersPage struct {
+	Links    hal.Links `json:"_links"`
+	Embedded struct {
+		Records []Payment `json:"records"`
+	} `json:"_embedded"`
+}
+
 // SingleMetric represents a metric with a single value
 type SingleMetric struct {
 	Value int `json:"value"`


### PR DESCRIPTION
There's no struct for the payments page yet, used in endpoints like https://www.stellar.org/developers/horizon/reference/endpoints/payments-for-ledger.html