### PR TITLE
support/historyarchive: Fix error reporting

### DIFF
--- a/exp/ingest/io/single_ledger_state_reader.go
+++ b/exp/ingest/io/single_ledger_state_reader.go
@@ -58,7 +58,7 @@ type TempSet interface {
 // preloadedEntries defines a number of bucket entries to preload from a
 // bucket in a single run. This is done to allow preloading keys from
 // temp set.
-const preloadedEntries = 50000
+const preloadedEntries = 20000
 
 // MakeSingleLedgerStateReader is a factory method for SingleLedgerStateReader
 func MakeSingleLedgerStateReader(

--- a/support/historyarchive/xdrstream.go
+++ b/support/historyarchive/xdrstream.go
@@ -133,11 +133,15 @@ func (x *XdrStream) ReadOne(in interface{}) error {
 	}
 
 	readi, err := xdr.Unmarshal(&x.buf, in)
+	if err != nil {
+		x.rdr.Close()
+		return err
+	}
 	if int64(readi) != int64(nbytes) {
 		return fmt.Errorf("Unmarshalled %d bytes from XDR, expected %d)",
 			readi, nbytes)
 	}
-	return err
+	return nil
 }
 
 func WriteFramedXdr(out io.Writer, in interface{}) error {

--- a/support/historyarchive/xdrstream.go
+++ b/support/historyarchive/xdrstream.go
@@ -123,13 +123,13 @@ func (x *XdrStream) ReadOne(in interface{}) error {
 	}
 	x.buf.Grow(int(nbytes))
 	read, err := x.buf.ReadFrom(io.LimitReader(x.rdr, int64(nbytes)))
-	if read != int64(nbytes) {
-		x.rdr.Close()
-		return errors.New("Read wrong number of bytes from XDR")
-	}
 	if err != nil {
 		x.rdr.Close()
 		return err
+	}
+	if read != int64(nbytes) {
+		x.rdr.Close()
+		return errors.New("Read wrong number of bytes from XDR")
 	}
 
 	readi, err := xdr.Unmarshal(&x.buf, in)


### PR DESCRIPTION
After deploying `release-horizon-v0.20.1` branch to staging server it stopped processing ledger entries after around 300k entries with an error:
```
Read wrong number of bytes from XDR
```
returned from `XdrStream.ReadOne`. First, I changed the code to return `err` values before proceeding to the next checks. This reveal the real error:
```
stream error: stream ID 311; PROTOCOL_ERROR
```
I couldn't find any information online about this but I suspect this is happening because of the idle timeout. In `SingleLedgerStateReader` we preload entries for a better performance (smaller round-trip time) when getting temporary data from `TempSet`. When entries are being processed the connection stays idle. The second fix (actually: quickfix) was decreasing `preloadedEntries` to `20000` what makes a delay between streaming batches shorter. However it's not a permanent fix. The issue is tracked in https://github.com/stellar/go/issues/1649.