### PR TITLE
xdr: get address from signer key without panic

### DIFF
--- a/xdr/signer_key.go
+++ b/xdr/signer_key.go
@@ -41,7 +41,7 @@ func (skey *SignerKey) GetAddress() (string, error) {
 		key := skey.MustPreAuthTx()
 		copy(raw, key[:])
 	default:
-		return "", fmt.Errorf("Unknown signer key type: %v", skey.Type)
+		return "", fmt.Errorf("unknown signer key type: %v", skey.Type)
 	}
 
 	return strkey.Encode(vb, raw)

--- a/xdr/signer_key.go
+++ b/xdr/signer_key.go
@@ -10,8 +10,18 @@ import (
 // Address returns the strkey encoded form of this signer key.  This method will
 // panic if the SignerKey is of an unknown type.
 func (skey *SignerKey) Address() string {
+	address, err := skey.GetAddress()
+	if err != nil {
+		panic(err)
+	}
+	return address
+}
+
+// GetAddress returns the strkey encoded form of this signer key, and an error if the
+// SignerKey is of an unknown type.
+func (skey *SignerKey) GetAddress() (string, error) {
 	if skey == nil {
-		return ""
+		return "", nil
 	}
 
 	vb := strkey.VersionByte(0)
@@ -31,10 +41,10 @@ func (skey *SignerKey) Address() string {
 		key := skey.MustPreAuthTx()
 		copy(raw, key[:])
 	default:
-		panic(fmt.Errorf("Unknown signer key type: %v", skey.Type))
+		return "", fmt.Errorf("Unknown signer key type: %v", skey.Type)
 	}
 
-	return strkey.MustEncode(vb, raw)
+	return strkey.Encode(vb, raw)
 }
 
 // Equals returns true if `other` is equivalent to `skey`

--- a/xdr/signer_key_test.go
+++ b/xdr/signer_key_test.go
@@ -7,6 +7,45 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSignerKey_GetAddress(t *testing.T) {
+	tests := []struct {
+		name        string
+		wantAddress string
+	}{
+		{
+			"NilKey",
+			"",
+		},
+		{
+			"AccountID",
+			"GA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQHES5",
+		},
+		{
+			"HashxX",
+			"TBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWHXL7",
+		},
+		{
+			"HashX",
+			"XBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWGTOG",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := &SignerKey{}
+			if tt.wantAddress != "" {
+				err := key.SetAddress(tt.wantAddress)
+				assert.NoError(t, err)
+			} else {
+				key = nil
+			}
+
+			gotAddress, err := key.GetAddress()
+			assert.Equal(t, tt.wantAddress, gotAddress)
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func TestSignerKey_SetAddress(t *testing.T) {
 	cases := []struct {
 		Name    string


### PR DESCRIPTION
### What

This PR adds a panic-free method to return the address from an `xdr.SignerKey` 
This PR adds a method to the `xdr.SignerKey` struct that returns the address with an error. The existing `Address` method is now a thin wrapper around this method.

### Why

In long-running, data-intensive applications, like the Hubble project, we want to avoid panics wherever possible. A panic on a single malformed input can abort the entire pipeline. A panic-free method to get the address of an `xdr.SignerKey` struct helps reduce such possible failures.

### Known limitations

N/A
