### PR TITLE
Fix "int64: value out of range" in trade aggregations

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,6 +6,10 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## Unreleased
+
+* Fix "int64: value out of range" errors in trade aggregations (#1319).
+
 ## v0.17.6 - 2019-04-29
 
 * Fixed a bug in `/order_book` when sum of amounts at a single price level exceeds `int64_max` (#1037).

--- a/services/horizon/internal/db2/history/trade_aggregation.go
+++ b/services/horizon/internal/db2/history/trade_aggregation.go
@@ -30,8 +30,8 @@ var StrictResolutionFiltering = true
 type TradeAggregation struct {
 	Timestamp     int64     `db:"timestamp"`
 	TradeCount    int64     `db:"count"`
-	BaseVolume    int64     `db:"base_volume"`
-	CounterVolume int64     `db:"counter_volume"`
+	BaseVolume    string    `db:"base_volume"`
+	CounterVolume string    `db:"counter_volume"`
 	Average       float64   `db:"avg"`
 	High          xdr.Price `db:"high"`
 	Low           xdr.Price `db:"low"`

--- a/services/horizon/internal/resourceadapter/trade_aggregation.go
+++ b/services/horizon/internal/resourceadapter/trade_aggregation.go
@@ -15,11 +15,18 @@ func PopulateTradeAggregation(
 	ctx context.Context,
 	dest *TradeAggregation,
 	row history.TradeAggregation,
-) (err error) {
+) error {
+	var err error
 	dest.Timestamp = row.Timestamp
 	dest.TradeCount = row.TradeCount
-	dest.BaseVolume = amount.StringFromInt64(row.BaseVolume)
-	dest.CounterVolume = amount.StringFromInt64(row.CounterVolume)
+	dest.BaseVolume, err = amount.IntStringToAmount(row.BaseVolume)
+	if err != nil {
+		return err
+	}
+	dest.CounterVolume, err = amount.IntStringToAmount(row.CounterVolume)
+	if err != nil {
+		return err
+	}
 	dest.Average = price.StringFromFloat64(row.Average)
 	dest.High = row.High.String()
 	dest.HighR = row.High
@@ -29,5 +36,5 @@ func PopulateTradeAggregation(
 	dest.OpenR = row.Open
 	dest.Close = row.Close.String()
 	dest.CloseR = row.Close
-	return
+	return nil
 }


### PR DESCRIPTION
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.

## Summary

Sum of traded assets can exceed `INT64_MAX` in a single bucket. In this
commit destination types have been changed to `string` and are converted
to decimal amounts (divide by `10^7`) using `amount.IntStringToAmount`.

If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description.

Close #1268.