### PR TITLE
services/ticker: prepare for v1.1.0 release

### DIFF
--- a/services/ticker/CHANGELOG.md
+++ b/services/ticker/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [v1.1.0] - 2019-07-22
+
+- Added support for running the ticker on Stellar's Test Network, by using the `--testnet` CLI flag.
+- The ticker now retries requests to Horizon if it gets rate-limited.
+- Minor bug fixes and performance improvements.
+
+
 ## [v1.0.0] - 2019-05-20
 
 Initial release of the ticker.

--- a/services/ticker/cmd/generate.go
+++ b/services/ticker/cmd/generate.go
@@ -9,7 +9,6 @@ import (
 
 var MarketsOutFile string
 var AssetsOutFile string
-var CMCFormat bool
 
 func init() {
 	rootCmd.AddCommand(cmdGenerate)
@@ -30,13 +29,6 @@ func init() {
 		"o",
 		"assets.json",
 		"Set the name of the output file",
-	)
-
-	cmdGenerateMarketData.Flags().BoolVar(
-		&CMCFormat,
-		"cmc",
-		false,
-		"Format output specifically for CoinMarketCap",
 	)
 }
 
@@ -60,7 +52,7 @@ var cmdGenerateMarketData = &cobra.Command{
 		}
 
 		Logger.Infof("Starting market data generation, outputting to: %s\n", MarketsOutFile)
-		err = ticker.GenerateMarketSummaryFile(&session, Logger, MarketsOutFile, CMCFormat)
+		err = ticker.GenerateMarketSummaryFile(&session, Logger, MarketsOutFile)
 		if err != nil {
 			Logger.Fatal("could not generate market data:", err)
 		}

--- a/services/ticker/docker/setup
+++ b/services/ticker/docker/setup
@@ -10,7 +10,7 @@ mkdir -p /opt/stellar/www
 chown -R stellar:stellar /opt/stellar/www
 mkdir -p /opt/stellar/postgresql/data
 
-export TICKER="ticker-v1.0.0"
+export TICKER="ticker-v1.1.0"
 export TICKER_PATH="$TICKER-linux-amd64"
 wget -O ticker.tar.gz https://github.com/stellar/go/releases/download/$TICKER/$TICKER_PATH.tar.gz
 tar -xvzf ticker.tar.gz

--- a/services/ticker/internal/actions_market.go
+++ b/services/ticker/internal/actions_market.go
@@ -2,7 +2,6 @@ package ticker
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/stellar/go/services/ticker/internal/tickerdb"
@@ -12,19 +11,13 @@ import (
 
 // GenerateMarketSummaryFile generates a MarketSummary with the statistics for all
 // valid markets within the database and outputs it to <filename>.
-func GenerateMarketSummaryFile(s *tickerdb.TickerSession, l *hlog.Entry, filename string, forCMC bool) error {
+func GenerateMarketSummaryFile(s *tickerdb.TickerSession, l *hlog.Entry, filename string) error {
 	l.Infoln("Generating market data...")
 	marketSummary, err := GenerateMarketSummary(s)
 	if err != nil {
 		return err
 	}
 	l.Infoln("Market data successfully generated!")
-
-	if forCMC {
-		l.Infoln("Inverting CMC markets...")
-		invertCMCMarkets(&marketSummary)
-		l.Infoln("Markets successfully adapted for CoinMarketCap")
-	}
 
 	jsonMkt, err := json.MarshalIndent(marketSummary, "", "    ")
 	if err != nil {
@@ -97,114 +90,5 @@ func dbMarketToMarketStats(m tickerdb.Market) MarketStats {
 		Spread:           spread,
 		SpreadMidPoint:   spreadMidPoint,
 		CloseTime:        closeTime,
-	}
-}
-
-// This is a set of temporary functions that are used to invert
-// some asset pairs when generating the assets.json report to fix
-// the prices / volumes on CoinMarketCap.
-
-func invertIfNotNull(n float64) float64 {
-	if n != 0.0 {
-		return 1.0 / n
-	}
-	return n
-}
-
-func invertMarketStats(m *MarketStats) {
-	// Uncomment if we need to change the trade pair order:
-	//
-	// tradePairItems := strings.Split(m.TradePairName, "_")
-	// m.TradePairName = fmt.Sprintf("%s_%s", tradePairItems[1], tradePairItems[0])
-
-	m.Close = invertIfNotNull(m.Close)
-	m.Price = m.Close
-
-	// Re-calculating 24h stats:
-	m.Open24h = invertIfNotNull(m.Open24h)
-
-	currLow24h := m.Low24h
-	currHigh24h := m.High24h
-
-	if currHigh24h != 0.0 {
-		m.Low24h = 1.0 / currHigh24h
-	}
-
-	if currLow24h != 0.0 {
-		m.High24h = 1.0 / currLow24h
-	}
-
-	m.Change24h = m.Close - m.Open24h
-
-	// Re-calculating 7d stats:
-	m.Open7d = invertIfNotNull(m.Open7d)
-
-	currLow7d := m.Low7d
-	currHigh7d := m.High7d
-
-	if currHigh7d != 0.0 {
-		m.Low7d = 1.0 / currHigh7d
-	}
-
-	if currLow7d != 0.0 {
-		m.High7d = 1.0 / currLow7d
-	}
-
-	m.Change7d = m.Close - m.Open7d
-
-	// Since we're reversing the asset pairs, the orderbook data is invalidated:
-	m.BidCount = 0.0
-	m.BidVolume = 0.0
-	m.BidMax = 0.0
-	m.AskCount = 0.0
-	m.AskVolume = 0.0
-	m.AskMin = 0.0
-	m.Spread = 0.0
-	m.SpreadMidPoint = 0.0
-}
-
-func shouldMarketBeInvertdForCMC(pairName string) bool {
-	cmcMarketPairs := []string{
-		"XLM_SHX",
-		"XLM_SLT",
-		"XLM_DOGET",
-		"XLM_RMT",
-		"XLM_MOBI",
-		"XLM_ETH",
-		"XLM_BTC",
-		"XLM_KIN",
-		"XLM_XRP",
-		"XLM_XLB",
-		"XLM_TERN",
-		"XLM_BTX",
-		"XLM_GRAT",
-		"XLM_DRA",
-		"XLM_PEDI",
-		"XLM_ABDT",
-		"XLM_ZRX",
-		"XLM_WLO",
-		"XLM_LTC",
-		"XLM_SHADE",
-		"XLM_XLMG",
-		"XLM_OMG",
-		"XLM_ETX",
-		"XLM_NEOX",
-		"XLM_REPO",
-	}
-	for _, cmcPair := range cmcMarketPairs {
-		if pairName == cmcPair {
-			fmt.Println("Found a matching pair")
-			return true
-		}
-	}
-
-	return false
-}
-
-func invertCMCMarkets(ms *MarketSummary) {
-	for i, mkt := range ms.Pairs {
-		if shouldMarketBeInvertdForCMC(mkt.TradePairName) {
-			invertMarketStats(&ms.Pairs[i])
-		}
 	}
 }


### PR DESCRIPTION
This PR:

- updates the `CHANGELOG.md` in preparation for the release of v1.1.0 of the ticker. 
- removes some functions/logic that aimed to temporarily solve an issue with CMC (see #1364), which has already been addressed by them.
