### PR TITLE
exp/ingest/io: Fix AccountSignersChanged for account merge

### DIFF
--- a/exp/ingest/io/ledger_transaction.go
+++ b/exp/ingest/io/ledger_transaction.go
@@ -29,13 +29,10 @@ func (c *Change) AccountSignersChanged() bool {
 		return true
 	}
 
-	// Account merged, check if master key weight > 0, if so, it means
-	// it got removed. Merged account can't have subentries so we don't
-	// need to check other signers.
+	// Account merged. Account being merge can still have signers.
 	// c.Pre != nil at this point.
 	if c.Post == nil {
-		preAccountEntry := c.Pre.MustAccount()
-		return preAccountEntry.MasterKeyWeight() > 0
+		return true
 	}
 
 	// c.Pre != nil && c.Post != nil at this point.

--- a/exp/ingest/io/ledger_transaction_test.go
+++ b/exp/ingest/io/ledger_transaction_test.go
@@ -63,7 +63,8 @@ func TestChangeAccountSignersChangedNoPostNoMasterKey(t *testing.T) {
 		Post: nil,
 	}
 
-	assert.False(t, change.AccountSignersChanged())
+	// Account being merge can still have signers so they will be removed.
+	assert.True(t, change.AccountSignersChanged())
 }
 
 func TestChangeAccountSignersChangedMasterKeyRemoved(t *testing.T) {

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -10,8 +10,10 @@ bumps.  A breaking change will get clearly notified in this log.
 
 * `/paths/strict-send` can now accept a `destination_account` parameter. If `destination_account` is provided then the endpoint will return all payment paths which terminate with an asset held by `destination_account`. Note that the endpoint will accept a `destination_account` or a `destination_asset` but not both.
 * Add experimental support for `/offers`. To enable it, set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable.
+* When experimental ingestion is enabled a state verification routine is started every 64 ledgers to ensure a local state is the same as in history buckets. This can be disabled by setting `--ingest-disable-state-verification` CLI param or `INGEST-DISABLE-STATE-VERIFICATION` env variable.
 * Add flag to apply pending migrations before running horizon. If there are pending migrations, previously you needed to run `horizon db migrate up` before running `horizon`. Those two steps can be combined into one with the `--apply-migrations` flag (`APPLY_MIGRATIONS` env variable).
 * Improved the speed of state ingestion in experimental ingestion system.
+* Fixed a bug in "Signers for Account" (experimental) transaction meta ingesting code.
 * Fixed performance issue in Effects related endpoints.
 * Dropped support for Go 1.10, 1.11.
 

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -32,7 +32,8 @@ const (
 	//      ingestion.
 	// - 3: Fixes a bug that could potentialy result in invalid state
 	//      (#1722). Update the version to clear the state.
-	CurrentVersion = 3
+	// - 4: Fixes a bug in AccountSignersChanged method.
+	CurrentVersion = 4
 )
 
 var log = ilog.DefaultLogger.WithField("service", "expingest")

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -22,7 +22,7 @@ const verifyBatchSize = 50000
 // check them.
 // There is a test that checks it, to fix it: update the actual `verifyState`
 // method instead of just updating this value!
-const stateVerifierExpectedIngestionVersion = 3
+const stateVerifierExpectedIngestionVersion = 4
 
 // verifyState is called as a go routine from pipeline post hook every 64
 // ledgers. It checks if the state is correct. If another go routine is already


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>


This commit fixes a bug in `exp/ingest/io.Changes.AccountSignersChanged()` helper method. This method returns `true` when tx meta indicates that signers on account have changed. It was returning invalid `false` when master weight is `0` but account still has signers (I thought that signers must be removed from account before merging but it's [not true](https://github.com/stellar/stellar-core/blob/7a845698202bdead155b05095cd792dbc938b717/src/transactions/MergeOpFrame.cpp#L95)).

Transaction that revealed a bug: https://horizon.stellar.org/transactions/035e896af5b30942f751d4c2be692d6b46e8efc248428321bef5bbb6ab7d3560