### PR TITLE
Reduce memory requirements of ingest_state_diff job

### DIFF
--- a/exp/tools/dump-ledger-state/diff_test.sh
+++ b/exp/tools/dump-ledger-state/diff_test.sh
@@ -8,7 +8,7 @@ do
     continue
   fi
   wc -l ${i}.csv
-  sort -S 1G -o ${i}_sorted.csv ${i}.csv
+  sort -S 500M -o ${i}_sorted.csv ${i}.csv
 done
 
 echo "Sorting stellar-core output files..."
@@ -19,7 +19,7 @@ do
     continue
   fi
   wc -l ${i}_core.csv
-  sort -S 1G -o ${i}_core_sorted.csv ${i}_core.csv
+  sort -S 500M -o ${i}_core_sorted.csv ${i}_core.csv
 done
 
 echo "Checking diffs..."


### PR DESCRIPTION
`sort` is using 90% of available memory by default. We reduced it to 1GB what was working fine however it seems that `sort` process gets killed by CI container system. This commit reduces it even more to 500MB.