### PR TITLE
exp/keystore: use http put request to store keys

### DIFF
--- a/exp/services/keystore/api_test.go
+++ b/exp/services/keystore/api_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-func TestStoreKeysAPI(t *testing.T) {
+func TestPutKeys(t *testing.T) {
 	db := openKeystoreDB(t)
 	defer db.Close() // drop test db
 
@@ -37,7 +37,7 @@ func TestStoreKeysAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("POST", "/store-keys", bytes.NewReader([]byte(body)))
+	req := httptest.NewRequest("PUT", "/keys", bytes.NewReader([]byte(body)))
 	req = req.WithContext(withUserID(context.Background(), "test-user"))
 
 	rr := httptest.NewRecorder()

--- a/exp/services/keystore/api_test.go
+++ b/exp/services/keystore/api_test.go
@@ -20,11 +20,11 @@ func TestPutKeys(t *testing.T) {
 
 	h := ServeMux(&Service{conn.DB})
 
-	blob := `{
-		"type": "plaintextKey",
-		"pubkey": "stellar-pubkey",
-		"encrypted_seed": "encrypted-stellar-privatekey"
-	}`
+	blob := `[{
+		"keyType": "plaintextKey",
+		"publicKey": "stellar-pubkey",
+		"privateKey": "encrypted-stellar-privatekey"
+	}]`
 	encodedBlob := base64.RawURLEncoding.EncodeToString([]byte(blob))
 	encrypterName := "identity"
 	salt := "random-salt"

--- a/exp/services/keystore/keys.go
+++ b/exp/services/keystore/keys.go
@@ -2,7 +2,6 @@ package keystore
 
 import (
 	"context"
-	"database/sql"
 	"encoding/base64"
 	"time"
 
@@ -52,13 +51,13 @@ func (s *Service) storeKeys(ctx context.Context, in storeKeysRequest) (*encrypte
 		modifiedAt pq.NullTime
 	)
 	err = s.db.QueryRowContext(ctx, q, userID, keysData, in.Salt, in.EncrypterName).Scan(&keysBlob, &out.Salt, &out.EncrypterName, &out.CreatedAt, &modifiedAt)
-	if err == sql.ErrNoRows {
-		return nil, probDuplicateKeys
+	if err != nil {
+		return nil, errors.Wrap(err, "storing keys blob")
 	}
 
 	out.KeysBlob = base64.RawURLEncoding.EncodeToString(keysBlob)
 	if modifiedAt.Valid {
 		out.ModifiedAt = &modifiedAt.Time
 	}
-	return &out, errors.Wrap(err, "storing keys blob")
+	return &out, nil
 }

--- a/exp/services/keystore/problems.go
+++ b/exp/services/keystore/problems.go
@@ -1,6 +1,8 @@
 package keystore
 
 import (
+	"net/http"
+
 	"github.com/stellar/go/support/render/problem"
 )
 
@@ -12,12 +14,20 @@ var (
 		Detail: "Your request body is invalid.",
 	}
 
+	probMethodNotAllowed = problem.P{
+		Type:   "method_not_allowed",
+		Title:  "Method Not Allowed",
+		Status: http.StatusMethodNotAllowed,
+		Detail: "This endpoint does not support the request method you used. " +
+			"The server supports HTTP GET/PUT/DELETE for the /keys endpoint.",
+	}
+
 	probInvalidKeysBlob = problem.P{
 		Type:   "invalid_keys_blob",
 		Title:  "Invalid Keys Blob",
 		Status: 400,
-		Detail: "The keys-blob in your request body is not a valid base64 string. " +
-			"Please encode the keys-blob in your request body as a base64 string " +
+		Detail: "The keysBlob in your request body is not a valid base64 string. " +
+			"Please encode the keysBlob in your request body as a base64 string " +
 			"properly and try again.",
 	}
 
@@ -26,13 +36,5 @@ var (
 		Title:  "Not Authorized",
 		Status: 401,
 		Detail: "Your request is not authorized.",
-	}
-
-	probDuplicateKeys = problem.P{
-		Type:   "duplicate_keys",
-		Title:  "Duplicate Keys",
-		Status: 400,
-		Detail: "You have previously stored a keys-blob with the same encrypter. " +
-			"Please use the update endpoint if you wish to modify the keys-blob.",
 	}
 )

--- a/support/render/hal/handler.go
+++ b/support/render/hal/handler.go
@@ -22,14 +22,14 @@ type handler struct {
 	readFromBody bool
 }
 
-// PostHandler returns an HTTP Handler for function fn.
+// ReqBodyHandler returns an HTTP Handler for function fn.
 // If fn has an input type, it will try to decode the request body into the
 // function's input type.
 // If fn returns a non-nil error, the handler will use problem.Render.
 // Please refer to funcParamType for the allowed function signature.
 // The caller of this function should probably panic on the returned error, if
 // any.
-func PostHandler(fn interface{}) (http.Handler, error) {
+func ReqBodyHandler(fn interface{}) (http.Handler, error) {
 	fv := reflect.ValueOf(fn)
 	inType, err := funcParamType(fv)
 	if err != nil {

--- a/support/render/hal/handler_test.go
+++ b/support/render/hal/handler_test.go
@@ -62,7 +62,7 @@ func TestPostHandler(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		h, err := PostHandler(tc.f)
+		h, err := ReqBodyHandler(tc.f)
 		if err != nil {
 			t.Errorf("Handler(%v) got err %v", tc.f, err)
 			continue


### PR DESCRIPTION
We have updated the keystore spec so that we will conform REST
convention. We are going to be using HTTP GET/PUT/DELETE to manipulate
our encrypted keys blob.

This PR renames the `PostHandler` in `support/hal/render` to
`ReqBodyHandler` because it can actually be used by all kinds of http
methods as long as we don't put the param in the URL.

This PR adds a `keysHTTPMethodHandler` so that we know which function to
call based on the method we receive. Because of this, we introduced a new problem `probMethodNotAllowed` in this PR in the case of getting a method we don't support.