### PR TITLE
exp/ticker: TOML Validation

### DIFF
--- a/exp/ticker/internal/scraper/asset_scraper.go
+++ b/exp/ticker/internal/scraper/asset_scraper.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -79,7 +81,11 @@ func fetchTOMLData(asset hProtocol.AssetStat) (data string, err error) {
 		return
 	}
 
-	resp, err := http.Get(tomlURL)
+	timeout := time.Duration(10 * time.Second)
+	client := http.Client{
+		Timeout: timeout,
+	}
+	resp, err := client.Get(tomlURL)
 	if err != nil {
 		return
 	}
@@ -221,36 +227,82 @@ func processAsset(asset hProtocol.AssetStat) (processedAsset TOMLAsset, err erro
 	return
 }
 
-// cleanUpAssets filters the assets that don't match the shouldDiscardAsset criteria
-func cleanUpAssets(assets []hProtocol.AssetStat) (cleanAssets []TOMLAsset, numTrash int) {
-	fmt.Println("Cleaning up assets")
-	// TODO: use some paralellization here to improve speed?
-	for _, asset := range assets {
-		if !shouldDiscardAsset(asset) {
-			tomlAsset, err := processAsset(asset)
-			if err != nil {
-				fmt.Println("Error processing asset:", err)
-				continue
+// parallelCleanUpAssets filters the assets that don't match the shouldDiscardAsset criteria.
+// The TOML validation is performed in parallel to improve performance.
+func parallelCleanUpAssets(assets []hProtocol.AssetStat, parallelism int) (cleanAssets []TOMLAsset, numTrash int) {
+	queue := make(chan TOMLAsset, parallelism)
+
+	var mutex = &sync.Mutex{}
+	var wg sync.WaitGroup
+	numAssets := len(assets)
+	chunkSize := int(math.Ceil(float64(numAssets) / float64(parallelism)))
+	wg.Add(numAssets)
+
+	// The assets are divided into chunks of chunkSize, and each goroutine is responsible
+	// for cleaning up one chunk
+	for i := 0; i < parallelism; i++ {
+		go func(start int) {
+			end := start + chunkSize
+
+			if end > numAssets {
+				end = numAssets
 			}
-			fmt.Println(tomlAsset)
-			cleanAssets = append(cleanAssets, tomlAsset)
-		} else {
-			// TODO: define if we should start storing the "Trash" assets as well
-			numTrash++
-		}
+
+			for j := start; j < end; j++ {
+				if !shouldDiscardAsset(assets[j]) {
+					tomlAsset, err := processAsset(assets[j])
+					if err != nil {
+						mutex.Lock()
+						numTrash++
+						mutex.Unlock()
+						// Invalid assets are also sent to the queue to preserve
+						// the WaitGroup count
+						queue <- TOMLAsset{IsTrash: true}
+						continue
+					}
+					queue <- tomlAsset
+				} else {
+					mutex.Lock()
+					numTrash++
+					mutex.Unlock()
+					// Discarded assets are also sent to the queue to preserve
+					// the WaitGroup count
+					queue <- TOMLAsset{IsTrash: true}
+				}
+			}
+		}(i * chunkSize)
 	}
+
+	// Whenever a new asset is sent to the channel, it is appended to the cleanAssets
+	// slice. This does not preserve the original order, but shouldn't be an issue
+	// in this case.
+	go func() {
+		count := 0
+		for t := range queue {
+			count++
+			if !t.IsTrash {
+				cleanAssets = append(cleanAssets, t)
+			}
+			fmt.Println("Total assets cleaned up:", count)
+			wg.Done()
+		}
+	}()
+
+	wg.Wait()
 
 	return
 }
 
-// retrieveAssets retrieves all existing assets from the Horizon API
-func retrieveAssets(c *horizonclient.Client) (assets []hProtocol.AssetStat, err error) {
+// retrieveAssets retrieves existing assets from the Horizon API. If limit=0, will fetch all assets.
+func retrieveAssets(c *horizonclient.Client, limit int) (assets []hProtocol.AssetStat, err error) {
 	r := horizonclient.AssetRequest{Limit: 200}
 
 	assetsPage, err := c.Assets(r)
 	if err != nil {
 		return
 	}
+
+	fmt.Println("Fetching assets from Horizon")
 
 	for assetsPage.Links.Next.Href != assetsPage.Links.Self.Href {
 		assetsPage, err = c.Assets(r)
@@ -259,14 +311,24 @@ func retrieveAssets(c *horizonclient.Client) (assets []hProtocol.AssetStat, err 
 		}
 		assets = append(assets, assetsPage.Embedded.Records...)
 
+		if limit != 0 { // for performance reasons, only perform these additional checks when limit != 0
+			numAssets := len(assets)
+			if numAssets >= limit {
+				diff := numAssets - limit
+				assets = assets[0 : numAssets-diff]
+				break
+			}
+		}
+
 		n, err := nextCursor(assetsPage)
 		if err != nil {
 			return assets, err
 		}
-		fmt.Println("Fetching all assets with cursor at:", n)
+		fmt.Println("Cursor currently at:", n)
 
 		r = horizonclient.AssetRequest{Limit: 200, Cursor: n}
 	}
 
+	fmt.Printf("Fetched: %d assets\n", len(assets))
 	return
 }

--- a/exp/ticker/internal/scraper/asset_scraper.go
+++ b/exp/ticker/internal/scraper/asset_scraper.go
@@ -1,10 +1,16 @@
 package scraper
 
 import (
+	"errors"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
+
+	"github.com/BurntSushi/toml"
 
 	horizonclient "github.com/stellar/go/exp/clients/horizon"
 	hProtocol "github.com/stellar/go/protocols/horizon"
@@ -58,12 +64,178 @@ func shouldDiscardAsset(asset hProtocol.AssetStat) bool {
 	return false
 }
 
+// decodeTOMLIssuer decodes retrieved TOML issuer data into a TOMLIssuer struct
+func decodeTOMLIssuer(tomlData string) (issuer TOMLIssuer, err error) {
+	_, err = toml.Decode(tomlData, &issuer)
+	return
+}
+
+// fetchTOMLData fetches the TOML data for a given hProtocol.AssetStat
+func fetchTOMLData(asset hProtocol.AssetStat) (data string, err error) {
+	tomlURL := asset.Links.Toml.Href
+
+	if tomlURL == "" {
+		err = errors.New("Asset does not have a TOML URL")
+		return
+	}
+
+	resp, err := http.Get(tomlURL)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+
+	data = string(body)
+	return
+}
+
+func domainsMatch(tomlURL *url.URL, orgURL *url.URL) bool {
+	tomlDomainParts := strings.Split(tomlURL.Host, ".")
+	orgDomainParts := strings.Split(orgURL.Host, ".")
+
+	if len(orgDomainParts) < len(tomlDomainParts) {
+		// Org can only be a subdomain if it has more (or equal)
+		// pieces than the TOML domain
+		return false
+	}
+
+	lenDiff := len(orgDomainParts) - len(tomlDomainParts)
+	orgDomainParts = orgDomainParts[lenDiff:]
+	orgRootDomain := strings.Join(orgDomainParts, ".")
+	if tomlURL.Host != orgRootDomain {
+		return false
+	}
+
+	return true
+}
+
+// isDomainVerified performs some checking to ensure we can trust the Asset's domain
+func isDomainVerified(orgURL string, tomlURL string, hasCurrency bool) bool {
+	if tomlURL == "" {
+		return false
+	}
+
+	parsedTomlURL, err := url.Parse(tomlURL)
+	if err != nil || parsedTomlURL.Scheme != "https" {
+		return false
+	}
+
+	if !hasCurrency {
+		return false
+	}
+
+	if orgURL == "" {
+		// if no orgURL is provided, we'll simply use tomlURL, so no need
+		// for domain verification
+		return true
+	}
+
+	parsedOrgURL, err := url.Parse(orgURL)
+	if err != nil || parsedOrgURL.Scheme != "https" {
+		return false
+	}
+
+	if !domainsMatch(parsedTomlURL, parsedOrgURL) {
+		return false
+	}
+	return true
+}
+
+// makeTomlAsset aggregates Horizon Data with TOML Data
+func makeTOMLAsset(
+	asset hProtocol.AssetStat,
+	issuer TOMLIssuer,
+	errors []error,
+) (t TOMLAsset, err error) {
+	amount, err := strconv.ParseFloat(asset.Amount, 64)
+	if err != nil {
+		return
+	}
+
+	t = TOMLAsset{
+		Type:          asset.Type,
+		Code:          asset.Code,
+		Issuer:        asset.Issuer,
+		NumAccounts:   asset.NumAccounts,
+		AuthRequired:  asset.Flags.AuthRequired,
+		AuthRevocable: asset.Flags.AuthRevocable,
+		Amount:        amount,
+		IssuerDetails: issuer,
+	}
+
+	hasCurrency := false
+	for _, currency := range t.IssuerDetails.Currencies {
+		if currency.Code == asset.Code && currency.Issuer == asset.Issuer {
+			hasCurrency = true
+			t.AnchorAsset = currency.AnchorAsset
+			t.AnchorAsset = currency.AnchorAsset
+		}
+	}
+	t.AssetControlledByDomain = isDomainVerified(
+		t.IssuerDetails.Documentation.OrgURL,
+		asset.Links.Toml.Href,
+		hasCurrency,
+	)
+
+	// TODO: determine if the asset is valid even if the issuer doesn't have
+	// it listed in its currencies
+
+	now := time.Now()
+	if len(errors) > 0 {
+		t.Error = fmt.Sprintf("%v", errors)
+		t.IsValid = false
+	} else {
+		t.LastValid = now
+		t.IsValid = true
+	}
+	t.LastChecked = now
+	t.AnchorAssetType = strings.ToLower(t.AnchorAssetType)
+
+	return
+}
+
+// processAsset merges data from an AssetStat with data retrieved from its corresponding TOML file
+func processAsset(asset hProtocol.AssetStat) (processedAsset TOMLAsset, err error) {
+	var errors []error
+
+	tomlData, err := fetchTOMLData(asset)
+	if err != nil {
+		errors = append(errors, err)
+	}
+
+	issuer, err := decodeTOMLIssuer(tomlData)
+	if err != nil {
+		errors = append(errors, err)
+	}
+
+	processedAsset, err = makeTOMLAsset(asset, issuer, errors)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
 // cleanUpAssets filters the assets that don't match the shouldDiscardAsset criteria
-func cleanUpAssets(assets []hProtocol.AssetStat) (cleanAssets []hProtocol.AssetStat, numTrash int) {
+func cleanUpAssets(assets []hProtocol.AssetStat) (cleanAssets []TOMLAsset, numTrash int) {
+	fmt.Println("Cleaning up assets")
+	// TODO: use some paralellization here to improve speed?
 	for _, asset := range assets {
 		if !shouldDiscardAsset(asset) {
-			cleanAssets = append(cleanAssets, asset)
+			tomlAsset, err := processAsset(asset)
+			if err != nil {
+				fmt.Println("Error processing asset:", err)
+				continue
+			}
+			fmt.Println(tomlAsset)
+			cleanAssets = append(cleanAssets, tomlAsset)
 		} else {
+			// TODO: define if we should start storing the "Trash" assets as well
 			numTrash++
 		}
 	}

--- a/exp/ticker/internal/scraper/asset_scraper_test.go
+++ b/exp/ticker/internal/scraper/asset_scraper_test.go
@@ -1,6 +1,7 @@
 package scraper
 
 import (
+	"net/url"
 	"testing"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
@@ -67,4 +68,63 @@ func TestShouldDiscardAsset(t *testing.T) {
 	testAsset.Code = "SOMETHINGVALID"
 	testAsset.Links.Toml.Href = "https://www.stellar.org/.well-known/stellar.toml"
 	assert.Equal(t, shouldDiscardAsset(testAsset), false)
+}
+
+func TestDomainsMatch(t *testing.T) {
+	tomlURL, _ := url.Parse("https://stellar.org/stellar.toml")
+	orgURL, _ := url.Parse("https://stellar.org/")
+	assert.True(t, domainsMatch(tomlURL, orgURL))
+
+	tomlURL, _ = url.Parse("https://assets.stellar.org/stellar.toml")
+	orgURL, _ = url.Parse("https://stellar.org/")
+	assert.False(t, domainsMatch(tomlURL, orgURL))
+
+	tomlURL, _ = url.Parse("https://stellar.org/stellar.toml")
+	orgURL, _ = url.Parse("https://home.stellar.org/")
+	assert.True(t, domainsMatch(tomlURL, orgURL))
+
+	tomlURL, _ = url.Parse("https://stellar.org/stellar.toml")
+	orgURL, _ = url.Parse("https://home.stellar.com/")
+	assert.False(t, domainsMatch(tomlURL, orgURL))
+
+	tomlURL, _ = url.Parse("https://stellar.org/stellar.toml")
+	orgURL, _ = url.Parse("https://stellar.com/")
+	assert.False(t, domainsMatch(tomlURL, orgURL))
+}
+
+func TestIsDomainVerified(t *testing.T) {
+	tomlURL := "https://stellar.org/stellar.toml"
+	orgURL := "https://stellar.org/"
+	hasCurrency := true
+	assert.True(t, isDomainVerified(orgURL, tomlURL, hasCurrency))
+
+	tomlURL = "https://stellar.org/stellar.toml"
+	orgURL = ""
+	hasCurrency = true
+	assert.True(t, isDomainVerified(orgURL, tomlURL, hasCurrency))
+
+	tomlURL = ""
+	orgURL = ""
+	hasCurrency = true
+	assert.False(t, isDomainVerified(orgURL, tomlURL, hasCurrency))
+
+	tomlURL = "https://stellar.org/stellar.toml"
+	orgURL = "https://stellar.org/"
+	hasCurrency = false
+	assert.False(t, isDomainVerified(orgURL, tomlURL, hasCurrency))
+
+	tomlURL = "http://stellar.org/stellar.toml"
+	orgURL = "https://stellar.org/"
+	hasCurrency = true
+	assert.False(t, isDomainVerified(orgURL, tomlURL, hasCurrency))
+
+	tomlURL = "https://stellar.org/stellar.toml"
+	orgURL = "http://stellar.org/"
+	hasCurrency = true
+	assert.False(t, isDomainVerified(orgURL, tomlURL, hasCurrency))
+
+	tomlURL = "https://stellar.org/stellar.toml"
+	orgURL = "https://stellar.com/"
+	hasCurrency = true
+	assert.False(t, isDomainVerified(orgURL, tomlURL, hasCurrency))
 }

--- a/exp/ticker/internal/scraper/main.go
+++ b/exp/ticker/internal/scraper/main.go
@@ -52,16 +52,17 @@ type TOMLAsset struct {
 	IsValid                 bool       `json:"is_valid"`
 	LastValid               time.Time  `json:"last_valid"`
 	LastChecked             time.Time  `json:"last_checked"`
+	IsTrash                 bool       `json:"-"`
 }
 
-// FetchAllAssets fetches all assets from the Horizon public net
-func FetchAllAssets(c *horizonclient.Client) (assets []TOMLAsset, err error) {
-	dirtyAssets, err := retrieveAssets(c)
+// FetchAllAssets fetches assets from the Horizon public net. If limit = 0, will fetch all assets.
+func FetchAllAssets(c *horizonclient.Client, limit int, parallelism int) (assets []TOMLAsset, err error) {
+	dirtyAssets, err := retrieveAssets(c, limit)
 	if err != nil {
 		return
 	}
 
-	assets, numTrash := cleanUpAssets(dirtyAssets)
+	assets, numTrash := parallelCleanUpAssets(dirtyAssets, parallelism)
 
 	fmt.Printf(
 		"Scanned %d entries. Trash: %d. Non-trash: %d\n",

--- a/exp/ticker/internal/scraper/main.go
+++ b/exp/ticker/internal/scraper/main.go
@@ -2,13 +2,60 @@ package scraper
 
 import (
 	"fmt"
+	"time"
 
 	horizonclient "github.com/stellar/go/exp/clients/horizon"
-	hProtocol "github.com/stellar/go/protocols/horizon"
 )
 
+// TOMLDoc is the interface for storing TOML Issuer Documentation.
+// See: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md#currency-documentation
+type TOMLDoc struct {
+	OrgURL string `toml:"ORG_URL"`
+}
+
+// TOMLCurrency is the interface for storing TOML Currency Information.
+// See: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md#currency-documentation
+type TOMLCurrency struct {
+	Code            string `toml:"code"`
+	Issuer          string `toml:"issuer"`
+	AnchorAsset     string `toml:"anchor_asset"`
+	AnchorAssetType string `toml:"anchor_asset_type"`
+}
+
+// TOMLIssuer is the interface for storing TOML Issuer Information.
+// See: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md#currency-documentation
+type TOMLIssuer struct {
+	FederationServer string         `toml:"FEDERATION_SERVER"`
+	AuthServer       string         `toml:"AUTH_SERVER"`
+	TransferServer   string         `toml:"TRANSFER_SERVER"`
+	WebAuthEndpoint  string         `toml:"WEB_AUTH_ENDPOINT"`
+	SigningKey       string         `toml:"SIGNING_KEY"`
+	DepositServer    string         `toml:"DEPOSIT_SERVER"` // for legacy purposes
+	Documentation    TOMLDoc        `toml:"DOCUMENTATION"`
+	Currencies       []TOMLCurrency `toml:"CURRENCIES"`
+}
+
+// TOMLAsset is the interface to represent the aggregated Asset data.
+type TOMLAsset struct {
+	Code                    string     `json:"code"`
+	Issuer                  string     `json:"issuer"`
+	Type                    string     `json:"type"`
+	NumAccounts             int32      `json:"num_accounts"`
+	AuthRequired            bool       `json:"auth_required"`
+	AuthRevocable           bool       `json:"auth_revocable"`
+	Amount                  float64    `json:"amount"`
+	IssuerDetails           TOMLIssuer `json:"-"`
+	AssetControlledByDomain bool       `json:"asset_controlled_by_domain"`
+	Error                   string     `json:"error"`
+	AnchorAsset             string     `json:"anchor_asset"`
+	AnchorAssetType         string     `json:"anchor_asset_type"`
+	IsValid                 bool       `json:"is_valid"`
+	LastValid               time.Time  `json:"last_valid"`
+	LastChecked             time.Time  `json:"last_checked"`
+}
+
 // FetchAllAssets fetches all assets from the Horizon public net
-func FetchAllAssets(c *horizonclient.Client) (assets []hProtocol.AssetStat, err error) {
+func FetchAllAssets(c *horizonclient.Client) (assets []TOMLAsset, err error) {
 	dirtyAssets, err := retrieveAssets(c)
 	if err != nil {
 		return

--- a/exp/ticker/main.go
+++ b/exp/ticker/main.go
@@ -34,10 +34,10 @@ func writeResultsToFile(jsonBytes []byte, filename string) (numBytes int, err er
 func main() {
 	// Temporary main function to run / test packages
 	c := horizonclient.DefaultPublicNetClient
-	assetStatList, err := scraper.FetchAllAssets(c)
+	tomlAssetList, err := scraper.FetchAllAssets(c)
 	check(err)
 
-	jsonAssets, err := json.MarshalIndent(assetStatList, "", "\t")
+	jsonAssets, err := json.MarshalIndent(tomlAssetList, "", "\t")
 	check(err)
 
 	writeResultsToFile(jsonAssets, "assets.json")

--- a/exp/ticker/main.go
+++ b/exp/ticker/main.go
@@ -34,7 +34,7 @@ func writeResultsToFile(jsonBytes []byte, filename string) (numBytes int, err er
 func main() {
 	// Temporary main function to run / test packages
 	c := horizonclient.DefaultPublicNetClient
-	tomlAssetList, err := scraper.FetchAllAssets(c)
+	tomlAssetList, err := scraper.FetchAllAssets(c, 0, 500)
 	check(err)
 
 	jsonAssets, err := json.MarshalIndent(tomlAssetList, "", "\t")


### PR DESCRIPTION
This PR is part of issue #1080. It aims to:

- Improve the Horizon Asset scraper by validating the information provided by their respective TOML files, if applicable.
- Make the overall asset scraping run faster – especially the TOML validation, which is now performed in parallel (see function `parallelCleanUpAssets`).
- Add some more tests :)