### PR TITLE
exp/ticker: use a specific User Agent to identify ticker requests

### DIFF
--- a/exp/ticker/internal/scraper/asset_scraper.go
+++ b/exp/ticker/internal/scraper/asset_scraper.go
@@ -68,7 +68,11 @@ func fetchTOMLData(asset hProtocol.AssetStat) (data string, err error) {
 	client := http.Client{
 		Timeout: timeout,
 	}
-	resp, err := client.Get(tomlURL)
+
+	req, err := http.NewRequest("GET", tomlURL, nil)
+	req.Header.Set("User-Agent", "Stellar Ticker v1.0")
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This PR updates the ticker's TOML scraper requests to use a specific user agent (`Stellar Ticker v1.0`). This has been done to:
- Allow servers to identify which requests are made by the ticker
- Bypass some filters created by asset issuers to prevent unknown bots from scraping their TOML data