### PR TITLE
exp/keystore: add log-file and log-level flags

### DIFF
--- a/exp/services/keystore/cmd/keystored/README.md
+++ b/exp/services/keystore/cmd/keystored/README.md
@@ -64,3 +64,12 @@ There are four environment variables used for starting keystored:
 ```sh
 keystored -tls-cert=PATH_TO_TLS_CERT -tls-key=PATH_TO_TLS_KEY -auth=false serve
 ```
+
+## Logging
+
+You can put the log messages in a designated file with the `-log-file` flag as well as determine
+the log severity level with the `-log-level` flag:
+
+```sh
+keystored -log-file=PATH_TO_YOUR_LOG_FILE -log-level=[debug|info|warn|error] serve
+```

--- a/exp/services/keystore/service.go
+++ b/exp/services/keystore/service.go
@@ -3,8 +3,6 @@ package keystore
 import (
 	"context"
 	"database/sql"
-
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -16,9 +14,6 @@ type Config struct {
 	DBURL          string
 	MaxIdleDBConns int
 	MaxOpenDBConns int
-
-	LogFile  string
-	LogLevel logrus.Level
 
 	AUTHURL string
 


### PR DESCRIPTION
We haven't really started to log anything in a log file. With this PR,
dev-ops can easily create a file and use the flag `-log-file=LOG_FILE_PATH`
to start logging.