### PR TITLE
horizonclient: add version

### DIFF
--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -17,7 +17,6 @@ import (
 	"github.com/manucorporat/sse"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/protocols/horizon/operations"
-	"github.com/stellar/go/support/app"
 	"github.com/stellar/go/support/errors"
 )
 
@@ -93,7 +92,6 @@ func (c *Client) stream(
 			return errors.Wrap(err, "error creating HTTP request")
 		}
 		req.Header.Set("Accept", "text/event-stream")
-		// to do: confirm name and version
 		c.setClientAppHeaders(req)
 
 		// We can use c.HTTP here because we set Timeout per request not on the client. See sendRequest()
@@ -198,7 +196,7 @@ func (c *Client) stream(
 
 func (c *Client) setClientAppHeaders(req *http.Request) {
 	req.Header.Set("X-Client-Name", "go-stellar-sdk")
-	req.Header.Set("X-Client-Version", app.Version())
+	req.Header.Set("X-Client-Version", c.Version())
 	req.Header.Set("X-App-Name", c.AppName)
 	req.Header.Set("X-App-Version", c.AppVersion)
 }
@@ -513,6 +511,11 @@ func (c *Client) FetchTimebounds(seconds int64) (txnbuild.Timebounds, error) {
 func (c *Client) Root() (root hProtocol.Root, err error) {
 	err = c.sendRequestURL(c.fixHorizonURL(), "get", &root)
 	return
+}
+
+// Version returns the current version.
+func (c *Client) Version() string {
+	return version
 }
 
 // ensure that the horizon client implements ClientInterface

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -92,7 +92,7 @@ func (c *Client) stream(
 			return errors.Wrap(err, "error creating HTTP request")
 		}
 		req.Header.Set("Accept", "text/event-stream")
-    c.setDefaultClient()
+		c.setDefaultClient()
 		c.setClientAppHeaders(req)
 
 		// We can use c.HTTP here because we set Timeout per request not on the client. See sendRequest()

--- a/clients/horizonclient/version.go
+++ b/clients/horizonclient/version.go
@@ -1,0 +1,5 @@
+package horizonclient
+
+// version is the current version of the horizonclient.
+// This is updated for every release.
+const version = "1.1"


### PR DESCRIPTION
This PR adds a version file `version.go` to the `horizonclient` package which is used to track the released versions. 
We decided to go this route because we don't release binaries for this package so we can't leverage `app.Version` from the `support/app` package which depends on the version tag being populated during the build process.
Note that this file should be updated for every release.
Closes #1227 