### PR TITLE
ci: ensure check_deprecations runs on tagged releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,6 @@ jobs:
       - image: circleci/golang:1.10
     steps:
       - govet
-      - check_deprecations
 
   # check_code_1_11 performs code checks using Go 1.11 (gofmt is only run for 1.12).
   check_code_1_11:
@@ -103,7 +102,6 @@ jobs:
       - image: circleci/golang:1.11
     steps:
       - govet
-      - check_deprecations
 
   # check_code_1_12 performs code checks using Go 1.12.
   check_code_1_12:
@@ -113,7 +111,6 @@ jobs:
     steps:
       - gofmt
       - govet
-      - check_deprecations
 
   # test_code_1_10 performs all package tests using Go 1.10.
   test_code_1_10:
@@ -184,6 +181,7 @@ jobs:
     docker:
       - image: circleci/golang:1.11
     steps:
+      - check_deprecations
       - install_go_deps
       - build_packages
       - attach_workspace:


### PR DESCRIPTION
This PR ensures CircleCI checks for deprecations before publishing artifacts to tagged releases.