### PR TITLE
txnbuild: SimpleAccount implementation

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased [v1.2.0] 
+
+* In addition to account resoponses from horizon, transactions and operations can now be built with SimpleAccount structs constructed locally. 
+
 ## [v1.1.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.1.0) - 2019-02-02
 
 * Support for multiple signatures ([#1198](https://github.com/stellar/go/pull/1198))

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -5,7 +5,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased [v1.2.0] 
 
-* In addition to account responses from horizon, transactions and operations can now be built with SimpleAccount structs constructed locally. 
+* In addition to account responses from horizon, transactions and operations can now be built with txnbuild.SimpleAccount structs constructed locally. 
 * Added `MaxTrustlineLimit` which represents the maximum value for a trustline limit.
 * ChangeTrust operation with no `Limit` field set now defaults to `MaxTrustlineLimit`.
 

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -5,7 +5,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased [v1.2.0] 
 
-* In addition to account resoponses from horizon, transactions and operations can now be built with SimpleAccount structs constructed locally. 
+* In addition to account responses from horizon, transactions and operations can now be built with SimpleAccount structs constructed locally. 
 
 ## [v1.1.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.1.0) - 2019-02-02
 

--- a/txnbuild/change_trust_test.go
+++ b/txnbuild/change_trust_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestChangeTrustMaxLimit(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := makeTestAccount(kp0, "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	changeTrust := ChangeTrust{
 		Line: CreditAsset{"ABCD", kp0.Address()},

--- a/txnbuild/signers_test.go
+++ b/txnbuild/signers_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestAccountMergeMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	accountMerge := AccountMerge{
 		Destination:   "GAS4V4O2B7DW5T7IQRPEEVCRXMDZESKISR7DVIGKZQYYV3OSQ5SH5LVP",
@@ -33,10 +33,10 @@ func TestAccountMergeMultSigners(t *testing.T) {
 
 func TestAllowTrustMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	opSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
+	opSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	txSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
+	txSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	issuedAsset := CreditAsset{"ABCD", kp1.Address()}
 	allowTrust := AllowTrust{
@@ -60,10 +60,10 @@ func TestAllowTrustMultSigners(t *testing.T) {
 
 func TestBumpSequenceMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	bumpSequence := BumpSequence{
 		BumpTo:        9606132444168300,
@@ -84,10 +84,10 @@ func TestBumpSequenceMultSigners(t *testing.T) {
 
 func TestChangeTrustMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	changeTrust := ChangeTrust{
 		Line:          CreditAsset{"ABCD", kp0.Address()},
@@ -108,10 +108,10 @@ func TestChangeTrustMultSigners(t *testing.T) {
 
 func TestCreateAccountMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
@@ -133,10 +133,10 @@ func TestCreateAccountMultSigners(t *testing.T) {
 
 func TestCreatePassiveSellOfferMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	createPassiveOffer := CreatePassiveSellOffer{
 		Selling:       NativeAsset{},
@@ -160,10 +160,10 @@ func TestCreatePassiveSellOfferMultSigners(t *testing.T) {
 
 func TestInflationMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	inflation := Inflation{
 		SourceAccount: &opSourceAccount,
@@ -183,10 +183,10 @@ func TestInflationMultSigners(t *testing.T) {
 
 func TestManageDataMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	manageData := ManageData{
 		Name:          "Fruit preference",
@@ -208,10 +208,10 @@ func TestManageDataMultSigners(t *testing.T) {
 
 func TestManageOfferCreateMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	selling := NativeAsset{}
 	buying := CreditAsset{"ABCD", kp0.Address()}
@@ -234,10 +234,10 @@ func TestManageOfferCreateMultSigners(t *testing.T) {
 
 func TestManageOfferDeleteMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	offerID := int64(2921622)
 	deleteOffer, err := DeleteOfferOp(offerID, &opSourceAccount)
@@ -257,10 +257,10 @@ func TestManageOfferDeleteMultSigners(t *testing.T) {
 
 func TestManageOfferUpdateMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	selling := NativeAsset{}
 	buying := CreditAsset{"ABCD", kp0.Address()}
@@ -284,10 +284,10 @@ func TestManageOfferUpdateMultSigners(t *testing.T) {
 
 func TestPathPaymentMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
 	pathPayment := PathPayment{
@@ -315,10 +315,10 @@ func TestPathPaymentMultSigners(t *testing.T) {
 
 func TestPaymentMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	payment := Payment{
 		Destination:   "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
@@ -341,10 +341,10 @@ func TestPaymentMultSigners(t *testing.T) {
 
 func TestSetOptionsMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	setOptions := SetOptions{
 		SetFlags:      []AccountFlag{AuthRequired, AuthRevocable},

--- a/txnbuild/signers_test.go
+++ b/txnbuild/signers_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestAccountMergeMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := makeTestAccount(kp0, "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
 
 	kp1 := newKeypair1()
-	opSourceAccount := makeTestAccount(kp1, "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
 
 	accountMerge := AccountMerge{
 		Destination:   "GAS4V4O2B7DW5T7IQRPEEVCRXMDZESKISR7DVIGKZQYYV3OSQ5SH5LVP",
@@ -33,10 +33,10 @@ func TestAccountMergeMultSigners(t *testing.T) {
 
 func TestAllowTrustMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	opSourceAccount := makeTestAccount(kp0, "9605939170639898")
+	opSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
 
 	kp1 := newKeypair1()
-	txSourceAccount := makeTestAccount(kp1, "9606132444168199")
+	txSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
 
 	issuedAsset := CreditAsset{"ABCD", kp1.Address()}
 	allowTrust := AllowTrust{
@@ -60,10 +60,10 @@ func TestAllowTrustMultSigners(t *testing.T) {
 
 func TestBumpSequenceMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := makeTestAccount(kp0, "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
 
 	kp1 := newKeypair1()
-	opSourceAccount := makeTestAccount(kp1, "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
 
 	bumpSequence := BumpSequence{
 		BumpTo:        9606132444168300,
@@ -84,10 +84,10 @@ func TestBumpSequenceMultSigners(t *testing.T) {
 
 func TestChangeTrustMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := makeTestAccount(kp0, "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
 
 	kp1 := newKeypair1()
-	opSourceAccount := makeTestAccount(kp1, "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
 
 	changeTrust := ChangeTrust{
 		Line:          CreditAsset{"ABCD", kp0.Address()},
@@ -108,10 +108,10 @@ func TestChangeTrustMultSigners(t *testing.T) {
 
 func TestCreateAccountMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := makeTestAccount(kp0, "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
 
 	kp1 := newKeypair1()
-	opSourceAccount := makeTestAccount(kp1, "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
 
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
@@ -133,10 +133,10 @@ func TestCreateAccountMultSigners(t *testing.T) {
 
 func TestCreatePassiveSellOfferMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := makeTestAccount(kp0, "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
 
 	kp1 := newKeypair1()
-	opSourceAccount := makeTestAccount(kp1, "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
 
 	createPassiveOffer := CreatePassiveSellOffer{
 		Selling:       NativeAsset{},
@@ -160,10 +160,10 @@ func TestCreatePassiveSellOfferMultSigners(t *testing.T) {
 
 func TestInflationMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := makeTestAccount(kp0, "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
 
 	kp1 := newKeypair1()
-	opSourceAccount := makeTestAccount(kp1, "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
 
 	inflation := Inflation{
 		SourceAccount: &opSourceAccount,
@@ -183,10 +183,10 @@ func TestInflationMultSigners(t *testing.T) {
 
 func TestManageDataMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := makeTestAccount(kp0, "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
 
 	kp1 := newKeypair1()
-	opSourceAccount := makeTestAccount(kp1, "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
 
 	manageData := ManageData{
 		Name:          "Fruit preference",
@@ -208,10 +208,10 @@ func TestManageDataMultSigners(t *testing.T) {
 
 func TestManageOfferCreateMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := makeTestAccount(kp0, "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
 
 	kp1 := newKeypair1()
-	opSourceAccount := makeTestAccount(kp1, "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
 
 	selling := NativeAsset{}
 	buying := CreditAsset{"ABCD", kp0.Address()}
@@ -234,10 +234,10 @@ func TestManageOfferCreateMultSigners(t *testing.T) {
 
 func TestManageOfferDeleteMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := makeTestAccount(kp0, "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
 
 	kp1 := newKeypair1()
-	opSourceAccount := makeTestAccount(kp1, "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
 
 	offerID := int64(2921622)
 	deleteOffer, err := DeleteOfferOp(offerID, &opSourceAccount)
@@ -257,10 +257,10 @@ func TestManageOfferDeleteMultSigners(t *testing.T) {
 
 func TestManageOfferUpdateMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := makeTestAccount(kp0, "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
 
 	kp1 := newKeypair1()
-	opSourceAccount := makeTestAccount(kp1, "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
 
 	selling := NativeAsset{}
 	buying := CreditAsset{"ABCD", kp0.Address()}
@@ -284,10 +284,10 @@ func TestManageOfferUpdateMultSigners(t *testing.T) {
 
 func TestPathPaymentMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := makeTestAccount(kp0, "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
 
 	kp1 := newKeypair1()
-	opSourceAccount := makeTestAccount(kp1, "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
 
 	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
 	pathPayment := PathPayment{
@@ -315,10 +315,10 @@ func TestPathPaymentMultSigners(t *testing.T) {
 
 func TestPaymentMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := makeTestAccount(kp0, "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
 
 	kp1 := newKeypair1()
-	opSourceAccount := makeTestAccount(kp1, "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
 
 	payment := Payment{
 		Destination:   "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
@@ -341,10 +341,10 @@ func TestPaymentMultSigners(t *testing.T) {
 
 func TestSetOptionsMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	txSourceAccount := makeTestAccount(kp0, "9605939170639898")
+	txSourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
 
 	kp1 := newKeypair1()
-	opSourceAccount := makeTestAccount(kp1, "9606132444168199")
+	opSourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
 
 	setOptions := SetOptions{
 		SetFlags:      []AccountFlag{AuthRequired, AuthRevocable},

--- a/txnbuild/simple_account.go
+++ b/txnbuild/simple_account.go
@@ -1,16 +1,13 @@
 package txnbuild
 
 import (
-	"strconv"
-
-	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 
-// SimpleAccount implements the Account interface.
+// SimpleAccount is a minimal implementation of an Account.
 type SimpleAccount struct {
 	AccountID string
-	Sequence  string
+	Sequence  int64
 }
 
 // GetAccountID returns the Account ID.
@@ -21,31 +18,17 @@ func (sa *SimpleAccount) GetAccountID() string {
 // IncrementSequenceNumber increments the internal record of the
 // account's sequence number by 1.
 func (sa *SimpleAccount) IncrementSequenceNumber() (xdr.SequenceNumber, error) {
-	seqNum, err := sa.GetSequenceNumber()
-	if err != nil {
-		return xdr.SequenceNumber(0), err
-	}
-	seqNum++
-	sa.Sequence = strconv.FormatInt(int64(seqNum), 10)
+	sa.Sequence++
 	return sa.GetSequenceNumber()
 }
 
 // GetSequenceNumber returns the sequence number of the account.
 func (sa *SimpleAccount) GetSequenceNumber() (xdr.SequenceNumber, error) {
-	seqNum, err := strconv.ParseUint(sa.Sequence, 10, 64)
-	if err != nil {
-		return 0, errors.Wrap(err, "Failed to parse account sequence number")
-	}
-
-	return xdr.SequenceNumber(seqNum), nil
+	return xdr.SequenceNumber(sa.Sequence), nil
 }
 
 // NewSimpleAccount is a factory method that creates a SimpleAccount from "accountID" and "sequence".
-// If "sequence" is not set, it defaults to 0.
-func NewSimpleAccount(accountID string, sequence string) SimpleAccount {
-	if sequence == "" {
-		sequence = "0"
-	}
+func NewSimpleAccount(accountID string, sequence int64) SimpleAccount {
 	return SimpleAccount{accountID, sequence}
 }
 

--- a/txnbuild/simple_account.go
+++ b/txnbuild/simple_account.go
@@ -1,0 +1,53 @@
+package txnbuild
+
+import (
+	"strconv"
+
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+// SimpleAccount implements the Account interface.
+type SimpleAccount struct {
+	AccountID string
+	Sequence  string
+}
+
+// GetAccountID returns the Account ID.
+func (sa *SimpleAccount) GetAccountID() string {
+	return sa.AccountID
+}
+
+// IncrementSequenceNumber increments the internal record of the
+// account's sequence number by 1.
+func (sa *SimpleAccount) IncrementSequenceNumber() (xdr.SequenceNumber, error) {
+	seqNum, err := sa.GetSequenceNumber()
+	if err != nil {
+		return xdr.SequenceNumber(0), err
+	}
+	seqNum++
+	sa.Sequence = strconv.FormatInt(int64(seqNum), 10)
+	return sa.GetSequenceNumber()
+}
+
+// GetSequenceNumber returns the sequence number of the account.
+func (sa *SimpleAccount) GetSequenceNumber() (xdr.SequenceNumber, error) {
+	seqNum, err := strconv.ParseUint(sa.Sequence, 10, 64)
+	if err != nil {
+		return 0, errors.Wrap(err, "Failed to parse account sequence number")
+	}
+
+	return xdr.SequenceNumber(seqNum), nil
+}
+
+// NewSimpleAccount is a factory method that creates a SimpleAccount from "accountID" and "sequence".
+// If "sequence" is not set, it defaults to 0.
+func NewSimpleAccount(accountID string, sequence string) SimpleAccount {
+	if sequence == "" {
+		sequence = "0"
+	}
+	return SimpleAccount{accountID, sequence}
+}
+
+// ensure that SimpleAccount implements Account interface.
+var _ Account = &SimpleAccount{}

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -27,6 +27,7 @@ import (
 type Account interface {
 	GetAccountID() string
 	IncrementSequenceNumber() (xdr.SequenceNumber, error)
+	GetSequenceNumber() (xdr.SequenceNumber, error)
 }
 
 // Transaction represents a Stellar transaction. See

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -27,7 +27,9 @@ import (
 type Account interface {
 	GetAccountID() string
 	IncrementSequenceNumber() (xdr.SequenceNumber, error)
-	GetSequenceNumber() (xdr.SequenceNumber, error)
+	// To do: implement in v2.0.0: change the signature of IncrementSequenceNumber and add GetSequenceNumber
+	// IncrementSequenceNumber() xdr.SequenceNumber
+	// GetSequenceNumber() xdr.SequenceNumber
 }
 
 // Transaction represents a Stellar transaction. See

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -27,9 +27,8 @@ import (
 type Account interface {
 	GetAccountID() string
 	IncrementSequenceNumber() (xdr.SequenceNumber, error)
-	// To do: implement in v2.0.0: change the signature of IncrementSequenceNumber and add GetSequenceNumber
-	// IncrementSequenceNumber() xdr.SequenceNumber
-	// GetSequenceNumber() xdr.SequenceNumber
+	// To do: implement in v2.0.0: add GetSequenceNumber method
+	// GetSequenceNumber() (xdr.SequenceNumber, error)
 }
 
 // Transaction represents a Stellar transaction. See

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -3,25 +3,14 @@ package txnbuild
 import (
 	"testing"
 
-	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
-	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func makeTestAccount(kp *keypair.Full, seqnum string) hProtocol.Account {
-	return hProtocol.Account{
-		HistoryAccount: hProtocol.HistoryAccount{
-			AccountID: kp.Address(),
-		},
-		Sequence: seqnum,
-	}
-}
-
 func TestInflation(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := makeTestAccount(kp0, "3556091187167235")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "3556091187167235")
 
 	inflation := Inflation{}
 
@@ -40,7 +29,7 @@ func TestInflation(t *testing.T) {
 
 func TestCreateAccount(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := makeTestAccount(kp0, "9605939170639897")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639897")
 
 	createAccount := CreateAccount{
 		Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
@@ -61,7 +50,7 @@ func TestCreateAccount(t *testing.T) {
 
 func TestPayment(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := makeTestAccount(kp0, "9605939170639898")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
 
 	payment := Payment{
 		Destination: "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
@@ -83,7 +72,7 @@ func TestPayment(t *testing.T) {
 
 func TestPaymentFailsIfNoAssetSpecified(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := makeTestAccount(kp0, "9605939170639898")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
 
 	payment := Payment{
 		Destination: "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
@@ -104,7 +93,7 @@ func TestPaymentFailsIfNoAssetSpecified(t *testing.T) {
 
 func TestBumpSequence(t *testing.T) {
 	kp1 := newKeypair1()
-	sourceAccount := makeTestAccount(kp1, "9606132444168199")
+	sourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
 
 	bumpSequence := BumpSequence{
 		BumpTo: 9606132444168300,
@@ -124,7 +113,7 @@ func TestBumpSequence(t *testing.T) {
 
 func TestAccountMerge(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := makeTestAccount(kp0, "40385577484298")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484298")
 
 	accountMerge := AccountMerge{
 		Destination: "GAS4V4O2B7DW5T7IQRPEEVCRXMDZESKISR7DVIGKZQYYV3OSQ5SH5LVP",
@@ -144,7 +133,7 @@ func TestAccountMerge(t *testing.T) {
 
 func TestManageData(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := makeTestAccount(kp0, "3556091187167235")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "3556091187167235")
 
 	manageData := ManageData{
 		Name:  "Fruit preference",
@@ -166,7 +155,7 @@ func TestManageData(t *testing.T) {
 
 func TestManageDataRemoveDataEntry(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := makeTestAccount(kp0, "40385577484309")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484309")
 
 	manageData := ManageData{
 		Name: "Fruit preference",
@@ -187,7 +176,7 @@ func TestManageDataRemoveDataEntry(t *testing.T) {
 func TestSetOptionsInflationDestination(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := makeTestAccount(kp0, "40385577484315")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484315")
 
 	setOptions := SetOptions{
 		InflationDestination: NewInflationDestination(kp1.Address()),
@@ -207,7 +196,7 @@ func TestSetOptionsInflationDestination(t *testing.T) {
 
 func TestSetOptionsSetFlags(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := makeTestAccount(kp0, "40385577484318")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484318")
 
 	setOptions := SetOptions{
 		SetFlags: []AccountFlag{AuthRequired, AuthRevocable},
@@ -227,7 +216,7 @@ func TestSetOptionsSetFlags(t *testing.T) {
 
 func TestSetOptionsClearFlags(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := makeTestAccount(kp0, "40385577484319")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484319")
 
 	setOptions := SetOptions{
 		ClearFlags: []AccountFlag{AuthRequired, AuthRevocable},
@@ -247,7 +236,7 @@ func TestSetOptionsClearFlags(t *testing.T) {
 
 func TestSetOptionsMasterWeight(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := makeTestAccount(kp0, "40385577484320")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484320")
 
 	setOptions := SetOptions{
 		MasterWeight: NewThreshold(10),
@@ -267,7 +256,7 @@ func TestSetOptionsMasterWeight(t *testing.T) {
 
 func TestSetOptionsThresholds(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := makeTestAccount(kp0, "40385577484322")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484322")
 
 	setOptions := SetOptions{
 		LowThreshold:    NewThreshold(1),
@@ -289,7 +278,7 @@ func TestSetOptionsThresholds(t *testing.T) {
 
 func TestSetOptionsHomeDomain(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := makeTestAccount(kp0, "40385577484325")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484325")
 
 	setOptions := SetOptions{
 		HomeDomain: NewHomeDomain("LovelyLumensLookLuminous.com"),
@@ -309,7 +298,7 @@ func TestSetOptionsHomeDomain(t *testing.T) {
 
 func TestSetOptionsHomeDomainTooLong(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := makeTestAccount(kp0, "40385577484323")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484323")
 
 	setOptions := SetOptions{
 		HomeDomain: NewHomeDomain("LovelyLumensLookLuminousLately.com"),
@@ -329,7 +318,7 @@ func TestSetOptionsHomeDomainTooLong(t *testing.T) {
 func TestSetOptionsSigner(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := makeTestAccount(kp0, "40385577484325")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484325")
 
 	setOptions := SetOptions{
 		Signer: &Signer{Address: kp1.Address(), Weight: Threshold(4)},
@@ -349,7 +338,7 @@ func TestSetOptionsSigner(t *testing.T) {
 
 func TestMultipleOperations(t *testing.T) {
 	kp1 := newKeypair1()
-	sourceAccount := makeTestAccount(kp1, "9606132444168199")
+	sourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
 
 	inflation := Inflation{}
 	bumpSequence := BumpSequence{
@@ -371,7 +360,7 @@ func TestMultipleOperations(t *testing.T) {
 func TestChangeTrust(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := makeTestAccount(kp0, "40385577484348")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484348")
 
 	changeTrust := ChangeTrust{
 		Line:  CreditAsset{"ABCD", kp1.Address()},
@@ -392,7 +381,7 @@ func TestChangeTrust(t *testing.T) {
 
 func TestChangeTrustNativeAssetNotAllowed(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := makeTestAccount(kp0, "40385577484348")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484348")
 
 	changeTrust := ChangeTrust{
 		Line:  NativeAsset{},
@@ -414,7 +403,7 @@ func TestChangeTrustNativeAssetNotAllowed(t *testing.T) {
 func TestChangeTrustDeleteTrustline(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := makeTestAccount(kp0, "40385577484354")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484354")
 
 	issuedAsset := CreditAsset{"ABCD", kp1.Address()}
 	removeTrust := RemoveTrustlineOp(issuedAsset)
@@ -434,7 +423,7 @@ func TestChangeTrustDeleteTrustline(t *testing.T) {
 func TestAllowTrust(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := makeTestAccount(kp0, "40385577484366")
+	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484366")
 
 	issuedAsset := CreditAsset{"ABCD", kp1.Address()}
 	allowTrust := AllowTrust{
@@ -458,7 +447,7 @@ func TestAllowTrust(t *testing.T) {
 func TestManageSellOfferNewOffer(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := makeTestAccount(kp1, "41137196761092")
+	sourceAccount := NewSimpleAccount(kp1.Address(), "41137196761092")
 
 	selling := NativeAsset{}
 	buying := CreditAsset{"ABCD", kp0.Address()}
@@ -481,7 +470,7 @@ func TestManageSellOfferNewOffer(t *testing.T) {
 
 func TestManageSellOfferDeleteOffer(t *testing.T) {
 	kp1 := newKeypair1()
-	sourceAccount := makeTestAccount(kp1, "41137196761105")
+	sourceAccount := NewSimpleAccount(kp1.Address(), "41137196761105")
 
 	offerID := int64(2921622)
 	deleteOffer, err := DeleteOfferOp(offerID)
@@ -502,7 +491,7 @@ func TestManageSellOfferDeleteOffer(t *testing.T) {
 func TestManageSellOfferUpdateOffer(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := makeTestAccount(kp1, "41137196761097")
+	sourceAccount := NewSimpleAccount(kp1.Address(), "41137196761097")
 
 	selling := NativeAsset{}
 	buying := CreditAsset{"ABCD", kp0.Address()}
@@ -527,7 +516,7 @@ func TestManageSellOfferUpdateOffer(t *testing.T) {
 func TestCreatePassiveSellOffer(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := makeTestAccount(kp1, "41137196761100")
+	sourceAccount := NewSimpleAccount(kp1.Address(), "41137196761100")
 
 	createPassiveOffer := CreatePassiveSellOffer{
 		Selling: NativeAsset{},
@@ -551,7 +540,7 @@ func TestCreatePassiveSellOffer(t *testing.T) {
 func TestPathPayment(t *testing.T) {
 	kp0 := newKeypair0()
 	kp2 := newKeypair2()
-	sourceAccount := makeTestAccount(kp2, "187316408680450")
+	sourceAccount := NewSimpleAccount(kp2.Address(), "187316408680450")
 
 	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
 	pathPayment := PathPayment{
@@ -577,7 +566,7 @@ func TestPathPayment(t *testing.T) {
 
 func TestMemoText(t *testing.T) {
 	kp2 := newKeypair2()
-	sourceAccount := makeTestAccount(kp2, "3556099777101824")
+	sourceAccount := NewSimpleAccount(kp2.Address(), "3556099777101824")
 
 	tx := Transaction{
 		SourceAccount: &sourceAccount,
@@ -595,7 +584,7 @@ func TestMemoText(t *testing.T) {
 
 func TestMemoID(t *testing.T) {
 	kp2 := newKeypair2()
-	sourceAccount := makeTestAccount(kp2, "3428320205078528")
+	sourceAccount := NewSimpleAccount(kp2.Address(), "3428320205078528")
 
 	tx := Transaction{
 		SourceAccount: &sourceAccount,
@@ -612,7 +601,7 @@ func TestMemoID(t *testing.T) {
 
 func TestMemoHash(t *testing.T) {
 	kp2 := newKeypair2()
-	sourceAccount := makeTestAccount(kp2, "3428320205078528")
+	sourceAccount := NewSimpleAccount(kp2.Address(), "3428320205078528")
 
 	tx := Transaction{
 		SourceAccount: &sourceAccount,
@@ -629,7 +618,7 @@ func TestMemoHash(t *testing.T) {
 
 func TestMemoReturn(t *testing.T) {
 	kp2 := newKeypair2()
-	sourceAccount := makeTestAccount(kp2, "3428320205078528")
+	sourceAccount := NewSimpleAccount(kp2.Address(), "3428320205078528")
 
 	tx := Transaction{
 		SourceAccount: &sourceAccount,

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestInflation(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "3556091187167235")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(3556091187167235))
 
 	inflation := Inflation{}
 
@@ -29,7 +29,7 @@ func TestInflation(t *testing.T) {
 
 func TestCreateAccount(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639897")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
 
 	createAccount := CreateAccount{
 		Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
@@ -50,7 +50,7 @@ func TestCreateAccount(t *testing.T) {
 
 func TestPayment(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	payment := Payment{
 		Destination: "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
@@ -72,7 +72,7 @@ func TestPayment(t *testing.T) {
 
 func TestPaymentFailsIfNoAssetSpecified(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "9605939170639898")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	payment := Payment{
 		Destination: "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
@@ -93,7 +93,7 @@ func TestPaymentFailsIfNoAssetSpecified(t *testing.T) {
 
 func TestBumpSequence(t *testing.T) {
 	kp1 := newKeypair1()
-	sourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	bumpSequence := BumpSequence{
 		BumpTo: 9606132444168300,
@@ -113,7 +113,7 @@ func TestBumpSequence(t *testing.T) {
 
 func TestAccountMerge(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484298")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484298))
 
 	accountMerge := AccountMerge{
 		Destination: "GAS4V4O2B7DW5T7IQRPEEVCRXMDZESKISR7DVIGKZQYYV3OSQ5SH5LVP",
@@ -133,7 +133,7 @@ func TestAccountMerge(t *testing.T) {
 
 func TestManageData(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "3556091187167235")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(3556091187167235))
 
 	manageData := ManageData{
 		Name:  "Fruit preference",
@@ -155,7 +155,7 @@ func TestManageData(t *testing.T) {
 
 func TestManageDataRemoveDataEntry(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484309")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484309))
 
 	manageData := ManageData{
 		Name: "Fruit preference",
@@ -176,7 +176,7 @@ func TestManageDataRemoveDataEntry(t *testing.T) {
 func TestSetOptionsInflationDestination(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484315")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484315))
 
 	setOptions := SetOptions{
 		InflationDestination: NewInflationDestination(kp1.Address()),
@@ -196,7 +196,7 @@ func TestSetOptionsInflationDestination(t *testing.T) {
 
 func TestSetOptionsSetFlags(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484318")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484318))
 
 	setOptions := SetOptions{
 		SetFlags: []AccountFlag{AuthRequired, AuthRevocable},
@@ -216,7 +216,7 @@ func TestSetOptionsSetFlags(t *testing.T) {
 
 func TestSetOptionsClearFlags(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484319")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484319))
 
 	setOptions := SetOptions{
 		ClearFlags: []AccountFlag{AuthRequired, AuthRevocable},
@@ -236,7 +236,7 @@ func TestSetOptionsClearFlags(t *testing.T) {
 
 func TestSetOptionsMasterWeight(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484320")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484320))
 
 	setOptions := SetOptions{
 		MasterWeight: NewThreshold(10),
@@ -256,7 +256,7 @@ func TestSetOptionsMasterWeight(t *testing.T) {
 
 func TestSetOptionsThresholds(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484322")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484322))
 
 	setOptions := SetOptions{
 		LowThreshold:    NewThreshold(1),
@@ -278,7 +278,7 @@ func TestSetOptionsThresholds(t *testing.T) {
 
 func TestSetOptionsHomeDomain(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484325")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484325))
 
 	setOptions := SetOptions{
 		HomeDomain: NewHomeDomain("LovelyLumensLookLuminous.com"),
@@ -298,7 +298,7 @@ func TestSetOptionsHomeDomain(t *testing.T) {
 
 func TestSetOptionsHomeDomainTooLong(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484323")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484323))
 
 	setOptions := SetOptions{
 		HomeDomain: NewHomeDomain("LovelyLumensLookLuminousLately.com"),
@@ -318,7 +318,7 @@ func TestSetOptionsHomeDomainTooLong(t *testing.T) {
 func TestSetOptionsSigner(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484325")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484325))
 
 	setOptions := SetOptions{
 		Signer: &Signer{Address: kp1.Address(), Weight: Threshold(4)},
@@ -338,7 +338,7 @@ func TestSetOptionsSigner(t *testing.T) {
 
 func TestMultipleOperations(t *testing.T) {
 	kp1 := newKeypair1()
-	sourceAccount := NewSimpleAccount(kp1.Address(), "9606132444168199")
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	inflation := Inflation{}
 	bumpSequence := BumpSequence{
@@ -360,7 +360,7 @@ func TestMultipleOperations(t *testing.T) {
 func TestChangeTrust(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484348")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484348))
 
 	changeTrust := ChangeTrust{
 		Line:  CreditAsset{"ABCD", kp1.Address()},
@@ -381,7 +381,7 @@ func TestChangeTrust(t *testing.T) {
 
 func TestChangeTrustNativeAssetNotAllowed(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484348")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484348))
 
 	changeTrust := ChangeTrust{
 		Line:  NativeAsset{},
@@ -403,7 +403,7 @@ func TestChangeTrustNativeAssetNotAllowed(t *testing.T) {
 func TestChangeTrustDeleteTrustline(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484354")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484354))
 
 	issuedAsset := CreditAsset{"ABCD", kp1.Address()}
 	removeTrust := RemoveTrustlineOp(issuedAsset)
@@ -423,7 +423,7 @@ func TestChangeTrustDeleteTrustline(t *testing.T) {
 func TestAllowTrust(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := NewSimpleAccount(kp0.Address(), "40385577484366")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484366))
 
 	issuedAsset := CreditAsset{"ABCD", kp1.Address()}
 	allowTrust := AllowTrust{
@@ -447,7 +447,7 @@ func TestAllowTrust(t *testing.T) {
 func TestManageSellOfferNewOffer(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := NewSimpleAccount(kp1.Address(), "41137196761092")
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761092))
 
 	selling := NativeAsset{}
 	buying := CreditAsset{"ABCD", kp0.Address()}
@@ -470,7 +470,7 @@ func TestManageSellOfferNewOffer(t *testing.T) {
 
 func TestManageSellOfferDeleteOffer(t *testing.T) {
 	kp1 := newKeypair1()
-	sourceAccount := NewSimpleAccount(kp1.Address(), "41137196761105")
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761105))
 
 	offerID := int64(2921622)
 	deleteOffer, err := DeleteOfferOp(offerID)
@@ -491,7 +491,7 @@ func TestManageSellOfferDeleteOffer(t *testing.T) {
 func TestManageSellOfferUpdateOffer(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := NewSimpleAccount(kp1.Address(), "41137196761097")
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761097))
 
 	selling := NativeAsset{}
 	buying := CreditAsset{"ABCD", kp0.Address()}
@@ -516,7 +516,7 @@ func TestManageSellOfferUpdateOffer(t *testing.T) {
 func TestCreatePassiveSellOffer(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
-	sourceAccount := NewSimpleAccount(kp1.Address(), "41137196761100")
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761100))
 
 	createPassiveOffer := CreatePassiveSellOffer{
 		Selling: NativeAsset{},
@@ -540,7 +540,7 @@ func TestCreatePassiveSellOffer(t *testing.T) {
 func TestPathPayment(t *testing.T) {
 	kp0 := newKeypair0()
 	kp2 := newKeypair2()
-	sourceAccount := NewSimpleAccount(kp2.Address(), "187316408680450")
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(187316408680450))
 
 	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
 	pathPayment := PathPayment{
@@ -566,7 +566,7 @@ func TestPathPayment(t *testing.T) {
 
 func TestMemoText(t *testing.T) {
 	kp2 := newKeypair2()
-	sourceAccount := NewSimpleAccount(kp2.Address(), "3556099777101824")
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(3556099777101824))
 
 	tx := Transaction{
 		SourceAccount: &sourceAccount,
@@ -584,7 +584,7 @@ func TestMemoText(t *testing.T) {
 
 func TestMemoID(t *testing.T) {
 	kp2 := newKeypair2()
-	sourceAccount := NewSimpleAccount(kp2.Address(), "3428320205078528")
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(3428320205078528))
 
 	tx := Transaction{
 		SourceAccount: &sourceAccount,
@@ -601,7 +601,7 @@ func TestMemoID(t *testing.T) {
 
 func TestMemoHash(t *testing.T) {
 	kp2 := newKeypair2()
-	sourceAccount := NewSimpleAccount(kp2.Address(), "3428320205078528")
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(3428320205078528))
 
 	tx := Transaction{
 		SourceAccount: &sourceAccount,
@@ -618,7 +618,7 @@ func TestMemoHash(t *testing.T) {
 
 func TestMemoReturn(t *testing.T) {
 	kp2 := newKeypair2()
-	sourceAccount := NewSimpleAccount(kp2.Address(), "3428320205078528")
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(3428320205078528))
 
 	tx := Transaction{
 		SourceAccount: &sourceAccount,


### PR DESCRIPTION
This PR adds a `SimpleAccount` struct that implements the `Account` interface. 
The `Account` interface is also updated with a `GetSequenceNumber` method.
`NewSimpleAccount` is a factory method for creating `SimpleAccount` it replaces `makeTestAccount` in all the tests. 
This PR closes #1266 