### PR TITLE
circleci: Add CircleCI step to publish horizon docker image for every release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,6 +206,23 @@ jobs:
             else
                 echo "No files found in ./dist. No binaries to publish for ${CIRCLE_TAG}."
             fi
+
+  publish_horizon_docker_image:
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build and Push Docker image
+          command: |
+            # CIRCLE_TAG will be prefixed by "horizon-v", here we build the horizon docker image and tag it with stellar/horizon:$VERSION
+            # where version is CIRCLE_TAG without the "horizon-v" prefiix
+            VERSION=$(echo $CIRCLE_BRANCH | sed -e "s/^horizon-v//")
+            docker build -f services/horizon/docker/Dockerfile -t stellar/horizon:$VERSION .
+            docker login -u "$DOCKER_USER" -u "$DOCKER_PASS"
+            docker push stellar/horizon:$VERSION
+
 #-------------------------------------------------------------------------#
 # Workflows orchestrate jobs and make sure they run in the right sequence #
 #-------------------------------------------------------------------------#
@@ -221,6 +238,12 @@ workflows:
       - test_code_1_10
       - test_code_1_11
       - test_code_1_12
+      - publish_horizon_docker_image:
+          filters:
+              tags:
+                only: /^horizon-v.*/
+              branches:
+                only: /^horizon-v.*/
 
   build_and_deploy:
     jobs:


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Add CircleCI step to publish horizon docker image for every release

### Goal and scope

The goal of this PR is to publish a horizon docker image for every release of horizon.

### Summary of changes

* Add `publish_horizon_docker_image` , a circle CI job which builds and pushes a horizon docker image
* invoke  `publish_horizon_docker_image` on all tags which match the following regular expression `^ horizon-v.*`

Note we will need to add a docker hub login and password in the CircleCI build environment

### Known limitations & issues

N / A

### What shouldn't be reviewed

N / A
