### PR TITLE
exp/clients/horizon: orderbook

### DIFF
--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -238,3 +238,9 @@ func (c *Client) TransactionDetail(txHash string) (tx hProtocol.Transaction, err
 	err = c.sendRequest(request, &tx)
 	return
 }
+
+// OrderBook returns the orderbook for an asset pair (https://www.stellar.org/developers/horizon/reference/resources/orderbook.html)
+func (c *Client) OrderBook(request OrderBookRequest) (obs hProtocol.OrderBookSummary, err error) {
+	err = c.sendRequest(request, &obs)
+	return
+}

--- a/exp/clients/horizon/internal.go
+++ b/exp/clients/horizon/internal.go
@@ -2,7 +2,6 @@ package horizonclient
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -94,7 +93,6 @@ func addQueryParams(params ...interface{}) string {
 				}
 			}
 		default:
-			fmt.Printf("param is of type %T\n", param)
 			panic("Unknown parameter type")
 		}
 	}

--- a/exp/clients/horizon/internal.go
+++ b/exp/clients/horizon/internal.go
@@ -2,6 +2,7 @@ package horizonclient
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -86,7 +87,14 @@ func addQueryParams(params ...interface{}) string {
 			if param {
 				query.Add("include_failed", "true")
 			}
+		case map[string]string:
+			for key, value := range param {
+				if value != "" {
+					query.Add(key, value)
+				}
+			}
 		default:
+			fmt.Printf("param is of type %T\n", param)
 			panic("Unknown parameter type")
 		}
 	}

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -31,17 +31,20 @@ type assetIssuer string
 // includeFailed represents `include_failed` param in queries
 type includeFailed bool
 
+// AssetType represents `asset_type` param in queries
+type AssetType string
+
 const (
 	// OrderAsc represents an ascending order parameter
 	OrderAsc Order = "asc"
 	// OrderDesc represents an descending order parameter
 	OrderDesc Order = "desc"
 	// AssetType4 represents an asset type that is 4 characters long
-	AssetType4 string = "credit_alphanum4"
+	AssetType4 AssetType = "credit_alphanum4"
 	// AssetType12 represents an asset type that is 12 characters long
-	AssetType12 string = "credit_alphanum12"
+	AssetType12 AssetType = "credit_alphanum12"
 	// AssetTypeNative represents the asset type for Stellar Lumens (XLM)
-	AssetTypeNative string = "native"
+	AssetTypeNative AssetType = "native"
 )
 
 // Error struct contains the problem returned by Horizon
@@ -210,10 +213,10 @@ type TransactionRequest struct {
 
 // OrderBookRequest struct contains data for getting the orderbook for an asset pair from an horizon server
 type OrderBookRequest struct {
-	SellingAssetType   string
+	SellingAssetType   AssetType
 	SellingAssetCode   string
 	SellingAssetIssuer string
-	BuyingAssetType    string
+	BuyingAssetType    AssetType
 	BuyingAssetCode    string
 	BuyingAssetIssuer  string
 	Limit              uint

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -32,8 +32,16 @@ type assetIssuer string
 type includeFailed bool
 
 const (
-	OrderAsc  Order = "asc"
+	// OrderAsc represents an ascending order parameter
+	OrderAsc Order = "asc"
+	// OrderDesc represents an descending order parameter
 	OrderDesc Order = "desc"
+	// AssetType4 represents an asset type that is 4 characters long
+	AssetType4 string = "credit_alphanum4"
+	// AssetType12 represents an asset type that is 12 characters long
+	AssetType12 string = "credit_alphanum12"
+	// AssetTypeNative represents the asset type for Stellar Lumens (XLM)
+	AssetTypeNative string = "native"
 )
 
 // Error struct contains the problem returned by Horizon
@@ -93,6 +101,7 @@ type ClientInterface interface {
 	SubmitTransaction(transactionXdr string) (hProtocol.TransactionSuccess, error)
 	Transactions(request TransactionRequest) (hProtocol.TransactionsPage, error)
 	TransactionDetail(txHash string) (hProtocol.Transaction, error)
+	OrderBook(request OrderBookRequest) (hProtocol.OrderBookSummary, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network
@@ -197,4 +206,15 @@ type TransactionRequest struct {
 	Cursor             string
 	Limit              uint
 	IncludeFailed      bool
+}
+
+// OrderBookRequest struct contains data for getting the orderbook for an asset pair from an horizon server
+type OrderBookRequest struct {
+	SellingAssetType   string
+	SellingAssetCode   string
+	SellingAssetIssuer string
+	BuyingAssetType    string
+	BuyingAssetCode    string
+	BuyingAssetIssuer  string
+	Limit              uint
 }

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -106,5 +106,11 @@ func (m *MockClient) TransactionDetail(txHash string) (hProtocol.Transaction, er
 	return a.Get(0).(hProtocol.Transaction), a.Error(1)
 }
 
+// OrderBook is a mocking method
+func (m *MockClient) OrderBook(request OrderBookRequest) (hProtocol.OrderBookSummary, error) {
+	a := m.Called(request)
+	return a.Get(0).(hProtocol.OrderBookSummary), a.Error(1)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}

--- a/exp/clients/horizon/order_book_request.go
+++ b/exp/clients/horizon/order_book_request.go
@@ -1,0 +1,35 @@
+package horizonclient
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/stellar/go/support/errors"
+)
+
+// BuildUrl creates the endpoint to be queried based on the data in the OrderBookRequest struct.
+func (obr OrderBookRequest) BuildUrl() (endpoint string, err error) {
+	endpoint = "order_book"
+
+	// add the parameters to a map here so it is easier for addQueryParams to populate the parameter list
+	// We can't use assetCode and assetIssuer types here because the paremeter names are different
+	paramMap := make(map[string]string)
+	paramMap["selling_asset_type"] = obr.SellingAssetType
+	paramMap["selling_asset_code"] = obr.SellingAssetCode
+	paramMap["selling_asset_issuer"] = obr.SellingAssetIssuer
+	paramMap["buying_asset_type"] = obr.BuyingAssetType
+	paramMap["buying_asset_code"] = obr.BuyingAssetCode
+	paramMap["buying_asset_issuer"] = obr.BuyingAssetIssuer
+
+	queryParams := addQueryParams(paramMap, limit(obr.Limit))
+	if queryParams != "" {
+		endpoint = fmt.Sprintf("%s?%s", endpoint, queryParams)
+	}
+
+	_, err = url.Parse(endpoint)
+	if err != nil {
+		err = errors.Wrap(err, "failed to parse endpoint")
+	}
+
+	return endpoint, err
+}

--- a/exp/clients/horizon/order_book_request.go
+++ b/exp/clients/horizon/order_book_request.go
@@ -14,10 +14,10 @@ func (obr OrderBookRequest) BuildUrl() (endpoint string, err error) {
 	// add the parameters to a map here so it is easier for addQueryParams to populate the parameter list
 	// We can't use assetCode and assetIssuer types here because the paremeter names are different
 	paramMap := make(map[string]string)
-	paramMap["selling_asset_type"] = obr.SellingAssetType
+	paramMap["selling_asset_type"] = string(obr.SellingAssetType)
 	paramMap["selling_asset_code"] = obr.SellingAssetCode
 	paramMap["selling_asset_issuer"] = obr.SellingAssetIssuer
-	paramMap["buying_asset_type"] = obr.BuyingAssetType
+	paramMap["buying_asset_type"] = string(obr.BuyingAssetType)
 	paramMap["buying_asset_code"] = obr.BuyingAssetCode
 	paramMap["buying_asset_issuer"] = obr.BuyingAssetIssuer
 

--- a/exp/clients/horizon/order_book_request_test.go
+++ b/exp/clients/horizon/order_book_request_test.go
@@ -1,0 +1,32 @@
+package horizonclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrderBookRequestBuildUrl(t *testing.T) {
+	obr := OrderBookRequest{}
+	endpoint, err := obr.BuildUrl()
+
+	// It should return no errors and orderbook endpoint
+	// Horizon will return an error though because there are no parameters
+	require.NoError(t, err)
+	assert.Equal(t, "order_book", endpoint)
+
+	obr = OrderBookRequest{SellingAssetType: "native", BuyingAssetType: "native"}
+	endpoint, err = obr.BuildUrl()
+
+	// It should return valid assets endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "order_book?buying_asset_type=native&selling_asset_type=native", endpoint)
+
+	obr = OrderBookRequest{SellingAssetType: "native", BuyingAssetType: AssetType4, BuyingAssetCode: "ABC", BuyingAssetIssuer: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
+	endpoint, err = obr.BuildUrl()
+
+	// It should return valid assets endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "order_book?buying_asset_code=ABC&buying_asset_issuer=GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU&buying_asset_type=credit_alphanum4&selling_asset_type=native", endpoint)
+}

--- a/exp/clients/horizon/order_book_request_test.go
+++ b/exp/clients/horizon/order_book_request_test.go
@@ -16,14 +16,14 @@ func TestOrderBookRequestBuildUrl(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "order_book", endpoint)
 
-	obr = OrderBookRequest{SellingAssetType: "native", BuyingAssetType: "native"}
+	obr = OrderBookRequest{SellingAssetType: AssetTypeNative, BuyingAssetType: AssetTypeNative}
 	endpoint, err = obr.BuildUrl()
 
 	// It should return valid assets endpoint and no errors
 	require.NoError(t, err)
 	assert.Equal(t, "order_book?buying_asset_type=native&selling_asset_type=native", endpoint)
 
-	obr = OrderBookRequest{SellingAssetType: "native", BuyingAssetType: AssetType4, BuyingAssetCode: "ABC", BuyingAssetIssuer: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
+	obr = OrderBookRequest{SellingAssetType: AssetTypeNative, BuyingAssetType: AssetType4, BuyingAssetCode: "ABC", BuyingAssetIssuer: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
 	endpoint, err = obr.BuildUrl()
 
 	// It should return valid assets endpoint and no errors


### PR DESCRIPTION
This PR adds support for querying the orderbook of asset pairs.
This is part of the tasks to be done in #1021 