### PR TITLE
exp/clients/horizon: StreamLedgers

### DIFF
--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -433,5 +433,12 @@ func (c *Client) StreamEffects(ctx context.Context, request EffectRequest, handl
 	return request.StreamEffects(ctx, c, handler)
 }
 
+// StreamLedgers streams stellar ledgers. It can be used to stream all ledgers. Use context.WithCancel
+// to stop streaming or context.Background() if you want to stream indefinitely.
+// LedgerHandler is a user-supplied function that is executed for each streamed ledger received.
+func (c *Client) StreamLedgers(ctx context.Context, request LedgerRequest, handler LedgerHandler) error {
+	return request.StreamLedgers(ctx, c, handler)
+}
+
 // ensure that the horizon client implements ClientInterface
 var _ ClientInterface = &Client{}

--- a/exp/clients/horizon/ledger_request.go
+++ b/exp/clients/horizon/ledger_request.go
@@ -58,7 +58,7 @@ func (lr LedgerRequest) StreamLedgers(ctx context.Context, client *Client,
 		var ledger hProtocol.Ledger
 		err = json.Unmarshal(data, &ledger)
 		if err != nil {
-			return errors.Wrap(err, "Error unmarshaling data for ledger reques")
+			return errors.Wrap(err, "Error unmarshaling data for ledger request")
 		}
 		handler(ledger)
 		return nil

--- a/exp/clients/horizon/ledger_request.go
+++ b/exp/clients/horizon/ledger_request.go
@@ -40,17 +40,20 @@ func (lr LedgerRequest) BuildUrl() (endpoint string, err error) {
 	return endpoint, err
 }
 
-// Stream streams incoming ledgers. Use context.WithCancel to stop streaming or
-// context.Background() if you want to stream indefinitely.
-func (lr LedgerRequest) Stream(ctx context.Context, client *Client,
-	handler func(interface{})) (err error) {
+// LedgerHandler is a function that is called when a new ledger is received
+type LedgerHandler func(hProtocol.Ledger)
+
+// StreamLedgers streams stellar ledgers. It can be used to stream all ledgers. Use context.WithCancel
+// to stop streaming or context.Background() if you want to stream indefinitely.
+// LedgerHandler is a user-supplied function that is executed for each streamed ledger received.
+func (lr LedgerRequest) StreamLedgers(ctx context.Context, client *Client,
+	handler LedgerHandler) (err error) {
 	endpoint, err := lr.BuildUrl()
 	if err != nil {
 		return errors.Wrap(err, "Unable to build endpoint")
 	}
 
 	url := fmt.Sprintf("%s%s", client.getHorizonURL(), endpoint)
-
 	return client.stream(ctx, url, func(data []byte) error {
 		var ledger hProtocol.Ledger
 		err = json.Unmarshal(data, &ledger)

--- a/exp/clients/horizon/ledger_request.go
+++ b/exp/clients/horizon/ledger_request.go
@@ -50,7 +50,7 @@ func (lr LedgerRequest) StreamLedgers(ctx context.Context, client *Client,
 	handler LedgerHandler) (err error) {
 	endpoint, err := lr.BuildUrl()
 	if err != nil {
-		return errors.Wrap(err, "Unable to build endpoint")
+		return errors.Wrap(err, "Unable to build endpoint for ledger request")
 	}
 
 	url := fmt.Sprintf("%s%s", client.getHorizonURL(), endpoint)
@@ -58,7 +58,7 @@ func (lr LedgerRequest) StreamLedgers(ctx context.Context, client *Client,
 		var ledger hProtocol.Ledger
 		err = json.Unmarshal(data, &ledger)
 		if err != nil {
-			return errors.Wrap(err, "Error unmarshaling data")
+			return errors.Wrap(err, "Error unmarshaling data for ledger reques")
 		}
 		handler(ledger)
 		return nil

--- a/exp/clients/horizon/ledger_request_test.go
+++ b/exp/clients/horizon/ledger_request_test.go
@@ -2,7 +2,9 @@ package horizonclient
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/http/httptest"
@@ -105,7 +107,27 @@ func TestLedgerDetail(t *testing.T) {
 	}
 }
 
-func TestLedgerStream(t *testing.T) {
+func ExampleClient_StreamLedgers() {
+	client := DefaultTestNetClient
+	// all ledgers from now
+	ledgerRequest := LedgerRequest{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		// Stop streaming after 60 seconds.
+		time.Sleep(60 * time.Second)
+		cancel()
+	}()
+
+	printHandler := func(ledger hProtocol.Ledger) {
+		fmt.Println(ledger)
+	}
+	err := client.StreamLedgers(ctx, ledgerRequest, printHandler)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+func TestLedgerRequestStreamLedgers(t *testing.T) {
 	hmock := httptest.NewClient()
 	client := &Client{
 		HorizonURL: "https://localhost/",
@@ -120,11 +142,8 @@ func TestLedgerStream(t *testing.T) {
 	).ReturnString(200, ledgerStreamResponse)
 
 	ledgers := make([]hProtocol.Ledger, 1)
-	err := client.Stream(ctx, ledgerRequest, func(ledger interface{}) {
-		resp, ok := ledger.(hProtocol.Ledger)
-		if ok {
-			ledgers[0] = resp
-		}
+	err := client.StreamLedgers(ctx, ledgerRequest, func(ledger hProtocol.Ledger) {
+		ledgers[0] = ledger
 		cancel()
 
 	})
@@ -142,12 +161,8 @@ func TestLedgerStream(t *testing.T) {
 		"https://localhost/ledgers?cursor=now",
 	).ReturnString(500, ledgerStreamResponse)
 
-	ledgers = make([]hProtocol.Ledger, 1)
-	err = client.Stream(ctx, ledgerRequest, func(ledger interface{}) {
-		resp, ok := ledger.(hProtocol.Ledger)
-		if ok {
-			ledgers[0] = resp
-		}
+	err = client.StreamLedgers(ctx, ledgerRequest, func(ledger hProtocol.Ledger) {
+		ledgers[0] = ledger
 		cancel()
 
 	})

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -132,6 +132,7 @@ type ClientInterface interface {
 	StreamTransactions(ctx context.Context, request TransactionRequest, handler TransactionHandler) error
 	StreamTrades(ctx context.Context, request TradeRequest, handler TradeHandler) error
 	StreamEffects(ctx context.Context, request EffectRequest, handler EffectHandler) error
+	StreamLedgers(ctx context.Context, request LedgerRequest, handler LedgerHandler) error
 }
 
 // DefaultTestNetClient is a default client to connect to test network

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -162,5 +162,13 @@ func (m *MockClient) StreamEffects(ctx context.Context,
 	return m.Called(ctx, request, handler).Error(0)
 }
 
+// StreamLedgers is a mocking method
+func (m *MockClient) StreamLedgers(ctx context.Context,
+	request LedgerRequest,
+	handler LedgerHandler,
+) error {
+	return m.Called(ctx, request, handler).Error(0)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}


### PR DESCRIPTION
This PR modifies streaming for ledgers to use the new `StreamLedgers` function.