### PR TITLE
docs: add a developing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,3 +24,8 @@ Check out the [Stellar Contribution Guide](https://github.com/stellar/docs/blob/
 
 * Use `gofmt` or preferably `goimports` to format code
 * Follow [Effective Go](https://golang.org/doc/effective_go.html) and [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
+
+### Go Coding conventions
+
+- Always document exported package elements: vars, consts, funcs, types, etc.
+- Tests are better than no tests.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,6 +1,6 @@
 # Developing
 
-Welcome to the Stellar Go monorepo. These instructions help launch you into making and testing code changes to this repository. If you're aiming to submit a contribution make sure to also read the [contributing guidelines](CONTRIBUTING.md).
+Welcome to the Stellar Go monorepo. These instructions help launch 🚀 you into making and testing code changes to this repository. If you're aiming to submit a contribution make sure to also read the [contributing guidelines](CONTRIBUTING.md).
 
 ## Requirements
 To checkout, build, and run most tests these tools are required:

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -2,6 +2,8 @@
 
 Welcome to the Stellar Go monorepo. These instructions help launch 🚀 you into making and testing code changes to this repository. If you're aiming to submit a contribution make sure to also read the [contributing guidelines](CONTRIBUTING.md).
 
+For details about what's in this repository and how it is organized read the [README.md](README.md).
+
 ## Requirements
 To checkout, build, and run most tests these tools are required:
 - Git

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -24,9 +24,7 @@ Note: If you're using Go 1.12 and you checkout to a path inside your `GOPATH` yo
 
 ## Installing dependencies
 
-Dependencies are managed using [Modules](https://github.com/golang/go/wiki/Modules) and will be installed as they are required by the Go tool.
-
-Go module dependencies for the packages you are building will be installed automatically when running any Go command that requires them. If you need to pre-download all dependencies for the repository for offline development, run `go mod download`.
+Dependencies are managed using [Modules](https://github.com/golang/go/wiki/Modules). Dependencies for the packages you are building will be installed automatically when running any Go command that requires them. If you need to pre-download all dependencies for the repository for offline development, run `go mod download`.
 
 See [Dependency management](#dependency-management) for more details.
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,96 @@
+# Developing
+
+Welcome to the Stellar Go monorepo. These instructions help launch you into making and testing code changes to this repository. If you're aiming to submit a contribution make sure to also read the [contributing guidelines](CONTRIBUTING.md).
+
+## Requirements
+To checkout, build, and run most tests these tools are required:
+- Git
+- [Go 1.12 or Go 1.13](https://golang.org/dl)
+
+To run some tests these tools are also required:
+- PostgreSQL 9.6+ server running locally, or set [environment variables](https://www.postgresql.org/docs/9.6/libpq-envars.html) (e.g. `PGHOST`, etc) for alternative host.
+- MySQL 10.1+ server running locally as root.
+- Redis 5.0+ server running on localhost port 6379.
+
+## Get the code
+
+Check the code out anywhere, using a `GOPATH` is not required.
+
+```
+git clone https://github.com/stellar/go
+```
+
+Note: If you're using Go 1.12 and you checkout to a path inside your `GOPATH` you'll need to set the environment variable `GO111MODULE=on` for [modules](https://github.com/golang/go/wiki/Modules) dependency management to function.
+
+## Installing dependencies
+
+Dependencies are managed using [Modules](https://github.com/golang/go/wiki/Modules) and will be installed as they are required by the Go tool. See [below](#dependency-management) for more details.
+
+## Running tests
+
+```
+go test ./...
+```
+
+## Running services/tools
+
+```
+go run ./services/<service>
+```
+
+```
+go run ./tools/<tool>
+```
+
+## Dependency management
+
+Dependencies are managed using [Modules](https://github.com/golang/go/wiki/Modules) and are tracked in the repository across three files:
+- [go.mod](go.mod): Contains a list of direct dependencies, and some indirect dependencies (see [why](https://github.com/golang/go/wiki/Modules#why-does-go-mod-tidy-record-indirect-and-test-dependencies-in-my-gomod)).
+- [go.sum](go.sum): Contains hashes for dependencies that are used for verifying downloaded dependencies.
+- [go.list](go.list): A file that is unique to this Go repository, containing the output of `go list -m all`, and captures all direct and indirect dependencies and their versions used in builds and tests within this repository. This is not a lock file but instead it helps us track over time which versions are being used for builds and tests, and to see when that changes in PR diffs.
+
+Go module dependencies for the packages you are building will be installed automatically when running any Go command that requires them. If you need to pre-download all dependencies for the repository for offline development, run `go mod download`.
+
+### Adding new dependencies
+
+Add new dependencies by adding the import paths to the code. The next time you execute a Go command the tool will update the `go.mod` and `go.sum` files.
+
+To add a specific version of a dependency use `go get`:
+
+```
+go get <importpath>@<version>
+```
+
+Go modules files track the minimum dependency required, not the exact dependency version that will be used. To validate the version of the dependency being used update the `go.list` file by running `go mod -m all > go.list`.
+
+Before opening a PR make sure to run these commands to tidy the module files:
+- `go mod tidy`
+- `go list -m all > go.list`
+
+### Updating a dependency
+
+Update an existing dependency by using `go get`:
+
+```
+go get <importpath>@<version>
+```
+
+Go modules files track the minimum dependency required, not the exact dependency version that will be used. To validate the version of the dependency being used update the `go.list` file by running `go mod -m all > go.list`.
+
+Before opening a PR make sure to run these commands to tidy the module files:
+```
+go mod tidy
+go list -m all > go.list
+```
+
+### Removing a dependency
+
+Remove a dependency by removing all import paths from the code, then use the following commands to remove any unneeded direct or indirect dependencies:
+
+```
+go mod tidy
+go list -m all > go.list
+```
+
+Note: `go list -m all` may show that the dependency is still being used. It will be possible that the dependency is still an indirect dependency. If it's important to understand why the dependency is still being used, use `go mod why <importpath>/...` and `go mod graph | grep <importpath>` to understand which modules are importing it.
+

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -24,7 +24,11 @@ Note: If you're using Go 1.12 and you checkout to a path inside your `GOPATH` yo
 
 ## Installing dependencies
 
-Dependencies are managed using [Modules](https://github.com/golang/go/wiki/Modules) and will be installed as they are required by the Go tool. See [below](#dependency-management) for more details.
+Dependencies are managed using [Modules](https://github.com/golang/go/wiki/Modules) and will be installed as they are required by the Go tool.
+
+Go module dependencies for the packages you are building will be installed automatically when running any Go command that requires them. If you need to pre-download all dependencies for the repository for offline development, run `go mod download`.
+
+See [Dependency management](#dependency-management) for more details.
 
 ## Running tests
 
@@ -48,8 +52,6 @@ Dependencies are managed using [Modules](https://github.com/golang/go/wiki/Modul
 - [go.mod](go.mod): Contains a list of direct dependencies, and some indirect dependencies (see [why](https://github.com/golang/go/wiki/Modules#why-does-go-mod-tidy-record-indirect-and-test-dependencies-in-my-gomod)).
 - [go.sum](go.sum): Contains hashes for dependencies that are used for verifying downloaded dependencies.
 - [go.list](go.list): A file that is unique to this Go repository, containing the output of `go list -m all`, and captures all direct and indirect dependencies and their versions used in builds and tests within this repository. This is not a lock file but instead it helps us track over time which versions are being used for builds and tests, and to see when that changes in PR diffs.
-
-Go module dependencies for the packages you are building will be installed automatically when running any Go command that requires them. If you need to pre-download all dependencies for the repository for offline development, run `go mod download`.
 
 ### Adding new dependencies
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -9,7 +9,7 @@ To checkout, build, and run most tests these tools are required:
 
 To run some tests these tools are also required:
 - PostgreSQL 9.6+ server running locally, or set [environment variables](https://www.postgresql.org/docs/9.6/libpq-envars.html) (e.g. `PGHOST`, etc) for alternative host.
-- MySQL 10.1+ server running locally as root.
+- MySQL 10.1+ server running locally.
 - Redis 5.0+ server running on localhost port 6379.
 
 ## Get the code

--- a/README.md
+++ b/README.md
@@ -68,3 +68,7 @@ Often, we provide test packages that aid in the creation of tests that interact 
 ### Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
+
+### Developing
+
+See [DEVELOPING.md](DEVELOPING.md) for helpful instructions for getting started developing code in this repository.

--- a/README.md
+++ b/README.md
@@ -65,8 +65,6 @@ Generally, file contents are sorted by exported/unexported, then declaration typ
 
 Often, we provide test packages that aid in the creation of tests that interact with our other packages.  For example, the `support/db` package has the `support/db/dbtest` package underneath it that contains elements that make it easier to test code that accesses a SQL database.  We've found that this pattern of having a separate test package maximizes flexibility and simplifies package dependencies.
 
+### Contributing
 
-## Coding conventions
-
-- Always document exported package elements: vars, consts, funcs, types, etc.
-- Tests are better than no tests.
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Add a `DEVELOPING.md` capturing some basic instructions on how to develop in this repository, including instructions on how to use Modules to add, update and remove dependencies.

### Goal and scope

To make a clear path for folks to add, update and remove dependencies. While we mostly use the standard Go modules features to manage dependencies they are relatively new in the ecosystem and it is helpful if we anyone adding dependencies knows how to get it right first time without needing to iterate, receive CI or PR feedback, and then do more work.

We also use a non-standard [go.list](go.list) file so that we can see what our actual build/tested dependency versions are in PR diffs, according to `go list -m all`.

CI will error if any steps haven't been followed for updating dependencies, but as @graydon pointed out when he was our first person doing an upgrade, it's helpful if we can give developers clear instructions so they have the opportunity to get it right and so it's not an unknown they're stepping into.

It's worth addressing that there is some overlap of these instructional files, e.g. `README.md`, `DEVELOPING.md` and `CONTRIBUTING.md`, but each has a different target audience and are relevant at different stages.

- `README.md`: Folks learning about our code, importing the Go SDK, installing from source.
- `DEVELOPING.md`: Developers wanting to make changes to the code.
- `CONTRIBUTING.md`: Developers wanting to contribute changes back to this repo.

For this reason it would be overwhelming to dump all this information into `README.md`, or to clutter `CONTRIBUTING.md` with details that are no longer relevant to a developer when they are thinking about opening a PR.

This is a follow up to #1634.

### Summary of changes

- Add `DEVELOPING.md`
- Link to it from the `README.md`

### Known limitations & issues

N/A

### What shouldn't be reviewed

N/A

### Merging

This PR is intended to be merged to `master` after #1751 which already contains commit cb3300f.