### PR TITLE
Update timebounds format from ISO8601 to RFC3339.

### DIFF
--- a/services/horizon/internal/docs/reference/resources/transaction.md
+++ b/services/horizon/internal/docs/reference/resources/transaction.md
@@ -29,8 +29,8 @@ To learn more about the concept of transactions in the Stellar network, take a l
 | memo_type        | string | |
 | memo             | string | |
 | signatures | string[] | An array of signatures used to sign this transaction |
-| valid_after | ISO8601 string | |
-| valid_before | ISO8601 string | |
+| valid_after | RFC3339 date-time string | |
+| valid_before | RFC3339 date-time string | |
 
 ## Links
 


### PR DESCRIPTION
Let's make it clear that we are returning an RFC3339 date-time and not ISO8601. There are some deviations between both formats, specifically, RFC3339 expects the years to be in the current era.

See https://github.com/stellar/go/issues/1381 for more info.

