### PR TITLE
horizonclient: add methods for next and prev trade aggregations

### DIFF
--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -6,6 +6,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ## [v1.4.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.4.0) - 2019-08-09
 
 - Add support for querying operation endpoint with `join` parameter [#1521](https://github.com/stellar/go/issues/1521).
+- Add support for querying previous and next trade aggregations with `Client.NextTradeAggregationsPage` and `Client.PrevTradeAggregationsPage` methods.
 
 
 ## [v1.3.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.3.0) - 2019-07-08

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -634,5 +634,19 @@ func (c *Client) HomeDomainForAccount(aid string) (string, error) {
 	return accountDetail.HomeDomain, nil
 }
 
+// NextTradeAggregationsPage returns the next page of trade aggregations from the current
+// trade aggregations response.
+func (c *Client) NextTradeAggregationsPage(page hProtocol.TradeAggregationsPage) (ta hProtocol.TradeAggregationsPage, err error) {
+	err = c.sendRequestURL(page.Links.Next.Href, "get", &ta)
+	return
+}
+
+// PrevTradeAggregationsPage returns the previous page of trade aggregations from the current
+// trade aggregations response.
+func (c *Client) PrevTradeAggregationsPage(page hProtocol.TradeAggregationsPage) (ta hProtocol.TradeAggregationsPage, err error) {
+	err = c.sendRequestURL(page.Links.Prev.Href, "get", &ta)
+	return
+}
+
 // ensure that the horizon client implements ClientInterface
 var _ ClientInterface = &Client{}

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -179,6 +179,8 @@ type ClientInterface interface {
 	NextTradesPage(hProtocol.TradesPage) (hProtocol.TradesPage, error)
 	PrevTradesPage(hProtocol.TradesPage) (hProtocol.TradesPage, error)
 	HomeDomainForAccount(aid string) (string, error)
+	NextTradeAggregationsPage(hProtocol.TradeAggregationsPage) (hProtocol.TradeAggregationsPage, error)
+	PrevTradeAggregationsPage(hProtocol.TradeAggregationsPage) (hProtocol.TradeAggregationsPage, error)
 }
 
 // DefaultTestNetClient is a default client to connect to test network.

--- a/clients/horizonclient/mocks.go
+++ b/clients/horizonclient/mocks.go
@@ -287,5 +287,17 @@ func (m *MockClient) HomeDomainForAccount(aid string) (string, error) {
 	return a.Get(0).(string), a.Error(1)
 }
 
+// NextTradeAggregationsPage is a mocking method
+func (m *MockClient) NextTradeAggregationsPage(page hProtocol.TradeAggregationsPage) (hProtocol.TradeAggregationsPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(hProtocol.TradeAggregationsPage), a.Error(1)
+}
+
+// PrevTradeAggregationsPage is a mocking method
+func (m *MockClient) PrevTradeAggregationsPage(page hProtocol.TradeAggregationsPage) (hProtocol.TradeAggregationsPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(hProtocol.TradeAggregationsPage), a.Error(1)
+}
+
 // ensure that the MockClient implements ClientInterface
 var _ ClientInterface = &MockClient{}

--- a/clients/horizonclient/trade_aggregation_request_test.go
+++ b/clients/horizonclient/trade_aggregation_request_test.go
@@ -117,6 +117,170 @@ func TestTradeAggregationsRequest(t *testing.T) {
 	}
 }
 
+func ExampleClient_NextTradeAggregationsPage() {
+	client := DefaultPublicNetClient
+	// Find trade aggregations
+	ta := TradeAggregationRequest{
+		StartTime:          testTime,
+		EndTime:            testTime,
+		Resolution:         FiveMinuteResolution,
+		BaseAssetType:      AssetTypeNative,
+		CounterAssetType:   AssetType4,
+		CounterAssetCode:   "SLT",
+		CounterAssetIssuer: "GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP",
+		Order:              OrderDesc,
+	}
+	tradeAggs, err := client.TradeAggregations(ta)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(tradeAggs)
+
+	// get next pages.
+	recordsFound := false
+	if len(tradeAggs.Embedded.Records) > 0 {
+		recordsFound = true
+	}
+	page := tradeAggs
+	// get the next page of records if recordsFound is true
+	for recordsFound {
+		// next page
+		nextPage, err := client.NextTradeAggregationsPage(page)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		page = nextPage
+		if len(nextPage.Embedded.Records) == 0 {
+			recordsFound = false
+		}
+		fmt.Println(nextPage)
+	}
+}
+
+func ExampleClient_PrevTradeAggregationsPage() {
+	client := DefaultPublicNetClient
+	// Find trade aggregations
+	ta := TradeAggregationRequest{
+		StartTime:          testTime,
+		EndTime:            testTime,
+		Resolution:         FiveMinuteResolution,
+		BaseAssetType:      AssetTypeNative,
+		CounterAssetType:   AssetType4,
+		CounterAssetCode:   "SLT",
+		CounterAssetIssuer: "GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP",
+		Order:              OrderDesc,
+	}
+	tradeAggs, err := client.TradeAggregations(ta)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(tradeAggs)
+
+	// get prev pages.
+	recordsFound := false
+	if len(tradeAggs.Embedded.Records) > 0 {
+		recordsFound = true
+	}
+	page := tradeAggs
+	// get the prev page of records if recordsFound is true
+	for recordsFound {
+		// prev page
+		prevPage, err := client.PrevTradeAggregationsPage(page)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		page = prevPage
+		if len(prevPage.Embedded.Records) == 0 {
+			recordsFound = false
+		}
+		fmt.Println(prevPage)
+	}
+}
+
+func TestNextTradeAggregationsPage(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	taRequest := TradeAggregationRequest{
+		StartTime:          testTime,
+		EndTime:            testTime,
+		Resolution:         DayResolution,
+		BaseAssetType:      AssetTypeNative,
+		CounterAssetType:   AssetType4,
+		CounterAssetCode:   "SLT",
+		CounterAssetIssuer: "GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP",
+		Order:              OrderDesc,
+	}
+
+	hmock.On(
+		"GET",
+		"https://localhost/trade_aggregations?base_asset_type=native&counter_asset_code=SLT&counter_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP&counter_asset_type=credit_alphanum4&end_time=1517521726000&offset=0&order=desc&resolution=86400000&start_time=1517521726000",
+	).ReturnString(200, firstTradeAggsPage)
+	tradeAggs, err := client.TradeAggregations(taRequest)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, len(tradeAggs.Embedded.Records), 2)
+	}
+
+	hmock.On(
+		"GET",
+		"https://horizon-testnet.stellar.org/trade_aggregations?base_asset_code=USD&base_asset_issuer=GDLEUZYDSFMWA5ZLQIOCYS7DMLYDKFS2KWJ5M3RQ3P3WS4L75ZTWKELP&base_asset_type=credit_alphanum4&counter_asset_code=BTC&counter_asset_issuer=GDLEUZYDSFMWA5ZLQIOCYS7DMLYDKFS2KWJ5M3RQ3P3WS4L75ZTWKELP&counter_asset_type=credit_alphanum4&limit=2&resolution=60000&start_time=0",
+	).ReturnString(200, emptyTradeAggsPage)
+
+	nextPage, err := client.NextTradeAggregationsPage(tradeAggs)
+	if assert.NoError(t, err) {
+		assert.Equal(t, len(nextPage.Embedded.Records), 0)
+	}
+}
+
+func TestPrevTradeAggregationsPage(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	taRequest := TradeAggregationRequest{
+		StartTime:          testTime,
+		EndTime:            testTime,
+		Resolution:         DayResolution,
+		BaseAssetType:      AssetTypeNative,
+		CounterAssetType:   AssetType4,
+		CounterAssetCode:   "SLT",
+		CounterAssetIssuer: "GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP",
+		Order:              OrderDesc,
+	}
+
+	hmock.On(
+		"GET",
+		"https://localhost/trade_aggregations?base_asset_type=native&counter_asset_code=SLT&counter_asset_issuer=GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP&counter_asset_type=credit_alphanum4&end_time=1517521726000&offset=0&order=desc&resolution=86400000&start_time=1517521726000",
+	).ReturnString(200, emptyTradeAggsPage)
+	tradeAggs, err := client.TradeAggregations(taRequest)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, len(tradeAggs.Embedded.Records), 0)
+	}
+
+	hmock.On(
+		"GET",
+		"https://horizon-testnet.stellar.org/trade_aggregations?base_asset_type=credit_alphanum4&base_asset_code=USD&base_asset_issuer=GDLEUZYDSFMWA5ZLQIOCYS7DMLYDKFS2KWJ5M3RQ3P3WS4L75ZTWKELP&counter_asset_type=credit_alphanum4&counter_asset_code=BTC&counter_asset_issuer=GDLEUZYDSFMWA5ZLQIOCYS7DMLYDKFS2KWJ5M3RQ3P3WS4L75ZTWKELP&start_time=1565132904&resolution=60000&limit=2",
+	).ReturnString(200, firstTradeAggsPage)
+
+	prevPage, err := client.PrevTradeAggregationsPage(tradeAggs)
+	if assert.NoError(t, err) {
+		assert.Equal(t, len(prevPage.Embedded.Records), 2)
+	}
+}
+
 var tradeAggsResponse = `{
   "_links": {
     "self": {
@@ -183,5 +347,94 @@ var tradeAggsResponse = `{
         }
       }
     ]
+  }
+}`
+
+var firstTradeAggsPage = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/trade_aggregations?base_asset_type=credit_alphanum4&base_asset_code=USD&base_asset_issuer=GDLEUZYDSFMWA5ZLQIOCYS7DMLYDKFS2KWJ5M3RQ3P3WS4L75ZTWKELP&counter_asset_type=credit_alphanum4&counter_asset_code=BTC&counter_asset_issuer=GDLEUZYDSFMWA5ZLQIOCYS7DMLYDKFS2KWJ5M3RQ3P3WS4L75ZTWKELP&resolution=60000&limit=2"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/trade_aggregations?base_asset_code=USD&base_asset_issuer=GDLEUZYDSFMWA5ZLQIOCYS7DMLYDKFS2KWJ5M3RQ3P3WS4L75ZTWKELP&base_asset_type=credit_alphanum4&counter_asset_code=BTC&counter_asset_issuer=GDLEUZYDSFMWA5ZLQIOCYS7DMLYDKFS2KWJ5M3RQ3P3WS4L75ZTWKELP&counter_asset_type=credit_alphanum4&limit=2&resolution=60000&start_time=0"
+    },
+    "prev": {
+      "href": ""
+    }
+  },
+  "_embedded": {
+    "records": [
+      {
+        "timestamp": 1565026860000,
+        "trade_count": 3,
+        "base_volume": "23781.2128418",
+        "counter_volume": "2.0000000",
+        "avg": "0.0000841",
+        "high": "0.0000841",
+        "high_r": {
+          "N": 841,
+          "D": 10000000
+        },
+        "low": "0.0000841",
+        "low_r": {
+          "N": 841,
+          "D": 10000000
+        },
+        "open": "0.0000841",
+        "open_r": {
+          "N": 841,
+          "D": 10000000
+        },
+        "close": "0.0000841",
+        "close_r": {
+          "N": 841,
+          "D": 10000000
+        }
+      },
+      {
+        "timestamp": 1565026920000,
+        "trade_count": 1,
+        "base_volume": "11890.6052319",
+        "counter_volume": "0.9999999",
+        "avg": "0.0000841",
+        "high": "0.0000841",
+        "high_r": {
+          "N": 841,
+          "D": 10000000
+        },
+        "low": "0.0000841",
+        "low_r": {
+          "N": 841,
+          "D": 10000000
+        },
+        "open": "0.0000841",
+        "open_r": {
+          "N": 841,
+          "D": 10000000
+        },
+        "close": "0.0000841",
+        "close_r": {
+          "N": 841,
+          "D": 10000000
+        }
+      }
+    ]
+  }
+}`
+
+var emptyTradeAggsPage = `{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/trade_aggregations?base_asset_type=credit_alphanum4&base_asset_code=USD&base_asset_issuer=GDLEUZYDSFMWA5ZLQIOCYS7DMLYDKFS2KWJ5M3RQ3P3WS4L75ZTWKELP&counter_asset_type=credit_alphanum4&counter_asset_code=BTC&counter_asset_issuer=GDLEUZYDSFMWA5ZLQIOCYS7DMLYDKFS2KWJ5M3RQ3P3WS4L75ZTWKELP&resolution=60000&limit=2"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/trade_aggregations?base_asset_code=USD&base_asset_issuer=GDLEUZYDSFMWA5ZLQIOCYS7DMLYDKFS2KWJ5M3RQ3P3WS4L75ZTWKELP&base_asset_type=credit_alphanum4&counter_asset_code=BTC&counter_asset_issuer=GDLEUZYDSFMWA5ZLQIOCYS7DMLYDKFS2KWJ5M3RQ3P3WS4L75ZTWKELP&counter_asset_type=credit_alphanum4&limit=2&resolution=60000&start_time=0"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/trade_aggregations?base_asset_type=credit_alphanum4&base_asset_code=USD&base_asset_issuer=GDLEUZYDSFMWA5ZLQIOCYS7DMLYDKFS2KWJ5M3RQ3P3WS4L75ZTWKELP&counter_asset_type=credit_alphanum4&counter_asset_code=BTC&counter_asset_issuer=GDLEUZYDSFMWA5ZLQIOCYS7DMLYDKFS2KWJ5M3RQ3P3WS4L75ZTWKELP&start_time=1565132904&resolution=60000&limit=2"
+    }
+  },
+  "_embedded": {
+    "records": []
   }
 }`


### PR DESCRIPTION
This PR adds helper methods for getting prev and next trade aggregations from a current trade aggregations response.
The following methods have been added to the Client 
- `Client.NextTradeAggregationsPage`
- `Client.PrevTradeAggregationsPage`