### PR TITLE
exp/keystore: add auth forwarding mechanism with HTTP GET

### DIFF
--- a/exp/services/keystore/api.go
+++ b/exp/services/keystore/api.go
@@ -62,6 +62,7 @@ func authHandler(next http.Handler, authenticator *Authenticator) http.Handler {
 		var (
 			proxyReq *http.Request
 			err      error
+			clientIP string
 		)
 		ctx := req.Context()
 		// set a 5-second timeout
@@ -84,7 +85,7 @@ func authHandler(next http.Handler, authenticator *Authenticator) http.Handler {
 
 		// shallow copy
 		proxyReq.Header = req.Header
-		if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+		if clientIP, _, err = net.SplitHostPort(req.RemoteAddr); err == nil {
 			proxyReq.Header.Set("X-Forwarded-For", clientIP)
 		}
 

--- a/exp/services/keystore/api.go
+++ b/exp/services/keystore/api.go
@@ -54,7 +54,8 @@ func (s *Service) keysHTTPMethodHandler() http.Handler {
 func authHandler(next http.Handler, authenticator *Authenticator) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if authenticator == nil {
-			next.ServeHTTP(rw, req)
+			// to facilitate API testing
+			next.ServeHTTP(rw, req.WithContext(withUserID(req.Context(), "test-user")))
 			return
 		}
 
@@ -63,6 +64,7 @@ func authHandler(next http.Handler, authenticator *Authenticator) http.Handler {
 			err      error
 		)
 		ctx := req.Context()
+		// set a 5-second timeout
 		client := http.Client{Timeout: time.Duration(5 * time.Second)}
 
 		switch authenticator.APIType {

--- a/exp/services/keystore/api.go
+++ b/exp/services/keystore/api.go
@@ -2,7 +2,11 @@ package keystore
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
@@ -18,13 +22,14 @@ func init() {
 	problem.RegisterHost("")
 }
 
-func wrapMiddleware(handler http.Handler) http.Handler {
+func (s *Service) wrapMiddleware(handler http.Handler) http.Handler {
+	handler = authHandler(handler, s.authenticator)
 	return recoverHandler(handler)
 }
 
 func ServeMux(s *Service) http.Handler {
 	mux := http.NewServeMux()
-	mux.Handle("/keys", wrapMiddleware(s.keysHTTPMethodHandler()))
+	mux.Handle("/keys", s.wrapMiddleware(s.keysHTTPMethodHandler()))
 	return mux
 }
 
@@ -43,6 +48,65 @@ func (s *Service) keysHTTPMethodHandler() http.Handler {
 		default:
 			problem.Render(req.Context(), rw, probMethodNotAllowed)
 		}
+	})
+}
+
+func authHandler(next http.Handler, authenticator *Authenticator) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if authenticator == nil {
+			next.ServeHTTP(rw, req)
+			return
+		}
+
+		var (
+			proxyReq *http.Request
+			err      error
+		)
+		ctx := req.Context()
+		client := http.Client{Timeout: time.Duration(5 * time.Second)}
+
+		switch authenticator.APIType {
+		case REST:
+			proxyReq, err = http.NewRequest("GET", authenticator.URL, nil)
+			if err != nil {
+				problem.Render(ctx, rw, err)
+				return
+			}
+
+		case GraphQL:
+			// to be implemented later
+		default:
+			problem.Render(ctx, rw, probNotAuthorized)
+			return
+		}
+
+		// shallow copy
+		proxyReq.Header = req.Header
+		if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+			proxyReq.Header.Set("X-Forwarded-For", clientIP)
+		}
+
+		resp, err := client.Do(proxyReq)
+		if err != nil {
+			problem.Render(ctx, rw, err)
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				problem.Render(ctx, rw, err)
+				return
+			}
+			// assuming the context-type is text/plain
+			ctx = withUserID(ctx, strings.TrimSpace(string(body)))
+		} else {
+			problem.Render(ctx, rw, probNotAuthorized)
+			return
+		}
+
+		next.ServeHTTP(rw, req.WithContext(ctx))
 	})
 }
 

--- a/exp/services/keystore/api_test.go
+++ b/exp/services/keystore/api_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -22,7 +23,18 @@ func TestPutKeysAPI(t *testing.T) {
 	conn := db.Open()
 	defer conn.Close() // close db connection
 
-	h := ServeMux(&Service{conn.DB})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "test-user")
+	}))
+	defer ts.Close()
+
+	h := ServeMux(&Service{
+		db: conn.DB,
+		authenticator: &Authenticator{
+			URL:     ts.URL,
+			APIType: REST,
+		},
+	})
 
 	blob := `[{
 		"keyType": "plaintextKey",
@@ -42,13 +54,11 @@ func TestPutKeysAPI(t *testing.T) {
 	}
 
 	req := httptest.NewRequest("PUT", "/keys", bytes.NewReader([]byte(body)))
-	req = req.WithContext(withUserID(context.Background(), "test-user"))
-
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusOK {
-		t.Errorf("PUT %s responded with %s, want %s", req.URL, http.StatusText(rr.Code), http.StatusText(http.StatusOK))
+		t.Fatalf("PUT %s responded with %s, want %s", req.URL, http.StatusText(rr.Code), http.StatusText(http.StatusOK))
 	}
 	got := &encryptedKeys{}
 	json.Unmarshal(rr.Body.Bytes(), &got)
@@ -80,8 +90,18 @@ func TestGetKeysAPI(t *testing.T) {
 	conn := db.Open()
 	defer conn.Close() // close db connection
 
-	ctx := withUserID(context.Background(), "test-user")
-	s := &Service{conn.DB}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "test-user")
+	}))
+	defer ts.Close()
+
+	s := &Service{
+		db: conn.DB,
+		authenticator: &Authenticator{
+			URL:     ts.URL,
+			APIType: REST,
+		},
+	}
 	h := ServeMux(s)
 
 	blob := `[{
@@ -93,7 +113,7 @@ func TestGetKeysAPI(t *testing.T) {
 	encrypterName := "identity"
 	salt := "random-salt"
 
-	_, err := s.putKeys(ctx, putKeysRequest{
+	_, err := s.putKeys(withUserID(context.Background(), "test-user"), putKeysRequest{
 		KeysBlob:      encodedBlob,
 		EncrypterName: encrypterName,
 		Salt:          salt,
@@ -103,13 +123,11 @@ func TestGetKeysAPI(t *testing.T) {
 	}
 
 	req := httptest.NewRequest("GET", "/keys", nil)
-	req = req.WithContext(ctx)
-
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusOK {
-		t.Errorf("GET %s responded with %s, want %s", req.URL, http.StatusText(rr.Code), http.StatusText(http.StatusOK))
+		t.Fatalf("GET %s responded with %s, want %s", req.URL, http.StatusText(rr.Code), http.StatusText(http.StatusOK))
 	}
 	got := &encryptedKeys{}
 	json.Unmarshal(rr.Body.Bytes(), &got)
@@ -141,8 +159,18 @@ func TestDeleteKeysAPI(t *testing.T) {
 	conn := db.Open()
 	defer conn.Close() // close db connection
 
-	ctx := withUserID(context.Background(), "test-user")
-	s := &Service{conn.DB}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "test-user")
+	}))
+	defer ts.Close()
+
+	s := &Service{
+		db: conn.DB,
+		authenticator: &Authenticator{
+			URL:     ts.URL,
+			APIType: REST,
+		},
+	}
 	h := ServeMux(s)
 
 	blob := `[{
@@ -154,6 +182,7 @@ func TestDeleteKeysAPI(t *testing.T) {
 	encrypterName := "identity"
 	salt := "random-salt"
 
+	ctx := withUserID(context.Background(), "test-user")
 	_, err := s.putKeys(ctx, putKeysRequest{
 		KeysBlob:      encodedBlob,
 		EncrypterName: encrypterName,
@@ -164,13 +193,11 @@ func TestDeleteKeysAPI(t *testing.T) {
 	}
 
 	req := httptest.NewRequest("DELETE", "/keys", nil)
-	req = req.WithContext(ctx)
-
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusOK {
-		t.Errorf("DELETE %s responded with %s, want %s", req.URL, http.StatusText(rr.Code), http.StatusText(http.StatusOK))
+		t.Fatalf("DELETE %s responded with %s, want %s", req.URL, http.StatusText(rr.Code), http.StatusText(http.StatusOK))
 	}
 
 	got := rr.Body.Bytes()

--- a/exp/services/keystore/cmd/keystored/README.md
+++ b/exp/services/keystore/cmd/keystored/README.md
@@ -41,9 +41,23 @@ You can check whether there is any unapplied migrations by running
 keystored migrate status
 ```
 
-Run `keystored` in development:
+Run `keystored` in development with authentication disabled:
 
 ```sh
-keystored -tls-cert=tls/server.crt -tls-key=tls/server.key serve
+keystored -tls-cert=tls/server.crt -tls-key=tls/server.key -auth=false serve
 ```
 
+Before you have a valid endpoint that can handle your auth token and return a
+user id in plaintext, you might want to disable authentication for testing.
+
+Run `keystored` in production with authentication disabled:
+
+There are four environment variables used for starting keystored:
+`KEYSTORE_DATABASE_URL`, `DB_MAX_IDLE_CONNS`, `DB_MAX_OPEN_CONNS`, `KEYSTORE_AUTHFORWARDING_URL`.
+* `KEYSTORE_DATABASE_URL` and `KEYSTORE_AUTHFORWARDING_URL` are required.
+* `DB_MAX_IDLE_CONNS` and `DB_MAX_OPEN_CONNS` are default to 5.
+* `KEYSTORE_AUTHFORWARDING_URL` is ignored when authentication is turned off.
+
+```sh
+keystored -tls-cert=PATH_TO_TLS_CERT -tls-key=PATH_TO_TLS_KEY -auth=false serve
+```

--- a/exp/services/keystore/cmd/keystored/README.md
+++ b/exp/services/keystore/cmd/keystored/README.md
@@ -12,14 +12,14 @@ tls/server.crt, tls/server.key, and tls/server.csr.
 
 We will only be using `server.crt` and `server.key`.
 
-Install the `keystored` command:
+## Install the `keystored` command:
 
 ```sh
 cd github.com/stellar/go/exp/services/keystore
 go install ./cmd/keystored
 ```
 
-Set up `keystore` Postgres database locally:
+## Set up `keystore` Postgres database locally:
 
 ```sh
 createdb keystore
@@ -41,7 +41,7 @@ You can check whether there is any unapplied migrations by running
 keystored migrate status
 ```
 
-Run `keystored` in development with authentication disabled:
+## Run `keystored` in development with authentication disabled:
 
 ```sh
 keystored -tls-cert=tls/server.crt -tls-key=tls/server.key -auth=false serve
@@ -50,7 +50,7 @@ keystored -tls-cert=tls/server.crt -tls-key=tls/server.key -auth=false serve
 Before you have a valid endpoint that can handle your auth token and return a
 user id in plaintext, you might want to disable authentication for testing.
 
-Run `keystored` in production with authentication disabled:
+## Run `keystored` in production with authentication disabled:
 
 There are four environment variables used for starting keystored:
 `KEYSTORE_DATABASE_URL`, `DB_MAX_IDLE_CONNS`, `DB_MAX_OPEN_CONNS`, `KEYSTORE_AUTHFORWARDING_URL`.

--- a/exp/services/keystore/cmd/keystored/dev.go
+++ b/exp/services/keystore/cmd/keystored/dev.go
@@ -12,5 +12,6 @@ func getConfig() *keystore.Config {
 		DBURL:          env.String("KEYSTORE_DATABASE_URL", "postgres:///keystore?sslmode=disable"),
 		MaxIdleDBConns: env.Int("DB_MAX_IDLE_CONNS", 5),
 		MaxOpenDBConns: env.Int("DB_MAX_OPEN_CONNS", 5),
+		AUTHURL:        env.String("KEYSTORE_AUTHFORWARDING_URL", ""),
 	}
 }

--- a/exp/services/keystore/cmd/keystored/main.go
+++ b/exp/services/keystore/cmd/keystored/main.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	migrate "github.com/rubenv/sql-migrate"
@@ -29,6 +31,8 @@ func main() {
 	ctx := context.Background()
 	tlsCert := flag.String("tls-cert", "", "TLS certificate file path")
 	tlsKey := flag.String("tls-key", "", "TLS private key file path")
+	auth := flag.Bool("auth", true, "Enable authentication")
+	apiType := flag.String("api-type", "REST", "Auth Forwarding API Type")
 
 	flag.Parse()
 	if len(flag.Args()) < 1 {
@@ -54,6 +58,23 @@ func main() {
 		log.DefaultLogger.Logger.SetLevel(cfg.LogLevel)
 	}
 
+	if *auth == true {
+		if cfg.AUTHURL == "" {
+			fmt.Fprintln(os.Stderr, "Auth is enabled but auth forwarding URL is not set")
+			os.Exit(1)
+		}
+		if _, err := url.Parse(cfg.AUTHURL); err != nil {
+			fmt.Fprintln(os.Stderr, "Invalid auth forwarding URL")
+			os.Exit(1)
+		}
+	}
+
+	aType := strings.ToUpper(*apiType)
+	if aType != keystore.REST && aType != keystore.GraphQL {
+		fmt.Fprintln(os.Stderr, `Auth forwarding endpoint type can only be either "REST" or "GRAPHQL"`)
+		os.Exit(1)
+	}
+
 	db, err := sql.Open(dbDriverName, cfg.DBURL)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error opening database: %v\n", err)
@@ -72,9 +93,17 @@ func main() {
 	switch cmd {
 	case "serve":
 		addr := ":8443"
+		var authenticator *keystore.Authenticator
+		if *auth {
+			authenticator = &keystore.Authenticator{
+				URL:     cfg.AUTHURL,
+				APIType: aType,
+			}
+		}
+
 		server := &http.Server{
 			Addr:    addr,
-			Handler: keystore.ServeMux(keystore.NewService(ctx, db)),
+			Handler: keystore.ServeMux(keystore.NewService(ctx, db, authenticator)),
 		}
 
 		listener, err := net.Listen("tcp", addr)

--- a/exp/services/keystore/keys_test.go
+++ b/exp/services/keystore/keys_test.go
@@ -18,7 +18,7 @@ func TestPutKeys(t *testing.T) {
 	defer conn.Close() // close db connection
 
 	ctx := withUserID(context.Background(), "test-user")
-	s := &Service{conn.DB}
+	s := &Service{conn.DB, nil}
 
 	blob := `[{
 		"keyType": "plaintextKey",
@@ -63,7 +63,7 @@ func TestGetKeys(t *testing.T) {
 	defer conn.Close() // close db connection
 
 	ctx := withUserID(context.Background(), "test-user")
-	s := &Service{conn.DB}
+	s := &Service{conn.DB, nil}
 
 	blob := `[{
 		"keyType": "plaintextKey",
@@ -113,7 +113,7 @@ func TestDeleteKeys(t *testing.T) {
 	defer conn.Close() // close db connection
 
 	ctx := withUserID(context.Background(), "test-user")
-	s := &Service{conn.DB}
+	s := &Service{conn.DB, nil}
 
 	blob := `[{
 		"keyType": "plaintextKey",

--- a/exp/services/keystore/service.go
+++ b/exp/services/keystore/service.go
@@ -7,6 +7,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	REST    = "REST"
+	GraphQL = "GRAPHQL"
+)
+
 type Config struct {
 	DBURL          string
 	MaxIdleDBConns int
@@ -14,12 +19,21 @@ type Config struct {
 
 	LogFile  string
 	LogLevel logrus.Level
+
+	AUTHURL string
+}
+
+type Authenticator struct {
+	URL     string
+	APIType string
+	//GraphQL related fields will be added later
 }
 
 type Service struct {
-	db *sql.DB
+	db            *sql.DB
+	authenticator *Authenticator
 }
 
-func NewService(ctx context.Context, db *sql.DB) *Service {
-	return &Service{db: db}
+func NewService(ctx context.Context, db *sql.DB, authenticator *Authenticator) *Service {
+	return &Service{db: db, authenticator: authenticator}
 }


### PR DESCRIPTION
This PR introduces one environment variable `KEYSTORE_AUTHFORWARDING_URL` in order to relay client requests for the purpose of authentication. This PR also introduces a command line flag `auth` to turn the auth forwarding off for easy testing.

We simply grab all headers in the request and add a `X-FORWARDED-FOR` field and send it to the designated URL with HTTP GET and expect a plaintext response. If everything goes well, we use the response as the userid and pass it along with the context.