### PR TITLE
support/env: make test helpers more specific and better named

### DIFF
--- a/support/env/env_test.go
+++ b/support/env/env_test.go
@@ -12,17 +12,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func randomStr(t *testing.T, length int) string {
-	raw := make([]byte, (length+1)/2)
+// randomEnvName generates a random name for an environment variable. Calls
+// t.Fatal if sufficient randomness is unavailable.
+func randomEnvName(t *testing.T) string {
+	raw := make([]byte, 5)
 	_, err := rand.Read(raw)
 	require.NoError(t, err)
-	return hex.EncodeToString(raw)[:length]
+	return t.Name() + "_" + hex.EncodeToString(raw)
 }
 
 // TestString_set tests that env.String will return the value of the
 // environment variable when the environment variable is set.
 func TestString_set(t *testing.T) {
-	envVar := "TestString_set_" + randomStr(t, 10)
+	envVar := randomEnvName(t)
 	err := os.Setenv(envVar, "value")
 	require.NoError(t, err)
 	defer os.Unsetenv(envVar)
@@ -34,7 +36,7 @@ func TestString_set(t *testing.T) {
 // TestString_set tests that env.String will return the default value given
 // when the environment variable is not set.
 func TestString_notSet(t *testing.T) {
-	envVar := "TestString_notSet_" + randomStr(t, 10)
+	envVar := randomEnvName(t)
 	value := env.String(envVar, "default")
 	assert.Equal(t, "default", value)
 }
@@ -42,7 +44,7 @@ func TestString_notSet(t *testing.T) {
 // TestInt_set tests that env.Int will return the value of the environment
 // variable as an int when the environment variable is set.
 func TestInt_set(t *testing.T) {
-	envVar := "TestInt_set_" + randomStr(t, 10)
+	envVar := randomEnvName(t)
 	err := os.Setenv(envVar, "12345")
 	require.NoError(t, err)
 	defer os.Unsetenv(envVar)
@@ -54,7 +56,7 @@ func TestInt_set(t *testing.T) {
 // TestInt_set tests that env.Int will return the default value given when the
 // environment variable is not set.
 func TestInt_notSet(t *testing.T) {
-	envVar := "TestInt_notSet_" + randomStr(t, 10)
+	envVar := randomEnvName(t)
 	value := env.Int(envVar, 67890)
 	assert.Equal(t, 67890, value)
 }
@@ -63,7 +65,7 @@ func TestInt_notSet(t *testing.T) {
 // environment variable as a time.Duration when the environment variable is
 // set to a duration string.
 func TestDuration_set(t *testing.T) {
-	envVar := "TestDuration_set_" + randomStr(t, 10)
+	envVar := randomEnvName(t)
 	err := os.Setenv(envVar, "5m30s")
 	require.NoError(t, err)
 	defer os.Unsetenv(envVar)
@@ -77,7 +79,7 @@ func TestDuration_set(t *testing.T) {
 // TestDuration_set tests that env.Duration will return the default value given
 // when the environment variable is not set.
 func TestDuration_notSet(t *testing.T) {
-	envVar := "TestDuration_notSet_" + randomStr(t, 10)
+	envVar := randomEnvName(t)
 	defaultValue := 5*time.Minute + 30*time.Second
 	value := env.Duration(envVar, defaultValue)
 	assert.Equal(t, defaultValue, value)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Rename the `randomStr` test helper that is used in the `support/env` package to `randomEnvName` and make it self contain the length and test name prefix logic.

### Goal and scope

I added the `randomStr` func in #1877 with the original intention I'd be generating a couple types of random strings, but in the end I only used it for generating the names of environment variables of fixed lengths. Since the function has the `testing.T` we can get the function name for the env var and encode the pattern of how it used into the function itself.

### Summary of changes

- Remove length as a parameter and hardcode it to 5, which will result in text strings of 10 length, sufficient for uniqueness.
- Get the test name from `testing.T` instead of hardcoding it.

### Known limitations & issues

N/A

### What shouldn't be reviewed

N/A