### PR TITLE
exp/hubble: add helpers for all ledger changes in tests

### DIFF
--- a/exp/hubble/helper_functions_test.go
+++ b/exp/hubble/helper_functions_test.go
@@ -61,3 +61,64 @@ func makeLedgerEntryChangeData(address, name, value string) *xdr.LedgerEntryChan
 		},
 	}
 }
+
+func makeLedgerEntryChangeSeqnumState(seqnum uint32) *xdr.LedgerEntryChange {
+	return &xdr.LedgerEntryChange{
+		Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+		State: &xdr.LedgerEntry{
+			LastModifiedLedgerSeq: xdr.Uint32(seqnum),
+			Data: xdr.LedgerEntryData{
+				Type:    xdr.LedgerEntryTypeAccount,
+				Account: &xdr.AccountEntry{},
+			},
+		},
+	}
+}
+
+func makeLedgerEntryChangeAccountRemoved(address string) *xdr.LedgerEntryChange {
+	return &xdr.LedgerEntryChange{
+		Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+		Removed: &xdr.LedgerKey{
+			Account: &xdr.LedgerKeyAccount{
+				AccountId: xdr.MustAddress(address),
+			},
+		},
+	}
+}
+
+func makeLedgerEntryChangeTrustlineRemoved(issuer, code string) *xdr.LedgerEntryChange {
+	return &xdr.LedgerEntryChange{
+		Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+		Removed: &xdr.LedgerKey{
+			Type: xdr.LedgerEntryTypeTrustline,
+			TrustLine: &xdr.LedgerKeyTrustLine{
+				AccountId: xdr.MustAddress(issuer),
+				Asset:     xdr.MustNewCreditAsset(code, issuer),
+			},
+		},
+	}
+}
+
+func makeLedgerEntryChangeDataRemoved(key string) *xdr.LedgerEntryChange {
+	return &xdr.LedgerEntryChange{
+		Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+		Removed: &xdr.LedgerKey{
+			Type: xdr.LedgerEntryTypeData,
+			Data: &xdr.LedgerKeyData{
+				DataName: xdr.String64(key),
+			},
+		},
+	}
+}
+
+func makeLedgerEntryChangeOfferRemoved(id int) *xdr.LedgerEntryChange {
+	return &xdr.LedgerEntryChange{
+		Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+		Removed: &xdr.LedgerKey{
+			Type: xdr.LedgerEntryTypeOffer,
+			Offer: &xdr.LedgerKeyOffer{
+				OfferId: xdr.Int64(id),
+			},
+		},
+	}
+}

--- a/exp/hubble/schema_factory_test.go
+++ b/exp/hubble/schema_factory_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 const wantAddress = "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"
+const wantAddress2 = "GBDT3K42LOPSHNAEHEJ6AVPADIJ4MAR64QEKKW2LQPBSKLYD22KUEH4P"
 
 func TestMakeNewAccountStateSuccess(t *testing.T) {
 	var trustlineKey = fmt.Sprintf("credit_alphanum4/USD/%s", wantAddress)
@@ -22,48 +23,28 @@ func TestMakeNewAccountStateSuccess(t *testing.T) {
 	}{
 		{"AccountRemoved",
 			&accountState{address: wantAddress},
-			&xdr.LedgerEntryChange{
-				Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-				Removed: &xdr.LedgerKey{
-					Account: &xdr.LedgerKeyAccount{
-						AccountId: xdr.MustAddress(wantAddress),
-					},
-				},
-			},
+			makeLedgerEntryChangeAccountRemoved(wantAddress),
 			nil,
 		},
 		{"SeqnumNotChanged",
 			&accountState{seqnum: 11},
-			&xdr.LedgerEntryChange{
-				Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-				State: &xdr.LedgerEntry{
-					LastModifiedLedgerSeq: xdr.Uint32(11),
-					Data: xdr.LedgerEntryData{
-						Type:    xdr.LedgerEntryTypeAccount,
-						Account: &xdr.AccountEntry{},
-					},
-				},
-			},
+			makeLedgerEntryChangeSeqnumState(11),
 			&accountState{seqnum: 11},
 		},
 		{"SeqnumChanged",
 			&accountState{seqnum: 11},
-			&xdr.LedgerEntryChange{
-				Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-				State: &xdr.LedgerEntry{
-					LastModifiedLedgerSeq: xdr.Uint32(2947523),
-					Data: xdr.LedgerEntryData{
-						Type:    xdr.LedgerEntryTypeAccount,
-						Account: &xdr.AccountEntry{},
-					},
-				},
-			},
+			makeLedgerEntryChangeSeqnumState(2947523),
 			&accountState{seqnum: 2947523},
 		},
 		{"BalanceChanged",
 			&accountState{balance: 222},
 			makeLedgerEntryChangeAccount(&xdr.AccountEntry{Balance: xdr.Int64(111)}),
 			&accountState{balance: 111},
+		},
+		{"SignersRemoved",
+			&accountState{signers: []signer{{address: wantAddress, weight: uint32(1)}}},
+			makeLedgerEntryChangeAccount(&xdr.AccountEntry{Signers: []xdr.Signer{}}),
+			&accountState{},
 		},
 		{"SignersNotChanged",
 			&accountState{signers: []signer{{address: wantAddress, weight: uint32(1)}}},
@@ -75,7 +56,20 @@ func TestMakeNewAccountStateSuccess(t *testing.T) {
 			}),
 			&accountState{signers: []signer{{address: wantAddress, weight: uint32(1)}}},
 		},
-		{"SignersChanged",
+		{"SignersChangedSigner",
+			&accountState{signers: []signer{{address: wantAddress, weight: uint32(1)}}},
+			makeLedgerEntryChangeAccount(&xdr.AccountEntry{
+				Signers: []xdr.Signer{
+					{Key: xdr.MustSigner(wantAddress), Weight: xdr.Uint32(1)},
+					{Key: xdr.MustSigner(wantAddress2), Weight: xdr.Uint32(1)},
+				},
+			}),
+			&accountState{signers: []signer{
+				{address: wantAddress, weight: uint32(1)},
+				{address: wantAddress2, weight: uint32(1)},
+			}},
+		},
+		{"SignersChangedWeight",
 			&accountState{signers: []signer{{address: wantAddress, weight: uint32(1)}}},
 			makeLedgerEntryChangeAccount(&xdr.AccountEntry{
 				Signers: []xdr.Signer{{
@@ -89,16 +83,7 @@ func TestMakeNewAccountStateSuccess(t *testing.T) {
 			&accountState{trustlines: map[string]trustline{
 				trustlineKey: trustline{asset: trustlineKey, balance: uint32(0), limit: uint32(100)}},
 			},
-			&xdr.LedgerEntryChange{
-				Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-				Removed: &xdr.LedgerKey{
-					Type: xdr.LedgerEntryTypeTrustline,
-					TrustLine: &xdr.LedgerKeyTrustLine{
-						AccountId: xdr.MustAddress(wantAddress),
-						Asset:     xdr.MustNewCreditAsset("USD", wantAddress),
-					},
-				},
-			},
+			makeLedgerEntryChangeTrustlineRemoved(wantAddress, "USD"),
 			&accountState{trustlines: map[string]trustline{}},
 		},
 		{"TrustlinesChanged",
@@ -112,15 +97,7 @@ func TestMakeNewAccountStateSuccess(t *testing.T) {
 		},
 		{"DataRemoved",
 			&accountState{data: map[string][]byte{"key": []byte("value")}},
-			&xdr.LedgerEntryChange{
-				Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-				Removed: &xdr.LedgerKey{
-					Type: xdr.LedgerEntryTypeData,
-					Data: &xdr.LedgerKeyData{
-						DataName: xdr.String64("key"),
-					},
-				},
-			},
+			makeLedgerEntryChangeDataRemoved("key"),
 			&accountState{data: map[string][]byte{}},
 		},
 		{"DataChanged",
@@ -130,15 +107,7 @@ func TestMakeNewAccountStateSuccess(t *testing.T) {
 		},
 		{"OffersRemoved",
 			&accountState{offers: map[uint32]offer{1: offer{id: 1}}},
-			&xdr.LedgerEntryChange{
-				Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-				Removed: &xdr.LedgerKey{
-					Type: xdr.LedgerEntryTypeOffer,
-					Offer: &xdr.LedgerKeyOffer{
-						OfferId: xdr.Int64(1),
-					},
-				},
-			},
+			makeLedgerEntryChangeOfferRemoved(1),
 			&accountState{offers: map[uint32]offer{}},
 		},
 		{"OffersChanged",


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR adds helper functions to create all `xdr.LedgerEntryChange` structs in the Hubble testing suite. 

### Why

This significantly helps test readability and adds useful utilities for future unit tests.

### Known limitations

N/A
