### PR TITLE
Remove custom handler for sql.ErrNoRows in stream.

### DIFF
--- a/services/horizon/internal/render/sse/stream.go
+++ b/services/horizon/internal/render/sse/stream.go
@@ -2,7 +2,6 @@ package sse
 
 import (
 	"context"
-	"database/sql"
 	"net/http"
 	"sync"
 
@@ -16,7 +15,6 @@ var (
 	errBadStream = errors.New("Unexpected stream error")
 
 	// known errors
-	errNoObject    = errors.New("Object not found")
 	ErrRateLimited = errors.New("Rate limit exceeded")
 )
 
@@ -104,12 +102,6 @@ func (s *Stream) Err(err error) {
 	if s.sent == 0 {
 		problem.Render(s.ctx, s.w, err)
 		return
-	}
-
-	rootErr := errors.Cause(err)
-	if rootErr == sql.ErrNoRows {
-		//TODO: return errNoObject directly in SSE() methods.
-		err = errNoObject
 	}
 
 	if knownErr := problem.IsKnownError(err); knownErr != nil {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fix #2011: `Object not found` error.

### Why
 
We change the implementation in https://github.com/stellar/go/pull/2008/files#diff-0a5d051d9afdb26132d468c0138c21bbR115 to look directly at the err and not `rootError`. This was causing the code not to recognize the custom err for object not found. Instead of keeping a custom err for `sql.NoRows` we should delegate this to problem which already handles `sql.NoRows`.

### Known limitations

- This could be a breaking change for people using streaming and then parsing the string `Object not found`, with the custom handle the message would be `not_found` (see test).  I'm inclined towards doing this and remove more custom error handling in this file.
