### PR TITLE
archivist: range fixes

### DIFF
--- a/support/historyarchive/archive_test.go
+++ b/support/historyarchive/archive_test.go
@@ -155,6 +155,46 @@ func TestScan(t *testing.T) {
 	GetRandomPopulatedArchive().Scan(opts)
 }
 
+func TestScanSize(t *testing.T) {
+	defer cleanup()
+	opts := testOptions()
+	arch := GetRandomPopulatedArchive()
+	arch.Scan(opts)
+	assert.Equal(t, opts.Range.Size(),
+		len(arch.checkpointFiles["history"]))
+}
+
+func TestScanSizeSubrange(t *testing.T) {
+	defer cleanup()
+	opts := testOptions()
+	arch := GetRandomPopulatedArchive()
+	opts.Range.Low = NextCheckpoint(opts.Range.Low)
+	opts.Range.High = PrevCheckpoint(opts.Range.High)
+	arch.Scan(opts)
+	assert.Equal(t, opts.Range.Size(),
+		len(arch.checkpointFiles["history"]))
+}
+
+func TestScanSizeSubrangeFewBuckets(t *testing.T) {
+	defer cleanup()
+	opts := testOptions()
+	arch := GetRandomPopulatedArchive()
+	opts.Range.Low = 0x1ff
+	opts.Range.High = 0x1ff
+	arch.Scan(opts)
+	// We should only scan one checkpoint worth of buckets.
+	assert.Less(t, len(arch.allBuckets), 40)
+}
+
+func TestScanSizeSubrangeAllBuckets(t *testing.T) {
+	defer cleanup()
+	opts := testOptions()
+	arch := GetRandomPopulatedArchive()
+	arch.Scan(opts)
+	// We should scan all checkpoints worth of buckets.
+	assert.Less(t, 300, len(arch.allBuckets))
+}
+
 func countMissing(arch *Archive, opts *CommandOptions) int {
 	n := 0
 	arch.Scan(opts)

--- a/support/historyarchive/range.go
+++ b/support/historyarchive/range.go
@@ -67,7 +67,7 @@ func (r Range) String() string {
 func (r Range) Checkpoints() chan uint32 {
 	ch := make(chan uint32)
 	go func() {
-		for i := uint64(r.Low); i < uint64(r.High); i += uint64(CheckpointFreq) {
+		for i := uint64(r.Low); i <= uint64(r.High); i += uint64(CheckpointFreq) {
 			ch <- uint32(i)
 		}
 		close(ch)

--- a/support/historyarchive/range.go
+++ b/support/historyarchive/range.go
@@ -76,7 +76,7 @@ func (r Range) Checkpoints() chan uint32 {
 }
 
 func (r Range) Size() int {
-	return int(r.High-r.Low) / int(CheckpointFreq)
+	return 1 + (int(r.High-r.Low) / int(CheckpointFreq))
 }
 
 func (r Range) collapsedString() string {

--- a/support/historyarchive/range_test.go
+++ b/support/historyarchive/range_test.go
@@ -18,6 +18,20 @@ func (r Range) allCheckpoints() []uint32 {
 	return s
 }
 
+func TestRangeSize(t *testing.T) {
+	assert.Equal(t, 1,
+		MakeRange(0x3f, 0x3f).Size())
+
+	assert.Equal(t, 2,
+		MakeRange(0x3f, 0x7f).Size())
+
+	assert.Equal(t, 2,
+		MakeRange(0, 100).Size())
+
+	assert.Equal(t, 4,
+		MakeRange(0xff3f, 0xffff).Size())
+}
+
 func TestRangeEnumeration(t *testing.T) {
 	assert.Equal(t,
 		[]uint32{0x3f, 0x7f},

--- a/support/historyarchive/range_test.go
+++ b/support/historyarchive/range_test.go
@@ -10,6 +10,36 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func (r Range) allCheckpoints() []uint32 {
+	var s []uint32
+	for chk := range r.Checkpoints() {
+		s = append(s, chk)
+	}
+	return s
+}
+
+func TestRangeEnumeration(t *testing.T) {
+	assert.Equal(t,
+		[]uint32{0x3f, 0x7f},
+		MakeRange(0x3f, 0x7f).allCheckpoints())
+
+	assert.Equal(t,
+		[]uint32{0x3f},
+		MakeRange(0x3f, 0x3f).allCheckpoints())
+
+	assert.Equal(t,
+		[]uint32{0x3f},
+		MakeRange(0, 0).allCheckpoints())
+
+	assert.Equal(t,
+		[]uint32{0x3f, 0x7f},
+		MakeRange(0, 0x40).allCheckpoints())
+
+	assert.Equal(t,
+		[]uint32{0xff},
+		MakeRange(0xff, 0x40).allCheckpoints())
+}
+
 func TestFmtRangeList(t *testing.T) {
 
 	assert.Equal(t,

--- a/support/historyarchive/scan.go
+++ b/support/historyarchive/scan.go
@@ -205,7 +205,7 @@ func (arch *Archive) ScanBuckets(opts *CommandOptions) error {
 	// go. But this is faster when we can do it.
 	doList := arch.backend.CanListFiles()
 	has, err := arch.GetRootHAS()
-	if e == nil {
+	if err == nil {
 		fullRange := MakeRange(0, has.CurrentLedger)
 		doList = doList && opts.Range.Size() == fullRange.Size()
 	} else {

--- a/support/historyarchive/scan.go
+++ b/support/historyarchive/scan.go
@@ -133,6 +133,9 @@ func (arch *Archive) ScanCheckpointsFast(opts *CommandOptions) error {
 				}
 				ch, es := arch.ListCategoryCheckpoints(r.category, r.pathprefix)
 				for n := range ch {
+					if n < opts.Range.Low || n > opts.Range.High {
+						continue
+					}
 					tick <- true
 					arch.NoteCheckpointFile(r.category, n, true)
 					if opts.Verify {

--- a/support/historyarchive/scan.go
+++ b/support/historyarchive/scan.go
@@ -204,7 +204,7 @@ func (arch *Archive) ScanBuckets(opts *CommandOptions) error {
 	// entire range); if not, we'll do an exists-check on each bucket as we
 	// go. But this is faster when we can do it.
 	doList := arch.backend.CanListFiles()
-	has, e := arch.GetRootHAS()
+	has, err := arch.GetRootHAS()
 	if e == nil {
 		fullRange := MakeRange(0, has.CurrentLedger)
 		doList = doList && opts.Range.Size() == fullRange.Size()

--- a/support/historyarchive/scan.go
+++ b/support/historyarchive/scan.go
@@ -202,9 +202,16 @@ func (arch *Archive) ScanBuckets(opts *CommandOptions) error {
 
 	// First scan _all_ buckets if we can; if not, we'll do an exists-check
 	// on each bucket as we go. But this is faster when we can do it.
-	doList := arch.backend.CanListFiles()
+	doList := false
+	has, e := arch.GetRootHAS()
+	if e == nil {
+		fullRange := MakeRange(0, has.CurrentLedger)
+		doList = arch.backend.CanListFiles() && opts.Range.Size() == fullRange.Size()
+	}
 	if doList {
 		errs += noteError(arch.ScanAllBuckets())
+	} else {
+		log.Printf("Scanning buckets for %d checkpoints", opts.Range.Size())
 	}
 
 	// Grab the set of checkpoints we have HASs for, to read references.

--- a/support/historyarchive/scan.go
+++ b/support/historyarchive/scan.go
@@ -209,7 +209,8 @@ func (arch *Archive) ScanBuckets(opts *CommandOptions) error {
 		fullRange := MakeRange(0, has.CurrentLedger)
 		doList = doList && opts.Range.Size() == fullRange.Size()
 	} else {
-		log.Printf("Missing root archive state, possibly corrupt archive")
+		log.Print("Error retrieving root archive state, possibly corrupt archive:", err)
+		log.Print("Continuing and will do an exists-check on each bucket as we go, this will be slower")
 	}
 	if doList {
 		errs += noteError(arch.ScanAllBuckets())


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Fix a couple bugs with ranges in stellar-archivist. This just makes it behave more like it's documented to / how users would expect:

  - Treat the range values as inclusive rather than excluding the high endpoint.
  - Don't clobber the destination pointer when a mirror range doesn't end on that value.

