### PR TITLE
txnbuild: prevent multiple build calls from incrementing operations

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -6,6 +6,8 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * Add `Transaction.BuildChallengeTx` method for building [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md) challenge transaction.
+* Add `TransactionFromXDR` function for building `txnbuild.Transaction` struct from a  base64 XDR transaction envelope[#1329](https://github.com/stellar/go/issues/1329).
+* Fix bug that allowed multiple calls to `Transaction.Build` increment the number of operations in a transaction [#1448](https://github.com/stellar/go/issues/1448).
 
 
 ## [v1.3.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.3.0) - 2019-07-08

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -93,7 +93,17 @@ func (tx *Transaction) SetDefaultFee() {
 // Build for Transaction completely configures the Transaction. After calling Build,
 // the Transaction is ready to be serialised or signed.
 func (tx *Transaction) Build() error {
-	// to do: check if tx is already signed
+	// If transaction envelope has been signed, don't build transaction
+	if tx.xdrEnvelope != nil {
+		if tx.xdrEnvelope.Signatures != nil {
+			return errors.New("transaction has been signed. can not be modified.")
+		}
+		tx.xdrEnvelope = &xdr.TransactionEnvelope{}
+		tx.xdrEnvelope.Tx = xdr.Transaction{}
+	}
+
+	// reset tx.xdrTransaction
+	tx.xdrTransaction = xdr.Transaction{}
 
 	accountID := tx.SourceAccount.GetAccountID()
 	// Public keys start with 'G'
@@ -147,10 +157,8 @@ func (tx *Transaction) Build() error {
 	tx.SetDefaultFee()
 
 	// Initialise transaction envelope
-	if tx.xdrEnvelope == nil {
-		tx.xdrEnvelope = &xdr.TransactionEnvelope{}
-		tx.xdrEnvelope.Tx = tx.xdrTransaction
-	}
+	tx.xdrEnvelope = &xdr.TransactionEnvelope{}
+	tx.xdrEnvelope.Tx = tx.xdrTransaction
 
 	return nil
 }

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -96,8 +96,9 @@ func (tx *Transaction) Build() error {
 	// If transaction envelope has been signed, don't build transaction
 	if tx.xdrEnvelope != nil {
 		if tx.xdrEnvelope.Signatures != nil {
-			return errors.New("transaction has been signed. can not be modified.")
+			return errors.New("transaction has already been signed, so cannot be rebuilt.")
 		}
+		// clear the existing XDR so we don't append to any existing fields
 		tx.xdrEnvelope = &xdr.TransactionEnvelope{}
 		tx.xdrEnvelope.Tx = xdr.Transaction{}
 	}

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1081,7 +1081,7 @@ func TestBuild(t *testing.T) {
 	// build again
 	err = tx.Build()
 	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "transaction has been signed. can not be modified.")
+		assert.Contains(t, err.Error(), "transaction has already been signed, so cannot be rebuilt.")
 	}
 	txeB64, err = tx.Base64()
 	assert.NoError(t, err)

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -759,7 +759,6 @@ func TestBuildChallengeTx(t *testing.T) {
 	// 5 minutes timebound
 	txeBase64, err = BuildChallengeTx(kp0.Seed(), kp0.Address(), "SDF1", network.TestNetworkPassphrase, time.Duration(5*time.Minute))
 	assert.NoError(t, err)
-
 	var txXDR1 xdr.TransactionEnvelope
 	err = xdr.SafeUnmarshalBase64(txeBase64, &txXDR1)
 	assert.NoError(t, err)
@@ -1000,7 +999,6 @@ func TestHashXTransaction(t *testing.T) {
 }
 
 func TestFromXDR(t *testing.T) {
-
 	txeB64 := "AAAAACYWIvM98KlTMs0IlQBZ06WkYpZ+gILsQN6ega0++I/sAAAAZAAXeEkAAAABAAAAAAAAAAEAAAAQMkExVjZKNTcwM0c0N1hIWQAAAAEAAAABAAAAACYWIvM98KlTMs0IlQBZ06WkYpZ+gILsQN6ega0++I/sAAAAAQAAAADMSEvcRKXsaUNna++Hy7gWm/CfqTjEA7xoGypfrFGUHAAAAAAAAAACCPHRAAAAAAAAAAABPviP7AAAAEBu6BCKf4WZHPum5+29Nxf6SsJNN8bgjp1+e1uNBaHjRg3rdFZYgUqEqbHxVEs7eze3IeRbjMZxS3zPf/xwJCEI"
 
 	newTx, err := TransactionFromXDR(txeB64)
@@ -1050,4 +1048,74 @@ func TestFromXDR(t *testing.T) {
 	assert.Equal(t, nil, op2.SourceAccount, "Operation source should match")
 	assert.Equal(t, "test", op2.Name, "Name should match")
 	assert.Equal(t, "value", string(op2.Value), "Value should match")
+}
+
+func TestBuild(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
+	createAccount := CreateAccount{
+		Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
+		Amount:      "10",
+	}
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&createAccount},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+	expectedUnsigned := "AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAiII0AAAAaAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAITg3tq8G0kvnvoIhZPMYJsY+9KVV8xAA6NxhtKxIXZUAAAAAAX14QAAAAAAAAAAAA=="
+
+	expectedSigned := "AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAiII0AAAAaAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAITg3tq8G0kvnvoIhZPMYJsY+9KVV8xAA6NxhtKxIXZUAAAAAAX14QAAAAAAAAAAAeoucsUAAABAHsyMojA0Q5MiNsR5X5AiNpCn9mlXmqluRsNpTniCR91M4U5TFmrrqVNLkU58/l+Y8hUPwidDTRSzLZKbMUL/Bw=="
+
+	err := tx.Build()
+	assert.NoError(t, err)
+	txeB64, err := tx.Base64()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedUnsigned, txeB64, "tx envelope should match")
+	err = tx.Sign(kp0)
+	assert.NoError(t, err)
+	txeB64, err = tx.Base64()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedSigned, txeB64, "tx envelope should match")
+
+	// build again
+	err = tx.Build()
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "transaction has been signed. can not be modified.")
+	}
+	txeB64, err = tx.Base64()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedSigned, txeB64, "tx envelope should match")
+}
+
+func TestFromXDRBuildSignEncode(t *testing.T) {
+	expectedUnsigned := "AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAiII0AAAAaAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAITg3tq8G0kvnvoIhZPMYJsY+9KVV8xAA6NxhtKxIXZUAAAAAAX14QAAAAAAAAAAAA=="
+
+	expectedSigned := "AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAiII0AAAAaAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAITg3tq8G0kvnvoIhZPMYJsY+9KVV8xAA6NxhtKxIXZUAAAAAAX14QAAAAAAAAAAAeoucsUAAABAHsyMojA0Q5MiNsR5X5AiNpCn9mlXmqluRsNpTniCR91M4U5TFmrrqVNLkU58/l+Y8hUPwidDTRSzLZKbMUL/Bw=="
+
+	kp0 := newKeypair0()
+
+	// test signing transaction  without modification
+	newTx, err := TransactionFromXDR(expectedUnsigned)
+	assert.NoError(t, err)
+	//passphrase is needed for signing
+	newTx.Network = network.TestNetworkPassphrase
+	err = newTx.Sign(kp0)
+	assert.NoError(t, err)
+	txeB64, err := newTx.Base64()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedSigned, txeB64, "tx envelope should match")
+
+	// test signing transaction  with modification
+	expectedSigned2 := "AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAiII0AAAAbAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAABW5ld3R4AAAAAAAAAQAAAAAAAAAAAAAAAITg3tq8G0kvnvoIhZPMYJsY+9KVV8xAA6NxhtKxIXZUAAAAAAX14QAAAAAAAAAAAeoucsUAAABADPbbXNzpC408WyYGQszN3VA9e41sNpsyZ2HcS62RXvUDsN0A+IXMPRMaCb+Wgn1OM6Ikam9ol0MJYNeK0BPxCg=="
+	newTx, err = TransactionFromXDR(expectedUnsigned)
+	assert.NoError(t, err)
+	//passphrase is needed for signing
+	newTx.Network = network.TestNetworkPassphrase
+	newTx.Memo = MemoText("newtx")
+
+	//Note: calling build will increment the sequence number
+	txeB64, err = newTx.BuildSignEncode(kp0)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedSigned2, txeB64, "tx envelope should match")
 }


### PR DESCRIPTION
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

This PR prevents multiple calls to `Transaction.Build` from modifying the number of operations

### Goal and scope

Fix #1448 

### Summary of changes

- Prevent signed transactions from being rebuilt
- `Transaction.xdrTransaction` is reset at the start of a build process
- Tests were added for Build and FromXDR
- Changelog has been updated

### Known limitations & issues

- When the `Build`  method is called multiple times, it also increments the sequence number. This is a known issue and suggestions on how to resolve this is discussed in #1259 

### What shouldn't be reviewed

