### PR TITLE
support/env: add env.Duration

### DIFF
--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -218,7 +218,7 @@ func dialRedis(redisURL *url.URL) func() (redis.Conn, error) {
 		}
 
 		if redisURL.User == nil {
-			return c, nil
+			return c, err
 		}
 
 		if pass, ok := redisURL.User.Password(); ok {

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -218,7 +218,7 @@ func dialRedis(redisURL *url.URL) func() (redis.Conn, error) {
 		}
 
 		if redisURL.User == nil {
-			return c, err
+			return c, nil
 		}
 
 		if pass, ok := redisURL.User.Password(); ok {

--- a/support/env/env.go
+++ b/support/env/env.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"time"
 )
 
 // String returns the value of the environment variable "name".
@@ -21,6 +22,23 @@ func Int(name string, value int) int {
 	if s := os.Getenv(name); s != "" {
 		var err error
 		value, err = strconv.Atoi(s)
+		if err != nil {
+			log.Println(name, err)
+			os.Exit(1)
+		}
+	}
+	return value
+}
+
+// Duration returns the value of the environment variable "name" as a
+// time.Duration where the value of the environment variable is parsed as a
+// duration string as defined in the Go stdlib time documentation. e.g. 5m30s.
+// If name is not set, it returns value.
+// Ref: https://golang.org/pkg/time/#ParseDuration
+func Duration(name string, value time.Duration) time.Duration {
+	if s := os.Getenv(name); s != "" {
+		var err error
+		value, err = time.ParseDuration(s)
 		if err != nil {
 			log.Println(name, err)
 			os.Exit(1)

--- a/support/env/env_test.go
+++ b/support/env/env_test.go
@@ -72,16 +72,17 @@ func TestDuration_set(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Unsetenv(envVar)
 
+	setValue := time.Duration(330000000000)
 	defaultValue := 2 * time.Minute
 	value := env.Duration(envVar, defaultValue)
-	assert.Equal(t, time.Duration(330000000000), value)
+	assert.Equal(t, setValue, value)
 }
 
 // TestDuration_set tests that env.Duration will return the default value given
 // when the environment variable is not set.
 func TestDuration_notSet(t *testing.T) {
-	envVar := randomStr(10)
+	envVar := "TestDuration_notSet_" + randomStr(10)
 	defaultValue := 5*time.Minute + 30*time.Second
 	value := env.Duration(envVar, defaultValue)
-	assert.Equal(t, time.Duration(330000000000), value)
+	assert.Equal(t, defaultValue, value)
 }

--- a/support/env/env_test.go
+++ b/support/env/env_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stellar/go/support/env"
 	"github.com/stellar/go/support/errors"
@@ -60,4 +61,25 @@ func TestInt_notSet(t *testing.T) {
 	envVar := "TestInt_notSet_" + randomStr(10)
 	value := env.Int(envVar, 67890)
 	assert.Equal(t, 67890, value)
+}
+
+// TestDuration_set tests that env.Duration will return the value of the
+// environment variable as a time.Duration when the environment variable is
+// set to a duration string.
+func TestDuration_set(t *testing.T) {
+	envVar := "TestDuration_set_" + randomStr(10)
+	err := os.Setenv(envVar, "5m30s")
+	require.NoError(t, err)
+	defer os.Unsetenv(envVar)
+
+	value := env.Duration(envVar, 5*time.Minute+30*time.Second)
+	assert.Equal(t, time.Duration(330_000_000_000), value)
+}
+
+// TestDuration_set tests that env.Duration will return the default value given
+// when the environment variable is not set.
+func TestDuration_notSet(t *testing.T) {
+	envVar := randomStr(10)
+	value := env.Duration(envVar, 5*time.Minute+30*time.Second)
+	assert.Equal(t, time.Duration(330_000_000_000), value)
 }

--- a/support/env/env_test.go
+++ b/support/env/env_test.go
@@ -73,7 +73,7 @@ func TestDuration_set(t *testing.T) {
 	defer os.Unsetenv(envVar)
 
 	value := env.Duration(envVar, 5*time.Minute+30*time.Second)
-	assert.Equal(t, time.Duration(330_000_000_000), value)
+	assert.Equal(t, time.Duration(330000000000), value)
 }
 
 // TestDuration_set tests that env.Duration will return the default value given
@@ -81,5 +81,5 @@ func TestDuration_set(t *testing.T) {
 func TestDuration_notSet(t *testing.T) {
 	envVar := randomStr(10)
 	value := env.Duration(envVar, 5*time.Minute+30*time.Second)
-	assert.Equal(t, time.Duration(330_000_000_000), value)
+	assert.Equal(t, time.Duration(330000000000), value)
 }

--- a/support/env/env_test.go
+++ b/support/env/env_test.go
@@ -1,0 +1,63 @@
+package env_test
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"testing"
+
+	"github.com/stellar/go/support/env"
+	"github.com/stellar/go/support/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func randomStr(length int) string {
+	raw := make([]byte, (length+1)/2)
+	_, err := rand.Read(raw)
+	if err != nil {
+		err = errors.Wrap(err, "read from crypto/rand failed")
+		panic(err)
+	}
+	return hex.EncodeToString(raw)[:length]
+}
+
+// TestString_set tests that env.String will return the value of the
+// environment variable when the environment variable is set.
+func TestString_set(t *testing.T) {
+	envVar := "TestString_set_" + randomStr(10)
+	err := os.Setenv(envVar, "value")
+	require.NoError(t, err)
+	defer os.Unsetenv(envVar)
+
+	value := env.String(envVar, "default")
+	assert.Equal(t, "value", value)
+}
+
+// TestString_set tests that env.String will return the default value given
+// when the environment variable is not set.
+func TestString_notSet(t *testing.T) {
+	envVar := "TestString_notSet_" + randomStr(10)
+	value := env.String(envVar, "default")
+	assert.Equal(t, "default", value)
+}
+
+// TestInt_set tests that env.Int will return the value of the environment
+// variable as an int when the environment variable is set.
+func TestInt_set(t *testing.T) {
+	envVar := "TestInt_set_" + randomStr(10)
+	err := os.Setenv(envVar, "12345")
+	require.NoError(t, err)
+	defer os.Unsetenv(envVar)
+
+	value := env.Int(envVar, 67890)
+	assert.Equal(t, 12345, value)
+}
+
+// TestInt_set tests that env.Int will return the default value given when the
+// environment variable is not set.
+func TestInt_notSet(t *testing.T) {
+	envVar := "TestInt_notSet_" + randomStr(10)
+	value := env.Int(envVar, 67890)
+	assert.Equal(t, 67890, value)
+}

--- a/support/env/env_test.go
+++ b/support/env/env_test.go
@@ -72,7 +72,8 @@ func TestDuration_set(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Unsetenv(envVar)
 
-	value := env.Duration(envVar, 5*time.Minute+30*time.Second)
+	defaultValue := 2 * time.Minute
+	value := env.Duration(envVar, defaultValue)
 	assert.Equal(t, time.Duration(330000000000), value)
 }
 
@@ -80,6 +81,7 @@ func TestDuration_set(t *testing.T) {
 // when the environment variable is not set.
 func TestDuration_notSet(t *testing.T) {
 	envVar := randomStr(10)
-	value := env.Duration(envVar, 5*time.Minute+30*time.Second)
+	defaultValue := 5*time.Minute + 30*time.Second
+	value := env.Duration(envVar, defaultValue)
 	assert.Equal(t, time.Duration(330000000000), value)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Add `env.Duration` that functions the same as the existing functions `env.Int` and `env.String` but parses the environment variable as a duration string, e.g. `5m30s`, and returns a `time.Duration`.

### Goal and scope

I'm writing some code that already uses the `env` package to read in and parse integers, and I'm writing code to read in a new environment variable that is ultimately a `time.Duration`. It seems useful to make that a first class function that relies on the Go stdlibs definition and parsing of durations. We can use this for any configuration environment variables defining time instead of defining time in seconds, milliseconds, or other arbitrary units, and this makes duration values that we store in environment variables easier to read.

### Summary of changes

- Add tests for existing `env` funcs.
- Add tests for the new `Duration` func
- Add logic for `Duration` function

### Known limitations & issues

- I've copied the existing behavior of using `os.Exit(1)` in the event of an error parsing the input. The use of `os.Exit(1)` rather than a `panic` makes it impossible to test that code path.

### What shouldn't be reviewed

N/A
