### PR TITLE
services/horizon: Use PostgresTempSet in Horizon

### DIFF
--- a/exp/ingest/io/postgres_temp_set.go
+++ b/exp/ingest/io/postgres_temp_set.go
@@ -27,28 +27,36 @@ const (
 // It's around 4x slower than MemoryStateReaderTempStore but has much
 // lower memory requirements. `postgresTempSetCacheSize` can be changed
 // to achieve better speed at the cost of higher memory usage.
+// If `DSN` is passed, a new `db.Session` will be created.
+// If `Session` is passed, it will be cloned.
 type PostgresTempSet struct {
-	DSN string
+	DSN     string
+	Session *db.Session
 
 	afterFirstDump bool
 	// cache can contain both true and false values. false values can be set
 	// when key is not in cache: then the value will be checked in a database
 	// and later cached.
 	cache     map[string]bool
-	session   *db.Session
 	tableName string
 }
 
 // Open connects to a DB and creates a temporary table and data structures.
 func (s *PostgresTempSet) Open() error {
 	var err error
-	s.session, err = db.Open("postgres", s.DSN)
-	if err != nil {
-		return err
+	if s.Session == nil {
+		s.Session, err = db.Open("postgres", s.DSN)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Clone existing session to prevent deadlock if the existing session
+		// is in a transaction.
+		s.Session = s.Session.Clone()
 	}
 
 	// Begin transaction - without it `ON COMMIT DROP` won't work.
-	err = s.session.Begin()
+	err = s.Session.Begin()
 	if err != nil {
 		return err
 	}
@@ -63,7 +71,7 @@ func (s *PostgresTempSet) Open() error {
 	s.tableName = fmt.Sprintf("exp_state_reader_%s", hex.EncodeToString(r))
 
 	// Create table
-	_, err = s.session.ExecRaw(fmt.Sprintf(`
+	_, err = s.Session.ExecRaw(fmt.Sprintf(`
 	CREATE TEMPORARY TABLE %s (
 	    key character varying(255) NOT NULL,
 	    PRIMARY KEY (key)
@@ -105,7 +113,7 @@ func (s *PostgresTempSet) Preload(keys []string) error {
 	rows, err := psql.Select("key").
 		From(s.tableName).
 		Where(map[string]interface{}{"key": loadKeys}).
-		RunWith(s.session.GetTx().Tx).
+		RunWith(s.Session.GetTx().Tx).
 		Query()
 
 	if err != nil {
@@ -169,7 +177,7 @@ func (s *PostgresTempSet) dumpCacheIfNeeded() error {
 		// postgres query is 65535. When we are approaching the max params,
 		// insert rows we have so far and create a new builder.
 		if queryParams > postgresMaxQueryParams-500 {
-			_, err := s.session.Exec(query)
+			_, err := s.Session.Exec(query)
 			if err != nil {
 				return err
 			}
@@ -188,7 +196,7 @@ func (s *PostgresTempSet) dumpCacheIfNeeded() error {
 
 	// Insert the last batch.
 	if queryParams > 0 {
-		_, err := s.session.Exec(query)
+		_, err := s.Session.Exec(query)
 		return err
 	}
 
@@ -237,7 +245,7 @@ func (s *PostgresTempSet) dbGet(key string) (bool, error) {
 		Where("key = ?", key)
 
 	var value int
-	if err := s.session.Get(&value, query); err != nil {
+	if err := s.Session.Get(&value, query); err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
 			return false, nil
 		}
@@ -250,6 +258,7 @@ func (s *PostgresTempSet) dbGet(key string) (bool, error) {
 
 // Close closes a database connection what also removes a temporary table.
 func (s *PostgresTempSet) Close() error {
-	// This will also drop temp table
-	return s.session.Close()
+	// This will drop temp table. Do not use `s.Session.Close` as
+	// DB in `s.Session` can be shared by many sessions.
+	return s.Session.Rollback()
 }

--- a/exp/ingest/io/postgres_temp_set.go
+++ b/exp/ingest/io/postgres_temp_set.go
@@ -258,6 +258,8 @@ func (s *PostgresTempSet) dbGet(key string) (bool, error) {
 
 // Close closes a database connection what also removes a temporary table.
 func (s *PostgresTempSet) Close() error {
+	// Dereference map
+	s.cache = nil
 	// This will drop temp table. Do not use `s.Session.Close` as
 	// DB in `s.Session` can be shared by many sessions.
 	return s.Session.Rollback()

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stellar/go/clients/stellarcore"
 	"github.com/stellar/go/exp/ingest"
+	"github.com/stellar/go/exp/ingest/io"
 	"github.com/stellar/go/exp/ingest/ledgerbackend"
 	"github.com/stellar/go/exp/orderbook"
 	supportPipeline "github.com/stellar/go/exp/support/pipeline"
@@ -29,11 +30,13 @@ const (
 var log = ilog.DefaultLogger.WithField("service", "expingest")
 
 type Config struct {
-	CoreSession       *db.Session
+	CoreSession    *db.Session
+	StellarCoreURL string
+
 	HistorySession    *db.Session
 	HistoryArchiveURL string
-	StellarCoreURL    string
-	OrderBookGraph    *orderbook.OrderBookGraph
+
+	OrderBookGraph *orderbook.OrderBookGraph
 }
 
 type System struct {
@@ -76,6 +79,10 @@ func NewSystem(config Config) (*System, error) {
 
 		StateReporter:  &LoggingStateReporter{Log: log, Interval: 100000},
 		LedgerReporter: &LoggingLedgerReporter{Log: log},
+
+		TempSet: &io.PostgresTempSet{
+			Session: config.HistorySession,
+		},
 	}
 
 	addPipelineHooks(


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

This PR updates Horizon to use `PostgresTempSet` created in #1539 instead of `MemoryTempSet` to lower memory requirements.

Close #1565.