### PR TITLE
keystore/cmd: implement basic keystored

### DIFF
--- a/exp/services/keystore/cmd/keystored/dev.go
+++ b/exp/services/keystore/cmd/keystored/dev.go
@@ -1,0 +1,16 @@
+// +build !aws
+
+package main
+
+import (
+	"github.com/stellar/go/exp/services/keystore"
+	"github.com/stellar/go/support/env"
+)
+
+func getConfig() *keystore.Config {
+	return &keystore.Config{
+		DBURL:          env.String("DATABASE_URL", "postgres:///keystore?sslmode=disable"),
+		MaxIdleDBConns: env.Int("DB_MAX_IDLE_CONNS", 5),
+		MaxOpenDBConns: env.Int("DB_MAX_OPEN_CONNS", 5),
+	}
+}

--- a/exp/services/keystore/cmd/keystored/dev.go
+++ b/exp/services/keystore/cmd/keystored/dev.go
@@ -9,7 +9,7 @@ import (
 
 func getConfig() *keystore.Config {
 	return &keystore.Config{
-		DBURL:          env.String("DATABASE_URL", "postgres:///keystore?sslmode=disable"),
+		DBURL:          env.String("KEYSTORE_DATABASE_URL", "postgres:///keystore?sslmode=disable"),
 		MaxIdleDBConns: env.Int("DB_MAX_IDLE_CONNS", 5),
 		MaxOpenDBConns: env.Int("DB_MAX_OPEN_CONNS", 5),
 	}

--- a/exp/services/keystore/cmd/keystored/main.go
+++ b/exp/services/keystore/cmd/keystored/main.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/stellar/go/exp/services/keystore"
+	"github.com/stellar/go/support/log"
+)
+
+func main() {
+	ctx := context.Background()
+
+	if len(flag.Args()) < 1 {
+		fmt.Fprintln(os.Stderr, "too few arguments")
+		os.Exit(1)
+	}
+
+	cfg := getConfig()
+	if cfg.LogFile != "" {
+		logFile, err := os.OpenFile(cfg.LogFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Failed to open file to log", err)
+			os.Exit(1)
+		}
+
+		log.DefaultLogger.Logger.Out = logFile
+		log.DefaultLogger.Logger.SetLevel(cfg.LogLevel)
+	}
+
+	db, err := sql.Open("postgres", cfg.DBURL)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error opening database", err)
+		os.Exit(1)
+	}
+	db.SetMaxOpenConns(cfg.MaxOpenDBConns)
+	db.SetMaxIdleConns(cfg.MaxIdleDBConns)
+
+	cmd := flag.Arg(0)
+	switch cmd {
+	case "serve":
+		_, err := keystore.NewService(ctx, db)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "error initializing service object", err)
+			os.Exit(1)
+		}
+
+		addr := ":8443"
+		server := &http.Server{
+			Addr: addr,
+			//TODO: implement ServeMux
+			// Handler: keystore.ServeMux(service),
+		}
+
+		ln, err := net.Listen("tcp", addr)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "error listening", err)
+			os.Exit(1)
+		}
+
+		//TODO: add tls config
+
+		go func() {
+			err := server.Serve(ln)
+			if err != nil {
+				panic(err)
+			}
+		}()
+		fmt.Fprintln(os.Stdout, "Server listening at https://localhost"+addr)
+
+		// block forever without using any resources so this process won't quit while
+		// the goroutine containing ListenAndServe is still working
+		select {}
+	}
+}

--- a/exp/services/keystore/cmd/keystored/main.go
+++ b/exp/services/keystore/cmd/keystored/main.go
@@ -11,17 +11,21 @@ import (
 
 	"github.com/stellar/go/exp/services/keystore"
 	"github.com/stellar/go/support/log"
+
+	_ "github.com/lib/pq"
 )
 
 func main() {
 	ctx := context.Background()
 
+	flag.Parse()
 	if len(flag.Args()) < 1 {
 		fmt.Fprintln(os.Stderr, "too few arguments")
 		os.Exit(1)
 	}
 
 	cfg := getConfig()
+	// will read the value from AWS parameter store
 	if cfg.LogFile != "" {
 		logFile, err := os.OpenFile(cfg.LogFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
@@ -40,6 +44,13 @@ func main() {
 	}
 	db.SetMaxOpenConns(cfg.MaxOpenDBConns)
 	db.SetMaxIdleConns(cfg.MaxIdleDBConns)
+
+	err = db.Ping()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error accessing database", err)
+		os.Exit(1)
+	}
+	fmt.Fprintln(os.Stdout, "Successfully connected to keystore db")
 
 	cmd := flag.Arg(0)
 	switch cmd {

--- a/exp/services/keystore/service.go
+++ b/exp/services/keystore/service.go
@@ -1,0 +1,25 @@
+package keystore
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/sirupsen/logrus"
+)
+
+type Config struct {
+	DBURL          string
+	MaxIdleDBConns int
+	MaxOpenDBConns int
+
+	LogFile  string
+	LogLevel logrus.Level
+}
+
+type Service struct {
+	db *sql.DB
+}
+
+func NewService(ctx context.Context, db *sql.DB) (*Service, error) {
+	return &Service{db: db}, nil
+}

--- a/support/env/env.go
+++ b/support/env/env.go
@@ -1,0 +1,30 @@
+package env
+
+import (
+	"log"
+	"os"
+	"strconv"
+)
+
+// String returns the value of the environment variable "name".
+// If name is not set, it returns value.
+func String(name string, value string) string {
+	if s := os.Getenv(name); s != "" {
+		value = s
+	}
+	return value
+}
+
+// Int returns the value of the environment variable "name" as an int.
+// If name is not set, it returns value.
+func Int(name string, value int) int {
+	if s := os.Getenv(name); s != "" {
+		var err error
+		value, err = strconv.Atoi(s)
+		if err != nil {
+			log.Println(name, err)
+			os.Exit(1)
+		}
+	}
+	return value
+}


### PR DESCRIPTION
This is the skeleton of the keystored. It doesn't do anything.

This PR introduces the lightweight package env to deal with environment
variables.

Next I'm going add `keystored migrate` command to handle migration.