### PR TITLE
services/horizon: make @bartekn's fork of throttled the primary dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -89,6 +89,13 @@
   revision = "8649d278323ebf6bd20c9cd56ecb152b1c617375"
 
 [[projects]]
+  digest = "1:85f93fc9078d0c5c9cf27001d947e1b6d811c0903ac7fada7c763dba43124f65"
+  name = "github.com/bartekn/throttled"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "3ec61875fad47a6490c3caa8494c77caa707f19e"
+
+[[projects]]
   digest = "1:df45a13368450db7e5a2015aafd8fef7349afd7c9910fb511c74a775ac55a3e8"
   name = "github.com/btcsuite/btcd"
   packages = [
@@ -687,14 +694,6 @@
   revision = "976c720a22c8eb4eb6a0b4348ad85ad12491a506"
 
 [[projects]]
-  digest = "1:a6dd23012ca65b72dbca7b3e06dac44a9bb33b018221a26f213b1802cddfc337"
-  name = "github.com/throttled/throttled"
-  packages = ["."]
-  pruneopts = "T"
-  revision = "c99eef3ad70a3be5a983770523e0e379699c805c"
-  source = "https://github.com/bartekn/throttled.git"
-
-[[projects]]
   branch = "master"
   digest = "1:ec528a786fa75556deed44de7118a74ced456360e782786a20aed292a03955a5"
   name = "github.com/tyler-smith/go-bip32"
@@ -904,6 +903,7 @@
     "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/s3",
+    "github.com/bartekn/throttled",
     "github.com/btcsuite/btcd/chaincfg",
     "github.com/btcsuite/btcd/chaincfg/chainhash",
     "github.com/btcsuite/btcd/rpcclient",
@@ -953,7 +953,6 @@
     "github.com/stretchr/testify/mock",
     "github.com/stretchr/testify/require",
     "github.com/stretchr/testify/suite",
-    "github.com/throttled/throttled",
     "github.com/tyler-smith/go-bip32",
     "github.com/tyler-smith/go-bip39",
     "golang.org/x/crypto/ed25519",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -55,9 +55,8 @@
   revision = "070c81def33f6362a8267b6a4e56fb7bf23fc6b5"
 
 [[constraint]]
-  name = "github.com/throttled/throttled"
-  source = "https://github.com/bartekn/throttled.git"
-  revision = "c99eef3ad70a3be5a983770523e0e379699c805c"
+  name = "github.com/bartekn/throttled"
+  revision = "3ec61875fad47a6490c3caa8494c77caa707f19e"
 
 [[constraint]]
   name = "golang.org/x/crypto"

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/bartekn/throttled"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -15,7 +16,6 @@ import (
 	apkg "github.com/stellar/go/support/app"
 	support "github.com/stellar/go/support/config"
 	"github.com/stellar/go/support/log"
-	"github.com/throttled/throttled"
 )
 
 var config horizon.Config

--- a/services/horizon/internal/actions/rate_limiter_provider.go
+++ b/services/horizon/internal/actions/rate_limiter_provider.go
@@ -1,6 +1,6 @@
 package actions
 
-import "github.com/throttled/throttled"
+import "github.com/bartekn/throttled"
 
 // RateLimiterProvider is an interface that provides access to the type's HTTPRateLimiter.
 type RateLimiterProvider interface {

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bartekn/throttled"
 	"github.com/gomodule/redigo/redis"
 	metrics "github.com/rcrowley/go-metrics"
 	"github.com/stellar/go/clients/stellarcore"
@@ -29,7 +30,6 @@ import (
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
-	"github.com/throttled/throttled"
 	"golang.org/x/net/http2"
 	graceful "gopkg.in/tylerb/graceful.v1"
 )

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"github.com/throttled/throttled"
+	"github.com/bartekn/throttled"
 )
 
 // Config is the configuration for horizon.  It gets populated by the

--- a/services/horizon/internal/helpers_test.go
+++ b/services/horizon/internal/helpers_test.go
@@ -8,12 +8,12 @@ import (
 	"net/http/httptest"
 	"time"
 
+	"github.com/bartekn/throttled"
 	"github.com/go-chi/chi"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/test"
 	supportLog "github.com/stellar/go/support/log"
-	"github.com/throttled/throttled"
 )
 
 func NewTestApp() *App {

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -4,10 +4,10 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/bartekn/throttled"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/throttled/throttled"
 )
 
 type RateLimitMiddlewareTestSuite struct {

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bartekn/throttled"
 	"github.com/go-chi/chi"
 	chimiddleware "github.com/go-chi/chi/middleware"
 	metrics "github.com/rcrowley/go-metrics"
@@ -24,7 +25,6 @@ import (
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/problem"
-	"github.com/throttled/throttled"
 )
 
 const LRUCacheSize = 50000


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [ ] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [ ] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [ ] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Make @bartekn's fork of the `throttled` dependency the primary dependency for that dependency instead of being just a custom source.

### Goal and scope

This is part of the initiative to move to Modules (#1634) and is a small change to simplify our Gopkg.toml/lock files to make that transition possible and simpler.

Using the fork seems to be confusing the go tooling in go1.12 and go1.13rc1, with both behaving a little differently. There is an issue open golang/go#33795 about it. The issue seems to be limited to replacing modules that don't have a `go.mod`, which is the case with the `throttled` module. Since this fork is the only fork of a dependency we use and it is simple package, it is straight forward for us to switch to using the fork fully in name rather than to try and make it work consistently with both versions, and we did that in bartekn/throttled#2. See that issue for more details about why we felt like this is the right move.

For context, in modules a `replace` directive is how we tell the go toolchain that we want to use a fork of a module. However, a replace statement only applies when go commands are executed inside this repo as the main module and so importers of our repo won't be using the fork. This doesn't really matter for `throttled` because we only use it in `internal` and `main` modules of `horizon`, but because of this the go toolchain does care about the original source since importers of our repo will get the original source, not the replacement.

### Important

The revision of `bartekn/throttled` that we're importing did change. You can see the diff here:
https://github.com/bartekn/throttled/compare/c99eef3ad70a3be5a983770523e0e379699c805c...3ec61875fad47a6490c3caa8494c77caa707f19e

### Summary of changes

- Replace `github.com/throttled/throttled` as a dependency with `github.com/bartekn/throttled` so that it is the name of the dependency and not just the source used to retrieve the dependency.
- Replace `github.com/throttled/throttled` in import paths with `github.com/bartekn/throttled`.
- Change the revision of `github.com/bartekn/throttled` to include an additional commits from bartekn/throttled#1, bartekn/throttled#2, and bartekn/throttled@42c87bfa5f9d2a819d12e2347d5516fc5048b643.

### Known limitations & issues

- This pattern of entirely replacing a package with a fork isn't a pattern we can use in every situation. If we were using a fork of a more complex package with sub-packages those sub-packages would still reference it. This is a pattern we have the luxury of using with this simple package, and if the package was more complex we'd have to find a more complex solution or possibly work with the developers of the go toolchain to identify the precise way forward.

### What shouldn't be reviewed

[TODO]