### PR TITLE
protocols/horizon/effects: Add UnmarshalJSON to SequenceBumped.

### DIFF
--- a/clients/horizonclient/effect_request_test.go
+++ b/clients/horizonclient/effect_request_test.go
@@ -232,7 +232,7 @@ func TestNextEffectsPage(t *testing.T) {
 	efp, err := client.Effects(effectRequest)
 
 	if assert.NoError(t, err) {
-		assert.Equal(t, len(efp.Embedded.Records), 2)
+		assert.Len(t, efp.Embedded.Records, 4)
 	}
 
 	hmock.On(
@@ -242,7 +242,7 @@ func TestNextEffectsPage(t *testing.T) {
 
 	nextPage, err := client.NextEffectsPage(efp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, len(nextPage.Embedded.Records), 0)
+		assert.Len(t, nextPage.Embedded.Records, 0)
 	}
 }
 
@@ -304,6 +304,46 @@ var firstEffectsPage = `{
         "weight": 1,
         "public_key": "GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD",
         "key": ""
+	  },
+	  {
+        "_links": {
+          "operation": {
+            "href": "https://horizon-testnet.stellar.org/operations/249108107265"
+          },
+          "succeeds": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=249108107265-1"
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=249108107265-1"
+          }
+        },
+        "id": "0000000249108107265-0000000001",
+        "paging_token": "249108107265-1",
+        "account": "GCQZP3IU7XU6EJ63JZXKCQOYT2RNXN3HB5CNHENNUEUHSMA4VUJJJSEN",
+        "type": "sequence_bumped",
+        "type_i": 43,
+        "created_at": "2019-06-03T16:36:24Z",
+        "new_seq": 300000000000
+	  },
+	  {
+        "_links": {
+          "operation": {
+            "href": "https://horizon-testnet.stellar.org/operations/249108107266"
+          },
+          "succeeds": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=249108107266-1"
+          },
+          "precedes": {
+            "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=249108107266-1"
+          }
+        },
+        "id": "0000000249108107266-0000000001",
+        "paging_token": "249108107266-1",
+        "account": "GCQZP3IU7XU6EJ63JZXKCQOYT2RNXN3HB5CNHENNUEUHSMA4VUJJJSEN",
+        "type": "sequence_bumped",
+        "type_i": 43,
+        "created_at": "2019-06-03T16:36:24Z",
+        "new_seq": "300000000000"
       }
     ]
   }

--- a/clients/horizonclient/effect_request_test.go
+++ b/clients/horizonclient/effect_request_test.go
@@ -232,7 +232,7 @@ func TestNextEffectsPage(t *testing.T) {
 	efp, err := client.Effects(effectRequest)
 
 	if assert.NoError(t, err) {
-		assert.Len(t, efp.Embedded.Records, 4)
+		assert.Len(t, efp.Embedded.Records, 2)
 	}
 
 	hmock.On(
@@ -243,6 +243,47 @@ func TestNextEffectsPage(t *testing.T) {
 	nextPage, err := client.NextEffectsPage(efp)
 	if assert.NoError(t, err) {
 		assert.Len(t, nextPage.Embedded.Records, 0)
+	}
+}
+
+func TestSequenceBumpedNewSeq(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+	effectRequest := EffectRequest{ForAccount: "GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD"}
+	testCases := []struct {
+		desc    string
+		payload string
+	}{
+		{
+			desc:    "new_seq as a string",
+			payload: sequenceBumpedAsStringPage,
+		},
+		{
+			desc:    "new_seq as a number",
+			payload: sequenceBumpedAsNumberPage,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			hmock.On(
+				"GET",
+				"https://localhost/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects",
+			).ReturnString(200, tc.payload)
+
+			efp, err := client.Effects(effectRequest)
+
+			if assert.NoError(t, err) {
+				assert.Len(t, efp.Embedded.Records, 1)
+			}
+
+			effect, ok := efp.Embedded.Records[0].(effects.SequenceBumped)
+			assert.True(t, ok)
+			assert.Equal(t, int64(300000000000), effect.NewSeq)
+
+		})
 	}
 }
 
@@ -304,50 +345,86 @@ var firstEffectsPage = `{
         "weight": 1,
         "public_key": "GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD",
         "key": ""
-	  },
-	  {
-        "_links": {
-          "operation": {
-            "href": "https://horizon-testnet.stellar.org/operations/249108107265"
-          },
-          "succeeds": {
-            "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=249108107265-1"
-          },
-          "precedes": {
-            "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=249108107265-1"
-          }
-        },
-        "id": "0000000249108107265-0000000001",
-        "paging_token": "249108107265-1",
-        "account": "GCQZP3IU7XU6EJ63JZXKCQOYT2RNXN3HB5CNHENNUEUHSMA4VUJJJSEN",
-        "type": "sequence_bumped",
-        "type_i": 43,
-        "created_at": "2019-06-03T16:36:24Z",
-        "new_seq": 300000000000
-	  },
-	  {
-        "_links": {
-          "operation": {
-            "href": "https://horizon-testnet.stellar.org/operations/249108107266"
-          },
-          "succeeds": {
-            "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=249108107266-1"
-          },
-          "precedes": {
-            "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=249108107266-1"
-          }
-        },
-        "id": "0000000249108107266-0000000001",
-        "paging_token": "249108107266-1",
-        "account": "GCQZP3IU7XU6EJ63JZXKCQOYT2RNXN3HB5CNHENNUEUHSMA4VUJJJSEN",
-        "type": "sequence_bumped",
-        "type_i": 43,
-        "created_at": "2019-06-03T16:36:24Z",
-        "new_seq": "300000000000"
-      }
+	  }
     ]
   }
 }`
+
+var sequenceBumpedAsNumberPage = `{
+	"_links": {
+	  "self": {
+		"href": "https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=&limit=10&order=asc"
+	  },
+	  "next": {
+		"href": "https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=1557363731492865-3&limit=10&order=asc"
+	  },
+	  "prev": {
+		"href": "https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=1557363731492865-1&limit=10&order=desc"
+	  }
+	},
+	"_embedded": {
+	  "records": [
+		{
+		  "_links": {
+			"operation": {
+			  "href": "https://horizon-testnet.stellar.org/operations/249108107265"
+			},
+			"succeeds": {
+			  "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=249108107265-1"
+			},
+			"precedes": {
+			  "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=249108107265-1"
+			}
+		  },
+		  "id": "0000000249108107265-0000000001",
+		  "paging_token": "249108107265-1",
+		  "account": "GCQZP3IU7XU6EJ63JZXKCQOYT2RNXN3HB5CNHENNUEUHSMA4VUJJJSEN",
+		  "type": "sequence_bumped",
+		  "type_i": 43,
+		  "created_at": "2019-06-03T16:36:24Z",
+		  "new_seq": 300000000000
+		}
+	  ]
+	}
+  }`
+
+var sequenceBumpedAsStringPage = `{
+	"_links": {
+	  "self": {
+		"href": "https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=&limit=10&order=asc"
+	  },
+	  "next": {
+		"href": "https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=1557363731492865-3&limit=10&order=asc"
+	  },
+	  "prev": {
+		"href": "https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=1557363731492865-1&limit=10&order=desc"
+	  }
+	},
+	"_embedded": {
+	  "records": [
+		{
+		  "_links": {
+			"operation": {
+			  "href": "https://horizon-testnet.stellar.org/operations/249108107265"
+			},
+			"succeeds": {
+			  "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=249108107265-1"
+			},
+			"precedes": {
+			  "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=249108107265-1"
+			}
+		  },
+		  "id": "0000000249108107265-0000000001",
+		  "paging_token": "249108107265-1",
+		  "account": "GCQZP3IU7XU6EJ63JZXKCQOYT2RNXN3HB5CNHENNUEUHSMA4VUJJJSEN",
+		  "type": "sequence_bumped",
+		  "type_i": 43,
+		  "created_at": "2019-06-03T16:36:24Z",
+		  "new_seq": "300000000000"
+		}
+	  ]
+	}
+  }`
 
 var emptyEffectsPage = `{
   "_links": {

--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -2,7 +2,6 @@ package effects
 
 import (
 	"encoding/json"
-	"strconv"
 	"time"
 
 	"github.com/stellar/go/protocols/horizon/base"
@@ -205,35 +204,23 @@ type SequenceBumped struct {
 // UnmarshalJSON is the custom unmarshal method for SequenceBumped. It allows
 // parsing of new_seq as a string or an int64.
 func (effect *SequenceBumped) UnmarshalJSON(data []byte) error {
-	var raw map[string]interface{}
 	var temp struct {
-		NewSeq int64 `json:"new_seq"`
-	}
-
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-
-	if s, ok := raw["new_seq"].(string); ok {
-		ns, err := strconv.ParseInt(s, 10, 64)
-		if err != nil {
-			return err
-		}
-
-		effect.NewSeq = ns
-	} else {
-		// letting Unmarshal handle the conversion so we don't have to convert
-		// from interface{} to int64 which requires multiple checks.
-		if err := json.Unmarshal(data, &temp); err != nil {
-			return err
-		}
-
-		effect.NewSeq = temp.NewSeq
+		NewSeq json.Number `json:"new_seq"`
 	}
 
 	if err := json.Unmarshal(data, &effect.Base); err != nil {
 		return err
 	}
+
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+
+	newSeq, err := temp.NewSeq.Int64()
+	if err != nil {
+		return err
+	}
+	effect.NewSeq = newSeq
 
 	return nil
 }

--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -2,6 +2,7 @@ package effects
 
 import (
 	"encoding/json"
+	"strconv"
 	"time"
 
 	"github.com/stellar/go/protocols/horizon/base"
@@ -199,6 +200,42 @@ type AccountFlagsUpdated struct {
 type SequenceBumped struct {
 	Base
 	NewSeq int64 `json:"new_seq"`
+}
+
+// UnmarshalJSON is the custom unmarshal method for SequenceBumped. It allows
+// parsing of new_seq as a string or an int64.
+func (effect *SequenceBumped) UnmarshalJSON(data []byte) error {
+	var raw map[string]interface{}
+	var temp struct {
+		NewSeq int64 `json:"new_seq"`
+	}
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if s, ok := raw["new_seq"].(string); ok {
+		ns, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return err
+		}
+
+		effect.NewSeq = ns
+	} else {
+		// letting Unmarshal handle the convertion so we don't have to convert
+		// from interface{} to int64 which requires multiple checks.
+		if err := json.Unmarshal(data, &temp); err != nil {
+			return err
+		}
+
+		effect.NewSeq = temp.NewSeq
+	}
+
+	if err := json.Unmarshal(data, &effect.Base); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 type SignerCreated struct {

--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -222,7 +222,7 @@ func (effect *SequenceBumped) UnmarshalJSON(data []byte) error {
 
 		effect.NewSeq = ns
 	} else {
-		// letting Unmarshal handle the convertion so we don't have to convert
+		// letting Unmarshal handle the conversion so we don't have to convert
 		// from interface{} to int64 which requires multiple checks.
 		if err := json.Unmarshal(data, &temp); err != nil {
 			return err


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add `UnmarshalJSON` to `SequenceBumped`,  this method supports `new_seq` as a `string` or a `int64` in the JSON payload. This will allow us to cut a new release for the horizon client which won't break once we change the data type on the JSON payload.

### Why

Using Int64 in JSON payloads produces inconsistent results in JS (see https://github.com/stellar/go/issues/1363).

We are in the process of updating all the int64 JSON fields to be of type string. The idea with this change is to extend the Unmarshal function to take either `int64` or `string`, that way we can release a version of the horizon client which won't break once the payload changes in the API.

See https://github.com/stellar/go/issues/1609

### Known limitations

[TODO or N/A]
