### PR TITLE
txnbuild: memo support

### DIFF
--- a/exp/txnbuild/memo.go
+++ b/exp/txnbuild/memo.go
@@ -1,0 +1,26 @@
+package txnbuild
+
+import (
+	"fmt"
+
+	"github.com/stellar/go/xdr"
+)
+
+type MemoText string
+type MemoID uint64
+type MemoHash [32]byte
+type MemoReturn [32]byte
+
+const MemoTextMaxLength = 28
+
+type Memo interface {
+	ToXDR() (xdr.Memo, error)
+}
+
+func (mt MemoText) ToXDR() (xdr.Memo, error) {
+	if len(mt) > MemoTextMaxLength {
+		return xdr.Memo{}, fmt.Errorf("Memo text too long (more than %d bytes", MemoTextMaxLength)
+	}
+
+	return xdr.NewMemo(xdr.MemoTypeMemoText, string(mt))
+}

--- a/exp/txnbuild/memo.go
+++ b/exp/txnbuild/memo.go
@@ -29,7 +29,7 @@ type Memo interface {
 // ToXDR for MemoText returns an XDR object representation of a Memo of the same type.
 func (mt MemoText) ToXDR() (xdr.Memo, error) {
 	if len(mt) > MemoTextMaxLength {
-		return xdr.Memo{}, fmt.Errorf("Memo text too long (more than %d bytes", MemoTextMaxLength)
+		return xdr.Memo{}, fmt.Errorf("Memo text can't be longer than %d bytes", MemoTextMaxLength)
 	}
 
 	return xdr.NewMemo(xdr.MemoTypeMemoText, string(mt))

--- a/exp/txnbuild/memo.go
+++ b/exp/txnbuild/memo.go
@@ -6,21 +6,46 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
+// MemoText is used to send human messages of up to 28 bytes of ASCII/UTF-8.
 type MemoText string
+
+// MemoID is an identifier representing the transaction originator.
 type MemoID uint64
+
+// MemoHash is a hash representing a reference to another transaction.
 type MemoHash [32]byte
+
+// MemoReturn is a hash representing the hash of the transaction the sender is refunding.
 type MemoReturn [32]byte
 
+// MemoTextMaxLength is the maximum number of bytes allowed for a text memo.
 const MemoTextMaxLength = 28
 
+// Memo represents the superset of all memo types.
 type Memo interface {
 	ToXDR() (xdr.Memo, error)
 }
 
+// ToXDR for MemoText returns an XDR object representation of a Memo of the same type.
 func (mt MemoText) ToXDR() (xdr.Memo, error) {
 	if len(mt) > MemoTextMaxLength {
 		return xdr.Memo{}, fmt.Errorf("Memo text too long (more than %d bytes", MemoTextMaxLength)
 	}
 
 	return xdr.NewMemo(xdr.MemoTypeMemoText, string(mt))
+}
+
+// ToXDR for MemoID returns an XDR object representation of a Memo of the same type.
+func (mid MemoID) ToXDR() (xdr.Memo, error) {
+	return xdr.NewMemo(xdr.MemoTypeMemoId, xdr.Uint64(mid))
+}
+
+// ToXDR for MemoHash returns an XDR object representation of a Memo of the same type.
+func (mh MemoHash) ToXDR() (xdr.Memo, error) {
+	return xdr.NewMemo(xdr.MemoTypeMemoHash, xdr.Hash(mh))
+}
+
+// ToXDR for MemoReturn returns an XDR object representation of a Memo of the same type.
+func (mr MemoReturn) ToXDR() (xdr.Memo, error) {
+	return xdr.NewMemo(xdr.MemoTypeMemoReturn, xdr.Hash(mr))
 }

--- a/exp/txnbuild/transaction.go
+++ b/exp/txnbuild/transaction.go
@@ -27,6 +27,7 @@ type Transaction struct {
 	Operations     []Operation
 	xdrTransaction xdr.Transaction
 	BaseFee        uint64 // TODO: Why is this a uint 64? Can it be a plain int?
+	Memo           Memo
 	xdrEnvelope    *xdr.TransactionEnvelope
 	Network        string
 }
@@ -91,6 +92,15 @@ func (tx *Transaction) Build() error {
 			return errors.Wrap(err, fmt.Sprintf("Failed to build operation %T", op))
 		}
 		tx.xdrTransaction.Operations = append(tx.xdrTransaction.Operations, xdrOperation)
+	}
+
+	// Handle the memo, if one is present
+	if tx.Memo != nil {
+		xdrMemo, err := tx.Memo.ToXDR()
+		if err != nil {
+			return errors.Wrap(err, "Couldn't build memo XDR")
+		}
+		tx.xdrTransaction.Memo = xdrMemo
 	}
 
 	// Set a default fee, if it hasn't been set yet

--- a/exp/txnbuild/transaction_test.go
+++ b/exp/txnbuild/transaction_test.go
@@ -543,3 +543,24 @@ func TestPathPayment(t *testing.T) {
 	expected := "AAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAZAAAql0AAAADAAAAAAAAAAAAAAABAAAAAAAAAAIAAAAAAAAAAAX14QAAAAAAfhHLNNY19eGrAtSgLD3VpaRm2AjNjxIBWQg9zS4VWZgAAAAAAAAAAACYloAAAAABAAAAAUFCQ0QAAAAA4Nxt4XJcrGZRYrUvrOc1sooiQ+QdEk1suS1wo+oucsUAAAAAAAAAAS4VWZgAAABAZBS66leC0Y7UMg6jPYWh04lLWW9cLOdjWKKIWCjBTwRPmRhb5KyVsRepZdAvl8jmaLnbTk20uJ1yWbenbbbqCw=="
 	assert.Equal(t, expected, received, "Base 64 XDR should match")
 }
+
+func TestMemo(t *testing.T) {
+	kp2 := newKeypair2()
+	sourceAccount := makeTestAccount(kp2, "3428320205078528")
+
+	bumpSequence := BumpSequence{
+		BumpTo: 1,
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Network:       network.TestNetworkPassphrase,
+		Operations:    []Operation{&bumpSequence},
+		Memo:          MemoText("Twas brillig"),
+	}
+
+	received := buildSignEncode(tx, kp2, t)
+	// https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAZAAMLgoAAAABAAAAAAAAAAEAAAAMVHdhcyBicmlsbGlnAAAAAQAAAAAAAAALAAAAAAAAAAEAAAAAAAAAAS4VWZgAAABAstxxDHhcXkfmDkHbe2ck2QFjh6w69VlBzqOeHbT0p0ZxS6cQrhlFZBdvBb4T5qlo0RF4D06z04ygqDqrXmiSDg%3D%3D&type=TransactionEnvelope&network=test
+	expected := "AAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAZAAMLgoAAAABAAAAAAAAAAEAAAAMVHdhcyBicmlsbGlnAAAAAQAAAAAAAAALAAAAAAAAAAEAAAAAAAAAAS4VWZgAAABAstxxDHhcXkfmDkHbe2ck2QFjh6w69VlBzqOeHbT0p0ZxS6cQrhlFZBdvBb4T5qlo0RF4D06z04ygqDqrXmiSDg=="
+	assert.Equal(t, expected, received, "Base 64 XDR should match")
+}

--- a/exp/txnbuild/transaction_test.go
+++ b/exp/txnbuild/transaction_test.go
@@ -548,14 +548,10 @@ func TestMemoText(t *testing.T) {
 	kp2 := newKeypair2()
 	sourceAccount := makeTestAccount(kp2, "3428320205078528")
 
-	bumpSequence := BumpSequence{
-		BumpTo: 1,
-	}
-
 	tx := Transaction{
 		SourceAccount: &sourceAccount,
 		Network:       network.TestNetworkPassphrase,
-		Operations:    []Operation{&bumpSequence},
+		Operations:    []Operation{&BumpSequence{BumpTo: 1}},
 		Memo:          MemoText("Twas brillig"),
 	}
 
@@ -569,14 +565,10 @@ func TestMemoID(t *testing.T) {
 	kp2 := newKeypair2()
 	sourceAccount := makeTestAccount(kp2, "3428320205078528")
 
-	bumpSequence := BumpSequence{
-		BumpTo: 1,
-	}
-
 	tx := Transaction{
 		SourceAccount: &sourceAccount,
 		Network:       network.TestNetworkPassphrase,
-		Operations:    []Operation{&bumpSequence},
+		Operations:    []Operation{&BumpSequence{BumpTo: 1}},
 		Memo:          MemoID(314159),
 	}
 
@@ -590,14 +582,10 @@ func TestMemoHash(t *testing.T) {
 	kp2 := newKeypair2()
 	sourceAccount := makeTestAccount(kp2, "3428320205078528")
 
-	bumpSequence := BumpSequence{
-		BumpTo: 1,
-	}
-
 	tx := Transaction{
 		SourceAccount: &sourceAccount,
 		Network:       network.TestNetworkPassphrase,
-		Operations:    []Operation{&bumpSequence},
+		Operations:    []Operation{&BumpSequence{BumpTo: 1}},
 		Memo:          MemoHash([32]byte{0x01}),
 	}
 
@@ -611,14 +599,10 @@ func TestMemoReturn(t *testing.T) {
 	kp2 := newKeypair2()
 	sourceAccount := makeTestAccount(kp2, "3428320205078528")
 
-	bumpSequence := BumpSequence{
-		BumpTo: 1,
-	}
-
 	tx := Transaction{
 		SourceAccount: &sourceAccount,
 		Network:       network.TestNetworkPassphrase,
-		Operations:    []Operation{&bumpSequence},
+		Operations:    []Operation{&BumpSequence{BumpTo: 1}},
 		Memo:          MemoReturn([32]byte{0x01}),
 	}
 

--- a/exp/txnbuild/transaction_test.go
+++ b/exp/txnbuild/transaction_test.go
@@ -544,7 +544,7 @@ func TestPathPayment(t *testing.T) {
 	assert.Equal(t, expected, received, "Base 64 XDR should match")
 }
 
-func TestMemo(t *testing.T) {
+func TestMemoText(t *testing.T) {
 	kp2 := newKeypair2()
 	sourceAccount := makeTestAccount(kp2, "3428320205078528")
 
@@ -562,5 +562,68 @@ func TestMemo(t *testing.T) {
 	received := buildSignEncode(tx, kp2, t)
 	// https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAZAAMLgoAAAABAAAAAAAAAAEAAAAMVHdhcyBicmlsbGlnAAAAAQAAAAAAAAALAAAAAAAAAAEAAAAAAAAAAS4VWZgAAABAstxxDHhcXkfmDkHbe2ck2QFjh6w69VlBzqOeHbT0p0ZxS6cQrhlFZBdvBb4T5qlo0RF4D06z04ygqDqrXmiSDg%3D%3D&type=TransactionEnvelope&network=test
 	expected := "AAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAZAAMLgoAAAABAAAAAAAAAAEAAAAMVHdhcyBicmlsbGlnAAAAAQAAAAAAAAALAAAAAAAAAAEAAAAAAAAAAS4VWZgAAABAstxxDHhcXkfmDkHbe2ck2QFjh6w69VlBzqOeHbT0p0ZxS6cQrhlFZBdvBb4T5qlo0RF4D06z04ygqDqrXmiSDg=="
+	assert.Equal(t, expected, received, "Base 64 XDR should match")
+}
+
+func TestMemoID(t *testing.T) {
+	kp2 := newKeypair2()
+	sourceAccount := makeTestAccount(kp2, "3428320205078528")
+
+	bumpSequence := BumpSequence{
+		BumpTo: 1,
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Network:       network.TestNetworkPassphrase,
+		Operations:    []Operation{&bumpSequence},
+		Memo:          MemoID(314159),
+	}
+
+	received := buildSignEncode(tx, kp2, t)
+	// https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAZAAMLgoAAAABAAAAAAAAAAIAAAAAAATLLwAAAAEAAAAAAAAACwAAAAAAAAABAAAAAAAAAAEuFVmYAAAAQCKqa1rqle3g8Ksdvl9J67sKdHoXvVXgsmV2QVMZskO%2BDhGSnyxAZBjGf7MFWuz1JoXr5VMo0zphTBRjtMWQvAA%3D&type=TransactionEnvelope&network=test
+	expected := "AAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAZAAMLgoAAAABAAAAAAAAAAIAAAAAAATLLwAAAAEAAAAAAAAACwAAAAAAAAABAAAAAAAAAAEuFVmYAAAAQCKqa1rqle3g8Ksdvl9J67sKdHoXvVXgsmV2QVMZskO+DhGSnyxAZBjGf7MFWuz1JoXr5VMo0zphTBRjtMWQvAA="
+	assert.Equal(t, expected, received, "Base 64 XDR should match")
+}
+
+func TestMemoHash(t *testing.T) {
+	kp2 := newKeypair2()
+	sourceAccount := makeTestAccount(kp2, "3428320205078528")
+
+	bumpSequence := BumpSequence{
+		BumpTo: 1,
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Network:       network.TestNetworkPassphrase,
+		Operations:    []Operation{&bumpSequence},
+		Memo:          MemoHash([32]byte{0x01}),
+	}
+
+	received := buildSignEncode(tx, kp2, t)
+	// https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAZAAMLgoAAAABAAAAAAAAAAMBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAACwAAAAAAAAABAAAAAAAAAAEuFVmYAAAAQJeRgV2MPt3E4IktlsDm6herfaR%2F5VTplcUUwFgBMbPyIxjZW8GEZAIUxjWBV7T9XWjzLrw7pEyldeOcC76PYwc%3D&type=TransactionEnvelope&network=test
+	expected := "AAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAZAAMLgoAAAABAAAAAAAAAAMBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAACwAAAAAAAAABAAAAAAAAAAEuFVmYAAAAQJeRgV2MPt3E4IktlsDm6herfaR/5VTplcUUwFgBMbPyIxjZW8GEZAIUxjWBV7T9XWjzLrw7pEyldeOcC76PYwc="
+	assert.Equal(t, expected, received, "Base 64 XDR should match")
+}
+
+func TestMemoReturn(t *testing.T) {
+	kp2 := newKeypair2()
+	sourceAccount := makeTestAccount(kp2, "3428320205078528")
+
+	bumpSequence := BumpSequence{
+		BumpTo: 1,
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Network:       network.TestNetworkPassphrase,
+		Operations:    []Operation{&bumpSequence},
+		Memo:          MemoReturn([32]byte{0x01}),
+	}
+
+	received := buildSignEncode(tx, kp2, t)
+	// https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAZAAMLgoAAAABAAAAAAAAAAQBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAACwAAAAAAAAABAAAAAAAAAAEuFVmYAAAAQNhrY46fggs%2BTnOYvh3ILgWqmXjkW0968s00si5RLdxFh2%2FA7TTGgmBTarTEtF21hsAyNmW%2B0YkqVVzJ7eFAXAk%3D&type=TransactionEnvelope&network=test
+	expected := "AAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAZAAMLgoAAAABAAAAAAAAAAQBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAACwAAAAAAAAABAAAAAAAAAAEuFVmYAAAAQNhrY46fggs+TnOYvh3ILgWqmXjkW0968s00si5RLdxFh2/A7TTGgmBTarTEtF21hsAyNmW+0YkqVVzJ7eFAXAk="
 	assert.Equal(t, expected, received, "Base 64 XDR should match")
 }


### PR DESCRIPTION
This PR adds support for [transaction memos](https://www.stellar.org/developers/guides/concepts/transactions.html#memo) to `txnbuild`.

Closes #1147.