### PR TITLE
ci: fix issue with go-sqlite3 build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,9 @@ commands:
           name: Install dependencies
           command: sudo apt-get update && sudo apt-get install postgresql-client-9.6 mariadb-client-10.1
       - run:
+          name: Installing go-sqlite3 via "go install", to avoid build issues
+          command: go install github.com/stellar/go/vendor/github.com/mattn/go-sqlite3
+      - run:
           name: Install dockerize
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:


### PR DESCRIPTION
This PR fixes an issue that occurs with tests run through CI that depend on `go-sqlite3`, such as:

https://circleci.com/gh/stellar/go/2116
https://circleci.com/gh/stellar/go/2120

The fix is done by running `go install` for the go-sqlite3 package prior to running tests, as suggested on https://github.com/mattn/go-sqlite3/issues/224.