### PR TITLE
Remove unnecessary whitespace and fix typo in godoc comments

### DIFF
--- a/build/main.go
+++ b/build/main.go
@@ -1,5 +1,5 @@
 // Package build implements a builder system for constructing various xdr
-// structures used by the stellar network, most importanly transactions.
+// structures used by the stellar network, most importantly transactions.
 //
 // At the core of this package is the *Builder and *Mutator types.  A Builder
 // object (ex. PaymentBuilder, TransactionBuilder) contain an underlying xdr

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -464,7 +464,7 @@ func (c *Client) StreamEffects(ctx context.Context, request EffectRequest, handl
 // StreamOperations streams stellar operations. It can be used to stream all operations or operations
 // for an account. Use context.WithCancel to stop streaming or context.Background() if you want to
 // stream indefinitely. OperationHandler is a user-supplied function that is executed for each streamed
-//  operation received.
+// operation received.
 func (c *Client) StreamOperations(ctx context.Context, request OperationRequest, handler OperationHandler) error {
 	return request.SetOperationsEndpoint().StreamOperations(ctx, c, handler)
 }
@@ -473,7 +473,7 @@ func (c *Client) StreamOperations(ctx context.Context, request OperationRequest,
 // for an account. Payments include create_account, payment, path_payment and account_merge operations.
 // Use context.WithCancel to stop streaming or context.Background() if you want to
 // stream indefinitely. OperationHandler is a user-supplied function that is executed for each streamed
-//  operation received.
+// operation received.
 func (c *Client) StreamPayments(ctx context.Context, request OperationRequest, handler OperationHandler) error {
 	return request.SetPaymentsEndpoint().StreamOperations(ctx, c, handler)
 }

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -222,7 +222,7 @@ type AccountRequest struct {
 
 // EffectRequest struct contains data for getting effects from a horizon server.
 // "ForAccount", "ForLedger", "ForOperation" and "ForTransaction": Not more than one of these
-//  can be set at a time. If none are set, the default is to return all effects.
+// can be set at a time. If none are set, the default is to return all effects.
 // The query parameters (Order, Cursor and Limit) are optional. All or none can be set.
 type EffectRequest struct {
 	ForAccount     string

--- a/clients/horizonclient/operation_request.go
+++ b/clients/horizonclient/operation_request.go
@@ -78,7 +78,7 @@ type OperationHandler func(operations.Operation)
 // StreamOperations streams stellar operations. It can be used to stream all operations or operations
 // for and account. Use context.WithCancel to stop streaming or context.Background() if you want to
 // stream indefinitely. OperationHandler is a user-supplied function that is executed for each streamed
-//  operation received.
+// operation received.
 func (op OperationRequest) StreamOperations(ctx context.Context, client *Client, handler OperationHandler) error {
 	endpoint, err := op.BuildURL()
 	if err != nil {


### PR DESCRIPTION
This fixes lines with an unintended two-space prefix in code comments. The extra space prefix causes godoc to render those lines as a code block. For example, see [horizonclient#Client.StreamOperations](https://godoc.org/github.com/stellar/go/clients/horizonclient#Client.StreamOperations).
