### PR TITLE
CircleCI: check for binaries before publishing release artifacts 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,9 +199,13 @@ jobs:
       - run:
           name: "Publish release on GitHub"
           command: |
-            go get github.com/tcnksm/ghr
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./dist/
-
+            if [ -d "./dist" ] 
+            then
+              go get github.com/tcnksm/ghr
+              ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./dist/
+            else
+                echo "./dist does not exist. No binaries to publish for ${CIRCLE_TAG}."
+            fi            
 #-------------------------------------------------------------------------#
 # Workflows orchestrate jobs and make sure they run in the right sequence #
 #-------------------------------------------------------------------------#


### PR DESCRIPTION
This PR checks if the `./dist` directory is present before attempting to publish for binaries. 
This is needed for packages that do not release binaries such as `horizonclient` and `txnbuild`.
Fixes #1304 