### PR TITLE
tools/stellar-archivist: add "log" subcommand to list archive checkpoints.

### DIFF
--- a/support/historyarchive/archive.go
+++ b/support/historyarchive/archive.go
@@ -40,6 +40,7 @@ type ConnectOptions struct {
 
 type ArchiveBackend interface {
 	Exists(path string) (bool, error)
+	Size(path string) (int64, error)
 	GetFile(path string) (io.ReadCloser, error)
 	PutFile(path string, in io.ReadCloser) error
 	ListFiles(path string) (chan string, chan error)
@@ -194,14 +195,16 @@ func (a *Archive) ListCategoryCheckpoints(cat string, pth string) (chan uint32, 
 	return ch, errs
 }
 
-func (a *Archive) GetXdrStreamForHash(hash Hash) (*XdrStream, error) {
-	path := fmt.Sprintf(
+func (a *Archive) GetBucketPathForHash(hash Hash) string {
+	return fmt.Sprintf(
 		"bucket/%s/bucket-%s.xdr.gz",
 		HashPrefix(hash).Path(),
 		hash.String(),
 	)
+}
 
-	return a.GetXdrStream(path)
+func (a *Archive) GetXdrStreamForHash(hash Hash) (*XdrStream, error) {
+	return a.GetXdrStream(a.GetBucketPathForHash(hash))
 }
 
 func (a *Archive) GetXdrStream(pth string) (*XdrStream, error) {

--- a/support/historyarchive/fs_archive.go
+++ b/support/historyarchive/fs_archive.go
@@ -32,6 +32,19 @@ func (b *FsArchiveBackend) Exists(pth string) (bool, error) {
 	return true, nil
 }
 
+func (b *FsArchiveBackend) Size(pth string) (int64, error) {
+	pth = path.Join(b.prefix, pth)
+	fi, err := os.Stat(pth)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		} else {
+			return 0, err
+		}
+	}
+	return fi.Size(), nil
+}
+
 func (b *FsArchiveBackend) PutFile(pth string, in io.ReadCloser) error {
 	dir := path.Join(b.prefix, path.Dir(pth))
 	exists, err := b.Exists(dir)

--- a/support/historyarchive/http_archive.go
+++ b/support/historyarchive/http_archive.go
@@ -48,24 +48,46 @@ func (b *HttpArchiveBackend) GetFile(pth string) (io.ReadCloser, error) {
 	return resp.Body, nil
 }
 
-func (b *HttpArchiveBackend) Exists(pth string) (bool, error) {
+func (b *HttpArchiveBackend) Head(pth string) (*http.Response, error) {
 	var derived url.URL = b.base
 	derived.Path = path.Join(derived.Path, pth)
 	resp, err := b.client.Head(derived.String())
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
 	if resp.Body != nil {
 		resp.Body.Close()
 	}
 
+	return resp, nil
+}
+
+func (b *HttpArchiveBackend) Exists(pth string) (bool, error) {
+	resp, err := b.Head(pth)
+	if err != nil {
+		return false, err
+	}
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
 		return true, nil
 	} else if resp.StatusCode == http.StatusNotFound {
 		return false, nil
 	} else {
 		return false, errors.Errorf("Unkown status code=%d", resp.StatusCode)
+	}
+}
+
+func (b *HttpArchiveBackend) Size(pth string) (int64, error) {
+	resp, err := b.Head(pth)
+	if err != nil {
+		return 0, err
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+		return resp.ContentLength, nil
+	} else if resp.StatusCode == http.StatusNotFound {
+		return 0, nil
+	} else {
+		return 0, errors.Errorf("Unkown status code=%d", resp.StatusCode)
 	}
 }
 

--- a/support/historyarchive/log.go
+++ b/support/historyarchive/log.go
@@ -1,0 +1,135 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+package historyarchive
+
+import (
+	"github.com/stellar/go/xdr"
+	"io"
+	"log"
+	"time"
+)
+
+func (has *HistoryArchiveState) GetChangedBuckets(arch *Archive, prevHas *HistoryArchiveState) (string, int, int64) {
+	var (
+		nChangedBytes   int64
+		nChangedBuckets int
+		changedBuckets  string
+	)
+
+	for i, b := range has.CurrentBuckets {
+		if prevHas.CurrentBuckets[i].Curr != b.Curr {
+			nChangedBuckets += 1
+			changedBuckets += "#"
+			nChangedBytes += arch.MustGetBucketSize(MustDecodeHash(b.Curr))
+		} else {
+			changedBuckets += "_"
+		}
+		if prevHas.CurrentBuckets[i].Snap != b.Snap {
+			nChangedBuckets += 1
+			changedBuckets += "#"
+			nChangedBytes += arch.MustGetBucketSize(MustDecodeHash(b.Snap))
+		} else {
+			changedBuckets += "_"
+		}
+	}
+	return changedBuckets, nChangedBuckets, nChangedBytes
+}
+
+func (arch *Archive) MustGetBucketSize(hash Hash) int64 {
+	sz, err := arch.backend.Size(arch.GetBucketPathForHash(hash))
+	if err != nil {
+		panic(err)
+	}
+	return sz
+}
+
+func (arch *Archive) MustGetLedgerHeaderHistoryEntries(chk uint32) []xdr.LedgerHeaderHistoryEntry {
+	path := CategoryCheckpointPath("ledger", chk)
+	rdr, err := arch.GetXdrStream(path)
+	if err != nil {
+		panic(err)
+	}
+	defer rdr.Close()
+	var lhes []xdr.LedgerHeaderHistoryEntry
+	for {
+		lhe := xdr.LedgerHeaderHistoryEntry{}
+		if err = rdr.ReadOne(&lhe); err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				panic(err)
+			}
+		}
+		lhes = append(lhes, lhe)
+	}
+	return lhes
+}
+
+func (arch *Archive) MustGetTransactionHistoryEntries(chk uint32) []xdr.TransactionHistoryEntry {
+	path := CategoryCheckpointPath("transactions", chk)
+	rdr, err := arch.GetXdrStream(path)
+	if err != nil {
+		panic(err)
+	}
+	defer rdr.Close()
+	var thes []xdr.TransactionHistoryEntry
+	for {
+		the := xdr.TransactionHistoryEntry{}
+		if err = rdr.ReadOne(&the); err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				panic(err)
+			}
+		}
+		thes = append(thes, the)
+	}
+	return thes
+}
+
+func (arch *Archive) Log(opts *CommandOptions) error {
+	state, e := arch.GetRootHAS()
+	if e != nil {
+		return e
+	}
+	opts.Range = opts.Range.clamp(state.Range())
+
+	log.SetFlags(0)
+	log.Printf("Log of checkpoint files in range: %s", opts.Range)
+	log.Printf("\n")
+	log.Printf("%10s | %10s | %20s | %5s | %s",
+		"ledger", "hex", "close time", "txs", "buckets changed")
+
+	prevHas, err := arch.GetCheckpointHAS(PrevCheckpoint(opts.Range.Low))
+	if err != nil {
+		return err
+	}
+
+	for chk := range opts.Range.Checkpoints() {
+		has, err := arch.GetCheckpointHAS(chk)
+		if err != nil {
+			return err
+		}
+
+		changedBuckets, nChangedBuckets, nChangedBytes := has.GetChangedBuckets(arch, &prevHas)
+		prevHas = has
+
+		lhes := arch.MustGetLedgerHeaderHistoryEntries(chk)
+		lastlhe := lhes[len(lhes)-1]
+		closeTime := time.Unix(int64(lastlhe.Header.ScpValue.CloseTime), 0)
+
+		nTxs := 0
+		thes := arch.MustGetTransactionHistoryEntries(chk)
+		for _, tx := range thes {
+			nTxs += len(tx.TxSet.Txs)
+		}
+
+		log.Printf("%10d | 0x%08x | %20s | %5d | %2d buckets, %10d bytes, %s",
+			has.CurrentLedger, has.CurrentLedger,
+			closeTime.UTC().Format(time.RFC3339),
+			nTxs, nChangedBuckets, nChangedBytes, changedBuckets)
+	}
+	return nil
+}

--- a/support/historyarchive/mock_archive.go
+++ b/support/historyarchive/mock_archive.go
@@ -25,6 +25,17 @@ func (b *MockArchiveBackend) Exists(pth string) (bool, error) {
 	return ok, nil
 }
 
+func (b *MockArchiveBackend) Size(pth string) (int64, error) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	f, ok := b.files[pth]
+	sz := int64(0)
+	if ok {
+		sz = int64(len(f))
+	}
+	return sz, nil
+}
+
 func (b *MockArchiveBackend) GetFile(pth string) (io.ReadCloser, error) {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()

--- a/tools/stellar-archivist/main.go
+++ b/tools/stellar-archivist/main.go
@@ -72,6 +72,12 @@ func (opts *Options) MaybeProfile() {
 	}
 }
 
+func logArchive(a string, opts *Options) {
+	arch := historyarchive.MustConnect(a, opts.ConnectOpts)
+	opts.SetRange(arch)
+	arch.Log(&opts.CommandOpts)
+}
+
 func scan(a string, opts *Options) {
 	arch := historyarchive.MustConnect(a, opts.ConnectOpts)
 	opts.SetRange(arch)
@@ -208,6 +214,14 @@ func main() {
 		Use: "status",
 		Run: func(cmd *cobra.Command, args []string) {
 			status(firstArg(args), &opts)
+		},
+	})
+
+	rootCmd.AddCommand(&cobra.Command{
+		Use: "log",
+		Run: func(cmd *cobra.Command, args []string) {
+			opts.MaybeProfile()
+			logArchive(firstArg(args), &opts)
 		},
 	})
 


### PR DESCRIPTION

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

This PR adds a new `log` subcommand to stellar-archivist. It includes a very little bit of refactoring of the backends to support a new size query of files in an archive. The output of `log` looks like this:

~~~
$ stellar-archivist log file:///usr/local/stellar-local-archive --last 100000
Log of checkpoint files in range: [0x01810f3f, 0x0182963f]

    ledger |        hex |           close time |   txs | buckets changed
  25235263 | 0x01810f3f | 2019-08-08T22:45:10Z |  1820 |  9 buckets,     963357 bytes, #########_____________
  25235327 | 0x01810f7f | 2019-08-08T22:50:50Z |  1359 |  7 buckets,     353290 bytes, #######_______________
  25235391 | 0x01810fbf | 2019-08-08T22:56:34Z |  1453 |  9 buckets,     876669 bytes, #########_____________
  25235455 | 0x01810fff | 2019-08-08T23:02:15Z |  1382 |  7 buckets,     224811 bytes, #######_______________
  25235519 | 0x0181103f | 2019-08-08T23:07:59Z |  1380 | 13 buckets,    4092383 bytes, #############_________
  25235583 | 0x0181107f | 2019-08-08T23:13:44Z |  1635 |  7 buckets,     507826 bytes, #######_______________
  25235647 | 0x018110bf | 2019-08-08T23:19:28Z |  1348 |  9 buckets,     830184 bytes, #########_____________
  25235711 | 0x018110ff | 2019-08-08T23:25:12Z |  1290 |  7 buckets,     479342 bytes, #######_______________
  25235775 | 0x0181113f | 2019-08-08T23:30:58Z |  1481 |  9 buckets,     913797 bytes, #########_____________
  25235839 | 0x0181117f | 2019-08-08T23:36:39Z |  1345 |  7 buckets,     465308 bytes, #######_______________
  25235903 | 0x018111bf | 2019-08-08T23:42:30Z |  1611 |  9 buckets,    1102281 bytes, #########_____________
  25235967 | 0x018111ff | 2019-08-08T23:48:16Z |  1671 |  7 buckets,     535842 bytes, #######_______________
~~~

### Goal and scope

The goal is to make it a little easier to answer questions like "did we see a spike in new writes to an archive recently" or "when was the last big merge" or such. It's a tool for operators and developers.

### Summary of changes

One new command, "log".

### Known limitations & issues

There's little error handling, it's just an informational command. Also it doesn't use any sort of request parallelism like other commands, so it's kinda slow unless run locally. Should also probably have some sub-modes that make it read less data if the user isn't interested (currently it reads all ledger headers and transaction files, and stats all buckets).

### What shouldn't be reviewed

N/A, happy to fiddle with anything, I just wanted to get a sketch of this written and was thinking of putting it in core, but it's more appropriate in archivist.