### PR TITLE
horizonclient/txnbuild README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This repo is the home for all of the public go code produced by SDF.  In additio
 ## Package Index
 
 * [Horizon Server](services/horizon): Full-featured API server for Stellar network
-* [Go Clients (Horizon SDK)](clients): Go SDK for making requests to Horizon Server
+* [Go Horizon SDK - horizonclient](clients/horizonclient): Client for Horizon server (queries and transaction submission)
+* [Go Horizon SDK - txnbuild](txnbuild): Construct Stellar transactions and operations
 * [Bifrost](services/bifrost): Bitcoin/Ethereum -> Stellar bridge
 * Servers for Anchors & Financial Institutions
   * [Bridge Server](services/bridge): send payments and take action when payments are received

--- a/clients/README.md
+++ b/clients/README.md
@@ -1,10 +1,15 @@
 # Clients package
 
-Packages contained by this package provide client libraries for accessing the ecosystem of stellar services.  At present, it only contains a simple horizon client library, but in the future it will contain clients to interact with stellar-core, federation, the bridge server and more.
+Packages here provide client libraries for accessing the ecosystem of Stellar services.
 
-See [godoc](https://godoc.org/github.com/stellar/go/clients) for details about each package.
+* `horizonclient` - programmatic client access to Horizon (use in conjunction with [txnbuild](../txnbuild))
+* `stellartoml` - parse Stellar.toml files from the internet
+* `federation` - resolve federation addresses into stellar account IDs, suitable for use within a transaction
+* `horizon` (DEPRECATED) - the original Horizon client, now superceded by `horizonclient`
 
-## Adding new client packages
+See [GoDoc](https://godoc.org/github.com/stellar/go/clients) for more details.
+
+## For developers: Adding new client packages
 
 Ideally, each one of our client packages will have commonalities in their API to ease the cost of learning each.  It's recommended that we follow a pattern similar to the `net/http` package's client shape:
 

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -1,9 +1,6 @@
-// Package horizon provides client access to a horizon server, allowing an
-// application to post transactions and lookup ledger information.
+// Package horizon is DEPRECATED in favour of clients/horizonclient! It used to provide client access to a horizon
+// server, allowing an application to post transactions and lookup ledger information.
 //
-// Create an instance of `Client` to customize the server used, or alternatively
-// use `DefaultTestNetClient` or `DefaultPublicNetClient` to access the SDF run
-// horizon servers.
 // Deprecated: clients/horizon package with all its exported methods and variables will no longer be
 // maintained. It will be removed in future versions of the SDK.
 // Use clients/horizonclient (https://godoc.org/github.com/stellar/go/clients/horizonclient) instead.

--- a/clients/horizonclient/README.md
+++ b/clients/horizonclient/README.md
@@ -26,20 +26,20 @@ This library is aimed at developers building Go applications that interact with 
     import hClient "github.com/stellar/go/clients/horizonclient"
     ...
 
-    // use the default pubnet client
+    // Use the default pubnet client
     client := hClient.DefaultPublicNetClient
-    // create an account request
+
+    // Create an account request
     accountRequest := hClient.AccountRequest{AccountID: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"}
 
-    // load the account detail from the network
+    // Load the account detail from the network
     account, err := client.AccountDetail(accountRequest)
     if err != nil {
         fmt.Println(err)
         return
     }
-    // account contains information about the stellar account
+    // Account contains information about the stellar account
     fmt.Print(account)
-
 ```
 For more examples, refer to the [documentation](https://godoc.org/github.com/stellar/go/clients/horizonclient).
 
@@ -47,7 +47,9 @@ For more examples, refer to the [documentation](https://godoc.org/github.com/ste
 Run the unit tests from the package directory: `go test`
 
 ## Contributing
-Please read [CONTRIBUTING](../../CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+Please read [Code of Conduct](https://github.com/stellar/.github/blob/master/CODE_OF_CONDUCT.md) to understand this project's communication rules.
+
+To submit improvements and fixes to this library, please see [CONTRIBUTING](../CONTRIBUTING.md).
 
 ## License
 This project is licensed under the Apache License - see the [LICENSE](../../LICENSE-APACHE.txt) file for details.

--- a/txnbuild/README.md
+++ b/txnbuild/README.md
@@ -4,7 +4,7 @@
 
 This project is maintained by the Stellar Development Foundation.
 
-```
+```golang
   import (
 	"log"
 	
@@ -79,7 +79,9 @@ To see the SDK in action, build and run the demo:
 
 
 ## Contributing
-Please read [CONTRIBUTING](../../CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+Please read [Code of Conduct](https://github.com/stellar/.github/blob/master/CODE_OF_CONDUCT.md) to understand this project's communication rules.
+
+To submit improvements and fixes to this library, please see [CONTRIBUTING](../CONTRIBUTING.md).
 
 ## License
 This project is licensed under the Apache License - see the [LICENSE](../../LICENSE-APACHE.txt) file for details.


### PR DESCRIPTION
This PR updates various READMEs relevant to the new Go SDK, to

* point at correct docs
* remove out of date info
* make deprecation of old SDK more obvious