### PR TITLE
services/horizon/expingest: Batch insert ledger entries during state ingestion

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,16 +6,14 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
-## Unreleased
-
-* Fixed performance issue in Effects related endpoints.
-* Dropped support for Go 1.10, 1.11.
-* Add experimental support for `/offers`. To enable it, set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
-* Add flag to apply pending migrations before running horizon. If there are pending migrations, previously you needed to run `horizon db migrate up` before running `horizon`. Those two steps can be combined into one with the `--apply-migrations` flag (`APPLY_MIGRATIONS` env variable).
-
 ## v0.21.0
 
 * `/paths/strict-send` can now accept a `destination_account` parameter. If `destination_account` is provided then the endpoint will return all payment paths which terminate with an asset held by `destination_account`. Note that the endpoint will accept a `destination_account` or a `destination_asset` but not both.
+* Add experimental support for `/offers`. To enable it, set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
+* Add flag to apply pending migrations before running horizon. If there are pending migrations, previously you needed to run `horizon db migrate up` before running `horizon`. Those two steps can be combined into one with the `--apply-migrations` flag (`APPLY_MIGRATIONS` env variable).
+* Improved the speed of state ingestion in experimental ingestion system.
+* Fixed performance issue in Effects related endpoints.
+* Dropped support for Go 1.10, 1.11.
 
 ## v0.20.1
 

--- a/services/horizon/internal/db2/history/account_signers_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/account_signers_batch_insert_builder.go
@@ -1,0 +1,13 @@
+package history
+
+func (i *accountSignersBatchInsertBuilder) Add(signer AccountSigner) error {
+	return i.builder.Row(map[string]interface{}{
+		"account": signer.Account,
+		"signer":  signer.Signer,
+		"weight":  signer.Weight,
+	})
+}
+
+func (i *accountSignersBatchInsertBuilder) Exec() error {
+	return i.builder.Exec()
+}

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -136,6 +136,16 @@ type AccountSigner struct {
 	Weight  int32  `db:"weight"`
 }
 
+type AccountSignersBatchInsertBuilder interface {
+	Add(signer AccountSigner) error
+	Exec() error
+}
+
+// accountSignersBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
+type accountSignersBatchInsertBuilder struct {
+	builder db.BatchInsertBuilder
+}
+
 // Asset is a row of data from the `history_assets` table
 type Asset struct {
 	ID     int64  `db:"id"`
@@ -287,6 +297,16 @@ type Offer struct {
 	LastModifiedLedger uint32    `db:"last_modified_ledger"`
 }
 
+type OffersBatchInsertBuilder interface {
+	Add(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) error
+	Exec() error
+}
+
+// offersBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
+type offersBatchInsertBuilder struct {
+	builder db.BatchInsertBuilder
+}
+
 // OperationsQ is a helper struct to aid in configuring queries that loads
 // slices of Operation structs.
 type OperationsQ struct {
@@ -310,6 +330,7 @@ type QSigners interface {
 	GetLastLedgerExpIngest() (uint32, error)
 	UpdateLastLedgerExpIngest(ledgerSequence uint32) error
 	AccountsForSigner(signer string, page db2.PageQuery) ([]AccountSigner, error)
+	NewAccountSignersBatchInsertBuilder(maxBatchSize int) AccountSignersBatchInsertBuilder
 	CreateAccountSigner(account, signer string, weight int32) error
 	RemoveAccountSigner(account, signer string) error
 }
@@ -325,6 +346,7 @@ type OffersQuery struct {
 // QOffers defines offer related queries.
 type QOffers interface {
 	GetAllOffers() ([]Offer, error)
+	NewOffersBatchInsertBuilder(maxBatchSize int) OffersBatchInsertBuilder
 	UpsertOffer(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) error
 	RemoveOffer(offerID xdr.Int64) error
 }
@@ -405,6 +427,24 @@ type TransactionsQ struct {
 	parent        *Q
 	sql           sq.SelectBuilder
 	includeFailed bool
+}
+
+func (q *Q) NewAccountSignersBatchInsertBuilder(maxBatchSize int) AccountSignersBatchInsertBuilder {
+	return &accountSignersBatchInsertBuilder{
+		builder: db.BatchInsertBuilder{
+			Table:        q.GetTable("accounts_signers"),
+			MaxBatchSize: maxBatchSize,
+		},
+	}
+}
+
+func (q *Q) NewOffersBatchInsertBuilder(maxBatchSize int) OffersBatchInsertBuilder {
+	return &offersBatchInsertBuilder{
+		builder: db.BatchInsertBuilder{
+			Table:        q.GetTable("offers"),
+			MaxBatchSize: maxBatchSize,
+		},
+	}
 }
 
 // ElderLedger loads the oldest ledger known to the history database

--- a/services/horizon/internal/db2/history/mock_account_signers_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_account_signers_batch_insert_builder.go
@@ -1,0 +1,19 @@
+package history
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+type MockAccountSignersBatchInsertBuilder struct {
+	mock.Mock
+}
+
+func (m *MockAccountSignersBatchInsertBuilder) Add(signer AccountSigner) error {
+	a := m.Called(signer)
+	return a.Error(0)
+}
+
+func (m *MockAccountSignersBatchInsertBuilder) Exec() error {
+	a := m.Called()
+	return a.Error(0)
+}

--- a/services/horizon/internal/db2/history/mock_offers_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_offers_batch_insert_builder.go
@@ -1,0 +1,20 @@
+package history
+
+import (
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockOffersBatchInsertBuilder struct {
+	mock.Mock
+}
+
+func (m *MockOffersBatchInsertBuilder) Add(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) error {
+	a := m.Called(offer, lastModifiedLedger)
+	return a.Error(0)
+}
+
+func (m *MockOffersBatchInsertBuilder) Exec() error {
+	a := m.Called()
+	return a.Error(0)
+}

--- a/services/horizon/internal/db2/history/offers_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/offers_batch_insert_builder.go
@@ -5,12 +5,14 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
+// Add adds a new offer entry to the batch. `lastModifiedLedger` is another
+// parameter because `xdr.OfferEntry` does not have a field to hold this value.
 func (i *offersBatchInsertBuilder) Add(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) error {
 	var price float64
-	if offer.Price.N > 0 {
-		price = float64(offer.Price.N) / float64(offer.Price.D)
-	} else if offer.Price.D == 0 {
+	if offer.Price.D == 0 {
 		return errors.New("offer price denominator is zero")
+	} else if offer.Price.N > 0 {
+		price = float64(offer.Price.N) / float64(offer.Price.D)
 	}
 	buyingAsset, err := xdr.MarshalBase64(offer.Buying)
 	if err != nil {

--- a/services/horizon/internal/db2/history/offers_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/offers_batch_insert_builder.go
@@ -1,0 +1,40 @@
+package history
+
+import (
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+func (i *offersBatchInsertBuilder) Add(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) error {
+	var price float64
+	if offer.Price.N > 0 {
+		price = float64(offer.Price.N) / float64(offer.Price.D)
+	} else if offer.Price.D == 0 {
+		return errors.New("offer price denominator is zero")
+	}
+	buyingAsset, err := xdr.MarshalBase64(offer.Buying)
+	if err != nil {
+		return errors.Wrap(err, "cannot marshal buying asset in offer")
+	}
+	sellingAsset, err := xdr.MarshalBase64(offer.Selling)
+	if err != nil {
+		return errors.Wrap(err, "cannot marshal selling asset in offer")
+	}
+
+	return i.builder.Row(map[string]interface{}{
+		"sellerid":             offer.SellerId.Address(),
+		"offerid":              offer.OfferId,
+		"sellingasset":         sellingAsset,
+		"buyingasset":          buyingAsset,
+		"amount":               offer.Amount,
+		"pricen":               offer.Price.N,
+		"priced":               offer.Price.D,
+		"price":                price,
+		"flags":                offer.Flags,
+		"last_modified_ledger": lastModifiedLedger,
+	})
+}
+
+func (i *offersBatchInsertBuilder) Exec() error {
+	return i.builder.Exec()
+}

--- a/services/horizon/internal/db2/history/q_offers_mock.go
+++ b/services/horizon/internal/db2/history/q_offers_mock.go
@@ -16,6 +16,11 @@ func (m *MockQOffers) GetAllOffers() ([]Offer, error) {
 	return a.Get(0).([]Offer), a.Error(1)
 }
 
+func (m *MockQOffers) NewOffersBatchInsertBuilder(maxBatchSize int) OffersBatchInsertBuilder {
+	a := m.Called()
+	return a.Get(0).(OffersBatchInsertBuilder)
+}
+
 func (m *MockQOffers) UpsertOffer(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) error {
 	a := m.Called(offer, lastModifiedLedger)
 	return a.Error(0)

--- a/services/horizon/internal/db2/history/q_offers_mock.go
+++ b/services/horizon/internal/db2/history/q_offers_mock.go
@@ -17,7 +17,7 @@ func (m *MockQOffers) GetAllOffers() ([]Offer, error) {
 }
 
 func (m *MockQOffers) NewOffersBatchInsertBuilder(maxBatchSize int) OffersBatchInsertBuilder {
-	a := m.Called()
+	a := m.Called(maxBatchSize)
 	return a.Get(0).(OffersBatchInsertBuilder)
 }
 

--- a/services/horizon/internal/db2/history/q_signers_mock.go
+++ b/services/horizon/internal/db2/history/q_signers_mock.go
@@ -29,6 +29,11 @@ func (m *MockQSigners) AccountsForSigner(signer string, page db2.PageQuery) ([]A
 	return a.Get(0).([]AccountSigner), a.Error(1)
 }
 
+func (m *MockQSigners) NewAccountSignersBatchInsertBuilder(maxBatchSize int) AccountSignersBatchInsertBuilder {
+	a := m.Called(maxBatchSize)
+	return a.Get(0).(AccountSignersBatchInsertBuilder)
+}
+
 func (m *MockQSigners) CreateAccountSigner(account, signer string, weight int32) error {
 	a := m.Called(account, signer, weight)
 	return a.Error(0)

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -28,7 +28,7 @@ func accountForSignerStateNode(q *history.Q) *supportPipeline.PipelineNode {
 	return pipeline.StateNode(&processors.EntryTypeFilter{Type: xdr.LedgerEntryTypeAccount}).
 		Pipe(
 			pipeline.StateNode(&horizonProcessors.DatabaseProcessor{
-				HistoryQ: q,
+				SignersQ: q,
 				Action:   horizonProcessors.AccountsForSigner,
 			}),
 		)
@@ -70,7 +70,7 @@ func buildStatePipeline(historyQ *history.Q, graph *orderbook.OrderBookGraph) *p
 
 func accountForSignerLedgerNode(q *history.Q) *supportPipeline.PipelineNode {
 	return pipeline.LedgerNode(&horizonProcessors.DatabaseProcessor{
-		HistoryQ: q,
+		SignersQ: q,
 		Action:   horizonProcessors.AccountsForSigner,
 	})
 }

--- a/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
@@ -31,7 +31,7 @@ func (s *AccountsSignerProcessorTestSuiteState) SetupTest() {
 
 	s.processor = &DatabaseProcessor{
 		Action:   AccountsForSigner,
-		HistoryQ: s.mockQ,
+		SignersQ: s.mockQ,
 	}
 
 	// Reader and Writer should be always closed and once
@@ -169,7 +169,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) SetupTest() {
 
 	s.processor = &DatabaseProcessor{
 		Action:   AccountsForSigner,
-		HistoryQ: s.mockQ,
+		SignersQ: s.mockQ,
 	}
 
 	// Reader and Writer should be always closed and once

--- a/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
@@ -18,14 +18,16 @@ func TestAccountsSignerProcessorTestSuiteState(t *testing.T) {
 
 type AccountsSignerProcessorTestSuiteState struct {
 	suite.Suite
-	processor       *DatabaseProcessor
-	mockQ           *history.MockQSigners
-	mockStateReader *io.MockStateReader
-	mockStateWriter *io.MockStateWriter
+	processor              *DatabaseProcessor
+	mockQ                  *history.MockQSigners
+	mockBatchInsertBuilder *history.MockAccountSignersBatchInsertBuilder
+	mockStateReader        *io.MockStateReader
+	mockStateWriter        *io.MockStateWriter
 }
 
 func (s *AccountsSignerProcessorTestSuiteState) SetupTest() {
 	s.mockQ = &history.MockQSigners{}
+	s.mockBatchInsertBuilder = &history.MockAccountSignersBatchInsertBuilder{}
 	s.mockStateReader = &io.MockStateReader{}
 	s.mockStateWriter = &io.MockStateWriter{}
 
@@ -35,17 +37,17 @@ func (s *AccountsSignerProcessorTestSuiteState) SetupTest() {
 	}
 
 	// Reader and Writer should be always closed and once
-	s.mockStateReader.
-		On("Close").
-		Return(nil).Once()
+	s.mockStateReader.On("Close").Return(nil).Once()
+	s.mockStateWriter.On("Close").Return(nil).Once()
 
-	s.mockStateWriter.
-		On("Close").
-		Return(nil).Once()
+	s.mockQ.
+		On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
+		Return(s.mockBatchInsertBuilder).Once()
 }
 
 func (s *AccountsSignerProcessorTestSuiteState) TearDownTest() {
 	s.mockQ.AssertExpectations(s.T())
+	s.mockBatchInsertBuilder.AssertExpectations(s.T())
 	s.mockStateReader.AssertExpectations(s.T())
 	s.mockStateWriter.AssertExpectations(s.T())
 }
@@ -54,6 +56,8 @@ func (s *AccountsSignerProcessorTestSuiteState) TestNoEntries() {
 	s.mockStateReader.
 		On("Read").
 		Return(xdr.LedgerEntryChange{}, stdio.EOF).Once()
+
+	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
 
 	err := s.processor.ProcessState(
 		context.Background(),
@@ -98,14 +102,12 @@ func (s *AccountsSignerProcessorTestSuiteState) TestCreatesSigners() {
 			},
 		}, nil).Once()
 
-	s.mockQ.
-		On(
-			"CreateAccountSigner",
-			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-			int32(1),
-		).
-		Return(nil).Once()
+	s.mockBatchInsertBuilder.
+		On("Add", history.AccountSigner{
+			Account: "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+			Signer:  "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+			Weight:  int32(1),
+		}).Return(nil).Once()
 
 	s.mockStateReader.
 		On("Read").
@@ -127,18 +129,18 @@ func (s *AccountsSignerProcessorTestSuiteState) TestCreatesSigners() {
 			},
 		}, nil).Once()
 
-	s.mockQ.
-		On(
-			"CreateAccountSigner",
-			"GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX",
-			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-			int32(10),
-		).
-		Return(nil).Once()
+	s.mockBatchInsertBuilder.
+		On("Add", history.AccountSigner{
+			Account: "GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX",
+			Signer:  "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+			Weight:  int32(10),
+		}).Return(nil).Once()
 
 	s.mockStateReader.
 		On("Read").
 		Return(xdr.LedgerEntryChange{}, stdio.EOF).Once()
+
+	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
 
 	err := s.processor.ProcessState(
 		context.Background(),

--- a/services/horizon/internal/expingest/processors/database_processor.go
+++ b/services/horizon/internal/expingest/processors/database_processor.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stellar/go/exp/ingest/io"
 	ingestpipeline "github.com/stellar/go/exp/ingest/pipeline"
 	"github.com/stellar/go/exp/support/pipeline"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -15,6 +16,22 @@ import (
 func (p *DatabaseProcessor) ProcessState(ctx context.Context, store *pipeline.Store, r io.StateReader, w io.StateWriter) error {
 	defer r.Close()
 	defer w.Close()
+
+	const maxBatchSize = 100000
+
+	var (
+		accountSignerBatch history.AccountSignersBatchInsertBuilder
+		offersBatch        history.OffersBatchInsertBuilder
+	)
+
+	switch p.Action {
+	case AccountsForSigner:
+		accountSignerBatch = p.SignersQ.NewAccountSignersBatchInsertBuilder(maxBatchSize)
+	case Offers:
+		offersBatch = p.OffersQ.NewOffersBatchInsertBuilder(maxBatchSize)
+	default:
+		return errors.Errorf("Invalid action type (%s)", p.Action)
+	}
 
 	for {
 		entryChange, err := r.Read()
@@ -40,13 +57,13 @@ func (p *DatabaseProcessor) ProcessState(ctx context.Context, store *pipeline.St
 			accountEntry := entryChange.MustState().Data.MustAccount()
 			account := accountEntry.AccountId.Address()
 			for signer, weight := range accountEntry.SignerSummary() {
-				err = p.HistoryQ.CreateAccountSigner(
-					account,
-					signer,
-					weight,
-				)
+				err = accountSignerBatch.Add(history.AccountSigner{
+					Account: account,
+					Signer:  signer,
+					Weight:  weight,
+				})
 				if err != nil {
-					return errors.Wrap(err, "Error updating account for signer")
+					return errors.Wrap(err, "Error adding row to accountSignerBatch")
 				}
 			}
 		case Offers:
@@ -55,9 +72,12 @@ func (p *DatabaseProcessor) ProcessState(ctx context.Context, store *pipeline.St
 				continue
 			}
 
-			offer := entryChange.MustState().Data.MustOffer()
-			if err := p.OffersQ.UpsertOffer(offer, entryChange.MustState().LastModifiedLedgerSeq); err != nil {
-				return errors.Wrap(err, "Error inserting offers")
+			err = offersBatch.Add(
+				entryChange.MustState().Data.MustOffer(),
+				entryChange.MustState().LastModifiedLedgerSeq,
+			)
+			if err != nil {
+				return errors.Wrap(err, "Error adding row to offersBatch")
 			}
 		default:
 			return errors.New("Unknown action")
@@ -69,6 +89,21 @@ func (p *DatabaseProcessor) ProcessState(ctx context.Context, store *pipeline.St
 		default:
 			continue
 		}
+	}
+
+	var err error
+
+	switch p.Action {
+	case AccountsForSigner:
+		err = accountSignerBatch.Exec()
+	case Offers:
+		err = offersBatch.Exec()
+	default:
+		return errors.Errorf("Invalid action type (%s)", p.Action)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "Error batch inserting rows")
 	}
 
 	return nil
@@ -133,7 +168,7 @@ func (p *DatabaseProcessor) processLedgerAccountsForSigner(transaction io.Ledger
 		if change.Pre != nil {
 			preAccountEntry := change.Pre.MustAccount()
 			for signer := range preAccountEntry.SignerSummary() {
-				err := p.HistoryQ.RemoveAccountSigner(preAccountEntry.AccountId.Address(), signer)
+				err := p.SignersQ.RemoveAccountSigner(preAccountEntry.AccountId.Address(), signer)
 				if err != nil {
 					return errors.Wrap(err, "Error removing a signer")
 				}
@@ -143,7 +178,7 @@ func (p *DatabaseProcessor) processLedgerAccountsForSigner(transaction io.Ledger
 		if change.Post != nil {
 			postAccountEntry := change.Post.MustAccount()
 			for signer, weight := range postAccountEntry.SignerSummary() {
-				err := p.HistoryQ.CreateAccountSigner(postAccountEntry.AccountId.Address(), signer, weight)
+				err := p.SignersQ.CreateAccountSigner(postAccountEntry.AccountId.Address(), signer, weight)
 				if err != nil {
 					return errors.Wrap(err, "Error inserting a signer")
 				}

--- a/services/horizon/internal/expingest/processors/database_processor.go
+++ b/services/horizon/internal/expingest/processors/database_processor.go
@@ -13,11 +13,11 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
+const maxBatchSize = 100000
+
 func (p *DatabaseProcessor) ProcessState(ctx context.Context, store *pipeline.Store, r io.StateReader, w io.StateWriter) error {
 	defer r.Close()
 	defer w.Close()
-
-	const maxBatchSize = 100000
 
 	var (
 		accountSignerBatch history.AccountSignersBatchInsertBuilder

--- a/services/horizon/internal/expingest/processors/main.go
+++ b/services/horizon/internal/expingest/processors/main.go
@@ -24,7 +24,7 @@ const (
 // *history.Q object to share a common transaction. `Action` defines what each
 // processor is responsible for.
 type DatabaseProcessor struct {
-	HistoryQ history.QSigners
+	SignersQ history.QSigners
 	OffersQ  history.QOffers
 	Action   DatabaseProcessorActionType
 }

--- a/support/db/batch_insert_builder.go
+++ b/support/db/batch_insert_builder.go
@@ -1,0 +1,84 @@
+package db
+
+import (
+	"fmt"
+	"sort"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/stellar/go/support/errors"
+)
+
+// Row adds a new row to the batch. All rows must have exactly the same columns
+// (map keys). Otherwise, error will be returned. Please note that rows are not
+// added one by one but in batches when Exec is called.
+func (b *BatchInsertBuilder) Row(row map[string]interface{}) error {
+	if b.columns == nil {
+		b.columns = make([]string, 0, len(row))
+		b.rows = make([][]interface{}, 0)
+
+		for column, _ := range row {
+			b.columns = append(b.columns, column)
+		}
+
+		sort.Strings(b.columns)
+	}
+
+	if len(b.columns) != len(row) {
+		return errors.Errorf("Invalid number of columns (expected=%d, actual=%d)", len(b.columns), len(row))
+	}
+
+	rowSlice := make([]interface{}, 0, len(b.columns))
+	for _, column := range b.columns {
+		val, ok := row[column]
+		if !ok {
+			return errors.Errorf(`Column "%s" does not exist`, column)
+		}
+		rowSlice = append(rowSlice, val)
+	}
+
+	b.rows = append(b.rows, rowSlice)
+
+	// Call Exec when MaxBatchSize is reached.
+	if len(b.rows) == b.MaxBatchSize {
+		return b.Exec()
+	}
+
+	return nil
+}
+
+func (b *BatchInsertBuilder) createInsertBuilder() {
+	b.sql = sq.Insert(b.Table.Name).Columns(b.columns...)
+}
+
+// Exec inserts rows in batches. In case of errors it's possible that some batches
+// were added so this should be run in a DB transaction for easy rollbacks.
+func (b *BatchInsertBuilder) Exec() error {
+	b.createInsertBuilder()
+	paramsCount := 0
+
+	for _, row := range b.rows {
+		b.sql = b.sql.Values(row...)
+		paramsCount += len(row)
+
+		if paramsCount > postgresQueryMaxParams-2*len(b.columns) {
+			_, err := b.Table.Session.Exec(b.sql)
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("Error adding values while inserting to %s", b.Table.Name))
+			}
+			paramsCount = 0
+			b.createInsertBuilder()
+		}
+	}
+
+	// Insert last batch
+	if paramsCount > 0 {
+		_, err := b.Table.Session.Exec(b.sql)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Error adding values while inserting to %s", b.Table.Name))
+		}
+	}
+
+	// Clear the rows so user can reuse it for batch inserting to a single table
+	b.rows = make([][]interface{}, 0)
+	return nil
+}

--- a/support/db/batch_insert_builder.go
+++ b/support/db/batch_insert_builder.go
@@ -10,7 +10,8 @@ import (
 
 // Row adds a new row to the batch. All rows must have exactly the same columns
 // (map keys). Otherwise, error will be returned. Please note that rows are not
-// added one by one but in batches when Exec is called.
+// added one by one but in batches when `Exec` is called (or `MaxBatchSize` is
+// reached).
 func (b *BatchInsertBuilder) Row(row map[string]interface{}) error {
 	if b.columns == nil {
 		b.columns = make([]string, 0, len(row))

--- a/support/db/batch_insert_builder.go
+++ b/support/db/batch_insert_builder.go
@@ -75,7 +75,7 @@ func (b *BatchInsertBuilder) Exec() error {
 	if paramsCount > 0 {
 		_, err := b.Table.Session.Exec(b.sql)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Error adding values while inserting to %s", b.Table.Name))
+			return errors.Wrap(err, fmt.Sprintf("error adding values while inserting to %s", b.Table.Name))
 		}
 	}
 

--- a/support/db/batch_insert_builder.go
+++ b/support/db/batch_insert_builder.go
@@ -47,14 +47,10 @@ func (b *BatchInsertBuilder) Row(row map[string]interface{}) error {
 	return nil
 }
 
-func (b *BatchInsertBuilder) createInsertBuilder() {
-	b.sql = sq.Insert(b.Table.Name).Columns(b.columns...)
-}
-
 // Exec inserts rows in batches. In case of errors it's possible that some batches
 // were added so this should be run in a DB transaction for easy rollbacks.
 func (b *BatchInsertBuilder) Exec() error {
-	b.createInsertBuilder()
+	b.sql = sq.Insert(b.Table.Name).Columns(b.columns...)
 	paramsCount := 0
 
 	for _, row := range b.rows {
@@ -67,7 +63,7 @@ func (b *BatchInsertBuilder) Exec() error {
 				return errors.Wrap(err, fmt.Sprintf("error adding values while inserting to %s", b.Table.Name))
 			}
 			paramsCount = 0
-			b.createInsertBuilder()
+			b.sql = sq.Insert(b.Table.Name).Columns(b.columns...)
 		}
 	}
 

--- a/support/db/batch_insert_builder.go
+++ b/support/db/batch_insert_builder.go
@@ -32,7 +32,7 @@ func (b *BatchInsertBuilder) Row(row map[string]interface{}) error {
 	for _, column := range b.columns {
 		val, ok := row[column]
 		if !ok {
-			return errors.Errorf(`Column "%s" does not exist`, column)
+			return errors.Errorf(`column "%s" does not exist`, column)
 		}
 		rowSlice = append(rowSlice, val)
 	}

--- a/support/db/batch_insert_builder.go
+++ b/support/db/batch_insert_builder.go
@@ -64,7 +64,7 @@ func (b *BatchInsertBuilder) Exec() error {
 		if paramsCount > postgresQueryMaxParams-2*len(b.columns) {
 			_, err := b.Table.Session.Exec(b.sql)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("Error adding values while inserting to %s", b.Table.Name))
+				return errors.Wrap(err, fmt.Sprintf("error adding values while inserting to %s", b.Table.Name))
 			}
 			paramsCount = 0
 			b.createInsertBuilder()

--- a/support/db/batch_insert_builder.go
+++ b/support/db/batch_insert_builder.go
@@ -17,7 +17,7 @@ func (b *BatchInsertBuilder) Row(row map[string]interface{}) error {
 		b.columns = make([]string, 0, len(row))
 		b.rows = make([][]interface{}, 0)
 
-		for column, _ := range row {
+		for column := range row {
 			b.columns = append(b.columns, column)
 		}
 

--- a/support/db/batch_insert_builder.go
+++ b/support/db/batch_insert_builder.go
@@ -25,7 +25,7 @@ func (b *BatchInsertBuilder) Row(row map[string]interface{}) error {
 	}
 
 	if len(b.columns) != len(row) {
-		return errors.Errorf("Invalid number of columns (expected=%d, actual=%d)", len(b.columns), len(row))
+		return errors.Errorf("invalid number of columns (expected=%d, actual=%d)", len(b.columns), len(row))
 	}
 
 	rowSlice := make([]interface{}, 0, len(b.columns))

--- a/support/db/batch_insert_builder_test.go
+++ b/support/db/batch_insert_builder_test.go
@@ -38,20 +38,20 @@ func TestBatchInsertBuilder(t *testing.T) {
 		"hunger_level": "120",
 		"abc":          "def",
 	})
-	assert.EqualError(t, err, "Invalid number of columns (expected=2, actual=3)")
+	assert.EqualError(t, err, "invalid number of columns (expected=2, actual=3)")
 
 	// Not enough columns
 	err = insertBuilder.Row(map[string]interface{}{
 		"name": "bubba",
 	})
-	assert.EqualError(t, err, "Invalid number of columns (expected=2, actual=1)")
+	assert.EqualError(t, err, "invalid number of columns (expected=2, actual=1)")
 
 	// Invalid column
 	err = insertBuilder.Row(map[string]interface{}{
 		"name":  "bubba",
 		"hello": "120",
 	})
-	assert.EqualError(t, err, `Column "hunger_level" does not exist`)
+	assert.EqualError(t, err, `column "hunger_level" does not exist`)
 
 	err = insertBuilder.Exec()
 	assert.NoError(t, err)

--- a/support/db/batch_insert_builder_test.go
+++ b/support/db/batch_insert_builder_test.go
@@ -1,0 +1,71 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stellar/go/support/db/dbtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchInsertBuilder(t *testing.T) {
+	db := dbtest.Postgres(t).Load(testSchema)
+	defer db.Close()
+	sess := &Session{DB: db.Open()}
+	defer sess.DB.Close()
+
+	insertBuilder := &BatchInsertBuilder{
+		Table: sess.GetTable("people"),
+	}
+
+	var err error
+
+	err = insertBuilder.Row(map[string]interface{}{
+		"name":         "bubba",
+		"hunger_level": "120",
+	})
+	assert.NoError(t, err)
+
+	err = insertBuilder.Row(map[string]interface{}{
+		"name":         "bubba2",
+		"hunger_level": "1202",
+	})
+	assert.NoError(t, err)
+
+	// Extra column
+	err = insertBuilder.Row(map[string]interface{}{
+		"name":         "bubba",
+		"hunger_level": "120",
+		"abc":          "def",
+	})
+	assert.EqualError(t, err, "Invalid number of columns (expected=2, actual=3)")
+
+	// Not enough columns
+	err = insertBuilder.Row(map[string]interface{}{
+		"name": "bubba",
+	})
+	assert.EqualError(t, err, "Invalid number of columns (expected=2, actual=1)")
+
+	// Invalid column
+	err = insertBuilder.Row(map[string]interface{}{
+		"name":  "bubba",
+		"hello": "120",
+	})
+	assert.EqualError(t, err, `Column "hunger_level" does not exist`)
+
+	err = insertBuilder.Exec()
+	assert.NoError(t, err)
+
+	// Check rows
+	var found []person
+	err = sess.SelectRaw(&found, `SELECT * FROM people WHERE name like 'bubba%'`)
+
+	require.NoError(t, err)
+	if assert.Len(t, found, 2) {
+		assert.Equal(t, "bubba", found[0].Name)
+		assert.Equal(t, "120", found[0].HungerLevel)
+
+		assert.Equal(t, "bubba2", found[1].Name)
+		assert.Equal(t, "1202", found[1].HungerLevel)
+	}
+}

--- a/support/db/batch_insert_builder_test.go
+++ b/support/db/batch_insert_builder_test.go
@@ -56,6 +56,14 @@ func TestBatchInsertBuilder(t *testing.T) {
 	err = insertBuilder.Exec()
 	assert.NoError(t, err)
 
+	query, args, err := insertBuilder.sql.ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, "INSERT INTO people (hunger_level,name) VALUES (?,?),(?,?)", query)
+	assert.Equal(t, []interface{}{
+		"120", "bubba",
+		"1202", "bubba2",
+	}, args)
+
 	// Check rows
 	var found []person
 	err = sess.SelectRaw(&found, `SELECT * FROM people WHERE name like 'bubba%'`)

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -25,6 +25,9 @@ import (
 	_ "github.com/lib/pq"
 )
 
+// postgresQueryMaxParams defines the maximum number of parameters in a query.
+var postgresQueryMaxParams = 65535
+
 // Conn represents a connection to a single database.
 type Conn interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
@@ -52,6 +55,22 @@ type InsertBuilder struct {
 	rows        []interface{}
 	ignoredCols map[string]bool
 	sql         squirrel.InsertBuilder
+}
+
+// BatchInsertBuilder works like sq.InsertBuilder but has a better support for batching
+// large number of rows.
+// It is NOT safe for concurent use.
+type BatchInsertBuilder struct {
+	Table *Table
+	// MaxBatchSize defines the maximum size of a batch. If this number is
+	// reached after calling Row() it will call Exec() immediately inserting
+	// all rows to a DB.
+	// Zero (default) will not add rows until explicitly calling Exec.
+	MaxBatchSize int
+
+	columns []string
+	rows    [][]interface{}
+	sql     squirrel.InsertBuilder
 }
 
 // GetBuilder is a helper struct used to construct sql queries of the SELECT

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -59,7 +59,7 @@ type InsertBuilder struct {
 
 // BatchInsertBuilder works like sq.InsertBuilder but has a better support for batching
 // large number of rows.
-// It is NOT safe for concurent use.
+// It is NOT safe for concurrent use.
 type BatchInsertBuilder struct {
 	Table *Table
 	// MaxBatchSize defines the maximum size of a batch. If this number is


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

During state ingestion we add a large number of ledger entries to a database. To make the process faster the code in this commit adds them in batches instead of one by one. Public network state ingestion that's using batch inserts takes 4-8 minutes on my machine (depends on machine's CPU usage by other processes) vs ~40 minutes before. Proper performance tests should be done in the staging environment.

Close #1613.

### Goal and scope

The goal of this PR is to make state ingestion faster in Horizon.

Adding a large number of rows to a database table one by one can be slow because each query adds a round trip connection time to a total running time of insert session. The solution for this is adding rows in batches that add round trip connection time only when batch is inserted.

Because batch inserts may be useful outside Horizon a new `BatchInsertBuilder` was added to `support/db` package. By default batch is inserted when calling `Exec` method however users can define `MaxBatchSize`. When it 's reached, the `Exec` method is called automatically after adding a new row in `Row` method. Additionally `BatchInsertBuilder` has a protection against batches that are too big for Postgres to process. The maximum number of params in a query is equal to 65535. `BatchInsertBuilder` will split current batch into smaller batches if the number of params is close to the maximum.

### Summary of changes

* Created `BatchInsertBuilder` in `support/db` package.
* Added two wrappers in `horizon/db2/history`: `accountSignersBatchInsertBuilder` and `offersBatchInsertBuilder` that allow easier use of `BatchInsertBuilder` in Horizon context.
* Added new methods that return interface types for new builders. This was done to make testing possible.

### Known limitations & issues

I experimented with batch inserting rows to tables with constrains and indexes removed. While this was (obviously) faster the code implementing removing and adding back indexes would not be readable and easy to maintain.

### What shouldn't be reviewed

Tests will be added to this PR after initial 👍 on the design.