### PR TITLE
exp/ticker: fix db tests that would sporadically break due to rounding issues

### DIFF
--- a/exp/ticker/internal/tickerdb/queries_asset_test.go
+++ b/exp/ticker/internal/tickerdb/queries_asset_test.go
@@ -105,15 +105,8 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 	assert.Equal(t, code, dbAsset2.Code)
 	assert.Equal(t, issuerAccount, dbAsset1.IssuerAccount)
 	assert.Equal(t, dbIssuer.ID, dbAsset2.IssuerID)
-	assert.NotEqual(
-		t,
-		firstTime.Local().Truncate(time.Millisecond),
-		dbAsset2.LastValid.Local().Truncate(time.Millisecond),
-	)
-	assert.NotEqual(t,
-		firstTime.Local().Truncate(time.Millisecond),
-		dbAsset2.LastChecked.Local().Truncate(time.Millisecond),
-	)
+	assert.True(t, dbAsset2.LastValid.After(firstTime))
+	assert.True(t, dbAsset2.LastChecked.After(firstTime))
 	assert.Equal(
 		t,
 		secondTime.Local().Truncate(time.Millisecond),
@@ -145,16 +138,8 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 	assert.Equal(t, code, dbAsset3.Code)
 	assert.Equal(t, issuerAccount, dbAsset3.IssuerAccount)
 	assert.Equal(t, dbIssuer.ID, dbAsset3.IssuerID)
-	assert.NotEqual(
-		t,
-		thirdTime.Local().Truncate(time.Millisecond),
-		dbAsset3.LastValid.Local().Truncate(time.Millisecond),
-	)
-	assert.NotEqual(
-		t,
-		thirdTime.Local().Truncate(time.Millisecond),
-		dbAsset3.LastChecked.Local().Truncate(time.Millisecond),
-	)
+	assert.True(t, dbAsset3.LastValid.Before(thirdTime))
+	assert.True(t, dbAsset3.LastChecked.Before(thirdTime))
 	assert.Equal(
 		t,
 		dbAsset2.LastValid.Local().Truncate(time.Millisecond),


### PR DESCRIPTION
This PR fixes #1205 – an issue that occurs sporadically during CI tests.

Since we're rounding times when performing comparisons (as dbs don't store times in the same precision level as the Go language itself), there would be some cases in which the time difference was lower than the precision level we're comparing. In those cases, rounding would make times look equal, and tests with `NotEqual` assertion would consequently fail.

To fix this, we're changing `NotEqual` tests with `Before` and `After` comparisons (without rounding), which should be more accurate.