### PR TITLE
exp/clients/horizon: payments

### DIFF
--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -177,7 +177,7 @@ func (c *Client) Offers(request OfferRequest) (offers hProtocol.OffersPage, err 
 // Operations returns stellar operations (https://www.stellar.org/developers/horizon/reference/resources/operation.html)
 // It can be used to return operations for an account, a ledger, a transaction and all operations on the network.
 func (c *Client) Operations(request OperationRequest) (ops operations.OperationsPage, err error) {
-	err = c.sendRequest(request, &ops)
+	err = c.sendRequest(request.setEndpoint("operations"), &ops)
 	return
 }
 
@@ -188,7 +188,7 @@ func (c *Client) OperationDetail(id string) (ops operations.Operation, err error
 		return ops, errors.New("Invalid operation id provided")
 	}
 
-	request := OperationRequest{forOperationId: id}
+	request := OperationRequest{forOperationId: id, endpoint: "operations"}
 
 	var record interface{}
 
@@ -248,6 +248,13 @@ func (c *Client) OrderBook(request OrderBookRequest) (obs hProtocol.OrderBookSum
 // Paths returns the available paths to make a payment. See https://www.stellar.org/developers/horizon/reference/endpoints/path-finding.html
 func (c *Client) Paths(request PathsRequest) (paths hProtocol.PathsPage, err error) {
 	err = c.sendRequest(request, &paths)
+	return
+}
+
+// Payments returns stellar account_merge, create_account, path payment and payment operations.
+// It can be used to return payments for an account, a ledger, a transaction and all payments on the network.
+func (c *Client) Payments(request OperationRequest) (ops operations.OperationsPage, err error) {
+	err = c.sendRequest(request.setEndpoint("payments"), &ops)
 	return
 }
 

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -244,3 +244,12 @@ func (c *Client) OrderBook(request OrderBookRequest) (obs hProtocol.OrderBookSum
 	err = c.sendRequest(request, &obs)
 	return
 }
+
+// Paths returns the available paths to make a payment. See https://www.stellar.org/developers/horizon/reference/endpoints/path-finding.html
+func (c *Client) Paths(request PathsRequest) (paths hProtocol.PathsPage, err error) {
+	err = c.sendRequest(request, &paths)
+	return
+}
+
+// ensure that the horizon client implements ClientInterface
+var _ ClientInterface = &Client{}

--- a/exp/clients/horizon/internal.go
+++ b/exp/clients/horizon/internal.go
@@ -2,6 +2,7 @@ package horizonclient
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -93,6 +94,7 @@ func addQueryParams(params ...interface{}) string {
 				}
 			}
 		default:
+			fmt.Printf("param is of type %T\n", param)
 			panic("Unknown parameter type")
 		}
 	}

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -106,6 +106,7 @@ type ClientInterface interface {
 	TransactionDetail(txHash string) (hProtocol.Transaction, error)
 	OrderBook(request OrderBookRequest) (hProtocol.OrderBookSummary, error)
 	Paths(request PathsRequest) (hProtocol.PathsPage, error)
+	Payments(request OperationRequest) (operations.OperationsPage, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network
@@ -194,6 +195,7 @@ type OperationRequest struct {
 	Cursor         string
 	Limit          uint
 	IncludeFailed  bool
+	endpoint       string
 }
 
 type submitRequest struct {

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -105,6 +105,7 @@ type ClientInterface interface {
 	Transactions(request TransactionRequest) (hProtocol.TransactionsPage, error)
 	TransactionDetail(txHash string) (hProtocol.Transaction, error)
 	OrderBook(request OrderBookRequest) (hProtocol.OrderBookSummary, error)
+	Paths(request PathsRequest) (hProtocol.PathsPage, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network
@@ -220,4 +221,14 @@ type OrderBookRequest struct {
 	BuyingAssetCode    string
 	BuyingAssetIssuer  string
 	Limit              uint
+}
+
+// PathsRequest struct contains data for getting available payment paths from an horizon server
+type PathsRequest struct {
+	DestinationAccount     string
+	DestinationAssetType   AssetType
+	DestinationAssetCode   string
+	DestinationAssetIssuer string
+	DestinationAmount      string
+	SourceAccount          string
 }

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -277,6 +277,40 @@ func ExampleClient_OrderBook() {
 	fmt.Print(obs)
 }
 
+func ExampleClient_Payments() {
+
+	client := DefaultPublicNetClient
+	// payments for an account
+	opRequest := OperationRequest{ForAccount: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
+	ops, err := client.Payments(opRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(ops)
+
+	// all payments
+	opRequest = OperationRequest{Cursor: "now"}
+	ops, err = client.Payments(opRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(ops)
+	records := ops.Embedded.Records
+
+	for _, value := range records {
+		// prints the type
+		fmt.Print(value.GetType())
+		// for example if the type is create_account
+		c, ok := value.(operations.CreateAccount)
+		if ok {
+			// access create_account fields
+			fmt.Print(c.StartingBalance)
+		}
+
+	}
+}
 func TestAccountDetail(t *testing.T) {
 	hmock := httptest.NewClient()
 	client := &Client{
@@ -718,6 +752,36 @@ func TestOperationsRequest(t *testing.T) {
 		assert.Equal(t, c.TransactionHash, "ade3c60f1b581e8744596673d95bffbdb8f68f199e0e2f7d63b7c3af9fd8d868")
 	}
 
+	// all payments
+	hmock.On(
+		"GET",
+		"https://localhost/payments",
+	).ReturnString(200, paymentsResponse)
+
+	ops, err = client.Payments(operationRequest)
+	if assert.NoError(t, err) {
+		assert.IsType(t, ops, operations.OperationsPage{})
+		links := ops.Links
+		assert.Equal(t, links.Self.Href, "https://horizon-testnet.stellar.org/payments?cursor=&limit=2&order=desc")
+
+		assert.Equal(t, links.Next.Href, "https://horizon-testnet.stellar.org/payments?cursor=2024660468248577&limit=2&order=desc")
+
+		assert.Equal(t, links.Prev.Href, "https://horizon-testnet.stellar.org/payments?cursor=2024660468256769&limit=2&order=asc")
+
+		createAccountOp := ops.Embedded.Records[0]
+		paymentOp := ops.Embedded.Records[1]
+
+		assert.IsType(t, paymentOp, operations.Payment{})
+		assert.IsType(t, createAccountOp, operations.CreateAccount{})
+
+		p, ok := paymentOp.(operations.Payment)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, p.ID, "2024660468248577")
+		assert.Equal(t, p.Amount, "177.0000000")
+		assert.Equal(t, p.TransactionHash, "87d7a29539e7902b14a6c720094856f74a77128ab332d8629432c5a176a9fe7b")
+	}
+
+	// operations for account
 	operationRequest = OperationRequest{ForAccount: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
 	hmock.On(
 		"GET",
@@ -1792,4 +1856,83 @@ var orderBookNotFound = `{
   "title": "Invalid Order Book Parameters",
   "status": 400,
   "detail": "The parameters that specify what order book to view are invalid in some way. Please ensure that your type parameters (selling_asset_type and buying_asset_type) are one the following valid values: native, credit_alphanum4, credit_alphanum12.  Also ensure that you have specified selling_asset_code and selling_asset_issuer if selling_asset_type is not 'native', as well as buying_asset_code and buying_asset_issuer if buying_asset_type is not 'native'"
+}`
+
+var paymentsResponse = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/payments?cursor=&limit=2&order=desc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/payments?cursor=2024660468248577&limit=2&order=desc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/payments?cursor=2024660468256769&limit=2&order=asc"
+    }
+  },
+  "_embedded": {
+    "records": [
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/operations/2024660468256769"
+          },
+          "transaction": {
+            "href": "https://horizon-testnet.stellar.org/transactions/a0207513c372146bae8cdb299975047216cb1ffb393074b2015b39496e8767c2"
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/operations/2024660468256769/effects"
+          },
+          "succeeds": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc&cursor=2024660468256769"
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc&cursor=2024660468256769"
+          }
+        },
+        "id": "2024660468256769",
+        "paging_token": "2024660468256769",
+        "transaction_successful": true,
+        "source_account": "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR",
+        "type": "create_account",
+        "type_i": 0,
+        "created_at": "2019-03-27T09:55:41Z",
+        "transaction_hash": "a0207513c372146bae8cdb299975047216cb1ffb393074b2015b39496e8767c2",
+        "starting_balance": "10000.0000000",
+        "funder": "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR",
+        "account": "GB4OHVQE7OZH4HLCHFNR7OHDMZVNKOJT3RCRAXRNGGCNUHFRVGUGKW36"
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/operations/2024660468248577"
+          },
+          "transaction": {
+            "href": "https://horizon-testnet.stellar.org/transactions/87d7a29539e7902b14a6c720094856f74a77128ab332d8629432c5a176a9fe7b"
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/operations/2024660468248577/effects"
+          },
+          "succeeds": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc&cursor=2024660468248577"
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc&cursor=2024660468248577"
+          }
+        },
+        "id": "2024660468248577",
+        "paging_token": "2024660468248577",
+        "transaction_successful": true,
+        "source_account": "GAL6CXEVI3Y4O4J3FIX3KCRF7HSUG5RW2IRQRUUFC6XHZOLNV3NU35TL",
+        "type": "payment",
+        "type_i": 1,
+        "created_at": "2019-03-27T09:55:41Z",
+        "transaction_hash": "87d7a29539e7902b14a6c720094856f74a77128ab332d8629432c5a176a9fe7b",
+        "asset_type": "native",
+        "from": "GAL6CXEVI3Y4O4J3FIX3KCRF7HSUG5RW2IRQRUUFC6XHZOLNV3NU35TL",
+        "to": "GDGEQS64ISS6Y2KDM5V67B6LXALJX4E7VE4MIA54NANSUX5MKGKBZM5G",
+        "amount": "177.0000000"
+      }
+    ]
+  }
 }`

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -112,5 +112,11 @@ func (m *MockClient) OrderBook(request OrderBookRequest) (hProtocol.OrderBookSum
 	return a.Get(0).(hProtocol.OrderBookSummary), a.Error(1)
 }
 
+// Paths is a mocking method
+func (m *MockClient) Paths(request PathsRequest) (hProtocol.PathsPage, error) {
+	a := m.Called(request)
+	return a.Get(0).(hProtocol.PathsPage), a.Error(1)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -118,5 +118,11 @@ func (m *MockClient) Paths(request PathsRequest) (hProtocol.PathsPage, error) {
 	return a.Get(0).(hProtocol.PathsPage), a.Error(1)
 }
 
+// Payments is a mocking method
+func (m *MockClient) Payments(request OperationRequest) (operations.OperationsPage, error) {
+	a := m.Called(request)
+	return a.Get(0).(operations.OperationsPage), a.Error(1)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}

--- a/exp/clients/horizon/operation_request_test.go
+++ b/exp/clients/horizon/operation_request_test.go
@@ -8,42 +8,42 @@ import (
 )
 
 func TestOperationRequestBuildUrl(t *testing.T) {
-	op := OperationRequest{}
+	op := OperationRequest{endpoint: "operations"}
 	endpoint, err := op.BuildUrl()
 
 	// It should return valid all operations endpoint and no errors
 	require.NoError(t, err)
 	assert.Equal(t, "operations", endpoint)
 
-	op = OperationRequest{ForAccount: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
+	op = OperationRequest{ForAccount: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU", endpoint: "operations"}
 	endpoint, err = op.BuildUrl()
 
 	// It should return valid account operations endpoint and no errors
 	require.NoError(t, err)
 	assert.Equal(t, "accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/operations", endpoint)
 
-	op = OperationRequest{ForLedger: 123}
+	op = OperationRequest{ForLedger: 123, endpoint: "operations"}
 	endpoint, err = op.BuildUrl()
 
 	// It should return valid ledger operations endpoint and no errors
 	require.NoError(t, err)
 	assert.Equal(t, "ledgers/123/operations", endpoint)
 
-	op = OperationRequest{forOperationId: "123"}
+	op = OperationRequest{forOperationId: "123", endpoint: "operations"}
 	endpoint, err = op.BuildUrl()
 
 	// It should return valid operation operations endpoint and no errors
 	require.NoError(t, err)
 	assert.Equal(t, "operations/123", endpoint)
 
-	op = OperationRequest{ForTransaction: "123"}
+	op = OperationRequest{ForTransaction: "123", endpoint: "payments"}
 	endpoint, err = op.BuildUrl()
 
-	// It should return valid transaction operations endpoint and no errors
+	// It should return valid transaction payments endpoint and no errors
 	require.NoError(t, err)
-	assert.Equal(t, "transactions/123/operations", endpoint)
+	assert.Equal(t, "transactions/123/payments", endpoint)
 
-	op = OperationRequest{ForLedger: 123, forOperationId: "789"}
+	op = OperationRequest{ForLedger: 123, forOperationId: "789", endpoint: "operations"}
 	endpoint, err = op.BuildUrl()
 
 	// error case: too many parameters for building any operation endpoint
@@ -51,10 +51,16 @@ func TestOperationRequestBuildUrl(t *testing.T) {
 		assert.Contains(t, err.Error(), "Invalid request. Too many parameters")
 	}
 
-	op = OperationRequest{Cursor: "123456", Limit: 30, Order: OrderAsc}
+	op = OperationRequest{Cursor: "123456", Limit: 30, Order: OrderAsc, endpoint: "operations"}
 	endpoint, err = op.BuildUrl()
 	// It should return valid all operations endpoint with query params and no errors
 	require.NoError(t, err)
 	assert.Equal(t, "operations?cursor=123456&limit=30&order=asc", endpoint)
+
+	op = OperationRequest{Cursor: "123456", Limit: 30, Order: OrderAsc, endpoint: "payments"}
+	endpoint, err = op.BuildUrl()
+	// It should return valid all operations endpoint with query params and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "payments?cursor=123456&limit=30&order=asc", endpoint)
 
 }

--- a/exp/clients/horizon/paths_request.go
+++ b/exp/clients/horizon/paths_request.go
@@ -1,0 +1,35 @@
+package horizonclient
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/stellar/go/support/errors"
+)
+
+// BuildUrl creates the endpoint to be queried based on the data in the PathsRequest struct.
+func (pr PathsRequest) BuildUrl() (endpoint string, err error) {
+	endpoint = "paths"
+
+	// add the parameters to a map here so it is easier for addQueryParams to populate the parameter list
+	// We can't use assetCode and assetIssuer types here because the paremeter names are different
+	paramMap := make(map[string]string)
+	paramMap["destination_account"] = pr.DestinationAccount
+	paramMap["destination_asset_type"] = string(pr.DestinationAssetType)
+	paramMap["destination_asset_code"] = pr.DestinationAssetCode
+	paramMap["destination_asset_issuer"] = pr.DestinationAssetIssuer
+	paramMap["destination_amount"] = pr.DestinationAmount
+	paramMap["source_account"] = pr.SourceAccount
+
+	queryParams := addQueryParams(paramMap)
+	if queryParams != "" {
+		endpoint = fmt.Sprintf("%s?%s", endpoint, queryParams)
+	}
+
+	_, err = url.Parse(endpoint)
+	if err != nil {
+		err = errors.Wrap(err, "failed to parse endpoint")
+	}
+
+	return endpoint, err
+}

--- a/exp/clients/horizon/paths_request_test.go
+++ b/exp/clients/horizon/paths_request_test.go
@@ -1,0 +1,178 @@
+package horizonclient
+
+import (
+	"fmt"
+	"testing"
+
+	hProtocol "github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/support/http/httptest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathsRequestBuildUrl(t *testing.T) {
+	pr := PathsRequest{}
+	endpoint, err := pr.BuildUrl()
+
+	// It should return no errors and orderbook endpoint
+	// Horizon will return an error though because there are no parameters
+	require.NoError(t, err)
+	assert.Equal(t, "paths", endpoint)
+
+	pr = PathsRequest{
+		DestinationAccount:     "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+		DestinationAmount:      "100",
+		DestinationAssetCode:   "NGN",
+		DestinationAssetIssuer: "GDZST3XVCDTUJ76ZAV2HA72KYQODXXZ5PTMAPZGDHZ6CS7RO7MGG3DBM",
+		DestinationAssetType:   AssetType4,
+		SourceAccount:          "GDZST3XVCDTUJ76ZAV2HA72KYQODXXZ5PTMAPZGDHZ6CS7RO7MGG3DBM",
+	}
+
+	endpoint, err = pr.BuildUrl()
+
+	// It should return valid assets endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "paths?destination_account=GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU&destination_amount=100&destination_asset_code=NGN&destination_asset_issuer=GDZST3XVCDTUJ76ZAV2HA72KYQODXXZ5PTMAPZGDHZ6CS7RO7MGG3DBM&destination_asset_type=credit_alphanum4&source_account=GDZST3XVCDTUJ76ZAV2HA72KYQODXXZ5PTMAPZGDHZ6CS7RO7MGG3DBM", endpoint)
+
+}
+
+func ExampleClient_Paths() {
+
+	client := DefaultPublicNetClient
+	// Find paths for XLM->NGN
+	pr := PathsRequest{
+		DestinationAccount:     "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+		DestinationAmount:      "100",
+		DestinationAssetCode:   "NGN",
+		DestinationAssetIssuer: "GDZST3XVCDTUJ76ZAV2HA72KYQODXXZ5PTMAPZGDHZ6CS7RO7MGG3DBM",
+		DestinationAssetType:   AssetType4,
+		SourceAccount:          "GDZST3XVCDTUJ76ZAV2HA72KYQODXXZ5PTMAPZGDHZ6CS7RO7MGG3DBM",
+	}
+	paths, err := client.Paths(pr)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(paths)
+}
+
+func TestPathsRequest(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	pr := PathsRequest{
+		DestinationAccount:     "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+		DestinationAmount:      "100",
+		DestinationAssetCode:   "NGN",
+		DestinationAssetIssuer: "GDZST3XVCDTUJ76ZAV2HA72KYQODXXZ5PTMAPZGDHZ6CS7RO7MGG3DBM",
+		DestinationAssetType:   AssetType4,
+		SourceAccount:          "GDZST3XVCDTUJ76ZAV2HA72KYQODXXZ5PTMAPZGDHZ6CS7RO7MGG3DBM",
+	}
+
+	// orderbook for XLM/USD
+	hmock.On(
+		"GET",
+		"https://localhost/paths?destination_account=GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU&destination_amount=100&destination_asset_code=NGN&destination_asset_issuer=GDZST3XVCDTUJ76ZAV2HA72KYQODXXZ5PTMAPZGDHZ6CS7RO7MGG3DBM&destination_asset_type=credit_alphanum4&source_account=GDZST3XVCDTUJ76ZAV2HA72KYQODXXZ5PTMAPZGDHZ6CS7RO7MGG3DBM",
+	).ReturnString(200, pathsResponse)
+
+	paths, err := client.Paths(pr)
+	if assert.NoError(t, err) {
+		assert.IsType(t, paths, hProtocol.PathsPage{})
+		record := paths.Embedded.Records[0]
+		assert.Equal(t, record.DestinationAmount, "20.0000000")
+		assert.Equal(t, record.DestinationAssetCode, "EUR")
+		assert.Equal(t, record.SourceAmount, "30.0000000")
+	}
+
+	// failure response
+	pr = PathsRequest{}
+	hmock.On(
+		"GET",
+		"https://localhost/paths",
+	).ReturnString(400, badRequestResponse)
+
+	_, err = client.Paths(pr)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Horizon error")
+		horizonError, ok := err.(*Error)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, horizonError.Problem.Title, "Bad Request")
+	}
+
+}
+
+var badRequestResponse = `{
+  "type": "https://stellar.org/horizon-errors/bad_request",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The request you sent was invalid in some way",
+  "extras": {
+    "invalid_field": "destination_amount",
+    "reason": "Value must be positive"
+  }
+}`
+
+var pathsResponse = `{
+  "_embedded": {
+    "records": [
+      {
+        "destination_amount": "20.0000000",
+        "destination_asset_code": "EUR",
+        "destination_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+        "destination_asset_type": "credit_alphanum4",
+        "path": [],
+        "source_amount": "30.0000000",
+        "source_asset_code": "USD",
+        "source_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+        "source_asset_type": "credit_alphanum4"
+      },
+      {
+        "destination_amount": "20.0000000",
+        "destination_asset_code": "EUR",
+        "destination_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+        "destination_asset_type": "credit_alphanum4",
+        "path": [
+          {
+            "asset_code": "1",
+            "asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+            "asset_type": "credit_alphanum4"
+          }
+        ],
+        "source_amount": "20.0000000",
+        "source_asset_code": "USD",
+        "source_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+        "source_asset_type": "credit_alphanum4"
+      },
+      {
+        "destination_amount": "20.0000000",
+        "destination_asset_code": "EUR",
+        "destination_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+        "destination_asset_type": "credit_alphanum4",
+        "path": [
+          {
+            "asset_code": "21",
+            "asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+            "asset_type": "credit_alphanum4"
+          },
+          {
+            "asset_code": "22",
+            "asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+            "asset_type": "credit_alphanum4"
+          }
+        ],
+        "source_amount": "20.0000000",
+        "source_asset_code": "USD",
+        "source_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+        "source_asset_type": "credit_alphanum4"
+      }
+    ]
+  },
+  "_links": {
+    "self": {
+      "href": "/paths"
+    }
+  }
+}`

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -612,3 +612,11 @@ type TransactionsPage struct {
 		Records []Transaction
 	} `json:"_embedded"`
 }
+
+// PathsPage contains records of payment paths found by horizon
+type PathsPage struct {
+	Links    hal.Links `json:"_links"`
+	Embedded struct {
+		Records []Path
+	} `json:"_embedded"`
+}


### PR DESCRIPTION
This PR adds support for querying the payments endpoint. 
Given that `/payments` return multiple operation types, we extend `OperationRequest` instead of creating a `PaymentRequest` struct which will be a duplicate.
Closes #1019 
