### PR TITLE
support/clock,clients/horizonclient: add a mockable clock

### DIFF
--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -508,8 +508,7 @@ func (c *Client) FetchTimebounds(seconds int64) (txnbuild.Timebounds, error) {
 	if err != nil {
 		return txnbuild.Timebounds{}, errors.Wrap(err, "unable to parse horizon url")
 	}
-	c.setDefaultCurrentUniversalTime()
-	currentTime := currentServerTime(serverURL.Hostname(), c.currentUniversalTime())
+	currentTime := currentServerTime(serverURL.Hostname(), c.clock.Now().UTC().Unix())
 	if currentTime != 0 {
 		return txnbuild.NewTimebounds(0, currentTime+seconds), nil
 	}
@@ -650,21 +649,6 @@ func (c *Client) NextTradeAggregationsPage(page hProtocol.TradeAggregationsPage)
 func (c *Client) PrevTradeAggregationsPage(page hProtocol.TradeAggregationsPage) (ta hProtocol.TradeAggregationsPage, err error) {
 	err = c.sendRequestURL(page.Links.Prev.Href, "get", &ta)
 	return
-}
-
-// setDefaultCurrentUniversalTime sets the currentUniversalTime function for the horizon client if non has been
-// provided to the default function that returns the current UTC time. This is needed when the client is
-// initialised directly.
-func (c *Client) setDefaultCurrentUniversalTime() {
-	if c.currentUniversalTime == nil {
-		c.SetCurrentUniversalTime(universalTimeFunc)
-	}
-}
-
-// SetCurrentUniversalTime sets the currentUniversalTime function to the provided handler function. Users can
-// use this method to set a custom handler function.
-func (c *Client) SetCurrentUniversalTime(handler UniversalTimeHandler) {
-	c.currentUniversalTime = handler
 }
 
 // ensure that the horizon client implements ClientInterface

--- a/clients/horizonclient/internal.go
+++ b/clients/horizonclient/internal.go
@@ -124,8 +124,7 @@ func setCurrentServerTime(host string, serverDate []string, hc *Client) {
 		return
 	}
 	serverTimeMapMutex.Lock()
-	hc.setDefaultCurrentUniversalTime()
-	ServerTimeMap[host] = ServerTimeRecord{ServerTime: st.UTC().Unix(), LocalTimeRecorded: hc.currentUniversalTime()}
+	ServerTimeMap[host] = ServerTimeRecord{ServerTime: st.UTC().Unix(), LocalTimeRecorded: hc.clock.Now().UTC().Unix()}
 	serverTimeMapMutex.Unlock()
 }
 
@@ -144,9 +143,4 @@ func currentServerTime(host string, currentTimeUTC int64) int64 {
 		return 0
 	}
 	return currentTimeUTC - st.LocalTimeRecorded + st.ServerTime
-}
-
-// universalTimeFunc returns the current UTC unix time in seconds.
-var universalTimeFunc = func() int64 {
-	return time.Now().UTC().Unix()
 }

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -21,6 +21,7 @@ import (
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/protocols/horizon/effects"
 	"github.com/stellar/go/protocols/horizon/operations"
+	"github.com/stellar/go/support/clock"
 	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/txnbuild"
 )
@@ -134,8 +135,8 @@ type Client struct {
 	horizonTimeOut time.Duration
 	isTestNet      bool
 
-	// currentUniversalTime is a function that returns the current UTC unix time in seconds.
-	currentUniversalTime UniversalTimeHandler
+	// clock is a Clock returning the current time.
+	clock clock.Clock
 }
 
 // ClientInterface contains methods implemented by the horizon client
@@ -193,19 +194,17 @@ type ClientInterface interface {
 
 // DefaultTestNetClient is a default client to connect to test network.
 var DefaultTestNetClient = &Client{
-	HorizonURL:           "https://horizon-testnet.stellar.org/",
-	HTTP:                 http.DefaultClient,
-	horizonTimeOut:       HorizonTimeOut,
-	isTestNet:            true,
-	currentUniversalTime: universalTimeFunc,
+	HorizonURL:     "https://horizon-testnet.stellar.org/",
+	HTTP:           http.DefaultClient,
+	horizonTimeOut: HorizonTimeOut,
+	isTestNet:      true,
 }
 
 // DefaultPublicNetClient is a default client to connect to public network.
 var DefaultPublicNetClient = &Client{
-	HorizonURL:           "https://horizon.stellar.org/",
-	HTTP:                 http.DefaultClient,
-	horizonTimeOut:       HorizonTimeOut,
-	currentUniversalTime: universalTimeFunc,
+	HorizonURL:     "https://horizon.stellar.org/",
+	HTTP:           http.DefaultClient,
+	horizonTimeOut: HorizonTimeOut,
 }
 
 // HorizonRequest contains methods implemented by request structs for horizon endpoints.

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -136,7 +136,7 @@ type Client struct {
 	isTestNet      bool
 
 	// clock is a Clock returning the current time.
-	clock clock.Clock
+	clock *clock.Clock
 }
 
 // ClientInterface contains methods implemented by the horizon client

--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/protocols/horizon/effects"
 	"github.com/stellar/go/protocols/horizon/operations"
+	"github.com/stellar/go/support/clock/clocktest"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/http/httptest"
 	"github.com/stellar/go/txnbuild"
@@ -1021,12 +1023,8 @@ func TestFetchTimebounds(t *testing.T) {
 	client := &Client{
 		HorizonURL: "https://localhost/",
 		HTTP:       hmock,
+		clock:      clocktest.NewFixed(time.Unix(1560947096, 0)),
 	}
-
-	// mock currentUniversalTime
-	client.SetCurrentUniversalTime(func() int64 {
-		return int64(1560947096)
-	})
 
 	// When no saved server time, return local time
 	st, err := client.FetchTimebounds(100)
@@ -1055,7 +1053,7 @@ func TestFetchTimebounds(t *testing.T) {
 	}
 
 	// mock server time
-	newRecord := ServerTimeRecord{ServerTime: 100, LocalTimeRecorded: client.currentUniversalTime()}
+	newRecord := ServerTimeRecord{ServerTime: 100, LocalTimeRecorded: 1560947096}
 	ServerTimeMap["localhost"] = newRecord
 	st, err = client.FetchTimebounds(100)
 	assert.NoError(t, err)

--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -1024,7 +1024,7 @@ func TestFetchTimebounds(t *testing.T) {
 	client := &Client{
 		HorizonURL: "https://localhost/",
 		HTTP:       hmock,
-		clock: clock.Clock{
+		clock: &clock.Clock{
 			Source: clocktest.FixedSource(time.Unix(1560947096, 0)),
 		},
 	}

--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -9,6 +9,7 @@ import (
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/protocols/horizon/effects"
 	"github.com/stellar/go/protocols/horizon/operations"
+	"github.com/stellar/go/support/clock"
 	"github.com/stellar/go/support/clock/clocktest"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/http/httptest"
@@ -1023,7 +1024,9 @@ func TestFetchTimebounds(t *testing.T) {
 	client := &Client{
 		HorizonURL: "https://localhost/",
 		HTTP:       hmock,
-		clock:      clocktest.NewFixed(time.Unix(1560947096, 0)),
+		clock: clock.Clock{
+			Source: clocktest.FixedSource(time.Unix(1560947096, 0)),
+		},
 	}
 
 	// When no saved server time, return local time

--- a/support/clock/clocktest/fixed.go
+++ b/support/clock/clocktest/fixed.go
@@ -8,7 +8,7 @@ import (
 // a specific time.
 type FixedSource time.Time
 
-// Now returns the fixed sources constant time.
+// Now returns the fixed source's constant time.
 func (s FixedSource) Now() time.Time {
 	return time.Time(s)
 }

--- a/support/clock/clocktest/fixed.go
+++ b/support/clock/clocktest/fixed.go
@@ -1,0 +1,21 @@
+package clocktest
+
+import (
+	"time"
+
+	"github.com/stellar/go/support/clock"
+)
+
+type fixedSource time.Time
+
+func (s fixedSource) Now() time.Time {
+	return time.Time(s)
+}
+
+// NewFixed creates a Clock with its time stopped and fixed to the time
+// given.
+func NewFixed(t time.Time) clock.Clock {
+	return clock.Clock{
+		Source: fixedSource(t),
+	}
+}

--- a/support/clock/clocktest/fixed.go
+++ b/support/clock/clocktest/fixed.go
@@ -2,20 +2,13 @@ package clocktest
 
 import (
 	"time"
-
-	"github.com/stellar/go/support/clock"
 )
 
-type fixedSource time.Time
+// FixedSource is a clock source that has its current time stopped and fixed at
+// a specific time.
+type FixedSource time.Time
 
-func (s fixedSource) Now() time.Time {
+// Now returns the fixed sources constant time.
+func (s FixedSource) Now() time.Time {
 	return time.Time(s)
-}
-
-// NewFixed creates a Clock with its time stopped and fixed to the time
-// given.
-func NewFixed(t time.Time) clock.Clock {
-	return clock.Clock{
-		Source: fixedSource(t),
-	}
 }

--- a/support/clock/clocktest/fixed_test.go
+++ b/support/clock/clocktest/fixed_test.go
@@ -17,7 +17,8 @@ func TestFixedSource_Now(t *testing.T) {
 	assert.Equal(t, timeNow, c.Now())
 }
 
-// TestNewFixed_compose tests that FixedSource can be used to change time.
+// TestNewFixed_compose tests that FixedSource can be used easily to change
+// time during a test.
 func TestFixedSource_compose(t *testing.T) {
 	timeNow := time.Date(2015, 9, 30, 17, 15, 54, 0, time.UTC)
 	c := clock.Clock{Source: clocktest.FixedSource(timeNow)}

--- a/support/clock/clocktest/fixed_test.go
+++ b/support/clock/clocktest/fixed_test.go
@@ -1,16 +1,27 @@
-package clocktest
+package clocktest_test
 
 import (
 	"testing"
 	"time"
 
+	"github.com/stellar/go/support/clock"
+	"github.com/stellar/go/support/clock/clocktest"
 	"github.com/stretchr/testify/assert"
 )
 
 // TestNewFixed tests that the time returned from the fixed clocks Now()
 // function is equal to the time given when creating the clock.
-func TestNewFixed(t *testing.T) {
+func TestFixedSource_Now(t *testing.T) {
 	timeNow := time.Date(2015, 9, 30, 17, 15, 54, 0, time.UTC)
-	c := NewFixed(timeNow)
+	c := clock.Clock{Source: clocktest.FixedSource(timeNow)}
 	assert.Equal(t, timeNow, c.Now())
+}
+
+// TestNewFixed_compose tests that FixedSource can be used to change time.
+func TestFixedSource_compose(t *testing.T) {
+	timeNow := time.Date(2015, 9, 30, 17, 15, 54, 0, time.UTC)
+	c := clock.Clock{Source: clocktest.FixedSource(timeNow)}
+	assert.Equal(t, timeNow, c.Now())
+	c.Source = clocktest.FixedSource(timeNow.AddDate(0, 0, 1))
+	assert.Equal(t, timeNow.AddDate(0, 0, 1), c.Now())
 }

--- a/support/clock/clocktest/fixed_test.go
+++ b/support/clock/clocktest/fixed_test.go
@@ -11,6 +11,6 @@ import (
 // function is equal to the time given when creating the clock.
 func TestNewFixed(t *testing.T) {
 	timeNow := time.Date(2015, 9, 30, 17, 15, 54, 0, time.UTC)
-	fs := NewFixed(timeNow)
-	assert.Equal(t, timeNow, fs.Now())
+	c := NewFixed(timeNow)
+	assert.Equal(t, timeNow, c.Now())
 }

--- a/support/clock/clocktest/fixed_test.go
+++ b/support/clock/clocktest/fixed_test.go
@@ -1,0 +1,16 @@
+package clocktest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewFixed tests that the time returned from the fixed clocks Now()
+// function is equal to the time given when creating the clock.
+func TestNewFixed(t *testing.T) {
+	timeNow := time.Date(2015, 9, 30, 17, 15, 54, 0, time.UTC)
+	fs := NewFixed(timeNow)
+	assert.Equal(t, timeNow, fs.Now())
+}

--- a/support/clock/main.go
+++ b/support/clock/main.go
@@ -1,0 +1,35 @@
+package clock
+
+import "time"
+
+// Clock provides access to the current time from an underlying source.
+type Clock struct {
+	Source Source
+}
+
+func (c Clock) getSource() Source {
+	if c.Source == nil {
+		return RealSource{}
+	}
+	return c.Source
+}
+
+// Now returns the current time as defined by the Clock's Source.
+func (c Clock) Now() time.Time {
+	return c.getSource().Now()
+}
+
+// Source is any type providing a Now function that returns the current time.
+type Source interface {
+	// Now returns the current time.
+	Now() time.Time
+}
+
+// RealSource is a Source that uses the real time as provided by the stdlib
+// time.Now() function as the current time.
+type RealSource struct{}
+
+// Now returns the real system time as reported by time.Now().
+func (RealSource) Now() time.Time {
+	return time.Now()
+}

--- a/support/clock/main.go
+++ b/support/clock/main.go
@@ -7,15 +7,15 @@ type Clock struct {
 	Source Source
 }
 
-func (c Clock) getSource() Source {
-	if c.Source == nil {
+func (c *Clock) getSource() Source {
+	if c == nil || c.Source == nil {
 		return RealSource{}
 	}
 	return c.Source
 }
 
 // Now returns the current time as defined by the Clock's Source.
-func (c Clock) Now() time.Time {
+func (c *Clock) Now() time.Time {
 	return c.getSource().Now()
 }
 

--- a/support/clock/main_test.go
+++ b/support/clock/main_test.go
@@ -1,0 +1,32 @@
+package clock_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stellar/go/support/clock"
+	"github.com/stellar/go/support/clock/clocktest"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestClock_Now_sourceNotSet tests that when the Source field is not set that
+// the real time is used when the Clock is asked for the current time.
+func TestClock_Now_sourceNotSet(t *testing.T) {
+	c := clock.Clock{}
+	before := time.Now()
+	cNow := c.Now()
+	after := time.Now()
+	assert.True(t, cNow.After(before))
+	assert.True(t, cNow.Before(after))
+}
+
+// TestClock_Now_sourceSet tests that when the Source field is set that it is
+// used when the Clock is asked for the current time.
+func TestClock_Now_sourceSet(t *testing.T) {
+	timeNow := time.Date(2015, 9, 30, 17, 15, 54, 0, time.UTC)
+	c := clock.Clock{
+		Source: clocktest.NewFixed(timeNow),
+	}
+	cNow := c.Now()
+	assert.Equal(t, timeNow, cNow)
+}

--- a/support/clock/main_test.go
+++ b/support/clock/main_test.go
@@ -25,7 +25,7 @@ func TestClock_Now_sourceNotSet(t *testing.T) {
 func TestClock_Now_sourceSet(t *testing.T) {
 	timeNow := time.Date(2015, 9, 30, 17, 15, 54, 0, time.UTC)
 	c := clock.Clock{
-		Source: clocktest.NewFixed(timeNow),
+		Source: clocktest.FixedSource(timeNow),
 	}
 	cNow := c.Now()
 	assert.Equal(t, timeNow, cNow)

--- a/support/clock/main_test.go
+++ b/support/clock/main_test.go
@@ -20,6 +20,17 @@ func TestClock_Now_sourceNotSet(t *testing.T) {
 	assert.True(t, cNow.Before(after))
 }
 
+// TestClock_Now_sourceNotSetPtrNil tests that when the identifier is a
+// unset/nil pointer to a Clock, it still has default behavior.
+func TestClock_Now_sourceNotSetPtrNil(t *testing.T) {
+	c := (*clock.Clock)(nil)
+	before := time.Now()
+	cNow := c.Now()
+	after := time.Now()
+	assert.True(t, cNow.After(before))
+	assert.True(t, cNow.Before(after))
+}
+
 // TestClock_Now_sourceSet tests that when the Source field is set that it is
 // used when the Clock is asked for the current time.
 func TestClock_Now_sourceSet(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Add a mockable `Clock` type that by default uses real time (`time.Now()`) for the current time, but supports wrapping any other source of time.

Default clock:

```go
clock := clock.Clock{}
clock.Now()
```

Mockable with a fixed clock:
```go
source := clocktest.FixedSource(time.Date(2015, 9, 30, 17, 15, 54, 0, time.UTC))
clock := clock.Clock{Source: source}
clock.Now() // 2015-09-30 17:15:54 +0000 UTC
```

Mockable with additional implementations if we need:
```go
type OtherSource struct {
	...
}
func (os OtherSource) Now() time.Time {
	return ...
}
source := OffsetSource{...}
clock := clock.Clock{Source: source}
clock.Now()
```

### Goal and scope

In #1675 we identified a need to mock time when tests were flakey because of `time.Now()` usage in code and test logic that assumed that the return value of `time.Now()` didn't change significantly between test start and finish. We have other places in the code where we've used time.Now that will be difficult to test reliably and we're likely to have more. In new code we write or old code we want to add tests we can use `Clock` in place of it and then easily change what the current time is while the code runs. The `Source` interface allows a tester to write any clock implementation they need. The fact that `Clock` is a type with default behavior makes it easy to insert into existing code and removes the chance that we forget to initialize it in production code.

Many implementations of clocks are typically only an interface. But it might be difficult to insert an interface into our code safely. If we add only a clock interface that requires being set it is a breaking change. We'd need to check that it is set at every call site and fallback to a default value if it isn't set at that point. Using the `Clock` struct that contains the default behavior addresses that problem without having to set default checks throughout code.

Closes #1717.

### Summary of changes

- Add `clock` and `clocktest` packages.
- Use them in `clients/horizonclient` where the logic was previously added in #1675.

### Known limitations & issues

N/A

### What shouldn't be reviewed

N/A