### PR TITLE
services/horizon/internal/render/sse: Send bye bye event before exiting a StreamHandler

### DIFF
--- a/services/horizon/internal/render/sse/stream_handler.go
+++ b/services/horizon/internal/render/sse/stream_handler.go
@@ -74,6 +74,7 @@ func (handler StreamHandler) ServeStream(
 		case currentLedgerSequence = <-handler.LedgerSource.NextLedger(currentLedgerSequence):
 			continue
 		case <-ctx.Done():
+			stream.Done()
 			return
 		}
 	}

--- a/services/horizon/internal/render/sse/stream_handler_test.go
+++ b/services/horizon/internal/render/sse/stream_handler_test.go
@@ -1,0 +1,38 @@
+package sse
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stellar/go/services/horizon/internal/ledger"
+)
+
+func TestSendByeByeOnContextDone(t *testing.T) {
+	ledgerSource := ledger.NewTestingSource(1)
+	handler := StreamHandler{
+		LedgerSource: ledgerSource,
+	}
+
+	r, err := http.NewRequest("GET", "http://localhost", nil)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+
+	handler.ServeStream(w, r, 10, func() ([]Event, error) {
+		cancel()
+		return []Event{}, nil
+	})
+
+	expected := "retry: 1000\nevent: open\ndata: \"hello\"\n\n" +
+		"retry: 10\nevent: close\ndata: \"byebye\"\n\n"
+
+	if got := w.Body.String(); got != expected {
+		t.Fatalf("expected '%v' but got '%v'", expected, got)
+	}
+}


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

We should be sending a bye bye event before closing an SSE request.
But we neglect to do so when the StreamHandler context terminates the request.

Close https://github.com/stellar/go/issues/1934
