### PR TITLE
services/horizon: Check state in all exp endpoints

### DIFF
--- a/services/horizon/internal/actions_path_test.go
+++ b/services/horizon/internal/actions_path_test.go
@@ -124,10 +124,18 @@ func TestPathActionsStateInvalid(t *testing.T) {
 	)
 	rh.RH = test.NewRequestHelper(rh.App.web.router)
 
-	err := rh.App.historyQ.UpdateExpStateInvalid(true)
+	w := rh.Get("/paths")
+	// Still ingesting
+	rh.Assert.Equal(503, w.Code)
+
+	err := rh.App.historyQ.UpdateLastLedgerExpIngest(10)
 	rh.Assert.NoError(err)
 
-	w := rh.Get("/paths")
+	err = rh.App.historyQ.UpdateExpStateInvalid(true)
+	rh.Assert.NoError(err)
+
+	w = rh.Get("/paths")
+	// State invalid
 	rh.Assert.Equal(500, w.Code)
 }
 

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -119,12 +119,12 @@ func installPathFindingRoutes(
 	findPaths FindPathsHandler,
 	findFixedPaths FindFixedPathsHandler,
 	r *chi.Mux,
-	checkState bool,
+	expIngest bool,
 ) {
 	r.Group(func(r chi.Router) {
 		r.Use(acceptOnlyJSON)
-		if checkState {
-			r.Use(ensureStateCorrect)
+		if expIngest {
+			r.Use(requiresExperimentalIngestion)
 		}
 		r.Method("GET", "/paths", findPaths)
 		r.Method("GET", "/paths/strict-receive", findPaths)
@@ -175,7 +175,7 @@ func (w *web) mustInstallActions(config Config, pathFinder paths.Finder) {
 
 	// account actions
 	r.Route("/accounts", func(r chi.Router) {
-		r.With(requiresExperimentalIngestion, ensureStateCorrect).
+		r.With(requiresExperimentalIngestion).
 			Get("/", accountIndexActionHandler(w.getAccountPage))
 		r.Route("/{account_id}", func(r chi.Router) {
 			r.Get("/", w.streamShowActionHandler(w.getAccountInfo, true))


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

This commit moves checking if the state was found to be invalid to `requiresExperimentalIngestion` middleware that is run before all new experimental ingestion endpoints.

### Goal and scope

Since #1691 Horizon checks if the state is correct every 64 ledgers. If it's found to be incorrect it sets a special flag in a DB. This flag is later checked in middleware to remove access to endpoints with invalid state. This is done to prevent invalid data consumption by clients.

`ensureStateCorrect` middleware that checks for invalid state condition was added only to a part of new endpoints. This commit merges it into `requiresExperimentalIngestion`.

### Summary of changes

* `ensureStateCorrect` middleware merged into `requiresExperimentalIngestion`.
* Adds logging for DB errors.