### PR TITLE
horizonclient: Fund() method from friendbot

### DIFF
--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -399,7 +399,7 @@ func (c *Client) Trades(request TradeRequest) (tds hProtocol.TradesPage, err err
 // Fund creates a new account funded from friendbot. It only works on test networks. See
 // https://www.stellar.org/developers/guides/get-started/create-account.html for more information.
 func (c *Client) Fund(addr string) (*http.Response, error) {
-	if !c.isTest {
+	if !c.isTestNet {
 		return nil, errors.New("Can't fund account from friendbot on production network")
 	}
 	return http.Get(c.HorizonURL + "friendbot?addr=" + addr)

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -396,6 +396,15 @@ func (c *Client) Trades(request TradeRequest) (tds hProtocol.TradesPage, err err
 	return
 }
 
+// Fund creates a new account funded from friendbot. It only works on test networks. See
+// https://www.stellar.org/developers/guides/get-started/create-account.html for more information.
+func (c *Client) Fund(addr string) (*http.Response, error) {
+	if !c.isTest {
+		return nil, errors.New("Can't fund account from friendbot on production network")
+	}
+	return http.Get(c.HorizonURL + "friendbot?addr=" + addr)
+}
+
 // StreamTrades streams executed trades. It can be used to stream all trades, trades for an account and
 // trades for an offer. Use context.WithCancel to stop streaming or context.Background() if you want
 // to stream indefinitely. TradeHandler is a user-supplied function that is executed for each streamed trade received.

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -105,7 +105,7 @@ type Client struct {
 	horizonTimeOut time.Duration
 	AppName        string
 	AppVersion     string
-	isTest         bool
+	isTestNet      bool
 }
 
 // ClientInterface contains methods implemented by the horizon client
@@ -146,7 +146,7 @@ var DefaultTestNetClient = &Client{
 	HorizonURL:     "https://horizon-testnet.stellar.org/",
 	HTTP:           http.DefaultClient,
 	horizonTimeOut: HorizonTimeOut,
-	isTest:         true,
+	isTestNet:      true,
 }
 
 // DefaultPublicNetClient is a default client to connect to public network

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -105,6 +105,7 @@ type Client struct {
 	horizonTimeOut time.Duration
 	AppName        string
 	AppVersion     string
+	isTest         bool
 }
 
 // ClientInterface contains methods implemented by the horizon client
@@ -129,6 +130,7 @@ type ClientInterface interface {
 	Payments(request OperationRequest) (operations.OperationsPage, error)
 	TradeAggregations(request TradeAggregationRequest) (hProtocol.TradeAggregationsPage, error)
 	Trades(request TradeRequest) (hProtocol.TradesPage, error)
+	Fund(addr string) (*http.Response, error)
 	StreamTransactions(ctx context.Context, request TransactionRequest, handler TransactionHandler) error
 	StreamTrades(ctx context.Context, request TradeRequest, handler TradeHandler) error
 	StreamEffects(ctx context.Context, request EffectRequest, handler EffectHandler) error
@@ -144,6 +146,7 @@ var DefaultTestNetClient = &Client{
 	HorizonURL:     "https://horizon-testnet.stellar.org/",
 	HTTP:           http.DefaultClient,
 	horizonTimeOut: HorizonTimeOut,
+	isTest:         true,
 }
 
 // DefaultPublicNetClient is a default client to connect to public network

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -2,6 +2,7 @@ package horizonclient
 
 import (
 	"context"
+	"net/http"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/protocols/horizon/operations"
@@ -134,6 +135,12 @@ func (m *MockClient) TradeAggregations(request TradeAggregationRequest) (hProtoc
 func (m *MockClient) Trades(request TradeRequest) (hProtocol.TradesPage, error) {
 	a := m.Called(request)
 	return a.Get(0).(hProtocol.TradesPage), a.Error(1)
+}
+
+// Fund is a mocking method
+func (m *MockClient) Fund(addr string) (*http.Response, error) {
+	a := m.Called(addr)
+	return nil, a.Error(1)
 }
 
 // StreamTransactions is a mocking method

--- a/exp/txnbuild/cmd/txnbuild_examples/main.go
+++ b/exp/txnbuild/cmd/txnbuild_examples/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/stellar/go/clients/horizon"
+	horizonclient "github.com/stellar/go/exp/clients/horizon"
 	"github.com/stellar/go/exp/txnbuild"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
@@ -50,7 +51,11 @@ func initKeys() []key {
 }
 
 func main() {
-	client := horizon.DefaultTestNetClient
+	client := horizonclient.DefaultTestNetClient
+	pair := createKeypair()
+	resp, err := client.Fund(pair.Address())
+	fmt.Println(resp)
+	fmt.Println(err)
 
 	// resp := exampleCreateAccount(client, false)
 	// resp := exampleSendLumens(client, false)
@@ -67,8 +72,8 @@ func main() {
 	// resp := exampleManageOfferDeleteOffer(client, false)
 	// resp := exampleManageOfferUpdateOffer(client, false)
 	// resp := exampleCreatePassiveOffer(client, false)
-	resp := examplePathPayment(client, false)
-	fmt.Println(resp.TransactionSuccessToString())
+	// resp := examplePathPayment(client, false)
+	// fmt.Println(resp.TransactionSuccessToString())
 }
 
 func examplePathPayment(client *horizon.Client, mock bool) horizon.TransactionSuccess {


### PR DESCRIPTION
This small PR adds a small helper method, `Fund()`, which funds the provided address from friendbot. This saves users (and us) from having to cut and paste the friendbot usage code in tests and examples.

Closes #1117.