### PR TITLE
exp/ticker: create CLI command to output asset data to a file

### DIFF
--- a/exp/ticker/internal/actions_asset.go
+++ b/exp/ticker/internal/actions_asset.go
@@ -2,9 +2,8 @@ package ticker
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"strings"
+	"time"
 
 	horizonclient "github.com/stellar/go/exp/clients/horizon"
 	"github.com/stellar/go/exp/ticker/internal/scraper"
@@ -23,15 +22,6 @@ func RefreshAssets(s *tickerdb.TickerSession, c *horizonclient.Client, l *hlog.E
 	if err != nil {
 		return
 	}
-
-	// TODO: move this to a separate function:
-	filename := "assets.json"
-	numBytes, err := writeAssetsToFile(finalAssetList, filename)
-	if err != nil {
-		l.Error("Could not write assets to file.")
-	}
-	l.Infof("Wrote %d bytes to %s\n", numBytes, filename)
-	// TODO END
 
 	for _, finalAsset := range finalAssetList {
 		dbIssuer := tomlIssuerToDBIssuer(finalAsset.IssuerDetails)
@@ -54,18 +44,40 @@ func RefreshAssets(s *tickerdb.TickerSession, c *horizonclient.Client, l *hlog.E
 	return
 }
 
-// writeAssetsToFile creates a list of assets exported in a JSON file.
-func writeAssetsToFile(assets []scraper.FinalAsset, filename string) (numBytes int, err error) {
-	jsonAssets, err := json.MarshalIndent(assets, "", "\t")
+// GenerateAssetsFile generates a file with the info about all valid scraped Assets
+func GenerateAssetsFile(s *tickerdb.TickerSession, l *hlog.Entry, filename string) error {
+	l.Infoln("Retrieving asset data from db...")
+	var finalAssets []scraper.FinalAsset
+	validAssets, err := s.GetAllValidAssets()
+	if err != nil {
+		return err
+	}
+
+	for _, dbAsset := range validAssets {
+		finalAsset := dbAssetToFinalAsset(dbAsset)
+		finalAssets = append(finalAssets, finalAsset)
+	}
+	l.Infoln("Asset data successfully retrieved! Writing to: ", filename)
+	assetSummary := AssetSummary{
+		GeneratedAt: time.Now().UnixNano() / 1000000,
+		Assets:      finalAssets,
+	}
+	numBytes, err := writeAssetSummaryToFile(assetSummary, filename)
+	if err != nil {
+		return err
+	}
+	l.Infof("Wrote %d bytes to %s\n", numBytes, filename)
+	return nil
+}
+
+// writeAssetSummaryToFile creates a list of assets exported in a JSON file.
+func writeAssetSummaryToFile(assetSummary AssetSummary, filename string) (numBytes int, err error) {
+	jsonAssets, err := json.MarshalIndent(assetSummary, "", "\t")
 	if err != nil {
 		return
 	}
 
-	dirPath := filepath.Join(".", "tmp")
-	_ = os.Mkdir(dirPath, os.ModePerm) // ignore if dir already exists
-	path := filepath.Join(".", "tmp", filename)
-
-	numBytes, err = utils.WriteJSONToFile(jsonAssets, path)
+	numBytes, err = utils.WriteJSONToFile(jsonAssets, filename)
 	if err != nil {
 		return
 	}
@@ -101,6 +113,39 @@ func finalAssetToDBAsset(asset scraper.FinalAsset, issuerID int32) tickerdb.Asse
 		RedemptionInstructions:      asset.RedemptionInstructions,
 		CollateralAddresses:         strings.Join(asset.CollateralAddresses, ","),
 		CollateralAddressSignatures: strings.Join(asset.CollateralAddressSignatures, ","),
+		Countries:                   asset.Countries,
+		Status:                      asset.Status,
+	}
+}
+
+// finalAssetToDBAsset converts a tickerdb.Asset to a scraper.TOMLAsset.
+func dbAssetToFinalAsset(asset tickerdb.Asset) scraper.FinalAsset {
+	return scraper.FinalAsset{
+		Code:                        asset.Code,
+		Issuer:                      asset.IssuerAccount,
+		Type:                        asset.Type,
+		NumAccounts:                 asset.NumAccounts,
+		AuthRequired:                asset.AuthRequired,
+		AuthRevocable:               asset.AuthRevocable,
+		Amount:                      asset.Amount,
+		AssetControlledByDomain:     asset.AssetControlledByDomain,
+		AnchorAsset:                 asset.AnchorAssetCode,
+		AnchorAssetType:             asset.AnchorAssetType,
+		IsValid:                     asset.IsValid,
+		Error:                       asset.ValidationError,
+		LastValid:                   asset.LastValid,
+		LastChecked:                 asset.LastChecked,
+		DisplayDecimals:             asset.DisplayDecimals,
+		Name:                        asset.Name,
+		Desc:                        asset.Desc,
+		Conditions:                  asset.Conditions,
+		IsAssetAnchored:             asset.IsAssetAnchored,
+		FixedNumber:                 asset.FixedNumber,
+		MaxNumber:                   asset.MaxNumber,
+		IsUnlimited:                 asset.IsUnlimited,
+		RedemptionInstructions:      asset.RedemptionInstructions,
+		CollateralAddresses:         strings.Split(asset.CollateralAddresses, ","),
+		CollateralAddressSignatures: strings.Split(asset.CollateralAddressSignatures, ","),
 		Countries:                   asset.Countries,
 		Status:                      asset.Status,
 	}

--- a/exp/ticker/internal/actions_asset.go
+++ b/exp/ticker/internal/actions_asset.go
@@ -47,20 +47,20 @@ func RefreshAssets(s *tickerdb.TickerSession, c *horizonclient.Client, l *hlog.E
 // GenerateAssetsFile generates a file with the info about all valid scraped Assets
 func GenerateAssetsFile(s *tickerdb.TickerSession, l *hlog.Entry, filename string) error {
 	l.Infoln("Retrieving asset data from db...")
-	var finalAssets []scraper.FinalAsset
+	var assets []Asset
 	validAssets, err := s.GetAllValidAssets()
 	if err != nil {
 		return err
 	}
 
 	for _, dbAsset := range validAssets {
-		finalAsset := dbAssetToFinalAsset(dbAsset)
-		finalAssets = append(finalAssets, finalAsset)
+		asset := dbAssetToAsset(dbAsset)
+		assets = append(assets, asset)
 	}
 	l.Infoln("Asset data successfully retrieved! Writing to: ", filename)
 	assetSummary := AssetSummary{
 		GeneratedAt: time.Now().UnixNano() / 1000000,
-		Assets:      finalAssets,
+		Assets:      assets,
 	}
 	numBytes, err := writeAssetSummaryToFile(assetSummary, filename)
 	if err != nil {
@@ -118,35 +118,42 @@ func finalAssetToDBAsset(asset scraper.FinalAsset, issuerID int32) tickerdb.Asse
 	}
 }
 
-// finalAssetToDBAsset converts a tickerdb.Asset to a scraper.TOMLAsset.
-func dbAssetToFinalAsset(asset tickerdb.Asset) scraper.FinalAsset {
-	return scraper.FinalAsset{
-		Code:                        asset.Code,
-		Issuer:                      asset.IssuerAccount,
-		Type:                        asset.Type,
-		NumAccounts:                 asset.NumAccounts,
-		AuthRequired:                asset.AuthRequired,
-		AuthRevocable:               asset.AuthRevocable,
-		Amount:                      asset.Amount,
-		AssetControlledByDomain:     asset.AssetControlledByDomain,
-		AnchorAsset:                 asset.AnchorAssetCode,
-		AnchorAssetType:             asset.AnchorAssetType,
-		IsValid:                     asset.IsValid,
-		Error:                       asset.ValidationError,
-		LastValid:                   asset.LastValid,
-		LastChecked:                 asset.LastChecked,
-		DisplayDecimals:             asset.DisplayDecimals,
-		Name:                        asset.Name,
-		Desc:                        asset.Desc,
-		Conditions:                  asset.Conditions,
-		IsAssetAnchored:             asset.IsAssetAnchored,
-		FixedNumber:                 asset.FixedNumber,
-		MaxNumber:                   asset.MaxNumber,
-		IsUnlimited:                 asset.IsUnlimited,
-		RedemptionInstructions:      asset.RedemptionInstructions,
-		CollateralAddresses:         strings.Split(asset.CollateralAddresses, ","),
-		CollateralAddressSignatures: strings.Split(asset.CollateralAddressSignatures, ","),
-		Countries:                   asset.Countries,
-		Status:                      asset.Status,
+// dbAssetToAsset converts a tickerdb.Asset to an Asset.
+func dbAssetToAsset(dbAsset tickerdb.Asset) (a Asset) {
+	collAddrs := strings.Split(dbAsset.CollateralAddresses, ",")
+	if len(collAddrs) == 1 && collAddrs[0] == "" {
+		collAddrs = []string{}
 	}
+
+	collAddrSigns := strings.Split(dbAsset.CollateralAddressSignatures, ",")
+	if len(collAddrSigns) == 1 && collAddrSigns[0] == "" {
+		collAddrSigns = []string{}
+	}
+
+	a.Code = dbAsset.Code
+	a.Issuer = dbAsset.IssuerAccount
+	a.Type = dbAsset.Type
+	a.NumAccounts = dbAsset.NumAccounts
+	a.AuthRequired = dbAsset.AuthRequired
+	a.AuthRevocable = dbAsset.AuthRevocable
+	a.Amount = dbAsset.Amount
+	a.AssetControlledByDomain = dbAsset.AssetControlledByDomain
+	a.AnchorAsset = dbAsset.AnchorAssetCode
+	a.AnchorAssetType = dbAsset.AnchorAssetType
+	a.LastValidTimestamp = dbAsset.LastValid.UnixNano() / 1000000
+	a.DisplayDecimals = dbAsset.DisplayDecimals
+	a.Name = dbAsset.Name
+	a.Desc = dbAsset.Desc
+	a.Conditions = dbAsset.Conditions
+	a.IsAssetAnchored = dbAsset.IsAssetAnchored
+	a.FixedNumber = dbAsset.FixedNumber
+	a.MaxNumber = dbAsset.MaxNumber
+	a.IsUnlimited = dbAsset.IsUnlimited
+	a.RedemptionInstructions = dbAsset.RedemptionInstructions
+	a.CollateralAddresses = collAddrs
+	a.CollateralAddressSignatures = collAddrSigns
+	a.Countries = dbAsset.Countries
+	a.Status = dbAsset.Status
+
+	return
 }

--- a/exp/ticker/internal/actions_asset.go
+++ b/exp/ticker/internal/actions_asset.go
@@ -59,7 +59,7 @@ func GenerateAssetsFile(s *tickerdb.TickerSession, l *hlog.Entry, filename strin
 	}
 	l.Infoln("Asset data successfully retrieved! Writing to: ", filename)
 	assetSummary := AssetSummary{
-		GeneratedAt: time.Now().UnixNano() / 1000000,
+		GeneratedAt: utils.TimeToUnixEpoch(time.Now()),
 		Assets:      assets,
 	}
 	numBytes, err := writeAssetSummaryToFile(assetSummary, filename)
@@ -140,7 +140,7 @@ func dbAssetToAsset(dbAsset tickerdb.Asset) (a Asset) {
 	a.AssetControlledByDomain = dbAsset.AssetControlledByDomain
 	a.AnchorAsset = dbAsset.AnchorAssetCode
 	a.AnchorAssetType = dbAsset.AnchorAssetType
-	a.LastValidTimestamp = dbAsset.LastValid.UnixNano() / 1000000
+	a.LastValidTimestamp = utils.TimeToUnixEpoch(dbAsset.LastValid)
 	a.DisplayDecimals = dbAsset.DisplayDecimals
 	a.Name = dbAsset.Name
 	a.Desc = dbAsset.Desc

--- a/exp/ticker/internal/actions_market.go
+++ b/exp/ticker/internal/actions_market.go
@@ -38,7 +38,7 @@ func GenerateMarketSummaryFile(s *tickerdb.TickerSession, l *hlog.Entry, filenam
 func GenerateMarketSummary(s *tickerdb.TickerSession) (ms MarketSummary, err error) {
 	var marketStatsSlice []MarketStats
 	now := time.Now()
-	nowMillis := now.UnixNano() / 1000000
+	nowMillis := utils.TimeToUnixEpoch(now)
 
 	dbMarkets, err := s.RetrieveMarketData()
 	if err != nil {
@@ -58,7 +58,7 @@ func GenerateMarketSummary(s *tickerdb.TickerSession) (ms MarketSummary, err err
 }
 
 func dbMarketToJSON(m tickerdb.Market) MarketStats {
-	closeTime := m.LastPriceCloseTime.UnixNano() / 1000000
+	closeTime := utils.TimeToUnixEpoch(m.LastPriceCloseTime)
 	return MarketStats{
 		TradePairName:      m.TradePair,
 		BaseVolume24h:      m.BaseVolume24h,

--- a/exp/ticker/internal/main.go
+++ b/exp/ticker/internal/main.go
@@ -29,6 +29,13 @@ type MarketStats struct {
 
 // Asset Sumary represents the collection of valid assets.
 type AssetSummary struct {
-	GeneratedAt int64                `json:"generated_at"`
-	Assets      []scraper.FinalAsset `json:"assets"`
+	GeneratedAt int64   `json:"generated_at"`
+	Assets      []Asset `json:"assets"`
+}
+
+// Asset represent the aggregated data for a given asset.
+type Asset struct {
+	scraper.FinalAsset
+
+	LastValidTimestamp int64 `json:"last_valid"`
 }

--- a/exp/ticker/internal/main.go
+++ b/exp/ticker/internal/main.go
@@ -1,5 +1,9 @@
 package ticker
 
+import (
+	"github.com/stellar/go/exp/ticker/internal/scraper"
+)
+
 // MarketSummary represents a summary of statistics of all valid markets
 // within a given period of time.
 type MarketSummary struct {
@@ -21,4 +25,10 @@ type MarketStats struct {
 	LastPriceCloseTime int64   `json:"last_price_close_time"`
 	PriceChange24h     float64 `json:"price_change_24h"`
 	PriceChange7d      float64 `json:"price_change_7d"`
+}
+
+// Asset Sumary represents the collection of valid assets.
+type AssetSummary struct {
+	GeneratedAt int64                `json:"generated_at"`
+	Assets      []scraper.FinalAsset `json:"assets"`
 }

--- a/exp/ticker/internal/scraper/main.go
+++ b/exp/ticker/internal/scraper/main.go
@@ -69,12 +69,12 @@ type FinalAsset struct {
 	Amount                      float64    `json:"amount"`
 	IssuerDetails               TOMLIssuer `json:"-"`
 	AssetControlledByDomain     bool       `json:"asset_controlled_by_domain"`
-	Error                       string     `json:"error"`
+	Error                       string     `json:"-"`
 	AnchorAsset                 string     `json:"anchor_asset"`
 	AnchorAssetType             string     `json:"anchor_asset_type"`
-	IsValid                     bool       `json:"is_valid"`
-	LastValid                   time.Time  `json:"last_valid"`
-	LastChecked                 time.Time  `json:"last_checked"`
+	IsValid                     bool       `json:"-"`
+	LastValid                   time.Time  `json:"-"`
+	LastChecked                 time.Time  `json:"-"`
 	IsTrash                     bool       `json:"-"`
 	DisplayDecimals             int        `json:"display_decimals"`
 	Name                        string     `json:"name"`

--- a/exp/ticker/internal/tickerdb/queries_asset.go
+++ b/exp/ticker/internal/tickerdb/queries_asset.go
@@ -55,3 +55,16 @@ func (s *TickerSession) GetAssetByCodeAndIssuerAccount(
 	}
 	return
 }
+
+// GetAllValidAssets returns a slice with all assets in the database
+// with is_valid = true
+func (s *TickerSession) GetAllValidAssets() (assets []Asset, err error) {
+	tbl := s.GetTable("assets")
+
+	err = tbl.Select(
+		&assets,
+		"assets.is_valid = TRUE",
+	).Exec()
+
+	return
+}

--- a/exp/ticker/internal/utils/main.go
+++ b/exp/ticker/internal/utils/main.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"time"
 )
 
 // PanicIfError is an utility function that panics if err != nil
@@ -51,4 +52,9 @@ func GetAssetString(assetType string, code string, issuer string) string {
 		return "native"
 	}
 	return fmt.Sprintf("%s:%s", code, issuer)
+}
+
+// TimeToTimestamp converts a time.Time into a Unix epoch
+func TimeToUnixEpoch(t time.Time) int64 {
+	return t.UnixNano() / 1000000
 }


### PR DESCRIPTION
This PR:
- Closes #1085.

It aims to:
- Provide a CLI command for retrieving the asset data from the database and dumping it to a JSON file.