### PR TITLE
horizonclient: add support for join param.

### DIFF
--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+- Add support for querying operation endpoint with `join` parameter [#1521](https://github.com/stellar/go/issues/1521).
+
+
 ## [v1.3.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.3.0) - 2019-07-08
 
 - Transaction information returned by methods now contain new fields: `FeeCharged` and `MaxFee`. `FeePaid` is deprecated and will be removed in later versions.

--- a/clients/horizonclient/internal.go
+++ b/clients/horizonclient/internal.go
@@ -95,6 +95,10 @@ func addQueryParams(params ...interface{}) string {
 			if param {
 				query.Add("include_failed", "true")
 			}
+		case join:
+			if param != "" {
+				query.Add("join", string(param))
+			}
 		case map[string]string:
 			for key, value := range param {
 				if value != "" {

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -46,6 +46,9 @@ type includeFailed bool
 // AssetType represents `asset_type` param in queries
 type AssetType string
 
+// join represents `join` param in queries
+type join string
+
 const (
 	// OrderAsc represents an ascending order parameter
 	OrderAsc Order = "asc"
@@ -271,6 +274,7 @@ type OperationRequest struct {
 	Cursor         string
 	Limit          uint
 	IncludeFailed  bool
+	Join           string
 	endpoint       string
 }
 

--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -733,12 +733,12 @@ func TestOperationsRequest(t *testing.T) {
 		HTTP:       hmock,
 	}
 
-	operationRequest := OperationRequest{}
+	operationRequest := OperationRequest{Join: "transactions"}
 
 	// all operations
 	hmock.On(
 		"GET",
-		"https://localhost/operations",
+		"https://localhost/operations?join=transactions",
 	).ReturnString(200, multipleOpsResponse)
 
 	ops, err := client.Operations(operationRequest)
@@ -768,7 +768,7 @@ func TestOperationsRequest(t *testing.T) {
 	// all payments
 	hmock.On(
 		"GET",
-		"https://localhost/payments",
+		"https://localhost/payments?join=transactions",
 	).ReturnString(200, paymentsResponse)
 
 	ops, err = client.Payments(operationRequest)

--- a/clients/horizonclient/operation_request.go
+++ b/clients/horizonclient/operation_request.go
@@ -38,7 +38,7 @@ func (op OperationRequest) BuildURL() (endpoint string, err error) {
 	}
 
 	queryParams := addQueryParams(cursor(op.Cursor), limit(op.Limit), op.Order,
-		includeFailed(op.IncludeFailed))
+		includeFailed(op.IncludeFailed), join(op.Join))
 	if queryParams != "" {
 		endpoint = fmt.Sprintf("%s?%s", endpoint, queryParams)
 	}

--- a/clients/horizonclient/operation_request_test.go
+++ b/clients/horizonclient/operation_request_test.go
@@ -56,17 +56,29 @@ func TestOperationRequestBuildUrl(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid request: too many parameters")
 	}
 
-	op = OperationRequest{Cursor: "123456", Limit: 30, Order: OrderAsc, endpoint: "operations"}
+	op = OperationRequest{Cursor: "123456", Limit: 30, Order: OrderAsc, endpoint: "operations", Join: "transactions"}
 	endpoint, err = op.BuildURL()
 	// It should return valid all operations endpoint with query params and no errors
 	require.NoError(t, err)
-	assert.Equal(t, "operations?cursor=123456&limit=30&order=asc", endpoint)
+	assert.Equal(t, "operations?cursor=123456&join=transactions&limit=30&order=asc", endpoint)
 
-	op = OperationRequest{Cursor: "123456", Limit: 30, Order: OrderAsc, endpoint: "payments"}
+	op = OperationRequest{Cursor: "123456", Limit: 30, Order: OrderAsc, endpoint: "payments", Join: "transactions"}
 	endpoint, err = op.BuildURL()
 	// It should return valid all operations endpoint with query params and no errors
 	require.NoError(t, err)
-	assert.Equal(t, "payments?cursor=123456&limit=30&order=asc", endpoint)
+	assert.Equal(t, "payments?cursor=123456&join=transactions&limit=30&order=asc", endpoint)
+
+	op = OperationRequest{ForAccount: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU", endpoint: "payments", Join: "transactions"}
+	endpoint, err = op.BuildURL()
+	// It should return valid all operations endpoint with query params and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "accounts/GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU/payments?join=transactions", endpoint)
+
+	op = OperationRequest{forOperationID: "1234", endpoint: "payments", Join: "transactions"}
+	endpoint, err = op.BuildURL()
+	// It should return valid all operations endpoint with query params and no errors
+	require.NoError(t, err)
+	assert.Equal(t, "operations/1234?join=transactions", endpoint)
 }
 
 func ExampleClient_StreamOperations() {


### PR DESCRIPTION

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Allow users to get transaction information when querying an operation endpoint.
Closes #1521 

### Goal and scope

Add the `join` parameter to operations and payments request. This allows horizon server to return transaction information along with an operation response

### Summary of changes
- Added `join` param type
- Updated OperationRequest struct
- Added tests to check that the URL is built correctly.

### Known limitations & issues


### What shouldn't be reviewed

