### PR TITLE
Remove default values for history archives

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -9,7 +9,7 @@ bumps.  A breaking change will get clearly notified in this log.
 ## v0.19.0
 
 * Add `join` parameter to operations and payments endpoints. Currently, the only valid value for the parameter is `transactions`. If `join=transactions` is included in a request then the response will include a `transaction` field for each operation in the response.
-* Add experimental "Accounts For Signers" endpoint. To enable it set `--enable-accounts-for-signer` CLI param or `ENABLE_ACCOUNTS_FOR_SIGNER=true` env variable. This will expose `/accounts` endpoint. This requires around 4GB of RAM for initial state ingestion.
+* Add experimental "Accounts For Signers" endpoint. To enable it set `--enable-accounts-for-signer` CLI param or `ENABLE_ACCOUNTS_FOR_SIGNER=true` env variable. Additionally new feature requires links to history archive: CLI: `--history-archive-urls="archive1,archive2,archive3"`, env variable: `HISTORY_ARCHIVE_URLS="archive1,archive2,archive3"`. This will expose `/accounts` endpoint. This requires around 4GB of RAM for initial state ingestion.
 
 ## v0.18.1
 

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -89,7 +89,7 @@ var configOpts = []*support.ConfigOption{
 		ConfigKey:   &config.HistoryArchiveURLs,
 		OptType:     types.String,
 		Required:    false,
-		FlagDefault: "https://history.stellar.org/prd/core-live/core_live_001/,https://history.stellar.org/prd/core-live/core_live_002/,https://history.stellar.org/prd/core-live/core_live_003/",
+		FlagDefault: "",
 		CustomSetValue: func(co *support.ConfigOption) {
 			stringOfUrls := viper.GetString(co.Name)
 			urlStrings := strings.Split(stringOfUrls, ",")

--- a/support/historyarchive/archive.go
+++ b/support/historyarchive/archive.go
@@ -230,6 +230,11 @@ func Connect(u string, opts ConnectOptions) (*Archive, error) {
 	for _, cat := range Categories() {
 		arch.checkpointFiles[cat] = make(map[uint32]bool)
 	}
+
+	if u == "" {
+		return &arch, errors.New("URL is empty")
+	}
+
 	parsed, err := url.Parse(u)
 	if err != nil {
 		return &arch, err


### PR DESCRIPTION
In https://github.com/stellar/go/pull/1490#pullrequestreview-259451959 I suggested to set default values of `history-archive-urls` to SDF archives. The problem with this is that Horizon may be connected to another network (ex. testnet) and this will cause checksum errors. It's probably better to remove defaults because "error creating history archive: URL is empty" is more clear.