### PR TITLE
services/horizon: Pass errors to problem.Render in ExperimentalIngestionMiddleware

### DIFF
--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/render"
 	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/support/db"
+	supportErrors "github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/problem"
 )
@@ -267,7 +268,6 @@ type ExperimentalIngestionMiddleware struct {
 // Wrap executes the middleware on a given http handler
 func (m *ExperimentalIngestionMiddleware) Wrap(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
 		if !m.EnableExperimentalIngestion {
 			problem.Render(r.Context(), w, problem.NotFound)
 			return
@@ -279,7 +279,6 @@ func (m *ExperimentalIngestionMiddleware) Wrap(h http.Handler) http.Handler {
 			return
 		}
 
-		localLog := log.Ctx(ctx)
 		session := m.HorizonSession.Clone()
 		q := &history.Q{session}
 
@@ -290,7 +289,7 @@ func (m *ExperimentalIngestionMiddleware) Wrap(h http.Handler) http.Handler {
 				ReadOnly:  true,
 			})
 			if err != nil {
-				localLog.WithField("err", err).Error("Error starting exp ingestion read transaction")
+				err = supportErrors.Wrap(err, "Error starting exp ingestion read transaction")
 				problem.Render(r.Context(), w, err)
 				return
 			}
@@ -298,7 +297,7 @@ func (m *ExperimentalIngestionMiddleware) Wrap(h http.Handler) http.Handler {
 
 			lastIngestedLedger, err := q.GetLastLedgerExpIngestNonBlocking()
 			if err != nil {
-				localLog.WithField("err", err).Error("Error running GetLastLedgerExpIngestNonBlocking")
+				err = supportErrors.Wrap(err, "Error running GetLastLedgerExpIngestNonBlocking")
 				problem.Render(r.Context(), w, err)
 				return
 			}
@@ -307,7 +306,7 @@ func (m *ExperimentalIngestionMiddleware) Wrap(h http.Handler) http.Handler {
 
 		stateInvalid, err := q.GetExpStateInvalid()
 		if err != nil {
-			localLog.WithField("err", err).Error("Error running GetExpStateInvalid")
+			err = supportErrors.Wrap(err, "Error running GetExpStateInvalid")
 			problem.Render(r.Context(), w, err)
 			return
 		}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

This commit changes `ExperimentalIngestionMiddleware` to pass wrapped errors to `problem.Render` instead of logging them directly. This prevents errors connected to context timeout/deadline to be logged with `error` level.