### PR TITLE
services/horizon: Change NewSeq attribute in SequenceBumped to be a string.

### DIFF
--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -198,7 +198,7 @@ type AccountFlagsUpdated struct {
 
 type SequenceBumped struct {
 	Base
-	NewSeq int64 `json:"new_seq"`
+	NewSeq string `json:"new_seq"`
 }
 
 type SignerCreated struct {

--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -198,7 +198,7 @@ type AccountFlagsUpdated struct {
 
 type SequenceBumped struct {
 	Base
-	NewSeq string `json:"new_seq"`
+	NewSeq int64 `json:"new_seq,string"`
 }
 
 type SignerCreated struct {

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -8,14 +8,16 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ## v0.20.0
 
+### Breaking changes
+
+- `new_seq` field in `/effects` is now a String [#1604](https://github.com/stellar/go/pull/1604).
+
+### Changes
+
 * Experimental ingestion system is now run concurrently on all Horizon servers (with feature flag set - see below). This improves ingestion availability.
 * Add experimental path finding endpoint which uses an in memory order book for improved performance. To enable it set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable. Note that the `enable-experimental-ingestion` flag enables both the new path finding endpoint and the accounts for signer endpoint.
 * `--enable-accounts-for-signer` CLI param or `ENABLE_ACCOUNTS_FOR_SIGNER=true` env variable are merged with `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
 Add experimental get offers by id endpoint`/offers/{id}` which uses the new ingestion system to fill up the offers table. To enable it, set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
-
-### Breaking changes
-
-- `new_seq` field in `/effects` is now a String [#1604](https://github.com/stellar/go/pull/1604).
 
 ## v0.19.0
 

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -13,6 +13,10 @@ bumps.  A breaking change will get clearly notified in this log.
 * `--enable-accounts-for-signer` CLI param or `ENABLE_ACCOUNTS_FOR_SIGNER=true` env variable are merged with `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
 Add experimental get offers by id endpoint`/offers/{id}` which uses the new ingestion system to fill up the offers table. To enable it, set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
 
+### Breaking changes
+
+- `new_seq` field in `/effects` is now a String [#1604](https://github.com/stellar/go/pull/1604).
+
 ## v0.19.0
 
 * Add `join` parameter to operations and payments endpoints. Currently, the only valid value for the parameter is `transactions`. If `join=transactions` is included in a request then the response will include a `transaction` field for each operation in the response.

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -321,7 +321,16 @@ func TestOperationEffect_BumpSequence(t *testing.T) {
 	if ht.Assert.Equal(200, w.Code) {
 		var result []effects.SequenceBumped
 		ht.UnmarshalPage(w.Body, &result)
-		ht.Assert.Equal("300000000000", result[0].NewSeq)
+		ht.Assert.Equal(int64(300000000000), result[0].NewSeq)
+
+		data, err := json.Marshal(&result[0])
+		ht.Assert.NoError(err)
+		effect := struct {
+			NewSeq string `json:"new_seq"`
+		}{}
+
+		json.Unmarshal(data, &effect)
+		ht.Assert.Equal("300000000000", effect.NewSeq)
 	}
 }
 

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/protocols/horizon/effects"
 	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
@@ -309,6 +310,18 @@ func TestOperation_BumpSequence(t *testing.T) {
 		ht.Require.NoError(err, "failed to parse body")
 		ht.Assert.Equal("bump_sequence", result.Type)
 		ht.Assert.Equal("300000000003", result.BumpTo)
+	}
+}
+
+func TestOperationEffect_BumpSequence(t *testing.T) {
+	ht := StartHTTPTest(t, "kahuna")
+	defer ht.Finish()
+
+	w := ht.Get("/operations/249108107265/effects")
+	if ht.Assert.Equal(200, w.Code) {
+		var result []effects.SequenceBumped
+		ht.UnmarshalPage(w.Body, &result)
+		ht.Assert.Equal("300000000000", result[0].NewSeq)
 	}
 }
 

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -8,6 +8,7 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/guregu/null"
+
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/xdr"
@@ -160,6 +161,12 @@ type Effect struct {
 	Order              int32       `db:"order"`
 	Type               EffectType  `db:"type"`
 	DetailsString      null.String `db:"details"`
+}
+
+// SequenceBumped is a struct of data from `effects.DetailsString`
+// when the effect type is sequence bumped.
+type SequenceBumped struct {
+	NewSeq int64 `json:"new_seq"`
 }
 
 // EffectsQ is a helper struct to aid in configuring queries that loads

--- a/services/horizon/internal/resourceadapter/effects.go
+++ b/services/horizon/internal/resourceadapter/effects.go
@@ -2,7 +2,6 @@ package resourceadapter
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stellar/go/protocols/horizon/effects"
@@ -114,7 +113,7 @@ func NewEffect(
 		e := effects.SequenceBumped{Base: basev}
 		hsb := history.SequenceBumped{}
 		err = row.UnmarshalDetails(&hsb)
-		e.NewSeq = strconv.FormatInt(hsb.NewSeq, 10)
+		e.NewSeq = hsb.NewSeq
 		result = e
 	default:
 		result = basev

--- a/services/horizon/internal/resourceadapter/effects.go
+++ b/services/horizon/internal/resourceadapter/effects.go
@@ -2,6 +2,7 @@ package resourceadapter
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stellar/go/protocols/horizon/effects"
@@ -111,7 +112,9 @@ func NewEffect(
 		result = e
 	case history.EffectSequenceBumped:
 		e := effects.SequenceBumped{Base: basev}
-		err = row.UnmarshalDetails(&e)
+		hsb := history.SequenceBumped{}
+		err = row.UnmarshalDetails(&hsb)
+		e.NewSeq = strconv.FormatInt(hsb.NewSeq, 10)
 		result = e
 	default:
 		result = basev


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [X] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ X] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [X] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [X] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary
Change data type for field `NewSeq` in `SequenceBumped` effect from `int64` to `string.` Fixes #1363.

### Goal and scope

Update horizon's `JSON `response for field `new_seq` in `NewSequenceBumped` effect to return a `string` instead of an `int64`. Using an `int64` produces inconsistent results for clients using `JavaScript` since some `int64 `numbers cannot be represented as JavaScript numbers.

### Summary of changes
1. Add a new struct to represent `SequenceBumped` at the database (`history`) level.
2. Update the `effects` resource adapter to use the new struct when parsing the `jsonb` in effects and then pass the value as a string to the horizon representation of effect.

### Known limitations & issues

This will likely break clients who are expecting an `int64` instead of a `string`.

### What shouldn't be reviewed

N/A
