### PR TITLE
docs: Update order of SDK's to reflect docs sidebar.

### DIFF
--- a/services/horizon/internal/docs/readme.md
+++ b/services/horizon/internal/docs/readme.md
@@ -12,7 +12,7 @@ SDF runs a instance of Horizon that is connected to the test net [https://horizo
 
 SDF maintained libraries:<br />
 - [JavaScript](https://github.com/stellar/js-stellar-sdk)
-- [Go](https://github.com/stellar/go/tree/master/clients)
+- [Go](https://github.com/stellar/go/tree/master/clients/horizonclient)
 - [Java](https://github.com/stellar/java-stellar-sdk)
 
 Community maintained libraries (in various states of completeness) for interacting with Horizon in other languages:<br>

--- a/services/horizon/internal/docs/readme.md
+++ b/services/horizon/internal/docs/readme.md
@@ -12,12 +12,13 @@ SDF runs a instance of Horizon that is connected to the test net [https://horizo
 
 SDF maintained libraries:<br />
 - [JavaScript](https://github.com/stellar/js-stellar-sdk)
+- [Go](https://github.com/stellar/go/tree/master/clients)
 - [Java](https://github.com/stellar/java-stellar-sdk)
-- [Go](https://github.com/stellar/go)
 
 Community maintained libraries (in various states of completeness) for interacting with Horizon in other languages:<br>
-- [Ruby](https://github.com/stellar/ruby-stellar-sdk)
 - [Python](https://github.com/StellarCN/py-stellar-base)
-- [C# .NET 2.0](https://github.com/QuantozTechnology/csharp-stellar-base)
 - [C# .NET Core 2.x](https://github.com/elucidsoft/dotnetcore-stellar-sdk)
-- [C++](https://bitbucket.org/bnogal/stellarqore/wiki/Home)
+- [Ruby](https://github.com/bloom-solutions/ruby-stellar-sdk)
+- [iOS and macOS](https://github.com/Soneso/stellar-ios-mac-sdk)
+- [Scala SDK](https://github.com/synesso/scala-stellar-sdk)
+- [C++ SDK](https://github.com/bnogalm/StellarQtSDK)

--- a/services/horizon/internal/docs/reference/readme.md
+++ b/services/horizon/internal/docs/reference/readme.md
@@ -16,10 +16,13 @@ SDF runs a instance of Horizon that is connected to the test net: [https://horiz
 
 SDF maintained libraries:<br />
 - [JavaScript](https://github.com/stellar/js-stellar-sdk)
+- [Go](https://github.com/stellar/go/tree/master/clients)
 - [Java](https://github.com/stellar/java-stellar-sdk)
-- [Go](https://github.com/stellar/go)
 
 Community maintained libraries (in various states of completeness) for interacting with Horizon in other languages:<br>
-- [Ruby](https://github.com/stellar/ruby-stellar-sdk)
 - [Python](https://github.com/StellarCN/py-stellar-base)
-- [C#](https://github.com/elucidsoft/dotnet-stellar-sdk)
+- [C# .NET Core 2.x](https://github.com/elucidsoft/dotnetcore-stellar-sdk)
+- [Ruby](https://github.com/bloom-solutions/ruby-stellar-sdk)
+- [iOS and macOS](https://github.com/Soneso/stellar-ios-mac-sdk)
+- [Scala SDK](https://github.com/synesso/scala-stellar-sdk)
+- [C++ SDK](https://github.com/bnogalm/StellarQtSDK)

--- a/services/horizon/internal/docs/reference/readme.md
+++ b/services/horizon/internal/docs/reference/readme.md
@@ -16,7 +16,7 @@ SDF runs a instance of Horizon that is connected to the test net: [https://horiz
 
 SDF maintained libraries:<br />
 - [JavaScript](https://github.com/stellar/js-stellar-sdk)
-- [Go](https://github.com/stellar/go/tree/master/clients)
+- [Go](https://github.com/stellar/go/tree/master/clients/horizonclient)
 - [Java](https://github.com/stellar/java-stellar-sdk)
 
 Community maintained libraries (in various states of completeness) for interacting with Horizon in other languages:<br>


### PR DESCRIPTION
If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description.

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.

## Summary

### Goal and scope

Updated the order of the SDK's for Horizon's docs to match the sidebar ordering on the docs site. I was tempted to remove them, but I figured it would be good for these links to exist in the go repository themselves — could be convinced out of this rather easily though, I don't have strong opinions. It does create a decent amount of duplication when changing these links across multiple repos.
