### PR TITLE
support/render/hal: relax the return value constraint

### DIFF
--- a/exp/services/keystore/keys.go
+++ b/exp/services/keystore/keys.go
@@ -101,12 +101,10 @@ func (s *Service) getKeys(ctx context.Context) (*encryptedKeys, error) {
 	return &out, nil
 }
 
-//TODO: make support/render/hal be able to handle function with only 1 return
-//value
-func (s *Service) deleteKeys(ctx context.Context) (interface{}, error) {
+func (s *Service) deleteKeys(ctx context.Context) error {
 	userID := userID(ctx)
 	if userID == "" {
-		return nil, probNotAuthorized
+		return probNotAuthorized
 	}
 
 	q := `
@@ -114,5 +112,5 @@ func (s *Service) deleteKeys(ctx context.Context) (interface{}, error) {
 		WHERE user_id = $1
 	`
 	_, err := s.db.ExecContext(ctx, q, userID)
-	return nil, errors.Wrap(err, "deleting keys blob")
+	return errors.Wrap(err, "deleting keys blob")
 }

--- a/exp/services/keystore/keys_test.go
+++ b/exp/services/keystore/keys_test.go
@@ -133,7 +133,7 @@ func TestDeleteKeys(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = s.deleteKeys(ctx)
+	err = s.deleteKeys(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/support/render/hal/handler.go
+++ b/support/render/hal/handler.go
@@ -70,10 +70,6 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if res == nil {
-		res = &DefaultResponse
-	}
-
 	Render(w, res)
 }
 

--- a/support/render/hal/handler.go
+++ b/support/render/hal/handler.go
@@ -158,7 +158,7 @@ func funcParamType(fv reflect.Value) (reflect.Type, error) {
 	if n := ft.NumOut(); n == 2 && !ft.Out(1).Implements(errorType) {
 		return nil, fmt.Errorf("%s: second return value must be an error", ft.String())
 	} else if n > 2 {
-		return nil, fmt.Errorf("%s can only have at most two return values", ft.String())
+		return nil, fmt.Errorf("%s can have at most two return values", ft.String())
 	}
 
 	return paramType, nil

--- a/support/render/hal/handler.go
+++ b/support/render/hal/handler.go
@@ -95,9 +95,27 @@ func (h *handler) executeFunc(ctx context.Context, req *http.Request) (interface
 		}
 	}
 
+	var (
+		res interface{}
+		err error
+	)
 	rv := h.fv.Call(a)
-	err, _ := rv[1].Interface().(error)
-	return rv[0].Interface(), err
+	switch n := len(rv); {
+	case n == 0:
+		res = &DefaultResponse
+	case n == 1:
+		if h.fv.Type().Out(0).Implements(errorType) {
+			res = &DefaultResponse
+			err, _ = rv[0].Interface().(error)
+		} else {
+			res = rv[0].Interface()
+		}
+	case n == 2:
+		res = rv[0].Interface()
+		err, _ = rv[1].Interface().(error)
+	}
+
+	return res, err
 }
 
 // ExecuteFunc executes the fn with the param after checking whether the
@@ -124,10 +142,11 @@ func ExecuteFunc(ctx context.Context, fn, param interface{}) (interface{}, bool,
 // functions with certain signatures.
 // The allowed function signature is as following:
 //
-//   func fn(ctx context.Context, an_optional_param) (interface{}, err)
+//   func fn(ctx context.Context, an_optional_param) (at_most_two_return_values)
 //
-// The caller must provide a function with at least 1 input (request context) and up to 2 inputs,
-// and exact 2 return values, where the second value has to be error type.
+// The caller must provide a function with at least 1 input (request context)
+// and up to 2 inputs, and up to 2 return values. If there are two return
+// values, the second value has to be error type.
 func funcParamType(fv reflect.Value) (reflect.Type, error) {
 	ft := fv.Type()
 
@@ -140,8 +159,10 @@ func funcParamType(fv reflect.Value) (reflect.Type, error) {
 		paramType = ft.In(1)
 	}
 
-	if ft.NumOut() != 2 || !ft.Out(1).Implements(errorType) {
-		return nil, fmt.Errorf("%s must have two return values, and the second return value must be an error", ft.String())
+	if n := ft.NumOut(); n == 2 && !ft.Out(1).Implements(errorType) {
+		return nil, fmt.Errorf("%s: second return value must be an error", ft.String())
+	} else if n > 2 {
+		return nil, fmt.Errorf("%s can only have at most two return values", ft.String())
 	}
 
 	return paramType, nil

--- a/support/render/hal/handler_test.go
+++ b/support/render/hal/handler_test.go
@@ -107,3 +107,19 @@ func TestFuncParamTypeError(t *testing.T) {
 		}
 	}
 }
+
+func TestFuncParamTypeNoError(t *testing.T) {
+	cases := []interface{}{
+		func(context.Context) {},                                  // no return value
+		func(context.Context) int { return 0 },                    // one non-error type return value
+		func(context.Context) error { return nil },                // one error type return value
+		func(context.Context, int) (int, error) { return 0, nil }, // two return values
+	}
+
+	for _, tc := range cases {
+		_, err := funcParamType(reflect.ValueOf(tc))
+		if err != nil {
+			t.Errorf("funcParamType(%T) got error %v", tc, err)
+		}
+	}
+}

--- a/support/render/hal/handler_test.go
+++ b/support/render/hal/handler_test.go
@@ -50,7 +50,7 @@ func TestHandler(t *testing.T) {
 	}
 }
 
-func TestPostHandler(t *testing.T) {
+func TestReqBodyHandler(t *testing.T) {
 	cases := []struct {
 		input   string
 		output  string
@@ -95,7 +95,6 @@ func TestFuncParamTypeError(t *testing.T) {
 		"a string",                               // not a function
 		func() (int, error) { return 0, nil },    // no inputs
 		func(int) (int, error) { return 0, nil }, // first input is not context
-		func(context.Context) {},                 // not return values
 		func(context.Context, int, int) (int, error) { return 0, nil }, // too many inputs
 		func(context.Context, int) (int, int) { return 0, 0 },          // second return value is not an error
 		func() (int, int, error) { return 0, 0, nil },                  // too many return values


### PR DESCRIPTION
This PR relaxes the two-return-value constraint in the function type check. We will return a default response if there's no return value. If there's one return value, we will return something based on whether that single return value is an error or not.

The motivation behind this improvement is that in keystore we have a HTTP DELETE endpoint, where we only return a default response if it's successful.