### PR TITLE
txnbuild: support alternate signatures

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -11,6 +11,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 * `AllowTrust` operations no longer requires the asset issuer, only asset code is required ([#1330](https://github.com/stellar/go/issues/1330)).
 * `Transaction.SetDefaultFee` method is deprecated and will be removed in the next major release ([#1221](https://github.com/stellar/go/issues/1221)).
 * `Transaction.TransactionFee` method has been added to get the fee that will be paid for a transaction.
+* `Transaction.SignHashX` method adds support for signing transactions with hash(x) signature types.
 
 ## [v1.2.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.2.0) - 2019-05-16
 

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -233,19 +233,20 @@ func (tx *Transaction) TransactionFee() int {
 }
 
 // SignHashX signs a transaction with HashX signature type.
+// See description here: https://www.stellar.org/developers/guides/concepts/multi-sig.html#hashx.
 func (tx *Transaction) SignHashX(preimage []byte) error {
-
 	if tx.xdrEnvelope == nil {
 		tx.xdrEnvelope = &xdr.TransactionEnvelope{}
 		tx.xdrEnvelope.Tx = tx.xdrTransaction
 	}
 
-	if len(preimage) > 64 {
+	if len(preimage) > xdr.Signature(preimage).XDRMaxSize() {
 		return errors.New("preimage cannnot be more than 64 bytes")
 	}
 
 	preimageHash := sha256.Sum256(preimage)
 	var hint [4]byte
+	// copy the last 4-bytes of the signer public key to be used as hint
 	copy(hint[:], preimageHash[28:])
 
 	sig := xdr.DecoratedSignature{

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -821,15 +821,15 @@ func TestTransactionFee(t *testing.T) {
 func TestPreAuthTransaction(t *testing.T) {
 	// Address: GDK3YEHGI3ORGVO7ZEV2XF4SV5JU3BOKHMHPP4QFJ74ZRIIRROZ7ITOJ
 	kp0 := newKeypair("SDY4PF6F6OWWERZT6OL2LVNREHUGHKALUI5W4U2JK4GAKPAC2RM43OAU")
-	sourceAccount := NewSimpleAccount(kp0.Address(), int64(4353383146192898))
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(4353383146192898)) // sequence number is in the future
 
 	createAccount := CreateAccount{
 		Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:      "10",
 	}
 
-	// build future transaction
-	tx := Transaction{
+	// build transaction to be submitted in the future.
+	txFuture := Transaction{
 		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&createAccount},
 		Timebounds:    NewInfiniteTimeout(),
@@ -837,48 +837,56 @@ func TestPreAuthTransaction(t *testing.T) {
 		BaseFee:       100,
 	}
 
-	err := tx.Build()
-	assert.NoError(t, err)
-	txHash, err := tx.Hash()
+	err := txFuture.Build()
 	assert.NoError(t, err)
 
-	err = tx.Sign()
+	// save the hash of the future transaction.
+	txFutureHash, err := txFuture.Hash()
 	assert.NoError(t, err)
 
-	txeB64, err := tx.Base64()
+	// sign transaction without keypairs, the hash of the future transaction on the account
+	//  will be used for authorisation.
+	err = txFuture.Sign()
+	assert.NoError(t, err)
+
+	txeFutureB64, err := txFuture.Base64()
 	assert.NoError(t, err)
 	expected := "AAAAANW8EOZG3RNV38krq5eSr1NNhco7DvfyBU/5mKERi7P0AAAAZAAPd2EAAAADAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAITg3tq8G0kvnvoIhZPMYJsY+9KVV8xAA6NxhtKxIXZUAAAAAAX14QAAAAAAAAAAAA=="
-	assert.Equal(t, expected, txeB64, "Base 64 XDR should match")
+	assert.Equal(t, expected, txeFutureB64, "Base 64 XDR should match")
 
-	//encode txhash
-	preAuth, err := strkey.Encode(strkey.VersionByteHashTx, txHash[:])
+	//encode the txFutureHash as a stellar HashTx signer key.
+	preAuth, err := strkey.Encode(strkey.VersionByteHashTx, txFutureHash[:])
+	assert.NoError(t, err)
 
-	// add hash of future transaction to account
+	// set sequence number to the current number.
+	sourceAccount.Sequence = int64(4353383146192897)
+
+	// add hash of future transaction as signer to account
 	setOptions := SetOptions{
 		Signer: &Signer{Address: preAuth, Weight: Threshold(2)},
 	}
 
-	sourceAccount.Sequence = int64(4353383146192897)
-
-	tx = Transaction{
+	// build a transaction to add the hash of the future transaction as a signer on the account.
+	txNow := Transaction{
 		SourceAccount: &sourceAccount,
 		Operations:    []Operation{&setOptions},
 		Timebounds:    NewInfiniteTimeout(),
 		Network:       network.TestNetworkPassphrase,
 		BaseFee:       500,
 	}
-	err = tx.Build()
+	err = txNow.Build()
 	assert.NoError(t, err)
-	txFee := tx.TransactionFee()
+	txFee := txNow.TransactionFee()
 	assert.Equal(t, 500, txFee, "Transaction fee should match")
 
-	err = tx.Sign(kp0)
+	err = txNow.Sign(kp0)
 	assert.NoError(t, err)
 
-	txeB64, err = tx.Base64()
+	txeNowB64, err := txNow.Base64()
 	assert.NoError(t, err)
 	expected = "AAAAANW8EOZG3RNV38krq5eSr1NNhco7DvfyBU/5mKERi7P0AAAB9AAPd2EAAAACAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAY9c66YpCPn8yMopKaNBd7gbiD2cr+aTLOaZE4whmeO1AAAAAgAAAAAAAAABEYuz9AAAAEC62tXQKDTcrB8VvOQIaI3ECV0uypBkpGNuyodnLLY27ii4QMdB4g4otYIvKY6nbWQqYYapNh6Q9dVsYfK6OHQM"
-	assert.Equal(t, expected, txeB64, "Base 64 XDR should match")
+	assert.Equal(t, expected, txeNowB64, "Base 64 XDR should match")
+	// Note: txeFutureB64 can be submitted to the network after txeNowB64 has been applied to the account
 }
 
 func TestHashXTransaction(t *testing.T) {
@@ -887,10 +895,11 @@ func TestHashXTransaction(t *testing.T) {
 
 	preimageHash := sha256.Sum256([]byte(preimage))
 
-	//encode hashx
+	//encode preimageHash as a stellar HashX signer key
 	hashx, err := strkey.Encode(strkey.VersionByteHashX, preimageHash[:])
+	assert.NoError(t, err)
 
-	// add hashx as signer account
+	// add hashx as signer to the account
 	setOptions := SetOptions{
 		Signer: &Signer{Address: hashx, Weight: Threshold(1)},
 	}
@@ -920,6 +929,7 @@ func TestHashXTransaction(t *testing.T) {
 	expected := "AAAAANW8EOZG3RNV38krq5eSr1NNhco7DvfyBU/5mKERi7P0AAAB9AAPd2EAAAAEAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAvslgb5oIfuISFP8FYvTqsciG1iSUerJB3Au6T2WLqMFAAAAAQAAAAAAAAABEYuz9AAAAECHBwfCbcOwFyoILLW7OZejvdbsVPEwB6z6ocAG4cRGu69vXKCrBFYD2mMdJRCeglgJgfgaFj2qshBgL8yQ14UH"
 	assert.Equal(t, expected, txeB64, "Base 64 XDR should match")
 
+	// build a transaction to test hashx signer
 	payment := Payment{
 		Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:      "10",
@@ -939,6 +949,7 @@ func TestHashXTransaction(t *testing.T) {
 	err = tx.Build()
 	assert.NoError(t, err)
 
+	// sign transaction with the preimage
 	err = tx.SignHashX([]byte(preimage))
 	assert.NoError(t, err)
 

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1,9 +1,11 @@
 package txnbuild
 
 import (
+	"crypto/sha256"
 	"testing"
 
 	"github.com/stellar/go/network"
+	"github.com/stellar/go/strkey"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -813,5 +815,138 @@ func TestTransactionFee(t *testing.T) {
 	txeB64, err := tx.Base64()
 	assert.NoError(t, err)
 	expected := "AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAB9AAiII0AAAAbAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAITg3tq8G0kvnvoIhZPMYJsY+9KVV8xAA6NxhtKxIXZUAAAAAAX14QAAAAAAAAAAAeoucsUAAABAnc69aKw6dg1LlHxkIetKZu8Ou8hgbj4mICV0tiOJeuiq8DvivSlAngnD+FlVIaotmg8i3dEzBg+LcLnG9UttBQ=="
+	assert.Equal(t, expected, txeB64, "Base 64 XDR should match")
+}
+
+func TestPreAuthTransaction(t *testing.T) {
+	// Address: GDK3YEHGI3ORGVO7ZEV2XF4SV5JU3BOKHMHPP4QFJ74ZRIIRROZ7ITOJ
+	kp0 := newKeypair("SDY4PF6F6OWWERZT6OL2LVNREHUGHKALUI5W4U2JK4GAKPAC2RM43OAU")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(4353383146192898))
+
+	createAccount := CreateAccount{
+		Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
+		Amount:      "10",
+	}
+
+	// build future transaction
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&createAccount},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+		BaseFee:       100,
+	}
+
+	err := tx.Build()
+	assert.NoError(t, err)
+	txHash, err := tx.Hash()
+	assert.NoError(t, err)
+
+	err = tx.Sign()
+	assert.NoError(t, err)
+
+	txeB64, err := tx.Base64()
+	assert.NoError(t, err)
+	expected := "AAAAANW8EOZG3RNV38krq5eSr1NNhco7DvfyBU/5mKERi7P0AAAAZAAPd2EAAAADAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAITg3tq8G0kvnvoIhZPMYJsY+9KVV8xAA6NxhtKxIXZUAAAAAAX14QAAAAAAAAAAAA=="
+	assert.Equal(t, expected, txeB64, "Base 64 XDR should match")
+
+	//encode txhash
+	preAuth, err := strkey.Encode(strkey.VersionByteHashTx, txHash[:])
+
+	// add hash of future transaction to account
+	setOptions := SetOptions{
+		Signer: &Signer{Address: preAuth, Weight: Threshold(2)},
+	}
+
+	sourceAccount.Sequence = int64(4353383146192897)
+
+	tx = Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&setOptions},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+		BaseFee:       500,
+	}
+	err = tx.Build()
+	assert.NoError(t, err)
+	txFee := tx.TransactionFee()
+	assert.Equal(t, 500, txFee, "Transaction fee should match")
+
+	err = tx.Sign(kp0)
+	assert.NoError(t, err)
+
+	txeB64, err = tx.Base64()
+	assert.NoError(t, err)
+	expected = "AAAAANW8EOZG3RNV38krq5eSr1NNhco7DvfyBU/5mKERi7P0AAAB9AAPd2EAAAACAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAY9c66YpCPn8yMopKaNBd7gbiD2cr+aTLOaZE4whmeO1AAAAAgAAAAAAAAABEYuz9AAAAEC62tXQKDTcrB8VvOQIaI3ECV0uypBkpGNuyodnLLY27ii4QMdB4g4otYIvKY6nbWQqYYapNh6Q9dVsYfK6OHQM"
+	assert.Equal(t, expected, txeB64, "Base 64 XDR should match")
+}
+
+func TestHashXTransaction(t *testing.T) {
+	// 256 bit preimage
+	preimage := "this is a preimage for hashx transactions on the stellar network"
+
+	preimageHash := sha256.Sum256([]byte(preimage))
+
+	//encode hashx
+	hashx, err := strkey.Encode(strkey.VersionByteHashX, preimageHash[:])
+
+	// add hashx as signer account
+	setOptions := SetOptions{
+		Signer: &Signer{Address: hashx, Weight: Threshold(1)},
+	}
+
+	// Address: GDK3YEHGI3ORGVO7ZEV2XF4SV5JU3BOKHMHPP4QFJ74ZRIIRROZ7ITOJ
+	kp0 := newKeypair("SDY4PF6F6OWWERZT6OL2LVNREHUGHKALUI5W4U2JK4GAKPAC2RM43OAU")
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(4353383146192899))
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&setOptions},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+		BaseFee:       500,
+	}
+	err = tx.Build()
+	assert.NoError(t, err)
+	txFee := tx.TransactionFee()
+	assert.Equal(t, 500, txFee, "Transaction fee should match")
+
+	err = tx.Sign(kp0)
+	assert.NoError(t, err)
+
+	txeB64, err := tx.Base64()
+	assert.NoError(t, err)
+
+	expected := "AAAAANW8EOZG3RNV38krq5eSr1NNhco7DvfyBU/5mKERi7P0AAAB9AAPd2EAAAAEAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAvslgb5oIfuISFP8FYvTqsciG1iSUerJB3Au6T2WLqMFAAAAAQAAAAAAAAABEYuz9AAAAECHBwfCbcOwFyoILLW7OZejvdbsVPEwB6z6ocAG4cRGu69vXKCrBFYD2mMdJRCeglgJgfgaFj2qshBgL8yQ14UH"
+	assert.Equal(t, expected, txeB64, "Base 64 XDR should match")
+
+	payment := Payment{
+		Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
+		Amount:      "10",
+		Asset:       NativeAsset{},
+	}
+
+	sourceAccount.Sequence = int64(4353383146192902)
+
+	tx = Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&payment},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+		BaseFee:       100,
+	}
+
+	err = tx.Build()
+	assert.NoError(t, err)
+
+	err = tx.Sign()
+	assert.NoError(t, err)
+
+	err = tx.SignHashX([]byte(preimage))
+	assert.NoError(t, err)
+
+	txeB64, err = tx.Base64()
+	assert.NoError(t, err)
+	expected = "AAAAANW8EOZG3RNV38krq5eSr1NNhco7DvfyBU/5mKERi7P0AAAAZAAPd2EAAAAHAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAABAAAAAITg3tq8G0kvnvoIhZPMYJsY+9KVV8xAA6NxhtKxIXZUAAAAAAAAAAAF9eEAAAAAAAAAAAGWLqMFAAAAQHRoaXMgaXMgYSBwcmVpbWFnZSBmb3IgaGFzaHggdHJhbnNhY3Rpb25zIG9uIHRoZSBzdGVsbGFyIG5ldHdvcms="
 	assert.Equal(t, expected, txeB64, "Base 64 XDR should match")
 }

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -939,9 +939,6 @@ func TestHashXTransaction(t *testing.T) {
 	err = tx.Build()
 	assert.NoError(t, err)
 
-	err = tx.Sign()
-	assert.NoError(t, err)
-
 	err = tx.SignHashX([]byte(preimage))
 	assert.NoError(t, err)
 


### PR DESCRIPTION
This PR adds support for signing transactions with signatures other than `ed25519` keys.
- Pre-authorized Transaction signatures were already supported so a test was added for it.
- `Transaction.SignHashX` method added to support Hash(x) signatures.
- Changelog updated.

Closes #955 