### PR TITLE
support/env: use t.Fatal instead of panic in test

### DIFF
--- a/support/env/env_test.go
+++ b/support/env/env_test.go
@@ -15,9 +15,7 @@ import (
 func randomStr(t *testing.T, length int) string {
 	raw := make([]byte, (length+1)/2)
 	_, err := rand.Read(raw)
-	if err != nil {
-		t.Fatalf("error reading from crypto/rand: %v", err)
-	}
+	require.NoError(t, err)
 	return hex.EncodeToString(raw)[:length]
 }
 

--- a/support/env/env_test.go
+++ b/support/env/env_test.go
@@ -8,17 +8,15 @@ import (
 	"time"
 
 	"github.com/stellar/go/support/env"
-	"github.com/stellar/go/support/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func randomStr(length int) string {
+func randomStr(t *testing.T, length int) string {
 	raw := make([]byte, (length+1)/2)
 	_, err := rand.Read(raw)
 	if err != nil {
-		err = errors.Wrap(err, "read from crypto/rand failed")
-		panic(err)
+		t.Fatalf("error reading from crypto/rand: %v", err)
 	}
 	return hex.EncodeToString(raw)[:length]
 }
@@ -26,7 +24,7 @@ func randomStr(length int) string {
 // TestString_set tests that env.String will return the value of the
 // environment variable when the environment variable is set.
 func TestString_set(t *testing.T) {
-	envVar := "TestString_set_" + randomStr(10)
+	envVar := "TestString_set_" + randomStr(t, 10)
 	err := os.Setenv(envVar, "value")
 	require.NoError(t, err)
 	defer os.Unsetenv(envVar)
@@ -38,7 +36,7 @@ func TestString_set(t *testing.T) {
 // TestString_set tests that env.String will return the default value given
 // when the environment variable is not set.
 func TestString_notSet(t *testing.T) {
-	envVar := "TestString_notSet_" + randomStr(10)
+	envVar := "TestString_notSet_" + randomStr(t, 10)
 	value := env.String(envVar, "default")
 	assert.Equal(t, "default", value)
 }
@@ -46,7 +44,7 @@ func TestString_notSet(t *testing.T) {
 // TestInt_set tests that env.Int will return the value of the environment
 // variable as an int when the environment variable is set.
 func TestInt_set(t *testing.T) {
-	envVar := "TestInt_set_" + randomStr(10)
+	envVar := "TestInt_set_" + randomStr(t, 10)
 	err := os.Setenv(envVar, "12345")
 	require.NoError(t, err)
 	defer os.Unsetenv(envVar)
@@ -58,7 +56,7 @@ func TestInt_set(t *testing.T) {
 // TestInt_set tests that env.Int will return the default value given when the
 // environment variable is not set.
 func TestInt_notSet(t *testing.T) {
-	envVar := "TestInt_notSet_" + randomStr(10)
+	envVar := "TestInt_notSet_" + randomStr(t, 10)
 	value := env.Int(envVar, 67890)
 	assert.Equal(t, 67890, value)
 }
@@ -67,7 +65,7 @@ func TestInt_notSet(t *testing.T) {
 // environment variable as a time.Duration when the environment variable is
 // set to a duration string.
 func TestDuration_set(t *testing.T) {
-	envVar := "TestDuration_set_" + randomStr(10)
+	envVar := "TestDuration_set_" + randomStr(t, 10)
 	err := os.Setenv(envVar, "5m30s")
 	require.NoError(t, err)
 	defer os.Unsetenv(envVar)
@@ -81,7 +79,7 @@ func TestDuration_set(t *testing.T) {
 // TestDuration_set tests that env.Duration will return the default value given
 // when the environment variable is not set.
 func TestDuration_notSet(t *testing.T) {
-	envVar := "TestDuration_notSet_" + randomStr(10)
+	envVar := "TestDuration_notSet_" + randomStr(t, 10)
 	defaultValue := 5*time.Minute + 30*time.Second
 	value := env.Duration(envVar, defaultValue)
 	assert.Equal(t, defaultValue, value)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Use `t.Fatal` instead of `panic` in tests in `support/env`.

### Goal and scope

In #1877 I added a helper function `randomStr` which called `panic` in the event there was an error retrieving random data. A `panic` will terminate all tests running and using `t.Fatal` will allow other tests to keep running.

### Summary of changes

- Pass down `t` to helper function
- Use `t.Fatal` instead of `panic`

### Known limitations & issues

N/A

### What shouldn't be reviewed

N/A
