### PR TITLE
horizonclient: assets next and prev methods

### DIFF
--- a/clients/horizonclient/asset_request_test.go
+++ b/clients/horizonclient/asset_request_test.go
@@ -1,6 +1,7 @@
 package horizonclient
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,4 +29,62 @@ func TestAssetRequestBuildUrl(t *testing.T) {
 	// It should return valid assets endpoint and no errors
 	require.NoError(t, err)
 	assert.Equal(t, "assets?asset_code=ABC&asset_issuer=GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU&order=desc", endpoint)
+}
+
+func ExampleClient_NextAssetsPage() {
+	client := DefaultPublicNetClient
+	// assets for asset issuer
+	assetRequest := AssetRequest{ForAssetIssuer: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+		Limit: 20}
+	asset, err := client.Assets(assetRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(asset)
+
+	// all assets
+	assetRequest = AssetRequest{}
+	asset, err = client.Assets(assetRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// next page
+	nextPage, err := client.NextAssetsPage(asset)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(nextPage)
+}
+
+func ExampleClient_PrevAssetsPage() {
+	client := DefaultPublicNetClient
+	// assets for asset issuer
+	assetRequest := AssetRequest{ForAssetIssuer: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+		Limit: 20}
+	asset, err := client.Assets(assetRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(asset)
+
+	// all assets
+	assetRequest = AssetRequest{}
+	asset, err = client.Assets(assetRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// next page
+	prevPage, err := client.PrevAssetsPage(asset)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(prevPage)
 }

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -527,5 +527,17 @@ func (c *Client) Version() string {
 	return version
 }
 
+// NextAssetsPage returns the next page of assets
+func (c *Client) NextAssetsPage(page hProtocol.AssetsPage) (assets hProtocol.AssetsPage, err error) {
+	err = c.sendRequestURL(page.Links.Next.Href, "get", &assets)
+	return
+}
+
+// PrevAssetsPage returns the previous page of assets
+func (c *Client) PrevAssetsPage(page hProtocol.AssetsPage) (assets hProtocol.AssetsPage, err error) {
+	err = c.sendRequestURL(page.Links.Prev.Href, "get", &assets)
+	return
+}
+
 // ensure that the horizon client implements ClientInterface
 var _ ClientInterface = &Client{}

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -159,6 +159,8 @@ type ClientInterface interface {
 	StreamLedgers(ctx context.Context, request LedgerRequest, handler LedgerHandler) error
 	StreamOrderBooks(ctx context.Context, request OrderBookRequest, handler OrderBookHandler) error
 	Root() (hProtocol.Root, error)
+	NextAssetsPage(hProtocol.AssetsPage) (hProtocol.AssetsPage, error)
+	PrevAssetsPage(hProtocol.AssetsPage) (hProtocol.AssetsPage, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network.

--- a/clients/horizonclient/mocks.go
+++ b/clients/horizonclient/mocks.go
@@ -187,5 +187,17 @@ func (m *MockClient) Root() (hProtocol.Root, error) {
 	return a.Get(0).(hProtocol.Root), a.Error(1)
 }
 
+// NextAssetsPage is a mocking method
+func (m *MockClient) NextAssetsPage(page hProtocol.AssetsPage) (hProtocol.AssetsPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(hProtocol.AssetsPage), a.Error(1)
+}
+
+// PrevAssetsPage is a mocking method
+func (m *MockClient) PrevAssetsPage(page hProtocol.AssetsPage) (hProtocol.AssetsPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(hProtocol.AssetsPage), a.Error(1)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}


### PR DESCRIPTION
This is the first set of PRs to add methods to get the previous and next pages of a response from horizon. 
This PR implements this method for the assets page. Other pages will be implemented as listed in #985 