### PR TITLE
Increment sequence number during tx build

### DIFF
--- a/exp/txnbuild/cmd/txnbuild_examples/main.go
+++ b/exp/txnbuild/cmd/txnbuild_examples/main.go
@@ -598,12 +598,13 @@ func createKeypair() *keypair.Full {
 	return pair
 }
 
-func mapAccounts(horizonAccount horizon.Account) txnbuild.Account {
-	myAccount := txnbuild.Account{
+func mapAccounts(horizonAccount horizon.Account) txnbuild.TXNAccount {
+	myAccount := txnbuild.TXNAccount{
 		ID: horizonAccount.ID,
 	}
 	var err error
-	myAccount.SequenceNumber, err = horizonAccount.GetSequenceNumber()
+	// myAccount.SequenceNumber, err = horizonAccount.GetSequenceNumber()
+	myAccount.SequenceNumber = horizonAccount.Sequence
 	dieIfError("GetSequenceNumber", err)
 
 	return myAccount

--- a/exp/txnbuild/cmd/txnbuild_examples/main.go
+++ b/exp/txnbuild/cmd/txnbuild_examples/main.go
@@ -598,16 +598,8 @@ func createKeypair() *keypair.Full {
 	return pair
 }
 
-func mapAccounts(horizonAccount horizon.Account) *txnbuild.TXNAccount {
-	myAccount := txnbuild.TXNAccount{
-		ID: horizonAccount.ID,
-	}
-	var err error
-	// myAccount.SequenceNumber, err = horizonAccount.GetSequenceNumber()
-	myAccount.SequenceNumber = horizonAccount.Sequence
-	dieIfError("GetSequenceNumber", err)
-
-	return &myAccount
+func mapAccounts(horizonAccount horizon.Account) *horizon.Account {
+	return &horizonAccount
 }
 
 // PrintHorizonError decodes and prints the contents of horizon.Error.Problem.

--- a/exp/txnbuild/cmd/txnbuild_examples/main.go
+++ b/exp/txnbuild/cmd/txnbuild_examples/main.go
@@ -598,7 +598,7 @@ func createKeypair() *keypair.Full {
 	return pair
 }
 
-func mapAccounts(horizonAccount horizon.Account) txnbuild.TXNAccount {
+func mapAccounts(horizonAccount horizon.Account) *txnbuild.TXNAccount {
 	myAccount := txnbuild.TXNAccount{
 		ID: horizonAccount.ID,
 	}
@@ -607,7 +607,7 @@ func mapAccounts(horizonAccount horizon.Account) txnbuild.TXNAccount {
 	myAccount.SequenceNumber = horizonAccount.Sequence
 	dieIfError("GetSequenceNumber", err)
 
-	return myAccount
+	return &myAccount
 }
 
 // PrintHorizonError decodes and prints the contents of horizon.Error.Problem.

--- a/exp/txnbuild/transaction.go
+++ b/exp/txnbuild/transaction.go
@@ -81,11 +81,11 @@ func (tx *Transaction) Build() error {
 
 	// TODO: Validate Seq Num is present in struct
 	tx.SourceAccount.IncrementSequenceNumber()
-	var err error
-	tx.xdrTransaction.SeqNum, err = tx.SourceAccount.GetSequenceNumber()
+	seqnum, err := tx.SourceAccount.GetSequenceNumber()
 	if err != nil {
 		return errors.Wrap(err, "Failed to parse sequence number")
 	}
+	tx.xdrTransaction.SeqNum = seqnum
 
 	for _, op := range tx.Operations {
 		xdrOperation, err := op.BuildXDR()

--- a/exp/txnbuild/transaction.go
+++ b/exp/txnbuild/transaction.go
@@ -18,8 +18,7 @@ import (
 // Account represents the aspects of a Stellar account necessary to construct transactions.
 type Account interface {
 	GetAccountID() string
-	GetSequenceNumber() (xdr.SequenceNumber, error)
-	IncrementSequenceNumber() error
+	IncrementSequenceNumber() (xdr.SequenceNumber, error)
 }
 
 // Transaction represents a Stellar Transaction.
@@ -80,8 +79,7 @@ func (tx *Transaction) Build() error {
 	tx.xdrTransaction.SourceAccount.SetAddress(tx.SourceAccount.GetAccountID())
 
 	// TODO: Validate Seq Num is present in struct
-	tx.SourceAccount.IncrementSequenceNumber()
-	seqnum, err := tx.SourceAccount.GetSequenceNumber()
+	seqnum, err := tx.SourceAccount.IncrementSequenceNumber()
 	if err != nil {
 		return errors.Wrap(err, "Failed to parse sequence number")
 	}

--- a/exp/txnbuild/transaction.go
+++ b/exp/txnbuild/transaction.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"strconv"
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
@@ -15,15 +16,49 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-// Account represents a Stellar Account from the perspective of a Transaction.
-type Account struct {
+// TXNAccount represents a Stellar TXNAccount from the perspective of a Transaction.
+type TXNAccount struct {
 	ID             string
-	SequenceNumber xdr.SequenceNumber
+	SequenceNumber string
+}
+
+// GetAccountID is to be deleted once refactor is complete
+func (t *TXNAccount) GetAccountID() string {
+	return t.ID
+}
+
+// GetSequenceNumber is to be deleted once refactor is complete
+func (t *TXNAccount) GetSequenceNumber() (xdr.SequenceNumber, error) {
+	seqNum, err := strconv.ParseUint(t.SequenceNumber, 10, 64)
+
+	if err != nil {
+		return 0, errors.Wrap(err, "Failed to parse account sequence number")
+	}
+
+	return xdr.SequenceNumber(seqNum), nil
+}
+
+// IncrementSequenceNumber is to be deleted once refactor is complete
+func (t *TXNAccount) IncrementSequenceNumber() error {
+	seqNum, err := t.GetSequenceNumber()
+	if err != nil {
+		return err
+	}
+	seqNum++
+	t.SequenceNumber = strconv.FormatInt(int64(seqNum), 10)
+	return nil
+}
+
+// Account represents the aspects of a Stellar account necessary to construct transactions.
+type Account interface {
+	GetAccountID() string
+	GetSequenceNumber() (xdr.SequenceNumber, error)
+	IncrementSequenceNumber() error
 }
 
 // Transaction represents a Stellar Transaction.
 type Transaction struct {
-	SourceAccount  Account
+	SourceAccount  TXNAccount
 	Operations     []Operation
 	xdrTransaction xdr.Transaction
 	BaseFee        uint64 // TODO: Why is this a uint 64? Can it be a plain int?
@@ -79,7 +114,12 @@ func (tx *Transaction) Build() error {
 	tx.xdrTransaction.SourceAccount.SetAddress(tx.SourceAccount.ID)
 
 	// TODO: Validate Seq Num is present in struct
-	tx.xdrTransaction.SeqNum = tx.SourceAccount.SequenceNumber + 1
+	tx.SourceAccount.IncrementSequenceNumber()
+	var err error
+	tx.xdrTransaction.SeqNum, err = tx.SourceAccount.GetSequenceNumber()
+	if err != nil {
+		return errors.Wrap(err, "Failed to parse sequence number")
+	}
 
 	for _, op := range tx.Operations {
 		xdrOperation, err := op.BuildXDR()

--- a/exp/txnbuild/transaction.go
+++ b/exp/txnbuild/transaction.go
@@ -23,12 +23,12 @@ type TXNAccount struct {
 }
 
 // GetAccountID is to be deleted once refactor is complete
-func (t *TXNAccount) GetAccountID() string {
+func (t TXNAccount) GetAccountID() string {
 	return t.ID
 }
 
 // GetSequenceNumber is to be deleted once refactor is complete
-func (t *TXNAccount) GetSequenceNumber() (xdr.SequenceNumber, error) {
+func (t TXNAccount) GetSequenceNumber() (xdr.SequenceNumber, error) {
 	seqNum, err := strconv.ParseUint(t.SequenceNumber, 10, 64)
 
 	if err != nil {
@@ -58,7 +58,7 @@ type Account interface {
 
 // Transaction represents a Stellar Transaction.
 type Transaction struct {
-	SourceAccount  TXNAccount
+	SourceAccount  Account
 	Operations     []Operation
 	xdrTransaction xdr.Transaction
 	BaseFee        uint64 // TODO: Why is this a uint 64? Can it be a plain int?
@@ -111,7 +111,7 @@ func (tx *Transaction) SetDefaultFee() {
 func (tx *Transaction) Build() error {
 	// Set account ID in XDR
 	// TODO: Validate provided key before going further
-	tx.xdrTransaction.SourceAccount.SetAddress(tx.SourceAccount.ID)
+	tx.xdrTransaction.SourceAccount.SetAddress(tx.SourceAccount.GetAccountID())
 
 	// TODO: Validate Seq Num is present in struct
 	tx.SourceAccount.IncrementSequenceNumber()

--- a/exp/txnbuild/transaction.go
+++ b/exp/txnbuild/transaction.go
@@ -8,46 +8,12 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"strconv"
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
-
-// TXNAccount represents a Stellar TXNAccount from the perspective of a Transaction.
-type TXNAccount struct {
-	ID             string
-	SequenceNumber string
-}
-
-// GetAccountID is to be deleted once refactor is complete
-func (t TXNAccount) GetAccountID() string {
-	return t.ID
-}
-
-// GetSequenceNumber is to be deleted once refactor is complete
-func (t TXNAccount) GetSequenceNumber() (xdr.SequenceNumber, error) {
-	seqNum, err := strconv.ParseUint(t.SequenceNumber, 10, 64)
-
-	if err != nil {
-		return 0, errors.Wrap(err, "Failed to parse account sequence number")
-	}
-
-	return xdr.SequenceNumber(seqNum), nil
-}
-
-// IncrementSequenceNumber is to be deleted once refactor is complete
-func (t *TXNAccount) IncrementSequenceNumber() error {
-	seqNum, err := t.GetSequenceNumber()
-	if err != nil {
-		return err
-	}
-	seqNum++
-	t.SequenceNumber = strconv.FormatInt(int64(seqNum), 10)
-	return nil
-}
 
 // Account represents the aspects of a Stellar account necessary to construct transactions.
 type Account interface {

--- a/exp/txnbuild/transaction_test.go
+++ b/exp/txnbuild/transaction_test.go
@@ -4,19 +4,24 @@ import (
 	"testing"
 
 	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func makeTestAccount(kp *keypair.Full, seqnum string) horizon.Account {
+	return horizon.Account{
+		HistoryAccount: horizon.HistoryAccount{
+			AccountID: kp.Address(),
+		},
+		Sequence: seqnum,
+	}
+}
+
 func TestInflation(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := horizon.Account{
-		HistoryAccount: horizon.HistoryAccount{
-			AccountID: kp0.Address(),
-		},
-		Sequence: "9605939170639897",
-	}
+	sourceAccount := makeTestAccount(kp0, "9605939170639897")
 
 	inflation := Inflation{}
 
@@ -33,11 +38,7 @@ func TestInflation(t *testing.T) {
 
 func TestCreateAccount(t *testing.T) {
 	kp0 := newKeypair0()
-
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "9605939170639897",
-	}
+	sourceAccount := makeTestAccount(kp0, "9605939170639897")
 
 	createAccount := CreateAccount{
 		Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
@@ -58,10 +59,7 @@ func TestCreateAccount(t *testing.T) {
 
 func TestPayment(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "9605939170639898",
-	}
+	sourceAccount := makeTestAccount(kp0, "9605939170639898")
 
 	payment := Payment{
 		Destination: "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
@@ -82,10 +80,7 @@ func TestPayment(t *testing.T) {
 
 func TestPaymentFailsIfNoAssetSpecified(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "9605939170639898",
-	}
+	sourceAccount := makeTestAccount(kp0, "9605939170639898")
 
 	payment := Payment{
 		Destination: "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
@@ -105,10 +100,7 @@ func TestPaymentFailsIfNoAssetSpecified(t *testing.T) {
 
 func TestBumpSequence(t *testing.T) {
 	kp1 := newKeypair1()
-	sourceAccount := TXNAccount{
-		ID:             kp1.Address(),
-		SequenceNumber: "9606132444168199",
-	}
+	sourceAccount := makeTestAccount(kp1, "9606132444168199")
 
 	bumpSequence := BumpSequence{
 		BumpTo: 9606132444168300,
@@ -127,11 +119,7 @@ func TestBumpSequence(t *testing.T) {
 
 func TestAccountMerge(t *testing.T) {
 	kp0 := newKeypair0()
-
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "40385577484298",
-	}
+	sourceAccount := makeTestAccount(kp0, "40385577484298")
 
 	accountMerge := AccountMerge{
 		Destination: "GAS4V4O2B7DW5T7IQRPEEVCRXMDZESKISR7DVIGKZQYYV3OSQ5SH5LVP",
@@ -150,10 +138,7 @@ func TestAccountMerge(t *testing.T) {
 
 func TestManageData(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "40385577484298",
-	}
+	sourceAccount := makeTestAccount(kp0, "40385577484298")
 
 	manageData := ManageData{
 		Name:  "Fruit preference",
@@ -172,10 +157,7 @@ func TestManageData(t *testing.T) {
 }
 func TestManageDataRemoveDataEntry(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "40385577484309",
-	}
+	sourceAccount := makeTestAccount(kp0, "40385577484309")
 
 	manageData := ManageData{
 		Name: "Fruit preference",
@@ -195,10 +177,7 @@ func TestManageDataRemoveDataEntry(t *testing.T) {
 func TestSetOptionsInflationDestination(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "40385577484315",
-	}
+	sourceAccount := makeTestAccount(kp0, "40385577484315")
 
 	setOptions := SetOptions{
 		InflationDestination: NewInflationDestination(kp1.Address()),
@@ -217,10 +196,7 @@ func TestSetOptionsInflationDestination(t *testing.T) {
 
 func TestSetOptionsSetFlags(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "40385577484318",
-	}
+	sourceAccount := makeTestAccount(kp0, "40385577484318")
 
 	setOptions := SetOptions{
 		SetFlags: []AccountFlag{AuthRequired, AuthRevocable},
@@ -239,10 +215,7 @@ func TestSetOptionsSetFlags(t *testing.T) {
 
 func TestSetOptionsClearFlags(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "40385577484319",
-	}
+	sourceAccount := makeTestAccount(kp0, "40385577484319")
 
 	setOptions := SetOptions{
 		ClearFlags: []AccountFlag{AuthRequired, AuthRevocable},
@@ -261,10 +234,7 @@ func TestSetOptionsClearFlags(t *testing.T) {
 
 func TestSetOptionsMasterWeight(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "40385577484320",
-	}
+	sourceAccount := makeTestAccount(kp0, "40385577484320")
 
 	setOptions := SetOptions{
 		MasterWeight: NewThreshold(10),
@@ -283,10 +253,7 @@ func TestSetOptionsMasterWeight(t *testing.T) {
 
 func TestSetOptionsThresholds(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "40385577484322",
-	}
+	sourceAccount := makeTestAccount(kp0, "40385577484322")
 
 	setOptions := SetOptions{
 		LowThreshold:    NewThreshold(1),
@@ -307,10 +274,7 @@ func TestSetOptionsThresholds(t *testing.T) {
 
 func TestSetOptionsHomeDomain(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "40385577484325",
-	}
+	sourceAccount := makeTestAccount(kp0, "40385577484325")
 
 	setOptions := SetOptions{
 		HomeDomain: NewHomeDomain("LovelyLumensLookLuminous.com"),
@@ -329,10 +293,7 @@ func TestSetOptionsHomeDomain(t *testing.T) {
 
 func TestSetOptionsHomeDomainTooLong(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "40385577484323",
-	}
+	sourceAccount := makeTestAccount(kp0, "40385577484323")
 
 	setOptions := SetOptions{
 		HomeDomain: NewHomeDomain("LovelyLumensLookLuminousLately.com"),
@@ -351,10 +312,7 @@ func TestSetOptionsHomeDomainTooLong(t *testing.T) {
 func TestSetOptionsSigner(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "40385577484325",
-	}
+	sourceAccount := makeTestAccount(kp0, "40385577484325")
 
 	setOptions := SetOptions{
 		Signer: &Signer{Address: kp1.Address(), Weight: Threshold(4)},
@@ -373,10 +331,7 @@ func TestSetOptionsSigner(t *testing.T) {
 
 func TestMultipleOperations(t *testing.T) {
 	kp1 := newKeypair1()
-	sourceAccount := TXNAccount{
-		ID:             kp1.Address(),
-		SequenceNumber: "9606132444168199",
-	}
+	sourceAccount := makeTestAccount(kp1, "9606132444168199")
 
 	inflation := Inflation{}
 	bumpSequence := BumpSequence{
@@ -397,11 +352,7 @@ func TestMultipleOperations(t *testing.T) {
 func TestChangeTrust(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "40385577484348",
-	}
+	sourceAccount := makeTestAccount(kp0, "40385577484348")
 
 	changeTrust := ChangeTrust{
 		Line:  NewAsset("ABCD", kp1.Address()),
@@ -421,11 +372,7 @@ func TestChangeTrust(t *testing.T) {
 
 func TestChangeTrustNativeAssetNotAllowed(t *testing.T) {
 	kp0 := newKeypair0()
-
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "40385577484348",
-	}
+	sourceAccount := makeTestAccount(kp0, "40385577484348")
 
 	changeTrust := ChangeTrust{
 		Line:  NewNativeAsset(),
@@ -446,11 +393,7 @@ func TestChangeTrustNativeAssetNotAllowed(t *testing.T) {
 func TestChangeTrustDeleteTrustline(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "40385577484354",
-	}
+	sourceAccount := makeTestAccount(kp0, "40385577484354")
 
 	issuedAsset := NewAsset("ABCD", kp1.Address())
 	removeTrust := NewRemoveTrustlineOp(issuedAsset)
@@ -469,11 +412,7 @@ func TestChangeTrustDeleteTrustline(t *testing.T) {
 func TestAllowTrust(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "40385577484366",
-	}
+	sourceAccount := makeTestAccount(kp0, "40385577484366")
 
 	issuedAsset := NewAsset("ABCD", kp1.Address())
 	allowTrust := AllowTrust{
@@ -496,11 +435,7 @@ func TestAllowTrust(t *testing.T) {
 func TestManageOfferNewOffer(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-
-	sourceAccount := TXNAccount{
-		ID:             kp1.Address(),
-		SequenceNumber: "41137196761092",
-	}
+	sourceAccount := makeTestAccount(kp1, "41137196761092")
 
 	selling := NewNativeAsset()
 	buying := NewAsset("ABCD", kp0.Address())
@@ -521,11 +456,7 @@ func TestManageOfferNewOffer(t *testing.T) {
 
 func TestManageOfferDeleteOffer(t *testing.T) {
 	kp1 := newKeypair1()
-
-	sourceAccount := TXNAccount{
-		ID:             kp1.Address(),
-		SequenceNumber: "41137196761105",
-	}
+	sourceAccount := makeTestAccount(kp1, "41137196761105")
 
 	offerID := uint64(2921622)
 	deleteOffer := NewDeleteOfferOp(offerID)
@@ -544,11 +475,7 @@ func TestManageOfferDeleteOffer(t *testing.T) {
 func TestManageOfferUpdateOffer(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-
-	sourceAccount := TXNAccount{
-		ID:             kp1.Address(),
-		SequenceNumber: "41137196761097",
-	}
+	sourceAccount := makeTestAccount(kp1, "41137196761097")
 
 	selling := NewNativeAsset()
 	buying := NewAsset("ABCD", kp0.Address())
@@ -571,11 +498,7 @@ func TestManageOfferUpdateOffer(t *testing.T) {
 func TestCreatePassiveOffer(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-
-	sourceAccount := TXNAccount{
-		ID:             kp1.Address(),
-		SequenceNumber: "41137196761100",
-	}
+	sourceAccount := makeTestAccount(kp1, "41137196761100")
 
 	createPassiveOffer := CreatePassiveOffer{
 		Selling: NewNativeAsset(),
@@ -597,13 +520,9 @@ func TestCreatePassiveOffer(t *testing.T) {
 func TestPathPayment(t *testing.T) {
 	kp0 := newKeypair0()
 	kp2 := newKeypair2()
+	sourceAccount := makeTestAccount(kp2, "187316408680450")
 
-	sourceAccount := TXNAccount{
-		ID:             kp2.Address(),
-		SequenceNumber: "187316408680450",
-	}
 	abcdAsset := NewAsset("ABCD", kp0.Address())
-
 	pathPayment := PathPayment{
 		SendAsset:   NewNativeAsset(),
 		SendMax:     "10",

--- a/exp/txnbuild/transaction_test.go
+++ b/exp/txnbuild/transaction_test.go
@@ -10,9 +10,14 @@ import (
 
 func TestInflation(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := Account{
+	// sourceAccount := horizon.Account{
+	// 	HistoryAccount: horizon.HistoryAccount{
+	// 		AccountID: kp0.Address(),
+	// Sequence: "9605939170639897",
+	// 	},
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 9605939170639897,
+		SequenceNumber: "9605939170639897",
 	}
 
 	inflation := Inflation{}
@@ -31,9 +36,9 @@ func TestInflation(t *testing.T) {
 func TestCreateAccount(t *testing.T) {
 	kp0 := newKeypair0()
 
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 9605939170639897,
+		SequenceNumber: "9605939170639897",
 	}
 
 	createAccount := CreateAccount{
@@ -55,9 +60,9 @@ func TestCreateAccount(t *testing.T) {
 
 func TestPayment(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 9605939170639898,
+		SequenceNumber: "9605939170639898",
 	}
 
 	payment := Payment{
@@ -79,9 +84,9 @@ func TestPayment(t *testing.T) {
 
 func TestPaymentFailsIfNoAssetSpecified(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 9605939170639898,
+		SequenceNumber: "9605939170639898",
 	}
 
 	payment := Payment{
@@ -102,9 +107,9 @@ func TestPaymentFailsIfNoAssetSpecified(t *testing.T) {
 
 func TestBumpSequence(t *testing.T) {
 	kp1 := newKeypair1()
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp1.Address(),
-		SequenceNumber: 9606132444168199,
+		SequenceNumber: "9606132444168199",
 	}
 
 	bumpSequence := BumpSequence{
@@ -125,9 +130,9 @@ func TestBumpSequence(t *testing.T) {
 func TestAccountMerge(t *testing.T) {
 	kp0 := newKeypair0()
 
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 40385577484298,
+		SequenceNumber: "40385577484298",
 	}
 
 	accountMerge := AccountMerge{
@@ -147,9 +152,9 @@ func TestAccountMerge(t *testing.T) {
 
 func TestManageData(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 40385577484298,
+		SequenceNumber: "40385577484298",
 	}
 
 	manageData := ManageData{
@@ -169,9 +174,9 @@ func TestManageData(t *testing.T) {
 }
 func TestManageDataRemoveDataEntry(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 40385577484309,
+		SequenceNumber: "40385577484309",
 	}
 
 	manageData := ManageData{
@@ -192,9 +197,9 @@ func TestManageDataRemoveDataEntry(t *testing.T) {
 func TestSetOptionsInflationDestination(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 40385577484315,
+		SequenceNumber: "40385577484315",
 	}
 
 	setOptions := SetOptions{
@@ -214,9 +219,9 @@ func TestSetOptionsInflationDestination(t *testing.T) {
 
 func TestSetOptionsSetFlags(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 40385577484318,
+		SequenceNumber: "40385577484318",
 	}
 
 	setOptions := SetOptions{
@@ -236,9 +241,9 @@ func TestSetOptionsSetFlags(t *testing.T) {
 
 func TestSetOptionsClearFlags(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 40385577484319,
+		SequenceNumber: "40385577484319",
 	}
 
 	setOptions := SetOptions{
@@ -258,9 +263,9 @@ func TestSetOptionsClearFlags(t *testing.T) {
 
 func TestSetOptionsMasterWeight(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 40385577484320,
+		SequenceNumber: "40385577484320",
 	}
 
 	setOptions := SetOptions{
@@ -280,9 +285,9 @@ func TestSetOptionsMasterWeight(t *testing.T) {
 
 func TestSetOptionsThresholds(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 40385577484322,
+		SequenceNumber: "40385577484322",
 	}
 
 	setOptions := SetOptions{
@@ -304,9 +309,9 @@ func TestSetOptionsThresholds(t *testing.T) {
 
 func TestSetOptionsHomeDomain(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 40385577484325,
+		SequenceNumber: "40385577484325",
 	}
 
 	setOptions := SetOptions{
@@ -326,9 +331,9 @@ func TestSetOptionsHomeDomain(t *testing.T) {
 
 func TestSetOptionsHomeDomainTooLong(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 40385577484323,
+		SequenceNumber: "40385577484323",
 	}
 
 	setOptions := SetOptions{
@@ -348,9 +353,9 @@ func TestSetOptionsHomeDomainTooLong(t *testing.T) {
 func TestSetOptionsSigner(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 40385577484325,
+		SequenceNumber: "40385577484325",
 	}
 
 	setOptions := SetOptions{
@@ -370,9 +375,9 @@ func TestSetOptionsSigner(t *testing.T) {
 
 func TestMultipleOperations(t *testing.T) {
 	kp1 := newKeypair1()
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp1.Address(),
-		SequenceNumber: 9606132444168199,
+		SequenceNumber: "9606132444168199",
 	}
 
 	inflation := Inflation{}
@@ -395,9 +400,9 @@ func TestChangeTrust(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
 
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 40385577484348,
+		SequenceNumber: "40385577484348",
 	}
 
 	changeTrust := ChangeTrust{
@@ -419,9 +424,9 @@ func TestChangeTrust(t *testing.T) {
 func TestChangeTrustNativeAssetNotAllowed(t *testing.T) {
 	kp0 := newKeypair0()
 
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 40385577484348,
+		SequenceNumber: "40385577484348",
 	}
 
 	changeTrust := ChangeTrust{
@@ -444,9 +449,9 @@ func TestChangeTrustDeleteTrustline(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
 
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 40385577484354,
+		SequenceNumber: "40385577484354",
 	}
 
 	issuedAsset := NewAsset("ABCD", kp1.Address())
@@ -467,9 +472,9 @@ func TestAllowTrust(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
 
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp0.Address(),
-		SequenceNumber: 40385577484366,
+		SequenceNumber: "40385577484366",
 	}
 
 	issuedAsset := NewAsset("ABCD", kp1.Address())
@@ -494,9 +499,9 @@ func TestManageOfferNewOffer(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
 
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp1.Address(),
-		SequenceNumber: 41137196761092,
+		SequenceNumber: "41137196761092",
 	}
 
 	selling := NewNativeAsset()
@@ -519,9 +524,9 @@ func TestManageOfferNewOffer(t *testing.T) {
 func TestManageOfferDeleteOffer(t *testing.T) {
 	kp1 := newKeypair1()
 
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp1.Address(),
-		SequenceNumber: 41137196761105,
+		SequenceNumber: "41137196761105",
 	}
 
 	offerID := uint64(2921622)
@@ -542,9 +547,9 @@ func TestManageOfferUpdateOffer(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
 
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp1.Address(),
-		SequenceNumber: 41137196761097,
+		SequenceNumber: "41137196761097",
 	}
 
 	selling := NewNativeAsset()
@@ -569,9 +574,9 @@ func TestCreatePassiveOffer(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
 
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp1.Address(),
-		SequenceNumber: 41137196761100,
+		SequenceNumber: "41137196761100",
 	}
 
 	createPassiveOffer := CreatePassiveOffer{
@@ -595,9 +600,9 @@ func TestPathPayment(t *testing.T) {
 	kp0 := newKeypair0()
 	kp2 := newKeypair2()
 
-	sourceAccount := Account{
+	sourceAccount := TXNAccount{
 		ID:             kp2.Address(),
-		SequenceNumber: 187316408680450,
+		SequenceNumber: "187316408680450",
 	}
 	abcdAsset := NewAsset("ABCD", kp0.Address())
 

--- a/exp/txnbuild/transaction_test.go
+++ b/exp/txnbuild/transaction_test.go
@@ -3,6 +3,7 @@ package txnbuild
 import (
 	"testing"
 
+	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/network"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -10,20 +11,17 @@ import (
 
 func TestInflation(t *testing.T) {
 	kp0 := newKeypair0()
-	// sourceAccount := horizon.Account{
-	// 	HistoryAccount: horizon.HistoryAccount{
-	// 		AccountID: kp0.Address(),
-	// Sequence: "9605939170639897",
-	// 	},
-	sourceAccount := TXNAccount{
-		ID:             kp0.Address(),
-		SequenceNumber: "9605939170639897",
+	sourceAccount := horizon.Account{
+		HistoryAccount: horizon.HistoryAccount{
+			AccountID: kp0.Address(),
+		},
+		Sequence: "9605939170639897",
 	}
 
 	inflation := Inflation{}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&inflation},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -48,7 +46,7 @@ func TestCreateAccount(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&createAccount},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -72,7 +70,7 @@ func TestPayment(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&payment},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -95,7 +93,7 @@ func TestPaymentFailsIfNoAssetSpecified(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&payment},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -117,7 +115,7 @@ func TestBumpSequence(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&bumpSequence},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -140,7 +138,7 @@ func TestAccountMerge(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&accountMerge},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -163,7 +161,7 @@ func TestManageData(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&manageData},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -184,7 +182,7 @@ func TestManageDataRemoveDataEntry(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&manageData},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -207,7 +205,7 @@ func TestSetOptionsInflationDestination(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&setOptions},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -229,7 +227,7 @@ func TestSetOptionsSetFlags(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&setOptions},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -251,7 +249,7 @@ func TestSetOptionsClearFlags(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&setOptions},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -273,7 +271,7 @@ func TestSetOptionsMasterWeight(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&setOptions},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -297,7 +295,7 @@ func TestSetOptionsThresholds(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&setOptions},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -319,7 +317,7 @@ func TestSetOptionsHomeDomain(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&setOptions},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -341,7 +339,7 @@ func TestSetOptionsHomeDomainTooLong(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&setOptions},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -363,7 +361,7 @@ func TestSetOptionsSigner(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&setOptions},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -386,7 +384,7 @@ func TestMultipleOperations(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&inflation, &bumpSequence},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -411,7 +409,7 @@ func TestChangeTrust(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&changeTrust},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -435,7 +433,7 @@ func TestChangeTrustNativeAssetNotAllowed(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&changeTrust},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -458,7 +456,7 @@ func TestChangeTrustDeleteTrustline(t *testing.T) {
 	removeTrust := NewRemoveTrustlineOp(issuedAsset)
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&removeTrust},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -485,7 +483,7 @@ func TestAllowTrust(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&allowTrust},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -511,7 +509,7 @@ func TestManageOfferNewOffer(t *testing.T) {
 	createOffer := NewCreateOfferOp(selling, buying, sellAmount, price)
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&createOffer},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -533,7 +531,7 @@ func TestManageOfferDeleteOffer(t *testing.T) {
 	deleteOffer := NewDeleteOfferOp(offerID)
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&deleteOffer},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -560,7 +558,7 @@ func TestManageOfferUpdateOffer(t *testing.T) {
 	updateOffer := NewUpdateOfferOp(selling, buying, sellAmount, price, offerID)
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&updateOffer},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -586,7 +584,7 @@ func TestCreatePassiveOffer(t *testing.T) {
 		Price:   "1.0"}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&createPassiveOffer},
 		Network:       network.TestNetworkPassphrase,
 	}
@@ -616,7 +614,7 @@ func TestPathPayment(t *testing.T) {
 	}
 
 	tx := Transaction{
-		SourceAccount: sourceAccount,
+		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&pathPayment},
 		Network:       network.TestNetworkPassphrase,
 	}

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -96,14 +96,14 @@ func (a Account) GetSequenceNumber() (xdr.SequenceNumber, error) {
 // IncrementSequenceNumber increments the internal record of the account's sequence
 // number by 1. This is typically used after a transaction build so that the next
 // transaction to be built will be valid.
-func (a *Account) IncrementSequenceNumber() error {
+func (a *Account) IncrementSequenceNumber() (xdr.SequenceNumber, error) {
 	seqNum, err := a.GetSequenceNumber()
 	if err != nil {
-		return err
+		return xdr.SequenceNumber(0), err
 	}
 	seqNum++
 	a.Sequence = strconv.FormatInt(int64(seqNum), 10)
-	return nil
+	return a.GetSequenceNumber()
 }
 
 // MustGetData returns decoded value for a given key. If the key does

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -53,6 +53,12 @@ type Account struct {
 	Data                 map[string]string `json:"data"`
 }
 
+// GetAccountID returns the Stellar account ID. This exists to satisfy the Account interface
+// of txnbuild.
+func (a Account) GetAccountID() string {
+	return a.AccountID
+}
+
 // GetNativeBalance returns the native balance of the account
 func (a Account) GetNativeBalance() (string, error) {
 	for _, balance := range a.Balances {

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -103,8 +103,8 @@ func (a *Account) IncrementSequenceNumber() error {
 // MustGetData returns decoded value for a given key. If the key does
 // not exist, empty slice will be returned. If there is an error
 // decoding a value, it will panic.
-func (this *Account) MustGetData(key string) []byte {
-	bytes, err := this.GetData(key)
+func (a *Account) MustGetData(key string) []byte {
+	bytes, err := a.GetData(key)
 	if err != nil {
 		panic(err)
 	}
@@ -113,8 +113,8 @@ func (this *Account) MustGetData(key string) []byte {
 
 // GetData returns decoded value for a given key. If the key does
 // not exist, empty slice will be returned.
-func (this *Account) GetData(key string) ([]byte, error) {
-	return base64.StdEncoding.DecodeString(this.Data[key])
+func (a *Account) GetData(key string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(a.Data[key])
 }
 
 // AccountFlags represents the state of an account's flags
@@ -199,8 +199,8 @@ type Ledger struct {
 	HeaderXDR                  string    `json:"header_xdr"`
 }
 
-func (this Ledger) PagingToken() string {
-	return this.PT
+func (l Ledger) PagingToken() string {
+	return l.PT
 }
 
 // Offer is the display form of an offer to trade currency.
@@ -222,8 +222,8 @@ type Offer struct {
 	LastModifiedTime   *time.Time `json:"last_modified_time"`
 }
 
-func (this Offer) PagingToken() string {
-	return this.PT
+func (o Offer) PagingToken() string {
+	return o.PT
 }
 
 // OrderBookSummary represents a snapshot summary of a given order book
@@ -248,7 +248,7 @@ type Path struct {
 }
 
 // stub implementation to satisfy pageable interface
-func (this Path) PagingToken() string {
+func (p Path) PagingToken() string {
 	return ""
 }
 

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -87,6 +87,19 @@ func (a Account) GetSequenceNumber() (xdr.SequenceNumber, error) {
 	return xdr.SequenceNumber(seqNum), nil
 }
 
+// IncrementSequenceNumber increments the internal record of the account's sequence
+// number by 1. This is typically used after a transaction build so that the next
+// transaction to be built will be valid.
+func (a *Account) IncrementSequenceNumber() error {
+	seqNum, err := a.GetSequenceNumber()
+	if err != nil {
+		return err
+	}
+	seqNum++
+	a.Sequence = strconv.FormatInt(int64(seqNum), 10)
+	return nil
+}
+
 // MustGetData returns decoded value for a given key. If the key does
 // not exist, empty slice will be returned. If there is an error
 // decoding a value, it will panic.

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -53,8 +53,8 @@ type Account struct {
 	Data                 map[string]string `json:"data"`
 }
 
-// GetAccountID returns the Stellar account ID. This exists to satisfy the Account interface
-// of txnbuild.
+// GetAccountID returns the Stellar account ID. This is to satisfy the
+// Account interface of txnbuild.
 func (a Account) GetAccountID() string {
 	return a.AccountID
 }

--- a/protocols/horizon/main_test.go
+++ b/protocols/horizon/main_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,6 +15,16 @@ var exampleAccount = Account{
 		"test":    "aGVsbG8=",
 		"invalid": "a_*&^*",
 	},
+	Sequence: "3002985298788353",
+}
+
+func TestAccount_IncrementSequenceNumber(t *testing.T) {
+	exampleAccount.IncrementSequenceNumber()
+	seqNum, err := exampleAccount.GetSequenceNumber()
+
+	assert.Nil(t, err)
+	assert.Equal(t, "3002985298788354", exampleAccount.Sequence, "sequence number string was incremented")
+	assert.Equal(t, xdr.SequenceNumber(3002985298788354), seqNum, "incremented sequence number is correct value/type")
 }
 
 // Testing the GetData method of Account

--- a/protocols/horizon/main_test.go
+++ b/protocols/horizon/main_test.go
@@ -27,38 +27,30 @@ func TestAccount_IncrementSequenceNumber(t *testing.T) {
 	assert.Equal(t, xdr.SequenceNumber(3002985298788354), seqNum, "incremented sequence number is correct value/type")
 }
 
-// Testing the GetData method of Account
 func TestAccount_GetData(t *testing.T) {
-	// Should return the decoded value if the key exists
 	decoded, err := exampleAccount.GetData("test")
 	assert.Nil(t, err)
-	assert.Equal(t, string(decoded), "hello")
+	assert.Equal(t, string(decoded), "hello", "returns decoded value when key exists")
 
-	// Should return an empty slice if key doesn't exist
 	decoded, err = exampleAccount.GetData("test2")
 	assert.Nil(t, err)
-	assert.Equal(t, len(decoded), 0)
+	assert.Equal(t, len(decoded), 0, "returns empty slice if key doesn't exist")
 
-	// Should return error slice if value is invalid
 	_, err = exampleAccount.GetData("invalid")
-	assert.NotNil(t, err)
+	assert.NotNil(t, err, "returns error slice if value is invalid")
 }
 
 func TestAccount_MustGetData(t *testing.T) {
-	// Should return the decoded value if the key exists
 	decoded := exampleAccount.MustGetData("test")
-	assert.Equal(t, string(decoded), "hello")
+	assert.Equal(t, string(decoded), "hello", "returns decoded value when the key exists")
 
-	// Should return an empty slice if key doesn't exist
 	decoded = exampleAccount.MustGetData("test2")
-	assert.Equal(t, len(decoded), 0)
+	assert.Equal(t, len(decoded), 0, "returns empty slice if key doesn't exist")
 
-	// Should panic if the value is invalid
-	assert.Panics(t, func() { exampleAccount.MustGetData("invalid") })
+	assert.Panics(t, func() { exampleAccount.MustGetData("invalid") }, "panics on invalid input")
 }
 
 // Transaction Tests
-// After marshalling and unmarshalling, the resulting struct should be the exact same as the original
 func TestTransactionJSONMarshal(t *testing.T) {
 	transaction := Transaction{
 		ID:       "12345",
@@ -70,11 +62,9 @@ func TestTransactionJSONMarshal(t *testing.T) {
 	assert.Nil(t, marshalErr)
 	var result Transaction
 	json.Unmarshal(marshaledTransaction, &result)
-	assert.Equal(t, result, transaction)
+	assert.Equal(t, result, transaction, "data matches original input")
 }
 
-//For text memos, even if memo is an empty string, the resulting JSON should
-// still include memo as a field
 func TestTransactionEmptyMemoText(t *testing.T) {
 	transaction := Transaction{
 		MemoType: "text",
@@ -86,10 +76,9 @@ func TestTransactionEmptyMemoText(t *testing.T) {
 		Memo *string
 	}
 	json.Unmarshal(marshaledTransaction, &result)
-	assert.NotNil(t, result.Memo)
+	assert.NotNil(t, result.Memo, "memo field is present even if input memo was empty string")
 }
 
-// If a transaction's memo type is None, then the memo field should be omitted from JSON
 func TestTransactionMemoTypeNone(t *testing.T) {
 	transaction := Transaction{
 		MemoType: "none",
@@ -100,5 +89,5 @@ func TestTransactionMemoTypeNone(t *testing.T) {
 		Memo *string
 	}
 	json.Unmarshal(marshaledTransaction, &result)
-	assert.Nil(t, result.Memo)
+	assert.Nil(t, result.Memo, "no memo field is present when memo input type was `none`")
 }

--- a/protocols/horizon/main_test.go
+++ b/protocols/horizon/main_test.go
@@ -19,8 +19,7 @@ var exampleAccount = Account{
 }
 
 func TestAccount_IncrementSequenceNumber(t *testing.T) {
-	exampleAccount.IncrementSequenceNumber()
-	seqNum, err := exampleAccount.GetSequenceNumber()
+	seqNum, err := exampleAccount.IncrementSequenceNumber()
 
 	assert.Nil(t, err)
 	assert.Equal(t, "3002985298788354", exampleAccount.Sequence, "sequence number string was incremented")


### PR DESCRIPTION
This closes #1126 and does the following:

- Removes the custom `Account` object from `txnbuild`, and instead depend on a new `Account` interface
- Modifies `protocols/horizon` to allow it to conform to the new interface, and in particular to add methods to manipulate the account sequence number, which needs to be be manipulated as a number, but stored as a string. `GetAccountID` protects the caller from the underlying ID implementation (which is helpful since there are more than one, and only one is correct to use).
- Improves unit tests by abstracting account type to a helper, and making test strings more explicit
- Addresses some golint naming warnings

The code from this PR is needed to unblock #1070.