### PR TITLE
support/render/httpjson: update comments for OptString

### DIFF
--- a/support/render/httpjson/encoding.go
+++ b/support/render/httpjson/encoding.go
@@ -60,7 +60,7 @@ func isSpace(c byte) bool {
 }
 
 // This type is used to tell whether a JSON key is presented with its value
-// being an empty string or is not presented.
+// being a JSON null value or is not presented.
 type OptString struct {
 	Value string
 	Valid bool


### PR DESCRIPTION
The previous comment wasn't wrong, but it could be achieved by just using a pointer to the type. What's special about this type is that it is able to differentiate JSON null value and key being absence.