### PR TITLE
exp/tools/dump-ledger-state: Publish docker image to run state diff checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,6 @@ jobs:
       - check_ingest_state
 
   publish_state_diff_docker_image:
-    working_directory: /go/src/github.com/stellar/go/
     docker:
       - image: circleci/buildpack-deps:stretch
     steps:
@@ -294,9 +293,10 @@ jobs:
       - run:
           name: Build and Push Docker image
           command: |
-            docker build -f exp/tools/dump-ledger-state/Dockerfile --build-arg GITCOMMIT=$CIRCLE_SHA1 -t stellar/ledger-state-diff:$CIRCLE_SHA1 .
-            docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+            docker build -f exp/tools/dump-ledger-state/Dockerfile --build-arg GITCOMMIT=$CIRCLE_SHA1 -t stellar/ledger-state-diff:$CIRCLE_SHA1 -t stellar/ledger-state-diff:latest .
             docker push stellar/ledger-state-diff:$CIRCLE_SHA1
+            docker push stellar/ledger-state-diff:latest
 
 #-------------------------------------------------------------------------#
 # Workflows orchestrate jobs and make sure they run in the right sequence #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,20 @@ jobs:
       - install_go_deps
       - check_ingest_state
 
+  publish_state_diff_docker_image:
+    working_directory: /go/src/github.com/stellar/go/
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build and Push Docker image
+          command: |
+            docker build -f exp/tools/dump-ledger-state/Dockerfile --build-arg GITCOMMIT=$CIRCLE_SHA1 -t stellar/ledger-state-diff:$CIRCLE_SHA1 .
+            docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+            docker push stellar/ledger-state-diff:$CIRCLE_SHA1
+
 #-------------------------------------------------------------------------#
 # Workflows orchestrate jobs and make sure they run in the right sequence #
 #-------------------------------------------------------------------------#
@@ -297,6 +311,11 @@ workflows:
       - check_code_1_13
       - test_code_1_12
       - test_code_1_13
+      - publish_state_diff_docker_image:
+          filters:
+              branches:
+                only:
+                  - master
       - ingest_state_diff:
           filters:
               branches:

--- a/exp/tools/dump-ledger-state/Dockerfile
+++ b/exp/tools/dump-ledger-state/Dockerfile
@@ -1,0 +1,39 @@
+FROM golang:1.13.0-buster
+
+RUN apt-get update -y
+RUN apt-get install -y apt-transport-https
+RUN wget -qO - https://apt.stellar.org/SDF.asc | apt-key add -
+RUN echo "deb https://apt.stellar.org/public stable/" | tee -a /etc/apt/sources.list.d/SDF.list
+RUN apt-get update -y
+
+RUN apt-get install -y stellar-core jq
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(env -i bash -c '. /etc/os-release; echo $VERSION_CODENAME')-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list && \
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    apt-get update && \
+    apt-get install -y postgresql-9.6 postgresql-contrib-9.6 postgresql-client-9.6 
+
+# Create a PostgreSQL role named `circleci` and then create a database `core` owned by the `circleci` role.
+RUN  su - postgres -c "/etc/init.d/postgresql start && psql --command \"CREATE USER circleci WITH SUPERUSER;\" && createdb -O circleci core"
+
+# Adjust PostgreSQL configuration so that remote connections to the
+# database are possible.
+RUN echo "host all all all trust" > /etc/postgresql/9.6/main/pg_hba.conf
+
+# And add `listen_addresses` to `/etc/postgresql/9.6/main/postgresql.conf`
+RUN echo "listen_addresses='*'" >> /etc/postgresql/9.6/main/postgresql.conf
+
+WORKDIR /go/src/github.com/stellar/go
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . ./
+
+ENV PGPORT=5432
+ENV PGUSER=circleci
+ENV PGHOST=localhost
+
+WORKDIR /go/src/github.com/stellar/go/exp/tools/dump-ledger-state
+
+ARG GITCOMMIT
+ENV GITCOMMIT=${GITCOMMIT}
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/exp/tools/dump-ledger-state/docker-entrypoint.sh
+++ b/exp/tools/dump-ledger-state/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+set -e
+
+/etc/init.d/postgresql start
+
+while ! psql -U circleci -d core -h localhost -p 5432 -c 'select 1' >/dev/null 2>&1; do
+    echo "Waiting for postgres to be available..."
+    sleep 1
+done
+
+stellar-core --conf ./stellar-core.cfg new-db
+
+export LATEST_LEDGER=`curl -s http://history.stellar.org/prd/core-live/core_live_001/.well-known/stellar-history.json | jq -r '.currentLedger'`
+
+if ! ./run_test.sh; then
+    curl -X POST --data-urlencode "payload={ \"username\": \"ingestion-check\", \"text\": \"ingestion dump (git commit \`$GITCOMMIT\`) of ledger \`$LATEST_LEDGER\` does not match stellar core db.\"}" $SLACK_URL
+    exit 1
+fi

--- a/exp/tools/dump-ledger-state/run_test.sh
+++ b/exp/tools/dump-ledger-state/run_test.sh
@@ -1,10 +1,12 @@
 #! /bin/bash
 set -e
 
-# Get latest ledger
-echo "Getting latest checkpoint ledger..."
-export LATEST_LEDGER=`curl -s http://history.stellar.org/prd/core-live/core_live_001/.well-known/stellar-history.json | jq -r '.currentLedger'`
-echo "Latest ledger: $LATEST_LEDGER"
+if [ -z ${LATEST_LEDGER+x} ]; then
+    # Get latest ledger
+    echo "Getting latest checkpoint ledger..."
+    export LATEST_LEDGER=`curl -s http://history.stellar.org/prd/core-live/core_live_001/.well-known/stellar-history.json | jq -r '.currentLedger'`
+    echo "Latest ledger: $LATEST_LEDGER"
+fi
 
 # Dump state using Golang
 echo "Dumping state using ingest..."
@@ -12,11 +14,11 @@ go run ./main.go
 echo "State dumped..."
 
 # Catchup core
-stellar-core catchup $LATEST_LEDGER/1
+stellar-core --conf ./stellar-core.cfg catchup $LATEST_LEDGER/1
 
 echo "Dumping state from stellar-core..."
-dump_core_db.sh
+./dump_core_db.sh
 echo "State dumped..."
 
 echo "Comparing state dumps..."
-diff_test.sh
+./diff_test.sh


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

* Add a docker image which encapsulates everything needed to run `exp/tools/dump-ledger-state/run_test.sh` along with alerting via slack in case the script fails.
* Publish the docker image upon every merge to master.

Fixes https://github.com/stellar/go/issues/1687

### Goal and scope

As stated in https://github.com/stellar/go/issues/1687 , we want to check that the data extracted from history archive snapshots matches the stellar core database. We currently implement this check as a nightly CircleCI job. However, we would like to increase the frequency so that every history archive snapshot (a snapshot is produced every 64 ledger) is covered.

We can achieve that coverage by scheduling the ingestion diff check as a kubernetes cron job which runs every 5 minutes. The kubernetes manifest would look like:

```
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  name: ledger-state-diff
spec:
  schedule: "*/5 * * * *"
  successfulJobsHistoryLimit: 0
  failedJobsHistoryLimit: 1
  jobTemplate:
    spec:
      template:
        spec:
          containers:
          - name: check
            image: stellar/ledger-state-diff:latest
            imagePullPolicy: Always
            env:
            - name: SLACK_URL
              valueFrom:
                secretKeyRef:
                  name: ledger-state-diff-alert-slack-url
                  key: url
          restartPolicy: OnFailure
```

This PR will setup automatic publishing of  `stellar/ledger-state-diff`. We will deploy the kubernetes manifest listed above once this PR is merged. 
