### PR TITLE
services/horizon: Distributed ingestion

### DIFF
--- a/exp/ingest/main.go
+++ b/exp/ingest/main.go
@@ -13,9 +13,9 @@ import (
 
 // standardSession contains common methods used by all sessions.
 type standardSession struct {
-	shutdown              chan bool
-	rwLock                sync.RWMutex
-	latestProcessedLedger uint32
+	shutdown                          chan bool
+	rwLock                            sync.RWMutex
+	latestSuccessfullyProcessedLedger uint32
 
 	runningMutex sync.Mutex
 	running      bool
@@ -67,10 +67,11 @@ type Session interface {
 	// Session user to determine what was the last ledger processed by a
 	// Session as it's stateless (or if Run() should be called first).
 	Resume(ledgerSequence uint32) error
-	// GetLatestProcessedLedger returns the latest ledger sequence processed in
-	// the session. Return 0 if no ledgers were processed yet.
+	// GetLatestSuccessfullyProcessedLedger returns the ledger sequence of the
+	// latest successfully processed ledger in the session. Return 0 if no
+	// ledgers were processed yet.
 	// Please note that this value is not synchronized with pipeline hooks.
-	GetLatestProcessedLedger() uint32
+	GetLatestSuccessfullyProcessedLedger() uint32
 	// Shutdown gracefully stops running session and stops all internal
 	// objects.
 	// Calling Shutdown() does not trigger post processing hooks.

--- a/exp/ingest/single_ledger_session.go
+++ b/exp/ingest/single_ledger_session.go
@@ -29,7 +29,7 @@ func (s *SingleLedgerSession) Run() error {
 		return errors.Wrap(err, "processState errored")
 	}
 
-	s.standardSession.latestProcessedLedger = sequence
+	s.standardSession.latestSuccessfullyProcessedLedger = sequence
 	return nil
 }
 

--- a/exp/ingest/standard_session.go
+++ b/exp/ingest/standard_session.go
@@ -30,6 +30,6 @@ func (s *standardSession) UpdateUnlock() {
 	s.rwLock.Unlock()
 }
 
-func (s *standardSession) GetLatestProcessedLedger() uint32 {
-	return s.latestProcessedLedger
+func (s *standardSession) GetLatestSuccessfullyProcessedLedger() uint32 {
+	return s.latestSuccessfullyProcessedLedger
 }

--- a/exp/support/pipeline/main.go
+++ b/exp/support/pipeline/main.go
@@ -41,7 +41,7 @@ type multiWriter struct {
 type Pipeline struct {
 	root *PipelineNode
 
-	preProcessingHooks  []func(context.Context) error
+	preProcessingHooks  []func(context.Context) (context.Context, error)
 	postProcessingHooks []func(context.Context, error) error
 
 	// mutex protects internal fields that may be modified from
@@ -57,7 +57,10 @@ type Pipeline struct {
 // in structs that embed Pipeline.
 type PipelineInterface interface {
 	SetRoot(rootProcessor *PipelineNode)
-	AddPreProcessingHook(hook func(context.Context) error)
+	// AddPreProcessingHook adds a pre-processing hook function. Returned
+	// context.Context will be passed to the processors. If error is returned
+	// pipeline will not start processing data.
+	AddPreProcessingHook(hook func(context.Context) (context.Context, error))
 	AddPostProcessingHook(hook func(context.Context, error) error)
 	Shutdown()
 	PrintStatus()

--- a/exp/support/pipeline/pipeline_test.go
+++ b/exp/support/pipeline/pipeline_test.go
@@ -58,9 +58,9 @@ func TestHooksCalled(t *testing.T) {
 	)
 
 	preHookCalled := false
-	p.AddPreProcessingHook(func(ctx context.Context) error {
+	p.AddPreProcessingHook(func(ctx context.Context) (context.Context, error) {
 		preHookCalled = true
-		return nil
+		return ctx, nil
 	})
 
 	postHookCalled := false

--- a/exp/tools/horizon-demo/pipelines.go
+++ b/exp/tools/horizon-demo/pipelines.go
@@ -68,10 +68,10 @@ func addPipelineHooks(
 	session ingest.Session,
 	orderBookGraph *orderbook.OrderBookGraph,
 ) {
-	p.AddPreProcessingHook(func(ctx context.Context) error {
+	p.AddPreProcessingHook(func(ctx context.Context) (context.Context, error) {
 		ledgerSeq := pipeline.GetLedgerSequenceFromContext(ctx)
 		fmt.Printf("%T Processing ledger: %d\n", p, ledgerSeq)
-		return db.Begin()
+		return ctx, db.Begin()
 	})
 
 	p.AddPostProcessingHook(func(ctx context.Context, err error) error {

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -8,8 +8,9 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ## v0.20.0
 
+* Experimental ingestion system is now run concurrently on all Horizon servers (with feature flag set - see below). This improves ingestion availability.
 * Add experimental path finding endpoint which uses an in memory order book for improved performance. To enable it set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable. Note that the `enable-experimental-ingestion` flag enables both the new path finding endpoint and the accounts for signer endpoint.
-
+* `--enable-accounts-for-signer` CLI param or `ENABLE_ACCOUNTS_FOR_SIGNER=true` env variable are merged with `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
 
 ## v0.19.0
 

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -63,7 +63,7 @@ func AccountInfo(ctx context.Context, cq *core.Q, addr string) (*protocol.Accoun
 // used to find accounts for signer but also accounts for assets,
 // home domain, inflation_dest etc.
 func AccountPage(ctx context.Context, hq history.QSigners, signer string, pq db2.PageQuery) (hal.Page, error) {
-	lastIngestedLedger, err := hq.GetLastLedgerExpIngest(false)
+	lastIngestedLedger, err := hq.GetLastLedgerExpIngestNonBlocking()
 	if err != nil {
 		return hal.Page{}, errors.Wrap(err, "error loading last ledger ingested by expingest")
 	}

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -63,7 +63,7 @@ func AccountInfo(ctx context.Context, cq *core.Q, addr string) (*protocol.Accoun
 // used to find accounts for signer but also accounts for assets,
 // home domain, inflation_dest etc.
 func AccountPage(ctx context.Context, hq history.QSigners, signer string, pq db2.PageQuery) (hal.Page, error) {
-	lastIngestedLedger, err := hq.GetLastLedgerExpIngest()
+	lastIngestedLedger, err := hq.GetLastLedgerExpIngest(false)
 	if err != nil {
 		return hal.Page{}, errors.Wrap(err, "error loading last ledger ingested by expingest")
 	}

--- a/services/horizon/internal/actions/account_test.go
+++ b/services/horizon/internal/actions/account_test.go
@@ -35,7 +35,7 @@ func TestAccountInfo(t *testing.T) {
 func TestAccountPageStillIngesting(t *testing.T) {
 	mockQ := &history.MockQSigners{}
 
-	mockQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	mockQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
 
 	_, err := AccountPage(context.Background(), mockQ, "", db2.PageQuery{})
 	assert.Error(t, err)
@@ -45,7 +45,7 @@ func TestAccountPageStillIngesting(t *testing.T) {
 func TestAccountPageNoResults(t *testing.T) {
 	mockQ := &history.MockQSigners{}
 
-	mockQ.On("GetLastLedgerExpIngest").Return(uint32(10), nil).Once()
+	mockQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(10), nil).Once()
 
 	mockQ.
 		On(
@@ -68,7 +68,7 @@ func TestAccountPageNoResults(t *testing.T) {
 func TestAccountPageResults(t *testing.T) {
 	mockQ := &history.MockQSigners{}
 
-	mockQ.On("GetLastLedgerExpIngest").Return(uint32(10), nil).Once()
+	mockQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(10), nil).Once()
 
 	pq := db2.PageQuery{
 		Order: "asc",

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -210,7 +210,7 @@ func (a *App) UpdateLedgerState() {
 		return
 	}
 
-	next.ExpHistoryLatest, err = a.HistoryQ().GetLastLedgerExpIngest(false)
+	next.ExpHistoryLatest, err = a.HistoryQ().GetLastLedgerExpIngestUnsafe()
 	if err != nil {
 		logErr(err, "failed to load the oldest known exp ledger state from history DB")
 		return

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -210,7 +210,7 @@ func (a *App) UpdateLedgerState() {
 		return
 	}
 
-	next.ExpHistoryLatest, err = a.HistoryQ().GetLastLedgerExpIngestUnsafe()
+	next.ExpHistoryLatest, err = a.HistoryQ().GetLastLedgerExpIngestNonBlocking()
 	if err != nil {
 		logErr(err, "failed to load the oldest known exp ledger state from history DB")
 		return

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -105,7 +105,14 @@ func (a *App) Serve() {
 	go a.run()
 
 	if a.expingester != nil {
-		go a.expingester.Run()
+		go func() {
+			// Run will return errors only for initial state building.
+			// For ledger updates it will try again in case of errors.
+			err := a.expingester.Run()
+			if err != nil {
+				log.Panic(err)
+			}
+		}()
 	}
 
 	var err error
@@ -203,7 +210,7 @@ func (a *App) UpdateLedgerState() {
 		return
 	}
 
-	next.ExpHistoryLatest, err = a.HistoryQ().GetLastLedgerExpIngest()
+	next.ExpHistoryLatest, err = a.HistoryQ().GetLastLedgerExpIngest(false)
 	if err != nil {
 		logErr(err, "failed to load the oldest known exp ledger state from history DB")
 		return

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -105,14 +105,7 @@ func (a *App) Serve() {
 	go a.run()
 
 	if a.expingester != nil {
-		go func() {
-			// Run will return errors only for initial state building.
-			// For ledger updates it will try again in case of errors.
-			err := a.expingester.Run()
-			if err != nil {
-				log.Panic(err)
-			}
-		}()
+		go a.expingester.Run()
 	}
 
 	var err error

--- a/services/horizon/internal/db2/history/key_value.go
+++ b/services/horizon/internal/db2/history/key_value.go
@@ -16,9 +16,33 @@ const (
 	lastLedgerKey = "exp_ingest_last_ledger"
 )
 
+// GetLastLedgerExpIngestUnsafe works like GetLastLedgerExpIngest but
+// it does not block the value and does not return error if the value
+// has not been previously set.
+// This is used in status reporting (ex. in root resource of Horizon).
+func (q *Q) GetLastLedgerExpIngestUnsafe() (uint32, error) {
+	lastIngestedLedger, err := q.getValueFromStore(lastLedgerKey, false)
+	if err != nil {
+		return 0, err
+	}
+
+	if lastIngestedLedger == "" {
+		return 0, nil
+	} else {
+		ledgerSequence, err := strconv.ParseUint(lastIngestedLedger, 10, 32)
+		if err != nil {
+			return 0, errors.Wrap(err, "Error converting lastIngestedLedger value")
+		}
+
+		return uint32(ledgerSequence), nil
+	}
+}
+
 // GetLastLedgerExpIngest returns the last ledger ingested by expingest system
-// in Horizon. Returns 0 if no value has been previously set. This can be set
-// using UpdateLastLedgerExpIngest.
+// in Horizon. Returns error if no value has been previously set. This behaviour
+// is critical in distributed ingestion so do not change it unless you know
+// what you are doing.
+// The value can be set using UpdateLastLedgerExpIngest.
 // `forUpdate` parameter determines whether the value should be locked `FOR UPDATE`.
 func (q *Q) GetLastLedgerExpIngest(forUpdate bool) (uint32, error) {
 	lastIngestedLedger, err := q.getValueFromStore(lastLedgerKey, forUpdate)

--- a/services/horizon/internal/db2/history/key_value.go
+++ b/services/horizon/internal/db2/history/key_value.go
@@ -39,13 +39,13 @@ func (q *Q) GetLastLedgerExpIngestNonBlocking() (uint32, error) {
 }
 
 // GetLastLedgerExpIngest returns the last ledger ingested by expingest system
-// in Horizon. Returns error if no value has been previously set. This behaviour
-// is critical in distributed ingestion so do not change it unless you know
-// what you are doing.
+// in Horizon. Returns ErrKeyNotFound error if no value has been previously set.
+// This is using `SELECT ... FOR UPDATE` what means it's blocking the row for all other
+// transactions.This behaviour is critical in distributed ingestion so do not change
+// it unless you know what you are doing.
 // The value can be set using UpdateLastLedgerExpIngest.
-// `forUpdate` parameter determines whether the value should be locked `FOR UPDATE`.
-func (q *Q) GetLastLedgerExpIngest(forUpdate bool) (uint32, error) {
-	lastIngestedLedger, err := q.getValueFromStore(lastLedgerKey, forUpdate)
+func (q *Q) GetLastLedgerExpIngest() (uint32, error) {
+	lastIngestedLedger, err := q.getValueFromStore(lastLedgerKey, true)
 	if err != nil {
 		return 0, err
 	}
@@ -101,7 +101,8 @@ func (q *Q) UpdateExpIngestVersion(ledgerSequence int) error {
 	)
 }
 
-// getValueFromStore returns a value for a given key from KV store
+// getValueFromStore returns a value for a given key from KV store. If value
+// is not present in the key value store "" will be returned.
 func (q *Q) getValueFromStore(key string, forUpdate bool) (string, error) {
 	query := sq.Select("key_value_store.value").
 		From("key_value_store").

--- a/services/horizon/internal/db2/history/key_value.go
+++ b/services/horizon/internal/db2/history/key_value.go
@@ -16,11 +16,11 @@ const (
 	lastLedgerKey = "exp_ingest_last_ledger"
 )
 
-// GetLastLedgerExpIngestUnsafe works like GetLastLedgerExpIngest but
+// GetLastLedgerExpIngestNonBlocking works like GetLastLedgerExpIngest but
 // it does not block the value and does not return error if the value
 // has not been previously set.
 // This is used in status reporting (ex. in root resource of Horizon).
-func (q *Q) GetLastLedgerExpIngestUnsafe() (uint32, error) {
+func (q *Q) GetLastLedgerExpIngestNonBlocking() (uint32, error) {
 	lastIngestedLedger, err := q.getValueFromStore(lastLedgerKey, false)
 	if err != nil {
 		return 0, err

--- a/services/horizon/internal/db2/history/key_value.go
+++ b/services/horizon/internal/db2/history/key_value.go
@@ -10,20 +10,26 @@ import (
 
 const (
 	ingestVersion = "exp_ingest_version"
+	// Distributed ingestion in Horizon relies on this key and it is part
+	// of migration files. If you need to update the key name remember
+	// to upgrade it in migration files too!
 	lastLedgerKey = "exp_ingest_last_ledger"
 )
 
 // GetLastLedgerExpIngest returns the last ledger ingested by expingest system
 // in Horizon. Returns 0 if no value has been previously set. This can be set
 // using UpdateLastLedgerExpIngest.
-func (q *Q) GetLastLedgerExpIngest() (uint32, error) {
-	lastIngestedLedger, err := q.getValueFromStore(lastLedgerKey)
+// `forUpdate` parameter determines whether the value should be locked `FOR UPDATE`.
+func (q *Q) GetLastLedgerExpIngest(forUpdate bool) (uint32, error) {
+	lastIngestedLedger, err := q.getValueFromStore(lastLedgerKey, forUpdate)
 	if err != nil {
 		return 0, err
 	}
 
 	if lastIngestedLedger == "" {
-		return 0, nil
+		// This key should always be in a DB (is added in migrations). Otherwise
+		// locking won't work.
+		return 0, errors.Errorf("`%s` key cannot be found in the key value store", ingestVersion)
 	} else {
 		ledgerSequence, err := strconv.ParseUint(lastIngestedLedger, 10, 32)
 		if err != nil {
@@ -46,7 +52,7 @@ func (q *Q) UpdateLastLedgerExpIngest(ledgerSequence uint32) error {
 // GetExpIngestVersion returns the exp ingest version. Returns zero
 // if there is no value.
 func (q *Q) GetExpIngestVersion() (int, error) {
-	expVersion, err := q.getValueFromStore(ingestVersion)
+	expVersion, err := q.getValueFromStore(ingestVersion, false)
 	if err != nil {
 		return 0, err
 	}
@@ -72,10 +78,14 @@ func (q *Q) UpdateExpIngestVersion(ledgerSequence int) error {
 }
 
 // getValueFromStore returns a value for a given key from KV store
-func (q *Q) getValueFromStore(key string) (string, error) {
+func (q *Q) getValueFromStore(key string, forUpdate bool) (string, error) {
 	query := sq.Select("key_value_store.value").
 		From("key_value_store").
 		Where("key_value_store.key = ?", key)
+
+	if forUpdate {
+		query = query.Suffix("FOR UPDATE")
+	}
 
 	var value string
 	if err := q.Get(&value, query); err != nil {

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -298,7 +298,7 @@ type Q struct {
 
 // QSigners defines signer related queries.
 type QSigners interface {
-	GetLastLedgerExpIngest() (uint32, error)
+	GetLastLedgerExpIngest(forUpdate bool) (uint32, error)
 	UpdateLastLedgerExpIngest(ledgerSequence uint32) error
 	AccountsForSigner(signer string, page db2.PageQuery) ([]AccountSigner, error)
 	CreateAccountSigner(account, signer string, weight int32) error

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -298,6 +298,7 @@ type Q struct {
 
 // QSigners defines signer related queries.
 type QSigners interface {
+	GetLastLedgerExpIngestNonBlocking() (uint32, error)
 	GetLastLedgerExpIngest(forUpdate bool) (uint32, error)
 	UpdateLastLedgerExpIngest(ledgerSequence uint32) error
 	AccountsForSigner(signer string, page db2.PageQuery) ([]AccountSigner, error)

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -299,7 +299,7 @@ type Q struct {
 // QSigners defines signer related queries.
 type QSigners interface {
 	GetLastLedgerExpIngestNonBlocking() (uint32, error)
-	GetLastLedgerExpIngest(forUpdate bool) (uint32, error)
+	GetLastLedgerExpIngest() (uint32, error)
 	UpdateLastLedgerExpIngest(ledgerSequence uint32) error
 	AccountsForSigner(signer string, page db2.PageQuery) ([]AccountSigner, error)
 	CreateAccountSigner(account, signer string, weight int32) error

--- a/services/horizon/internal/db2/history/q_signers_mock.go
+++ b/services/horizon/internal/db2/history/q_signers_mock.go
@@ -14,8 +14,8 @@ func (m *MockQSigners) GetLastLedgerExpIngestNonBlocking() (uint32, error) {
 	return a.Get(0).(uint32), a.Error(1)
 }
 
-func (m *MockQSigners) GetLastLedgerExpIngest(forUpdate bool) (uint32, error) {
-	a := m.Called(forUpdate)
+func (m *MockQSigners) GetLastLedgerExpIngest() (uint32, error) {
+	a := m.Called()
 	return a.Get(0).(uint32), a.Error(1)
 }
 

--- a/services/horizon/internal/db2/history/q_signers_mock.go
+++ b/services/horizon/internal/db2/history/q_signers_mock.go
@@ -9,6 +9,11 @@ type MockQSigners struct {
 	mock.Mock
 }
 
+func (m *MockQSigners) GetLastLedgerExpIngestNonBlocking() (uint32, error) {
+	a := m.Called()
+	return a.Get(0).(uint32), a.Error(1)
+}
+
 func (m *MockQSigners) GetLastLedgerExpIngest(forUpdate bool) (uint32, error) {
 	a := m.Called(forUpdate)
 	return a.Get(0).(uint32), a.Error(1)

--- a/services/horizon/internal/db2/history/q_signers_mock.go
+++ b/services/horizon/internal/db2/history/q_signers_mock.go
@@ -9,8 +9,8 @@ type MockQSigners struct {
 	mock.Mock
 }
 
-func (m *MockQSigners) GetLastLedgerExpIngest() (uint32, error) {
-	a := m.Called()
+func (m *MockQSigners) GetLastLedgerExpIngest(forUpdate bool) (uint32, error) {
+	a := m.Called(forUpdate)
 	return a.Get(0).(uint32), a.Error(1)
 }
 

--- a/services/horizon/internal/db2/schema/bindata.go
+++ b/services/horizon/internal/db2/schema/bindata.go
@@ -560,27 +560,27 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"latest.sql": latestSql,
-	"migrations/10_add_trades_price.sql": migrations10_add_trades_priceSql,
-	"migrations/11_add_trades_account_index.sql": migrations11_add_trades_account_indexSql,
-	"migrations/12_asset_stats_amount_string.sql": migrations12_asset_stats_amount_stringSql,
-	"migrations/13_trade_offer_ids.sql": migrations13_trade_offer_idsSql,
-	"migrations/14_fix_asset_toml_field.sql": migrations14_fix_asset_toml_fieldSql,
-	"migrations/15_ledger_failed_txs.sql": migrations15_ledger_failed_txsSql,
-	"migrations/16_ingest_failed_transactions.sql": migrations16_ingest_failed_transactionsSql,
-	"migrations/17_transaction_fee_paid.sql": migrations17_transaction_fee_paidSql,
-	"migrations/18_account_for_signers.sql": migrations18_account_for_signersSql,
-	"migrations/19_offers.sql": migrations19_offersSql,
-	"migrations/1_initial_schema.sql": migrations1_initial_schemaSql,
-	"migrations/2_index_participants_by_toid.sql": migrations2_index_participants_by_toidSql,
+	"latest.sql":                                        latestSql,
+	"migrations/10_add_trades_price.sql":                migrations10_add_trades_priceSql,
+	"migrations/11_add_trades_account_index.sql":        migrations11_add_trades_account_indexSql,
+	"migrations/12_asset_stats_amount_string.sql":       migrations12_asset_stats_amount_stringSql,
+	"migrations/13_trade_offer_ids.sql":                 migrations13_trade_offer_idsSql,
+	"migrations/14_fix_asset_toml_field.sql":            migrations14_fix_asset_toml_fieldSql,
+	"migrations/15_ledger_failed_txs.sql":               migrations15_ledger_failed_txsSql,
+	"migrations/16_ingest_failed_transactions.sql":      migrations16_ingest_failed_transactionsSql,
+	"migrations/17_transaction_fee_paid.sql":            migrations17_transaction_fee_paidSql,
+	"migrations/18_account_for_signers.sql":             migrations18_account_for_signersSql,
+	"migrations/19_offers.sql":                          migrations19_offersSql,
+	"migrations/1_initial_schema.sql":                   migrations1_initial_schemaSql,
+	"migrations/2_index_participants_by_toid.sql":       migrations2_index_participants_by_toidSql,
 	"migrations/3_use_sequence_in_history_accounts.sql": migrations3_use_sequence_in_history_accountsSql,
-	"migrations/4_add_protocol_version.sql": migrations4_add_protocol_versionSql,
-	"migrations/5_create_trades_table.sql": migrations5_create_trades_tableSql,
-	"migrations/6_create_assets_table.sql": migrations6_create_assets_tableSql,
-	"migrations/7_modify_trades_table.sql": migrations7_modify_trades_tableSql,
-	"migrations/8_add_aggregators.sql": migrations8_add_aggregatorsSql,
-	"migrations/8_create_asset_stats_table.sql": migrations8_create_asset_stats_tableSql,
-	"migrations/9_add_header_xdr.sql": migrations9_add_header_xdrSql,
+	"migrations/4_add_protocol_version.sql":             migrations4_add_protocol_versionSql,
+	"migrations/5_create_trades_table.sql":              migrations5_create_trades_tableSql,
+	"migrations/6_create_assets_table.sql":              migrations6_create_assets_tableSql,
+	"migrations/7_modify_trades_table.sql":              migrations7_modify_trades_tableSql,
+	"migrations/8_add_aggregators.sql":                  migrations8_add_aggregatorsSql,
+	"migrations/8_create_asset_stats_table.sql":         migrations8_create_asset_stats_tableSql,
+	"migrations/9_add_header_xdr.sql":                   migrations9_add_header_xdrSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -622,29 +622,30 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"latest.sql": &bintree{latestSql, map[string]*bintree{}},
 	"migrations": &bintree{nil, map[string]*bintree{
-		"10_add_trades_price.sql": &bintree{migrations10_add_trades_priceSql, map[string]*bintree{}},
-		"11_add_trades_account_index.sql": &bintree{migrations11_add_trades_account_indexSql, map[string]*bintree{}},
-		"12_asset_stats_amount_string.sql": &bintree{migrations12_asset_stats_amount_stringSql, map[string]*bintree{}},
-		"13_trade_offer_ids.sql": &bintree{migrations13_trade_offer_idsSql, map[string]*bintree{}},
-		"14_fix_asset_toml_field.sql": &bintree{migrations14_fix_asset_toml_fieldSql, map[string]*bintree{}},
-		"15_ledger_failed_txs.sql": &bintree{migrations15_ledger_failed_txsSql, map[string]*bintree{}},
-		"16_ingest_failed_transactions.sql": &bintree{migrations16_ingest_failed_transactionsSql, map[string]*bintree{}},
-		"17_transaction_fee_paid.sql": &bintree{migrations17_transaction_fee_paidSql, map[string]*bintree{}},
-		"18_account_for_signers.sql": &bintree{migrations18_account_for_signersSql, map[string]*bintree{}},
-		"19_offers.sql": &bintree{migrations19_offersSql, map[string]*bintree{}},
-		"1_initial_schema.sql": &bintree{migrations1_initial_schemaSql, map[string]*bintree{}},
-		"2_index_participants_by_toid.sql": &bintree{migrations2_index_participants_by_toidSql, map[string]*bintree{}},
+		"10_add_trades_price.sql":                &bintree{migrations10_add_trades_priceSql, map[string]*bintree{}},
+		"11_add_trades_account_index.sql":        &bintree{migrations11_add_trades_account_indexSql, map[string]*bintree{}},
+		"12_asset_stats_amount_string.sql":       &bintree{migrations12_asset_stats_amount_stringSql, map[string]*bintree{}},
+		"13_trade_offer_ids.sql":                 &bintree{migrations13_trade_offer_idsSql, map[string]*bintree{}},
+		"14_fix_asset_toml_field.sql":            &bintree{migrations14_fix_asset_toml_fieldSql, map[string]*bintree{}},
+		"15_ledger_failed_txs.sql":               &bintree{migrations15_ledger_failed_txsSql, map[string]*bintree{}},
+		"16_ingest_failed_transactions.sql":      &bintree{migrations16_ingest_failed_transactionsSql, map[string]*bintree{}},
+		"17_transaction_fee_paid.sql":            &bintree{migrations17_transaction_fee_paidSql, map[string]*bintree{}},
+		"18_account_for_signers.sql":             &bintree{migrations18_account_for_signersSql, map[string]*bintree{}},
+		"19_offers.sql":                          &bintree{migrations19_offersSql, map[string]*bintree{}},
+		"1_initial_schema.sql":                   &bintree{migrations1_initial_schemaSql, map[string]*bintree{}},
+		"2_index_participants_by_toid.sql":       &bintree{migrations2_index_participants_by_toidSql, map[string]*bintree{}},
 		"3_use_sequence_in_history_accounts.sql": &bintree{migrations3_use_sequence_in_history_accountsSql, map[string]*bintree{}},
-		"4_add_protocol_version.sql": &bintree{migrations4_add_protocol_versionSql, map[string]*bintree{}},
-		"5_create_trades_table.sql": &bintree{migrations5_create_trades_tableSql, map[string]*bintree{}},
-		"6_create_assets_table.sql": &bintree{migrations6_create_assets_tableSql, map[string]*bintree{}},
-		"7_modify_trades_table.sql": &bintree{migrations7_modify_trades_tableSql, map[string]*bintree{}},
-		"8_add_aggregators.sql": &bintree{migrations8_add_aggregatorsSql, map[string]*bintree{}},
-		"8_create_asset_stats_table.sql": &bintree{migrations8_create_asset_stats_tableSql, map[string]*bintree{}},
-		"9_add_header_xdr.sql": &bintree{migrations9_add_header_xdrSql, map[string]*bintree{}},
+		"4_add_protocol_version.sql":             &bintree{migrations4_add_protocol_versionSql, map[string]*bintree{}},
+		"5_create_trades_table.sql":              &bintree{migrations5_create_trades_tableSql, map[string]*bintree{}},
+		"6_create_assets_table.sql":              &bintree{migrations6_create_assets_tableSql, map[string]*bintree{}},
+		"7_modify_trades_table.sql":              &bintree{migrations7_modify_trades_tableSql, map[string]*bintree{}},
+		"8_add_aggregators.sql":                  &bintree{migrations8_add_aggregatorsSql, map[string]*bintree{}},
+		"8_create_asset_stats_table.sql":         &bintree{migrations8_create_asset_stats_tableSql, map[string]*bintree{}},
+		"9_add_header_xdr.sql":                   &bintree{migrations9_add_header_xdrSql, map[string]*bintree{}},
 	}},
 }}
 
@@ -694,4 +695,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/services/horizon/internal/db2/schema/bindata.go
+++ b/services/horizon/internal/db2/schema/bindata.go
@@ -103,7 +103,7 @@ func latestSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "latest.sql", size: 24565, mode: os.FileMode(420), modTime: time.Unix(1564657216, 0)}
+	info := bindataFileInfo{name: "latest.sql", size: 24565, mode: os.FileMode(420), modTime: time.Unix(1565092423, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -123,7 +123,7 @@ func migrations10_add_trades_priceSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/10_add_trades_price.sql", size: 1220, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/10_add_trades_price.sql", size: 1220, mode: os.FileMode(420), modTime: time.Unix(1535025415, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -143,7 +143,7 @@ func migrations11_add_trades_account_indexSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/11_add_trades_account_index.sql", size: 273, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/11_add_trades_account_index.sql", size: 273, mode: os.FileMode(420), modTime: time.Unix(1535025415, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -163,7 +163,7 @@ func migrations12_asset_stats_amount_stringSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/12_asset_stats_amount_string.sql", size: 197, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/12_asset_stats_amount_string.sql", size: 197, mode: os.FileMode(420), modTime: time.Unix(1535025415, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -183,7 +183,7 @@ func migrations13_trade_offer_idsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/13_trade_offer_ids.sql", size: 482, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/13_trade_offer_ids.sql", size: 482, mode: os.FileMode(420), modTime: time.Unix(1547162949, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -203,7 +203,7 @@ func migrations14_fix_asset_toml_fieldSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/14_fix_asset_toml_field.sql", size: 156, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/14_fix_asset_toml_field.sql", size: 156, mode: os.FileMode(420), modTime: time.Unix(1547162949, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -223,7 +223,7 @@ func migrations15_ledger_failed_txsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/15_ledger_failed_txs.sql", size: 333, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/15_ledger_failed_txs.sql", size: 333, mode: os.FileMode(420), modTime: time.Unix(1549313787, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -243,7 +243,7 @@ func migrations16_ingest_failed_transactionsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/16_ingest_failed_transactions.sql", size: 509, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/16_ingest_failed_transactions.sql", size: 509, mode: os.FileMode(420), modTime: time.Unix(1552435564, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -263,7 +263,7 @@ func migrations17_transaction_fee_paidSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/17_transaction_fee_paid.sql", size: 287, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/17_transaction_fee_paid.sql", size: 287, mode: os.FileMode(420), modTime: time.Unix(1560443961, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -283,12 +283,12 @@ func migrations18_account_for_signersSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/18_account_for_signers.sql", size: 481, mode: os.FileMode(420), modTime: time.Unix(1564561619, 0)}
+	info := bindataFileInfo{name: "migrations/18_account_for_signers.sql", size: 481, mode: os.FileMode(420), modTime: time.Unix(1565013256, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
-var _migrations19_offersSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x7c\x92\xc1\x6e\xab\x30\x10\x45\xf7\xfe\x8a\x59\x26\x7a\xc9\xf2\x75\xc3\x2a\x69\xac\x0a\x95\x42\x44\x41\x6a\x56\xc8\x98\xc1\x1d\x89\x18\x64\x9b\xb6\xfc\x7d\xd5\x10\x10\x49\x0b\xeb\x3b\xf7\xd8\x73\x34\xdb\x2d\xfc\x3b\x93\x32\xc2\x21\xa4\x0d\x63\x8f\x31\xdf\x25\x1c\x92\xdd\x3e\xe0\x50\x97\x25\x1a\x0b\x2b\x06\x00\x60\xb1\xaa\xd0\x50\x01\xf2\x5d\x18\x21\x1d\x1a\xf8\x10\xa6\x23\xad\x56\xff\x1f\xd6\x10\x46\x09\x84\x69\x10\x6c\x2e\xc3\x97\x26\x15\x90\x93\x22\xed\xe0\x18\xfb\x2f\xbb\xf8\x04\xcf\xfc\xb4\x19\x61\xa4\x95\xb0\x16\x1d\x38\xfc\x72\x77\xfd\xbc\xed\x96\x62\x71\xae\x5b\xed\x06\xfa\x6d\xd6\x18\x92\xa8\x81\xb4\x43\x85\xe6\xaf\xb0\x58\x0a\xa1\xa8\xdb\xbc\x42\x68\x0c\x4a\xb2\x54\xeb\xbb\xa1\xb2\x12\xca\xfe\x02\xb0\xb5\x37\xba\xf3\xc3\x03\x7f\xbb\xba\xcb\xf2\x2e\xeb\xc5\x41\x14\x0e\x3e\xd3\x57\x3f\x7c\x82\x7d\x12\x73\xbe\x1a\xac\xae\xbd\xa5\x3a\x69\x95\xf5\x32\xe6\x29\x83\xaf\x79\x52\x2f\x75\x11\x34\xf1\xfe\xb3\xd1\xf4\x3a\x0e\xf5\xa7\x66\xec\x10\x47\xc7\x99\x0d\xbd\xf9\x70\x7c\x76\x66\x66\xfa\x33\xef\xfa\xc8\xcd\x09\x4a\x61\xa5\x28\xd0\xfb\x0e\x00\x00\xff\xff\x2f\xed\xf5\xe9\xaf\x02\x00\x00")
+var _migrations19_offersSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x7c\x93\x41\x73\xda\x30\x10\x85\xef\xfe\x15\xef\x06\x4c\x21\xd3\x4b\x7b\xe1\x44\x82\x9b\x78\x4a\xed\x8c\x63\xda\xe6\xe4\x11\xf6\x5a\xec\x44\x91\x18\x49\x0e\x71\x7f\x7d\x47\x36\x30\x49\x5a\xb8\x70\x79\x6f\x3f\xc6\xdf\xae\x66\x33\x7c\x7a\x66\x69\x85\x27\xac\x77\x51\x74\x93\xc7\x8b\x22\x46\xb1\xb8\x5e\xc5\x30\x4d\x43\xd6\x61\x1c\x01\x80\x23\xa5\xc8\x72\x8d\x6a\x2b\xac\xa8\x3c\x59\xbc\x08\xdb\xb1\x96\xe3\x2f\x5f\x27\x48\xb3\x02\xe9\x7a\xb5\x9a\xf6\xe5\x7e\x92\x6b\x6c\x58\xb2\xf6\xb8\xcf\x93\x1f\x8b\xfc\x11\xdf\xe3\xc7\xe9\x09\xc6\x5a\x0a\xe7\xc8\xc3\xd3\xab\xff\x30\xbf\x69\xbb\x4b\xb1\x78\x36\xad\xf6\x47\xfa\xfb\x6c\x67\xb9\x22\x0d\xd6\x9e\x24\xd9\xff\x85\xf5\xa5\x10\xb5\x69\x37\x8a\xb0\xb3\x54\xb1\x63\xa3\x3f\x94\x1a\x25\xa4\xfb\x07\x10\x4d\xe6\x27\x77\x49\xba\x8c\x7f\x1f\xdc\x95\x9b\xae\x1c\xc4\x21\x4b\x8f\x3e\xd7\x0f\x49\x7a\x8b\xeb\x22\x8f\xe3\xf1\xd1\xea\x64\x7e\x69\x9c\xb5\x2c\x07\x19\xe7\x29\x47\x5f\xe7\x49\x83\xd4\x8b\xa0\x37\xde\xc3\x17\xcd\x66\x58\xb2\xf3\x96\x37\xad\xef\xb5\x49\x72\x3e\x38\xb1\xa4\x98\x1c\x8c\x86\x80\x63\x2d\x15\xe1\x45\xa8\x96\xa0\x4c\xf5\x44\x35\x1a\x63\xd1\xee\x6a\xe1\x59\xcb\x40\xe1\x50\x5c\x5e\x5f\xe1\xd7\x96\x34\xee\x8c\xe5\x3f\x46\xc3\x79\x61\xbd\x43\xa5\x48\x58\xf8\x2d\x59\x02\x3b\x68\x73\x60\x39\x83\x3d\xa1\xb2\x14\x8e\x93\x7d\xe0\x84\xce\x15\x92\x66\x68\x8f\x1c\x04\x2a\xa3\x1b\xc5\x95\x07\x7b\x3c\x93\xd0\x2e\x64\x07\x02\x3b\x08\x65\x49\xd4\xdd\x01\xef\x4c\xa0\xec\xc3\x96\xa1\x8d\xdf\xb2\x96\x57\x51\x92\x3e\xc4\x79\x81\x24\x2d\x32\x3c\x51\x57\xf6\xb3\xa5\xf3\xc6\x12\xc6\x4f\xd4\x4d\x07\xda\xa4\xdf\xff\xcf\xc5\x6a\x1d\x3f\x60\x3c\xa2\xd7\x5d\x39\x08\x29\x95\x08\x3f\x54\x4b\xb2\xa3\x29\x46\x9f\x47\x43\x35\x4b\x71\x93\xa5\xdf\x56\xc9\x4d\xd1\x73\x26\x58\x66\xe1\x62\xee\x92\xf4\x76\x90\x7b\x7a\x7a\x4b\xb3\xd7\x51\xb4\xcc\xb3\xfb\x33\xe7\x33\x3f\x1f\x9e\x76\x7a\xa6\xf3\x76\xed\xf3\xc3\x9f\xbc\x7b\xdf\x95\x70\x95\xa8\x69\x1e\xfd\x0d\x00\x00\xff\xff\xf0\xc4\xbc\x15\x0d\x04\x00\x00")
 
 func migrations19_offersSqlBytes() ([]byte, error) {
 	return bindataRead(
@@ -303,7 +303,7 @@ func migrations19_offersSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/19_offers.sql", size: 687, mode: os.FileMode(420), modTime: time.Unix(1564566167, 0)}
+	info := bindataFileInfo{name: "migrations/19_offers.sql", size: 1037, mode: os.FileMode(420), modTime: time.Unix(1565119896, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -323,7 +323,7 @@ func migrations1_initial_schemaSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/1_initial_schema.sql", size: 10559, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/1_initial_schema.sql", size: 10559, mode: os.FileMode(420), modTime: time.Unix(1510233604, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -343,7 +343,7 @@ func migrations2_index_participants_by_toidSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/2_index_participants_by_toid.sql", size: 277, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/2_index_participants_by_toid.sql", size: 277, mode: os.FileMode(420), modTime: time.Unix(1510233604, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -363,7 +363,7 @@ func migrations3_use_sequence_in_history_accountsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/3_use_sequence_in_history_accounts.sql", size: 447, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/3_use_sequence_in_history_accounts.sql", size: 447, mode: os.FileMode(420), modTime: time.Unix(1510233604, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -383,7 +383,7 @@ func migrations4_add_protocol_versionSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/4_add_protocol_version.sql", size: 188, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/4_add_protocol_version.sql", size: 188, mode: os.FileMode(420), modTime: time.Unix(1510233604, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -403,7 +403,7 @@ func migrations5_create_trades_tableSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/5_create_trades_table.sql", size: 1100, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/5_create_trades_table.sql", size: 1100, mode: os.FileMode(420), modTime: time.Unix(1510233604, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -423,7 +423,7 @@ func migrations6_create_assets_tableSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/6_create_assets_table.sql", size: 366, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/6_create_assets_table.sql", size: 366, mode: os.FileMode(420), modTime: time.Unix(1510233604, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -443,7 +443,7 @@ func migrations7_modify_trades_tableSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/7_modify_trades_table.sql", size: 2303, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/7_modify_trades_table.sql", size: 2303, mode: os.FileMode(420), modTime: time.Unix(1512493789, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -463,7 +463,7 @@ func migrations8_add_aggregatorsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/8_add_aggregators.sql", size: 907, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/8_add_aggregators.sql", size: 907, mode: os.FileMode(420), modTime: time.Unix(1514478914, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -483,7 +483,7 @@ func migrations8_create_asset_stats_tableSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/8_create_asset_stats_table.sql", size: 441, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/8_create_asset_stats_table.sql", size: 441, mode: os.FileMode(420), modTime: time.Unix(1514478914, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -503,7 +503,7 @@ func migrations9_add_header_xdrSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/9_add_header_xdr.sql", size: 161, mode: os.FileMode(420), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/9_add_header_xdr.sql", size: 161, mode: os.FileMode(420), modTime: time.Unix(1535025415, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -560,27 +560,27 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"latest.sql":                                        latestSql,
-	"migrations/10_add_trades_price.sql":                migrations10_add_trades_priceSql,
-	"migrations/11_add_trades_account_index.sql":        migrations11_add_trades_account_indexSql,
-	"migrations/12_asset_stats_amount_string.sql":       migrations12_asset_stats_amount_stringSql,
-	"migrations/13_trade_offer_ids.sql":                 migrations13_trade_offer_idsSql,
-	"migrations/14_fix_asset_toml_field.sql":            migrations14_fix_asset_toml_fieldSql,
-	"migrations/15_ledger_failed_txs.sql":               migrations15_ledger_failed_txsSql,
-	"migrations/16_ingest_failed_transactions.sql":      migrations16_ingest_failed_transactionsSql,
-	"migrations/17_transaction_fee_paid.sql":            migrations17_transaction_fee_paidSql,
-	"migrations/18_account_for_signers.sql":             migrations18_account_for_signersSql,
-	"migrations/19_offers.sql":                          migrations19_offersSql,
-	"migrations/1_initial_schema.sql":                   migrations1_initial_schemaSql,
-	"migrations/2_index_participants_by_toid.sql":       migrations2_index_participants_by_toidSql,
+	"latest.sql": latestSql,
+	"migrations/10_add_trades_price.sql": migrations10_add_trades_priceSql,
+	"migrations/11_add_trades_account_index.sql": migrations11_add_trades_account_indexSql,
+	"migrations/12_asset_stats_amount_string.sql": migrations12_asset_stats_amount_stringSql,
+	"migrations/13_trade_offer_ids.sql": migrations13_trade_offer_idsSql,
+	"migrations/14_fix_asset_toml_field.sql": migrations14_fix_asset_toml_fieldSql,
+	"migrations/15_ledger_failed_txs.sql": migrations15_ledger_failed_txsSql,
+	"migrations/16_ingest_failed_transactions.sql": migrations16_ingest_failed_transactionsSql,
+	"migrations/17_transaction_fee_paid.sql": migrations17_transaction_fee_paidSql,
+	"migrations/18_account_for_signers.sql": migrations18_account_for_signersSql,
+	"migrations/19_offers.sql": migrations19_offersSql,
+	"migrations/1_initial_schema.sql": migrations1_initial_schemaSql,
+	"migrations/2_index_participants_by_toid.sql": migrations2_index_participants_by_toidSql,
 	"migrations/3_use_sequence_in_history_accounts.sql": migrations3_use_sequence_in_history_accountsSql,
-	"migrations/4_add_protocol_version.sql":             migrations4_add_protocol_versionSql,
-	"migrations/5_create_trades_table.sql":              migrations5_create_trades_tableSql,
-	"migrations/6_create_assets_table.sql":              migrations6_create_assets_tableSql,
-	"migrations/7_modify_trades_table.sql":              migrations7_modify_trades_tableSql,
-	"migrations/8_add_aggregators.sql":                  migrations8_add_aggregatorsSql,
-	"migrations/8_create_asset_stats_table.sql":         migrations8_create_asset_stats_tableSql,
-	"migrations/9_add_header_xdr.sql":                   migrations9_add_header_xdrSql,
+	"migrations/4_add_protocol_version.sql": migrations4_add_protocol_versionSql,
+	"migrations/5_create_trades_table.sql": migrations5_create_trades_tableSql,
+	"migrations/6_create_assets_table.sql": migrations6_create_assets_tableSql,
+	"migrations/7_modify_trades_table.sql": migrations7_modify_trades_tableSql,
+	"migrations/8_add_aggregators.sql": migrations8_add_aggregatorsSql,
+	"migrations/8_create_asset_stats_table.sql": migrations8_create_asset_stats_tableSql,
+	"migrations/9_add_header_xdr.sql": migrations9_add_header_xdrSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -622,30 +622,29 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
-
 var _bintree = &bintree{nil, map[string]*bintree{
 	"latest.sql": &bintree{latestSql, map[string]*bintree{}},
 	"migrations": &bintree{nil, map[string]*bintree{
-		"10_add_trades_price.sql":                &bintree{migrations10_add_trades_priceSql, map[string]*bintree{}},
-		"11_add_trades_account_index.sql":        &bintree{migrations11_add_trades_account_indexSql, map[string]*bintree{}},
-		"12_asset_stats_amount_string.sql":       &bintree{migrations12_asset_stats_amount_stringSql, map[string]*bintree{}},
-		"13_trade_offer_ids.sql":                 &bintree{migrations13_trade_offer_idsSql, map[string]*bintree{}},
-		"14_fix_asset_toml_field.sql":            &bintree{migrations14_fix_asset_toml_fieldSql, map[string]*bintree{}},
-		"15_ledger_failed_txs.sql":               &bintree{migrations15_ledger_failed_txsSql, map[string]*bintree{}},
-		"16_ingest_failed_transactions.sql":      &bintree{migrations16_ingest_failed_transactionsSql, map[string]*bintree{}},
-		"17_transaction_fee_paid.sql":            &bintree{migrations17_transaction_fee_paidSql, map[string]*bintree{}},
-		"18_account_for_signers.sql":             &bintree{migrations18_account_for_signersSql, map[string]*bintree{}},
-		"19_offers.sql":                          &bintree{migrations19_offersSql, map[string]*bintree{}},
-		"1_initial_schema.sql":                   &bintree{migrations1_initial_schemaSql, map[string]*bintree{}},
-		"2_index_participants_by_toid.sql":       &bintree{migrations2_index_participants_by_toidSql, map[string]*bintree{}},
+		"10_add_trades_price.sql": &bintree{migrations10_add_trades_priceSql, map[string]*bintree{}},
+		"11_add_trades_account_index.sql": &bintree{migrations11_add_trades_account_indexSql, map[string]*bintree{}},
+		"12_asset_stats_amount_string.sql": &bintree{migrations12_asset_stats_amount_stringSql, map[string]*bintree{}},
+		"13_trade_offer_ids.sql": &bintree{migrations13_trade_offer_idsSql, map[string]*bintree{}},
+		"14_fix_asset_toml_field.sql": &bintree{migrations14_fix_asset_toml_fieldSql, map[string]*bintree{}},
+		"15_ledger_failed_txs.sql": &bintree{migrations15_ledger_failed_txsSql, map[string]*bintree{}},
+		"16_ingest_failed_transactions.sql": &bintree{migrations16_ingest_failed_transactionsSql, map[string]*bintree{}},
+		"17_transaction_fee_paid.sql": &bintree{migrations17_transaction_fee_paidSql, map[string]*bintree{}},
+		"18_account_for_signers.sql": &bintree{migrations18_account_for_signersSql, map[string]*bintree{}},
+		"19_offers.sql": &bintree{migrations19_offersSql, map[string]*bintree{}},
+		"1_initial_schema.sql": &bintree{migrations1_initial_schemaSql, map[string]*bintree{}},
+		"2_index_participants_by_toid.sql": &bintree{migrations2_index_participants_by_toidSql, map[string]*bintree{}},
 		"3_use_sequence_in_history_accounts.sql": &bintree{migrations3_use_sequence_in_history_accountsSql, map[string]*bintree{}},
-		"4_add_protocol_version.sql":             &bintree{migrations4_add_protocol_versionSql, map[string]*bintree{}},
-		"5_create_trades_table.sql":              &bintree{migrations5_create_trades_tableSql, map[string]*bintree{}},
-		"6_create_assets_table.sql":              &bintree{migrations6_create_assets_tableSql, map[string]*bintree{}},
-		"7_modify_trades_table.sql":              &bintree{migrations7_modify_trades_tableSql, map[string]*bintree{}},
-		"8_add_aggregators.sql":                  &bintree{migrations8_add_aggregatorsSql, map[string]*bintree{}},
-		"8_create_asset_stats_table.sql":         &bintree{migrations8_create_asset_stats_tableSql, map[string]*bintree{}},
-		"9_add_header_xdr.sql":                   &bintree{migrations9_add_header_xdrSql, map[string]*bintree{}},
+		"4_add_protocol_version.sql": &bintree{migrations4_add_protocol_versionSql, map[string]*bintree{}},
+		"5_create_trades_table.sql": &bintree{migrations5_create_trades_tableSql, map[string]*bintree{}},
+		"6_create_assets_table.sql": &bintree{migrations6_create_assets_tableSql, map[string]*bintree{}},
+		"7_modify_trades_table.sql": &bintree{migrations7_modify_trades_tableSql, map[string]*bintree{}},
+		"8_add_aggregators.sql": &bintree{migrations8_add_aggregatorsSql, map[string]*bintree{}},
+		"8_create_asset_stats_table.sql": &bintree{migrations8_create_asset_stats_tableSql, map[string]*bintree{}},
+		"9_add_header_xdr.sql": &bintree{migrations9_add_header_xdrSql, map[string]*bintree{}},
 	}},
 }}
 
@@ -695,3 +694,4 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
+

--- a/services/horizon/internal/db2/schema/migrations/19_offers.sql
+++ b/services/horizon/internal/db2/schema/migrations/19_offers.sql
@@ -16,6 +16,14 @@ CREATE INDEX offers_by_seller ON offers USING BTREE(sellerid);
 CREATE INDEX offers_by_selling_asset ON offers USING BTREE(sellingasset);
 CREATE INDEX offers_by_buying_asset ON offers USING BTREE(buyingasset);
 
+-- Distributed ingestion relies on a single value locked for updating
+-- in a DB. When Horizon starts clear there is no value so we create it
+-- here. If there's a conflict it means the value is already there so
+-- we do nothing.
+INSERT INTO key_value_store (key, value)
+    VALUES ('exp_ingest_last_ledger', '0')
+    ON CONFLICT (key) DO NOTHING;
+
 -- +migrate Down
 
 DROP INDEX offers_by_seller;

--- a/services/horizon/internal/expingest/load_orderbook_graph_test.go
+++ b/services/horizon/internal/expingest/load_orderbook_graph_test.go
@@ -64,9 +64,8 @@ func TestLoadOrderBookGraphFromEmptyDB(t *testing.T) {
 	q := &history.Q{tt.HorizonSession()}
 	graph := orderbook.NewOrderBookGraph()
 
-	lastIngestedLedger, err := loadOrderBookGraphFromDB(q, graph)
+	err := loadOrderBookGraphFromDB(q, graph)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal(uint32(0), lastIngestedLedger)
 	tt.Assert.True(graph.IsEmpty())
 }
 
@@ -81,9 +80,8 @@ func TestLoadOrderBookGraph(t *testing.T) {
 	tt.Assert.NoError(q.UpsertOffer(eurOffer))
 	tt.Assert.NoError(q.UpsertOffer(twoEurOffer))
 
-	lastIngestedLedger, err := loadOrderBookGraphFromDB(q, graph)
+	err := loadOrderBookGraphFromDB(q, graph)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal(uint32(123), lastIngestedLedger)
 	tt.Assert.False(graph.IsEmpty())
 
 	offers := graph.Offers()

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -4,7 +4,6 @@
 package expingest
 
 import (
-	"database/sql"
 	"time"
 
 	"github.com/stellar/go/clients/stellarcore"
@@ -122,60 +121,73 @@ func NewSystem(config Config) (*System, error) {
 //     a database.
 //   * If instances is a NOT leader, it runs ledger pipeline without updating a
 //     a database so order book graph is updated but database is not overwritten.
-func (s *System) Run() error {
-	// Transaction will be commited or rolled back in pipelines post hooks.
-	// This needs to be `REPEATABLE READ` isolation because offers are loaded
-	// from a DB later on and we need a consistent view.
-	err := s.historyQ.BeginTx(&sql.TxOptions{
-		Isolation: sql.LevelRepeatableRead,
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error starting a transaction")
-	}
-
-	// This will get the value `FOR UPDATE`, blocking it for other nodes.
-	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest(true)
-	if err != nil {
-		return errors.Wrap(err, "Error getting last ingested ledger")
-	}
-
-	ingestVersion, err := s.historyQ.GetExpIngestVersion()
-	if err != nil {
-		return errors.Wrap(err, "Error getting exp ingest version")
-	}
-
-	if ingestVersion != CurrentVersion || lastIngestedLedger == 0 {
-		// This block is either starting from empty state or ingestion
-		// version upgrade.
-		// This will always run on a single instance due to the fact that
-		// `LastLedgerExpIngest` value is blocked for update and will always
-		// be updated when leading instance finishes processing state.
-		log.Info("Starting ingestion system from empty state...")
-
-		err = s.historyQ.Session.TruncateTables(
-			history.ExperimentalIngestionTables,
-		)
+func (s *System) Run() {
+	// continueAfter loop is needed only in case of initial state sync errors.
+	// If the state is successfully ingested `resumeFromLedger` method continues
+	// processing ledgers.
+	continueAfter(time.Second, func() error {
+		// Transaction will be commited or rolled back in pipelines post hooks.
+		err := s.historyQ.Begin()
 		if err != nil {
-			return errors.Wrap(err, "Error clearing ingest tables")
+			return errors.Wrap(err, "Error starting a transaction")
+		}
+		// We rollback in pipelines post-hooks but the error can happen before
+		// pipeline starts processing.
+		defer s.historyQ.Rollback()
+
+		// This will get the value `FOR UPDATE`, blocking it for other nodes.
+		lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
+		if err != nil {
+			return errors.Wrap(err, "Error getting last ingested ledger")
 		}
 
-		s.runFromEmptyState()
-	} else {
-		// The other node already ingested a state (just now or in the past)
-		// so we need to get offers from a DB, then resume session normally.
-		// State pipeline is NOT processed.
-		log.WithField("last_ledger", lastIngestedLedger).
-			Info("Resuming ingestion system from last processed ledger...")
-
-		err = loadOrderBookGraphFromDB(s.historyQ, s.graph)
+		ingestVersion, err := s.historyQ.GetExpIngestVersion()
 		if err != nil {
-			return errors.Wrap(err, "Error loading order book graph from db")
+			return errors.Wrap(err, "Error getting exp ingest version")
+		}
+
+		if ingestVersion != CurrentVersion || lastIngestedLedger == 0 {
+			// This block is either starting from empty state or ingestion
+			// version upgrade.
+			// This will always run on a single instance due to the fact that
+			// `LastLedgerExpIngest` value is blocked for update and will always
+			// be updated when leading instance finishes processing state.
+			// In case of errors it will start `Run` from the beginning.
+			log.Info("Starting ingestion system from empty state...")
+
+			err = s.historyQ.Session.TruncateTables(
+				history.ExperimentalIngestionTables,
+			)
+			if err != nil {
+				return errors.Wrap(err, "Error clearing ingest tables")
+			}
+
+			err = s.session.Run()
+			if err != nil {
+				// Check if session processed a state, if so, continue since the
+				// last processed ledger, otherwise start over.
+				lastIngestedLedger = s.session.GetLatestSuccessfullyProcessedLedger()
+				if lastIngestedLedger == 0 {
+					return err
+				}
+			}
+		} else {
+			// The other node already ingested a state (just now or in the past)
+			// so we need to get offers from a DB, then resume session normally.
+			// State pipeline is NOT processed.
+			log.WithField("last_ledger", lastIngestedLedger).
+				Info("Resuming ingestion system from last processed ledger...")
+
+			err = loadOrderBookGraphFromDB(s.historyQ, s.graph)
+			if err != nil {
+				return errors.Wrap(err, "Error loading order book graph from db")
+			}
+
 		}
 
 		s.resumeFromLedger(lastIngestedLedger)
-	}
-
-	return nil
+		return nil
+	})
 }
 
 func loadOrderBookGraphFromDB(historyQ *history.Q, graph *orderbook.OrderBookGraph) error {
@@ -213,42 +225,17 @@ func loadOrderBookGraphFromDB(historyQ *history.Q, graph *orderbook.OrderBookGra
 	return err
 }
 
-func (s *System) runFromEmptyState() {
-	for {
-		lastIngestedLedger := s.session.GetLatestProcessedLedger()
-
-		var err error
-		if lastIngestedLedger == 0 {
-			err = s.session.Run()
-		} else {
-			s.resumeFromLedger(lastIngestedLedger)
-			return
-		}
-
-		if err != nil {
-			log.WithField("error", err).Error("Error returned from ingest.LiveSession")
-			time.Sleep(time.Second)
-			continue
-		}
-
-		log.Info("Session shut down")
-		break
-	}
-}
-
 func (s *System) resumeFromLedger(lastIngestedLedger uint32) {
-	for {
+	continueAfter(time.Second, func() error {
 		err := s.session.Resume(lastIngestedLedger + 1)
 		if err != nil {
-			lastIngestedLedger = s.session.GetLatestProcessedLedger()
-			log.WithField("error", err).Error("Error returned from ingest.LiveSession")
-			time.Sleep(time.Second)
-			continue
+			lastIngestedLedger = s.session.GetLatestSuccessfullyProcessedLedger()
+			return errors.Wrap(err, "Error returned from ingest.LiveSession")
 		}
 
 		log.Info("Session shut down")
-		break
-	}
+		return nil
+	})
 }
 
 func (s *System) Shutdown() {
@@ -261,4 +248,19 @@ func createArchive(archiveURL string) (*historyarchive.Archive, error) {
 		archiveURL,
 		historyarchive.ConnectOptions{},
 	)
+}
+
+// continueAfter is a helper function that runs function f synchronically every
+// `duration` until it returns no error.
+// Logs all returned errors with `error` level.
+func continueAfter(sleepDuration time.Duration, f func() error) {
+	for {
+		err := f()
+		if err != nil {
+			log.Error(err)
+			time.Sleep(sleepDuration)
+			continue
+		}
+		break
+	}
 }

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -122,10 +122,10 @@ func NewSystem(config Config) (*System, error) {
 //   * If instances is a NOT leader, it runs ledger pipeline without updating a
 //     a database so order book graph is updated but database is not overwritten.
 func (s *System) Run() {
-	// continueAfter loop is needed only in case of initial state sync errors.
+	// retryOnError loop is needed only in case of initial state sync errors.
 	// If the state is successfully ingested `resumeFromLedger` method continues
 	// processing ledgers.
-	continueAfter(time.Second, func() error {
+	retryOnError(time.Second, func() error {
 		// Transaction will be commited or rolled back in pipelines post hooks.
 		err := s.historyQ.Begin()
 		if err != nil {
@@ -170,6 +170,11 @@ func (s *System) Run() {
 				if lastIngestedLedger == 0 {
 					return err
 				}
+
+				log.WithFields(ilog.F{
+					"err":                  err,
+					"last_ingested_ledger": lastIngestedLedger,
+				}).Error("Error running session, resuming from the last ingested ledger")
 			}
 		} else {
 			// The other node already ingested a state (just now or in the past)
@@ -226,7 +231,7 @@ func loadOrderBookGraphFromDB(historyQ *history.Q, graph *orderbook.OrderBookGra
 }
 
 func (s *System) resumeFromLedger(lastIngestedLedger uint32) {
-	continueAfter(time.Second, func() error {
+	retryOnError(time.Second, func() error {
 		err := s.session.Resume(lastIngestedLedger + 1)
 		if err != nil {
 			lastIngestedLedger = s.session.GetLatestSuccessfullyProcessedLedger()
@@ -250,10 +255,10 @@ func createArchive(archiveURL string) (*historyarchive.Archive, error) {
 	)
 }
 
-// continueAfter is a helper function that runs function f synchronically every
+// retryOnError is a helper function that runs function f synchronically every
 // `duration` until it returns no error.
 // Logs all returned errors with `error` level.
-func continueAfter(sleepDuration time.Duration, f func() error) {
+func retryOnError(sleepDuration time.Duration, f func() error) {
 	for {
 		err := f()
 		if err != nil {

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -4,13 +4,13 @@
 package expingest
 
 import (
+	"database/sql"
 	"time"
 
 	"github.com/stellar/go/clients/stellarcore"
 	"github.com/stellar/go/exp/ingest"
 	"github.com/stellar/go/exp/ingest/ledgerbackend"
 	"github.com/stellar/go/exp/orderbook"
-	supportPipeline "github.com/stellar/go/exp/support/pipeline"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
@@ -23,7 +23,12 @@ const (
 	// CurrentVersion reflects the latest version of the ingestion
 	// algorithm. This value is stored in KV store and is used to decide
 	// if there's a need to reprocess the ledger state or reingest data.
-	CurrentVersion = 2 // in version 2 we added the orderbook and offers processors
+	//
+	// Version history:
+	// - 1: Initial version
+	// - 2: We added the orderbook, offers processors and distributed
+	//      ingestion.
+	CurrentVersion = 2
 )
 
 var log = ilog.DefaultLogger.WithField("service", "expingest")
@@ -54,22 +59,12 @@ func NewSystem(config Config) (*System, error) {
 	}
 
 	historyQ := &history.Q{config.HistorySession}
-	stateNodes := []*supportPipeline.PipelineNode{
-		accountForSignerStateNode(historyQ),
-		orderBookDBStateNode(historyQ),
-		orderBookGraphStateNode(config.OrderBookGraph),
-	}
-	ledgerNodes := []*supportPipeline.PipelineNode{
-		accountForSignerLedgerNode(historyQ),
-		orderBookDBLedgerNode(historyQ),
-		orderBookGraphLedgerNode(config.OrderBookGraph),
-	}
 
 	session := &ingest.LiveSession{
 		Archive:        archive,
 		LedgerBackend:  ledgerBackend,
-		StatePipeline:  buildStatePipeline(stateNodes),
-		LedgerPipeline: buildLedgerPipeline(ledgerNodes),
+		StatePipeline:  buildStatePipeline(historyQ, config.OrderBookGraph),
+		LedgerPipeline: buildLedgerPipeline(historyQ, config.OrderBookGraph),
 		StellarCoreClient: &stellarcore.Client{
 			URL: config.StellarCoreURL,
 		},
@@ -98,103 +93,124 @@ func NewSystem(config Config) (*System, error) {
 	}, nil
 }
 
-func (s *System) Run() {
-	var ingestVersion int
-	var lastIngestedLedger uint32
-	var err error
-	for {
-		lastIngestedLedger, err = s.historyQ.GetLastLedgerExpIngest()
-		if err != nil {
-			log.WithField("error", err).Error("Error getting last ingested ledger")
-			time.Sleep(time.Second)
-			continue
-		}
+// Run starts ingestion system. Ingestion system supports distributed ingestion
+// that means that Horizon ingestion can be running on multiple machines and
+// only one, random node will lead the ingestion.
+//
+// It needs to support cartesian product of the following run scenarios cases:
+// - Init from empty state (1a) and resuming from existing state (1b).
+// - Ingestion system version has been upgraded (2a) or not (2b).
+// - Current node is leading ingestion (3a) or not (3b).
+//
+// We always clear state when ingestion system is upgraded so 2a and 2b are
+// included in 1a.
+//
+// We ensure that only one instance is a leader because in each round instances
+// try to acquire a lock on `LastLedgerExpIngest value in key value store and only
+// one instance will be able to acquire it. This happens in both initial processing
+// and ledger processing. So this solves 3a and 3b in both 1a and 1b.
+//
+// Finally, 1a and 1b are tricky because we need to keep the latest version
+// of order book graph in memory of each Horizon instance. To solve this:
+// * For state init:
+//   * If instance is a leader, we update the order book graph by running state
+//     pipeline normally.
+//   * If instance is NOT a leader, we build a graph from offers present in a
+//     database. We completely omit state pipeline in this case.
+// * For resuming:
+//   * If instances is a leader, it runs full ledger pipeline, including updating
+//     a database.
+//   * If instances is a NOT leader, it runs ledger pipeline without updating a
+//     a database so order book graph is updated but database is not overwritten.
+func (s *System) Run() error {
+	// Transaction will be commited or rolled back in pipelines post hooks.
+	// This needs to be `REPEATABLE READ` isolation because offers are loaded
+	// from a DB later on and we need a consistent view.
+	err := s.historyQ.BeginTx(&sql.TxOptions{
+		Isolation: sql.LevelRepeatableRead,
+	})
+	if err != nil {
+		return errors.Wrap(err, "Error starting a transaction")
+	}
 
-		ingestVersion, err = s.historyQ.GetExpIngestVersion()
-		if err != nil {
-			log.WithField("error", err).Error("Error getting exp ingest version")
-			time.Sleep(time.Second)
-			continue
-		}
+	// This will get the value `FOR UPDATE`, blocking it for other nodes.
+	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest(true)
+	if err != nil {
+		return errors.Wrap(err, "Error getting last ingested ledger")
+	}
 
-		break
+	ingestVersion, err := s.historyQ.GetExpIngestVersion()
+	if err != nil {
+		return errors.Wrap(err, "Error getting exp ingest version")
 	}
 
 	if ingestVersion != CurrentVersion || lastIngestedLedger == 0 {
+		// This block is either starting from empty state or ingestion
+		// version upgrade.
+		// This will always run on a single instance due to the fact that
+		// `LastLedgerExpIngest` value is blocked for update and will always
+		// be updated when leading instance finishes processing state.
 		log.Info("Starting ingestion system from empty state...")
 
-		for {
-			err = s.historyQ.Session.TruncateTables(
-				history.ExperimentalIngestionTables,
-			)
-			if err != nil {
-				log.WithField("error", err).Error("Error clearing ingest tables")
-				time.Sleep(time.Second)
-				continue
-			}
-			break
+		err = s.historyQ.Session.TruncateTables(
+			history.ExperimentalIngestionTables,
+		)
+		if err != nil {
+			return errors.Wrap(err, "Error clearing ingest tables")
 		}
 
 		s.runFromEmptyState()
-		return
 	} else {
+		// The other node already ingested a state (just now or in the past)
+		// so we need to get offers from a DB, then resume session normally.
+		// State pipeline is NOT processed.
 		log.WithField("last_ledger", lastIngestedLedger).
 			Info("Resuming ingestion system from last processed ledger...")
 
-		for {
-			lastIngestedLedger, err = loadOrderBookGraphFromDB(s.historyQ, s.graph)
-			if err != nil {
-				log.WithField("error", err).Error("Error loading order book graph from db")
-				time.Sleep(time.Second)
-				continue
-			}
-			break
+		err = loadOrderBookGraphFromDB(s.historyQ, s.graph)
+		if err != nil {
+			return errors.Wrap(err, "Error loading order book graph from db")
 		}
 
 		s.resumeFromLedger(lastIngestedLedger)
-		return
 	}
+
+	return nil
 }
 
-func loadOrderBookGraphFromDB(historyQ *history.Q, graph *orderbook.OrderBookGraph) (uint32, error) {
-	var lastIngestedLedger uint32
-	err := historyQ.Begin()
-	if err != nil {
-		return lastIngestedLedger, err
-	}
-	defer historyQ.Rollback()
+func loadOrderBookGraphFromDB(historyQ *history.Q, graph *orderbook.OrderBookGraph) error {
 	defer graph.Discard()
 
-	lastIngestedLedger, err = historyQ.GetLastLedgerExpIngest()
-	if err != nil {
-		return lastIngestedLedger, err
-	}
+	log.Info("Loading offers from a database into memory store...")
+	start := time.Now()
 
 	offers, err := historyQ.GetAllOffers()
 	if err != nil {
-		return lastIngestedLedger, err
+		return err
 	}
 
-	err = historyQ.Commit()
-	if err == nil {
-		for _, offer := range offers {
-			sellerID := xdr.MustAddress(offer.SellerID)
-			graph.AddOffer(xdr.OfferEntry{
-				SellerId: sellerID,
-				OfferId:  offer.OfferID,
-				Selling:  offer.SellingAsset,
-				Buying:   offer.BuyingAsset,
-				Amount:   offer.Amount,
-				Price: xdr.Price{
-					N: xdr.Int32(offer.Pricen),
-					D: xdr.Int32(offer.Priced),
-				},
-				Flags: xdr.Uint32(offer.Flags),
-			})
-		}
-		err = graph.Apply()
+	for _, offer := range offers {
+		sellerID := xdr.MustAddress(offer.SellerID)
+		graph.AddOffer(xdr.OfferEntry{
+			SellerId: sellerID,
+			OfferId:  offer.OfferID,
+			Selling:  offer.SellingAsset,
+			Buying:   offer.BuyingAsset,
+			Amount:   offer.Amount,
+			Price: xdr.Price{
+				N: xdr.Int32(offer.Pricen),
+				D: xdr.Int32(offer.Priced),
+			},
+			Flags: xdr.Uint32(offer.Flags),
+		})
 	}
-	return lastIngestedLedger, err
+
+	err = graph.Apply()
+	if err == nil {
+		log.WithField("duration", time.Since(start).Seconds()).Info("Finished offers from a database into memory store")
+	}
+
+	return err
 }
 
 func (s *System) runFromEmptyState() {

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -46,12 +46,16 @@ func orderBookGraphStateNode(graph *orderbook.OrderBookGraph) *supportPipeline.P
 		)
 }
 
-func buildStatePipeline(children []*supportPipeline.PipelineNode) *pipeline.StatePipeline {
+func buildStatePipeline(historyQ *history.Q, graph *orderbook.OrderBookGraph) *pipeline.StatePipeline {
 	statePipeline := &pipeline.StatePipeline{}
 
 	statePipeline.SetRoot(
 		pipeline.StateNode(&processors.RootProcessor{}).
-			Pipe(children...),
+			Pipe(
+				accountForSignerStateNode(historyQ),
+				orderBookDBStateNode(historyQ),
+				orderBookGraphStateNode(graph),
+			),
 	)
 
 	return statePipeline
@@ -77,11 +81,20 @@ func orderBookGraphLedgerNode(graph *orderbook.OrderBookGraph) *supportPipeline.
 	})
 }
 
-func buildLedgerPipeline(children []*supportPipeline.PipelineNode) *pipeline.LedgerPipeline {
+func buildLedgerPipeline(historyQ *history.Q, graph *orderbook.OrderBookGraph) *pipeline.LedgerPipeline {
 	ledgerPipeline := &pipeline.LedgerPipeline{}
 
 	ledgerPipeline.SetRoot(
-		pipeline.LedgerNode(&processors.RootProcessor{}).Pipe(children...),
+		pipeline.LedgerNode(&processors.RootProcessor{}).
+			Pipe(
+				// This subtree will only run when `IngestUpdateDatabase` is set.
+				pipeline.LedgerNode(&horizonProcessors.ContextFilter{horizonProcessors.IngestUpdateDatabase}).
+					Pipe(
+						accountForSignerLedgerNode(historyQ),
+						orderBookDBLedgerNode(historyQ),
+					),
+				orderBookGraphLedgerNode(graph),
+			),
 	)
 
 	return ledgerPipeline
@@ -105,10 +118,49 @@ func addPipelineHooks(
 
 	historyQ := &history.Q{historySession}
 
-	p.AddPreProcessingHook(func(ctx context.Context) error {
+	p.AddPreProcessingHook(func(ctx context.Context) (context.Context, error) {
+		// Start a transaction only if not in a transaction already.
+		// The only case this can happen is during the first run when
+		// a transaction is started to get the latest ledger `FOR UPDATE`
+		// in `System.Run()`.
+		if tx := historySession.GetTx(); tx == nil {
+			err := historySession.Begin()
+			if err != nil {
+				return ctx, errors.Wrap(err, "Error starting a transaction")
+			}
+		}
+
+		// We need to get this value `FOR UPDATE` so all other instances
+		// are blocked.
+		lastIngestedLedger, err := historyQ.GetLastLedgerExpIngest(true)
+		if err != nil {
+			return ctx, errors.Wrap(err, "Error getting last ledger")
+		}
+
 		ledgerSeq := pipeline.GetLedgerSequenceFromContext(ctx)
-		log.WithFields(ilog.F{"ledger": ledgerSeq, "type": pipelineType}).Info("Processing ledger")
-		return historySession.Begin()
+
+		updateDatabase := false
+		if pipelineType == "state_pipeline" {
+			// State pipeline is always fully run because loading offers
+			// from a database is done outside the pipeline.
+			updateDatabase = true
+		} else {
+			if lastIngestedLedger+1 == ledgerSeq {
+				// lastIngestedLedger+1 == ledgerSeq what means that this instance
+				// is the main ingesting instance in this round and should update a
+				// database.
+				updateDatabase = true
+				ctx = context.WithValue(ctx, horizonProcessors.IngestUpdateDatabase, true)
+			}
+		}
+
+		log.WithFields(ilog.F{
+			"ledger":            ledgerSeq,
+			"type":              pipelineType,
+			"updating_database": updateDatabase,
+		}).Info("Processing ledger")
+
+		return ctx, nil
 	})
 
 	p.AddPostProcessingHook(func(ctx context.Context, err error) error {

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -132,7 +132,7 @@ func addPipelineHooks(
 
 		// We need to get this value `FOR UPDATE` so all other instances
 		// are blocked.
-		lastIngestedLedger, err := historyQ.GetLastLedgerExpIngest(true)
+		lastIngestedLedger, err := historyQ.GetLastLedgerExpIngest()
 		if err != nil {
 			return ctx, errors.Wrap(err, "Error getting last ledger")
 		}
@@ -152,6 +152,12 @@ func addPipelineHooks(
 				updateDatabase = true
 				ctx = context.WithValue(ctx, horizonProcessors.IngestUpdateDatabase, true)
 			}
+		}
+
+		// If we are not going to update a DB release a lock by rolling back a
+		// transaction.
+		if !updateDatabase {
+			historySession.Rollback()
 		}
 
 		log.WithFields(ilog.F{

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -186,15 +186,30 @@ func addPipelineHooks(
 			return err
 		}
 
-		if err := historyQ.UpdateLastLedgerExpIngest(ledgerSeq); err != nil {
-			return errors.Wrap(err, "Error updating last ingested ledger")
-		}
-
-		if err := historyQ.UpdateExpIngestVersion(CurrentVersion); err != nil {
-			return errors.Wrap(err, "Error updating expingest version")
-		}
-
 		if tx := historySession.GetTx(); tx != nil {
+			// If we're in a transaction we're updating database with new data.
+			// We get lastIngestedLedger from a DB here to do an extra check
+			// if the current node should really be updating a DB.
+			// This is "just in case" if lastIngestedLedger is not selected
+			// `FOR UPDATE` due to a bug or accident. In such case we error and
+			// rollback.
+			lastIngestedLedger, err := historyQ.GetLastLedgerExpIngest()
+			if err != nil {
+				return errors.Wrap(err, "Error getting last ledger")
+			}
+
+			if lastIngestedLedger+1 != ledgerSeq {
+				return errors.New("The local latest sequence is not equal to global sequence + 1")
+			}
+
+			if err := historyQ.UpdateLastLedgerExpIngest(ledgerSeq); err != nil {
+				return errors.Wrap(err, "Error updating last ingested ledger")
+			}
+
+			if err := historyQ.UpdateExpIngestVersion(CurrentVersion); err != nil {
+				return errors.Wrap(err, "Error updating expingest version")
+			}
+
 			if err := historySession.Commit(); err != nil {
 				return errors.Wrap(err, "Error commiting db transaction")
 			}

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -194,14 +194,14 @@ func addPipelineHooks(
 			return errors.Wrap(err, "Error updating expingest version")
 		}
 
-		if err := historySession.Commit(); err != nil {
-			return errors.Wrap(err, "Error commiting db transaction")
+		if tx := historySession.GetTx(); tx != nil {
+			if err := historySession.Commit(); err != nil {
+				return errors.Wrap(err, "Error commiting db transaction")
+			}
 		}
 
-		if graph != nil {
-			if err := graph.Apply(); err != nil {
-				return errors.Wrap(err, "Error applying order book changes")
-			}
+		if err := graph.Apply(); err != nil {
+			return errors.Wrap(err, "Error applying order book changes")
 		}
 
 		log.WithFields(ilog.F{"ledger": ledgerSeq, "type": pipelineType}).Info("Processed ledger")

--- a/services/horizon/internal/expingest/processors/context_filter.go
+++ b/services/horizon/internal/expingest/processors/context_filter.go
@@ -1,0 +1,98 @@
+package processors
+
+import (
+	"context"
+	"fmt"
+	stdio "io"
+
+	"github.com/stellar/go/exp/ingest/io"
+	ingestpipeline "github.com/stellar/go/exp/ingest/pipeline"
+	"github.com/stellar/go/exp/support/pipeline"
+)
+
+func (p *ContextFilter) ProcessState(ctx context.Context, store *pipeline.Store, r io.StateReader, w io.StateWriter) error {
+	defer r.Close()
+	defer w.Close()
+
+	// Exit early if Key not found in `ctx`
+	if v := ctx.Value(p.Key); v == nil {
+		return nil
+	}
+
+	for {
+		entryChange, err := r.Read()
+		if err != nil {
+			if err == stdio.EOF {
+				break
+			} else {
+				return err
+			}
+		}
+
+		err = w.Write(entryChange)
+		if err != nil {
+			if err == stdio.ErrClosedPipe {
+				// Reader does not need more data
+				return nil
+			}
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			continue
+		}
+	}
+
+	return nil
+}
+
+func (p *ContextFilter) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) error {
+	defer r.Close()
+	defer w.Close()
+
+	// Exit early if Key not found in `ctx`
+	if v := ctx.Value(p.Key); v == nil {
+		return nil
+	}
+
+	for {
+		transaction, err := r.Read()
+		if err != nil {
+			if err == stdio.EOF {
+				break
+			} else {
+				return err
+			}
+		}
+
+		err = w.Write(transaction)
+		if err != nil {
+			if err == stdio.ErrClosedPipe {
+				// Reader does not need more data
+				return nil
+			}
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			continue
+		}
+	}
+
+	return nil
+}
+
+func (p *ContextFilter) Name() string {
+	return fmt.Sprintf("ContextFilter (%s)", p.Key)
+}
+
+func (p *ContextFilter) Reset() {}
+
+var _ ingestpipeline.StateProcessor = &ContextFilter{}
+var _ ingestpipeline.LedgerProcessor = &ContextFilter{}

--- a/services/horizon/internal/expingest/processors/main.go
+++ b/services/horizon/internal/expingest/processors/main.go
@@ -5,6 +5,12 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 )
 
+type PipelineContextKey string
+
+const (
+	IngestUpdateDatabase = PipelineContextKey("IngestUpdateDatabase")
+)
+
 type DatabaseProcessorActionType string
 
 const (
@@ -28,4 +34,10 @@ type DatabaseProcessor struct {
 // can be later used for path finding.
 type OrderbookProcessor struct {
 	OrderBookGraph *orderbook.OrderBookGraph
+}
+
+// ContextFilter writes read objects only if a given key is present in the
+// pipline context.
+type ContextFilter struct {
+	Key PipelineContextKey
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

This PR changes new ingestion system in Horizon to allow distributed ingestion. This means that ingestion will be running on all Horizon nodes but only one, random node will be a leader that updates a database (at the same time all of the nodes will update in-memory order book graph).

Close #1529.

### Goal and scope

In #1519 we added in-memory order book graph that allows faster path finding. The issue we noticed is that the graph is updated by ingesting pipeline which runs on a single Horizon instance only. To solve this we decided to run ingestion on all nodes. This will also improve availability of Horizon: if one node goes down other nodes can continue ingestion.

We need to support cartesian product of the following run scenarios cases:
- Init from empty state (1a) and resuming from existing state (1b).
- Ingestion system version has been upgraded (2a) or not (2b).
- Current node is leading ingestion (3a) or not (3b).

We always clear state when ingestion system is upgraded so 2a and 2b are included in 1a.

We ensure that only one instance is a leader because in each round instances try to acquire a lock on `LastLedgerExpIngest` value in key value store and only one instance will be able to acquire it. This happens in both initial processing and ledger processing. So this solves 3a and 3b in both 1a and 1b.
 
Finally, 1a and 1b are tricky because we need to keep the latest version of order book graph in memory of each Horizon instance. To solve this:
* For state init:
  * If instance is a leader, we update the order book graph by running state pipeline normally.
  * If instance is NOT a leader, we build a graph from offers present in a database. We completely omit state pipeline in this case.
* For resuming:
  * If instances is a leader, it runs full ledger pipeline, including updating a database.
  * If instances is a NOT leader, it runs ledger pipeline without updating a database so order book graph is updated but database is not overwritten.

### Summary of changes

* Update `System.Run` to support distributed ingestion. It also returns errors during init (that later panic) to make the code more readable. In case of ledger processing errors the system logs errors and continues (instead of returning errors).
* Add `ContextFilter` processor that writes objects only if a given key is present in pipeline `ctx`.
* Fix a bug connected to unbuffered channels in `support/pipeline.Pipeline`.
* Change pre-processing hook function signature to support returning a new context that will be passed to a pipeline.
* Update migration to make sure `exp_ingest_last_ledger` key is always present in key value store.

### Known limitations & issues

* The code will happily run ingestion with DB updates on more than one node in case of distributed ingestion issues due to "upsert" queries. We need to either change upsert to insert/update queries or add another table (ledgers?) that will cause unique constraint violation in case of multiple ingesting sessions running at the same time.
* No test for new code...