### PR TITLE
exp/tools/dump-ledger-state: Add extra flags to LATEST_LEDGER curl request

### DIFF
--- a/exp/tools/dump-ledger-state/docker-entrypoint.sh
+++ b/exp/tools/dump-ledger-state/docker-entrypoint.sh
@@ -12,10 +12,10 @@ echo "using version $(stellar-core version)"
 
 if [ -z ${TESTNET+x} ]; then
     stellar-core --conf ./stellar-core.cfg new-db
-    export LATEST_LEDGER=`curl -s --max-time 10 --retry 3 --retry-delay 5 https://history.stellar.org/prd/core-live/core_live_001/.well-known/stellar-history.json | jq -r '.currentLedger'`
+    export LATEST_LEDGER=`curl -v --max-time 10 --retry 3 --retry-connrefused --retry-delay 5 https://history.stellar.org/prd/core-live/core_live_001/.well-known/stellar-history.json | jq -r '.currentLedger'`
 else
     stellar-core --conf ./stellar-core-testnet.cfg new-db
-    export LATEST_LEDGER=`curl -s --max-time 10 --retry 3 --retry-delay 5 https://history.stellar.org/prd/core-testnet/core_testnet_001/.well-known/stellar-history.json | jq -r '.currentLedger'`
+    export LATEST_LEDGER=`curl -v --max-time 10 --retry 3 --retry-connrefused --retry-delay 5 https://history.stellar.org/prd/core-testnet/core_testnet_001/.well-known/stellar-history.json | jq -r '.currentLedger'`
 fi
 echo "Latest ledger: $LATEST_LEDGER"
 


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

`--retry-connrefused` will consider ECONNREFUSED as a transient error too for --retry
`-v` will output extra logs which are useful for debugging failures
