### PR TITLE
services/horizon/expingest: Store ingestion system version

### DIFF
--- a/services/horizon/internal/db2/history/key_value.go
+++ b/services/horizon/internal/db2/history/key_value.go
@@ -9,6 +9,7 @@ import (
 )
 
 const (
+	ingestVersion = "exp_ingest_version"
 	lastLedgerKey = "exp_ingest_last_ledger"
 )
 
@@ -38,6 +39,34 @@ func (q *Q) GetLastLedgerExpIngest() (uint32, error) {
 func (q *Q) UpdateLastLedgerExpIngest(ledgerSequence uint32) error {
 	return q.updateValueInStore(
 		lastLedgerKey,
+		strconv.FormatUint(uint64(ledgerSequence), 10),
+	)
+}
+
+// GetExpIngestVersion returns the exp ingest version. Returns zero
+// if there is no value.
+func (q *Q) GetExpIngestVersion() (int, error) {
+	expVersion, err := q.getValueFromStore(ingestVersion)
+	if err != nil {
+		return 0, err
+	}
+
+	if expVersion == "" {
+		return 0, nil
+	} else {
+		version, err := strconv.ParseInt(expVersion, 10, 32)
+		if err != nil {
+			return 0, errors.Wrap(err, "Error converting expVersion value")
+		}
+
+		return int(version), nil
+	}
+}
+
+// UpdateExpIngestVersion upsets the exp ingest version.
+func (q *Q) UpdateExpIngestVersion(ledgerSequence int) error {
+	return q.updateValueInStore(
+		ingestVersion,
 		strconv.FormatUint(uint64(ledgerSequence), 10),
 	)
 }

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -16,6 +16,13 @@ import (
 	ilog "github.com/stellar/go/support/log"
 )
 
+const (
+	// CurrentVersion reflects the latest version of the ingestion
+	// algorithm. This value is stored in KV store and is used to decide
+	// if there's a need to reprocess the ledger state or reingest data.
+	CurrentVersion = 1
+)
+
 var log = ilog.DefaultLogger.WithField("service", "expingest")
 
 type Config struct {

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -91,6 +91,11 @@ func addPipelineHooks(
 			return errors.Wrap(err, "Error updating last ingested ledger")
 		}
 
+		err = historyQ.UpdateExpIngestVersion(CurrentVersion)
+		if err != nil {
+			return errors.Wrap(err, "Error updating expingest version")
+		}
+
 		err = historySession.Commit()
 		if err != nil {
 			return errors.Wrap(err, "Error commiting db transaction")


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Track version number of ingestion system to simplify migrations.

### Goal and scope

This commit adds `CurrentVersion` const that defines the current version of the ingestion system that is stored after pipeline processing is finished. This is done to simplify migrations/reingestion when new version of the system is deployed. Ex. in the next Horizon version we will probably ship path finding using the order book in-memory graph. If the system notices that the version has changed it can flush the current state in the storage and run the state pipeline again to process offers.