### PR TITLE
services/friendbot: adds Stellar channels to friendbot

### DIFF
--- a/services/friendbot/friendbot.cfg
+++ b/services/friendbot/friendbot.cfg
@@ -3,3 +3,4 @@ friendbot_secret = "SA6WAWCCMRZSEFD5PEN5GK5BHK347YEQ552XZM72NV553TAGWFVHW2G5"
 network_passphrase = "Test SDF Network ; September 2015"
 horizon_url = "https://horizon-testnet.stellar.org"
 starting_balance = "10000.00"
+num_minions = 1000

--- a/services/friendbot/friendbot.cfg
+++ b/services/friendbot/friendbot.cfg
@@ -2,5 +2,5 @@ port = 8000
 friendbot_secret = "SA6WAWCCMRZSEFD5PEN5GK5BHK347YEQ552XZM72NV553TAGWFVHW2G5"
 network_passphrase = "Test SDF Network ; September 2015"
 horizon_url = "https://horizon-testnet.stellar.org"
-starting_balance = "9999.00"
+starting_balance = "10000.00"
 num_minions = 100

--- a/services/friendbot/friendbot.cfg
+++ b/services/friendbot/friendbot.cfg
@@ -3,4 +3,4 @@ friendbot_secret = "SCYBHYXF23Q7QMLNTDVB5USAJ3ODOKA7E6DKUO7UQG53KRO4BLNN5R67"
 network_passphrase = "Test SDF Network ; September 2015"
 horizon_url = "https://horizon-testnet.stellar.org"
 starting_balance = "100.00"
-num_minions = 2
+num_minions = 10

--- a/services/friendbot/friendbot.cfg
+++ b/services/friendbot/friendbot.cfg
@@ -1,6 +1,6 @@
 port = 8000
-friendbot_secret = "SCYBHYXF23Q7QMLNTDVB5USAJ3ODOKA7E6DKUO7UQG53KRO4BLNN5R67"
+friendbot_secret = "SA6WAWCCMRZSEFD5PEN5GK5BHK347YEQ552XZM72NV553TAGWFVHW2G5"
 network_passphrase = "Test SDF Network ; September 2015"
 horizon_url = "https://horizon-testnet.stellar.org"
-starting_balance = "100.00"
-num_minions = 10
+starting_balance = "10000.00"
+num_minions = 100

--- a/services/friendbot/friendbot.cfg
+++ b/services/friendbot/friendbot.cfg
@@ -1,6 +1,6 @@
 port = 8000
-friendbot_secret = "SA6WAWCCMRZSEFD5PEN5GK5BHK347YEQ552XZM72NV553TAGWFVHW2G5"
+friendbot_secret = "SCYBHYXF23Q7QMLNTDVB5USAJ3ODOKA7E6DKUO7UQG53KRO4BLNN5R67"
 network_passphrase = "Test SDF Network ; September 2015"
 horizon_url = "https://horizon-testnet.stellar.org"
-starting_balance = "10000.00"
-num_minions = 1000
+starting_balance = "100.00"
+num_minions = 2

--- a/services/friendbot/friendbot.cfg
+++ b/services/friendbot/friendbot.cfg
@@ -2,5 +2,5 @@ port = 8000
 friendbot_secret = "SA6WAWCCMRZSEFD5PEN5GK5BHK347YEQ552XZM72NV553TAGWFVHW2G5"
 network_passphrase = "Test SDF Network ; September 2015"
 horizon_url = "https://horizon-testnet.stellar.org"
-starting_balance = "9997.00"
+starting_balance = "9999.00"
 num_minions = 100

--- a/services/friendbot/friendbot.cfg
+++ b/services/friendbot/friendbot.cfg
@@ -2,5 +2,5 @@ port = 8000
 friendbot_secret = "SA6WAWCCMRZSEFD5PEN5GK5BHK347YEQ552XZM72NV553TAGWFVHW2G5"
 network_passphrase = "Test SDF Network ; September 2015"
 horizon_url = "https://horizon-testnet.stellar.org"
-starting_balance = "10000.00"
+starting_balance = "9997.00"
 num_minions = 100

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
@@ -43,11 +41,7 @@ func initFriendbot(
 	botKeypair := botKP.(*keypair.Full)
 	botAccount := internal.Account{AccountID: botKeypair.Address()}
 
-	minionBalance, err := getMinionBalance(startingBalance, numMinions)
-	if err != nil {
-		return nil, errors.Wrap(err, "getting minion balance")
-	}
-	minions, err := createMinionAccounts(botAccount, botKeypair, minionBalance, networkPassphrase, numMinions, hclient)
+	minions, err := createMinionAccounts(botAccount, botKeypair, networkPassphrase, numMinions, hclient)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating minion accounts")
 	}
@@ -64,7 +58,7 @@ func initFriendbot(
 
 }
 
-func createMinionAccounts(botAccount txnbuild.Account, botKeypair *keypair.Full, minionBalance, networkPassphrase string, numMinions uint16, hclient *horizonclient.Client) ([]internal.Minion, error) {
+func createMinionAccounts(botAccount txnbuild.Account, botKeypair *keypair.Full, networkPassphrase string, numMinions uint16, hclient *horizonclient.Client) ([]internal.Minion, error) {
 	var (
 		ops     []txnbuild.Operation
 		minions []internal.Minion
@@ -79,13 +73,13 @@ func createMinionAccounts(botAccount txnbuild.Account, botKeypair *keypair.Full,
 		signers = append(signers, minionKeypair)
 
 		minions = append(minions, internal.Minion{
-			SourceAccount: &internal.Account{AccountID: minionKeypair.Address()},
-			Keypair:       minionKeypair,
+			Account: internal.Account{AccountID: minionKeypair.Address()},
+			Keypair: minionKeypair,
 		})
 
 		ops = append(ops, &txnbuild.CreateAccount{
 			Destination: minionKeypair.Address(),
-			Amount:      minionBalance,
+			Amount:      "0.00",
 		})
 	}
 
@@ -104,13 +98,4 @@ func createMinionAccounts(botAccount txnbuild.Account, botKeypair *keypair.Full,
 		return []internal.Minion{}, errors.Wrap(err, "submitting create accounts tx")
 	}
 	return minions, nil
-}
-
-func getMinionBalance(botBalanceStr string, numMinions uint16) (string, error) {
-	botBalanceFloat, err := strconv.ParseFloat(botBalanceStr, 64)
-	if err != nil {
-		return "", errors.Wrap(err, "parsing bot balance")
-	}
-	minionBalanceStr := fmt.Sprintf("%f", botBalanceFloat/float64(numMinions))
-	return minionBalanceStr, nil
 }

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -3,12 +3,14 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 
-	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/services/friendbot/internal"
 	"github.com/stellar/go/strkey"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/txnbuild"
 )
 
 func initFriendbot(
@@ -19,77 +21,96 @@ func initFriendbot(
 	numMinions uint16,
 ) (*internal.Bot, error) {
 	if friendbotSecret == "" || networkPassphrase == "" || horizonURL == "" || startingBalance == "" {
-		// XXX: Check error formatting syntax
-		return nil, fmt.Errorf("invalid input param")
+		return nil, errors.New("invalid input param(s)")
 	}
 
-	// ensure its a seed if its not blank
+	// Guarantee that friendbotSecret is a seed, if not blank.
 	strkey.MustDecode(strkey.VersionByteSeed, friendbotSecret)
 
-	// XXX: Change type
-	hclient := &horizon.Client{
-		URL:     horizonURL,
-		HTTP:    http.DefaultClient,
-		AppName: "friendbot",
+	hclient := &horizonclient.Client{
+		HorizonURL: horizonURL,
+		HTTP:       http.DefaultClient,
+		AppName:    "friendbot",
 	}
 
-	var minions []internal.Minion
-	// XXX: Looping logic discussed with Nikhil
-	for i := 0; i < numMinions; i++ {
-		minionSecret, err := createNewAccount(friendbotSecret, networkPassphrase, hclient)
-		if err != nil {
-			return nil, fmt.Errorf("creating minion account", err)
-		}
-		minions = append(minions, internal.Minion{
-			Secret:       minionSecret,
-			DestAddrChan: make(chan string),
-			TxResultChan: make(chan internal.TxResult),
-		})
+	botKP, err := keypair.Parse(friendbotSecret)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing bot keypair")
+	}
+
+	// Casting from the interface type will work, since we
+	// already confirmed that friendbotSecret is a seed.
+	botKeypair := botKP.(*keypair.Full)
+	botAccount := internal.Account{AccountID: botKeypair.Address()}
+
+	minionBalance, err := getMinionBalance(startingBalance, numMinions)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting minion balance")
+	}
+	minions, err := createMinionAccounts(botAccount, botKeypair, minionBalance, networkPassphrase, numMinions, hclient)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating minion accounts")
 	}
 
 	return &internal.Bot{
-		Secret:            friendbotSecret,
 		Horizon:           hclient,
+		Account:           botAccount,
+		Keypair:           botKeypair,
 		Network:           networkPassphrase,
 		StartingBalance:   startingBalance,
 		SubmitTransaction: internal.AsyncSubmitTransaction,
 		Minions:           minions,
 	}, nil
+
 }
 
-// XXX: Change horizon Client type
-// XXX: Rewrite to return a list and take in a number of secret keys
-func createNewAccount(sourceSeed, networkPassphrase string, hclient *horizon.Client) (string, error) {
-	kp, err := keypair.Random()
-	if err != nil {
-		return "", fmt.Errorf("creating keypair", err)
-	}
-	destAddr := kp.Address()
-	// XXX: Create tx without CreateAccount
-	tx, err := build.Transaction(
-		build.SourceAccount{AddressOrSeed: sourceSeed},
-		build.Network{Passphrase: networkPassphrase},
-		build.AutoSequence{SequenceProvider: hclient},
-		// XXX: See Nikhil PR comment
-		build.CreateAccount(
-			build.Destination{AddressOrSeed: destAddr},
-			// XXX: Add StartingBalance here
-		),
+func createMinionAccounts(botAccount txnbuild.Account, botKeypair *keypair.Full, minionBalance, networkPassphrase string, numMinions uint16, hclient *horizonclient.Client) ([]internal.Minion, error) {
+	var (
+		ops     []txnbuild.Operation
+		minions []internal.Minion
 	)
-	// XXX: Loop over tx and add CreateAccount ops
+	signers := []*keypair.Full{botKeypair}
 
-	txe, err := tx.Sign(sourceSeed)
-	if err != nil {
-		return "", fmt.Errorf("signing tx", err)
+	for i := uint16(0); i < numMinions; i++ {
+		minionKeypair, err := keypair.Random()
+		if err != nil {
+			return []internal.Minion{}, errors.Wrap(err, "making keypair")
+		}
+		signers = append(signers, minionKeypair)
+
+		minions = append(minions, internal.Minion{
+			SourceAccount: &internal.Account{AccountID: minionKeypair.Address()},
+			Keypair:       minionKeypair,
+		})
+
+		ops = append(ops, &txnbuild.CreateAccount{
+			Destination: minionKeypair.Address(),
+			Amount:      minionBalance,
+		})
 	}
 
-	txeB64, err := txe.Base64()
-	if err != nil {
-		return "", fmt.Errorf("converting to base 64", err)
+	txn := txnbuild.Transaction{
+		SourceAccount: botAccount,
+		Operations:    ops,
+		Timebounds:    txnbuild.NewTimebounds(0, 300),
+		Network:       networkPassphrase,
 	}
-	_, err = hclient.SubmitTransaction(txeB64)
+	txe, err := txn.BuildSignEncode(signers...)
 	if err != nil {
-		return "", fmt.Errorf("submitting tx", err)
+		return []internal.Minion{}, errors.Wrap(err, "making create accounts tx")
 	}
-	return destKeypair.Seed(), nil
+	_, err = hclient.SubmitTransactionXDR(txe)
+	if err != nil {
+		return []internal.Minion{}, errors.Wrap(err, "submitting create accounts tx")
+	}
+	return minions, nil
+}
+
+func getMinionBalance(botBalanceStr string, numMinions uint16) (string, error) {
+	botBalanceFloat, err := strconv.ParseFloat(botBalanceStr, 64)
+	if err != nil {
+		return "", errors.Wrap(err, "parsing bot balance")
+	}
+	minionBalanceStr := fmt.Sprintf("%f", botBalanceFloat/float64(numMinions))
+	return minionBalanceStr, nil
 }

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -16,9 +16,9 @@ func initFriendbot(
 	networkPassphrase string,
 	horizonURL string,
 	startingBalance string,
-	numMinions uint16,
+	numMinions int,
 ) (*internal.Bot, error) {
-	if friendbotSecret == "" || networkPassphrase == "" || horizonURL == "" || startingBalance == "" {
+	if friendbotSecret == "" || networkPassphrase == "" || horizonURL == "" || startingBalance == "" || numMinions < 0 {
 		return nil, errors.New("invalid input param(s)")
 	}
 
@@ -58,14 +58,14 @@ func initFriendbot(
 
 }
 
-func createMinionAccounts(botAccount txnbuild.Account, botKeypair *keypair.Full, networkPassphrase string, numMinions uint16, hclient *horizonclient.Client) ([]internal.Minion, error) {
+func createMinionAccounts(botAccount txnbuild.Account, botKeypair *keypair.Full, networkPassphrase string, numMinions int, hclient *horizonclient.Client) ([]internal.Minion, error) {
 	var (
 		ops     []txnbuild.Operation
 		minions []internal.Minion
 	)
 	signers := []*keypair.Full{botKeypair}
 
-	for i := uint16(0); i < numMinions; i++ {
+	for i := 0; i < numMinions; i++ {
 		minionKeypair, err := keypair.Random()
 		if err != nil {
 			return []internal.Minion{}, errors.Wrap(err, "making keypair")

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -54,10 +54,7 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 	numRemainingMinions := numMinions
 	minionBatchSize := 100
 	for numRemainingMinions > 0 {
-		var (
-			ops        []txnbuild.Operation
-			newMinions []internal.Minion
-		)
+		var ops []txnbuild.Operation
 		// Refresh the sequence number before submitting a new transaction.
 		err := botAccount.RefreshSequenceNumber(hclient)
 		if err != nil {
@@ -90,7 +87,6 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 			})
 		}
 		numRemainingMinions -= numCreateMinions
-		minions = append(minions, newMinions...)
 
 		// Build and submit batched account creation tx.
 		txn := txnbuild.Transaction{

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -40,76 +40,78 @@ func initFriendbot(
 	// already confirmed that friendbotSecret is a seed.
 	botKeypair := botKP.(*keypair.Full)
 	botAccount := internal.Account{AccountID: botKeypair.Address()}
-	err = botAccount.RefreshSequenceNumber(hclient)
+	minionBalance := "10.0"
+	minions, err := createMinionAccounts(botAccount, botKeypair, networkPassphrase, startingBalance, minionBalance, numMinions, hclient)
 	if err != nil {
-		return nil, errors.Wrap(err, "refreshing bot seqnum")
+		return nil, errors.Wrap(err, "creating minion accounts")
 	}
 
-	// Create Minions in batches of 100.
+	// Launch long-running go routine per-Minion.
+	for _, minion := range minions {
+		go minion.Run()
+	}
+	return &internal.Bot{Minions: minions}, nil
+}
+
+func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full, networkPassphrase, newAccountBalance, minionBalance string, numMinions int, hclient *horizonclient.Client) ([]internal.Minion, error) {
 	var minions []internal.Minion
 	numRemainingMinions := numMinions
 	minionBatchSize := 100
 	for numRemainingMinions > 0 {
+		var (
+			ops        []txnbuild.Operation
+			newMinions []internal.Minion
+		)
+		// Refresh the sequence number before submitting a new transaction.
+		err := botAccount.RefreshSequenceNumber(hclient)
+		if err != nil {
+			return nil, errors.Wrap(err, "refreshing bot seqnum")
+		}
+		// The tx will create min(numRemainingMinions, 100) Minion accounts.
 		numCreateMinions := minionBatchSize
 		if numRemainingMinions < minionBatchSize {
 			numCreateMinions = numRemainingMinions
 		}
-		newMinions, err := createMinionAccounts(botAccount, botKeypair, networkPassphrase, numCreateMinions, hclient)
-		if err != nil {
-			return nil, errors.Wrap(err, "creating minion accounts")
+		for i := 0; i < numCreateMinions; i++ {
+			minionKeypair, err := keypair.Random()
+			if err != nil {
+				return []internal.Minion{}, errors.Wrap(err, "making keypair")
+			}
+			minions = append(minions, internal.Minion{
+				Account:           internal.Account{AccountID: minionKeypair.Address()},
+				Keypair:           minionKeypair,
+				BotAccount:        botAccount,
+				BotKeypair:        botKeypair,
+				Horizon:           hclient,
+				Network:           networkPassphrase,
+				StartingBalance:   newAccountBalance,
+				InputChan:         make(chan internal.MinionInput),
+				SubmitTransaction: internal.SubmitTransaction,
+			})
+
+			ops = append(ops, &txnbuild.CreateAccount{
+				Destination: minionKeypair.Address(),
+				Amount:      minionBalance,
+			})
 		}
-		minions = append(minions, newMinions...)
 		numRemainingMinions -= numCreateMinions
-	}
+		minions = append(minions, newMinions...)
 
-	return &internal.Bot{
-		Horizon:           hclient,
-		Account:           botAccount,
-		Keypair:           botKeypair,
-		Network:           networkPassphrase,
-		StartingBalance:   startingBalance,
-		SubmitTransaction: internal.AsyncSubmitTransaction,
-		Minions:           minions,
-	}, nil
-
-}
-
-func createMinionAccounts(botAccount txnbuild.Account, botKeypair *keypair.Full, networkPassphrase string, numMinions int, hclient *horizonclient.Client) ([]internal.Minion, error) {
-	var (
-		ops     []txnbuild.Operation
-		minions []internal.Minion
-	)
-
-	for i := 0; i < numMinions; i++ {
-		minionKeypair, err := keypair.Random()
-		if err != nil {
-			return []internal.Minion{}, errors.Wrap(err, "making keypair")
+		// Build and submit batched account creation tx.
+		txn := txnbuild.Transaction{
+			SourceAccount: botAccount,
+			Operations:    ops,
+			Timebounds:    txnbuild.NewTimeout(300),
+			Network:       networkPassphrase,
 		}
-
-		minions = append(minions, internal.Minion{
-			Account: internal.Account{AccountID: minionKeypair.Address()},
-			Keypair: minionKeypair,
-		})
-
-		ops = append(ops, &txnbuild.CreateAccount{
-			Destination: minionKeypair.Address(),
-			Amount:      "0.00",
-		})
-	}
-
-	txn := txnbuild.Transaction{
-		SourceAccount: botAccount,
-		Operations:    ops,
-		Timebounds:    txnbuild.NewTimebounds(0, 300),
-		Network:       networkPassphrase,
-	}
-	txe, err := txn.BuildSignEncode(botKeypair)
-	if err != nil {
-		return []internal.Minion{}, errors.Wrap(err, "making create accounts tx")
-	}
-	_, err = hclient.SubmitTransactionXDR(txe)
-	if err != nil {
-		return []internal.Minion{}, errors.Wrap(err, "submitting create accounts tx")
+		txe, err := txn.BuildSignEncode(botKeypair)
+		if err != nil {
+			return []internal.Minion{}, errors.Wrap(err, "making create accounts tx")
+		}
+		_, err = hclient.SubmitTransactionXDR(txe)
+		if err != nil {
+			return []internal.Minion{}, errors.Wrap(err, "submitting create accounts tx")
+		}
 	}
 	return minions, nil
 }

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/stellar/go/clients/horizonclient"
@@ -40,7 +41,7 @@ func initFriendbot(
 	// already confirmed that friendbotSecret is a seed.
 	botKeypair := botKP.(*keypair.Full)
 	botAccount := internal.Account{AccountID: botKeypair.Address()}
-	minionBalance := "1000000.00" // Each channel account is given 1M testnet XLM to cover base balances and fees.
+	minionBalance := "101.00"
 	minions, err := createMinionAccounts(botAccount, botKeypair, networkPassphrase, startingBalance, minionBalance, numMinions, hclient)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating minion accounts")
@@ -99,8 +100,9 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 		if err != nil {
 			return []internal.Minion{}, errors.Wrap(err, "making create accounts tx")
 		}
-		_, err = hclient.SubmitTransactionXDR(txe)
+		resp, err := hclient.SubmitTransactionXDR(txe)
 		if err != nil {
+			log.Print(resp)
 			return []internal.Minion{}, errors.Wrap(err, "submitting create accounts tx")
 		}
 	}

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -40,10 +40,26 @@ func initFriendbot(
 	// already confirmed that friendbotSecret is a seed.
 	botKeypair := botKP.(*keypair.Full)
 	botAccount := internal.Account{AccountID: botKeypair.Address()}
-
-	minions, err := createMinionAccounts(botAccount, botKeypair, networkPassphrase, numMinions, hclient)
+	err = botAccount.RefreshSequenceNumber(hclient)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating minion accounts")
+		return nil, errors.Wrap(err, "refreshing bot seqnum")
+	}
+
+	// Create Minions in batches of 100.
+	var minions []internal.Minion
+	numRemainingMinions := numMinions
+	minionBatchSize := 100
+	for numRemainingMinions > 0 {
+		numCreateMinions := minionBatchSize
+		if numRemainingMinions < minionBatchSize {
+			numCreateMinions = numRemainingMinions
+		}
+		newMinions, err := createMinionAccounts(botAccount, botKeypair, networkPassphrase, numCreateMinions, hclient)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating minion accounts")
+		}
+		minions = append(minions, newMinions...)
+		numRemainingMinions -= numCreateMinions
 	}
 
 	return &internal.Bot{
@@ -63,14 +79,12 @@ func createMinionAccounts(botAccount txnbuild.Account, botKeypair *keypair.Full,
 		ops     []txnbuild.Operation
 		minions []internal.Minion
 	)
-	signers := []*keypair.Full{botKeypair}
 
 	for i := 0; i < numMinions; i++ {
 		minionKeypair, err := keypair.Random()
 		if err != nil {
 			return []internal.Minion{}, errors.Wrap(err, "making keypair")
 		}
-		signers = append(signers, minionKeypair)
 
 		minions = append(minions, internal.Minion{
 			Account: internal.Account{AccountID: minionKeypair.Address()},
@@ -89,7 +103,7 @@ func createMinionAccounts(botAccount txnbuild.Account, botKeypair *keypair.Full,
 		Timebounds:    txnbuild.NewTimebounds(0, 300),
 		Network:       networkPassphrase,
 	}
-	txe, err := txn.BuildSignEncode(signers...)
+	txe, err := txn.BuildSignEncode(botKeypair)
 	if err != nil {
 		return []internal.Minion{}, errors.Wrap(err, "making create accounts tx")
 	}

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -3,7 +3,9 @@ package main
 import (
 	"net/http"
 
+	"github.com/stellar/go/build"
 	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/services/friendbot/internal"
 	"github.com/stellar/go/strkey"
 )
@@ -13,24 +15,71 @@ func initFriendbot(
 	networkPassphrase string,
 	horizonURL string,
 	startingBalance string,
+	numMinions int,
 ) *internal.Bot {
-
-	if friendbotSecret == "" || networkPassphrase == "" || horizonURL == "" || startingBalance == "" {
+	if friendbotSecret == "" || networkPassphrase == "" || horizonURL == "" || startingBalance == "" || numMinions < 0 {
 		return nil
 	}
 
 	// ensure its a seed if its not blank
 	strkey.MustDecode(strkey.VersionByteSeed, friendbotSecret)
 
+	hclient := &horizon.Client{
+		URL:     horizonURL,
+		HTTP:    http.DefaultClient,
+		AppName: "friendbot",
+	}
+
+	minions := make([]internal.Minion, numMinions)
+	for i := 0; i < numMinions; i++ {
+		minionSecret, err := createNewAccount(friendbotSecret, networkPassphrase, hclient)
+		if err != nil {
+			return nil
+		}
+		minions = append(minions, internal.Minion{
+			Secret:       minionSecret,
+			DestAddrChan: make(chan string),
+			TxResultChan: make(chan internal.TxResult),
+		})
+	}
+
 	return &internal.Bot{
-		Secret: friendbotSecret,
-		Horizon: &horizon.Client{
-			URL:     horizonURL,
-			HTTP:    http.DefaultClient,
-			AppName: "friendbot",
-		},
+		Secret:            friendbotSecret,
+		Horizon:           hclient,
 		Network:           networkPassphrase,
 		StartingBalance:   startingBalance,
 		SubmitTransaction: internal.AsyncSubmitTransaction,
+		Minions:           minions,
 	}
+}
+
+func createNewAccount(sourceSeed, networkPassphrase string, hclient *horizon.Client) (string, error) {
+	destKeypair, err := keypair.Random()
+	if err != nil {
+		return "", nil
+	}
+	destAddr := destKeypair.Address()
+	tx, err := build.Transaction(
+		build.SourceAccount{AddressOrSeed: sourceSeed},
+		build.Network{Passphrase: networkPassphrase},
+		build.AutoSequence{SequenceProvider: hclient},
+		build.CreateAccount(
+			build.Destination{AddressOrSeed: destAddr},
+		),
+	)
+
+	txe, err := tx.Sign(sourceSeed)
+	if err != nil {
+		return "", nil
+	}
+
+	txeB64, err := txe.Base64()
+	if err != nil {
+		return "", nil
+	}
+	_, err = hclient.SubmitTransaction(txeB64)
+	if err != nil {
+		return "", nil
+	}
+	return destKeypair.Seed(), nil
 }

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"log"
 	"net/http"
 
 	"github.com/stellar/go/clients/horizonclient"
@@ -47,8 +49,10 @@ func initFriendbot(
 	}
 
 	// Launch long-running go routine per-Minion.
+	ctx := context.Background()
 	for _, minion := range minions {
-		go minion.Run()
+		log.Printf("launching Run on minion %v", minion)
+		go minion.Run(ctx)
 	}
 	return &internal.Bot{Minions: minions}, nil
 }
@@ -85,7 +89,7 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 				Horizon:           hclient,
 				Network:           networkPassphrase,
 				StartingBalance:   newAccountBalance,
-				InputChan:         make(chan internal.MinionInput),
+				InputChan:         make(chan internal.MinionInput, 1),
 				SubmitTransaction: internal.SubmitTransaction,
 			})
 
@@ -110,6 +114,13 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 		}
 		_, err = hclient.SubmitTransactionXDR(txe)
 		if err != nil {
+			// XXX: Remove debug switch.
+			switch e := err.(type) {
+			case *horizonclient.Error:
+				resCode, _ := e.ResultCodes()
+				log.Print(resCode.TransactionCode)
+				log.Print(resCode.OperationCodes)
+			}
 			return []internal.Minion{}, errors.Wrap(err, "submitting create accounts tx")
 		}
 	}

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/stellar/go/build"
@@ -15,26 +16,29 @@ func initFriendbot(
 	networkPassphrase string,
 	horizonURL string,
 	startingBalance string,
-	numMinions int,
-) *internal.Bot {
-	if friendbotSecret == "" || networkPassphrase == "" || horizonURL == "" || startingBalance == "" || numMinions < 0 {
-		return nil
+	numMinions uint16,
+) (*internal.Bot, error) {
+	if friendbotSecret == "" || networkPassphrase == "" || horizonURL == "" || startingBalance == "" {
+		// XXX: Check error formatting syntax
+		return nil, fmt.Errorf("invalid input param")
 	}
 
 	// ensure its a seed if its not blank
 	strkey.MustDecode(strkey.VersionByteSeed, friendbotSecret)
 
+	// XXX: Change type
 	hclient := &horizon.Client{
 		URL:     horizonURL,
 		HTTP:    http.DefaultClient,
 		AppName: "friendbot",
 	}
 
-	minions := make([]internal.Minion, numMinions)
+	var minions []internal.Minion
+	// XXX: Looping logic discussed with Nikhil
 	for i := 0; i < numMinions; i++ {
 		minionSecret, err := createNewAccount(friendbotSecret, networkPassphrase, hclient)
 		if err != nil {
-			return nil
+			return nil, fmt.Errorf("creating minion account", err)
 		}
 		minions = append(minions, internal.Minion{
 			Secret:       minionSecret,
@@ -50,36 +54,42 @@ func initFriendbot(
 		StartingBalance:   startingBalance,
 		SubmitTransaction: internal.AsyncSubmitTransaction,
 		Minions:           minions,
-	}
+	}, nil
 }
 
+// XXX: Change horizon Client type
+// XXX: Rewrite to return a list and take in a number of secret keys
 func createNewAccount(sourceSeed, networkPassphrase string, hclient *horizon.Client) (string, error) {
-	destKeypair, err := keypair.Random()
+	kp, err := keypair.Random()
 	if err != nil {
-		return "", nil
+		return "", fmt.Errorf("creating keypair", err)
 	}
-	destAddr := destKeypair.Address()
+	destAddr := kp.Address()
+	// XXX: Create tx without CreateAccount
 	tx, err := build.Transaction(
 		build.SourceAccount{AddressOrSeed: sourceSeed},
 		build.Network{Passphrase: networkPassphrase},
 		build.AutoSequence{SequenceProvider: hclient},
+		// XXX: See Nikhil PR comment
 		build.CreateAccount(
 			build.Destination{AddressOrSeed: destAddr},
+			// XXX: Add StartingBalance here
 		),
 	)
+	// XXX: Loop over tx and add CreateAccount ops
 
 	txe, err := tx.Sign(sourceSeed)
 	if err != nil {
-		return "", nil
+		return "", fmt.Errorf("signing tx", err)
 	}
 
 	txeB64, err := txe.Base64()
 	if err != nil {
-		return "", nil
+		return "", fmt.Errorf("converting to base 64", err)
 	}
 	_, err = hclient.SubmitTransaction(txeB64)
 	if err != nil {
-		return "", nil
+		return "", fmt.Errorf("submitting tx", err)
 	}
 	return destKeypair.Seed(), nil
 }

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -40,7 +40,7 @@ func initFriendbot(
 	// already confirmed that friendbotSecret is a seed.
 	botKeypair := botKP.(*keypair.Full)
 	botAccount := internal.Account{AccountID: botKeypair.Address()}
-	minionBalance := "10.0"
+	minionBalance := "1000000.00" // Each channel account is given 1M testnet XLM to cover base balances and fees.
 	minions, err := createMinionAccounts(botAccount, botKeypair, networkPassphrase, startingBalance, minionBalance, numMinions, hclient)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating minion accounts")

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"context"
-	"log"
 	"net/http"
 
 	"github.com/stellar/go/clients/horizonclient"
@@ -48,12 +46,6 @@ func initFriendbot(
 		return nil, errors.Wrap(err, "creating minion accounts")
 	}
 
-	// Launch long-running go routine per-Minion.
-	ctx := context.Background()
-	for _, minion := range minions {
-		log.Printf("launching Run on minion %v", minion)
-		go minion.Run(ctx)
-	}
 	return &internal.Bot{Minions: minions}, nil
 }
 
@@ -89,7 +81,6 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 				Horizon:           hclient,
 				Network:           networkPassphrase,
 				StartingBalance:   newAccountBalance,
-				InputChan:         make(chan internal.MinionInput, 1),
 				SubmitTransaction: internal.SubmitTransaction,
 			})
 
@@ -114,13 +105,6 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 		}
 		_, err = hclient.SubmitTransactionXDR(txe)
 		if err != nil {
-			// XXX: Remove debug switch.
-			switch e := err.(type) {
-			case *horizonclient.Error:
-				resCode, _ := e.ResultCodes()
-				log.Print(resCode.TransactionCode)
-				log.Print(resCode.OperationCodes)
-			}
 			return []internal.Minion{}, errors.Wrap(err, "submitting create accounts tx")
 		}
 	}

--- a/services/friendbot/internal/account.go
+++ b/services/friendbot/internal/account.go
@@ -1,0 +1,42 @@
+package internal
+
+import (
+	"strconv"
+
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+// Account implements the `txnbuild.Account` interface.
+type Account struct {
+	AccountID string
+	Sequence  xdr.SequenceNumber
+}
+
+// GetAccountID returns the Account ID.
+func (a Account) GetAccountID() string {
+	return a.AccountID
+}
+
+// IncrementSequenceNumber increments the internal record of the
+// account's sequence number by 1.
+func (a Account) IncrementSequenceNumber() (xdr.SequenceNumber, error) {
+	a.Sequence++
+	return a.Sequence, nil
+}
+
+// RefreshSequenceNumber gets an Account's correct in-memory sequence number from Horizon.
+func (a *Account) RefreshSequenceNumber(hclient *horizonclient.Client) error {
+	accountRequest := horizonclient.AccountRequest{AccountID: a.GetAccountID()}
+	accountDetail, err := hclient.AccountDetail(accountRequest)
+	if err != nil {
+		return errors.Wrap(err, "getting account detail")
+	}
+	seq, err := strconv.ParseInt(accountDetail.Sequence, 10, 64)
+	if err != nil {
+		return errors.Wrap(err, "parsing account seqnum")
+	}
+	a.Sequence = xdr.SequenceNumber(seq)
+	return nil
+}

--- a/services/friendbot/internal/friendbot.go
+++ b/services/friendbot/internal/friendbot.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/clients/horizonclient"
-	b "github.com/stellar/go/exp/txnbuild"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/support/errors"
+	b "github.com/stellar/go/txnbuild"
 )
 
 // Minion contains a Stellar channel account and Go channels to communicate with friendbot.
 type Minion struct {
+	// XXX: Change to Account
 	Secret string
 	// XXX: Rename field
 	txInputChan chan TxInput
@@ -143,7 +144,26 @@ func (minion *Minion) checkSequenceRefresh(hclient *horizonclient.Client) error 
 	return minion.refreshSequence(hclient)
 }
 
-func (minion *Minion) makeTx(input TxInput) (string, error) {
+func (minion *Minion) makeTx(input TxInput) error {
+
+	createAccountOp := b.CreateAccount{
+		Destination: input.destAddress,
+		Amount:      "0.00", // XXX: Should this be input.startingBalance?
+	}
+	// XXX: Source acct for payment should be friendbot, not Stellar channel account.
+	paymentOp := b.Payment{
+		Destination: input.destAddress,
+		Amount:      input.startingBalance,
+		Asset:       b.NativeAsset{},
+	}
+	txn := b.Transaction{
+		SourceAccount: minion.SourceAccount,
+		Operations:    []b.Operation{&createAccountOp, &paymentOp},
+		Network:       input.network,
+	}
+}
+
+func (minion *Minion) makeTxOld(input TxInput) (string, error) {
 	txnOld, err := b.Transaction(
 		b.SourceAccount{AddressOrSeed: minion.Secret},
 		b.Sequence{Sequence: minion.sequence + 1},

--- a/services/friendbot/internal/friendbot.go
+++ b/services/friendbot/internal/friendbot.go
@@ -1,201 +1,37 @@
 package internal
 
 import (
-	"strconv"
-
-	"github.com/stellar/go/clients/horizonclient"
-	"github.com/stellar/go/keypair"
 	hProtocol "github.com/stellar/go/protocols/horizon"
-	"github.com/stellar/go/support/errors"
-	"github.com/stellar/go/txnbuild"
-	"github.com/stellar/go/xdr"
 )
 
-// Account implements the `txnbuild.Account` interface.
-type Account struct {
-	AccountID string
-	Sequence  xdr.SequenceNumber
-}
-
-// GetAccountID returns the Account ID.
-func (a Account) GetAccountID() string {
-	return a.AccountID
-}
-
-// IncrementSequenceNumber increments the internal record of the
-// account's sequence number by 1.
-func (a Account) IncrementSequenceNumber() (xdr.SequenceNumber, error) {
-	a.Sequence++
-	return a.Sequence, nil
-}
-
-// RefreshSequenceNumber gets an Account's correct in-memory sequence number from Horizon.
-func (a Account) RefreshSequenceNumber(hclient *horizonclient.Client) error {
-	accountRequest := horizonclient.AccountRequest{AccountID: a.GetAccountID()}
-	accountDetail, err := hclient.AccountDetail(accountRequest)
-	if err != nil {
-		return errors.Wrap(err, "getting account detail")
-	}
-	seq, err := strconv.ParseInt(accountDetail.Sequence, 10, 64)
-	if err != nil {
-		return errors.Wrap(err, "parsing account seqnum")
-	}
-	a.Sequence = xdr.SequenceNumber(seq)
-	return nil
-}
-
-// Minion contains a Stellar channel account and Go channels to communicate with friendbot.
-type Minion struct {
-	Account Account
-	Keypair *keypair.Full
-
-	// Uninitialized.
-	forceRefreshSequence bool
+// Bot represents the friendbot subsystem and primarily delegates work
+// to its Minions.
+type Bot struct {
+	Minions         []Minion
+	nextMinionIndex int
 }
 
 // MinionInput is the input to the Minion from the Bot to construct a payment.
 type MinionInput struct {
-	botAccount      txnbuild.Account
-	botKeypair      *keypair.Full
-	destAddress     string
-	network         string
-	startingBalance string
+	destAddress string
+	resultChan  chan SubmitResult
 }
 
-// TxResult is the result from the asynchronous payment tx construction method.
-type TxResult struct {
-	maybeTxXDR *string
-	maybeErr   error
-}
-
-// SubmitResult is the result from the asynchronous submit transaction method over a channel.
+// SubmitResult is the result from the asynchronous tx submission.
 type SubmitResult struct {
 	maybeTransactionSuccess *hProtocol.TransactionSuccess
 	maybeErr                error
 }
 
-// Bot represents the friendbot subsystem.
-type Bot struct {
-	Horizon           *horizonclient.Client
-	Account           txnbuild.Account
-	Keypair           *keypair.Full
-	Network           string
-	StartingBalance   string
-	SubmitTransaction func(minion *Minion, channel chan SubmitResult, hclient *horizonclient.Client, signed string)
-	Minions           []Minion
-	nextMinionIndex   int
-}
-
 // Pay funds the account at `destAddress`.
 func (bot *Bot) Pay(destAddress string) (*hProtocol.TransactionSuccess, error) {
 	minion := bot.Minions[bot.nextMinionIndex]
-	// XXX: Launch separate thread, potentially.
-	input := MinionInput{
-		destAddress:     destAddress,
-		botAccount:      bot.Account,
-		botKeypair:      bot.Keypair,
-		network:         bot.Network,
-		startingBalance: bot.StartingBalance,
+	resultChan := make(chan SubmitResult)
+	minion.InputChan <- MinionInput{
+		destAddress: destAddress,
+		resultChan:  resultChan,
 	}
-
-	txResultChan := make(chan TxResult)
-	go minion.run(bot.Horizon, input, txResultChan)
-	maybeTxResult := <-txResultChan
-	if maybeTxResult.maybeErr != nil {
-		return nil, errors.Wrap(maybeTxResult.maybeErr, "making tx")
-	}
-
-	submitResultChan := make(chan SubmitResult)
-	go bot.SubmitTransaction(&minion, submitResultChan, bot.Horizon, *maybeTxResult.maybeTxXDR)
 	bot.nextMinionIndex = (bot.nextMinionIndex + 1) % len(bot.Minions)
-
-	maybeSubmitResult := <-submitResultChan
+	maybeSubmitResult := <-resultChan
 	return maybeSubmitResult.maybeTransactionSuccess, maybeSubmitResult.maybeErr
-}
-
-// AsyncSubmitTransaction should be passed to the bot.
-func AsyncSubmitTransaction(minion *Minion, channel chan SubmitResult, hclient *horizonclient.Client, txXDR string) {
-	result, err := hclient.SubmitTransactionXDR(txXDR)
-	if err != nil {
-		switch e := err.(type) {
-		case *horizonclient.Error:
-			minion.checkHandleBadSequence(e)
-		}
-
-		channel <- SubmitResult{
-			maybeTransactionSuccess: nil,
-			maybeErr:                err,
-		}
-	} else {
-		channel <- SubmitResult{
-			maybeTransactionSuccess: &result,
-			maybeErr:                nil,
-		}
-	}
-}
-
-func (minion *Minion) run(hclient *horizonclient.Client, input MinionInput, channel chan TxResult) {
-	err := minion.checkSequenceRefresh(hclient)
-	if err != nil {
-		channel <- TxResult{
-			maybeTxXDR: nil,
-			maybeErr:   errors.Wrap(err, "checking minion seq"),
-		}
-	}
-	txStr, err := minion.makeTx(input)
-	channel <- TxResult{
-		maybeTxXDR: txStr,
-		maybeErr:   errors.Wrap(err, "making payment tx"),
-	}
-}
-
-func (minion *Minion) checkHandleBadSequence(err *horizonclient.Error) {
-	resCode, e := err.ResultCodes()
-	isTxBadSeqCode := e == nil && resCode.TransactionCode == "tx_bad_seq"
-	if !isTxBadSeqCode {
-		return
-	}
-	minion.forceRefreshSequence = true
-}
-
-// Establishes the minion's initial sequence number, if needed.
-func (minion *Minion) checkSequenceRefresh(hclient *horizonclient.Client) error {
-	if minion.Account.Sequence != 0 && !minion.forceRefreshSequence {
-		return nil
-	}
-	err := minion.Account.RefreshSequenceNumber(hclient)
-	if err != nil {
-		return errors.Wrap(err, "refreshing minion seqnum")
-	}
-	minion.forceRefreshSequence = false
-	return nil
-}
-
-func (minion *Minion) makeTx(input MinionInput) (*string, error) {
-	createAccountOp := txnbuild.CreateAccount{
-		Destination: input.destAddress,
-		Amount:      input.startingBalance,
-	}
-	paymentOp := txnbuild.Payment{
-		Destination:   input.destAddress,
-		Amount:        input.startingBalance,
-		Asset:         txnbuild.NativeAsset{},
-		SourceAccount: input.botAccount,
-	}
-	txn := txnbuild.Transaction{
-		SourceAccount: minion.Account,
-		Operations:    []txnbuild.Operation{&createAccountOp, &paymentOp},
-		Network:       input.network,
-		Timebounds:    txnbuild.NewTimebounds(0, 300),
-	}
-	txe, err := txn.BuildSignEncode(minion.Keypair, input.botKeypair)
-	if err != nil {
-		return nil, errors.Wrap(err, "making account payment tx")
-	}
-	// Increment the in-memory sequence number, since the tx will be submitted.
-	_, err = minion.Account.IncrementSequenceNumber()
-	if err != nil {
-		return nil, errors.Wrap(err, "incrementing minion seq")
-	}
-	return &txe, err
 }

--- a/services/friendbot/internal/friendbot.go
+++ b/services/friendbot/internal/friendbot.go
@@ -3,25 +3,41 @@ package internal
 import (
 	"strconv"
 
-	b "github.com/stellar/go/build"
 	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
+	b "github.com/stellar/go/exp/txnbuild"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/support/errors"
 )
 
 // Minion contains a Stellar channel account and Go channels to communicate with friendbot.
 type Minion struct {
-	Secret       string
-	DestAddrChan chan string
-	TxResultChan chan TxResult
+	Secret string
+	// XXX: Rename field
+	txInputChan chan TxInput
 
 	// Uninitialized.
 	sequence             uint64
 	forceRefreshSequence bool
 }
 
-// TxResult is the result from the asynchronous submit transaction method over a channel.
+// TxInput is the input to the Minion for constructing a payment transaction.
+type TxInput struct {
+	destAddress     string
+	botSecret       string
+	network         string
+	startingBalance string
+}
+
+// TxResult is the result from the asynchronous payment tx construction method.
 type TxResult struct {
+	// XXX: Check type
+	maybeTransaction *string
+	maybeErr         error
+}
+
+// SubmitResult is the result from the asynchronous submit transaction method over a channel.
+type SubmitResult struct {
 	// XXX: Change this
 	maybeTransactionSuccess *horizon.TransactionSuccess
 	maybeErr                error
@@ -29,13 +45,11 @@ type TxResult struct {
 
 // Bot represents the friendbot subsystem.
 type Bot struct {
-	// XXX: Change this type
-	Horizon         *horizon.Client
-	Secret          string
-	Network         string
-	StartingBalance string
-	// XXX: Change hclient type
-	SubmitTransaction func(minion *Minion, hclient *horizon.Client, signed string)
+	Horizon           *horizonclient.Client
+	Secret            string
+	Network           string
+	StartingBalance   string
+	SubmitTransaction func(minion *Minion, channel chan SubmitResult, hclient *horizonclient.Client, signed string)
 	Minions           []Minion
 	nextMinionIndex   int
 }
@@ -44,25 +58,32 @@ type Bot struct {
 // XXX: Change return type
 func (bot *Bot) Pay(destAddress string) (*horizon.TransactionSuccess, error) {
 	minion := bot.Minions[bot.nextMinionIndex]
-	err := minion.checkSequenceRefresh(bot.Horizon)
-	if err != nil {
-		return nil, err
+	// XXX: Launch separate thread
+	input := TxInput{
+		destAddress:     destAddress,
+		botSecret:       bot.Secret,
+		network:         bot.Network,
+		startingBalance: bot.StartingBalance,
 	}
 
-	signed, err := minion.makeTx(destAddress, bot.Secret, bot.Network, bot.StartingBalance)
-	if err != nil {
-		return nil, err
+	txResultChan := make(chan TxResult)
+	go minion.run(bot.Horizon, input, txResultChan)
+	maybeTxResult := <-txResultChan
+	if maybeTxResult.maybeErr != nil {
+		return nil, errors.Wrap(maybeTxResult.maybeErr, "making tx")
 	}
-	go bot.SubmitTransaction(&minion, bot.Horizon, signed)
+
+	submitResultChan := make(chan SubmitResult)
+	go bot.SubmitTransaction(&minion, submitResultChan, bot.Horizon, *maybeTxResult.maybeTransaction)
 	bot.nextMinionIndex = (bot.nextMinionIndex + 1) % len(bot.Minions)
 
-	v := <-minion.TxResultChan
-	return v.maybeTransactionSuccess, v.maybeErr
+	maybeSubmitResult := <-submitResultChan
+	return maybeSubmitResult.maybeTransactionSuccess, maybeSubmitResult.maybeErr
 }
 
 // AsyncSubmitTransaction should be passed to the bot.
-// XXX: Change second argument type
-func AsyncSubmitTransaction(minion *Minion, hclient *horizon.Client, signed string) {
+func AsyncSubmitTransaction(minion *Minion, channel chan SubmitResult, hclient *horizonclient.Client, signed string) {
+	// XXX: Change input to SubmitTransaction
 	result, err := hclient.SubmitTransaction(signed)
 	if err != nil {
 		switch e := err.(type) {
@@ -71,15 +92,36 @@ func AsyncSubmitTransaction(minion *Minion, hclient *horizon.Client, signed stri
 			minion.checkHandleBadSequence(e)
 		}
 
-		minion.TxResultChan <- TxResult{
+		channel <- SubmitResult{
 			maybeTransactionSuccess: nil,
 			maybeErr:                err,
 		}
 	} else {
-		minion.TxResultChan <- TxResult{
+		channel <- SubmitResult{
 			maybeTransactionSuccess: &result,
 			maybeErr:                nil,
 		}
+	}
+}
+
+func (minion *Minion) run(hclient *horizonclient.Client, input TxInput, channel chan TxResult) {
+	err := minion.checkSequenceRefresh(hclient)
+	if err != nil {
+		channel <- TxResult{
+			maybeTransaction: nil,
+			maybeErr:         errors.Wrap(err, "checking minion seq"),
+		}
+	}
+	signed, err := minion.makeTx(input)
+	if err != nil {
+		channel <- TxResult{
+			maybeTransaction: nil,
+			maybeErr:         errors.Wrap(err, "making payment tx"),
+		}
+	}
+	channel <- TxResult{
+		maybeTransaction: &signed,
+		maybeErr:         nil,
 	}
 }
 
@@ -94,26 +136,25 @@ func (minion *Minion) checkHandleBadSequence(err *horizon.Error) {
 }
 
 // Establishes the minion's initial sequence number, if needed.
-// XXX: Change param type
-func (minion *Minion) checkSequenceRefresh(hclient *horizon.Client) error {
+func (minion *Minion) checkSequenceRefresh(hclient *horizonclient.Client) error {
 	if minion.sequence != 0 && !minion.forceRefreshSequence {
 		return nil
 	}
 	return minion.refreshSequence(hclient)
 }
 
-func (minion *Minion) makeTx(destAddress, botSecret, networkPassphrase, initBalance string) (string, error) {
-	txn, err := b.Transaction(
+func (minion *Minion) makeTx(input TxInput) (string, error) {
+	txnOld, err := b.Transaction(
 		b.SourceAccount{AddressOrSeed: minion.Secret},
 		b.Sequence{Sequence: minion.sequence + 1},
-		b.Network{Passphrase: networkPassphrase},
+		b.Network{Passphrase: input.network},
 		b.CreateAccount(
-			b.Destination{AddressOrSeed: destAddress},
+			b.Destination{AddressOrSeed: input.destAddress},
 		),
 		b.Payment(
-			b.SourceAccount{AddressOrSeed: botSecret},
-			b.Destination{AddressOrSeed: destAddress},
-			b.NativeAmount{Amount: initBalance},
+			b.SourceAccount{AddressOrSeed: input.botSecret},
+			b.Destination{AddressOrSeed: input.destAddress},
+			b.NativeAmount{Amount: input.startingBalance},
 		),
 	)
 
@@ -121,7 +162,7 @@ func (minion *Minion) makeTx(destAddress, botSecret, networkPassphrase, initBala
 		return "", errors.Wrap(err, "Error building a transaction")
 	}
 
-	txs, err := txn.Sign(botSecret, minion.Secret)
+	txs, err := txn.Sign(input.botSecret, minion.Secret)
 	if err != nil {
 		return "", errors.Wrap(err, "Error signing a transaction")
 	}
@@ -136,8 +177,8 @@ func (minion *Minion) makeTx(destAddress, botSecret, networkPassphrase, initBala
 }
 
 // Refreshes the in-memory sequence number from the minion Stellar account.
-// XXX: Change param type
-func (minion *Minion) refreshSequence(hclient *horizon.Client) error {
+func (minion *Minion) refreshSequence(hclient *horizonclient.Client) error {
+	// XXX: Change the LoadAccount call
 	minionAccount, err := hclient.LoadAccount(minion.address())
 	if err != nil {
 		minion.sequence = 0

--- a/services/friendbot/internal/friendbot.go
+++ b/services/friendbot/internal/friendbot.go
@@ -22,22 +22,26 @@ type Minion struct {
 
 // TxResult is the result from the asynchronous submit transaction method over a channel.
 type TxResult struct {
+	// XXX: Change this
 	maybeTransactionSuccess *horizon.TransactionSuccess
 	maybeErr                error
 }
 
 // Bot represents the friendbot subsystem.
 type Bot struct {
-	Horizon           *horizon.Client
-	Secret            string
-	Network           string
-	StartingBalance   string
+	// XXX: Change this type
+	Horizon         *horizon.Client
+	Secret          string
+	Network         string
+	StartingBalance string
+	// XXX: Change hclient type
 	SubmitTransaction func(minion *Minion, hclient *horizon.Client, signed string)
 	Minions           []Minion
 	nextMinionIndex   int
 }
 
 // Pay funds the account at `destAddress`.
+// XXX: Change return type
 func (bot *Bot) Pay(destAddress string) (*horizon.TransactionSuccess, error) {
 	minion := bot.Minions[bot.nextMinionIndex]
 	err := minion.checkSequenceRefresh(bot.Horizon)
@@ -57,10 +61,12 @@ func (bot *Bot) Pay(destAddress string) (*horizon.TransactionSuccess, error) {
 }
 
 // AsyncSubmitTransaction should be passed to the bot.
+// XXX: Change second argument type
 func AsyncSubmitTransaction(minion *Minion, hclient *horizon.Client, signed string) {
 	result, err := hclient.SubmitTransaction(signed)
 	if err != nil {
 		switch e := err.(type) {
+		// XXX: Change horizon type
 		case *horizon.Error:
 			minion.checkHandleBadSequence(e)
 		}
@@ -77,6 +83,7 @@ func AsyncSubmitTransaction(minion *Minion, hclient *horizon.Client, signed stri
 	}
 }
 
+// XXX: Change param type
 func (minion *Minion) checkHandleBadSequence(err *horizon.Error) {
 	resCode, e := err.ResultCodes()
 	isTxBadSeqCode := e == nil && resCode.TransactionCode == "tx_bad_seq"
@@ -87,6 +94,7 @@ func (minion *Minion) checkHandleBadSequence(err *horizon.Error) {
 }
 
 // Establishes the minion's initial sequence number, if needed.
+// XXX: Change param type
 func (minion *Minion) checkSequenceRefresh(hclient *horizon.Client) error {
 	if minion.sequence != 0 && !minion.forceRefreshSequence {
 		return nil
@@ -128,6 +136,7 @@ func (minion *Minion) makeTx(destAddress, botSecret, networkPassphrase, initBala
 }
 
 // Refreshes the in-memory sequence number from the minion Stellar account.
+// XXX: Change param type
 func (minion *Minion) refreshSequence(hclient *horizon.Client) error {
 	minionAccount, err := hclient.LoadAccount(minion.address())
 	if err != nil {

--- a/services/friendbot/internal/friendbot.go
+++ b/services/friendbot/internal/friendbot.go
@@ -2,13 +2,23 @@ package internal
 
 import (
 	"strconv"
-	"sync"
 
 	b "github.com/stellar/go/build"
 	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/support/errors"
 )
+
+// Minion contains a Stellar channel account and the needed tools to communicate with friendbot
+type Minion struct {
+	Secret       string
+	DestAddrChan chan string
+	TxResultChan chan TxResult
+
+	// uninitialized
+	sequence             uint64
+	forceRefreshSequence bool
+}
 
 // TxResult is the result from the asynchronous submit transaction method over a channel
 type TxResult struct {
@@ -22,90 +32,78 @@ type Bot struct {
 	Secret            string
 	Network           string
 	StartingBalance   string
-	SubmitTransaction func(bot *Bot, channel chan TxResult, signed string)
-
-	// uninitialized
-	sequence             uint64
-	forceRefreshSequence bool
-	lock                 sync.Mutex
+	SubmitTransaction func(minion *Minion, hclient *horizon.Client, signed string)
+	Minions           []Minion
+	nextMinionIndex   int
 }
 
 // Pay funds the account at `destAddress`
 func (bot *Bot) Pay(destAddress string) (*horizon.TransactionSuccess, error) {
-	channel := make(chan TxResult)
-	err := bot.lockedPay(channel, destAddress)
+	minion := bot.Minions[bot.nextMinionIndex]
+	err := minion.checkSequenceRefresh(bot.Horizon)
 	if err != nil {
 		return nil, err
 	}
-
-	v := <-channel
+	signed, err := minion.makeTx(destAddress, bot.Secret, bot.Network, bot.StartingBalance)
+	if err != nil {
+		return nil, err
+	}
+	go bot.SubmitTransaction(&minion, bot.Horizon, signed)
+	v := <-minion.TxResultChan
+	bot.nextMinionIndex = (bot.nextMinionIndex + 1) % len(bot.Minions)
 	return v.maybeTransactionSuccess, v.maybeErr
 }
 
-func (bot *Bot) lockedPay(channel chan TxResult, destAddress string) error {
-	bot.lock.Lock()
-	defer bot.lock.Unlock()
-
-	err := bot.checkSequenceRefresh()
-	if err != nil {
-		return err
-	}
-
-	signed, err := bot.makeTx(destAddress)
-	if err != nil {
-		return err
-	}
-
-	go bot.SubmitTransaction(bot, channel, signed)
-	return nil
-}
-
-// AsyncSubmitTransaction should be passed into the bot
-func AsyncSubmitTransaction(bot *Bot, channel chan TxResult, signed string) {
-	result, err := bot.Horizon.SubmitTransaction(signed)
+// AsyncSubmitTransaction should be passed to the bot
+func AsyncSubmitTransaction(minion *Minion, hclient *horizon.Client, signed string) {
+	result, err := hclient.SubmitTransaction(signed)
 	if err != nil {
 		switch e := err.(type) {
 		case *horizon.Error:
-			bot.checkHandleBadSequence(e)
+			minion.checkHandleBadSequence(e)
 		}
 
-		channel <- TxResult{
+		minion.TxResultChan <- TxResult{
 			maybeTransactionSuccess: nil,
 			maybeErr:                err,
 		}
 	} else {
-		channel <- TxResult{
+		minion.TxResultChan <- TxResult{
 			maybeTransactionSuccess: &result,
 			maybeErr:                nil,
 		}
 	}
 }
 
-func (bot *Bot) checkHandleBadSequence(err *horizon.Error) {
+func (minion *Minion) checkHandleBadSequence(err *horizon.Error) {
 	resCode, e := err.ResultCodes()
 	isTxBadSeqCode := e == nil && resCode.TransactionCode == "tx_bad_seq"
 	if !isTxBadSeqCode {
 		return
 	}
-	bot.forceRefreshSequence = true
+	minion.forceRefreshSequence = true
 }
 
 // establish initial sequence if needed
-func (bot *Bot) checkSequenceRefresh() error {
-	if bot.sequence != 0 && !bot.forceRefreshSequence {
+func (minion *Minion) checkSequenceRefresh(hclient *horizon.Client) error {
+	if minion.sequence != 0 && !minion.forceRefreshSequence {
 		return nil
 	}
-	return bot.refreshSequence()
+	return minion.refreshSequence(hclient)
 }
 
-func (bot *Bot) makeTx(destAddress string) (string, error) {
+func (minion *Minion) makeTx(destAddress, botSecret, networkPassphrase, initBalance string) (string, error) {
 	txn, err := b.Transaction(
-		b.SourceAccount{AddressOrSeed: bot.Secret},
-		b.Sequence{Sequence: bot.sequence + 1},
-		b.Network{Passphrase: bot.Network},
+		b.SourceAccount{AddressOrSeed: minion.Secret},
+		b.Sequence{Sequence: minion.sequence + 1},
+		b.Network{Passphrase: networkPassphrase},
 		b.CreateAccount(
 			b.Destination{AddressOrSeed: destAddress},
-			b.NativeAmount{Amount: bot.StartingBalance},
+		),
+		b.Payment(
+			b.SourceAccount{AddressOrSeed: botSecret},
+			b.Destination{AddressOrSeed: destAddress},
+			b.NativeAmount{Amount: initBalance},
 		),
 	)
 
@@ -113,40 +111,38 @@ func (bot *Bot) makeTx(destAddress string) (string, error) {
 		return "", errors.Wrap(err, "Error building a transaction")
 	}
 
-	txs, err := txn.Sign(bot.Secret)
+	txs, err := txn.Sign(botSecret, minion.Secret)
 	if err != nil {
 		return "", errors.Wrap(err, "Error signing a transaction")
 	}
 
 	base64, err := txs.Base64()
 
-	// only increment the in-memory sequence number if we are going to submit the transaction, while we hold the lock
+	// only increment the in-memory sequence number if we are going to submit the transaction
 	if err == nil {
-		bot.sequence++
+		minion.sequence++
 	}
 	return base64, err
 }
 
-// refreshes the sequence from the bot account
-func (bot *Bot) refreshSequence() error {
-	botAccount, err := bot.Horizon.LoadAccount(bot.address())
+// refreshes the sequence from a minion account
+func (minion *Minion) refreshSequence(hclient *horizon.Client) error {
+	minionAccount, err := hclient.LoadAccount(minion.address())
 	if err != nil {
-		bot.sequence = 0
+		minion.sequence = 0
 		return err
 	}
-
-	seq, err := strconv.ParseInt(botAccount.Sequence, 10, 64)
+	seq, err := strconv.ParseInt(minionAccount.Sequence, 10, 64)
 	if err != nil {
-		bot.sequence = 0
+		minion.sequence = 0
 		return err
 	}
-
-	bot.sequence = uint64(seq)
-	bot.forceRefreshSequence = false
+	minion.sequence = uint64(seq)
+	minion.forceRefreshSequence = false
 	return nil
 }
 
-func (bot *Bot) address() string {
-	kp := keypair.MustParse(bot.Secret)
+func (minion *Minion) address() string {
+	kp := keypair.MustParse(minion.Secret)
 	return kp.Address()
 }

--- a/services/friendbot/internal/friendbot.go
+++ b/services/friendbot/internal/friendbot.go
@@ -29,6 +29,21 @@ func (a Account) IncrementSequenceNumber() (xdr.SequenceNumber, error) {
 	return a.Sequence, nil
 }
 
+// RefreshSequenceNumber gets an Account's correct in-memory sequence number from Horizon.
+func (a Account) RefreshSequenceNumber(hclient *horizonclient.Client) error {
+	accountRequest := horizonclient.AccountRequest{AccountID: a.GetAccountID()}
+	accountDetail, err := hclient.AccountDetail(accountRequest)
+	if err != nil {
+		return errors.Wrap(err, "getting account detail")
+	}
+	seq, err := strconv.ParseInt(accountDetail.Sequence, 10, 64)
+	if err != nil {
+		return errors.Wrap(err, "parsing account seqnum")
+	}
+	a.Sequence = xdr.SequenceNumber(seq)
+	return nil
+}
+
 // Minion contains a Stellar channel account and Go channels to communicate with friendbot.
 type Minion struct {
 	Account Account
@@ -148,7 +163,12 @@ func (minion *Minion) checkSequenceRefresh(hclient *horizonclient.Client) error 
 	if minion.Account.Sequence != 0 && !minion.forceRefreshSequence {
 		return nil
 	}
-	return minion.refreshSequence(hclient)
+	err := minion.Account.RefreshSequenceNumber(hclient)
+	if err != nil {
+		return errors.Wrap(err, "refreshing minion seqnum")
+	}
+	minion.forceRefreshSequence = false
+	return nil
 }
 
 func (minion *Minion) makeTx(input MinionInput) (*string, error) {
@@ -178,21 +198,4 @@ func (minion *Minion) makeTx(input MinionInput) (*string, error) {
 		return nil, errors.Wrap(err, "incrementing minion seq")
 	}
 	return &txe, err
-}
-
-// Refreshes the in-memory sequence number from the minion Stellar account.
-func (minion *Minion) refreshSequence(hclient *horizonclient.Client) error {
-	minion.Account.Sequence = 0
-	accountRequest := horizonclient.AccountRequest{AccountID: minion.Account.GetAccountID()}
-	minionAccount, err := hclient.AccountDetail(accountRequest)
-	if err != nil {
-		return err
-	}
-	seq, err := strconv.ParseInt(minionAccount.Sequence, 10, 64)
-	if err != nil {
-		return err
-	}
-	minion.Account.Sequence = xdr.SequenceNumber(seq)
-	minion.forceRefreshSequence = false
-	return nil
 }

--- a/services/friendbot/internal/friendbot.go
+++ b/services/friendbot/internal/friendbot.go
@@ -166,6 +166,7 @@ func (minion *Minion) makeTx(input MinionInput) (*string, error) {
 		SourceAccount: minion.Account,
 		Operations:    []txnbuild.Operation{&createAccountOp, &paymentOp},
 		Network:       input.network,
+		Timebounds:    txnbuild.NewTimebounds(0, 300),
 	}
 	txe, err := txn.BuildSignEncode(minion.Keypair, input.botKeypair)
 	if err != nil {

--- a/services/friendbot/internal/friendbot.go
+++ b/services/friendbot/internal/friendbot.go
@@ -22,9 +22,8 @@ func (bot *Bot) Pay(destAddress string) (*hProtocol.TransactionSuccess, error) {
 	minion := bot.Minions[bot.nextMinionIndex]
 	resultChan := make(chan SubmitResult)
 	go minion.Run(destAddress, resultChan)
+	bot.nextMinionIndex = (bot.nextMinionIndex + 1) % len(bot.Minions)
 	maybeSubmitResult := <-resultChan
 	close(resultChan)
-
-	bot.nextMinionIndex = (bot.nextMinionIndex + 1) % len(bot.Minions)
 	return maybeSubmitResult.maybeTransactionSuccess, maybeSubmitResult.maybeErr
 }

--- a/services/friendbot/internal/friendbot.go
+++ b/services/friendbot/internal/friendbot.go
@@ -9,18 +9,18 @@ import (
 	"github.com/stellar/go/support/errors"
 )
 
-// Minion contains a Stellar channel account and the needed tools to communicate with friendbot
+// Minion contains a Stellar channel account and Go channels to communicate with friendbot.
 type Minion struct {
 	Secret       string
 	DestAddrChan chan string
 	TxResultChan chan TxResult
 
-	// uninitialized
+	// Uninitialized.
 	sequence             uint64
 	forceRefreshSequence bool
 }
 
-// TxResult is the result from the asynchronous submit transaction method over a channel
+// TxResult is the result from the asynchronous submit transaction method over a channel.
 type TxResult struct {
 	maybeTransactionSuccess *horizon.TransactionSuccess
 	maybeErr                error
@@ -37,24 +37,26 @@ type Bot struct {
 	nextMinionIndex   int
 }
 
-// Pay funds the account at `destAddress`
+// Pay funds the account at `destAddress`.
 func (bot *Bot) Pay(destAddress string) (*horizon.TransactionSuccess, error) {
 	minion := bot.Minions[bot.nextMinionIndex]
 	err := minion.checkSequenceRefresh(bot.Horizon)
 	if err != nil {
 		return nil, err
 	}
+
 	signed, err := minion.makeTx(destAddress, bot.Secret, bot.Network, bot.StartingBalance)
 	if err != nil {
 		return nil, err
 	}
 	go bot.SubmitTransaction(&minion, bot.Horizon, signed)
-	v := <-minion.TxResultChan
 	bot.nextMinionIndex = (bot.nextMinionIndex + 1) % len(bot.Minions)
+
+	v := <-minion.TxResultChan
 	return v.maybeTransactionSuccess, v.maybeErr
 }
 
-// AsyncSubmitTransaction should be passed to the bot
+// AsyncSubmitTransaction should be passed to the bot.
 func AsyncSubmitTransaction(minion *Minion, hclient *horizon.Client, signed string) {
 	result, err := hclient.SubmitTransaction(signed)
 	if err != nil {
@@ -84,7 +86,7 @@ func (minion *Minion) checkHandleBadSequence(err *horizon.Error) {
 	minion.forceRefreshSequence = true
 }
 
-// establish initial sequence if needed
+// Establishes the minion's initial sequence number, if needed.
 func (minion *Minion) checkSequenceRefresh(hclient *horizon.Client) error {
 	if minion.sequence != 0 && !minion.forceRefreshSequence {
 		return nil
@@ -118,14 +120,14 @@ func (minion *Minion) makeTx(destAddress, botSecret, networkPassphrase, initBala
 
 	base64, err := txs.Base64()
 
-	// only increment the in-memory sequence number if we are going to submit the transaction
+	// We only increment the in-memory sequence number if the tx will be submitted.
 	if err == nil {
 		minion.sequence++
 	}
 	return base64, err
 }
 
-// refreshes the sequence from a minion account
+// Refreshes the in-memory sequence number from the minion Stellar account.
 func (minion *Minion) refreshSequence(hclient *horizon.Client) error {
 	minionAccount, err := hclient.LoadAccount(minion.address())
 	if err != nil {

--- a/services/friendbot/internal/friendbot.go
+++ b/services/friendbot/internal/friendbot.go
@@ -1,9 +1,6 @@
 package internal
 
 import (
-	"log"
-
-	"github.com/stellar/go/clients/horizonclient"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 )
 
@@ -14,12 +11,6 @@ type Bot struct {
 	nextMinionIndex int
 }
 
-// MinionInput is the input to the Minion from the Bot to construct a payment.
-type MinionInput struct {
-	destAddress string
-	resultChan  chan SubmitResult
-}
-
 // SubmitResult is the result from the asynchronous tx submission.
 type SubmitResult struct {
 	maybeTransactionSuccess *hProtocol.TransactionSuccess
@@ -28,26 +19,12 @@ type SubmitResult struct {
 
 // Pay funds the account at `destAddress`.
 func (bot *Bot) Pay(destAddress string) (*hProtocol.TransactionSuccess, error) {
-	log.Print("top of Pay")
 	minion := bot.Minions[bot.nextMinionIndex]
 	resultChan := make(chan SubmitResult)
-	log.Printf("about to pass to minion %v", minion)
-	minion.InputChan <- MinionInput{
-		destAddress: destAddress,
-		resultChan:  resultChan,
-	}
-	bot.nextMinionIndex = (bot.nextMinionIndex + 1) % len(bot.Minions)
+	go minion.Run(destAddress, resultChan)
 	maybeSubmitResult := <-resultChan
 	close(resultChan)
-	// XXX: Remove debug nil check.
-	log.Print("just got back potential result")
-	if maybeSubmitResult.maybeErr != nil {
-		switch e := maybeSubmitResult.maybeErr.(type) {
-		case *horizonclient.Error:
-			resCode, _ := e.ResultCodes()
-			log.Print(resCode.TransactionCode)
-			log.Print(resCode.OperationCodes)
-		}
-	}
+
+	bot.nextMinionIndex = (bot.nextMinionIndex + 1) % len(bot.Minions)
 	return maybeSubmitResult.maybeTransactionSuccess, maybeSubmitResult.maybeErr
 }

--- a/services/friendbot/internal/friendbot.go
+++ b/services/friendbot/internal/friendbot.go
@@ -3,53 +3,67 @@ package internal
 import (
 	"strconv"
 
-	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/errors"
-	b "github.com/stellar/go/txnbuild"
+	"github.com/stellar/go/txnbuild"
+	"github.com/stellar/go/xdr"
 )
+
+// Account implements the `txnbuild.Account` interface.
+type Account struct {
+	AccountID string
+	Sequence  xdr.SequenceNumber
+}
+
+// GetAccountID returns the Account ID.
+func (a Account) GetAccountID() string {
+	return a.AccountID
+}
+
+// IncrementSequenceNumber increments the internal record of the
+// account's sequence number by 1.
+func (a Account) IncrementSequenceNumber() (xdr.SequenceNumber, error) {
+	a.Sequence++
+	return a.Sequence, nil
+}
 
 // Minion contains a Stellar channel account and Go channels to communicate with friendbot.
 type Minion struct {
-	// XXX: Change to Account
-	Secret string
-
+	Account Account
 	Keypair *keypair.Full
-	// XXX: Rename field
-	txInputChan chan TxInput
 
 	// Uninitialized.
-	sequence             uint64
 	forceRefreshSequence bool
 }
 
-// TxInput is the input to the Minion for constructing a payment transaction.
-type TxInput struct {
+// MinionInput is the input to the Minion from the Bot to construct a payment.
+type MinionInput struct {
+	botAccount      txnbuild.Account
+	botKeypair      *keypair.Full
 	destAddress     string
-	botSecret       string
 	network         string
 	startingBalance string
 }
 
 // TxResult is the result from the asynchronous payment tx construction method.
 type TxResult struct {
-	// XXX: Check type
-	maybeTransaction *string
-	maybeErr         error
+	maybeTxXDR *string
+	maybeErr   error
 }
 
 // SubmitResult is the result from the asynchronous submit transaction method over a channel.
 type SubmitResult struct {
-	// XXX: Change this
-	maybeTransactionSuccess *horizon.TransactionSuccess
+	maybeTransactionSuccess *hProtocol.TransactionSuccess
 	maybeErr                error
 }
 
 // Bot represents the friendbot subsystem.
 type Bot struct {
 	Horizon           *horizonclient.Client
-	Secret            string
+	Account           txnbuild.Account
+	Keypair           *keypair.Full
 	Network           string
 	StartingBalance   string
 	SubmitTransaction func(minion *Minion, channel chan SubmitResult, hclient *horizonclient.Client, signed string)
@@ -58,13 +72,13 @@ type Bot struct {
 }
 
 // Pay funds the account at `destAddress`.
-// XXX: Change return type
-func (bot *Bot) Pay(destAddress string) (*horizon.TransactionSuccess, error) {
+func (bot *Bot) Pay(destAddress string) (*hProtocol.TransactionSuccess, error) {
 	minion := bot.Minions[bot.nextMinionIndex]
-	// XXX: Launch separate thread
-	input := TxInput{
+	// XXX: Launch separate thread, potentially.
+	input := MinionInput{
 		destAddress:     destAddress,
-		botSecret:       bot.Secret,
+		botAccount:      bot.Account,
+		botKeypair:      bot.Keypair,
 		network:         bot.Network,
 		startingBalance: bot.StartingBalance,
 	}
@@ -77,7 +91,7 @@ func (bot *Bot) Pay(destAddress string) (*horizon.TransactionSuccess, error) {
 	}
 
 	submitResultChan := make(chan SubmitResult)
-	go bot.SubmitTransaction(&minion, submitResultChan, bot.Horizon, *maybeTxResult.maybeTransaction)
+	go bot.SubmitTransaction(&minion, submitResultChan, bot.Horizon, *maybeTxResult.maybeTxXDR)
 	bot.nextMinionIndex = (bot.nextMinionIndex + 1) % len(bot.Minions)
 
 	maybeSubmitResult := <-submitResultChan
@@ -85,13 +99,11 @@ func (bot *Bot) Pay(destAddress string) (*horizon.TransactionSuccess, error) {
 }
 
 // AsyncSubmitTransaction should be passed to the bot.
-func AsyncSubmitTransaction(minion *Minion, channel chan SubmitResult, hclient *horizonclient.Client, signed string) {
-	// XXX: Change input to SubmitTransaction
-	result, err := hclient.SubmitTransaction(signed)
+func AsyncSubmitTransaction(minion *Minion, channel chan SubmitResult, hclient *horizonclient.Client, txXDR string) {
+	result, err := hclient.SubmitTransactionXDR(txXDR)
 	if err != nil {
 		switch e := err.(type) {
-		// XXX: Change horizon type
-		case *horizon.Error:
+		case *horizonclient.Error:
 			minion.checkHandleBadSequence(e)
 		}
 
@@ -107,29 +119,22 @@ func AsyncSubmitTransaction(minion *Minion, channel chan SubmitResult, hclient *
 	}
 }
 
-func (minion *Minion) run(hclient *horizonclient.Client, input TxInput, channel chan TxResult) {
+func (minion *Minion) run(hclient *horizonclient.Client, input MinionInput, channel chan TxResult) {
 	err := minion.checkSequenceRefresh(hclient)
 	if err != nil {
 		channel <- TxResult{
-			maybeTransaction: nil,
-			maybeErr:         errors.Wrap(err, "checking minion seq"),
+			maybeTxXDR: nil,
+			maybeErr:   errors.Wrap(err, "checking minion seq"),
 		}
 	}
-	signed, err := minion.makeTx(input)
-	if err != nil {
-		channel <- TxResult{
-			maybeTransaction: nil,
-			maybeErr:         errors.Wrap(err, "making payment tx"),
-		}
-	}
+	txStr, err := minion.makeTx(input)
 	channel <- TxResult{
-		maybeTransaction: &signed,
-		maybeErr:         nil,
+		maybeTxXDR: txStr,
+		maybeErr:   errors.Wrap(err, "making payment tx"),
 	}
 }
 
-// XXX: Change param type
-func (minion *Minion) checkHandleBadSequence(err *horizon.Error) {
+func (minion *Minion) checkHandleBadSequence(err *horizonclient.Error) {
 	resCode, e := err.ResultCodes()
 	isTxBadSeqCode := e == nil && resCode.TransactionCode == "tx_bad_seq"
 	if !isTxBadSeqCode {
@@ -140,85 +145,53 @@ func (minion *Minion) checkHandleBadSequence(err *horizon.Error) {
 
 // Establishes the minion's initial sequence number, if needed.
 func (minion *Minion) checkSequenceRefresh(hclient *horizonclient.Client) error {
-	if minion.sequence != 0 && !minion.forceRefreshSequence {
+	if minion.Account.Sequence != 0 && !minion.forceRefreshSequence {
 		return nil
 	}
 	return minion.refreshSequence(hclient)
 }
 
-func (minion *Minion) makeTx(input TxInput) error {
-
-	createAccountOp := b.CreateAccount{
-		Destination: input.destAddress,
-		Amount:      "0.00", // XXX: Should this be input.startingBalance?
-	}
-	// XXX: Source acct for payment should be friendbot, not Stellar channel account.
-	paymentOp := b.Payment{
+func (minion *Minion) makeTx(input MinionInput) (*string, error) {
+	createAccountOp := txnbuild.CreateAccount{
 		Destination: input.destAddress,
 		Amount:      input.startingBalance,
-		Asset:       b.NativeAsset{},
 	}
-	txn := b.Transaction{
-		SourceAccount: minion.SourceAccount,
-		Operations:    []b.Operation{&createAccountOp, &paymentOp},
+	paymentOp := txnbuild.Payment{
+		Destination:   input.destAddress,
+		Amount:        input.startingBalance,
+		Asset:         txnbuild.NativeAsset{},
+		SourceAccount: input.botAccount,
+	}
+	txn := txnbuild.Transaction{
+		SourceAccount: minion.Account,
+		Operations:    []txnbuild.Operation{&createAccountOp, &paymentOp},
 		Network:       input.network,
 	}
-	// XXX: Enable multiple signers.
-	txe, err := txn.BuildSignEncode(minion.Keypair)
-}
-
-func (minion *Minion) makeTxOld(input TxInput) (string, error) {
-	txnOld, err := b.Transaction(
-		b.SourceAccount{AddressOrSeed: minion.Secret},
-		b.Sequence{Sequence: minion.sequence + 1},
-		b.Network{Passphrase: input.network},
-		b.CreateAccount(
-			b.Destination{AddressOrSeed: input.destAddress},
-		),
-		b.Payment(
-			b.SourceAccount{AddressOrSeed: input.botSecret},
-			b.Destination{AddressOrSeed: input.destAddress},
-			b.NativeAmount{Amount: input.startingBalance},
-		),
-	)
-
+	txe, err := txn.BuildSignEncode(minion.Keypair, input.botKeypair)
 	if err != nil {
-		return "", errors.Wrap(err, "Error building a transaction")
+		return nil, errors.Wrap(err, "making account payment tx")
 	}
-
-	txs, err := txn.Sign(input.botSecret, minion.Secret)
+	// Increment the in-memory sequence number, since the tx will be submitted.
+	_, err = minion.Account.IncrementSequenceNumber()
 	if err != nil {
-		return "", errors.Wrap(err, "Error signing a transaction")
+		return nil, errors.Wrap(err, "incrementing minion seq")
 	}
-
-	base64, err := txs.Base64()
-
-	// We only increment the in-memory sequence number if the tx will be submitted.
-	if err == nil {
-		minion.sequence++
-	}
-	return base64, err
+	return &txe, err
 }
 
 // Refreshes the in-memory sequence number from the minion Stellar account.
 func (minion *Minion) refreshSequence(hclient *horizonclient.Client) error {
-	// XXX: Change the LoadAccount call
-	minionAccount, err := hclient.LoadAccount(minion.address())
+	minion.Account.Sequence = 0
+	accountRequest := horizonclient.AccountRequest{AccountID: minion.Account.GetAccountID()}
+	minionAccount, err := hclient.AccountDetail(accountRequest)
 	if err != nil {
-		minion.sequence = 0
 		return err
 	}
 	seq, err := strconv.ParseInt(minionAccount.Sequence, 10, 64)
 	if err != nil {
-		minion.sequence = 0
 		return err
 	}
-	minion.sequence = uint64(seq)
+	minion.Account.Sequence = xdr.SequenceNumber(seq)
 	minion.forceRefreshSequence = false
 	return nil
-}
-
-func (minion *Minion) address() string {
-	kp := keypair.MustParse(minion.Secret)
-	return kp.Address()
 }

--- a/services/friendbot/internal/friendbot.go
+++ b/services/friendbot/internal/friendbot.go
@@ -1,6 +1,9 @@
 package internal
 
 import (
+	"log"
+
+	"github.com/stellar/go/clients/horizonclient"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 )
 
@@ -25,13 +28,26 @@ type SubmitResult struct {
 
 // Pay funds the account at `destAddress`.
 func (bot *Bot) Pay(destAddress string) (*hProtocol.TransactionSuccess, error) {
+	log.Print("top of Pay")
 	minion := bot.Minions[bot.nextMinionIndex]
 	resultChan := make(chan SubmitResult)
+	log.Printf("about to pass to minion %v", minion)
 	minion.InputChan <- MinionInput{
 		destAddress: destAddress,
 		resultChan:  resultChan,
 	}
 	bot.nextMinionIndex = (bot.nextMinionIndex + 1) % len(bot.Minions)
 	maybeSubmitResult := <-resultChan
+	close(resultChan)
+	// XXX: Remove debug nil check.
+	log.Print("just got back potential result")
+	if maybeSubmitResult.maybeErr != nil {
+		switch e := maybeSubmitResult.maybeErr.(type) {
+		case *horizonclient.Error:
+			resCode, _ := e.ResultCodes()
+			log.Print(resCode.TransactionCode)
+			log.Print(resCode.OperationCodes)
+		}
+	}
 	return maybeSubmitResult.maybeTransactionSuccess, maybeSubmitResult.maybeErr
 }

--- a/services/friendbot/internal/friendbot.go
+++ b/services/friendbot/internal/friendbot.go
@@ -14,6 +14,8 @@ import (
 type Minion struct {
 	// XXX: Change to Account
 	Secret string
+
+	Keypair *keypair.Full
 	// XXX: Rename field
 	txInputChan chan TxInput
 
@@ -161,6 +163,8 @@ func (minion *Minion) makeTx(input TxInput) error {
 		Operations:    []b.Operation{&createAccountOp, &paymentOp},
 		Network:       input.network,
 	}
+	// XXX: Enable multiple signers.
+	txe, err := txn.BuildSignEncode(minion.Keypair)
 }
 
 func (minion *Minion) makeTxOld(input TxInput) (string, error) {

--- a/services/friendbot/internal/friendbot_handler.go
+++ b/services/friendbot/internal/friendbot_handler.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"log"
 	"net/http"
 	"net/url"
 
@@ -29,7 +28,6 @@ func (handler *FriendbotHandler) Handle(w http.ResponseWriter, r *http.Request) 
 
 // doHandle is just a convenience method that returns the object to be rendered
 func (handler *FriendbotHandler) doHandle(r *http.Request) (*horizon.TransactionSuccess, error) {
-	log.Print("top of doHandle")
 	err := handler.checkEnabled()
 	if err != nil {
 		return nil, err
@@ -44,7 +42,6 @@ func (handler *FriendbotHandler) doHandle(r *http.Request) (*horizon.Transaction
 	if err != nil {
 		return nil, problem.MakeInvalidFieldProblem("addr", err)
 	}
-	log.Print("about to call loadResult")
 	return handler.loadResult(address)
 }
 
@@ -62,7 +59,6 @@ func (handler *FriendbotHandler) checkEnabled() error {
 }
 
 func (handler *FriendbotHandler) loadAddress(r *http.Request) (string, error) {
-	log.Print("top of loadAddress")
 	address := r.Form.Get("addr")
 	unescaped, err := url.QueryUnescape(address)
 	if err != nil {
@@ -70,12 +66,10 @@ func (handler *FriendbotHandler) loadAddress(r *http.Request) (string, error) {
 	}
 
 	_, err = strkey.Decode(strkey.VersionByteAccountID, unescaped)
-	log.Print("bottom of loadAddress")
 	return unescaped, err
 }
 
 func (handler *FriendbotHandler) loadResult(address string) (*horizon.TransactionSuccess, error) {
-	log.Print("top of loadResult")
 	result, err := handler.Friendbot.Pay(address)
 	switch e := err.(type) {
 	case horizon.Error:

--- a/services/friendbot/internal/friendbot_handler.go
+++ b/services/friendbot/internal/friendbot_handler.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"log"
 	"net/http"
 	"net/url"
 
@@ -28,6 +29,7 @@ func (handler *FriendbotHandler) Handle(w http.ResponseWriter, r *http.Request) 
 
 // doHandle is just a convenience method that returns the object to be rendered
 func (handler *FriendbotHandler) doHandle(r *http.Request) (*horizon.TransactionSuccess, error) {
+	log.Print("top of doHandle")
 	err := handler.checkEnabled()
 	if err != nil {
 		return nil, err
@@ -42,7 +44,7 @@ func (handler *FriendbotHandler) doHandle(r *http.Request) (*horizon.Transaction
 	if err != nil {
 		return nil, problem.MakeInvalidFieldProblem("addr", err)
 	}
-
+	log.Print("about to call loadResult")
 	return handler.loadResult(address)
 }
 
@@ -60,6 +62,7 @@ func (handler *FriendbotHandler) checkEnabled() error {
 }
 
 func (handler *FriendbotHandler) loadAddress(r *http.Request) (string, error) {
+	log.Print("top of loadAddress")
 	address := r.Form.Get("addr")
 	unescaped, err := url.QueryUnescape(address)
 	if err != nil {
@@ -67,10 +70,12 @@ func (handler *FriendbotHandler) loadAddress(r *http.Request) (string, error) {
 	}
 
 	_, err = strkey.Decode(strkey.VersionByteAccountID, unescaped)
+	log.Print("bottom of loadAddress")
 	return unescaped, err
 }
 
 func (handler *FriendbotHandler) loadResult(address string) (*horizon.TransactionSuccess, error) {
+	log.Print("top of loadResult")
 	result, err := handler.Friendbot.Pay(address)
 	switch e := err.(type) {
 	case horizon.Error:

--- a/services/friendbot/internal/friendbot_test.go
+++ b/services/friendbot/internal/friendbot_test.go
@@ -40,18 +40,16 @@ func TestFriendbot_Pay(t *testing.T) {
 		BotKeypair:        botKeypair.(*keypair.Full),
 		Network:           "Test SDF Network ; September 2015",
 		StartingBalance:   "10000.00",
-		InputChan:         make(chan MinionInput),
 		SubmitTransaction: mockSubmitTransaction,
 	}
 	fb := &Bot{Minions: []Minion{minion}}
-	go minion.Run()
 
 	recipientAddress := "GDJIN6W6PLTPKLLM57UW65ZH4BITUXUMYQHIMAZFYXF45PZVAWDBI77Z"
 	txSuccess, err := fb.Pay(recipientAddress)
 	if !assert.NoError(t, err) {
 		return
 	}
-	expectedTxn := "AAAAAGOiyZ/+kecCdxYBXywkAFwsSrGLYqD4IiVglvKCvaWHAAAAyAAAAAAAAAACAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAANKG+t565vUtbO/pb3cn4FE6XozEDoYDJcXLzr81BYYUAAAAF0h26AAAAAABAAAAAGOiyZ/+kecCdxYBXywkAFwsSrGLYqD4IiVglvKCvaWHAAAAAQAAAADShvreeub1LWzv6W93J+BROl6MxA6GAyXFy86/NQWGFAAAAAAAAAAXSHboAAAAAAAAAAACgr2lhwAAAEBoQgfzvxb81HRrjMYgQbGwhhs4iXE+vqdLk9qayJJEc31HU6MMEmRCzusIJh7cpSdunqoqaxpYbXZVqtLAFd0Cgr2lhwAAAEBoQgfzvxb81HRrjMYgQbGwhhs4iXE+vqdLk9qayJJEc31HU6MMEmRCzusIJh7cpSdunqoqaxpYbXZVqtLAFd0C"
+	expectedTxn := "AAAAAGOiyZ/+kecCdxYBXywkAFwsSrGLYqD4IiVglvKCvaWHAAAAyAAAAAAAAAACAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAEAAAAAY6LJn/6R5wJ3FgFfLCQAXCxKsYtioPgiJWCW8oK9pYcAAAAAAAAAANKG+t565vUtbO/pb3cn4FE6XozEDoYDJcXLzr81BYYUAAAAAAHJw4AAAAABAAAAAGOiyZ/+kecCdxYBXywkAFwsSrGLYqD4IiVglvKCvaWHAAAAAQAAAADShvreeub1LWzv6W93J+BROl6MxA6GAyXFy86/NQWGFAAAAAAAAAAXSHboAAAAAAAAAAACgr2lhwAAAEBt+7drpsNo3bFHELxKCa1TiGNDGIFjWZGxEdCOGXw64+wUn3djRI2EuAXQkZLVKr8E/1BZEUShbGfQ3wrnlF0Ggr2lhwAAAEBt+7drpsNo3bFHELxKCa1TiGNDGIFjWZGxEdCOGXw64+wUn3djRI2EuAXQkZLVKr8E/1BZEUShbGfQ3wrnlF0G"
 	assert.Equal(t, expectedTxn, txSuccess.Env)
 
 	// Don't assert on tx values below, since the completion order is unknown.

--- a/services/friendbot/internal/friendbot_test.go
+++ b/services/friendbot/internal/friendbot_test.go
@@ -41,7 +41,7 @@ func TestFriendbot_Pay(t *testing.T) {
 		BotAccount:        botAccount,
 		BotKeypair:        botKeypair.(*keypair.Full),
 		Network:           "Test SDF Network ; September 2015",
-		StartingBalance:   "9999.00",
+		StartingBalance:   "10000.00",
 		SubmitTransaction: mockSubmitTransaction,
 	}
 	fb := &Bot{Minions: []Minion{minion}}
@@ -51,7 +51,7 @@ func TestFriendbot_Pay(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	expectedTxn := "AAAAAPgDPeMpTqVvOr8vkcb38bMFP4Vi6w7PvWjJgxtmQ/4YAAAAyAAAAAAAAAACAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAEAAAAA+AM94ylOpW86vy+RxvfxswU/hWLrDs+9aMmDG2ZD/hgAAAAAAAAAANKG+t565vUtbO/pb3cn4FE6XozEDoYDJcXLzr81BYYUAAAAAACYloAAAAABAAAAAPXQ8gjyrVHa47a6JDPkVHwPPDKxNRE2QBcamA4JvlOGAAAAAQAAAADShvreeub1LWzv6W93J+BROl6MxA6GAyXFy86/NQWGFAAAAAAAAAAXR95RgAAAAAAAAAACZkP+GAAAAEDpGRrZjQhnRxJwFoOA7jj2CPeYbGZcYAMke1I5XEb0qzXPgOfTyLlSolcrSzPT1sMvED7gEGc8s+bNiAe/5GYGCb5ThgAAAECd46/tB7j4h/5rUhmDobZT1DO0zK3DguZEyHQr1H4Wl7w2ozU5oP9oaWYH87H2mRnT1EfkUKnIFdnVBl6UAmAO"
+	expectedTxn := "AAAAAPgDPeMpTqVvOr8vkcb38bMFP4Vi6w7PvWjJgxtmQ/4YAAAAZAAAAAAAAAACAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAEAAAAA9dDyCPKtUdrjtrokM+RUfA88MrE1ETZAFxqYDgm+U4YAAAAAAAAAANKG+t565vUtbO/pb3cn4FE6XozEDoYDJcXLzr81BYYUAAAAF0h26AAAAAAAAAAAAmZD/hgAAABANEsSWMNVgAudOT2YNx5AR3k+uNDITctQCOy0jJNYfm39M/3T0XrpOAR8EUozFIoXp+Rrtm49xKzjSLHgCiYSCgm+U4YAAABA9Iazzw7Be5vPtRPqcWG+EXjsRB9o6yaIiw6SODNSuYGjKklBOYwxuB6LHSR1t8epLvn6J58ml1cs0UOt4afGAQ=="
 	assert.Equal(t, expectedTxn, txSuccess.Env)
 
 	// Don't assert on tx values below, since the completion order is unknown.

--- a/services/friendbot/internal/friendbot_test.go
+++ b/services/friendbot/internal/friendbot_test.go
@@ -11,49 +11,47 @@ import (
 )
 
 func TestFriendbot_Pay(t *testing.T) {
-	mockSubmitTransaction := func(minion *Minion, channel chan SubmitResult, hclient *horizonclient.Client, txXDR string) {
+	mockSubmitTransaction := func(minion *Minion, hclient *horizonclient.Client, tx string) (*hProtocol.TransactionSuccess, error) {
 		// Instead of submitting the tx, we emulate a success.
-		txSuccess := hProtocol.TransactionSuccess{Env: txXDR}
-		channel <- SubmitResult{
-			maybeTransactionSuccess: &txSuccess,
-			maybeErr:                nil,
-		}
+		txSuccess := hProtocol.TransactionSuccess{Env: tx}
+		return &txSuccess, nil
 	}
+
+	botSeed := "SC6K74F25SXMNHFLXJDRIIJWBCEOWXDHU3R6RW43RZSZTA2XFIOFYCFT"
+	botKeypair, err := keypair.Parse(botSeed)
+	if !assert.NoError(t, err) {
+		return
+	}
+	botAccount := Account{AccountID: botKeypair.Address()}
 
 	minionSeed := "SC6K74F25SXMNHFLXJDRIIJWBCEOWXDHU3R6RW43RZSZTA2XFIOFYCFT"
 	minionKeypair, err := keypair.Parse(minionSeed)
 	if !assert.NoError(t, err) {
 		return
 	}
-	minions := []Minion{
-		Minion{
-			Account: Account{
-				AccountID: minionKeypair.Address(),
-				Sequence:  1,
-			},
-			Keypair: minionKeypair.(*keypair.Full),
+
+	minion := Minion{
+		Account: Account{
+			AccountID: minionKeypair.Address(),
+			Sequence:  1,
 		},
-	}
-	botSeed := "SC6K74F25SXMNHFLXJDRIIJWBCEOWXDHU3R6RW43RZSZTA2XFIOFYCFT"
-	botKeypair, err := keypair.Parse(botSeed)
-	if !assert.NoError(t, err) {
-		return
-	}
-	fb := &Bot{
-		Account:           Account{AccountID: botKeypair.Address()},
-		Keypair:           botKeypair.(*keypair.Full),
+		Keypair:           minionKeypair.(*keypair.Full),
+		BotAccount:        botAccount,
+		BotKeypair:        botKeypair.(*keypair.Full),
 		Network:           "Test SDF Network ; September 2015",
 		StartingBalance:   "10000.00",
+		InputChan:         make(chan MinionInput),
 		SubmitTransaction: mockSubmitTransaction,
-		Minions:           minions,
 	}
+	fb := &Bot{Minions: []Minion{minion}}
+	go minion.Run()
 
 	recipientAddress := "GDJIN6W6PLTPKLLM57UW65ZH4BITUXUMYQHIMAZFYXF45PZVAWDBI77Z"
 	txSuccess, err := fb.Pay(recipientAddress)
 	if !assert.NoError(t, err) {
 		return
 	}
-	expectedTxn := "AAAAAGOiyZ/+kecCdxYBXywkAFwsSrGLYqD4IiVglvKCvaWHAAAAyAAAAAAAAAACAAAAAQAAAAAAAAAAAAAAAAAAASwAAAAAAAAAAgAAAAAAAAAAAAAAANKG+t565vUtbO/pb3cn4FE6XozEDoYDJcXLzr81BYYUAAAAF0h26AAAAAABAAAAAGOiyZ/+kecCdxYBXywkAFwsSrGLYqD4IiVglvKCvaWHAAAAAQAAAADShvreeub1LWzv6W93J+BROl6MxA6GAyXFy86/NQWGFAAAAAAAAAAXSHboAAAAAAAAAAACgr2lhwAAAEDcQhEvaKc/tNyDUWQtRYRH3MDZ/Aam3X/OPMbSWTozd/B2KzZzwEFj6qI5TpsDUFZ9OgYKJmYrsjOwQxxhdrMAgr2lhwAAAEDcQhEvaKc/tNyDUWQtRYRH3MDZ/Aam3X/OPMbSWTozd/B2KzZzwEFj6qI5TpsDUFZ9OgYKJmYrsjOwQxxhdrMA"
+	expectedTxn := "AAAAAGOiyZ/+kecCdxYBXywkAFwsSrGLYqD4IiVglvKCvaWHAAAAyAAAAAAAAAACAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAANKG+t565vUtbO/pb3cn4FE6XozEDoYDJcXLzr81BYYUAAAAF0h26AAAAAABAAAAAGOiyZ/+kecCdxYBXywkAFwsSrGLYqD4IiVglvKCvaWHAAAAAQAAAADShvreeub1LWzv6W93J+BROl6MxA6GAyXFy86/NQWGFAAAAAAAAAAXSHboAAAAAAAAAAACgr2lhwAAAEBoQgfzvxb81HRrjMYgQbGwhhs4iXE+vqdLk9qayJJEc31HU6MMEmRCzusIJh7cpSdunqoqaxpYbXZVqtLAFd0Cgr2lhwAAAEBoQgfzvxb81HRrjMYgQbGwhhs4iXE+vqdLk9qayJJEc31HU6MMEmRCzusIJh7cpSdunqoqaxpYbXZVqtLAFd0C"
 	assert.Equal(t, expectedTxn, txSuccess.Env)
 
 	// Don't assert on tx values below, since the completion order is unknown.

--- a/services/friendbot/internal/friendbot_test.go
+++ b/services/friendbot/internal/friendbot_test.go
@@ -1,63 +1,71 @@
 package internal
 
 import (
-	"log"
+	"sync"
 	"testing"
 
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/keypair"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stretchr/testify/assert"
-
-	"sync"
 )
 
 func TestFriendbot_Pay(t *testing.T) {
-	mockSubmitTransaction := func(minion *Minion, hclient *horizon.Client, signed string) {
-		txSuccess := horizon.TransactionSuccess{Env: signed}
-		// we don't want to submit the tx but emulate a success instead
-		minion.TxResultChan <- TxResult{
+	mockSubmitTransaction := func(minion *Minion, channel chan SubmitResult, hclient *horizonclient.Client, txXDR string) {
+		// Instead of submitting the tx, we emulate a success.
+		txSuccess := hProtocol.TransactionSuccess{Env: txXDR}
+		channel <- SubmitResult{
 			maybeTransactionSuccess: &txSuccess,
 			maybeErr:                nil,
 		}
 	}
 
-	minions := []Minion{
-		Minion{
-			Secret:       "SC6K74F25SXMNHFLXJDRIIJWBCEOWXDHU3R6RW43RZSZTA2XFIOFYCFT",
-			DestAddrChan: make(chan string),
-			TxResultChan: make(chan TxResult),
-			sequence:     2,
-		},
-	}
-	fb := &Bot{
-		Secret:            "SAQWC7EPIYF3XGILYVJM4LVAVSLZKT27CTEI3AFBHU2VRCMQ3P3INPG5",
-		Network:           "Test SDF Network ; September 2015",
-		StartingBalance:   "100.00",
-		SubmitTransaction: mockSubmitTransaction,
-		Minions:           minions,
-		nextMinionIndex:   0,
-	}
-
-	txSuccess, err := fb.Pay("GDJIN6W6PLTPKLLM57UW65ZH4BITUXUMYQHIMAZFYXF45PZVAWDBI77Z")
+	minionSeed := "SC6K74F25SXMNHFLXJDRIIJWBCEOWXDHU3R6RW43RZSZTA2XFIOFYCFT"
+	minionKeypair, err := keypair.Parse(minionSeed)
 	if !assert.NoError(t, err) {
 		return
 	}
+	minions := []Minion{
+		Minion{
+			Account: Account{
+				AccountID: minionKeypair.Address(),
+				Sequence:  1,
+			},
+			Keypair: minionKeypair.(*keypair.Full),
+		},
+	}
+	botSeed := "SC6K74F25SXMNHFLXJDRIIJWBCEOWXDHU3R6RW43RZSZTA2XFIOFYCFT"
+	botKeypair, err := keypair.Parse(botSeed)
+	if !assert.NoError(t, err) {
+		return
+	}
+	fb := &Bot{
+		Account:           Account{AccountID: botKeypair.Address()},
+		Keypair:           botKeypair.(*keypair.Full),
+		Network:           "Test SDF Network ; September 2015",
+		StartingBalance:   "10000.00",
+		SubmitTransaction: mockSubmitTransaction,
+		Minions:           minions,
+	}
 
-	log.Print(txSuccess.Env)
-
-	expectedTxn := "AAAAAGOiyZ/+kecCdxYBXywkAFwsSrGLYqD4IiVglvKCvaWHAAAAyAAAAAAAAAADAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAA0ob63nrm9S1s7+lvdyfgUTpejMQOhgMlxcvOvzUFhhQAAAAAAAAAAAAAAAEAAAAA+5h/vHsoa8Vf1+MJH1YhqhNffIcljBfplLHrDvoc+MQAAAABAAAAANKG+t565vUtbO/pb3cn4FE6XozEDoYDJcXLzr81BYYUAAAAAAAAAAA7msoAAAAAAAAAAAL6HPjEAAAAQK+pRYAmYSks2TwQI32M5f6l43HD19tr96xfMhTAzt8JBoycWrsqQd2wyBI43SIXAoJyqq/wi9xGf0WReDFF4AuCvaWHAAAAQF3Ipfu8bgH3JNewaJRMAZDNcb+gGLIHoM6+u7lsqWkhkmTlP51BK0CqG9BybkjoGQsObjtqqScmmy7g2pWR2AI="
+	recipientAddress := "GDJIN6W6PLTPKLLM57UW65ZH4BITUXUMYQHIMAZFYXF45PZVAWDBI77Z"
+	txSuccess, err := fb.Pay(recipientAddress)
+	if !assert.NoError(t, err) {
+		return
+	}
+	expectedTxn := "AAAAAGOiyZ/+kecCdxYBXywkAFwsSrGLYqD4IiVglvKCvaWHAAAAyAAAAAAAAAACAAAAAQAAAAAAAAAAAAAAAAAAASwAAAAAAAAAAgAAAAAAAAAAAAAAANKG+t565vUtbO/pb3cn4FE6XozEDoYDJcXLzr81BYYUAAAAF0h26AAAAAABAAAAAGOiyZ/+kecCdxYBXywkAFwsSrGLYqD4IiVglvKCvaWHAAAAAQAAAADShvreeub1LWzv6W93J+BROl6MxA6GAyXFy86/NQWGFAAAAAAAAAAXSHboAAAAAAAAAAACgr2lhwAAAEDcQhEvaKc/tNyDUWQtRYRH3MDZ/Aam3X/OPMbSWTozd/B2KzZzwEFj6qI5TpsDUFZ9OgYKJmYrsjOwQxxhdrMAgr2lhwAAAEDcQhEvaKc/tNyDUWQtRYRH3MDZ/Aam3X/OPMbSWTozd/B2KzZzwEFj6qI5TpsDUFZ9OgYKJmYrsjOwQxxhdrMA"
 	assert.Equal(t, expectedTxn, txSuccess.Env)
 
+	// Don't assert on tx values below, since the completion order is unknown.
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		_, err := fb.Pay("GDJIN6W6PLTPKLLM57UW65ZH4BITUXUMYQHIMAZFYXF45PZVAWDBI77Z")
-		// don't assert on the txn value here because the ordering is not guaranteed between these 2 goroutines
+		_, err := fb.Pay(recipientAddress)
 		assert.NoError(t, err)
 		wg.Done()
 	}()
 	go func() {
-		_, err := fb.Pay("GDJIN6W6PLTPKLLM57UW65ZH4BITUXUMYQHIMAZFYXF45PZVAWDBI77Z")
-		// don't assert on the txn value here because the ordering is not guaranteed between these 2 goroutines
+		_, err := fb.Pay(recipientAddress)
 		assert.NoError(t, err)
 		wg.Done()
 	}()

--- a/services/friendbot/internal/friendbot_test.go
+++ b/services/friendbot/internal/friendbot_test.go
@@ -17,14 +17,16 @@ func TestFriendbot_Pay(t *testing.T) {
 		return &txSuccess, nil
 	}
 
-	botSeed := "SC6K74F25SXMNHFLXJDRIIJWBCEOWXDHU3R6RW43RZSZTA2XFIOFYCFT"
+	// Public key: GD25B4QI6KWVDWXDW25CIM7EKR6A6PBSWE2RCNSAC4NJQDQJXZJYMMKR
+	botSeed := "SCWNLYELENPBXN46FHYXETT5LJCYBZD5VUQQVW4KZPHFO2YTQJUWT4D5"
 	botKeypair, err := keypair.Parse(botSeed)
 	if !assert.NoError(t, err) {
 		return
 	}
 	botAccount := Account{AccountID: botKeypair.Address()}
 
-	minionSeed := "SC6K74F25SXMNHFLXJDRIIJWBCEOWXDHU3R6RW43RZSZTA2XFIOFYCFT"
+	// Public key: GD4AGPPDFFHKK3Z2X4XZDRXX6GZQKP4FMLVQ5T55NDEYGG3GIP7BQUHM
+	minionSeed := "SDTNSEERJPJFUE2LSDNYBFHYGVTPIWY7TU2IOJZQQGLWO2THTGB7NU5A"
 	minionKeypair, err := keypair.Parse(minionSeed)
 	if !assert.NoError(t, err) {
 		return
@@ -39,7 +41,7 @@ func TestFriendbot_Pay(t *testing.T) {
 		BotAccount:        botAccount,
 		BotKeypair:        botKeypair.(*keypair.Full),
 		Network:           "Test SDF Network ; September 2015",
-		StartingBalance:   "10000.00",
+		StartingBalance:   "9999.00",
 		SubmitTransaction: mockSubmitTransaction,
 	}
 	fb := &Bot{Minions: []Minion{minion}}
@@ -49,7 +51,7 @@ func TestFriendbot_Pay(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	expectedTxn := "AAAAAGOiyZ/+kecCdxYBXywkAFwsSrGLYqD4IiVglvKCvaWHAAAAyAAAAAAAAAACAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAEAAAAAY6LJn/6R5wJ3FgFfLCQAXCxKsYtioPgiJWCW8oK9pYcAAAAAAAAAANKG+t565vUtbO/pb3cn4FE6XozEDoYDJcXLzr81BYYUAAAAAAHJw4AAAAABAAAAAGOiyZ/+kecCdxYBXywkAFwsSrGLYqD4IiVglvKCvaWHAAAAAQAAAADShvreeub1LWzv6W93J+BROl6MxA6GAyXFy86/NQWGFAAAAAAAAAAXSHboAAAAAAAAAAACgr2lhwAAAEBt+7drpsNo3bFHELxKCa1TiGNDGIFjWZGxEdCOGXw64+wUn3djRI2EuAXQkZLVKr8E/1BZEUShbGfQ3wrnlF0Ggr2lhwAAAEBt+7drpsNo3bFHELxKCa1TiGNDGIFjWZGxEdCOGXw64+wUn3djRI2EuAXQkZLVKr8E/1BZEUShbGfQ3wrnlF0G"
+	expectedTxn := "AAAAAPgDPeMpTqVvOr8vkcb38bMFP4Vi6w7PvWjJgxtmQ/4YAAAAyAAAAAAAAAACAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAEAAAAA+AM94ylOpW86vy+RxvfxswU/hWLrDs+9aMmDG2ZD/hgAAAAAAAAAANKG+t565vUtbO/pb3cn4FE6XozEDoYDJcXLzr81BYYUAAAAAACYloAAAAABAAAAAPXQ8gjyrVHa47a6JDPkVHwPPDKxNRE2QBcamA4JvlOGAAAAAQAAAADShvreeub1LWzv6W93J+BROl6MxA6GAyXFy86/NQWGFAAAAAAAAAAXR95RgAAAAAAAAAACZkP+GAAAAEDpGRrZjQhnRxJwFoOA7jj2CPeYbGZcYAMke1I5XEb0qzXPgOfTyLlSolcrSzPT1sMvED7gEGc8s+bNiAe/5GYGCb5ThgAAAECd46/tB7j4h/5rUhmDobZT1DO0zK3DguZEyHQr1H4Wl7w2ozU5oP9oaWYH87H2mRnT1EfkUKnIFdnVBl6UAmAO"
 	assert.Equal(t, expectedTxn, txSuccess.Env)
 
 	// Don't assert on tx values below, since the completion order is unknown.

--- a/services/friendbot/internal/friendbot_test.go
+++ b/services/friendbot/internal/friendbot_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"log"
 	"testing"
 
 	"github.com/stellar/go/clients/horizon"
@@ -10,30 +11,40 @@ import (
 )
 
 func TestFriendbot_Pay(t *testing.T) {
-	mockSubmitTransaction := func(bot *Bot, channel chan TxResult, signed string) {
+	mockSubmitTransaction := func(minion *Minion, hclient *horizon.Client, signed string) {
 		txSuccess := horizon.TransactionSuccess{Env: signed}
-		// we don't want to actually submit the tx here but emulate a success instead
-		channel <- TxResult{
+		// we don't want to submit the tx but emulate a success instead
+		minion.TxResultChan <- TxResult{
 			maybeTransactionSuccess: &txSuccess,
 			maybeErr:                nil,
 		}
 	}
 
+	minions := []Minion{
+		Minion{
+			Secret:       "SC6K74F25SXMNHFLXJDRIIJWBCEOWXDHU3R6RW43RZSZTA2XFIOFYCFT",
+			DestAddrChan: make(chan string),
+			TxResultChan: make(chan TxResult),
+			sequence:     2,
+		},
+	}
 	fb := &Bot{
 		Secret:            "SAQWC7EPIYF3XGILYVJM4LVAVSLZKT27CTEI3AFBHU2VRCMQ3P3INPG5",
 		Network:           "Test SDF Network ; September 2015",
 		StartingBalance:   "100.00",
 		SubmitTransaction: mockSubmitTransaction,
-		sequence:          2,
+		Minions:           minions,
+		nextMinionIndex:   0,
 	}
 
 	txSuccess, err := fb.Pay("GDJIN6W6PLTPKLLM57UW65ZH4BITUXUMYQHIMAZFYXF45PZVAWDBI77Z")
 	if !assert.NoError(t, err) {
 		return
 	}
-	expectedTxn := "AAAAAPuYf7x7KGvFX9fjCR9WIaoTX3yHJYwX6ZSx6w76HPjEAAAAZAAAAAAAAAADAAAAAAAAAAAAAAAB" +
-		"AAAAAAAAAAAAAAAA0ob63nrm9S1s7+lvdyfgUTpejMQOhgMlxcvOvzUFhhQAAAAAO5rKAAAAAAAAAAAB+hz4xAAAAEC" +
-		"zNV2yXevMYKzm7OhXX2gYwmLZ5V37yeRHUX3Vhb6eT8wkUtpj2vJsUwzLWjdKMyGonFCPkaG4twRFUVqBRLEH"
+
+	log.Print(txSuccess.Env)
+
+	expectedTxn := "AAAAAGOiyZ/+kecCdxYBXywkAFwsSrGLYqD4IiVglvKCvaWHAAAAyAAAAAAAAAADAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAA0ob63nrm9S1s7+lvdyfgUTpejMQOhgMlxcvOvzUFhhQAAAAAAAAAAAAAAAEAAAAA+5h/vHsoa8Vf1+MJH1YhqhNffIcljBfplLHrDvoc+MQAAAABAAAAANKG+t565vUtbO/pb3cn4FE6XozEDoYDJcXLzr81BYYUAAAAAAAAAAA7msoAAAAAAAAAAAL6HPjEAAAAQK+pRYAmYSks2TwQI32M5f6l43HD19tr96xfMhTAzt8JBoycWrsqQd2wyBI43SIXAoJyqq/wi9xGf0WReDFF4AuCvaWHAAAAQF3Ipfu8bgH3JNewaJRMAZDNcb+gGLIHoM6+u7lsqWkhkmTlP51BK0CqG9BybkjoGQsObjtqqScmmy7g2pWR2AI="
 	assert.Equal(t, expectedTxn, txSuccess.Env)
 
 	var wg sync.WaitGroup

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -87,18 +87,12 @@ func (minion *Minion) checkHandleBadSequence(err *horizonclient.Error) {
 func (minion *Minion) makeTx(destAddress string) (string, error) {
 	createAccountOp := txnbuild.CreateAccount{
 		Destination:   destAddress,
-		SourceAccount: minion.Account,
-		Amount:        createAccountInitialAmount, // Minimum account amount.
-	}
-	paymentOp := txnbuild.Payment{
-		Destination:   destAddress,
-		Amount:        minion.StartingBalance,
-		Asset:         txnbuild.NativeAsset{},
 		SourceAccount: minion.BotAccount,
+		Amount:        minion.StartingBalance,
 	}
 	txn := txnbuild.Transaction{
 		SourceAccount: minion.Account,
-		Operations:    []txnbuild.Operation{&createAccountOp, &paymentOp},
+		Operations:    []txnbuild.Operation{&createAccountOp},
 		Network:       minion.Network,
 		Timebounds:    txnbuild.NewInfiniteTimeout(),
 	}

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stellar/go/txnbuild"
 )
 
-const createAccountInitAmt = "3.0"
+const createAccountInitialAmount = "1.0"
 
 // Minion contains a Stellar channel account and Go channels to communicate with friendbot.
 type Minion struct {
@@ -88,7 +88,7 @@ func (minion *Minion) makeTx(destAddress string) (string, error) {
 	createAccountOp := txnbuild.CreateAccount{
 		Destination:   destAddress,
 		SourceAccount: minion.Account,
-		Amount:        "1.00", // Minimum account amount.
+		Amount:        createAccountInitialAmount, // Minimum account amount.
 	}
 	paymentOp := txnbuild.Payment{
 		Destination:   destAddress,

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -85,7 +85,6 @@ func (minion *Minion) checkHandleBadSequence(err *horizonclient.Error) {
 }
 
 func (minion *Minion) makeTx(destAddress string) (string, error) {
-	// XXX: Subtract CreateAccount Amount from payment balance.
 	createAccountOp := txnbuild.CreateAccount{
 		Destination:   destAddress,
 		SourceAccount: minion.Account,

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -1,10 +1,6 @@
 package internal
 
 import (
-	"context"
-	"log"
-	"time"
-
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	hProtocol "github.com/stellar/go/protocols/horizon"
@@ -23,7 +19,6 @@ type Minion struct {
 	Horizon           *horizonclient.Client
 	Network           string
 	StartingBalance   string
-	InputChan         chan MinionInput
 	SubmitTransaction func(minion *Minion, hclient *horizonclient.Client, tx string) (*hProtocol.TransactionSuccess, error)
 
 	// Uninitialized.
@@ -32,40 +27,25 @@ type Minion struct {
 
 // Run reads a payment destination address and an output channel. It attempts
 // to pay that address and submits the result to the channel.
-func (minion *Minion) Run(ctx context.Context) {
-	defer log.Printf("Run for Minion with address %s exiting", minion.Account.GetAccountID())
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case minionInput, ok := <-minion.InputChan:
-			log.Printf("Ok value: %v", ok)
-			log.Print("just received minion input")
-			log.Print("calling checkSequenceRefresh")
-			err := minion.checkSequenceRefresh(minion.Horizon)
-			if err != nil {
-				minionInput.resultChan <- SubmitResult{
-					maybeTransactionSuccess: nil,
-					maybeErr:                errors.Wrap(err, "checking minion seq"),
-				}
-			}
-			log.Printf("calling makeTx with destAddress %s", minionInput.destAddress)
-			txStr, err := minion.makeTx(minionInput.destAddress)
-			if err != nil {
-				minionInput.resultChan <- SubmitResult{
-					maybeTransactionSuccess: nil,
-					maybeErr:                errors.Wrap(err, "making payment tx"),
-				}
-			}
-			log.Print("about to SubmitTransaction")
-			succ, err := minion.SubmitTransaction(minion, minion.Horizon, txStr)
-			minionInput.resultChan <- SubmitResult{
-				maybeTransactionSuccess: succ,
-				maybeErr:                err,
-			}
-		default:
-			time.Sleep(1)
+func (minion *Minion) Run(destAddress string, resultChan chan SubmitResult) {
+	err := minion.checkSequenceRefresh(minion.Horizon)
+	if err != nil {
+		resultChan <- SubmitResult{
+			maybeTransactionSuccess: nil,
+			maybeErr:                errors.Wrap(err, "checking minion seq"),
 		}
+	}
+	txStr, err := minion.makeTx(destAddress)
+	if err != nil {
+		resultChan <- SubmitResult{
+			maybeTransactionSuccess: nil,
+			maybeErr:                errors.Wrap(err, "making payment tx"),
+		}
+	}
+	succ, err := minion.SubmitTransaction(minion, minion.Horizon, txStr)
+	resultChan <- SubmitResult{
+		maybeTransactionSuccess: succ,
+		maybeErr:                err,
 	}
 }
 
@@ -87,13 +67,11 @@ func (minion *Minion) checkSequenceRefresh(hclient *horizonclient.Client) error 
 	if minion.Account.Sequence != 0 && !minion.forceRefreshSequence {
 		return nil
 	}
-	log.Print("about to refresh seqnum")
 	err := minion.Account.RefreshSequenceNumber(hclient)
 	if err != nil {
 		return errors.Wrap(err, "refreshing minion seqnum")
 	}
 	minion.forceRefreshSequence = false
-	log.Print("returning from checkSequenceRefresh")
 	return nil
 }
 
@@ -107,10 +85,11 @@ func (minion *Minion) checkHandleBadSequence(err *horizonclient.Error) {
 }
 
 func (minion *Minion) makeTx(destAddress string) (string, error) {
+	// XXX: Subtract CreateAccount Amount from payment balance.
 	createAccountOp := txnbuild.CreateAccount{
 		Destination:   destAddress,
 		SourceAccount: minion.Account,
-		Amount:        createAccountInitAmt,
+		Amount:        "3.00",
 	}
 	paymentOp := txnbuild.Payment{
 		Destination:   destAddress,

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -1,12 +1,18 @@
 package internal
 
 import (
+	"context"
+	"log"
+	"time"
+
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/txnbuild"
 )
+
+const createAccountInitAmt = "3.0"
 
 // Minion contains a Stellar channel account and Go channels to communicate with friendbot.
 type Minion struct {
@@ -26,27 +32,39 @@ type Minion struct {
 
 // Run reads a payment destination address and an output channel. It attempts
 // to pay that address and submits the result to the channel.
-func (minion *Minion) Run() {
+func (minion *Minion) Run(ctx context.Context) {
+	defer log.Printf("Run for Minion with address %s exiting", minion.Account.GetAccountID())
 	for {
-		minionInput := <-minion.InputChan
-		err := minion.checkSequenceRefresh(minion.Horizon)
-		if err != nil {
-			minionInput.resultChan <- SubmitResult{
-				maybeTransactionSuccess: nil,
-				maybeErr:                errors.Wrap(err, "checking minion seq"),
+		select {
+		case <-ctx.Done():
+			return
+		case minionInput, ok := <-minion.InputChan:
+			log.Printf("Ok value: %v", ok)
+			log.Print("just received minion input")
+			log.Print("calling checkSequenceRefresh")
+			err := minion.checkSequenceRefresh(minion.Horizon)
+			if err != nil {
+				minionInput.resultChan <- SubmitResult{
+					maybeTransactionSuccess: nil,
+					maybeErr:                errors.Wrap(err, "checking minion seq"),
+				}
 			}
-		}
-		txStr, err := minion.makeTx(minionInput.destAddress)
-		if err != nil {
-			minionInput.resultChan <- SubmitResult{
-				maybeTransactionSuccess: nil,
-				maybeErr:                errors.Wrap(err, "making payment tx"),
+			log.Printf("calling makeTx with destAddress %s", minionInput.destAddress)
+			txStr, err := minion.makeTx(minionInput.destAddress)
+			if err != nil {
+				minionInput.resultChan <- SubmitResult{
+					maybeTransactionSuccess: nil,
+					maybeErr:                errors.Wrap(err, "making payment tx"),
+				}
 			}
-		}
-		succ, err := minion.SubmitTransaction(minion, minion.Horizon, txStr)
-		minionInput.resultChan <- SubmitResult{
-			maybeTransactionSuccess: succ,
-			maybeErr:                err,
+			log.Print("about to SubmitTransaction")
+			succ, err := minion.SubmitTransaction(minion, minion.Horizon, txStr)
+			minionInput.resultChan <- SubmitResult{
+				maybeTransactionSuccess: succ,
+				maybeErr:                err,
+			}
+		default:
+			time.Sleep(1)
 		}
 	}
 }
@@ -69,11 +87,13 @@ func (minion *Minion) checkSequenceRefresh(hclient *horizonclient.Client) error 
 	if minion.Account.Sequence != 0 && !minion.forceRefreshSequence {
 		return nil
 	}
+	log.Print("about to refresh seqnum")
 	err := minion.Account.RefreshSequenceNumber(hclient)
 	if err != nil {
 		return errors.Wrap(err, "refreshing minion seqnum")
 	}
 	minion.forceRefreshSequence = false
+	log.Print("returning from checkSequenceRefresh")
 	return nil
 }
 
@@ -88,8 +108,9 @@ func (minion *Minion) checkHandleBadSequence(err *horizonclient.Error) {
 
 func (minion *Minion) makeTx(destAddress string) (string, error) {
 	createAccountOp := txnbuild.CreateAccount{
-		Destination: destAddress,
-		Amount:      minion.StartingBalance,
+		Destination:   destAddress,
+		SourceAccount: minion.Account,
+		Amount:        createAccountInitAmt,
 	}
 	paymentOp := txnbuild.Payment{
 		Destination:   destAddress,

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -45,7 +45,7 @@ func (minion *Minion) Run(destAddress string, resultChan chan SubmitResult) {
 	succ, err := minion.SubmitTransaction(minion, minion.Horizon, txStr)
 	resultChan <- SubmitResult{
 		maybeTransactionSuccess: succ,
-		maybeErr:                err,
+		maybeErr:                errors.Wrap(err, "submitting tx to minion"),
 	}
 }
 
@@ -57,7 +57,7 @@ func SubmitTransaction(minion *Minion, hclient *horizonclient.Client, tx string)
 		case *horizonclient.Error:
 			minion.checkHandleBadSequence(e)
 		}
-		return nil, err
+		return nil, errors.Wrap(err, "submitting tx to horizon")
 	}
 	return &result, nil
 }
@@ -88,7 +88,7 @@ func (minion *Minion) makeTx(destAddress string) (string, error) {
 	createAccountOp := txnbuild.CreateAccount{
 		Destination:   destAddress,
 		SourceAccount: minion.Account,
-		Amount:        "3.00",
+		Amount:        "1.00", // Minimum account amount.
 	}
 	paymentOp := txnbuild.Payment{
 		Destination:   destAddress,

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/keypair"
+	hProtocol "github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/txnbuild"
+)
+
+// Minion contains a Stellar channel account and Go channels to communicate with friendbot.
+type Minion struct {
+	Account           Account
+	Keypair           *keypair.Full
+	BotAccount        txnbuild.Account
+	BotKeypair        *keypair.Full
+	Horizon           *horizonclient.Client
+	Network           string
+	StartingBalance   string
+	InputChan         chan MinionInput
+	SubmitTransaction func(minion *Minion, hclient *horizonclient.Client, tx string) (*hProtocol.TransactionSuccess, error)
+
+	// Uninitialized.
+	forceRefreshSequence bool
+}
+
+// Run reads a payment destination address and an output channel. It attempts
+// to pay that address and submits the result to the channel.
+func (minion *Minion) Run() {
+	for {
+		minionInput := <-minion.InputChan
+		err := minion.checkSequenceRefresh(minion.Horizon)
+		if err != nil {
+			minionInput.resultChan <- SubmitResult{
+				maybeTransactionSuccess: nil,
+				maybeErr:                errors.Wrap(err, "checking minion seq"),
+			}
+		}
+		txStr, err := minion.makeTx(minionInput.destAddress)
+		if err != nil {
+			minionInput.resultChan <- SubmitResult{
+				maybeTransactionSuccess: nil,
+				maybeErr:                errors.Wrap(err, "making payment tx"),
+			}
+		}
+		succ, err := minion.SubmitTransaction(minion, minion.Horizon, txStr)
+		minionInput.resultChan <- SubmitResult{
+			maybeTransactionSuccess: succ,
+			maybeErr:                err,
+		}
+	}
+}
+
+// SubmitTransaction should be passed to the Minion.
+func SubmitTransaction(minion *Minion, hclient *horizonclient.Client, tx string) (*hProtocol.TransactionSuccess, error) {
+	result, err := hclient.SubmitTransactionXDR(tx)
+	if err != nil {
+		switch e := err.(type) {
+		case *horizonclient.Error:
+			minion.checkHandleBadSequence(e)
+		}
+		return nil, err
+	}
+	return &result, nil
+}
+
+// Establishes the minion's initial sequence number, if needed.
+func (minion *Minion) checkSequenceRefresh(hclient *horizonclient.Client) error {
+	if minion.Account.Sequence != 0 && !minion.forceRefreshSequence {
+		return nil
+	}
+	err := minion.Account.RefreshSequenceNumber(hclient)
+	if err != nil {
+		return errors.Wrap(err, "refreshing minion seqnum")
+	}
+	minion.forceRefreshSequence = false
+	return nil
+}
+
+func (minion *Minion) checkHandleBadSequence(err *horizonclient.Error) {
+	resCode, e := err.ResultCodes()
+	isTxBadSeqCode := e == nil && resCode.TransactionCode == "tx_bad_seq"
+	if !isTxBadSeqCode {
+		return
+	}
+	minion.forceRefreshSequence = true
+}
+
+func (minion *Minion) makeTx(destAddress string) (string, error) {
+	createAccountOp := txnbuild.CreateAccount{
+		Destination: destAddress,
+		Amount:      minion.StartingBalance,
+	}
+	paymentOp := txnbuild.Payment{
+		Destination:   destAddress,
+		Amount:        minion.StartingBalance,
+		Asset:         txnbuild.NativeAsset{},
+		SourceAccount: minion.BotAccount,
+	}
+	txn := txnbuild.Transaction{
+		SourceAccount: minion.Account,
+		Operations:    []txnbuild.Operation{&createAccountOp, &paymentOp},
+		Network:       minion.Network,
+		Timebounds:    txnbuild.NewInfiniteTimeout(),
+	}
+	txe, err := txn.BuildSignEncode(minion.Keypair, minion.BotKeypair)
+	if err != nil {
+		return "", errors.Wrap(err, "making account payment tx")
+	}
+	// Increment the in-memory sequence number, since the tx will be submitted.
+	_, err = minion.Account.IncrementSequenceNumber()
+	if err != nil {
+		return "", errors.Wrap(err, "incrementing minion seq")
+	}
+	return txe, err
+}

--- a/services/friendbot/loadtest/loadtest.go
+++ b/services/friendbot/loadtest/loadtest.go
@@ -17,8 +17,7 @@ type maybeDuration struct {
 }
 
 func main() {
-	// Friendbot must be running
-	// Get Friendbot URL from CL. Friendbot must be running as a local server.
+	// Friendbot must be running as a local server. Get Friendbot URL from CL.
 	fbURL := flag.String("url", "http://0.0.0.0:8000/", "URL of friendbot")
 	numRequests := flag.Int("requests", 500, "number of requests")
 	flag.Parse()
@@ -32,9 +31,7 @@ func main() {
 		go makeFriendbotRequest(address, *fbURL, durationChannel)
 
 		time.Sleep(time.Duration(500) * time.Millisecond)
-		time.Sleep(time.Second)
 	}
-	time.Sleep(time.Duration(10) * time.Second)
 	durations := []time.Duration{}
 	for i := 0; i < *numRequests; i++ {
 		durations = append(durations, <-durationChannel)
@@ -51,7 +48,6 @@ func makeFriendbotRequest(address, fbURL string, durationChannel chan time.Durat
 	resp, _ := http.PostForm(fbURL, formData)
 	var result map[string]interface{}
 	json.NewDecoder(resp.Body).Decode(&result)
-	log.Print(result)
 }
 
 func timeTrack(start time.Time, name string, durationChannel chan time.Duration) {

--- a/services/friendbot/loadtest/loadtest.go
+++ b/services/friendbot/loadtest/loadtest.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/stellar/go/keypair"
+)
+
+func main() {
+	// Friendbot must be running
+	// Get Friendbot URL from CL. Friendbot must be running as a local server.
+	fbURL := flag.String("url", "http://0.0.0.0:8000/", "URL of friendbot")
+	numRequests := flag.Int("requests", 500, "number of requests")
+	flag.Parse()
+	durations := []time.Duration{}
+	for i := 0; i < 500; i++ {
+		kp, err := keypair.Random()
+		if err != nil {
+			panic(err)
+		}
+		address := kp.Address()
+		err = makeFriendbotRequest(address, *fbURL, &durations)
+		if err != nil {
+			panic(err)
+		}
+		time.Sleep(time.Duration(500) * time.Millisecond)
+	}
+	log.Printf("Got %d times with average %d", *numRequests, mean(durations))
+}
+
+func makeFriendbotRequest(address, fbURL string, durations *[]time.Duration) error {
+	defer timeTrack(time.Now(), "makeFriendbotRequest", durations)
+	formData := url.Values{
+		"addr": {address},
+	}
+	resp, err := http.PostForm(fbURL, formData)
+	if err != nil {
+		return err
+	}
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	log.Print(result)
+	return nil
+}
+
+func timeTrack(start time.Time, name string, durations *[]time.Duration) {
+	elapsed := time.Since(start)
+	log.Printf("%s took %s", name, elapsed)
+	*durations = append(*durations, elapsed)
+}
+
+func mean(durations []time.Duration) time.Duration {
+	var total time.Duration
+	for _, d := range durations {
+		total += d
+	}
+	return total / time.Duration(len(durations))
+}

--- a/services/friendbot/loadtest/loadtest.go
+++ b/services/friendbot/loadtest/loadtest.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/support/errors"
 )
 
 type maybeDuration struct {
@@ -21,7 +22,7 @@ func main() {
 	fbURL := flag.String("url", "http://0.0.0.0:8000/", "URL of friendbot")
 	numRequests := flag.Int("requests", 500, "number of requests")
 	flag.Parse()
-	durationChannel := make(chan time.Duration, *numRequests)
+	durationChannel := make(chan maybeDuration, *numRequests)
 	for i := 0; i < *numRequests; i++ {
 		kp, err := keypair.Random()
 		if err != nil {
@@ -32,7 +33,7 @@ func main() {
 
 		time.Sleep(time.Duration(500) * time.Millisecond)
 	}
-	durations := []time.Duration{}
+	durations := []maybeDuration{}
 	for i := 0; i < *numRequests; i++ {
 		durations = append(durations, <-durationChannel)
 	}
@@ -40,26 +41,40 @@ func main() {
 	log.Printf("Got %d times with average %s", *numRequests, mean(durations))
 }
 
-func makeFriendbotRequest(address, fbURL string, durationChannel chan time.Duration) {
-	defer timeTrack(time.Now(), "makeFriendbotRequest", durationChannel)
+func makeFriendbotRequest(address, fbURL string, durationChannel chan maybeDuration) {
+	start := time.Now()
 	formData := url.Values{
 		"addr": {address},
 	}
-	resp, _ := http.PostForm(fbURL, formData)
+	resp, err := http.PostForm(fbURL, formData)
+	if err != nil {
+		log.Printf("Got post error: %s", err)
+		durationChannel <- maybeDuration{maybeError: errors.Wrap(err, "posting form")}
+	}
 	var result map[string]interface{}
-	json.NewDecoder(resp.Body).Decode(&result)
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	if err != nil {
+		log.Printf("Got decode error: %s", err)
+		durationChannel <- maybeDuration{maybeError: errors.Wrap(err, "decoding json")}
+	}
+	timeTrack(start, "makeFriendbotRequest", durationChannel)
 }
 
-func timeTrack(start time.Time, name string, durationChannel chan time.Duration) {
+func timeTrack(start time.Time, name string, durationChannel chan maybeDuration) {
 	elapsed := time.Since(start)
 	log.Printf("%s took %s", name, elapsed)
-	durationChannel <- elapsed
+	durationChannel <- maybeDuration{maybeDuration: elapsed}
 }
 
-func mean(durations []time.Duration) time.Duration {
+func mean(durations []maybeDuration) time.Duration {
 	var total time.Duration
+	count := 0
 	for _, d := range durations {
-		total += d
+		if d.maybeError != nil {
+			continue
+		}
+		total += d.maybeDuration
+		count++
 	}
-	return total / time.Duration(len(durations))
+	return total / time.Duration(count)
 }

--- a/services/friendbot/loadtest/loadtest.go
+++ b/services/friendbot/loadtest/loadtest.go
@@ -11,47 +11,53 @@ import (
 	"github.com/stellar/go/keypair"
 )
 
+type maybeDuration struct {
+	maybeDuration time.Duration
+	maybeError    error
+}
+
 func main() {
 	// Friendbot must be running
 	// Get Friendbot URL from CL. Friendbot must be running as a local server.
 	fbURL := flag.String("url", "http://0.0.0.0:8000/", "URL of friendbot")
 	numRequests := flag.Int("requests", 500, "number of requests")
 	flag.Parse()
-	durations := []time.Duration{}
-	for i := 0; i < 500; i++ {
+	durationChannel := make(chan time.Duration, *numRequests)
+	for i := 0; i < *numRequests; i++ {
 		kp, err := keypair.Random()
 		if err != nil {
 			panic(err)
 		}
 		address := kp.Address()
-		err = makeFriendbotRequest(address, *fbURL, &durations)
-		if err != nil {
-			panic(err)
-		}
+		go makeFriendbotRequest(address, *fbURL, durationChannel)
+
 		time.Sleep(time.Duration(500) * time.Millisecond)
+		time.Sleep(time.Second)
 	}
-	log.Printf("Got %d times with average %d", *numRequests, mean(durations))
+	time.Sleep(time.Duration(10) * time.Second)
+	durations := []time.Duration{}
+	for i := 0; i < *numRequests; i++ {
+		durations = append(durations, <-durationChannel)
+	}
+	close(durationChannel)
+	log.Printf("Got %d times with average %s", *numRequests, mean(durations))
 }
 
-func makeFriendbotRequest(address, fbURL string, durations *[]time.Duration) error {
-	defer timeTrack(time.Now(), "makeFriendbotRequest", durations)
+func makeFriendbotRequest(address, fbURL string, durationChannel chan time.Duration) {
+	defer timeTrack(time.Now(), "makeFriendbotRequest", durationChannel)
 	formData := url.Values{
 		"addr": {address},
 	}
-	resp, err := http.PostForm(fbURL, formData)
-	if err != nil {
-		return err
-	}
+	resp, _ := http.PostForm(fbURL, formData)
 	var result map[string]interface{}
 	json.NewDecoder(resp.Body).Decode(&result)
 	log.Print(result)
-	return nil
 }
 
-func timeTrack(start time.Time, name string, durations *[]time.Duration) {
+func timeTrack(start time.Time, name string, durationChannel chan time.Duration) {
 	elapsed := time.Since(start)
 	log.Printf("%s took %s", name, elapsed)
-	*durations = append(*durations, elapsed)
+	durationChannel <- elapsed
 }
 
 func mean(durations []time.Duration) time.Duration {

--- a/services/friendbot/main.go
+++ b/services/friendbot/main.go
@@ -58,7 +58,11 @@ func run(cmd *cobra.Command, args []string) {
 		}
 		os.Exit(1)
 	}
-	fb := initFriendbot(cfg.FriendbotSecret, cfg.NetworkPassphrase, cfg.HorizonURL, cfg.StartingBalance, cfg.NumMinions)
+	fb, err := initFriendbot(cfg.FriendbotSecret, cfg.NetworkPassphrase, cfg.HorizonURL, cfg.StartingBalance, cfg.NumMinions)
+	if err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
 	router := initRouter(fb)
 	registerProblems()
 

--- a/services/friendbot/main.go
+++ b/services/friendbot/main.go
@@ -25,6 +25,7 @@ type Config struct {
 	HorizonURL        string      `toml:"horizon_url" valid:"required"`
 	StartingBalance   string      `toml:"starting_balance" valid:"required"`
 	TLS               *config.TLS `valid:"optional"`
+	NumMinions        int         `toml:"num_minions" valid:"optional"`
 }
 
 func main() {
@@ -57,8 +58,7 @@ func run(cmd *cobra.Command, args []string) {
 		}
 		os.Exit(1)
 	}
-
-	fb := initFriendbot(cfg.FriendbotSecret, cfg.NetworkPassphrase, cfg.HorizonURL, cfg.StartingBalance)
+	fb := initFriendbot(cfg.FriendbotSecret, cfg.NetworkPassphrase, cfg.HorizonURL, cfg.StartingBalance, cfg.NumMinions)
 	router := initRouter(fb)
 	registerProblems()
 


### PR DESCRIPTION
This PR adds Stellar channels to friendbot. The goal is to reduce bad sequence errors (`tx_bad_seq`) and general slowness during heavy load. The new `Minion` struct contains the Stellar channel, a sequence number, and associated methods that are moved from `Bot`. `Bot` contains a list of `Minions`. This also updates friendbot to use the new Go SDK. Closes #1156, #1249  .