### PR TITLE
services/horizon: add missing required configs to .env.template

### DIFF
--- a/services/horizon/.env.template
+++ b/services/horizon/.env.template
@@ -3,7 +3,9 @@
 DATABASE_URL              = "postgres://localhost/horizon_development?sslmode=disable"
 STELLAR_CORE_DATABASE_URL = "postgres://localhost/hayashi_development?sslmode=disable"
 STELLAR_CORE_URL          = "http://localhost:8080"
+NETWORK_PASSPHRASE        = "Test SDF Network ; September 2015"
 REDIS_URL                 = "redis://127.0.0.1:6379"
+RATE_LIMIT_REDIS_KEY      = "ratelimit"
 PER_HOUR_RATE_LIMIT       = 72000
 FRIENDBOT_URL             = "http://localhost:8004/"
 RUBY_HORIZON_URL          = "http://localhost:3000/"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [ ] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [ ] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [ ] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Add the `RATE_LIMIT_REDIS_KEY` and `NETWORK_PASSPHRASE` config options to
the horizon `.env.template` file.

### Goal and scope

The template file looks like the fastest way to get started with some
good defaults when developing, but when I ran horizon using the file I
had to add values for these two keys because they require a value.
Adding them should make it a bit easier for the next person and both
are options I think we should be able to offer a good default for.

### Known limitations & issues

N/A

### What shouldn't be reviewed

N/A