### PR TITLE
support/render/httpjson: add OptString type

### DIFF
--- a/support/render/httpjson/encoding.go
+++ b/support/render/httpjson/encoding.go
@@ -61,13 +61,13 @@ func isSpace(c byte) bool {
 
 // This type is used to tell whether a JSON key is presented with its value
 // being an empty string or is not presented.
-type JSONString struct {
+type OptString struct {
 	Value string
 	Valid bool
 	IsSet bool
 }
 
-func (s *JSONString) UnmarshalJSON(in []byte) error {
+func (s *OptString) UnmarshalJSON(in []byte) error {
 	s.IsSet = true
 
 	if string(in) == "null" {

--- a/support/render/httpjson/encoding.go
+++ b/support/render/httpjson/encoding.go
@@ -1,6 +1,10 @@
 package httpjson
 
-import "github.com/stellar/go/support/errors"
+import (
+	"encoding/json"
+
+	"github.com/stellar/go/support/errors"
+)
 
 // ErrNotJSONObject is returned when Object.UnmarshalJSON is called
 // with bytes not representing a valid json object.
@@ -53,4 +57,30 @@ func (o *RawObject) UnmarshalJSON(in []byte) error {
 // https://github.com/golang/go/blob/9f193fbe31d7ffa5f6e71a6387cbcf4636306660/src/encoding/json/scanner.go#L160-L162
 func isSpace(c byte) bool {
 	return c == ' ' || c == '\t' || c == '\r' || c == '\n'
+}
+
+// This type is used to tell whether a JSON key is presented with its value
+// being an empty string or is not presented.
+type JSONString struct {
+	Value string
+	Valid bool
+	IsSet bool
+}
+
+func (s *JSONString) UnmarshalJSON(in []byte) error {
+	s.IsSet = true
+
+	if string(in) == "null" {
+		s.Valid = false
+		return nil
+	}
+
+	var val string
+	if err := json.Unmarshal(in, &val); err != nil {
+		return err
+	}
+
+	s.Value = val
+	s.Valid = true
+	return nil
 }

--- a/support/render/httpjson/encoding_test.go
+++ b/support/render/httpjson/encoding_test.go
@@ -66,3 +66,34 @@ func TestRawObjectUnmarshaler(t *testing.T) {
 		}
 	}
 }
+
+func TestJSONStringUnmarshaler(t *testing.T) {
+	cases := []struct {
+		input []byte
+		isSet bool
+		valid bool
+	}{
+		{[]byte(`{}`), false, false},
+		{[]byte(`{"input":null}`), true, false},
+		{[]byte(`{"input":"a string"}`), true, true},
+	}
+
+	for _, tc := range cases {
+		var out struct {
+			Input JSONString `json:"input"`
+		}
+
+		err := json.Unmarshal(tc.input, &out)
+		if err != nil {
+			t.Errorf("case %s got error %v but shouldn't", string(tc.input), err)
+			continue
+		}
+
+		if out.Input.IsSet != tc.isSet {
+			t.Errorf("case %s got IsSet: %t, want: %t ", tc.input, out.Input.IsSet, tc.isSet)
+		}
+		if out.Input.Valid != tc.valid {
+			t.Errorf("case %s got Valid: %t, want: %t ", tc.input, out.Input.Valid, tc.valid)
+		}
+	}
+}

--- a/support/render/httpjson/encoding_test.go
+++ b/support/render/httpjson/encoding_test.go
@@ -67,7 +67,7 @@ func TestRawObjectUnmarshaler(t *testing.T) {
 	}
 }
 
-func TestJSONStringUnmarshaler(t *testing.T) {
+func TestOptStringUnmarshaler(t *testing.T) {
 	cases := []struct {
 		input []byte
 		isSet bool
@@ -80,7 +80,7 @@ func TestJSONStringUnmarshaler(t *testing.T) {
 
 	for _, tc := range cases {
 		var out struct {
-			Input JSONString `json:"input"`
+			Input OptString `json:"input"`
 		}
 
 		err := json.Unmarshal(tc.input, &out)


### PR DESCRIPTION
This PR adds a OptString type to differentiate the cases where a json
key is not presented and a json key's value is an empty string.

This is useful when it comes to patching a resource's attribute. We
can't patch a resource attribute to an empty string if it's not even
provided in the request.