### PR TITLE
all: update gopkg.in/yaml.v2 7ad95dd0798a => v2.2.2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -945,11 +945,12 @@
   version = "v1.2.13"
 
 [[projects]]
-  digest = "1:37bf0c8e8da86322a5caa03c3a1979dd3538983d7d929e942f1542f865f3d5f2"
+  digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "T"
-  revision = "7ad95dd0798a40da1ccdff6dff35fd177b5edf40"
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -92,3 +92,7 @@
 [[constraint]]
   name = "github.com/rcrowley/go-metrics"
   revision = "51425a2415d21afadfd55cd93432c0bc69e9598d"
+
+[[override]]
+  name = "gopkg.in/yaml.v2"
+  version = "=v2.2.2"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Update `gopkg.in/yaml.v2` for transition to Modules (#1634).

From: `gopkg.in/yaml.v2@7ad95dd0798a`
To: `gopkg.in/yaml.v2@v2.2.2`

Diff: https://github.com/go-yaml/yaml/compare/7ad95dd0798a...v2.2.2 (96 commits)

### Goal and scope

To make the transition to Modules possible. Some dependencies at their current version have incompatible relationships with other dependencies we have. Dep was more tolerant to incompatible versions than Modules. Making this change ahead of the PR that switches us to Modules makes that PR a functional no-op.

The reason Modules is updating `yaml.v2` is because the monorepo is also dependent on `github.com/onsi/gomega` which had to be upgraded due to another dependency requirement. The version of `gomega` we're using is explicitly dependent on at least `v2.2.1` of `yaml.v2` requiring us to update to a newer version.

I'm taking the dependency all the way to `v2.2.2` which is the latest patch release. While I don't understand all the changes deeply in the diff, the changes don't appear to be significant.

As a bonus these newer versions of `yaml.v2` are released under a more desirable license, Apache License 2.0. The commit we were dependent on previously was released under LGPL 3.

### Summary of changes

- Change the version of the package to the version that Modules selects.

### Known limitations & issues

N/A

### What shouldn't be reviewed

N/A