### PR TITLE
services/ticker: add docs about which asset in a pair is the base

### DIFF
--- a/services/ticker/docs/API.md
+++ b/services/ticker/docs/API.md
@@ -9,6 +9,14 @@ Assets from different issuers but with the same code are aggregated, so trades b
 
 are aggregated in the `XLM_BTC` pair.
 
+### Trade Pairs
+
+Trade pairs are ordered `<Counter>_<Base>`.
+
+Example:
+
+The pair `XLM_ZZZ` has the `XLM` as the counter currency and `ZZZ` as the base. For that pair if the API returns a `close` value of `2`, then the last trade for the pair was `2 XLM` exchanged for `1 ZZZ`.
+
 ### Response Fields
 
 * `generated_at`: UNIX timestamp of when data was generated


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Add docs about which asset in a trade pair is the base, and which is the counter.

### Goal and scope

To make it less confusing for new comers looking at the API to determine what the values returned by the API mean in the context of a trade pair.

It was confusing to me that the base is on the right-hand-side because the base is usually the currency on the left-hand-side, at least in traditional markets. Some examples of this:
- https://en.wikipedia.org/wiki/Currency_pair
- https://www.investopedia.com/terms/b/basecurrency.asp

We probably can't change the order at this point, and there are probably a good reason we went with this order that I'm not aware of (@tomquisel?), so documenting it at the top of the API docs should alleviate confusion.

### Summary of changes

- Add docs to `services/ticker/docs/API.md`

### Known limitations & issues

N/A

### What shouldn't be reviewed

N/A
