### PR TITLE
CircleCI: fix publish artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,12 +199,12 @@ jobs:
       - run:
           name: "Publish release on GitHub"
           command: |
-            if [ -d "./dist" ]
+            if [ "$(ls -A ./dist)" ]
             then
               go get github.com/tcnksm/ghr
               ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./dist/
             else
-                echo "./dist does not exist. No binaries to publish for ${CIRCLE_TAG}."
+                echo "No files found in ./dist. No binaries to publish for ${CIRCLE_TAG}."
             fi
 #-------------------------------------------------------------------------#
 # Workflows orchestrate jobs and make sure they run in the right sequence #


### PR DESCRIPTION
CircleCI workflow fails when it tries to publish binaries for releases that dont have any, like the horizonclient package. 
This PR adjusts the check for binaries by checking if the `dist` folder is empty. 
Previously, it check if this folder existed. This worked for a while but seems to be failing now: https://circleci.com/gh/stellar/go/5385