### PR TITLE
exp/keystore: add delete keys endpoint

### DIFF
--- a/exp/services/keystore/api.go
+++ b/exp/services/keystore/api.go
@@ -38,7 +38,7 @@ func (s *Service) keysHTTPMethodHandler() http.Handler {
 			jsonHandler(s.putKeys).ServeHTTP(rw, req)
 
 		case http.MethodDelete:
-			// Remove the record.
+			jsonHandler(s.deleteKeys).ServeHTTP(rw, req)
 
 		default:
 			problem.Render(req.Context(), rw, probMethodNotAllowed)

--- a/exp/services/keystore/api_test.go
+++ b/exp/services/keystore/api_test.go
@@ -3,12 +3,15 @@ package keystore
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/stellar/go/support/errors"
 )
 
 func TestPutKeysAPI(t *testing.T) {
@@ -127,5 +130,71 @@ func TestGetKeysAPI(t *testing.T) {
 
 	if got.CreatedAt.Before(time.Now().Add(-time.Hour)) {
 		t.Errorf("got CreatedAt=%s, want CreatedAt within the last hour", got.CreatedAt)
+	}
+}
+
+func TestDeleteKeysAPI(t *testing.T) {
+	db := openKeystoreDB(t)
+	defer db.Close() // drop test db
+
+	conn := db.Open()
+	defer conn.Close() // close db connection
+
+	ctx := withUserID(context.Background(), "test-user")
+	s := &Service{conn.DB}
+	h := ServeMux(s)
+
+	blob := `[{
+		"keyType": "plaintextKey",
+		"publicKey": "stellar-pubkey",
+		"privateKey": "encrypted-stellar-privatekey"
+	}]`
+	encodedBlob := base64.RawURLEncoding.EncodeToString([]byte(blob))
+	encrypterName := "identity"
+	salt := "random-salt"
+
+	_, err := s.putKeys(ctx, putKeysRequest{
+		KeysBlob:      encodedBlob,
+		EncrypterName: encrypterName,
+		Salt:          salt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("DELETE", "/keys", nil)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("DELETE %s responded with %s, want %s", req.URL, http.StatusText(rr.Code), http.StatusText(http.StatusOK))
+	}
+	got := &encryptedKeys{}
+	json.Unmarshal(rr.Body.Bytes(), &got)
+	if got == nil {
+		t.Error("Expected to receive an encryptedKeys response but did not")
+	}
+
+	if got.KeysBlob != encodedBlob {
+		t.Errorf("got blob: %s, want: %s\n", got.KeysBlob, encodedBlob)
+	}
+
+	if got.EncrypterName != encrypterName {
+		t.Errorf("got encrypter name: %s, want: %s\n", got.EncrypterName, encrypterName)
+	}
+
+	if got.Salt != salt {
+		t.Errorf("got salt: %s, want: %s\n", got.Salt, salt)
+	}
+
+	if got.CreatedAt.Before(time.Now().Add(-time.Hour)) {
+		t.Errorf("got CreatedAt=%s, want CreatedAt within the last hour\n", got.CreatedAt)
+	}
+
+	_, err = s.getKeys(ctx)
+	if errors.Cause(err) != sql.ErrNoRows {
+		t.Errorf("expect the keys blob of the user %s to be deleted", userID(ctx))
 	}
 }

--- a/exp/services/keystore/api_test.go
+++ b/exp/services/keystore/api_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/render/hal"
 )
 
 func TestPutKeysAPI(t *testing.T) {
@@ -171,26 +172,11 @@ func TestDeleteKeysAPI(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Errorf("DELETE %s responded with %s, want %s", req.URL, http.StatusText(rr.Code), http.StatusText(http.StatusOK))
 	}
-	got := &encryptedKeys{}
-	json.Unmarshal(rr.Body.Bytes(), &got)
-	if got == nil {
-		t.Error("Expected to receive an encryptedKeys response but did not")
-	}
 
-	if got.KeysBlob != encodedBlob {
-		t.Errorf("got blob: %s, want: %s\n", got.KeysBlob, encodedBlob)
-	}
-
-	if got.EncrypterName != encrypterName {
-		t.Errorf("got encrypter name: %s, want: %s\n", got.EncrypterName, encrypterName)
-	}
-
-	if got.Salt != salt {
-		t.Errorf("got salt: %s, want: %s\n", got.Salt, salt)
-	}
-
-	if got.CreatedAt.Before(time.Now().Add(-time.Hour)) {
-		t.Errorf("got CreatedAt=%s, want CreatedAt within the last hour\n", got.CreatedAt)
+	got := rr.Body.Bytes()
+	dr, _ := json.MarshalIndent(hal.DefaultResponse, "", "  ")
+	if !bytes.Equal(got, dr) {
+		t.Errorf("got: %s, expected: %s", got, dr)
 	}
 
 	_, err = s.getKeys(ctx)

--- a/exp/services/keystore/keys.go
+++ b/exp/services/keystore/keys.go
@@ -100,3 +100,31 @@ func (s *Service) getKeys(ctx context.Context) (*encryptedKeys, error) {
 	}
 	return &out, nil
 }
+
+func (s *Service) deleteKeys(ctx context.Context) (*encryptedKeys, error) {
+	userID := userID(ctx)
+	if userID == "" {
+		return nil, probNotAuthorized
+	}
+
+	q := `
+		DELETE FROM encrypted_keys
+		WHERE user_id = $1
+		RETURNING encrypted_keys_data, salt, encrypter_name, created_at, modified_at
+	`
+	var (
+		keysBlob   []byte
+		out        encryptedKeys
+		modifiedAt pq.NullTime
+	)
+	err := s.db.QueryRowContext(ctx, q, userID).Scan(&keysBlob, &out.Salt, &out.EncrypterName, &out.CreatedAt, &modifiedAt)
+	if err != nil {
+		return nil, errors.Wrap(err, "deleting keys blob")
+	}
+
+	out.KeysBlob = base64.RawURLEncoding.EncodeToString(keysBlob)
+	if modifiedAt.Valid {
+		out.ModifiedAt = &modifiedAt.Time
+	}
+	return &out, nil
+}

--- a/exp/services/keystore/keys.go
+++ b/exp/services/keystore/keys.go
@@ -101,7 +101,9 @@ func (s *Service) getKeys(ctx context.Context) (*encryptedKeys, error) {
 	return &out, nil
 }
 
-func (s *Service) deleteKeys(ctx context.Context) (*encryptedKeys, error) {
+//TODO: make support/render/hal be able to handle function with only 1 return
+//value
+func (s *Service) deleteKeys(ctx context.Context) (interface{}, error) {
 	userID := userID(ctx)
 	if userID == "" {
 		return nil, probNotAuthorized
@@ -110,21 +112,7 @@ func (s *Service) deleteKeys(ctx context.Context) (*encryptedKeys, error) {
 	q := `
 		DELETE FROM encrypted_keys
 		WHERE user_id = $1
-		RETURNING encrypted_keys_data, salt, encrypter_name, created_at, modified_at
 	`
-	var (
-		keysBlob   []byte
-		out        encryptedKeys
-		modifiedAt pq.NullTime
-	)
-	err := s.db.QueryRowContext(ctx, q, userID).Scan(&keysBlob, &out.Salt, &out.EncrypterName, &out.CreatedAt, &modifiedAt)
-	if err != nil {
-		return nil, errors.Wrap(err, "deleting keys blob")
-	}
-
-	out.KeysBlob = base64.RawURLEncoding.EncodeToString(keysBlob)
-	if modifiedAt.Valid {
-		out.ModifiedAt = &modifiedAt.Time
-	}
-	return &out, nil
+	_, err := s.db.ExecContext(ctx, q, userID)
+	return nil, errors.Wrap(err, "deleting keys blob")
 }

--- a/exp/services/keystore/keys_test.go
+++ b/exp/services/keystore/keys_test.go
@@ -133,25 +133,9 @@ func TestDeleteKeys(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := s.deleteKeys(ctx)
+	_, err = s.deleteKeys(ctx)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	if got.KeysBlob != encodedBlob {
-		t.Errorf("got blob: %s, want: %s\n", got.KeysBlob, encodedBlob)
-	}
-
-	if got.EncrypterName != encrypterName {
-		t.Errorf("got encrypter name: %s, want: %s\n", got.EncrypterName, encrypterName)
-	}
-
-	if got.Salt != salt {
-		t.Errorf("got salt: %s, want: %s\n", got.Salt, salt)
-	}
-
-	if got.CreatedAt.Before(time.Now().Add(-time.Hour)) {
-		t.Errorf("got CreatedAt=%s, want CreatedAt within the last hour\n", got.CreatedAt)
 	}
 
 	_, err = s.getKeys(ctx)

--- a/exp/services/keystore/keys_test.go
+++ b/exp/services/keystore/keys_test.go
@@ -2,9 +2,12 @@ package keystore
 
 import (
 	"context"
+	"database/sql"
 	"encoding/base64"
 	"testing"
 	"time"
+
+	"github.com/stellar/go/support/errors"
 )
 
 func TestPutKeys(t *testing.T) {
@@ -99,5 +102,60 @@ func TestGetKeys(t *testing.T) {
 
 	if got.CreatedAt.Before(time.Now().Add(-time.Hour)) {
 		t.Errorf("got CreatedAt=%s, want CreatedAt within the last hour", got.CreatedAt)
+	}
+}
+
+func TestDeleteKeys(t *testing.T) {
+	db := openKeystoreDB(t)
+	defer db.Close() // drop test db
+
+	conn := db.Open()
+	defer conn.Close() // close db connection
+
+	ctx := withUserID(context.Background(), "test-user")
+	s := &Service{conn.DB}
+
+	blob := `[{
+		"keyType": "plaintextKey",
+		"publicKey": "stellar-pubkey",
+		"privateKey": "encrypted-stellar-privatekey"
+	}]`
+	encodedBlob := base64.RawURLEncoding.EncodeToString([]byte(blob))
+	encrypterName := "identity"
+	salt := "random-salt"
+
+	_, err := s.putKeys(ctx, putKeysRequest{
+		KeysBlob:      encodedBlob,
+		EncrypterName: encrypterName,
+		Salt:          salt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.deleteKeys(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.KeysBlob != encodedBlob {
+		t.Errorf("got blob: %s, want: %s\n", got.KeysBlob, encodedBlob)
+	}
+
+	if got.EncrypterName != encrypterName {
+		t.Errorf("got encrypter name: %s, want: %s\n", got.EncrypterName, encrypterName)
+	}
+
+	if got.Salt != salt {
+		t.Errorf("got salt: %s, want: %s\n", got.Salt, salt)
+	}
+
+	if got.CreatedAt.Before(time.Now().Add(-time.Hour)) {
+		t.Errorf("got CreatedAt=%s, want CreatedAt within the last hour\n", got.CreatedAt)
+	}
+
+	_, err = s.getKeys(ctx)
+	if errors.Cause(err) != sql.ErrNoRows {
+		t.Errorf("expect the keys blob of the user %s to be deleted", userID(ctx))
 	}
 }

--- a/exp/services/keystore/spec.md
+++ b/exp/services/keystore/spec.md
@@ -128,8 +128,12 @@ the token is valid. This endpoint does not take any parameter.
 
 Delete Keys Response:
 
+*Success:*
+
 ```typescript
-type DeleteKeysResponse = EncryptedKeysData;
+interface Success {
+	message: "ok";
+}
 ```
 
 <details><summary>Errors</summary>

--- a/support/render/hal/handler.go
+++ b/support/render/hal/handler.go
@@ -2,6 +2,7 @@ package hal
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -14,6 +15,8 @@ var (
 	errorType   = reflect.TypeOf((*error)(nil)).Elem()
 	contextType = reflect.TypeOf((*context.Context)(nil)).Elem()
 )
+
+var DefaultResponse = json.RawMessage(`{"message":"ok"}`)
 
 type handler struct {
 	fv           reflect.Value
@@ -65,6 +68,10 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		problem.Render(ctx, w, err)
 		return
+	}
+
+	if res == nil {
+		res = &DefaultResponse
 	}
 
 	Render(w, res)


### PR DESCRIPTION
This PR adds HTTP `DELETE` method to `/keys`. This PR updates the spec so that we return a default response `{message: "ok"}` once the operation is successful.