### PR TITLE
txnbuild: add GetSourceAccount to all operations

### DIFF
--- a/txnbuild/account_merge.go
+++ b/txnbuild/account_merge.go
@@ -54,3 +54,9 @@ func (am *AccountMerge) Validate() error {
 	}
 	return nil
 }
+
+// GetSourceAccount returns the source account of the operation, or nil if not
+// set.
+func (am *AccountMerge) GetSourceAccount() Account {
+	return am.SourceAccount
+}

--- a/txnbuild/allow_trust.go
+++ b/txnbuild/allow_trust.go
@@ -89,3 +89,9 @@ func (at *AllowTrust) Validate() error {
 	}
 	return nil
 }
+
+// GetSourceAccount returns the source account of the operation, or nil if not
+// set.
+func (at *AllowTrust) GetSourceAccount() Account {
+	return at.SourceAccount
+}

--- a/txnbuild/bump_sequence.go
+++ b/txnbuild/bump_sequence.go
@@ -46,3 +46,9 @@ func (bs *BumpSequence) Validate() error {
 	}
 	return nil
 }
+
+// GetSourceAccount returns the source account of the operation, or nil if not
+// set.
+func (bs *BumpSequence) GetSourceAccount() Account {
+	return bs.SourceAccount
+}

--- a/txnbuild/change_trust.go
+++ b/txnbuild/change_trust.go
@@ -96,3 +96,9 @@ func (ct *ChangeTrust) Validate() error {
 	}
 	return nil
 }
+
+// GetSourceAccount returns the source account of the operation, or nil if not
+// set.
+func (ct *ChangeTrust) GetSourceAccount() Account {
+	return ct.SourceAccount
+}

--- a/txnbuild/create_account.go
+++ b/txnbuild/create_account.go
@@ -67,3 +67,9 @@ func (ca *CreateAccount) Validate() error {
 
 	return nil
 }
+
+// GetSourceAccount returns the source account of the operation, or nil if not
+// set.
+func (ca *CreateAccount) GetSourceAccount() Account {
+	return ca.SourceAccount
+}

--- a/txnbuild/create_passive_offer.go
+++ b/txnbuild/create_passive_offer.go
@@ -87,3 +87,9 @@ func (cpo *CreatePassiveSellOffer) FromXDR(xdrOp xdr.Operation) error {
 func (cpo *CreatePassiveSellOffer) Validate() error {
 	return validatePassiveOffer(cpo.Buying, cpo.Selling, cpo.Amount, cpo.Price)
 }
+
+// GetSourceAccount returns the source account of the operation, or nil if not
+// set.
+func (cpo *CreatePassiveSellOffer) GetSourceAccount() Account {
+	return cpo.SourceAccount
+}

--- a/txnbuild/inflation.go
+++ b/txnbuild/inflation.go
@@ -38,3 +38,9 @@ func (inf *Inflation) Validate() error {
 	// no required fields, return nil.
 	return nil
 }
+
+// GetSourceAccount returns the source account of the operation, or nil if not
+// set.
+func (inf *Inflation) GetSourceAccount() Account {
+	return inf.SourceAccount
+}

--- a/txnbuild/manage_buy_offer.go
+++ b/txnbuild/manage_buy_offer.go
@@ -90,3 +90,9 @@ func (mo *ManageBuyOffer) FromXDR(xdrOp xdr.Operation) error {
 func (mo *ManageBuyOffer) Validate() error {
 	return validateOffer(mo.Buying, mo.Selling, mo.Amount, mo.Price, mo.OfferID)
 }
+
+// GetSourceAccount returns the source account of the operation, or nil if not
+// set.
+func (mo *ManageBuyOffer) GetSourceAccount() Account {
+	return mo.SourceAccount
+}

--- a/txnbuild/manage_data.go
+++ b/txnbuild/manage_data.go
@@ -60,3 +60,9 @@ func (md *ManageData) Validate() error {
 	}
 	return nil
 }
+
+// GetSourceAccount returns the source account of the operation, or nil if not
+// set.
+func (md *ManageData) GetSourceAccount() Account {
+	return md.SourceAccount
+}

--- a/txnbuild/manage_offer.go
+++ b/txnbuild/manage_offer.go
@@ -154,3 +154,9 @@ func (mo *ManageSellOffer) FromXDR(xdrOp xdr.Operation) error {
 func (mo *ManageSellOffer) Validate() error {
 	return validateOffer(mo.Buying, mo.Selling, mo.Amount, mo.Price, mo.OfferID)
 }
+
+// GetSourceAccount returns the source account of the operation, or nil if not
+// set.
+func (mo *ManageSellOffer) GetSourceAccount() Account {
+	return mo.SourceAccount
+}

--- a/txnbuild/operation.go
+++ b/txnbuild/operation.go
@@ -9,6 +9,7 @@ type Operation interface {
 	BuildXDR() (xdr.Operation, error)
 	FromXDR(xdrOp xdr.Operation) error
 	Validate() error
+	GetSourceAccount() Account
 }
 
 // SetOpSourceAccount sets the source account ID on an Operation.

--- a/txnbuild/path_payment.go
+++ b/txnbuild/path_payment.go
@@ -158,3 +158,9 @@ func (pp *PathPaymentStrictReceive) Validate() error {
 
 	return nil
 }
+
+// GetSourceAccount returns the source account of the operation, or nil if not
+// set.
+func (pp *PathPaymentStrictReceive) GetSourceAccount() Account {
+	return pp.SourceAccount
+}

--- a/txnbuild/path_payment_strict_send.go
+++ b/txnbuild/path_payment_strict_send.go
@@ -152,3 +152,9 @@ func (pp *PathPaymentStrictSend) Validate() error {
 
 	return nil
 }
+
+// GetSourceAccount returns the source account of the operation, or nil if not
+// set.
+func (pp *PathPaymentStrictSend) GetSourceAccount() Account {
+	return pp.SourceAccount
+}

--- a/txnbuild/payment.go
+++ b/txnbuild/payment.go
@@ -92,3 +92,9 @@ func (p *Payment) Validate() error {
 
 	return nil
 }
+
+// GetSourceAccount returns the source account of the operation, or nil if not
+// set.
+func (p *Payment) GetSourceAccount() Account {
+	return p.SourceAccount
+}

--- a/txnbuild/set_options.go
+++ b/txnbuild/set_options.go
@@ -317,3 +317,9 @@ func (so *SetOptions) Validate() error {
 	// Refactoring is out of the scope of this issue(https://github.com/stellar/go/issues/1041) so will leave as is for now.
 	return nil
 }
+
+// GetSourceAccount returns the source account of the operation, or nil if not
+// set.
+func (so *SetOptions) GetSourceAccount() Account {
+	return so.SourceAccount
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add `GetSourceAccount()` function to the `txnbuild.Operation` interface and to all implementers, surfacing the source account that exists on every implementer.

### Why

I was working with the txnbuild package and was trying to validate that a transaction only contained operations relating to a specific set of accounts and no others. My code validating the accounts impacted by the operation doesn't have any knowledge about the type of operations that might be in the transaction. Every operation has a source account and every future operation is very likely to have a source account as that is how operations can be composed for multiple accounts in a single transaction. So it's very easy to expand the interface of the `txnbuild.Operation` to require it. I think it's important we make it possible for applications to validate the accounts a transaction will directly impact without needing to know about every type of operation. This will help reduce the changes required to an application when new operations are added.

It would be feasible to use the `xdr` package to get the source account for every operation instead of using txnbuild, but given that txnbuild is friendlier and a developer is more likely to be interacting with it already, it makes sense to make this accessible here.

### Known limitations

If we ever have an operation that cannot have a different source account as the transaction this interface will be broken, but given how source accounts are used in operations to group operations relating to multiple accounts and to separate an account surfacing a sequence number and an account the operation is being performed on, I think this is unlikely.
