### PR TITLE
protocols/horizon: Change JSON response from int64 to string in multiple places.

### DIFF
--- a/clients/horizon/main_test.go
+++ b/clients/horizon/main_test.go
@@ -704,7 +704,7 @@ var accountOffersResponse = `{
             "href": "https://horizon.stellar.org/accounts/GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK"
           }
         },
-        "id": 161,
+        "id": "161",
         "paging_token": "161",
         "seller": "GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK",
         "selling": {
@@ -731,7 +731,7 @@ var accountOffersResponse = `{
             "href": "https://horizon.stellar.org/accounts/GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK"
           }
         },
-        "id": 2539,
+        "id": "2539",
         "paging_token": "2539",
         "seller": "GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK",
         "selling": {

--- a/clients/horizonclient/effect_request_test.go
+++ b/clients/horizonclient/effect_request_test.go
@@ -170,11 +170,7 @@ func TestSequenceBumpedNewSeq(t *testing.T) {
 	}{
 		{
 			desc:    "new_seq as a string",
-			payload: sequenceBumpedAsStringPage,
-		},
-		{
-			desc:    "new_seq as a number",
-			payload: sequenceBumpedAsNumberPage,
+			payload: sequenceBumpedPage,
 		},
 	}
 	for _, tc := range testCases {
@@ -297,45 +293,7 @@ var firstEffectsPage = `{
   }
 }`
 
-var sequenceBumpedAsNumberPage = `{
-	"_links": {
-	  "self": {
-		"href": "https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=&limit=10&order=asc"
-	  },
-	  "next": {
-		"href": "https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=1557363731492865-3&limit=10&order=asc"
-	  },
-	  "prev": {
-		"href": "https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=1557363731492865-1&limit=10&order=desc"
-	  }
-	},
-	"_embedded": {
-	  "records": [
-		{
-		  "_links": {
-			"operation": {
-			  "href": "https://horizon-testnet.stellar.org/operations/249108107265"
-			},
-			"succeeds": {
-			  "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=249108107265-1"
-			},
-			"precedes": {
-			  "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=249108107265-1"
-			}
-		  },
-		  "id": "0000000249108107265-0000000001",
-		  "paging_token": "249108107265-1",
-		  "account": "GCQZP3IU7XU6EJ63JZXKCQOYT2RNXN3HB5CNHENNUEUHSMA4VUJJJSEN",
-		  "type": "sequence_bumped",
-		  "type_i": 43,
-		  "created_at": "2019-06-03T16:36:24Z",
-		  "new_seq": 300000000000
-		}
-	  ]
-	}
-  }`
-
-var sequenceBumpedAsStringPage = `{
+var sequenceBumpedPage = `{
 	"_links": {
 	  "self": {
 		"href": "https://horizon-testnet.stellar.org/accounts/GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD/effects?cursor=&limit=10&order=asc"

--- a/clients/horizonclient/effect_request_test.go
+++ b/clients/horizonclient/effect_request_test.go
@@ -207,7 +207,7 @@ func TestTradeEffectOfferID(t *testing.T) {
 	}{
 		{
 			desc:    "offer_id as a string",
-			payload: tradeEffectStringOfferID,
+			payload: tradeEffectPage,
 		},
 	}
 	for _, tc := range testCases {
@@ -331,7 +331,7 @@ var sequenceBumpedPage = `{
 	}
   }`
 
-var tradeEffectStringOfferID = `
+var tradeEffectPage = `
 {
 	"_embedded": {
 	  "records": [

--- a/clients/horizonclient/effect_request_test.go
+++ b/clients/horizonclient/effect_request_test.go
@@ -210,10 +210,6 @@ func TestTradeEffectOfferID(t *testing.T) {
 		payload string
 	}{
 		{
-			desc:    "offer_id as a number",
-			payload: tradeEffectNumberOfferID,
-		},
-		{
 			desc:    "offer_id as a string",
 			payload: tradeEffectStringOfferID,
 		},
@@ -376,42 +372,6 @@ var sequenceBumpedAsStringPage = `{
 	  ]
 	}
   }`
-
-var tradeEffectNumberOfferID = `
-{
-	"_embedded": {
-	  "records": [
-		{
-		  "_links": {
-			"operation": {
-			  "href": "https://horizon-testnet.stellar.org/operations/224209713045979100"
-			},
-			"succeeds": {
-			  "href": "https://horizon-testnet.stellar.org/effects?order=desc&cursor=224209713045979100-3"
-			},
-			"precedes": {
-			  "href": "https://horizon-testnet.stellar.org/effects?order=asc&cursor=224209713045979100-3"
-			}
-		  },
-		  "id": "2214209713045979100-0000000003",
-		  "paging_token": "224209713045979100-3",
-		  "account": "GCDIZFWLOTBWHTPODXCBH6XNXPFMSQFRVIDRP3JLEKQZN66G7NF3ANOD",
-		  "type": "trade",
-		  "type_i": 33,
-		  "created_at": "2019-11-01T23:05:58Z",
-		  "seller": "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX",
-		  "offer_id": 127538672,
-		  "sold_amount": "14.5984123",
-		  "sold_asset_type": "native",
-		  "bought_amount": "1.0000000",
-		  "bought_asset_type": "credit_alphanum4",
-		  "bought_asset_code": "USD",
-		  "bought_asset_issuer": "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"
-		}
-	  ]
-	}
-}
-`
 
 var tradeEffectStringOfferID = `
 {

--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -1195,7 +1195,7 @@ var offersResponse = `{
             "href": "https://horizon-testnet.stellar.org/accounts/GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F"
           }
         },
-        "id": 432323,
+        "id": "432323",
         "paging_token": "432323",
         "seller": "GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F",
         "selling": {
@@ -1302,7 +1302,7 @@ var multipleOpsResponse = `{
         "selling_asset_type": "credit_alphanum4",
         "selling_asset_code": "XRP",
         "selling_asset_issuer": "GBVOL67TMUQBGL4TZYNMY3ZQ5WGQYFPFD5VJRWXR72VA33VFNL225PL5",
-        "offer_id": 73938565
+        "offer_id": "73938565"
       },  
       {
         "_links": {

--- a/clients/horizonclient/offer_request_test.go
+++ b/clients/horizonclient/offer_request_test.go
@@ -130,7 +130,7 @@ func TestStringOfferID(t *testing.T) {
 	assert.Equal(t, int64(2946580), offers.Embedded.Records[0].ID)
 }
 
-var offerStreamResponse = `data: {"_links":{"self":{"href":"https://horizon-testnet.stellar.org/offers/5269100"},"offer_maker":{"href":"https://horizon-testnet.stellar.org/accounts/GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C"}},"id":5269100,"paging_token":"5269100","seller":"GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C","selling":{"asset_type":"credit_alphanum4","asset_code":"DSQ","asset_issuer":"GBDQPTQJDATT7Z7EO4COS4IMYXH44RDLLI6N6WIL5BZABGMUOVMLWMQF"},"buying":{"asset_type":"credit_alphanum4","asset_code":"XCS6","asset_issuer":"GBH2V47NOZRC56QAYCPV5JUBG5NVFJQF5AQTUNFNWNDHSWWTKH2MWR2L"},"amount":"20.4266087","price_r":{"n":24819,"d":10000000},"price":"0.0024819","last_modified_ledger":674449,"last_modified_time":"2019-04-08T11:56:41Z"}
+var offerStreamResponse = `data: {"_links":{"self":{"href":"https://horizon-testnet.stellar.org/offers/5269100"},"offer_maker":{"href":"https://horizon-testnet.stellar.org/accounts/GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C"}},"id":"5269100","paging_token":"5269100","seller":"GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C","selling":{"asset_type":"credit_alphanum4","asset_code":"DSQ","asset_issuer":"GBDQPTQJDATT7Z7EO4COS4IMYXH44RDLLI6N6WIL5BZABGMUOVMLWMQF"},"buying":{"asset_type":"credit_alphanum4","asset_code":"XCS6","asset_issuer":"GBH2V47NOZRC56QAYCPV5JUBG5NVFJQF5AQTUNFNWNDHSWWTKH2MWR2L"},"amount":"20.4266087","price_r":{"n":24819,"d":10000000},"price":"0.0024819","last_modified_ledger":674449,"last_modified_time":"2019-04-08T11:56:41Z"}
 `
 var emptyOffersPage = `{
   "_links": {
@@ -172,7 +172,7 @@ var firstOffersPage = `{
             "href": "https://horizon-testnet.stellar.org/accounts/GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG"
           }
         },
-        "id": 2946580,
+        "id": "2946580",
         "paging_token": "2946580",
         "seller": "GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG",
         "selling": {
@@ -203,7 +203,7 @@ var firstOffersPage = `{
             "href": "https://horizon-testnet.stellar.org/accounts/GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG"
           }
         },
-        "id": 2946581,
+        "id": "2946581",
         "paging_token": "2946581",
         "seller": "GBZ5OD56VRTRQKMNADD6VUZUG3FCILMAMYQY5ZSC3AW3GBXNEPIK76IG",
         "selling": {

--- a/clients/horizonclient/operation_request_test.go
+++ b/clients/horizonclient/operation_request_test.go
@@ -188,7 +188,7 @@ func TestManageSellManageBuyOfferOfferID(t *testing.T) {
 	}{
 		{
 			desc:    "offer_id as a string",
-			payload: stringManageSellBuyOfferOperations,
+			payload: manageSellBuyOfferOperationsPage,
 		},
 	}
 	for _, tc := range testCases {
@@ -407,7 +407,7 @@ var numberManageSellBuyOfferOperations = `{
 	}
   }`
 
-var stringManageSellBuyOfferOperations = `{
+var manageSellBuyOfferOperationsPage = `{
 	"_links": {
 	  "self": {
 		"href": "https://horizon-testnet.stellar.org/operations?cursor=661424967682&limit=2&order=asc"

--- a/clients/horizonclient/operation_request_test.go
+++ b/clients/horizonclient/operation_request_test.go
@@ -187,10 +187,6 @@ func TestManageSellManageBuyOfferOfferID(t *testing.T) {
 		payload string
 	}{
 		{
-			desc:    "offer_id as a number",
-			payload: numberManageSellBuyOfferOperations,
-		},
-		{
 			desc:    "offer_id as a string",
 			payload: stringManageSellBuyOfferOperations,
 		},

--- a/clients/horizonclient/trade_aggregation_request_test.go
+++ b/clients/horizonclient/trade_aggregation_request_test.go
@@ -219,8 +219,8 @@ var tradeAggsResponse = `{
   "_embedded": {
     "records": [
       {
-        "timestamp": 1517522400000,
-        "trade_count": 26,
+        "timestamp": "1517522400000",
+        "trade_count": "26",
         "base_volume": "27575.0201596",
         "counter_volume": "5085.6410385",
         "avg": "0.1844293",
@@ -246,8 +246,8 @@ var tradeAggsResponse = `{
         }
       },
       {
-        "timestamp": 1517526000000,
-        "trade_count": 15,
+        "timestamp": "1517526000000",
+        "trade_count": "15",
         "base_volume": "3913.8224543",
         "counter_volume": "719.4993608",
         "avg": "0.1838355",
@@ -291,8 +291,8 @@ var firstTradeAggsPage = `{
   "_embedded": {
     "records": [
       {
-        "timestamp": 1565026860000,
-        "trade_count": 3,
+        "timestamp": "1565026860000",
+        "trade_count": "3",
         "base_volume": "23781.2128418",
         "counter_volume": "2.0000000",
         "avg": "0.0000841",
@@ -318,8 +318,8 @@ var firstTradeAggsPage = `{
         }
       },
       {
-        "timestamp": 1565026920000,
-        "trade_count": 1,
+        "timestamp": "1565026920000",
+        "trade_count": "1",
         "base_volume": "11890.6052319",
         "counter_volume": "0.9999999",
         "avg": "0.0000841",

--- a/protocols/horizon/base/main.go
+++ b/protocols/horizon/base/main.go
@@ -1,7 +1,5 @@
 package base
 
-import "encoding/json"
-
 type Price struct {
 	N int32 `json:"n"`
 	D int32 `json:"d"`
@@ -22,23 +20,4 @@ type Asset struct {
 // value from the old field to the new field.
 type Rehydratable interface {
 	Rehydrate() error
-}
-
-// ExtractOfferID extracts offer_id from a JSON payload
-// Action needed in release: horizon-v0.25.0: remove
-func ExtractOfferID(data []byte) (int64, error) {
-	var temp struct {
-		OfferID json.Number `json:"offer_id"`
-	}
-
-	if err := json.Unmarshal(data, &temp); err != nil {
-		return 0, err
-	}
-
-	offerID, err := temp.OfferID.Int64()
-	if err != nil {
-		return 0, err
-	}
-
-	return offerID, nil
 }

--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -198,8 +198,7 @@ type AccountFlagsUpdated struct {
 
 type SequenceBumped struct {
 	Base
-	// Action needed in release: horizon-v0.25.0: make new_seq as string
-	NewSeq int64 `json:"new_seq"`
+	NewSeq int64 `json:"new_seq,string"`
 }
 
 // UnmarshalJSON is the custom unmarshal method for SequenceBumped. It allows
@@ -280,10 +279,10 @@ type TrustlineDeauthorized struct {
 	AssetCode string `json:"asset_code,omitempty"`
 }
 
-// Action needed in release: horizon-v0.25.0: move back to Trade, remove
-// embedded struct
-type tradeBase struct {
+type Trade struct {
+	Base
 	Seller            string `json:"seller"`
+	OfferID           int64  `json:"offer_id,string"`
 	SoldAmount        string `json:"sold_amount"`
 	SoldAssetType     string `json:"sold_asset_type"`
 	SoldAssetCode     string `json:"sold_asset_code,omitempty"`
@@ -292,37 +291,6 @@ type tradeBase struct {
 	BoughtAssetType   string `json:"bought_asset_type"`
 	BoughtAssetCode   string `json:"bought_asset_code,omitempty"`
 	BoughtAssetIssuer string `json:"bought_asset_issuer,omitempty"`
-}
-
-type Trade struct {
-	Base
-	tradeBase
-	// Action needed in release: horizon-v0.25.0: Make offer_id a string
-	OfferID int64 `json:"offer_id"`
-}
-
-// UnmarshalJSON is the custom unmarshal method for Trade. It allows
-// parsing of offer_id as a string or an int64.
-// Action needed in release: horizon-v0.25.0: Delete
-func (effect *Trade) UnmarshalJSON(data []byte) error {
-	var tradeWithoutOfferID struct {
-		Base
-		tradeBase
-	}
-	if err := json.Unmarshal(data, &tradeWithoutOfferID); err != nil {
-		return err
-	}
-
-	offerID, err := base.ExtractOfferID(data)
-	if err != nil {
-		return err
-	}
-
-	effect.Base = tradeWithoutOfferID.Base
-	effect.tradeBase = tradeWithoutOfferID.tradeBase
-	effect.OfferID = offerID
-
-	return nil
 }
 
 // Effect contains methods that are implemented by all effect types.

--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -201,31 +201,6 @@ type SequenceBumped struct {
 	NewSeq int64 `json:"new_seq,string"`
 }
 
-// UnmarshalJSON is the custom unmarshal method for SequenceBumped. It allows
-// parsing of new_seq as a string or an int64.
-// Action needed in release: horizon-v0.25.0: Delete
-func (effect *SequenceBumped) UnmarshalJSON(data []byte) error {
-	var temp struct {
-		NewSeq json.Number `json:"new_seq"`
-	}
-
-	if err := json.Unmarshal(data, &effect.Base); err != nil {
-		return err
-	}
-
-	if err := json.Unmarshal(data, &temp); err != nil {
-		return err
-	}
-
-	newSeq, err := temp.NewSeq.Int64()
-	if err != nil {
-		return err
-	}
-	effect.NewSeq = newSeq
-
-	return nil
-}
-
 type SignerCreated struct {
 	Base
 	Weight    int32  `json:"weight"`

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -230,6 +230,7 @@ type offerBase struct {
 		OfferMaker hal.Link `json:"offer_maker"`
 	} `json:"_links"`
 
+	ID                 int64      `json:"id,string"`
 	PT                 string     `json:"paging_token"`
 	Seller             string     `json:"seller"`
 	Selling            Asset      `json:"selling"`
@@ -413,9 +414,10 @@ type TradeEffect struct {
 	LedgerCloseTime   time.Time `json:"created_at"`
 }
 
-// Action needed in release: horizon-v0.25.0: Move back to TradeAggregation,
-// remove embedded struct
-type tradeAggregationBase struct {
+// TradeAggregation represents trade data aggregation over a period of time
+type TradeAggregation struct {
+	Timestamp     int64     `json:"timestamp,string"`
+	TradeCount    int64     `json:"trade_count,string"`
 	BaseVolume    string    `json:"base_volume"`
 	CounterVolume string    `json:"counter_volume"`
 	Average       string    `json:"avg"`
@@ -429,51 +431,9 @@ type tradeAggregationBase struct {
 	CloseR        xdr.Price `json:"close_r"`
 }
 
-// TradeAggregation represents trade data aggregation over a period of time
-type TradeAggregation struct {
-	tradeAggregationBase
-	// Action needed in release: horizon-v0.25.0: Make timestamp a string
-	Timestamp int64 `json:"timestamp"`
-	// Action needed in release: horizon-v0.25.0: Make trade_count a string
-	TradeCount int64 `json:"trade_count"`
-}
-
 // PagingToken implementation for hal.Pageable. Not actually used
 func (res TradeAggregation) PagingToken() string {
 	return string(res.Timestamp)
-}
-
-// UnmarshalJSON is the custom unmarshal method for TradeAggregation. It allows
-// parsing of timestamp and trade_count as a string or an int64.
-// Action needed in release: horizon-v0.25.0: Delete
-func (res *TradeAggregation) UnmarshalJSON(data []byte) error {
-	var temp struct {
-		Timestamp  json.Number `json:"timestamp"`
-		TradeCount json.Number `json:"trade_count"`
-	}
-
-	if err := json.Unmarshal(data, &res.tradeAggregationBase); err != nil {
-		return err
-	}
-
-	if err := json.Unmarshal(data, &temp); err != nil {
-		return err
-	}
-
-	timestamp, err := temp.Timestamp.Int64()
-	if err != nil {
-		return err
-	}
-
-	tradeCount, err := temp.TradeCount.Int64()
-	if err != nil {
-		return err
-	}
-
-	res.Timestamp = timestamp
-	res.TradeCount = tradeCount
-
-	return nil
 }
 
 // Transaction represents a single, successful transaction

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -223,8 +223,8 @@ func (l Ledger) PagingToken() string {
 	return l.PT
 }
 
-// Action needed in release: horizon-v0.25.0: Move back to Offer, remove embedded struct
-type offerBase struct {
+// Offer is the display form of an offer to trade currency.
+type Offer struct {
 	Links struct {
 		Self       hal.Link `json:"self"`
 		OfferMaker hal.Link `json:"offer_maker"`
@@ -242,41 +242,8 @@ type offerBase struct {
 	LastModifiedTime   *time.Time `json:"last_modified_time"`
 }
 
-// Offer is the display form of an offer to trade currency.
-type Offer struct {
-	offerBase
-	// Action needed in release: horizon-v0.25.0: Make id a string
-	ID int64 `json:"id"`
-}
-
 func (o Offer) PagingToken() string {
 	return o.PT
-}
-
-// UnmarshalJSON is the custom unmarshal method for Offer. It allows
-// parsing of id as a string or an int64.
-// Action needed in release: horizon-v0.25.0: Delete
-func (o *Offer) UnmarshalJSON(data []byte) error {
-	var temp struct {
-		ID json.Number `json:"id"`
-	}
-
-	if err := json.Unmarshal(data, &o.offerBase); err != nil {
-		return err
-	}
-
-	if err := json.Unmarshal(data, &temp); err != nil {
-		return err
-	}
-
-	offerID, err := temp.ID.Int64()
-	if err != nil {
-		return err
-	}
-
-	o.ID = offerID
-
-	return nil
 }
 
 // OrderBookSummary represents a snapshot summary of a given order book

--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -151,55 +151,14 @@ type CreatePassiveSellOffer struct {
 // is ManageSellOffer.
 type ManageSellOffer struct {
 	Offer
-	// Action needed in release: horizon-v0.25.0: Make offer_id a string
-	OfferID int64 `json:"offer_id"`
-}
-
-// UnmarshalJSON is the custom unmarshal method for ManageSellOffer. It allows
-// parsing of offer_id as a string or an int64.
-// Action needed in release: horizon-v0.25.0: Delete
-func (operation *ManageSellOffer) UnmarshalJSON(data []byte) error {
-	if err := json.Unmarshal(data, &operation.Offer); err != nil {
-		return err
-	}
-
-	offerID, err := base.ExtractOfferID(data)
-
-	if err != nil {
-		return err
-	}
-
-	operation.OfferID = offerID
-
-	return nil
+	OfferID int64 `json:"offer_id,string"`
 }
 
 // ManageBuyOffer is the json resource representing a single operation whose type
 // is ManageBuyOffer.
 type ManageBuyOffer struct {
 	Offer
-
-	// Action needed in release: horizon-v0.25.0: Make offer_id a string
-	OfferID int64 `json:"offer_id"`
-}
-
-// UnmarshalJSON is the custom unmarshal method for ManageBuyOffer. It allows
-// parsing of offer_id as a string or an int64.
-// Action needed in release: horizon-v0.25.0: Delete
-func (operation *ManageBuyOffer) UnmarshalJSON(data []byte) error {
-	if err := json.Unmarshal(data, &operation.Offer); err != nil {
-		return err
-	}
-
-	offerID, err := base.ExtractOfferID(data)
-
-	if err != nil {
-		return err
-	}
-
-	operation.OfferID = offerID
-
-	return nil
+	OfferID int64 `json:"offer_id,string"`
 }
 
 // SetOptions is the json resource representing a single operation whose type is

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -322,6 +322,15 @@ func TestOperationEffect_BumpSequence(t *testing.T) {
 		var result []effects.SequenceBumped
 		ht.UnmarshalPage(w.Body, &result)
 		ht.Assert.Equal(int64(300000000000), result[0].NewSeq)
+
+		data, err := json.Marshal(&result[0])
+		ht.Assert.NoError(err)
+		effect := struct {
+			NewSeq string `json:"new_seq"`
+		}{}
+
+		json.Unmarshal(data, &effect)
+		ht.Assert.Equal("300000000000", effect.NewSeq)
 	}
 }
 

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -333,6 +333,26 @@ func TestOperationEffect_BumpSequence(t *testing.T) {
 		ht.Assert.Equal("300000000000", effect.NewSeq)
 	}
 }
+func TestOperationEffect_Trade(t *testing.T) {
+	ht := StartHTTPTest(t, "kahuna")
+	defer ht.Finish()
+
+	w := ht.Get("/operations/103079219201/effects")
+	if ht.Assert.Equal(200, w.Code) {
+		var result []effects.Trade
+		ht.UnmarshalPage(w.Body, &result)
+		ht.Assert.Equal(int64(3), result[0].OfferID)
+
+		data, err := json.Marshal(&result[0])
+		ht.Assert.NoError(err)
+		effect := struct {
+			OfferID string `json:"offer_id"`
+		}{}
+
+		json.Unmarshal(data, &effect)
+		ht.Assert.Equal("3", effect.OfferID)
+	}
+}
 
 func TestOperation_IncludeTransaction(t *testing.T) {
 	ht := StartHTTPTest(t, "kahuna")

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -384,6 +384,12 @@ type Operation struct {
 	TransactionSuccessful *bool `db:"transaction_successful"`
 }
 
+// ManageOffer is a struct of data from `operations.DetailsString`
+// when the operation type is manage sell offer or manage buy offer
+type ManageOffer struct {
+	OfferID int64 `json:"offer_id"`
+}
+
 // Offer is row of data from the `offers` table from horizon DB
 type Offer struct {
 	SellerID string    `db:"seller_id"`

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -261,6 +261,21 @@ type Effect struct {
 	DetailsString      null.String `db:"details"`
 }
 
+// TradeEffectDetails is a struct of data from `effects.DetailsString`
+// when the effect type is trade
+type TradeEffectDetails struct {
+	Seller            string `json:"seller"`
+	OfferID           int64  `json:"offer_id"`
+	SoldAmount        string `json:"sold_amount"`
+	SoldAssetType     string `json:"sold_asset_type"`
+	SoldAssetCode     string `json:"sold_asset_code,omitempty"`
+	SoldAssetIssuer   string `json:"sold_asset_issuer,omitempty"`
+	BoughtAmount      string `json:"bought_amount"`
+	BoughtAssetType   string `json:"bought_asset_type"`
+	BoughtAssetCode   string `json:"bought_asset_code,omitempty"`
+	BoughtAssetIssuer string `json:"bought_asset_issuer,omitempty"`
+}
+
 // SequenceBumped is a struct of data from `effects.DetailsString`
 // when the effect type is sequence bumped.
 type SequenceBumped struct {

--- a/services/horizon/internal/resourceadapter/effects.go
+++ b/services/horizon/internal/resourceadapter/effects.go
@@ -107,13 +107,28 @@ func NewEffect(
 		result = e
 	case history.EffectTrade:
 		e := effects.Trade{Base: basev}
-		err = row.UnmarshalDetails(&e)
+		tradeDetails := history.TradeEffectDetails{}
+		err = row.UnmarshalDetails(&tradeDetails)
+		if err == nil {
+			e.Seller = tradeDetails.Seller
+			e.OfferID = tradeDetails.OfferID
+			e.SoldAmount = tradeDetails.SoldAmount
+			e.SoldAssetType = tradeDetails.SoldAssetType
+			e.SoldAssetCode = tradeDetails.SoldAssetCode
+			e.SoldAssetIssuer = tradeDetails.SoldAssetIssuer
+			e.BoughtAmount = tradeDetails.BoughtAmount
+			e.BoughtAssetType = tradeDetails.BoughtAssetType
+			e.BoughtAssetCode = tradeDetails.BoughtAssetCode
+			e.BoughtAssetIssuer = tradeDetails.BoughtAssetIssuer
+		}
 		result = e
 	case history.EffectSequenceBumped:
 		e := effects.SequenceBumped{Base: basev}
 		hsb := history.SequenceBumped{}
 		err = row.UnmarshalDetails(&hsb)
-		e.NewSeq = hsb.NewSeq
+		if err == nil {
+			e.NewSeq = hsb.NewSeq
+		}
 		result = e
 	default:
 		result = basev

--- a/services/horizon/internal/resourceadapter/operations.go
+++ b/services/horizon/internal/resourceadapter/operations.go
@@ -45,12 +45,22 @@ func NewOperation(
 	case xdr.OperationTypeManageBuyOffer:
 		e := operations.ManageBuyOffer{}
 		e.Offer.Base = base
-		err = operationRow.UnmarshalDetails(&e)
+		err = operationRow.UnmarshalDetails(&e.Offer)
+		if err == nil {
+			hmo := history.ManageOffer{}
+			err = operationRow.UnmarshalDetails(&hmo)
+			e.OfferID = hmo.OfferID
+		}
 		result = e
 	case xdr.OperationTypeManageSellOffer:
 		e := operations.ManageSellOffer{}
 		e.Offer.Base = base
-		err = operationRow.UnmarshalDetails(&e)
+		err = operationRow.UnmarshalDetails(&e.Offer)
+		if err == nil {
+			hmo := history.ManageOffer{}
+			err = operationRow.UnmarshalDetails(&hmo)
+			e.OfferID = hmo.OfferID
+		}
 		result = e
 	case xdr.OperationTypeCreatePassiveSellOffer:
 		e := operations.CreatePassiveSellOffer{}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

 Change the type for multiple JSON fields using `int64` to be of type `string`:
    
- Attribute `offer_id` in [manage buy offer](https://www.stellar.org/developers/horizon/reference/resources/operation.html#manage-buy-offer) and [manage sell offer](https://www.stellar.org/developers/horizon/reference/resources/operation.html#manage-sell-offer) operations.
- Attribute `offer_id` in [Trade](https://www.stellar.org/developers/horizon/reference/resources/effect.html#trading-effects) effect.
- Attribute `id` in [Offer](https://www.stellar.org/developers/horizon/reference/resources/offer.html) resource.
- Attribute `timestamp` and `trade_count` in [Trade Aggregation](https://www.stellar.org/developers/horizon/reference/resources/trade_aggregation.html) resource.
- Attribute `new_seq` in [Sequence Bumpeed](https://www.stellar.org/developers/horizon/reference/resources/effect.html#misc-effects) effect.

 ### Why

As discussed in the following issues:  #1609,  #1363 -- we should be using string for int64 values since it leads to data getting lost when using JS.

### Known limitations

- N/A

### TODO

Update branch once fee deprecation has been merge in 0.25.0 release
