### PR TITLE
services/horizon/internal: Fix slice bounds out of range error in operations action

### DIFF
--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -76,7 +76,10 @@ func (action *OperationIndexAction) SSE(stream *sse.Stream) error {
 		func() {
 			stream.SetLimit(int(action.PagingParams.Limit))
 			operationRecords := action.OperationRecords[stream.SentCount():]
-			transactionRecords := action.TransactionRecords[stream.SentCount():]
+			var transactionRecords = action.TransactionRecords
+			if action.IncludeTransactions {
+				transactionRecords = action.TransactionRecords[stream.SentCount():]
+			}
 			for i, operationRecord := range operationRecords {
 				ledger, found := action.Ledgers.Records[operationRecord.LedgerSequence()]
 				if !found {

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -76,7 +76,7 @@ func (action *OperationIndexAction) SSE(stream *sse.Stream) error {
 		func() {
 			stream.SetLimit(int(action.PagingParams.Limit))
 			operationRecords := action.OperationRecords[stream.SentCount():]
-			var transactionRecords = action.TransactionRecords
+			var transactionRecords []history.Transaction
 			if action.IncludeTransactions {
 				transactionRecords = action.TransactionRecords[stream.SentCount():]
 			}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Fix slice bounds out of range error in operations action

### Goal and scope

Fixes
https://github.com/stellar/go/issues/1516

### Summary of changes

`action.TransactionRecords` is empty if `action.IncludeTransactions` is false otherwise `action.IncludeTransactions` will have the same length as `action.OperationRecords`.

If you have a slice `input` and it is empty, the slice expression `input[x:]` will trigger a slice bounds out of range error.
 
### Known limitations & issues

N / A

### What shouldn't be reviewed

N / A