### PR TITLE
exp/keystore: update spec

### DIFF
--- a/exp/services/keystore/spec.md
+++ b/exp/services/keystore/spec.md
@@ -28,7 +28,7 @@ is no need for a userid argument to the endpoints below.
 
 ### Raw Key Data
 
-RawKeyData Object:
+*RawKeyData Object:*
 
 ```typescript
 interface RawKeyData {
@@ -49,7 +49,7 @@ The clients will transmit the encrypted keys blob as a base64 URL encoded string
 
 ### Encrypted Key Data
 
-EncryptedKeysData Object:
+*EncryptedKeysData Object:*
 
 ```typescript
 interface EncryptedKeysData {

--- a/exp/services/keystore/spec.md
+++ b/exp/services/keystore/spec.md
@@ -61,22 +61,24 @@ interface EncryptedKeysData {
 }
 ```
 
-### /store-keys
+We support three different kinds of HTTP methods to manipulate keys:
 
-Store Keys Request:
+### PUT /keys
+
+Put Keys Request:
 
 ```typescript
-interface StoreKeysRequest {
+interface PutKeysRequest {
 	encrypterName: string;
 	salt: string;
 	keysBlob: string;
 }
 ```
 
-Store Keys Response:
+Put Keys Response:
 
 ```typescript
-type StoreKeysResponse = EncryptedKeysData;
+type PutKeysResponse = EncryptedKeysData;
 ```
 
 <details><summary>Errors</summary>
@@ -91,18 +93,18 @@ TBD
 ```
 </details>
 
-### /load-keys
+### GET /keys
 
-Load Keys Request:
+Get Keys Request:
 
 This endpoint will return the keys blob corresponding to the auth token
 in the request header, if the token is valid. This endpoint does not take
 any parameter.
 
-Load Keys Response:
+Get Keys Response:
 
 ```typescript
-type LoadKeysResponse = EncryptedKeysData;
+type GetKeysResponse = EncryptedKeysData;
 ```
 <details><summary>Errors</summary>
 
@@ -116,7 +118,7 @@ TBD
 ```
 </details>
 
-### /delete-keys
+### DELETE /keys
 
 Delete Keys Request:
 

--- a/exp/services/keystore/spec.md
+++ b/exp/services/keystore/spec.md
@@ -26,35 +26,36 @@ is no need for a userid argument to the endpoints below.
 
 <img src=attachments/2019-04-24-keystore-auth-flows.png>
 
-### Encrypted Key
+### Raw Key Data
 
-EncryptedKey Object:
+RawKeyData Object:
 
 ```typescript
-interface EncryptedKey {
+interface RawKeyData {
 	keyType: string;
 	publicKey: string;
+	privateKey: string;
 	path?: string;
 	extra?: any;
-	encrypterName: string;
-	encryptedPrivateKey: string;
-	salt: string;
 }
 ```
 
+```typescript
+type RawKeys = RawKeyData[]
+```
+
+The clients will encrypt RawKeys with a salt based on the encrypter they use.
+The clients will transmit the encrypted keys blob as a base64 URL encoded string.
+
 ### Encrypted Key Data
 
-EncryptedKeyData Object:
+EncryptedKeysData Object:
 
 ```typescript
-interface EncryptedKeyData {
-	keyType: string;
-	publicKey: string;
-	path?: string;
-	extra?: any;
+interface EncryptedKeysData {
 	encrypterName: string;
-	encryptedPrivateKey: string;
 	salt: string;
+	keysBlob: string;
 	creationTime: number;
 	modifiedTime: number;	
 }
@@ -66,16 +67,16 @@ Store Keys Request:
 
 ```typescript
 interface StoreKeysRequest {
-	encryptedKeys: EncryptedKey[];
+	encrypterName: string;
+	salt: string;
+	keysBlob: string;
 }
 ```
 
 Store Keys Response:
 
 ```typescript
-interface StoreKeysResponse {
-	encryptedKeys: EncryptedKeyData[];
-}
+type StoreKeysResponse = EncryptedKeysData;
 ```
 
 <details><summary>Errors</summary>
@@ -90,19 +91,18 @@ TBD
 ```
 </details>
 
-### /load-all-keys
+### /load-keys
 
-Load All Keys Request:
+Load Keys Request:
 
-This endpoint currently doesn't take any parameters.
-We can potentially add some filters in the request.
+This endpoint will return the keys blob corresponding to the auth token
+in the request header, if the token is valid. This endpoint does not take
+any parameter.
 
-Load All Keys Response:
+Load Keys Response:
 
 ```typescript
-interface LoadAllKeysResponse {
-	encryptedKeys: EncryptedKeyData[];
-}
+type LoadKeysResponse = EncryptedKeysData;
 ```
 <details><summary>Errors</summary>
 
@@ -116,77 +116,18 @@ TBD
 ```
 </details>
 
-### /load-key
+### /delete-keys
 
-Load Key Request:
+Delete Keys Request:
 
-```typescript
-interface LoadKeyRequest {
-	publicKey: string;
-}
-```
+This endpoint will delete the keys blob corresponding to the auth token
+in the request header and return the deleted keys blob to the client, if
+the token is valid. This endpoint does not take any parameter.
 
-Load Key Response:
+Delete Keys Response:
 
 ```typescript
-type LoadKeyResponse = EncryptedKeyData;
-```
-
-<details><summary>Errors</summary>
-
-TBD
-```json
-{
-	"code": "some error code",
-	"message": "some error message",
-	"retriable": false,
-}
-```
-</details>
-
-### /update-keys
-
-Update Keys Request:
-
-```typescript
-interface UpdateKeysRequest {
-	encryptedKeys: EncryptedKey[];
-}
-```
-
-Update Keys Response:
-
-```typescript
-interface UpdateKeysResponse {
-	encryptedKeys: EncryptedKeyData[];
-}
-```
-<details><summary>Errors</summary>
-
-TBD
-```json
-{
-	"code": "some error code",
-	"message": "some error message",
-	"retriable": false,
-}
-```
-</details>
-
-### /remove-key
-
-Remove Key Request:
-
-```typescript
-interface RemoveKeyRequest {
-	publicKey: string;
-}
-```
-
-Remove Key Response:
-
-```typescript
-type RemoveKeyResponse = EncryptedKeyData;
+type DeleteKeysResponse = EncryptedKeysData;
 ```
 
 <details><summary>Errors</summary>


### PR DESCRIPTION
We decided to encrypt all users' public keys in case the keystore gets
hacked. As a result, each user will only have one row in the database of
the keystore, and all keys belonging to a user will be stored in the same blob.

This means the `/update-key` endpoint will be implemented on the client
side such that it will call `/load-keys` endpoint, decrypt the blob,
modified the blob, re-encrypt the blob, and finally call `/store-keys`
endpoint. Similar logic applies to `/remove-key` endpoint.
