### PR TITLE
horizonclient: tx and ops prev/next methods

### DIFF
--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -563,5 +563,39 @@ func (c *Client) PrevEffectsPage(page effects.EffectsPage) (efp effects.EffectsP
 	return
 }
 
+// NextTransactionsPage returns the next page of transactions.
+func (c *Client) NextTransactionsPage(page hProtocol.TransactionsPage) (transactions hProtocol.TransactionsPage, err error) {
+	err = c.sendRequestURL(page.Links.Next.Href, "get", &transactions)
+	return
+}
+
+// PrevTransactionsPage returns the previous page of transactions.
+func (c *Client) PrevTransactionsPage(page hProtocol.TransactionsPage) (transactions hProtocol.TransactionsPage, err error) {
+	err = c.sendRequestURL(page.Links.Prev.Href, "get", &transactions)
+	return
+}
+
+// NextOperationsPage returns the next page of operations.
+func (c *Client) NextOperationsPage(page operations.OperationsPage) (operations operations.OperationsPage, err error) {
+	err = c.sendRequestURL(page.Links.Next.Href, "get", &operations)
+	return
+}
+
+// PrevOperationsPage returns the previous page of operations.
+func (c *Client) PrevOperationsPage(page operations.OperationsPage) (operations operations.OperationsPage, err error) {
+	err = c.sendRequestURL(page.Links.Prev.Href, "get", &operations)
+	return
+}
+
+// NextPaymentsPage returns the next page of payments.
+func (c *Client) NextPaymentsPage(page operations.OperationsPage) (operations.OperationsPage, error) {
+	return c.NextOperationsPage(page)
+}
+
+// PrevPaymentsPage returns the previous page of payments.
+func (c *Client) PrevPaymentsPage(page operations.OperationsPage) (operations.OperationsPage, error) {
+	return c.PrevOperationsPage(page)
+}
+
 // ensure that the horizon client implements ClientInterface
 var _ ClientInterface = &Client{}

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -165,6 +165,12 @@ type ClientInterface interface {
 	PrevLedgersPage(hProtocol.LedgersPage) (hProtocol.LedgersPage, error)
 	NextEffectsPage(effects.EffectsPage) (effects.EffectsPage, error)
 	PrevEffectsPage(effects.EffectsPage) (effects.EffectsPage, error)
+	NextTransactionsPage(hProtocol.TransactionsPage) (hProtocol.TransactionsPage, error)
+	PrevTransactionsPage(hProtocol.TransactionsPage) (hProtocol.TransactionsPage, error)
+	NextOperationsPage(operations.OperationsPage) (operations.OperationsPage, error)
+	PrevOperationsPage(operations.OperationsPage) (operations.OperationsPage, error)
+	NextPaymentsPage(operations.OperationsPage) (operations.OperationsPage, error)
+	PrevPaymentsPage(operations.OperationsPage) (operations.OperationsPage, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network.

--- a/clients/horizonclient/mocks.go
+++ b/clients/horizonclient/mocks.go
@@ -223,5 +223,39 @@ func (m *MockClient) PrevEffectsPage(page effects.EffectsPage) (effects.EffectsP
 	return a.Get(0).(effects.EffectsPage), a.Error(1)
 }
 
+// NextTransactionsPage is a mocking method
+func (m *MockClient) NextTransactionsPage(page hProtocol.TransactionsPage) (hProtocol.TransactionsPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(hProtocol.TransactionsPage), a.Error(1)
+}
+
+// PrevTransactionsPage is a mocking method
+func (m *MockClient) PrevTransactionsPage(page hProtocol.TransactionsPage) (hProtocol.TransactionsPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(hProtocol.TransactionsPage), a.Error(1)
+}
+
+// NextOperationsPage is a mocking method
+func (m *MockClient) NextOperationsPage(page operations.OperationsPage) (operations.OperationsPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(operations.OperationsPage), a.Error(1)
+}
+
+// PrevOperationsPage is a mocking method
+func (m *MockClient) PrevOperationsPage(page operations.OperationsPage) (operations.OperationsPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(operations.OperationsPage), a.Error(1)
+}
+
+// NextPaymentsPage is a mocking method
+func (m *MockClient) NextPaymentsPage(page operations.OperationsPage) (operations.OperationsPage, error) {
+	return m.NextOperationsPage(page)
+}
+
+// PrevPaymentsPage is a mocking method
+func (m *MockClient) PrevPaymentsPage(page operations.OperationsPage) (operations.OperationsPage, error) {
+	return m.PrevOperationsPage(page)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}

--- a/clients/horizonclient/operation_request_test.go
+++ b/clients/horizonclient/operation_request_test.go
@@ -111,6 +111,105 @@ func ExampleClient_StreamPayments() {
 	}
 }
 
+func ExampleClient_NextOperationsPage() {
+	client := DefaultPublicNetClient
+	// all operations
+	operationRequest := OperationRequest{Limit: 20}
+	operations, err := client.Operations(operationRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(operations)
+
+	// get next pages.
+	recordsFound := false
+	if len(operations.Embedded.Records) > 0 {
+		recordsFound = true
+	}
+	page := operations
+	// get the next page of records if recordsFound is true
+	for recordsFound {
+		// next page
+		nextPage, err := client.NextOperationsPage(page)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		page = nextPage
+		if len(nextPage.Embedded.Records) == 0 {
+			recordsFound = false
+		}
+		fmt.Println(nextPage)
+	}
+}
+
+func ExampleClient_PrevOperationsPage() {
+	client := DefaultPublicNetClient
+	// all operations
+	operationRequest := OperationRequest{Limit: 20}
+	operations, err := client.Operations(operationRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(operations)
+
+	// get prev pages.
+	recordsFound := false
+	if len(operations.Embedded.Records) > 0 {
+		recordsFound = true
+	}
+	page := operations
+	// get the prev page of records if recordsFound is true
+	for recordsFound {
+		// prev page
+		prevPage, err := client.PrevOperationsPage(page)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		page = prevPage
+		if len(prevPage.Embedded.Records) == 0 {
+			recordsFound = false
+		}
+		fmt.Println(prevPage)
+	}
+}
+
+func TestNextOperationsPage(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	operationRequest := OperationRequest{Limit: 2}
+
+	hmock.On(
+		"GET",
+		"https://localhost/operations?limit=2",
+	).ReturnString(200, firstOperationsPage)
+
+	operations, err := client.Operations(operationRequest)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, len(operations.Embedded.Records), 2)
+	}
+
+	hmock.On(
+		"GET",
+		"https://horizon-testnet.stellar.org/operations?cursor=661424967682&limit=2&order=asc",
+	).ReturnString(200, emptyOperationsPage)
+
+	nextPage, err := client.NextOperationsPage(operations)
+	if assert.NoError(t, err) {
+		assert.Equal(t, len(nextPage.Embedded.Records), 0)
+	}
+}
+
 func TestOperationRequestStreamOperations(t *testing.T) {
 	hmock := httptest.NewClient()
 	client := &Client{
@@ -178,3 +277,98 @@ func TestOperationRequestStreamOperations(t *testing.T) {
 
 var operationStreamResponse = `data: {"_links":{"self":{"href":"https://horizon-testnet.stellar.org/operations/4934917427201"},"transaction":{"href":"https://horizon-testnet.stellar.org/transactions/1c1449106a54cccd8a2ec2094815ad9db30ae54c69c3309dd08d13fdb8c749de"},"effects":{"href":"https://horizon-testnet.stellar.org/operations/4934917427201/effects"},"succeeds":{"href":"https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=4934917427201"},"precedes":{"href":"https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=4934917427201"}},"id":"4934917427201","paging_token":"4934917427201","transaction_successful":true,"source_account":"GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR","type":"create_account","type_i":0,"created_at":"2019-02-27T11:32:39Z","transaction_hash":"1c1449106a54cccd8a2ec2094815ad9db30ae54c69c3309dd08d13fdb8c749de","starting_balance":"10000.0000000","funder":"GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR","account":"GDBLBBDIUULY3HGIKXNK6WVBISY7DCNCDA45EL7NTXWX5R4UZ26HGMGS"}
 `
+
+var firstOperationsPage = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/operations?cursor=&limit=2&order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/operations?cursor=661424967682&limit=2&order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/operations?cursor=661424967681&limit=2&order=desc"
+    }
+  },
+  "_embedded": {
+    "records": [
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/operations/661424967681"
+          },
+          "transaction": {
+            "href": "https://horizon-testnet.stellar.org/transactions/749e4f8933221b9942ef38a02856803f379789ec8d971f1f60535db70135673e"
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/operations/661424967681/effects"
+          },
+          "succeeds": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc&cursor=661424967681"
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc&cursor=661424967681"
+          }
+        },
+        "id": "661424967681",
+        "paging_token": "661424967681",
+        "transaction_successful": true,
+        "source_account": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+        "type": "create_account",
+        "type_i": 0,
+        "created_at": "2019-04-24T09:16:14Z",
+        "transaction_hash": "749e4f8933221b9942ef38a02856803f379789ec8d971f1f60535db70135673e",
+        "starting_balance": "10000000000.0000000",
+        "funder": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+        "account": "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR"
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/operations/661424967682"
+          },
+          "transaction": {
+            "href": "https://horizon-testnet.stellar.org/transactions/749e4f8933221b9942ef38a02856803f379789ec8d971f1f60535db70135673e"
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/operations/661424967682/effects"
+          },
+          "succeeds": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc&cursor=661424967682"
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc&cursor=661424967682"
+          }
+        },
+        "id": "661424967682",
+        "paging_token": "661424967682",
+        "transaction_successful": true,
+        "source_account": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+        "type": "create_account",
+        "type_i": 0,
+        "created_at": "2019-04-24T09:16:14Z",
+        "transaction_hash": "749e4f8933221b9942ef38a02856803f379789ec8d971f1f60535db70135673e",
+        "starting_balance": "10000.0000000",
+        "funder": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+        "account": "GDO34SQXVOSNODK7JCTAXLZUPSAF3JIH4ADQELVIKOQJUWQ3U4BMSCSH"
+      }
+    ]
+  }
+}`
+
+var emptyOperationsPage = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/operations?cursor=661424967682&limit=2&order=asc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/operations?cursor=661424967684&limit=2&order=asc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/operations?cursor=661424967683&limit=2&order=desc"
+    }
+  },
+  "_embedded": {
+    "records": []
+  }
+}`

--- a/clients/horizonclient/operation_request_test.go
+++ b/clients/horizonclient/operation_request_test.go
@@ -115,19 +115,19 @@ func ExampleClient_NextOperationsPage() {
 	client := DefaultPublicNetClient
 	// all operations
 	operationRequest := OperationRequest{Limit: 20}
-	operations, err := client.Operations(operationRequest)
+	ops, err := client.Operations(operationRequest)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	fmt.Print(operations)
+	fmt.Print(ops)
 
 	// get next pages.
 	recordsFound := false
-	if len(operations.Embedded.Records) > 0 {
+	if len(ops.Embedded.Records) > 0 {
 		recordsFound = true
 	}
-	page := operations
+	page := ops
 	// get the next page of records if recordsFound is true
 	for recordsFound {
 		// next page
@@ -149,19 +149,19 @@ func ExampleClient_PrevOperationsPage() {
 	client := DefaultPublicNetClient
 	// all operations
 	operationRequest := OperationRequest{Limit: 20}
-	operations, err := client.Operations(operationRequest)
+	ops, err := client.Operations(operationRequest)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	fmt.Print(operations)
+	fmt.Print(ops)
 
 	// get prev pages.
 	recordsFound := false
-	if len(operations.Embedded.Records) > 0 {
+	if len(ops.Embedded.Records) > 0 {
 		recordsFound = true
 	}
-	page := operations
+	page := ops
 	// get the prev page of records if recordsFound is true
 	for recordsFound {
 		// prev page
@@ -193,10 +193,10 @@ func TestNextOperationsPage(t *testing.T) {
 		"https://localhost/operations?limit=2",
 	).ReturnString(200, firstOperationsPage)
 
-	operations, err := client.Operations(operationRequest)
+	ops, err := client.Operations(operationRequest)
 
 	if assert.NoError(t, err) {
-		assert.Equal(t, len(operations.Embedded.Records), 2)
+		assert.Equal(t, len(ops.Embedded.Records), 2)
 	}
 
 	hmock.On(
@@ -204,7 +204,7 @@ func TestNextOperationsPage(t *testing.T) {
 		"https://horizon-testnet.stellar.org/operations?cursor=661424967682&limit=2&order=asc",
 	).ReturnString(200, emptyOperationsPage)
 
-	nextPage, err := client.NextOperationsPage(operations)
+	nextPage, err := client.NextOperationsPage(ops)
 	if assert.NoError(t, err) {
 		assert.Equal(t, len(nextPage.Embedded.Records), 0)
 	}

--- a/clients/horizonclient/transaction_request_test.go
+++ b/clients/horizonclient/transaction_request_test.go
@@ -78,6 +78,105 @@ func ExampleClient_StreamTransactions() {
 	}
 }
 
+func ExampleClient_NextTransactionsPage() {
+	client := DefaultPublicNetClient
+	// all transactions
+	transactionRequest := TransactionRequest{Limit: 20}
+	transactions, err := client.Transactions(transactionRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(transactions)
+
+	// get next pages.
+	recordsFound := false
+	if len(transactions.Embedded.Records) > 0 {
+		recordsFound = true
+	}
+	page := transactions
+	// get the next page of records if recordsFound is true
+	for recordsFound {
+		// next page
+		nextPage, err := client.NextTransactionsPage(page)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		page = nextPage
+		if len(nextPage.Embedded.Records) == 0 {
+			recordsFound = false
+		}
+		fmt.Println(nextPage)
+	}
+}
+
+func ExampleClient_PrevTransactionsPage() {
+	client := DefaultPublicNetClient
+	// all transactions
+	transactionRequest := TransactionRequest{Limit: 20}
+	transactions, err := client.Transactions(transactionRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(transactions)
+
+	// get prev pages.
+	recordsFound := false
+	if len(transactions.Embedded.Records) > 0 {
+		recordsFound = true
+	}
+	page := transactions
+	// get the prev page of records if recordsFound is true
+	for recordsFound {
+		// prev page
+		prevPage, err := client.PrevTransactionsPage(page)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		page = prevPage
+		if len(prevPage.Embedded.Records) == 0 {
+			recordsFound = false
+		}
+		fmt.Println(prevPage)
+	}
+}
+
+func TestNextTransactionsPage(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	transactionRequest := TransactionRequest{Limit: 2}
+
+	hmock.On(
+		"GET",
+		"https://localhost/transactions?limit=2",
+	).ReturnString(200, firstTransactionsPage)
+
+	transactions, err := client.Transactions(transactionRequest)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, len(transactions.Embedded.Records), 2)
+	}
+
+	hmock.On(
+		"GET",
+		"https://horizon-testnet.stellar.org/transactions?cursor=1566052450312192&limit=2&order=desc",
+	).ReturnString(200, emptyTransactionsPage)
+
+	nextPage, err := client.NextTransactionsPage(transactions)
+	if assert.NoError(t, err) {
+		assert.Equal(t, len(nextPage.Embedded.Records), 0)
+	}
+}
+
 func TestTransactionRequestStreamTransactions(t *testing.T) {
 	hmock := httptest.NewClient()
 	client := &Client{
@@ -146,3 +245,128 @@ func TestTransactionRequestStreamTransactions(t *testing.T) {
 
 var txStreamResponse = `data: {"_links":{"self":{"href":"https://horizon-testnet.stellar.org/transactions/1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e"},"account":{"href":"https://horizon-testnet.stellar.org/accounts/GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR"},"ledger":{"href":"https://horizon-testnet.stellar.org/ledgers/607387"},"operations":{"href":"https://horizon-testnet.stellar.org/transactions/1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e/operations{?cursor,limit,order}","templated":true},"effects":{"href":"https://horizon-testnet.stellar.org/transactions/1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e/effects{?cursor,limit,order}","templated":true},"precedes":{"href":"https://horizon-testnet.stellar.org/transactions?order=asc\u0026cursor=2608707301036032"},"succeeds":{"href":"https://horizon-testnet.stellar.org/transactions?order=desc\u0026cursor=2608707301036032"}},"id":"1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e","paging_token":"2608707301036032","successful":true,"hash":"1534f6507420c6871b557cc2fc800c29fb1ed1e012e694993ffe7a39c824056e","ledger":607387,"created_at":"2019-04-04T12:07:03Z","source_account":"GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR","source_account_sequence":"4660039930473","fee_paid":100,"operation_count":1,"envelope_xdr":"AAAAABB90WssODNIgi6BHveqzxTRmIpvAFRyVNM+Hm2GVuCcAAAAZAAABD0ABlJpAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAmLuzasXDMqsqgFK4xkbLxJLzmQQzkiCF2SnKPD+b1TsAAAAXSHboAAAAAAAAAAABhlbgnAAAAECqxhXduvtzs65keKuTzMtk76cts2WeVB2pZKYdlxlOb1EIbOpFhYizDSXVfQlAvvg18qV6oNRr7ls4nnEm2YIK","result_xdr":"AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=","result_meta_xdr":"AAAAAQAAAAIAAAADAAlEmwAAAAAAAAAAEH3Rayw4M0iCLoEe96rPFNGYim8AVHJU0z4ebYZW4JwBT3aiixBA2AAABD0ABlJoAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAlEmwAAAAAAAAAAEH3Rayw4M0iCLoEe96rPFNGYim8AVHJU0z4ebYZW4JwBT3aiixBA2AAABD0ABlJpAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMACUSbAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFPdqKLEEDYAAAEPQAGUmkAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEACUSbAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFPdotCmVjYAAAEPQAGUmkAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAACUSbAAAAAAAAAACYu7NqxcMyqyqAUrjGRsvEkvOZBDOSIIXZKco8P5vVOwAAABdIdugAAAlEmwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==","fee_meta_xdr":"AAAAAgAAAAMACUSaAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFPdqKLEEE8AAAEPQAGUmgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEACUSbAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFPdqKLEEDYAAAEPQAGUmgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==","memo_type":"none","signatures":["qsYV3br7c7OuZHirk8zLZO+nLbNlnlQdqWSmHZcZTm9RCGzqRYWIsw0l1X0JQL74NfKleqDUa+5bOJ5xJtmCCg=="]}
 `
+
+var firstTransactionsPage = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/transactions?cursor=&limit=2&order=desc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/transactions?cursor=1566052450312192&limit=2&order=desc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/transactions?cursor=1566052450316288&limit=2&order=asc"
+    }
+  },
+  "_embedded": {
+    "records": [
+      {
+        "memo": "3232096465",
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/transactions/a748158973896c2b0a4fc32a2ae1c96954e4a52e3385f942832a1852fce6d775"
+          },
+          "account": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GDRZVYB5QI6UFR4NR4RXQ3HR5IH4KL2ECR4IUZXGHOUMPGLN2OGCSAOK"
+          },
+          "ledger": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/364625"
+          },
+          "operations": {
+            "href": "https://horizon-testnet.stellar.org/transactions/a748158973896c2b0a4fc32a2ae1c96954e4a52e3385f942832a1852fce6d775/operations{?cursor,limit,order}",
+            "templated": true
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/transactions/a748158973896c2b0a4fc32a2ae1c96954e4a52e3385f942832a1852fce6d775/effects{?cursor,limit,order}",
+            "templated": true
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/transactions?order=asc&cursor=1566052450316288"
+          },
+          "succeeds": {
+            "href": "https://horizon-testnet.stellar.org/transactions?order=desc&cursor=1566052450316288"
+          }
+        },
+        "id": "a748158973896c2b0a4fc32a2ae1c96954e4a52e3385f942832a1852fce6d775",
+        "paging_token": "1566052450316288",
+        "successful": true,
+        "hash": "a748158973896c2b0a4fc32a2ae1c96954e4a52e3385f942832a1852fce6d775",
+        "ledger": 364625,
+        "created_at": "2019-05-16T10:17:44Z",
+        "source_account": "GDRZVYB5QI6UFR4NR4RXQ3HR5IH4KL2ECR4IUZXGHOUMPGLN2OGCSAOK",
+        "source_account_sequence": "1566048155336705",
+        "fee_paid": 100,
+        "operation_count": 1,
+        "envelope_xdr": "AAAAAOOa4D2CPULHjY8jeGzx6g/FL0QUeIpm5juox5lt04wpAAAAZAAFkFAAAAABAAAAAAAAAAEAAAAKMzIzMjA5NjQ2NQAAAAAAAQAAAAEAAAAA45rgPYI9QseNjyN4bPHqD8UvRBR4imbmO6jHmW3TjCkAAAABAAAAAE3j7m7lhZ39noA3ToXWDjJ9QuMmmp/1UaIg0chYzRSlAAAAAAAAAAJMTD+AAAAAAAAAAAFt04wpAAAAQAxFRWcepbQoisfiZ0PG7XhPIBl2ssiD9ymMVpsDyLoHyWXboJLaqibNbiPUHk/KEToTVg7G/JCZ06Mfj0daVAc=",
+        "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+        "result_meta_xdr": "AAAAAQAAAAIAAAADAAWQUQAAAAAAAAAA45rgPYI9QseNjyN4bPHqD8UvRBR4imbmO6jHmW3TjCkAAAAXSHbnnAAFkFAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAWQUQAAAAAAAAAA45rgPYI9QseNjyN4bPHqD8UvRBR4imbmO6jHmW3TjCkAAAAXSHbnnAAFkFAAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMABZBQAAAAAAAAAABN4+5u5YWd/Z6AN06F1g4yfULjJpqf9VGiINHIWM0UpQAAQkzJKzWcAAF79QAAP30AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEABZBRAAAAAAAAAABN4+5u5YWd/Z6AN06F1g4yfULjJpqf9VGiINHIWM0UpQAAQk8Vd3UcAAF79QAAP30AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMABZBRAAAAAAAAAADjmuA9gj1Cx42PI3hs8eoPxS9EFHiKZuY7qMeZbdOMKQAAABdIduecAAWQUAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEABZBRAAAAAAAAAADjmuA9gj1Cx42PI3hs8eoPxS9EFHiKZuY7qMeZbdOMKQAAABT8KqgcAAWQUAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+        "fee_meta_xdr": "AAAAAgAAAAMABZBQAAAAAAAAAADjmuA9gj1Cx42PI3hs8eoPxS9EFHiKZuY7qMeZbdOMKQAAABdIdugAAAWQUAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEABZBRAAAAAAAAAADjmuA9gj1Cx42PI3hs8eoPxS9EFHiKZuY7qMeZbdOMKQAAABdIduecAAWQUAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+        "memo_type": "text",
+        "signatures": [
+          "DEVFZx6ltCiKx+JnQ8bteE8gGXayyIP3KYxWmwPIugfJZdugktqqJs1uI9QeT8oROhNWDsb8kJnTox+PR1pUBw=="
+        ]
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/transactions/80af95a8aeb49bd19eeb2c89fbdd18c691fe80d1a0609fd20c8418fdde0ea943"
+          },
+          "account": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GCYN7MI6VXVRP74KR6MKBAW2ELLCXL6QCY5H4YQ62HVWZWMCE6Y232UC"
+          },
+          "ledger": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/364625"
+          },
+          "operations": {
+            "href": "https://horizon-testnet.stellar.org/transactions/80af95a8aeb49bd19eeb2c89fbdd18c691fe80d1a0609fd20c8418fdde0ea943/operations{?cursor,limit,order}",
+            "templated": true
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/transactions/80af95a8aeb49bd19eeb2c89fbdd18c691fe80d1a0609fd20c8418fdde0ea943/effects{?cursor,limit,order}",
+            "templated": true
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/transactions?order=asc&cursor=1566052450312192"
+          },
+          "succeeds": {
+            "href": "https://horizon-testnet.stellar.org/transactions?order=desc&cursor=1566052450312192"
+          }
+        },
+        "id": "80af95a8aeb49bd19eeb2c89fbdd18c691fe80d1a0609fd20c8418fdde0ea943",
+        "paging_token": "1566052450312192",
+        "successful": true,
+        "hash": "80af95a8aeb49bd19eeb2c89fbdd18c691fe80d1a0609fd20c8418fdde0ea943",
+        "ledger": 364625,
+        "created_at": "2019-05-16T10:17:44Z",
+        "source_account": "GCYN7MI6VXVRP74KR6MKBAW2ELLCXL6QCY5H4YQ62HVWZWMCE6Y232UC",
+        "source_account_sequence": "132761734108361",
+        "fee_paid": 5000,
+        "operation_count": 50,
+        "envelope_xdr": "AAAAALDfsR6t6xf/io...",
+        "result_xdr": "AAAAALDfsR6t6xf/io...",
+        "fee_meta_xdr": "AAAAAgAAAAMABZBQAAAAAAAAAACw37EeresX/4qPmKCC2iLWK6/QFjp+Yh7R62zZgiexrQAAABdB/2doAAB4vwAAVMgAAACLAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEABZBRAAAAAAAAAACw37EeresX/4qPmKCC2iLWK6/QFjp+Yh7R62zZgiexrQAAABdB/1PgAAB4vwAAVMgAAACLAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+        "memo_type": "none",
+        "signatures": [
+          "y3niLNdTDYEmLv9n13RAm58VBy0zTexh5IsbM/ajTDOA00ozphxymabRayRL8xHQZRWFka9kh+zlyLfnIB4JBw=="
+        ]
+      }
+    ]
+  }
+}`
+
+var emptyTransactionsPage = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/transactions?cursor=1566052450312192&limit=2&order=desc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/transactions?cursor=1566048155353088&limit=2&order=desc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/transactions?cursor=1566052450308096&limit=2&order=asc"
+    }
+  },
+  "_embedded": {
+    "records": []
+  }
+}`


### PR DESCRIPTION
This is last set of PRs to add methods to get the previous and next pages of a response from horizon.
This PR implements these methods for transactions and operation pages.
Other pages will be implemented as listed in #985.