### PR TITLE
docs: update README.md to use Circle CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Stellar Go 
-[![Build Status](https://travis-ci.org/stellar/go.svg?branch=master)](https://travis-ci.org/stellar/go) 
+[![Build Status](https://circleci.com/gh/stellar/go.svg?style=shield)](https://circleci.com/gh/stellar/go)
 [![GoDoc](https://godoc.org/github.com/stellar/go?status.svg)](https://godoc.org/github.com/stellar/go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/stellar/go)](https://goreportcard.com/report/github.com/stellar/go)
 


### PR DESCRIPTION
This PR aims to replace the monorepo's `README.md` build status badge (currently based on Travis CI's status report) with the one Circle CI provides.