### PR TITLE
Enable Friendbot's base fee to be configured via friendbot.cfg

### DIFF
--- a/services/friendbot/friendbot.cfg
+++ b/services/friendbot/friendbot.cfg
@@ -3,4 +3,5 @@ friendbot_secret = "SA6WAWCCMRZSEFD5PEN5GK5BHK347YEQ552XZM72NV553TAGWFVHW2G5"
 network_passphrase = "Test SDF Network ; September 2015"
 horizon_url = "https://horizon-testnet.stellar.org"
 starting_balance = "10000.00"
-num_minions = 1000
+num_minions = 1
+base_fee = 300

--- a/services/friendbot/friendbot.cfg
+++ b/services/friendbot/friendbot.cfg
@@ -3,5 +3,5 @@ friendbot_secret = "SA6WAWCCMRZSEFD5PEN5GK5BHK347YEQ552XZM72NV553TAGWFVHW2G5"
 network_passphrase = "Test SDF Network ; September 2015"
 horizon_url = "https://horizon-testnet.stellar.org"
 starting_balance = "10000.00"
-num_minions = 1
+num_minions = 1000
 base_fee = 300

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -19,6 +19,7 @@ func initFriendbot(
 	horizonURL string,
 	startingBalance string,
 	numMinions int,
+	baseFee uint32,
 ) (*internal.Bot, error) {
 	if friendbotSecret == "" || networkPassphrase == "" || horizonURL == "" || startingBalance == "" || numMinions < 0 {
 		return nil, errors.New("invalid input param(s)")
@@ -47,7 +48,7 @@ func initFriendbot(
 		numMinions = 1000
 	}
 	log.Printf("Found all valid params, now creating %d minions", numMinions)
-	minions, err := createMinionAccounts(botAccount, botKeypair, networkPassphrase, startingBalance, minionBalance, numMinions, hclient)
+	minions, err := createMinionAccounts(botAccount, botKeypair, networkPassphrase, startingBalance, minionBalance, numMinions, baseFee, hclient)
 	if err != nil && len(minions) == 0 {
 		return nil, errors.Wrap(err, "creating minion accounts")
 	}
@@ -55,7 +56,7 @@ func initFriendbot(
 	return &internal.Bot{Minions: minions}, nil
 }
 
-func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full, networkPassphrase, newAccountBalance, minionBalance string, numMinions int, hclient *horizonclient.Client) ([]internal.Minion, error) {
+func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full, networkPassphrase, newAccountBalance, minionBalance string, numMinions int, baseFee uint32, hclient *horizonclient.Client) ([]internal.Minion, error) {
 	var minions []internal.Minion
 	numRemainingMinions := numMinions
 	minionBatchSize := 100
@@ -89,6 +90,7 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 				Network:           networkPassphrase,
 				StartingBalance:   newAccountBalance,
 				SubmitTransaction: internal.SubmitTransaction,
+				BaseFee:           baseFee,
 			})
 
 			ops = append(ops, &txnbuild.CreateAccount{

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -106,6 +106,10 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 			Timebounds:    txnbuild.NewTimeout(300),
 			Network:       networkPassphrase,
 		}
+		if baseFee > 0 {
+			txn.BaseFee = baseFee
+		}
+
 		txe, err := txn.BuildSignEncode(botKeypair)
 		if err != nil {
 			return minions, errors.Wrap(err, "making create accounts tx")

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -105,9 +105,7 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 			Operations:    ops,
 			Timebounds:    txnbuild.NewTimeout(300),
 			Network:       networkPassphrase,
-		}
-		if baseFee > 0 {
-			txn.BaseFee = baseFee
+			BaseFee:       baseFee,
 		}
 
 		txe, err := txn.BuildSignEncode(botKeypair)

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -110,9 +110,7 @@ func (minion *Minion) makeTx(destAddress string) (string, error) {
 		Operations:    []txnbuild.Operation{&createAccountOp},
 		Network:       minion.Network,
 		Timebounds:    txnbuild.NewInfiniteTimeout(),
-	}
-	if minion.BaseFee > 0 {
-		txn.BaseFee = minion.BaseFee
+		BaseFee:       minion.BaseFee,
 	}
 
 	txe, err := txn.BuildSignEncode(minion.Keypair, minion.BotKeypair)

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -24,6 +24,7 @@ type Minion struct {
 	Network           string
 	StartingBalance   string
 	SubmitTransaction func(minion *Minion, hclient *horizonclient.Client, tx string) (*hProtocol.TransactionSuccess, error)
+	BaseFee           uint32
 
 	// Uninitialized.
 	forceRefreshSequence bool
@@ -110,6 +111,10 @@ func (minion *Minion) makeTx(destAddress string) (string, error) {
 		Network:       minion.Network,
 		Timebounds:    txnbuild.NewInfiniteTimeout(),
 	}
+	if minion.BaseFee > 0 {
+		txn.BaseFee = minion.BaseFee
+	}
+
 	txe, err := txn.BuildSignEncode(minion.Keypair, minion.BotKeypair)
 	if err != nil {
 		return "", errors.Wrap(err, "making account payment tx")

--- a/services/friendbot/main.go
+++ b/services/friendbot/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	stdhttp "net/http"
 	"os"
-	"strconv"
 
 	"github.com/go-chi/chi"
 	"github.com/spf13/cobra"
@@ -27,6 +26,7 @@ type Config struct {
 	StartingBalance   string      `toml:"starting_balance" valid:"required"`
 	TLS               *config.TLS `valid:"optional"`
 	NumMinions        int         `toml:"num_minions" valid:"optional"`
+	BaseFee           uint32      `toml:"base_fee" valid:"optional"`
 }
 
 func main() {
@@ -46,7 +46,6 @@ func run(cmd *cobra.Command, args []string) {
 	var (
 		cfg     Config
 		cfgPath = cmd.PersistentFlags().Lookup("conf").Value.String()
-		baseFee uint32
 	)
 	log.SetLevel(log.InfoLevel)
 
@@ -61,18 +60,7 @@ func run(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	baseFeeStr := os.Getenv("BASE_FEE")
-	if baseFeeStr != "" {
-		baseFee64, err := strconv.ParseUint(baseFeeStr, 10, 32)
-
-		if err != nil {
-			log.Error(err)
-			os.Exit(1)
-		}
-
-		baseFee = uint32(baseFee64)
-	}
-	fb, err := initFriendbot(cfg.FriendbotSecret, cfg.NetworkPassphrase, cfg.HorizonURL, cfg.StartingBalance, cfg.NumMinions, baseFee)
+	fb, err := initFriendbot(cfg.FriendbotSecret, cfg.NetworkPassphrase, cfg.HorizonURL, cfg.StartingBalance, cfg.NumMinions, cfg.BaseFee)
 	if err != nil {
 		log.Error(err)
 		os.Exit(1)

--- a/services/friendbot/main.go
+++ b/services/friendbot/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	stdhttp "net/http"
 	"os"
+	"strconv"
 
 	"github.com/go-chi/chi"
 	"github.com/spf13/cobra"
@@ -45,6 +46,7 @@ func run(cmd *cobra.Command, args []string) {
 	var (
 		cfg     Config
 		cfgPath = cmd.PersistentFlags().Lookup("conf").Value.String()
+		baseFee uint32
 	)
 	log.SetLevel(log.InfoLevel)
 
@@ -58,7 +60,19 @@ func run(cmd *cobra.Command, args []string) {
 		}
 		os.Exit(1)
 	}
-	fb, err := initFriendbot(cfg.FriendbotSecret, cfg.NetworkPassphrase, cfg.HorizonURL, cfg.StartingBalance, cfg.NumMinions)
+
+	baseFeeStr := os.Getenv("BASE_FEE")
+	if baseFeeStr != "" {
+		baseFee64, err := strconv.ParseUint(baseFeeStr, 10, 32)
+
+		if err != nil {
+			log.Error(err)
+			os.Exit(1)
+		}
+
+		baseFee = uint32(baseFee64)
+	}
+	fb, err := initFriendbot(cfg.FriendbotSecret, cfg.NetworkPassphrase, cfg.HorizonURL, cfg.StartingBalance, cfg.NumMinions, baseFee)
 	if err != nil {
 		log.Error(err)
 		os.Exit(1)


### PR DESCRIPTION
This Pull Request enables the base fee used by Friendbot's transactions to be configured through `friendbot.cfg`.