### PR TITLE
horizonclient: trades and offers next/prev methods

### DIFF
--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -563,5 +563,29 @@ func (c *Client) PrevEffectsPage(page effects.EffectsPage) (efp effects.EffectsP
 	return
 }
 
+// NextOffersPage returns the next page of offers.
+func (c *Client) NextOffersPage(page hProtocol.OffersPage) (offers hProtocol.OffersPage, err error) {
+	err = c.sendRequestURL(page.Links.Next.Href, "get", &offers)
+	return
+}
+
+// PrevOffersPage returns the previous page of offers.
+func (c *Client) PrevOffersPage(page hProtocol.OffersPage) (offers hProtocol.OffersPage, err error) {
+	err = c.sendRequestURL(page.Links.Prev.Href, "get", &offers)
+	return
+}
+
+// NextTradesPage returns the next page of trades.
+func (c *Client) NextTradesPage(page hProtocol.TradesPage) (trades hProtocol.TradesPage, err error) {
+	err = c.sendRequestURL(page.Links.Next.Href, "get", &trades)
+	return
+}
+
+// PrevTradesPage returns the previous page of trades.
+func (c *Client) PrevTradesPage(page hProtocol.TradesPage) (trades hProtocol.TradesPage, err error) {
+	err = c.sendRequestURL(page.Links.Prev.Href, "get", &trades)
+	return
+}
+
 // ensure that the horizon client implements ClientInterface
 var _ ClientInterface = &Client{}

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -165,6 +165,10 @@ type ClientInterface interface {
 	PrevLedgersPage(hProtocol.LedgersPage) (hProtocol.LedgersPage, error)
 	NextEffectsPage(effects.EffectsPage) (effects.EffectsPage, error)
 	PrevEffectsPage(effects.EffectsPage) (effects.EffectsPage, error)
+	NextOffersPage(hProtocol.OffersPage) (hProtocol.OffersPage, error)
+	PrevOffersPage(hProtocol.OffersPage) (hProtocol.OffersPage, error)
+	NextTradesPage(hProtocol.TradesPage) (hProtocol.TradesPage, error)
+	PrevTradesPage(hProtocol.TradesPage) (hProtocol.TradesPage, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network.

--- a/clients/horizonclient/mocks.go
+++ b/clients/horizonclient/mocks.go
@@ -223,5 +223,29 @@ func (m *MockClient) PrevEffectsPage(page effects.EffectsPage) (effects.EffectsP
 	return a.Get(0).(effects.EffectsPage), a.Error(1)
 }
 
+// NextOffersPage is a mocking method
+func (m *MockClient) NextOffersPage(page hProtocol.OffersPage) (hProtocol.OffersPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(hProtocol.OffersPage), a.Error(1)
+}
+
+// PrevOffersPage is a mocking method
+func (m *MockClient) PrevOffersPage(page hProtocol.OffersPage) (hProtocol.OffersPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(hProtocol.OffersPage), a.Error(1)
+}
+
+// NextTradesPage is a mocking method
+func (m *MockClient) NextTradesPage(page hProtocol.TradesPage) (hProtocol.TradesPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(hProtocol.TradesPage), a.Error(1)
+}
+
+// PrevTradesPage is a mocking method
+func (m *MockClient) PrevTradesPage(page hProtocol.TradesPage) (hProtocol.TradesPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(hProtocol.TradesPage), a.Error(1)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}

--- a/clients/horizonclient/offer_request_test.go
+++ b/clients/horizonclient/offer_request_test.go
@@ -50,6 +50,105 @@ func ExampleClient_StreamOffers() {
 	}
 }
 
+func ExampleClient_NextOffersPage() {
+	client := DefaultPublicNetClient
+	// all offers
+	offerRequest := OfferRequest{ForAccount: "GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C", Limit: 20}
+	offers, err := client.Offers(offerRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(offers)
+
+	// get next pages.
+	recordsFound := false
+	if len(offers.Embedded.Records) > 0 {
+		recordsFound = true
+	}
+	page := offers
+	// get the next page of records if recordsFound is true
+	for recordsFound {
+		// next page
+		nextPage, err := client.NextOffersPage(page)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		page = nextPage
+		if len(nextPage.Embedded.Records) == 0 {
+			recordsFound = false
+		}
+		fmt.Println(nextPage)
+	}
+}
+
+func ExampleClient_PrevOffersPage() {
+	client := DefaultPublicNetClient
+	// all offers
+	offerRequest := OfferRequest{ForAccount: "GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C", Limit: 20}
+	offers, err := client.Offers(offerRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(offers)
+
+	// get prev pages.
+	recordsFound := false
+	if len(offers.Embedded.Records) > 0 {
+		recordsFound = true
+	}
+	page := offers
+	// get the prev page of records if recordsFound is true
+	for recordsFound {
+		// prev page
+		prevPage, err := client.PrevOffersPage(page)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		page = prevPage
+		if len(prevPage.Embedded.Records) == 0 {
+			recordsFound = false
+		}
+		fmt.Println(prevPage)
+	}
+}
+
+func TestNextOffersPage(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	offerRequest := OfferRequest{ForAccount: "GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG", Limit: 2}
+
+	hmock.On(
+		"GET",
+		"https://localhost/accounts/GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG/offers?limit=2",
+	).ReturnString(200, firstOffersPage)
+
+	offers, err := client.Offers(offerRequest)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, len(offers.Embedded.Records), 2)
+	}
+
+	hmock.On(
+		"GET",
+		"https://horizon-testnet.stellar.org/accounts/GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG/offers?cursor=2946581&limit=2&order=asc",
+	).ReturnString(200, emptyOffersPage)
+
+	nextPage, err := client.NextOffersPage(offers)
+	if assert.NoError(t, err) {
+		assert.Equal(t, len(nextPage.Embedded.Records), 0)
+	}
+}
+
 func TestOfferRequestStreamOffers(t *testing.T) {
 
 	hmock := httptest.NewClient()
@@ -99,3 +198,100 @@ func TestOfferRequestStreamOffers(t *testing.T) {
 
 var offerStreamResponse = `data: {"_links":{"self":{"href":"https://horizon-testnet.stellar.org/offers/5269100"},"offer_maker":{"href":"https://horizon-testnet.stellar.org/accounts/GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C"}},"id":5269100,"paging_token":"5269100","seller":"GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C","selling":{"asset_type":"credit_alphanum4","asset_code":"DSQ","asset_issuer":"GBDQPTQJDATT7Z7EO4COS4IMYXH44RDLLI6N6WIL5BZABGMUOVMLWMQF"},"buying":{"asset_type":"credit_alphanum4","asset_code":"XCS6","asset_issuer":"GBH2V47NOZRC56QAYCPV5JUBG5NVFJQF5AQTUNFNWNDHSWWTKH2MWR2L"},"amount":"20.4266087","price_r":{"n":24819,"d":10000000},"price":"0.0024819","last_modified_ledger":674449,"last_modified_time":"2019-04-08T11:56:41Z"}
 `
+
+var firstOffersPage = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG/offers?cursor=&limit=2&order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG/offers?cursor=2946581&limit=2&order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG/offers?cursor=2946580&limit=2&order=desc"
+    }
+  },
+  "_embedded": {
+    "records": [
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/offers/2946580"
+          },
+          "offer_maker": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG"
+          }
+        },
+        "id": 2946580,
+        "paging_token": "2946580",
+        "seller": "GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG",
+        "selling": {
+          "asset_type": "credit_alphanum4",
+          "asset_code": "HT",
+          "asset_issuer": "GCNSGHUCG5VMGLT5RIYYZSO7VQULQKAJ62QA33DBC5PPBSO57LFWVV6P"
+        },
+        "buying": {
+          "asset_type": "credit_alphanum4",
+          "asset_code": "BTC",
+          "asset_issuer": "GCNSGHUCG5VMGLT5RIYYZSO7VQULQKAJ62QA33DBC5PPBSO57LFWVV6P"
+        },
+        "amount": "33.7252478",
+        "price_r": {
+          "n": 15477,
+          "d": 43975000
+        },
+        "price": "0.0003519",
+        "last_modified_ledger": 363492,
+        "last_modified_time": "2019-05-16T08:35:22Z"
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/offers/2946581"
+          },
+          "offer_maker": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG"
+          }
+        },
+        "id": 2946581,
+        "paging_token": "2946581",
+        "seller": "GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG",
+        "selling": {
+          "asset_type": "credit_alphanum4",
+          "asset_code": "HT",
+          "asset_issuer": "GCNSGHUCG5VMGLT5RIYYZSO7VQULQKAJ62QA33DBC5PPBSO57LFWVV6P"
+        },
+        "buying": {
+          "asset_type": "credit_alphanum4",
+          "asset_code": "BTC",
+          "asset_issuer": "GCNSGHUCG5VMGLT5RIYYZSO7VQULQKAJ62QA33DBC5PPBSO57LFWVV6P"
+        },
+        "amount": "20.0242956",
+        "price_r": {
+          "n": 3157,
+          "d": 8795000
+        },
+        "price": "0.0003590",
+        "last_modified_ledger": 363492,
+        "last_modified_time": "2019-05-16T08:35:22Z"
+      }
+    ]
+  }
+}`
+
+var emptyOffersPage = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG/offers?cursor=2946581&limit=2&order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG/offers?cursor=2946583&limit=2&order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG/offers?cursor=2946582&limit=2&order=desc"
+    }
+  },
+  "_embedded": {
+    "records": []
+  }
+}`


### PR DESCRIPTION
This is part of a set of PRs to add methods to get the previous and next pages of a response from horizon.
This PR implements these methods for the trades and offers page.
Other pages will be implemented as listed in #985.