### PR TITLE
exp/ingest: Add Reporter interface for sessions

### DIFF
--- a/exp/ingest/main.go
+++ b/exp/ingest/main.go
@@ -116,7 +116,7 @@ type reporterStateReader struct {
 
 func (r reporterStateReader) Read() (xdr.LedgerEntryChange, error) {
 	entry, err := r.StateReader.Read()
-	if err != nil {
+	if err == nil {
 		r.OnStateEntry()
 	}
 
@@ -150,7 +150,7 @@ type reporterLedgerReader struct {
 
 func (r reporterLedgerReader) Read() (io.LedgerTransaction, error) {
 	entry, err := r.LedgerReader.Read()
-	if err != nil {
+	if err == nil {
 		r.OnLedgerTransaction()
 	}
 

--- a/exp/ingest/main.go
+++ b/exp/ingest/main.go
@@ -4,9 +4,11 @@ import (
 	"sync"
 
 	"github.com/stellar/go/clients/stellarcore"
+	"github.com/stellar/go/exp/ingest/io"
 	"github.com/stellar/go/exp/ingest/ledgerbackend"
 	"github.com/stellar/go/exp/ingest/pipeline"
 	"github.com/stellar/go/support/historyarchive"
+	"github.com/stellar/go/xdr"
 )
 
 // standardSession contains common methods used by all sessions.
@@ -32,7 +34,9 @@ type LiveSession struct {
 	// instance the cursor name needs to be different in each session.
 	StellarCoreCursor string
 	StatePipeline     *pipeline.StatePipeline
+	StateReporter     StateReporter
 	LedgerPipeline    *pipeline.LedgerPipeline
+	LedgerReporter    LedgerReporter
 }
 
 // SingleLedgerSession initializes the ledger state using `Archive` and `StatePipeline`
@@ -44,6 +48,7 @@ type SingleLedgerSession struct {
 	Archive        *historyarchive.Archive
 	LedgerSequence uint32
 	StatePipeline  *pipeline.StatePipeline
+	StateReporter  StateReporter
 }
 
 // Session is an implementation of a ingesting scenario. Some useful sessions
@@ -82,4 +87,72 @@ type Session interface {
 	UpdateLock()
 	// UpdateUnlock unlocks write lock of the session.
 	UpdateUnlock()
+}
+
+// StateReporter can be used by a session to log progress
+// or update metrics as the session runs its state pipelines.
+type StateReporter interface {
+	// OnStartState is called when the session begins processing
+	// a history archive snapshot at the given sequence number.
+	OnStartState(sequence uint32)
+	// OnStateEntry is called when the session processes an entry
+	// from the io.StateReader
+	OnStateEntry()
+	// OnEndState is called when the session finishes processing
+	// a history archive snapshot.
+	// if err is not nil it means that the session stoped processing the
+	// history archive snapshot because of an error.
+	// if shutdown is true it means the session stopped processing the
+	// history archive snapshot because it received a shutdown signal
+	OnEndState(err error, shutdown bool)
+}
+
+// reporterLedgerReader instruments a io.StateReader with a StateReporter
+// which reports each xdr.LedgerEntryChange which is read from the reader
+type reporterStateReader struct {
+	io.StateReader
+	StateReporter
+}
+
+func (r reporterStateReader) Read() (xdr.LedgerEntryChange, error) {
+	entry, err := r.StateReader.Read()
+	if err != nil {
+		r.OnStateEntry()
+	}
+
+	return entry, err
+}
+
+// LedgerReporter can be used by a session to log progress
+// or update metrics as the session runs its ledger pipelines.
+type LedgerReporter interface {
+	// OnNewLedger is called when the session begins processing
+	// a ledger at the given sequence number.
+	OnNewLedger(sequence uint32)
+	// OnLedgerEntry is called when the session processes a transaction
+	// from the io.LedgerReader
+	OnLedgerTransaction()
+	// OnEndLedger is called when the session finishes processing
+	// a ledger.
+	// if err is not nil it means that the session stoped processing the
+	// ledger because of an error.
+	// if shutdown is true it means the session stopped processing the
+	// ledger because it received a shutdown signal
+	OnEndLedger(err error, shutdown bool)
+}
+
+// reporterLedgerReader instruments a io.LedgerReader with a LedgerReporter
+// which reports each io.LedgerTransaction which is read from the reader
+type reporterLedgerReader struct {
+	io.LedgerReader
+	LedgerReporter
+}
+
+func (r reporterLedgerReader) Read() (io.LedgerTransaction, error) {
+	entry, err := r.LedgerReader.Read()
+	if err != nil {
+		r.OnLedgerTransaction()
+	}
+
+	return entry, err
 }

--- a/exp/tools/horizon-demo/main.go
+++ b/exp/tools/horizon-demo/main.go
@@ -26,8 +26,11 @@ func main() {
 			URL: "http://localhost:11620",
 		},
 
-		StatePipeline:  buildStatePipeline(db, orderBookGraph),
+		StatePipeline: buildStatePipeline(db, orderBookGraph),
+		// logs every 50,000 state entries
+		StateReporter:  NewLoggingStateReporter(50000),
 		LedgerPipeline: buildLedgerPipeline(db, orderBookGraph),
+		LedgerReporter: NewLoggingLedgerReporter(),
 	}
 
 	addPipelineHooks(session.StatePipeline, db, session, orderBookGraph)

--- a/exp/tools/horizon-demo/pipelines.go
+++ b/exp/tools/horizon-demo/pipelines.go
@@ -26,8 +26,7 @@ func buildStatePipeline(db *Database, orderBookGraph *orderbook.OrderBookGraph) 
 	statePipeline := &pipeline.StatePipeline{}
 
 	statePipeline.SetRoot(
-		// Prints number of read entries every N entries...
-		statePipeline.Node(&processors.StatusLogger{N: 50000}).
+		statePipeline.Node(&processors.RootProcessor{}).
 			Pipe(
 				statePipeline.Node(&processors.EntryTypeFilter{Type: xdr.LedgerEntryTypeAccount}).
 					Pipe(

--- a/exp/tools/horizon-demo/reporter.go
+++ b/exp/tools/horizon-demo/reporter.go
@@ -9,6 +9,7 @@ import (
 // LoggingStateReporter logs the progress of a session running its
 // state pipelines
 type LoggingStateReporter struct {
+	log         *log.Entry
 	logInterval int
 	entryCount  int
 	sequence    uint32
@@ -17,14 +18,17 @@ type LoggingStateReporter struct {
 
 // NewLoggingStateReporter constructs a new LoggingStateReporter instance
 func NewLoggingStateReporter(logInterval int) *LoggingStateReporter {
+	logger := log.New()
+	logger.SetLevel(log.InfoLevel)
 	return &LoggingStateReporter{
 		logInterval: logInterval,
+		log:         logger,
 	}
 }
 
 // OnStartState logs that the session has started reading from the history archive snapshot
 func (lr *LoggingStateReporter) OnStartState(sequence uint32) {
-	log.WithField("sequence", sequence).Info("Reading from History Archive Snapshot")
+	lr.log.WithField("sequence", sequence).Info("Reading from History Archive Snapshot")
 	lr.entryCount = 0
 	lr.sequence = sequence
 	lr.startTime = time.Now()
@@ -34,7 +38,7 @@ func (lr *LoggingStateReporter) OnStartState(sequence uint32) {
 func (lr *LoggingStateReporter) OnStateEntry() {
 	lr.entryCount++
 	if lr.entryCount%lr.logInterval == 0 {
-		log.WithField("sequence", lr.sequence).
+		lr.log.WithField("sequence", lr.sequence).
 			WithField("numEntries", lr.entryCount).
 			Info("Processed entries from History Archive Snapshot")
 	}
@@ -43,17 +47,18 @@ func (lr *LoggingStateReporter) OnStateEntry() {
 // OnEndState logs that the session has finished processing the history archive snapshot
 func (lr *LoggingStateReporter) OnEndState(err error, shutdown bool) {
 	elapsedTime := time.Since(lr.startTime)
-	log.WithField("sequence", lr.sequence).
+	lr.log.WithField("sequence", lr.sequence).
 		WithField("numEntries", lr.entryCount).
 		WithError(err).
 		WithField("shutdown", shutdown).
-		WithField("elapsedSeconds", elapsedTime.Seconds).
+		WithField("elapsedSeconds", elapsedTime.Seconds()).
 		Info("Finished processing History Archive Snapshot")
 }
 
 // LoggingLedgerReporter logs the progress of a session running its
 // ledger pipelines
 type LoggingLedgerReporter struct {
+	log        *log.Entry
 	entryCount int
 	sequence   uint32
 	startTime  time.Time
@@ -61,12 +66,16 @@ type LoggingLedgerReporter struct {
 
 // NewLoggingLedgerReporter constructs a new LoggingLedgerReporter instance
 func NewLoggingLedgerReporter() *LoggingLedgerReporter {
-	return &LoggingLedgerReporter{}
+	logger := log.New()
+	logger.SetLevel(log.InfoLevel)
+	return &LoggingLedgerReporter{
+		log: logger,
+	}
 }
 
 // OnNewLedger logs that the session has started reading a new ledger
 func (lr *LoggingLedgerReporter) OnNewLedger(sequence uint32) {
-	log.WithField("sequence", sequence).Info("Reading new ledger")
+	lr.log.WithField("sequence", sequence).Info("Reading new ledger")
 	lr.entryCount = 0
 	lr.sequence = sequence
 	lr.startTime = time.Now()
@@ -80,10 +89,10 @@ func (lr *LoggingLedgerReporter) OnLedgerTransaction() {
 // OnEndLedger logs that the session has finished processing the ledger
 func (lr *LoggingLedgerReporter) OnEndLedger(err error, shutdown bool) {
 	elapsedTime := time.Since(lr.startTime)
-	log.WithField("sequence", lr.sequence).
+	lr.log.WithField("sequence", lr.sequence).
 		WithField("numEntries", lr.entryCount).
 		WithError(err).
 		WithField("shutdown", shutdown).
-		WithField("elapsedSeconds", elapsedTime.Seconds).
+		WithField("elapsedSeconds", elapsedTime.Seconds()).
 		Info("Finished processing ledger")
 }

--- a/exp/tools/horizon-demo/reporter.go
+++ b/exp/tools/horizon-demo/reporter.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"time"
+
+	"github.com/stellar/go/support/log"
+)
+
+// LoggingStateReporter logs the progress of a session running its
+// state pipelines
+type LoggingStateReporter struct {
+	logInterval int
+	entryCount  int
+	sequence    uint32
+	startTime   time.Time
+}
+
+// NewLoggingStateReporter constructs a new LoggingStateReporter instance
+func NewLoggingStateReporter(logInterval int) *LoggingStateReporter {
+	return &LoggingStateReporter{
+		logInterval: logInterval,
+	}
+}
+
+// OnStartState logs that the session has started reading from the history archive snapshot
+func (lr *LoggingStateReporter) OnStartState(sequence uint32) {
+	log.WithField("sequence", sequence).Info("Reading from History Archive Snapshot")
+	lr.entryCount = 0
+	lr.sequence = sequence
+	lr.startTime = time.Now()
+}
+
+// OnStateEntry logs that the session has processed an entry from the history archive snapshot
+func (lr *LoggingStateReporter) OnStateEntry() {
+	lr.entryCount++
+	if lr.entryCount%lr.logInterval == 0 {
+		log.WithField("sequence", lr.sequence).
+			WithField("numEntries", lr.entryCount).
+			Info("Processed entries from History Archive Snapshot")
+	}
+}
+
+// OnEndState logs that the session has finished processing the history archive snapshot
+func (lr *LoggingStateReporter) OnEndState(err error, shutdown bool) {
+	elapsedTime := time.Now().Sub(lr.startTime)
+	log.WithField("sequence", lr.sequence).
+		WithField("numEntries", lr.entryCount).
+		WithError(err).
+		WithField("shutdown", shutdown).
+		WithField("elapsedSeconds", elapsedTime.Seconds).
+		Info("Finished processing History Archive Snapshot")
+}
+
+// LoggingLedgerReporter logs the progress of a session running its
+// ledger pipelines
+type LoggingLedgerReporter struct {
+	entryCount int
+	sequence   uint32
+	startTime  time.Time
+}
+
+// NewLoggingLedgerReporter constructs a new LoggingLedgerReporter instance
+func NewLoggingLedgerReporter() *LoggingLedgerReporter {
+	return &LoggingLedgerReporter{}
+}
+
+// OnNewLedger logs that the session has started reading a new ledger
+func (lr *LoggingLedgerReporter) OnNewLedger(sequence uint32) {
+	log.WithField("sequence", sequence).Info("Reading new ledger")
+	lr.entryCount = 0
+	lr.sequence = sequence
+	lr.startTime = time.Now()
+}
+
+// OnLedgerTransaction records that the session has processed a transaction from the ledger
+func (lr *LoggingLedgerReporter) OnLedgerTransaction() {
+	lr.entryCount++
+}
+
+// OnEndLedger logs that the session has finished processing the ledger
+func (lr *LoggingLedgerReporter) OnEndLedger(err error, shutdown bool) {
+	elapsedTime := time.Now().Sub(lr.startTime)
+	log.WithField("sequence", lr.sequence).
+		WithField("numEntries", lr.entryCount).
+		WithError(err).
+		WithField("shutdown", shutdown).
+		WithField("elapsedSeconds", elapsedTime.Seconds).
+		Info("Finished processing ledger")
+}

--- a/exp/tools/horizon-demo/reporter.go
+++ b/exp/tools/horizon-demo/reporter.go
@@ -42,7 +42,7 @@ func (lr *LoggingStateReporter) OnStateEntry() {
 
 // OnEndState logs that the session has finished processing the history archive snapshot
 func (lr *LoggingStateReporter) OnEndState(err error, shutdown bool) {
-	elapsedTime := time.Now().Sub(lr.startTime)
+	elapsedTime := time.Since(lr.startTime)
 	log.WithField("sequence", lr.sequence).
 		WithField("numEntries", lr.entryCount).
 		WithError(err).
@@ -79,7 +79,7 @@ func (lr *LoggingLedgerReporter) OnLedgerTransaction() {
 
 // OnEndLedger logs that the session has finished processing the ledger
 func (lr *LoggingLedgerReporter) OnEndLedger(err error, shutdown bool) {
-	elapsedTime := time.Now().Sub(lr.startTime)
+	elapsedTime := time.Since(lr.startTime)
 	log.WithField("sequence", lr.sequence).
 		WithField("numEntries", lr.entryCount).
 		WithError(err).


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

A Reporter is used by a session to report progress while executing state / ledger pipelines

Fixes https://github.com/stellar/go/issues/1459

### Goal and scope

We want to provide a mechanism to log progress and/or record metrics as a session processes its pipelines.

### Summary of changes

Define a reporter interface which is invoked by sessions during significant events such as:
the session as started to process a new history archive snapshot / ledger
the session has processed a new entry from the StateReader / LedgerReader
the session has finished processing the history archive snapshot / ledger

### Known limitations & issues


### What shouldn't be reviewed

N / A