### PR TITLE
keypair: add ParseFull function

### DIFF
--- a/keypair/main.go
+++ b/keypair/main.go
@@ -89,11 +89,11 @@ func Parse(addressOrSeed string) (KP, error) {
 // be a seed.
 func ParseFull(seed string) (*Full, error) {
 	_, err := strkey.Decode(strkey.VersionByteSeed, seed)
-	if err == nil {
-		return &Full{seed}, nil
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, err
+	return &Full{seed}, nil
 }
 
 // FromRawSeed creates a new keypair from the provided raw ED25519 seed

--- a/keypair/main.go
+++ b/keypair/main.go
@@ -85,7 +85,7 @@ func Parse(addressOrSeed string) (KP, error) {
 	return ParseFull(addressOrSeed)
 }
 
-// Parse constructs a new Full keypair from the provided string, which should
+// ParseFull constructs a new Full keypair from the provided string, which should
 // be a seed.
 func ParseFull(seed string) (*Full, error) {
 	_, err := strkey.Decode(strkey.VersionByteSeed, seed)

--- a/keypair/main.go
+++ b/keypair/main.go
@@ -82,9 +82,15 @@ func Parse(addressOrSeed string) (KP, error) {
 		return nil, err
 	}
 
-	_, err = strkey.Decode(strkey.VersionByteSeed, addressOrSeed)
+	return ParseFull(addressOrSeed)
+}
+
+// Parse constructs a new Full keypair from the provided string, which should
+// be a seed.
+func ParseFull(seed string) (*Full, error) {
+	_, err := strkey.Decode(strkey.VersionByteSeed, seed)
 	if err == nil {
-		return &Full{addressOrSeed}, nil
+		return &Full{seed}, nil
 	}
 
 	return nil, err

--- a/keypair/main_test.go
+++ b/keypair/main_test.go
@@ -108,6 +108,47 @@ var _ = DescribeTable("keypair.Parse()",
 	}),
 )
 
+type ParseFullCase struct {
+	Input    string
+	FullCase types.GomegaMatcher
+	ErrCase  types.GomegaMatcher
+}
+
+var _ = DescribeTable("keypair.ParseFull()",
+	func(c ParseFullCase) {
+		kp, err := ParseFull(c.Input)
+
+		Expect(kp).To(c.FullCase)
+		Expect(err).To(c.ErrCase)
+	},
+
+	Entry("a valid address", ParseFullCase{
+		Input:    "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+		FullCase: BeNil(),
+		ErrCase:  HaveOccurred(),
+	}),
+	Entry("a corrupted address", ParseFullCase{
+		Input:    "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7O32H",
+		FullCase: BeNil(),
+		ErrCase:  HaveOccurred(),
+	}),
+	Entry("a valid seed", ParseFullCase{
+		Input:    "SDHOAMBNLGCE2MV5ZKIVZAQD3VCLGP53P3OBSBI6UN5L5XZI5TKHFQL4",
+		FullCase: Equal(&Full{seed: "SDHOAMBNLGCE2MV5ZKIVZAQD3VCLGP53P3OBSBI6UN5L5XZI5TKHFQL4"}),
+		ErrCase:  BeNil(),
+	}),
+	Entry("a corrupted seed", ParseFullCase{
+		Input:    "SDHOAMBNLGCE2MV5ZKIVZAQD3VCLGP53P3OBSBI6UN5L5XZI5TKHFQL3",
+		FullCase: BeNil(),
+		ErrCase:  HaveOccurred(),
+	}),
+	Entry("a blank string", ParseFullCase{
+		Input:    "",
+		FullCase: BeNil(),
+		ErrCase:  HaveOccurred(),
+	}),
+)
+
 var _ = Describe("keypair.Random()", func() {
 	It("does not return the same value twice", func() {
 		seen := map[string]bool{}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add `keypair.ParseFull` function that behaves the same as
`keypair.Parse`, but returns a `keypair.Full` instead of a `keypair.KP`.

### Why

A couple times in my own coding I've found that my code knows that I
have a seed, not an address, and I need to get a `keypair.Full`. The
path to doing that is inconvenient because I first need to call
`keypair.Parse` to get back a `keypair.KP`, and then I need to cast that
to a `keypair.Full`.

The `keypair.Parse` function first attempts to decode as an address,
then as a seed. In cases where we know we have a seed it would be
convenient to be able to parse just expecting a full key.

### Known limitations

N/A
