### PR TITLE
services/horizon: Add accounts and account data to ingestion pipeline

### DIFF
--- a/exp/ingest/io/ledger_transaction.go
+++ b/exp/ingest/io/ledger_transaction.go
@@ -1,6 +1,9 @@
 package io
 
 import (
+	"bytes"
+
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 
@@ -13,8 +16,77 @@ import (
 // If an entry is removed: Pre is not nil and Post is nil.
 type Change struct {
 	Type xdr.LedgerEntryType
-	Pre  *xdr.LedgerEntryData
-	Post *xdr.LedgerEntryData
+	Pre  *xdr.LedgerEntry
+	Post *xdr.LedgerEntry
+}
+
+// AccountChangedExceptSigners returns true if account has changed WITHOUT
+// checking the signers (except master key weight!). In other words, if the only
+// change is connected to signers, this function will return false.
+func (c *Change) AccountChangedExceptSigners() (bool, error) {
+	if c.Type != xdr.LedgerEntryTypeAccount {
+		panic("This should not be called on changes other than Account changes")
+	}
+
+	// New account
+	if c.Pre == nil {
+		return true, nil
+	}
+
+	// Account merged
+	// c.Pre != nil at this point.
+	if c.Post == nil {
+		return true, nil
+	}
+
+	// c.Pre != nil && c.Post != nil at this point.
+	if c.Pre.LastModifiedLedgerSeq != c.Post.LastModifiedLedgerSeq {
+		return true, nil
+	}
+
+	// Don't use short assignment statement (:=) to ensure variables below
+	// are not pointers (if `xdr` package changes in the future)!
+	var preAccountEntry, postAccountEntry xdr.AccountEntry
+	preAccountEntry = c.Pre.Data.MustAccount()
+	postAccountEntry = c.Post.Data.MustAccount()
+
+	// preAccountEntry and postAccountEntry are copies so it's fine to
+	// modify them here, EXCEPT pointers inside them!
+	if preAccountEntry.Ext.V == 0 {
+		preAccountEntry.Ext.V = 1
+		preAccountEntry.Ext.V1 = &xdr.AccountEntryV1{
+			Liabilities: xdr.Liabilities{
+				Buying:  0,
+				Selling: 0,
+			},
+		}
+	}
+
+	preAccountEntry.Signers = nil
+
+	if postAccountEntry.Ext.V == 0 {
+		postAccountEntry.Ext.V = 1
+		postAccountEntry.Ext.V1 = &xdr.AccountEntryV1{
+			Liabilities: xdr.Liabilities{
+				Buying:  0,
+				Selling: 0,
+			},
+		}
+	}
+
+	postAccountEntry.Signers = nil
+
+	preBinary, err := preAccountEntry.MarshalBinary()
+	if err != nil {
+		return false, errors.Wrap(err, "Error running preAccountEntry.MarshalBinary")
+	}
+
+	postBinary, err := postAccountEntry.MarshalBinary()
+	if err != nil {
+		return false, errors.Wrap(err, "Error running postAccountEntry.MarshalBinary")
+	}
+
+	return !bytes.Equal(preBinary, postBinary), nil
 }
 
 // AccountSignersChanged returns true if account signers have changed.
@@ -36,8 +108,8 @@ func (c *Change) AccountSignersChanged() bool {
 	}
 
 	// c.Pre != nil && c.Post != nil at this point.
-	preAccountEntry := c.Pre.MustAccount()
-	postAccountEntry := c.Post.MustAccount()
+	preAccountEntry := c.Pre.Data.MustAccount()
+	postAccountEntry := c.Post.Data.MustAccount()
 
 	preSigners := preAccountEntry.SignerSummary()
 	postSigners := postAccountEntry.SignerSummary()
@@ -106,21 +178,21 @@ func getChangesFromLedgerEntryChanges(ledgerEntryChanges xdr.LedgerEntryChanges)
 			changes = append(changes, Change{
 				Type: created.Data.Type,
 				Pre:  nil,
-				Post: &created.Data,
+				Post: &created,
 			})
 		case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
 			state := ledgerEntryChanges[i-1].MustState()
 			updated := entryChange.MustUpdated()
 			changes = append(changes, Change{
 				Type: state.Data.Type,
-				Pre:  &state.Data,
-				Post: &updated.Data,
+				Pre:  &state,
+				Post: &updated,
 			})
 		case xdr.LedgerEntryChangeTypeLedgerEntryRemoved:
 			state := ledgerEntryChanges[i-1].MustState()
 			changes = append(changes, Change{
 				Type: state.Data.Type,
-				Pre:  &state.Data,
+				Pre:  &state,
 				Post: nil,
 			})
 		case xdr.LedgerEntryChangeTypeLedgerEntryState:

--- a/exp/tools/horizon-demo/database_processor.go
+++ b/exp/tools/horizon-demo/database_processor.go
@@ -128,19 +128,19 @@ func (p *DatabaseProcessor) processLedgerAccountsForSigner(transaction io.Ledger
 			continue
 		}
 
-		accountEntry := change.Pre.MustAccount()
+		accountEntry := change.Pre.Data.MustAccount()
 		account := accountEntry.AccountId.Address()
 
 		// This removes all Pre signers adds Post signers but can be
 		// improved by finding a diff
-		for _, signer := range change.Pre.MustAccount().Signers {
+		for _, signer := range change.Pre.Data.MustAccount().Signers {
 			_, err := p.Database.RemoveAccountSigner(account, signer.Key.Address())
 			if err != nil {
 				return errors.Wrap(err, "Error removing a signer")
 			}
 		}
 
-		for _, signer := range change.Post.MustAccount().Signers {
+		for _, signer := range change.Post.Data.MustAccount().Signers {
 			_, err := p.Database.InsertAccountSigner(account, signer.Key.Address())
 			if err != nil {
 				return errors.Wrap(err, "Error inserting a signer")

--- a/exp/tools/horizon-demo/orderbook_processor.go
+++ b/exp/tools/horizon-demo/orderbook_processor.go
@@ -73,11 +73,11 @@ func (p *OrderbookProcessor) ProcessLedger(ctx context.Context, store *pipeline.
 			switch {
 			case change.Post != nil:
 				// Created or updated
-				offer := change.Post.MustOffer()
+				offer := change.Post.Data.MustOffer()
 				p.OrderBookGraph.AddOffer(offer)
 			case change.Pre != nil && change.Post == nil:
 				// Removed
-				offer := change.Pre.MustOffer()
+				offer := change.Pre.Data.MustOffer()
 				p.OrderBookGraph.RemoveOffer(offer.OfferId)
 			}
 		}

--- a/services/horizon/internal/db2/history/account_data.go
+++ b/services/horizon/internal/db2/history/account_data.go
@@ -1,0 +1,138 @@
+package history
+
+import (
+	"encoding/base64"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+func (q *Q) CountAccountsData() (int, error) {
+	sql := sq.Select("count(*)").From("accounts_data")
+
+	var count int
+	if err := q.Get(&count, sql); err != nil {
+		return 0, errors.Wrap(err, "could not run select query")
+	}
+
+	return count, nil
+}
+
+// GetAccountDataByKeys loads a row from the `accounts_data` table, selected by multiple keys.
+func (q *Q) GetAccountDataByKeys(keys []xdr.LedgerKeyData) ([]Data, error) {
+	var data []Data
+	lkeys := make([]string, 0, len(keys))
+	for _, key := range keys {
+		lkey, err := ledgerKeyDataToString(key)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error running ledgerKeyTrustLineToString")
+		}
+		lkeys = append(lkeys, lkey)
+	}
+	sql := selectAccountData.Where(map[string]interface{}{"accounts_data.lkey": lkeys})
+	err := q.Select(&data, sql)
+	return data, err
+}
+
+func ledgerKeyDataToString(data xdr.LedgerKeyData) (string, error) {
+	ledgerKey := &xdr.LedgerKey{}
+	err := ledgerKey.SetData(data.AccountId, string(data.DataName))
+	if err != nil {
+		return "", errors.Wrap(err, "Error running ledgerKey.SetData")
+	}
+	key, err := ledgerKey.MarshalBinary()
+	if err != nil {
+		return "", errors.Wrap(err, "Error running MarshalBinaryCompress")
+	}
+
+	return base64.StdEncoding.EncodeToString(key), nil
+}
+
+func dataEntryToLedgerKeyString(data xdr.DataEntry) (string, error) {
+	ledgerKey := &xdr.LedgerKey{}
+	err := ledgerKey.SetData(data.AccountId, string(data.DataName))
+	if err != nil {
+		return "", errors.Wrap(err, "Error running ledgerKey.SetTrustline")
+	}
+	key, err := ledgerKey.MarshalBinary()
+	if err != nil {
+		return "", errors.Wrap(err, "Error running MarshalBinaryCompress")
+	}
+
+	return base64.StdEncoding.EncodeToString(key), nil
+}
+
+// InsertAccountData creates a row in the accounts_data table.
+// Returns number of rows affected and error.
+func (q *Q) InsertAccountData(data xdr.DataEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
+	// Add lkey only when inserting rows
+	key, err := dataEntryToLedgerKeyString(data)
+	if err != nil {
+		return 0, errors.Wrap(err, "Error running dataEntryToLedgerKeyString")
+	}
+
+	sql := sq.Insert("accounts_data").
+		Columns("lkey", "account", "name", "value", "last_modified_ledger").
+		Values(
+			key,
+			data.AccountId.Address(),
+			data.DataName,
+			AccountDataValue(data.DataValue),
+			lastModifiedLedger,
+		)
+
+	result, err := q.Exec(sql)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.RowsAffected()
+}
+
+// UpdateAccountData updates a row in the accounts_data table.
+// Returns number of rows affected and error.
+func (q *Q) UpdateAccountData(data xdr.DataEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
+	key, err := dataEntryToLedgerKeyString(data)
+	if err != nil {
+		return 0, errors.Wrap(err, "Error running dataEntryToLedgerKeyString")
+	}
+
+	sql := sq.Update("accounts_data").
+		SetMap(map[string]interface{}{
+			"value":                AccountDataValue(data.DataValue),
+			"last_modified_ledger": lastModifiedLedger,
+		}).
+		Where(sq.Eq{"lkey": key})
+	result, err := q.Exec(sql)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.RowsAffected()
+}
+
+// RemoveAccountData deletes a row in the accounts_data table.
+// Returns number of rows affected and error.
+func (q *Q) RemoveAccountData(key xdr.LedgerKeyData) (int64, error) {
+	lkey, err := ledgerKeyDataToString(key)
+	if err != nil {
+		return 0, errors.Wrap(err, "Error running ledgerKeyDataToString")
+	}
+
+	sql := sq.Delete("accounts_data").
+		Where(sq.Eq{"lkey": lkey})
+	result, err := q.Exec(sql)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.RowsAffected()
+}
+
+var selectAccountData = sq.Select(`
+	account,
+	name,
+	value,
+	last_modified_ledger
+`).From("accounts_data")

--- a/services/horizon/internal/db2/history/account_data_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/account_data_batch_insert_builder.go
@@ -1,0 +1,26 @@
+package history
+
+import (
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+func (i *accountDataBatchInsertBuilder) Add(data xdr.DataEntry, lastModifiedLedger xdr.Uint32) error {
+	// Add lkey only when inserting rows
+	key, err := dataEntryToLedgerKeyString(data)
+	if err != nil {
+		return errors.Wrap(err, "Error running dataEntryToLedgerKeyString")
+	}
+
+	return i.builder.Row(map[string]interface{}{
+		"lkey":                 key,
+		"account":              data.AccountId.Address(),
+		"name":                 data.DataName,
+		"value":                AccountDataValue(data.DataValue),
+		"last_modified_ledger": lastModifiedLedger,
+	})
+}
+
+func (i *accountDataBatchInsertBuilder) Exec() error {
+	return i.builder.Exec()
+}

--- a/services/horizon/internal/db2/history/account_data_test.go
+++ b/services/horizon/internal/db2/history/account_data_test.go
@@ -1,0 +1,108 @@
+package history
+
+import (
+	"testing"
+
+	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	data1 = xdr.DataEntry{
+		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		DataName:  "test data",
+		// This also tests if base64 encoding is working as 0 is invalid UTF-8 byte
+		DataValue: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+	}
+
+	data2 = xdr.DataEntry{
+		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		DataName:  "test data2",
+		DataValue: []byte{10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
+	}
+)
+
+func TestInsertAccountData(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	rows, err := q.InsertAccountData(data1, 1234)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rows)
+
+	rows, err = q.InsertAccountData(data2, 1235)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rows)
+
+	keys := []xdr.LedgerKeyData{
+		{AccountId: data1.AccountId, DataName: data1.DataName},
+		{AccountId: data2.AccountId, DataName: data2.DataName},
+	}
+
+	datas, err := q.GetAccountDataByKeys(keys)
+	assert.NoError(t, err)
+	assert.Len(t, datas, 2)
+
+	assert.Equal(t, data1.DataName, xdr.String64(datas[0].Name))
+	assert.Equal(t, []byte(data1.DataValue), []byte(datas[0].Value))
+
+	assert.Equal(t, data2.DataName, xdr.String64(datas[1].Name))
+	assert.Equal(t, []byte(data2.DataValue), []byte(datas[1].Value))
+}
+
+func TestUpdateAccountData(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	rows, err := q.InsertAccountData(data1, 1234)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rows)
+
+	modifiedData := data1
+	modifiedData.DataValue[0] = 1
+
+	rows, err = q.UpdateAccountData(modifiedData, 1235)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rows)
+
+	keys := []xdr.LedgerKeyData{
+		{AccountId: data1.AccountId, DataName: data1.DataName},
+	}
+	datas, err := q.GetAccountDataByKeys(keys)
+	assert.NoError(t, err)
+	assert.Len(t, datas, 1)
+
+	assert.Equal(t, modifiedData.DataName, xdr.String64(datas[0].Name))
+	assert.Equal(t, []byte(modifiedData.DataValue), []byte(datas[0].Value))
+	assert.Equal(t, uint32(1235), datas[0].LastModifiedLedger)
+}
+
+func TestRemoveAccountData(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	rows, err := q.InsertAccountData(data1, 1234)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rows)
+
+	key := xdr.LedgerKeyData{AccountId: data1.AccountId, DataName: data1.DataName}
+	rows, err = q.RemoveAccountData(key)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rows)
+
+	datas, err := q.GetAccountDataByKeys([]xdr.LedgerKeyData{key})
+	assert.NoError(t, err)
+	assert.Len(t, datas, 0)
+
+	// Doesn't exist anymore
+	rows, err = q.RemoveAccountData(key)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), rows)
+}

--- a/services/horizon/internal/db2/history/account_data_value.go
+++ b/services/horizon/internal/db2/history/account_data_value.go
@@ -1,0 +1,26 @@
+package history
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"encoding/base64"
+)
+
+var _ driver.Valuer = (*AccountDataValue)(nil)
+var _ sql.Scanner = (*AccountDataValue)(nil)
+
+// Scan base64 decodes into an []byte
+func (t *AccountDataValue) Scan(src interface{}) error {
+	decoded, err := base64.StdEncoding.DecodeString(src.(string))
+	if err != nil {
+		return err
+	}
+
+	*t = decoded
+	return nil
+}
+
+// Value implements driver.Valuer
+func (value AccountDataValue) Value() (driver.Value, error) {
+	return driver.Value([]uint8(base64.StdEncoding.EncodeToString(value))), nil
+}

--- a/services/horizon/internal/db2/history/account_signers.go
+++ b/services/horizon/internal/db2/history/account_signers.go
@@ -6,17 +6,6 @@ import (
 	"github.com/stellar/go/support/errors"
 )
 
-func (q *Q) CountAccounts() (int, error) {
-	sql := sq.Select("count(distinct account)").From("accounts_signers")
-
-	var count int
-	if err := q.Get(&count, sql); err != nil {
-		return 0, errors.Wrap(err, "could not run select query")
-	}
-
-	return count, nil
-}
-
 func (q *Q) SignersForAccounts(accounts []string) ([]AccountSigner, error) {
 	sql := selectAccountSigners.Where(map[string]interface{}{"accounts_signers.account": accounts})
 

--- a/services/horizon/internal/db2/history/accounts.go
+++ b/services/horizon/internal/db2/history/accounts.go
@@ -1,0 +1,117 @@
+package history
+
+import (
+	sq "github.com/Masterminds/squirrel"
+
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+func (q *Q) CountAccounts() (int, error) {
+	sql := sq.Select("count(*)").From("accounts")
+
+	var count int
+	if err := q.Get(&count, sql); err != nil {
+		return 0, errors.Wrap(err, "could not run select query")
+	}
+
+	return count, nil
+}
+
+func (q *Q) GetAccountsByIDs(ids []string) ([]AccountEntry, error) {
+	var accounts []AccountEntry
+	sql := selectAccounts.Where(map[string]interface{}{"accounts.account_id": ids})
+	err := q.Select(&accounts, sql)
+	return accounts, err
+}
+
+func accountToMap(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) map[string]interface{} {
+	var buyingliabilities, sellingliabilities xdr.Int64
+	if account.Ext.V1 != nil {
+		v1 := account.Ext.V1
+		buyingliabilities = v1.Liabilities.Buying
+		sellingliabilities = v1.Liabilities.Selling
+	}
+
+	var inflationDestination = ""
+	if account.InflationDest != nil {
+		inflationDestination = account.InflationDest.Address()
+	}
+
+	return map[string]interface{}{
+		"account_id":            account.AccountId.Address(),
+		"balance":               account.Balance,
+		"buying_liabilities":    buyingliabilities,
+		"selling_liabilities":   sellingliabilities,
+		"sequence_number":       account.SeqNum,
+		"num_subentries":        account.NumSubEntries,
+		"inflation_destination": inflationDestination,
+		"flags":                 account.Flags,
+		"home_domain":           account.HomeDomain,
+		"master_weight":         account.MasterKeyWeight(),
+		"threshold_low":         account.ThresholdLow(),
+		"threshold_medium":      account.ThresholdMedium(),
+		"threshold_high":        account.ThresholdHigh(),
+		"last_modified_ledger":  lastModifiedLedger,
+	}
+}
+
+// InsertAccount creates a row in the accounts table.
+// Returns number of rows affected and error.
+func (q *Q) InsertAccount(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
+	m := accountToMap(account, lastModifiedLedger)
+
+	sql := sq.Insert("accounts").SetMap(m)
+	result, err := q.Exec(sql)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.RowsAffected()
+}
+
+// UpdateAccount updates a row in the offers table.
+// Returns number of rows affected and error.
+func (q *Q) UpdateAccount(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
+	m := accountToMap(account, lastModifiedLedger)
+
+	accountID := m["account_id"]
+	delete(m, "account_id")
+
+	sql := sq.Update("accounts").SetMap(m).Where(sq.Eq{"account_id": accountID})
+	result, err := q.Exec(sql)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.RowsAffected()
+}
+
+// RemoveAccount deletes a row in the offers table.
+// Returns number of rows affected and error.
+func (q *Q) RemoveAccount(accountID string) (int64, error) {
+	sql := sq.Delete("accounts").Where(sq.Eq{"account_id": accountID})
+	result, err := q.Exec(sql)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.RowsAffected()
+}
+
+var selectAccounts = sq.Select(`
+	account_id,
+	balance,
+	buying_liabilities,
+	selling_liabilities,
+	sequence_number,
+	num_subentries,
+	inflation_destination,
+	flags,
+	home_domain,
+	master_weight,
+	threshold_low,
+	threshold_medium,
+	threshold_high,
+	last_modified_ledger
+`).From("accounts")

--- a/services/horizon/internal/db2/history/accounts_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/accounts_batch_insert_builder.go
@@ -1,0 +1,11 @@
+package history
+
+import "github.com/stellar/go/xdr"
+
+func (i *accountsBatchInsertBuilder) Add(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) error {
+	return i.builder.Row(accountToMap(account, lastModifiedLedger))
+}
+
+func (i *accountsBatchInsertBuilder) Exec() error {
+	return i.builder.Exec()
+}

--- a/services/horizon/internal/db2/history/accounts_test.go
+++ b/services/horizon/internal/db2/history/accounts_test.go
@@ -1,0 +1,172 @@
+package history
+
+import (
+	"testing"
+
+	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	inflationDest = xdr.MustAddress("GBUH7T6U36DAVEKECMKN5YEBQYZVRBPNSZAAKBCO6P5HBMDFSQMQL4Z4")
+
+	account1 = xdr.AccountEntry{
+		AccountId:     xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		Balance:       20000,
+		SeqNum:        223456789,
+		NumSubEntries: 10,
+		InflationDest: &inflationDest,
+		Flags:         1,
+		HomeDomain:    "stellar.org",
+		Thresholds:    xdr.Thresholds{1, 2, 3, 4},
+		Ext: xdr.AccountEntryExt{
+			V: 1,
+			V1: &xdr.AccountEntryV1{
+				Liabilities: xdr.Liabilities{
+					Buying:  3,
+					Selling: 4,
+				},
+			},
+		},
+	}
+
+	account2 = xdr.AccountEntry{
+		AccountId:     xdr.MustAddress("GCT2NQM5KJJEF55NPMY444C6M6CA7T33HRNCMA6ZFBIIXKNCRO6J25K7"),
+		Balance:       50000,
+		SeqNum:        648736,
+		NumSubEntries: 10,
+		InflationDest: &inflationDest,
+		Flags:         2,
+		HomeDomain:    "meridian.stellar.org",
+		Thresholds:    xdr.Thresholds{5, 6, 7, 8},
+		Ext: xdr.AccountEntryExt{
+			V: 1,
+			V1: &xdr.AccountEntryV1{
+				Liabilities: xdr.Liabilities{
+					Buying:  30,
+					Selling: 40,
+				},
+			},
+		},
+	}
+)
+
+func TestInsertAccount(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	rows, err := q.InsertAccount(account1, 1234)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rows)
+
+	rows, err = q.InsertAccount(account2, 1235)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rows)
+
+	accounts, err := q.GetAccountsByIDs([]string{
+		"GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB",
+		"GCT2NQM5KJJEF55NPMY444C6M6CA7T33HRNCMA6ZFBIIXKNCRO6J25K7",
+	})
+	assert.NoError(t, err)
+	assert.Len(t, accounts, 2)
+
+	assert.Equal(t, "GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB", accounts[0].AccountID)
+	assert.Equal(t, int64(20000), accounts[0].Balance)
+	assert.Equal(t, int64(223456789), accounts[0].SequenceNumber)
+	assert.Equal(t, uint32(10), accounts[0].NumSubEntries)
+	assert.Equal(t, "GBUH7T6U36DAVEKECMKN5YEBQYZVRBPNSZAAKBCO6P5HBMDFSQMQL4Z4", accounts[0].InflationDestination)
+	assert.Equal(t, uint32(1), accounts[0].Flags)
+	assert.Equal(t, "stellar.org", accounts[0].HomeDomain)
+	assert.Equal(t, byte(1), accounts[0].MasterWeight)
+	assert.Equal(t, byte(2), accounts[0].ThresholdLow)
+	assert.Equal(t, byte(3), accounts[0].ThresholdMedium)
+	assert.Equal(t, byte(4), accounts[0].ThresholdHigh)
+	assert.Equal(t, int64(3), accounts[0].BuyingLiabilities)
+	assert.Equal(t, int64(4), accounts[0].SellingLiabilities)
+}
+
+func TestUpdateAccount(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	rows, err := q.InsertAccount(account1, 1234)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rows)
+
+	modifiedAccount := account1
+	modifiedAccount.Balance = 32847893
+
+	rows, err = q.UpdateAccount(modifiedAccount, 1235)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rows)
+
+	keys := []string{
+		"GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB",
+		"GCT2NQM5KJJEF55NPMY444C6M6CA7T33HRNCMA6ZFBIIXKNCRO6J25K7",
+	}
+	accounts, err := q.GetAccountsByIDs(keys)
+	assert.NoError(t, err)
+	assert.Len(t, accounts, 1)
+
+	expectedBinary, err := modifiedAccount.MarshalBinary()
+	assert.NoError(t, err)
+
+	dbEntry := xdr.AccountEntry{
+		AccountId:     xdr.MustAddress(accounts[0].AccountID),
+		Balance:       xdr.Int64(accounts[0].Balance),
+		SeqNum:        xdr.SequenceNumber(accounts[0].SequenceNumber),
+		NumSubEntries: xdr.Uint32(accounts[0].NumSubEntries),
+		InflationDest: &inflationDest,
+		Flags:         xdr.Uint32(accounts[0].Flags),
+		HomeDomain:    xdr.String32(accounts[0].HomeDomain),
+		Thresholds: xdr.Thresholds{
+			accounts[0].MasterWeight,
+			accounts[0].ThresholdLow,
+			accounts[0].ThresholdMedium,
+			accounts[0].ThresholdHigh,
+		},
+		Ext: xdr.AccountEntryExt{
+			V: 1,
+			V1: &xdr.AccountEntryV1{
+				Liabilities: xdr.Liabilities{
+					Buying:  xdr.Int64(accounts[0].BuyingLiabilities),
+					Selling: xdr.Int64(accounts[0].SellingLiabilities),
+				},
+			},
+		},
+	}
+
+	actualBinary, err := dbEntry.MarshalBinary()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBinary, actualBinary)
+	assert.Equal(t, uint32(1235), accounts[0].LastModifiedLedger)
+}
+
+func TestRemoveAccount(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	rows, err := q.InsertAccount(account1, 1234)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rows)
+
+	rows, err = q.RemoveAccount("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rows)
+
+	accounts, err := q.GetAccountsByIDs([]string{"GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"})
+	assert.NoError(t, err)
+	assert.Len(t, accounts, 0)
+
+	// Doesn't exist anymore
+	rows, err = q.RemoveAccount("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), rows)
+}

--- a/services/horizon/internal/db2/history/mock_account_data_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_account_data_batch_insert_builder.go
@@ -1,0 +1,20 @@
+package history
+
+import (
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockAccountDataBatchInsertBuilder struct {
+	mock.Mock
+}
+
+func (m *MockAccountDataBatchInsertBuilder) Add(data xdr.DataEntry, lastModifiedLedger xdr.Uint32) error {
+	a := m.Called(data, lastModifiedLedger)
+	return a.Error(0)
+}
+
+func (m *MockAccountDataBatchInsertBuilder) Exec() error {
+	a := m.Called()
+	return a.Error(0)
+}

--- a/services/horizon/internal/db2/history/mock_accounts_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_accounts_batch_insert_builder.go
@@ -1,0 +1,20 @@
+package history
+
+import (
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockAccountsBatchInsertBuilder struct {
+	mock.Mock
+}
+
+func (m *MockAccountsBatchInsertBuilder) Add(accounts xdr.AccountEntry, lastModifiedLedger xdr.Uint32) error {
+	a := m.Called(accounts, lastModifiedLedger)
+	return a.Error(0)
+}
+
+func (m *MockAccountsBatchInsertBuilder) Exec() error {
+	a := m.Called()
+	return a.Error(0)
+}

--- a/services/horizon/internal/db2/history/mock_q_accounts.go
+++ b/services/horizon/internal/db2/history/mock_q_accounts.go
@@ -1,0 +1,37 @@
+package history
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"github.com/stellar/go/xdr"
+)
+
+// MockQAccounts is a mock implementation of the QAccounts interface
+type MockQAccounts struct {
+	mock.Mock
+}
+
+func (m *MockQAccounts) GetAccountsByIDs(ids []string) ([]AccountEntry, error) {
+	a := m.Called()
+	return a.Get(0).([]AccountEntry), a.Error(1)
+}
+
+func (m *MockQAccounts) NewAccountsBatchInsertBuilder(maxBatchSize int) AccountsBatchInsertBuilder {
+	a := m.Called(maxBatchSize)
+	return a.Get(0).(AccountsBatchInsertBuilder)
+}
+
+func (m *MockQAccounts) InsertAccount(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
+	a := m.Called(account, lastModifiedLedger)
+	return a.Get(0).(int64), a.Error(1)
+}
+
+func (m *MockQAccounts) UpdateAccount(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
+	a := m.Called(account, lastModifiedLedger)
+	return a.Get(0).(int64), a.Error(1)
+}
+
+func (m *MockQAccounts) RemoveAccount(accountID string) (int64, error) {
+	a := m.Called(accountID)
+	return a.Get(0).(int64), a.Error(1)
+}

--- a/services/horizon/internal/db2/history/mock_q_data.go
+++ b/services/horizon/internal/db2/history/mock_q_data.go
@@ -1,0 +1,37 @@
+package history
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"github.com/stellar/go/xdr"
+)
+
+// MockQData is a mock implementation of the QAccounts interface
+type MockQData struct {
+	mock.Mock
+}
+
+func (m *MockQData) GetAccountDataByKeys(keys []xdr.LedgerKeyData) ([]Data, error) {
+	a := m.Called()
+	return a.Get(0).([]Data), a.Error(1)
+}
+
+func (m *MockQData) NewAccountDataBatchInsertBuilder(maxBatchSize int) AccountDataBatchInsertBuilder {
+	a := m.Called(maxBatchSize)
+	return a.Get(0).(AccountDataBatchInsertBuilder)
+}
+
+func (m *MockQData) InsertAccountData(data xdr.DataEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
+	a := m.Called(data, lastModifiedLedger)
+	return a.Get(0).(int64), a.Error(1)
+}
+
+func (m *MockQData) UpdateAccountData(data xdr.DataEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
+	a := m.Called(data, lastModifiedLedger)
+	return a.Get(0).(int64), a.Error(1)
+}
+
+func (m *MockQData) RemoveAccountData(key xdr.LedgerKeyData) (int64, error) {
+	a := m.Called(key)
+	return a.Get(0).(int64), a.Error(1)
+}

--- a/services/horizon/internal/db2/history/trust_lines_test.go
+++ b/services/horizon/internal/db2/history/trust_lines_test.go
@@ -135,6 +135,10 @@ func TestRemoveTrustLine(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), rows)
 
+	lines, err := q.GetTrustLinesByKeys([]xdr.LedgerKeyTrustLine{key})
+	assert.NoError(t, err)
+	assert.Len(t, lines, 0)
+
 	// Doesn't exist anymore
 	rows, err = q.RemoveTrustLine(key)
 	assert.NoError(t, err)

--- a/services/horizon/internal/db2/schema/bindata.go
+++ b/services/horizon/internal/db2/schema/bindata.go
@@ -15,6 +15,7 @@
 // migrations/21_trades_remove_zero_amount_constraints.sql (765B)
 // migrations/22_trust_lines.sql (915B)
 // migrations/23_exp_asset_stats.sql (883B)
+// migrations/24_accounts.sql (1.375kB)
 // migrations/2_index_participants_by_toid.sql (277B)
 // migrations/3_use_sequence_in_history_accounts.sql (447B)
 // migrations/4_add_protocol_version.sql (188B)
@@ -387,8 +388,28 @@ func migrations23_exp_asset_statsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/23_exp_asset_stats.sql", size: 883, mode: os.FileMode(0644), modTime: time.Unix(1570789732, 0)}
+	info := bindataFileInfo{name: "migrations/23_exp_asset_stats.sql", size: 883, mode: os.FileMode(0644), modTime: time.Unix(1570840968, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x5f, 0x23, 0x96, 0xcb, 0x81, 0x52, 0xd5, 0xb, 0x3c, 0xd4, 0xb9, 0xd9, 0x24, 0xd3, 0x1a, 0x3d, 0x1a, 0xe0, 0xd2, 0x4, 0x40, 0xf5, 0x75, 0xe2, 0x1d, 0x26, 0xd3, 0x19, 0xcf, 0x70, 0xf, 0x36}}
+	return a, nil
+}
+
+var _migrations24_accountsSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x9c\x94\x5d\x6f\xe2\x3c\x10\x85\xef\xf3\x2b\xe6\x12\xf4\x96\x57\xfb\x41\x91\x56\x5c\xc1\x12\xad\x50\x69\xe8\xb2\x20\x6d\xaf\xac\x49\x3c\x24\xa3\xf5\x47\x6b\x3b\x45\xfc\xfb\x55\x02\xb4\x69\x08\x2a\xda\xbb\x44\x7e\x7c\xec\x99\x73\xc6\x83\x01\xfc\xa7\x39\x77\x18\x08\x36\x4f\x51\xf4\x7d\x15\x4f\xd6\x31\xac\x27\xd3\x45\x0c\x98\x65\xb6\x34\xc1\x43\x2f\x02\x80\xd3\xaf\x60\x09\x59\x81\x0e\xb3\x40\x0e\x5e\xd0\xed\xd9\xe4\xbd\xdb\x51\x1f\x92\xe5\x1a\x92\xcd\x62\x71\x53\xe3\x29\x2a\x34\x19\x41\xca\x39\x9b\xd0\x5e\x2c\xab\x5d\x42\x31\xa6\xac\x38\x30\xf9\x6e\xce\x93\x52\x57\x82\xcf\x25\x99\x8c\x84\x29\x75\x4a\xae\x1b\x32\xa5\x16\xbe\x4c\xc9\x04\x57\x09\x9d\x03\x6c\xb6\x0a\x03\x5b\x23\x24\xf9\xc0\xa6\xfe\xbe\xaa\xda\xad\xc2\xbc\x4b\xb1\xb0\x9a\x84\xb4\x1a\xb9\x4b\xe7\xeb\x97\xb6\x8e\x46\x1f\xc8\x89\x1d\x71\x5e\x04\xf0\x1a\xab\xfa\xdb\xa2\xa1\x70\xe4\x0b\xab\xa4\x50\x76\xf7\x31\xa4\x49\x72\xa9\x3f\xe6\x0a\xce\x8b\x4b\x94\x42\x1f\x84\xb6\x92\xb7\x4c\x52\x28\x92\x39\x39\x98\x27\xeb\x16\xf6\xb0\x9a\xdf\x4f\x56\x8f\x70\x17\x3f\x42\xef\x2d\x30\xfd\xa8\x3f\x7e\x0d\xd7\x3c\x99\xc5\xbf\x5f\xc3\x25\xba\x7b\xbe\x4c\xde\xe2\xb7\xf9\x35\x4f\x7e\xc0\x74\xbd\x8a\xe3\x5e\x27\xdd\x1f\x5f\xd0\x6e\x76\xff\x92\x62\x83\x69\x5c\xf2\xfd\x04\x08\x89\x01\x8f\x63\x30\x18\x80\xfa\x43\x7b\x60\x0f\x08\x8b\xba\x11\x77\xb4\x07\x8d\xce\x17\xa8\x48\x42\xe9\xd9\xe4\x70\x7f\xf8\x9f\xb2\x41\xb7\x3f\x6d\x44\x23\x21\x45\x4f\xa3\xe1\x80\x4c\x66\x65\x4d\x93\x84\x60\x21\xb5\xd6\x07\x78\x22\xb7\xb5\xba\x9e\x1b\xbb\x05\x6f\x35\xc1\x73\x49\x55\x5a\xff\x3f\xd8\x50\x9d\x7c\x9e\xa3\xcf\xb7\x9f\xda\x41\x3a\x5e\xfd\xaa\xf0\x1a\xd4\xd4\x01\x8e\x86\x6d\xf0\x05\x55\xd9\x45\x7e\x6b\x1e\x5f\x15\xda\x2a\x72\x34\x84\x74\x1f\xc8\xff\x73\x94\xaa\xba\xdf\x85\x68\x93\xcc\x7f\x6e\xce\xfc\xae\x6c\x12\xa7\xd8\xd5\x55\x35\x5c\x3f\x98\xd8\xb4\xfe\xb8\x72\x53\x37\xa0\x12\x6f\x3e\x87\x33\xbb\x33\x51\x34\x5b\x2d\x1f\xda\xcf\x61\x86\x3e\x43\x49\xe3\xae\xc5\xc3\x21\x27\xe2\x6f\x00\x00\x00\xff\xff\xd2\x96\x51\x5a\x5f\x05\x00\x00")
+
+func migrations24_accountsSqlBytes() ([]byte, error) {
+	return bindataRead(
+		_migrations24_accountsSql,
+		"migrations/24_accounts.sql",
+	)
+}
+
+func migrations24_accountsSql() (*asset, error) {
+	bytes, err := migrations24_accountsSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "migrations/24_accounts.sql", size: 1375, mode: os.FileMode(0644), modTime: time.Unix(1570841155, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xaf, 0x93, 0xc0, 0xf8, 0xf7, 0x68, 0x13, 0xf9, 0xaa, 0x6c, 0x69, 0xc1, 0xca, 0xd0, 0x22, 0xf7, 0x43, 0x41, 0x55, 0x90, 0x35, 0xec, 0x98, 0xa3, 0xf0, 0x55, 0x1a, 0xec, 0x15, 0x8c, 0x8f, 0xdc}}
 	return a, nil
 }
 
@@ -693,6 +714,8 @@ var _bindata = map[string]func() (*asset, error){
 
 	"migrations/23_exp_asset_stats.sql": migrations23_exp_asset_statsSql,
 
+	"migrations/24_accounts.sql": migrations24_accountsSql,
+
 	"migrations/2_index_participants_by_toid.sql": migrations2_index_participants_by_toidSql,
 
 	"migrations/3_use_sequence_in_history_accounts.sql": migrations3_use_sequence_in_history_accountsSql,
@@ -769,6 +792,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"21_trades_remove_zero_amount_constraints.sql": &bintree{migrations21_trades_remove_zero_amount_constraintsSql, map[string]*bintree{}},
 		"22_trust_lines.sql":                           &bintree{migrations22_trust_linesSql, map[string]*bintree{}},
 		"23_exp_asset_stats.sql":                       &bintree{migrations23_exp_asset_statsSql, map[string]*bintree{}},
+		"24_accounts.sql":                              &bintree{migrations24_accountsSql, map[string]*bintree{}},
 		"2_index_participants_by_toid.sql":             &bintree{migrations2_index_participants_by_toidSql, map[string]*bintree{}},
 		"3_use_sequence_in_history_accounts.sql":       &bintree{migrations3_use_sequence_in_history_accountsSql, map[string]*bintree{}},
 		"4_add_protocol_version.sql":                   &bintree{migrations4_add_protocol_versionSql, map[string]*bintree{}},

--- a/services/horizon/internal/db2/schema/migrations/24_accounts.sql
+++ b/services/horizon/internal/db2/schema/migrations/24_accounts.sql
@@ -1,0 +1,40 @@
+-- +migrate Up
+
+CREATE TABLE accounts (
+    account_id character varying(56) NOT NULL,
+    balance bigint NOT NULL,
+    buying_liabilities bigint NOT NULL,
+    selling_liabilities bigint NOT NULL,
+    sequence_number bigint NOT NULL,
+    num_subentries int NOT NULL,
+    inflation_destination character varying(56) NOT NULL,
+    flags int NOT NULL,
+    home_domain character varying(32) NOT NULL,
+    master_weight smallint NOT NULL,
+    threshold_low smallint NOT NULL,
+    threshold_medium smallint NOT NULL,
+    threshold_high smallint NOT NULL,
+    last_modified_ledger INT NOT NULL,
+    PRIMARY KEY (account_id)
+);
+
+CREATE INDEX accounts_inflation_destination ON accounts USING BTREE(inflation_destination);
+CREATE INDEX accounts_home_domain ON accounts USING BTREE(home_domain);
+
+CREATE TABLE accounts_data (
+    -- lkey is a LedgerKey marshaled using MarshalBinary
+    -- and base64-encoded used to boost perfomance of some queries.
+    lkey character varying(150) NOT NULL,
+    account character varying(56) NOT NULL,
+    name character varying(64) NOT NULL,
+    value character varying(90) NOT NULL, -- base64-encoded 64 bytes
+    last_modified_ledger INT NOT NULL,
+    PRIMARY KEY (lkey)
+);
+
+CREATE UNIQUE INDEX accounts_data_account_name ON accounts_data USING BTREE(account, name);
+
+-- +migrate Down
+
+DROP TABLE accounts cascade;
+DROP TABLE accounts_data cascade;

--- a/services/horizon/internal/expingest/BETA_TESTING.md
+++ b/services/horizon/internal/expingest/BETA_TESTING.md
@@ -13,10 +13,12 @@ The new ingestion system solves issues found in the previous version like: incon
 ## Prerequisities
 
 * The init stage (state ingestion) for public network requires around 1.5GB of RAM. The memory is released after the state ingestion. State ingestion is performed only once, restarting the server will not trigger it unless Horizon has been upgraded to a newer version (with updated ingestion pipeline). We are currently working on alternative solutions to make RAM requirements smaller however we believe that it will become smaller and smaller as more buckets are [CAP-20](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0020.md) compatible. The CPU footprint of the new ingestion is really small. We were able to run experimental ingestion on `c5.large` instance on AWS. The init stage takes a few minutes on `c5.large`.
-* The state data requires additional 3.7GB DB disk space for public network (as of version 0.22.0):
+* The state data requires additional 5GB DB disk space for public network (as of version 0.22.0):
   * `accounts_signers` table: 1914 MB
   * `trust_lines` table: 1780 MB
+  * `accounts` table: 1332 MB
   * `offers` table: 26 MB
+  * `accounts_data` table: 13 MB
   * `exp_asset_stats` table: less than 1 MB
 * Flags needed to enable experimental ingestion:
   * `ENABLE_EXPERIMENTAL_INGESTION=true`

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -29,11 +29,12 @@ const (
 	// Version history:
 	// - 1: Initial version
 	// - 2: Added the orderbook, offers processors and distributed ingestion.
-	// - 3: Fixes a bug that could potentialy result in invalid state
+	// - 3: Fixed a bug that could potentialy result in invalid state
 	//      (#1722). Update the version to clear the state.
-	// - 4: Fixes a bug in AccountSignersChanged method.
+	// - 4: Fixed a bug in AccountSignersChanged method.
 	// - 5: Added trust lines.
-	CurrentVersion = 5
+	// - 6: Added accounts and accounts data.
+	CurrentVersion = 6
 )
 
 var log = ilog.DefaultLogger.WithField("service", "expingest")

--- a/services/horizon/internal/expingest/processors/accounts_data_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_data_processor_test.go
@@ -1,0 +1,325 @@
+package processors
+
+import (
+	"context"
+	stdio "io"
+	"testing"
+
+	"github.com/stellar/go/exp/ingest/io"
+	supportPipeline "github.com/stellar/go/exp/support/pipeline"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestAccountsDataProcessorTestSuiteState(t *testing.T) {
+	suite.Run(t, new(AccountsDataProcessorTestSuiteState))
+}
+
+type AccountsDataProcessorTestSuiteState struct {
+	suite.Suite
+	processor              *DatabaseProcessor
+	mockQ                  *history.MockQData
+	mockBatchInsertBuilder *history.MockAccountDataBatchInsertBuilder
+	mockStateReader        *io.MockStateReader
+	mockStateWriter        *io.MockStateWriter
+}
+
+func (s *AccountsDataProcessorTestSuiteState) SetupTest() {
+	s.mockQ = &history.MockQData{}
+	s.mockBatchInsertBuilder = &history.MockAccountDataBatchInsertBuilder{}
+	s.mockStateReader = &io.MockStateReader{}
+	s.mockStateWriter = &io.MockStateWriter{}
+
+	s.processor = &DatabaseProcessor{
+		Action: Data,
+		DataQ:  s.mockQ,
+	}
+
+	// Reader and Writer should be always closed and once
+	s.mockStateReader.On("Close").Return(nil).Once()
+	s.mockStateWriter.On("Close").Return(nil).Once()
+
+	s.mockQ.
+		On("NewAccountDataBatchInsertBuilder", maxBatchSize).
+		Return(s.mockBatchInsertBuilder).Once()
+}
+
+func (s *AccountsDataProcessorTestSuiteState) TearDownTest() {
+	s.mockQ.AssertExpectations(s.T())
+	s.mockBatchInsertBuilder.AssertExpectations(s.T())
+	s.mockStateReader.AssertExpectations(s.T())
+	s.mockStateWriter.AssertExpectations(s.T())
+}
+
+func (s *AccountsDataProcessorTestSuiteState) TestNoEntries() {
+	s.mockStateReader.
+		On("Read").
+		Return(xdr.LedgerEntryChange{}, stdio.EOF).Once()
+
+	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
+
+	err := s.processor.ProcessState(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockStateReader,
+		s.mockStateWriter,
+	)
+
+	s.Assert().NoError(err)
+}
+
+func (s *AccountsDataProcessorTestSuiteState) TestInvalidEntry() {
+	s.mockStateReader.
+		On("Read").
+		Return(xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+		}, nil).Once()
+
+	err := s.processor.ProcessState(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockStateReader,
+		s.mockStateWriter,
+	)
+
+	s.Assert().EqualError(err, "DatabaseProcessor requires LedgerEntryChangeTypeLedgerEntryState changes only")
+}
+
+func (s *AccountsDataProcessorTestSuiteState) TestCreatesAccounts() {
+	data := xdr.DataEntry{
+		AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+		DataName:  "test",
+		DataValue: []byte{1, 1, 1, 1},
+	}
+	lastModifiedLedgerSeq := xdr.Uint32(123)
+	s.mockStateReader.
+		On("Read").
+		Return(xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type: xdr.LedgerEntryTypeData,
+					Data: &data,
+				},
+				LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+			},
+		}, nil).Once()
+
+	s.mockBatchInsertBuilder.On("Add", data, lastModifiedLedgerSeq).Return(nil).Once()
+
+	s.mockStateReader.
+		On("Read").
+		Return(xdr.LedgerEntryChange{}, stdio.EOF).Once()
+
+	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
+
+	err := s.processor.ProcessState(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockStateReader,
+		s.mockStateWriter,
+	)
+
+	s.Assert().NoError(err)
+}
+
+func TestAccountsDataProcessorTestSuiteLedger(t *testing.T) {
+	suite.Run(t, new(AccountsDataProcessorTestSuiteLedger))
+}
+
+type AccountsDataProcessorTestSuiteLedger struct {
+	suite.Suite
+	processor        *DatabaseProcessor
+	mockQ            *history.MockQData
+	mockLedgerReader *io.MockLedgerReader
+	mockLedgerWriter *io.MockLedgerWriter
+}
+
+func (s *AccountsDataProcessorTestSuiteLedger) SetupTest() {
+	s.mockQ = &history.MockQData{}
+	s.mockLedgerReader = &io.MockLedgerReader{}
+	s.mockLedgerWriter = &io.MockLedgerWriter{}
+
+	s.processor = &DatabaseProcessor{
+		Action: Data,
+		DataQ:  s.mockQ,
+	}
+
+	// Reader and Writer should be always closed and once
+	s.mockLedgerReader.
+		On("Close").
+		Return(nil).Once()
+
+	s.mockLedgerWriter.
+		On("Close").
+		Return(nil).Once()
+}
+
+func (s *AccountsDataProcessorTestSuiteLedger) TearDownTest() {
+	s.mockQ.AssertExpectations(s.T())
+	s.mockLedgerReader.AssertExpectations(s.T())
+	s.mockLedgerWriter.AssertExpectations(s.T())
+}
+
+func (s *AccountsDataProcessorTestSuiteLedger) TestNoTransactions() {
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{}, stdio.EOF).Once()
+
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().NoError(err)
+}
+
+func (s *AccountsDataProcessorTestSuiteLedger) TestNewAccount() {
+	data := xdr.DataEntry{
+		AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+		DataName:  "test",
+		DataValue: []byte{1, 1, 1, 1},
+	}
+	lastModifiedLedgerSeq := xdr.Uint32(123)
+
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+							Created: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+								Data: xdr.LedgerEntryData{
+									Type: xdr.LedgerEntryTypeData,
+									Data: &data,
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+
+	s.mockQ.On(
+		"InsertAccountData",
+		data,
+		lastModifiedLedgerSeq,
+	).Return(int64(1), nil).Once()
+
+	updatedData := xdr.DataEntry{
+		AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+		DataName:  "test",
+		DataValue: []byte{2, 2, 2, 2},
+	}
+	s.mockLedgerReader.On("Read").
+		Return(io.LedgerTransaction{
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						// State
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+							State: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq - 1,
+								Data: xdr.LedgerEntryData{
+									Type: xdr.LedgerEntryTypeData,
+									Data: &data,
+								},
+							},
+						},
+						// Updated
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
+							Updated: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+								Data: xdr.LedgerEntryData{
+									Type: xdr.LedgerEntryTypeData,
+									Data: &updatedData,
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+	s.mockQ.On(
+		"UpdateAccountData",
+		updatedData,
+		lastModifiedLedgerSeq,
+	).Return(int64(1), nil).Once()
+
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{}, stdio.EOF).Once()
+
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().NoError(err)
+}
+
+func (s *AccountsDataProcessorTestSuiteLedger) TestRemoveAccount() {
+	s.mockLedgerReader.On("Read").
+		Return(io.LedgerTransaction{
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+							State: &xdr.LedgerEntry{
+								Data: xdr.LedgerEntryData{
+									Type: xdr.LedgerEntryTypeData,
+									Data: &xdr.DataEntry{
+										AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+										DataName:  "test",
+										DataValue: []byte{1, 1, 1, 1},
+									},
+								},
+							},
+						},
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+							Removed: &xdr.LedgerKey{
+								Type: xdr.LedgerEntryTypeData,
+								Data: &xdr.LedgerKeyData{
+									AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+									DataName:  "test",
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+
+	s.mockQ.On(
+		"RemoveAccountData",
+		xdr.LedgerKeyData{
+			AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+			DataName:  "test",
+		},
+	).Return(int64(1), nil).Once()
+
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{}, stdio.EOF).Once()
+
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().NoError(err)
+}

--- a/services/horizon/internal/expingest/processors/accounts_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_processor_test.go
@@ -1,0 +1,328 @@
+package processors
+
+import (
+	"context"
+	stdio "io"
+	"testing"
+
+	"github.com/stellar/go/exp/ingest/io"
+	supportPipeline "github.com/stellar/go/exp/support/pipeline"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestAccountsProcessorTestSuiteState(t *testing.T) {
+	suite.Run(t, new(AccountsProcessorTestSuiteState))
+}
+
+type AccountsProcessorTestSuiteState struct {
+	suite.Suite
+	processor              *DatabaseProcessor
+	mockQ                  *history.MockQAccounts
+	mockBatchInsertBuilder *history.MockAccountsBatchInsertBuilder
+	mockStateReader        *io.MockStateReader
+	mockStateWriter        *io.MockStateWriter
+}
+
+func (s *AccountsProcessorTestSuiteState) SetupTest() {
+	s.mockQ = &history.MockQAccounts{}
+	s.mockBatchInsertBuilder = &history.MockAccountsBatchInsertBuilder{}
+	s.mockStateReader = &io.MockStateReader{}
+	s.mockStateWriter = &io.MockStateWriter{}
+
+	s.processor = &DatabaseProcessor{
+		Action:    Accounts,
+		AccountsQ: s.mockQ,
+	}
+
+	// Reader and Writer should be always closed and once
+	s.mockStateReader.On("Close").Return(nil).Once()
+	s.mockStateWriter.On("Close").Return(nil).Once()
+
+	s.mockQ.
+		On("NewAccountsBatchInsertBuilder", maxBatchSize).
+		Return(s.mockBatchInsertBuilder).Once()
+}
+
+func (s *AccountsProcessorTestSuiteState) TearDownTest() {
+	s.mockQ.AssertExpectations(s.T())
+	s.mockBatchInsertBuilder.AssertExpectations(s.T())
+	s.mockStateReader.AssertExpectations(s.T())
+	s.mockStateWriter.AssertExpectations(s.T())
+}
+
+func (s *AccountsProcessorTestSuiteState) TestNoEntries() {
+	s.mockStateReader.
+		On("Read").
+		Return(xdr.LedgerEntryChange{}, stdio.EOF).Once()
+
+	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
+
+	err := s.processor.ProcessState(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockStateReader,
+		s.mockStateWriter,
+	)
+
+	s.Assert().NoError(err)
+}
+
+func (s *AccountsProcessorTestSuiteState) TestInvalidEntry() {
+	s.mockStateReader.
+		On("Read").
+		Return(xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+		}, nil).Once()
+
+	err := s.processor.ProcessState(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockStateReader,
+		s.mockStateWriter,
+	)
+
+	s.Assert().EqualError(err, "DatabaseProcessor requires LedgerEntryChangeTypeLedgerEntryState changes only")
+}
+
+func (s *AccountsProcessorTestSuiteState) TestCreatesAccounts() {
+	account := xdr.AccountEntry{
+		AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+		Thresholds: [4]byte{1, 1, 1, 1},
+	}
+	lastModifiedLedgerSeq := xdr.Uint32(123)
+	s.mockStateReader.
+		On("Read").
+		Return(xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type:    xdr.LedgerEntryTypeAccount,
+					Account: &account,
+				},
+				LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+			},
+		}, nil).Once()
+
+	s.mockBatchInsertBuilder.On("Add", account, lastModifiedLedgerSeq).Return(nil).Once()
+
+	s.mockStateReader.
+		On("Read").
+		Return(xdr.LedgerEntryChange{}, stdio.EOF).Once()
+
+	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
+
+	err := s.processor.ProcessState(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockStateReader,
+		s.mockStateWriter,
+	)
+
+	s.Assert().NoError(err)
+}
+
+func TestAccountsProcessorTestSuiteLedger(t *testing.T) {
+	suite.Run(t, new(AccountsProcessorTestSuiteLedger))
+}
+
+type AccountsProcessorTestSuiteLedger struct {
+	suite.Suite
+	processor        *DatabaseProcessor
+	mockQ            *history.MockQAccounts
+	mockLedgerReader *io.MockLedgerReader
+	mockLedgerWriter *io.MockLedgerWriter
+}
+
+func (s *AccountsProcessorTestSuiteLedger) SetupTest() {
+	s.mockQ = &history.MockQAccounts{}
+	s.mockLedgerReader = &io.MockLedgerReader{}
+	s.mockLedgerWriter = &io.MockLedgerWriter{}
+
+	s.processor = &DatabaseProcessor{
+		Action:    Accounts,
+		AccountsQ: s.mockQ,
+	}
+
+	// Reader and Writer should be always closed and once
+	s.mockLedgerReader.
+		On("Close").
+		Return(nil).Once()
+
+	s.mockLedgerWriter.
+		On("Close").
+		Return(nil).Once()
+}
+
+func (s *AccountsProcessorTestSuiteLedger) TearDownTest() {
+	s.mockQ.AssertExpectations(s.T())
+	s.mockLedgerReader.AssertExpectations(s.T())
+	s.mockLedgerWriter.AssertExpectations(s.T())
+}
+
+func (s *AccountsProcessorTestSuiteLedger) TestNoTransactions() {
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{}, stdio.EOF).Once()
+
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().NoError(err)
+}
+
+func (s *AccountsProcessorTestSuiteLedger) TestNewAccount() {
+	account := xdr.AccountEntry{
+		AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+		Thresholds: [4]byte{1, 1, 1, 1},
+	}
+	lastModifiedLedgerSeq := xdr.Uint32(123)
+
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+							Created: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+								Data: xdr.LedgerEntryData{
+									Type:    xdr.LedgerEntryTypeAccount,
+									Account: &account,
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+
+	s.mockQ.On(
+		"InsertAccount",
+		account,
+		lastModifiedLedgerSeq,
+	).Return(int64(1), nil).Once()
+
+	updatedAccount := xdr.AccountEntry{
+		AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+		Thresholds: [4]byte{0, 1, 2, 3},
+		HomeDomain: "stellar.org",
+	}
+
+	// failed tx shouldn't be ignored in accounts processor (seqnum and fees!)
+	s.mockLedgerReader.On("Read").
+		Return(io.LedgerTransaction{
+			Result: xdr.TransactionResultPair{
+				Result: xdr.TransactionResult{
+					Result: xdr.TransactionResultResult{
+						Code: xdr.TransactionResultCodeTxFailed,
+					},
+				},
+			},
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						// State
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+							State: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq - 1,
+								Data: xdr.LedgerEntryData{
+									Type:    xdr.LedgerEntryTypeAccount,
+									Account: &account,
+								},
+							},
+						},
+						// Updated
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
+							Updated: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+								Data: xdr.LedgerEntryData{
+									Type:    xdr.LedgerEntryTypeAccount,
+									Account: &updatedAccount,
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+	s.mockQ.On(
+		"UpdateAccount",
+		updatedAccount,
+		lastModifiedLedgerSeq,
+	).Return(int64(1), nil).Once()
+
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{}, stdio.EOF).Once()
+
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().NoError(err)
+}
+
+func (s *AccountsProcessorTestSuiteLedger) TestRemoveAccount() {
+	// add offer
+	s.mockLedgerReader.On("Read").
+		Return(io.LedgerTransaction{
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+							State: &xdr.LedgerEntry{
+								Data: xdr.LedgerEntryData{
+									Type: xdr.LedgerEntryTypeAccount,
+									Account: &xdr.AccountEntry{
+										AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+										Thresholds: [4]byte{1, 1, 1, 1},
+									},
+								},
+							},
+						},
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+							Removed: &xdr.LedgerKey{
+								Type: xdr.LedgerEntryTypeAccount,
+								Account: &xdr.LedgerKeyAccount{
+									AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+
+	s.mockQ.On(
+		"RemoveAccount",
+		"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+	).Return(int64(1), nil).Once()
+
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{}, stdio.EOF).Once()
+
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().NoError(err)
+}

--- a/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
@@ -172,7 +172,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) SetupTest() {
 	s.mockLedgerWriter = &io.MockLedgerWriter{}
 
 	s.processor = &DatabaseProcessor{
-		Action:   All,
+		Action:   AccountsForSigner,
 		SignersQ: s.mockQ,
 	}
 
@@ -230,7 +230,6 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewAccount() {
 				},
 			}),
 		}, nil).Once()
-	s.mockLedgerReader.On("GetSequence").Return(uint32(1)).Once()
 
 	s.mockQ.
 		On(
@@ -306,7 +305,6 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewSigner() {
 				},
 			}),
 		}, nil).Once()
-	s.mockLedgerReader.On("GetSequence").Return(uint32(1)).Once()
 
 	// Remove old signer
 	s.mockQ.
@@ -401,7 +399,6 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestSignerRemoved() {
 				},
 			}),
 		}, nil).Once()
-	s.mockLedgerReader.On("GetSequence").Return(uint32(1)).Once()
 
 	// Remove old signers
 	s.mockQ.
@@ -476,7 +473,6 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestRemoveAccount() {
 				},
 			}),
 		}, nil).Once()
-	s.mockLedgerReader.On("GetSequence").Return(uint32(1)).Once()
 
 	s.mockQ.
 		On(
@@ -523,7 +519,6 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewAccountNoRowsAffected() 
 				},
 			}),
 		}, nil).Once()
-	s.mockLedgerReader.On("GetSequence").Return(uint32(1)).Once()
 
 	s.mockQ.
 		On(
@@ -583,7 +578,6 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestRemoveAccountNoRowsAffected
 				},
 			}),
 		}, nil).Once()
-	s.mockLedgerReader.On("GetSequence").Return(uint32(1)).Once()
 
 	s.mockQ.
 		On(

--- a/services/horizon/internal/expingest/processors/main.go
+++ b/services/horizon/internal/expingest/processors/main.go
@@ -14,7 +14,9 @@ const (
 type DatabaseProcessorActionType string
 
 const (
+	Accounts          DatabaseProcessorActionType = "Accounts"
 	AccountsForSigner DatabaseProcessorActionType = "AccountsForSigner"
+	Data              DatabaseProcessorActionType = "Data"
 	Offers            DatabaseProcessorActionType = "Offers"
 	TrustLines        DatabaseProcessorActionType = "TrustLines"
 	All               DatabaseProcessorActionType = "All"
@@ -26,6 +28,8 @@ const (
 // *history.Q object to share a common transaction. `Action` defines what each
 // processor is responsible for.
 type DatabaseProcessor struct {
+	AccountsQ   history.QAccounts
+	DataQ       history.QData
 	SignersQ    history.QSigners
 	OffersQ     history.QOffers
 	TrustLinesQ history.QTrustLines

--- a/services/horizon/internal/expingest/processors/offers_processor_test.go
+++ b/services/horizon/internal/expingest/processors/offers_processor_test.go
@@ -155,7 +155,7 @@ func (s *OffersProcessorTestSuiteLedger) TestInsertOffer() {
 	}
 	// should be ignored because it's not an offer type
 	s.Assert().NoError(
-		s.processor.processLedgerOffers(accountTransaction.GetChanges()[0], 1),
+		s.processor.processLedgerOffers(accountTransaction.GetChanges()[0]),
 	)
 
 	// should be ignored because transaction was not successful
@@ -204,6 +204,7 @@ func (s *OffersProcessorTestSuiteLedger) TestInsertOffer() {
 						xdr.LedgerEntryChange{
 							Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
 							Created: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq,
 								Data: xdr.LedgerEntryData{
 									Type:  xdr.LedgerEntryTypeOffer,
 									Offer: &offer,
@@ -214,7 +215,6 @@ func (s *OffersProcessorTestSuiteLedger) TestInsertOffer() {
 				},
 			}),
 		}, nil).Once()
-	s.mockLedgerReader.On("GetSequence").Return(uint32(lastModifiedLedgerSeq))
 
 	s.mockQ.On(
 		"InsertOffer",
@@ -235,6 +235,7 @@ func (s *OffersProcessorTestSuiteLedger) TestInsertOffer() {
 						xdr.LedgerEntryChange{
 							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
 							State: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq - 1,
 								Data: xdr.LedgerEntryData{
 									Type:  xdr.LedgerEntryTypeOffer,
 									Offer: &offer,
@@ -245,6 +246,7 @@ func (s *OffersProcessorTestSuiteLedger) TestInsertOffer() {
 						xdr.LedgerEntryChange{
 							Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
 							Updated: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq,
 								Data: xdr.LedgerEntryData{
 									Type:  xdr.LedgerEntryTypeOffer,
 									Offer: &updatedOffer,
@@ -277,7 +279,6 @@ func (s *OffersProcessorTestSuiteLedger) TestInsertOffer() {
 
 func (s *OffersProcessorTestSuiteLedger) TestUpdateOfferNoRowsAffected() {
 	lastModifiedLedgerSeq := xdr.Uint32(1234)
-	s.mockLedgerReader.On("GetSequence").Return(uint32(lastModifiedLedgerSeq))
 
 	offer := xdr.OfferEntry{
 		OfferId: xdr.Int64(2),
@@ -296,6 +297,7 @@ func (s *OffersProcessorTestSuiteLedger) TestUpdateOfferNoRowsAffected() {
 						xdr.LedgerEntryChange{
 							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
 							State: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq - 1,
 								Data: xdr.LedgerEntryData{
 									Type:  xdr.LedgerEntryTypeOffer,
 									Offer: &offer,
@@ -306,6 +308,7 @@ func (s *OffersProcessorTestSuiteLedger) TestUpdateOfferNoRowsAffected() {
 						xdr.LedgerEntryChange{
 							Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
 							Updated: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq,
 								Data: xdr.LedgerEntryData{
 									Type:  xdr.LedgerEntryTypeOffer,
 									Offer: &updatedOffer,
@@ -366,7 +369,6 @@ func (s *OffersProcessorTestSuiteLedger) TestRemoveOffer() {
 				},
 			}),
 		}, nil).Once()
-	s.mockLedgerReader.On("GetSequence").Return(uint32(123))
 
 	s.mockQ.On(
 		"RemoveOffer",
@@ -419,7 +421,6 @@ func (s *OffersProcessorTestSuiteLedger) TestRemoveOfferNoRowsAffected() {
 				},
 			}),
 		}, nil).Once()
-	s.mockLedgerReader.On("GetSequence").Return(uint32(123))
 
 	s.mockQ.On(
 		"RemoveOffer",

--- a/services/horizon/internal/expingest/processors/orderbook_processor.go
+++ b/services/horizon/internal/expingest/processors/orderbook_processor.go
@@ -65,11 +65,11 @@ func (p *OrderbookProcessor) ProcessLedger(ctx context.Context, store *pipeline.
 			switch {
 			case change.Post != nil:
 				// Created or updated
-				offer := change.Post.MustOffer()
+				offer := change.Post.Data.MustOffer()
 				p.OrderBookGraph.AddOffer(offer)
 			case change.Pre != nil && change.Post == nil:
 				// Removed
-				offer := change.Pre.MustOffer()
+				offer := change.Pre.Data.MustOffer()
 				p.OrderBookGraph.RemoveOffer(offer.OfferId)
 			}
 		}

--- a/services/horizon/internal/expingest/processors/trust_lines_processor_test.go
+++ b/services/horizon/internal/expingest/processors/trust_lines_processor_test.go
@@ -176,7 +176,7 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestInsertTrustLine() {
 	}
 	// should be ignored because it's not an trust line type
 	s.Assert().NoError(
-		s.processor.processLedgerTrustLines(accountTransaction.GetChanges()[0], 1),
+		s.processor.processLedgerTrustLines(accountTransaction.GetChanges()[0]),
 	)
 
 	// should be ignored because transaction was not successful
@@ -226,6 +226,7 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestInsertTrustLine() {
 						xdr.LedgerEntryChange{
 							Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
 							Created: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq,
 								Data: xdr.LedgerEntryData{
 									Type:      xdr.LedgerEntryTypeTrustline,
 									TrustLine: &trustLine,
@@ -236,7 +237,6 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestInsertTrustLine() {
 				},
 			}),
 		}, nil).Once()
-	s.mockLedgerReader.On("GetSequence").Return(uint32(lastModifiedLedgerSeq))
 
 	s.mockQ.On(
 		"InsertTrustLine",
@@ -270,6 +270,7 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestInsertTrustLine() {
 						xdr.LedgerEntryChange{
 							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
 							State: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq - 1,
 								Data: xdr.LedgerEntryData{
 									Type:      xdr.LedgerEntryTypeTrustline,
 									TrustLine: &trustLine,
@@ -280,6 +281,7 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestInsertTrustLine() {
 						xdr.LedgerEntryChange{
 							Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
 							Updated: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq,
 								Data: xdr.LedgerEntryData{
 									Type:      xdr.LedgerEntryTypeTrustline,
 									TrustLine: &updatedTrustLine,
@@ -330,7 +332,6 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestInsertTrustLine() {
 
 func (s *TrustLinesProcessorTestSuiteLedger) TestUpdateTrustLineNoRowsAffected() {
 	lastModifiedLedgerSeq := xdr.Uint32(1234)
-	s.mockLedgerReader.On("GetSequence").Return(uint32(lastModifiedLedgerSeq))
 
 	trustLine := xdr.TrustLineEntry{
 		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
@@ -351,6 +352,7 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestUpdateTrustLineNoRowsAffected()
 						xdr.LedgerEntryChange{
 							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
 							State: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq - 1,
 								Data: xdr.LedgerEntryData{
 									Type:      xdr.LedgerEntryTypeTrustline,
 									TrustLine: &trustLine,
@@ -361,6 +363,7 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestUpdateTrustLineNoRowsAffected()
 						xdr.LedgerEntryChange{
 							Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
 							Updated: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq,
 								Data: xdr.LedgerEntryData{
 									Type:      xdr.LedgerEntryTypeTrustline,
 									TrustLine: &updatedTrustLine,
@@ -440,7 +443,6 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestRemoveTrustLine() {
 				},
 			}),
 		}, nil).Once()
-	s.mockLedgerReader.On("GetSequence").Return(uint32(123))
 
 	s.mockQ.On(
 		"RemoveTrustLine",
@@ -513,7 +515,6 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestRemoveOfferNoRowsAffected() {
 				},
 			}),
 		}, nil).Once()
-	s.mockLedgerReader.On("GetSequence").Return(uint32(123))
 
 	s.mockQ.On(
 		"RemoveTrustLine",

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -26,7 +26,7 @@ const assetStatsBatchSize = 500
 // check them.
 // There is a test that checks it, to fix it: update the actual `verifyState`
 // method instead of just updating this value!
-const stateVerifierExpectedIngestionVersion = 5
+const stateVerifierExpectedIngestionVersion = 6
 
 // verifyState is called as a go routine from pipeline post hook every 64
 // ledgers. It checks if the state is correct. If another go routine is already
@@ -139,12 +139,15 @@ func (s *System) verifyState() error {
 		}
 
 		accounts := make([]string, 0, verifyBatchSize)
+		data := make([]xdr.LedgerKeyData, 0, verifyBatchSize)
 		offers := make([]int64, 0, verifyBatchSize)
 		trustLines := make([]xdr.LedgerKeyTrustLine, 0, verifyBatchSize)
 		for _, key := range keys {
 			switch key.Type {
 			case xdr.LedgerEntryTypeAccount:
 				accounts = append(accounts, key.Account.AccountId.Address())
+			case xdr.LedgerEntryTypeData:
+				data = append(data, *key.Data)
 			case xdr.LedgerEntryTypeOffer:
 				offers = append(offers, int64(key.Offer.OfferId))
 			case xdr.LedgerEntryTypeTrustline:
@@ -157,6 +160,11 @@ func (s *System) verifyState() error {
 		err = addAccountsToStateVerifier(verifier, historyQ, accounts)
 		if err != nil {
 			return errors.Wrap(err, "addAccountsToStateVerifier failed")
+		}
+
+		err = addDataToStateVerifier(verifier, historyQ, data)
+		if err != nil {
+			return errors.Wrap(err, "addDataToStateVerifier failed")
 		}
 
 		err = addOffersToStateVerifier(verifier, historyQ, offers)
@@ -180,6 +188,11 @@ func (s *System) verifyState() error {
 		return errors.Wrap(err, "Error running historyQ.CountAccounts")
 	}
 
+	countData, err := historyQ.CountAccountsData()
+	if err != nil {
+		return errors.Wrap(err, "Error running historyQ.CountData")
+	}
+
 	countOffers, err := historyQ.CountOffers()
 	if err != nil {
 		return errors.Wrap(err, "Error running historyQ.CountOffers")
@@ -190,7 +203,7 @@ func (s *System) verifyState() error {
 		return errors.Wrap(err, "Error running historyQ.CountTrustLines")
 	}
 
-	err = verifier.Verify(countAccounts + countOffers + countTrustLines)
+	err = verifier.Verify(countAccounts + countData + countOffers + countTrustLines)
 	if err != nil {
 		return errors.Wrap(err, "verifier.Verify failed")
 	}
@@ -259,63 +272,110 @@ func addAccountsToStateVerifier(verifier *verify.StateVerifier, q *history.Q, id
 		return nil
 	}
 
+	accounts, err := q.GetAccountsByIDs(ids)
+	if err != nil {
+		return errors.Wrap(err, "Error running history.Q.GetAccountsByIDs")
+	}
+
 	signers, err := q.SignersForAccounts(ids)
 	if err != nil {
 		return errors.Wrap(err, "Error running history.Q.SignersForAccounts")
 	}
 
-	var account *xdr.AccountEntry
+	masterWeightMap := make(map[string]int32)
+	signersMap := make(map[string][]xdr.Signer)
 	for _, row := range signers {
-		if account == nil || account.AccountId.Address() != row.Account {
-			if account != nil {
-				// Sort signers
-				account.Signers = xdr.SortSignersByKey(account.Signers)
-
-				entry := xdr.LedgerEntry{
-					Data: xdr.LedgerEntryData{
-						Type:    xdr.LedgerEntryTypeAccount,
-						Account: account,
-					},
-				}
-				err = verifier.Write(entry)
-				if err != nil {
-					return err
-				}
-			}
-
-			account = &xdr.AccountEntry{
-				AccountId: xdr.MustAddress(row.Account),
-				Signers:   []xdr.Signer{},
-			}
-		}
-
 		if row.Account == row.Signer {
-			// Master key
-			account.Thresholds = [4]byte{
-				// Store master weight only
-				byte(row.Weight), 0, 0, 0,
-			}
+			masterWeightMap[row.Account] = row.Weight
 		} else {
-			// Normal signer
-			account.Signers = append(account.Signers, xdr.Signer{
-				Key:    xdr.MustSigner(row.Signer),
-				Weight: xdr.Uint32(row.Weight),
-			})
+			signersMap[row.Account] = append(
+				signersMap[row.Account],
+				xdr.Signer{
+					Key:    xdr.MustSigner(row.Signer),
+					Weight: xdr.Uint32(row.Weight),
+				},
+			)
 		}
 	}
 
-	if account != nil {
-		// Sort signers
-		account.Signers = xdr.SortSignersByKey(account.Signers)
+	for _, row := range accounts {
+		var inflationDest *xdr.AccountId
+		if row.InflationDestination != "" {
+			t := xdr.MustAddress(row.InflationDestination)
+			inflationDest = &t
+		}
 
-		// Add last created in a loop account
+		// Ensure master weight matches, if not it's a state error!
+		if int32(row.MasterWeight) != masterWeightMap[row.AccountID] {
+			return verify.NewStateError(errors.New("Master key weight in accounts does not match "))
+		}
+
+		account := &xdr.AccountEntry{
+			AccountId:     xdr.MustAddress(row.AccountID),
+			Balance:       xdr.Int64(row.Balance),
+			SeqNum:        xdr.SequenceNumber(row.SequenceNumber),
+			NumSubEntries: xdr.Uint32(row.NumSubEntries),
+			InflationDest: inflationDest,
+			Flags:         xdr.Uint32(row.Flags),
+			HomeDomain:    xdr.String32(row.HomeDomain),
+			Thresholds: xdr.Thresholds{
+				row.MasterWeight,
+				row.ThresholdLow,
+				row.ThresholdMedium,
+				row.ThresholdHigh,
+			},
+			Signers: xdr.SortSignersByKey(signersMap[row.AccountID]),
+			Ext: xdr.AccountEntryExt{
+				V: 1,
+				V1: &xdr.AccountEntryV1{
+					Liabilities: xdr.Liabilities{
+						Buying:  xdr.Int64(row.BuyingLiabilities),
+						Selling: xdr.Int64(row.SellingLiabilities),
+					},
+				},
+			},
+		}
+
 		entry := xdr.LedgerEntry{
+			LastModifiedLedgerSeq: xdr.Uint32(row.LastModifiedLedger),
 			Data: xdr.LedgerEntryData{
 				Type:    xdr.LedgerEntryTypeAccount,
 				Account: account,
 			},
 		}
+
 		err = verifier.Write(entry)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func addDataToStateVerifier(verifier *verify.StateVerifier, q *history.Q, keys []xdr.LedgerKeyData) error {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	data, err := q.GetAccountDataByKeys(keys)
+	if err != nil {
+		return errors.Wrap(err, "Error running history.Q.GetAccountDataByKeys")
+	}
+
+	for _, row := range data {
+		entry := xdr.LedgerEntry{
+			LastModifiedLedgerSeq: xdr.Uint32(row.LastModifiedLedger),
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeData,
+				Data: &xdr.DataEntry{
+					AccountId: xdr.MustAddress(row.AccountID),
+					DataName:  xdr.String64(row.Name),
+					DataValue: xdr.DataValue(row.Value),
+				},
+			},
+		}
+		err := verifier.Write(entry)
 		if err != nil {
 			return err
 		}
@@ -419,27 +479,21 @@ func transformEntry(entry xdr.LedgerEntry) (bool, xdr.LedgerEntry) {
 	switch entry.Data.Type {
 	case xdr.LedgerEntryTypeAccount:
 		accountEntry := entry.Data.Account
-
-		// We don't store accounts with no signers and no master.
-		// Ignore such accounts.
-		if accountEntry.MasterKeyWeight() == 0 && len(accountEntry.Signers) == 0 {
-			return true, xdr.LedgerEntry{}
-		}
-
-		// We store account id, master weight and signers only
-		return false, xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
-				Type: xdr.LedgerEntryTypeAccount,
-				Account: &xdr.AccountEntry{
-					AccountId: accountEntry.AccountId,
-					Thresholds: [4]byte{
-						// Store master weight only
-						accountEntry.Thresholds[0], 0, 0, 0,
-					},
-					Signers: xdr.SortSignersByKey(accountEntry.Signers),
+		// Sort signers
+		accountEntry.Signers = xdr.SortSignersByKey(accountEntry.Signers)
+		// Account can have ext=0. For those, create ext=1
+		// with 0 liabilities.
+		if accountEntry.Ext.V == 0 {
+			accountEntry.Ext.V = 1
+			accountEntry.Ext.V1 = &xdr.AccountEntryV1{
+				Liabilities: xdr.Liabilities{
+					Buying:  0,
+					Selling: 0,
 				},
-			},
+			}
 		}
+
+		return false, entry
 	case xdr.LedgerEntryTypeOffer:
 		// Full check of offer object
 		return false, entry
@@ -459,8 +513,8 @@ func transformEntry(entry xdr.LedgerEntry) (bool, xdr.LedgerEntry) {
 
 		return false, entry
 	case xdr.LedgerEntryTypeData:
-		// Ignore
-		return true, xdr.LedgerEntry{}
+		// Full check of data object
+		return false, entry
 	default:
 		panic("Invalid type")
 	}

--- a/xdr/account_entry.go
+++ b/xdr/account_entry.go
@@ -16,3 +16,15 @@ func (a *AccountEntry) SignerSummary() map[string]int32 {
 func (a *AccountEntry) MasterKeyWeight() byte {
 	return a.Thresholds[0]
 }
+
+func (a *AccountEntry) ThresholdLow() byte {
+	return a.Thresholds[1]
+}
+
+func (a *AccountEntry) ThresholdMedium() byte {
+	return a.Thresholds[2]
+}
+
+func (a *AccountEntry) ThresholdHigh() byte {
+	return a.Thresholds[3]
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

This commit adds accounts and account data to ingestion pipeline.

### Summary of changes

* Adds a new migration file adding a new `accounts` and `accounts_data` tables.
* Updates `db2/history` package with accounts and data related interfaces and structs.
* Updates `DatabaseProcessor` to process accounts and data in state and ledger pipelines.
