### PR TITLE
services/ticker: add nested issuer_detail field on assets.json

### DIFF
--- a/services/ticker/CHANGELOG.md
+++ b/services/ticker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [UNRELEASED]
+- Added nested `"issuer_detail"` field to `/assets.json`.
+
+
 ## [v1.1.0] - 2019-07-22
 
 - Added support for running the ticker on Stellar's Test Network, by using the `--testnet` CLI flag.

--- a/services/ticker/internal/actions_asset.go
+++ b/services/ticker/internal/actions_asset.go
@@ -48,7 +48,7 @@ func RefreshAssets(s *tickerdb.TickerSession, c *horizonclient.Client, l *hlog.E
 func GenerateAssetsFile(s *tickerdb.TickerSession, l *hlog.Entry, filename string) error {
 	l.Infoln("Retrieving asset data from db...")
 	var assets []Asset
-	validAssets, err := s.GetAllValidAssets()
+	validAssets, err := s.GetAssetsWithNestedIssuer()
 	if err != nil {
 		return err
 	}
@@ -156,6 +156,20 @@ func dbAssetToAsset(dbAsset tickerdb.Asset) (a Asset) {
 	a.CollateralAddressSignatures = collAddrSigns
 	a.Countries = dbAsset.Countries
 	a.Status = dbAsset.Status
+
+	i := Issuer{
+		PublicKey:        dbAsset.Issuer.PublicKey,
+		Name:             dbAsset.Issuer.Name,
+		URL:              dbAsset.Issuer.URL,
+		TOMLURL:          dbAsset.Issuer.TOMLURL,
+		FederationServer: dbAsset.Issuer.FederationServer,
+		AuthServer:       dbAsset.Issuer.AuthServer,
+		TransferServer:   dbAsset.Issuer.TransferServer,
+		WebAuthEndpoint:  dbAsset.Issuer.WebAuthEndpoint,
+		DepositServer:    dbAsset.Issuer.DepositServer,
+		OrgTwitter:       dbAsset.Issuer.OrgTwitter,
+	}
+	a.IssuerDetail = i
 
 	return
 }

--- a/services/ticker/internal/main.go
+++ b/services/ticker/internal/main.go
@@ -54,5 +54,20 @@ type AssetSummary struct {
 type Asset struct {
 	scraper.FinalAsset
 
+	IssuerDetail       Issuer `json:"issuer_detail"`
 	LastValidTimestamp string `json:"last_valid"`
+}
+
+// Issuer represents the aggregated data for a given issuer.
+type Issuer struct {
+	PublicKey        string `json:"public_key"`
+	Name             string `json:"name"`
+	URL              string `json:"url"`
+	TOMLURL          string `json:"toml_url"`
+	FederationServer string `json:"federation_server"`
+	AuthServer       string `json:"auth_server"`
+	TransferServer   string `json:"transfer_server"`
+	WebAuthEndpoint  string `json:"web_auth_endpoint"`
+	DepositServer    string `json:"deposit_server"`
+	OrgTwitter       string `json:"org_twitter"`
 }

--- a/services/ticker/internal/tickerdb/helpers.go
+++ b/services/ticker/internal/tickerdb/helpers.go
@@ -14,7 +14,7 @@ func getDBFieldTags(model interface{}, excludeID bool) (fields []string) {
 	r := reflect.ValueOf(model)
 	for i := 0; i < r.Type().NumField(); i++ {
 		dbField := r.Type().Field(i).Tag.Get("db")
-		if excludeID && dbField == "id" {
+		if (excludeID && dbField == "id") || dbField == "-" { // ensure fields marked with a "-" tag are ignored
 			continue
 		}
 		fields = append(fields, dbField)
@@ -38,7 +38,7 @@ func getDBFieldValues(model interface{}, excludeID bool) (values []interface{}) 
 	for i := 0; i < r.Type().NumField(); i++ {
 		dbField := r.Type().Field(i).Tag.Get("db")
 		dbVal := r.Field(i).Interface()
-		if excludeID && dbField == "id" {
+		if (excludeID && dbField == "id") || dbField == "-" { // ensure fields marked with a "-" tag are ignored
 			continue
 		}
 		values = append(values, dbVal)

--- a/services/ticker/internal/tickerdb/main.go
+++ b/services/ticker/internal/tickerdb/main.go
@@ -47,6 +47,7 @@ type Asset struct {
 	Countries                   string    `db:"countries"`
 	Status                      string    `db:"status"`
 	IssuerID                    int32     `db:"issuer_id"`
+	Issuer                      Issuer    `db:"-"`
 }
 
 // Issuer represents an entry on the issuers table

--- a/services/ticker/internal/tickerdb/queries_asset.go
+++ b/services/ticker/internal/tickerdb/queries_asset.go
@@ -44,3 +44,46 @@ func (s *TickerSession) GetAllValidAssets() (assets []Asset, err error) {
 
 	return
 }
+
+// GetAssetsWithNestedIssuer returns a slice with all assets in the database
+// with is_valid = true, also adding the nested Issuer attribute
+func (s *TickerSession) GetAssetsWithNestedIssuer() (assets []Asset, err error) {
+	const q = `
+		SELECT
+			a.code, a.issuer_account, a.type, a.num_accounts, a.auth_required, a.auth_revocable,
+			a.amount, a.asset_controlled_by_domain, a.anchor_asset_code, a.anchor_asset_type,
+			a.is_valid, a.validation_error, a.last_valid, a.last_checked, a.display_decimals,
+			a.name, a.description, a.conditions, a.is_asset_anchored, a.fixed_number, a.max_number,
+			a.is_unlimited, a.redemption_instructions, a.collateral_addresses, a.collateral_address_signatures,
+			a.countries, a.status, a.issuer_id, i.public_key, i.name, i.url, i.toml_url, i.federation_server,
+			i.auth_server, i.transfer_server, i.web_auth_endpoint, i.deposit_server, i.org_twitter
+		FROM assets AS a
+		INNER JOIN issuers AS i ON a.issuer_id = i.id
+		WHERE a.is_valid = TRUE
+	`
+
+	rows, err := s.DB.Query(q)
+	if err != nil {
+		return
+	}
+
+	for rows.Next() {
+		var a Asset
+		var i Issuer
+
+		err = rows.Scan(
+			&a.Code, &a.IssuerAccount, &a.Type, &a.NumAccounts, &a.AuthRequired, &a.AuthRevocable,
+			&a.Amount, &a.AssetControlledByDomain, &a.AnchorAssetCode, &a.AnchorAssetType,
+			&a.IsValid, &a.ValidationError, &a.LastValid, &a.LastChecked, &a.DisplayDecimals,
+			&a.Name, &a.Desc, &a.Conditions, &a.IsAssetAnchored, &a.FixedNumber, &a.MaxNumber,
+			&a.IsUnlimited, &a.RedemptionInstructions, &a.CollateralAddresses, &a.CollateralAddressSignatures,
+			&a.Countries, &a.Status, &a.IssuerID, &i.PublicKey, &i.Name, &i.URL, &i.TOMLURL, &i.FederationServer,
+			&i.AuthServer, &i.TransferServer, &i.WebAuthEndpoint, &i.DepositServer, &i.OrgTwitter,
+		)
+		a.Issuer = i
+
+		assets = append(assets, a)
+	}
+
+	return
+}

--- a/services/ticker/internal/tickerdb/queries_asset.go
+++ b/services/ticker/internal/tickerdb/queries_asset.go
@@ -80,8 +80,11 @@ func (s *TickerSession) GetAssetsWithNestedIssuer() (assets []Asset, err error) 
 			&a.Countries, &a.Status, &a.IssuerID, &i.PublicKey, &i.Name, &i.URL, &i.TOMLURL, &i.FederationServer,
 			&i.AuthServer, &i.TransferServer, &i.WebAuthEndpoint, &i.DepositServer, &i.OrgTwitter,
 		)
-		a.Issuer = i
+		if err != nil {
+			return
+		}
 
+		a.Issuer = i
 		assets = append(assets, a)
 	}
 

--- a/services/ticker/internal/tickerdb/queries_asset.go
+++ b/services/ticker/internal/tickerdb/queries_asset.go
@@ -68,8 +68,10 @@ func (s *TickerSession) GetAssetsWithNestedIssuer() (assets []Asset, err error) 
 	}
 
 	for rows.Next() {
-		var a Asset
-		var i Issuer
+		var (
+			a Asset
+			i Issuer
+		)
 
 		err = rows.Scan(
 			&a.Code, &a.IssuerAccount, &a.Type, &a.NumAccounts, &a.AuthRequired, &a.AuthRevocable,


### PR DESCRIPTION
This PR closes #1541 

It aims to add a nested `issuer_detail` field for each asset on the `/assets.json` endpoint. 

**Note:** I've opted to add a separate `"issuer_detail"` field instead of simply using `issuer` to ensure backwards compatibility, since an `"issuer"` field was already being used to provide the issuer's public key.