### PR TITLE
Horizon 0.18.0 CHANGELOG

### DIFF
--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -349,7 +349,7 @@ func (c *Client) OperationDetail(id string) (ops operations.Operation, err error
 		return ops, errors.Wrap(err, "unmarshaling json")
 	}
 
-	ops, err = operations.UnmarshalOperation(baseRecord.GetType(), dataString)
+	ops, err = operations.UnmarshalOperation(baseRecord.GetTypeI(), dataString)
 	return ops, errors.Wrap(err, "unmarshaling to the correct operation type")
 }
 

--- a/clients/horizonclient/operation_request.go
+++ b/clients/horizonclient/operation_request.go
@@ -93,7 +93,7 @@ func (op OperationRequest) StreamOperations(ctx context.Context, client *Client,
 			return errors.Wrap(err, "error unmarshaling data for operation request")
 		}
 
-		ops, err := operations.UnmarshalOperation(baseRecord.GetType(), data)
+		ops, err := operations.UnmarshalOperation(baseRecord.GetTypeI(), data)
 		if err != nil {
 			return errors.Wrap(err, "unmarshaling to the correct operation type")
 		}

--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -204,7 +204,7 @@ func (this Base) GetType() string {
 	return this.Type
 }
 
-// GetType returns the ID of type of operation
+// GetTypeI returns the ID of type of operation
 func (this Base) GetTypeI() int32 {
 	return this.TypeI
 }

--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -13,15 +13,11 @@ import (
 // OperationTypeNames maps from operation type to the string used to represent that type
 // in horizon's JSON responses
 var TypeNames = map[xdr.OperationType]string{
-	xdr.OperationTypeCreateAccount: "create_account",
-	xdr.OperationTypePayment:       "payment",
-	xdr.OperationTypePathPayment:   "path_payment",
-	// Deprecated - remove in: horizon-v0.18.0
-	// Change name to `manage_sell_offer`
-	xdr.OperationTypeManageSellOffer: "manage_offer",
-	// Deprecated - remove in: horizon-v0.18.0
-	// Change name to `create_passive_sell_offer`
-	xdr.OperationTypeCreatePassiveSellOffer: "create_passive_offer",
+	xdr.OperationTypeCreateAccount:          "create_account",
+	xdr.OperationTypePayment:                "payment",
+	xdr.OperationTypePathPayment:            "path_payment",
+	xdr.OperationTypeManageSellOffer:        "manage_sell_offer",
+	xdr.OperationTypeCreatePassiveSellOffer: "create_passive_sell_offer",
 	xdr.OperationTypeSetOptions:             "set_options",
 	xdr.OperationTypeChangeTrust:            "change_trust",
 	xdr.OperationTypeAllowTrust:             "allow_trust",
@@ -208,6 +204,11 @@ func (this Base) GetType() string {
 	return this.Type
 }
 
+// GetType returns the ID of type of operation
+func (this Base) GetTypeI() int32 {
+	return this.TypeI
+}
+
 func (this Base) GetID() string {
 	return this.ID
 }
@@ -251,7 +252,7 @@ func (ops *OperationsPage) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		op, err := UnmarshalOperation(b.Type, dataString)
+		op, err := UnmarshalOperation(b.TypeI, dataString)
 		if err != nil {
 			return err
 		}
@@ -264,81 +265,81 @@ func (ops *OperationsPage) UnmarshalJSON(data []byte) error {
 }
 
 // UnmarshalOperation decodes responses to the correct operation struct
-func UnmarshalOperation(operationType string, dataString []byte) (ops Operation, err error) {
-	switch operationType {
-	case TypeNames[xdr.OperationTypeCreateAccount]:
+func UnmarshalOperation(operationTypeID int32, dataString []byte) (ops Operation, err error) {
+	switch xdr.OperationType(operationTypeID) {
+	case xdr.OperationTypeCreateAccount:
 		var op CreateAccount
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return
 		}
 		ops = op
-	case TypeNames[xdr.OperationTypePathPayment]:
+	case xdr.OperationTypePathPayment:
 		var op PathPayment
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return
 		}
 		ops = op
-	case TypeNames[xdr.OperationTypePayment]:
+	case xdr.OperationTypePayment:
 		var op Payment
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return
 		}
 		ops = op
-	case TypeNames[xdr.OperationTypeManageSellOffer]:
+	case xdr.OperationTypeManageSellOffer:
 		var op ManageSellOffer
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return
 		}
 		ops = op
-	case TypeNames[xdr.OperationTypeCreatePassiveSellOffer]:
+	case xdr.OperationTypeCreatePassiveSellOffer:
 		var op CreatePassiveSellOffer
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return
 		}
 		ops = op
-	case TypeNames[xdr.OperationTypeSetOptions]:
+	case xdr.OperationTypeSetOptions:
 		var op SetOptions
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return
 		}
 		ops = op
-	case TypeNames[xdr.OperationTypeChangeTrust]:
+	case xdr.OperationTypeChangeTrust:
 		var op ChangeTrust
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return
 		}
 		ops = op
-	case TypeNames[xdr.OperationTypeAllowTrust]:
+	case xdr.OperationTypeAllowTrust:
 		var op AllowTrust
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return
 		}
 		ops = op
-	case TypeNames[xdr.OperationTypeAccountMerge]:
+	case xdr.OperationTypeAccountMerge:
 		var op AccountMerge
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return
 		}
 		ops = op
-	case TypeNames[xdr.OperationTypeInflation]:
+	case xdr.OperationTypeInflation:
 		var op Inflation
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return
 		}
 		ops = op
-	case TypeNames[xdr.OperationTypeManageData]:
+	case xdr.OperationTypeManageData:
 		var op ManageData
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return
 		}
 		ops = op
-	case TypeNames[xdr.OperationTypeBumpSequence]:
+	case xdr.OperationTypeBumpSequence:
 		var op BumpSequence
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return
 		}
 		ops = op
-	case TypeNames[xdr.OperationTypeManageBuyOffer]:
+	case xdr.OperationTypeManageBuyOffer:
 		var op ManageBuyOffer
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,11 +6,18 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
-## Unreleased
+## v0.18.0
 
-## Breaking changes
+### Breaking changes
 
-Horizon requires Postgres 9.5+.
+* Horizon requires Postgres 9.5+.
+* The following table presents breaking changes in Horizon responses:
+
+Removed | Use
+-|-
+`manage_offer` operation type | `manage_sell_offer` operation type
+`create_passive_offer` operation type | `create_passive_sell_offer` operation type
+`/operation_fee_stats` endpoint | `/fee_stats` endpoint
 
 ### Changes
 

--- a/services/horizon/internal/actions_operation_fee_stats_test.go
+++ b/services/horizon/internal/actions_operation_fee_stats_test.go
@@ -84,7 +84,7 @@ func TestOperationFeeTestsActions_Show(t *testing.T) {
 	}
 
 	for _, kase := range testCases {
-		t.Run("/operation_fee_stats", func(t *testing.T) {
+		t.Run("/fee_stats", func(t *testing.T) {
 			ht := StartHTTPTest(t, kase.scenario)
 			defer ht.Finish()
 
@@ -94,7 +94,7 @@ func TestOperationFeeTestsActions_Show(t *testing.T) {
 
 			ht.App.UpdateOperationFeeStatsState()
 
-			w := ht.Get("/operation_fee_stats")
+			w := ht.Get("/fee_stats")
 
 			if ht.Assert.Equal(200, w.Code) {
 				var result map[string]string

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -194,8 +194,6 @@ func (w *web) mustInstallActions(enableAssetStats bool, friendbotURL *url.URL) {
 
 	// Network state related endpoints
 	r.Get("/fee_stats", OperationFeeStatsAction{}.Handle)
-	// Deprecated - remove in: horizon-v0.18.0
-	r.Get("/operation_fee_stats", OperationFeeStatsAction{}.Handle)
 
 	// friendbot
 	if friendbotURL != nil {


### PR DESCRIPTION
@poliha I changed the way `UnmarshalOperation` function works to make it compatible with versions pre 0.18.0 and 0.18.x. It's now using `type_i` to determine operation type.