### PR TITLE
services/horizon: Rename `OperationFeeStats` to `FeeStats`

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,6 +6,10 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## v0.24.0
+
+* Rename `OperationFeeStats` to `FeeStats` ([#1950](https://github.com/stellar/go/pull/1950))
+
 ## v0.23.1
 
 * Add `ReadTimeout` to Horizon HTTP server configuration to fix potential DoS vector.

--- a/services/horizon/internal/actions_operation_fee_stats.go
+++ b/services/horizon/internal/actions_operation_fee_stats.go
@@ -12,13 +12,13 @@ import (
 
 // This file contains the actions:
 //
-// OperationFeeStatsAction: stats representing current state of network fees
+// FeeStatsAction: stats representing current state of network fees
 
-var _ actions.JSONer = (*OperationFeeStatsAction)(nil)
+var _ actions.JSONer = (*FeeStatsAction)(nil)
 
-// OperationFeeStatsAction renders a few useful statistics that describe the
+// FeeStatsAction renders a few useful statistics that describe the
 // current state of operation fees on the network.
-type OperationFeeStatsAction struct {
+type FeeStatsAction struct {
 	Action
 	FeeMin              int64
 	FeeMode             int64
@@ -39,7 +39,7 @@ type OperationFeeStatsAction struct {
 }
 
 // JSON is a method for actions.JSON
-func (action *OperationFeeStatsAction) JSON() error {
+func (action *FeeStatsAction) JSON() error {
 	if !action.App.config.IngestFailedTransactions {
 		// If Horizon is not ingesting failed transaction it does not make sense to display
 		// operation fee stats because they will be incorrect.
@@ -80,7 +80,7 @@ func (action *OperationFeeStatsAction) JSON() error {
 	return action.Err
 }
 
-func (action *OperationFeeStatsAction) loadRecords() {
+func (action *FeeStatsAction) loadRecords() {
 	cur := operationfeestats.CurrentState()
 	action.FeeMin = cur.FeeMin
 	action.FeeMode = cur.FeeMode

--- a/services/horizon/internal/actions_operation_fee_stats_test.go
+++ b/services/horizon/internal/actions_operation_fee_stats_test.go
@@ -92,7 +92,7 @@ func TestOperationFeeTestsActions_Show(t *testing.T) {
 			_, err := ht.HorizonSession().ExecRaw("UPDATE history_ledgers SET max_tx_set_size = 50")
 			ht.Require.NoError(err)
 
-			ht.App.UpdateOperationFeeStatsState()
+			ht.App.UpdateFeeStatsState()
 
 			w := ht.Get("/fee_stats")
 
@@ -134,7 +134,7 @@ func TestOperationFeeTestsActions_ShowMultiOp(t *testing.T) {
 	_, err = ht.HorizonSession().ExecRaw("UPDATE history_transactions SET operation_count = operation_count * 2")
 	ht.Require.NoError(err)
 
-	ht.App.UpdateOperationFeeStatsState()
+	ht.App.UpdateFeeStatsState()
 
 	w := ht.Get("/fee_stats")
 
@@ -172,7 +172,7 @@ func TestOperationFeeTestsActions_NotInterpolating(t *testing.T) {
 	_, err = ht.HorizonSession().ExecRaw("UPDATE history_transactions SET max_fee = 256000, operation_count = 16 WHERE transaction_hash = '6a349e7331e93a251367287e274fb1699abaf723bde37aebe96248c76fd3071a'")
 	ht.Require.NoError(err)
 
-	ht.App.UpdateOperationFeeStatsState()
+	ht.App.UpdateFeeStatsState()
 
 	w := ht.Get("/fee_stats")
 

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -211,8 +211,8 @@ func (a *App) UpdateLedgerState() {
 	ledger.SetState(next)
 }
 
-// UpdateOperationFeeStatsState triggers a refresh of several operation fee metrics.
-func (a *App) UpdateOperationFeeStatsState() {
+// UpdateFeeStatsState triggers a refresh of several operation fee metrics.
+func (a *App) UpdateFeeStatsState() {
 	var (
 		next          operationfeestats.State
 		latest        history.LatestLedger
@@ -245,7 +245,7 @@ func (a *App) UpdateOperationFeeStatsState() {
 	next.LastBaseFee = int64(latest.BaseFee)
 	next.LastLedger = int64(latest.Sequence)
 
-	err = a.HistoryQ().OperationFeeStats(latest.Sequence, &feeStats)
+	err = a.HistoryQ().FeeStats(latest.Sequence, &feeStats)
 	if err != nil {
 		logErr(err, "failed to load operation fee stats")
 		return
@@ -355,7 +355,7 @@ func (a *App) Tick() {
 	// update ledger state, operation fee state, and stellar-core info in parallel
 	wg.Add(3)
 	go func() { a.UpdateLedgerState(); wg.Done() }()
-	go func() { a.UpdateOperationFeeStatsState(); wg.Done() }()
+	go func() { a.UpdateFeeStatsState(); wg.Done() }()
 	go func() { a.UpdateStellarCoreInfo(); wg.Done() }()
 	wg.Wait()
 

--- a/services/horizon/internal/db2/history/operation.go
+++ b/services/horizon/internal/db2/history/operation.go
@@ -38,10 +38,10 @@ func (r *Operation) UnmarshalDetails(dest interface{}) error {
 	return err
 }
 
-// OperationFeeStats returns operation fee stats for the last 5 ledgers.
+// FeeStats returns operation fee stats for the last 5 ledgers.
 // Currently, we hard code the query to return the last 5 ledgers worth of transactions.
 // TODO: make the number of ledgers configurable.
-func (q *Q) OperationFeeStats(currentSeq int32, dest *FeeStats) error {
+func (q *Q) FeeStats(currentSeq int32, dest *FeeStats) error {
 	return q.GetRaw(dest, `
 		SELECT
 			ceil(min(max_fee/operation_count))::bigint AS "min",

--- a/services/horizon/internal/main_generated.go
+++ b/services/horizon/internal/main_generated.go
@@ -58,7 +58,7 @@ func (action OffersByAccountAction) Handle(w http.ResponseWriter, r *http.Reques
 	ap.Execute(&action)
 }
 
-func (action OperationFeeStatsAction) Handle(w http.ResponseWriter, r *http.Request) {
+func (action FeeStatsAction) Handle(w http.ResponseWriter, r *http.Request) {
 	ap := &action.Action
 	ap.Prepare(w, r)
 	ap.Execute(&action)

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -313,7 +313,7 @@ func (w *web) mustInstallActions(
 	}
 
 	// Network state related endpoints
-	r.Get("/fee_stats", OperationFeeStatsAction{}.Handle)
+	r.Get("/fee_stats", FeeStatsAction{}.Handle)
 
 	// friendbot
 	if config.FriendbotURL != nil {


### PR DESCRIPTION
### What

Renames `OperationFeeStats` to `FeeStats` across the horizon service.

### Why

Fixes #1952 

### Known limitations

N/A