### PR TITLE
services/ticker: fix flakey spec comparing time with postgres stored time

### DIFF
--- a/services/ticker/internal/tickerdb/queries_asset_test.go
+++ b/services/ticker/internal/tickerdb/queries_asset_test.go
@@ -1,8 +1,10 @@
 package tickerdb
 
 import (
+	"reflect"
 	"testing"
 	"time"
+	"unsafe"
 
 	_ "github.com/lib/pq"
 	migrate "github.com/rubenv/sql-migrate"
@@ -50,7 +52,18 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 	require.NoError(t, err)
 
 	// Creating first asset:
-	firstTime := time.Now()
+	//firstTime := time.Now()
+	firstTimeTmpl := &time.Time{}
+	{
+		firstTimeValue := reflect.ValueOf(firstTimeTmpl).Elem()
+		wallField := firstTimeValue.FieldByName("wall")
+		reflect.NewAt(wallField.Type(), unsafe.Pointer(wallField.UnsafeAddr())).Elem().SetUint(0xbf5a63f0b825c654)
+		extField := firstTimeValue.FieldByName("ext")
+		reflect.NewAt(extField.Type(), unsafe.Pointer(extField.UnsafeAddr())).Elem().SetInt(353520401)
+		locField := firstTimeValue.FieldByName("loc")
+		reflect.NewAt(locField.Type(), unsafe.Pointer(locField.UnsafeAddr())).Elem().Set(reflect.ValueOf(time.Local))
+	}
+	firstTime := *firstTimeTmpl
 	a := Asset{
 		Code:          code,
 		IssuerAccount: issuerAccount,

--- a/services/ticker/internal/tickerdb/queries_asset_test.go
+++ b/services/ticker/internal/tickerdb/queries_asset_test.go
@@ -88,13 +88,13 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 	assert.Equal(t, dbIssuer.ID, dbAsset1.IssuerID)
 	assert.Equal(
 		t,
-		firstTime.Local().Truncate(time.Millisecond),
-		dbAsset1.LastValid.Local().Truncate(time.Millisecond),
+		firstTime.Local().Round(time.Millisecond),
+		dbAsset1.LastValid.Local().Round(time.Millisecond),
 	)
 	assert.Equal(
 		t,
-		firstTime.Local().Truncate(time.Millisecond),
-		dbAsset1.LastChecked.Local().Truncate(time.Millisecond),
+		firstTime.Local().Round(time.Millisecond),
+		dbAsset1.LastChecked.Local().Round(time.Millisecond),
 	)
 
 	// Creating Seconde Asset:
@@ -122,13 +122,13 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 	assert.True(t, dbAsset2.LastChecked.After(firstTime))
 	assert.Equal(
 		t,
-		secondTime.Local().Truncate(time.Millisecond),
-		dbAsset2.LastValid.Local().Truncate(time.Millisecond),
+		secondTime.Local().Round(time.Millisecond),
+		dbAsset2.LastValid.Local().Round(time.Millisecond),
 	)
 	assert.Equal(
 		t,
-		secondTime.Local().Truncate(time.Millisecond),
-		dbAsset2.LastChecked.Local().Truncate(time.Millisecond),
+		secondTime.Local().Round(time.Millisecond),
+		dbAsset2.LastChecked.Local().Round(time.Millisecond),
 	)
 
 	// Creating Third Asset:
@@ -155,12 +155,12 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 	assert.True(t, dbAsset3.LastChecked.Before(thirdTime))
 	assert.Equal(
 		t,
-		dbAsset2.LastValid.Local().Truncate(time.Millisecond),
-		dbAsset3.LastValid.Local().Truncate(time.Millisecond),
+		dbAsset2.LastValid.Local().Round(time.Millisecond),
+		dbAsset3.LastValid.Local().Round(time.Millisecond),
 	)
 	assert.Equal(
-		t, dbAsset2.LastValid.Local().Truncate(time.Millisecond),
-		dbAsset3.LastChecked.Local().Truncate(time.Millisecond),
+		t, dbAsset2.LastValid.Local().Round(time.Millisecond),
+		dbAsset3.LastChecked.Local().Round(time.Millisecond),
 	)
 }
 

--- a/services/ticker/internal/tickerdb/queries_asset_test.go
+++ b/services/ticker/internal/tickerdb/queries_asset_test.go
@@ -1,10 +1,8 @@
 package tickerdb
 
 import (
-	"reflect"
 	"testing"
 	"time"
-	"unsafe"
 
 	_ "github.com/lib/pq"
 	migrate "github.com/rubenv/sql-migrate"
@@ -52,18 +50,7 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 	require.NoError(t, err)
 
 	// Creating first asset:
-	//firstTime := time.Now()
-	firstTimeTmpl := &time.Time{}
-	{
-		firstTimeValue := reflect.ValueOf(firstTimeTmpl).Elem()
-		wallField := firstTimeValue.FieldByName("wall")
-		reflect.NewAt(wallField.Type(), unsafe.Pointer(wallField.UnsafeAddr())).Elem().SetUint(0xbf5a63f0b825c654)
-		extField := firstTimeValue.FieldByName("ext")
-		reflect.NewAt(extField.Type(), unsafe.Pointer(extField.UnsafeAddr())).Elem().SetInt(353520401)
-		locField := firstTimeValue.FieldByName("loc")
-		reflect.NewAt(locField.Type(), unsafe.Pointer(locField.UnsafeAddr())).Elem().Set(reflect.ValueOf(time.Local))
-	}
-	firstTime := *firstTimeTmpl
+	firstTime := time.Now()
 	a := Asset{
 		Code:          code,
 		IssuerAccount: issuerAccount,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Change the `TestInsertOrUpdateAsset` test to `Round` instead of `Truncate` time values that are being compared with time that was stored in Postgres.

### Goal and scope

Intermittently the `TestInsertOrUpdateAsset` test will fail because a time value that's been stored in Postgres doesn't match the time value we gave to Postgres to store. We attempt to do our best to make them match by using the `Truncate` value on both the input and output values, but that doesn't work for some cases.

I managed to reproduce the failure 100% of the time by using a specific input time of `12:08:50.9419997` where the `milliseconds` component will be rounded up because of the values in the `nanosecond` component by Postgres when it reduces the value to `microseconds`. To see the exact failure case, take a look at the first commit where I hardcoded it for consistent failures. This isn't the only failure case though. When I ran the tests thousands of times I had plenty of times where it failed. Because we use the `Truncate` function, we are comparing a rounded down value with a rounded up value in any cases where the millisecond component gets rounded up when the microsecond component is rounded up.

To illustrate exactly what is happening here, this is our original time:
```
12:08:50.9419997
```

When Postgres is truncating it to microseconds, which is six decimal places, it is rounding to the nearest, which in this case is up:
```
12:08:50.942000
```

In our test we use the truncate function to truncate to milliseconds:
```
12:08:50.941
```

Using `Round` instead causes us to round up to the same value.

Close #1733 

### Summary of changes

- Replace use of `Truncate` with `Round`.

### Known limitations & issues

The fix in this change isn't perfect according to discussion at https://github.com/lib/pq/issues/227#issuecomment-33869993, where a commenter states that Postgres' rounding function rounds to nearest and *in the event of a tie rounds to even*, which is different to Go's `Round` function which rounds to nearest and *in the event of a tie rounds away from zero*. This would cause a problem in this situation:

However, in the tests I ran with time `12:08:50.9419995` and rounding to the nearest `microsecond`, both Postgres and Go had rounded in the same directions, so I don't see evidence that this is an issue.

Even if this was still an issue I think this change is the best simple change we can make to the test and it would significantly reduce the number of cases this test fails.

### What shouldn't be reviewed

N/A
