### PR TITLE
txnbuild: add new methods to transaction

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+* Add support for getting the hex-encoded transaction hash with `HashHex` method.
+* Add support for getting the `TransactionEnvelope` struct with `TxEnvelope` method.
+
 ## [v1.2.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.2.0) - 2019-05-16
 
 * In addition to account responses from horizon, transactions and operations can now be built with txnbuild.SimpleAccount structs constructed locally ([#1266](https://github.com/stellar/go/issues/1266)). 

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -5,8 +5,8 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-* Add support for getting the hex-encoded transaction hash with `HashHex` method.
-* Add support for getting the `TransactionEnvelope` struct with `TxEnvelope` method.
+* Add support for getting the hex-encoded transaction hash with `Transaction.HashHex` method.
+* Add support for getting the `TransactionEnvelope` struct with `Transaction.TxEnvelope` method.
 
 ## [v1.2.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.2.0) - 2019-05-16
 

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -14,6 +14,7 @@ package txnbuild
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/stellar/go/keypair"
@@ -60,7 +61,7 @@ func (tx *Transaction) MarshalBinary() ([]byte, error) {
 	return txBytes.Bytes(), nil
 }
 
-// Base64 returns the base 64 XDR representation of the Transaction.
+// Base64 returns the base 64 XDR representation of the transaction envelope.
 func (tx *Transaction) Base64() (string, error) {
 	bs, err := tx.MarshalBinary()
 	if err != nil {
@@ -177,4 +178,18 @@ func (tx *Transaction) BuildSignEncode(keypairs ...*keypair.Full) (string, error
 	}
 
 	return txeBase64, err
+}
+
+// HashHex returns the hex-encododed hash of the transaction
+func (tx *Transaction) HashHex() (string, error) {
+	hashByte, err := tx.Hash()
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hashByte[:]), nil
+}
+
+// TxEnvelope returns the TransactionEnvelope XDR struct
+func (tx *Transaction) TxEnvelope() *xdr.TransactionEnvelope {
+	return tx.xdrEnvelope
 }

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -50,7 +50,7 @@ func (tx *Transaction) Hash() ([32]byte, error) {
 	return network.HashTransaction(&tx.xdrTransaction, tx.Network)
 }
 
-// MarshalBinary returns the binary XDR representation of the Transaction.
+// MarshalBinary returns the binary XDR representation of the transaction envelope.
 func (tx *Transaction) MarshalBinary() ([]byte, error) {
 	var txBytes bytes.Buffer
 	_, err := xdr.Marshal(&txBytes, tx.xdrEnvelope)
@@ -180,7 +180,7 @@ func (tx *Transaction) BuildSignEncode(keypairs ...*keypair.Full) (string, error
 	return txeBase64, err
 }
 
-// HashHex returns the hex-encododed hash of the transaction
+// HashHex returns the hex-encoded hash of the transaction.
 func (tx *Transaction) HashHex() (string, error) {
 	hashByte, err := tx.Hash()
 	if err != nil {
@@ -189,7 +189,7 @@ func (tx *Transaction) HashHex() (string, error) {
 	return hex.EncodeToString(hashByte[:]), nil
 }
 
-// TxEnvelope returns the TransactionEnvelope XDR struct
+// TxEnvelope returns the TransactionEnvelope XDR struct.
 func (tx *Transaction) TxEnvelope() *xdr.TransactionEnvelope {
 	return tx.xdrEnvelope
 }

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -744,5 +744,5 @@ func TestHashHex(t *testing.T) {
 
 	txEnv := tx.TxEnvelope()
 	assert.NotNil(t, txEnv, "transaction xdr envelope should not be nil")
-	assert.IsType(t, txEnv, xdr.TransactionEnvelope{}, "tx.TxEnvelope should return type of *xdr.TransactionEnvelope")
+	assert.IsType(t, txEnv, &xdr.TransactionEnvelope{}, "tx.TxEnvelope should return type of *xdr.TransactionEnvelope")
 }

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stellar/go/network"
+	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -741,5 +742,7 @@ func TestHashHex(t *testing.T) {
 	expected = "1b3905ba8c3c0ecc68ae812f2d77f27c697195e8daf568740fc0f5662f65f759"
 	assert.Equal(t, expected, hashHex, "hex encoded hash should match")
 
-	assert.NotNil(t, tx.TxEnvelope(), "transaction xdr envelope should not be nil")
+	txEnv := tx.TxEnvelope()
+	assert.NotNil(t, txEnv, "transaction xdr envelope should not be nil")
+	assert.IsType(t, txEnv, xdr.TransactionEnvelope{}, "tx.TxEnvelope should return type of *xdr.TransactionEnvelope")
 }

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -708,3 +708,38 @@ func TestManageBuyOfferUpdateOffer(t *testing.T) {
 	expected := "AAAAACXK8doPx27P6IReQlRRuweSSUiUfjqgyswxiu3Sh2R+AAAAZAAAJWoAAAAKAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAMAAAAAAAAAAFBQkNEAAAAACXK8doPx27P6IReQlRRuweSSUiUfjqgyswxiu3Sh2R+AAAAAB3NZQAAAAABAAAAMgAAAAAALJSWAAAAAAAAAAHSh2R+AAAAQK/sasTxgNqvkz3dGaDOyUgfa9UAAmUBmgiyaQU1dMlNNvTVH1D7PQKXkTooWmb6qK7Ee8vaTCFU6gGmShhA9wE="
 	assert.Equal(t, expected, received, "Base 64 XDR should match")
 }
+
+func TestHashHex(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
+
+	createAccount := CreateAccount{
+		Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
+		Amount:      "10",
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&createAccount},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	assert.NoError(t, err)
+
+	err = tx.Sign(kp0)
+	assert.NoError(t, err)
+
+	txeB64, err := tx.Base64()
+	assert.NoError(t, err)
+	expected := "AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAiII0AAAAaAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAITg3tq8G0kvnvoIhZPMYJsY+9KVV8xAA6NxhtKxIXZUAAAAAAX14QAAAAAAAAAAAeoucsUAAABAHsyMojA0Q5MiNsR5X5AiNpCn9mlXmqluRsNpTniCR91M4U5TFmrrqVNLkU58/l+Y8hUPwidDTRSzLZKbMUL/Bw=="
+	assert.Equal(t, expected, txeB64, "Base 64 XDR should match")
+
+	hashHex, err := tx.HashHex()
+	assert.NoError(t, err)
+	expected = "1b3905ba8c3c0ecc68ae812f2d77f27c697195e8daf568740fc0f5662f65f759"
+	assert.Equal(t, expected, hashHex, "hex encoded hash should match")
+
+	assert.NotNil(t, tx.TxEnvelope(), "transaction xdr envelope should not be nil")
+}


### PR DESCRIPTION
This PR adds two new methods to the transaction struct
- `TxEnvelope`: This returns a the `xdr.TransactionEnvelope` struct for the transaction. Closes #1415 
- `HashHex`: This returns the transaction hash as a hex string
