### PR TITLE
exp/ingest: io.MemoryStateReader tests

### DIFF
--- a/exp/ingest/adapters/history_archive_adapter.go
+++ b/exp/ingest/adapters/history_archive_adapter.go
@@ -11,11 +11,11 @@ const msrBufferSize = 50000
 
 // HistoryArchiveAdapter is an adapter for the historyarchive package to read from history archives
 type HistoryArchiveAdapter struct {
-	archive *historyarchive.Archive
+	archive historyarchive.ArchiveInterface
 }
 
 // MakeHistoryArchiveAdapter is a factory method to make a HistoryArchiveAdapter
-func MakeHistoryArchiveAdapter(archive *historyarchive.Archive) *HistoryArchiveAdapter {
+func MakeHistoryArchiveAdapter(archive historyarchive.ArchiveInterface) *HistoryArchiveAdapter {
 	return &HistoryArchiveAdapter{archive: archive}
 }
 

--- a/exp/ingest/io/memory_state_reader.go
+++ b/exp/ingest/io/memory_state_reader.go
@@ -23,7 +23,7 @@ type readResult struct {
 // by `Read()` are exactly the ledger entries present at the given ledger.
 type MemoryStateReader struct {
 	has        *historyarchive.HistoryArchiveState
-	archive    *historyarchive.Archive
+	archive    historyarchive.ArchiveInterface
 	sequence   uint32
 	readChan   chan readResult
 	streamOnce sync.Once
@@ -31,11 +31,11 @@ type MemoryStateReader struct {
 	done       chan bool
 }
 
-// enforce MemoryStateReader to implement StateReadCloser
+// Ensure MemoryStateReader implements StateReadCloser
 var _ StateReadCloser = &MemoryStateReader{}
 
 // MakeMemoryStateReader is a factory method for MemoryStateReader
-func MakeMemoryStateReader(archive *historyarchive.Archive, sequence uint32, bufferSize uint16) (*MemoryStateReader, error) {
+func MakeMemoryStateReader(archive historyarchive.ArchiveInterface, sequence uint32, bufferSize uint16) (*MemoryStateReader, error) {
 	has, e := archive.GetCheckpointHAS(sequence)
 	if e != nil {
 		return nil, fmt.Errorf("unable to get checkpoint HAS at ledger sequence %d: %s", sequence, e)

--- a/exp/ingest/io/memory_state_reader_test.go
+++ b/exp/ingest/io/memory_state_reader_test.go
@@ -1,0 +1,273 @@
+package io
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stellar/go/support/historyarchive"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestMemoryStateReaderTestSuite(t *testing.T) {
+	suite.Run(t, new(MemoryStateReaderTestSuite))
+}
+
+type MemoryStateReaderTestSuite struct {
+	suite.Suite
+	mockArchive *historyarchive.MockArchive
+	reader      *MemoryStateReader
+	has         historyarchive.HistoryArchiveState
+}
+
+func (s *MemoryStateReaderTestSuite) SetupTest() {
+	s.mockArchive = &historyarchive.MockArchive{}
+
+	err := json.Unmarshal([]byte(hasExample), &s.has)
+	s.Require().NoError(err)
+
+	s.mockArchive.
+		On("GetCheckpointHAS", uint32(24123007)).
+		Return(s.has, nil)
+
+	// BucketExists should be called 21 times (11 levels, last without `snap`)
+	s.mockArchive.
+		On("BucketExists", mock.AnythingOfType("historyarchive.Hash")).
+		Return(true).Times(21)
+
+	s.reader, err = MakeMemoryStateReader(s.mockArchive, uint32(24123007), 5000)
+	s.Require().NotNil(s.reader)
+	s.Require().NoError(err)
+	s.Assert().Equal(uint32(24123007), s.reader.sequence)
+}
+
+func (s *MemoryStateReaderTestSuite) TearDownTest() {
+	s.mockArchive.AssertExpectations(s.T())
+}
+
+// TestSimple test reading buckets with a single live entry.
+func (s *MemoryStateReaderTestSuite) TestSimple() {
+	curr1 := createXdrStream(
+		xdr.BucketEntry{
+			Type: xdr.BucketEntryTypeLiveentry,
+			LiveEntry: &xdr.LedgerEntry{
+				LastModifiedLedgerSeq: 1,
+				Data: xdr.LedgerEntryData{
+					Type: xdr.LedgerEntryTypeAccount,
+					Account: &xdr.AccountEntry{
+						AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+					},
+				},
+			},
+		},
+	)
+
+	nextBucket := s.getNextBucket()
+
+	// Return curr1 stream for the first bucket...
+	s.mockArchive.
+		On("GetXdrStreamForHash", <-nextBucket).
+		Return(curr1, nil).Once()
+
+	// ...and empty streams for the rest of the buckets.
+	for hash := range nextBucket {
+		s.mockArchive.
+			On("GetXdrStreamForHash", hash).
+			Return(createXdrStream(), nil).Once()
+	}
+
+	var e xdr.LedgerEntry
+	var err error
+	e, err = s.reader.Read()
+	s.Require().NoError(err)
+
+	id := e.Data.MustAccount().AccountId
+	s.Assert().Equal("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", id.Address())
+
+	_, err = s.reader.Read()
+	s.Require().Error(err, EOF)
+}
+
+// TestRemoved test reading buckets with a single live entry that was removed.
+func (s *MemoryStateReaderTestSuite) TestRemoved() {
+	curr1 := createXdrStream(
+		xdr.BucketEntry{
+			Type: xdr.BucketEntryTypeDeadentry,
+			DeadEntry: &xdr.LedgerKey{
+				Type:    xdr.LedgerEntryTypeAccount,
+				Account: &xdr.LedgerKeyAccount{xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML")},
+			},
+		},
+	)
+
+	snap1 := createXdrStream(
+		xdr.BucketEntry{
+			Type: xdr.BucketEntryTypeLiveentry,
+			LiveEntry: &xdr.LedgerEntry{
+				LastModifiedLedgerSeq: 1,
+				Data: xdr.LedgerEntryData{
+					Type: xdr.LedgerEntryTypeAccount,
+					Account: &xdr.AccountEntry{
+						AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+					},
+				},
+			},
+		},
+	)
+
+	nextBucket := s.getNextBucket()
+
+	// Return curr1 and snap1 stream for the first two bucket...
+	s.mockArchive.
+		On("GetXdrStreamForHash", <-nextBucket).
+		Return(curr1, nil).Once()
+
+	s.mockArchive.
+		On("GetXdrStreamForHash", <-nextBucket).
+		Return(snap1, nil).Once()
+
+	// ...and empty streams for the rest of the buckets.
+	for hash := range nextBucket {
+		s.mockArchive.
+			On("GetXdrStreamForHash", hash).
+			Return(createXdrStream(), nil).Once()
+	}
+
+	_, err := s.reader.Read()
+	s.Require().Error(err, EOF)
+}
+
+func createXdrStream(entries ...xdr.BucketEntry) *historyarchive.XdrStream {
+	b := &bytes.Buffer{}
+	for _, e := range entries {
+		err := historyarchive.WriteFramedXdr(b, e)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return historyarchive.NewXdrStream(ioutil.NopCloser(b))
+}
+
+// getNextBucket is a helper that returns next bucket hash in the order of processing.
+// This allows to write simpler test code that ensures that mocked calls are in a
+// correct order.
+func (s *MemoryStateReaderTestSuite) getNextBucket() <-chan (historyarchive.Hash) {
+	// 11 levels with 2 buckets each = buffer of 22
+	c := make(chan (historyarchive.Hash), 22)
+
+	for i := 0; i < len(s.has.CurrentBuckets); i++ {
+		b := s.has.CurrentBuckets[i]
+
+		curr := historyarchive.MustDecodeHash(b.Curr)
+		if !curr.IsZero() {
+			c <- curr
+		}
+
+		snap := historyarchive.MustDecodeHash(b.Snap)
+		if !snap.IsZero() {
+			c <- snap
+		}
+	}
+
+	close(c)
+	return c
+}
+
+var hasExample = `{
+    "version": 1,
+    "server": "v11.1.0",
+    "currentLedger": 24123007,
+    "currentBuckets": [
+        {
+            "curr": "517bea4c6627a688a8ce501febd8c562e737e3d86b29689d9956217640f3c74b",
+            "next": {
+                "state": 0
+            },
+            "snap": "75c8c5540a825da61e05ae23d0b0be9d29f2bdb8fdfa550a3f3496f030f62ffd"
+        },
+        {
+            "curr": "5bca6165dbf6832ff4550e67d0e564eca56494acfc9b7fd46c740f4d66c74609",
+            "next": {
+                "state": 1,
+                "output": "75c8c5540a825da61e05ae23d0b0be9d29f2bdb8fdfa550a3f3496f030f62ffd"
+            },
+            "snap": "b6bad6183a3394087aae3d05ed393c5dcb80e35ed557e2c8935cba855f20dfa5"
+        },
+        {
+            "curr": "56b70bb56fcb27dd05759b00b07bc3c9dc7cc6dbfc9d409cfec2a41d9fd4a1e8",
+            "next": {
+                "state": 1,
+                "output": "cfa973ce4ba1fbdf3b5767e398a5b7b86e30461855d24b7b50dc499eb313b4d0"
+            },
+            "snap": "974a089a6980bf25d8ad1a6a71370bac2663e9bb14702ba90b9db657464c0b3a"
+        },
+        {
+            "curr": "16742c8e61a4dde3b35179bedbdd7c56e67d03a5faf8973a6094c57e430322df",
+            "next": {
+                "state": 1,
+                "output": "ef39804657a928139750e801c63d1d911532d7d126c80f151ba362f49147972e"
+            },
+            "snap": "b415a283c5e33d8c425cbb003a86c780f73e8d2016fb5dcc6ba1477e551a2c66"
+        },
+        {
+            "curr": "b081e1c075c9114a6c74cf87a0767ee877f02e88e18a8bf97b8f268ff120ad0d",
+            "next": {
+                "state": 1,
+                "output": "162b859558c7c51c6416f659dbd8d70236c75540196e5d7a5dee2a66744ebbf5"
+            },
+            "snap": "66f8fb3f36bbe328bbbe14151951891d455ad0fba1d19d05531226c0909a84c7"
+        },
+        {
+            "curr": "822b766e755e83d4ad08a38e86466f47452a2d7c4702295ebd3235332db76a05",
+            "next": {
+                "state": 1,
+                "output": "1c04dc66c3410efc535044f4250c02490627b549f99a8873e4857b2cec4d51c8"
+            },
+            "snap": "163a49fa560761217710f6bbbf85179514aa7714d373337dde7f200f8d6c623a"
+        },
+        {
+            "curr": "75b77814875529876258760ed6b6f37d81b5a39183812c684b9e3014bb6b8cf6",
+            "next": {
+                "state": 1,
+                "output": "444088f447eb7ea3d397e7098d57c4f63b66912d24c4a26a29bf1dde7a4fdecc"
+            },
+            "snap": "35472156c463eaf62867c9b229b92e8192e2fe40cf86e269cab65fd0045c996f"
+        },
+        {
+            "curr": "b331675d693bdb4456f409083a1b8cbadbcef977df765ba7d4ddd787800bdc84",
+            "next": {
+                "state": 1,
+                "output": "3d9627fa5ef81486688dc584f52445560a55496d3b961a7664b0e536655179bb"
+            },
+            "snap": "5a7996730755a90ea5cbd2d726a982f3f3703c3db8bc2a2217bd496b9c0cf3d1"
+        },
+        {
+            "curr": "11f8c2f8e1cb0d47576f74d9e2fa838f5f3a37180907a24a85d0ad8b647862e4",
+            "next": {
+                "state": 1,
+                "output": "6c0133dfd0411f9975c74d792911bb80fc1555830a943249cea6c2a80e5064d1"
+            },
+            "snap": "48f435285dd96511d0822f7ae1a20e28c6c28019e385313713655fc76fe3bc03"
+        },
+        {
+            "curr": "5f351041761b45f3e725f98bb8b6713873e30ab6c8aee56ba0823d357c7ebd0d",
+            "next": {
+                "state": 1,
+                "output": "264d3a93bc5fff47a968cc53f0f2f50297e5f9015300bbc357cfb8dec30899c6"
+            },
+            "snap": "4100ad3b1085bd14d1c808ece3b38db97171532d0d11ed5edd57aff0e416e06a"
+        },
+        {
+            "curr": "a4811c9ba9505e421f0015e5fcfd9f5d204ae85b584766759e844ef85db10d47",
+            "next": {
+                "state": 1,
+                "output": "be4ecc289998a40319be24662c88f161f5e78d4be846b083923614573aa17336"
+            },
+            "snap": "0000000000000000000000000000000000000000000000000000000000000000"
+        }
+    ]
+}`

--- a/exp/ingest/io/memory_state_reader_test.go
+++ b/exp/ingest/io/memory_state_reader_test.go
@@ -31,8 +31,11 @@ func (s *MemoryStateReaderTestSuite) SetupTest() {
 	err := json.Unmarshal([]byte(hasExample), &s.has)
 	s.Require().NoError(err)
 
+	ledgerSeq := uint32(24123007)
+	bufferSize := uint16(5000)
+
 	s.mockArchive.
-		On("GetCheckpointHAS", uint32(24123007)).
+		On("GetCheckpointHAS", ledgerSeq).
 		Return(s.has, nil)
 
 	// BucketExists should be called 21 times (11 levels, last without `snap`)
@@ -40,10 +43,10 @@ func (s *MemoryStateReaderTestSuite) SetupTest() {
 		On("BucketExists", mock.AnythingOfType("historyarchive.Hash")).
 		Return(true).Times(21)
 
-	s.reader, err = MakeMemoryStateReader(s.mockArchive, uint32(24123007), 5000)
+	s.reader, err = MakeMemoryStateReader(s.mockArchive, ledgerSeq, bufferSize)
 	s.Require().NotNil(s.reader)
 	s.Require().NoError(err)
-	s.Assert().Equal(uint32(24123007), s.reader.sequence)
+	s.Assert().Equal(ledgerSeq, s.reader.sequence)
 }
 
 func (s *MemoryStateReaderTestSuite) TearDownTest() {

--- a/support/historyarchive/mocks.go
+++ b/support/historyarchive/mocks.go
@@ -1,0 +1,84 @@
+package historyarchive
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+// MockArchive is a mockable archive.
+type MockArchive struct {
+	mock.Mock
+}
+
+func (m *MockArchive) GetPathHAS(path string) (HistoryArchiveState, error) {
+	a := m.Called(path)
+	return a.Get(0).(HistoryArchiveState), a.Error(1)
+}
+
+func (m *MockArchive) PutPathHAS(path string, has HistoryArchiveState, opts *CommandOptions) error {
+	a := m.Called(path, has, opts)
+	return a.Error(0)
+}
+
+func (m *MockArchive) BucketExists(bucket Hash) bool {
+	a := m.Called(bucket)
+	return a.Get(0).(bool)
+}
+
+func (m *MockArchive) CategoryCheckpointExists(cat string, chk uint32) bool {
+	a := m.Called(cat, chk)
+	return a.Get(0).(bool)
+}
+
+func (m *MockArchive) GetRootHAS() (HistoryArchiveState, error) {
+	a := m.Called()
+	return a.Get(0).(HistoryArchiveState), a.Error(1)
+}
+
+func (m *MockArchive) GetCheckpointHAS(chk uint32) (HistoryArchiveState, error) {
+	a := m.Called(chk)
+	return a.Get(0).(HistoryArchiveState), a.Error(1)
+}
+
+func (m *MockArchive) PutCheckpointHAS(chk uint32, has HistoryArchiveState, opts *CommandOptions) error {
+	a := m.Called(chk, has, opts)
+	return a.Error(0)
+}
+
+func (m *MockArchive) PutRootHAS(has HistoryArchiveState, opts *CommandOptions) error {
+	a := m.Called(has, opts)
+	return a.Error(0)
+}
+
+func (m *MockArchive) ListBucket(dp DirPrefix) (chan string, chan error) {
+	m.Called(dp)
+	panic("Returning channels not implemented")
+	return make(chan string), make(chan error)
+}
+
+func (m *MockArchive) ListAllBuckets() (chan string, chan error) {
+	m.Called()
+	panic("Returning channels not implemented")
+	return make(chan string), make(chan error)
+}
+
+func (m *MockArchive) ListAllBucketHashes() (chan Hash, chan error) {
+	m.Called()
+	panic("Returning channels not implemented")
+	return make(chan Hash), make(chan error)
+}
+
+func (m *MockArchive) ListCategoryCheckpoints(cat string, pth string) (chan uint32, chan error) {
+	m.Called(cat, pth)
+	panic("Returning channels not implemented")
+	return make(chan uint32), make(chan error)
+}
+
+func (m *MockArchive) GetXdrStreamForHash(hash Hash) (*XdrStream, error) {
+	a := m.Called(hash)
+	return a.Get(0).(*XdrStream), a.Error(1)
+}
+
+func (m *MockArchive) GetXdrStream(pth string) (*XdrStream, error) {
+	a := m.Called(pth)
+	return a.Get(0).(*XdrStream), a.Error(1)
+}

--- a/support/historyarchive/xdrstream.go
+++ b/support/historyarchive/xdrstream.go
@@ -64,7 +64,6 @@ func (x *XdrStream) ReadOne(in interface{}) error {
 		} else {
 			return err
 		}
-
 	}
 	nbytes &= 0x7fffffff
 	x.buf.Reset()

--- a/support/historyarchive/xdrstream.go
+++ b/support/historyarchive/xdrstream.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/stellar/go/xdr"
 )
@@ -34,27 +33,6 @@ func NewXdrGzStream(in io.ReadCloser) (*XdrStream, error) {
 		return nil, err
 	}
 	return &XdrStream{rdr: bufReadCloser(rdr), rdr2: in}, nil
-}
-
-func (a *Archive) GetXdrStreamForHash(hash Hash) (*XdrStream, error) {
-	path := fmt.Sprintf(
-		"bucket/%s/bucket-%s.xdr.gz",
-		HashPrefix(hash).Path(),
-		hash.String(),
-	)
-
-	return a.GetXdrStream(path)
-}
-
-func (a *Archive) GetXdrStream(pth string) (*XdrStream, error) {
-	if !strings.HasSuffix(pth, ".xdr.gz") {
-		return nil, errors.New("File has non-.xdr.gz suffix: " + pth)
-	}
-	rdr, err := a.backend.GetFile(pth)
-	if err != nil {
-		return nil, err
-	}
-	return NewXdrGzStream(rdr)
 }
 
 func HashXdr(x interface{}) (Hash, error) {
@@ -81,11 +59,7 @@ func (x *XdrStream) ReadOne(in interface{}) error {
 	err := binary.Read(x.rdr, binary.BigEndian, &nbytes)
 	if err != nil {
 		x.rdr.Close()
-		if err == io.ErrUnexpectedEOF {
-			return io.EOF
-		} else {
-			return err
-		}
+		return err
 	}
 	nbytes &= 0x7fffffff
 	x.buf.Reset()

--- a/support/historyarchive/xdrstream.go
+++ b/support/historyarchive/xdrstream.go
@@ -59,7 +59,12 @@ func (x *XdrStream) ReadOne(in interface{}) error {
 	err := binary.Read(x.rdr, binary.BigEndian, &nbytes)
 	if err != nil {
 		x.rdr.Close()
-		return err
+		if err == io.ErrUnexpectedEOF {
+			return io.EOF
+		} else {
+			return err
+		}
+
 	}
 	nbytes &= 0x7fffffff
 	x.buf.Reset()

--- a/xdr/account_id.go
+++ b/xdr/account_id.go
@@ -51,6 +51,15 @@ func (aid *AccountId) LedgerKey() (ret LedgerKey) {
 	return
 }
 
+func MustAddress(address string) AccountId {
+	aid := AccountId{}
+	err := aid.SetAddress(address)
+	if err != nil {
+		panic(err)
+	}
+	return aid
+}
+
 // SetAddress modifies the receiver, setting it's value to the AccountId form
 // of the provided address.
 func (aid *AccountId) SetAddress(address string) error {


### PR DESCRIPTION
Adds simple tests for `exp/ingest/io.MemoryStateReader`.