### PR TITLE
exp/ticker: new market data fields

### DIFF
--- a/exp/ticker/internal/actions_market.go
+++ b/exp/ticker/internal/actions_market.go
@@ -46,7 +46,7 @@ func GenerateMarketSummary(s *tickerdb.TickerSession) (ms MarketSummary, err err
 	}
 
 	for _, dbMarket := range dbMarkets {
-		marketStats := dbMarketToJSON(dbMarket)
+		marketStats := dbMarketToMarketStats(dbMarket)
 		marketStatsSlice = append(marketStatsSlice, marketStats)
 	}
 
@@ -57,19 +57,25 @@ func GenerateMarketSummary(s *tickerdb.TickerSession) (ms MarketSummary, err err
 	return
 }
 
-func dbMarketToJSON(m tickerdb.Market) MarketStats {
+func dbMarketToMarketStats(m tickerdb.Market) MarketStats {
 	closeTime := utils.TimeToUnixEpoch(m.LastPriceCloseTime)
 	return MarketStats{
-		TradePairName:      m.TradePair,
-		BaseVolume24h:      m.BaseVolume24h,
-		CounterVolume24h:   m.CounterVolume24h,
-		TradeCount24h:      m.TradeCount24h,
-		BaseVolume7d:       m.BaseVolume7d,
-		CounterVolume7d:    m.CounterVolume7d,
-		TradeCount7d:       m.TradeCount7d,
-		LastPrice:          m.LastPrice,
-		LastPriceCloseTime: closeTime,
-		PriceChange24h:     m.PriceChange24h,
-		PriceChange7d:      m.PriceChange7d,
+		TradePairName:    m.TradePair,
+		BaseVolume24h:    m.BaseVolume24h,
+		CounterVolume24h: m.CounterVolume24h,
+		TradeCount24h:    m.TradeCount24h,
+		Open24h:          m.OpenPrice24h,
+		Low24h:           m.LowestPrice24h,
+		High24h:          m.HighestPrice24h,
+		Change24h:        m.PriceChange24h,
+		BaseVolume7d:     m.BaseVolume7d,
+		CounterVolume7d:  m.CounterVolume7d,
+		TradeCount7d:     m.TradeCount7d,
+		Open7d:           m.OpenPrice7d,
+		Low7d:            m.LowestPrice7d,
+		High7d:           m.HighestPrice7d,
+		Change7d:         m.PriceChange7d,
+		Close:            m.LastPrice,
+		CloseTime:        closeTime,
 	}
 }

--- a/exp/ticker/internal/main.go
+++ b/exp/ticker/internal/main.go
@@ -14,17 +14,23 @@ type MarketSummary struct {
 // Market stats represents the statistics of a specific market (identified by
 // a trade pair).
 type MarketStats struct {
-	TradePairName      string  `json:"name"`
-	BaseVolume24h      float64 `json:"base_volume"`
-	CounterVolume24h   float64 `json:"counter_volume"`
-	TradeCount24h      int64   `json:"trade_count"`
-	BaseVolume7d       float64 `json:"base_volume_7d"`
-	CounterVolume7d    float64 `json:"counter_volume_7d"`
-	TradeCount7d       int64   `json:"trade_count_7d"`
-	LastPrice          float64 `json:"price"`
-	LastPriceCloseTime int64   `json:"last_price_close_time"`
-	PriceChange24h     float64 `json:"price_change_24h"`
-	PriceChange7d      float64 `json:"price_change_7d"`
+	TradePairName    string  `json:"name"`
+	BaseVolume24h    float64 `json:"base_volume"`
+	CounterVolume24h float64 `json:"counter_volume"`
+	TradeCount24h    int64   `json:"trade_count"`
+	Open24h          float64 `json:"open"`
+	Low24h           float64 `json:"low"`
+	High24h          float64 `json:"high"`
+	Change24h        float64 `json:"change"`
+	BaseVolume7d     float64 `json:"base_volume_7d"`
+	CounterVolume7d  float64 `json:"counter_volume_7d"`
+	TradeCount7d     int64   `json:"trade_count_7d"`
+	Open7d           float64 `json:"open_7d"`
+	Low7d            float64 `json:"low_7d"`
+	High7d           float64 `json:"high_7d"`
+	Change7d         float64 `json:"change_7d"`
+	Close            float64 `json:"close"`
+	CloseTime        int64   `json:"close_time"`
 }
 
 // Asset Sumary represents the collection of valid assets.

--- a/exp/ticker/internal/tickerdb/main.go
+++ b/exp/ticker/internal/tickerdb/main.go
@@ -83,19 +83,25 @@ type Trade struct {
 }
 
 // Market represent the aggregated market data retrieved from the database.
-// Note: this struct does *not* directly maps to a db entity.
+// Note: this struct does *not* directly map to a db entity.
 type Market struct {
 	TradePair          string    `db:"trade_pair_name"`
 	BaseVolume24h      float64   `db:"base_volume_24h"`
 	CounterVolume24h   float64   `db:"counter_volume_24h"`
 	TradeCount24h      int64     `db:"trade_count_24h"`
+	OpenPrice24h       float64   `db:"open_price_24h"`
+	LowestPrice24h     float64   `db:"lowest_price_24h"`
+	HighestPrice24h    float64   `db:"highest_price_24h"`
+	PriceChange24h     float64   `db:"price_change_24h"`
 	BaseVolume7d       float64   `db:"base_volume_7d"`
 	CounterVolume7d    float64   `db:"counter_volume_7d"`
 	TradeCount7d       int64     `db:"trade_count_7d"`
-	LastPrice          float64   `db:"last_price"`
-	LastPriceCloseTime time.Time `db:"close_time"`
-	PriceChange24h     float64   `db:"price_change_24h"`
+	OpenPrice7d        float64   `db:"open_price_7d"`
+	LowestPrice7d      float64   `db:"lowest_price_7d"`
+	HighestPrice7d     float64   `db:"highest_price_7d"`
 	PriceChange7d      float64   `db:"price_change_7d"`
+	LastPriceCloseTime time.Time `db:"close_time"`
+	LastPrice          float64   `db:"last_price"`
 }
 
 // CreateSession returns a new TickerSession that connects to the given db settings

--- a/exp/ticker/internal/tickerdb/queries_market.go
+++ b/exp/ticker/internal/tickerdb/queries_market.go
@@ -11,16 +11,21 @@ SELECT
 	COALESCE(t1.base_volume_24h, 0.0) as base_volume_24h,
 	COALESCE(t1.counter_volume_24h, 0.0) as counter_volume_24h,
 	COALESCE(t1.trade_count_24h, 0) as trade_count_24h,
+	COALESCE(t1.highest_price_24h, 0.0) as highest_price_24h,
+	COALESCE(t1.lowest_price_24h, 0.0) as lowest_price_24h,
+	COALESCE(t4.price_24h_ago - last_price, 0.0) as price_change_24h,
+	COALESCE(t4.price_24h_ago, 0.0) as open_price_24h,
 
 	COALESCE(t2.base_volume_7d, 0) as base_volume_7d,
 	COALESCE(t2.counter_volume_7d, 0) as counter_volume_7d,
 	COALESCE(t2.trade_count_7d, 0) as trade_count_7d,
+	COALESCE(t2.highest_price_7d, 0.0) as highest_price_7d,
+	COALESCE(t2.lowest_price_7d, 0.0) as lowest_price_7d,
+	COALESCE(t5.price_7d_ago - last_price, 0.0) as price_change_7d,
+	COALESCE(t5.price_7d_ago, 0.0) as open_price_7d,
 
 	COALESCE(t3.last_price, 0.0) as last_price,
-	COALESCE(t3.last_close_time, now()) as close_time,
-
-	COALESCE(t4.price_24h_ago - last_price, 0.0) as price_change_24h,
-	COALESCE(t5.price_7d_ago - last_price, 0.0) as price_change_7d
+	COALESCE(t3.last_close_time, now()) as close_time
 
 FROM (
 	-- All trades between valid assets in the last 24h aggregated:
@@ -28,6 +33,8 @@ FROM (
 		concat(bAsset.code, '_', cAsset.code) as trade_pair_name,
 		sum(t.base_amount) as base_volume_24h,
 		sum(t.counter_amount) as counter_volume_24h,
+		max(t.price) as highest_price_24h,
+		min(t.price) as lowest_price_24h,
 		count(t.base_amount) as trade_count_24h
 	FROM trades as t
 		JOIN assets as bAsset
@@ -45,6 +52,8 @@ FULL JOIN (
 		concat(bAsset.code, '_', cAsset.code) as trade_pair_name,
 		sum(t.base_amount) as base_volume_7d,
 		sum(t.counter_amount) as counter_volume_7d,
+		max(t.price) as highest_price_7d,
+		min(t.price) as lowest_price_7d,
 		count(t.base_amount) as trade_count_7d
 	FROM trades as t
 		JOIN assets as bAsset

--- a/exp/ticker/internal/tickerdb/queries_market_test.go
+++ b/exp/ticker/internal/tickerdb/queries_market_test.go
@@ -177,10 +177,16 @@ func TestRetrieveMarketData(t *testing.T) {
 	assert.Equal(t, 100.0, xlmbtcMkt.BaseVolume24h)
 	assert.Equal(t, 10.0, xlmbtcMkt.CounterVolume24h)
 	assert.Equal(t, int64(1), xlmbtcMkt.TradeCount24h)
+	assert.Equal(t, 0.1, xlmbtcMkt.OpenPrice24h)
+	assert.Equal(t, 0.1, xlmbtcMkt.LowestPrice24h)
+	assert.Equal(t, 0.1, xlmbtcMkt.HighestPrice24h)
 
 	assert.Equal(t, 150.0, xlmbtcMkt.BaseVolume7d)
 	assert.Equal(t, 16.0, xlmbtcMkt.CounterVolume7d)
 	assert.Equal(t, int64(2), xlmbtcMkt.TradeCount7d)
+	assert.Equal(t, 0.12, xlmbtcMkt.OpenPrice7d)
+	assert.Equal(t, 0.1, xlmbtcMkt.LowestPrice7d)
+	assert.Equal(t, 0.12, xlmbtcMkt.HighestPrice7d)
 
 	assert.Equal(t, 0.1, xlmbtcMkt.LastPrice)
 	assert.Equal(
@@ -199,10 +205,16 @@ func TestRetrieveMarketData(t *testing.T) {
 	assert.Equal(t, 74.0, xlmethMkt.BaseVolume24h)
 	assert.Equal(t, 76.0, xlmethMkt.CounterVolume24h)
 	assert.Equal(t, int64(2), xlmethMkt.TradeCount24h)
+	assert.Equal(t, 0.92, xlmethMkt.OpenPrice24h)
+	assert.Equal(t, 0.92, xlmethMkt.LowestPrice24h)
+	assert.Equal(t, 1.0, xlmethMkt.HighestPrice24h)
 
 	assert.Equal(t, 74.0, xlmethMkt.BaseVolume7d)
 	assert.Equal(t, 76.0, xlmethMkt.CounterVolume7d)
 	assert.Equal(t, int64(2), xlmethMkt.TradeCount7d)
+	assert.Equal(t, 0.92, xlmethMkt.OpenPrice7d)
+	assert.Equal(t, 0.92, xlmethMkt.LowestPrice7d)
+	assert.Equal(t, 1.0, xlmethMkt.HighestPrice7d)
 
 	assert.Equal(t, 1.0, xlmethMkt.LastPrice)
 	assert.Equal(


### PR DESCRIPTION
This PR aims to add the following fields to the aggregated market data:

```
- open
- low
- high
- open_7d
- low_7d
- high_7d
```

It also changes some of the output field names to avoid the verbosity of the `_price` word, so `close_price` now becomes `close`, for instance.