### PR TITLE
set client app name and app version explicitly in exp Go SDK

### DIFF
--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -33,8 +33,15 @@ func (c *Client) sendRequest(hr HorizonRequest, a interface{}) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "Error creating HTTP request")
 	}
-	req.Header.Set("X-Client-Name", "go-stellar-sdk")
-	req.Header.Set("X-Client-Version", app.Version())
+
+	if c.AppName == "" {
+		c.AppName = "go-stellar-sdk"
+	}
+	req.Header.Set("X-Client-Name", c.AppName)
+	if c.AppVersion == "" {
+		c.AppVersion = app.Version()
+	}
+	req.Header.Set("X-Client-Version", c.AppVersion)
 
 	if c.horizonTimeOut == 0 {
 		c.horizonTimeOut = HorizonTimeOut

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -33,15 +33,10 @@ func (c *Client) sendRequest(hr HorizonRequest, a interface{}) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "Error creating HTTP request")
 	}
-
-	if c.AppName == "" {
-		c.AppName = "go-stellar-sdk"
-	}
-	req.Header.Set("X-Client-Name", c.AppName)
-	if c.AppVersion == "" {
-		c.AppVersion = app.Version()
-	}
-	req.Header.Set("X-Client-Version", c.AppVersion)
+	req.Header.Set("X-Client-Name", "go-stellar-sdk")
+	req.Header.Set("X-Client-Version", app.Version())
+	req.Header.Set("X-App-Name", c.AppName)
+	req.Header.Set("X-App-Version", c.AppVersion)
 
 	if c.horizonTimeOut == 0 {
 		c.horizonTimeOut = HorizonTimeOut

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -103,6 +103,8 @@ type Client struct {
 	HorizonURL     string
 	HTTP           HTTP
 	horizonTimeOut time.Duration
+	AppName        string
+	AppVersion     string
 }
 
 // ClientInterface contains methods implemented by the horizon client

--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -53,6 +53,8 @@ func contextMiddleware(next http.Handler) http.Handler {
 const (
 	clientNameHeader    = "X-Client-Name"
 	clientVersionHeader = "X-Client-Version"
+	appNameHeader       = "X-App-Name"
+	appVersionHeader    = "X-App-Version"
 )
 
 // loggerMiddleware logs http requests and resposnes to the logging subsytem of horizon.
@@ -99,6 +101,8 @@ func logStartOfRequest(ctx context.Context, r *http.Request, streaming bool) {
 	log.Ctx(ctx).WithFields(log.F{
 		"client_name":    getClientData(r, clientNameHeader),
 		"client_version": getClientData(r, clientVersionHeader),
+		"app_name":       getClientData(r, appNameHeader),
+		"app_version":    getClientData(r, appVersionHeader),
 		"forwarded_ip":   firstXForwardedFor(r),
 		"host":           r.Host,
 		"ip":             remoteAddrIP(r),
@@ -121,6 +125,8 @@ func logEndOfRequest(ctx context.Context, r *http.Request, duration time.Duratio
 		"bytes":          mw.BytesWritten(),
 		"client_name":    getClientData(r, clientNameHeader),
 		"client_version": getClientData(r, clientVersionHeader),
+		"app_name":       getClientData(r, appNameHeader),
+		"app_version":    getClientData(r, appVersionHeader),
 		"duration":       duration.Seconds(),
 		"forwarded_ip":   firstXForwardedFor(r),
 		"host":           r.Host,


### PR DESCRIPTION
this allows any app using the new SDK to set the client app name and version explicitly