### PR TITLE
clients/horizonclient: fix server time storage

### DIFF
--- a/clients/horizonclient/internal.go
+++ b/clients/horizonclient/internal.go
@@ -122,7 +122,9 @@ func setCurrentServerTime(host string, serverDate []string) {
 
 // currentServerTime returns the current server time for a given horizon server
 func currentServerTime(host string) int64 {
+	serverTimeMapMutex.Lock()
 	st := ServerTimeMap[host]
+	serverTimeMapMutex.Unlock()
 	if &st == nil {
 		return 0
 	}

--- a/clients/horizonclient/internal.go
+++ b/clients/horizonclient/internal.go
@@ -111,6 +111,9 @@ func addQueryParams(params ...interface{}) string {
 
 // setCurrentServerTime saves the current time returned by a horizon server
 func setCurrentServerTime(host string, serverDate []string) {
+	if len(serverDate) == 0 {
+		return
+	}
 	st, err := time.Parse(time.RFC1123, serverDate[0])
 	if err != nil {
 		return


### PR DESCRIPTION
This PR adds two small fixes to the storage of Horizon server times in the shared server time map.
1) It follows #1276 by locking when getting from the map.
2) It checks for an empty server date when setting in the map.