### PR TITLE
exp/ticker: Market data aggregation

### DIFF
--- a/exp/ticker/cmd/generate.go
+++ b/exp/ticker/cmd/generate.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"github.com/lib/pq"
+	"github.com/spf13/cobra"
+	ticker "github.com/stellar/go/exp/ticker/internal"
+	"github.com/stellar/go/exp/ticker/internal/tickerdb"
+)
+
+var OutFile string
+
+func init() {
+	rootCmd.AddCommand(cmdGenerate)
+	cmdGenerate.AddCommand(cmdGenerateMarketData)
+
+	cmdGenerateMarketData.Flags().StringVarP(
+		&OutFile,
+		"out-file",
+		"o",
+		"markets.json",
+		"Set the name of the output file",
+	)
+}
+
+var cmdGenerate = &cobra.Command{
+	Use:   "generate [data type]",
+	Short: "Generates reports about assets and markets",
+}
+
+var cmdGenerateMarketData = &cobra.Command{
+	Use:   "market-data",
+	Short: "Generate the aggregated market data (for 24h and 7d) and outputs to a file.",
+	Run: func(cmd *cobra.Command, args []string) {
+		dbInfo, err := pq.ParseURL(DatabaseURL)
+		if err != nil {
+			Logger.Fatal("could not parse db-url:", err)
+		}
+
+		session, err := tickerdb.CreateSession("postgres", dbInfo)
+		if err != nil {
+			Logger.Fatal("could not connect to db:", err)
+		}
+
+		Logger.Infof("Starting market data generation, outputting to: %s\n", OutFile)
+		err = ticker.GenerateMarketSummaryFile(&session, Logger, OutFile)
+		if err != nil {
+			Logger.Fatal("could not generate market data:", err)
+		}
+	},
+}

--- a/exp/ticker/internal/actions_asset.go
+++ b/exp/ticker/internal/actions_asset.go
@@ -2,6 +2,8 @@ package ticker
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 
 	horizonclient "github.com/stellar/go/exp/clients/horizon"
@@ -59,7 +61,11 @@ func writeAssetsToFile(assets []scraper.FinalAsset, filename string) (numBytes i
 		return
 	}
 
-	numBytes, err = utils.WriteJSONToFile(jsonAssets, filename)
+	dirPath := filepath.Join(".", "tmp")
+	_ = os.Mkdir(dirPath, os.ModePerm) // ignore if dir already exists
+	path := filepath.Join(".", "tmp", filename)
+
+	numBytes, err = utils.WriteJSONToFile(jsonAssets, path)
 	if err != nil {
 		return
 	}

--- a/exp/ticker/internal/actions_market.go
+++ b/exp/ticker/internal/actions_market.go
@@ -58,6 +58,7 @@ func GenerateMarketSummary(s *tickerdb.TickerSession) (ms MarketSummary, err err
 }
 
 func dbMarketToJSON(m tickerdb.Market) MarketStats {
+	closeTime := m.LastPriceCloseTime.UnixNano() / 1000000
 	return MarketStats{
 		TradePairName:      m.TradePair,
 		BaseVolume24h:      m.BaseVolume24h,
@@ -67,6 +68,6 @@ func dbMarketToJSON(m tickerdb.Market) MarketStats {
 		CounterVolume7d:    m.CounterVolume7d,
 		TradeCount7d:       m.TradeCount7d,
 		LastPrice:          m.LastPrice,
-		LastPriceCloseTime: m.LastPriceCloseTime,
+		LastPriceCloseTime: closeTime,
 	}
 }

--- a/exp/ticker/internal/actions_market.go
+++ b/exp/ticker/internal/actions_market.go
@@ -69,5 +69,7 @@ func dbMarketToJSON(m tickerdb.Market) MarketStats {
 		TradeCount7d:       m.TradeCount7d,
 		LastPrice:          m.LastPrice,
 		LastPriceCloseTime: closeTime,
+		PriceChange24h:     m.PriceChange24h,
+		PriceChange7d:      m.PriceChange7d,
 	}
 }

--- a/exp/ticker/internal/actions_market.go
+++ b/exp/ticker/internal/actions_market.go
@@ -1,0 +1,72 @@
+package ticker
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/stellar/go/exp/ticker/internal/tickerdb"
+	"github.com/stellar/go/exp/ticker/internal/utils"
+	hlog "github.com/stellar/go/support/log"
+)
+
+// GenerateMarketSummary generates a MarketSummary with the statistics for all
+// valid markets within the database and outputs it to <filename>.
+func GenerateMarketSummaryFile(s *tickerdb.TickerSession, l *hlog.Entry, filename string) error {
+	l.Infoln("Generating market data...")
+	marketSummary, err := GenerateMarketSummary(s)
+	if err != nil {
+		return err
+	}
+	l.Infoln("Market data successfully generated!")
+
+	jsonMkt, err := json.MarshalIndent(marketSummary, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	l.Infoln("Writing market data to: ", filename)
+	numBytes, err := utils.WriteJSONToFile(jsonMkt, filename)
+	if err != nil {
+		return err
+	}
+	l.Infof("Wrote %d bytes to %s\n", numBytes, filename)
+	return nil
+}
+
+// GenerateMarketSummary outputs a MarketSummary with the statistics for all
+// valid markets within the database.
+func GenerateMarketSummary(s *tickerdb.TickerSession) (ms MarketSummary, err error) {
+	var marketStatsSlice []MarketStats
+	now := time.Now()
+	nowMillis := now.UnixNano() / 1000000
+
+	dbMarkets, err := s.RetrieveMarketData()
+	if err != nil {
+		return
+	}
+
+	for _, dbMarket := range dbMarkets {
+		marketStats := dbMarketToJSON(dbMarket)
+		marketStatsSlice = append(marketStatsSlice, marketStats)
+	}
+
+	ms = MarketSummary{
+		GeneratedAt: nowMillis,
+		Pairs:       marketStatsSlice,
+	}
+	return
+}
+
+func dbMarketToJSON(m tickerdb.Market) MarketStats {
+	return MarketStats{
+		TradePairName:      m.TradePair,
+		BaseVolume24h:      m.BaseVolume24h,
+		CounterVolume24h:   m.CounterVolume24h,
+		TradeCount24h:      m.TradeCount24h,
+		BaseVolume7d:       m.BaseVolume7d,
+		CounterVolume7d:    m.CounterVolume7d,
+		TradeCount7d:       m.TradeCount7d,
+		LastPrice:          m.LastPrice,
+		LastPriceCloseTime: m.LastPriceCloseTime,
+	}
+}

--- a/exp/ticker/internal/actions_market.go
+++ b/exp/ticker/internal/actions_market.go
@@ -9,7 +9,7 @@ import (
 	hlog "github.com/stellar/go/support/log"
 )
 
-// GenerateMarketSummary generates a MarketSummary with the statistics for all
+// GenerateMarketSummaryFile generates a MarketSummary with the statistics for all
 // valid markets within the database and outputs it to <filename>.
 func GenerateMarketSummaryFile(s *tickerdb.TickerSession, l *hlog.Entry, filename string) error {
 	l.Infoln("Generating market data...")

--- a/exp/ticker/internal/main.go
+++ b/exp/ticker/internal/main.go
@@ -19,4 +19,6 @@ type MarketStats struct {
 	TradeCount7d       int64   `json:"trade_count_7d"`
 	LastPrice          float64 `json:"price"`
 	LastPriceCloseTime int64   `json:"last_price_close_time"`
+	PriceChange24h     float64 `json:"price_change_24h"`
+	PriceChange7d      float64 `json:"price_change_7d"`
 }

--- a/exp/ticker/internal/main.go
+++ b/exp/ticker/internal/main.go
@@ -1,1 +1,24 @@
 package ticker
+
+import "time"
+
+// MarketSummary represents a summary of statistics of all valid markets
+// within a given period of time.
+type MarketSummary struct {
+	GeneratedAt int64         `json:"generated_at"`
+	Pairs       []MarketStats `json:"pairs"`
+}
+
+// Market stats represents the statistics of a specific market (identified by
+// a trade pair).
+type MarketStats struct {
+	TradePairName      string    `json:"name"`
+	BaseVolume24h      float64   `json:"base_volume"`
+	CounterVolume24h   float64   `json:"counter_volume"`
+	TradeCount24h      int64     `json:"trade_count"`
+	BaseVolume7d       float64   `json:"base_volume_7d"`
+	CounterVolume7d    float64   `json:"counter_volume_7d"`
+	TradeCount7d       int64     `json:"trade_count_7d"`
+	LastPrice          float64   `json:"price"`
+	LastPriceCloseTime time.Time `json:"last_price_close_time"`
+}

--- a/exp/ticker/internal/main.go
+++ b/exp/ticker/internal/main.go
@@ -1,7 +1,5 @@
 package ticker
 
-import "time"
-
 // MarketSummary represents a summary of statistics of all valid markets
 // within a given period of time.
 type MarketSummary struct {
@@ -12,13 +10,13 @@ type MarketSummary struct {
 // Market stats represents the statistics of a specific market (identified by
 // a trade pair).
 type MarketStats struct {
-	TradePairName      string    `json:"name"`
-	BaseVolume24h      float64   `json:"base_volume"`
-	CounterVolume24h   float64   `json:"counter_volume"`
-	TradeCount24h      int64     `json:"trade_count"`
-	BaseVolume7d       float64   `json:"base_volume_7d"`
-	CounterVolume7d    float64   `json:"counter_volume_7d"`
-	TradeCount7d       int64     `json:"trade_count_7d"`
-	LastPrice          float64   `json:"price"`
-	LastPriceCloseTime time.Time `json:"last_price_close_time"`
+	TradePairName      string  `json:"name"`
+	BaseVolume24h      float64 `json:"base_volume"`
+	CounterVolume24h   float64 `json:"counter_volume"`
+	TradeCount24h      int64   `json:"trade_count"`
+	BaseVolume7d       float64 `json:"base_volume_7d"`
+	CounterVolume7d    float64 `json:"counter_volume_7d"`
+	TradeCount7d       int64   `json:"trade_count_7d"`
+	LastPrice          float64 `json:"price"`
+	LastPriceCloseTime int64   `json:"last_price_close_time"`
 }

--- a/exp/ticker/internal/tickerdb/main.go
+++ b/exp/ticker/internal/tickerdb/main.go
@@ -94,6 +94,8 @@ type Market struct {
 	TradeCount7d       int64     `db:"trade_count_7d"`
 	LastPrice          float64   `db:"last_price"`
 	LastPriceCloseTime time.Time `db:"close_time"`
+	PriceChange24h     float64   `db:"price_change_24h"`
+	PriceChange7d      float64   `db:"price_change_7d"`
 }
 
 // CreateSession returns a new TickerSession that connects to the given db settings

--- a/exp/ticker/internal/tickerdb/main.go
+++ b/exp/ticker/internal/tickerdb/main.go
@@ -82,6 +82,20 @@ type Trade struct {
 	Price           float64   `db:"price"`
 }
 
+// Market represent the aggregated market data retrieved from the database.
+// Note: this struct does *not* directly maps to a db entity.
+type Market struct {
+	TradePair          string    `db:"trade_pair_name"`
+	BaseVolume24h      float64   `db:"base_volume_24h"`
+	CounterVolume24h   float64   `db:"counter_volume_24h"`
+	TradeCount24h      int64     `db:"trade_count_24h"`
+	BaseVolume7d       float64   `db:"base_volume_7d"`
+	CounterVolume7d    float64   `db:"counter_volume_7d"`
+	TradeCount7d       int64     `db:"trade_count_7d"`
+	LastPrice          float64   `db:"last_price"`
+	LastPriceCloseTime time.Time `db:"close_time"`
+}
+
 // CreateSession returns a new TickerSession that connects to the given db settings
 func CreateSession(driverName, dataSourceName string) (session TickerSession, err error) {
 	dbconn, err := sqlx.Connect(driverName, dataSourceName)

--- a/exp/ticker/internal/tickerdb/queries_market.go
+++ b/exp/ticker/internal/tickerdb/queries_market.go
@@ -1,0 +1,73 @@
+package tickerdb
+
+func (s *TickerSession) RetrieveMarketData() (markets []Market, err error) {
+	err = s.SelectRaw(&markets, marketQuery)
+	return
+}
+
+var marketQuery = `
+SELECT
+	t2.trade_pair_name as trade_pair_name,
+	COALESCE(t1.base_volume_24h, 0.0) as base_volume_24h,
+	COALESCE(t1.counter_volume_24h, 0.0) as counter_volume_24h,
+	COALESCE(t1.trade_count_24h, 0) as trade_count_24h,
+
+	COALESCE(t2.base_volume_7d, 0) as base_volume_7d,
+	COALESCE(t2.counter_volume_7d, 0) as counter_volume_7d,
+	COALESCE(t2.trade_count_7d, 0) as trade_count_7d,
+
+	COALESCE(t3.last_price, 0.0) as last_price,
+	COALESCE(t3.last_close_time, now()) as close_time
+FROM (
+	-- All trades between valid assets in the last 24h aggregated:
+	SELECT
+		concat(bAsset.code, '_', cAsset.code) as trade_pair_name,
+		sum(t.base_amount) as base_volume_24h,
+		sum(t.counter_amount) as counter_volume_24h,
+		count(t.base_amount) as trade_count_24h
+	FROM trades as t
+		JOIN assets as bAsset
+		ON t.base_asset_id = bAsset.id
+		JOIN assets as cAsset
+		ON t.counter_asset_id = cAsset.id
+	WHERE bAsset.is_valid = TRUE
+		AND cAsset.is_valid = TRUE
+		AND t.ledger_close_time > now() - interval '1 day'
+	GROUP BY trade_pair_name
+) t1
+FULL JOIN (
+	-- All trades between valid assets in the last 7d aggregated:
+	SELECT
+		concat(bAsset.code, '_', cAsset.code) as trade_pair_name,
+		sum(t.base_amount) as base_volume_7d,
+		sum(t.counter_amount) as counter_volume_7d,
+		count(t.base_amount) as trade_count_7d
+	FROM trades as t
+		JOIN assets as bAsset
+		ON t.base_asset_id = bAsset.id
+		JOIN assets as cAsset
+		ON t.counter_asset_id = cAsset.id
+	WHERE bAsset.is_valid = TRUE
+		AND cAsset.is_valid = TRUE
+		AND t.ledger_close_time > now() - interval '7 days'
+	GROUP BY trade_pair_name
+
+) t2 ON t1.trade_pair_name = t2.trade_pair_name
+INNER JOIN (
+	-- Last prices and close times:
+	SELECT DISTINCT ON (trade_pair_name)
+		concat(bAsset.code, '_', cAsset.code) as trade_pair_name,
+		t.price as last_price,
+		t.ledger_close_time as last_close_time
+	FROM trades as t
+		JOIN assets as bAsset
+		ON t.base_asset_id = bAsset.id
+		JOIN assets as cAsset
+		ON t.counter_asset_id = cAsset.id
+	WHERE bAsset.is_valid = TRUE
+		AND cAsset.is_valid = TRUE
+		AND t.ledger_close_time > now() - interval '7 days'
+	ORDER BY trade_pair_name, t.ledger_close_time DESC
+) t3 ON t2.trade_pair_name = t3.trade_pair_name
+ORDER BY trade_pair_name;
+`

--- a/exp/ticker/internal/tickerdb/queries_market.go
+++ b/exp/ticker/internal/tickerdb/queries_market.go
@@ -17,7 +17,11 @@ SELECT
 	COALESCE(t2.trade_count_7d, 0) as trade_count_7d,
 
 	COALESCE(t3.last_price, 0.0) as last_price,
-	COALESCE(t3.last_close_time, now()) as close_time
+	COALESCE(t3.last_close_time, now()) as close_time,
+
+	COALESCE(t4.price_24h_ago - last_price, 0.0) as price_change_24h,
+	COALESCE(t5.price_7d_ago - last_price, 0.0) as price_change_7d
+
 FROM (
 	-- All trades between valid assets in the last 24h aggregated:
 	SELECT
@@ -69,5 +73,36 @@ INNER JOIN (
 		AND t.ledger_close_time > now() - interval '7 days'
 	ORDER BY trade_pair_name, t.ledger_close_time DESC
 ) t3 ON t2.trade_pair_name = t3.trade_pair_name
+LEFT JOIN (
+	-- Price 24h ago:
+	SELECT DISTINCT ON (trade_pair_name)
+		concat(bAsset.code, '_', cAsset.code) as trade_pair_name,
+		t.price as price_24h_ago
+	FROM trades as t
+		JOIN assets as bAsset
+		ON t.base_asset_id = bAsset.id
+		JOIN assets as cAsset
+		ON t.counter_asset_id = cAsset.id
+	WHERE bAsset.is_valid = TRUE
+		AND cAsset.is_valid = TRUE
+		AND t.ledger_close_time > now() - interval '1 days'
+	ORDER BY trade_pair_name, t.ledger_close_time ASC
+) t4 ON t3.trade_pair_name = t4.trade_pair_name
+LEFT JOIN (
+	-- Price 7d ago:
+	SELECT DISTINCT ON (trade_pair_name)
+		concat(bAsset.code, '_', cAsset.code) as trade_pair_name,
+		t.price as price_7d_ago
+	FROM trades as t
+		JOIN assets as bAsset
+		ON t.base_asset_id = bAsset.id
+		JOIN assets as cAsset
+		ON t.counter_asset_id = cAsset.id
+	WHERE bAsset.is_valid = TRUE
+		AND cAsset.is_valid = TRUE
+		AND t.ledger_close_time > now() - interval '7 days'
+	ORDER BY trade_pair_name, t.ledger_close_time ASC
+
+) t5 ON t4.trade_pair_name = t5.trade_pair_name
 ORDER BY trade_pair_name;
 `

--- a/exp/ticker/internal/tickerdb/queries_market_test.go
+++ b/exp/ticker/internal/tickerdb/queries_market_test.go
@@ -2,6 +2,7 @@ package tickerdb
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -188,6 +189,13 @@ func TestRetrieveMarketData(t *testing.T) {
 		xlmbtcMkt.LastPriceCloseTime.Local().Truncate(time.Millisecond),
 	)
 
+	assert.Equal(t, 0.0, xlmbtcMkt.PriceChange24h)
+	// There might be some floating point rounding issues, so this test
+	// needs to be a bit more flexible. Since the change is 0.02, an error
+	// around 0.0000000000001 is acceptable:
+	priceChange7dDiff := math.Abs(0.02 - xlmbtcMkt.PriceChange7d)
+	assert.True(t, priceChange7dDiff < 0.0000000000001)
+
 	assert.Equal(t, 74.0, xlmethMkt.BaseVolume24h)
 	assert.Equal(t, 76.0, xlmethMkt.CounterVolume24h)
 	assert.Equal(t, int64(2), xlmethMkt.TradeCount24h)
@@ -202,4 +210,15 @@ func TestRetrieveMarketData(t *testing.T) {
 		now.Local().Truncate(time.Millisecond),
 		xlmbtcMkt.LastPriceCloseTime.Local().Truncate(time.Millisecond),
 	)
+
+	// There might be some floating point rounding issues, so this test
+	// needs to be a bit more flexible. Since the change is 0.08, an error
+	// around 0.0000000000001 is acceptable:
+	priceChange24hDiff := math.Abs(-0.08 - xlmethMkt.PriceChange24h)
+	assert.True(t, priceChange24hDiff < 0.0000000000001)
+
+	priceChange7dDiff = math.Abs(-0.08 - xlmethMkt.PriceChange7d)
+	assert.True(t, priceChange7dDiff < 0.0000000000001)
+
+	assert.Equal(t, priceChange24hDiff, priceChange7dDiff)
 }

--- a/exp/ticker/internal/tickerdb/queries_market_test.go
+++ b/exp/ticker/internal/tickerdb/queries_market_test.go
@@ -1,0 +1,198 @@
+package tickerdb
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	migrate "github.com/rubenv/sql-migrate"
+	"github.com/stellar/go/support/db/dbtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetrieveMarketData(t *testing.T) {
+	db := dbtest.Postgres(t)
+	defer db.Close()
+
+	var session TickerSession
+	session.DB = db.Open()
+	defer session.DB.Close()
+
+	// Run migrations to make sure the tests are run
+	// on the most updated schema version
+	migrations := &migrate.FileMigrationSource{
+		Dir: "./migrations",
+	}
+	_, err := migrate.Exec(session.DB.DB, "postgres", migrations, migrate.Up)
+	require.NoError(t, err)
+
+	// Adding a seed issuer to be used later:
+	tbl := session.GetTable("issuers")
+	_, err = tbl.Insert(Issuer{
+		PublicKey: "GCF3TQXKZJNFJK7HCMNE2O2CUNKCJH2Y2ROISTBPLC7C5EIA5NNG2XZB",
+		Name:      "FOO BAR",
+	}).IgnoreCols("id").Exec()
+	require.NoError(t, err)
+	var issuer Issuer
+	err = session.GetRaw(&issuer, `
+		SELECT *
+		FROM issuers
+		ORDER BY id DESC
+		LIMIT 1`,
+	)
+	require.NoError(t, err)
+
+	// Adding a seed asset to be used later:
+	err = session.InsertOrUpdateAsset(&Asset{
+		Code:     "XLM",
+		IssuerID: issuer.ID,
+		IsValid:  true,
+	}, []string{"code", "issuer_id"})
+	require.NoError(t, err)
+	var xlmAsset Asset
+	err = session.GetRaw(&xlmAsset, `
+		SELECT *
+		FROM assets
+		ORDER BY id DESC
+		LIMIT 1`,
+	)
+	require.NoError(t, err)
+
+	// Adding another asset to be used later:
+	err = session.InsertOrUpdateAsset(&Asset{
+		Code:     "BTC",
+		IssuerID: issuer.ID,
+		IsValid:  true,
+	}, []string{"code", "issuer_id"})
+	require.NoError(t, err)
+	var btcAsset Asset
+	err = session.GetRaw(&btcAsset, `
+		SELECT *
+		FROM assets
+		ORDER BY id DESC
+		LIMIT 1`,
+	)
+	require.NoError(t, err)
+
+	// Adding a third asset:
+	err = session.InsertOrUpdateAsset(&Asset{
+		Code:     "ETH",
+		IssuerID: issuer.ID,
+		IsValid:  true,
+	}, []string{"code", "issuer_id"})
+	require.NoError(t, err)
+	var ethAsset Asset
+	err = session.GetRaw(&ethAsset, `
+		SELECT *
+		FROM assets
+		ORDER BY id DESC
+		LIMIT 1`,
+	)
+	require.NoError(t, err)
+
+	// Verify that we actually have three assets:
+	assert.NotEqual(t, xlmAsset.ID, btcAsset.ID)
+	assert.NotEqual(t, btcAsset.ID, ethAsset.ID)
+	assert.NotEqual(t, xlmAsset.ID, ethAsset.ID)
+
+	// A few times to be used:
+	now := time.Now()
+	oneHourAgo := now.Add(-1 * time.Hour)
+	threeDaysAgo := now.AddDate(0, 0, -3)
+	oneMonthAgo := now.AddDate(0, -1, 0)
+
+	// Now let's create the trades:
+	trades := []Trade{
+		Trade{ // XLM_BTC trade
+			HorizonID:       "hrzid1",
+			BaseAssetID:     xlmAsset.ID,
+			BaseAmount:      100.0,
+			CounterAssetID:  btcAsset.ID,
+			CounterAmount:   10.0,
+			Price:           0.1,
+			LedgerCloseTime: now,
+		},
+		Trade{ // XLM_ETH trade
+			HorizonID:       "hrzid3",
+			BaseAssetID:     xlmAsset.ID,
+			BaseAmount:      24.0,
+			CounterAssetID:  ethAsset.ID,
+			CounterAmount:   26.0,
+			Price:           0.92,
+			LedgerCloseTime: oneHourAgo,
+		},
+		Trade{ // XLM_ETH trade
+			HorizonID:       "hrzid2",
+			BaseAssetID:     xlmAsset.ID,
+			BaseAmount:      50.0,
+			CounterAssetID:  ethAsset.ID,
+			CounterAmount:   50.0,
+			Price:           1.0,
+			LedgerCloseTime: now,
+		},
+		Trade{ // XLM_BTC trade
+			HorizonID:       "hrzid4",
+			BaseAssetID:     xlmAsset.ID,
+			BaseAmount:      50.0,
+			CounterAssetID:  btcAsset.ID,
+			CounterAmount:   6.0,
+			Price:           0.12,
+			LedgerCloseTime: threeDaysAgo,
+		},
+		Trade{ // XLM_ETH trade
+			HorizonID:       "hrzid5",
+			BaseAssetID:     xlmAsset.ID,
+			BaseAmount:      24.0,
+			CounterAssetID:  ethAsset.ID,
+			CounterAmount:   28.0,
+			Price:           1.10,
+			LedgerCloseTime: oneMonthAgo,
+		},
+	}
+	err = session.BulkInsertTrades(trades)
+	require.NoError(t, err)
+
+	markets, err := session.RetrieveMarketData()
+	require.NoError(t, err)
+	fmt.Println(markets)
+	assert.Equal(t, 2, len(markets))
+
+	// Mapping the retrieved markets:
+	var xlmbtcMkt, xlmethMkt Market
+	for _, mkt := range markets {
+		if mkt.TradePair == "XLM_BTC" {
+			xlmbtcMkt = mkt
+		}
+
+		if mkt.TradePair == "XLM_ETH" {
+			xlmethMkt = mkt
+		}
+	}
+	assert.NotEqual(t, "", xlmbtcMkt.TradePair)
+	assert.NotEqual(t, "", xlmethMkt.TradePair)
+
+	// Validating the aggregated data
+	assert.Equal(t, 100.0, xlmbtcMkt.BaseVolume24h)
+	assert.Equal(t, 10.0, xlmbtcMkt.CounterVolume24h)
+
+	assert.Equal(t, 150.0, xlmbtcMkt.BaseVolume7d)
+	assert.Equal(t, 16.0, xlmbtcMkt.CounterVolume7d)
+	assert.Equal(t, 0.1, xlmbtcMkt.LastPrice)
+	assert.Equal(
+		t,
+		now.Local().Truncate(time.Millisecond),
+		xlmbtcMkt.LastPriceCloseTime.Local().Truncate(time.Millisecond),
+	)
+
+	assert.Equal(t, 74.0, xlmethMkt.BaseVolume24h)
+	assert.Equal(t, 76.0, xlmethMkt.CounterVolume24h)
+	assert.Equal(t, 74.0, xlmethMkt.BaseVolume7d)
+	assert.Equal(t, 76.0, xlmethMkt.CounterVolume7d)
+	assert.Equal(t, 1.0, xlmethMkt.LastPrice)
+	assert.Equal(
+		t,
+		now.Local().Truncate(time.Millisecond),
+		xlmbtcMkt.LastPriceCloseTime.Local().Truncate(time.Millisecond),
+	)
+}

--- a/exp/ticker/internal/tickerdb/queries_market_test.go
+++ b/exp/ticker/internal/tickerdb/queries_market_test.go
@@ -175,9 +175,12 @@ func TestRetrieveMarketData(t *testing.T) {
 	// Validating the aggregated data
 	assert.Equal(t, 100.0, xlmbtcMkt.BaseVolume24h)
 	assert.Equal(t, 10.0, xlmbtcMkt.CounterVolume24h)
+	assert.Equal(t, int64(1), xlmbtcMkt.TradeCount24h)
 
 	assert.Equal(t, 150.0, xlmbtcMkt.BaseVolume7d)
 	assert.Equal(t, 16.0, xlmbtcMkt.CounterVolume7d)
+	assert.Equal(t, int64(2), xlmbtcMkt.TradeCount7d)
+
 	assert.Equal(t, 0.1, xlmbtcMkt.LastPrice)
 	assert.Equal(
 		t,
@@ -187,8 +190,12 @@ func TestRetrieveMarketData(t *testing.T) {
 
 	assert.Equal(t, 74.0, xlmethMkt.BaseVolume24h)
 	assert.Equal(t, 76.0, xlmethMkt.CounterVolume24h)
+	assert.Equal(t, int64(2), xlmethMkt.TradeCount24h)
+
 	assert.Equal(t, 74.0, xlmethMkt.BaseVolume7d)
 	assert.Equal(t, 76.0, xlmethMkt.CounterVolume7d)
+	assert.Equal(t, int64(2), xlmethMkt.TradeCount7d)
+
 	assert.Equal(t, 1.0, xlmethMkt.LastPrice)
 	assert.Equal(
 		t,

--- a/exp/ticker/internal/utils/main.go
+++ b/exp/ticker/internal/utils/main.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 )
 
 // PanicIfError is an utility function that panics if err != nil
@@ -13,12 +12,9 @@ func PanicIfError(e error) {
 	}
 }
 
-// WriteJSONToFile wrtites a json []byte dump to .tmp/<filename>
+// WriteJSONToFile wrtites a json []byte dump to <filename>
 func WriteJSONToFile(jsonBytes []byte, filename string) (numBytes int, err error) {
-	path := filepath.Join(".", "tmp")
-	_ = os.Mkdir(path, os.ModePerm) // ignore if dir already exists
-
-	f, err := os.Create(filepath.Join(".", "tmp", filename))
+	f, err := os.Create(filename)
 	PanicIfError(err)
 	defer f.Close()
 


### PR DESCRIPTION
This PR:
- Closes #1083.

It aims to:
- Add support for calculating the following attributes from all the stored (and validated) trade pairs in a given time window (e.g. 24h, 7d):
```
- base_volume
- counter_volume
- trade_pair_name
- price (last price)
- trade_count
- volume24h
- price_change_24h
- volume_7d
- price_change_7d
```
- Provide a CLI command for outputting aggregated market data to a JSON file.


