### PR TITLE
all: drop support for go1.11, add support for go1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,7 @@ jobs:
   publish_artifacts:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: circleci/golang:1.12-stretch
+      - image: circleci/golang:1.13-buster
     steps:
       - check_deprecations
       - install_go_deps
@@ -258,7 +258,7 @@ jobs:
   ingest_state_diff:
     working_directory: /go/src/github.com/stellar/go/
     docker:
-      - image: circleci/golang:1.12-stretch
+      - image: circleci/golang:1.13-buster
         environment:
           PGHOST: localhost
           PGPORT: 5432

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,18 +159,6 @@ commands:
 #-----------------------------------------------------------------------------#
 
 jobs:
-  # check_code_1_11 performs code checks using Go 1.11 (gofmt is only run for 1.12).
-  check_code_1_11:
-    working_directory: /go/src/github.com/stellar/go
-    docker:
-      - image: circleci/golang:1.11-stretch
-        environment:
-          GO111MODULE: "on"
-    steps:
-      - install_go_deps
-      - check_go_deps
-      - govet
-
   # check_code_1_12 performs code checks using Go 1.12.
   check_code_1_12:
     working_directory: /go/src/github.com/stellar/go
@@ -189,34 +177,13 @@ jobs:
   check_code_1_13:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: circleci/golang:1.13rc1-buster
+      - image: circleci/golang:1.13-buster
     steps:
       - install_go_deps
       - check_go_deps
       - gofmt
       - govet
       - staticcheck
-
-  # test_code_1_11 performs all package tests using Go 1.11.
-  test_code_1_11:
-    working_directory: /go/src/github.com/stellar/go
-    docker:
-      - image: circleci/golang:1.11-stretch
-        environment:
-          GO111MODULE: "on"
-          PGHOST: localhost
-          PGPORT: 5432
-          PGUSER: circleci
-          MYSQL_HOST: 127.0.0.1
-          MYSQL_PORT: 3306
-      - image: circleci/postgres:9.6.5-alpine-ram
-        environment:
-          POSTGRES_USER: circleci
-      - image: circleci/mysql:5.7
-      - image: circleci/redis:5.0-alpine
-    steps:
-      - install_go_deps
-      - test_packages
 
   # test_code_1_12 performs all package tests using Go 1.12.
   test_code_1_12:
@@ -243,7 +210,7 @@ jobs:
   test_code_1_13:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: circleci/golang:1.13rc1-buster
+      - image: circleci/golang:1.13-buster
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -313,10 +280,8 @@ workflows:
 
   check_code_and_test:
     jobs:
-      - check_code_1_11
       - check_code_1_12
       - check_code_1_13
-      - test_code_1_11
       - test_code_1_12
       - test_code_1_13
       - ingest_state_diff:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repo is the home for all of the public go code produced by SDF.  In additio
 
 ## Dependencies
 
-This repository is officially supported on the last two releases of Go, which is currently Go 1.11 and Go 1.12. When using Go 1.11, a minimum minor version of Go 1.11.4 is required.
+This repository is officially supported on the last two releases of Go, which is currently Go 1.12 and Go 1.13.
 
 It depends on a [number of external dependencies](./go.mod), and uses Go [Modules](https://github.com/golang/go/wiki/Modules) to manage them. Running any `go` command will automatically download dependencies required for that operation.
 

--- a/clients/horizon/main_test.go
+++ b/clients/horizon/main_test.go
@@ -76,8 +76,8 @@ func TestLoadAccount(t *testing.T) {
 		assert.Equal(t, account.Signers[0].Key, "XBT5HNPK6DAL6222MAWTLHNOZSDKPJ2AKNEQ5Q324CHHCNQFQ7EHBHZN")
 		assert.Equal(t, account.Signers[0].Type, "sha256_hash")
 		assert.Equal(t, account.Data["test"], "R0NCVkwzU1FGRVZLUkxQNkFKNDdVS0tXWUVCWTQ1V0hBSkhDRVpLVldNVEdNQ1Q0SDROS1FZTEg=")
-		balance, err := account.GetNativeBalance()
-		assert.Nil(t, err)
+		balance, balanceErr := account.GetNativeBalance()
+		assert.Nil(t, balanceErr)
 		assert.Equal(t, balance, "948522307.6146000")
 	}
 

--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -5,7 +5,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-- Dropped support for Go 1.10.
+- Dropped support for Go 1.10, 1.11.
 
 ## [v1.4.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.4.0) - 2019-08-09
 

--- a/clients/horizonclient/README.md
+++ b/clients/horizonclient/README.md
@@ -12,7 +12,7 @@ This library is aimed at developers building Go applications that interact with 
 * The [txnbuild API reference](https://godoc.org/github.com/stellar/go/txnbuild).
 
 ### Prerequisites
-* Go 1.11.4 or greater
+* Go 1.12 or greater
 * [Modules](https://github.com/golang/go/wiki/Modules) to manage dependencies
 
 ### Installing

--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -419,8 +419,8 @@ func TestAccountDetail(t *testing.T) {
 		assert.Equal(t, account.Signers[0].Key, "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU")
 		assert.Equal(t, account.Signers[0].Type, "ed25519_public_key")
 		assert.Equal(t, account.Data["test"], "dGVzdA==")
-		balance, err := account.GetNativeBalance()
-		assert.Nil(t, err)
+		balance, balanceErr := account.GetNativeBalance()
+		assert.Nil(t, balanceErr)
 		assert.Equal(t, balance, "9999.9999900")
 	}
 

--- a/exp/ingest/processors/csv_printer.go
+++ b/exp/ingest/processors/csv_printer.go
@@ -63,7 +63,6 @@ func (p *CSVPrinter) ProcessState(ctx context.Context, store *pipeline.Store, r 
 				inflationDest = entry.Data.Account.InflationDest.Address()
 			}
 
-			var err error
 			var signers string
 			if len(account.Signers) > 0 {
 				signers, err = xdr.MarshalBase64(account.Signers)
@@ -119,13 +118,14 @@ func (p *CSVPrinter) ProcessState(ctx context.Context, store *pipeline.Store, r 
 		case xdr.LedgerEntryTypeOffer:
 			offer := entry.Data.MustOffer()
 
-			var err error
-			selling, err := xdr.MarshalBase64(offer.Selling)
+			var selling string
+			selling, err = xdr.MarshalBase64(offer.Selling)
 			if err != nil {
 				return err
 			}
 
-			buying, err := xdr.MarshalBase64(offer.Buying)
+			var buying string
+			buying, err = xdr.MarshalBase64(offer.Buying)
 			if err != nil {
 				return err
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stellar/go
 
-go 1.11
+go 1.12
 
 require (
 	bitbucket.org/ww/goautoneg v0.0.0-20120707110453-75cd24fc2f2c

--- a/gomod.sh
+++ b/gomod.sh
@@ -3,10 +3,6 @@ set -e
 
 go mod tidy
 git diff --exit-code -- go.mod || (echo "Go file go.mod is dirty, update the file with 'go mod tidy' locally." && exit 1)
-if [[ ! $GOLANG_VERSION = 1.11.* ]]; then
-  git diff --exit-code -- go.sum || (echo "Go file go.sum is dirty, update the file with 'go mod tidy' locally." && exit 1)
-else
-  echo "Skipping go.sum check for Go 1.11.* because it doesn't generate go.sum files consistently with other versions of Go."
-fi
+git diff --exit-code -- go.sum || (echo "Go file go.sum is dirty, update the file with 'go mod tidy' locally." && exit 1)
 diff -u go.list <(go list -m all) || (echo "Go dependencies have changed, update the go.list file with 'go list -m all > go.list' locally." && exit 1)
 go mod verify || (echo "One or more Go dependencies failed verification. Either a version is no longer available, or the author or someone else has modified the version so it no longer points to the same code." && exit 1)

--- a/govet.sh
+++ b/govet.sh
@@ -1,24 +1,22 @@
 #! /bin/bash
 set -e
 
-# TODO: 1) Build and install shadow analyzer for go vet in 1.12+
-# See https://github.com/golang/go/issues/29260
-# https://golang.org/doc/go1.12#vet
-# For now we just skip the shadow checking for Go 1.12+
-# TODO: 2) Not triggering on shadowed vars (output not stdout?)
-# TODO: 3) Fix syntax for Go 1.12+ (go tool vet -> go vet, but fails to find packages?)
-if [[ $GOLANG_VERSION = 1.11.* ]]; then
-    echo "Running go vet checks..."
-OUTPUT=$(ls -d */ \
-  | egrep -v '^vendor|^docs' \
-  | xargs -I {} -P 4 go tool vet -all -composites=false -unreachable=false -tests=false -shadow {})
+printf "Running go vet...\n"
+go vet -all -composites=false -unreachable=false -tests=false ./...
+
+# -vettool was added in 1.12, and broken in the initial 1.13 release
+# https://github.com/golang/go/issues/34053
+if [[ $GOLANG_VERSION = 1.12.* ]]; then
+  printf "Running go vet shadow...\n"
+  command -v shadow >/dev/null 2>&1 || (
+    dir=$(mktemp -d)
+    pushd $dir
+    go mod init tool
+    go get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
+    popd
+  )
+
+  go vet -vettool=$(which shadow) ./...
 else
-    echo "Skipping go vet checks for this version of Go..."
-fi
-
-
-if [[ $OUTPUT ]]; then
-  printf "govet found some issues:\n\n"
-  echo "$OUTPUT"
-  exit 1
+  echo "Skipping go vet shadow checks for this version of Go..."
 fi

--- a/services/bridge/CHANGELOG.md
+++ b/services/bridge/CHANGELOG.md
@@ -5,7 +5,7 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 ## Unreleased
 
 * Fixed path-payment operation in `/payment`
-* Dropped support for Go 1.10.
+* Dropped support for Go 1.10, 1.11.
 
 ## 0.0.32
 

--- a/services/bridge/internal/handlers/request_handler_builder.go
+++ b/services/bridge/internal/handlers/request_handler_builder.go
@@ -95,7 +95,8 @@ func (rh *RequestHandler) Builder(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, s := range request.Signers {
-		kp, err := keypair.Parse(s)
+		var kp keypair.KP
+		kp, err = keypair.Parse(s)
 		if err != nil {
 			log.WithFields(log.Fields{"err": err, "request": request}).Error("Error converting signers to keypairs")
 			helpers.Write(w, helpers.InternalServerError)

--- a/services/bridge/internal/handlers/request_handler_payment.go
+++ b/services/bridge/internal/handlers/request_handler_payment.go
@@ -191,7 +191,8 @@ func (rh *RequestHandler) standardPayment(w http.ResponseWriter, request *bridge
 
 	var rSource *string
 	if request.Source != "" {
-		kp, err := keypair.Parse(request.Source)
+		var kp keypair.KP
+		kp, err = keypair.Parse(request.Source)
 		if err != nil {
 			log.WithFields(log.Fields{"error": err}).Error("Unable to convert seed to keypair")
 			helpers.Write(w, helpers.NewInvalidParameterError("source", "Source must be a valid secret seed."))

--- a/services/bridge/internal/listener/payment_listener_test.go
+++ b/services/bridge/internal/listener/payment_listener_test.go
@@ -526,8 +526,8 @@ func TestPostForm_MACKey(t *testing.T) {
 		assert.Empty(t, req.Header.Get("X_PAYLOAD_MAC"), "unexpected MAC present")
 	})
 	handler.HandleFunc("/mac", func(w http.ResponseWriter, req *http.Request) {
-		body, err := ioutil.ReadAll(req.Body)
-		require.NoError(t, err)
+		body, bodyReadErr := ioutil.ReadAll(req.Body)
+		require.NoError(t, bodyReadErr)
 
 		macer := hmac.New(sha256.New, rawkey)
 		macer.Write(body)

--- a/services/compliance/CHANGELOG.md
+++ b/services/compliance/CHANGELOG.md
@@ -4,7 +4,7 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 ## Unreleased
 
-* Dropped support for Go 1.10.
+* Dropped support for Go 1.10, 1.11.
 
 ## 0.0.32
 

--- a/services/federation/CHANGELOG.md
+++ b/services/federation/CHANGELOG.md
@@ -11,7 +11,7 @@ bumps.  A breaking change will get clearly notified in this log.
 ### Changed
 
 - BREAKING CHANGE: The `url` database configuration has been renamed to `dsn` to more accurately reflect its content.
-- Dropped support for Go 1.10.
+- Dropped support for Go 1.10, 1.11.
 
 ### Fixed
 

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -9,7 +9,7 @@ bumps.  A breaking change will get clearly notified in this log.
 ## Unreleased
 
 * Fixed performance issue in Effects related endpoints.
-* Dropped support for Go 1.10.
+* Dropped support for Go 1.10, 1.11.
 
 ## v0.20.1
 

--- a/services/horizon/internal/db2/history/operation.go
+++ b/services/horizon/internal/db2/history/operation.go
@@ -90,7 +90,7 @@ func (q *Q) OperationByID(includeTransactions bool, id int64) (Operation, *Trans
 
 	if includeTransactions {
 		var transaction Transaction
-		if err := q.TransactionByHash(&transaction, operation.TransactionHash); err != nil {
+		if err = q.TransactionByHash(&transaction, operation.TransactionHash); err != nil {
 			return operation, nil, err
 		}
 

--- a/services/horizon/internal/docs/admin.md
+++ b/services/horizon/internal/docs/admin.md
@@ -36,7 +36,7 @@ To test the installation, simply run `horizon --help` from a terminal.  If the h
 Should you decide not to use one of our prebuilt releases, you may instead build Horizon from source.  To do so, you need to install some developer tools:
 
 - A unix-like operating system with the common core commands (cp, tar, mkdir, bash, etc.)
-- A compatible distribution of Go (Go 1.11.4 or later)
+- A compatible distribution of Go (Go 1.12 or later)
 - [git](https://git-scm.com/)
 - [mercurial](https://www.mercurial-scm.org/)
 

--- a/services/horizon/internal/docs/developing.md
+++ b/services/horizon/internal/docs/developing.md
@@ -11,7 +11,7 @@ If you are just starting with Horizon and want to try it out, consider the [Quic
 Building Horizon requires the following developer tools:
 
 - A [Unix-like](https://en.wikipedia.org/wiki/Unix-like) operating system with the common core commands (cp, tar, mkdir, bash, etc.)
-- Golang 1.11.4 or later
+- Golang 1.12 or later
 - [git](https://git-scm.com/) (to check out Horizon's source code)
 - [mercurial](https://www.mercurial-scm.org/) (needed for `go-dep`)
 

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -194,8 +194,8 @@ func initRedis(app *App) {
 		IdleTimeout: 240 * time.Second,
 		Dial:        dialRedis(redisURL),
 		TestOnBorrow: func(c redis.Conn, t time.Time) error {
-			_, err := c.Do("PING")
-			return err
+			_, pingErr := c.Do("PING")
+			return pingErr
 		},
 	}
 

--- a/services/keystore/CHANGELOG.md
+++ b/services/keystore/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Dropped support for Go 1.10.
+- Dropped support for Go 1.10, 1.11.
 
 ## [v1.0.0] - 2019-06-18
 

--- a/services/ticker/CHANGELOG.md
+++ b/services/ticker/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [UNRELEASED]
 - Added nested `"issuer_detail"` field to `/assets.json`.
-- Dropped support for Go 1.10.
+- Dropped support for Go 1.10, 1.11.
 
 
 ## [v1.1.0] - 2019-07-22

--- a/services/ticker/internal/actions_trade.go
+++ b/services/ticker/internal/actions_trade.go
@@ -79,12 +79,14 @@ func BackfillTrades(
 	var dbTrades []tickerdb.Trade
 
 	for _, trade := range trades {
-		bID, cID, err := findBaseAndCounter(s, trade)
+		var bID, cID int32
+		bID, cID, err = findBaseAndCounter(s, trade)
 		if err != nil {
 			continue
 		}
 
-		dbTrade, err := hProtocolTradeToDBTrade(trade, bID, cID)
+		var dbTrade tickerdb.Trade
+		dbTrade, err = hProtocolTradeToDBTrade(trade, bID, cID)
 		if err != nil {
 			l.Errorln("Could not convert entry to DB Trade: ", err)
 			continue

--- a/tools/stellar-archivist/CHANGELOG.md
+++ b/tools/stellar-archivist/CHANGELOG.md
@@ -9,7 +9,7 @@ bumps.  A breaking change will get clearly notified in this log.
 ## ???
 
 * Fix race condition in `mirror` command
-* Dropped support for Go 1.10.
+* Dropped support for Go 1.10, 1.11.
 
 ## [v0.1.0] - 2016-08-17
 

--- a/tools/stellar-hd-wallet/CHANGELOG.md
+++ b/tools/stellar-hd-wallet/CHANGELOG.md
@@ -8,7 +8,7 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ## Unreleased
 
-- Dropped support for Go 1.10.
+- Dropped support for Go 1.10, 1.11.
 
 ## [v0.0.1] - 2017-12-28
 

--- a/tools/stellar-sign/CHANGELOG.md
+++ b/tools/stellar-sign/CHANGELOG.md
@@ -8,7 +8,7 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ## Unreleased
 
-- Dropped support for Go 1.10.
+- Dropped support for Go 1.10, 1.11.
 
 ## [v0.2.0] - 2016-08-19
 

--- a/tools/stellar-sign/main.go
+++ b/tools/stellar-sign/main.go
@@ -106,7 +106,8 @@ func readLine(prompt string, private bool) (string, error) {
 	var err error
 
 	if private {
-		str, err := gopass.GetPasswdMasked()
+		var str []byte
+		str, err = gopass.GetPasswdMasked()
 		if err != nil {
 			return "", err
 		}

--- a/tools/stellar-vanity-gen/CHANGELOG.md
+++ b/tools/stellar-vanity-gen/CHANGELOG.md
@@ -8,7 +8,7 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ## Unreleased
 
-- Dropped support for Go 1.10.
+- Dropped support for Go 1.10, 1.11.
 
 ## [v0.1.0] - 2016-08-17
 

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -5,7 +5,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-* Dropped support for Go 1.10.
+* Dropped support for Go 1.10, 1.11.
 
 ## [v1.4.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.4.0) - 2019-08-09
 

--- a/txnbuild/README.md
+++ b/txnbuild/README.md
@@ -61,7 +61,7 @@ This library is aimed at developers building Go applications on top of the [Stel
 An easy-to-follow demonstration that exercises this SDK on the TestNet with actual accounts is also included! See the [Demo](#demo) section below.
 
 ### Prerequisites
-* Go 1.11.4 or greater
+* Go 1.12 or greater
 * [Modules](https://github.com/golang/go/wiki/Modules) to manage dependencies
 
 ### Installing


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Add testing and support for Go 1.13 and discontinue support for Go 1.11.

### Goal and scope

To maintain consistency with supported and released versions of Go. Go provides security updates for the last two versions of Go, this means the current release (1.13) and the previous release (1.12). Go 1.13 was released today meaning security updates will no longer be released for Go 1.11.

Go 1.13 also comes with several new features relating to Modules including more efficient and reliable downloading of dependencies. As we switch to using Modules it will be a better experience for all and we'll be making the most of the change to promote and use Go 1.13.

Close #1696 

### Summary of changes

- Update 1.13 builds to use latest release of 1.13.
- Remove 1.11 from builds.
- Update all documentation references of supported versions of Go.
- Update `govet.sh` to use `-vettool` option that was added in Go 1.12. This was an outstanding TODO item in the file already, but we needed to do it to make the file work with Go 1.12+. Closes #1038.
- Add notes to changelogs.

### Known limitations & issues

There is a bug in the Go 1.13's `go vet` tool that prevents it from being used with shadow. For this reason only the standard vet checks run on Go 1.13 builds, and the additional shadow check runs on Go 1.12 only. I stumbled onto this issue and opened an issue here for it: golang/go#34053.

### What shouldn't be reviewed

N/A