### PR TITLE
services/horizon/internal: Fix path finding bug with empty source account

### DIFF
--- a/services/horizon/internal/actions_path.go
+++ b/services/horizon/internal/actions_path.go
@@ -46,6 +46,10 @@ func (action *PathIndexAction) loadSourceAssets() {
 }
 
 func (action *PathIndexAction) loadRecords() {
+	if len(action.Query.SourceAssets) == 0 {
+		action.Records = []paths.Path{}
+		return
+	}
 	action.Records, action.Err = action.App.paths.Find(action.Query, action.App.config.MaxPathLength)
 	if action.Err == simplepath.ErrEmptyInMemoryOrderBook {
 		action.Err = problem.StillIngesting

--- a/services/horizon/internal/actions_path_test.go
+++ b/services/horizon/internal/actions_path_test.go
@@ -150,6 +150,53 @@ func TestPathActionsInMemoryFinder(t *testing.T) {
 	}
 }
 
+func TestPathActionsEmptySourceAcount(t *testing.T) {
+	ht := StartHTTPTest(t, "paths")
+	defer ht.Finish()
+
+	orderBookGraph := orderbook.NewOrderBookGraph()
+
+	loadOffers(ht.T, orderBookGraph, "GA2NC4ZOXMXLVQAQQ5IQKJX47M3PKBQV2N5UV5Z4OXLQJ3CKMBA2O2YL")
+	loadOffers(ht.T, orderBookGraph, "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN")
+
+	var q = make(url.Values)
+
+	q.Add(
+		"destination_account",
+		"GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V",
+	)
+	q.Add(
+		"source_account",
+		// there is no account associated with this address
+		"GD5PM5X7Q5MM54ERO2P5PXW3HD6HVZI5IRZGEDWS4OPFBGHNTF6XOWQO",
+	)
+	q.Add(
+		"destination_asset_issuer",
+		"GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+	)
+	q.Add("destination_asset_type", "credit_alphanum4")
+	q.Add("destination_asset_code", "EUR")
+	q.Add("destination_amount", "10")
+
+	for _, uri := range []string{"/paths", "/paths/strict-receive"} {
+		ht.App.paths = simplepath.NewInMemoryFinder(orderBookGraph)
+
+		w := ht.Get(uri + "?" + q.Encode())
+		ht.Assert.Equal(http.StatusOK, w.Code)
+		inMemoryResponse := []horizon.Path{}
+		ht.UnmarshalPage(w.Body, &inMemoryResponse)
+		ht.Assert.Empty(inMemoryResponse)
+
+		ht.App.paths = &simplepath.Finder{ht.App.CoreQ()}
+
+		w = ht.Get(uri + "?" + q.Encode())
+		ht.Assert.Equal(http.StatusOK, w.Code)
+		dbResponse := []horizon.Path{}
+		ht.UnmarshalPage(w.Body, &dbResponse)
+		ht.Assert.Empty(dbResponse)
+	}
+}
+
 func TestPathActionsStrictSend(t *testing.T) {
 	ht := StartHTTPTest(t, "paths")
 	defer ht.Finish()

--- a/services/horizon/internal/db2/core/trustline.go
+++ b/services/horizon/internal/db2/core/trustline.go
@@ -17,7 +17,11 @@ func (q *Q) AssetsForAddress(addy string) ([]xdr.Asset, []xdr.Int64, error) {
 	var tls []Trustline
 	var account Account
 
-	if err := q.AccountByAddress(&account, addy); err != nil {
+	if err := q.AccountByAddress(&account, addy); q.NoRows(err) {
+		// if there is no account for the given address then
+		// we return an empty list of assets and balances
+		return []xdr.Asset{}, []xdr.Int64{}, nil
+	} else if err != nil {
 		return nil, nil, err
 	}
 

--- a/services/horizon/internal/db2/core/trustline_test.go
+++ b/services/horizon/internal/db2/core/trustline_test.go
@@ -39,3 +39,20 @@ func TestAssetsForAddress(t *testing.T) {
 
 	tt.Assert.Equal(expected, assetsToBalance)
 }
+
+func TestAssetsForAddressWithoutAccount(t *testing.T) {
+	tt := test.Start(t).Scenario("order_books")
+	defer tt.Finish()
+	q := &Q{tt.CoreSession()}
+
+	var account Account
+	err := q.AccountByAddress(&account, "GD5PM5X7Q5MM54ERO2P5PXW3HD6HVZI5IRZGEDWS4OPFBGHNTF6XOWQO")
+	tt.Assert.True(q.NoRows(err))
+
+	assets, balances, err := q.AssetsForAddress(
+		"GD5PM5X7Q5MM54ERO2P5PXW3HD6HVZI5IRZGEDWS4OPFBGHNTF6XOWQO",
+	)
+	tt.Assert.NoError(err)
+	tt.Assert.Empty(assets)
+	tt.Assert.Empty(balances)
+}


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

If you send a path finding request where there is no account for the
source account address, the endpoint will respond with a 404.
In this case we should instead respond with an empty list of paths.

