### PR TITLE
txnbuild: validate operation structs

### DIFF
--- a/txnbuild/account_merge.go
+++ b/txnbuild/account_merge.go
@@ -48,8 +48,9 @@ func (am *AccountMerge) FromXDR(xdrOp xdr.Operation) error {
 // Validate for AccountMerge validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
 func (am *AccountMerge) Validate() error {
-	if !validateStellarPublicKey(am.Destination) {
-		return NewValidationError("Destination", "public key is invalid")
+	err := validateStellarPublicKey(am.Destination)
+	if err != nil {
+		return NewValidationError("Destination", err.Error())
 	}
 	return nil
 }

--- a/txnbuild/account_merge.go
+++ b/txnbuild/account_merge.go
@@ -44,3 +44,12 @@ func (am *AccountMerge) FromXDR(xdrOp xdr.Operation) error {
 
 	return nil
 }
+
+// Validate for AccountMerge validates the required struct fields. It returns an error if any of the fields are
+// invalid. Otherwise, it returns nil.
+func (am *AccountMerge) Validate() error {
+	if !validateStellarPublicKey(am.Destination) {
+		return NewValidationError("Destination", "public key is invalid")
+	}
+	return nil
+}

--- a/txnbuild/account_merge_test.go
+++ b/txnbuild/account_merge_test.go
@@ -24,7 +24,7 @@ func TestAccountMergeValidate(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.AccountMerge struct: Field: Destination, Error: public key is invalid"
+		expected := "validation failed for *txnbuild.AccountMerge operation: Field: Destination, Error: GBAV is not a valid stellar public key"
 		assert.Contains(t, err.Error(), expected)
 	}
 }

--- a/txnbuild/account_merge_test.go
+++ b/txnbuild/account_merge_test.go
@@ -1,0 +1,30 @@
+package txnbuild
+
+import (
+	"testing"
+
+	"github.com/stellar/go/network"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccountMergeValidate(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484298))
+
+	accountMerge := AccountMerge{
+		Destination: "GBAV",
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&accountMerge},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.AccountMerge struct: Field: Destination, Error: public key is invalid"
+		assert.Contains(t, err.Error(), expected)
+	}
+}

--- a/txnbuild/allow_trust.go
+++ b/txnbuild/allow_trust.go
@@ -78,11 +78,13 @@ func (at *AllowTrust) FromXDR(xdrOp xdr.Operation) error {
 // Validate for AllowTrust validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
 func (at *AllowTrust) Validate() error {
-	if !validateStellarPublicKey(at.Trustor) {
-		return NewValidationError("Trustor", "public key is invalid")
+	err := validateStellarPublicKey(at.Trustor)
+	if err != nil {
+		return NewValidationError("Trustor", err.Error())
 	}
 
-	if err := validateAllowTrustAsset(at.Type); err != nil {
+	err = validateAllowTrustAsset(at.Type)
+	if err != nil {
 		return NewValidationError("Type", err.Error())
 	}
 	return nil

--- a/txnbuild/allow_trust.go
+++ b/txnbuild/allow_trust.go
@@ -74,3 +74,16 @@ func (at *AllowTrust) FromXDR(xdrOp xdr.Operation) error {
 
 	return nil
 }
+
+// Validate for AllowTrust validates the required struct fields. It returns an error if any of the fields are
+// invalid. Otherwise, it returns nil.
+func (at *AllowTrust) Validate() error {
+	if !validateStellarPublicKey(at.Trustor) {
+		return NewValidationError("Trustor", "public key is invalid")
+	}
+
+	if err := validateAllowTrustAsset(at.Type); err != nil {
+		return NewValidationError("Type", err.Error())
+	}
+	return nil
+}

--- a/txnbuild/allow_trust_test.go
+++ b/txnbuild/allow_trust_test.go
@@ -28,7 +28,7 @@ func TestAllowTrustValidateAsset(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.AllowTrust struct: Field: Type, Error: asset code length must be between 1 and 12 characters"
+		expected := "validation failed for *txnbuild.AllowTrust operation: Field: Type, Error: asset code length must be between 1 and 12 characters"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -54,7 +54,7 @@ func TestAllowTrustValidateTrustor(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.AllowTrust struct: Field: Trustor, Error: public key is invalid"
+		expected := "validation failed for *txnbuild.AllowTrust operation: Field: Trustor, Error: public key is undefined"
 		assert.Contains(t, err.Error(), expected)
 	}
 }

--- a/txnbuild/allow_trust_test.go
+++ b/txnbuild/allow_trust_test.go
@@ -1,0 +1,60 @@
+package txnbuild
+
+import (
+	"testing"
+
+	"github.com/stellar/go/network"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllowTrustValidateAsset(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484366))
+
+	issuedAsset := CreditAsset{"", kp1.Address()}
+	allowTrust := AllowTrust{
+		Trustor:   kp1.Address(),
+		Type:      issuedAsset,
+		Authorize: true,
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&allowTrust},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.AllowTrust struct: Field: Type, Error: asset code length must be between 1 and 12 characters"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestAllowTrustValidateTrustor(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484366))
+
+	issuedAsset := CreditAsset{"ABCD", kp1.Address()}
+	allowTrust := AllowTrust{
+		Trustor:   "",
+		Type:      issuedAsset,
+		Authorize: true,
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&allowTrust},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.AllowTrust struct: Field: Trustor, Error: public key is invalid"
+		assert.Contains(t, err.Error(), expected)
+	}
+}

--- a/txnbuild/asset.go
+++ b/txnbuild/asset.go
@@ -68,7 +68,7 @@ func (ca CreditAsset) GetType() (AssetType, error) {
 	case len(ca.Code) >= 5 && len(ca.Code) <= 12:
 		return AssetTypeCreditAlphanum12, nil
 	default:
-		return AssetTypeCreditAlphanum4, errors.New("invalid asset code")
+		return AssetTypeCreditAlphanum4, errors.New("asset code length must be between 1 and 12 characters")
 	}
 }
 

--- a/txnbuild/bump_sequence.go
+++ b/txnbuild/bump_sequence.go
@@ -40,7 +40,7 @@ func (bs *BumpSequence) FromXDR(xdrOp xdr.Operation) error {
 // Validate for BumpSequence validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
 func (bs *BumpSequence) Validate() error {
-	err := validateNumber(bs.BumpTo)
+	err := validateAmount(bs.BumpTo)
 	if err != nil {
 		return NewValidationError("BumpTo", err.Error())
 	}

--- a/txnbuild/bump_sequence.go
+++ b/txnbuild/bump_sequence.go
@@ -36,3 +36,13 @@ func (bs *BumpSequence) FromXDR(xdrOp xdr.Operation) error {
 	bs.BumpTo = int64(result.BumpTo)
 	return nil
 }
+
+// Validate for BumpSequence validates the required struct fields. It returns an error if any of the fields are
+// invalid. Otherwise, it returns nil.
+func (bs *BumpSequence) Validate() error {
+	err := validateNumber(bs.BumpTo)
+	if err != nil {
+		return NewValidationError("BumpTo", err.Error())
+	}
+	return nil
+}

--- a/txnbuild/bump_sequence_test.go
+++ b/txnbuild/bump_sequence_test.go
@@ -24,7 +24,7 @@ func TestBumpSequenceValidate(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.BumpSequence struct: Field: BumpTo, Error: value should be positve or zero"
+		expected := "validation failed for *txnbuild.BumpSequence operation: Field: BumpTo, Error: amount can not be negative"
 		assert.Contains(t, err.Error(), expected)
 	}
 }

--- a/txnbuild/bump_sequence_test.go
+++ b/txnbuild/bump_sequence_test.go
@@ -1,0 +1,30 @@
+package txnbuild
+
+import (
+	"testing"
+
+	"github.com/stellar/go/network"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBumpSequenceValidate(t *testing.T) {
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
+
+	bumpSequence := BumpSequence{
+		BumpTo: -10,
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&bumpSequence},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.BumpSequence struct: Field: BumpTo, Error: value should be positve or zero"
+		assert.Contains(t, err.Error(), expected)
+	}
+}

--- a/txnbuild/change_trust.go
+++ b/txnbuild/change_trust.go
@@ -78,3 +78,21 @@ func (ct *ChangeTrust) FromXDR(xdrOp xdr.Operation) error {
 	ct.Line = asset
 	return nil
 }
+
+// Validate for ChangeTrust validates the required struct fields. It returns an error if any of the fields are
+// invalid. Otherwise, it returns nil.
+func (ct *ChangeTrust) Validate() error {
+	// only validate limit if it has a value. Empty limit is set to the max trustline limit.
+	if ct.Limit != "" {
+		err := validateNumber(ct.Limit)
+		if err != nil {
+			return NewValidationError("Limit", err.Error())
+		}
+	}
+
+	err := validateChangeTrustAsset(ct.Line)
+	if err != nil {
+		return NewValidationError("Line", err.Error())
+	}
+	return nil
+}

--- a/txnbuild/change_trust.go
+++ b/txnbuild/change_trust.go
@@ -84,7 +84,7 @@ func (ct *ChangeTrust) FromXDR(xdrOp xdr.Operation) error {
 func (ct *ChangeTrust) Validate() error {
 	// only validate limit if it has a value. Empty limit is set to the max trustline limit.
 	if ct.Limit != "" {
-		err := validateNumber(ct.Limit)
+		err := validateAmount(ct.Limit)
 		if err != nil {
 			return NewValidationError("Limit", err.Error())
 		}

--- a/txnbuild/change_trust_test.go
+++ b/txnbuild/change_trust_test.go
@@ -44,7 +44,7 @@ func TestChangeTrustValidateInvalidAsset(t *testing.T) {
 	}
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.ChangeTrust struct: Field: Line, Error: native (XLM) asset type is not allowed"
+		expected := "validation failed for *txnbuild.ChangeTrust operation: Field: Line, Error: native (XLM) asset type is not allowed"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -66,7 +66,7 @@ func TestChangeTrustValidateInvalidLimit(t *testing.T) {
 	}
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.ChangeTrust struct: Field: Limit, Error: value should be positve or zero"
+		expected := "validation failed for *txnbuild.ChangeTrust operation: Field: Limit, Error: amount can not be negative"
 		assert.Contains(t, err.Error(), expected)
 	}
 }

--- a/txnbuild/change_trust_test.go
+++ b/txnbuild/change_trust_test.go
@@ -27,3 +27,46 @@ func TestChangeTrustMaxLimit(t *testing.T) {
 	expected := "AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAiII0AAAAbAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAGAAAAAUFCQ0QAAAAA4Nxt4XJcrGZRYrUvrOc1sooiQ+QdEk1suS1wo+oucsV//////////wAAAAAAAAAB6i5yxQAAAEBen+Aa821qqfb+ASHhCg074ulPcCbIsUNvzUg2x92R/vRRKIGF5RztvPGBkktWkXLarDe5yqlBA+L3zpcVs+wB"
 	assert.Equal(t, expected, received, "Base 64 XDR should match")
 }
+
+func TestChangeTrustValidateInvalidAsset(t *testing.T) {
+	kp0 := newKeypair0()
+	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
+
+	changeTrust := ChangeTrust{
+		Line: NativeAsset{},
+	}
+
+	tx := Transaction{
+		SourceAccount: &txSourceAccount,
+		Operations:    []Operation{&changeTrust},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.ChangeTrust struct: Field: Line, Error: native (XLM) asset type is not allowed"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestChangeTrustValidateInvalidLimit(t *testing.T) {
+	kp0 := newKeypair0()
+	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
+
+	changeTrust := ChangeTrust{
+		Line:  CreditAsset{"ABCD", kp0.Address()},
+		Limit: "-1",
+	}
+
+	tx := Transaction{
+		SourceAccount: &txSourceAccount,
+		Operations:    []Operation{&changeTrust},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.ChangeTrust struct: Field: Limit, Error: value should be positve or zero"
+		assert.Contains(t, err.Error(), expected)
+	}
+}

--- a/txnbuild/create_account.go
+++ b/txnbuild/create_account.go
@@ -55,11 +55,12 @@ func (ca *CreateAccount) FromXDR(xdrOp xdr.Operation) error {
 // Validate for CreateAccount validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
 func (ca *CreateAccount) Validate() error {
-	if !validateStellarPublicKey(ca.Destination) {
-		return NewValidationError("Destination", "public key is invalid")
+	err := validateStellarPublicKey(ca.Destination)
+	if err != nil {
+		return NewValidationError("Destination", err.Error())
 	}
 
-	err := validateNumber(ca.Amount)
+	err = validateAmount(ca.Amount)
 	if err != nil {
 		return NewValidationError("Amount", err.Error())
 	}

--- a/txnbuild/create_account.go
+++ b/txnbuild/create_account.go
@@ -51,3 +51,18 @@ func (ca *CreateAccount) FromXDR(xdrOp xdr.Operation) error {
 
 	return nil
 }
+
+// Validate for CreateAccount validates the required struct fields. It returns an error if any of the fields are
+// invalid. Otherwise, it returns nil.
+func (ca *CreateAccount) Validate() error {
+	if !validateStellarPublicKey(ca.Destination) {
+		return NewValidationError("Destination", "public key is invalid")
+	}
+
+	err := validateNumber(ca.Amount)
+	if err != nil {
+		return NewValidationError("Amount", err.Error())
+	}
+
+	return nil
+}

--- a/txnbuild/create_account_test.go
+++ b/txnbuild/create_account_test.go
@@ -25,7 +25,7 @@ func TestCreateAccountValidateDestination(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.CreateAccount struct: Field: Destination, Error: public key is invalid"
+		expected := "validation failed for *txnbuild.CreateAccount operation: Field: Destination, Error: public key is undefined"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -48,7 +48,7 @@ func TestCreateAccountValidateAmount(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.CreateAccount struct: Field: Amount, Error: invalid amount format"
+		expected := "validation failed for *txnbuild.CreateAccount operation: Field: Amount, Error: invalid amount format"
 		assert.Contains(t, err.Error(), expected)
 	}
 }

--- a/txnbuild/create_account_test.go
+++ b/txnbuild/create_account_test.go
@@ -1,0 +1,54 @@
+package txnbuild
+
+import (
+	"testing"
+
+	"github.com/stellar/go/network"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateAccountValidateDestination(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
+
+	createAccount := CreateAccount{
+		Destination: "",
+		Amount:      "43",
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&createAccount},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.CreateAccount struct: Field: Destination, Error: public key is invalid"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestCreateAccountValidateAmount(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
+
+	createAccount := CreateAccount{
+		Destination: "GDYNXQFHU6W5RBW2CCCDDAAU3TMTSU2RMGIBM6HGHAR4NJJKY3IJETHT",
+		Amount:      "",
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&createAccount},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.CreateAccount struct: Field: Amount, Error: invalid amount format"
+		assert.Contains(t, err.Error(), expected)
+	}
+}

--- a/txnbuild/create_passive_offer.go
+++ b/txnbuild/create_passive_offer.go
@@ -81,3 +81,9 @@ func (cpo *CreatePassiveSellOffer) FromXDR(xdrOp xdr.Operation) error {
 	cpo.Selling = sellingAsset
 	return nil
 }
+
+// Validate for CreatePassiveSellOffer validates the required struct fields. It returns an error if any
+// of the fields are invalid. Otherwise, it returns nil.
+func (cpo *CreatePassiveSellOffer) Validate() error {
+	return validatePassiveOffer(cpo.Buying, cpo.Selling, cpo.Amount, cpo.Price)
+}

--- a/txnbuild/create_passive_offer_test.go
+++ b/txnbuild/create_passive_offer_test.go
@@ -1,0 +1,112 @@
+package txnbuild
+
+import (
+	"testing"
+
+	"github.com/stellar/go/network"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreatePassiveSellOfferValidateBuyingAsset(t *testing.T) {
+	// kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761100))
+
+	createPassiveOffer := CreatePassiveSellOffer{
+		Selling: NativeAsset{},
+		Buying:  CreditAsset{"ABCD", ""},
+		Amount:  "10",
+		Price:   "1.0",
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&createPassiveOffer},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.CreatePassiveSellOffer struct: Field: Buying, Error: asset issuer is not a valid stellar public key"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestCreatePassiveSellOfferValidateSellingAsset(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761100))
+
+	createPassiveOffer := CreatePassiveSellOffer{
+		Selling: CreditAsset{"ABCD0123456789", kp0.Address()},
+		Buying:  NativeAsset{},
+		Amount:  "10",
+		Price:   "1.0",
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&createPassiveOffer},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.CreatePassiveSellOffer struct: Field: Selling, Error: asset code length must be between 1 and 12 characters"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestCreatePassiveSellOfferValidateAmount(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761100))
+
+	createPassiveOffer := CreatePassiveSellOffer{
+		Selling: CreditAsset{"ABCD", kp0.Address()},
+		Buying:  NativeAsset{},
+		Amount:  "-3",
+		Price:   "1.0",
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&createPassiveOffer},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.CreatePassiveSellOffer struct: Field: Amount, Error: value should be positve or zero"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestCreatePassiveSellOfferValidatePrice(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761100))
+
+	createPassiveOffer := CreatePassiveSellOffer{
+		Selling: CreditAsset{"ABCD", kp0.Address()},
+		Buying:  NativeAsset{},
+		Amount:  "3",
+		Price:   "-1.0",
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&createPassiveOffer},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.CreatePassiveSellOffer struct: Field: Price, Error: value should be positve or zero"
+		assert.Contains(t, err.Error(), expected)
+	}
+}

--- a/txnbuild/create_passive_offer_test.go
+++ b/txnbuild/create_passive_offer_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestCreatePassiveSellOfferValidateBuyingAsset(t *testing.T) {
-	// kp0 := newKeypair0()
 	kp1 := newKeypair1()
 	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761100))
 
@@ -28,7 +27,7 @@ func TestCreatePassiveSellOfferValidateBuyingAsset(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.CreatePassiveSellOffer struct: Field: Buying, Error: asset issuer is not a valid stellar public key"
+		expected := "validation failed for *txnbuild.CreatePassiveSellOffer operation: Field: Buying, Error: asset issuer: public key is undefined"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -54,7 +53,7 @@ func TestCreatePassiveSellOfferValidateSellingAsset(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.CreatePassiveSellOffer struct: Field: Selling, Error: asset code length must be between 1 and 12 characters"
+		expected := `validation failed for *txnbuild.CreatePassiveSellOffer operation: Field: Selling, Error: asset code length must be between 1 and 12 characters`
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -80,7 +79,7 @@ func TestCreatePassiveSellOfferValidateAmount(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.CreatePassiveSellOffer struct: Field: Amount, Error: value should be positve or zero"
+		expected := `validation failed for *txnbuild.CreatePassiveSellOffer operation: Field: Amount, Error: amount can not be negative`
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -106,7 +105,7 @@ func TestCreatePassiveSellOfferValidatePrice(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.CreatePassiveSellOffer struct: Field: Price, Error: value should be positve or zero"
+		expected := `validation failed for *txnbuild.CreatePassiveSellOffer operation: Field: Price, Error: amount can not be negative`
 		assert.Contains(t, err.Error(), expected)
 	}
 }

--- a/txnbuild/helpers.go
+++ b/txnbuild/helpers.go
@@ -1,0 +1,160 @@
+package txnbuild
+
+import (
+	"fmt"
+
+	"github.com/stellar/go/amount"
+	"github.com/stellar/go/strkey"
+	"github.com/stellar/go/support/errors"
+)
+
+// validateStellarPublicKey returns true if a public key is valid. Otherwise, it returns false.
+// It is a wrapper around the IsValidEd25519PublicKey method of the strkey package.
+func validateStellarPublicKey(publicKey string) bool {
+	return strkey.IsValidEd25519PublicKey(publicKey)
+}
+
+// validateStellarAsset checks if the asset supplied is a valid stellar Asset. It returns an error if the asset is
+// nil, has an invalid asset code or issuer.
+func validateStellarAsset(asset Asset) error {
+	if asset == nil {
+		return errors.New("asset is required")
+	}
+
+	if asset.IsNative() {
+		return nil
+	}
+
+	_, err := asset.GetType()
+	if err != nil {
+		return errors.New("asset code length must be between 1 and 12 characters")
+	}
+
+	if !validateStellarPublicKey(asset.GetIssuer()) {
+		return errors.New("asset issuer is not a valid stellar public key")
+	}
+
+	return nil
+}
+
+// validateNumber checks if the provided value is a valid stellar amount, it returns an error if not.
+// This is used to validate price and amount fields in structs.
+func validateNumber(n interface{}) error {
+	var stellarAmount int64
+	// type switch can be extended to handle other types. Currently, the types for number values in the txnbuild
+	// package are string or int64.
+	switch value := n.(type) {
+	case int64:
+		stellarAmount = value
+	case string:
+		v, err := amount.ParseInt64(value)
+		if err != nil {
+			return err
+		}
+		stellarAmount = v
+	default:
+		return errors.New("validation failed, unknown type")
+	}
+
+	if stellarAmount < 0 {
+		return errors.New("value should be positve or zero")
+	}
+	return nil
+}
+
+// validateAllowTrustAsset checks if the provided asset is valid for use in AllowTrust operation.
+// It returns an error if the asset is invalid.
+// The asset must be non native (XLM) with a valid asset code.
+func validateAllowTrustAsset(asset Asset) error {
+	if asset == nil {
+		return errors.New("asset is required")
+	}
+
+	if asset.IsNative() {
+		return errors.New("native (XLM) asset type is not allowed")
+	}
+
+	_, err := asset.GetType()
+	if err != nil {
+		return errors.Errorf("asset code length must be between 1 and 12 characters")
+	}
+	return nil
+}
+
+// validateChangeTrustAsset checks if the provided asset is valid for use in ChangeTrust operation.
+// It returns an error if the asset is invalid.
+// The asset must be non native (XLM) with a valid asset code and issuer.
+func validateChangeTrustAsset(asset Asset) error {
+	err := validateAllowTrustAsset(asset)
+	if err != nil {
+		return err
+	}
+
+	if !validateStellarPublicKey(asset.GetIssuer()) {
+		return errors.New("asset issuer is not a valid stellar public key")
+	}
+
+	return nil
+}
+
+// validatePassiveOffer checks if the fields of a CreatePassiveOffer struct are valid.
+// It checks that the buying and selling assets are valid stellar assets, and that amount and price are valid.
+// It returns an error if any field is invalid.
+func validatePassiveOffer(buying, selling Asset, offerAmount, price string) error {
+	err := validateStellarAsset(buying)
+	if err != nil {
+		return NewValidationError("Buying", err.Error())
+	}
+
+	err = validateStellarAsset(selling)
+	if err != nil {
+		return NewValidationError("Selling", err.Error())
+	}
+
+	err = validateNumber(offerAmount)
+	if err != nil {
+		return NewValidationError("Amount", err.Error())
+	}
+
+	err = validateNumber(price)
+	if err != nil {
+		return NewValidationError("Price", err.Error())
+	}
+
+	return nil
+}
+
+// validateOffer checks if the fields of ManageBuyOffer or ManageSellOffer struct are valid.
+// It checks that the buying and selling assets are valid stellar assets, and that amount, price and offerID
+// are valid. It returns an error if any field is invalid.
+func validateOffer(buying, selling Asset, offerAmount, price string, offerID int64) error {
+	err := validatePassiveOffer(buying, selling, offerAmount, price)
+	if err != nil {
+		return err
+	}
+
+	err = validateNumber(offerID)
+	if err != nil {
+		return NewValidationError("OfferID", err.Error())
+	}
+	return nil
+}
+
+// ValidationError is a custom error struct that holds validation errors of txnbuild's operation structs.
+type ValidationError struct {
+	Field   string // Field is the struct field on which the validation error occured.
+	Message string // Message is the validation error message.
+}
+
+// Error for ValidationError struct implements the error interface.
+func (opError *ValidationError) Error() string {
+	return fmt.Sprintf("Field: %s, Error: %s", opError.Field, opError.Message)
+}
+
+// NewValidationError creates a ValidationError struct with the provided field and message values.
+func NewValidationError(field, message string) *ValidationError {
+	return &ValidationError{
+		Field:   field,
+		Message: message,
+	}
+}

--- a/txnbuild/helpers_test.go
+++ b/txnbuild/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newKeypair0() *keypair.Full {
@@ -62,4 +63,238 @@ func unmarshalBase64(txeB64 string) (xdr.TransactionEnvelope, error) {
 	var xdrEnv xdr.TransactionEnvelope
 	err := xdr.SafeUnmarshalBase64(txeB64, &xdrEnv)
 	return xdrEnv, err
+}
+
+func TestValidateStellarPublicKey(t *testing.T) {
+	validKey := "GDWZCOEQRODFCH6ISYQPWY67L3ULLWS5ISXYYL5GH43W7YFMTLB65PYM"
+	isValid := validateStellarPublicKey(validKey)
+	assert.Equal(t, true, isValid, "public key should be valid")
+
+	invalidKey := "GDWZCOEQRODFCH6ISYQPWY67L3ULLWS5ISXYYL5GH43W7Y"
+	isValid = validateStellarPublicKey(invalidKey)
+	assert.Equal(t, false, isValid, "public key should be invalid")
+
+	invalidKey = ""
+	isValid = validateStellarPublicKey(invalidKey)
+	assert.Equal(t, false, isValid, "public key should be invalid")
+
+	invalidKey = "SBCVMMCBEDB64TVJZFYJOJAERZC4YVVUOE6SYR2Y76CBTENGUSGWRRVO"
+	isValid = validateStellarPublicKey(invalidKey)
+	assert.Equal(t, false, isValid, "public key should be invalid")
+}
+
+func TestValidateStellarAssetWithValidAsset(t *testing.T) {
+	nativeAsset := NativeAsset{}
+	err := validateStellarAsset(nativeAsset)
+	assert.NoError(t, err)
+
+	kp0 := newKeypair0()
+	creditAsset := CreditAsset{"XYZ", kp0.Address()}
+	err = validateStellarAsset(creditAsset)
+	assert.NoError(t, err)
+}
+
+func TestValidateStellarAssetWithInValidAsset(t *testing.T) {
+	err := validateStellarAsset(nil)
+	assert.Error(t, err)
+	expectedErrMsg := "asset is required"
+	require.EqualError(t, err, expectedErrMsg, "An asset is required")
+
+	kp0 := newKeypair0()
+	creditAssetNoCode := CreditAsset{Code: "", Issuer: kp0.Address()}
+	err = validateStellarAsset(creditAssetNoCode)
+	assert.Error(t, err)
+	expectedErrMsg = "asset code length must be between 1 and 12 characters"
+	require.EqualError(t, err, expectedErrMsg, "An asset code is required")
+
+	creditAssetNoIssuer := CreditAsset{Code: "ABC", Issuer: ""}
+	err = validateStellarAsset(creditAssetNoIssuer)
+	assert.Error(t, err)
+	expectedErrMsg = "asset issuer is not a valid stellar public key"
+	require.EqualError(t, err, expectedErrMsg, "An asset issuer is required")
+}
+
+func TestValidateNumber(t *testing.T) {
+	err := validateNumber(int64(10))
+	assert.NoError(t, err)
+
+	err = validateNumber("10")
+	assert.NoError(t, err)
+
+	err = validateNumber(int64(0))
+	assert.NoError(t, err)
+
+	err = validateNumber("0")
+	assert.NoError(t, err)
+}
+
+func TestValidateNumberInvalidValue(t *testing.T) {
+	err := validateNumber(int64(-10))
+	assert.Error(t, err)
+	expectedErrMsg := "value should be positve or zero"
+	require.EqualError(t, err, expectedErrMsg, "should be a valid stellar amount")
+
+	err = validateNumber("-10")
+	assert.Error(t, err)
+	expectedErrMsg = "value should be positve or zero"
+	require.EqualError(t, err, expectedErrMsg, "should be a valid stellar amount")
+
+	err = validateNumber(10)
+	assert.Error(t, err)
+	expectedErrMsg = "validation failed, unknown type"
+	require.EqualError(t, err, expectedErrMsg, "should be a valid stellar amount")
+
+	err = validateNumber("abc")
+	assert.Error(t, err)
+	expectedErrMsg = "invalid amount format: abc"
+	require.EqualError(t, err, expectedErrMsg, "should be a valid stellar amount")
+}
+
+func TestValidateAllowTrustAsset(t *testing.T) {
+	err := validateAllowTrustAsset(nil)
+	assert.Error(t, err)
+	expectedErrMsg := "asset is required"
+	require.EqualError(t, err, expectedErrMsg, "An asset is required")
+
+	err = validateAllowTrustAsset(NativeAsset{})
+	assert.Error(t, err)
+	expectedErrMsg = "native (XLM) asset type is not allowed"
+	require.EqualError(t, err, expectedErrMsg, "An asset is required")
+
+	// allow trust asset does not require asset issuer
+	atAsset := CreditAsset{Code: "ABCD"}
+	err = validateAllowTrustAsset(atAsset)
+	assert.NoError(t, err)
+}
+
+func TestValidateChangeTrustAsset(t *testing.T) {
+	err := validateChangeTrustAsset(nil)
+	assert.Error(t, err)
+	expectedErrMsg := "asset is required"
+	require.EqualError(t, err, expectedErrMsg, "An asset is required")
+
+	err = validateChangeTrustAsset(NativeAsset{})
+	assert.Error(t, err)
+	expectedErrMsg = "native (XLM) asset type is not allowed"
+	require.EqualError(t, err, expectedErrMsg, "A custom asset is required")
+
+	kp0 := newKeypair0()
+	ctAsset0 := CreditAsset{Issuer: kp0.Address()}
+	err = validateChangeTrustAsset(ctAsset0)
+	assert.Error(t, err)
+	expectedErrMsg = "asset code length must be between 1 and 12 characters"
+	require.EqualError(t, err, expectedErrMsg, "asset code is required")
+
+	ctAsset1 := CreditAsset{Code: "ABCD"}
+	err = validateChangeTrustAsset(ctAsset1)
+	assert.Error(t, err)
+	expectedErrMsg = "asset issuer is not a valid stellar public key"
+	require.EqualError(t, err, expectedErrMsg, "asset issuer is required")
+
+	ctAsset2 := CreditAsset{Code: "ABCD", Issuer: kp0.Address()}
+	err = validateChangeTrustAsset(ctAsset2)
+	assert.NoError(t, err)
+}
+
+func TestValidatePassiveOfferZeroValues(t *testing.T) {
+	cpo := CreatePassiveSellOffer{}
+	err := validatePassiveOffer(cpo.Buying, cpo.Selling, cpo.Amount, cpo.Price)
+	assert.Error(t, err)
+	expectedErrMsg := "Field: Buying, Error: asset is required"
+	require.EqualError(t, err, expectedErrMsg, "Buying asset is required")
+}
+
+func TestValidatePassiveOfferInvalidAmount(t *testing.T) {
+	kp0 := newKeypair0()
+	buying := CreditAsset{Code: "ABCD", Issuer: kp0.Address()}
+	selling := NativeAsset{}
+	cpo := CreatePassiveSellOffer{
+		Buying:  buying,
+		Selling: selling,
+		Price:   "1",
+		Amount:  "-1",
+	}
+	err := validatePassiveOffer(cpo.Buying, cpo.Selling, cpo.Amount, cpo.Price)
+	assert.Error(t, err)
+	expectedErrMsg := "Field: Amount, Error: value should be positve or zero"
+	require.EqualError(t, err, expectedErrMsg, "valid amount is required")
+}
+
+func TestValidatePassiveOfferInvalidPrice(t *testing.T) {
+	kp0 := newKeypair0()
+	buying := CreditAsset{Code: "ABCD", Issuer: kp0.Address()}
+	selling := NativeAsset{}
+	cpo := CreatePassiveSellOffer{
+		Buying:  buying,
+		Selling: selling,
+		Price:   "-1",
+		Amount:  "10",
+	}
+	err := validatePassiveOffer(cpo.Buying, cpo.Selling, cpo.Amount, cpo.Price)
+	assert.Error(t, err)
+	expectedErrMsg := "Field: Price, Error: value should be positve or zero"
+	require.EqualError(t, err, expectedErrMsg, "valid price is required")
+}
+
+func TestValidatePassiveOfferInvalidAsset(t *testing.T) {
+	buying := NativeAsset{}
+	selling := CreditAsset{Code: "ABCD"}
+	cpo := CreatePassiveSellOffer{
+		Buying:  buying,
+		Selling: selling,
+		Price:   "1",
+		Amount:  "10",
+	}
+	err := validatePassiveOffer(cpo.Buying, cpo.Selling, cpo.Amount, cpo.Price)
+	assert.Error(t, err)
+	expectedErrMsg := "Field: Selling, Error: asset issuer is not a valid stellar public key"
+	require.EqualError(t, err, expectedErrMsg, "Selling asset is required")
+
+	kp0 := newKeypair0()
+	buying1 := CreditAsset{Issuer: kp0.Address()}
+	selling1 := NativeAsset{}
+	cpo1 := CreatePassiveSellOffer{
+		Buying:  buying1,
+		Selling: selling1,
+		Price:   "1",
+		Amount:  "10",
+	}
+	err = validatePassiveOffer(cpo1.Buying, cpo1.Selling, cpo1.Amount, cpo1.Price)
+	assert.Error(t, err)
+	expectedErrMsg = "Field: Buying, Error: asset code length must be between 1 and 12 characters"
+	require.EqualError(t, err, expectedErrMsg, "Selling asset is required")
+}
+
+func TestValidateOfferManageBuyOffer(t *testing.T) {
+	kp0 := newKeypair0()
+	buying := CreditAsset{Code: "ABCD", Issuer: kp0.Address()}
+	selling := NativeAsset{}
+	mbo := ManageBuyOffer{
+		Buying:  buying,
+		Selling: selling,
+		Price:   "1",
+		Amount:  "10",
+		OfferID: -1,
+	}
+	err := validateOffer(mbo.Buying, mbo.Selling, mbo.Amount, mbo.Price, mbo.OfferID)
+	assert.Error(t, err)
+	expectedErrMsg := "Field: OfferID, Error: value should be positve or zero"
+	require.EqualError(t, err, expectedErrMsg, "valid offerID is required")
+}
+
+func TestValidateOfferManageSellOffer(t *testing.T) {
+	kp0 := newKeypair0()
+	buying := CreditAsset{Code: "ABCD", Issuer: kp0.Address()}
+	selling := NativeAsset{}
+	mso := ManageSellOffer{
+		Buying:  buying,
+		Selling: selling,
+		Price:   "1",
+		Amount:  "10",
+		OfferID: -1,
+	}
+	err := validateOffer(mso.Buying, mso.Selling, mso.Amount, mso.Price, mso.OfferID)
+	assert.Error(t, err)
+	expectedErrMsg := "Field: OfferID, Error: value should be positve or zero"
+	require.EqualError(t, err, expectedErrMsg, "valid offerID is required")
 }

--- a/txnbuild/inflation.go
+++ b/txnbuild/inflation.go
@@ -32,8 +32,8 @@ func (inf *Inflation) FromXDR(xdrOp xdr.Operation) error {
 	return nil
 }
 
-// Validate for Inflation validates the required struct fields. It returns an error if any
-// of the fields are invalid. Otherwise, it returns nil.
+// Validate for Inflation is just a method that implements the Operation interface. No logic is actually performed
+// because the inflation operation does not have any required field. Nil is always returned.
 func (inf *Inflation) Validate() error {
 	// no required fields, return nil.
 	return nil

--- a/txnbuild/inflation.go
+++ b/txnbuild/inflation.go
@@ -31,3 +31,10 @@ func (inf *Inflation) FromXDR(xdrOp xdr.Operation) error {
 	inf.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	return nil
 }
+
+// Validate for Inflation validates the required struct fields. It returns an error if any
+// of the fields are invalid. Otherwise, it returns nil.
+func (inf *Inflation) Validate() error {
+	// no required fields, return nil.
+	return nil
+}

--- a/txnbuild/manage_buy_offer.go
+++ b/txnbuild/manage_buy_offer.go
@@ -84,3 +84,9 @@ func (mo *ManageBuyOffer) FromXDR(xdrOp xdr.Operation) error {
 	mo.Selling = sellingAsset
 	return nil
 }
+
+// Validate for ManageBuyOffer validates the required struct fields. It returns an error if any
+// of the fields are invalid. Otherwise, it returns nil.
+func (mo *ManageBuyOffer) Validate() error {
+	return validateOffer(mo.Buying, mo.Selling, mo.Amount, mo.Price, mo.OfferID)
+}

--- a/txnbuild/manage_buy_offer_test.go
+++ b/txnbuild/manage_buy_offer_test.go
@@ -29,7 +29,7 @@ func TestManageBuyOfferValidateSellingAsset(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.ManageBuyOffer struct: Field: Selling, Error: asset code length must be between 1 and 12 characters"
+		expected := "validation failed for *txnbuild.ManageBuyOffer operation: Field: Selling, Error: asset code length must be between 1 and 12 characters"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -56,7 +56,7 @@ func TestManageBuyOfferValidateBuyingAsset(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.ManageBuyOffer struct: Field: Buying, Error: asset issuer is not a valid stellar public key"
+		expected := "validation failed for *txnbuild.ManageBuyOffer operation: Field: Buying, Error: asset issuer: public key is undefined"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -83,7 +83,7 @@ func TestManageBuyOfferValidateAmount(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.ManageBuyOffer struct: Field: Amount, Error: invalid amount format"
+		expected := "validation failed for *txnbuild.ManageBuyOffer operation: Field: Amount, Error: invalid amount format:"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -110,7 +110,7 @@ func TestManageBuyOfferValidatePrice(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.ManageBuyOffer struct: Field: Price, Error: value should be positve or zero"
+		expected := "validation failed for *txnbuild.ManageBuyOffer operation: Field: Price, Error: amount can not be negative"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -137,7 +137,7 @@ func TestManageBuyOfferValidateOfferID(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.ManageBuyOffer struct: Field: OfferID, Error: value should be positve or zero"
+		expected := "validation failed for *txnbuild.ManageBuyOffer operation: Field: OfferID, Error: amount can not be negative"
 		assert.Contains(t, err.Error(), expected)
 	}
 }

--- a/txnbuild/manage_buy_offer_test.go
+++ b/txnbuild/manage_buy_offer_test.go
@@ -1,0 +1,143 @@
+package txnbuild
+
+import (
+	"testing"
+
+	"github.com/stellar/go/network"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManageBuyOfferValidateSellingAsset(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761092))
+
+	buyOffer := ManageBuyOffer{
+		Selling: CreditAsset{"", kp0.Address()},
+		Buying:  NativeAsset{},
+		Amount:  "100",
+		Price:   "0.01",
+		OfferID: 0,
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&buyOffer},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.ManageBuyOffer struct: Field: Selling, Error: asset code length must be between 1 and 12 characters"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestManageBuyOfferValidateBuyingAsset(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761092))
+
+	buyOffer := ManageBuyOffer{
+		Selling: CreditAsset{"ABC", kp0.Address()},
+		Buying:  CreditAsset{"XYZ", ""},
+		Amount:  "100",
+		Price:   "0.01",
+		OfferID: 0,
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&buyOffer},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.ManageBuyOffer struct: Field: Buying, Error: asset issuer is not a valid stellar public key"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestManageBuyOfferValidateAmount(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761092))
+
+	buyOffer := ManageBuyOffer{
+		Selling: CreditAsset{"ABCD", kp0.Address()},
+		Buying:  NativeAsset{},
+		Amount:  "",
+		Price:   "0.01",
+		OfferID: 0,
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&buyOffer},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.ManageBuyOffer struct: Field: Amount, Error: invalid amount format"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestManageBuyOfferValidatePrice(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761092))
+
+	buyOffer := ManageBuyOffer{
+		Selling: CreditAsset{"ABCD", kp0.Address()},
+		Buying:  NativeAsset{},
+		Amount:  "0",
+		Price:   "-0.01",
+		OfferID: 0,
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&buyOffer},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.ManageBuyOffer struct: Field: Price, Error: value should be positve or zero"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestManageBuyOfferValidateOfferID(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761092))
+
+	buyOffer := ManageBuyOffer{
+		Selling: CreditAsset{"ABCD", kp0.Address()},
+		Buying:  NativeAsset{},
+		Amount:  "0",
+		Price:   "0.01",
+		OfferID: -1,
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&buyOffer},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.ManageBuyOffer struct: Field: OfferID, Error: value should be positve or zero"
+		assert.Contains(t, err.Error(), expected)
+	}
+}

--- a/txnbuild/manage_data.go
+++ b/txnbuild/manage_data.go
@@ -47,3 +47,16 @@ func (md *ManageData) FromXDR(xdrOp xdr.Operation) error {
 	md.Value = *result.DataValue
 	return nil
 }
+
+// Validate for ManageData validates the required struct fields. It returns an error if any
+// of the fields are invalid. Otherwise, it returns nil.
+func (md *ManageData) Validate() error {
+	if len(md.Name) > 64 {
+		return NewValidationError("Name", "maximum length is 64 characters")
+	}
+
+	if len(md.Value) > 64 {
+		return NewValidationError("Value", "maximum length is 64 bytes")
+	}
+	return nil
+}

--- a/txnbuild/manage_data_test.go
+++ b/txnbuild/manage_data_test.go
@@ -25,7 +25,7 @@ func TestManageDataValidateName(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.ManageData struct: Field: Name, Error: maximum length is 64 characters"
+		expected := "validation failed for *txnbuild.ManageData operation: Field: Name, Error: maximum length is 64 characters"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -48,7 +48,7 @@ func TestManageDataValidateValue(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.ManageData struct: Field: Value, Error: maximum length is 64 bytes"
+		expected := "validation failed for *txnbuild.ManageData operation: Field: Value, Error: maximum length is 64 bytes"
 		assert.Contains(t, err.Error(), expected)
 	}
 }

--- a/txnbuild/manage_data_test.go
+++ b/txnbuild/manage_data_test.go
@@ -1,0 +1,54 @@
+package txnbuild
+
+import (
+	"testing"
+
+	"github.com/stellar/go/network"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManageDataValidateName(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(3556091187167235))
+
+	manageData := ManageData{
+		Name:  "This is a very long name for a field that only accepts 64 characters",
+		Value: []byte(""),
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&manageData},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.ManageData struct: Field: Name, Error: maximum length is 64 characters"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestManageDataValidateValue(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(3556091187167235))
+
+	manageData := ManageData{
+		Name:  "cars",
+		Value: []byte("toyota, ford, porsche, lamborghini, hyundai, volkswagen, gmc, kia"),
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&manageData},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.ManageData struct: Field: Value, Error: maximum length is 64 bytes"
+		assert.Contains(t, err.Error(), expected)
+	}
+}

--- a/txnbuild/manage_offer.go
+++ b/txnbuild/manage_offer.go
@@ -148,3 +148,9 @@ func (mo *ManageSellOffer) FromXDR(xdrOp xdr.Operation) error {
 	mo.Selling = sellingAsset
 	return nil
 }
+
+// Validate for ManageSellOffer validates the required struct fields. It returns an error if any
+// of the fields are invalid. Otherwise, it returns nil.
+func (mo *ManageSellOffer) Validate() error {
+	return validateOffer(mo.Buying, mo.Selling, mo.Amount, mo.Price, mo.OfferID)
+}

--- a/txnbuild/manage_offer_test.go
+++ b/txnbuild/manage_offer_test.go
@@ -1,0 +1,139 @@
+package txnbuild
+
+import (
+	"testing"
+
+	"github.com/stellar/go/network"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManageSellOfferValidateSellingAsset(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761092))
+
+	selling := CreditAsset{"", kp0.Address()}
+	buying := NativeAsset{}
+	sellAmount := "100"
+	price := "0.01"
+	createOffer, err := CreateOfferOp(selling, buying, sellAmount, price)
+	check(err)
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&createOffer},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err = tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.ManageSellOffer struct: Field: Selling, Error: asset code length must be between 1 and 12 characters"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestManageSellOfferValidateBuyingAsset(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761092))
+
+	selling := NativeAsset{}
+	buying := CreditAsset{"", kp0.Address()}
+	sellAmount := "100"
+	price := "0.01"
+	createOffer, err := CreateOfferOp(selling, buying, sellAmount, price)
+	check(err)
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&createOffer},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err = tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.ManageSellOffer struct: Field: Buying, Error: asset code length must be between 1 and 12 characters"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestManageSellOfferValidateAmount(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761092))
+
+	selling := NativeAsset{}
+	buying := CreditAsset{"ABCD", kp0.Address()}
+	sellAmount := "-1"
+	price := "0.01"
+	createOffer, err := CreateOfferOp(selling, buying, sellAmount, price)
+	check(err)
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&createOffer},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err = tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.ManageSellOffer struct: Field: Amount, Error: value should be positve or zero"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestManageSellOfferValidatePrice(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761092))
+
+	selling := NativeAsset{}
+	buying := CreditAsset{"ABCD", kp0.Address()}
+	sellAmount := "0"
+	price := "-0.01"
+	createOffer, err := CreateOfferOp(selling, buying, sellAmount, price)
+	check(err)
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&createOffer},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err = tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.ManageSellOffer struct: Field: Price, Error: value should be positve or zero"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestManageSellOfferValidateOfferID(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	sourceAccount := NewSimpleAccount(kp1.Address(), int64(41137196761092))
+
+	mso := ManageSellOffer{
+		Selling: CreditAsset{"ABCD", kp0.Address()},
+		Buying:  NativeAsset{},
+		Amount:  "0",
+		Price:   "0.01",
+		OfferID: -1,
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&mso},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.ManageSellOffer struct: Field: OfferID, Error: value should be positve or zero"
+		assert.Contains(t, err.Error(), expected)
+	}
+}

--- a/txnbuild/manage_offer_test.go
+++ b/txnbuild/manage_offer_test.go
@@ -28,7 +28,7 @@ func TestManageSellOfferValidateSellingAsset(t *testing.T) {
 
 	err = tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.ManageSellOffer struct: Field: Selling, Error: asset code length must be between 1 and 12 characters"
+		expected := "validation failed for *txnbuild.ManageSellOffer operation: Field: Selling, Error: asset code length must be between 1 and 12 characters"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -54,7 +54,7 @@ func TestManageSellOfferValidateBuyingAsset(t *testing.T) {
 
 	err = tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.ManageSellOffer struct: Field: Buying, Error: asset code length must be between 1 and 12 characters"
+		expected := "validation failed for *txnbuild.ManageSellOffer operation: Field: Buying, Error: asset code length must be between 1 and 12 characters"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -80,7 +80,7 @@ func TestManageSellOfferValidateAmount(t *testing.T) {
 
 	err = tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.ManageSellOffer struct: Field: Amount, Error: value should be positve or zero"
+		expected := "validation failed for *txnbuild.ManageSellOffer operation: Field: Amount, Error: amount can not be negative"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -106,7 +106,7 @@ func TestManageSellOfferValidatePrice(t *testing.T) {
 
 	err = tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.ManageSellOffer struct: Field: Price, Error: value should be positve or zero"
+		expected := "validation failed for *txnbuild.ManageSellOffer operation: Field: Price, Error: amount can not be negative"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -133,7 +133,7 @@ func TestManageSellOfferValidateOfferID(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.ManageSellOffer struct: Field: OfferID, Error: value should be positve or zero"
+		expected := "validation failed for *txnbuild.ManageSellOffer operation: Field: OfferID, Error: amount can not be negative"
 		assert.Contains(t, err.Error(), expected)
 	}
 }

--- a/txnbuild/operation.go
+++ b/txnbuild/operation.go
@@ -8,6 +8,7 @@ import (
 type Operation interface {
 	BuildXDR() (xdr.Operation, error)
 	FromXDR(xdrOp xdr.Operation) error
+	Validate() error
 }
 
 // SetOpSourceAccount sets the source account ID on an Operation.

--- a/txnbuild/path_payment.go
+++ b/txnbuild/path_payment.go
@@ -121,3 +121,33 @@ func (pp *PathPayment) FromXDR(xdrOp xdr.Operation) error {
 
 	return nil
 }
+
+// Validate for PathPayment validates the required struct fields. It returns an error if any
+// of the fields are invalid. Otherwise, it returns nil.
+func (pp *PathPayment) Validate() error {
+	if !validateStellarPublicKey(pp.Destination) {
+		return NewValidationError("Destination", "public key is invalid")
+	}
+
+	err := validateStellarAsset(pp.SendAsset)
+	if err != nil {
+		return NewValidationError("SendAsset", err.Error())
+	}
+
+	err = validateStellarAsset(pp.DestAsset)
+	if err != nil {
+		return NewValidationError("DestAsset", err.Error())
+	}
+
+	err = validateNumber(pp.SendMax)
+	if err != nil {
+		return NewValidationError("SendMax", err.Error())
+	}
+
+	err = validateNumber(pp.DestAmount)
+	if err != nil {
+		return NewValidationError("DestAmount", err.Error())
+	}
+
+	return nil
+}

--- a/txnbuild/path_payment.go
+++ b/txnbuild/path_payment.go
@@ -125,11 +125,12 @@ func (pp *PathPayment) FromXDR(xdrOp xdr.Operation) error {
 // Validate for PathPayment validates the required struct fields. It returns an error if any
 // of the fields are invalid. Otherwise, it returns nil.
 func (pp *PathPayment) Validate() error {
-	if !validateStellarPublicKey(pp.Destination) {
-		return NewValidationError("Destination", "public key is invalid")
+	err := validateStellarPublicKey(pp.Destination)
+	if err != nil {
+		return NewValidationError("Destination", err.Error())
 	}
 
-	err := validateStellarAsset(pp.SendAsset)
+	err = validateStellarAsset(pp.SendAsset)
 	if err != nil {
 		return NewValidationError("SendAsset", err.Error())
 	}
@@ -139,12 +140,12 @@ func (pp *PathPayment) Validate() error {
 		return NewValidationError("DestAsset", err.Error())
 	}
 
-	err = validateNumber(pp.SendMax)
+	err = validateAmount(pp.SendMax)
 	if err != nil {
 		return NewValidationError("SendMax", err.Error())
 	}
 
-	err = validateNumber(pp.DestAmount)
+	err = validateAmount(pp.DestAmount)
 	if err != nil {
 		return NewValidationError("DestAmount", err.Error())
 	}

--- a/txnbuild/path_payment_test.go
+++ b/txnbuild/path_payment_test.go
@@ -31,7 +31,7 @@ func TestPathPaymentValidateSendAsset(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.PathPayment struct: Field: SendAsset, Error: asset issuer is not a valid stellar public key"
+		expected := "validation failed for *txnbuild.PathPayment operation: Field: SendAsset, Error: asset issuer: public key is undefined"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -60,7 +60,7 @@ func TestPathPaymentValidateDestAsset(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.PathPayment struct: Field: DestAsset, Error: asset code length must be between 1 and 12 characters"
+		expected := "validation failed for *txnbuild.PathPayment operation: Field: DestAsset, Error: asset code length must be between 1 and 12 characters"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -89,7 +89,7 @@ func TestPathPaymentValidateDestination(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.PathPayment struct: Field: Destination, Error: public key is invalid"
+		expected := "validation failed for *txnbuild.PathPayment operation: Field: Destination, Error: SASND3NRUY5K43PN3H3HOP5JNTIDXJFLOKKNSCZQQAFBRSEIRD5OJKXZ is not a valid stellar public key"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -118,7 +118,7 @@ func TestPathPaymentValidateSendMax(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.PathPayment struct: Field: SendMax, Error: invalid amount format: abc"
+		expected := "validation failed for *txnbuild.PathPayment operation: Field: SendMax, Error: invalid amount format: abc"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -147,7 +147,7 @@ func TestPathPaymentValidateDestAmount(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.PathPayment struct: Field: DestAmount, Error: value should be positve or zero"
+		expected := "validation failed for *txnbuild.PathPayment operation: Field: DestAmount, Error: amount can not be negative"
 		assert.Contains(t, err.Error(), expected)
 	}
 }

--- a/txnbuild/path_payment_test.go
+++ b/txnbuild/path_payment_test.go
@@ -1,0 +1,153 @@
+package txnbuild
+
+import (
+	"testing"
+
+	"github.com/stellar/go/network"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPathPaymentValidateSendAsset(t *testing.T) {
+	kp0 := newKeypair0()
+	kp2 := newKeypair2()
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(187316408680450))
+
+	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
+	pathPayment := PathPayment{
+		SendAsset:   CreditAsset{"ABCD", ""},
+		SendMax:     "10",
+		Destination: kp2.Address(),
+		DestAsset:   NativeAsset{},
+		DestAmount:  "1",
+		Path:        []Asset{abcdAsset},
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&pathPayment},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.PathPayment struct: Field: SendAsset, Error: asset issuer is not a valid stellar public key"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestPathPaymentValidateDestAsset(t *testing.T) {
+	kp0 := newKeypair0()
+	kp2 := newKeypair2()
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(187316408680450))
+
+	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
+	pathPayment := PathPayment{
+		SendAsset:   NativeAsset{},
+		SendMax:     "10",
+		Destination: kp2.Address(),
+		DestAsset:   CreditAsset{"", kp0.Address()},
+		DestAmount:  "1",
+		Path:        []Asset{abcdAsset},
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&pathPayment},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.PathPayment struct: Field: DestAsset, Error: asset code length must be between 1 and 12 characters"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestPathPaymentValidateDestination(t *testing.T) {
+	kp0 := newKeypair0()
+	kp2 := newKeypair2()
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(187316408680450))
+
+	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
+	pathPayment := PathPayment{
+		SendAsset:   NativeAsset{},
+		SendMax:     "10",
+		Destination: "SASND3NRUY5K43PN3H3HOP5JNTIDXJFLOKKNSCZQQAFBRSEIRD5OJKXZ",
+		DestAsset:   CreditAsset{"ABCD", kp0.Address()},
+		DestAmount:  "1",
+		Path:        []Asset{abcdAsset},
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&pathPayment},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.PathPayment struct: Field: Destination, Error: public key is invalid"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestPathPaymentValidateSendMax(t *testing.T) {
+	kp0 := newKeypair0()
+	kp2 := newKeypair2()
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(187316408680450))
+
+	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
+	pathPayment := PathPayment{
+		SendAsset:   NativeAsset{},
+		SendMax:     "abc",
+		Destination: kp2.Address(),
+		DestAsset:   CreditAsset{"ABCD", kp0.Address()},
+		DestAmount:  "1",
+		Path:        []Asset{abcdAsset},
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&pathPayment},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.PathPayment struct: Field: SendMax, Error: invalid amount format: abc"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestPathPaymentValidateDestAmount(t *testing.T) {
+	kp0 := newKeypair0()
+	kp2 := newKeypair2()
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(187316408680450))
+
+	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
+	pathPayment := PathPayment{
+		SendAsset:   NativeAsset{},
+		SendMax:     "10",
+		Destination: kp2.Address(),
+		DestAsset:   CreditAsset{"ABCD", kp0.Address()},
+		DestAmount:  "-1",
+		Path:        []Asset{abcdAsset},
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&pathPayment},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.PathPayment struct: Field: DestAmount, Error: value should be positve or zero"
+		assert.Contains(t, err.Error(), expected)
+	}
+}

--- a/txnbuild/payment.go
+++ b/txnbuild/payment.go
@@ -75,16 +75,17 @@ func (p *Payment) FromXDR(xdrOp xdr.Operation) error {
 // Validate for Payment validates the required struct fields. It returns an error if any
 // of the fields are invalid. Otherwise, it returns nil.
 func (p *Payment) Validate() error {
-	if !validateStellarPublicKey(p.Destination) {
-		return NewValidationError("Destination", "public key is invalid")
+	err := validateStellarPublicKey(p.Destination)
+	if err != nil {
+		return NewValidationError("Destination", err.Error())
 	}
 
-	err := validateStellarAsset(p.Asset)
+	err = validateStellarAsset(p.Asset)
 	if err != nil {
 		return NewValidationError("Asset", err.Error())
 	}
 
-	err = validateNumber(p.Amount)
+	err = validateAmount(p.Amount)
 	if err != nil {
 		return NewValidationError("Amount", err.Error())
 	}

--- a/txnbuild/payment.go
+++ b/txnbuild/payment.go
@@ -71,3 +71,23 @@ func (p *Payment) FromXDR(xdrOp xdr.Operation) error {
 
 	return nil
 }
+
+// Validate for Payment validates the required struct fields. It returns an error if any
+// of the fields are invalid. Otherwise, it returns nil.
+func (p *Payment) Validate() error {
+	if !validateStellarPublicKey(p.Destination) {
+		return NewValidationError("Destination", "public key is invalid")
+	}
+
+	err := validateStellarAsset(p.Asset)
+	if err != nil {
+		return NewValidationError("Asset", err.Error())
+	}
+
+	err = validateNumber(p.Amount)
+	if err != nil {
+		return NewValidationError("Amount", err.Error())
+	}
+
+	return nil
+}

--- a/txnbuild/payment_test.go
+++ b/txnbuild/payment_test.go
@@ -26,7 +26,7 @@ func TestPaymentValidateDestination(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.Payment struct: Field: Destination, Error: public key is invalid"
+		expected := "validation failed for *txnbuild.Payment operation: Field: Destination, Error: public key is undefined"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -50,7 +50,7 @@ func TestPaymentValidateAmount(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.Payment struct: Field: Amount, Error: invalid amount format: ten"
+		expected := "validation failed for *txnbuild.Payment operation: Field: Amount, Error: invalid amount format: ten"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -74,7 +74,7 @@ func TestPaymentValidateAsset(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.Payment struct: Field: Asset, Error: asset code length must be between 1 and 12 characters"
+		expected := "validation failed for *txnbuild.Payment operation: Field: Asset, Error: asset code length must be between 1 and 12 characters"
 		assert.Contains(t, err.Error(), expected)
 	}
 }

--- a/txnbuild/payment_test.go
+++ b/txnbuild/payment_test.go
@@ -1,0 +1,80 @@
+package txnbuild
+
+import (
+	"testing"
+
+	"github.com/stellar/go/network"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPaymentValidateDestination(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
+
+	payment := Payment{
+		Destination: "",
+		Amount:      "10",
+		Asset:       NativeAsset{},
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&payment},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.Payment struct: Field: Destination, Error: public key is invalid"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestPaymentValidateAmount(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
+
+	payment := Payment{
+		Destination: "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
+		Amount:      "ten",
+		Asset:       NativeAsset{},
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&payment},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.Payment struct: Field: Amount, Error: invalid amount format: ten"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestPaymentValidateAsset(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
+
+	payment := Payment{
+		Destination: "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
+		Amount:      "10",
+		Asset:       CreditAsset{},
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&payment},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.Payment struct: Field: Asset, Error: asset code length must be between 1 and 12 characters"
+		assert.Contains(t, err.Error(), expected)
+	}
+}

--- a/txnbuild/set_options.go
+++ b/txnbuild/set_options.go
@@ -309,3 +309,11 @@ func (so *SetOptions) FromXDR(xdrOp xdr.Operation) error {
 
 	return nil
 }
+
+// Validate for SetOptions validates the required struct fields. It returns an error if any
+// of the fields are invalid. Otherwise, it returns nil.
+func (so *SetOptions) Validate() error {
+	// skipping checks here because the individual methods above already check for required fields.
+	// Refactoring is out of the scope of this issue(https://github.com/stellar/go/issues/1041) so will leave as is for now.
+	return nil
+}

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -128,6 +128,10 @@ func (tx *Transaction) Build() error {
 	tx.xdrTransaction.SeqNum = seqnum
 
 	for _, op := range tx.Operations {
+		if verr := op.Validate(); verr != nil {
+			return errors.Wrap(verr, fmt.Sprintf("validation failed for %T struct", op))
+		}
+
 		xdrOperation, err2 := op.BuildXDR()
 		if err2 != nil {
 			return errors.Wrap(err2, fmt.Sprintf("failed to build operation %T", op))

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -129,7 +129,7 @@ func (tx *Transaction) Build() error {
 
 	for _, op := range tx.Operations {
 		if verr := op.Validate(); verr != nil {
-			return errors.Wrap(verr, fmt.Sprintf("validation failed for %T struct", op))
+			return errors.Wrap(verr, fmt.Sprintf("validation failed for %T operation", op))
 		}
 
 		xdrOperation, err2 := op.BuildXDR()

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -92,7 +92,7 @@ func TestPaymentFailsIfNoAssetSpecified(t *testing.T) {
 	}
 
 	err := tx.Build()
-	expectedErrMsg := "failed to build operation *txnbuild.Payment: you must specify an asset for payment"
+	expectedErrMsg := "validation failed for *txnbuild.Payment struct: Field: Asset, Error: asset is required"
 	require.EqualError(t, err, expectedErrMsg, "An asset is required")
 }
 
@@ -401,7 +401,7 @@ func TestChangeTrustNativeAssetNotAllowed(t *testing.T) {
 	}
 
 	err := tx.Build()
-	expectedErrMsg := "failed to build operation *txnbuild.ChangeTrust: trustline cannot be extended to a native (XLM) asset"
+	expectedErrMsg := "validation failed for *txnbuild.ChangeTrust struct: Field: Line, Error: native (XLM) asset type is not allowed"
 	require.EqualError(t, err, expectedErrMsg, "No trustlines for native assets")
 }
 

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -92,7 +92,7 @@ func TestPaymentFailsIfNoAssetSpecified(t *testing.T) {
 	}
 
 	err := tx.Build()
-	expectedErrMsg := "validation failed for *txnbuild.Payment struct: Field: Asset, Error: asset is required"
+	expectedErrMsg := "validation failed for *txnbuild.Payment operation: Field: Asset, Error: asset is undefined"
 	require.EqualError(t, err, expectedErrMsg, "An asset is required")
 }
 
@@ -401,7 +401,7 @@ func TestChangeTrustNativeAssetNotAllowed(t *testing.T) {
 	}
 
 	err := tx.Build()
-	expectedErrMsg := "validation failed for *txnbuild.ChangeTrust struct: Field: Line, Error: native (XLM) asset type is not allowed"
+	expectedErrMsg := "validation failed for *txnbuild.ChangeTrust operation: Field: Line, Error: native (XLM) asset type is not allowed"
 	require.EqualError(t, err, expectedErrMsg, "No trustlines for native assets")
 }
 


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

This PR adds validation logic to the txnbuilds operation structs so that invalid fields can be returned with the appropriate error message.

### Goal and scope

- Validate required fields in the txnbuild's operation structs
- Return clear error messages instead of `panic()`
- Close #1041 

### Summary of changes

- Added `Validate` method to the `Operation` interface.
- Implemented `Validate` method for each operation type.
- Call `Validate` method before building a transaction.
- Created `helpers.go` which contains reusable validation methods.
- Created `*_test.go` for each operation type. The `transaction_test.go` file was becoming too bulky.
- Added `ValidationError` type that holds errors that occur during validation. This implements the error interface.

### Note

Validation was not added for the following
- inflation: It has no required fields
- SetOptions: All the fields here are optional. Plus, validation logic has already been implemented in the `BuildXDR` method. Refactoring it was out of the scope of the issue.
- Operation SourceAccount: This is not a required field. Plus, to validate the sequence number, we the the `GetSequenceNumber` method implemented on the `Account` interface which is slated for v2.0.0

