### PR TITLE
support/render/problem: reset reportFn after test

### DIFF
--- a/support/render/problem/problem_test.go
+++ b/support/render/problem/problem_test.go
@@ -143,6 +143,7 @@ func TestRegisterReportFunc(t *testing.T) {
 	assert.Equal(t, "", buf.String())
 
 	RegisterReportFunc(reportFunc)
+	defer RegisterReportFunc(nil)
 
 	// after register the reportFunc
 	want := "captured an unexpected error"


### PR DESCRIPTION
This PR resets the global variable reportFn after the unit test to
prevent it from affecting other tests.