### PR TITLE
services/horizon: Fix ledger processor when not ingesting into a DB

### DIFF
--- a/services/horizon/internal/expingest/processors/database_processor.go
+++ b/services/horizon/internal/expingest/processors/database_processor.go
@@ -384,13 +384,18 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 		}
 	}
 
-	return p.ingestLedgerHeader(r, successTxCount, failedTxCount, opCount)
+	return p.ingestLedgerHeader(ctx, r, successTxCount, failedTxCount, opCount)
 }
 
 func (p *DatabaseProcessor) ingestLedgerHeader(
-	r io.LedgerReader, successTxCount, failedTxCount, opCount int,
+	ctx context.Context, r io.LedgerReader, successTxCount, failedTxCount, opCount int,
 ) error {
 	if p.Action != All && p.Action != Ledgers {
+		return nil
+	}
+
+	// Exit early if not ingesting into a DB
+	if v := ctx.Value(IngestUpdateDatabase); v == nil {
 		return nil
 	}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes ledger processor to not insert data into a DB when not in a DB ingestion.

### Why

All processors updating a database are ancestors of `ContextFilter` with `IngestUpdateDatabase` set. `ContextFilter` will only pass transactions to the stream writer if the given value in the context is present, otherwise it will close the writer (but the processors below it, will still be executed . This works well for existing processors but ledgers processor is different: instead of operating on per transactions basis, it inserts data into a DB (ledger header) only once.

The previous code was trying to insert ledger header into a DB even when it shouldn't (`IngestUpdateDatabase` not present in the context).