### PR TITLE
exp/clients/horizon: submit tx object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 /dist
 /local-archive
 /.vscode/*.sql
+/.vscode/settings.json
 .idea
 debug
 .bundle
 *.swp
+

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -361,9 +361,7 @@ func (c *Client) SubmitTransaction(transaction txnbuild.Transaction) (txSuccess 
 		return
 	}
 
-	request := submitRequest{endpoint: "transactions", transactionXdr: txeBase64}
-	err = c.sendRequest(request, &txSuccess)
-	return
+	return c.SubmitTransactionXDR(txeBase64)
 }
 
 // Transactions returns stellar transactions (https://www.stellar.org/developers/horizon/reference/resources/transaction.html)

--- a/exp/clients/horizon/client.go
+++ b/exp/clients/horizon/client.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/manucorporat/sse"
+	"github.com/stellar/go/exp/txnbuild"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/support/app"
@@ -341,14 +342,28 @@ func (c *Client) OperationDetail(id string) (ops operations.Operation, err error
 	return ops, errors.Wrap(err, "unmarshaling to the correct operation type")
 }
 
-// SubmitTransaction submits a transaction to the network. err can be either error object or horizon.Error object.
+// SubmitTransactionXDR submits a transaction represented as a base64 XDR string to the network. err can be either error object or horizon.Error object.
 // See https://www.stellar.org/developers/horizon/reference/endpoints/transactions-create.html
-func (c *Client) SubmitTransaction(transactionXdr string) (txSuccess hProtocol.TransactionSuccess,
+func (c *Client) SubmitTransactionXDR(transactionXdr string) (txSuccess hProtocol.TransactionSuccess,
 	err error) {
 	request := submitRequest{endpoint: "transactions", transactionXdr: transactionXdr}
 	err = c.sendRequest(request, &txSuccess)
 	return
+}
 
+// SubmitTransaction submits a transaction to the network. err can be either error object or horizon.Error object.
+// See https://www.stellar.org/developers/horizon/reference/endpoints/transactions-create.html
+func (c *Client) SubmitTransaction(transaction txnbuild.Transaction) (txSuccess hProtocol.TransactionSuccess,
+	err error) {
+	txeBase64, err := transaction.Base64()
+	if err != nil {
+		err = errors.Wrap(err, "Unable to convert transaction object to base64 string")
+		return
+	}
+
+	request := submitRequest{endpoint: "transactions", transactionXdr: txeBase64}
+	err = c.sendRequest(request, &txSuccess)
+	return
 }
 
 // Transactions returns stellar transactions (https://www.stellar.org/developers/horizon/reference/resources/transaction.html)

--- a/exp/clients/horizon/main.go
+++ b/exp/clients/horizon/main.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/stellar/go/exp/txnbuild"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/support/render/problem"
@@ -121,7 +122,8 @@ type ClientInterface interface {
 	Offers(request OfferRequest) (hProtocol.OffersPage, error)
 	Operations(request OperationRequest) (operations.OperationsPage, error)
 	OperationDetail(id string) (operations.Operation, error)
-	SubmitTransaction(transactionXdr string) (hProtocol.TransactionSuccess, error)
+	SubmitTransactionXDR(transactionXdr string) (hProtocol.TransactionSuccess, error)
+	SubmitTransaction(transactionXdr txnbuild.Transaction) (hProtocol.TransactionSuccess, error)
 	Transactions(request TransactionRequest) (hProtocol.TransactionsPage, error)
 	TransactionDetail(txHash string) (hProtocol.Transaction, error)
 	OrderBook(request OrderBookRequest) (hProtocol.OrderBookSummary, error)

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -169,14 +169,14 @@ func ExampleClient_OperationDetail() {
 	fmt.Print(ops)
 }
 
-func ExampleClient_SubmitTransaction() {
+func ExampleClient_SubmitTransactionXDR() {
 
 	client := DefaultPublicNetClient
 	// https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAAOoS%2F5V%2BBiCPXRiVcz8YsnkDdODufq%2Bg7xdqTdIXN8vyAAAE4gFiW0YAAALxAAAAAQAAAAAAAAAAAAAAAFyuBUcAAAABAAAABzIyMjgyNDUAAAAAAQAAAAEAAAAALhsY%2FFdAHXllTmb025DtCVBw06WDSQjq6I9NrCQHOV8AAAABAAAAAHT8zKV7bRQzuGTpk9AO3gjWJ9jVxBXTgguFORkxHVIKAAAAAAAAAAAAOnDwAAAAAAAAAAIkBzlfAAAAQPefqlsOvni6xX1g3AqddvOp1GOM88JYzayGZodbzTfV5toyhxZvL1ZggY3prFsvrereugEpj1kyPJ67z6gcRg0XN8vyAAAAQGwmoTssW49gaze8iQkz%2FUA2E2N%2BBOo%2B6v7YdOSsvIcZnMc37KmXH920nLosKpDLqkNChVztSZFcbVUlHhjbQgA%3D&type=TransactionEnvelope&network=public
 	txXdr := `AAAAAOoS/5V+BiCPXRiVcz8YsnkDdODufq+g7xdqTdIXN8vyAAAE4gFiW0YAAALxAAAAAQAAAAAAAAAAAAAAAFyuBUcAAAABAAAABzIyMjgyNDUAAAAAAQAAAAEAAAAALhsY/FdAHXllTmb025DtCVBw06WDSQjq6I9NrCQHOV8AAAABAAAAAHT8zKV7bRQzuGTpk9AO3gjWJ9jVxBXTgguFORkxHVIKAAAAAAAAAAAAOnDwAAAAAAAAAAIkBzlfAAAAQPefqlsOvni6xX1g3AqddvOp1GOM88JYzayGZodbzTfV5toyhxZvL1ZggY3prFsvrereugEpj1kyPJ67z6gcRg0XN8vyAAAAQGwmoTssW49gaze8iQkz/UA2E2N+BOo+6v7YdOSsvIcZnMc37KmXH920nLosKpDLqkNChVztSZFcbVUlHhjbQgA=`
 
 	// submit transaction
-	resp, err := client.SubmitTransaction(txXdr)
+	resp, err := client.SubmitTransactionXDR(txXdr)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -195,7 +195,7 @@ func ExampleClient_SetHorizonTimeOut() {
 
 	// test user timeout
 	client = client.SetHorizonTimeOut(30)
-	resp, err := client.SubmitTransaction(txXdr)
+	resp, err := client.SubmitTransactionXDR(txXdr)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -754,7 +754,7 @@ func TestSubmitRequest(t *testing.T) {
 		On("POST", "https://localhost/transactions").
 		ReturnString(400, transactionFailure)
 
-	_, err := client.SubmitTransaction(txXdr)
+	_, err := client.SubmitTransactionXDR(txXdr)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "horizon error")
 		horizonError, ok := errors.Cause(err).(*Error)
@@ -767,7 +767,7 @@ func TestSubmitRequest(t *testing.T) {
 		On("POST", "https://localhost/transactions").
 		ReturnError("http.Client error")
 
-	_, err = client.SubmitTransaction(txXdr)
+	_, err = client.SubmitTransactionXDR(txXdr)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "http.Client error")
 		_, ok := err.(*Error)
@@ -780,7 +780,7 @@ func TestSubmitRequest(t *testing.T) {
 		"https://localhost/transactions?tx=AAAAABB90WssODNIgi6BHveqzxTRmIpvAFRyVNM%2BHm2GVuCcAAAAZAAABD0AAuV%2FAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAyTBGxOgfSApppsTnb%2FYRr6gOR8WT0LZNrhLh4y3FCgoAAAAXSHboAAAAAAAAAAABhlbgnAAAAEAivKe977CQCxMOKTuj%2BcWTFqc2OOJU8qGr9afrgu2zDmQaX5Q0cNshc3PiBwe0qw%2F%2BD%2FqJk5QqM5dYeSUGeDQP",
 	).ReturnString(200, txSuccess)
 
-	resp, err := client.SubmitTransaction(txXdr)
+	resp, err := client.SubmitTransactionXDR(txXdr)
 	if assert.NoError(t, err) {
 		assert.IsType(t, resp, hProtocol.TransactionSuccess{})
 		assert.Equal(t, resp.Links.Transaction.Href, "https://horizon-testnet.stellar.org/transactions/bcc7a97264dca0a51a63f7ea971b5e7458e334489673078bb2a34eb0cce910ca")

--- a/exp/clients/horizon/mocks.go
+++ b/exp/clients/horizon/mocks.go
@@ -3,6 +3,7 @@ package horizonclient
 import (
 	"context"
 
+	"github.com/stellar/go/exp/txnbuild"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stretchr/testify/mock"
@@ -88,9 +89,15 @@ func (m *MockClient) OperationDetail(id string) (operations.Operation, error) {
 	return a.Get(0).(operations.Operation), a.Error(1)
 }
 
-// SubmitTransaction is a mocking method
-func (m *MockClient) SubmitTransaction(transactionXdr string) (hProtocol.TransactionSuccess, error) {
+// SubmitTransactionXDR is a mocking method
+func (m *MockClient) SubmitTransactionXDR(transactionXdr string) (hProtocol.TransactionSuccess, error) {
 	a := m.Called(transactionXdr)
+	return a.Get(0).(hProtocol.TransactionSuccess), a.Error(1)
+}
+
+// SubmitTransaction is a mocking method
+func (m *MockClient) SubmitTransaction(transaction txnbuild.Transaction) (hProtocol.TransactionSuccess, error) {
+	a := m.Called(transaction)
 	return a.Get(0).(hProtocol.TransactionSuccess), a.Error(1)
 }
 


### PR DESCRIPTION
This PR add support for allowing users to submit transaction objects and not only transaction envelopes as XDR strings.
Closes #1043 