### PR TITLE
exp/ticker: ensure 24h OHLC values fall back to 7d close value on markets.json

### DIFF
--- a/exp/ticker/internal/tickerdb/queries_market.go
+++ b/exp/ticker/internal/tickerdb/queries_market.go
@@ -115,10 +115,10 @@ SELECT
 	COALESCE(base_volume_24h, 0.0) as base_volume_24h,
 	COALESCE(counter_volume_24h, 0.0) as counter_volume_24h,
 	COALESCE(trade_count_24h, 0) as trade_count_24h,
-	COALESCE(highest_price_24h, 0.0) as highest_price_24h,
-	COALESCE(lowest_price_24h, 0.0) as lowest_price_24h,
+	COALESCE(highest_price_24h, last_price_7d, 0.0) as highest_price_24h,
+	COALESCE(lowest_price_24h, last_price_7d, 0.0) as lowest_price_24h,
 	COALESCE(price_change_24h, 0.0) as price_change_24h,
-	COALESCE(open_price_24h, 0.0) as open_price_24h,
+	COALESCE(open_price_24h, last_price_7d, 0.0) as open_price_24h,
 
 	COALESCE(base_volume_7d, 0) as base_volume_7d,
 	COALESCE(counter_volume_7d, 0) as counter_volume_7d,
@@ -128,7 +128,7 @@ SELECT
 	COALESCE(price_change_7d, 0.0) as price_change_7d,
 	COALESCE(open_price_7d, 0.0) as open_price_7d,
 
-	COALESCE(last_price, 0.0) as last_price,
+	COALESCE(last_price, last_price_7d, 0.0) as last_price,
 	COALESCE(last_close_time_24h, last_close_time_7d) as close_time,
 
 	COALESCE(os.num_bids, 0) as num_bids,
@@ -167,6 +167,7 @@ FROM (
 			max(t.price) AS highest_price_7d,
 			min(t.price) AS lowest_price_7d,
 			(array_agg(t.price ORDER BY t.ledger_close_time ASC))[1] AS open_price_7d,
+			(array_agg(t.price ORDER BY t.ledger_close_time DESC))[1] AS last_price_7d,
 			((array_agg(t.price ORDER BY t.ledger_close_time DESC))[1] - (array_agg(t.price ORDER BY t.ledger_close_time ASC))[1]) AS price_change_7d,
 			max(t.ledger_close_time) AS last_close_time_7d
 		FROM trades AS t


### PR DESCRIPTION
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs)
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs otherwise)
* [x] This PR's title starts with name of package that is most changed in the PR, ex. `services/friendbot`


### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md` files, etc...) affected by this change

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if needed with deprecations, added features, breaking changes, and DB schema changes
* [x] I've decided if this PR requires a new major/minor version according to [semver](https://semver.org/), or if it's monly a patch change. The PR is targeted at the next release branch if it's not a patch change.


## Summary

### Goal and scope

This PR closes #1218. It aims to provide more accurate market data by making the 24h OHLC stats fall back to the 7-day close value on `markets.json`.

### Summary of changes

Updated the markets db query and added some tests to make sure the system is behaving accordingly.

### What shouldn't be reviewed

Database query tests require a lot of preparations steps – skipping to the end of the test functions might be a good idea to get a better understanding of what's actually being tested :)
