### PR TITLE
support/db: Support concurrent queries in a transaction

### DIFF
--- a/support/db/main.go
+++ b/support/db/main.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"sync"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/jmoiron/sqlx"
@@ -117,7 +118,16 @@ type Session struct {
 	// Ctx is the context in which the repo is operating under.
 	Ctx context.Context
 
-	tx *sqlx.Tx
+	// Synchronized is an EXPERIMENTAL flag that allows sending queries
+	// concurrently in a DB tx. When set to `true` all Exec and Query methods
+	// sent in a transaction are protected by mutex. It is not needed outside
+	// transaction context because then all queries are sent in a separate DB
+	// connections.
+	// Please note that Begin, Commit and Rollback must not be run in parallel.
+	// Also, Query methods are not available when in Synchronized transaction.
+	Synchronized bool
+	txMutex      sync.Mutex
+	tx           *sqlx.Tx
 }
 
 type SessionInterface interface {

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -119,7 +119,7 @@ type Session struct {
 	Ctx context.Context
 
 	// Synchronized is an EXPERIMENTAL flag that allows sending queries
-	// concurrently in a DB tx. When set to `true` all Exec and Query methods
+	// concurrently in a DB tx. When set to `true` all Exec and Select methods
 	// sent in a transaction are protected by mutex. It is not needed outside
 	// transaction context because then all queries are sent in a separate DB
 	// connections.

--- a/support/db/session_test.go
+++ b/support/db/session_test.go
@@ -31,18 +31,19 @@ func TestConcurrentQueriesTransaction(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			istr := fmt.Sprintf("%d", i)
+			var err2 error
 			if i%3 == 0 {
 				var names []string
-				err = sess.SelectRaw(&names, "SELECT name FROM people")
+				err2 = sess.SelectRaw(&names, "SELECT name FROM people")
 			} else if i%3 == 1 {
 				var name string
-				err = sess.GetRaw(&name, "SELECT name FROM people LIMIT 1")
+				err2 = sess.GetRaw(&name, "SELECT name FROM people LIMIT 1")
 			} else {
-				_, err = sess.ExecRaw(
+				_, err2 = sess.ExecRaw(
 					"INSERT INTO people (name, hunger_level) VALUES ('bartek" + istr + "', " + istr + ")",
 				)
 			}
-			assert.NoError(t, err)
+			assert.NoError(t, err2)
 			wg.Done()
 		}(i)
 	}

--- a/support/db/session_test.go
+++ b/support/db/session_test.go
@@ -31,7 +31,6 @@ func TestConcurrentQueriesTransaction(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			istr := fmt.Sprintf("%d", i)
-			var err error
 			if i%3 == 0 {
 				var names []string
 				err = sess.SelectRaw(&names, "SELECT name FROM people")

--- a/support/db/session_test.go
+++ b/support/db/session_test.go
@@ -2,12 +2,56 @@ package db
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stellar/go/support/db/dbtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestConcurrentQueriesTransaction(t *testing.T) {
+	db := dbtest.Postgres(t).Load(testSchema)
+	defer db.Close()
+
+	sess := &Session{
+		Ctx: context.Background(),
+		DB:  db.Open(),
+		// This test would fail for `Synchronized: false`
+		Synchronized: true,
+	}
+	defer sess.DB.Close()
+
+	err := sess.Begin()
+	assert.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func(i int) {
+			istr := fmt.Sprintf("%d", i)
+			var err error
+			if i%3 == 0 {
+				var names []string
+				err = sess.SelectRaw(&names, "SELECT name FROM people")
+			} else if i%3 == 1 {
+				var name string
+				err = sess.GetRaw(&name, "SELECT name FROM people LIMIT 1")
+			} else {
+				_, err = sess.ExecRaw(
+					"INSERT INTO people (name, hunger_level) VALUES ('bartek" + istr + "', " + istr + ")",
+				)
+			}
+			assert.NoError(t, err)
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
+	err = sess.Rollback()
+	assert.NoError(t, err)
+}
 
 func TestSession(t *testing.T) {
 	db := dbtest.Postgres(t).Load(testSchema)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit adds `Synchronized` flag to `support/db.Session`. When set to `true` and `Session` runs a transaction all `Exec*` and `Select*` methods are protected by mutex what allows running them in multiple goroutines.

This is an experimental feature (see below) and not a breaking change (default is `false`).

### Why

Postgres protocol does not allow sending Exec query results if previously sent Query haven't been fully read. This issue manifested itself when a PR that's sending read and write queries in multiple goroutines was merged.

More info: lib/pq#81 lib/pq#635

### Known limitations

* It's possible that it will not be needed if we decide to remove concurrency from ingestion pipeline (see #1983). We are adding this to unblock development of new ingestion processors with a more readable code (currently all database processors are merged into one big processor that is hard to read and test). Splitting `DatabaseProcessor` will be done in a separate PR/PRs.
* During Horizon Team meeting we agreed to create a new `SynchronizedSession` struct embedding `db.Session` inside that would not be placed in a shared `support` package. The problem is that `history.Q` embeds `db.Session` inside. Changing this to `db.SessionInterface` requires updating a lot of files that create `history.Q` objects, tests and mocks. Given that we may want to revert this change in the future, the change in this commit seems to be simpler.