### PR TITLE
keystore: add migrate command to handle migrations

### DIFF
--- a/exp/services/keystore/cmd/keystored/README.md
+++ b/exp/services/keystore/cmd/keystored/README.md
@@ -19,6 +19,13 @@ cd github.com/stellar/go/exp/services/keystore
 go install ./cmd/keystored
 ```
 
+Create `keytore` Postgres database locally:
+
+```sh
+createdb keystore
+keystored migrate up
+```
+
 Run `keystored` in development:
 
 ```sh

--- a/exp/services/keystore/cmd/keystored/README.md
+++ b/exp/services/keystore/cmd/keystored/README.md
@@ -19,11 +19,26 @@ cd github.com/stellar/go/exp/services/keystore
 go install ./cmd/keystored
 ```
 
-Create `keytore` Postgres database locally:
+Set up `keytore` Postgres database locally:
 
 ```sh
 createdb keystore
 keystored migrate up
+```
+
+You can undo all migrations by running
+```sh
+keystored migrate down
+```
+
+You can redo the last migration by running
+```sh
+keystored migrate redo
+```
+
+You can check whether there is any unapplied migrations by running
+```sh
+keystored migrate status
 ```
 
 Run `keystored` in development:

--- a/exp/services/keystore/cmd/keystored/README.md
+++ b/exp/services/keystore/cmd/keystored/README.md
@@ -19,7 +19,7 @@ cd github.com/stellar/go/exp/services/keystore
 go install ./cmd/keystored
 ```
 
-Set up `keytore` Postgres database locally:
+Set up `keystore` Postgres database locally:
 
 ```sh
 createdb keystore

--- a/exp/services/keystore/cmd/keystored/main.go
+++ b/exp/services/keystore/cmd/keystored/main.go
@@ -11,11 +11,16 @@ import (
 	"os"
 	"time"
 
+	migrate "github.com/rubenv/sql-migrate"
 	"github.com/stellar/go/exp/services/keystore"
 	"github.com/stellar/go/support/log"
 
 	_ "github.com/lib/pq"
 )
+
+var migrations = &migrate.FileMigrationSource{
+	Dir: "migrations",
+}
 
 func main() {
 	ctx := context.Background()
@@ -105,6 +110,30 @@ func main() {
 		// block forever without using any resources so this process won't quit while
 		// the goroutine containing ListenAndServe is still working
 		select {}
+	case "migrate":
+		migrateCmd := flag.Arg(1)
+		switch migrateCmd {
+		case "up":
+			n, err := migrate.Exec(db, "postgres", migrations, migrate.Up)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "error applying up migrations", err)
+				os.Exit(1)
+			}
+			fmt.Printf("Applied %d up migrations!\n", n)
+
+		case "down":
+			n, err := migrate.Exec(db, "postgres", migrations, migrate.Down)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "error applying down migrations", err)
+				os.Exit(1)
+			}
+			fmt.Printf("Applied %d down migrations!\n", n)
+		}
+
+	default:
+		fmt.Fprintf(os.Stderr, "unrecognized command: %q\n", cmd)
+		os.Exit(1)
+
 	}
 }
 

--- a/exp/services/keystore/cmd/keystored/main.go
+++ b/exp/services/keystore/cmd/keystored/main.go
@@ -23,6 +23,8 @@ var keystoreMigrations = &migrate.FileMigrationSource{
 	Dir: "migrations",
 }
 
+const dbDriverName = "postgres"
+
 func main() {
 	ctx := context.Background()
 	tlsCert := flag.String("tls-cert", "", "TLS certificate file path")
@@ -52,7 +54,7 @@ func main() {
 		log.DefaultLogger.Logger.SetLevel(cfg.LogLevel)
 	}
 
-	db, err := sql.Open("postgres", cfg.DBURL)
+	db, err := sql.Open(dbDriverName, cfg.DBURL)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error opening database", err)
 		os.Exit(1)
@@ -65,7 +67,6 @@ func main() {
 		fmt.Fprintln(os.Stderr, "error accessing database", err)
 		os.Exit(1)
 	}
-	fmt.Fprintln(os.Stdout, "Successfully connected to keystore db")
 
 	cmd := flag.Arg(0)
 	switch cmd {
@@ -111,24 +112,48 @@ func main() {
 		// block forever without using any resources so this process won't quit while
 		// the goroutine containing ListenAndServe is still working
 		select {}
+
 	case "migrate":
 		migrateCmd := flag.Arg(1)
 		switch migrateCmd {
 		case "up":
-			n, err := migrate.Exec(db, "postgres", keystoreMigrations, migrate.Up)
+			n, err := migrate.Exec(db, dbDriverName, keystoreMigrations, migrate.Up)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "error applying up migrations", err)
 				os.Exit(1)
 			}
+
 			fmt.Fprintf(os.Stdout, "Applied %d up migrations!\n", n)
 
 		case "down":
-			n, err := migrate.Exec(db, "postgres", keystoreMigrations, migrate.Down)
+			n, err := migrate.Exec(db, dbDriverName, keystoreMigrations, migrate.Down)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "error applying down migrations", err)
 				os.Exit(1)
 			}
+
 			fmt.Fprintf(os.Stdout, "Applied %d down migrations!\n", n)
+
+		case "redo":
+			migrations, _, err := migrate.PlanMigration(db, dbDriverName, keystoreMigrations, migrate.Down, 1)
+			if len(migrations) == 0 {
+				fmt.Fprintln(os.Stdout, "Nothing to do!")
+				os.Exit(0)
+			}
+
+			_, err = migrate.ExecMax(db, dbDriverName, keystoreMigrations, migrate.Down, 1)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "error applying the last down migration", err)
+				os.Exit(1)
+			}
+
+			_, err = migrate.ExecMax(db, dbDriverName, keystoreMigrations, migrate.Up, 1)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "error applying the last up migration", err)
+				os.Exit(1)
+			}
+
+			fmt.Fprintf(os.Stdout, "Reapplied migration %s.\n", migrations[0].Id)
 
 		case "status":
 			unappliedMigrations := getUnappliedMigrations(db)
@@ -174,7 +199,7 @@ func getUnappliedMigrations(db *sql.DB) []string {
 		os.Exit(1)
 	}
 
-	records, err := migrate.GetMigrationRecords(db, "postgres")
+	records, err := migrate.GetMigrationRecords(db, dbDriverName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error getting keystore migrations records", err)
 		os.Exit(1)

--- a/exp/services/keystore/cmd/keystored/main.go
+++ b/exp/services/keystore/cmd/keystored/main.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sort"
 	"time"
 
 	migrate "github.com/rubenv/sql-migrate"
@@ -18,7 +19,7 @@ import (
 	_ "github.com/lib/pq"
 )
 
-var migrations = &migrate.FileMigrationSource{
+var keystoreMigrations = &migrate.FileMigrationSource{
 	Dir: "migrations",
 }
 
@@ -114,20 +115,31 @@ func main() {
 		migrateCmd := flag.Arg(1)
 		switch migrateCmd {
 		case "up":
-			n, err := migrate.Exec(db, "postgres", migrations, migrate.Up)
+			n, err := migrate.Exec(db, "postgres", keystoreMigrations, migrate.Up)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "error applying up migrations", err)
 				os.Exit(1)
 			}
-			fmt.Printf("Applied %d up migrations!\n", n)
+			fmt.Fprintf(os.Stdout, "Applied %d up migrations!\n", n)
 
 		case "down":
-			n, err := migrate.Exec(db, "postgres", migrations, migrate.Down)
+			n, err := migrate.Exec(db, "postgres", keystoreMigrations, migrate.Down)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "error applying down migrations", err)
 				os.Exit(1)
 			}
-			fmt.Printf("Applied %d down migrations!\n", n)
+			fmt.Fprintf(os.Stdout, "Applied %d down migrations!\n", n)
+
+		case "status":
+			unappliedMigrations := getUnappliedMigrations(db)
+			if len(unappliedMigrations) > 0 {
+				fmt.Fprintf(os.Stdout, "There are %d unapplied migrations:\n", len(unappliedMigrations))
+				for _, id := range unappliedMigrations {
+					fmt.Fprintln(os.Stdout, id)
+				}
+			} else {
+				fmt.Fprintln(os.Stdout, "All migrations have been unapplied!")
+			}
 
 		default:
 			fmt.Fprintf(os.Stderr, "unrecognized migration command: %q\n", migrateCmd)
@@ -153,4 +165,41 @@ func (ln tcpKeepAliveListener) Accept() (net.Conn, error) {
 	tc.SetKeepAlive(true)
 	tc.SetKeepAlivePeriod(3 * time.Minute)
 	return tc, nil
+}
+
+func getUnappliedMigrations(db *sql.DB) []string {
+	migrations, err := keystoreMigrations.FindMigrations()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error getting keystore migrations", err)
+		os.Exit(1)
+	}
+
+	records, err := migrate.GetMigrationRecords(db, "postgres")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error getting keystore migrations records", err)
+		os.Exit(1)
+	}
+
+	unappliedMigrations := make(map[string]struct{})
+	for _, m := range migrations {
+		unappliedMigrations[m.Id] = struct{}{}
+	}
+
+	for _, r := range records {
+		if _, ok := unappliedMigrations[r.Id]; !ok {
+			fmt.Fprintf(os.Stdout, "Could not find migration file: %v\n", r.Id)
+			continue
+		}
+
+		delete(unappliedMigrations, r.Id)
+	}
+
+	result := make([]string, 0, len(unappliedMigrations))
+	for id := range unappliedMigrations {
+		result = append(result, id)
+	}
+
+	sort.Strings(result)
+
+	return result
 }

--- a/exp/services/keystore/cmd/keystored/main.go
+++ b/exp/services/keystore/cmd/keystored/main.go
@@ -128,12 +128,15 @@ func main() {
 				os.Exit(1)
 			}
 			fmt.Printf("Applied %d down migrations!\n", n)
+
+		default:
+			fmt.Fprintf(os.Stderr, "unrecognized migration command: %q\n", migrateCmd)
+			os.Exit(1)
 		}
 
 	default:
 		fmt.Fprintf(os.Stderr, "unrecognized command: %q\n", cmd)
 		os.Exit(1)
-
 	}
 }
 

--- a/exp/services/keystore/cmd/keystored/main.go
+++ b/exp/services/keystore/cmd/keystored/main.go
@@ -46,7 +46,7 @@ func main() {
 	if cfg.LogFile != "" {
 		logFile, err := os.OpenFile(cfg.LogFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "Failed to open file to log", err)
+			fmt.Fprintf(os.Stderr, "Failed to open file to log: %v\n", err)
 			os.Exit(1)
 		}
 
@@ -56,7 +56,7 @@ func main() {
 
 	db, err := sql.Open(dbDriverName, cfg.DBURL)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "error opening database", err)
+		fmt.Fprintf(os.Stderr, "error opening database: %v\n", err)
 		os.Exit(1)
 	}
 	db.SetMaxOpenConns(cfg.MaxOpenDBConns)
@@ -64,7 +64,7 @@ func main() {
 
 	err = db.Ping()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "error accessing database", err)
+		fmt.Fprintf(os.Stderr, "error accessing database: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -73,7 +73,7 @@ func main() {
 	case "serve":
 		_, err := keystore.NewService(ctx, db)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "error initializing service object", err)
+			fmt.Fprintf(os.Stderr, "error initializing service object: %v\n", err)
 			os.Exit(1)
 		}
 
@@ -86,7 +86,7 @@ func main() {
 
 		listener, err := net.Listen("tcp", addr)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "error listening", err)
+			fmt.Fprintf(os.Stderr, "error listening: %v\n", err)
 			os.Exit(1)
 		}
 
@@ -94,7 +94,7 @@ func main() {
 		if *tlsCert != "" {
 			cer, err := tls.LoadX509KeyPair(*tlsCert, *tlsKey)
 			if err != nil {
-				fmt.Fprintln(os.Stderr, "error parsing TLS keypair", err)
+				fmt.Fprintf(os.Stderr, "error parsing TLS keypair: %v\n", err)
 				os.Exit(1)
 			}
 
@@ -119,7 +119,7 @@ func main() {
 		case "up":
 			n, err := migrate.Exec(db, dbDriverName, keystoreMigrations, migrate.Up)
 			if err != nil {
-				fmt.Fprintln(os.Stderr, "error applying up migrations", err)
+				fmt.Fprintf(os.Stderr, "error applying up migrations: %v\n", err)
 				os.Exit(1)
 			}
 
@@ -128,7 +128,7 @@ func main() {
 		case "down":
 			n, err := migrate.Exec(db, dbDriverName, keystoreMigrations, migrate.Down)
 			if err != nil {
-				fmt.Fprintln(os.Stderr, "error applying down migrations", err)
+				fmt.Fprintf(os.Stderr, "error applying down migrations: %v\n", err)
 				os.Exit(1)
 			}
 
@@ -143,13 +143,13 @@ func main() {
 
 			_, err = migrate.ExecMax(db, dbDriverName, keystoreMigrations, migrate.Down, 1)
 			if err != nil {
-				fmt.Fprintln(os.Stderr, "error applying the last down migration", err)
+				fmt.Fprintf(os.Stderr, "error applying the last down migration: %v\n", err)
 				os.Exit(1)
 			}
 
 			_, err = migrate.ExecMax(db, dbDriverName, keystoreMigrations, migrate.Up, 1)
 			if err != nil {
-				fmt.Fprintln(os.Stderr, "error applying the last up migration", err)
+				fmt.Fprintf(os.Stderr, "error applying the last up migration: %v\n", err)
 				os.Exit(1)
 			}
 
@@ -163,7 +163,7 @@ func main() {
 					fmt.Fprintln(os.Stdout, id)
 				}
 			} else {
-				fmt.Fprintln(os.Stdout, "All migrations have been unapplied!")
+				fmt.Fprintln(os.Stdout, "All migrations have been applied!")
 			}
 
 		default:
@@ -195,13 +195,13 @@ func (ln tcpKeepAliveListener) Accept() (net.Conn, error) {
 func getUnappliedMigrations(db *sql.DB) []string {
 	migrations, err := keystoreMigrations.FindMigrations()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "error getting keystore migrations", err)
+		fmt.Fprintf(os.Stderr, "error getting keystore migrations: %v\n", err)
 		os.Exit(1)
 	}
 
 	records, err := migrate.GetMigrationRecords(db, dbDriverName)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "error getting keystore migrations records", err)
+		fmt.Fprintf(os.Stderr, "error getting keystore migrations records: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/exp/services/keystore/migrations/2019-05-07.0.initial-migrations.sql
+++ b/exp/services/keystore/migrations/2019-05-07.0.initial-migrations.sql
@@ -1,0 +1,21 @@
+-- +migrate Up
+
+CREATE TABLE public.encrypted_keys (
+    user_id text NOT NULL,
+    type text NOT NULL,
+    pubkey text NOT NULL,
+    path text,
+    extra bytea,
+    encrypter_name text NOT NULL,
+    encrypted_seed bytea NOT NULL,
+    salt text NOT NULL,
+    created_at timestamp with time zone NOT NULL DEFAULT NOW(),
+    modified_at timestamp with time zone,
+    PRIMARY KEY (user_id, pubkey, encrypter_name)
+);
+
+CREATE INDEX encrypted_keys_user_id_idx ON public.encrypted_keys (user_id);
+
+-- +migrate Down
+
+DROP TABLE public.encrypted_keys;


### PR DESCRIPTION
This PR introduces `keystored migrate up/down` command to handle
migrations. It also defines an initial migration for the `encrypted_keys`
table.
