### PR TITLE
exp/keystore: return Not_Found error when no entry

### DIFF
--- a/exp/services/keystore/api.go
+++ b/exp/services/keystore/api.go
@@ -1,6 +1,7 @@
 package keystore
 
 import (
+	"database/sql"
 	"fmt"
 	"net/http"
 
@@ -13,6 +14,7 @@ import (
 func init() {
 	// register errors
 	problem.RegisterError(httpjson.ErrBadRequest, probInvalidRequest)
+	problem.RegisterError(sql.ErrNoRows, problem.NotFound)
 
 	// register service host as an empty string
 	problem.RegisterHost("")

--- a/exp/services/keystore/api_test.go
+++ b/exp/services/keystore/api_test.go
@@ -132,6 +132,18 @@ func TestGetKeysAPI(t *testing.T) {
 	if got.CreatedAt.Before(time.Now().Add(-time.Hour)) {
 		t.Errorf("got CreatedAt=%s, want CreatedAt within the last hour", got.CreatedAt)
 	}
+
+	err = s.deleteKeys(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("GET %s responded with %s, want %s", req.URL, http.StatusText(rr.Code), http.StatusText(http.StatusNotFound))
+	}
 }
 
 func TestDeleteKeysAPI(t *testing.T) {


### PR DESCRIPTION
Without this PR, the GET keys endpoint will result in an internal error when there is no entry existing in the database for the associated user.