### PR TITLE
circleci: Fix CircleCI OOM errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,14 @@ commands:
             dockerize -wait tcp://localhost:6379 -timeout 1m
       - run:
           name: Run package tests
+          environment:
+            # When running on Docker in Circle, Go thinks there are 36 CPUs
+            # which means the default number of parallel build processes will be 36
+            # but using 36 build processes can lead to OOM errors
+            # because according to https://circleci.com/docs/2.0/configuration-reference/#resource_class ,
+            # the default Docker container only has 2 CPUs available.
+            # That is why we explicitly specify -p=4 to reduce the number of parallel build processes
+            GOFLAGS: -p=4
           command: ./support/scripts/run_tests
 
   # build_packages creates the project's artifacts.

--- a/support/scripts/run_tests
+++ b/support/scripts/run_tests
@@ -1,6 +1,7 @@
 #! /bin/bash
 set -e
 
+echo "using GOFLAGS=$GOFLAGS"
 go test -race .
 find . -maxdepth 1 -mindepth 1 -type d \
   | egrep -v '^\.\/vendor|^.\/docs|^\.\/\..*' \


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Occasionally CircleCI jobs triggered by PRs fail because of OOM errors (see https://circleci.com/gh/stellar/go/6268#usage-queue/containers/0 for an example). The cause and fix for this issue is outlined here:

https://github.com/golang/go/issues/26186#issuecomment-435544512
