### PR TITLE
clients/horizonclient: support goroutines

### DIFF
--- a/clients/horizonclient/internal.go
+++ b/clients/horizonclient/internal.go
@@ -115,7 +115,9 @@ func setCurrentServerTime(host string, serverDate []string) {
 	if err != nil {
 		return
 	}
+	serverTimeMapMutex.Lock()
 	ServerTimeMap[host] = ServerTimeRecord{ServerTime: st.UTC().Unix(), LocalTimeRecorded: time.Now().UTC().Unix()}
+	serverTimeMapMutex.Unlock()
 }
 
 // currentServerTime returns the current server time for a given horizon server

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
@@ -342,3 +343,4 @@ type ServerTimeRecord struct {
 
 // ServerTimeMap holds the ServerTimeRecord for different horizon instances.
 var ServerTimeMap = make(map[string]ServerTimeRecord)
+var serverTimeMapMutex = &sync.Mutex{}


### PR DESCRIPTION
This PR makes the new Horizon client goroutine compatible. It (un)locks around access to the `ServerTimeMap`; concurrent access to this shared resource resulted in an error documented in #1254 . Accordingly, this PR closes that issue.