### PR TITLE
services/horizon/internal/expingest: Emit error log after 3 failed attempts to validate state

### DIFF
--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -93,7 +93,9 @@ type System struct {
 
 	// stateVerificationRunning is true when verification routine is currently
 	// running.
-	stateVerificationMutex   sync.Mutex
+	stateVerificationMutex sync.Mutex
+	// number of consecutive state verification runs which encountered errors
+	stateVerificationErrors  int
 	stateVerificationRunning bool
 	disableStateVerification bool
 }
@@ -368,6 +370,19 @@ func (s *System) setStateReady() {
 	s.stateReadyLock.Lock()
 	defer s.stateReadyLock.Unlock()
 	s.stateReady = true
+}
+
+func (s *System) incrementStateVerificationErrors() int {
+	s.stateVerificationMutex.Lock()
+	defer s.stateVerificationMutex.Unlock()
+	s.stateVerificationErrors++
+	return s.stateVerificationErrors
+}
+
+func (s *System) resetStateVerificationErrors() {
+	s.stateVerificationMutex.Lock()
+	defer s.stateVerificationMutex.Unlock()
+	s.stateVerificationErrors = 0
 }
 
 func (s *System) Shutdown() {

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -276,8 +276,6 @@ func postProcessingHook(
 			err := system.verifyState()
 			if err != nil {
 				errorCount := system.incrementStateVerificationErrors()
-
-				system.stateVerificationErrors++
 				switch errors.Cause(err).(type) {
 				case verify.StateError:
 					markStateInvalid(historySession, err)

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -22,8 +22,9 @@ import (
 type pType string
 
 const (
-	statePipeline  pType = "state_pipeline"
-	ledgerPipeline pType = "ledger_pipeline"
+	statePipeline                   pType = "state_pipeline"
+	ledgerPipeline                  pType = "ledger_pipeline"
+	stateVerificationErrorThreshold       = 3
 )
 
 func accountsStateNode(q *history.Q) *supportPipeline.PipelineNode {
@@ -274,12 +275,21 @@ func postProcessingHook(
 		go func() {
 			err := system.verifyState()
 			if err != nil {
+				errorCount := system.incrementStateVerificationErrors()
+
+				system.stateVerificationErrors++
 				switch errors.Cause(err).(type) {
 				case verify.StateError:
 					markStateInvalid(historySession, err)
 				default:
-					log.WithField("err", err).Error("State verification errored")
+					logError := log.WithField("err", err).Warn
+					if errorCount >= stateVerificationErrorThreshold {
+						logError = log.WithField("err", err).Error
+					}
+					logError("State verification errored")
 				}
+			} else {
+				system.resetStateVerificationErrors()
 			}
 		}()
 	}

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -280,11 +280,11 @@ func postProcessingHook(
 				case verify.StateError:
 					markStateInvalid(historySession, err)
 				default:
-					logError := log.WithField("err", err).Warn
+					logger := log.WithField("err", err).Warn
 					if errorCount >= stateVerificationErrorThreshold {
-						logError = log.WithField("err", err).Error
+						logger = log.WithField("err", err).Error
 					}
-					logError("State verification errored")
+					logger("State verification errored")
 				}
 			} else {
 				system.resetStateVerificationErrors()


### PR DESCRIPTION
Currently we emit error log every time there's a problem with state validation, however, sometimes temporary errors like network connection issues happen. To avoid spamming the error log we only use the error log level after encountering 3 consecutive state validation errors

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Emit error log after 3 failed attempts to validate state

Close https://github.com/stellar/go/issues/1822

### Why

Currently we emit an error log every time there's a problem with state validation, however, sometimes temporary errors like network connection issues happen. To avoid spamming the error log we only use the error log level after encountering 3 consecutive state validation errors