### PR TITLE
services/horizon/internal/actions: Update asset filter on accounts

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -13,9 +13,9 @@ bumps.  A breaking change will get clearly notified in this log.
 * Fixes a bug in `/paths/strict-send`.
 * Add experimental support for filtering accounts who are trustees to an asset via `/accounts`. To enable it, set `--enable-experimental-ingestion` CLI param or `ENABLE_EXPERIMENTAL_INGESTION=true` env variable. ([#1835](https://github.com/stellar/go/pull/1835))
   
-    The following request will return all accounts who have a trustline to the asset identified by `asset_type=credit_alphanum4`, `asset_code=COP`, and `asset_issuer=GC2GFGZ5CZCFCDJSQF3YYEAYBOS3ZREXJSPU7LUJ7JU3LP3BQNHY7YKS`:
+    The following request will return all accounts who have a trustline to the asset `COP` issued by `GC2GFGZ5CZCFCDJSQF3YYEAYBOS3ZREXJSPU7LUJ7JU3LP3BQNHY7YKS`:
     
-     `/accounts?asset_type=credit_alphanum4&asset_code=COP&asset_issuer=GC2GFGZ5CZCFCDJSQF3YYEAYBOS3ZREXJSPU7LUJ7JU3LP3BQNHY7YKS`
+     `/accounts?asset=COP:GC2GFGZ5CZCFCDJSQF3YYEAYBOS3ZREXJSPU7LUJ7JU3LP3BQNHY7YKS`
 * Update payload in experimental "Accounts For Signers" end-point to return an account resource. ([#1876](https://github.com/stellar/go/pull/1876))
 
 ## v0.22.1

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -60,9 +60,7 @@ func AccountInfo(ctx context.Context, cq *core.Q, addr string) (*protocol.Accoun
 // AccountsQuery query struct for accounts end-point
 type AccountsQuery struct {
 	Signer      string `schema:"signer" valid:"accountID,optional"`
-	AssetType   string `schema:"asset_type" valid:"assetType,optional"`
-	AssetIssuer string `schema:"asset_issuer" valid:"accountID,optional"`
-	AssetCode   string `schema:"asset_code" valid:"-"`
+	AssetFilter string `schema:"asset" valid:"asset,optional"`
 }
 
 // URITemplate returns a rfc6570 URI template the query struct
@@ -79,13 +77,15 @@ var invalidAccountsParams = problem.P{
 
 // Validate runs custom validations.
 func (q AccountsQuery) Validate() error {
-	if len(q.Signer) == 0 && q.Asset() == nil {
-		return invalidAccountsParams
+	if q.AssetFilter == "native" {
+		return problem.MakeInvalidFieldProblem(
+			"asset",
+			errors.New("you can't filter by asset: native"),
+		)
 	}
 
-	err := validateAssetParams(q.AssetType, q.AssetCode, q.AssetIssuer, "")
-	if err != nil {
-		return err
+	if len(q.Signer) == 0 && q.Asset() == nil {
+		return invalidAccountsParams
 	}
 
 	if len(q.Signer) > 0 && q.Asset() != nil {
@@ -95,31 +95,17 @@ func (q AccountsQuery) Validate() error {
 		)
 	}
 
-	if q.Asset() != nil && q.AssetType == "native" {
-		return problem.MakeInvalidFieldProblem(
-			"asset_type",
-			errors.New("you can't filter by asset type: native"),
-		)
-	}
-
 	return nil
 }
 
 // Asset returns an xdr.Asset representing the Asset we want to find the trustees by.
 func (q AccountsQuery) Asset() *xdr.Asset {
-	if len(q.AssetType) == 0 {
+	if len(q.AssetFilter) == 0 {
 		return nil
 	}
 
-	asset, err := xdr.BuildAsset(
-		q.AssetType,
-		q.AssetIssuer,
-		q.AssetCode,
-	)
-
-	if err != nil {
-		panic(err)
-	}
+	parts := strings.Split(q.AssetFilter, ":")
+	asset := xdr.MustNewCreditAsset(parts[0], parts[1])
 
 	return &asset
 }

--- a/services/horizon/internal/actions/account_test.go
+++ b/services/horizon/internal/actions/account_test.go
@@ -299,9 +299,7 @@ func TestGetAccountsHandlerPageResultsByAsset(t *testing.T) {
 	var assetType, code, issuer string
 	usd.MustExtract(&assetType, &code, &issuer)
 	params := map[string]string{
-		"asset_issuer": issuer,
-		"asset_code":   code,
-		"asset_type":   assetType,
+		"asset": code + ":" + issuer,
 	}
 
 	records, err := handler.GetResourcePage(
@@ -358,10 +356,8 @@ func TestGetAccountsHandlerInvalidParams(t *testing.T) {
 		{
 			desc: "signer and seller",
 			params: map[string]string{
-				"signer":       accountOne,
-				"asset_issuer": accountOne,
-				"asset_code":   "USD",
-				"asset_type":   "credit_alphanum4",
+				"signer": accountOne,
+				"asset":  "USD" + ":" + accountOne,
 			},
 			expectedInvalidField: "signer",
 			expectedErr:          "you can't filter by signer and asset at the same time",
@@ -369,20 +365,19 @@ func TestGetAccountsHandlerInvalidParams(t *testing.T) {
 		{
 			desc: "filtering by native asset",
 			params: map[string]string{
-				"asset_type": "native",
+				"asset": "native",
 			},
-			expectedInvalidField: "asset_type",
-			expectedErr:          "you can't filter by asset type: native",
+			expectedInvalidField: "asset",
+			expectedErr:          "you can't filter by asset: native",
 		},
 		{
 			desc: "invalid asset",
 			params: map[string]string{
 				"asset_issuer": accountOne,
-				"asset_code":   "USDCOP",
-				"asset_type":   "credit_alphanum4",
+				"asset":        "USDCOP:someissuer",
 			},
-			expectedInvalidField: "asset_code",
-			expectedErr:          "Asset code must be 1-12 alphanumeric characters",
+			expectedInvalidField: "asset",
+			expectedErr:          customTagsErrorMessages["asset"],
 		},
 	}
 	for _, tc := range testCases {
@@ -421,7 +416,7 @@ func TestGetAccountsHandlerInvalidParams(t *testing.T) {
 
 func TestAccountQueryURLTemplate(t *testing.T) {
 	tt := assert.New(t)
-	expected := "/accounts{?signer,asset_type,asset_issuer,asset_code,cursor,limit,order}"
+	expected := "/accounts{?signer,asset,cursor,limit,order}"
 	accountsQuery := AccountsQuery{}
 	tt.Equal(expected, accountsQuery.URITemplate())
 }

--- a/services/horizon/internal/actions/validators_test.go
+++ b/services/horizon/internal/actions/validators_test.go
@@ -98,3 +98,67 @@ func TestAccountIDValidator(t *testing.T) {
 		})
 	}
 }
+
+func TestAssetValidator(t *testing.T) {
+	type Query struct {
+		Asset string `valid:"asset"`
+	}
+
+	for _, testCase := range []struct {
+		desc  string
+		asset string
+		valid bool
+	}{
+		{
+			"native",
+			"native",
+			true,
+		},
+		{
+			"credit_alphanum4",
+			"USD:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+			true,
+		},
+		{
+			"credit_alphanum12",
+			"SDFUSD:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+			true,
+		},
+		{
+			"invalid credit_alphanum12",
+			"SDFUSDSDFUSDSDFUSD:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+			false,
+		},
+		{
+			"invalid no issuer",
+			"FOO",
+			false,
+		},
+		{
+			"invalid issuer",
+			"FOO:BAR",
+			false,
+		},
+		{
+			"empty colon",
+			":",
+			false,
+		},
+	} {
+		t.Run(testCase.desc, func(t *testing.T) {
+			tt := assert.New(t)
+
+			q := Query{
+				Asset: testCase.asset,
+			}
+
+			result, err := govalidator.ValidateStruct(q)
+			if testCase.valid {
+				tt.NoError(err)
+				tt.True(result)
+			} else {
+				tt.Error(err)
+			}
+		})
+	}
+}

--- a/services/horizon/internal/actions_root_test.go
+++ b/services/horizon/internal/actions_root_test.go
@@ -71,7 +71,7 @@ func TestRootActionWithIngestion(t *testing.T) {
 		err := json.Unmarshal(w.Body.Bytes(), &actual)
 		ht.Require.NoError(err)
 		ht.Assert.Equal(
-			"http://localhost/accounts{?signer,asset_type,asset_issuer,asset_code,cursor,limit,order}",
+			"http://localhost/accounts{?signer,asset,cursor,limit,order}",
 			actual.Links.Accounts.Href,
 		)
 		ht.Assert.Equal(

--- a/services/horizon/internal/docs/reference/endpoints/accounts.md
+++ b/services/horizon/internal/docs/reference/endpoints/accounts.md
@@ -4,14 +4,14 @@ title: Accounts
 
 This endpoint allows filtering accounts who have a given `signer` or have a trustline to an `asset`. The result is a list of [accounts](../resources/account.md).
 
-To find all accounts who are trustees to asset, specify the asset using the query parameters `asset_type`, `asset_code` and `asset_issuer`.
+To find all accounts who are trustees to an asset, pass the query parameter `asset` using the canonical representation for an issued assets which is `Code:IssuerAccountID`. Read more about canonical representation of assets in [SEP-0011](https://github.com/stellar/stellar-protocol/blob/0c675fb3a482183dcf0f5db79c12685acf82a95c/ecosystem/sep-0011.md#values).
 
 **Note**: This endpoint is still experimental and available only if Horizon is running the [new ingestion system](https://github.com/stellar/go/blob/master/services/horizon/internal/expingest/BETA_TESTING.md).
 
 ## Request
 
 ```
-GET /accounts{?signer,asset_type,asset_issuer,asset_code,cursor,limit,order}
+GET /accounts{?signer,asset,cursor,limit,order}
 ```
 
 ### Arguments
@@ -19,9 +19,7 @@ GET /accounts{?signer,asset_type,asset_issuer,asset_code,cursor,limit,order}
 | name | notes | description | example |
 | ---- | ----- | ----------- | ------- |
 | `?signer` | optional, string | Account ID | GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB |
-| `?asset_type` | required, string | Type of the Asset  | `credit_alphanum4` |
-| `?asset_code` | required if `asset_type` is not `native`, string | Code of the Asset  | `USD` |
-| `?asset_issuer` | required if `asset_type` is not `native`, string | Account ID of the issuer of the Asset | `GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36` |
+| `?asset` | optional, string | An issued asset represented as "Code:IssuerAccountID". | `USD:GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V,native` |
 | `?cursor` | optional, default _null_ | A paging token, specifying where to start returning records from. | `GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36` |
 | `?order` | optional, string, default `asc` | The order in which to return rows, "asc" or "desc". | `asc` |
 | `?limit` | optional, number, default `10` | Maximum number of records to return. | `200` |


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Use canonical representation for issued assets as defined in SEP0011 to filter accounts who have a trustline to an asset.

### Why

Being able to specify  an asset using a single parameter  `AssetCode:Issuer` is more ergonomic than having to define three different query params: `type`, `code` and `issuer`.

### Known limitations

[TODO or N/A]
