### PR TITLE
keystore: forward only Authorization and Cookie headers for auth

### DIFF
--- a/services/keystore/api.go
+++ b/services/keystore/api.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/stellar/go/support/errors"
@@ -61,6 +62,11 @@ type authResponse struct {
 	UserID string `json:"userID"`
 }
 
+var forwardHeaders = map[string]struct{}{
+	"authorization": struct{}{},
+	"cookie":        struct{}{},
+}
+
 func authHandler(next http.Handler, authenticator *Authenticator) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if authenticator == nil {
@@ -93,8 +99,13 @@ func authHandler(next http.Handler, authenticator *Authenticator) http.Handler {
 			return
 		}
 
-		// shallow copy
-		proxyReq.Header = req.Header
+		proxyReq.Header = make(http.Header)
+		for k, v := range req.Header {
+			if _, ok := forwardHeaders[strings.ToLower(k)]; ok {
+				proxyReq.Header[k] = v
+			}
+		}
+
 		if clientIP, _, err = net.SplitHostPort(req.RemoteAddr); err == nil {
 			proxyReq.Header.Set("X-Forwarded-For", clientIP)
 		}

--- a/services/keystore/api.go
+++ b/services/keystore/api.go
@@ -101,6 +101,8 @@ func authHandler(next http.Handler, authenticator *Authenticator) http.Handler {
 
 		proxyReq.Header = make(http.Header)
 		for k, v := range req.Header {
+			// http headers are case-insensitive
+			// https://www.ietf.org/rfc/rfc2616.txt
 			if _, ok := forwardHeaders[strings.ToLower(k)]; ok {
 				proxyReq.Header[k] = v
 			}

--- a/services/keystore/spec.md
+++ b/services/keystore/spec.md
@@ -20,11 +20,11 @@ auth token to the client server.
 
 <img src=attachments/2019-07-10-keystore-auth.png>
 
-Keystore will forward every header field to the designated endpoint on the
-client server with an extra header field *X-Forwarded-For* specifying the
-request's origin. At this moment, keystore forwards incoming requests by using
-HTTP GET method. We plan on adding the support for clients who use GraphQL to
-authenticate in the future.
+Keystore will forward two header fields, *Authorization* and *Cookie*, to the
+designated endpoint on the client server with an extra header field
+*X-Forwarded-For* specifying the request's origin. At this moment, keystore
+forwards incoming requests by using HTTP GET method. We plan on adding the
+support for clients who use GraphQL to authenticate in the future.
 
 Clients are expected to put their auth tokens in one of the request header
 fields. For example, those who use a bearer token to authenticate should have an


### PR DESCRIPTION
This PR addresses the issue [here](https://github.com/stellar/go/pull/1498#discussion_r302265272) in this thread. Caching headers may cause trouble or confuses for the auth server.