### PR TITLE
services/ticker: use a different strategy for comparing times on db tests

### DIFF
--- a/services/ticker/internal/tickerdb/queries_market_test.go
+++ b/services/ticker/internal/tickerdb/queries_market_test.go
@@ -249,8 +249,8 @@ func TestRetrieveMarketData(t *testing.T) {
 	assert.Equal(t, 0.1, xlmbtcMkt.LastPrice)
 	assert.Equal(
 		t,
-		now.Local().Truncate(time.Millisecond),
-		xlmbtcMkt.LastPriceCloseTime.Local().Truncate(time.Millisecond),
+		now.Local().Truncate(time.Second),
+		xlmbtcMkt.LastPriceCloseTime.Local().Truncate(time.Second),
 	)
 
 	assert.Equal(t, 0.0, xlmbtcMkt.PriceChange24h)
@@ -277,8 +277,8 @@ func TestRetrieveMarketData(t *testing.T) {
 	assert.Equal(t, 1.0, xlmethMkt.LastPrice)
 	assert.Equal(
 		t,
-		now.Local().Truncate(time.Millisecond),
-		xlmbtcMkt.LastPriceCloseTime.Local().Truncate(time.Millisecond),
+		now.Local().Truncate(time.Second),
+		xlmbtcMkt.LastPriceCloseTime.Local().Truncate(time.Second),
 	)
 
 	// There might be some floating point rounding issues, so this test
@@ -555,13 +555,13 @@ func TestRetrievePartialMarkets(t *testing.T) {
 	assert.Equal(t, 0.1, btceth1Mkt.Low)
 	assert.Equal(
 		t,
-		oneHourAgo.Local().Truncate(time.Millisecond),
-		btceth1Mkt.FirstLedgerCloseTime.Local().Truncate(time.Millisecond),
+		oneHourAgo.Local().Truncate(time.Second),
+		btceth1Mkt.FirstLedgerCloseTime.Local().Truncate(time.Second),
 	)
 	assert.Equal(
 		t,
-		tenMinutesAgo.Local().Truncate(time.Millisecond),
-		btceth1Mkt.LastLedgerCloseTime.Local().Truncate(time.Millisecond),
+		tenMinutesAgo.Local().Truncate(time.Second),
+		btceth1Mkt.LastLedgerCloseTime.Local().Truncate(time.Second),
 	)
 
 	assert.Equal(t, 24.0, btceth2Mkt.BaseVolume)
@@ -574,13 +574,13 @@ func TestRetrievePartialMarkets(t *testing.T) {
 	assert.Equal(t, 0.92, btceth2Mkt.Low)
 	assert.Equal(
 		t,
-		now.Local().Truncate(time.Millisecond),
-		btceth2Mkt.FirstLedgerCloseTime.Local().Truncate(time.Millisecond),
+		now.Local().Truncate(time.Second),
+		btceth2Mkt.FirstLedgerCloseTime.Local().Truncate(time.Second),
 	)
 	assert.Equal(
 		t,
-		now.Local().Truncate(time.Millisecond),
-		btceth2Mkt.FirstLedgerCloseTime.Local().Truncate(time.Millisecond),
+		now.Local().Truncate(time.Second),
+		btceth2Mkt.FirstLedgerCloseTime.Local().Truncate(time.Second),
 	)
 
 	// Analyzing non-aggregated orderbook data
@@ -615,13 +615,13 @@ func TestRetrievePartialMarkets(t *testing.T) {
 	assert.Equal(t, 0.1, partialAggMkt.Low)
 	assert.Equal(
 		t,
-		oneHourAgo.Local().Truncate(time.Millisecond),
-		partialAggMkt.FirstLedgerCloseTime.Local().Truncate(time.Millisecond),
+		oneHourAgo.Local().Truncate(time.Second),
+		partialAggMkt.FirstLedgerCloseTime.Local().Truncate(time.Second),
 	)
 	assert.Equal(
 		t,
-		now.Local().Truncate(time.Millisecond),
-		partialAggMkt.LastLedgerCloseTime.Local().Truncate(time.Millisecond),
+		now.Local().Truncate(time.Second),
+		partialAggMkt.LastLedgerCloseTime.Local().Truncate(time.Second),
 	)
 
 	// There might be some floating point rounding issues, so this test

--- a/services/ticker/internal/tickerdb/queries_market_test.go
+++ b/services/ticker/internal/tickerdb/queries_market_test.go
@@ -247,11 +247,7 @@ func TestRetrieveMarketData(t *testing.T) {
 	assert.Equal(t, 0.12, xlmbtcMkt.HighestPrice7d)
 
 	assert.Equal(t, 0.1, xlmbtcMkt.LastPrice)
-	assert.Equal(
-		t,
-		now.Local().Truncate(time.Second),
-		xlmbtcMkt.LastPriceCloseTime.Local().Truncate(time.Second),
-	)
+	assert.WithinDuration(t, now.Local(), xlmbtcMkt.LastPriceCloseTime.Local(), 10*time.Millisecond)
 
 	assert.Equal(t, 0.0, xlmbtcMkt.PriceChange24h)
 	// There might be some floating point rounding issues, so this test
@@ -275,11 +271,7 @@ func TestRetrieveMarketData(t *testing.T) {
 	assert.Equal(t, 1.0, xlmethMkt.HighestPrice7d)
 
 	assert.Equal(t, 1.0, xlmethMkt.LastPrice)
-	assert.Equal(
-		t,
-		now.Local().Truncate(time.Second),
-		xlmbtcMkt.LastPriceCloseTime.Local().Truncate(time.Second),
-	)
+	assert.WithinDuration(t, now.Local(), xlmbtcMkt.LastPriceCloseTime.Local(), 10*time.Millisecond)
 
 	// There might be some floating point rounding issues, so this test
 	// needs to be a bit more flexible. Since the change is 0.08, an error
@@ -553,17 +545,8 @@ func TestRetrievePartialMarkets(t *testing.T) {
 	assert.Equal(t, -0.9, btceth1Mkt.Change)
 	assert.Equal(t, 1.0, btceth1Mkt.High)
 	assert.Equal(t, 0.1, btceth1Mkt.Low)
-	assert.Equal(
-		t,
-		oneHourAgo.Local().Truncate(time.Second),
-		btceth1Mkt.FirstLedgerCloseTime.Local().Truncate(time.Second),
-	)
-	assert.Equal(
-		t,
-		tenMinutesAgo.Local().Truncate(time.Second),
-		btceth1Mkt.LastLedgerCloseTime.Local().Truncate(time.Second),
-	)
-
+	assert.WithinDuration(t, oneHourAgo.Local(), btceth1Mkt.FirstLedgerCloseTime.Local(), 10*time.Millisecond)
+	assert.WithinDuration(t, tenMinutesAgo.Local(), btceth1Mkt.LastLedgerCloseTime.Local(), 10*time.Millisecond)
 	assert.Equal(t, 24.0, btceth2Mkt.BaseVolume)
 	assert.Equal(t, 26.0, btceth2Mkt.CounterVolume)
 	assert.Equal(t, int32(1), btceth2Mkt.TradeCount)
@@ -572,16 +555,8 @@ func TestRetrievePartialMarkets(t *testing.T) {
 	assert.Equal(t, 0.0, btceth2Mkt.Change)
 	assert.Equal(t, 0.92, btceth2Mkt.High)
 	assert.Equal(t, 0.92, btceth2Mkt.Low)
-	assert.Equal(
-		t,
-		now.Local().Truncate(time.Second),
-		btceth2Mkt.FirstLedgerCloseTime.Local().Truncate(time.Second),
-	)
-	assert.Equal(
-		t,
-		now.Local().Truncate(time.Second),
-		btceth2Mkt.FirstLedgerCloseTime.Local().Truncate(time.Second),
-	)
+	assert.WithinDuration(t, now.Local(), btceth2Mkt.FirstLedgerCloseTime.Local(), 10*time.Millisecond)
+	assert.WithinDuration(t, now.Local(), btceth2Mkt.LastLedgerCloseTime.Local(), 10*time.Millisecond)
 
 	// Analyzing non-aggregated orderbook data
 	assert.Equal(t, 15, btceth1Mkt.NumBids)
@@ -613,16 +588,8 @@ func TestRetrievePartialMarkets(t *testing.T) {
 	assert.Equal(t, 0.92, partialAggMkt.Close)
 	assert.Equal(t, 1.0, partialAggMkt.High)
 	assert.Equal(t, 0.1, partialAggMkt.Low)
-	assert.Equal(
-		t,
-		oneHourAgo.Local().Truncate(time.Second),
-		partialAggMkt.FirstLedgerCloseTime.Local().Truncate(time.Second),
-	)
-	assert.Equal(
-		t,
-		now.Local().Truncate(time.Second),
-		partialAggMkt.LastLedgerCloseTime.Local().Truncate(time.Second),
-	)
+	assert.WithinDuration(t, oneHourAgo.Local(), partialAggMkt.FirstLedgerCloseTime.Local(), 10*time.Millisecond)
+	assert.WithinDuration(t, now.Local(), partialAggMkt.LastLedgerCloseTime.Local(), 10*time.Millisecond)
 
 	// There might be some floating point rounding issues, so this test
 	// needs to be a bit more flexible. Since the change is 0.08, an error

--- a/services/ticker/internal/tickerdb/queries_orderbook_test.go
+++ b/services/ticker/internal/tickerdb/queries_orderbook_test.go
@@ -72,16 +72,8 @@ func TestInsertOrUpdateOrderbokStats(t *testing.T) {
 	assert.Equal(t, code, dbAsset1.Code)
 	assert.Equal(t, issuerAccount, dbAsset1.IssuerAccount)
 	assert.Equal(t, dbIssuer.ID, dbAsset1.IssuerID)
-	assert.Equal(
-		t,
-		firstTime.Local().Truncate(time.Second),
-		dbAsset1.LastValid.Local().Truncate(time.Second),
-	)
-	assert.Equal(
-		t,
-		firstTime.Local().Truncate(time.Second),
-		dbAsset1.LastChecked.Local().Truncate(time.Second),
-	)
+	assert.WithinDuration(t, firstTime.Local(), dbAsset1.LastValid.Local(), 10*time.Millisecond)
+	assert.WithinDuration(t, firstTime.Local(), dbAsset1.LastChecked.Local(), 10*time.Millisecond)
 
 	// Creating Seconde Asset:
 	secondTime := time.Now()
@@ -139,11 +131,7 @@ func TestInsertOrUpdateOrderbokStats(t *testing.T) {
 	assert.Equal(t, 0.1, dbOS.LowestAsk)
 	assert.Equal(t, 0.93, dbOS.Spread)
 	assert.Equal(t, 0.35, dbOS.SpreadMidPoint)
-	assert.Equal(
-		t,
-		obTime.Local().Truncate(time.Second),
-		dbOS.UpdatedAt.Local().Truncate(time.Second),
-	)
+	assert.WithinDuration(t, obTime.Local(), dbOS.UpdatedAt.Local(), 10*time.Millisecond)
 
 	// Making sure we're upserting:
 	obTime2 := time.Now()
@@ -187,9 +175,5 @@ func TestInsertOrUpdateOrderbokStats(t *testing.T) {
 	assert.Equal(t, 0.1, dbOS2.LowestAsk) // should keep the old value, since on preserveFields
 	assert.Equal(t, 1.86, dbOS2.Spread)
 	assert.Equal(t, 0.7, dbOS2.SpreadMidPoint)
-	assert.Equal(
-		t,
-		obTime2.Local().Truncate(time.Second),
-		dbOS2.UpdatedAt.Local().Truncate(time.Second),
-	)
+	assert.WithinDuration(t, obTime2.Local(), dbOS2.UpdatedAt.Local(), 10*time.Millisecond)
 }

--- a/services/ticker/internal/tickerdb/queries_orderbook_test.go
+++ b/services/ticker/internal/tickerdb/queries_orderbook_test.go
@@ -74,13 +74,13 @@ func TestInsertOrUpdateOrderbokStats(t *testing.T) {
 	assert.Equal(t, dbIssuer.ID, dbAsset1.IssuerID)
 	assert.Equal(
 		t,
-		firstTime.Local().Truncate(time.Millisecond),
-		dbAsset1.LastValid.Local().Truncate(time.Millisecond),
+		firstTime.Local().Truncate(time.Second),
+		dbAsset1.LastValid.Local().Truncate(time.Second),
 	)
 	assert.Equal(
 		t,
-		firstTime.Local().Truncate(time.Millisecond),
-		dbAsset1.LastChecked.Local().Truncate(time.Millisecond),
+		firstTime.Local().Truncate(time.Second),
+		dbAsset1.LastChecked.Local().Truncate(time.Second),
 	)
 
 	// Creating Seconde Asset:
@@ -141,8 +141,8 @@ func TestInsertOrUpdateOrderbokStats(t *testing.T) {
 	assert.Equal(t, 0.35, dbOS.SpreadMidPoint)
 	assert.Equal(
 		t,
-		obTime.Local().Truncate(time.Millisecond),
-		dbOS.UpdatedAt.Local().Truncate(time.Millisecond),
+		obTime.Local().Truncate(time.Second),
+		dbOS.UpdatedAt.Local().Truncate(time.Second),
 	)
 
 	// Making sure we're upserting:
@@ -189,7 +189,7 @@ func TestInsertOrUpdateOrderbokStats(t *testing.T) {
 	assert.Equal(t, 0.7, dbOS2.SpreadMidPoint)
 	assert.Equal(
 		t,
-		obTime2.Local().Truncate(time.Millisecond),
-		dbOS2.UpdatedAt.Local().Truncate(time.Millisecond),
+		obTime2.Local().Truncate(time.Second),
+		dbOS2.UpdatedAt.Local().Truncate(time.Second),
 	)
 }

--- a/services/ticker/internal/tickerdb/queries_trade_test.go
+++ b/services/ticker/internal/tickerdb/queries_trade_test.go
@@ -217,11 +217,7 @@ func TestGetLastTrade(t *testing.T) {
 
 	lastTrade, err := session.GetLastTrade()
 	require.NoError(t, err)
-	assert.Equal(
-		t,
-		now.Local().Truncate(time.Second),
-		lastTrade.LedgerCloseTime.Local().Truncate(time.Second),
-	)
+	assert.WithinDuration(t, now.Local(), lastTrade.LedgerCloseTime.Local(), 10*time.Millisecond)
 }
 
 func TestDeleteOldTrades(t *testing.T) {
@@ -348,14 +344,6 @@ func TestDeleteOldTrades(t *testing.T) {
 
 	assert.NotEqual(t, trade1.HorizonID, "")
 	assert.NotEqual(t, trade2.HorizonID, "")
-	assert.Equal(
-		t,
-		now.Local().Truncate(time.Second),
-		trade1.LedgerCloseTime.Local().Truncate(time.Second),
-	)
-	assert.Equal(
-		t,
-		oneDayAgo.Local().Truncate(time.Second),
-		trade2.LedgerCloseTime.Local().Truncate(time.Second),
-	)
+	assert.WithinDuration(t, now.Local(), trade1.LedgerCloseTime.Local(), 10*time.Millisecond)
+	assert.WithinDuration(t, oneDayAgo.Local(), trade2.LedgerCloseTime.Local(), 10*time.Millisecond)
 }

--- a/services/ticker/internal/tickerdb/queries_trade_test.go
+++ b/services/ticker/internal/tickerdb/queries_trade_test.go
@@ -219,8 +219,8 @@ func TestGetLastTrade(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(
 		t,
-		now.Local().Truncate(time.Millisecond),
-		lastTrade.LedgerCloseTime.Local().Truncate(time.Millisecond),
+		now.Local().Truncate(time.Second),
+		lastTrade.LedgerCloseTime.Local().Truncate(time.Second),
 	)
 }
 
@@ -350,12 +350,12 @@ func TestDeleteOldTrades(t *testing.T) {
 	assert.NotEqual(t, trade2.HorizonID, "")
 	assert.Equal(
 		t,
-		now.Local().Truncate(time.Millisecond),
-		trade1.LedgerCloseTime.Local().Truncate(time.Millisecond),
+		now.Local().Truncate(time.Second),
+		trade1.LedgerCloseTime.Local().Truncate(time.Second),
 	)
 	assert.Equal(
 		t,
-		oneDayAgo.Local().Truncate(time.Millisecond),
-		trade2.LedgerCloseTime.Local().Truncate(time.Millisecond),
+		oneDayAgo.Local().Truncate(time.Second),
+		trade2.LedgerCloseTime.Local().Truncate(time.Second),
 	)
 }


### PR DESCRIPTION
This PR fixes #1403 by using a lower precision when comparing times on database tests.

This shouldn't impact the effectiveness/accuracy of the tests, since none of them rely on time differences in the order of milliseconds – they're mostly in the order of seconds, minutes, or even days.