### PR TITLE
exp/ingest/ledgerbackend: Fix index out of range error in GetLatestLedgerSequence()

### DIFF
--- a/exp/ingest/ledgerbackend/database_backend.go
+++ b/exp/ingest/ledgerbackend/database_backend.go
@@ -46,6 +46,9 @@ func (dbb *DatabaseBackend) GetLatestLedgerSequence() (uint32, error) {
 	if err != nil {
 		return 0, errors.Wrap(err, "couldn't select ledger sequence")
 	}
+	if len(ledger) == 0 {
+		return 0, errors.New("No ledgers found in ledgerheaders table")
+	}
 
 	return ledger[0].LedgerSeq, nil
 }

--- a/exp/ingest/ledgerbackend/database_backend.go
+++ b/exp/ingest/ledgerbackend/database_backend.go
@@ -47,7 +47,7 @@ func (dbb *DatabaseBackend) GetLatestLedgerSequence() (uint32, error) {
 		return 0, errors.Wrap(err, "couldn't select ledger sequence")
 	}
 	if len(ledger) == 0 {
-		return 0, errors.New("No ledgers found in ledgerheaders table")
+		return 0, errors.New("no ledgers exist in ledgerheaders table")
 	}
 
 	return ledger[0].LedgerSeq, nil

--- a/services/horizon/internal/expingest/database_backend_test.go
+++ b/services/horizon/internal/expingest/database_backend_test.go
@@ -30,5 +30,5 @@ func TestGetLatestLedgerNotFound(t *testing.T) {
 	backend, err := ledgerbackend.NewDatabaseBackendFromSession(q.Session)
 	tt.Assert.NoError(err)
 	_, err = backend.GetLatestLedgerSequence()
-	tt.Assert.EqualError(err, "No ledgers found in ledgerheaders table")
+	tt.Assert.EqualError(err, "no ledgers exist in ledgerheaders table")
 }

--- a/services/horizon/internal/expingest/database_backend_test.go
+++ b/services/horizon/internal/expingest/database_backend_test.go
@@ -1,0 +1,34 @@
+package expingest
+
+import (
+	"testing"
+
+	"github.com/stellar/go/exp/ingest/ledgerbackend"
+	"github.com/stellar/go/services/horizon/internal/db2/core"
+	"github.com/stellar/go/services/horizon/internal/test"
+)
+
+func TestGetLatestLedger(t *testing.T) {
+	tt := test.Start(t).ScenarioWithoutHorizon("base")
+	defer tt.Finish()
+
+	backend, err := ledgerbackend.NewDatabaseBackendFromSession(tt.CoreSession())
+	tt.Assert.NoError(err)
+	seq, err := backend.GetLatestLedgerSequence()
+	tt.Assert.NoError(err)
+	tt.Assert.Equal(uint32(3), seq)
+}
+
+func TestGetLatestLedgerNotFound(t *testing.T) {
+	tt := test.Start(t).ScenarioWithoutHorizon("base")
+	defer tt.Finish()
+	q := &core.Q{tt.CoreSession()}
+
+	_, err := tt.CoreDB.Exec(`DELETE FROM ledgerheaders`)
+	tt.Assert.NoError(err, "failed to remove ledgerheaders")
+
+	backend, err := ledgerbackend.NewDatabaseBackendFromSession(q.Session)
+	tt.Assert.NoError(err)
+	_, err = backend.GetLatestLedgerSequence()
+	tt.Assert.EqualError(err, "No ledgers found in ledgerheaders table")
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

If there are no rows in the `ledgerheaders` table then `DatabaseBackend.GetLatestLedgerSequence()` crashes with an index out of range error.

Close https://github.com/stellar/go/issues/1888
