### PR TITLE
support/env: use readable presentation of time.Duration value in test

### DIFF
--- a/support/env/env_test.go
+++ b/support/env/env_test.go
@@ -68,7 +68,7 @@ func TestDuration_set(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Unsetenv(envVar)
 
-	setValue := time.Duration(330000000000)
+	setValue := 5*time.Minute + 30*time.Second
 	defaultValue := 2 * time.Minute
 	value := env.Duration(envVar, defaultValue)
 	assert.Equal(t, setValue, value)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] ~I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.~
</details>

### Summary

Replace `time.Duration(330000000000)` with `5*time.Minute + 30*time.Second`.

### Goal and scope

I added the hardcoded value in a test in #1877. @howardtw pointed out it'd be easier to read if it used the `time.Duration` constants.

### Summary of changes

- Replace nanoseconds with minutes and seconds.

### Known limitations & issues

N/A

### What shouldn't be reviewed

N/A
