### PR TITLE
support/render/problem: add ReportFunc to report unknown errors

### DIFF
--- a/support/render/problem/problem_test.go
+++ b/support/render/problem/problem_test.go
@@ -124,3 +124,28 @@ func testRender(ctx context.Context, err error) *httptest.ResponseRecorder {
 	Render(ctx, w, err)
 	return w
 }
+
+func TestRegisterReportFunc(t *testing.T) {
+	var buf strings.Builder
+	ctx := context.Background()
+
+	reportFunc := func(ctx context.Context, err error) {
+		buf.WriteString("captured ")
+		buf.WriteString(err.Error())
+	}
+
+	err := errors.New("an unexpected error")
+
+	w := httptest.NewRecorder()
+
+	// before register the reportFunc
+	Render(ctx, w, err)
+	assert.Equal(t, "", buf.String())
+
+	RegisterReportFunc(reportFunc)
+
+	// after register the reportFunc
+	want := "captured an unexpected error"
+	Render(ctx, w, err)
+	assert.Equal(t, want, buf.String())
+}


### PR DESCRIPTION
This PR adds a function type used to report unknown errors to a
destination you like. It can be a log, sentry, or other services as long
as the function you used matches ReportFunc signature.

This PR is a part of https://github.com/stellar/go/pull/1795. We decided
to split it up since we don't want to introduce too many dependencies in
the mono-repo.