### PR TITLE
Don't repeat Horizon prefix if it's present when inflating problems.

### DIFF
--- a/support/render/problem/main.go
+++ b/support/render/problem/main.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-const HorizonHost = "https://stellar.org/horizon-errors/"
+const horizonHost = "https://stellar.org/horizon-errors/"
 
 // P is a struct that represents an error response to be rendered to a connected
 // client.
@@ -46,9 +46,9 @@ func RegisterError(err error, p P) {
 func Inflate(p *P) {
 	//TODO: add requesting url to extra info
 
-	if !strings.HasPrefix(p.Type, HorizonHost) {
-		//TODO: make the HorizonHost prefix configurable
-		p.Type = HorizonHost + p.Type
+	if !strings.HasPrefix(p.Type, horizonHost) {
+		//TODO: make the horizonHost prefix configurable
+		p.Type = horizonHost + p.Type
 	}
 
 	p.Instance = ""

--- a/support/render/problem/main.go
+++ b/support/render/problem/main.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
+	"net/http"
+	"strings"
 )
+
+const HorizonHost = "https://stellar.org/horizon-errors/"
 
 // P is a struct that represents an error response to be rendered to a connected
 // client.
@@ -44,8 +46,10 @@ func RegisterError(err error, p P) {
 func Inflate(p *P) {
 	//TODO: add requesting url to extra info
 
-	//TODO: make this prefix configurable
-	p.Type = "https://stellar.org/horizon-errors/" + p.Type
+	if !strings.HasPrefix(p.Type, HorizonHost) {
+		//TODO: make the HorizonHost prefix configurable
+		p.Type = HorizonHost + p.Type
+	}
 
 	p.Instance = ""
 }

--- a/support/render/problem/main_test.go
+++ b/support/render/problem/main_test.go
@@ -119,7 +119,7 @@ func TestServerErrorConversion(t *testing.T) {
 
 // TestInflate test errors that come inflated from horizon
 func TestInflate(t *testing.T) {
-	kase := struct {
+	testCase := struct {
 		name string
 		p    interface{}
 		want string
@@ -129,12 +129,12 @@ func TestInflate(t *testing.T) {
 		"https://stellar.org/horizon-errors/not_found",
 	}
 
-	t.Run(kase.name, func(t *testing.T) {
-		w := testRender(context.Background(), kase.p)
+	t.Run(testCase.name, func(t *testing.T) {
+		w := testRender(context.Background(), testCase.p)
 		var payload P
 		json.Unmarshal([]byte(w.Body.String()), &payload)
 
-		assert.Equal(t, kase.want, payload.Type)
+		assert.Equal(t, testCase.want, payload.Type)
 	})
 }
 

--- a/support/render/problem/main_test.go
+++ b/support/render/problem/main_test.go
@@ -132,7 +132,11 @@ func TestInflate(t *testing.T) {
 	t.Run(testCase.name, func(t *testing.T) {
 		w := testRender(context.Background(), testCase.p)
 		var payload P
-		json.Unmarshal([]byte(w.Body.String()), &payload)
+		err := json.Unmarshal([]byte(w.Body.String()), &payload)
+
+		if err != nil {
+			t.Error("expected body to be a JSON encoded value, got ", err)
+		}
 
 		assert.Equal(t, testCase.want, payload.Type)
 	})

--- a/support/render/problem/main_test.go
+++ b/support/render/problem/main_test.go
@@ -133,12 +133,9 @@ func TestInflate(t *testing.T) {
 		w := testRender(context.Background(), testCase.p)
 		var payload P
 		err := json.Unmarshal([]byte(w.Body.String()), &payload)
-
-		if err != nil {
-			t.Error("expected body to be a JSON encoded value, got ", err)
+		if assert.NoError(t, err) {
+			assert.Equal(t, testCase.want, payload.Type)
 		}
-
-		assert.Equal(t, testCase.want, payload.Type)
 	})
 }
 

--- a/support/render/problem/main_test.go
+++ b/support/render/problem/main_test.go
@@ -120,9 +120,9 @@ func TestServerErrorConversion(t *testing.T) {
 // TestInflate test errors that come inflated from horizon
 func TestInflate(t *testing.T) {
 	kase := struct {
-		name     string
-		p        interface{}
-		want     string
+		name string
+		p    interface{}
+		want string
 	}{
 		"renders the type correctly",
 		P{Type: "https://stellar.org/horizon-errors/not_found"},

--- a/support/render/problem/main_test.go
+++ b/support/render/problem/main_test.go
@@ -2,6 +2,7 @@ package problem
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http/httptest"
@@ -114,6 +115,27 @@ func TestServerErrorConversion(t *testing.T) {
 			)
 		})
 	}
+}
+
+// TestInflate test errors that come inflated from horizon
+func TestInflate(t *testing.T) {
+	kase := struct {
+		name     string
+		p        interface{}
+		want     string
+	}{
+		"renders the type correctly",
+		P{Type: "https://stellar.org/horizon-errors/not_found"},
+		"https://stellar.org/horizon-errors/not_found",
+	}
+
+	t.Run(kase.name, func(t *testing.T) {
+		w := testRender(context.Background(), kase.p)
+		var payload P
+		json.Unmarshal([]byte(w.Body.String()), &payload)
+
+		assert.Equal(t, kase.want, payload.Type)
+	})
 }
 
 func testRender(ctx context.Context, p interface{}) *httptest.ResponseRecorder {


### PR DESCRIPTION
There is an inconsistency in the `type` returned by `friendbot` when making request which fail in `Horizon`. The following is an example taken from a failed request (notice the prefix in type):

```
{
  "type":"https://stellar.org/horizon-errors/https://stellar.org/horizon-errors/not_found",
  "title":"Resource Missing",
  "status":404,
  "detail":"The resource at the url requested was not found.  This is
  usually occurs for one of two reasons:  The url requested is not
  valid, or no data in our database could be found with the parameters
  provided."
}
```

The issue was on the `Inflate` method which is used across different projects. Horizon was returning the type already "inflated" and then`friendbot` was inflating it again, appending the prefix twice.