### PR TITLE
archivist: fix recent semantic drift in S3 SDK

### DIFF
--- a/support/historyarchive/archive_test.go
+++ b/support/historyarchive/archive_test.go
@@ -24,8 +24,15 @@ func GetTestS3Archive() *Archive {
 	if e != nil {
 		panic(e)
 	}
-	return MustConnect(fmt.Sprintf("s3://history-stg.stellar.org/dev/archivist/test-%s", r),
-		ConnectOptions{S3Region: "eu-west-1"})
+	bucket := fmt.Sprintf("s3://history-stg.stellar.org/dev/archivist/test-%s", r)
+	region := "eu-west-1"
+	if env_bucket := os.Getenv("ARCHIVIST_TEST_S3_BUCKET"); env_bucket != "" {
+		bucket = fmt.Sprintf(env_bucket+"/archivist/test-%s", r)
+	}
+	if env_region := os.Getenv("ARCHIVIST_TEST_S3_REGION"); env_region != "" {
+		region = env_region
+	}
+	return MustConnect(bucket, ConnectOptions{S3Region: region})
 }
 
 func GetTestMockArchive() *Archive {

--- a/support/historyarchive/scan.go
+++ b/support/historyarchive/scan.go
@@ -158,10 +158,10 @@ func (arch *Archive) ScanCheckpointsFast(opts *CommandOptions) error {
 
 func (arch *Archive) Scan(opts *CommandOptions) error {
 	e1 := arch.ScanCheckpoints(opts)
-	e2 := arch.ScanBuckets(opts)
 	if e1 != nil {
 		return e1
 	}
+	e2 := arch.ScanBuckets(opts)
 	if e2 != nil {
 		return e2
 	}

--- a/tools/stellar-archivist/main.go
+++ b/tools/stellar-archivist/main.go
@@ -70,7 +70,10 @@ func (opts *Options) SetRange(srcArch *historyarchive.Archive, dstArch *historya
 		} else if opts.Last != -1 {
 			state, e := srcArch.GetRootHAS()
 			if e == nil {
-				low := state.CurrentLedger - uint32(opts.Last)
+				low := uint32(0)
+				if state.CurrentLedger > uint32(opts.Last) {
+					low = state.CurrentLedger - uint32(opts.Last)
+				}
 				opts.CommandOpts.Range =
 					historyarchive.MakeRange(low, state.CurrentLedger)
 				return


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Fixes to the S3 backend for stellar-archivist. The S3 APIs changed semantics since I last tested it.