### PR TITLE
Archivist: Mirror --recent mode

### DIFF
--- a/support/historyarchive/mirror.go
+++ b/support/historyarchive/mirror.go
@@ -90,8 +90,8 @@ func Mirror(src *Archive, dst *Archive, opts *CommandOptions) error {
 	}
 
 	wg.Wait()
-	log.Printf("Copied %d checkpoints, %d buckets",
-		opts.Range.Size(), len(bucketFetch))
+	log.Printf("copied %d checkpoints, %d buckets, range %s",
+		opts.Range.Size(), len(bucketFetch), opts.Range)
 	close(tick)
 	e = dst.PutRootHAS(rootHAS, opts)
 	errs += noteError(e)

--- a/support/historyarchive/range.go
+++ b/support/historyarchive/range.go
@@ -22,7 +22,7 @@ func PrevCheckpoint(i uint32) uint32 {
 	if i < freq {
 		return freq - 1
 	}
-	return ((i / freq) * freq) - 1
+	return (((i + 1) / freq) * freq) - 1
 }
 
 func NextCheckpoint(i uint32) uint32 {
@@ -31,7 +31,7 @@ func NextCheckpoint(i uint32) uint32 {
 	}
 	freq := uint64(CheckpointFreq)
 	v := uint64(i)
-	n := (((v + freq - 1) / freq) * freq) - 1
+	n := (((v + freq) / freq) * freq) - 1
 	if n >= 0xffffffff {
 		return 0xffffffff
 	}

--- a/tools/stellar-archivist/CHANGELOG.md
+++ b/tools/stellar-archivist/CHANGELOG.md
@@ -10,6 +10,8 @@ bumps.  A breaking change will get clearly notified in this log.
 
 * Fix race condition in `mirror` command
 * Dropped support for Go 1.10, 1.11.
+* Add `log` command
+* Add `--recent` flag for `mirror` command
 
 ## [v0.1.0] - 2016-08-17
 

--- a/tools/stellar-archivist/README.md
+++ b/tools/stellar-archivist/README.md
@@ -42,6 +42,7 @@ Flags:
       --last int          number of recent ledgers to act on (default -1)
       --low int           first ledger to act on
       --profile           collect and serve profile locally
+  -r, --recent            act on ledger-range difference between achives
       --s3region string   S3 region to connect to (default "us-east-1")
       --s3endpoint string S3 endpoint (default to AWS endpoint for selected region)
       --thorough          decode and re-encode all buckets
@@ -121,9 +122,23 @@ $ stellar-archivist mirror http://s3-eu-west-1.amazonaws.com/history.stellar.org
 
 ```
 
-### Incremental update to a mirror
+### Incremental update to a mirror with --recent
 ```
-$ stellar-archivist --last 1024 mirror http://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-testnet/core_testnet_001 file://local-archive
+$ stellar-archivist mirror --recent http://history.stellar.org/prd/core-live/core_live_001 file://local-archive
+
+2019/08/21 13:53:15 mirroring http://history.stellar.org/prd/core-live/core_live_001 -> file://local-archive
+2019/08/21 13:53:15 copying range [0x01843cbf, 0x01843d7f]
+2019/08/21 13:53:19 skipping existing bucket/18/43/cc/bucket-1843cce32e1c4d6d0765858c9464a7435a6f46c25c8ab164a0d9a11b3da5098b.xdr.gz
+2019/08/21 13:53:20 skipping existing bucket/ff/08/f4/bucket-ff08f47f9d90fdaed40c1d6f0fdb1ea20344cdfac18849690d52aab7125c303c.xdr.gz
+...
+2019/08/21 13:53:20 skipping existing bucket/1e/1e/97/bucket-1e1e97031a1829fe3dff1875abed509103f5fc0569eef0718e02392d411b9c0a.xdr.gz
+2019/08/21 13:53:20 skipping existing bucket/36/e1/0c/bucket-36e10c7087567c3dd230e615851771062acc71cb3e8e7bc08605b1829f49f53c.xdr.gz
+2019/08/21 13:53:22 copied 3 checkpoints, 49 buckets, range [0x01843cbf, 0x01843d7f]
+```
+
+### Incremental update to a mirror with --last N
+```
+$ stellar-archivist --last 1024 mirror http://history.stellar.org/prd/core-testnet/core_testnet_001 file://local-archive
 
 2016/02/10 19:14:01 mirroring http://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-testnet/core_testnet_001 -> file://local-archive
 2016/02/10 19:14:02 copying range [0x0025b23f, 0x0025b6bf]

--- a/tools/stellar-archivist/main.go
+++ b/tools/stellar-archivist/main.go
@@ -43,21 +43,43 @@ type Options struct {
 	Low         int
 	High        uint32
 	Last        int
+	Recent      bool
 	Profile     bool
 	CommandOpts historyarchive.CommandOptions
 	ConnectOpts historyarchive.ConnectOptions
 }
 
-func (opts *Options) SetRange(arch *historyarchive.Archive) {
-	if arch != nil && opts.Last != -1 {
-		state, e := arch.GetRootHAS()
-		if e == nil {
-			low := state.CurrentLedger - uint32(opts.Last)
-			opts.CommandOpts.Range =
-				historyarchive.MakeRange(low, state.CurrentLedger)
-			return
+func (opts *Options) SetRange(srcArch *historyarchive.Archive, dstArch *historyarchive.Archive) {
+	if srcArch != nil {
+
+		// If we got a src and dst archive and were passed --recent, we extract
+		// the range as the sequence-difference between the two.
+		if dstArch != nil && opts.Recent {
+			srcState, e1 := srcArch.GetRootHAS()
+			dstState, e2 := dstArch.GetRootHAS()
+			if e1 == nil && e2 == nil {
+				low := dstState.CurrentLedger
+				high := srcState.CurrentLedger
+				opts.CommandOpts.Range =
+					historyarchive.MakeRange(low, high)
+				return
+			}
+
+			// If we got a src, no dst, and a --last N flag, we extract the
+			// range as the last N ledgers in the src archive.
+		} else if opts.Last != -1 {
+			state, e := srcArch.GetRootHAS()
+			if e == nil {
+				low := state.CurrentLedger - uint32(opts.Last)
+				opts.CommandOpts.Range =
+					historyarchive.MakeRange(low, state.CurrentLedger)
+				return
+			}
 		}
 	}
+
+	// Otherwise we fall back to the provided low and high, which further
+	// default to the entire numeric range of a uint32.
 	opts.CommandOpts.Range =
 		historyarchive.MakeRange(uint32(opts.Low),
 			uint32(opts.High))
@@ -74,13 +96,13 @@ func (opts *Options) MaybeProfile() {
 
 func logArchive(a string, opts *Options) {
 	arch := historyarchive.MustConnect(a, opts.ConnectOpts)
-	opts.SetRange(arch)
+	opts.SetRange(arch, nil)
 	arch.Log(&opts.CommandOpts)
 }
 
 func scan(a string, opts *Options) {
 	arch := historyarchive.MustConnect(a, opts.ConnectOpts)
-	opts.SetRange(arch)
+	opts.SetRange(arch, nil)
 	e1 := arch.Scan(&opts.CommandOpts)
 	e2 := arch.ReportMissing(&opts.CommandOpts)
 	e3 := arch.ReportInvalid(&opts.CommandOpts)
@@ -98,7 +120,7 @@ func scan(a string, opts *Options) {
 func mirror(src string, dst string, opts *Options) {
 	srcArch := historyarchive.MustConnect(src, opts.ConnectOpts)
 	dstArch := historyarchive.MustConnect(dst, opts.ConnectOpts)
-	opts.SetRange(srcArch)
+	opts.SetRange(srcArch, dstArch)
 	log.Printf("mirroring %v -> %v\n", src, dst)
 	e := historyarchive.Mirror(srcArch, dstArch, &opts.CommandOpts)
 	if e != nil {
@@ -109,7 +131,7 @@ func mirror(src string, dst string, opts *Options) {
 func repair(src string, dst string, opts *Options) {
 	srcArch := historyarchive.MustConnect(src, opts.ConnectOpts)
 	dstArch := historyarchive.MustConnect(dst, opts.ConnectOpts)
-	opts.SetRange(srcArch)
+	opts.SetRange(srcArch, dstArch)
 	log.Printf("repairing %v -> %v\n", src, dst)
 	e := historyarchive.Repair(srcArch, dstArch, &opts.CommandOpts)
 	if e != nil {
@@ -142,6 +164,14 @@ func main() {
 		"high",
 		uint32(0xffffffff),
 		"last ledger to act on",
+	)
+
+	rootCmd.PersistentFlags().BoolVarP(
+		&opts.Recent,
+		"recent",
+		"r",
+		false,
+		"act on ledger-range difference between achives",
 	)
 
 	rootCmd.PersistentFlags().IntVar(

--- a/tools/stellar-archivist/main_test.go
+++ b/tools/stellar-archivist/main_test.go
@@ -1,0 +1,47 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+package main
+
+import (
+	"github.com/stellar/go/support/historyarchive"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestLastOption(t *testing.T) {
+	src_arch := historyarchive.MustConnect("mock://test", historyarchive.ConnectOptions{})
+	assert.NotEqual(t, nil, src_arch)
+
+	var src_has historyarchive.HistoryArchiveState
+	src_has.CurrentLedger = uint32(0xbf)
+	cmd_opts := &historyarchive.CommandOptions{Force: true}
+	src_arch.PutRootHAS(src_has, cmd_opts)
+
+	var opts Options
+	opts.Last = 10
+	opts.SetRange(src_arch, nil)
+	assert.Equal(t, uint32(0x7f), opts.CommandOpts.Range.Low)
+	assert.Equal(t, uint32(0xbf), opts.CommandOpts.Range.High)
+}
+
+func TestRecentOption(t *testing.T) {
+	src_arch := historyarchive.MustConnect("mock://test1", historyarchive.ConnectOptions{})
+	dst_arch := historyarchive.MustConnect("mock://test2", historyarchive.ConnectOptions{})
+	assert.NotEqual(t, nil, src_arch)
+	assert.NotEqual(t, nil, dst_arch)
+
+	var src_has, dst_has historyarchive.HistoryArchiveState
+	src_has.CurrentLedger = uint32(0xbf)
+	dst_has.CurrentLedger = uint32(0x3f)
+	cmd_opts := &historyarchive.CommandOptions{Force: true}
+	src_arch.PutRootHAS(src_has, cmd_opts)
+	dst_arch.PutRootHAS(dst_has, cmd_opts)
+
+	var opts Options
+	opts.Recent = true
+	opts.SetRange(src_arch, dst_arch)
+	assert.Equal(t, uint32(0x3f), opts.CommandOpts.Range.Low)
+	assert.Equal(t, uint32(0xbf), opts.CommandOpts.Range.High)
+}


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] (patch) I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Add a `--recent` mode for `mirror`. This saves the user from guessing the appropriate `N` for `--last N`, or a range for `--low` / `--high`. Simply call `stellar-archivist mirror --recent src dst` and it will copy the range from dst's most recent HAS to src's. Running this in a loop should be sufficient to incrementally mirror archives.

### Goal and scope

Make it easier to incrementally mirror an archive.

### Summary of changes

One new flag and bugfix / logging changes.

### Known limitations & issues

It doesn't (and no mode of archivist currently does) do an exact delta between the archives. If something is corrupt or missing in the dst -- but not identified by just "copying the range difference" -- this doesn't find or fix it. A general, fast cross-archive repair mechanism doesn't exist yet.

### What shouldn't be reviewed

N/A
