### PR TITLE
exp/ingest: Process ledger upgrade meta

### DIFF
--- a/exp/ingest/io/ledger_reader.go
+++ b/exp/ingest/io/ledger_reader.go
@@ -12,14 +12,16 @@ import (
 // DBLedgerReader is a database-backed implementation of the io.LedgerReader interface.
 // Use NewDBLedgerReader to create a new instance.
 type DBLedgerReader struct {
-	sequence       uint32
-	backend        ledgerbackend.LedgerBackend
-	header         xdr.LedgerHeaderHistoryEntry
-	transactions   []LedgerTransaction
-	upgradeChanges []Change
-	readMutex      sync.Mutex
-	readIdx        int
-	upgradeReadIdx int
+	sequence                uint32
+	backend                 ledgerbackend.LedgerBackend
+	header                  xdr.LedgerHeaderHistoryEntry
+	transactions            []LedgerTransaction
+	upgradeChanges          []Change
+	readMutex               sync.Mutex
+	readIdx                 int
+	upgradeReadIdx          int
+	readUpgradeChangeCalled bool
+	ignoreUpgradeChanges    bool
 }
 
 // Ensure DBLedgerReader implements LedgerReader
@@ -70,6 +72,7 @@ func (dblrc *DBLedgerReader) ReadUpgradeChange() (Change, error) {
 	// Protect all accesses to dblrc.upgradeReadIdx
 	dblrc.readMutex.Lock()
 	defer dblrc.readMutex.Unlock()
+	dblrc.readUpgradeChangeCalled = true
 
 	if dblrc.upgradeReadIdx < len(dblrc.upgradeChanges) {
 		dblrc.upgradeReadIdx++
@@ -83,12 +86,17 @@ func (dblrc *DBLedgerReader) GetUpgradeChanges() []Change {
 	return dblrc.upgradeChanges
 }
 
+func (dblrc *DBLedgerReader) IgnoreUpgradeChanges() {
+	dblrc.ignoreUpgradeChanges = true
+}
+
 // Close moves the read pointer so that subsequent calls to Read() will return EOF.
 func (dblrc *DBLedgerReader) Close() error {
 	dblrc.readMutex.Lock()
 	dblrc.readIdx = len(dblrc.transactions)
-	if dblrc.upgradeReadIdx != len(dblrc.upgradeChanges) {
-		return errors.New("Ledger upgrade changes not fully read!")
+	if !dblrc.ignoreUpgradeChanges &&
+		(!dblrc.readUpgradeChangeCalled || dblrc.upgradeReadIdx != len(dblrc.upgradeChanges)) {
+		return errors.New("Ledger upgrade changes not read! Use ReadUpgradeChange() method.")
 	}
 	dblrc.readMutex.Unlock()
 

--- a/exp/ingest/io/ledger_reader.go
+++ b/exp/ingest/io/ledger_reader.go
@@ -11,13 +11,15 @@ import (
 
 // DBLedgerReader is a database-backed implementation of the io.LedgerReader interface.
 type DBLedgerReader struct {
-	sequence     uint32
-	backend      ledgerbackend.LedgerBackend
-	header       xdr.LedgerHeaderHistoryEntry
-	transactions []LedgerTransaction
-	readIdx      int
-	initOnce     sync.Once
-	readMutex    sync.Mutex
+	sequence       uint32
+	backend        ledgerbackend.LedgerBackend
+	header         xdr.LedgerHeaderHistoryEntry
+	transactions   []LedgerTransaction
+	upgradeChanges []Change
+	initOnce       sync.Once
+	readMutex      sync.Mutex
+	readIdx        int
+	upgradeReadIdx int
 }
 
 // Ensure DBLedgerReader implements LedgerReader
@@ -76,6 +78,26 @@ func (dblrc *DBLedgerReader) Read() (LedgerTransaction, error) {
 	return LedgerTransaction{}, io.EOF
 }
 
+// ReadUpgradeChange returns the next upgrade change in the ledger, each time it is called. When there
+// are no more upgrades to return, an EOF error is returned.
+func (dblrc *DBLedgerReader) ReadUpgradeChange() (Change, error) {
+	var err error
+	dblrc.initOnce.Do(func() { err = dblrc.init() })
+	if err != nil {
+		return Change{}, err
+	}
+
+	// Protect all accesses to dblrc.readIdx
+	dblrc.readMutex.Lock()
+	defer dblrc.readMutex.Unlock()
+
+	if dblrc.upgradeReadIdx < len(dblrc.transactions) {
+		dblrc.upgradeReadIdx++
+		return dblrc.upgradeChanges[dblrc.upgradeReadIdx-1], nil
+	}
+	return Change{}, io.EOF
+}
+
 // Close moves the read pointer so that subsequent calls to Read() will return EOF.
 func (dblrc *DBLedgerReader) Close() error {
 	dblrc.readMutex.Lock()
@@ -99,6 +121,10 @@ func (dblrc *DBLedgerReader) init() error {
 	dblrc.header = ledgerCloseMeta.LedgerHeader
 
 	dblrc.storeTransactions(ledgerCloseMeta)
+	for _, upgradeChanges := range ledgerCloseMeta.UpgradesMeta {
+		changes := getChangesFromLedgerEntryChanges(upgradeChanges)
+		dblrc.upgradeChanges = append(dblrc.upgradeChanges, changes...)
+	}
 
 	return nil
 }

--- a/exp/ingest/io/ledger_reader.go
+++ b/exp/ingest/io/ledger_reader.go
@@ -10,6 +10,7 @@ import (
 )
 
 // DBLedgerReader is a database-backed implementation of the io.LedgerReader interface.
+// Use NewDBLedgerReader to create a new instance.
 type DBLedgerReader struct {
 	sequence       uint32
 	backend        ledgerbackend.LedgerBackend
@@ -33,7 +34,7 @@ func NewDBLedgerReader(sequence uint32, backend ledgerbackend.LedgerBackend) (*D
 	}
 
 	var err error
-	reader.initOnce.Do(func() { err = reader.init() })
+	err = reader.init()
 	if err != nil {
 		return nil, err
 	}
@@ -48,25 +49,12 @@ func (dblrc *DBLedgerReader) GetSequence() uint32 {
 
 // GetHeader returns the XDR Header data associated with the stored ledger.
 func (dblrc *DBLedgerReader) GetHeader() xdr.LedgerHeaderHistoryEntry {
-	var err error
-	dblrc.initOnce.Do(func() { err = dblrc.init() })
-	if err != nil {
-		// TODO, object should be initialized in constructor.
-		// Not returning error here, makes this much simpler.
-		panic(err)
-	}
 	return dblrc.header
 }
 
 // Read returns the next transaction in the ledger, ordered by tx number, each time it is called. When there
 // are no more transactions to return, an EOF error is returned.
 func (dblrc *DBLedgerReader) Read() (LedgerTransaction, error) {
-	var err error
-	dblrc.initOnce.Do(func() { err = dblrc.init() })
-	if err != nil {
-		return LedgerTransaction{}, err
-	}
-
 	// Protect all accesses to dblrc.readIdx
 	dblrc.readMutex.Lock()
 	defer dblrc.readMutex.Unlock()
@@ -78,30 +66,33 @@ func (dblrc *DBLedgerReader) Read() (LedgerTransaction, error) {
 	return LedgerTransaction{}, io.EOF
 }
 
-// ReadUpgradeChange returns the next upgrade change in the ledger, each time it is called. When there
-// are no more upgrades to return, an EOF error is returned.
+// ReadUpgradeChange returns the next upgrade change in the ledger, each time it
+// is called. When there are no more upgrades to return, an EOF error is returned.
 func (dblrc *DBLedgerReader) ReadUpgradeChange() (Change, error) {
-	var err error
-	dblrc.initOnce.Do(func() { err = dblrc.init() })
-	if err != nil {
-		return Change{}, err
-	}
-
-	// Protect all accesses to dblrc.readIdx
+	// Protect all accesses to dblrc.upgradeReadIdx
 	dblrc.readMutex.Lock()
 	defer dblrc.readMutex.Unlock()
 
-	if dblrc.upgradeReadIdx < len(dblrc.transactions) {
+	if dblrc.upgradeReadIdx < len(dblrc.upgradeChanges) {
 		dblrc.upgradeReadIdx++
 		return dblrc.upgradeChanges[dblrc.upgradeReadIdx-1], nil
 	}
 	return Change{}, io.EOF
 }
 
+// GetUpgradeChanges returns all ledger upgrade changes.
+func (dblrc *DBLedgerReader) GetUpgradeChanges() []Change {
+	return dblrc.upgradeChanges
+}
+
 // Close moves the read pointer so that subsequent calls to Read() will return EOF.
 func (dblrc *DBLedgerReader) Close() error {
 	dblrc.readMutex.Lock()
 	dblrc.readIdx = len(dblrc.transactions)
+	if dblrc.upgradeReadIdx != len(dblrc.upgradeChanges) {
+		return errors.New("Ledger upgrade changes not fully read!")
+	}
+	dblrc.upgradeReadIdx = len(dblrc.upgradeChanges)
 	dblrc.readMutex.Unlock()
 
 	return nil
@@ -121,6 +112,7 @@ func (dblrc *DBLedgerReader) init() error {
 	dblrc.header = ledgerCloseMeta.LedgerHeader
 
 	dblrc.storeTransactions(ledgerCloseMeta)
+
 	for _, upgradeChanges := range ledgerCloseMeta.UpgradesMeta {
 		changes := getChangesFromLedgerEntryChanges(upgradeChanges)
 		dblrc.upgradeChanges = append(dblrc.upgradeChanges, changes...)

--- a/exp/ingest/io/ledger_reader.go
+++ b/exp/ingest/io/ledger_reader.go
@@ -17,7 +17,6 @@ type DBLedgerReader struct {
 	header         xdr.LedgerHeaderHistoryEntry
 	transactions   []LedgerTransaction
 	upgradeChanges []Change
-	initOnce       sync.Once
 	readMutex      sync.Mutex
 	readIdx        int
 	upgradeReadIdx int
@@ -33,8 +32,7 @@ func NewDBLedgerReader(sequence uint32, backend ledgerbackend.LedgerBackend) (*D
 		backend:  backend,
 	}
 
-	var err error
-	err = reader.init()
+	err := reader.init()
 	if err != nil {
 		return nil, err
 	}

--- a/exp/ingest/io/ledger_reader.go
+++ b/exp/ingest/io/ledger_reader.go
@@ -90,7 +90,6 @@ func (dblrc *DBLedgerReader) Close() error {
 	if dblrc.upgradeReadIdx != len(dblrc.upgradeChanges) {
 		return errors.New("Ledger upgrade changes not fully read!")
 	}
-	dblrc.upgradeReadIdx = len(dblrc.upgradeChanges)
 	dblrc.readMutex.Unlock()
 
 	return nil

--- a/exp/ingest/io/main.go
+++ b/exp/ingest/io/main.go
@@ -49,10 +49,15 @@ type LedgerReader interface {
 	// be updated with upgrade changes.
 	// Values returned by this method must not be modified.
 	ReadUpgradeChange() (Change, error)
+	// IgnoreLedgerEntryChanges will change `Close()`` behaviour to not error
+	// when changes returned by `ReadUpgradeChange` are not fully read.
+	IgnoreUpgradeChanges()
 	// Close should be called when reading is finished. This is especially
 	// helpful when there are still some transactions available so reader can stop
 	// streaming them.
-	// Close should return error if `ReadUpgradeChange` are not fully read.
+	// Close should return error if `ReadUpgradeChange` are not fully read or
+	// `ReadUpgradeChange` was not called even once. However, this behaviour can
+	// be disabled by calling `IgnoreUpgradeChanges()`.
 	Close() error
 }
 

--- a/exp/ingest/io/main.go
+++ b/exp/ingest/io/main.go
@@ -47,11 +47,17 @@ type LedgerReader interface {
 	// Ledger upgrades MUST be processed AFTER all transactions and only ONCE.
 	// If app is tracking state in more than one store, all of them need to
 	// be updated with upgrade changes.
+	// Values returned by this method must not be modified.
 	ReadUpgradeChange() (Change, error)
 	// Close should be called when reading is finished. This is especially
 	// helpful when there are still some transactions available so reader can stop
 	// streaming them.
+	// Close should return error if `ReadUpgradeChange` are not fully read.
 	Close() error
+}
+
+type UpgradeChangesContainer interface {
+	GetUpgradeChanges() []Change
 }
 
 // LedgerWriter provides convenient, streaming access to the transactions within a ledger.

--- a/exp/ingest/io/main.go
+++ b/exp/ingest/io/main.go
@@ -42,6 +42,12 @@ type LedgerReader interface {
 	// Read should return the next transaction. If there are no more
 	// transactions it should return `io.EOF` error.
 	Read() (LedgerTransaction, error)
+	// Read should return the next ledger entry change from ledger upgrades. If
+	// there are no more changes it should return `io.EOF` error.
+	// Ledger upgrades MUST be processed AFTER all transactions and only ONCE.
+	// If app is tracking state in more than one store, all of them need to
+	// be updated with upgrade changes.
+	ReadUpgradeChange() (Change, error)
 	// Close should be called when reading is finished. This is especially
 	// helpful when there are still some transactions available so reader can stop
 	// streaming them.
@@ -64,9 +70,12 @@ type LedgerWriter interface {
 
 // LedgerTransaction represents the data for a single transaction within a ledger.
 type LedgerTransaction struct {
-	Index      uint32
-	Envelope   xdr.TransactionEnvelope
-	Result     xdr.TransactionResultPair
-	Meta       xdr.TransactionMeta
+	Index    uint32
+	Envelope xdr.TransactionEnvelope
+	Result   xdr.TransactionResultPair
+	// FeeChanges and Meta are low level values.
+	// Use LedgerTransaction.GetChanges() for higher level access to ledger
+	// entry changes.
 	FeeChanges xdr.LedgerEntryChanges
+	Meta       xdr.TransactionMeta
 }

--- a/exp/ingest/io/mock_ledger_reader.go
+++ b/exp/ingest/io/mock_ledger_reader.go
@@ -26,6 +26,11 @@ func (m *MockLedgerReader) Read() (LedgerTransaction, error) {
 	return args.Get(0).(LedgerTransaction), args.Error(1)
 }
 
+func (m *MockLedgerReader) ReadUpgradeChange() (Change, error) {
+	args := m.Called()
+	return args.Get(0).(Change), args.Error(1)
+}
+
 func (m *MockLedgerReader) Close() error {
 	args := m.Called()
 	return args.Error(0)

--- a/exp/ingest/io/mock_ledger_reader.go
+++ b/exp/ingest/io/mock_ledger_reader.go
@@ -31,6 +31,15 @@ func (m *MockLedgerReader) ReadUpgradeChange() (Change, error) {
 	return args.Get(0).(Change), args.Error(1)
 }
 
+func (m *MockLedgerReader) GetUpgradeChanges() []Change {
+	args := m.Called()
+	return args.Get(0).([]Change)
+}
+
+func (m *MockLedgerReader) IgnoreUpgradeChanges() {
+	m.Called()
+}
+
 func (m *MockLedgerReader) Close() error {
 	args := m.Called()
 	return args.Error(0)

--- a/exp/ingest/ledgerbackend/database_backend.go
+++ b/exp/ingest/ledgerbackend/database_backend.go
@@ -13,6 +13,7 @@ const (
 	txHistoryQuery       = "select txbody, txresult, txmeta, txindex from txhistory where ledgerseq = ? "
 	ledgerHeaderQuery    = "select ledgerhash, data from ledgerheaders where ledgerseq = ? "
 	txFeeHistoryQuery    = "select txchanges, txindex from txfeehistory where ledgerseq = ? "
+	upgradeHistoryQuery  = "select ledgerseq, upgradeindex, upgrade, changes from upgradehistory where ledgerseq = ? order by upgradeindex asc"
 	orderBy              = "order by txindex asc"
 	dbDriver             = "postgres"
 )
@@ -112,6 +113,21 @@ func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, LedgerCloseMeta, e
 		}
 		lcm.TransactionFeeChanges = append(lcm.TransactionFeeChanges, tx.TXChanges)
 	}
+
+	// Query - upgradehistory
+	var upgradeHistoryRows []upgradeHistory
+	err = dbb.session.SelectRaw(&upgradeHistoryRows, upgradeHistoryQuery, sequence)
+	// Return errors...
+	if err != nil {
+		return false, lcm, errors.Wrap(err, "Error getting upgradeHistoryRows")
+	}
+
+	// ...otherwise store the data
+	var upgradesMeta []xdr.LedgerEntryChanges
+	for _, upgradeHistoryRow := range upgradeHistoryRows {
+		upgradesMeta = append(upgradesMeta, upgradeHistoryRow.Changes)
+	}
+	lcm.UpgradesMeta = upgradesMeta
 
 	return true, lcm, nil
 }

--- a/exp/ingest/ledgerbackend/ledger_backend.go
+++ b/exp/ingest/ledgerbackend/ledger_backend.go
@@ -25,6 +25,7 @@ type LedgerCloseMeta struct {
 	TransactionResult     []xdr.TransactionResultPair
 	TransactionMeta       []xdr.TransactionMeta
 	TransactionFeeChanges []xdr.LedgerEntryChanges
+	UpgradesMeta          []xdr.LedgerEntryChanges
 }
 
 // ledgerHeaderHistory is a helper struct used to unmarshall header fields from a stellar-core DB.
@@ -69,9 +70,9 @@ type txFeeHistory struct {
 // }
 
 // upgradeHistory holds a row of data from the stellar-core `upgradehistory` table.
-// type upgradeHistory struct {
-// 	LedgerSeq    uint32 `db:"ledgerseq"`
-// 	UpgradeIndex uint32 `db:"upgradeindex"`
-// 	Upgrade      string `db:"upgrade"`
-// 	Changes      string `db:"changes"`
-// }
+type upgradeHistory struct {
+	LedgerSeq    uint32                 `db:"ledgerseq"`
+	UpgradeIndex uint32                 `db:"upgradeindex"`
+	Upgrade      xdr.LedgerUpgrade      `db:"upgrade"`
+	Changes      xdr.LedgerEntryChanges `db:"changes"`
+}

--- a/exp/ingest/main.go
+++ b/exp/ingest/main.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/stellar/go/clients/stellarcore"
@@ -158,4 +159,14 @@ func (r reporterLedgerReader) Read() (io.LedgerTransaction, error) {
 	}
 
 	return entry, err
+}
+
+func (r reporterLedgerReader) GetUpgradeChanges() []io.Change {
+	// upgradeChangesContainer is implemented by *io.DBLedgerReader and readerWrapperLedger.
+	reader, ok := r.LedgerReader.(io.UpgradeChangesContainer)
+	if !ok {
+		panic(fmt.Sprintf("Cannot get upgrade changes from unknown reader type: %T", r.LedgerReader))
+	}
+
+	return reader.GetUpgradeChanges()
 }

--- a/exp/ingest/pipeline/ledger_pipeline_test.go
+++ b/exp/ingest/pipeline/ledger_pipeline_test.go
@@ -1,0 +1,100 @@
+package pipeline_test
+
+import (
+	"context"
+	stdio "io"
+	"testing"
+
+	"github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/exp/ingest/pipeline"
+	"github.com/stellar/go/exp/ingest/processors"
+	supportPipeline "github.com/stellar/go/exp/support/pipeline"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpgradeChangesPassed(t *testing.T) {
+	mockLedgerReader := &io.MockLedgerReader{}
+
+	account := xdr.AccountEntry{
+		AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+		Thresholds: [4]byte{1, 1, 1, 1},
+	}
+
+	mockLedgerReader.On("GetSequence").Return(uint32(1000))
+	mockLedgerReader.On("GetHeader").Return(xdr.LedgerHeaderHistoryEntry{})
+	mockLedgerReader.On("Read").Return(io.LedgerTransaction{}, stdio.EOF)
+	mockLedgerReader.On("GetUpgradeChanges").Return([]io.Change{
+		io.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Pre:  nil,
+			Post: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type:    xdr.LedgerEntryTypeAccount,
+					Account: &account,
+				},
+				LastModifiedLedgerSeq: 1000,
+			},
+		},
+	})
+	mockLedgerReader.On("IgnoreUpgradeChanges").Once()
+	mockLedgerReader.On("Close").Return(nil).Once()
+
+	// Ensure upgrade changes are available to processors to read
+	ledgerPipeline := &pipeline.LedgerPipeline{}
+	ledgerPipeline.SetRoot(
+		pipeline.LedgerNode(&processors.RootProcessor{}).
+			Pipe(
+				pipeline.LedgerNode(&testLedgerProcessor{t}).
+					Pipe(
+						pipeline.LedgerNode(&testLedgerProcessor{t}),
+					),
+				pipeline.LedgerNode(&testLedgerProcessor{t}).
+					Pipe(
+						pipeline.LedgerNode(&testLedgerProcessor{t}),
+					),
+			),
+	)
+
+	err := <-ledgerPipeline.Process(mockLedgerReader)
+	assert.NoError(t, err)
+}
+
+type testLedgerProcessor struct {
+	t *testing.T
+}
+
+func (p *testLedgerProcessor) ProcessLedger(ctx context.Context, store *supportPipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
+	defer func() {
+		// io.LedgerReader.Close() returns error if upgrade changes have not
+		// been processed so it's worth checking the error.
+		closeErr := r.Close()
+		// Do not overwrite the previous error
+		if err == nil {
+			err = closeErr
+		}
+	}()
+	defer w.Close()
+
+	_, err = r.Read()
+	assert.Error(p.t, err)
+	assert.Equal(p.t, stdio.EOF, err)
+
+	change, err := r.ReadUpgradeChange()
+	assert.NoError(p.t, err)
+	assert.Equal(p.t, change.Type, xdr.LedgerEntryTypeAccount)
+
+	_, err = r.ReadUpgradeChange()
+	assert.Error(p.t, err)
+	assert.Equal(p.t, stdio.EOF, err)
+
+	return nil
+}
+
+func (*testLedgerProcessor) Name() string {
+	return "Test processor"
+}
+
+func (*testLedgerProcessor) Reset() {
+	//
+}

--- a/exp/ingest/pipeline/main.go
+++ b/exp/ingest/pipeline/main.go
@@ -11,8 +11,9 @@ import (
 type ContextKey string
 
 const (
-	LedgerSequenceContextKey ContextKey = "ledger_sequence"
-	LedgerHeaderContextKey   ContextKey = "ledger_header"
+	LedgerSequenceContextKey       ContextKey = "ledger_sequence"
+	LedgerHeaderContextKey         ContextKey = "ledger_header"
+	LedgerUpgradeChangesContextKey ContextKey = "ledger_upgrade_changes"
 )
 
 func GetLedgerSequenceFromContext(ctx context.Context) uint32 {
@@ -33,6 +34,16 @@ func GetLedgerHeaderFromContext(ctx context.Context) xdr.LedgerHeaderHistoryEntr
 	}
 
 	return v.(xdr.LedgerHeaderHistoryEntry)
+}
+
+func GetLedgerUpgradeChangesFromContext(ctx context.Context) []io.Change {
+	v := ctx.Value(LedgerUpgradeChangesContextKey)
+
+	if v == nil {
+		panic("ledger upgrade changes not found in context")
+	}
+
+	return v.([]io.Change)
 }
 
 type StatePipeline struct {
@@ -131,7 +142,15 @@ type LedgerProcessor interface {
 	// Given all information above `ProcessLedger` should always look like this:
 	//
 	//    func (p *Processor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) error {
-	//    	defer r.Close()
+	//      defer func() {
+	//      	// io.LedgerReader.Close() returns error if upgrade changes have not
+	//      	// been processed so it's worth checking the error.
+	//      	closeErr := r.Close()
+	//      	// Do not overwrite the previous error
+	//      	if err == nil {
+	//      		err = closeErr
+	//      	}
+	//      }()
 	//    	defer w.Close()
 	//
 	//    	// Some pre code...
@@ -167,6 +186,18 @@ type LedgerProcessor interface {
 	//    		default:
 	//    			continue
 	//    		}
+	//    	}
+	//
+	//    	for {
+	//    		change, err := r.ReadUpgradeChange()
+	//    		if err != nil {
+	//    			if err == stdio.EOF {
+	//    				break
+	//    		} else {
+	//    			return err
+	//    		}
+	//
+	//    		// Process ledger upgrade change...
 	//    	}
 	//
 	//    	// Some post code...
@@ -221,6 +252,10 @@ var _ io.StateReader = &readerWrapperState{}
 // readerWrapperLedger wraps pipeline.Reader to implement LedgerReader interface.
 type readerWrapperLedger struct {
 	supportPipeline.Reader
+
+	upgradeChanges []io.Change
+	// currentUpgrade points to the upgrade to be read by `ReadUpgradeChange`.
+	currentUpgradeChange int
 }
 
 var _ io.LedgerReader = &readerWrapperLedger{}

--- a/exp/ingest/pipeline/main.go
+++ b/exp/ingest/pipeline/main.go
@@ -141,7 +141,7 @@ type LedgerProcessor interface {
 	//
 	// Given all information above `ProcessLedger` should always look like this:
 	//
-	//    func (p *Processor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) error {
+	//    func (p *Processor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
 	//      defer func() {
 	//      	// io.LedgerReader.Close() returns error if upgrade changes have not
 	//      	// been processed so it's worth checking the error.
@@ -255,7 +255,9 @@ type readerWrapperLedger struct {
 
 	upgradeChanges []io.Change
 	// currentUpgrade points to the upgrade to be read by `ReadUpgradeChange`.
-	currentUpgradeChange int
+	currentUpgradeChange    int
+	readUpgradeChangeCalled bool
+	ignoreUpgradeChanges    bool
 }
 
 var _ io.LedgerReader = &readerWrapperLedger{}

--- a/exp/ingest/pipeline/main.go
+++ b/exp/ingest/pipeline/main.go
@@ -123,6 +123,10 @@ type LedgerProcessor interface {
 	// The first argument `ctx` is a context with cancel. Processor should monitor
 	// `ctx.Done()` channel and exit when it returns a value. This can happen when
 	// pipeline execution is interrupted, ex. due to an error.
+	// Please note that processor can filter transactions (by not passing them to
+	// `io.LedgerWriter`) but it cannot filter ledger upgrade changes
+	// (`io.LeaderReader.ReadUpgradeChange`). All upgrade changes will be available
+	// for the next processor to read.
 	//
 	// Given all information above `ProcessLedger` should always look like this:
 	//

--- a/exp/ingest/pipeline/wrappers.go
+++ b/exp/ingest/pipeline/wrappers.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"fmt"
 	stdio "io"
 
 	"github.com/stellar/go/exp/ingest/io"
@@ -23,7 +24,10 @@ func (w *ledgerProcessorWrapper) Process(ctx context.Context, store *supportPipe
 	return w.LedgerProcessor.ProcessLedger(
 		ctx,
 		store,
-		&readerWrapperLedger{reader},
+		&readerWrapperLedger{
+			Reader:         reader,
+			upgradeChanges: GetLedgerUpgradeChangesFromContext(reader.GetContext()),
+		},
 		&writerWrapperLedger{writer},
 	)
 }
@@ -46,6 +50,16 @@ func (w *ledgerReaderWrapper) GetContext() context.Context {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, LedgerSequenceContextKey, w.LedgerReader.GetSequence())
 	ctx = context.WithValue(ctx, LedgerHeaderContextKey, w.LedgerReader.GetHeader())
+
+	// Save upgrade changes in context. UpgradeChangesContainer is implemented by
+	// *io.DBLedgerReader and readerWrapperLedger.
+	reader, ok := w.LedgerReader.(io.UpgradeChangesContainer)
+	if !ok {
+		panic(fmt.Sprintf("Cannot get upgrade changes from unknown reader type: %T", w.LedgerReader))
+	}
+
+	ctx = context.WithValue(ctx, LedgerUpgradeChangesContextKey, reader.GetUpgradeChanges())
+
 	return ctx
 }
 
@@ -89,9 +103,27 @@ func (w *readerWrapperLedger) Read() (io.LedgerTransaction, error) {
 	return entry, nil
 }
 
+// ReadUpgradeChange returns the next ledger upgrade change or EOF if there are
+// no more upgrade changes. Not safe for concurrent use!
 func (w *readerWrapperLedger) ReadUpgradeChange() (io.Change, error) {
-	// TODO!
+	if w.currentUpgradeChange < len(w.upgradeChanges) {
+		change := w.upgradeChanges[w.currentUpgradeChange]
+		w.currentUpgradeChange++
+		return change, nil
+	}
+
 	return io.Change{}, stdio.EOF
+}
+
+func (w *readerWrapperLedger) GetUpgradeChanges() []io.Change {
+	return w.upgradeChanges
+}
+
+func (w *readerWrapperLedger) Close() error {
+	if w.currentUpgradeChange != len(w.upgradeChanges) {
+		return errors.New("Ledger upgrade changes not fully read!")
+	}
+	return w.Reader.Close()
 }
 
 func (w *writerWrapperState) Write(entry xdr.LedgerEntryChange) error {

--- a/exp/ingest/pipeline/wrappers.go
+++ b/exp/ingest/pipeline/wrappers.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	stdio "io"
 
 	"github.com/stellar/go/exp/ingest/io"
 	supportPipeline "github.com/stellar/go/exp/support/pipeline"
@@ -86,6 +87,11 @@ func (w *readerWrapperLedger) Read() (io.LedgerTransaction, error) {
 	}
 
 	return entry, nil
+}
+
+func (w *readerWrapperLedger) ReadUpgradeChange() (io.Change, error) {
+	// TODO!
+	return io.Change{}, stdio.EOF
 }
 
 func (w *writerWrapperState) Write(entry xdr.LedgerEntryChange) error {

--- a/exp/ingest/pipeline/wrappers.go
+++ b/exp/ingest/pipeline/wrappers.go
@@ -106,6 +106,8 @@ func (w *readerWrapperLedger) Read() (io.LedgerTransaction, error) {
 // ReadUpgradeChange returns the next ledger upgrade change or EOF if there are
 // no more upgrade changes. Not safe for concurrent use!
 func (w *readerWrapperLedger) ReadUpgradeChange() (io.Change, error) {
+	w.readUpgradeChangeCalled = true
+
 	if w.currentUpgradeChange < len(w.upgradeChanges) {
 		change := w.upgradeChanges[w.currentUpgradeChange]
 		w.currentUpgradeChange++
@@ -115,14 +117,27 @@ func (w *readerWrapperLedger) ReadUpgradeChange() (io.Change, error) {
 	return io.Change{}, stdio.EOF
 }
 
+func (w *readerWrapperLedger) IgnoreUpgradeChanges() {
+	w.ignoreUpgradeChanges = true
+}
+
 func (w *readerWrapperLedger) GetUpgradeChanges() []io.Change {
 	return w.upgradeChanges
 }
 
 func (w *readerWrapperLedger) Close() error {
-	if w.currentUpgradeChange != len(w.upgradeChanges) {
-		return errors.New("Ledger upgrade changes not fully read!")
+	if !w.ignoreUpgradeChanges &&
+		(!w.readUpgradeChangeCalled || w.currentUpgradeChange != len(w.upgradeChanges)) {
+		return errors.New("Ledger upgrade changes not read! Use ReadUpgradeChange() method.")
 	}
+
+	// Call IgnoreUpgradeChanges on a wrapped reader because `readerWrapperLedger`
+	// is responsible for streaming ledger upgrade changes now.
+	wrapper, ok := w.Reader.(*ledgerReaderWrapper)
+	if ok {
+		wrapper.LedgerReader.IgnoreUpgradeChanges()
+	}
+
 	return w.Reader.Close()
 }
 

--- a/exp/ingest/processors/csv_printer.go
+++ b/exp/ingest/processors/csv_printer.go
@@ -172,9 +172,18 @@ func (p *CSVPrinter) ProcessState(ctx context.Context, store *pipeline.Store, r 
 	return nil
 }
 
-func (p *CSVPrinter) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) error {
-	defer r.Close()
+func (p *CSVPrinter) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
+	defer func() {
+		// io.LedgerReader.Close() returns error if upgrade changes have not
+		// been processed so it's worth checking the error.
+		closeErr := r.Close()
+		// Do not overwrite the previous error
+		if err == nil {
+			err = closeErr
+		}
+	}()
 	defer w.Close()
+	r.IgnoreUpgradeChanges()
 
 	f, err := p.fileHandle()
 	if err != nil {

--- a/exp/ingest/processors/root_processor.go
+++ b/exp/ingest/processors/root_processor.go
@@ -42,9 +42,18 @@ func (p *RootProcessor) ProcessState(ctx context.Context, store *pipeline.Store,
 	return nil
 }
 
-func (p *RootProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) error {
-	defer r.Close()
+func (p *RootProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
+	defer func() {
+		// io.LedgerReader.Close() returns error if upgrade changes have not
+		// been processed so it's worth checking the error.
+		closeErr := r.Close()
+		// Do not overwrite the previous error
+		if err == nil {
+			err = closeErr
+		}
+	}()
 	defer w.Close()
+	r.IgnoreUpgradeChanges()
 
 	for {
 		transaction, err := r.Read()

--- a/services/horizon/internal/expingest/processors/accounts_data_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_data_processor_test.go
@@ -327,3 +327,92 @@ func (s *AccountsDataProcessorTestSuiteLedger) TestRemoveAccount() {
 
 	s.Assert().NoError(err)
 }
+
+func (s *AccountsDataProcessorTestSuiteLedger) TestProcessUpgradeChange() {
+	// Removes ReadUpgradeChange assertion
+	s.mockLedgerReader = &io.MockLedgerReader{}
+
+	data := xdr.DataEntry{
+		AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+		DataName:  "test",
+		DataValue: []byte{1, 1, 1, 1},
+	}
+	lastModifiedLedgerSeq := xdr.Uint32(123)
+
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+							Created: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+								Data: xdr.LedgerEntryData{
+									Type: xdr.LedgerEntryTypeData,
+									Data: &data,
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+
+	s.mockQ.On(
+		"InsertAccountData",
+		data,
+		lastModifiedLedgerSeq,
+	).Return(int64(1), nil).Once()
+
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{}, stdio.EOF).Once()
+
+	// Process ledger entry upgrades
+	modifiedData := data
+	modifiedData.DataValue = []byte{2, 2, 2, 2}
+
+	s.mockLedgerReader.
+		On("ReadUpgradeChange").
+		Return(
+			io.Change{
+				Type: xdr.LedgerEntryTypeData,
+				Pre: &xdr.LedgerEntry{
+					LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+					Data: xdr.LedgerEntryData{
+						Type: xdr.LedgerEntryTypeData,
+						Data: &data,
+					},
+				},
+				Post: &xdr.LedgerEntry{
+					LastModifiedLedgerSeq: lastModifiedLedgerSeq + 1,
+					Data: xdr.LedgerEntryData{
+						Type: xdr.LedgerEntryTypeData,
+						Data: &modifiedData,
+					},
+				},
+			}, nil).Once()
+
+	s.mockLedgerReader.
+		On("ReadUpgradeChange").
+		Return(io.Change{}, stdio.EOF).Once()
+
+	s.mockLedgerReader.On("Close").Return(nil).Once()
+
+	s.mockQ.On(
+		"UpdateAccountData",
+		modifiedData,
+		lastModifiedLedgerSeq+1,
+	).Return(int64(1), nil).Once()
+
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().NoError(err)
+}

--- a/services/horizon/internal/expingest/processors/accounts_data_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_data_processor_test.go
@@ -148,6 +148,10 @@ func (s *AccountsDataProcessorTestSuiteLedger) SetupTest() {
 
 	// Reader and Writer should be always closed and once
 	s.mockLedgerReader.
+		On("ReadUpgradeChange").
+		Return(io.Change{}, stdio.EOF).Once()
+
+	s.mockLedgerReader.
 		On("Close").
 		Return(nil).Once()
 

--- a/services/horizon/internal/expingest/processors/accounts_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_processor_test.go
@@ -147,6 +147,10 @@ func (s *AccountsProcessorTestSuiteLedger) SetupTest() {
 
 	// Reader and Writer should be always closed and once
 	s.mockLedgerReader.
+		On("ReadUpgradeChange").
+		Return(io.Change{}, stdio.EOF).Once()
+
+	s.mockLedgerReader.
 		On("Close").
 		Return(nil).Once()
 

--- a/services/horizon/internal/expingest/processors/accounts_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_processor_test.go
@@ -330,3 +330,93 @@ func (s *AccountsProcessorTestSuiteLedger) TestRemoveAccount() {
 
 	s.Assert().NoError(err)
 }
+
+func (s *AccountsProcessorTestSuiteLedger) TestProcessUpgradeChange() {
+	// Removes ReadUpgradeChange assertion
+	s.mockLedgerReader = &io.MockLedgerReader{}
+
+	account := xdr.AccountEntry{
+		AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+		Thresholds: [4]byte{1, 1, 1, 1},
+	}
+	lastModifiedLedgerSeq := xdr.Uint32(123)
+
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+							Created: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+								Data: xdr.LedgerEntryData{
+									Type:    xdr.LedgerEntryTypeAccount,
+									Account: &account,
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+
+	s.mockQ.On(
+		"InsertAccount",
+		account,
+		lastModifiedLedgerSeq,
+	).Return(int64(1), nil).Once()
+
+	updatedAccount := xdr.AccountEntry{
+		AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+		Thresholds: [4]byte{0, 1, 2, 3},
+		HomeDomain: "stellar.org",
+	}
+
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{}, stdio.EOF).Once()
+
+	s.mockLedgerReader.
+		On("ReadUpgradeChange").
+		Return(
+			io.Change{
+				Type: xdr.LedgerEntryTypeAccount,
+				Pre: &xdr.LedgerEntry{
+					LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+					Data: xdr.LedgerEntryData{
+						Type:    xdr.LedgerEntryTypeAccount,
+						Account: &account,
+					},
+				},
+				Post: &xdr.LedgerEntry{
+					LastModifiedLedgerSeq: lastModifiedLedgerSeq + 1,
+					Data: xdr.LedgerEntryData{
+						Type:    xdr.LedgerEntryTypeAccount,
+						Account: &updatedAccount,
+					},
+				},
+			}, nil).Once()
+
+	s.mockLedgerReader.
+		On("ReadUpgradeChange").
+		Return(io.Change{}, stdio.EOF).Once()
+
+	s.mockLedgerReader.On("Close").Return(nil).Once()
+
+	s.mockQ.On(
+		"UpdateAccount",
+		updatedAccount,
+		lastModifiedLedgerSeq+1,
+	).Return(int64(1), nil).Once()
+
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().NoError(err)
+}

--- a/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
@@ -178,6 +178,10 @@ func (s *AccountsSignerProcessorTestSuiteLedger) SetupTest() {
 
 	// Reader and Writer should be always closed and once
 	s.mockLedgerReader.
+		On("ReadUpgradeChange").
+		Return(io.Change{}, stdio.EOF).Once()
+
+	s.mockLedgerReader.
 		On("Close").
 		Return(nil).Once()
 
@@ -497,6 +501,10 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestRemoveAccount() {
 }
 
 func (s *AccountsSignerProcessorTestSuiteLedger) TestNewAccountNoRowsAffected() {
+	// Removes ReadUpgradeChange assertion
+	s.mockLedgerReader = &io.MockLedgerReader{}
+	s.mockLedgerReader.On("Close").Return(nil).Once()
+
 	s.mockLedgerReader.
 		On("Read").
 		Return(io.LedgerTransaction{
@@ -547,6 +555,10 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewAccountNoRowsAffected() 
 }
 
 func (s *AccountsSignerProcessorTestSuiteLedger) TestRemoveAccountNoRowsAffected() {
+	// Removes ReadUpgradeChange assertion
+	s.mockLedgerReader = &io.MockLedgerReader{}
+	s.mockLedgerReader.On("Close").Return(nil).Once()
+
 	s.mockLedgerReader.
 		On("Read").
 		Return(io.LedgerTransaction{

--- a/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_signer_processor_test.go
@@ -616,6 +616,164 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestRemoveAccountNoRowsAffected
 	)
 }
 
+func (s *AccountsSignerProcessorTestSuiteLedger) TestProcessUpgradeChange() {
+	// Removes ReadUpgradeChange assertion
+	s.mockLedgerReader = &io.MockLedgerReader{}
+
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						// State
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+							State: &xdr.LedgerEntry{
+								Data: xdr.LedgerEntryData{
+									Type: xdr.LedgerEntryTypeAccount,
+									Account: &xdr.AccountEntry{
+										AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+										Signers: []xdr.Signer{
+											xdr.Signer{
+												Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
+												Weight: 10,
+											},
+										},
+									},
+								},
+							},
+						},
+						// Updated
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
+							Updated: &xdr.LedgerEntry{
+								Data: xdr.LedgerEntryData{
+									Type: xdr.LedgerEntryTypeAccount,
+									Account: &xdr.AccountEntry{
+										AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+										Signers: []xdr.Signer{
+											xdr.Signer{
+												Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
+												Weight: 10,
+											},
+											xdr.Signer{
+												Key:    xdr.MustSigner("GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS"),
+												Weight: 15,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+
+	// Remove old signer
+	s.mockQ.
+		On(
+			"RemoveAccountSigner",
+			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+			"GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
+		).
+		Return(int64(1), nil).Once()
+
+	// Create new and old signer
+	s.mockQ.
+		On(
+			"CreateAccountSigner",
+			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+			"GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
+			int32(10),
+		).
+		Return(int64(1), nil).Once()
+
+	s.mockQ.
+		On(
+			"CreateAccountSigner",
+			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+			"GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS",
+			int32(15),
+		).
+		Return(int64(1), nil).Once()
+
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{}, stdio.EOF).Once()
+
+	s.mockLedgerReader.
+		On("ReadUpgradeChange").
+		Return(
+			io.Change{
+				Type: xdr.LedgerEntryTypeAccount,
+				Pre: &xdr.LedgerEntry{
+					LastModifiedLedgerSeq: 1000,
+					Data: xdr.LedgerEntryData{
+						Type: xdr.LedgerEntryTypeAccount,
+						Account: &xdr.AccountEntry{
+							AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+							Signers: []xdr.Signer{
+								xdr.Signer{
+									Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
+									Weight: 10,
+								},
+							},
+						},
+					},
+				},
+				Post: &xdr.LedgerEntry{
+					LastModifiedLedgerSeq: 1001,
+					Data: xdr.LedgerEntryData{
+						Type: xdr.LedgerEntryTypeAccount,
+						Account: &xdr.AccountEntry{
+							AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+							Signers: []xdr.Signer{
+								xdr.Signer{
+									Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
+									Weight: 12,
+								},
+							},
+						},
+					},
+				},
+			}, nil).Once()
+
+	// Update signer
+	s.mockQ.
+		On(
+			"RemoveAccountSigner",
+			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+			"GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
+		).
+		Return(int64(1), nil).Once()
+
+	s.mockQ.
+		On(
+			"CreateAccountSigner",
+			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+			"GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
+			int32(12),
+		).
+		Return(int64(1), nil).Once()
+
+	s.mockLedgerReader.
+		On("ReadUpgradeChange").
+		Return(io.Change{}, stdio.EOF).Once()
+
+	s.mockLedgerReader.On("Close").Return(nil).Once()
+
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().NoError(err)
+}
+
 func createTransactionMeta(opMeta []xdr.OperationMeta) xdr.TransactionMeta {
 	return xdr.TransactionMeta{
 		V: 1,

--- a/services/horizon/internal/expingest/processors/database_processor.go
+++ b/services/horizon/internal/expingest/processors/database_processor.go
@@ -198,6 +198,7 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 		actions = append(actions, p.Action)
 	}
 
+	// Process transaction meta
 	for {
 		transaction, err := r.Read()
 		if err != nil {
@@ -229,6 +230,40 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 						fmt.Sprintf("Error in %s handler", action),
 					)
 				}
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			continue
+		}
+	}
+
+	// Process upgrades meta
+	for {
+		change, err := r.ReadUpgradeChange()
+		if err != nil {
+			if err == stdio.EOF {
+				break
+			} else {
+				return err
+			}
+		}
+
+		for _, action := range actions {
+			handler, ok := actionHandlers[action]
+			if !ok {
+				return errors.New("Unknown action")
+			}
+
+			err := handler(change)
+			if err != nil {
+				return errors.Wrap(
+					err,
+					fmt.Sprintf("Error in %s handler", action),
+				)
 			}
 		}
 

--- a/services/horizon/internal/expingest/processors/database_processor.go
+++ b/services/horizon/internal/expingest/processors/database_processor.go
@@ -176,8 +176,16 @@ func (p *DatabaseProcessor) ProcessState(ctx context.Context, store *pipeline.St
 	return nil
 }
 
-func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) error {
-	defer r.Close()
+func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
+	defer func() {
+		// io.LedgerReader.Close() returns error if upgrade changes have not
+		// been processed so it's worth checking the error.
+		closeErr := r.Close()
+		// Do not overwrite the previous error
+		if err == nil {
+			err = closeErr
+		}
+	}()
 	defer w.Close()
 
 	actionHandlers := map[DatabaseProcessorActionType]func(change io.Change) error{

--- a/services/horizon/internal/expingest/processors/offers_processor_test.go
+++ b/services/horizon/internal/expingest/processors/offers_processor_test.go
@@ -397,6 +397,95 @@ func (s *OffersProcessorTestSuiteLedger) TestRemoveOffer() {
 	s.Assert().NoError(err)
 }
 
+func (s *OffersProcessorTestSuiteLedger) TestProcessUpgradeChange() {
+	// Removes ReadUpgradeChange assertion
+	s.mockLedgerReader = &io.MockLedgerReader{}
+
+	// add offer
+	offer := xdr.OfferEntry{
+		OfferId: xdr.Int64(2),
+		Price:   xdr.Price{1, 2},
+	}
+	lastModifiedLedgerSeq := xdr.Uint32(1234)
+	s.mockLedgerReader.On("Read").
+		Return(io.LedgerTransaction{
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						// State
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+							Created: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+								Data: xdr.LedgerEntryData{
+									Type:  xdr.LedgerEntryTypeOffer,
+									Offer: &offer,
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+
+	s.mockQ.On(
+		"InsertOffer",
+		offer,
+		lastModifiedLedgerSeq,
+	).Return(int64(1), nil).Once()
+
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{}, stdio.EOF).Once()
+
+	updatedOffer := xdr.OfferEntry{
+		OfferId: xdr.Int64(2),
+		Price:   xdr.Price{1, 6},
+	}
+
+	s.mockLedgerReader.
+		On("ReadUpgradeChange").
+		Return(
+			io.Change{
+				Type: xdr.LedgerEntryTypeOffer,
+				Pre: &xdr.LedgerEntry{
+					LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+					Data: xdr.LedgerEntryData{
+						Type:  xdr.LedgerEntryTypeOffer,
+						Offer: &offer,
+					},
+				},
+				Post: &xdr.LedgerEntry{
+					LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+					Data: xdr.LedgerEntryData{
+						Type:  xdr.LedgerEntryTypeOffer,
+						Offer: &updatedOffer,
+					},
+				},
+			}, nil).Once()
+
+	s.mockQ.On(
+		"UpdateOffer",
+		updatedOffer,
+		lastModifiedLedgerSeq,
+	).Return(int64(1), nil).Once()
+
+	s.mockLedgerReader.
+		On("ReadUpgradeChange").
+		Return(io.Change{}, stdio.EOF).Once()
+
+	s.mockLedgerReader.On("Close").Return(nil).Once()
+
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().NoError(err)
+}
+
 func (s *OffersProcessorTestSuiteLedger) TestRemoveOfferNoRowsAffected() {
 	// Removes ReadUpgradeChange assertion
 	s.mockLedgerReader = &io.MockLedgerReader{}

--- a/services/horizon/internal/expingest/processors/offers_processor_test.go
+++ b/services/horizon/internal/expingest/processors/offers_processor_test.go
@@ -118,6 +118,10 @@ func (s *OffersProcessorTestSuiteLedger) SetupTest() {
 
 	// Reader and Writer should be always closed and once
 	s.mockLedgerReader.
+		On("ReadUpgradeChange").
+		Return(io.Change{}, stdio.EOF).Once()
+
+	s.mockLedgerReader.
 		On("Close").
 		Return(nil).Once()
 
@@ -278,6 +282,10 @@ func (s *OffersProcessorTestSuiteLedger) TestInsertOffer() {
 }
 
 func (s *OffersProcessorTestSuiteLedger) TestUpdateOfferNoRowsAffected() {
+	// Removes ReadUpgradeChange assertion
+	s.mockLedgerReader = &io.MockLedgerReader{}
+	s.mockLedgerReader.On("Close").Return(nil).Once()
+
 	lastModifiedLedgerSeq := xdr.Uint32(1234)
 
 	offer := xdr.OfferEntry{
@@ -390,6 +398,10 @@ func (s *OffersProcessorTestSuiteLedger) TestRemoveOffer() {
 }
 
 func (s *OffersProcessorTestSuiteLedger) TestRemoveOfferNoRowsAffected() {
+	// Removes ReadUpgradeChange assertion
+	s.mockLedgerReader = &io.MockLedgerReader{}
+	s.mockLedgerReader.On("Close").Return(nil).Once()
+
 	// add offer
 	s.mockLedgerReader.On("Read").
 		Return(io.LedgerTransaction{

--- a/services/horizon/internal/expingest/processors/orderbook_processor.go
+++ b/services/horizon/internal/expingest/processors/orderbook_processor.go
@@ -39,8 +39,16 @@ func (p *OrderbookProcessor) ProcessState(ctx context.Context, store *pipeline.S
 	return nil
 }
 
-func (p *OrderbookProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) error {
-	defer r.Close()
+func (p *OrderbookProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
+	defer func() {
+		// io.LedgerReader.Close() returns error if upgrade changes have not
+		// been processed so it's worth checking the error.
+		closeErr := r.Close()
+		// Do not overwrite the previous error
+		if err == nil {
+			err = closeErr
+		}
+	}()
 	defer w.Close()
 
 	for {
@@ -58,20 +66,7 @@ func (p *OrderbookProcessor) ProcessLedger(ctx context.Context, store *pipeline.
 		}
 
 		for _, change := range transaction.GetChanges() {
-			if change.Type != xdr.LedgerEntryTypeOffer {
-				continue
-			}
-
-			switch {
-			case change.Post != nil:
-				// Created or updated
-				offer := change.Post.Data.MustOffer()
-				p.OrderBookGraph.AddOffer(offer)
-			case change.Pre != nil && change.Post == nil:
-				// Removed
-				offer := change.Pre.Data.MustOffer()
-				p.OrderBookGraph.RemoveOffer(offer.OfferId)
-			}
+			p.processChange(change)
 		}
 
 		select {
@@ -82,7 +77,45 @@ func (p *OrderbookProcessor) ProcessLedger(ctx context.Context, store *pipeline.
 		}
 	}
 
+	// Process upgrades meta
+	for {
+		change, err := r.ReadUpgradeChange()
+		if err != nil {
+			if err == stdio.EOF {
+				break
+			} else {
+				return err
+			}
+		}
+
+		p.processChange(change)
+
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			continue
+		}
+	}
+
 	return nil
+}
+
+func (p *OrderbookProcessor) processChange(change io.Change) {
+	if change.Type != xdr.LedgerEntryTypeOffer {
+		return
+	}
+
+	switch {
+	case change.Post != nil:
+		// Created or updated
+		offer := change.Post.Data.MustOffer()
+		p.OrderBookGraph.AddOffer(offer)
+	case change.Pre != nil && change.Post == nil:
+		// Removed
+		offer := change.Pre.Data.MustOffer()
+		p.OrderBookGraph.RemoveOffer(offer.OfferId)
+	}
 }
 
 func (p *OrderbookProcessor) Name() string {

--- a/services/horizon/internal/expingest/processors/orderbook_processor_test.go
+++ b/services/horizon/internal/expingest/processors/orderbook_processor_test.go
@@ -115,6 +115,7 @@ func TestProcessOrderBookLedger(t *testing.T) {
 	processor := OrderbookProcessor{graph}
 
 	reader.On("Read").Return(io.LedgerTransaction{}, stdio.EOF).Once()
+	reader.On("ReadUpgradeChange").Return(io.Change{}, stdio.EOF).Once()
 	reader.On("Close").Return(nil).Once()
 	writer.On("Close").Return(nil).Once()
 	if err := processor.ProcessLedger(context.Background(), nil, reader, writer); err != nil {
@@ -314,6 +315,7 @@ func TestProcessOrderBookLedger(t *testing.T) {
 	reader.On("Read").
 		Return(io.LedgerTransaction{}, stdio.EOF).Once()
 
+	reader.On("ReadUpgradeChange").Return(io.Change{}, stdio.EOF).Once()
 	reader.On("Close").Return(nil).Once()
 	writer.On("Close").Return(nil).Once()
 

--- a/services/horizon/internal/expingest/processors/orderbook_processor_test.go
+++ b/services/horizon/internal/expingest/processors/orderbook_processor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stellar/go/exp/ingest/io"
 	"github.com/stellar/go/exp/orderbook"
 	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestProcessOrderBookState(t *testing.T) {
@@ -346,4 +347,83 @@ func TestProcessOrderBookLedger(t *testing.T) {
 	if len(expectedOffers) != 0 {
 		t.Fatal("expected offers does not match offers in graph")
 	}
+}
+
+func TestProcessOrderBookLedgerProcessUpgradeChanges(t *testing.T) {
+	reader := &io.MockLedgerReader{}
+	writer := &io.MockLedgerWriter{}
+	graph := orderbook.NewOrderBookGraph()
+	processor := OrderbookProcessor{graph}
+
+	// add offer
+	reader.On("Read").
+		Return(io.LedgerTransaction{
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						// State
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+							Created: &xdr.LedgerEntry{
+								Data: xdr.LedgerEntryData{
+									Type: xdr.LedgerEntryTypeOffer,
+									Offer: &xdr.OfferEntry{
+										OfferId: xdr.Int64(1),
+										Price:   xdr.Price{1, 2},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+
+	reader.On("Read").
+		Return(io.LedgerTransaction{}, stdio.EOF).Once()
+
+	// Process upgrade changes
+	reader.On("ReadUpgradeChange").Return(io.Change{
+		Type: xdr.LedgerEntryTypeOffer,
+		Pre: &xdr.LedgerEntry{
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeOffer,
+				Offer: &xdr.OfferEntry{
+					OfferId: xdr.Int64(1),
+					Price:   xdr.Price{1, 2},
+				},
+			},
+		},
+		Post: &xdr.LedgerEntry{
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeOffer,
+				Offer: &xdr.OfferEntry{
+					OfferId: xdr.Int64(1),
+					Price:   xdr.Price{100, 2},
+				},
+			},
+		},
+	}, nil).Once()
+
+	reader.
+		On("ReadUpgradeChange").
+		Return(io.Change{}, stdio.EOF).Once()
+
+	reader.On("Close").Return(nil).Once()
+	writer.On("Close").Return(nil).Once()
+
+	if err := processor.ProcessLedger(context.Background(), nil, reader, writer); err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	writer.AssertExpectations(t)
+	reader.AssertExpectations(t)
+
+	if err := graph.Apply(2); err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	offers := graph.Offers()
+	assert.Equal(t, xdr.Int32(100), offers[0].Price.N)
+	assert.Equal(t, xdr.Int32(2), offers[0].Price.D)
 }

--- a/services/horizon/internal/expingest/processors/trust_lines_processor_test.go
+++ b/services/horizon/internal/expingest/processors/trust_lines_processor_test.go
@@ -138,6 +138,10 @@ func (s *TrustLinesProcessorTestSuiteLedger) SetupTest() {
 
 	// Reader and Writer should be always closed and once
 	s.mockLedgerReader.
+		On("ReadUpgradeChange").
+		Return(io.Change{}, stdio.EOF).Once()
+
+	s.mockLedgerReader.
 		On("Close").
 		Return(nil).Once()
 
@@ -331,6 +335,10 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestInsertTrustLine() {
 }
 
 func (s *TrustLinesProcessorTestSuiteLedger) TestUpdateTrustLineNoRowsAffected() {
+	// Removes ReadUpgradeChange assertion
+	s.mockLedgerReader = &io.MockLedgerReader{}
+	s.mockLedgerReader.On("Close").Return(nil).Once()
+
 	lastModifiedLedgerSeq := xdr.Uint32(1234)
 
 	trustLine := xdr.TrustLineEntry{
@@ -483,6 +491,10 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestRemoveTrustLine() {
 }
 
 func (s *TrustLinesProcessorTestSuiteLedger) TestRemoveOfferNoRowsAffected() {
+	// Removes ReadUpgradeChange assertion
+	s.mockLedgerReader = &io.MockLedgerReader{}
+	s.mockLedgerReader.On("Close").Return(nil).Once()
+
 	s.mockLedgerReader.On("Read").
 		Return(io.LedgerTransaction{
 			Meta: createTransactionMeta([]xdr.OperationMeta{

--- a/services/horizon/internal/expingest/processors/trust_lines_processor_test.go
+++ b/services/horizon/internal/expingest/processors/trust_lines_processor_test.go
@@ -490,6 +490,128 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestRemoveTrustLine() {
 	s.Assert().NoError(err)
 }
 
+func (s *TrustLinesProcessorTestSuiteLedger) TestProcessUpgradeChange() {
+	// Removes ReadUpgradeChange assertion
+	s.mockLedgerReader = &io.MockLedgerReader{}
+
+	// add trust line
+	trustLine := xdr.TrustLineEntry{
+		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		Asset:     xdr.MustNewCreditAsset("EUR", trustLineIssuer.Address()),
+		Balance:   0,
+	}
+	lastModifiedLedgerSeq := xdr.Uint32(1234)
+	s.mockLedgerReader.On("Read").
+		Return(io.LedgerTransaction{
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						// State
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+							Created: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+								Data: xdr.LedgerEntryData{
+									Type:      xdr.LedgerEntryTypeTrustline,
+									TrustLine: &trustLine,
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+
+	s.mockQ.On(
+		"InsertTrustLine",
+		trustLine,
+		lastModifiedLedgerSeq,
+	).Return(int64(1), nil).Once()
+
+	s.mockAssetStatsQ.On("GetAssetStat",
+		xdr.AssetTypeAssetTypeCreditAlphanum4,
+		"EUR",
+		trustLineIssuer.Address(),
+	).Return(history.ExpAssetStat{}, sql.ErrNoRows).Once()
+	s.mockAssetStatsQ.On("InsertAssetStat", history.ExpAssetStat{
+		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AssetIssuer: trustLineIssuer.Address(),
+		AssetCode:   "EUR",
+		Amount:      "0",
+		NumAccounts: 1,
+	}).Return(int64(1), nil).Once()
+
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{}, stdio.EOF).Once()
+
+	updatedTrustLine := xdr.TrustLineEntry{
+		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		Asset:     xdr.MustNewCreditAsset("EUR", trustLineIssuer.Address()),
+		Balance:   10,
+	}
+
+	s.mockLedgerReader.
+		On("ReadUpgradeChange").
+		Return(
+			io.Change{
+				Type: xdr.LedgerEntryTypeTrustline,
+				Pre: &xdr.LedgerEntry{
+					LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+					Data: xdr.LedgerEntryData{
+						Type:      xdr.LedgerEntryTypeTrustline,
+						TrustLine: &trustLine,
+					},
+				},
+				Post: &xdr.LedgerEntry{
+					LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+					Data: xdr.LedgerEntryData{
+						Type:      xdr.LedgerEntryTypeTrustline,
+						TrustLine: &updatedTrustLine,
+					},
+				},
+			}, nil).Once()
+
+	s.mockQ.On(
+		"UpdateTrustLine",
+		updatedTrustLine,
+		lastModifiedLedgerSeq,
+	).Return(int64(1), nil).Once()
+	s.mockAssetStatsQ.On("GetAssetStat",
+		xdr.AssetTypeAssetTypeCreditAlphanum4,
+		"EUR",
+		trustLineIssuer.Address(),
+	).Return(history.ExpAssetStat{
+		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AssetIssuer: trustLineIssuer.Address(),
+		AssetCode:   "EUR",
+		Amount:      "0",
+		NumAccounts: 1,
+	}, nil).Once()
+	s.mockAssetStatsQ.On("UpdateAssetStat", history.ExpAssetStat{
+		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AssetIssuer: trustLineIssuer.Address(),
+		AssetCode:   "EUR",
+		Amount:      "10",
+		NumAccounts: 1,
+	}).Return(int64(1), nil).Once()
+
+	s.mockLedgerReader.
+		On("ReadUpgradeChange").
+		Return(io.Change{}, stdio.EOF).Once()
+
+	s.mockLedgerReader.On("Close").Return(nil).Once()
+
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().NoError(err)
+}
+
 func (s *TrustLinesProcessorTestSuiteLedger) TestRemoveOfferNoRowsAffected() {
 	// Removes ReadUpgradeChange assertion
 	s.mockLedgerReader = &io.MockLedgerReader{}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

This commits adds support for getting ledger upgrade changes from `exp/ingest/io.LedgerReader` and updates ledger processors in Horizon to process ledger upgrade meta.

Requirement for #1848.
Close #1470.

### Goal and scope

As described in [Integration](https://github.com/stellar/stellar-core/blob/master/docs/integration.md#applying-changes-in-the-high-resolution-custom-view) doc in stellar-core the ledger meta changes need to be processed in the following order:
* transaction set "meta" (fee, txmeta)
* ledger upgrades "meta".

This commit adds missing ledger upgrade processing by adding a new method on `LedgerReader` that streams `io.Change` objects connected to a given ledger upgrades. Because processing ledger upgrade meta is essential to update the state correctly, `LedgerReader.Close()` will return an error in case some ledger upgrades have not been read.

### Summary of changes

* Added `ReadUpgradeChange` to `io.LedgerReader`.
* Updated pipeline wrappers to pass reference to upgrades to the next reader in the pipeline.
* Updated Horizon processors to process ledger upgrade meta.

### Known limitations & issues

* `LedgerEntryChanges` connected to ledger upgrade can be of arbitrary size. Currently all ledger upgrade changes are read fully into memory because they are stored in a single field in stellar-core DB (streaming them would require an awkward code that calls `substr` on an upgrade DB row). This should be solved when stellar-core ledger protocol is finished. `LedgerReader` API is designed to support streaming upgrade changes.

### What shouldn't be reviewed

* Tests were not updated yet to check if upgrade meta processing works.
