### PR TITLE
services/horizon/internal/expingest: Execute all ledger processors in one node

### DIFF
--- a/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
@@ -230,6 +230,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewAccount() {
 				},
 			}),
 		}, nil).Once()
+	s.mockLedgerReader.On("GetSequence").Return(uint32(1)).Once()
 
 	s.mockQ.
 		On(
@@ -305,6 +306,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewSigner() {
 				},
 			}),
 		}, nil).Once()
+	s.mockLedgerReader.On("GetSequence").Return(uint32(1)).Once()
 
 	// Remove old signer
 	s.mockQ.
@@ -399,6 +401,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestSignerRemoved() {
 				},
 			}),
 		}, nil).Once()
+	s.mockLedgerReader.On("GetSequence").Return(uint32(1)).Once()
 
 	// Remove old signers
 	s.mockQ.
@@ -473,6 +476,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestRemoveAccount() {
 				},
 			}),
 		}, nil).Once()
+	s.mockLedgerReader.On("GetSequence").Return(uint32(1)).Once()
 
 	s.mockQ.
 		On(
@@ -519,6 +523,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewAccountNoRowsAffected() 
 				},
 			}),
 		}, nil).Once()
+	s.mockLedgerReader.On("GetSequence").Return(uint32(1)).Once()
 
 	s.mockQ.
 		On(
@@ -540,7 +545,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewAccountNoRowsAffected() 
 	s.Assert().IsType(verify.StateError{}, errors.Cause(err))
 	s.Assert().EqualError(
 		err,
-		"Error in processLedgerAccountsForSigner: No rows affected when inserting "+
+		"Error in AccountsForSigner handler: No rows affected when inserting "+
 			"account=GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML "+
 			"signer=GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML to database",
 	)
@@ -578,6 +583,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestRemoveAccountNoRowsAffected
 				},
 			}),
 		}, nil).Once()
+	s.mockLedgerReader.On("GetSequence").Return(uint32(1)).Once()
 
 	s.mockQ.
 		On(
@@ -598,7 +604,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestRemoveAccountNoRowsAffected
 	s.Assert().IsType(verify.StateError{}, errors.Cause(err))
 	s.Assert().EqualError(
 		err,
-		"Error in processLedgerAccountsForSigner: Expected "+
+		"Error in AccountsForSigner handler: Expected "+
 			"account=GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML "+
 			"signer=GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML in database but not found when removing",
 	)

--- a/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
@@ -172,7 +172,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) SetupTest() {
 	s.mockLedgerWriter = &io.MockLedgerWriter{}
 
 	s.processor = &DatabaseProcessor{
-		Action:   AccountsForSigner,
+		Action:   All,
 		SignersQ: s.mockQ,
 	}
 

--- a/services/horizon/internal/expingest/processors/database_processor.go
+++ b/services/horizon/internal/expingest/processors/database_processor.go
@@ -144,6 +144,19 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 	defer r.Close()
 	defer w.Close()
 
+	actionHandlers := map[DatabaseProcessorActionType]func(change io.Change, currentLedger uint32) error{
+		AccountsForSigner: p.processLedgerAccountsForSigner,
+		Offers:            p.processLedgerOffers,
+		TrustLines:        p.processLedgerTrustLines,
+	}
+
+	actions := []DatabaseProcessorActionType{}
+	if p.Action == All {
+		actions = append(actions, AccountsForSigner, Offers, TrustLines)
+	} else {
+		actions = append(actions, p.Action)
+	}
+
 	for {
 		transaction, err := r.Read()
 		if err != nil {
@@ -158,24 +171,21 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 			continue
 		}
 
-		switch p.Action {
-		case AccountsForSigner:
-			err := p.processLedgerAccountsForSigner(transaction)
-			if err != nil {
-				return errors.Wrap(err, "Error in processLedgerAccountsForSigner")
+		sequence := r.GetSequence()
+		for _, action := range actions {
+			handler, ok := actionHandlers[action]
+			if !ok {
+				return errors.New("Unknown action")
 			}
-		case Offers:
-			err := p.processLedgerOffers(transaction, r.GetSequence())
-			if err != nil {
-				return errors.Wrap(err, "Error in processLedgerOffers")
+			for _, change := range transaction.GetChanges() {
+				err := handler(change, sequence)
+				if err != nil {
+					return errors.Wrap(
+						err,
+						fmt.Sprintf("Error in %s handler", action),
+					)
+				}
 			}
-		case TrustLines:
-			err := p.processLedgerTrustLines(transaction, r.GetSequence())
-			if err != nil {
-				return errors.Wrap(err, "Error in processLedgerTrustLines")
-			}
-		default:
-			return errors.New("Unknown action")
 		}
 
 		select {
@@ -189,100 +199,96 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 	return nil
 }
 
-func (p *DatabaseProcessor) processLedgerAccountsForSigner(transaction io.LedgerTransaction) error {
-	for _, change := range transaction.GetChanges() {
-		if change.Type != xdr.LedgerEntryTypeAccount {
-			continue
-		}
+func (p *DatabaseProcessor) processLedgerAccountsForSigner(change io.Change, currentLedger uint32) error {
+	if change.Type != xdr.LedgerEntryTypeAccount {
+		return nil
+	}
 
-		if !change.AccountSignersChanged() {
-			continue
-		}
+	if !change.AccountSignersChanged() {
+		return nil
+	}
 
-		// The code below removes all Pre signers adds Post signers but
-		// can be improved by finding a diff (check performance first).
-		if change.Pre != nil {
-			preAccountEntry := change.Pre.MustAccount()
-			for signer := range preAccountEntry.SignerSummary() {
-				rowsAffected, err := p.SignersQ.RemoveAccountSigner(preAccountEntry.AccountId.Address(), signer)
-				if err != nil {
-					return errors.Wrap(err, "Error removing a signer")
-				}
+	// The code below removes all Pre signers adds Post signers but
+	// can be improved by finding a diff (check performance first).
+	if change.Pre != nil {
+		preAccountEntry := change.Pre.MustAccount()
+		for signer := range preAccountEntry.SignerSummary() {
+			rowsAffected, err := p.SignersQ.RemoveAccountSigner(preAccountEntry.AccountId.Address(), signer)
+			if err != nil {
+				return errors.Wrap(err, "Error removing a signer")
+			}
 
-				if rowsAffected != 1 {
-					return verify.NewStateError(errors.Errorf(
-						"Expected account=%s signer=%s in database but not found when removing",
-						preAccountEntry.AccountId.Address(),
-						signer,
-					))
-				}
+			if rowsAffected != 1 {
+				return verify.NewStateError(errors.Errorf(
+					"Expected account=%s signer=%s in database but not found when removing",
+					preAccountEntry.AccountId.Address(),
+					signer,
+				))
 			}
 		}
+	}
 
-		if change.Post != nil {
-			postAccountEntry := change.Post.MustAccount()
-			for signer, weight := range postAccountEntry.SignerSummary() {
-				rowsAffected, err := p.SignersQ.CreateAccountSigner(postAccountEntry.AccountId.Address(), signer, weight)
-				if err != nil {
-					return errors.Wrap(err, "Error inserting a signer")
-				}
+	if change.Post != nil {
+		postAccountEntry := change.Post.MustAccount()
+		for signer, weight := range postAccountEntry.SignerSummary() {
+			rowsAffected, err := p.SignersQ.CreateAccountSigner(postAccountEntry.AccountId.Address(), signer, weight)
+			if err != nil {
+				return errors.Wrap(err, "Error inserting a signer")
+			}
 
-				if rowsAffected != 1 {
-					return verify.NewStateError(errors.Errorf(
-						"No rows affected when inserting account=%s signer=%s to database",
-						postAccountEntry.AccountId.Address(),
-						signer,
-					))
-				}
+			if rowsAffected != 1 {
+				return verify.NewStateError(errors.Errorf(
+					"No rows affected when inserting account=%s signer=%s to database",
+					postAccountEntry.AccountId.Address(),
+					signer,
+				))
 			}
 		}
 	}
 	return nil
 }
 
-func (p *DatabaseProcessor) processLedgerOffers(transaction io.LedgerTransaction, currentLedger uint32) error {
-	for _, change := range transaction.GetChanges() {
-		if change.Type != xdr.LedgerEntryTypeOffer {
-			continue
-		}
+func (p *DatabaseProcessor) processLedgerOffers(change io.Change, currentLedger uint32) error {
+	if change.Type != xdr.LedgerEntryTypeOffer {
+		return nil
+	}
 
-		var rowsAffected int64
-		var err error
-		var action string
-		var offerID xdr.Int64
+	var rowsAffected int64
+	var err error
+	var action string
+	var offerID xdr.Int64
 
-		switch {
-		case change.Pre == nil && change.Post != nil:
-			// Created
-			action = "inserting"
-			offer := change.Post.MustOffer()
-			offerID = offer.OfferId
-			rowsAffected, err = p.OffersQ.InsertOffer(offer, xdr.Uint32(currentLedger))
-		case change.Pre != nil && change.Post == nil:
-			// Removed
-			action = "removing"
-			offer := change.Pre.MustOffer()
-			offerID = offer.OfferId
-			rowsAffected, err = p.OffersQ.RemoveOffer(offer.OfferId)
-		default:
-			// Updated
-			action = "updating"
-			offer := change.Post.MustOffer()
-			offerID = offer.OfferId
-			rowsAffected, err = p.OffersQ.UpdateOffer(offer, xdr.Uint32(currentLedger))
-		}
+	switch {
+	case change.Pre == nil && change.Post != nil:
+		// Created
+		action = "inserting"
+		offer := change.Post.MustOffer()
+		offerID = offer.OfferId
+		rowsAffected, err = p.OffersQ.InsertOffer(offer, xdr.Uint32(currentLedger))
+	case change.Pre != nil && change.Post == nil:
+		// Removed
+		action = "removing"
+		offer := change.Pre.MustOffer()
+		offerID = offer.OfferId
+		rowsAffected, err = p.OffersQ.RemoveOffer(offer.OfferId)
+	default:
+		// Updated
+		action = "updating"
+		offer := change.Post.MustOffer()
+		offerID = offer.OfferId
+		rowsAffected, err = p.OffersQ.UpdateOffer(offer, xdr.Uint32(currentLedger))
+	}
 
-		if err != nil {
-			return err
-		}
+	if err != nil {
+		return err
+	}
 
-		if rowsAffected != 1 {
-			return verify.NewStateError(errors.Errorf(
-				"No rows affected when %s offer %d",
-				action,
-				offerID,
-			))
-		}
+	if rowsAffected != 1 {
+		return verify.NewStateError(errors.Errorf(
+			"No rows affected when %s offer %d",
+			action,
+			offerID,
+		))
 	}
 	return nil
 }
@@ -392,72 +398,70 @@ func (p *DatabaseProcessor) adjustAssetStat(
 	return nil
 }
 
-func (p *DatabaseProcessor) processLedgerTrustLines(transaction io.LedgerTransaction, currentLedger uint32) error {
-	for _, change := range transaction.GetChanges() {
-		if change.Type != xdr.LedgerEntryTypeTrustline {
-			continue
-		}
+func (p *DatabaseProcessor) processLedgerTrustLines(change io.Change, currentLedger uint32) error {
+	if change.Type != xdr.LedgerEntryTypeTrustline {
+		return nil
+	}
 
-		var rowsAffected int64
-		var err error
-		var action string
-		var ledgerKey xdr.LedgerKey
+	var rowsAffected int64
+	var err error
+	var action string
+	var ledgerKey xdr.LedgerKey
 
-		switch {
-		case change.Pre == nil && change.Post != nil:
-			// Created
-			action = "inserting"
-			trustLine := change.Post.MustTrustLine()
-			err = ledgerKey.SetTrustline(trustLine.AccountId, trustLine.Asset)
-			if err != nil {
-				return errors.Wrap(err, "Error creating ledger key")
-			}
-			err = p.adjustAssetStat(trustLine, trustLine.Balance, 1)
-			if err != nil {
-				return errors.Wrap(err, "Error adjusting asset stat")
-			}
-			rowsAffected, err = p.TrustLinesQ.InsertTrustLine(trustLine, xdr.Uint32(currentLedger))
-		case change.Pre != nil && change.Post == nil:
-			// Removed
-			action = "removing"
-			trustLine := change.Pre.MustTrustLine()
-			err = ledgerKey.SetTrustline(trustLine.AccountId, trustLine.Asset)
-			if err != nil {
-				return errors.Wrap(err, "Error creating ledger key")
-			}
-			err = p.adjustAssetStat(trustLine, -trustLine.Balance, -1)
-			if err != nil {
-				return errors.Wrap(err, "Error adjusting asset stat")
-			}
-			rowsAffected, err = p.TrustLinesQ.RemoveTrustLine(*ledgerKey.TrustLine)
-		default:
-			// Updated
-			action = "updating"
-			preTrustLine := change.Pre.MustTrustLine()
-			trustLine := change.Post.MustTrustLine()
-			err = ledgerKey.SetTrustline(trustLine.AccountId, trustLine.Asset)
-			if err != nil {
-				return errors.Wrap(err, "Error creating ledger key")
-			}
-			err = p.adjustAssetStat(trustLine, trustLine.Balance-preTrustLine.Balance, 0)
-			if err != nil {
-				return errors.Wrap(err, "Error adjusting asset stat")
-			}
-			rowsAffected, err = p.TrustLinesQ.UpdateTrustLine(trustLine, xdr.Uint32(currentLedger))
-		}
-
+	switch {
+	case change.Pre == nil && change.Post != nil:
+		// Created
+		action = "inserting"
+		trustLine := change.Post.MustTrustLine()
+		err = ledgerKey.SetTrustline(trustLine.AccountId, trustLine.Asset)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "Error creating ledger key")
 		}
+		err = p.adjustAssetStat(trustLine, trustLine.Balance, 1)
+		if err != nil {
+			return errors.Wrap(err, "Error adjusting asset stat")
+		}
+		rowsAffected, err = p.TrustLinesQ.InsertTrustLine(trustLine, xdr.Uint32(currentLedger))
+	case change.Pre != nil && change.Post == nil:
+		// Removed
+		action = "removing"
+		trustLine := change.Pre.MustTrustLine()
+		err = ledgerKey.SetTrustline(trustLine.AccountId, trustLine.Asset)
+		if err != nil {
+			return errors.Wrap(err, "Error creating ledger key")
+		}
+		err = p.adjustAssetStat(trustLine, -trustLine.Balance, -1)
+		if err != nil {
+			return errors.Wrap(err, "Error adjusting asset stat")
+		}
+		rowsAffected, err = p.TrustLinesQ.RemoveTrustLine(*ledgerKey.TrustLine)
+	default:
+		// Updated
+		action = "updating"
+		preTrustLine := change.Pre.MustTrustLine()
+		trustLine := change.Post.MustTrustLine()
+		err = ledgerKey.SetTrustline(trustLine.AccountId, trustLine.Asset)
+		if err != nil {
+			return errors.Wrap(err, "Error creating ledger key")
+		}
+		err = p.adjustAssetStat(trustLine, trustLine.Balance-preTrustLine.Balance, 0)
+		if err != nil {
+			return errors.Wrap(err, "Error adjusting asset stat")
+		}
+		rowsAffected, err = p.TrustLinesQ.UpdateTrustLine(trustLine, xdr.Uint32(currentLedger))
+	}
 
-		if rowsAffected != 1 {
-			return verify.NewStateError(errors.Errorf(
-				"No rows affected when %s trustline: %s %s",
-				action,
-				ledgerKey.TrustLine.AccountId.Address(),
-				ledgerKey.TrustLine.Asset.String(),
-			))
-		}
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected != 1 {
+		return verify.NewStateError(errors.Errorf(
+			"No rows affected when %s trustline: %s %s",
+			action,
+			ledgerKey.TrustLine.AccountId.Address(),
+			ledgerKey.TrustLine.Asset.String(),
+		))
 	}
 	return nil
 }

--- a/services/horizon/internal/expingest/processors/database_processor.go
+++ b/services/horizon/internal/expingest/processors/database_processor.go
@@ -144,17 +144,18 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 	defer r.Close()
 	defer w.Close()
 
+	if p.Action != All {
+		return errors.New("ledger processor must process all actions")
+	}
+
 	actionHandlers := map[DatabaseProcessorActionType]func(change io.Change, currentLedger uint32) error{
 		AccountsForSigner: p.processLedgerAccountsForSigner,
 		Offers:            p.processLedgerOffers,
 		TrustLines:        p.processLedgerTrustLines,
 	}
 
-	actions := []DatabaseProcessorActionType{}
-	if p.Action == All {
-		actions = append(actions, AccountsForSigner, Offers, TrustLines)
-	} else {
-		actions = append(actions, p.Action)
+	actions := []DatabaseProcessorActionType{
+		AccountsForSigner, Offers, TrustLines,
 	}
 
 	for {

--- a/services/horizon/internal/expingest/processors/main.go
+++ b/services/horizon/internal/expingest/processors/main.go
@@ -17,6 +17,7 @@ const (
 	AccountsForSigner DatabaseProcessorActionType = "AccountsForSigner"
 	Offers            DatabaseProcessorActionType = "Offers"
 	TrustLines        DatabaseProcessorActionType = "TrustLines"
+	All               DatabaseProcessorActionType = "All"
 )
 
 // DatabaseProcessor is a processor (both state and ledger) that's responsible

--- a/services/horizon/internal/expingest/processors/offers_processor_test.go
+++ b/services/horizon/internal/expingest/processors/offers_processor_test.go
@@ -112,7 +112,7 @@ func (s *OffersProcessorTestSuiteLedger) SetupTest() {
 	s.mockLedgerWriter = &io.MockLedgerWriter{}
 
 	s.processor = &DatabaseProcessor{
-		Action:  Offers,
+		Action:  All,
 		OffersQ: s.mockQ,
 	}
 
@@ -133,29 +133,30 @@ func (s *OffersProcessorTestSuiteLedger) TearDownTest() {
 }
 
 func (s *OffersProcessorTestSuiteLedger) TestInsertOffer() {
-	// should be ignored because it's not an offer type
-	s.mockLedgerReader.
-		On("Read").
-		Return(io.LedgerTransaction{
-			Meta: createTransactionMeta([]xdr.OperationMeta{
-				xdr.OperationMeta{
-					Changes: []xdr.LedgerEntryChange{
-						xdr.LedgerEntryChange{
-							Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
-							Created: &xdr.LedgerEntry{
-								Data: xdr.LedgerEntryData{
-									Type: xdr.LedgerEntryTypeAccount,
-									Account: &xdr.AccountEntry{
-										AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-										Thresholds: [4]byte{1, 1, 1, 1},
-									},
+	accountTransaction := io.LedgerTransaction{
+		Meta: createTransactionMeta([]xdr.OperationMeta{
+			xdr.OperationMeta{
+				Changes: []xdr.LedgerEntryChange{
+					xdr.LedgerEntryChange{
+						Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+						Created: &xdr.LedgerEntry{
+							Data: xdr.LedgerEntryData{
+								Type: xdr.LedgerEntryTypeAccount,
+								Account: &xdr.AccountEntry{
+									AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+									Thresholds: [4]byte{1, 1, 1, 1},
 								},
 							},
 						},
 					},
 				},
-			}),
-		}, nil).Once()
+			},
+		}),
+	}
+	// should be ignored because it's not an offer type
+	s.Assert().NoError(
+		s.processor.processLedgerOffers(accountTransaction.GetChanges()[0], 1),
+	)
 
 	// should be ignored because transaction was not successful
 	s.mockLedgerReader.On("Read").

--- a/services/horizon/internal/expingest/processors/offers_processor_test.go
+++ b/services/horizon/internal/expingest/processors/offers_processor_test.go
@@ -330,7 +330,7 @@ func (s *OffersProcessorTestSuiteLedger) TestUpdateOfferNoRowsAffected() {
 
 	s.Assert().Error(err)
 	s.Assert().IsType(verify.StateError{}, errors.Cause(err))
-	s.Assert().EqualError(err, "Error in processLedgerOffers: No rows affected when updating offer 2")
+	s.Assert().EqualError(err, "Error in Offers handler: No rows affected when updating offer 2")
 }
 
 func (s *OffersProcessorTestSuiteLedger) TestRemoveOffer() {
@@ -434,5 +434,5 @@ func (s *OffersProcessorTestSuiteLedger) TestRemoveOfferNoRowsAffected() {
 
 	s.Assert().Error(err)
 	s.Assert().IsType(verify.StateError{}, errors.Cause(err))
-	s.Assert().EqualError(err, "Error in processLedgerOffers: No rows affected when removing offer 3")
+	s.Assert().EqualError(err, "Error in Offers handler: No rows affected when removing offer 3")
 }

--- a/services/horizon/internal/expingest/processors/trust_lines_processor_test.go
+++ b/services/horizon/internal/expingest/processors/trust_lines_processor_test.go
@@ -131,7 +131,7 @@ func (s *TrustLinesProcessorTestSuiteLedger) SetupTest() {
 	s.mockAssetStatsQ = &history.MockQAssetStats{}
 
 	s.processor = &DatabaseProcessor{
-		Action:      TrustLines,
+		Action:      All,
 		TrustLinesQ: s.mockQ,
 		AssetStatsQ: s.mockAssetStatsQ,
 	}
@@ -154,29 +154,30 @@ func (s *TrustLinesProcessorTestSuiteLedger) TearDownTest() {
 }
 
 func (s *TrustLinesProcessorTestSuiteLedger) TestInsertTrustLine() {
-	// should be ignored because it's not an trust line type
-	s.mockLedgerReader.
-		On("Read").
-		Return(io.LedgerTransaction{
-			Meta: createTransactionMeta([]xdr.OperationMeta{
-				xdr.OperationMeta{
-					Changes: []xdr.LedgerEntryChange{
-						xdr.LedgerEntryChange{
-							Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
-							Created: &xdr.LedgerEntry{
-								Data: xdr.LedgerEntryData{
-									Type: xdr.LedgerEntryTypeAccount,
-									Account: &xdr.AccountEntry{
-										AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-										Thresholds: [4]byte{1, 1, 1, 1},
-									},
+	accountTransaction := io.LedgerTransaction{
+		Meta: createTransactionMeta([]xdr.OperationMeta{
+			xdr.OperationMeta{
+				Changes: []xdr.LedgerEntryChange{
+					xdr.LedgerEntryChange{
+						Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+						Created: &xdr.LedgerEntry{
+							Data: xdr.LedgerEntryData{
+								Type: xdr.LedgerEntryTypeAccount,
+								Account: &xdr.AccountEntry{
+									AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+									Thresholds: [4]byte{1, 1, 1, 1},
 								},
 							},
 						},
 					},
 				},
-			}),
-		}, nil).Once()
+			},
+		}),
+	}
+	// should be ignored because it's not an trust line type
+	s.Assert().NoError(
+		s.processor.processLedgerTrustLines(accountTransaction.GetChanges()[0], 1),
+	)
 
 	// should be ignored because transaction was not successful
 	s.mockLedgerReader.On("Read").

--- a/services/horizon/internal/expingest/processors/trust_lines_processor_test.go
+++ b/services/horizon/internal/expingest/processors/trust_lines_processor_test.go
@@ -403,7 +403,7 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestUpdateTrustLineNoRowsAffected()
 
 	s.Assert().Error(err)
 	s.Assert().IsType(verify.StateError{}, errors.Cause(err))
-	s.Assert().EqualError(err, "Error in processLedgerTrustLines: No rows affected when updating trustline: GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB credit_alphanum4/EUR/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	s.Assert().EqualError(err, "Error in TrustLines handler: No rows affected when updating trustline: GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB credit_alphanum4/EUR/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
 }
 
 func (s *TrustLinesProcessorTestSuiteLedger) TestRemoveTrustLine() {
@@ -547,5 +547,5 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestRemoveOfferNoRowsAffected() {
 
 	s.Assert().Error(err)
 	s.Assert().IsType(verify.StateError{}, errors.Cause(err))
-	s.Assert().EqualError(err, "Error in processLedgerTrustLines: No rows affected when removing trustline: GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB credit_alphanum4/EUR/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	s.Assert().EqualError(err, "Error in TrustLines handler: No rows affected when removing trustline: GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB credit_alphanum4/EUR/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

The ingestion pipelines are structured so that all processor nodes in the pipeline tree share the same transaction instance. Sibling processor nodes in the pipeline tree are executed concurrently which means that multiple goroutines end up accessing the shared transaction instance concurrently.

`sql.Tx` is not thread-safe and the concurrent access of `sql.Tx` has resulted in the error described in https://github.com/stellar/go/issues/1836 . The reason this error has only occurred recently is because the error seems to trigger only when there is a sql exec which occurs before a sql query has finished. When we added asset stats to the ingestion system, we introduced code which read from the asset stats table in the DatabaseProcessor. Prior to that, the DatabaseProcessor only submitted sql execs to the shared transaction.

This PR fixes the issue by ensuring there is only one DatabaseProcessor in the ledger pipeline. Therefore, there is only one goroutine accessing the shared transaction.

Note that the state pipeline still has multiple goroutines accessing the shared transaction. However, none of those goroutines are submitting queries to the shared transaction so we are safe for now. Still, it would be good to rewrite the state processor so that either the concurrency is removed or access to the shared transaction is protected by a lock. This change is currently outside the scope of this PR and should be implemented in a separate PR.
