### PR TITLE
Add updated orderbook examples.

### DIFF
--- a/services/horizon/internal/docs/reference/endpoints/offers-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/offers-for-account.md
@@ -61,6 +61,7 @@ var offerHandler = function (offerResponse) {
 };
 
 var es = server.offers('accounts', 'GBYUUJHG6F4EPJGNLERINATVQLNDOFRUD7SGJZ26YZLG5PAYLG7XUSGF')
+  .cursor('now')
   .stream({
     onmessage: offerHandler
   })

--- a/services/horizon/internal/docs/reference/endpoints/offers-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/offers-for-account.md
@@ -4,9 +4,14 @@ clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=offers&endpoint=for_account
 ---
 
-People on the Stellar network can make [offers](../resources/offer.md) to buy or sell assets.  This endpoint represents all the offers a particular account makes.
-This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to listen as offers are processed in the Stellar network.
-If called in streaming mode Horizon will start at the earliest known offer unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream offers created since your request time.
+People on the Stellar network can make [offers](../resources/offer.md) to buy or sell assets. This
+endpoint represents all the offers a particular account makes.
+
+This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to
+listen as offers are processed in the Stellar network. If called in streaming mode Horizon will
+start at the earliest known offer unless a `cursor` is set. In that case it will start from the
+`cursor`. You can also set `cursor` value to `now` to only stream offers created since your request
+time.
 
 ## Request
 
@@ -18,7 +23,7 @@ GET /accounts/{account}/offers{?cursor,limit,order}
 
 | name | notes | description | example |
 | ---- | ----- | ----------- | ------- |
-| `account` | required, string | Account ID | `GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36` |
+| `account` | required, string | Account ID | `GBYUUJHG6F4EPJGNLERINATVQLNDOFRUD7SGJZ26YZLG5PAYLG7XUSGF` |
 | `?cursor` | optional, any, default _null_ | A paging token, specifying where to start returning records from. | `12884905984` |
 | `?order`  | optional, string, default `asc` | The order in which to return rows, "asc" or "desc". | `asc` |
 | `?limit`  | optional, number, default: `10` | Maximum number of records to return. | `200` |
@@ -26,16 +31,16 @@ GET /accounts/{account}/offers{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4/offers"
+curl "https://horizon-testnet.stellar.org/accounts/GBYUUJHG6F4EPJGNLERINATVQLNDOFRUD7SGJZ26YZLG5PAYLG7XUSGF/offers"
 ```
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
-server.offers('accounts', 'GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4')
+server.offers('accounts', 'GBYUUJHG6F4EPJGNLERINATVQLNDOFRUD7SGJZ26YZLG5PAYLG7XUSGF')
   .call()
   .then(function (offerResult) {
     console.log(offerResult);
@@ -45,25 +50,42 @@ server.offers('accounts', 'GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVG
   })
 ```
 
+### JavaScript Streaming Example
+
+```javascript
+var StellarSdk = require('stellar-sdk')
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+var offerHandler = function (offerResponse) {
+  console.log(offerResponse);
+};
+
+var es = server.offers('accounts', 'GBYUUJHG6F4EPJGNLERINATVQLNDOFRUD7SGJZ26YZLG5PAYLG7XUSGF')
+  .stream({
+    onmessage: offerHandler
+  })
+```
+
 ## Response
 
 The list of offers.
 
-**Note:** a response of 200 with an empty records array may either mean there are no offers for `account_id` or `account_id` does not exist.
+**Note:** a response of 200 with an empty records array may either mean there are no offers for
+`account_id` or `account_id` does not exist.
 
 ### Example Response
 
-```js
+```json
 {
   "_links": {
     "self": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4/offers?order=asc&limit=10&cursor="
+      "href": "https://horizon-testnet.stellar.org/accounts/GBYUUJHG6F4EPJGNLERINATVQLNDOFRUD7SGJZ26YZLG5PAYLG7XUSGF/offers?cursor=&limit=10&order=asc"
     },
     "next": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4/offers?order=asc&limit=10&cursor=122"
+      "href": "https://horizon-testnet.stellar.org/accounts/GBYUUJHG6F4EPJGNLERINATVQLNDOFRUD7SGJZ26YZLG5PAYLG7XUSGF/offers?cursor=5443256&limit=10&order=asc"
     },
     "prev": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4/offers?order=desc&limit=10&cursor=121"
+      "href": "https://horizon-testnet.stellar.org/accounts/GBYUUJHG6F4EPJGNLERINATVQLNDOFRUD7SGJZ26YZLG5PAYLG7XUSGF/offers?cursor=5443256&limit=10&order=desc"
     }
   },
   "_embedded": {
@@ -71,64 +93,31 @@ The list of offers.
       {
         "_links": {
           "self": {
-            "href": "https://horizon-testnet.stellar.org/offers/121"
+            "href": "https://horizon-testnet.stellar.org/offers/5443256"
           },
           "offer_maker": {
-            "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4"
+            "href": "https://horizon-testnet.stellar.org/accounts/GBYUUJHG6F4EPJGNLERINATVQLNDOFRUD7SGJZ26YZLG5PAYLG7XUSGF"
           }
         },
-        "id": 121,
-        "paging_token": "121",
-        "seller": "GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4",
+        "id": 5443256,
+        "paging_token": "5443256",
+        "seller": "GBYUUJHG6F4EPJGNLERINATVQLNDOFRUD7SGJZ26YZLG5PAYLG7XUSGF",
         "selling": {
-          "asset_type": "credit_alphanum4",
-          "asset_code": "BAR",
-          "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
+          "asset_type": "native"
         },
         "buying": {
           "asset_type": "credit_alphanum4",
           "asset_code": "FOO",
-          "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
+          "asset_issuer": "GAGLYFZJMN5HEULSTH5CIGPOPAVUYPG5YSWIYDJMAPIECYEBPM2TA3QR"
         },
-        "amount": "23.6692509",
+        "amount": "10.0000000",
         "price_r": {
-          "n": 387,
-          "d": 50
+          "n": 1,
+          "d": 1
         },
-        "price": "7.7400000",
-        "last_modified_time": "1970-01-01T00:00:05Z",
-        "last_modified_ledger": 22379074,
-      },
-      {
-        "_links": {
-          "self": {
-            "href": "https://horizon-testnet.stellar.org/offers/122"
-          },
-          "offer_maker": {
-            "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4"
-          }
-        },
-        "id": 122,
-        "paging_token": "122",
-        "seller": "GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4",
-        "selling": {
-          "asset_type": "credit_alphanum4",
-          "asset_code": "BAR",
-          "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
-        },
-        "buying": {
-          "asset_type": "credit_alphanum4",
-          "asset_code": "FOO",
-          "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
-        },
-        "amount": "72.0000000",
-        "price_r": {
-          "n": 779,
-          "d": 100
-        },
-        "price": "7.7900000",
-        "last_modified_time": "1970-01-01T00:00:06Z",
-        "last_modified_ledger": 22379074,
+        "price": "1.0000000",
+        "last_modified_ledger": 694974,
+        "last_modified_time": "2019-04-09T17:14:22Z"
       }
     ]
   }

--- a/services/horizon/internal/docs/reference/endpoints/orderbook-details.md
+++ b/services/horizon/internal/docs/reference/endpoints/orderbook-details.md
@@ -68,6 +68,7 @@ var orderbookHandler = function (orderbookResponse) {
 };
 
 var es = server.orderbook(new StellarSdk.Asset.native(), new StellarSdk.Asset('FOO', 'GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG'))
+  .cursor('now')
   .stream({
     onmessage: orderbookHandler
   })

--- a/services/horizon/internal/docs/reference/endpoints/orderbook-details.md
+++ b/services/horizon/internal/docs/reference/endpoints/orderbook-details.md
@@ -4,12 +4,18 @@ clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=order_book&endpoint=details
 ---
 
-People on the Stellar network can make [offers](../resources/offer.md) to buy or sell assets.  These offers are summarized by the assets being bought and sold in [orderbooks](../resources/orderbook.md).
+People on the Stellar network can make [offers](../resources/offer.md) to buy or sell assets.
+These offers are summarized by the assets being bought and sold in
+[orderbooks](../resources/orderbook.md).
 
-Horizon will return, for each orderbook, a summary of the orderbook and the bids and asks associated with that orderbook.
+Horizon will return, for each orderbook, a summary of the orderbook and the bids and asks
+associated with that orderbook.
 
-This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to listen as offers are processed in the Stellar network.
-If called in streaming mode Horizon will start at the earliest known offer unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream offers created since your request time.
+This endpoint can also be used in [streaming](../streaming.md) mode so it is possible to use it to
+listen as offers are processed in the Stellar network.  If called in streaming mode Horizon will
+start at the earliest known offer unless a `cursor` is set. In that case it will start from the
+`cursor`. You can also set `cursor` value to `now` to only stream offers created since your request
+time.
 
 ## Request
 
@@ -37,14 +43,34 @@ curl "https://horizon-testnet.stellar.org/order_book?selling_asset_type=native&b
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.orderbook(new StellarSdk.Asset.native(), new StellarSdk.Asset('FOO', 'GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG'))
   .call()
-  .then(function(resp) { console.log(resp); })
-  .catch(function(err) { console.log(err); })
+  .then(function(resp) {
+    console.log(resp);
+  })
+  .catch(function(err) {
+    console.log(err);
+  })
+```
+
+### JavaScript Streaming Example
+
+```javascript
+var StellarSdk = require('stellar-sdk')
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+var orderbookHandler = function (orderbookResponse) {
+  console.log(orderbookResponse);
+};
+
+var es = server.orderbook(new StellarSdk.Asset.native(), new StellarSdk.Asset('FOO', 'GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG'))
+  .stream({
+    onmessage: orderbookHandler
+  })
 ```
 
 ## Response

--- a/services/horizon/internal/docs/reference/endpoints/trade_aggregations.md
+++ b/services/horizon/internal/docs/reference/endpoints/trade_aggregations.md
@@ -2,9 +2,17 @@
 title: Trade Aggregations
 ---
 
-Trade Aggregations are catered specifically for developers of trading clients. They facilitate efficient gathering of historical trade data. This is done by dividing a given time range into segments and aggregating statistics, for a given asset pair (`base`, `counter`) over each of these segments.
-The duration of the segments is specified with the `resolution` parameter. The start and end of the time range are given by `startTime` and `endTime` respectively, which are both rounded to the nearest multiple of `resolution` since epoch. 
-The individual segments are also aligned with multiples of `resolution` since epoch. If you want to change this alignment, the segments can be offset by specifying the `offset` parameter.
+Trade Aggregations are catered specifically for developers of trading clients. They facilitate
+efficient gathering of historical trade data. This is done by dividing a given time range into
+segments and aggregating statistics, for a given asset pair (`base`, `counter`) over each of these
+segments.
+
+The duration of the segments is specified with the `resolution` parameter. The start and end of the
+time range are given by `startTime` and `endTime` respectively, which are both rounded to the
+nearest multiple of `resolution` since epoch.
+
+The individual segments are also aligned with multiples of `resolution` since epoch. If you want to
+change this alignment, the segments can be offset by specifying the `offset` parameter.
 
 
 ## Request
@@ -17,10 +25,10 @@ GET /trade_aggregations?base_asset_type={base_asset_type}&base_asset_code={base_
 
 | name | notes | description | example |
 | ---- | ----- | ----------- | ------- |
-| `start_time` | long | lower time boundary represented as millis since epoch| 1512689100000 |
-| `end_time` | long | upper time boundary represented as millis since epoch| 1512775500000|
-| `resolution` | long | segment duration as millis since epoch. *Supported values are 1 minute (60000), 5 minutes (300000), 15 minutes (900000), 1 hour (3600000), 1 day (86400000) and 1 week (604800000).*| 300000|
-| `offset` | long | segments can be offset using this parameter. Expressed in milliseconds. Can only be used if the resolution is greater than 1 hour. *Value must be in whole hours, less than the provided resolution, and less than 24 hours.*| 3600000 (1 hour)|
+| `start_time` | long | lower time boundary represented as millis since epoch | 1512689100000 |
+| `end_time` | long | upper time boundary represented as millis since epoch | 1512775500000 |
+| `resolution` | long | segment duration as millis since epoch. *Supported values are 1 minute (60000), 5 minutes (300000), 15 minutes (900000), 1 hour (3600000), 1 day (86400000) and 1 week (604800000).* | 300000 |
+| `offset` | long | segments can be offset using this parameter. Expressed in milliseconds. Can only be used if the resolution is greater than 1 hour. *Value must be in whole hours, less than the provided resolution, and less than 24 hours.* | 3600000 (1 hour) |
 | `base_asset_type` | string | Type of base asset | `native` |
 | `base_asset_code` | string | Code of base asset, not required if type is `native` | `USD` |
 | `base_asset_issuer` | string | Issuer of base asset, not required if type is `native` | 'GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36' |
@@ -31,8 +39,31 @@ GET /trade_aggregations?base_asset_type={base_asset_type}&base_asset_code={base_
 | `?limit`  | optional, number, default: `10` | Maximum number of records to return. | `200` |
 
 ### curl Example Request
-```sh 
+```sh
 curl https://horizon.stellar.org/trade_aggregations?base_asset_type=native&counter_asset_code=SLT&counter_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP&counter_asset_type=credit_alphanum4&limit=200&order=asc&resolution=3600000&start_time=1517521726000&end_time=1517532526000
+```
+
+### JavaScript Example Request
+
+```javascript
+var StellarSdk = require('stellar-sdk');
+var server = new StellarSdk.Server('https://horizon.stellar.org');
+
+var base = new StellarSdk.Asset.native();
+var counter = new StellarSdk.Asset("SLT", "GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP");
+var startTime = 1517521726000;
+var endTime = 1517532526000;
+var resolution = 3600000;
+var offset = 0;
+
+server.tradeAggregation(base, counter, startTime, endTime, resolution, offset)
+  .call()
+  .then(function (tradeAggregation) {
+    console.log(tradeAggregation);
+  })
+  .catch(function (err) {
+    console.log(err);
+  })
 ```
 
 ## Response
@@ -41,7 +72,10 @@ A list of collected trade aggregations.
 
 Note
 - Segments that fit into the time range but have 0 trades in them, will not be included.
-- Partial segments, in the beginning and end of the time range, will not be included.
+- Partial segments, in the beginning and end of the time range, will not be included. Thus if your
+  start time is noon Wednesday, your end time is noon Thursday, and your resolution is one day, you
+  will not receive back any data. Instead, you would want to either start at midnight Wednesday and
+  midnight Thursday, or shorten the resolution interval to better cover your time frame.
 
 ### Example Response
 ```json

--- a/services/horizon/internal/docs/reference/endpoints/trades-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/trades-for-account.md
@@ -32,12 +32,12 @@ curl "https://horizon-testnet.stellar.org/accounts/GBYTR4MC5JAX4ALGUBJD7EIKZVM7C
 
 ### JavaScript Example Request
 
-```js
+```javascript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
 server.trades()
-  .forAccount("GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ")
+  .forAccount("GBYTR4MC5JAX4ALGUBJD7EIKZVM7CUGWKXIUJMRSMK573XH2O7VAK3SR")
   .call()
   .then(function (accountResult) {
     console.log(accountResult);

--- a/services/horizon/internal/docs/reference/endpoints/trades.md
+++ b/services/horizon/internal/docs/reference/endpoints/trades.md
@@ -66,7 +66,9 @@ var tradesHandler = function (tradeResponse) {
   console.log(tradeResponse);
 };
 
-var es = server.trades().stream({
+var es = server.trades()
+  .cursor('now')
+  .stream({
   onmessage: tradesHandler
 })
 ```

--- a/services/horizon/internal/docs/reference/endpoints/trades.md
+++ b/services/horizon/internal/docs/reference/endpoints/trades.md
@@ -2,12 +2,17 @@
 title: Trades
 ---
 
-People on the Stellar network can make [offers](../resources/offer.md) to buy or sell assets. When an offer is fully or partially fulfilled, a [trade](../resources/trade.md) happens.
+People on the Stellar network can make [offers](../resources/offer.md) to buy or sell assets. When
+an offer is fully or partially fulfilled, a [trade](../resources/trade.md) happens.
 
-Trades can be filtered for specific orderbook, defined by an asset pair: `base` and `counter`. 
+Trades can be filtered for a specific orderbook, defined by an asset pair: `base` and `counter`.
 
-This endpoint can also be used in [streaming](../streaming.md) mode, making it possible to listen for new trades as they occur on the Stellar network.
-If called in streaming mode Horizon will start at the earliest known trade unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream trades created since your request time.
+This endpoint can also be used in [streaming](../streaming.md) mode, making it possible to listen
+for new trades as they occur on the Stellar network.
+
+If called in streaming mode Horizon will start at the earliest known trade unless a `cursor` is
+set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only
+stream trades created since your request time.
 
 ## Request
 
@@ -31,8 +36,39 @@ GET /trades?base_asset_type={base_asset_type}&base_asset_code={base_asset_code}&
 | `?limit`  | optional, number, default: `10` | Maximum number of records to return. | `200` |
 
 ### curl Example Request
-```sh 
+```sh
 curl https://horizon.stellar.org/trades?base_asset_type=native&counter_asset_code=SLT&counter_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP&counter_asset_type=credit_alphanum4&limit=2&order=desc
+```
+
+### JavaScript Example Request
+
+```javascript
+var StellarSdk = require('stellar-sdk');
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+server.trades()
+  .call()
+  .then(function (tradesResult) {
+    console.log(tradesResult.records);
+  })
+  .catch(function (err) {
+    console.log(err)
+  })
+```
+
+### JavaScript Example Streaming Request
+
+```javascript
+var StellarSdk = require('stellar-sdk')
+var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+var tradesHandler = function (tradeResponse) {
+  console.log(tradeResponse);
+};
+
+var es = server.trades().stream({
+  onmessage: tradesHandler
+})
 ```
 
 ## Response
@@ -44,77 +80,89 @@ The list of trades. `base` and `counter` in the records will match the asset pai
 {
   "_links": {
     "self": {
-      "href": "https://horizon.stellar.org/trades?base_asset_type=native\u0026counter_asset_code=SLT\u0026counter_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP\u0026counter_asset_type=credit_alphanum4\u0026cursor=\u0026limit=2\u0026order=desc"
+      "href": "https://horizon-testnet.stellar.org/trades?cursor=&limit=10&order=asc"
     },
     "next": {
-      "href": "https://horizon.stellar.org/trades?base_asset_type=native\u0026counter_asset_code=SLT\u0026counter_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP\u0026counter_asset_type=credit_alphanum4\u0026cursor=68836785177763841-0\u0026limit=2\u0026order=desc"
+      "href": "https://horizon-testnet.stellar.org/trades?cursor=6025839120434-0&limit=10&order=asc"
     },
     "prev": {
-      "href": "https://horizon.stellar.org/trades?base_asset_type=native\u0026counter_asset_code=SLT\u0026counter_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP\u0026counter_asset_type=credit_alphanum4\u0026cursor=68836918321750017-0\u0026limit=2\u0026order=asc"
+      "href": "https://horizon-testnet.stellar.org/trades?cursor=6012954218535-0&limit=10&order=desc"
     }
   },
   "_embedded": {
     "records": [
       {
         "_links": {
+          "self": {
+            "href": ""
+          },
           "base": {
-            "href": "https://horizon.stellar.org/accounts/GBZXCJIUEPDXGHMS64UBJHUVKV6ETWYOVHADLTBXJNJFUC7A7RU5B3GN"
+            "href": "https://horizon-testnet.stellar.org/accounts/GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C"
           },
           "counter": {
-            "href": "https://horizon.stellar.org/accounts/GBHKUQDYXGK5IEYORI7DZMMXANOIEHHOF364LNT4Q7EWPUL7FOO2SP6D"
+            "href": "https://horizon-testnet.stellar.org/accounts/GCYN7MI6VXVRP74KR6MKBAW2ELLCXL6QCY5H4YQ62HVWZWMCE6Y232UC"
           },
           "operation": {
-            "href": "https://horizon.stellar.org/operations/68836918321750017"
+            "href": "https://horizon-testnet.stellar.org/operations/6012954218535"
           }
         },
-        "id": "68836918321750017-0",
-        "paging_token": "68836918321750017-0",
-        "ledger_close_time": "2018-02-02T00:20:10Z",
-        "base_offer_id": "695254",
-        "base_account": "GBZXCJIUEPDXGHMS64UBJHUVKV6ETWYOVHADLTBXJNJFUC7A7RU5B3GN",
-        "base_amount": "0.1217566",
-        "base_asset_type": "native",
-        "counter_offer_id": "O30064775169",        
-        "counter_account": "GBHKUQDYXGK5IEYORI7DZMMXANOIEHHOF364LNT4Q7EWPUL7FOO2SP6D",
-        "counter_amount": "0.0199601",
+        "id": "6012954218535-0",
+        "paging_token": "6012954218535-0",
+        "ledger_close_time": "2019-02-27T11:54:53Z",
+        "offer_id": "37",
+        "base_offer_id": "4611692031381606439",
+        "base_account": "GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C",
+        "base_amount": "25.6687300",
+        "base_asset_type": "credit_alphanum4",
+        "base_asset_code": "DSQ",
+        "base_asset_issuer": "GBDQPTQJDATT7Z7EO4COS4IMYXH44RDLLI6N6WIL5BZABGMUOVMLWMQF",
+        "counter_offer_id": "37",
+        "counter_account": "GCYN7MI6VXVRP74KR6MKBAW2ELLCXL6QCY5H4YQ62HVWZWMCE6Y232UC",
+        "counter_amount": "1.0265563",
         "counter_asset_type": "credit_alphanum4",
-        "counter_asset_code": "SLT",
-        "counter_asset_issuer": "GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP",
-        "base_is_seller": true,
+        "counter_asset_code": "USD",
+        "counter_asset_issuer": "GAA4MFNZGUPJAVLWWG6G5XZJFZDHLKQNG3Q6KB24BAD6JHNNVXDCF4XG",
+        "base_is_seller": false,
         "price": {
-          "n": 10,
-          "d": 61
+          "n": 10000000,
+          "d": 250046977
         }
       },
       {
         "_links": {
+          "self": {
+            "href": ""
+          },
           "base": {
-            "href": "https://horizon.stellar.org/accounts/GCUODCZAU6CSXEKKWZZNWQXDITIWLWCDK6M4IZ7H5PACLC3QAWEJSOTR"
+            "href": "https://horizon-testnet.stellar.org/accounts/GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C"
           },
           "counter": {
-            "href": "https://horizon.stellar.org/accounts/GBHKUQDYXGK5IEYORI7DZMMXANOIEHHOF364LNT4Q7EWPUL7FOO2SP6D"
+            "href": "https://horizon-testnet.stellar.org/accounts/GCYN7MI6VXVRP74KR6MKBAW2ELLCXL6QCY5H4YQ62HVWZWMCE6Y232UC"
           },
           "operation": {
-            "href": "https://horizon.stellar.org/operations/68836785177763841"
+            "href": "https://horizon-testnet.stellar.org/operations/6025839120385"
           }
         },
-        "id": "68836785177763841-0",
-        "paging_token": "68836785177763841-0",
-        "ledger_close_time": "2018-02-02T00:18:00Z",
-        "base_offer_id": "695244",
-        "base_account": "GCUODCZAU6CSXEKKWZZNWQXDITIWLWCDK6M4IZ7H5PACLC3QAWEJSOTR",
-        "base_amount": "0.0000050",
-        "base_asset_type": "native",
-        "counter_offer_id": "4611686044197195777",   
-        "counter_account": "GBHKUQDYXGK5IEYORI7DZMMXANOIEHHOF364LNT4Q7EWPUL7FOO2SP6D",
-        "counter_amount": "0.0000009",
+        "id": "6025839120385-0",
+        "paging_token": "6025839120385-0",
+        "ledger_close_time": "2019-02-27T11:55:09Z",
+        "offer_id": "1",
+        "base_offer_id": "4611692044266508289",
+        "base_account": "GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C",
+        "base_amount": "1434.4442973",
+        "base_asset_type": "credit_alphanum4",
+        "base_asset_code": "DSQ",
+        "base_asset_issuer": "GBDQPTQJDATT7Z7EO4COS4IMYXH44RDLLI6N6WIL5BZABGMUOVMLWMQF",
+        "counter_offer_id": "1",
+        "counter_account": "GCYN7MI6VXVRP74KR6MKBAW2ELLCXL6QCY5H4YQ62HVWZWMCE6Y232UC",
+        "counter_amount": "0.5622050",
         "counter_asset_type": "credit_alphanum4",
-        "counter_asset_code": "SLT",
-        "counter_asset_issuer": "GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP",
+        "counter_asset_code": "SXRT",
+        "counter_asset_issuer": "GAIOQ3UYK5NYIZY5ZFAG4JBN4O37NAVFKZM5YDYEB6YEFBZSZ5KDCUFO",
         "base_is_seller": false,
         "price": {
-          "n": 2,
-          "d": 11
+          "n": 642706,
+          "d": 1639839483
         }
       }
     ]
@@ -122,34 +170,6 @@ The list of trades. `base` and `counter` in the records will match the asset pai
 }
 ```
 
-## Example Streaming Event
-```
-{ 
-  _links: 
-   { self: { href: '' },
-     base: 
-      { href: '/accounts/GDJNMHET4DTS7HUHU7IG5DB274OSMHUYA7TRRKOD6ZABHPUW5YWJ4SUD' },
-     counter: 
-      { href: '/accounts/GCALYDRCCJEUPMV24TAX2N2N3IBX7NUUYZNM7I5FQS5GIEQ4A7EVKUOP' },
-     operation: { href: '/operations/47261068505915393' } },
-  id: '47261068505915393-0',
-  paging_token: '47261068505915393-0',
-  ledger_close_time: '2018-09-11T19:42:04Z',
-  offer_id: '734529',
-  base_account: 'GDJNMHET4DTS7HUHU7IG5DB274OSMHUYA7TRRKOD6ZABHPUW5YWJ4SUD',
-  base_amount: '0.0175999',
-  base_asset_type: 'credit_alphanum4',
-  base_asset_code: 'BOC',
-  base_asset_issuer: 'GCTS32RGWRH6RJM62UVZ4UT5ZN5L6B2D3LPGO6Z2NM2EOGVQA7TA6SKO',
-  counter_account: 'GCALYDRCCJEUPMV24TAX2N2N3IBX7NUUYZNM7I5FQS5GIEQ4A7EVKUOP',
-  counter_amount: '0.0199998',
-  counter_asset_type: 'credit_alphanum4',
-  counter_asset_code: 'ABC',
-  counter_asset_issuer: 'GCTS32RGWRH6RJM62UVZ4UT5ZN5L6B2D3LPGO6Z2NM2EOGVQA7TA6SKO',
-  base_is_seller: true,
-  price: { n: 2840909, d: 2500000 }
-}
-```
 ## Possible Errors
 
 - The [standard errors](../errors.md#Standard_Errors).


### PR DESCRIPTION
Updated examples for all of the trade endpoints (ran in testnet) based on the changes in #549.

Intentionally deleted the streaming example from the trades endpoint, as it was a JavaScript object (copied from the node console) rather than a JSON response, and the JSON response was identical to the existing example.