### PR TITLE
all: Use context from session in sqlx functions

### DIFF
--- a/services/horizon/internal/ingest/asset_stat_test.go
+++ b/services/horizon/internal/ingest/asset_stat_test.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"testing"
@@ -117,7 +118,7 @@ func TestStatTrustlinesInfo(t *testing.T) {
 			tt := test.Start(t).ScenarioWithoutHorizon(kase.scenario)
 			defer tt.Finish()
 
-			session := &db.Session{DB: tt.CoreDB}
+			session := &db.Session{DB: tt.CoreDB, Ctx: context.Background()}
 
 			for i, asset := range kase.assetState {
 				numAccounts, amount, err := statTrustlinesInfo(session, asset.assetType, asset.assetCode, asset.assetIssuer)
@@ -160,7 +161,7 @@ func TestStatAccountInfo(t *testing.T) {
 			tt := test.Start(t).ScenarioWithoutHorizon("asset_stat_account")
 			defer tt.Finish()
 
-			session := &db.Session{DB: tt.CoreDB}
+			session := &db.Session{DB: tt.CoreDB, Ctx: context.Background()}
 
 			flags, toml, err := statAccountInfo(session, kase.account)
 			tt.Require.NoError(err)
@@ -364,7 +365,7 @@ func TestAssetModified(t *testing.T) {
 			if kase.needsCoreQ {
 				tt := test.Start(t).ScenarioWithoutHorizon("asset_stat_operations")
 				defer tt.Finish()
-				session = &db.Session{DB: tt.CoreDB}
+				session = &db.Session{DB: tt.CoreDB, Ctx: context.Background()}
 			}
 
 			assetsStats := AssetStats{CoreSession: session}

--- a/services/horizon/internal/ingest/ingestion_test.go
+++ b/services/horizon/internal/ingest/ingestion_test.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 	"time"
@@ -20,7 +21,8 @@ func TestEmptySignature(t *testing.T) {
 	dbConn := testDB.Horizon(t)
 	ingestion := Ingestion{
 		DB: &db.Session{
-			DB: dbConn,
+			DB:  dbConn,
+			Ctx: context.Background(),
 		},
 	}
 	test.ResetHorizonDB(t, dbConn)
@@ -61,7 +63,8 @@ func TestFeeMax(t *testing.T) {
 
 	ingestion := Ingestion{
 		DB: &db.Session{
-			DB: testDB.Horizon(t),
+			DB:  testDB.Horizon(t),
+			Ctx: context.Background(),
 		},
 	}
 	ingestion.Start()
@@ -119,7 +122,8 @@ func TestTimeBoundsMaxBig(t *testing.T) {
 	dbConn := testDB.Horizon(t)
 	ingestion := Ingestion{
 		DB: &db.Session{
-			DB: dbConn,
+			DB:  dbConn,
+			Ctx: context.Background(),
 		},
 	}
 	test.ResetHorizonDB(t, dbConn)

--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -281,10 +281,10 @@ func (m *ExperimentalIngestionMiddleware) Wrap(h http.Handler) http.Handler {
 
 		localLog := log.Ctx(ctx)
 		session := m.HorizonSession.Clone()
-		session.Ctx = r.Context()
 		q := &history.Q{session}
 
 		if render.Negotiate(r) != render.MimeEventStream {
+			session.Ctx = r.Context()
 			err := session.BeginTx(&sql.TxOptions{
 				Isolation: sql.LevelRepeatableRead,
 				ReadOnly:  true,

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -61,6 +61,7 @@ func init() {
 	problem.RegisterError(db2.ErrInvalidLimit, problem.BadRequest)
 	problem.RegisterError(db2.ErrInvalidOrder, problem.BadRequest)
 	problem.RegisterError(sse.ErrRateLimited, hProblem.RateLimitExceeded)
+	problem.RegisterError(context.DeadlineExceeded, hProblem.Timeout)
 }
 
 // mustInitWeb installed a new Web instance onto the provided app object.

--- a/services/ticker/internal/tickerdb/main.go
+++ b/services/ticker/internal/tickerdb/main.go
@@ -1,6 +1,7 @@
 package tickerdb
 
 import (
+	"context"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -168,6 +169,7 @@ func CreateSession(driverName, dataSourceName string) (session TickerSession, er
 	}
 
 	session.DB = dbconn
+	session.Ctx = context.Background()
 	return
 }
 

--- a/services/ticker/internal/tickerdb/queries_asset_test.go
+++ b/services/ticker/internal/tickerdb/queries_asset_test.go
@@ -1,6 +1,7 @@
 package tickerdb
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 
 	var session TickerSession
 	session.DB = db.Open()
+	session.Ctx = context.Background()
 	defer session.DB.Close()
 
 	// Run migrations to make sure the tests are run
@@ -157,6 +159,7 @@ func TestGetAssetByCodeAndIssuerAccount(t *testing.T) {
 
 	var session TickerSession
 	session.DB = db.Open()
+	session.Ctx = context.Background()
 	defer session.DB.Close()
 
 	// Run migrations to make sure the tests are run

--- a/services/ticker/internal/tickerdb/queries_issuer_test.go
+++ b/services/ticker/internal/tickerdb/queries_issuer_test.go
@@ -1,6 +1,7 @@
 package tickerdb
 
 import (
+	"context"
 	"testing"
 
 	_ "github.com/lib/pq"
@@ -16,6 +17,7 @@ func TestInsertOrUpdateIssuer(t *testing.T) {
 
 	var session TickerSession
 	session.DB = db.Open()
+	session.Ctx = context.Background()
 	defer session.DB.Close()
 
 	// Run migrations to make sure the tests are run

--- a/services/ticker/internal/tickerdb/queries_market_test.go
+++ b/services/ticker/internal/tickerdb/queries_market_test.go
@@ -1,6 +1,7 @@
 package tickerdb
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"testing"
@@ -18,6 +19,7 @@ func TestRetrieveMarketData(t *testing.T) {
 
 	var session TickerSession
 	session.DB = db.Open()
+	session.Ctx = context.Background()
 	defer session.DB.Close()
 
 	// Run migrations to make sure the tests are run
@@ -306,6 +308,7 @@ func TestRetrievePartialMarkets(t *testing.T) {
 
 	var session TickerSession
 	session.DB = db.Open()
+	session.Ctx = context.Background()
 	defer session.DB.Close()
 
 	// Run migrations to make sure the tests are run
@@ -620,6 +623,7 @@ func Test24hStatsFallback(t *testing.T) {
 
 	var session TickerSession
 	session.DB = db.Open()
+	session.Ctx = context.Background()
 	defer session.DB.Close()
 
 	// Run migrations to make sure the tests are run
@@ -725,6 +729,7 @@ func TestPreferAnchorAssetCode(t *testing.T) {
 
 	var session TickerSession
 	session.DB = db.Open()
+	session.Ctx = context.Background()
 	defer session.DB.Close()
 
 	// Run migrations to make sure the tests are run

--- a/services/ticker/internal/tickerdb/queries_orderbook_test.go
+++ b/services/ticker/internal/tickerdb/queries_orderbook_test.go
@@ -1,6 +1,7 @@
 package tickerdb
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ func TestInsertOrUpdateOrderbokStats(t *testing.T) {
 
 	var session TickerSession
 	session.DB = db.Open()
+	session.Ctx = context.Background()
 	defer session.DB.Close()
 
 	// Run migrations to make sure the tests are run

--- a/services/ticker/internal/tickerdb/queries_trade_test.go
+++ b/services/ticker/internal/tickerdb/queries_trade_test.go
@@ -1,6 +1,7 @@
 package tickerdb
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ func TestBulkInsertTrades(t *testing.T) {
 
 	var session TickerSession
 	session.DB = db.Open()
+	session.Ctx = context.Background()
 	defer session.DB.Close()
 
 	// Run migrations to make sure the tests are run
@@ -123,6 +125,7 @@ func TestGetLastTrade(t *testing.T) {
 
 	var session TickerSession
 	session.DB = db.Open()
+	session.Ctx = context.Background()
 	defer session.DB.Close()
 
 	// Run migrations to make sure the tests are run
@@ -226,6 +229,7 @@ func TestDeleteOldTrades(t *testing.T) {
 
 	var session TickerSession
 	session.DB = db.Open()
+	session.Ctx = context.Background()
 	defer session.DB.Close()
 
 	// Run migrations to make sure the tests are run

--- a/support/db/batch_insert_builder_test.go
+++ b/support/db/batch_insert_builder_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stellar/go/support/db/dbtest"
@@ -11,7 +12,7 @@ import (
 func TestBatchInsertBuilder(t *testing.T) {
 	db := dbtest.Postgres(t).Load(testSchema)
 	defer db.Close()
-	sess := &Session{DB: db.Open()}
+	sess := &Session{DB: db.Open(), Ctx: context.Background()}
 	defer sess.DB.Close()
 
 	insertBuilder := &BatchInsertBuilder{

--- a/support/db/delete_builder_test.go
+++ b/support/db/delete_builder_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stellar/go/support/db/dbtest"
@@ -11,7 +12,7 @@ import (
 func TestDeleteBuilder_Exec(t *testing.T) {
 	db := dbtest.Postgres(t).Load(testSchema)
 	defer db.Close()
-	sess := &Session{DB: db.Open()}
+	sess := &Session{DB: db.Open(), Ctx: context.Background()}
 	defer sess.DB.Close()
 
 	tbl := sess.GetTable("people")

--- a/support/db/get_builder_test.go
+++ b/support/db/get_builder_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stellar/go/support/db/dbtest"
@@ -10,7 +11,7 @@ import (
 func TestGetBuilder_Exec(t *testing.T) {
 	db := dbtest.Postgres(t).Load(testSchema)
 	defer db.Close()
-	sess := &Session{DB: db.Open()}
+	sess := &Session{DB: db.Open(), Ctx: context.Background()}
 	defer sess.DB.Close()
 
 	var found person

--- a/support/db/insert_builder_test.go
+++ b/support/db/insert_builder_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stellar/go/support/db/dbtest"
@@ -11,7 +12,7 @@ import (
 func TestInsertBuilder_Exec(t *testing.T) {
 	db := dbtest.Postgres(t).Load(testSchema)
 	defer db.Close()
-	sess := &Session{DB: db.Open()}
+	sess := &Session{DB: db.Open(), Ctx: context.Background()}
 	defer sess.DB.Close()
 
 	tbl := sess.GetTable("people")

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -108,7 +108,7 @@ type Session struct {
 	// DB is the database connection that queries should be executed against.
 	DB *sqlx.DB
 
-	// Ctx is the optional context in which the repo is operating under.
+	// Ctx is the context in which the repo is operating under.
 	Ctx context.Context
 
 	tx *sqlx.Tx

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -28,11 +28,11 @@ var postgresQueryMaxParams = 65535
 
 // Conn represents a connection to a single database.
 type Conn interface {
-	Exec(query string, args ...interface{}) (sql.Result, error)
-	Get(dest interface{}, query string, args ...interface{}) error
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error
 	Rebind(sql string) string
-	Queryx(query string, args ...interface{}) (*sqlx.Rows, error)
-	Select(dest interface{}, query string, args ...interface{}) error
+	QueryxContext(ctx context.Context, query string, args ...interface{}) (*sqlx.Rows, error)
+	SelectContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error
 }
 
 // DeleteBuilder is a helper struct used to construct sql queries of the DELETE
@@ -146,7 +146,7 @@ func Open(dialect, dsn string) (*Session, error) {
 		return nil, errors.Wrap(err, "connect failed")
 	}
 
-	return &Session{DB: db}, nil
+	return &Session{DB: db, Ctx: context.Background()}, nil
 }
 
 // Wrap wraps a bare *sql.DB (from the database/sql stdlib package) in a
@@ -154,7 +154,7 @@ func Open(dialect, dsn string) (*Session, error) {
 // control the instantiation of the database connection, but would still like to
 // leverage the facilities provided in Session.
 func Wrap(base *sql.DB, dialect string) *Session {
-	return &Session{DB: sqlx.NewDb(base, dialect)}
+	return &Session{DB: sqlx.NewDb(base, dialect), Ctx: context.Background()}
 }
 
 // ensure various types conform to Conn interface

--- a/support/db/main_test.go
+++ b/support/db/main_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stellar/go/support/db/dbtest"
@@ -17,7 +18,7 @@ type person struct {
 func TestGetTable(t *testing.T) {
 	db := dbtest.Postgres(t).Load(testSchema)
 	defer db.Close()
-	sess := &Session{DB: db.Open()}
+	sess := &Session{DB: db.Open(), Ctx: context.Background()}
 	defer sess.DB.Close()
 
 	tbl := sess.GetTable("users")

--- a/support/db/select_builder_test.go
+++ b/support/db/select_builder_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stellar/go/support/db/dbtest"
@@ -11,7 +12,7 @@ import (
 func TestSelectBuilder_Exec(t *testing.T) {
 	db := dbtest.Postgres(t).Load(testSchema)
 	defer db.Close()
-	sess := &Session{DB: db.Open()}
+	sess := &Session{DB: db.Open(), Ctx: context.Background()}
 	defer sess.DB.Close()
 
 	var results []person

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -121,7 +121,7 @@ func (s *Session) GetRaw(dest interface{}, query string, args ...interface{}) er
 	}
 
 	start := time.Now()
-	err = s.conn().Get(dest, query, args...)
+	err = s.conn().GetContext(s.Ctx, dest, query, args...)
 	s.log("get", start, query, args)
 
 	if err == nil {
@@ -186,7 +186,7 @@ func (s *Session) ExecRaw(query string, args ...interface{}) (sql.Result, error)
 	}
 
 	start := time.Now()
-	result, err := s.conn().Exec(query, args...)
+	result, err := s.conn().ExecContext(s.Ctx, query, args...)
 	s.log("exec", start, query, args)
 
 	if err == nil {
@@ -223,7 +223,7 @@ func (s *Session) QueryRaw(query string, args ...interface{}) (*sqlx.Rows, error
 	}
 
 	start := time.Now()
-	result, err := s.conn().Queryx(query, args...)
+	result, err := s.conn().QueryxContext(s.Ctx, query, args...)
 	s.log("query", start, query, args)
 
 	if err == nil {
@@ -283,7 +283,7 @@ func (s *Session) SelectRaw(
 	}
 
 	start := time.Now()
-	err = s.conn().Select(dest, query, args...)
+	err = s.conn().SelectContext(s.Ctx, dest, query, args...)
 	s.log("select", start, query, args)
 
 	if err == nil {

--- a/support/db/session_test.go
+++ b/support/db/session_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stellar/go/support/db/dbtest"
@@ -14,7 +15,7 @@ func TestSession(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	sess := &Session{DB: db.Open()}
+	sess := &Session{DB: db.Open(), Ctx: context.Background()}
 	defer sess.DB.Close()
 
 	assert.Equal("postgres", sess.Dialect())


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Close https://github.com/stellar/go/issues/1950 , https://github.com/stellar/go/issues/1974

Use the context in `db.Session` when executing sql queries and statements on the session connection. A consequence of this change is that the session context is no longer optional.

### Why

It should be possible to pass context.Context to set timeout for queries sent to a database. This is to prevent long running queries to occupy DB connection for a long period of time.

### Known limitations

[TODO or N/A]
