### PR TITLE
exp/client/horizon: support transactions endpoints

### DIFF
--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -219,3 +219,22 @@ func (c *Client) SubmitTransaction(transactionXdr string) (txSuccess hProtocol.T
 	return
 
 }
+
+// Transactions returns stellar transactions (https://www.stellar.org/developers/horizon/reference/resources/transaction.html)
+// It can be used to return transactions for an account, a ledger,and all transactions on the network.
+func (c *Client) Transactions(request TransactionRequest) (txs hProtocol.TransactionsPage, err error) {
+	err = c.sendRequest(request, &txs)
+	return
+}
+
+// TransactionDetail returns information about a particular transaction for a given transaction hash
+// See https://www.stellar.org/developers/horizon/reference/endpoints/transactions-single.html
+func (c *Client) TransactionDetail(txHash string) (tx hProtocol.Transaction, err error) {
+	if txHash == "" {
+		return tx, errors.New("No transaction hash provided")
+	}
+
+	request := TransactionRequest{forTransactionHash: txHash}
+	err = c.sendRequest(request, &tx)
+	return
+}

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -58,7 +58,7 @@ var (
 	// "result_xdr" extra field populated when it is expected to be.
 	ErrResultNotPopulated = errors.New("result_xdr not populated")
 
-	// HorizonTimeout is the default number of seconds before a request to horizon times out.
+	// HorizonTimeOut is the default number of seconds before a request to horizon times out.
 	HorizonTimeOut = time.Duration(60)
 )
 
@@ -91,6 +91,8 @@ type ClientInterface interface {
 	Operations(request OperationRequest) (operations.OperationsPage, error)
 	OperationDetail(id string) (operations.Operation, error)
 	SubmitTransaction(transactionXdr string) (hProtocol.TransactionSuccess, error)
+	Transactions(request TransactionRequest) (hProtocol.TransactionsPage, error)
+	TransactionDetail(txHash string) (hProtocol.Transaction, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network
@@ -172,7 +174,7 @@ type OfferRequest struct {
 // OperationRequest struct contains data for getting operation details from an horizon servers
 type OperationRequest struct {
 	ForAccount     string
-	ForLedger      int
+	ForLedger      uint
 	ForTransaction string
 	forOperationId string
 	Order          Order
@@ -184,4 +186,15 @@ type OperationRequest struct {
 type submitRequest struct {
 	endpoint       string
 	transactionXdr string
+}
+
+// TransactionRequest struct contains data for getting transaction details from an horizon server
+type TransactionRequest struct {
+	ForAccount         string
+	ForLedger          uint
+	forTransactionHash string
+	Order              Order
+	Cursor             string
+	Limit              uint
+	IncludeFailed      bool
 }

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -100,5 +100,11 @@ func (m *MockClient) Transactions(request TransactionRequest) (hProtocol.Transac
 	return a.Get(0).(hProtocol.TransactionsPage), a.Error(1)
 }
 
+// TransactionDetail is a mocking method
+func (m *MockClient) TransactionDetail(txHash string) (hProtocol.Transaction, error) {
+	a := m.Called(txHash)
+	return a.Get(0).(hProtocol.Transaction), a.Error(1)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -58,7 +58,7 @@ func (m *MockClient) LedgerDetail(sequence uint32) (hProtocol.Ledger, error) {
 	return a.Get(0).(hProtocol.Ledger), a.Error(1)
 }
 
-// MEtrics is a mocking method
+// Metrics is a mocking method
 func (m *MockClient) Metrics() (hProtocol.Metrics, error) {
 	a := m.Called()
 	return a.Get(0).(hProtocol.Metrics), a.Error(1)

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -37,6 +37,7 @@ func (m *MockClient) Assets(request AssetRequest) (hProtocol.AssetsPage, error) 
 	return a.Get(0).(hProtocol.AssetsPage), a.Error(1)
 }
 
+// Stream is a mocking method
 func (m *MockClient) Stream(ctx context.Context,
 	request StreamRequest,
 	handler func(interface{}),
@@ -45,44 +46,58 @@ func (m *MockClient) Stream(ctx context.Context,
 	return a.Error(0)
 }
 
+// Ledgers is a mocking method
 func (m *MockClient) Ledgers(request LedgerRequest) (hProtocol.LedgersPage, error) {
 	a := m.Called(request)
 	return a.Get(0).(hProtocol.LedgersPage), a.Error(1)
 }
 
+// LedgerDetail is a mocking method
 func (m *MockClient) LedgerDetail(sequence uint32) (hProtocol.Ledger, error) {
 	a := m.Called(sequence)
 	return a.Get(0).(hProtocol.Ledger), a.Error(1)
 }
 
+// MEtrics is a mocking method
 func (m *MockClient) Metrics() (hProtocol.Metrics, error) {
 	a := m.Called()
 	return a.Get(0).(hProtocol.Metrics), a.Error(1)
 }
 
+// FeeStats is a mocking method
 func (m *MockClient) FeeStats() (hProtocol.FeeStats, error) {
 	a := m.Called()
 	return a.Get(0).(hProtocol.FeeStats), a.Error(1)
 }
 
+// Offers is a mocking method
 func (m *MockClient) Offers(request OfferRequest) (hProtocol.OffersPage, error) {
 	a := m.Called(request)
 	return a.Get(0).(hProtocol.OffersPage), a.Error(1)
 }
 
+// Operations is a mocking method
 func (m *MockClient) Operations(request OperationRequest) (operations.OperationsPage, error) {
 	a := m.Called(request)
 	return a.Get(0).(operations.OperationsPage), a.Error(1)
 }
 
+// OperationDetail is a mocking method
 func (m *MockClient) OperationDetail(id string) (operations.Operation, error) {
 	a := m.Called(id)
 	return a.Get(0).(operations.Operation), a.Error(1)
 }
 
+// SubmitTransaction is a mocking method
 func (m *MockClient) SubmitTransaction(transactionXdr string) (hProtocol.TransactionSuccess, error) {
 	a := m.Called(transactionXdr)
 	return a.Get(0).(hProtocol.TransactionSuccess), a.Error(1)
+}
+
+// Transactions is a mocking method
+func (m *MockClient) Transactions(request TransactionRequest) (hProtocol.TransactionsPage, error) {
+	a := m.Called(request)
+	return a.Get(0).(hProtocol.TransactionsPage), a.Error(1)
 }
 
 // ensure that the MockClient implements ClientInterface

--- a/exp/clients/horizon/transaction_request.go
+++ b/exp/clients/horizon/transaction_request.go
@@ -1,0 +1,42 @@
+package horizonclient
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/stellar/go/support/errors"
+)
+
+// BuildUrl creates the endpoint to be queried based on the data in the TransactionRequest struct.
+// If no data is set, it defaults to the build the URL for all transactions
+func (tr TransactionRequest) BuildUrl() (endpoint string, err error) {
+	nParams := countParams(tr.ForAccount, tr.ForLedger, tr.forTransactionHash)
+
+	if nParams > 1 {
+		return endpoint, errors.New("Invalid request. Too many parameters")
+	}
+
+	endpoint = "transactions"
+	if tr.ForAccount != "" {
+		endpoint = fmt.Sprintf("accounts/%s/transactions", tr.ForAccount)
+	}
+	if tr.ForLedger > 0 {
+		endpoint = fmt.Sprintf("ledgers/%d/transactions", tr.ForLedger)
+	}
+	if tr.forTransactionHash != "" {
+		endpoint = fmt.Sprintf("transactions/%s", tr.forTransactionHash)
+	}
+
+	queryParams := addQueryParams(cursor(tr.Cursor), limit(tr.Limit), tr.Order,
+		includeFailed(tr.IncludeFailed))
+	if queryParams != "" {
+		endpoint = fmt.Sprintf("%s?%s", endpoint, queryParams)
+	}
+
+	_, err = url.Parse(endpoint)
+	if err != nil {
+		err = errors.Wrap(err, "failed to parse endpoint")
+	}
+
+	return endpoint, err
+}

--- a/exp/clients/horizon/transaction_request_test.go
+++ b/exp/clients/horizon/transaction_request_test.go
@@ -1,0 +1,53 @@
+package horizonclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransactionRequestBuildUrl(t *testing.T) {
+	tr := TransactionRequest{}
+	endpoint, err := tr.BuildUrl()
+
+	// It should return valid all transactions endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "transactions", endpoint)
+
+	tr = TransactionRequest{ForAccount: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
+	endpoint, err = tr.BuildUrl()
+
+	// It should return valid account transactions endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/transactions", endpoint)
+
+	tr = TransactionRequest{ForLedger: 123}
+	endpoint, err = tr.BuildUrl()
+
+	// It should return valid ledger transactions endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "ledgers/123/transactions", endpoint)
+
+	tr = TransactionRequest{forTransactionHash: "123"}
+	endpoint, err = tr.BuildUrl()
+
+	// It should return valid operation transactions endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "transactions/123", endpoint)
+
+	tr = TransactionRequest{ForLedger: 123, forTransactionHash: "789"}
+	endpoint, err = tr.BuildUrl()
+
+	// error case: too many parameters for building any operation endpoint
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Invalid request. Too many parameters")
+	}
+
+	tr = TransactionRequest{Cursor: "123456", Limit: 30, Order: OrderAsc}
+	endpoint, err = tr.BuildUrl()
+	// It should return valid all transactions endpoint with query params and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "transactions?cursor=123456&limit=30&order=asc", endpoint)
+
+}

--- a/exp/clients/horizon/transaction_request_test.go
+++ b/exp/clients/horizon/transaction_request_test.go
@@ -44,10 +44,10 @@ func TestTransactionRequestBuildUrl(t *testing.T) {
 		assert.Contains(t, err.Error(), "Invalid request. Too many parameters")
 	}
 
-	tr = TransactionRequest{Cursor: "123456", Limit: 30, Order: OrderAsc}
+	tr = TransactionRequest{Cursor: "123456", Limit: 30, Order: OrderAsc, IncludeFailed: true}
 	endpoint, err = tr.BuildUrl()
 	// It should return valid all transactions endpoint with query params and no errors
 	require.NoError(t, err)
-	assert.Equal(t, "transactions?cursor=123456&limit=30&order=asc", endpoint)
+	assert.Equal(t, "transactions?cursor=123456&include_failed=true&limit=30&order=asc", endpoint)
 
 }

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -604,3 +604,11 @@ type FeeStats struct {
 	P95AcceptedFee      int     `json:"p95_accepted_fee,string"`
 	P99AcceptedFee      int     `json:"p99_accepted_fee,string"`
 }
+
+// TransactionsPage contains records of transaction information returned by Horizon
+type TransactionsPage struct {
+	Links    hal.Links `json:"_links"`
+	Embedded struct {
+		Records []Transaction
+	} `json:"_embedded"`
+}


### PR DESCRIPTION
This PR add support for retrieving transaction information for accounts, ledgers, a transaction hash and all transactions.
Closes #957 
Closes #1018 