### PR TITLE
Protocol v11 XDR changes

### DIFF
--- a/build/manage_offer.go
+++ b/build/manage_offer.go
@@ -45,8 +45,8 @@ type ManageOfferMutator interface {
 type ManageOfferBuilder struct {
 	PassiveOffer bool
 	O            xdr.Operation
-	MO           xdr.ManageOfferOp
-	PO           xdr.CreatePassiveOfferOp
+	MO           xdr.ManageSellOfferOp
+	PO           xdr.CreatePassiveSellOfferOp
 	Err          error
 }
 
@@ -79,9 +79,9 @@ func (m Amount) MutateManageOffer(o interface{}) (err error) {
 	switch o := o.(type) {
 	default:
 		err = errors.New("Unexpected operation type")
-	case *xdr.ManageOfferOp:
+	case *xdr.ManageSellOfferOp:
 		o.Amount, err = amount.Parse(string(m))
-	case *xdr.CreatePassiveOfferOp:
+	case *xdr.CreatePassiveSellOfferOp:
 		o.Amount, err = amount.Parse(string(m))
 	}
 	return
@@ -92,8 +92,8 @@ func (m OfferID) MutateManageOffer(o interface{}) (err error) {
 	switch o := o.(type) {
 	default:
 		err = errors.New("Unexpected operation type")
-	case *xdr.ManageOfferOp:
-		o.OfferId = xdr.Uint64(m)
+	case *xdr.ManageSellOfferOp:
+		o.OfferId = xdr.Int64(m)
 	}
 	return
 }
@@ -103,7 +103,7 @@ func (m Rate) MutateManageOffer(o interface{}) (err error) {
 	switch o := o.(type) {
 	default:
 		err = errors.New("Unexpected operation type")
-	case *xdr.ManageOfferOp:
+	case *xdr.ManageSellOfferOp:
 		o.Selling, err = m.Selling.ToXDR()
 		if err != nil {
 			return
@@ -115,7 +115,7 @@ func (m Rate) MutateManageOffer(o interface{}) (err error) {
 		}
 
 		o.Price, err = price.Parse(string(m.Price))
-	case *xdr.CreatePassiveOfferOp:
+	case *xdr.CreatePassiveSellOfferOp:
 		o.Selling, err = m.Selling.ToXDR()
 		if err != nil {
 			return

--- a/build/manage_offer_test.go
+++ b/build/manage_offer_test.go
@@ -49,7 +49,7 @@ var _ = Describe("ManageOffer", func() {
 					Expect(builder.MO.Price.N).To(Equal(xdr.Int32(8253)))
 					Expect(builder.MO.Price.D).To(Equal(xdr.Int32(200)))
 
-					Expect(builder.MO.OfferId).To(Equal(xdr.Uint64(0)))
+					Expect(builder.MO.OfferId).To(Equal(xdr.Int64(0)))
 				})
 			})
 		})
@@ -75,7 +75,7 @@ var _ = Describe("ManageOffer", func() {
 					Expect(builder.MO.Price.N).To(Equal(xdr.Int32(8253)))
 					Expect(builder.MO.Price.D).To(Equal(xdr.Int32(200)))
 
-					Expect(builder.MO.OfferId).To(Equal(xdr.Uint64(5)))
+					Expect(builder.MO.OfferId).To(Equal(xdr.Int64(5)))
 				})
 			})
 		})
@@ -101,7 +101,7 @@ var _ = Describe("ManageOffer", func() {
 					Expect(builder.MO.Price.N).To(Equal(xdr.Int32(8253)))
 					Expect(builder.MO.Price.D).To(Equal(xdr.Int32(200)))
 
-					Expect(builder.MO.OfferId).To(Equal(xdr.Uint64(10)))
+					Expect(builder.MO.OfferId).To(Equal(xdr.Int64(10)))
 				})
 			})
 		})

--- a/build/transaction.go
+++ b/build/transaction.go
@@ -243,10 +243,10 @@ func (m ManageOfferBuilder) MutateTransaction(o *TransactionBuilder) error {
 	}
 
 	if m.PassiveOffer {
-		m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypeCreatePassiveOffer, m.PO)
+		m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypeCreatePassiveSellOffer, m.PO)
 		o.TX.Operations = append(o.TX.Operations, m.O)
 	} else {
-		m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypeManageOffer, m.MO)
+		m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypeManageSellOffer, m.MO)
 		o.TX.Operations = append(o.TX.Operations, m.O)
 	}
 	return m.Err
@@ -283,7 +283,7 @@ func (m MemoText) MutateTransaction(o *TransactionBuilder) (err error) {
 }
 
 func (m Timebounds) MutateTransaction(o *TransactionBuilder) error {
-	o.TX.TimeBounds = &xdr.TimeBounds{MinTime: xdr.Uint64(m.MinTime), MaxTime: xdr.Uint64(m.MaxTime)}
+	o.TX.TimeBounds = &xdr.TimeBounds{MinTime: xdr.TimePoint(m.MinTime), MaxTime: xdr.TimePoint(m.MaxTime)}
 	return nil
 }
 

--- a/build/transaction_test.go
+++ b/build/transaction_test.go
@@ -115,8 +115,8 @@ var _ = Describe("Transaction Mutators:", func() {
 		BeforeEach(func() { mut = Timebounds{1521056118, 1521056298} })
 		It("succeeds", func() { Expect(err).NotTo(HaveOccurred()) })
 		It("sets an minimum and maximum timebound on the transaction", func() {
-			Expect(subject.TX.TimeBounds.MinTime).To(Equal(xdr.Uint64(1521056118)))
-			Expect(subject.TX.TimeBounds.MaxTime).To(Equal(xdr.Uint64(1521056298)))
+			Expect(subject.TX.TimeBounds.MinTime).To(Equal(xdr.TimePoint(1521056118)))
+			Expect(subject.TX.TimeBounds.MaxTime).To(Equal(xdr.TimePoint(1521056298)))
 		})
 	})
 

--- a/exp/clients/horizon/main_test.go
+++ b/exp/clients/horizon/main_test.go
@@ -645,7 +645,7 @@ func TestOperationsRequest(t *testing.T) {
 		mangageOfferOp := ops.Embedded.Records[1]
 		createAccountOp := ops.Embedded.Records[2]
 		assert.IsType(t, paymentOp, operations.Payment{})
-		assert.IsType(t, mangageOfferOp, operations.ManageOffer{})
+		assert.IsType(t, mangageOfferOp, operations.ManageSellOffer{})
 		assert.IsType(t, createAccountOp, operations.CreateAccount{})
 
 		c, ok := createAccountOp.(operations.CreateAccount)

--- a/exp/txnbuild/cmd/txnbuild_examples/main.go
+++ b/exp/txnbuild/cmd/txnbuild_examples/main.go
@@ -171,7 +171,7 @@ func exampleCreatePassiveOffer(client *horizon.Client, mock bool) horizon.Transa
 	sellAmount := "10"
 	price := "1.0"
 
-	createPassiveOffer := txnbuild.CreatePassiveOffer{
+	createPassiveOffer := txnbuild.CreatePassiveSellOffer{
 		Selling: selling,
 		Buying:  &buying,
 		Amount:  sellAmount,

--- a/exp/txnbuild/cmd/txnbuild_examples/main.go
+++ b/exp/txnbuild/cmd/txnbuild_examples/main.go
@@ -202,7 +202,7 @@ func exampleManageOfferUpdateOffer(client *horizon.Client, mock bool) horizon.Tr
 	}
 	sellAmount := "50"
 	price := "0.02"
-	offerID := uint64(2497628)
+	offerID := int64(2497628)
 
 	updateOffer := txnbuild.UpdateOfferOp(selling, &buying, sellAmount, price, offerID)
 
@@ -224,7 +224,7 @@ func exampleManageOfferDeleteOffer(client *horizon.Client, mock bool) horizon.Tr
 	dieIfError("loadaccount", err)
 	sourceAccount := mapAccounts(horizonSourceAccount)
 
-	offerID := uint64(4326054)
+	offerID := int64(4326054)
 
 	deleteOffer := txnbuild.DeleteOfferOp(offerID)
 

--- a/exp/txnbuild/create_passive_offer.go
+++ b/exp/txnbuild/create_passive_offer.go
@@ -7,17 +7,17 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-// CreatePassiveOffer represents the Stellar create passive offer operation. See
+// CreatePassiveSellOffer represents the Stellar create passive offer operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
-type CreatePassiveOffer struct {
+type CreatePassiveSellOffer struct {
 	Selling Asset
 	Buying  Asset
 	Amount  string
 	Price   string // TODO: Extend to include number, and n/d fraction. See package 'amount'
 }
 
-// BuildXDR for CreatePassiveOffer returns a fully configured XDR Operation.
-func (cpo *CreatePassiveOffer) BuildXDR() (xdr.Operation, error) {
+// BuildXDR for CreatePassiveSellOffer returns a fully configured XDR Operation.
+func (cpo *CreatePassiveSellOffer) BuildXDR() (xdr.Operation, error) {
 	xdrSelling, err := cpo.Selling.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "failed to set XDR 'Selling' field")
@@ -38,14 +38,14 @@ func (cpo *CreatePassiveOffer) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to parse 'Price'")
 	}
 
-	xdrOp := xdr.CreatePassiveOfferOp{
+	xdrOp := xdr.CreatePassiveSellOfferOp{
 		Selling: xdrSelling,
 		Buying:  xdrBuying,
 		Amount:  xdrAmount,
 		Price:   xdrPrice,
 	}
 
-	opType := xdr.OperationTypeCreatePassiveOffer
+	opType := xdr.OperationTypeCreatePassiveSellOffer
 	body, err := xdr.NewOperationBody(opType, xdrOp)
 
 	return xdr.Operation{Body: body}, errors.Wrap(err, "failed to build XDR OperationBody")

--- a/exp/txnbuild/manage_offer.go
+++ b/exp/txnbuild/manage_offer.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-//CreateOfferOp returns a ManageOffer operation to create a new offer, by
+//CreateOfferOp returns a ManageSellOffer operation to create a new offer, by
 // setting the OfferID to "0".
-func CreateOfferOp(selling, buying Asset, amount, price string) ManageOffer {
-	return ManageOffer{
+func CreateOfferOp(selling, buying Asset, amount, price string) ManageSellOffer {
+	return ManageSellOffer{
 		Selling: selling,
 		Buying:  buying,
 		Amount:  amount,
@@ -19,9 +19,9 @@ func CreateOfferOp(selling, buying Asset, amount, price string) ManageOffer {
 	}
 }
 
-//UpdateOfferOp returns a ManageOffer operation to update an offer.
-func UpdateOfferOp(selling, buying Asset, amount, price string, offerID uint64) ManageOffer {
-	return ManageOffer{
+//UpdateOfferOp returns a ManageSellOffer operation to update an offer.
+func UpdateOfferOp(selling, buying Asset, amount, price string, offerID int64) ManageSellOffer {
+	return ManageSellOffer{
 		Selling: selling,
 		Buying:  buying,
 		Amount:  amount,
@@ -30,14 +30,14 @@ func UpdateOfferOp(selling, buying Asset, amount, price string, offerID uint64) 
 	}
 }
 
-//DeleteOfferOp returns a ManageOffer operation to delete an offer, by
+//DeleteOfferOp returns a ManageSellOffer operation to delete an offer, by
 // setting the Amount to "0".
-func DeleteOfferOp(offerID uint64) ManageOffer {
+func DeleteOfferOp(offerID int64) ManageSellOffer {
 	// It turns out Stellar core doesn't care about any of these fields except the amount.
-	// However, Horizon will reject ManageOffer if it is missing fields.
+	// However, Horizon will reject ManageSellOffer if it is missing fields.
 	// Horizon will also reject if Buying == Selling.
 	// Therefore unfortunately we have to make up some dummy values here.
-	return ManageOffer{
+	return ManageSellOffer{
 		Selling: NativeAsset{},
 		Buying:  CreditAsset{Code: "FAKE", Issuer: "GBAQPADEYSKYMYXTMASBUIS5JI3LMOAWSTM2CHGDBJ3QDDPNCSO3DVAA"},
 		Amount:  "0",
@@ -46,18 +46,18 @@ func DeleteOfferOp(offerID uint64) ManageOffer {
 	}
 }
 
-// ManageOffer represents the Stellar manage offer operation. See
+// ManageSellOffer represents the Stellar manage offer operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
-type ManageOffer struct {
+type ManageSellOffer struct {
 	Selling Asset
 	Buying  Asset
 	Amount  string
 	Price   string // TODO: Extend to include number, and n/d fraction. See package 'amount'
-	OfferID uint64
+	OfferID int64
 }
 
-// BuildXDR for ManageOffer returns a fully configured XDR Operation.
-func (mo *ManageOffer) BuildXDR() (xdr.Operation, error) {
+// BuildXDR for ManageSellOffer returns a fully configured XDR Operation.
+func (mo *ManageSellOffer) BuildXDR() (xdr.Operation, error) {
 	xdrSelling, err := mo.Selling.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "failed to set XDR 'Selling' field")
@@ -78,13 +78,13 @@ func (mo *ManageOffer) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to parse 'Price'")
 	}
 
-	opType := xdr.OperationTypeManageOffer
-	xdrOp := xdr.ManageOfferOp{
+	opType := xdr.OperationTypeManageSellOffer
+	xdrOp := xdr.ManageSellOfferOp{
 		Selling: xdrSelling,
 		Buying:  xdrBuying,
 		Amount:  xdrAmount,
 		Price:   xdrPrice,
-		OfferId: xdr.Uint64(mo.OfferID),
+		OfferId: xdr.Int64(mo.OfferID),
 	}
 	body, err := xdr.NewOperationBody(opType, xdrOp)
 

--- a/exp/txnbuild/transaction.go
+++ b/exp/txnbuild/transaction.go
@@ -99,8 +99,8 @@ func (tx *Transaction) Build() error {
 	if err != nil {
 		return err
 	}
-	tx.xdrTransaction.TimeBounds = &xdr.TimeBounds{MinTime: xdr.Uint64(tx.Timebounds.MinTime),
-		MaxTime: xdr.Uint64(tx.Timebounds.MaxTime)}
+	tx.xdrTransaction.TimeBounds = &xdr.TimeBounds{MinTime: xdr.TimePoint(tx.Timebounds.MinTime),
+		MaxTime: xdr.TimePoint(tx.Timebounds.MaxTime)}
 
 	// Handle the memo, if one is present
 	if tx.Memo != nil {

--- a/exp/txnbuild/transaction_test.go
+++ b/exp/txnbuild/transaction_test.go
@@ -526,7 +526,7 @@ func TestCreatePassiveOffer(t *testing.T) {
 	kp1 := newKeypair1()
 	sourceAccount := makeTestAccount(kp1, "41137196761100")
 
-	createPassiveOffer := CreatePassiveOffer{
+	createPassiveOffer := CreatePassiveSellOffer{
 		Selling: NativeAsset{},
 		Buying:  CreditAsset{"ABCD", kp0.Address()},
 		Amount:  "10",

--- a/exp/txnbuild/transaction_test.go
+++ b/exp/txnbuild/transaction_test.go
@@ -482,7 +482,7 @@ func TestManageOfferDeleteOffer(t *testing.T) {
 	kp1 := newKeypair1()
 	sourceAccount := makeTestAccount(kp1, "41137196761105")
 
-	offerID := uint64(2921622)
+	offerID := int64(2921622)
 	deleteOffer := DeleteOfferOp(offerID)
 
 	tx := Transaction{
@@ -506,7 +506,7 @@ func TestManageOfferUpdateOffer(t *testing.T) {
 	buying := CreditAsset{"ABCD", kp0.Address()}
 	sellAmount := "50"
 	price := "0.02"
-	offerID := uint64(2497628)
+	offerID := int64(2497628)
 	updateOffer := UpdateOfferOp(selling, buying, sellAmount, price, offerID)
 
 	tx := Transaction{

--- a/protocols/stellarcore/tx_response.go
+++ b/protocols/stellarcore/tx_response.go
@@ -12,6 +12,11 @@ const (
 	// TXStatusDuplicate represents the status value returned by stellar-core when a submitted
 	// transaction is a duplicate
 	TXStatusDuplicate = "DUPLICATE"
+
+	// TXStatusTryAgainLater represents the status value returned by stellar-core when a submitted
+	// transaction was not included in the previous 4 ledgers and get banned for being added in the
+	// next few ledgers.
+	TXStatusTryAgainLater = "TRY_AGAIN_LATER"
 )
 
 // TXResponse represents the response returned from a submission request sent to stellar-core's /tx

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -219,7 +219,7 @@ func TestOperationActions_Regressions(t *testing.T) {
 	test.LoadScenario("trades")
 	w = ht.Get("/operations/25769807873")
 	if ht.Assert.Equal(200, w.Code) {
-		var result operations.ManageOffer
+		var result operations.ManageSellOffer
 		err := json.Unmarshal(w.Body.Bytes(), &result)
 		ht.Require.NoError(err, "failed to parse body")
 		ht.Assert.Equal("1.0000000", result.Price)

--- a/services/horizon/internal/codes/main.go
+++ b/services/horizon/internal/codes/main.go
@@ -74,6 +74,10 @@ func String(code interface{}) (string, error) {
 			return "op_no_source_account", nil
 		case xdr.OperationResultCodeOpNotSupported:
 			return "op_not_supported", nil
+		case xdr.OperationResultCodeOpTooManySubentries:
+			return "op_too_many_subentries", nil
+		case xdr.OperationResultCodeOpExceededWorkLimit:
+			return "op_exceeded_work_limit", nil
 		}
 	case xdr.CreateAccountResultCode:
 		switch code {
@@ -140,33 +144,62 @@ func String(code interface{}) (string, error) {
 		case xdr.PathPaymentResultCodePathPaymentOverSendmax:
 			return "op_over_source_max", nil
 		}
-	case xdr.ManageOfferResultCode:
+	case xdr.ManageBuyOfferResultCode:
 		switch code {
-		case xdr.ManageOfferResultCodeManageOfferSuccess:
+		case xdr.ManageBuyOfferResultCodeManageBuyOfferSuccess:
 			return OpSuccess, nil
-		case xdr.ManageOfferResultCodeManageOfferMalformed:
+		case xdr.ManageBuyOfferResultCodeManageBuyOfferMalformed:
 			return OpMalformed, nil
-		case xdr.ManageOfferResultCodeManageOfferSellNoTrust:
+		case xdr.ManageBuyOfferResultCodeManageBuyOfferSellNoTrust:
 			return "op_sell_no_trust", nil
-		case xdr.ManageOfferResultCodeManageOfferBuyNoTrust:
+		case xdr.ManageBuyOfferResultCodeManageBuyOfferBuyNoTrust:
 			return "op_buy_no_trust", nil
-		case xdr.ManageOfferResultCodeManageOfferSellNotAuthorized:
+		case xdr.ManageBuyOfferResultCodeManageBuyOfferSellNotAuthorized:
 			return "sell_not_authorized", nil
-		case xdr.ManageOfferResultCodeManageOfferBuyNotAuthorized:
+		case xdr.ManageBuyOfferResultCodeManageBuyOfferBuyNotAuthorized:
 			return "buy_not_authorized", nil
-		case xdr.ManageOfferResultCodeManageOfferLineFull:
+		case xdr.ManageBuyOfferResultCodeManageBuyOfferLineFull:
 			return OpLineFull, nil
-		case xdr.ManageOfferResultCodeManageOfferUnderfunded:
+		case xdr.ManageBuyOfferResultCodeManageBuyOfferUnderfunded:
 			return OpUnderfunded, nil
-		case xdr.ManageOfferResultCodeManageOfferCrossSelf:
+		case xdr.ManageBuyOfferResultCodeManageBuyOfferCrossSelf:
 			return "op_cross_self", nil
-		case xdr.ManageOfferResultCodeManageOfferSellNoIssuer:
+		case xdr.ManageBuyOfferResultCodeManageBuyOfferSellNoIssuer:
 			return "op_sell_no_issuer", nil
-		case xdr.ManageOfferResultCodeManageOfferBuyNoIssuer:
+		case xdr.ManageBuyOfferResultCodeManageBuyOfferBuyNoIssuer:
 			return "buy_no_issuer", nil
-		case xdr.ManageOfferResultCodeManageOfferNotFound:
+		case xdr.ManageBuyOfferResultCodeManageBuyOfferNotFound:
 			return "op_offer_not_found", nil
-		case xdr.ManageOfferResultCodeManageOfferLowReserve:
+		case xdr.ManageBuyOfferResultCodeManageBuyOfferLowReserve:
+			return OpLowReserve, nil
+		}
+	case xdr.ManageSellOfferResultCode:
+		switch code {
+		case xdr.ManageSellOfferResultCodeManageSellOfferSuccess:
+			return OpSuccess, nil
+		case xdr.ManageSellOfferResultCodeManageSellOfferMalformed:
+			return OpMalformed, nil
+		case xdr.ManageSellOfferResultCodeManageSellOfferSellNoTrust:
+			return "op_sell_no_trust", nil
+		case xdr.ManageSellOfferResultCodeManageSellOfferBuyNoTrust:
+			return "op_buy_no_trust", nil
+		case xdr.ManageSellOfferResultCodeManageSellOfferSellNotAuthorized:
+			return "sell_not_authorized", nil
+		case xdr.ManageSellOfferResultCodeManageSellOfferBuyNotAuthorized:
+			return "buy_not_authorized", nil
+		case xdr.ManageSellOfferResultCodeManageSellOfferLineFull:
+			return OpLineFull, nil
+		case xdr.ManageSellOfferResultCodeManageSellOfferUnderfunded:
+			return OpUnderfunded, nil
+		case xdr.ManageSellOfferResultCodeManageSellOfferCrossSelf:
+			return "op_cross_self", nil
+		case xdr.ManageSellOfferResultCodeManageSellOfferSellNoIssuer:
+			return "op_sell_no_issuer", nil
+		case xdr.ManageSellOfferResultCodeManageSellOfferBuyNoIssuer:
+			return "buy_no_issuer", nil
+		case xdr.ManageSellOfferResultCodeManageSellOfferNotFound:
+			return "op_offer_not_found", nil
+		case xdr.ManageSellOfferResultCodeManageSellOfferLowReserve:
 			return OpLowReserve, nil
 		}
 	case xdr.SetOptionsResultCode:
@@ -286,10 +319,12 @@ func ForOperationResult(opr xdr.OperationResult) (string, error) {
 		ic = ir.MustPaymentResult().Code
 	case xdr.OperationTypePathPayment:
 		ic = ir.MustPathPaymentResult().Code
-	case xdr.OperationTypeManageOffer:
-		ic = ir.MustManageOfferResult().Code
-	case xdr.OperationTypeCreatePassiveOffer:
-		ic = ir.MustCreatePassiveOfferResult().Code
+	case xdr.OperationTypeManageBuyOffer:
+		ic = ir.MustManageBuyOfferResult().Code
+	case xdr.OperationTypeManageSellOffer:
+		ic = ir.MustManageSellOfferResult().Code
+	case xdr.OperationTypeCreatePassiveSellOffer:
+		ic = ir.MustCreatePassiveSellOfferResult().Code
 	case xdr.OperationTypeSetOptions:
 		ic = ir.MustSetOptionsResult().Code
 	case xdr.OperationTypeChangeTrust:

--- a/services/horizon/internal/docs/reference/resources/account.md
+++ b/services/horizon/internal/docs/reference/resources/account.md
@@ -59,7 +59,7 @@ When horizon returns information about an account it uses the following format:
 | Attribute     | Type             |                                                                                                                        |
 |---------------|------------------|------------------------------------------------------------------------------------------------------------------------|
 | low_threshold | number           | The weight required for a valid transaction including the [Allow Trust][allow_trust] and [Bump Sequence][bump_seq] operations. |
-| med_threshold | number           | The weight required for a valid transaction including the [Create Account][create_acc], [Payment][payment], [Path Payment][path_payment], [Manage Offer][manage_offer], [Create Passive Offer][passive_offer], [Change Trust][change_trust], [Inflation][inflation], and [Manage Data][manage_data] operations. |
+| med_threshold | number           | The weight required for a valid transaction including the [Create Account][create_acc], [Payment][payment], [Path Payment][path_payment], [Manage Buy Offer][manage_buy_offer], [Manage Sell Offer][manage_sell_offer], [Create Passive Sell Offer][passive_sell_offer], [Change Trust][change_trust], [Inflation][inflation], and [Manage Data][manage_data] operations. |
 | high_threshold | number           | The weight required for a valid transaction including the [Account Merge][account_merge] and [Set Options]() operations. |
 
 [account_merge]: https://www.stellar.org/developers/guides/concepts/list-of-operations.html#account-merge
@@ -69,8 +69,9 @@ When horizon returns information about an account it uses the following format:
 [create_acc]: https://www.stellar.org/developers/guides/concepts/list-of-operations.html#create-account
 [inflation]: https://www.stellar.org/developers/guides/concepts/list-of-operations.html#inflation
 [manage_data]: https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-data
-[manage_offer]: https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-offer
-[passive_offer]: https://www.stellar.org/developers/guides/concepts/list-of-operations.html#create-passive-offer
+[manage_buy_offer]: https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-buy-offer
+[manage_sell_offer]: https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-sell-offer
+[passive_sell_offer]: https://www.stellar.org/developers/guides/concepts/list-of-operations.html#create-passive-sell-offer
 [path_payment]: https://www.stellar.org/developers/guides/concepts/list-of-operations.html#path-payment
 [payment]: https://www.stellar.org/developers/guides/concepts/list-of-operations.html#payment
 [set_options]: https://www.stellar.org/developers/guides/concepts/list-of-operations.html#set-options

--- a/services/horizon/internal/docs/reference/resources/effect.md
+++ b/services/horizon/internal/docs/reference/resources/effect.md
@@ -51,10 +51,10 @@ We can distinguish 6 effect groups:
 
 | Type          | Operation                                        |
 | --- | --- |
-| Offer Created | manage_offer, create_passive_offer               |
-| Offer Removed | manage_offer, create_passive_offer, path_payment |
-| Offer Updated | manage_offer, create_passive_offer, path_payment |
-| Trade         | manage_offer, create_passive_offer, path_payment |
+| Offer Created | manage_buy_offer, manage_offer (manage_sell_offer from v0.18.0), create_passive_offer (create_passive_sell_offer from v0.18.0)               |
+| Offer Removed | manage_buy_offer, manage_offer (manage_sell_offer from v0.18.0), create_passive_offer (create_passive_sell_offer from v0.18.0), path_payment |
+| Offer Updated | manage_buy_offer, manage_offer (manage_sell_offer from v0.18.0), create_passive_offer (create_passive_sell_offer from v0.18.0), path_payment |
+| Trade         | manage_buy_offer, manage_offer (manage_sell_offer from v0.18.0), create_passive_offer (create_passive_sell_offer from v0.18.0), path_payment |
 
 ### Data effects
 

--- a/services/horizon/internal/docs/reference/resources/operation.md
+++ b/services/horizon/internal/docs/reference/resources/operation.md
@@ -12,18 +12,19 @@ To learn more about the concept of operations in the Stellar network, take a loo
 
 | type                                          | type_i | description                                                                                                |
 |-----------------------------------------------|--------|------------------------------------------------------------------------------------------------------------|
-| [CREATE_ACCOUNT](#create-account)             | 0      | Creates a new account in Stellar network.
-| [PAYMENT](#payment)                           | 1      | Sends a simple payment between two accounts in Stellar network.
-| [PATH_PAYMENT](#path-payment)                 | 2      | Sends a path payment between two accounts in the Stellar network.
-| [MANAGE_OFFER](#manage-offer)                 | 3      | Creates, updates or deletes an offer in the Stellar network.
-| [CREATE_PASSIVE_OFFER](#create-passive-offer) | 4      | Creates an offer that won't consume a counter offer that exactly matches this offer.
-| [SET_OPTIONS](#set-options)                   | 5      | Sets account options (inflation destination, adding signers, etc.)
-| [CHANGE_TRUST](#change-trust)                 | 6      | Creates, updates or deletes a trust line.
-| [ALLOW_TRUST](#allow-trust)                   | 7      | Updates the "authorized" flag of an existing trust line this is called by the issuer of the related asset.
-| [ACCOUNT_MERGE](#account-merge)               | 8      | Deletes account and transfers remaining balance to destination account.
-| [INFLATION](#inflation)                       | 9      | Runs inflation.
-| [MANAGE_DATA](#manage-data)                   | 10     | Set, modify or delete a Data Entry (name/value pair) for an account.
-| [BUMP_SEQUENCE](#bump-sequence)               | 11     | Bumps forward the sequence number of an account.
+| [CREATE_ACCOUNT](#create-account)                       | 0      | Creates a new account in Stellar network.
+| [PAYMENT](#payment)                                     | 1      | Sends a simple payment between two accounts in Stellar network.
+| [PATH_PAYMENT](#path-payment)                           | 2      | Sends a path payment between two accounts in the Stellar network.
+| [MANAGE_SELL_OFFER](#manage-sell-offer)                 | 3      | Creates, updates or deletes a sell offer in the Stellar network.
+| [CREATE_PASSIVE_SELL_OFFER](#create-passive-sell-offer) | 4      | Creates an offer that won't consume a counter offer that exactly matches this offer.
+| [SET_OPTIONS](#set-options)                             | 5      | Sets account options (inflation destination, adding signers, etc.)
+| [CHANGE_TRUST](#change-trust)                           | 6      | Creates, updates or deletes a trust line.
+| [ALLOW_TRUST](#allow-trust)                             | 7      | Updates the "authorized" flag of an existing trust line this is called by the issuer of the related asset.
+| [ACCOUNT_MERGE](#account-merge)                         | 8      | Deletes account and transfers remaining balance to destination account.
+| [INFLATION](#inflation)                                 | 9      | Runs inflation.
+| [MANAGE_DATA](#manage-data)                             | 10     | Set, modify or delete a Data Entry (name/value pair) for an account.
+| [BUMP_SEQUENCE](#bump-sequence)                         | 11     | Bumps forward the sequence number of an account.
+| [MANAGE_BUY_OFFER](#manage-buy-offer)                   | 12     | Creates, updates or deletes a buy offer in the Stellar network.
 
 
 Every operation type shares a set of common attributes and links, some operations also contain
@@ -221,10 +222,10 @@ A path payment operation represents a payment from one account to another throug
 }
 ```
 
-<a id="manage-offer"></a>
-### Manage Offer
+<a id="manage-sell-offer"></a>
+### Manage Sell Offer
 
-A "Manage Offer" operation can create, update or delete an
+A "Manage Offer" operation can create, update or delete a sell
 offer to trade assets in the Stellar network.
 It specifies an issuer, a price and amount of a given asset to
 buy or sell.
@@ -290,12 +291,12 @@ offers or payments, this offer can potentially be filled.
   "selling_asset_type": "credit_alphanum4",
   "transaction_successful": true,
   "type_i": 3,
-  "type": "manage_offer"
+  "type": "manage_offer" // `manage_sell_offer` from v0.18.0
 }
 ```
 
-<a id="create-passive-offer"></a>
-### Create Passive Offer
+<a id="create-passive-sell-offer"></a>
+### Create Passive Sell Offer
 
 “Create Passive Offer” operation creates an offer that won't consume a counter offer that exactly matches this offer. This is useful for offers just used as 1:1 exchanges for path payments. Use Manage Offer to manage this offer after using this operation to create it.
 
@@ -340,7 +341,7 @@ As in [Manage Offer](#manage-offer) operation.
   "selling_asset_type": "native",
   "transaction_successful": true,
   "type_i": 4,
-  "type": "create_passive_offer"
+  "type": "create_passive_offer" // `create_passive_sell_offer` from v0.18.0
 }
 ```
 
@@ -684,3 +685,76 @@ Bumps forward the sequence number of the source account of the operation, allowi
 | [Ledger Operations](../operations-for-ledger.md)   | Collection | `/ledgers/{id}/operations{?cursor,limit,order}` |
 | [Account Operations](../operations-for-account.md) | Collection | `/accounts/:account_id/operations` |
 | [Account Payments](../payments-for-account.md)     | Collection | `/accounts/:account_id/payments` |
+
+<a id="manage-buy-offer"></a>
+### Manage Buy Offer
+
+A "Manage Buy Offer" operation can create, update or delete a buy
+offer to trade assets in the Stellar network.
+It specifies an issuer, a price and amount of a given asset to
+buy or sell.
+
+When this operation is applied to the ledger, trades can potentially be executed if
+this offer crosses others that already exist in the ledger.
+
+In the event that there are not enough crossing orders to fill the order completely
+a new "Offer" object will be created in the ledger.  As other accounts make
+offers or payments, this offer can potentially be filled.
+
+#### Attributes
+
+| Field           |  Type  | Description       |
+| --------------- | ------ | ----------------- |
+| offer_id | number | Offer ID. |
+| amount     | string | Amount of asset to be sold. |
+| buying_asset_code | string | The code of asset to buy. |
+| buying_asset_issuer | string | The issuer of asset to buy. |
+| buying_asset_type | string | Type of asset to buy (native / alphanum4 / alphanum12) |
+| price | string | Price to buy a buying_asset |
+| price_r | Object | n: price numerator, d: price denominator |
+| selling_asset_code | string | The code of asset to sell. |
+| selling_asset_issuer | string | The issuer of asset to sell. |
+| selling_asset_type | string | Type of asset to sell (native / alphanum4 / alphanum12) |
+
+#### Example
+
+```json
+{
+  "_links": {
+    "effects": {
+      "href": "/operations/592323234762753/effects{?cursor,limit,order}",
+      "templated": true
+    },
+    "precedes": {
+      "href": "/operations?cursor=592323234762753\u0026order=asc"
+    },
+    "self": {
+      "href": "/operations/592323234762753"
+    },
+    "succeeds": {
+      "href": "/operations?cursor=592323234762753\u0026order=desc"
+    },
+    "transaction": {
+      "href": "/transactions/592323234762752"
+    }
+  },
+  "amount": "100.0",
+  "buying_asset_code": "CHP",
+  "buying_asset_issuer": "GAC2ZUXVI5266NMMGDPBMXHH4BTZKJ7MMTGXRZGX2R5YLMFRYLJ7U5EA",
+  "buying_asset_type": "credit_alphanum4",
+  "id": 592323234762753,
+  "offer_id": 8,
+  "paging_token": "592323234762753",
+  "price": "2.0",
+  "price_r": {
+    "d": 1,
+    "n": 2
+  },
+  "selling_asset_code": "YEN",
+  "selling_asset_issuer": "GDVXG2FMFFSUMMMBIUEMWPZAIU2FNCH7QNGJMWRXRD6K5FZK5KJS4DDR",
+  "selling_asset_type": "credit_alphanum4",
+  "transaction_successful": true,
+  "type_i": 11,
+  "type": "manage_buy_offer"
+}
+```

--- a/services/horizon/internal/docs/reference/resources/operation.md
+++ b/services/horizon/internal/docs/reference/resources/operation.md
@@ -16,6 +16,7 @@ To learn more about the concept of operations in the Stellar network, take a loo
 | [PAYMENT](#payment)                                     | 1      | Sends a simple payment between two accounts in Stellar network.
 | [PATH_PAYMENT](#path-payment)                           | 2      | Sends a path payment between two accounts in the Stellar network.
 | [MANAGE_SELL_OFFER](#manage-sell-offer)                 | 3      | Creates, updates or deletes a sell offer in the Stellar network.
+| [MANAGE_BUY_OFFER](#manage-buy-offer)                   | 12     | Creates, updates or deletes a buy offer in the Stellar network.
 | [CREATE_PASSIVE_SELL_OFFER](#create-passive-sell-offer) | 4      | Creates an offer that won't consume a counter offer that exactly matches this offer.
 | [SET_OPTIONS](#set-options)                             | 5      | Sets account options (inflation destination, adding signers, etc.)
 | [CHANGE_TRUST](#change-trust)                           | 6      | Creates, updates or deletes a trust line.
@@ -24,7 +25,7 @@ To learn more about the concept of operations in the Stellar network, take a loo
 | [INFLATION](#inflation)                                 | 9      | Runs inflation.
 | [MANAGE_DATA](#manage-data)                             | 10     | Set, modify or delete a Data Entry (name/value pair) for an account.
 | [BUMP_SEQUENCE](#bump-sequence)                         | 11     | Bumps forward the sequence number of an account.
-| [MANAGE_BUY_OFFER](#manage-buy-offer)                   | 12     | Creates, updates or deletes a buy offer in the Stellar network.
+
 
 
 Every operation type shares a set of common attributes and links, some operations also contain
@@ -225,7 +226,88 @@ A path payment operation represents a payment from one account to another throug
 <a id="manage-sell-offer"></a>
 ### Manage Sell Offer
 
-A "Manage Offer" operation can create, update or delete a sell
+A "Manage Sell Offer" operation can create, update or delete a sell
+offer to trade assets in the Stellar network.
+It specifies an issuer, a price and amount of a given asset to
+buy or sell.
+
+When this operation is applied to the ledger, trades can potentially be executed if
+this offer crosses others that already exist in the ledger.
+
+In the event that there are not enough crossing orders to fill the order completely
+a new "Offer" object will be created in the ledger.  As other accounts make
+offers or payments, this offer can potentially be filled.
+
+#### Sell Offer vs. Buy Offer
+
+A [sell offer](#manage-sell-offer) specifies a certain amount of the `selling` asset that should be sold in exchange for the maximum quantity of the `buying` asset. It additionally only crosses offers where the price is higher than `price`.
+
+A [buy offer](#manage-buy-offer) specifies a certain amount of the `buying` asset that should be bought in exchange for the minimum quantity of the `selling` asset. It additionally only crosses offers where the price is lower than `price`.
+
+Both will fill only partially (or not at all) if there are few (or no) offers that cross them.
+
+#### Attributes
+
+| Field           |  Type  | Description       |
+| --------------- | ------ | ----------------- |
+| offer_id | number | Offer ID. |
+| amount     | string | Amount of asset to be sold. |
+| buying_asset_code | string | The code of asset to buy. |
+| buying_asset_issuer | string | The issuer of asset to buy. |
+| buying_asset_type | string | Type of asset to buy (native / alphanum4 / alphanum12) |
+| price | string | Price of selling_asset in units of buying_asset |
+| price_r | Object | n: price numerator, d: price denominator |
+| selling_asset_code | string | The code of asset to sell. |
+| selling_asset_issuer | string | The issuer of asset to sell. |
+| selling_asset_type | string | Type of asset to sell (native / alphanum4 / alphanum12) |
+
+#### Example
+
+```json
+{
+  "_links": {
+    "effects": {
+      "href": "/operations/592323234762753/effects{?cursor,limit,order}",
+      "templated": true
+    },
+    "precedes": {
+      "href": "/operations?cursor=592323234762753\u0026order=asc"
+    },
+    "self": {
+      "href": "/operations/592323234762753"
+    },
+    "succeeds": {
+      "href": "/operations?cursor=592323234762753\u0026order=desc"
+    },
+    "transaction": {
+      "href": "/transactions/592323234762752"
+    }
+  },
+  "amount": "100.0",
+  "buying_asset_code": "CHP",
+  "buying_asset_issuer": "GAC2ZUXVI5266NMMGDPBMXHH4BTZKJ7MMTGXRZGX2R5YLMFRYLJ7U5EA",
+  "buying_asset_type": "credit_alphanum4",
+  "id": 592323234762753,
+  "offer_id": 8,
+  "paging_token": "592323234762753",
+  "price": "2.0",
+  "price_r": {
+    "d": 1,
+    "n": 2
+  },
+  "selling_asset_code": "YEN",
+  "selling_asset_issuer": "GDVXG2FMFFSUMMMBIUEMWPZAIU2FNCH7QNGJMWRXRD6K5FZK5KJS4DDR",
+  "selling_asset_type": "credit_alphanum4",
+  "transaction_successful": true,
+  "type_i": 3,
+  "type": "manage_offer" // `manage_sell_offer` from v0.18.0
+}
+```
+
+<a id="manage-buy-offer"></a>
+### Manage Buy Offer
+
+A "Manage Buy Offer" operation can create, update or delete a buy
 offer to trade assets in the Stellar network.
 It specifies an issuer, a price and amount of a given asset to
 buy or sell.
@@ -290,8 +372,8 @@ offers or payments, this offer can potentially be filled.
   "selling_asset_issuer": "GDVXG2FMFFSUMMMBIUEMWPZAIU2FNCH7QNGJMWRXRD6K5FZK5KJS4DDR",
   "selling_asset_type": "credit_alphanum4",
   "transaction_successful": true,
-  "type_i": 3,
-  "type": "manage_offer" // `manage_sell_offer` from v0.18.0
+  "type_i": 12,
+  "type": "manage_buy_offer"
 }
 ```
 
@@ -302,7 +384,7 @@ offers or payments, this offer can potentially be filled.
 
 #### Attributes
 
-As in [Manage Offer](#manage-offer) operation.
+As in [Manage Sell Offer](#manage-sell-offer) operation.
 
 #### Example
 
@@ -685,76 +767,3 @@ Bumps forward the sequence number of the source account of the operation, allowi
 | [Ledger Operations](../operations-for-ledger.md)   | Collection | `/ledgers/{id}/operations{?cursor,limit,order}` |
 | [Account Operations](../operations-for-account.md) | Collection | `/accounts/:account_id/operations` |
 | [Account Payments](../payments-for-account.md)     | Collection | `/accounts/:account_id/payments` |
-
-<a id="manage-buy-offer"></a>
-### Manage Buy Offer
-
-A "Manage Buy Offer" operation can create, update or delete a buy
-offer to trade assets in the Stellar network.
-It specifies an issuer, a price and amount of a given asset to
-buy or sell.
-
-When this operation is applied to the ledger, trades can potentially be executed if
-this offer crosses others that already exist in the ledger.
-
-In the event that there are not enough crossing orders to fill the order completely
-a new "Offer" object will be created in the ledger.  As other accounts make
-offers or payments, this offer can potentially be filled.
-
-#### Attributes
-
-| Field           |  Type  | Description       |
-| --------------- | ------ | ----------------- |
-| offer_id | number | Offer ID. |
-| amount     | string | Amount of asset to be sold. |
-| buying_asset_code | string | The code of asset to buy. |
-| buying_asset_issuer | string | The issuer of asset to buy. |
-| buying_asset_type | string | Type of asset to buy (native / alphanum4 / alphanum12) |
-| price | string | Price to buy a buying_asset |
-| price_r | Object | n: price numerator, d: price denominator |
-| selling_asset_code | string | The code of asset to sell. |
-| selling_asset_issuer | string | The issuer of asset to sell. |
-| selling_asset_type | string | Type of asset to sell (native / alphanum4 / alphanum12) |
-
-#### Example
-
-```json
-{
-  "_links": {
-    "effects": {
-      "href": "/operations/592323234762753/effects{?cursor,limit,order}",
-      "templated": true
-    },
-    "precedes": {
-      "href": "/operations?cursor=592323234762753\u0026order=asc"
-    },
-    "self": {
-      "href": "/operations/592323234762753"
-    },
-    "succeeds": {
-      "href": "/operations?cursor=592323234762753\u0026order=desc"
-    },
-    "transaction": {
-      "href": "/transactions/592323234762752"
-    }
-  },
-  "amount": "100.0",
-  "buying_asset_code": "CHP",
-  "buying_asset_issuer": "GAC2ZUXVI5266NMMGDPBMXHH4BTZKJ7MMTGXRZGX2R5YLMFRYLJ7U5EA",
-  "buying_asset_type": "credit_alphanum4",
-  "id": 592323234762753,
-  "offer_id": 8,
-  "paging_token": "592323234762753",
-  "price": "2.0",
-  "price_r": {
-    "d": 1,
-    "n": 2
-  },
-  "selling_asset_code": "YEN",
-  "selling_asset_issuer": "GDVXG2FMFFSUMMMBIUEMWPZAIU2FNCH7QNGJMWRXRD6K5FZK5KJS4DDR",
-  "selling_asset_type": "credit_alphanum4",
-  "transaction_successful": true,
-  "type_i": 11,
-  "type": "manage_buy_offer"
-}
-```

--- a/services/horizon/internal/docs/reference/resources/operation.md
+++ b/services/horizon/internal/docs/reference/resources/operation.md
@@ -324,11 +324,11 @@ offers or payments, this offer can potentially be filled.
 | Field           |  Type  | Description       |
 | --------------- | ------ | ----------------- |
 | offer_id | number | Offer ID. |
-| amount     | string | Amount of asset to be sold. |
+| buy_amount     | string | Amount of asset to be bought. |
 | buying_asset_code | string | The code of asset to buy. |
 | buying_asset_issuer | string | The issuer of asset to buy. |
 | buying_asset_type | string | Type of asset to buy (native / alphanum4 / alphanum12) |
-| price | string | Price to buy a buying_asset |
+| price | string | Price of thing being bought in terms of what you are selling. |
 | price_r | Object | n: price numerator, d: price denominator |
 | selling_asset_code | string | The code of asset to sell. |
 | selling_asset_issuer | string | The issuer of asset to sell. |

--- a/services/horizon/internal/docs/reference/resources/operation.md
+++ b/services/horizon/internal/docs/reference/resources/operation.md
@@ -380,7 +380,7 @@ offers or payments, this offer can potentially be filled.
 <a id="create-passive-sell-offer"></a>
 ### Create Passive Sell Offer
 
-“Create Passive Offer” operation creates an offer that won't consume a counter offer that exactly matches this offer. This is useful for offers just used as 1:1 exchanges for path payments. Use Manage Offer to manage this offer after using this operation to create it.
+“Create Passive Sell Offer” operation creates an offer that won't consume a counter offer that exactly matches this offer. This is useful for offers just used as 1:1 exchanges for path payments. Use Manage Sell Offer to manage this offer after using this operation to create it.
 
 #### Attributes
 

--- a/services/horizon/internal/ingest/asset_stat.go
+++ b/services/horizon/internal/ingest/asset_stat.go
@@ -84,14 +84,18 @@ func (assetStats *AssetStats) IngestOperation(op *xdr.Operation, source *xdr.Acc
 		for _, asset := range body.PathPaymentOp.Path {
 			assetStats.add(asset)
 		}
-	case xdr.OperationTypeManageOffer:
+	case xdr.OperationTypeManageBuyOffer:
 		// if this gets expensive then we can limit it to only include those assets that includes the issuer
-		assetStats.add(body.ManageOfferOp.Buying)
-		assetStats.add(body.ManageOfferOp.Selling)
-	case xdr.OperationTypeCreatePassiveOffer:
+		assetStats.add(body.ManageBuyOfferOp.Buying)
+		assetStats.add(body.ManageBuyOfferOp.Selling)
+	case xdr.OperationTypeManageSellOffer:
 		// if this gets expensive then we can limit it to only include those assets that includes the issuer
-		assetStats.add(body.CreatePassiveOfferOp.Buying)
-		assetStats.add(body.CreatePassiveOfferOp.Selling)
+		assetStats.add(body.ManageSellOfferOp.Buying)
+		assetStats.add(body.ManageSellOfferOp.Selling)
+	case xdr.OperationTypeCreatePassiveSellOffer:
+		// if this gets expensive then we can limit it to only include those assets that includes the issuer
+		assetStats.add(body.CreatePassiveSellOfferOp.Buying)
+		assetStats.add(body.CreatePassiveSellOfferOp.Selling)
 	case xdr.OperationTypeChangeTrust:
 		assetStats.add(body.ChangeTrustOp.Line)
 	case xdr.OperationTypeAllowTrust:

--- a/services/horizon/internal/ingest/asset_stat_test.go
+++ b/services/horizon/internal/ingest/asset_stat_test.go
@@ -229,7 +229,7 @@ func TestAssetModified(t *testing.T) {
 				"credit_alphanum4/USD/GCFZWN3AOVFQM2BZTZX7P47WSI4QMGJC62LILPKODTNDLVKZZNA5BQJ3", // issuerUSD
 			},
 		}, {
-			opBody: makeOperationBody(xdr.OperationTypeManageOffer, xdr.ManageOfferOp{
+			opBody: makeOperationBody(xdr.OperationTypeManageSellOffer, xdr.ManageSellOfferOp{
 				Selling: sourceUSD,
 				Buying:  anotherUSD,
 				Amount:  1000000,
@@ -241,7 +241,7 @@ func TestAssetModified(t *testing.T) {
 				"credit_alphanum4/USD/GCYLTPOU7IVYHHA3XKQF4YB4W4ZWHFERMOQ7K47IWANKNBFBNJJNEOG5", // sourceUSD
 			},
 		}, {
-			opBody: makeOperationBody(xdr.OperationTypeManageOffer, xdr.ManageOfferOp{
+			opBody: makeOperationBody(xdr.OperationTypeManageSellOffer, xdr.ManageSellOfferOp{
 				Selling: issuerUSD,
 				Buying:  sourceUSD,
 				Amount:  1000000,
@@ -253,7 +253,7 @@ func TestAssetModified(t *testing.T) {
 				"credit_alphanum4/USD/GCYLTPOU7IVYHHA3XKQF4YB4W4ZWHFERMOQ7K47IWANKNBFBNJJNEOG5", // sourceUSD
 			},
 		}, {
-			opBody: makeOperationBody(xdr.OperationTypeManageOffer, xdr.ManageOfferOp{
+			opBody: makeOperationBody(xdr.OperationTypeManageSellOffer, xdr.ManageSellOfferOp{
 				Selling: issuerUSD,
 				Buying:  anotherUSD,
 				Amount:  1000000,
@@ -265,7 +265,7 @@ func TestAssetModified(t *testing.T) {
 				"credit_alphanum4/USD/GCFZWN3AOVFQM2BZTZX7P47WSI4QMGJC62LILPKODTNDLVKZZNA5BQJ3", // issuerUSD
 			},
 		}, {
-			opBody: makeOperationBody(xdr.OperationTypeCreatePassiveOffer, xdr.CreatePassiveOfferOp{
+			opBody: makeOperationBody(xdr.OperationTypeCreatePassiveSellOffer, xdr.CreatePassiveSellOfferOp{
 				Selling: sourceUSD,
 				Buying:  anotherUSD,
 				Amount:  1000000,
@@ -276,7 +276,7 @@ func TestAssetModified(t *testing.T) {
 				"credit_alphanum4/USD/GCYLTPOU7IVYHHA3XKQF4YB4W4ZWHFERMOQ7K47IWANKNBFBNJJNEOG5", // sourceUSD
 			},
 		}, {
-			opBody: makeOperationBody(xdr.OperationTypeCreatePassiveOffer, xdr.CreatePassiveOfferOp{
+			opBody: makeOperationBody(xdr.OperationTypeCreatePassiveSellOffer, xdr.CreatePassiveSellOfferOp{
 				Selling: issuerUSD,
 				Buying:  sourceUSD,
 				Amount:  1000000,
@@ -287,7 +287,7 @@ func TestAssetModified(t *testing.T) {
 				"credit_alphanum4/USD/GCYLTPOU7IVYHHA3XKQF4YB4W4ZWHFERMOQ7K47IWANKNBFBNJJNEOG5", // sourceUSD
 			},
 		}, {
-			opBody: makeOperationBody(xdr.OperationTypeCreatePassiveOffer, xdr.CreatePassiveOfferOp{
+			opBody: makeOperationBody(xdr.OperationTypeCreatePassiveSellOffer, xdr.CreatePassiveSellOfferOp{
 				Selling: issuerUSD,
 				Buying:  anotherUSD,
 				Amount:  1000000,

--- a/services/horizon/internal/ingest/ingestion_test.go
+++ b/services/horizon/internal/ingest/ingestion_test.go
@@ -76,8 +76,8 @@ func TestTimeBoundsMaxBig(t *testing.T) {
 		"",
 		sqx.StringArray([]string{}),
 		ingestion.formatTimeBounds(&xdr.TimeBounds{
-			MinTime: xdr.Uint64(0),
-			MaxTime: xdr.Uint64(9999999999999999999),
+			MinTime: xdr.TimePoint(0),
+			MaxTime: xdr.TimePoint(9999999999999999999),
 		}),
 		"id",
 		"111",

--- a/services/horizon/internal/ingest/participants/main.go
+++ b/services/horizon/internal/ingest/participants/main.go
@@ -28,9 +28,11 @@ func ForOperation(
 		result = append(result, op.Body.MustPaymentOp().Destination)
 	case xdr.OperationTypePathPayment:
 		result = append(result, op.Body.MustPathPaymentOp().Destination)
-	case xdr.OperationTypeManageOffer:
+	case xdr.OperationTypeManageBuyOffer:
 		// the only direct participant is the source_account
-	case xdr.OperationTypeCreatePassiveOffer:
+	case xdr.OperationTypeManageSellOffer:
+		// the only direct participant is the source_account
+	case xdr.OperationTypeCreatePassiveSellOffer:
 		// the only direct participant is the source_account
 	case xdr.OperationTypeSetOptions:
 		// the only direct participant is the source_account

--- a/services/horizon/internal/ingest/session.go
+++ b/services/horizon/internal/ingest/session.go
@@ -197,19 +197,22 @@ func (is *Session) ingestEffects() {
 		effects.Add(source, history.EffectAccountDebited, dets)
 
 		is.ingestTradeEffects(effects, source, resultSuccess.Offers)
-	case xdr.OperationTypeManageOffer:
-		result := is.Cursor.OperationResult().MustManageOfferResult().MustSuccess()
+	case xdr.OperationTypeManageBuyOffer:
+		result := is.Cursor.OperationResult().MustManageBuyOfferResult().MustSuccess()
 		is.ingestTradeEffects(effects, source, result.OffersClaimed)
-	case xdr.OperationTypeCreatePassiveOffer:
+	case xdr.OperationTypeManageSellOffer:
+		result := is.Cursor.OperationResult().MustManageSellOfferResult().MustSuccess()
+		is.ingestTradeEffects(effects, source, result.OffersClaimed)
+	case xdr.OperationTypeCreatePassiveSellOffer:
 		claims := []xdr.ClaimOfferAtom{}
 		result := is.Cursor.OperationResult()
 
 		// KNOWN ISSUE:  stellar-core creates results for CreatePassiveOffer operations
 		// with the wrong result arm set.
-		if result.Type == xdr.OperationTypeManageOffer {
-			claims = result.MustManageOfferResult().MustSuccess().OffersClaimed
+		if result.Type == xdr.OperationTypeManageSellOffer {
+			claims = result.MustManageSellOfferResult().MustSuccess().OffersClaimed
 		} else {
-			claims = result.MustCreatePassiveOfferResult().MustSuccess().OffersClaimed
+			claims = result.MustCreatePassiveSellOfferResult().MustSuccess().OffersClaimed
 		}
 
 		is.ingestTradeEffects(effects, source, claims)
@@ -539,22 +542,27 @@ func (is *Session) ingestTrades() {
 			MustSuccess().
 			Offers
 
-	case xdr.OperationTypeManageOffer:
-		manageOfferResult := cursor.OperationResult().MustManageOfferResult().MustSuccess()
+	case xdr.OperationTypeManageBuyOffer:
+		manageOfferResult := cursor.OperationResult().MustManageBuyOfferResult().MustSuccess()
 		trades = manageOfferResult.OffersClaimed
 		buyOffer, buyOfferExists = manageOfferResult.Offer.GetOffer()
 
-	case xdr.OperationTypeCreatePassiveOffer:
+	case xdr.OperationTypeManageSellOffer:
+		manageOfferResult := cursor.OperationResult().MustManageSellOfferResult().MustSuccess()
+		trades = manageOfferResult.OffersClaimed
+		buyOffer, buyOfferExists = manageOfferResult.Offer.GetOffer()
+
+	case xdr.OperationTypeCreatePassiveSellOffer:
 		result := cursor.OperationResult()
 
 		// KNOWN ISSUE:  stellar-core creates results for CreatePassiveOffer operations
 		// with the wrong result arm set.
-		if result.Type == xdr.OperationTypeManageOffer {
-			manageOfferResult := result.MustManageOfferResult().MustSuccess()
+		if result.Type == xdr.OperationTypeManageSellOffer {
+			manageOfferResult := result.MustManageSellOfferResult().MustSuccess()
 			trades = manageOfferResult.OffersClaimed
 			buyOffer, buyOfferExists = manageOfferResult.Offer.GetOffer()
 		} else {
-			passiveOfferResult := result.MustCreatePassiveOfferResult().MustSuccess()
+			passiveOfferResult := result.MustCreatePassiveSellOfferResult().MustSuccess()
 			trades = passiveOfferResult.OffersClaimed
 			buyOffer, buyOfferExists = passiveOfferResult.Offer.GetOffer()
 		}
@@ -748,8 +756,19 @@ func (is *Session) operationDetails() map[string]interface{} {
 			is.assetDetails(path[i], op.Path[i], "")
 		}
 		details["path"] = path
-	case xdr.OperationTypeManageOffer:
-		op := c.Operation().Body.MustManageOfferOp()
+	case xdr.OperationTypeManageBuyOffer:
+		op := c.Operation().Body.MustManageBuyOfferOp()
+		details["offer_id"] = op.OfferId
+		details["amount"] = amount.String(op.BuyAmount)
+		details["price"] = op.Price.String()
+		details["price_r"] = map[string]interface{}{
+			"n": op.Price.N,
+			"d": op.Price.D,
+		}
+		is.assetDetails(details, op.Buying, "buying_")
+		is.assetDetails(details, op.Selling, "selling_")
+	case xdr.OperationTypeManageSellOffer:
+		op := c.Operation().Body.MustManageSellOfferOp()
 		details["offer_id"] = op.OfferId
 		details["amount"] = amount.String(op.Amount)
 		details["price"] = op.Price.String()
@@ -759,9 +778,8 @@ func (is *Session) operationDetails() map[string]interface{} {
 		}
 		is.assetDetails(details, op.Buying, "buying_")
 		is.assetDetails(details, op.Selling, "selling_")
-
-	case xdr.OperationTypeCreatePassiveOffer:
-		op := c.Operation().Body.MustCreatePassiveOfferOp()
+	case xdr.OperationTypeCreatePassiveSellOffer:
+		op := c.Operation().Body.MustCreatePassiveSellOfferOp()
 		details["amount"] = amount.String(op.Amount)
 		details["price"] = op.Price.String()
 		details["price_r"] = map[string]interface{}{

--- a/services/horizon/internal/resourceadapter/operations.go
+++ b/services/horizon/internal/resourceadapter/operations.go
@@ -40,13 +40,19 @@ func NewOperation(
 		e.Payment.Base = base
 		err = row.UnmarshalDetails(&e)
 		result = e
-	case xdr.OperationTypeManageOffer:
-		e := operations.ManageOffer{}
-		e.CreatePassiveOffer.Base = base
+	case xdr.OperationTypeManageBuyOffer:
+		e := operations.ManageBuyOffer{}
+		e.Offer.Base = base
 		err = row.UnmarshalDetails(&e)
 		result = e
-	case xdr.OperationTypeCreatePassiveOffer:
-		e := operations.CreatePassiveOffer{Base: base}
+	case xdr.OperationTypeManageSellOffer:
+		e := operations.ManageSellOffer{}
+		e.Offer.Base = base
+		err = row.UnmarshalDetails(&e)
+		result = e
+	case xdr.OperationTypeCreatePassiveSellOffer:
+		e := operations.CreatePassiveSellOffer{}
+		e.Offer.Base = base
 		err = row.UnmarshalDetails(&e)
 		result = e
 	case xdr.OperationTypeSetOptions:

--- a/services/horizon/internal/txsub/submitter.go
+++ b/services/horizon/internal/txsub/submitter.go
@@ -59,7 +59,7 @@ func (sub *submitter) Submit(ctx context.Context, env string) (result Submission
 	switch cresp.Status {
 	case proto.TXStatusError:
 		result.Err = &FailedTransactionError{cresp.Error}
-	case proto.TXStatusPending, proto.TXStatusDuplicate:
+	case proto.TXStatusPending, proto.TXStatusDuplicate, proto.TXStatusTryAgainLater:
 		//noop.  A nil Err indicates success
 	default:
 		result.Err = errors.Errorf("Unrecognized stellar-core status response: %s", cresp.Status)

--- a/xdr/Stellar-ledger-entries.x
+++ b/xdr/Stellar-ledger-entries.x
@@ -12,6 +12,7 @@ typedef opaque Thresholds[4];
 typedef string string32<32>;
 typedef string string64<64>;
 typedef int64 SequenceNumber;
+typedef uint64 TimePoint;
 typedef opaque DataValue<64>;
 
 enum AssetType
@@ -105,7 +106,6 @@ const MASK_ACCOUNT_FLAGS = 0x7;
     Other ledger entries created require an account.
 
 */
-
 struct AccountEntry
 {
     AccountID accountID;      // master public key for this account
@@ -210,7 +210,7 @@ const MASK_OFFERENTRY_FLAGS = 1;
 struct OfferEntry
 {
     AccountID sellerID;
-    uint64 offerID;
+    int64 offerID;
     Asset selling; // A
     Asset buying;  // B
     int64 amount;  // amount of A
@@ -283,6 +283,7 @@ enum EnvelopeType
 {
     ENVELOPE_TYPE_SCP = 1,
     ENVELOPE_TYPE_TX = 2,
-    ENVELOPE_TYPE_AUTH = 3
+    ENVELOPE_TYPE_AUTH = 3,
+    ENVELOPE_TYPE_SCPVALUE = 4
 };
 }

--- a/xdr/Stellar-ledger.x
+++ b/xdr/Stellar-ledger.x
@@ -10,12 +10,24 @@ namespace stellar
 
 typedef opaque UpgradeType<128>;
 
+enum StellarValueType
+{
+    STELLAR_VALUE_BASIC = 0,
+    STELLAR_VALUE_SIGNED = 1
+};
+
+struct LedgerCloseValueSignature
+{
+    NodeID nodeID;       // which node introduced the value
+    Signature signature; // nodeID's signature
+};
+
 /* StellarValue is the value used by SCP to reach consensus on a given ledger
-*/
+ */
 struct StellarValue
 {
-    Hash txSetHash;   // transaction set to apply to previous ledger
-    uint64 closeTime; // network close time
+    Hash txSetHash;      // transaction set to apply to previous ledger
+    TimePoint closeTime; // network close time
 
     // upgrades to apply to the previous ledger (usually empty)
     // this is a vector of encoded 'LedgerUpgrade' so that nodes can drop
@@ -27,15 +39,17 @@ struct StellarValue
     // reserved for future use
     union switch (int v)
     {
-    case 0:
+    case STELLAR_VALUE_BASIC:
         void;
+    case STELLAR_VALUE_SIGNED:
+        LedgerCloseValueSignature lcValueSignature;
     }
     ext;
 };
 
 /* The LedgerHeader is the highest level structure representing the
  * state of a ledger, cryptographically linked to previous ledgers.
-*/
+ */
 struct LedgerHeader
 {
     uint32 ledgerVersion;    // the protocol version of the ledger
@@ -120,7 +134,7 @@ case OFFER:
     struct
     {
         AccountID sellerID;
-        uint64 offerID;
+        int64 offerID;
     } offer;
 
 case DATA:
@@ -133,17 +147,38 @@ case DATA:
 
 enum BucketEntryType
 {
-    LIVEENTRY = 0,
-    DEADENTRY = 1
+    METAENTRY =
+        -1, // At-and-after protocol 11: bucket metadata, should come first.
+    LIVEENTRY = 0, // Before protocol 11: created-or-updated;
+                   // At-and-after protocol 11: only updated.
+    DEADENTRY = 1,
+    INITENTRY = 2 // At-and-after protocol 11: only created.
+};
+
+struct BucketMetadata
+{
+    // Indicates the protocol version used to create / merge this bucket.
+    uint32 ledgerVersion;
+
+    // reserved for future use
+    union switch (int v)
+    {
+    case 0:
+        void;
+    }
+    ext;
 };
 
 union BucketEntry switch (BucketEntryType type)
 {
 case LIVEENTRY:
+case INITENTRY:
     LedgerEntry liveEntry;
 
 case DEADENTRY:
     LedgerKey deadEntry;
+case METAENTRY:
+    BucketMetadata metaEntry;
 };
 
 // Transaction sets are the unit used by SCP to decide on transitions
@@ -268,7 +303,7 @@ struct OperationMeta
 struct TransactionMetaV1
 {
     LedgerEntryChanges txChanges; // tx level changes if any
-    OperationMeta operations<>; // meta for each operation
+    OperationMeta operations<>;   // meta for each operation
 };
 
 // this is the meta produced when applying transactions

--- a/xdr/Stellar-transaction.x
+++ b/xdr/Stellar-transaction.x
@@ -18,15 +18,16 @@ enum OperationType
     CREATE_ACCOUNT = 0,
     PAYMENT = 1,
     PATH_PAYMENT = 2,
-    MANAGE_OFFER = 3,
-    CREATE_PASSIVE_OFFER = 4,
+    MANAGE_SELL_OFFER = 3,
+    CREATE_PASSIVE_SELL_OFFER = 4,
     SET_OPTIONS = 5,
     CHANGE_TRUST = 6,
     ALLOW_TRUST = 7,
     ACCOUNT_MERGE = 8,
     INFLATION = 9,
     MANAGE_DATA = 10,
-    BUMP_SEQUENCE = 11
+    BUMP_SEQUENCE = 11,
+    MANAGE_BUY_OFFER = 12
 };
 
 /* CreateAccount
@@ -37,7 +38,6 @@ Threshold: med
 Result: CreateAccountResult
 
 */
-
 struct CreateAccountOp
 {
     AccountID destination; // account to create
@@ -88,10 +88,10 @@ struct PathPaymentOp
 
 Threshold: med
 
-Result: ManageOfferResult
+Result: ManageSellOfferResult
 
 */
-struct ManageOfferOp
+struct ManageSellOfferOp
 {
     Asset selling;
     Asset buying;
@@ -99,17 +99,36 @@ struct ManageOfferOp
     Price price;  // price of thing being sold in terms of what you are buying
 
     // 0=create a new offer, otherwise edit an existing offer
-    uint64 offerID;
+    int64 offerID;
+};
+
+/* Creates, updates or deletes an offer with amount in terms of buying asset
+
+Threshold: med
+
+Result: ManageBuyOfferResult
+
+*/
+struct ManageBuyOfferOp
+{
+    Asset selling;
+    Asset buying;
+    int64 buyAmount; // amount being bought. if set to 0, delete the offer
+    Price price;     // price of thing being bought in terms of what you are
+                     // selling
+
+    // 0=create a new offer, otherwise edit an existing offer
+    int64 offerID;
 };
 
 /* Creates an offer that doesn't take offers of the same price
 
 Threshold: med
 
-Result: CreatePassiveOfferResult
+Result: CreatePassiveSellOfferResult
 
 */
-struct CreatePassiveOfferOp
+struct CreatePassiveSellOfferOp
 {
     Asset selling; // A
     Asset buying;  // B
@@ -126,7 +145,6 @@ struct CreatePassiveOfferOp
 
     Result: SetOptionsResult
 */
-
 struct SetOptionsOp
 {
     AccountID* inflationDest; // sets the inflation destination
@@ -215,7 +233,6 @@ Result: InflationResult
 
     Result: ManageDataResult
 */
-
 struct ManageDataOp
 {
     string64 dataName;
@@ -226,9 +243,10 @@ struct ManageDataOp
 
     increases the sequence to a given level
 
+    Threshold: low
+
     Result: BumpSequenceResult
 */
-
 struct BumpSequenceOp
 {
     SequenceNumber bumpTo;
@@ -250,10 +268,10 @@ struct Operation
         PaymentOp paymentOp;
     case PATH_PAYMENT:
         PathPaymentOp pathPaymentOp;
-    case MANAGE_OFFER:
-        ManageOfferOp manageOfferOp;
-    case CREATE_PASSIVE_OFFER:
-        CreatePassiveOfferOp createPassiveOfferOp;
+    case MANAGE_SELL_OFFER:
+        ManageSellOfferOp manageSellOfferOp;
+    case CREATE_PASSIVE_SELL_OFFER:
+        CreatePassiveSellOfferOp createPassiveSellOfferOp;
     case SET_OPTIONS:
         SetOptionsOp setOptionsOp;
     case CHANGE_TRUST:
@@ -268,6 +286,8 @@ struct Operation
         ManageDataOp manageDataOp;
     case BUMP_SEQUENCE:
         BumpSequenceOp bumpSequenceOp;
+    case MANAGE_BUY_OFFER:
+        ManageBuyOfferOp manageBuyOfferOp;
     }
     body;
 };
@@ -297,9 +317,12 @@ case MEMO_RETURN:
 
 struct TimeBounds
 {
-    uint64 minTime;
-    uint64 maxTime; // 0 here means no maxTime
+    TimePoint minTime;
+    TimePoint maxTime; // 0 here means no maxTime
 };
+
+// maximum number of operations per transaction
+const MAX_OPS_PER_TX = 100;
 
 /* a transaction is a container for a set of operations
     - is executed by an account
@@ -308,7 +331,6 @@ struct TimeBounds
           either all operations are applied or none are
           if any returns a failing code
 */
-
 struct Transaction
 {
     // account used to run the transaction
@@ -325,7 +347,7 @@ struct Transaction
 
     Memo memo;
 
-    Operation operations<100>;
+    Operation operations<MAX_OPS_PER_TX>;
 
     // reserved for future use
     union switch (int v)
@@ -364,7 +386,7 @@ struct ClaimOfferAtom
 {
     // emitted to identify the offer
     AccountID sellerID; // Account that owns the offer
-    uint64 offerID;
+    int64 offerID;
 
     // amount and asset taken from the owner
     Asset assetSold;
@@ -468,29 +490,29 @@ default:
     void;
 };
 
-/******* ManageOffer Result ********/
+/******* ManageSellOffer Result ********/
 
-enum ManageOfferResultCode
+enum ManageSellOfferResultCode
 {
     // codes considered as "success" for the operation
-    MANAGE_OFFER_SUCCESS = 0,
+    MANAGE_SELL_OFFER_SUCCESS = 0,
 
     // codes considered as "failure" for the operation
-    MANAGE_OFFER_MALFORMED = -1,     // generated offer would be invalid
-    MANAGE_OFFER_SELL_NO_TRUST = -2, // no trust line for what we're selling
-    MANAGE_OFFER_BUY_NO_TRUST = -3,  // no trust line for what we're buying
-    MANAGE_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
-    MANAGE_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
-    MANAGE_OFFER_LINE_FULL = -6,      // can't receive more of what it's buying
-    MANAGE_OFFER_UNDERFUNDED = -7,    // doesn't hold what it's trying to sell
-    MANAGE_OFFER_CROSS_SELF = -8,     // would cross an offer from the same user
-    MANAGE_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
-    MANAGE_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
+    MANAGE_SELL_OFFER_MALFORMED = -1,     // generated offer would be invalid
+    MANAGE_SELL_OFFER_SELL_NO_TRUST = -2, // no trust line for what we're selling
+    MANAGE_SELL_OFFER_BUY_NO_TRUST = -3,  // no trust line for what we're buying
+    MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
+    MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
+    MANAGE_SELL_OFFER_LINE_FULL = -6,      // can't receive more of what it's buying
+    MANAGE_SELL_OFFER_UNDERFUNDED = -7,    // doesn't hold what it's trying to sell
+    MANAGE_SELL_OFFER_CROSS_SELF = -8,     // would cross an offer from the same user
+    MANAGE_SELL_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
+    MANAGE_SELL_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
 
     // update errors
-    MANAGE_OFFER_NOT_FOUND = -11, // offerID does not match an existing offer
+    MANAGE_SELL_OFFER_NOT_FOUND = -11, // offerID does not match an existing offer
 
-    MANAGE_OFFER_LOW_RESERVE = -12 // not enough funds to create a new Offer
+    MANAGE_SELL_OFFER_LOW_RESERVE = -12 // not enough funds to create a new Offer
 };
 
 enum ManageOfferEffect
@@ -516,9 +538,42 @@ struct ManageOfferSuccessResult
     offer;
 };
 
-union ManageOfferResult switch (ManageOfferResultCode code)
+union ManageSellOfferResult switch (ManageSellOfferResultCode code)
 {
-case MANAGE_OFFER_SUCCESS:
+case MANAGE_SELL_OFFER_SUCCESS:
+    ManageOfferSuccessResult success;
+default:
+    void;
+};
+
+/******* ManageBuyOffer Result ********/
+
+enum ManageBuyOfferResultCode
+{
+    // codes considered as "success" for the operation
+    MANAGE_BUY_OFFER_SUCCESS = 0,
+
+    // codes considered as "failure" for the operation
+    MANAGE_BUY_OFFER_MALFORMED = -1,     // generated offer would be invalid
+    MANAGE_BUY_OFFER_SELL_NO_TRUST = -2, // no trust line for what we're selling
+    MANAGE_BUY_OFFER_BUY_NO_TRUST = -3,  // no trust line for what we're buying
+    MANAGE_BUY_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
+    MANAGE_BUY_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
+    MANAGE_BUY_OFFER_LINE_FULL = -6,      // can't receive more of what it's buying
+    MANAGE_BUY_OFFER_UNDERFUNDED = -7,    // doesn't hold what it's trying to sell
+    MANAGE_BUY_OFFER_CROSS_SELF = -8,     // would cross an offer from the same user
+    MANAGE_BUY_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
+    MANAGE_BUY_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
+
+    // update errors
+    MANAGE_BUY_OFFER_NOT_FOUND = -11, // offerID does not match an existing offer
+
+    MANAGE_BUY_OFFER_LOW_RESERVE = -12 // not enough funds to create a new Offer
+};
+
+union ManageBuyOfferResult switch (ManageBuyOfferResultCode code)
+{
+case MANAGE_BUY_OFFER_SUCCESS:
     ManageOfferSuccessResult success;
 default:
     void;
@@ -563,7 +618,7 @@ enum ChangeTrustResultCode
                                      // cannot create with a limit of 0
     CHANGE_TRUST_LOW_RESERVE =
         -4, // not enough funds to create a new trust line,
-    CHANGE_TRUST_SELF_NOT_ALLOWED = -5 // trusting self is not allowed
+    CHANGE_TRUST_SELF_NOT_ALLOWED = -5  // trusting self is not allowed
 };
 
 union ChangeTrustResult switch (ChangeTrustResultCode code)
@@ -693,7 +748,9 @@ enum OperationResultCode
 
     opBAD_AUTH = -1,     // too few valid signatures / wrong network
     opNO_ACCOUNT = -2,   // source account was not found
-    opNOT_SUPPORTED = -3 // operation not supported at this time
+    opNOT_SUPPORTED = -3, // operation not supported at this time
+    opTOO_MANY_SUBENTRIES = -4, // max number of subentries already reached
+    opEXCEEDED_WORK_LIMIT = -5  // operation did too much work
 };
 
 union OperationResult switch (OperationResultCode code)
@@ -707,10 +764,10 @@ case opINNER:
         PaymentResult paymentResult;
     case PATH_PAYMENT:
         PathPaymentResult pathPaymentResult;
-    case MANAGE_OFFER:
-        ManageOfferResult manageOfferResult;
-    case CREATE_PASSIVE_OFFER:
-        ManageOfferResult createPassiveOfferResult;
+    case MANAGE_SELL_OFFER:
+        ManageSellOfferResult manageSellOfferResult;
+    case CREATE_PASSIVE_SELL_OFFER:
+        ManageSellOfferResult createPassiveSellOfferResult;
     case SET_OPTIONS:
         SetOptionsResult setOptionsResult;
     case CHANGE_TRUST:
@@ -725,6 +782,8 @@ case opINNER:
         ManageDataResult manageDataResult;
     case BUMP_SEQUENCE:
         BumpSequenceResult bumpSeqResult;
+    case MANAGE_BUY_OFFER:
+	ManageBuyOfferResult manageBuyOfferResult;
     }
     tr;
 default:

--- a/xdr/ledger_key.go
+++ b/xdr/ledger_key.go
@@ -63,7 +63,7 @@ func (key *LedgerKey) SetData(account AccountId, name string) error {
 // SetOffer mutates `key` such that it represents the identity of the
 // data entry owned by `account` and for offer `id`.
 func (key *LedgerKey) SetOffer(account AccountId, id uint64) error {
-	data := LedgerKeyOffer{account, Uint64(id)}
+	data := LedgerKeyOffer{account, Int64(id)}
 	nkey, err := NewLedgerKey(LedgerEntryTypeOffer, data)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR updates XDR files to be up to date with stellar-core v11. Changes affecting this repository:
* Operation type names changes:
  * `manage_offer` -> `manage_sell_offer`,
  * `create_passive_offer` -> `create_passive_sell_offer`,
  * New `manage_buy_offer` operation.
* Offer IDs are now of `int64` type.

For backward compatibility, `manage_offer` and `create_passive_offer` type names have not been changed in Horizon. This will be a breaking change in Horizon 0.18.0.

Builders for `manage_buy_offer` operation has **not** been added in this PR (new issue: https://github.com/stellar/go/issues/1165).