### PR TITLE
services/horizon: Add referer to Horizon logs

### DIFF
--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -110,6 +110,7 @@ func logStartOfRequest(ctx context.Context, r *http.Request, streaming bool) {
 		"method":         r.Method,
 		"path":           r.URL.String(),
 		"streaming":      streaming,
+		"referer":        r.Referer(),
 	}).Info("Starting request")
 }
 
@@ -137,6 +138,7 @@ func logEndOfRequest(ctx context.Context, r *http.Request, duration time.Duratio
 		"route":          routePattern,
 		"status":         mw.Status(),
 		"streaming":      streaming,
+		"referer":        r.Referer(),
 	}).Info("Finished request")
 }
 


### PR DESCRIPTION
Add `Referer` header to Horizon logs to better understand who is using it.