### PR TITLE
services/horizon: Bump expingest version

### DIFF
--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -37,7 +37,9 @@ const (
 	// - 7: Fixes a bug in AccountSignersChanged method.
 	// - 8: Fixes AccountSigners processor to remove preauth tx signer
 	//      when preauth tx is failed.
-	CurrentVersion = 8
+	// - 9: Fixes a bug in asset stats processor that counted unauthorized
+	//      trustlines.
+	CurrentVersion = 9
 )
 
 var log = ilog.DefaultLogger.WithField("service", "expingest")

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -26,7 +26,7 @@ const assetStatsBatchSize = 500
 // check them.
 // There is a test that checks it, to fix it: update the actual `verifyState`
 // method instead of just updating this value!
-const stateVerifierExpectedIngestionVersion = 8
+const stateVerifierExpectedIngestionVersion = 9
 
 // verifyState is called as a go routine from pipeline post hook every 64
 // ledgers. It checks if the state is correct. If another go routine is already


### PR DESCRIPTION
### What

Bumps `expingest.CurrentVersion` to recreate state due to a bug fixed in #1936.

### Why

We need to reingest existing state due to a rules change connected to trust lines authorization.
