### PR TITLE
exp/txnbuild: reduce xdr scope

### DIFF
--- a/exp/clients/horizon/error.go
+++ b/exp/clients/horizon/error.go
@@ -2,6 +2,8 @@ package horizonclient
 
 import (
 	"encoding/json"
+	"fmt"
+	"reflect"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/errors"
@@ -69,6 +71,9 @@ func (herr *Error) ResultCodes() (*hProtocol.TransactionResultCodes, error) {
 		return nil, ErrResultCodesNotPopulated
 	}
 
+	println(raw)
+	fmt.Println(reflect.TypeOf(raw))
+	fmt.Println(raw)
 	rawB, ok := raw.([]byte)
 	if !ok {
 		return nil, errors.New("type assertion failed")

--- a/exp/txnbuild/account_merge.go
+++ b/exp/txnbuild/account_merge.go
@@ -13,19 +13,15 @@ type AccountMerge struct {
 
 // BuildXDR for AccountMerge returns a fully configured XDR Operation.
 func (am *AccountMerge) BuildXDR() (xdr.Operation, error) {
-	var err error
 	var xdrOp xdr.AccountId
 
-	err = xdrOp.SetAddress(am.Destination)
+	err := xdrOp.SetAddress(am.Destination)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set destination address")
 	}
 
 	opType := xdr.OperationTypeAccountMerge
 	body, err := xdr.NewOperationBody(opType, xdrOp)
-	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
-	}
 
-	return xdr.Operation{Body: body}, nil
+	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")
 }

--- a/exp/txnbuild/account_merge.go
+++ b/exp/txnbuild/account_merge.go
@@ -8,21 +8,21 @@ import (
 // AccountMerge represents the Stellar merge account operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type AccountMerge struct {
-	destAccountID xdr.AccountId
-	Destination   string
-	xdrOp         xdr.AccountId
+	Destination string
 }
 
 // BuildXDR for AccountMerge returns a fully configured XDR Operation.
 func (am *AccountMerge) BuildXDR() (xdr.Operation, error) {
-	err := am.destAccountID.SetAddress(am.Destination)
+	var err error
+	var xdrOp xdr.AccountId
+
+	err = xdrOp.SetAddress(am.Destination)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set destination address")
 	}
-	am.xdrOp = am.destAccountID
 
 	opType := xdr.OperationTypeAccountMerge
-	body, err := xdr.NewOperationBody(opType, am.xdrOp)
+	body, err := xdr.NewOperationBody(opType, xdrOp)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
 	}

--- a/exp/txnbuild/allow_trust.go
+++ b/exp/txnbuild/allow_trust.go
@@ -15,11 +15,10 @@ type AllowTrust struct {
 
 // BuildXDR for AllowTrust returns a fully configured XDR Operation.
 func (at *AllowTrust) BuildXDR() (xdr.Operation, error) {
-	var err error
 	var xdrOp xdr.AllowTrustOp
 
 	// Set XDR address associated with the trustline
-	err = xdrOp.Trustor.SetAddress(at.Trustor)
+	err := xdrOp.Trustor.SetAddress(at.Trustor)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set trustor address")
 	}
@@ -40,9 +39,6 @@ func (at *AllowTrust) BuildXDR() (xdr.Operation, error) {
 
 	opType := xdr.OperationTypeAllowTrust
 	body, err := xdr.NewOperationBody(opType, xdrOp)
-	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
-	}
 
-	return xdr.Operation{Body: body}, nil
+	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")
 }

--- a/exp/txnbuild/allow_trust.go
+++ b/exp/txnbuild/allow_trust.go
@@ -11,15 +11,15 @@ type AllowTrust struct {
 	Trustor   string
 	Type      *Asset
 	Authorize bool
-	xdrOp     xdr.AllowTrustOp
 }
 
 // BuildXDR for AllowTrust returns a fully configured XDR Operation.
 func (at *AllowTrust) BuildXDR() (xdr.Operation, error) {
 	var err error
+	var xdrOp xdr.AllowTrustOp
 
 	// Set XDR address associated with the trustline
-	err = at.xdrOp.Trustor.SetAddress(at.Trustor)
+	err = xdrOp.Trustor.SetAddress(at.Trustor)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set trustor address")
 	}
@@ -30,16 +30,16 @@ func (at *AllowTrust) BuildXDR() (xdr.Operation, error) {
 	}
 
 	// AllowTrust has a special asset type - map to it
-	at.xdrOp.Asset, err = at.Type.ToXDRAllowTrustOpAsset()
+	xdrOp.Asset, err = at.Type.ToXDRAllowTrustOpAsset()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Can't convert asset for trustline to XDR")
 	}
 
 	// Set XDR auth flag
-	at.xdrOp.Authorize = at.Authorize
+	xdrOp.Authorize = at.Authorize
 
 	opType := xdr.OperationTypeAllowTrust
-	body, err := xdr.NewOperationBody(opType, at.xdrOp)
+	body, err := xdr.NewOperationBody(opType, xdrOp)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
 	}

--- a/exp/txnbuild/bump_sequence.go
+++ b/exp/txnbuild/bump_sequence.go
@@ -9,15 +9,16 @@ import (
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type BumpSequence struct {
 	BumpTo int64
-	xdrOp  xdr.BumpSequenceOp
 }
 
 // BuildXDR for BumpSequence returns a fully configured XDR Operation.
 func (bs *BumpSequence) BuildXDR() (xdr.Operation, error) {
-	bs.xdrOp.BumpTo = xdr.SequenceNumber(bs.BumpTo)
+	var xdrOp xdr.BumpSequenceOp
+
+	xdrOp.BumpTo = xdr.SequenceNumber(bs.BumpTo)
 
 	opType := xdr.OperationTypeBumpSequence
-	body, err := xdr.NewOperationBody(opType, bs.xdrOp)
+	body, err := xdr.NewOperationBody(opType, xdrOp)
 
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")

--- a/exp/txnbuild/bump_sequence.go
+++ b/exp/txnbuild/bump_sequence.go
@@ -13,11 +13,8 @@ type BumpSequence struct {
 
 // BuildXDR for BumpSequence returns a fully configured XDR Operation.
 func (bs *BumpSequence) BuildXDR() (xdr.Operation, error) {
-	var xdrOp xdr.BumpSequenceOp
-
-	xdrOp.BumpTo = xdr.SequenceNumber(bs.BumpTo)
-
 	opType := xdr.OperationTypeBumpSequence
+	xdrOp := xdr.BumpSequenceOp{BumpTo: xdr.SequenceNumber(bs.BumpTo)}
 	body, err := xdr.NewOperationBody(opType, xdrOp)
 
 	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")

--- a/exp/txnbuild/bump_sequence.go
+++ b/exp/txnbuild/bump_sequence.go
@@ -20,9 +20,5 @@ func (bs *BumpSequence) BuildXDR() (xdr.Operation, error) {
 	opType := xdr.OperationTypeBumpSequence
 	body, err := xdr.NewOperationBody(opType, xdrOp)
 
-	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
-	}
-
-	return xdr.Operation{Body: body}, nil
+	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")
 }

--- a/exp/txnbuild/change_trust.go
+++ b/exp/txnbuild/change_trust.go
@@ -11,7 +11,6 @@ import (
 type ChangeTrust struct {
 	Line  *Asset
 	Limit string
-	xdrOp xdr.ChangeTrustOp
 }
 
 // NewRemoveTrustlineOp returns a ChangeTrust operation to remove the trustline of the described asset,
@@ -26,21 +25,23 @@ func NewRemoveTrustlineOp(issuedAsset *Asset) ChangeTrust {
 // BuildXDR for ChangeTrust returns a fully configured XDR Operation.
 func (ct *ChangeTrust) BuildXDR() (xdr.Operation, error) {
 	var err error
+	var xdrOp xdr.ChangeTrustOp
+
 	if ct.Line.IsNative() {
 		return xdr.Operation{}, errors.New("Trustline cannot be extended to a native (XLM) asset")
 	}
-	ct.xdrOp.Line, err = ct.Line.ToXDR()
+	xdrOp.Line, err = ct.Line.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Can't convert asset for trustline to XDR")
 	}
 
-	ct.xdrOp.Limit, err = amount.Parse(ct.Limit)
+	xdrOp.Limit, err = amount.Parse(ct.Limit)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to parse limit amount")
 	}
 
 	opType := xdr.OperationTypeChangeTrust
-	body, err := xdr.NewOperationBody(opType, ct.xdrOp)
+	body, err := xdr.NewOperationBody(opType, xdrOp)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
 	}

--- a/exp/txnbuild/change_trust.go
+++ b/exp/txnbuild/change_trust.go
@@ -24,23 +24,24 @@ func NewRemoveTrustlineOp(issuedAsset *Asset) ChangeTrust {
 
 // BuildXDR for ChangeTrust returns a fully configured XDR Operation.
 func (ct *ChangeTrust) BuildXDR() (xdr.Operation, error) {
-	var err error
-	var xdrOp xdr.ChangeTrustOp
-
 	if ct.Line.IsNative() {
 		return xdr.Operation{}, errors.New("Trustline cannot be extended to a native (XLM) asset")
 	}
-	xdrOp.Line, err = ct.Line.ToXDR()
+	xdrLine, err := ct.Line.ToXDR()
 	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "Can't convert asset for trustline to XDR")
+		return xdr.Operation{}, errors.Wrap(err, "Can't convert trustline asset to XDR")
 	}
 
-	xdrOp.Limit, err = amount.Parse(ct.Limit)
+	xdrLimit, err := amount.Parse(ct.Limit)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to parse limit amount")
 	}
 
 	opType := xdr.OperationTypeChangeTrust
+	xdrOp := xdr.ChangeTrustOp{
+		Line:  xdrLine,
+		Limit: xdrLimit,
+	}
 	body, err := xdr.NewOperationBody(opType, xdrOp)
 
 	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")

--- a/exp/txnbuild/change_trust.go
+++ b/exp/txnbuild/change_trust.go
@@ -42,9 +42,6 @@ func (ct *ChangeTrust) BuildXDR() (xdr.Operation, error) {
 
 	opType := xdr.OperationTypeChangeTrust
 	body, err := xdr.NewOperationBody(opType, xdrOp)
-	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
-	}
 
-	return xdr.Operation{Body: body}, nil
+	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")
 }

--- a/exp/txnbuild/create_account.go
+++ b/exp/txnbuild/create_account.go
@@ -30,9 +30,6 @@ func (ca *CreateAccount) BuildXDR() (xdr.Operation, error) {
 
 	opType := xdr.OperationTypeCreateAccount
 	body, err := xdr.NewOperationBody(opType, xdrOp)
-	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
-	}
 
-	return xdr.Operation{Body: body}, nil
+	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")
 }

--- a/exp/txnbuild/create_account.go
+++ b/exp/txnbuild/create_account.go
@@ -9,28 +9,27 @@ import (
 // CreateAccount represents the Stellar create account operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type CreateAccount struct {
-	destAccountID xdr.AccountId
-	Destination   string
-	Amount        string
-	Asset         string // TODO: Not used yet
-	xdrOp         xdr.CreateAccountOp
+	Destination string
+	Amount      string
+	Asset       string // TODO: Not used yet
 }
 
 // BuildXDR for CreateAccount returns a fully configured XDR Operation.
 func (ca *CreateAccount) BuildXDR() (xdr.Operation, error) {
-	err := ca.destAccountID.SetAddress(ca.Destination)
+	var xdrOp xdr.CreateAccountOp
+
+	err := xdrOp.Destination.SetAddress(ca.Destination)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set destination address")
 	}
-	ca.xdrOp.Destination = ca.destAccountID
 
-	ca.xdrOp.StartingBalance, err = amount.Parse(ca.Amount)
+	xdrOp.StartingBalance, err = amount.Parse(ca.Amount)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to parse amount")
 	}
 
 	opType := xdr.OperationTypeCreateAccount
-	body, err := xdr.NewOperationBody(opType, ca.xdrOp)
+	body, err := xdr.NewOperationBody(opType, xdrOp)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
 	}

--- a/exp/txnbuild/create_passive_offer.go
+++ b/exp/txnbuild/create_passive_offer.go
@@ -18,27 +18,31 @@ type CreatePassiveOffer struct {
 
 // BuildXDR for CreatePassiveOffer returns a fully configured XDR Operation.
 func (cpo *CreatePassiveOffer) BuildXDR() (xdr.Operation, error) {
-	var err error
-	var xdrOp xdr.CreatePassiveOfferOp
-
-	xdrOp.Selling, err = cpo.Selling.ToXDR()
+	xdrSelling, err := cpo.Selling.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set XDR 'Selling' field")
 	}
 
-	xdrOp.Buying, err = cpo.Buying.ToXDR()
+	xdrBuying, err := cpo.Buying.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set XDR 'Buying' field")
 	}
 
-	xdrOp.Amount, err = amount.Parse(cpo.Amount)
+	xdrAmount, err := amount.Parse(cpo.Amount)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to parse 'Amount'")
 	}
 
-	xdrOp.Price, err = price.Parse(cpo.Price)
+	xdrPrice, err := price.Parse(cpo.Price)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to parse 'Price'")
+	}
+
+	xdrOp := xdr.CreatePassiveOfferOp{
+		Selling: xdrSelling,
+		Buying:  xdrBuying,
+		Amount:  xdrAmount,
+		Price:   xdrPrice,
 	}
 
 	opType := xdr.OperationTypeCreatePassiveOffer

--- a/exp/txnbuild/create_passive_offer.go
+++ b/exp/txnbuild/create_passive_offer.go
@@ -43,9 +43,6 @@ func (cpo *CreatePassiveOffer) BuildXDR() (xdr.Operation, error) {
 
 	opType := xdr.OperationTypeCreatePassiveOffer
 	body, err := xdr.NewOperationBody(opType, xdrOp)
-	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
-	}
 
-	return xdr.Operation{Body: body}, nil
+	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")
 }

--- a/exp/txnbuild/inflation.go
+++ b/exp/txnbuild/inflation.go
@@ -7,9 +7,7 @@ import (
 
 // Inflation represents the Stellar inflation operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
-type Inflation struct {
-	xdrOp struct{}
-}
+type Inflation struct{}
 
 // BuildXDR for Inflation returns a fully configured XDR Operation.
 func (inf *Inflation) BuildXDR() (xdr.Operation, error) {

--- a/exp/txnbuild/inflation.go
+++ b/exp/txnbuild/inflation.go
@@ -13,9 +13,6 @@ type Inflation struct{}
 func (inf *Inflation) BuildXDR() (xdr.Operation, error) {
 	opType := xdr.OperationTypeInflation
 	body, err := xdr.NewOperationBody(opType, nil)
-	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
-	}
 
-	return xdr.Operation{Body: body}, nil
+	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")
 }

--- a/exp/txnbuild/manage_data.go
+++ b/exp/txnbuild/manage_data.go
@@ -28,9 +28,6 @@ func (md *ManageData) BuildXDR() (xdr.Operation, error) {
 
 	opType := xdr.OperationTypeManageData
 	body, err := xdr.NewOperationBody(opType, xdrOp)
-	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
-	}
 
-	return xdr.Operation{Body: body}, nil
+	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")
 }

--- a/exp/txnbuild/manage_data.go
+++ b/exp/txnbuild/manage_data.go
@@ -14,9 +14,7 @@ type ManageData struct {
 
 // BuildXDR for ManageData returns a fully configured XDR Operation.
 func (md *ManageData) BuildXDR() (xdr.Operation, error) {
-	var xdrOp xdr.ManageDataOp
-
-	xdrOp.DataName = xdr.String64(md.Name)
+	xdrOp := xdr.ManageDataOp{DataName: xdr.String64(md.Name)}
 
 	// No data value clears the named data entry on the account
 	if md.Value == nil {

--- a/exp/txnbuild/manage_data.go
+++ b/exp/txnbuild/manage_data.go
@@ -10,23 +10,24 @@ import (
 type ManageData struct {
 	Name  string
 	Value []byte
-	xdrOp xdr.ManageDataOp
 }
 
 // BuildXDR for ManageData returns a fully configured XDR Operation.
 func (md *ManageData) BuildXDR() (xdr.Operation, error) {
-	md.xdrOp.DataName = xdr.String64(md.Name)
+	var xdrOp xdr.ManageDataOp
+
+	xdrOp.DataName = xdr.String64(md.Name)
 
 	// No data value clears the named data entry on the account
 	if md.Value == nil {
-		md.xdrOp.DataValue = nil
+		xdrOp.DataValue = nil
 	} else {
 		xdrDV := xdr.DataValue(md.Value)
-		md.xdrOp.DataValue = &xdrDV
+		xdrOp.DataValue = &xdrDV
 	}
 
 	opType := xdr.OperationTypeManageData
-	body, err := xdr.NewOperationBody(opType, md.xdrOp)
+	body, err := xdr.NewOperationBody(opType, xdrOp)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
 	}

--- a/exp/txnbuild/manage_offer.go
+++ b/exp/txnbuild/manage_offer.go
@@ -54,39 +54,40 @@ type ManageOffer struct {
 	Amount  string
 	Price   string // TODO: Extend to include number, and n/d fraction. See package 'amount'
 	OfferID uint64
-	xdrOp   xdr.ManageOfferOp
 }
 
 // BuildXDR for ManageOffer returns a fully configured XDR Operation.
 func (mo *ManageOffer) BuildXDR() (xdr.Operation, error) {
+	var xdrOp xdr.ManageOfferOp
+
 	xdrSelling, err := mo.Selling.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set XDR 'Selling' field")
 	}
-	mo.xdrOp.Selling = xdrSelling
+	xdrOp.Selling = xdrSelling
 
 	xdrBuying, err := mo.Buying.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set XDR 'Buying' field")
 	}
-	mo.xdrOp.Buying = xdrBuying
+	xdrOp.Buying = xdrBuying
 
 	xdrAmount, err := amount.Parse(mo.Amount)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to parse 'Amount'")
 	}
-	mo.xdrOp.Amount = xdrAmount
+	xdrOp.Amount = xdrAmount
 
 	xdrPrice, err := price.Parse(mo.Price)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to parse 'Price'")
 	}
-	mo.xdrOp.Price = xdrPrice
+	xdrOp.Price = xdrPrice
 
-	mo.xdrOp.OfferId = xdr.Uint64(mo.OfferID)
+	xdrOp.OfferId = xdr.Uint64(mo.OfferID)
 
 	opType := xdr.OperationTypeManageOffer
-	body, err := xdr.NewOperationBody(opType, mo.xdrOp)
+	body, err := xdr.NewOperationBody(opType, xdrOp)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
 	}

--- a/exp/txnbuild/manage_offer.go
+++ b/exp/txnbuild/manage_offer.go
@@ -88,9 +88,6 @@ func (mo *ManageOffer) BuildXDR() (xdr.Operation, error) {
 
 	opType := xdr.OperationTypeManageOffer
 	body, err := xdr.NewOperationBody(opType, xdrOp)
-	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
-	}
 
-	return xdr.Operation{Body: body}, nil
+	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")
 }

--- a/exp/txnbuild/manage_offer.go
+++ b/exp/txnbuild/manage_offer.go
@@ -58,35 +58,34 @@ type ManageOffer struct {
 
 // BuildXDR for ManageOffer returns a fully configured XDR Operation.
 func (mo *ManageOffer) BuildXDR() (xdr.Operation, error) {
-	var xdrOp xdr.ManageOfferOp
-
 	xdrSelling, err := mo.Selling.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set XDR 'Selling' field")
 	}
-	xdrOp.Selling = xdrSelling
 
 	xdrBuying, err := mo.Buying.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set XDR 'Buying' field")
 	}
-	xdrOp.Buying = xdrBuying
 
 	xdrAmount, err := amount.Parse(mo.Amount)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to parse 'Amount'")
 	}
-	xdrOp.Amount = xdrAmount
 
 	xdrPrice, err := price.Parse(mo.Price)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to parse 'Price'")
 	}
-	xdrOp.Price = xdrPrice
-
-	xdrOp.OfferId = xdr.Uint64(mo.OfferID)
 
 	opType := xdr.OperationTypeManageOffer
+	xdrOp := xdr.ManageOfferOp{
+		Selling: xdrSelling,
+		Buying:  xdrBuying,
+		Amount:  xdrAmount,
+		Price:   xdrPrice,
+		OfferId: xdr.Uint64(mo.OfferID),
+	}
 	body, err := xdr.NewOperationBody(opType, xdrOp)
 
 	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")

--- a/exp/txnbuild/path_payment.go
+++ b/exp/txnbuild/path_payment.go
@@ -15,12 +15,12 @@ type PathPayment struct {
 	DestAsset   *Asset
 	DestAmount  string
 	Path        []Asset
-	xdrOp       xdr.PathPaymentOp
 }
 
 // BuildXDR for Payment returns a fully configured XDR Operation.
 func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
 	var err error
+	var xdrOp xdr.PathPaymentOp
 
 	// Set XDR send asset
 	if pp.SendAsset == nil {
@@ -30,16 +30,16 @@ func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set asset type")
 	}
-	pp.xdrOp.SendAsset = xdrSendAsset
+	xdrOp.SendAsset = xdrSendAsset
 
 	// Set XDR send max
-	pp.xdrOp.SendMax, err = amount.Parse(pp.SendMax)
+	xdrOp.SendMax, err = amount.Parse(pp.SendMax)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to parse maximum amount to send")
 	}
 
 	// Set XDR destination
-	err = pp.xdrOp.Destination.SetAddress(pp.Destination)
+	err = xdrOp.Destination.SetAddress(pp.Destination)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set destination address")
 	}
@@ -52,10 +52,10 @@ func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set asset type")
 	}
-	pp.xdrOp.DestAsset = xdrDestAsset
+	xdrOp.DestAsset = xdrDestAsset
 
 	// Set XDR destination amount
-	pp.xdrOp.DestAmount, err = amount.Parse(pp.DestAmount)
+	xdrOp.DestAmount, err = amount.Parse(pp.DestAmount)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to parse amount of asset destination account receives")
 	}
@@ -70,10 +70,10 @@ func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
 		}
 		xdrPath = append(xdrPath, xdrPathAsset)
 	}
-	pp.xdrOp.Path = xdrPath
+	xdrOp.Path = xdrPath
 
 	opType := xdr.OperationTypePathPayment
-	body, err := xdr.NewOperationBody(opType, pp.xdrOp)
+	body, err := xdr.NewOperationBody(opType, xdrOp)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
 	}

--- a/exp/txnbuild/path_payment.go
+++ b/exp/txnbuild/path_payment.go
@@ -19,8 +19,6 @@ type PathPayment struct {
 
 // BuildXDR for Payment returns a fully configured XDR Operation.
 func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
-	var xdrOp xdr.PathPaymentOp
-
 	// Set XDR send asset
 	if pp.SendAsset == nil {
 		return xdr.Operation{}, errors.New("You must specify an asset to send for payment")
@@ -29,16 +27,16 @@ func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set asset type")
 	}
-	xdrOp.SendAsset = xdrSendAsset
 
 	// Set XDR send max
-	xdrOp.SendMax, err = amount.Parse(pp.SendMax)
+	xdrSendMax, err := amount.Parse(pp.SendMax)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to parse maximum amount to send")
 	}
 
 	// Set XDR destination
-	err = xdrOp.Destination.SetAddress(pp.Destination)
+	var xdrDestination xdr.AccountId
+	err = xdrDestination.SetAddress(pp.Destination)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set destination address")
 	}
@@ -51,10 +49,9 @@ func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set asset type")
 	}
-	xdrOp.DestAsset = xdrDestAsset
 
 	// Set XDR destination amount
-	xdrOp.DestAmount, err = amount.Parse(pp.DestAmount)
+	xdrDestAmount, err := amount.Parse(pp.DestAmount)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to parse amount of asset destination account receives")
 	}
@@ -69,9 +66,16 @@ func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
 		}
 		xdrPath = append(xdrPath, xdrPathAsset)
 	}
-	xdrOp.Path = xdrPath
 
 	opType := xdr.OperationTypePathPayment
+	xdrOp := xdr.PathPaymentOp{
+		SendAsset:   xdrSendAsset,
+		SendMax:     xdrSendMax,
+		Destination: xdrDestination,
+		DestAsset:   xdrDestAsset,
+		DestAmount:  xdrDestAmount,
+		Path:        xdrPath,
+	}
 	body, err := xdr.NewOperationBody(opType, xdrOp)
 
 	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")

--- a/exp/txnbuild/path_payment.go
+++ b/exp/txnbuild/path_payment.go
@@ -19,7 +19,6 @@ type PathPayment struct {
 
 // BuildXDR for Payment returns a fully configured XDR Operation.
 func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
-	var err error
 	var xdrOp xdr.PathPaymentOp
 
 	// Set XDR send asset
@@ -74,9 +73,6 @@ func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
 
 	opType := xdr.OperationTypePathPayment
 	body, err := xdr.NewOperationBody(opType, xdrOp)
-	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
-	}
 
-	return xdr.Operation{Body: body}, nil
+	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")
 }

--- a/exp/txnbuild/payment.go
+++ b/exp/txnbuild/payment.go
@@ -17,10 +17,9 @@ type Payment struct {
 
 // BuildXDR for Payment returns a fully configured XDR Operation.
 func (p *Payment) BuildXDR() (xdr.Operation, error) {
-	var err error
 	var xdrOp xdr.PaymentOp
 
-	err = p.destAccountID.SetAddress(p.Destination)
+	err := p.destAccountID.SetAddress(p.Destination)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set destination address")
 	}
@@ -42,9 +41,6 @@ func (p *Payment) BuildXDR() (xdr.Operation, error) {
 
 	opType := xdr.OperationTypePayment
 	body, err := xdr.NewOperationBody(opType, xdrOp)
-	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
-	}
 
-	return xdr.Operation{Body: body}, nil
+	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")
 }

--- a/exp/txnbuild/payment.go
+++ b/exp/txnbuild/payment.go
@@ -13,18 +13,20 @@ type Payment struct {
 	Amount        string
 	Asset         *Asset
 	destAccountID xdr.AccountId
-	xdrOp         xdr.PaymentOp
 }
 
 // BuildXDR for Payment returns a fully configured XDR Operation.
 func (p *Payment) BuildXDR() (xdr.Operation, error) {
-	err := p.destAccountID.SetAddress(p.Destination)
+	var err error
+	var xdrOp xdr.PaymentOp
+
+	err = p.destAccountID.SetAddress(p.Destination)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set destination address")
 	}
-	p.xdrOp.Destination = p.destAccountID
+	xdrOp.Destination = p.destAccountID
 
-	p.xdrOp.Amount, err = amount.Parse(p.Amount)
+	xdrOp.Amount, err = amount.Parse(p.Amount)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to parse amount")
 	}
@@ -36,10 +38,10 @@ func (p *Payment) BuildXDR() (xdr.Operation, error) {
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set asset type")
 	}
-	p.xdrOp.Asset = xdrAsset
+	xdrOp.Asset = xdrAsset
 
 	opType := xdr.OperationTypePayment
-	body, err := xdr.NewOperationBody(opType, p.xdrOp)
+	body, err := xdr.NewOperationBody(opType, xdrOp)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
 	}

--- a/exp/txnbuild/payment.go
+++ b/exp/txnbuild/payment.go
@@ -9,23 +9,21 @@ import (
 // Payment represents the Stellar payment operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type Payment struct {
-	Destination   string
-	Amount        string
-	Asset         *Asset
-	destAccountID xdr.AccountId
+	Destination string
+	Amount      string
+	Asset       *Asset
 }
 
 // BuildXDR for Payment returns a fully configured XDR Operation.
 func (p *Payment) BuildXDR() (xdr.Operation, error) {
-	var xdrOp xdr.PaymentOp
+	var destAccountID xdr.AccountId
 
-	err := p.destAccountID.SetAddress(p.Destination)
+	err := destAccountID.SetAddress(p.Destination)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set destination address")
 	}
-	xdrOp.Destination = p.destAccountID
 
-	xdrOp.Amount, err = amount.Parse(p.Amount)
+	xdrAmount, err := amount.Parse(p.Amount)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to parse amount")
 	}
@@ -37,9 +35,13 @@ func (p *Payment) BuildXDR() (xdr.Operation, error) {
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set asset type")
 	}
-	xdrOp.Asset = xdrAsset
 
 	opType := xdr.OperationTypePayment
+	xdrOp := xdr.PaymentOp{
+		Destination: destAccountID,
+		Amount:      xdrAmount,
+		Asset:       xdrAsset,
+	}
 	body, err := xdr.NewOperationBody(opType, xdrOp)
 
 	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")

--- a/exp/txnbuild/set_options.go
+++ b/exp/txnbuild/set_options.go
@@ -64,8 +64,7 @@ type SetOptions struct {
 
 // BuildXDR for SetOptions returns a fully configured XDR Operation.
 func (so *SetOptions) BuildXDR() (xdr.Operation, error) {
-	var err error
-	err = so.handleInflation()
+	err := so.handleInflation()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Failed to set inflation destination address")
 	}
@@ -87,11 +86,8 @@ func (so *SetOptions) BuildXDR() (xdr.Operation, error) {
 
 	opType := xdr.OperationTypeSetOptions
 	body, err := xdr.NewOperationBody(opType, so.xdrOp)
-	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "Failed to build XDR OperationBody")
-	}
 
-	return xdr.Operation{Body: body}, nil
+	return xdr.Operation{Body: body}, errors.Wrap(err, "Failed to build XDR OperationBody")
 }
 
 // handleInflation for SetOptions sets the XDR inflation destination.


### PR DESCRIPTION
This small refactoring PR moves the internal `xdrOp` field out of each `Operation`'s struct to a local variable (see #1040 for rationale).

`CreatePassiveOffer` is missing because it was already done.
`SetOptions` was not changed because it has multiple methods that manipulate the state of the internal xdr, so a struct-level variable is actually useful there.

This closes #1040.