### PR TITLE
all: use stretch instead of buster for all builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ jobs:
   check_code_1_13:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: circleci/golang:1.13-buster
+      - image: circleci/golang:1.13-stretch
     steps:
       - install_go_deps
       - check_go_deps
@@ -223,7 +223,7 @@ jobs:
   test_code_1_13:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: circleci/golang:1.13-buster
+      - image: circleci/golang:1.13-stretch
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -247,7 +247,7 @@ jobs:
   publish_artifacts:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: circleci/golang:1.13-buster
+      - image: circleci/golang:1.13-stretch
     steps:
       - check_deprecations
       - install_go_deps
@@ -271,7 +271,7 @@ jobs:
   ingest_state_diff:
     working_directory: /go/src/github.com/stellar/go/
     docker:
-      - image: circleci/golang:1.13-buster
+      - image: circleci/golang:1.13-stretch
         environment:
           PGHOST: localhost
           PGPORT: 5432


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Change the Debian version that the Go 1.13 checks, tests, and publishing occurs with to Debian Stretch, instead of Debian Buster.

### Goal and scope

When we added tests for Go 1.13 the only image available on DockerHub was based on Debian Stretch. We made a case for publishing a Stretch version for at least a year while Stretch is still in use in docker-library/golang#296 and it was added in docker-library/golang/pull/300 and docker-library/official-images#6597.

Since we're still using Debian Stretch we agreed it would be worthwhile to run our tests and builds on it until we upgrade.

Close #1718

### Notes

I left the postgresql fallback install code that pulls the deb from the official postgres apt repo when it's not available in the default system repo. That was also added for Buster because Buster doesn't have the version we need, version 9.6. I left that code there because we're likely to use it soon enough when we move everything to Buster anyway.

### Summary of changes

- Replace uses of the buster image with the stretch image.

### Known limitations & issues

N/A

### What shouldn't be reviewed

N/A