### PR TITLE
keystore: add a README file

### DIFF
--- a/exp/services/keystore/cmd/keystored/README.md
+++ b/exp/services/keystore/cmd/keystored/README.md
@@ -1,0 +1,27 @@
+# Run keystored in development
+
+Generate the certificate and the private key pair for localhost
+if you haven't done so:
+
+```sh
+cd github.com/stellar/go/exp/services/keystore
+./tls/regen.sh
+```
+Simply choose all the default options. This will create three files:
+tls/server.crt, tls/server.key, and tls/server.csr.
+
+We will only be using `server.crt` and `server.key`.
+
+Install the `keystored` command:
+
+```sh
+cd github.com/stellar/go/exp/services/keystore
+go install ./cmd/keystored
+```
+
+Run `keystored` in development:
+
+```sh
+keystored -tls-cert=tls/server.crt -tls-key=tls/server.key serve
+```
+


### PR DESCRIPTION
This README file adds the instructions to start keystored with TLS
properly.