### PR TITLE
txnbuild: move asset from pointer to interface

### DIFF
--- a/exp/txnbuild/allow_trust.go
+++ b/exp/txnbuild/allow_trust.go
@@ -9,7 +9,7 @@ import (
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type AllowTrust struct {
 	Trustor   string
-	Type      *Asset
+	Type      Asset
 	Authorize bool
 }
 
@@ -34,7 +34,7 @@ func (at *AllowTrust) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "Can't convert asset for trustline to XDR")
 	}
 
-	xdrOp.Asset, err = xdrAsset.ToAllowTrustOpAsset(at.Type.Code)
+	xdrOp.Asset, err = xdrAsset.ToAllowTrustOpAsset(at.Type.GetCode())
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "Can't convert asset for trustline to allow trust asset type")
 	}

--- a/exp/txnbuild/asset.go
+++ b/exp/txnbuild/asset.go
@@ -5,52 +5,95 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-// Asset represents assets on the Stellar network.
-type Asset struct {
+// AssetType represents the type of a Stellar asset.
+type AssetType xdr.AssetType
+
+// AssetTypeNative, AssetTypeCreditAlphanum4, AssetTypeCreditAlphanum12 enumerate the different
+// types of asset on the Stellar network.
+const (
+	AssetTypeNative           AssetType = AssetType(xdr.AssetTypeAssetTypeNative)
+	AssetTypeCreditAlphanum4  AssetType = AssetType(xdr.AssetTypeAssetTypeCreditAlphanum4)
+	AssetTypeCreditAlphanum12 AssetType = AssetType(xdr.AssetTypeAssetTypeCreditAlphanum12)
+)
+
+// Asset represents a Stellar asset.
+type Asset interface {
+	GetType() (AssetType, error)
+	IsNative() bool
+	GetCode() string
+	GetIssuer() string
+	ToXDR() (xdr.Asset, error)
+}
+
+// NativeAsset represents the native XLM asset.
+type NativeAsset struct{}
+
+// GetType for NativeAsset returns the enum type of the asset.
+func (na NativeAsset) GetType() (AssetType, error) {
+	return AssetTypeNative, nil
+}
+
+// IsNative for NativeAsset returns true (this is an XLM asset).
+func (na NativeAsset) IsNative() bool {
+	return true
+}
+
+// GetCode for NativeAsset returns an empty string (XLM doesn't have a code).
+func (na NativeAsset) GetCode() string { return "" }
+
+// GetIssuer for NativeAsset returns an empty string (XLM doesn't have an issuer).
+func (na NativeAsset) GetIssuer() string { return "" }
+
+// ToXDR for NativeAsset produces a corresponding XDR asset.
+func (na NativeAsset) ToXDR() (xdr.Asset, error) {
+	xdrAsset := xdr.Asset{}
+	err := xdrAsset.SetNative()
+	if err != nil {
+		return xdr.Asset{}, err
+	}
+	return xdrAsset, nil
+}
+
+// CreditAsset represents non-XLM assets on the Stellar network.
+type CreditAsset struct {
 	Code   string
 	Issuer string
 }
 
-// NewNativeAsset is syntactic sugar that makes instantiating an XLM *Asset more convenient.
-func NewNativeAsset() *Asset {
-	a := Asset{}
-	return &a
-}
-
-// NewAsset is syntactic sugar that makes instantiating *Asset more convenient.
-func NewAsset(code, issuer string) *Asset {
-	a := Asset{
-		Code:   code,
-		Issuer: issuer,
+// GetType for CreditAsset returns the enum type of the asset, based on its code length.
+func (ca CreditAsset) GetType() (AssetType, error) {
+	switch {
+	case len(ca.Code) >= 1 && len(ca.Code) <= 4:
+		return AssetTypeCreditAlphanum4, nil
+	case len(ca.Code) >= 5 && len(ca.Code) <= 12:
+		return AssetTypeCreditAlphanum12, nil
+	default:
+		return AssetTypeCreditAlphanum4, errors.New("Invalid asset code")
 	}
-	return &a
 }
 
-// IsNative for Asset returns true if this is an XLM asset.
-func (a *Asset) IsNative() bool {
-	// Native (Lumens) has no code or issuer
-	return a.Code == "" && a.Issuer == ""
+// IsNative for CreditAsset returns false (this is not an XLM asset).
+func (ca CreditAsset) IsNative() bool {
+	return false
 }
 
-// ToXDR for Asset produces a corresponding XDR asset.
-func (a *Asset) ToXDR() (xdr.Asset, error) {
+// GetCode for CreditAsset returns the asset code.
+func (ca CreditAsset) GetCode() string { return ca.Code }
+
+// GetIssuer for CreditAsset returns the address of the issuing account.
+func (ca CreditAsset) GetIssuer() string { return ca.Issuer }
+
+// ToXDR for CreditAsset produces a corresponding XDR asset.
+func (ca CreditAsset) ToXDR() (xdr.Asset, error) {
 	xdrAsset := xdr.Asset{}
-	var err error
-	if a.IsNative() {
-		err = xdrAsset.SetNative()
-		if err != nil {
-			return xdr.Asset{}, err
-		}
-		return xdrAsset, nil
-	}
-
 	var issuer xdr.AccountId
-	err = issuer.SetAddress(a.Issuer)
+
+	err := issuer.SetAddress(ca.Issuer)
 	if err != nil {
 		return xdr.Asset{}, err
 	}
 
-	err = xdrAsset.SetCredit(a.Code, issuer)
+	err = xdrAsset.SetCredit(ca.Code, issuer)
 	if err != nil {
 		return xdr.Asset{}, errors.Wrap(err, "Asset code length must be between 1 and 12 characters")
 	}

--- a/exp/txnbuild/asset.go
+++ b/exp/txnbuild/asset.go
@@ -34,9 +34,7 @@ func (na NativeAsset) GetType() (AssetType, error) {
 }
 
 // IsNative for NativeAsset returns true (this is an XLM asset).
-func (na NativeAsset) IsNative() bool {
-	return true
-}
+func (na NativeAsset) IsNative() bool { return true }
 
 // GetCode for NativeAsset returns an empty string (XLM doesn't have a code).
 func (na NativeAsset) GetCode() string { return "" }
@@ -73,9 +71,7 @@ func (ca CreditAsset) GetType() (AssetType, error) {
 }
 
 // IsNative for CreditAsset returns false (this is not an XLM asset).
-func (ca CreditAsset) IsNative() bool {
-	return false
-}
+func (ca CreditAsset) IsNative() bool { return false }
 
 // GetCode for CreditAsset returns the asset code.
 func (ca CreditAsset) GetCode() string { return ca.Code }

--- a/exp/txnbuild/asset_test.go
+++ b/exp/txnbuild/asset_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNativeAssetToXDR(t *testing.T) {
-	asset := Asset{}
+	asset := NativeAsset{}
 
 	received, err := asset.ToXDR()
 	assert.Nil(t, err)
@@ -20,7 +20,7 @@ func TestNativeAssetToXDR(t *testing.T) {
 }
 
 func TestAlphaNum4AssetToXDR(t *testing.T) {
-	asset := Asset{
+	asset := CreditAsset{
 		Code:   "USD",
 		Issuer: newKeypair0().Address(),
 	}
@@ -41,7 +41,7 @@ func TestAlphaNum4AssetToXDR(t *testing.T) {
 }
 
 func TestAlphaNum12AssetToXDR(t *testing.T) {
-	asset := Asset{
+	asset := CreditAsset{
 		Code:   "MEGAUSD",
 		Issuer: newKeypair0().Address(),
 	}
@@ -62,7 +62,7 @@ func TestAlphaNum12AssetToXDR(t *testing.T) {
 }
 
 func TestCodeTooShort(t *testing.T) {
-	asset := Asset{
+	asset := CreditAsset{
 		Code:   "",
 		Issuer: newKeypair0().Address(),
 	}
@@ -77,7 +77,7 @@ func TestCodeTooShort(t *testing.T) {
 }
 
 func TestCodeTooLong(t *testing.T) {
-	asset := Asset{
+	asset := CreditAsset{
 		Code:   "THIRTEENCHARS",
 		Issuer: newKeypair0().Address(),
 	}
@@ -92,7 +92,7 @@ func TestCodeTooLong(t *testing.T) {
 }
 
 func TestBadIssuer(t *testing.T) {
-	asset := Asset{
+	asset := CreditAsset{
 		Code:   "USD",
 		Issuer: "DOESNTLOOKLIKEANADDRESS",
 	}

--- a/exp/txnbuild/change_trust.go
+++ b/exp/txnbuild/change_trust.go
@@ -9,13 +9,13 @@ import (
 // ChangeTrust represents the Stellar change trust operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type ChangeTrust struct {
-	Line  *Asset
+	Line  Asset
 	Limit string
 }
 
 // RemoveTrustlineOp returns a ChangeTrust operation to remove the trustline of the described asset,
 // by setting the limit to "0".
-func RemoveTrustlineOp(issuedAsset *Asset) ChangeTrust {
+func RemoveTrustlineOp(issuedAsset Asset) ChangeTrust {
 	return ChangeTrust{
 		Line:  issuedAsset,
 		Limit: "0",

--- a/exp/txnbuild/cmd/txnbuild_examples/main.go
+++ b/exp/txnbuild/cmd/txnbuild_examples/main.go
@@ -76,11 +76,11 @@ func examplePathPayment(client *horizon.Client, mock bool) horizon.TransactionSu
 	// test1 - has a trustline for ABCD
 	// test2 - doesn't need a trustline for ABCD
 	keys := initKeys()
-	abcdAsset := txnbuild.Asset{
+	abcdAsset := txnbuild.CreditAsset{
 		Code:   "ABCD",
 		Issuer: keys[0].Address,
 	}
-	xlmAsset := txnbuild.NewNativeAsset()
+	xlmAsset := txnbuild.NativeAsset{}
 
 	// test0 creates an offer to sell ABCD
 	horizonSourceAccount0, err := client.LoadAccount(keys[0].Address)
@@ -163,8 +163,8 @@ func exampleCreatePassiveOffer(client *horizon.Client, mock bool) horizon.Transa
 	dieIfError("loadaccount", err)
 	sourceAccount := mapAccounts(horizonSourceAccount)
 
-	selling := txnbuild.NewNativeAsset()
-	buying := txnbuild.Asset{
+	selling := txnbuild.NativeAsset{}
+	buying := txnbuild.CreditAsset{
 		Code:   "ABCD",
 		Issuer: keys[0].Address,
 	}
@@ -195,8 +195,8 @@ func exampleManageOfferUpdateOffer(client *horizon.Client, mock bool) horizon.Tr
 	dieIfError("loadaccount", err)
 	sourceAccount := mapAccounts(horizonSourceAccount)
 
-	selling := txnbuild.NewNativeAsset()
-	buying := txnbuild.Asset{
+	selling := txnbuild.NativeAsset{}
+	buying := txnbuild.CreditAsset{
 		Code:   "ABCD",
 		Issuer: keys[0].Address,
 	}
@@ -246,8 +246,8 @@ func exampleManageOfferNewOffer(client *horizon.Client, mock bool) horizon.Trans
 	dieIfError("loadaccount", err)
 	sourceAccount := mapAccounts(horizonSourceAccount)
 
-	selling := txnbuild.NewNativeAsset()
-	buying := txnbuild.Asset{
+	selling := txnbuild.NativeAsset{}
+	buying := txnbuild.CreditAsset{
 		Code:   "ABCD",
 		Issuer: keys[0].Address,
 	}
@@ -274,7 +274,10 @@ func exampleAllowTrust(client *horizon.Client, mock bool) horizon.TransactionSuc
 	dieIfError("loadaccount", err)
 	sourceAccount := mapAccounts(horizonSourceAccount)
 
-	issued := txnbuild.NewAsset("ABCD", keys[0].Address)
+	issued := txnbuild.CreditAsset{
+		Code:   "ABCD",
+		Issuer: keys[0].Address,
+	}
 	allowTrust := txnbuild.AllowTrust{
 		Trustor:   keys[1].Address,
 		Type:      issued,
@@ -299,7 +302,10 @@ func exampleChangeTrust(client *horizon.Client, mock bool) horizon.TransactionSu
 	dieIfError("loadaccount", err)
 	sourceAccount := mapAccounts(horizonSourceAccount)
 
-	issuer := txnbuild.NewAsset("ABCD", keys[0].Address)
+	issuer := txnbuild.CreditAsset{
+		Code:   "ABCD",
+		Issuer: keys[0].Address,
+	}
 	changeTrust := txnbuild.ChangeTrust{
 		Line:  issuer,
 		Limit: "1000",
@@ -323,7 +329,10 @@ func exampleChangeTrustDeleteTrustline(client *horizon.Client, mock bool) horizo
 	dieIfError("loadaccount", err)
 	sourceAccount := mapAccounts(horizonSourceAccount)
 
-	issuedAsset := txnbuild.NewAsset("ABCD", keys[1].Address)
+	issuedAsset := txnbuild.CreditAsset{
+		Code:   "ABCD",
+		Issuer: keys[1].Address,
+	}
 	removeTrust := txnbuild.RemoveTrustlineOp(issuedAsset)
 
 	tx := txnbuild.Transaction{
@@ -473,7 +482,10 @@ func exampleSendNonNative(client *horizon.Client, mock bool) horizon.Transaction
 	payment := txnbuild.Payment{
 		Destination: keys[1].Address,
 		Amount:      "100",
-		Asset:       txnbuild.NewAsset("ABCD", keys[0].Address),
+		Asset: txnbuild.CreditAsset{
+			Code:   "ABCD",
+			Issuer: keys[0].Address,
+		},
 	}
 
 	tx := txnbuild.Transaction{

--- a/exp/txnbuild/cmd/txnbuild_examples/main.go
+++ b/exp/txnbuild/cmd/txnbuild_examples/main.go
@@ -533,7 +533,6 @@ func exampleCreateAccount(client *horizon.Client, mock bool) horizon.Transaction
 	createAccount := txnbuild.CreateAccount{
 		Destination: "GAS4V4O2B7DW5T7IQRPEEVCRXMDZESKISR7DVIGKZQYYV3OSQ5SH5LVP",
 		Amount:      "10",
-		Asset:       "native",
 	}
 
 	tx := txnbuild.Transaction{

--- a/exp/txnbuild/create_account.go
+++ b/exp/txnbuild/create_account.go
@@ -11,7 +11,6 @@ import (
 type CreateAccount struct {
 	Destination string
 	Amount      string
-	Asset       string // TODO: Not used yet
 }
 
 // BuildXDR for CreateAccount returns a fully configured XDR Operation.

--- a/exp/txnbuild/create_passive_offer.go
+++ b/exp/txnbuild/create_passive_offer.go
@@ -10,8 +10,8 @@ import (
 // CreatePassiveOffer represents the Stellar create passive offer operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type CreatePassiveOffer struct {
-	Selling *Asset
-	Buying  *Asset
+	Selling Asset
+	Buying  Asset
 	Amount  string
 	Price   string // TODO: Extend to include number, and n/d fraction. See package 'amount'
 }

--- a/exp/txnbuild/manage_offer.go
+++ b/exp/txnbuild/manage_offer.go
@@ -9,7 +9,7 @@ import (
 
 //CreateOfferOp returns a ManageOffer operation to create a new offer, by
 // setting the OfferID to "0".
-func CreateOfferOp(selling, buying *Asset, amount, price string) ManageOffer {
+func CreateOfferOp(selling, buying Asset, amount, price string) ManageOffer {
 	return ManageOffer{
 		Selling: selling,
 		Buying:  buying,
@@ -20,7 +20,7 @@ func CreateOfferOp(selling, buying *Asset, amount, price string) ManageOffer {
 }
 
 //UpdateOfferOp returns a ManageOffer operation to update an offer.
-func UpdateOfferOp(selling, buying *Asset, amount, price string, offerID uint64) ManageOffer {
+func UpdateOfferOp(selling, buying Asset, amount, price string, offerID uint64) ManageOffer {
 	return ManageOffer{
 		Selling: selling,
 		Buying:  buying,
@@ -38,8 +38,8 @@ func DeleteOfferOp(offerID uint64) ManageOffer {
 	// Horizon will also reject if Buying == Selling.
 	// Therefore unfortunately we have to make up some dummy values here.
 	return ManageOffer{
-		Selling: NewNativeAsset(),
-		Buying:  NewAsset("FAKE", "GBAQPADEYSKYMYXTMASBUIS5JI3LMOAWSTM2CHGDBJ3QDDPNCSO3DVAA"),
+		Selling: NativeAsset{},
+		Buying:  CreditAsset{Code: "FAKE", Issuer: "GBAQPADEYSKYMYXTMASBUIS5JI3LMOAWSTM2CHGDBJ3QDDPNCSO3DVAA"},
 		Amount:  "0",
 		Price:   "1",
 		OfferID: offerID,
@@ -49,8 +49,8 @@ func DeleteOfferOp(offerID uint64) ManageOffer {
 // ManageOffer represents the Stellar manage offer operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type ManageOffer struct {
-	Selling *Asset
-	Buying  *Asset
+	Selling Asset
+	Buying  Asset
 	Amount  string
 	Price   string // TODO: Extend to include number, and n/d fraction. See package 'amount'
 	OfferID uint64

--- a/exp/txnbuild/path_payment.go
+++ b/exp/txnbuild/path_payment.go
@@ -9,10 +9,10 @@ import (
 // PathPayment represents the Stellar path payment operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type PathPayment struct {
-	SendAsset   *Asset
+	SendAsset   Asset
 	SendMax     string
 	Destination string
-	DestAsset   *Asset
+	DestAsset   Asset
 	DestAmount  string
 	Path        []Asset
 }

--- a/exp/txnbuild/payment.go
+++ b/exp/txnbuild/payment.go
@@ -11,7 +11,7 @@ import (
 type Payment struct {
 	Destination string
 	Amount      string
-	Asset       *Asset
+	Asset       Asset
 }
 
 // BuildXDR for Payment returns a fully configured XDR Operation.

--- a/exp/txnbuild/transaction.go
+++ b/exp/txnbuild/transaction.go
@@ -26,7 +26,7 @@ type Transaction struct {
 	SourceAccount  Account
 	Operations     []Operation
 	xdrTransaction xdr.Transaction
-	BaseFee        uint64 // TODO: Why is this a uint 64? Can it be a plain int?
+	BaseFee        uint32
 	xdrEnvelope    *xdr.TransactionEnvelope
 	Network        string
 }
@@ -60,9 +60,8 @@ func (tx *Transaction) Base64() (string, error) {
 // SetDefaultFee sets a sensible minimum default for the Transaction fee, if one has not
 // already been set. It is a linear function of the number of Operations in the Transaction.
 func (tx *Transaction) SetDefaultFee() {
-	// TODO: Check if default base fee used elsewhere - otherwise just use int
 	// TODO: Generalise to pull this from a client call
-	var DefaultBaseFee uint64 = 100
+	var DefaultBaseFee uint32 = 100
 	if tx.BaseFee == 0 {
 		tx.BaseFee = DefaultBaseFee
 	}

--- a/exp/txnbuild/transaction_test.go
+++ b/exp/txnbuild/transaction_test.go
@@ -64,7 +64,7 @@ func TestPayment(t *testing.T) {
 	payment := Payment{
 		Destination: "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
 		Amount:      "10",
-		Asset:       NewNativeAsset(),
+		Asset:       NativeAsset{},
 	}
 
 	tx := Transaction{
@@ -355,7 +355,7 @@ func TestChangeTrust(t *testing.T) {
 	sourceAccount := makeTestAccount(kp0, "40385577484348")
 
 	changeTrust := ChangeTrust{
-		Line:  NewAsset("ABCD", kp1.Address()),
+		Line:  CreditAsset{"ABCD", kp1.Address()},
 		Limit: "10",
 	}
 
@@ -375,7 +375,7 @@ func TestChangeTrustNativeAssetNotAllowed(t *testing.T) {
 	sourceAccount := makeTestAccount(kp0, "40385577484348")
 
 	changeTrust := ChangeTrust{
-		Line:  NewNativeAsset(),
+		Line:  NativeAsset{},
 		Limit: "10",
 	}
 
@@ -395,7 +395,7 @@ func TestChangeTrustDeleteTrustline(t *testing.T) {
 	kp1 := newKeypair1()
 	sourceAccount := makeTestAccount(kp0, "40385577484354")
 
-	issuedAsset := NewAsset("ABCD", kp1.Address())
+	issuedAsset := CreditAsset{"ABCD", kp1.Address()}
 	removeTrust := RemoveTrustlineOp(issuedAsset)
 
 	tx := Transaction{
@@ -414,7 +414,7 @@ func TestAllowTrust(t *testing.T) {
 	kp1 := newKeypair1()
 	sourceAccount := makeTestAccount(kp0, "40385577484366")
 
-	issuedAsset := NewAsset("ABCD", kp1.Address())
+	issuedAsset := CreditAsset{"ABCD", kp1.Address()}
 	allowTrust := AllowTrust{
 		Trustor:   kp1.Address(),
 		Type:      issuedAsset,
@@ -437,8 +437,8 @@ func TestManageOfferNewOffer(t *testing.T) {
 	kp1 := newKeypair1()
 	sourceAccount := makeTestAccount(kp1, "41137196761092")
 
-	selling := NewNativeAsset()
-	buying := NewAsset("ABCD", kp0.Address())
+	selling := NativeAsset{}
+	buying := CreditAsset{"ABCD", kp0.Address()}
 	sellAmount := "100"
 	price := "0.01"
 	createOffer := CreateOfferOp(selling, buying, sellAmount, price)
@@ -477,8 +477,8 @@ func TestManageOfferUpdateOffer(t *testing.T) {
 	kp1 := newKeypair1()
 	sourceAccount := makeTestAccount(kp1, "41137196761097")
 
-	selling := NewNativeAsset()
-	buying := NewAsset("ABCD", kp0.Address())
+	selling := NativeAsset{}
+	buying := CreditAsset{"ABCD", kp0.Address()}
 	sellAmount := "50"
 	price := "0.02"
 	offerID := uint64(2497628)
@@ -501,8 +501,8 @@ func TestCreatePassiveOffer(t *testing.T) {
 	sourceAccount := makeTestAccount(kp1, "41137196761100")
 
 	createPassiveOffer := CreatePassiveOffer{
-		Selling: NewNativeAsset(),
-		Buying:  NewAsset("ABCD", kp0.Address()),
+		Selling: NativeAsset{},
+		Buying:  CreditAsset{"ABCD", kp0.Address()},
 		Amount:  "10",
 		Price:   "1.0"}
 
@@ -522,14 +522,14 @@ func TestPathPayment(t *testing.T) {
 	kp2 := newKeypair2()
 	sourceAccount := makeTestAccount(kp2, "187316408680450")
 
-	abcdAsset := NewAsset("ABCD", kp0.Address())
+	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
 	pathPayment := PathPayment{
-		SendAsset:   NewNativeAsset(),
+		SendAsset:   NativeAsset{},
 		SendMax:     "10",
 		Destination: kp2.Address(),
-		DestAsset:   NewNativeAsset(),
+		DestAsset:   NativeAsset{},
 		DestAmount:  "1",
-		Path:        []Asset{*abcdAsset},
+		Path:        []Asset{abcdAsset},
 	}
 
 	tx := Transaction{

--- a/exp/txnbuild/transaction_test.go
+++ b/exp/txnbuild/transaction_test.go
@@ -43,7 +43,6 @@ func TestCreateAccount(t *testing.T) {
 	createAccount := CreateAccount{
 		Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:      "10",
-		Asset:       "native",
 	}
 
 	tx := Transaction{


### PR DESCRIPTION
As discussed in #1029, this PR replaces the use of `*Asset` with a new `Asset` interface. This allows us to maintain the convention that pointers are optional, while producing concrete asset types that have sensible default behaviour.

This change makes the existing syntactic sugar helper methods redundant, which is a nice bonus.

One consequence of the move to an interface is the need to add methods for `Code` and `Issuer`. This is required because no fields can be relied on when an interface is passed.

A second consequence is that methods like `func (ca CreditAsset) GetType() (AssetType, error)` are not pointer receivers, to avoid having to pass pointers in to conform to the interface. Luckily there are no mutable operations here.

Effective Go [argues](https://golang.org/doc/effective_go.html#names) that getters in Go never need to have the word `Get` in their names, because one can always make the struct field names private (lowercase). Unfortunately, that is not true here, because as a baseline design choice we chose public struct fields for ease of instantiation. 

Two other small API changes were made:
- the unnecessary asset was removed from `createAccount()`
- Transaction.BaseFee was changed to `uint32`, to match the `xdr` type that it is mapped to internally

Closes #1029.