### PR TITLE
keystore/cmd: add tls config to keystore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@
 debug
 .bundle
 *.swp
-
+*.crt
+*.csr
+*.key

--- a/exp/services/keystore/cmd/keystored/main.go
+++ b/exp/services/keystore/cmd/keystored/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"database/sql"
 	"flag"
 	"fmt"
@@ -17,10 +18,17 @@ import (
 
 func main() {
 	ctx := context.Background()
+	tlsCert := flag.String("tls-cert", "", "TLS certificate file path")
+	tlsKey := flag.String("tls-key", "", "TLS private key file path")
 
 	flag.Parse()
 	if len(flag.Args()) < 1 {
 		fmt.Fprintln(os.Stderr, "too few arguments")
+		os.Exit(1)
+	}
+
+	if (*tlsCert == "" && *tlsKey != "") || (*tlsCert != "" && *tlsKey == "") {
+		fmt.Fprintln(os.Stderr, "TLS cert and TLS key have to be presented together")
 		os.Exit(1)
 	}
 
@@ -74,10 +82,16 @@ func main() {
 			os.Exit(1)
 		}
 
-		//TODO: add tls config
+		cer, err := tls.LoadX509KeyPair(*tlsCert, *tlsKey)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "error parsing TLS keypair", err)
+			os.Exit(1)
+		}
+
+		tlsListener := tls.NewListener(ln, &tls.Config{Certificates: []tls.Certificate{cer}})
 
 		go func() {
-			err := server.Serve(ln)
+			err := server.Serve(tlsListener)
 			if err != nil {
 				panic(err)
 			}

--- a/exp/services/keystore/cmd/keystored/main.go
+++ b/exp/services/keystore/cmd/keystored/main.go
@@ -76,22 +76,24 @@ func main() {
 			// Handler: keystore.ServeMux(service),
 		}
 
-		ln, err := net.Listen("tcp", addr)
+		listener, err := net.Listen("tcp", addr)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "error listening", err)
 			os.Exit(1)
 		}
 
-		cer, err := tls.LoadX509KeyPair(*tlsCert, *tlsKey)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "error parsing TLS keypair", err)
-			os.Exit(1)
+		if *tlsCert != "" {
+			cer, err := tls.LoadX509KeyPair(*tlsCert, *tlsKey)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "error parsing TLS keypair", err)
+				os.Exit(1)
+			}
+
+			listener = tls.NewListener(listener, &tls.Config{Certificates: []tls.Certificate{cer}})
 		}
 
-		tlsListener := tls.NewListener(ln, &tls.Config{Certificates: []tls.Certificate{cer}})
-
 		go func() {
-			err := server.Serve(tlsListener)
+			err := server.Serve(listener)
 			if err != nil {
 				panic(err)
 			}

--- a/exp/services/keystore/tls/localhost.conf
+++ b/exp/services/keystore/tls/localhost.conf
@@ -1,0 +1,17 @@
+[ req ]
+distinguished_name     = req_distinguished_name
+
+[ req_distinguished_name ]
+C                    = US
+C_default            = US
+ST                   = New York
+ST_default           = New York
+L                    = New York
+L_default            = New York
+O                    = Stellar Development Foundation
+O_default            = Stellar Development Foundation
+OU                   = Engineering
+OU_default           = Engineering
+CN                   = localhost:8443
+CN_default           = localhost:8443
+emailAddress_default =

--- a/exp/services/keystore/tls/regen.sh
+++ b/exp/services/keystore/tls/regen.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd $DIR
+
+openssl genrsa -des3 -passout pass:x -out new.pass.key 2048
+openssl rsa -passin pass:x -in new.pass.key -out new.key
+rm new.pass.key
+openssl req -new -key new.key -out new.csr -config localhost.conf
+openssl x509 -req -days 365 -in new.csr -signkey new.key -out new.crt
+
+mv new.csr server.csr
+mv new.crt server.crt
+mv new.key server.key


### PR DESCRIPTION
This PR adds tls config to the keystore server. It copies the regen script and the localhost config from Horizon. Of course, it updates the config file so that it points to the right port.

After istalling keystored, one can do `keystored -tls-cert=path_to_cert
-tls-key=path_to_key serve` to start keystored. I will add a README as the next step.