### PR TITLE
services/horizon: Make error field name consistent

### DIFF
--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -418,7 +418,7 @@ func reingestRange(i *ingest.System, from, to int32) error {
 
 		_, err := i.ReingestRange(lr.from, lr.to)
 		if err != nil {
-			localLog.WithField("err", err).Error("Worker failed range, work will be processed again")
+			localLog.WithError(err).Error("Worker failed range, work will be processed again")
 			// Add the work again
 			pool.AddWork(lr)
 			return

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -190,7 +190,7 @@ func (a *App) UpdateLedgerState() {
 	var next ledger.State
 
 	logErr := func(err error, msg string) {
-		log.WithStack(err).WithField("err", err.Error()).Error(msg)
+		log.WithStack(err).WithError(err).Error(msg)
 	}
 
 	err := a.CoreQ().LatestLedger(&next.CoreLatest)
@@ -235,7 +235,7 @@ func (a *App) UpdateFeeStatsState() {
 			return
 		}
 
-		log.WithStack(err).WithField("err", err.Error()).Error(msg)
+		log.WithStack(err).WithError(err).Error(msg)
 	}
 
 	cur := operationfeestats.CurrentState()

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -283,7 +283,7 @@ func postProcessingHook(
 
 	stateInvalid, err := historyQ.GetExpStateInvalid()
 	if err != nil {
-		log.WithField("err", err).Error("Error getting state invalid value")
+		log.WithError(err).Error("Error getting state invalid value")
 	}
 
 	// Run verification routine only when...
@@ -308,9 +308,9 @@ func postProcessingHook(
 				case verify.StateError:
 					markStateInvalid(historySession, err)
 				default:
-					logger := log.WithField("err", err).Warn
+					logger := log.WithError(err).Warn
 					if errorCount >= stateVerificationErrorThreshold {
-						logger = log.WithField("err", err).Error
+						logger = log.WithError(err).Error
 					}
 					logger("State verification errored")
 				}
@@ -325,10 +325,10 @@ func postProcessingHook(
 }
 
 func markStateInvalid(historySession *db.Session, err error) {
-	log.WithField("err", err).Error("STATE IS INVALID!")
+	log.WithError(err).Error("STATE IS INVALID!")
 	q := &history.Q{historySession.Clone()}
 	if err := q.UpdateExpStateInvalid(true); err != nil {
-		log.WithField("err", err).Error("Error updating state invalid value")
+		log.WithError(err).Error("Error updating state invalid value")
 	}
 }
 

--- a/services/horizon/internal/expingest/reporter.go
+++ b/services/horizon/internal/expingest/reporter.go
@@ -48,7 +48,7 @@ func (lr *LoggingStateReporter) OnEndState(err error, shutdown bool) {
 	}
 
 	if err != nil {
-		l.WithField("err", err).Error("Error processing History Archive Snapshot")
+		l.WithError(err).Error("Error processing History Archive Snapshot")
 	} else if shutdown {
 		l.Info("Processing History Archive Snapshot shutdown")
 	} else {
@@ -91,7 +91,7 @@ func (lr *LoggingLedgerReporter) OnEndLedger(err error, shutdown bool) {
 	}
 
 	if err != nil {
-		l.WithField("err", err).Error("Error processing ledger")
+		l.WithError(err).Error("Error processing ledger")
 	} else if shutdown {
 		l.Info("Processing ledger shutdown")
 	} else {

--- a/services/horizon/internal/expingest/reporter.go
+++ b/services/horizon/internal/expingest/reporter.go
@@ -48,7 +48,7 @@ func (lr *LoggingStateReporter) OnEndState(err error, shutdown bool) {
 	}
 
 	if err != nil {
-		l.WithError(err).Error("Error processing History Archive Snapshot")
+		l.WithField("err", err).Error("Error processing History Archive Snapshot")
 	} else if shutdown {
 		l.Info("Processing History Archive Snapshot shutdown")
 	} else {
@@ -91,7 +91,7 @@ func (lr *LoggingLedgerReporter) OnEndLedger(err error, shutdown bool) {
 	}
 
 	if err != nil {
-		l.WithError(err).Error("Error processing ledger")
+		l.WithField("err", err).Error("Error processing ledger")
 	} else if shutdown {
 		l.Info("Processing ledger shutdown")
 	} else {

--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -290,7 +290,7 @@ func (m *ExperimentalIngestionMiddleware) Wrap(h http.Handler) http.Handler {
 				ReadOnly:  true,
 			})
 			if err != nil {
-				localLog.WithField("err", err).Error("Error starting exp ingestion read transaction")
+				localLog.WithError(err).Error("Error starting exp ingestion read transaction")
 				problem.Render(r.Context(), w, err)
 				return
 			}
@@ -298,7 +298,7 @@ func (m *ExperimentalIngestionMiddleware) Wrap(h http.Handler) http.Handler {
 
 			lastIngestedLedger, err := q.GetLastLedgerExpIngestNonBlocking()
 			if err != nil {
-				localLog.WithField("err", err).Error("Error running GetLastLedgerExpIngestNonBlocking")
+				localLog.WithError(err).Error("Error running GetLastLedgerExpIngestNonBlocking")
 				problem.Render(r.Context(), w, err)
 				return
 			}
@@ -307,7 +307,7 @@ func (m *ExperimentalIngestionMiddleware) Wrap(h http.Handler) http.Handler {
 
 		stateInvalid, err := q.GetExpStateInvalid()
 		if err != nil {
-			localLog.WithField("err", err).Error("Error running GetExpStateInvalid")
+			localLog.WithError(err).Error("Error running GetExpStateInvalid")
 			problem.Render(r.Context(), w, err)
 			return
 		}

--- a/support/log/entry.go
+++ b/support/log/entry.go
@@ -47,6 +47,17 @@ func (e *Entry) WithField(key string, value interface{}) *Entry {
 	}
 }
 
+// WithError creates a child logger annotated with the provided error in `err`
+// field.
+// A subsequent call to one of the logging methods (Debug(), Error(), etc.) to
+// the return value from this function will cause the emitted log line to
+// include the provided value.
+func (e *Entry) WithError(err error) *Entry {
+	return &Entry{
+		Entry: *e.Entry.WithField(ErrorKey, err),
+	}
+}
+
 // WithFields creates a child logger annotated with the provided key value
 // pairs.
 func (e *Entry) WithFields(fields F) *Entry {

--- a/support/log/main.go
+++ b/support/log/main.go
@@ -12,6 +12,9 @@ import (
 // context.
 var DefaultLogger *Entry
 
+// ErrorKey is a field name used in `WithError`
+const ErrorKey = "err"
+
 const (
 	PanicLevel = logrus.PanicLevel
 	ErrorLevel = logrus.ErrorLevel


### PR DESCRIPTION
### What

This commit changes all `WithError` calls to `WithField("err", err)`.

### Why

`WithError` function generates a log entry with `error` field, whereas `err` name is used everywhere else. This makes it harder to build log views and search the logs.