### PR TITLE
exp/ingest: Add support for protocol v11 buckets

### DIFF
--- a/exp/tools/accounts-for-signer/filters.go
+++ b/exp/tools/accounts-for-signer/filters.go
@@ -171,11 +171,11 @@ func (p *PrintAllProcessor) ProcessState(ctx context.Context, store *pipeline.St
 				entry.Data.Account.SeqNum,
 			)
 			foundEntries++
-			if foundEntries == 3 {
-				// We only want a few entries...
-				// return errors.New("Some error")
-				return nil
-			}
+			// if foundEntries == 3 {
+			// 	// We only want a few entries...
+			// 	// return errors.New("Some error")
+			// 	return nil
+			// }
 		default:
 			// Ignore for now
 		}

--- a/exp/tools/accounts-for-signer/filters.go
+++ b/exp/tools/accounts-for-signer/filters.go
@@ -171,11 +171,6 @@ func (p *PrintAllProcessor) ProcessState(ctx context.Context, store *pipeline.St
 				entry.Data.Account.SeqNum,
 			)
 			foundEntries++
-			// if foundEntries == 3 {
-			// 	// We only want a few entries...
-			// 	// return errors.New("Some error")
-			// 	return nil
-			// }
 		default:
 			// Ignore for now
 		}

--- a/exp/tools/accounts-for-signer/main.go
+++ b/exp/tools/accounts-for-signer/main.go
@@ -24,7 +24,7 @@ func main() {
 		panic(err)
 	}
 
-	// seq := uint32(23991935)
+	// seq = uint32(24311487)
 
 	fmt.Printf("Getting data for ledger seq = %d\n", seq)
 
@@ -75,7 +75,7 @@ func buildPipeline() (*pipeline.Pipeline, error) {
 			Pipe(
 				// Finds accounts for a single signer
 				p.Node(&AccountsForSignerProcessor{Signer: "GBMALBYJT6A73SYQWOWVVCGSPUPJPBX4AFDJ7A63GG64QCNRCAFYWWEN"}).
-					Pipe(p.Node(&PrintAllProcessor{Filename: "./accounts_for_signer.txt"})),
+					Pipe(p.Node(&PrintAllProcessor{Filename: "./accounts_for_signer.csv"})),
 			),
 	)
 

--- a/exp/tools/accounts-for-signer/main.go
+++ b/exp/tools/accounts-for-signer/main.go
@@ -24,8 +24,6 @@ func main() {
 		panic(err)
 	}
 
-	// seq = uint32(24311487)
-
 	fmt.Printf("Getting data for ledger seq = %d\n", seq)
 
 	stateReader, err := historyAdapter.GetState(seq)


### PR DESCRIPTION
## Summary

[CAP-0020](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0020.md) makes some improvements in buckets structure. We should update `MemoryStateReader` code to support v11 buckets.

Close #1389.

### Summary of changes

* Added a new code that supports new `BucketEntry` types: `INITENTRY` and `METAENTRY`. Additionally removed `removed` map as it's redundant (`seen` map is enough).
* Added new `MemoryStateReader.error` function to remove code duplication (instantiating empty `xdr.LedgerEntry` object).

### Known limitations & issues

No tests - update #1365 after merging this PR.

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~ #1365 will be extended with new tests.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [X] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.