### PR TITLE
services/horizon/internal/docs: Use full links instead of relative links.

### DIFF
--- a/services/horizon/internal/docs/reference/endpoints/path-finding-strict-receive.md
+++ b/services/horizon/internal/docs/reference/endpoints/path-finding-strict-receive.md
@@ -8,7 +8,7 @@ The Stellar Network allows payments to be made across assets through _path payme
 payment specifies a series of assets to route a payment through, from source asset (the asset
 debited from the payer) to destination asset (the asset credited to the payee).
 
-A [Path Payment Strict Receive](../../../guides/concepts/list-of-operations.html#path-payment-strict-receive) allows a user to specify the *amount of the asset received*. The amount sent varies based on offers in the order books.  If you would like to search for a path specifying the amount to be sent, use the [Find Payment Paths (Strict Send)](./path-finding-strict-send.html).
+A [Path Payment Strict Receive](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#path-payment-strict-receive) allows a user to specify the *amount of the asset received*. The amount sent varies based on offers in the order books.  If you would like to search for a path specifying the amount to be sent, use the [Find Payment Paths (Strict Send)](./path-finding-strict-send.html).
 
 A strict receive path search is specified using:
 

--- a/services/horizon/internal/docs/reference/endpoints/path-finding-strict-send.md
+++ b/services/horizon/internal/docs/reference/endpoints/path-finding-strict-send.md
@@ -8,7 +8,7 @@ The Stellar Network allows payments to be made across assets through _path payme
 payment specifies a series of assets to route a payment through, from source asset (the asset
 debited from the payer) to destination asset (the asset credited to the payee).
 
-A [Path Payment Strict Send](../../../guides/concepts/list-of-operations.html#path-payment-strict-send) allows a user to specify the amount of the asset to send. The amount received will vary based on offers in the order books.
+A [Path Payment Strict Send](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#path-payment-strict-send) allows a user to specify the amount of the asset to send. The amount received will vary based on offers in the order books.
 
 
 A path payment strict send search is specified using:

--- a/services/horizon/internal/docs/reference/endpoints/transactions-create.md
+++ b/services/horizon/internal/docs/reference/endpoints/transactions-create.md
@@ -36,7 +36,7 @@ If you are encountering this error it means that either:
 The former case may happen because there was no room for your transaction in the 3 consecutive ledgers. In such case, Core server removes a transaction from a queue. To solve this you can either:
 
 * Keep resubmitting the same transaction (with the same sequence number) and wait until it finally is added to a new ledger or:
-* Increase the [fee](../../../guides/concepts/fees.html).
+* Increase the [fee](https://www.stellar.org/developers/guides/concepts/fees.html).
 
 ## Request
 

--- a/services/horizon/internal/docs/reference/errors/transaction-malformed.md
+++ b/services/horizon/internal/docs/reference/errors/transaction-malformed.md
@@ -7,8 +7,8 @@ error. There are many ways in which a transaction could be malformed, including:
 
 - You submitted an empty string.
 - Your base64-encoded string is invalid.
-- Your [XDR](../../learn/xdr.md) structure is invalid.
-- You have leftover bytes in your [XDR](../../learn/xdr.md) structure.
+- Your [XDR](https://www.stellar.org/developers/guides/concepts/xdr.html) structure is invalid.
+- You have leftover bytes in your [XDR](https://www.stellar.org/developers/guides/concepts/xdr.html) structure.
 
 If you are encountering this error, please check the contents of the transaction you are
 submitting. This error returns a

--- a/services/horizon/internal/docs/reference/resources/ledger.md
+++ b/services/horizon/internal/docs/reference/resources/ledger.md
@@ -12,7 +12,7 @@ To learn more about the concept of ledgers in the Stellar network, take a look a
 |------------------------------|--------|-------------------------------------------------------------------------------------------------------------------------------|
 | id                           | string | The id is a unique identifier for this ledger.                                                                                |
 | paging_token                 | number | A [paging token](./page.md) suitable for use as a `cursor` parameter.                                                         |
-| hash                         | string | A hex-encoded SHA-256 hash of the ledger's [XDR](../../learn/xdr.md)-encoded form.                                            |
+| hash                         | string | A hex-encoded SHA-256 hash of the ledger's [XDR](https://www.stellar.org/developers/guides/concepts/xdr.html)-encoded form.                                            |
 | prev_hash                    | string | The hash of the ledger that chronologically came before this one.                                                             |
 | sequence                     | number | Sequence number of this ledger, suitable for use as the as the :id parameter for url templates that require a ledger number.  |
 | transaction_count            | number | *REMOVED in 0.17.0: USE `successful_transaction_count` INSTEAD*. The number of successful transactions in this ledger.               |

--- a/services/horizon/internal/docs/reference/resources/transaction.md
+++ b/services/horizon/internal/docs/reference/resources/transaction.md
@@ -15,7 +15,7 @@ To learn more about the concept of transactions in the Stellar network, take a l
 | id               | string | The canonical id of this transaction, suitable for use as the :id parameter for url templates that require a transaction's ID. |
 | paging_token     | string | A [paging token](./page.md) suitable for use as the `cursor` parameter to transaction collection resources.                   |
 | successful       | bool | *From 0.17.0* Indicates if transaction was successful or not.       |
-| hash             | string | A hex-encoded SHA-256 hash of the transaction's [XDR](../../learn/xdr.md)-encoded form.                                                              |
+| hash             | string | A hex-encoded SHA-256 hash of the transaction's [XDR](https://www.stellar.org/developers/guides/concepts/xdr.html)-encoded form.                                                              |
 | ledger           | number | Sequence number of the ledger in which this transaction was applied.       |
 | created_at       | ISO8601 string | |
 | source_account   | string |                                                                                                                                |
@@ -110,4 +110,4 @@ To learn more about the concept of transactions in the Stellar network, take a l
 
 
 ## Submitting transactions
-To submit a new transaction to Stellar network, it must first be built and signed locally. Then you can submit a hex representation of your transaction’s [XDR](../../learn/xdr.md) to the `/transactions` endpoint. Read more about submitting transactions in [Post Transaction](../transactions-create.md) doc.
+To submit a new transaction to Stellar network, it must first be built and signed locally. Then you can submit a hex representation of your transaction’s [XDR](https://www.stellar.org/developers/guides/concepts/xdr.html) to the `/transactions` endpoint. Read more about submitting transactions in [Post Transaction](../transactions-create.md) doc.

--- a/services/horizon/internal/docs/reference/tutorials/follow-received-payments.md
+++ b/services/horizon/internal/docs/reference/tutorials/follow-received-payments.md
@@ -168,9 +168,9 @@ New payment:
 
 ## Testing it out
 
-We now know how to get a stream of transactions to an account. Let's check if our solution actually works and if new payments appear. Let's watch as we send a payment ([`create_account` operation](../../../guides/concepts/list-of-operations.html#create-account)) from our account to another account.
+We now know how to get a stream of transactions to an account. Let's check if our solution actually works and if new payments appear. Let's watch as we send a payment ([`create_account` operation](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#create-account)) from our account to another account.
 
-We use the `create_account` operation because we are sending payment to a new, unfunded account. If we were sending payment to an account that is already funded, we would use the [`payment` operation](../../../guides/concepts/list-of-operations.html#payment).
+We use the `create_account` operation because we are sending payment to a new, unfunded account. If we were sending payment to an account that is already funded, we would use the [`payment` operation](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#payment).
 
 First, let's check our account sequence number so we can create a payment transaction. To do this we send a request to horizon:
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Use full URL for some links.

### Why

Some of the fixed links don't work today in the production docs and also fixes some links added in https://github.com/stellar/go/pull/1887

### Known limitations

N/A
