### PR TITLE
services/keystore: update changelog to signal current revision as v1.2.0

### DIFF
--- a/services/keystore/CHANGELOG.md
+++ b/services/keystore/CHANGELOG.md
@@ -1,11 +1,9 @@
 ## Unreleased
 
+## [v1.2.0] - 2019-11-20
+
 - Add `ReadTimeout` to Keystore HTTP server configuration to fix potential DoS vector.
 - Dropped support for Go 1.10, 1.11.
-
-## [v1.0.0] - 2019-06-18
-
-Initial release of the keystore.
 
 ## [v1.1.0] - 2019-08-21
 
@@ -13,3 +11,7 @@ Keystore has new interface for managing keys blob.
 Please refer to the [spec](https://github.com/stellar/go/blob/bcaf3d55229df822b155442633adc230294588b4/services/keystore/spec.md) for the new changes.
 Note that the data you previously store will be wiped out. Be sure to save the
 data that's important to you before upgrading to this version.
+
+## [v1.0.0] - 2019-06-18
+
+Initial release of the keystore.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] ~This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).~
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Update the Keystore CHANGELOG to signal that the current revision is v1.2.0.

Also, I re-ordered the versions so they are in descending order, like our other changelogs.

### Why

An important fix was made to Keystore and we should signal that the current version is a usable version of Keystore.
### Known limitations

It appears we haven't been tagging releases or releasing binaries of Keystore at the moment because our only deployment of it is continuously deployed commit-by-commit irrespective of versions. I think given the two fixes are noteworthy it's worth signaling them as v1.2.0 to encourage someone who might be happen to checking out the application to use a new version oft he application but I don't want to address the tagging or releasing in this release especially as this service is still really experimental and we're not using it as we had intended.