### PR TITLE
txnbuild: Initialise transaction envelope in build

### DIFF
--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -1,12 +1,10 @@
 /*
 Package txnbuild implements transactions and operations on the Stellar network.
-
 This library provides an interface to the Stellar transaction model. It supports the building of Go applications on
 top of the Stellar network (https://www.stellar.org/). Transactions constructed by this library may be submitted
 to any Horizon instance for processing onto the ledger, using any Stellar SDK client. The recommended client for Go
 programmers is horizonclient (https://github.com/stellar/go/tree/master/clients/horizonclient). Together, these two
 libraries provide a complete Stellar SDK.
-
 For more information and further examples, see https://www.stellar.org/developers/go/reference/index.html.
 */
 package txnbuild
@@ -125,6 +123,12 @@ func (tx *Transaction) Build() error {
 	// Set a default fee, if it hasn't been set yet
 	tx.SetDefaultFee()
 
+	// Initialise transaction envelope
+	if tx.xdrEnvelope == nil {
+		tx.xdrEnvelope = &xdr.TransactionEnvelope{}
+		tx.xdrEnvelope.Tx = tx.xdrTransaction
+	}
+
 	return nil
 }
 
@@ -133,11 +137,6 @@ func (tx *Transaction) Build() error {
 func (tx *Transaction) Sign(kps ...*keypair.Full) error {
 	// TODO: Only sign if Transaction has been previously built
 	// TODO: Validate network set before sign
-	// Initialise transaction envelope
-	if tx.xdrEnvelope == nil {
-		tx.xdrEnvelope = &xdr.TransactionEnvelope{}
-		tx.xdrEnvelope.Tx = tx.xdrTransaction
-	}
 
 	// Hash the transaction
 	hash, err := tx.Hash()


### PR DESCRIPTION
Instead of building the transaction envelope at the start of Sign we can do this at the end of build. This allows an unsigned envelope to be returned for signing offline/elsewhere

Fix for: https://github.com/stellar/go/issues/956

This is my first ever PR on Github so hopefully I got this bit right :)