### PR TITLE
services/horizon/internal: Add destination account parameter to path finding endpoint

### DIFF
--- a/exp/orderbook/dfs.go
+++ b/exp/orderbook/dfs.go
@@ -22,6 +22,22 @@ type Path struct {
 	InteriorNodes []xdr.Asset
 }
 
+// SourceAssetString returns the string representation of the path's source asset
+func (p *Path) SourceAssetString() string {
+	if p.sourceAssetString == "" {
+		p.sourceAssetString = p.SourceAsset.String()
+	}
+	return p.sourceAssetString
+}
+
+// DestinationAssetString returns the string representation of the path's destination asset
+func (p *Path) DestinationAssetString() string {
+	if p.destinationAssetString == "" {
+		p.destinationAssetString = p.DestinationAsset.String()
+	}
+	return p.destinationAssetString
+}
+
 type searchState interface {
 	isTerminalNode(
 		currentAsset string,

--- a/exp/orderbook/dfs.go
+++ b/exp/orderbook/dfs.go
@@ -8,14 +8,18 @@ import (
 
 // Path represents a payment path from a source asset to some destination asset
 type Path struct {
-	SourceAmount xdr.Int64
-	SourceAsset  xdr.Asset
-	// sourceAssetString is included as an optimization to improve the performance
-	// of sorting paths by avoiding serializing assets to strings repeatedly
-	sourceAssetString string
-	InteriorNodes     []xdr.Asset
+	SourceAmount      xdr.Int64
+	SourceAsset       xdr.Asset
 	DestinationAsset  xdr.Asset
 	DestinationAmount xdr.Int64
+
+	// sourceAssetString and destinationAssetString are included as an optimization
+	// to improve the performance of sorting paths by avoiding
+	// serializing assets to strings repeatedly
+	sourceAssetString      string
+	destinationAssetString string
+
+	InteriorNodes []xdr.Asset
 }
 
 type searchState interface {
@@ -207,11 +211,12 @@ func (state *buyingGraphSearchState) appendToPaths(
 	}
 
 	state.paths = append(state.paths, Path{
-		SourceAmount:      state.sourceAssetAmount,
-		SourceAsset:       state.sourceAsset,
-		InteriorNodes:     interiorNodes,
-		DestinationAsset:  updatedVisitedList[len(updatedVisitedList)-1],
-		DestinationAmount: currentAssetAmount,
+		SourceAmount:           state.sourceAssetAmount,
+		SourceAsset:            state.sourceAsset,
+		InteriorNodes:          interiorNodes,
+		DestinationAsset:       updatedVisitedList[len(updatedVisitedList)-1],
+		DestinationAmount:      currentAssetAmount,
+		destinationAssetString: currentAsset,
 	})
 }
 

--- a/exp/orderbook/graph.go
+++ b/exp/orderbook/graph.go
@@ -224,6 +224,8 @@ func (graph *OrderBookGraph) FindPaths(
 	return sortAndFilterPaths(
 		searchState.paths,
 		maxAssetsPerPath,
+		compareSourceAsset,
+		sourceAssetEquals,
 	), nil
 }
 
@@ -238,6 +240,7 @@ func (graph *OrderBookGraph) FindFixedPaths(
 	sourceAsset xdr.Asset,
 	amountToSpend xdr.Int64,
 	destinationAssets []xdr.Asset,
+	maxAssetsPerPath int,
 ) ([]Path, error) {
 	target := map[string]bool{}
 	for _, destinationAsset := range destinationAssets {
@@ -272,30 +275,66 @@ func (graph *OrderBookGraph) FindFixedPaths(
 		return searchState.paths[i].DestinationAmount > searchState.paths[j].DestinationAmount
 	})
 
-	return searchState.paths, nil
+	return sortAndFilterPaths(
+		searchState.paths,
+		maxAssetsPerPath,
+		compareDestinationAsset,
+		destinationAssetEquals,
+	), nil
 }
 
-// sortAndFilterPaths sorts the given list of paths by
-// source asset, source asset amount, and path length
-// also, we limit the number of paths with the same source asset to maxPathsPerAsset
+// compareSourceAsset will group payment paths by `SourceAsset`
+// paths which spend less `SourceAmount` will appear earlier in the sorting
+// if there are multiple paths which spend the same `SourceAmount` then shorter payment paths
+// will be prioritized
+func compareSourceAsset(allPaths []Path, i, j int) bool {
+	if allPaths[i].SourceAsset.Equals(allPaths[j].SourceAsset) {
+		if allPaths[i].SourceAmount == allPaths[j].SourceAmount {
+			return len(allPaths[i].InteriorNodes) < len(allPaths[j].InteriorNodes)
+		}
+		return allPaths[i].SourceAmount < allPaths[j].SourceAmount
+	}
+	return allPaths[i].sourceAssetString < allPaths[j].sourceAssetString
+}
+
+// compareDestinationAsset will group payment paths by `DestinationAsset`
+// paths which deliver a higher `DestinationAmount` will appear earlier in the sorting
+// if there are multiple paths which deliver the same `DestinationAmount` then shorter payment paths
+// will be prioritized
+func compareDestinationAsset(allPaths []Path, i, j int) bool {
+	if allPaths[i].DestinationAsset.Equals(allPaths[j].DestinationAsset) {
+		if allPaths[i].DestinationAmount == allPaths[j].DestinationAmount {
+			return len(allPaths[i].InteriorNodes) < len(allPaths[j].InteriorNodes)
+		}
+		return allPaths[i].DestinationAmount > allPaths[j].DestinationAmount
+	}
+	return allPaths[i].destinationAssetString > allPaths[j].destinationAssetString
+}
+
+func sourceAssetEquals(path, otherPath Path) bool {
+	return path.SourceAsset.Equals(otherPath.SourceAsset)
+}
+
+func destinationAssetEquals(path, otherPath Path) bool {
+	return path.DestinationAsset.Equals(otherPath.DestinationAsset)
+}
+
+// sortAndFilterPaths sorts the given list of paths using `comparePaths`
+// also, we limit the number of paths with the same asset to `maxPathsPerAsset`
 func sortAndFilterPaths(
 	allPaths []Path,
 	maxPathsPerAsset int,
+	comparePaths func(allPaths []Path, i, j int) bool,
+	assetsEqual func(path, otherPath Path) bool,
 ) []Path {
 	sort.Slice(allPaths, func(i, j int) bool {
-		if allPaths[i].SourceAsset.Equals(allPaths[j].SourceAsset) {
-			if allPaths[i].SourceAmount == allPaths[j].SourceAmount {
-				return len(allPaths[i].InteriorNodes) < len(allPaths[j].InteriorNodes)
-			}
-			return allPaths[i].SourceAmount < allPaths[j].SourceAmount
-		}
-		return allPaths[i].sourceAssetString < allPaths[j].sourceAssetString
+		return comparePaths(allPaths, i, j)
 	})
 
 	filtered := []Path{}
 	countForAsset := 0
 	for _, entry := range allPaths {
-		if len(filtered) == 0 || !filtered[len(filtered)-1].SourceAsset.Equals(entry.SourceAsset) {
+		if len(filtered) == 0 || !assetsEqual(filtered[len(filtered)-1], entry) {
 			countForAsset = 1
 			filtered = append(filtered, entry)
 		} else if countForAsset < maxPathsPerAsset {

--- a/exp/orderbook/graph.go
+++ b/exp/orderbook/graph.go
@@ -237,10 +237,13 @@ func (graph *OrderBookGraph) FindFixedPaths(
 	sourceAccountID *xdr.AccountId,
 	sourceAsset xdr.Asset,
 	amountToSpend xdr.Int64,
-	destinationAsset xdr.Asset,
+	destinationAssets []xdr.Asset,
 ) ([]Path, error) {
-	destinationAssetString := destinationAsset.String()
-	target := map[string]bool{destinationAssetString: true}
+	target := map[string]bool{}
+	for _, destinationAsset := range destinationAssets {
+		destinationAssetString := destinationAsset.String()
+		target[destinationAssetString] = true
+	}
 
 	searchState := &buyingGraphSearchState{
 		graph:             graph,

--- a/exp/orderbook/graph.go
+++ b/exp/orderbook/graph.go
@@ -16,6 +16,13 @@ var (
 	errBatchAlreadyApplied         = errors.New("cannot apply batched updates more than once")
 )
 
+type sortByType string
+
+const (
+	sortBySourceAsset      sortByType = "source"
+	sortByDestinationAsset sortByType = "destination"
+)
+
 // trading pair represents two assets that can be exchanged if an order is fulfilled
 type tradingPair struct {
 	// buyingAsset is obtained by calling offer.Buying.String() where offer is an xdr.OfferEntry
@@ -224,9 +231,8 @@ func (graph *OrderBookGraph) FindPaths(
 	return sortAndFilterPaths(
 		searchState.paths,
 		maxAssetsPerPath,
-		compareSourceAsset,
-		sourceAssetEquals,
-	), nil
+		sortBySourceAsset,
+	)
 }
 
 // FindFixedPaths returns a list of payment paths where the source and destination
@@ -278,9 +284,8 @@ func (graph *OrderBookGraph) FindFixedPaths(
 	return sortAndFilterPaths(
 		searchState.paths,
 		maxAssetsPerPath,
-		compareDestinationAsset,
-		destinationAssetEquals,
-	), nil
+		sortByDestinationAsset,
+	)
 }
 
 // compareSourceAsset will group payment paths by `SourceAsset`
@@ -294,7 +299,7 @@ func compareSourceAsset(allPaths []Path, i, j int) bool {
 		}
 		return allPaths[i].SourceAmount < allPaths[j].SourceAmount
 	}
-	return allPaths[i].sourceAssetString < allPaths[j].sourceAssetString
+	return allPaths[i].SourceAssetString() < allPaths[j].SourceAssetString()
 }
 
 // compareDestinationAsset will group payment paths by `DestinationAsset`
@@ -308,15 +313,15 @@ func compareDestinationAsset(allPaths []Path, i, j int) bool {
 		}
 		return allPaths[i].DestinationAmount > allPaths[j].DestinationAmount
 	}
-	return allPaths[i].destinationAssetString > allPaths[j].destinationAssetString
+	return allPaths[i].DestinationAssetString() < allPaths[j].DestinationAssetString()
 }
 
-func sourceAssetEquals(path, otherPath Path) bool {
-	return path.SourceAsset.Equals(otherPath.SourceAsset)
+func sourceAssetEquals(p, otherPath Path) bool {
+	return p.SourceAsset.Equals(otherPath.SourceAsset)
 }
 
-func destinationAssetEquals(path, otherPath Path) bool {
-	return path.DestinationAsset.Equals(otherPath.DestinationAsset)
+func destinationAssetEquals(p, otherPath Path) bool {
+	return p.DestinationAsset.Equals(otherPath.DestinationAsset)
 }
 
 // sortAndFilterPaths sorts the given list of paths using `comparePaths`
@@ -324,9 +329,22 @@ func destinationAssetEquals(path, otherPath Path) bool {
 func sortAndFilterPaths(
 	allPaths []Path,
 	maxPathsPerAsset int,
-	comparePaths func(allPaths []Path, i, j int) bool,
-	assetsEqual func(path, otherPath Path) bool,
-) []Path {
+	sortType sortByType,
+) ([]Path, error) {
+	var comparePaths func([]Path, int, int) bool
+	var assetsEqual func(Path, Path) bool
+
+	switch sortType {
+	case sortBySourceAsset:
+		comparePaths = compareSourceAsset
+		assetsEqual = sourceAssetEquals
+	case sortByDestinationAsset:
+		comparePaths = compareDestinationAsset
+		assetsEqual = destinationAssetEquals
+	default:
+		return nil, errors.New("invalid sort by type")
+	}
+
 	sort.Slice(allPaths, func(i, j int) bool {
 		return comparePaths(allPaths, i, j)
 	})
@@ -343,5 +361,5 @@ func sortAndFilterPaths(
 		}
 	}
 
-	return filtered
+	return filtered, nil
 }

--- a/exp/orderbook/graph_test.go
+++ b/exp/orderbook/graph_test.go
@@ -1382,7 +1382,7 @@ func TestFindPathsStartingAt(t *testing.T) {
 		&ignoreOffersFrom,
 		usdAsset,
 		5,
-		nativeAsset,
+		[]xdr.Asset{nativeAsset},
 	)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -1414,7 +1414,7 @@ func TestFindPathsStartingAt(t *testing.T) {
 		nil,
 		yenAsset,
 		5,
-		nativeAsset,
+		[]xdr.Asset{nativeAsset},
 	)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -1429,7 +1429,7 @@ func TestFindPathsStartingAt(t *testing.T) {
 		nil,
 		yenAsset,
 		5,
-		nativeAsset,
+		[]xdr.Asset{nativeAsset},
 	)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -1455,7 +1455,7 @@ func TestFindPathsStartingAt(t *testing.T) {
 		nil,
 		yenAsset,
 		5,
-		nativeAsset,
+		[]xdr.Asset{nativeAsset},
 	)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -1485,5 +1485,51 @@ func TestFindPathsStartingAt(t *testing.T) {
 		},
 	}
 
+	assertPathEquals(t, paths, expectedPaths)
+
+	paths, err = graph.FindFixedPaths(
+		5,
+		nil,
+		yenAsset,
+		5,
+		[]xdr.Asset{nativeAsset, usdAsset},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	expectedPaths = []Path{
+		Path{
+			SourceAmount: 5,
+			SourceAsset:  yenAsset,
+			InteriorNodes: []xdr.Asset{
+				chfAsset,
+				eurAsset,
+				usdAsset,
+			},
+			DestinationAsset:  nativeAsset,
+			DestinationAmount: 80,
+		},
+		Path{
+			SourceAmount: 5,
+			SourceAsset:  yenAsset,
+			InteriorNodes: []xdr.Asset{
+				chfAsset,
+				eurAsset,
+			},
+			DestinationAsset:  nativeAsset,
+			DestinationAmount: 20,
+		},
+		Path{
+			SourceAmount: 5,
+			SourceAsset:  yenAsset,
+			InteriorNodes: []xdr.Asset{
+				chfAsset,
+				eurAsset,
+			},
+			DestinationAsset:  usdAsset,
+			DestinationAmount: 20,
+		},
+	}
 	assertPathEquals(t, paths, expectedPaths)
 }

--- a/exp/orderbook/graph_test.go
+++ b/exp/orderbook/graph_test.go
@@ -982,7 +982,7 @@ func TestConsumeOffersForBuyingAsset(t *testing.T) {
 
 }
 
-func TestSortAndFilterPaths(t *testing.T) {
+func TestSortAndFilterPathsBySourceAsset(t *testing.T) {
 	allPaths := []Path{
 		Path{
 			SourceAmount:      3,
@@ -1038,6 +1038,8 @@ func TestSortAndFilterPaths(t *testing.T) {
 	sortedAndFiltered := sortAndFilterPaths(
 		allPaths,
 		3,
+		compareSourceAsset,
+		sourceAssetEquals,
 	)
 	expectedPaths := []Path{
 		Path{
@@ -1076,6 +1078,107 @@ func TestSortAndFilterPaths(t *testing.T) {
 			InteriorNodes:     []xdr.Asset{},
 			DestinationAsset:  yenAsset,
 			DestinationAmount: 1000,
+		},
+	}
+
+	assertPathEquals(t, sortedAndFiltered, expectedPaths)
+}
+
+func TestSortAndFilterPathsByDestinationAsset(t *testing.T) {
+	allPaths := []Path{
+		Path{
+			SourceAmount:           1000,
+			SourceAsset:            yenAsset,
+			InteriorNodes:          []xdr.Asset{},
+			DestinationAsset:       eurAsset,
+			destinationAssetString: eurAsset.String(),
+			DestinationAmount:      3,
+		},
+		Path{
+			SourceAmount:           1000,
+			SourceAsset:            yenAsset,
+			InteriorNodes:          []xdr.Asset{},
+			DestinationAsset:       eurAsset,
+			destinationAssetString: eurAsset.String(),
+			DestinationAmount:      4,
+		},
+		Path{
+			SourceAmount:           1000,
+			SourceAsset:            yenAsset,
+			InteriorNodes:          []xdr.Asset{},
+			DestinationAsset:       usdAsset,
+			destinationAssetString: usdAsset.String(),
+			DestinationAmount:      1,
+		},
+		Path{
+			SourceAmount:           1000,
+			SourceAsset:            yenAsset,
+			sourceAssetString:      eurAsset.String(),
+			InteriorNodes:          []xdr.Asset{},
+			DestinationAsset:       eurAsset,
+			destinationAssetString: eurAsset.String(),
+			DestinationAmount:      2,
+		},
+		Path{
+			SourceAmount: 1000,
+			SourceAsset:  yenAsset,
+			InteriorNodes: []xdr.Asset{
+				nativeAsset,
+			},
+			DestinationAsset:       eurAsset,
+			destinationAssetString: eurAsset.String(),
+			DestinationAmount:      2,
+		},
+		Path{
+			SourceAmount:           1000,
+			SourceAsset:            yenAsset,
+			InteriorNodes:          []xdr.Asset{},
+			DestinationAsset:       nativeAsset,
+			destinationAssetString: nativeAsset.String(),
+			DestinationAmount:      10,
+		},
+	}
+	sortedAndFiltered := sortAndFilterPaths(
+		allPaths,
+		3,
+		compareDestinationAsset,
+		destinationAssetEquals,
+	)
+	expectedPaths := []Path{
+		Path{
+			SourceAmount:      1000,
+			SourceAsset:       yenAsset,
+			InteriorNodes:     []xdr.Asset{},
+			DestinationAsset:  nativeAsset,
+			DestinationAmount: 10,
+		},
+		Path{
+			SourceAmount:      1000,
+			SourceAsset:       yenAsset,
+			InteriorNodes:     []xdr.Asset{},
+			DestinationAsset:  usdAsset,
+			DestinationAmount: 1,
+		},
+		Path{
+			SourceAmount:      1000,
+			SourceAsset:       yenAsset,
+			InteriorNodes:     []xdr.Asset{},
+			DestinationAsset:  eurAsset,
+			DestinationAmount: 4,
+		},
+		Path{
+			SourceAmount:      1000,
+			SourceAsset:       yenAsset,
+			InteriorNodes:     []xdr.Asset{},
+			DestinationAsset:  eurAsset,
+			DestinationAmount: 3,
+		},
+		Path{
+			SourceAmount:      1000,
+			SourceAsset:       yenAsset,
+			InteriorNodes:     []xdr.Asset{},
+			DestinationAsset:  eurAsset,
+			DestinationAmount: 2,
 		},
 	}
 
@@ -1383,6 +1486,7 @@ func TestFindPathsStartingAt(t *testing.T) {
 		usdAsset,
 		5,
 		[]xdr.Asset{nativeAsset},
+		5,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -1415,6 +1519,7 @@ func TestFindPathsStartingAt(t *testing.T) {
 		yenAsset,
 		5,
 		[]xdr.Asset{nativeAsset},
+		5,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -1430,6 +1535,7 @@ func TestFindPathsStartingAt(t *testing.T) {
 		yenAsset,
 		5,
 		[]xdr.Asset{nativeAsset},
+		5,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -1456,6 +1562,7 @@ func TestFindPathsStartingAt(t *testing.T) {
 		yenAsset,
 		5,
 		[]xdr.Asset{nativeAsset},
+		5,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -1493,6 +1600,7 @@ func TestFindPathsStartingAt(t *testing.T) {
 		yenAsset,
 		5,
 		[]xdr.Asset{nativeAsset, usdAsset},
+		5,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)

--- a/exp/orderbook/graph_test.go
+++ b/exp/orderbook/graph_test.go
@@ -1035,12 +1035,14 @@ func TestSortAndFilterPathsBySourceAsset(t *testing.T) {
 			DestinationAmount: 1000,
 		},
 	}
-	sortedAndFiltered := sortAndFilterPaths(
+	sortedAndFiltered, err := sortAndFilterPaths(
 		allPaths,
 		3,
-		compareSourceAsset,
-		sourceAssetEquals,
+		sortBySourceAsset,
 	)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
 	expectedPaths := []Path{
 		Path{
 			SourceAmount:      2,
@@ -1138,27 +1140,15 @@ func TestSortAndFilterPathsByDestinationAsset(t *testing.T) {
 			DestinationAmount:      10,
 		},
 	}
-	sortedAndFiltered := sortAndFilterPaths(
+	sortedAndFiltered, err := sortAndFilterPaths(
 		allPaths,
 		3,
-		compareDestinationAsset,
-		destinationAssetEquals,
+		sortByDestinationAsset,
 	)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
 	expectedPaths := []Path{
-		Path{
-			SourceAmount:      1000,
-			SourceAsset:       yenAsset,
-			InteriorNodes:     []xdr.Asset{},
-			DestinationAsset:  nativeAsset,
-			DestinationAmount: 10,
-		},
-		Path{
-			SourceAmount:      1000,
-			SourceAsset:       yenAsset,
-			InteriorNodes:     []xdr.Asset{},
-			DestinationAsset:  usdAsset,
-			DestinationAmount: 1,
-		},
 		Path{
 			SourceAmount:      1000,
 			SourceAsset:       yenAsset,
@@ -1179,6 +1169,20 @@ func TestSortAndFilterPathsByDestinationAsset(t *testing.T) {
 			InteriorNodes:     []xdr.Asset{},
 			DestinationAsset:  eurAsset,
 			DestinationAmount: 2,
+		},
+		Path{
+			SourceAmount:      1000,
+			SourceAsset:       yenAsset,
+			InteriorNodes:     []xdr.Asset{},
+			DestinationAsset:  usdAsset,
+			DestinationAmount: 1,
+		},
+		Path{
+			SourceAmount:      1000,
+			SourceAsset:       yenAsset,
+			InteriorNodes:     []xdr.Asset{},
+			DestinationAsset:  nativeAsset,
+			DestinationAmount: 10,
 		},
 	}
 
@@ -1613,6 +1617,16 @@ func TestFindPathsStartingAt(t *testing.T) {
 			InteriorNodes: []xdr.Asset{
 				chfAsset,
 				eurAsset,
+			},
+			DestinationAsset:  usdAsset,
+			DestinationAmount: 20,
+		},
+		Path{
+			SourceAmount: 5,
+			SourceAsset:  yenAsset,
+			InteriorNodes: []xdr.Asset{
+				chfAsset,
+				eurAsset,
 				usdAsset,
 			},
 			DestinationAsset:  nativeAsset,
@@ -1626,16 +1640,6 @@ func TestFindPathsStartingAt(t *testing.T) {
 				eurAsset,
 			},
 			DestinationAsset:  nativeAsset,
-			DestinationAmount: 20,
-		},
-		Path{
-			SourceAmount: 5,
-			SourceAsset:  yenAsset,
-			InteriorNodes: []xdr.Asset{
-				chfAsset,
-				eurAsset,
-			},
-			DestinationAsset:  usdAsset,
 			DestinationAmount: 20,
 		},
 	}

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,13 +6,18 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
-
 ## Unreleased
 
 * Fixed performance issue in Effects related endpoints.
 * Dropped support for Go 1.10, 1.11.
 * Add experimental support for `/offers`. To enable it, set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
 * Add flag to apply pending migrations before running horizon. If there are pending migrations, previously you needed to run `horizon db migrate up` before running `horizon`. Those two steps can be combined into one with the `--apply-migrations` flag (`APPLY_MIGRATIONS` env variable).
+
+## v0.21.0
+
+* `/paths/strict-send` can now accept a `destination_account` parameter. If `destination_account` is provided then the endpoint will return
+all payment paths which terminate with an asset held by `destination_account`. Note that the endpoint will accept a `destination_account`
+or a `destination_asset` but not both.
 
 ## v0.20.1
 

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -15,9 +15,7 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ## v0.21.0
 
-* `/paths/strict-send` can now accept a `destination_account` parameter. If `destination_account` is provided then the endpoint will return
-all payment paths which terminate with an asset held by `destination_account`. Note that the endpoint will accept a `destination_account`
-or a `destination_asset` but not both.
+* `/paths/strict-send` can now accept a `destination_account` parameter. If `destination_account` is provided then the endpoint will return all payment paths which terminate with an asset held by `destination_account`. Note that the endpoint will accept a `destination_account` or a `destination_asset` but not both.
 
 ## v0.20.1
 

--- a/services/horizon/internal/actions_path.go
+++ b/services/horizon/internal/actions_path.go
@@ -76,10 +76,10 @@ func (handler FindPathsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		if err == simplepath.ErrEmptyInMemoryOrderBook {
 			err = horizonProblem.StillIngesting
 		}
-	}
-	if err != nil {
-		problem.Render(ctx, w, err)
-		return
+		if err != nil {
+			problem.Render(ctx, w, err)
+			return
+		}
 	}
 
 	renderPaths(ctx, records, w)
@@ -105,6 +105,22 @@ func renderPaths(ctx context.Context, records []paths.Path, w http.ResponseWrite
 type FindFixedPathsHandler struct {
 	maxPathLength uint
 	pathFinder    paths.Finder
+	coreQ         *core.Q
+}
+
+var destinationAssetOrDestinationAccount = problem.P{
+	Type:   "bad_request",
+	Title:  "Bad Request",
+	Status: http.StatusBadRequest,
+	Detail: "The request requires either a destination asset or a destination account." +
+		"Both fields cannot be present",
+}
+
+var sourceAccountIsDestinationAccount = problem.P{
+	Type:   "bad_request",
+	Title:  "Bad Request",
+	Status: http.StatusBadRequest,
+	Detail: "The source account is the same as the destination account.",
 }
 
 // ServeHTTP implements the http.Handler interface
@@ -128,10 +144,32 @@ func (handler FindFixedPathsHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	destinationAsset, err := actions.GetAsset(r, "destination_")
+	destinationAsset, destinationAssetPresent := actions.MaybeGetAsset(r, "destination_")
+	destinationAccount, err := getAccountID(r, "destination_account", false)
 	if err != nil {
 		problem.Render(ctx, w, err)
 		return
+	}
+
+	if (destinationAccount != "") == destinationAssetPresent {
+		problem.Render(ctx, w, destinationAssetOrDestinationAccount)
+		return
+	}
+
+	destinationAssets := []xdr.Asset{destinationAsset}
+	if destinationAccount != "" {
+		if sourceAccount == destinationAccount {
+			problem.Render(ctx, w, sourceAccountIsDestinationAccount)
+			return
+		}
+
+		destinationAssets, _, err = handler.coreQ.AssetsForAddress(
+			destinationAccount,
+		)
+		if err != nil {
+			problem.Render(ctx, w, err)
+			return
+		}
 	}
 
 	sourceAsset, err := actions.GetAsset(r, "source_")
@@ -146,19 +184,22 @@ func (handler FindFixedPathsHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	records, err := handler.pathFinder.FindFixedPaths(
-		sourceAccountID,
-		sourceAsset,
-		amountToSpend,
-		destinationAsset,
-		handler.maxPathLength,
-	)
-	if err == simplepath.ErrEmptyInMemoryOrderBook {
-		err = horizonProblem.StillIngesting
-	}
-	if err != nil {
-		problem.Render(ctx, w, err)
-		return
+	records := []paths.Path{}
+	if len(destinationAssets) > 0 {
+		records, err = handler.pathFinder.FindFixedPaths(
+			sourceAccountID,
+			sourceAsset,
+			amountToSpend,
+			destinationAssets,
+			handler.maxPathLength,
+		)
+		if err == simplepath.ErrEmptyInMemoryOrderBook {
+			err = horizonProblem.StillIngesting
+		}
+		if err != nil {
+			problem.Render(ctx, w, err)
+			return
+		}
 	}
 
 	renderPaths(ctx, records, w)

--- a/services/horizon/internal/actions_path.go
+++ b/services/horizon/internal/actions_path.go
@@ -112,8 +112,8 @@ var destinationAssetOrDestinationAccount = problem.P{
 	Type:   "bad_request",
 	Title:  "Bad Request",
 	Status: http.StatusBadRequest,
-	Detail: "The request requires either a destination asset or a destination account." +
-		"Both fields cannot be present",
+	Detail: "The request requires either a destination asset or a destination account. " +
+		"Both fields cannot be present.",
 }
 
 var sourceAccountIsDestinationAccount = problem.P{

--- a/services/horizon/internal/actions_path_test.go
+++ b/services/horizon/internal/actions_path_test.go
@@ -12,9 +12,10 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/services/horizon/internal/paths"
-	"github.com/stellar/go/services/horizon/internal/render/problem"
+	horizonProblem "github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/services/horizon/internal/simplepath"
 	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/xdr"
 )
 
@@ -26,6 +27,7 @@ func pathFindingClient(tt *test.T, pathFinder paths.Finder) test.RequestHelper {
 	}
 	findFixedPaths := FindFixedPathsHandler{
 		pathFinder: pathFinder,
+		coreQ:      &core.Q{tt.CoreSession()},
 	}
 
 	installPathFindingRoutes(findPaths, findFixedPaths, router)
@@ -102,7 +104,8 @@ func TestPathActionsStillIngesting(t *testing.T) {
 
 	for _, uri := range []string{"/paths", "/paths/strict-receive"} {
 		w := rh.Get(uri + "?" + q.Encode())
-		assertions.Equal(problem.StillIngesting.Status, w.Code)
+		assertions.Equal(horizonProblem.StillIngesting.Status, w.Code)
+		assertions.Problem(w.Body, horizonProblem.StillIngesting)
 	}
 }
 
@@ -234,6 +237,82 @@ func TestPathActionsEmptySourceAcount(t *testing.T) {
 	}
 }
 
+func TestPathActionsStrictSendDestinationAssetValidation(t *testing.T) {
+	tt := test.Start(t).Scenario("paths")
+	defer tt.Finish()
+	assertions := &Assertions{tt.Assert}
+	orderBookGraph := orderbook.NewOrderBookGraph()
+	rh := pathFindingClient(
+		tt,
+		simplepath.NewInMemoryFinder(orderBookGraph),
+	)
+
+	missingDestinationAccountAndAsset := make(url.Values)
+	missingDestinationAccountAndAsset.Add(
+		"source_asset_issuer",
+		"GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+	)
+	missingDestinationAccountAndAsset.Add(
+		"source_account",
+		"GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP",
+	)
+	missingDestinationAccountAndAsset.Add("source_asset_type", "credit_alphanum4")
+	missingDestinationAccountAndAsset.Add("source_asset_code", "USD")
+	missingDestinationAccountAndAsset.Add("source_amount", "10")
+
+	destinationAccountAndAsset, err := url.ParseQuery(
+		missingDestinationAccountAndAsset.Encode(),
+	)
+	tt.Assert.NoError(err)
+	destinationAccountAndAsset.Add(
+		"destination_asset_issuer",
+		"GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+	)
+	destinationAccountAndAsset.Add("destination_asset_type", "credit_alphanum4")
+	destinationAccountAndAsset.Add("destination_asset_code", "EUR")
+	destinationAccountAndAsset.Add(
+		"destination_account",
+		"GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+	)
+
+	destinationAccountMatchesSourceAccount, err := url.ParseQuery(
+		missingDestinationAccountAndAsset.Encode(),
+	)
+	tt.Assert.NoError(err)
+	destinationAccountMatchesSourceAccount.Add(
+		"destination_account",
+		"GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP",
+	)
+
+	for _, testCase := range []struct {
+		name            string
+		q               url.Values
+		expectedProblem problem.P
+	}{
+		{
+			"both destination asset and destination account are missing",
+			missingDestinationAccountAndAsset,
+			destinationAssetOrDestinationAccount,
+		},
+		{
+			"both destination asset and destination account are present",
+			destinationAccountAndAsset,
+			destinationAssetOrDestinationAccount,
+		},
+		{
+			"destination account is the same as source account",
+			destinationAccountMatchesSourceAccount,
+			sourceAccountIsDestinationAccount,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			w := rh.Get("/paths/strict-send?" + testCase.q.Encode())
+			assertions.Equal(testCase.expectedProblem.Status, w.Code)
+			assertions.Problem(w.Body, testCase.expectedProblem)
+		})
+	}
+}
+
 func TestPathActionsStrictSend(t *testing.T) {
 	tt := test.Start(t).Scenario("paths")
 	defer tt.Finish()
@@ -282,6 +361,66 @@ func TestPathActionsStrictSend(t *testing.T) {
 		assertions.Equal(path.DestinationAssetType, "credit_alphanum4")
 		assertions.Equal(path.DestinationAssetIssuer, "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN")
 		if i > 1 {
+			previous, err := strconv.ParseFloat(inMemoryResponse[i-1].DestinationAmount, 64)
+			assertions.NoError(err)
+
+			current, err := strconv.ParseFloat(path.DestinationAmount, 64)
+			assertions.NoError(err)
+
+			assertions.True(previous >= current)
+		}
+	}
+}
+
+func TestPathActionsStrictSendAccount(t *testing.T) {
+	tt := test.Start(t).Scenario("paths")
+	defer tt.Finish()
+	assertions := &Assertions{tt.Assert}
+	orderBookGraph := orderbook.NewOrderBookGraph()
+	rh := pathFindingClient(
+		tt,
+		simplepath.NewInMemoryFinder(orderBookGraph),
+	)
+
+	loadOffers(tt, orderBookGraph, "GA2NC4ZOXMXLVQAQQ5IQKJX47M3PKBQV2N5UV5Z4OXLQJ3CKMBA2O2YL")
+	loadOffers(tt, orderBookGraph, "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN")
+
+	var q = make(url.Values)
+
+	q.Add(
+		"source_asset_issuer",
+		"GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+	)
+	q.Add("source_asset_type", "credit_alphanum4")
+	q.Add("source_asset_code", "USD")
+	q.Add("source_amount", "10")
+	q.Add(
+		"destination_account",
+		"GA2NC4ZOXMXLVQAQQ5IQKJX47M3PKBQV2N5UV5Z4OXLQJ3CKMBA2O2YL",
+	)
+
+	w := rh.Get("/paths/strict-send?" + q.Encode())
+	assertions.Equal(http.StatusOK, w.Code)
+	inMemoryResponse := []horizon.Path{}
+	tt.UnmarshalPage(w.Body, &inMemoryResponse)
+	assertions.Len(inMemoryResponse, 12)
+
+	for i, path := range inMemoryResponse {
+		assertions.Equal(path.SourceAssetCode, "USD")
+		assertions.Equal(path.SourceAssetType, "credit_alphanum4")
+		assertions.Equal(path.SourceAssetIssuer, "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN")
+		assertions.Equal(path.SourceAmount, "10.0000000")
+
+		if path.DestinationAssetType == "credit_alphanum4" && path.DestinationAssetCode == "USD" {
+			assertions.Equal(path.DestinationAssetIssuer, "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN")
+			assertions.Equal(path.DestinationAmount, "10.0000000")
+			assertions.Len(path.Path, 0)
+		}
+
+		if i > 1 &&
+			inMemoryResponse[i-1].DestinationAssetType == path.DestinationAssetType &&
+			inMemoryResponse[i-1].DestinationAssetCode == path.DestinationAssetCode &&
+			inMemoryResponse[i-1].DestinationAssetIssuer == path.DestinationAssetIssuer {
 			previous, err := strconv.ParseFloat(inMemoryResponse[i-1].DestinationAmount, 64)
 			assertions.NoError(err)
 

--- a/services/horizon/internal/paths/main.go
+++ b/services/horizon/internal/paths/main.go
@@ -33,7 +33,7 @@ type Finder interface {
 		sourceAccount *xdr.AccountId,
 		sourceAsset xdr.Asset,
 		amountToSpend xdr.Int64,
-		destinationAsset xdr.Asset,
+		destinationAssets []xdr.Asset,
 		maxLength uint,
 	) ([]Path, error)
 }

--- a/services/horizon/internal/simplepath/finder.go
+++ b/services/horizon/internal/simplepath/finder.go
@@ -64,7 +64,7 @@ func (f *Finder) FindFixedPaths(
 	sourceAccount *xdr.AccountId,
 	sourceAsset xdr.Asset,
 	amountToSpend xdr.Int64,
-	destinationAsset xdr.Asset,
+	destinationAssets []xdr.Asset,
 	maxLength uint,
 ) ([]paths.Path, error) {
 	return nil, errors.New("Not implemented")

--- a/services/horizon/internal/simplepath/inmemory.go
+++ b/services/horizon/internal/simplepath/inmemory.go
@@ -75,7 +75,7 @@ func (finder InMemoryFinder) FindFixedPaths(
 	sourceAccount *xdr.AccountId,
 	sourceAsset xdr.Asset,
 	amountToSpend xdr.Int64,
-	destinationAsset xdr.Asset,
+	destinationAssets []xdr.Asset,
 	maxLength uint,
 ) ([]paths.Path, error) {
 	if finder.graph.IsEmpty() {
@@ -94,7 +94,7 @@ func (finder InMemoryFinder) FindFixedPaths(
 		sourceAccount,
 		sourceAsset,
 		amountToSpend,
-		destinationAsset,
+		destinationAssets,
 	)
 	results := make([]paths.Path, len(orderbookPaths))
 	for i, path := range orderbookPaths {

--- a/services/horizon/internal/simplepath/inmemory.go
+++ b/services/horizon/internal/simplepath/inmemory.go
@@ -95,6 +95,7 @@ func (finder InMemoryFinder) FindFixedPaths(
 		sourceAsset,
 		amountToSpend,
 		destinationAssets,
+		maxAssetsPerPath,
 	)
 	results := make([]paths.Path, len(orderbookPaths))
 	for i, path := range orderbookPaths {

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -216,6 +216,7 @@ func (w *web) mustInstallActions(config Config, pathFinder paths.Finder) {
 	findFixedPaths := FindFixedPathsHandler{
 		maxPathLength: config.MaxPathLength,
 		pathFinder:    pathFinder,
+		coreQ:         w.coreQ,
 	}
 	installPathFindingRoutes(findPaths, findFixedPaths, w.router)
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Add destination account parameter to path finding endpoint.

### Goal and scope

This PR addresses the feedback on the `paths/strict-send` endpoint from:

https://github.com/stellar/go/issues/1489#issuecomment-524524803

### Summary of changes

* update graph interface
* update action
* add tests
* update change log
