### PR TITLE
Send coverage reports to codecov.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,6 @@ jobs:
     steps:
       - install_go_deps
       - test_packages
-      - send_coverage_report
 
   # test_code_1_13 performs all package tests using Go 1.13.
   test_code_1_13:
@@ -234,6 +233,7 @@ jobs:
     steps:
       - install_go_deps
       - test_packages
+      - send_coverage_report
 
   # publish_artifacts builds and uploads artifacts to any tagged commit.
   #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ commands:
             # the default Docker container only has 2 CPUs available.
             # That is why we explicitly specify -p=4 to reduce the number of parallel build processes
             GOFLAGS: -p=4
-          command: ./support/scripts/run_tests
+          command: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
   # build_packages creates the project's artifacts.
   build_packages:
@@ -153,6 +153,13 @@ commands:
       - run:
           name: Build release artifacts
           command: go run ./support/scripts/build_release_artifacts/main.go
+
+  # send_coverage_report sends coverage report to codecov.io
+  send_coverage_report:
+    steps:
+      - run:
+          name: Send report to codecov.io
+          command: bash <(curl -s https://codecov.io/bash)
 
 #-----------------------------------------------------------------------------#
 # Jobs use the commands to accomplish a given task, and run through workflows #
@@ -205,6 +212,7 @@ jobs:
     steps:
       - install_go_deps
       - test_packages
+      - send_coverage_report
 
   # test_code_1_13 performs all package tests using Go 1.13.
   test_code_1_13:

--- a/services/horizon/internal/docs/developing.md
+++ b/services/horizon/internal/docs/developing.md
@@ -47,7 +47,7 @@ Horizon uses a Postgres database backend to store test fixtures and record infor
 At this point you should be able to run Horizon's unit tests:
 ```bash
 cd $GOPATH/src/github.com/stellar/go/services/horizon
-bash ../../support/scripts/run_tests
+go test ./...
 ```
 
 ## Set up Stellar Core

--- a/services/horizon/internal/docs/notes_for_developers.md
+++ b/services/horizon/internal/docs/notes_for_developers.md
@@ -94,7 +94,7 @@ redis-server
 then, run the all the Go monorepo tests like so (assuming you are at stellar/go, or run from stellar/go/services/horizon for just the Horizon subset):
 
 ```bash
-bash ./support/scripts/run_tests
+go test ./...
 ```
 
 or run individual Horizon tests like so, providing the expected arguments:

--- a/support/scripts/run_tests
+++ b/support/scripts/run_tests
@@ -1,9 +1,0 @@
-#! /bin/bash
-set -e
-
-echo "using GOFLAGS=$GOFLAGS"
-go test -race .
-find . -maxdepth 1 -mindepth 1 -type d \
-  | egrep -v '^\.\/vendor|^.\/docs|^\.\/\..*' \
-  | sed 's/.*/&\/.../g' \
-  | xargs -I {} -P 4 go test -race {}


### PR DESCRIPTION
* Sends coverage reports to codecov.io
* Removes `run_tests` script as it looks like `go test` ignores `vendors` directory when Go Modules are used.

Close #1686.