### PR TITLE
exp/keystore: make port number configurable

### DIFF
--- a/exp/services/keystore/cmd/keystored/README.md
+++ b/exp/services/keystore/cmd/keystored/README.md
@@ -43,6 +43,9 @@ keystored migrate status
 
 Run `keystored` in development:
 
+You might want to set the `KEYSTORE_LISTENER_PORT` environment variable
+for the keystored listener. Otherwise, the default value is port 8000.
+
 ```sh
 keystored -tls-cert=tls/server.crt -tls-key=tls/server.key serve
 ```

--- a/exp/services/keystore/cmd/keystored/dev.go
+++ b/exp/services/keystore/cmd/keystored/dev.go
@@ -12,5 +12,6 @@ func getConfig() *keystore.Config {
 		DBURL:          env.String("KEYSTORE_DATABASE_URL", "postgres:///keystore?sslmode=disable"),
 		MaxIdleDBConns: env.Int("DB_MAX_IDLE_CONNS", 5),
 		MaxOpenDBConns: env.Int("DB_MAX_OPEN_CONNS", 5),
+		ListenerPort:   env.Int("KEYSTORE_LISTENER_PORT", 8000),
 	}
 }

--- a/exp/services/keystore/cmd/keystored/main.go
+++ b/exp/services/keystore/cmd/keystored/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"sort"
+	"strconv"
 	"time"
 
 	migrate "github.com/rubenv/sql-migrate"
@@ -54,6 +55,11 @@ func main() {
 		log.DefaultLogger.Logger.SetLevel(cfg.LogLevel)
 	}
 
+	if cfg.ListenerPort < 0 {
+		fmt.Fprintf(os.Stderr, "Port number %d cannot be negative\n", cfg.ListenerPort)
+		os.Exit(1)
+	}
+
 	db, err := sql.Open(dbDriverName, cfg.DBURL)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error opening database: %v\n", err)
@@ -71,7 +77,7 @@ func main() {
 	cmd := flag.Arg(0)
 	switch cmd {
 	case "serve":
-		addr := ":8443"
+		addr := ":" + strconv.Itoa(cfg.ListenerPort)
 		server := &http.Server{
 			Addr:    addr,
 			Handler: keystore.ServeMux(keystore.NewService(ctx, db)),

--- a/exp/services/keystore/service.go
+++ b/exp/services/keystore/service.go
@@ -14,6 +14,8 @@ type Config struct {
 
 	LogFile  string
 	LogLevel logrus.Level
+
+	ListenerPort int
 }
 
 type Service struct {


### PR DESCRIPTION
This PR adds `KEYSTORE_LISTENER_PORT` environment variable so that one can
start keystored at a preferred port number.