### PR TITLE
keypair: add MustRandom

### DIFF
--- a/keypair/main.go
+++ b/keypair/main.go
@@ -109,3 +109,13 @@ func MustParse(addressOrSeed string) KP {
 
 	return kp
 }
+
+// MustRandom is the panic-on-fail version of Random.
+func MustRandom() *Full {
+	kp, err := Random()
+	if err != nil {
+		panic(err)
+	}
+
+	return kp
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add `MustRandom()` that wraps `Random()` and works the same as `MustParse()`, converting any error returned by `Random()` into a `panic`.

### Why

Make it easier to hack on prototypes where keys are needed, and make `Random` functionally symmetrical with the other common entry point `Parse`. While I was spiking a prototype solution for an idea I found `MustParse()` helpful to keep my non-production code and test code thinner. `Random()` can be a helpful function to use in tests and when prototyping ideas to generate temporary keys on application boot, and the addition of the error checking is repetitive and mostly going to be dropping a panic anyway.

There were no tests for the `Random` functions so I added some basic tests.

### Known limitations

N/A
