### PR TITLE
all: attempt to make method for shadow checks consistent with 1.12 and 1.13

### DIFF
--- a/govet.sh
+++ b/govet.sh
@@ -8,16 +8,24 @@ printf "Running go vet shadow...\n"
 command -v shadow >/dev/null 2>&1 || (
   dir=$(mktemp -d)
   pushd $dir
-  go mod init tool
-  go get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
+  go mod init shadow
+  # The go vet -vettool option was added in 1.12, and broken in the initial
+  # 1.13 release for any vettool that doesn't support the unsafeptr flag. The
+  # shadow tool doesn't support the unsafeptr flag.  Until either support for
+  # unsafeptr is added to shadow or passing through that flag is removed from
+  # go vet we can use the anazlyer by wrapping it in our own main that ignores
+  # unsafeptr. This temporary work around was suggested here:
+  # https://github.com/golang/go/issues/34053
+  gofmt > main.go <<-EOF
+    package main
+    import "flag"
+    import "golang.org/x/tools/go/analysis/passes/shadow"
+    import "golang.org/x/tools/go/analysis/singlechecker"
+    func init() { flag.String("unsafeptr", "", "") }
+    func main() { singlechecker.Main(shadow.Analyzer) }
+EOF
+  go install
   popd
 )
 
-# The go vet -vettool option was added in 1.12, and broken in the initial 1.13
-# release. Until it is fixed we must call vettool's directly as a work around.
-# https://github.com/golang/go/issues/34053
-if [[ $GOLANG_VERSION = 1.12.* ]]; then
-  go vet -vettool=$(which shadow) ./...
-else
-  shadow ./...
-fi
+go vet -vettool=$(which shadow) ./...

--- a/govet.sh
+++ b/govet.sh
@@ -13,7 +13,7 @@ command -v shadow >/dev/null 2>&1 || (
   # 1.13 release for any vettool that doesn't support the unsafeptr flag. The
   # shadow tool doesn't support the unsafeptr flag.  Until either support for
   # unsafeptr is added to shadow or passing through that flag is removed from
-  # go vet we can use the anazlyer by wrapping it in our own main that ignores
+  # go vet we can use the analyzer by wrapping it in our own main that ignores
   # unsafeptr. This temporary work around was suggested here:
   # https://github.com/golang/go/issues/34053
   gofmt > main.go <<-EOF


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Change the `govet.sh` script so that it runs the shadows check the same way for Go 1.12 and Go 1.13 builds, wrapping the shadow analyzer in a tiny main function that catches and ignores the `unsafeptr` flag that gets passed through by `go vet` in Go 1.13+.

### Goal and scope

On a couple occasions we've had builds break after #1778 was merged. The failures reported have only been on Go 1.13. The specific failure seems to be inconsistent and was reported to golang/go#34557. The fact that we've seen this failure only occur on Go 1.13 is curious. It's possible that there's a change in the language that is contributing to that behavior, or it's possible that different way we run the shadow checker for our 1.13 builds is causing tests to be included in some different way.

When I implemented #1778 I had the option of making the 1.12 and 1.13 builds execute the binary the same way like in this PR, or to execute differently like how it was done in #1778. I mostly flipped a coin.

I'm not sure if doing it this other way will yield more consistent go vet runs, but I figure worth a shot before we remove it.

### Summary of changes

- Remove the code that runs shadow differently on Go 1.13
- When installing the shadow analyzer, wrap it in a simple main that will gobble the unsafeptr flag

### Known limitations & issues

- This might not make a difference to the failures.
- This doesn't address the actual cause of the failures, or the inconsistency, and is just attempting to make our own two builds more consistent with each other.

### What shouldn't be reviewed

N/A
