### PR TITLE
services/horizon: Set  for empty referer

### DIFF
--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -128,6 +128,11 @@ func logEndOfRequest(ctx context.Context, r *http.Request, duration time.Duratio
 		routePattern = "undefined"
 	}
 
+	referer := r.Referer()
+	if routePattern == "" {
+		referer = "undefined"
+	}
+
 	log.Ctx(ctx).WithFields(log.F{
 		"bytes":          mw.BytesWritten(),
 		"client_name":    getClientData(r, clientNameHeader),
@@ -144,7 +149,7 @@ func logEndOfRequest(ctx context.Context, r *http.Request, duration time.Duratio
 		"route":          routePattern,
 		"status":         mw.Status(),
 		"streaming":      streaming,
-		"referer":        r.Referer(),
+		"referer":        referer,
 	}).Info("Finished request")
 }
 

--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -104,6 +104,11 @@ func getClientData(r *http.Request, headerName string) string {
 }
 
 func logStartOfRequest(ctx context.Context, r *http.Request, streaming bool) {
+	referer := r.Referer()
+	if referer == "" {
+		referer = "undefined"
+	}
+
 	log.Ctx(ctx).WithFields(log.F{
 		"client_name":    getClientData(r, clientNameHeader),
 		"client_version": getClientData(r, clientVersionHeader),
@@ -116,7 +121,7 @@ func logStartOfRequest(ctx context.Context, r *http.Request, streaming bool) {
 		"method":         r.Method,
 		"path":           r.URL.String(),
 		"streaming":      streaming,
-		"referer":        r.Referer(),
+		"referer":        referer,
 	}).Info("Starting request")
 }
 
@@ -129,7 +134,7 @@ func logEndOfRequest(ctx context.Context, r *http.Request, duration time.Duratio
 	}
 
 	referer := r.Referer()
-	if routePattern == "" {
+	if referer == "" {
 		referer = "undefined"
 	}
 


### PR DESCRIPTION
This commit sets `referer` value to `undefined` if `Referer` HTTP header is empty. This is to help support logging in system that have problems parsing empty values.