### PR TITLE
services/horizon: Fix ledger capacity usage in fee stats

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,6 +6,10 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## Unreleased
+
+* Fixed `/fee_stats` to correctly calculate ledger capacity in protocol v11.
+
 ## v0.18.0
 
 ### Breaking changes


### PR DESCRIPTION
## Summary

In protocol version 11 that implemented [CAP-0005](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0005.md) the number of operations is used as the indicator of ledger capacity. `/fee_stats` endpoint is incorrectly using transaction count for ledger capacity stats.

### Goal and scope

Rewrite a query that calculates ledger capacity usage to correctly report fee stats.

### Summary of changes

The query that calculates ledger capacity in the last 5 ledgers has been rewritten. Because we don't have access to number of failed operations in `history_ledgers` table (#1385) we first run subquery that returns number of operations for ledgers in question along with `max_tx_set_size` for each ledger and then calculate the capacity in the parent query.

### Known limitations & issues

* The query can be simplified when #1385 is implemented.

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.