### PR TITLE
services/horizon/internal: Fix index out of range for requests with empty named url params.

### DIFF
--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -608,9 +608,10 @@ func (base *Base) GetTimeMillis(name string) (timeMillis time.Millis) {
 func GetURLParam(r *http.Request, key string) (string, bool) {
 	rctx := chi.RouteContext(r.Context())
 
-	// Return immediately if there are no values for the URLParams.
+	// Return immediately if keys does not match Values
 	// This can happen when a named param is not specified.
-	if len(rctx.URLParams.Values) == 0 {
+	// This is a bug in chi: https://github.com/go-chi/chi/issues/426
+	if len(rctx.URLParams.Keys) != len(rctx.URLParams.Values) {
 		return "", false
 	}
 
@@ -697,7 +698,8 @@ func GetParams(dst interface{}, r *http.Request) error {
 				)
 			}
 
-			query.Set(key, rctx.URLParam(key))
+			param, _ := GetURLParam(r, key)
+			query.Set(key, param)
 		}
 	}
 

--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -607,6 +607,13 @@ func (base *Base) GetTimeMillis(name string) (timeMillis time.Millis) {
 // Ref: https://github.com/go-chi/chi/blob/d132b31857e5922a2cc7963f4fcfd8f46b3f2e97/context.go#L69
 func GetURLParam(r *http.Request, key string) (string, bool) {
 	rctx := chi.RouteContext(r.Context())
+
+	// Return immediately if there are no values for the URLParams.
+	// This can happen when a named param is not specified.
+	if len(rctx.URLParams.Values) == 0 {
+		return "", false
+	}
+
 	for k := len(rctx.URLParams.Keys) - 1; k >= 0; k-- {
 		if rctx.URLParams.Keys[k] == key {
 			return rctx.URLParams.Values[k], true

--- a/services/horizon/internal/actions/helpers_test.go
+++ b/services/horizon/internal/actions/helpers_test.go
@@ -426,7 +426,7 @@ func TestPath(t *testing.T) {
 	tt.Assert.Equal("/foo-bar/blah", action.Path())
 }
 
-func TestGetURLParam(t *testing.T) {
+func TestBaseGetURLParam(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
 	action := makeTestAction()
@@ -444,6 +444,23 @@ func TestGetURLParam(t *testing.T) {
 	val, ok = action.GetURLParam("foobarcursor")
 	tt.Assert.Equal("", val)
 	tt.Assert.Equal(false, ok)
+}
+
+func TestGetURLParam(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	r := makeAction("/accounts/{account_id}/operations?limit=100", nil).R
+
+	// simulates a request where the named param is not passed.
+	// Regression for https://github.com/stellar/go/issues/1965
+	rctx := chi.RouteContext(r.Context())
+	rctx.URLParams.Keys = []string{
+		"account_id",
+	}
+
+	val, ok := GetURLParam(r, "account_id")
+	tt.Assert.Empty(val)
+	tt.Assert.False(ok)
 }
 
 func TestGetAssets(t *testing.T) {

--- a/services/horizon/internal/actions/offer.go
+++ b/services/horizon/internal/actions/offer.go
@@ -110,6 +110,11 @@ func (handler GetOffersHandler) GetResourcePage(
 	return offers, nil
 }
 
+// AccountOffersQuery query struct for offers end-point
+type AccountOffersQuery struct {
+	AccountID string `schema:"account_id" valid:"accountID,required"`
+}
+
 // GetAccountOffersHandler is the action handler for the
 // `/accounts/{account_id}/offers` endpoint when using experimental ingestion.
 type GetAccountOffersHandler struct {
@@ -121,14 +126,15 @@ func (handler GetAccountOffersHandler) parseOffersQuery(r *http.Request) (histor
 		return history.OffersQuery{}, err
 	}
 
-	seller, err := GetAccountID(r, "account_id")
+	qp := AccountOffersQuery{}
+	err = GetParams(&qp, r)
 	if err != nil {
 		return history.OffersQuery{}, err
 	}
 
 	query := history.OffersQuery{
 		PageQuery: pq,
-		SellerID:  seller.Address(),
+		SellerID:  qp.AccountID,
 	}
 
 	return query, nil

--- a/services/horizon/internal/actions/offer.go
+++ b/services/horizon/internal/actions/offer.go
@@ -121,14 +121,14 @@ func (handler GetAccountOffersHandler) parseOffersQuery(r *http.Request) (histor
 		return history.OffersQuery{}, err
 	}
 
-	seller, err := GetString(r, "account_id")
+	seller, err := GetAccountID(r, "account_id")
 	if err != nil {
 		return history.OffersQuery{}, err
 	}
 
 	query := history.OffersQuery{
 		PageQuery: pq,
-		SellerID:  seller,
+		SellerID:  seller.Address(),
 	}
 
 	return query, nil

--- a/services/horizon/internal/actions/offer_test.go
+++ b/services/horizon/internal/actions/offer_test.go
@@ -393,6 +393,17 @@ func TestGetAccountOffersHandler(t *testing.T) {
 	for _, offer := range offers {
 		tt.Assert.Equal(issuer.Address(), offer.Seller)
 	}
+
+	records, err = handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t,
+			map[string]string{},
+			map[string]string{},
+			q.Session,
+		),
+	)
+	tt.Assert.Error(err)
 }
 
 func pageableToOffers(t *testing.T, page []hal.Pageable) []horizon.Offer {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fix index out of range for requests with empty named url params #1965 


### Why

Making a request without passing the named URL params can cause the following error

```
runtime.boundsError runtime error: index out of range [0] with length 0
```

This happens because of the way chi processes named params, if you don't pass the require segment, they match against the right URL, but don't push anything in the URL values. This seems like a bug in chi and someone already reported it https://github.com/go-chi/chi/issues/426

This PR fixes our param reader to return early if the number of `Keys` doesn't match the number of `Values` in the URLParams and adds regression tests for it. 

While fixing this I also added some extra hardening to the account offers action to have proper validation for `account_id` and use better error messages.

### Known limitations

[TODO or N/A]
