### PR TITLE
Use new sdk for bridge and compliance. 

### DIFF
--- a/services/bridge/internal/handlers/request_handler_authorize.go
+++ b/services/bridge/internal/handlers/request_handler_authorize.go
@@ -5,10 +5,11 @@ import (
 	"net/http"
 
 	log "github.com/sirupsen/logrus"
-	b "github.com/stellar/go/build"
 	hc "github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/services/internal/bridge-compliance-shared/http/helpers"
 	"github.com/stellar/go/services/internal/bridge-compliance-shared/protocols/bridge"
+	"github.com/stellar/go/txnbuild"
 )
 
 // Authorize implements /authorize endpoint
@@ -33,16 +34,27 @@ func (rh *RequestHandler) Authorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	operationMutator := b.AllowTrust(
-		b.Trustor{request.AccountID},
-		b.Authorize{true},
-		b.AllowTrustAsset{request.AssetCode},
-	)
+	kp, err := keypair.Parse(rh.Config.Accounts.AuthorizingSeed)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Error("Error parsing authorizing seed")
+		helpers.Write(w, helpers.InternalServerError)
+	}
+
+	sourceAccount := kp.Address()
+
+	allowTrustOp := bridge.AllowTrustOperationBody{
+		Source:    &sourceAccount,
+		Authorize: true,
+		Trustor:   request.AccountID,
+		AssetCode: request.AssetCode,
+	}
+
+	operationBuilder := allowTrustOp.Build()
 
 	submitResponse, err := rh.TransactionSubmitter.SubmitTransaction(
 		nil,
 		rh.Config.Accounts.AuthorizingSeed,
-		operationMutator,
+		[]txnbuild.Operation{operationBuilder},
 		nil,
 	)
 

--- a/services/bridge/internal/handlers/request_handler_builder.go
+++ b/services/bridge/internal/handlers/request_handler_builder.go
@@ -6,10 +6,11 @@ import (
 	"strconv"
 
 	log "github.com/sirupsen/logrus"
-	b "github.com/stellar/go/build"
 	hc "github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/services/internal/bridge-compliance-shared/http/helpers"
 	"github.com/stellar/go/services/internal/bridge-compliance-shared/protocols/bridge"
+	"github.com/stellar/go/txnbuild"
 )
 
 // Builder implements /builder endpoint
@@ -58,12 +59,13 @@ func (rh *RequestHandler) Builder(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		sequenceNumber, err = strconv.ParseUint(accountResponse.Sequence, 10, 64)
-		if err == nil {
-			// increment sequence number when none is provided
-			sequenceNumber = sequenceNumber + 1
-		}
 	} else {
 		sequenceNumber, err = strconv.ParseUint(request.SequenceNumber, 10, 64)
+		if err == nil {
+			// decrement sequence number when it is provided because txnbuild will autoincrement
+			// to do: remove in txnbuild v2.*
+			sequenceNumber = sequenceNumber - 1
+		}
 	}
 
 	if err != nil {
@@ -72,37 +74,47 @@ func (rh *RequestHandler) Builder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	mutators := []b.TransactionMutator{
-		b.SourceAccount{request.Source},
-		b.Sequence{sequenceNumber},
-		b.Network{rh.Config.NetworkPassphrase},
-	}
-
+	var txOps []txnbuild.Operation
 	for _, operation := range request.Operations {
-		mutators = append(mutators, operation.Body.ToTransactionMutator())
+		txOps = append(txOps, operation.Body.Build())
 	}
 
-	tx, err := b.Transaction(mutators...)
+	tx := txnbuild.Transaction{
+		SourceAccount: &txnbuild.SimpleAccount{AccountID: request.Source, Sequence: int64(sequenceNumber)},
+		Operations:    txOps,
+		Timebounds:    txnbuild.NewInfiniteTimeout(),
+		Network:       rh.Config.NetworkPassphrase,
+	}
 
+	err = tx.Build()
 	if err != nil {
 		log.WithFields(log.Fields{"err": err, "request": request}).Error("TransactionBuilder returned error")
 		helpers.Write(w, helpers.InternalServerError)
 		return
 	}
 
-	txe, err := tx.Sign(request.Signers...)
-	if err != nil {
-		log.WithFields(log.Fields{"err": err, "request": request}).Error("Error signing transaction")
-		helpers.Write(w, helpers.InternalServerError)
-		return
+	for _, s := range request.Signers {
+		kp, err := keypair.Parse(s)
+		if err != nil {
+			log.WithFields(log.Fields{"err": err, "request": request}).Error("Error converting signers to keypairs")
+			helpers.Write(w, helpers.InternalServerError)
+			return
+		}
+
+		err = tx.Sign(kp.(*keypair.Full))
+		if err != nil {
+			log.WithFields(log.Fields{"err": err, "request": request}).Error("Error signing transaction")
+			helpers.Write(w, helpers.InternalServerError)
+			return
+		}
 	}
 
-	txeB64, err := txe.Base64()
+	txeBase64, err := tx.Base64()
 	if err != nil {
 		log.WithFields(log.Fields{"err": err, "request": request}).Error("Error encoding transaction envelope")
 		helpers.Write(w, helpers.InternalServerError)
 		return
 	}
 
-	helpers.Write(w, &bridge.BuilderResponse{TransactionEnvelope: txeB64})
+	helpers.Write(w, &bridge.BuilderResponse{TransactionEnvelope: txeBase64})
 }

--- a/services/bridge/internal/handlers/request_handler_payment.go
+++ b/services/bridge/internal/handlers/request_handler_payment.go
@@ -10,14 +10,16 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/stellar/go/address"
-	b "github.com/stellar/go/build"
 	hc "github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/keypair"
 	hProtocol "github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/txnbuild"
 
 	"github.com/stellar/go/protocols/compliance"
 	"github.com/stellar/go/protocols/federation"
 	shared "github.com/stellar/go/services/internal/bridge-compliance-shared"
 	"github.com/stellar/go/services/internal/bridge-compliance-shared/http/helpers"
+	"github.com/stellar/go/services/internal/bridge-compliance-shared/protocols"
 	"github.com/stellar/go/services/internal/bridge-compliance-shared/protocols/bridge"
 	callback "github.com/stellar/go/services/internal/bridge-compliance-shared/protocols/compliance"
 	"github.com/stellar/go/xdr"
@@ -187,58 +189,68 @@ func (rh *RequestHandler) standardPayment(w http.ResponseWriter, request *bridge
 		return
 	}
 
-	var payWithMutator *b.PayWithPath
-
-	if request.SendMax != "" {
-		// Path payment
-		var sendAsset b.Asset
-		if request.SendAssetCode == "" && request.SendAssetIssuer == "" {
-			sendAsset = b.NativeAsset()
-		} else {
-			sendAsset = b.CreditAsset(request.SendAssetCode, request.SendAssetIssuer)
+	var rSource *string
+	if request.Source != "" {
+		kp, err := keypair.Parse(request.Source)
+		if err != nil {
+			log.WithFields(log.Fields{"error": err}).Error("Unable to convert seed to keypair")
+			helpers.Write(w, helpers.NewInvalidParameterError("source", "Source must be a valid secret seed."))
 		}
-
-		payWith := b.PayWith(sendAsset, request.SendMax)
-
-		for _, asset := range request.Path {
-			payWith = payWith.Through(asset.ToBaseAsset())
-		}
-
-		payWithMutator = &payWith
+		kpAddress := kp.Address()
+		rSource = &kpAddress
 	}
 
-	var operationBuilder interface{}
+	var operationBuilder txnbuild.Operation
 
+	// check if Path payment
+
+	if request.SendMax != "" {
+		paymentOp := bridge.PathPaymentOperationBody{
+			Source:            rSource,
+			SendMax:           request.SendMax,
+			SendAsset:         protocols.Asset{Code: request.SendAssetCode, Issuer: request.SendAssetIssuer},
+			Destination:       request.Destination,
+			DestinationAmount: request.Amount,
+			DestinationAsset:  protocols.Asset{Code: request.AssetCode, Issuer: request.AssetIssuer},
+			Path:              request.Path,
+		}
+
+		operationBuilder = paymentOp.Build()
+	}
+
+	// if payment is to a custom asset
 	if request.AssetCode != "" && request.AssetIssuer != "" {
-		mutators := []interface{}{
-			b.Destination{destinationObject.AccountID},
-			b.CreditAmount{request.AssetCode, request.AssetIssuer, request.Amount},
+		paymentOp := bridge.PaymentOperationBody{
+			Source:      rSource,
+			Destination: request.Destination,
+			Amount:      request.Amount,
+			Asset:       protocols.Asset{Code: request.AssetCode, Issuer: request.AssetIssuer},
 		}
 
-		if payWithMutator != nil {
-			mutators = append(mutators, *payWithMutator)
-		}
+		operationBuilder = paymentOp.Build()
 
-		operationBuilder = b.Payment(mutators...)
+	}
+
+	// if xlm payment
+	// Check if destination account exist
+	accountRequest := hc.AccountRequest{AccountID: destinationObject.AccountID}
+	_, err = rh.Horizon.AccountDetail(accountRequest)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("Error loading account")
+		paymentOp := bridge.CreateAccountOperationBody{
+			Source:          rSource,
+			Destination:     request.Destination,
+			StartingBalance: request.Amount,
+		}
+		operationBuilder = paymentOp.Build()
 	} else {
-		mutators := []interface{}{
-			b.Destination{destinationObject.AccountID},
-			b.NativeAmount{request.Amount},
+		paymentOp := bridge.PaymentOperationBody{
+			Source:      rSource,
+			Destination: request.Destination,
+			Amount:      request.Amount,
+			Asset:       protocols.Asset{Code: request.AssetCode, Issuer: request.AssetIssuer},
 		}
-
-		if payWithMutator != nil {
-			mutators = append(mutators, *payWithMutator)
-		}
-
-		// Check if destination account exist
-		accountRequest := hc.AccountRequest{AccountID: destinationObject.AccountID}
-		_, err = rh.Horizon.AccountDetail(accountRequest)
-		if err != nil {
-			log.WithFields(log.Fields{"error": err}).Error("Error loading account")
-			operationBuilder = b.CreateAccount(mutators...)
-		} else {
-			operationBuilder = b.Payment(mutators...)
-		}
+		operationBuilder = paymentOp.Build()
 	}
 
 	memoType := request.MemoType
@@ -255,7 +267,8 @@ func (rh *RequestHandler) standardPayment(w http.ResponseWriter, request *bridge
 		memo = destinationObject.Memo.Value
 	}
 
-	var memoMutator interface{}
+	var txMemo txnbuild.Memo
+
 	switch {
 	case memoType == "":
 		break
@@ -267,9 +280,9 @@ func (rh *RequestHandler) standardPayment(w http.ResponseWriter, request *bridge
 			helpers.Write(w, helpers.NewInvalidParameterError("memo", "Memo.id must be a number"))
 			return
 		}
-		memoMutator = b.MemoID{id}
+		txMemo = txnbuild.MemoID(id)
 	case memoType == "text":
-		memoMutator = b.MemoText{memo}
+		txMemo = txnbuild.MemoText(memo)
 	case memoType == "hash":
 		var memoBytes []byte
 		memoBytes, err = hex.DecodeString(memo)
@@ -280,15 +293,14 @@ func (rh *RequestHandler) standardPayment(w http.ResponseWriter, request *bridge
 		}
 		var b32 [32]byte
 		copy(b32[:], memoBytes[0:32])
-		hash := xdr.Hash(b32)
-		memoMutator = b.MemoHash{hash}
+		txMemo = txnbuild.MemoHash(b32)
 	default:
 		log.Print("Not supported memo type: ", memoType)
 		helpers.Write(w, helpers.NewInvalidParameterError("memo", "Memo type not supported"))
 		return
 	}
 
-	submitResponse, err := rh.TransactionSubmitter.SubmitTransaction(paymentID, request.Source, operationBuilder, memoMutator)
+	submitResponse, err := rh.TransactionSubmitter.SubmitTransaction(paymentID, request.Source, []txnbuild.Operation{operationBuilder}, txMemo)
 	rh.handleTransactionSubmitResponse(w, submitResponse, err)
 }
 

--- a/services/bridge/internal/submitter/transaction_submitter.go
+++ b/services/bridge/internal/submitter/transaction_submitter.go
@@ -8,19 +8,19 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"github.com/stellar/go/build"
 	hc "github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/bridge/internal/db"
 	shared "github.com/stellar/go/services/internal/bridge-compliance-shared"
 	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
 )
 
 // TransactionSubmitterInterface helps mocking TransactionSubmitter
 type TransactionSubmitterInterface interface {
-	SubmitTransaction(paymentID *string, seed string, operation, memo interface{}) (response hProtocol.TransactionSuccess, err error)
+	SubmitTransaction(paymentID *string, seed string, operation []txnbuild.Operation, memo txnbuild.Memo) (response hProtocol.TransactionSuccess, err error)
 	SignAndSubmitRawTransaction(paymentID *string, seed string, tx *xdr.Transaction) (response hProtocol.TransactionSuccess, err error)
 }
 
@@ -30,7 +30,7 @@ type TransactionSubmitter struct {
 	Accounts      map[string]*Account // seed => *Account
 	AccountsMutex sync.Mutex
 	Database      db.Database
-	Network       build.Network
+	Network       string
 	log           *logrus.Entry
 	now           func() time.Time
 }
@@ -53,7 +53,7 @@ func NewTransactionSubmitter(
 	ts.Horizon = horizon
 	ts.Database = database
 	ts.Accounts = make(map[string]*Account)
-	ts.Network = build.Network{networkPassphrase}
+	ts.Network = networkPassphrase
 	ts.log = logrus.WithFields(logrus.Fields{
 		"service": "TransactionSubmitter",
 	})
@@ -128,7 +128,7 @@ func (ts *TransactionSubmitter) SignAndSubmitRawTransaction(paymentID *string, s
 	tx.SeqNum = xdr.SequenceNumber(account.SequenceNumber)
 	account.Mutex.Unlock()
 
-	hash, err := shared.TransactionHash(tx, ts.Network.Passphrase)
+	hash, err := shared.TransactionHash(tx, ts.Network)
 	if err != nil {
 		ts.log.WithFields(logrus.Fields{"err": err}).Error("Error calculating transaction hash")
 		return
@@ -151,64 +151,21 @@ func (ts *TransactionSubmitter) SignAndSubmitRawTransaction(paymentID *string, s
 		return
 	}
 
-	transactionHashBytes, err := shared.TransactionHash(tx, ts.Network.Passphrase)
+	transactionHashBytes, err := shared.TransactionHash(tx, ts.Network)
 	if err != nil {
 		ts.log.WithFields(logrus.Fields{"err": err}).Warn("Error calculating tx hash")
 		return
 	}
 
-	nullPaymentID := sql.NullString{Valid: false}
-	if paymentID != nil {
-		nullPaymentID = sql.NullString{
-			String: *paymentID,
-			Valid:  true,
-		}
-	}
-
-	sentTransaction := &db.SentTransaction{
-		PaymentID:     nullPaymentID,
-		TransactionID: hex.EncodeToString(transactionHashBytes[:]),
-		Status:        db.SentTransactionStatusSending,
-		Source:        account.Keypair.Address(),
-		SubmittedAt:   ts.now(),
-		EnvelopeXdr:   txeB64,
-	}
-	err = ts.Database.InsertSentTransaction(sentTransaction)
-	if err != nil {
-		ts.log.WithFields(logrus.Fields{"err": err}).Error("Error inserting sent transaction")
-		return
-	}
-
-	ts.log.WithFields(logrus.Fields{"tx": txeB64}).Info("Submitting transaction")
-
 	var herr *hc.Error
-	response, err = ts.Horizon.SubmitTransactionXDR(txeB64)
-	if err == nil {
-		sentTransaction.Status = db.SentTransactionStatusSuccess
-		sentTransaction.Ledger = &response.Ledger
-		now := time.Now()
-		sentTransaction.SucceededAt = &now
-	} else {
+	response, err = ts.SubmitAndSave(paymentID, account.Keypair.Address(), txeB64, hex.EncodeToString(transactionHashBytes[:]))
+	if err != nil {
 		var isHorizonError bool
 		herr, isHorizonError = err.(*hc.Error)
 		if !isHorizonError {
 			ts.log.WithFields(logrus.Fields{"err": err}).Error("Error submitting transaction ", err)
 			return
 		}
-
-		var result string
-		result, err = herr.ResultString()
-		if err != nil {
-			result = errors.Wrap(err, "Error getting tx result").Error()
-		}
-		sentTransaction.Status = db.SentTransactionStatusFailure
-		sentTransaction.ResultXdr = &result
-	}
-
-	err = ts.Database.UpdateSentTransaction(sentTransaction)
-	if err != nil {
-		ts.log.WithFields(logrus.Fields{"err": err}).Error("Error updating sent transaction")
-		return
 	}
 
 	// Sync sequence number
@@ -240,37 +197,108 @@ func (ts *TransactionSubmitter) SignAndSubmitRawTransaction(paymentID *string, s
 }
 
 // SubmitTransaction builds and submits transaction to Stellar network
-func (ts *TransactionSubmitter) SubmitTransaction(paymentID *string, seed string, operation, memo interface{}) (hProtocol.TransactionSuccess, error) {
+func (ts *TransactionSubmitter) SubmitTransaction(paymentID *string, seed string, operation []txnbuild.Operation, memo txnbuild.Memo) (hProtocol.TransactionSuccess, error) {
 	account, err := ts.LoadAccount(seed)
 	if err != nil {
 		return hProtocol.TransactionSuccess{}, errors.Wrap(err, "Error loading an account")
 	}
 
-	operationMutator, ok := operation.(build.TransactionMutator)
-	if !ok {
-		ts.log.Error("Cannot cast operationMutator to build.TransactionMutator")
-		return hProtocol.TransactionSuccess{}, errors.New("Cannot cast operationMutator to build.TransactionMutator")
+	tx := txnbuild.Transaction{
+		SourceAccount: &txnbuild.SimpleAccount{AccountID: account.Keypair.Address(), Sequence: int64(account.SequenceNumber)},
+		Operations:    operation,
+		Timebounds:    txnbuild.NewInfiniteTimeout(),
+		Network:       ts.Network,
+		Memo:          memo,
 	}
 
-	mutators := []build.TransactionMutator{
-		build.SourceAccount{account.Seed},
-		ts.Network,
-		operationMutator,
-	}
-
-	if memo != nil {
-		memoMutator, ok := memo.(build.TransactionMutator)
-		if !ok {
-			ts.log.Error("Cannot cast memo to build.TransactionMutator")
-			return hProtocol.TransactionSuccess{}, errors.New("Cannot cast memo to build.TransactionMutator")
-		}
-		mutators = append(mutators, memoMutator)
-	}
-
-	txBuilder, err := build.Transaction(mutators...)
+	err = tx.Build()
 	if err != nil {
-		return hProtocol.TransactionSuccess{}, errors.Wrap(err, "Error building a transaction")
+		ts.log.Error("Unable to build transaction")
+		return hProtocol.TransactionSuccess{}, errors.Wrap(err, "unable to build transaction")
 	}
 
-	return ts.SignAndSubmitRawTransaction(paymentID, seed, txBuilder.TX)
+	kp, err := keypair.Parse(seed)
+	if err != nil {
+		ts.log.Error("Unable to convert seed to keypair")
+		return hProtocol.TransactionSuccess{}, errors.Wrap(err, "unable to convert seed to keypair")
+	}
+
+	err = tx.Sign(kp.(*keypair.Full))
+	if err != nil {
+		ts.log.Error("Unable to sign transaction")
+		return hProtocol.TransactionSuccess{}, errors.Wrap(err, "unable to sign transaction")
+	}
+
+	txe, err := tx.Base64()
+	if err != nil {
+		ts.log.Error("Unable to encode transaction")
+		return hProtocol.TransactionSuccess{}, errors.Wrap(err, "unable to encode transaction")
+	}
+
+	txHashBytes, err := tx.Hash()
+	if err != nil {
+		ts.log.Error("Unable to get transaction hash")
+		return hProtocol.TransactionSuccess{}, errors.Wrap(err, "unable to get transaction hash")
+	}
+
+	return ts.SubmitAndSave(paymentID, tx.SourceAccount.GetAccountID(), txe, hex.EncodeToString(txHashBytes[:]))
+}
+
+// SubmitAndSave sumbits a transaction to horizon and saves the details in the bridge server database.
+func (ts *TransactionSubmitter) SubmitAndSave(paymentID *string, sourceAccount, txeB64, txHash string) (response hProtocol.TransactionSuccess, err error) {
+	nullPaymentID := sql.NullString{Valid: false}
+	if paymentID != nil {
+		nullPaymentID = sql.NullString{
+			String: *paymentID,
+			Valid:  true,
+		}
+	}
+
+	sentTransaction := &db.SentTransaction{
+		PaymentID:     nullPaymentID,
+		TransactionID: txHash,
+		Status:        db.SentTransactionStatusSending,
+		Source:        sourceAccount,
+		SubmittedAt:   ts.now(),
+		EnvelopeXdr:   txeB64,
+	}
+
+	err = ts.Database.InsertSentTransaction(sentTransaction)
+	if err != nil {
+		ts.log.WithFields(logrus.Fields{"err": err}).Error("Error inserting sent transaction")
+		return
+	}
+
+	ts.log.WithFields(logrus.Fields{"tx": txeB64}).Info("Submitting transaction")
+
+	var herr *hc.Error
+	response, err = ts.Horizon.SubmitTransactionXDR(txeB64)
+	if err == nil {
+		sentTransaction.Status = db.SentTransactionStatusSuccess
+		sentTransaction.Ledger = &response.Ledger
+		now := time.Now()
+		sentTransaction.SucceededAt = &now
+	} else {
+		var isHorizonError bool
+		herr, isHorizonError = err.(*hc.Error)
+		if !isHorizonError {
+			ts.log.WithFields(logrus.Fields{"err": err}).Error("Error submitting transaction ", err)
+			return
+		}
+		var result string
+		result, err = herr.ResultString()
+		if err != nil {
+			result = errors.Wrap(err, "Error getting tx result").Error()
+		}
+		sentTransaction.Status = db.SentTransactionStatusFailure
+		sentTransaction.ResultXdr = &result
+	}
+
+	err = ts.Database.UpdateSentTransaction(sentTransaction)
+	if err != nil {
+		ts.log.WithFields(logrus.Fields{"err": err}).Error("Error updating sent transaction")
+		return
+	}
+
+	return
 }

--- a/services/compliance/internal/handlers/request_handler_send.go
+++ b/services/compliance/internal/handlers/request_handler_send.go
@@ -7,15 +7,16 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stellar/go/address"
-	b "github.com/stellar/go/build"
 	"github.com/stellar/go/clients/stellartoml"
 	"github.com/stellar/go/protocols/compliance"
 	"github.com/stellar/go/protocols/federation"
 	"github.com/stellar/go/services/compliance/internal/db"
 	shared "github.com/stellar/go/services/internal/bridge-compliance-shared"
 	"github.com/stellar/go/services/internal/bridge-compliance-shared/http/helpers"
+	"github.com/stellar/go/services/internal/bridge-compliance-shared/protocols"
+	"github.com/stellar/go/services/internal/bridge-compliance-shared/protocols/bridge"
 	callback "github.com/stellar/go/services/internal/bridge-compliance-shared/protocols/compliance"
-	"github.com/stellar/go/xdr"
+	"github.com/stellar/go/txnbuild"
 )
 
 // HandlerSend implements /send endpoint
@@ -122,62 +123,46 @@ func (rh *RequestHandler) HandlerSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var payWithMutator *b.PayWithPath
+	var rSource *string
+	if request.Source != "" {
+		rSource = &request.Source
+	}
+	var operationBuilder txnbuild.Operation
+
+	// check if Path payment
 
 	if request.SendMax != "" {
-		// Path payment
-		var sendAsset b.Asset
+		var sendAsset protocols.Asset
 		if request.SendAssetCode != "" && request.SendAssetIssuer != "" {
-			sendAsset = b.CreditAsset(request.SendAssetCode, request.SendAssetIssuer)
+			sendAsset = protocols.Asset{Code: request.SendAssetCode, Issuer: request.SendAssetIssuer}
 		} else if request.SendAssetCode == "" && request.SendAssetIssuer == "" {
-			sendAsset = b.NativeAsset()
+			sendAsset = protocols.Asset{}
 		} else {
 			log.Print("Missing send asset param.")
 			helpers.Write(w, helpers.NewMissingParameter("send asset"))
 			return
 		}
 
-		payWith := b.PayWith(sendAsset, request.SendMax)
-
-		for _, asset := range request.Path {
-			if asset.Code == "" && asset.Issuer == "" {
-				payWith = payWith.Through(b.NativeAsset())
-			} else {
-				payWith = payWith.Through(b.CreditAsset(asset.Code, asset.Issuer))
-			}
+		paymentOp := bridge.PathPaymentOperationBody{
+			Source:            rSource,
+			SendMax:           request.SendMax,
+			SendAsset:         sendAsset,
+			Destination:       destinationObject.AccountID,
+			DestinationAmount: request.Amount,
+			DestinationAsset:  protocols.Asset{Code: request.AssetCode, Issuer: request.AssetIssuer},
+			Path:              request.Path,
 		}
 
-		payWithMutator = &payWith
-	}
-
-	mutators := []interface{}{
-		b.Destination{destinationObject.AccountID},
-	}
-
-	if request.AssetCode == "" {
-		mutators = append(mutators, b.NativeAmount{
-			request.Amount,
-		})
-
+		operationBuilder = paymentOp.Build()
 	} else {
-		mutators = append(mutators, b.CreditAmount{
-			request.AssetCode,
-			request.AssetIssuer,
-			request.Amount,
-		})
-	}
+		paymentOp := bridge.PaymentOperationBody{
+			Source:      rSource,
+			Destination: destinationObject.AccountID,
+			Amount:      request.Amount,
+			Asset:       protocols.Asset{Code: request.AssetCode, Issuer: request.AssetIssuer},
+		}
 
-	if payWithMutator != nil {
-		mutators = append(mutators, *payWithMutator)
-	}
-
-	operationMutator := b.Payment(mutators...)
-	if operationMutator.Err != nil {
-		log.WithFields(log.Fields{
-			"err": operationMutator.Err,
-		}).Error("Error creating operation")
-		helpers.Write(w, helpers.InternalServerError)
-		return
+		operationBuilder = paymentOp.Build()
 	}
 
 	// Fetch Sender Info
@@ -253,18 +238,17 @@ func (rh *RequestHandler) HandlerSend(w http.ResponseWriter, r *http.Request) {
 		helpers.Write(w, helpers.InternalServerError)
 		return
 	}
-	memoMutator := &b.MemoHash{xdr.Hash(attachmentHashBytes)}
+
+	memo := txnbuild.MemoHash(attachmentHashBytes)
 
 	transaction, err := shared.BuildTransaction(
 		request.Source,
 		rh.Config.NetworkPassphrase,
-		operationMutator,
-		memoMutator,
+		[]txnbuild.Operation{operationBuilder},
+		memo,
 	)
-
-	txBase64, err := xdr.MarshalBase64(transaction)
 	if err != nil {
-		log.WithFields(log.Fields{"err": err}).Error("Error mashaling transaction")
+		log.WithFields(log.Fields{"err": err}).Error("Error building transaction")
 		helpers.Write(w, helpers.InternalServerError)
 		return
 	}
@@ -272,7 +256,7 @@ func (rh *RequestHandler) HandlerSend(w http.ResponseWriter, r *http.Request) {
 	authData := compliance.AuthData{
 		Sender:         request.Sender,
 		NeedInfo:       rh.Config.NeedsAuth,
-		Tx:             txBase64,
+		Tx:             transaction,
 		AttachmentJSON: string(attachmentJSON),
 	}
 

--- a/services/internal/bridge-compliance-shared/protocols/asset.go
+++ b/services/internal/bridge-compliance-shared/protocols/asset.go
@@ -3,17 +3,17 @@ package protocols
 import (
 	"fmt"
 
-	"github.com/stellar/go/build"
 	shared "github.com/stellar/go/services/internal/bridge-compliance-shared"
 	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/txnbuild"
 )
 
 // ToBaseAsset transforms Asset to github.com/stellar/go-stellar-base/build.Asset
-func (a Asset) ToBaseAsset() build.Asset {
+func (a Asset) ToBaseAsset() txnbuild.Asset {
 	if a.Code == "" && a.Issuer == "" {
-		return build.NativeAsset()
+		return txnbuild.NativeAsset{}
 	}
-	return build.CreditAsset(a.Code, a.Issuer)
+	return txnbuild.CreditAsset{Code: a.Code, Issuer: a.Issuer}
 }
 
 // String returns string representation of this asset

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"strconv"
 
-	b "github.com/stellar/go/build"
 	shared "github.com/stellar/go/services/internal/bridge-compliance-shared"
 	"github.com/stellar/go/services/internal/bridge-compliance-shared/http/helpers"
+	"github.com/stellar/go/txnbuild"
 )
 
 // OperationType is the type of operation
@@ -142,7 +142,8 @@ type Operation struct {
 
 // OperationBody interface is a common interface for builder operations
 type OperationBody interface {
-	ToTransactionMutator() b.TransactionMutator
+	// ToTransactionMutator() b.TransactionMutator
+	Build() txnbuild.Operation
 	Validate() error
 }
 

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_account_merge.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_account_merge.go
@@ -1,9 +1,9 @@
 package bridge
 
 import (
-	b "github.com/stellar/go/build"
 	shared "github.com/stellar/go/services/internal/bridge-compliance-shared"
 	"github.com/stellar/go/services/internal/bridge-compliance-shared/http/helpers"
+	"github.com/stellar/go/txnbuild"
 )
 
 // AccountMergeOperationBody represents account_merge operation
@@ -12,15 +12,17 @@ type AccountMergeOperationBody struct {
 	Destination string
 }
 
-// ToTransactionMutator returns stellar/go TransactionMutator
-func (op AccountMergeOperationBody) ToTransactionMutator() b.TransactionMutator {
-	mutators := []interface{}{b.Destination{op.Destination}}
-
-	if op.Source != nil {
-		mutators = append(mutators, b.SourceAccount{*op.Source})
+// Build returns a txnbuild.Operation
+func (op AccountMergeOperationBody) Build() txnbuild.Operation {
+	txnOp := txnbuild.AccountMerge{
+		Destination: op.Destination,
 	}
 
-	return b.AccountMerge(mutators...)
+	if op.Source != nil {
+		txnOp.SourceAccount = &txnbuild.SimpleAccount{AccountID: *op.Source}
+	}
+
+	return &txnOp
 }
 
 // Validate validates if operation body is valid.

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_change_trust.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_change_trust.go
@@ -2,10 +2,10 @@ package bridge
 
 import (
 	"github.com/stellar/go/amount"
-	b "github.com/stellar/go/build"
 	shared "github.com/stellar/go/services/internal/bridge-compliance-shared"
 	"github.com/stellar/go/services/internal/bridge-compliance-shared/http/helpers"
 	"github.com/stellar/go/services/internal/bridge-compliance-shared/protocols"
+	"github.com/stellar/go/txnbuild"
 )
 
 // ChangeTrustOperationBody represents change_trust operation
@@ -16,24 +16,21 @@ type ChangeTrustOperationBody struct {
 	Limit *string
 }
 
-// ToTransactionMutator returns go-stellar-base TransactionMutator
-func (op ChangeTrustOperationBody) ToTransactionMutator() b.TransactionMutator {
-	mutators := []interface{}{
-		op.Asset.ToBaseAsset(),
+// Build returns a txnbuild.Operation
+func (op ChangeTrustOperationBody) Build() txnbuild.Operation {
+	txnOp := txnbuild.ChangeTrust{
+		Line: txnbuild.CreditAsset{Code: op.Asset.Code, Issuer: op.Asset.Issuer},
 	}
 
-	if op.Limit == nil {
-		// Set MaxLimit
-		mutators = append(mutators, b.MaxLimit)
-	} else {
-		mutators = append(mutators, b.Limit(*op.Limit))
+	if op.Limit != nil {
+		txnOp.Limit = *op.Limit
 	}
 
 	if op.Source != nil {
-		mutators = append(mutators, b.SourceAccount{*op.Source})
+		txnOp.SourceAccount = &txnbuild.SimpleAccount{AccountID: *op.Source}
 	}
 
-	return b.ChangeTrust(mutators...)
+	return &txnOp
 }
 
 // Validate validates if operation body is valid.

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_create_account.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_create_account.go
@@ -2,9 +2,9 @@ package bridge
 
 import (
 	"github.com/stellar/go/amount"
-	b "github.com/stellar/go/build"
 	shared "github.com/stellar/go/services/internal/bridge-compliance-shared"
 	"github.com/stellar/go/services/internal/bridge-compliance-shared/http/helpers"
+	"github.com/stellar/go/txnbuild"
 )
 
 // CreateAccountOperationBody represents create_account operation
@@ -14,18 +14,18 @@ type CreateAccountOperationBody struct {
 	StartingBalance string `json:"starting_balance"`
 }
 
-// ToTransactionMutator returns go-stellar-base TransactionMutator
-func (op CreateAccountOperationBody) ToTransactionMutator() b.TransactionMutator {
-	mutators := []interface{}{
-		b.Destination{op.Destination},
-		b.NativeAmount{op.StartingBalance},
+// Build returns a txnbuild.Operation
+func (op CreateAccountOperationBody) Build() txnbuild.Operation {
+	txnOp := txnbuild.CreateAccount{
+		Destination: op.Destination,
+		Amount:      op.StartingBalance,
 	}
 
 	if op.Source != nil {
-		mutators = append(mutators, b.SourceAccount{*op.Source})
+		txnOp.SourceAccount = &txnbuild.SimpleAccount{AccountID: *op.Source}
 	}
 
-	return b.CreateAccount(mutators...)
+	return &txnOp
 }
 
 // Validate validates if operation body is valid.

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_inflation.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_inflation.go
@@ -4,11 +4,23 @@ import (
 	b "github.com/stellar/go/build"
 	shared "github.com/stellar/go/services/internal/bridge-compliance-shared"
 	"github.com/stellar/go/services/internal/bridge-compliance-shared/http/helpers"
+	"github.com/stellar/go/txnbuild"
 )
 
 // InflationOperationBody represents inflation operation
 type InflationOperationBody struct {
 	Source *string
+}
+
+// Build returns a txnbuild.Operation
+func (op InflationOperationBody) Build() txnbuild.Operation {
+	txnOp := txnbuild.Inflation{}
+
+	if op.Source != nil {
+		txnOp.SourceAccount = &txnbuild.SimpleAccount{AccountID: *op.Source}
+	}
+
+	return &txnOp
 }
 
 // ToTransactionMutator returns go-stellar-base TransactionMutator

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_manage_data.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_manage_data.go
@@ -3,9 +3,9 @@ package bridge
 import (
 	"encoding/base64"
 
-	b "github.com/stellar/go/build"
 	shared "github.com/stellar/go/services/internal/bridge-compliance-shared"
 	"github.com/stellar/go/services/internal/bridge-compliance-shared/http/helpers"
+	"github.com/stellar/go/txnbuild"
 )
 
 // ManageDataOperationBody represents manage_data operation
@@ -15,23 +15,22 @@ type ManageDataOperationBody struct {
 	Data   string
 }
 
-// ToTransactionMutator returns go-stellar-base TransactionMutator
-func (op ManageDataOperationBody) ToTransactionMutator() b.TransactionMutator {
-	var builder b.ManageDataBuilder
+// Build returns a txnbuild.Operation
+func (op ManageDataOperationBody) Build() txnbuild.Operation {
 
-	if op.Data == "" {
-		builder = b.ClearData(op.Name)
-	} else {
-		// This is validated in Validate()
-		data, _ := base64.StdEncoding.DecodeString(op.Data)
-		builder = b.SetData(op.Name, data)
+	// This is validated in Validate()
+	data, _ := base64.StdEncoding.DecodeString(op.Data)
+
+	txnOp := txnbuild.ManageData{
+		Name:  op.Name,
+		Value: data,
 	}
 
 	if op.Source != nil {
-		builder.Mutate(b.SourceAccount{*op.Source})
+		txnOp.SourceAccount = &txnbuild.SimpleAccount{AccountID: *op.Source}
 	}
 
-	return builder
+	return &txnOp
 }
 
 // Validate validates if operation body is valid.


### PR DESCRIPTION
This PR adds the changes made in #1327 and #1340  to master. Bridge and compliance servers now use the new sdk packages, `horizonclient` and `txnbuild`. Once this is merged, we will work on features that will go into the new release for bridge and compliance.
closes #1250 
closes #1251 
closes #1252 
closes #1062 