### PR TITLE
services/horizon/internal: Use registered errors to recover from errors in streaming.

### DIFF
--- a/services/horizon/internal/render/sse/stream.go
+++ b/services/horizon/internal/render/sse/stream.go
@@ -112,8 +112,9 @@ func (s *Stream) Err(err error) {
 		err = errNoObject
 	}
 
-	err = problem.IsKnownError(err)
-	if err == nil {
+	if knownErr := problem.IsKnownError(err); knownErr != nil {
+		err = knownErr
+	} else {
 		log.Ctx(s.ctx).WithStack(err).Error(err)
 		err = errBadStream
 	}

--- a/services/horizon/internal/render/sse/stream.go
+++ b/services/horizon/internal/render/sse/stream.go
@@ -20,11 +20,6 @@ var (
 	ErrRateLimited = errors.New("Rate limit exceeded")
 )
 
-var knownErrors = map[error]struct{}{
-	sql.ErrNoRows:  struct{}{},
-	ErrRateLimited: struct{}{},
-}
-
 type Stream struct {
 	ctx      context.Context
 	initSync sync.Once  // Variable to ensure that Init only writes the preamble once.
@@ -117,9 +112,9 @@ func (s *Stream) Err(err error) {
 		err = errNoObject
 	}
 
-	_, ok := knownErrors[rootErr]
-	if !ok {
-		log.Ctx(s.ctx).Error(err)
+	err = problem.IsKnownError(err)
+	if err == nil {
+		log.Ctx(s.ctx).WithStack(err).Error(err)
 		err = errBadStream
 	}
 

--- a/services/horizon/internal/render/sse/stream_test.go
+++ b/services/horizon/internal/render/sse/stream_test.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"testing"
 
+	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
+	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/support/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -68,6 +70,20 @@ func (suite *StreamTestSuite) TestStream_Err() {
 	suite.stream.Err(err)
 	suite.checkHeadersAndPreamble()
 	assert.Contains(suite.T(), suite.w.Body.String(), "event: error\ndata: Unexpected stream error\n\n")
+	assert.True(suite.T(), suite.stream.IsDone())
+}
+
+// Tests that Stream can send handled registered errors
+func (suite *StreamTestSuite) TestStream_ErrRegisterError() {
+	problem.RegisterError(context.DeadlineExceeded, hProblem.Timeout)
+	defer problem.UnRegisterErrors()
+
+	suite.w = httptest.NewRecorder()
+	suite.stream = NewStream(suite.ctx, suite.w)
+	suite.stream.sent++
+	suite.stream.Err(context.DeadlineExceeded)
+	suite.checkHeadersAndPreamble()
+	assert.Contains(suite.T(), suite.w.Body.String(), "event: error\ndata: problem: timeout\n\n")
 	assert.True(suite.T(), suite.stream.IsDone())
 }
 

--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -76,6 +76,26 @@ func RegisterError(err error, p P) {
 	errToProblemMap[err] = p
 }
 
+// IsKnownError maps an error to a list of known errors
+func IsKnownError(err error) error {
+	origErr := errors.Cause(err)
+
+	switch origErr.(type) {
+	case error:
+		if err, ok := errToProblemMap[origErr]; ok {
+			return err
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+// UnRegisterErrors removes all registered errors
+func UnRegisterErrors() {
+	errToProblemMap = map[error]P{}
+}
+
 // RegisterHost registers the service host url. It is used to prepend the host
 // url to the error type. If you don't wish to prepend anything to the error
 // type, register host as an empty string.

--- a/support/render/problem/problem_test.go
+++ b/support/render/problem/problem_test.go
@@ -150,3 +150,24 @@ func TestRegisterReportFunc(t *testing.T) {
 	Render(ctx, w, err)
 	assert.Equal(t, want, buf.String())
 }
+
+func TestUnRegisterErrors(t *testing.T) {
+	RegisterError(context.DeadlineExceeded, ServerError)
+	err := IsKnownError(context.DeadlineExceeded)
+	assert.Error(t, err, ServerError.Error())
+
+	UnRegisterErrors()
+
+	err = IsKnownError(context.DeadlineExceeded)
+	assert.NoError(t, err)
+}
+
+func IsTestKnownError(t *testing.T) {
+	RegisterError(context.DeadlineExceeded, ServerError)
+	defer UnRegisterErrors()
+	err := IsKnownError(context.DeadlineExceeded)
+	assert.Error(t, err, ServerError.Error())
+
+	err = IsKnownError(errors.New("foo"))
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Use `problem.RegisterErrors` in streaming code and extend `support/problems` to expose register errors to its consumers.

### Why

#2007 and  #2005 were occurring because we were not handling properly `context.DeadlineExceeded`, `context.Canceled` or `db.ErrCancelled` -  this occurred because `stream` had its own list of `knownErrors` instead of using the map from `support/problem` which is initialized in `web.go`.

This will also reduce the need to keep track of `knownErrors` in two different places, we should use `problem.RegisterErrors` as the source of truth.

### Known limitations

[TODO or N/A]
