### PR TITLE
exp/clients/horizon: add prev and next methods for Ledger Requests

### DIFF
--- a/exp/clients/horizon/ledger_request.go
+++ b/exp/clients/horizon/ledger_request.go
@@ -64,3 +64,15 @@ func (lr LedgerRequest) StreamLedgers(ctx context.Context, client *Client,
 		return nil
 	})
 }
+
+// Next returns the next page of ledgers
+func (lr LedgerRequest) Next(lp hProtocol.LedgersPage, client *Client) (nextPage hProtocol.LedgersPage, err error) {
+	err = client.sendURLRequest(lp.Links.Next.Href, &nextPage)
+	return
+}
+
+// Prev returns the previous page of ledgers
+func (lr LedgerRequest) Prev(lp hProtocol.LedgersPage, client *Client) (prevPage hProtocol.LedgersPage, err error) {
+	err = client.sendURLRequest(lp.Links.Prev.Href, &prevPage)
+	return
+}

--- a/exp/clients/horizon/ledger_request_test.go
+++ b/exp/clients/horizon/ledger_request_test.go
@@ -174,5 +174,171 @@ func TestLedgerRequestStreamLedgers(t *testing.T) {
 
 }
 
+func TestLedgerRequestLedgers(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+	ledgerRequest := LedgerRequest{Cursor: "1"}
+
+	hmock.On(
+		"GET",
+		"https://localhost/ledgers?cursor=1",
+	).ReturnString(200, ledgersResponse)
+
+	ledgers, err := client.Ledgers(ledgerRequest)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, ledgers.Embedded.Records[0].Sequence, int32(1))
+	}
+
+	// test next page
+	ledgerRequest = LedgerRequest{Cursor: "now", Limit: 1}
+	hmock.On(
+		"GET",
+		"https://localhost/ledgers?cursor=now&limit=1",
+	).ReturnString(200, ledgersResponse)
+
+	ledgers, err = client.Ledgers(ledgerRequest)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, ledgers.Embedded.Records[0].Sequence, int32(1))
+
+		hmock.On(
+			"GET",
+			"https://horizon-testnet.stellar.org/ledgers?cursor=4294967296&limit=1&order=asc",
+		).ReturnString(200, ledgersNextResponse)
+
+		ledgers, err = ledgerRequest.Next(ledgers, client)
+		if assert.NoError(t, err) {
+			assert.Equal(t, ledgers.Embedded.Records[0].Sequence, int32(2))
+
+			//test prev page
+			hmock.On(
+				"GET",
+				"https://horizon-testnet.stellar.org/ledgers?cursor=8589934592&limit=1&order=desc",
+			).ReturnString(200, ledgersResponse)
+			ledgers, err = ledgerRequest.Prev(ledgers, client)
+			if assert.NoError(t, err) {
+				assert.Equal(t, ledgers.Embedded.Records[0].Sequence, int32(1))
+			}
+		}
+	}
+}
+
 var ledgerStreamResponse = `data: {"_links":{"self":{"href":"https://horizon-testnet.stellar.org/ledgers/560339"},"transactions":{"href":"https://horizon-testnet.stellar.org/ledgers/560339/transactions{?cursor,limit,order}","templated":true},"operations":{"href":"https://horizon-testnet.stellar.org/ledgers/560339/operations{?cursor,limit,order}","templated":true},"payments":{"href":"https://horizon-testnet.stellar.org/ledgers/560339/payments{?cursor,limit,order}","templated":true},"effects":{"href":"https://horizon-testnet.stellar.org/ledgers/560339/effects{?cursor,limit,order}","templated":true}},"id":"66f4d95dab22dbc422585cc4b011716014e81df3599cee8db9c776cfc3a31e93","paging_token":"2406637679673344","hash":"66f4d95dab22dbc422585cc4b011716014e81df3599cee8db9c776cfc3a31e93","prev_hash":"6071f1e52a6bf37aba3f7437081577eafe69f78593c465fc5028c46a4746dda3","sequence":560339,"successful_transaction_count":5,"failed_transaction_count":1,"operation_count":44,"closed_at":"2019-04-01T16:47:05Z","total_coins":"100057227213.0436903","fee_pool":"57227816.6766542","base_fee_in_stroops":100,"base_reserve_in_stroops":5000000,"max_tx_set_size":100,"protocol_version":10,"header_xdr":"AAAACmBx8eUqa/N6uj90NwgVd+r+afeFk8Rl/FAoxGpHRt2jdIn+3X+/O3PFUUZ8Tgy4rfD1oNamR+9NMOCM2V6ndksAAAAAXKJAiQAAAAAAAAAAPyIIYU6Y37lve/MwZls1vmbgxgFdx93hdzOn6g8kHhQ1BS9aAKuXtApQoE3gKpjQ5ze0H9qUruyOUsbM776zXQAIjNMN4r8uJHCvJwACCHvk18POAAAAAwAAAAAAQZnVAAAAZABMS0AAAABkkiIcXkjaTtc9zTQBn0o72CUBe3u+2Mz7W6dgkvkYcJJle8JCNmXx5HcRlDSHJzzBShc8C3rQUIsIuJ93eoBMgHeYAzfholE8hjvrHrqoHq8jfPowxj1FGD6HaUPD1PHTcBXmf0U0cs2Ki0NBDDKNcwKC84nUPdumCkdAxSuEzn4AAAAA"}
 `
+
+var ledgersResponse = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/ledgers?cursor=&limit=1&order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/ledgers?cursor=4294967296&limit=1&order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/ledgers?cursor=4294967296&limit=1&order=desc"
+    }
+  },
+  "_embedded": {
+    "records": [
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/1"
+          },
+          "transactions": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/1/transactions{?cursor,limit,order}",
+            "templated": true
+          },
+          "operations": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/1/operations{?cursor,limit,order}",
+            "templated": true
+          },
+          "payments": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/1/payments{?cursor,limit,order}",
+            "templated": true
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/1/effects{?cursor,limit,order}",
+            "templated": true
+          }
+        },
+        "id": "63d98f536ee68d1b27b5b89f23af5311b7569a24faf1403ad0b52b633b07be99",
+        "paging_token": "4294967296",
+        "hash": "63d98f536ee68d1b27b5b89f23af5311b7569a24faf1403ad0b52b633b07be99",
+        "sequence": 1,
+        "successful_transaction_count": 0,
+        "failed_transaction_count": 0,
+        "operation_count": 0,
+        "closed_at": "1970-01-01T00:00:00Z",
+        "total_coins": "100000000000.0000000",
+        "fee_pool": "0.0000000",
+        "base_fee_in_stroops": 100,
+        "base_reserve_in_stroops": 100000000,
+        "max_tx_set_size": 100,
+        "protocol_version": 0,
+        "header_xdr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABXKi4y/ySKB7DnD9H20xjB+s0gtswIwz1XdSWYaBJaFgAAAAEN4Lazp2QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAX14QAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      }
+    ]
+  }
+}`
+
+var ledgersNextResponse = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/ledgers?cursor=4294967296&limit=1&order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/ledgers?cursor=8589934592&limit=1&order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/ledgers?cursor=8589934592&limit=1&order=desc"
+    }
+  },
+  "_embedded": {
+    "records": [
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/2"
+          },
+          "transactions": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/2/transactions{?cursor,limit,order}",
+            "templated": true
+          },
+          "operations": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/2/operations{?cursor,limit,order}",
+            "templated": true
+          },
+          "payments": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/2/payments{?cursor,limit,order}",
+            "templated": true
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/2/effects{?cursor,limit,order}",
+            "templated": true
+          }
+        },
+        "id": "1685117d8d2270aed3cf81b641087b4f8d8e2b0774b4bb82d1de34d9472fb3d5",
+        "paging_token": "8589934592",
+        "hash": "1685117d8d2270aed3cf81b641087b4f8d8e2b0774b4bb82d1de34d9472fb3d5",
+        "prev_hash": "63d98f536ee68d1b27b5b89f23af5311b7569a24faf1403ad0b52b633b07be99",
+        "sequence": 2,
+        "successful_transaction_count": 0,
+        "failed_transaction_count": 0,
+        "operation_count": 0,
+        "closed_at": "2019-02-27T09:50:12Z",
+        "total_coins": "100000000000.0000000",
+        "fee_pool": "0.0000000",
+        "base_fee_in_stroops": 100,
+        "base_reserve_in_stroops": 100000000,
+        "max_tx_set_size": 100,
+        "protocol_version": 0,
+        "header_xdr": "AAAAAGPZj1Nu5o0bJ7W4nyOvUxG3Vpok+vFAOtC1K2M7B76ZuZRHr9UdXKbTKiclfOjy72YZFJUkJPVcKT5htvorm1QAAAAAXHZdVAAAAAAAAAAA3z9hmASpL9tAVxktxD3XSOp3itxSvEmM6AUkwBS4ERlzUiftOYRhKRI3aHsIRGqiybCW4MmKRi2t2lafBd0khAAAAAIN4Lazp2QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAX14QAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      }
+    ]
+  }
+}`


### PR DESCRIPTION
This PR adds support for the horizonclient to be able to return previous and next result pages for certain endpoints; similar to the JS sdk `result.next()`. 
Here, it is implemented for `/ledgers`. For each page returned, you can call `LedgerRequest.Next(returnedPage, client)` to get the next set of pages from the `Link` specified in the `returnedPage`. This can also the be done to get previous page.

I would like to know your thoughts around having `Prev()` and `Next()` on the `LedgerRequest` struct. 
Before settling to implement it in this manner I had some other options

1. Implement  `Prev()` and `Next()` on the result struct, e.g `hProtocol.LedgersPage.Next()`.  This would mean that I will have to use a new client to fulfil the requests. Using the same horizon client will lead to a cyclic dependency error.

2. Implement  `Prev()` and `Next()` on the horizon client, e.g `Client.Next(resultPage) resultPage`. The 
problem with this is that `resultPage` will have to be of type `interface{}` in other to be used by all the different result structs.

