### PR TITLE
horizonclient, txnbuild: dev docs

### DIFF
--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -1,4 +1,14 @@
-// Package horizonclient is an experimental horizon client that provides access to the horizon server
+/*
+ Package horizonclient provides client access to a Horizon server, allowing an application to post
+ transactions and look up ledger information.
+
+This library provides an interface to the Stellar Horizon service. It supports the building of Go applications on
+top of the Stellar network (https://www.stellar.org/). Transactions may be constructed using the sister package to
+this one, txnbuild (https://github.com/stellar/go/tree/master/txnbuild), and then submitted with this client to any
+Horizon instance for processing onto the ledger. Together, these two libraries provide a complete Stellar SDK.
+
+For more information and further examples, see https://www.stellar.org/developers/go/reference/index.html.
+*/
 package horizonclient
 
 import (

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -2,17 +2,17 @@
 title: Overview
 ---
 
-The Go SDK contains packages for interacting with most aspects of the stellar ecosystem.  In addition to generally useful, low-level packages such as [`keypair`](https://godoc.org/github.com/stellar/go/keypair) (used for creating stellar-compliant public/secret key pairs), the Go SDK also contains code for the server applications and client tools written in go.
+The Go SDK is a set of packages for interacting with most aspects of the Stellar ecosystem. The primary component is the Horizon SDK, which provides convenient access to Horizon services. There are also packages for other Stellar services such as [TOML support](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md) and [federation](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0002.md).
 
-## Godoc reference
+## Horizon SDK
 
-The most accurate and up-to-date reference information on the Go SDK is found within godoc.  The godoc.org service automatically updates the documentation for the Go SDK everytime github is updated.  The godoc for all of our packages can be found at (https://godoc.org/github.com/stellar/go).
+The Horizon SDK is composed of two complementary libraries: `txnbuild` + `horizonclient`.
+The `txnbuild` ([source](https://github.com/stellar/go/tree/master/txnbuild), [docs](https://godoc.org/github.com/stellar/go/txnbuild)) package enables the construction, signing and encoding of Stellar [transactions](https://www.stellar.org/developers/guides/concepts/transactions.html) and [operations](https://www.stellar.org/developers/guides/concepts/list-of-operations.html) in Go. The `horizonclient` ([source](https://github.com/stellar/go/tree/master/clients/horizonclient), [docs](https://godoc.org/github.com/stellar/go/clients/horizonclient)) package provides a web client for interfacing with [Horizon](https://www.stellar.org/developers/guides/get-started/) server REST endpoints to retrieve ledger information, and to submit transactions built with `txnbuild`.
 
-## Client Packages
+## List of major SDK packages
 
-The Go SDK contains packages for interacting with the various stellar services:
-
-- [`horizon`](https://godoc.org/github.com/stellar/go/clients/horizon) provides client access to a horizon server, allowing you to load account information, stream payments, post transactions and more.
-- [`stellartoml`](https://godoc.org/github.com/stellar/go/clients/stellartoml) provides the ability to resolve Stellar.toml files from the internet.  You can read about [Stellar.toml concepts here](../../guides/concepts/stellar-toml.md).
-- [`federation`](https://godoc.org/github.com/stellar/go/clients/federation) makes it easy to resolve a stellar addresses (e.g. `scott*stellar.org`) into a stellar account ID suitable for use within a transaction.
+- `horizonclient` ([source](https://github.com/stellar/go/tree/master/clients/horizonclient), [docs](https://godoc.org/github.com/stellar/go/clients/horizonclient)) - programmatic client access to Horizon
+- `txnbuild` ([source](https://github.com/stellar/go/tree/master/txnbuild), [docs](https://godoc.org/github.com/stellar/go/txnbuild)) - construction, signing and encoding of Stellar transactions and operations
+- `stellartoml` ([source](https://github.com/stellar/go/tree/master/clients/horizonclient), [docs](https://godoc.org/github.com/stellar/go/clients/stellartoml)) - parse [Stellar.toml](../../guides/concepts/stellar-toml.md) files from the internet
+- `federation` ([source](https://godoc.org/github.com/stellar/go/clients/federation)) - resolve federation addresses  into stellar account IDs, suitable for use within a transaction
 

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -6,6 +6,8 @@ top of the Stellar network (https://www.stellar.org/). Transactions constructed 
 to any Horizon instance for processing onto the ledger, using any Stellar SDK client. The recommended client for Go
 programmers is horizonclient (https://github.com/stellar/go/tree/master/clients/horizonclient). Together, these two
 libraries provide a complete Stellar SDK.
+
+For more information and further examples, see https://www.stellar.org/developers/go/reference/index.html.
 */
 package txnbuild
 


### PR DESCRIPTION
This PR adds minimal developer docs for `horizonclient` and `txnbuild`, the components of the new Go SDK.

This does enough to close #863, although more examples (at least payment) on these pages in due course would be good.