### PR TITLE
services/horizon/internal/actions:  Find all accounts who are trustees to an asset.

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -11,6 +11,12 @@ bumps.  A breaking change will get clearly notified in this log.
 * Add `Latest-Ledger` header with the sequence number of the last processed ledger by the experimental ingestion system. The endpoints built using the experimental ingestion system will always respond with data which is consistent with the ledger in `Latest-Ledger`.
 * Fixes a bug in `/fee_stats`.
 * Fixes a bug in `/paths/strict-send`.
+* Add experimental support for filtering accounts who are trustees to an asset via `/accounts`. To enable it, set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable. ([#1835](https://github.com/stellar/go/pull/1835))
+  
+    The following request will return all accounts who have a trustline to the asset identified by `asset_type=credit_alphanum4`, `asset_code=COP`, and `asset_issuer=GC2GFGZ5CZCFCDJSQF3YYEAYBOS3ZREXJSPU7LUJ7JU3LP3BQNHY7YKS`:
+    
+     `/accounts?asset_type=credit_alphanum4&asset_code=COP&asset_issuer=GC2GFGZ5CZCFCDJSQF3YYEAYBOS3ZREXJSPU7LUJ7JU3LP3BQNHY7YKS`
+
 
 ### Breaking Changes
 

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -123,17 +123,17 @@ func (handler GetAccountsHandler) GetResourcePage(
 			accountIDs = append(accountIDs, record.AccountID)
 		}
 
-		signers, err := loadSigners(handler.HistoryQ, accountIDs)
+		signers, err := handler.loadSigners(handler.HistoryQ, accountIDs)
 		if err != nil {
 			return nil, err
 		}
 
-		trustlines, err := loadTrustlines(handler.HistoryQ, accountIDs)
+		trustlines, err := handler.loadTrustlines(handler.HistoryQ, accountIDs)
 		if err != nil {
 			return nil, err
 		}
 
-		data, err := loadData(handler.HistoryQ, accountIDs)
+		data, err := handler.loadData(handler.HistoryQ, accountIDs)
 		if err != nil {
 			return nil, err
 		}
@@ -164,7 +164,7 @@ func (handler GetAccountsHandler) GetResourcePage(
 	return accounts, nil
 }
 
-func loadData(historyQ *history.Q, accounts []string) (map[string][]history.Data, error) {
+func (handler GetAccountsHandler) loadData(historyQ *history.Q, accounts []string) (map[string][]history.Data, error) {
 	data := make(map[string][]history.Data)
 
 	records, err := historyQ.GetAccountDataByAccountsID(accounts)
@@ -183,7 +183,7 @@ func loadData(historyQ *history.Q, accounts []string) (map[string][]history.Data
 	return data, nil
 }
 
-func loadTrustlines(historyQ *history.Q, accounts []string) (map[string][]history.TrustLine, error) {
+func (handler GetAccountsHandler) loadTrustlines(historyQ *history.Q, accounts []string) (map[string][]history.TrustLine, error) {
 	trustLines := make(map[string][]history.TrustLine)
 
 	records, err := historyQ.GetTrustLinesByAccountsID(accounts)
@@ -202,7 +202,7 @@ func loadTrustlines(historyQ *history.Q, accounts []string) (map[string][]histor
 	return trustLines, nil
 }
 
-func loadSigners(historyQ *history.Q, accounts []string) (map[string][]history.AccountSigner, error) {
+func (handler GetAccountsHandler) loadSigners(historyQ *history.Q, accounts []string) (map[string][]history.AccountSigner, error) {
 	signers := make(map[string][]history.AccountSigner)
 
 	records, err := historyQ.SignersForAccounts(accounts)

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -81,12 +81,18 @@ func (handler GetAccountsHandler) GetResourcePage(
 	}
 	var accounts []hal.Pageable
 
+	historyQ, err := historyQFromRequest(r)
+	if err != nil {
+		return nil, err
+	}
+
 	if len(rawSigner) > 0 {
+
 		signer, err := GetAccountID(r, "signer")
 		if err != nil {
 			return nil, err
 		}
-		records, err := handler.HistoryQ.AccountsForSigner(signer.Address(), pq)
+		records, err := historyQ.AccountsForSigner(signer.Address(), pq)
 		if err != nil {
 			return nil, errors.Wrap(err, "loading account records")
 		}
@@ -102,7 +108,7 @@ func (handler GetAccountsHandler) GetResourcePage(
 			return nil, err
 		}
 
-		records, err := handler.HistoryQ.AccountsForAsset(asset, pq)
+		records, err := historyQ.AccountsForAsset(asset, pq)
 		if err != nil {
 			return nil, errors.Wrap(err, "loading account records")
 		}

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -173,13 +173,9 @@ func (handler GetAccountsHandler) loadData(historyQ *history.Q, accounts []strin
 	}
 
 	for _, record := range records {
-		_, ok := data[record.AccountID]
-		if ok {
-			data[record.AccountID] = append(data[record.AccountID], record)
-		} else {
-			data[record.AccountID] = []history.Data{record}
-		}
+		data[record.AccountID] = append(data[record.AccountID], record)
 	}
+
 	return data, nil
 }
 
@@ -192,13 +188,9 @@ func (handler GetAccountsHandler) loadTrustlines(historyQ *history.Q, accounts [
 	}
 
 	for _, record := range records {
-		_, ok := trustLines[record.AccountID]
-		if ok {
-			trustLines[record.AccountID] = append(trustLines[record.AccountID], record)
-		} else {
-			trustLines[record.AccountID] = []history.TrustLine{record}
-		}
+		trustLines[record.AccountID] = append(trustLines[record.AccountID], record)
 	}
+
 	return trustLines, nil
 }
 
@@ -211,12 +203,8 @@ func (handler GetAccountsHandler) loadSigners(historyQ *history.Q, accounts []st
 	}
 
 	for _, record := range records {
-		_, ok := signers[record.Account]
-		if ok {
-			signers[record.Account] = append(signers[record.Account], record)
-		} else {
-			signers[record.Account] = []history.AccountSigner{record}
-		}
+		signers[record.Account] = append(signers[record.Account], record)
 	}
+
 	return signers, nil
 }

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -192,5 +192,20 @@ func loadTrustlines(historyQ *history.Q, accounts []string) (map[string][]histor
 }
 
 func loadSigners(historyQ *history.Q, accounts []string) (map[string][]history.AccountSigner, error) {
-	return make(map[string][]history.AccountSigner), nil
+	signers := make(map[string][]history.AccountSigner)
+
+	records, err := historyQ.SignersForAccounts(accounts)
+	if err != nil {
+		return signers, err
+	}
+
+	for _, record := range records {
+		_, ok := signers[record.Account]
+		if ok {
+			signers[record.Account] = append(signers[record.Account], record)
+		} else {
+			signers[record.Account] = []history.AccountSigner{record}
+		}
+	}
+	return signers, nil
 }

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -92,13 +92,44 @@ func (handler GetAccountsHandler) GetResourcePage(
 			return nil, errors.Wrap(err, "loading account records")
 		}
 
+		accountIDS := make([]string, len(records))
+		for _, record := range records {
+			accountIDS = append(accountIDS, record.AccountID)
+		}
+
+		signers, err := loadSigners(accountIDS)
+		if err != nil {
+			return nil, err
+		}
+
+		trustlines, err := loadTrustlines(accountIDS)
+		if err != nil {
+			return nil, err
+		}
+
+		data, err := loadData(accountIDS)
+		if err != nil {
+			return nil, err
+		}
+
 		for _, record := range records {
 			var res protocol.Account
-			data := []history.Data{}
-			signers := []history.AccountSigner{}
-			trustlines := []history.TrustLine{}
+			s, ok := signers[record.AccountID]
+			if !ok {
+				s = []history.AccountSigner{}
+			}
 
-			resourceadapter.PopulateAccountEntry(ctx, &res, record, data, signers, trustlines)
+			t, ok := trustlines[record.AccountID]
+			if !ok {
+				t = []history.TrustLine{}
+			}
+
+			d, ok := data[record.AccountID]
+			if !ok {
+				d = []history.Data{}
+			}
+
+			resourceadapter.PopulateAccountEntry(ctx, &res, record, d, s, t)
 
 			accounts = append(accounts, res)
 		}
@@ -120,4 +151,16 @@ func (handler GetAccountsHandler) GetResourcePage(
 	}
 
 	return accounts, nil
+}
+
+func loadData(accountsID []string) (map[string][]history.Data, error) {
+	return make(map[string][]history.Data), nil
+}
+
+func loadTrustlines(accountsID []string) (map[string][]history.TrustLine, error) {
+	return make(map[string][]history.TrustLine), nil
+}
+
+func loadSigners(accountsID []string) (map[string][]history.AccountSigner, error) {
+	return make(map[string][]history.AccountSigner), nil
 }

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -173,7 +173,22 @@ func loadData(historyQ *history.Q, accounts []string) (map[string][]history.Data
 }
 
 func loadTrustlines(historyQ *history.Q, accounts []string) (map[string][]history.TrustLine, error) {
-	return make(map[string][]history.TrustLine), nil
+	trustLines := make(map[string][]history.TrustLine)
+
+	records, err := historyQ.GetTrustLinesByAccountsID(accounts)
+	if err != nil {
+		return trustLines, err
+	}
+
+	for _, record := range records {
+		_, ok := trustLines[record.AccountID]
+		if ok {
+			trustLines[record.AccountID] = append(trustLines[record.AccountID], record)
+		} else {
+			trustLines[record.AccountID] = []history.TrustLine{record}
+		}
+	}
+	return trustLines, nil
 }
 
 func loadSigners(historyQ *history.Q, accounts []string) (map[string][]history.AccountSigner, error) {

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -92,6 +92,11 @@ func (handler GetAccountsHandler) GetResourcePage(
 			return nil, errors.Wrap(err, "loading account records")
 		}
 
+		if len(records) == 0 {
+			// early return
+			return accounts, nil
+		}
+
 		accountIDS := make([]string, 0, len(records))
 		for _, record := range records {
 			accountIDS = append(accountIDS, record.AccountID)

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -169,7 +169,7 @@ func (handler GetAccountsHandler) loadData(historyQ *history.Q, accounts []strin
 
 	records, err := historyQ.GetAccountDataByAccountsID(accounts)
 	if err != nil {
-		return data, err
+		return data, errors.Wrap(err, "loading account data records by accounts")
 	}
 
 	for _, record := range records {
@@ -184,7 +184,7 @@ func (handler GetAccountsHandler) loadTrustlines(historyQ *history.Q, accounts [
 
 	records, err := historyQ.GetTrustLinesByAccountsID(accounts)
 	if err != nil {
-		return trustLines, err
+		return trustLines, errors.Wrap(err, "loading trustline records by accounts")
 	}
 
 	for _, record := range records {
@@ -199,7 +199,7 @@ func (handler GetAccountsHandler) loadSigners(historyQ *history.Q, accounts []st
 
 	records, err := historyQ.SignersForAccounts(accounts)
 	if err != nil {
-		return signers, err
+		return signers, errors.Wrap(err, "loading account signers by account")
 	}
 
 	for _, record := range records {

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -118,22 +118,22 @@ func (handler GetAccountsHandler) GetResourcePage(
 			return accounts, nil
 		}
 
-		accountIDS := make([]string, 0, len(records))
+		accountIDs := make([]string, 0, len(records))
 		for _, record := range records {
-			accountIDS = append(accountIDS, record.AccountID)
+			accountIDs = append(accountIDs, record.AccountID)
 		}
 
-		signers, err := loadSigners(handler.HistoryQ, accountIDS)
+		signers, err := loadSigners(handler.HistoryQ, accountIDs)
 		if err != nil {
 			return nil, err
 		}
 
-		trustlines, err := loadTrustlines(handler.HistoryQ, accountIDS)
+		trustlines, err := loadTrustlines(handler.HistoryQ, accountIDs)
 		if err != nil {
 			return nil, err
 		}
 
-		data, err := loadData(handler.HistoryQ, accountIDS)
+		data, err := loadData(handler.HistoryQ, accountIDs)
 		if err != nil {
 			return nil, err
 		}

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -120,7 +120,6 @@ func (q AccountsQuery) Asset() *xdr.Asset {
 
 // GetAccountsHandler is the action handler for the /accounts endpoint
 type GetAccountsHandler struct {
-	HistoryQ *history.Q
 }
 
 // GetResourcePage returns a page containing the account records that have
@@ -179,17 +178,17 @@ func (handler GetAccountsHandler) GetResourcePage(
 			accountIDs = append(accountIDs, record.AccountID)
 		}
 
-		signers, err := handler.loadSigners(handler.HistoryQ, accountIDs)
+		signers, err := handler.loadSigners(historyQ, accountIDs)
 		if err != nil {
 			return nil, err
 		}
 
-		trustlines, err := handler.loadTrustlines(handler.HistoryQ, accountIDs)
+		trustlines, err := handler.loadTrustlines(historyQ, accountIDs)
 		if err != nil {
 			return nil, err
 		}
 
-		data, err := handler.loadData(handler.HistoryQ, accountIDs)
+		data, err := handler.loadData(historyQ, accountIDs)
 		if err != nil {
 			return nil, err
 		}

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -123,11 +123,7 @@ type GetAccountsHandler struct {
 }
 
 // GetResourcePage returns a page containing the account records that have
-// `signer` as a signer. This doesn't return full account details resource
-// because of the limitations of existing ingestion architecture. In a future,
-// when the new ingestion system is fully integrated, this endpoint can be used
-// to find accounts for signer but also accounts for assets, home domain,
-// inflation_dest etc.
+// `signer` as a signer or have a trustline to the given asset.
 func (handler GetAccountsHandler) GetResourcePage(
 	w HeaderWriter,
 	r *http.Request,
@@ -195,20 +191,9 @@ func (handler GetAccountsHandler) GetResourcePage(
 
 		for _, record := range records {
 			var res protocol.Account
-			s, ok := signers[record.AccountID]
-			if !ok {
-				s = []history.AccountSigner{}
-			}
-
-			t, ok := trustlines[record.AccountID]
-			if !ok {
-				t = []history.TrustLine{}
-			}
-
-			d, ok := data[record.AccountID]
-			if !ok {
-				d = []history.Data{}
-			}
+			s := signers[record.AccountID]
+			t := trustlines[record.AccountID]
+			d := data[record.AccountID]
 
 			resourceadapter.PopulateAccountEntry(ctx, &res, record, d, s, t)
 

--- a/services/horizon/internal/actions/account_test.go
+++ b/services/horizon/internal/actions/account_test.go
@@ -132,7 +132,7 @@ func TestGetAccountsHandlerPageNoResults(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := &GetAccountsHandler{HistoryQ: q}
+	handler := &GetAccountsHandler{}
 	records, err := handler.GetResourcePage(
 		httptest.NewRecorder(),
 		makeRequest(
@@ -154,7 +154,7 @@ func TestGetAccountsHandlerPageResultsBySigner(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := &GetAccountsHandler{HistoryQ: q}
+	handler := &GetAccountsHandler{}
 
 	rows := accountSigners()
 
@@ -214,7 +214,7 @@ func TestGetAccountsHandlerPageResultsByAsset(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := &GetAccountsHandler{HistoryQ: q}
+	handler := &GetAccountsHandler{}
 
 	_, err := q.InsertAccount(account1, 1234)
 	tt.Assert.NoError(err)
@@ -327,7 +327,7 @@ func TestGetAccountsHandlerInvalidParams(t *testing.T) {
 			tt := test.Start(t)
 			defer tt.Finish()
 			q := &history.Q{tt.HorizonSession()}
-			handler := &GetAccountsHandler{HistoryQ: q}
+			handler := &GetAccountsHandler{}
 
 			_, err := handler.GetResourcePage(
 				httptest.NewRecorder(),

--- a/services/horizon/internal/actions/account_test.go
+++ b/services/horizon/internal/actions/account_test.go
@@ -4,17 +4,64 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	protocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/xdr"
+)
+
+var (
+	trustLineIssuer = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
+	accountOne      = "GABGMPEKKDWR2WFH5AJOZV5PDKLJEHGCR3Q24ALETWR5H3A7GI3YTS7V"
+	accountTwo      = "GADTXHUTHIAESMMQ2ZWSTIIGBZRLHUCBLCHPLLUEIAWDEFRDC4SYDKOZ"
+	accountThree    = "GDP347UYM2ZKE6ED6T5OM3BQ5IAS76NKRVEUPNB5PCQ26Z5D7Q7PJOMI"
+	signer          = "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU"
+	usd             = xdr.MustNewCreditAsset("USD", trustLineIssuer)
+	euro            = xdr.MustNewCreditAsset("EUR", trustLineIssuer)
+
+	eurTrustLine = xdr.TrustLineEntry{
+		AccountId: xdr.MustAddress(accountOne),
+		Asset:     euro,
+		Balance:   20000,
+		Limit:     223456789,
+		Flags:     1,
+		Ext: xdr.TrustLineEntryExt{
+			V: 1,
+			V1: &xdr.TrustLineEntryV1{
+				Liabilities: xdr.Liabilities{
+					Buying:  3,
+					Selling: 4,
+				},
+			},
+		},
+	}
+
+	usdTrustLine = xdr.TrustLineEntry{
+		AccountId: xdr.MustAddress(accountTwo),
+		Asset:     usd,
+		Balance:   10000,
+		Limit:     123456789,
+		Flags:     0,
+		Ext: xdr.TrustLineEntryExt{
+			V: 1,
+			V1: &xdr.TrustLineEntryV1{
+				Liabilities: xdr.Liabilities{
+					Buying:  1,
+					Selling: 2,
+				},
+			},
+		},
+	}
 )
 
 func TestAccountInfo(t *testing.T) {
 	tt := test.Start(t).Scenario("allow_trust")
 	defer tt.Finish()
 
-	account, err := AccountInfo(tt.Ctx, &core.Q{tt.CoreSession()}, "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU")
+	account, err := AccountInfo(tt.Ctx, &core.Q{tt.CoreSession()}, signer)
 	tt.Assert.NoError(err)
 
 	tt.Assert.Equal("8589934593", account.Sequence)
@@ -40,7 +87,7 @@ func TestGetAccountsHandlerPageNoResults(t *testing.T) {
 		makeRequest(
 			t,
 			map[string]string{
-				"signer": "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
+				"signer": signer,
 			},
 			map[string]string{},
 			q.Session,
@@ -50,7 +97,7 @@ func TestGetAccountsHandlerPageNoResults(t *testing.T) {
 	tt.Assert.Len(records, 0)
 }
 
-func TestGetAccountsHandlerPageResults(t *testing.T) {
+func TestGetAccountsHandlerPageResultsBySigner(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
@@ -58,23 +105,7 @@ func TestGetAccountsHandlerPageResults(t *testing.T) {
 	q := &history.Q{tt.HorizonSession()}
 	handler := &GetAccountsHandler{HistoryQ: q}
 
-	rows := []history.AccountSigner{
-		history.AccountSigner{
-			Account: "GABGMPEKKDWR2WFH5AJOZV5PDKLJEHGCR3Q24ALETWR5H3A7GI3YTS7V",
-			Signer:  "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
-			Weight:  1,
-		},
-		history.AccountSigner{
-			Account: "GADTXHUTHIAESMMQ2ZWSTIIGBZRLHUCBLCHPLLUEIAWDEFRDC4SYDKOZ",
-			Signer:  "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
-			Weight:  2,
-		},
-		history.AccountSigner{
-			Account: "GDP347UYM2ZKE6ED6T5OM3BQ5IAS76NKRVEUPNB5PCQ26Z5D7Q7PJOMI",
-			Signer:  "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
-			Weight:  3,
-		},
-	}
+	rows := accountSigners()
 
 	for _, row := range rows {
 		q.CreateAccountSigner(row.Account, row.Signer, row.Weight)
@@ -85,7 +116,7 @@ func TestGetAccountsHandlerPageResults(t *testing.T) {
 		makeRequest(
 			t,
 			map[string]string{
-				"signer": "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
+				"signer": signer,
 			},
 			map[string]string{},
 			q.Session,
@@ -123,5 +154,66 @@ func TestGetAccountsHandlerPageResults(t *testing.T) {
 		tt.Assert.Equal(row.Account, result.AccountID)
 		tt.Assert.Equal(row.Signer, result.Signer.Key)
 		tt.Assert.Equal(row.Weight, result.Signer.Weight)
+	}
+}
+
+func TestGetAccountsHandlerPageResultsByAsset(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+
+	q := &history.Q{tt.HorizonSession()}
+	handler := &GetAccountsHandler{HistoryQ: q}
+
+	rows := accountSigners()
+
+	for _, row := range rows {
+		q.CreateAccountSigner(row.Account, row.Signer, row.Weight)
+	}
+
+	var assetType, code, issuer string
+	usd.MustExtract(&assetType, &code, &issuer)
+	params := map[string]string{
+		"asset_issuer": issuer,
+		"asset_code":   code,
+		"asset_type":   assetType,
+	}
+
+	records, err := handler.GetResourcePage(makeRequest(t, params, map[string]string{}))
+
+	tt.Assert.NoError(err)
+	tt.Assert.Equal(0, len(records))
+
+	_, err = q.InsertTrustLine(eurTrustLine, 1234)
+	assert.NoError(t, err)
+	_, err = q.InsertTrustLine(usdTrustLine, 1235)
+	assert.NoError(t, err)
+
+	records, err = handler.GetResourcePage(makeRequest(t, params, map[string]string{}))
+
+	tt.Assert.NoError(err)
+	tt.Assert.Equal(1, len(records))
+
+	result := records[0].(protocol.AccountSigner)
+	tt.Assert.Equal(accountTwo, result.AccountID)
+}
+
+func accountSigners() []history.AccountSigner {
+	return []history.AccountSigner{
+		history.AccountSigner{
+			Account: accountOne,
+			Signer:  signer,
+			Weight:  1,
+		},
+		history.AccountSigner{
+			Account: accountTwo,
+			Signer:  signer,
+			Weight:  2,
+		},
+		history.AccountSigner{
+			Account: accountThree,
+			Signer:  signer,
+			Weight:  3,
+		},
 	}
 }

--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -778,7 +778,7 @@ func validateAssetParams(aType, code, issuer, prefix string) error {
 	if len(aType) == 0 {
 		if len(code) > 0 || len(issuer) > 0 {
 			return problem.MakeInvalidFieldProblem(
-				prefix+"_asset_type",
+				prefix+"asset_type",
 				errors.New("Missing parameter"),
 			)
 		}
@@ -789,7 +789,7 @@ func validateAssetParams(aType, code, issuer, prefix string) error {
 	t, err := assets.Parse(aType)
 	if err != nil {
 		return problem.MakeInvalidFieldProblem(
-			prefix+"_asset_type",
+			prefix+"asset_type",
 			err,
 		)
 	}
@@ -802,12 +802,12 @@ func validateAssetParams(aType, code, issuer, prefix string) error {
 		switch {
 		case len(code) > 0:
 			return problem.MakeInvalidFieldProblem(
-				prefix+"_asset_code",
+				prefix+"asset_code",
 				errors.New("native asset does not have a code"),
 			)
 		case len(issuer) > 0:
 			return problem.MakeInvalidFieldProblem(
-				prefix+"_asset_issuer",
+				prefix+"asset_issuer",
 				errors.New("native asset does not have an issuer"),
 			)
 		}
@@ -822,14 +822,14 @@ func validateAssetParams(aType, code, issuer, prefix string) error {
 	codeLen := len(code)
 	if codeLen == 0 || codeLen > validLen {
 		return problem.MakeInvalidFieldProblem(
-			prefix+"_asset_code",
+			prefix+"asset_code",
 			errors.New("Asset code must be 1-12 alphanumeric characters"),
 		)
 	}
 
 	if len(issuer) == 0 {
 		return problem.MakeInvalidFieldProblem(
-			prefix+"_asset_issuer",
+			prefix+"asset_issuer",
 			errors.New("Missing parameter"),
 		)
 	}

--- a/services/horizon/internal/actions/query_params.go
+++ b/services/horizon/internal/actions/query_params.go
@@ -17,11 +17,11 @@ type SellingBuyingAssetQueryParams struct {
 
 // Validate runs custom validations buying and selling
 func (q SellingBuyingAssetQueryParams) Validate() error {
-	err := validateAssetParams(q.SellingAssetType, q.SellingAssetCode, q.SellingAssetIssuer, "selling")
+	err := validateAssetParams(q.SellingAssetType, q.SellingAssetCode, q.SellingAssetIssuer, "selling_")
 	if err != nil {
 		return err
 	}
-	err = validateAssetParams(q.BuyingAssetType, q.BuyingAssetCode, q.BuyingAssetIssuer, "buying")
+	err = validateAssetParams(q.BuyingAssetType, q.BuyingAssetCode, q.BuyingAssetIssuer, "buying_")
 	if err != nil {
 		return err
 	}

--- a/services/horizon/internal/db2/history/account_data.go
+++ b/services/horizon/internal/db2/history/account_data.go
@@ -130,6 +130,14 @@ func (q *Q) RemoveAccountData(key xdr.LedgerKeyData) (int64, error) {
 	return result.RowsAffected()
 }
 
+// GetAccountDataByAccountsID loads account data for a list of account ID
+func (q *Q) GetAccountDataByAccountsID(id []string) ([]Data, error) {
+	var data []Data
+	sql := selectAccountData.Where(sq.Eq{"account": id})
+	err := q.Select(&data, sql)
+	return data, err
+}
+
 var selectAccountData = sq.Select(`
 	account,
 	name,

--- a/services/horizon/internal/db2/history/account_data_test.go
+++ b/services/horizon/internal/db2/history/account_data_test.go
@@ -106,3 +106,29 @@ func TestRemoveAccountData(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(0), rows)
 }
+
+func TestGetAccountDataByAccountsID(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	_, err := q.InsertAccountData(data1, 1234)
+	assert.NoError(t, err)
+	_, err = q.InsertAccountData(data2, 1235)
+	assert.NoError(t, err)
+
+	ids := []string{
+		data1.AccountId.Address(),
+		data2.AccountId.Address(),
+	}
+	datas, err := q.GetAccountDataByAccountsID(ids)
+	assert.NoError(t, err)
+	assert.Len(t, datas, 2)
+
+	assert.Equal(t, data1.DataName, xdr.String64(datas[0].Name))
+	assert.Equal(t, []byte(data1.DataValue), []byte(datas[0].Value))
+
+	assert.Equal(t, data2.DataName, xdr.String64(datas[1].Name))
+	assert.Equal(t, []byte(data2.DataValue), []byte(datas[1].Value))
+}

--- a/services/horizon/internal/db2/history/account_signers.go
+++ b/services/horizon/internal/db2/history/account_signers.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/support/errors"
-	"github.com/stellar/go/xdr"
 )
 
 func (q *Q) SignersForAccounts(accounts []string) ([]AccountSigner, error) {
@@ -64,37 +63,6 @@ func (q *Q) RemoveAccountSigner(account, signer string) (int64, error) {
 	}
 
 	return result.RowsAffected()
-}
-
-// AccountSignersForAsset returns a list of `AccountSigner` rows who are trustee to an
-// asset Using this type for now, we should probably change the type on this
-// end-point to be consistent with what the end-point is supposed to be
-// returning.
-func (q *Q) AccountSignersForAsset(asset xdr.Asset, page db2.PageQuery) ([]AccountSigner, error) {
-	var assetType, code, issuer string
-	asset.MustExtract(&assetType, &code, &issuer)
-
-	sql := sq.
-		Select("accounts_signers.*").
-		From("accounts_signers").
-		Join("trust_lines ON accounts_signers.account = trust_lines.accountid").
-		Where(map[string]interface{}{
-			"trust_lines.assettype":   int32(asset.Type),
-			"trust_lines.assetissuer": issuer,
-			"trust_lines.assetcode":   code,
-		})
-
-	sql, err := page.ApplyToUsingCursor(sql, "trust_lines.accountid", page.Cursor)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not apply query to page")
-	}
-
-	var results []AccountSigner
-	if err := q.Select(&results, sql); err != nil {
-		return nil, errors.Wrap(err, "could not run select query")
-	}
-
-	return results, nil
 }
 
 var selectAccountSigners = sq.Select("accounts_signers.*").From("accounts_signers")

--- a/services/horizon/internal/db2/history/accounts.go
+++ b/services/horizon/internal/db2/history/accounts.go
@@ -119,9 +119,7 @@ func (q *Q) RemoveAccount(accountID string) (int64, error) {
 }
 
 // AccountSignersForAsset returns a list of `AccountSigner` rows who are trustee to an
-// asset Using this type for now, we should probably change the type on this
-// end-point to be consistent with what the end-point is supposed to be
-// returning.
+// asset
 func (q *Q) AccountsForAsset(asset xdr.Asset, page db2.PageQuery) ([]AccountEntry, error) {
 	var assetType, code, issuer string
 	asset.MustExtract(&assetType, &code, &issuer)

--- a/services/horizon/internal/db2/history/accounts.go
+++ b/services/horizon/internal/db2/history/accounts.go
@@ -3,6 +3,7 @@ package history
 import (
 	sq "github.com/Masterminds/squirrel"
 
+	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -115,6 +116,37 @@ func (q *Q) RemoveAccount(accountID string) (int64, error) {
 	}
 
 	return result.RowsAffected()
+}
+
+// AccountSignersForAsset returns a list of `AccountSigner` rows who are trustee to an
+// asset Using this type for now, we should probably change the type on this
+// end-point to be consistent with what the end-point is supposed to be
+// returning.
+func (q *Q) AccountsForAsset(asset xdr.Asset, page db2.PageQuery) ([]AccountEntry, error) {
+	var assetType, code, issuer string
+	asset.MustExtract(&assetType, &code, &issuer)
+
+	sql := sq.
+		Select("accounts.*").
+		From("accounts").
+		Join("trust_lines ON accounts.account_id = trust_lines.accountid").
+		Where(map[string]interface{}{
+			"trust_lines.assettype":   int32(asset.Type),
+			"trust_lines.assetissuer": issuer,
+			"trust_lines.assetcode":   code,
+		})
+
+	sql, err := page.ApplyToUsingCursor(sql, "trust_lines.accountid", page.Cursor)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not apply query to page")
+	}
+
+	var results []AccountEntry
+	if err := q.Select(&results, sql); err != nil {
+		return nil, errors.Wrap(err, "could not run select query")
+	}
+
+	return results, nil
 }
 
 var selectAccounts = sq.Select(`

--- a/services/horizon/internal/db2/history/accounts_test.go
+++ b/services/horizon/internal/db2/history/accounts_test.go
@@ -3,6 +3,7 @@ package history
 import (
 	"testing"
 
+	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
@@ -169,4 +170,40 @@ func TestRemoveAccount(t *testing.T) {
 	rows, err = q.RemoveAccount("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB")
 	assert.NoError(t, err)
 	assert.Equal(t, int64(0), rows)
+}
+
+func TestAccountsForAsset(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	eurTrustLine.AccountId = account1.AccountId
+	usdTrustLine.AccountId = account2.AccountId
+
+	_, err := q.InsertAccount(account1, 1234)
+	tt.Assert.NoError(err)
+	_, err = q.InsertAccount(account2, 1235)
+	tt.Assert.NoError(err)
+
+	_, err = q.InsertTrustLine(eurTrustLine, 1234)
+	tt.Assert.NoError(err)
+	_, err = q.InsertTrustLine(usdTrustLine, 1235)
+	tt.Assert.NoError(err)
+
+	pq := db2.PageQuery{
+		Order:  db2.OrderAscending,
+		Limit:  db2.DefaultPageSize,
+		Cursor: "",
+	}
+
+	accounts, err := q.AccountsForAsset(eurTrustLine.Asset, pq)
+	assert.NoError(t, err)
+	tt.Assert.Len(accounts, 1)
+	tt.Assert.Equal(account1.AccountId.Address(), accounts[0].AccountID)
+
+	accounts, err = q.AccountsForAsset(usdTrustLine.Asset, pq)
+	assert.NoError(t, err)
+	tt.Assert.Len(accounts, 1)
+	tt.Assert.Equal(account2.AccountId.Address(), accounts[0].AccountID)
 }

--- a/services/horizon/internal/db2/history/accounts_test.go
+++ b/services/horizon/internal/db2/history/accounts_test.go
@@ -206,4 +206,9 @@ func TestAccountsForAsset(t *testing.T) {
 	assert.NoError(t, err)
 	tt.Assert.Len(accounts, 1)
 	tt.Assert.Equal(account2.AccountId.Address(), accounts[0].AccountID)
+
+	pq.Cursor = account2.AccountId.Address()
+	accounts, err = q.AccountsForAsset(usdTrustLine.Asset, pq)
+	assert.NoError(t, err)
+	tt.Assert.Len(accounts, 0)
 }

--- a/services/horizon/internal/db2/history/trust_lines.go
+++ b/services/horizon/internal/db2/history/trust_lines.go
@@ -105,6 +105,14 @@ func (q *Q) RemoveTrustLine(ledgerKey xdr.LedgerKeyTrustLine) (int64, error) {
 	return result.RowsAffected()
 }
 
+// GetTrustLinesByAccountsID loads trust lines for a list of accounts ID
+func (q *Q) GetTrustLinesByAccountsID(id []string) ([]TrustLine, error) {
+	var data []TrustLine
+	sql := selectTrustLines.Where(sq.Eq{"accountid": id})
+	err := q.Select(&data, sql)
+	return data, err
+}
+
 func trustLineEntryToLedgerKeyString(trustLine xdr.TrustLineEntry) (string, error) {
 	ledgerKey := &xdr.LedgerKey{}
 	err := ledgerKey.SetTrustline(trustLine.AccountId, trustLine.Asset)

--- a/services/horizon/internal/db2/history/trust_lines_test.go
+++ b/services/horizon/internal/db2/history/trust_lines_test.go
@@ -156,3 +156,22 @@ func TestRemoveTrustLine(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(0), rows)
 }
+func TestGetTrustLinesByAccountsID(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	_, err := q.InsertTrustLine(eurTrustLine, 1234)
+	assert.NoError(t, err)
+	_, err = q.InsertTrustLine(usdTrustLine, 1235)
+	assert.NoError(t, err)
+
+	ids := []string{
+		eurTrustLine.AccountId.Address(),
+		usdTrustLine.Asset.String(),
+	}
+
+	lines, err := q.GetTrustLinesByAccountsID(ids)
+	assert.Len(t, lines, 2)
+}

--- a/services/horizon/internal/db2/history/trust_lines_test.go
+++ b/services/horizon/internal/db2/history/trust_lines_test.go
@@ -29,7 +29,7 @@ var (
 	}
 
 	usdTrustLine = xdr.TrustLineEntry{
-		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		AccountId: xdr.MustAddress("GCYVFGI3SEQJGBNQQG7YCMFWEYOHK3XPVOVPA6C566PXWN4SN7LILZSM"),
 		Asset:     xdr.MustNewCreditAsset("USDUSD", trustLineIssuer.Address()),
 		Balance:   10000,
 		Limit:     123456789,
@@ -169,7 +169,7 @@ func TestGetTrustLinesByAccountsID(t *testing.T) {
 
 	ids := []string{
 		eurTrustLine.AccountId.Address(),
-		usdTrustLine.Asset.String(),
+		usdTrustLine.AccountId.Address(),
 	}
 
 	lines, err := q.GetTrustLinesByAccountsID(ids)

--- a/services/horizon/internal/db2/history/trust_lines_test.go
+++ b/services/horizon/internal/db2/history/trust_lines_test.go
@@ -163,9 +163,9 @@ func TestGetTrustLinesByAccountsID(t *testing.T) {
 	q := &Q{tt.HorizonSession()}
 
 	_, err := q.InsertTrustLine(eurTrustLine, 1234)
-	assert.NoError(t, err)
+	tt.Assert.NoError(err)
 	_, err = q.InsertTrustLine(usdTrustLine, 1235)
-	assert.NoError(t, err)
+	tt.Assert.NoError(err)
 
 	ids := []string{
 		eurTrustLine.AccountId.Address(),
@@ -173,5 +173,6 @@ func TestGetTrustLinesByAccountsID(t *testing.T) {
 	}
 
 	lines, err := q.GetTrustLinesByAccountsID(ids)
-	assert.Len(t, lines, 2)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(lines, 2)
 }

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -190,7 +190,7 @@ func (w *web) mustInstallActions(
 			Method(
 				http.MethodGet,
 				"/",
-				restPageHandler(actions.GetAccountsHandler{HistoryQ: w.historyQ}),
+				restPageHandler(actions.GetAccountsHandler{}),
 			)
 		r.Route("/{account_id}", func(r chi.Router) {
 			r.Get("/", w.streamShowActionHandler(w.getAccountInfo, true))


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Extend the `/accounts` end-point to support finding all accounts who are trustees to an asset. 

The following request:

https://horizon-testnet.stellar.org/accounts?asset_type=credit_alphanum4&asset_code=USD&asset_issuer=GAXT72C4PLIRVD4DI5IATBEIQXTV5XV4YNEALIF6WFALCOPUFYRDZBHL

Will returns all accounts with a trust_line to the `alphanum4` asset, with code `USD` issued by `GAXT72C4PLIRVD4DI5IATBEIQXTV5XV4YNEALIF6WFALCOPUFYRDZBHL`.

### Goal and scope

- Allow account filtering by `asset_type`, `asset_issuer` and `asset_code`.

### Summary of changes

- Add helper method to find accounts who trust a given asset
- Extend `GetAccountsHandler` to allow filtering by asset or signer
- Add `AccountsForAsset`
- Add `GetTrustLinesByAccountsID`
- Add `GetAccountDataByAccountsID`

### Known limitations & issues

Redefine the kind of data this end-point is returning, it should returns `[]horizon.Account`. Maybe for the first version of this we should go ahead with `[]AccountSigner` but put a deprecation. `[]horizon.AccountSigner` is almost a subset of `[]horizon.Account`, unfortunately we return "signer" not "signers".

We should also define if we want to allow mixing on some of the query params or they should be an XOR.  e.g: give me all account that trust a given asset and have account X as signer

### What shouldn't be reviewed

- n/A
