### PR TITLE
services/horizon/internal: Fix ParseFloat bug in /fee_stats

### DIFF
--- a/services/horizon/internal/actions_operation_fee_stats.go
+++ b/services/horizon/internal/actions_operation_fee_stats.go
@@ -82,13 +82,16 @@ func (action *FeeStatsAction) loadRecords() {
 	action.feeStats.LastLedgerBaseFee = cur.LastBaseFee
 	action.feeStats.LastLedger = cur.LastLedger
 
-	ledgerCapacityUsage, err := strconv.ParseFloat(cur.LedgerCapacityUsage, 64)
-	if err != nil {
-		action.Err = err
-		return
+	// LedgerCapacityUsage is the empty string when operationfeestats has not had its state set
+	if len(cur.LedgerCapacityUsage) > 0 {
+		action.feeStats.LedgerCapacityUsage, action.Err = strconv.ParseFloat(
+			cur.LedgerCapacityUsage,
+			64,
+		)
+		if action.Err != nil {
+			return
+		}
 	}
-
-	action.feeStats.LedgerCapacityUsage = ledgerCapacityUsage
 
 	// FeeCharged
 	action.feeStats.FeeCharged.Max = cur.FeeChargedMax

--- a/services/horizon/internal/actions_operation_fee_stats.go
+++ b/services/horizon/internal/actions_operation_fee_stats.go
@@ -78,12 +78,12 @@ func (action *FeeStatsAction) JSON() error {
 }
 
 func (action *FeeStatsAction) loadRecords() {
-	cur := operationfeestats.CurrentState()
+	cur, ok := operationfeestats.CurrentState()
 	action.feeStats.LastLedgerBaseFee = cur.LastBaseFee
 	action.feeStats.LastLedger = cur.LastLedger
 
 	// LedgerCapacityUsage is the empty string when operationfeestats has not had its state set
-	if len(cur.LedgerCapacityUsage) > 0 {
+	if ok {
 		action.feeStats.LedgerCapacityUsage, action.Err = strconv.ParseFloat(
 			cur.LedgerCapacityUsage,
 			64,

--- a/services/horizon/internal/actions_operation_fee_stats_test.go
+++ b/services/horizon/internal/actions_operation_fee_stats_test.go
@@ -284,6 +284,17 @@ func TestOperationFeeTestsActions_ShowMultiOp(t *testing.T) {
 	}
 }
 
+func TestEmptyFeeStats(t *testing.T) {
+	ht := StartHTTPTestWithoutScenario(t)
+	defer ht.Finish()
+	w := ht.Get("/fee_stats")
+	ht.Assert.Equal(200, w.Code)
+	var result hProtocol.FeeStats
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	ht.Require.NoError(err)
+	ht.Assert.Equal(result, hProtocol.FeeStats{})
+}
+
 func TestOperationFeeTestsActions_NotInterpolating(t *testing.T) {
 	ht := StartHTTPTest(t, "operation_fee_stats_3")
 	defer ht.Finish()

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -238,7 +238,7 @@ func (a *App) UpdateFeeStatsState() {
 		log.WithStack(err).WithField("err", err.Error()).Error(msg)
 	}
 
-	cur := operationfeestats.CurrentState()
+	cur, ok := operationfeestats.CurrentState()
 
 	err := a.HistoryQ().LatestLedgerBaseFeeAndSequence(&latest)
 	if err != nil {
@@ -247,7 +247,7 @@ func (a *App) UpdateFeeStatsState() {
 	}
 
 	// finish early if no new ledgers
-	if cur.LastLedger == uint32(latest.Sequence) {
+	if ok && cur.LastLedger == uint32(latest.Sequence) {
 		return
 	}
 

--- a/services/horizon/internal/operationfeestats/main.go
+++ b/services/horizon/internal/operationfeestats/main.go
@@ -48,12 +48,14 @@ type State struct {
 	LedgerCapacityUsage string
 }
 
-// CurrentState returns the cached snapshot of operation fee state
-func CurrentState() State {
+// CurrentState returns the cached snapshot of operation fee state and a boolean indicating
+// if the cache has been populated
+func CurrentState() (State, bool) {
 	lock.RLock()
 	ret := current
+	ok := present
 	lock.RUnlock()
-	return ret
+	return ret, ok
 }
 
 // SetState updates the cached snapshot of the operation fee state
@@ -64,13 +66,16 @@ func SetState(next State) {
 	if current.LastLedger < next.LastLedger {
 		current = next
 	}
+	present = true
 	lock.Unlock()
 }
 
 // ResetState is used only for testing purposes
 func ResetState() {
 	current = State{}
+	present = false
 }
 
 var current State
+var present bool
 var lock sync.RWMutex


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fix ParseFloat bug in /fee_stats endpoint.

Close https://github.com/stellar/go/issues/2006

### Why

`operationfeestats.CurrentState()` returns a struct with the following fields:

https://github.com/stellar/go/blob/release-horizon-v0.24.0/services/horizon/internal/operationfeestats/main.go#L14-L49

Before `operationfeestats.SetState()` is ever called, `operationfeestats.CurrentState()` would return the default empty struct which means `LedgerCapacityUsage` would be set to the empty string.

The previous code attempted to parse this string as float thereby causing the handler to fail. To fix this I check that `LedgerCapacityUsage` is not empty before parsing it.

### Known limitations

[TODO or N/A]
