### PR TITLE
all: remove use of errors.Wrap(nil, ...)

### DIFF
--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -289,7 +289,10 @@ func (c *Client) LoadAccountTransactions(accountID string, params ...interface{}
 	}
 
 	err = decodeResponse(resp, &tx)
-	return tx, errors.Wrap(err, "decoding response to transaction")
+	if err != nil {
+		return tx, errors.Wrap(err, "decoding response to transaction")
+	}
+	return tx, nil
 }
 
 // LoadOperation loads a single operation from Horizon server

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -349,7 +349,10 @@ func (c *Client) OperationDetail(id string) (ops operations.Operation, err error
 	}
 
 	ops, err = operations.UnmarshalOperation(baseRecord.GetTypeI(), dataString)
-	return ops, errors.Wrap(err, "unmarshaling to the correct operation type")
+	if err != nil {
+		return ops, errors.Wrap(err, "unmarshaling to the correct operation type")
+	}
+	return ops, nil
 }
 
 // SubmitTransactionXDR submits a transaction represented as a base64 XDR string to the network. err can be either error object or horizon.Error object.

--- a/services/ticker/internal/scraper/orderbook_scraper.go
+++ b/services/ticker/internal/scraper/orderbook_scraper.go
@@ -42,7 +42,10 @@ func (c *ScraperConfig) fetchOrderbook(bType, bCode, bIssuer, cType, cCode, cIss
 	}
 
 	err = calcOrderbookStats(&obStats, summary)
-	return obStats, errors.Wrap(err, "could not calculate orderbook stats")
+	if err != nil {
+		return obStats, errors.Wrap(err, "could not calculate orderbook stats")
+	}
+	return obStats, nil
 }
 
 // calcOrderbookStats calculates the NumBids, BidVolume, BidMax, NumAsks, AskVolume and AskMin


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Remove use of `errors.Wrap(err, ...)` where `err` may be `nil`, replacing it with the canonical `if err != nil { ... }`.

### Goal and scope

To improve code clarity, and to set precedence for not using this feature of `github.com/pkg/errors`.

The `errors.Wrap(err, ...)` function call has a magical feature that if `err` is `nil` the function returns `nil`, essentially negating the need to check the error. On the surface it feels good to use because it turns this code:
```go
if err != nil {
    return nil, errors.Wrap(err, "it broke")
}
return thing, nil
```
Into this code:
```go
return thing, errors.Wrap(err, "it broke")
```
The shortening of the code feels good as the writer, but it can be misleading to a reader. It's very easy to misread code that uses this feature because there are not clear code paths for success and failure.

Code clarity is near the top of the list of things we should value as it will help prevent us from making mistakes; when we don't understand the code we're reading, we make it do things we don't intend to. In the absence for compelling business critical reasons to write code that isn't clear, e.g. for performance critical code, we should use patterns that are easily recognizable.

The `if err != nil { ... }` while tedious is one of the most well known patterns in Go code. Recent attempts to remove that pattern from Go by adding new language features were met with a lot of push back, including this very popular issue: golang/go#32825.

Removing these few examples won't prevent us from using this feature, but hopefully it sets precedence. And in six months when the current version of Go (1.13) is the oldest version we support we can drop use of `github.com/pkg/errors` in favor of Go's built-in error wrapping. When we do this, we'll lose this magical feature anyway.

### Known limitations & issues

There may be other places where we use this feature, as it's difficult to grep for. I mostly wanted to open this change to create a discussion point, and at least fix the cases I'd seen.

### What shouldn't be reviewed

N/A