### PR TITLE
exp/ingest/io: Ignore PROTOCOL_ERROR when retrying xdr streams

### DIFF
--- a/exp/ingest/io/single_ledger_state_reader.go
+++ b/exp/ingest/io/single_ledger_state_reader.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"strings"
 	"sync"
 
 	"github.com/stellar/go/support/errors"
@@ -167,10 +166,6 @@ func (msr *SingleLedgerStateReader) streamBuckets() {
 	}
 }
 
-func ignoreCloseError(err error) bool {
-	return strings.Contains(err.Error(), "PROTOCOL_ERROR")
-}
-
 // readBucketEntry will attempt to read a bucket entry from `stream`.
 // If any errors are encountered while reading from `stream`, readBucketEntry will
 // retry the operation using a new *historyarchive.XdrStream.
@@ -192,13 +187,7 @@ func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrSt
 			break
 		}
 
-		err = stream.CloseWithoutValidation()
-		if err != nil && !ignoreCloseError(err) {
-			err = errors.Wrap(err, "Error closing stream")
-			break
-		} else {
-			err = nil
-		}
+		stream.Close()
 
 		var retryStream *historyarchive.XdrStream
 		retryStream, err = msr.newXDRStream(hash)

--- a/exp/ingest/io/single_ledger_state_reader_test.go
+++ b/exp/ingest/io/single_ledger_state_reader_test.go
@@ -355,20 +355,6 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryAllRetriesFail() {
 	s.Require().EqualError(err, "Read wrong number of bytes from XDR")
 }
 
-func (s *ReadBucketEntryTestSuite) TestReadEntryRetryFailsWithCloseError() {
-	emptyHash := historyarchive.EmptyXdrArrayHash()
-
-	s.mockArchive.
-		On("GetXdrStreamForHash", emptyHash).
-		Return(createInvalidXdrStream(errors.New("cannot close")), nil).Once()
-
-	stream, err := s.reader.newXDRStream(emptyHash)
-	s.Require().NoError(err)
-
-	_, err = s.reader.readBucketEntry(stream, emptyHash)
-	s.Require().EqualError(err, "Error closing stream: cannot close")
-}
-
 func (s *ReadBucketEntryTestSuite) TestReadEntryRetryIgnoresProtocolCloseError() {
 	emptyHash := historyarchive.EmptyXdrArrayHash()
 

--- a/exp/ingest/io/single_ledger_state_reader_test.go
+++ b/exp/ingest/io/single_ledger_state_reader_test.go
@@ -338,15 +338,15 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryAllRetriesFail() {
 
 	s.mockArchive.
 		On("GetXdrStreamForHash", emptyHash).
-		Return(createInvalidXdrStream(), nil).Once()
+		Return(createInvalidXdrStream(nil), nil).Once()
 
 	s.mockArchive.
 		On("GetXdrStreamForHash", emptyHash).
-		Return(createInvalidXdrStream(), nil).Once()
+		Return(createInvalidXdrStream(nil), nil).Once()
 
 	s.mockArchive.
 		On("GetXdrStreamForHash", emptyHash).
-		Return(createInvalidXdrStream(), nil).Once()
+		Return(createInvalidXdrStream(nil), nil).Once()
 
 	stream, err := s.reader.newXDRStream(emptyHash)
 	s.Require().NoError(err)
@@ -355,12 +355,56 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryAllRetriesFail() {
 	s.Require().EqualError(err, "Read wrong number of bytes from XDR")
 }
 
+func (s *ReadBucketEntryTestSuite) TestReadEntryRetryFailsWithCloseError() {
+	emptyHash := historyarchive.EmptyXdrArrayHash()
+
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(createInvalidXdrStream(errors.New("cannot close")), nil).Once()
+
+	stream, err := s.reader.newXDRStream(emptyHash)
+	s.Require().NoError(err)
+
+	_, err = s.reader.readBucketEntry(stream, emptyHash)
+	s.Require().EqualError(err, "Error closing stream: cannot close")
+}
+
+func (s *ReadBucketEntryTestSuite) TestReadEntryRetryIgnoresProtocolCloseError() {
+	emptyHash := historyarchive.EmptyXdrArrayHash()
+
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(
+			createInvalidXdrStream(errors.New("stream error: stream ID 75; PROTOCOL_ERROR")),
+			nil,
+		).Once()
+
+	expectedEntry := metaEntry(1)
+	s.mockArchive.
+		On("GetXdrStreamForHash", emptyHash).
+		Return(createXdrStream(expectedEntry), nil).Once()
+
+	stream, err := s.reader.newXDRStream(emptyHash)
+	s.Require().NoError(err)
+
+	entry, err := s.reader.readBucketEntry(stream, emptyHash)
+	s.Require().NoError(err)
+	s.Require().Equal(entry, expectedEntry)
+
+	hash, ok := stream.ExpectedHash()
+	s.Require().Equal(historyarchive.Hash(hash), emptyHash)
+	s.Require().True(ok)
+
+	_, err = s.reader.readBucketEntry(stream, emptyHash)
+	s.Require().Equal(err, io.EOF)
+}
+
 func (s *ReadBucketEntryTestSuite) TestReadEntryRetryFailsToCreateNewStream() {
 	emptyHash := historyarchive.EmptyXdrArrayHash()
 
 	s.mockArchive.
 		On("GetXdrStreamForHash", emptyHash).
-		Return(createInvalidXdrStream(), nil).Once()
+		Return(createInvalidXdrStream(nil), nil).Once()
 
 	var nilStream *historyarchive.XdrStream
 	s.mockArchive.
@@ -379,11 +423,11 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryRetrySucceeds() {
 
 	s.mockArchive.
 		On("GetXdrStreamForHash", emptyHash).
-		Return(createInvalidXdrStream(), nil).Once()
+		Return(createInvalidXdrStream(nil), nil).Once()
 
 	s.mockArchive.
 		On("GetXdrStreamForHash", emptyHash).
-		Return(createInvalidXdrStream(), nil).Once()
+		Return(createInvalidXdrStream(nil), nil).Once()
 
 	expectedEntry := metaEntry(1)
 	s.mockArchive.
@@ -510,11 +554,18 @@ func entryAccount(t xdr.BucketEntryType, id string, balance uint32) xdr.BucketEn
 	}
 }
 
-func createInvalidXdrStream() *historyarchive.XdrStream {
+type errCloser struct {
+	io.Reader
+	err error
+}
+
+func (e errCloser) Close() error { return e.err }
+
+func createInvalidXdrStream(closeError error) *historyarchive.XdrStream {
 	b := &bytes.Buffer{}
 	writeInvalidFrame(b)
 
-	return xdrStreamFromBuffer(b)
+	return historyarchive.NewXdrStream(errCloser{b, closeError})
 }
 
 func writeInvalidFrame(b *bytes.Buffer) {

--- a/support/historyarchive/xdrstream.go
+++ b/support/historyarchive/xdrstream.go
@@ -127,6 +127,9 @@ func (x *XdrStream) Close() error {
 func (x *XdrStream) CloseWithoutValidation() error {
 	if x.rdr != nil {
 		if err := x.rdr.Close(); err != nil {
+			if x.rdr2 != nil {
+				x.rdr2.Close()
+			}
 			return err
 		}
 	}

--- a/support/historyarchive/xdrstream.go
+++ b/support/historyarchive/xdrstream.go
@@ -106,7 +106,7 @@ func (x *XdrStream) Close() error {
 		_, err := io.Copy(ioutil.Discard, x.rdr)
 		if err != nil {
 			// close the internal readers to avoid memory leaks
-			x.CloseWithoutValidation()
+			x.closeReaders()
 			return errors.Wrap(err, "Error reading remaining bytes from rdr")
 		}
 
@@ -114,17 +114,15 @@ func (x *XdrStream) Close() error {
 
 		if !bytes.Equal(x.expectedHash[:], actualHash[:]) {
 			// close the internal readers to avoid memory leaks
-			x.CloseWithoutValidation()
+			x.closeReaders()
 			return errors.New("Stream hash does not match expected hash!")
 		}
 	}
 
-	return x.CloseWithoutValidation()
+	return x.closeReaders()
 }
 
-// CloseWithoutValidation closes all internal readers without validating the
-// hash of the stream contents
-func (x *XdrStream) CloseWithoutValidation() error {
+func (x *XdrStream) closeReaders() error {
 	if x.rdr != nil {
 		if err := x.rdr.Close(); err != nil {
 			if x.rdr2 != nil {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Close https://github.com/stellar/go/issues/1979

If we encounter errors when we read a bucket entry from the history archive snapshot we attempt to retry the operation by creating a new stream. However, before creating a new stream we first close the current stream. Currently, if we encounter an error while closing the stream we abort the retry operation. But, it turns out that this is not the desired behavior and we should still continue the retry process for certain cases of errors.

### Known limitations

[TODO or N/A]
