### PR TITLE
txnbuild: add deprecate warning to default fee

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -6,9 +6,11 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * Add support for getting the hex-encoded transaction hash with `Transaction.HashHex` method.
+* `TransactionEnvelope` is now available after building a transaction(`Transaction.Build`). Previously, this was only available after signing a transaction. ([#1376](https://github.com/stellar/go/pull/1376)) 
 * Add support for getting the `TransactionEnvelope` struct with `Transaction.TxEnvelope` method ([#1415](https://github.com/stellar/go/issues/1415)).
 * `AllowTrust` operations no longer requires the asset issuer, only asset code is required ([#1330](https://github.com/stellar/go/issues/1330)).
-
+* `Transaction.SetDefaultFee` method is deprecated and will be removed in the next major release ([#1221](https://github.com/stellar/go/issues/1221)).
+* `Transaction.TransactionFee` method has been added to get the fee that will be paid for a transaction.
 
 ## [v1.2.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.2.0) - 2019-05-16
 

--- a/txnbuild/example_test.go
+++ b/txnbuild/example_test.go
@@ -84,6 +84,45 @@ func ExamplePayment() {
 	// Output: AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAMoj8AAAAEAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAABAAAAAITg3tq8G0kvnvoIhZPMYJsY+9KVV8xAA6NxhtKxIXZUAAAAAAAAAAAF9eEAAAAAAAAAAAHqLnLFAAAAQHb8LTro4QVpzcGzOToW28p340o54KX5/xxodABM+izweQlbVKb9bISRUOu+sNfi50weXeAeGVL+oTQS5YR4lgI=
 }
 
+func ExamplePayment_setBaseFee() {
+	kp, _ := keypair.Parse("SBPQUZ6G4FZNWFHKUWC5BEYWF6R52E3SEP7R3GWYSM2XTKGF5LNTWW4R")
+	client := horizonclient.DefaultTestNetClient
+	ar := horizonclient.AccountRequest{AccountID: kp.Address()}
+	sourceAccount, err := client.AccountDetail(ar)
+	check(err)
+
+	op1 := Payment{
+		Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
+		Amount:      "10",
+		Asset:       NativeAsset{},
+	}
+
+	op2 := Payment{
+		Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
+		Amount:      "100",
+		Asset:       NativeAsset{},
+	}
+
+	// get fees from network
+
+	feeStats, err := client.FeeStats()
+	check(err)
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&op1, &op2},
+		Timebounds:    NewInfiniteTimeout(), // Use a real timeout in production!
+		Network:       network.TestNetworkPassphrase,
+		BaseFee:       uint32(feeStats.P50AcceptedFee),
+	}
+
+	txe, err := tx.BuildSignEncode(kp.(*keypair.Full))
+	check(err)
+	fmt.Println(txe)
+
+	// Output: AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAEsAAMoj8AAAAEAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAABAAAAAITg3tq8G0kvnvoIhZPMYJsY+9KVV8xAA6NxhtKxIXZUAAAAAAAAAAAF9eEAAAAAAAAAAAEAAAAAhODe2rwbSS+e+giFk8xgmxj70pVXzEADo3GG0rEhdlQAAAAAAAAAADuaygAAAAAAAAAAAeoucsUAAABAyY5c/6T3cQ1i27t681O7aHrdSQ2tCcXpyLj06HVe59DeuHNLgN3X7oBeqBZrgVty+VNVGPEK6uR+UjhGi/bGBA==
+}
+
 func ExampleBumpSequence() {
 	kp, _ := keypair.Parse("SBPQUZ6G4FZNWFHKUWC5BEYWF6R52E3SEP7R3GWYSM2XTKGF5LNTWW4R")
 	client := horizonclient.DefaultTestNetClient

--- a/txnbuild/example_test.go
+++ b/txnbuild/example_test.go
@@ -104,7 +104,6 @@ func ExamplePayment_setBaseFee() {
 	}
 
 	// get fees from network
-
 	feeStats, err := client.FeeStats()
 	check(err)
 

--- a/txnbuild/examplehorizonclient/examplehorizonclient.go
+++ b/txnbuild/examplehorizonclient/examplehorizonclient.go
@@ -24,3 +24,25 @@ func (client *Client) AccountDetail(req AccountRequest) (hProtocol.Account, erro
 		Sequence:  "3556091187167235",
 	}, nil
 }
+
+// FeeStats returns mock network fee information
+func (client *Client) FeeStats() (hProtocol.FeeStats, error) {
+	return hProtocol.FeeStats{
+		LastLedger:          22606298,
+		LastLedgerBaseFee:   100,
+		LedgerCapacityUsage: 0.97,
+		MinAcceptedFee:      100,
+		ModeAcceptedFee:     200,
+		P10AcceptedFee:      250,
+		P20AcceptedFee:      300,
+		P30AcceptedFee:      350,
+		P40AcceptedFee:      500,
+		P50AcceptedFee:      600,
+		P60AcceptedFee:      700,
+		P70AcceptedFee:      800,
+		P80AcceptedFee:      900,
+		P90AcceptedFee:      2000,
+		P95AcceptedFee:      3000,
+		P99AcceptedFee:      5000,
+	}, nil
+}

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -28,7 +28,8 @@ import (
 type Account interface {
 	GetAccountID() string
 	IncrementSequenceNumber() (xdr.SequenceNumber, error)
-	// To do: implement in v2.0.0: add GetSequenceNumber method
+	// Action needed in release: horizonclient-v2.0.0
+	// add GetSequenceNumber method
 	// GetSequenceNumber() (xdr.SequenceNumber, error)
 }
 
@@ -74,6 +75,7 @@ func (tx *Transaction) Base64() (string, error) {
 // SetDefaultFee sets a sensible minimum default for the Transaction fee, if one has not
 // already been set. It is a linear function of the number of Operations in the Transaction.
 // Deprecated: This will be removed in v2.0.0 and setting `Transaction.BaseFee` will be mandatory.
+// Action needed in release: horizonclient-v2.0.0
 func (tx *Transaction) SetDefaultFee() {
 	// TODO: Generalise to pull this from a client call
 	var DefaultBaseFee uint32 = 100
@@ -92,19 +94,20 @@ func (tx *Transaction) SetDefaultFee() {
 func (tx *Transaction) Build() error {
 
 	accountID := tx.SourceAccount.GetAccountID()
+	// Public keys start with 'G'
+	if accountID[0] != 'G' {
+		return errors.New("invalid public key for transaction source account")
+	}
 	_, err := keypair.Parse(accountID)
 	if err != nil {
-		return err
-	}
-
-	if accountID[0] != 'G' {
 		return err
 	}
 
 	// Set account ID in XDR
 	tx.xdrTransaction.SourceAccount.SetAddress(accountID)
 
-	// TODO: Validate Seq Num is present in struct. Requires Account.GetSequenceNumber (v.2.0.0)
+	// Action needed in release: horizonclient-v2.0.0
+	// Validate Seq Num is present in struct. Requires Account.GetSequenceNumber (v.2.0.0)
 	seqnum, err := tx.SourceAccount.IncrementSequenceNumber()
 	if err != nil {
 		return errors.Wrap(err, "failed to parse sequence number")
@@ -137,7 +140,8 @@ func (tx *Transaction) Build() error {
 	}
 
 	// Set a default fee, if it hasn't been set yet
-	// To Do: replace with tx.setTransactionfee in v2.0.0
+	// Action needed in release: horizonclient-v2.0.0
+	// replace with tx.setTransactionfee
 	tx.SetDefaultFee()
 
 	return nil
@@ -217,20 +221,8 @@ func (tx *Transaction) setTransactionFee() error {
 	return nil
 }
 
-// func (tx *Transaction) getNetworkFees() (hProtocol.FeeStats, error) {
-// 	client := horizonclient.Client{}
-// 	if tx.Network == network.TestNetworkPassphrase {
-// 		client = horizonclient.DefaultTestNetClient
-// 	} else if tx.Network == network.PublicNetworkPassphrase {
-// 		client = horizonclient.DefaultPublicNetClient
-// 	} else {
-// 		return hProtocol.FeeStats{MinAcceptedFee: int(100)}, nil
-// 	}
-
-// 	fs, err := client.FeeStats()
-// 	if err != nil {
-// 		return hProtocol.FeeStats{}, errors.Wrap(err, "unable to get fee stats from network")
-// 	}
-
-// 	return fs, nil
-// }
+// TransactionFee returns the fee to be paid for a transaction.
+// It defaults to zero if transaction has not been built.
+func (tx *Transaction) TransactionFee() int {
+	return int(tx.xdrTransaction.Fee)
+}

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -222,7 +222,6 @@ func (tx *Transaction) setTransactionFee() error {
 }
 
 // TransactionFee returns the fee to be paid for a transaction.
-// It defaults to zero if transaction has not been built.
 func (tx *Transaction) TransactionFee() int {
 	return int(int(tx.BaseFee) * len(tx.xdrTransaction.Operations))
 }

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -224,5 +224,5 @@ func (tx *Transaction) setTransactionFee() error {
 // TransactionFee returns the fee to be paid for a transaction.
 // It defaults to zero if transaction has not been built.
 func (tx *Transaction) TransactionFee() int {
-	return int(tx.xdrTransaction.Fee)
+	return int(int(tx.BaseFee) * len(tx.xdrTransaction.Operations))
 }

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -223,5 +223,10 @@ func (tx *Transaction) setTransactionFee() error {
 
 // TransactionFee returns the fee to be paid for a transaction.
 func (tx *Transaction) TransactionFee() int {
-	return int(int(tx.BaseFee) * len(tx.xdrTransaction.Operations))
+	err := tx.setTransactionFee()
+	// error is returned when BaseFee is zero
+	if err != nil {
+		return 0
+	}
+	return int(tx.xdrTransaction.Fee)
 }


### PR DESCRIPTION
This PR does the following
- Adds a warning that `Transaction.SetDefaultFee` is deprecated and will be removed.
- Adds an example showing how to set `Transaction.BaseFee` by querying horizon for fee stats.
- Add an unexported method `Transaction.setTransactionFee` for setting the transaction fee.
- Validates accountID before building a transaction

closes #1221 
