### PR TITLE
services/horizon: Improve performance of AssetStats processor

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -9,6 +9,7 @@ bumps.  A breaking change will get clearly notified in this log.
 ## v0.24.0
 
 * Rename `OperationFeeStats` to `FeeStats` ([#1950](https://github.com/stellar/go/pull/1950))
+* Improved performance of asset stats processor ([#1987](https://github.com/stellar/go/pull/1987))
 
 ## v0.23.1
 

--- a/services/horizon/internal/expingest/processors/database_processor.go
+++ b/services/horizon/internal/expingest/processors/database_processor.go
@@ -320,10 +320,10 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 					))
 				}
 
-				var err error
-				rowsAffected, err = p.AssetStatsQ.InsertAssetStat(delta)
-				if err != nil {
-					return errors.Wrap(err, "could not insert asset stat")
+				var errInsert error
+				rowsAffected, errInsert = p.AssetStatsQ.InsertAssetStat(delta)
+				if errInsert != nil {
+					return errors.Wrap(errInsert, "could not insert asset stat")
 				}
 			} else {
 				statBalance, ok := new(big.Int).SetString(stat.Amount, 10)

--- a/services/horizon/internal/expingest/processors/database_processor.go
+++ b/services/horizon/internal/expingest/processors/database_processor.go
@@ -191,6 +191,8 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 	}()
 	defer w.Close()
 
+	p.AssetStatSet = AssetStatSet{}
+
 	actionHandlers := map[DatabaseProcessorActionType]func(change io.Change) error{
 		Accounts:          p.processLedgerAccounts,
 		AccountsForSigner: p.processLedgerAccountSigners,
@@ -288,6 +290,97 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 			return nil
 		default:
 			continue
+		}
+	}
+
+	// Asset stats
+	if p.Action == All || p.Action == TrustLines {
+		assetStatsDeltas := p.AssetStatSet.All()
+		for _, delta := range assetStatsDeltas {
+			var rowsAffected int64
+
+			stat, err := p.AssetStatsQ.GetAssetStat(
+				delta.AssetType,
+				delta.AssetCode,
+				delta.AssetIssuer,
+			)
+			assetStatNotFound := err == sql.ErrNoRows
+			if !assetStatNotFound && err != nil {
+				return errors.Wrap(err, "could not fetch asset stat from db")
+			}
+
+			if assetStatNotFound {
+				// Insert
+				if delta.NumAccounts < 0 {
+					return verify.NewStateError(errors.Errorf(
+						"NumAccounts negative but DB entry does not exist for asset: %s %s %s",
+						delta.AssetType,
+						delta.AssetCode,
+						delta.AssetIssuer,
+					))
+				}
+
+				var err error
+				rowsAffected, err = p.AssetStatsQ.InsertAssetStat(delta)
+				if err != nil {
+					return errors.Wrap(err, "could not insert asset stat")
+				}
+			} else {
+				statBalance, ok := new(big.Int).SetString(stat.Amount, 10)
+				if !ok {
+					return errors.New("Error parsing: " + stat.Amount)
+				}
+
+				deltaBalance, ok := new(big.Int).SetString(delta.Amount, 10)
+				if !ok {
+					return errors.New("Error parsing: " + stat.Amount)
+				}
+
+				// statBalance = statBalance + deltaBalance
+				statBalance.Add(statBalance, deltaBalance)
+				statAccounts := stat.NumAccounts + delta.NumAccounts
+
+				if statAccounts == 0 {
+					// Remove stats
+					if statBalance.Cmp(big.NewInt(0)) != 0 {
+						return verify.NewStateError(errors.Errorf(
+							"Removing asset stat by final amount non-zero for: %s %s %s",
+							delta.AssetType,
+							delta.AssetCode,
+							delta.AssetIssuer,
+						))
+					}
+					rowsAffected, err = p.AssetStatsQ.RemoveAssetStat(
+						delta.AssetType,
+						delta.AssetCode,
+						delta.AssetIssuer,
+					)
+					if err != nil {
+						return errors.Wrap(err, "could not remove asset stat")
+					}
+				} else {
+					// Update
+					rowsAffected, err = p.AssetStatsQ.UpdateAssetStat(history.ExpAssetStat{
+						AssetType:   delta.AssetType,
+						AssetCode:   delta.AssetCode,
+						AssetIssuer: delta.AssetIssuer,
+						Amount:      statBalance.String(),
+						NumAccounts: statAccounts,
+					})
+					if err != nil {
+						return errors.Wrap(err, "could not update asset stat")
+					}
+				}
+			}
+
+			if rowsAffected != 1 {
+				return verify.NewStateError(errors.Errorf(
+					"No rows affected when adjusting asset stat for asset: %s %s %s",
+					delta.AssetType,
+					delta.AssetCode,
+					delta.AssetIssuer,
+				))
+			}
 		}
 	}
 
@@ -605,102 +698,9 @@ func (p *DatabaseProcessor) adjustAssetStat(
 		return verify.NewStateError(errors.New("both pre and post trustlines cannot be nil"))
 	}
 
-	if deltaBalance == 0 && deltaAccounts == 0 {
-		return nil
-	}
-
-	var assetType xdr.AssetType
-	var assetIssuer, assetCode string
-	if err := trustline.Asset.Extract(&assetType, &assetCode, &assetIssuer); err != nil {
-		return errors.Wrap(err, "could not extract asset info from trustline")
-	}
-
-	stat, err := p.AssetStatsQ.GetAssetStat(assetType, assetCode, assetIssuer)
-	assetStatNotFound := err == sql.ErrNoRows
-	if !assetStatNotFound && err != nil {
-		return errors.Wrap(err, "could not fetch asset stat from db")
-	}
-
-	currentBalance := big.NewInt(0)
-	if assetStatNotFound {
-		stat.AssetType = assetType
-		stat.AssetCode = assetCode
-		stat.AssetIssuer = assetIssuer
-	} else {
-		_, ok := currentBalance.SetString(stat.Amount, 10)
-		if !ok {
-			return verify.NewStateError(errors.Errorf(
-				"Could not parse asset stat amount %s when processing trustline: %s %s",
-				stat.Amount,
-				trustline.AccountId.Address(),
-				trustline.Asset.String(),
-			))
-		}
-	}
-	currentBalance = currentBalance.Add(currentBalance, big.NewInt(int64(deltaBalance)))
-	stat.Amount = currentBalance.String()
-	stat.NumAccounts += deltaAccounts
-
-	if currentBalance.Cmp(big.NewInt(0)) < 0 {
-		return verify.NewStateError(errors.Errorf(
-			"Asset stat has negative amount %s when processing trustline: %s %s",
-			stat.Amount,
-			trustline.AccountId.Address(),
-			trustline.Asset.String(),
-		))
-	}
-
-	if stat.NumAccounts < 0 {
-		return verify.NewStateError(errors.Errorf(
-			"Asset stat has negative num accounts when processing trustline: %s %s",
-			trustline.AccountId.Address(),
-			trustline.Asset.String(),
-		))
-	}
-
-	var rowsAffected int64
-	if assetStatNotFound {
-		// deltaAccounts is 0 if we are updating an account
-		// deltaAccounts is < 0 if we are removing an account
-		// therefore if deltaAccounts <= 0 the asset stat must exist in the db
-		if deltaAccounts <= 0 {
-			return verify.NewStateError(errors.Errorf(
-				"Expected asset stat to exist when processing trustline: %s %s",
-				trustline.AccountId.Address(),
-				trustline.Asset.String(),
-			))
-		}
-		rowsAffected, err = p.AssetStatsQ.InsertAssetStat(stat)
-		if err != nil {
-			return errors.Wrap(err, "could not insert asset stat")
-		}
-	} else if stat.NumAccounts == 0 {
-		if currentBalance.Cmp(big.NewInt(0)) != 0 {
-			return verify.NewStateError(errors.Errorf(
-				"Expected asset stat with no accounts to have amount of 0 "+
-					"(amount was %s) when processing trustline: %s %s",
-				stat.Amount,
-				trustline.AccountId.Address(),
-				trustline.Asset.String(),
-			))
-		}
-		rowsAffected, err = p.AssetStatsQ.RemoveAssetStat(assetType, assetCode, assetIssuer)
-		if err != nil {
-			return errors.Wrap(err, "could not update asset stat")
-		}
-	} else {
-		rowsAffected, err = p.AssetStatsQ.UpdateAssetStat(stat)
-		if err != nil {
-			return errors.Wrap(err, "could not update asset stat")
-		}
-	}
-
-	if rowsAffected != 1 {
-		return verify.NewStateError(errors.Errorf(
-			"No rows affected when adjusting asset stat from trustline: %s %s",
-			trustline.AccountId.Address(),
-			trustline.Asset.String(),
-		))
+	err := p.AssetStatSet.AddDelta(trustline.Asset, int64(deltaBalance), deltaAccounts)
+	if err != nil {
+		return errors.Wrap(err, "error running AssetStatSet.AddDelta")
 	}
 	return nil
 }

--- a/services/horizon/internal/expingest/processors/main.go
+++ b/services/horizon/internal/expingest/processors/main.go
@@ -38,6 +38,8 @@ type DatabaseProcessor struct {
 	LedgersQ      history.QExpLedgers
 	Action        DatabaseProcessorActionType
 	IngestVersion int
+	// AssetStatSet is used in TrustLines processor
+	AssetStatSet AssetStatSet
 }
 
 // OrderbookProcessor is a processor (both state and ledger) that's responsible

--- a/services/horizon/internal/expingest/processors/trust_lines_processor_test.go
+++ b/services/horizon/internal/expingest/processors/trust_lines_processor_test.go
@@ -281,18 +281,6 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestInsertTrustLine() {
 		unauthorizedTrustline,
 		lastModifiedLedgerSeq,
 	).Return(int64(1), nil).Once()
-	s.mockAssetStatsQ.On("GetAssetStat",
-		xdr.AssetTypeAssetTypeCreditAlphanum4,
-		"EUR",
-		trustLineIssuer.Address(),
-	).Return(history.ExpAssetStat{}, sql.ErrNoRows).Once()
-	s.mockAssetStatsQ.On("InsertAssetStat", history.ExpAssetStat{
-		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
-		AssetIssuer: trustLineIssuer.Address(),
-		AssetCode:   "EUR",
-		Amount:      "0",
-		NumAccounts: 1,
-	}).Return(int64(1), nil).Once()
 
 	updatedTrustLine := xdr.TrustLineEntry{
 		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
@@ -372,14 +360,8 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestInsertTrustLine() {
 		xdr.AssetTypeAssetTypeCreditAlphanum4,
 		"EUR",
 		trustLineIssuer.Address(),
-	).Return(history.ExpAssetStat{
-		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
-		AssetIssuer: trustLineIssuer.Address(),
-		AssetCode:   "EUR",
-		Amount:      "0",
-		NumAccounts: 1,
-	}, nil).Once()
-	s.mockAssetStatsQ.On("UpdateAssetStat", history.ExpAssetStat{
+	).Return(history.ExpAssetStat{}, sql.ErrNoRows).Once()
+	s.mockAssetStatsQ.On("InsertAssetStat", history.ExpAssetStat{
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "EUR",
@@ -390,6 +372,100 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestInsertTrustLine() {
 	s.mockLedgerReader.
 		On("Read").
 		Return(io.LedgerTransaction{}, stdio.EOF).Once()
+
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().NoError(err)
+}
+
+func (s *TrustLinesProcessorTestSuiteLedger) TestUpdateTrustLine() {
+	// Removes ReadUpgradeChange assertion
+	s.mockLedgerReader = &io.MockLedgerReader{}
+	s.mockLedgerReader.On("Close").Return(nil).Once()
+
+	lastModifiedLedgerSeq := xdr.Uint32(1234)
+
+	trustLine := xdr.TrustLineEntry{
+		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		Asset:     xdr.MustNewCreditAsset("EUR", trustLineIssuer.Address()),
+		Balance:   0,
+		Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag),
+	}
+	updatedTrustLine := xdr.TrustLineEntry{
+		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		Asset:     xdr.MustNewCreditAsset("EUR", trustLineIssuer.Address()),
+		Balance:   10,
+		Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag),
+	}
+	s.mockLedgerReader.On("Read").
+		Return(io.LedgerTransaction{
+			Meta: createTransactionMeta([]xdr.OperationMeta{
+				xdr.OperationMeta{
+					Changes: []xdr.LedgerEntryChange{
+						// State
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+							State: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq - 1,
+								Data: xdr.LedgerEntryData{
+									Type:      xdr.LedgerEntryTypeTrustline,
+									TrustLine: &trustLine,
+								},
+							},
+						},
+						// Updated
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
+							Updated: &xdr.LedgerEntry{
+								LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+								Data: xdr.LedgerEntryData{
+									Type:      xdr.LedgerEntryTypeTrustline,
+									TrustLine: &updatedTrustLine,
+								},
+							},
+						},
+					},
+				},
+			}),
+		}, nil).Once()
+
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{}, stdio.EOF).Once()
+
+	s.mockLedgerReader.
+		On("ReadUpgradeChange").
+		Return(io.Change{}, stdio.EOF).Once()
+
+	s.mockQ.On(
+		"UpdateTrustLine",
+		updatedTrustLine,
+		lastModifiedLedgerSeq,
+	).Return(int64(1), nil).Once()
+
+	s.mockAssetStatsQ.On("GetAssetStat",
+		xdr.AssetTypeAssetTypeCreditAlphanum4,
+		"EUR",
+		trustLineIssuer.Address(),
+	).Return(history.ExpAssetStat{
+		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AssetIssuer: trustLineIssuer.Address(),
+		AssetCode:   "EUR",
+		Amount:      "100",
+		NumAccounts: 1,
+	}, nil).Once()
+	s.mockAssetStatsQ.On("UpdateAssetStat", history.ExpAssetStat{
+		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AssetIssuer: trustLineIssuer.Address(),
+		AssetCode:   "EUR",
+		Amount:      "110",
+		NumAccounts: 1,
+	}).Return(int64(1), nil).Once()
 
 	err := s.processor.ProcessLedger(
 		context.Background(),
@@ -456,24 +532,6 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestUpdateTrustLineNoRowsAffected()
 		updatedTrustLine,
 		lastModifiedLedgerSeq,
 	).Return(int64(0), nil).Once()
-	s.mockAssetStatsQ.On("GetAssetStat",
-		xdr.AssetTypeAssetTypeCreditAlphanum4,
-		"EUR",
-		trustLineIssuer.Address(),
-	).Return(history.ExpAssetStat{
-		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
-		AssetIssuer: trustLineIssuer.Address(),
-		AssetCode:   "EUR",
-		Amount:      "0",
-		NumAccounts: 1,
-	}, nil).Once()
-	s.mockAssetStatsQ.On("UpdateAssetStat", history.ExpAssetStat{
-		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
-		AssetIssuer: trustLineIssuer.Address(),
-		AssetCode:   "EUR",
-		Amount:      "10",
-		NumAccounts: 1,
-	}).Return(int64(1), nil).Once()
 
 	err := s.processor.ProcessLedger(
 		context.Background(),
@@ -765,19 +823,6 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestProcessUpgradeChange() {
 		lastModifiedLedgerSeq,
 	).Return(int64(1), nil).Once()
 
-	s.mockAssetStatsQ.On("GetAssetStat",
-		xdr.AssetTypeAssetTypeCreditAlphanum4,
-		"EUR",
-		trustLineIssuer.Address(),
-	).Return(history.ExpAssetStat{}, sql.ErrNoRows).Once()
-	s.mockAssetStatsQ.On("InsertAssetStat", history.ExpAssetStat{
-		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
-		AssetIssuer: trustLineIssuer.Address(),
-		AssetCode:   "EUR",
-		Amount:      "0",
-		NumAccounts: 1,
-	}).Return(int64(1), nil).Once()
-
 	s.mockLedgerReader.
 		On("Read").
 		Return(io.LedgerTransaction{}, stdio.EOF).Once()
@@ -815,18 +860,13 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestProcessUpgradeChange() {
 		updatedTrustLine,
 		lastModifiedLedgerSeq,
 	).Return(int64(1), nil).Once()
+
 	s.mockAssetStatsQ.On("GetAssetStat",
 		xdr.AssetTypeAssetTypeCreditAlphanum4,
 		"EUR",
 		trustLineIssuer.Address(),
-	).Return(history.ExpAssetStat{
-		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
-		AssetIssuer: trustLineIssuer.Address(),
-		AssetCode:   "EUR",
-		Amount:      "0",
-		NumAccounts: 1,
-	}, nil).Once()
-	s.mockAssetStatsQ.On("UpdateAssetStat", history.ExpAssetStat{
+	).Return(history.ExpAssetStat{}, sql.ErrNoRows).Once()
+	s.mockAssetStatsQ.On("InsertAssetStat", history.ExpAssetStat{
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "EUR",
@@ -896,22 +936,6 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestRemoveTrustlineNoRowsAffected()
 			Asset:     xdr.MustNewCreditAsset("EUR", trustLineIssuer.Address()),
 		},
 	).Return(int64(0), nil).Once()
-	s.mockAssetStatsQ.On("GetAssetStat",
-		xdr.AssetTypeAssetTypeCreditAlphanum4,
-		"EUR",
-		trustLineIssuer.Address(),
-	).Return(history.ExpAssetStat{
-		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
-		AssetIssuer: trustLineIssuer.Address(),
-		AssetCode:   "EUR",
-		Amount:      "0",
-		NumAccounts: 1,
-	}, nil).Once()
-	s.mockAssetStatsQ.On("RemoveAssetStat",
-		xdr.AssetTypeAssetTypeCreditAlphanum4,
-		"EUR",
-		trustLineIssuer.Address(),
-	).Return(int64(1), nil).Once()
 
 	err := s.processor.ProcessLedger(
 		context.Background(),


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes performance of asset stats processor.

### Why

For each ledger entry change connected to trust lines existing asset stats processor sends two DB queries. In order to decrease number of DB queries the code was changed to track delta change of each asset within a single ledger in memory and update DB when processing is done. This reduces DB queries to two per each asset with non-zero delta and zero if delta is zero (ex. asset is exchanged between existing asset holders).

### Known limitations

For ledgers with many operations that issue/remove different assets it may still be a bottleneck. To solve this we can add `GetAssetStats` method that gets stats for multiple assets. This will require `n+1` DB queries when `n` is a number of assets affected.