### PR TITLE
services/horizon/internal/actions: Update payload for "Accounts For Signers" end-point.

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -16,7 +16,7 @@ bumps.  A breaking change will get clearly notified in this log.
     The following request will return all accounts who have a trustline to the asset identified by `asset_type=credit_alphanum4`, `asset_code=COP`, and `asset_issuer=GC2GFGZ5CZCFCDJSQF3YYEAYBOS3ZREXJSPU7LUJ7JU3LP3BQNHY7YKS`:
     
      `/accounts?asset_type=credit_alphanum4&asset_code=COP&asset_issuer=GC2GFGZ5CZCFCDJSQF3YYEAYBOS3ZREXJSPU7LUJ7JU3LP3BQNHY7YKS`
-
+* Update payload in experimental "Accounts For Signers" end-point to return an account resource. ([#1876](https://github.com/stellar/go/pull/1876))
 
 ## v0.22.1
 

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -147,58 +147,54 @@ func (handler GetAccountsHandler) GetResourcePage(
 		return nil, err
 	}
 
+	var records []history.AccountEntry
+
 	if len(qp.Signer) > 0 {
-		records, err := historyQ.AccountsForSigner(qp.Signer, pq)
+		records, err = historyQ.AccountEntriesForSigner(qp.Signer, pq)
 		if err != nil {
 			return nil, errors.Wrap(err, "loading account records")
-		}
-
-		for _, record := range records {
-			var res protocol.AccountSigner
-			resourceadapter.PopulateAccountSigner(ctx, &res, record)
-			accounts = append(accounts, res)
 		}
 	} else {
-		records, err := historyQ.AccountsForAsset(*qp.Asset(), pq)
+		records, err = historyQ.AccountsForAsset(*qp.Asset(), pq)
 		if err != nil {
 			return nil, errors.Wrap(err, "loading account records")
 		}
+	}
 
-		if len(records) == 0 {
-			// early return
-			return accounts, nil
-		}
+	if len(records) == 0 {
+		// early return
+		return accounts, nil
+	}
 
-		accountIDs := make([]string, 0, len(records))
-		for _, record := range records {
-			accountIDs = append(accountIDs, record.AccountID)
-		}
+	accountIDs := make([]string, 0, len(records))
+	for _, record := range records {
+		accountIDs = append(accountIDs, record.AccountID)
+	}
 
-		signers, err := handler.loadSigners(historyQ, accountIDs)
-		if err != nil {
-			return nil, err
-		}
+	signers, err := handler.loadSigners(historyQ, accountIDs)
+	if err != nil {
+		return nil, err
+	}
 
-		trustlines, err := handler.loadTrustlines(historyQ, accountIDs)
-		if err != nil {
-			return nil, err
-		}
+	trustlines, err := handler.loadTrustlines(historyQ, accountIDs)
+	if err != nil {
+		return nil, err
+	}
 
-		data, err := handler.loadData(historyQ, accountIDs)
-		if err != nil {
-			return nil, err
-		}
+	data, err := handler.loadData(historyQ, accountIDs)
+	if err != nil {
+		return nil, err
+	}
 
-		for _, record := range records {
-			var res protocol.Account
-			s := signers[record.AccountID]
-			t := trustlines[record.AccountID]
-			d := data[record.AccountID]
+	for _, record := range records {
+		var res protocol.Account
+		s := signers[record.AccountID]
+		t := trustlines[record.AccountID]
+		d := data[record.AccountID]
 
-			resourceadapter.PopulateAccountEntry(ctx, &res, record, d, s, t)
+		resourceadapter.PopulateAccountEntry(ctx, &res, record, d, s, t)
 
-			accounts = append(accounts, res)
-		}
+		accounts = append(accounts, res)
 	}
 
 	return accounts, nil

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -134,8 +134,6 @@ func (handler GetAccountsHandler) GetResourcePage(
 		return nil, err
 	}
 
-	var accounts []hal.Pageable
-
 	historyQ, err := historyQFromRequest(r)
 	if err != nil {
 		return nil, err
@@ -160,6 +158,8 @@ func (handler GetAccountsHandler) GetResourcePage(
 			return nil, errors.Wrap(err, "loading account records")
 		}
 	}
+
+	accounts := make([]hal.Pageable, 0, len(records))
 
 	if len(records) == 0 {
 		// early return

--- a/services/horizon/internal/db2/history/accounts.go
+++ b/services/horizon/internal/db2/history/accounts.go
@@ -118,7 +118,7 @@ func (q *Q) RemoveAccount(accountID string) (int64, error) {
 	return result.RowsAffected()
 }
 
-// AccountSignersForAsset returns a list of `AccountSigner` rows who are trustee to an
+// AccountsForAsset returns a list of `AccountEntry` rows who are trustee to an
 // asset
 func (q *Q) AccountsForAsset(asset xdr.Asset, page db2.PageQuery) ([]AccountEntry, error) {
 	var assetType, code, issuer string
@@ -135,6 +135,29 @@ func (q *Q) AccountsForAsset(asset xdr.Asset, page db2.PageQuery) ([]AccountEntr
 		})
 
 	sql, err := page.ApplyToUsingCursor(sql, "trust_lines.accountid", page.Cursor)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not apply query to page")
+	}
+
+	var results []AccountEntry
+	if err := q.Select(&results, sql); err != nil {
+		return nil, errors.Wrap(err, "could not run select query")
+	}
+
+	return results, nil
+}
+
+// AccountEntriesForSigner returns a list of `AccountEntry` rows for a given signer
+func (q *Q) AccountEntriesForSigner(signer string, page db2.PageQuery) ([]AccountEntry, error) {
+	sql := sq.
+		Select("accounts.*").
+		From("accounts").
+		Join("accounts_signers ON accounts.account_id = accounts_signers.account").
+		Where(map[string]interface{}{
+			"accounts_signers.signer": signer,
+		})
+
+	sql, err := page.ApplyToUsingCursor(sql, "accounts_signers.account", page.Cursor)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not apply query to page")
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Account for signers was using a partial representation of accounts since we didn't have all the necessary information in the database to build the full representation. Since #1819 we are now ingesting account data and can return all the fields related with an account. This PR updates the end-point making it consistent with the results when  fetching a single account or filtering accounts by a given trustline. Fixes #1875 

### Goal and scope

- Update payload in account for signers.

### Summary of changes

- Add new method to history, so we can fetch account entries from a signer.

### Known limitations & issues


### What shouldn't be reviewed

