### PR TITLE
all: drop support for go 1.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,14 +95,6 @@ commands:
 #-----------------------------------------------------------------------------#
 
 jobs:
-  # check_code_1_10 performs code checks using Go 1.10 (gofmt is only run for 1.12).
-  check_code_1_10:
-    working_directory: /go/src/github.com/stellar/go
-    docker:
-      - image: circleci/golang:1.10-stretch
-    steps:
-      - govet
-
   # check_code_1_11 performs code checks using Go 1.11 (gofmt is only run for 1.12).
   check_code_1_11:
     working_directory: /go/src/github.com/stellar/go
@@ -121,26 +113,6 @@ jobs:
       - gofmt
       - govet
       - staticcheck
-
-  # test_code_1_10 performs all package tests using Go 1.10.
-  test_code_1_10:
-    working_directory: /go/src/github.com/stellar/go
-    docker:
-      - image: circleci/golang:1.10-stretch
-        environment:
-          PGHOST: localhost
-          PGPORT: 5432
-          PGUSER: circleci
-          MYSQL_HOST: 127.0.0.1
-          MYSQL_PORT: 3306
-      - image: circleci/postgres:9.6.5-alpine-ram
-        environment:
-          POSTGRES_USER: circleci
-      - image: circleci/mysql:5.7
-      - image: circleci/redis:5.0-alpine
-    steps:
-      - install_go_deps
-      - test_packages
 
   # test_code_1_11 performs all package tests using Go 1.11.
   test_code_1_11:
@@ -215,10 +187,8 @@ workflows:
 
   check_code_and_test:
     jobs:
-      - check_code_1_10
       - check_code_1_11
       - check_code_1_12
-      - test_code_1_10
       - test_code_1_11
       - test_code_1_12
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,8 +193,10 @@ workflows:
 
   check_code_and_test:
     jobs:
+      - check_code_1_10
       - check_code_1_11
       - check_code_1_12
+      - test_code_1_10
       - test_code_1_11
       - test_code_1_12
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,11 @@ commands:
 jobs:
   # check_code_1_10 is being removed, but kept here because removing jobs is a two step process
   check_code_1_10:
+    working_directory: /go/src/github.com/stellar/go
+    docker:
+      - image: circleci/golang:1.10-stretch
+    steps:
+      - govet
 
   # check_code_1_11 performs code checks using Go 1.11 (gofmt is only run for 1.12).
   check_code_1_11:
@@ -119,6 +124,23 @@ jobs:
 
   # test_code_1_10 is being removed, but kept here because removing jobs is a two step process
   test_code_1_10:
+    working_directory: /go/src/github.com/stellar/go
+    docker:
+      - image: circleci/golang:1.10-stretch
+        environment:
+          PGHOST: localhost
+          PGPORT: 5432
+          PGUSER: circleci
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_PORT: 3306
+      - image: circleci/postgres:9.6.5-alpine-ram
+        environment:
+          POSTGRES_USER: circleci
+      - image: circleci/mysql:5.7
+      - image: circleci/redis:5.0-alpine
+    steps:
+      - install_go_deps
+      - test_packages
 
   # test_code_1_11 performs all package tests using Go 1.11.
   test_code_1_11:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,14 +95,6 @@ commands:
 #-----------------------------------------------------------------------------#
 
 jobs:
-  # check_code_1_10 is being removed, but kept here because removing jobs is a two step process
-  check_code_1_10:
-    working_directory: /go/src/github.com/stellar/go
-    docker:
-      - image: circleci/golang:1.10-stretch
-    steps:
-      - govet
-
   # check_code_1_11 performs code checks using Go 1.11 (gofmt is only run for 1.12).
   check_code_1_11:
     working_directory: /go/src/github.com/stellar/go
@@ -121,26 +113,6 @@ jobs:
       - gofmt
       - govet
       - staticcheck
-
-  # test_code_1_10 is being removed, but kept here because removing jobs is a two step process
-  test_code_1_10:
-    working_directory: /go/src/github.com/stellar/go
-    docker:
-      - image: circleci/golang:1.10-stretch
-        environment:
-          PGHOST: localhost
-          PGPORT: 5432
-          PGUSER: circleci
-          MYSQL_HOST: 127.0.0.1
-          MYSQL_PORT: 3306
-      - image: circleci/postgres:9.6.5-alpine-ram
-        environment:
-          POSTGRES_USER: circleci
-      - image: circleci/mysql:5.7
-      - image: circleci/redis:5.0-alpine
-    steps:
-      - install_go_deps
-      - test_packages
 
   # test_code_1_11 performs all package tests using Go 1.11.
   test_code_1_11:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,9 @@ commands:
 #-----------------------------------------------------------------------------#
 
 jobs:
+  # check_code_1_10 is being removed, but kept here because removing jobs is a two step process
+  check_code_1_10:
+
   # check_code_1_11 performs code checks using Go 1.11 (gofmt is only run for 1.12).
   check_code_1_11:
     working_directory: /go/src/github.com/stellar/go
@@ -113,6 +116,9 @@ jobs:
       - gofmt
       - govet
       - staticcheck
+
+  # test_code_1_10 is being removed, but kept here because removing jobs is a two step process
+  test_code_1_10:
 
   # test_code_1_11 performs all package tests using Go 1.11.
   test_code_1_11:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,10 +215,8 @@ workflows:
 
   check_code_and_test:
     jobs:
-      - check_code_1_10
       - check_code_1_11
       - check_code_1_12
-      - test_code_1_10
       - test_code_1_11
       - test_code_1_12
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
   ssh_known_hosts:
   - bitbucket.org
 go:
-- '1.10'
 - '1.11'
 - '1.12'
 - tip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3
+FROM golang:1.12.9
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 WORKDIR /go/src/github.com/stellar/go
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.9
+FROM golang:1.12
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 WORKDIR /go/src/github.com/stellar/go
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ This repo is the home for all of the public go code produced by SDF.  In additio
 
 ## Dependencies
 
-This repository depends upon a [number of external dependencies](./Gopkg.lock), and uses [dep](https://golang.github.io/dep/) to manage them (see installation instructions [here](https://golang.github.io/dep/docs/installation.html)).  
+This repository is officially supported on the last two releases of Go, which is currently Go 1.11 and Go 1.12.
+
+It depends on a [number of external dependencies](./Gopkg.lock), and uses [dep](https://golang.github.io/dep/) to manage them (see installation instructions [here](https://golang.github.io/dep/docs/installation.html)).
 
 To satisfy dependencies and populate the `vendor` directory run: 
 

--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+- Dropped support for Go 1.10.
+
 ## [v1.4.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.4.0) - 2019-08-09
 
 - Add support for querying operation endpoint with `join` parameter [#1521](https://github.com/stellar/go/issues/1521).

--- a/clients/horizonclient/README.md
+++ b/clients/horizonclient/README.md
@@ -12,7 +12,7 @@ This library is aimed at developers building Go applications that interact with 
 * The [txnbuild API reference](https://godoc.org/github.com/stellar/go/txnbuild).
 
 ### Prerequisites
-* Go 1.10 or greater
+* Go 1.11 or greater
 
 ### Installing
 * Download the Stellar Go monorepo: `git clone git@github.com:stellar/go.git`

--- a/govet.sh
+++ b/govet.sh
@@ -7,7 +7,7 @@ set -e
 # For now we just skip the shadow checking for Go 1.12+
 # TODO: 2) Not triggering on shadowed vars (output not stdout?)
 # TODO: 3) Fix syntax for Go 1.12+ (go tool vet -> go vet, but fails to find packages?)
-if [[ $GOLANG_VERSION = 1.9.* ]] || [[ $GOLANG_VERSION = 1.10.* ]] || [[ $GOLANG_VERSION = 1.11.* ]]; then
+if [[ $GOLANG_VERSION = 1.11.* ]]; then
     echo "Running go vet checks..."
 OUTPUT=$(ls -d */ \
   | egrep -v '^vendor|^docs' \

--- a/services/bridge/CHANGELOG.md
+++ b/services/bridge/CHANGELOG.md
@@ -5,6 +5,7 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 ## Unreleased
 
 * Fixed path-payment operation in `/payment`
+* Dropped support for Go 1.10.
 
 ## 0.0.32
 

--- a/services/compliance/CHANGELOG.md
+++ b/services/compliance/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 As this project is pre 1.0, breaking changes may happen for minor version bumps. A breaking change will get clearly notified in this log.
 
+## Unreleased
+
+* Dropped support for Go 1.10.
+
 ## 0.0.32
 
 * Compliance server now uses the new Go SDK.

--- a/services/federation/CHANGELOG.md
+++ b/services/federation/CHANGELOG.md
@@ -11,6 +11,7 @@ bumps.  A breaking change will get clearly notified in this log.
 ### Changed
 
 - BREAKING CHANGE: The `url` database configuration has been renamed to `dsn` to more accurately reflect its content.
+- Dropped support for Go 1.10.
 
 ### Fixed
 

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,6 +6,10 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## Unreleased
+
+* Dropped support for Go 1.10.
+
 ## v0.19.0
 
 * Add `join` parameter to operations and payments endpoints. Currently, the only valid value for the parameter is `transactions`. If `join=transactions` is included in a request then the response will include a `transaction` field for each operation in the response.

--- a/services/horizon/internal/docs/admin.md
+++ b/services/horizon/internal/docs/admin.md
@@ -36,7 +36,7 @@ To test the installation, simply run `horizon --help` from a terminal.  If the h
 Should you decide not to use one of our prebuilt releases, you may instead build Horizon from source.  To do so, you need to install some developer tools:
 
 - A unix-like operating system with the common core commands (cp, tar, mkdir, bash, etc.)
-- A compatible distribution of Go (we officially support Go 1.10 and later)
+- A compatible distribution of Go (Go 1.11 or later)
 - [go-dep](https://golang.github.io/dep/)
 - [git](https://git-scm.com/)
 - [mercurial](https://www.mercurial-scm.org/)

--- a/services/horizon/internal/docs/developing.md
+++ b/services/horizon/internal/docs/developing.md
@@ -11,7 +11,7 @@ If you are just starting with Horizon and want to try it out, consider the [Quic
 Building Horizon requires the following developer tools:
 
 - A [Unix-like](https://en.wikipedia.org/wiki/Unix-like) operating system with the common core commands (cp, tar, mkdir, bash, etc.)
-- Golang 1.10 or later
+- Golang 1.11 or later
 - [git](https://git-scm.com/) (to check out Horizon's source code)
 - [go-dep](https://golang.github.io/dep/) (package manager for Go)
 - [mercurial](https://www.mercurial-scm.org/) (needed for `go-dep`)

--- a/services/keystore/CHANGELOG.md
+++ b/services/keystore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Dropped support for Go 1.10.
+
 ## [v1.0.0] - 2019-06-18
 
 Initial release of the keystore.

--- a/services/ticker/CHANGELOG.md
+++ b/services/ticker/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [UNRELEASED]
 - Added nested `"issuer_detail"` field to `/assets.json`.
+- Dropped support for Go 1.10.
 
 
 ## [v1.1.0] - 2019-07-22

--- a/tools/stellar-archivist/CHANGELOG.md
+++ b/tools/stellar-archivist/CHANGELOG.md
@@ -9,6 +9,7 @@ bumps.  A breaking change will get clearly notified in this log.
 ## ???
 
 * Fix race condition in `mirror` command
+* Dropped support for Go 1.10.
 
 ## [v0.1.0] - 2016-08-17
 

--- a/tools/stellar-hd-wallet/CHANGELOG.md
+++ b/tools/stellar-hd-wallet/CHANGELOG.md
@@ -6,6 +6,10 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## Unreleased
+
+- Dropped support for Go 1.10.
+
 ## [v0.0.1] - 2017-12-28
 
 Initial release.

--- a/tools/stellar-sign/CHANGELOG.md
+++ b/tools/stellar-sign/CHANGELOG.md
@@ -6,6 +6,10 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## Unreleased
+
+- Dropped support for Go 1.10.
+
 ## [v0.2.0] - 2016-08-19
 
 ### Added

--- a/tools/stellar-vanity-gen/CHANGELOG.md
+++ b/tools/stellar-vanity-gen/CHANGELOG.md
@@ -6,6 +6,10 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## Unreleased
+
+- Dropped support for Go 1.10.
+
 ## [v0.1.0] - 2016-08-17
 
 Initial release after import from https://github.com/stellar/go-stellar-base/cmd/stellar-vanity-gen

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+* Dropped support for Go 1.10.
+
 ## [v1.4.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.4.0) - 2019-08-09
 
 * Add `BuildChallengeTx` function for building [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md) challenge transaction([#1466](https://github.com/stellar/go/issues/1466)).

--- a/txnbuild/README.md
+++ b/txnbuild/README.md
@@ -61,7 +61,7 @@ This library is aimed at developers building Go applications on top of the [Stel
 An easy-to-follow demonstration that exercises this SDK on the TestNet with actual accounts is also included! See the [Demo](#demo) section below.
 
 ### Prerequisites
-* Go 1.10 or greater
+* Go 1.11 or greater
 
 ### Installing
 * Download the Stellar Go monorepo: `git clone git@github.com:stellar/go.git`


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [ ] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [ ] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Drop support for Go 1.10, which makes the official supported versions:
 - Go 1.11
 - Go 1.12

### Goal and scope

The code in this repository is used in critical systems and we should encourage its use with versions of Go that receive security updates.

The officially supported versions of Go are only the last two releases. Right now the last release is Go 1.12, and so only that version and the version prior are supported. Versions prior to 1.11 do not get security updates.

We also plan to move to using Go Modules instead of Go Dep for dependency management. Go Modules are only supported in Go 1.11 onwards.

### Summary of changes

 - Remove CI jobs that ran checks and tests on Go 1.10.
 - Remove mentions of Go 1.10 in scripts.
 - Replace any Dockerfiles using Go 1.10 with using the latest version of Go.
 - Replace mentions of Go 1.10 being the min supported version, and replaced with Go 1.11.
 - Add explanation of what versions of Go are supported and how that is determined to the top-level README.
 - Add CHANGELOG entries to all services and released packages (txnbuild, horizon client).

### Known limitations & issues

N/A

### Related

Closes #1548 
Related to #1542 