### PR TITLE
txnbuild: add max limit to change trust

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased [v1.2.0] 
+
+* Added `MaxTrustlineLimit` which represents the maximum value for a trustline limit.
+* ChangeTrust operation with no `Limit` field set now defaults to `MaxTrustlineLimit`.
+
 ## [v1.1.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.1.0) - 2019-02-02
 
 * Support for multiple signatures ([#1198](https://github.com/stellar/go/pull/1198))

--- a/txnbuild/change_trust.go
+++ b/txnbuild/change_trust.go
@@ -10,14 +10,14 @@ import (
 
 // ChangeTrust represents the Stellar change trust operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html.
-// If Limit is omitted,  it defaults to txnbuild.MaxTrustlineLimit; the max int64 value.
+// If Limit is omitted, it defaults to txnbuild.MaxTrustlineLimit.
 type ChangeTrust struct {
 	Line          Asset
 	Limit         string
 	SourceAccount Account
 }
 
-// MaxTrustlineLimit represents the maximum value that can be passed as trutline Limit
+// MaxTrustlineLimit represents the maximum value that can be set as a trustline limit.
 var MaxTrustlineLimit = amount.StringFromInt64(math.MaxInt64)
 
 // RemoveTrustlineOp returns a ChangeTrust operation to remove the trustline of the described asset,

--- a/txnbuild/change_trust.go
+++ b/txnbuild/change_trust.go
@@ -1,18 +1,24 @@
 package txnbuild
 
 import (
+	"math"
+
 	"github.com/stellar/go/amount"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 
 // ChangeTrust represents the Stellar change trust operation. See
-// https://www.stellar.org/developers/guides/concepts/list-of-operations.html
+// https://www.stellar.org/developers/guides/concepts/list-of-operations.html.
+// If Limit is omitted,  it defaults to txnbuild.MaxTrustlineLimit; the max int64 value.
 type ChangeTrust struct {
 	Line          Asset
 	Limit         string
 	SourceAccount Account
 }
+
+// MaxTrustlineLimit represents the maximum value that can be passed as trutline Limit
+var MaxTrustlineLimit = amount.StringFromInt64(math.MaxInt64)
 
 // RemoveTrustlineOp returns a ChangeTrust operation to remove the trustline of the described asset,
 // by setting the limit to "0".
@@ -31,6 +37,10 @@ func (ct *ChangeTrust) BuildXDR() (xdr.Operation, error) {
 	xdrLine, err := ct.Line.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "can't convert trustline asset to XDR")
+	}
+
+	if ct.Limit == "" {
+		ct.Limit = MaxTrustlineLimit
 	}
 
 	xdrLimit, err := amount.Parse(ct.Limit)

--- a/txnbuild/change_trust_test.go
+++ b/txnbuild/change_trust_test.go
@@ -1,0 +1,27 @@
+package txnbuild
+
+import (
+	"testing"
+
+	"github.com/stellar/go/network"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChangeTrustMaxLimit(t *testing.T) {
+	kp0 := newKeypair0()
+	txSourceAccount := makeTestAccount(kp0, "9605939170639898")
+
+	changeTrust := ChangeTrust{
+		Line: CreditAsset{"ABCD", kp0.Address()},
+	}
+
+	tx := Transaction{
+		SourceAccount: &txSourceAccount,
+		Operations:    []Operation{&changeTrust},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+	received := buildSignEncode(t, tx, kp0)
+	expected := "AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAiII0AAAAbAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAGAAAAAUFCQ0QAAAAA4Nxt4XJcrGZRYrUvrOc1sooiQ+QdEk1suS1wo+oucsV//////////wAAAAAAAAAB6i5yxQAAAEBen+Aa821qqfb+ASHhCg074ulPcCbIsUNvzUg2x92R/vRRKIGF5RztvPGBkktWkXLarDe5yqlBA+L3zpcVs+wB"
+	assert.Equal(t, expected, received, "Base 64 XDR should match")
+}

--- a/txnbuild/change_trust_test.go
+++ b/txnbuild/change_trust_test.go
@@ -22,6 +22,8 @@ func TestChangeTrustMaxLimit(t *testing.T) {
 		Network:       network.TestNetworkPassphrase,
 	}
 	received := buildSignEncode(t, tx, kp0)
+
+	// https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAiII0AAAAbAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAGAAAAAUFCQ0QAAAAA4Nxt4XJcrGZRYrUvrOc1sooiQ%2BQdEk1suS1wo%2BoucsV%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwAAAAAAAAAB6i5yxQAAAEBen%2BAa821qqfb%2BASHhCg074ulPcCbIsUNvzUg2x92R%2FvRRKIGF5RztvPGBkktWkXLarDe5yqlBA%2BL3zpcVs%2BwB&type=TransactionEnvelope&network=test
 	expected := "AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAiII0AAAAbAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAGAAAAAUFCQ0QAAAAA4Nxt4XJcrGZRYrUvrOc1sooiQ+QdEk1suS1wo+oucsV//////////wAAAAAAAAAB6i5yxQAAAEBen+Aa821qqfb+ASHhCg074ulPcCbIsUNvzUg2x92R/vRRKIGF5RztvPGBkktWkXLarDe5yqlBA+L3zpcVs+wB"
 	assert.Equal(t, expected, received, "Base 64 XDR should match")
 }


### PR DESCRIPTION
This PR adds the maximum trustline limit to a change trust operation when no limit is set. 
Closes #1265 