### PR TITLE
services/horizon: ingest-state-reader-temp-set option

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,6 +6,10 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## v0.20.1
+
+* Add `--ingest-state-reader-temp-set` flag (`INGEST_STATE_READER_TEMP_SET` env variable) which defines the storage type used for temporary objects during state ingestion in the new ingestion system. The possible options are: `memory` (requires ~1.5GB RAM, fast) and `postgres` (stores data in temporary table in Postgres, less RAM but slower).
+
 ## v0.20.0
 
 ### Changes

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -315,6 +315,13 @@ var configOpts = []*support.ConfigOption{
 		FlagDefault: false,
 		Usage:       "[EXPERIMENTAL] enables experimental ingestion system",
 	},
+	&support.ConfigOption{
+		Name:        "ingest-state-reader-temp-set",
+		ConfigKey:   &config.IngestStateReaderTempSet,
+		OptType:     types.String,
+		FlagDefault: "memory",
+		Usage:       "defines where to store temporary objects during state ingestion: `memory` (default, more RAM usage, faster) or `postgres` (less RAM usage, slower)",
+	},
 }
 
 func init() {
@@ -359,6 +366,10 @@ func initConfig() {
 
 	// Configure log level
 	log.DefaultLogger.Logger.SetLevel(config.LogLevel)
+
+	if config.IngestStateReaderTempSet != "memory" && config.IngestStateReaderTempSet != "postgres" {
+		log.Fatal("Invalid `ingest-state-reader-temp-set` value: " + config.IngestStateReaderTempSet)
+	}
 
 	// Configure DB params. When config.MaxDBConnections is set, set other
 	// DB params to that value for backward compatibility.

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -49,6 +49,9 @@ type Config struct {
 	// * In-Memory path finding
 	// * Accounts for signers endpoint
 	EnableExperimentalIngestion bool
+	// IngestStateReaderTempSet defines where to store temporary objects during state
+	// ingestion. Possible options are `memory` and `postgres`.
+	IngestStateReaderTempSet string
 	// IngestFailedTransactions toggles whether to ingest failed transactions
 	IngestFailedTransactions bool
 	// CursorName is the cursor used for ingesting from stellar-core.

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -9,6 +9,7 @@ import (
 	raven "github.com/getsentry/raven-go"
 	"github.com/gomodule/redigo/redis"
 	metrics "github.com/rcrowley/go-metrics"
+	ingestio "github.com/stellar/go/exp/ingest/io"
 	"github.com/stellar/go/exp/orderbook"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -70,6 +71,14 @@ func initIngester(app *App) {
 }
 
 func initExpIngester(app *App, orderBookGraph *orderbook.OrderBookGraph) {
+	var tempSet ingestio.TempSet = &ingestio.MemoryTempSet{}
+	switch app.config.IngestStateReaderTempSet {
+	case "postgres":
+		tempSet = &ingestio.PostgresTempSet{
+			Session: app.HorizonSession(context.Background()),
+		}
+	}
+
 	var err error
 	app.expingester, err = expingest.NewSystem(expingest.Config{
 		CoreSession:    app.CoreSession(context.Background()),
@@ -80,6 +89,7 @@ func initExpIngester(app *App, orderBookGraph *orderbook.OrderBookGraph) {
 		HistoryArchiveURL: app.config.HistoryArchiveURLs[0],
 		StellarCoreURL:    app.config.StellarCoreURL,
 		OrderBookGraph:    orderBookGraph,
+		TempSet:           tempSet,
 	})
 	if err != nil {
 		log.Panic(err)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

Horizon 0.20.0 shipped with [`PostgresTempSet`](https://godoc.org/github.com/stellar/go/exp/ingest/io#PostgresTempSet) used for a temporary objects storage in state ingestion in the new ingestion system. Unfortunately it's extremely slow in highly used DBs. This commit adds a new option that allows admins to select the storage for temporary objects:
* `memory` - requires ~1.5GB of RAM during state ingestion and is fast (default),
* `postgres` - smaller RAM requirements but slower (and extremely slow in some deployments).