### PR TITLE
txnbuild: support protocol 12

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -5,7 +5,12 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [v1.5.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.5.0) - 2019-10-09
+
 * Dropped support for Go 1.10, 1.11.
+* Add support for stellar-core [protocol 12](https://github.com/stellar/stellar-core/releases/tag/v12.0.0), which implements [CAP-0024](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0024.md) ("Make PathPayment Symmetrical"). ([#1737](https://github.com/stellar/go/issues/1737)).
+* **Deprecated:** Following CAP-0024, the operation `txnbuild.PathPayment` is now deprecated in favour of [`txnbuild.PathPaymentStrictReceive`](https://godoc.org/github.com/stellar/go/txnbuild#PathPaymentStrictReceive), and will be removed in a future release. This is a rename - the new operation behaves identically to the old one. Client code should be updated to use the new operation.
+* **Add:** New operation [`txnbuild.PathPaymentStrictSend`](https://godoc.org/github.com/stellar/go/txnbuild#PathPaymentStrictSend) allows a path payment to be made where the amount sent is specified, and the amount received can vary.
 
 ## [v1.4.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.4.0) - 2019-08-09
 

--- a/txnbuild/example_test.go
+++ b/txnbuild/example_test.go
@@ -474,6 +474,68 @@ func ExamplePathPayment() {
 	// Output: AAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAZAAMoj8AAAAEAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAACAAAAAAAAAAAF9eEAAAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAAAAAAAAAmJaAAAAAAQAAAAFBQkNEAAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAAAAAAAEuFVmYAAAAQOGE+w2bvIp8JQIPIFXWk5kO77cNUOlPZwlItA5V68/qmZTbJWq8wqdZtjELkZtNcQQX4x8EToShbn5nitG3RA4=
 }
 
+func ExamplePathPaymentStrictReceive() {
+	kp, _ := keypair.Parse("SBZVMB74Z76QZ3ZOY7UTDFYKMEGKW5XFJEB6PFKBF4UYSSWHG4EDH7PY")
+	client := horizonclient.DefaultTestNetClient
+	ar := horizonclient.AccountRequest{AccountID: kp.Address()}
+	sourceAccount, err := client.AccountDetail(ar)
+	check(err)
+
+	abcdAsset := CreditAsset{"ABCD", "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3"}
+	op := PathPaymentStrictReceive{
+		SendAsset:   NativeAsset{},
+		SendMax:     "10",
+		Destination: kp.Address(),
+		DestAsset:   NativeAsset{},
+		DestAmount:  "1",
+		Path:        []Asset{abcdAsset},
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&op},
+		Timebounds:    NewInfiniteTimeout(), // Use a real timeout in production!
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	txe, err := tx.BuildSignEncode(kp.(*keypair.Full))
+	check(err)
+	fmt.Println(txe)
+
+	// Output: AAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAZAAMoj8AAAAEAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAACAAAAAAAAAAAF9eEAAAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAAAAAAAAAmJaAAAAAAQAAAAFBQkNEAAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAAAAAAAEuFVmYAAAAQOGE+w2bvIp8JQIPIFXWk5kO77cNUOlPZwlItA5V68/qmZTbJWq8wqdZtjELkZtNcQQX4x8EToShbn5nitG3RA4=
+}
+
+func ExamplePathPaymentStrictSend() {
+	kp, _ := keypair.Parse("SBZVMB74Z76QZ3ZOY7UTDFYKMEGKW5XFJEB6PFKBF4UYSSWHG4EDH7PY")
+	client := horizonclient.DefaultTestNetClient
+	ar := horizonclient.AccountRequest{AccountID: kp.Address()}
+	sourceAccount, err := client.AccountDetail(ar)
+	check(err)
+
+	abcdAsset := CreditAsset{"ABCD", "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3"}
+	op := PathPaymentStrictSend{
+		SendAsset:   NativeAsset{},
+		SendAmount:  "1",
+		Destination: kp.Address(),
+		DestAsset:   NativeAsset{},
+		DestMin:     "10",
+		Path:        []Asset{abcdAsset},
+	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&op},
+		Timebounds:    NewInfiniteTimeout(), // Use a real timeout in production!
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	txe, err := tx.BuildSignEncode(kp.(*keypair.Full))
+	check(err)
+	fmt.Println(txe)
+
+	// Output: AAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAZAAMoj8AAAAEAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAANAAAAAAAAAAAAmJaAAAAAAH4RyzTWNfXhqwLUoCw91aWkZtgIzY8SAVkIPc0uFVmYAAAAAAAAAAAF9eEAAAAAAQAAAAFBQkNEAAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAAAAAAAEuFVmYAAAAQNXoKZHgBO+2baoHMcT1SqpL3lmcggeCm5TuFNk7fwMeF/6h5lDTYMa+y3i9gwwAg8aQwCwuV8A38AWKfPvgMAM=
+}
+
 func ExampleManageBuyOffer() {
 	kp, _ := keypair.Parse("SBZVMB74Z76QZ3ZOY7UTDFYKMEGKW5XFJEB6PFKBF4UYSSWHG4EDH7PY")
 	client := horizonclient.DefaultTestNetClient

--- a/txnbuild/path_payment.go
+++ b/txnbuild/path_payment.go
@@ -8,7 +8,7 @@ import (
 
 // PathPayment represents the Stellar path_payment operation. This operation was removed
 // in Stellar Protocol 12 and replaced by PathPaymentStrictReceive.
-// Deprecated: This operation is deprecated in favour of PathPaymentStrictReceive,
+// Deprecated: This operation was renamed to PathPaymentStrictReceive,
 // which functions identically.
 type PathPayment = PathPaymentStrictReceive
 

--- a/txnbuild/path_payment.go
+++ b/txnbuild/path_payment.go
@@ -6,15 +6,15 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
+// PathPayment represents the Stellar path_payment operation. This operation was removed
+// in Stellar Protocol 12.
+// Deprecated: This operation is deprecated in favour of PathPaymentStrictReceive,
+// which functions identically.
+type PathPayment = PathPaymentStrictReceive
+
 // PathPaymentStrictReceive represents the Stellar path_payment_strict_receive operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
-type PathPaymentStrictReceive = PathPayment
-
-// PathPayment represents the Stellar path payment operation. See
-// https://www.stellar.org/developers/guides/concepts/list-of-operations.html
-// Deprecated: This operation is deprecated in favour of PathPaymentStrictReceive, which functions
-// identically.
-type PathPayment struct {
+type PathPaymentStrictReceive struct {
 	SendAsset     Asset
 	SendMax       string
 	Destination   string
@@ -24,8 +24,8 @@ type PathPayment struct {
 	SourceAccount Account
 }
 
-// BuildXDR for Payment returns a fully configured XDR Operation.
-func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
+// BuildXDR for PathPaymentStrictReceive returns a fully configured XDR Operation.
+func (pp *PathPaymentStrictReceive) BuildXDR() (xdr.Operation, error) {
 	// Set XDR send asset
 	if pp.SendAsset == nil {
 		return xdr.Operation{}, errors.New("you must specify an asset to send for payment")
@@ -92,8 +92,8 @@ func (pp *PathPayment) BuildXDR() (xdr.Operation, error) {
 	return op, nil
 }
 
-// FromXDR for PathPayment initialises the txnbuild struct from the corresponding xdr Operation.
-func (pp *PathPayment) FromXDR(xdrOp xdr.Operation) error {
+// FromXDR for PathPaymentStrictReceive initialises the txnbuild struct from the corresponding xdr Operation.
+func (pp *PathPaymentStrictReceive) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetPathPaymentStrictReceiveOp()
 	if !ok {
 		return errors.New("error parsing path_payment operation from xdr")
@@ -128,9 +128,9 @@ func (pp *PathPayment) FromXDR(xdrOp xdr.Operation) error {
 	return nil
 }
 
-// Validate for PathPayment validates the required struct fields. It returns an error if any
+// Validate for PathPaymentStrictReceive validates the required struct fields. It returns an error if any
 // of the fields are invalid. Otherwise, it returns nil.
-func (pp *PathPayment) Validate() error {
+func (pp *PathPaymentStrictReceive) Validate() error {
 	err := validateStellarPublicKey(pp.Destination)
 	if err != nil {
 		return NewValidationError("Destination", err.Error())

--- a/txnbuild/path_payment.go
+++ b/txnbuild/path_payment.go
@@ -6,12 +6,14 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-// PathPayment represents the Stellar path_payment_strict_receive operation. See
+// PathPaymentStrictReceive represents the Stellar path_payment_strict_receive operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
-type PathPaymentStrictReceive PathPayment
+type PathPaymentStrictReceive = PathPayment
 
 // PathPayment represents the Stellar path payment operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
+// Deprecated: This operation is deprecated in favour of PathPaymentStrictReceive, which functions
+// identically.
 type PathPayment struct {
 	SendAsset     Asset
 	SendMax       string

--- a/txnbuild/path_payment.go
+++ b/txnbuild/path_payment.go
@@ -7,7 +7,7 @@ import (
 )
 
 // PathPayment represents the Stellar path_payment operation. This operation was removed
-// in Stellar Protocol 12.
+// in Stellar Protocol 12 and replaced by PathPaymentStrictReceive.
 // Deprecated: This operation is deprecated in favour of PathPaymentStrictReceive,
 // which functions identically.
 type PathPayment = PathPaymentStrictReceive

--- a/txnbuild/path_payment_test.go
+++ b/txnbuild/path_payment_test.go
@@ -31,7 +31,7 @@ func TestPathPaymentValidateSendAsset(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.PathPayment operation: Field: SendAsset, Error: asset issuer: public key is undefined"
+		expected := "validation failed for *txnbuild.PathPaymentStrictReceive operation: Field: SendAsset, Error: asset issuer: public key is undefined"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -60,7 +60,7 @@ func TestPathPaymentValidateDestAsset(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.PathPayment operation: Field: DestAsset, Error: asset code length must be between 1 and 12 characters"
+		expected := "validation failed for *txnbuild.PathPaymentStrictReceive operation: Field: DestAsset, Error: asset code length must be between 1 and 12 characters"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -89,7 +89,7 @@ func TestPathPaymentValidateDestination(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.PathPayment operation: Field: Destination, Error: SASND3NRUY5K43PN3H3HOP5JNTIDXJFLOKKNSCZQQAFBRSEIRD5OJKXZ is not a valid stellar public key"
+		expected := "validation failed for *txnbuild.PathPaymentStrictReceive operation: Field: Destination, Error: SASND3NRUY5K43PN3H3HOP5JNTIDXJFLOKKNSCZQQAFBRSEIRD5OJKXZ is not a valid stellar public key"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -118,7 +118,7 @@ func TestPathPaymentValidateSendMax(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.PathPayment operation: Field: SendMax, Error: invalid amount format: abc"
+		expected := "validation failed for *txnbuild.PathPaymentStrictReceive operation: Field: SendMax, Error: invalid amount format: abc"
 		assert.Contains(t, err.Error(), expected)
 	}
 }
@@ -147,7 +147,7 @@ func TestPathPaymentValidateDestAmount(t *testing.T) {
 
 	err := tx.Build()
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.PathPayment operation: Field: DestAmount, Error: amount can not be negative"
+		expected := "validation failed for *txnbuild.PathPaymentStrictReceive operation: Field: DestAmount, Error: amount can not be negative"
 		assert.Contains(t, err.Error(), expected)
 	}
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Fixes `PathPaymentStrictReceive`, so we can release `txnbuild` support for v12. Prior to this fix methods on this struct are not usable.

### Summary of changes

* Used an [alias definition](https://yourbasic.org/golang/type-alias/) to allow methods on `PathPaymentStrictReceive` to be called
* Added testable examples to the docs
* Updated changelog

### Known limitations & issues

Still need to update more general docs in developers repo. ~TODO: needs to be based from a new release branch `release-horizonclient-v1.5.0`.~

### What shouldn't be reviewed

N/A
