### PR TITLE
Fix race condition in `mirror` command

### DIFF
--- a/support/historyarchive/mirror.go
+++ b/support/historyarchive/mirror.go
@@ -62,18 +62,18 @@ func Mirror(src *Archive, dst *Archive, opts *CommandOptions) error {
 					bucketFetchMutex.Unlock()
 					if !alreadyFetching {
 						pth := BucketPath(bucket)
-						e = copyPath(src, dst, pth, opts)
-						atomic.AddUint32(&errs, noteError(e))
+						err = copyPath(src, dst, pth, opts)
+						atomic.AddUint32(&errs, noteError(err))
 					}
 				}
 
 				for _, cat := range Categories() {
 					pth := CategoryCheckpointPath(cat, ix)
-					e = copyPath(src, dst, pth, opts)
-					if e != nil && !categoryRequired(cat) {
+					err = copyPath(src, dst, pth, opts)
+					if err != nil && !categoryRequired(cat) {
 						continue
 					}
-					atomic.AddUint32(&errs, noteError(e))
+					atomic.AddUint32(&errs, noteError(err))
 				}
 				tick <- true
 			}

--- a/tools/stellar-archivist/CHANGELOG.md
+++ b/tools/stellar-archivist/CHANGELOG.md
@@ -6,6 +6,10 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## ???
+
+* Fix race condition in `mirror` command
+
 ## [v0.1.0] - 2016-08-17
 
 Initial release after import from https://github.com/stellar/archivist


### PR DESCRIPTION
Use an error variable scoped to the goroutine function instead of the
outer function. Otherwise there can be a race condition where different
goroutines overwrite each others error variable.

This led to errors such as:

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x4629e5]

    goroutine 15 [running]:
    errors.(*errorString).Error(0x0, 0xc4205df648, 0x4c5d67)
            /usr/lib/go-1.10/src/errors/errors.go:19 +0x5
    github.com/stellar/go/support/historyarchive.noteError(0xbd7140, 0x0, 0x1)
            /home/enode/go/src/github.com/stellar/go/support/historyarchive/util.go:122 +0x3e
    github.com/stellar/go/support/historyarchive.Mirror.func2(0xc42008e0c0, 0xc42025f950, 0xc4200282a8, 0xc4200282a0, 0xc420168360, 0xc42025f9e0, 0xc420192440, 0xc42017aeb0, 0xc42008e060, 0xc4200282b0)
            /home/enode/go/src/github.com/stellar/go/support/historyarchive/mirror.go:81 +0x6d1
    created by github.com/stellar/go/support/historyarchive.Mirror
            /home/enode/go/src/github.com/stellar/go/support/historyarchive/mirror.go:44 +0x3b5
