### PR TITLE
clients/federation: use horizonclient

### DIFF
--- a/clients/federation/client.go
+++ b/clients/federation/client.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/stellar/go/address"
-	hc "github.com/stellar/go/clients/horizonclient"
 	proto "github.com/stellar/go/protocols/federation"
 	"github.com/stellar/go/support/errors"
 )
@@ -52,12 +51,11 @@ func (c *Client) LookupByAddress(addy string) (*proto.NameResponse, error) {
 // account id is used to resolve what server the request should be made against.
 func (c *Client) LookupByAccountID(aid string) (*proto.IDResponse, error) {
 
-	accountDetail, err := c.Horizon.AccountDetail(hc.AccountRequest{AccountID: aid})
+	domain, err := c.Horizon.HomeDomainForAccount(aid)
 	if err != nil {
 		return nil, errors.Wrap(err, "get homedomain failed")
 	}
 
-	domain := accountDetail.HomeDomain
 	if domain == "" {
 		return nil, errors.New("homedomain not set")
 	}

--- a/clients/federation/client.go
+++ b/clients/federation/client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/stellar/go/address"
+	hc "github.com/stellar/go/clients/horizonclient"
 	proto "github.com/stellar/go/protocols/federation"
 	"github.com/stellar/go/support/errors"
 )
@@ -51,11 +52,12 @@ func (c *Client) LookupByAddress(addy string) (*proto.NameResponse, error) {
 // account id is used to resolve what server the request should be made against.
 func (c *Client) LookupByAccountID(aid string) (*proto.IDResponse, error) {
 
-	domain, err := c.Horizon.HomeDomainForAccount(aid)
+	accountDetail, err := c.Horizon.AccountDetail(hc.AccountRequest{AccountID: aid})
 	if err != nil {
 		return nil, errors.Wrap(err, "get homedomain failed")
 	}
 
+	domain := accountDetail.HomeDomain
 	if domain == "" {
 		return nil, errors.New("homedomain not set")
 	}

--- a/clients/federation/client_test.go
+++ b/clients/federation/client_test.go
@@ -9,10 +9,8 @@ import (
 
 	hc "github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/clients/stellartoml"
-	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/http/httptest"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestLookupByAddress(t *testing.T) {
@@ -128,8 +126,8 @@ func TestLookupByID(t *testing.T) {
 	horizonMock := &hc.MockClient{}
 	client := &Client{Horizon: horizonMock}
 
-	horizonMock.On("AccountDetail", mock.AnythingOfType("horizonclient.AccountRequest")).
-		Return(hProtocol.Account{HomeDomain: ""}, errors.New("homedomain not set"))
+	horizonMock.On("HomeDomainForAccount", "GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C").
+		Return("", errors.New("homedomain not set"))
 
 	// an account without a homedomain set fails
 	_, err := client.LookupByAccountID("GASTNVNLHVR3NFO3QACMHCJT3JUSIV4NBXDHDO4VTPDTNN65W3B2766C")

--- a/clients/federation/main.go
+++ b/clients/federation/main.go
@@ -4,9 +4,10 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/stellar/go/clients/horizon"
+	hc "github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/clients/stellartoml"
 	proto "github.com/stellar/go/protocols/federation"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 )
 
 // FederationResponseMaxSize is the maximum size of response from a federation server
@@ -15,14 +16,14 @@ const FederationResponseMaxSize = 100 * 1024
 // DefaultTestNetClient is a default federation client for testnet
 var DefaultTestNetClient = &Client{
 	HTTP:        http.DefaultClient,
-	Horizon:     horizon.DefaultTestNetClient,
+	Horizon:     hc.DefaultTestNetClient,
 	StellarTOML: stellartoml.DefaultClient,
 }
 
 // DefaultPublicNetClient is a default federation client for pubnet
 var DefaultPublicNetClient = &Client{
 	HTTP:        http.DefaultClient,
-	Horizon:     horizon.DefaultPublicNetClient,
+	Horizon:     hc.DefaultPublicNetClient,
 	StellarTOML: stellartoml.DefaultClient,
 }
 
@@ -44,7 +45,7 @@ type ClientInterface interface {
 // Horizon represents a horizon client that can be consulted for data when
 // needed as part of the federation protocol
 type Horizon interface {
-	HomeDomainForAccount(aid string) (string, error)
+	AccountDetail(request hc.AccountRequest) (hProtocol.Account, error)
 }
 
 // HTTP represents the http client that a federation client uses to make http

--- a/clients/federation/main.go
+++ b/clients/federation/main.go
@@ -7,7 +7,6 @@ import (
 	hc "github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/clients/stellartoml"
 	proto "github.com/stellar/go/protocols/federation"
-	hProtocol "github.com/stellar/go/protocols/horizon"
 )
 
 // FederationResponseMaxSize is the maximum size of response from a federation server
@@ -45,7 +44,7 @@ type ClientInterface interface {
 // Horizon represents a horizon client that can be consulted for data when
 // needed as part of the federation protocol
 type Horizon interface {
-	AccountDetail(request hc.AccountRequest) (hProtocol.Account, error)
+	HomeDomainForAccount(aid string) (string, error)
 }
 
 // HTTP represents the http client that a federation client uses to make http

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -620,5 +620,19 @@ func (c *Client) PrevTradesPage(page hProtocol.TradesPage) (trades hProtocol.Tra
 	return
 }
 
+// HomeDomainForAccount returns the home domain for a single account.
+func (c *Client) HomeDomainForAccount(aid string) (string, error) {
+	if aid == "" {
+		return "", errors.New("no account ID provided")
+	}
+
+	accountDetail, err := c.AccountDetail(AccountRequest{AccountID: aid})
+	if err != nil {
+		return "", errors.Wrap(err, "get account detail failed")
+	}
+
+	return accountDetail.HomeDomain, nil
+}
+
 // ensure that the horizon client implements ClientInterface
 var _ ClientInterface = &Client{}

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -175,6 +175,7 @@ type ClientInterface interface {
 	PrevOffersPage(hProtocol.OffersPage) (hProtocol.OffersPage, error)
 	NextTradesPage(hProtocol.TradesPage) (hProtocol.TradesPage, error)
 	PrevTradesPage(hProtocol.TradesPage) (hProtocol.TradesPage, error)
+	HomeDomainForAccount(aid string) (string, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network.

--- a/clients/horizonclient/mocks.go
+++ b/clients/horizonclient/mocks.go
@@ -281,5 +281,11 @@ func (m *MockClient) PrevTradesPage(page hProtocol.TradesPage) (hProtocol.Trades
 	return a.Get(0).(hProtocol.TradesPage), a.Error(1)
 }
 
+// HomeDomainForAccount is a mocking method
+func (m *MockClient) HomeDomainForAccount(aid string) (string, error) {
+	a := m.Called(aid)
+	return a.Get(0).(string), a.Error(1)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}


### PR DESCRIPTION
This PR swaps out the deprecated `horizon` package with the new `horizonclient` package. This is a fairly straightforward swap and no changes has been made to the federation client features.