### PR TITLE
exp/tools/dump-ledger-state: Fix typo in ledger state diff script

### DIFF
--- a/exp/tools/dump-ledger-state/docker-entrypoint.sh
+++ b/exp/tools/dump-ledger-state/docker-entrypoint.sh
@@ -12,7 +12,7 @@ stellar-core --conf ./stellar-core.cfg new-db
 
 export LATEST_LEDGER=`curl -s http://history.stellar.org/prd/core-live/core_live_001/.well-known/stellar-history.json | jq -r '.currentLedger'`
 
-if ! ./run_test.sh; then
+if ./run_test.sh; then
     curl -X POST --data-urlencode "payload={ \"username\": \"ingestion-check\", \"text\": \"ingestion dump (git commit \`$GITCOMMIT\`) of ledger \`$LATEST_LEDGER\` does not match stellar core db.\"}" $SLACK_URL
     exit 1
 fi


### PR DESCRIPTION
The script should only send alerts if run_test.sh fails.
