### PR TITLE
exp/ticker: fix trade db backfill logic

### DIFF
--- a/exp/ticker/internal/scraper/trade_scraper.go
+++ b/exp/ticker/internal/scraper/trade_scraper.go
@@ -37,11 +37,9 @@ func (c *ScraperConfig) retrieveTrades(since time.Time, limit int) (trades []hPr
 	for tradesPage.Links.Next.Href != tradesPage.Links.Self.Href {
 		// Enforcing time boundaries:
 		last, cleanTrades := c.checkRecords(tradesPage.Embedded.Records, since)
+		trades = append(trades, cleanTrades...)
 		if last {
-			trades = append(trades, cleanTrades...)
 			break
-		} else {
-			trades = append(trades, tradesPage.Embedded.Records...)
 		}
 
 		// Enforcing limit of results:


### PR DESCRIPTION
This PR aims to fix a logic error in the trade db backfill logic, which previously only performed asset cleanup / checks on the last page of scraped trades.