### PR TITLE
services/horizon/internal/actions: Update strict receive path action to use query struct.

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -296,6 +296,7 @@ type Root struct {
 		Offers              *hal.Link `json:"offers,omitempty"`
 		OrderBook           hal.Link  `json:"order_book"`
 		Self                hal.Link  `json:"self"`
+		StrictReceivePaths  *hal.Link `json:"strict_receive_paths"`
 		StrictSendPaths     *hal.Link `json:"strict_send_paths"`
 		Transaction         hal.Link  `json:"transaction"`
 		Transactions        hal.Link  `json:"transactions"`

--- a/services/horizon/internal/actions_path_test.go
+++ b/services/horizon/internal/actions_path_test.go
@@ -597,6 +597,22 @@ func TestFindFixedPathsQueryQueryURLTemplate(t *testing.T) {
 		"source_amount",
 	}
 	expected := "/paths/strict-send{?" + strings.Join(params, ",") + "}"
-	accountsQuery := FindFixedPathsQuery{}
-	tt.Equal(expected, accountsQuery.URITemplate())
+	qp := FindFixedPathsQuery{}
+	tt.Equal(expected, qp.URITemplate())
+}
+
+func TestStrictReceivePathsQueryURLTemplate(t *testing.T) {
+	tt := assert.New(t)
+	params := []string{
+		"source_assets",
+		"source_account",
+		"destination_account",
+		"destination_asset_type",
+		"destination_asset_issuer",
+		"destination_asset_code",
+		"destination_amount",
+	}
+	expected := "/paths/strict-receive{?" + strings.Join(params, ",") + "}"
+	qp := StrictReceivePathsQuery{}
+	tt.Equal(expected, qp.URITemplate())
 }

--- a/services/horizon/internal/actions_root.go
+++ b/services/horizon/internal/actions_root.go
@@ -21,9 +21,10 @@ type RootAction struct {
 func (action *RootAction) JSON() error {
 	var res horizon.Root
 	templates := map[string]string{
-		"accounts":        actions.AccountsQuery{}.URITemplate(),
-		"offers":          actions.OffersQuery{}.URITemplate(),
-		"strictSendPaths": FindFixedPathsQuery{}.URITemplate(),
+		"accounts":           actions.AccountsQuery{}.URITemplate(),
+		"offers":             actions.OffersQuery{}.URITemplate(),
+		"strictReceivePaths": StrictReceivePathsQuery{}.URITemplate(),
+		"strictSendPaths":    FindFixedPathsQuery{}.URITemplate(),
 	}
 	resourceadapter.PopulateRoot(
 		action.R.Context(),

--- a/services/horizon/internal/actions_root_test.go
+++ b/services/horizon/internal/actions_root_test.go
@@ -94,5 +94,19 @@ func TestRootActionWithIngestion(t *testing.T) {
 			actual.Links.StrictSendPaths.Href,
 		)
 
+		params = []string{
+			"source_assets",
+			"source_account",
+			"destination_account",
+			"destination_asset_type",
+			"destination_asset_issuer",
+			"destination_asset_code",
+			"destination_amount",
+		}
+
+		ht.Assert.Equal(
+			"http://localhost/paths/strict-receive{?"+strings.Join(params, ",")+"}",
+			actual.Links.StrictReceivePaths.Href,
+		)
 	}
 }

--- a/services/horizon/internal/resourceadapter/root.go
+++ b/services/horizon/internal/resourceadapter/root.go
@@ -49,10 +49,12 @@ func PopulateRoot(
 		accountsLink := lb.Link(templates["accounts"])
 		offerLink := lb.Link("/offers/{offer_id}")
 		offersLink := lb.Link(templates["offers"])
+		strictReceivePaths := lb.Link(templates["strictReceivePaths"])
 		strictSendPaths := lb.Link(templates["strictSendPaths"])
 		dest.Links.Accounts = &accountsLink
 		dest.Links.Offer = &offerLink
 		dest.Links.Offers = &offersLink
+		dest.Links.StrictReceivePaths = &strictReceivePaths
 		dest.Links.StrictSendPaths = &strictSendPaths
 	}
 

--- a/services/horizon/internal/resourceadapter/root_test.go
+++ b/services/horizon/internal/resourceadapter/root_test.go
@@ -14,9 +14,10 @@ import (
 func TestPopulateRoot(t *testing.T) {
 	res := &horizon.Root{}
 	templates := map[string]string{
-		"accounts":        "/accounts{?signer,asset_type,asset_issuer,asset_code}",
-		"offers":          "/offers",
-		"strictSendPaths": "/paths/strict-send",
+		"accounts":           "/accounts{?signer,asset_type,asset_issuer,asset_code}",
+		"offers":             "/offers",
+		"strictReceivePaths": "/paths/strict-receive",
+		"strictSendPaths":    "/paths/strict-send",
 	}
 
 	PopulateRoot(context.Background(),
@@ -42,6 +43,7 @@ func TestPopulateRoot(t *testing.T) {
 	assert.Empty(t, res.Links.Accounts)
 	assert.Empty(t, res.Links.Offer)
 	assert.Empty(t, res.Links.Offers)
+	assert.Empty(t, res.Links.StrictReceivePaths)
 	assert.Empty(t, res.Links.StrictSendPaths)
 
 	// Without testbot
@@ -88,6 +90,11 @@ func TestPopulateRoot(t *testing.T) {
 		t,
 		templates["offers"],
 		res.Links.Offers.Href,
+	)
+	assert.Equal(
+		t,
+		templates["strictReceivePaths"],
+		res.Links.StrictReceivePaths.Href,
 	)
 	assert.Equal(
 		t,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Update strict receive path action to use query structs.

### Why

We are in the process of documenting all the experimental endpoints and paths/strict-receive does not get listed on the root resource in Horizon. To facilite documentation, this PR adds query structs to the strict send paths action handler and uses the query struct to autogenerate the templated URI.

### Known limitations

N/A