### PR TITLE
services/horizon/internal: remove unused layer of router

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -78,9 +78,6 @@ func NewApp(config Config) *App {
 // Serve starts the horizon web server, binding it to a socket, setting up
 // the shutdown signals.
 func (a *App) Serve() {
-	mux := http.NewServeMux()
-	mux.Handle("/", a.web.router)
-
 	addr := fmt.Sprintf(":%d", a.config.Port)
 
 	srv := &graceful.Server{
@@ -88,7 +85,7 @@ func (a *App) Serve() {
 
 		Server: &http.Server{
 			Addr:              addr,
-			Handler:           mux,
+			Handler:           a.web.router,
 			ReadHeaderTimeout: 5 * time.Second,
 		},
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove the extra serve mux http handler layer between the http.Server and the chi.Router, which itself is a http.Handler.

### Why

The chi.Router is a handler, and we don't need to wrap it in another serve mux, whether it be the default or our own one.

I noticed in #1935 when we replaced the default serve mux with our own one that both are unnecessary.

### Known limitations

N/A
