### PR TITLE
support/ioutil: add ReadAllSafe

### DIFF
--- a/support/ioutil/ioutil.go
+++ b/support/ioutil/ioutil.go
@@ -1,0 +1,13 @@
+// Package ioutil contains a collection of utilities for working with io.Readers.
+package ioutil
+
+import (
+	"io"
+	"io/ioutil"
+)
+
+// ReadAllSafe reads the io.Reader to it's EOF, or until the maxSizeToRead
+// bytes have been consumed.
+func ReadAllSafe(r io.Reader, maxSizeToRead int64) ([]byte, error) {
+	return ioutil.ReadAll(io.LimitReader(r, maxSizeToRead))
+}

--- a/support/ioutil/ioutil_test.go
+++ b/support/ioutil/ioutil_test.go
@@ -1,0 +1,79 @@
+package ioutil
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReadAllSafe_lessThanMax tests if the size of the contents of the reader
+// is less than the max size that it returns a byte slice containing the full
+// contents of the reader.
+func TestReadAllSafe_lessThanMax(t *testing.T) {
+	bOrig := [50]byte{}
+	_, err := rand.Read(bOrig[:])
+	require.NoError(t, err)
+
+	// Copy the original bytes to ensure we don't pollute it.
+	rBytes := bOrig
+	r := bytes.NewReader(rBytes[:])
+
+	bRead, err := ReadAllSafe(r, 100)
+	require.NoError(t, err)
+	assert.Equal(t, bOrig[:], bRead)
+}
+
+// TestReadAllSafe_eqToMax tests if the size of the contents of the reader is
+// equal to the max size that it returns a byte slice containing the full
+// contents of the reader.
+func TestReadAllSafe_eqToMax(t *testing.T) {
+	bOrig := [50]byte{}
+	_, err := rand.Read(bOrig[:])
+	require.NoError(t, err)
+
+	// Copy the original bytes to ensure we don't pollute it.
+	rBytes := bOrig
+	r := bytes.NewReader(rBytes[:])
+
+	bRead, err := ReadAllSafe(r, 50)
+	require.NoError(t, err)
+	assert.Equal(t, bOrig[:], bRead)
+}
+
+// TestReadAllSafe_greaterThanMax tests if the size of the contents of the
+// reader is greater than the max size that it returns a byte slice containing
+// the full contents of the reader.
+func TestReadAllSafe_greaterThanMax(t *testing.T) {
+	bOrig := [50]byte{}
+	_, err := rand.Read(bOrig[:])
+	require.NoError(t, err)
+
+	// Copy the original bytes to ensure we don't pollute it.
+	rBytes := bOrig
+	r := bytes.NewReader(rBytes[:])
+
+	bRead, err := ReadAllSafe(r, 40)
+	require.NoError(t, err)
+	assert.Equal(t, bOrig[:40], bRead)
+}
+
+// TestReadAllSafe_passThroughErr tests if the reader returns an error it is
+// passed through.
+func TestReadAllSafe_passThroughErr(t *testing.T) {
+	wantErr := errors.New("an error occurred")
+	r := errReader{Err: wantErr}
+	_, err := ReadAllSafe(r, 40)
+	assert.Error(t, err, wantErr)
+}
+
+type errReader struct {
+	Err error
+}
+
+func (er errReader) Read(_ []byte) (n int, err error) {
+	return 0, er.Err
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Add `"github.com/stellar/go/support/ioutil".ReadAllSafe` that behaves like `ioutil.ReadAll` but limits the bytes that will be read by the number of bytes given to the function.

### Goal and scope

When working in one of our other code bases we were frequently writing `ioutil.ReadAll(io.LimitReader(req.Body, 1024000))` and @howardtw suggested we could reduce the repetitiveness by writing a utility function. The function will also serve to standardize and knowledge share a safe way to read untrusted `io.Reader`s.

### Summary of changes

- Add `support/ioutil` package.
- Add `ReadAllSafe` function with tests.

### Known limitations & issues

- This function could be a simple way we knowledge share a safe way to use `ioutil.ReadAll`, but it doesn't address all situations where code might read an untrusted `io.Reader`. If a `req.Body` is being passed direction to a decoder like `json.Decoder` this utility function will be useless and the developer will need to know to use `io.LimitReader`.

### What shouldn't be reviewed

N/A
