### PR TITLE
services/ticker: ensure docker pulls ticker binary from stellar/go releases

### DIFF
--- a/services/ticker/docker/setup
+++ b/services/ticker/docker/setup
@@ -10,7 +10,9 @@ mkdir -p /opt/stellar/www
 chown -R stellar:stellar /opt/stellar/www
 mkdir -p /opt/stellar/postgresql/data
 
-wget -O ticker.tar.gz https://github.com/accordeiro/ticker-releases/releases/download/v0.5.3-alpha/ticker.tar.gz
+export TICKER="ticker-v1.0.0"
+export TICKER_PATH="$TICKER-linux-amd64"
+wget -O ticker.tar.gz https://github.com/stellar/go/releases/download/$TICKER/$TICKER_PATH.tar.gz
 tar -xvzf ticker.tar.gz
-mv ticker /opt/stellar/bin/ticker
+mv $TICKER_PATH/ticker /opt/stellar/bin/ticker
 chmod +x /opt/stellar/bin/ticker


### PR DESCRIPTION
The ticker Docker config originally pulled the ticker binary from a separate repo. This PR aims to change this config, so Docker pulls the ticker bin directly from `stellar/go` releases. 

After merging, we should create a `ticker-v1.0.0` release targeting the squashed commit of this PR.