### PR TITLE
services/horizon: history archive url + accounts for signer feature flag

### DIFF
--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -89,7 +89,7 @@ var configOpts = []*support.ConfigOption{
 		ConfigKey:   &config.HistoryArchiveURLs,
 		OptType:     types.String,
 		Required:    false,
-		FlagDefault: "http://history.stellar.org/prd/core-live/core_live_001/,http://history.stellar.org/prd/core-live/core_live_002/,http://history.stellar.org/prd/core-live/core_live_003/",
+		FlagDefault: "https://history.stellar.org/prd/core-live/core_live_001/,https://history.stellar.org/prd/core-live/core_live_002/,https://history.stellar.org/prd/core-live/core_live_003/",
 		CustomSetValue: func(co *support.ConfigOption) {
 			stringOfUrls := viper.GetString(co.Name)
 			urlStrings := strings.Split(stringOfUrls, ",")

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"go/types"
 	stdLog "log"
 	"os"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -84,11 +85,18 @@ var configOpts = []*support.ConfigOption{
 		Usage:     "stellar-core to connect with (for http commands)",
 	},
 	&support.ConfigOption{
-		Name:      "history-archive-url",
-		ConfigKey: &config.HistoryArchiveURL,
-		OptType:   types.String,
-		Required:  false, // TODO: make required when ingestion system is released from feature flag
-		Usage:     "stellar history archive to connect with",
+		Name:        "history-archive-urls",
+		ConfigKey:   &config.HistoryArchiveURLs,
+		OptType:     types.String,
+		Required:    false,
+		FlagDefault: "http://history.stellar.org/prd/core-live/core_live_001/,http://history.stellar.org/prd/core-live/core_live_002/,http://history.stellar.org/prd/core-live/core_live_003/",
+		CustomSetValue: func(co *support.ConfigOption) {
+			stringOfUrls := viper.GetString(co.Name)
+			urlStrings := strings.Split(stringOfUrls, ",")
+
+			*(co.ConfigKey.(*[]string)) = urlStrings
+		},
+		Usage: "comma-separated list of stellar history archives to connect with",
 	},
 	&support.ConfigOption{
 		Name:        "port",

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -28,7 +28,7 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-// validateBothOrNeither ensures that both options are provided, if either is provided
+// validateBothOrNeither ensures that both options are provided, if either is provided.
 func validateBothOrNeither(option1, option2 string) {
 	arg1, arg2 := viper.GetString(option1), viper.GetString(option2)
 	if arg1 != "" && arg2 == "" {
@@ -39,7 +39,7 @@ func validateBothOrNeither(option1, option2 string) {
 	}
 }
 
-// checkMigrations looks for necessary database migrations and fails with a descriptive error if migrations are needed
+// checkMigrations looks for necessary database migrations and fails with a descriptive error if migrations are needed.
 func checkMigrations() {
 	migrationsToApplyUp := schema.GetMigrationsUp(viper.GetString("db-url"))
 	if len(migrationsToApplyUp) > 0 {
@@ -57,7 +57,7 @@ func checkMigrations() {
 	}
 }
 
-// configOpts defines the complete flag configuration for horizon
+// configOpts defines the complete flag configuration for horizon.
 // Add a new entry here to connect a new field in the horizon.Config struct
 var configOpts = []*support.ConfigOption{
 	&support.ConfigOption{
@@ -82,6 +82,13 @@ var configOpts = []*support.ConfigOption{
 		OptType:   types.String,
 		Required:  true,
 		Usage:     "stellar-core to connect with (for http commands)",
+	},
+	&support.ConfigOption{
+		Name:      "history-archive-url",
+		ConfigKey: &config.HistoryArchiveURL,
+		OptType:   types.String,
+		Required:  false, // TODO: make required when ingestion system is released from feature flag
+		Usage:     "stellar history archive to connect with",
 	},
 	&support.ConfigOption{
 		Name:        "port",

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -300,6 +300,13 @@ var configOpts = []*support.ConfigOption{
 		FlagDefault: false,
 		Usage:       "enables asset stats during the ingestion and expose `/assets` endpoint, Enabling it has a negative impact on CPU",
 	},
+	&support.ConfigOption{
+		Name:        "enable-accounts-for-signer",
+		ConfigKey:   &config.EnableAccountsForSigner,
+		OptType:     types.Bool,
+		FlagDefault: false,
+		Usage:       "[EXPERIMENTAL] enables accounts for signer endpoint using an alternative ingest system",
+	},
 }
 
 func init() {

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -14,7 +14,7 @@ type Config struct {
 	DatabaseURL            string
 	StellarCoreDatabaseURL string
 	StellarCoreURL         string
-	HistoryArchiveURL      string
+	HistoryArchiveURLs     []string
 	Port                   uint
 
 	// MaxDBConnections has a priority over all 4 values below.

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -68,4 +68,7 @@ type Config struct {
 	// Enabling it has a negative impact on CPU when ingesting ledgers full of
 	// many different assets related operations.
 	EnableAssetStats bool
+	// EnableAccountsForSigner is a feature flag that enables an experimental "accounts for signer"
+	// endpoint. This endpoint uses a new ingestion system based primarily on historical archives.
+	EnableAccountsForSigner bool
 }

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	DatabaseURL            string
 	StellarCoreDatabaseURL string
 	StellarCoreURL         string
+	HistoryArchiveURL      string
 	Port                   uint
 
 	// MaxDBConnections has a priority over all 4 values below.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

This PR adds two new flags to support the accounts for signer MVP. `history-archive-url` specifies the history archive to use. `enable-accounts-for-signer` adds a feature flag for the new feature. Closes #1484 and #1487.

### Goal and scope

Two flags added. They are currently unused.

This was suspiciously quick and easy. Let me know if I misunderstood anything with the requirements.