### PR TITLE
services/horizon: Truncate exp_asset_stats table when reingesting state

### DIFF
--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -115,6 +115,7 @@ var ExperimentalIngestionTables = []string{
 	"accounts",
 	"accounts_data",
 	"accounts_signers",
+	"exp_asset_stats",
 	"offers",
 	"trust_lines",
 }


### PR DESCRIPTION
### What

Updates `ExperimentalIngestionTables` with `exp_asset_stats` that contains asset stats populated by experimental ingestion pipeline.

### Why

When `expingest` rebuilds state it truncates state tables to start from scratch. One of the new tables introduced in 0.23.0 were not truncated what resulted in: `duplicate key value violates unique constraint` error.

### Known limitations

We should add tests to not forget about truncating new tables in the future. Created: https://github.com/stellar/go/issues/1941