### PR TITLE
exp/keystore/migration: add a unique index

### DIFF
--- a/exp/services/keystore/migrations/2019-05-24.0.initial-migrations.sql
+++ b/exp/services/keystore/migrations/2019-05-24.0.initial-migrations.sql
@@ -9,6 +9,9 @@ CREATE TABLE public.encrypted_keys (
     modified_at timestamp with time zone
 );
 
+CREATE UNIQUE INDEX encrypted_keys_user_id_salt_encrypter_name_idx on public.encrypted_keys (user_id, salt, encrypter_name);
+
 -- +migrate Down
 
 DROP TABLE public.encrypted_keys;
+DROP INDEX encrypted_keys_user_id_salt_encrypter_name_idx;


### PR DESCRIPTION
This is to prevent a user from storing a keys-blob with the same salt
and encrypter_name as it might imply an error. The user should use the
update endpoint to add more keys.
