### PR TITLE
txnbuild: remove asset issuer requirement for allow_trust

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -6,7 +6,9 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * Add support for getting the hex-encoded transaction hash with `Transaction.HashHex` method.
-* Add support for getting the `TransactionEnvelope` struct with `Transaction.TxEnvelope` method.
+* Add support for getting the `TransactionEnvelope` struct with `Transaction.TxEnvelope` method ([#1415](https://github.com/stellar/go/issues/1415)).
+* `AllowTrust` operations no longer requires the asset issuer, only asset code is required ([#1330](https://github.com/stellar/go/issues/1330)).
+
 
 ## [v1.2.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.2.0) - 2019-05-16
 

--- a/txnbuild/allow_trust.go
+++ b/txnbuild/allow_trust.go
@@ -30,10 +30,7 @@ func (at *AllowTrust) BuildXDR() (xdr.Operation, error) {
 	}
 
 	// AllowTrust has a special asset type - map to it
-	xdrAsset, err := at.Type.ToXDR()
-	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "can't convert asset for trustline to XDR")
-	}
+	xdrAsset := xdr.Asset{}
 
 	xdrOp.Asset, err = xdrAsset.ToAllowTrustOpAsset(at.Type.GetCode())
 	if err != nil {

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -445,6 +445,30 @@ func TestAllowTrust(t *testing.T) {
 	assert.Equal(t, expected, received, "Base 64 XDR should match")
 }
 
+func TestAllowTrustNoIssuer(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484366))
+
+	issuedAsset := CreditAsset{Code: "XYZ"}
+	allowTrust := AllowTrust{
+		Trustor:   kp1.Address(),
+		Type:      issuedAsset,
+		Authorize: true,
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&allowTrust},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	received := buildSignEncode(t, tx, kp0)
+	expected := "AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAAJLsAAABPAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAHAAAAACXK8doPx27P6IReQlRRuweSSUiUfjqgyswxiu3Sh2R+AAAAAVhZWgAAAAABAAAAAAAAAAHqLnLFAAAAQO8mcsi/+RObrKto8tABtN8RwUi6101FqBDTwqMQp4hNuujw+SGEFaBCYLNw/u40DHFRQoBNi6zcBKbBSg+gVwE="
+	assert.Equal(t, expected, received, "Base 64 XDR should match")
+}
+
 func TestManageSellOfferNewOffer(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()


### PR DESCRIPTION
This PR removes the need for an asset issuer to be specified when building an `AllowTrust` operation. 
This operation only needs the asset code to be specified.
Closes #1330 