### PR TITLE
doc: lower the barrier-to-entry of writing great pr descriptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
-<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
-template and use a short description. -->
+<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
+template and use a short description, but in your description aim to include both what the
+change is, and why it is being made, with enough context for anyone to understand. -->
 
 <details>
   <summary>PR Checklist</summary>
@@ -29,22 +30,14 @@ template and use a short description. -->
   release branch if it's not a patch change.
 </details>
 
-### Summary
+### What
 
-[TODO]
+[TODO: Short statement about what is changing.]
 
-### Goal and scope
+### Why
 
-[TODO]
+[TODO: Why this change is being made. Include any context required to understand the why.]
 
-### Summary of changes
+### Known limitations
 
-[TODO]
-
-### Known limitations & issues
-
-[TODO]
-
-### What shouldn't be reviewed
-
-[TODO]
+[TODO or N/A]


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, just delete this
template and use a short description, but in your description always aim to include clearly both
what the change is, and why it is being made with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] ~I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.~
</details>

### What

Change the PR template to use simple language and less concepts. Change
the `goal and scope` question to simply `why`, asking that question
directly and as simply as possible.

- Change `Summary` to `What`.
- Change `Goal and scope` to `Why`.
- Remove `Summary of changes`
- Remove `What shouldn't be reviewed`

### Why

To focus the bulk of the effort of our PR descriptions on the most
important thing to communicate, the `why`. And to reduce the effort
required to complete the PR template so that we are more likely to
communicate that why consistently.

Our PR template is large. It contains a lot of great things, like the
questions in its checklist. However:
- Some of these sections are rarely used, and when they are it is with
minimal gain.
  - `Summary of changes` often repeats the `Summary` or lists the code
that is changing, which can be more clearly understood by looking at the
diff of any appropriately narrow change.
  - `What shouldn't be reviewed` is often not required since most
changes need to be fully reviewed and what should be reviewed should
almost always be a decision made by the reviewer.
- Some of these sections are ambiguous as to what exact questions are
important for the author to answer by their contents. e.g. `Summary`.
- And, some of these sections mix multiple questions and concepts
together, and use terms that are not part of the everyday language we
use when talking with one another. e.g. `Goal and scope`.

Browsing through our PRs I can see that most of the time we write a
compelling narrative under the `Summary` section, then our use of the
other sections is different from person-to-person. I think this points
to those sections being ambiguous.

We also aren't quick to adopt the template on new repositories which
suggests that we see some value in it, but maybe not for the effort it
requires.

We can maximize the value we get from this PR template and minimize the
effort required to use it by simplifying the language and focusing it on
answering the two most common questions a reader will have.

The most natural questions that arise out of any conversation about a
proposal is to first communicate `what` the proposal is and `why` it is
meaningful. To express our changes and ideas in this way is natural and
accessible.

This change renames `Summary` to `What` because the first question we
have about a PR is about what it adds, changes or removes. `What` is not
a description of the code change, but a description of the conceptual
change. This section is brief, focused only on what, and not on
describing how or why the change is being made. `How` is better answered
by the code diff, and separating the `why` ensures it is a first-class
concept that gets answered in full. We're committed to narrowly scoped
PRs and so the `what` paragraph will be one or two sentences at most.
In the event a PR is cannot be narrowly scoped, this is also a good
place to include a list of the changes, but that will be rare.

This change renames `Goal and scope` to `Why`. It drops `scope` because
that term is not part of everyday language and is more useful when
planning the work. If a change does have interesting scope the author
can still discuss that in the why section. Surfacing the topic of scope
in the title can be distracting from the most important thing we have to
communicate, `why`. The change renams `goal` to `why` because `why` is
broader in meaning, and more common in everyday language. Any
communication we can make using everyday language is lower effort and
higher throughput.

When we focus the bulk of our PR description on communicating why it
helps others developers and our future selves understand the context and
intention behind our change, and that helps others review our PRs faster
because they are starting on a similar page as ourselves.

`Known limitations` is rarely used but it seems to deliver significant value
when it is answered. This proposal doesn't change anything about it because
of this.

### Known limitations

N/A