### PR TITLE
docs: deprecate the main.go/internal.go Horizon convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,9 @@ While much of the code in individual packages is organized based upon different 
 
 In each package, there may be one or more of a set of common files:
 
-- *main.go*: Every package should have a `main.go` file.  This file contains the package documentation (unless a separate `doc.go` file is used), _all_ of the exported vars, consts, types and funcs for the package. 
-- *internal.go*:  This file should contain unexported vars, consts, types, and funcs.  Conceptually, it should be considered the private counterpart to the `main.go` file of a package
 - *errors.go*: This file should contains declarations (both types and vars) for errors that are used by the package.
 - *example_test.go*: This file should contains example tests, as described at https://blog.golang.org/examples.
+- *main.go/internal.go* (**deprecated**): Older packages may have a `main.go` (public symbols) or `internal.go` (private symbols).  These files contain, respectively, the exported and unexported vars, consts, types and funcs for the package. More recently updated packages follow the standard Go convention and co-locate structs and their methods in shared files. 
 
 In addition to the above files, a package often has files that contains code that is specific to one declared type.  This file uses the snake case form of the type name (for example `loggly_hook.go` would correspond to the type `LogglyHook`).  This file should contain method declarations, interface implementation assertions and any other declarations that are tied solely to that type.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ In each package, there may be one or more of a set of common files:
 
 - *errors.go*: This file should contains declarations (both types and vars) for errors that are used by the package.
 - *example_test.go*: This file should contains example tests, as described at https://blog.golang.org/examples.
-- *main.go/internal.go* (**deprecated**): Older packages may have a `main.go` (public symbols) or `internal.go` (private symbols).  These files contain, respectively, the exported and unexported vars, consts, types and funcs for the package. More recently updated packages follow the standard Go convention and co-locate structs and their methods in shared files. 
+- *main.go/internal.go* (**deprecated**): Older packages may have a `main.go` (public symbols) or `internal.go` (private symbols).  These files contain, respectively, the exported and unexported vars, consts, types and funcs for the package. New packages do not follow this pattern, and instead follow the standard Go convention to co-locate structs and their methods in the same files. 
+- *main.go* (**new convention**): If present, this file contains a `main` function as part of an executable `main` package.
 
 In addition to the above files, a package often has files that contains code that is specific to one declared type.  This file uses the snake case form of the type name (for example `loggly_hook.go` would correspond to the type `LogglyHook`).  This file should contain method declarations, interface implementation assertions and any other declarations that are tied solely to that type.
 


### PR DESCRIPTION
### What

Update developer docs to indicate that Horizon's `main.go`/`internal.go` is deprecated.

### Why

Historically, Horizon has used `main.go` to hold public symbols, and `internal.go` to hold private symbols. Going forward, we'd like to adopt the standard approach (used in e.g. the Go [standard library](https://golang.org/src/context/context.go)) of placing structs and their related methods in the same file (with files created based on logical groupings) . This should be easier to understand and also reduce the quirkiness of the Horizon codebase with respect to our other projects and the rest of the world.

Since we aren't going to port everything in one go, it's appropriate to mention the convention but also clearly indicate that it's deprecated.

### Known limitations

[N/A]
