### PR TITLE
Strkey: validation methods

### DIFF
--- a/strkey/main.go
+++ b/strkey/main.go
@@ -161,3 +161,29 @@ func decodeString(src string) ([]byte, error) {
 
 	return raw, nil
 }
+
+// IsValidEd25519PublicKey validates a stellar public key
+func IsValidEd25519PublicKey(i interface{}) bool {
+	enc, ok := i.(string)
+
+	if !ok {
+		return false
+	}
+
+	_, err := Decode(VersionByteAccountID, enc)
+
+	return err == nil
+}
+
+// IsValidEd25519SecretSeed validates a stellar secret key
+func IsValidEd25519SecretSeed(i interface{}) bool {
+	enc, ok := i.(string)
+
+	if !ok {
+		return false
+	}
+
+	_, err := Decode(VersionByteSeed, enc)
+
+	return err == nil
+}

--- a/strkey/main_test.go
+++ b/strkey/main_test.go
@@ -59,6 +59,10 @@ func TestIsValidEd25519PublicKey(t *testing.T) {
 	invalidKey = ""
 	isValid = IsValidEd25519PublicKey(invalidKey)
 	assert.Equal(t, false, isValid)
+
+	invalidKey = "SBCVMMCBEDB64TVJZFYJOJAERZC4YVVUOE6SYR2Y76CBTENGUSGWRRVO"
+	isValid = IsValidEd25519PublicKey(invalidKey)
+	assert.Equal(t, false, isValid)
 }
 
 func TestIsValidEd25519SecretSeed(t *testing.T) {
@@ -71,6 +75,10 @@ func TestIsValidEd25519SecretSeed(t *testing.T) {
 	assert.Equal(t, false, isValid)
 
 	invalidKey = ""
+	isValid = IsValidEd25519SecretSeed(invalidKey)
+	assert.Equal(t, false, isValid)
+
+	invalidKey = "GDWZCOEQRODFCH6ISYQPWY67L3ULLWS5ISXYYL5GH43W7YFMTLB65PYM"
 	isValid = IsValidEd25519SecretSeed(invalidKey)
 	assert.Equal(t, false, isValid)
 }

--- a/strkey/main_test.go
+++ b/strkey/main_test.go
@@ -46,3 +46,31 @@ func TestVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestIsValidEd25519PublicKey(t *testing.T) {
+	validKey := "GDWZCOEQRODFCH6ISYQPWY67L3ULLWS5ISXYYL5GH43W7YFMTLB65PYM"
+	isValid := IsValidEd25519PublicKey(validKey)
+	assert.Equal(t, true, isValid)
+
+	invalidKey := "GDWZCOEQRODFCH6ISYQPWY67L3ULLWS5ISXYYL5GH43W7Y"
+	isValid = IsValidEd25519PublicKey(invalidKey)
+	assert.Equal(t, false, isValid)
+
+	invalidKey = ""
+	isValid = IsValidEd25519PublicKey(invalidKey)
+	assert.Equal(t, false, isValid)
+}
+
+func TestIsValidEd25519SecretSeed(t *testing.T) {
+	validKey := "SBCVMMCBEDB64TVJZFYJOJAERZC4YVVUOE6SYR2Y76CBTENGUSGWRRVO"
+	isValid := IsValidEd25519SecretSeed(validKey)
+	assert.Equal(t, true, isValid)
+
+	invalidKey := "SBCVMMCBEDB64TVJZFYJOJAERZC4YVVUOE6SYR2Y76CBTENGUSG"
+	isValid = IsValidEd25519SecretSeed(invalidKey)
+	assert.Equal(t, false, isValid)
+
+	invalidKey = ""
+	isValid = IsValidEd25519SecretSeed(invalidKey)
+	assert.Equal(t, false, isValid)
+}


### PR DESCRIPTION
This PR adds 2 methods to the `strkey` package for validating public and secret keys.

- `strkey.IsValidEd25519PublicKey`
- `strkey.IsValidEd25519SecretSeed`

Note: there are similar methods in `support/config` we should probably retire those?
Closes #1447 