### PR TITLE
all: remove dep source for govalidator

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -48,12 +48,12 @@
   revision = "523a5da1a92f01b01f840b61689c0340a0243532"
 
 [[projects]]
+  branch = "master"
   digest = "1:a9d72387197f5b54e24fd51499668fb597e25db8f5223bfb51db3bdd10e2d8eb"
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
   pruneopts = "T"
   revision = "7d2e70ef918f16bd6455529af38304d6d025c952"
-  source = "https://github.com/asaskevich/govalidator.git"
 
 [[projects]]
   digest = "1:b6ce38ef977bd5df1f9a7824549f03e542b772edf86f565ad1392a9fa68b9676"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,8 +3,8 @@
   name = "bitbucket.org/ww/goautoneg"
 
 [[constraint]]
+  branch = "master"
   name = "github.com/asaskevich/govalidator"
-  source = "https://github.com/asaskevich/govalidator.git"
 
 [[constraint]]
   name = "github.com/go-chi/chi"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [ ] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [ ] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [ ] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Remove the `source` parameter for the `github.com/asaskevich/govalidator` dependency in the dep Gopkg.* files.

### Goal and scope

This change is being made to simplify the `go.mod` file that will be generated when we move to Modules (#1634).

The `source` parameter for the `github.com/asaskevich/govalidator` dependency is pointing to the same repository as the dependency name, just with a `.git` extension. GitHub treats the two repository URLs the same and it was probably an error that we set the source to that value. The presence of the `source` parameter causes `go mod init` when converting from go dep to go modules to think the `source` is pointing to a fork which adds an extra unnecessary `replace` directive to the the `go.mod` file that is generated.

This change is expected to be a no-op on existing functionality and on the dependencies that get pulled in during a build as it should cause no changes to the dependencies that `dep` pulls in.

### Summary of changes

- Replace the `source` parameter with a `branch` parameter. The branch parameter is required because either a `source`, `revision`, or `branch` parameter must be provided.

### Known limitations & issues

N/A

### What shouldn't be reviewed

N/A