### PR TITLE
horizon/expingest: Fix ingest session resume

### DIFF
--- a/exp/ingest/live_session.go
+++ b/exp/ingest/live_session.go
@@ -155,7 +155,7 @@ func (s *LiveSession) resume(ledgerSequence uint32, ledgerAdapter *adapters.Ledg
 				}
 
 				if latestLedger > ledgerSequence {
-					return errors.New("Gap detected")
+					return errors.Errorf("Gap detected (ledger %d does not exist but %d is latest)", ledgerSequence, latestLedger)
 				}
 
 				select {

--- a/exp/ingest/live_session.go
+++ b/exp/ingest/live_session.go
@@ -88,6 +88,15 @@ func (s *LiveSession) updateCursor(ledgerSequence uint32) error {
 	return nil
 }
 
+// Resume resumes the session from `ledgerSequence`.
+//
+// WARNING: it's likely that developers will use
+// `LiveSession.GetLatestSuccessfullyProcessedLedger()` to get the latest
+// successfuly processed ledger after `Resume` returns error. It's critical
+// to understand that `GetLatestSuccessfullyProcessedLedger()` will return `0`
+// when no ledgers have been successfully processed, ex. error while trying
+// to process a ledger after application restart. You should always check
+// if the value is equal `0` before overwriting your local variable.
 func (s *LiveSession) Resume(ledgerSequence uint32) error {
 	s.standardSession.shutdown = make(chan bool)
 
@@ -212,6 +221,10 @@ func (s *LiveSession) resume(ledgerSequence uint32, ledgerAdapter *adapters.Ledg
 	return nil
 }
 
+// GetLatestSuccessfullyProcessedLedger returns the last SUCCESSFULLY
+// processed ledger. Returns zero (`0`) if no ledgers have been successfully
+// processed yet. Please check `Resume` godoc to understand possible
+// implications.
 func (s *LiveSession) GetLatestSuccessfullyProcessedLedger() uint32 {
 	return s.standardSession.latestSuccessfullyProcessedLedger
 }

--- a/exp/ingest/live_session.go
+++ b/exp/ingest/live_session.go
@@ -53,7 +53,7 @@ func (s *LiveSession) Run() error {
 		return errors.Wrap(err, "initState error")
 	}
 
-	s.standardSession.latestSuccessfullyProcessedLedger = currentLedger
+	s.latestSuccessfullyProcessedLedger = currentLedger
 
 	// Exit early if Shutdown() was called.
 	select {
@@ -90,13 +90,13 @@ func (s *LiveSession) updateCursor(ledgerSequence uint32) error {
 
 // Resume resumes the session from `ledgerSequence`.
 //
-// WARNING: it's likely that developers will use
-// `LiveSession.GetLatestSuccessfullyProcessedLedger()` to get the latest
-// successfuly processed ledger after `Resume` returns error. It's critical
-// to understand that `GetLatestSuccessfullyProcessedLedger()` will return `0`
-// when no ledgers have been successfully processed, ex. error while trying
-// to process a ledger after application restart. You should always check
-// if the value is equal `0` before overwriting your local variable.
+// WARNING: it's likely that developers will use `GetLatestSuccessfullyProcessedLedger()`
+// to get the latest successfuly processed ledger after `Resume` returns error.
+// It's critical to understand that `GetLatestSuccessfullyProcessedLedger()` will
+// return `(0, false)` when no ledgers have been successfully processed, ex.
+// error while trying to process a ledger after application restart.
+// You should always check if the second returned value is equal `false` before
+// overwriting your local variable.
 func (s *LiveSession) Resume(ledgerSequence uint32) error {
 	s.standardSession.shutdown = make(chan bool)
 
@@ -206,7 +206,7 @@ func (s *LiveSession) resume(ledgerSequence uint32, ledgerAdapter *adapters.Ledg
 		if s.LedgerReporter != nil {
 			s.LedgerReporter.OnEndLedger(nil, false)
 		}
-		s.standardSession.latestSuccessfullyProcessedLedger = ledgerSequence
+		s.latestSuccessfullyProcessedLedger = ledgerSequence
 
 		// Update cursor - this needs to be done after `latestSuccessfullyProcessedLedger`
 		// is updated as the cursor update shouldn't affect this value.
@@ -221,12 +221,16 @@ func (s *LiveSession) resume(ledgerSequence uint32, ledgerAdapter *adapters.Ledg
 	return nil
 }
 
-// GetLatestSuccessfullyProcessedLedger returns the last SUCCESSFULLY
-// processed ledger. Returns zero (`0`) if no ledgers have been successfully
-// processed yet. Please check `Resume` godoc to understand possible
-// implications.
-func (s *LiveSession) GetLatestSuccessfullyProcessedLedger() uint32 {
-	return s.standardSession.latestSuccessfullyProcessedLedger
+// GetLatestSuccessfullyProcessedLedger returns the last SUCCESSFULLY processed
+// ledger. Returns (0, false) if no ledgers have been successfully processed yet
+// to prevent situations where `GetLatestSuccessfullyProcessedLedger()` value is
+// not properly checked in a loop resulting in ingesting ledger 0+1=1.
+// Please check `Resume` godoc to understand possible implications.
+func (s *LiveSession) GetLatestSuccessfullyProcessedLedger() (ledgerSequence uint32, processed bool) {
+	if s.latestSuccessfullyProcessedLedger == 0 {
+		return 0, false
+	}
+	return s.latestSuccessfullyProcessedLedger, true
 }
 
 func (s *LiveSession) validate() error {

--- a/exp/ingest/main.go
+++ b/exp/ingest/main.go
@@ -13,9 +13,8 @@ import (
 
 // standardSession contains common methods used by all sessions.
 type standardSession struct {
-	shutdown                          chan bool
-	rwLock                            sync.RWMutex
-	latestSuccessfullyProcessedLedger uint32
+	shutdown chan bool
+	rwLock   sync.RWMutex
 
 	runningMutex sync.Mutex
 	running      bool
@@ -40,6 +39,8 @@ type LiveSession struct {
 	// TempSet is a store used to hold temporary objects generated during
 	// state processing. If nil, defaults to io.MemoryTempSet.
 	TempSet io.TempSet
+
+	latestSuccessfullyProcessedLedger uint32
 }
 
 // SingleLedgerSession initializes the ledger state using `Archive` and `StatePipeline`
@@ -67,11 +68,6 @@ type Session interface {
 	// Session user to determine what was the last ledger processed by a
 	// Session as it's stateless (or if Run() should be called first).
 	Resume(ledgerSequence uint32) error
-	// GetLatestSuccessfullyProcessedLedger returns the ledger sequence of the
-	// latest successfully processed ledger in the session. Return 0 if no
-	// ledgers were processed yet.
-	// Please note that this value is not synchronized with pipeline hooks.
-	GetLatestSuccessfullyProcessedLedger() uint32
 	// Shutdown gracefully stops running session and stops all internal
 	// objects.
 	// Calling Shutdown() does not trigger post processing hooks.

--- a/exp/ingest/single_ledger_session.go
+++ b/exp/ingest/single_ledger_session.go
@@ -29,7 +29,6 @@ func (s *SingleLedgerSession) Run() error {
 		return errors.Wrap(err, "processState errored")
 	}
 
-	s.standardSession.latestSuccessfullyProcessedLedger = sequence
 	return nil
 }
 

--- a/exp/ingest/standard_session.go
+++ b/exp/ingest/standard_session.go
@@ -29,7 +29,3 @@ func (s *standardSession) UpdateLock() {
 func (s *standardSession) UpdateUnlock() {
 	s.rwLock.Unlock()
 }
-
-func (s *standardSession) GetLatestSuccessfullyProcessedLedger() uint32 {
-	return s.latestSuccessfullyProcessedLedger
-}

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -29,7 +29,9 @@ const (
 	// - 1: Initial version
 	// - 2: We added the orderbook, offers processors and distributed
 	//      ingestion.
-	CurrentVersion = 2
+	// - 3: Fixes a bug that could potentialy result in invalid state
+	//      (#1722). Update the version to clear the state.
+	CurrentVersion = 3
 )
 
 var log = ilog.DefaultLogger.WithField("service", "expingest")

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -181,8 +181,9 @@ func (s *System) Run() {
 			if err != nil {
 				// Check if session processed a state, if so, continue since the
 				// last processed ledger, otherwise start over.
-				lastIngestedLedger = s.session.GetLatestSuccessfullyProcessedLedger()
-				if lastIngestedLedger == 0 {
+				var processed bool
+				lastIngestedLedger, processed = s.session.GetLatestSuccessfullyProcessedLedger()
+				if !processed {
 					return err
 				}
 
@@ -249,10 +250,10 @@ func (s *System) resumeFromLedger(lastIngestedLedger uint32) {
 	retryOnError(time.Second, func() error {
 		err := s.session.Resume(lastIngestedLedger + 1)
 		if err != nil {
-			// If no ledgers processed so far it will return 0. In such case
-			// try again with the lastIngestedLedger+1.
-			sessionLastLedger := s.session.GetLatestSuccessfullyProcessedLedger()
-			if sessionLastLedger > 0 {
+			// If no ledgers processed so far, try again with the
+			// lastIngestedLedger+1.
+			sessionLastLedger, processed := s.session.GetLatestSuccessfullyProcessedLedger()
+			if !processed {
 				lastIngestedLedger = sessionLastLedger
 			}
 			return errors.Wrap(err, "Error returned from ingest.LiveSession")

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -251,9 +251,11 @@ func (s *System) resumeFromLedger(lastIngestedLedger uint32) {
 		err := s.session.Resume(lastIngestedLedger + 1)
 		if err != nil {
 			// If no ledgers processed so far, try again with the
-			// lastIngestedLedger+1.
+			// lastIngestedLedger+1 (do nothing).
+			// Otherwise, set lastIngestedLedger to the last successfully
+			// ingested ledger in the session.
 			sessionLastLedger, processed := s.session.GetLatestSuccessfullyProcessedLedger()
-			if !processed {
+			if processed {
 				lastIngestedLedger = sessionLastLedger
 			}
 			return errors.Wrap(err, "Error returned from ingest.LiveSession")

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -247,7 +247,12 @@ func (s *System) resumeFromLedger(lastIngestedLedger uint32) {
 	retryOnError(time.Second, func() error {
 		err := s.session.Resume(lastIngestedLedger + 1)
 		if err != nil {
-			lastIngestedLedger = s.session.GetLatestSuccessfullyProcessedLedger()
+			// If no ledgers processed so far it will return 0. In such case
+			// try again with the lastIngestedLedger+1.
+			sessionLastLedger := s.session.GetLatestSuccessfullyProcessedLedger()
+			if sessionLastLedger > 0 {
+				lastIngestedLedger = sessionLastLedger
+			}
 			return errors.Wrap(err, "Error returned from ingest.LiveSession")
 		}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

This PR fixes a bug in `expingest.System` session resume code. Check the existing code for `resumeFromLedger` method:
```go
func (s *System) resumeFromLedger(lastIngestedLedger uint32) {
	retryOnError(time.Second, func() error {
		err := s.session.Resume(lastIngestedLedger + 1)
		if err != nil {
			lastIngestedLedger = s.session.GetLatestSuccessfullyProcessedLedger()
			return errors.Wrap(err, "Error returned from ingest.LiveSession")
		}

		log.Info("Session shut down")
		return nil
	})
}
```
Now, consider that Horizon is starting up to resume ingesting ledgers (state ingested before). In such situation `GetLatestSuccessfullyProcessedLedger()` returned by `s.session` is equal `0`. If `s.session.Resume(lastIngestedLedger + 1)` returns any error (ex. temporary DB connection issue), the code will update `lastIngestedLedger` to `0` and resume ingestion from ledger `1`!

The issue could happen only if ALL conditions below are true:
* Horizon is connected to stellar-core will full history.
* Horizon has been restarted and state has been ingested in the previous run.
* There was a temporary error while ingesting the first ledger after the last ingested ledger.

To solve the issue we now return two values in `GetLatestSuccessfullyProcessedLedger()`: `ledgerSequence uint32, processed bool`. This way developer is encouraged to check both values and act accordingly. The godoc have been also updated to better explain potential issues.

This issue shows that we need to close/fix the following issues before shipping critical endpoints:
- Periodic state verification is critical for data correctness and safety (#1550).
- We don't have good test coverage for `exp/ingest` and `horizon/expingest`. This was started by @tamirms in #1607 but we should aim for 90%+ test coverage for critical packages (#1343).
- We shouldn't use UPSERTs in state updating code. Normal insert/update/delete can act as additional line of defence (ex. inserting row that shouldn't exist will error with unique constraint violation, etc.) https://github.com/stellar/go/issues/1723