### PR TITLE
Change NewSeq back to int64 in horizon response.

### DIFF
--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -198,7 +198,7 @@ type AccountFlagsUpdated struct {
 
 type SequenceBumped struct {
 	Base
-	NewSeq int64 `json:"new_seq,string"`
+	NewSeq int64 `json:"new_seq"`
 }
 
 type SignerCreated struct {

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -8,16 +8,13 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ## v0.20.0
 
-### Breaking changes
-
-- `new_seq` field in `/effects` is now a String [#1604](https://github.com/stellar/go/pull/1604).
-
 ### Changes
 
 * Experimental ingestion system is now run concurrently on all Horizon servers (with feature flag set - see below). This improves ingestion availability.
 * Add experimental path finding endpoints which use an in memory order book for improved performance. To enable the endpoints set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable. Note that the `enable-experimental-ingestion` flag enables both the new path finding endpoints and the accounts for signer endpoint. There are two path finding endpoints. `/paths/strict-send` returns payment paths where both the source and destination assets are fixed. This endpoint is able to answer questions like: "Get me the most EUR possible for my 10 USD." `/paths/strict-receive` is the other endpoint which is an alias to the existing `/paths` endpoint. 
 * `--enable-accounts-for-signer` CLI param or `ENABLE_ACCOUNTS_FOR_SIGNER=true` env variable are merged with `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
 * Add experimental get offers by id endpoint`/offers/{id}` which uses the new ingestion system to fill up the offers table. To enable it, set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
+
 
 ## v0.19.0
 

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -15,6 +15,16 @@ bumps.  A breaking change will get clearly notified in this log.
 * `--enable-accounts-for-signer` CLI param or `ENABLE_ACCOUNTS_FOR_SIGNER=true` env variable are merged with `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
 * Add experimental get offers by id endpoint`/offers/{id}` which uses the new ingestion system to fill up the offers table. To enable it, set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
 
+### Scheduled Breaking Changes
+
+The type for the following attributes will be changed from `int64` to `string` in the upcoming `0.22` release.
+
+- Attribute `offer_id` in [manage buy offer](https://www.stellar.org/developers/horizon/reference/resources/operation.html#manage-buy-offer) and [manage sell offer](https://www.stellar.org/developers/horizon/reference/resources/operation.html#manage-sell-offer) operations.
+- Attribute `offer_id` in `Trade` effect.
+- Attribute `id` in [Offer](https://www.stellar.org/developers/horizon/reference/resources/offer.html) resource.
+- Attribute `timestamp` and `trade_count` in [Trade Aggregation](https://www.stellar.org/developers/horizon/reference/resources/trade_aggregation.html) resource.
+
+If you are an SDK maintainer, update your code to prepare for this change.
 
 ## v0.19.0
 

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -322,15 +322,6 @@ func TestOperationEffect_BumpSequence(t *testing.T) {
 		var result []effects.SequenceBumped
 		ht.UnmarshalPage(w.Body, &result)
 		ht.Assert.Equal(int64(300000000000), result[0].NewSeq)
-
-		data, err := json.Marshal(&result[0])
-		ht.Assert.NoError(err)
-		effect := struct {
-			NewSeq string `json:"new_seq"`
-		}{}
-
-		json.Unmarshal(data, &effect)
-		ht.Assert.Equal("300000000000", effect.NewSeq)
 	}
 }
 


### PR DESCRIPTION
Reverting the change which fixes #1363 -- we'll introduce this breaking change in Horizon 0.22
