### PR TITLE
Horizon 0.20.0 CHANGELOG update

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -19,6 +19,8 @@ Check (Beta Testing New Ingestion System)[https://github.com/stellar/go/blob/mas
 
 ## v0.20.0
 
+If you want to use experimental ingestion skip this version and use v0.20.1 instead.
+
 ### Changes
 
 * Experimental ingestion system is now run concurrently on all Horizon servers (with feature flag set - see below). This improves ingestion availability.

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -19,7 +19,7 @@ Check (Beta Testing New Ingestion System)[https://github.com/stellar/go/blob/mas
 
 ## v0.20.0
 
-If you want to use experimental ingestion skip this version and use v0.20.1 instead.
+If you want to use experimental ingestion skip this version and use v0.20.1 instead. v0.20.0 has a performance issue.
 
 ### Changes
 


### PR DESCRIPTION
Update Horizon v0.20.0 CHANGELOG informing experimental ingestion testers to skip to 0.20.1.

See: #1673.