### PR TITLE
services/horizon/internal/scripts: Add script to dump horizon db schema

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,18 @@
             "args": []
         },
         {
+            "name": "Dump Horizon DB Schema",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "remotePath": "",
+            "port": 2345,
+            "host": "127.0.0.1",
+            "program": "${workspaceRoot}/services/horizon/internal/scripts/schema/main.go",
+            "env": {},
+            "args": []
+        },
+        {
           "name": "Remote",
           "type": "go",
           "request": "launch",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -40,6 +40,17 @@
   revision = "20f192218cf52a73397fa2df45bdda720f3e47c8"
 
 [[projects]]
+  digest = "1:39805d87640f58a20344f21f0158299802dc6395464ba3848b9aec8b068057ea"
+  name = "github.com/Microsoft/go-winio"
+  packages = [
+    ".",
+    "pkg/guid",
+  ]
+  pruneopts = "T"
+  revision = "6c72808b55902eae4c5943626030429ff20f3b63"
+  version = "v0.4.14"
+
+[[projects]]
   branch = "master"
   digest = "1:0f58bf4103da77bfd026185b49755f4cd020fec4f12657ea4609d9de4593513c"
   name = "github.com/ajg/form"
@@ -144,6 +155,66 @@
   packages = ["spew"]
   pruneopts = "T"
   revision = "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
+
+[[projects]]
+  digest = "1:d4f83648c3259dd3d07b0f98d505d3e2d2fd0c9388671a76d0e54041b8006338"
+  name = "github.com/docker/distribution"
+  packages = [
+    "digestset",
+    "reference",
+    "registry/api/errcode",
+  ]
+  pruneopts = "T"
+  revision = "2461543d988979529609e8cb6fca9ca190dc48da"
+  version = "v2.7.1"
+
+[[projects]]
+  digest = "1:3abe09d91011f8792dc13caae72bdce42a0a8d5104fece5a45853d673426fd49"
+  name = "github.com/docker/docker"
+  packages = [
+    "api",
+    "api/types",
+    "api/types/blkiodev",
+    "api/types/container",
+    "api/types/events",
+    "api/types/filters",
+    "api/types/image",
+    "api/types/mount",
+    "api/types/network",
+    "api/types/registry",
+    "api/types/strslice",
+    "api/types/swarm",
+    "api/types/swarm/runtime",
+    "api/types/time",
+    "api/types/versions",
+    "api/types/volume",
+    "client",
+    "errdefs",
+  ]
+  pruneopts = "T"
+  revision = "fa8dd90ceb7bcb9d554d27e0b9087ab83e54bd2b"
+  source = "github.com/docker/engine"
+  version = "v19.03.1"
+
+[[projects]]
+  digest = "1:b64eea95d41af3792092af9c951efcd2d8d8bfd2335c851f7afaf54d6be12c66"
+  name = "github.com/docker/go-connections"
+  packages = [
+    "nat",
+    "sockets",
+    "tlsconfig",
+  ]
+  pruneopts = "T"
+  revision = "7395e3f8aa162843a74ed6d48e79627d9792ac55"
+  version = "v0.4.0"
+
+[[projects]]
+  digest = "1:e95ef557dc3120984bb66b385ae01b4bb8ff56bcde28e7b0d1beed0cccc4d69f"
+  name = "github.com/docker/go-units"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "519db1ee28dcc9fd2474ae59fca29a810482bfb1"
+  version = "v0.4.0"
 
 [[projects]]
   digest = "1:044b2f1eea2f5cfb0d3678baf60892734f59d5c2ea3932cb6ed894a97ccba15c"
@@ -254,12 +325,34 @@
   version = "v1.6.0"
 
 [[projects]]
+  digest = "1:c6e109ed32d266dea072dd6d00e3ee26fb960f86ed0ba7f6a07e5d2bfdeab868"
+  name = "github.com/gogo/protobuf"
+  packages = ["proto"]
+  pruneopts = "T"
+  revision = "ba06b47c162d49f2af050fb4c75bcbc86a159d5c"
+  version = "v1.2.1"
+
+[[projects]]
   branch = "master"
   digest = "1:205b3c069003f9d1458e4304427ab3652d8d7bac3bde1568a2d5486451e453bd"
   name = "github.com/goji/httpauth"
   packages = ["."]
   pruneopts = "T"
   revision = "2da839ab0f4df05a6db5eb277995589dadbd4fb9"
+
+[[projects]]
+  digest = "1:ee6b8c03e5ab6cf9628a3c538430d007f8534483dc46c7ff5955a4359d5ef865"
+  name = "github.com/golang/protobuf"
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp",
+  ]
+  pruneopts = "T"
+  revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
+  version = "v1.3.2"
 
 [[projects]]
   digest = "1:eca5b59a68125905e4f62d6f5072f01740a7648a808e93f6d76c5334ff948601"
@@ -534,6 +627,25 @@
   ]
   pruneopts = "T"
   revision = "649b44d988ce182cabcda7dba01fcf3b6179ad19"
+
+[[projects]]
+  digest = "1:ee4d4af67d93cc7644157882329023ce9a7bcfce956a079069a9405521c7cc8d"
+  name = "github.com/opencontainers/go-digest"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
+  version = "v1.0.0-rc1"
+
+[[projects]]
+  digest = "1:eb47da2fdabb69f64ce3a42a1790ec0ed9da6718c8378f3fdc41cbe6af184519"
+  name = "github.com/opencontainers/image-spec"
+  packages = [
+    "specs-go",
+    "specs-go/v1",
+  ]
+  pruneopts = "T"
+  revision = "d60099175f88c47cd379c4738d158884749ed235"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:a88448fcd2802025fa764388e12f31f0a64d5d436b369a71b97a6c9da783fafe"
@@ -817,6 +929,7 @@
     "http2/hpack",
     "idna",
     "lex/httplex",
+    "proxy",
     "publicsuffix",
     "websocket",
   ]
@@ -857,6 +970,28 @@
   ]
   pruneopts = "T"
   revision = "1cbadb444a806fd9430d14ad08967ed91da4fa0a"
+
+[[projects]]
+  branch = "master"
+  digest = "1:e1505a39ad844b6a89856ffb97363cc47cbee0c511c1423d2d9c673cc4a215a0"
+  name = "google.golang.org/genproto"
+  packages = ["googleapis/rpc/status"]
+  pruneopts = "T"
+  revision = "24fa4b261c55da65468f2abfdae2b024eef27dfb"
+
+[[projects]]
+  digest = "1:92bc59c5f3ca559a2ec0a39256c767b2759cbec8bba4fce5811f8f509046f0f2"
+  name = "google.golang.org/grpc"
+  packages = [
+    "codes",
+    "connectivity",
+    "grpclog",
+    "internal",
+    "status",
+  ]
+  pruneopts = "T"
+  revision = "6eaf6f47437a6b4e2153a190160ef39a92c7eceb"
+  version = "v1.23.0"
 
 [[projects]]
   digest = "1:3ccd10c863188cfe0d936fcfe6a055c95362e43af8e7039e33baade846928e74"
@@ -928,6 +1063,9 @@
     "github.com/btcsuite/btcd/txscript",
     "github.com/btcsuite/btcd/wire",
     "github.com/btcsuite/btcutil",
+    "github.com/docker/docker/api/types",
+    "github.com/docker/docker/api/types/container",
+    "github.com/docker/docker/client",
     "github.com/elazarl/go-bindata-assetfs",
     "github.com/ethereum/go-ethereum/common",
     "github.com/ethereum/go-ethereum/core/types",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,3 +88,12 @@
 [[constraint]]
   branch = "master"
   name = "github.com/shurcooL/httpfs"
+
+# We are using `github.com/docker/engine` as source since it has tagged
+# versions, unlike `github.com/moby/moby`, please read
+# https://github.com/moby/moby/issues/38063#issuecomment-431324613 for a
+# detailed explanation.
+[[constraint]]
+  name = "github.com/docker/docker"
+  source = "github.com/docker/engine"
+  version = "19.03.1"

--- a/services/horizon/internal/scripts/schema/main.go
+++ b/services/horizon/internal/scripts/schema/main.go
@@ -1,0 +1,166 @@
+// this script produces a dump of the horizon database schema
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	dockerClient "github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/sirupsen/logrus"
+	"github.com/stellar/go/services/horizon/internal/db2/schema"
+)
+
+func pullImage(cli *dockerClient.Client, image string) error {
+	reader, err := cli.ImagePull(context.Background(), image, types.ImagePullOptions{})
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	// wait for the pull to finish
+	if _, err := io.Copy(os.Stderr, reader); err != nil {
+		return err
+	}
+	return nil
+}
+
+func startContainer(cli *dockerClient.Client, image string, env []string) (string, error) {
+
+	config := &container.Config{Image: image, Env: env}
+
+	hostConfig := &container.HostConfig{
+		AutoRemove:      true,
+		PublishAllPorts: true,
+	}
+
+	containerInfo, err := cli.ContainerCreate(context.Background(), config, hostConfig, nil, "")
+	if err != nil {
+		if dockerClient.IsErrNotFound(err) {
+			if err := pullImage(cli, image); err != nil {
+				return "", err
+			}
+			containerInfo, err = cli.ContainerCreate(context.Background(), config, hostConfig, nil, "")
+			if err != nil {
+				return "", err
+			}
+		} else {
+			return "", err
+		}
+	}
+
+	if err = cli.ContainerStart(context.Background(), containerInfo.ID, types.ContainerStartOptions{}); err != nil {
+		return "", err
+	}
+
+	return containerInfo.ID, err
+}
+
+func dbURLFromContainer(cli *dockerClient.Client, containerID, dbName string) (string, error) {
+	inspectResult, err := cli.ContainerInspect(context.Background(), containerID)
+	if err != nil {
+		return "", err
+	}
+
+	if entry, ok := inspectResult.NetworkSettings.Ports["5432/tcp"]; !ok || len(entry) != 1 {
+		return "", errors.New("container missing 5432 port")
+	}
+
+	hostAndPort := inspectResult.NetworkSettings.Ports["5432/tcp"][0]
+	return fmt.Sprintf(
+		"postgres://postgres@localhost:%s/%s?sslmode=disable",
+		hostAndPort.HostPort,
+		dbName,
+	), nil
+}
+
+const pingTimeoutSeconds = 30
+
+func main() {
+	cli, err := dockerClient.NewEnvClient()
+	if err != nil {
+		logrus.WithError(err).Error("could not create docker client")
+		return
+	}
+
+	containerID, err := startContainer(cli, "postgres:9.6.15-alpine", []string{"POSTGRES_DB=horizon"})
+	if err != nil {
+		logrus.WithError(err).Error("could not create postgres container")
+		return
+	}
+	dbURL, err := dbURLFromContainer(cli, containerID, "horizon")
+	if err != nil {
+		logrus.WithError(err).Error("could not extract postgres url from container")
+		return
+	}
+	defer cli.ContainerRemove(
+		context.Background(),
+		containerID,
+		types.ContainerRemoveOptions{Force: true},
+	)
+
+	db, err := sql.Open("postgres", dbURL)
+	if err != nil {
+		logrus.WithError(err).Error("could not open postgres connection")
+		return
+	}
+
+	for secs := 0; secs <= pingTimeoutSeconds; secs++ {
+		if err = db.Ping(); err == nil {
+			break
+		}
+		if secs >= pingTimeoutSeconds {
+			logrus.WithError(err).Error("could not ping postgres container")
+			return
+		}
+		time.Sleep(time.Millisecond * 500)
+	}
+
+	_, err = schema.Migrate(db, schema.MigrateUp, 0)
+	if err != nil {
+		logrus.WithError(err).Error("could not apply migrations")
+		return
+	}
+
+	execResponse, err := cli.ContainerExecCreate(context.Background(), containerID, types.ExecConfig{
+		Cmd: []string{
+			"pg_dump",
+			"postgres://postgres@localhost/horizon?sslmode=disable",
+			"-n",
+			"public",
+			"--no-owner",
+			"--no-acl",
+			"--inserts",
+			"--no-security-labels",
+		},
+		AttachStdout: true,
+		AttachStderr: true,
+	})
+	if err != nil {
+		logrus.WithError(err).Error("could not apply migrations")
+		return
+	}
+
+	resp, err := cli.ContainerExecAttach(context.Background(), execResponse.ID, types.ExecStartCheck{
+		Tty:    false,
+		Detach: false,
+	})
+	if err != nil {
+		logrus.WithError(err).Error("could not run pg dump")
+		return
+	}
+	defer resp.Close()
+
+	_, err = stdcopy.StdCopy(os.Stdout, os.Stderr, resp.Reader)
+	if err != nil {
+		logrus.WithError(err).Error("could not obtain output from container")
+		return
+	}
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Without latest.sql there is no easy to view the horizon schema. To address this concern I have added a script, services/horizon/internal/scripts/schema/main.go which will print the horizon schema to std out.
You do not need to have postgres running in the background to execute the script because it will create a postgres instance using docker.

To make the transition to go modules easier, this PR should be reviews and merged after the monorepo is using go modules instead of dep