### PR TITLE
support/scripts/build_release_artifacts: don't build binaries based solely on semver

### DIFF
--- a/support/scripts/build_release_artifacts/main.go
+++ b/support/scripts/build_release_artifacts/main.go
@@ -1,6 +1,6 @@
 package main
 
-// See README.md for a description of this script
+// This is a build script that Travis uses to build Stellar release packages.
 
 import (
 	"flag"
@@ -148,6 +148,12 @@ func buildByTag() {
 
 	if bin == "" {
 		log.Info("could not extract info from TRAVIS_TAG: skipping artifact packaging")
+		os.Exit(0)
+	}
+
+	// Don't build anything if no package can be found
+	if pkg == "" {
+		log.Infof("could not find `%s` in expected binary locations: skipping artifact packaging", bin)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs)
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs otherwise)
* [x] This PR's title starts with name of package that is most changed in the PR, ex. `services/friendbot`


### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md` files, etc...) affected by this change

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if needed with deprecations, added features, breaking changes, and DB schema changes
* [ ] I've decided if this PR requires a new major/minor version according to [semver](https://semver.org/), or if it's only a patch change. The PR is targeted at the next release branch if it's not a patch change.


## Summary
Fixes the situation where a tagged semVer release leads to the build system producing junk binary releases, when there is nothing to build. Closes #1208.

### Goal and scope

See #1208.

### Summary of changes

Build script exits with a log message if there is nothing to build.

### Testing

This was tested locally with hardcoded variable names.