### PR TITLE
services/{bridge,compliance}/internal/config: remove mysql support

### DIFF
--- a/services/bridge/internal/config/main.go
+++ b/services/bridge/internal/config/main.go
@@ -92,8 +92,7 @@ func (c *Config) Validate() (err error) {
 		}
 	}
 
-	var dbURL *url.URL
-	dbURL, err = url.Parse(c.Database.URL)
+	_, err = url.Parse(c.Database.URL)
 	if err != nil {
 		err = errors.New("Cannot parse database.url param")
 		return
@@ -101,11 +100,8 @@ func (c *Config) Validate() (err error) {
 
 	switch c.Database.Type {
 	case "mysql":
-		// Add `parseTime=true` param to mysql url
-		query := dbURL.Query()
-		query.Set("parseTime", "true")
-		dbURL.RawQuery = query.Encode()
-		c.Database.URL = dbURL.String()
+		err = errors.New("Invalid database.type param, mysql support is discontinued")
+		return
 	case "postgres":
 		break
 	case "":

--- a/services/bridge/internal/config/main_test.go
+++ b/services/bridge/internal/config/main_test.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Validate_db_type(t *testing.T) {
+	c := Config{
+		Port:              func(i int) *int { return &i }(8001),
+		Horizon:           "https://example.com",
+		NetworkPassphrase: "Test SDF Network ; September 2015",
+		Database: &Database{
+			Type: "",
+			URL:  "",
+		},
+	}
+
+	testCases := []struct {
+		dbType  string
+		wantErr error
+	}{
+		{dbType: "", wantErr: nil},
+		{dbType: "postgres", wantErr: nil},
+		{dbType: "mysql", wantErr: errors.New("Invalid database.type param, mysql support is discontinued")},
+		{dbType: "bogus", wantErr: errors.New("Invalid database.type param")},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.dbType, func(t *testing.T) {
+			c.Database.Type = tc.dbType
+			err := c.Validate()
+			if tc.wantErr == nil {
+				assert.Nil(t, err)
+			} else {
+				require.NotNil(t, err)
+				assert.Equal(t, tc.wantErr.Error(), err.Error())
+			}
+		})
+	}
+}
+
+func TestConfig_Validate_db_url(t *testing.T) {
+	c := Config{
+		Port:              func(i int) *int { return &i }(8001),
+		Horizon:           "https://example.com",
+		NetworkPassphrase: "Test SDF Network ; September 2015",
+		Database: &Database{
+			Type: "",
+			URL:  "",
+		},
+	}
+
+	testCases := []struct {
+		url     string
+		wantErr error
+	}{
+		{url: "", wantErr: nil},
+		{url: "postgres://localhost/db", wantErr: nil},
+		{url: " postgres:", wantErr: errors.New("Cannot parse database.url param")},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.url, func(t *testing.T) {
+			c.Database.URL = tc.url
+			err := c.Validate()
+			if tc.wantErr == nil {
+				assert.Nil(t, err)
+			} else {
+				assert.Equal(t, tc.wantErr.Error(), err.Error())
+			}
+		})
+	}
+}

--- a/services/compliance/internal/config/main.go
+++ b/services/compliance/internal/config/main.go
@@ -76,8 +76,7 @@ func (c *Config) Validate() (err error) {
 		}
 	}
 
-	var dbURL *url.URL
-	dbURL, err = url.Parse(c.Database.URL)
+	_, err = url.Parse(c.Database.URL)
 	if err != nil {
 		err = errors.New("Cannot parse database.url param")
 		return
@@ -85,11 +84,8 @@ func (c *Config) Validate() (err error) {
 
 	switch c.Database.Type {
 	case "mysql":
-		// Add `parseTime=true` param to mysql url
-		query := dbURL.Query()
-		query.Set("parseTime", "true")
-		dbURL.RawQuery = query.Encode()
-		c.Database.URL = dbURL.String()
+		err = errors.New("Invalid database.type param, mysql support is discontinued")
+		return
 	case "postgres":
 		break
 	default:

--- a/services/compliance/internal/config/main_test.go
+++ b/services/compliance/internal/config/main_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Validate_db_type(t *testing.T) {
+	c := Config{
+		ExternalPort:      func(i int) *int { return &i }(8001),
+		InternalPort:      func(i int) *int { return &i }(8001),
+		LogFormat:         "",
+		NetworkPassphrase: "Test SDF Network ; September 2015",
+		Database: Database{
+			Type: "",
+			URL:  "",
+		},
+		Keys: Keys{
+			SigningSeed: "SBEL63EBNQUTQ2ZTGHGLLXEMP6THALGS3VQ2N4RVHUWIBB5KGDJWVF3R",
+		},
+	}
+
+	testCases := []struct {
+		dbType  string
+		wantErr error
+	}{
+		{dbType: "", wantErr: errors.New("Invalid database.type param")},
+		{dbType: "postgres", wantErr: nil},
+		{dbType: "mysql", wantErr: errors.New("Invalid database.type param, mysql support is discontinued")},
+		{dbType: "bogus", wantErr: errors.New("Invalid database.type param")},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.dbType, func(t *testing.T) {
+			c.Database.Type = tc.dbType
+			err := c.Validate()
+			if tc.wantErr == nil {
+				assert.Nil(t, err)
+			} else {
+				require.NotNil(t, err)
+				assert.Equal(t, tc.wantErr.Error(), err.Error())
+			}
+		})
+	}
+}
+
+func TestConfig_Validate_db_url(t *testing.T) {
+	c := Config{
+		ExternalPort:      func(i int) *int { return &i }(8001),
+		InternalPort:      func(i int) *int { return &i }(8001),
+		LogFormat:         "",
+		NetworkPassphrase: "Test SDF Network ; September 2015",
+		Database: Database{
+			Type: "postgres",
+			URL:  "",
+		},
+		Keys: Keys{
+			SigningSeed: "SBEL63EBNQUTQ2ZTGHGLLXEMP6THALGS3VQ2N4RVHUWIBB5KGDJWVF3R",
+		},
+	}
+
+	testCases := []struct {
+		url     string
+		wantErr error
+	}{
+		{url: "", wantErr: nil},
+		{url: "postgres://localhost/db", wantErr: nil},
+		{url: " postgres:", wantErr: errors.New("Cannot parse database.url param")},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.url, func(t *testing.T) {
+			c.Database.URL = tc.url
+			err := c.Validate()
+			if tc.wantErr == nil {
+				assert.Nil(t, err)
+			} else {
+				assert.Equal(t, tc.wantErr.Error(), err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] !I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] ~I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.~
</details>

### Summary

Remove MySQL support from config parsing in Bridge and Compliance services.

### Goal and scope

Clean up code that is no longer supported. We announced that MySQL was no longer supported for Bridge and Compliance a few months ago in commits 9d0a49bee411 and addf94e97f98 but there was still some code left over in both services to parse configs containing MySQL database connection details. Users of these services who are using MySQL won't see an error when their config is parsed and they may continue to use the database even though we don't support it. It's better that we provide immediate at config parse rather than folks use features we no longer support.

Close #1659 

### Summary of changes

- Add tests for the database type and URL config values for both Bridge and Compliance, because there was no tests for the area of code that needed to change.
- Remove MySQL as valid values.

### Known limitations & issues

N/A

### What shouldn't be reviewed

N/A