### PR TITLE
exp/clients/horizon: support streaming trades

### DIFF
--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -405,7 +405,10 @@ func (c *Client) Trades(request TradeRequest) (tds hProtocol.TradesPage, err err
 	return
 }
 
-// StreamTrades support streaming all trades on the network, for an account or for an offer.
+// StreamTrades streams executed trades. It can be used to stream all trades, trades for an account and
+// trades for an offer. Use context.WithCancel to stop streaming or context.Background() if you want
+// to stream indefinitely. TradeHandler is a function that expects a Trade object parameter.
+// This parameter will contain the streamed trades.
 func (c *Client) StreamTrades(ctx context.Context, request TradeRequest, handler TradeHandler) (err error) {
 	err = request.StreamTrades(ctx, c, handler)
 	return

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -407,8 +407,7 @@ func (c *Client) Trades(request TradeRequest) (tds hProtocol.TradesPage, err err
 
 // StreamTrades streams executed trades. It can be used to stream all trades, trades for an account and
 // trades for an offer. Use context.WithCancel to stop streaming or context.Background() if you want
-// to stream indefinitely. TradeHandler is a function that expects a Trade object parameter.
-// This parameter will contain the streamed trades.
+// to stream indefinitely. TradeHandler is a user-supplied function that is executed for each streamed trade received.
 func (c *Client) StreamTrades(ctx context.Context, request TradeRequest, handler TradeHandler) (err error) {
 	err = request.StreamTrades(ctx, c, handler)
 	return

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -405,6 +405,12 @@ func (c *Client) Trades(request TradeRequest) (tds hProtocol.TradesPage, err err
 	return
 }
 
+// StreamTrades support streaming all trades on the network, for an account or for an offer.
+func (c *Client) StreamTrades(ctx context.Context, request TradeRequest, handler TradeHandler) (err error) {
+	err = request.StreamTrades(ctx, c, handler)
+	return
+}
+
 // TradeAggregations returns stellar trade aggregations (https://www.stellar.org/developers/horizon/reference/resources/trade_aggregation.html)
 func (c *Client) TradeAggregations(request TradeAggregationRequest) (tds hProtocol.TradeAggregationsPage, err error) {
 	err = c.sendRequest(request, &tds)

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -129,6 +129,7 @@ type ClientInterface interface {
 	Payments(request OperationRequest) (operations.OperationsPage, error)
 	TradeAggregations(request TradeAggregationRequest) (hProtocol.TradeAggregationsPage, error)
 	Trades(request TradeRequest) (hProtocol.TradesPage, error)
+	StreamTrades(ctx context.Context, request TradeRequest, handler TradeHandler) error
 }
 
 // DefaultTestNetClient is a default client to connect to test network

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -136,5 +136,14 @@ func (m *MockClient) Trades(request TradeRequest) (hProtocol.TradesPage, error) 
 	return a.Get(0).(hProtocol.TradesPage), a.Error(1)
 }
 
+// StreamTrades is a mocking method
+func (m *MockClient) StreamTrades(ctx context.Context,
+	request TradeRequest,
+	handler TradeHandler,
+) error {
+	a := m.Called(ctx, request, handler)
+	return a.Error(0)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}

--- a/exp/clients/horizon/trade_request.go
+++ b/exp/clients/horizon/trade_request.go
@@ -1,9 +1,12 @@
 package horizonclient
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/errors"
 )
 
@@ -57,4 +60,26 @@ func (tr TradeRequest) BuildUrl() (endpoint string, err error) {
 	}
 
 	return endpoint, err
+}
+
+// Stream streams executed trades. It can be used to stream all trades, trades for an account and
+// trades for an offer. Use context.WithCancel to stop streaming or context.Background() if you want to stream indefinitely.
+func (tr TradeRequest) Stream(ctx context.Context, client *Client,
+	handler func(interface{})) (err error) {
+	endpoint, err := tr.BuildUrl()
+	if err != nil {
+		return errors.Wrap(err, "Unable to build endpoint")
+	}
+
+	url := fmt.Sprintf("%s%s", client.getHorizonURL(), endpoint)
+
+	return client.stream(ctx, url, func(data []byte) error {
+		var trade hProtocol.Trade
+		err = json.Unmarshal(data, &trade)
+		if err != nil {
+			return errors.Wrap(err, "Error unmarshaling data")
+		}
+		handler(trade)
+		return nil
+	})
 }

--- a/exp/clients/horizon/trade_request.go
+++ b/exp/clients/horizon/trade_request.go
@@ -62,10 +62,13 @@ func (tr TradeRequest) BuildUrl() (endpoint string, err error) {
 	return endpoint, err
 }
 
-// Stream streams executed trades. It can be used to stream all trades, trades for an account and
+// TradeHandler is a function that is called when a new trade is received
+type TradeHandler func(hProtocol.Trade)
+
+// StreamTrades streams executed trades. It can be used to stream all trades, trades for an account and
 // trades for an offer. Use context.WithCancel to stop streaming or context.Background() if you want to stream indefinitely.
-func (tr TradeRequest) Stream(ctx context.Context, client *Client,
-	handler func(interface{})) (err error) {
+func (tr TradeRequest) StreamTrades(ctx context.Context, client *Client,
+	handler TradeHandler) (err error) {
 	endpoint, err := tr.BuildUrl()
 	if err != nil {
 		return errors.Wrap(err, "Unable to build endpoint")

--- a/exp/clients/horizon/trade_request.go
+++ b/exp/clients/horizon/trade_request.go
@@ -66,7 +66,8 @@ func (tr TradeRequest) BuildUrl() (endpoint string, err error) {
 type TradeHandler func(hProtocol.Trade)
 
 // StreamTrades streams executed trades. It can be used to stream all trades, trades for an account and
-// trades for an offer. Use context.WithCancel to stop streaming or context.Background() if you want to stream indefinitely.
+// trades for an offer. Use context.WithCancel to stop streaming or context.Background() if you want
+// to stream indefinitely. TradeHandler is a user-supplied function that is executed for each streamed trade received.
 func (tr TradeRequest) StreamTrades(ctx context.Context, client *Client,
 	handler TradeHandler) (err error) {
 	endpoint, err := tr.BuildUrl()

--- a/exp/clients/horizon/trade_request_test.go
+++ b/exp/clients/horizon/trade_request_test.go
@@ -141,9 +141,10 @@ func ExampleClient_StreamTrades() {
 		cancel()
 	}()
 
-	err := client.StreamTrades(ctx, tradeRequest, func(tr hProtocol.Trade) {
+	printHandler := func(tr hProtocol.Trade) {
 		fmt.Println(tr)
-	})
+	}
+	err := client.StreamTrades(ctx, tradeRequest, printHandler)
 
 	if err != nil {
 		fmt.Println(err)

--- a/exp/clients/horizon/trade_request_test.go
+++ b/exp/clients/horizon/trade_request_test.go
@@ -1,6 +1,7 @@
 package horizonclient
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -127,6 +128,102 @@ func TestTradesRequest(t *testing.T) {
 	}
 }
 
+func TestTradeRequestStream(t *testing.T) {
+
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	// all trades
+	trRequest := TradeRequest{}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	hmock.On(
+		"GET",
+		"https://localhost/trades?cursor=now",
+	).ReturnString(200, tradeStreamResponse)
+
+	trades := make([]hProtocol.Trade, 1)
+	err := client.Stream(ctx, trRequest, func(tr interface{}) {
+		resp, ok := tr.(hProtocol.Trade)
+		if ok {
+			trades[0] = resp
+		}
+		cancel()
+	})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, trades[0].ID, "76909979385857-0")
+		assert.Equal(t, trades[0].OfferID, "494")
+	}
+
+	// trades for accounts
+	trRequest = TradeRequest{ForAccount: "GCRHQBHX7JNBZE4HHPLNOAAYDRDVAGBJKJ4KPGHIID3CBGVALXBD6TVQ"}
+	ctx, cancel = context.WithCancel(context.Background())
+
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GCRHQBHX7JNBZE4HHPLNOAAYDRDVAGBJKJ4KPGHIID3CBGVALXBD6TVQ/trades?cursor=now",
+	).ReturnString(200, tradeStreamResponse)
+
+	trades = make([]hProtocol.Trade, 1)
+	err = client.Stream(ctx, trRequest, func(tr interface{}) {
+		resp, ok := tr.(hProtocol.Trade)
+		if ok {
+			trades[0] = resp
+		}
+		cancel()
+	})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, trades[0].ID, "76909979385857-0")
+		assert.Equal(t, trades[0].OfferID, "494")
+	}
+
+	// trades for offers
+	trRequest = TradeRequest{ForOfferID: "494"}
+	ctx, cancel = context.WithCancel(context.Background())
+
+	hmock.On(
+		"GET",
+		"https://localhost/offers/494/trades?cursor=now",
+	).ReturnString(200, tradeStreamResponse)
+
+	trades = make([]hProtocol.Trade, 1)
+	err = client.Stream(ctx, trRequest, func(tr interface{}) {
+		resp, ok := tr.(hProtocol.Trade)
+		if ok {
+			trades[0] = resp
+		}
+		cancel()
+	})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, trades[0].ID, "76909979385857-0")
+		assert.Equal(t, trades[0].OfferID, "494")
+	}
+
+	// test error
+	trRequest = TradeRequest{}
+	ctx, cancel = context.WithCancel(context.Background())
+
+	hmock.On(
+		"GET",
+		"https://localhost/trades?cursor=now",
+	).ReturnString(500, tradeStreamResponse)
+
+	trades = make([]hProtocol.Trade, 1)
+	err = client.Stream(ctx, trRequest, func(tx interface{}) {
+		cancel()
+	})
+
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Got bad HTTP status code 500")
+	}
+}
+
 var tradesResponse = `{
   "_links": {
     "self": {
@@ -218,3 +315,6 @@ var tradesResponse = `{
     ]
   }
 }`
+
+var tradeStreamResponse = `data: {"_links":{"self":{"href":""},"base":{"href":"https://horizon-testnet.stellar.org/accounts/GCRHQBHX7JNBZE4HHPLNOAAYDRDVAGBJKJ4KPGHIID3CBGVALXBD6TVQ"},"counter":{"href":"https://horizon-testnet.stellar.org/accounts/GAEETTPUI5CO3CSYXXM5CRX4FHLDWJ3KD6XRRJ3GJISWQSCYF5ALN6JC"},"operation":{"href":"https://horizon-testnet.stellar.org/operations/76909979385857"}},"id":"76909979385857-0","paging_token":"76909979385857-0","ledger_close_time":"2019-02-28T11:29:40Z","offer_id":"494","base_offer_id":"4611762928406773761","base_account":"GCRHQBHX7JNBZE4HHPLNOAAYDRDVAGBJKJ4KPGHIID3CBGVALXBD6TVQ","base_amount":"0.0000001","base_asset_type":"native","counter_offer_id":"494","counter_account":"GAEETTPUI5CO3CSYXXM5CRX4FHLDWJ3KD6XRRJ3GJISWQSCYF5ALN6JC","counter_amount":"0.0001000","counter_asset_type":"credit_alphanum4","counter_asset_code":"WTF","counter_asset_issuer":"GAQZKAGUAHCN4OHAMQVQ3PNA5DUHCQ3CEVOSOTPUAXHG3UHTRSSUFHUL","base_is_seller":false,"price":{"n":1000,"d":1}}
+`

--- a/exp/clients/horizon/trade_request_test.go
+++ b/exp/clients/horizon/trade_request_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/http/httptest"
@@ -128,7 +129,28 @@ func TestTradesRequest(t *testing.T) {
 	}
 }
 
-func TestTradeRequestStream(t *testing.T) {
+func ExampleClient_StreamTrades() {
+	client := DefaultTestNetClient
+	// all trades
+	tradeRequest := TradeRequest{Cursor: "760209215489"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		// Stop streaming after 60 seconds.
+		time.Sleep(60 * time.Second)
+		cancel()
+	}()
+
+	err := client.StreamTrades(ctx, tradeRequest, func(tr hProtocol.Trade) {
+		fmt.Println(tr)
+	})
+
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func TestTradeRequestStreamTrades(t *testing.T) {
 
 	hmock := httptest.NewClient()
 	client := &Client{
@@ -146,11 +168,8 @@ func TestTradeRequestStream(t *testing.T) {
 	).ReturnString(200, tradeStreamResponse)
 
 	trades := make([]hProtocol.Trade, 1)
-	err := client.Stream(ctx, trRequest, func(tr interface{}) {
-		resp, ok := tr.(hProtocol.Trade)
-		if ok {
-			trades[0] = resp
-		}
+	err := client.StreamTrades(ctx, trRequest, func(tr hProtocol.Trade) {
+		trades[0] = tr
 		cancel()
 	})
 
@@ -169,11 +188,8 @@ func TestTradeRequestStream(t *testing.T) {
 	).ReturnString(200, tradeStreamResponse)
 
 	trades = make([]hProtocol.Trade, 1)
-	err = client.Stream(ctx, trRequest, func(tr interface{}) {
-		resp, ok := tr.(hProtocol.Trade)
-		if ok {
-			trades[0] = resp
-		}
+	err = client.StreamTrades(ctx, trRequest, func(tr hProtocol.Trade) {
+		trades[0] = tr
 		cancel()
 	})
 
@@ -192,11 +208,8 @@ func TestTradeRequestStream(t *testing.T) {
 	).ReturnString(200, tradeStreamResponse)
 
 	trades = make([]hProtocol.Trade, 1)
-	err = client.Stream(ctx, trRequest, func(tr interface{}) {
-		resp, ok := tr.(hProtocol.Trade)
-		if ok {
-			trades[0] = resp
-		}
+	err = client.StreamTrades(ctx, trRequest, func(tr hProtocol.Trade) {
+		trades[0] = tr
 		cancel()
 	})
 
@@ -215,7 +228,7 @@ func TestTradeRequestStream(t *testing.T) {
 	).ReturnString(500, tradeStreamResponse)
 
 	trades = make([]hProtocol.Trade, 1)
-	err = client.Stream(ctx, trRequest, func(tx interface{}) {
+	err = client.StreamTrades(ctx, trRequest, func(tr hProtocol.Trade) {
 		cancel()
 	})
 


### PR DESCRIPTION
This PR supports streaming trades that occur on the network.
Closes #1076 