### PR TITLE
all: Add flag to apply migrations before running horizon

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -12,6 +12,7 @@ bumps.  A breaking change will get clearly notified in this log.
 * Fixed performance issue in Effects related endpoints.
 * Dropped support for Go 1.10.
 * Add experimental support for `/offers`. To enable it, set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
+* Add flag to apply pending migrations before running horizon. If there are pending migrations, previously you needed to run `horizon db migrate up` before running `horizon`. Those two steps can be combined into one with the `--apply-migrations` flag (`APPLY_MIGRATIONS` env variable).
 
 ## v0.20.0
 

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -160,6 +160,7 @@ var dbMigrateCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
+		pingDB(db)
 
 		numMigrationsRun, err := schema.Migrate(db, dir, count)
 		if err != nil {

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -48,18 +48,16 @@ func validateBothOrNeither(option1, option2 string) {
 
 func pingDB(db *sql.DB) {
 	for attempt := 0; attempt < maxDBPingAttempts; attempt++ {
-		err := db.Ping()
-		if err == nil {
+		if db.Ping() == nil {
 			return
 		}
-		stdLog.Printf("could not ping horizon db: %v\n", err)
 		time.Sleep(time.Second)
 		if attempt+1 < maxDBPingAttempts {
-			stdLog.Println("retrying ping")
+			stdLog.Println("Waiting for a horizon DB connection...")
 		}
 	}
 
-	stdLog.Fatalf("failed to ping horiizon db after %v attempts", maxDBPingAttempts)
+	stdLog.Fatalf("failed to connect to horizon DB after %v attempts", maxDBPingAttempts)
 }
 
 func applyMigrations() {

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
+	"database/sql"
 	"fmt"
 	"go/types"
 	stdLog "log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -18,16 +20,20 @@ import (
 	"github.com/stellar/throttled"
 )
 
-var config horizon.Config
+var (
+	config horizon.Config
 
-var rootCmd = &cobra.Command{
-	Use:   "horizon",
-	Short: "client-facing api server for the stellar network",
-	Long:  "client-facing api server for the stellar network. It acts as the interface between Stellar Core and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.",
-	Run: func(cmd *cobra.Command, args []string) {
-		initApp().Serve()
-	},
-}
+	rootCmd = &cobra.Command{
+		Use:   "horizon",
+		Short: "client-facing api server for the stellar network",
+		Long:  "client-facing api server for the stellar network. It acts as the interface between Stellar Core and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.",
+		Run: func(cmd *cobra.Command, args []string) {
+			initApp().Serve()
+		},
+	}
+)
+
+const dbPingTimeoutSeconds = 30
 
 // validateBothOrNeither ensures that both options are provided, if either is provided.
 func validateBothOrNeither(option1, option2 string) {
@@ -40,9 +46,35 @@ func validateBothOrNeither(option1, option2 string) {
 	}
 }
 
+func applyMigrations() {
+	db, err := sql.Open("postgres", config.DatabaseURL)
+	if err != nil {
+		stdLog.Fatalf("could not connect to horizon db: %v", err)
+	}
+	defer db.Close()
+
+	for secs := 0; secs <= dbPingTimeoutSeconds; secs++ {
+		if err = db.Ping(); err == nil {
+			break
+		}
+		if secs >= dbPingTimeoutSeconds {
+			stdLog.Fatal("could not ping horizon db")
+		}
+		time.Sleep(time.Second)
+	}
+
+	numMigrations, err := schema.Migrate(db, schema.MigrateUp, 0)
+	if err != nil {
+		stdLog.Fatalf("could not apply migrations: %v", err)
+	}
+	if numMigrations > 0 {
+		stdLog.Printf("successfully applied %v horizon migrations", numMigrations)
+	}
+}
+
 // checkMigrations looks for necessary database migrations and fails with a descriptive error if migrations are needed.
 func checkMigrations() {
-	migrationsToApplyUp := schema.GetMigrationsUp(viper.GetString("db-url"))
+	migrationsToApplyUp := schema.GetMigrationsUp(config.DatabaseURL)
 	if len(migrationsToApplyUp) > 0 {
 		stdLog.Printf(`There are %v migrations to apply in the "up" direction.`, len(migrationsToApplyUp))
 		stdLog.Printf("The necessary migrations are: %v", migrationsToApplyUp)
@@ -50,7 +82,7 @@ func checkMigrations() {
 		os.Exit(1)
 	}
 
-	nMigrationsDown := schema.GetNumMigrationsDown(viper.GetString("db-url"))
+	nMigrationsDown := schema.GetNumMigrationsDown(config.DatabaseURL)
 	if nMigrationsDown > 0 {
 		stdLog.Printf("A database migration DOWN to an earlier version of the schema is required to run this version (%v) of Horizon. Consult the Changelog (https://github.com/stellar/go/blob/master/services/horizon/CHANGELOG.md) for more information.", apkg.Version())
 		stdLog.Printf("In order to migrate the database DOWN, using the HIGHEST version number of Horizon you have installed (not this binary), run \"horizon db migrate down %v\".", nMigrationsDown)
@@ -315,6 +347,14 @@ var configOpts = []*support.ConfigOption{
 		FlagDefault: false,
 		Usage:       "[EXPERIMENTAL] enables experimental ingestion system",
 	},
+	&support.ConfigOption{
+		Name:        "apply-migrations",
+		ConfigKey:   &config.ApplyMigrations,
+		OptType:     types.Bool,
+		FlagDefault: false,
+		Required:    false,
+		Usage:       "applies pending migrations before starting horizon",
+	},
 }
 
 func init() {
@@ -338,6 +378,10 @@ func initConfig() {
 	for _, co := range configOpts {
 		co.Require()
 		co.SetValue()
+	}
+
+	if config.ApplyMigrations {
+		applyMigrations()
 	}
 
 	// Migrations should be checked as early as possible

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -33,7 +33,7 @@ var (
 	}
 )
 
-const dbPingTimeoutSeconds = 30
+const maxDBPingAttempts = 30
 
 // validateBothOrNeither ensures that both options are provided, if either is provided.
 func validateBothOrNeither(option1, option2 string) {
@@ -46,29 +46,36 @@ func validateBothOrNeither(option1, option2 string) {
 	}
 }
 
+func pingDB(db *sql.DB) {
+	for attempt := 0; attempt < maxDBPingAttempts; attempt++ {
+		err := db.Ping()
+		if err == nil {
+			return
+		}
+		stdLog.Printf("could not ping horizon db: %v\n", err)
+		time.Sleep(time.Second)
+		if attempt+1 < maxDBPingAttempts {
+			stdLog.Println("retrying ping")
+		}
+	}
+
+	stdLog.Fatalf("failed to ping horiizon db after %v attempts", maxDBPingAttempts)
+}
+
 func applyMigrations() {
 	db, err := sql.Open("postgres", config.DatabaseURL)
 	if err != nil {
 		stdLog.Fatalf("could not connect to horizon db: %v", err)
 	}
 	defer db.Close()
-
-	for secs := 0; secs <= dbPingTimeoutSeconds; secs++ {
-		if err = db.Ping(); err == nil {
-			break
-		}
-		if secs >= dbPingTimeoutSeconds {
-			stdLog.Fatal("could not ping horizon db")
-		}
-		time.Sleep(time.Second)
-	}
+	pingDB(db)
 
 	numMigrations, err := schema.Migrate(db, schema.MigrateUp, 0)
 	if err != nil {
 		stdLog.Fatalf("could not apply migrations: %v", err)
 	}
 	if numMigrations > 0 {
-		stdLog.Printf("successfully applied %v horizon migrations", numMigrations)
+		stdLog.Printf("successfully applied %v horizon migrations\n", numMigrations)
 	}
 }
 

--- a/services/horizon/docker/Dockerfile
+++ b/services/horizon/docker/Dockerfile
@@ -14,5 +14,5 @@ FROM alpine:3.10
 RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /go/bin/horizon ./
-COPY ./services/horizon/docker/horizon-entry.sh ./
-ENTRYPOINT ["./horizon-entry.sh"]
+
+ENTRYPOINT ["./horizon"]

--- a/services/horizon/docker/docker-compose.yml
+++ b/services/horizon/docker/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       - STELLAR_CORE_URL=http://host.docker.internal:11626
       - INGEST=true
     network_mode: '${NETWORK_MODE:-bridge}'
+    command: ["--apply-migrations"]
 
 volumes:
   core-db-data:

--- a/services/horizon/docker/horizon-entry.sh
+++ b/services/horizon/docker/horizon-entry.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-./horizon db init || echo "Horizon database initialization failed (possibly because it has been done before)"
-./horizon

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -73,4 +73,7 @@ type Config struct {
 	// Enabling it has a negative impact on CPU when ingesting ledgers full of
 	// many different assets related operations.
 	EnableAssetStats bool
+	// ApplyMigrations will apply pending migrations to the horizon database
+	// before starting the horizon service
+	ApplyMigrations bool
 }

--- a/services/horizon/internal/db2/schema/main.go
+++ b/services/horizon/internal/db2/schema/main.go
@@ -78,6 +78,7 @@ func GetMigrationsUp(dbUrl string) (migrationIds []string) {
 	if dbErr != nil {
 		stdLog.Fatal(dbErr)
 	}
+	defer db.Close()
 
 	// Get the possible migrations
 	possibleMigrations, _, migrateErr := migrate.PlanMigration(db, "postgres", Migrations, migrate.Up, 0)
@@ -103,6 +104,7 @@ func GetNumMigrationsDown(dbUrl string) (nMigrations int) {
 	if dbErr != nil {
 		stdLog.Fatal(dbErr)
 	}
+	defer db.Close()
 
 	// Get the set of migrations recorded in the database
 	migrationRecords, recordErr := migrate.GetMigrationRecords(db, "postgres")


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Add flag to apply migrations before running horizon. Fixes https://github.com/stellar/go/issues/1668

### Goal and scope

If there are pending migrations, previously you needed to run `horizon db migrate up` before running `horizon`. Those two steps can be combined into one with the `--apply-migrations` flag.

One benefit of the apply migrations flag is that it allows us to get rid of the entrypoint script in the horizon docker compose workflow.

### Summary of changes

* Add optional `--apply-migrations` flag which is set to `false` by default
* Apply migrations if flag is set
* Simplify docker compose workflow by using `--apply-migrations` and removing the entrypoint script.

### Known limitations & issues

N / A

### What shouldn't be reviewed

N / A