### PR TITLE
exp/ticker: GraphQL server Docker integration

### DIFF
--- a/exp/ticker/cmd/serve.go
+++ b/exp/ticker/cmd/serve.go
@@ -12,7 +12,7 @@ var ServerAddr string
 func init() {
 	rootCmd.AddCommand(cmdServe)
 
-	cmdIngestTrades.Flags().StringVar(
+	cmdServe.Flags().StringVar(
 		&ServerAddr,
 		"address",
 		"0.0.0.0:3000",

--- a/exp/ticker/docker/conf/nginx.conf
+++ b/exp/ticker/docker/conf/nginx.conf
@@ -39,8 +39,20 @@ http {
 
 		server_name _;
 
+		rewrite ^/(.*)/$ /$1 permanent;
+
 		location / {
 			try_files $uri $uri/ =404;
+		}
+
+		location  ~ ^/(graphql|graphiql) {
+			proxy_pass http://localhost:8080;
+			proxy_set_header Host $host;
+			proxy_set_header X-Real-IP $remote_addr;
+			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+			proxy_set_header X-Forwarded-Proto $scheme;
+			proxy_http_version 1.1;
+			proxy_set_header Connection "";
 		}
 	}
 }

--- a/exp/ticker/docker/conf/supervisord.conf
+++ b/exp/ticker/docker/conf/supervisord.conf
@@ -42,6 +42,14 @@ autorestart=true
 priority=30
 
 
+[program:graphqlserver]
+user=stellar
+command=/opt/stellar/bin/ticker serve --address 0.0.0.0:8080 --db-url=postgres://127.0.0.1:5432/ticker
+autostart=true
+autorestart=true
+priority=30
+
+
 [program:cron]
 command=cron -f -L 15
 autostart=true

--- a/exp/ticker/docker/setup
+++ b/exp/ticker/docker/setup
@@ -10,7 +10,7 @@ mkdir -p /opt/stellar/www
 chown -R stellar:stellar /opt/stellar/www
 mkdir -p /opt/stellar/postgresql/data
 
-wget -O ticker.tar.gz https://github.com/accordeiro/ticker-releases/releases/download/v0.1-alpha/ticker.tar.gz
+wget -O ticker.tar.gz https://github.com/accordeiro/ticker-releases/releases/download/v0.4-alpha/ticker.tar.gz
 tar -xvzf ticker.tar.gz
 mv ticker /opt/stellar/bin/ticker
 chmod +x /opt/stellar/bin/ticker


### PR DESCRIPTION
This PR:
- Closes #1163 

It aims to:
- Integrate the GraphQL server in the docker container setup, by adding a service that is monitored by Supervisor and forwarding the GraphQL queries from Nginx directly to the Go service.