### PR TITLE
services/compliance use txnbuild assets in compliance

### DIFF
--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_manage_offer.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_manage_offer.go
@@ -25,8 +25,8 @@ type ManageOfferOperationBody struct {
 func (op ManageOfferOperationBody) Build() txnbuild.Operation {
 	if op.PassiveOffer {
 		txnOp := txnbuild.CreatePassiveSellOffer{
-			Selling: txnbuild.CreditAsset{Code: op.Selling.Code, Issuer: op.Selling.Issuer},
-			Buying:  txnbuild.CreditAsset{Code: op.Buying.Code, Issuer: op.Buying.Issuer},
+			Selling: op.Selling.ToBaseAsset(),
+			Buying:  op.Buying.ToBaseAsset(),
 			Amount:  op.Amount,
 			Price:   op.Price,
 		}

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_path_payment.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_path_payment.go
@@ -73,8 +73,8 @@ func (op PathPaymentOperationBody) Build() txnbuild.Operation {
 	txnOp := txnbuild.PathPayment{
 		Destination: op.Destination,
 		DestAmount:  op.DestinationAmount,
-		DestAsset:   txnbuild.CreditAsset{Code: op.DestinationAsset.Code, Issuer: op.DestinationAsset.Issuer},
-		SendAsset:   txnbuild.CreditAsset{Code: op.SendAsset.Code, Issuer: op.SendAsset.Issuer},
+		DestAsset:   op.DestinationAsset.ToBaseAsset(),
+		SendAsset:   op.SendAsset.ToBaseAsset(),
 		SendMax:     op.SendMax,
 		Path:        paths,
 	}

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_payment.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_payment.go
@@ -21,7 +21,7 @@ func (op PaymentOperationBody) Build() txnbuild.Operation {
 	txnOp := txnbuild.Payment{
 		Destination: op.Destination,
 		Amount:      op.Amount,
-		Asset:       txnbuild.CreditAsset{Code: op.Asset.Code, Issuer: op.Asset.Issuer},
+		Asset:       op.Asset.ToBaseAsset(),
 	}
 
 	if op.Source != nil {

--- a/services/internal/bridge-compliance-shared/protocols/main.go
+++ b/services/internal/bridge-compliance-shared/protocols/main.go
@@ -14,8 +14,8 @@ const (
 
 // Asset represents asset
 type Asset struct {
-	Code   string `name:"asset_code" json:"code"`
-	Issuer string `name:"asset_issuer" json:"issuer"`
+	Code   string `valid:"required" name:"asset_code" json:"code"`
+	Issuer string `valid:"optional" name:"asset_issuer" json:"issuer"`
 }
 
 // ForwardDestination contains fields required to create forward federation request


### PR DESCRIPTION
This PR enables payment operations built by the compliance server to use either txnbuild's `CreditAsset` or  `NativeAsset` types. 