### PR TITLE
xdr: move allow trust converter to XDR lib

### DIFF
--- a/exp/txnbuild/allow_trust.go
+++ b/exp/txnbuild/allow_trust.go
@@ -29,10 +29,11 @@ func (at *AllowTrust) BuildXDR() (xdr.Operation, error) {
 	}
 
 	// AllowTrust has a special asset type - map to it
-	xdrOp.Asset, err = at.Type.ToXDRAllowTrustOpAsset()
+	xdrAsset, err := at.Type.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Can't convert asset for trustline to XDR")
 	}
+	xdrOp.Asset, err = xdrAsset.ToAllowTrustOpAsset(at.Type.Code)
 
 	// Set XDR auth flag
 	xdrOp.Authorize = at.Authorize

--- a/exp/txnbuild/allow_trust.go
+++ b/exp/txnbuild/allow_trust.go
@@ -33,7 +33,11 @@ func (at *AllowTrust) BuildXDR() (xdr.Operation, error) {
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Can't convert asset for trustline to XDR")
 	}
+
 	xdrOp.Asset, err = xdrAsset.ToAllowTrustOpAsset(at.Type.Code)
+	if err != nil {
+		return xdr.Operation{}, errors.Wrap(err, "Can't convert asset for trustline to allow trust asset type")
+	}
 
 	// Set XDR auth flag
 	xdrOp.Authorize = at.Authorize

--- a/exp/txnbuild/asset.go
+++ b/exp/txnbuild/asset.go
@@ -57,25 +57,3 @@ func (a *Asset) ToXDR() (xdr.Asset, error) {
 
 	return xdrAsset, nil
 }
-
-// ToXDRAllowTrustOpAsset for Asset produces a corresponding XDR "allow trust" asset, used by the
-// XDR allow trust operation.
-func (a *Asset) ToXDRAllowTrustOpAsset() (xdr.AllowTrustOpAsset, error) {
-	length := len(a.Code)
-
-	// TODO: This code could be moved to XDR library as is done with xdr.Asset()
-	switch {
-	case length >= 1 && length <= 4:
-		var code [4]byte
-		byteArray := []byte(a.Code)
-		copy(code[:], byteArray[0:length])
-		return xdr.NewAllowTrustOpAsset(xdr.AssetTypeAssetTypeCreditAlphanum4, code)
-	case length >= 5 && length <= 12:
-		var code [12]byte
-		byteArray := []byte(a.Code)
-		copy(code[:], byteArray[0:length])
-		return xdr.NewAllowTrustOpAsset(xdr.AssetTypeAssetTypeCreditAlphanum12, code)
-	default:
-		return xdr.AllowTrustOpAsset{}, errors.New("Asset code length is invalid")
-	}
-}

--- a/xdr/allow_trust_op_asset.go
+++ b/xdr/allow_trust_op_asset.go
@@ -4,19 +4,18 @@ import (
 	"fmt"
 )
 
-// ToAsset converts `a` to a proper xdr.Asset
-func (a AllowTrustOpAsset) ToAsset(issuer AccountId) (ret Asset) {
+// ToAsset for AllowTrustOpAsset converts the xdr.AllowTrustOpAsset to a standard xdr.Asset.
+func (a AllowTrustOpAsset) ToAsset(issuer AccountId) (asset Asset) {
 	var err error
 
 	switch a.Type {
 	case AssetTypeAssetTypeCreditAlphanum4:
-
-		ret, err = NewAsset(AssetTypeAssetTypeCreditAlphanum4, AssetAlphaNum4{
+		asset, err = NewAsset(AssetTypeAssetTypeCreditAlphanum4, AssetAlphaNum4{
 			AssetCode: a.MustAssetCode4(),
 			Issuer:    issuer,
 		})
 	case AssetTypeAssetTypeCreditAlphanum12:
-		ret, err = NewAsset(AssetTypeAssetTypeCreditAlphanum12, AssetAlphaNum12{
+		asset, err = NewAsset(AssetTypeAssetTypeCreditAlphanum12, AssetAlphaNum12{
 			AssetCode: a.MustAssetCode12(),
 			Issuer:    issuer,
 		})

--- a/xdr/asset.go
+++ b/xdr/asset.go
@@ -10,6 +10,7 @@ import (
 
 // This file contains helpers for working with xdr.Asset structs
 
+// MustNewNativeAsset returns a new native asset, panicking if it can't.
 func MustNewNativeAsset() Asset {
 	a := Asset{}
 	err := a.SetNative()
@@ -19,6 +20,7 @@ func MustNewNativeAsset() Asset {
 	return a
 }
 
+// MustNewCreditAsset returns a new general asset, panicking if it can't.
 func MustNewCreditAsset(code string, issuer string) Asset {
 	a := Asset{}
 	accountID := AccountId{}
@@ -69,6 +71,27 @@ func (a *Asset) SetNative() error {
 	}
 	*a = newa
 	return nil
+}
+
+// ToAllowTrustOpAsset for Asset converts the Asset to a corresponding XDR
+// "allow trust" asset, used by the XDR allow trust operation.
+func (a *Asset) ToAllowTrustOpAsset(code string) (AllowTrustOpAsset, error) {
+	length := len(code)
+
+	switch {
+	case length >= 1 && length <= 4:
+		var bytecode [4]byte
+		byteArray := []byte(code)
+		copy(bytecode[:], byteArray[0:length])
+		return NewAllowTrustOpAsset(AssetTypeAssetTypeCreditAlphanum4, bytecode)
+	case length >= 5 && length <= 12:
+		var bytecode [12]byte
+		byteArray := []byte(code)
+		copy(bytecode[:], byteArray[0:length])
+		return NewAllowTrustOpAsset(AssetTypeAssetTypeCreditAlphanum12, bytecode)
+	default:
+		return AllowTrustOpAsset{}, errors.New("Asset code length is invalid")
+	}
 }
 
 // String returns a display friendly form of the asset

--- a/xdr/asset_test.go
+++ b/xdr/asset_test.go
@@ -198,3 +198,33 @@ func TestAssetSetCredit(t *testing.T) {
 	assert.Equal(t, issuer, a.AlphaNum12.Issuer)
 	assert.Equal(t, [12]byte{'U', 'S', 'D', 'U', 'S', 'D', 0, 0, 0, 0, 0, 0}, a.AlphaNum12.AssetCode)
 }
+
+func TestToAllowTrustOpAsset_AlphaNum4(t *testing.T) {
+	a := &Asset{}
+	at, err := a.ToAllowTrustOpAsset("ABCD")
+	if assert.NoError(t, err) {
+		code, ok := at.GetAssetCode4()
+		assert.True(t, ok)
+		var expected [4]byte
+		copy(expected[:], "ABCD")
+		assert.Equal(t, expected, code)
+	}
+}
+
+func TestToAllowTrustOpAsset_AlphaNum12(t *testing.T) {
+	a := &Asset{}
+	at, err := a.ToAllowTrustOpAsset("ABCDEFGHIJKL")
+	if assert.NoError(t, err) {
+		code, ok := at.GetAssetCode12()
+		assert.True(t, ok)
+		var expected [12]byte
+		copy(expected[:], "ABCDEFGHIJKL")
+		assert.Equal(t, expected, code)
+	}
+}
+
+func TestToAllowTrustOpAsset_Error(t *testing.T) {
+	a := &Asset{}
+	_, err := a.ToAllowTrustOpAsset("")
+	assert.EqualError(t, err, "Asset code length is invalid")
+}


### PR DESCRIPTION
Move allow trust asset helper func from `txnbuild` to the XDR library, where similar things already exist. Closes #1013.