### PR TITLE
exp/ticker: fix process of ingesting trades through streaming

### DIFF
--- a/exp/ticker/internal/actions_trade.go
+++ b/exp/ticker/internal/actions_trade.go
@@ -31,10 +31,12 @@ func StreamTrades(
 		scraper.NormalizeTradeAssets(&trade)
 		bID, cID, err := findBaseAndCounter(s, trade)
 		if err != nil {
+			l.Errorln(err)
 			return
 		}
 		dbTrade, err := hProtocolTradeToDBTrade(trade, bID, cID)
 		if err != nil {
+			l.Errorln(err)
 			return
 		}
 

--- a/exp/ticker/internal/actions_trade.go
+++ b/exp/ticker/internal/actions_trade.go
@@ -28,6 +28,7 @@ func StreamTrades(
 	}
 	handler := func(trade hProtocol.Trade) {
 		l.Infof("New trade arrived. ID: %v; Close Time: %v\n", trade.ID, trade.LedgerCloseTime)
+		scraper.NormalizeTradeAssets(&trade)
 		bID, cID, err := findBaseAndCounter(s, trade)
 		if err != nil {
 			return

--- a/exp/ticker/internal/scraper/trade_scraper_test.go
+++ b/exp/ticker/internal/scraper/trade_scraper_test.go
@@ -110,7 +110,7 @@ func TestNormalizeTradeAssets(t *testing.T) {
 		Price:            &price,
 	}
 
-	normalizeTradeAssets(&trade1)
+	NormalizeTradeAssets(&trade1)
 	assert.Equal(t, baseAmount, trade1.CounterAmount)
 	assert.Equal(t, baseAccount, trade1.CounterAccount)
 	assert.Equal(t, baseAssetCode, trade1.CounterAssetCode)
@@ -136,7 +136,7 @@ func TestNormalizeTradeAssets(t *testing.T) {
 		CounterAssetIssuer: counterAssetIssuer,
 		Price:              &price,
 	}
-	normalizeTradeAssets(&trade2)
+	NormalizeTradeAssets(&trade2)
 	assert.Equal(t, baseAmount, trade2.CounterAmount)
 	assert.Equal(t, baseAccount, trade2.CounterAccount)
 	assert.Equal(t, "BBB", trade2.CounterAssetCode)


### PR DESCRIPTION
This PR fixes an issue through which trades ingested via streaming were not being pre-processed.

With this fix, trade pairs are normalized (in the same way we do for the trade backfill process), and native assets receive an `XLM` code.