### PR TITLE
services/horizon: Check rows affected in DatabaseProcessor

### DIFF
--- a/exp/ingest/verify/main.go
+++ b/exp/ingest/verify/main.go
@@ -27,6 +27,11 @@ type StateError struct {
 	error
 }
 
+// NewStateError creates a new StateError.
+func NewStateError(err error) StateError {
+	return StateError{err}
+}
+
 // StateVerifier verifies if ledger entries provided by Add method are the same
 // as in the checkpoint ledger entries provided by SingleLedgerStateReader.
 // The algorithm works in the following way:

--- a/services/horizon/internal/action_offers_expingest_test.go
+++ b/services/horizon/internal/action_offers_expingest_test.go
@@ -56,8 +56,11 @@ func TestOfferActions_Show(t *testing.T) {
 	q := &history.Q{ht.HorizonSession()}
 
 	ht.Assert.NoError(q.UpdateLastLedgerExpIngest(3))
-	ht.Assert.NoError(q.UpsertOffer(eurOffer, 3))
-	ht.Assert.NoError(q.UpsertOffer(twoEurOffer, 20))
+
+	_, err := q.InsertOffer(eurOffer, 3)
+	ht.Assert.NoError(err)
+	_, err = q.InsertOffer(twoEurOffer, 20)
+	ht.Assert.NoError(err)
 
 	w := ht.Get(fmt.Sprintf("/offers/%v", eurOffer.OfferId))
 

--- a/services/horizon/internal/actions/offer_test.go
+++ b/services/horizon/internal/actions/offer_test.go
@@ -128,9 +128,12 @@ func TestGetOffersHandler(t *testing.T) {
 	tt.Assert.NoError(ingestion.Flush())
 	tt.Assert.NoError(ingestion.Close())
 
-	tt.Assert.NoError(q.UpsertOffer(eurOffer, 3))
-	tt.Assert.NoError(q.UpsertOffer(twoEurOffer, 3))
-	tt.Assert.NoError(q.UpsertOffer(usdOffer, 3))
+	_, err := q.InsertOffer(eurOffer, 3)
+	tt.Assert.NoError(err)
+	_, err = q.InsertOffer(twoEurOffer, 3)
+	tt.Assert.NoError(err)
+	_, err = q.InsertOffer(usdOffer, 3)
+	tt.Assert.NoError(err)
 
 	t.Run("No filter", func(t *testing.T) {
 		records, err := handler.GetResourcePage(makeOffersRequest(t, map[string]string{}))
@@ -251,9 +254,12 @@ func TestGetAccountOffersHandler(t *testing.T) {
 		HistoryQ: q,
 	}
 
-	tt.Assert.NoError(q.UpsertOffer(eurOffer, 3))
-	tt.Assert.NoError(q.UpsertOffer(twoEurOffer, 3))
-	tt.Assert.NoError(q.UpsertOffer(usdOffer, 3))
+	_, err := q.InsertOffer(eurOffer, 3)
+	tt.Assert.NoError(err)
+	_, err = q.InsertOffer(twoEurOffer, 3)
+	tt.Assert.NoError(err)
+	_, err = q.InsertOffer(usdOffer, 3)
+	tt.Assert.NoError(err)
 
 	records, err := handler.GetResourcePage(
 		makeAccountOffersRequest(t, issuer.Address(), map[string]string{}),

--- a/services/horizon/internal/db2/history/account_signers.go
+++ b/services/horizon/internal/db2/history/account_signers.go
@@ -44,26 +44,35 @@ func (q *Q) AccountsForSigner(signer string, page db2.PageQuery) ([]AccountSigne
 	return results, nil
 }
 
-// CreateAccountSigner creates a row in the accounts_signers table
-func (q *Q) CreateAccountSigner(account, signer string, weight int32) error {
+// CreateAccountSigner creates a row in the accounts_signers table.
+// Returns number of rows affected and error.
+func (q *Q) CreateAccountSigner(account, signer string, weight int32) (int64, error) {
 	sql := sq.Insert("accounts_signers").
 		Columns("account", "signer", "weight").
-		Values(account, signer, weight).
-		Suffix("ON CONFLICT (signer, account) DO UPDATE SET weight=EXCLUDED.weight")
+		Values(account, signer, weight)
 
-	_, err := q.Exec(sql)
-	return err
+	result, err := q.Exec(sql)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.RowsAffected()
 }
 
-// RemoveAccountSigner deletes a row in the accounts_signers table
-func (q *Q) RemoveAccountSigner(account, signer string) error {
+// RemoveAccountSigner deletes a row in the accounts_signers table.
+// Returns number of rows affected and error.
+func (q *Q) RemoveAccountSigner(account, signer string) (int64, error) {
 	sql := sq.Delete("accounts_signers").Where(sq.Eq{
 		"account": account,
 		"signer":  signer,
 	})
 
-	_, err := q.Exec(sql)
-	return err
+	result, err := q.Exec(sql)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.RowsAffected()
 }
 
 var selectAccountSigners = sq.Select("accounts_signers.*").From("accounts_signers")

--- a/services/horizon/internal/db2/history/account_signers_test.go
+++ b/services/horizon/internal/db2/history/account_signers_test.go
@@ -26,7 +26,9 @@ func TestInsertAccountSigner(t *testing.T) {
 	account := "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2"
 	signer := "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4"
 	weight := int32(123)
-	tt.Assert.NoError(q.CreateAccountSigner(account, signer, weight))
+	rowsAffected, err := q.CreateAccountSigner(account, signer, weight)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal(int64(1), rowsAffected)
 
 	expected := AccountSigner{
 		Account: account,
@@ -39,13 +41,9 @@ func TestInsertAccountSigner(t *testing.T) {
 	tt.Assert.Equal(expected, results[0])
 
 	weight = 321
-	tt.Assert.NoError(q.CreateAccountSigner(account, signer, weight))
-
-	expected.Weight = weight
-	results, err = q.AccountsForSigner(signer, db2.PageQuery{Order: "asc", Limit: 10})
-	tt.Assert.NoError(err)
-	tt.Assert.Len(results, 1)
-	tt.Assert.Equal(expected, results[0])
+	_, err = q.CreateAccountSigner(account, signer, weight)
+	tt.Assert.Error(err)
+	tt.Assert.EqualError(err, `exec failed: pq: duplicate key value violates unique constraint "accounts_signers_pkey"`)
 }
 
 func TestMultipleAccountsForSigner(t *testing.T) {
@@ -56,11 +54,15 @@ func TestMultipleAccountsForSigner(t *testing.T) {
 	account := "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH1"
 	signer := "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO2"
 	weight := int32(123)
-	tt.Assert.NoError(q.CreateAccountSigner(account, signer, weight))
+	rowsAffected, err := q.CreateAccountSigner(account, signer, weight)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal(int64(1), rowsAffected)
 
 	anotherAccount := "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
 	anotherWeight := int32(321)
-	tt.Assert.NoError(q.CreateAccountSigner(anotherAccount, signer, anotherWeight))
+	rowsAffected, err = q.CreateAccountSigner(anotherAccount, signer, anotherWeight)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal(int64(1), rowsAffected)
 
 	expected := []AccountSigner{
 		AccountSigner{
@@ -87,7 +89,9 @@ func TestRemoveNonExistantAccountSigner(t *testing.T) {
 
 	account := "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH3"
 	signer := "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO5"
-	tt.Assert.NoError(q.RemoveAccountSigner(account, signer))
+	rowsAffected, err := q.RemoveAccountSigner(account, signer)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal(int64(0), rowsAffected)
 }
 
 func TestRemoveAccountSigner(t *testing.T) {
@@ -98,7 +102,8 @@ func TestRemoveAccountSigner(t *testing.T) {
 	account := "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH6"
 	signer := "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO7"
 	weight := int32(123)
-	tt.Assert.NoError(q.CreateAccountSigner(account, signer, weight))
+	_, err := q.CreateAccountSigner(account, signer, weight)
+	tt.Assert.NoError(err)
 
 	expected := AccountSigner{
 		Account: account,
@@ -110,7 +115,9 @@ func TestRemoveAccountSigner(t *testing.T) {
 	tt.Assert.Len(results, 1)
 	tt.Assert.Equal(expected, results[0])
 
-	tt.Assert.NoError(q.RemoveAccountSigner(account, signer))
+	rowsAffected, err := q.RemoveAccountSigner(account, signer)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal(int64(1), rowsAffected)
 
 	results, err = q.AccountsForSigner(signer, db2.PageQuery{Order: "asc", Limit: 10})
 	tt.Assert.NoError(err)

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -331,8 +331,8 @@ type QSigners interface {
 	UpdateLastLedgerExpIngest(ledgerSequence uint32) error
 	AccountsForSigner(signer string, page db2.PageQuery) ([]AccountSigner, error)
 	NewAccountSignersBatchInsertBuilder(maxBatchSize int) AccountSignersBatchInsertBuilder
-	CreateAccountSigner(account, signer string, weight int32) error
-	RemoveAccountSigner(account, signer string) error
+	CreateAccountSigner(account, signer string, weight int32) (int64, error)
+	RemoveAccountSigner(account, signer string) (int64, error)
 }
 
 // OffersQuery is a helper struct to configure queries to offers
@@ -347,8 +347,9 @@ type OffersQuery struct {
 type QOffers interface {
 	GetAllOffers() ([]Offer, error)
 	NewOffersBatchInsertBuilder(maxBatchSize int) OffersBatchInsertBuilder
-	UpsertOffer(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) error
-	RemoveOffer(offerID xdr.Int64) error
+	InsertOffer(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) (int64, error)
+	UpdateOffer(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) (int64, error)
+	RemoveOffer(offerID xdr.Int64) (int64, error)
 }
 
 // TotalOrderID represents the ID portion of rows that are identified by the

--- a/services/horizon/internal/db2/history/offers.go
+++ b/services/horizon/internal/db2/history/offers.go
@@ -78,60 +78,83 @@ func (q *Q) GetAllOffers() ([]Offer, error) {
 	return offers, err
 }
 
-// UpsertOffer creates / updates a row in the offers table
-func (q *Q) UpsertOffer(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) error {
+func offerToMap(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) (map[string]interface{}, error) {
 	var price float64
 	if offer.Price.N > 0 {
 		price = float64(offer.Price.N) / float64(offer.Price.D)
 	} else if offer.Price.D == 0 {
-		return errors.New("offer price denominator is zero")
+		return nil, errors.New("offer price denominator is zero")
 	}
 	buyingAsset, err := xdr.MarshalBase64(offer.Buying)
 	if err != nil {
-		return errors.Wrap(err, "cannot marshal buying asset in offer")
+		return nil, errors.Wrap(err, "cannot marshal buying asset in offer")
 	}
 	sellingAsset, err := xdr.MarshalBase64(offer.Selling)
 	if err != nil {
-		return errors.Wrap(err, "cannot marshal selling asset in offer")
+		return nil, errors.Wrap(err, "cannot marshal selling asset in offer")
 	}
-	sql := sq.Insert("offers").SetMap(
-		map[string]interface{}{
-			"sellerid":             offer.SellerId.Address(),
-			"offerid":              offer.OfferId,
-			"sellingasset":         sellingAsset,
-			"buyingasset":          buyingAsset,
-			"amount":               offer.Amount,
-			"pricen":               offer.Price.N,
-			"priced":               offer.Price.D,
-			"price":                price,
-			"flags":                offer.Flags,
-			"last_modified_ledger": lastModifiedLedger,
-		},
-	).Suffix(`
-			ON CONFLICT (offerid) DO UPDATE SET
-				sellerid=EXCLUDED.sellerid,
-				sellingasset=EXCLUDED.sellingasset,
-				buyingasset=EXCLUDED.buyingasset,
-				amount=EXCLUDED.amount,
-				pricen=EXCLUDED.pricen,
-				priced=EXCLUDED.priced,
-				price=EXCLUDED.price,
-				flags=EXCLUDED.flags,
-				last_modified_ledger=EXCLUDED.last_modified_ledger
-		`)
 
-	_, err = q.Exec(sql)
-	return err
+	return map[string]interface{}{
+		"sellerid":             offer.SellerId.Address(),
+		"offerid":              offer.OfferId,
+		"sellingasset":         sellingAsset,
+		"buyingasset":          buyingAsset,
+		"amount":               offer.Amount,
+		"pricen":               offer.Price.N,
+		"priced":               offer.Price.D,
+		"price":                price,
+		"flags":                offer.Flags,
+		"last_modified_ledger": lastModifiedLedger,
+	}, nil
 }
 
-// RemoveOffer deletes a row in the offers table
-func (q *Q) RemoveOffer(offerID xdr.Int64) error {
-	sql := sq.Delete("offers").Where(sq.Eq{
-		"offerid": offerID,
-	})
+// InsertOffer creates a row in the offers table.
+// Returns number of rows affected and error.
+func (q *Q) InsertOffer(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
+	m, err := offerToMap(offer, lastModifiedLedger)
+	if err != nil {
+		return 0, err
+	}
 
-	_, err := q.Exec(sql)
-	return err
+	sql := sq.Insert("offers").SetMap(m)
+	result, err := q.Exec(sql)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.RowsAffected()
+}
+
+// UpdateOffer updates a row in the offers table.
+// Returns number of rows affected and error.
+func (q *Q) UpdateOffer(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
+	m, err := offerToMap(offer, lastModifiedLedger)
+	if err != nil {
+		return 0, err
+	}
+
+	offerID := m["offerid"]
+	delete(m, "offerid")
+
+	sql := sq.Update("offers").SetMap(m).Where(sq.Eq{"offerid": offerID})
+	result, err := q.Exec(sql)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.RowsAffected()
+}
+
+// RemoveOffer deletes a row in the offers table.
+// Returns number of rows affected and error.
+func (q *Q) RemoveOffer(offerID xdr.Int64) (int64, error) {
+	sql := sq.Delete("offers").Where(sq.Eq{"offerid": offerID})
+	result, err := q.Exec(sql)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.RowsAffected()
 }
 
 var selectOffers = sq.Select(`

--- a/services/horizon/internal/db2/history/offers_test.go
+++ b/services/horizon/internal/db2/history/offers_test.go
@@ -114,7 +114,8 @@ func TestGetOfferByID(t *testing.T) {
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
-	tt.Assert.NoError(q.UpsertOffer(eurOffer, 1234))
+	_, err := q.InsertOffer(eurOffer, 1234)
+	tt.Assert.NoError(err)
 	offer, err := q.GetOfferByID(int64(eurOffer.OfferId))
 	tt.Assert.NoError(err)
 	assertOfferEntryMatchesDBOffer(t, eurOffer, offer, 1234)
@@ -144,8 +145,10 @@ func TestInsertOffers(t *testing.T) {
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
-	tt.Assert.NoError(q.UpsertOffer(eurOffer, 1234))
-	tt.Assert.NoError(q.UpsertOffer(twoEurOffer, 1235))
+	_, err := q.InsertOffer(eurOffer, 1234)
+	tt.Assert.NoError(err)
+	_, err = q.InsertOffer(twoEurOffer, 1235)
+	tt.Assert.NoError(err)
 
 	offers, err := q.GetAllOffers()
 	tt.Assert.NoError(err)
@@ -165,7 +168,9 @@ func TestUpdateOffer(t *testing.T) {
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
-	tt.Assert.NoError(q.UpsertOffer(eurOffer, 1234))
+	rowsAffected, err := q.InsertOffer(eurOffer, 1234)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal(int64(1), rowsAffected)
 
 	offers, err := q.GetAllOffers()
 	tt.Assert.NoError(err)
@@ -176,7 +181,9 @@ func TestUpdateOffer(t *testing.T) {
 	modifiedEurOffer := eurOffer
 	modifiedEurOffer.Amount -= 10
 
-	tt.Assert.NoError(q.UpsertOffer(modifiedEurOffer, 1235))
+	rowsAffected, err = q.UpdateOffer(modifiedEurOffer, 1235)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal(int64(1), rowsAffected)
 
 	offers, err = q.GetAllOffers()
 	tt.Assert.NoError(err)
@@ -190,7 +197,8 @@ func TestRemoveNonExistantOffer(t *testing.T) {
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
-	tt.Assert.NoError(q.RemoveOffer(xdr.Int64(12345)))
+	_, err := q.RemoveOffer(xdr.Int64(12345))
+	tt.Assert.NoError(err)
 }
 
 func TestRemoveOffer(t *testing.T) {
@@ -198,13 +206,16 @@ func TestRemoveOffer(t *testing.T) {
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
-	tt.Assert.NoError(q.UpsertOffer(eurOffer, 1234))
+	_, err := q.InsertOffer(eurOffer, 1234)
+	tt.Assert.NoError(err)
 	offers, err := q.GetAllOffers()
 	tt.Assert.NoError(err)
 	tt.Assert.Len(offers, 1)
 	assertOfferEntryMatchesDBOffer(t, eurOffer, offers[0], 1234)
 
-	tt.Assert.NoError(q.RemoveOffer(eurOffer.OfferId))
+	rowsAffected, err := q.RemoveOffer(eurOffer.OfferId)
+	tt.Assert.Equal(int64(1), rowsAffected)
+	tt.Assert.NoError(err)
 
 	offers, err = q.GetAllOffers()
 	tt.Assert.NoError(err)
@@ -216,8 +227,10 @@ func TestGetOffers(t *testing.T) {
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
-	tt.Assert.NoError(q.UpsertOffer(eurOffer, 1234))
-	tt.Assert.NoError(q.UpsertOffer(twoEurOffer, 1235))
+	_, err := q.InsertOffer(eurOffer, 1234)
+	tt.Assert.NoError(err)
+	_, err = q.InsertOffer(twoEurOffer, 1235)
+	tt.Assert.NoError(err)
 
 	pageQuery, err := db2.NewPageQuery("", false, "", 10)
 	tt.Assert.NoError(err)

--- a/services/horizon/internal/db2/history/q_offers_mock.go
+++ b/services/horizon/internal/db2/history/q_offers_mock.go
@@ -21,12 +21,17 @@ func (m *MockQOffers) NewOffersBatchInsertBuilder(maxBatchSize int) OffersBatchI
 	return a.Get(0).(OffersBatchInsertBuilder)
 }
 
-func (m *MockQOffers) UpsertOffer(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) error {
+func (m *MockQOffers) InsertOffer(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
 	a := m.Called(offer, lastModifiedLedger)
-	return a.Error(0)
+	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQOffers) RemoveOffer(offerID xdr.Int64) error {
+func (m *MockQOffers) UpdateOffer(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
+	a := m.Called(offer, lastModifiedLedger)
+	return a.Get(0).(int64), a.Error(1)
+}
+
+func (m *MockQOffers) RemoveOffer(offerID xdr.Int64) (int64, error) {
 	a := m.Called(offerID)
-	return a.Error(0)
+	return a.Get(0).(int64), a.Error(1)
 }

--- a/services/horizon/internal/db2/history/q_signers_mock.go
+++ b/services/horizon/internal/db2/history/q_signers_mock.go
@@ -34,12 +34,12 @@ func (m *MockQSigners) NewAccountSignersBatchInsertBuilder(maxBatchSize int) Acc
 	return a.Get(0).(AccountSignersBatchInsertBuilder)
 }
 
-func (m *MockQSigners) CreateAccountSigner(account, signer string, weight int32) error {
+func (m *MockQSigners) CreateAccountSigner(account, signer string, weight int32) (int64, error) {
 	a := m.Called(account, signer, weight)
-	return a.Error(0)
+	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQSigners) RemoveAccountSigner(account, signer string) error {
+func (m *MockQSigners) RemoveAccountSigner(account, signer string) (int64, error) {
 	a := m.Called(account, signer)
-	return a.Error(0)
+	return a.Get(0).(int64), a.Error(1)
 }

--- a/services/horizon/internal/expingest/load_orderbook_graph_test.go
+++ b/services/horizon/internal/expingest/load_orderbook_graph_test.go
@@ -77,10 +77,12 @@ func TestLoadOrderBookGraph(t *testing.T) {
 	graph := orderbook.NewOrderBookGraph()
 
 	tt.Assert.NoError(q.UpdateLastLedgerExpIngest(123))
-	tt.Assert.NoError(q.UpsertOffer(eurOffer, 123))
-	tt.Assert.NoError(q.UpsertOffer(twoEurOffer, 123))
+	_, err := q.InsertOffer(eurOffer, 123)
+	tt.Assert.NoError(err)
+	_, err = q.InsertOffer(twoEurOffer, 123)
+	tt.Assert.NoError(err)
 
-	err := loadOrderBookGraphFromDB(q, graph)
+	err = loadOrderBookGraphFromDB(q, graph)
 	tt.Assert.NoError(err)
 	tt.Assert.False(graph.IsEmpty())
 

--- a/services/horizon/internal/expingest/pipeline_hooks_test.go
+++ b/services/horizon/internal/expingest/pipeline_hooks_test.go
@@ -31,7 +31,7 @@ func TestStatePreProcessingHook(t *testing.T) {
 
 	tt.Assert.Nil(session.GetTx())
 	newCtx, err := preProcessingHook(ctx, pipelineType, session)
-	tt.Assert.Nil(err)
+	tt.Assert.NoError(err)
 	tt.Assert.NotNil(session.GetTx())
 	tt.Assert.Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
 
@@ -42,7 +42,7 @@ func TestStatePreProcessingHook(t *testing.T) {
 	tt.Assert.NotNil(session.GetTx())
 
 	newCtx, err = preProcessingHook(ctx, pipelineType, session)
-	tt.Assert.Nil(err)
+	tt.Assert.NoError(err)
 	tt.Assert.NotNil(session.GetTx())
 	tt.Assert.Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
 }
@@ -64,7 +64,7 @@ func TestLedgerPreProcessingHook(t *testing.T) {
 
 	tt.Assert.Nil(session.GetTx())
 	newCtx, err := preProcessingHook(ctx, pipelineType, session)
-	tt.Assert.Nil(err)
+	tt.Assert.NoError(err)
 	tt.Assert.NotNil(session.GetTx())
 	tt.Assert.Equal(newCtx.Value(horizonProcessors.IngestUpdateDatabase), true)
 
@@ -74,7 +74,7 @@ func TestLedgerPreProcessingHook(t *testing.T) {
 	tt.Assert.Nil(session.Begin())
 	tt.Assert.NotNil(session.GetTx())
 	newCtx, err = preProcessingHook(ctx, pipelineType, session)
-	tt.Assert.Nil(err)
+	tt.Assert.NoError(err)
 	tt.Assert.NotNil(session.GetTx())
 	tt.Assert.Equal(newCtx.Value(horizonProcessors.IngestUpdateDatabase), true)
 
@@ -83,14 +83,14 @@ func TestLedgerPreProcessingHook(t *testing.T) {
 
 	tt.Assert.Nil(historyQ.UpdateLastLedgerExpIngest(2))
 	newCtx, err = preProcessingHook(ctx, pipelineType, session)
-	tt.Assert.Nil(err)
+	tt.Assert.NoError(err)
 	tt.Assert.Nil(session.GetTx())
 	tt.Assert.Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
 
 	tt.Assert.Nil(session.Begin())
 	tt.Assert.NotNil(session.GetTx())
 	newCtx, err = preProcessingHook(ctx, pipelineType, session)
-	tt.Assert.Nil(err)
+	tt.Assert.NoError(err)
 	tt.Assert.Nil(session.GetTx())
 	tt.Assert.Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
 }
@@ -163,7 +163,8 @@ func TestPostProcessingHook(t *testing.T) {
 		t.Run(testCase.name, func(_ *testing.T) {
 			tt.Assert.Nil(historyQ.UpdateLastLedgerExpIngest(testCase.lastLedger))
 			tt.Assert.Nil(historyQ.UpdateExpIngestVersion(0))
-			tt.Assert.Nil(historyQ.RemoveAccountSigner(account, signer))
+			_, err := historyQ.RemoveAccountSigner(account, signer)
+			tt.Assert.NoError(err)
 
 			ctx := context.WithValue(
 				context.Background(),
@@ -179,12 +180,13 @@ func TestPostProcessingHook(t *testing.T) {
 				tt.Assert.Nil(session.Begin())
 				// queue an insert on the transaction so we can check if the post
 				// processing hook committed it to the db
-				tt.Assert.Nil(historyQ.CreateAccountSigner(account, signer, weight))
+				_, err := historyQ.CreateAccountSigner(account, signer, weight)
+				tt.Assert.NoError(err)
 			}
 
-			err := postProcessingHook(ctx, testCase.err, statePipeline, nil, graph, session)
+			err = postProcessingHook(ctx, testCase.err, statePipeline, nil, graph, session)
 			if testCase.expectedError == "" {
-				tt.Assert.Nil(err)
+				tt.Assert.NoError(err)
 				tt.Assert.Equal(graph.Offers(), []xdr.OfferEntry{eurOffer})
 			} else {
 				tt.Assert.Contains(err.Error(), testCase.expectedError)
@@ -195,10 +197,10 @@ func TestPostProcessingHook(t *testing.T) {
 			if testCase.inTx && testCase.expectedError == "" {
 				// check that the ingest version and the ingest sequence was updated
 				version, err := historyQ.GetExpIngestVersion()
-				tt.Assert.Nil(err)
+				tt.Assert.NoError(err)
 				tt.Assert.Equal(version, CurrentVersion)
 				seq, err := historyQ.GetLastLedgerExpIngestNonBlocking()
-				tt.Assert.Nil(err)
+				tt.Assert.NoError(err)
 				tt.Assert.Equal(seq, testCase.pipelineLedger)
 
 				// check that the transaction was committed
@@ -209,10 +211,10 @@ func TestPostProcessingHook(t *testing.T) {
 			} else {
 				// check that the transaction was rolled back and nothing was committed
 				version, err := historyQ.GetExpIngestVersion()
-				tt.Assert.Nil(err)
+				tt.Assert.NoError(err)
 				tt.Assert.Equal(version, 0)
 				seq, err := historyQ.GetLastLedgerExpIngestNonBlocking()
-				tt.Assert.Nil(err)
+				tt.Assert.NoError(err)
 				tt.Assert.Equal(seq, testCase.lastLedger)
 
 				accounts, err := historyQ.AccountsForSigner(signer, db2.PageQuery{Order: "asc", Limit: 10})

--- a/services/horizon/internal/expingest/pipeline_hooks_test.go
+++ b/services/horizon/internal/expingest/pipeline_hooks_test.go
@@ -180,7 +180,7 @@ func TestPostProcessingHook(t *testing.T) {
 				tt.Assert.Nil(session.Begin())
 				// queue an insert on the transaction so we can check if the post
 				// processing hook committed it to the db
-				_, err := historyQ.CreateAccountSigner(account, signer, weight)
+				_, err = historyQ.CreateAccountSigner(account, signer, weight)
 				tt.Assert.NoError(err)
 			}
 

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -182,13 +182,18 @@ func postProcessingHook(
 	ledgerSeq := pipeline.GetLedgerSequenceFromContext(ctx)
 
 	if err != nil {
-		log.
-			WithFields(ilog.F{
-				"ledger": ledgerSeq,
-				"type":   pipelineType,
-				"err":    err,
-			}).
-			Error("Error processing ledger")
+		switch errors.Cause(err).(type) {
+		case verify.StateError:
+			markStateInvalid(historySession, err)
+		default:
+			log.
+				WithFields(ilog.F{
+					"ledger": ledgerSeq,
+					"type":   pipelineType,
+					"err":    err,
+				}).
+				Error("Error processing ledger")
+		}
 		return err
 	}
 
@@ -236,13 +241,9 @@ func postProcessingHook(
 		go func() {
 			err := system.verifyState()
 			if err != nil {
-				switch err := errors.Cause(err).(type) {
+				switch errors.Cause(err).(type) {
 				case verify.StateError:
-					log.WithField("err", err).Error("STATE IS INVALID!")
-					q := &history.Q{historySession.Clone()}
-					if err := q.UpdateExpStateInvalid(true); err != nil {
-						log.WithField("err", err).Error("Error updating state invalid value")
-					}
+					markStateInvalid(historySession, err)
 				default:
 					log.WithField("err", err).Error("State verification errored")
 				}
@@ -252,6 +253,14 @@ func postProcessingHook(
 
 	log.WithFields(ilog.F{"ledger": ledgerSeq, "type": pipelineType}).Info("Processed ledger")
 	return nil
+}
+
+func markStateInvalid(historySession *db.Session, err error) {
+	log.WithField("err", err).Error("STATE IS INVALID!")
+	q := &history.Q{historySession.Clone()}
+	if err := q.UpdateExpStateInvalid(true); err != nil {
+		log.WithField("err", err).Error("Error updating state invalid value")
+	}
 }
 
 func addPipelineHooks(

--- a/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 
 	"github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/exp/ingest/verify"
 	supportPipeline "github.com/stellar/go/exp/support/pipeline"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/suite"
 )
@@ -535,6 +537,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewAccountNoRowsAffected() 
 	)
 
 	s.Assert().Error(err)
+	s.Assert().IsType(verify.StateError{}, errors.Cause(err))
 	s.Assert().EqualError(
 		err,
 		"Error in processLedgerAccountsForSigner: No rows affected when inserting "+
@@ -592,6 +595,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestRemoveAccountNoRowsAffected
 	)
 
 	s.Assert().Error(err)
+	s.Assert().IsType(verify.StateError{}, errors.Cause(err))
 	s.Assert().EqualError(
 		err,
 		"Error in processLedgerAccountsForSigner: Expected "+

--- a/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
@@ -236,7 +236,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewAccount() {
 			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 			int32(1),
 		).
-		Return(nil).Once()
+		Return(int64(1), nil).Once()
 
 	s.mockLedgerReader.
 		On("Read").
@@ -311,7 +311,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewSigner() {
 			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 			"GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
 		).
-		Return(nil).Once()
+		Return(int64(1), nil).Once()
 
 	// Create new and old signer
 	s.mockQ.
@@ -321,7 +321,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewSigner() {
 			"GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
 			int32(10),
 		).
-		Return(nil).Once()
+		Return(int64(1), nil).Once()
 
 	s.mockQ.
 		On(
@@ -330,7 +330,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewSigner() {
 			"GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS",
 			int32(15),
 		).
-		Return(nil).Once()
+		Return(int64(1), nil).Once()
 
 	s.mockLedgerReader.
 		On("Read").
@@ -405,7 +405,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestSignerRemoved() {
 			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 			"GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
 		).
-		Return(nil).Once()
+		Return(int64(1), nil).Once()
 
 	s.mockQ.
 		On(
@@ -413,7 +413,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestSignerRemoved() {
 			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 			"GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS",
 		).
-		Return(nil).Once()
+		Return(int64(1), nil).Once()
 
 	// Create new signer
 	s.mockQ.
@@ -423,7 +423,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestSignerRemoved() {
 			"GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS",
 			int32(15),
 		).
-		Return(nil).Once()
+		Return(int64(1), nil).Once()
 
 	s.mockLedgerReader.
 		On("Read").
@@ -478,7 +478,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestRemoveAccount() {
 			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 		).
-		Return(nil).Once()
+		Return(int64(1), nil).Once()
 
 	s.mockLedgerReader.
 		On("Read").
@@ -492,6 +492,112 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestRemoveAccount() {
 	)
 
 	s.Assert().NoError(err)
+}
+
+func (s *AccountsSignerProcessorTestSuiteLedger) TestNewAccountNoRowsAffected() {
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+							Created: &xdr.LedgerEntry{
+								Data: xdr.LedgerEntryData{
+									Type: xdr.LedgerEntryTypeAccount,
+									Account: &xdr.AccountEntry{
+										AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+										Thresholds: [4]byte{1, 1, 1, 1},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+
+	s.mockQ.
+		On(
+			"CreateAccountSigner",
+			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+			int32(1),
+		).
+		Return(int64(0), nil).Once()
+
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().Error(err)
+	s.Assert().EqualError(
+		err,
+		"Error in processLedgerAccountsForSigner: No rows affected when inserting "+
+			"account=GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML "+
+			"signer=GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML to database",
+	)
+}
+
+func (s *AccountsSignerProcessorTestSuiteLedger) TestRemoveAccountNoRowsAffected() {
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+							State: &xdr.LedgerEntry{
+								Data: xdr.LedgerEntryData{
+									Type: xdr.LedgerEntryTypeAccount,
+									Account: &xdr.AccountEntry{
+										AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+										Thresholds: [4]byte{1, 1, 1, 1},
+									},
+								},
+							},
+						},
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+							Removed: &xdr.LedgerKey{
+								Type: xdr.LedgerEntryTypeAccount,
+								Account: &xdr.LedgerKeyAccount{
+									AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+
+	s.mockQ.
+		On(
+			"RemoveAccountSigner",
+			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+		).
+		Return(int64(0), nil).Once()
+
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().Error(err)
+	s.Assert().EqualError(
+		err,
+		"Error in processLedgerAccountsForSigner: Expected "+
+			"account=GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML "+
+			"signer=GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML in database but not found when removing",
+	)
 }
 
 func createTransactionMeta(opMeta []xdr.OperationMeta) xdr.TransactionMeta {

--- a/services/horizon/internal/expingest/processors/database_processor.go
+++ b/services/horizon/internal/expingest/processors/database_processor.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stellar/go/exp/ingest/io"
 	ingestpipeline "github.com/stellar/go/exp/ingest/pipeline"
+	"github.com/stellar/go/exp/ingest/verify"
 	"github.com/stellar/go/exp/support/pipeline"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/errors"
@@ -174,11 +175,11 @@ func (p *DatabaseProcessor) processLedgerAccountsForSigner(transaction io.Ledger
 				}
 
 				if rowsAffected != 1 {
-					return errors.Errorf(
+					return verify.NewStateError(errors.Errorf(
 						"Expected account=%s signer=%s in database but not found when removing",
 						preAccountEntry.AccountId.Address(),
 						signer,
-					)
+					))
 				}
 			}
 		}
@@ -192,11 +193,11 @@ func (p *DatabaseProcessor) processLedgerAccountsForSigner(transaction io.Ledger
 				}
 
 				if rowsAffected != 1 {
-					return errors.Errorf(
+					return verify.NewStateError(errors.Errorf(
 						"No rows affected when inserting account=%s signer=%s to database",
 						postAccountEntry.AccountId.Address(),
 						signer,
-					)
+					))
 				}
 			}
 		}
@@ -241,11 +242,11 @@ func (p *DatabaseProcessor) processLedgerOffers(transaction io.LedgerTransaction
 		}
 
 		if rowsAffected != 1 {
-			return errors.Errorf(
+			return verify.NewStateError(errors.Errorf(
 				"No rows affected when %s offer %d",
 				action,
 				offerID,
-			)
+			))
 		}
 	}
 	return nil

--- a/services/horizon/internal/expingest/processors/database_processor.go
+++ b/services/horizon/internal/expingest/processors/database_processor.go
@@ -168,9 +168,17 @@ func (p *DatabaseProcessor) processLedgerAccountsForSigner(transaction io.Ledger
 		if change.Pre != nil {
 			preAccountEntry := change.Pre.MustAccount()
 			for signer := range preAccountEntry.SignerSummary() {
-				err := p.SignersQ.RemoveAccountSigner(preAccountEntry.AccountId.Address(), signer)
+				rowsAffected, err := p.SignersQ.RemoveAccountSigner(preAccountEntry.AccountId.Address(), signer)
 				if err != nil {
 					return errors.Wrap(err, "Error removing a signer")
+				}
+
+				if rowsAffected != 1 {
+					return errors.Errorf(
+						"Expected account=%s signer=%s in database but not found when removing",
+						preAccountEntry.AccountId.Address(),
+						signer,
+					)
 				}
 			}
 		}
@@ -178,9 +186,17 @@ func (p *DatabaseProcessor) processLedgerAccountsForSigner(transaction io.Ledger
 		if change.Post != nil {
 			postAccountEntry := change.Post.MustAccount()
 			for signer, weight := range postAccountEntry.SignerSummary() {
-				err := p.SignersQ.CreateAccountSigner(postAccountEntry.AccountId.Address(), signer, weight)
+				rowsAffected, err := p.SignersQ.CreateAccountSigner(postAccountEntry.AccountId.Address(), signer, weight)
 				if err != nil {
 					return errors.Wrap(err, "Error inserting a signer")
+				}
+
+				if rowsAffected != 1 {
+					return errors.Errorf(
+						"No rows affected when inserting account=%s signer=%s to database",
+						postAccountEntry.AccountId.Address(),
+						signer,
+					)
 				}
 			}
 		}
@@ -194,17 +210,43 @@ func (p *DatabaseProcessor) processLedgerOffers(transaction io.LedgerTransaction
 			continue
 		}
 
+		var rowsAffected int64
+		var err error
+		var action string
+		var offerID xdr.Int64
+
 		switch {
-		case change.Post != nil:
-			// Created or updated
+		case change.Pre == nil && change.Post != nil:
+			// Created
+			action = "inserting"
 			offer := change.Post.MustOffer()
-			p.OffersQ.UpsertOffer(offer, xdr.Uint32(currentLedger))
+			offerID = offer.OfferId
+			rowsAffected, err = p.OffersQ.InsertOffer(offer, xdr.Uint32(currentLedger))
 		case change.Pre != nil && change.Post == nil:
 			// Removed
+			action = "removing"
 			offer := change.Pre.MustOffer()
-			p.OffersQ.RemoveOffer(offer.OfferId)
+			offerID = offer.OfferId
+			rowsAffected, err = p.OffersQ.RemoveOffer(offer.OfferId)
+		default:
+			// Updated
+			action = "updating"
+			offer := change.Post.MustOffer()
+			offerID = offer.OfferId
+			rowsAffected, err = p.OffersQ.UpdateOffer(offer, xdr.Uint32(currentLedger))
 		}
 
+		if err != nil {
+			return err
+		}
+
+		if rowsAffected != 1 {
+			return errors.Errorf(
+				"No rows affected when %s offer %d",
+				action,
+				offerID,
+			)
+		}
 	}
 	return nil
 }

--- a/services/horizon/internal/expingest/processors/offers_processor_test.go
+++ b/services/horizon/internal/expingest/processors/offers_processor_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 
 	"github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/exp/ingest/verify"
 	supportPipeline "github.com/stellar/go/exp/support/pipeline"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/suite"
 )
@@ -327,6 +329,7 @@ func (s *OffersProcessorTestSuiteLedger) TestUpdateOfferNoRowsAffected() {
 	)
 
 	s.Assert().Error(err)
+	s.Assert().IsType(verify.StateError{}, errors.Cause(err))
 	s.Assert().EqualError(err, "Error in processLedgerOffers: No rows affected when updating offer 2")
 }
 
@@ -430,5 +433,6 @@ func (s *OffersProcessorTestSuiteLedger) TestRemoveOfferNoRowsAffected() {
 	)
 
 	s.Assert().Error(err)
+	s.Assert().IsType(verify.StateError{}, errors.Cause(err))
 	s.Assert().EqualError(err, "Error in processLedgerOffers: No rows affected when removing offer 3")
 }

--- a/services/horizon/internal/expingest/processors/offers_processor_test.go
+++ b/services/horizon/internal/expingest/processors/offers_processor_test.go
@@ -130,7 +130,7 @@ func (s *OffersProcessorTestSuiteLedger) TearDownTest() {
 	s.mockLedgerWriter.AssertExpectations(s.T())
 }
 
-func (s *OffersProcessorTestSuiteLedger) TestUpsertOffer() {
+func (s *OffersProcessorTestSuiteLedger) TestInsertOffer() {
 	// should be ignored because it's not an offer type
 	s.mockLedgerReader.
 		On("Read").
@@ -214,10 +214,10 @@ func (s *OffersProcessorTestSuiteLedger) TestUpsertOffer() {
 	s.mockLedgerReader.On("GetSequence").Return(uint32(lastModifiedLedgerSeq))
 
 	s.mockQ.On(
-		"UpsertOffer",
+		"InsertOffer",
 		offer,
 		lastModifiedLedgerSeq,
-	).Return(nil).Once()
+	).Return(int64(1), nil).Once()
 
 	updatedOffer := xdr.OfferEntry{
 		OfferId: xdr.Int64(2),
@@ -253,10 +253,10 @@ func (s *OffersProcessorTestSuiteLedger) TestUpsertOffer() {
 			}),
 		}, nil).Once()
 	s.mockQ.On(
-		"UpsertOffer",
+		"UpdateOffer",
 		updatedOffer,
 		lastModifiedLedgerSeq,
-	).Return(nil).Once()
+	).Return(int64(1), nil).Once()
 
 	s.mockLedgerReader.
 		On("Read").
@@ -270,6 +270,64 @@ func (s *OffersProcessorTestSuiteLedger) TestUpsertOffer() {
 	)
 
 	s.Assert().NoError(err)
+}
+
+func (s *OffersProcessorTestSuiteLedger) TestUpdateOfferNoRowsAffected() {
+	lastModifiedLedgerSeq := xdr.Uint32(1234)
+	s.mockLedgerReader.On("GetSequence").Return(uint32(lastModifiedLedgerSeq))
+
+	offer := xdr.OfferEntry{
+		OfferId: xdr.Int64(2),
+		Price:   xdr.Price{1, 2},
+	}
+	updatedOffer := xdr.OfferEntry{
+		OfferId: xdr.Int64(2),
+		Price:   xdr.Price{1, 6},
+	}
+	s.mockLedgerReader.On("Read").
+		Return(io.LedgerTransaction{
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						// State
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+							State: &xdr.LedgerEntry{
+								Data: xdr.LedgerEntryData{
+									Type:  xdr.LedgerEntryTypeOffer,
+									Offer: &offer,
+								},
+							},
+						},
+						// Updated
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
+							Updated: &xdr.LedgerEntry{
+								Data: xdr.LedgerEntryData{
+									Type:  xdr.LedgerEntryTypeOffer,
+									Offer: &updatedOffer,
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+	s.mockQ.On(
+		"UpdateOffer",
+		updatedOffer,
+		lastModifiedLedgerSeq,
+	).Return(int64(0), nil).Once()
+
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Error in processLedgerOffers: No rows affected when updating offer 2")
 }
 
 func (s *OffersProcessorTestSuiteLedger) TestRemoveOffer() {
@@ -309,7 +367,7 @@ func (s *OffersProcessorTestSuiteLedger) TestRemoveOffer() {
 	s.mockQ.On(
 		"RemoveOffer",
 		xdr.Int64(3),
-	).Return(nil).Once()
+	).Return(int64(1), nil).Once()
 
 	s.mockLedgerReader.
 		On("Read").
@@ -323,4 +381,54 @@ func (s *OffersProcessorTestSuiteLedger) TestRemoveOffer() {
 	)
 
 	s.Assert().NoError(err)
+}
+
+func (s *OffersProcessorTestSuiteLedger) TestRemoveOfferNoRowsAffected() {
+	// add offer
+	s.mockLedgerReader.On("Read").
+		Return(io.LedgerTransaction{
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+							State: &xdr.LedgerEntry{
+								Data: xdr.LedgerEntryData{
+									Type: xdr.LedgerEntryTypeOffer,
+									Offer: &xdr.OfferEntry{
+										OfferId: xdr.Int64(3),
+										Price:   xdr.Price{3, 1},
+									},
+								},
+							},
+						},
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+							Removed: &xdr.LedgerKey{
+								Type: xdr.LedgerEntryTypeOffer,
+								Offer: &xdr.LedgerKeyOffer{
+									OfferId: xdr.Int64(3),
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+	s.mockLedgerReader.On("GetSequence").Return(uint32(123))
+
+	s.mockQ.On(
+		"RemoveOffer",
+		xdr.Int64(3),
+	).Return(int64(0), nil).Once()
+
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Error in processLedgerOffers: No rows affected when removing offer 3")
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

This commit checks rows affected value for CUD operations in `DatabaseProcessor`. This is done to ensure state correctness in Horizon database.

Close #1723.

### Goal and scope

When inserting/updating/deleting rows in state connected tables we ignore rows affected value however we can use it to ensure that the change applied is actually correct given current state. Let's say we are removing a signer (by using `RemoveAccountSigner` method) from a DB when a new transaction removing it appears. Let's also assume the database state is incorrect and there is no such signer in Horizon database. Previously there was no way of checking if a row was actually removed from a DB because `RemoveAccountSigner` did not return number of rows affected by a query. We can check it now.

This allows us to detect state issues minutes before state verification routine (#1691) detects them.

### Summary of changes

* All of the following methods now return a number of rows affected:
  * `CreateAccountSigner`
  * `RemoveAccountSigner`
  * `InsertOffer` (new method, replaced `UpsertOffer`)
  * `UpdateOffer` (new method, replaced `UpsertOffer`)
  * `RemoveOffer`
* Rows affected value is checked in `DatabaseProcessor` an errors if no rows are affected.
* Added helper methods.
* Fixed ignoring errors in `processLedgerOffers`.
* Fixed tests and added tests checking rows affected values.