### PR TITLE
 exp/orderbook: Fix bug in strict send path finding search

### DIFF
--- a/exp/orderbook/dfs.go
+++ b/exp/orderbook/dfs.go
@@ -289,8 +289,11 @@ func consumeOffersForSellingAsset(
 		totalConsumed += xdr.Int64(buyingUnitsFromOffer)
 		currentAssetAmount -= xdr.Int64(sellingUnitsFromOffer)
 
-		if currentAssetAmount <= 0 {
+		if currentAssetAmount == 0 {
 			return totalConsumed, nil
+		}
+		if currentAssetAmount < 0 {
+			return -1, errSoldTooMuch
 		}
 	}
 
@@ -319,7 +322,15 @@ func consumeOffersForBuyingAsset(
 		// otherwise consume entire offer and move on to the next one
 		amountSold, err := price.MulFractionRoundDown(int64(currentAssetAmount), d, n)
 		if err == nil {
-			if amountSoldXDR := xdr.Int64(amountSold); amountSoldXDR > 0 && amountSoldXDR <= offer.Amount {
+			amountSoldXDR := xdr.Int64(amountSold)
+			if amountSoldXDR == 0 {
+				// we do not have enough of the buying asset to consume the offer
+				return -1, nil
+			}
+			if amountSoldXDR < 0 {
+				return -1, errSoldTooMuch
+			}
+			if amountSoldXDR <= offer.Amount {
 				totalConsumed += amountSoldXDR
 				return totalConsumed, nil
 			}
@@ -344,8 +355,11 @@ func consumeOffersForBuyingAsset(
 		totalConsumed += xdr.Int64(sellingUnitsFromOffer)
 		currentAssetAmount -= xdr.Int64(buyingUnitsFromOffer)
 
-		if currentAssetAmount <= 0 {
+		if currentAssetAmount == 0 {
 			return totalConsumed, nil
+		}
+		if currentAssetAmount < 0 {
+			return -1, errSoldTooMuch
 		}
 	}
 

--- a/exp/orderbook/graph.go
+++ b/exp/orderbook/graph.go
@@ -12,6 +12,7 @@ var (
 	errOfferNotPresent     = errors.New("offer is not present in the order book graph")
 	errEmptyOffers         = errors.New("offers is empty")
 	errAssetAmountIsZero   = errors.New("current asset amount is 0")
+	errSoldTooMuch         = errors.New("sold more than current balance")
 	errBatchAlreadyApplied = errors.New("cannot apply batched updates more than once")
 	errUnexpectedLedger    = errors.New("cannot apply unexpected ledger")
 )

--- a/exp/orderbook/graph_test.go
+++ b/exp/orderbook/graph_test.go
@@ -1151,8 +1151,15 @@ func TestConsumeOffersForBuyingAsset(t *testing.T) {
 			"offer denominator cannot be zero",
 			[]xdr.OfferEntry{denominatorZeroOffer},
 			10000,
-			0,
-			price.ErrDivisionByZero,
+			-1,
+			nil,
+		},
+		{
+			"balance too low to consume offers",
+			[]xdr.OfferEntry{twoEurOffer},
+			1,
+			-1,
+			nil,
 		},
 		{
 			"not enough offers to consume",

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -10,6 +10,7 @@ bumps.  A breaking change will get clearly notified in this log.
 
 * Add `Latest-Ledger` header with the sequence number of the last processed ledger by the experimental ingestion system. The endpoints built using the experimental ingestion system will always respond with data which is consistent with the ledger in `Latest-Ledger`.
 * Fixes a bug in `/fee_stats`.
+* Fixes a bug in `/paths/strict-send`.
 
 ### Breaking Changes
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

There is a bug in `consumeOffersForBuyingAsset()` which manifests when `currentAssetAmount` is not high enough to purchase the selling asset. In such cases `consumeOffersForBuyingAsset()` should return -1, nil but because of the bug the function returns a positive amount with no error.

Fixes https://github.com/stellar/go/issues/1856
