### PR TITLE
exp/tools/dump-ledger-state: Simplify ingestion proof of concept

### DIFF
--- a/exp/ingest/adapters/history_archive_adapter.go
+++ b/exp/ingest/adapters/history_archive_adapter.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/stellar/go/exp/ingest/io"
@@ -49,7 +50,7 @@ func (haa *HistoryArchiveAdapter) BucketListHash(sequence uint32) (xdr.Hash, err
 }
 
 // GetState returns a reader with the state of the ledger at the provided sequence number
-func (haa *HistoryArchiveAdapter) GetState(sequence uint32, tempSet io.TempSet) (io.StateReader, error) {
+func (haa *HistoryArchiveAdapter) GetState(ctx context.Context, sequence uint32, tempSet io.TempSet) (io.StateReader, error) {
 	exists, err := haa.archive.CategoryCheckpointExists("history", sequence)
 	if err != nil {
 		return nil, errors.Wrap(err, "error checking if category checkpoint exists")
@@ -58,7 +59,7 @@ func (haa *HistoryArchiveAdapter) GetState(sequence uint32, tempSet io.TempSet) 
 		return nil, fmt.Errorf("history checkpoint does not exist for ledger %d", sequence)
 	}
 
-	sr, e := io.NewStateReaderForLedger(haa.archive, tempSet, sequence)
+	sr, e := io.NewStateReaderForLedger(ctx, haa.archive, tempSet, sequence)
 	if e != nil {
 		return nil, errors.Wrap(e, "could not make memory state reader")
 	}

--- a/exp/ingest/adapters/history_archive_adapter.go
+++ b/exp/ingest/adapters/history_archive_adapter.go
@@ -58,7 +58,7 @@ func (haa *HistoryArchiveAdapter) GetState(sequence uint32, tempSet io.TempSet) 
 		return nil, fmt.Errorf("history checkpoint does not exist for ledger %d", sequence)
 	}
 
-	sr, e := io.MakeSingleLedgerStateReader(haa.archive, tempSet, sequence)
+	sr, e := io.NewStateReaderForLedger(haa.archive, tempSet, sequence)
 	if e != nil {
 		return nil, errors.Wrap(e, "could not make memory state reader")
 	}

--- a/exp/ingest/adapters/history_archive_adapter_test.go
+++ b/exp/ingest/adapters/history_archive_adapter_test.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"context"
 	"fmt"
 	stdio "io"
 	"testing"
@@ -37,7 +38,7 @@ func TestGetState_Sequence(t *testing.T) {
 		return
 	}
 
-	sr, e := haa.GetState(seq, &io.MemoryTempSet{})
+	sr, e := haa.GetState(context.Background(), seq, &io.MemoryTempSet{})
 	if !assert.NoError(t, e) {
 		return
 	}
@@ -51,7 +52,7 @@ func TestGetState_Read(t *testing.T) {
 	}
 	haa := MakeHistoryArchiveAdapter(archive)
 
-	sr, e := haa.GetState(21686847, &io.MemoryTempSet{})
+	sr, e := haa.GetState(context.Background(), 21686847, &io.MemoryTempSet{})
 	if !assert.NoError(t, e) {
 		return
 	}

--- a/exp/ingest/io/single_ledger_state_reader.go
+++ b/exp/ingest/io/single_ledger_state_reader.go
@@ -62,8 +62,21 @@ const msrBufferSize = 50000
 // temp set.
 const preloadedEntries = 20000
 
-// MakeSingleLedgerStateReader is a factory method for SingleLedgerStateReader
-func MakeSingleLedgerStateReader(
+// NewStateReader constructs a StateReader for the most recently published checkpoint ledger
+func NewStateReader(
+	archive historyarchive.ArchiveInterface,
+	tempStore TempSet,
+) (*SingleLedgerStateReader, error) {
+	has, e := archive.GetRootHAS()
+	if e != nil {
+		return nil, fmt.Errorf("could not get root HAS: %s", e)
+	}
+
+	return NewStateReaderForLedger(archive, tempStore, has.CurrentLedger)
+}
+
+// NewStateReaderForLedger constructs a StateReader for a given sequence number
+func NewStateReaderForLedger(
 	archive historyarchive.ArchiveInterface,
 	tempStore TempSet,
 	sequence uint32,

--- a/exp/ingest/io/single_ledger_state_reader_test.go
+++ b/exp/ingest/io/single_ledger_state_reader_test.go
@@ -43,7 +43,7 @@ func (s *SingleLedgerStateReaderTestSuite) SetupTest() {
 		On("BucketExists", mock.AnythingOfType("historyarchive.Hash")).
 		Return(true, nil).Times(21)
 
-	s.reader, err = MakeSingleLedgerStateReader(s.mockArchive, &MemoryTempSet{}, ledgerSeq)
+	s.reader, err = NewStateReaderForLedger(s.mockArchive, &MemoryTempSet{}, ledgerSeq)
 	s.Require().NotNil(s.reader)
 	s.Require().NoError(err)
 	s.Assert().Equal(ledgerSeq, s.reader.sequence)

--- a/exp/ingest/io/single_ledger_state_reader_test.go
+++ b/exp/ingest/io/single_ledger_state_reader_test.go
@@ -2,6 +2,7 @@ package io
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -43,7 +44,12 @@ func (s *SingleLedgerStateReaderTestSuite) SetupTest() {
 		On("BucketExists", mock.AnythingOfType("historyarchive.Hash")).
 		Return(true, nil).Times(21)
 
-	s.reader, err = NewStateReaderForLedger(s.mockArchive, &MemoryTempSet{}, ledgerSeq)
+	s.reader, err = NewStateReaderForLedger(
+		context.Background(),
+		s.mockArchive,
+		&MemoryTempSet{},
+		ledgerSeq,
+	)
 	s.Require().NotNil(s.reader)
 	s.Require().NoError(err)
 	s.Assert().Equal(ledgerSeq, s.reader.sequence)

--- a/exp/ingest/live_session.go
+++ b/exp/ingest/live_session.go
@@ -260,7 +260,7 @@ func (s *LiveSession) initState(historyAdapter *adapters.HistoryArchiveAdapter, 
 		tempSet = s.TempSet
 	}
 
-	stateReader, err := historyAdapter.GetState(sequence, tempSet)
+	stateReader, err := historyAdapter.GetState(context.TODO(), sequence, tempSet)
 	if err != nil {
 		return errors.Wrap(err, "Error getting state from history archive")
 	}

--- a/exp/ingest/single_ledger_session.go
+++ b/exp/ingest/single_ledger_session.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"context"
 	"github.com/stellar/go/exp/ingest/adapters"
 	"github.com/stellar/go/exp/ingest/io"
 	"github.com/stellar/go/support/errors"
@@ -42,7 +43,7 @@ func (s *SingleLedgerSession) processState(historyAdapter *adapters.HistoryArchi
 		tempSet = s.TempSet
 	}
 
-	stateReader, err := historyAdapter.GetState(sequence, tempSet)
+	stateReader, err := historyAdapter.GetState(context.TODO(), sequence, tempSet)
 	if err != nil {
 		return errors.Wrap(err, "Error getting state from history archive")
 	}

--- a/exp/tools/dump-ledger-state/csv.go
+++ b/exp/tools/dump-ledger-state/csv.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+// csvMap maintains a mapping from ledger entry type to csv file
+type csvMap struct {
+	files   map[xdr.LedgerEntryType]*os.File
+	writers map[xdr.LedgerEntryType]*csv.Writer
+}
+
+// newCSVMap constructs an empty csvMap instance
+func newCSVMap() csvMap {
+	return csvMap{
+		files:   map[xdr.LedgerEntryType]*os.File{},
+		writers: map[xdr.LedgerEntryType]*csv.Writer{},
+	}
+}
+
+// put creates a new file with the given file name and links that file to the
+// given ledger entry type
+func (c csvMap) put(entryType xdr.LedgerEntryType, fileName string) error {
+	if _, ok := c.files[entryType]; ok {
+		return fmt.Errorf("entry type %s is already present in the file set", fileName)
+	}
+
+	file, err := os.Create(fileName)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("could not open file %s", fileName))
+	}
+
+	c.files[entryType] = file
+	c.writers[entryType] = csv.NewWriter(file)
+
+	return nil
+}
+
+// get returns a csv writer for the given ledger entry type if it exists in the mapping
+func (c csvMap) get(entryType xdr.LedgerEntryType) (*csv.Writer, bool) {
+	writer, ok := c.writers[entryType]
+	return writer, ok
+}
+
+// close will close all files contained in the mapping
+func (c csvMap) close() {
+	for entryType, file := range c.files {
+		if err := file.Close(); err != nil {
+			fmt.Printf("could not close file for entry type: %s\n", entryType.String())
+		}
+		delete(c.files, entryType)
+		delete(c.writers, entryType)
+	}
+}

--- a/exp/tools/dump-ledger-state/main.go
+++ b/exp/tools/dump-ledger-state/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	stdio "io"
@@ -87,6 +88,7 @@ func main() {
 	}
 
 	reader, err := io.NewStateReaderForLedger(
+		context.Background(),
 		archive,
 		&io.MemoryTempSet{},
 		uint32(ledgerSequence),

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -171,8 +171,10 @@ func NewSystem(config Config) (*System, error) {
 			processors.NewAccountStore(historyQ),
 			processors.NewAccountDataStore(historyQ),
 			processors.NewAccountSignerStore(historyQ),
-			processors.NewOfferStore(historyQ, config.OrderBookGraph),
-			processors.NewTrustLineStore(historyQ, historyQ),
+			processors.NewOfferStore(historyQ),
+			processors.NewOrderbookStore(config.OrderBookGraph),
+			processors.NewTrustLineStore(historyQ),
+			processors.NewAssetStatsStore(historyQ),
 		},
 
 		session:                  session,

--- a/services/horizon/internal/expingest/pipeline_hooks_test.go
+++ b/services/horizon/internal/expingest/pipeline_hooks_test.go
@@ -199,7 +199,8 @@ func TestPostProcessingHook(t *testing.T) {
 				tt.Assert.NoError(err)
 			}
 
-			err = postProcessingHook(ctx, testCase.err, statePipeline, nil, graph, session)
+			ledgerSeq := pipeline.GetLedgerSequenceFromContext(ctx)
+			err = postProcessingHook(testCase.err, ledgerSeq, statePipeline, nil, graph, session)
 			if testCase.expectedError == "" {
 				tt.Assert.NoError(err)
 				tt.Assert.Equal(graph.Offers(), []xdr.OfferEntry{eurOffer})

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -192,8 +192,8 @@ func preProcessingHook(
 }
 
 func postProcessingHook(
-	ctx context.Context,
 	err error,
+	ledgerSeq uint32,
 	pipelineType pType,
 	system *System,
 	graph *orderbook.OrderBookGraph,
@@ -203,8 +203,6 @@ func postProcessingHook(
 	defer graph.Discard()
 	historyQ := &history.Q{historySession}
 	isMaster := false
-
-	ledgerSeq := pipeline.GetLedgerSequenceFromContext(ctx)
 
 	if err != nil {
 		switch errors.Cause(err).(type) {
@@ -318,6 +316,7 @@ func addPipelineHooks(
 	})
 
 	p.AddPostProcessingHook(func(ctx context.Context, err error) error {
-		return postProcessingHook(ctx, err, pipelineType, system, graph, historySession)
+		ledgerSeq := pipeline.GetLedgerSequenceFromContext(ctx)
+		return postProcessingHook(err, ledgerSeq, pipelineType, system, graph, historySession)
 	})
 }

--- a/services/horizon/internal/expingest/processors/account_data_store.go
+++ b/services/horizon/internal/expingest/processors/account_data_store.go
@@ -1,0 +1,35 @@
+package processors
+
+import (
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+type AccountDataStore struct {
+	batch history.AccountDataBatchInsertBuilder
+}
+
+func NewAccountDataStore(dataQ history.QData) AccountDataStore {
+	return AccountDataStore{dataQ.NewAccountDataBatchInsertBuilder(maxBatchSize)}
+}
+
+func (s AccountDataStore) Add(entryChange xdr.LedgerEntryChange) error {
+	if entryChange.EntryType() != xdr.LedgerEntryTypeData {
+		return nil
+	}
+
+	err := s.batch.Add(
+		entryChange.MustState().Data.MustData(),
+		entryChange.MustState().LastModifiedLedgerSeq,
+	)
+	if err != nil {
+		return errors.Wrap(err, "Error adding row to accountSignerBatch")
+	}
+
+	return nil
+}
+
+func (s AccountDataStore) Flush() error {
+	return s.batch.Exec()
+}

--- a/services/horizon/internal/expingest/processors/account_signer_store.go
+++ b/services/horizon/internal/expingest/processors/account_signer_store.go
@@ -1,0 +1,39 @@
+package processors
+
+import (
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+type AccountSignerStore struct {
+	batch history.AccountSignersBatchInsertBuilder
+}
+
+func NewAccountSignerStore(dataQ history.QSigners) AccountSignerStore {
+	return AccountSignerStore{dataQ.NewAccountSignersBatchInsertBuilder(maxBatchSize)}
+}
+
+func (s AccountSignerStore) Add(entryChange xdr.LedgerEntryChange) error {
+	if entryChange.EntryType() != xdr.LedgerEntryTypeAccount {
+		return nil
+	}
+
+	accountEntry := entryChange.MustState().Data.MustAccount()
+	account := accountEntry.AccountId.Address()
+	for signer, weight := range accountEntry.SignerSummary() {
+		err := s.batch.Add(history.AccountSigner{
+			Account: account,
+			Signer:  signer,
+			Weight:  weight,
+		})
+		if err != nil {
+			return errors.Wrap(err, "Error adding row to accountSignerBatch")
+		}
+	}
+	return nil
+}
+
+func (s AccountSignerStore) Flush() error {
+	return s.batch.Exec()
+}

--- a/services/horizon/internal/expingest/processors/account_store.go
+++ b/services/horizon/internal/expingest/processors/account_store.go
@@ -1,0 +1,35 @@
+package processors
+
+import (
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+type AccountStore struct {
+	batch history.AccountsBatchInsertBuilder
+}
+
+func NewAccountStore(accountsQ history.QAccounts) AccountStore {
+	return AccountStore{accountsQ.NewAccountsBatchInsertBuilder(maxBatchSize)}
+}
+
+func (s AccountStore) Add(entryChange xdr.LedgerEntryChange) error {
+	if entryChange.EntryType() != xdr.LedgerEntryTypeAccount {
+		return nil
+	}
+
+	err := s.batch.Add(
+		entryChange.MustState().Data.MustAccount(),
+		entryChange.MustState().LastModifiedLedgerSeq,
+	)
+	if err != nil {
+		return errors.Wrap(err, "Error adding row to accountSignerBatch")
+	}
+
+	return nil
+}
+
+func (s AccountStore) Flush() error {
+	return s.batch.Exec()
+}

--- a/services/horizon/internal/expingest/processors/asset_stats_store.go
+++ b/services/horizon/internal/expingest/processors/asset_stats_store.go
@@ -1,0 +1,37 @@
+package processors
+
+import (
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+type AssetStatsStore struct {
+	assetStats  AssetStatSet
+	assetStatsQ history.QAssetStats
+}
+
+func NewAssetStatsStore(assetStatsQ history.QAssetStats) AssetStatsStore {
+	return AssetStatsStore{
+		assetStats:  AssetStatSet{},
+		assetStatsQ: assetStatsQ,
+	}
+}
+
+func (s AssetStatsStore) Add(entryChange xdr.LedgerEntryChange) error {
+	if entryChange.EntryType() != xdr.LedgerEntryTypeTrustline {
+		return nil
+	}
+
+	trustline := entryChange.MustState().Data.MustTrustLine()
+	err := s.assetStats.Add(trustline)
+	if err != nil {
+		return errors.Wrap(err, "Error adding trustline to asset stats set")
+	}
+
+	return nil
+}
+
+func (s AssetStatsStore) Flush() error {
+	return s.assetStatsQ.InsertAssetStats(s.assetStats.All(), maxBatchSize)
+}

--- a/services/horizon/internal/expingest/processors/offer_store.go
+++ b/services/horizon/internal/expingest/processors/offer_store.go
@@ -1,22 +1,17 @@
 package processors
 
 import (
-	"github.com/stellar/go/exp/orderbook"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 
 type OfferStore struct {
-	batch          history.OffersBatchInsertBuilder
-	orderbookGraph *orderbook.OrderBookGraph
+	batch history.OffersBatchInsertBuilder
 }
 
-func NewOfferStore(
-	dataQ history.QOffers,
-	orderbookGraph *orderbook.OrderBookGraph,
-) OfferStore {
-	return OfferStore{dataQ.NewOffersBatchInsertBuilder(maxBatchSize), orderbookGraph}
+func NewOfferStore(dataQ history.QOffers) OfferStore {
+	return OfferStore{dataQ.NewOffersBatchInsertBuilder(maxBatchSize)}
 }
 
 func (s OfferStore) Add(entryChange xdr.LedgerEntryChange) error {
@@ -25,8 +20,6 @@ func (s OfferStore) Add(entryChange xdr.LedgerEntryChange) error {
 	}
 
 	offer := entryChange.MustState().Data.MustOffer()
-	s.orderbookGraph.AddOffer(offer)
-
 	err := s.batch.Add(
 		offer,
 		entryChange.MustState().LastModifiedLedgerSeq,

--- a/services/horizon/internal/expingest/processors/offer_store.go
+++ b/services/horizon/internal/expingest/processors/offer_store.go
@@ -1,0 +1,43 @@
+package processors
+
+import (
+	"github.com/stellar/go/exp/orderbook"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+type OfferStore struct {
+	batch          history.OffersBatchInsertBuilder
+	orderbookGraph *orderbook.OrderBookGraph
+}
+
+func NewOfferStore(
+	dataQ history.QOffers,
+	orderbookGraph *orderbook.OrderBookGraph,
+) OfferStore {
+	return OfferStore{dataQ.NewOffersBatchInsertBuilder(maxBatchSize), orderbookGraph}
+}
+
+func (s OfferStore) Add(entryChange xdr.LedgerEntryChange) error {
+	if entryChange.EntryType() != xdr.LedgerEntryTypeOffer {
+		return nil
+	}
+
+	offer := entryChange.MustState().Data.MustOffer()
+	s.orderbookGraph.AddOffer(offer)
+
+	err := s.batch.Add(
+		offer,
+		entryChange.MustState().LastModifiedLedgerSeq,
+	)
+	if err != nil {
+		return errors.Wrap(err, "Error adding row to offersBatch")
+	}
+
+	return nil
+}
+
+func (s OfferStore) Flush() error {
+	return s.batch.Exec()
+}

--- a/services/horizon/internal/expingest/processors/orderbook_store.go
+++ b/services/horizon/internal/expingest/processors/orderbook_store.go
@@ -1,0 +1,29 @@
+package processors
+
+import (
+	"github.com/stellar/go/exp/orderbook"
+	"github.com/stellar/go/xdr"
+)
+
+type OrderbookStore struct {
+	orderbookGraph *orderbook.OrderBookGraph
+}
+
+func NewOrderbookStore(orderbookGraph *orderbook.OrderBookGraph) OrderbookStore {
+	return OrderbookStore{orderbookGraph}
+}
+
+func (s OrderbookStore) Add(entryChange xdr.LedgerEntryChange) error {
+	if entryChange.EntryType() != xdr.LedgerEntryTypeOffer {
+		return nil
+	}
+
+	offer := entryChange.MustState().Data.MustOffer()
+	s.orderbookGraph.AddOffer(offer)
+
+	return nil
+}
+
+func (s OrderbookStore) Flush() error {
+	return nil
+}

--- a/services/horizon/internal/expingest/processors/trust_line_store.go
+++ b/services/horizon/internal/expingest/processors/trust_line_store.go
@@ -1,0 +1,55 @@
+package processors
+
+import (
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+type TrustLineStore struct {
+	batch       history.TrustLinesBatchInsertBuilder
+	assetStats  AssetStatSet
+	assetStatsQ history.QAssetStats
+}
+
+func NewTrustLineStore(
+	dataQ history.QTrustLines,
+	assetStatsQ history.QAssetStats,
+) TrustLineStore {
+	return TrustLineStore{
+		batch:       dataQ.NewTrustLinesBatchInsertBuilder(maxBatchSize),
+		assetStats:  AssetStatSet{},
+		assetStatsQ: assetStatsQ,
+	}
+}
+
+func (s TrustLineStore) Add(entryChange xdr.LedgerEntryChange) error {
+	if entryChange.EntryType() != xdr.LedgerEntryTypeTrustline {
+		return nil
+	}
+
+	trustline := entryChange.MustState().Data.MustTrustLine()
+	err := s.assetStats.Add(trustline)
+	if err != nil {
+		return errors.Wrap(err, "Error adding trustline to asset stats set")
+	}
+
+	err = s.batch.Add(
+		trustline,
+		entryChange.MustState().LastModifiedLedgerSeq,
+	)
+	if err != nil {
+		return errors.Wrap(err, "Error adding row to trustLinesBatch")
+	}
+
+	return nil
+}
+
+func (s TrustLineStore) Flush() error {
+	err := s.batch.Exec()
+	if err == nil {
+		err = s.assetStatsQ.InsertAssetStats(s.assetStats.All(), maxBatchSize)
+	}
+
+	return err
+}

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -110,13 +110,13 @@ func (s *System) verifyState() error {
 
 	localLog.Info("Creating state reader...")
 
-	stateReader, err := io.MakeSingleLedgerStateReader(
+	stateReader, err := io.NewStateReaderForLedger(
 		s.session.GetArchive(),
 		&io.MemoryTempSet{},
 		ledgerSequence,
 	)
 	if err != nil {
-		return errors.Wrap(err, "Error running io.MakeSingleLedgerStateReader")
+		return errors.Wrap(err, "Error running io.NewStateReaderForLedger")
 	}
 	defer stateReader.Close()
 

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -111,6 +111,7 @@ func (s *System) verifyState() error {
 	localLog.Info("Creating state reader...")
 
 	stateReader, err := io.NewStateReaderForLedger(
+		s.context,
 		s.session.GetArchive(),
 		&io.MemoryTempSet{},
 		ledgerSequence,

--- a/tools/archive-reader/archive_reader.go
+++ b/tools/archive-reader/archive_reader.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	stdio "io"
@@ -27,7 +28,7 @@ func main() {
 	}
 	haa := adapters.MakeHistoryArchiveAdapter(archive)
 
-	sr, e := haa.GetState(seqNum, &io.MemoryTempSet{})
+	sr, e := haa.GetState(context.Background(), seqNum, &io.MemoryTempSet{})
 	if e != nil {
 		panic(e)
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR is not meant to be merged. I want to use this PR to start a discussion on how ingestion could be simplified.

Please direct your focus to the `exp/tools/dump-ledger-state` package. I have rewritten the dump ledger state job without using the ingestion pipeline framework. I believe this version of the dump ledger state job is easier to understand.

### Why

I think ingestion, at a conceptual level, is pretty simple. Ingestion can be described in two steps:

* iterate through the state of the blockchain
* apply transforms on the blockchain state to produce a desired output

But, I think working with the experimental ingestion system is more complicated than it should be. It requires the programmer to understand several layers of abstraction (see: https://docs.google.com/document/d/1EiedvRAL6bqWm9N_n2UuclyhfDK3wxulLbgLuA2ZKGI/edit ).

If you look at the [old dump ledger state job](https://github.com/stellar/go/blob/master/exp/tools/dump-ledger-state/main.go) you will come across three ingestion abstractions: sessions, pipelines, and processors. When you're writing ingestion code for the first time, understanding each of those concepts and how they all relate can be challenging (particularly, the data flow and how concurrency is handled in the pipeline node tree).

Not to mention the internals of the implementation aren't so easy to understand either (a good example of this would be the interplay between the `exp/ingest/pipeline` and `exp/support/pipeline` packages).

The [new dump ledger state job](https://github.com/stellar/go/blob/3c3f2c6344d67c31ba210e938112bed47a810c24/exp/tools/dump-ledger-state/main.go) produces the same output as the old but, to someone new to ingestion, it is much easier to understand. The only abstraction the programmer needs to understand is the concept of a `io.StateReader`.

The `io.StateReader` provides a mechanism to iterate through the state of the blockchain. By interacting with the `io.StateReader` directly, the programmer can structure the control flow as they wish. The programmer doesn't need to establish a mental model of the pipeline-session-processor framework and can focus most of their effort on the code which transforms entries emitted by the `io.StateReader`.

With regards to performance, the new dump ledger state job seems to be slightly faster than the old one but the difference isn't significant.