### PR TITLE
services/ticker: ensure ticker ingestion scripts can overcome Horizon's rate limiting

### DIFF
--- a/services/ticker/internal/scraper/trade_scraper.go
+++ b/services/ticker/internal/scraper/trade_scraper.go
@@ -63,7 +63,7 @@ func (c *ScraperConfig) retrieveTrades(since time.Time, limit int) (trades []hPr
 		c.Logger.Debugln("Cursor currently at:", n)
 		r.Cursor = n
 
-		err = utils.Retry(5, 500*time.Millisecond, c.Logger, func() error {
+		err = utils.Retry(5, 1*time.Second, c.Logger, func() error {
 			tradesPage, err = c.Client.Trades(r)
 			if err != nil {
 				c.Logger.Infoln("Horizon rate limit reached!")

--- a/services/ticker/internal/scraper/trade_scraper.go
+++ b/services/ticker/internal/scraper/trade_scraper.go
@@ -63,8 +63,11 @@ func (c *ScraperConfig) retrieveTrades(since time.Time, limit int) (trades []hPr
 		c.Logger.Debugln("Cursor currently at:", n)
 		r.Cursor = n
 
-		err = utils.Retry(3, 1*time.Second, func() error {
+		err = utils.Retry(5, 500*time.Millisecond, c.Logger, func() error {
 			tradesPage, err = c.Client.Trades(r)
+			if err != nil {
+				c.Logger.Infoln("Horizon rate limit reached!")
+			}
 			return err
 		})
 		if err != nil {

--- a/services/ticker/internal/scraper/trade_scraper.go
+++ b/services/ticker/internal/scraper/trade_scraper.go
@@ -63,7 +63,7 @@ func (c *ScraperConfig) retrieveTrades(since time.Time, limit int) (trades []hPr
 		c.Logger.Debugln("Cursor currently at:", n)
 		r.Cursor = n
 
-		err = utils.Retry(5, 1*time.Second, c.Logger, func() error {
+		err = utils.Retry(5, 5*time.Second, c.Logger, func() error {
 			tradesPage, err = c.Client.Trades(r)
 			if err != nil {
 				c.Logger.Infoln("Horizon rate limit reached!")

--- a/services/ticker/internal/scraper/trade_scraper.go
+++ b/services/ticker/internal/scraper/trade_scraper.go
@@ -3,6 +3,8 @@ package scraper
 import (
 	"time"
 
+	"github.com/stellar/go/services/ticker/internal/utils"
+
 	horizonclient "github.com/stellar/go/clients/horizonclient"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 )
@@ -60,7 +62,11 @@ func (c *ScraperConfig) retrieveTrades(since time.Time, limit int) (trades []hPr
 		}
 		c.Logger.Debugln("Cursor currently at:", n)
 		r.Cursor = n
-		tradesPage, err = c.Client.Trades(r)
+
+		err = utils.Retry(3, 1*time.Second, func() error {
+			tradesPage, err = c.Client.Trades(r)
+			return err
+		})
 		if err != nil {
 			return trades, err
 		}

--- a/services/ticker/internal/utils/main.go
+++ b/services/ticker/internal/utils/main.go
@@ -85,7 +85,7 @@ func Retry(numRetries int, delay time.Duration, logger *hlog.Entry, f func() err
 			jitter := time.Duration(rand.Int63n(int64(delay)))
 			delay = delay + jitter/2
 
-			logger.Infof("Backing off for %d milliseconds before retrying", delay.Truncate(time.Millisecond))
+			logger.Infof("Backing off for %.3f seconds before retrying", delay.Seconds())
 
 			time.Sleep(delay)
 			return Retry(numRetries, 2*delay, logger, f)

--- a/services/ticker/internal/utils/main.go
+++ b/services/ticker/internal/utils/main.go
@@ -5,6 +5,8 @@ import (
 	"math/rand"
 	"os"
 	"time"
+
+	hlog "github.com/stellar/go/support/log"
 )
 
 // PanicIfError is an utility function that panics if err != nil
@@ -77,15 +79,16 @@ func CalcSpread(bidMax float64, askMin float64) (spread float64, midPoint float6
 
 // Retry retries running a function that returns an error numRetries times, multiplying
 // the sleep time by a factor of 2 each time it retries.
-func Retry(numRetries int, delay time.Duration, f func() error) error {
-	fmt.Println("Running retry function")
+func Retry(numRetries int, delay time.Duration, logger *hlog.Entry, f func() error) error {
 	if err := f(); err != nil {
 		if numRetries--; numRetries > 0 {
 			jitter := time.Duration(rand.Int63n(int64(delay)))
 			delay = delay + jitter/2
 
+			logger.Infof("Backing off for %d milliseconds before retrying", delay.Truncate(time.Millisecond))
+
 			time.Sleep(delay)
-			return Retry(numRetries, 2*delay, f)
+			return Retry(numRetries, 2*delay, logger, f)
 		}
 		return err
 	}

--- a/services/ticker/internal/utils/main.go
+++ b/services/ticker/internal/utils/main.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"time"
 )
@@ -72,4 +73,26 @@ func CalcSpread(bidMax float64, askMin float64) (spread float64, midPoint float6
 	spread = (askMin - bidMax) / askMin
 	midPoint = bidMax + spread/2.0
 	return
+}
+
+// Retry retries running a function that returns an error numRetries times, multiplying
+// the sleep time by a factor of 2 each time it retries.
+func Retry(numRetries int, delay time.Duration, f func() error) error {
+	fmt.Println("Running retry function")
+	if err := f(); err != nil {
+		if numRetries--; numRetries > 0 {
+			jitter := time.Duration(rand.Int63n(int64(delay)))
+			delay = delay + jitter/2
+
+			time.Sleep(delay)
+			return Retry(numRetries, 2*delay, f)
+		}
+		return err
+	}
+
+	return nil
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
 }


### PR DESCRIPTION
This PR adds a retry logic to the ticker when scraping `assets`, `trades` and `orderbooks`, so it can overcome Horizon's rate limiting.