### PR TITLE
codecov: disable pr comments, enable status check

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+comment: off
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+        base: auto
+    patch: no
+    changes: no


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] ~I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.~
</details>

### Summary

Disable codecov PR comments and replace with status check.

### Goal and scope

Codecov was added recently by @bartekn and is a good tool for giving us visibility into what code coverage new and existing code we write has, but it's default PR comments are quite long. This change disables the comments and instead adds a status check that is configured to only display changes between this PR and the commit it is based on.

The status check makes the additional details codecov provides accessible via a link in the status box. From there the author or any reviewer can see what parts of the diff have coverage and how coverage has changed.

The check will show ❌ if the changes reduce the coverage by more than `0.5%`, but the check won't block merging PRs. We should use the check as a prompt to making our code better, but not all changes we make can improve coverage so we shouldn't block work on it.

### Summary of changes

- Add a `.codecov.yml`.

### Known limitations & issues

N/A

### What shouldn't be reviewed

N/A