### PR TITLE
services/horizon/internal/expingest: Implement state verifier for order book graph

### DIFF
--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -1,6 +1,7 @@
 package expingest
 
 import (
+	"bytes"
 	"database/sql"
 	"fmt"
 	"time"
@@ -393,6 +394,19 @@ func addDataToStateVerifier(verifier *verify.StateVerifier, q *history.Q, keys [
 	return nil
 }
 
+func offerEntryEquals(offer, other xdr.OfferEntry) (bool, error) {
+	serialized, err := offer.MarshalBinary()
+	if err != nil {
+		return false, errors.Wrap(err, "could not serialize offer")
+	}
+	otherSerialized, err := other.MarshalBinary()
+	if err != nil {
+		return false, errors.Wrap(err, "could not serialize offer")
+	}
+
+	return bytes.Equal(serialized, otherSerialized), nil
+}
+
 func addOffersToStateVerifier(
 	verifier *verify.StateVerifier,
 	q *history.Q,
@@ -433,7 +447,9 @@ func addOffersToStateVerifier(
 				fmt.Errorf("offer %v is not in orderbook graph", row.OfferID),
 			)
 		}
-		if graphOffer != *entry.Data.Offer {
+		if equal, err := offerEntryEquals(graphOffer, *entry.Data.Offer); err != nil {
+			return errors.Wrap(err, "could not compare offers")
+		} else if !equal {
 			return verify.NewStateError(
 				fmt.Errorf(
 					"offer %v from db does not match offer in orderbook graph",

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -31,7 +31,7 @@ const stateVerifierExpectedIngestionVersion = 8
 // verifyState is called as a go routine from pipeline post hook every 64
 // ledgers. It checks if the state is correct. If another go routine is already
 // running it exists.
-func (s *System) verifyState() error {
+func (s *System) verifyState(graphOffers map[xdr.Int64]xdr.OfferEntry) error {
 	s.stateVerificationMutex.Lock()
 	if s.stateVerificationRunning {
 		log.Warn("State verification is already running...")
@@ -167,7 +167,7 @@ func (s *System) verifyState() error {
 			return errors.Wrap(err, "addDataToStateVerifier failed")
 		}
 
-		err = addOffersToStateVerifier(verifier, historyQ, offers)
+		err = addOffersToStateVerifier(verifier, historyQ, offers, graphOffers)
 		if err != nil {
 			return errors.Wrap(err, "addOffersToStateVerifier failed")
 		}
@@ -182,6 +182,15 @@ func (s *System) verifyState() error {
 	}
 
 	localLog.WithField("total", total).Info("Finished writing to StateVerifier")
+
+	if len(graphOffers) != 0 {
+		return verify.NewStateError(
+			fmt.Errorf(
+				"orderbook graph contains %v offers missing from HAS",
+				len(graphOffers),
+			),
+		)
+	}
 
 	countAccounts, err := historyQ.CountAccounts()
 	if err != nil {
@@ -384,7 +393,12 @@ func addDataToStateVerifier(verifier *verify.StateVerifier, q *history.Q, keys [
 	return nil
 }
 
-func addOffersToStateVerifier(verifier *verify.StateVerifier, q *history.Q, ids []int64) error {
+func addOffersToStateVerifier(
+	verifier *verify.StateVerifier,
+	q *history.Q,
+	ids []int64,
+	graphOffers map[xdr.Int64]xdr.OfferEntry,
+) error {
 	if len(ids) == 0 {
 		return nil
 	}
@@ -413,6 +427,21 @@ func addOffersToStateVerifier(verifier *verify.StateVerifier, q *history.Q, ids 
 				},
 			},
 		}
+		graphOffer, ok := graphOffers[row.OfferID]
+		if !ok {
+			return verify.NewStateError(
+				fmt.Errorf("offer %v is not in orderbook graph", row.OfferID),
+			)
+		}
+		if graphOffer != *entry.Data.Offer {
+			return verify.NewStateError(
+				fmt.Errorf(
+					"offer %v from db does not match offer in orderbook graph",
+					row.OfferID,
+				),
+			)
+		}
+		delete(graphOffers, row.OfferID)
 		err := verifier.Write(entry)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Implement state verifier for order book graph

### Why
Close https://github.com/stellar/go/issues/1872
> We check the state correctness in Horizon DB using ingest/verify.StateVerifier but we don't check in-memory order book graph.


