### PR TITLE
services/horizon/internal/actions: Add latest ingested ledger in experimental ingestion endpoints

### DIFF
--- a/exp/orderbook/batch.go
+++ b/exp/orderbook/batch.go
@@ -50,7 +50,7 @@ func (tx *orderBookBatchedUpdates) removeOffer(offerID xdr.Int64) *orderBookBatc
 }
 
 // apply will attempt to apply all the updates in the batch to the order book
-func (tx *orderBookBatchedUpdates) apply() error {
+func (tx *orderBookBatchedUpdates) apply(ledger uint32) error {
 	tx.orderbook.lock.Lock()
 	defer tx.orderbook.lock.Unlock()
 
@@ -59,6 +59,10 @@ func (tx *orderBookBatchedUpdates) apply() error {
 		panic(errBatchAlreadyApplied)
 	}
 	tx.committed = true
+
+	if ledger < tx.orderbook.lastLedger {
+		return errOutdatedLedger
+	}
 
 	for _, operation := range tx.operations {
 		switch operation.operationType {
@@ -74,6 +78,8 @@ func (tx *orderBookBatchedUpdates) apply() error {
 			panic(errors.New("invalid operation type"))
 		}
 	}
+
+	tx.orderbook.lastLedger = ledger
 
 	return nil
 }

--- a/exp/orderbook/batch.go
+++ b/exp/orderbook/batch.go
@@ -60,8 +60,8 @@ func (tx *orderBookBatchedUpdates) apply(ledger uint32) error {
 	}
 	tx.committed = true
 
-	if ledger < tx.orderbook.lastLedger {
-		return errOutdatedLedger
+	if tx.orderbook.lastLedger > 0 && ledger != tx.orderbook.lastLedger+1 {
+		return errUnexpectedLedger
 	}
 
 	for _, operation := range tx.operations {

--- a/exp/orderbook/graph.go
+++ b/exp/orderbook/graph.go
@@ -13,6 +13,7 @@ var (
 	errEmptyOffers         = errors.New("offers is empty")
 	errAssetAmountIsZero   = errors.New("current asset amount is 0")
 	errBatchAlreadyApplied = errors.New("cannot apply batched updates more than once")
+	errOutdatedLedger      = errors.New("cannot apply outdated ledger")
 )
 
 type sortByType string
@@ -46,6 +47,8 @@ type OrderBookGraph struct {
 	// batchedUpdates is internal batch of updates to this graph. Users can
 	// create multiple batches using `Batch()` method but sometimes only one
 	// batch is enough.
+	// the orderbook graph is accurate up to lastLedger
+	lastLedger     uint32
 	batchedUpdates *orderBookBatchedUpdates
 	lock           sync.RWMutex
 }
@@ -85,8 +88,8 @@ func (graph *OrderBookGraph) Discard() {
 
 // Apply will attempt to apply all the updates in the internal batch to the order book.
 // When Apply is successful, a new empty, instance of internal batch will be created.
-func (graph *OrderBookGraph) Apply() error {
-	err := graph.batchedUpdates.apply()
+func (graph *OrderBookGraph) Apply(ledger uint32) error {
+	err := graph.batchedUpdates.apply(ledger)
 	if err != nil {
 		return err
 	}
@@ -156,7 +159,7 @@ func (graph *OrderBookGraph) findOffers(
 // Both Asks and Bids will span at most `maxPriceLevels` price levels
 func (graph *OrderBookGraph) FindAsksAndBids(
 	selling, buying xdr.Asset, maxPriceLevels int,
-) ([]xdr.OfferEntry, []xdr.OfferEntry) {
+) ([]xdr.OfferEntry, []xdr.OfferEntry, uint32) {
 	buyingString := buying.String()
 	sellingString := selling.String()
 
@@ -165,7 +168,7 @@ func (graph *OrderBookGraph) FindAsksAndBids(
 	asks := graph.findOffers(sellingString, buyingString, maxPriceLevels)
 	bids := graph.findOffers(buyingString, sellingString, maxPriceLevels)
 
-	return asks, bids
+	return asks, bids, graph.lastLedger
 }
 
 // add inserts a given offer into the order book graph
@@ -246,7 +249,7 @@ func (graph *OrderBookGraph) FindPaths(
 	sourceAssetBalances []xdr.Int64,
 	validateSourceBalance bool,
 	maxAssetsPerPath int,
-) ([]Path, error) {
+) ([]Path, uint32, error) {
 	destinationAssetString := destinationAsset.String()
 	sourceAssetsMap := map[string]xdr.Int64{}
 	for i, sourceAsset := range sourceAssets {
@@ -273,16 +276,18 @@ func (graph *OrderBookGraph) FindPaths(
 		destinationAsset,
 		destinationAmount,
 	)
+	lastLedger := graph.lastLedger
 	graph.lock.RUnlock()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not determine paths")
+		return nil, lastLedger, errors.Wrap(err, "could not determine paths")
 	}
 
-	return sortAndFilterPaths(
+	paths, err := sortAndFilterPaths(
 		searchState.paths,
 		maxAssetsPerPath,
 		sortBySourceAsset,
 	)
+	return paths, lastLedger, err
 }
 
 // FindFixedPaths returns a list of payment paths where the source and destination
@@ -296,7 +301,7 @@ func (graph *OrderBookGraph) FindFixedPaths(
 	amountToSpend xdr.Int64,
 	destinationAssets []xdr.Asset,
 	maxAssetsPerPath int,
-) ([]Path, error) {
+) ([]Path, uint32, error) {
 	target := map[string]bool{}
 	for _, destinationAsset := range destinationAssets {
 		destinationAssetString := destinationAsset.String()
@@ -320,20 +325,22 @@ func (graph *OrderBookGraph) FindFixedPaths(
 		sourceAsset,
 		amountToSpend,
 	)
+	lastLedger := graph.lastLedger
 	graph.lock.RUnlock()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not determine paths")
+		return nil, lastLedger, errors.Wrap(err, "could not determine paths")
 	}
 
 	sort.Slice(searchState.paths, func(i, j int) bool {
 		return searchState.paths[i].DestinationAmount > searchState.paths[j].DestinationAmount
 	})
 
-	return sortAndFilterPaths(
+	paths, err := sortAndFilterPaths(
 		searchState.paths,
 		maxAssetsPerPath,
 		sortByDestinationAsset,
 	)
+	return paths, lastLedger, err
 }
 
 // compareSourceAsset will group payment paths by `SourceAsset`

--- a/exp/orderbook/graph.go
+++ b/exp/orderbook/graph.go
@@ -13,7 +13,7 @@ var (
 	errEmptyOffers         = errors.New("offers is empty")
 	errAssetAmountIsZero   = errors.New("current asset amount is 0")
 	errBatchAlreadyApplied = errors.New("cannot apply batched updates more than once")
-	errOutdatedLedger      = errors.New("cannot apply outdated ledger")
+	errUnexpectedLedger    = errors.New("cannot apply unexpected ledger")
 )
 
 type sortByType string

--- a/exp/orderbook/graph_test.go
+++ b/exp/orderbook/graph_test.go
@@ -320,8 +320,20 @@ func TestApplyOutdatedLedger(t *testing.T) {
 	err = graph.
 		AddOffer(eurOffer).
 		Apply(1)
-	if err != errOutdatedLedger {
-		t.Fatalf("expected error %v but got %v", errOutdatedLedger, err)
+	if err != errUnexpectedLedger {
+		t.Fatalf("expected error %v but got %v", errUnexpectedLedger, err)
+	}
+	if graph.lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, graph.lastLedger)
+	}
+
+	graph.Discard()
+
+	err = graph.
+		AddOffer(eurOffer).
+		Apply(4)
+	if err != errUnexpectedLedger {
+		t.Fatalf("expected error %v but got %v", errUnexpectedLedger, err)
 	}
 	if graph.lastLedger != 2 {
 		t.Fatalf("expected last ledger to be %v but got %v", 2, graph.lastLedger)

--- a/exp/orderbook/graph_test.go
+++ b/exp/orderbook/graph_test.go
@@ -301,6 +301,33 @@ func TestRemoveEdgeSet(t *testing.T) {
 	})
 }
 
+func TestApplyOutdatedLedger(t *testing.T) {
+	graph := NewOrderBookGraph()
+	if graph.lastLedger != 0 {
+		t.Fatalf("expected last ledger to be %v but got %v", 0, graph.lastLedger)
+	}
+
+	err := graph.
+		AddOffer(fiftyCentsOffer).
+		Apply(2)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if graph.lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, graph.lastLedger)
+	}
+
+	err = graph.
+		AddOffer(eurOffer).
+		Apply(1)
+	if err != errOutdatedLedger {
+		t.Fatalf("expected error %v but got %v", errOutdatedLedger, err)
+	}
+	if graph.lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, graph.lastLedger)
+	}
+}
+
 func TestAddOfferOrderBook(t *testing.T) {
 	graph := NewOrderBookGraph()
 
@@ -311,9 +338,12 @@ func TestAddOfferOrderBook(t *testing.T) {
 		AddOffer(twoEurOffer).
 		AddOffer(quarterOffer).
 		AddOffer(fiftyCentsOffer).
-		Apply()
+		Apply(1)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+	if graph.lastLedger != 1 {
+		t.Fatalf("expected last ledger to be %v but got %v", 1, graph.lastLedger)
 	}
 
 	eurUsdOffer := xdr.OfferEntry{
@@ -355,9 +385,12 @@ func TestAddOfferOrderBook(t *testing.T) {
 		AddOffer(eurUsdOffer).
 		AddOffer(otherEurUsdOffer).
 		AddOffer(usdEurOffer).
-		Apply()
+		Apply(2)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+	if graph.lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, graph.lastLedger)
 	}
 
 	expectedGraph := &OrderBookGraph{
@@ -432,9 +465,12 @@ func TestAddOfferOrderBook(t *testing.T) {
 		AddOffer(usdEurOffer).
 		AddOffer(dollarOffer).
 		AddOffer(threeEurOffer).
-		Apply()
+		Apply(3)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+	if graph.lastLedger != 3 {
+		t.Fatalf("expected last ledger to be %v but got %v", 3, graph.lastLedger)
 	}
 
 	assertGraphEquals(t, graph, expectedGraph)
@@ -454,9 +490,12 @@ func TestUpdateOfferOrderBook(t *testing.T) {
 		AddOffer(twoEurOffer).
 		AddOffer(quarterOffer).
 		AddOffer(fiftyCentsOffer).
-		Apply()
+		Apply(1)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+	if graph.lastLedger != 1 {
+		t.Fatalf("expected last ledger to be %v but got %v", 1, graph.lastLedger)
 	}
 
 	if graph.IsEmpty() {
@@ -502,9 +541,12 @@ func TestUpdateOfferOrderBook(t *testing.T) {
 		AddOffer(eurUsdOffer).
 		AddOffer(otherEurUsdOffer).
 		AddOffer(usdEurOffer).
-		Apply()
+		Apply(2)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+	if graph.lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, graph.lastLedger)
 	}
 
 	usdEurOffer.Price.N = 4
@@ -519,9 +561,12 @@ func TestUpdateOfferOrderBook(t *testing.T) {
 		AddOffer(usdEurOffer).
 		AddOffer(otherEurUsdOffer).
 		AddOffer(dollarOffer).
-		Apply()
+		Apply(3)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+	if graph.lastLedger != 3 {
+		t.Fatalf("expected last ledger to be %v but got %v", 3, graph.lastLedger)
 	}
 
 	expectedGraph := &OrderBookGraph{
@@ -604,21 +649,31 @@ func TestDiscard(t *testing.T) {
 		AddOffer(quarterOffer).
 		AddOffer(fiftyCentsOffer).
 		Discard()
-	if err := graph.Apply(); err != nil {
+	if graph.lastLedger != 0 {
+		t.Fatalf("expected last ledger to be %v but got %v", 0, graph.lastLedger)
+	}
+
+	if err := graph.Apply(1); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 	if !graph.IsEmpty() {
 		t.Fatal("expected graph to be empty")
 	}
+	if graph.lastLedger != 1 {
+		t.Fatalf("expected last ledger to be %v but got %v", 1, graph.lastLedger)
+	}
 
 	err := graph.
 		AddOffer(dollarOffer).
-		Apply()
+		Apply(2)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 	if graph.IsEmpty() {
 		t.Fatal("expected graph to be not empty")
+	}
+	if graph.lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, graph.lastLedger)
 	}
 
 	expectedOffers := []xdr.OfferEntry{dollarOffer}
@@ -638,9 +693,12 @@ func TestRemoveOfferOrderBook(t *testing.T) {
 		AddOffer(twoEurOffer).
 		AddOffer(quarterOffer).
 		AddOffer(fiftyCentsOffer).
-		Apply()
+		Apply(1)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+	if graph.lastLedger != 1 {
+		t.Fatalf("expected last ledger to be %v but got %v", 1, graph.lastLedger)
 	}
 
 	eurUsdOffer := xdr.OfferEntry{
@@ -685,9 +743,12 @@ func TestRemoveOfferOrderBook(t *testing.T) {
 		RemoveOffer(usdEurOffer.OfferId).
 		RemoveOffer(otherEurUsdOffer.OfferId).
 		RemoveOffer(dollarOffer.OfferId).
-		Apply()
+		Apply(2)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+	if graph.lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, graph.lastLedger)
 	}
 
 	expectedGraph := &OrderBookGraph{
@@ -746,9 +807,12 @@ func TestRemoveOfferOrderBook(t *testing.T) {
 		RemoveOffer(twoEurOffer.OfferId).
 		RemoveOffer(threeEurOffer.OfferId).
 		RemoveOffer(eurUsdOffer.OfferId).
-		Apply()
+		Apply(3)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+	if graph.lastLedger != 3 {
+		t.Fatalf("expected last ledger to be %v but got %v", 3, graph.lastLedger)
 	}
 
 	expectedGraph.edgesForSellingAsset = map[string]edgeSet{}
@@ -779,7 +843,7 @@ func TestFindOffers(t *testing.T) {
 		AddOffer(threeEurOffer).
 		AddOffer(eurOffer).
 		AddOffer(twoEurOffer).
-		Apply()
+		Apply(1)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -802,7 +866,7 @@ func TestFindOffers(t *testing.T) {
 		graph.AddOffer(otherTwoEurOffer)
 		extraTwoEurOffers = append(extraTwoEurOffers, otherTwoEurOffer)
 	}
-	if err := graph.Apply(); err != nil {
+	if err := graph.Apply(2); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 
@@ -821,7 +885,7 @@ func TestFindOffers(t *testing.T) {
 func TestFindAsksAndBids(t *testing.T) {
 	graph := NewOrderBookGraph()
 
-	asks, bids := graph.FindAsksAndBids(nativeAsset, eurAsset, 0)
+	asks, bids, lastLedger := graph.FindAsksAndBids(nativeAsset, eurAsset, 0)
 	assertOfferListEquals(
 		t,
 		[]xdr.OfferEntry{},
@@ -832,8 +896,11 @@ func TestFindAsksAndBids(t *testing.T) {
 		[]xdr.OfferEntry{},
 		bids,
 	)
+	if lastLedger != 0 {
+		t.Fatalf("expected last ledger to be %v but got %v", 0, lastLedger)
+	}
 
-	asks, bids = graph.FindAsksAndBids(nativeAsset, eurAsset, 5)
+	asks, bids, lastLedger = graph.FindAsksAndBids(nativeAsset, eurAsset, 5)
 	assertOfferListEquals(
 		t,
 		[]xdr.OfferEntry{},
@@ -844,17 +911,20 @@ func TestFindAsksAndBids(t *testing.T) {
 		[]xdr.OfferEntry{},
 		bids,
 	)
+	if lastLedger != 0 {
+		t.Fatalf("expected last ledger to be %v but got %v", 0, lastLedger)
+	}
 
 	err := graph.
 		AddOffer(threeEurOffer).
 		AddOffer(eurOffer).
 		AddOffer(twoEurOffer).
-		Apply()
+		Apply(1)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 
-	asks, bids = graph.FindAsksAndBids(nativeAsset, eurAsset, 0)
+	asks, bids, lastLedger = graph.FindAsksAndBids(nativeAsset, eurAsset, 0)
 	assertOfferListEquals(
 		t,
 		[]xdr.OfferEntry{},
@@ -865,6 +935,9 @@ func TestFindAsksAndBids(t *testing.T) {
 		[]xdr.OfferEntry{},
 		bids,
 	)
+	if lastLedger != 1 {
+		t.Fatalf("expected last ledger to be %v but got %v", 1, lastLedger)
+	}
 
 	extraTwoEurOffers := []xdr.OfferEntry{}
 	for i := 0; i < 4; i++ {
@@ -873,18 +946,18 @@ func TestFindAsksAndBids(t *testing.T) {
 		graph.AddOffer(otherTwoEurOffer)
 		extraTwoEurOffers = append(extraTwoEurOffers, otherTwoEurOffer)
 	}
-	if err := graph.Apply(); err != nil {
+	if err := graph.Apply(2); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 
 	sellEurOffer := twoEurOffer
 	sellEurOffer.Buying, sellEurOffer.Selling = sellEurOffer.Selling, sellEurOffer.Buying
 	sellEurOffer.OfferId = 35
-	if err := graph.AddOffer(sellEurOffer).Apply(); err != nil {
+	if err := graph.AddOffer(sellEurOffer).Apply(3); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 
-	asks, bids = graph.FindAsksAndBids(nativeAsset, eurAsset, 3)
+	asks, bids, lastLedger = graph.FindAsksAndBids(nativeAsset, eurAsset, 3)
 	assertOfferListEquals(
 		t,
 		append(append([]xdr.OfferEntry{eurOffer, twoEurOffer}, extraTwoEurOffers...), threeEurOffer),
@@ -895,6 +968,9 @@ func TestFindAsksAndBids(t *testing.T) {
 		[]xdr.OfferEntry{sellEurOffer},
 		bids,
 	)
+	if lastLedger != 3 {
+		t.Fatalf("expected last ledger to be %v but got %v", 3, lastLedger)
+	}
 }
 
 func TestConsumeOffersForSellingAsset(t *testing.T) {
@@ -1337,7 +1413,7 @@ func TestFindPaths(t *testing.T) {
 		AddOffer(twoEurOffer).
 		AddOffer(quarterOffer).
 		AddOffer(fiftyCentsOffer).
-		Apply()
+		Apply(1)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -1407,7 +1483,7 @@ func TestFindPaths(t *testing.T) {
 		AddOffer(usdEurOffer).
 		AddOffer(chfEurOffer).
 		AddOffer(yenChfOffer).
-		Apply()
+		Apply(2)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -1418,7 +1494,7 @@ func TestFindPaths(t *testing.T) {
 	}
 	ignoreOffersFrom := xdr.MustAddress(kp.Address())
 
-	paths, err := graph.FindPaths(
+	paths, lastLedger, err := graph.FindPaths(
 		3,
 		nativeAsset,
 		20,
@@ -1438,8 +1514,11 @@ func TestFindPaths(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 	assertPathEquals(t, paths, []Path{})
+	if lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, lastLedger)
+	}
 
-	paths, err = graph.FindPaths(
+	paths, lastLedger, err = graph.FindPaths(
 		3,
 		nativeAsset,
 		20,
@@ -1457,6 +1536,9 @@ func TestFindPaths(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+	if lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, lastLedger)
 	}
 
 	expectedPaths := []Path{
@@ -1490,7 +1572,7 @@ func TestFindPaths(t *testing.T) {
 
 	assertPathEquals(t, paths, expectedPaths)
 
-	paths, err = graph.FindPaths(
+	paths, lastLedger, err = graph.FindPaths(
 		3,
 		nativeAsset,
 		20,
@@ -1510,8 +1592,11 @@ func TestFindPaths(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 	assertPathEquals(t, paths, expectedPaths)
+	if lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, lastLedger)
+	}
 
-	paths, err = graph.FindPaths(
+	paths, lastLedger, err = graph.FindPaths(
 		4,
 		nativeAsset,
 		20,
@@ -1527,6 +1612,9 @@ func TestFindPaths(t *testing.T) {
 		true,
 		5,
 	)
+	if lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, lastLedger)
+	}
 
 	expectedPaths = []Path{
 		Path{
@@ -1574,7 +1662,7 @@ func TestFindPaths(t *testing.T) {
 
 	assertPathEquals(t, paths, expectedPaths)
 
-	paths, err = graph.FindPaths(
+	paths, lastLedger, err = graph.FindPaths(
 		4,
 		nativeAsset,
 		20,
@@ -1590,6 +1678,9 @@ func TestFindPaths(t *testing.T) {
 		true,
 		5,
 	)
+	if lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, lastLedger)
+	}
 
 	expectedPaths = []Path{
 		Path{
@@ -1648,7 +1739,7 @@ func TestFindPathsStartingAt(t *testing.T) {
 		AddOffer(twoEurOffer).
 		AddOffer(quarterOffer).
 		AddOffer(fiftyCentsOffer).
-		Apply()
+		Apply(1)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -1718,12 +1809,12 @@ func TestFindPathsStartingAt(t *testing.T) {
 		AddOffer(usdEurOffer).
 		AddOffer(chfEurOffer).
 		AddOffer(yenChfOffer).
-		Apply()
+		Apply(2)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 
-	paths, err := graph.FindFixedPaths(
+	paths, lastLedger, err := graph.FindFixedPaths(
 		3,
 		usdAsset,
 		5,
@@ -1732,6 +1823,9 @@ func TestFindPathsStartingAt(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+	if lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, lastLedger)
 	}
 
 	expectedPaths := []Path{
@@ -1755,7 +1849,7 @@ func TestFindPathsStartingAt(t *testing.T) {
 
 	assertPathEquals(t, paths, expectedPaths)
 
-	paths, err = graph.FindFixedPaths(
+	paths, lastLedger, err = graph.FindFixedPaths(
 		2,
 		yenAsset,
 		5,
@@ -1765,12 +1859,15 @@ func TestFindPathsStartingAt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
+	if lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, lastLedger)
+	}
 
 	expectedPaths = []Path{}
 
 	assertPathEquals(t, paths, expectedPaths)
 
-	paths, err = graph.FindFixedPaths(
+	paths, lastLedger, err = graph.FindFixedPaths(
 		3,
 		yenAsset,
 		5,
@@ -1779,6 +1876,9 @@ func TestFindPathsStartingAt(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+	if lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, lastLedger)
 	}
 
 	expectedPaths = []Path{
@@ -1796,7 +1896,7 @@ func TestFindPathsStartingAt(t *testing.T) {
 
 	assertPathEquals(t, paths, expectedPaths)
 
-	paths, err = graph.FindFixedPaths(
+	paths, lastLedger, err = graph.FindFixedPaths(
 		5,
 		yenAsset,
 		5,
@@ -1805,6 +1905,9 @@ func TestFindPathsStartingAt(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+	if lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, lastLedger)
 	}
 
 	expectedPaths = []Path{
@@ -1833,7 +1936,7 @@ func TestFindPathsStartingAt(t *testing.T) {
 
 	assertPathEquals(t, paths, expectedPaths)
 
-	paths, err = graph.FindFixedPaths(
+	paths, lastLedger, err = graph.FindFixedPaths(
 		5,
 		yenAsset,
 		5,
@@ -1842,6 +1945,9 @@ func TestFindPathsStartingAt(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+	if lastLedger != 2 {
+		t.Fatalf("expected last ledger to be %v but got %v", 2, lastLedger)
 	}
 
 	expectedPaths = []Path{

--- a/exp/tools/horizon-demo/pipelines.go
+++ b/exp/tools/horizon-demo/pipelines.go
@@ -91,7 +91,7 @@ func addPipelineHooks(
 		wg.Add(2)
 
 		go func() {
-			err = orderBookGraph.Apply()
+			err = orderBookGraph.Apply(ledgerSeq)
 			wg.Done()
 		}()
 

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -8,6 +8,8 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ## v0.23.0
 
+* Add `Latest-Ledger` header with the sequence number of the last processed ledger by the experimental ingestion system. The endpoints built using the experimental ingestion system will always respond with data which is consistent with the ledger in `Latest-Ledger`.
+
 ### Breaking Changes
 
 * Remove deprecated `fee_paid` field on Transaction resource. Please use new fields added in 0.18.0: `max_fee` that defines the maximum fee the source account is willing to pay and `fee_charged` that defines the fee that was actually paid for a transaction. See [CAP-0005](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0005.md) for more information.

--- a/services/horizon/internal/action_offers_expingest_test.go
+++ b/services/horizon/internal/action_offers_expingest_test.go
@@ -146,7 +146,7 @@ func TestOfferActionsExperimentalIngestion(t *testing.T) {
 	}
 	app.config.EnableExperimentalIngestion = true
 
-	handler := actions.GetAccountOffersHandler{HistoryQ: q}
+	handler := actions.GetAccountOffersHandler{}
 	client := accountOffersClient(tt, app, handler)
 
 	tt.Assert.NoError(q.UpdateLastLedgerExpIngest(0))

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -66,8 +66,8 @@ type GetAccountsHandler struct {
 // to find accounts for signer but also accounts for assets, home domain,
 // inflation_dest etc.
 func (handler GetAccountsHandler) GetResourcePage(
-	r *http.Request,
 	w HeaderWriter,
+	r *http.Request,
 ) ([]hal.Pageable, error) {
 	ctx := r.Context()
 

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -65,7 +65,10 @@ type GetAccountsHandler struct {
 // when the new ingestion system is fully integrated, this endpoint can be used
 // to find accounts for signer but also accounts for assets, home domain,
 // inflation_dest etc.
-func (handler GetAccountsHandler) GetResourcePage(r *http.Request) ([]hal.Pageable, error) {
+func (handler GetAccountsHandler) GetResourcePage(
+	r *http.Request,
+	w HeaderWriter,
+) ([]hal.Pageable, error) {
 	ctx := r.Context()
 
 	signer, err := GetAccountID(r, "signer")

--- a/services/horizon/internal/actions/account_test.go
+++ b/services/horizon/internal/actions/account_test.go
@@ -36,6 +36,7 @@ func TestGetAccountsHandlerPageNoResults(t *testing.T) {
 	q := &history.Q{tt.HorizonSession()}
 	handler := &GetAccountsHandler{HistoryQ: q}
 	records, err := handler.GetResourcePage(
+		httptest.NewRecorder(),
 		makeRequest(
 			t,
 			map[string]string{
@@ -44,7 +45,6 @@ func TestGetAccountsHandlerPageNoResults(t *testing.T) {
 			map[string]string{},
 			q.Session,
 		),
-		httptest.NewRecorder(),
 	)
 	tt.Assert.NoError(err)
 	tt.Assert.Len(records, 0)
@@ -81,6 +81,7 @@ func TestGetAccountsHandlerPageResults(t *testing.T) {
 	}
 
 	records, err := handler.GetResourcePage(
+		httptest.NewRecorder(),
 		makeRequest(
 			t,
 			map[string]string{
@@ -89,7 +90,6 @@ func TestGetAccountsHandlerPageResults(t *testing.T) {
 			map[string]string{},
 			q.Session,
 		),
-		httptest.NewRecorder(),
 	)
 
 	tt.Assert.NoError(err)

--- a/services/horizon/internal/actions/account_test.go
+++ b/services/horizon/internal/actions/account_test.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	protocol "github.com/stellar/go/protocols/horizon"
@@ -34,9 +35,17 @@ func TestGetAccountsHandlerPageNoResults(t *testing.T) {
 
 	q := &history.Q{tt.HorizonSession()}
 	handler := &GetAccountsHandler{HistoryQ: q}
-	records, err := handler.GetResourcePage(makeRequest(t, map[string]string{
-		"signer": "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
-	}, map[string]string{}))
+	records, err := handler.GetResourcePage(
+		makeRequest(
+			t,
+			map[string]string{
+				"signer": "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
+			},
+			map[string]string{},
+			q.Session,
+		),
+		httptest.NewRecorder(),
+	)
 	tt.Assert.NoError(err)
 	tt.Assert.Len(records, 0)
 }
@@ -71,9 +80,17 @@ func TestGetAccountsHandlerPageResults(t *testing.T) {
 		q.CreateAccountSigner(row.Account, row.Signer, row.Weight)
 	}
 
-	records, err := handler.GetResourcePage(makeRequest(t, map[string]string{
-		"signer": "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
-	}, map[string]string{}))
+	records, err := handler.GetResourcePage(
+		makeRequest(
+			t,
+			map[string]string{
+				"signer": "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
+			},
+			map[string]string{},
+			q.Session,
+		),
+		httptest.NewRecorder(),
+	)
 
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(3, len(records))

--- a/services/horizon/internal/actions/helpers_test.go
+++ b/services/horizon/internal/actions/helpers_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/services/horizon/internal/toid"
+	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/xdr"
 )
@@ -620,6 +621,7 @@ func makeRequest(
 	t *testing.T,
 	queryParams map[string]string,
 	routeParams map[string]string,
+	session *db.Session,
 ) *http.Request {
 	request, err := http.NewRequest("GET", "/", nil)
 	if err != nil {
@@ -635,6 +637,11 @@ func makeRequest(
 	for key, value := range routeParams {
 		chiRouteContext.URLParams.Add(key, value)
 	}
-	ctx := context.WithValue(context.Background(), chi.RouteCtxKey, chiRouteContext)
+	ctx := context.WithValue(
+		context.WithValue(context.Background(), chi.RouteCtxKey, chiRouteContext),
+		&horizonContext.SessionContextKey,
+		session,
+	)
+
 	return request.WithContext(ctx)
 }

--- a/services/horizon/internal/actions/offer.go
+++ b/services/horizon/internal/actions/offer.go
@@ -18,8 +18,8 @@ type GetOffersHandler struct {
 
 // GetResourcePage returns a page of offers.
 func (handler GetOffersHandler) GetResourcePage(
-	r *http.Request,
 	w HeaderWriter,
+	r *http.Request,
 ) ([]hal.Pageable, error) {
 	ctx := r.Context()
 	pq, err := GetPageQuery(r)
@@ -88,8 +88,8 @@ func (handler GetAccountOffersHandler) parseOffersQuery(r *http.Request) (histor
 
 // GetResourcePage returns a page of offers for a given account.
 func (handler GetAccountOffersHandler) GetResourcePage(
-	r *http.Request,
 	w HeaderWriter,
+	r *http.Request,
 ) ([]hal.Pageable, error) {
 	ctx := r.Context()
 	query, err := handler.parseOffersQuery(r)

--- a/services/horizon/internal/actions/offer.go
+++ b/services/horizon/internal/actions/offer.go
@@ -14,11 +14,13 @@ import (
 
 // GetOffersHandler is the action handler for the /offers endpoint
 type GetOffersHandler struct {
-	HistoryQ *history.Q
 }
 
 // GetResourcePage returns a page of offers.
-func (handler GetOffersHandler) GetResourcePage(r *http.Request) ([]hal.Pageable, error) {
+func (handler GetOffersHandler) GetResourcePage(
+	r *http.Request,
+	w HeaderWriter,
+) ([]hal.Pageable, error) {
 	ctx := r.Context()
 	pq, err := GetPageQuery(r)
 	if err != nil {
@@ -47,7 +49,12 @@ func (handler GetOffersHandler) GetResourcePage(r *http.Request) ([]hal.Pageable
 		Buying:    buying,
 	}
 
-	offers, err := getOffersPage(ctx, handler.HistoryQ, query)
+	historyQ, err := historyQFromRequest(r)
+	if err != nil {
+		return nil, err
+	}
+
+	offers, err := getOffersPage(ctx, historyQ, query)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +65,6 @@ func (handler GetOffersHandler) GetResourcePage(r *http.Request) ([]hal.Pageable
 // GetAccountOffersHandler is the action handler for the
 // `/accounts/{account_id}/offers` endpoint when using experimental ingestion.
 type GetAccountOffersHandler struct {
-	HistoryQ *history.Q
 }
 
 func (handler GetAccountOffersHandler) parseOffersQuery(r *http.Request) (history.OffersQuery, error) {
@@ -81,14 +87,22 @@ func (handler GetAccountOffersHandler) parseOffersQuery(r *http.Request) (histor
 }
 
 // GetResourcePage returns a page of offers for a given account.
-func (handler GetAccountOffersHandler) GetResourcePage(r *http.Request) ([]hal.Pageable, error) {
+func (handler GetAccountOffersHandler) GetResourcePage(
+	r *http.Request,
+	w HeaderWriter,
+) ([]hal.Pageable, error) {
 	ctx := r.Context()
 	query, err := handler.parseOffersQuery(r)
 	if err != nil {
 		return nil, err
 	}
 
-	offers, err := getOffersPage(ctx, handler.HistoryQ, query)
+	historyQ, err := historyQFromRequest(r)
+	if err != nil {
+		return nil, err
+	}
+
+	offers, err := getOffersPage(ctx, historyQ, query)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/offer_test.go
+++ b/services/horizon/internal/actions/offer_test.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -65,7 +66,7 @@ func TestGetOffersHandler(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOffersHandler{HistoryQ: q}
+	handler := GetOffersHandler{}
 	ingestion := ingest.Ingestion{DB: tt.HorizonSession()}
 
 	ledgerCloseTime := time.Now().Unix()
@@ -88,7 +89,12 @@ func TestGetOffersHandler(t *testing.T) {
 	tt.Assert.NoError(err)
 
 	t.Run("No filter", func(t *testing.T) {
-		records, err := handler.GetResourcePage(makeRequest(t, map[string]string{}, map[string]string{}))
+		records, err := handler.GetResourcePage(
+			makeRequest(
+				t, map[string]string{}, map[string]string{}, q.Session,
+			),
+			httptest.NewRecorder(),
+		)
 		tt.Assert.NoError(err)
 		tt.Assert.Len(records, 3)
 
@@ -104,13 +110,17 @@ func TestGetOffersHandler(t *testing.T) {
 	})
 
 	t.Run("Filter by seller", func(t *testing.T) {
-		records, err := handler.GetResourcePage(makeRequest(
-			t,
-			map[string]string{
-				"seller": issuer.Address(),
-			},
-			map[string]string{},
-		))
+		records, err := handler.GetResourcePage(
+			makeRequest(
+				t,
+				map[string]string{
+					"seller": issuer.Address(),
+				},
+				map[string]string{},
+				q.Session,
+			),
+			httptest.NewRecorder(),
+		)
 		tt.Assert.NoError(err)
 		tt.Assert.Len(records, 2)
 
@@ -123,14 +133,17 @@ func TestGetOffersHandler(t *testing.T) {
 	t.Run("Filter by selling asset", func(t *testing.T) {
 		asset := horizon.Asset{}
 		nativeAsset.Extract(&asset.Type, &asset.Code, &asset.Issuer)
-
-		records, err := handler.GetResourcePage(makeRequest(
-			t,
-			map[string]string{
-				"selling_asset_type": asset.Type,
-			},
-			map[string]string{},
-		))
+		records, err := handler.GetResourcePage(
+			makeRequest(
+				t,
+				map[string]string{
+					"selling_asset_type": asset.Type,
+				},
+				map[string]string{},
+				q.Session,
+			),
+			httptest.NewRecorder(),
+		)
 		tt.Assert.NoError(err)
 		tt.Assert.Len(records, 2)
 
@@ -142,15 +155,19 @@ func TestGetOffersHandler(t *testing.T) {
 		asset = horizon.Asset{}
 		eurAsset.Extract(&asset.Type, &asset.Code, &asset.Issuer)
 
-		records, err = handler.GetResourcePage(makeRequest(
-			t,
-			map[string]string{
-				"selling_asset_type":   asset.Type,
-				"selling_asset_code":   asset.Code,
-				"selling_asset_issuer": asset.Issuer,
-			},
-			map[string]string{},
-		))
+		records, err = handler.GetResourcePage(
+			makeRequest(
+				t,
+				map[string]string{
+					"selling_asset_type":   asset.Type,
+					"selling_asset_code":   asset.Code,
+					"selling_asset_issuer": asset.Issuer,
+				},
+				map[string]string{},
+				q.Session,
+			),
+			httptest.NewRecorder(),
+		)
 		tt.Assert.NoError(err)
 		tt.Assert.Len(records, 1)
 
@@ -162,15 +179,19 @@ func TestGetOffersHandler(t *testing.T) {
 		asset := horizon.Asset{}
 		eurAsset.Extract(&asset.Type, &asset.Code, &asset.Issuer)
 
-		records, err := handler.GetResourcePage(makeRequest(
-			t,
-			map[string]string{
-				"buying_asset_type":   asset.Type,
-				"buying_asset_code":   asset.Code,
-				"buying_asset_issuer": asset.Issuer,
-			},
-			map[string]string{},
-		))
+		records, err := handler.GetResourcePage(
+			makeRequest(
+				t,
+				map[string]string{
+					"buying_asset_type":   asset.Type,
+					"buying_asset_code":   asset.Code,
+					"buying_asset_issuer": asset.Issuer,
+				},
+				map[string]string{},
+				q.Session,
+			),
+			httptest.NewRecorder(),
+		)
 		tt.Assert.NoError(err)
 		tt.Assert.Len(records, 2)
 
@@ -182,15 +203,19 @@ func TestGetOffersHandler(t *testing.T) {
 		asset = horizon.Asset{}
 		usdAsset.Extract(&asset.Type, &asset.Code, &asset.Issuer)
 
-		records, err = handler.GetResourcePage(makeRequest(
-			t,
-			map[string]string{
-				"buying_asset_type":   asset.Type,
-				"buying_asset_code":   asset.Code,
-				"buying_asset_issuer": asset.Issuer,
-			},
-			map[string]string{},
-		))
+		records, err = handler.GetResourcePage(
+			makeRequest(
+				t,
+				map[string]string{
+					"buying_asset_type":   asset.Type,
+					"buying_asset_code":   asset.Code,
+					"buying_asset_issuer": asset.Issuer,
+				},
+				map[string]string{},
+				q.Session,
+			),
+			httptest.NewRecorder(),
+		)
 		tt.Assert.NoError(err)
 		tt.Assert.Len(records, 1)
 
@@ -207,9 +232,7 @@ func TestGetAccountOffersHandler(t *testing.T) {
 
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetAccountOffersHandler{
-		HistoryQ: q,
-	}
+	handler := GetAccountOffersHandler{}
 
 	_, err := q.InsertOffer(eurOffer, 3)
 	tt.Assert.NoError(err)
@@ -219,7 +242,13 @@ func TestGetAccountOffersHandler(t *testing.T) {
 	tt.Assert.NoError(err)
 
 	records, err := handler.GetResourcePage(
-		makeRequest(t, map[string]string{}, map[string]string{"account_id": issuer.Address()}),
+		makeRequest(
+			t,
+			map[string]string{},
+			map[string]string{"account_id": issuer.Address()},
+			q.Session,
+		),
+		httptest.NewRecorder(),
 	)
 	tt.Assert.NoError(err)
 	tt.Assert.Len(records, 2)

--- a/services/horizon/internal/actions/offer_test.go
+++ b/services/horizon/internal/actions/offer_test.go
@@ -90,10 +90,10 @@ func TestGetOffersHandler(t *testing.T) {
 
 	t.Run("No filter", func(t *testing.T) {
 		records, err := handler.GetResourcePage(
+			httptest.NewRecorder(),
 			makeRequest(
 				t, map[string]string{}, map[string]string{}, q.Session,
 			),
-			httptest.NewRecorder(),
 		)
 		tt.Assert.NoError(err)
 		tt.Assert.Len(records, 3)
@@ -111,6 +111,7 @@ func TestGetOffersHandler(t *testing.T) {
 
 	t.Run("Filter by seller", func(t *testing.T) {
 		records, err := handler.GetResourcePage(
+			httptest.NewRecorder(),
 			makeRequest(
 				t,
 				map[string]string{
@@ -119,7 +120,6 @@ func TestGetOffersHandler(t *testing.T) {
 				map[string]string{},
 				q.Session,
 			),
-			httptest.NewRecorder(),
 		)
 		tt.Assert.NoError(err)
 		tt.Assert.Len(records, 2)
@@ -134,6 +134,7 @@ func TestGetOffersHandler(t *testing.T) {
 		asset := horizon.Asset{}
 		nativeAsset.Extract(&asset.Type, &asset.Code, &asset.Issuer)
 		records, err := handler.GetResourcePage(
+			httptest.NewRecorder(),
 			makeRequest(
 				t,
 				map[string]string{
@@ -142,7 +143,6 @@ func TestGetOffersHandler(t *testing.T) {
 				map[string]string{},
 				q.Session,
 			),
-			httptest.NewRecorder(),
 		)
 		tt.Assert.NoError(err)
 		tt.Assert.Len(records, 2)
@@ -156,6 +156,7 @@ func TestGetOffersHandler(t *testing.T) {
 		eurAsset.Extract(&asset.Type, &asset.Code, &asset.Issuer)
 
 		records, err = handler.GetResourcePage(
+			httptest.NewRecorder(),
 			makeRequest(
 				t,
 				map[string]string{
@@ -166,7 +167,6 @@ func TestGetOffersHandler(t *testing.T) {
 				map[string]string{},
 				q.Session,
 			),
-			httptest.NewRecorder(),
 		)
 		tt.Assert.NoError(err)
 		tt.Assert.Len(records, 1)
@@ -180,6 +180,7 @@ func TestGetOffersHandler(t *testing.T) {
 		eurAsset.Extract(&asset.Type, &asset.Code, &asset.Issuer)
 
 		records, err := handler.GetResourcePage(
+			httptest.NewRecorder(),
 			makeRequest(
 				t,
 				map[string]string{
@@ -190,7 +191,6 @@ func TestGetOffersHandler(t *testing.T) {
 				map[string]string{},
 				q.Session,
 			),
-			httptest.NewRecorder(),
 		)
 		tt.Assert.NoError(err)
 		tt.Assert.Len(records, 2)
@@ -204,6 +204,7 @@ func TestGetOffersHandler(t *testing.T) {
 		usdAsset.Extract(&asset.Type, &asset.Code, &asset.Issuer)
 
 		records, err = handler.GetResourcePage(
+			httptest.NewRecorder(),
 			makeRequest(
 				t,
 				map[string]string{
@@ -214,7 +215,6 @@ func TestGetOffersHandler(t *testing.T) {
 				map[string]string{},
 				q.Session,
 			),
-			httptest.NewRecorder(),
 		)
 		tt.Assert.NoError(err)
 		tt.Assert.Len(records, 1)
@@ -242,13 +242,13 @@ func TestGetAccountOffersHandler(t *testing.T) {
 	tt.Assert.NoError(err)
 
 	records, err := handler.GetResourcePage(
+		httptest.NewRecorder(),
 		makeRequest(
 			t,
 			map[string]string{},
 			map[string]string{"account_id": issuer.Address()},
 			q.Session,
 		),
-		httptest.NewRecorder(),
 	)
 	tt.Assert.NoError(err)
 	tt.Assert.Len(records, 2)

--- a/services/horizon/internal/actions/orderbook.go
+++ b/services/horizon/internal/actions/orderbook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 	"net/http"
+	"strconv"
 
 	"github.com/stellar/go/amount"
 	"github.com/stellar/go/exp/orderbook"
@@ -12,6 +13,19 @@ import (
 	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/xdr"
 )
+
+// LastLedgerHeaderName is the header which is set on all experimental ingestion endpoints
+const LastLedgerHeaderName = "Latest-Ledger"
+
+// HeaderWriter is an interface for setting HTTP response headers
+type HeaderWriter interface {
+	Header() http.Header
+}
+
+// SetLastLedgerHeader sets the Latest-Ledger header
+func SetLastLedgerHeader(w HeaderWriter, lastLedger uint32) {
+	w.Header().Set(LastLedgerHeaderName, strconv.FormatUint(uint64(lastLedger), 10))
+}
 
 // StreamableObjectResponse is an interface for objects returned by streamable object endpoints
 // A streamable object endpoint is an SSE endpoint which returns a single JSON object response
@@ -112,30 +126,30 @@ func offersToPriceLevels(offers []xdr.OfferEntry, invert bool) ([]protocol.Price
 
 func (handler GetOrderbookHandler) orderBookSummary(
 	ctx context.Context, selling, buying xdr.Asset, limit int,
-) (protocol.OrderBookSummary, error) {
+) (protocol.OrderBookSummary, uint32, error) {
 	response := protocol.OrderBookSummary{}
 	if err := resourceadapter.PopulateAsset(ctx, &response.Selling, selling); err != nil {
-		return response, err
+		return response, 0, err
 	}
 	if err := resourceadapter.PopulateAsset(ctx, &response.Buying, buying); err != nil {
-		return response, err
+		return response, 0, err
 	}
 
 	var err error
-	asks, bids := handler.OrderBookGraph.FindAsksAndBids(selling, buying, limit)
+	asks, bids, lastLedger := handler.OrderBookGraph.FindAsksAndBids(selling, buying, limit)
 	if response.Asks, err = offersToPriceLevels(asks, false); err != nil {
-		return response, err
+		return response, 0, err
 	}
 
 	if response.Bids, err = offersToPriceLevels(bids, true); err != nil {
-		return response, err
+		return response, 0, err
 	}
 
-	return response, nil
+	return response, lastLedger, nil
 }
 
 // GetResource implements the /order_book endpoint
-func (handler GetOrderbookHandler) GetResource(r *http.Request) (StreamableObjectResponse, error) {
+func (handler GetOrderbookHandler) GetResource(r *http.Request, w HeaderWriter) (StreamableObjectResponse, error) {
 	selling, err := GetAsset(r, "selling_")
 	if err != nil {
 		return nil, invalidOrderBook
@@ -149,10 +163,11 @@ func (handler GetOrderbookHandler) GetResource(r *http.Request) (StreamableObjec
 		return nil, invalidOrderBook
 	}
 
-	summary, err := handler.orderBookSummary(r.Context(), selling, buying, int(limit))
+	summary, lastLedger, err := handler.orderBookSummary(r.Context(), selling, buying, int(limit))
 	if err != nil {
 		return nil, err
 	}
 
+	SetLastLedgerHeader(w, lastLedger)
 	return OrderBookResponse{summary}, nil
 }

--- a/services/horizon/internal/actions/orderbook.go
+++ b/services/horizon/internal/actions/orderbook.go
@@ -149,7 +149,7 @@ func (handler GetOrderbookHandler) orderBookSummary(
 }
 
 // GetResource implements the /order_book endpoint
-func (handler GetOrderbookHandler) GetResource(r *http.Request, w HeaderWriter) (StreamableObjectResponse, error) {
+func (handler GetOrderbookHandler) GetResource(w HeaderWriter, r *http.Request) (StreamableObjectResponse, error) {
 	selling, err := GetAsset(r, "selling_")
 	if err != nil {
 		return nil, invalidOrderBook

--- a/services/horizon/internal/actions/orderbook_test.go
+++ b/services/horizon/internal/actions/orderbook_test.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"math"
+	"net/http/httptest"
 	"strconv"
 	"testing"
 
@@ -450,10 +451,14 @@ func TestOrderbookGetResourceValidation(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			r := makeRequest(t, testCase.queryParams, map[string]string{})
-			_, err := handler.GetResource(r)
+			r := makeRequest(t, testCase.queryParams, map[string]string{}, nil)
+			w := httptest.NewRecorder()
+			_, err := handler.GetResource(r, w)
 			if err == nil || err.Error() != invalidOrderBook.Error() {
 				t.Fatalf("expected error %v but got %v", invalidOrderBook, err)
+			}
+			if lastLedger := w.Header().Get(LastLedgerHeaderName); lastLedger != "" {
+				t.Fatalf("expected last ledger to be not set but got %v", lastLedger)
 			}
 		})
 	}
@@ -481,7 +486,7 @@ func TestOrderbookGetResource(t *testing.T) {
 	}
 
 	asksButNoBidsGraph := orderbook.NewOrderBookGraph()
-	if err := asksButNoBidsGraph.AddOffer(twoEurOffer).Apply(); err != nil {
+	if err := asksButNoBidsGraph.AddOffer(twoEurOffer).Apply(1); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 	asksButNoBidsResponse := empty
@@ -497,7 +502,7 @@ func TestOrderbookGetResource(t *testing.T) {
 	sellEurOffer.Buying, sellEurOffer.Selling = sellEurOffer.Selling, sellEurOffer.Buying
 	sellEurOffer.OfferId = 15
 	bidsButNoAsksGraph := orderbook.NewOrderBookGraph()
-	if err := bidsButNoAsksGraph.AddOffer(sellEurOffer).Apply(); err != nil {
+	if err := bidsButNoAsksGraph.AddOffer(sellEurOffer).Apply(2); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 	bidsButNoAsksResponse := empty
@@ -510,31 +515,31 @@ func TestOrderbookGetResource(t *testing.T) {
 	}
 
 	fullGraph := orderbook.NewOrderBookGraph()
-	if err := fullGraph.AddOffer(twoEurOffer).Apply(); err != nil {
+	if err := fullGraph.AddOffer(twoEurOffer).Apply(3); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 	otherEurOffer := twoEurOffer
 	otherEurOffer.Amount = xdr.Int64(math.MaxInt64)
 	otherEurOffer.OfferId = 16
-	if err := fullGraph.AddOffer(otherEurOffer).Apply(); err != nil {
+	if err := fullGraph.AddOffer(otherEurOffer).Apply(4); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 	threeEurOffer := twoEurOffer
 	threeEurOffer.Price.N = 3
 	threeEurOffer.OfferId = 20
-	if err := fullGraph.AddOffer(threeEurOffer).Apply(); err != nil {
+	if err := fullGraph.AddOffer(threeEurOffer).Apply(5); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 
 	sellEurOffer.Price.N = 9
 	sellEurOffer.Price.D = 10
-	if err := fullGraph.AddOffer(sellEurOffer).Apply(); err != nil {
+	if err := fullGraph.AddOffer(sellEurOffer).Apply(6); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 	otherSellEurOffer := sellEurOffer
 	otherSellEurOffer.OfferId = 17
 	otherSellEurOffer.Price.N *= 2
-	if err := fullGraph.AddOffer(otherSellEurOffer).Apply(); err != nil {
+	if err := fullGraph.AddOffer(otherSellEurOffer).Apply(7); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 
@@ -581,40 +586,46 @@ func TestOrderbookGetResource(t *testing.T) {
 	}
 
 	for _, testCase := range []struct {
-		name     string
-		graph    *orderbook.OrderBookGraph
-		limit    int
-		expected OrderBookResponse
+		name       string
+		graph      *orderbook.OrderBookGraph
+		limit      int
+		expected   OrderBookResponse
+		lastLedger string
 	}{
 		{
 			"empty orderbook",
 			orderbook.NewOrderBookGraph(),
 			10,
 			empty,
+			"0",
 		},
 		{
 			"orderbook with asks but no bids",
 			asksButNoBidsGraph,
 			10,
 			asksButNoBidsResponse,
+			"1",
 		},
 		{
 			"orderbook with bids but no asks",
 			bidsButNoAsksGraph,
 			10,
 			bidsButNoAsksResponse,
+			"2",
 		},
 		{
 			"full orderbook",
 			fullGraph,
 			10,
 			fullResponse,
+			"7",
 		},
 		{
 			"limit request",
 			fullGraph,
 			1,
 			limitResponse,
+			"7",
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -631,13 +642,23 @@ func TestOrderbookGetResource(t *testing.T) {
 					"limit":               strconv.Itoa(testCase.limit),
 				},
 				map[string]string{},
+				nil,
 			)
-			response, err := handler.GetResource(r)
+			w := httptest.NewRecorder()
+			response, err := handler.GetResource(r, w)
 			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}
 			if !response.Equals(testCase.expected) {
 				t.Fatalf("expected %v but got %v", testCase.expected, response)
+			}
+			lastLedger := w.Header().Get(LastLedgerHeaderName)
+			if lastLedger != testCase.lastLedger {
+				t.Fatalf(
+					"expected last ledger to be %v but got %v",
+					testCase.lastLedger,
+					lastLedger,
+				)
 			}
 		})
 	}

--- a/services/horizon/internal/actions/orderbook_test.go
+++ b/services/horizon/internal/actions/orderbook_test.go
@@ -453,7 +453,7 @@ func TestOrderbookGetResourceValidation(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			r := makeRequest(t, testCase.queryParams, map[string]string{}, nil)
 			w := httptest.NewRecorder()
-			_, err := handler.GetResource(r, w)
+			_, err := handler.GetResource(w, r)
 			if err == nil || err.Error() != invalidOrderBook.Error() {
 				t.Fatalf("expected error %v but got %v", invalidOrderBook, err)
 			}
@@ -645,7 +645,7 @@ func TestOrderbookGetResource(t *testing.T) {
 				nil,
 			)
 			w := httptest.NewRecorder()
-			response, err := handler.GetResource(r, w)
+			response, err := handler.GetResource(w, r)
 			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}

--- a/services/horizon/internal/actions/session.go
+++ b/services/horizon/internal/actions/session.go
@@ -1,0 +1,19 @@
+package actions
+
+import (
+	"net/http"
+
+	horizonContext "github.com/stellar/go/services/horizon/internal/context"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/support/errors"
+)
+
+func historyQFromRequest(request *http.Request) (*history.Q, error) {
+	ctx := request.Context()
+	session, ok := ctx.Value(&horizonContext.SessionContextKey).(*db.Session)
+	if !ok {
+		return nil, errors.New("missing session in request context")
+	}
+	return &history.Q{session}, nil
+}

--- a/services/horizon/internal/actions_path_test.go
+++ b/services/horizon/internal/actions_path_test.go
@@ -179,7 +179,12 @@ func TestPathActionsStateInvalid(t *testing.T) {
 	rh.Assert.Equal("", w.Header().Get(actions.LastLedgerHeaderName))
 }
 
-func loadOffers(tt *test.T, orderBookGraph *orderbook.OrderBookGraph, fromAddress string) {
+func loadOffers(
+	tt *test.T,
+	orderBookGraph *orderbook.OrderBookGraph,
+	fromAddress string,
+	ledger uint32,
+) {
 	coreQ := &core.Q{tt.CoreSession()}
 	offers := []core.Offer{}
 	pageQuery := db2.PageQuery{
@@ -199,7 +204,7 @@ func loadOffers(tt *test.T, orderBookGraph *orderbook.OrderBookGraph, fromAddres
 			Price:    xdr.Price{N: xdr.Int32(offer.Price * 100), D: 100},
 		})
 	}
-	tt.Assert.NoError(orderBookGraph.Apply(1))
+	tt.Assert.NoError(orderBookGraph.Apply(ledger))
 }
 
 func TestPathActionsInMemoryFinder(t *testing.T) {
@@ -222,8 +227,8 @@ func TestPathActionsInMemoryFinder(t *testing.T) {
 		len(sourceAssets),
 	)
 
-	loadOffers(tt, orderBookGraph, "GA2NC4ZOXMXLVQAQQ5IQKJX47M3PKBQV2N5UV5Z4OXLQJ3CKMBA2O2YL")
-	loadOffers(tt, orderBookGraph, "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN")
+	loadOffers(tt, orderBookGraph, "GA2NC4ZOXMXLVQAQQ5IQKJX47M3PKBQV2N5UV5Z4OXLQJ3CKMBA2O2YL", 1)
+	loadOffers(tt, orderBookGraph, "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN", 2)
 
 	var withSourceAccount = make(url.Values)
 	withSourceAccount.Add(
@@ -254,7 +259,7 @@ func TestPathActionsInMemoryFinder(t *testing.T) {
 		tt.Assert.Equal(http.StatusOK, w.Code)
 		inMemorySourceAccountResponse := []horizon.Path{}
 		tt.UnmarshalPage(w.Body, &inMemorySourceAccountResponse)
-		tt.Assert.Equal("1", w.Header().Get(actions.LastLedgerHeaderName))
+		tt.Assert.Equal("2", w.Header().Get(actions.LastLedgerHeaderName))
 
 		w = dbPathsClient.Get(uri + "?" + withSourceAccount.Encode())
 		tt.Assert.Equal(http.StatusOK, w.Code)
@@ -269,7 +274,7 @@ func TestPathActionsInMemoryFinder(t *testing.T) {
 		tt.Assert.Equal(http.StatusOK, w.Code)
 		inMemorySourceAssetsResponse := []horizon.Path{}
 		tt.UnmarshalPage(w.Body, &inMemorySourceAssetsResponse)
-		tt.Assert.Equal("1", w.Header().Get(actions.LastLedgerHeaderName))
+		tt.Assert.Equal("2", w.Header().Get(actions.LastLedgerHeaderName))
 
 		w = dbPathsClient.Get(uri + "?" + withSourceAccount.Encode())
 		tt.Assert.Equal(http.StatusOK, w.Code)
@@ -297,8 +302,8 @@ func TestPathActionsEmptySourceAcount(t *testing.T) {
 		3,
 	)
 
-	loadOffers(tt, orderBookGraph, "GA2NC4ZOXMXLVQAQQ5IQKJX47M3PKBQV2N5UV5Z4OXLQJ3CKMBA2O2YL")
-	loadOffers(tt, orderBookGraph, "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN")
+	loadOffers(tt, orderBookGraph, "GA2NC4ZOXMXLVQAQQ5IQKJX47M3PKBQV2N5UV5Z4OXLQJ3CKMBA2O2YL", 1)
+	loadOffers(tt, orderBookGraph, "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN", 2)
 
 	var q = make(url.Values)
 
@@ -513,8 +518,8 @@ func TestPathActionsStrictSend(t *testing.T) {
 		len(destinationAssets),
 	)
 
-	loadOffers(tt, orderBookGraph, "GA2NC4ZOXMXLVQAQQ5IQKJX47M3PKBQV2N5UV5Z4OXLQJ3CKMBA2O2YL")
-	loadOffers(tt, orderBookGraph, "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN")
+	loadOffers(tt, orderBookGraph, "GA2NC4ZOXMXLVQAQQ5IQKJX47M3PKBQV2N5UV5Z4OXLQJ3CKMBA2O2YL", 1)
+	loadOffers(tt, orderBookGraph, "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN", 2)
 
 	var q = make(url.Values)
 
@@ -535,7 +540,7 @@ func TestPathActionsStrictSend(t *testing.T) {
 	accountResponse := []horizon.Path{}
 	tt.UnmarshalPage(w.Body, &accountResponse)
 	assertions.Len(accountResponse, 12)
-	assertions.Equal("1", w.Header().Get(actions.LastLedgerHeaderName))
+	assertions.Equal("2", w.Header().Get(actions.LastLedgerHeaderName))
 
 	for i, path := range accountResponse {
 		assertions.Equal(path.SourceAssetCode, "USD")
@@ -571,7 +576,7 @@ func TestPathActionsStrictSend(t *testing.T) {
 	tt.UnmarshalPage(w.Body, &assetListResponse)
 	assertions.Len(assetListResponse, 12)
 	tt.Assert.Equal(accountResponse, assetListResponse)
-	assertions.Equal("1", w.Header().Get(actions.LastLedgerHeaderName))
+	assertions.Equal("2", w.Header().Get(actions.LastLedgerHeaderName))
 }
 
 func assetsToURLParam(xdrAssets []xdr.Asset) string {

--- a/services/horizon/internal/actions_path_test.go
+++ b/services/horizon/internal/actions_path_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/stellar/go/exp/orderbook"
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/actions"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
-	"github.com/stellar/go/services/horizon/internal/paths"
 	horizonProblem "github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/services/horizon/internal/simplepath"
 	"github.com/stellar/go/services/horizon/internal/test"
@@ -22,16 +22,48 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-func pathFindingClient(tt *test.T, pathFinder paths.Finder, maxAssetsParamLength int) test.RequestHelper {
+func inMemoryPathFindingClient(
+	tt *test.T,
+	graph *orderbook.OrderBookGraph,
+	maxAssetsParamLength int,
+) test.RequestHelper {
 	router := chi.NewRouter()
 	findPaths := FindPathsHandler{
-		pathFinder:           pathFinder,
+		pathFinder:           simplepath.NewInMemoryFinder(graph),
 		maxAssetsParamLength: maxAssetsParamLength,
+		setLastLedgerHeader:  true,
 		coreQ:                &core.Q{tt.CoreSession()},
 	}
 	findFixedPaths := FindFixedPathsHandler{
-		pathFinder:           pathFinder,
+		pathFinder:           simplepath.NewInMemoryFinder(graph),
 		maxAssetsParamLength: maxAssetsParamLength,
+		setLastLedgerHeader:  true,
+		coreQ:                &core.Q{tt.CoreSession()},
+	}
+
+	installPathFindingRoutes(findPaths, findFixedPaths, router, false)
+	return test.NewRequestHelper(router)
+}
+
+func dbPathFindingClient(
+	tt *test.T,
+	maxAssetsParamLength int,
+) test.RequestHelper {
+	router := chi.NewRouter()
+	findPaths := FindPathsHandler{
+		pathFinder: &simplepath.Finder{
+			Q: &core.Q{tt.CoreSession()},
+		},
+		maxAssetsParamLength: maxAssetsParamLength,
+		setLastLedgerHeader:  false,
+		coreQ:                &core.Q{tt.CoreSession()},
+	}
+	findFixedPaths := FindFixedPathsHandler{
+		pathFinder: &simplepath.Finder{
+			Q: &core.Q{tt.CoreSession()},
+		},
+		maxAssetsParamLength: maxAssetsParamLength,
+		setLastLedgerHeader:  false,
 		coreQ:                &core.Q{tt.CoreSession()},
 	}
 
@@ -43,11 +75,8 @@ func TestPathActions_Index(t *testing.T) {
 	tt := test.Start(t).Scenario("paths")
 	assertions := &Assertions{tt.Assert}
 	defer tt.Finish()
-	rh := pathFindingClient(
+	rh := dbPathFindingClient(
 		tt,
-		&simplepath.Finder{
-			Q: &core.Q{tt.CoreSession()},
-		},
 		3,
 	)
 
@@ -78,6 +107,7 @@ func TestPathActions_Index(t *testing.T) {
 		w = rh.Get(uri + "?" + q.Encode())
 		assertions.Equal(200, w.Code)
 		assertions.PageOf(3, w.Body)
+		assertions.Equal("", w.Header().Get(actions.LastLedgerHeaderName))
 	}
 }
 
@@ -85,9 +115,9 @@ func TestPathActionsStillIngesting(t *testing.T) {
 	tt := test.Start(t).Scenario("paths")
 	defer tt.Finish()
 	assertions := &Assertions{tt.Assert}
-	rh := pathFindingClient(
+	rh := inMemoryPathFindingClient(
 		tt,
-		simplepath.NewInMemoryFinder(orderbook.NewOrderBookGraph()),
+		orderbook.NewOrderBookGraph(),
 		3,
 	)
 
@@ -113,6 +143,7 @@ func TestPathActionsStillIngesting(t *testing.T) {
 		w := rh.Get(uri + "?" + q.Encode())
 		assertions.Equal(horizonProblem.StillIngesting.Status, w.Code)
 		assertions.Problem(w.Body, horizonProblem.StillIngesting)
+		assertions.Equal("", w.Header().Get(actions.LastLedgerHeaderName))
 	}
 }
 
@@ -134,6 +165,7 @@ func TestPathActionsStateInvalid(t *testing.T) {
 	w := rh.Get("/paths")
 	// Still ingesting
 	rh.Assert.Equal(503, w.Code)
+	rh.Assert.Equal("", w.Header().Get(actions.LastLedgerHeaderName))
 
 	err := rh.App.historyQ.UpdateLastLedgerExpIngest(10)
 	rh.Assert.NoError(err)
@@ -144,6 +176,7 @@ func TestPathActionsStateInvalid(t *testing.T) {
 	w = rh.Get("/paths")
 	// State invalid
 	rh.Assert.Equal(500, w.Code)
+	rh.Assert.Equal("", w.Header().Get(actions.LastLedgerHeaderName))
 }
 
 func loadOffers(tt *test.T, orderBookGraph *orderbook.OrderBookGraph, fromAddress string) {
@@ -166,7 +199,7 @@ func loadOffers(tt *test.T, orderBookGraph *orderbook.OrderBookGraph, fromAddres
 			Price:    xdr.Price{N: xdr.Int32(offer.Price * 100), D: 100},
 		})
 	}
-	tt.Assert.NoError(orderBookGraph.Apply())
+	tt.Assert.NoError(orderBookGraph.Apply(1))
 }
 
 func TestPathActionsInMemoryFinder(t *testing.T) {
@@ -179,16 +212,13 @@ func TestPathActionsInMemoryFinder(t *testing.T) {
 	sourceAssets, _, err := coreQ.AssetsForAddress(sourceAccount)
 	tt.Assert.NoError(err)
 
-	inMemoryPathsClient := pathFindingClient(
+	inMemoryPathsClient := inMemoryPathFindingClient(
 		tt,
-		simplepath.NewInMemoryFinder(orderBookGraph),
+		orderBookGraph,
 		len(sourceAssets),
 	)
-	dbPathsClient := pathFindingClient(
+	dbPathsClient := dbPathFindingClient(
 		tt,
-		&simplepath.Finder{
-			Q: &core.Q{tt.CoreSession()},
-		},
 		len(sourceAssets),
 	)
 
@@ -224,11 +254,13 @@ func TestPathActionsInMemoryFinder(t *testing.T) {
 		tt.Assert.Equal(http.StatusOK, w.Code)
 		inMemorySourceAccountResponse := []horizon.Path{}
 		tt.UnmarshalPage(w.Body, &inMemorySourceAccountResponse)
+		tt.Assert.Equal("1", w.Header().Get(actions.LastLedgerHeaderName))
 
 		w = dbPathsClient.Get(uri + "?" + withSourceAccount.Encode())
 		tt.Assert.Equal(http.StatusOK, w.Code)
 		dbSourceAccountResponse := []horizon.Path{}
 		tt.UnmarshalPage(w.Body, &dbSourceAccountResponse)
+		tt.Assert.Equal("", w.Header().Get(actions.LastLedgerHeaderName))
 
 		tt.Assert.True(len(inMemorySourceAccountResponse) > 0)
 		tt.Assert.Equal(inMemorySourceAccountResponse, dbSourceAccountResponse)
@@ -237,11 +269,13 @@ func TestPathActionsInMemoryFinder(t *testing.T) {
 		tt.Assert.Equal(http.StatusOK, w.Code)
 		inMemorySourceAssetsResponse := []horizon.Path{}
 		tt.UnmarshalPage(w.Body, &inMemorySourceAssetsResponse)
+		tt.Assert.Equal("1", w.Header().Get(actions.LastLedgerHeaderName))
 
 		w = dbPathsClient.Get(uri + "?" + withSourceAccount.Encode())
 		tt.Assert.Equal(http.StatusOK, w.Code)
 		dbSourceAssetsResponse := []horizon.Path{}
 		tt.UnmarshalPage(w.Body, &dbSourceAssetsResponse)
+		tt.Assert.Equal("", w.Header().Get(actions.LastLedgerHeaderName))
 
 		tt.Assert.Equal(inMemorySourceAssetsResponse, dbSourceAssetsResponse)
 		tt.Assert.Equal(inMemorySourceAssetsResponse, inMemorySourceAccountResponse)
@@ -253,16 +287,13 @@ func TestPathActionsEmptySourceAcount(t *testing.T) {
 	defer tt.Finish()
 	orderBookGraph := orderbook.NewOrderBookGraph()
 	assertions := &Assertions{tt.Assert}
-	inMemoryPathsClient := pathFindingClient(
+	inMemoryPathsClient := inMemoryPathFindingClient(
 		tt,
-		simplepath.NewInMemoryFinder(orderBookGraph),
+		orderBookGraph,
 		3,
 	)
-	dbPathsClient := pathFindingClient(
+	dbPathsClient := dbPathFindingClient(
 		tt,
-		&simplepath.Finder{
-			Q: &core.Q{tt.CoreSession()},
-		},
 		3,
 	)
 
@@ -294,12 +325,14 @@ func TestPathActionsEmptySourceAcount(t *testing.T) {
 		inMemoryResponse := []horizon.Path{}
 		tt.UnmarshalPage(w.Body, &inMemoryResponse)
 		assertions.Empty(inMemoryResponse)
+		tt.Assert.Equal("", w.Header().Get(actions.LastLedgerHeaderName))
 
 		w = dbPathsClient.Get(uri + "?" + q.Encode())
 		assertions.Equal(http.StatusOK, w.Code)
 		dbResponse := []horizon.Path{}
 		tt.UnmarshalPage(w.Body, &dbResponse)
 		assertions.Empty(dbResponse)
+		tt.Assert.Equal("", w.Header().Get(actions.LastLedgerHeaderName))
 	}
 }
 
@@ -308,9 +341,9 @@ func TestPathActionsSourceAssetsValidation(t *testing.T) {
 	defer tt.Finish()
 	assertions := &Assertions{tt.Assert}
 	orderBookGraph := orderbook.NewOrderBookGraph()
-	rh := pathFindingClient(
+	rh := inMemoryPathFindingClient(
 		tt,
-		simplepath.NewInMemoryFinder(orderBookGraph),
+		orderBookGraph,
 		3,
 	)
 
@@ -376,6 +409,7 @@ func TestPathActionsSourceAssetsValidation(t *testing.T) {
 			w := rh.Get("/paths/strict-receive?" + testCase.q.Encode())
 			assertions.Equal(testCase.expectedProblem.Status, w.Code)
 			assertions.Problem(w.Body, testCase.expectedProblem)
+			assertions.Equal("", w.Header().Get(actions.LastLedgerHeaderName))
 		})
 	}
 }
@@ -385,9 +419,9 @@ func TestPathActionsDestinationAssetsValidation(t *testing.T) {
 	defer tt.Finish()
 	assertions := &Assertions{tt.Assert}
 	orderBookGraph := orderbook.NewOrderBookGraph()
-	rh := pathFindingClient(
+	rh := inMemoryPathFindingClient(
 		tt,
-		simplepath.NewInMemoryFinder(orderBookGraph),
+		orderBookGraph,
 		3,
 	)
 
@@ -457,6 +491,7 @@ func TestPathActionsDestinationAssetsValidation(t *testing.T) {
 			w := rh.Get("/paths/strict-send?" + testCase.q.Encode())
 			assertions.Equal(testCase.expectedProblem.Status, w.Code)
 			assertions.Problem(w.Body, testCase.expectedProblem)
+			assertions.Equal("", w.Header().Get(actions.LastLedgerHeaderName))
 		})
 	}
 }
@@ -472,9 +507,9 @@ func TestPathActionsStrictSend(t *testing.T) {
 	destinationAssets, _, err := coreQ.AssetsForAddress(destinationAccount)
 	tt.Assert.NoError(err)
 
-	rh := pathFindingClient(
+	rh := inMemoryPathFindingClient(
 		tt,
-		simplepath.NewInMemoryFinder(orderBookGraph),
+		orderBookGraph,
 		len(destinationAssets),
 	)
 
@@ -500,6 +535,7 @@ func TestPathActionsStrictSend(t *testing.T) {
 	accountResponse := []horizon.Path{}
 	tt.UnmarshalPage(w.Body, &accountResponse)
 	assertions.Len(accountResponse, 12)
+	assertions.Equal("1", w.Header().Get(actions.LastLedgerHeaderName))
 
 	for i, path := range accountResponse {
 		assertions.Equal(path.SourceAssetCode, "USD")
@@ -535,6 +571,7 @@ func TestPathActionsStrictSend(t *testing.T) {
 	tt.UnmarshalPage(w.Body, &assetListResponse)
 	assertions.Len(assetListResponse, 12)
 	tt.Assert.Equal(accountResponse, assetListResponse)
+	assertions.Equal("1", w.Header().Get(actions.LastLedgerHeaderName))
 }
 
 func assetsToURLParam(xdrAssets []xdr.Asset) string {

--- a/services/horizon/internal/context/context_key.go
+++ b/services/horizon/internal/context/context_key.go
@@ -5,3 +5,4 @@ type CtxKey string
 var AppContextKey = CtxKey("app")
 var RequestContextKey = CtxKey("request")
 var ClientContextKey = CtxKey("client")
+var SessionContextKey = CtxKey("session")

--- a/services/horizon/internal/expingest/load_orderbook_graph_test.go
+++ b/services/horizon/internal/expingest/load_orderbook_graph_test.go
@@ -64,7 +64,7 @@ func TestLoadOrderBookGraphFromEmptyDB(t *testing.T) {
 	q := &history.Q{tt.HorizonSession()}
 	graph := orderbook.NewOrderBookGraph()
 
-	err := loadOrderBookGraphFromDB(q, graph)
+	err := loadOrderBookGraphFromDB(q, graph, 1)
 	tt.Assert.NoError(err)
 	tt.Assert.True(graph.IsEmpty())
 }
@@ -82,7 +82,7 @@ func TestLoadOrderBookGraph(t *testing.T) {
 	_, err = q.InsertOffer(twoEurOffer, 123)
 	tt.Assert.NoError(err)
 
-	err = loadOrderBookGraphFromDB(q, graph)
+	err = loadOrderBookGraphFromDB(q, graph, 1)
 	tt.Assert.NoError(err)
 	tt.Assert.False(graph.IsEmpty())
 

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -278,7 +278,7 @@ func (s *System) Run() {
 			log.WithField("last_ledger", lastIngestedLedger).
 				Info("Resuming ingestion system from last processed ledger...")
 
-			err = loadOrderBookGraphFromDB(s.historyQ, s.graph)
+			err = loadOrderBookGraphFromDB(s.historyQ, s.graph, lastIngestedLedger)
 			if err != nil {
 				return errors.Wrap(err, "Error loading order book graph from db")
 			}
@@ -289,7 +289,11 @@ func (s *System) Run() {
 	})
 }
 
-func loadOrderBookGraphFromDB(historyQ dbQ, graph *orderbook.OrderBookGraph) error {
+func loadOrderBookGraphFromDB(
+	historyQ dbQ,
+	graph *orderbook.OrderBookGraph,
+	lastIngestedLedger uint32,
+) error {
 	defer graph.Discard()
 
 	log.Info("Loading offers from a database into memory store...")
@@ -316,7 +320,7 @@ func loadOrderBookGraphFromDB(historyQ dbQ, graph *orderbook.OrderBookGraph) err
 		})
 	}
 
-	err = graph.Apply()
+	err = graph.Apply(lastIngestedLedger)
 	if err == nil {
 		log.WithField(
 			"duration",

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -250,7 +250,7 @@ func postProcessingHook(
 		}
 	}
 
-	err = graph.Apply()
+	err = graph.Apply(ledgerSeq)
 	if err != nil {
 		return errors.Wrap(err, "Error applying order book changes")
 	}

--- a/services/horizon/internal/expingest/processors/orderbook_processor_test.go
+++ b/services/horizon/internal/expingest/processors/orderbook_processor_test.go
@@ -23,7 +23,7 @@ func TestProcessOrderBookState(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 	writer.AssertExpectations(t)
-	if err := graph.Apply(); err != nil {
+	if err := graph.Apply(1); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 
@@ -86,7 +86,7 @@ func TestProcessOrderBookState(t *testing.T) {
 
 	writer.AssertExpectations(t)
 	reader.AssertExpectations(t)
-	if err := graph.Apply(); err != nil {
+	if err := graph.Apply(2); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 
@@ -122,7 +122,7 @@ func TestProcessOrderBookLedger(t *testing.T) {
 	}
 	writer.AssertExpectations(t)
 	reader.AssertExpectations(t)
-	if err := graph.Apply(); err != nil {
+	if err := graph.Apply(1); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 
@@ -323,7 +323,7 @@ func TestProcessOrderBookLedger(t *testing.T) {
 
 	writer.AssertExpectations(t)
 	reader.AssertExpectations(t)
-	if err := graph.Apply(); err != nil {
+	if err := graph.Apply(2); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 

--- a/services/horizon/internal/handler.go
+++ b/services/horizon/internal/handler.go
@@ -342,7 +342,10 @@ func validateCursorWithinHistory(pq db2.PageQuery) error {
 const singleObjectStreamLimit = 10
 
 type streamableObjectAction interface {
-	GetResource(r *http.Request) (actions.StreamableObjectResponse, error)
+	GetResource(
+		r *http.Request,
+		w actions.HeaderWriter,
+	) (actions.StreamableObjectResponse, error)
 }
 
 type streamableObjectActionHandler struct {
@@ -350,10 +353,13 @@ type streamableObjectActionHandler struct {
 	streamHandler sse.StreamHandler
 }
 
-func (handler streamableObjectActionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (handler streamableObjectActionHandler) ServeHTTP(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
 	switch render.Negotiate(r) {
 	case render.MimeHal, render.MimeJSON:
-		response, err := handler.action.GetResource(r)
+		response, err := handler.action.GetResource(r, w)
 		if err != nil {
 			problem.Render(r.Context(), w, err)
 			return
@@ -373,7 +379,10 @@ func (handler streamableObjectActionHandler) ServeHTTP(w http.ResponseWriter, r 
 	problem.Render(r.Context(), w, hProblem.NotAcceptable)
 }
 
-func (handler streamableObjectActionHandler) renderStream(w http.ResponseWriter, r *http.Request) {
+func (handler streamableObjectActionHandler) renderStream(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
 	var lastResponse actions.StreamableObjectResponse
 
 	handler.streamHandler.ServeStream(
@@ -381,7 +390,7 @@ func (handler streamableObjectActionHandler) renderStream(w http.ResponseWriter,
 		r,
 		singleObjectStreamLimit,
 		func() ([]sse.Event, error) {
-			response, err := handler.action.GetResource(r)
+			response, err := handler.action.GetResource(r, w)
 			if err != nil {
 				return nil, err
 			}
@@ -396,7 +405,7 @@ func (handler streamableObjectActionHandler) renderStream(w http.ResponseWriter,
 }
 
 type pageAction interface {
-	GetResourcePage(r *http.Request) ([]hal.Pageable, error)
+	GetResourcePage(r *http.Request, w actions.HeaderWriter) ([]hal.Pageable, error)
 }
 
 type pageActionHandler struct {
@@ -421,7 +430,7 @@ func streamablePageHandler(
 }
 
 func (handler pageActionHandler) renderPage(w http.ResponseWriter, r *http.Request) {
-	records, err := handler.action.GetResourcePage(r)
+	records, err := handler.action.GetResourcePage(r, w)
 	if err != nil {
 		problem.Render(r.Context(), w, err)
 		return
@@ -453,7 +462,7 @@ func (handler pageActionHandler) renderStream(w http.ResponseWriter, r *http.Req
 		r,
 		int(pq.Limit),
 		func() ([]sse.Event, error) {
-			records, err := handler.action.GetResourcePage(r)
+			records, err := handler.action.GetResourcePage(r, w)
 			if err != nil {
 				return nil, err
 			}

--- a/services/horizon/internal/handler.go
+++ b/services/horizon/internal/handler.go
@@ -343,8 +343,8 @@ const singleObjectStreamLimit = 10
 
 type streamableObjectAction interface {
 	GetResource(
-		r *http.Request,
 		w actions.HeaderWriter,
+		r *http.Request,
 	) (actions.StreamableObjectResponse, error)
 }
 
@@ -359,7 +359,7 @@ func (handler streamableObjectActionHandler) ServeHTTP(
 ) {
 	switch render.Negotiate(r) {
 	case render.MimeHal, render.MimeJSON:
-		response, err := handler.action.GetResource(r, w)
+		response, err := handler.action.GetResource(w, r)
 		if err != nil {
 			problem.Render(r.Context(), w, err)
 			return
@@ -390,7 +390,7 @@ func (handler streamableObjectActionHandler) renderStream(
 		r,
 		singleObjectStreamLimit,
 		func() ([]sse.Event, error) {
-			response, err := handler.action.GetResource(r, w)
+			response, err := handler.action.GetResource(w, r)
 			if err != nil {
 				return nil, err
 			}
@@ -405,7 +405,7 @@ func (handler streamableObjectActionHandler) renderStream(
 }
 
 type pageAction interface {
-	GetResourcePage(r *http.Request, w actions.HeaderWriter) ([]hal.Pageable, error)
+	GetResourcePage(w actions.HeaderWriter, r *http.Request) ([]hal.Pageable, error)
 }
 
 type pageActionHandler struct {
@@ -430,7 +430,7 @@ func streamablePageHandler(
 }
 
 func (handler pageActionHandler) renderPage(w http.ResponseWriter, r *http.Request) {
-	records, err := handler.action.GetResourcePage(r, w)
+	records, err := handler.action.GetResourcePage(w, r)
 	if err != nil {
 		problem.Render(r.Context(), w, err)
 		return
@@ -462,7 +462,7 @@ func (handler pageActionHandler) renderStream(w http.ResponseWriter, r *http.Req
 		r,
 		int(pq.Limit),
 		func() ([]sse.Event, error) {
-			records, err := handler.action.GetResourcePage(r, w)
+			records, err := handler.action.GetResourcePage(w, r)
 			if err != nil {
 				return nil, err
 			}

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -1,10 +1,17 @@
 package horizon
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"testing"
 
+	"github.com/stellar/go/services/horizon/internal/actions"
+	horizonContext "github.com/stellar/go/services/horizon/internal/context"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/support/db"
 	"github.com/stellar/throttled"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -141,4 +148,64 @@ func TestRateLimit_Redis(t *testing.T) {
 
 	w = rh.Get("/", test.RequestHelperRemoteAddr("127.0.0.2"))
 	assert.Equal(t, 200, w.Code)
+}
+
+func TestRequiresExperimentalIngestion(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &history.Q{tt.HorizonSession()}
+	app := &App{
+		historyQ: q,
+	}
+
+	request, err := http.NewRequest("GET", "http://localhost", nil)
+	if err != nil {
+		tt.Assert.NoError(err)
+	}
+
+	if q.GetTx() != nil {
+		t.Fatal("unexpected transaction in history.Q")
+	}
+
+	endpoint := func(w http.ResponseWriter, r *http.Request) {
+		session := r.Context().Value(&horizonContext.SessionContextKey).(*db.Session)
+		if session.GetTx() == nil {
+			t.Fatal("expected transaction to be in session")
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+	appMiddleWare := appContextMiddleware(app)
+	handler := appMiddleWare(requiresExperimentalIngestion(http.HandlerFunc(endpoint)))
+
+	// requiresExperimentalIngestion responds with 404 if experimental ingestion is not enabled
+	app.config.EnableExperimentalIngestion = false
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, request)
+	tt.Assert.Equal(http.StatusNotFound, w.Code)
+
+	app.config.EnableExperimentalIngestion = true
+	// requiresExperimentalIngestion responds with hProblem.StillIngesting
+	// if the last ingested ledger is 0
+	tt.Assert.NoError(q.UpdateLastLedgerExpIngest(0))
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, request)
+	tt.Assert.Equal(hProblem.StillIngesting.Status, w.Code)
+
+	app.config.EnableExperimentalIngestion = true
+	tt.Assert.NoError(q.UpdateLastLedgerExpIngest(1))
+	tt.Assert.NoError(q.UpdateExpStateInvalid(true))
+	// requiresExperimentalIngestion responds with 500 if q.GetExpStateInvalid returns true
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, request)
+	tt.Assert.Equal(http.StatusInternalServerError, w.Code)
+
+	app.config.EnableExperimentalIngestion = true
+	tt.Assert.NoError(q.UpdateLastLedgerExpIngest(3))
+	tt.Assert.NoError(q.UpdateExpStateInvalid(false))
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, request)
+	tt.Assert.Equal(http.StatusOK, w.Code)
+	tt.Assert.Equal(w.Header().Get(actions.LastLedgerHeaderName), "3")
 }

--- a/services/horizon/internal/paths/main.go
+++ b/services/horizon/internal/paths/main.go
@@ -28,7 +28,7 @@ type Path struct {
 // Finder finds paths.
 type Finder interface {
 	// Returns path for a Query of a maximum length `maxLength`
-	Find(q Query, maxLength uint) ([]Path, error)
+	Find(q Query, maxLength uint) ([]Path, uint32, error)
 	// FindFixedPaths return a list of payment paths each of which
 	// start by spending `amountToSpend` of `sourceAsset` and end
 	// with delivering a postive amount of `destinationAsset`
@@ -37,5 +37,5 @@ type Finder interface {
 		amountToSpend xdr.Int64,
 		destinationAssets []xdr.Asset,
 		maxLength uint,
-	) ([]Path, error)
+	) ([]Path, uint32, error)
 }

--- a/services/horizon/internal/paths/main.go
+++ b/services/horizon/internal/paths/main.go
@@ -27,11 +27,14 @@ type Path struct {
 
 // Finder finds paths.
 type Finder interface {
-	// Returns path for a Query of a maximum length `maxLength`
+	// Return a list of payment paths and the most recent ledger
+	// for a Query of a maximum length `maxLength`. The payment paths
+	// are accurate and consistent with the returned ledger sequence number
 	Find(q Query, maxLength uint) ([]Path, uint32, error)
-	// FindFixedPaths return a list of payment paths each of which
-	// start by spending `amountToSpend` of `sourceAsset` and end
-	// with delivering a postive amount of `destinationAsset`
+	// FindFixedPaths return a list of payment paths the most recent ledger
+	// Each of the payment paths start by spending `amountToSpend` of `sourceAsset` and end
+	// with delivering a postive amount of `destinationAsset`.
+	// The payment paths are accurate and consistent with the returned ledger sequence number
 	FindFixedPaths(
 		sourceAsset xdr.Asset,
 		amountToSpend xdr.Int64,

--- a/services/horizon/internal/simplepath/finder.go
+++ b/services/horizon/internal/simplepath/finder.go
@@ -21,7 +21,7 @@ type Finder struct {
 var _ paths.Finder = &Finder{}
 
 // Find performs a path find with the provided query.
-func (f *Finder) Find(q paths.Query, maxLength uint) (result []paths.Path, err error) {
+func (f *Finder) Find(q paths.Query, maxLength uint) (result []paths.Path, lastLedger uint32, err error) {
 	log.WithField("source_assets", q.SourceAssets).
 		WithField("destination_asset", q.DestinationAsset).
 		WithField("destination_amount", q.DestinationAmount).
@@ -65,6 +65,6 @@ func (f *Finder) FindFixedPaths(
 	amountToSpend xdr.Int64,
 	destinationAssets []xdr.Asset,
 	maxLength uint,
-) ([]paths.Path, error) {
-	return nil, errors.New("Not implemented")
+) ([]paths.Path, uint32, error) {
+	return nil, 0, errors.New("Not implemented")
 }

--- a/services/horizon/internal/simplepath/finder_test.go
+++ b/services/horizon/internal/simplepath/finder_test.go
@@ -45,7 +45,7 @@ func TestFinder(t *testing.T) {
 		SourceAssets:      []xdr.Asset{usd},
 	}
 
-	p, err := finder.Find(query, MaxPathLength)
+	p, _, err := finder.Find(query, MaxPathLength)
 	if tt.Assert.NoError(err) {
 		tt.Assert.Len(p, 3)
 
@@ -84,7 +84,7 @@ func TestFinder(t *testing.T) {
 	}
 
 	query.DestinationAmount = xdr.Int64(200000001)
-	p, err = finder.Find(query, MaxPathLength)
+	p, _, err = finder.Find(query, MaxPathLength)
 	if tt.Assert.NoError(err) {
 		tt.Assert.Len(p, 2)
 
@@ -105,7 +105,7 @@ func TestFinder(t *testing.T) {
 	}
 
 	query.DestinationAmount = xdr.Int64(500000001)
-	p, err = finder.Find(query, MaxPathLength)
+	p, _, err = finder.Find(query, MaxPathLength)
 	if tt.Assert.NoError(err) {
 		tt.Assert.Len(p, 0)
 	}
@@ -117,7 +117,7 @@ func TestFinder(t *testing.T) {
 		DestinationAmount: xdr.Int64(1),
 		SourceAssets:      []xdr.Asset{usd, native},
 	}
-	p, err = finder.Find(query, MaxPathLength)
+	p, _, err = finder.Find(query, MaxPathLength)
 	if tt.Assert.NoError(err) {
 		tt.Assert.Len(p, 2)
 	}
@@ -152,7 +152,7 @@ func TestFinder(t *testing.T) {
 		DestinationAmount: xdr.Int64(100000000), // 10.0
 		SourceAssets:      []xdr.Asset{aaa},
 	}
-	p, err = finder.Find(query, MaxPathLength)
+	p, _, err = finder.Find(query, MaxPathLength)
 	if tt.Assert.NoError(err) {
 		if tt.Assert.Len(p, 1) {
 			tt.Assert.Equal(p[0].Source.String(), aaa.String())

--- a/services/horizon/internal/simplepath/inmemory.go
+++ b/services/horizon/internal/simplepath/inmemory.go
@@ -32,19 +32,19 @@ func NewInMemoryFinder(graph *orderbook.OrderBookGraph) InMemoryFinder {
 }
 
 // Find implements the path payments finder interface
-func (finder InMemoryFinder) Find(q paths.Query, maxLength uint) ([]paths.Path, error) {
+func (finder InMemoryFinder) Find(q paths.Query, maxLength uint) ([]paths.Path, uint32, error) {
 	if finder.graph.IsEmpty() {
-		return nil, ErrEmptyInMemoryOrderBook
+		return nil, 0, ErrEmptyInMemoryOrderBook
 	}
 
 	if maxLength == 0 {
 		maxLength = MaxInMemoryPathLength
 	}
 	if maxLength > MaxInMemoryPathLength {
-		return nil, errors.New("invalid value of maxLength")
+		return nil, 0, errors.New("invalid value of maxLength")
 	}
 
-	orderbookPaths, err := finder.graph.FindPaths(
+	orderbookPaths, lastLedger, err := finder.graph.FindPaths(
 		int(maxLength),
 		q.DestinationAsset,
 		q.DestinationAmount,
@@ -64,7 +64,7 @@ func (finder InMemoryFinder) Find(q paths.Query, maxLength uint) ([]paths.Path, 
 			DestinationAmount: path.DestinationAmount,
 		}
 	}
-	return results, err
+	return results, lastLedger, err
 }
 
 // FindFixedPaths returns a list of payment paths where the source and destination
@@ -77,19 +77,19 @@ func (finder InMemoryFinder) FindFixedPaths(
 	amountToSpend xdr.Int64,
 	destinationAssets []xdr.Asset,
 	maxLength uint,
-) ([]paths.Path, error) {
+) ([]paths.Path, uint32, error) {
 	if finder.graph.IsEmpty() {
-		return nil, ErrEmptyInMemoryOrderBook
+		return nil, 0, ErrEmptyInMemoryOrderBook
 	}
 
 	if maxLength == 0 {
 		maxLength = MaxInMemoryPathLength
 	}
 	if maxLength > MaxInMemoryPathLength {
-		return nil, errors.New("invalid value of maxLength")
+		return nil, 0, errors.New("invalid value of maxLength")
 	}
 
-	orderbookPaths, err := finder.graph.FindFixedPaths(
+	orderbookPaths, lastLedger, err := finder.graph.FindFixedPaths(
 		int(maxLength),
 		sourceAsset,
 		amountToSpend,
@@ -106,5 +106,5 @@ func (finder InMemoryFinder) FindFixedPaths(
 			DestinationAmount: path.DestinationAmount,
 		}
 	}
-	return results, err
+	return results, lastLedger, err
 }

--- a/services/horizon/internal/stream_handler_test.go
+++ b/services/horizon/internal/stream_handler_test.go
@@ -136,8 +136,8 @@ type testPageAction struct {
 }
 
 func (action *testPageAction) GetResourcePage(
-	r *http.Request,
 	w actions.HeaderWriter,
+	r *http.Request,
 ) ([]hal.Pageable, error) {
 	objects, ok := action.objects[action.ledgerSource.CurrentLedger()]
 	if !ok {
@@ -361,8 +361,8 @@ type testObjectAction struct {
 }
 
 func (action *testObjectAction) GetResource(
-	r *http.Request,
 	w actions.HeaderWriter,
+	r *http.Request,
 ) (actions.StreamableObjectResponse, error) {
 	ledger := action.ledgerSource.CurrentLedger()
 	object, ok := action.objects[ledger]

--- a/services/horizon/internal/stream_handler_test.go
+++ b/services/horizon/internal/stream_handler_test.go
@@ -135,7 +135,10 @@ type testPageAction struct {
 	ledgerSource ledger.Source
 }
 
-func (action *testPageAction) GetResourcePage(r *http.Request) ([]hal.Pageable, error) {
+func (action *testPageAction) GetResourcePage(
+	r *http.Request,
+	w actions.HeaderWriter,
+) ([]hal.Pageable, error) {
 	objects, ok := action.objects[action.ledgerSource.CurrentLedger()]
 	if !ok {
 		return nil, fmt.Errorf("unexpected ledger")
@@ -357,7 +360,10 @@ type testObjectAction struct {
 	ledgerSource ledger.Source
 }
 
-func (action *testObjectAction) GetResource(r *http.Request) (actions.StreamableObjectResponse, error) {
+func (action *testObjectAction) GetResource(
+	r *http.Request,
+	w actions.HeaderWriter,
+) (actions.StreamableObjectResponse, error) {
 	ledger := action.ledgerSource.CurrentLedger()
 	object, ok := action.objects[ledger]
 	if !ok {

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -199,9 +199,6 @@ func (w *web) mustInstallActions(
 			r.Get("/data/{key}", DataShowAction{}.Handle)
 		})
 	})
-	offersHandler := actions.GetAccountOffersHandler{
-		HistoryQ: w.historyQ,
-	}
 
 	streamHandler := sse.StreamHandler{
 		RateLimiter:  w.rateLimiter,
@@ -209,7 +206,7 @@ func (w *web) mustInstallActions(
 	}
 
 	installAccountOfferRoute(
-		offersHandler,
+		actions.GetAccountOffersHandler{},
 		streamHandler,
 		config.EnableExperimentalIngestion,
 		r,
@@ -248,7 +245,7 @@ func (w *web) mustInstallActions(
 			Method(
 				http.MethodGet,
 				"/",
-				restPageHandler(actions.GetOffersHandler{HistoryQ: w.historyQ}),
+				restPageHandler(actions.GetOffersHandler{}),
 			)
 		r.With(acceptOnlyJSON, requiresExperimentalIngestion).
 			Get("/{id}", getOfferResource)
@@ -276,6 +273,7 @@ func (w *web) mustInstallActions(
 	findPaths := FindPathsHandler{
 		staleThreshold:       config.StaleThreshold,
 		checkHistoryIsStale:  !config.EnableExperimentalIngestion,
+		setLastLedgerHeader:  config.EnableExperimentalIngestion,
 		maxPathLength:        config.MaxPathLength,
 		maxAssetsParamLength: maxAssetsForPathFinding,
 		pathFinder:           pathFinder,
@@ -283,6 +281,7 @@ func (w *web) mustInstallActions(
 	}
 	findFixedPaths := FindFixedPathsHandler{
 		maxPathLength:        config.MaxPathLength,
+		setLastLedgerHeader:  config.EnableExperimentalIngestion,
 		maxAssetsParamLength: maxAssetsForPathFinding,
 		pathFinder:           pathFinder,
 		coreQ:                w.coreQ,


### PR DESCRIPTION
Include a Latest-Ledger header with the sequence number of the last processed ledger by the
experimental ingestion system. Also, ensure the endpoint responses contains only data consistent
with the sequence number included in the header

<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Add `Latest-Ledger` header with the sequence number of the last processed ledger by the experimental ingestion system. The endpoints built using the experimental ingestion system will always respond with data which is consistent with the ledger in `Latest-Ledger`.

Fixes https://github.com/stellar/go/issues/1791

### Goal and scope

See https://github.com/stellar/go/issues/1791 for motivation
