### PR TITLE
exp/keystore: add get keys endpoint

### DIFF
--- a/exp/services/keystore/api.go
+++ b/exp/services/keystore/api.go
@@ -32,10 +32,10 @@ func (s *Service) keysHTTPMethodHandler() http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.Method {
 		case http.MethodGet:
-			// Serve the resource.
+			jsonHandler(s.getKeys).ServeHTTP(rw, req)
 
 		case http.MethodPut:
-			jsonHandler(s.storeKeys).ServeHTTP(rw, req)
+			jsonHandler(s.putKeys).ServeHTTP(rw, req)
 
 		case http.MethodDelete:
 			// Remove the record.

--- a/exp/services/keystore/api_test.go
+++ b/exp/services/keystore/api_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-func TestPutKeys(t *testing.T) {
+func TestPutKeysAPI(t *testing.T) {
 	db := openKeystoreDB(t)
 	defer db.Close() // drop test db
 
@@ -28,7 +28,7 @@ func TestPutKeys(t *testing.T) {
 	encodedBlob := base64.RawURLEncoding.EncodeToString([]byte(blob))
 	encrypterName := "identity"
 	salt := "random-salt"
-	body, err := json.Marshal(storeKeysRequest{
+	body, err := json.Marshal(putKeysRequest{
 		KeysBlob:      encodedBlob,
 		EncrypterName: encrypterName,
 		Salt:          salt,
@@ -44,7 +44,68 @@ func TestPutKeys(t *testing.T) {
 	h.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusOK {
-		t.Errorf("POST %s responded with %s, want %s", req.URL, http.StatusText(rr.Code), http.StatusText(http.StatusOK))
+		t.Errorf("PUT %s responded with %s, want %s", req.URL, http.StatusText(rr.Code), http.StatusText(http.StatusOK))
+	}
+	got := &encryptedKeys{}
+	json.Unmarshal(rr.Body.Bytes(), &got)
+	if got == nil {
+		t.Error("Expected to receive an encryptedKeys response but did not")
+	}
+
+	if got.KeysBlob != encodedBlob {
+		t.Errorf("got blob: %s, want: %s\n", got.KeysBlob, encodedBlob)
+	}
+
+	if got.EncrypterName != encrypterName {
+		t.Errorf("got encrypter name: %s, want: %s\n", got.EncrypterName, encrypterName)
+	}
+
+	if got.Salt != salt {
+		t.Errorf("got salt: %s, want: %s\n", got.Salt, salt)
+	}
+
+	if got.CreatedAt.Before(time.Now().Add(-time.Hour)) {
+		t.Errorf("got CreatedAt=%s, want CreatedAt within the last hour", got.CreatedAt)
+	}
+}
+
+func TestGetKeysAPI(t *testing.T) {
+	db := openKeystoreDB(t)
+	defer db.Close() // drop test db
+
+	conn := db.Open()
+	defer conn.Close() // close db connection
+
+	ctx := withUserID(context.Background(), "test-user")
+	s := &Service{conn.DB}
+	h := ServeMux(s)
+
+	blob := `[{
+		"keyType": "plaintextKey",
+		"publicKey": "stellar-pubkey",
+		"privateKey": "encrypted-stellar-privatekey"
+	}]`
+	encodedBlob := base64.RawURLEncoding.EncodeToString([]byte(blob))
+	encrypterName := "identity"
+	salt := "random-salt"
+
+	_, err := s.putKeys(ctx, putKeysRequest{
+		KeysBlob:      encodedBlob,
+		EncrypterName: encrypterName,
+		Salt:          salt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/keys", nil)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("GET %s responded with %s, want %s", req.URL, http.StatusText(rr.Code), http.StatusText(http.StatusOK))
 	}
 	got := &encryptedKeys{}
 	json.Unmarshal(rr.Body.Bytes(), &got)

--- a/exp/services/keystore/keys_test.go
+++ b/exp/services/keystore/keys_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func TestStoreKeys(t *testing.T) {
+func TestPutKeys(t *testing.T) {
 	db := openKeystoreDB(t)
 	defer db.Close() // drop test db
 
@@ -17,21 +17,70 @@ func TestStoreKeys(t *testing.T) {
 	ctx := withUserID(context.Background(), "test-user")
 	s := &Service{conn.DB}
 
-	blob := `{
-		"type": "plaintextKey",
-		"pubkey": "stellar-pubkey",
-		"encrypted_seed": "encrypted-stellar-privatekey"
-	}`
+	blob := `[{
+		"keyType": "plaintextKey",
+		"publicKey": "stellar-pubkey",
+		"privateKey": "encrypted-stellar-privatekey"
+	}]`
 	encodedBlob := base64.RawURLEncoding.EncodeToString([]byte(blob))
 	encrypterName := "identity"
 	salt := "random-salt"
-	req := storeKeysRequest{
+
+	got, err := s.putKeys(ctx, putKeysRequest{
 		KeysBlob:      encodedBlob,
 		EncrypterName: encrypterName,
 		Salt:          salt,
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	got, err := s.storeKeys(ctx, req)
+	if got.KeysBlob != encodedBlob {
+		t.Errorf("got blob: %s, want: %s\n", got.KeysBlob, encodedBlob)
+	}
+
+	if got.EncrypterName != encrypterName {
+		t.Errorf("got encrypter name: %s, want: %s\n", got.EncrypterName, encrypterName)
+	}
+
+	if got.Salt != salt {
+		t.Errorf("got salt: %s, want: %s\n", got.Salt, salt)
+	}
+
+	if got.CreatedAt.Before(time.Now().Add(-time.Hour)) {
+		t.Errorf("got CreatedAt=%s, want CreatedAt within the last hour", got.CreatedAt)
+	}
+}
+
+func TestGetKeys(t *testing.T) {
+	db := openKeystoreDB(t)
+	defer db.Close() // drop test db
+
+	conn := db.Open()
+	defer conn.Close() // close db connection
+
+	ctx := withUserID(context.Background(), "test-user")
+	s := &Service{conn.DB}
+
+	blob := `[{
+		"keyType": "plaintextKey",
+		"publicKey": "stellar-pubkey",
+		"privateKey": "encrypted-stellar-privatekey"
+	}]`
+	encodedBlob := base64.RawURLEncoding.EncodeToString([]byte(blob))
+	encrypterName := "identity"
+	salt := "random-salt"
+
+	_, err := s.putKeys(ctx, putKeysRequest{
+		KeysBlob:      encodedBlob,
+		EncrypterName: encrypterName,
+		Salt:          salt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.getKeys(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR adds HTTP `GET` method to `/keys`. This PR also renames `storeKeys` to `putKeys` so that it is consistent with the spec.