### PR TITLE
Txnbuild: Refactor SourceAccount field for SetOperations Structs

### DIFF
--- a/services/compliance/internal/handlers/request_handler_auth_test.go
+++ b/services/compliance/internal/handlers/request_handler_auth_test.go
@@ -102,7 +102,7 @@ func TestRequestHandlerAuthInvalidParams(t *testing.T) {
 		Destination:   "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE",
 		Amount:        "20",
 		Asset:         txnbuild.CreditAsset{Code: "USD", Issuer: "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE"},
-		SourceAccount: &txnbuild.SimpleAccount{AccountID: "GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD"},
+		SourceAccount: "GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD",
 	}
 
 	tx := txnbuild.Transaction{
@@ -173,7 +173,7 @@ func TestRequestHandlerAuthInvalidParams(t *testing.T) {
 		Destination:   "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE",
 		Amount:        "20",
 		Asset:         txnbuild.CreditAsset{Code: "USD", Issuer: "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE"},
-		SourceAccount: &txnbuild.SimpleAccount{AccountID: "GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD"},
+		SourceAccount: "GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD",
 	}
 
 	tx = txnbuild.Transaction{
@@ -271,7 +271,7 @@ func TestRequestHandlerAuthValidParams(t *testing.T) {
 		Destination:   "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE",
 		Amount:        "20",
 		Asset:         txnbuild.CreditAsset{Code: "USD", Issuer: "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE"},
-		SourceAccount: &txnbuild.SimpleAccount{AccountID: "GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD"},
+		SourceAccount: "GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD",
 	}
 
 	tx := txnbuild.Transaction{
@@ -414,7 +414,7 @@ func TestRequestHandlerAuthSanctionsCheck(t *testing.T) {
 		Destination:   "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE",
 		Amount:        "20",
 		Asset:         txnbuild.CreditAsset{Code: "USD", Issuer: "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE"},
-		SourceAccount: &txnbuild.SimpleAccount{AccountID: "GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD"},
+		SourceAccount: "GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD",
 	}
 
 	tx := txnbuild.Transaction{
@@ -675,7 +675,7 @@ func TestRequestHandlerAuthSanctionsCheckNeedInfo(t *testing.T) {
 		Destination:   "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE",
 		Amount:        "20",
 		Asset:         txnbuild.CreditAsset{Code: "USD", Issuer: "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE"},
-		SourceAccount: &txnbuild.SimpleAccount{AccountID: "GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD"},
+		SourceAccount: "GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD",
 	}
 
 	tx := txnbuild.Transaction{

--- a/services/compliance/internal/handlers/request_handler_send_test.go
+++ b/services/compliance/internal/handlers/request_handler_send_test.go
@@ -212,7 +212,7 @@ func TestRequestHandlerSendValidParams(t *testing.T) {
 		Destination:   "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE",
 		Amount:        "20",
 		Asset:         txnbuild.CreditAsset{Code: "USD", Issuer: "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE"},
-		SourceAccount: &txnbuild.SimpleAccount{AccountID: "GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD"},
+		SourceAccount: "GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD",
 	}
 
 	tx := txnbuild.Transaction{
@@ -358,7 +358,7 @@ func TestRequestHandlerSendValidParams(t *testing.T) {
 		Destination:   "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE",
 		DestAmount:    "20",
 		DestAsset:     txnbuild.CreditAsset{Code: "USD", Issuer: "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE"},
-		SourceAccount: &txnbuild.SimpleAccount{AccountID: "GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD"},
+		SourceAccount: "GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD",
 		Path:          []txnbuild.Asset{txnbuild.NativeAsset{}, txnbuild.CreditAsset{Code: "EUR", Issuer: "GAF3PBFQLH57KPECN4GRGHU5NUZ3XXKYYWLOTBIRJMBYHPUBWANIUCZU"}},
 	}
 
@@ -512,7 +512,7 @@ func TestRequestHandlerSendValidParams(t *testing.T) {
 		Destination:   "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE",
 		Amount:        "20",
 		Asset:         txnbuild.CreditAsset{Code: "USD", Issuer: "GAMVF7G4GJC4A7JMFJWLUAEIBFQD5RT3DCB5DC5TJDEKQBBACQ4JZVEE"},
-		SourceAccount: &txnbuild.SimpleAccount{AccountID: "GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD"},
+		SourceAccount: "GAW77Z6GPWXSODJOMF5L5BMX6VMYGEJRKUNBC2CZ725JTQZORK74HQQD",
 	}
 
 	tx = txnbuild.Transaction{

--- a/services/friendbot/friendbot.cfg
+++ b/services/friendbot/friendbot.cfg
@@ -4,3 +4,4 @@ network_passphrase = "Test SDF Network ; September 2015"
 horizon_url = "https://horizon-testnet.stellar.org"
 starting_balance = "10000.00"
 num_minions = 1000
+base_fee = 300

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -84,7 +84,7 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 			newMinions = append(newMinions, internal.Minion{
 				Account:           internal.Account{AccountID: minionKeypair.Address()},
 				Keypair:           minionKeypair,
-				BotAccount:        botAccount,
+				BotAccount:        botAccount.AccountID,
 				BotKeypair:        botKeypair,
 				Horizon:           hclient,
 				Network:           networkPassphrase,

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -19,6 +19,7 @@ func initFriendbot(
 	horizonURL string,
 	startingBalance string,
 	numMinions int,
+	baseFee uint32,
 ) (*internal.Bot, error) {
 	if friendbotSecret == "" || networkPassphrase == "" || horizonURL == "" || startingBalance == "" || numMinions < 0 {
 		return nil, errors.New("invalid input param(s)")
@@ -47,7 +48,7 @@ func initFriendbot(
 		numMinions = 1000
 	}
 	log.Printf("Found all valid params, now creating %d minions", numMinions)
-	minions, err := createMinionAccounts(botAccount, botKeypair, networkPassphrase, startingBalance, minionBalance, numMinions, hclient)
+	minions, err := createMinionAccounts(botAccount, botKeypair, networkPassphrase, startingBalance, minionBalance, numMinions, baseFee, hclient)
 	if err != nil && len(minions) == 0 {
 		return nil, errors.Wrap(err, "creating minion accounts")
 	}
@@ -55,7 +56,7 @@ func initFriendbot(
 	return &internal.Bot{Minions: minions}, nil
 }
 
-func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full, networkPassphrase, newAccountBalance, minionBalance string, numMinions int, hclient *horizonclient.Client) ([]internal.Minion, error) {
+func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full, networkPassphrase, newAccountBalance, minionBalance string, numMinions int, baseFee uint32, hclient *horizonclient.Client) ([]internal.Minion, error) {
 	var minions []internal.Minion
 	numRemainingMinions := numMinions
 	minionBatchSize := 100
@@ -89,6 +90,7 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 				Network:           networkPassphrase,
 				StartingBalance:   newAccountBalance,
 				SubmitTransaction: internal.SubmitTransaction,
+				BaseFee:           baseFee,
 			})
 
 			ops = append(ops, &txnbuild.CreateAccount{
@@ -103,7 +105,9 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 			Operations:    ops,
 			Timebounds:    txnbuild.NewTimeout(300),
 			Network:       networkPassphrase,
+			BaseFee:       baseFee,
 		}
+
 		txe, err := txn.BuildSignEncode(botKeypair)
 		if err != nil {
 			return minions, errors.Wrap(err, "making create accounts tx")

--- a/services/friendbot/internal/friendbot_test.go
+++ b/services/friendbot/internal/friendbot_test.go
@@ -23,7 +23,7 @@ func TestFriendbot_Pay(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	botAccount := Account{AccountID: botKeypair.Address()}
+	botAccount := botKeypair.Address()
 
 	// Public key: GD4AGPPDFFHKK3Z2X4XZDRXX6GZQKP4FMLVQ5T55NDEYGG3GIP7BQUHM
 	minionSeed := "SDTNSEERJPJFUE2LSDNYBFHYGVTPIWY7TU2IOJZQQGLWO2THTGB7NU5A"

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -18,7 +18,7 @@ var ErrAccountExists error = errors.New(fmt.Sprintf("createAccountAlreadyExist (
 type Minion struct {
 	Account           Account
 	Keypair           *keypair.Full
-	BotAccount        txnbuild.Account
+	BotAccount        string
 	BotKeypair        *keypair.Full
 	Horizon           *horizonclient.Client
 	Network           string
@@ -102,7 +102,7 @@ func (minion *Minion) checkHandleBadSequence(err *horizonclient.Error) {
 func (minion *Minion) makeTx(destAddress string) (string, error) {
 	createAccountOp := txnbuild.CreateAccount{
 		Destination:   destAddress,
-		SourceAccount: minion.BotAccount.GetAccountID(),
+		SourceAccount: minion.BotAccount,
 		Amount:        minion.StartingBalance,
 	}
 	txn := txnbuild.Transaction{

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -102,7 +102,7 @@ func (minion *Minion) checkHandleBadSequence(err *horizonclient.Error) {
 func (minion *Minion) makeTx(destAddress string) (string, error) {
 	createAccountOp := txnbuild.CreateAccount{
 		Destination:   destAddress,
-		SourceAccount: minion.BotAccount,
+		SourceAccount: minion.BotAccount.GetAccountID(),
 		Amount:        minion.StartingBalance,
 	}
 	txn := txnbuild.Transaction{

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -24,6 +24,7 @@ type Minion struct {
 	Network           string
 	StartingBalance   string
 	SubmitTransaction func(minion *Minion, hclient *horizonclient.Client, tx string) (*hProtocol.TransactionSuccess, error)
+	BaseFee           uint32
 
 	// Uninitialized.
 	forceRefreshSequence bool
@@ -109,7 +110,9 @@ func (minion *Minion) makeTx(destAddress string) (string, error) {
 		Operations:    []txnbuild.Operation{&createAccountOp},
 		Network:       minion.Network,
 		Timebounds:    txnbuild.NewInfiniteTimeout(),
+		BaseFee:       minion.BaseFee,
 	}
+
 	txe, err := txn.BuildSignEncode(minion.Keypair, minion.BotKeypair)
 	if err != nil {
 		return "", errors.Wrap(err, "making account payment tx")

--- a/services/friendbot/main.go
+++ b/services/friendbot/main.go
@@ -26,6 +26,7 @@ type Config struct {
 	StartingBalance   string      `toml:"starting_balance" valid:"required"`
 	TLS               *config.TLS `valid:"optional"`
 	NumMinions        int         `toml:"num_minions" valid:"optional"`
+	BaseFee           uint32      `toml:"base_fee" valid:"optional"`
 }
 
 func main() {
@@ -58,7 +59,8 @@ func run(cmd *cobra.Command, args []string) {
 		}
 		os.Exit(1)
 	}
-	fb, err := initFriendbot(cfg.FriendbotSecret, cfg.NetworkPassphrase, cfg.HorizonURL, cfg.StartingBalance, cfg.NumMinions)
+
+	fb, err := initFriendbot(cfg.FriendbotSecret, cfg.NetworkPassphrase, cfg.HorizonURL, cfg.StartingBalance, cfg.NumMinions, cfg.BaseFee)
 	if err != nil {
 		log.Error(err)
 		os.Exit(1)

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_account_merge.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_account_merge.go
@@ -19,7 +19,7 @@ func (op AccountMergeOperationBody) Build() txnbuild.Operation {
 	}
 
 	if op.Source != nil {
-		txnOp.SourceAccount = &txnbuild.SimpleAccount{AccountID: *op.Source}
+		txnOp.SourceAccount = *op.Source
 	}
 
 	return &txnOp

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_allow_trust.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_allow_trust.go
@@ -22,7 +22,7 @@ func (op AllowTrustOperationBody) Build() txnbuild.Operation {
 	}
 
 	if op.Source != nil {
-		txnOp.SourceAccount = &txnbuild.SimpleAccount{AccountID: *op.Source}
+		txnOp.SourceAccount = *op.Source
 		txnOp.Type = txnbuild.CreditAsset{Code: op.AssetCode, Issuer: *op.Source}
 	}
 

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_change_trust.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_change_trust.go
@@ -27,7 +27,7 @@ func (op ChangeTrustOperationBody) Build() txnbuild.Operation {
 	}
 
 	if op.Source != nil {
-		txnOp.SourceAccount = &txnbuild.SimpleAccount{AccountID: *op.Source}
+		txnOp.SourceAccount = *op.Source
 	}
 
 	return &txnOp

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_create_account.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_create_account.go
@@ -22,7 +22,7 @@ func (op CreateAccountOperationBody) Build() txnbuild.Operation {
 	}
 
 	if op.Source != nil {
-		txnOp.SourceAccount = &txnbuild.SimpleAccount{AccountID: *op.Source}
+		txnOp.SourceAccount = *op.Source
 	}
 
 	return &txnOp

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_inflation.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_inflation.go
@@ -17,7 +17,7 @@ func (op InflationOperationBody) Build() txnbuild.Operation {
 	txnOp := txnbuild.Inflation{}
 
 	if op.Source != nil {
-		txnOp.SourceAccount = &txnbuild.SimpleAccount{AccountID: *op.Source}
+		txnOp.SourceAccount = *op.Source
 	}
 
 	return &txnOp

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_manage_data.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_manage_data.go
@@ -27,7 +27,7 @@ func (op ManageDataOperationBody) Build() txnbuild.Operation {
 	}
 
 	if op.Source != nil {
-		txnOp.SourceAccount = &txnbuild.SimpleAccount{AccountID: *op.Source}
+		txnOp.SourceAccount = *op.Source
 	}
 
 	return &txnOp

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_manage_offer.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_manage_offer.go
@@ -32,7 +32,7 @@ func (op ManageOfferOperationBody) Build() txnbuild.Operation {
 		}
 
 		if op.Source != nil {
-			txnOp.SourceAccount = &txnbuild.SimpleAccount{AccountID: *op.Source}
+			txnOp.SourceAccount = *op.Source
 		}
 
 		return &txnOp

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_manage_offer.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_manage_offer.go
@@ -52,7 +52,7 @@ func (op ManageOfferOperationBody) Build() txnbuild.Operation {
 	}
 
 	if op.Source != nil {
-		txnOp.SourceAccount = &txnbuild.SimpleAccount{AccountID: *op.Source}
+		txnOp.SourceAccount = *op.Source
 	}
 
 	return &txnOp

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_path_payment.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_path_payment.go
@@ -80,7 +80,7 @@ func (op PathPaymentOperationBody) Build() txnbuild.Operation {
 	}
 
 	if op.Source != nil {
-		txnOp.SourceAccount = &txnbuild.SimpleAccount{AccountID: *op.Source}
+		txnOp.SourceAccount = *op.Source
 	}
 
 	return &txnOp

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_payment.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_payment.go
@@ -25,7 +25,7 @@ func (op PaymentOperationBody) Build() txnbuild.Operation {
 	}
 
 	if op.Source != nil {
-		txnOp.SourceAccount = &txnbuild.SimpleAccount{AccountID: *op.Source}
+		txnOp.SourceAccount = *op.Source
 	}
 
 	return &txnOp

--- a/services/internal/bridge-compliance-shared/protocols/bridge/builder_set_options.go
+++ b/services/internal/bridge-compliance-shared/protocols/bridge/builder_set_options.go
@@ -74,7 +74,7 @@ func (op SetOptionsOperationBody) Build() txnbuild.Operation {
 	}
 
 	if op.Source != nil {
-		txnOp.SourceAccount = &txnbuild.SimpleAccount{AccountID: *op.Source}
+		txnOp.SourceAccount = *op.Source
 	}
 
 	return &txnOp

--- a/services/keystore/api.go
+++ b/services/keystore/api.go
@@ -28,7 +28,9 @@ func init() {
 
 func (s *Service) wrapMiddleware(handler http.Handler) http.Handler {
 	handler = authHandler(handler, s.authenticator)
-	return recoverHandler(handler)
+	handler = recoverHandler(handler)
+	handler = corsHandler(handler)
+	return handler
 }
 
 func ServeMux(s *Service) http.Handler {
@@ -175,6 +177,13 @@ func recoverHandler(next http.Handler) http.Handler {
 			problem.Render(ctx, rw, err)
 		}()
 
+		next.ServeHTTP(rw, req)
+	})
+}
+
+func corsHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("Access-Control-Allow-Origin", "*")
 		next.ServeHTTP(rw, req)
 	})
 }

--- a/txnbuild/account_merge.go
+++ b/txnbuild/account_merge.go
@@ -9,7 +9,7 @@ import (
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type AccountMerge struct {
 	Destination   string
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for AccountMerge returns a fully configured XDR Operation.
@@ -37,7 +37,7 @@ func (am *AccountMerge) FromXDR(xdrOp xdr.Operation) error {
 		return errors.New("error parsing account_merge operation from xdr")
 	}
 
-	am.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	am.SourceAccount = accountIDFromXDR(xdrOp.SourceAccount)
 	if xdrOp.Body.Destination != nil {
 		am.Destination = xdrOp.Body.Destination.Address()
 	}

--- a/txnbuild/allow_trust.go
+++ b/txnbuild/allow_trust.go
@@ -13,7 +13,7 @@ type AllowTrust struct {
 	Trustor       string
 	Type          Asset
 	Authorize     bool
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for AllowTrust returns a fully configured XDR Operation.
@@ -59,7 +59,7 @@ func (at *AllowTrust) FromXDR(xdrOp xdr.Operation) error {
 		return errors.New("error parsing allow_trust operation from xdr")
 	}
 
-	at.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	at.SourceAccount = accountIDFromXDR(xdrOp.SourceAccount)
 	at.Trustor = result.Trustor.Address()
 	at.Authorize = result.Authorize
 	//Because AllowTrust has a special asset type, we don't use assetFromXDR() here.

--- a/txnbuild/bump_sequence.go
+++ b/txnbuild/bump_sequence.go
@@ -9,7 +9,7 @@ import (
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type BumpSequence struct {
 	BumpTo        int64
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for BumpSequence returns a fully configured XDR Operation.
@@ -32,7 +32,7 @@ func (bs *BumpSequence) FromXDR(xdrOp xdr.Operation) error {
 		return errors.New("error parsing bump_sequence operation from xdr")
 	}
 
-	bs.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	bs.SourceAccount = accountIDFromXDR(xdrOp.SourceAccount)
 	bs.BumpTo = int64(result.BumpTo)
 	return nil
 }

--- a/txnbuild/change_trust.go
+++ b/txnbuild/change_trust.go
@@ -14,7 +14,7 @@ import (
 type ChangeTrust struct {
 	Line          Asset
 	Limit         string
-	SourceAccount Account
+	SourceAccount string
 }
 
 // MaxTrustlineLimit represents the maximum value that can be set as a trustline limit.
@@ -69,7 +69,7 @@ func (ct *ChangeTrust) FromXDR(xdrOp xdr.Operation) error {
 		return errors.New("error parsing change_trust operation from xdr")
 	}
 
-	ct.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	ct.SourceAccount = accountIDFromXDR(xdrOp.SourceAccount)
 	ct.Limit = amount.String(result.Limit)
 	asset, err := assetFromXDR(result.Line)
 	if err != nil {

--- a/txnbuild/create_account.go
+++ b/txnbuild/create_account.go
@@ -11,7 +11,7 @@ import (
 type CreateAccount struct {
 	Destination   string
 	Amount        string
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for CreateAccount returns a fully configured XDR Operation.
@@ -45,7 +45,7 @@ func (ca *CreateAccount) FromXDR(xdrOp xdr.Operation) error {
 		return errors.New("error parsing create_account operation from xdr")
 	}
 
-	ca.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	ca.SourceAccount = accountIDFromXDR(xdrOp.SourceAccount)
 	ca.Destination = result.Destination.Address()
 	ca.Amount = amount.String(result.StartingBalance)
 

--- a/txnbuild/create_passive_offer.go
+++ b/txnbuild/create_passive_offer.go
@@ -14,7 +14,7 @@ type CreatePassiveSellOffer struct {
 	Buying        Asset
 	Amount        string
 	Price         string
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for CreatePassiveSellOffer returns a fully configured XDR Operation.
@@ -63,7 +63,7 @@ func (cpo *CreatePassiveSellOffer) FromXDR(xdrOp xdr.Operation) error {
 		return errors.New("error parsing create_passive_sell_offer operation from xdr")
 	}
 
-	cpo.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	cpo.SourceAccount = accountIDFromXDR(xdrOp.SourceAccount)
 	cpo.Amount = amount.String(result.Amount)
 	if result.Price != (xdr.Price{}) {
 		cpo.Price = price.StringFromFloat64(float64(result.Price.N) / float64(result.Price.D))

--- a/txnbuild/inflation.go
+++ b/txnbuild/inflation.go
@@ -8,7 +8,7 @@ import (
 // Inflation represents the Stellar inflation operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type Inflation struct {
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for Inflation returns a fully configured XDR Operation.
@@ -28,6 +28,6 @@ func (inf *Inflation) FromXDR(xdrOp xdr.Operation) error {
 	if xdrOp.Body.Type != xdr.OperationTypeInflation {
 		return errors.New("error parsing inflation operation from xdr")
 	}
-	inf.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	inf.SourceAccount = accountIDFromXDR(xdrOp.SourceAccount)
 	return nil
 }

--- a/txnbuild/manage_buy_offer.go
+++ b/txnbuild/manage_buy_offer.go
@@ -15,7 +15,7 @@ type ManageBuyOffer struct {
 	Amount        string
 	Price         string
 	OfferID       int64
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for ManageBuyOffer returns a fully configured XDR Operation.
@@ -65,7 +65,7 @@ func (mo *ManageBuyOffer) FromXDR(xdrOp xdr.Operation) error {
 		return errors.New("error parsing manage_buy_offer operation from xdr")
 	}
 
-	mo.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	mo.SourceAccount = accountIDFromXDR(xdrOp.SourceAccount)
 	mo.OfferID = int64(result.OfferId)
 	mo.Amount = amount.String(result.BuyAmount)
 	if result.Price != (xdr.Price{}) {

--- a/txnbuild/manage_data.go
+++ b/txnbuild/manage_data.go
@@ -10,7 +10,7 @@ import (
 type ManageData struct {
 	Name          string
 	Value         []byte
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for ManageData returns a fully configured XDR Operation.
@@ -42,7 +42,7 @@ func (md *ManageData) FromXDR(xdrOp xdr.Operation) error {
 		return errors.New("error parsing create_account operation from xdr")
 	}
 
-	md.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	md.SourceAccount = accountIDFromXDR(xdrOp.SourceAccount)
 	md.Name = string(result.DataName)
 	md.Value = *result.DataValue
 	return nil

--- a/txnbuild/manage_offer.go
+++ b/txnbuild/manage_offer.go
@@ -10,7 +10,7 @@ import (
 //CreateOfferOp returns a ManageSellOffer operation to create a new offer, by
 // setting the OfferID to "0". The sourceAccount is optional, and if not provided,
 // will be that of the surrounding transaction.
-func CreateOfferOp(selling, buying Asset, amount, price string, sourceAccount ...Account) (ManageSellOffer, error) {
+func CreateOfferOp(selling, buying Asset, amount, price string, sourceAccount ...string) (ManageSellOffer, error) {
 	if len(sourceAccount) > 1 {
 		return ManageSellOffer{}, errors.New("offer can't have multiple source accounts")
 	}
@@ -30,7 +30,7 @@ func CreateOfferOp(selling, buying Asset, amount, price string, sourceAccount ..
 // UpdateOfferOp returns a ManageSellOffer operation to update an offer.
 // The sourceAccount is optional, and if not provided, will be that of
 // the surrounding transaction.
-func UpdateOfferOp(selling, buying Asset, amount, price string, offerID int64, sourceAccount ...Account) (ManageSellOffer, error) {
+func UpdateOfferOp(selling, buying Asset, amount, price string, offerID int64, sourceAccount ...string) (ManageSellOffer, error) {
 	if len(sourceAccount) > 1 {
 		return ManageSellOffer{}, errors.New("offer can't have multiple source accounts")
 	}
@@ -50,7 +50,7 @@ func UpdateOfferOp(selling, buying Asset, amount, price string, offerID int64, s
 //DeleteOfferOp returns a ManageSellOffer operation to delete an offer, by
 // setting the Amount to "0". The sourceAccount is optional, and if not provided,
 // will be that of the surrounding transaction.
-func DeleteOfferOp(offerID int64, sourceAccount ...Account) (ManageSellOffer, error) {
+func DeleteOfferOp(offerID int64, sourceAccount ...string) (ManageSellOffer, error) {
 	// It turns out Stellar core doesn't care about any of these fields except the amount.
 	// However, Horizon will reject ManageSellOffer if it is missing fields.
 	// Horizon will also reject if Buying == Selling.
@@ -79,7 +79,7 @@ type ManageSellOffer struct {
 	Amount        string
 	Price         string
 	OfferID       int64
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for ManageSellOffer returns a fully configured XDR Operation.
@@ -129,7 +129,7 @@ func (mo *ManageSellOffer) FromXDR(xdrOp xdr.Operation) error {
 		return errors.New("error parsing manage_sell_offer operation from xdr")
 	}
 
-	mo.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	mo.SourceAccount = accountIDFromXDR(xdrOp.SourceAccount)
 	mo.OfferID = int64(result.OfferId)
 	mo.Amount = amount.String(result.Amount)
 	if result.Price != (xdr.Price{}) {

--- a/txnbuild/operation.go
+++ b/txnbuild/operation.go
@@ -11,12 +11,12 @@ type Operation interface {
 }
 
 // SetOpSourceAccount sets the source account ID on an Operation.
-func SetOpSourceAccount(op *xdr.Operation, sourceAccount Account) {
-	if sourceAccount == nil {
+func SetOpSourceAccount(op *xdr.Operation, sourceAccount string) {
+	if sourceAccount == "" {
 		return
 	}
 	var opSourceAccountID xdr.AccountId
-	opSourceAccountID.SetAddress(sourceAccount.GetAccountID())
+	opSourceAccountID.SetAddress(sourceAccount)
 	op.SourceAccount = &opSourceAccountID
 }
 
@@ -57,9 +57,17 @@ func operationFromXDR(xdrOp xdr.Operation) (Operation, error) {
 }
 
 // accountFromXDR returns a txnbuild Account from a XDR Account.
-func accountFromXDR(account *xdr.AccountId) Account {
+// func accountFromXDR(account *xdr.AccountId) Account {
+// 	if account != nil {
+// 		return &SimpleAccount{AccountID: account.Address()}
+// 	}
+// 	return nil
+// }
+
+// accountIDFromXDR returns an Account ID string from a XDR Account.
+func accountIDFromXDR(account *xdr.AccountId) string {
 	if account != nil {
-		return &SimpleAccount{AccountID: account.Address()}
+		return account.Address()
 	}
-	return nil
+	return ""
 }

--- a/txnbuild/operation.go
+++ b/txnbuild/operation.go
@@ -56,14 +56,6 @@ func operationFromXDR(xdrOp xdr.Operation) (Operation, error) {
 	return newOp, err
 }
 
-// accountFromXDR returns a txnbuild Account from a XDR Account.
-// func accountFromXDR(account *xdr.AccountId) Account {
-// 	if account != nil {
-// 		return &SimpleAccount{AccountID: account.Address()}
-// 	}
-// 	return nil
-// }
-
 // accountIDFromXDR returns an Account ID string from a XDR Account.
 func accountIDFromXDR(account *xdr.AccountId) string {
 	if account != nil {

--- a/txnbuild/operation_test.go
+++ b/txnbuild/operation_test.go
@@ -17,7 +17,7 @@ func TestCreateAccountFromXDR(t *testing.T) {
 		var ca CreateAccount
 		err = ca.FromXDR(xdrEnv.Tx.Operations[0])
 		if assert.NoError(t, err) {
-			assert.Equal(t, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR", ca.SourceAccount.GetAccountID(), "source accounts should match")
+			assert.Equal(t, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR", ca.SourceAccount, "source accounts should match")
 			assert.Equal(t, "GCPHE7DYMAUAY4UWA6OIYDFGLKRXGLLEMT6MVETC36L7LW4Z3A37EJW5", ca.Destination, "destination should match")
 			assert.Equal(t, "10000.0000000", ca.Amount, "starting balance should match")
 		}
@@ -29,7 +29,7 @@ func TestCreateAccountFromXDR(t *testing.T) {
 		var ca CreateAccount
 		err = ca.FromXDR(xdrEnv.Tx.Operations[0])
 		if assert.NoError(t, err) {
-			assert.Equal(t, nil, ca.SourceAccount, "source accounts should match")
+			assert.Equal(t, "", ca.SourceAccount, "source accounts should match")
 			assert.Equal(t, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR", ca.Destination, "destination should match")
 			assert.Equal(t, "198.0000000", ca.Amount, "starting balance should match")
 		}
@@ -45,7 +45,7 @@ func TestPaymentFromXDR(t *testing.T) {
 		var p Payment
 		err = p.FromXDR(xdrEnv.Tx.Operations[0])
 		if assert.NoError(t, err) {
-			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", p.SourceAccount.GetAccountID(), "source accounts should match")
+			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", p.SourceAccount, "source accounts should match")
 			assert.Equal(t, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR", p.Destination, "destination should match")
 			assert.Equal(t, "10.0000000", p.Amount, "amount should match")
 			assert.Equal(t, true, p.Asset.IsNative(), "Asset should be native")
@@ -53,7 +53,7 @@ func TestPaymentFromXDR(t *testing.T) {
 
 		err = p.FromXDR(xdrEnv.Tx.Operations[1])
 		if assert.NoError(t, err) {
-			assert.Equal(t, nil, p.SourceAccount, "source accounts should match")
+			assert.Equal(t, "", p.SourceAccount, "source accounts should match")
 			assert.Equal(t, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR", p.Destination, "destination should match")
 			assert.Equal(t, "134.0000000", p.Amount, "amount should match")
 			assetType, e := p.Asset.GetType()
@@ -73,7 +73,7 @@ func TestPathPaymentFromXDR(t *testing.T) {
 		var pp PathPayment
 		err = pp.FromXDR(xdrEnv.Tx.Operations[0])
 		if assert.NoError(t, err) {
-			assert.Equal(t, nil, pp.SourceAccount, "source accounts should match")
+			assert.Equal(t, "", pp.SourceAccount, "source accounts should match")
 			assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", pp.Destination, "destination should match")
 			assert.Equal(t, "1.0000000", pp.DestAmount, "DestAmount should match")
 			assert.Equal(t, "10.0000000", pp.SendMax, "SendMax should match")
@@ -96,7 +96,7 @@ func TestManageSellOfferFromXDR(t *testing.T) {
 		var mso ManageSellOffer
 		err = mso.FromXDR(xdrEnv.Tx.Operations[0])
 		if assert.NoError(t, err) {
-			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", mso.SourceAccount.GetAccountID(), "source accounts should match")
+			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", mso.SourceAccount, "source accounts should match")
 			assert.Equal(t, int64(0), mso.OfferID, "OfferID should match")
 			assert.Equal(t, "300.0000000", mso.Amount, "Amount should match")
 			assert.Equal(t, "5.0000000", mso.Price, "Price should match")
@@ -110,7 +110,7 @@ func TestManageSellOfferFromXDR(t *testing.T) {
 
 		err = mso.FromXDR(xdrEnv.Tx.Operations[1])
 		if assert.NoError(t, err) {
-			assert.Equal(t, nil, mso.SourceAccount, "source accounts should match")
+			assert.Equal(t, "", mso.SourceAccount, "source accounts should match")
 			assert.Equal(t, int64(0), mso.OfferID, "OfferID should match")
 			assert.Equal(t, "400.0000000", mso.Amount, "Amount should match")
 			assert.Equal(t, "5.0000000", mso.Price, "Price should match")
@@ -133,7 +133,7 @@ func TestManageBuyOfferFromXDR(t *testing.T) {
 		var mbo ManageBuyOffer
 		err = mbo.FromXDR(xdrEnv.Tx.Operations[0])
 		if assert.NoError(t, err) {
-			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", mbo.SourceAccount.GetAccountID(), "source accounts should match")
+			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", mbo.SourceAccount, "source accounts should match")
 			assert.Equal(t, int64(0), mbo.OfferID, "OfferID should match")
 			assert.Equal(t, "100.0000000", mbo.Amount, "Amount should match")
 			assert.Equal(t, "0.5000000", mbo.Price, "Price should match")
@@ -147,7 +147,7 @@ func TestManageBuyOfferFromXDR(t *testing.T) {
 
 		err = mbo.FromXDR(xdrEnv.Tx.Operations[1])
 		if assert.NoError(t, err) {
-			assert.Equal(t, nil, mbo.SourceAccount, "source accounts should match")
+			assert.Equal(t, "", mbo.SourceAccount, "source accounts should match")
 			assert.Equal(t, int64(0), mbo.OfferID, "OfferID should match")
 			assert.Equal(t, "300.0000000", mbo.Amount, "Amount should match")
 			assert.Equal(t, "0.6000000", mbo.Price, "Price should match")
@@ -170,7 +170,7 @@ func TestCreatePassiveSellOfferFromXDR(t *testing.T) {
 		var cpo CreatePassiveSellOffer
 		err = cpo.FromXDR(xdrEnv.Tx.Operations[0])
 		if assert.NoError(t, err) {
-			assert.Equal(t, nil, cpo.SourceAccount, "source accounts should match")
+			assert.Equal(t, "", cpo.SourceAccount, "source accounts should match")
 			assert.Equal(t, "10.0000000", cpo.Amount, "Amount should match")
 			assert.Equal(t, "1.0000000", cpo.Price, "Price should match")
 			assert.Equal(t, true, cpo.Selling.IsNative(), "Selling should be native")
@@ -226,7 +226,7 @@ func TestSetOptionsFromXDR(t *testing.T) {
 	var so SetOptions
 	err = so.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", so.SourceAccount.GetAccountID(), "source accounts should match")
+		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", so.SourceAccount, "source accounts should match")
 		assert.Equal(t, Threshold(7), *so.MasterWeight, "master weight should match")
 		assert.Equal(t, Threshold(2), *so.LowThreshold, "low threshold should match")
 		assert.Equal(t, Threshold(4), *so.MediumThreshold, "medium threshold should match")
@@ -268,7 +268,7 @@ func TestChangeTrustFromXDR(t *testing.T) {
 	var ct ChangeTrust
 	err = ct.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", ct.SourceAccount.GetAccountID(), "source accounts should match")
+		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", ct.SourceAccount, "source accounts should match")
 		assetType, e := ct.Line.GetType()
 		assert.NoError(t, e)
 
@@ -309,7 +309,7 @@ func TestAllowTrustFromXDR(t *testing.T) {
 	var at AllowTrust
 	err = at.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", at.SourceAccount.GetAccountID(), "source accounts should match")
+		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", at.SourceAccount, "source accounts should match")
 
 		assetType, e := at.Type.GetType()
 		assert.NoError(t, e)
@@ -340,7 +340,7 @@ func TestAccountMergeFromXDR(t *testing.T) {
 	var am AccountMerge
 	err = am.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", am.SourceAccount.GetAccountID(), "source accounts should match")
+		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", am.SourceAccount, "source accounts should match")
 		assert.Equal(t, "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3", am.Destination, "destination accounts should match")
 	}
 }
@@ -358,7 +358,7 @@ func TestInflationFromXDR(t *testing.T) {
 	var inf Inflation
 	err = inf.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", inf.SourceAccount.GetAccountID(), "source accounts should match")
+		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", inf.SourceAccount, "source accounts should match")
 	}
 }
 
@@ -385,7 +385,7 @@ func TestManageDataFromXDR(t *testing.T) {
 	var md ManageData
 	err = md.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", md.SourceAccount.GetAccountID(), "source accounts should match")
+		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", md.SourceAccount, "source accounts should match")
 		assert.Equal(t, "data", md.Name, "Name should match")
 		assert.Equal(t, "value", string(md.Value), "Value should match")
 	}
@@ -411,7 +411,7 @@ func TestBumpSequenceFromXDR(t *testing.T) {
 	var bs BumpSequence
 	err = bs.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", bs.SourceAccount.GetAccountID(), "source accounts should match")
+		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", bs.SourceAccount, "source accounts should match")
 		assert.Equal(t, int64(45), bs.BumpTo, "BumpTo should match")
 	}
 }

--- a/txnbuild/path_payment.go
+++ b/txnbuild/path_payment.go
@@ -15,7 +15,7 @@ type PathPayment struct {
 	DestAsset     Asset
 	DestAmount    string
 	Path          []Asset
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for Payment returns a fully configured XDR Operation.
@@ -93,7 +93,7 @@ func (pp *PathPayment) FromXDR(xdrOp xdr.Operation) error {
 		return errors.New("error parsing path_payment operation from xdr")
 	}
 
-	pp.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	pp.SourceAccount = accountIDFromXDR(xdrOp.SourceAccount)
 	pp.Destination = result.Destination.Address()
 	pp.DestAmount = amount.String(result.DestAmount)
 	pp.SendMax = amount.String(result.SendMax)

--- a/txnbuild/payment.go
+++ b/txnbuild/payment.go
@@ -12,7 +12,7 @@ type Payment struct {
 	Destination   string
 	Amount        string
 	Asset         Asset
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for Payment returns a fully configured XDR Operation.
@@ -59,7 +59,7 @@ func (p *Payment) FromXDR(xdrOp xdr.Operation) error {
 		return errors.New("error parsing payment operation from xdr")
 	}
 
-	p.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	p.SourceAccount = accountIDFromXDR(xdrOp.SourceAccount)
 	p.Destination = result.Destination.Address()
 	p.Amount = amount.String(result.Amount)
 

--- a/txnbuild/set_options.go
+++ b/txnbuild/set_options.go
@@ -60,7 +60,7 @@ type SetOptions struct {
 	HomeDomain           *string
 	Signer               *Signer
 	xdrOp                xdr.SetOptionsOp
-	SourceAccount        Account
+	SourceAccount        string
 }
 
 // BuildXDR for SetOptions returns a fully configured XDR Operation.
@@ -296,7 +296,7 @@ func (so *SetOptions) FromXDR(xdrOp xdr.Operation) error {
 		return errors.New("error parsing set_options operation from xdr")
 	}
 
-	so.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	so.SourceAccount = accountIDFromXDR(xdrOp.SourceAccount)
 	so.handleInflationXDR(result.InflationDest)
 	so.handleClearFlagsXDR(result.ClearFlags)
 	so.handleSetFlagsXDR(result.SetFlags)

--- a/txnbuild/signers_test.go
+++ b/txnbuild/signers_test.go
@@ -12,11 +12,11 @@ func TestAccountMergeMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
+	opSourceAccount := kp1.Address()
 
 	accountMerge := AccountMerge{
 		Destination:   "GAS4V4O2B7DW5T7IQRPEEVCRXMDZESKISR7DVIGKZQYYV3OSQ5SH5LVP",
-		SourceAccount: &opSourceAccount,
+		SourceAccount: opSourceAccount,
 	}
 
 	tx := Transaction{
@@ -33,7 +33,7 @@ func TestAccountMergeMultSigners(t *testing.T) {
 
 func TestAllowTrustMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	opSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
+	opSourceAccount := kp0.Address()
 
 	kp1 := newKeypair1()
 	txSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
@@ -43,7 +43,7 @@ func TestAllowTrustMultSigners(t *testing.T) {
 		Trustor:       kp1.Address(),
 		Type:          issuedAsset,
 		Authorize:     true,
-		SourceAccount: &opSourceAccount,
+		SourceAccount: opSourceAccount,
 	}
 
 	tx := Transaction{
@@ -63,11 +63,11 @@ func TestBumpSequenceMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
+	opSourceAccount := kp1.Address()
 
 	bumpSequence := BumpSequence{
 		BumpTo:        9606132444168300,
-		SourceAccount: &opSourceAccount,
+		SourceAccount: opSourceAccount,
 	}
 
 	tx := Transaction{
@@ -87,12 +87,12 @@ func TestChangeTrustMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
+	opSourceAccount := kp1.Address()
 
 	changeTrust := ChangeTrust{
 		Line:          CreditAsset{"ABCD", kp0.Address()},
 		Limit:         "10",
-		SourceAccount: &opSourceAccount,
+		SourceAccount: opSourceAccount,
 	}
 
 	tx := Transaction{
@@ -111,12 +111,12 @@ func TestCreateAccountMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
+	opSourceAccount := kp1.Address()
 
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:        "10",
-		SourceAccount: &opSourceAccount,
+		SourceAccount: opSourceAccount,
 	}
 
 	tx := Transaction{
@@ -136,14 +136,14 @@ func TestCreatePassiveSellOfferMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
+	opSourceAccount := kp1.Address()
 
 	createPassiveOffer := CreatePassiveSellOffer{
 		Selling:       NativeAsset{},
 		Buying:        CreditAsset{"ABCD", kp0.Address()},
 		Amount:        "10",
 		Price:         "1.0",
-		SourceAccount: &opSourceAccount,
+		SourceAccount: opSourceAccount,
 	}
 
 	tx := Transaction{
@@ -163,10 +163,10 @@ func TestInflationMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
+	opSourceAccount := kp1.Address()
 
 	inflation := Inflation{
-		SourceAccount: &opSourceAccount,
+		SourceAccount: opSourceAccount,
 	}
 
 	tx := Transaction{
@@ -186,12 +186,12 @@ func TestManageDataMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
+	opSourceAccount := kp1.Address()
 
 	manageData := ManageData{
 		Name:          "Fruit preference",
 		Value:         []byte("Apple"),
-		SourceAccount: &opSourceAccount,
+		SourceAccount: opSourceAccount,
 	}
 
 	tx := Transaction{
@@ -211,13 +211,13 @@ func TestManageOfferCreateMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
+	opSourceAccount := kp1.Address()
 
 	selling := NativeAsset{}
 	buying := CreditAsset{"ABCD", kp0.Address()}
 	sellAmount := "100"
 	price := "0.01"
-	createOffer, err := CreateOfferOp(selling, buying, sellAmount, price, &opSourceAccount)
+	createOffer, err := CreateOfferOp(selling, buying, sellAmount, price, opSourceAccount)
 	check(err)
 
 	tx := Transaction{
@@ -237,10 +237,10 @@ func TestManageOfferDeleteMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
+	opSourceAccount := kp1.Address()
 
 	offerID := int64(2921622)
-	deleteOffer, err := DeleteOfferOp(offerID, &opSourceAccount)
+	deleteOffer, err := DeleteOfferOp(offerID, opSourceAccount)
 	check(err)
 
 	tx := Transaction{
@@ -260,14 +260,14 @@ func TestManageOfferUpdateMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
+	opSourceAccount := kp1.Address()
 
 	selling := NativeAsset{}
 	buying := CreditAsset{"ABCD", kp0.Address()}
 	sellAmount := "50"
 	price := "0.02"
 	offerID := int64(2497628)
-	updateOffer, err := UpdateOfferOp(selling, buying, sellAmount, price, offerID, &opSourceAccount)
+	updateOffer, err := UpdateOfferOp(selling, buying, sellAmount, price, offerID, opSourceAccount)
 	check(err)
 
 	tx := Transaction{
@@ -287,7 +287,7 @@ func TestPathPaymentMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
+	opSourceAccount := kp1.Address()
 
 	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
 	pathPayment := PathPayment{
@@ -297,7 +297,7 @@ func TestPathPaymentMultSigners(t *testing.T) {
 		DestAsset:     NativeAsset{},
 		DestAmount:    "1",
 		Path:          []Asset{abcdAsset},
-		SourceAccount: &opSourceAccount,
+		SourceAccount: opSourceAccount,
 	}
 
 	tx := Transaction{
@@ -318,13 +318,13 @@ func TestPaymentMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
+	opSourceAccount := kp1.Address()
 
 	payment := Payment{
 		Destination:   "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
 		Amount:        "10",
 		Asset:         NativeAsset{},
-		SourceAccount: &opSourceAccount,
+		SourceAccount: opSourceAccount,
 	}
 
 	tx := Transaction{
@@ -344,11 +344,11 @@ func TestSetOptionsMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
+	opSourceAccount := kp1.Address()
 
 	setOptions := SetOptions{
 		SetFlags:      []AccountFlag{AuthRequired, AuthRevocable},
-		SourceAccount: &opSourceAccount,
+		SourceAccount: opSourceAccount,
 	}
 
 	tx := Transaction{

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -239,11 +239,6 @@ func BuildChallengeTx(serverSignerSecret, clientAccountID, anchorName, network s
 		Sequence: int64(-1),
 	}
 
-	// represent client account as SimpleAccount
-	ca := SimpleAccount{
-		AccountID: clientAccountID,
-	}
-
 	if timebound == 0 {
 		return "", errors.New("timebound cannot be 0")
 	}
@@ -257,7 +252,7 @@ func BuildChallengeTx(serverSignerSecret, clientAccountID, anchorName, network s
 		SourceAccount: &sa,
 		Operations: []Operation{
 			&ManageData{
-				SourceAccount: &ca,
+				SourceAccount: clientAccountID,
 				Name:          anchorName + " auth",
 				Value:         []byte(randomNonceToString),
 			},
@@ -452,7 +447,7 @@ func VerifyChallengeTx(challengeTx, serverAccountID, network string) (bool, erro
 	if !ok {
 		return false, errors.New("operation type should be manage_data")
 	}
-	if op.SourceAccount == nil {
+	if op.SourceAccount == "" {
 		return false, errors.New("operation should have a source account")
 	}
 
@@ -470,7 +465,7 @@ func VerifyChallengeTx(challengeTx, serverAccountID, network string) (bool, erro
 	}
 
 	// verify signature from operation source
-	ok, err = verifyTxSignature(tx, op.SourceAccount.GetAccountID())
+	ok, err = verifyTxSignature(tx, op.SourceAccount)
 	if err != nil {
 		return ok, err
 	}

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1018,7 +1018,7 @@ func TestFromXDR(t *testing.T) {
 	assert.IsType(t, newTx.Operations[0], &Payment{}, "Operation types should match")
 	paymentOp, ok1 := newTx.Operations[0].(*Payment)
 	assert.Equal(t, true, ok1)
-	assert.Equal(t, "GATBMIXTHXYKSUZSZUEJKACZ2OS2IYUWP2AIF3CA32PIDLJ67CH6Y5UY", paymentOp.SourceAccount.GetAccountID(), "Operation source should match")
+	assert.Equal(t, "GATBMIXTHXYKSUZSZUEJKACZ2OS2IYUWP2AIF3CA32PIDLJ67CH6Y5UY", paymentOp.SourceAccount, "Operation source should match")
 	assert.Equal(t, "GDGEQS64ISS6Y2KDM5V67B6LXALJX4E7VE4MIA54NANSUX5MKGKBZM5G", paymentOp.Destination, "Operation destination should match")
 	assert.Equal(t, "874.0000000", paymentOp.Amount, "Operation amount should match")
 
@@ -1040,7 +1040,7 @@ func TestFromXDR(t *testing.T) {
 	assert.IsType(t, newTx2.Operations[1], &ManageData{}, "Operation types should match")
 	op1, ok1 := newTx2.Operations[0].(*ChangeTrust)
 	assert.Equal(t, true, ok1)
-	assert.Equal(t, "GD4Q3HT4IMFTIYLYRPTJQ7XLKROGGEUV74WTL26KPEWUTF72AJKGSJS7", op1.SourceAccount.GetAccountID(), "Operation source should match")
+	assert.Equal(t, "GD4Q3HT4IMFTIYLYRPTJQ7XLKROGGEUV74WTL26KPEWUTF72AJKGSJS7", op1.SourceAccount, "Operation source should match")
 	assetType, err := op1.Line.GetType()
 	assert.NoError(t, err)
 
@@ -1051,7 +1051,7 @@ func TestFromXDR(t *testing.T) {
 
 	op2, ok2 := newTx2.Operations[1].(*ManageData)
 	assert.Equal(t, true, ok2)
-	assert.Equal(t, nil, op2.SourceAccount, "Operation source should match")
+	assert.Equal(t, "", op2.SourceAccount, "Operation source should match")
 	assert.Equal(t, "test", op2.Name, "Name should match")
 	assert.Equal(t, "value", string(op2.Value), "Value should match")
 }
@@ -1131,11 +1131,11 @@ func TestSignWithSecretKey(t *testing.T) {
 	kp1 := newKeypair1()
 	txSource := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
 	tx1Source := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
-	opSource := NewSimpleAccount(kp1.Address(), 0)
+	opSource := kp1.Address()
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:        "10",
-		SourceAccount: &opSource,
+		SourceAccount: opSource,
 	}
 	tx := Transaction{
 		SourceAccount: &txSource,
@@ -1167,11 +1167,11 @@ func TestVerifyTxSignatureUnsignedTx(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
 	txSource := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
-	opSource := NewSimpleAccount(kp1.Address(), 0)
+	opSource := kp1.Address()
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:        "10",
-		SourceAccount: &opSource,
+		SourceAccount: opSource,
 	}
 	tx := Transaction{
 		SourceAccount: &txSource,
@@ -1194,11 +1194,11 @@ func TestVerifyTxSignatureSingle(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
 	txSource := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
-	opSource := NewSimpleAccount(kp1.Address(), 0)
+	opSource := kp1.Address()
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:        "10",
-		SourceAccount: &opSource,
+		SourceAccount: opSource,
 	}
 	tx := Transaction{
 		SourceAccount: &txSource,
@@ -1220,11 +1220,11 @@ func TestVerifyTxSignatureMultiple(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
 	txSource := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
-	opSource := NewSimpleAccount(kp1.Address(), 0)
+	opSource := kp1.Address()
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:        "10",
-		SourceAccount: &opSource,
+		SourceAccount: opSource,
 	}
 	tx := Transaction{
 		SourceAccount: &txSource,
@@ -1248,11 +1248,11 @@ func TestVerifyTxSignatureInvalid(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
 	txSource := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
-	opSource := NewSimpleAccount(kp1.Address(), 0)
+	opSource := kp1.Address()
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:        "10",
-		SourceAccount: &opSource,
+		SourceAccount: opSource,
 	}
 	tx := Transaction{
 		SourceAccount: &txSource,
@@ -1336,11 +1336,11 @@ func TestVerifyChallengeTxInvalidOp(t *testing.T) {
 
 	// invalid operation type
 	txSource := NewSimpleAccount(kp0.Address(), -1)
-	opSource := NewSimpleAccount(kp1.Address(), 0)
+	opSource := kp1.Address()
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:        "10",
-		SourceAccount: &opSource,
+		SourceAccount: opSource,
 	}
 	newTx := Transaction{
 		SourceAccount: &txSource,
@@ -1388,7 +1388,7 @@ func TestVerifyChallengeTxSequenceNumber(t *testing.T) {
 
 	// invalid sequence number
 	txSource := NewSimpleAccount(kp0.Address(), 100)
-	opSource := NewSimpleAccount(kp1.Address(), 0)
+	opSource := kp1.Address()
 	randomNonce, err := generateRandomNonce(48)
 	assert.NoError(t, err)
 	randomNonceToString := base64.StdEncoding.EncodeToString(randomNonce)
@@ -1396,7 +1396,7 @@ func TestVerifyChallengeTxSequenceNumber(t *testing.T) {
 		SourceAccount: &txSource,
 		Operations: []Operation{
 			&ManageData{
-				SourceAccount: &opSource,
+				SourceAccount: opSource,
 				Name:          "sdf auth",
 				Value:         []byte(randomNonceToString),
 			},
@@ -1423,7 +1423,7 @@ func TestVerifyChallengeTxRandomNonce(t *testing.T) {
 	kp1 := newKeypair1()
 
 	txSource := NewSimpleAccount(kp0.Address(), -1)
-	opSource := NewSimpleAccount(kp1.Address(), 0)
+	opSource := kp1.Address()
 	// invalid nonce
 	randomNonce, err := generateRandomNonce(40)
 	assert.NoError(t, err)
@@ -1432,7 +1432,7 @@ func TestVerifyChallengeTxRandomNonce(t *testing.T) {
 		SourceAccount: &txSource,
 		Operations: []Operation{
 			&ManageData{
-				SourceAccount: &opSource,
+				SourceAccount: opSource,
 				Name:          "sdf auth",
 				Value:         []byte(randomNonceToString),
 			},


### PR DESCRIPTION
In the current version of the SDK (1.4.0) the source account field for each operation requires a Txnbuild account object. I have refactored the following:

* accountFromXDR function becomes accountIDFromXDR. The return becomes a string that either returns the account.Address() from the xdr.AccountID object or an empty string
* All of the setOptions operations have been updated to use a string instead of an Account object in the struct
* I updated all of the tests as well to take account of the refactor

Since the SourceAccount field does not consume a sequence we don't actually need an Account object here - a string will suffice and arguably make end user code cleaner. By using the string type for the SourceAccount field the Go SDK will now also match the JS SDK's constructor as well.

PS: Sorry about the older commits on this PR - I was trying to get my fork synced up and I think something didn't quite work as I expected... I think I had a previous PR unmerged on my local master which caused some trouble when I tried to merge upstream to master.