### PR TITLE
support/db: Return ErrCancelled when query cancelled

### DIFF
--- a/services/horizon/internal/db2/history/asset_stats.go
+++ b/services/horizon/internal/db2/history/asset_stats.go
@@ -170,10 +170,8 @@ func (q *Q) GetAssetStats(assetCode, assetIssuer string, page db2.PageQuery) ([]
 
 	sql = sql.OrderBy("(asset_code, asset_issuer) " + orderBy).Limit(page.Limit)
 
-	sqlQ := "SELECT pg_sleep(10)"
-
 	var results []ExpAssetStat
-	if err := q.SelectRaw(&results, sqlQ); err != nil {
+	if err := q.Select(&results, sql); err != nil {
 		return nil, errors.Wrap(err, "could not run select query")
 	}
 

--- a/services/horizon/internal/db2/history/asset_stats.go
+++ b/services/horizon/internal/db2/history/asset_stats.go
@@ -170,8 +170,10 @@ func (q *Q) GetAssetStats(assetCode, assetIssuer string, page db2.PageQuery) ([]
 
 	sql = sql.OrderBy("(asset_code, asset_issuer) " + orderBy).Limit(page.Limit)
 
+	sqlQ := "SELECT pg_sleep(10)"
+
 	var results []ExpAssetStat
-	if err := q.Select(&results, sql); err != nil {
+	if err := q.SelectRaw(&results, sqlQ); err != nil {
 		return nil, errors.Wrap(err, "could not run select query")
 	}
 

--- a/services/horizon/internal/render/problem/problem.go
+++ b/services/horizon/internal/render/problem/problem.go
@@ -8,6 +8,16 @@ import (
 
 // Well-known and reused problems below:
 var (
+	// Cancelled is a well-known problem type.  Use it as a shortcut
+	// in your actions.
+	Cancelled = problem.P{
+		Type:   "cancelled",
+		Title:  "Cancelled",
+		Status: http.StatusNoContent,
+		Detail: "The request has been cancelled due to user action or application " +
+			"shut down.",
+	}
+
 	// RateLimitExceeded is a well-known problem type.  Use it as a shortcut
 	// in your actions.
 	RateLimitExceeded = problem.P{

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -62,6 +62,8 @@ func init() {
 	problem.RegisterError(db2.ErrInvalidOrder, problem.BadRequest)
 	problem.RegisterError(sse.ErrRateLimited, hProblem.RateLimitExceeded)
 	problem.RegisterError(context.DeadlineExceeded, hProblem.Timeout)
+	problem.RegisterError(context.Canceled, hProblem.Cancelled)
+	problem.RegisterError(db.ErrCancelled, hProblem.Cancelled)
 }
 
 // mustInitWeb installed a new Web instance onto the provided app object.

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -26,6 +26,12 @@ import (
 // postgresQueryMaxParams defines the maximum number of parameters in a query.
 var postgresQueryMaxParams = 65535
 
+var (
+	// ErrCancelled is an error returned by Session methods when request has
+	// been cancelled (ex. context cancelled).
+	ErrCancelled = errors.New("canceling statement due to user request")
+)
+
 // Conn represents a connection to a single database.
 type Conn interface {
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit adds `ErrCancelled` error to `support/db` package. The error is returned when query is cancelled.

### Why

We add a new error to be able to compare is easily (instead of using `strings.Contains`).