### PR TITLE
exp/hubble: retrieve data from change without panics

### DIFF
--- a/exp/hubble/processors.go
+++ b/exp/hubble/processors.go
@@ -111,7 +111,7 @@ func (p *CurrentStateProcessor) ProcessState(ctx context.Context, store *support
 			}
 		}
 
-		accountID, err := makeAccountID(&entry)
+		accountID, err := makeAccountIDFromChange(&entry)
 		if err != nil {
 			return errors.Wrap(err, "could not get ledger account address")
 		}

--- a/exp/hubble/processors.go
+++ b/exp/hubble/processors.go
@@ -116,6 +116,12 @@ func (p *CurrentStateProcessor) ProcessState(ctx context.Context, store *support
 			return errors.Wrap(err, "could not get ledger account address")
 		}
 		currentState := p.ledgerState[accountID]
+		// If we have stored no prior state for this account, we should initialize
+		// its state with the already-found address.
+		if currentState.address == "" {
+			currentState.address = accountID
+		}
+
 		newState, err := makeNewAccountState(&currentState, &entry)
 		if err != nil {
 			return errors.Wrap(err, "could not update account state")

--- a/exp/hubble/schema_factory.go
+++ b/exp/hubble/schema_factory.go
@@ -189,6 +189,7 @@ func makeSigners(state *accountState, change *xdr.LedgerEntryChange) ([]signer, 
 
 	var signers []signer
 	for _, accountSigner := range account.Signers {
+		// TODO: Replace `SignerKey.Address()` with a panic-free version.
 		signers = append(signers, signer{
 			address: accountSigner.Key.Address(),
 			weight:  uint32(accountSigner.Weight),

--- a/exp/hubble/schema_factory.go
+++ b/exp/hubble/schema_factory.go
@@ -25,14 +25,15 @@ func makeNewAccountState(state *accountState, change *xdr.LedgerEntryChange) (*a
 	// per-function checks for nil state.
 	if state == nil {
 		state = &accountState{}
+		accountID, err := makeAccountIDFromChange(change)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get ledger account address")
+		}
+		state.address = accountID
 	}
 
 	var newAccountState accountState
-	address, err := makeAccountIDFromStateOrChange(state, change)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get address")
-	}
-	state.address = address
+	newAccountState.address = state.address
 
 	seqnum, err := makeSeqnum(state, change)
 	if err != nil {
@@ -86,13 +87,6 @@ func isAccountRemoved(change *xdr.LedgerEntryChange) (bool, error) {
 	}
 
 	return (ledgerKey.Type == xdr.LedgerEntryTypeAccount), nil
-}
-
-func makeAccountIDFromStateOrChange(state *accountState, change *xdr.LedgerEntryChange) (string, error) {
-	if state != nil {
-		return state.address, nil
-	}
-	return makeAccountIDFromChange(change)
 }
 
 func makeAccountIDFromChange(change *xdr.LedgerEntryChange) (string, error) {

--- a/exp/hubble/schema_factory.go
+++ b/exp/hubble/schema_factory.go
@@ -12,7 +12,7 @@ import (
 func makeNewAccountState(state *accountState, change *xdr.LedgerEntryChange) (*accountState, error) {
 	// TODO: Handle account removal.
 	var newAccountState accountState
-	address, err := makeAccountID(change, state)
+	address, err := makeAccountIDFromStateOrChange(state, change)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get address")
 	}
@@ -57,28 +57,53 @@ func makeNewAccountState(state *accountState, change *xdr.LedgerEntryChange) (*a
 	return &newAccountState, nil
 }
 
-func makeAccountID(change *xdr.LedgerEntryChange, states ...*accountState) (string, error) {
-	// If the address has already been set on the account state, we return it.
-	// We pass this as a optional parameter, so we can use this function more easily in the processor.
-	if len(states) == 1 {
-		return states[0].address, nil
+func makeAccountIDFromStateOrChange(state *accountState, change *xdr.LedgerEntryChange) (string, error) {
+	if state != nil {
+		return state.address, nil
 	}
+	return makeAccountIDFromChange(change)
+}
 
-	key := change.LedgerKey()
-	var accountID xdr.AccountId
-	switch keyType := key.Type; keyType {
-	case xdr.LedgerEntryTypeAccount:
-		accountID = key.MustAccount().AccountId
-	case xdr.LedgerEntryTypeTrustline:
-		accountID = key.MustTrustLine().AccountId
-	case xdr.LedgerEntryTypeOffer:
-		accountID = key.MustOffer().SellerId
-	case xdr.LedgerEntryTypeData:
-		accountID = key.MustData().AccountId
-	default:
-		return "", fmt.Errorf("Unknown entry type: %v", keyType)
+func makeAccountIDFromChange(change *xdr.LedgerEntryChange) (string, error) {
+	entry, ok := change.GetLedgerEntry()
+	if !ok {
+		return "", fmt.Errorf("Could not get ledger entry from change")
 	}
-	return accountID.Address(), nil
+	var accountID xdr.AccountId
+	entryData := entry.Data
+	switch entryType := entryData.Type; entryType {
+	case xdr.LedgerEntryTypeAccount:
+		account, ok := entryData.GetAccount()
+		if !ok {
+			return "", fmt.Errorf("could not get account")
+		}
+		accountID = account.AccountId
+	case xdr.LedgerEntryTypeTrustline:
+		trustline, ok := entryData.GetTrustLine()
+		if !ok {
+			return "", fmt.Errorf("could not get trustline")
+		}
+		accountID = trustline.AccountId
+	case xdr.LedgerEntryTypeOffer:
+		offer, ok := entryData.GetOffer()
+		if !ok {
+			return "", fmt.Errorf("could not get offer")
+		}
+		accountID = offer.SellerId
+	case xdr.LedgerEntryTypeData:
+		data, ok := entryData.GetData()
+		if !ok {
+			return "", fmt.Errorf("could not get data")
+		}
+		accountID = data.AccountId
+	default:
+		return "", fmt.Errorf("Unknown entry type: %v", entryType)
+	}
+	address, err := accountID.GetAddress()
+	if err != nil {
+		return "", errors.Wrap(err, "could not get address")
+	}
+	return address, nil
 }
 
 func makeSeqnum(state *accountState, change *xdr.LedgerEntryChange) (uint32, error) {

--- a/exp/hubble/schema_factory.go
+++ b/exp/hubble/schema_factory.go
@@ -20,16 +20,9 @@ func makeNewAccountState(state *accountState, change *xdr.LedgerEntryChange) (*a
 	}
 
 	// We should never be given a nil pointer for account state, rather one
-	// to an empty accountState struct. If we are given a nil pointer to state
-	// somehow, we replace it with the desired input. This prevents repeated,
-	// per-function checks for nil state.
+	// to an empty accountState struct.
 	if state == nil {
-		state = &accountState{}
-		accountID, aerr := makeAccountIDFromChange(change)
-		if aerr != nil {
-			return nil, errors.Wrap(aerr, "could not get ledger account address")
-		}
-		state.address = accountID
+		return nil, errors.Wrap(err, "cannot process nil state ptr")
 	}
 
 	var newAccountState accountState
@@ -154,9 +147,11 @@ func makeBalance(state *accountState, change *xdr.LedgerEntryChange) (uint32, er
 
 	entry, ok := change.GetLedgerEntry()
 	if !ok {
-		return state.balance, nil
+		return 0, fmt.Errorf("Could not get ledger entry")
 	}
 
+	// If the entry is not of account type (trustline, offer, etc.), then we return
+	// the current balance.
 	account, ok := entry.Data.GetAccount()
 	if !ok {
 		return state.balance, nil
@@ -174,9 +169,11 @@ func makeSigners(state *accountState, change *xdr.LedgerEntryChange) ([]signer, 
 
 	entry, ok := change.GetLedgerEntry()
 	if !ok {
-		return state.signers, nil
+		return nil, fmt.Errorf("Could not get ledger entry")
 	}
 
+	// If the entry is not of account type (i.e., trustline, offer, or data), then we
+	// return the current signers, as those would not be modified by this change.
 	account, ok := entry.Data.GetAccount()
 	if !ok {
 		return state.signers, nil
@@ -216,14 +213,19 @@ func makeTrustlines(state *accountState, change *xdr.LedgerEntryChange) (map[str
 		return trustlines, nil
 	}
 
-	// Get the trustline entry from the change and an error if we cannot.
+	// Get the trustline entry from the change. If the change does not contain
+	// a ledger entry, we return an error, as the only valid non-entry ledger changes
+	// are Removed.
 	entry, ok := change.GetLedgerEntry()
 	if !ok {
 		return nil, fmt.Errorf("Could not get ledger entry")
 	}
+
+	// If the change is not of type trustline, then we return the current trustlines,
+	// as those would not be changed.
 	trustlineEntry, ok := entry.Data.GetTrustLine()
 	if !ok {
-		return nil, fmt.Errorf("Could not get trustline entry")
+		return trustlines, nil
 	}
 
 	assetKey := trustlineEntry.Asset.String()
@@ -261,14 +263,19 @@ func makeOffers(state *accountState, change *xdr.LedgerEntryChange) (map[uint32]
 		return offers, nil
 	}
 
-	// Get and store the offer.
+	// Get the offer entry from the change. If the change does not contain
+	// a ledger entry, we return an error, as the only valid non-entry ledger changes
+	// are Removed.
 	entry, ok := change.GetLedgerEntry()
 	if !ok {
 		return nil, fmt.Errorf("Could not get ledger entry")
 	}
+
+	// If the change is not of type offer, then we return the current offers,
+	// as those would not be changed.
 	offerEntry, ok := entry.Data.GetOffer()
 	if !ok {
-		return nil, fmt.Errorf("Could not get offer entry")
+		return offers, nil
 	}
 
 	offerSellerAddress, err := offerEntry.SellerId.GetAddress()
@@ -318,9 +325,11 @@ func makeData(state *accountState, change *xdr.LedgerEntryChange) (map[string][]
 		return nil, fmt.Errorf("Could not get ledger entry")
 	}
 
+	// If the change is not of type data, then we return the current data,
+	// as those would not be changed.
 	dataEntry, ok := entry.Data.GetData()
 	if !ok {
-		return nil, fmt.Errorf("Could not get data entry")
+		return data, nil
 	}
 
 	data[string(dataEntry.DataName)] = dataEntry.DataValue

--- a/exp/hubble/schema_factory.go
+++ b/exp/hubble/schema_factory.go
@@ -25,9 +25,9 @@ func makeNewAccountState(state *accountState, change *xdr.LedgerEntryChange) (*a
 	// per-function checks for nil state.
 	if state == nil {
 		state = &accountState{}
-		accountID, err := makeAccountIDFromChange(change)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not get ledger account address")
+		accountID, aerr := makeAccountIDFromChange(change)
+		if aerr != nil {
+			return nil, errors.Wrap(aerr, "could not get ledger account address")
 		}
 		state.address = accountID
 	}

--- a/exp/hubble/schema_factory.go
+++ b/exp/hubble/schema_factory.go
@@ -10,7 +10,22 @@ import (
 )
 
 func makeNewAccountState(state *accountState, change *xdr.LedgerEntryChange) (*accountState, error) {
-	// TODO: Handle account removal.
+	accountRemoved, err := isAccountRemoved(change)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not check removed account")
+	}
+	// If the account has been removed, then we return a nil account state.
+	if accountRemoved {
+		return nil, nil
+	}
+
+	// We should never be given a nil pointer for account state, rather one
+	// to an empty account state. If we are given a nil pointer to state
+	// somehow, we replace it with a pointer to empty account state.
+	if state == nil {
+		state = &accountState{}
+	}
+
 	var newAccountState accountState
 	address, err := makeAccountIDFromStateOrChange(state, change)
 	if err != nil {
@@ -55,6 +70,21 @@ func makeNewAccountState(state *accountState, change *xdr.LedgerEntryChange) (*a
 	newAccountState.data = data
 
 	return &newAccountState, nil
+}
+
+func isAccountRemoved(change *xdr.LedgerEntryChange) (bool, error) {
+	// If the change is not of Removed type, it cannot represent the
+	// removal of an Account.
+	if change.Type != xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
+		return false, nil
+	}
+
+	ledgerKey, ok := change.GetRemoved()
+	if !ok {
+		return false, fmt.Errorf("Could not get ledger key from Removed struct")
+	}
+
+	return (ledgerKey.Type == xdr.LedgerEntryTypeAccount), nil
 }
 
 func makeAccountIDFromStateOrChange(state *accountState, change *xdr.LedgerEntryChange) (string, error) {
@@ -107,48 +137,53 @@ func makeAccountIDFromChange(change *xdr.LedgerEntryChange) (string, error) {
 }
 
 func makeSeqnum(state *accountState, change *xdr.LedgerEntryChange) (uint32, error) {
-	var seqnum xdr.Uint32
-	switch entryType := change.Type; entryType {
-	case xdr.LedgerEntryChangeTypeLedgerEntryCreated:
-		seqnum = change.MustCreated().LastModifiedLedgerSeq
-	case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
-		seqnum = change.MustUpdated().LastModifiedLedgerSeq
-	case xdr.LedgerEntryChangeTypeLedgerEntryState:
-		seqnum = change.MustState().LastModifiedLedgerSeq
-
-	// We do not need to update the seqnum for removed changes, because
-	// we just remove the accompanying account's state.
-	case xdr.LedgerEntryChangeTypeLedgerEntryRemoved:
-		return 0, nil
-	default:
-		return 0, fmt.Errorf("Unknown entry type: %v", entryType)
+	// Removed entries would not be of Account type, and thus
+	// do not change the last modified ledger seqnum.
+	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
+		return state.seqnum, nil
 	}
-	return uint32(seqnum), nil
+
+	entry, ok := change.GetLedgerEntry()
+	if !ok {
+		return state.seqnum, fmt.Errorf("Could not get ledger entry")
+	}
+	return uint32(entry.LastModifiedLedgerSeq), nil
 }
 
 func makeBalance(state *accountState, change *xdr.LedgerEntryChange) (uint32, error) {
-	account, err := getAccountEntry(change)
-	if err != nil {
-		return 0, err
-	}
-
-	// The change does not update the account state, so we return
-	// the current balance.
-	if account == nil {
+	// If the change is a non-account removal or a change of non-account type, then
+	// we simply return the current balance (or 0, if we were passed a nil state pointer).
+	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
 		return state.balance, nil
 	}
+
+	entry, ok := change.GetLedgerEntry()
+	if !ok {
+		return state.balance, nil
+	}
+
+	account, ok := entry.Data.GetAccount()
+	if !ok {
+		return state.balance, nil
+	}
+
 	return uint32(account.Balance), nil
 }
 
 func makeSigners(state *accountState, change *xdr.LedgerEntryChange) ([]signer, error) {
-	account, err := getAccountEntry(change)
-	if err != nil {
-		return nil, err
+	// If the change is a non-account removal or a change of non-account type, then
+	// we simply return the current signers (or empty list, if we were passed a nil state pointer).
+	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
+		return state.signers, nil
 	}
 
-	// The change does not update the account state, so we return
-	// the current signers.
-	if account == nil {
+	entry, ok := change.GetLedgerEntry()
+	if !ok {
+		return state.signers, nil
+	}
+
+	account, ok := entry.Data.GetAccount()
+	if !ok {
 		return state.signers, nil
 	}
 
@@ -163,6 +198,7 @@ func makeSigners(state *accountState, change *xdr.LedgerEntryChange) ([]signer, 
 }
 
 func makeTrustlines(state *accountState, change *xdr.LedgerEntryChange) (map[string]trustline, error) {
+	// TODO: Replace reference to `EntryType` with a panic-free version.
 	if change.EntryType() != xdr.LedgerEntryTypeTrustline {
 		return state.trustlines, nil
 	}
@@ -175,22 +211,24 @@ func makeTrustlines(state *accountState, change *xdr.LedgerEntryChange) (map[str
 
 	// If the change is removed, remove the corresponding trustline.
 	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
-		asset := change.MustRemoved().TrustLine.Asset.String()
+		removeEntry, ok := change.GetRemoved()
+		if !ok {
+			return trustlines, fmt.Errorf("Could not get removed ledger key")
+		}
+		asset := removeEntry.TrustLine.Asset.String()
 		delete(trustlines, asset)
 		return trustlines, nil
 	}
 
-	// Get and store the new trustline.
-	var trustlineEntry xdr.TrustLineEntry
-	switch entryType := change.Type; entryType {
-	case xdr.LedgerEntryChangeTypeLedgerEntryCreated:
-		trustlineEntry = change.MustCreated().Data.MustTrustLine()
-	case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
-		trustlineEntry = change.MustUpdated().Data.MustTrustLine()
-	case xdr.LedgerEntryChangeTypeLedgerEntryState:
-		trustlineEntry = change.MustState().Data.MustTrustLine()
-	default:
-		return nil, fmt.Errorf("Unknown entry type: %v", entryType)
+	// Get the trustline entry from the change. If we cannot get this entry,
+	// return the current state's trustlines and an error.
+	entry, ok := change.GetLedgerEntry()
+	if !ok {
+		return trustlines, fmt.Errorf("Could not get ledger entry")
+	}
+	trustlineEntry, ok := entry.Data.GetTrustLine()
+	if !ok {
+		return trustlines, fmt.Errorf("Could not get trustline entry")
 	}
 
 	assetKey := trustlineEntry.Asset.String()
@@ -206,6 +244,7 @@ func makeTrustlines(state *accountState, change *xdr.LedgerEntryChange) (map[str
 }
 
 func makeOffers(state *accountState, change *xdr.LedgerEntryChange) (map[uint32]offer, error) {
+	// TODO: Replace reference to `EntryType` with a panic-free version.
 	if change.EntryType() != xdr.LedgerEntryTypeOffer {
 		return state.offers, nil
 	}
@@ -218,28 +257,34 @@ func makeOffers(state *accountState, change *xdr.LedgerEntryChange) (map[uint32]
 
 	// If the change is removed, remove the corresponding offer.
 	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
-		id := uint32(change.MustRemoved().Offer.OfferId)
+		removeEntry, ok := change.GetRemoved()
+		if !ok {
+			return offers, fmt.Errorf("Could not get removed ledger key")
+		}
+		id := uint32(removeEntry.Offer.OfferId)
 		delete(offers, id)
 		return offers, nil
 	}
 
 	// Get and store the offer.
-	var offerEntry xdr.OfferEntry
-	switch entryType := change.Type; entryType {
-	case xdr.LedgerEntryChangeTypeLedgerEntryCreated:
-		offerEntry = change.MustCreated().Data.MustOffer()
-	case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
-		offerEntry = change.MustUpdated().Data.MustOffer()
-	case xdr.LedgerEntryChangeTypeLedgerEntryState:
-		offerEntry = change.MustState().Data.MustOffer()
-	default:
-		return nil, fmt.Errorf("Unknown entry type: %v", entryType)
+	entry, ok := change.GetLedgerEntry()
+	if !ok {
+		return offers, fmt.Errorf("Could not get ledger entry")
+	}
+	offerEntry, ok := entry.Data.GetOffer()
+	if !ok {
+		return offers, fmt.Errorf("Could not get offer entry")
+	}
+
+	offerSellerAddress, err := offerEntry.SellerId.GetAddress()
+	if err != nil {
+		return offers, errors.Wrap(err, "could not get offer seller address")
 	}
 
 	offerID := uint32(offerEntry.OfferId)
 	newOffer := offer{
 		id:         offerID,
-		seller:     offerEntry.SellerId.Address(),
+		seller:     offerSellerAddress,
 		selling:    offerEntry.Selling.String(),
 		buying:     offerEntry.Buying.String(),
 		amount:     uint32(offerEntry.Amount),
@@ -252,6 +297,7 @@ func makeOffers(state *accountState, change *xdr.LedgerEntryChange) (map[uint32]
 }
 
 func makeData(state *accountState, change *xdr.LedgerEntryChange) (map[string][]byte, error) {
+	// TODO: Replace reference to `EntryType` with a panic-free version.
 	if change.EntryType() != xdr.LedgerEntryTypeData {
 		return state.data, nil
 	}
@@ -262,43 +308,26 @@ func makeData(state *accountState, change *xdr.LedgerEntryChange) (map[string][]
 	}
 
 	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
-		name := string(change.MustRemoved().Data.DataName)
+		key, ok := change.GetRemoved()
+		if !ok {
+			return data, fmt.Errorf("Could not get removed ledger key")
+		}
+		name := string(key.Data.DataName)
 		delete(data, name)
 		return data, nil
 	}
 
 	// Get and store the data key-value pair.
-	var dataEntry xdr.DataEntry
-	switch entryType := change.Type; entryType {
-	case xdr.LedgerEntryChangeTypeLedgerEntryCreated:
-		dataEntry = change.MustCreated().Data.MustData()
-	case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
-		dataEntry = change.MustUpdated().Data.MustData()
-	case xdr.LedgerEntryChangeTypeLedgerEntryState:
-		dataEntry = change.MustState().Data.MustData()
-	default:
-		return nil, fmt.Errorf("Unknown entry type: %v", entryType)
+	entry, ok := change.GetLedgerEntry()
+	if !ok {
+		return data, fmt.Errorf("Could not get ledger entry")
 	}
+
+	dataEntry, ok := entry.Data.GetData()
+	if !ok {
+		return data, fmt.Errorf("Could not get data entry")
+	}
+
 	data[string(dataEntry.DataName)] = dataEntry.DataValue
 	return data, nil
-}
-
-func getAccountEntry(change *xdr.LedgerEntryChange) (*xdr.AccountEntry, error) {
-	if change.EntryType() != xdr.LedgerEntryTypeAccount {
-		return nil, nil
-	}
-	var account xdr.AccountEntry
-	switch entryType := change.Type; entryType {
-	case xdr.LedgerEntryChangeTypeLedgerEntryCreated:
-		account = change.MustCreated().Data.MustAccount()
-	case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
-		account = change.MustUpdated().Data.MustAccount()
-	case xdr.LedgerEntryChangeTypeLedgerEntryState:
-		account = change.MustState().Data.MustAccount()
-	case xdr.LedgerEntryChangeTypeLedgerEntryRemoved:
-		return nil, nil
-	default:
-		return nil, fmt.Errorf("Unknown entry type: %v", entryType)
-	}
-	return &account, nil
 }

--- a/exp/hubble/schema_factory.go
+++ b/exp/hubble/schema_factory.go
@@ -20,8 +20,9 @@ func makeNewAccountState(state *accountState, change *xdr.LedgerEntryChange) (*a
 	}
 
 	// We should never be given a nil pointer for account state, rather one
-	// to an empty account state. If we are given a nil pointer to state
-	// somehow, we replace it with a pointer to empty account state.
+	// to an empty accountState struct. If we are given a nil pointer to state
+	// somehow, we replace it with the desired input. This prevents repeated,
+	// per-function checks for nil state.
 	if state == nil {
 		state = &accountState{}
 	}
@@ -145,7 +146,7 @@ func makeSeqnum(state *accountState, change *xdr.LedgerEntryChange) (uint32, err
 
 	entry, ok := change.GetLedgerEntry()
 	if !ok {
-		return state.seqnum, fmt.Errorf("Could not get ledger entry")
+		return 0, fmt.Errorf("Could not get ledger entry")
 	}
 	return uint32(entry.LastModifiedLedgerSeq), nil
 }
@@ -214,22 +215,21 @@ func makeTrustlines(state *accountState, change *xdr.LedgerEntryChange) (map[str
 	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
 		removeEntry, ok := change.GetRemoved()
 		if !ok {
-			return trustlines, fmt.Errorf("Could not get removed ledger key")
+			return nil, fmt.Errorf("Could not get removed ledger key")
 		}
 		asset := removeEntry.TrustLine.Asset.String()
 		delete(trustlines, asset)
 		return trustlines, nil
 	}
 
-	// Get the trustline entry from the change. If we cannot get this entry,
-	// return the current state's trustlines and an error.
+	// Get the trustline entry from the change and an error if we cannot.
 	entry, ok := change.GetLedgerEntry()
 	if !ok {
-		return trustlines, fmt.Errorf("Could not get ledger entry")
+		return nil, fmt.Errorf("Could not get ledger entry")
 	}
 	trustlineEntry, ok := entry.Data.GetTrustLine()
 	if !ok {
-		return trustlines, fmt.Errorf("Could not get trustline entry")
+		return nil, fmt.Errorf("Could not get trustline entry")
 	}
 
 	assetKey := trustlineEntry.Asset.String()
@@ -260,7 +260,7 @@ func makeOffers(state *accountState, change *xdr.LedgerEntryChange) (map[uint32]
 	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
 		removeEntry, ok := change.GetRemoved()
 		if !ok {
-			return offers, fmt.Errorf("Could not get removed ledger key")
+			return nil, fmt.Errorf("Could not get removed ledger key")
 		}
 		id := uint32(removeEntry.Offer.OfferId)
 		delete(offers, id)
@@ -270,16 +270,16 @@ func makeOffers(state *accountState, change *xdr.LedgerEntryChange) (map[uint32]
 	// Get and store the offer.
 	entry, ok := change.GetLedgerEntry()
 	if !ok {
-		return offers, fmt.Errorf("Could not get ledger entry")
+		return nil, fmt.Errorf("Could not get ledger entry")
 	}
 	offerEntry, ok := entry.Data.GetOffer()
 	if !ok {
-		return offers, fmt.Errorf("Could not get offer entry")
+		return nil, fmt.Errorf("Could not get offer entry")
 	}
 
 	offerSellerAddress, err := offerEntry.SellerId.GetAddress()
 	if err != nil {
-		return offers, errors.Wrap(err, "could not get offer seller address")
+		return nil, errors.Wrap(err, "could not get offer seller address")
 	}
 
 	offerID := uint32(offerEntry.OfferId)
@@ -311,7 +311,7 @@ func makeData(state *accountState, change *xdr.LedgerEntryChange) (map[string][]
 	if change.Type == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
 		key, ok := change.GetRemoved()
 		if !ok {
-			return data, fmt.Errorf("Could not get removed ledger key")
+			return nil, fmt.Errorf("Could not get removed ledger key")
 		}
 		name := string(key.Data.DataName)
 		delete(data, name)
@@ -321,12 +321,12 @@ func makeData(state *accountState, change *xdr.LedgerEntryChange) (map[string][]
 	// Get and store the data key-value pair.
 	entry, ok := change.GetLedgerEntry()
 	if !ok {
-		return data, fmt.Errorf("Could not get ledger entry")
+		return nil, fmt.Errorf("Could not get ledger entry")
 	}
 
 	dataEntry, ok := entry.Data.GetData()
 	if !ok {
-		return data, fmt.Errorf("Could not get data entry")
+		return nil, fmt.Errorf("Could not get data entry")
 	}
 
 	data[string(dataEntry.DataName)] = dataEntry.DataValue

--- a/exp/hubble/schema_factory_test.go
+++ b/exp/hubble/schema_factory_test.go
@@ -10,7 +10,29 @@ import (
 )
 
 // TODO: Replace manual equality check with `assert`, across all tests.
-func TestMakeAccountIDFromStateOrChange(t *testing.T) {
+
+func TestAccountRemoved(t *testing.T) {
+	testAddress := "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"
+	change := xdr.LedgerEntryChange{
+		Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+		Removed: &xdr.LedgerKey{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.LedgerKeyAccount{
+				AccountId: xdr.MustAddress(testAddress),
+			},
+		},
+	}
+	wantRemoved := false
+	gotRemoved, err := isAccountRemoved(&change)
+	if assert.Nil(t, err) {
+		return
+	}
+	if assert.Equal(t, wantRemoved, gotRemoved) {
+		return
+	}
+}
+
+func TestMakeAccountIDFromState(t *testing.T) {
 	wantAddress := "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"
 	state := accountState{address: wantAddress}
 	change := xdr.LedgerEntryChange{
@@ -80,7 +102,7 @@ func TestMakeSeqnumFromNonRemoved(t *testing.T) {
 }
 
 func TestMakeSeqnumFromRemoved(t *testing.T) {
-	wantSeqnum := uint32(0)
+	wantSeqnum := uint32(11)
 	state := accountState{seqnum: 11}
 	change := xdr.LedgerEntryChange{
 		Type:  xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
@@ -92,84 +114,6 @@ func TestMakeSeqnumFromRemoved(t *testing.T) {
 	}
 	if wantSeqnum != gotSeqnum {
 		t.Fatalf("got seqnum %d, want seqnum %d", gotSeqnum, wantSeqnum)
-	}
-}
-
-func TestGetAccountEntryNotAccount(t *testing.T) {
-	accountID, err := xdr.AddressToAccountId("GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF")
-	if err != nil {
-		t.Error(err)
-	}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-		State: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
-				Type: xdr.LedgerEntryTypeData,
-				Data: &xdr.DataEntry{
-					AccountId: accountID,
-					DataName:  xdr.String64("name"),
-					DataValue: xdr.DataValue([]byte("value")),
-				},
-			},
-		},
-	}
-
-	entry, err := getAccountEntry(&change)
-	if err != nil {
-		t.Error(err)
-	}
-	if entry != nil {
-		t.Fatal("got account entry non-nil, want account entry nil")
-	}
-}
-
-func TestGetAccountEntryRemoved(t *testing.T) {
-	accountID, err := xdr.AddressToAccountId("GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF")
-	if err != nil {
-		t.Error(err)
-	}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-		Removed: &xdr.LedgerKey{
-			Type: xdr.LedgerEntryTypeAccount,
-			Account: &xdr.LedgerKeyAccount{
-				AccountId: accountID,
-			},
-		},
-	}
-	accountEntry, err := getAccountEntry(&change)
-	if err != nil {
-		t.Error(err)
-	}
-	if accountEntry != nil {
-		t.Fatal("got account entry non-nil for removal, want account entry nil")
-	}
-}
-
-func TestGetAccountEntryNotRemoved(t *testing.T) {
-	wantAddress := "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"
-	accountID, err := xdr.AddressToAccountId(wantAddress)
-	if err != nil {
-		t.Error(err)
-	}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-		State: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
-				Type: xdr.LedgerEntryTypeAccount,
-				Account: &xdr.AccountEntry{
-					AccountId: accountID,
-				},
-			},
-		},
-	}
-	accountEntry, err := getAccountEntry(&change)
-	if err != nil {
-		t.Error(err)
-	}
-	gotAddress := accountEntry.AccountId.Address()
-	if gotAddress != wantAddress {
-		t.Fatalf("got address %s, want address %s", gotAddress, wantAddress)
 	}
 }
 

--- a/exp/hubble/schema_factory_test.go
+++ b/exp/hubble/schema_factory_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TODO: Replace manual equality check with `assert`, across all tests.
-func TestMakeAccountIDFromState(t *testing.T) {
+func TestMakeAccountIDFromStateOrChange(t *testing.T) {
 	wantAddress := "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"
 	state := accountState{address: wantAddress}
 	change := xdr.LedgerEntryChange{
@@ -21,7 +21,7 @@ func TestMakeAccountIDFromState(t *testing.T) {
 			},
 		},
 	}
-	gotAddress, err := makeAccountID(&change, &state)
+	gotAddress, err := makeAccountIDFromStateOrChange(&state, &change)
 	if err != nil {
 		t.Error(err)
 	}
@@ -47,7 +47,7 @@ func TestMakeAccountIDFromChange(t *testing.T) {
 			},
 		},
 	}
-	gotAddress, err := makeAccountID(&change)
+	gotAddress, err := makeAccountIDFromStateOrChange(nil, &change)
 	if err != nil {
 		t.Error(err)
 	}

--- a/exp/hubble/schema_factory_test.go
+++ b/exp/hubble/schema_factory_test.go
@@ -32,26 +32,6 @@ func TestAccountRemoved(t *testing.T) {
 	}
 }
 
-func TestMakeAccountIDFromState(t *testing.T) {
-	wantAddress := "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"
-	state := accountState{address: wantAddress}
-	change := xdr.LedgerEntryChange{
-		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-		State: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
-				Type: xdr.LedgerEntryTypeAccount,
-			},
-		},
-	}
-	gotAddress, err := makeAccountIDFromStateOrChange(&state, &change)
-	if err != nil {
-		t.Error(err)
-	}
-	if wantAddress != gotAddress {
-		t.Fatalf("got address %s, want address %s", gotAddress, wantAddress)
-	}
-}
-
 func TestMakeAccountIDFromChange(t *testing.T) {
 	wantAddress := "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"
 	accountID, err := xdr.AddressToAccountId(wantAddress)
@@ -69,7 +49,7 @@ func TestMakeAccountIDFromChange(t *testing.T) {
 			},
 		},
 	}
-	gotAddress, err := makeAccountIDFromStateOrChange(nil, &change)
+	gotAddress, err := makeAccountIDFromChange(&change)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
### What

This PR changes the functions used to retrieve the various fields from an `xdr.LedgerEntryChange` to be panic-free.

### Why
We want to minimize panics in a long-running, data-intensive application like Hubble, because a single malformed input can potentially end the entire ingestion process.

### Known limitations

While not a limitation per se, note that this PR is split off from a larger testing rewrite (#1985). It is a functional change that can be made separately, and splitting it off reduces reviewer fatigue on that already-large PR.