### PR TITLE
services/horizon - db clear command truncates all tables

### DIFF
--- a/services/horizon/internal/ingest/ingestion.go
+++ b/services/horizon/internal/ingest/ingestion.go
@@ -17,7 +17,19 @@ import (
 
 // ClearAll clears the entire history database
 func (ingest *Ingestion) ClearAll() error {
-	return ingest.Clear(0, math.MaxInt64)
+	tables := []string{
+		string(AssetStatsTableName),
+		string(AccountsTableName),
+		string(AssetsTableName),
+		string(EffectsTableName),
+		string(LedgersTableName),
+		string(OperationParticipantsTableName),
+		string(OperationsTableName),
+		string(TradesTableName),
+		string(TransactionParticipantsTableName),
+		string(TransactionsTableName),
+	}
+	return ingest.DB.TruncateTables(tables)
 }
 
 // Clear removes a range of data from the history database, exclusive of the end

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -36,6 +36,8 @@ type TableName string
 
 const (
 	AssetStatsTableName              TableName = "asset_stats"
+	AccountsTableName                TableName = "history_accounts"
+	AssetsTableName                  TableName = "history_assets"
 	EffectsTableName                 TableName = "history_effects"
 	LedgersTableName                 TableName = "history_ledgers"
 	OperationParticipantsTableName   TableName = "history_operation_participants"

--- a/services/horizon/internal/ingest/system_test.go
+++ b/services/horizon/internal/ingest/system_test.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stellar/go/network"
@@ -40,9 +41,29 @@ func TestClearAll(t *testing.T) {
 
 	tt.Require.NoError(err)
 
-	// ensure no ledgers
+	// ensure all tables are cleared
+	tables := []TableName{
+		AssetStatsTableName,
+		AccountsTableName,
+		AssetsTableName,
+		EffectsTableName,
+		LedgersTableName,
+		OperationParticipantsTableName,
+		OperationsTableName,
+		TradesTableName,
+		TransactionParticipantsTableName,
+		TransactionsTableName,
+	}
+
+	for _, tableName := range tables {
+		ensureEmpty(tt, tableName)
+	}
+}
+
+func ensureEmpty(tt *test.T, tableName TableName) {
 	var found int
-	err = tt.HorizonSession().GetRaw(&found, "SELECT COUNT(*) FROM history_ledgers")
+	query := fmt.Sprintf("SELECT COUNT(*) FROM %s", string(tableName))
+	err := tt.HorizonSession().GetRaw(&found, query)
 	tt.Require.NoError(err)
 	tt.Assert.Equal(0, found)
 }

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -112,6 +113,12 @@ func (s *Session) GetTable(name string) *Table {
 		Name:    name,
 		Session: s,
 	}
+}
+
+func (s *Session) TruncateTables(tables []string) error {
+	truncateCmd := fmt.Sprintf("truncate %s cascade", strings.Join(tables[:], ","))
+	_, err := s.ExecRaw(truncateCmd)
+	return err
 }
 
 // Exec runs `query`


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary
```Ingestion.ClearAll()``` truncates all tables instead of deleting by range.

### Goal and scope
The goal is make ```db clear``` command operate as intended. Reference: https://github.com/stellar/go/issues/1371

### Summary of changes
- added missing ```TableName```s const declarations
- modified ```Ingestion.ClearAll()``` to truncate all tables
- added ```Session.TruncateTables()``` utility method
- modified ```TestClearAll()``` to test for all empty tables

### Known limitations & issues
none

### What shouldn't be reviewed
n/a