### PR TITLE
services/horizon: Fix upgrade when database not empty

### DIFF
--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -163,7 +163,7 @@ func (s *System) Run() {
 			log.Info("Starting ingestion system from empty state...")
 
 			// Clear last_ingested_ledger in key value store
-			if err := s.historyQ.UpdateLastLedgerExpIngest(0); err != nil {
+			if err = s.historyQ.UpdateLastLedgerExpIngest(0); err != nil {
 				return errors.Wrap(err, "Error updating last ingested ledger")
 			}
 

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -162,6 +162,11 @@ func (s *System) Run() {
 			// In case of errors it will start `Run` from the beginning.
 			log.Info("Starting ingestion system from empty state...")
 
+			// Clear last_ingested_ledger in key value store
+			if err := s.historyQ.UpdateLastLedgerExpIngest(0); err != nil {
+				return errors.Wrap(err, "Error updating last ingested ledger")
+			}
+
 			err = s.historyQ.Session.TruncateTables(
 				history.ExperimentalIngestionTables,
 			)

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -198,7 +198,7 @@ func addPipelineHooks(
 				return errors.Wrap(err, "Error getting last ledger")
 			}
 
-			if lastIngestedLedger+1 != ledgerSeq {
+			if lastIngestedLedger != 0 && lastIngestedLedger+1 != ledgerSeq {
 				return errors.New("The local latest sequence is not equal to global sequence + 1")
 			}
 


### PR DESCRIPTION
This commit fixes a scenario when a state is cleared because of the ingestion system upgrade. In the pipelines post-processing hook we have an extra check to ensure that the ledger sequence of the last locally processed ledger is exactly +1 the the ledger sequence of the last processed ledger in a database. This fails for init state if there are some ledgers ingested because `LastLedgerExpIngest` was not reset during clearing state.