### PR TITLE
services/horizon: Fix regexp in actions_effects

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -9,6 +9,7 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ## Unreleased
 
+* Fixed performance issue in Effects related endpoints.
 * Dropped support for Go 1.10.
 
 ## v0.20.0

--- a/services/horizon/internal/actions_effects.go
+++ b/services/horizon/internal/actions_effects.go
@@ -22,6 +22,8 @@ import (
 var _ actions.JSONer = (*EffectIndexAction)(nil)
 var _ actions.EventStreamer = (*EffectIndexAction)(nil)
 
+var effectsCursorRegexp = regexp.MustCompile("now|\\d+(-\\d+)?")
+
 // EffectIndexAction renders a page of effect resources, identified by
 // a normal page query and optionally filtered by an account, ledger,
 // transaction, or operation.
@@ -180,13 +182,7 @@ func (action *EffectIndexAction) ValidateCursor() {
 		return
 	}
 
-	ok, err := regexp.MatchString("now|\\d+(-\\d+)?", c)
-	if err != nil {
-		action.Err = err
-		return
-	}
-
-	if !ok {
+	if ok := effectsCursorRegexp.MatchString(c); !ok {
 		action.SetInvalidField("cursor", errors.New("invalid format"))
 	}
 }

--- a/services/horizon/internal/actions_effects.go
+++ b/services/horizon/internal/actions_effects.go
@@ -22,7 +22,7 @@ import (
 var _ actions.JSONer = (*EffectIndexAction)(nil)
 var _ actions.EventStreamer = (*EffectIndexAction)(nil)
 
-var effectsCursorRegexp = regexp.MustCompile("now|\\d+(-\\d+)?")
+var effectsCursorRegexp = regexp.MustCompile(`now|\d+(-\d+)?`)
 
 // EffectIndexAction renders a page of effect resources, identified by
 // a normal page query and optionally filtered by an account, ledger,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

This commit fixes the code to compile regexp in `actions_effects.go` only once. I noticed a correlation between CPU spikes and number of requests to effects endpoints and probably this is the reason.