### PR TITLE
services/horizon: Change "panic" log level entries to "fatal"

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -116,7 +116,7 @@ func (a *App) Serve() {
 	}
 
 	if err != nil {
-		log.Panic(err)
+		log.Fatal(err)
 	}
 
 	a.CloseDB()

--- a/services/horizon/internal/app_test.go
+++ b/services/horizon/internal/app_test.go
@@ -3,21 +3,7 @@ package horizon
 import (
 	"net/http"
 	"testing"
-
-	"github.com/stellar/go/services/horizon/internal/test"
 )
-
-func TestNewApp(t *testing.T) {
-	tt := test.Start(t)
-	defer tt.Finish()
-
-	config := NewTestConfig()
-	config.SentryDSN = "Not a url"
-
-	tt.Assert.Panics(func() {
-		NewApp(config).Close()
-	})
-}
 
 func TestGenericHTTPFeatures(t *testing.T) {
 	ht := StartHTTPTest(t, "base")

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -82,7 +82,7 @@ func initExpIngester(app *App, orderBookGraph *orderbook.OrderBookGraph) {
 		OrderBookGraph:    orderBookGraph,
 	})
 	if err != nil {
-		log.Panic(err)
+		log.Fatal(err)
 	}
 }
 
@@ -103,7 +103,7 @@ func initSentry(app *App) {
 	log.WithField("dsn", app.config.SentryDSN).Info("Initializing sentry")
 	err := raven.SetDSN(app.config.SentryDSN)
 	if err != nil {
-		log.Panic(err)
+		log.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Change `PANIC` entries level to `FATAL` to not print stack trace that can be misleading for users (see: https://github.com/stellar/go/issues/1643#issue-484760269).