### PR TITLE
exp/txnbuild: rename constructor functions

### DIFF
--- a/exp/txnbuild/change_trust.go
+++ b/exp/txnbuild/change_trust.go
@@ -13,9 +13,9 @@ type ChangeTrust struct {
 	Limit string
 }
 
-// NewRemoveTrustlineOp returns a ChangeTrust operation to remove the trustline of the described asset,
+// RemoveTrustlineOp returns a ChangeTrust operation to remove the trustline of the described asset,
 // by setting the limit to "0".
-func NewRemoveTrustlineOp(issuedAsset *Asset) ChangeTrust {
+func RemoveTrustlineOp(issuedAsset *Asset) ChangeTrust {
 	return ChangeTrust{
 		Line:  issuedAsset,
 		Limit: "0",

--- a/exp/txnbuild/cmd/txnbuild_examples/main.go
+++ b/exp/txnbuild/cmd/txnbuild_examples/main.go
@@ -91,7 +91,7 @@ func examplePathPayment(client *horizon.Client, mock bool) horizon.TransactionSu
 	buying1 := xlmAsset
 	sellAmount1 := "5"
 	price1 := "4"
-	offer1 := txnbuild.NewCreateOfferOp(selling1, buying1, sellAmount1, price1)
+	offer1 := txnbuild.CreateOfferOp(selling1, buying1, sellAmount1, price1)
 
 	// test1 creates an offer to buy ABCD
 	horizonSourceAccount1, err := client.LoadAccount(keys[1].Address)
@@ -102,7 +102,7 @@ func examplePathPayment(client *horizon.Client, mock bool) horizon.TransactionSu
 	buying2 := &abcdAsset
 	sellAmount2 := "10"
 	price2 := "1"
-	offer2 := txnbuild.NewCreateOfferOp(selling2, buying2, sellAmount2, price2)
+	offer2 := txnbuild.CreateOfferOp(selling2, buying2, sellAmount2, price2)
 
 	// test2 performs the path payment
 	horizonSourceAccount2, err := client.LoadAccount(keys[2].Address)
@@ -204,7 +204,7 @@ func exampleManageOfferUpdateOffer(client *horizon.Client, mock bool) horizon.Tr
 	price := "0.02"
 	offerID := uint64(2497628)
 
-	updateOffer := txnbuild.NewUpdateOfferOp(selling, &buying, sellAmount, price, offerID)
+	updateOffer := txnbuild.UpdateOfferOp(selling, &buying, sellAmount, price, offerID)
 
 	tx := txnbuild.Transaction{
 		SourceAccount: sourceAccount,
@@ -226,7 +226,7 @@ func exampleManageOfferDeleteOffer(client *horizon.Client, mock bool) horizon.Tr
 
 	offerID := uint64(4326054)
 
-	deleteOffer := txnbuild.NewDeleteOfferOp(offerID)
+	deleteOffer := txnbuild.DeleteOfferOp(offerID)
 
 	tx := txnbuild.Transaction{
 		SourceAccount: sourceAccount,
@@ -254,7 +254,7 @@ func exampleManageOfferNewOffer(client *horizon.Client, mock bool) horizon.Trans
 	sellAmount := "100"
 	price := "0.01"
 
-	createOffer := txnbuild.NewCreateOfferOp(selling, &buying, sellAmount, price)
+	createOffer := txnbuild.CreateOfferOp(selling, &buying, sellAmount, price)
 
 	tx := txnbuild.Transaction{
 		SourceAccount: sourceAccount,
@@ -324,7 +324,7 @@ func exampleChangeTrustDeleteTrustline(client *horizon.Client, mock bool) horizo
 	sourceAccount := mapAccounts(horizonSourceAccount)
 
 	issuedAsset := txnbuild.NewAsset("ABCD", keys[1].Address)
-	removeTrust := txnbuild.NewRemoveTrustlineOp(issuedAsset)
+	removeTrust := txnbuild.RemoveTrustlineOp(issuedAsset)
 
 	tx := txnbuild.Transaction{
 		SourceAccount: sourceAccount,

--- a/exp/txnbuild/manage_offer.go
+++ b/exp/txnbuild/manage_offer.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-//NewCreateOfferOp returns a ManageOffer operation to create a new offer, by
+//CreateOfferOp returns a ManageOffer operation to create a new offer, by
 // setting the OfferID to "0".
-func NewCreateOfferOp(selling, buying *Asset, amount, price string) ManageOffer {
+func CreateOfferOp(selling, buying *Asset, amount, price string) ManageOffer {
 	return ManageOffer{
 		Selling: selling,
 		Buying:  buying,
@@ -19,8 +19,8 @@ func NewCreateOfferOp(selling, buying *Asset, amount, price string) ManageOffer 
 	}
 }
 
-//NewUpdateOfferOp returns a ManageOffer operation to update an offer.
-func NewUpdateOfferOp(selling, buying *Asset, amount, price string, offerID uint64) ManageOffer {
+//UpdateOfferOp returns a ManageOffer operation to update an offer.
+func UpdateOfferOp(selling, buying *Asset, amount, price string, offerID uint64) ManageOffer {
 	return ManageOffer{
 		Selling: selling,
 		Buying:  buying,
@@ -30,9 +30,9 @@ func NewUpdateOfferOp(selling, buying *Asset, amount, price string, offerID uint
 	}
 }
 
-//NewDeleteOfferOp returns a ManageOffer operation to delete an offer, by
+//DeleteOfferOp returns a ManageOffer operation to delete an offer, by
 // setting the Amount to "0".
-func NewDeleteOfferOp(offerID uint64) ManageOffer {
+func DeleteOfferOp(offerID uint64) ManageOffer {
 	// It turns out Stellar core doesn't care about any of these fields except the amount.
 	// However, Horizon will reject ManageOffer if it is missing fields.
 	// Horizon will also reject if Buying == Selling.

--- a/exp/txnbuild/transaction_test.go
+++ b/exp/txnbuild/transaction_test.go
@@ -396,7 +396,7 @@ func TestChangeTrustDeleteTrustline(t *testing.T) {
 	sourceAccount := makeTestAccount(kp0, "40385577484354")
 
 	issuedAsset := NewAsset("ABCD", kp1.Address())
-	removeTrust := NewRemoveTrustlineOp(issuedAsset)
+	removeTrust := RemoveTrustlineOp(issuedAsset)
 
 	tx := Transaction{
 		SourceAccount: &sourceAccount,
@@ -441,7 +441,7 @@ func TestManageOfferNewOffer(t *testing.T) {
 	buying := NewAsset("ABCD", kp0.Address())
 	sellAmount := "100"
 	price := "0.01"
-	createOffer := NewCreateOfferOp(selling, buying, sellAmount, price)
+	createOffer := CreateOfferOp(selling, buying, sellAmount, price)
 
 	tx := Transaction{
 		SourceAccount: &sourceAccount,
@@ -459,7 +459,7 @@ func TestManageOfferDeleteOffer(t *testing.T) {
 	sourceAccount := makeTestAccount(kp1, "41137196761105")
 
 	offerID := uint64(2921622)
-	deleteOffer := NewDeleteOfferOp(offerID)
+	deleteOffer := DeleteOfferOp(offerID)
 
 	tx := Transaction{
 		SourceAccount: &sourceAccount,
@@ -482,7 +482,7 @@ func TestManageOfferUpdateOffer(t *testing.T) {
 	sellAmount := "50"
 	price := "0.02"
 	offerID := uint64(2497628)
-	updateOffer := NewUpdateOfferOp(selling, buying, sellAmount, price, offerID)
+	updateOffer := UpdateOfferOp(selling, buying, sellAmount, price, offerID)
 
 	tx := Transaction{
 		SourceAccount: &sourceAccount,


### PR DESCRIPTION
Quick refactoring PR to fix some unwieldy names which caused confusion for multiple reviewers.

Closes #1039.