### PR TITLE
support/historyarchives - allow https scheme

### DIFF
--- a/support/historyarchive/archive.go
+++ b/support/historyarchive/archive.go
@@ -198,7 +198,7 @@ func Connect(u string, opts ConnectOptions) (*Archive, error) {
 	} else if parsed.Scheme == "file" {
 		pth = path.Join(parsed.Host, pth)
 		arch.backend = makeFsBackend(pth, opts)
-	} else if parsed.Scheme == "http" {
+	} else if parsed.Scheme == "http" || parsed.Scheme == "https" {
 		arch.backend = makeHttpBackend(parsed, opts)
 	} else if parsed.Scheme == "mock" {
 		arch.backend = makeMockBackend(opts)


### PR DESCRIPTION
Allows to retreive history archives with https scheme (`stellar-archivist scan https://...`)