### PR TITLE
services/horizon/internal/actions: Fix asset issuer does not exist bug in /assets endpoint

### DIFF
--- a/services/horizon/internal/actions/asset.go
+++ b/services/horizon/internal/actions/asset.go
@@ -90,15 +90,6 @@ func (handler AssetStatsHandler) findIssuersForAssets(
 		delete(issuerSet, account.AccountID)
 	}
 
-	if len(issuerSet) > 0 {
-		var issuer string
-		for key := range issuerSet {
-			issuer = key
-			break
-		}
-		return nil, fmt.Errorf("Account for issuer %s does not exist", issuer)
-	}
-
 	return accountsByID, nil
 }
 

--- a/services/horizon/internal/actions/asset.go
+++ b/services/horizon/internal/actions/asset.go
@@ -90,6 +90,10 @@ func (handler AssetStatsHandler) findIssuersForAssets(
 		delete(issuerSet, account.AccountID)
 	}
 
+	// Note it's possible that no accounts can be found for certain issuers.
+	// That can occur because an account can be removed when there are only empty trustlines
+	// pointing to it. We still continue to serve asset stats for such issuers.
+
 	return accountsByID, nil
 }
 

--- a/services/horizon/internal/actions/asset_test.go
+++ b/services/horizon/internal/actions/asset_test.go
@@ -335,14 +335,21 @@ func TestAssetStatsIssuerDoesNotExist(t *testing.T) {
 	tt.Assert.Equal(numChanged, int64(1))
 
 	r := makeRequest(t, map[string]string{}, map[string]string{}, q.Session)
-	_, err = handler.GetResourcePage(httptest.NewRecorder(), r)
-	if err == nil {
-		t.Fatal("error but got not nil")
+	results, err := handler.GetResourcePage(httptest.NewRecorder(), r)
+	tt.Assert.NoError(err)
+
+	expectedAssetStatResponse := horizon.AssetStat{
+		Amount:      "0.0000001",
+		NumAccounts: usdAssetStat.NumAccounts,
+		Asset: base.Asset{
+			Type:   "credit_alphanum4",
+			Code:   usdAssetStat.AssetCode,
+			Issuer: usdAssetStat.AssetIssuer,
+		},
+		PT: usdAssetStat.AssetCode + ":" + usdAssetStat.AssetIssuer,
 	}
 
-	expected := "Account for issuer GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H does not exist"
-
-	if err.Error() != expected {
-		t.Fatalf("expected error %v but got %v", expected, err)
-	}
+	tt.Assert.Len(results, 1)
+	assetStat := results[0].(horizon.AssetStat)
+	tt.Assert.Equal(assetStat, expectedAssetStatResponse)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fix asset issuer does not exist bug in /assets endpoint

Close https://github.com/stellar/go/issues/1928

### Why

It seems that account can be removed when there are empty trust lines pointing to it. So Horizon should continue populating asset stats response when issuer does not exist.

