### PR TITLE
exp/clients/horizon: stream transactions

### DIFF
--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -411,5 +411,13 @@ func (c *Client) TradeAggregations(request TradeAggregationRequest) (tds hProtoc
 	return
 }
 
+// StreamTransactions streams processed transactions. It can be used to stream all transactions and
+// transactions for an account. Use context.WithCancel to stop streaming or context.Background()
+// if you want to stream indefinitely. TransactionHandler is a user-supplied function that is executed for each streamed transaction received.
+func (c *Client) StreamTransactions(ctx context.Context, request TransactionRequest, handler TransactionHandler) (err error) {
+	err = request.StreamTransactions(ctx, c, handler)
+	return
+}
+
 // ensure that the horizon client implements ClientInterface
 var _ ClientInterface = &Client{}

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -422,9 +422,8 @@ func (c *Client) TradeAggregations(request TradeAggregationRequest) (tds hProtoc
 // StreamTransactions streams processed transactions. It can be used to stream all transactions and
 // transactions for an account. Use context.WithCancel to stop streaming or context.Background()
 // if you want to stream indefinitely. TransactionHandler is a user-supplied function that is executed for each streamed transaction received.
-func (c *Client) StreamTransactions(ctx context.Context, request TransactionRequest, handler TransactionHandler) (err error) {
-	err = request.StreamTransactions(ctx, c, handler)
-	return
+func (c *Client) StreamTransactions(ctx context.Context, request TransactionRequest, handler TransactionHandler) error {
+	return request.StreamTransactions(ctx, c, handler)
 }
 
 // ensure that the horizon client implements ClientInterface

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -129,6 +129,7 @@ type ClientInterface interface {
 	Payments(request OperationRequest) (operations.OperationsPage, error)
 	TradeAggregations(request TradeAggregationRequest) (hProtocol.TradeAggregationsPage, error)
 	Trades(request TradeRequest) (hProtocol.TradesPage, error)
+	StreamTransactions(ctx context.Context, request TransactionRequest, handler TransactionHandler) error
 }
 
 // DefaultTestNetClient is a default client to connect to test network

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -136,5 +136,14 @@ func (m *MockClient) Trades(request TradeRequest) (hProtocol.TradesPage, error) 
 	return a.Get(0).(hProtocol.TradesPage), a.Error(1)
 }
 
+// StreamTransactions is a mocking method
+func (m *MockClient) StreamTransactions(ctx context.Context,
+	request TransactionRequest,
+	handler TransactionHandler,
+) error {
+	a := m.Called(ctx, request, handler)
+	return a.Error(0)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}

--- a/exp/clients/horizon/transaction_request.go
+++ b/exp/clients/horizon/transaction_request.go
@@ -1,9 +1,12 @@
 package horizonclient
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/errors"
 )
 
@@ -39,4 +42,25 @@ func (tr TransactionRequest) BuildUrl() (endpoint string, err error) {
 	}
 
 	return endpoint, err
+}
+
+// Stream streams transactions. These can be all transactions on the network or for a specific account.
+// Use context.WithCancel to stop streaming or context.Background() if you want to stream indefinitely.
+func (tr TransactionRequest) Stream(ctx context.Context, client *Client,
+	handler func(interface{})) (err error) {
+	endpoint, err := tr.BuildUrl()
+	if err != nil {
+		return errors.Wrap(err, "Unable to build endpoint")
+	}
+
+	url := fmt.Sprintf("%s%s", client.getHorizonURL(), endpoint)
+	return client.stream(ctx, url, func(data []byte) error {
+		var tx hProtocol.Transaction
+		err = json.Unmarshal(data, &tx)
+		if err != nil {
+			return errors.Wrap(err, "Error unmarshaling data")
+		}
+		handler(tx)
+		return nil
+	})
 }

--- a/exp/clients/horizon/transaction_request.go
+++ b/exp/clients/horizon/transaction_request.go
@@ -44,23 +44,27 @@ func (tr TransactionRequest) BuildUrl() (endpoint string, err error) {
 	return endpoint, err
 }
 
-// Stream streams transactions. These can be all transactions on the network or for a specific account.
-// Use context.WithCancel to stop streaming or context.Background() if you want to stream indefinitely.
-func (tr TransactionRequest) Stream(ctx context.Context, client *Client,
-	handler func(interface{})) (err error) {
+// TransactionHandler is a function that is called when a new transaction is received
+type TransactionHandler func(hProtocol.Transaction)
+
+// StreamTransactions streams executed transactions. It can be used to stream all transactions and  transactions for an account. Use context.WithCancel to stop streaming or context.Background() if you want
+// to stream indefinitely. TransactionHandler is a user-supplied function that is executed for each streamed transaction received.
+func (tr TransactionRequest) StreamTransactions(ctx context.Context, client *Client,
+	handler TransactionHandler) (err error) {
 	endpoint, err := tr.BuildUrl()
 	if err != nil {
 		return errors.Wrap(err, "Unable to build endpoint")
 	}
 
 	url := fmt.Sprintf("%s%s", client.getHorizonURL(), endpoint)
+
 	return client.stream(ctx, url, func(data []byte) error {
-		var tx hProtocol.Transaction
-		err = json.Unmarshal(data, &tx)
+		var transaction hProtocol.Transaction
+		err = json.Unmarshal(data, &transaction)
 		if err != nil {
 			return errors.Wrap(err, "Error unmarshaling data")
 		}
-		handler(tx)
+		handler(transaction)
 		return nil
 	})
 }

--- a/exp/clients/horizon/transaction_request_test.go
+++ b/exp/clients/horizon/transaction_request_test.go
@@ -1,8 +1,12 @@
 package horizonclient
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	hProtocol "github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/support/http/httptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,3 +55,64 @@ func TestTransactionRequestBuildUrl(t *testing.T) {
 	assert.Equal(t, "transactions?cursor=123456&include_failed=true&limit=30&order=asc", endpoint)
 
 }
+
+func TestTransactionRequestStream(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+	txRequest := TransactionRequest{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	hmock.On(
+		"GET",
+		"https://localhost/transactions?cursor=now",
+	).ReturnString(200, txStreamResponse)
+
+	var txs []hProtocol.Transaction
+	err := client.Stream(ctx, txRequest, func(tx interface{}) {
+
+		resp, ok := tx.(hProtocol.Transaction)
+		if ok {
+			txs = append(txs, resp)
+		}
+		cancel()
+	})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, txs[0].Hash, "1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e")
+		assert.Equal(t, txs[0].Account, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR")
+	}
+
+	// test error
+	txRequest = TransactionRequest{}
+	ctx, cancel = context.WithCancel(context.Background())
+
+	hmock.On(
+		"GET",
+		"https://localhost/transactions?cursor=now",
+	).ReturnString(500, txStreamResponse)
+
+	go func() {
+		// Stop streaming after 1 second.
+		time.Sleep(1 * time.Second)
+		cancel()
+	}()
+
+	err = client.Stream(ctx, txRequest, func(tx interface{}) {
+		resp, ok := tx.(hProtocol.Transaction)
+		if ok {
+			txs[0] = resp
+		}
+	})
+
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Got bad HTTP status code 500")
+	}
+
+}
+
+var txStreamResponse = `data: {"_links":{"self":{"href":"https://horizon-testnet.stellar.org/transactions/1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e"},"account":{"href":"https://horizon-testnet.stellar.org/accounts/GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR"},"ledger":{"href":"https://horizon-testnet.stellar.org/ledgers/607387"},"operations":{"href":"https://horizon-testnet.stellar.org/transactions/1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e/operations{?cursor,limit,order}","templated":true},"effects":{"href":"https://horizon-testnet.stellar.org/transactions/1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e/effects{?cursor,limit,order}","templated":true},"precedes":{"href":"https://horizon-testnet.stellar.org/transactions?order=asc\u0026cursor=2608707301036032"},"succeeds":{"href":"https://horizon-testnet.stellar.org/transactions?order=desc\u0026cursor=2608707301036032"}},"id":"1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e","paging_token":"2608707301036032","successful":true,"hash":"1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e","ledger":607387,"created_at":"2019-04-04T12:07:03Z","source_account":"GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR","source_account_sequence":"4660039930473","fee_paid":100,"operation_count":1,"envelope_xdr":"AAAAABB90WssODNIgi6BHveqzxTRmIpvAFRyVNM+Hm2GVuCcAAAAZAAABD0ABlJpAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAmLuzasXDMqsqgFK4xkbLxJLzmQQzkiCF2SnKPD+b1TsAAAAXSHboAAAAAAAAAAABhlbgnAAAAECqxhXduvtzs65keKuTzMtk76cts2WeVB2pZKYdlxlOb1EIbOpFhYizDSXVfQlAvvg18qV6oNRr7ls4nnEm2YIK","result_xdr":"AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=","result_meta_xdr":"AAAAAQAAAAIAAAADAAlEmwAAAAAAAAAAEH3Rayw4M0iCLoEe96rPFNGYim8AVHJU0z4ebYZW4JwBT3aiixBA2AAABD0ABlJoAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAlEmwAAAAAAAAAAEH3Rayw4M0iCLoEe96rPFNGYim8AVHJU0z4ebYZW4JwBT3aiixBA2AAABD0ABlJpAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMACUSbAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFPdqKLEEDYAAAEPQAGUmkAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEACUSbAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFPdotCmVjYAAAEPQAGUmkAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAACUSbAAAAAAAAAACYu7NqxcMyqyqAUrjGRsvEkvOZBDOSIIXZKco8P5vVOwAAABdIdugAAAlEmwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==","fee_meta_xdr":"AAAAAgAAAAMACUSaAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFPdqKLEEE8AAAEPQAGUmgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEACUSbAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFPdqKLEEDYAAAEPQAGUmgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==","memo_type":"none","signatures":["qsYV3br7c7OuZHirk8zLZO+nLbNlnlQdqWSmHZcZTm9RCGzqRYWIsw0l1X0JQL74NfKleqDUa+5bOJ5xJtmCCg=="]}
+`

--- a/exp/clients/horizon/transaction_request_test.go
+++ b/exp/clients/horizon/transaction_request_test.go
@@ -2,6 +2,7 @@ package horizonclient
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -56,7 +57,30 @@ func TestTransactionRequestBuildUrl(t *testing.T) {
 
 }
 
-func TestTransactionRequestStream(t *testing.T) {
+func ExampleClient_StreamTransactions() {
+	client := DefaultTestNetClient
+	// all transactions
+	transactionRequest := TransactionRequest{Cursor: "760209215489"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		// Stop streaming after 60 seconds.
+		time.Sleep(60 * time.Second)
+		cancel()
+	}()
+
+	printHandler := func(tr hProtocol.Transaction) {
+		fmt.Println(tr)
+	}
+	err := client.StreamTransactions(ctx, transactionRequest, printHandler)
+
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func TestTransactionRequestStreamTransactions(t *testing.T) {
+
 	hmock := httptest.NewClient()
 	client := &Client{
 		HorizonURL: "https://localhost/",
@@ -64,7 +88,7 @@ func TestTransactionRequestStream(t *testing.T) {
 	}
 
 	// all transactions
-	txRequest := TransactionRequest{}
+	trRequest := TransactionRequest{}
 	ctx, cancel := context.WithCancel(context.Background())
 
 	hmock.On(
@@ -72,23 +96,19 @@ func TestTransactionRequestStream(t *testing.T) {
 		"https://localhost/transactions?cursor=now",
 	).ReturnString(200, txStreamResponse)
 
-	var txs []hProtocol.Transaction
-	err := client.Stream(ctx, txRequest, func(tx interface{}) {
-
-		resp, ok := tx.(hProtocol.Transaction)
-		if ok {
-			txs = append(txs, resp)
-		}
+	transactions := make([]hProtocol.Transaction, 1)
+	err := client.StreamTransactions(ctx, trRequest, func(tr hProtocol.Transaction) {
+		transactions[0] = tr
 		cancel()
 	})
 
 	if assert.NoError(t, err) {
-		assert.Equal(t, txs[0].Hash, "1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e")
-		assert.Equal(t, txs[0].Account, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR")
+		assert.Equal(t, transactions[0].Hash, "1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e")
+		assert.Equal(t, transactions[0].Account, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR")
 	}
 
-	// transactions for account
-	txRequest = TransactionRequest{ForAccount: "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR"}
+	// transactions for accounts
+	trRequest = TransactionRequest{ForAccount: "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR"}
 	ctx, cancel = context.WithCancel(context.Background())
 
 	hmock.On(
@@ -96,22 +116,19 @@ func TestTransactionRequestStream(t *testing.T) {
 		"https://localhost/accounts/GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR/transactions?cursor=now",
 	).ReturnString(200, txStreamResponse)
 
-	err = client.Stream(ctx, txRequest, func(tx interface{}) {
-
-		resp, ok := tx.(hProtocol.Transaction)
-		if ok {
-			txs = append(txs, resp)
-		}
+	transactions = make([]hProtocol.Transaction, 1)
+	err = client.StreamTransactions(ctx, trRequest, func(tr hProtocol.Transaction) {
+		transactions[0] = tr
 		cancel()
 	})
 
 	if assert.NoError(t, err) {
-		assert.Equal(t, txs[0].Hash, "1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e")
-		assert.Equal(t, txs[0].Account, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR")
+		assert.Equal(t, transactions[0].Hash, "1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e")
+		assert.Equal(t, transactions[0].Account, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR")
 	}
 
 	// test error
-	txRequest = TransactionRequest{}
+	trRequest = TransactionRequest{}
 	ctx, cancel = context.WithCancel(context.Background())
 
 	hmock.On(
@@ -119,23 +136,14 @@ func TestTransactionRequestStream(t *testing.T) {
 		"https://localhost/transactions?cursor=now",
 	).ReturnString(500, txStreamResponse)
 
-	go func() {
-		// Stop streaming after 1 second.
-		time.Sleep(1 * time.Second)
+	transactions = make([]hProtocol.Transaction, 1)
+	err = client.StreamTransactions(ctx, trRequest, func(tr hProtocol.Transaction) {
 		cancel()
-	}()
-
-	err = client.Stream(ctx, txRequest, func(tx interface{}) {
-		resp, ok := tx.(hProtocol.Transaction)
-		if ok {
-			txs[0] = resp
-		}
 	})
 
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "Got bad HTTP status code 500")
 	}
-
 }
 
 var txStreamResponse = `data: {"_links":{"self":{"href":"https://horizon-testnet.stellar.org/transactions/1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e"},"account":{"href":"https://horizon-testnet.stellar.org/accounts/GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR"},"ledger":{"href":"https://horizon-testnet.stellar.org/ledgers/607387"},"operations":{"href":"https://horizon-testnet.stellar.org/transactions/1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e/operations{?cursor,limit,order}","templated":true},"effects":{"href":"https://horizon-testnet.stellar.org/transactions/1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e/effects{?cursor,limit,order}","templated":true},"precedes":{"href":"https://horizon-testnet.stellar.org/transactions?order=asc\u0026cursor=2608707301036032"},"succeeds":{"href":"https://horizon-testnet.stellar.org/transactions?order=desc\u0026cursor=2608707301036032"}},"id":"1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e","paging_token":"2608707301036032","successful":true,"hash":"1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e","ledger":607387,"created_at":"2019-04-04T12:07:03Z","source_account":"GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR","source_account_sequence":"4660039930473","fee_paid":100,"operation_count":1,"envelope_xdr":"AAAAABB90WssODNIgi6BHveqzxTRmIpvAFRyVNM+Hm2GVuCcAAAAZAAABD0ABlJpAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAmLuzasXDMqsqgFK4xkbLxJLzmQQzkiCF2SnKPD+b1TsAAAAXSHboAAAAAAAAAAABhlbgnAAAAECqxhXduvtzs65keKuTzMtk76cts2WeVB2pZKYdlxlOb1EIbOpFhYizDSXVfQlAvvg18qV6oNRr7ls4nnEm2YIK","result_xdr":"AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=","result_meta_xdr":"AAAAAQAAAAIAAAADAAlEmwAAAAAAAAAAEH3Rayw4M0iCLoEe96rPFNGYim8AVHJU0z4ebYZW4JwBT3aiixBA2AAABD0ABlJoAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAlEmwAAAAAAAAAAEH3Rayw4M0iCLoEe96rPFNGYim8AVHJU0z4ebYZW4JwBT3aiixBA2AAABD0ABlJpAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMACUSbAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFPdqKLEEDYAAAEPQAGUmkAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEACUSbAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFPdotCmVjYAAAEPQAGUmkAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAACUSbAAAAAAAAAACYu7NqxcMyqyqAUrjGRsvEkvOZBDOSIIXZKco8P5vVOwAAABdIdugAAAlEmwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==","fee_meta_xdr":"AAAAAgAAAAMACUSaAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFPdqKLEEE8AAAEPQAGUmgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEACUSbAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFPdqKLEEDYAAAEPQAGUmgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==","memo_type":"none","signatures":["qsYV3br7c7OuZHirk8zLZO+nLbNlnlQdqWSmHZcZTm9RCGzqRYWIsw0l1X0JQL74NfKleqDUa+5bOJ5xJtmCCg=="]}

--- a/exp/clients/horizon/transaction_request_test.go
+++ b/exp/clients/horizon/transaction_request_test.go
@@ -73,14 +73,12 @@ func ExampleClient_StreamTransactions() {
 		fmt.Println(tr)
 	}
 	err := client.StreamTransactions(ctx, transactionRequest, printHandler)
-
 	if err != nil {
 		fmt.Println(err)
 	}
 }
 
 func TestTransactionRequestStreamTransactions(t *testing.T) {
-
 	hmock := httptest.NewClient()
 	client := &Client{
 		HorizonURL: "https://localhost/",

--- a/exp/clients/horizon/transaction_request_test.go
+++ b/exp/clients/horizon/transaction_request_test.go
@@ -62,8 +62,9 @@ func TestTransactionRequestStream(t *testing.T) {
 		HorizonURL: "https://localhost/",
 		HTTP:       hmock,
 	}
-	txRequest := TransactionRequest{}
 
+	// all transactions
+	txRequest := TransactionRequest{}
 	ctx, cancel := context.WithCancel(context.Background())
 
 	hmock.On(
@@ -73,6 +74,29 @@ func TestTransactionRequestStream(t *testing.T) {
 
 	var txs []hProtocol.Transaction
 	err := client.Stream(ctx, txRequest, func(tx interface{}) {
+
+		resp, ok := tx.(hProtocol.Transaction)
+		if ok {
+			txs = append(txs, resp)
+		}
+		cancel()
+	})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, txs[0].Hash, "1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e")
+		assert.Equal(t, txs[0].Account, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR")
+	}
+
+	// transactions for account
+	txRequest = TransactionRequest{ForAccount: "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR"}
+	ctx, cancel = context.WithCancel(context.Background())
+
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR/transactions?cursor=now",
+	).ReturnString(200, txStreamResponse)
+
+	err = client.Stream(ctx, txRequest, func(tx interface{}) {
 
 		resp, ok := tx.(hProtocol.Transaction)
 		if ok {


### PR DESCRIPTION
This PR adds supports for streaming transactions that occur on the network. It allows users to stream all transactions and transactions for an account.

Closes #1075 
Closes #261 