### PR TITLE
.circleci: remove go mod checks for go 1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,6 @@ workflows:
 
   check_code_and_test:
     jobs:
-      - check_code_1_12
       - check_code_1_13
       - test_code_1_12
       - test_code_1_13

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,6 @@ jobs:
           GO111MODULE: "on"
     steps:
       - install_go_deps
-      - check_go_deps
       - gofmt
       - govet
       - staticcheck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,19 +173,6 @@ commands:
 #-----------------------------------------------------------------------------#
 
 jobs:
-  # check_code_1_12 performs code checks using Go 1.12.
-  check_code_1_12:
-    working_directory: /go/src/github.com/stellar/go
-    docker:
-      - image: circleci/golang:1.12-stretch
-        environment:
-          GO111MODULE: "on"
-    steps:
-      - install_go_deps
-      - gofmt
-      - govet
-      - staticcheck
-
   # check_code_1_13 performs code checks using Go 1.13.
   check_code_1_13:
     working_directory: /go/src/github.com/stellar/go


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR removes the `go mod`-related checks for Go 1.12. 

### Why

Go 1.13-specific projects like [Hubble](https://github.com/stellar/go/tree/master/exp/hubble) creates divergence in the dependencies, and the spread of 1.13 in the larger community makes continued support of 1.12 less important in the longer term. Additionally, [community best practices ](https://github.com/golang/go/issues/34135#issuecomment-530497290)advise against running these checks on multiple Go versions.

### Known limitations

N/A
