### PR TITLE
xdr: get address from AccountId without panic

### DIFF
--- a/xdr/account_id.go
+++ b/xdr/account_id.go
@@ -10,8 +10,18 @@ import (
 // Address returns the strkey encoded form of this AccountId.  This method will
 // panic if the accountid is backed by a public key of an unknown type.
 func (aid *AccountId) Address() string {
+	address, err := aid.GetAddress()
+	if err != nil {
+		panic(err)
+	}
+	return address
+}
+
+// GetAddress returns the strkey encoded form of this AccountId, and an error
+// if the AccountId is backed by a public key of an unknown type.
+func (aid *AccountId) GetAddress() (string, error) {
 	if aid == nil {
-		return ""
+		return "", nil
 	}
 
 	switch aid.Type {
@@ -19,9 +29,9 @@ func (aid *AccountId) Address() string {
 		ed := aid.MustEd25519()
 		raw := make([]byte, 32)
 		copy(raw, ed[:])
-		return strkey.MustEncode(strkey.VersionByteAccountID, raw)
+		return strkey.MustEncode(strkey.VersionByteAccountID, raw), nil
 	default:
-		panic(fmt.Errorf("Unknown account id type: %v", aid.Type))
+		return "", fmt.Errorf("Unknown account id type: %v", aid.Type)
 	}
 }
 

--- a/xdr/account_id.go
+++ b/xdr/account_id.go
@@ -26,10 +26,13 @@ func (aid *AccountId) GetAddress() (string, error) {
 
 	switch aid.Type {
 	case PublicKeyTypePublicKeyTypeEd25519:
-		ed := aid.MustEd25519()
+		ed, ok := aid.GetEd25519()
+		if !ok {
+			return "", fmt.Errorf("Could not get Ed25519")
+		}
 		raw := make([]byte, 32)
 		copy(raw, ed[:])
-		return strkey.MustEncode(strkey.VersionByteAccountID, raw), nil
+		return strkey.Encode(strkey.VersionByteAccountID, raw)
 	default:
 		return "", fmt.Errorf("Unknown account id type: %v", aid.Type)
 	}


### PR DESCRIPTION
### What

This PR adds a method to the `xdr.AccountId` struct that returns the address with an error. The existing `Address` method is now a thin wrapper around this method.

### Why

In long-running, data-intensive applications, like the Hubble project, we want to avoid panics wherever possible. A `panic` on a single malformed input can abort the entire pipeline. A panic-free method to get the address of an `xdr.AccountId` struct helps reduce such possible failures.

### Known limitations

N/A
