### PR TITLE
build: add deprecated tags

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,3 @@
+# build
+
+## This package is deprecated use [txnbuild](../txnbuild) instead

--- a/build/README.md
+++ b/build/README.md
@@ -1,3 +1,3 @@
 # build
 
-## This package is deprecated use [txnbuild](../txnbuild) instead
+## This package is deprecated: use [txnbuild](../txnbuild) instead

--- a/build/account_merge.go
+++ b/build/account_merge.go
@@ -20,6 +20,7 @@ type AccountMergeMutator interface {
 }
 
 // AccountMergeBuilder represents a transaction that is being built.
+// Deprecated use txnbuild.AccountMerge instead
 type AccountMergeBuilder struct {
 	O           xdr.Operation
 	Destination xdr.AccountId

--- a/build/allow_trust.go
+++ b/build/allow_trust.go
@@ -19,6 +19,7 @@ type AllowTrustMutator interface {
 }
 
 // AllowTrustBuilder represents a transaction that is being built.
+// Deprecated use txnbuild.AllowTrust instead
 type AllowTrustBuilder struct {
 	O   xdr.Operation
 	AT  xdr.AllowTrustOp

--- a/build/bump_sequence.go
+++ b/build/bump_sequence.go
@@ -20,6 +20,7 @@ type BumpSequenceMutator interface {
 }
 
 // BumpSequenceBuilder helps to build BumpSequenceOp structs.
+// Deprecated use txnbuild.BumpSequence instead
 type BumpSequenceBuilder struct {
 	O   xdr.Operation
 	BS  xdr.BumpSequenceOp

--- a/build/change_trust.go
+++ b/build/change_trust.go
@@ -20,6 +20,7 @@ type ChangeTrustMutator interface {
 }
 
 // ChangeTrustBuilder represents a transaction that is being built.
+// Deprecated use txnbuild.ChangeTrust instead
 type ChangeTrustBuilder struct {
 	O   xdr.Operation
 	CT  xdr.ChangeTrustOp

--- a/build/create_account.go
+++ b/build/create_account.go
@@ -21,6 +21,7 @@ type CreateAccountMutator interface {
 }
 
 // CreateAccountBuilder helps to build CreateAccountOp structs.
+// Deprecated use txnbuild.CreateAccount instead
 type CreateAccountBuilder struct {
 	O   xdr.Operation
 	CA  xdr.CreateAccountOp

--- a/build/inflation.go
+++ b/build/inflation.go
@@ -12,6 +12,7 @@ func Inflation(muts ...interface{}) (result InflationBuilder) {
 }
 
 // InflationBuilder represents an operation that is being built.
+// Deprecated use txnbuild.Inflation instead
 type InflationBuilder struct {
 	O   xdr.Operation
 	Err error

--- a/build/main.go
+++ b/build/main.go
@@ -5,8 +5,8 @@
 // object (ex. PaymentBuilder, TransactionBuilder) contain an underlying xdr
 // struct that is being iteratively built by having zero or more Mutator structs
 // applied to it. See ExampleTransactionBuilder in main_test.go for an example.
-// Deprecated: build package with all its exported methods and variables will no longer
-// maintained. It will be removed in future versions of the SDK. Use txnbuild instead.
+// Deprecated: build package with all its exported methods and variables will no longer be
+// maintained. It will be removed in future versions of the SDK. Use txnbuild (https://godoc.org/github.com/stellar/go/txnbuild) instead.
 package build
 
 import (

--- a/build/main.go
+++ b/build/main.go
@@ -5,7 +5,8 @@
 // object (ex. PaymentBuilder, TransactionBuilder) contain an underlying xdr
 // struct that is being iteratively built by having zero or more Mutator structs
 // applied to it. See ExampleTransactionBuilder in main_test.go for an example.
-//
+// Deprecated: build package with all its exported methods and variables will no longer
+// maintained. It will be removed in future versions of the SDK. Use txnbuild instead.
 package build
 
 import (

--- a/build/manage_data.go
+++ b/build/manage_data.go
@@ -27,6 +27,7 @@ func SetData(name string, value []byte, muts ...interface{}) (result ManageDataB
 }
 
 // ManageDataBuilder helps to build ManageDataOp structs.
+// Deprecated use txnbuild.ManageData instead
 type ManageDataBuilder struct {
 	O   xdr.Operation
 	MD  xdr.ManageDataOp

--- a/build/manage_offer.go
+++ b/build/manage_offer.go
@@ -42,6 +42,7 @@ type ManageOfferMutator interface {
 }
 
 // ManageOfferBuilder represents a transaction that is being built.
+// Deprecated use txnbuild.ManageSellOffer instead
 type ManageOfferBuilder struct {
 	PassiveOffer bool
 	O            xdr.Operation

--- a/build/payment.go
+++ b/build/payment.go
@@ -21,6 +21,7 @@ type PaymentMutator interface {
 }
 
 // PaymentBuilder represents a transaction that is being built.
+// Deprecated use txnbuild.Payment instead
 type PaymentBuilder struct {
 	PathPayment bool
 	O           xdr.Operation

--- a/build/set_options.go
+++ b/build/set_options.go
@@ -19,6 +19,7 @@ type SetOptionsMutator interface {
 }
 
 // SetOptionsBuilder represents a transaction that is being built.
+// Deprecated use txnbuild.SetOptions instead
 type SetOptionsBuilder struct {
 	O   xdr.Operation
 	SO  xdr.SetOptionsOp

--- a/build/transaction.go
+++ b/build/transaction.go
@@ -32,6 +32,7 @@ type TransactionMutator interface {
 }
 
 // TransactionBuilder represents a Transaction that is being constructed.
+// Deprecated use txnbuild.Transaction instead
 type TransactionBuilder struct {
 	TX                *xdr.Transaction
 	NetworkPassphrase string

--- a/clients/horizon/README.md
+++ b/clients/horizon/README.md
@@ -1,0 +1,3 @@
+# horizon
+
+## This package is deprecated use [horizonclient](../horizonclient) instead

--- a/clients/horizon/README.md
+++ b/clients/horizon/README.md
@@ -1,3 +1,3 @@
 # horizon
 
-## This package is deprecated use [horizonclient](../horizonclient) instead
+## This package is deprecated use: [horizonclient](../horizonclient) instead

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -4,8 +4,9 @@
 // Create an instance of `Client` to customize the server used, or alternatively
 // use `DefaultTestNetClient` or `DefaultPublicNetClient` to access the SDF run
 // horizon servers.
-// Deprecated: clients/horizon package with all its exported methods and variables will no longer
-// maintained. It will be removed in future versions of the SDK. Use clients/horizonclient instead.
+// Deprecated: clients/horizon package with all its exported methods and variables will no longer be
+// maintained. It will be removed in future versions of the SDK.
+// Use clients/horizonclient (https://godoc.org/github.com/stellar/go/clients/horizonclient) instead.
 package horizon
 
 import (


### PR DESCRIPTION
This PR add deprecated tags to the `build` package. 
It also adds readme files to the `build` and `clients/horizon` packages with  a notice that these packages are deprecated. 
This is to be merged after `txnbuild` is moved from the `exp` folder