### PR TITLE
Pre-release updates to Horizon 0.20.0

### DIFF
--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -256,7 +256,8 @@ type TrustlineDeauthorized struct {
 
 type Trade struct {
 	Base
-	Seller            string `json:"seller"`
+	Seller string `json:"seller"`
+	// Action needed in release: horizon-v0.22.0
 	OfferID           int64  `json:"offer_id"`
 	SoldAmount        string `json:"sold_amount"`
 	SoldAssetType     string `json:"sold_asset_type"`

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -225,6 +225,7 @@ type Offer struct {
 		OfferMaker hal.Link `json:"offer_maker"`
 	} `json:"_links"`
 
+	// Action needed in release: horizon-v0.22.0
 	ID                 int64      `json:"id"`
 	PT                 string     `json:"paging_token"`
 	Seller             string     `json:"seller"`
@@ -373,7 +374,9 @@ type TradeEffect struct {
 
 // TradeAggregation represents trade data aggregation over a period of time
 type TradeAggregation struct {
-	Timestamp     int64     `json:"timestamp"`
+	// Action needed in release: horizon-v0.22.0
+	Timestamp int64 `json:"timestamp"`
+	// Action needed in release: horizon-v0.22.0
 	TradeCount    int64     `json:"trade_count"`
 	BaseVolume    string    `json:"base_volume"`
 	CounterVolume string    `json:"counter_volume"`
@@ -412,7 +415,7 @@ type Transaction struct {
 	LedgerCloseTime time.Time `json:"created_at"`
 	Account         string    `json:"source_account"`
 	AccountSequence string    `json:"source_account_sequence"`
-	// Action needed in release: horizon-v0.19.0
+	// Action needed in release: horizon-v0.22.0
 	// Action needed in release: horizonclient-v2.0.0
 	// Remove this field.
 	FeePaid        int32    `json:"fee_paid"`

--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -17,10 +17,10 @@ var TypeNames = map[xdr.OperationType]string{
 	xdr.OperationTypeCreateAccount: "create_account",
 	xdr.OperationTypePayment:       "payment",
 	xdr.OperationTypePathPayment:   "path_payment",
-	// Action needed in release: horizon-v0.19.0
+	// Action needed in release: horizon-v0.22.0
 	// Change name to `manage_sell_offer`
 	xdr.OperationTypeManageSellOffer: "manage_offer",
-	// Action needed in release: horizon-v0.19.0
+	// Action needed in release: horizon-v0.22.0
 	// Change name to `create_passive_sell_offer`
 	xdr.OperationTypeCreatePassiveSellOffer: "create_passive_offer",
 	xdr.OperationTypeSetOptions:             "set_options",
@@ -136,6 +136,7 @@ type CreatePassiveSellOffer struct {
 // is ManageSellOffer.
 type ManageSellOffer struct {
 	Offer
+	// Action needed in release: horizon-v0.22.0
 	OfferID int64 `json:"offer_id"`
 }
 
@@ -143,6 +144,7 @@ type ManageSellOffer struct {
 // is ManageBuyOffer.
 type ManageBuyOffer struct {
 	Offer
+	// Action needed in release: horizon-v0.22.0
 	OfferID int64 `json:"offer_id"`
 }
 

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -17,12 +17,13 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ### Scheduled Breaking Changes
 
-The type for the following attributes will be changed from `int64` to `string` in the upcoming `0.22` release.
-
-- Attribute `offer_id` in [manage buy offer](https://www.stellar.org/developers/horizon/reference/resources/operation.html#manage-buy-offer) and [manage sell offer](https://www.stellar.org/developers/horizon/reference/resources/operation.html#manage-sell-offer) operations.
-- Attribute `offer_id` in `Trade` effect.
-- Attribute `id` in [Offer](https://www.stellar.org/developers/horizon/reference/resources/offer.html) resource.
-- Attribute `timestamp` and `trade_count` in [Trade Aggregation](https://www.stellar.org/developers/horizon/reference/resources/trade_aggregation.html) resource.
+* `fee_paid` field on Transaction resource has been deprecated and will be removed in 0.22.0. Please use new fields added in 0.18.0: `max_fee` that defines the maximum fee the source account is willing to pay and `fee_charged` that defines the fee that was actually paid for a transaction. See [CAP-0005](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0005.md) for more information. This change has been previously scheduled for 0.19.0 release.
+* The following operation type names have been deprecated: `manage_offer` and `create_passive_offer`. The names will be changed to: `manage_sell_offer` and `create_passive_offer` in 0.22.0. This has been previously scheduled for 0.19.0 release.
+* The type for the following attributes will be changed from `int64` to `string` in 0.22.0:
+  - Attribute `offer_id` in [manage buy offer](https://www.stellar.org/developers/horizon/reference/resources/operation.html#manage-buy-offer) and [manage sell offer](https://www.stellar.org/developers/horizon/reference/resources/operation.html#manage-sell-offer) operations.
+  - Attribute `offer_id` in `Trade` effect.
+  - Attribute `id` in [Offer](https://www.stellar.org/developers/horizon/reference/resources/offer.html) resource.
+  - Attribute `timestamp` and `trade_count` in [Trade Aggregation](https://www.stellar.org/developers/horizon/reference/resources/trade_aggregation.html) resource.
 
 If you are an SDK maintainer, update your code to prepare for this change.
 

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -28,8 +28,7 @@ const (
 	// - 1: Initial version
 	// - 2: We added the orderbook, offers processors and distributed
 	//      ingestion.
-	// - 3: We added last_modified_ledger to the offers table.
-	CurrentVersion = 3
+	CurrentVersion = 2
 )
 
 var log = ilog.DefaultLogger.WithField("service", "expingest")


### PR DESCRIPTION
* Updates CHANGELOG with old deprecated, postponed fields.
* Adds `Action Needed` tag for deprecated fields.
* Changes `expingest.CurrentVersion` to `2` (no need to increment it more than once in a single release).