### PR TITLE
 support/render/httpjson: add comments and tests for encoding 

### DIFF
--- a/support/render/httpjson/encoding.go
+++ b/support/render/httpjson/encoding.go
@@ -2,21 +2,38 @@ package httpjson
 
 import "github.com/stellar/go/support/errors"
 
-// ErrNotObject is returned when Object.UnmarshalJSON is called
+// ErrNotJSONObject is returned when Object.UnmarshalJSON is called
 // with bytes not representing a valid json object.
 // A valid json object means it starts with `null` or `{`, not `[`.
-var ErrNotJsonObject = errors.New("input is not a json object")
+var ErrNotJSONObject = errors.New("input is not a json object")
 
-type Object []byte
+// RawObject can be used directly to make sure that what's in the request body
+// is not a json array:
+//
+// func example(ctx context.Context, in httpjson.RawObject)
+//
+// It can also be used as a field in a struct:
+//
+// type example struct {
+//  	name string
+//   	extra httpjson.RawObject
+// }
+//
+// In this case, Unmarshaler will check whether extra is a json object ot not.
+// It will error if extra is a json number/string/array/boolean.
+//
+// RawObject also implements Marshaler so that we would populate an empty json
+// object is extra is not set.
+type RawObject []byte
 
-func (o Object) MarshalJSON() ([]byte, error) {
+func (o RawObject) MarshalJSON() ([]byte, error) {
 	if len(o) == 0 {
 		return []byte("{}"), nil
 	}
 	return o, nil
 }
 
-func (o *Object) UnmarshalJSON(in []byte) error {
+func (o *RawObject) UnmarshalJSON(in []byte) error {
 	var first byte
 	for _, c := range in {
 		if !isSpace(c) {
@@ -26,7 +43,7 @@ func (o *Object) UnmarshalJSON(in []byte) error {
 	}
 	// input does not start with 'n' ("null") or '{'
 	if first != 'n' && first != '{' {
-		return ErrNotJsonObject
+		return ErrNotJSONObject
 	}
 
 	*o = in

--- a/support/render/httpjson/encoding_test.go
+++ b/support/render/httpjson/encoding_test.go
@@ -1,0 +1,54 @@
+package httpjson
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestRawObjectMarshaler(t *testing.T) {
+	var in RawObject
+	got, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []byte("{}")
+	if !bytes.Equal(got, want) {
+		t.Errorf("got: %s, want: %s", string(got), string(want))
+	}
+}
+
+func TestRawObjectUnmarshaler(t *testing.T) {
+	cases := []struct {
+		input   []byte
+		wantErr bool
+	}{
+		{[]byte(`{"input":{}}`), false},              // empty object
+		{[]byte(`{"input":{"key":"value"}}`), false}, // object
+		{[]byte(`{"input":null}`), false},            // null
+		{[]byte(`{"input":[]}`), true},               // empty array
+		{[]byte(`{"input":"json string"}`), true},    // string
+		{[]byte(`{"input":10}`), true},               // positive number
+		{[]byte(`{"input":-10}`), true},              // negative number
+		{[]byte(`{"input":false}`), true},            // boolean
+		{[]byte(`{"input":true}`), true},             // boolean
+	}
+
+	for _, tc := range cases {
+		var out struct {
+			Input RawObject `json:"input"`
+		}
+
+		err := json.Unmarshal(tc.input, &out)
+		if tc.wantErr {
+			if err != ErrNotJSONObject {
+				t.Errorf("case %s wanted error but did not", string(tc.input))
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("case %s got error %v but shouldn't", string(tc.input), err)
+		}
+	}
+}

--- a/support/render/httpjson/encoding_test.go
+++ b/support/render/httpjson/encoding_test.go
@@ -17,6 +17,20 @@ func TestRawObjectMarshaler(t *testing.T) {
 	if !bytes.Equal(got, want) {
 		t.Errorf("got: %s, want: %s", string(got), string(want))
 	}
+
+	var inField struct {
+		Input RawObject `json:"input"`
+	}
+
+	got, err = json.Marshal(inField)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want = []byte(`{"input":{}}`)
+	if !bytes.Equal(got, want) {
+		t.Errorf("got: %s, want: %s", string(got), string(want))
+	}
 }
 
 func TestRawObjectUnmarshaler(t *testing.T) {


### PR DESCRIPTION
This PR makes the intention of the manual type more clear. It renames `Object` to `RawObject` as well as adds examples of the usage.