### PR TITLE
services/horizon/internal: Automate root url generation with query structs.

### DIFF
--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	protocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
@@ -62,6 +63,11 @@ type AccountsQuery struct {
 	AssetType   string `schema:"asset_type" valid:"assetType,optional"`
 	AssetIssuer string `schema:"asset_issuer" valid:"accountID,optional"`
 	AssetCode   string `schema:"asset_code" valid:"-"`
+}
+
+// URITemplate returns a rfc6570 URI template the query struct
+func (q AccountsQuery) URITemplate() string {
+	return "/accounts{?" + strings.Join(getURIParams(&q, true), ",") + "}"
 }
 
 var invalidAccountsParams = problem.P{

--- a/services/horizon/internal/actions/account_test.go
+++ b/services/horizon/internal/actions/account_test.go
@@ -418,3 +418,10 @@ func TestGetAccountsHandlerInvalidParams(t *testing.T) {
 		})
 	}
 }
+
+func TestAccountQueryURLTemplate(t *testing.T) {
+	tt := assert.New(t)
+	expected := "/accounts{?signer,asset_type,asset_issuer,asset_code,cursor,limit,order}"
+	accountsQuery := AccountsQuery{}
+	tt.Equal(expected, accountsQuery.URITemplate())
+}

--- a/services/horizon/internal/actions/helpers_test.go
+++ b/services/horizon/internal/actions/helpers_test.go
@@ -748,3 +748,24 @@ func makeRequest(
 
 	return request.WithContext(ctx)
 }
+
+func TestGetURIParams(t *testing.T) {
+	tt := assert.New(t)
+	type QueryParams struct {
+		SellingBuyingAssetQueryParams `valid:"-"`
+		Account                       string `schema:"account_id" valid:"accountID"`
+	}
+
+	expected := []string{
+		"selling_asset_type",
+		"selling_asset_issuer",
+		"selling_asset_code",
+		"buying_asset_type",
+		"buying_asset_issuer",
+		"buying_asset_code",
+		"account_id",
+	}
+
+	qp := QueryParams{}
+	tt.Equal(expected, getURIParams(&qp, false))
+}

--- a/services/horizon/internal/actions/offer.go
+++ b/services/horizon/internal/actions/offer.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -56,6 +57,11 @@ func (handler GetOfferByID) GetResource(
 type OffersQuery struct {
 	SellingBuyingAssetQueryParams `valid:"-"`
 	Seller                        string `schema:"seller" valid:"accountID,optional"`
+}
+
+// URITemplate returns a rfc6570 URI template the query struct
+func (q OffersQuery) URITemplate() string {
+	return "/offers{?" + strings.Join(getURIParams(&q, true), ",") + "}"
 }
 
 // Validate runs custom validations.

--- a/services/horizon/internal/actions/offer_test.go
+++ b/services/horizon/internal/actions/offer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stellar/go/support/render/hal"
 	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -400,4 +401,11 @@ func pageableToOffers(t *testing.T, page []hal.Pageable) []horizon.Offer {
 		offers = append(offers, entry.(horizon.Offer))
 	}
 	return offers
+}
+
+func TestOffersQueryURLTemplate(t *testing.T) {
+	tt := assert.New(t)
+	expected := "/offers{?selling_asset_type,selling_asset_issuer,selling_asset_code,buying_asset_type,buying_asset_issuer,buying_asset_code,seller,cursor,limit,order}"
+	offersQuery := OffersQuery{}
+	tt.Equal(expected, offersQuery.URITemplate())
 }

--- a/services/horizon/internal/actions_root.go
+++ b/services/horizon/internal/actions_root.go
@@ -20,6 +20,9 @@ type RootAction struct {
 // JSON renders the json response for RootAction
 func (action *RootAction) JSON() error {
 	var res horizon.Root
+	templates := map[string]string{
+		"accounts": actions.AccountsQuery{}.URITemplate(),
+	}
 	resourceadapter.PopulateRoot(
 		action.R.Context(),
 		&res,
@@ -31,6 +34,7 @@ func (action *RootAction) JSON() error {
 		action.App.coreSupportedProtocolVersion,
 		action.App.config.FriendbotURL,
 		action.App.config.EnableExperimentalIngestion,
+		templates,
 	)
 
 	hal.Render(action.W, res)

--- a/services/horizon/internal/actions_root.go
+++ b/services/horizon/internal/actions_root.go
@@ -22,6 +22,7 @@ func (action *RootAction) JSON() error {
 	var res horizon.Root
 	templates := map[string]string{
 		"accounts": actions.AccountsQuery{}.URITemplate(),
+		"offers":   actions.OffersQuery{}.URITemplate(),
 	}
 	resourceadapter.PopulateRoot(
 		action.R.Context(),

--- a/services/horizon/internal/actions_root_test.go
+++ b/services/horizon/internal/actions_root_test.go
@@ -74,5 +74,10 @@ func TestRootActionWithIngestion(t *testing.T) {
 			"http://localhost/accounts{?signer,asset_type,asset_issuer,asset_code,cursor,limit,order}",
 			actual.Links.Accounts.Href,
 		)
+		ht.Assert.Equal(
+			"http://localhost/offers{?selling_asset_type,selling_asset_issuer,selling_asset_code,buying_asset_type,buying_asset_issuer,buying_asset_code,seller,cursor,limit,order}",
+			actual.Links.Offers.Href,
+		)
+
 	}
 }

--- a/services/horizon/internal/actions_root_test.go
+++ b/services/horizon/internal/actions_root_test.go
@@ -41,3 +41,38 @@ func TestRootAction(t *testing.T) {
 		ht.Assert.Equal(int32(3), actual.CurrentProtocolVersion)
 	}
 }
+
+func TestRootActionWithIngestion(t *testing.T) {
+	ht := StartHTTPTest(t, "base")
+	defer ht.Finish()
+
+	server := test.NewStaticMockServer(`{
+			"info": {
+				"network": "test",
+				"build": "test-core",
+				"ledger": {
+					"version": 3
+				},
+				"protocol_version": 4
+			}
+		}`)
+	defer server.Close()
+
+	ht.App.horizonVersion = "test-horizon"
+	ht.App.config.StellarCoreURL = server.URL
+	ht.App.config.NetworkPassphrase = "test"
+	ht.App.UpdateStellarCoreInfo()
+	ht.App.config.EnableExperimentalIngestion = true
+
+	w := ht.Get("/")
+
+	if ht.Assert.Equal(200, w.Code) {
+		var actual horizon.Root
+		err := json.Unmarshal(w.Body.Bytes(), &actual)
+		ht.Require.NoError(err)
+		ht.Assert.Equal(
+			"http://localhost/accounts{?signer,asset_type,asset_issuer,asset_code,cursor,limit,order}",
+			actual.Links.Accounts.Href,
+		)
+	}
+}

--- a/services/horizon/internal/resourceadapter/root.go
+++ b/services/horizon/internal/resourceadapter/root.go
@@ -21,6 +21,7 @@ func PopulateRoot(
 	coreSupportedProtocolVersion int32,
 	friendBotURL *url.URL,
 	experimentalIngestionEnabled bool,
+	templates map[string]string,
 ) {
 	dest.ExpHorizonSequence = ledgerState.ExpHistoryLatest
 	dest.HorizonSequence = ledgerState.HistoryLatest
@@ -45,7 +46,7 @@ func PopulateRoot(
 	dest.Links.Metrics = lb.Link("/metrics")
 
 	if experimentalIngestionEnabled {
-		accountsLink := lb.Link("/accounts?{signer}")
+		accountsLink := lb.Link(templates["accounts"])
 		offerLink := lb.Link("/offers/{offer_id}")
 		offersLink := lb.Link("/offers{?seller,selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,cursor,limit,order}")
 		dest.Links.Accounts = &accountsLink

--- a/services/horizon/internal/resourceadapter/root.go
+++ b/services/horizon/internal/resourceadapter/root.go
@@ -48,7 +48,7 @@ func PopulateRoot(
 	if experimentalIngestionEnabled {
 		accountsLink := lb.Link(templates["accounts"])
 		offerLink := lb.Link("/offers/{offer_id}")
-		offersLink := lb.Link("/offers{?seller,selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,cursor,limit,order}")
+		offersLink := lb.Link(templates["offers"])
 		dest.Links.Accounts = &accountsLink
 		dest.Links.Offer = &offerLink
 		dest.Links.Offers = &offersLink

--- a/services/horizon/internal/resourceadapter/root_test.go
+++ b/services/horizon/internal/resourceadapter/root_test.go
@@ -15,6 +15,7 @@ func TestPopulateRoot(t *testing.T) {
 	res := &horizon.Root{}
 	templates := map[string]string{
 		"accounts": "/accounts{?signer,asset_type,asset_issuer,asset_code}",
+		"offers":   "/offers",
 	}
 
 	PopulateRoot(context.Background(),
@@ -81,7 +82,11 @@ func TestPopulateRoot(t *testing.T) {
 
 	assert.Equal(t, templates["accounts"], res.Links.Accounts.Href)
 	assert.Equal(t, "/offers/{offer_id}", res.Links.Offer.Href)
-	assert.Equal(t, "/offers{?seller,selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,cursor,limit,order}", res.Links.Offers.Href)
+	assert.Equal(
+		t,
+		templates["offers"],
+		res.Links.Offers.Href,
+	)
 }
 
 func urlMustParse(t *testing.T, s string) *url.URL {

--- a/services/horizon/internal/resourceadapter/root_test.go
+++ b/services/horizon/internal/resourceadapter/root_test.go
@@ -13,6 +13,10 @@ import (
 
 func TestPopulateRoot(t *testing.T) {
 	res := &horizon.Root{}
+	templates := map[string]string{
+		"accounts": "/accounts{?signer,asset_type,asset_issuer,asset_code}",
+	}
+
 	PopulateRoot(context.Background(),
 		res,
 		ledger.State{CoreLatest: 1, HistoryLatest: 3, HistoryElder: 2},
@@ -23,6 +27,7 @@ func TestPopulateRoot(t *testing.T) {
 		101,
 		urlMustParse(t, "https://friendbot.example.com"),
 		false,
+		templates,
 	)
 
 	assert.Equal(t, int32(1), res.CoreSequence)
@@ -48,6 +53,7 @@ func TestPopulateRoot(t *testing.T) {
 		101,
 		nil,
 		false,
+		templates,
 	)
 
 	assert.Equal(t, int32(1), res.CoreSequence)
@@ -70,9 +76,10 @@ func TestPopulateRoot(t *testing.T) {
 		101,
 		urlMustParse(t, "https://friendbot.example.com"),
 		true,
+		templates,
 	)
 
-	assert.Equal(t, "/accounts?{signer}", res.Links.Accounts.Href)
+	assert.Equal(t, templates["accounts"], res.Links.Accounts.Href)
 	assert.Equal(t, "/offers/{offer_id}", res.Links.Offer.Href)
 	assert.Equal(t, "/offers{?seller,selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,cursor,limit,order}", res.Links.Offers.Href)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### Summary

Automate URI template generation using query struct and schema tag. Fixes #1884. This will also help us towards #1839

### Goal and scope

- Use query structs to generate a valid rfc6570 URI template

### Summary of changes

- Extend helper to read schema value from a given struct.
- Create helper function in query param struct to return URI template.
- Use URI template from query structs in root url generation.

### Known limitations & issues

- N/A

### What shouldn't be reviewed

- N/A
