### PR TITLE
support/env: replace os.Exit(1) with panic

### DIFF
--- a/support/env/env.go
+++ b/support/env/env.go
@@ -1,10 +1,11 @@
 package env
 
 import (
-	"log"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/stellar/go/support/errors"
 )
 
 // String returns the value of the environment variable "name".
@@ -23,8 +24,7 @@ func Int(name string, value int) int {
 		var err error
 		value, err = strconv.Atoi(s)
 		if err != nil {
-			log.Println(name, err)
-			os.Exit(1)
+			panic(errors.Wrapf(err, "env var %q cannot be parsed as int", name))
 		}
 	}
 	return value
@@ -40,8 +40,7 @@ func Duration(name string, value time.Duration) time.Duration {
 		var err error
 		value, err = time.ParseDuration(s)
 		if err != nil {
-			log.Println(name, err)
-			os.Exit(1)
+			panic(errors.Wrapf(err, "env var %q cannot be parsed as time.Duration", name))
 		}
 	}
 	return value


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Replace use of `os.Exit(1)` and logging in the `support/env` package
with `panic`s.

### Why
When we call `os.Exit` in a library it gives the applications that is
using the library no opportunity to respond to something going wrong.
The `support/env` convenience functions were designed on the assumption
that if there is anything wrong it should be a stop-the-world event, but
if we use `panic` instead of exit we maintain that convenience and give
the caller the option to catch the panic and report it to an exception
monitoring service.

It also becomes impossible to test the behavior that will trigger the
`os.Exit(1)`. This is because when an exit is encountered by `go test`
the test will be reported as failed and all tests thereafter will be
aborted. There's no way to catch the exit and report that it was
expected, or to allow other tests to complete.

Close #1878

### Known limitations

N/A
