### PR TITLE
txnbuild: Fix manage data value in sep10 challenge

### DIFF
--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -210,13 +210,13 @@ func BuildChallengeTx(serverSignerSecret, clientAccountID, anchorName, network s
 		return "", err
 	}
 
-	randomNonce, err := generateRandomNonce(64)
+	randomNonce, err := generateRandomNonce(48)
 	if err != nil {
 		return "", err
 	}
 
-	if len(randomNonce) != 64 {
-		return "", errors.New("64 byte long random nonce required")
+	if len(randomNonce) != 48 {
+		return "", errors.New("48 byte long random nonce required")
 	}
 
 	// represent server signing account as SimpleAccount

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -210,13 +210,15 @@ func BuildChallengeTx(serverSignerSecret, clientAccountID, anchorName, network s
 		return "", err
 	}
 
+	// SEP10 spec requires 48 byte cryptographic-quality random string
 	randomNonce, err := generateRandomNonce(48)
 	if err != nil {
 		return "", err
 	}
-
-	if len(randomNonce) != 48 {
-		return "", errors.New("48 byte long random nonce required")
+	// Encode 48-byte nonce to base64 for a total of 64-bytes
+	randomNonceToString := base64.StdEncoding.EncodeToString(randomNonce)
+	if len(randomNonceToString) != 64 {
+		return "", errors.New("64 byte long random nonce required")
 	}
 
 	// represent server signing account as SimpleAccount
@@ -248,7 +250,7 @@ func BuildChallengeTx(serverSignerSecret, clientAccountID, anchorName, network s
 			&ManageData{
 				SourceAccount: &ca,
 				Name:          anchorName + " auth",
-				Value:         randomNonce,
+				Value:         []byte(randomNonceToString),
 			},
 		},
 		Timebounds: txTimebound,

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -2,7 +2,6 @@ package txnbuild
 
 import (
 	"crypto/sha256"
-	"encoding/base64"
 	"testing"
 	"time"
 
@@ -755,9 +754,7 @@ func TestBuildChallengeTx(t *testing.T) {
 	op := txXDR.Tx.Operations[0]
 	assert.Equal(t, xdr.OperationTypeManageData, op.Body.Type, "operation type should be manage data")
 	assert.Equal(t, xdr.String64("SDF auth"), op.Body.ManageDataOp.DataName, "DataName should be 'SDF auth'")
-	assert.Equal(t, 48, len(*op.Body.ManageDataOp.DataValue), "DataValue should be 48 bytes")
-	dvB64 := base64.StdEncoding.EncodeToString(*op.Body.ManageDataOp.DataValue)
-	assert.Equal(t, 64, len(dvB64), "DataValue as base64 should be 64 bytes")
+	assert.Equal(t, 64, len(*op.Body.ManageDataOp.DataValue), "DataValue should be 48 bytes")
 
 	// 5 minutes timebound
 	txeBase64, err = BuildChallengeTx(kp0.Seed(), kp0.Address(), "SDF1", network.TestNetworkPassphrase, time.Duration(5*time.Minute))
@@ -775,9 +772,7 @@ func TestBuildChallengeTx(t *testing.T) {
 	op1 := txXDR1.Tx.Operations[0]
 	assert.Equal(t, xdr.OperationTypeManageData, op1.Body.Type, "operation type should be manage data")
 	assert.Equal(t, xdr.String64("SDF1 auth"), op1.Body.ManageDataOp.DataName, "DataName should be 'SDF1 auth'")
-	assert.Equal(t, 48, len(*op1.Body.ManageDataOp.DataValue), "DataValue should be 48 bytes")
-	dvB64 = base64.StdEncoding.EncodeToString(*op.Body.ManageDataOp.DataValue)
-	assert.Equal(t, 64, len(dvB64), "DataValue as base64 should be 64 bytes")
+	assert.Equal(t, 64, len(*op1.Body.ManageDataOp.DataValue), "DataValue should be 64 bytes")
 }
 
 func TestHashHex(t *testing.T) {

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -754,7 +754,7 @@ func TestBuildChallengeTx(t *testing.T) {
 	op := txXDR.Tx.Operations[0]
 	assert.Equal(t, xdr.OperationTypeManageData, op.Body.Type, "operation type should be manage data")
 	assert.Equal(t, xdr.String64("SDF auth"), op.Body.ManageDataOp.DataName, "DataName should be 'SDF auth'")
-	assert.Equal(t, 64, len(*op.Body.ManageDataOp.DataValue), "DataValue should be 48 bytes")
+	assert.Equal(t, 64, len(*op.Body.ManageDataOp.DataValue), "DataValue should be 64 bytes")
 
 	// 5 minutes timebound
 	txeBase64, err = BuildChallengeTx(kp0.Seed(), kp0.Address(), "SDF1", network.TestNetworkPassphrase, time.Duration(5*time.Minute))

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -2,6 +2,7 @@ package txnbuild
 
 import (
 	"crypto/sha256"
+	"encoding/base64"
 	"testing"
 	"time"
 
@@ -754,7 +755,9 @@ func TestBuildChallengeTx(t *testing.T) {
 	op := txXDR.Tx.Operations[0]
 	assert.Equal(t, xdr.OperationTypeManageData, op.Body.Type, "operation type should be manage data")
 	assert.Equal(t, xdr.String64("SDF auth"), op.Body.ManageDataOp.DataName, "DataName should be 'SDF auth'")
-	assert.Equal(t, 64, len(*op.Body.ManageDataOp.DataValue), "DataValue should be 64 bytes")
+	assert.Equal(t, 48, len(*op.Body.ManageDataOp.DataValue), "DataValue should be 48 bytes")
+	dvB64 := base64.StdEncoding.EncodeToString(*op.Body.ManageDataOp.DataValue)
+	assert.Equal(t, 64, len(dvB64), "DataValue as base64 should be 64 bytes")
 
 	// 5 minutes timebound
 	txeBase64, err = BuildChallengeTx(kp0.Seed(), kp0.Address(), "SDF1", network.TestNetworkPassphrase, time.Duration(5*time.Minute))
@@ -772,7 +775,9 @@ func TestBuildChallengeTx(t *testing.T) {
 	op1 := txXDR1.Tx.Operations[0]
 	assert.Equal(t, xdr.OperationTypeManageData, op1.Body.Type, "operation type should be manage data")
 	assert.Equal(t, xdr.String64("SDF1 auth"), op1.Body.ManageDataOp.DataName, "DataName should be 'SDF1 auth'")
-	assert.Equal(t, 64, len(*op1.Body.ManageDataOp.DataValue), "DataValue should be 64 bytes")
+	assert.Equal(t, 48, len(*op1.Body.ManageDataOp.DataValue), "DataValue should be 48 bytes")
+	dvB64 = base64.StdEncoding.EncodeToString(*op.Body.ManageDataOp.DataValue)
+	assert.Equal(t, 64, len(dvB64), "DataValue as base64 should be 64 bytes")
 }
 
 func TestHashHex(t *testing.T) {


### PR DESCRIPTION
This PR uses the correct length of bytes for the manage data value. 
As per the protocol
>The value must be 64 bytes long. It contains a 48 byte cryptographic-quality random string encoded using base64 (for a total of 64 bytes after encoding).

Closes #1562 