### PR TITLE
"Action needed" tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
             if [ "$CIRCLE_TAG" != "" ]; then
               # Negate the result so process exits with 1 if anything found
               echo "Searching for \"action needed\" tags..."
-              ! egrep -irn -A 1 --include=*.go "Action.+needed.+before:.+$CIRCLE_TAG" ./
+              ! egrep -irn -A 1 --include=*.go "Action.+needed.+in.+release:.+$CIRCLE_TAG" ./
             fi
 
   # install_go_deps installs the go dependencies of the project.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,8 @@ commands:
           command: |
             if [ "$CIRCLE_TAG" != "" ]; then
               # Negate the result so process exits with 1 if anything found
-              echo "Searching for deprecated values in Horizon..."
-              ! egrep -irn -A 1 --include=*.go "Deprecated.+-.+remove.+in:.+$CIRCLE_TAG" ./services/horizon/ ./protocols/horizon/
+              echo "Searching for \"action needed\" tags..."
+              ! egrep -irn -A 1 --include=*.go "Action.+needed.+before:.+$CIRCLE_TAG" ./
             fi
 
   # install_go_deps installs the go dependencies of the project.

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -401,15 +401,16 @@ type Transaction struct {
 	LedgerCloseTime time.Time `json:"created_at"`
 	Account         string    `json:"source_account"`
 	AccountSequence string    `json:"source_account_sequence"`
-	// Action needed before: horizon-v0.19.0
-	// Action needed before: horizonclient-v2.0.0
+	// Action needed in release: horizon-v0.19.0
+	// Action needed in release: horizonclient-v2.0.0
+	// Remove this field.
 	FeePaid int32 `json:"fee_paid"`
-	// Action needed before: horizon-v0.18.0
-	// Action needed before: horizonclient-v1.3.0
+	// Action needed in release: horizon-v0.18.0
+	// Action needed in release: horizonclient-v1.3.0
 	// Start displaying in horizon-v0.18.0 and horizonclient-v1.3.0
 	// FeeCharged int32 `json:"fee_charged"`
-	// Action needed before: horizon-v0.18.0
-	// Action needed before: horizonclient-v1.3.0
+	// Action needed in release: horizon-v0.18.0
+	// Action needed in release: horizonclient-v1.3.0
 	// Start displaying in horizon-v0.18.0 and horizonclient-v1.3.0
 	// MaxFee         int32    `json:"max_fee"`
 	OperationCount int32    `json:"operation_count"`

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -401,12 +401,15 @@ type Transaction struct {
 	LedgerCloseTime time.Time `json:"created_at"`
 	Account         string    `json:"source_account"`
 	AccountSequence string    `json:"source_account_sequence"`
-	// Deprecated - remove in: horizon-v0.19.0 and horizonclient-v2.0.0
+	// Action needed before: horizon-v0.19.0
+	// Action needed before: horizonclient-v2.0.0
 	FeePaid int32 `json:"fee_paid"`
-	// Deprecated - remove in: horizon-v0.18.0
+	// Action needed before: horizon-v0.18.0
+	// Action needed before: horizonclient-v1.3.0
 	// Start displaying in horizon-v0.18.0 and horizonclient-v1.3.0
 	// FeeCharged int32 `json:"fee_charged"`
-	// Deprecated - remove in: horizon-v0.18.0
+	// Action needed before: horizon-v0.18.0
+	// Action needed before: horizonclient-v1.3.0
 	// Start displaying in horizon-v0.18.0 and horizonclient-v1.3.0
 	// MaxFee         int32    `json:"max_fee"`
 	OperationCount int32    `json:"operation_count"`

--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -16,10 +16,10 @@ var TypeNames = map[xdr.OperationType]string{
 	xdr.OperationTypeCreateAccount: "create_account",
 	xdr.OperationTypePayment:       "payment",
 	xdr.OperationTypePathPayment:   "path_payment",
-	// Action needed before: horizon-v0.18.0
+	// Action needed in release: horizon-v0.18.0
 	// Change name to `manage_sell_offer`
 	xdr.OperationTypeManageSellOffer: "manage_offer",
-	// Action needed before: horizon-v0.18.0
+	// Action needed in release: horizon-v0.18.0
 	// Change name to `create_passive_sell_offer`
 	xdr.OperationTypeCreatePassiveSellOffer: "create_passive_offer",
 	xdr.OperationTypeSetOptions:             "set_options",

--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -16,10 +16,10 @@ var TypeNames = map[xdr.OperationType]string{
 	xdr.OperationTypeCreateAccount: "create_account",
 	xdr.OperationTypePayment:       "payment",
 	xdr.OperationTypePathPayment:   "path_payment",
-	// Deprecated - remove in: horizon-v0.18.0
+	// Action needed before: horizon-v0.18.0
 	// Change name to `manage_sell_offer`
 	xdr.OperationTypeManageSellOffer: "manage_offer",
-	// Deprecated - remove in: horizon-v0.18.0
+	// Action needed before: horizon-v0.18.0
 	// Change name to `create_passive_sell_offer`
 	xdr.OperationTypeCreatePassiveSellOffer: "create_passive_offer",
 	xdr.OperationTypeSetOptions:             "set_options",

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,7 +6,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
-## Unreleased
+## Unreleased v0.17.7
 
 * Fixed `fee_paid` value in Transaction resource.
 * Fix "int64: value out of range" errors in trade aggregations (#1319).

--- a/services/horizon/internal/resourceadapter/transaction.go
+++ b/services/horizon/internal/resourceadapter/transaction.go
@@ -34,7 +34,7 @@ func PopulateTransaction(
 	dest.AccountSequence = row.AccountSequence
 	dest.FeePaid = row.FeeCharged
 
-	// Deprecated - remove in: horizon-v0.18.0
+	// Action needed before: horizon-v0.18.0
 	// Uncomment in horizon-v0.18.0
 	// dest.FeeCharged = row.FeeCharged
 	// dest.MaxFee = row.MaxFee

--- a/services/horizon/internal/resourceadapter/transaction.go
+++ b/services/horizon/internal/resourceadapter/transaction.go
@@ -34,7 +34,7 @@ func PopulateTransaction(
 	dest.AccountSequence = row.AccountSequence
 	dest.FeePaid = row.FeeCharged
 
-	// Action needed before: horizon-v0.18.0
+	// Action needed in release: horizon-v0.18.0
 	// Uncomment in horizon-v0.18.0
 	// dest.FeeCharged = row.FeeCharged
 	// dest.MaxFee = row.MaxFee

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -194,7 +194,8 @@ func (w *web) mustInstallActions(enableAssetStats bool, friendbotURL *url.URL) {
 
 	// Network state related endpoints
 	r.Get("/fee_stats", OperationFeeStatsAction{}.Handle)
-	// Action needed before: horizon-v0.18.0
+	// Action needed in release: horizon-v0.18.0
+	// Remove this endpoint.
 	r.Get("/operation_fee_stats", OperationFeeStatsAction{}.Handle)
 
 	// friendbot

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -194,7 +194,7 @@ func (w *web) mustInstallActions(enableAssetStats bool, friendbotURL *url.URL) {
 
 	// Network state related endpoints
 	r.Get("/fee_stats", OperationFeeStatsAction{}.Handle)
-	// Deprecated - remove in: horizon-v0.18.0
+	// Action needed before: horizon-v0.18.0
 	r.Get("/operation_fee_stats", OperationFeeStatsAction{}.Handle)
 
 	// friendbot


### PR DESCRIPTION
In #833 we introduced Horizon deprecation tags that act like a reminder to remove deprecated fields in a given version. It seems that deprecations are not the only thing you want to be reminded about. I propose to change this tag to:
```
Action needed before: $CIRCLE_TAG
```
and the following line explains what need to be done before releasing a given version.