### PR TITLE
all: simplify gofmt script

### DIFF
--- a/gofmt.sh
+++ b/gofmt.sh
@@ -2,9 +2,7 @@
 set -e
 
 printf "Running gofmt checks...\n"
-OUTPUT=$(ls -d */ \
-  | egrep -v '^vendor|^docs' \
-  | xargs -I {} -P 4 gofmt -d {})
+OUTPUT=$(gofmt -d .)
 
 if [[ $OUTPUT ]]; then
   printf "gofmt found unformatted files:\n\n"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Remove the ls xargs dance from the gofmt and just get gofmt to run it's checks over everything of what's different.

### Goal and scope

I was looking at copying this script to another repository and noticed that the dance with excluding certain folders and piping to xargs to run in parallel is really not necessary.

I'm not making this change to improve the performance of this, because I don't think it's meaningful right here, but just mentioning this for completeness that when I run the script as it is now sharing across 4 processes it was actually marginally slower than just running gofmt once like this change does. So this change isn't introducing a slowdown in CI runtime.

### Summary of changes

- Remove use of ls, xargs, etc
- Replace with a simple gofmt call

### Known limitations & issues

N/A

### What shouldn't be reviewed

N/A