### PR TITLE
horizonclient: next and prev methods

### DIFF
--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -539,5 +539,17 @@ func (c *Client) PrevAssetsPage(page hProtocol.AssetsPage) (assets hProtocol.Ass
 	return
 }
 
+// NextLedgersPage returns the next page of assets
+func (c *Client) NextLedgersPage(page hProtocol.LedgersPage) (ledgers hProtocol.LedgersPage, err error) {
+	err = c.sendRequestURL(page.Links.Next.Href, "get", &ledgers)
+	return
+}
+
+// PrevLedgersPage returns the previous page of assets
+func (c *Client) PrevLedgersPage(page hProtocol.LedgersPage) (ledgers hProtocol.LedgersPage, err error) {
+	err = c.sendRequestURL(page.Links.Prev.Href, "get", &ledgers)
+	return
+}
+
 // ensure that the horizon client implements ClientInterface
 var _ ClientInterface = &Client{}

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -539,15 +539,27 @@ func (c *Client) PrevAssetsPage(page hProtocol.AssetsPage) (assets hProtocol.Ass
 	return
 }
 
-// NextLedgersPage returns the next page of assets
+// NextLedgersPage returns the next page of ledgers
 func (c *Client) NextLedgersPage(page hProtocol.LedgersPage) (ledgers hProtocol.LedgersPage, err error) {
 	err = c.sendRequestURL(page.Links.Next.Href, "get", &ledgers)
 	return
 }
 
-// PrevLedgersPage returns the previous page of assets
+// PrevLedgersPage returns the previous page of ledgers
 func (c *Client) PrevLedgersPage(page hProtocol.LedgersPage) (ledgers hProtocol.LedgersPage, err error) {
 	err = c.sendRequestURL(page.Links.Prev.Href, "get", &ledgers)
+	return
+}
+
+// NextEffectsPage returns the next page of effects
+func (c *Client) NextEffectsPage(page effects.EffectsPage) (efp effects.EffectsPage, err error) {
+	err = c.sendRequestURL(page.Links.Next.Href, "get", &efp)
+	return
+}
+
+// PrevEffectsPage returns the previous page of effects
+func (c *Client) PrevEffectsPage(page effects.EffectsPage) (efp effects.EffectsPage, err error) {
+	err = c.sendRequestURL(page.Links.Prev.Href, "get", &efp)
 	return
 }
 

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -527,37 +527,37 @@ func (c *Client) Version() string {
 	return version
 }
 
-// NextAssetsPage returns the next page of assets
+// NextAssetsPage returns the next page of assets.
 func (c *Client) NextAssetsPage(page hProtocol.AssetsPage) (assets hProtocol.AssetsPage, err error) {
 	err = c.sendRequestURL(page.Links.Next.Href, "get", &assets)
 	return
 }
 
-// PrevAssetsPage returns the previous page of assets
+// PrevAssetsPage returns the previous page of assets.
 func (c *Client) PrevAssetsPage(page hProtocol.AssetsPage) (assets hProtocol.AssetsPage, err error) {
 	err = c.sendRequestURL(page.Links.Prev.Href, "get", &assets)
 	return
 }
 
-// NextLedgersPage returns the next page of ledgers
+// NextLedgersPage returns the next page of ledgers.
 func (c *Client) NextLedgersPage(page hProtocol.LedgersPage) (ledgers hProtocol.LedgersPage, err error) {
 	err = c.sendRequestURL(page.Links.Next.Href, "get", &ledgers)
 	return
 }
 
-// PrevLedgersPage returns the previous page of ledgers
+// PrevLedgersPage returns the previous page of ledgers.
 func (c *Client) PrevLedgersPage(page hProtocol.LedgersPage) (ledgers hProtocol.LedgersPage, err error) {
 	err = c.sendRequestURL(page.Links.Prev.Href, "get", &ledgers)
 	return
 }
 
-// NextEffectsPage returns the next page of effects
+// NextEffectsPage returns the next page of effects.
 func (c *Client) NextEffectsPage(page effects.EffectsPage) (efp effects.EffectsPage, err error) {
 	err = c.sendRequestURL(page.Links.Next.Href, "get", &efp)
 	return
 }
 
-// PrevEffectsPage returns the previous page of effects
+// PrevEffectsPage returns the previous page of effects.
 func (c *Client) PrevEffectsPage(page effects.EffectsPage) (efp effects.EffectsPage, err error) {
 	err = c.sendRequestURL(page.Links.Prev.Href, "get", &efp)
 	return

--- a/clients/horizonclient/effect_request_test.go
+++ b/clients/horizonclient/effect_request_test.go
@@ -64,6 +64,45 @@ func TestEffectRequestBuildUrl(t *testing.T) {
 
 }
 
+func ExampleClient_NextEffectsPage() {
+	client := DefaultPublicNetClient
+	// all effects
+	effectRequest := EffectRequest{Limit: 20}
+	efp, err := client.Effects(effectRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(efp)
+
+	// next page
+	nextPage, err := client.NextEffectsPage(efp)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(nextPage)
+}
+
+func ExampleClient_PrevEffectsPage() {
+	client := DefaultPublicNetClient
+	// all effects
+	effectRequest := EffectRequest{Limit: 20}
+	efp, err := client.Effects(effectRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(efp)
+
+	// prev page
+	prevPage, err := client.PrevEffectsPage(efp)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(prevPage)
+}
 func ExampleClient_StreamEffects() {
 	client := DefaultTestNetClient
 	// all effects

--- a/clients/horizonclient/effect_request_test.go
+++ b/clients/horizonclient/effect_request_test.go
@@ -75,13 +75,27 @@ func ExampleClient_NextEffectsPage() {
 	}
 	fmt.Print(efp)
 
-	// next page
-	nextPage, err := client.NextEffectsPage(efp)
-	if err != nil {
-		fmt.Println(err)
-		return
+	// get next pages.
+	recordsFound := false
+	if len(efp.Embedded.Records) > 0 {
+		recordsFound = true
 	}
-	fmt.Println(nextPage)
+	page := efp
+	// get the next page of records if recordsFound is true
+	for recordsFound {
+		// next page
+		nextPage, err := client.NextEffectsPage(page)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		page = nextPage
+		if len(nextPage.Embedded.Records) == 0 {
+			recordsFound = false
+		}
+		fmt.Println(nextPage)
+	}
 }
 
 func ExampleClient_PrevEffectsPage() {
@@ -95,13 +109,27 @@ func ExampleClient_PrevEffectsPage() {
 	}
 	fmt.Print(efp)
 
-	// prev page
-	prevPage, err := client.PrevEffectsPage(efp)
-	if err != nil {
-		fmt.Println(err)
-		return
+	// get prev pages.
+	recordsFound := false
+	if len(efp.Embedded.Records) > 0 {
+		recordsFound = true
 	}
-	fmt.Println(prevPage)
+	page := efp
+	// get the prev page of records if recordsFound is true
+	for recordsFound {
+		// prev page
+		prevPage, err := client.PrevEffectsPage(page)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		page = prevPage
+		if len(prevPage.Embedded.Records) == 0 {
+			recordsFound = false
+		}
+		fmt.Println(prevPage)
+	}
 }
 func ExampleClient_StreamEffects() {
 	client := DefaultTestNetClient
@@ -186,5 +214,114 @@ func TestEffectRequestStreamEffects(t *testing.T) {
 	}
 }
 
+func TestNextEffectsPage(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	// Account effects
+	effectRequest := EffectRequest{ForAccount: "GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD"}
+
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects",
+	).ReturnString(200, firstEffectsPage)
+
+	efp, err := client.Effects(effectRequest)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, len(efp.Embedded.Records), 2)
+	}
+
+	hmock.On(
+		"GET",
+		"https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=1557363731492865-3&limit=10&order=asc",
+	).ReturnString(200, emptyEffectsPage)
+
+	nextPage, err := client.NextEffectsPage(efp)
+	if assert.NoError(t, err) {
+		assert.Equal(t, len(nextPage.Embedded.Records), 0)
+	}
+}
+
 var effectStreamResponse = `data: {"_links":{"operation":{"href":"https://horizon-testnet.stellar.org/operations/2531135896703017"},"succeeds":{"href":"https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=2531135896703017-1"},"precedes":{"href":"https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=2531135896703017-1"}},"id":"0002531135896703017-0000000001","paging_token":"2531135896703017-1","account":"GBNZN27NAOHRJRCMHQF2ZN2F6TAPVEWKJIGZIRNKIADWIS2HDENIS6CI","type":"account_credited","type_i":2,"created_at":"2019-04-03T10:14:17Z","asset_type":"credit_alphanum4","asset_code":"qwop","asset_issuer":"GBM4HXXNDBWWQBXOL4QCTZIUQAP6XFUI3FPINUGUPBMULMTEHJPIKX6T","amount":"0.0460000"}
 `
+
+var firstEffectsPage = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=&limit=10&order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=1557363731492865-3&limit=10&order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=1557363731492865-1&limit=10&order=desc"
+    }
+  },
+  "_embedded": {
+    "records": [
+      {
+        "_links": {
+          "operation": {
+            "href": "https://horizon-testnet.stellar.org/operations/1557363731492865"
+          },
+          "succeeds": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc&cursor=1557363731492865-1"
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc&cursor=1557363731492865-1"
+          }
+        },
+        "id": "0001557363731492865-0000000001",
+        "paging_token": "1557363731492865-1",
+        "account": "GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD",
+        "type": "account_created",
+        "type_i": 0,
+        "created_at": "2019-05-16T07:13:25Z",
+        "starting_balance": "10000.0000000"
+      },
+      {
+        "_links": {
+          "operation": {
+            "href": "https://horizon-testnet.stellar.org/operations/1557363731492865"
+          },
+          "succeeds": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc&cursor=1557363731492865-3"
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc&cursor=1557363731492865-3"
+          }
+        },
+        "id": "0001557363731492865-0000000003",
+        "paging_token": "1557363731492865-3",
+        "account": "GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD",
+        "type": "signer_created",
+        "type_i": 10,
+        "created_at": "2019-05-16T07:13:25Z",
+        "weight": 1,
+        "public_key": "GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD",
+        "key": ""
+      }
+    ]
+  }
+}`
+
+var emptyEffectsPage = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=1557363731492865-3&limit=10&order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=1557363731492865-3&limit=10&order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=1557363731492865-3&limit=10&order=desc"
+    }
+  },
+  "_embedded": {
+    "records": []
+  }
+}`

--- a/clients/horizonclient/ledger_request_test.go
+++ b/clients/horizonclient/ledger_request_test.go
@@ -42,6 +42,46 @@ func TestLedgerRequestBuildUrl(t *testing.T) {
 	assert.Equal(t, "ledgers?cursor=now&order=desc", endpoint)
 }
 
+func ExampleClient_NextLedgersPage() {
+	client := DefaultPublicNetClient
+	// all ledgers
+	ledgerRequest := LedgerRequest{Limit: 20}
+	ledger, err := client.Ledgers(ledgerRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(ledger)
+
+	// next page
+	nextPage, err := client.NextLedgersPage(ledger)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(nextPage)
+}
+
+func ExampleClient_PrevLedgersPage() {
+	client := DefaultPublicNetClient
+	// all ledgers
+	ledgerRequest := LedgerRequest{Limit: 20}
+	ledger, err := client.Ledgers(ledgerRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(ledger)
+
+	// prev page
+	prevPage, err := client.PrevLedgersPage(ledger)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(prevPage)
+}
+
 func TestLedgerDetail(t *testing.T) {
 	hmock := httptest.NewClient()
 	client := &Client{
@@ -171,7 +211,6 @@ func TestLedgerRequestStreamLedgers(t *testing.T) {
 		assert.Contains(t, err.Error(), "got bad HTTP status code 500")
 
 	}
-
 }
 
 var ledgerStreamResponse = `data: {"_links":{"self":{"href":"https://horizon-testnet.stellar.org/ledgers/560339"},"transactions":{"href":"https://horizon-testnet.stellar.org/ledgers/560339/transactions{?cursor,limit,order}","templated":true},"operations":{"href":"https://horizon-testnet.stellar.org/ledgers/560339/operations{?cursor,limit,order}","templated":true},"payments":{"href":"https://horizon-testnet.stellar.org/ledgers/560339/payments{?cursor,limit,order}","templated":true},"effects":{"href":"https://horizon-testnet.stellar.org/ledgers/560339/effects{?cursor,limit,order}","templated":true}},"id":"66f4d95dab22dbc422585cc4b011716014e81df3599cee8db9c776cfc3a31e93","paging_token":"2406637679673344","hash":"66f4d95dab22dbc422585cc4b011716014e81df3599cee8db9c776cfc3a31e93","prev_hash":"6071f1e52a6bf37aba3f7437081577eafe69f78593c465fc5028c46a4746dda3","sequence":560339,"successful_transaction_count":5,"failed_transaction_count":1,"operation_count":44,"closed_at":"2019-04-01T16:47:05Z","total_coins":"100057227213.0436903","fee_pool":"57227816.6766542","base_fee_in_stroops":100,"base_reserve_in_stroops":5000000,"max_tx_set_size":100,"protocol_version":10,"header_xdr":"AAAACmBx8eUqa/N6uj90NwgVd+r+afeFk8Rl/FAoxGpHRt2jdIn+3X+/O3PFUUZ8Tgy4rfD1oNamR+9NMOCM2V6ndksAAAAAXKJAiQAAAAAAAAAAPyIIYU6Y37lve/MwZls1vmbgxgFdx93hdzOn6g8kHhQ1BS9aAKuXtApQoE3gKpjQ5ze0H9qUruyOUsbM776zXQAIjNMN4r8uJHCvJwACCHvk18POAAAAAwAAAAAAQZnVAAAAZABMS0AAAABkkiIcXkjaTtc9zTQBn0o72CUBe3u+2Mz7W6dgkvkYcJJle8JCNmXx5HcRlDSHJzzBShc8C3rQUIsIuJ93eoBMgHeYAzfholE8hjvrHrqoHq8jfPowxj1FGD6HaUPD1PHTcBXmf0U0cs2Ki0NBDDKNcwKC84nUPdumCkdAxSuEzn4AAAAA"}

--- a/clients/horizonclient/ledger_request_test.go
+++ b/clients/horizonclient/ledger_request_test.go
@@ -46,40 +46,68 @@ func ExampleClient_NextLedgersPage() {
 	client := DefaultPublicNetClient
 	// all ledgers
 	ledgerRequest := LedgerRequest{Limit: 20}
-	ledger, err := client.Ledgers(ledgerRequest)
+	ledgers, err := client.Ledgers(ledgerRequest)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	fmt.Print(ledger)
+	fmt.Print(ledgers)
 
-	// next page
-	nextPage, err := client.NextLedgersPage(ledger)
-	if err != nil {
-		fmt.Println(err)
-		return
+	// get next pages.
+	recordsFound := false
+	if len(ledgers.Embedded.Records) > 0 {
+		recordsFound = true
 	}
-	fmt.Println(nextPage)
+	page := ledgers
+	// get the next page of records if recordsFound is true
+	for recordsFound {
+		// next page
+		nextPage, err := client.NextLedgersPage(page)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		page = nextPage
+		if len(nextPage.Embedded.Records) == 0 {
+			recordsFound = false
+		}
+		fmt.Println(nextPage)
+	}
 }
 
 func ExampleClient_PrevLedgersPage() {
 	client := DefaultPublicNetClient
 	// all ledgers
 	ledgerRequest := LedgerRequest{Limit: 20}
-	ledger, err := client.Ledgers(ledgerRequest)
+	ledgers, err := client.Ledgers(ledgerRequest)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	fmt.Print(ledger)
+	fmt.Print(ledgers)
 
-	// prev page
-	prevPage, err := client.PrevLedgersPage(ledger)
-	if err != nil {
-		fmt.Println(err)
-		return
+	// get prev pages.
+	recordsFound := false
+	if len(ledgers.Embedded.Records) > 0 {
+		recordsFound = true
 	}
-	fmt.Println(prevPage)
+	page := ledgers
+	// get the prev page of records if recordsFound is true
+	for recordsFound {
+		// prev page
+		prevPage, err := client.PrevLedgersPage(page)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		page = prevPage
+		if len(prevPage.Embedded.Records) == 0 {
+			recordsFound = false
+		}
+		fmt.Println(prevPage)
+	}
 }
 
 func TestLedgerDetail(t *testing.T) {
@@ -213,5 +241,149 @@ func TestLedgerRequestStreamLedgers(t *testing.T) {
 	}
 }
 
+func TestNextLedgersPage(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	ledgerRequest := LedgerRequest{Limit: 2}
+
+	hmock.On(
+		"GET",
+		"https://localhost/ledgers?limit=2",
+	).ReturnString(200, firstLedgersPage)
+
+	ledgers, err := client.Ledgers(ledgerRequest)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, len(ledgers.Embedded.Records), 2)
+	}
+
+	hmock.On(
+		"GET",
+		"https://horizon-testnet.stellar.org/ledgers?cursor=1559012998905856&limit=2&order=desc",
+	).ReturnString(200, emptyLedgersPage)
+
+	nextPage, err := client.NextLedgersPage(ledgers)
+	if assert.NoError(t, err) {
+		assert.Equal(t, len(nextPage.Embedded.Records), 0)
+	}
+}
+
 var ledgerStreamResponse = `data: {"_links":{"self":{"href":"https://horizon-testnet.stellar.org/ledgers/560339"},"transactions":{"href":"https://horizon-testnet.stellar.org/ledgers/560339/transactions{?cursor,limit,order}","templated":true},"operations":{"href":"https://horizon-testnet.stellar.org/ledgers/560339/operations{?cursor,limit,order}","templated":true},"payments":{"href":"https://horizon-testnet.stellar.org/ledgers/560339/payments{?cursor,limit,order}","templated":true},"effects":{"href":"https://horizon-testnet.stellar.org/ledgers/560339/effects{?cursor,limit,order}","templated":true}},"id":"66f4d95dab22dbc422585cc4b011716014e81df3599cee8db9c776cfc3a31e93","paging_token":"2406637679673344","hash":"66f4d95dab22dbc422585cc4b011716014e81df3599cee8db9c776cfc3a31e93","prev_hash":"6071f1e52a6bf37aba3f7437081577eafe69f78593c465fc5028c46a4746dda3","sequence":560339,"successful_transaction_count":5,"failed_transaction_count":1,"operation_count":44,"closed_at":"2019-04-01T16:47:05Z","total_coins":"100057227213.0436903","fee_pool":"57227816.6766542","base_fee_in_stroops":100,"base_reserve_in_stroops":5000000,"max_tx_set_size":100,"protocol_version":10,"header_xdr":"AAAACmBx8eUqa/N6uj90NwgVd+r+afeFk8Rl/FAoxGpHRt2jdIn+3X+/O3PFUUZ8Tgy4rfD1oNamR+9NMOCM2V6ndksAAAAAXKJAiQAAAAAAAAAAPyIIYU6Y37lve/MwZls1vmbgxgFdx93hdzOn6g8kHhQ1BS9aAKuXtApQoE3gKpjQ5ze0H9qUruyOUsbM776zXQAIjNMN4r8uJHCvJwACCHvk18POAAAAAwAAAAAAQZnVAAAAZABMS0AAAABkkiIcXkjaTtc9zTQBn0o72CUBe3u+2Mz7W6dgkvkYcJJle8JCNmXx5HcRlDSHJzzBShc8C3rQUIsIuJ93eoBMgHeYAzfholE8hjvrHrqoHq8jfPowxj1FGD6HaUPD1PHTcBXmf0U0cs2Ki0NBDDKNcwKC84nUPdumCkdAxSuEzn4AAAAA"}
 `
+
+var firstLedgersPage = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/ledgers?cursor=1559021588840447&limit=2&order=desc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/ledgers?cursor=1559012998905856&limit=2&order=desc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/ledgers?cursor=1559017293873152&limit=2&order=asc"
+    }
+  },
+  "_embedded": {
+    "records": [
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/362987"
+          },
+          "transactions": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/362987/transactions{?cursor,limit,order}",
+            "templated": true
+          },
+          "operations": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/362987/operations{?cursor,limit,order}",
+            "templated": true
+          },
+          "payments": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/362987/payments{?cursor,limit,order}",
+            "templated": true
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/362987/effects{?cursor,limit,order}",
+            "templated": true
+          }
+        },
+        "id": "e346ec9065a61c311e012989ac8368a14438cf716246045227b9133a9f7b527c",
+        "paging_token": "1559017293873152",
+        "hash": "e346ec9065a61c311e012989ac8368a14438cf716246045227b9133a9f7b527c",
+        "prev_hash": "018bf9ac8ee44d57982ca154b27056a9e0dbab85c074d5af696265876a539c95",
+        "sequence": 362987,
+        "successful_transaction_count": 5,
+        "failed_transaction_count": 0,
+        "operation_count": 102,
+        "closed_at": "2019-05-16T07:48:28Z",
+        "total_coins": "100286463748.0798442",
+        "fee_pool": "286463903.1537236",
+        "base_fee_in_stroops": 100,
+        "base_reserve_in_stroops": 5000000,
+        "max_tx_set_size": 150,
+        "protocol_version": 11,
+        "header_xdr": "AAAACwGL+ayO5E1XmCyhVLJwVqng26uFwHTVr2liZYdqU5yVfaWG9R/+ORte/mnEN9e19MjAXhEYCkpE55NUbhoTvQIAAAAAXN0VzAAAAAAAAAAAM+Y77/jsRfTQJd4Rc77eAxLFqf51z1hkL+lAmXdque/KKHfTioV3SodQAb9sTonc3y2WbQ+3SHIpzafWzw5ofAAFiesN6uQTCtgI6gAKLV+/4m5UAAAADwAAAAAAQdNFAAAAZABMS0AAAACWxYbq8s16ytvhOI1WVPxU7sZf8hLAl3EcsegF9EH/6uL1KqOTvsbW9+L7KRHuAFSBaOAkfdNlxX+010AN80K7r+TXs0UcgvyyUvvA0BuNTik2ZGi6lBdt9kg11m7anDbLAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/362986"
+          },
+          "transactions": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/362986/transactions{?cursor,limit,order}",
+            "templated": true
+          },
+          "operations": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/362986/operations{?cursor,limit,order}",
+            "templated": true
+          },
+          "payments": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/362986/payments{?cursor,limit,order}",
+            "templated": true
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/362986/effects{?cursor,limit,order}",
+            "templated": true
+          }
+        },
+        "id": "018bf9ac8ee44d57982ca154b27056a9e0dbab85c074d5af696265876a539c95",
+        "paging_token": "1559012998905856",
+        "hash": "018bf9ac8ee44d57982ca154b27056a9e0dbab85c074d5af696265876a539c95",
+        "prev_hash": "e96448c838514bbf08d9a198d1d589f3d396aa57d85c85a170ac7b9c965fc102",
+        "sequence": 362986,
+        "successful_transaction_count": 2,
+        "failed_transaction_count": 1,
+        "operation_count": 21,
+        "closed_at": "2019-05-16T07:48:21Z",
+        "total_coins": "100286463748.0798442",
+        "fee_pool": "286463903.1527036",
+        "base_fee_in_stroops": 100,
+        "base_reserve_in_stroops": 5000000,
+        "max_tx_set_size": 150,
+        "protocol_version": 11,
+        "header_xdr": "AAAAC+lkSMg4UUu/CNmhmNHVifPTlqpX2FyFoXCse5yWX8ECCX4L/N934EuR74itfcXN38l7B/bfVKdjCE/RstuR6icAAAAAXN0VxQAAAAAAAAAAl4WBEEVHCpGjWQy8VWnCezcSbSgGi3rHCdppElGC9Rzs7mcFl393ae4zKfU586pM5divzZ1PgHW2yGNx2/uXMwAFieoN6uQTCtgI6gAKLV+/4kZ8AAAADwAAAAAAQdMVAAAAZABMS0AAAACWxYbq8s16ytvhOI1WVPxU7sZf8hLAl3EcsegF9EH/6uL1KqOTvsbW9+L7KRHuAFSBaOAkfdNlxX+010AN80K7r+TXs0UcgvyyUvvA0BuNTik2ZGi6lBdt9kg11m7anDbLAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      }
+    ]
+  }
+}`
+
+var emptyLedgersPage = `{
+ "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/ledgers?cursor=1559012998905856&limit=2&order=desc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/ledgers?cursor=1559004408971264&limit=2&order=desc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/ledgers?cursor=1559008703938560&limit=2&order=asc"
+    }
+  },
+  "_embedded": {
+    "records": []
+  }
+}`

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -163,6 +163,8 @@ type ClientInterface interface {
 	PrevAssetsPage(hProtocol.AssetsPage) (hProtocol.AssetsPage, error)
 	NextLedgersPage(hProtocol.LedgersPage) (hProtocol.LedgersPage, error)
 	PrevLedgersPage(hProtocol.LedgersPage) (hProtocol.LedgersPage, error)
+	NextEffectsPage(effects.EffectsPage) (effects.EffectsPage, error)
+	PrevEffectsPage(effects.EffectsPage) (effects.EffectsPage, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network.

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -161,6 +161,8 @@ type ClientInterface interface {
 	Root() (hProtocol.Root, error)
 	NextAssetsPage(hProtocol.AssetsPage) (hProtocol.AssetsPage, error)
 	PrevAssetsPage(hProtocol.AssetsPage) (hProtocol.AssetsPage, error)
+	NextLedgersPage(hProtocol.LedgersPage) (hProtocol.LedgersPage, error)
+	PrevLedgersPage(hProtocol.LedgersPage) (hProtocol.LedgersPage, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network.

--- a/clients/horizonclient/mocks.go
+++ b/clients/horizonclient/mocks.go
@@ -211,5 +211,17 @@ func (m *MockClient) PrevLedgersPage(page hProtocol.LedgersPage) (hProtocol.Ledg
 	return a.Get(0).(hProtocol.LedgersPage), a.Error(1)
 }
 
+// NextEffectsPage is a mocking method
+func (m *MockClient) NextEffectsPage(page effects.EffectsPage) (effects.EffectsPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(effects.EffectsPage), a.Error(1)
+}
+
+// PrevEffectsPage is a mocking method
+func (m *MockClient) PrevEffectsPage(page effects.EffectsPage) (effects.EffectsPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(effects.EffectsPage), a.Error(1)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}

--- a/clients/horizonclient/mocks.go
+++ b/clients/horizonclient/mocks.go
@@ -199,5 +199,17 @@ func (m *MockClient) PrevAssetsPage(page hProtocol.AssetsPage) (hProtocol.Assets
 	return a.Get(0).(hProtocol.AssetsPage), a.Error(1)
 }
 
+// NextLedgersPage is a mocking method
+func (m *MockClient) NextLedgersPage(page hProtocol.LedgersPage) (hProtocol.LedgersPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(hProtocol.LedgersPage), a.Error(1)
+}
+
+// PrevLedgersPage is a mocking method
+func (m *MockClient) PrevLedgersPage(page hProtocol.LedgersPage) (hProtocol.LedgersPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(hProtocol.LedgersPage), a.Error(1)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}


### PR DESCRIPTION
This is part of a set of PRs to add methods to get the previous and next pages of a response from horizon.
This PR implements these methods for the ledgers and effects page. 
Other pages will be implemented as listed in #985