### PR TITLE
use staticcheck-2019.2

### DIFF
--- a/staticcheck.sh
+++ b/staticcheck.sh
@@ -4,6 +4,15 @@ set -e
 # Check if staticcheck is installed, if not install it.
 command -v staticcheck >/dev/null 2>&1 || go get honnef.co/go/tools/cmd/staticcheck
 
+# use staticcheck stable version
+cd $GOPATH/src/honnef.co/go/tools/cmd/staticcheck
+git checkout 2019.2
+go get
+go install
+
+# go back to previous directory
+cd -
+
 printf "Running staticcheck...\n"
 
 ls -d */ \


### PR DESCRIPTION
When installing `staticcheck` using `go get honnef.co/go/tools/cmd/staticcheck` the master branch is pulled in by default. This branch is unstable and it will be better to use the stable release branch.
This workaround is suggested by the docs: https://staticcheck.io/docs/

>If you use Go modules, you can simply run go get honnef.co/go/tools/cmd/staticcheck to obtain the latest released version. If you're still using a GOPATH-based workflow, then the above command will instead fetch the master branch. It is suggested that you explicitly check out the latest release branch instead, which is currently 2019.2. One way of doing so would be as follows:
```bash
cd $GOPATH/src/honnef.co/go/tools/cmd/staticcheck
git checkout 2019.2
go get
go install
```