### PR TITLE
support/historyarchive: Add HTTP timeout for historyarchive.ArchiveBackend operations

### DIFF
--- a/exp/tools/dump-ledger-state/main.go
+++ b/exp/tools/dump-ledger-state/main.go
@@ -82,6 +82,7 @@ func archive() (*historyarchive.Archive, error) {
 		historyarchive.ConnectOptions{
 			S3Region:         "eu-west-1",
 			UnsignedRequests: true,
+			HTTPTimeout:      2 * time.Minute,
 		},
 	)
 }

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -8,6 +8,8 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ## v0.23.0
 
+* Add `HTTPTimeout` to `historyarchive.ConnectOptions` for configuring timeouts on `historyarchive.ArchiveBackend` operations. Also, set the `HTTPTimeout` to 2 minutes when constructng `historyarchive.Archive` instances for the horizon ingestion pipelines.
+
 ### Breaking Changes
 
 * Remove deprecated `fee_paid` field on Transaction resource. Please use new fields added in 0.18.0: `max_fee` that defines the maximum fee the source account is willing to pay and `fee_charged` that defines the fee that was actually paid for a transaction. See [CAP-0005](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0005.md) for more information.

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -355,6 +355,8 @@ func (s *System) Shutdown() {
 func createArchive(archiveURL string) (*historyarchive.Archive, error) {
 	return historyarchive.Connect(
 		archiveURL,
-		historyarchive.ConnectOptions{},
+		historyarchive.ConnectOptions{
+			HTTPTimeout: 2 * time.Minute,
+		},
 	)
 }

--- a/support/historyarchive/archive.go
+++ b/support/historyarchive/archive.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 const hexPrefixPat = "/[0-9a-f]{2}/[0-9a-f]{2}/[0-9a-f]{2}/"
@@ -36,6 +37,8 @@ type ConnectOptions struct {
 	S3Region         string
 	S3Endpoint       string
 	UnsignedRequests bool
+	// HTTPTimeout is a timeout applied on HTTP requests issued from the ArchiveBackend
+	HTTPTimeout time.Duration
 }
 
 type ArchiveBackend interface {

--- a/support/historyarchive/http_archive.go
+++ b/support/historyarchive/http_archive.go
@@ -110,7 +110,10 @@ func (b *HttpArchiveBackend) CanListFiles() bool {
 }
 
 func makeHttpBackend(base *url.URL, opts ConnectOptions) ArchiveBackend {
-	return &HttpArchiveBackend{
+	backend := &HttpArchiveBackend{
 		base: *base,
 	}
+	backend.client.Timeout = opts.HTTPTimeout
+
+	return backend
 }

--- a/support/historyarchive/s3_archive.go
+++ b/support/historyarchive/s3_archive.go
@@ -176,7 +176,7 @@ func makeS3Backend(bucket string, prefix string, opts ConnectOptions) (ArchiveBa
 		Region:   aws.String(opts.S3Region),
 		Endpoint: aws.String(opts.S3Endpoint),
 	}
-	cfg = cfg.WithS3ForcePathStyle(true)
+	cfg = cfg.WithS3ForcePathStyle(true).WithHTTPClient(&http.Client{Timeout: opts.HTTPTimeout})
 
 	sess, err := session.NewSession(cfg)
 	if err != nil {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Fixes https://github.com/stellar/go/issues/1681

>Currently it's not possible to add Timeout to http.Client in HttpArchiveBackend. historyarchive.Connect does not allow passing http.Client or timeout value.

>Without timeout it's possible that connection to history archive file will wait indefinitely blocking other components using this package.

