### PR TITLE
exp/orderbook: improvement to consumeOffers

### DIFF
--- a/exp/orderbook/graph.go
+++ b/exp/orderbook/graph.go
@@ -347,11 +347,12 @@ func consumeOffers(
 
 		totalConsumed += xdr.Int64(buyingUnitsFromOffer)
 		currentAssetAmount -= xdr.Int64(sellingUnitsFromOffer)
+
+		if currentAssetAmount <= 0 {
+			return totalConsumed, nil
+		}
 	}
 
-	if currentAssetAmount <= 0 {
-		return totalConsumed, nil
-	}
 	return -1, nil
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->


<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Exit `consumeOffers()` early if we have no asset units to sell.

### Goal and scope

Improve performance of `consumeOffers()`

### Summary of changes

It's not necessary to iterate through all the offers if we've already consumed enough offers to sell all units of our current asset.

### Known limitations & issues

N / A

### What shouldn't be reviewed

N / A
