### PR TITLE
use strings.Contains() instead of regex.Match() when populating HAL t…

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,6 +6,10 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## v0.19.1
+
+* HAL response population is implemented using Go `strings` package intsead of `regexp`, improving its performance.
+
 ## v0.19.0
 
 * Add `join` parameter to operations and payments endpoints. Currently, the only valid value for the parameter is `transactions`. If `join=transactions` is included in a request then the response will include a `transaction` field for each operation in the response.

--- a/support/render/hal/link.go
+++ b/support/render/hal/link.go
@@ -1,7 +1,7 @@
 package hal
 
 import (
-	"regexp"
+	"strings"
 )
 
 type Link struct {
@@ -10,11 +10,7 @@ type Link struct {
 }
 
 func (l *Link) PopulateTemplated() {
-	var err error
-	l.Templated, err = regexp.Match("{.*}", []byte(l.Href))
-	if err != nil {
-		panic(err)
-	}
+	l.Templated = strings.Contains(l.Href, "{")
 }
 
 func NewLink(href string) Link {


### PR DESCRIPTION
Second PR following discussion in #1446 and #1504 (please see these discussions). This time only improving the performance of HAL response construction using `PopulateTemplated()` without involving calling Go `regexp` package. This improves response performance.
