### PR TITLE
horizonclient: update Fund method

### DIFF
--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## [v1.0.1] - (draft release)
+## [v1.1.0] - (draft release)
 
 ### Added
+
 - `Client.Root()` method for querying the root endpoint of a horizon server.
+
+### Changes 
+
+- `Client.Fund()` now returns `TransactionSuccess` instead of a http response pointer.

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -422,11 +422,13 @@ func (c *Client) Trades(request TradeRequest) (tds hProtocol.TradesPage, err err
 
 // Fund creates a new account funded from friendbot. It only works on test networks. See
 // https://www.stellar.org/developers/guides/get-started/create-account.html for more information.
-func (c *Client) Fund(addr string) (*http.Response, error) {
+func (c *Client) Fund(addr string) (txSuccess hProtocol.TransactionSuccess, err error) {
 	if !c.isTestNet {
-		return nil, errors.New("Can't fund account from friendbot on production network")
+		return txSuccess, errors.New("can't fund account from friendbot on production network")
 	}
-	return http.Get(c.HorizonURL + "friendbot?addr=" + addr)
+	friendbotURL := fmt.Sprintf("%sfriendbot?addr=%s", c.fixHorizonURL(), addr)
+	err = c.sendRequestURL(friendbotURL, "get", &txSuccess)
+	return
 }
 
 // StreamTrades streams executed trades. It can be used to stream all trades, trades for an account and

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -141,7 +141,7 @@ type ClientInterface interface {
 	Payments(request OperationRequest) (operations.OperationsPage, error)
 	TradeAggregations(request TradeAggregationRequest) (hProtocol.TradeAggregationsPage, error)
 	Trades(request TradeRequest) (hProtocol.TradesPage, error)
-	Fund(addr string) (*http.Response, error)
+	Fund(addr string) (hProtocol.TransactionSuccess, error)
 	StreamTransactions(ctx context.Context, request TransactionRequest, handler TransactionHandler) error
 	StreamTrades(ctx context.Context, request TradeRequest, handler TradeHandler) error
 	StreamEffects(ctx context.Context, request EffectRequest, handler EffectHandler) error

--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -282,6 +282,76 @@ func ExampleClient_Payments() {
 	}
 }
 
+func ExampleClient_Fund() {
+
+	client := DefaultTestNetClient
+	// fund an account
+	resp, err := client.Fund("GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(resp)
+}
+
+func TestClientFund(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	testAccount := "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"
+
+	// not testnet
+	hmock.On(
+		"GET",
+		"https://localhost/friendbot?addr=GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+	).ReturnString(200, txSuccess)
+
+	_, err := client.Fund(testAccount)
+	// error case: not testnet
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "can't fund account from friendbot on production network")
+	}
+
+	// happy path
+	hmock.On(
+		"GET",
+		"https://localhost/friendbot?addr=GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+	).ReturnString(200, txSuccess)
+
+	client.isTestNet = true
+	resp, err := client.Fund(testAccount)
+
+	if assert.NoError(t, err) {
+		assert.IsType(t, resp, hProtocol.TransactionSuccess{})
+		assert.Equal(t, resp.Links.Transaction.Href, "https://horizon-testnet.stellar.org/transactions/bcc7a97264dca0a51a63f7ea971b5e7458e334489673078bb2a34eb0cce910ca")
+		assert.Equal(t, resp.Hash, "bcc7a97264dca0a51a63f7ea971b5e7458e334489673078bb2a34eb0cce910ca")
+		assert.Equal(t, resp.Ledger, int32(354811))
+		assert.Equal(t, resp.Env, `AAAAABB90WssODNIgi6BHveqzxTRmIpvAFRyVNM+Hm2GVuCcAAAAZAAABD0AAuV/AAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAyTBGxOgfSApppsTnb/YRr6gOR8WT0LZNrhLh4y3FCgoAAAAXSHboAAAAAAAAAAABhlbgnAAAAEAivKe977CQCxMOKTuj+cWTFqc2OOJU8qGr9afrgu2zDmQaX5Q0cNshc3PiBwe0qw/+D/qJk5QqM5dYeSUGeDQP`)
+		assert.Equal(t, resp.Result, "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=")
+		assert.Equal(t, resp.Meta, `AAAAAQAAAAIAAAADAAVp+wAAAAAAAAAAEH3Rayw4M0iCLoEe96rPFNGYim8AVHJU0z4ebYZW4JwACBP/TuycHAAABD0AAuV+AAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAVp+wAAAAAAAAAAEH3Rayw4M0iCLoEe96rPFNGYim8AVHJU0z4ebYZW4JwACBP/TuycHAAABD0AAuV/AAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMABWn7AAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAAIE/9O7JwcAAAEPQAC5X8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEABWn7AAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAAIE+gGdbQcAAAEPQAC5X8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAABWn7AAAAAAAAAADJMEbE6B9ICmmmxOdv9hGvqA5HxZPQtk2uEuHjLcUKCgAAABdIdugAAAVp+wAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==`)
+	}
+
+	// failure response
+	hmock.On(
+		"GET",
+		"https://localhost/friendbot?addr=GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+	).ReturnString(400, transactionFailure)
+
+	_, err = client.Fund(testAccount)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "horizon error")
+		horizonError, ok := errors.Cause(err).(*Error)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, horizonError.Problem.Title, "Transaction Failed")
+		resultString, err := horizonError.ResultString()
+		assert.Nil(t, err)
+		assert.Equal(t, resultString, "AAAAAAAAAAD////4AAAAAA==")
+	}
+}
+
 func TestAccountDetail(t *testing.T) {
 	hmock := httptest.NewClient()
 	client := &Client{

--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -283,7 +283,6 @@ func ExampleClient_Payments() {
 }
 
 func ExampleClient_Fund() {
-
 	client := DefaultTestNetClient
 	// fund an account
 	resp, err := client.Fund("GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU")

--- a/clients/horizonclient/mocks.go
+++ b/clients/horizonclient/mocks.go
@@ -2,7 +2,6 @@ package horizonclient
 
 import (
 	"context"
-	"net/http"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/protocols/horizon/operations"
@@ -145,9 +144,9 @@ func (m *MockClient) Trades(request TradeRequest) (hProtocol.TradesPage, error) 
 }
 
 // Fund is a mocking method
-func (m *MockClient) Fund(addr string) (*http.Response, error) {
+func (m *MockClient) Fund(addr string) (hProtocol.TransactionSuccess, error) {
 	a := m.Called(addr)
-	return nil, a.Error(1)
+	return a.Get(0).(hProtocol.TransactionSuccess), a.Error(1)
 }
 
 // StreamTransactions is a mocking method


### PR DESCRIPTION
This PR updates the Fund method that is used to fund new accounts on testnet.
It now uses the internal http client which allows us to set the app headers.
Also it returns TransactionSuccess struct instead of a http response.

Closes #1201