### PR TITLE
horizonclient: Set default HTTP client

### DIFF
--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -53,7 +53,7 @@ func (c *Client) sendRequestURL(requestURL string, method string, a interface{})
 		return errors.Wrap(err, "error creating HTTP request")
 	}
 	c.setClientAppHeaders(req)
-	c.fixHTTPOnce.Do(c.fixHTTP)
+	c.setDefaultClient()
 	if c.horizonTimeOut == 0 {
 		c.horizonTimeOut = HorizonTimeOut
 	}
@@ -93,7 +93,7 @@ func (c *Client) stream(
 			return errors.Wrap(err, "error creating HTTP request")
 		}
 		req.Header.Set("Accept", "text/event-stream")
-		c.fixHTTPOnce.Do(c.fixHTTP)
+		c.setDefaultClient()
 		// to do: confirm name and version
 		c.setClientAppHeaders(req)
 
@@ -204,8 +204,8 @@ func (c *Client) setClientAppHeaders(req *http.Request) {
 	req.Header.Set("X-App-Version", c.AppVersion)
 }
 
-// fixHTTP sets the default HTTP client when non is provided.
-func (c *Client) fixHTTP() {
+// setDefaultClient sets the default HTTP client when none is provided.
+func (c *Client) setDefaultClient() {
 	if c.HTTP == nil {
 		c.HTTP = http.DefaultClient
 	}

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -53,7 +53,7 @@ func (c *Client) sendRequestURL(requestURL string, method string, a interface{})
 		return errors.Wrap(err, "error creating HTTP request")
 	}
 	c.setClientAppHeaders(req)
-
+	c.fixHTTPOnce.Do(c.fixHTTP)
 	if c.horizonTimeOut == 0 {
 		c.horizonTimeOut = HorizonTimeOut
 	}
@@ -93,6 +93,7 @@ func (c *Client) stream(
 			return errors.Wrap(err, "error creating HTTP request")
 		}
 		req.Header.Set("Accept", "text/event-stream")
+		c.fixHTTPOnce.Do(c.fixHTTP)
 		// to do: confirm name and version
 		c.setClientAppHeaders(req)
 
@@ -201,6 +202,13 @@ func (c *Client) setClientAppHeaders(req *http.Request) {
 	req.Header.Set("X-Client-Version", app.Version())
 	req.Header.Set("X-App-Name", c.AppName)
 	req.Header.Set("X-App-Version", c.AppVersion)
+}
+
+// fixHTTP sets the default HTTP client when non is provided.
+func (c *Client) fixHTTP() {
+	if c.HTTP == nil {
+		c.HTTP = http.DefaultClient
+	}
 }
 
 // fixHorizonURL strips all slashes(/) at the end of HorizonURL if any, then adds a single slash

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
-	"sync"
 	"time"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
@@ -117,7 +116,6 @@ type Client struct {
 	AppName        string
 	AppVersion     string
 	isTestNet      bool
-	fixHTTPOnce    sync.Once
 }
 
 // ClientInterface contains methods implemented by the horizon client

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
@@ -116,6 +117,7 @@ type Client struct {
 	AppName        string
 	AppVersion     string
 	isTestNet      bool
+	fixHTTPOnce    sync.Once
 }
 
 // ClientInterface contains methods implemented by the horizon client

--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -2,6 +2,7 @@ package horizonclient
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -291,6 +292,17 @@ func ExampleClient_Fund() {
 		return
 	}
 	fmt.Print(resp)
+}
+
+func TestFixHTTP(t *testing.T) {
+	client := &Client{
+		HorizonURL: "https://localhost/",
+	}
+	// No HTTP client is provided
+	assert.Nil(t, client.HTTP, "client HTTP is nil")
+	client.Root()
+	// When a request is made, default HTTP client is set
+	assert.IsType(t, client.HTTP, &http.Client{})
 }
 
 func TestClientFund(t *testing.T) {


### PR DESCRIPTION
This PR sets the default HTTP client if non is provided. 
It closes #1182.