### PR TITLE
all: Upgrade to protocol v12

### DIFF
--- a/build/allow_trust.go
+++ b/build/allow_trust.go
@@ -58,12 +58,12 @@ func (m AllowTrustAsset) MutateAllowTrust(o *xdr.AllowTrustOp) (err error) {
 
 	switch {
 	case length >= 1 && length <= 4:
-		var code [4]byte
+		var code xdr.AssetCode4
 		byteArray := []byte(m.Code)
 		copy(code[:], byteArray[0:length])
 		o.Asset, err = xdr.NewAllowTrustOpAsset(xdr.AssetTypeAssetTypeCreditAlphanum4, code)
 	case length >= 5 && length <= 12:
-		var code [12]byte
+		var code xdr.AssetCode12
 		byteArray := []byte(m.Code)
 		copy(code[:], byteArray[0:length])
 		o.Asset, err = xdr.NewAllowTrustOpAsset(xdr.AssetTypeAssetTypeCreditAlphanum12, code)

--- a/build/allow_trust_test.go
+++ b/build/allow_trust_test.go
@@ -71,7 +71,7 @@ var _ = Describe("AllowTrustBuilder Mutators", func() {
 
 			It("sets Asset properly", func() {
 				Expect(subject.AT.Asset.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum4))
-				Expect(*subject.AT.Asset.AssetCode4).To(Equal([4]byte{'U', 'S', 'D', 0}))
+				Expect(*subject.AT.Asset.AssetCode4).To(Equal(xdr.AssetCode4{'U', 'S', 'D', 0}))
 				Expect(subject.AT.Asset.AssetCode12).To(BeNil())
 			})
 		})
@@ -84,7 +84,7 @@ var _ = Describe("AllowTrustBuilder Mutators", func() {
 			It("sets Asset properly", func() {
 				Expect(subject.AT.Asset.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum12))
 				Expect(subject.AT.Asset.AssetCode4).To(BeNil())
-				Expect(*subject.AT.Asset.AssetCode12).To(Equal([12]byte{'A', 'B', 'C', 'D', 'E', 'F', 0, 0, 0, 0, 0, 0}))
+				Expect(*subject.AT.Asset.AssetCode12).To(Equal(xdr.AssetCode12{'A', 'B', 'C', 'D', 'E', 'F', 0, 0, 0, 0, 0, 0}))
 			})
 		})
 

--- a/build/asset.go
+++ b/build/asset.go
@@ -29,13 +29,13 @@ func (a Asset) ToXDR() (xdr.Asset, error) {
 	length := len(a.Code)
 	switch {
 	case length >= 1 && length <= 4:
-		var codeArray [4]byte
+		var codeArray xdr.AssetCode4
 		byteArray := []byte(a.Code)
 		copy(codeArray[:], byteArray[0:length])
 		asset := xdr.AssetAlphaNum4{AssetCode: codeArray, Issuer: issuer}
 		return xdr.NewAsset(xdr.AssetTypeAssetTypeCreditAlphanum4, asset)
 	case length >= 5 && length <= 12:
-		var codeArray [12]byte
+		var codeArray xdr.AssetCode12
 		byteArray := []byte(a.Code)
 		copy(codeArray[:], byteArray[0:length])
 		asset := xdr.AssetAlphaNum12{AssetCode: codeArray, Issuer: issuer}

--- a/build/asset_test.go
+++ b/build/asset_test.go
@@ -32,7 +32,7 @@ func TestAsset_ToXDR(t *testing.T) {
 			Expected: xdr.Asset{
 				Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
 				AlphaNum4: &xdr.AssetAlphaNum4{
-					AssetCode: [4]byte{0x55, 0x53, 0x44, 0x00}, //USD
+					AssetCode: xdr.AssetCode4{0x55, 0x53, 0x44, 0x00}, //USD
 					Issuer:    issuer,
 				},
 			},

--- a/build/change_trust_test.go
+++ b/build/change_trust_test.go
@@ -50,7 +50,7 @@ var _ = Describe("ChangeTrustBuilder Mutators", func() {
 
 			It("sets Asset properly", func() {
 				Expect(subject.CT.Line.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum4))
-				Expect(subject.CT.Line.AlphaNum4.AssetCode).To(Equal([4]byte{'U', 'S', 'D', 0}))
+				Expect(subject.CT.Line.AlphaNum4.AssetCode).To(Equal(xdr.AssetCode4{'U', 'S', 'D', 0}))
 				Expect(subject.CT.Line.AlphaNum12).To(BeNil())
 			})
 		})
@@ -63,7 +63,7 @@ var _ = Describe("ChangeTrustBuilder Mutators", func() {
 			It("sets Asset properly", func() {
 				Expect(subject.CT.Line.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum12))
 				Expect(subject.CT.Line.AlphaNum4).To(BeNil())
-				Expect(subject.CT.Line.AlphaNum12.AssetCode).To(Equal([12]byte{'A', 'B', 'C', 'D', 'E', 'F', 0, 0, 0, 0, 0, 0}))
+				Expect(subject.CT.Line.AlphaNum12.AssetCode).To(Equal(xdr.AssetCode12{'A', 'B', 'C', 'D', 'E', 'F', 0, 0, 0, 0, 0, 0}))
 			})
 		})
 

--- a/build/manage_offer_test.go
+++ b/build/manage_offer_test.go
@@ -36,7 +36,7 @@ var _ = Describe("ManageOffer", func() {
 					Expect(builder.MO.Amount).To(Equal(xdr.Int64(200000000)))
 
 					Expect(builder.MO.Selling.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum4))
-					Expect(builder.MO.Selling.AlphaNum4.AssetCode).To(Equal([4]byte{'E', 'U', 'R', 0}))
+					Expect(builder.MO.Selling.AlphaNum4.AssetCode).To(Equal(xdr.AssetCode4{'E', 'U', 'R', 0}))
 					var aid xdr.AccountId
 					aid.SetAddress(rate.Selling.Issuer)
 					Expect(builder.MO.Selling.AlphaNum4.Issuer.MustEd25519()).To(Equal(aid.MustEd25519()))
@@ -62,7 +62,7 @@ var _ = Describe("ManageOffer", func() {
 					Expect(builder.MO.Amount).To(Equal(xdr.Int64(1000000000)))
 
 					Expect(builder.MO.Selling.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum4))
-					Expect(builder.MO.Selling.AlphaNum4.AssetCode).To(Equal([4]byte{'E', 'U', 'R', 0}))
+					Expect(builder.MO.Selling.AlphaNum4.AssetCode).To(Equal(xdr.AssetCode4{'E', 'U', 'R', 0}))
 					var aid xdr.AccountId
 					aid.SetAddress(rate.Selling.Issuer)
 					Expect(builder.MO.Selling.AlphaNum4.Issuer.MustEd25519()).To(Equal(aid.MustEd25519()))
@@ -88,7 +88,7 @@ var _ = Describe("ManageOffer", func() {
 					Expect(builder.MO.Amount).To(Equal(xdr.Int64(0)))
 
 					Expect(builder.MO.Selling.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum4))
-					Expect(builder.MO.Selling.AlphaNum4.AssetCode).To(Equal([4]byte{'E', 'U', 'R', 0}))
+					Expect(builder.MO.Selling.AlphaNum4.AssetCode).To(Equal(xdr.AssetCode4{'E', 'U', 'R', 0}))
 					var aid xdr.AccountId
 					aid.SetAddress(rate.Selling.Issuer)
 					Expect(builder.MO.Selling.AlphaNum4.Issuer.MustEd25519()).To(Equal(aid.MustEd25519()))
@@ -153,7 +153,7 @@ var _ = Describe("ManageOffer", func() {
 					Expect(builder.PO.Amount).To(Equal(xdr.Int64(200000000)))
 
 					Expect(builder.PO.Selling.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum4))
-					Expect(builder.PO.Selling.AlphaNum4.AssetCode).To(Equal([4]byte{'E', 'U', 'R', 0}))
+					Expect(builder.PO.Selling.AlphaNum4.AssetCode).To(Equal(xdr.AssetCode4{'E', 'U', 'R', 0}))
 					var aid xdr.AccountId
 					aid.SetAddress(rate.Selling.Issuer)
 					Expect(builder.PO.Selling.AlphaNum4.Issuer.MustEd25519()).To(Equal(aid.MustEd25519()))

--- a/build/payment.go
+++ b/build/payment.go
@@ -26,7 +26,7 @@ type PaymentBuilder struct {
 	PathPayment bool
 	O           xdr.Operation
 	P           xdr.PaymentOp
-	PP          xdr.PathPaymentOp
+	PP          xdr.PathPaymentStrictReceiveOp
 	Err         error
 }
 
@@ -73,7 +73,7 @@ func (m CreditAmount) MutatePayment(o interface{}) (err error) {
 		}
 
 		o.Asset, err = createAlphaNumAsset(m.Code, m.Issuer)
-	case *xdr.PathPaymentOp:
+	case *xdr.PathPaymentStrictReceiveOp:
 		o.DestAmount, err = amount.Parse(m.Amount)
 		if err != nil {
 			return
@@ -91,7 +91,7 @@ func (m Destination) MutatePayment(o interface{}) error {
 		return errors.New("Unexpected operation type")
 	case *xdr.PaymentOp:
 		return setAccountId(m.AddressOrSeed, &o.Destination)
-	case *xdr.PathPaymentOp:
+	case *xdr.PathPaymentStrictReceiveOp:
 		return setAccountId(m.AddressOrSeed, &o.Destination)
 	}
 }
@@ -109,7 +109,7 @@ func (m NativeAmount) MutatePayment(o interface{}) (err error) {
 		}
 
 		o.Asset, err = xdr.NewAsset(xdr.AssetTypeAssetTypeNative, nil)
-	case *xdr.PathPaymentOp:
+	case *xdr.PathPaymentStrictReceiveOp:
 		o.DestAmount, err = amount.Parse(m.Amount)
 		if err != nil {
 			return
@@ -123,9 +123,9 @@ func (m NativeAmount) MutatePayment(o interface{}) (err error) {
 // MutatePayment for PayWithPath sets the PathPaymentOp's SendAsset,
 // SendMax and Path fields
 func (m PayWithPath) MutatePayment(o interface{}) (err error) {
-	var pathPaymentOp *xdr.PathPaymentOp
+	var pathPaymentOp *xdr.PathPaymentStrictReceiveOp
 	var ok bool
-	if pathPaymentOp, ok = o.(*xdr.PathPaymentOp); !ok {
+	if pathPaymentOp, ok = o.(*xdr.PathPaymentStrictReceiveOp); !ok {
 		return errors.New("Unexpected operation type")
 	}
 

--- a/build/payment_test.go
+++ b/build/payment_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Payment Mutators", func() {
 				It("sets the asset properly", func() {
 					Expect(subject.P.Amount).To(Equal(xdr.Int64(500000000)))
 					Expect(subject.P.Asset.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum4))
-					Expect(subject.P.Asset.AlphaNum4.AssetCode).To(Equal([4]byte{'U', 'S', 'D', 0}))
+					Expect(subject.P.Asset.AlphaNum4.AssetCode).To(Equal(xdr.AssetCode4{'U', 'S', 'D', 0}))
 					var aid xdr.AccountId
 					aid.SetAddress(address)
 					Expect(subject.P.Asset.AlphaNum4.Issuer.MustEd25519()).To(Equal(aid.MustEd25519()))
@@ -49,7 +49,7 @@ var _ = Describe("Payment Mutators", func() {
 					Expect(subject.P.Amount).To(Equal(xdr.Int64(500000000)))
 					Expect(subject.P.Asset.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum12))
 					Expect(subject.P.Asset.AlphaNum4).To(BeNil())
-					Expect(subject.P.Asset.AlphaNum12.AssetCode).To(Equal([12]byte{'A', 'B', 'C', 'D', 'E', 'F', 0, 0, 0, 0, 0, 0}))
+					Expect(subject.P.Asset.AlphaNum12.AssetCode).To(Equal(xdr.AssetCode12{'A', 'B', 'C', 'D', 'E', 'F', 0, 0, 0, 0, 0, 0}))
 					var aid xdr.AccountId
 					aid.SetAddress(address)
 					Expect(subject.P.Asset.AlphaNum12.Issuer.MustEd25519()).To(Equal(aid.MustEd25519()))
@@ -209,7 +209,7 @@ var _ = Describe("Payment Mutators", func() {
 				It("sets the asset properly", func() {
 					Expect(subject.PP.DestAmount).To(Equal(xdr.Int64(500000000)))
 					Expect(subject.PP.DestAsset.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum4))
-					Expect(subject.PP.DestAsset.AlphaNum4.AssetCode).To(Equal([4]byte{'U', 'S', 'D', 0}))
+					Expect(subject.PP.DestAsset.AlphaNum4.AssetCode).To(Equal(xdr.AssetCode4{'U', 'S', 'D', 0}))
 					var aid xdr.AccountId
 					aid.SetAddress(address)
 					Expect(subject.PP.DestAsset.AlphaNum4.Issuer.MustEd25519()).To(Equal(aid.MustEd25519()))
@@ -228,7 +228,7 @@ var _ = Describe("Payment Mutators", func() {
 					Expect(subject.PP.DestAmount).To(Equal(xdr.Int64(500000000)))
 					Expect(subject.PP.DestAsset.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum12))
 					Expect(subject.PP.DestAsset.AlphaNum4).To(BeNil())
-					Expect(subject.PP.DestAsset.AlphaNum12.AssetCode).To(Equal([12]byte{'A', 'B', 'C', 'D', 'E', 'F', 0, 0, 0, 0, 0, 0}))
+					Expect(subject.PP.DestAsset.AlphaNum12.AssetCode).To(Equal(xdr.AssetCode12{'A', 'B', 'C', 'D', 'E', 'F', 0, 0, 0, 0, 0, 0}))
 					var aid xdr.AccountId
 					aid.SetAddress(address)
 					Expect(subject.PP.DestAsset.AlphaNum12.Issuer.MustEd25519()).To(Equal(aid.MustEd25519()))

--- a/build/transaction.go
+++ b/build/transaction.go
@@ -302,7 +302,7 @@ func (m PaymentBuilder) MutateTransaction(o *TransactionBuilder) error {
 	}
 
 	if m.PathPayment {
-		m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypePathPayment, m.PP)
+		m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypePathPaymentStrictReceive, m.PP)
 		o.TX.Operations = append(o.TX.Operations, m.O)
 		return m.Err
 	}

--- a/build/util.go
+++ b/build/util.go
@@ -29,13 +29,13 @@ func createAlphaNumAsset(code, issuerAccountId string) (xdr.Asset, error) {
 	length := len(code)
 	switch {
 	case length >= 1 && length <= 4:
-		var codeArray [4]byte
+		var codeArray xdr.AssetCode4
 		byteArray := []byte(code)
 		copy(codeArray[:], byteArray[0:length])
 		asset := xdr.AssetAlphaNum4{AssetCode: codeArray, Issuer: issuer}
 		return xdr.NewAsset(xdr.AssetTypeAssetTypeCreditAlphanum4, asset)
 	case length >= 5 && length <= 12:
-		var codeArray [12]byte
+		var codeArray xdr.AssetCode12
 		byteArray := []byte(code)
 		copy(codeArray[:], byteArray[0:length])
 		asset := xdr.AssetAlphaNum12{AssetCode: codeArray, Issuer: issuer}

--- a/govet.sh
+++ b/govet.sh
@@ -1,8 +1,12 @@
 #! /bin/bash
 set -e
 
+cat -n ./keypair/main.go
+
 printf "Running go vet...\n"
 go vet -all -composites=false -unreachable=false -tests=false ./...
+
+cat -n ./keypair/main.go
 
 printf "Running go vet shadow...\n"
 command -v shadow >/dev/null 2>&1 || (
@@ -13,6 +17,8 @@ command -v shadow >/dev/null 2>&1 || (
   popd
 )
 
+cat -n ./keypair/main.go
+
 # The go vet -vettool option was added in 1.12, and broken in the initial 1.13
 # release. Until it is fixed we must call vettool's directly as a work around.
 # https://github.com/golang/go/issues/34053
@@ -21,3 +27,5 @@ if [[ $GOLANG_VERSION = 1.12.* ]]; then
 else
   shadow ./...
 fi
+
+cat -n ./keypair/main.go

--- a/govet.sh
+++ b/govet.sh
@@ -1,12 +1,8 @@
 #! /bin/bash
 set -e
 
-cat -n ./keypair/main.go
-
 printf "Running go vet...\n"
 go vet -all -composites=false -unreachable=false -tests=false ./...
-
-cat -n ./keypair/main.go
 
 printf "Running go vet shadow...\n"
 command -v shadow >/dev/null 2>&1 || (
@@ -17,8 +13,6 @@ command -v shadow >/dev/null 2>&1 || (
   popd
 )
 
-cat -n ./keypair/main.go
-
 # The go vet -vettool option was added in 1.12, and broken in the initial 1.13
 # release. Until it is fixed we must call vettool's directly as a work around.
 # https://github.com/golang/go/issues/34053
@@ -27,5 +21,3 @@ if [[ $GOLANG_VERSION = 1.12.* ]]; then
 else
   shadow ./...
 fi
-
-cat -n ./keypair/main.go

--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -16,7 +16,9 @@ import (
 var TypeNames = map[xdr.OperationType]string{
 	xdr.OperationTypeCreateAccount: "create_account",
 	xdr.OperationTypePayment:       "payment",
-	xdr.OperationTypePathPayment:   "path_payment",
+	// Action needed in release: horizon-v0.22.0
+	// Change name to `path_payment_strict_receive`
+	xdr.OperationTypePathPaymentStrictReceive: "path_payment",
 	// Action needed in release: horizon-v0.22.0
 	// Change name to `manage_sell_offer`
 	xdr.OperationTypeManageSellOffer: "manage_offer",
@@ -31,6 +33,7 @@ var TypeNames = map[xdr.OperationType]string{
 	xdr.OperationTypeManageData:             "manage_data",
 	xdr.OperationTypeBumpSequence:           "bump_sequence",
 	xdr.OperationTypeManageBuyOffer:         "manage_buy_offer",
+	xdr.OperationTypePathPaymentStrictSend:  "path_payment_strict_send",
 }
 
 // Base represents the common attributes of an operation resource
@@ -99,6 +102,18 @@ type PathPayment struct {
 	Path              []base.Asset `json:"path"`
 	SourceAmount      string       `json:"source_amount"`
 	SourceMax         string       `json:"source_max"`
+	SourceAssetType   string       `json:"source_asset_type"`
+	SourceAssetCode   string       `json:"source_asset_code,omitempty"`
+	SourceAssetIssuer string       `json:"source_asset_issuer,omitempty"`
+}
+
+// PathPaymentStrictSend is the json resource representing a single operation whose type
+// is PathPaymentStrictSend.
+type PathPaymentStrictSend struct {
+	Payment
+	Path              []base.Asset `json:"path"`
+	SourceAmount      string       `json:"source_amount"`
+	DestinationMin    string       `json:"destination_min"`
 	SourceAssetType   string       `json:"source_asset_type"`
 	SourceAssetCode   string       `json:"source_asset_code,omitempty"`
 	SourceAssetIssuer string       `json:"source_asset_issuer,omitempty"`
@@ -286,7 +301,7 @@ func UnmarshalOperation(operationTypeID int32, dataString []byte) (ops Operation
 			return
 		}
 		ops = op
-	case xdr.OperationTypePathPayment:
+	case xdr.OperationTypePathPaymentStrictReceive:
 		var op PathPayment
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return
@@ -354,6 +369,12 @@ func UnmarshalOperation(operationTypeID int32, dataString []byte) (ops Operation
 		ops = op
 	case xdr.OperationTypeManageBuyOffer:
 		var op ManageBuyOffer
+		if err = json.Unmarshal(dataString, &op); err != nil {
+			return
+		}
+		ops = op
+	case xdr.OperationTypePathPaymentStrictSend:
+		var op PathPaymentStrictSend
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return
 		}

--- a/services/compliance/internal/handlers/request_handler_auth.go
+++ b/services/compliance/internal/handlers/request_handler_auth.go
@@ -264,9 +264,12 @@ func (rh *RequestHandler) HandlerAuth(w http.ResponseWriter, r *http.Request) {
 				if operationBody.Type == xdr.OperationTypePayment {
 					amount = baseAmount.String(operationBody.PaymentOp.Amount)
 					operationBody.PaymentOp.Asset.Extract(&assetType, &assetCode, &assetIssuer)
-				} else if operationBody.Type == xdr.OperationTypePathPayment {
-					amount = baseAmount.String(operationBody.PathPaymentOp.DestAmount)
-					operationBody.PathPaymentOp.DestAsset.Extract(&assetType, &assetCode, &assetIssuer)
+				} else if operationBody.Type == xdr.OperationTypePathPaymentStrictReceive {
+					amount = baseAmount.String(operationBody.PathPaymentStrictReceiveOp.DestAmount)
+					operationBody.PathPaymentStrictReceiveOp.DestAsset.Extract(&assetType, &assetCode, &assetIssuer)
+				} else if operationBody.Type == xdr.OperationTypePathPaymentStrictSend {
+					amount = baseAmount.String(operationBody.PathPaymentStrictSendOp.DestMin)
+					operationBody.PathPaymentStrictSendOp.DestAsset.Extract(&assetType, &assetCode, &assetIssuer)
 				}
 			}
 

--- a/services/horizon/internal/codes/main.go
+++ b/services/horizon/internal/codes/main.go
@@ -115,33 +115,33 @@ func String(code interface{}) (string, error) {
 		case xdr.PaymentResultCodePaymentNoIssuer:
 			return OpNoIssuer, nil
 		}
-	case xdr.PathPaymentResultCode:
+	case xdr.PathPaymentStrictReceiveResultCode:
 		switch code {
-		case xdr.PathPaymentResultCodePathPaymentSuccess:
+		case xdr.PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSuccess:
 			return OpSuccess, nil
-		case xdr.PathPaymentResultCodePathPaymentMalformed:
+		case xdr.PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveMalformed:
 			return OpMalformed, nil
-		case xdr.PathPaymentResultCodePathPaymentUnderfunded:
+		case xdr.PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveUnderfunded:
 			return OpUnderfunded, nil
-		case xdr.PathPaymentResultCodePathPaymentSrcNoTrust:
+		case xdr.PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSrcNoTrust:
 			return "op_src_no_trust", nil
-		case xdr.PathPaymentResultCodePathPaymentSrcNotAuthorized:
+		case xdr.PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSrcNotAuthorized:
 			return "op_src_not_authorized", nil
-		case xdr.PathPaymentResultCodePathPaymentNoDestination:
+		case xdr.PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoDestination:
 			return "op_no_destination", nil
-		case xdr.PathPaymentResultCodePathPaymentNoTrust:
+		case xdr.PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoTrust:
 			return "op_no_trust", nil
-		case xdr.PathPaymentResultCodePathPaymentNotAuthorized:
+		case xdr.PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNotAuthorized:
 			return "op_not_authorized", nil
-		case xdr.PathPaymentResultCodePathPaymentLineFull:
+		case xdr.PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveLineFull:
 			return OpLineFull, nil
-		case xdr.PathPaymentResultCodePathPaymentNoIssuer:
+		case xdr.PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoIssuer:
 			return OpNoIssuer, nil
-		case xdr.PathPaymentResultCodePathPaymentTooFewOffers:
+		case xdr.PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveTooFewOffers:
 			return "op_too_few_offers", nil
-		case xdr.PathPaymentResultCodePathPaymentOfferCrossSelf:
+		case xdr.PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveOfferCrossSelf:
 			return "op_cross_self", nil
-		case xdr.PathPaymentResultCodePathPaymentOverSendmax:
+		case xdr.PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveOverSendmax:
 			return "op_over_source_max", nil
 		}
 	case xdr.ManageBuyOfferResultCode:
@@ -297,6 +297,36 @@ func String(code interface{}) (string, error) {
 		case xdr.BumpSequenceResultCodeBumpSequenceBadSeq:
 			return "op_bad_seq", nil
 		}
+
+	case xdr.PathPaymentStrictSendResultCode:
+		switch code {
+		case xdr.PathPaymentStrictSendResultCodePathPaymentStrictSendSuccess:
+			return OpSuccess, nil
+		case xdr.PathPaymentStrictSendResultCodePathPaymentStrictSendMalformed:
+			return OpMalformed, nil
+		case xdr.PathPaymentStrictSendResultCodePathPaymentStrictSendUnderfunded:
+			return OpUnderfunded, nil
+		case xdr.PathPaymentStrictSendResultCodePathPaymentStrictSendSrcNoTrust:
+			return "op_src_no_trust", nil
+		case xdr.PathPaymentStrictSendResultCodePathPaymentStrictSendSrcNotAuthorized:
+			return "op_src_not_authorized", nil
+		case xdr.PathPaymentStrictSendResultCodePathPaymentStrictSendNoDestination:
+			return "op_no_destination", nil
+		case xdr.PathPaymentStrictSendResultCodePathPaymentStrictSendNoTrust:
+			return "op_no_trust", nil
+		case xdr.PathPaymentStrictSendResultCodePathPaymentStrictSendNotAuthorized:
+			return "op_not_authorized", nil
+		case xdr.PathPaymentStrictSendResultCodePathPaymentStrictSendLineFull:
+			return OpLineFull, nil
+		case xdr.PathPaymentStrictSendResultCodePathPaymentStrictSendNoIssuer:
+			return OpNoIssuer, nil
+		case xdr.PathPaymentStrictSendResultCodePathPaymentStrictSendTooFewOffers:
+			return "op_too_few_offers", nil
+		case xdr.PathPaymentStrictSendResultCodePathPaymentStrictSendOfferCrossSelf:
+			return "op_cross_self", nil
+		case xdr.PathPaymentStrictSendResultCodePathPaymentStrictSendUnderDestmin:
+			return "op_under_dest_min", nil
+		}
 	}
 
 	return "", errors.New(ErrUnknownCode)
@@ -317,8 +347,8 @@ func ForOperationResult(opr xdr.OperationResult) (string, error) {
 		ic = ir.MustCreateAccountResult().Code
 	case xdr.OperationTypePayment:
 		ic = ir.MustPaymentResult().Code
-	case xdr.OperationTypePathPayment:
-		ic = ir.MustPathPaymentResult().Code
+	case xdr.OperationTypePathPaymentStrictReceive:
+		ic = ir.MustPathPaymentStrictReceiveResult().Code
 	case xdr.OperationTypeManageBuyOffer:
 		ic = ir.MustManageBuyOfferResult().Code
 	case xdr.OperationTypeManageSellOffer:
@@ -339,6 +369,8 @@ func ForOperationResult(opr xdr.OperationResult) (string, error) {
 		ic = ir.MustManageDataResult().Code
 	case xdr.OperationTypeBumpSequence:
 		ic = ir.MustBumpSeqResult().Code
+	case xdr.OperationTypePathPaymentStrictSend:
+		ic = ir.MustPathPaymentStrictSendResult().Code
 	}
 
 	return String(ic)

--- a/services/horizon/internal/db2/history/operation.go
+++ b/services/horizon/internal/db2/history/operation.go
@@ -166,7 +166,8 @@ func (q *OperationsQ) OnlyPayments() *OperationsQ {
 	q.sql = q.sql.Where(sq.Eq{"hop.type": []xdr.OperationType{
 		xdr.OperationTypeCreateAccount,
 		xdr.OperationTypePayment,
-		xdr.OperationTypePathPayment,
+		xdr.OperationTypePathPaymentStrictReceive,
+		xdr.OperationTypePathPaymentStrictSend,
 		xdr.OperationTypeAccountMerge,
 	}})
 	return q

--- a/services/horizon/internal/db2/history/operation_test.go
+++ b/services/horizon/internal/db2/history/operation_test.go
@@ -169,7 +169,7 @@ func TestPaymentsSuccessfulOnly(t *testing.T) {
 	sql, _, err := query.sql.ToSql()
 	tt.Assert.NoError(err)
 	// Note: brackets around `(ht.successful = true OR ht.successful IS NULL)` are critical!
-	tt.Assert.Contains(sql, "WHERE hop.type IN (?,?,?,?) AND hopp.history_account_id = ? AND (ht.successful = true OR ht.successful IS NULL)")
+	tt.Assert.Contains(sql, "WHERE hop.type IN (?,?,?,?,?) AND hopp.history_account_id = ? AND (ht.successful = true OR ht.successful IS NULL)")
 }
 
 // TestPaymentsIncludeFailed tests `IncludeFailed` method.
@@ -201,7 +201,7 @@ func TestPaymentsIncludeFailed(t *testing.T) {
 
 	sql, _, err := query.sql.ToSql()
 	tt.Assert.NoError(err)
-	tt.Assert.Equal("SELECT hop.id, hop.transaction_id, hop.application_order, hop.type, hop.details, hop.source_account, ht.transaction_hash, ht.tx_result, ht.successful as transaction_successful FROM history_operations hop LEFT JOIN history_transactions ht ON ht.id = hop.transaction_id JOIN history_operation_participants hopp ON hopp.history_operation_id = hop.id WHERE hop.type IN (?,?,?,?) AND hopp.history_account_id = ?", sql)
+	tt.Assert.Equal("SELECT hop.id, hop.transaction_id, hop.application_order, hop.type, hop.details, hop.source_account, ht.transaction_hash, ht.tx_result, ht.successful as transaction_successful FROM history_operations hop LEFT JOIN history_transactions ht ON ht.id = hop.transaction_id JOIN history_operation_participants hopp ON hopp.history_operation_id = hop.id WHERE hop.type IN (?,?,?,?,?) AND hopp.history_account_id = ?", sql)
 }
 
 func TestExtraChecksOperationsTransactionSuccessfulTrueResultFalse(t *testing.T) {

--- a/services/horizon/internal/db2/schema/bindata.go
+++ b/services/horizon/internal/db2/schema/bindata.go
@@ -11,6 +11,7 @@
 // migrations/18_account_for_signers.sql (481B)
 // migrations/19_offers.sql (1.064kB)
 // migrations/1_initial_schema.sql (10.515kB)
+// migrations/21_trades_remove_zero_amount_constraints.sql (765B)
 // migrations/2_index_participants_by_toid.sql (277B)
 // migrations/3_use_sequence_in_history_accounts.sql (447B)
 // migrations/4_add_protocol_version.sql (188B)
@@ -103,7 +104,7 @@ func migrations10_add_trades_priceSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/10_add_trades_price.sql", size: 1220, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/10_add_trades_price.sql", size: 1220, mode: os.FileMode(0644), modTime: time.Unix(1535025415, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x85, 0x1e, 0x7f, 0x86, 0xc2, 0x2c, 0xc9, 0x91, 0xe2, 0x3f, 0x1a, 0xb2, 0x15, 0xea, 0x6c, 0x5, 0xfa, 0x1f, 0x99, 0xd2, 0xbb, 0x1, 0x5e, 0x75, 0x91, 0x8b, 0xb, 0x46, 0xa, 0x6, 0xbc, 0x61}}
 	return a, nil
 }
@@ -123,7 +124,7 @@ func migrations11_add_trades_account_indexSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/11_add_trades_account_index.sql", size: 273, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/11_add_trades_account_index.sql", size: 273, mode: os.FileMode(0644), modTime: time.Unix(1535025415, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x98, 0xa4, 0x60, 0x40, 0x6b, 0xa6, 0x5e, 0xcc, 0x67, 0xb3, 0x85, 0x82, 0xce, 0x39, 0xc6, 0xbb, 0x2c, 0xa7, 0x2e, 0xb6, 0x9a, 0xd, 0xba, 0x91, 0x28, 0x80, 0x77, 0x46, 0x8c, 0x67, 0x55, 0x9f}}
 	return a, nil
 }
@@ -143,7 +144,7 @@ func migrations12_asset_stats_amount_stringSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/12_asset_stats_amount_string.sql", size: 197, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/12_asset_stats_amount_string.sql", size: 197, mode: os.FileMode(0644), modTime: time.Unix(1535025415, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3a, 0xd1, 0x4c, 0x37, 0xe7, 0xfd, 0xdb, 0x3a, 0xf2, 0x37, 0x9b, 0x8d, 0x77, 0x99, 0x61, 0x15, 0x10, 0x51, 0xe5, 0xe5, 0x7f, 0xec, 0x7e, 0x7, 0xe5, 0x18, 0x8a, 0xf2, 0xb4, 0x66, 0x17, 0x60}}
 	return a, nil
 }
@@ -163,7 +164,7 @@ func migrations13_trade_offer_idsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/13_trade_offer_ids.sql", size: 484, mode: os.FileMode(0644), modTime: time.Unix(1566996542, 0)}
+	info := bindataFileInfo{name: "migrations/13_trade_offer_ids.sql", size: 484, mode: os.FileMode(0644), modTime: time.Unix(1567680202, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x77, 0x71, 0x79, 0x45, 0x9b, 0x9e, 0x80, 0x36, 0x80, 0x5a, 0xc2, 0x1f, 0xb4, 0xba, 0xdd, 0x85, 0x65, 0xd0, 0x5c, 0x47, 0x47, 0xf, 0x4d, 0xc7, 0x9b, 0x92, 0x36, 0xd7, 0xe6, 0x57, 0x46, 0xa}}
 	return a, nil
 }
@@ -183,7 +184,7 @@ func migrations14_fix_asset_toml_fieldSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/14_fix_asset_toml_field.sql", size: 156, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/14_fix_asset_toml_field.sql", size: 156, mode: os.FileMode(0644), modTime: time.Unix(1547162949, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xdf, 0x28, 0x86, 0x8, 0xa5, 0xec, 0x44, 0x7b, 0xf7, 0x88, 0x3b, 0x6d, 0xf6, 0x5c, 0x6a, 0x17, 0x92, 0xbc, 0xd2, 0x88, 0x94, 0xd4, 0x42, 0xb1, 0xc2, 0xac, 0x97, 0xb6, 0xd0, 0xeb, 0xd8, 0xa7}}
 	return a, nil
 }
@@ -203,7 +204,7 @@ func migrations15_ledger_failed_txsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/15_ledger_failed_txs.sql", size: 333, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/15_ledger_failed_txs.sql", size: 333, mode: os.FileMode(0644), modTime: time.Unix(1549313787, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xeb, 0x7, 0xd7, 0xc9, 0x5d, 0xbe, 0xd2, 0x21, 0xc1, 0xb0, 0x20, 0xc8, 0x5f, 0x3a, 0xe9, 0x99, 0xba, 0x5d, 0x83, 0xb4, 0xe8, 0x9f, 0x2d, 0xc3, 0x9a, 0xe1, 0x46, 0xf2, 0xd1, 0x1b, 0x48, 0x7a}}
 	return a, nil
 }
@@ -223,7 +224,7 @@ func migrations16_ingest_failed_transactionsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/16_ingest_failed_transactions.sql", size: 509, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/16_ingest_failed_transactions.sql", size: 509, mode: os.FileMode(0644), modTime: time.Unix(1552435564, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xf9, 0x24, 0xd, 0x8a, 0x56, 0x1d, 0x41, 0x6a, 0x4, 0x7b, 0xe1, 0x9f, 0xfb, 0x78, 0x2, 0xec, 0xe2, 0x98, 0xac, 0xef, 0xc7, 0xc0, 0x96, 0xd1, 0xbf, 0x8f, 0xc6, 0x16, 0xa7, 0x3c, 0x4a, 0x33}}
 	return a, nil
 }
@@ -243,7 +244,7 @@ func migrations17_transaction_fee_paidSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/17_transaction_fee_paid.sql", size: 287, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/17_transaction_fee_paid.sql", size: 287, mode: os.FileMode(0644), modTime: time.Unix(1560443961, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x64, 0x93, 0x1c, 0x21, 0xf6, 0x63, 0xac, 0x5c, 0x8, 0x6b, 0xe9, 0x4f, 0xcb, 0xcb, 0xae, 0xdf, 0xa, 0x28, 0xa8, 0x6a, 0xfd, 0x61, 0x29, 0xc2, 0x60, 0xaf, 0xb7, 0x74, 0xfd, 0x0, 0x85, 0xb7}}
 	return a, nil
 }
@@ -263,7 +264,7 @@ func migrations18_account_for_signersSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/18_account_for_signers.sql", size: 481, mode: os.FileMode(0644), modTime: time.Unix(1566913223, 0)}
+	info := bindataFileInfo{name: "migrations/18_account_for_signers.sql", size: 481, mode: os.FileMode(0644), modTime: time.Unix(1565013256, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x37, 0xdc, 0xe4, 0xb4, 0xd5, 0xcc, 0x53, 0xd9, 0x42, 0x8c, 0x12, 0x37, 0xcf, 0x13, 0x2c, 0x47, 0xe, 0xc7, 0xba, 0xe5, 0xc2, 0x17, 0x73, 0xe2, 0xc, 0xd2, 0x4a, 0xb3, 0x62, 0x75, 0x54, 0x7f}}
 	return a, nil
 }
@@ -283,7 +284,7 @@ func migrations19_offersSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/19_offers.sql", size: 1064, mode: os.FileMode(0644), modTime: time.Unix(1566913223, 0)}
+	info := bindataFileInfo{name: "migrations/19_offers.sql", size: 1064, mode: os.FileMode(0644), modTime: time.Unix(1567081172, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xbd, 0xff, 0xef, 0xfe, 0xb0, 0x5b, 0xa3, 0x92, 0xac, 0x9d, 0x98, 0x6c, 0xd4, 0x90, 0x9c, 0xe9, 0xae, 0x89, 0xfc, 0x54, 0x2b, 0xe3, 0x33, 0x1f, 0x0, 0xd6, 0x24, 0x9a, 0x1, 0xe1, 0xa6, 0x39}}
 	return a, nil
 }
@@ -303,8 +304,28 @@ func migrations1_initial_schemaSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/1_initial_schema.sql", size: 10515, mode: os.FileMode(0644), modTime: time.Unix(1566913223, 0)}
+	info := bindataFileInfo{name: "migrations/1_initial_schema.sql", size: 10515, mode: os.FileMode(0644), modTime: time.Unix(1567081172, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x27, 0x3e, 0x89, 0x23, 0x20, 0x34, 0xb6, 0xbd, 0x18, 0x3b, 0x51, 0x34, 0xc7, 0x59, 0x7, 0x1c, 0xb2, 0x7, 0x26, 0x3b, 0x9b, 0x75, 0xf4, 0x65, 0xff, 0xcb, 0x12, 0xe0, 0xd6, 0xa1, 0xfa, 0xa8}}
+	return a, nil
+}
+
+var _migrations21_trades_remove_zero_amount_constraintsSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xd2\xd5\x55\xd0\xce\xcd\x4c\x2f\x4a\x2c\x49\x55\x08\x2d\xe0\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\xc8\xc8\x2c\x2e\xc9\x2f\xaa\x8c\x2f\x29\x4a\x4c\x49\x2d\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x0b\x0e\x09\x72\xf4\xf4\x0b\x41\x93\x8e\x4f\x4a\x2c\x4e\x8d\x4f\xcc\xcd\x2f\xcd\x2b\x89\x4f\xce\x48\x4d\xce\xb6\xa6\xc0\xb0\x64\x90\x31\xa9\x45\x68\xe6\xe1\x33\xd0\xd1\xc5\x85\x14\xc7\x29\x38\x7b\xb8\x3a\x7b\x2b\x68\x20\x49\x28\xd8\xd9\x2a\x18\x68\xe2\x75\x35\x7e\x4b\xb0\x39\x1a\x66\x0f\xaa\x1c\xcc\x2a\x2e\xe4\xe0\x77\xc9\x2f\xcf\x1b\xe1\x11\x40\xbf\xf0\x07\xdb\x04\x08\x00\x00\xff\xff\xfc\x1d\x38\xf5\xfd\x02\x00\x00")
+
+func migrations21_trades_remove_zero_amount_constraintsSqlBytes() ([]byte, error) {
+	return bindataRead(
+		_migrations21_trades_remove_zero_amount_constraintsSql,
+		"migrations/21_trades_remove_zero_amount_constraints.sql",
+	)
+}
+
+func migrations21_trades_remove_zero_amount_constraintsSql() (*asset, error) {
+	bytes, err := migrations21_trades_remove_zero_amount_constraintsSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "migrations/21_trades_remove_zero_amount_constraints.sql", size: 765, mode: os.FileMode(0644), modTime: time.Unix(1569417410, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x24, 0x1a, 0x4b, 0x15, 0xd5, 0xce, 0x4, 0xe9, 0x43, 0x61, 0x69, 0xce, 0xed, 0x82, 0x11, 0x4e, 0xc7, 0x58, 0xef, 0x4a, 0x46, 0xef, 0x2a, 0x28, 0x13, 0x5e, 0x59, 0xf0, 0x69, 0x50, 0x45, 0x84}}
 	return a, nil
 }
 
@@ -323,7 +344,7 @@ func migrations2_index_participants_by_toidSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/2_index_participants_by_toid.sql", size: 277, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/2_index_participants_by_toid.sql", size: 277, mode: os.FileMode(0644), modTime: time.Unix(1510233604, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xdd, 0x9f, 0x5c, 0xe6, 0xd0, 0x43, 0x82, 0xa3, 0x8d, 0xb3, 0x64, 0xb1, 0x2, 0x4b, 0xe1, 0x96, 0x3, 0x92, 0xb3, 0xea, 0x3c, 0x2e, 0xb2, 0xad, 0x47, 0xcd, 0x92, 0x4c, 0x6c, 0x5c, 0x46, 0xfd}}
 	return a, nil
 }
@@ -343,7 +364,7 @@ func migrations3_use_sequence_in_history_accountsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/3_use_sequence_in_history_accounts.sql", size: 447, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/3_use_sequence_in_history_accounts.sql", size: 447, mode: os.FileMode(0644), modTime: time.Unix(1510233604, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x5, 0xcc, 0xcc, 0x51, 0xec, 0x12, 0x8, 0x85, 0x4d, 0x85, 0x25, 0x32, 0x18, 0x23, 0x54, 0xc5, 0x10, 0x42, 0x5b, 0x51, 0x28, 0xe4, 0x9, 0xa2, 0x56, 0xdc, 0xb5, 0xf8, 0x41, 0x1b, 0x28, 0x8}}
 	return a, nil
 }
@@ -363,7 +384,7 @@ func migrations4_add_protocol_versionSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/4_add_protocol_version.sql", size: 188, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/4_add_protocol_version.sql", size: 188, mode: os.FileMode(0644), modTime: time.Unix(1510233604, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x26, 0x7f, 0xb6, 0x87, 0x30, 0xa5, 0x8c, 0xee, 0x55, 0xbb, 0x12, 0x6, 0x1b, 0xee, 0xfc, 0x6a, 0xa0, 0x71, 0x60, 0xcc, 0xf7, 0x36, 0x56, 0xb3, 0x39, 0x1f, 0x1a, 0xd2, 0x6, 0xe4, 0x58, 0x8e}}
 	return a, nil
 }
@@ -383,7 +404,7 @@ func migrations5_create_trades_tableSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/5_create_trades_table.sql", size: 1100, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/5_create_trades_table.sql", size: 1100, mode: os.FileMode(0644), modTime: time.Unix(1510233604, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x4f, 0x51, 0x6e, 0x49, 0x10, 0xd6, 0xf1, 0x48, 0xc6, 0x8d, 0xe5, 0xbe, 0x2, 0x94, 0xba, 0x20, 0x37, 0x7b, 0x10, 0x8b, 0x84, 0x7, 0xac, 0x1b, 0xb4, 0xac, 0xc3, 0x6d, 0xbc, 0x54, 0x81, 0xe3}}
 	return a, nil
 }
@@ -403,7 +424,7 @@ func migrations6_create_assets_tableSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/6_create_assets_table.sql", size: 366, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/6_create_assets_table.sql", size: 366, mode: os.FileMode(0644), modTime: time.Unix(1510233604, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb1, 0x3f, 0x47, 0xea, 0x8a, 0x5d, 0x60, 0xc8, 0x90, 0x36, 0xc8, 0x4f, 0x68, 0xc5, 0xd3, 0xa0, 0xcd, 0xae, 0x5a, 0xc3, 0x75, 0xbd, 0xb4, 0xbb, 0x51, 0xf2, 0x68, 0x54, 0x79, 0xac, 0xa2, 0x8a}}
 	return a, nil
 }
@@ -423,7 +444,7 @@ func migrations7_modify_trades_tableSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/7_modify_trades_table.sql", size: 2303, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/7_modify_trades_table.sql", size: 2303, mode: os.FileMode(0644), modTime: time.Unix(1512493789, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb1, 0x2e, 0xba, 0x36, 0x5e, 0x3a, 0x3f, 0x3a, 0x8f, 0xe4, 0xfd, 0xc6, 0xb8, 0xeb, 0xbf, 0xda, 0x2b, 0xc6, 0xcd, 0xe3, 0xb5, 0x9a, 0x78, 0xf9, 0x9c, 0x2d, 0xcf, 0xe7, 0xb1, 0x6e, 0xa0, 0x3e}}
 	return a, nil
 }
@@ -443,7 +464,7 @@ func migrations8_add_aggregatorsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/8_add_aggregators.sql", size: 907, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/8_add_aggregators.sql", size: 907, mode: os.FileMode(0644), modTime: time.Unix(1514478914, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xae, 0xba, 0x87, 0x6f, 0x41, 0xf3, 0xf6, 0x28, 0x25, 0xc2, 0x19, 0xdf, 0x41, 0x9a, 0x4b, 0xf3, 0x8, 0x37, 0x29, 0x2b, 0x92, 0x12, 0x9f, 0xb5, 0x9f, 0x9d, 0x50, 0x82, 0x6, 0xa5, 0xbb, 0xf6}}
 	return a, nil
 }
@@ -463,7 +484,7 @@ func migrations8_create_asset_stats_tableSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/8_create_asset_stats_table.sql", size: 441, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/8_create_asset_stats_table.sql", size: 441, mode: os.FileMode(0644), modTime: time.Unix(1514478914, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x2d, 0x21, 0x5, 0xfc, 0x3f, 0xe0, 0xe1, 0xe6, 0x50, 0x2c, 0x25, 0xc0, 0x23, 0x87, 0xa3, 0x99, 0xad, 0xc8, 0xc1, 0x67, 0xca, 0x65, 0xc0, 0x91, 0xf6, 0x5c, 0x29, 0xab, 0x78, 0xbe, 0xe4, 0x5e}}
 	return a, nil
 }
@@ -483,7 +504,7 @@ func migrations9_add_header_xdrSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/9_add_header_xdr.sql", size: 161, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/9_add_header_xdr.sql", size: 161, mode: os.FileMode(0644), modTime: time.Unix(1535025415, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x44, 0xe5, 0x20, 0x47, 0xc8, 0x66, 0xd0, 0x16, 0xfa, 0xeb, 0xe, 0xba, 0x80, 0xbd, 0xc3, 0xa6, 0x0, 0x9e, 0xc, 0xb5, 0x45, 0xb9, 0x78, 0x26, 0x8, 0xef, 0x94, 0x23, 0xbe, 0x85, 0x2c, 0xe4}}
 	return a, nil
 }
@@ -601,6 +622,8 @@ var _bindata = map[string]func() (*asset, error){
 
 	"migrations/1_initial_schema.sql": migrations1_initial_schemaSql,
 
+	"migrations/21_trades_remove_zero_amount_constraints.sql": migrations21_trades_remove_zero_amount_constraintsSql,
+
 	"migrations/2_index_participants_by_toid.sql": migrations2_index_participants_by_toidSql,
 
 	"migrations/3_use_sequence_in_history_accounts.sql": migrations3_use_sequence_in_history_accountsSql,
@@ -662,26 +685,27 @@ type bintree struct {
 
 var _bintree = &bintree{nil, map[string]*bintree{
 	"migrations": &bintree{nil, map[string]*bintree{
-		"10_add_trades_price.sql":                &bintree{migrations10_add_trades_priceSql, map[string]*bintree{}},
-		"11_add_trades_account_index.sql":        &bintree{migrations11_add_trades_account_indexSql, map[string]*bintree{}},
-		"12_asset_stats_amount_string.sql":       &bintree{migrations12_asset_stats_amount_stringSql, map[string]*bintree{}},
-		"13_trade_offer_ids.sql":                 &bintree{migrations13_trade_offer_idsSql, map[string]*bintree{}},
-		"14_fix_asset_toml_field.sql":            &bintree{migrations14_fix_asset_toml_fieldSql, map[string]*bintree{}},
-		"15_ledger_failed_txs.sql":               &bintree{migrations15_ledger_failed_txsSql, map[string]*bintree{}},
-		"16_ingest_failed_transactions.sql":      &bintree{migrations16_ingest_failed_transactionsSql, map[string]*bintree{}},
-		"17_transaction_fee_paid.sql":            &bintree{migrations17_transaction_fee_paidSql, map[string]*bintree{}},
-		"18_account_for_signers.sql":             &bintree{migrations18_account_for_signersSql, map[string]*bintree{}},
-		"19_offers.sql":                          &bintree{migrations19_offersSql, map[string]*bintree{}},
-		"1_initial_schema.sql":                   &bintree{migrations1_initial_schemaSql, map[string]*bintree{}},
-		"2_index_participants_by_toid.sql":       &bintree{migrations2_index_participants_by_toidSql, map[string]*bintree{}},
-		"3_use_sequence_in_history_accounts.sql": &bintree{migrations3_use_sequence_in_history_accountsSql, map[string]*bintree{}},
-		"4_add_protocol_version.sql":             &bintree{migrations4_add_protocol_versionSql, map[string]*bintree{}},
-		"5_create_trades_table.sql":              &bintree{migrations5_create_trades_tableSql, map[string]*bintree{}},
-		"6_create_assets_table.sql":              &bintree{migrations6_create_assets_tableSql, map[string]*bintree{}},
-		"7_modify_trades_table.sql":              &bintree{migrations7_modify_trades_tableSql, map[string]*bintree{}},
-		"8_add_aggregators.sql":                  &bintree{migrations8_add_aggregatorsSql, map[string]*bintree{}},
-		"8_create_asset_stats_table.sql":         &bintree{migrations8_create_asset_stats_tableSql, map[string]*bintree{}},
-		"9_add_header_xdr.sql":                   &bintree{migrations9_add_header_xdrSql, map[string]*bintree{}},
+		"10_add_trades_price.sql":                      &bintree{migrations10_add_trades_priceSql, map[string]*bintree{}},
+		"11_add_trades_account_index.sql":              &bintree{migrations11_add_trades_account_indexSql, map[string]*bintree{}},
+		"12_asset_stats_amount_string.sql":             &bintree{migrations12_asset_stats_amount_stringSql, map[string]*bintree{}},
+		"13_trade_offer_ids.sql":                       &bintree{migrations13_trade_offer_idsSql, map[string]*bintree{}},
+		"14_fix_asset_toml_field.sql":                  &bintree{migrations14_fix_asset_toml_fieldSql, map[string]*bintree{}},
+		"15_ledger_failed_txs.sql":                     &bintree{migrations15_ledger_failed_txsSql, map[string]*bintree{}},
+		"16_ingest_failed_transactions.sql":            &bintree{migrations16_ingest_failed_transactionsSql, map[string]*bintree{}},
+		"17_transaction_fee_paid.sql":                  &bintree{migrations17_transaction_fee_paidSql, map[string]*bintree{}},
+		"18_account_for_signers.sql":                   &bintree{migrations18_account_for_signersSql, map[string]*bintree{}},
+		"19_offers.sql":                                &bintree{migrations19_offersSql, map[string]*bintree{}},
+		"1_initial_schema.sql":                         &bintree{migrations1_initial_schemaSql, map[string]*bintree{}},
+		"21_trades_remove_zero_amount_constraints.sql": &bintree{migrations21_trades_remove_zero_amount_constraintsSql, map[string]*bintree{}},
+		"2_index_participants_by_toid.sql":             &bintree{migrations2_index_participants_by_toidSql, map[string]*bintree{}},
+		"3_use_sequence_in_history_accounts.sql":       &bintree{migrations3_use_sequence_in_history_accountsSql, map[string]*bintree{}},
+		"4_add_protocol_version.sql":                   &bintree{migrations4_add_protocol_versionSql, map[string]*bintree{}},
+		"5_create_trades_table.sql":                    &bintree{migrations5_create_trades_tableSql, map[string]*bintree{}},
+		"6_create_assets_table.sql":                    &bintree{migrations6_create_assets_tableSql, map[string]*bintree{}},
+		"7_modify_trades_table.sql":                    &bintree{migrations7_modify_trades_tableSql, map[string]*bintree{}},
+		"8_add_aggregators.sql":                        &bintree{migrations8_add_aggregatorsSql, map[string]*bintree{}},
+		"8_create_asset_stats_table.sql":               &bintree{migrations8_create_asset_stats_tableSql, map[string]*bintree{}},
+		"9_add_header_xdr.sql":                         &bintree{migrations9_add_header_xdrSql, map[string]*bintree{}},
 	}},
 }}
 

--- a/services/horizon/internal/db2/schema/migrations/21_trades_remove_zero_amount_constraints.sql
+++ b/services/horizon/internal/db2/schema/migrations/21_trades_remove_zero_amount_constraints.sql
@@ -1,0 +1,15 @@
+-- +migrate Up
+
+ALTER TABLE history_trades DROP CONSTRAINT history_trades_base_amount_check;
+ALTER TABLE history_trades DROP CONSTRAINT history_trades_counter_amount_check;
+
+ALTER TABLE history_trades ADD CONSTRAINT history_trades_base_amount_check CHECK (base_amount >= 0);
+ALTER TABLE history_trades ADD CONSTRAINT history_trades_counter_amount_check CHECK (counter_amount >= 0);
+
+-- +migrate Down
+
+ALTER TABLE history_trades DROP CONSTRAINT history_trades_base_amount_check;
+ALTER TABLE history_trades DROP CONSTRAINT history_trades_counter_amount_check;
+
+ALTER TABLE history_trades ADD CONSTRAINT history_trades_base_amount_check CHECK (base_amount > 0);
+ALTER TABLE history_trades ADD CONSTRAINT history_trades_counter_amount_check CHECK (counter_amount > 0);

--- a/services/horizon/internal/ingest/asset_stat.go
+++ b/services/horizon/internal/ingest/asset_stat.go
@@ -77,11 +77,18 @@ func (assetStats *AssetStats) IngestOperation(op *xdr.Operation, source *xdr.Acc
 	case xdr.OperationTypePayment:
 		// payments is the only operation where we currently perform the optimization of checking against the issuer
 		return assetStats.handlePaymentOp(body.PaymentOp, sourceAccount)
-	case xdr.OperationTypePathPayment:
+	case xdr.OperationTypePathPaymentStrictReceive:
 		// if this gets expensive then we can limit it to only include those assets that includes the issuer
-		assetStats.add(body.PathPaymentOp.DestAsset)
-		assetStats.add(body.PathPaymentOp.SendAsset)
-		for _, asset := range body.PathPaymentOp.Path {
+		assetStats.add(body.PathPaymentStrictReceiveOp.DestAsset)
+		assetStats.add(body.PathPaymentStrictReceiveOp.SendAsset)
+		for _, asset := range body.PathPaymentStrictReceiveOp.Path {
+			assetStats.add(asset)
+		}
+	case xdr.OperationTypePathPaymentStrictSend:
+		// if this gets expensive then we can limit it to only include those assets that includes the issuer
+		assetStats.add(body.PathPaymentStrictSendOp.DestAsset)
+		assetStats.add(body.PathPaymentStrictSendOp.SendAsset)
+		for _, asset := range body.PathPaymentStrictSendOp.Path {
 			assetStats.add(asset)
 		}
 	case xdr.OperationTypeManageBuyOffer:

--- a/services/horizon/internal/ingest/asset_stat_test.go
+++ b/services/horizon/internal/ingest/asset_stat_test.go
@@ -215,12 +215,26 @@ func TestAssetModified(t *testing.T) {
 			}),
 			wantAssets: []string{"credit_alphanum4/USD/GCYLTPOU7IVYHHA3XKQF4YB4W4ZWHFERMOQ7K47IWANKNBFBNJJNEOG5"}, // sourceUSD
 		}, {
-			opBody: makeOperationBody(xdr.OperationTypePathPayment, xdr.PathPaymentOp{
+			opBody: makeOperationBody(xdr.OperationTypePathPaymentStrictReceive, xdr.PathPaymentStrictReceiveOp{
 				SendAsset:   issuerUSD,
 				SendMax:     1000000,
 				Destination: destAccount,
 				DestAsset:   anotherUSD,
 				DestAmount:  100,
+				Path:        []xdr.Asset{issuerUSD, destEUR, anotherUSD},
+			}),
+			wantAssets: []string{
+				"credit_alphanum4/EUR/GCSX4PDUZP3BL522ZVMFXCEJ55NKEOHEMII7PSMJZNAAESJ444GSSJMO", // destEUR
+				"credit_alphanum4/USD/GAB7GMQPJ5YY2E4UJMLNAZPDEUKPK4AAIPRXIZHKZGUIRC6FP2LAQSDN", // anotherUSD
+				"credit_alphanum4/USD/GCFZWN3AOVFQM2BZTZX7P47WSI4QMGJC62LILPKODTNDLVKZZNA5BQJ3", // issuerUSD
+			},
+		}, {
+			opBody: makeOperationBody(xdr.OperationTypePathPaymentStrictSend, xdr.PathPaymentStrictSendOp{
+				SendAsset:   issuerUSD,
+				SendAmount:  1000000,
+				Destination: destAccount,
+				DestAsset:   anotherUSD,
+				DestMin:     100,
 				Path:        []xdr.Asset{issuerUSD, destEUR, anotherUSD},
 			}),
 			wantAssets: []string{
@@ -413,8 +427,8 @@ func makeAccount(secret string, code string) (xdr.AccountId, xdr.Asset) {
 	return accountId, asset
 }
 
-func makeCodeBytes(code string) *[4]byte {
-	codeBytes := [4]byte{}
+func makeCodeBytes(code string) *xdr.AssetCode4 {
+	codeBytes := xdr.AssetCode4{}
 	copy(codeBytes[:], []byte(code))
 	return &codeBytes
 }

--- a/services/horizon/internal/ingest/participants/main.go
+++ b/services/horizon/internal/ingest/participants/main.go
@@ -26,8 +26,8 @@ func ForOperation(
 		result = append(result, op.Body.MustCreateAccountOp().Destination)
 	case xdr.OperationTypePayment:
 		result = append(result, op.Body.MustPaymentOp().Destination)
-	case xdr.OperationTypePathPayment:
-		result = append(result, op.Body.MustPathPaymentOp().Destination)
+	case xdr.OperationTypePathPaymentStrictReceive:
+		result = append(result, op.Body.MustPathPaymentStrictReceiveOp().Destination)
 	case xdr.OperationTypeManageBuyOffer:
 		// the only direct participant is the source_account
 	case xdr.OperationTypeManageSellOffer:

--- a/services/horizon/internal/ingest/session.go
+++ b/services/horizon/internal/ingest/session.go
@@ -751,19 +751,15 @@ func (is *Session) operationDetails() map[string]interface{} {
 		is.assetDetails(details, op.Asset, "")
 	case xdr.OperationTypePathPaymentStrictReceive:
 		op := c.Operation().Body.MustPathPaymentStrictReceiveOp()
+		result := c.OperationResult().MustPathPaymentStrictReceiveResult()
 		details["from"] = source.Address()
 		details["to"] = op.Destination.Address()
 
 		details["amount"] = amount.String(op.DestAmount)
-		details["source_amount"] = amount.String(0)
+		details["source_amount"] = amount.String(result.SendAmount())
 		details["source_max"] = amount.String(op.SendMax)
 		is.assetDetails(details, op.DestAsset, "")
 		is.assetDetails(details, op.SendAsset, "source_")
-
-		if c.Transaction().IsSuccessful() {
-			result := c.OperationResult().MustPathPaymentStrictReceiveResult()
-			details["source_amount"] = amount.String(result.SendAmount())
-		}
 
 		var path = make([]map[string]interface{}, len(op.Path))
 		for i := range op.Path {
@@ -773,19 +769,15 @@ func (is *Session) operationDetails() map[string]interface{} {
 		details["path"] = path
 	case xdr.OperationTypePathPaymentStrictSend:
 		op := c.Operation().Body.MustPathPaymentStrictSendOp()
+		result := c.OperationResult().MustPathPaymentStrictSendResult()
 		details["from"] = source.Address()
 		details["to"] = op.Destination.Address()
 
-		details["amount"] = amount.String(0)
+		details["amount"] = amount.String(result.DestAmount())
 		details["source_amount"] = amount.String(op.SendAmount)
 		details["destination_min"] = amount.String(op.DestMin)
 		is.assetDetails(details, op.DestAsset, "")
 		is.assetDetails(details, op.SendAsset, "source_")
-
-		if c.Transaction().IsSuccessful() {
-			result := c.OperationResult().MustPathPaymentStrictSendResult()
-			details["amount"] = amount.String(result.DestAmount())
-		}
 
 		var path = make([]map[string]interface{}, len(op.Path))
 		for i := range op.Path {

--- a/services/horizon/internal/ingest/session.go
+++ b/services/horizon/internal/ingest/session.go
@@ -778,7 +778,7 @@ func (is *Session) operationDetails() map[string]interface{} {
 
 		details["amount"] = amount.String(0)
 		details["source_amount"] = amount.String(op.SendAmount)
-		details["dest_min"] = amount.String(op.DestMin)
+		details["destination_min"] = amount.String(op.DestMin)
 		is.assetDetails(details, op.DestAsset, "")
 		is.assetDetails(details, op.SendAsset, "source_")
 

--- a/services/horizon/internal/ingest/session.go
+++ b/services/horizon/internal/ingest/session.go
@@ -180,16 +180,30 @@ func (is *Session) ingestEffects() {
 		effects.Add(op.Destination, history.EffectAccountCredited, dets)
 		effects.Add(source, history.EffectAccountDebited, dets)
 
-	case xdr.OperationTypePathPayment:
-		op := opbody.MustPathPaymentOp()
-		resultSuccess := is.Cursor.OperationResult().MustPathPaymentResult().MustSuccess()
+	case xdr.OperationTypePathPaymentStrictReceive:
+		op := opbody.MustPathPaymentStrictReceiveOp()
+		resultSuccess := is.Cursor.OperationResult().MustPathPaymentStrictReceiveResult().MustSuccess()
 
 		dets := map[string]interface{}{"amount": amount.String(op.DestAmount)}
 		is.assetDetails(dets, op.DestAsset, "")
 		effects.Add(op.Destination, history.EffectAccountCredited, dets)
 
-		result := is.Cursor.OperationResult().MustPathPaymentResult()
+		result := is.Cursor.OperationResult().MustPathPaymentStrictReceiveResult()
 		dets = map[string]interface{}{"amount": amount.String(result.SendAmount())}
+		is.assetDetails(dets, op.SendAsset, "")
+		effects.Add(source, history.EffectAccountDebited, dets)
+
+		is.ingestTradeEffects(effects, source, resultSuccess.Offers)
+	case xdr.OperationTypePathPaymentStrictSend:
+		op := opbody.MustPathPaymentStrictSendOp()
+		resultSuccess := is.Cursor.OperationResult().MustPathPaymentStrictSendResult().MustSuccess()
+		result := is.Cursor.OperationResult().MustPathPaymentStrictSendResult()
+
+		dets := map[string]interface{}{"amount": amount.String(result.DestAmount())}
+		is.assetDetails(dets, op.DestAsset, "")
+		effects.Add(op.Destination, history.EffectAccountCredited, dets)
+
+		dets = map[string]interface{}{"amount": amount.String(op.SendAmount)}
 		is.assetDetails(dets, op.SendAsset, "")
 		effects.Add(source, history.EffectAccountDebited, dets)
 
@@ -531,9 +545,15 @@ func (is *Session) ingestTrades() {
 	var trades []xdr.ClaimOfferAtom
 
 	switch cursor.OperationType() {
-	case xdr.OperationTypePathPayment:
+	case xdr.OperationTypePathPaymentStrictReceive:
 		trades = cursor.OperationResult().
-			MustPathPaymentResult().
+			MustPathPaymentStrictReceiveResult().
+			MustSuccess().
+			Offers
+
+	case xdr.OperationTypePathPaymentStrictSend:
+		trades = cursor.OperationResult().
+			MustPathPaymentStrictSendResult().
 			MustSuccess().
 			Offers
 
@@ -729,8 +749,8 @@ func (is *Session) operationDetails() map[string]interface{} {
 		details["to"] = op.Destination.Address()
 		details["amount"] = amount.String(op.Amount)
 		is.assetDetails(details, op.Asset, "")
-	case xdr.OperationTypePathPayment:
-		op := c.Operation().Body.MustPathPaymentOp()
+	case xdr.OperationTypePathPaymentStrictReceive:
+		op := c.Operation().Body.MustPathPaymentStrictReceiveOp()
 		details["from"] = source.Address()
 		details["to"] = op.Destination.Address()
 
@@ -741,8 +761,30 @@ func (is *Session) operationDetails() map[string]interface{} {
 		is.assetDetails(details, op.SendAsset, "source_")
 
 		if c.Transaction().IsSuccessful() {
-			result := c.OperationResult().MustPathPaymentResult()
+			result := c.OperationResult().MustPathPaymentStrictReceiveResult()
 			details["source_amount"] = amount.String(result.SendAmount())
+		}
+
+		var path = make([]map[string]interface{}, len(op.Path))
+		for i := range op.Path {
+			path[i] = make(map[string]interface{})
+			is.assetDetails(path[i], op.Path[i], "")
+		}
+		details["path"] = path
+	case xdr.OperationTypePathPaymentStrictSend:
+		op := c.Operation().Body.MustPathPaymentStrictSendOp()
+		details["from"] = source.Address()
+		details["to"] = op.Destination.Address()
+
+		details["amount"] = amount.String(0)
+		details["source_amount"] = amount.String(op.SendAmount)
+		details["dest_min"] = amount.String(op.DestMin)
+		is.assetDetails(details, op.DestAsset, "")
+		is.assetDetails(details, op.SendAsset, "source_")
+
+		if c.Transaction().IsSuccessful() {
+			result := c.OperationResult().MustPathPaymentStrictSendResult()
+			details["amount"] = amount.String(result.DestAmount())
 		}
 
 		var path = make([]map[string]interface{}, len(op.Path))

--- a/services/horizon/internal/ingest/session.go
+++ b/services/horizon/internal/ingest/session.go
@@ -175,23 +175,23 @@ func (is *Session) ingestEffects() {
 	case xdr.OperationTypePayment:
 		op := opbody.MustPaymentOp()
 
-		dets := map[string]interface{}{"amount": amount.String(op.Amount)}
-		is.assetDetails(dets, op.Asset, "")
-		effects.Add(op.Destination, history.EffectAccountCredited, dets)
-		effects.Add(source, history.EffectAccountDebited, dets)
+		details := map[string]interface{}{"amount": amount.String(op.Amount)}
+		is.assetDetails(details, op.Asset, "")
+		effects.Add(op.Destination, history.EffectAccountCredited, details)
+		effects.Add(source, history.EffectAccountDebited, details)
 
 	case xdr.OperationTypePathPaymentStrictReceive:
 		op := opbody.MustPathPaymentStrictReceiveOp()
 		resultSuccess := is.Cursor.OperationResult().MustPathPaymentStrictReceiveResult().MustSuccess()
 
-		dets := map[string]interface{}{"amount": amount.String(op.DestAmount)}
-		is.assetDetails(dets, op.DestAsset, "")
-		effects.Add(op.Destination, history.EffectAccountCredited, dets)
+		details := map[string]interface{}{"amount": amount.String(op.DestAmount)}
+		is.assetDetails(details, op.DestAsset, "")
+		effects.Add(op.Destination, history.EffectAccountCredited, details)
 
 		result := is.Cursor.OperationResult().MustPathPaymentStrictReceiveResult()
-		dets = map[string]interface{}{"amount": amount.String(result.SendAmount())}
-		is.assetDetails(dets, op.SendAsset, "")
-		effects.Add(source, history.EffectAccountDebited, dets)
+		details = map[string]interface{}{"amount": amount.String(result.SendAmount())}
+		is.assetDetails(details, op.SendAsset, "")
+		effects.Add(source, history.EffectAccountDebited, details)
 
 		is.ingestTradeEffects(effects, source, resultSuccess.Offers)
 	case xdr.OperationTypePathPaymentStrictSend:
@@ -199,13 +199,13 @@ func (is *Session) ingestEffects() {
 		resultSuccess := is.Cursor.OperationResult().MustPathPaymentStrictSendResult().MustSuccess()
 		result := is.Cursor.OperationResult().MustPathPaymentStrictSendResult()
 
-		dets := map[string]interface{}{"amount": amount.String(result.DestAmount())}
-		is.assetDetails(dets, op.DestAsset, "")
-		effects.Add(op.Destination, history.EffectAccountCredited, dets)
+		details := map[string]interface{}{"amount": amount.String(result.DestAmount())}
+		is.assetDetails(details, op.DestAsset, "")
+		effects.Add(op.Destination, history.EffectAccountCredited, details)
 
-		dets = map[string]interface{}{"amount": amount.String(op.SendAmount)}
-		is.assetDetails(dets, op.SendAsset, "")
-		effects.Add(source, history.EffectAccountDebited, dets)
+		details = map[string]interface{}{"amount": amount.String(op.SendAmount)}
+		is.assetDetails(details, op.SendAsset, "")
+		effects.Add(source, history.EffectAccountDebited, details)
 
 		is.ingestTradeEffects(effects, source, resultSuccess.Offers)
 	case xdr.OperationTypeManageBuyOffer:
@@ -276,11 +276,11 @@ func (is *Session) ingestEffects() {
 
 	case xdr.OperationTypeChangeTrust:
 		op := opbody.MustChangeTrustOp()
-		dets := map[string]interface{}{"limit": amount.String(op.Limit)}
+		details := map[string]interface{}{"limit": amount.String(op.Limit)}
 		key := xdr.LedgerKey{}
 		effect := history.EffectType(0)
 
-		is.assetDetails(dets, op.Line, "")
+		is.assetDetails(details, op.Line, "")
 
 		key.SetTrustline(source, op.Line)
 
@@ -309,30 +309,30 @@ func (is *Session) ingestEffects() {
 			panic("Invalid before-and-after state")
 		}
 
-		effects.Add(source, effect, dets)
+		effects.Add(source, effect, details)
 	case xdr.OperationTypeAllowTrust:
 		op := opbody.MustAllowTrustOp()
 		asset := op.Asset.ToAsset(source)
-		dets := map[string]interface{}{
+		details := map[string]interface{}{
 			"trustor": op.Trustor.Address(),
 		}
-		is.assetDetails(dets, asset, "")
+		is.assetDetails(details, asset, "")
 
 		if op.Authorize {
-			effects.Add(source, history.EffectTrustlineAuthorized, dets)
+			effects.Add(source, history.EffectTrustlineAuthorized, details)
 		} else {
-			effects.Add(source, history.EffectTrustlineDeauthorized, dets)
+			effects.Add(source, history.EffectTrustlineDeauthorized, details)
 		}
 
 	case xdr.OperationTypeAccountMerge:
 		dest := opbody.MustDestination()
 		result := is.Cursor.OperationResult().MustAccountMergeResult()
-		dets := map[string]interface{}{
+		details := map[string]interface{}{
 			"amount":     amount.String(result.MustSourceAccountBalance()),
 			"asset_type": "native",
 		}
-		effects.Add(source, history.EffectAccountDebited, dets)
-		effects.Add(dest, history.EffectAccountCredited, dets)
+		effects.Add(source, history.EffectAccountDebited, details)
+		effects.Add(dest, history.EffectAccountCredited, details)
 		effects.Add(source, history.EffectAccountRemoved, map[string]interface{}{})
 	case xdr.OperationTypeInflation:
 		payouts := is.Cursor.OperationResult().MustInflationResult().MustPayouts()
@@ -346,7 +346,7 @@ func (is *Session) ingestEffects() {
 		}
 	case xdr.OperationTypeManageData:
 		op := opbody.MustManageDataOp()
-		dets := map[string]interface{}{"name": op.DataName}
+		details := map[string]interface{}{"name": op.DataName}
 		key := xdr.LedgerKey{}
 		effect := history.EffectType(0)
 
@@ -360,7 +360,7 @@ func (is *Session) ingestEffects() {
 
 		if after != nil {
 			raw := after.Data.MustData().DataValue
-			dets["value"] = base64.StdEncoding.EncodeToString(raw)
+			details["value"] = base64.StdEncoding.EncodeToString(raw)
 		}
 
 		switch {
@@ -374,14 +374,14 @@ func (is *Session) ingestEffects() {
 			panic("Invalid before-and-after state")
 		}
 
-		effects.Add(source, effect, dets)
+		effects.Add(source, effect, details)
 
 	case xdr.OperationTypeBumpSequence:
 		opChanges := is.Cursor.OperationChanges()
 		if len(opChanges) > 0 {
 			op := opbody.MustBumpSequenceOp()
-			dets := map[string]interface{}{"new_seq": op.BumpTo}
-			effects.Add(source, history.EffectSequenceBumped, dets)
+			details := map[string]interface{}{"new_seq": op.BumpTo}
+			effects.Add(source, history.EffectSequenceBumped, details)
 		}
 
 	default:

--- a/services/horizon/internal/resourceadapter/operations.go
+++ b/services/horizon/internal/resourceadapter/operations.go
@@ -37,7 +37,7 @@ func NewOperation(
 		e := operations.Payment{Base: base}
 		err = operationRow.UnmarshalDetails(&e)
 		result = e
-	case xdr.OperationTypePathPayment:
+	case xdr.OperationTypePathPaymentStrictReceive:
 		e := operations.PathPayment{}
 		e.Payment.Base = base
 		err = operationRow.UnmarshalDetails(&e)
@@ -79,6 +79,11 @@ func NewOperation(
 		result = e
 	case xdr.OperationTypeManageData:
 		e := operations.ManageData{Base: base}
+		err = operationRow.UnmarshalDetails(&e)
+		result = e
+	case xdr.OperationTypePathPaymentStrictSend:
+		e := operations.PathPaymentStrictSend{}
+		e.Payment.Base = base
 		err = operationRow.UnmarshalDetails(&e)
 		result = e
 	default:

--- a/txnbuild/operation.go
+++ b/txnbuild/operation.go
@@ -29,7 +29,7 @@ func operationFromXDR(xdrOp xdr.Operation) (Operation, error) {
 		newOp = &CreateAccount{}
 	case xdr.OperationTypePayment:
 		newOp = &Payment{}
-	case xdr.OperationTypePathPayment:
+	case xdr.OperationTypePathPaymentStrictReceive:
 		newOp = &PathPayment{}
 	case xdr.OperationTypeManageSellOffer:
 		newOp = &ManageSellOffer{}
@@ -51,6 +51,8 @@ func operationFromXDR(xdrOp xdr.Operation) (Operation, error) {
 		newOp = &BumpSequence{}
 	case xdr.OperationTypeManageBuyOffer:
 		newOp = &ManageBuyOffer{}
+	case xdr.OperationTypePathPaymentStrictSend:
+		newOp = &PathPaymentStrictSend{}
 	}
 
 	err := newOp.FromXDR(xdrOp)

--- a/txnbuild/path_payment_strict_send.go
+++ b/txnbuild/path_payment_strict_send.go
@@ -6,24 +6,20 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-// PathPayment represents the Stellar path_payment_strict_receive operation. See
+// PathPaymentStrictSend represents the Stellar path_payment_strict_send operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
-type PathPaymentStrictReceive PathPayment
-
-// PathPayment represents the Stellar path payment operation. See
-// https://www.stellar.org/developers/guides/concepts/list-of-operations.html
-type PathPayment struct {
+type PathPaymentStrictSend struct {
 	SendAsset     Asset
-	SendMax       string
+	SendAmount    string
 	Destination   string
 	DestAsset     Asset
-	DestAmount    string
+	DestMin       string
 	Path          []Asset
 	SourceAccount Account
 }
 
 // BuildXDR for Payment returns a fully configured XDR Operation.
-func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
+func (pp *PathPaymentStrictSend) BuildXDR() (xdr.Operation, error) {
 	// Set XDR send asset
 	if pp.SendAsset == nil {
 		return xdr.Operation{}, errors.New("you must specify an asset to send for payment")
@@ -33,10 +29,10 @@ func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to set asset type")
 	}
 
-	// Set XDR send max
-	xdrSendMax, err := amount.Parse(pp.SendMax)
+	// Set XDR dest min
+	xdrDestMin, err := amount.Parse(pp.DestMin)
 	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "failed to parse maximum amount to send")
+		return xdr.Operation{}, errors.Wrap(err, "failed to parse minimum amount to receive")
 	}
 
 	// Set XDR destination
@@ -56,9 +52,9 @@ func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
 	}
 
 	// Set XDR destination amount
-	xdrDestAmount, err := amount.Parse(pp.DestAmount)
+	xdrSendAmount, err := amount.Parse(pp.SendAmount)
 	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "failed to parse amount of asset destination account receives")
+		return xdr.Operation{}, errors.Wrap(err, "failed to parse amount of asset source account sends")
 	}
 
 	// Set XDR path
@@ -72,13 +68,13 @@ func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
 		xdrPath = append(xdrPath, xdrPathAsset)
 	}
 
-	opType := xdr.OperationTypePathPaymentStrictReceive
-	xdrOp := xdr.PathPaymentStrictReceiveOp{
+	opType := xdr.OperationTypePathPaymentStrictSend
+	xdrOp := xdr.PathPaymentStrictSendOp{
 		SendAsset:   xdrSendAsset,
-		SendMax:     xdrSendMax,
+		SendAmount:  xdrSendAmount,
 		Destination: xdrDestination,
 		DestAsset:   xdrDestAsset,
-		DestAmount:  xdrDestAmount,
+		DestMin:     xdrDestMin,
 		Path:        xdrPath,
 	}
 	body, err := xdr.NewOperationBody(opType, xdrOp)
@@ -90,17 +86,17 @@ func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
 	return op, nil
 }
 
-// FromXDR for PathPayment initialises the txnbuild struct from the corresponding xdr Operation.
-func (pp *PathPayment) FromXDR(xdrOp xdr.Operation) error {
-	result, ok := xdrOp.Body.GetPathPaymentStrictReceiveOp()
+// FromXDR for PathPaymentStrictSend initialises the txnbuild struct from the corresponding xdr Operation.
+func (pp *PathPaymentStrictSend) FromXDR(xdrOp xdr.Operation) error {
+	result, ok := xdrOp.Body.GetPathPaymentStrictSendOp()
 	if !ok {
 		return errors.New("error parsing path_payment operation from xdr")
 	}
 
 	pp.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	pp.Destination = result.Destination.Address()
-	pp.DestAmount = amount.String(result.DestAmount)
-	pp.SendMax = amount.String(result.SendMax)
+	pp.SendAmount = amount.String(result.SendAmount)
+	pp.DestMin = amount.String(result.DestMin)
 
 	destAsset, err := assetFromXDR(result.DestAsset)
 	if err != nil {
@@ -126,9 +122,9 @@ func (pp *PathPayment) FromXDR(xdrOp xdr.Operation) error {
 	return nil
 }
 
-// Validate for PathPayment validates the required struct fields. It returns an error if any
+// Validate for PathPaymentStrictSend validates the required struct fields. It returns an error if any
 // of the fields are invalid. Otherwise, it returns nil.
-func (pp *PathPayment) Validate() error {
+func (pp *PathPaymentStrictSend) Validate() error {
 	err := validateStellarPublicKey(pp.Destination)
 	if err != nil {
 		return NewValidationError("Destination", err.Error())
@@ -144,14 +140,14 @@ func (pp *PathPayment) Validate() error {
 		return NewValidationError("DestAsset", err.Error())
 	}
 
-	err = validateAmount(pp.SendMax)
+	err = validateAmount(pp.SendAmount)
 	if err != nil {
-		return NewValidationError("SendMax", err.Error())
+		return NewValidationError("SendAmount", err.Error())
 	}
 
-	err = validateAmount(pp.DestAmount)
+	err = validateAmount(pp.DestMin)
 	if err != nil {
-		return NewValidationError("DestAmount", err.Error())
+		return NewValidationError("DestMin", err.Error())
 	}
 
 	return nil

--- a/txnbuild/path_payment_strict_send_test.go
+++ b/txnbuild/path_payment_strict_send_test.go
@@ -1,0 +1,153 @@
+package txnbuild
+
+import (
+	"testing"
+
+	"github.com/stellar/go/network"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPathPaymentStrictSendValidateSendAsset(t *testing.T) {
+	kp0 := newKeypair0()
+	kp2 := newKeypair2()
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(187316408680450))
+
+	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
+	pathPayment := PathPaymentStrictSend{
+		SendAsset:   CreditAsset{"ABCD", ""},
+		SendAmount:  "10",
+		Destination: kp2.Address(),
+		DestAsset:   NativeAsset{},
+		DestMin:     "1",
+		Path:        []Asset{abcdAsset},
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&pathPayment},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.PathPaymentStrictSend operation: Field: SendAsset, Error: asset issuer: public key is undefined"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestPathPaymentStrictSendValidateDestAsset(t *testing.T) {
+	kp0 := newKeypair0()
+	kp2 := newKeypair2()
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(187316408680450))
+
+	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
+	pathPayment := PathPaymentStrictSend{
+		SendAsset:   NativeAsset{},
+		SendAmount:  "10",
+		Destination: kp2.Address(),
+		DestAsset:   CreditAsset{"", kp0.Address()},
+		DestMin:     "1",
+		Path:        []Asset{abcdAsset},
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&pathPayment},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.PathPaymentStrictSend operation: Field: DestAsset, Error: asset code length must be between 1 and 12 characters"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestPathPaymentStrictSendValidateDestination(t *testing.T) {
+	kp0 := newKeypair0()
+	kp2 := newKeypair2()
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(187316408680450))
+
+	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
+	pathPayment := PathPaymentStrictSend{
+		SendAsset:   NativeAsset{},
+		SendAmount:  "10",
+		Destination: "SASND3NRUY5K43PN3H3HOP5JNTIDXJFLOKKNSCZQQAFBRSEIRD5OJKXZ",
+		DestAsset:   CreditAsset{"ABCD", kp0.Address()},
+		DestMin:     "1",
+		Path:        []Asset{abcdAsset},
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&pathPayment},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.PathPaymentStrictSend operation: Field: Destination, Error: SASND3NRUY5K43PN3H3HOP5JNTIDXJFLOKKNSCZQQAFBRSEIRD5OJKXZ is not a valid stellar public key"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestPathPaymentStrictSendValidateSendMax(t *testing.T) {
+	kp0 := newKeypair0()
+	kp2 := newKeypair2()
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(187316408680450))
+
+	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
+	pathPayment := PathPaymentStrictSend{
+		SendAsset:   NativeAsset{},
+		SendAmount:  "abc",
+		Destination: kp2.Address(),
+		DestAsset:   CreditAsset{"ABCD", kp0.Address()},
+		DestMin:     "1",
+		Path:        []Asset{abcdAsset},
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&pathPayment},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.PathPaymentStrictSend operation: Field: SendAmount, Error: invalid amount format: abc"
+		assert.Contains(t, err.Error(), expected)
+	}
+}
+
+func TestPathPaymentStrictSendValidateDestAmount(t *testing.T) {
+	kp0 := newKeypair0()
+	kp2 := newKeypair2()
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(187316408680450))
+
+	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
+	pathPayment := PathPaymentStrictSend{
+		SendAsset:   NativeAsset{},
+		SendAmount:  "10",
+		Destination: kp2.Address(),
+		DestAsset:   CreditAsset{"ABCD", kp0.Address()},
+		DestMin:     "-1",
+		Path:        []Asset{abcdAsset},
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&pathPayment},
+		Timebounds:    NewInfiniteTimeout(),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	if assert.Error(t, err) {
+		expected := "validation failed for *txnbuild.PathPaymentStrictSend operation: Field: DestMin, Error: amount can not be negative"
+		assert.Contains(t, err.Error(), expected)
+	}
+}

--- a/xdr/Stellar-ledger-entries.x
+++ b/xdr/Stellar-ledger-entries.x
@@ -15,6 +15,12 @@ typedef int64 SequenceNumber;
 typedef uint64 TimePoint;
 typedef opaque DataValue<64>;
 
+// 1-4 alphanumeric characters right-padded with 0 bytes
+typedef opaque AssetCode4[4];
+
+// 5-12 alphanumeric characters right-padded with 0 bytes
+typedef opaque AssetCode12[12];
+
 enum AssetType
 {
     ASSET_TYPE_NATIVE = 0,
@@ -30,14 +36,14 @@ case ASSET_TYPE_NATIVE: // Not credit
 case ASSET_TYPE_CREDIT_ALPHANUM4:
     struct
     {
-        opaque assetCode[4]; // 1 to 4 characters
+        AssetCode4 assetCode;
         AccountID issuer;
     } alphaNum4;
 
 case ASSET_TYPE_CREDIT_ALPHANUM12:
     struct
     {
-        opaque assetCode[12]; // 5 to 12 characters
+        AssetCode12 assetCode;
         AccountID issuer;
     } alphaNum12;
 
@@ -78,7 +84,7 @@ enum LedgerEntryType
 struct Signer
 {
     SignerKey key;
-    uint32 weight; // really only need 1byte
+    uint32 weight; // really only need 1 byte
 };
 
 enum AccountFlags

--- a/xdr/Stellar-ledger.x
+++ b/xdr/Stellar-ledger.x
@@ -37,7 +37,7 @@ struct StellarValue
     UpgradeType upgrades<6>;
 
     // reserved for future use
-    union switch (int v)
+    union switch (StellarValueType v)
     {
     case STELLAR_VALUE_BASIC:
         void;

--- a/xdr/allow_trust_op_asset_test.go
+++ b/xdr/allow_trust_op_asset_test.go
@@ -11,12 +11,12 @@ var _ = Describe("xdr.AllowTrustOpAsset#ToAsset()", func() {
 	It("works", func() {
 		var aid AccountId
 		aid.SetAddress("GCR22L3WS7TP72S4Z27YTO6JIQYDJK2KLS2TQNHK6Y7XYPA3AGT3X4FH")
-		ata, _ := NewAllowTrustOpAsset(AssetTypeAssetTypeCreditAlphanum4, [4]byte{0x01})
+		ata, _ := NewAllowTrustOpAsset(AssetTypeAssetTypeCreditAlphanum4, AssetCode4{0x01})
 		a := ata.ToAsset(aid)
 		Expect(a.Type).To(Equal(AssetTypeAssetTypeCreditAlphanum4))
 		Expect(a.MustAlphaNum4().AssetCode[0]).To(Equal(uint8(0x01)))
 
-		ata, _ = NewAllowTrustOpAsset(AssetTypeAssetTypeCreditAlphanum12, [12]byte{0x02})
+		ata, _ = NewAllowTrustOpAsset(AssetTypeAssetTypeCreditAlphanum12, AssetCode12{0x02})
 		a = ata.ToAsset(aid)
 		Expect(a.Type).To(Equal(AssetTypeAssetTypeCreditAlphanum12))
 		Expect(a.MustAlphaNum12().AssetCode[0]).To(Equal(uint8(0x02)))

--- a/xdr/asset.go
+++ b/xdr/asset.go
@@ -80,12 +80,12 @@ func (a *Asset) ToAllowTrustOpAsset(code string) (AllowTrustOpAsset, error) {
 
 	switch {
 	case length >= 1 && length <= 4:
-		var bytecode [4]byte
+		var bytecode AssetCode4
 		byteArray := []byte(code)
 		copy(bytecode[:], byteArray[0:length])
 		return NewAllowTrustOpAsset(AssetTypeAssetTypeCreditAlphanum4, bytecode)
 	case length >= 5 && length <= 12:
-		var bytecode [12]byte
+		var bytecode AssetCode12
 		byteArray := []byte(code)
 		copy(bytecode[:], byteArray[0:length])
 		return NewAllowTrustOpAsset(AssetTypeAssetTypeCreditAlphanum12, bytecode)

--- a/xdr/asset_test.go
+++ b/xdr/asset_test.go
@@ -188,7 +188,7 @@ func TestAssetSetCredit(t *testing.T) {
 	assert.NotNil(t, a.AlphaNum4)
 	assert.Equal(t, AssetTypeAssetTypeCreditAlphanum4, a.Type)
 	assert.Equal(t, issuer, a.AlphaNum4.Issuer)
-	assert.Equal(t, [4]byte{'U', 'S', 'D', 0}, a.AlphaNum4.AssetCode)
+	assert.Equal(t, AssetCode4{'U', 'S', 'D', 0}, a.AlphaNum4.AssetCode)
 
 	a = &Asset{}
 	a.SetCredit("USDUSD", issuer)
@@ -196,7 +196,7 @@ func TestAssetSetCredit(t *testing.T) {
 	assert.NotNil(t, a.AlphaNum12)
 	assert.Equal(t, AssetTypeAssetTypeCreditAlphanum12, a.Type)
 	assert.Equal(t, issuer, a.AlphaNum12.Issuer)
-	assert.Equal(t, [12]byte{'U', 'S', 'D', 'U', 'S', 'D', 0, 0, 0, 0, 0, 0}, a.AlphaNum12.AssetCode)
+	assert.Equal(t, AssetCode12{'U', 'S', 'D', 'U', 'S', 'D', 0, 0, 0, 0, 0, 0}, a.AlphaNum12.AssetCode)
 }
 
 func TestToAllowTrustOpAsset_AlphaNum4(t *testing.T) {
@@ -205,7 +205,7 @@ func TestToAllowTrustOpAsset_AlphaNum4(t *testing.T) {
 	if assert.NoError(t, err) {
 		code, ok := at.GetAssetCode4()
 		assert.True(t, ok)
-		var expected [4]byte
+		var expected AssetCode4
 		copy(expected[:], "ABCD")
 		assert.Equal(t, expected, code)
 	}
@@ -217,7 +217,7 @@ func TestToAllowTrustOpAsset_AlphaNum12(t *testing.T) {
 	if assert.NoError(t, err) {
 		code, ok := at.GetAssetCode12()
 		assert.True(t, ok)
-		var expected [12]byte
+		var expected AssetCode12
 		copy(expected[:], "ABCDEFGHIJKL")
 		assert.Equal(t, expected, code)
 	}

--- a/xdr/path_payment_result.go
+++ b/xdr/path_payment_result.go
@@ -28,6 +28,10 @@ func (pr *PathPaymentStrictReceiveResult) SendAmount() Int64 {
 // DestAmount returns the amount received, denominated in the destination asset, in the
 // course of this path payment
 func (pr *PathPaymentStrictSendResult) DestAmount() Int64 {
-	panic("TODO")
-	return 0
+	s, ok := pr.GetSuccess()
+	if !ok {
+		return 0
+	}
+
+	return s.Last.Amount
 }

--- a/xdr/path_payment_result.go
+++ b/xdr/path_payment_result.go
@@ -2,7 +2,7 @@ package xdr
 
 // SendAmount returns the amount spent, denominated in the source asset, in the
 // course of this path payment
-func (pr *PathPaymentResult) SendAmount() Int64 {
+func (pr *PathPaymentStrictReceiveResult) SendAmount() Int64 {
 	s, ok := pr.GetSuccess()
 	if !ok {
 		return 0
@@ -23,4 +23,11 @@ func (pr *PathPaymentResult) SendAmount() Int64 {
 	}
 
 	return ret
+}
+
+// DestAmount returns the amount received, denominated in the destination asset, in the
+// course of this path payment
+func (pr *PathPaymentStrictSendResult) DestAmount() Int64 {
+	panic("TODO")
+	return 0
 }

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -853,6 +853,64 @@ var (
 	_ encoding.BinaryUnmarshaler = (*DataValue)(nil)
 )
 
+// AssetCode4 is an XDR Typedef defines as:
+//
+//   typedef opaque AssetCode4[4];
+//
+type AssetCode4 [4]byte
+
+// XDRMaxSize implements the Sized interface for AssetCode4
+func (e AssetCode4) XDRMaxSize() int {
+	return 4
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s AssetCode4) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *AssetCode4) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*AssetCode4)(nil)
+	_ encoding.BinaryUnmarshaler = (*AssetCode4)(nil)
+)
+
+// AssetCode12 is an XDR Typedef defines as:
+//
+//   typedef opaque AssetCode12[12];
+//
+type AssetCode12 [12]byte
+
+// XDRMaxSize implements the Sized interface for AssetCode12
+func (e AssetCode12) XDRMaxSize() int {
+	return 12
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s AssetCode12) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *AssetCode12) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*AssetCode12)(nil)
+	_ encoding.BinaryUnmarshaler = (*AssetCode12)(nil)
+)
+
 // AssetType is an XDR Enum defines as:
 //
 //   enum AssetType
@@ -911,12 +969,12 @@ var (
 //
 //   struct
 //        {
-//            opaque assetCode[4]; // 1 to 4 characters
+//            AssetCode4 assetCode;
 //            AccountID issuer;
 //        }
 //
 type AssetAlphaNum4 struct {
-	AssetCode [4]byte `xdrmaxsize:"4"`
+	AssetCode AssetCode4
 	Issuer    AccountId
 }
 
@@ -942,12 +1000,12 @@ var (
 //
 //   struct
 //        {
-//            opaque assetCode[12]; // 5 to 12 characters
+//            AssetCode12 assetCode;
 //            AccountID issuer;
 //        }
 //
 type AssetAlphaNum12 struct {
-	AssetCode [12]byte `xdrmaxsize:"12"`
+	AssetCode AssetCode12
 	Issuer    AccountId
 }
 
@@ -979,14 +1037,14 @@ var (
 //    case ASSET_TYPE_CREDIT_ALPHANUM4:
 //        struct
 //        {
-//            opaque assetCode[4]; // 1 to 4 characters
+//            AssetCode4 assetCode;
 //            AccountID issuer;
 //        } alphaNum4;
 //
 //    case ASSET_TYPE_CREDIT_ALPHANUM12:
 //        struct
 //        {
-//            opaque assetCode[12]; // 5 to 12 characters
+//            AssetCode12 assetCode;
 //            AccountID issuer;
 //        } alphaNum12;
 //
@@ -1292,7 +1350,7 @@ var (
 //   struct Signer
 //    {
 //        SignerKey key;
-//        uint32 weight; // really only need 1byte
+//        uint32 weight; // really only need 1 byte
 //    };
 //
 type Signer struct {
@@ -2705,7 +2763,7 @@ var (
 
 // StellarValueExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
+//   union switch (StellarValueType v)
 //        {
 //        case STELLAR_VALUE_BASIC:
 //            void;
@@ -2714,7 +2772,7 @@ var (
 //        }
 //
 type StellarValueExt struct {
-	V                int32
+	V                StellarValueType
 	LcValueSignature *LedgerCloseValueSignature
 }
 
@@ -2727,22 +2785,22 @@ func (u StellarValueExt) SwitchFieldName() string {
 // ArmForSwitch returns which field name should be used for storing
 // the value for an instance of StellarValueExt
 func (u StellarValueExt) ArmForSwitch(sw int32) (string, bool) {
-	switch int32(sw) {
-	case int32(StellarValueTypeStellarValueBasic):
+	switch StellarValueType(sw) {
+	case StellarValueTypeStellarValueBasic:
 		return "", true
-	case int32(StellarValueTypeStellarValueSigned):
+	case StellarValueTypeStellarValueSigned:
 		return "LcValueSignature", true
 	}
 	return "-", false
 }
 
 // NewStellarValueExt creates a new  StellarValueExt.
-func NewStellarValueExt(v int32, value interface{}) (result StellarValueExt, err error) {
+func NewStellarValueExt(v StellarValueType, value interface{}) (result StellarValueExt, err error) {
 	result.V = v
-	switch int32(v) {
-	case int32(StellarValueTypeStellarValueBasic):
+	switch StellarValueType(v) {
+	case StellarValueTypeStellarValueBasic:
 		// void
-	case int32(StellarValueTypeStellarValueSigned):
+	case StellarValueTypeStellarValueSigned:
 		tv, ok := value.(LedgerCloseValueSignature)
 		if !ok {
 			err = fmt.Errorf("invalid value, must be LedgerCloseValueSignature")
@@ -2811,7 +2869,7 @@ var (
 //        UpgradeType upgrades<6>;
 //
 //        // reserved for future use
-//        union switch (int v)
+//        union switch (StellarValueType v)
 //        {
 //        case STELLAR_VALUE_BASIC:
 //            void;
@@ -6091,7 +6149,7 @@ var (
 //    {
 //        CREATE_ACCOUNT = 0,
 //        PAYMENT = 1,
-//        PATH_PAYMENT = 2,
+//        PATH_PAYMENT_STRICT_RECEIVE = 2,
 //        MANAGE_SELL_OFFER = 3,
 //        CREATE_PASSIVE_SELL_OFFER = 4,
 //        SET_OPTIONS = 5,
@@ -6101,31 +6159,33 @@ var (
 //        INFLATION = 9,
 //        MANAGE_DATA = 10,
 //        BUMP_SEQUENCE = 11,
-//        MANAGE_BUY_OFFER = 12
+//        MANAGE_BUY_OFFER = 12,
+//        PATH_PAYMENT_STRICT_SEND = 13
 //    };
 //
 type OperationType int32
 
 const (
-	OperationTypeCreateAccount          OperationType = 0
-	OperationTypePayment                OperationType = 1
-	OperationTypePathPayment            OperationType = 2
-	OperationTypeManageSellOffer        OperationType = 3
-	OperationTypeCreatePassiveSellOffer OperationType = 4
-	OperationTypeSetOptions             OperationType = 5
-	OperationTypeChangeTrust            OperationType = 6
-	OperationTypeAllowTrust             OperationType = 7
-	OperationTypeAccountMerge           OperationType = 8
-	OperationTypeInflation              OperationType = 9
-	OperationTypeManageData             OperationType = 10
-	OperationTypeBumpSequence           OperationType = 11
-	OperationTypeManageBuyOffer         OperationType = 12
+	OperationTypeCreateAccount            OperationType = 0
+	OperationTypePayment                  OperationType = 1
+	OperationTypePathPaymentStrictReceive OperationType = 2
+	OperationTypeManageSellOffer          OperationType = 3
+	OperationTypeCreatePassiveSellOffer   OperationType = 4
+	OperationTypeSetOptions               OperationType = 5
+	OperationTypeChangeTrust              OperationType = 6
+	OperationTypeAllowTrust               OperationType = 7
+	OperationTypeAccountMerge             OperationType = 8
+	OperationTypeInflation                OperationType = 9
+	OperationTypeManageData               OperationType = 10
+	OperationTypeBumpSequence             OperationType = 11
+	OperationTypeManageBuyOffer           OperationType = 12
+	OperationTypePathPaymentStrictSend    OperationType = 13
 )
 
 var operationTypeMap = map[int32]string{
 	0:  "OperationTypeCreateAccount",
 	1:  "OperationTypePayment",
-	2:  "OperationTypePathPayment",
+	2:  "OperationTypePathPaymentStrictReceive",
 	3:  "OperationTypeManageSellOffer",
 	4:  "OperationTypeCreatePassiveSellOffer",
 	5:  "OperationTypeSetOptions",
@@ -6136,6 +6196,7 @@ var operationTypeMap = map[int32]string{
 	10: "OperationTypeManageData",
 	11: "OperationTypeBumpSequence",
 	12: "OperationTypeManageBuyOffer",
+	13: "OperationTypePathPaymentStrictSend",
 }
 
 // ValidEnum validates a proposed value for this enum.  Implements
@@ -6233,9 +6294,9 @@ var (
 	_ encoding.BinaryUnmarshaler = (*PaymentOp)(nil)
 )
 
-// PathPaymentOp is an XDR Struct defines as:
+// PathPaymentStrictReceiveOp is an XDR Struct defines as:
 //
-//   struct PathPaymentOp
+//   struct PathPaymentStrictReceiveOp
 //    {
 //        Asset sendAsset; // asset we pay with
 //        int64 sendMax;   // the maximum amount of sendAsset to
@@ -6249,7 +6310,7 @@ var (
 //        Asset path<5>; // additional hops it must go through to get there
 //    };
 //
-type PathPaymentOp struct {
+type PathPaymentStrictReceiveOp struct {
 	SendAsset   Asset
 	SendMax     Int64
 	Destination AccountId
@@ -6259,21 +6320,64 @@ type PathPaymentOp struct {
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.
-func (s PathPaymentOp) MarshalBinary() ([]byte, error) {
+func (s PathPaymentStrictReceiveOp) MarshalBinary() ([]byte, error) {
 	b := new(bytes.Buffer)
 	_, err := Marshal(b, s)
 	return b.Bytes(), err
 }
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler.
-func (s *PathPaymentOp) UnmarshalBinary(inp []byte) error {
+func (s *PathPaymentStrictReceiveOp) UnmarshalBinary(inp []byte) error {
 	_, err := Unmarshal(bytes.NewReader(inp), s)
 	return err
 }
 
 var (
-	_ encoding.BinaryMarshaler   = (*PathPaymentOp)(nil)
-	_ encoding.BinaryUnmarshaler = (*PathPaymentOp)(nil)
+	_ encoding.BinaryMarshaler   = (*PathPaymentStrictReceiveOp)(nil)
+	_ encoding.BinaryUnmarshaler = (*PathPaymentStrictReceiveOp)(nil)
+)
+
+// PathPaymentStrictSendOp is an XDR Struct defines as:
+//
+//   struct PathPaymentStrictSendOp
+//    {
+//        Asset sendAsset;  // asset we pay with
+//        int64 sendAmount; // amount of sendAsset to send (excluding fees)
+//
+//        AccountID destination; // recipient of the payment
+//        Asset destAsset;       // what they end up with
+//        int64 destMin;         // the minimum amount of dest asset to
+//                               // be received
+//                               // The operation will fail if it can't be met
+//
+//        Asset path<5>; // additional hops it must go through to get there
+//    };
+//
+type PathPaymentStrictSendOp struct {
+	SendAsset   Asset
+	SendAmount  Int64
+	Destination AccountId
+	DestAsset   Asset
+	DestMin     Int64
+	Path        []Asset `xdrmaxsize:"5"`
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s PathPaymentStrictSendOp) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *PathPaymentStrictSendOp) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*PathPaymentStrictSendOp)(nil)
+	_ encoding.BinaryUnmarshaler = (*PathPaymentStrictSendOp)(nil)
 )
 
 // ManageSellOfferOp is an XDR Struct defines as:
@@ -6481,18 +6585,18 @@ var (
 //        {
 //        // ASSET_TYPE_NATIVE is not allowed
 //        case ASSET_TYPE_CREDIT_ALPHANUM4:
-//            opaque assetCode4[4];
+//            AssetCode4 assetCode4;
 //
 //        case ASSET_TYPE_CREDIT_ALPHANUM12:
-//            opaque assetCode12[12];
+//            AssetCode12 assetCode12;
 //
 //            // add other asset types here in the future
 //        }
 //
 type AllowTrustOpAsset struct {
 	Type        AssetType
-	AssetCode4  *[4]byte  `xdrmaxsize:"4"`
-	AssetCode12 *[12]byte `xdrmaxsize:"12"`
+	AssetCode4  *AssetCode4
+	AssetCode12 *AssetCode12
 }
 
 // SwitchFieldName returns the field name in which this union's
@@ -6518,16 +6622,16 @@ func NewAllowTrustOpAsset(aType AssetType, value interface{}) (result AllowTrust
 	result.Type = aType
 	switch AssetType(aType) {
 	case AssetTypeAssetTypeCreditAlphanum4:
-		tv, ok := value.([4]byte)
+		tv, ok := value.(AssetCode4)
 		if !ok {
-			err = fmt.Errorf("invalid value, must be [4]byte")
+			err = fmt.Errorf("invalid value, must be AssetCode4")
 			return
 		}
 		result.AssetCode4 = &tv
 	case AssetTypeAssetTypeCreditAlphanum12:
-		tv, ok := value.([12]byte)
+		tv, ok := value.(AssetCode12)
 		if !ok {
-			err = fmt.Errorf("invalid value, must be [12]byte")
+			err = fmt.Errorf("invalid value, must be AssetCode12")
 			return
 		}
 		result.AssetCode12 = &tv
@@ -6537,7 +6641,7 @@ func NewAllowTrustOpAsset(aType AssetType, value interface{}) (result AllowTrust
 
 // MustAssetCode4 retrieves the AssetCode4 value from the union,
 // panicing if the value is not set.
-func (u AllowTrustOpAsset) MustAssetCode4() [4]byte {
+func (u AllowTrustOpAsset) MustAssetCode4() AssetCode4 {
 	val, ok := u.GetAssetCode4()
 
 	if !ok {
@@ -6549,7 +6653,7 @@ func (u AllowTrustOpAsset) MustAssetCode4() [4]byte {
 
 // GetAssetCode4 retrieves the AssetCode4 value from the union,
 // returning ok if the union's switch indicated the value is valid.
-func (u AllowTrustOpAsset) GetAssetCode4() (result [4]byte, ok bool) {
+func (u AllowTrustOpAsset) GetAssetCode4() (result AssetCode4, ok bool) {
 	armName, _ := u.ArmForSwitch(int32(u.Type))
 
 	if armName == "AssetCode4" {
@@ -6562,7 +6666,7 @@ func (u AllowTrustOpAsset) GetAssetCode4() (result [4]byte, ok bool) {
 
 // MustAssetCode12 retrieves the AssetCode12 value from the union,
 // panicing if the value is not set.
-func (u AllowTrustOpAsset) MustAssetCode12() [12]byte {
+func (u AllowTrustOpAsset) MustAssetCode12() AssetCode12 {
 	val, ok := u.GetAssetCode12()
 
 	if !ok {
@@ -6574,7 +6678,7 @@ func (u AllowTrustOpAsset) MustAssetCode12() [12]byte {
 
 // GetAssetCode12 retrieves the AssetCode12 value from the union,
 // returning ok if the union's switch indicated the value is valid.
-func (u AllowTrustOpAsset) GetAssetCode12() (result [12]byte, ok bool) {
+func (u AllowTrustOpAsset) GetAssetCode12() (result AssetCode12, ok bool) {
 	armName, _ := u.ArmForSwitch(int32(u.Type))
 
 	if armName == "AssetCode12" {
@@ -6612,10 +6716,10 @@ var (
 //        {
 //        // ASSET_TYPE_NATIVE is not allowed
 //        case ASSET_TYPE_CREDIT_ALPHANUM4:
-//            opaque assetCode4[4];
+//            AssetCode4 assetCode4;
 //
 //        case ASSET_TYPE_CREDIT_ALPHANUM12:
-//            opaque assetCode12[12];
+//            AssetCode12 assetCode12;
 //
 //            // add other asset types here in the future
 //        }
@@ -6716,8 +6820,8 @@ var (
 //            CreateAccountOp createAccountOp;
 //        case PAYMENT:
 //            PaymentOp paymentOp;
-//        case PATH_PAYMENT:
-//            PathPaymentOp pathPaymentOp;
+//        case PATH_PAYMENT_STRICT_RECEIVE:
+//            PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
 //        case MANAGE_SELL_OFFER:
 //            ManageSellOfferOp manageSellOfferOp;
 //        case CREATE_PASSIVE_SELL_OFFER:
@@ -6738,22 +6842,25 @@ var (
 //            BumpSequenceOp bumpSequenceOp;
 //        case MANAGE_BUY_OFFER:
 //            ManageBuyOfferOp manageBuyOfferOp;
+//        case PATH_PAYMENT_STRICT_SEND:
+//            PathPaymentStrictSendOp pathPaymentStrictSendOp;
 //        }
 //
 type OperationBody struct {
-	Type                     OperationType
-	CreateAccountOp          *CreateAccountOp
-	PaymentOp                *PaymentOp
-	PathPaymentOp            *PathPaymentOp
-	ManageSellOfferOp        *ManageSellOfferOp
-	CreatePassiveSellOfferOp *CreatePassiveSellOfferOp
-	SetOptionsOp             *SetOptionsOp
-	ChangeTrustOp            *ChangeTrustOp
-	AllowTrustOp             *AllowTrustOp
-	Destination              *AccountId
-	ManageDataOp             *ManageDataOp
-	BumpSequenceOp           *BumpSequenceOp
-	ManageBuyOfferOp         *ManageBuyOfferOp
+	Type                       OperationType
+	CreateAccountOp            *CreateAccountOp
+	PaymentOp                  *PaymentOp
+	PathPaymentStrictReceiveOp *PathPaymentStrictReceiveOp
+	ManageSellOfferOp          *ManageSellOfferOp
+	CreatePassiveSellOfferOp   *CreatePassiveSellOfferOp
+	SetOptionsOp               *SetOptionsOp
+	ChangeTrustOp              *ChangeTrustOp
+	AllowTrustOp               *AllowTrustOp
+	Destination                *AccountId
+	ManageDataOp               *ManageDataOp
+	BumpSequenceOp             *BumpSequenceOp
+	ManageBuyOfferOp           *ManageBuyOfferOp
+	PathPaymentStrictSendOp    *PathPaymentStrictSendOp
 }
 
 // SwitchFieldName returns the field name in which this union's
@@ -6770,8 +6877,8 @@ func (u OperationBody) ArmForSwitch(sw int32) (string, bool) {
 		return "CreateAccountOp", true
 	case OperationTypePayment:
 		return "PaymentOp", true
-	case OperationTypePathPayment:
-		return "PathPaymentOp", true
+	case OperationTypePathPaymentStrictReceive:
+		return "PathPaymentStrictReceiveOp", true
 	case OperationTypeManageSellOffer:
 		return "ManageSellOfferOp", true
 	case OperationTypeCreatePassiveSellOffer:
@@ -6792,6 +6899,8 @@ func (u OperationBody) ArmForSwitch(sw int32) (string, bool) {
 		return "BumpSequenceOp", true
 	case OperationTypeManageBuyOffer:
 		return "ManageBuyOfferOp", true
+	case OperationTypePathPaymentStrictSend:
+		return "PathPaymentStrictSendOp", true
 	}
 	return "-", false
 }
@@ -6814,13 +6923,13 @@ func NewOperationBody(aType OperationType, value interface{}) (result OperationB
 			return
 		}
 		result.PaymentOp = &tv
-	case OperationTypePathPayment:
-		tv, ok := value.(PathPaymentOp)
+	case OperationTypePathPaymentStrictReceive:
+		tv, ok := value.(PathPaymentStrictReceiveOp)
 		if !ok {
-			err = fmt.Errorf("invalid value, must be PathPaymentOp")
+			err = fmt.Errorf("invalid value, must be PathPaymentStrictReceiveOp")
 			return
 		}
-		result.PathPaymentOp = &tv
+		result.PathPaymentStrictReceiveOp = &tv
 	case OperationTypeManageSellOffer:
 		tv, ok := value.(ManageSellOfferOp)
 		if !ok {
@@ -6886,6 +6995,13 @@ func NewOperationBody(aType OperationType, value interface{}) (result OperationB
 			return
 		}
 		result.ManageBuyOfferOp = &tv
+	case OperationTypePathPaymentStrictSend:
+		tv, ok := value.(PathPaymentStrictSendOp)
+		if !ok {
+			err = fmt.Errorf("invalid value, must be PathPaymentStrictSendOp")
+			return
+		}
+		result.PathPaymentStrictSendOp = &tv
 	}
 	return
 }
@@ -6940,25 +7056,25 @@ func (u OperationBody) GetPaymentOp() (result PaymentOp, ok bool) {
 	return
 }
 
-// MustPathPaymentOp retrieves the PathPaymentOp value from the union,
+// MustPathPaymentStrictReceiveOp retrieves the PathPaymentStrictReceiveOp value from the union,
 // panicing if the value is not set.
-func (u OperationBody) MustPathPaymentOp() PathPaymentOp {
-	val, ok := u.GetPathPaymentOp()
+func (u OperationBody) MustPathPaymentStrictReceiveOp() PathPaymentStrictReceiveOp {
+	val, ok := u.GetPathPaymentStrictReceiveOp()
 
 	if !ok {
-		panic("arm PathPaymentOp is not set")
+		panic("arm PathPaymentStrictReceiveOp is not set")
 	}
 
 	return val
 }
 
-// GetPathPaymentOp retrieves the PathPaymentOp value from the union,
+// GetPathPaymentStrictReceiveOp retrieves the PathPaymentStrictReceiveOp value from the union,
 // returning ok if the union's switch indicated the value is valid.
-func (u OperationBody) GetPathPaymentOp() (result PathPaymentOp, ok bool) {
+func (u OperationBody) GetPathPaymentStrictReceiveOp() (result PathPaymentStrictReceiveOp, ok bool) {
 	armName, _ := u.ArmForSwitch(int32(u.Type))
 
-	if armName == "PathPaymentOp" {
-		result = *u.PathPaymentOp
+	if armName == "PathPaymentStrictReceiveOp" {
+		result = *u.PathPaymentStrictReceiveOp
 		ok = true
 	}
 
@@ -7190,6 +7306,31 @@ func (u OperationBody) GetManageBuyOfferOp() (result ManageBuyOfferOp, ok bool) 
 	return
 }
 
+// MustPathPaymentStrictSendOp retrieves the PathPaymentStrictSendOp value from the union,
+// panicing if the value is not set.
+func (u OperationBody) MustPathPaymentStrictSendOp() PathPaymentStrictSendOp {
+	val, ok := u.GetPathPaymentStrictSendOp()
+
+	if !ok {
+		panic("arm PathPaymentStrictSendOp is not set")
+	}
+
+	return val
+}
+
+// GetPathPaymentStrictSendOp retrieves the PathPaymentStrictSendOp value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u OperationBody) GetPathPaymentStrictSendOp() (result PathPaymentStrictSendOp, ok bool) {
+	armName, _ := u.ArmForSwitch(int32(u.Type))
+
+	if armName == "PathPaymentStrictSendOp" {
+		result = *u.PathPaymentStrictSendOp
+		ok = true
+	}
+
+	return
+}
+
 // MarshalBinary implements encoding.BinaryMarshaler.
 func (s OperationBody) MarshalBinary() ([]byte, error) {
 	b := new(bytes.Buffer)
@@ -7223,8 +7364,8 @@ var (
 //            CreateAccountOp createAccountOp;
 //        case PAYMENT:
 //            PaymentOp paymentOp;
-//        case PATH_PAYMENT:
-//            PathPaymentOp pathPaymentOp;
+//        case PATH_PAYMENT_STRICT_RECEIVE:
+//            PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
 //        case MANAGE_SELL_OFFER:
 //            ManageSellOfferOp manageSellOfferOp;
 //        case CREATE_PASSIVE_SELL_OFFER:
@@ -7245,6 +7386,8 @@ var (
 //            BumpSequenceOp bumpSequenceOp;
 //        case MANAGE_BUY_OFFER:
 //            ManageBuyOfferOp manageBuyOfferOp;
+//        case PATH_PAYMENT_STRICT_SEND:
+//            PathPaymentStrictSendOp pathPaymentStrictSendOp;
 //        }
 //        body;
 //    };
@@ -8152,91 +8295,91 @@ var (
 	_ encoding.BinaryUnmarshaler = (*PaymentResult)(nil)
 )
 
-// PathPaymentResultCode is an XDR Enum defines as:
+// PathPaymentStrictReceiveResultCode is an XDR Enum defines as:
 //
-//   enum PathPaymentResultCode
+//   enum PathPaymentStrictReceiveResultCode
 //    {
 //        // codes considered as "success" for the operation
-//        PATH_PAYMENT_SUCCESS = 0, // success
+//        PATH_PAYMENT_STRICT_RECEIVE_SUCCESS = 0, // success
 //
 //        // codes considered as "failure" for the operation
-//        PATH_PAYMENT_MALFORMED = -1,          // bad input
-//        PATH_PAYMENT_UNDERFUNDED = -2,        // not enough funds in source account
-//        PATH_PAYMENT_SRC_NO_TRUST = -3,       // no trust line on source account
-//        PATH_PAYMENT_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
-//        PATH_PAYMENT_NO_DESTINATION = -5,     // destination account does not exist
-//        PATH_PAYMENT_NO_TRUST = -6,           // dest missing a trust line for asset
-//        PATH_PAYMENT_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
-//        PATH_PAYMENT_LINE_FULL = -8,          // dest would go above their limit
-//        PATH_PAYMENT_NO_ISSUER = -9,          // missing issuer on one asset
-//        PATH_PAYMENT_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
-//        PATH_PAYMENT_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
-//        PATH_PAYMENT_OVER_SENDMAX = -12       // could not satisfy sendmax
+//        PATH_PAYMENT_STRICT_RECEIVE_MALFORMED = -1,          // bad input
+//        PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED = -2,        // not enough funds in source account
+//        PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST = -3,       // no trust line on source account
+//        PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
+//        PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION = -5,     // destination account does not exist
+//        PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST = -6,           // dest missing a trust line for asset
+//        PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
+//        PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL = -8,          // dest would go above their limit
+//        PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER = -9,          // missing issuer on one asset
+//        PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
+//        PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
+//        PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX = -12       // could not satisfy sendmax
 //    };
 //
-type PathPaymentResultCode int32
+type PathPaymentStrictReceiveResultCode int32
 
 const (
-	PathPaymentResultCodePathPaymentSuccess          PathPaymentResultCode = 0
-	PathPaymentResultCodePathPaymentMalformed        PathPaymentResultCode = -1
-	PathPaymentResultCodePathPaymentUnderfunded      PathPaymentResultCode = -2
-	PathPaymentResultCodePathPaymentSrcNoTrust       PathPaymentResultCode = -3
-	PathPaymentResultCodePathPaymentSrcNotAuthorized PathPaymentResultCode = -4
-	PathPaymentResultCodePathPaymentNoDestination    PathPaymentResultCode = -5
-	PathPaymentResultCodePathPaymentNoTrust          PathPaymentResultCode = -6
-	PathPaymentResultCodePathPaymentNotAuthorized    PathPaymentResultCode = -7
-	PathPaymentResultCodePathPaymentLineFull         PathPaymentResultCode = -8
-	PathPaymentResultCodePathPaymentNoIssuer         PathPaymentResultCode = -9
-	PathPaymentResultCodePathPaymentTooFewOffers     PathPaymentResultCode = -10
-	PathPaymentResultCodePathPaymentOfferCrossSelf   PathPaymentResultCode = -11
-	PathPaymentResultCodePathPaymentOverSendmax      PathPaymentResultCode = -12
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSuccess          PathPaymentStrictReceiveResultCode = 0
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveMalformed        PathPaymentStrictReceiveResultCode = -1
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveUnderfunded      PathPaymentStrictReceiveResultCode = -2
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSrcNoTrust       PathPaymentStrictReceiveResultCode = -3
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSrcNotAuthorized PathPaymentStrictReceiveResultCode = -4
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoDestination    PathPaymentStrictReceiveResultCode = -5
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoTrust          PathPaymentStrictReceiveResultCode = -6
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNotAuthorized    PathPaymentStrictReceiveResultCode = -7
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveLineFull         PathPaymentStrictReceiveResultCode = -8
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoIssuer         PathPaymentStrictReceiveResultCode = -9
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveTooFewOffers     PathPaymentStrictReceiveResultCode = -10
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveOfferCrossSelf   PathPaymentStrictReceiveResultCode = -11
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveOverSendmax      PathPaymentStrictReceiveResultCode = -12
 )
 
-var pathPaymentResultCodeMap = map[int32]string{
-	0:   "PathPaymentResultCodePathPaymentSuccess",
-	-1:  "PathPaymentResultCodePathPaymentMalformed",
-	-2:  "PathPaymentResultCodePathPaymentUnderfunded",
-	-3:  "PathPaymentResultCodePathPaymentSrcNoTrust",
-	-4:  "PathPaymentResultCodePathPaymentSrcNotAuthorized",
-	-5:  "PathPaymentResultCodePathPaymentNoDestination",
-	-6:  "PathPaymentResultCodePathPaymentNoTrust",
-	-7:  "PathPaymentResultCodePathPaymentNotAuthorized",
-	-8:  "PathPaymentResultCodePathPaymentLineFull",
-	-9:  "PathPaymentResultCodePathPaymentNoIssuer",
-	-10: "PathPaymentResultCodePathPaymentTooFewOffers",
-	-11: "PathPaymentResultCodePathPaymentOfferCrossSelf",
-	-12: "PathPaymentResultCodePathPaymentOverSendmax",
+var pathPaymentStrictReceiveResultCodeMap = map[int32]string{
+	0:   "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSuccess",
+	-1:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveMalformed",
+	-2:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveUnderfunded",
+	-3:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSrcNoTrust",
+	-4:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSrcNotAuthorized",
+	-5:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoDestination",
+	-6:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoTrust",
+	-7:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNotAuthorized",
+	-8:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveLineFull",
+	-9:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoIssuer",
+	-10: "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveTooFewOffers",
+	-11: "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveOfferCrossSelf",
+	-12: "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveOverSendmax",
 }
 
 // ValidEnum validates a proposed value for this enum.  Implements
-// the Enum interface for PathPaymentResultCode
-func (e PathPaymentResultCode) ValidEnum(v int32) bool {
-	_, ok := pathPaymentResultCodeMap[v]
+// the Enum interface for PathPaymentStrictReceiveResultCode
+func (e PathPaymentStrictReceiveResultCode) ValidEnum(v int32) bool {
+	_, ok := pathPaymentStrictReceiveResultCodeMap[v]
 	return ok
 }
 
 // String returns the name of `e`
-func (e PathPaymentResultCode) String() string {
-	name, _ := pathPaymentResultCodeMap[int32(e)]
+func (e PathPaymentStrictReceiveResultCode) String() string {
+	name, _ := pathPaymentStrictReceiveResultCodeMap[int32(e)]
 	return name
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.
-func (s PathPaymentResultCode) MarshalBinary() ([]byte, error) {
+func (s PathPaymentStrictReceiveResultCode) MarshalBinary() ([]byte, error) {
 	b := new(bytes.Buffer)
 	_, err := Marshal(b, s)
 	return b.Bytes(), err
 }
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler.
-func (s *PathPaymentResultCode) UnmarshalBinary(inp []byte) error {
+func (s *PathPaymentStrictReceiveResultCode) UnmarshalBinary(inp []byte) error {
 	_, err := Unmarshal(bytes.NewReader(inp), s)
 	return err
 }
 
 var (
-	_ encoding.BinaryMarshaler   = (*PathPaymentResultCode)(nil)
-	_ encoding.BinaryUnmarshaler = (*PathPaymentResultCode)(nil)
+	_ encoding.BinaryMarshaler   = (*PathPaymentStrictReceiveResultCode)(nil)
+	_ encoding.BinaryUnmarshaler = (*PathPaymentStrictReceiveResultCode)(nil)
 )
 
 // SimplePaymentResult is an XDR Struct defines as:
@@ -8272,7 +8415,7 @@ var (
 	_ encoding.BinaryUnmarshaler = (*SimplePaymentResult)(nil)
 )
 
-// PathPaymentResultSuccess is an XDR NestedStruct defines as:
+// PathPaymentStrictReceiveResultSuccess is an XDR NestedStruct defines as:
 //
 //   struct
 //        {
@@ -8280,82 +8423,82 @@ var (
 //            SimplePaymentResult last;
 //        }
 //
-type PathPaymentResultSuccess struct {
+type PathPaymentStrictReceiveResultSuccess struct {
 	Offers []ClaimOfferAtom
 	Last   SimplePaymentResult
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.
-func (s PathPaymentResultSuccess) MarshalBinary() ([]byte, error) {
+func (s PathPaymentStrictReceiveResultSuccess) MarshalBinary() ([]byte, error) {
 	b := new(bytes.Buffer)
 	_, err := Marshal(b, s)
 	return b.Bytes(), err
 }
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler.
-func (s *PathPaymentResultSuccess) UnmarshalBinary(inp []byte) error {
+func (s *PathPaymentStrictReceiveResultSuccess) UnmarshalBinary(inp []byte) error {
 	_, err := Unmarshal(bytes.NewReader(inp), s)
 	return err
 }
 
 var (
-	_ encoding.BinaryMarshaler   = (*PathPaymentResultSuccess)(nil)
-	_ encoding.BinaryUnmarshaler = (*PathPaymentResultSuccess)(nil)
+	_ encoding.BinaryMarshaler   = (*PathPaymentStrictReceiveResultSuccess)(nil)
+	_ encoding.BinaryUnmarshaler = (*PathPaymentStrictReceiveResultSuccess)(nil)
 )
 
-// PathPaymentResult is an XDR Union defines as:
+// PathPaymentStrictReceiveResult is an XDR Union defines as:
 //
-//   union PathPaymentResult switch (PathPaymentResultCode code)
+//   union PathPaymentStrictReceiveResult switch (PathPaymentStrictReceiveResultCode code)
 //    {
-//    case PATH_PAYMENT_SUCCESS:
+//    case PATH_PAYMENT_STRICT_RECEIVE_SUCCESS:
 //        struct
 //        {
 //            ClaimOfferAtom offers<>;
 //            SimplePaymentResult last;
 //        } success;
-//    case PATH_PAYMENT_NO_ISSUER:
+//    case PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER:
 //        Asset noIssuer; // the asset that caused the error
 //    default:
 //        void;
 //    };
 //
-type PathPaymentResult struct {
-	Code     PathPaymentResultCode
-	Success  *PathPaymentResultSuccess
+type PathPaymentStrictReceiveResult struct {
+	Code     PathPaymentStrictReceiveResultCode
+	Success  *PathPaymentStrictReceiveResultSuccess
 	NoIssuer *Asset
 }
 
 // SwitchFieldName returns the field name in which this union's
 // discriminant is stored
-func (u PathPaymentResult) SwitchFieldName() string {
+func (u PathPaymentStrictReceiveResult) SwitchFieldName() string {
 	return "Code"
 }
 
 // ArmForSwitch returns which field name should be used for storing
-// the value for an instance of PathPaymentResult
-func (u PathPaymentResult) ArmForSwitch(sw int32) (string, bool) {
-	switch PathPaymentResultCode(sw) {
-	case PathPaymentResultCodePathPaymentSuccess:
+// the value for an instance of PathPaymentStrictReceiveResult
+func (u PathPaymentStrictReceiveResult) ArmForSwitch(sw int32) (string, bool) {
+	switch PathPaymentStrictReceiveResultCode(sw) {
+	case PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSuccess:
 		return "Success", true
-	case PathPaymentResultCodePathPaymentNoIssuer:
+	case PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoIssuer:
 		return "NoIssuer", true
 	default:
 		return "", true
 	}
 }
 
-// NewPathPaymentResult creates a new  PathPaymentResult.
-func NewPathPaymentResult(code PathPaymentResultCode, value interface{}) (result PathPaymentResult, err error) {
+// NewPathPaymentStrictReceiveResult creates a new  PathPaymentStrictReceiveResult.
+func NewPathPaymentStrictReceiveResult(code PathPaymentStrictReceiveResultCode, value interface{}) (result PathPaymentStrictReceiveResult, err error) {
 	result.Code = code
-	switch PathPaymentResultCode(code) {
-	case PathPaymentResultCodePathPaymentSuccess:
-		tv, ok := value.(PathPaymentResultSuccess)
+	switch PathPaymentStrictReceiveResultCode(code) {
+	case PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSuccess:
+		tv, ok := value.(PathPaymentStrictReceiveResultSuccess)
 		if !ok {
-			err = fmt.Errorf("invalid value, must be PathPaymentResultSuccess")
+			err = fmt.Errorf("invalid value, must be PathPaymentStrictReceiveResultSuccess")
 			return
 		}
 		result.Success = &tv
-	case PathPaymentResultCodePathPaymentNoIssuer:
+	case PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoIssuer:
 		tv, ok := value.(Asset)
 		if !ok {
 			err = fmt.Errorf("invalid value, must be Asset")
@@ -8370,7 +8513,7 @@ func NewPathPaymentResult(code PathPaymentResultCode, value interface{}) (result
 
 // MustSuccess retrieves the Success value from the union,
 // panicing if the value is not set.
-func (u PathPaymentResult) MustSuccess() PathPaymentResultSuccess {
+func (u PathPaymentStrictReceiveResult) MustSuccess() PathPaymentStrictReceiveResultSuccess {
 	val, ok := u.GetSuccess()
 
 	if !ok {
@@ -8382,7 +8525,7 @@ func (u PathPaymentResult) MustSuccess() PathPaymentResultSuccess {
 
 // GetSuccess retrieves the Success value from the union,
 // returning ok if the union's switch indicated the value is valid.
-func (u PathPaymentResult) GetSuccess() (result PathPaymentResultSuccess, ok bool) {
+func (u PathPaymentStrictReceiveResult) GetSuccess() (result PathPaymentStrictReceiveResultSuccess, ok bool) {
 	armName, _ := u.ArmForSwitch(int32(u.Code))
 
 	if armName == "Success" {
@@ -8395,7 +8538,7 @@ func (u PathPaymentResult) GetSuccess() (result PathPaymentResultSuccess, ok boo
 
 // MustNoIssuer retrieves the NoIssuer value from the union,
 // panicing if the value is not set.
-func (u PathPaymentResult) MustNoIssuer() Asset {
+func (u PathPaymentStrictReceiveResult) MustNoIssuer() Asset {
 	val, ok := u.GetNoIssuer()
 
 	if !ok {
@@ -8407,7 +8550,7 @@ func (u PathPaymentResult) MustNoIssuer() Asset {
 
 // GetNoIssuer retrieves the NoIssuer value from the union,
 // returning ok if the union's switch indicated the value is valid.
-func (u PathPaymentResult) GetNoIssuer() (result Asset, ok bool) {
+func (u PathPaymentStrictReceiveResult) GetNoIssuer() (result Asset, ok bool) {
 	armName, _ := u.ArmForSwitch(int32(u.Code))
 
 	if armName == "NoIssuer" {
@@ -8419,21 +8562,272 @@ func (u PathPaymentResult) GetNoIssuer() (result Asset, ok bool) {
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.
-func (s PathPaymentResult) MarshalBinary() ([]byte, error) {
+func (s PathPaymentStrictReceiveResult) MarshalBinary() ([]byte, error) {
 	b := new(bytes.Buffer)
 	_, err := Marshal(b, s)
 	return b.Bytes(), err
 }
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler.
-func (s *PathPaymentResult) UnmarshalBinary(inp []byte) error {
+func (s *PathPaymentStrictReceiveResult) UnmarshalBinary(inp []byte) error {
 	_, err := Unmarshal(bytes.NewReader(inp), s)
 	return err
 }
 
 var (
-	_ encoding.BinaryMarshaler   = (*PathPaymentResult)(nil)
-	_ encoding.BinaryUnmarshaler = (*PathPaymentResult)(nil)
+	_ encoding.BinaryMarshaler   = (*PathPaymentStrictReceiveResult)(nil)
+	_ encoding.BinaryUnmarshaler = (*PathPaymentStrictReceiveResult)(nil)
+)
+
+// PathPaymentStrictSendResultCode is an XDR Enum defines as:
+//
+//   enum PathPaymentStrictSendResultCode
+//    {
+//        // codes considered as "success" for the operation
+//        PATH_PAYMENT_STRICT_SEND_SUCCESS = 0, // success
+//
+//        // codes considered as "failure" for the operation
+//        PATH_PAYMENT_STRICT_SEND_MALFORMED = -1,          // bad input
+//        PATH_PAYMENT_STRICT_SEND_UNDERFUNDED = -2,        // not enough funds in source account
+//        PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST = -3,       // no trust line on source account
+//        PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
+//        PATH_PAYMENT_STRICT_SEND_NO_DESTINATION = -5,     // destination account does not exist
+//        PATH_PAYMENT_STRICT_SEND_NO_TRUST = -6,           // dest missing a trust line for asset
+//        PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
+//        PATH_PAYMENT_STRICT_SEND_LINE_FULL = -8,          // dest would go above their limit
+//        PATH_PAYMENT_STRICT_SEND_NO_ISSUER = -9,          // missing issuer on one asset
+//        PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
+//        PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
+//        PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN = -12      // could not satisfy destMin
+//    };
+//
+type PathPaymentStrictSendResultCode int32
+
+const (
+	PathPaymentStrictSendResultCodePathPaymentStrictSendSuccess          PathPaymentStrictSendResultCode = 0
+	PathPaymentStrictSendResultCodePathPaymentStrictSendMalformed        PathPaymentStrictSendResultCode = -1
+	PathPaymentStrictSendResultCodePathPaymentStrictSendUnderfunded      PathPaymentStrictSendResultCode = -2
+	PathPaymentStrictSendResultCodePathPaymentStrictSendSrcNoTrust       PathPaymentStrictSendResultCode = -3
+	PathPaymentStrictSendResultCodePathPaymentStrictSendSrcNotAuthorized PathPaymentStrictSendResultCode = -4
+	PathPaymentStrictSendResultCodePathPaymentStrictSendNoDestination    PathPaymentStrictSendResultCode = -5
+	PathPaymentStrictSendResultCodePathPaymentStrictSendNoTrust          PathPaymentStrictSendResultCode = -6
+	PathPaymentStrictSendResultCodePathPaymentStrictSendNotAuthorized    PathPaymentStrictSendResultCode = -7
+	PathPaymentStrictSendResultCodePathPaymentStrictSendLineFull         PathPaymentStrictSendResultCode = -8
+	PathPaymentStrictSendResultCodePathPaymentStrictSendNoIssuer         PathPaymentStrictSendResultCode = -9
+	PathPaymentStrictSendResultCodePathPaymentStrictSendTooFewOffers     PathPaymentStrictSendResultCode = -10
+	PathPaymentStrictSendResultCodePathPaymentStrictSendOfferCrossSelf   PathPaymentStrictSendResultCode = -11
+	PathPaymentStrictSendResultCodePathPaymentStrictSendUnderDestmin     PathPaymentStrictSendResultCode = -12
+)
+
+var pathPaymentStrictSendResultCodeMap = map[int32]string{
+	0:   "PathPaymentStrictSendResultCodePathPaymentStrictSendSuccess",
+	-1:  "PathPaymentStrictSendResultCodePathPaymentStrictSendMalformed",
+	-2:  "PathPaymentStrictSendResultCodePathPaymentStrictSendUnderfunded",
+	-3:  "PathPaymentStrictSendResultCodePathPaymentStrictSendSrcNoTrust",
+	-4:  "PathPaymentStrictSendResultCodePathPaymentStrictSendSrcNotAuthorized",
+	-5:  "PathPaymentStrictSendResultCodePathPaymentStrictSendNoDestination",
+	-6:  "PathPaymentStrictSendResultCodePathPaymentStrictSendNoTrust",
+	-7:  "PathPaymentStrictSendResultCodePathPaymentStrictSendNotAuthorized",
+	-8:  "PathPaymentStrictSendResultCodePathPaymentStrictSendLineFull",
+	-9:  "PathPaymentStrictSendResultCodePathPaymentStrictSendNoIssuer",
+	-10: "PathPaymentStrictSendResultCodePathPaymentStrictSendTooFewOffers",
+	-11: "PathPaymentStrictSendResultCodePathPaymentStrictSendOfferCrossSelf",
+	-12: "PathPaymentStrictSendResultCodePathPaymentStrictSendUnderDestmin",
+}
+
+// ValidEnum validates a proposed value for this enum.  Implements
+// the Enum interface for PathPaymentStrictSendResultCode
+func (e PathPaymentStrictSendResultCode) ValidEnum(v int32) bool {
+	_, ok := pathPaymentStrictSendResultCodeMap[v]
+	return ok
+}
+
+// String returns the name of `e`
+func (e PathPaymentStrictSendResultCode) String() string {
+	name, _ := pathPaymentStrictSendResultCodeMap[int32(e)]
+	return name
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s PathPaymentStrictSendResultCode) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *PathPaymentStrictSendResultCode) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*PathPaymentStrictSendResultCode)(nil)
+	_ encoding.BinaryUnmarshaler = (*PathPaymentStrictSendResultCode)(nil)
+)
+
+// PathPaymentStrictSendResultSuccess is an XDR NestedStruct defines as:
+//
+//   struct
+//        {
+//            ClaimOfferAtom offers<>;
+//            SimplePaymentResult last;
+//        }
+//
+type PathPaymentStrictSendResultSuccess struct {
+	Offers []ClaimOfferAtom
+	Last   SimplePaymentResult
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s PathPaymentStrictSendResultSuccess) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *PathPaymentStrictSendResultSuccess) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*PathPaymentStrictSendResultSuccess)(nil)
+	_ encoding.BinaryUnmarshaler = (*PathPaymentStrictSendResultSuccess)(nil)
+)
+
+// PathPaymentStrictSendResult is an XDR Union defines as:
+//
+//   union PathPaymentStrictSendResult switch (PathPaymentStrictSendResultCode code)
+//    {
+//    case PATH_PAYMENT_STRICT_SEND_SUCCESS:
+//        struct
+//        {
+//            ClaimOfferAtom offers<>;
+//            SimplePaymentResult last;
+//        } success;
+//    case PATH_PAYMENT_STRICT_SEND_NO_ISSUER:
+//        Asset noIssuer; // the asset that caused the error
+//    default:
+//        void;
+//    };
+//
+type PathPaymentStrictSendResult struct {
+	Code     PathPaymentStrictSendResultCode
+	Success  *PathPaymentStrictSendResultSuccess
+	NoIssuer *Asset
+}
+
+// SwitchFieldName returns the field name in which this union's
+// discriminant is stored
+func (u PathPaymentStrictSendResult) SwitchFieldName() string {
+	return "Code"
+}
+
+// ArmForSwitch returns which field name should be used for storing
+// the value for an instance of PathPaymentStrictSendResult
+func (u PathPaymentStrictSendResult) ArmForSwitch(sw int32) (string, bool) {
+	switch PathPaymentStrictSendResultCode(sw) {
+	case PathPaymentStrictSendResultCodePathPaymentStrictSendSuccess:
+		return "Success", true
+	case PathPaymentStrictSendResultCodePathPaymentStrictSendNoIssuer:
+		return "NoIssuer", true
+	default:
+		return "", true
+	}
+}
+
+// NewPathPaymentStrictSendResult creates a new  PathPaymentStrictSendResult.
+func NewPathPaymentStrictSendResult(code PathPaymentStrictSendResultCode, value interface{}) (result PathPaymentStrictSendResult, err error) {
+	result.Code = code
+	switch PathPaymentStrictSendResultCode(code) {
+	case PathPaymentStrictSendResultCodePathPaymentStrictSendSuccess:
+		tv, ok := value.(PathPaymentStrictSendResultSuccess)
+		if !ok {
+			err = fmt.Errorf("invalid value, must be PathPaymentStrictSendResultSuccess")
+			return
+		}
+		result.Success = &tv
+	case PathPaymentStrictSendResultCodePathPaymentStrictSendNoIssuer:
+		tv, ok := value.(Asset)
+		if !ok {
+			err = fmt.Errorf("invalid value, must be Asset")
+			return
+		}
+		result.NoIssuer = &tv
+	default:
+		// void
+	}
+	return
+}
+
+// MustSuccess retrieves the Success value from the union,
+// panicing if the value is not set.
+func (u PathPaymentStrictSendResult) MustSuccess() PathPaymentStrictSendResultSuccess {
+	val, ok := u.GetSuccess()
+
+	if !ok {
+		panic("arm Success is not set")
+	}
+
+	return val
+}
+
+// GetSuccess retrieves the Success value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u PathPaymentStrictSendResult) GetSuccess() (result PathPaymentStrictSendResultSuccess, ok bool) {
+	armName, _ := u.ArmForSwitch(int32(u.Code))
+
+	if armName == "Success" {
+		result = *u.Success
+		ok = true
+	}
+
+	return
+}
+
+// MustNoIssuer retrieves the NoIssuer value from the union,
+// panicing if the value is not set.
+func (u PathPaymentStrictSendResult) MustNoIssuer() Asset {
+	val, ok := u.GetNoIssuer()
+
+	if !ok {
+		panic("arm NoIssuer is not set")
+	}
+
+	return val
+}
+
+// GetNoIssuer retrieves the NoIssuer value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u PathPaymentStrictSendResult) GetNoIssuer() (result Asset, ok bool) {
+	armName, _ := u.ArmForSwitch(int32(u.Code))
+
+	if armName == "NoIssuer" {
+		result = *u.NoIssuer
+		ok = true
+	}
+
+	return
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s PathPaymentStrictSendResult) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *PathPaymentStrictSendResult) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*PathPaymentStrictSendResult)(nil)
+	_ encoding.BinaryUnmarshaler = (*PathPaymentStrictSendResult)(nil)
 )
 
 // ManageSellOfferResultCode is an XDR Enum defines as:
@@ -10038,8 +10432,8 @@ var (
 //            CreateAccountResult createAccountResult;
 //        case PAYMENT:
 //            PaymentResult paymentResult;
-//        case PATH_PAYMENT:
-//            PathPaymentResult pathPaymentResult;
+//        case PATH_PAYMENT_STRICT_RECEIVE:
+//            PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
 //        case MANAGE_SELL_OFFER:
 //            ManageSellOfferResult manageSellOfferResult;
 //        case CREATE_PASSIVE_SELL_OFFER:
@@ -10060,23 +10454,26 @@ var (
 //            BumpSequenceResult bumpSeqResult;
 //        case MANAGE_BUY_OFFER:
 //    	ManageBuyOfferResult manageBuyOfferResult;
+//        case PATH_PAYMENT_STRICT_SEND:
+//            PathPaymentStrictSendResult pathPaymentStrictSendResult;
 //        }
 //
 type OperationResultTr struct {
-	Type                         OperationType
-	CreateAccountResult          *CreateAccountResult
-	PaymentResult                *PaymentResult
-	PathPaymentResult            *PathPaymentResult
-	ManageSellOfferResult        *ManageSellOfferResult
-	CreatePassiveSellOfferResult *ManageSellOfferResult
-	SetOptionsResult             *SetOptionsResult
-	ChangeTrustResult            *ChangeTrustResult
-	AllowTrustResult             *AllowTrustResult
-	AccountMergeResult           *AccountMergeResult
-	InflationResult              *InflationResult
-	ManageDataResult             *ManageDataResult
-	BumpSeqResult                *BumpSequenceResult
-	ManageBuyOfferResult         *ManageBuyOfferResult
+	Type                           OperationType
+	CreateAccountResult            *CreateAccountResult
+	PaymentResult                  *PaymentResult
+	PathPaymentStrictReceiveResult *PathPaymentStrictReceiveResult
+	ManageSellOfferResult          *ManageSellOfferResult
+	CreatePassiveSellOfferResult   *ManageSellOfferResult
+	SetOptionsResult               *SetOptionsResult
+	ChangeTrustResult              *ChangeTrustResult
+	AllowTrustResult               *AllowTrustResult
+	AccountMergeResult             *AccountMergeResult
+	InflationResult                *InflationResult
+	ManageDataResult               *ManageDataResult
+	BumpSeqResult                  *BumpSequenceResult
+	ManageBuyOfferResult           *ManageBuyOfferResult
+	PathPaymentStrictSendResult    *PathPaymentStrictSendResult
 }
 
 // SwitchFieldName returns the field name in which this union's
@@ -10093,8 +10490,8 @@ func (u OperationResultTr) ArmForSwitch(sw int32) (string, bool) {
 		return "CreateAccountResult", true
 	case OperationTypePayment:
 		return "PaymentResult", true
-	case OperationTypePathPayment:
-		return "PathPaymentResult", true
+	case OperationTypePathPaymentStrictReceive:
+		return "PathPaymentStrictReceiveResult", true
 	case OperationTypeManageSellOffer:
 		return "ManageSellOfferResult", true
 	case OperationTypeCreatePassiveSellOffer:
@@ -10115,6 +10512,8 @@ func (u OperationResultTr) ArmForSwitch(sw int32) (string, bool) {
 		return "BumpSeqResult", true
 	case OperationTypeManageBuyOffer:
 		return "ManageBuyOfferResult", true
+	case OperationTypePathPaymentStrictSend:
+		return "PathPaymentStrictSendResult", true
 	}
 	return "-", false
 }
@@ -10137,13 +10536,13 @@ func NewOperationResultTr(aType OperationType, value interface{}) (result Operat
 			return
 		}
 		result.PaymentResult = &tv
-	case OperationTypePathPayment:
-		tv, ok := value.(PathPaymentResult)
+	case OperationTypePathPaymentStrictReceive:
+		tv, ok := value.(PathPaymentStrictReceiveResult)
 		if !ok {
-			err = fmt.Errorf("invalid value, must be PathPaymentResult")
+			err = fmt.Errorf("invalid value, must be PathPaymentStrictReceiveResult")
 			return
 		}
-		result.PathPaymentResult = &tv
+		result.PathPaymentStrictReceiveResult = &tv
 	case OperationTypeManageSellOffer:
 		tv, ok := value.(ManageSellOfferResult)
 		if !ok {
@@ -10214,6 +10613,13 @@ func NewOperationResultTr(aType OperationType, value interface{}) (result Operat
 			return
 		}
 		result.ManageBuyOfferResult = &tv
+	case OperationTypePathPaymentStrictSend:
+		tv, ok := value.(PathPaymentStrictSendResult)
+		if !ok {
+			err = fmt.Errorf("invalid value, must be PathPaymentStrictSendResult")
+			return
+		}
+		result.PathPaymentStrictSendResult = &tv
 	}
 	return
 }
@@ -10268,25 +10674,25 @@ func (u OperationResultTr) GetPaymentResult() (result PaymentResult, ok bool) {
 	return
 }
 
-// MustPathPaymentResult retrieves the PathPaymentResult value from the union,
+// MustPathPaymentStrictReceiveResult retrieves the PathPaymentStrictReceiveResult value from the union,
 // panicing if the value is not set.
-func (u OperationResultTr) MustPathPaymentResult() PathPaymentResult {
-	val, ok := u.GetPathPaymentResult()
+func (u OperationResultTr) MustPathPaymentStrictReceiveResult() PathPaymentStrictReceiveResult {
+	val, ok := u.GetPathPaymentStrictReceiveResult()
 
 	if !ok {
-		panic("arm PathPaymentResult is not set")
+		panic("arm PathPaymentStrictReceiveResult is not set")
 	}
 
 	return val
 }
 
-// GetPathPaymentResult retrieves the PathPaymentResult value from the union,
+// GetPathPaymentStrictReceiveResult retrieves the PathPaymentStrictReceiveResult value from the union,
 // returning ok if the union's switch indicated the value is valid.
-func (u OperationResultTr) GetPathPaymentResult() (result PathPaymentResult, ok bool) {
+func (u OperationResultTr) GetPathPaymentStrictReceiveResult() (result PathPaymentStrictReceiveResult, ok bool) {
 	armName, _ := u.ArmForSwitch(int32(u.Type))
 
-	if armName == "PathPaymentResult" {
-		result = *u.PathPaymentResult
+	if armName == "PathPaymentStrictReceiveResult" {
+		result = *u.PathPaymentStrictReceiveResult
 		ok = true
 	}
 
@@ -10543,6 +10949,31 @@ func (u OperationResultTr) GetManageBuyOfferResult() (result ManageBuyOfferResul
 	return
 }
 
+// MustPathPaymentStrictSendResult retrieves the PathPaymentStrictSendResult value from the union,
+// panicing if the value is not set.
+func (u OperationResultTr) MustPathPaymentStrictSendResult() PathPaymentStrictSendResult {
+	val, ok := u.GetPathPaymentStrictSendResult()
+
+	if !ok {
+		panic("arm PathPaymentStrictSendResult is not set")
+	}
+
+	return val
+}
+
+// GetPathPaymentStrictSendResult retrieves the PathPaymentStrictSendResult value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u OperationResultTr) GetPathPaymentStrictSendResult() (result PathPaymentStrictSendResult, ok bool) {
+	armName, _ := u.ArmForSwitch(int32(u.Type))
+
+	if armName == "PathPaymentStrictSendResult" {
+		result = *u.PathPaymentStrictSendResult
+		ok = true
+	}
+
+	return
+}
+
 // MarshalBinary implements encoding.BinaryMarshaler.
 func (s OperationResultTr) MarshalBinary() ([]byte, error) {
 	b := new(bytes.Buffer)
@@ -10572,8 +11003,8 @@ var (
 //            CreateAccountResult createAccountResult;
 //        case PAYMENT:
 //            PaymentResult paymentResult;
-//        case PATH_PAYMENT:
-//            PathPaymentResult pathPaymentResult;
+//        case PATH_PAYMENT_STRICT_RECEIVE:
+//            PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
 //        case MANAGE_SELL_OFFER:
 //            ManageSellOfferResult manageSellOfferResult;
 //        case CREATE_PASSIVE_SELL_OFFER:
@@ -10594,6 +11025,8 @@ var (
 //            BumpSequenceResult bumpSeqResult;
 //        case MANAGE_BUY_OFFER:
 //    	ManageBuyOfferResult manageBuyOfferResult;
+//        case PATH_PAYMENT_STRICT_SEND:
+//            PathPaymentStrictSendResult pathPaymentStrictSendResult;
 //        }
 //        tr;
 //    default:


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

This commit updates Go monorepo to support Stellar Protocol v12. The new version changes some XDR types and adds a new `PathPaymentStrictSend` operation (see: [CAP-24](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0024.md)).

### Summary of changes

Below are per package changes added to support v12.

#### `xdr` package

* XDR Go definitions have been regenerated using `xdrgen`.
* Added `PathPaymentStrictSendResult.DestAmount()` helper method.

#### `build` package

Because this package is no longer supported the only changes are type name changes that allow the package to be compiled. No support for the new `PathPaymentStrictSend` operation.

#### `services/horizon` and `protocols/horizon` packages

* Added a new `PathPaymentStrictSend` response to operation responses.
* Added new error codes connected to `PathPaymentStrictSend` operation in `POST /transactions`.
* Changed `/payments` to include `path_payment_strict_send` operations.
* Updated `history_trades` table schema to allow amounts equal `0` (to support cases where `ClaimOfferAtom` contains `amountSold = 0` and `amountBought != 0`).
* Updated `ingest` package to support ingesting operations, effects and trades that result from `path_payment_strict_send` operations.


#### `services/compliance` package

Support for `PathPaymentStrictSend` in auth endpoint.

#### `txnbuild` package

Added support `PathPaymentStrictSend` support. Check next section for more information.

### Known limitations & issues

* Even though new operation has been implemented in Horizon's `ingest` package it has not been tested yet! New test scenarios are required but building them requires changes to `scc` (and `scc` requires changes to ruby SDK).
* `PathPaymentStrictSend` has been added to `txnbuild` but there's an ongoing discussion whether we should release it now or after v12 upgrade. See: #1773.
* Horizon schema change skips one number (`21` vs `20`) as `20` was used in Horizon 0.21.0 and it's not been merged into master yet.
