### PR TITLE
all: run go vet shadow for all go versions

### DIFF
--- a/govet.sh
+++ b/govet.sh
@@ -4,19 +4,20 @@ set -e
 printf "Running go vet...\n"
 go vet -all -composites=false -unreachable=false -tests=false ./...
 
-# -vettool was added in 1.12, and broken in the initial 1.13 release
+printf "Running go vet shadow...\n"
+command -v shadow >/dev/null 2>&1 || (
+  dir=$(mktemp -d)
+  pushd $dir
+  go mod init tool
+  go get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
+  popd
+)
+
+# The go vet -vettool option was added in 1.12, and broken in the initial 1.13
+# release. Until it is fixed we must call vettool's directly as a work around.
 # https://github.com/golang/go/issues/34053
 if [[ $GOLANG_VERSION = 1.12.* ]]; then
-  printf "Running go vet shadow...\n"
-  command -v shadow >/dev/null 2>&1 || (
-    dir=$(mktemp -d)
-    pushd $dir
-    go mod init tool
-    go get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
-    popd
-  )
-
   go vet -vettool=$(which shadow) ./...
 else
-  echo "Skipping go vet shadow checks for this version of Go..."
+  shadow ./...
 fi


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Run the go vet tool `shadow` for all Go versions, specifically making it possible to run it with Go 1.13.

### Goal and scope

We should have consistent checks and tests across the versions of Go we have running. When I initially added the Go 1.13 block and I excluded the shadow check it was because of golang/go#34053 and I didn't see a simple way to keep running it for Go 1.13. Simply running the tool directly is an easy way to still use the tool since we don't have to run it with `go vet`.

The reason we'd want to run it with `go vet` is that's the direction analysis tools are going, and the intention is that if you run multiple tools with go vet it will do certain parsing and loading of code only once. In our case this doesn't really matter right now.

### Summary of changes

- Change the `govet.sh` script to install the shadow tool regardless of Go version
- For Go 1.13 run `shadow ./...` but keep the `go vet -vettool` usage for Go 1.12.

### Known limitations & issues

N/A

### What shouldn't be reviewed

N/A