### PR TITLE
services/horizon/internal, services/horizon/internal/expingest: Ingestion readiness check

### DIFF
--- a/services/horizon/internal/actions/account_test.go
+++ b/services/horizon/internal/actions/account_test.go
@@ -101,4 +101,27 @@ func TestGetAccountsHandlerPageResults(t *testing.T) {
 		tt.Assert.Equal(row.Signer, result.Signer.Key)
 		tt.Assert.Equal(row.Weight, result.Signer.Weight)
 	}
+
+	records, err = handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t,
+			map[string]string{
+				"signer": "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
+				"cursor": "GABGMPEKKDWR2WFH5AJOZV5PDKLJEHGCR3Q24ALETWR5H3A7GI3YTS7V",
+			},
+			map[string]string{},
+			q.Session,
+		),
+	)
+
+	tt.Assert.NoError(err)
+	tt.Assert.Equal(2, len(records))
+
+	for i, row := range rows[1:] {
+		result := records[i].(protocol.AccountSigner)
+		tt.Assert.Equal(row.Account, result.AccountID)
+		tt.Assert.Equal(row.Signer, result.Signer.Key)
+		tt.Assert.Equal(row.Weight, result.Signer.Weight)
+	}
 }

--- a/services/horizon/internal/actions_account_test.go
+++ b/services/horizon/internal/actions_account_test.go
@@ -2,12 +2,9 @@ package horizon
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/stellar/go/protocols/horizon"
-	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/services/horizon/internal/render/problem"
 )
 
 func TestAccountActions_Show(t *testing.T) {
@@ -78,34 +75,4 @@ func TestAccountActions_InvalidID(t *testing.T) {
 		"/accounts/=cr%FF%98%CB%F3%AF%E72%D85%FE%28%15y%8Fz%C4Ng%CE%98h%02%2A:%B6%FF%B9%CF%92%88O%91%10d&S%7C%9Bi%D4%CFI%28%CFo",
 	)
 	ht.Assert.Equal(400, w.Code)
-}
-
-func TestAccountActionsStillIngesting_Index(t *testing.T) {
-	ht := StartHTTPTest(t, "base")
-	ht.App.config.EnableExperimentalIngestion = true
-
-	defer ht.Finish()
-	q := &history.Q{ht.HorizonSession()}
-	ht.Assert.NoError(q.UpdateLastLedgerExpIngest(0))
-
-	w := ht.Get("/accounts?signer=GDBAPLDCAEJV6LSEDFEAUDAVFYSNFRUYZ4X75YYJJMMX5KFVUOHX46SQ")
-	ht.Assert.Equal(problem.StillIngesting.Status, w.Code)
-}
-
-func TestAccountActions_Index(t *testing.T) {
-	ht := StartHTTPTest(t, "base")
-	ht.App.config.EnableExperimentalIngestion = true
-
-	defer ht.Finish()
-	q := &history.Q{ht.HorizonSession()}
-	ht.Assert.NoError(q.UpdateLastLedgerExpIngest(3))
-
-	w := ht.Get("/accounts?cursor=GDRREYWHQWJDICNH4SAH4TT2JRBYRPTDYIMLK4UWBDT3X3ZVVYT6I4UQ&limit=10&order=asc&signer=GDRREYWHQWJDICNH4SAH4TT2JRBYRPTDYIMLK4UWBDT3X3ZVVYT6I4UQ")
-
-	fmt.Println(w.Body.String())
-	if ht.Assert.Equal(200, w.Code) {
-		records := []horizon.AccountSigner{}
-		ht.UnmarshalPage(w.Body, &records)
-		ht.Assert.Len(records, 0)
-	}
 }

--- a/services/horizon/internal/actions_path_test.go
+++ b/services/horizon/internal/actions_path_test.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/go-chi/chi"
 	"github.com/stellar/go/exp/orderbook"
@@ -41,7 +40,19 @@ func inMemoryPathFindingClient(
 		coreQ:                &core.Q{tt.CoreSession()},
 	}
 
-	installPathFindingRoutes(findPaths, findFixedPaths, router, false)
+	installPathFindingRoutes(
+		findPaths,
+		findFixedPaths,
+		router,
+		false,
+		&ExperimentalIngestionMiddleware{
+			EnableExperimentalIngestion: true,
+			HorizonSession:              tt.HorizonSession(),
+			Ready: func() bool {
+				return true
+			},
+		},
+	)
 	return test.NewRequestHelper(router)
 }
 
@@ -67,7 +78,19 @@ func dbPathFindingClient(
 		coreQ:                &core.Q{tt.CoreSession()},
 	}
 
-	installPathFindingRoutes(findPaths, findFixedPaths, router, false)
+	installPathFindingRoutes(
+		findPaths,
+		findFixedPaths,
+		router,
+		false,
+		&ExperimentalIngestionMiddleware{
+			EnableExperimentalIngestion: false,
+			HorizonSession:              tt.HorizonSession(),
+			Ready: func() bool {
+				return false
+			},
+		},
+	)
 	return test.NewRequestHelper(router)
 }
 
@@ -145,38 +168,6 @@ func TestPathActionsStillIngesting(t *testing.T) {
 		assertions.Problem(w.Body, horizonProblem.StillIngesting)
 		assertions.Equal("", w.Header().Get(actions.LastLedgerHeaderName))
 	}
-}
-
-func TestPathActionsStateInvalid(t *testing.T) {
-	rh := StartHTTPTest(t, "paths")
-	defer rh.Finish()
-
-	rh.App.config.EnableExperimentalIngestion = true
-	rh.App.web.router = chi.NewRouter()
-	orderBookGraph := orderbook.NewOrderBookGraph()
-	rh.App.web.mustInstallMiddlewares(rh.App, time.Minute)
-	rh.App.web.mustInstallActions(
-		rh.App.config,
-		simplepath.NewInMemoryFinder(orderBookGraph),
-		orderBookGraph,
-	)
-	rh.RH = test.NewRequestHelper(rh.App.web.router)
-
-	w := rh.Get("/paths")
-	// Still ingesting
-	rh.Assert.Equal(503, w.Code)
-	rh.Assert.Equal("", w.Header().Get(actions.LastLedgerHeaderName))
-
-	err := rh.App.historyQ.UpdateLastLedgerExpIngest(10)
-	rh.Assert.NoError(err)
-
-	err = rh.App.historyQ.UpdateExpStateInvalid(true)
-	rh.Assert.NoError(err)
-
-	w = rh.Get("/paths")
-	// State invalid
-	rh.Assert.Equal(500, w.Code)
-	rh.Assert.Equal("", w.Header().Get(actions.LastLedgerHeaderName))
 }
 
 func loadOffers(

--- a/services/horizon/internal/actions_path_test.go
+++ b/services/horizon/internal/actions_path_test.go
@@ -48,7 +48,7 @@ func inMemoryPathFindingClient(
 		&ExperimentalIngestionMiddleware{
 			EnableExperimentalIngestion: true,
 			HorizonSession:              tt.HorizonSession(),
-			Ready: func() bool {
+			StateReady: func() bool {
 				return true
 			},
 		},
@@ -86,7 +86,7 @@ func dbPathFindingClient(
 		&ExperimentalIngestionMiddleware{
 			EnableExperimentalIngestion: false,
 			HorizonSession:              tt.HorizonSession(),
-			Ready: func() bool {
+			StateReady: func() bool {
 				return false
 			},
 		},

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -428,8 +428,18 @@ func (a *App) init() {
 	// This parameter will be removed soon.
 	a.web.mustInstallMiddlewares(a, a.config.ConnectionTimeout)
 
+	requiresExperimentalIngestion := &ExperimentalIngestionMiddleware{
+		EnableExperimentalIngestion: a.config.EnableExperimentalIngestion,
+		HorizonSession:              a.historyQ.Session,
+		Ready: func() bool {
+			if !a.config.EnableExperimentalIngestion {
+				return false
+			}
+			return a.expingester.Ready()
+		},
+	}
 	// web.actions
-	a.web.mustInstallActions(a.config, a.paths, orderBookGraph)
+	a.web.mustInstallActions(a.config, a.paths, orderBookGraph, requiresExperimentalIngestion)
 
 	// metrics and log.metrics
 	a.metrics = metrics.NewRegistry()

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -431,11 +431,11 @@ func (a *App) init() {
 	requiresExperimentalIngestion := &ExperimentalIngestionMiddleware{
 		EnableExperimentalIngestion: a.config.EnableExperimentalIngestion,
 		HorizonSession:              a.historyQ.Session,
-		Ready: func() bool {
+		StateReady: func() bool {
 			if !a.config.EnableExperimentalIngestion {
 				return false
 			}
-			return a.expingester.Ready()
+			return a.expingester.StateReady()
 		},
 	}
 	// web.actions

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -6,6 +6,7 @@ package expingest
 import (
 	"runtime/debug"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/stellar/go/clients/stellarcore"
@@ -85,6 +86,7 @@ type System struct {
 	historySession dbSession
 	graph          *orderbook.OrderBookGraph
 	retry          retry
+	ready          int32
 
 	// stateVerificationRunning is true when verification routine is currently
 	// running.
@@ -350,6 +352,11 @@ func (s *System) resumeFromLedger(lastIngestedLedger uint32) {
 		log.Info("Session shut down")
 		return nil
 	})
+}
+
+// Ready returns true if the ingestion system has finished running it's state pipelines
+func (s *System) Ready() bool {
+	return atomic.LoadInt32(&s.ready) > 0
 }
 
 func (s *System) Shutdown() {

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -6,7 +6,6 @@ package expingest
 import (
 	"runtime/debug"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/stellar/go/clients/stellarcore"
@@ -86,7 +85,8 @@ type System struct {
 	historySession dbSession
 	graph          *orderbook.OrderBookGraph
 	retry          retry
-	ready          int32
+	stateReady     bool
+	stateReadyLock sync.RWMutex
 
 	// stateVerificationRunning is true when verification routine is currently
 	// running.
@@ -354,9 +354,17 @@ func (s *System) resumeFromLedger(lastIngestedLedger uint32) {
 	})
 }
 
-// Ready returns true if the ingestion system has finished running it's state pipelines
-func (s *System) Ready() bool {
-	return atomic.LoadInt32(&s.ready) > 0
+// StateReady returns true if the ingestion system has finished running it's state pipelines
+func (s *System) StateReady() bool {
+	s.stateReadyLock.RLock()
+	defer s.stateReadyLock.RUnlock()
+	return s.stateReady
+}
+
+func (s *System) setStateReady() {
+	s.stateReadyLock.Lock()
+	defer s.stateReadyLock.Unlock()
+	s.stateReady = true
 }
 
 func (s *System) Shutdown() {

--- a/services/horizon/internal/expingest/pipeline_hooks_test.go
+++ b/services/horizon/internal/expingest/pipeline_hooks_test.go
@@ -35,7 +35,7 @@ func TestStatePreProcessingHook(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.NotNil(session.GetTx())
 	tt.Assert.Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
-	tt.Assert.False(system.Ready())
+	tt.Assert.False(system.StateReady())
 
 	tt.Assert.Nil(session.Rollback())
 	tt.Assert.Nil(session.GetTx())
@@ -47,7 +47,7 @@ func TestStatePreProcessingHook(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.NotNil(session.GetTx())
 	tt.Assert.Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
-	tt.Assert.False(system.Ready())
+	tt.Assert.False(system.StateReady())
 }
 
 func TestLedgerPreProcessingHook(t *testing.T) {
@@ -71,12 +71,12 @@ func TestLedgerPreProcessingHook(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.NotNil(session.GetTx())
 	tt.Assert.Equal(newCtx.Value(horizonProcessors.IngestUpdateDatabase), true)
-	tt.Assert.True(system.Ready())
+	tt.Assert.True(system.StateReady())
 
 	tt.Assert.Nil(session.Rollback())
 	tt.Assert.Nil(session.GetTx())
-	system.ready = 0
-	tt.Assert.False(system.Ready())
+	system.stateReady = false
+	tt.Assert.False(system.StateReady())
 
 	tt.Assert.Nil(session.Begin())
 	tt.Assert.NotNil(session.GetTx())
@@ -84,30 +84,30 @@ func TestLedgerPreProcessingHook(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.NotNil(session.GetTx())
 	tt.Assert.Equal(newCtx.Value(horizonProcessors.IngestUpdateDatabase), true)
-	tt.Assert.True(system.Ready())
+	tt.Assert.True(system.StateReady())
 
 	tt.Assert.Nil(session.Rollback())
 	tt.Assert.Nil(session.GetTx())
-	system.ready = 0
-	tt.Assert.False(system.Ready())
+	system.stateReady = false
+	tt.Assert.False(system.StateReady())
 
 	tt.Assert.Nil(historyQ.UpdateLastLedgerExpIngest(2))
 	newCtx, err = preProcessingHook(ctx, pipelineType, system, session)
 	tt.Assert.NoError(err)
 	tt.Assert.Nil(session.GetTx())
 	tt.Assert.Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
-	tt.Assert.True(system.Ready())
+	tt.Assert.True(system.StateReady())
 
 	tt.Assert.Nil(session.Begin())
 	tt.Assert.NotNil(session.GetTx())
-	system.ready = 0
-	tt.Assert.False(system.Ready())
+	system.stateReady = false
+	tt.Assert.False(system.StateReady())
 
 	newCtx, err = preProcessingHook(ctx, pipelineType, system, session)
 	tt.Assert.NoError(err)
 	tt.Assert.Nil(session.GetTx())
 	tt.Assert.Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
-	tt.Assert.True(system.Ready())
+	tt.Assert.True(system.StateReady())
 }
 
 func TestPostProcessingHook(t *testing.T) {

--- a/services/horizon/internal/expingest/pipeline_hooks_test.go
+++ b/services/horizon/internal/expingest/pipeline_hooks_test.go
@@ -18,6 +18,7 @@ func TestStatePreProcessingHook(t *testing.T) {
 	tt := test.Start(t).Scenario("base")
 	defer tt.Finish()
 
+	system := &System{}
 	session := tt.HorizonSession()
 	defer session.Rollback()
 	ctx := context.WithValue(
@@ -30,10 +31,11 @@ func TestStatePreProcessingHook(t *testing.T) {
 	tt.Assert.Nil(historyQ.UpdateLastLedgerExpIngest(0))
 
 	tt.Assert.Nil(session.GetTx())
-	newCtx, err := preProcessingHook(ctx, pipelineType, session)
+	newCtx, err := preProcessingHook(ctx, pipelineType, system, session)
 	tt.Assert.NoError(err)
 	tt.Assert.NotNil(session.GetTx())
 	tt.Assert.Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
+	tt.Assert.False(system.Ready())
 
 	tt.Assert.Nil(session.Rollback())
 	tt.Assert.Nil(session.GetTx())
@@ -41,16 +43,18 @@ func TestStatePreProcessingHook(t *testing.T) {
 	tt.Assert.Nil(session.Begin())
 	tt.Assert.NotNil(session.GetTx())
 
-	newCtx, err = preProcessingHook(ctx, pipelineType, session)
+	newCtx, err = preProcessingHook(ctx, pipelineType, system, session)
 	tt.Assert.NoError(err)
 	tt.Assert.NotNil(session.GetTx())
 	tt.Assert.Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
+	tt.Assert.False(system.Ready())
 }
 
 func TestLedgerPreProcessingHook(t *testing.T) {
 	tt := test.Start(t).Scenario("base")
 	defer tt.Finish()
 
+	system := &System{}
 	session := tt.HorizonSession()
 	defer session.Rollback()
 	ctx := context.WithValue(
@@ -63,36 +67,47 @@ func TestLedgerPreProcessingHook(t *testing.T) {
 	tt.Assert.Nil(historyQ.UpdateLastLedgerExpIngest(1))
 
 	tt.Assert.Nil(session.GetTx())
-	newCtx, err := preProcessingHook(ctx, pipelineType, session)
+	newCtx, err := preProcessingHook(ctx, pipelineType, system, session)
 	tt.Assert.NoError(err)
 	tt.Assert.NotNil(session.GetTx())
 	tt.Assert.Equal(newCtx.Value(horizonProcessors.IngestUpdateDatabase), true)
+	tt.Assert.True(system.Ready())
 
 	tt.Assert.Nil(session.Rollback())
 	tt.Assert.Nil(session.GetTx())
+	system.ready = 0
+	tt.Assert.False(system.Ready())
 
 	tt.Assert.Nil(session.Begin())
 	tt.Assert.NotNil(session.GetTx())
-	newCtx, err = preProcessingHook(ctx, pipelineType, session)
+	newCtx, err = preProcessingHook(ctx, pipelineType, system, session)
 	tt.Assert.NoError(err)
 	tt.Assert.NotNil(session.GetTx())
 	tt.Assert.Equal(newCtx.Value(horizonProcessors.IngestUpdateDatabase), true)
+	tt.Assert.True(system.Ready())
 
 	tt.Assert.Nil(session.Rollback())
 	tt.Assert.Nil(session.GetTx())
+	system.ready = 0
+	tt.Assert.False(system.Ready())
 
 	tt.Assert.Nil(historyQ.UpdateLastLedgerExpIngest(2))
-	newCtx, err = preProcessingHook(ctx, pipelineType, session)
+	newCtx, err = preProcessingHook(ctx, pipelineType, system, session)
 	tt.Assert.NoError(err)
 	tt.Assert.Nil(session.GetTx())
 	tt.Assert.Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
+	tt.Assert.True(system.Ready())
 
 	tt.Assert.Nil(session.Begin())
 	tt.Assert.NotNil(session.GetTx())
-	newCtx, err = preProcessingHook(ctx, pipelineType, session)
+	system.ready = 0
+	tt.Assert.False(system.Ready())
+
+	newCtx, err = preProcessingHook(ctx, pipelineType, system, session)
 	tt.Assert.NoError(err)
 	tt.Assert.Nil(session.GetTx())
 	tt.Assert.Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
+	tt.Assert.True(system.Ready())
 }
 
 func TestPostProcessingHook(t *testing.T) {

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -3,7 +3,6 @@ package expingest
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
 
 	"github.com/stellar/go/exp/ingest"
 	"github.com/stellar/go/exp/ingest/pipeline"
@@ -166,7 +165,7 @@ func preProcessingHook(
 	} else {
 		// mark the system as ready because we have progressed to running
 		// the ledger pipeline
-		atomic.StoreInt32(&system.ready, 1)
+		system.setStateReady()
 
 		if lastIngestedLedger+1 == ledgerSeq {
 			// lastIngestedLedger+1 == ledgerSeq what means that this instance

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -3,6 +3,7 @@ package expingest
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/stellar/go/exp/ingest"
 	"github.com/stellar/go/exp/ingest/pipeline"
@@ -132,6 +133,7 @@ func buildLedgerPipeline(historyQ *history.Q, graph *orderbook.OrderBookGraph) *
 func preProcessingHook(
 	ctx context.Context,
 	pipelineType pType,
+	system *System,
 	historySession *db.Session,
 ) (context.Context, error) {
 	historyQ := &history.Q{historySession}
@@ -162,6 +164,10 @@ func preProcessingHook(
 		// from a database is done outside the pipeline.
 		updateDatabase = true
 	} else {
+		// mark the system as ready because we have progressed to running
+		// the ledger pipeline
+		atomic.StoreInt32(&system.ready, 1)
+
 		if lastIngestedLedger+1 == ledgerSeq {
 			// lastIngestedLedger+1 == ledgerSeq what means that this instance
 			// is the main ingesting instance in this round and should update a
@@ -309,7 +315,7 @@ func addPipelineHooks(
 	}
 
 	p.AddPreProcessingHook(func(ctx context.Context) (context.Context, error) {
-		return preProcessingHook(ctx, pipelineType, historySession)
+		return preProcessingHook(ctx, pipelineType, system, historySession)
 	})
 
 	p.AddPostProcessingHook(func(ctx context.Context, err error) error {

--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -219,7 +219,7 @@ func acceptOnlyJSON(h http.Handler) http.Handler {
 type ExperimentalIngestionMiddleware struct {
 	EnableExperimentalIngestion bool
 	HorizonSession              *db.Session
-	Ready                       func() bool
+	StateReady                  func() bool
 }
 
 // Wrap executes the middleware on a given http handler
@@ -228,6 +228,12 @@ func (m *ExperimentalIngestionMiddleware) Wrap(h http.Handler) http.Handler {
 		ctx := r.Context()
 		if !m.EnableExperimentalIngestion {
 			problem.Render(r.Context(), w, problem.NotFound)
+			return
+		}
+
+		// expingest has not finished processing any ledger so no data.
+		if !m.StateReady() {
+			problem.Render(r.Context(), w, hProblem.StillIngesting)
 			return
 		}
 
@@ -244,12 +250,6 @@ func (m *ExperimentalIngestionMiddleware) Wrap(h http.Handler) http.Handler {
 			return
 		}
 		defer repeatableReadSession.Rollback()
-
-		// expingest has not finished processing any ledger so no data.
-		if !m.Ready() {
-			problem.Render(r.Context(), w, hProblem.StillIngesting)
-			return
-		}
 
 		q := &history.Q{repeatableReadSession}
 		stateInvalid, err := q.GetExpStateInvalid()

--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/httpx"
 	"github.com/stellar/go/services/horizon/internal/render"
 	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
+	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/problem"
 )
@@ -210,22 +211,29 @@ func acceptOnlyJSON(h http.Handler) http.Handler {
 	})
 }
 
-// requiresExperimentalIngestion is a middleware which enables a handler
+// ExperimentalIngestionMiddleware is a middleware which enables a handler
 // if the experimental ingestion system is enabled and initialized.
 // It also ensures that state (ledger entries) has been verified and are
 // correct. Otherwise returns `500 Internal Server Error` to prevent
 // returning invalid data to the user.
-func requiresExperimentalIngestion(h http.Handler) http.Handler {
+type ExperimentalIngestionMiddleware struct {
+	EnableExperimentalIngestion bool
+	HorizonSession              *db.Session
+	Ready                       func() bool
+}
+
+// Wrap executes the middleware on a given http handler
+func (m *ExperimentalIngestionMiddleware) Wrap(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		app := AppFromContext(ctx)
-		if !app.config.EnableExperimentalIngestion {
+		if !m.EnableExperimentalIngestion {
 			problem.Render(r.Context(), w, problem.NotFound)
 			return
 		}
 
 		localLog := log.Ctx(ctx)
-		repeatableReadSession := app.HorizonSession(r.Context())
+		repeatableReadSession := m.HorizonSession.Clone()
+		repeatableReadSession.Ctx = r.Context()
 		err := repeatableReadSession.BeginTx(&sql.TxOptions{
 			Isolation: sql.LevelRepeatableRead,
 			ReadOnly:  true,
@@ -237,33 +245,32 @@ func requiresExperimentalIngestion(h http.Handler) http.Handler {
 		}
 		defer repeatableReadSession.Rollback()
 
-		q := &history.Q{repeatableReadSession}
-		lastIngestedLedger, err := q.GetLastLedgerExpIngestNonBlocking()
-		if err != nil {
-			localLog.WithField("err", err).Error("Error running GetLastLedgerExpIngestNonBlocking")
-			problem.Render(r.Context(), w, err)
-			return
-		}
-
 		// expingest has not finished processing any ledger so no data.
-		if lastIngestedLedger == 0 {
+		if !m.Ready() {
 			problem.Render(r.Context(), w, hProblem.StillIngesting)
 			return
 		}
 
+		q := &history.Q{repeatableReadSession}
 		stateInvalid, err := q.GetExpStateInvalid()
 		if err != nil {
 			localLog.WithField("err", err).Error("Error running GetExpStateInvalid")
 			problem.Render(r.Context(), w, err)
 			return
 		}
-
 		if stateInvalid {
 			problem.Render(r.Context(), w, problem.ServerError)
 			return
 		}
 
+		lastIngestedLedger, err := q.GetLastLedgerExpIngestNonBlocking()
+		if err != nil {
+			localLog.WithField("err", err).Error("Error running GetLastLedgerExpIngestNonBlocking")
+			problem.Render(r.Context(), w, err)
+			return
+		}
 		actions.SetLastLedgerHeader(w, lastIngestedLedger)
+
 		h.ServeHTTP(w, r.WithContext(
 			context.WithValue(
 				r.Context(),

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -153,20 +153,11 @@ func TestRateLimit_Redis(t *testing.T) {
 func TestRequiresExperimentalIngestion(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
-
 	test.ResetHorizonDB(t, tt.HorizonDB)
-	q := &history.Q{tt.HorizonSession()}
-	app := &App{
-		historyQ: q,
-	}
 
 	request, err := http.NewRequest("GET", "http://localhost", nil)
 	if err != nil {
 		tt.Assert.NoError(err)
-	}
-
-	if q.GetTx() != nil {
-		t.Fatal("unexpected transaction in history.Q")
 	}
 
 	endpoint := func(w http.ResponseWriter, r *http.Request) {
@@ -176,32 +167,36 @@ func TestRequiresExperimentalIngestion(t *testing.T) {
 		}
 		w.WriteHeader(http.StatusOK)
 	}
-	appMiddleWare := appContextMiddleware(app)
-	handler := appMiddleWare(requiresExperimentalIngestion(http.HandlerFunc(endpoint)))
+	ready := false
+	requiresExperimentalIngestion := &ExperimentalIngestionMiddleware{
+		EnableExperimentalIngestion: false,
+		HorizonSession:              tt.HorizonSession(),
+		Ready: func() bool {
+			return ready
+		},
+	}
+	handler := requiresExperimentalIngestion.Wrap(http.HandlerFunc(endpoint))
+	q := &history.Q{tt.HorizonSession()}
 
 	// requiresExperimentalIngestion responds with 404 if experimental ingestion is not enabled
-	app.config.EnableExperimentalIngestion = false
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, request)
 	tt.Assert.Equal(http.StatusNotFound, w.Code)
 
-	app.config.EnableExperimentalIngestion = true
+	requiresExperimentalIngestion.EnableExperimentalIngestion = true
 	// requiresExperimentalIngestion responds with hProblem.StillIngesting
-	// if the last ingested ledger is 0
-	tt.Assert.NoError(q.UpdateLastLedgerExpIngest(0))
+	// if Ready() is false
 	w = httptest.NewRecorder()
 	handler.ServeHTTP(w, request)
 	tt.Assert.Equal(hProblem.StillIngesting.Status, w.Code)
 
-	app.config.EnableExperimentalIngestion = true
-	tt.Assert.NoError(q.UpdateLastLedgerExpIngest(1))
+	ready = true
 	tt.Assert.NoError(q.UpdateExpStateInvalid(true))
 	// requiresExperimentalIngestion responds with 500 if q.GetExpStateInvalid returns true
 	w = httptest.NewRecorder()
 	handler.ServeHTTP(w, request)
 	tt.Assert.Equal(http.StatusInternalServerError, w.Code)
 
-	app.config.EnableExperimentalIngestion = true
 	tt.Assert.NoError(q.UpdateLastLedgerExpIngest(3))
 	tt.Assert.NoError(q.UpdateExpStateInvalid(false))
 	w = httptest.NewRecorder()

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -171,7 +171,7 @@ func TestRequiresExperimentalIngestion(t *testing.T) {
 	requiresExperimentalIngestion := &ExperimentalIngestionMiddleware{
 		EnableExperimentalIngestion: false,
 		HorizonSession:              tt.HorizonSession(),
-		Ready: func() bool {
+		StateReady: func() bool {
 			return ready
 		},
 	}

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -124,11 +124,12 @@ func installPathFindingRoutes(
 	findFixedPaths FindFixedPathsHandler,
 	r *chi.Mux,
 	expIngest bool,
+	requiresExperimentalIngestion *ExperimentalIngestionMiddleware,
 ) {
 	r.Group(func(r chi.Router) {
 		r.Use(acceptOnlyJSON)
 		if expIngest {
-			r.Use(requiresExperimentalIngestion)
+			r.Use(requiresExperimentalIngestion.Wrap)
 		}
 		r.Method("GET", "/paths", findPaths)
 		r.Method("GET", "/paths/strict-receive", findPaths)
@@ -141,10 +142,11 @@ func installAccountOfferRoute(
 	streamHandler sse.StreamHandler,
 	enableExperimentalIngestion bool,
 	r *chi.Mux,
+	requiresExperimentalIngestion *ExperimentalIngestionMiddleware,
 ) {
 	path := "/accounts/{account_id}/offers"
 	if enableExperimentalIngestion {
-		r.With(requiresExperimentalIngestion).Method(
+		r.With(requiresExperimentalIngestion.Wrap).Method(
 			http.MethodGet,
 			path,
 			streamablePageHandler(offersAction, streamHandler),
@@ -160,6 +162,7 @@ func (w *web) mustInstallActions(
 	config Config,
 	pathFinder paths.Finder,
 	orderBookGraph *orderbook.OrderBookGraph,
+	requiresExperimentalIngestion *ExperimentalIngestionMiddleware,
 ) {
 	if w == nil {
 		log.Fatal("missing web instance for installing web actions")
@@ -183,7 +186,7 @@ func (w *web) mustInstallActions(
 
 	// account actions
 	r.Route("/accounts", func(r chi.Router) {
-		r.With(requiresExperimentalIngestion).
+		r.With(requiresExperimentalIngestion.Wrap).
 			Method(
 				http.MethodGet,
 				"/",
@@ -210,6 +213,7 @@ func (w *web) mustInstallActions(
 		streamHandler,
 		config.EnableExperimentalIngestion,
 		r,
+		requiresExperimentalIngestion,
 	)
 
 	// transaction history actions
@@ -241,13 +245,13 @@ func (w *web) mustInstallActions(
 	r.Get("/trade_aggregations", TradeAggregateIndexAction{}.Handle)
 
 	r.Route("/offers", func(r chi.Router) {
-		r.With(requiresExperimentalIngestion).
+		r.With(requiresExperimentalIngestion.Wrap).
 			Method(
 				http.MethodGet,
 				"/",
 				restPageHandler(actions.GetOffersHandler{}),
 			)
-		r.With(acceptOnlyJSON, requiresExperimentalIngestion).
+		r.With(acceptOnlyJSON, requiresExperimentalIngestion.Wrap).
 			Method(
 				http.MethodGet,
 				"/{id}",
@@ -257,7 +261,7 @@ func (w *web) mustInstallActions(
 	})
 
 	if config.EnableExperimentalIngestion {
-		r.With(requiresExperimentalIngestion).Method(
+		r.With(requiresExperimentalIngestion.Wrap).Method(
 			http.MethodGet,
 			"/order_book",
 			streamableObjectActionHandler{
@@ -290,7 +294,13 @@ func (w *web) mustInstallActions(
 		pathFinder:           pathFinder,
 		coreQ:                w.coreQ,
 	}
-	installPathFindingRoutes(findPaths, findFixedPaths, w.router, config.EnableExperimentalIngestion)
+	installPathFindingRoutes(
+		findPaths,
+		findFixedPaths,
+		w.router,
+		config.EnableExperimentalIngestion,
+		requiresExperimentalIngestion,
+	)
 
 	if config.EnableExperimentalIngestion {
 		r.With(requiresExperimentalIngestion).Method(

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -303,7 +303,7 @@ func (w *web) mustInstallActions(
 	)
 
 	if config.EnableExperimentalIngestion {
-		r.With(requiresExperimentalIngestion).Method(
+		r.With(requiresExperimentalIngestion.Wrap).Method(
 			http.MethodGet,
 			"/assets",
 			restPageHandler(actions.AssetStatsHandler{}),


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Disable ingestion endpoints while state pipeline is still running

Fixes https://github.com/stellar/go/issues/1663

### Goal and scope

 https://github.com/stellar/go/issues/1663
>When ingest version is upgraded (expingest.CurrentVersion++) Horizon will clear all state-related tables and rebuild the state using state pipeline. At this step ledger pipeline is not run waiting for the state ingestion to complete.

>It seems possible that during state ingestion a stale data connected to ledger entries can be served (/accounts, /offers, /paths). It seems not dangerous when all endpoints are migrated to the new system but now it can break some use cases (ex. comparing the current balance of an account with transactions since last check).

This PR fixes this issue by disabling ingestion endpoints while the state pipeline is still running

### Summary of changes

* add a ready flag to the expingest system
* check the ready flag in `ExperimentalIngestionMiddleware`

### What shouldn't be reviewed

Ignore the first commit because it will be reviewed here: https://github.com/stellar/go/pull/1846
