### PR TITLE
services/horizon: Revert max-db-connections config param

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -21,6 +21,11 @@ Removed | Use
 
 ### Changes
 
+* The following new config parameters were added. When old `max-db-connections` config parameter is set, it has a priority over the the new params. Run `horizon help` for more information.
+  * `horizon-db-max-open-connections`,
+  * `horizon-db-max-idle-connections`,
+  * `core-db-max-open-connections`,
+  * `core-db-max-idle-connections`.
 * Improved `horizon db reingest range` command.
 * Fix "int64: value out of range" errors in trade aggregations (#1319).
 

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -91,6 +91,13 @@ var configOpts = []*support.ConfigOption{
 		Usage:       "tcp port to listen on for http requests",
 	},
 	&support.ConfigOption{
+		Name:        "max-db-connections",
+		ConfigKey:   &config.MaxDBConnections,
+		OptType:     types.Int,
+		FlagDefault: 0,
+		Usage:       "when set has a priority over horizon-db-max-open-connections, horizon-db-max-idle-connections, core-db-max-open-connections, core-db-max-idle-connections. max horizon database open connections. may need to be increased when responses are slow but DB CPU is normal",
+	},
+	&support.ConfigOption{
 		Name:        "horizon-db-max-open-connections",
 		ConfigKey:   &config.HorizonDBMaxOpenConnections,
 		OptType:     types.Int,
@@ -101,7 +108,7 @@ var configOpts = []*support.ConfigOption{
 		Name:        "horizon-db-max-idle-connections",
 		ConfigKey:   &config.HorizonDBMaxIdleConnections,
 		OptType:     types.Int,
-		FlagDefault: 4,
+		FlagDefault: 20,
 		Usage:       "max horizon database idle connections. may need to be set to the same value as horizon-db-max-open-connections when responses are slow and DB CPU is normal, because it may indicate that a lot of time is spent closing/opening idle connections. This can happen in case of high variance in number of requests. must be equal or lower than max open connections",
 	},
 	&support.ConfigOption{
@@ -115,7 +122,7 @@ var configOpts = []*support.ConfigOption{
 		Name:        "core-db-max-idle-connections",
 		ConfigKey:   &config.CoreDBMaxIdleConnections,
 		OptType:     types.Int,
-		FlagDefault: 4,
+		FlagDefault: 20,
 		Usage:       "max core database idle connections. may need to be set to the same value as core-db-max-open-connections when responses are slow and DB CPU is normal, because it may indicate that a lot of time is spent closing/opening idle connections. This can happen in case of high variance in number of requests. must be equal or lower than max open connections",
 	},
 	&support.ConfigOption{
@@ -330,6 +337,15 @@ func initConfig() {
 
 	// Configure log level
 	log.DefaultLogger.Logger.SetLevel(config.LogLevel)
+
+	// Configure DB params. When config.MaxDBConnections is set, set other
+	// DB params to that value for backward compatibility.
+	if config.MaxDBConnections != 0 {
+		config.HorizonDBMaxOpenConnections = config.MaxDBConnections
+		config.HorizonDBMaxIdleConnections = config.MaxDBConnections
+		config.CoreDBMaxOpenConnections = config.MaxDBConnections
+		config.CoreDBMaxIdleConnections = config.MaxDBConnections
+	}
 }
 
 func Execute() {

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -15,19 +15,22 @@ type Config struct {
 	StellarCoreDatabaseURL string
 	StellarCoreURL         string
 	Port                   uint
-	// Database connection pool configuration
+
+	// MaxDBConnections has a priority over all 4 values below.
+	MaxDBConnections            int
 	HorizonDBMaxOpenConnections int
 	HorizonDBMaxIdleConnections int
 	CoreDBMaxOpenConnections    int
 	CoreDBMaxIdleConnections    int
-	SSEUpdateFrequency          time.Duration
-	ConnectionTimeout           time.Duration
-	RateQuota                   *throttled.RateQuota
-	RateLimitRedisKey           string
-	RedisURL                    string
-	FriendbotURL                *url.URL
-	LogLevel                    logrus.Level
-	LogFile                     string
+
+	SSEUpdateFrequency time.Duration
+	ConnectionTimeout  time.Duration
+	RateQuota          *throttled.RateQuota
+	RateLimitRedisKey  string
+	RedisURL           string
+	FriendbotURL       *url.URL
+	LogLevel           logrus.Level
+	LogFile            string
 	// MaxPathLength is the maximum length of the path returned by `/paths` endpoint.
 	MaxPathLength     uint
 	NetworkPassphrase string


### PR DESCRIPTION
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.

## Summary

This PR fixes #915 to be backward compatible. When `max-db-connections` is set, new DB params are ignored.