### PR TITLE
services/horizon: Increase HAS publish delay

### DIFF
--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -99,10 +99,10 @@ func (s *System) verifyState() error {
 		return nil
 	}
 
-	localLog.Info("Starting state verification. Waiting 20 seconds for stellar-core to publish HAS...")
+	localLog.Info("Starting state verification. Waiting 40 seconds for stellar-core to publish HAS...")
 
 	// Wait for stellar-core to publish HAS
-	time.Sleep(20 * time.Second)
+	time.Sleep(40 * time.Second)
 
 	localLog.Info("Creating state reader...")
 


### PR DESCRIPTION
After deploying the latest commit from 0.21.0 release branch to staging environment it looks like a delay between a checkpoint ledger and root HAS update sometimes is longer than 20 seconds. This commit is increasing a wait time to 40 seconds.