### PR TITLE
exp/hubble: convert schema factory tests to table-based

### DIFF
--- a/exp/hubble/helper_functions_test.go
+++ b/exp/hubble/helper_functions_test.go
@@ -1,0 +1,63 @@
+package hubble
+
+import "github.com/stellar/go/xdr"
+
+func makeLedgerEntryChangeAccount(entry *xdr.AccountEntry) *xdr.LedgerEntryChange {
+	return &xdr.LedgerEntryChange{
+		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+		State: &xdr.LedgerEntry{
+			Data: xdr.LedgerEntryData{
+				Type:    xdr.LedgerEntryTypeAccount,
+				Account: entry,
+			},
+		},
+	}
+}
+
+func makeLedgerEntryChangeTrustline(issuer, code string, balance, limit int) *xdr.LedgerEntryChange {
+	return &xdr.LedgerEntryChange{
+		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+		State: &xdr.LedgerEntry{
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeTrustline,
+				TrustLine: &xdr.TrustLineEntry{
+					AccountId: xdr.MustAddress(issuer),
+					Asset:     xdr.MustNewCreditAsset(code, issuer),
+					Balance:   xdr.Int64(balance),
+					Limit:     xdr.Int64(limit),
+				},
+			},
+		},
+	}
+}
+
+func makeLedgerEntryChangeOffer(offerID int, sellerID string) *xdr.LedgerEntryChange {
+	return &xdr.LedgerEntryChange{
+		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+		State: &xdr.LedgerEntry{
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeOffer,
+				Offer: &xdr.OfferEntry{
+					OfferId:  xdr.Int64(offerID),
+					SellerId: xdr.MustAddress(sellerID),
+				},
+			},
+		},
+	}
+}
+
+func makeLedgerEntryChangeData(address, name, value string) *xdr.LedgerEntryChange {
+	return &xdr.LedgerEntryChange{
+		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+		State: &xdr.LedgerEntry{
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeData,
+				Data: &xdr.DataEntry{
+					AccountId: xdr.MustAddress(address),
+					DataName:  xdr.String64(name),
+					DataValue: xdr.DataValue(value),
+				},
+			},
+		},
+	}
+}

--- a/exp/hubble/processors.go
+++ b/exp/hubble/processors.go
@@ -111,7 +111,7 @@ func (p *CurrentStateProcessor) ProcessState(ctx context.Context, store *support
 			}
 		}
 
-		accountID, err := makeAccountID(&entry)
+		accountID, err := makeAccountIDFromChange(&entry)
 		if err != nil {
 			return errors.Wrap(err, "could not get ledger account address")
 		}

--- a/exp/hubble/processors.go
+++ b/exp/hubble/processors.go
@@ -116,6 +116,13 @@ func (p *CurrentStateProcessor) ProcessState(ctx context.Context, store *support
 			return errors.Wrap(err, "could not get ledger account address")
 		}
 		currentState := p.ledgerState[accountID]
+
+		// If we have stored no prior state for this account, we should initialize
+		// its state with the already-found address.
+		if currentState.address == "" {
+			currentState.address = accountID
+		}
+
 		newState, err := makeNewAccountState(&currentState, &entry)
 		if err != nil {
 			return errors.Wrap(err, "could not update account state")

--- a/exp/hubble/schema_factory.go
+++ b/exp/hubble/schema_factory.go
@@ -10,13 +10,16 @@ import (
 )
 
 func makeNewAccountState(state *accountState, change *xdr.LedgerEntryChange) (*accountState, error) {
-	// TODO: Handle account removal.
+	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved && change.EntryType() == xdr.LedgerEntryTypeAccount {
+		return nil, nil
+	}
+
 	var newAccountState accountState
-	address, err := makeAccountID(change, *state)
+	address, err := makeAccountIDFromStateOrChange(state, change)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get address")
 	}
-	state.address = address
+	newAccountState.address = address
 
 	seqnum, err := makeSeqnum(state, change)
 	if err != nil {
@@ -57,24 +60,41 @@ func makeNewAccountState(state *accountState, change *xdr.LedgerEntryChange) (*a
 	return &newAccountState, nil
 }
 
-func makeAccountID(change *xdr.LedgerEntryChange, states ...accountState) (string, error) {
-	// If the address has already been set on the account state, we return it.
-	// We pass this as a optional parameter, so we can use this function more easily in the processor.
-	if len(states) == 1 {
-		return states[0].address, nil
+func makeAccountIDFromStateOrChange(state *accountState, change *xdr.LedgerEntryChange) (string, error) {
+	if state != nil {
+		return state.address, nil
 	}
+	return makeAccountIDFromChange(change)
+}
 
+func makeAccountIDFromChange(change *xdr.LedgerEntryChange) (string, error) {
 	key := change.LedgerKey()
 	var accountID xdr.AccountId
 	switch keyType := key.Type; keyType {
 	case xdr.LedgerEntryTypeAccount:
-		accountID = key.MustAccount().AccountId
+		account, ok := key.GetAccount()
+		if !ok {
+			return "", fmt.Errorf("could not get account")
+		}
+		accountID = account.AccountId
 	case xdr.LedgerEntryTypeTrustline:
-		accountID = key.MustTrustLine().AccountId
+		trustline, ok := key.GetTrustLine()
+		if !ok {
+			return "", fmt.Errorf("could not get trustline")
+		}
+		accountID = trustline.AccountId
 	case xdr.LedgerEntryTypeOffer:
-		accountID = key.MustOffer().SellerId
+		offer, ok := key.GetOffer()
+		if !ok {
+			return "", fmt.Errorf("could not get offer")
+		}
+		accountID = offer.SellerId
 	case xdr.LedgerEntryTypeData:
-		accountID = key.MustData().AccountId
+		data, ok := key.GetData()
+		if !ok {
+			return "", fmt.Errorf("could not get data")
+		}
+		accountID = data.AccountId
 	default:
 		return "", fmt.Errorf("Unknown entry type: %v", keyType)
 	}
@@ -82,23 +102,18 @@ func makeAccountID(change *xdr.LedgerEntryChange, states ...accountState) (strin
 }
 
 func makeSeqnum(state *accountState, change *xdr.LedgerEntryChange) (uint32, error) {
-	var seqnum xdr.Uint32
-	switch entryType := change.Type; entryType {
-	case xdr.LedgerEntryChangeTypeLedgerEntryCreated:
-		seqnum = change.MustCreated().LastModifiedLedgerSeq
-	case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
-		seqnum = change.MustUpdated().LastModifiedLedgerSeq
-	case xdr.LedgerEntryChangeTypeLedgerEntryState:
-		seqnum = change.MustState().LastModifiedLedgerSeq
-
-	// We do not need to update the seqnum for removed changes, because
-	// we just remove the accompanying account's state.
-	case xdr.LedgerEntryChangeTypeLedgerEntryRemoved:
-		return 0, nil
-	default:
-		return 0, fmt.Errorf("Unknown entry type: %v", entryType)
+	// Removed entries do not change the last modified ledger seqnum.
+	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
+		return state.seqnum, nil
 	}
-	return uint32(seqnum), nil
+
+	// TODO: Use state to check if change of seqnum is valid.
+
+	entry, err := getLedgerEntry(change)
+	if err != nil {
+		return 0, errors.Wrap(err, "could not get ledger entry")
+	}
+	return uint32(entry.LastModifiedLedgerSeq), nil
 }
 
 func makeBalance(state *accountState, change *xdr.LedgerEntryChange) (uint32, error) {
@@ -138,36 +153,41 @@ func makeSigners(state *accountState, change *xdr.LedgerEntryChange) ([]signer, 
 }
 
 func makeTrustlines(state *accountState, change *xdr.LedgerEntryChange) (map[string]trustline, error) {
-	if change.EntryType() != xdr.LedgerEntryTypeTrustline {
-		return state.trustlines, nil
+	// Get current trustlines.
+	var trustlines map[string]trustline
+	if state != nil {
+		if state.trustlines != nil {
+			trustlines = make(map[string]trustline)
+			for k, v := range state.trustlines {
+				trustlines[k] = v
+			}
+		}
 	}
 
-	// Copy the current state trustlines.
-	trustlines := make(map[string]trustline)
-	for k, v := range state.trustlines {
-		trustlines[k] = v
+	// Return existing trustlines if the change is not of type trustline.
+	if change.EntryType() != xdr.LedgerEntryTypeTrustline {
+		return trustlines, nil
 	}
 
 	// If the change is removed, remove the corresponding trustline.
 	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
-		asset := change.MustRemoved().TrustLine.Asset.String()
+		removeEntry, ok := change.GetRemoved()
+		if !ok {
+			return nil, fmt.Errorf("Could not get removed ledger key")
+		}
+		asset := removeEntry.TrustLine.Asset.String()
 		delete(trustlines, asset)
 		return trustlines, nil
 	}
 
-	// Get and store the new trustline.
-	var trustlineEntry xdr.TrustLineEntry
-	switch entryType := change.Type; entryType {
-	case xdr.LedgerEntryChangeTypeLedgerEntryCreated:
-		trustlineEntry = change.MustCreated().Data.MustTrustLine()
-	case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
-		trustlineEntry = change.MustUpdated().Data.MustTrustLine()
-	case xdr.LedgerEntryChangeTypeLedgerEntryState:
-		trustlineEntry = change.MustState().Data.MustTrustLine()
-	default:
-		return nil, fmt.Errorf("Unknown entry type: %v", entryType)
+	entry, err := getLedgerEntry(change)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get ledger entry")
 	}
-
+	trustlineEntry, ok := entry.Data.GetTrustLine()
+	if !ok {
+		return nil, fmt.Errorf("Could not get trustline")
+	}
 	assetKey := trustlineEntry.Asset.String()
 	newTrustline := trustline{
 		asset:      assetKey,
@@ -181,34 +201,41 @@ func makeTrustlines(state *accountState, change *xdr.LedgerEntryChange) (map[str
 }
 
 func makeOffers(state *accountState, change *xdr.LedgerEntryChange) (map[uint32]offer, error) {
+	// Return existing offers if the change is not of type offer.
 	if change.EntryType() != xdr.LedgerEntryTypeOffer {
-		return state.offers, nil
+		if state != nil {
+			return state.offers, nil
+		}
+		return nil, nil
 	}
 
-	// Copy the current state offers.
+	// Get current offers.
 	offers := make(map[uint32]offer)
-	for k, v := range state.offers {
-		offers[k] = v
+	if state != nil {
+		for k, v := range state.offers {
+			offers[k] = v
+		}
 	}
 
 	// If the change is removed, remove the corresponding offer.
 	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
-		id := uint32(change.MustRemoved().Offer.OfferId)
+		removeEntry, ok := change.GetRemoved()
+		if !ok {
+			return nil, fmt.Errorf("Could not get removed ledger key")
+		}
+		id := uint32(removeEntry.Offer.OfferId)
 		delete(offers, id)
 		return offers, nil
 	}
 
-	// Get and store the offer.
-	var offerEntry xdr.OfferEntry
-	switch entryType := change.Type; entryType {
-	case xdr.LedgerEntryChangeTypeLedgerEntryCreated:
-		offerEntry = change.MustCreated().Data.MustOffer()
-	case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
-		offerEntry = change.MustUpdated().Data.MustOffer()
-	case xdr.LedgerEntryChangeTypeLedgerEntryState:
-		offerEntry = change.MustState().Data.MustOffer()
-	default:
-		return nil, fmt.Errorf("Unknown entry type: %v", entryType)
+	// Get and store offer.
+	entry, err := getLedgerEntry(change)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get ledger entry")
+	}
+	offerEntry, ok := entry.Data.GetOffer()
+	if !ok {
+		return nil, fmt.Errorf("Could not get offer")
 	}
 
 	offerID := uint32(offerEntry.OfferId)
@@ -227,32 +254,40 @@ func makeOffers(state *accountState, change *xdr.LedgerEntryChange) (map[uint32]
 }
 
 func makeData(state *accountState, change *xdr.LedgerEntryChange) (map[string][]byte, error) {
+	// Return existing data if the change is not of type data.
 	if change.EntryType() != xdr.LedgerEntryTypeData {
-		return state.data, nil
+		if state != nil {
+			return state.data, nil
+		}
+		return nil, nil
 	}
 
+	// Copy current data.
 	data := make(map[string][]byte)
-	for k, v := range state.data {
-		data[k] = v
+	if state != nil {
+		for k, v := range state.data {
+			data[k] = v
+		}
 	}
 
 	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
-		name := string(change.MustRemoved().Data.DataName)
+		removeEntry, ok := change.GetRemoved()
+		if !ok {
+			return nil, fmt.Errorf("Could not get removed ledger key")
+		}
+		name := string(removeEntry.Data.DataName)
 		delete(data, name)
 		return data, nil
 	}
 
 	// Get and store the data key-value pair.
-	var dataEntry xdr.DataEntry
-	switch entryType := change.Type; entryType {
-	case xdr.LedgerEntryChangeTypeLedgerEntryCreated:
-		dataEntry = change.MustCreated().Data.MustData()
-	case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
-		dataEntry = change.MustUpdated().Data.MustData()
-	case xdr.LedgerEntryChangeTypeLedgerEntryState:
-		dataEntry = change.MustState().Data.MustData()
-	default:
-		return nil, fmt.Errorf("Unknown entry type: %v", entryType)
+	entry, err := getLedgerEntry(change)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get ledger entry")
+	}
+	dataEntry, ok := entry.Data.GetData()
+	if !ok {
+		return nil, fmt.Errorf("Could not get data")
 	}
 	data[string(dataEntry.DataName)] = dataEntry.DataValue
 	return data, nil
@@ -262,18 +297,40 @@ func getAccountEntry(change *xdr.LedgerEntryChange) (*xdr.AccountEntry, error) {
 	if change.EntryType() != xdr.LedgerEntryTypeAccount {
 		return nil, nil
 	}
-	var account xdr.AccountEntry
-	switch entryType := change.Type; entryType {
+
+	entry, err := getLedgerEntry(change)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get ledger entry")
+	}
+
+	account, ok := entry.Data.GetAccount()
+	if !ok {
+		return nil, fmt.Errorf("Could not get account")
+	}
+
+	return &account, nil
+}
+
+func getLedgerEntry(change *xdr.LedgerEntryChange) (*xdr.LedgerEntry, error) {
+	var (
+		account xdr.LedgerEntry
+		ok      bool
+	)
+	entryType := change.Type
+	switch entryType {
 	case xdr.LedgerEntryChangeTypeLedgerEntryCreated:
-		account = change.MustCreated().Data.MustAccount()
-	case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
-		account = change.MustUpdated().Data.MustAccount()
+		account, ok = change.GetCreated()
 	case xdr.LedgerEntryChangeTypeLedgerEntryState:
-		account = change.MustState().Data.MustAccount()
+		account, ok = change.GetState()
+	case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
+		account, ok = change.GetUpdated()
 	case xdr.LedgerEntryChangeTypeLedgerEntryRemoved:
-		return nil, nil
+		return nil, fmt.Errorf("Entry type %v does not have LedgerEntry", entryType)
 	default:
 		return nil, fmt.Errorf("Unknown entry type: %v", entryType)
+	}
+	if !ok {
+		return nil, fmt.Errorf("Could not get account from entry type %v", entryType)
 	}
 	return &account, nil
 }

--- a/exp/hubble/schema_factory.go
+++ b/exp/hubble/schema_factory.go
@@ -68,35 +68,40 @@ func makeAccountIDFromStateOrChange(state *accountState, change *xdr.LedgerEntry
 }
 
 func makeAccountIDFromChange(change *xdr.LedgerEntryChange) (string, error) {
-	key := change.LedgerKey()
+	entry, err := getLedgerEntry(change)
+	if err != nil {
+		return "", errors.Wrap(err, "could not get ledger entry")
+	}
+
 	var accountID xdr.AccountId
-	switch keyType := key.Type; keyType {
+	entryData := entry.Data
+	switch entryType := entryData.Type; entryType {
 	case xdr.LedgerEntryTypeAccount:
-		account, ok := key.GetAccount()
+		account, ok := entryData.GetAccount()
 		if !ok {
 			return "", fmt.Errorf("could not get account")
 		}
 		accountID = account.AccountId
 	case xdr.LedgerEntryTypeTrustline:
-		trustline, ok := key.GetTrustLine()
+		trustline, ok := entryData.GetTrustLine()
 		if !ok {
 			return "", fmt.Errorf("could not get trustline")
 		}
 		accountID = trustline.AccountId
 	case xdr.LedgerEntryTypeOffer:
-		offer, ok := key.GetOffer()
+		offer, ok := entryData.GetOffer()
 		if !ok {
 			return "", fmt.Errorf("could not get offer")
 		}
 		accountID = offer.SellerId
 	case xdr.LedgerEntryTypeData:
-		data, ok := key.GetData()
+		data, ok := entryData.GetData()
 		if !ok {
 			return "", fmt.Errorf("could not get data")
 		}
 		accountID = data.AccountId
 	default:
-		return "", fmt.Errorf("Unknown entry type: %v", keyType)
+		return "", fmt.Errorf("Unknown entry type: %v", entryType)
 	}
 	return accountID.Address(), nil
 }

--- a/exp/hubble/schema_factory.go
+++ b/exp/hubble/schema_factory.go
@@ -12,7 +12,7 @@ import (
 func makeNewAccountState(state *accountState, change *xdr.LedgerEntryChange) (*accountState, error) {
 	// TODO: Handle account removal.
 	var newAccountState accountState
-	address, err := makeAccountID(change, state)
+	address, err := makeAccountID(change, *state)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get address")
 	}
@@ -57,7 +57,7 @@ func makeNewAccountState(state *accountState, change *xdr.LedgerEntryChange) (*a
 	return &newAccountState, nil
 }
 
-func makeAccountID(change *xdr.LedgerEntryChange, states ...*accountState) (string, error) {
+func makeAccountID(change *xdr.LedgerEntryChange, states ...accountState) (string, error) {
 	// If the address has already been set on the account state, we return it.
 	// We pass this as a optional parameter, so we can use this function more easily in the processor.
 	if len(states) == 1 {

--- a/exp/hubble/schema_factory.go
+++ b/exp/hubble/schema_factory.go
@@ -10,16 +10,30 @@ import (
 )
 
 func makeNewAccountState(state *accountState, change *xdr.LedgerEntryChange) (*accountState, error) {
-	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved && change.EntryType() == xdr.LedgerEntryTypeAccount {
+	accountRemoved, err := isAccountRemoved(change)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not check removed account")
+	}
+	// If the account has been removed, then we return a nil account state.
+	if accountRemoved {
 		return nil, nil
 	}
 
-	var newAccountState accountState
-	address, err := makeAccountIDFromStateOrChange(state, change)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get address")
+	// We should never be given a nil pointer for account state, rather one
+	// to an empty accountState struct. If we are given a nil pointer to state
+	// somehow, we replace it with the desired input. This prevents repeated,
+	// per-function checks for nil state.
+	if state == nil {
+		state = &accountState{}
+		accountID, err := makeAccountIDFromChange(change)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get ledger account address")
+		}
+		state.address = accountID
 	}
-	newAccountState.address = address
+
+	var newAccountState accountState
+	newAccountState.address = state.address
 
 	seqnum, err := makeSeqnum(state, change)
 	if err != nil {
@@ -60,19 +74,26 @@ func makeNewAccountState(state *accountState, change *xdr.LedgerEntryChange) (*a
 	return &newAccountState, nil
 }
 
-func makeAccountIDFromStateOrChange(state *accountState, change *xdr.LedgerEntryChange) (string, error) {
-	if state != nil {
-		return state.address, nil
+func isAccountRemoved(change *xdr.LedgerEntryChange) (bool, error) {
+	// If the change is not of Removed type, it cannot represent the
+	// removal of an Account.
+	if change.Type != xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
+		return false, nil
 	}
-	return makeAccountIDFromChange(change)
+
+	ledgerKey, ok := change.GetRemoved()
+	if !ok {
+		return false, fmt.Errorf("Could not get ledger key from Removed struct")
+	}
+
+	return (ledgerKey.Type == xdr.LedgerEntryTypeAccount), nil
 }
 
 func makeAccountIDFromChange(change *xdr.LedgerEntryChange) (string, error) {
-	entry, err := getLedgerEntry(change)
-	if err != nil {
-		return "", errors.Wrap(err, "could not get ledger entry")
+	entry, ok := change.GetLedgerEntry()
+	if !ok {
+		return "", fmt.Errorf("Could not get ledger entry from change")
 	}
-
 	var accountID xdr.AccountId
 	entryData := entry.Data
 	switch entryType := entryData.Type; entryType {
@@ -103,52 +124,68 @@ func makeAccountIDFromChange(change *xdr.LedgerEntryChange) (string, error) {
 	default:
 		return "", fmt.Errorf("Unknown entry type: %v", entryType)
 	}
-	return accountID.Address(), nil
+
+	address, err := accountID.GetAddress()
+	if err != nil {
+		return "", errors.Wrap(err, "could not get address")
+	}
+	return address, nil
 }
 
 func makeSeqnum(state *accountState, change *xdr.LedgerEntryChange) (uint32, error) {
-	// Removed entries do not change the last modified ledger seqnum.
+	// Removed entries would not be of Account type, and thus
+	// do not change the last modified ledger seqnum.
 	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
 		return state.seqnum, nil
 	}
 
-	// TODO: Use state to check if the change of seqnum is valid.
-
-	entry, err := getLedgerEntry(change)
-	if err != nil {
-		return 0, errors.Wrap(err, "could not get ledger entry")
+	entry, ok := change.GetLedgerEntry()
+	if !ok {
+		return 0, fmt.Errorf("Could not get ledger entry")
 	}
 	return uint32(entry.LastModifiedLedgerSeq), nil
 }
 
 func makeBalance(state *accountState, change *xdr.LedgerEntryChange) (uint32, error) {
-	account, err := getAccountEntry(change)
-	if err != nil {
-		return 0, err
-	}
-
-	// The change does not update the account state, so we return
-	// the current balance.
-	if account == nil {
+	// If the change is a non-account removal or a change of non-account type, then
+	// we simply return the current balance (or 0, if we were passed a nil state pointer).
+	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
 		return state.balance, nil
 	}
+
+	entry, ok := change.GetLedgerEntry()
+	if !ok {
+		return state.balance, nil
+	}
+
+	account, ok := entry.Data.GetAccount()
+	if !ok {
+		return state.balance, nil
+	}
+
 	return uint32(account.Balance), nil
 }
 
 func makeSigners(state *accountState, change *xdr.LedgerEntryChange) ([]signer, error) {
-	account, err := getAccountEntry(change)
-	if err != nil {
-		return nil, err
+	// If the change is a non-account removal or a change of non-account type, then
+	// we simply return the current signers (or empty list, if we were passed a nil state pointer).
+	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
+		return state.signers, nil
 	}
 
-	// The change does not update the account state, so we return
-	// the current signers.
-	if account == nil {
+	entry, ok := change.GetLedgerEntry()
+	if !ok {
+		return state.signers, nil
+	}
+
+	account, ok := entry.Data.GetAccount()
+	if !ok {
 		return state.signers, nil
 	}
 
 	var signers []signer
 	for _, accountSigner := range account.Signers {
+		// TODO: Replace `SignerKey.Address()` with a panic-free version.
 		signers = append(signers, signer{
 			address: accountSigner.Key.Address(),
 			weight:  uint32(accountSigner.Weight),
@@ -158,20 +195,15 @@ func makeSigners(state *accountState, change *xdr.LedgerEntryChange) ([]signer, 
 }
 
 func makeTrustlines(state *accountState, change *xdr.LedgerEntryChange) (map[string]trustline, error) {
-	// Get current trustlines.
-	var trustlines map[string]trustline
-	if state != nil {
-		if state.trustlines != nil {
-			trustlines = make(map[string]trustline)
-			for k, v := range state.trustlines {
-				trustlines[k] = v
-			}
-		}
+	// TODO: Replace reference to `EntryType` with a panic-free version.
+	if change.EntryType() != xdr.LedgerEntryTypeTrustline {
+		return state.trustlines, nil
 	}
 
-	// Return existing trustlines if the change is not of type trustline.
-	if change.EntryType() != xdr.LedgerEntryTypeTrustline {
-		return trustlines, nil
+	// Copy the current state trustlines.
+	trustlines := make(map[string]trustline)
+	for k, v := range state.trustlines {
+		trustlines[k] = v
 	}
 
 	// If the change is removed, remove the corresponding trustline.
@@ -185,14 +217,16 @@ func makeTrustlines(state *accountState, change *xdr.LedgerEntryChange) (map[str
 		return trustlines, nil
 	}
 
-	entry, err := getLedgerEntry(change)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get ledger entry")
+	// Get the trustline entry from the change and an error if we cannot.
+	entry, ok := change.GetLedgerEntry()
+	if !ok {
+		return nil, fmt.Errorf("Could not get ledger entry")
 	}
 	trustlineEntry, ok := entry.Data.GetTrustLine()
 	if !ok {
-		return nil, fmt.Errorf("Could not get trustline")
+		return nil, fmt.Errorf("Could not get trustline entry")
 	}
+
 	assetKey := trustlineEntry.Asset.String()
 	newTrustline := trustline{
 		asset:      assetKey,
@@ -206,20 +240,15 @@ func makeTrustlines(state *accountState, change *xdr.LedgerEntryChange) (map[str
 }
 
 func makeOffers(state *accountState, change *xdr.LedgerEntryChange) (map[uint32]offer, error) {
-	// Return existing offers if the change is not of type offer.
+	// TODO: Replace reference to `EntryType` with a panic-free version.
 	if change.EntryType() != xdr.LedgerEntryTypeOffer {
-		if state != nil {
-			return state.offers, nil
-		}
-		return nil, nil
+		return state.offers, nil
 	}
 
-	// Get current offers.
+	// Copy the current state offers.
 	offers := make(map[uint32]offer)
-	if state != nil {
-		for k, v := range state.offers {
-			offers[k] = v
-		}
+	for k, v := range state.offers {
+		offers[k] = v
 	}
 
 	// If the change is removed, remove the corresponding offer.
@@ -233,20 +262,25 @@ func makeOffers(state *accountState, change *xdr.LedgerEntryChange) (map[uint32]
 		return offers, nil
 	}
 
-	// Get and store offer.
-	entry, err := getLedgerEntry(change)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get ledger entry")
+	// Get and store the offer.
+	entry, ok := change.GetLedgerEntry()
+	if !ok {
+		return nil, fmt.Errorf("Could not get ledger entry")
 	}
 	offerEntry, ok := entry.Data.GetOffer()
 	if !ok {
-		return nil, fmt.Errorf("Could not get offer")
+		return nil, fmt.Errorf("Could not get offer entry")
+	}
+
+	offerSellerAddress, err := offerEntry.SellerId.GetAddress()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get offer seller address")
 	}
 
 	offerID := uint32(offerEntry.OfferId)
 	newOffer := offer{
 		id:         offerID,
-		seller:     offerEntry.SellerId.Address(),
+		seller:     offerSellerAddress,
 		selling:    offerEntry.Selling.String(),
 		buying:     offerEntry.Buying.String(),
 		amount:     uint32(offerEntry.Amount),
@@ -259,83 +293,37 @@ func makeOffers(state *accountState, change *xdr.LedgerEntryChange) (map[uint32]
 }
 
 func makeData(state *accountState, change *xdr.LedgerEntryChange) (map[string][]byte, error) {
-	// Return existing data if the change is not of type data.
+	// TODO: Replace reference to `EntryType` with a panic-free version.
 	if change.EntryType() != xdr.LedgerEntryTypeData {
-		if state != nil {
-			return state.data, nil
-		}
-		return nil, nil
+		return state.data, nil
 	}
 
-	// Copy current data.
 	data := make(map[string][]byte)
-	if state != nil {
-		for k, v := range state.data {
-			data[k] = v
-		}
+	for k, v := range state.data {
+		data[k] = v
 	}
 
 	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
-		removeEntry, ok := change.GetRemoved()
+		key, ok := change.GetRemoved()
 		if !ok {
 			return nil, fmt.Errorf("Could not get removed ledger key")
 		}
-		name := string(removeEntry.Data.DataName)
+		name := string(key.Data.DataName)
 		delete(data, name)
 		return data, nil
 	}
 
 	// Get and store the data key-value pair.
-	entry, err := getLedgerEntry(change)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get ledger entry")
+	entry, ok := change.GetLedgerEntry()
+	if !ok {
+		return nil, fmt.Errorf("Could not get ledger entry")
 	}
+
 	dataEntry, ok := entry.Data.GetData()
 	if !ok {
-		return nil, fmt.Errorf("Could not get data")
+		return nil, fmt.Errorf("Could not get data entry")
 	}
+
 	data[string(dataEntry.DataName)] = dataEntry.DataValue
 	return data, nil
-}
-
-func getAccountEntry(change *xdr.LedgerEntryChange) (*xdr.AccountEntry, error) {
-	if change.EntryType() != xdr.LedgerEntryTypeAccount {
-		return nil, nil
-	}
-
-	entry, err := getLedgerEntry(change)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get ledger entry")
-	}
-
-	account, ok := entry.Data.GetAccount()
-	if !ok {
-		return nil, fmt.Errorf("Could not get account")
-	}
-
-	return &account, nil
-}
-
-func getLedgerEntry(change *xdr.LedgerEntryChange) (*xdr.LedgerEntry, error) {
-	var (
-		account xdr.LedgerEntry
-		ok      bool
-	)
-	entryType := change.Type
-	switch entryType {
-	case xdr.LedgerEntryChangeTypeLedgerEntryCreated:
-		account, ok = change.GetCreated()
-	case xdr.LedgerEntryChangeTypeLedgerEntryState:
-		account, ok = change.GetState()
-	case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
-		account, ok = change.GetUpdated()
-	case xdr.LedgerEntryChangeTypeLedgerEntryRemoved:
-		return nil, fmt.Errorf("Entry type %v does not have LedgerEntry", entryType)
-	default:
-		return nil, fmt.Errorf("Unknown entry type: %v", entryType)
-	}
-	if !ok {
-		return nil, fmt.Errorf("Could not get account from entry type %v", entryType)
-	}
-	return &account, nil
 }

--- a/exp/hubble/schema_factory.go
+++ b/exp/hubble/schema_factory.go
@@ -25,9 +25,9 @@ func makeNewAccountState(state *accountState, change *xdr.LedgerEntryChange) (*a
 	// per-function checks for nil state.
 	if state == nil {
 		state = &accountState{}
-		accountID, err := makeAccountIDFromChange(change)
+		accountID, aerr := makeAccountIDFromChange(change)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not get ledger account address")
+			return nil, errors.Wrap(aerr, "could not get ledger account address")
 		}
 		state.address = accountID
 	}

--- a/exp/hubble/schema_factory.go
+++ b/exp/hubble/schema_factory.go
@@ -107,7 +107,7 @@ func makeSeqnum(state *accountState, change *xdr.LedgerEntryChange) (uint32, err
 		return state.seqnum, nil
 	}
 
-	// TODO: Use state to check if change of seqnum is valid.
+	// TODO: Use state to check if the change of seqnum is valid.
 
 	entry, err := getLedgerEntry(change)
 	if err != nil {

--- a/exp/hubble/schema_factory_test.go
+++ b/exp/hubble/schema_factory_test.go
@@ -172,6 +172,44 @@ func TestMakeNewAccountStateSuccess(t *testing.T) {
 	}
 }
 
+func TestMakeNewAccountStateErrors(t *testing.T) {
+	var accountStateTests = []struct {
+		name      string
+		state     *accountState
+		change    *xdr.LedgerEntryChange
+		wantState *accountState // TODO: May not need this.
+	}{
+		// TODO: Test `makeAccountIDFromChange`, Account.
+		// TODO: Test `makeAccountIDFromChange`, Trustline.
+		// TODO: Test `makeAccountIDFromChange`, Offer.
+		// TODO: Test `makeAccountIDFromChange`, Data.
+		// TODO: Test `makeSeqnum`, `getLedgerEntry` failure.
+		// TODO: Test `makeBalance`, `getAccountEntry` failure.
+		// TODO: Test `makeTrustlines`, `change.GetRemoved` failure.
+		// TODO: Test `makeTrustlines`, `getLedgerEntry` failure.
+		// TODO: Test `makeTrustlines`, `entry.Data.GetTrustline()` failure.
+		// TODO: Test `makeOffers`, `change.GetRemoved` failure.
+		// TODO: Test `makeOffers`, `getLedgerEntry` failure.
+		// TODO: Test `makeOffers`, `entry.Data.GetOffer()` failure.
+		// TODO: Test `makeData`, `change.GetRemoved` failure.
+		// TODO: Test `makeData`, `getLedgerEntry` failure.
+		// TODO: Test `makeData`, `entry.Data.GetData()` failure.`
+	}
+
+	for _, tt := range accountStateTests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotState, err := makeNewAccountState(tt.state, tt.change)
+			if assert.NoError(t, err) {
+				return
+			}
+			// TODO: Check if we need this assert.
+			if !assert.Equal(t, tt.wantState, gotState) {
+				return
+			}
+		})
+	}
+}
+
 func TestGetAccountEntry(t *testing.T) {
 	var accountEntryTests = []struct {
 		name      string

--- a/exp/hubble/schema_factory_test.go
+++ b/exp/hubble/schema_factory_test.go
@@ -32,16 +32,6 @@ func TestMakeNewAccountStateSuccess(t *testing.T) {
 			},
 			nil,
 		},
-		{"AccountIDFromState",
-			&accountState{address: wantAddress},
-			makeLedgerEntryChangeAccount(&xdr.AccountEntry{}),
-			&accountState{address: wantAddress},
-		},
-		{"AccountIDFromChange",
-			nil,
-			makeLedgerEntryChangeAccount(&xdr.AccountEntry{AccountId: xdr.MustAddress(wantAddress)}),
-			&accountState{address: wantAddress},
-		},
 		{"SeqnumNotChanged",
 			&accountState{seqnum: 11},
 			&xdr.LedgerEntryChange{
@@ -173,52 +163,3 @@ func TestMakeNewAccountStateSuccess(t *testing.T) {
 }
 
 // TODO: Add tests for error cases.
-
-func TestGetAccountEntry(t *testing.T) {
-	var accountEntryTests = []struct {
-		name      string
-		change    *xdr.LedgerEntryChange
-		wantEntry *xdr.AccountEntry
-	}{
-		{"NotAccount",
-			makeLedgerEntryChangeData(wantAddress, "name", "value"),
-			nil,
-		},
-		{"Removed",
-			&xdr.LedgerEntryChange{
-				Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-				Removed: &xdr.LedgerKey{
-					Type: xdr.LedgerEntryTypeAccount,
-					Account: &xdr.LedgerKeyAccount{
-						AccountId: xdr.MustAddress("GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"),
-					},
-				},
-			},
-			nil,
-		},
-		{"NotRemoved",
-			makeLedgerEntryChangeAccount(&xdr.AccountEntry{AccountId: xdr.MustAddress(wantAddress)}),
-			&xdr.AccountEntry{AccountId: xdr.MustAddress(wantAddress)},
-		},
-	}
-
-	for _, tt := range accountEntryTests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotEntry, err := getAccountEntry(tt.change)
-			if tt.wantEntry == nil {
-				if !assert.Nil(t, gotEntry) {
-					return
-				}
-				return
-			}
-			if !assert.NoError(t, err) {
-				return
-			}
-			gotAddress := gotEntry.AccountId.Address()
-			wantAddress := tt.wantEntry.AccountId.Address()
-			if !assert.Equal(t, wantAddress, gotAddress) {
-				return
-			}
-		})
-	}
-}

--- a/exp/hubble/schema_factory_test.go
+++ b/exp/hubble/schema_factory_test.go
@@ -203,13 +203,13 @@ func TestGetAccountEntry(t *testing.T) {
 	for _, tt := range accountEntryTests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotEntry, err := getAccountEntry(tt.change)
-			if !assert.NoError(t, err) {
-				return
-			}
 			if tt.wantEntry == nil {
 				if !assert.Nil(t, gotEntry) {
 					return
 				}
+				return
+			}
+			if !assert.NoError(t, err) {
 				return
 			}
 			gotAddress := gotEntry.AccountId.Address()

--- a/exp/hubble/schema_factory_test.go
+++ b/exp/hubble/schema_factory_test.go
@@ -3,526 +3,497 @@
 package hubble
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
 )
 
-// TODO: Replace manual equality check with `assert`, across all tests.
-func TestMakeAccountIDFromState(t *testing.T) {
-	wantAddress := "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"
-	state := accountState{address: wantAddress}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-		State: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
-				Type: xdr.LedgerEntryTypeAccount,
-			},
-		},
-	}
-	gotAddress, err := makeAccountID(&change, &state)
-	if err != nil {
-		t.Error(err)
-	}
-	if wantAddress != gotAddress {
-		t.Fatalf("got address %s, want address %s", gotAddress, wantAddress)
-	}
-}
+const wantAddress = "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"
 
-func TestMakeAccountIDFromChange(t *testing.T) {
-	wantAddress := "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"
-	accountID, err := xdr.AddressToAccountId(wantAddress)
-	if err != nil {
-		t.Error(err)
-	}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-		State: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
-				Type: xdr.LedgerEntryTypeAccount,
-				Account: &xdr.AccountEntry{
-					AccountId: accountID,
+var accountIDTests = []struct {
+	testName      string
+	state         *accountState
+	wantAccountID string
+	change        xdr.LedgerEntryChange
+}{
+	{"FromState",
+		&accountState{address: wantAddress},
+		wantAddress,
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type: xdr.LedgerEntryTypeAccount,
 				},
 			},
 		},
-	}
-	gotAddress, err := makeAccountID(&change)
-	if err != nil {
-		t.Error(err)
-	}
-	if wantAddress != gotAddress {
-		t.Fatalf("got address %s, want address %s", wantAddress, gotAddress)
+	},
+	{"FromChange",
+		nil,
+		wantAddress,
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type: xdr.LedgerEntryTypeAccount,
+					Account: &xdr.AccountEntry{
+						AccountId: xdr.MustAddress(wantAddress),
+					},
+				},
+			},
+		},
+	},
+}
+
+func TestMakeAccount(t *testing.T) {
+	for _, tt := range accountIDTests {
+		t.Run(tt.testName, func(t *testing.T) {
+			var (
+				gotAccountID string
+				err          error
+			)
+			if tt.state == nil {
+				gotAccountID, err = makeAccountID(&tt.change)
+			} else {
+				gotAccountID, err = makeAccountID(&tt.change, *tt.state)
+			}
+			if err != nil {
+				t.Error(err)
+			}
+			if !assert.Equal(t, tt.wantAccountID, gotAccountID) {
+				t.Fatalf("got account id %s, want account id %s", tt.wantAccountID, gotAccountID)
+			}
+		})
 	}
 }
 
-// TODO: Replace error case tests with table-driven testing.
-func TestMakeSeqnumFromNonRemoved(t *testing.T) {
-	wantSeqnum := uint32(2947523)
-	state := accountState{seqnum: 11}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-		State: &xdr.LedgerEntry{
-			LastModifiedLedgerSeq: xdr.Uint32(wantSeqnum),
-			Data: xdr.LedgerEntryData{
+var seqnumTests = []struct {
+	testName   string
+	wantSeqnum uint32
+	change     xdr.LedgerEntryChange
+}{
+	{"Changed",
+		2947523,
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				LastModifiedLedgerSeq: xdr.Uint32(2947523),
+				Data: xdr.LedgerEntryData{
+					Type:    xdr.LedgerEntryTypeAccount,
+					Account: &xdr.AccountEntry{},
+				},
+			},
+		},
+	},
+	{"Removed",
+		0,
+		xdr.LedgerEntryChange{
+			Type:  xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+			State: &xdr.LedgerEntry{},
+		},
+	},
+}
+
+func TestMakeSeqnum(t *testing.T) {
+	for _, tt := range seqnumTests {
+		t.Run(string(tt.testName), func(t *testing.T) {
+			state := accountState{seqnum: 11}
+			gotSeqnum, err := makeSeqnum(&state, &tt.change)
+			if err != nil {
+				t.Error(err)
+			}
+			if !assert.Equal(t, tt.wantSeqnum, gotSeqnum) {
+				t.Fatalf("got seqnum %d, want seqnum %d", gotSeqnum, tt.wantSeqnum)
+			}
+		})
+	}
+}
+
+var accountEntryTests = []struct {
+	testName  string
+	wantEntry *xdr.AccountEntry
+	change    xdr.LedgerEntryChange
+}{
+	{"NotAccount",
+		nil,
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type: xdr.LedgerEntryTypeData,
+					Data: &xdr.DataEntry{
+						AccountId: xdr.MustAddress("GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"),
+						DataName:  xdr.String64("name"),
+						DataValue: xdr.DataValue([]byte("value")),
+					},
+				},
+			},
+		},
+	},
+	{"Removed",
+		nil,
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+			Removed: &xdr.LedgerKey{
+				Type: xdr.LedgerEntryTypeAccount,
+				Account: &xdr.LedgerKeyAccount{
+					AccountId: xdr.MustAddress("GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"),
+				},
+			},
+		},
+	},
+	{"NotRemoved",
+		&xdr.AccountEntry{AccountId: xdr.MustAddress(wantAddress)},
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type: xdr.LedgerEntryTypeAccount,
+					Account: &xdr.AccountEntry{
+						AccountId: xdr.MustAddress(wantAddress),
+					},
+				},
+			},
+		},
+	},
+}
+
+func TestGetAccountEntry(t *testing.T) {
+	for _, tt := range accountEntryTests {
+		t.Run(string(tt.testName), func(t *testing.T) {
+			gotEntry, err := getAccountEntry(&tt.change)
+			if err != nil {
+				t.Error(err)
+			}
+			if tt.wantEntry == nil {
+				if gotEntry != nil {
+					t.Fatal("got account entry non-nil, want account entry nil")
+				}
+			} else {
+				gotAddress := gotEntry.AccountId.Address()
+				wantAddress := tt.wantEntry.AccountId.Address()
+				if !assert.Equal(t, wantAddress, gotAddress) {
+					t.Fatalf("got address %s, want address %s", gotAddress, wantAddress)
+				}
+			}
+		})
+	}
+}
+
+var balanceTests = []struct {
+	testName    string
+	wantBalance uint32
+	change      xdr.LedgerEntryChange
+}{
+	{"NotChanged",
+		uint32(111),
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+			Removed: &xdr.LedgerKey{
 				Type:    xdr.LedgerEntryTypeAccount,
-				Account: &xdr.AccountEntry{},
+				Account: &xdr.LedgerKeyAccount{},
 			},
 		},
-	}
-	gotSeqnum, err := makeSeqnum(&state, &change)
-	if err != nil {
-		t.Error(err)
-	}
-	if wantSeqnum != gotSeqnum {
-		t.Fatalf("got seqnum %d, want seqnum %d", gotSeqnum, wantSeqnum)
-	}
-}
-
-func TestMakeSeqnumFromRemoved(t *testing.T) {
-	wantSeqnum := uint32(0)
-	state := accountState{seqnum: 11}
-	change := xdr.LedgerEntryChange{
-		Type:  xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-		State: &xdr.LedgerEntry{},
-	}
-	gotSeqnum, err := makeSeqnum(&state, &change)
-	if err != nil {
-		t.Error(err)
-	}
-	if wantSeqnum != gotSeqnum {
-		t.Fatalf("got seqnum %d, want seqnum %d", gotSeqnum, wantSeqnum)
-	}
-}
-
-func TestGetAccountEntryNotAccount(t *testing.T) {
-	accountID, err := xdr.AddressToAccountId("GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF")
-	if err != nil {
-		t.Error(err)
-	}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-		State: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
-				Type: xdr.LedgerEntryTypeData,
-				Data: &xdr.DataEntry{
-					AccountId: accountID,
-					DataName:  xdr.String64("name"),
-					DataValue: xdr.DataValue([]byte("value")),
+	},
+	{"Changed",
+		uint32(222),
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type: xdr.LedgerEntryTypeAccount,
+					Account: &xdr.AccountEntry{
+						Balance: xdr.Int64(222),
+					},
 				},
 			},
 		},
-	}
+	},
+}
 
-	entry, err := getAccountEntry(&change)
-	if err != nil {
-		t.Error(err)
-	}
-	if entry != nil {
-		t.Fatal("got account entry non-nil, want account entry nil")
+func TestMakeBalance(t *testing.T) {
+	for _, tt := range balanceTests {
+		t.Run(tt.testName, func(t *testing.T) {
+			state := accountState{balance: uint32(111)}
+			gotBalance, err := makeBalance(&state, &tt.change)
+			if err != nil {
+				t.Error(err)
+			}
+			if !assert.Equal(t, tt.wantBalance, gotBalance) {
+				t.Fatalf("got balance %d, want balance %d", gotBalance, tt.wantBalance)
+			}
+		})
 	}
 }
 
-func TestGetAccountEntryRemoved(t *testing.T) {
-	accountID, err := xdr.AddressToAccountId("GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF")
-	if err != nil {
-		t.Error(err)
-	}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-		Removed: &xdr.LedgerKey{
-			Type: xdr.LedgerEntryTypeAccount,
-			Account: &xdr.LedgerKeyAccount{
-				AccountId: accountID,
-			},
-		},
-	}
-	accountEntry, err := getAccountEntry(&change)
-	if err != nil {
-		t.Error(err)
-	}
-	if accountEntry != nil {
-		t.Fatal("got account entry non-nil for removal, want account entry nil")
-	}
-}
-
-func TestGetAccountEntryNotRemoved(t *testing.T) {
-	wantAddress := "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"
-	accountID, err := xdr.AddressToAccountId(wantAddress)
-	if err != nil {
-		t.Error(err)
-	}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-		State: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
-				Type: xdr.LedgerEntryTypeAccount,
-				Account: &xdr.AccountEntry{
-					AccountId: accountID,
-				},
-			},
-		},
-	}
-	accountEntry, err := getAccountEntry(&change)
-	if err != nil {
-		t.Error(err)
-	}
-	gotAddress := accountEntry.AccountId.Address()
-	if gotAddress != wantAddress {
-		t.Fatalf("got address %s, want address %s", gotAddress, wantAddress)
-	}
-}
-
-func TestMakeBalanceNotChanged(t *testing.T) {
-	wantBalance := uint32(999)
-	state := accountState{
-		balance: wantBalance,
-	}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-		Removed: &xdr.LedgerKey{
-			Type:    xdr.LedgerEntryTypeAccount,
-			Account: &xdr.LedgerKeyAccount{},
-		},
-	}
-	gotBalance, err := makeBalance(&state, &change)
-	if err != nil {
-		t.Error(err)
-	}
-	if gotBalance != wantBalance {
-		t.Fatalf("got balance %d, want balance %d", gotBalance, wantBalance)
-	}
-
-}
-
-func TestMakeBalanceChanged(t *testing.T) {
-	originalBalance := uint32(111)
-	wantBalance := uint32(222)
-	state := accountState{
-		balance: originalBalance,
-	}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-		State: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
-				Type: xdr.LedgerEntryTypeAccount,
-				Account: &xdr.AccountEntry{
-					Balance: xdr.Int64(wantBalance),
-				},
-			},
-		},
-	}
-	gotBalance, err := makeBalance(&state, &change)
-	if err != nil {
-		t.Error(err)
-	}
-	if gotBalance != wantBalance {
-		t.Fatalf("got balance %d, want balance %d", gotBalance, wantBalance)
-	}
-}
-
-func TestMakeSignersNotAccount(t *testing.T) {
-	wantSigners := []signer{}
-	wantSigners = append(wantSigners, signer{address: "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF", weight: uint32(1)})
-	state := accountState{
-		signers: wantSigners,
-	}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-		Removed: &xdr.LedgerKey{
-			Type:    xdr.LedgerEntryTypeAccount,
-			Account: &xdr.LedgerKeyAccount{},
-		},
-	}
-	gotSigners, err := makeSigners(&state, &change)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !assert.Equal(t, gotSigners, wantSigners) {
-		t.Fatalf("got signers %v, want signers %v", gotSigners, wantSigners)
-	}
-}
-
-func TestMakeSignersNotChanged(t *testing.T) {
-	wantAddress := "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"
-	wantSigners := []signer{}
-	wantSigners = append(wantSigners, signer{address: wantAddress, weight: uint32(1)})
-
-	xdrSigners := []xdr.Signer{}
-	signerKeyPtr := &xdr.SignerKey{}
-	err := signerKeyPtr.SetAddress(wantAddress)
-	if err != nil {
-		t.Error(err)
-	}
-	xdrSigner := xdr.Signer{
-		Key:    *signerKeyPtr,
-		Weight: xdr.Uint32(1),
-	}
-	xdrSigners = append(xdrSigners, xdrSigner)
-
-	state := accountState{
-		signers: wantSigners,
-	}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-		State: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
-				Type: xdr.LedgerEntryTypeAccount,
-				Account: &xdr.AccountEntry{
-					Signers: xdrSigners,
-				},
-			},
-		},
-	}
-	gotSigners, err := makeSigners(&state, &change)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !assert.Equal(t, gotSigners, wantSigners) {
-		t.Fatalf("got signers %v, want signers %v", gotSigners, wantSigners)
-	}
-}
-
-func TestMakeSignersChanged(t *testing.T) {
-	originalAddress := "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"
-	originalSigners := []signer{}
-	originalSigners = append(originalSigners, signer{address: originalAddress, weight: uint32(1)})
-
-	state := accountState{
-		signers: originalSigners,
-	}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-		State: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
+var signersTests = []struct {
+	testName    string
+	wantSigners []signer
+	change      xdr.LedgerEntryChange
+}{
+	{"NotAccount",
+		[]signer{{address: wantAddress, weight: uint32(1)}},
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+			Removed: &xdr.LedgerKey{
 				Type:    xdr.LedgerEntryTypeAccount,
-				Account: &xdr.AccountEntry{},
+				Account: &xdr.LedgerKeyAccount{},
+			},
+		}},
+	{"NotChanged",
+		[]signer{{address: wantAddress, weight: uint32(1)}},
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type: xdr.LedgerEntryTypeAccount,
+					Account: &xdr.AccountEntry{
+						Signers: []xdr.Signer{{
+							Key:    xdr.MustSigner(wantAddress),
+							Weight: xdr.Uint32(1),
+						}},
+					},
+				},
 			},
 		},
-	}
-	gotSigners, err := makeSigners(&state, &change)
-	if err != nil {
-		t.Error(err)
-	}
-	if gotSigners != nil {
-		t.Fatalf("got signers %v, want signers nil", gotSigners)
+	},
+}
+
+func TestSigners(t *testing.T) {
+	for _, tt := range signersTests {
+		t.Run(tt.testName, func(t *testing.T) {
+			originalSigners := []signer{{address: wantAddress, weight: uint32(1)}}
+			state := accountState{signers: originalSigners}
+			gotSigners, err := makeSigners(&state, &tt.change)
+			if err != nil {
+				t.Error(err)
+			}
+			if tt.wantSigners == nil {
+				if gotSigners != nil {
+					t.Fatalf("got signers %v, want signers nil", gotSigners)
+				}
+			} else {
+				if !assert.Equal(t, gotSigners, tt.wantSigners) {
+					t.Fatalf("got signers %v, want signers %v", gotSigners, tt.wantSigners)
+				}
+			}
+		})
 	}
 }
 
-func TestMakeTrustlinesNotTrustline(t *testing.T) {
-	wantTrustlines := make(map[string]trustline)
-	asset := "USD"
-	newTrustline := trustline{
-		asset:   asset,
-		balance: uint32(10),
-		limit:   uint32(100),
-	}
-	wantTrustlines[asset] = newTrustline
+var trustlineKey = fmt.Sprintf("credit_alphanum4/USD/%s", wantAddress)
 
-	state := accountState{
-		trustlines: wantTrustlines,
-	}
-
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-		State: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
-				Type:    xdr.LedgerEntryTypeAccount,
-				Account: &xdr.AccountEntry{},
+var trustlinesTests = []struct {
+	testName       string
+	wantTrustlines map[string]trustline
+	change         xdr.LedgerEntryChange
+}{
+	{"NotTrustline",
+		map[string]trustline{
+			trustlineKey: trustline{
+				asset:   trustlineKey,
+				balance: uint32(0),
+				limit:   uint32(100),
+			}},
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type:    xdr.LedgerEntryTypeAccount,
+					Account: &xdr.AccountEntry{},
+				},
 			},
 		},
-	}
-	gotTrustlines, err := makeTrustlines(&state, &change)
-	if err != nil {
-		t.Error(err)
-	}
-	if !assert.Equal(t, gotTrustlines, wantTrustlines) {
-		t.Fatalf("got trustlines %v, want trustlines %v", gotTrustlines, wantTrustlines)
-	}
-}
-
-func TestMakeTrustlinesRemoved(t *testing.T) {
-	originalTrustlines := make(map[string]trustline)
-	assetCode := "USD"
-	assetIssuer := "GBDT3K42LOPSHNAEHEJ6AVPADIJ4MAR64QEKKW2LQPBSKLYD22KUEH4P"
-	newTrustline := trustline{
-		asset:   assetCode,
-		balance: uint32(10),
-		limit:   uint32(100),
-	}
-	asset := xdr.MustNewCreditAsset(assetCode, assetIssuer)
-
-	originalTrustlines[asset.String()] = newTrustline
-	state := accountState{trustlines: originalTrustlines}
-
-	// wantAddress := "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"
-	assetIssuerAccountID, err := xdr.AddressToAccountId(assetIssuer)
-	if err != nil {
-		t.Error(err)
-	}
-
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-		Removed: &xdr.LedgerKey{
-			Type: xdr.LedgerEntryTypeTrustline,
-			TrustLine: &xdr.LedgerKeyTrustLine{
-				AccountId: assetIssuerAccountID,
-				Asset:     asset,
-			},
-		},
-	}
-	wantTrustlines := make(map[string]trustline)
-	gotTrustlines, err := makeTrustlines(&state, &change)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !assert.Equal(t, wantTrustlines, gotTrustlines) {
-		t.Fatalf("got trustlines %v, want nil trustlines", gotTrustlines)
-	}
-}
-
-func TestMakeTrustlinesChanged(t *testing.T) {
-	assetCode := "USD"
-	assetIssuer := "GBDT3K42LOPSHNAEHEJ6AVPADIJ4MAR64QEKKW2LQPBSKLYD22KUEH4P"
-	asset := xdr.MustNewCreditAsset(assetCode, assetIssuer)
-	assetString := asset.String()
-
-	originalBalance := 10
-	limit := 100
-	originalTrustline := trustline{
-		asset:   assetString,
-		balance: uint32(originalBalance),
-		limit:   uint32(limit),
-	}
-	originalTrustlines := make(map[string]trustline)
-	originalTrustlines[assetString] = originalTrustline
-	state := accountState{trustlines: originalTrustlines}
-
-	assetIssuerAccountID, err := xdr.AddressToAccountId(assetIssuer)
-	if err != nil {
-		t.Error(err)
-	}
-	newBalance := 20
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-		State: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
+	},
+	{"Removed",
+		map[string]trustline{},
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+			Removed: &xdr.LedgerKey{
 				Type: xdr.LedgerEntryTypeTrustline,
-				TrustLine: &xdr.TrustLineEntry{
-					AccountId: assetIssuerAccountID,
-					Asset:     asset,
-					Balance:   xdr.Int64(newBalance),
-					Limit:     xdr.Int64(limit),
+				TrustLine: &xdr.LedgerKeyTrustLine{
+					AccountId: xdr.MustAddress(wantAddress),
+					Asset:     xdr.MustNewCreditAsset("USD", wantAddress),
 				},
 			},
 		},
-	}
-
-	wantTrustlines := make(map[string]trustline)
-	newTrustline := trustline{
-		asset:   assetString,
-		balance: uint32(newBalance),
-		limit:   uint32(limit),
-	}
-	wantTrustlines[assetString] = newTrustline
-
-	gotTrustlines, err := makeTrustlines(&state, &change)
-	if err != nil {
-		t.Error(err)
-	}
-	if !assert.Equal(t, wantTrustlines, gotTrustlines) {
-		t.Fatalf("got trustlines %v, want trustlines %v", gotTrustlines, wantTrustlines)
-	}
-}
-
-func TestMakeDataNotData(t *testing.T) {
-	wantData := make(map[string][]byte)
-	wantData["key"] = []byte("value")
-	state := accountState{
-		data: wantData,
-	}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-		State: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
-				Type:    xdr.LedgerEntryTypeAccount,
-				Account: &xdr.AccountEntry{},
+	},
+	{"Changed",
+		map[string]trustline{
+			trustlineKey: trustline{
+				asset:   trustlineKey,
+				balance: uint32(20),
+				limit:   uint32(100),
+			}},
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type: xdr.LedgerEntryTypeTrustline,
+					TrustLine: &xdr.TrustLineEntry{
+						AccountId: xdr.MustAddress(wantAddress),
+						Asset:     xdr.MustNewCreditAsset("USD", wantAddress),
+						Balance:   xdr.Int64(20),
+						Limit:     xdr.Int64(100),
+					},
+				},
 			},
 		},
-	}
-	gotData, err := makeData(&state, &change)
-	if err != nil {
-		t.Error(err)
-	}
-	if !assert.Equal(t, wantData, gotData) {
-		t.Fatalf("got data %v, want data %v", gotData, wantData)
+	},
+}
+
+func TestTrustlines(t *testing.T) {
+	for _, tt := range trustlinesTests {
+		t.Run(tt.testName, func(t *testing.T) {
+			originalTrustlines := map[string]trustline{
+				trustlineKey: trustline{
+					asset:   trustlineKey,
+					balance: uint32(0),
+					limit:   uint32(100),
+				},
+			}
+			state := accountState{
+				trustlines: originalTrustlines,
+			}
+			gotTrustlines, err := makeTrustlines(&state, &tt.change)
+			if err != nil {
+				t.Error(err)
+			}
+			if !assert.Equal(t, tt.wantTrustlines, gotTrustlines) {
+				t.Fatalf("got trustlines %v, want trustlines %v", gotTrustlines, tt.wantTrustlines)
+			}
+		})
 	}
 }
 
-func TestMakeDataRemoved(t *testing.T) {
-	originalData := make(map[string][]byte)
-	dataName := "name"
-	originalData[dataName] = []byte("0")
-	state := accountState{
-		data: originalData,
-	}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-		Removed: &xdr.LedgerKey{
-			Type: xdr.LedgerEntryTypeData,
-			Data: &xdr.LedgerKeyData{
-				DataName: xdr.String64(dataName),
+var originalData = map[string][]byte{
+	"key": []byte("value"),
+}
+var dataTests = []struct {
+	testName string
+	wantData map[string][]byte
+	change   xdr.LedgerEntryChange
+}{
+	{"NotData",
+		originalData,
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type:    xdr.LedgerEntryTypeAccount,
+					Account: &xdr.AccountEntry{},
+				},
 			},
 		},
-	}
-	wantData := make(map[string][]byte)
-	gotData, err := makeData(&state, &change)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !assert.Equal(t, wantData, gotData) {
-		t.Fatalf("got data %v, want data %v", gotData, wantData)
-	}
-}
-
-func TestMakeDataChanged(t *testing.T) {
-	originalData := make(map[string][]byte)
-	originalDataName := "originalName"
-	originalDataValue := []byte("originalValue")
-	originalData[originalDataName] = originalDataValue
-	state := accountState{
-		data: originalData,
-	}
-
-	newDataName := "newName"
-	newDataValue := []byte("newValue")
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-		State: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
+	},
+	{"Removed",
+		map[string][]byte{},
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+			Removed: &xdr.LedgerKey{
 				Type: xdr.LedgerEntryTypeData,
-				Data: &xdr.DataEntry{
-					DataName:  xdr.String64(newDataName),
-					DataValue: xdr.DataValue(newDataValue),
+				Data: &xdr.LedgerKeyData{
+					DataName: xdr.String64("key"),
 				},
 			},
 		},
+	},
+	{"Changed",
+		map[string][]byte{"key": []byte("newValue")},
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type: xdr.LedgerEntryTypeData,
+					Data: &xdr.DataEntry{
+						DataName:  xdr.String64("key"),
+						DataValue: xdr.DataValue("newValue"),
+					},
+				},
+			},
+		},
+	},
+}
+
+func TestData(t *testing.T) {
+	for _, tt := range dataTests {
+		t.Run(tt.testName, func(t *testing.T) {
+
+			state := accountState{data: originalData}
+			gotData, err := makeData(&state, &tt.change)
+			if err != nil {
+				t.Error(err)
+			}
+			if !assert.Equal(t, tt.wantData, gotData) {
+				t.Fatalf("got data %v, want data %v", gotData, tt.wantData)
+			}
+		})
 	}
+}
 
-	wantData := make(map[string][]byte)
-	wantData[originalDataName] = originalDataValue
-	wantData[newDataName] = newDataValue
+var originalOffers = map[uint32]offer{1: offer{id: 1}}
+var offerTests = []struct {
+	testName   string
+	wantOffers map[uint32]offer
+	change     xdr.LedgerEntryChange
+}{
+	{"NotOffers",
+		originalOffers,
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type:    xdr.LedgerEntryTypeAccount,
+					Account: &xdr.AccountEntry{},
+				},
+			},
+		},
+	},
+	{"Removed",
+		map[uint32]offer{},
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+			Removed: &xdr.LedgerKey{
+				Type: xdr.LedgerEntryTypeOffer,
+				Offer: &xdr.LedgerKeyOffer{
+					OfferId: xdr.Int64(1),
+				},
+			},
+		},
+	},
+	{"Changed",
+		map[uint32]offer{1: offer{id: 1}, 2: offer{id: 2, seller: wantAddress, selling: "native", buying: "native"}},
+		xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type: xdr.LedgerEntryTypeOffer,
+					Offer: &xdr.OfferEntry{
+						OfferId:  xdr.Int64(2),
+						SellerId: xdr.MustAddress(wantAddress),
+					},
+				},
+			},
+		},
+	},
+}
 
-	gotData, err := makeData(&state, &change)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !assert.Equal(t, wantData, gotData) {
-		t.Fatalf("got data %v, want data %v", gotData, wantData)
+func TestOffers(t *testing.T) {
+	for _, tt := range offerTests {
+		t.Run(tt.testName, func(t *testing.T) {
+			originalOffers := map[uint32]offer{
+				1: offer{id: 1},
+			}
+			state := accountState{offers: originalOffers}
+			gotOffers, err := makeOffers(&state, &tt.change)
+			if err != nil {
+				t.Error(err)
+			}
+			if !assert.Equal(t, tt.wantOffers, gotOffers) {
+				t.Fatalf("got offers %v, want offers %v", gotOffers, tt.wantOffers)
+			}
+		})
 	}
 }

--- a/exp/hubble/schema_factory_test.go
+++ b/exp/hubble/schema_factory_test.go
@@ -12,487 +12,210 @@ import (
 
 const wantAddress = "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"
 
-var accountIDTests = []struct {
-	testName      string
-	state         *accountState
-	wantAccountID string
-	change        xdr.LedgerEntryChange
-}{
-	{"FromState",
-		&accountState{address: wantAddress},
-		wantAddress,
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-			State: &xdr.LedgerEntry{
-				Data: xdr.LedgerEntryData{
-					Type: xdr.LedgerEntryTypeAccount,
-				},
-			},
-		},
-	},
-	{"FromChange",
-		nil,
-		wantAddress,
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-			State: &xdr.LedgerEntry{
-				Data: xdr.LedgerEntryData{
-					Type: xdr.LedgerEntryTypeAccount,
-					Account: &xdr.AccountEntry{
+func TestMakeNewAccountStateSuccess(t *testing.T) {
+	var trustlineKey = fmt.Sprintf("credit_alphanum4/USD/%s", wantAddress)
+	var tests = []struct {
+		name      string
+		state     *accountState
+		change    *xdr.LedgerEntryChange
+		wantState *accountState
+	}{
+		{"AccountRemoved",
+			&accountState{address: wantAddress},
+			&xdr.LedgerEntryChange{
+				Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+				Removed: &xdr.LedgerKey{
+					Account: &xdr.LedgerKeyAccount{
 						AccountId: xdr.MustAddress(wantAddress),
 					},
 				},
 			},
+			nil,
 		},
-	},
-}
-
-func TestMakeAccount(t *testing.T) {
-	for _, tt := range accountIDTests {
-		t.Run(tt.testName, func(t *testing.T) {
-			var (
-				gotAccountID string
-				err          error
-			)
-			if tt.state == nil {
-				gotAccountID, err = makeAccountID(&tt.change)
-			} else {
-				gotAccountID, err = makeAccountID(&tt.change, *tt.state)
-			}
-			if err != nil {
-				t.Error(err)
-			}
-			if !assert.Equal(t, tt.wantAccountID, gotAccountID) {
-				t.Fatalf("got account id %s, want account id %s", tt.wantAccountID, gotAccountID)
-			}
-		})
-	}
-}
-
-var seqnumTests = []struct {
-	testName   string
-	wantSeqnum uint32
-	change     xdr.LedgerEntryChange
-}{
-	{"Changed",
-		2947523,
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-			State: &xdr.LedgerEntry{
-				LastModifiedLedgerSeq: xdr.Uint32(2947523),
-				Data: xdr.LedgerEntryData{
-					Type:    xdr.LedgerEntryTypeAccount,
-					Account: &xdr.AccountEntry{},
+		{"AccountIDFromState",
+			&accountState{address: wantAddress},
+			makeLedgerEntryChangeAccount(&xdr.AccountEntry{}),
+			&accountState{address: wantAddress},
+		},
+		{"AccountIDFromChange",
+			nil,
+			makeLedgerEntryChangeAccount(&xdr.AccountEntry{AccountId: xdr.MustAddress(wantAddress)}),
+			&accountState{address: wantAddress},
+		},
+		{"SeqnumNotChanged",
+			&accountState{seqnum: 11},
+			&xdr.LedgerEntryChange{
+				Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+				State: &xdr.LedgerEntry{
+					LastModifiedLedgerSeq: xdr.Uint32(11),
+					Data: xdr.LedgerEntryData{
+						Type:    xdr.LedgerEntryTypeAccount,
+						Account: &xdr.AccountEntry{},
+					},
 				},
 			},
+			&accountState{seqnum: 11},
 		},
-	},
-	{"Removed",
-		0,
-		xdr.LedgerEntryChange{
-			Type:  xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-			State: &xdr.LedgerEntry{},
+		{"SeqnumChanged",
+			&accountState{seqnum: 11},
+			&xdr.LedgerEntryChange{
+				Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+				State: &xdr.LedgerEntry{
+					LastModifiedLedgerSeq: xdr.Uint32(2947523),
+					Data: xdr.LedgerEntryData{
+						Type:    xdr.LedgerEntryTypeAccount,
+						Account: &xdr.AccountEntry{},
+					},
+				},
+			},
+			&accountState{seqnum: 2947523},
 		},
-	},
-}
-
-func TestMakeSeqnum(t *testing.T) {
-	for _, tt := range seqnumTests {
-		t.Run(string(tt.testName), func(t *testing.T) {
-			state := accountState{seqnum: 11}
-			gotSeqnum, err := makeSeqnum(&state, &tt.change)
-			if err != nil {
-				t.Error(err)
-			}
-			if !assert.Equal(t, tt.wantSeqnum, gotSeqnum) {
-				t.Fatalf("got seqnum %d, want seqnum %d", gotSeqnum, tt.wantSeqnum)
-			}
-		})
-	}
-}
-
-var accountEntryTests = []struct {
-	testName  string
-	wantEntry *xdr.AccountEntry
-	change    xdr.LedgerEntryChange
-}{
-	{"NotAccount",
-		nil,
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-			State: &xdr.LedgerEntry{
-				Data: xdr.LedgerEntryData{
+		{"BalanceChanged",
+			&accountState{balance: 222},
+			makeLedgerEntryChangeAccount(&xdr.AccountEntry{Balance: xdr.Int64(111)}),
+			&accountState{balance: 111},
+		},
+		{"SignersNotChanged",
+			&accountState{signers: []signer{{address: wantAddress, weight: uint32(1)}}},
+			makeLedgerEntryChangeAccount(&xdr.AccountEntry{
+				Signers: []xdr.Signer{{
+					Key:    xdr.MustSigner(wantAddress),
+					Weight: xdr.Uint32(1),
+				}},
+			}),
+			&accountState{signers: []signer{{address: wantAddress, weight: uint32(1)}}},
+		},
+		{"SignersChanged",
+			&accountState{signers: []signer{{address: wantAddress, weight: uint32(1)}}},
+			makeLedgerEntryChangeAccount(&xdr.AccountEntry{
+				Signers: []xdr.Signer{{
+					Key:    xdr.MustSigner(wantAddress),
+					Weight: xdr.Uint32(2),
+				}},
+			}),
+			&accountState{signers: []signer{{address: wantAddress, weight: uint32(2)}}},
+		},
+		{"TrustlinesRemoved",
+			&accountState{trustlines: map[string]trustline{
+				trustlineKey: trustline{asset: trustlineKey, balance: uint32(0), limit: uint32(100)}},
+			},
+			&xdr.LedgerEntryChange{
+				Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+				Removed: &xdr.LedgerKey{
+					Type: xdr.LedgerEntryTypeTrustline,
+					TrustLine: &xdr.LedgerKeyTrustLine{
+						AccountId: xdr.MustAddress(wantAddress),
+						Asset:     xdr.MustNewCreditAsset("USD", wantAddress),
+					},
+				},
+			},
+			&accountState{trustlines: map[string]trustline{}},
+		},
+		{"TrustlinesChanged",
+			&accountState{trustlines: map[string]trustline{
+				trustlineKey: trustline{asset: trustlineKey, balance: uint32(10), limit: uint32(100)}},
+			},
+			makeLedgerEntryChangeTrustline(wantAddress, "USD", 20, 100),
+			&accountState{trustlines: map[string]trustline{
+				trustlineKey: trustline{asset: trustlineKey, balance: uint32(20), limit: uint32(100)}},
+			},
+		},
+		{"DataRemoved",
+			&accountState{data: map[string][]byte{"key": []byte("value")}},
+			&xdr.LedgerEntryChange{
+				Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+				Removed: &xdr.LedgerKey{
 					Type: xdr.LedgerEntryTypeData,
-					Data: &xdr.DataEntry{
-						AccountId: xdr.MustAddress("GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"),
-						DataName:  xdr.String64("name"),
-						DataValue: xdr.DataValue([]byte("value")),
+					Data: &xdr.LedgerKeyData{
+						DataName: xdr.String64("key"),
 					},
 				},
 			},
+			&accountState{data: map[string][]byte{}},
 		},
-	},
-	{"Removed",
-		nil,
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-			Removed: &xdr.LedgerKey{
-				Type: xdr.LedgerEntryTypeAccount,
-				Account: &xdr.LedgerKeyAccount{
-					AccountId: xdr.MustAddress("GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"),
-				},
-			},
+		{"DataChanged",
+			&accountState{data: map[string][]byte{"key": []byte("old")}},
+			makeLedgerEntryChangeData(wantAddress, "key", "new"),
+			&accountState{data: map[string][]byte{"key": []byte("new")}},
 		},
-	},
-	{"NotRemoved",
-		&xdr.AccountEntry{AccountId: xdr.MustAddress(wantAddress)},
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-			State: &xdr.LedgerEntry{
-				Data: xdr.LedgerEntryData{
-					Type: xdr.LedgerEntryTypeAccount,
-					Account: &xdr.AccountEntry{
-						AccountId: xdr.MustAddress(wantAddress),
+		{"OffersRemoved",
+			&accountState{offers: map[uint32]offer{1: offer{id: 1}}},
+			&xdr.LedgerEntryChange{
+				Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+				Removed: &xdr.LedgerKey{
+					Type: xdr.LedgerEntryTypeOffer,
+					Offer: &xdr.LedgerKeyOffer{
+						OfferId: xdr.Int64(1),
 					},
 				},
 			},
+			&accountState{offers: map[uint32]offer{}},
 		},
-	},
+		{"OffersChanged",
+			&accountState{offers: map[uint32]offer{1: offer{id: 1}}},
+			makeLedgerEntryChangeOffer(2, wantAddress),
+			&accountState{offers: map[uint32]offer{
+				1: offer{id: 1}, 2: offer{id: 2, seller: wantAddress, selling: "native", buying: "native"}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotState, err := makeNewAccountState(tt.state, tt.change)
+			if !assert.NoError(t, err) {
+				return
+			}
+			if !assert.Equal(t, tt.wantState, gotState) {
+				return
+			}
+		})
+	}
 }
 
 func TestGetAccountEntry(t *testing.T) {
+	var accountEntryTests = []struct {
+		name      string
+		change    *xdr.LedgerEntryChange
+		wantEntry *xdr.AccountEntry
+	}{
+		{"NotAccount",
+			makeLedgerEntryChangeData(wantAddress, "name", "value"),
+			nil,
+		},
+		{"Removed",
+			&xdr.LedgerEntryChange{
+				Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+				Removed: &xdr.LedgerKey{
+					Type: xdr.LedgerEntryTypeAccount,
+					Account: &xdr.LedgerKeyAccount{
+						AccountId: xdr.MustAddress("GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"),
+					},
+				},
+			},
+			nil,
+		},
+		{"NotRemoved",
+			makeLedgerEntryChangeAccount(&xdr.AccountEntry{AccountId: xdr.MustAddress(wantAddress)}),
+			&xdr.AccountEntry{AccountId: xdr.MustAddress(wantAddress)},
+		},
+	}
+
 	for _, tt := range accountEntryTests {
-		t.Run(string(tt.testName), func(t *testing.T) {
-			gotEntry, err := getAccountEntry(&tt.change)
-			if err != nil {
-				t.Error(err)
+		t.Run(tt.name, func(t *testing.T) {
+			gotEntry, err := getAccountEntry(tt.change)
+			if !assert.NoError(t, err) {
+				return
 			}
 			if tt.wantEntry == nil {
-				if gotEntry != nil {
-					t.Fatal("got account entry non-nil, want account entry nil")
+				if !assert.Nil(t, gotEntry) {
+					return
 				}
-			} else {
-				gotAddress := gotEntry.AccountId.Address()
-				wantAddress := tt.wantEntry.AccountId.Address()
-				if !assert.Equal(t, wantAddress, gotAddress) {
-					t.Fatalf("got address %s, want address %s", gotAddress, wantAddress)
-				}
+				return
 			}
-		})
-	}
-}
-
-var balanceTests = []struct {
-	testName    string
-	wantBalance uint32
-	change      xdr.LedgerEntryChange
-}{
-	{"NotChanged",
-		uint32(111),
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-			Removed: &xdr.LedgerKey{
-				Type:    xdr.LedgerEntryTypeAccount,
-				Account: &xdr.LedgerKeyAccount{},
-			},
-		},
-	},
-	{"Changed",
-		uint32(222),
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-			State: &xdr.LedgerEntry{
-				Data: xdr.LedgerEntryData{
-					Type: xdr.LedgerEntryTypeAccount,
-					Account: &xdr.AccountEntry{
-						Balance: xdr.Int64(222),
-					},
-				},
-			},
-		},
-	},
-}
-
-func TestMakeBalance(t *testing.T) {
-	for _, tt := range balanceTests {
-		t.Run(tt.testName, func(t *testing.T) {
-			state := accountState{balance: uint32(111)}
-			gotBalance, err := makeBalance(&state, &tt.change)
-			if err != nil {
-				t.Error(err)
-			}
-			if !assert.Equal(t, tt.wantBalance, gotBalance) {
-				t.Fatalf("got balance %d, want balance %d", gotBalance, tt.wantBalance)
-			}
-		})
-	}
-}
-
-var signersTests = []struct {
-	testName    string
-	wantSigners []signer
-	change      xdr.LedgerEntryChange
-}{
-	{"NotAccount",
-		[]signer{{address: wantAddress, weight: uint32(1)}},
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-			Removed: &xdr.LedgerKey{
-				Type:    xdr.LedgerEntryTypeAccount,
-				Account: &xdr.LedgerKeyAccount{},
-			},
-		}},
-	{"NotChanged",
-		[]signer{{address: wantAddress, weight: uint32(1)}},
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-			State: &xdr.LedgerEntry{
-				Data: xdr.LedgerEntryData{
-					Type: xdr.LedgerEntryTypeAccount,
-					Account: &xdr.AccountEntry{
-						Signers: []xdr.Signer{{
-							Key:    xdr.MustSigner(wantAddress),
-							Weight: xdr.Uint32(1),
-						}},
-					},
-				},
-			},
-		},
-	},
-}
-
-func TestSigners(t *testing.T) {
-	for _, tt := range signersTests {
-		t.Run(tt.testName, func(t *testing.T) {
-			originalSigners := []signer{{address: wantAddress, weight: uint32(1)}}
-			state := accountState{signers: originalSigners}
-			gotSigners, err := makeSigners(&state, &tt.change)
-			if err != nil {
-				t.Error(err)
-			}
-			if tt.wantSigners == nil {
-				if gotSigners != nil {
-					t.Fatalf("got signers %v, want signers nil", gotSigners)
-				}
-			} else {
-				if !assert.Equal(t, gotSigners, tt.wantSigners) {
-					t.Fatalf("got signers %v, want signers %v", gotSigners, tt.wantSigners)
-				}
-			}
-		})
-	}
-}
-
-var trustlineKey = fmt.Sprintf("credit_alphanum4/USD/%s", wantAddress)
-
-var trustlinesTests = []struct {
-	testName       string
-	wantTrustlines map[string]trustline
-	change         xdr.LedgerEntryChange
-}{
-	{"NotTrustline",
-		map[string]trustline{
-			trustlineKey: trustline{
-				asset:   trustlineKey,
-				balance: uint32(0),
-				limit:   uint32(100),
-			}},
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-			State: &xdr.LedgerEntry{
-				Data: xdr.LedgerEntryData{
-					Type:    xdr.LedgerEntryTypeAccount,
-					Account: &xdr.AccountEntry{},
-				},
-			},
-		},
-	},
-	{"Removed",
-		map[string]trustline{},
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-			Removed: &xdr.LedgerKey{
-				Type: xdr.LedgerEntryTypeTrustline,
-				TrustLine: &xdr.LedgerKeyTrustLine{
-					AccountId: xdr.MustAddress(wantAddress),
-					Asset:     xdr.MustNewCreditAsset("USD", wantAddress),
-				},
-			},
-		},
-	},
-	{"Changed",
-		map[string]trustline{
-			trustlineKey: trustline{
-				asset:   trustlineKey,
-				balance: uint32(20),
-				limit:   uint32(100),
-			}},
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-			State: &xdr.LedgerEntry{
-				Data: xdr.LedgerEntryData{
-					Type: xdr.LedgerEntryTypeTrustline,
-					TrustLine: &xdr.TrustLineEntry{
-						AccountId: xdr.MustAddress(wantAddress),
-						Asset:     xdr.MustNewCreditAsset("USD", wantAddress),
-						Balance:   xdr.Int64(20),
-						Limit:     xdr.Int64(100),
-					},
-				},
-			},
-		},
-	},
-}
-
-func TestTrustlines(t *testing.T) {
-	for _, tt := range trustlinesTests {
-		t.Run(tt.testName, func(t *testing.T) {
-			originalTrustlines := map[string]trustline{
-				trustlineKey: trustline{
-					asset:   trustlineKey,
-					balance: uint32(0),
-					limit:   uint32(100),
-				},
-			}
-			state := accountState{
-				trustlines: originalTrustlines,
-			}
-			gotTrustlines, err := makeTrustlines(&state, &tt.change)
-			if err != nil {
-				t.Error(err)
-			}
-			if !assert.Equal(t, tt.wantTrustlines, gotTrustlines) {
-				t.Fatalf("got trustlines %v, want trustlines %v", gotTrustlines, tt.wantTrustlines)
-			}
-		})
-	}
-}
-
-var originalData = map[string][]byte{
-	"key": []byte("value"),
-}
-var dataTests = []struct {
-	testName string
-	wantData map[string][]byte
-	change   xdr.LedgerEntryChange
-}{
-	{"NotData",
-		originalData,
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-			State: &xdr.LedgerEntry{
-				Data: xdr.LedgerEntryData{
-					Type:    xdr.LedgerEntryTypeAccount,
-					Account: &xdr.AccountEntry{},
-				},
-			},
-		},
-	},
-	{"Removed",
-		map[string][]byte{},
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-			Removed: &xdr.LedgerKey{
-				Type: xdr.LedgerEntryTypeData,
-				Data: &xdr.LedgerKeyData{
-					DataName: xdr.String64("key"),
-				},
-			},
-		},
-	},
-	{"Changed",
-		map[string][]byte{"key": []byte("newValue")},
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-			State: &xdr.LedgerEntry{
-				Data: xdr.LedgerEntryData{
-					Type: xdr.LedgerEntryTypeData,
-					Data: &xdr.DataEntry{
-						DataName:  xdr.String64("key"),
-						DataValue: xdr.DataValue("newValue"),
-					},
-				},
-			},
-		},
-	},
-}
-
-func TestData(t *testing.T) {
-	for _, tt := range dataTests {
-		t.Run(tt.testName, func(t *testing.T) {
-
-			state := accountState{data: originalData}
-			gotData, err := makeData(&state, &tt.change)
-			if err != nil {
-				t.Error(err)
-			}
-			if !assert.Equal(t, tt.wantData, gotData) {
-				t.Fatalf("got data %v, want data %v", gotData, tt.wantData)
-			}
-		})
-	}
-}
-
-var originalOffers = map[uint32]offer{1: offer{id: 1}}
-var offerTests = []struct {
-	testName   string
-	wantOffers map[uint32]offer
-	change     xdr.LedgerEntryChange
-}{
-	{"NotOffers",
-		originalOffers,
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-			State: &xdr.LedgerEntry{
-				Data: xdr.LedgerEntryData{
-					Type:    xdr.LedgerEntryTypeAccount,
-					Account: &xdr.AccountEntry{},
-				},
-			},
-		},
-	},
-	{"Removed",
-		map[uint32]offer{},
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-			Removed: &xdr.LedgerKey{
-				Type: xdr.LedgerEntryTypeOffer,
-				Offer: &xdr.LedgerKeyOffer{
-					OfferId: xdr.Int64(1),
-				},
-			},
-		},
-	},
-	{"Changed",
-		map[uint32]offer{1: offer{id: 1}, 2: offer{id: 2, seller: wantAddress, selling: "native", buying: "native"}},
-		xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-			State: &xdr.LedgerEntry{
-				Data: xdr.LedgerEntryData{
-					Type: xdr.LedgerEntryTypeOffer,
-					Offer: &xdr.OfferEntry{
-						OfferId:  xdr.Int64(2),
-						SellerId: xdr.MustAddress(wantAddress),
-					},
-				},
-			},
-		},
-	},
-}
-
-func TestOffers(t *testing.T) {
-	for _, tt := range offerTests {
-		t.Run(tt.testName, func(t *testing.T) {
-			originalOffers := map[uint32]offer{
-				1: offer{id: 1},
-			}
-			state := accountState{offers: originalOffers}
-			gotOffers, err := makeOffers(&state, &tt.change)
-			if err != nil {
-				t.Error(err)
-			}
-			if !assert.Equal(t, tt.wantOffers, gotOffers) {
-				t.Fatalf("got offers %v, want offers %v", gotOffers, tt.wantOffers)
+			gotAddress := gotEntry.AccountId.Address()
+			wantAddress := tt.wantEntry.AccountId.Address()
+			if !assert.Equal(t, wantAddress, gotAddress) {
+				return
 			}
 		})
 	}

--- a/exp/hubble/schema_factory_test.go
+++ b/exp/hubble/schema_factory_test.go
@@ -172,43 +172,7 @@ func TestMakeNewAccountStateSuccess(t *testing.T) {
 	}
 }
 
-func TestMakeNewAccountStateErrors(t *testing.T) {
-	var accountStateTests = []struct {
-		name      string
-		state     *accountState
-		change    *xdr.LedgerEntryChange
-		wantState *accountState // TODO: May not need this.
-	}{
-		// TODO: Test `makeAccountIDFromChange`, Account.
-		// TODO: Test `makeAccountIDFromChange`, Trustline.
-		// TODO: Test `makeAccountIDFromChange`, Offer.
-		// TODO: Test `makeAccountIDFromChange`, Data.
-		// TODO: Test `makeSeqnum`, `getLedgerEntry` failure.
-		// TODO: Test `makeBalance`, `getAccountEntry` failure.
-		// TODO: Test `makeTrustlines`, `change.GetRemoved` failure.
-		// TODO: Test `makeTrustlines`, `getLedgerEntry` failure.
-		// TODO: Test `makeTrustlines`, `entry.Data.GetTrustline()` failure.
-		// TODO: Test `makeOffers`, `change.GetRemoved` failure.
-		// TODO: Test `makeOffers`, `getLedgerEntry` failure.
-		// TODO: Test `makeOffers`, `entry.Data.GetOffer()` failure.
-		// TODO: Test `makeData`, `change.GetRemoved` failure.
-		// TODO: Test `makeData`, `getLedgerEntry` failure.
-		// TODO: Test `makeData`, `entry.Data.GetData()` failure.`
-	}
-
-	for _, tt := range accountStateTests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotState, err := makeNewAccountState(tt.state, tt.change)
-			if assert.NoError(t, err) {
-				return
-			}
-			// TODO: Check if we need this assert.
-			if !assert.Equal(t, tt.wantState, gotState) {
-				return
-			}
-		})
-	}
-}
+// TODO: Add tests for error cases.
 
 func TestGetAccountEntry(t *testing.T) {
 	var accountEntryTests = []struct {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR rewrites the tests of the factory functions for our Elasticsearch schema to be table-based.

### Why

Table-based tests are more appropriate for testing the existence, or lack thereof, of errors. That is the primary goal of these tests.

### Known limitations

N/A
