### PR TITLE
exp/pipeline: Graceful shutdown of Pipeline

### DIFF
--- a/exp/ingest/live_session.go
+++ b/exp/ingest/live_session.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stellar/go/exp/ingest/adapters"
 	"github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/exp/support/pipeline"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/historyarchive"
-	"github.com/stellar/go/exp/support/pipeline"
 )
 
 var _ Session = &LiveSession{}

--- a/exp/ingest/live_session.go
+++ b/exp/ingest/live_session.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stellar/go/exp/ingest/io"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/historyarchive"
+	"github.com/stellar/go/exp/support/pipeline"
 )
 
 var _ Session = &LiveSession{}
@@ -196,6 +197,12 @@ func (s *LiveSession) resume(ledgerSequence uint32, ledgerAdapter *adapters.Ledg
 		select {
 		case err2 := <-errChan:
 			if err2 != nil {
+				// Return with no errors if pipeline shutdown
+				if err2 == pipeline.ErrShutdown {
+					s.LedgerReporter.OnEndLedger(nil, true)
+					return nil
+				}
+
 				if s.LedgerReporter != nil {
 					s.LedgerReporter.OnEndLedger(err2, false)
 				}
@@ -273,6 +280,12 @@ func (s *LiveSession) initState(historyAdapter *adapters.HistoryArchiveAdapter, 
 	select {
 	case err := <-errChan:
 		if err != nil {
+			// Return with no errors if pipeline shutdown
+			if err == pipeline.ErrShutdown {
+				s.StateReporter.OnEndState(nil, true)
+				return nil
+			}
+
 			if s.StateReporter != nil {
 				s.StateReporter.OnEndState(err, false)
 			}

--- a/exp/ingest/single_ledger_session.go
+++ b/exp/ingest/single_ledger_session.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"github.com/stellar/go/exp/ingest/adapters"
 	"github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/exp/support/pipeline"
 	"github.com/stellar/go/support/errors"
 )
 
@@ -55,6 +56,12 @@ func (s *SingleLedgerSession) processState(historyAdapter *adapters.HistoryArchi
 	select {
 	case err := <-errChan:
 		if err != nil {
+			// Return with no errors if pipeline shutdown
+			if err == pipeline.ErrShutdown {
+				s.StateReporter.OnEndState(nil, true)
+				return nil
+			}
+
 			if s.StateReporter != nil {
 				s.StateReporter.OnEndState(err, false)
 			}

--- a/exp/support/pipeline/main.go
+++ b/exp/support/pipeline/main.go
@@ -3,7 +3,13 @@ package pipeline
 import (
 	"context"
 	"sync"
+
+	"github.com/stellar/go/support/errors"
 )
+
+// ErrShutdown is an error send to post-processing hook when pipeline has been
+// shutdown.
+var ErrShutdown = errors.New("Pipeline shutdown")
 
 // BufferedReadWriter implements Reader and Writer and acts
 // like a pipe. All writes are queued in a buffered channel and are waiting

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -99,8 +99,16 @@ func (a *App) Serve() {
 
 	go a.run()
 
+	// WaitGroup for all go routines. Makes sure that DB is closed when
+	// all services gracefully shutdown.
+	var wg sync.WaitGroup
+
 	if a.expingester != nil {
-		go a.expingester.Run()
+		wg.Add(1)
+		go func() {
+			a.expingester.Run()
+			wg.Done()
+		}()
 	}
 
 	var err error
@@ -114,6 +122,7 @@ func (a *App) Serve() {
 		log.Fatal(err)
 	}
 
+	wg.Wait()
 	a.CloseDB()
 
 	log.Info("stopped")

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -208,6 +208,10 @@ func postProcessingHook(
 	ledgerSeq := pipeline.GetLedgerSequenceFromContext(ctx)
 
 	if err != nil {
+		if err == supportPipeline.ErrShutdown {
+			return nil
+		}
+
 		switch errors.Cause(err).(type) {
 		case verify.StateError:
 			markStateInvalid(historySession, err)

--- a/services/horizon/internal/expingest/reporter.go
+++ b/services/horizon/internal/expingest/reporter.go
@@ -41,12 +41,16 @@ func (lr *LoggingStateReporter) OnEndState(err error, shutdown bool) {
 	elapsedTime := time.Since(lr.startTime)
 
 	l := lr.Log.WithField("ledger", lr.sequence).
-		WithField("numEntries", lr.entryCount).
-		WithField("shutdown", shutdown).
 		WithField("duration", elapsedTime.Seconds())
+
+	if !shutdown {
+		l = l.WithField("numEntries", lr.entryCount)
+	}
 
 	if err != nil {
 		l.WithError(err).Error("Error processing History Archive Snapshot")
+	} else if shutdown {
+		l.Info("Processing History Archive Snapshot shutdown")
 	} else {
 		l.Info("Finished processing History Archive Snapshot")
 	}
@@ -80,12 +84,16 @@ func (lr *LoggingLedgerReporter) OnEndLedger(err error, shutdown bool) {
 	elapsedTime := time.Since(lr.startTime)
 
 	l := lr.Log.WithField("ledger", lr.sequence).
-		WithField("transactions", lr.transactionCount).
-		WithField("shutdown", shutdown).
 		WithField("duration", elapsedTime.Seconds())
+
+	if !shutdown {
+		l = l.WithField("transactions", lr.transactionCount)
+	}
 
 	if err != nil {
 		l.WithError(err).Error("Error processing ledger")
+	} else if shutdown {
+		l.Info("Processing ledger shutdown")
 	} else {
 		l.Info("Finished processing ledger")
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes multiple issues connected to graceful shutdown of pipelines.

### Why

Shutting down pipelines gracefully is important due to multiple reasons, most importantly data integrity.

When `Pipeline.Shutdown()` was called post-processing hooks had no way to indicate whether the pipeline finished processing without errors or was shutdown (in both cases `err` passed to post-processing hook was `nil`). This could lead to a DB connection leak. To fix this, pipeline code now sends `ErrShutdown` if the pipeline was shutdown in `Process` (if shutdown happened during or before processing) and to post-processing hooks. It also always sends post-processing hooks (even when pipeline was shutdown). This should fix #1943.

Next, `App.CloseDB()` is called when `expingest.System.Run()` returns what means that all the DB connections can be properly closed without a possibility of triggering `database closed` errors.

Finally, ledger and state reporters were updated with proper log messages when pipeline was shutdown.