### PR TITLE
Process LedgerEntryChange instead of LedgerEntry

### DIFF
--- a/exp/ingest/adapters/history_archive_adapter_test.go
+++ b/exp/ingest/adapters/history_archive_adapter_test.go
@@ -2,7 +2,6 @@ package ingestadapters
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
 	"github.com/stellar/go/exp/ingest/io"
@@ -57,17 +56,16 @@ func TestGetState_Read(t *testing.T) {
 		return
 	}
 
-	le, e := sr.Read()
+	lec, e := sr.Read()
 	if !assert.NoError(t, e) {
 		return
 	}
 	assert.NotEqual(t, e, io.EOF)
 
-	log.Printf("%v\n", le)
-	if !assert.NotNil(t, le) {
+	if !assert.NotNil(t, lec) {
 		return
 	}
-	assert.Equal(t, "GAFBQT4VRORLEVEECUYDQGWNVQ563ZN76LGRJR7T7KDL32EES54UOQST", le.Data.Account.AccountId.Address())
+	assert.Equal(t, "GAFBQT4VRORLEVEECUYDQGWNVQ563ZN76LGRJR7T7KDL32EES54UOQST", lec.State.Data.Account.AccountId.Address())
 }
 
 func getTestArchive() (*historyarchive.Archive, error) {

--- a/exp/ingest/io/main.go
+++ b/exp/ingest/io/main.go
@@ -14,7 +14,7 @@ type StateReadCloser interface {
 	GetSequence() uint32
 	// Read should return next ledger entry. If there are no more
 	// entries it should return `EOF` error.
-	Read() (xdr.LedgerEntry, error)
+	Read() (xdr.LedgerEntryChange, error)
 	// Close should be called when reading is finished. This is especially
 	// helpful when there are still some entries available so reader can stop
 	// streaming them.
@@ -23,12 +23,12 @@ type StateReadCloser interface {
 
 // StateWriteCloser interface placeholder
 type StateWriteCloser interface {
-	// Write is used to pass ledger entry to the next processor. It can return
+	// Write is used to pass ledger entry change to the next processor. It can return
 	// `ErrClosedPipe` when the pipe between processors has been closed meaning
 	// that next processor does not need more data. In such situation the current
 	// processor can terminate as sending more entries to a `StateWriteCloser`
 	// does not make sense (will not be read).
-	Write(xdr.LedgerEntry) error
+	Write(xdr.LedgerEntryChange) error
 	// Close should be called when there are no more entries
 	// to write.
 	Close() error

--- a/exp/ingest/pipeline/buffered_state_read_write_closer.go
+++ b/exp/ingest/pipeline/buffered_state_read_write_closer.go
@@ -8,7 +8,7 @@ import (
 const bufferSize = 50000
 
 func (b *bufferedStateReadWriteCloser) init() {
-	b.buffer = make(chan xdr.LedgerEntry, bufferSize)
+	b.buffer = make(chan xdr.LedgerEntryChange, bufferSize)
 }
 
 func (b *bufferedStateReadWriteCloser) close() {
@@ -23,7 +23,7 @@ func (b *bufferedStateReadWriteCloser) GetSequence() uint32 {
 	return 0
 }
 
-func (b *bufferedStateReadWriteCloser) Read() (xdr.LedgerEntry, error) {
+func (b *bufferedStateReadWriteCloser) Read() (xdr.LedgerEntryChange, error) {
 	b.initOnce.Do(b.init)
 
 	entry, more := <-b.buffer
@@ -33,11 +33,11 @@ func (b *bufferedStateReadWriteCloser) Read() (xdr.LedgerEntry, error) {
 		b.readEntriesMutex.Unlock()
 		return entry, nil
 	} else {
-		return xdr.LedgerEntry{}, io.EOF
+		return xdr.LedgerEntryChange{}, io.EOF
 	}
 }
 
-func (b *bufferedStateReadWriteCloser) Write(entry xdr.LedgerEntry) error {
+func (b *bufferedStateReadWriteCloser) Write(entry xdr.LedgerEntryChange) error {
 	b.initOnce.Do(b.init)
 
 	b.writeCloseMutex.Lock()

--- a/exp/ingest/pipeline/main.go
+++ b/exp/ingest/pipeline/main.go
@@ -23,7 +23,7 @@ type bufferedStateReadWriteCloser struct {
 
 	// closeOnce protects from closing buffer twice
 	closeOnce sync.Once
-	buffer    chan xdr.LedgerEntry
+	buffer    chan xdr.LedgerEntryChange
 	closed    bool
 }
 

--- a/exp/ingest/pipeline/multi_write_closer.go
+++ b/exp/ingest/pipeline/multi_write_closer.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-func (m *multiWriteCloser) Write(entry xdr.LedgerEntry) error {
+func (m *multiWriteCloser) Write(entry xdr.LedgerEntryChange) error {
 	m.mutex.Lock()
 	m.wroteEntries++
 	m.mutex.Unlock()
@@ -63,3 +63,5 @@ func (m *multiWriteCloser) Close() error {
 
 	return nil
 }
+
+var _ io.StateWriteCloser = &multiWriteCloser{}

--- a/exp/tools/accounts-for-signer/filters.go
+++ b/exp/tools/accounts-for-signer/filters.go
@@ -51,7 +51,7 @@ func (p *EntryTypeFilter) ProcessState(ctx context.Context, store *pipeline.Stor
 			}
 		}
 
-		if entry.Data.Type == p.Type {
+		if entry.State.Data.Type == p.Type {
 			err := w.Write(entry)
 			if err != nil {
 				if err == io.ErrClosedPipe {
@@ -97,11 +97,11 @@ func (p *AccountsForSignerProcessor) ProcessState(ctx context.Context, store *pi
 			}
 		}
 
-		if entry.Data.Type != xdr.LedgerEntryTypeAccount {
+		if entry.State.Data.Type != xdr.LedgerEntryTypeAccount {
 			continue
 		}
 
-		for _, signer := range entry.Data.Account.Signers {
+		for _, signer := range entry.State.Data.Account.Signers {
 			if signer.Key.Address() == p.Signer {
 				err := w.Write(entry)
 				if err != nil {
@@ -161,14 +161,14 @@ func (p *PrintAllProcessor) ProcessState(ctx context.Context, store *pipeline.St
 			}
 		}
 
-		switch entry.Data.Type {
+		switch entry.State.Data.Type {
 		case xdr.LedgerEntryTypeAccount:
 			fmt.Fprintf(
 				f,
 				"%s,%d,%d\n",
-				entry.Data.Account.AccountId.Address(),
-				entry.Data.Account.Balance,
-				entry.Data.Account.SeqNum,
+				entry.State.Data.Account.AccountId.Address(),
+				entry.State.Data.Account.Balance,
+				entry.State.Data.Account.SeqNum,
 			)
 			foundEntries++
 		default:

--- a/tools/archive-reader/archive_reader.go
+++ b/tools/archive-reader/archive_reader.go
@@ -44,7 +44,7 @@ func main() {
 			return
 		}
 
-		if ae, valid := le.Data.GetAccount(); valid {
+		if ae, valid := le.State.Data.GetAccount(); valid {
 			addr := ae.AccountId.Address()
 			if _, exists := accounts[addr]; exists {
 				log.Fatalf("error, total seen %d entries of which %d were unique accounts; repeated account: %s", i, count, addr)


### PR DESCRIPTION
In preparation for `ingest.Session` object implementation we change object type processed by `StateProcessor` from `LedgerEntry` to `LedgerEntryChange`.

`ingest.Session` responsibility is to connect and synchronize history and ledger backend pipelines. The main session types are:
* Checkpoint only session: in this session we build a state from a checkpoint history bucket and apply changes using aggregated ledger entry changes available in history archives (so called ["low resolution custom view"](https://github.com/stellar/stellar-core/blob/master/docs/integration.md#low-resolution-custom-view)).
* Live session: in this session we build a state from a checkpoint history bucket and apply changes using stellar-core real-time metadata, available for each transaction (so called ["high resolution custom view"](https://github.com/stellar/stellar-core/blob/master/docs/integration.md#high-resolution-custom-view)).

The motivation behind using `LedgerEntryChange` is that `StateProcessor` will be responsible not only for initializing a state but also for updating it in "Checkpoint-only Session". There is no way to pass information about updates or removals using `LedgerEntry` object. The following table describes responsibilities of each processor in a different session types:

x | Checkpoint-only Session | Live Session
-|-|-
Initializing state | `StateProcessor` | `StateProcessor`
Updating state | `StateProcessor` | `TransactionProcessor`
Processing transactions (envelope, results) | `TransactionProcessor` <sup>1</sup> | `TransactionProcessor`

<sup>1</sup> `Meta` field for a transaction will be empty as data is not available in history archives.

The `CheckpointSession` behaviour can be the following:
1. Initialize state using `StateProcessor` pipeline.
2. For each new checkpoint, process `LedgerEntryChange`s using `StateProcessor` pipeline.
3. [optional] Save transaction envelopes and results using `TransactionProcessor` pipeline.

The `LiveSession` behaviour can be the following:
1. Initialize state using `StateProcessor` pipeline.
2. For each new ledger, process transactions using `TransactionProcessor` pipeline (this also updates the state using transaction meta).