### PR TITLE
keystore: avoid the response body being compressed

### DIFF
--- a/services/keystore/api.go
+++ b/services/keystore/api.go
@@ -2,6 +2,7 @@ package keystore
 
 import (
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -121,6 +122,7 @@ func authHandler(next http.Handler, authenticator *Authenticator) http.Handler {
 		var authResp authResponse
 		err = json.Unmarshal(body, &authResp)
 		if err != nil {
+			log.Ctx(ctx).Infof("Response body as a plain string: %s\n. Response body as a hex dump string: %s\n", string(body), hex.Dump(body))
 			problem.Render(ctx, rw, errors.Wrap(err, "unmarshaling the auth response"))
 			return
 		}

--- a/services/keystore/api.go
+++ b/services/keystore/api.go
@@ -98,6 +98,7 @@ func authHandler(next http.Handler, authenticator *Authenticator) http.Handler {
 		if clientIP, _, err = net.SplitHostPort(req.RemoteAddr); err == nil {
 			proxyReq.Header.Set("X-Forwarded-For", clientIP)
 		}
+		proxyReq.Header.Set("Accept-Encoding", "identity")
 
 		resp, err := client.Do(proxyReq)
 		if err != nil {
@@ -120,7 +121,6 @@ func authHandler(next http.Handler, authenticator *Authenticator) http.Handler {
 		var authResp authResponse
 		err = json.Unmarshal(body, &authResp)
 		if err != nil {
-			log.Ctx(ctx).Infof("the response body is %s\n", string(body))
 			problem.Render(ctx, rw, errors.Wrap(err, "unmarshaling the auth response"))
 			return
 		}


### PR DESCRIPTION
While the keystore works locally, the hosted keystore is not being able to receive the right response. It looks like the response is compressed with gzip somewhere in our cluster. We might also have to disable the compression in the transport layer if this fix is not sufficient.