### PR TITLE
[services/friendbot] Return HTTP 400 when the account submitted to friendbot already exists

### DIFF
--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 
@@ -109,7 +110,12 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 		}
 		resp, err := hclient.SubmitTransactionXDR(txe)
 		if err != nil {
-			log.Print(resp)
+			log.Println(resp)
+			switch e := err.(type) {
+			case *horizonclient.Error:
+				problemString := fmt.Sprintf("Problem[Type=%s, Title=%s, Status=%d, Detail=%s, Extras=%v]", e.Problem.Type, e.Problem.Title, e.Problem.Status, e.Problem.Detail, e.Problem.Extras)
+				return minions, errors.Wrap(errors.Wrap(e, problemString), "submitting create accounts tx")
+			}
 			return minions, errors.Wrap(err, "submitting create accounts tx")
 		}
 

--- a/services/friendbot/internal/friendbot_handler.go
+++ b/services/friendbot/internal/friendbot_handler.go
@@ -17,6 +17,10 @@ type FriendbotHandler struct {
 
 // Handle is a method that implements http.HandlerFunc
 func (handler *FriendbotHandler) Handle(w http.ResponseWriter, r *http.Request) {
+	accountExistsProblem := problem.BadRequest
+	accountExistsProblem.Detail = ErrAccountExists.Error()
+	problem.RegisterError(ErrAccountExists, accountExistsProblem)
+
 	result, err := handler.doHandle(r)
 	if err != nil {
 		problem.Render(r.Context(), w, err)

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stellar/go/txnbuild"
 )
 
+var ErrAccountExists error = errors.New("createAccountAlreadyExist (AAAAAAAAAGT/////AAAAAQAAAAAAAAAA/////AAAAAA=)")
+
 // Minion contains a Stellar channel account and Go channels to communicate with friendbot.
 type Minion struct {
 	Account           Account
@@ -58,6 +60,9 @@ func SubmitTransaction(minion *Minion, hclient *horizonclient.Client, tx string)
 			resStr, resErr := e.ResultString()
 			if resErr != nil {
 				errStr += ": error getting horizon error code: " + resErr.Error()
+			} else if resStr == "AAAAAAAAAGT/////AAAAAQAAAAAAAAAA/////AAAAAA=" {
+				// createAccountAlreadyExist error
+				return nil, errors.Wrap(ErrAccountExists, errStr)
 			} else {
 				errStr += ": horizon error string: " + resStr
 			}

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"fmt"
+
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	hProtocol "github.com/stellar/go/protocols/horizon"
@@ -8,7 +10,9 @@ import (
 	"github.com/stellar/go/txnbuild"
 )
 
-var ErrAccountExists error = errors.New("createAccountAlreadyExist (AAAAAAAAAGT/////AAAAAQAAAAAAAAAA/////AAAAAA=)")
+const createAccountAlreadyExistXDR = "AAAAAAAAAGT/////AAAAAQAAAAAAAAAA/////AAAAAA="
+
+var ErrAccountExists error = errors.New(fmt.Sprintf("createAccountAlreadyExist (%s)", createAccountAlreadyExistXDR))
 
 // Minion contains a Stellar channel account and Go channels to communicate with friendbot.
 type Minion struct {
@@ -60,8 +64,7 @@ func SubmitTransaction(minion *Minion, hclient *horizonclient.Client, tx string)
 			resStr, resErr := e.ResultString()
 			if resErr != nil {
 				errStr += ": error getting horizon error code: " + resErr.Error()
-			} else if resStr == "AAAAAAAAAGT/////AAAAAQAAAAAAAAAA/////AAAAAA=" {
-				// createAccountAlreadyExist error
+			} else if resStr == createAccountAlreadyExistXDR {
 				return nil, errors.Wrap(ErrAccountExists, errStr)
 			} else {
 				errStr += ": horizon error string: " + resStr


### PR DESCRIPTION
fixes #1511 

<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Funding an account with friendbot used to return an HTTP 500. This PR addresses that and returns a HTTP 400

### Goal and scope

Fix error code returned with an informative error message

### Summary of changes

Register the friendbot account exists error so we treat it as a bad request HTTP 400 

### Known limitations & issues

None that i can think of

### What shouldn't be reviewed

N/A