### PR TITLE
exp/ticker: Create script to delete old trade data

### DIFF
--- a/exp/ticker/cmd/clean.go
+++ b/exp/ticker/cmd/clean.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/spf13/cobra"
+	"github.com/stellar/go/exp/ticker/internal/tickerdb"
+)
+
+var DaysToKeep int
+
+func init() {
+	rootCmd.AddCommand(cmdClean)
+	cmdClean.AddCommand(cmdCleanTrades)
+
+	cmdCleanTrades.Flags().IntVarP(
+		&DaysToKeep,
+		"keep-days",
+		"k",
+		7,
+		"Trade entries older than keep-days will be deleted",
+	)
+}
+
+var cmdClean = &cobra.Command{
+	Use:   "clean [data type]",
+	Short: "Cleans up the database for a given data type",
+}
+
+var cmdCleanTrades = &cobra.Command{
+	Use:   "trades",
+	Short: "Cleans up old trades from the database",
+	Run: func(cmd *cobra.Command, args []string) {
+		dbInfo, err := pq.ParseURL(DatabaseURL)
+		if err != nil {
+			Logger.Fatal("could not parse db-url:", err)
+		}
+
+		session, err := tickerdb.CreateSession("postgres", dbInfo)
+		if err != nil {
+			Logger.Fatal("could not connect to db:", err)
+		}
+
+		now := time.Now()
+		minDate := now.AddDate(0, 0, -DaysToKeep)
+		Logger.Infof("Deleting trade entries older than %d days", DaysToKeep)
+		err = session.DeleteOldTrades(minDate)
+		if err != nil {
+			Logger.Fatal("could not delete trade entries:", err)
+		}
+	},
+}

--- a/exp/ticker/internal/tickerdb/queries_trade.go
+++ b/exp/ticker/internal/tickerdb/queries_trade.go
@@ -3,6 +3,7 @@ package tickerdb
 import (
 	"math"
 	"strings"
+	"time"
 )
 
 // BulkInsertTrades inserts a slice of trades in the database. Trades
@@ -28,6 +29,12 @@ func (s *TickerSession) BulkInsertTrades(trades []Trade) (err error) {
 func (s *TickerSession) GetLastTrade() (trade Trade, err error) {
 	err = s.GetRaw(&trade, "SELECT * FROM trades ORDER BY ledger_close_time DESC LIMIT 1")
 	return
+}
+
+// DeleteOldTrades deletes trades in the database older than minDate.
+func (s *TickerSession) DeleteOldTrades(minDate time.Time) error {
+	_, err := s.ExecRaw("DELETE FROM trades WHERE ledger_close_time < ?", minDate)
+	return err
 }
 
 // chunkifyDBTrades transforms a slice into a slice of chunks (also slices) of chunkSize

--- a/exp/ticker/internal/tickerdb/queries_trade_test.go
+++ b/exp/ticker/internal/tickerdb/queries_trade_test.go
@@ -223,3 +223,139 @@ func TestGetLastTrade(t *testing.T) {
 		lastTrade.LedgerCloseTime.Local().Truncate(time.Millisecond),
 	)
 }
+
+func TestDeleteOldTrades(t *testing.T) {
+	db := dbtest.Postgres(t)
+	defer db.Close()
+
+	var session TickerSession
+	session.DB = db.Open()
+	defer session.DB.Close()
+
+	// Run migrations to make sure the tests are run
+	// on the most updated schema version
+	migrations := &migrate.FileMigrationSource{
+		Dir: "./migrations",
+	}
+	_, err := migrate.Exec(session.DB.DB, "postgres", migrations, migrate.Up)
+	require.NoError(t, err)
+
+	// Adding a seed issuer to be used later:
+	tbl := session.GetTable("issuers")
+	_, err = tbl.Insert(Issuer{
+		PublicKey: "GCF3TQXKZJNFJK7HCMNE2O2CUNKCJH2Y2ROISTBPLC7C5EIA5NNG2XZB",
+		Name:      "FOO BAR",
+	}).IgnoreCols("id").Exec()
+	require.NoError(t, err)
+	var issuer Issuer
+	err = session.GetRaw(&issuer, `
+		SELECT *
+		FROM issuers
+		ORDER BY id DESC
+		LIMIT 1`,
+	)
+	require.NoError(t, err)
+
+	// Adding a seed asset to be used later:
+	err = session.InsertOrUpdateAsset(&Asset{
+		Code:     "XLM",
+		IssuerID: issuer.ID,
+	}, []string{"code", "issuer_id"})
+	require.NoError(t, err)
+	var asset1 Asset
+	err = session.GetRaw(&asset1, `
+		SELECT *
+		FROM assets
+		ORDER BY id DESC
+		LIMIT 1`,
+	)
+	require.NoError(t, err)
+
+	// Adding another asset to be used later:
+	err = session.InsertOrUpdateAsset(&Asset{
+		Code:     "BTC",
+		IssuerID: issuer.ID,
+	}, []string{"code", "issuer_id"})
+	require.NoError(t, err)
+	var asset2 Asset
+	err = session.GetRaw(&asset2, `
+		SELECT *
+		FROM assets
+		ORDER BY id DESC
+		LIMIT 1`,
+	)
+	require.NoError(t, err)
+
+	// Verify that we actually have two assets:
+	assert.NotEqual(t, asset1.ID, asset2.ID)
+
+	// Setting up some times for testing
+	now := time.Now()
+	oneDayAgo := now.AddDate(0, 0, -1)
+	oneMonthAgo := now.AddDate(0, -1, 0)
+	oneYearAgo := now.AddDate(-1, 0, 0)
+
+	// Now let's create the trades:
+	trades := []Trade{
+		Trade{
+			HorizonID:       "hrzid1",
+			BaseAssetID:     asset1.ID,
+			CounterAssetID:  asset2.ID,
+			LedgerCloseTime: now,
+		},
+		Trade{
+			HorizonID:       "hrzid2",
+			BaseAssetID:     asset2.ID,
+			CounterAssetID:  asset1.ID,
+			LedgerCloseTime: oneDayAgo,
+		},
+		Trade{
+			HorizonID:       "hrzid3",
+			BaseAssetID:     asset2.ID,
+			CounterAssetID:  asset1.ID,
+			LedgerCloseTime: oneMonthAgo,
+		},
+		Trade{
+			HorizonID:       "hrzid4",
+			BaseAssetID:     asset2.ID,
+			CounterAssetID:  asset1.ID,
+			LedgerCloseTime: oneYearAgo,
+		},
+	}
+	err = session.BulkInsertTrades(trades)
+	require.NoError(t, err)
+
+	// Deleting trades older than 1 day ago:
+	err = session.DeleteOldTrades(oneDayAgo)
+	require.NoError(t, err)
+
+	var dbTrades []Trade
+	var trade1, trade2 Trade
+	err = session.SelectRaw(&dbTrades, "SELECT * FROM trades")
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(dbTrades))
+
+	// Make sure we're actually deleting the entries we wanted:
+	for i, trade := range dbTrades {
+		if trade.HorizonID == "hrzid1" {
+			trade1 = dbTrades[i]
+		}
+
+		if trade.HorizonID == "hrzid2" {
+			trade2 = dbTrades[i]
+		}
+	}
+
+	assert.NotEqual(t, trade1.HorizonID, "")
+	assert.NotEqual(t, trade2.HorizonID, "")
+	assert.Equal(
+		t,
+		now.Local().Truncate(time.Millisecond),
+		trade1.LedgerCloseTime.Local().Truncate(time.Millisecond),
+	)
+	assert.Equal(
+		t,
+		oneDayAgo.Local().Truncate(time.Millisecond),
+		trade2.LedgerCloseTime.Local().Truncate(time.Millisecond),
+	)
+}


### PR DESCRIPTION
If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description.

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.

## Summary

### Goal and scope

This PR closes #1086. It creates a script to clean up old database entries, since the Ticker APIs provide 7-day volume data at most.

### Summary of changes

- Created a query on tickerdb to delete old db entries
- Created a CLI command that uses that query and accepts a time window parameter (--keep-days)

### Known limitations & issues

N/A

### What shouldn't be reviewed

Database tests are long – the last assertion lines are probably the most useful to review.