### PR TITLE
support/render/problem: make service host configurable

### DIFF
--- a/clients/horizon/error.go
+++ b/clients/horizon/error.go
@@ -20,12 +20,11 @@ func (prob Problem) ToProblem() problem.P {
 	}
 
 	return problem.P{
-		Type:     prob.Type,
-		Title:    prob.Title,
-		Status:   prob.Status,
-		Detail:   prob.Detail,
-		Instance: prob.Instance,
-		Extras:   extras,
+		Type:   prob.Type,
+		Title:  prob.Title,
+		Status: prob.Status,
+		Detail: prob.Detail,
+		Extras: extras,
 	}
 }
 

--- a/services/horizon/internal/assertions_test.go
+++ b/services/horizon/internal/assertions_test.go
@@ -3,6 +3,7 @@ package horizon
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 
 	"net/url"
 
@@ -49,6 +50,7 @@ func (a *Assertions) Problem(body *bytes.Buffer, expected problem.P) bool {
 		return false
 	}
 
+	actual.Type = strings.TrimPrefix(actual.Type, problem.ServiceHost)
 	if expected.Type != "" && a.Equal(expected.Type, actual.Type, "problem type didn't match") {
 		return false
 	}

--- a/services/horizon/internal/assertions_test.go
+++ b/services/horizon/internal/assertions_test.go
@@ -6,8 +6,6 @@ import (
 
 	"net/url"
 
-	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
-	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/support/render/problem"
 	"github.com/stretchr/testify/assert"
 )
@@ -50,8 +48,6 @@ func (a *Assertions) Problem(body *bytes.Buffer, expected problem.P) bool {
 	if !a.NoError(err, "failed to parse body") {
 		return false
 	}
-
-	hProblem.Inflate(test.Context(), &expected)
 
 	if expected.Type != "" && a.Equal(expected.Type, actual.Type, "problem type didn't match") {
 		return false

--- a/services/horizon/internal/render/problem/problem.go
+++ b/services/horizon/internal/render/problem/problem.go
@@ -1,19 +1,10 @@
 package problem
 
 import (
-	"context"
 	"net/http"
 
-	"github.com/stellar/go/services/horizon/internal/hchi"
 	"github.com/stellar/go/support/render/problem"
 )
-
-// Inflate expands a problem with contextal information, including setting basic info.
-// At present it adds the request's id as the problem's Instance, if available.
-func Inflate(ctx context.Context, p *problem.P) {
-	problem.Inflate(p)
-	p.Instance = hchi.RequestID(ctx)
-}
 
 // Well-known and reused problems below:
 var (

--- a/services/horizon/internal/render/problem/problem_test.go
+++ b/services/horizon/internal/render/problem/problem_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/stellar/go/services/horizon/internal/hchi"
 	"github.com/stellar/go/support/render/problem"
 	"github.com/stretchr/testify/assert"
 )
@@ -33,17 +32,4 @@ func TestCommonProblems(t *testing.T) {
 			assert.Equal(t, tc.expectedCode, w.Code)
 		})
 	}
-}
-
-func TestInflate(t *testing.T) {
-	// Sets Instance to the request id based on the context
-	ctx2 := hchi.WithRequestID(ctx, "2")
-	p := problem.P{}
-
-	Inflate(ctx2, &p)
-	assert.Equal(t, "2", p.Instance)
-
-	// when no request id is set, instance should be ""
-	Inflate(ctx, &p)
-	assert.Equal(t, "", p.Instance)
 }

--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	serviceHost     = "https://stellar.org/horizon-errors/"
+	ServiceHost     = "https://stellar.org/horizon-errors/"
 	errToProblemMap = map[error]P{}
 )
 
@@ -81,7 +81,7 @@ func RegisterError(err error, p P) {
 // type, register host as an empty string.
 // The default service host points to `https://stellar.org/horizon-errors/`.
 func RegisterHost(host string) {
-	serviceHost = host
+	ServiceHost = host
 }
 
 // Render writes a http response to `w`, compliant with the "Problem
@@ -112,8 +112,8 @@ func Render(ctx context.Context, w http.ResponseWriter, err error) {
 }
 
 func renderProblem(ctx context.Context, w http.ResponseWriter, p P) {
-	if serviceHost != "" && !strings.HasPrefix(p.Type, serviceHost) {
-		p.Type = serviceHost + p.Type
+	if ServiceHost != "" && !strings.HasPrefix(p.Type, ServiceHost) {
+		p.Type = ServiceHost + p.Type
 	}
 
 	w.Header().Set("Content-Type", "application/problem+json; charset=utf-8")

--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -11,24 +11,57 @@ import (
 	"github.com/stellar/go/support/log"
 )
 
-const horizonHost = "https://stellar.org/horizon-errors/"
+var (
+	serviceHost     = "https://stellar.org/horizon-errors/"
+	errToProblemMap = map[error]P{}
+)
+
+var (
+	// ServerError is a well-known problem type. Use it as a shortcut.
+	ServerError = P{
+		Type:   "server_error",
+		Title:  "Internal Server Error",
+		Status: http.StatusInternalServerError,
+		Detail: "An error occurred while processing this request.  This is usually due " +
+			"to a bug within the server software.  Trying this request again may " +
+			"succeed if the bug is transient, otherwise please report this issue " +
+			"to the issue tracker at: https://github.com/stellar/go/issues." +
+			" Please include this response in your issue.",
+	}
+
+	// NotFound is a well-known problem type.  Use it as a shortcut in your actions
+	NotFound = P{
+		Type:   "not_found",
+		Title:  "Resource Missing",
+		Status: http.StatusNotFound,
+		Detail: "The resource at the url requested was not found.  This is usually " +
+			"occurs for one of two reasons:  The url requested is not valid, or no " +
+			"data in our database could be found with the parameters provided.",
+	}
+
+	// BadRequest is a well-known problem type.  Use it as a shortcut
+	// in your actions.
+	BadRequest = P{
+		Type:   "bad_request",
+		Title:  "Bad Request",
+		Status: http.StatusBadRequest,
+		Detail: "The request you sent was invalid in some way",
+	}
+)
 
 // P is a struct that represents an error response to be rendered to a connected
 // client.
 type P struct {
-	Type     string                 `json:"type"`
-	Title    string                 `json:"title"`
-	Status   int                    `json:"status"`
-	Detail   string                 `json:"detail,omitempty"`
-	Instance string                 `json:"instance,omitempty"`
-	Extras   map[string]interface{} `json:"extras,omitempty"`
+	Type   string                 `json:"type"`
+	Title  string                 `json:"title"`
+	Status int                    `json:"status"`
+	Detail string                 `json:"detail,omitempty"`
+	Extras map[string]interface{} `json:"extras,omitempty"`
 }
 
 func (p P) Error() string {
 	return fmt.Sprintf("problem: %s", p.Type)
 }
-
-var errToProblemMap = map[error]P{}
 
 // RegisterError records an error -> P mapping, allowing the app to register
 // specific errors that may occur in other packages to be rendered as a specific
@@ -43,16 +76,12 @@ func RegisterError(err error, p P) {
 	errToProblemMap[err] = p
 }
 
-// Inflate sets some basic parameters on the problem, mostly the type for now
-func Inflate(p *P) {
-	//TODO: add requesting url to extra info
-
-	if !strings.HasPrefix(p.Type, horizonHost) {
-		//TODO: make the horizonHost prefix configurable
-		p.Type = horizonHost + p.Type
-	}
-
-	p.Instance = ""
+// RegisterHost registers the service host url. It is used to prepend the host
+// url to the error type. If you don't wish to prepend anything to the error
+// type, register host as an empty string.
+// The default service host points to `https://stellar.org/horizon-errors/`.
+func RegisterHost(host string) {
+	serviceHost = host
 }
 
 // Render writes a http response to `w`, compliant with the "Problem
@@ -61,18 +90,31 @@ func Inflate(p *P) {
 func Render(ctx context.Context, w http.ResponseWriter, err error) {
 	origErr := errors.Cause(err)
 
+	var problem P
 	switch p := origErr.(type) {
 	case P:
-		renderProblem(ctx, w, p)
+		problem = p
 	case *P:
-		renderProblem(ctx, w, *p)
+		problem = *p
 	case error:
-		renderErr(ctx, w, err)
+		var ok bool
+		problem, ok = errToProblemMap[origErr]
+
+		// If this error is not a registered error
+		// log it and replace it with a 500 error
+		if !ok {
+			log.Ctx(ctx).WithStack(err).Error(err)
+			problem = ServerError
+		}
 	}
+
+	renderProblem(ctx, w, problem)
 }
 
 func renderProblem(ctx context.Context, w http.ResponseWriter, p P) {
-	Inflate(&p)
+	if serviceHost != "" && !strings.HasPrefix(p.Type, serviceHost) {
+		p.Type = serviceHost + p.Type
+	}
 
 	w.Header().Set("Content-Type", "application/problem+json; charset=utf-8")
 
@@ -86,52 +128,6 @@ func renderProblem(ctx context.Context, w http.ResponseWriter, p P) {
 
 	w.WriteHeader(p.Status)
 	w.Write(js)
-}
-
-func renderErr(ctx context.Context, w http.ResponseWriter, err error) {
-	origErr := errors.Cause(err)
-
-	p, ok := errToProblemMap[origErr]
-
-	// If this error is not a registered error
-	// log it and replace it with a 500 error
-	if !ok {
-		log.Ctx(ctx).WithStack(err).Error(err)
-		p = ServerError
-	}
-
-	renderProblem(ctx, w, p)
-}
-
-// ServerError is a well-known problem type. Use it as a shortcut.
-var ServerError = P{
-	Type:   "server_error",
-	Title:  "Internal Server Error",
-	Status: http.StatusInternalServerError,
-	Detail: "An error occurred while processing this request.  This is usually due " +
-		"to a bug within the server software.  Trying this request again may " +
-		"succeed if the bug is transient, otherwise please report this issue " +
-		"to the issue tracker at: https://github.com/stellar/go/issues." +
-		" Please include this response in your issue.",
-}
-
-// NotFound is a well-known problem type.  Use it as a shortcut in your actions
-var NotFound = P{
-	Type:   "not_found",
-	Title:  "Resource Missing",
-	Status: http.StatusNotFound,
-	Detail: "The resource at the url requested was not found.  This is usually " +
-		"occurs for one of two reasons:  The url requested is not valid, or no " +
-		"data in our database could be found with the parameters provided.",
-}
-
-// BadRequest is a well-known problem type.  Use it as a shortcut
-// in your actions.
-var BadRequest = P{
-	Type:   "bad_request",
-	Title:  "Bad Request",
-	Status: http.StatusBadRequest,
-	Detail: "The request you sent was invalid in some way",
 }
 
 // MakeInvalidFieldProblem is a helper function to make a BadRequest with extras

--- a/txnbuild/cmd/demo/operations/demo.go
+++ b/txnbuild/cmd/demo/operations/demo.go
@@ -395,7 +395,6 @@ func printHorizonError(hError *horizonclient.Error) error {
 	log.Println("Error title:", problem.Title)
 	log.Println("Error status:", problem.Status)
 	log.Println("Error detail:", problem.Detail)
-	log.Println("Error instance:", problem.Instance)
 
 	resultCodes, err := hError.ResultCodes()
 	if err != nil {


### PR DESCRIPTION
This PR makes the service host configurable by introducing `RegisterHost`
so we don't always have `https://www.stellar.org/horizon-errors` prepended
in the problem type. This makes the package more generic so it can be used
by the keystore.

This PR also removes an unused function `Inflate` in horizon internal as
well as removes an unused field `Instance` in `P`.

Finally, it makes `Render` more readable by removing `renderErr`.

