### PR TITLE
support/historyarchive: Provide mechanism for retrying XDR stream errors

### DIFF
--- a/exp/ingest/adapters/history_archive_adapter.go
+++ b/exp/ingest/adapters/history_archive_adapter.go
@@ -49,7 +49,12 @@ func (haa *HistoryArchiveAdapter) BucketListHash(sequence uint32) (xdr.Hash, err
 }
 
 // GetState returns a reader with the state of the ledger at the provided sequence number
-func (haa *HistoryArchiveAdapter) GetState(sequence uint32, tempSet io.TempSet) (io.StateReader, error) {
+// `maxStreamRetries` determines how many times the reader will retry when encountering
+// errors while streaming xdr bucket entries from the history archive.
+// Set `maxStreamRetries` to 0 if there should be no retry attempts
+func (haa *HistoryArchiveAdapter) GetState(
+	sequence uint32, tempSet io.TempSet, maxStreamRetries int,
+) (io.StateReader, error) {
 	exists, err := haa.archive.CategoryCheckpointExists("history", sequence)
 	if err != nil {
 		return nil, errors.Wrap(err, "error checking if category checkpoint exists")
@@ -58,7 +63,7 @@ func (haa *HistoryArchiveAdapter) GetState(sequence uint32, tempSet io.TempSet) 
 		return nil, fmt.Errorf("history checkpoint does not exist for ledger %d", sequence)
 	}
 
-	sr, e := io.MakeSingleLedgerStateReader(haa.archive, tempSet, sequence)
+	sr, e := io.MakeSingleLedgerStateReader(haa.archive, tempSet, sequence, maxStreamRetries)
 	if e != nil {
 		return nil, errors.Wrap(e, "could not make memory state reader")
 	}

--- a/exp/ingest/adapters/history_archive_adapter_test.go
+++ b/exp/ingest/adapters/history_archive_adapter_test.go
@@ -37,7 +37,7 @@ func TestGetState_Sequence(t *testing.T) {
 		return
 	}
 
-	sr, e := haa.GetState(seq, &io.MemoryTempSet{})
+	sr, e := haa.GetState(seq, &io.MemoryTempSet{}, 0)
 	if !assert.NoError(t, e) {
 		return
 	}
@@ -51,7 +51,7 @@ func TestGetState_Read(t *testing.T) {
 	}
 	haa := MakeHistoryArchiveAdapter(archive)
 
-	sr, e := haa.GetState(21686847, &io.MemoryTempSet{})
+	sr, e := haa.GetState(21686847, &io.MemoryTempSet{}, 0)
 	if !assert.NoError(t, e) {
 		return
 	}

--- a/exp/ingest/io/single_ledger_state_reader.go
+++ b/exp/ingest/io/single_ledger_state_reader.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-var log = logpkg.DefaultLogger.WithField("service", "expingest")
+var log = logpkg.DefaultLogger.WithField("component", "SingleLedgerStateReader")
 
 // readResult is the result of reading a bucket value
 type readResult struct {
@@ -169,9 +169,12 @@ func (msr *SingleLedgerStateReader) streamBuckets() {
 	}
 }
 
+// readBucketEntry will attempt to read a bucket entry from `stream`.
+// If any errors are encountered while reading from `stream`, readBucketEntry will
+// retry the operation using a new *historyarchive.XdrStream.
+// The total number of retries will not exceed `maxStreamRetries`.
 func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrStream, hash historyarchive.Hash) (
 	xdr.BucketEntry,
-	*historyarchive.XdrStream,
 	error,
 ) {
 	var entry xdr.BucketEntry
@@ -189,6 +192,12 @@ func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrSt
 			break
 		}
 
+		err = stream.CloseWithoutValidation()
+		if err != nil {
+			err = errors.Wrap(err, "Error closing stream")
+			break
+		}
+
 		log.WithFields(logpkg.F{
 			"hash":            hash.String(),
 			"currentPosition": currentPosition,
@@ -203,8 +212,7 @@ func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrSt
 			break
 		}
 
-		stream.Close()
-		stream = retryStream
+		*stream = *retryStream
 
 		_, err = stream.Discard(currentPosition)
 		if err != nil {
@@ -217,7 +225,7 @@ func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrSt
 		}
 	}
 
-	return entry, stream, err
+	return entry, err
 }
 
 func (msr *SingleLedgerStateReader) newXDRStream(hash historyarchive.Hash) (
@@ -271,7 +279,7 @@ LoopBucketEntry:
 
 			for i := 0; i < preloadedEntries; i++ {
 				var entry xdr.BucketEntry
-				entry, rdr, e = msr.readBucketEntry(rdr, hash)
+				entry, e = msr.readBucketEntry(rdr, hash)
 				if e != nil {
 					if e == io.EOF {
 						if len(batch) == 0 {

--- a/exp/ingest/io/single_ledger_state_reader.go
+++ b/exp/ingest/io/single_ledger_state_reader.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/historyarchive"
-	ilog "github.com/stellar/go/support/log"
+	logpkg "github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 )
 
-var log = ilog.DefaultLogger.WithField("service", "expingest")
+var log = logpkg.DefaultLogger.WithField("service", "expingest")
 
 // readResult is the result of reading a bucket value
 type readResult struct {
@@ -189,7 +189,7 @@ func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrSt
 			break
 		}
 
-		log.WithFields(ilog.F{
+		log.WithFields(logpkg.F{
 			"hash":            hash.String(),
 			"currentPosition": currentPosition,
 		}).Info("Restarting xdr stream")
@@ -208,7 +208,7 @@ func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrSt
 
 		_, err = stream.Discard(currentPosition)
 		if err != nil {
-			log.WithFields(ilog.F{
+			log.WithFields(logpkg.F{
 				"hash":         hash.String(),
 				"discardBytes": currentPosition,
 			}).WithError(err).Info("could not fast forward retry xdr stream")

--- a/exp/ingest/io/single_ledger_state_reader.go
+++ b/exp/ingest/io/single_ledger_state_reader.go
@@ -8,11 +8,8 @@ import (
 
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/historyarchive"
-	logpkg "github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 )
-
-var log = logpkg.DefaultLogger.WithField("component", "SingleLedgerStateReader")
 
 // readResult is the result of reading a bucket value
 type readResult struct {
@@ -186,8 +183,6 @@ func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrSt
 		if err == nil || err == io.EOF {
 			break
 		}
-		log.WithError(err).WithField("hash", hash.String()).
-			Info("could not read from xdr stream")
 		if attempts >= msr.maxStreamRetries {
 			break
 		}
@@ -198,16 +193,9 @@ func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrSt
 			break
 		}
 
-		log.WithFields(logpkg.F{
-			"hash":            hash.String(),
-			"currentPosition": currentPosition,
-		}).Info("Restarting xdr stream")
-
 		var retryStream *historyarchive.XdrStream
 		retryStream, err = msr.newXDRStream(hash)
 		if err != nil {
-			log.WithError(err).WithField("hash", hash.String()).
-				Info("could not create retry xdr stream")
 			err = errors.Wrap(err, "Error creating new xdr stream")
 			break
 		}
@@ -216,10 +204,6 @@ func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrSt
 
 		_, err = stream.Discard(currentPosition)
 		if err != nil {
-			log.WithFields(logpkg.F{
-				"hash":         hash.String(),
-				"discardBytes": currentPosition,
-			}).WithError(err).Info("could not fast forward retry xdr stream")
 			err = errors.Wrap(err, "Error discarding from xdr stream")
 			break
 		}

--- a/exp/ingest/io/single_ledger_state_reader.go
+++ b/exp/ingest/io/single_ledger_state_reader.go
@@ -8,8 +8,11 @@ import (
 
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/historyarchive"
+	ilog "github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 )
+
+var log = ilog.DefaultLogger.WithField("service", "expingest")
 
 // readResult is the result of reading a bucket value
 type readResult struct {
@@ -31,6 +34,9 @@ type SingleLedgerStateReader struct {
 	streamOnce sync.Once
 	closeOnce  sync.Once
 	done       chan bool
+	// how many times should we retry when there are errors in
+	// the xdr stream returned by GetXdrStreamForHash()
+	maxStreamRetries int
 
 	// This should be set to true in tests only
 	disableBucketListHashValidation bool
@@ -62,11 +68,15 @@ const msrBufferSize = 50000
 // temp set.
 const preloadedEntries = 20000
 
-// MakeSingleLedgerStateReader is a factory method for SingleLedgerStateReader
+// MakeSingleLedgerStateReader is a factory method for SingleLedgerStateReader.
+// `maxStreamRetries` determines how many times the reader will retry when encountering
+// errors while streaming xdr bucket entries from the history archive.
+// Set `maxStreamRetries` to 0 if there should be no retry attempts
 func MakeSingleLedgerStateReader(
 	archive historyarchive.ArchiveInterface,
 	tempStore TempSet,
 	sequence uint32,
+	maxStreamRetries int,
 ) (*SingleLedgerStateReader, error) {
 	has, err := archive.GetCheckpointHAS(sequence)
 	if err != nil {
@@ -79,14 +89,15 @@ func MakeSingleLedgerStateReader(
 	}
 
 	return &SingleLedgerStateReader{
-		has:        &has,
-		archive:    archive,
-		tempStore:  tempStore,
-		sequence:   sequence,
-		readChan:   make(chan readResult, msrBufferSize),
-		streamOnce: sync.Once{},
-		closeOnce:  sync.Once{},
-		done:       make(chan bool),
+		has:              &has,
+		archive:          archive,
+		tempStore:        tempStore,
+		sequence:         sequence,
+		readChan:         make(chan readResult, msrBufferSize),
+		streamOnce:       sync.Once{},
+		closeOnce:        sync.Once{},
+		done:             make(chan bool),
+		maxStreamRetries: maxStreamRetries,
 	}, nil
 }
 
@@ -158,18 +169,77 @@ func (msr *SingleLedgerStateReader) streamBuckets() {
 	}
 }
 
-// streamBucketContents pushes value onto the read channel, returning false when the channel needs to be closed otherwise true
-func (msr *SingleLedgerStateReader) streamBucketContents(hash historyarchive.Hash) bool {
-	rdr, e := msr.archive.GetXdrStreamForHash(hash)
-	if e != nil {
-		msr.readChan <- msr.error(fmt.Errorf("cannot get xdr stream for hash '%s': %s", hash.String(), e))
-		return false
+func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrStream, hash historyarchive.Hash) (
+	xdr.BucketEntry,
+	*historyarchive.XdrStream,
+	error,
+) {
+	var entry xdr.BucketEntry
+	var err error
+	currentPosition := stream.BytesRead()
+
+	for attempts := 0; ; attempts++ {
+		err = stream.ReadOne(&entry)
+		if err == nil || err == io.EOF {
+			break
+		}
+		log.WithError(err).WithField("hash", hash.String()).
+			Info("could not read from xdr stream")
+		if attempts >= msr.maxStreamRetries {
+			break
+		}
+
+		log.WithFields(ilog.F{
+			"hash":            hash.String(),
+			"currentPosition": currentPosition,
+		}).Info("Restarting xdr stream")
+
+		var retryStream *historyarchive.XdrStream
+		retryStream, err = msr.newXDRStream(hash)
+		if err != nil {
+			log.WithError(err).WithField("hash", hash.String()).
+				Info("could not create retry xdr stream")
+			err = errors.Wrap(err, "Error creating new xdr stream")
+			break
+		}
+
+		stream.Close()
+		stream = retryStream
+
+		_, err = stream.Discard(currentPosition)
+		if err != nil {
+			log.WithFields(ilog.F{
+				"hash":         hash.String(),
+				"discardBytes": currentPosition,
+			}).WithError(err).Info("could not fast forward retry xdr stream")
+			err = errors.Wrap(err, "Error discarding from xdr stream")
+			break
+		}
 	}
 
-	if !msr.disableBucketListHashValidation {
+	return entry, stream, err
+}
+
+func (msr *SingleLedgerStateReader) newXDRStream(hash historyarchive.Hash) (
+	*historyarchive.XdrStream,
+	error,
+) {
+	rdr, e := msr.archive.GetXdrStreamForHash(hash)
+	if e == nil && !msr.disableBucketListHashValidation {
 		// Calling SetExpectedHash will enable validation of the stream hash. If hashes
 		// don't match, rdr.Close() will return an error.
 		rdr.SetExpectedHash(hash)
+	}
+
+	return rdr, e
+}
+
+// streamBucketContents pushes value onto the read channel, returning false when the channel needs to be closed otherwise true
+func (msr *SingleLedgerStateReader) streamBucketContents(hash historyarchive.Hash) bool {
+	rdr, e := msr.newXDRStream(hash)
+	if e != nil {
+		msr.readChan <- msr.error(fmt.Errorf("cannot get xdr stream for hash '%s': %s", hash.String(), e))
+		return false
 	}
 
 	defer func() {
@@ -201,7 +271,8 @@ LoopBucketEntry:
 
 			for i := 0; i < preloadedEntries; i++ {
 				var entry xdr.BucketEntry
-				if e = rdr.ReadOne(&entry); e != nil {
+				entry, rdr, e = msr.readBucketEntry(rdr, hash)
+				if e != nil {
 					if e == io.EOF {
 						if len(batch) == 0 {
 							// No entries loaded for this batch, nothing more to process

--- a/exp/ingest/io/single_ledger_state_reader_test.go
+++ b/exp/ingest/io/single_ledger_state_reader_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/historyarchive"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/mock"
@@ -43,7 +44,12 @@ func (s *SingleLedgerStateReaderTestSuite) SetupTest() {
 		On("BucketExists", mock.AnythingOfType("historyarchive.Hash")).
 		Return(true, nil).Times(21)
 
-	s.reader, err = MakeSingleLedgerStateReader(s.mockArchive, &MemoryTempSet{}, ledgerSeq)
+	s.reader, err = MakeSingleLedgerStateReader(
+		s.mockArchive,
+		&MemoryTempSet{},
+		ledgerSeq,
+		0,
+	)
 	s.Require().NotNil(s.reader)
 	s.Require().NoError(err)
 	s.Assert().Equal(ledgerSeq, s.reader.sequence)
@@ -251,6 +257,236 @@ func (s *SingleLedgerStateReaderTestSuite) TestMalformedProtocol11BucketNoMeta()
 	s.Assert().Equal("Error while reading from buckets: Read INITENTRY from version <11 bucket: 0@517bea4c6627a688a8ce501febd8c562e737e3d86b29689d9956217640f3c74b", err.Error())
 }
 
+func TestReadBucketEntryTestSuite(t *testing.T) {
+	suite.Run(t, new(ReadBucketEntryTestSuite))
+}
+
+type ReadBucketEntryTestSuite struct {
+	suite.Suite
+	mockArchive *historyarchive.MockArchive
+	reader      *SingleLedgerStateReader
+}
+
+func (s *ReadBucketEntryTestSuite) SetupTest() {
+	s.mockArchive = &historyarchive.MockArchive{}
+
+	ledgerSeq := uint32(24123007)
+	s.mockArchive.
+		On("GetCheckpointHAS", ledgerSeq).
+		Return(historyarchive.HistoryArchiveState{}, nil)
+
+	var err error
+	s.reader, err = MakeSingleLedgerStateReader(
+		s.mockArchive,
+		&MemoryTempSet{},
+		ledgerSeq,
+		2,
+	)
+	s.Require().NoError(err)
+}
+
+func (s *ReadBucketEntryTestSuite) TearDownTest() {
+	s.mockArchive.AssertExpectations(s.T())
+}
+
+func (s *ReadBucketEntryTestSuite) TestNewXDRStream() {
+	emptyHash := historyarchive.EmptyXdrArrayHash()
+	expectedStream := createXdrStream(metaEntry(1), metaEntry(2))
+
+	hash, ok := expectedStream.ExpectedHash()
+	s.Require().NotEqual(historyarchive.Hash(hash), emptyHash)
+	s.Require().False(ok)
+
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(expectedStream, nil).Once()
+
+	stream, err := s.reader.newXDRStream(emptyHash)
+	s.Require().NoError(err)
+	s.Require().True(stream == expectedStream)
+
+	hash, ok = stream.ExpectedHash()
+	s.Require().Equal(historyarchive.Hash(hash), emptyHash)
+	s.Require().True(ok)
+}
+
+func (s *ReadBucketEntryTestSuite) TestReadAllEntries() {
+	emptyHash := historyarchive.EmptyXdrArrayHash()
+	firstEntry := metaEntry(1)
+	secondEntry := metaEntry(2)
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(createXdrStream(firstEntry, secondEntry), nil).Once()
+
+	stream, err := s.reader.newXDRStream(emptyHash)
+	s.Require().NoError(err)
+
+	entry, newStream, err := s.reader.readBucketEntry(stream, emptyHash)
+	s.Require().NoError(err)
+	s.Require().True(stream == newStream)
+	s.Require().Equal(entry, firstEntry)
+
+	entry, newStream, err = s.reader.readBucketEntry(stream, emptyHash)
+	s.Require().NoError(err)
+	s.Require().True(stream == newStream)
+	s.Require().Equal(entry, secondEntry)
+
+	_, newStream, err = s.reader.readBucketEntry(stream, emptyHash)
+	s.Require().Equal(io.EOF, err)
+	s.Require().True(stream == newStream)
+}
+
+func (s *ReadBucketEntryTestSuite) TestReadEntryAllRetriesFail() {
+	emptyHash := historyarchive.EmptyXdrArrayHash()
+
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(createInvalidXdrStream(), nil).Once()
+
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(createInvalidXdrStream(), nil).Once()
+
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(createInvalidXdrStream(), nil).Once()
+
+	stream, err := s.reader.newXDRStream(emptyHash)
+	s.Require().NoError(err)
+
+	_, newStream, err := s.reader.readBucketEntry(stream, emptyHash)
+	s.Require().EqualError(err, "Read wrong number of bytes from XDR")
+	s.Require().True(stream != newStream)
+}
+
+func (s *ReadBucketEntryTestSuite) TestReadEntryRetryFailsToCreateNewStream() {
+	emptyHash := historyarchive.EmptyXdrArrayHash()
+
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(createInvalidXdrStream(), nil).Once()
+
+	var nilStream *historyarchive.XdrStream
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(nilStream, errors.New("cannot create new stream")).Once()
+
+	stream, err := s.reader.newXDRStream(emptyHash)
+	s.Require().NoError(err)
+
+	_, newStream, err := s.reader.readBucketEntry(stream, emptyHash)
+	s.Require().EqualError(err, "Error creating new xdr stream: cannot create new stream")
+	s.Require().True(stream == newStream)
+}
+
+func (s *ReadBucketEntryTestSuite) TestReadEntryRetrySucceeds() {
+	emptyHash := historyarchive.EmptyXdrArrayHash()
+
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(createInvalidXdrStream(), nil).Once()
+
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(createInvalidXdrStream(), nil).Once()
+
+	expectedEntry := metaEntry(1)
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(createXdrStream(expectedEntry), nil).Once()
+
+	stream, err := s.reader.newXDRStream(emptyHash)
+	s.Require().NoError(err)
+
+	entry, newStream, err := s.reader.readBucketEntry(stream, emptyHash)
+	s.Require().NoError(err)
+	s.Require().Equal(entry, expectedEntry)
+	s.Require().True(stream != newStream)
+	stream = newStream
+
+	hash, ok := stream.ExpectedHash()
+	s.Require().Equal(historyarchive.Hash(hash), emptyHash)
+	s.Require().True(ok)
+
+	_, newStream, err = s.reader.readBucketEntry(stream, emptyHash)
+	s.Require().Equal(err, io.EOF)
+	s.Require().True(stream == newStream)
+}
+
+func (s *ReadBucketEntryTestSuite) TestReadEntryRetrySucceedsWithDiscard() {
+	emptyHash := historyarchive.EmptyXdrArrayHash()
+
+	firstEntry := metaEntry(1)
+	secondEntry := metaEntry(2)
+
+	b := &bytes.Buffer{}
+	s.Require().NoError(historyarchive.WriteFramedXdr(b, firstEntry))
+	b.WriteString("invalid-frame")
+
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(xdrStreamFromBuffer(b), nil).Once()
+
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(createXdrStream(firstEntry, secondEntry), nil).Once()
+
+	stream, err := s.reader.newXDRStream(emptyHash)
+	s.Require().NoError(err)
+
+	entry, newStream, err := s.reader.readBucketEntry(stream, emptyHash)
+	s.Require().NoError(err)
+	s.Require().Equal(entry, firstEntry)
+	s.Require().True(stream == newStream)
+
+	entry, newStream, err = s.reader.readBucketEntry(stream, emptyHash)
+	s.Require().NoError(err)
+	s.Require().Equal(entry, secondEntry)
+	s.Require().True(stream != newStream)
+	stream = newStream
+
+	hash, ok := stream.ExpectedHash()
+	s.Require().Equal(historyarchive.Hash(hash), emptyHash)
+	s.Require().True(ok)
+
+	_, newStream, err = s.reader.readBucketEntry(stream, emptyHash)
+	s.Require().Equal(err, io.EOF)
+	s.Require().True(stream == newStream)
+}
+
+func (s *ReadBucketEntryTestSuite) TestReadEntryRetryFailsWithDiscardError() {
+	emptyHash := historyarchive.EmptyXdrArrayHash()
+
+	firstEntry := metaEntry(1)
+
+	b := &bytes.Buffer{}
+	s.Require().NoError(historyarchive.WriteFramedXdr(b, firstEntry))
+	b.WriteString("invalid-frame")
+
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(xdrStreamFromBuffer(b), nil).Once()
+
+	b = &bytes.Buffer{}
+	b.WriteString("a")
+
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(xdrStreamFromBuffer(b), nil).Once()
+
+	stream, err := s.reader.newXDRStream(emptyHash)
+	s.Require().NoError(err)
+
+	entry, newStream, err := s.reader.readBucketEntry(stream, emptyHash)
+	s.Require().NoError(err)
+	s.Require().Equal(entry, firstEntry)
+	s.Require().True(stream == newStream)
+
+	_, newStream, err = s.reader.readBucketEntry(stream, emptyHash)
+	s.Require().EqualError(err, "Error discarding from xdr stream: EOF")
+	s.Require().True(stream != newStream)
+}
+
 func metaEntry(version uint32) xdr.BucketEntry {
 	return xdr.BucketEntry{
 		Type: xdr.BucketEntryTypeMetaentry,
@@ -288,6 +524,12 @@ func entryAccount(t xdr.BucketEntryType, id string, balance uint32) xdr.BucketEn
 	}
 }
 
+func createInvalidXdrStream() *historyarchive.XdrStream {
+	b := &bytes.Buffer{}
+	b.WriteString("invalid-xdr-stream")
+	return xdrStreamFromBuffer(b)
+}
+
 func createXdrStream(entries ...xdr.BucketEntry) *historyarchive.XdrStream {
 	b := &bytes.Buffer{}
 	for _, e := range entries {
@@ -297,6 +539,10 @@ func createXdrStream(entries ...xdr.BucketEntry) *historyarchive.XdrStream {
 		}
 	}
 
+	return xdrStreamFromBuffer(b)
+}
+
+func xdrStreamFromBuffer(b *bytes.Buffer) *historyarchive.XdrStream {
 	return historyarchive.NewXdrStream(ioutil.NopCloser(b))
 }
 

--- a/exp/ingest/io/single_ledger_state_reader_test.go
+++ b/exp/ingest/io/single_ledger_state_reader_test.go
@@ -321,19 +321,16 @@ func (s *ReadBucketEntryTestSuite) TestReadAllEntries() {
 	stream, err := s.reader.newXDRStream(emptyHash)
 	s.Require().NoError(err)
 
-	entry, newStream, err := s.reader.readBucketEntry(stream, emptyHash)
+	entry, err := s.reader.readBucketEntry(stream, emptyHash)
 	s.Require().NoError(err)
-	s.Require().True(stream == newStream)
 	s.Require().Equal(entry, firstEntry)
 
-	entry, newStream, err = s.reader.readBucketEntry(stream, emptyHash)
+	entry, err = s.reader.readBucketEntry(stream, emptyHash)
 	s.Require().NoError(err)
-	s.Require().True(stream == newStream)
 	s.Require().Equal(entry, secondEntry)
 
-	_, newStream, err = s.reader.readBucketEntry(stream, emptyHash)
+	_, err = s.reader.readBucketEntry(stream, emptyHash)
 	s.Require().Equal(io.EOF, err)
-	s.Require().True(stream == newStream)
 }
 
 func (s *ReadBucketEntryTestSuite) TestReadEntryAllRetriesFail() {
@@ -354,9 +351,8 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryAllRetriesFail() {
 	stream, err := s.reader.newXDRStream(emptyHash)
 	s.Require().NoError(err)
 
-	_, newStream, err := s.reader.readBucketEntry(stream, emptyHash)
+	_, err = s.reader.readBucketEntry(stream, emptyHash)
 	s.Require().EqualError(err, "Read wrong number of bytes from XDR")
-	s.Require().True(stream != newStream)
 }
 
 func (s *ReadBucketEntryTestSuite) TestReadEntryRetryFailsToCreateNewStream() {
@@ -374,9 +370,8 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryRetryFailsToCreateNewStream() {
 	stream, err := s.reader.newXDRStream(emptyHash)
 	s.Require().NoError(err)
 
-	_, newStream, err := s.reader.readBucketEntry(stream, emptyHash)
+	_, err = s.reader.readBucketEntry(stream, emptyHash)
 	s.Require().EqualError(err, "Error creating new xdr stream: cannot create new stream")
-	s.Require().True(stream == newStream)
 }
 
 func (s *ReadBucketEntryTestSuite) TestReadEntryRetrySucceeds() {
@@ -398,19 +393,16 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryRetrySucceeds() {
 	stream, err := s.reader.newXDRStream(emptyHash)
 	s.Require().NoError(err)
 
-	entry, newStream, err := s.reader.readBucketEntry(stream, emptyHash)
+	entry, err := s.reader.readBucketEntry(stream, emptyHash)
 	s.Require().NoError(err)
 	s.Require().Equal(entry, expectedEntry)
-	s.Require().True(stream != newStream)
-	stream = newStream
 
 	hash, ok := stream.ExpectedHash()
 	s.Require().Equal(historyarchive.Hash(hash), emptyHash)
 	s.Require().True(ok)
 
-	_, newStream, err = s.reader.readBucketEntry(stream, emptyHash)
+	_, err = s.reader.readBucketEntry(stream, emptyHash)
 	s.Require().Equal(err, io.EOF)
-	s.Require().True(stream == newStream)
 }
 
 func (s *ReadBucketEntryTestSuite) TestReadEntryRetrySucceedsWithDiscard() {
@@ -434,24 +426,20 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryRetrySucceedsWithDiscard() {
 	stream, err := s.reader.newXDRStream(emptyHash)
 	s.Require().NoError(err)
 
-	entry, newStream, err := s.reader.readBucketEntry(stream, emptyHash)
+	entry, err := s.reader.readBucketEntry(stream, emptyHash)
 	s.Require().NoError(err)
 	s.Require().Equal(entry, firstEntry)
-	s.Require().True(stream == newStream)
 
-	entry, newStream, err = s.reader.readBucketEntry(stream, emptyHash)
+	entry, err = s.reader.readBucketEntry(stream, emptyHash)
 	s.Require().NoError(err)
 	s.Require().Equal(entry, secondEntry)
-	s.Require().True(stream != newStream)
-	stream = newStream
 
 	hash, ok := stream.ExpectedHash()
 	s.Require().Equal(historyarchive.Hash(hash), emptyHash)
 	s.Require().True(ok)
 
-	_, newStream, err = s.reader.readBucketEntry(stream, emptyHash)
+	_, err = s.reader.readBucketEntry(stream, emptyHash)
 	s.Require().Equal(err, io.EOF)
-	s.Require().True(stream == newStream)
 }
 
 func (s *ReadBucketEntryTestSuite) TestReadEntryRetryFailsWithDiscardError() {
@@ -477,14 +465,12 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryRetryFailsWithDiscardError() {
 	stream, err := s.reader.newXDRStream(emptyHash)
 	s.Require().NoError(err)
 
-	entry, newStream, err := s.reader.readBucketEntry(stream, emptyHash)
+	entry, err := s.reader.readBucketEntry(stream, emptyHash)
 	s.Require().NoError(err)
 	s.Require().Equal(entry, firstEntry)
-	s.Require().True(stream == newStream)
 
-	_, newStream, err = s.reader.readBucketEntry(stream, emptyHash)
+	_, err = s.reader.readBucketEntry(stream, emptyHash)
 	s.Require().EqualError(err, "Error discarding from xdr stream: EOF")
-	s.Require().True(stream != newStream)
 }
 
 func metaEntry(version uint32) xdr.BucketEntry {

--- a/exp/ingest/io/single_ledger_state_reader_test.go
+++ b/exp/ingest/io/single_ledger_state_reader_test.go
@@ -421,7 +421,7 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryRetrySucceedsWithDiscard() {
 
 	b := &bytes.Buffer{}
 	s.Require().NoError(historyarchive.WriteFramedXdr(b, firstEntry))
-	b.WriteString("invalid-frame")
+	writeInvalidFrame(b)
 
 	s.mockArchive.
 		On("GetXdrStreamForHash", emptyHash).
@@ -461,7 +461,7 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryRetryFailsWithDiscardError() {
 
 	b := &bytes.Buffer{}
 	s.Require().NoError(historyarchive.WriteFramedXdr(b, firstEntry))
-	b.WriteString("invalid-frame")
+	writeInvalidFrame(b)
 
 	s.mockArchive.
 		On("GetXdrStreamForHash", emptyHash).
@@ -526,8 +526,19 @@ func entryAccount(t xdr.BucketEntryType, id string, balance uint32) xdr.BucketEn
 
 func createInvalidXdrStream() *historyarchive.XdrStream {
 	b := &bytes.Buffer{}
-	b.WriteString("invalid-xdr-stream")
+	writeInvalidFrame(b)
+
 	return xdrStreamFromBuffer(b)
+}
+
+func writeInvalidFrame(b *bytes.Buffer) {
+	bufferSize := b.Len()
+	err := historyarchive.WriteFramedXdr(b, metaEntry(1))
+	if err != nil {
+		panic(err)
+	}
+	frameSize := b.Len() - bufferSize
+	b.Truncate(bufferSize + frameSize/2)
 }
 
 func createXdrStream(entries ...xdr.BucketEntry) *historyarchive.XdrStream {

--- a/exp/ingest/live_session.go
+++ b/exp/ingest/live_session.go
@@ -260,7 +260,7 @@ func (s *LiveSession) initState(historyAdapter *adapters.HistoryArchiveAdapter, 
 		tempSet = s.TempSet
 	}
 
-	stateReader, err := historyAdapter.GetState(sequence, tempSet)
+	stateReader, err := historyAdapter.GetState(sequence, tempSet, s.MaxStreamRetries)
 	if err != nil {
 		return errors.Wrap(err, "Error getting state from history archive")
 	}

--- a/exp/ingest/main.go
+++ b/exp/ingest/main.go
@@ -42,7 +42,7 @@ type LiveSession struct {
 	TempSet io.TempSet
 	// MaxStreamRetries determines how many times the reader will retry when encountering
 	// errors while streaming xdr bucket entries from the history archive.
-	// Set MaxStreamRetries to 0 if there should be no retry attempts
+	// Default MaxStreamRetries value (0) means that there should be no retry attempts
 	MaxStreamRetries int
 
 	latestSuccessfullyProcessedLedger uint32

--- a/exp/ingest/main.go
+++ b/exp/ingest/main.go
@@ -40,6 +40,10 @@ type LiveSession struct {
 	// TempSet is a store used to hold temporary objects generated during
 	// state processing. If nil, defaults to io.MemoryTempSet.
 	TempSet io.TempSet
+	// MaxStreamRetries determines how many times the reader will retry when encountering
+	// errors while streaming xdr bucket entries from the history archive.
+	// Set MaxStreamRetries to 0 if there should be no retry attempts
+	MaxStreamRetries int
 
 	latestSuccessfullyProcessedLedger uint32
 }
@@ -57,6 +61,10 @@ type SingleLedgerSession struct {
 	// TempSet is a store used to hold temporary objects generated during
 	// state processing. If nil, defaults to io.MemoryTempSet.
 	TempSet io.TempSet
+	// MaxStreamRetries determines how many times the reader will retry when encountering
+	// errors while streaming xdr bucket entries from the history archive.
+	// Set MaxStreamRetries to 0 if there should be no retry attempts
+	MaxStreamRetries int
 }
 
 // Session is an implementation of a ingesting scenario. Some useful sessions

--- a/exp/ingest/single_ledger_session.go
+++ b/exp/ingest/single_ledger_session.go
@@ -42,7 +42,7 @@ func (s *SingleLedgerSession) processState(historyAdapter *adapters.HistoryArchi
 		tempSet = s.TempSet
 	}
 
-	stateReader, err := historyAdapter.GetState(sequence, tempSet)
+	stateReader, err := historyAdapter.GetState(sequence, tempSet, s.MaxStreamRetries)
 	if err != nil {
 		return errors.Wrap(err, "Error getting state from history archive")
 	}

--- a/exp/tools/dump-ledger-state/main.go
+++ b/exp/tools/dump-ledger-state/main.go
@@ -42,10 +42,11 @@ func main() {
 	}
 
 	session := &ingest.SingleLedgerSession{
-		LedgerSequence: uint32(ledgerSequence),
-		Archive:        archive,
-		StatePipeline:  statePipeline,
-		TempSet:        &io.MemoryTempSet{},
+		LedgerSequence:   uint32(ledgerSequence),
+		Archive:          archive,
+		StatePipeline:    statePipeline,
+		TempSet:          &io.MemoryTempSet{},
+		MaxStreamRetries: 3,
 	}
 
 	doneStats := printPipelineStats(statePipeline)

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -48,6 +48,11 @@ type Config struct {
 	TempSet                  io.TempSet
 	DisableStateVerification bool
 
+	// MaxStreamRetries determines how many times the reader will retry when encountering
+	// errors while streaming xdr bucket entries from the history archive.
+	// Set MaxStreamRetries to 0 if there should be no retry attempts
+	MaxStreamRetries int
+
 	OrderBookGraph *orderbook.OrderBookGraph
 }
 
@@ -80,13 +85,14 @@ type retry interface {
 }
 
 type System struct {
-	session        liveSession
-	historyQ       dbQ
-	historySession dbSession
-	graph          *orderbook.OrderBookGraph
-	retry          retry
-	stateReady     bool
-	stateReadyLock sync.RWMutex
+	session          liveSession
+	historyQ         dbQ
+	historySession   dbSession
+	graph            *orderbook.OrderBookGraph
+	retry            retry
+	stateReady       bool
+	stateReadyLock   sync.RWMutex
+	maxStreamRetries int
 
 	// stateVerificationRunning is true when verification routine is currently
 	// running.
@@ -125,10 +131,11 @@ func NewSystem(config Config) (*System, error) {
 	historyQ := &history.Q{config.HistorySession}
 
 	session := &ingest.LiveSession{
-		Archive:        archive,
-		LedgerBackend:  ledgerBackend,
-		StatePipeline:  buildStatePipeline(historyQ, config.OrderBookGraph),
-		LedgerPipeline: buildLedgerPipeline(historyQ, config.OrderBookGraph),
+		Archive:          archive,
+		MaxStreamRetries: config.MaxStreamRetries,
+		LedgerBackend:    ledgerBackend,
+		StatePipeline:    buildStatePipeline(historyQ, config.OrderBookGraph),
+		LedgerPipeline:   buildLedgerPipeline(historyQ, config.OrderBookGraph),
 		StellarCoreClient: &stellarcore.Client{
 			URL: config.StellarCoreURL,
 		},
@@ -146,6 +153,7 @@ func NewSystem(config Config) (*System, error) {
 		graph:                    config.OrderBookGraph,
 		retry:                    alwaysRetry{time.Second},
 		disableStateVerification: config.DisableStateVerification,
+		maxStreamRetries:         config.MaxStreamRetries,
 	}
 
 	addPipelineHooks(

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/historyarchive"
-	ilog "github.com/stellar/go/support/log"
+	logpkg "github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 )
 
@@ -37,7 +37,7 @@ const (
 	CurrentVersion = 6
 )
 
-var log = ilog.DefaultLogger.WithField("service", "expingest")
+var log = logpkg.DefaultLogger.WithField("service", "expingest")
 
 type Config struct {
 	CoreSession    *db.Session
@@ -209,7 +209,7 @@ func (s *System) Run() {
 	// TODO: This should be removed when expingest is no longer experimental.
 	defer func() {
 		if r := recover(); r != nil {
-			log.WithFields(ilog.F{
+			log.WithFields(logpkg.F{
 				"err":   r,
 				"stack": string(debug.Stack()),
 			}).Error("expingest panic")
@@ -277,7 +277,7 @@ func (s *System) Run() {
 					return err
 				}
 
-				log.WithFields(ilog.F{
+				log.WithFields(logpkg.F{
 					"err":                  err,
 					"last_ingested_ledger": lastIngestedLedger,
 				}).Error("Error running session, resuming from the last ingested ledger")

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/historyarchive"
-	ilog "github.com/stellar/go/support/log"
+	logpkg "github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 )
 
@@ -182,7 +182,7 @@ func preProcessingHook(
 		historySession.Rollback()
 	}
 
-	log.WithFields(ilog.F{
+	log.WithFields(logpkg.F{
 		"ledger":            ledgerSeq,
 		"type":              pipelineType,
 		"updating_database": updateDatabase,
@@ -212,7 +212,7 @@ func postProcessingHook(
 			markStateInvalid(historySession, err)
 		default:
 			log.
-				WithFields(ilog.F{
+				WithFields(logpkg.F{
 					"ledger": ledgerSeq,
 					"type":   pipelineType,
 					"err":    err,
@@ -284,7 +284,7 @@ func postProcessingHook(
 		}()
 	}
 
-	log.WithFields(ilog.F{"ledger": ledgerSeq, "type": pipelineType}).Info("Processed ledger")
+	log.WithFields(logpkg.F{"ledger": ledgerSeq, "type": pipelineType}).Info("Processed ledger")
 	return nil
 }
 

--- a/services/horizon/internal/expingest/reporter.go
+++ b/services/horizon/internal/expingest/reporter.go
@@ -3,13 +3,13 @@ package expingest
 import (
 	"time"
 
-	ilog "github.com/stellar/go/support/log"
+	logpkg "github.com/stellar/go/support/log"
 )
 
 // LoggingStateReporter logs the progress of a session running its
 // state pipelines
 type LoggingStateReporter struct {
-	Log      *ilog.Entry
+	Log      *logpkg.Entry
 	Interval int
 
 	entryCount int
@@ -55,7 +55,7 @@ func (lr *LoggingStateReporter) OnEndState(err error, shutdown bool) {
 // LoggingLedgerReporter logs the progress of a session running its
 // ledger pipelines
 type LoggingLedgerReporter struct {
-	Log *ilog.Entry
+	Log *logpkg.Entry
 
 	transactionCount int
 	sequence         uint32

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -114,6 +114,7 @@ func (s *System) verifyState() error {
 		s.session.GetArchive(),
 		&io.MemoryTempSet{},
 		ledgerSequence,
+		s.maxStreamRetries,
 	)
 	if err != nil {
 		return errors.Wrap(err, "Error running io.MakeSingleLedgerStateReader")

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/expingest/processors"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/historyarchive"
-	ilog "github.com/stellar/go/support/log"
+	logpkg "github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 )
 
@@ -78,7 +78,7 @@ func (s *System) verifyState() error {
 		return errors.Wrap(err, "Error running historyQ.GetLastLedgerExpIngestNonBlocking")
 	}
 
-	localLog := log.WithFields(ilog.F{
+	localLog := log.WithFields(logpkg.F{
 		"subservice": "state_verify",
 		"ledger":     ledgerSequence,
 	})

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -90,6 +90,7 @@ func initExpIngester(app *App, orderBookGraph *orderbook.OrderBookGraph) {
 		StellarCoreURL:           app.config.StellarCoreURL,
 		OrderBookGraph:           orderBookGraph,
 		TempSet:                  tempSet,
+		MaxStreamRetries:         3,
 		DisableStateVerification: app.config.IngestDisableStateVerification,
 	})
 	if err != nil {

--- a/support/historyarchive/xdrstream.go
+++ b/support/historyarchive/xdrstream.go
@@ -21,12 +21,33 @@ import (
 
 type XdrStream struct {
 	buf        bytes.Buffer
-	rdr        io.ReadCloser
+	rdr        *countReader
 	rdr2       io.ReadCloser
 	sha256Hash hash.Hash
 
 	validateHash bool
 	expectedHash [sha256.Size]byte
+}
+
+type countReader struct {
+	r         io.ReadCloser
+	bytesRead int64
+}
+
+func (c *countReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.bytesRead += int64(n)
+	return n, err
+}
+
+func (c *countReader) Close() error {
+	return c.r.Close()
+}
+
+func newCountReader(r io.ReadCloser) *countReader {
+	return &countReader{
+		r, 0,
+	}
 }
 
 func NewXdrStream(in io.ReadCloser) *XdrStream {
@@ -36,10 +57,12 @@ func NewXdrStream(in io.ReadCloser) *XdrStream {
 	teeReader := io.TeeReader(in, sha256Hash)
 
 	return &XdrStream{
-		rdr: struct {
-			io.Reader
-			io.Closer
-		}{bufio.NewReader(teeReader), in},
+		rdr: newCountReader(
+			struct {
+				io.Reader
+				io.Closer
+			}{bufio.NewReader(teeReader), in},
+		),
 		sha256Hash: sha256Hash,
 	}
 }
@@ -71,6 +94,12 @@ func HashXdr(x interface{}) (Hash, error) {
 func (x *XdrStream) SetExpectedHash(hash [sha256.Size]byte) {
 	x.validateHash = true
 	x.expectedHash = hash
+}
+
+// ExpectedHash returns the expected hash and a boolean indicating if the
+// expected hash was set
+func (x *XdrStream) ExpectedHash() ([sha256.Size]byte, bool) {
+	return x.expectedHash, x.validateHash
 }
 
 // Close closes all internal readers and checks if the expected hash
@@ -142,6 +171,16 @@ func (x *XdrStream) ReadOne(in interface{}) error {
 			readi, nbytes)
 	}
 	return nil
+}
+
+// BytesRead returns the number of bytes read in the stream
+func (x *XdrStream) BytesRead() int64 {
+	return x.rdr.bytesRead
+}
+
+// Discard removes n bytes from the stream
+func (x *XdrStream) Discard(n int64) (int64, error) {
+	return io.CopyN(ioutil.Discard, x.rdr, n)
 }
 
 func WriteFramedXdr(out io.Writer, in interface{}) error {

--- a/support/historyarchive/xdrstream.go
+++ b/support/historyarchive/xdrstream.go
@@ -105,16 +105,26 @@ func (x *XdrStream) Close() error {
 		// Read all remaining data from rdr
 		_, err := io.Copy(ioutil.Discard, x.rdr)
 		if err != nil {
+			// close the internal readers to avoid memory leaks
+			x.CloseWithoutValidation()
 			return errors.Wrap(err, "Error reading remaining bytes from rdr")
 		}
 
 		actualHash := x.sha256Hash.Sum([]byte{})
 
 		if !bytes.Equal(x.expectedHash[:], actualHash[:]) {
+			// close the internal readers to avoid memory leaks
+			x.CloseWithoutValidation()
 			return errors.New("Stream hash does not match expected hash!")
 		}
 	}
 
+	return x.CloseWithoutValidation()
+}
+
+// CloseWithoutValidation closes all internal readers without validating the
+// hash of the stream contents
+func (x *XdrStream) CloseWithoutValidation() error {
 	if x.rdr != nil {
 		if err := x.rdr.Close(); err != nil {
 			return err

--- a/support/historyarchive/xdrstream.go
+++ b/support/historyarchive/xdrstream.go
@@ -30,18 +30,14 @@ type XdrStream struct {
 }
 
 type countReader struct {
-	r         io.ReadCloser
+	io.ReadCloser
 	bytesRead int64
 }
 
 func (c *countReader) Read(p []byte) (int, error) {
-	n, err := c.r.Read(p)
+	n, err := c.ReadCloser.Read(p)
 	c.bytesRead += int64(n)
 	return n, err
-}
-
-func (c *countReader) Close() error {
-	return c.r.Close()
 }
 
 func newCountReader(r io.ReadCloser) *countReader {

--- a/support/historyarchive/xdrstream_test.go
+++ b/support/historyarchive/xdrstream_test.go
@@ -7,6 +7,7 @@ package historyarchive
 import (
 	"bytes"
 	"crypto/sha256"
+	"io"
 	"io/ioutil"
 	"testing"
 
@@ -31,7 +32,7 @@ func TestXdrStreamHash(t *testing.T) {
 	stream := createXdrStream(bucketEntry)
 
 	// Stream hash should be equal sha256 hash of concatenation of:
-	// - uint32 representing a number o bytes of a structure,
+	// - uint32 representing the number of bytes of a structure,
 	// - xdr-encoded `BucketEntry` above.
 	b := &bytes.Buffer{}
 	err := WriteFramedXdr(b, bucketEntry)
@@ -45,7 +46,76 @@ func TestXdrStreamHash(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, bucketEntry, readBucketEntry)
 
+	assert.Equal(t, int(stream.BytesRead()), b.Len())
+
+	assert.Equal(t, io.EOF, stream.ReadOne(&readBucketEntry))
+	assert.Equal(t, int(stream.BytesRead()), b.Len())
+
 	assert.NoError(t, stream.Close())
+}
+
+func TestXdrStreamDiscard(t *testing.T) {
+	firstEntry := xdr.BucketEntry{
+		Type: xdr.BucketEntryTypeLiveentry,
+		LiveEntry: &xdr.LedgerEntry{
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeAccount,
+				Account: &xdr.AccountEntry{
+					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+					Balance:   xdr.Int64(200000000),
+				},
+			},
+		},
+	}
+	secondEntry := xdr.BucketEntry{
+		Type: xdr.BucketEntryTypeLiveentry,
+		LiveEntry: &xdr.LedgerEntry{
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeAccount,
+				Account: &xdr.AccountEntry{
+					AccountId: xdr.MustAddress("GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4"),
+					Balance:   xdr.Int64(100000000),
+				},
+			},
+		},
+	}
+
+	fullStream := createXdrStream(firstEntry, secondEntry)
+	b := &bytes.Buffer{}
+	require.NoError(t, WriteFramedXdr(b, firstEntry))
+	require.NoError(t, WriteFramedXdr(b, secondEntry))
+	expectedHash := sha256.Sum256(b.Bytes())
+	fullStream.SetExpectedHash(expectedHash)
+
+	discardStream := createXdrStream(firstEntry, secondEntry)
+	discardStream.SetExpectedHash(expectedHash)
+
+	var readBucketEntry xdr.BucketEntry
+	require.NoError(t, fullStream.ReadOne(&readBucketEntry))
+	assert.Equal(t, firstEntry, readBucketEntry)
+
+	skipAmount := fullStream.BytesRead()
+	bytesRead, err := discardStream.Discard(skipAmount)
+	require.NoError(t, err)
+	assert.Equal(t, bytesRead, skipAmount)
+
+	require.NoError(t, fullStream.ReadOne(&readBucketEntry))
+	assert.Equal(t, secondEntry, readBucketEntry)
+
+	require.NoError(t, discardStream.ReadOne(&readBucketEntry))
+	assert.Equal(t, secondEntry, readBucketEntry)
+
+	assert.Equal(t, int(fullStream.BytesRead()), b.Len())
+	assert.Equal(t, fullStream.BytesRead(), discardStream.BytesRead())
+
+	assert.Equal(t, io.EOF, fullStream.ReadOne(&readBucketEntry))
+	assert.Equal(t, io.EOF, discardStream.ReadOne(&readBucketEntry))
+
+	assert.Equal(t, int(fullStream.BytesRead()), b.Len())
+	assert.Equal(t, fullStream.BytesRead(), discardStream.BytesRead())
+
+	assert.NoError(t, discardStream.Close())
+	assert.NoError(t, fullStream.Close())
 }
 
 func createXdrStream(entries ...xdr.BucketEntry) *XdrStream {

--- a/tools/archive-reader/archive_reader.go
+++ b/tools/archive-reader/archive_reader.go
@@ -27,7 +27,7 @@ func main() {
 	}
 	haa := adapters.MakeHistoryArchiveAdapter(archive)
 
-	sr, e := haa.GetState(seqNum, &io.MemoryTempSet{})
+	sr, e := haa.GetState(seqNum, &io.MemoryTempSet{}, 0)
 	if e != nil {
 		panic(e)
 	}


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

If a SingleLedgerStateReader fails to read a single bucket entry the reading process is aborted.
This commit provides a retry mechanism which creates new XDR streams in case of XDR stream errors.

Close https://github.com/stellar/go/issues/1649

### Why

`XdrStream.ReadOne` method returns this error from time to time:
```
stream error: stream ID 311; PROTOCOL_ERROR
```

This happens when the stream connection times out. To make ingestion pipelines more robust we should provide a way to retry when encountering these errors.

### Known limitations

Assume we have an XDR stream for a very large bucket and we encounter a transient error halfway through. Unfortunately, when we create the new XDR stream, we need to consume half of the bucket file so that we resume from the same point of failure. This means that we waste time and bandwidth re-downloading the part of the bucket file we have already successfully processed. We cannot avoid re-downloading because the history archive buckets are GZIP compressed and it is not possible to seek to a random position in a gizp compressed file (see https://stackoverflow.com/questions/429987/compression-formats-with-good-support-for-random-access-within-archives ).

If it were possible to seek to any position within a gzip file we would be able to start the new XDR stream from the point of failure without any wasted bandwidth using an HTTP range request (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests )



  
