### PR TITLE
services/friendbot: ensure Friendbot does not return a 500 due to unescaped params

### DIFF
--- a/services/friendbot/internal/friendbot_handler.go
+++ b/services/friendbot/internal/friendbot_handler.go
@@ -39,7 +39,9 @@ func (handler *FriendbotHandler) doHandle(r *http.Request) (*horizon.Transaction
 
 	err = r.ParseForm()
 	if err != nil {
-		return nil, err
+		p := problem.BadRequest
+		p.Detail = "Request parameters are not escaped or incorrectly formatted."
+		return nil, &p
 	}
 
 	address, err := handler.loadAddress(r)


### PR DESCRIPTION
This PR fixes Error 1 of issue #1512

Friendbot was returning a 500 on requests that provided non-url-escaped values for the `addr` parameter, as see on the logs:

**Request**
`time=“2019-07-30T08:19:47.697Z” level=info msg=“finished request” bytes=444 duration=“53.107µs” method=GET path=“/?addr=%s” pid=15931 req=frontend-friendbot-001a/HlNPxBapp5-053399 status=500 subsys=http`

**Log**
`time=“2019-07-30T08:19:47.697Z” level=error msg=“invalid URL escape \”%s\”” pid=15931 stack=unknown`

This PR fixes that issue by ensuring we return a Bad Request (400) status whenever we're unable to correctly parse the provided request parameters.
