### PR TITLE
services/horizon: Graceful shutdown when session errors

### DIFF
--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -365,7 +365,15 @@ func (s *System) resumeFromLedger(lastIngestedLedger uint32) {
 			if processed {
 				lastIngestedLedger = sessionLastLedger
 			}
-			return errors.Wrap(err, "Error returned from ingest.LiveSession")
+
+			select {
+			case <-s.shutdown:
+				log.WithField("err", err).
+					Error("System shut down but error returned from ingest.LiveSession")
+				return nil
+			default:
+				return errors.Wrap(err, "Error returned from ingest.LiveSession")
+			}
 		}
 
 		log.Info("Session shut down")


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit checks for shut down signal in `expingest/System.resumeFromLedger` and exits when signal has been received.

### Why

Ingestion pipeline (built using `exp/support/pipeline`) always returns an error (if occurred), even when shut down signal has been received. This is to prevent situations when an error that occurs during shutdown (ex. in post-processing hook) is missed because `ErrShutdown` is returned instead.

Because of this, when there's an error that persists between pipeline runs, `SIGTERM` is ignored (because pipeline always returns the error that occurred in the pipeline). To solve this, we check for shut down signal when pipeline returns an error.

### Known limitations

It's possible to limit number of `select`s waiting for shut down signal by implementing #1969.