### PR TITLE
tools/horizon-cmp: Add streaming endpoints tests

### DIFF
--- a/staticcheck.sh
+++ b/staticcheck.sh
@@ -4,6 +4,15 @@ set -e
 # Check if staticcheck is installed, if not install it.
 command -v staticcheck >/dev/null 2>&1 || go get honnef.co/go/tools/cmd/staticcheck
 
+# use staticcheck stable version
+cd $GOPATH/src/honnef.co/go/tools/cmd/staticcheck
+git checkout 2019.2
+go get
+go install
+
+# go back to previous directory
+cd -
+
 printf "Running staticcheck...\n"
 
 ls -d */ \

--- a/tools/horizon-cmp/main.go
+++ b/tools/horizon-cmp/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -24,54 +23,73 @@ const horizonNew = "http://localhost:8000"
 const maxLevels = 3
 
 type pathWithLevel struct {
-	Path  string
-	Level int
+	Path   string
+	Level  int
+	Stream bool
+}
+
+func (p pathWithLevel) ID() string {
+	return fmt.Sprintf("%t%s", p.Path, p.Stream)
+}
+
+var initPaths []string = []string{
+	"/transactions?order=desc",
+	"/transactions?order=desc",
+	"/transactions?order=desc&include_failed=false",
+	"/transactions?order=desc&include_failed=true",
+
+	"/operations?order=desc",
+	"/operations?order=desc&include_failed=false",
+	"/operations?order=desc&include_failed=true",
+
+	"/operations?join=transactions&order=desc",
+	"/operations?join=transactions&order=desc&include_failed=false",
+	"/operations?join=transactions&order=desc&include_failed=true",
+
+	"/payments?order=desc",
+	"/payments?order=desc&include_failed=false",
+	"/payments?order=desc&include_failed=true",
+
+	"/payments?join=transactions&order=desc",
+	"/payments?join=transactions&order=desc&include_failed=false",
+	"/payments?join=transactions&order=desc&include_failed=true",
+
+	"/ledgers?order=desc",
+	"/effects?order=desc",
+	"/trades?order=desc",
+
+	"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/transactions?limit=200",
+	"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/transactions?limit=200&include_failed=false",
+	"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/transactions?limit=200&include_failed=true",
+
+	"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/operations?limit=200",
+	"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/payments?limit=200",
+	"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/effects?limit=200",
+
+	"/accounts/GC2ZV6KGGFLQIMDVDWBWCP6LTODUDXYBLUPTUZCFHIMDCWHR43ULZITJ/trades?limit=200",
+	"/accounts/GC2ZV6KGGFLQIMDVDWBWCP6LTODUDXYBLUPTUZCFHIMDCWHR43ULZITJ/offers?limit=200",
+
+	// Pubnet markets
+	"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=LTC&buying_asset_issuer=GCSTRLTC73UVXIYPHYTTQUUSDTQU2KQW5VKCE4YCMEHWF44JKDMQAL23",
+	"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=XRP&buying_asset_issuer=GCSTRLTC73UVXIYPHYTTQUUSDTQU2KQW5VKCE4YCMEHWF44JKDMQAL23",
+	"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=BTC&buying_asset_issuer=GCSTRLTC73UVXIYPHYTTQUUSDTQU2KQW5VKCE4YCMEHWF44JKDMQAL23",
+	"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=USD&buying_asset_issuer=GBSTRUSD7IRX73RQZBL3RQUH6KS3O4NYFY3QCALDLZD77XMZOPWAVTUK",
+	"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=SLT&buying_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP",
+
+	"/trade_aggregations?base_asset_type=native&counter_asset_code=USD&counter_asset_issuer=GBSTRUSD7IRX73RQZBL3RQUH6KS3O4NYFY3QCALDLZD77XMZOPWAVTUK&counter_asset_type=credit_alphanum4&end_time=1551866400000&limit=200&order=desc&resolution=900000&start_time=1514764800",
 }
 
 // Starting corpus of paths to test. You may want to extend this with a list of
 // paths that you want to ensure are tested.
-var paths []pathWithLevel = []pathWithLevel{
-	pathWithLevel{"/transactions?order=desc", 0},
-	pathWithLevel{"/transactions?order=desc&include_failed=false", 0},
-	pathWithLevel{"/transactions?order=desc&include_failed=true", 0},
-
-	pathWithLevel{"/operations?order=desc", 0},
-	pathWithLevel{"/operations?order=desc&include_failed=false", 0},
-	pathWithLevel{"/operations?order=desc&include_failed=true", 0},
-
-	pathWithLevel{"/payments?order=desc", 0},
-	pathWithLevel{"/payments?order=desc&include_failed=false", 0},
-	pathWithLevel{"/payments?order=desc&include_failed=true", 0},
-
-	pathWithLevel{"/ledgers?order=desc", 0},
-	pathWithLevel{"/effects?order=desc", 0},
-	pathWithLevel{"/trades?order=desc", 0},
-
-	pathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/transactions?limit=200", 0},
-	pathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/transactions?limit=200&include_failed=false", 0},
-	pathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/transactions?limit=200&include_failed=true", 0},
-
-	pathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/operations?limit=200", 0},
-	pathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/payments?limit=200", 0},
-	pathWithLevel{"/accounts/GAKLCFRTFDXKOEEUSBS23FBSUUVJRMDQHGCHNGGGJZQRK7BCPIMHUC4P/effects?limit=200", 0},
-
-	pathWithLevel{"/accounts/GC2ZV6KGGFLQIMDVDWBWCP6LTODUDXYBLUPTUZCFHIMDCWHR43ULZITJ/trades?limit=200", 0},
-	pathWithLevel{"/accounts/GC2ZV6KGGFLQIMDVDWBWCP6LTODUDXYBLUPTUZCFHIMDCWHR43ULZITJ/offers?limit=200", 0},
-
-	// Pubnet markets
-	pathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=LTC&buying_asset_issuer=GCSTRLTC73UVXIYPHYTTQUUSDTQU2KQW5VKCE4YCMEHWF44JKDMQAL23", 0},
-	pathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=XRP&buying_asset_issuer=GCSTRLTC73UVXIYPHYTTQUUSDTQU2KQW5VKCE4YCMEHWF44JKDMQAL23", 0},
-	pathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=BTC&buying_asset_issuer=GCSTRLTC73UVXIYPHYTTQUUSDTQU2KQW5VKCE4YCMEHWF44JKDMQAL23", 0},
-	pathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=USD&buying_asset_issuer=GBSTRUSD7IRX73RQZBL3RQUH6KS3O4NYFY3QCALDLZD77XMZOPWAVTUK", 0},
-	pathWithLevel{"/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=SLT&buying_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP", 0},
-
-	pathWithLevel{"/trade_aggregations?base_asset_type=native&counter_asset_code=USD&counter_asset_issuer=GBSTRUSD7IRX73RQZBL3RQUH6KS3O4NYFY3QCALDLZD77XMZOPWAVTUK&counter_asset_type=credit_alphanum4&end_time=1551866400000&limit=200&order=desc&resolution=900000&start_time=1514764800", 0},
-}
-
+var paths []pathWithLevel
 var visitedPaths map[string]bool
 
 func init() {
 	visitedPaths = make(map[string]bool)
+	for _, p := range initPaths {
+		paths = append(paths, pathWithLevel{Path: p, Level: 0, Stream: false})
+		paths = append(paths, pathWithLevel{Path: p, Level: 0, Stream: true})
+	}
 }
 
 func main() {
@@ -97,34 +115,25 @@ func main() {
 		panic(err)
 	}
 
-	for {
-		if len(paths) == 0 {
-			return
-		}
-
+	for len(paths) > 0 {
 		var pl pathWithLevel
 		pl, paths = paths[0], paths[1:]
 
-		p := pl.Path
-		level := pl.Level
-
-		if level > maxLevels {
+		if pl.Level > maxLevels {
 			continue
 		}
 
-		if visitedPaths[p] {
+		if visitedPaths[pl.ID()] {
 			continue
 		}
 
-		visitedPaths[p] = true
+		visitedPaths[pl.ID()] = true
 
-		fmt.Printf("%s ", p)
+		fmt.Printf("[stream=%t] %s ", pl.Stream, pl.Path)
 
-		p = getPathWithCursor(p, cursor)
-
-		a := cmp.NewResponse(horizonOld, p)
+		a := cmp.NewResponse(horizonOld, pl.Path, pl.Stream)
 		fmt.Print(".")
-		b := cmp.NewResponse(horizonNew, p)
+		b := cmp.NewResponse(horizonNew, pl.Path, pl.Stream)
 		fmt.Print(".")
 
 		status := ""
@@ -133,19 +142,13 @@ func main() {
 		} else {
 			status = "diff"
 		}
-		fmt.Println(status)
+		fmt.Printf("%s %d %d %d\n", status, a.StatusCode, a.Size(), b.Size())
 		if status == "diff" {
 			a.SaveDiff(outputDir, b)
 		}
 
 		newPaths := a.GetPaths()
 		for _, newPath := range newPaths {
-			// Such links can get recent ledgers data that may be different
-			// if Horizon nodes are not at the same ledger.
-			if strings.Contains(newPath, "order=asc") {
-				continue
-			}
-
 			if (strings.Contains(newPath, "/transactions") ||
 				strings.Contains(newPath, "/operations") ||
 				strings.Contains(newPath, "/payments")) && !strings.Contains(newPath, "include_failed") {
@@ -154,12 +157,16 @@ func main() {
 					prefix = "&"
 				}
 
-				paths = append(paths, pathWithLevel{newPath + prefix + "include_failed=false", level + 1})
-				paths = append(paths, pathWithLevel{newPath + prefix + "include_failed=true", level + 1})
+				paths = append(paths, pathWithLevel{newPath + prefix + "include_failed=false", pl.Level + 1, false})
+				paths = append(paths, pathWithLevel{newPath + prefix + "include_failed=false", pl.Level + 1, true})
+
+				paths = append(paths, pathWithLevel{newPath + prefix + "include_failed=true", pl.Level + 1, false})
+				paths = append(paths, pathWithLevel{newPath + prefix + "include_failed=true", pl.Level + 1, true})
 				continue
 			}
 
-			paths = append(paths, pathWithLevel{newPath, level + 1})
+			paths = append(paths, pathWithLevel{newPath, pl.Level + 1, false})
+			paths = append(paths, pathWithLevel{newPath, pl.Level + 1, true})
 		}
 	}
 }
@@ -180,20 +187,4 @@ func getLatestLedger() protocol.Ledger {
 	}
 
 	return ledgers.Embedded.Records[0]
-}
-
-func getPathWithCursor(path, cursor string) string {
-	urlObj, err := url.Parse(path)
-	if err != nil {
-		panic(err)
-	}
-
-	// Add cursor if not present
-	q := urlObj.Query()
-	if q.Get("cursor") == "" {
-		q.Set("cursor", cursor)
-	}
-
-	urlObj.RawQuery = q.Encode()
-	return urlObj.String()
 }

--- a/tools/horizon-cmp/main.go
+++ b/tools/horizon-cmp/main.go
@@ -29,7 +29,7 @@ type pathWithLevel struct {
 }
 
 func (p pathWithLevel) ID() string {
-	return fmt.Sprintf("%t%s", p.Path, p.Stream)
+	return fmt.Sprintf("%t%s", p.Stream, p.Path)
 }
 
 var initPaths []string = []string{


### PR DESCRIPTION
This PR adds streaming endpoint tests and improves the code. Also, cherry-picked 9af9d5dae373bcfd14017e69de3e3354829ae98e to fix `staticcheck` errors.

Close #1184.