### PR TITLE
services/horizon/internal/expingest/processors: Only process authorized trustlines when updating asset stats 

### DIFF
--- a/services/horizon/internal/actions/asset.go
+++ b/services/horizon/internal/actions/asset.go
@@ -39,15 +39,15 @@ func (handler AssetStatsHandler) validateAssetParams(code, issuer string, pq db2
 	}
 
 	if pq.Cursor != "" {
-		parts := strings.Split(pq.Cursor, ":")
-		if len(parts) != 2 {
+		parts := strings.SplitN(pq.Cursor, "_", 3)
+		if len(parts) != 3 {
 			return problem.MakeInvalidFieldProblem(
 				"cursor",
 				errors.New("cursor must contain exactly one colon"),
 			)
 		}
 
-		cursorCode, cursorIssuer := parts[0], parts[1]
+		cursorCode, cursorIssuer, assetType := parts[0], parts[1], parts[2]
 		if !xdr.ValidAssetCode.MatchString(cursorCode) {
 			return problem.MakeInvalidFieldProblem(
 				"cursor",
@@ -61,6 +61,14 @@ func (handler AssetStatsHandler) validateAssetParams(code, issuer string, pq db2
 				fmt.Errorf("%s is not a valid asset issuer", cursorIssuer),
 			)
 		}
+
+		if _, ok := xdr.StringToAssetType[assetType]; !ok {
+			return problem.MakeInvalidFieldProblem(
+				"cursor",
+				fmt.Errorf("%s is not a valid asset type", assetType),
+			)
+		}
+
 	}
 
 	return nil

--- a/services/horizon/internal/actions/asset_test.go
+++ b/services/horizon/internal/actions/asset_test.go
@@ -40,17 +40,17 @@ func TestAssetStatsValidation(t *testing.T) {
 			"not a valid asset issuer",
 		},
 		{
-			"cursor has too many colons",
+			"cursor has too many underscores",
 			map[string]string{
-				"cursor": "ABC:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H:",
+				"cursor": "ABC_GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H_credit_alphanum4_",
 			},
 			"cursor",
-			"cursor must contain exactly one colon",
+			"credit_alphanum4_ is not a valid asset type",
 		},
 		{
 			"invalid cursor code",
 			map[string]string{
-				"cursor": "tooooooooolong:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+				"cursor": "tooooooooolong_GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H_credit_alphanum12",
 			},
 			"cursor",
 			"not a valid asset code",
@@ -58,10 +58,18 @@ func TestAssetStatsValidation(t *testing.T) {
 		{
 			"invalid cursor issuer",
 			map[string]string{
-				"cursor": "ABC:invalidissuer",
+				"cursor": "ABC_invalidissuer_credit_alphanum4",
 			},
 			"cursor",
 			"not a valid asset issuer",
+		},
+		{
+			"invalid cursor type",
+			map[string]string{
+				"cursor": "ABC_GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H_credit_alphanum123",
+			},
+			"cursor",
+			"credit_alphanum123 is not a valid asset type",
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -124,7 +132,7 @@ func TestAssetStats(t *testing.T) {
 			Code:   usdAssetStat.AssetCode,
 			Issuer: usdAssetStat.AssetIssuer,
 		},
-		PT:    usdAssetStat.AssetCode + ":" + usdAssetStat.AssetIssuer,
+		PT:    usdAssetStat.PagingToken(),
 		Flags: issuerFlags,
 	}
 
@@ -143,7 +151,7 @@ func TestAssetStats(t *testing.T) {
 			Code:   etherAssetStat.AssetCode,
 			Issuer: etherAssetStat.AssetIssuer,
 		},
-		PT:    etherAssetStat.AssetCode + ":" + etherAssetStat.AssetIssuer,
+		PT:    etherAssetStat.PagingToken(),
 		Flags: issuerFlags,
 	}
 
@@ -162,7 +170,7 @@ func TestAssetStats(t *testing.T) {
 			Code:   otherUSDAssetStat.AssetCode,
 			Issuer: otherUSDAssetStat.AssetIssuer,
 		},
-		PT: otherUSDAssetStat.AssetCode + ":" + otherUSDAssetStat.AssetIssuer,
+		PT: otherUSDAssetStat.PagingToken(),
 	}
 	otherUSDAssetStatResponse.Links.Toml = hal.NewLink(
 		"https://" + otherIssuer.HomeDomain + "/.well-known/stellar.toml",
@@ -183,7 +191,7 @@ func TestAssetStats(t *testing.T) {
 			Code:   eurAssetStat.AssetCode,
 			Issuer: eurAssetStat.AssetIssuer,
 		},
-		PT: eurAssetStat.AssetCode + ":" + eurAssetStat.AssetIssuer,
+		PT: eurAssetStat.PagingToken(),
 	}
 	eurAssetStatResponse.Links.Toml = hal.NewLink(
 		"https://" + otherIssuer.HomeDomain + "/.well-known/stellar.toml",
@@ -346,7 +354,7 @@ func TestAssetStatsIssuerDoesNotExist(t *testing.T) {
 			Code:   usdAssetStat.AssetCode,
 			Issuer: usdAssetStat.AssetIssuer,
 		},
-		PT: usdAssetStat.AssetCode + ":" + usdAssetStat.AssetIssuer,
+		PT: usdAssetStat.PagingToken(),
 	}
 
 	tt.Assert.Len(results, 1)

--- a/services/horizon/internal/db2/history/asset_stats.go
+++ b/services/horizon/internal/db2/history/asset_stats.go
@@ -104,12 +104,12 @@ func (q *Q) GetAssetStat(assetType xdr.AssetType, assetCode, assetIssuer string)
 }
 
 func parseAssetStatsCursor(cursor string) (string, string, error) {
-	parts := strings.Split(cursor, ":")
-	if len(parts) != 2 {
+	parts := strings.SplitN(cursor, "_", 3)
+	if len(parts) != 3 {
 		return "", "", fmt.Errorf("invalid asset stats cursor: %v", cursor)
 	}
 
-	code, issuer := parts[0], parts[1]
+	code, issuer, assetType := parts[0], parts[1], parts[2]
 	var issuerAccount xdr.AccountId
 	var asset xdr.Asset
 
@@ -125,6 +125,10 @@ func parseAssetStatsCursor(cursor string) (string, string, error) {
 			err,
 			fmt.Sprintf("invalid asset stats cursor: %v", cursor),
 		)
+	}
+
+	if _, ok := xdr.StringToAssetType[assetType]; !ok {
+		return "", "", errors.Errorf("invalid asset type in asset stats cursor: %v", cursor)
 	}
 
 	return code, issuer, nil

--- a/services/horizon/internal/db2/history/asset_stats_test.go
+++ b/services/horizon/internal/db2/history/asset_stats_test.go
@@ -241,28 +241,33 @@ func TestGetAssetStatsCursorValidation(t *testing.T) {
 		expectedError string
 	}{
 		{
-			"cursor does not use colon as serpator",
+			"cursor does not use underscore as serpator",
 			"usdc-GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 			"invalid asset stats cursor",
 		},
 		{
-			"cursor has no colon",
+			"cursor has no underscore",
 			"usdc",
 			"invalid asset stats cursor",
 		},
 		{
-			"cursor has too many colons",
-			"usdc:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H:",
-			"invalid asset stats cursor",
+			"cursor has too many underscores",
+			"usdc_GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H_credit_alphanum4_",
+			"invalid asset type in asset stats cursor",
 		},
 		{
 			"issuer in cursor is invalid",
-			"usd:abcdefghijklmnopqrstuv",
+			"usd_abcdefghijklmnopqrstuv_credit_alphanum4",
 			"invalid issuer in asset stats cursor",
 		},
 		{
+			"asset type in cursor is invalid",
+			"usd_GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H_credit_alphanum",
+			"invalid asset type in asset stats cursor",
+		},
+		{
 			"asset code in cursor is too long",
-			"abcdefghijklmnopqrstuv:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+			"abcdefghijklmnopqrstuv_GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H_credit_alphanum12",
 			"invalid asset stats cursor",
 		},
 	} {
@@ -376,7 +381,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 			"no filter with cursor",
 			"",
 			"",
-			"ABC:GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+			"ABC_GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2_credit_alphanum4",
 			"asc",
 			[]ExpAssetStat{
 				etherAssetStat,
@@ -389,7 +394,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 			"no filter with cursor descending",
 			"",
 			"",
-			"ZZZ:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+			"ZZZ_GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H_credit_alphanum4",
 			"desc",
 			[]ExpAssetStat{
 				usdAssetStat,
@@ -402,7 +407,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 			"no filter with cursor and offset",
 			"",
 			"",
-			"ETHER:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+			"ETHER_GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H_credit_alphanum12",
 			"asc",
 			[]ExpAssetStat{
 				eurAssetStat,
@@ -414,7 +419,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 			"no filter with cursor and offset descending",
 			"",
 			"",
-			"EUR:GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+			"EUR_GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2_credit_alphanum4",
 			"desc",
 			[]ExpAssetStat{
 				etherAssetStat,
@@ -424,7 +429,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 			"no filter with cursor and offset descending including eur",
 			"",
 			"",
-			"EUR:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+			"EUR_GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H_credit_alphanum4",
 			"desc",
 			[]ExpAssetStat{
 				eurAssetStat,
@@ -446,7 +451,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 			"filter on code with cursor",
 			"USD",
 			"",
-			"USD:GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+			"USD_GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2_credit_alphanum4",
 			"asc",
 			[]ExpAssetStat{
 				usdAssetStat,
@@ -456,7 +461,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 			"filter on code with cursor descending",
 			"USD",
 			"",
-			"USD:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+			"USD_GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H_credit_alphanum4",
 			"desc",
 			[]ExpAssetStat{
 				otherUSDAssetStat,
@@ -477,7 +482,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 			"filter on issuer with cursor",
 			"",
 			"GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
-			"EUR:GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+			"EUR_GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2_credit_alphanum4",
 			"asc",
 			[]ExpAssetStat{
 				otherUSDAssetStat,
@@ -487,7 +492,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 			"filter on issuer with cursor descending",
 			"",
 			"GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
-			"USD:GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+			"USD_GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2_credit_alphanum4",
 			"desc",
 			[]ExpAssetStat{
 				eurAssetStat,
@@ -505,7 +510,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 			"filter on non existant code with cursor",
 			"BTC",
 			"",
-			"BTC:GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+			"BTC_GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2_credit_alphanum4",
 			"asc",
 			nil,
 		},
@@ -521,7 +526,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 			"filter on non existant issuer with cursor",
 			"",
 			"GAEIHD6U4WSBHJGA2HPWOQ3OQEFQ3Y7QZE2DR76YKZNKPW5YDLYW4UGF",
-			"AAA:GAEIHD6U4WSBHJGA2HPWOQ3OQEFQ3Y7QZE2DR76YKZNKPW5YDLYW4UGF",
+			"AAA_GAEIHD6U4WSBHJGA2HPWOQ3OQEFQ3Y7QZE2DR76YKZNKPW5YDLYW4UGF_credit_alphanum4",
 			"asc",
 			nil,
 		},
@@ -537,7 +542,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 			"filter on non existant code and non existant issuer with cursor",
 			"BTC",
 			"GAEIHD6U4WSBHJGA2HPWOQ3OQEFQ3Y7QZE2DR76YKZNKPW5YDLYW4UGF",
-			"AAA:GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+			"AAA_GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2_credit_alphanum4",
 			"asc",
 			nil,
 		},
@@ -555,7 +560,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 			"filter on both code and issuer with cursor",
 			"USD",
 			"GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
-			"USC:GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+			"USC_GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2_credit_alphanum4",
 			"asc",
 			[]ExpAssetStat{
 				otherUSDAssetStat,
@@ -565,7 +570,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 			"filter on both code and issuer with cursor descending",
 			"USD",
 			"GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
-			"USE:GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+			"USE_GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2_credit_alphanum4",
 			"desc",
 			[]ExpAssetStat{
 				otherUSDAssetStat,
@@ -575,7 +580,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 			"cursor negates filter",
 			"USD",
 			"GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
-			"USD:GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+			"USD_GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2_credit_alphanum4",
 			"asc",
 			nil,
 		},

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -242,7 +242,12 @@ type ExpAssetStat struct {
 
 // PagingToken returns a cursor for this asset stat
 func (e ExpAssetStat) PagingToken() string {
-	return fmt.Sprintf("%s:%s", e.AssetCode, e.AssetIssuer)
+	return fmt.Sprintf(
+		"%s_%s_%s",
+		e.AssetCode,
+		e.AssetIssuer,
+		xdr.AssetTypeToString[e.AssetType],
+	)
 }
 
 // QAssetStats defines exp_asset_stats related queries.

--- a/services/horizon/internal/expingest/processors/asset_stats_set.go
+++ b/services/horizon/internal/expingest/processors/asset_stats_set.go
@@ -22,7 +22,12 @@ type assetStatValue struct {
 type AssetStatSet map[assetStatKey]*assetStatValue
 
 // Add updates the set with a trustline entry from a history archive snapshot
+// if the trustline is authorized
 func (s AssetStatSet) Add(trustLine xdr.TrustLineEntry) error {
+	if !xdr.TrustLineFlags(trustLine.Flags).IsAuthorized() {
+		return nil
+	}
+
 	var key assetStatKey
 	if err := trustLine.Asset.Extract(&key.assetType, &key.assetCode, &key.assetIssuer); err != nil {
 		return errors.Wrap(err, "could not extract asset info from trustline")

--- a/services/horizon/internal/expingest/processors/asset_stats_set_test.go
+++ b/services/horizon/internal/expingest/processors/asset_stats_set_test.go
@@ -40,6 +40,21 @@ func assertAllEquals(t *testing.T, set AssetStatSet, expected []history.ExpAsset
 	}
 }
 
+func TestAssetStatSetIgnoresUnauthorizedTrustlines(t *testing.T) {
+	set := AssetStatSet{}
+	err := set.Add(xdr.TrustLineEntry{
+		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		Asset:     xdr.MustNewCreditAsset("EUR", trustLineIssuer.Address()),
+		Balance:   1,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if all := set.All(); len(all) != 0 {
+		t.Fatalf("expected empty list but got %v", all)
+	}
+}
+
 func TestAddAndRemoveAssetStats(t *testing.T) {
 	set := AssetStatSet{}
 	eur := "EUR"
@@ -55,6 +70,7 @@ func TestAddAndRemoveAssetStats(t *testing.T) {
 		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
 		Asset:     xdr.MustNewCreditAsset(eur, trustLineIssuer.Address()),
 		Balance:   1,
+		Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -65,6 +81,7 @@ func TestAddAndRemoveAssetStats(t *testing.T) {
 		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
 		Asset:     xdr.MustNewCreditAsset(eur, trustLineIssuer.Address()),
 		Balance:   24,
+		Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -79,6 +96,7 @@ func TestAddAndRemoveAssetStats(t *testing.T) {
 		AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 		Asset:     xdr.MustNewCreditAsset(usd, trustLineIssuer.Address()),
 		Balance:   10,
+		Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -89,6 +107,7 @@ func TestAddAndRemoveAssetStats(t *testing.T) {
 		AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 		Asset:     xdr.MustNewCreditAsset(ether, trustLineIssuer.Address()),
 		Balance:   3,
+		Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -133,6 +152,7 @@ func TestOverflowAssetStatSet(t *testing.T) {
 		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
 		Asset:     xdr.MustNewCreditAsset(eur, trustLineIssuer.Address()),
 		Balance:   math.MaxInt64,
+		Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -157,6 +177,7 @@ func TestOverflowAssetStatSet(t *testing.T) {
 		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
 		Asset:     xdr.MustNewCreditAsset(eur, trustLineIssuer.Address()),
 		Balance:   math.MaxInt64,
+		Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The experimental ingestion pipeline has a bug in that it counts unauthorized trustlines when computing asset stats. Only authorized trustlines should be included.

Another issue fixed in this PR is that the cursor for the new asset stats endpoint diverges from the existing asset stats endpoint

Close https://github.com/stellar/go/issues/1933

### Why

The new asset stats endpoint should have identical semantics to the existing endpoint

