### PR TITLE
services/ticker: add logic and command to invert prices for CMC markets

### DIFF
--- a/services/ticker/cmd/generate.go
+++ b/services/ticker/cmd/generate.go
@@ -9,6 +9,7 @@ import (
 
 var MarketsOutFile string
 var AssetsOutFile string
+var CMCFormat bool
 
 func init() {
 	rootCmd.AddCommand(cmdGenerate)
@@ -29,6 +30,13 @@ func init() {
 		"o",
 		"assets.json",
 		"Set the name of the output file",
+	)
+
+	cmdGenerateMarketData.Flags().BoolVar(
+		&CMCFormat,
+		"cmc",
+		false,
+		"Format output specifically for CoinMarketCap",
 	)
 }
 
@@ -52,7 +60,7 @@ var cmdGenerateMarketData = &cobra.Command{
 		}
 
 		Logger.Infof("Starting market data generation, outputting to: %s\n", MarketsOutFile)
-		err = ticker.GenerateMarketSummaryFile(&session, Logger, MarketsOutFile)
+		err = ticker.GenerateMarketSummaryFile(&session, Logger, MarketsOutFile, CMCFormat)
 		if err != nil {
 			Logger.Fatal("could not generate market data:", err)
 		}

--- a/services/ticker/internal/actions_market.go
+++ b/services/ticker/internal/actions_market.go
@@ -165,7 +165,31 @@ func invertMarketStats(m *MarketStats) {
 
 func shouldMarketBeInvertdForCMC(pairName string) bool {
 	cmcMarketPairs := []string{
+		"XLM_SHX",
+		"XLM_SLT",
+		"XLM_DOGET",
+		"XLM_RMT",
 		"XLM_MOBI",
+		"XLM_ETH",
+		"XLM_BTC",
+		"XLM_KIN",
+		"XLM_XRP",
+		"XLM_XLB",
+		"XLM_TERN",
+		"XLM_BTX",
+		"XLM_GRAT",
+		"XLM_DRA",
+		"XLM_PEDI",
+		"XLM_ABDT",
+		"XLM_ZRX",
+		"XLM_WLO",
+		"XLM_LTC",
+		"XLM_SHADE",
+		"XLM_XLMG",
+		"XLM_OMG",
+		"XLM_ETX",
+		"XLM_NEOX",
+		"XLM_REPO",
 	}
 	for _, cmcPair := range cmcMarketPairs {
 		if pairName == cmcPair {

--- a/services/ticker/internal/actions_market.go
+++ b/services/ticker/internal/actions_market.go
@@ -2,6 +2,7 @@ package ticker
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/stellar/go/services/ticker/internal/tickerdb"
@@ -11,13 +12,19 @@ import (
 
 // GenerateMarketSummaryFile generates a MarketSummary with the statistics for all
 // valid markets within the database and outputs it to <filename>.
-func GenerateMarketSummaryFile(s *tickerdb.TickerSession, l *hlog.Entry, filename string) error {
+func GenerateMarketSummaryFile(s *tickerdb.TickerSession, l *hlog.Entry, filename string, forCMC bool) error {
 	l.Infoln("Generating market data...")
 	marketSummary, err := GenerateMarketSummary(s)
 	if err != nil {
 		return err
 	}
 	l.Infoln("Market data successfully generated!")
+
+	if forCMC {
+		l.Infoln("Inverting CMC markets...")
+		invertCMCMarkets(&marketSummary)
+		l.Infoln("Markets successfully adapted for CoinMarketCap")
+	}
 
 	jsonMkt, err := json.MarshalIndent(marketSummary, "", "    ")
 	if err != nil {
@@ -90,5 +97,90 @@ func dbMarketToMarketStats(m tickerdb.Market) MarketStats {
 		Spread:           spread,
 		SpreadMidPoint:   spreadMidPoint,
 		CloseTime:        closeTime,
+	}
+}
+
+// This is a set of temporary functions that are used to invert
+// some asset pairs when generating the assets.json report to fix
+// the prices / volumes on CoinMarketCap.
+
+func invertIfNotNull(n float64) float64 {
+	if n != 0.0 {
+		return 1.0 / n
+	}
+	return n
+}
+
+func invertMarketStats(m *MarketStats) {
+	// Uncomment if we need to change the trade pair order:
+	//
+	// tradePairItems := strings.Split(m.TradePairName, "_")
+	// m.TradePairName = fmt.Sprintf("%s_%s", tradePairItems[1], tradePairItems[0])
+
+	m.Close = invertIfNotNull(m.Close)
+	m.Price = m.Close
+
+	// Re-calculating 24h stats:
+	m.Open24h = invertIfNotNull(m.Open24h)
+
+	currLow24h := m.Low24h
+	currHigh24h := m.High24h
+
+	if currHigh24h != 0.0 {
+		m.Low24h = 1.0 / currHigh24h
+	}
+
+	if currLow24h != 0.0 {
+		m.High24h = 1.0 / currLow24h
+	}
+
+	m.Change24h = m.Close - m.Open24h
+
+	// Re-calculating 7d stats:
+	m.Open7d = invertIfNotNull(m.Open7d)
+
+	currLow7d := m.Low7d
+	currHigh7d := m.High7d
+
+	if currHigh7d != 0.0 {
+		m.Low7d = 1.0 / currHigh7d
+	}
+
+	if currLow7d != 0.0 {
+		m.High7d = 1.0 / currLow7d
+	}
+
+	m.Change7d = m.Close - m.Open7d
+
+	// Since we're reversing the asset pairs, the orderbook data is invalidated:
+	m.BidCount = 0.0
+	m.BidVolume = 0.0
+	m.BidMax = 0.0
+	m.AskCount = 0.0
+	m.AskVolume = 0.0
+	m.AskMin = 0.0
+	m.Spread = 0.0
+	m.SpreadMidPoint = 0.0
+}
+
+func shouldMarketBeInvertdForCMC(pairName string) bool {
+	cmcMarketPairs := []string{
+		"XLM_MOBI",
+	}
+	for _, cmcPair := range cmcMarketPairs {
+		if pairName == cmcPair {
+			fmt.Println("Found a matching pair")
+			return true
+		}
+	}
+
+	return false
+}
+
+func invertCMCMarkets(ms *MarketSummary) {
+	for i, mkt := range ms.Pairs {
+		if shouldMarketBeInvertdForCMC(mkt.TradePairName) {
+			invertMarketStats(&ms.Pairs[i])
+		}
 	}
 }


### PR DESCRIPTION
## Motivation

We need to invert the prices for some markets in order to ensure they correctly show up on CoinMarketCap. 

This is a temporary solution, since we've already reached out to their support to change how they compute SDEX data, but we haven't heard back from them so far.

## Background

This needs to be done because the previous ticker implemented the price for a trade pair as:

https://github.com/stellar/ticker-py/blob/master/ticker.py#L151

And we currently do as:

https://github.com/stellar/go/blob/master/services/ticker/internal/actions_trade.go#L146

## TODO

- [x] Validate the UA approach
- [x] Add all markets we need to invert to the `shouldMarketBeInvertdForCMC` function 
- [x] Update the cron job to also generate a `markets-cmc.json`
- [x] Update the nginx config to ensure `markets-cmc.json` is served to CMC
