### PR TITLE
xdr: get entry from ledger entry change

### DIFF
--- a/tools/horizon-cmp/README.md
+++ b/tools/horizon-cmp/README.md
@@ -3,4 +3,45 @@
 Tool that compares the responses of two Horizon servers and shows the diffs.
 Useful for checking for regressions.
 
-TODO: add more info
+## Install
+
+Compile the `horizon-cmp` binary:
+
+```bash
+go install ./tools/horizon-cmp
+```
+
+## Usage
+
+`horizon-cmp` can be run in two modes:
+
+- Crawling: start with a set of paths (defined in [init_paths.go](https://github.com/stellar/go/blob/master/tools/horizon-cmp/init_paths.go)) and then uses `_links` to find new paths.
+- ELB access log: send requests found in a provided ELB access log.
+
+### Crawling mode
+
+To run in crawling mode specify a `base` and `test` URL, where `base` is the current version of Horizon and `test` is the version you want to test.
+
+```bash
+horizon-cmp -t https://new-horizon.host.org -b https://horizon.stellar.org
+```
+
+The paths to be tested can be found in [init_paths.go](https://github.com/stellar/go/blob/master/tools/horizon-cmp/init_paths.go).
+
+### ELB access log
+
+To run using an ELB access log, use the flag `-a`.
+
+```bash
+horizon-cmp -t https://new-horizon.host.org -b https://horizon.stellar.org -a ./elb_access.log
+```
+
+Additionally you can specify which line to start in by using the flag `-s`.
+
+### Request per second
+
+By default `horizon-cmp` will send 1 request per second, however, you can change this value using the `--rps` flag.  The following will run `10` request per second. Please note that sending too many requests to a production server can result in rate limiting of requests.
+
+```bash
+horizon-cmp -t https://new-horizon.host.org -b https://horizon.stellar.org --rps 10
+```

--- a/xdr/ledger_entry_change.go
+++ b/xdr/ledger_entry_change.go
@@ -27,28 +27,19 @@ func (change *LedgerEntryChange) LedgerKey() LedgerKey {
 	}
 }
 
-// GetLedgerEntry returns the ledger entry that was changed in `change`, and
-// an error if that entry cannot be retrieved.
-func (change *LedgerEntryChange) GetLedgerEntry() (*LedgerEntry, error) {
-	var (
-		entry LedgerEntry
-		ok    bool
-	)
+// GetLedgerEntry returns the ledger entry that was changed in `change`, along
+// with a boolean indicating whether the entry value was valid.
+func (change *LedgerEntryChange) GetLedgerEntry() (LedgerEntry, bool) {
 	switch change.Type {
 	case LedgerEntryChangeTypeLedgerEntryCreated:
-		entry, ok = change.GetCreated()
+		return change.GetCreated()
 	case LedgerEntryChangeTypeLedgerEntryState:
-		entry, ok = change.GetState()
+		return change.GetState()
 	case LedgerEntryChangeTypeLedgerEntryUpdated:
-		entry, ok = change.GetUpdated()
+		return change.GetUpdated()
 	case LedgerEntryChangeTypeLedgerEntryRemoved:
-		return nil, fmt.Errorf("Entry type %v does not have ledger entry", change.Type)
+		return LedgerEntry{}, false
 	default:
-		return nil, fmt.Errorf("Unknown change type: %v", change.Type)
+		return LedgerEntry{}, false
 	}
-
-	if !ok {
-		return nil, fmt.Errorf("Could not get entry from change of type %v", change.Type)
-	}
-	return &entry, nil
 }

--- a/xdr/ledger_entry_change.go
+++ b/xdr/ledger_entry_change.go
@@ -43,6 +43,8 @@ func (change *LedgerEntryChange) GetLedgerEntry() (*LedgerEntry, error) {
 		entry, ok = change.GetUpdated()
 	case LedgerEntryChangeTypeLedgerEntryRemoved:
 		return nil, fmt.Errorf("Entry type %v does not have ledger entry", change.Type)
+	default:
+		return nil, fmt.Errorf("Unknown change type: %v", change.Type)
 	}
 
 	if !ok {

--- a/xdr/ledger_entry_change.go
+++ b/xdr/ledger_entry_change.go
@@ -26,3 +26,27 @@ func (change *LedgerEntryChange) LedgerKey() LedgerKey {
 		panic(fmt.Errorf("Unknown change type: %v", change.Type))
 	}
 }
+
+// GetLedgerEntry returns the ledger entry that was changed in `change`, and
+// an error if that entry cannot be retrieved.
+func (change *LedgerEntryChange) GetLedgerEntry() (*LedgerEntry, error) {
+	var (
+		entry LedgerEntry
+		ok    bool
+	)
+	switch change.Type {
+	case LedgerEntryChangeTypeLedgerEntryCreated:
+		entry, ok = change.GetCreated()
+	case LedgerEntryChangeTypeLedgerEntryState:
+		entry, ok = change.GetState()
+	case LedgerEntryChangeTypeLedgerEntryUpdated:
+		entry, ok = change.GetUpdated()
+	case LedgerEntryChangeTypeLedgerEntryRemoved:
+		return nil, fmt.Errorf("Entry type %v does not have ledger entry", change.Type)
+	}
+
+	if !ok {
+		return nil, fmt.Errorf("Could not get entry of type %v from change", change.Type)
+	}
+	return &entry, nil
+}

--- a/xdr/ledger_entry_change.go
+++ b/xdr/ledger_entry_change.go
@@ -48,7 +48,7 @@ func (change *LedgerEntryChange) GetLedgerEntry() (*LedgerEntry, error) {
 	}
 
 	if !ok {
-		return nil, fmt.Errorf("Could not get entry of type %v from change", change.Type)
+		return nil, fmt.Errorf("Could not get entry from change of type %v", change.Type)
 	}
 	return &entry, nil
 }


### PR DESCRIPTION
### What
This PR gets the entry from an `xdr.LedgerEntryChange`, and an error if that cannot be retrieved.

### Why

Working with `xdr.LedgerEntryChange` structs involves a great deal of boilerplate to get the contained entry. This boilerplate also requires calling many `Must*` functions in the `xdr` package, which panics when processing malformed inputs. In long-running data applications, like the ingestion pipeline and the Hubble project, we want to avoid panics wherever possible, as a `panic` on a single malformed input can abort the entire pipeline. This helper thus makes overall development easier and reduces the risk of panicking.

### Known limitations

N/A
