### PR TITLE
exp/services/horizon: Add path finding endpoint where source and destination are fixed

### DIFF
--- a/exp/orderbook/dfs.go
+++ b/exp/orderbook/dfs.go
@@ -1,0 +1,342 @@
+package orderbook
+
+import (
+	"github.com/stellar/go/price"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+// Path represents a payment path from a source asset to some destination asset
+type Path struct {
+	SourceAmount xdr.Int64
+	SourceAsset  xdr.Asset
+	// sourceAssetString is included as an optimization to improve the performance
+	// of sorting paths by avoiding serializing assets to strings repeatedly
+	sourceAssetString string
+	InteriorNodes     []xdr.Asset
+	DestinationAsset  xdr.Asset
+	DestinationAmount xdr.Int64
+}
+
+type searchState interface {
+	isTerminalNode(
+		currentAssetString string,
+		currentAsset xdr.Asset,
+		currentAssetAmount xdr.Int64,
+	) bool
+
+	appendToPaths(
+		updatedVisitedList []xdr.Asset,
+		currentAssetString string,
+		currentAsset xdr.Asset,
+		currentAssetAmount xdr.Int64,
+	)
+
+	edges(currentAssetString string) edgeSet
+
+	consumeOffers(
+		currentAssetAmount xdr.Int64,
+		offers []xdr.OfferEntry,
+	) (xdr.Asset, xdr.Int64, error)
+}
+
+func dfs(
+	state searchState,
+	maxPathLength int,
+	visited map[string]bool,
+	visitedList []xdr.Asset,
+	currentAssetString string,
+	currentAsset xdr.Asset,
+	currentAssetAmount xdr.Int64,
+) error {
+	if currentAssetAmount <= 0 {
+		return nil
+	}
+	if visited[currentAssetString] {
+		return nil
+	}
+	if len(visitedList) > maxPathLength {
+		return nil
+	}
+	visited[currentAssetString] = true
+	defer func() {
+		visited[currentAssetString] = false
+	}()
+
+	updatedVisitedList := append(visitedList, currentAsset)
+	if state.isTerminalNode(currentAssetString, currentAsset, currentAssetAmount) {
+		state.appendToPaths(
+			updatedVisitedList,
+			currentAssetString,
+			currentAsset,
+			currentAssetAmount,
+		)
+	}
+
+	for nextAssetString, offers := range state.edges(currentAssetString) {
+		if len(offers) == 0 {
+			continue
+		}
+
+		nextAsset, nextAssetAmount, err := state.consumeOffers(currentAssetAmount, offers)
+		if err != nil {
+			return err
+		}
+		if nextAssetAmount <= 0 {
+			continue
+		}
+
+		err = dfs(
+			state,
+			maxPathLength,
+			visited,
+			updatedVisitedList,
+			nextAssetString,
+			nextAsset,
+			nextAssetAmount,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// sellingGraphSearchState configures a DFS on the orderbook graph
+// where only edges in `graph.edgesForSellingAsset` are traversed.
+// The DFS maintains the following invariants:
+// no node is repeated
+// no offers are consumed from the `ignoreOffersFrom` account
+// each payment path must begin with an asset in `targetAssets`
+// also, the required source asset amount cannot exceed the balance in `targetAssets`
+type sellingGraphSearchState struct {
+	graph                  *OrderBookGraph
+	destinationAsset       xdr.Asset
+	destinationAssetAmount xdr.Int64
+	ignoreOffersFrom       xdr.AccountId
+	targetAssets           map[string]xdr.Int64
+	paths                  []Path
+}
+
+func (state *sellingGraphSearchState) isTerminalNode(
+	currentAssetString string,
+	currentAsset xdr.Asset,
+	currentAssetAmount xdr.Int64,
+) bool {
+	targetAssetBalance, ok := state.targetAssets[currentAssetString]
+	return ok && targetAssetBalance >= currentAssetAmount
+}
+
+func (state *sellingGraphSearchState) appendToPaths(
+	updatedVisitedList []xdr.Asset,
+	currentAssetString string,
+	currentAsset xdr.Asset,
+	currentAssetAmount xdr.Int64,
+) {
+	var interiorNodes []xdr.Asset
+	if len(updatedVisitedList) > 2 {
+		// reverse updatedVisitedList and skip the first and last elements
+		interiorNodes = make([]xdr.Asset, len(updatedVisitedList)-2)
+		position := 0
+		for i := len(updatedVisitedList) - 2; i >= 1; i-- {
+			interiorNodes[position] = updatedVisitedList[i]
+			position++
+		}
+	} else {
+		interiorNodes = []xdr.Asset{}
+	}
+
+	state.paths = append(state.paths, Path{
+		sourceAssetString: currentAssetString,
+		SourceAmount:      currentAssetAmount,
+		SourceAsset:       currentAsset,
+		InteriorNodes:     interiorNodes,
+		DestinationAsset:  state.destinationAsset,
+		DestinationAmount: state.destinationAssetAmount,
+	})
+}
+
+func (state *sellingGraphSearchState) edges(currentAssetString string) edgeSet {
+	return state.graph.edgesForSellingAsset[currentAssetString]
+}
+
+func (state *sellingGraphSearchState) consumeOffers(
+	currentAssetAmount xdr.Int64,
+	offers []xdr.OfferEntry,
+) (xdr.Asset, xdr.Int64, error) {
+	var nextAsset xdr.Asset
+	nextAmount, err := consumeOffersForSellingAsset(offers, state.ignoreOffersFrom, currentAssetAmount)
+	if err == nil {
+		nextAsset = offers[0].Buying
+	}
+
+	return nextAsset, nextAmount, err
+}
+
+// buyingGraphSearchState configures a DFS on the orderbook graph
+// where only edges in `graph.edgesForBuyingAsset` are traversed.
+// The DFS maintains the following invariants:
+// no node is repeated
+// no offers are consumed from the `ignoreOffersFrom` account
+// each payment path must terminate with an asset in `targetAssets`
+// each payment path must begin with `sourceAsset`
+type buyingGraphSearchState struct {
+	graph             *OrderBookGraph
+	sourceAsset       xdr.Asset
+	sourceAssetAmount xdr.Int64
+	ignoreOffersFrom  *xdr.AccountId
+	targetAssets      map[string]bool
+	paths             []Path
+}
+
+func (state *buyingGraphSearchState) isTerminalNode(
+	currentAssetString string,
+	currentAsset xdr.Asset,
+	currentAssetAmount xdr.Int64,
+) bool {
+	return state.targetAssets[currentAssetString]
+}
+
+func (state *buyingGraphSearchState) appendToPaths(
+	updatedVisitedList []xdr.Asset,
+	currentAssetString string,
+	currentAsset xdr.Asset,
+	currentAssetAmount xdr.Int64,
+) {
+	var interiorNodes []xdr.Asset
+	if len(updatedVisitedList) > 2 {
+		// skip the first and last elements
+		interiorNodes = make([]xdr.Asset, len(updatedVisitedList)-2)
+		copy(interiorNodes, updatedVisitedList[1:len(updatedVisitedList)-1])
+	} else {
+		interiorNodes = []xdr.Asset{}
+	}
+
+	state.paths = append(state.paths, Path{
+		SourceAmount:      state.sourceAssetAmount,
+		SourceAsset:       state.sourceAsset,
+		InteriorNodes:     interiorNodes,
+		DestinationAsset:  currentAsset,
+		DestinationAmount: currentAssetAmount,
+	})
+}
+
+func (state *buyingGraphSearchState) edges(currentAssetString string) edgeSet {
+	return state.graph.edgesForBuyingAsset[currentAssetString]
+}
+
+func (state *buyingGraphSearchState) consumeOffers(
+	currentAssetAmount xdr.Int64,
+	offers []xdr.OfferEntry,
+) (xdr.Asset, xdr.Int64, error) {
+	var nextAsset xdr.Asset
+	nextAmount, err := consumeOffersForBuyingAsset(offers, state.ignoreOffersFrom, currentAssetAmount)
+	if err == nil {
+		nextAsset = offers[0].Selling
+	}
+
+	return nextAsset, nextAmount, err
+}
+
+func consumeOffersForSellingAsset(
+	offers []xdr.OfferEntry,
+	ignoreOffersFrom xdr.AccountId,
+	currentAssetAmount xdr.Int64,
+) (xdr.Int64, error) {
+	totalConsumed := xdr.Int64(0)
+
+	if len(offers) == 0 {
+		return totalConsumed, errEmptyOffers
+	}
+
+	if currentAssetAmount == 0 {
+		return totalConsumed, errAssetAmountIsZero
+	}
+
+	for _, offer := range offers {
+		if offer.SellerId.Equals(ignoreOffersFrom) {
+			continue
+		}
+		if offer.Price.D == 0 {
+			return -1, errOfferPriceDenominatorIsZero
+		}
+
+		buyingUnitsFromOffer, sellingUnitsFromOffer, err := price.ConvertToBuyingUnits(
+			int64(offer.Amount),
+			int64(currentAssetAmount),
+			int64(offer.Price.N),
+			int64(offer.Price.D),
+		)
+		if err != nil {
+			return -1, errors.Wrap(err, "could not determine buying units")
+		}
+
+		totalConsumed += xdr.Int64(buyingUnitsFromOffer)
+		currentAssetAmount -= xdr.Int64(sellingUnitsFromOffer)
+
+		if currentAssetAmount <= 0 {
+			return totalConsumed, nil
+		}
+	}
+
+	return -1, nil
+}
+
+func consumeOffersForBuyingAsset(
+	offers []xdr.OfferEntry,
+	ignoreOffersFrom *xdr.AccountId,
+	currentAssetAmount xdr.Int64,
+) (xdr.Int64, error) {
+	totalConsumed := xdr.Int64(0)
+
+	if len(offers) == 0 {
+		return totalConsumed, errEmptyOffers
+	}
+
+	if currentAssetAmount == 0 {
+		return totalConsumed, errAssetAmountIsZero
+	}
+
+	for _, offer := range offers {
+		if ignoreOffersFrom != nil && ignoreOffersFrom.Equals(offer.SellerId) {
+			continue
+		}
+		if offer.Price.D == 0 {
+			return -1, errOfferPriceDenominatorIsZero
+		}
+
+		n := int64(offer.Price.N)
+		d := int64(offer.Price.D)
+
+		// check if we can spend all of currentAssetAmount on the current offer
+		// otherwise consume entire offer and move on to the next one
+		amountSold, err := price.MulFractionRoundDown(int64(currentAssetAmount), d, n)
+		if err != nil {
+			return -1, errors.Wrap(err, "could not determine selling units needed")
+		}
+		if amountSoldXDR := xdr.Int64(amountSold); amountSoldXDR <= offer.Amount {
+			totalConsumed += amountSoldXDR
+			return totalConsumed, nil
+		}
+
+		buyingUnitsFromOffer, sellingUnitsFromOffer, err := price.ConvertToBuyingUnits(
+			int64(offer.Amount),
+			int64(offer.Amount),
+			n,
+			d,
+		)
+		if err != nil {
+			return -1, errors.Wrap(err, "could not determine selling units")
+		}
+
+		totalConsumed += xdr.Int64(sellingUnitsFromOffer)
+		currentAssetAmount -= xdr.Int64(buyingUnitsFromOffer)
+
+		if currentAssetAmount <= 0 {
+			return totalConsumed, nil
+		}
+	}
+
+	return -1, nil
+}

--- a/exp/orderbook/dfs.go
+++ b/exp/orderbook/dfs.go
@@ -20,15 +20,13 @@ type Path struct {
 
 type searchState interface {
 	isTerminalNode(
-		currentAssetString string,
-		currentAsset xdr.Asset,
+		currentAsset string,
 		currentAssetAmount xdr.Int64,
 	) bool
 
 	appendToPaths(
 		updatedVisitedList []xdr.Asset,
-		currentAssetString string,
-		currentAsset xdr.Asset,
+		currentAsset string,
 		currentAssetAmount xdr.Int64,
 	)
 
@@ -64,11 +62,10 @@ func dfs(
 	}()
 
 	updatedVisitedList := append(visitedList, currentAsset)
-	if state.isTerminalNode(currentAssetString, currentAsset, currentAssetAmount) {
+	if state.isTerminalNode(currentAssetString, currentAssetAmount) {
 		state.appendToPaths(
 			updatedVisitedList,
 			currentAssetString,
-			currentAsset,
 			currentAssetAmount,
 		)
 	}
@@ -120,18 +117,16 @@ type sellingGraphSearchState struct {
 }
 
 func (state *sellingGraphSearchState) isTerminalNode(
-	currentAssetString string,
-	currentAsset xdr.Asset,
+	currentAsset string,
 	currentAssetAmount xdr.Int64,
 ) bool {
-	targetAssetBalance, ok := state.targetAssets[currentAssetString]
+	targetAssetBalance, ok := state.targetAssets[currentAsset]
 	return ok && targetAssetBalance >= currentAssetAmount
 }
 
 func (state *sellingGraphSearchState) appendToPaths(
 	updatedVisitedList []xdr.Asset,
-	currentAssetString string,
-	currentAsset xdr.Asset,
+	currentAsset string,
 	currentAssetAmount xdr.Int64,
 ) {
 	var interiorNodes []xdr.Asset
@@ -148,9 +143,9 @@ func (state *sellingGraphSearchState) appendToPaths(
 	}
 
 	state.paths = append(state.paths, Path{
-		sourceAssetString: currentAssetString,
+		sourceAssetString: currentAsset,
 		SourceAmount:      currentAssetAmount,
-		SourceAsset:       currentAsset,
+		SourceAsset:       updatedVisitedList[len(updatedVisitedList)-1],
 		InteriorNodes:     interiorNodes,
 		DestinationAsset:  state.destinationAsset,
 		DestinationAmount: state.destinationAssetAmount,
@@ -191,17 +186,15 @@ type buyingGraphSearchState struct {
 }
 
 func (state *buyingGraphSearchState) isTerminalNode(
-	currentAssetString string,
-	currentAsset xdr.Asset,
+	currentAsset string,
 	currentAssetAmount xdr.Int64,
 ) bool {
-	return state.targetAssets[currentAssetString]
+	return state.targetAssets[currentAsset]
 }
 
 func (state *buyingGraphSearchState) appendToPaths(
 	updatedVisitedList []xdr.Asset,
-	currentAssetString string,
-	currentAsset xdr.Asset,
+	currentAsset string,
 	currentAssetAmount xdr.Int64,
 ) {
 	var interiorNodes []xdr.Asset
@@ -217,13 +210,13 @@ func (state *buyingGraphSearchState) appendToPaths(
 		SourceAmount:      state.sourceAssetAmount,
 		SourceAsset:       state.sourceAsset,
 		InteriorNodes:     interiorNodes,
-		DestinationAsset:  currentAsset,
+		DestinationAsset:  updatedVisitedList[len(updatedVisitedList)-1],
 		DestinationAmount: currentAssetAmount,
 	})
 }
 
-func (state *buyingGraphSearchState) edges(currentAssetString string) edgeSet {
-	return state.graph.edgesForBuyingAsset[currentAssetString]
+func (state *buyingGraphSearchState) edges(currentAsset string) edgeSet {
+	return state.graph.edgesForBuyingAsset[currentAsset]
 }
 
 func (state *buyingGraphSearchState) consumeOffers(

--- a/exp/orderbook/edges.go
+++ b/exp/orderbook/edges.go
@@ -7,19 +7,17 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-// edgeSet maps an asset to all offers which buy that asset
-// note that each key in the map is obtained by calling offer.Buying.String()
-// also, the offers are sorted by price (in terms of the buying asset)
+// edgeSet maintains a maping of strings to sorted lists of offers.
+// The offers are sorted by price (in terms of the buying asset)
 // from cheapest to expensive
 type edgeSet map[string][]xdr.OfferEntry
 
 // add will insert the given offer into the edge set
-func (e edgeSet) add(offer xdr.OfferEntry) {
-	buyingAsset := offer.Buying.String()
+func (e edgeSet) add(key string, offer xdr.OfferEntry) {
 	// offers is sorted by cheapest to most expensive price to convert buyingAsset to sellingAsset
-	offers := e[buyingAsset]
+	offers := e[key]
 	if len(offers) == 0 {
-		e[buyingAsset] = []xdr.OfferEntry{offer}
+		e[key] = []xdr.OfferEntry{offer}
 		return
 	}
 
@@ -35,13 +33,12 @@ func (e edgeSet) add(offer xdr.OfferEntry) {
 		offers[insertIndex], offers[last] = offers[last], offers[insertIndex]
 		insertIndex++
 	}
-	e[buyingAsset] = offers
+	e[key] = offers
 }
 
 // remove will delete the given offer from the edge set
-// buyingAsset is obtained by calling offer.Buying.String()
-func (e edgeSet) remove(offerID xdr.Int64, buyingAsset string) bool {
-	edges := e[buyingAsset]
+func (e edgeSet) remove(offerID xdr.Int64, key string) bool {
+	edges := e[key]
 	if len(edges) == 0 {
 		return false
 	}
@@ -60,9 +57,9 @@ func (e edgeSet) remove(offerID xdr.Int64, buyingAsset string) bool {
 	}
 	if contains {
 		if len(edges) == 0 {
-			delete(e, buyingAsset)
+			delete(e, key)
 		} else {
-			e[buyingAsset] = edges
+			e[key] = edges
 		}
 	}
 

--- a/exp/orderbook/graph.go
+++ b/exp/orderbook/graph.go
@@ -31,6 +31,10 @@ type OrderBookGraph struct {
 	// note that each key in the map is obtained by calling offer.Selling.String()
 	// where offer is an xdr.OfferEntry
 	edgesForSellingAsset map[string]edgeSet
+	// edgesForBuyingAsset maps an asset to all offers which buy that asset
+	// note that each key in the map is obtained by calling offer.Buying.String()
+	// where offer is an xdr.OfferEntry
+	edgesForBuyingAsset map[string]edgeSet
 	// tradingPairForOffer maps an offer id to the assets which are being exchanged
 	// in the given offer
 	tradingPairForOffer map[xdr.Int64]tradingPair
@@ -45,6 +49,7 @@ type OrderBookGraph struct {
 func NewOrderBookGraph() *OrderBookGraph {
 	graph := &OrderBookGraph{
 		edgesForSellingAsset: map[string]edgeSet{},
+		edgesForBuyingAsset:  map[string]edgeSet{},
 		tradingPairForOffer:  map[xdr.Int64]tradingPair{},
 	}
 
@@ -118,15 +123,23 @@ func (graph *OrderBookGraph) add(offer xdr.OfferEntry) error {
 	}
 
 	sellingAsset := offer.Selling.String()
+	buyingAsset := offer.Buying.String()
 	graph.tradingPairForOffer[offer.OfferId] = tradingPair{
-		buyingAsset:  offer.Buying.String(),
+		buyingAsset:  buyingAsset,
 		sellingAsset: sellingAsset,
 	}
 	if set, ok := graph.edgesForSellingAsset[sellingAsset]; !ok {
 		graph.edgesForSellingAsset[sellingAsset] = edgeSet{}
-		graph.edgesForSellingAsset[sellingAsset].add(offer)
+		graph.edgesForSellingAsset[sellingAsset].add(buyingAsset, offer)
 	} else {
-		set.add(offer)
+		set.add(buyingAsset, offer)
+	}
+
+	if set, ok := graph.edgesForBuyingAsset[buyingAsset]; !ok {
+		graph.edgesForBuyingAsset[buyingAsset] = edgeSet{}
+		graph.edgesForBuyingAsset[buyingAsset].add(sellingAsset, offer)
+	} else {
+		set.add(sellingAsset, offer)
 	}
 
 	return nil
@@ -147,6 +160,14 @@ func (graph *OrderBookGraph) remove(offerID xdr.Int64) error {
 		return errOfferNotPresent
 	} else if len(set) == 0 {
 		delete(graph.edgesForSellingAsset, pair.sellingAsset)
+	}
+
+	if set, ok := graph.edgesForBuyingAsset[pair.buyingAsset]; !ok {
+		return errOfferNotPresent
+	} else if !set.remove(offerID, pair.sellingAsset) {
+		return errOfferNotPresent
+	} else if len(set) == 0 {
+		delete(graph.edgesForBuyingAsset, pair.buyingAsset)
 	}
 
 	return nil
@@ -170,7 +191,7 @@ type Path struct {
 // no offers are consumed from the `ignoreOffersFrom` account
 // each payment path must originate with an asset in `targetAssets`
 // also, the required source asset amount cannot exceed the balance in `targetAssets`
-func (graph *OrderBookGraph) findPaths(
+func (graph *OrderBookGraph) findPathsEndingAt(
 	maxPathLength int,
 	visited map[string]bool,
 	visitedList []xdr.Asset,
@@ -231,7 +252,7 @@ func (graph *OrderBookGraph) findPaths(
 		if len(offers) == 0 {
 			continue
 		}
-		nextAssetAmount, err := consumeOffers(offers, ignoreOffersFrom, currentAssetAmount)
+		nextAssetAmount, err := consumeOffersForSellingAsset(offers, ignoreOffersFrom, currentAssetAmount)
 		if err != nil {
 			return nil, err
 		}
@@ -240,7 +261,7 @@ func (graph *OrderBookGraph) findPaths(
 		}
 
 		nextAsset := offers[0].Buying
-		paths, err = graph.findPaths(
+		paths, err = graph.findPathsEndingAt(
 			maxPathLength,
 			visited,
 			updatedVisitedList,
@@ -249,6 +270,92 @@ func (graph *OrderBookGraph) findPaths(
 			nextAssetAmount,
 			destinationAsset,
 			destinationAssetAmount,
+			ignoreOffersFrom,
+			targetAssets,
+			paths,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return paths, nil
+}
+
+func (graph *OrderBookGraph) findPathsStartingAt(
+	maxPathLength int,
+	visited map[string]bool,
+	visitedList []xdr.Asset,
+	currentAssetString string,
+	currentAsset xdr.Asset,
+	currentAssetAmount xdr.Int64,
+	sourceAsset xdr.Asset,
+	sourceAssetAmount xdr.Int64,
+	ignoreOffersFrom *xdr.AccountId,
+	targetAssets map[string]bool,
+	paths []Path,
+) ([]Path, error) {
+	if currentAssetAmount <= 0 {
+		return paths, nil
+	}
+	if visited[currentAssetString] {
+		return paths, nil
+	}
+	if len(visitedList) > maxPathLength {
+		return paths, nil
+	}
+	visited[currentAssetString] = true
+	defer func() {
+		visited[currentAssetString] = false
+	}()
+
+	updatedVisitedList := append(visitedList, currentAsset)
+	if targetAssets[currentAssetString] {
+		var interiorNodes []xdr.Asset
+		if len(updatedVisitedList) > 2 {
+			// skip the first and last elements
+			interiorNodes = make([]xdr.Asset, len(updatedVisitedList)-2)
+			copy(interiorNodes, updatedVisitedList[1:len(updatedVisitedList)-1])
+		} else {
+			interiorNodes = []xdr.Asset{}
+		}
+
+		paths = append(paths, Path{
+			SourceAmount:      sourceAssetAmount,
+			SourceAsset:       sourceAsset,
+			InteriorNodes:     interiorNodes,
+			DestinationAsset:  currentAsset,
+			DestinationAmount: currentAssetAmount,
+		})
+	}
+
+	edges, ok := graph.edgesForBuyingAsset[currentAssetString]
+	if !ok {
+		return paths, nil
+	}
+
+	for nextAssetString, offers := range edges {
+		if len(offers) == 0 {
+			continue
+		}
+		nextAssetAmount, err := consumeOffersForBuyingAsset(offers, ignoreOffersFrom, currentAssetAmount)
+		if err != nil {
+			return nil, err
+		}
+		if nextAssetAmount <= 0 {
+			continue
+		}
+
+		nextAsset := offers[0].Selling
+		paths, err = graph.findPathsStartingAt(
+			maxPathLength,
+			visited,
+			updatedVisitedList,
+			nextAssetString,
+			nextAsset,
+			nextAssetAmount,
+			sourceAsset,
+			sourceAssetAmount,
 			ignoreOffersFrom,
 			targetAssets,
 			paths,
@@ -288,7 +395,7 @@ func (graph *OrderBookGraph) FindPaths(
 	}
 
 	graph.lock.RLock()
-	allPaths, err := graph.findPaths(
+	allPaths, err := graph.findPathsEndingAt(
 		maxPathLength,
 		map[string]bool{},
 		[]xdr.Asset{},
@@ -312,7 +419,48 @@ func (graph *OrderBookGraph) FindPaths(
 	), nil
 }
 
-func consumeOffers(
+// FindFixedPaths returns a list of payment paths where the source and destination
+// assets are fixed. All returned payment paths will start by spending `amountToSpend`
+// of `sourceAsset` and will end with some positive balance of `destinationAsset`.
+// `sourceAccountID` is optional. if `sourceAccountID` is provided then no offers
+// created by `sourceAccountID` will be considered when evaluating payment paths
+func (graph *OrderBookGraph) FindFixedPaths(
+	maxPathLength int,
+	sourceAccountID *xdr.AccountId,
+	sourceAsset xdr.Asset,
+	amountToSpend xdr.Int64,
+	destinationAsset xdr.Asset,
+) ([]Path, error) {
+	destinationAssetString := destinationAsset.String()
+	target := map[string]bool{destinationAssetString: true}
+
+	graph.lock.RLock()
+	allPaths, err := graph.findPathsStartingAt(
+		maxPathLength,
+		map[string]bool{},
+		[]xdr.Asset{},
+		sourceAsset.String(),
+		sourceAsset,
+		amountToSpend,
+		sourceAsset,
+		amountToSpend,
+		sourceAccountID,
+		target,
+		[]Path{},
+	)
+	graph.lock.RUnlock()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not determine paths")
+	}
+
+	sort.Slice(allPaths, func(i, j int) bool {
+		return allPaths[i].DestinationAmount > allPaths[j].DestinationAmount
+	})
+
+	return allPaths, nil
+}
+
+func consumeOffersForSellingAsset(
 	offers []xdr.OfferEntry,
 	ignoreOffersFrom xdr.AccountId,
 	currentAssetAmount xdr.Int64,
@@ -347,6 +495,64 @@ func consumeOffers(
 
 		totalConsumed += xdr.Int64(buyingUnitsFromOffer)
 		currentAssetAmount -= xdr.Int64(sellingUnitsFromOffer)
+
+		if currentAssetAmount <= 0 {
+			return totalConsumed, nil
+		}
+	}
+
+	return -1, nil
+}
+
+func consumeOffersForBuyingAsset(
+	offers []xdr.OfferEntry,
+	ignoreOffersFrom *xdr.AccountId,
+	currentAssetAmount xdr.Int64,
+) (xdr.Int64, error) {
+	totalConsumed := xdr.Int64(0)
+
+	if len(offers) == 0 {
+		return totalConsumed, errEmptyOffers
+	}
+
+	if currentAssetAmount == 0 {
+		return totalConsumed, errAssetAmountIsZero
+	}
+
+	for _, offer := range offers {
+		if ignoreOffersFrom != nil && ignoreOffersFrom.Equals(offer.SellerId) {
+			continue
+		}
+		if offer.Price.D == 0 {
+			return -1, errOfferPriceDenominatorIsZero
+		}
+
+		n := int64(offer.Price.N)
+		d := int64(offer.Price.D)
+
+		// check if we can spend all of currentAssetAmount on the current offer
+		// otherwise consume entire offer and move on to the next one
+		amountSold, err := price.MulFractionRoundDown(int64(currentAssetAmount), d, n)
+		if err != nil {
+			return -1, errors.Wrap(err, "could not determine selling units needed")
+		}
+		if amountSoldXDR := xdr.Int64(amountSold); amountSoldXDR <= offer.Amount {
+			totalConsumed += amountSoldXDR
+			return totalConsumed, nil
+		}
+
+		buyingUnitsFromOffer, sellingUnitsFromOffer, err := price.ConvertToBuyingUnits(
+			int64(offer.Amount),
+			int64(offer.Amount),
+			n,
+			d,
+		)
+		if err != nil {
+			return -1, errors.Wrap(err, "could not determine selling units")
+		}
+
+		totalConsumed += xdr.Int64(sellingUnitsFromOffer)
+		currentAssetAmount -= xdr.Int64(buyingUnitsFromOffer)
 
 		if currentAssetAmount <= 0 {
 			return totalConsumed, nil

--- a/exp/orderbook/graph.go
+++ b/exp/orderbook/graph.go
@@ -4,7 +4,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/stellar/go/price"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -173,201 +172,6 @@ func (graph *OrderBookGraph) remove(offerID xdr.Int64) error {
 	return nil
 }
 
-// Path represents a payment path from a source asset to some destination asset
-type Path struct {
-	SourceAmount xdr.Int64
-	SourceAsset  xdr.Asset
-	// sourceAssetString is included as an optimization to improve the performance
-	// of sorting paths by avoiding serializing assets to strings repeatedly
-	sourceAssetString string
-	InteriorNodes     []xdr.Asset
-	DestinationAsset  xdr.Asset
-	DestinationAmount xdr.Int64
-}
-
-// findPaths performs a DFS of maxPathLength depth
-// the DFS maintains the following invariants:
-// no node is repeated
-// no offers are consumed from the `ignoreOffersFrom` account
-// each payment path must originate with an asset in `targetAssets`
-// also, the required source asset amount cannot exceed the balance in `targetAssets`
-func (graph *OrderBookGraph) findPathsEndingAt(
-	maxPathLength int,
-	visited map[string]bool,
-	visitedList []xdr.Asset,
-	currentAssetString string,
-	currentAsset xdr.Asset,
-	currentAssetAmount xdr.Int64,
-	destinationAsset xdr.Asset,
-	destinationAssetAmount xdr.Int64,
-	ignoreOffersFrom xdr.AccountId,
-	targetAssets map[string]xdr.Int64,
-	paths []Path,
-) ([]Path, error) {
-	if currentAssetAmount <= 0 {
-		return paths, nil
-	}
-	if visited[currentAssetString] {
-		return paths, nil
-	}
-	if len(visitedList) > maxPathLength {
-		return paths, nil
-	}
-	visited[currentAssetString] = true
-	defer func() {
-		visited[currentAssetString] = false
-	}()
-
-	updatedVisitedList := append(visitedList, currentAsset)
-	if targetAssetBalance, ok := targetAssets[currentAssetString]; ok && targetAssetBalance >= currentAssetAmount {
-		var interiorNodes []xdr.Asset
-		if len(updatedVisitedList) > 2 {
-			// reverse updatedVisitedList and skip the first and last elements
-			interiorNodes = make([]xdr.Asset, len(updatedVisitedList)-2)
-			position := 0
-			for i := len(updatedVisitedList) - 2; i >= 1; i-- {
-				interiorNodes[position] = updatedVisitedList[i]
-				position++
-			}
-		} else {
-			interiorNodes = []xdr.Asset{}
-		}
-
-		paths = append(paths, Path{
-			sourceAssetString: currentAssetString,
-			SourceAmount:      currentAssetAmount,
-			SourceAsset:       currentAsset,
-			InteriorNodes:     interiorNodes,
-			DestinationAsset:  destinationAsset,
-			DestinationAmount: destinationAssetAmount,
-		})
-	}
-
-	edges, ok := graph.edgesForSellingAsset[currentAssetString]
-	if !ok {
-		return paths, nil
-	}
-
-	for nextAssetString, offers := range edges {
-		if len(offers) == 0 {
-			continue
-		}
-		nextAssetAmount, err := consumeOffersForSellingAsset(offers, ignoreOffersFrom, currentAssetAmount)
-		if err != nil {
-			return nil, err
-		}
-		if nextAssetAmount <= 0 {
-			continue
-		}
-
-		nextAsset := offers[0].Buying
-		paths, err = graph.findPathsEndingAt(
-			maxPathLength,
-			visited,
-			updatedVisitedList,
-			nextAssetString,
-			nextAsset,
-			nextAssetAmount,
-			destinationAsset,
-			destinationAssetAmount,
-			ignoreOffersFrom,
-			targetAssets,
-			paths,
-		)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return paths, nil
-}
-
-func (graph *OrderBookGraph) findPathsStartingAt(
-	maxPathLength int,
-	visited map[string]bool,
-	visitedList []xdr.Asset,
-	currentAssetString string,
-	currentAsset xdr.Asset,
-	currentAssetAmount xdr.Int64,
-	sourceAsset xdr.Asset,
-	sourceAssetAmount xdr.Int64,
-	ignoreOffersFrom *xdr.AccountId,
-	targetAssets map[string]bool,
-	paths []Path,
-) ([]Path, error) {
-	if currentAssetAmount <= 0 {
-		return paths, nil
-	}
-	if visited[currentAssetString] {
-		return paths, nil
-	}
-	if len(visitedList) > maxPathLength {
-		return paths, nil
-	}
-	visited[currentAssetString] = true
-	defer func() {
-		visited[currentAssetString] = false
-	}()
-
-	updatedVisitedList := append(visitedList, currentAsset)
-	if targetAssets[currentAssetString] {
-		var interiorNodes []xdr.Asset
-		if len(updatedVisitedList) > 2 {
-			// skip the first and last elements
-			interiorNodes = make([]xdr.Asset, len(updatedVisitedList)-2)
-			copy(interiorNodes, updatedVisitedList[1:len(updatedVisitedList)-1])
-		} else {
-			interiorNodes = []xdr.Asset{}
-		}
-
-		paths = append(paths, Path{
-			SourceAmount:      sourceAssetAmount,
-			SourceAsset:       sourceAsset,
-			InteriorNodes:     interiorNodes,
-			DestinationAsset:  currentAsset,
-			DestinationAmount: currentAssetAmount,
-		})
-	}
-
-	edges, ok := graph.edgesForBuyingAsset[currentAssetString]
-	if !ok {
-		return paths, nil
-	}
-
-	for nextAssetString, offers := range edges {
-		if len(offers) == 0 {
-			continue
-		}
-		nextAssetAmount, err := consumeOffersForBuyingAsset(offers, ignoreOffersFrom, currentAssetAmount)
-		if err != nil {
-			return nil, err
-		}
-		if nextAssetAmount <= 0 {
-			continue
-		}
-
-		nextAsset := offers[0].Selling
-		paths, err = graph.findPathsStartingAt(
-			maxPathLength,
-			visited,
-			updatedVisitedList,
-			nextAssetString,
-			nextAsset,
-			nextAssetAmount,
-			sourceAsset,
-			sourceAssetAmount,
-			ignoreOffersFrom,
-			targetAssets,
-			paths,
-		)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return paths, nil
-}
-
 // IsEmpty returns true if the orderbook graph is not populated
 func (graph *OrderBookGraph) IsEmpty() bool {
 	graph.lock.RLock()
@@ -394,19 +198,23 @@ func (graph *OrderBookGraph) FindPaths(
 		sourceAssetsMap[sourceAssetString] = sourceAssetBalances[i]
 	}
 
+	searchState := &sellingGraphSearchState{
+		graph:                  graph,
+		destinationAsset:       destinationAsset,
+		destinationAssetAmount: destinationAmount,
+		ignoreOffersFrom:       sourceAccountID,
+		targetAssets:           sourceAssetsMap,
+		paths:                  []Path{},
+	}
 	graph.lock.RLock()
-	allPaths, err := graph.findPathsEndingAt(
+	err := dfs(
+		searchState,
 		maxPathLength,
 		map[string]bool{},
 		[]xdr.Asset{},
 		destinationAssetString,
 		destinationAsset,
 		destinationAmount,
-		destinationAsset,
-		destinationAmount,
-		sourceAccountID,
-		sourceAssetsMap,
-		[]Path{},
 	)
 	graph.lock.RUnlock()
 	if err != nil {
@@ -414,7 +222,7 @@ func (graph *OrderBookGraph) FindPaths(
 	}
 
 	return sortAndFilterPaths(
-		allPaths,
+		searchState.paths,
 		maxAssetsPerPath,
 	), nil
 }
@@ -434,132 +242,34 @@ func (graph *OrderBookGraph) FindFixedPaths(
 	destinationAssetString := destinationAsset.String()
 	target := map[string]bool{destinationAssetString: true}
 
+	searchState := &buyingGraphSearchState{
+		graph:             graph,
+		sourceAsset:       sourceAsset,
+		sourceAssetAmount: amountToSpend,
+		ignoreOffersFrom:  sourceAccountID,
+		targetAssets:      target,
+		paths:             []Path{},
+	}
 	graph.lock.RLock()
-	allPaths, err := graph.findPathsStartingAt(
+	err := dfs(
+		searchState,
 		maxPathLength,
 		map[string]bool{},
 		[]xdr.Asset{},
 		sourceAsset.String(),
 		sourceAsset,
 		amountToSpend,
-		sourceAsset,
-		amountToSpend,
-		sourceAccountID,
-		target,
-		[]Path{},
 	)
 	graph.lock.RUnlock()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not determine paths")
 	}
 
-	sort.Slice(allPaths, func(i, j int) bool {
-		return allPaths[i].DestinationAmount > allPaths[j].DestinationAmount
+	sort.Slice(searchState.paths, func(i, j int) bool {
+		return searchState.paths[i].DestinationAmount > searchState.paths[j].DestinationAmount
 	})
 
-	return allPaths, nil
-}
-
-func consumeOffersForSellingAsset(
-	offers []xdr.OfferEntry,
-	ignoreOffersFrom xdr.AccountId,
-	currentAssetAmount xdr.Int64,
-) (xdr.Int64, error) {
-	totalConsumed := xdr.Int64(0)
-
-	if len(offers) == 0 {
-		return totalConsumed, errEmptyOffers
-	}
-
-	if currentAssetAmount == 0 {
-		return totalConsumed, errAssetAmountIsZero
-	}
-
-	for _, offer := range offers {
-		if offer.SellerId.Equals(ignoreOffersFrom) {
-			continue
-		}
-		if offer.Price.D == 0 {
-			return -1, errOfferPriceDenominatorIsZero
-		}
-
-		buyingUnitsFromOffer, sellingUnitsFromOffer, err := price.ConvertToBuyingUnits(
-			int64(offer.Amount),
-			int64(currentAssetAmount),
-			int64(offer.Price.N),
-			int64(offer.Price.D),
-		)
-		if err != nil {
-			return -1, errors.Wrap(err, "could not determine buying units")
-		}
-
-		totalConsumed += xdr.Int64(buyingUnitsFromOffer)
-		currentAssetAmount -= xdr.Int64(sellingUnitsFromOffer)
-
-		if currentAssetAmount <= 0 {
-			return totalConsumed, nil
-		}
-	}
-
-	return -1, nil
-}
-
-func consumeOffersForBuyingAsset(
-	offers []xdr.OfferEntry,
-	ignoreOffersFrom *xdr.AccountId,
-	currentAssetAmount xdr.Int64,
-) (xdr.Int64, error) {
-	totalConsumed := xdr.Int64(0)
-
-	if len(offers) == 0 {
-		return totalConsumed, errEmptyOffers
-	}
-
-	if currentAssetAmount == 0 {
-		return totalConsumed, errAssetAmountIsZero
-	}
-
-	for _, offer := range offers {
-		if ignoreOffersFrom != nil && ignoreOffersFrom.Equals(offer.SellerId) {
-			continue
-		}
-		if offer.Price.D == 0 {
-			return -1, errOfferPriceDenominatorIsZero
-		}
-
-		n := int64(offer.Price.N)
-		d := int64(offer.Price.D)
-
-		// check if we can spend all of currentAssetAmount on the current offer
-		// otherwise consume entire offer and move on to the next one
-		amountSold, err := price.MulFractionRoundDown(int64(currentAssetAmount), d, n)
-		if err != nil {
-			return -1, errors.Wrap(err, "could not determine selling units needed")
-		}
-		if amountSoldXDR := xdr.Int64(amountSold); amountSoldXDR <= offer.Amount {
-			totalConsumed += amountSoldXDR
-			return totalConsumed, nil
-		}
-
-		buyingUnitsFromOffer, sellingUnitsFromOffer, err := price.ConvertToBuyingUnits(
-			int64(offer.Amount),
-			int64(offer.Amount),
-			n,
-			d,
-		)
-		if err != nil {
-			return -1, errors.Wrap(err, "could not determine selling units")
-		}
-
-		totalConsumed += xdr.Int64(sellingUnitsFromOffer)
-		currentAssetAmount -= xdr.Int64(buyingUnitsFromOffer)
-
-		if currentAssetAmount <= 0 {
-			return totalConsumed, nil
-		}
-	}
-
-	return -1, nil
+	return searchState.paths, nil
 }
 
 // sortAndFilterPaths sorts the given list of paths by

--- a/price/main.go
+++ b/price/main.go
@@ -134,7 +134,7 @@ func ConvertToBuyingUnits(sellingOfferAmount int64, sellingUnitsNeeded int64, pr
 	// offerSellingBound
 	result := sellingOfferAmount
 	if pricen <= priced {
-		result, e = mulFractionRoundDown(sellingOfferAmount, pricen, priced)
+		result, e = MulFractionRoundDown(sellingOfferAmount, pricen, priced)
 		if e != nil {
 			return 0, 0, e
 		}
@@ -157,9 +157,9 @@ func ConvertToBuyingUnits(sellingOfferAmount int64, sellingUnitsNeeded int64, pr
 	return result, sellingUnitsExtracted, nil
 }
 
-// mulFractionRoundDown sets x = (x * n) / d, which is a round-down operation
+// MulFractionRoundDown sets x = (x * n) / d, which is a round-down operation
 // see https://github.com/stellar/stellar-core/blob/9af27ef4e20b66f38ab148d52ba7904e74fe502f/src/util/types.cpp#L201
-func mulFractionRoundDown(x int64, n int64, d int64) (int64, error) {
+func MulFractionRoundDown(x int64, n int64, d int64) (int64, error) {
 	var bn, bd big.Int
 	bn.SetInt64(n)
 	bd.SetInt64(d)

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -15,9 +15,9 @@ bumps.  A breaking change will get clearly notified in this log.
 ### Changes
 
 * Experimental ingestion system is now run concurrently on all Horizon servers (with feature flag set - see below). This improves ingestion availability.
-* Add experimental path finding endpoint which uses an in memory order book for improved performance. To enable it set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable. Note that the `enable-experimental-ingestion` flag enables both the new path finding endpoint and the accounts for signer endpoint.
+* Add experimental path finding endpoints which use an in memory order book for improved performance. To enable the endpoints set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable. Note that the `enable-experimental-ingestion` flag enables both the new path finding endpoints and the accounts for signer endpoint. There are two path finding endpoints. `/paths/strict-send` returns payment paths where both the source and destination assets are fixed. This endpoint is able to answer questions like: "Get me the most EUR possible for my 10 USD." `/paths/strict-receive` is the other endpoint which is an alias to the existing `/paths` endpoint. 
 * `--enable-accounts-for-signer` CLI param or `ENABLE_ACCOUNTS_FOR_SIGNER=true` env variable are merged with `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
-Add experimental get offers by id endpoint`/offers/{id}` which uses the new ingestion system to fill up the offers table. To enable it, set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
+* Add experimental get offers by id endpoint`/offers/{id}` which uses the new ingestion system to fill up the offers table. To enable it, set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
 
 ## v0.19.0
 

--- a/services/horizon/internal/actions_fixed_path.go
+++ b/services/horizon/internal/actions_fixed_path.go
@@ -1,0 +1,77 @@
+package horizon
+
+import (
+	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/actions"
+	"github.com/stellar/go/services/horizon/internal/paths"
+	"github.com/stellar/go/services/horizon/internal/render/problem"
+	"github.com/stellar/go/services/horizon/internal/resourceadapter"
+	"github.com/stellar/go/services/horizon/internal/simplepath"
+	"github.com/stellar/go/support/render/hal"
+	"github.com/stellar/go/xdr"
+)
+
+// Interface verification
+var _ actions.JSONer = (*FixedPathIndexAction)(nil)
+
+// FixedPathIndexAction provides path finding where the source asset and destination asset is fixed
+type FixedPathIndexAction struct {
+	Action
+
+	sourceAccount    *xdr.AccountId
+	sourceAsset      xdr.Asset
+	amountToSpend    xdr.Int64
+	destinationAsset xdr.Asset
+
+	Records []paths.Path
+	Page    hal.BasePage
+}
+
+// JSON implements actions.JSON
+func (action *FixedPathIndexAction) JSON() error {
+	action.Do(
+		action.loadQuery,
+		action.loadRecords,
+		action.loadPage,
+		func() { hal.Render(action.W, action.Page) },
+	)
+	return action.Err
+}
+
+func (action *FixedPathIndexAction) loadQuery() {
+	if action.Base.GetString("source_account") != "" {
+		accountID := action.Base.GetAccountID("source_account")
+		action.sourceAccount = &accountID
+	} else {
+		action.sourceAccount = nil
+	}
+	action.destinationAsset = action.GetAsset("destination_")
+	action.sourceAsset = action.GetAsset("source_")
+	action.amountToSpend = action.GetPositiveAmount("source_amount")
+}
+
+func (action *FixedPathIndexAction) loadRecords() {
+	action.Records, action.Err = action.App.paths.FindFixedPaths(
+		action.sourceAccount,
+		action.sourceAsset,
+		action.amountToSpend,
+		action.destinationAsset,
+		action.App.config.MaxPathLength,
+	)
+	if action.Err == simplepath.ErrEmptyInMemoryOrderBook {
+		action.Err = problem.StillIngesting
+	}
+}
+
+func (action *FixedPathIndexAction) loadPage() {
+	action.Page.Init()
+	for _, p := range action.Records {
+		var res horizon.Path
+		action.Err = resourceadapter.PopulatePath(action.R.Context(), &res, p)
+
+		if action.Err != nil {
+			return
+		}
+		action.Page.Add(res)
+	}
+}

--- a/services/horizon/internal/actions_path.go
+++ b/services/horizon/internal/actions_path.go
@@ -56,7 +56,7 @@ func (action *PathIndexAction) loadPage() {
 	action.Page.Init()
 	for _, p := range action.Records {
 		var res horizon.Path
-		action.Err = resourceadapter.PopulatePath(action.R.Context(), &res, action.Query, p)
+		action.Err = resourceadapter.PopulatePath(action.R.Context(), &res, p)
 
 		if action.Err != nil {
 			return

--- a/services/horizon/internal/main_generated.go
+++ b/services/horizon/internal/main_generated.go
@@ -22,6 +22,12 @@ func (action EffectIndexAction) Handle(w http.ResponseWriter, r *http.Request) {
 	ap.Execute(&action)
 }
 
+func (action FixedPathIndexAction) Handle(w http.ResponseWriter, r *http.Request) {
+	ap := &action.Action
+	ap.Prepare(w, r)
+	ap.Execute(&action)
+}
+
 func (action LedgerIndexAction) Handle(w http.ResponseWriter, r *http.Request) {
 	ap := &action.Action
 	ap.Prepare(w, r)

--- a/services/horizon/internal/paths/main.go
+++ b/services/horizon/internal/paths/main.go
@@ -15,15 +15,25 @@ type Query struct {
 
 // Path is the result returned by a path finder and is tied to the DestinationAmount used in the input query
 type Path struct {
-	Path        []xdr.Asset
-	Source      xdr.Asset
-	Destination xdr.Asset
-	// represents the source assets to be used as `sendMax` field for a `PathPaymentOp` struct
-	Cost xdr.Int64
+	Path              []xdr.Asset
+	Source            xdr.Asset
+	SourceAmount      xdr.Int64
+	Destination       xdr.Asset
+	DestinationAmount xdr.Int64
 }
 
 // Finder finds paths.
 type Finder interface {
 	// Returns path for a Query of a maximum length `maxLength`
 	Find(q Query, maxLength uint) ([]Path, error)
+	// FindFixedPaths return a list of payment paths each of which
+	// start by spending `amountToSpend` of `sourceAsset` and end
+	// with delivering a postive amount of `destinationAsset`
+	FindFixedPaths(
+		sourceAccount *xdr.AccountId,
+		sourceAsset xdr.Asset,
+		amountToSpend xdr.Int64,
+		destinationAsset xdr.Asset,
+		maxLength uint,
+	) ([]Path, error)
 }

--- a/services/horizon/internal/resourceadapter/path.go
+++ b/services/horizon/internal/resourceadapter/path.go
@@ -9,9 +9,9 @@ import (
 )
 
 // PopulatePath converts the paths.Path into a Path
-func PopulatePath(ctx context.Context, dest *horizon.Path, q paths.Query, p paths.Path) (err error) {
-	dest.DestinationAmount = amount.String(q.DestinationAmount)
-	dest.SourceAmount = amount.String(p.Cost)
+func PopulatePath(ctx context.Context, dest *horizon.Path, p paths.Path) (err error) {
+	dest.DestinationAmount = amount.String(p.DestinationAmount)
+	dest.SourceAmount = amount.String(p.SourceAmount)
 
 	err = p.Source.Extract(
 		&dest.SourceAssetType,

--- a/services/horizon/internal/simplepath/finder.go
+++ b/services/horizon/internal/simplepath/finder.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/services/horizon/internal/paths"
 	"github.com/stellar/go/support/log"
+	"github.com/stellar/go/xdr"
 )
 
 // Finder implements the paths.Finder interface and searchs for
@@ -55,4 +56,16 @@ func (f *Finder) Find(q paths.Query, maxLength uint) (result []paths.Path, err e
 		WithField("err", s.Err).
 		Info("Finished pathfind")
 	return
+}
+
+// FindFixedPaths will return an error because this implementation
+// does not support this operation
+func (f *Finder) FindFixedPaths(
+	sourceAccount *xdr.AccountId,
+	sourceAsset xdr.Asset,
+	amountToSpend xdr.Int64,
+	destinationAsset xdr.Asset,
+	maxLength uint,
+) ([]paths.Path, error) {
+	return nil, errors.New("Not implemented")
 }

--- a/services/horizon/internal/simplepath/finder_test.go
+++ b/services/horizon/internal/simplepath/finder_test.go
@@ -54,7 +54,8 @@ func TestFinder(t *testing.T) {
 		// - selling 10 USD for EUR, price = 0.5
 		tt.Assert.Equal(p[0].Source.String(), usd.String())
 		tt.Assert.Equal(p[0].Destination.String(), eur.String())
-		tt.Assert.Equal(p[0].Cost, xdr.Int64(100000000)) // 10.0000000
+		tt.Assert.Equal(p[0].SourceAmount, xdr.Int64(100000000)) // 10.0000000
+		tt.Assert.Equal(p[0].DestinationAmount, xdr.Int64(200000000))
 		tt.Assert.Len(p[0].Path, 0)
 
 		// Consuming offers:
@@ -62,7 +63,8 @@ func TestFinder(t *testing.T) {
 		// - selling 20 `1` for EUR, price = 1
 		tt.Assert.Equal(p[1].Source.String(), usd.String())
 		tt.Assert.Equal(p[1].Destination.String(), eur.String())
-		tt.Assert.Equal(p[1].Cost, xdr.Int64(200000000))
+		tt.Assert.Equal(p[1].SourceAmount, xdr.Int64(200000000))
+		tt.Assert.Equal(p[1].DestinationAmount, xdr.Int64(200000000))
 		if tt.Assert.Len(p[1].Path, 1) {
 			tt.Assert.Equal(p[1].Path[0].String(), inter1.String())
 		}
@@ -73,7 +75,8 @@ func TestFinder(t *testing.T) {
 		// - selling 20 `22` for EUR, price = 1
 		tt.Assert.Equal(p[2].Source.String(), usd.String())
 		tt.Assert.Equal(p[2].Destination.String(), eur.String())
-		tt.Assert.Equal(p[2].Cost, xdr.Int64(200000000))
+		tt.Assert.Equal(p[2].SourceAmount, xdr.Int64(200000000))
+		tt.Assert.Equal(p[2].DestinationAmount, xdr.Int64(200000000))
 		if tt.Assert.Len(p[2].Path, 2) {
 			tt.Assert.Equal(p[2].Path[0].String(), inter21.String())
 			tt.Assert.Equal(p[2].Path[1].String(), inter22.String())
@@ -87,12 +90,14 @@ func TestFinder(t *testing.T) {
 
 		tt.Assert.Equal(p[0].Source.String(), usd.String())
 		tt.Assert.Equal(p[0].Destination.String(), eur.String())
-		tt.Assert.Equal(p[0].Cost, xdr.Int64(100000001))
+		tt.Assert.Equal(p[0].SourceAmount, xdr.Int64(100000001))
+		tt.Assert.Equal(p[0].DestinationAmount, xdr.Int64(200000001))
 		tt.Assert.Len(p[0].Path, 0)
 
 		tt.Assert.Equal(p[1].Source.String(), usd.String())
 		tt.Assert.Equal(p[1].Destination.String(), eur.String())
-		tt.Assert.Equal(p[1].Cost, xdr.Int64(200000001))
+		tt.Assert.Equal(p[1].SourceAmount, xdr.Int64(200000001))
+		tt.Assert.Equal(p[1].DestinationAmount, xdr.Int64(200000001))
 		if tt.Assert.Len(p[1].Path, 2) {
 			tt.Assert.Equal(p[1].Path[0].String(), inter21.String())
 			tt.Assert.Equal(p[1].Path[1].String(), inter22.String())
@@ -152,7 +157,8 @@ func TestFinder(t *testing.T) {
 		if tt.Assert.Len(p, 1) {
 			tt.Assert.Equal(p[0].Source.String(), aaa.String())
 			tt.Assert.Equal(p[0].Destination.String(), ccc.String())
-			tt.Assert.Equal(p[0].Cost, xdr.Int64(110000000)) // 11.0
+			tt.Assert.Equal(p[0].SourceAmount, xdr.Int64(110000000))      // 11.0
+			tt.Assert.Equal(p[0].DestinationAmount, xdr.Int64(100000000)) // 10.0
 			if tt.Assert.Len(p[0].Path, 1) {
 				tt.Assert.Equal(p[0].Path[0].String(), bbb.String())
 			}

--- a/services/horizon/internal/simplepath/search.go
+++ b/services/horizon/internal/simplepath/search.go
@@ -41,12 +41,13 @@ type computedNode struct {
 	cost xdr.Int64
 }
 
-func (c computedNode) asPath() paths.Path {
+func (c computedNode) asPath(destinationAmount xdr.Int64) paths.Path {
 	return paths.Path{
-		Path:        c.path.Path(),
-		Source:      c.path.Source(),
-		Destination: c.path.Destination(),
-		Cost:        c.cost,
+		Path:              c.path.Path(),
+		Source:            c.path.Source(),
+		SourceAmount:      c.cost,
+		Destination:       c.path.Destination(),
+		DestinationAmount: destinationAmount,
 	}
 }
 
@@ -152,7 +153,7 @@ func (s *search) runOnce() {
 	id := cur.path.Asset.String()
 
 	if s.isTarget(id) {
-		s.Results = append(s.Results, cur.asPath())
+		s.Results = append(s.Results, cur.asPath(s.Query.DestinationAmount))
 	}
 
 	if cur.path.Depth == s.MaxLength {

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -189,6 +189,8 @@ func (w *web) mustInstallActions(enableAssetStats bool, friendbotURL *url.URL) {
 	// Transaction submission API
 	r.Post("/transactions", TransactionCreateAction{}.Handle)
 	r.Get("/paths", PathIndexAction{}.Handle)
+	r.Get("/paths/strict-receive", PathIndexAction{}.Handle)
+	r.Get("/paths/strict-send", FixedPathIndexAction{}.Handle)
 
 	if enableAssetStats {
 		// Asset related endpoints


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Add path finding endpoint where source and destination are fixed

Fixes https://github.com/stellar/go/issues/1489

### Goal and scope

Path payments don't handle the case where you have a fixed amount of the source asset. For example "Get me the most EUR possible for my 10 USD". This case is becoming increasingly important for Stellar applications. In this PR, we want to add a new endpoint which will be able to serve these types of requests.

### Summary of changes

We introduce two new endpoints:

`/paths/strict-send/` – contains the new functionality and takes source_asset, source_amount and destination_asset params parameters
`/paths/strict-receive/` – would basically be an alias of the current /paths functionality

On the orderbook graph side, we add an extra map which maps assets to the offers which buy a given asset. The buying asset map is used in the DFS for computing path payments with a fixed source.

### Known limitations & issues

Although this is targeting the 0.20.0 release branch, this feature will probably land in the 0.21.0 release

### What shouldn't be reviewed

N / A