### PR TITLE
services/horizon/expingest: More ingest tests

### DIFF
--- a/exp/ingest/adapters/history_archive_adapter.go
+++ b/exp/ingest/adapters/history_archive_adapter.go
@@ -9,6 +9,13 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
+type HistoryArchiveAdapterInterface interface {
+	GetLatestLedgerSequence() (uint32, error)
+	BucketListHash(sequence uint32) (xdr.Hash, error)
+	GetState(sequence uint32, tempSet io.TempSet) (io.StateReader, error)
+	GetLedger(sequence uint32) (io.ArchiveLedgerReader, error)
+}
+
 // HistoryArchiveAdapter is an adapter for the historyarchive package to read from history archives
 type HistoryArchiveAdapter struct {
 	archive historyarchive.ArchiveInterface
@@ -70,3 +77,5 @@ func (haa *HistoryArchiveAdapter) GetState(sequence uint32, tempSet io.TempSet) 
 func (haa *HistoryArchiveAdapter) GetLedger(sequence uint32) (io.ArchiveLedgerReader, error) {
 	return nil, fmt.Errorf("not implemented yet")
 }
+
+var _ HistoryArchiveAdapterInterface = (*HistoryArchiveAdapter)(nil)

--- a/exp/ingest/adapters/mock_history_archive_adapter.go
+++ b/exp/ingest/adapters/mock_history_archive_adapter.go
@@ -1,0 +1,33 @@
+package adapters
+
+import (
+	"github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ HistoryArchiveAdapterInterface = (*MockHistoryArchiveAdapter)(nil)
+
+type MockHistoryArchiveAdapter struct {
+	mock.Mock
+}
+
+func (m *MockHistoryArchiveAdapter) GetLatestLedgerSequence() (uint32, error) {
+	args := m.Called()
+	return args.Get(0).(uint32), args.Error(1)
+}
+
+func (m *MockHistoryArchiveAdapter) BucketListHash(sequence uint32) (xdr.Hash, error) {
+	args := m.Called(sequence)
+	return args.Get(0).(xdr.Hash), args.Error(1)
+}
+
+func (m *MockHistoryArchiveAdapter) GetState(sequence uint32, tempSet io.TempSet) (io.StateReader, error) {
+	args := m.Called(sequence, tempSet)
+	return args.Get(0).(io.StateReader), args.Error(1)
+}
+
+func (m *MockHistoryArchiveAdapter) GetLedger(sequence uint32) (io.ArchiveLedgerReader, error) {
+	args := m.Called(sequence)
+	return args.Get(0).(io.ArchiveLedgerReader), args.Error(1)
+}

--- a/exp/ingest/verify/main.go
+++ b/exp/ingest/verify/main.go
@@ -27,6 +27,12 @@ type StateError struct {
 	error
 }
 
+type StateVerifierInterface interface {
+	GetLedgerKeys(count int) ([]xdr.LedgerKey, error)
+	Write(entry xdr.LedgerEntry) error
+	Verify(countAll int) error
+}
+
 // StateVerifier verifies if ledger entries provided by Add method are the same
 // as in the checkpoint ledger entries provided by SingleLedgerStateReader.
 // The algorithm works in the following way:
@@ -210,3 +216,5 @@ func (v *StateVerifier) checkUnreadEntries() error {
 
 	return nil
 }
+
+var _ StateVerifierInterface = (*StateVerifier)(nil)

--- a/exp/ingest/verify/mock_state_verifier.go
+++ b/exp/ingest/verify/mock_state_verifier.go
@@ -1,0 +1,27 @@
+package verify
+
+import (
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ StateVerifierInterface = (*MockStateVerifier)(nil)
+
+type MockStateVerifier struct {
+	mock.Mock
+}
+
+func (m *MockStateVerifier) GetLedgerKeys(count int) ([]xdr.LedgerKey, error) {
+	args := m.Called(count)
+	return args.Get(0).([]xdr.LedgerKey), args.Error(1)
+}
+
+func (m *MockStateVerifier) Write(entry xdr.LedgerEntry) error {
+	args := m.Called(entry)
+	return args.Error(0)
+}
+
+func (m *MockStateVerifier) Verify(countAll int) error {
+	args := m.Called(countAll)
+	return args.Error(0)
+}

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -4,6 +4,7 @@
 package expingest
 
 import (
+	"database/sql"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -51,12 +52,18 @@ type Config struct {
 
 type dbQ interface {
 	Begin() error
+	BeginTx(*sql.TxOptions) error
 	Rollback() error
 	GetLastLedgerExpIngest() (uint32, error)
+	GetLastLedgerExpIngestNonBlocking() (uint32, error)
 	GetExpIngestVersion() (int, error)
 	UpdateLastLedgerExpIngest(uint32) error
 	UpdateExpStateInvalid(bool) error
 	GetAllOffers() ([]history.Offer, error)
+	GetOffersByIDs(ids []int64) ([]history.Offer, error)
+	SignersForAccounts(accounts []string) ([]history.AccountSigner, error)
+	CountAccounts() (int, error)
+	CountOffers() (int, error)
 }
 
 type dbSession interface {

--- a/services/horizon/internal/expingest/main_test.go
+++ b/services/horizon/internal/expingest/main_test.go
@@ -3,6 +3,7 @@ package expingest
 import (
 	"testing"
 
+	"github.com/stellar/go/exp/ingest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,4 +14,22 @@ func TestCheckVerifyStateVersion(t *testing.T) {
 		stateVerifierExpectedIngestionVersion,
 		"State verifier is outdated, update it, then update stateVerifierExpectedIngestionVersion value",
 	)
+}
+
+func TestNewSystem(t *testing.T) {
+	config := Config{
+		HistoryArchiveURL: "https://history.stellar.org",
+		StellarCoreURL:    "http://stellarcore:11625",
+		TempSet:           nil,
+	}
+
+	system, err := NewSystem(config)
+	assert.NoError(t, err)
+
+	session := system.session.(*ingest.LiveSession)
+
+	backend := session.GetArchive().GetURL()
+	assert.Equal(t, config.HistoryArchiveURL, backend)
+	assert.Equal(t, config.StellarCoreURL, session.StellarCoreClient.URL)
+	assert.Nil(t, session.TempSet)
 }

--- a/services/horizon/internal/expingest/processors/context_filter_test.go
+++ b/services/horizon/internal/expingest/processors/context_filter_test.go
@@ -1,0 +1,154 @@
+package processors
+
+import (
+	"context"
+	stdio "io"
+	"testing"
+
+	"github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/exp/support/pipeline"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestContextFilterTestSuite(t *testing.T) {
+	suite.Run(t, new(ContextFilterTestSuiteState))
+}
+
+type ContextFilterTestSuiteState struct {
+	suite.Suite
+	mockStateReader  *io.MockStateReader
+	mockStateWriter  *io.MockStateWriter
+	mockLedgerReader *io.MockLedgerReader
+	mockLedgerWriter *io.MockLedgerWriter
+}
+
+func (s *ContextFilterTestSuiteState) SetupTest() {
+	s.mockStateReader = &io.MockStateReader{}
+	s.mockStateWriter = &io.MockStateWriter{}
+	s.mockLedgerReader = &io.MockLedgerReader{}
+	s.mockLedgerWriter = &io.MockLedgerWriter{}
+}
+
+func (s *ContextFilterTestSuiteState) setupState() {
+	// Reader and Writer should be always closed and once
+	s.mockStateReader.On("Close").Return(nil).Once()
+	s.mockStateWriter.On("Close").Return(nil).Once()
+}
+
+func (s *ContextFilterTestSuiteState) setupLedger() {
+	// Reader and Writer should be always closed and once
+	s.mockLedgerReader.On("Close").Return(nil).Once()
+	s.mockLedgerWriter.On("Close").Return(nil).Once()
+}
+
+func (s *ContextFilterTestSuiteState) TearDownTest() {
+	s.mockStateReader.AssertExpectations(s.T())
+	s.mockStateWriter.AssertExpectations(s.T())
+	s.mockLedgerReader.AssertExpectations(s.T())
+	s.mockLedgerWriter.AssertExpectations(s.T())
+}
+
+func (s *ContextFilterTestSuiteState) TestName() {
+	filter := ContextFilter{
+		Key: IngestUpdateDatabase,
+	}
+	s.Assert().Equal("ContextFilter (IngestUpdateDatabase)", filter.Name())
+}
+
+func (s *ContextFilterTestSuiteState) TestStateKeyNotPresent() {
+	s.setupState()
+
+	filter := ContextFilter{
+		Key: IngestUpdateDatabase,
+	}
+
+	ctx := context.Background()
+	err := filter.ProcessState(ctx, &pipeline.Store{}, s.mockStateReader, s.mockStateWriter)
+	s.Assert().NoError(err)
+}
+
+func (s *ContextFilterTestSuiteState) TestStateKeyPresent() {
+	s.setupState()
+
+	filter := ContextFilter{
+		Key: IngestUpdateDatabase,
+	}
+
+	entryChange := xdr.LedgerEntryChange{
+		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+		State: &xdr.LedgerEntry{
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeAccount,
+				Account: &xdr.AccountEntry{
+					AccountId: xdr.MustAddress("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
+					Signers: []xdr.Signer{
+						xdr.Signer{
+							Key:    xdr.MustSigner("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+							Weight: 10,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.mockStateReader.On("Read").Return(entryChange, nil).Once()
+	s.mockStateReader.On("Read").Return(xdr.LedgerEntryChange{}, stdio.EOF).Once()
+
+	s.mockStateWriter.On("Write", entryChange).Return(nil).Once()
+
+	ctx := context.WithValue(context.Background(), IngestUpdateDatabase, true)
+	err := filter.ProcessState(ctx, &pipeline.Store{}, s.mockStateReader, s.mockStateWriter)
+	s.Assert().NoError(err)
+}
+
+func (s *ContextFilterTestSuiteState) TestLedgerKeyNotPresent() {
+	s.setupLedger()
+
+	filter := ContextFilter{
+		Key: IngestUpdateDatabase,
+	}
+
+	ctx := context.Background()
+	err := filter.ProcessLedger(ctx, &pipeline.Store{}, s.mockLedgerReader, s.mockLedgerWriter)
+	s.Assert().NoError(err)
+}
+
+func (s *ContextFilterTestSuiteState) TestLedgerKeyPresent() {
+	s.setupLedger()
+
+	filter := ContextFilter{
+		Key: IngestUpdateDatabase,
+	}
+
+	transaction := io.LedgerTransaction{
+		Meta: createTransactionMeta([]xdr.OperationMeta{
+			xdr.OperationMeta{
+				Changes: []xdr.LedgerEntryChange{
+					xdr.LedgerEntryChange{
+						Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+						Created: &xdr.LedgerEntry{
+							Data: xdr.LedgerEntryData{
+								Type: xdr.LedgerEntryTypeAccount,
+								Account: &xdr.AccountEntry{
+									AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+									Thresholds: [4]byte{1, 1, 1, 1},
+								},
+							},
+						},
+					},
+				},
+			},
+		}),
+	}
+
+	s.mockLedgerReader.On("Read").Return(transaction, nil).Once()
+	s.mockLedgerReader.On("Read").Return(io.LedgerTransaction{}, stdio.EOF).Once()
+
+	s.mockLedgerWriter.On("Write", transaction).Return(nil).Once()
+
+	ctx := context.WithValue(context.Background(), IngestUpdateDatabase, true)
+	err := filter.ProcessLedger(ctx, &pipeline.Store{}, s.mockLedgerReader, s.mockLedgerWriter)
+	s.Assert().NoError(err)
+}

--- a/services/horizon/internal/expingest/processors/orderbook_processor.go
+++ b/services/horizon/internal/expingest/processors/orderbook_processor.go
@@ -2,7 +2,6 @@ package processors
 
 import (
 	"context"
-	"fmt"
 	stdio "io"
 
 	"github.com/stellar/go/exp/ingest/io"
@@ -86,7 +85,7 @@ func (p *OrderbookProcessor) ProcessLedger(ctx context.Context, store *pipeline.
 }
 
 func (p *OrderbookProcessor) Name() string {
-	return fmt.Sprintf("OrderbookProcessor")
+	return "OrderbookProcessor"
 }
 
 func (p *OrderbookProcessor) Reset() {}

--- a/services/horizon/internal/expingest/processors/orderbook_processor_test.go
+++ b/services/horizon/internal/expingest/processors/orderbook_processor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stellar/go/exp/ingest/io"
 	"github.com/stellar/go/exp/orderbook"
 	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestProcessOrderBookState(t *testing.T) {
@@ -344,4 +345,10 @@ func TestProcessOrderBookLedger(t *testing.T) {
 	if len(expectedOffers) != 0 {
 		t.Fatal("expected offers does not match offers in graph")
 	}
+}
+
+func TestOrderBookProcessorName(t *testing.T) {
+	graph := orderbook.NewOrderBookGraph()
+	processor := OrderbookProcessor{graph}
+	assert.Equal(t, "OrderbookProcessor", processor.Name())
 }

--- a/services/horizon/internal/expingest/verify_test.go
+++ b/services/horizon/internal/expingest/verify_test.go
@@ -1,0 +1,423 @@
+package expingest
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stellar/go/exp/ingest/adapters"
+	"github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/exp/ingest/verify"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestAlreadyRunning(t *testing.T) {
+	system := &System{}
+	system.stateVerificationRunning = true
+	err := system.verifyState()
+	assert.NoError(t, err)
+	assert.True(t, system.stateVerificationRunning)
+}
+
+func TestTransformEntryAccount(t *testing.T) {
+	inflationDest := xdr.MustAddress("GDQ4U7X4YNDD4D6WYU3JNMPAECNG2IZMQLT4CFAGRVW7XYHBLKI4UKS7")
+	entry := xdr.LedgerEntry{
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId:     xdr.MustAddress("GDQ4U7X4YNDD4D6WYU3JNMPAECNG2IZMQLT4CFAGRVW7XYHBLKI4UKS7"),
+				Balance:       1000,
+				SeqNum:        1000,
+				NumSubEntries: 1000,
+				InflationDest: &inflationDest,
+				Flags:         20,
+				HomeDomain:    "stellar.org",
+				Thresholds:    [4]byte{1, 2, 3, 4},
+				Signers: []xdr.Signer{
+					{
+						Key:    xdr.MustSigner("GAIEKNJHOSMMCE2NDNNRAOQYXVHZH7U345IUABMBJE6QF3T3DVKDLH3K"),
+						Weight: xdr.Uint32(2),
+					},
+					{
+						Key:    xdr.MustSigner("GA7I72AGY4OJRFCB6QVPDPHPP2LRCRW67GWARQCP5GM4OA3GSR3ITXN5"),
+						Weight: xdr.Uint32(3),
+					},
+				},
+			},
+		},
+	}
+
+	expected := xdr.LedgerEntry{
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId:  xdr.MustAddress("GDQ4U7X4YNDD4D6WYU3JNMPAECNG2IZMQLT4CFAGRVW7XYHBLKI4UKS7"),
+				Thresholds: [4]byte{1, 0, 0, 0},
+				// Sorted!
+				Signers: []xdr.Signer{
+					{
+						Key:    xdr.MustSigner("GA7I72AGY4OJRFCB6QVPDPHPP2LRCRW67GWARQCP5GM4OA3GSR3ITXN5"),
+						Weight: xdr.Uint32(3),
+					},
+					{
+						Key:    xdr.MustSigner("GAIEKNJHOSMMCE2NDNNRAOQYXVHZH7U345IUABMBJE6QF3T3DVKDLH3K"),
+						Weight: xdr.Uint32(2),
+					},
+				},
+			},
+		},
+	}
+
+	ignore, newEntry := transformEntry(entry)
+	assert.False(t, ignore)
+	assert.Equal(t, expected, newEntry)
+}
+
+func TestTransformEntryAccountNoSigners(t *testing.T) {
+	entry := xdr.LedgerEntry{
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId:  xdr.MustAddress("GDQ4U7X4YNDD4D6WYU3JNMPAECNG2IZMQLT4CFAGRVW7XYHBLKI4UKS7"),
+				Thresholds: [4]byte{0, 2, 3, 4},
+				Signers:    []xdr.Signer{},
+			},
+		},
+	}
+	ignore, _ := transformEntry(entry)
+	assert.True(t, ignore)
+}
+
+func TestTransformEntryOffer(t *testing.T) {
+	entry := xdr.LedgerEntry{
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeOffer,
+			Offer: &xdr.OfferEntry{
+				SellerId: xdr.MustAddress("GDQ4U7X4YNDD4D6WYU3JNMPAECNG2IZMQLT4CFAGRVW7XYHBLKI4UKS7"),
+				OfferId:  10,
+				Selling:  xdr.MustNewCreditAsset("USD", "GDQ4U7X4YNDD4D6WYU3JNMPAECNG2IZMQLT4CFAGRVW7XYHBLKI4UKS7"),
+				Buying:   xdr.MustNewNativeAsset(),
+				Amount:   50,
+				Price:    xdr.Price{N: 100, D: 200},
+			},
+		},
+	}
+
+	ignore, newEntry := transformEntry(entry)
+	assert.False(t, ignore)
+	// No changes
+	assert.Equal(t, entry, newEntry)
+}
+
+func TestTransformEntryIgnore(t *testing.T) {
+	entry := xdr.LedgerEntry{
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeTrustline,
+		},
+	}
+	ignore, _ := transformEntry(entry)
+	assert.True(t, ignore)
+
+	entry = xdr.LedgerEntry{
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeData,
+		},
+	}
+	ignore, _ = transformEntry(entry)
+	assert.True(t, ignore)
+}
+
+type stateVerifierFactoryMock struct {
+	mock.Mock
+}
+
+func (m *stateVerifierFactoryMock) buildStateVerifier(stateReader io.StateReader) verify.StateVerifierInterface {
+	args := m.Called(stateReader)
+	return args.Get(0).(verify.StateVerifierInterface)
+}
+
+func TestStateVerifySuite(t *testing.T) {
+	suite.Run(t, new(StateVerifyTestSuite))
+}
+
+type StateVerifyTestSuite struct {
+	suite.Suite
+	stateVerifier            *stateVerifier
+	mockIngestStateVerifier  *verify.MockStateVerifier
+	mockStateVerifierFactory *stateVerifierFactoryMock
+	mockHistoryQ             *mockDBQ
+	mockHistoryAdapter       *adapters.MockHistoryArchiveAdapter
+	mockStateReader          *io.MockStateReader
+}
+
+func (s *StateVerifyTestSuite) SetupTest() {
+	s.mockHistoryQ = &mockDBQ{}
+	s.mockHistoryAdapter = &adapters.MockHistoryArchiveAdapter{}
+	s.mockIngestStateVerifier = &verify.MockStateVerifier{}
+	s.mockStateVerifierFactory = &stateVerifierFactoryMock{}
+	s.mockStateReader = &io.MockStateReader{}
+
+	s.stateVerifier = &stateVerifier{
+		verifierFactory: s.mockStateVerifierFactory,
+		historyQ:        s.mockHistoryQ,
+		historyAdapter:  s.mockHistoryAdapter,
+		sleepFn: func(d time.Duration) {
+			assert.Equal(s.T(), 40*time.Second, d)
+		},
+	}
+}
+
+func (s *StateVerifyTestSuite) TearDownTest() {
+	s.mockHistoryQ.AssertExpectations(s.T())
+	s.mockHistoryAdapter.AssertExpectations(s.T())
+	s.mockIngestStateVerifier.AssertExpectations(s.T())
+	s.mockStateVerifierFactory.AssertExpectations(s.T())
+	s.mockStateReader.AssertExpectations(s.T())
+}
+
+// prepareMocks programs mocks with OK behaviour up to given level in
+// the code. This limits code duplication in tests.
+func (s *StateVerifyTestSuite) prepareMocks(level int) {
+	if level >= 1 {
+		s.mockHistoryQ.
+			On("BeginTx", mock.AnythingOfType("*sql.TxOptions")).
+			Return(nil).
+			Once()
+
+		s.mockHistoryQ.On("Rollback").Return(nil).Once()
+	}
+	if level >= 2 {
+		s.mockHistoryQ.
+			On("GetLastLedgerExpIngestNonBlocking").
+			Return(uint32(63), nil).
+			Once()
+	}
+	if level >= 3 {
+		s.mockHistoryAdapter.
+			On("GetLatestLedgerSequence").
+			Return(uint32(63), nil).
+			Once()
+	}
+	if level >= 4 {
+		s.mockHistoryAdapter.
+			On("GetState", uint32(63), &io.MemoryTempSet{}).
+			Return(s.mockStateReader, nil).
+			Once()
+
+		s.mockStateReader.On("Close").Return(nil).Once()
+	}
+	if level >= 5 {
+		s.mockStateVerifierFactory.
+			On("buildStateVerifier", s.mockStateReader).
+			Return(s.mockIngestStateVerifier).
+			Once()
+	}
+}
+
+func (s *StateVerifyTestSuite) TestErrorBeginTx() {
+	s.mockHistoryQ.
+		On("BeginTx", mock.AnythingOfType("*sql.TxOptions")).
+		Run(func(args mock.Arguments) {
+			opts := args.Get(0).(*sql.TxOptions)
+			s.Assert().Equal(sql.LevelRepeatableRead, opts.Isolation)
+			s.Assert().True(opts.ReadOnly)
+		}).
+		Return(assert.AnError).
+		Once()
+
+	err := s.stateVerifier.verify()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Error starting transaction: assert.AnError general error for testing")
+}
+
+func (s *StateVerifyTestSuite) TestErrorGetLastLedgerExpIngestNonBlocking() {
+	s.prepareMocks(1)
+
+	s.mockHistoryQ.
+		On("GetLastLedgerExpIngestNonBlocking").
+		Return(uint32(0), assert.AnError).
+		Once()
+
+	err := s.stateVerifier.verify()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Error running historyQ.GetLastLedgerExpIngestNonBlocking: assert.AnError general error for testing")
+}
+
+func (s *StateVerifyTestSuite) TestNotCheckpointLedger() {
+	s.prepareMocks(1)
+
+	s.mockHistoryQ.
+		On("GetLastLedgerExpIngestNonBlocking").
+		Return(uint32(42), nil).
+		Once()
+
+	err := s.stateVerifier.verify()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Ledger 42 is not a checkpoint ledger.")
+}
+
+func (s *StateVerifyTestSuite) TestGetLatestLedgerSequenceError() {
+	s.prepareMocks(2)
+
+	s.mockHistoryAdapter.
+		On("GetLatestLedgerSequence").
+		Return(uint32(0), assert.AnError).
+		Once()
+
+	err := s.stateVerifier.verify()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Error getting the latest ledger sequence: assert.AnError general error for testing")
+}
+
+func (s *StateVerifyTestSuite) TestOldLedger() {
+	s.prepareMocks(1)
+
+	s.mockHistoryQ.
+		On("GetLastLedgerExpIngestNonBlocking").
+		Return(uint32(63), nil).
+		Once()
+
+	s.mockHistoryAdapter.
+		On("GetLatestLedgerSequence").
+		Return(uint32(1000), nil).
+		Once()
+
+	err := s.stateVerifier.verify()
+	// Should exit without error and verifying
+	s.Assert().NoError(err)
+}
+
+func (s *StateVerifyTestSuite) TestGetStateError() {
+	s.prepareMocks(3)
+
+	s.mockHistoryAdapter.
+		On("GetState", uint32(63), &io.MemoryTempSet{}).
+		Return(&io.SingleLedgerStateReader{}, assert.AnError).
+		Once()
+
+	err := s.stateVerifier.verify()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Error running historyAdapter.GetState: assert.AnError general error for testing")
+}
+
+func (s *StateVerifyTestSuite) TestGetLedgerKeysError() {
+	s.prepareMocks(5)
+
+	s.mockIngestStateVerifier.
+		On("GetLedgerKeys", verifyBatchSize).
+		Return([]xdr.LedgerKey{}, assert.AnError).
+		Once()
+
+	err := s.stateVerifier.verify()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "verifier.GetLedgerKeys error: assert.AnError general error for testing")
+}
+
+func (s *StateVerifyTestSuite) TestFull() {
+	s.prepareMocks(5)
+
+	accountKey := xdr.LedgerKey{}
+	accountKey.SetAccount(xdr.MustAddress("GDQ4U7X4YNDD4D6WYU3JNMPAECNG2IZMQLT4CFAGRVW7XYHBLKI4UKS7"))
+	offerKey := xdr.LedgerKey{}
+	offerKey.SetOffer(xdr.MustAddress("GDQ4U7X4YNDD4D6WYU3JNMPAECNG2IZMQLT4CFAGRVW7XYHBLKI4UKS7"), 10)
+
+	s.mockIngestStateVerifier.
+		On("GetLedgerKeys", verifyBatchSize).
+		Return([]xdr.LedgerKey{accountKey, offerKey}, nil).
+		Once()
+
+	s.mockHistoryQ.
+		On("SignersForAccounts", []string{"GDQ4U7X4YNDD4D6WYU3JNMPAECNG2IZMQLT4CFAGRVW7XYHBLKI4UKS7"}).
+		Return([]history.AccountSigner{
+			{
+				Account: "GDQ4U7X4YNDD4D6WYU3JNMPAECNG2IZMQLT4CFAGRVW7XYHBLKI4UKS7",
+				Signer:  "GDQ4U7X4YNDD4D6WYU3JNMPAECNG2IZMQLT4CFAGRVW7XYHBLKI4UKS7",
+				Weight:  1,
+			},
+			{
+				Account: "GDQ4U7X4YNDD4D6WYU3JNMPAECNG2IZMQLT4CFAGRVW7XYHBLKI4UKS7",
+				Signer:  "GAIEKNJHOSMMCE2NDNNRAOQYXVHZH7U345IUABMBJE6QF3T3DVKDLH3K",
+				Weight:  2,
+			},
+			{
+				Account: "GAIEKNJHOSMMCE2NDNNRAOQYXVHZH7U345IUABMBJE6QF3T3DVKDLH3K",
+				Signer:  "GAIEKNJHOSMMCE2NDNNRAOQYXVHZH7U345IUABMBJE6QF3T3DVKDLH3K",
+				Weight:  3,
+			},
+		}, nil).
+		Once()
+
+	s.mockIngestStateVerifier.
+		On("Write", xdr.LedgerEntry{
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeAccount,
+				Account: &xdr.AccountEntry{
+					AccountId:  xdr.MustAddress("GAIEKNJHOSMMCE2NDNNRAOQYXVHZH7U345IUABMBJE6QF3T3DVKDLH3K"),
+					Thresholds: [4]byte{3, 0, 0, 0},
+					Signers:    []xdr.Signer{},
+				},
+			},
+		}).
+		Return(nil).
+		Once()
+
+	s.mockIngestStateVerifier.
+		On("Write", xdr.LedgerEntry{
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeAccount,
+				Account: &xdr.AccountEntry{
+					AccountId:  xdr.MustAddress("GDQ4U7X4YNDD4D6WYU3JNMPAECNG2IZMQLT4CFAGRVW7XYHBLKI4UKS7"),
+					Thresholds: [4]byte{1, 0, 0, 0},
+					Signers: []xdr.Signer{
+						{
+							Key:    xdr.MustSigner("GAIEKNJHOSMMCE2NDNNRAOQYXVHZH7U345IUABMBJE6QF3T3DVKDLH3K"),
+							Weight: xdr.Uint32(2),
+						},
+					},
+				},
+			},
+		}).
+		Return(nil).
+		Once()
+
+	s.mockHistoryQ.
+		On("GetOffersByIDs", []int64{10}).
+		Return([]history.Offer{
+			{
+				OfferID:  10,
+				SellerID: "GDQ4U7X4YNDD4D6WYU3JNMPAECNG2IZMQLT4CFAGRVW7XYHBLKI4UKS7",
+			},
+		}, nil).
+		Once()
+
+	s.mockIngestStateVerifier.
+		On("Write", xdr.LedgerEntry{
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeOffer,
+				Offer: &xdr.OfferEntry{
+					OfferId:  10,
+					SellerId: xdr.MustAddress("GDQ4U7X4YNDD4D6WYU3JNMPAECNG2IZMQLT4CFAGRVW7XYHBLKI4UKS7"),
+				},
+			},
+		}).
+		Return(nil).
+		Once()
+
+	// Second iteration returns no keys
+	s.mockIngestStateVerifier.
+		On("GetLedgerKeys", verifyBatchSize).
+		Return([]xdr.LedgerKey{}, nil).
+		Once()
+
+	s.mockHistoryQ.On("CountAccounts").Return(2, nil).Once()
+	s.mockHistoryQ.On("CountOffers").Return(1, nil).Once()
+
+	s.mockIngestStateVerifier.On("Verify", 3).Return(nil).Once()
+
+	err := s.stateVerifier.verify()
+	s.Assert().NoError(err)
+}

--- a/support/historyarchive/archive.go
+++ b/support/historyarchive/archive.go
@@ -48,6 +48,7 @@ type ArchiveBackend interface {
 }
 
 type ArchiveInterface interface {
+	GetURL() string
 	GetPathHAS(path string) (HistoryArchiveState, error)
 	PutPathHAS(path string, has HistoryArchiveState, opts *CommandOptions) error
 	BucketExists(bucket Hash) (bool, error)
@@ -85,7 +86,12 @@ type Archive struct {
 	invalidTxSets       int
 	invalidTxResultSets int
 
+	url     string
 	backend ArchiveBackend
+}
+
+func (a *Archive) GetURL() string {
+	return a.url
 }
 
 func (a *Archive) GetPathHAS(path string) (HistoryArchiveState, error) {
@@ -220,6 +226,7 @@ func (a *Archive) GetXdrStream(pth string) (*XdrStream, error) {
 
 func Connect(u string, opts ConnectOptions) (*Archive, error) {
 	arch := Archive{
+		url:                     u,
 		checkpointFiles:         make(map[string](map[uint32]bool)),
 		allBuckets:              make(map[Hash]bool),
 		referencedBuckets:       make(map[Hash]bool),

--- a/support/historyarchive/mocks.go
+++ b/support/historyarchive/mocks.go
@@ -9,6 +9,11 @@ type MockArchive struct {
 	mock.Mock
 }
 
+func (m *MockArchive) GetURL() string {
+	a := m.Called()
+	return a.Get(0).(string)
+}
+
 func (m *MockArchive) GetPathHAS(path string) (HistoryArchiveState, error) {
 	a := m.Called(path)
 	return a.Get(0).(HistoryArchiveState), a.Error(1)


### PR DESCRIPTION
This PR is ongoing work to close #1343. Increases the coverage of ingestion related packages in Horizon:
```
github.com/stellar/go/services/horizon/internal/expingest coverage: 73.0% of statements (before: 31.1%)
github.com/stellar/go/services/horizon/internal/expingest/processors coverage: 79.6% of statements (before: 61.7%)
```

Unfortunately a small refactoring of `verify.go` was required to test the code properly but it shouldn't be hard to understand.