### PR TITLE
exp/ingest/pipeline: Pass ctx with cancel to processors and return errors channel

### DIFF
--- a/exp/ingest/pipeline/main.go
+++ b/exp/ingest/pipeline/main.go
@@ -37,7 +37,12 @@ type multiWriteCloser struct {
 
 type Pipeline struct {
 	rootStateProcessor *PipelineNode
-	done               bool
+
+	doneMutex sync.Mutex
+	done      bool
+
+	cancelledMutex sync.Mutex
+	cancelled      bool
 }
 
 type PipelineNode struct {

--- a/exp/ingest/pipeline/main.go
+++ b/exp/ingest/pipeline/main.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -61,7 +62,56 @@ type StateProcessor interface {
 	// written and `Close()` on `io.StateReadCloser` when reading is finished.
 	// Data required by following processors (like aggregated data) should be saved in
 	// `Store`. Read `Store` godoc to understand how to use it.
-	ProcessState(store *Store, readCloser io.StateReadCloser, writeCloser io.StateWriteCloser) (err error)
+	// The first argument `ctx` is a context with cancel. Processor should monitor
+	// `ctx.Done()` channel and exit when it returns a value. This can happen when
+	// pipeline execution is interrupted, ex. due to an error.
+	//
+	// Given all information above `ProcessState` should always look like this:
+	//
+	//    func (p *Processor) ProcessState(ctx context.Context, store *pipeline.Store, r io.StateReadCloser, w io.StateWriteCloser) error {
+	//    	defer r.Close()
+	//    	defer w.Close()
+	//
+	//    	// Some pre code...
+	//
+	//    	for {
+	//    		entry, err := r.Read()
+	//    		if err != nil {
+	//    			if err == io.EOF {
+	//    				break
+	//    			} else {
+	//    				return errors.Wrap(err, "Error reading from StateReadCloser in [ProcessorName]")
+	//    			}
+	//    		}
+	//
+	//    		// Process entry...
+	//
+	//    		// Write to StateWriteCloser if needed but exit if pipe is closed:
+	//    		err := w.Write(entry)
+	//    		if err != nil {
+	//    			if err == io.ErrClosedPipe {
+	//    				//    Reader does not need more data
+	//    				return nil
+	//    			}
+	//    			return errors.Wrap(err, "Error writing to StateWriteCloser in [ProcessorName]")
+	//    		}
+	//
+	//    		// Return errors if needed...
+	//
+	//    		// Exit when pipeline terminated due to an error in another processor...
+	//    		select {
+	//    		case <-ctx.Done():
+	//    			return nil
+	//    		default:
+	//    			continue
+	//    		}
+	//    	}
+	//
+	//    	// Some post code...
+	//
+	//    	return nil
+	//    }
+	ProcessState(context.Context, *Store, io.StateReadCloser, io.StateWriteCloser) error
 	// IsConcurrent defines if processing pipeline should start a single instance
 	// of the processor or multiple instances. Multiple instances will read
 	// from the same StateReader and write to the same StateWriter.

--- a/exp/ingest/pipeline/pipeline.go
+++ b/exp/ingest/pipeline/pipeline.go
@@ -65,6 +65,13 @@ func (p *Pipeline) AddStateProcessorTree(rootProcessor *PipelineNode) {
 }
 
 func (p *Pipeline) ProcessState(readCloser io.StateReadCloser) <-chan error {
+	p.doneMutex.Lock()
+	if p.done {
+		panic("Pipeline already running or done...")
+	}
+	p.done = true
+	p.doneMutex.Unlock()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	return p.processStateNode(ctx, &Store{}, p.rootStateProcessor, readCloser, cancel)
 }
@@ -99,6 +106,14 @@ func (p *Pipeline) processStateNode(ctx context.Context, store *Store, node *Pip
 
 			err := node.Processor.ProcessState(ctx, store, readCloser, writeCloser)
 			if err != nil {
+				// Protect from cancelling twice and sending multiple errors to err channel
+				p.cancelledMutex.Lock()
+				defer p.cancelledMutex.Unlock()
+
+				if p.cancelled {
+					return
+				}
+				p.cancelled = true
 				cancel()
 				errorChan <- err
 			}

--- a/exp/ingest/pipeline/pipeline.go
+++ b/exp/ingest/pipeline/pipeline.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -63,11 +64,12 @@ func (p *Pipeline) AddStateProcessorTree(rootProcessor *PipelineNode) {
 	p.rootStateProcessor = rootProcessor
 }
 
-func (p *Pipeline) ProcessState(readCloser io.StateReadCloser) (done chan error) {
-	return p.processStateNode(&Store{}, p.rootStateProcessor, readCloser)
+func (p *Pipeline) ProcessState(readCloser io.StateReadCloser) <-chan error {
+	ctx, cancel := context.WithCancel(context.Background())
+	return p.processStateNode(ctx, &Store{}, p.rootStateProcessor, readCloser, cancel)
 }
 
-func (p *Pipeline) processStateNode(store *Store, node *PipelineNode, readCloser io.StateReadCloser) chan error {
+func (p *Pipeline) processStateNode(ctx context.Context, store *Store, node *PipelineNode, readCloser io.StateReadCloser, cancel context.CancelFunc) <-chan error {
 	outputs := make([]io.StateWriteCloser, len(node.Children))
 
 	for i := range outputs {
@@ -88,30 +90,64 @@ func (p *Pipeline) processStateNode(store *Store, node *PipelineNode, readCloser
 		closeAfter: jobs,
 	}
 
+	errorChan := make(chan error)
+
 	for i := 1; i <= jobs; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 
-			err := node.Processor.ProcessState(store, readCloser, writeCloser)
+			err := node.Processor.ProcessState(ctx, store, readCloser, writeCloser)
 			if err != nil {
-				// TODO return to pipeline error channel
-				panic(err)
+				cancel()
+				errorChan <- err
 			}
 		}()
 	}
 
+	finishUpdatingStats := p.updateStats(node, readCloser, writeCloser)
+
+	for i, child := range node.Children {
+		wg.Add(1)
+		go func(i int, child *PipelineNode) {
+			defer wg.Done()
+			done := p.processStateNode(ctx, store, child, outputs[i].(*bufferedStateReadWriteCloser), cancel)
+			err := <-done
+			if err != nil {
+				errorChan <- err
+			}
+		}(i, child)
+	}
+
 	go func() {
-		// Update stats
+		wg.Wait()
+		finishUpdatingStats <- true
+		select {
+		case <-ctx.Done():
+			// Do nothing, err already sent to a channel...
+		default:
+			errorChan <- nil
+		}
+	}()
+
+	return errorChan
+}
+
+func (p *Pipeline) updateStats(node *PipelineNode, readCloser io.StateReadCloser, writeCloser *multiWriteCloser) chan<- bool {
+	// Update stats
+	interval := time.Second
+	done := make(chan bool)
+	ticker := time.NewTicker(interval)
+
+	go func() {
+		defer ticker.Stop()
+
 		for {
 			// This is not thread-safe: check if Mutex slows it down a lot...
 			readBuffer, readBufferIsBufferedStateReadWriteCloser := readCloser.(*bufferedStateReadWriteCloser)
-			writeBuffer := writeCloser
 
-			interval := time.Second
-
-			node.writesPerSecond = (writeBuffer.wroteEntries - node.wroteEntries) * int(time.Second/interval)
-			node.wroteEntries = writeBuffer.wroteEntries
+			node.writesPerSecond = (writeCloser.wroteEntries - node.wroteEntries) * int(time.Second/interval)
+			node.wroteEntries = writeCloser.wroteEntries
 
 			if readBufferIsBufferedStateReadWriteCloser {
 				node.readsPerSecond = (readBuffer.readEntries - node.readEntries) * int(time.Second/interval)
@@ -119,24 +155,14 @@ func (p *Pipeline) processStateNode(store *Store, node *PipelineNode, readCloser
 				node.queuedEntries = readBuffer.QueuedEntries()
 			}
 
-			time.Sleep(interval)
+			select {
+			case <-ticker.C:
+				continue
+			case <-done:
+				// Pipeline done
+				return
+			}
 		}
-	}()
-
-	for i, child := range node.Children {
-		wg.Add(1)
-		go func(i int, child *PipelineNode) {
-			defer wg.Done()
-			done := p.processStateNode(store, child, outputs[i].(*bufferedStateReadWriteCloser))
-			<-done
-		}(i, child)
-	}
-
-	done := make(chan error)
-
-	go func() {
-		wg.Wait()
-		done <- nil
 	}()
 
 	return done

--- a/exp/ingest/pipeline/pipeline_test.go
+++ b/exp/ingest/pipeline/pipeline_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"runtime"
@@ -244,7 +245,7 @@ type PassthroughProcessor struct {
 	SimpleProcessor
 }
 
-func (p *PassthroughProcessor) ProcessState(store *Store, r io.StateReadCloser, w io.StateWriteCloser) error {
+func (p *PassthroughProcessor) ProcessState(ctx context.Context, store *Store, r io.StateReadCloser, w io.StateWriteCloser) error {
 	defer w.Close()
 	defer r.Close()
 
@@ -266,6 +267,13 @@ func (p *PassthroughProcessor) ProcessState(store *Store, r io.StateReadCloser, 
 			}
 			return err
 		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			continue
+		}
 	}
 
 	return nil
@@ -285,7 +293,7 @@ type EntryTypeFilter struct {
 	Type xdr.LedgerEntryType
 }
 
-func (p *EntryTypeFilter) ProcessState(store *Store, r io.StateReadCloser, w io.StateWriteCloser) error {
+func (p *EntryTypeFilter) ProcessState(ctx context.Context, store *Store, r io.StateReadCloser, w io.StateWriteCloser) error {
 	defer w.Close()
 	defer r.Close()
 
@@ -309,6 +317,13 @@ func (p *EntryTypeFilter) ProcessState(store *Store, r io.StateReadCloser, w io.
 				return err
 			}
 		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			continue
+		}
 	}
 
 	return nil
@@ -324,7 +339,7 @@ type AccountsForSignerProcessor struct {
 	Signer string
 }
 
-func (p *AccountsForSignerProcessor) ProcessState(store *Store, r io.StateReadCloser, w io.StateWriteCloser) error {
+func (p *AccountsForSignerProcessor) ProcessState(ctx context.Context, store *Store, r io.StateReadCloser, w io.StateWriteCloser) error {
 	defer w.Close()
 	defer r.Close()
 
@@ -355,6 +370,13 @@ func (p *AccountsForSignerProcessor) ProcessState(store *Store, r io.StateReadCl
 				break
 			}
 		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			continue
+		}
 	}
 
 	return nil
@@ -369,7 +391,7 @@ type CountPrefixProcessor struct {
 	Prefix string
 }
 
-func (p *CountPrefixProcessor) ProcessState(store *Store, r io.StateReadCloser, w io.StateWriteCloser) error {
+func (p *CountPrefixProcessor) ProcessState(ctx context.Context, store *Store, r io.StateReadCloser, w io.StateWriteCloser) error {
 	defer w.Close()
 	defer r.Close()
 
@@ -403,6 +425,13 @@ func (p *CountPrefixProcessor) ProcessState(store *Store, r io.StateReadCloser, 
 			// Make it slower to test full buffer
 			// time.Sleep(50 * time.Millisecond)
 		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			continue
+		}
 	}
 
 	store.Lock()
@@ -428,7 +457,7 @@ type PrintCountersProcessor struct {
 	SimpleProcessor
 }
 
-func (p *PrintCountersProcessor) ProcessState(store *Store, r io.StateReadCloser, w io.StateWriteCloser) error {
+func (p *PrintCountersProcessor) ProcessState(ctx context.Context, store *Store, r io.StateReadCloser, w io.StateWriteCloser) error {
 	defer w.Close()
 	defer r.Close()
 
@@ -441,6 +470,13 @@ func (p *PrintCountersProcessor) ProcessState(store *Store, r io.StateReadCloser
 			} else {
 				return err
 			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			continue
 		}
 	}
 
@@ -466,7 +502,7 @@ type PrintAllProcessor struct {
 	SimpleProcessor
 }
 
-func (p *PrintAllProcessor) ProcessState(store *Store, r io.StateReadCloser, w io.StateWriteCloser) error {
+func (p *PrintAllProcessor) ProcessState(ctx context.Context, store *Store, r io.StateReadCloser, w io.StateWriteCloser) error {
 	defer w.Close()
 	defer r.Close()
 
@@ -483,6 +519,13 @@ func (p *PrintAllProcessor) ProcessState(store *Store, r io.StateReadCloser, w i
 
 		entries++
 		// fmt.Printf("%+v\n", entry)
+
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			continue
+		}
 	}
 
 	fmt.Printf("Found %d entries\n", entries)

--- a/exp/tools/accounts-for-signer/filters.go
+++ b/exp/tools/accounts-for-signer/filters.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sync"
@@ -36,7 +37,7 @@ type EntryTypeFilter struct {
 	Type xdr.LedgerEntryType
 }
 
-func (p *EntryTypeFilter) ProcessState(store *pipeline.Store, r io.StateReadCloser, w io.StateWriteCloser) error {
+func (p *EntryTypeFilter) ProcessState(ctx context.Context, store *pipeline.Store, r io.StateReadCloser, w io.StateWriteCloser) error {
 	defer r.Close()
 	defer w.Close()
 
@@ -60,6 +61,13 @@ func (p *EntryTypeFilter) ProcessState(store *pipeline.Store, r io.StateReadClos
 				return err
 			}
 		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			continue
+		}
 	}
 
 	return nil
@@ -75,7 +83,7 @@ type AccountsForSignerProcessor struct {
 	Signer string
 }
 
-func (p *AccountsForSignerProcessor) ProcessState(store *pipeline.Store, r io.StateReadCloser, w io.StateWriteCloser) error {
+func (p *AccountsForSignerProcessor) ProcessState(ctx context.Context, store *pipeline.Store, r io.StateReadCloser, w io.StateWriteCloser) error {
 	defer r.Close()
 	defer w.Close()
 
@@ -106,6 +114,13 @@ func (p *AccountsForSignerProcessor) ProcessState(store *pipeline.Store, r io.St
 				break
 			}
 		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			continue
+		}
 	}
 
 	return nil
@@ -124,7 +139,7 @@ type PrintAllProcessor struct {
 	Filename string
 }
 
-func (p *PrintAllProcessor) ProcessState(store *pipeline.Store, r io.StateReadCloser, w io.StateWriteCloser) error {
+func (p *PrintAllProcessor) ProcessState(ctx context.Context, store *pipeline.Store, r io.StateReadCloser, w io.StateWriteCloser) error {
 	defer r.Close()
 	defer w.Close()
 
@@ -158,10 +173,18 @@ func (p *PrintAllProcessor) ProcessState(store *pipeline.Store, r io.StateReadCl
 			foundEntries++
 			if foundEntries == 3 {
 				// We only want a few entries...
+				// return errors.New("Some error")
 				return nil
 			}
 		default:
 			// Ignore for now
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			continue
 		}
 	}
 


### PR DESCRIPTION
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.

## Summary

This PR passes `ctx` with cancel to processors and return errors channel in `pipeline.ProcessState`. This is done to gracefully exit all go routines in case of errors and when processing is done.

This has been tested using "Accounts for Signer" pipeline.

Close #1342.

### Known limitations & issues

It seems that even though go routines exit properly (`runtime.NumGoroutine()` returns 1: `main()`)  memory is not released (possibly objects in `MemoryStateReader` and `bufferedStateReadWriteCloser` buffered channels). We should decide later if we want to drain these channels manually or remove references to readers so they are garbage collected. Tracking in #1346.