### PR TITLE
 services/horizon/internal/expingest: Graceful shutdown StateVerifier

### DIFF
--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -98,6 +98,8 @@ type System struct {
 	stateReady       bool
 	stateReadyLock   sync.RWMutex
 	maxStreamRetries int
+	wg               sync.WaitGroup
+	shutdown         chan bool
 
 	// stateVerificationRunning is true when verification routine is currently
 	// running.
@@ -211,10 +213,12 @@ func NewSystem(config Config) (*System, error) {
 //   * If instances is a NOT leader, it runs ledger pipeline without updating a
 //     a database so order book graph is updated but database is not overwritten.
 func (s *System) Run() {
+	s.shutdown = make(chan bool)
 	// Expingest is an experimental package so we don't want entire Horizon app
 	// to crash in case of unexpected errors.
 	// TODO: This should be removed when expingest is no longer experimental.
 	defer func() {
+		s.wg.Wait()
 		if r := recover(); r != nil {
 			log.WithFields(logpkg.F{
 				"err":   r,
@@ -398,6 +402,12 @@ func (s *System) resetStateVerificationErrors() {
 func (s *System) Shutdown() {
 	log.Info("Shutting down ingestion system...")
 	s.session.Shutdown()
+	s.stateVerificationMutex.Lock()
+	defer s.stateVerificationMutex.Unlock()
+	if s.stateVerificationRunning {
+		log.Info("Shutting down state verifier...")
+	}
+	close(s.shutdown)
 }
 
 func createArchive(archiveURL string) (*historyarchive.Archive, error) {

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -99,7 +99,7 @@ type System struct {
 	stateReadyLock   sync.RWMutex
 	maxStreamRetries int
 	wg               sync.WaitGroup
-	shutdown         chan bool
+	shutdown         chan struct{}
 
 	// stateVerificationRunning is true when verification routine is currently
 	// running.
@@ -213,7 +213,7 @@ func NewSystem(config Config) (*System, error) {
 //   * If instances is a NOT leader, it runs ledger pipeline without updating a
 //     a database so order book graph is updated but database is not overwritten.
 func (s *System) Run() {
-	s.shutdown = make(chan bool)
+	s.shutdown = make(chan struct{})
 	// Expingest is an experimental package so we don't want entire Horizon app
 	// to crash in case of unexpected errors.
 	// TODO: This should be removed when expingest is no longer experimental.

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -278,6 +278,7 @@ func postProcessingHook(
 		historyarchive.IsCheckpoint(ledgerSeq) { // it's a checkpoint ledger.
 		system.wg.Add(1)
 		go func(offerEntries []xdr.OfferEntry) {
+			defer system.wg.Done()
 			graphOffers := map[xdr.Int64]xdr.OfferEntry{}
 			for _, entry := range offerEntries {
 				graphOffers[entry.OfferId] = entry
@@ -299,7 +300,6 @@ func postProcessingHook(
 			} else {
 				system.resetStateVerificationErrors()
 			}
-			system.wg.Done()
 		}(graph.Offers())
 	}
 

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -276,6 +276,7 @@ func postProcessingHook(
 		pipelineType == ledgerPipeline && // it's a ledger pipeline...
 		isMaster && // it's a master ingestion node (to verify on a single node only)...
 		historyarchive.IsCheckpoint(ledgerSeq) { // it's a checkpoint ledger.
+		system.wg.Add(1)
 		go func(offerEntries []xdr.OfferEntry) {
 			graphOffers := map[xdr.Int64]xdr.OfferEntry{}
 			for _, entry := range offerEntries {
@@ -298,6 +299,7 @@ func postProcessingHook(
 			} else {
 				system.resetStateVerificationErrors()
 			}
+			system.wg.Done()
 		}(graph.Offers())
 	}
 

--- a/services/horizon/internal/expingest/run_ingestion_test.go
+++ b/services/horizon/internal/expingest/run_ingestion_test.go
@@ -3,6 +3,7 @@ package expingest
 import (
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/stellar/go/exp/orderbook"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -443,4 +444,63 @@ func (s *ResumeIngestionTestSuite) TestLedgerUpdatesOnlyIfProcessed() {
 
 func TestResumeIngestionTestSuite(t *testing.T) {
 	suite.Run(t, new(ResumeIngestionTestSuite))
+}
+
+type SystemShutdownTestSuite struct {
+	suite.Suite
+	graph            *orderbook.OrderBookGraph
+	session          *mockDBSession
+	historyQ         *mockDBQ
+	ingestSession    *mockIngestSession
+	system           *System
+	attempts         int
+	expectedAttempts int
+}
+
+func (s *SystemShutdownTestSuite) SetupTest() {
+	s.graph = orderbook.NewOrderBookGraph()
+	s.session = &mockDBSession{}
+	s.historyQ = &mockDBQ{}
+	s.ingestSession = &mockIngestSession{}
+	s.attempts = 0
+	s.expectedAttempts = 0
+	s.system = &System{
+		session:        s.ingestSession,
+		historySession: s.session,
+		historyQ:       s.historyQ,
+		graph:          s.graph,
+		shutdown:       make(chan bool),
+	}
+}
+
+func (s *SystemShutdownTestSuite) TearDownTest() {
+	t := s.T()
+	s.session.AssertExpectations(t)
+	s.ingestSession.AssertExpectations(t)
+	s.historyQ.AssertExpectations(t)
+	if s.attempts != s.expectedAttempts {
+		t.Fatalf("expected only %v attempts but got %v", s.expectedAttempts, s.attempts)
+	}
+}
+
+func (s *SystemShutdownTestSuite) TestShutdownSucceeds() {
+	s.ingestSession.On("Shutdown").Return(nil).Once()
+	done := make(chan bool)
+	go func() {
+		<-s.system.shutdown
+		select {
+		case <-s.system.shutdown:
+			s.Assert().True(true, "channel is closed")
+		default:
+			s.Assert().Fail("channel should be closed")
+		}
+		done <- true
+	}()
+	time.Sleep(100 * time.Millisecond)
+	s.system.Shutdown()
+	<-done
+}
+
+func TestSystemShutdownTestSuite(t *testing.T) {
+	suite.Run(t, new(SystemShutdownTestSuite))
 }

--- a/services/horizon/internal/expingest/run_ingestion_test.go
+++ b/services/horizon/internal/expingest/run_ingestion_test.go
@@ -469,7 +469,7 @@ func (s *SystemShutdownTestSuite) SetupTest() {
 		historySession: s.session,
 		historyQ:       s.historyQ,
 		graph:          s.graph,
-		shutdown:       make(chan bool),
+		shutdown:       make(chan struct{}),
 	}
 }
 
@@ -485,7 +485,7 @@ func (s *SystemShutdownTestSuite) TearDownTest() {
 
 func (s *SystemShutdownTestSuite) TestShutdownSucceeds() {
 	s.ingestSession.On("Shutdown").Return(nil).Once()
-	done := make(chan bool)
+	done := make(chan struct{})
 	go func() {
 		<-s.system.shutdown
 		select {
@@ -494,7 +494,7 @@ func (s *SystemShutdownTestSuite) TestShutdownSucceeds() {
 		default:
 			s.Assert().Fail("channel should be closed")
 		}
-		done <- true
+		close(done)
 	}()
 	time.Sleep(100 * time.Millisecond)
 	s.system.Shutdown()

--- a/services/horizon/internal/expingest/run_ingestion_test.go
+++ b/services/horizon/internal/expingest/run_ingestion_test.go
@@ -480,14 +480,13 @@ func (s *SystemShutdownTestSuite) TestShutdownSucceeds() {
 	s.ingestSession.On("Shutdown").Return(nil).Once()
 	done := make(chan struct{})
 	go func() {
-		<-s.system.shutdown
+		defer close(done)
 		select {
 		case <-s.system.shutdown:
-			s.Assert().True(true, "channel is closed")
-		default:
-			s.Assert().Fail("channel should be closed")
+			s.Assert().True(true, "channel was closed")
+		case <-time.After(2 * time.Second):
+			s.Assert().Fail("channel should have been closed")
 		}
-		close(done)
 	}()
 	time.Sleep(100 * time.Millisecond)
 	s.system.Shutdown()

--- a/services/horizon/internal/expingest/run_ingestion_test.go
+++ b/services/horizon/internal/expingest/run_ingestion_test.go
@@ -448,13 +448,11 @@ func TestResumeIngestionTestSuite(t *testing.T) {
 
 type SystemShutdownTestSuite struct {
 	suite.Suite
-	graph            *orderbook.OrderBookGraph
-	session          *mockDBSession
-	historyQ         *mockDBQ
-	ingestSession    *mockIngestSession
-	system           *System
-	attempts         int
-	expectedAttempts int
+	graph         *orderbook.OrderBookGraph
+	session       *mockDBSession
+	historyQ      *mockDBQ
+	ingestSession *mockIngestSession
+	system        *System
 }
 
 func (s *SystemShutdownTestSuite) SetupTest() {
@@ -462,8 +460,6 @@ func (s *SystemShutdownTestSuite) SetupTest() {
 	s.session = &mockDBSession{}
 	s.historyQ = &mockDBQ{}
 	s.ingestSession = &mockIngestSession{}
-	s.attempts = 0
-	s.expectedAttempts = 0
 	s.system = &System{
 		session:        s.ingestSession,
 		historySession: s.session,
@@ -478,9 +474,6 @@ func (s *SystemShutdownTestSuite) TearDownTest() {
 	s.session.AssertExpectations(t)
 	s.ingestSession.AssertExpectations(t)
 	s.historyQ.AssertExpectations(t)
-	if s.attempts != s.expectedAttempts {
-		t.Fatalf("expected only %v attempts but got %v", s.expectedAttempts, s.attempts)
-	}
 }
 
 func (s *SystemShutdownTestSuite) TestShutdownSucceeds() {

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -140,6 +140,14 @@ func (s *System) verifyState(graphOffers map[xdr.Int64]xdr.OfferEntry) error {
 			return errors.Wrap(err, "verifier.GetLedgerKeys")
 		}
 
+		select {
+		case <-s.shutdown:
+			localLog.Info("State verifier shut down...")
+			return nil
+		default:
+			// continue
+		}
+
 		if len(keys) == 0 {
 			break
 		}

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -39,7 +39,6 @@ func (s *System) verifyState(graphOffers map[xdr.Int64]xdr.OfferEntry) error {
 		s.stateVerificationMutex.Unlock()
 		return nil
 	}
-	s.wg.Add(1)
 	s.stateVerificationRunning = true
 	s.stateVerificationMutex.Unlock()
 	if stateVerifierExpectedIngestionVersion != CurrentVersion {
@@ -54,10 +53,10 @@ func (s *System) verifyState(graphOffers map[xdr.Int64]xdr.OfferEntry) error {
 	startTime := time.Now()
 	session := s.historySession.Clone()
 
+	s.wg.Add(1)
 	defer func() {
 		log.WithField("duration", time.Since(startTime).Seconds()).Info("State verification finished")
 		session.Rollback()
-
 		s.stateVerificationMutex.Lock()
 		s.stateVerificationRunning = false
 		s.wg.Done()

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -53,13 +53,11 @@ func (s *System) verifyState(graphOffers map[xdr.Int64]xdr.OfferEntry) error {
 	startTime := time.Now()
 	session := s.historySession.Clone()
 
-	s.wg.Add(1)
 	defer func() {
 		log.WithField("duration", time.Since(startTime).Seconds()).Info("State verification finished")
 		session.Rollback()
 		s.stateVerificationMutex.Lock()
 		s.stateVerificationRunning = false
-		s.wg.Done()
 		s.stateVerificationMutex.Unlock()
 	}()
 

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -39,9 +39,9 @@ func (s *System) verifyState(graphOffers map[xdr.Int64]xdr.OfferEntry) error {
 		s.stateVerificationMutex.Unlock()
 		return nil
 	}
+	s.wg.Add(1)
 	s.stateVerificationRunning = true
 	s.stateVerificationMutex.Unlock()
-
 	if stateVerifierExpectedIngestionVersion != CurrentVersion {
 		log.Errorf(
 			"State verification expected version is %d but actual is: %d",
@@ -60,6 +60,7 @@ func (s *System) verifyState(graphOffers map[xdr.Int64]xdr.OfferEntry) error {
 
 		s.stateVerificationMutex.Lock()
 		s.stateVerificationRunning = false
+		s.wg.Done()
 		s.stateVerificationMutex.Unlock()
 	}()
 
@@ -88,7 +89,6 @@ func (s *System) verifyState(graphOffers map[xdr.Int64]xdr.OfferEntry) error {
 		localLog.Info("Current ledger is not a checkpoint ledger. Cancelling...")
 		return nil
 	}
-
 	// Get root HAS to check if we're checking one of the latest ledgers or
 	// Horizon is catching up. It doesn't make sense to verify old ledgers as
 	// we want to check the latest state.
@@ -105,9 +105,13 @@ func (s *System) verifyState(graphOffers map[xdr.Int64]xdr.OfferEntry) error {
 	}
 
 	localLog.Info("Starting state verification. Waiting 40 seconds for stellar-core to publish HAS...")
-
-	// Wait for stellar-core to publish HAS
-	time.Sleep(40 * time.Second)
+	select {
+	case <-s.shutdown:
+		localLog.Info("State verifier shut down...")
+		return nil
+	case <-time.After(40 * time.Second):
+		// Wait for stellar-core to publish HAS
+	}
 
 	localLog.Info("Creating state reader...")
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What


Graceful shutdown state verifier if it is running when the app gets shut down. Fix #1976 

### Why

If the app gets shutdown and the state verifier is running, it should wait for the verifier to gracefully shutdown instead of just killing the goroutine.

### Known limitations

