### PR TITLE
xdr: get data from LedgerEntryChange without panic

### DIFF
--- a/xdr/ledger_entry.go
+++ b/xdr/ledger_entry.go
@@ -2,42 +2,65 @@ package xdr
 
 import "fmt"
 
-// LedgerKey implements the `Keyer` interface
+// LedgerKey implements the `Keyer` interface.
 func (entry *LedgerEntry) LedgerKey() LedgerKey {
+	key, err := entry.GetLedgerKey()
+	if err != nil {
+		panic(err)
+	}
+	return key
+}
+
+// GetLedgerKey implements the `Keyer` interface, extracts the
+// information from a `LedgerEntry` into a `LedgerKey`, and returns
+// an error if it is unable to do so.
+func (entry *LedgerEntry) GetLedgerKey() (LedgerKey, error) {
 	var body interface{}
 
 	switch entry.Data.Type {
 	case LedgerEntryTypeAccount:
-		account := entry.Data.MustAccount()
+		account, ok := entry.Data.GetAccount()
+		if !ok {
+			return LedgerKey{}, fmt.Errorf("could not get account")
+		}
 		body = LedgerKeyAccount{
 			AccountId: account.AccountId,
 		}
 	case LedgerEntryTypeData:
-		data := entry.Data.MustData()
+		data, ok := entry.Data.GetData()
+		if !ok {
+			return LedgerKey{}, fmt.Errorf("could not get data")
+		}
 		body = LedgerKeyData{
 			AccountId: data.AccountId,
 			DataName:  data.DataName,
 		}
 	case LedgerEntryTypeOffer:
-		offer := entry.Data.MustOffer()
+		offer, ok := entry.Data.GetOffer()
+		if !ok {
+			return LedgerKey{}, fmt.Errorf("could not get offer")
+		}
 		body = LedgerKeyOffer{
 			SellerId: offer.SellerId,
 			OfferId:  offer.OfferId,
 		}
 	case LedgerEntryTypeTrustline:
-		tline := entry.Data.MustTrustLine()
+		tline, ok := entry.Data.GetTrustLine()
+		if !ok {
+			return LedgerKey{}, fmt.Errorf("could not get trustline")
+		}
 		body = LedgerKeyTrustLine{
 			AccountId: tline.AccountId,
 			Asset:     tline.Asset,
 		}
 	default:
-		panic(fmt.Errorf("Unknown entry type: %v", entry.Data.Type))
+		return LedgerKey{}, fmt.Errorf("unknown entry type: %v", entry.Data.Type)
 	}
 
 	ret, err := NewLedgerKey(entry.Data.Type, body)
 	if err != nil {
-		panic(err)
+		return LedgerKey{}, err
 	}
 
-	return ret
+	return ret, nil
 }

--- a/xdr/ledger_entry_change.go
+++ b/xdr/ledger_entry_change.go
@@ -2,9 +2,20 @@ package xdr
 
 import "fmt"
 
-// EntryType is a helper to get at the entry type for a change.
+// EntryType is a helper to get the entry type for a change. It
+// panics if unable to do so.
 func (change *LedgerEntryChange) EntryType() LedgerEntryType {
 	return change.LedgerKey().Type
+}
+
+// GetEntryType is a helper to get the entry type for a change, and it
+// returns an error if unable to do so.
+func (change *LedgerEntryChange) GetEntryType() (LedgerEntryType, error) {
+	key, err := change.GetLedgerKey()
+	if err != nil {
+		return LedgerEntryTypeAccount, err
+	}
+	return key.Type, nil
 }
 
 // LedgerKey returns the key for the ledger entry that was changed

--- a/xdr/ledger_entry_change.go
+++ b/xdr/ledger_entry_change.go
@@ -10,20 +10,43 @@ func (change *LedgerEntryChange) EntryType() LedgerEntryType {
 // LedgerKey returns the key for the ledger entry that was changed
 // in `change`.
 func (change *LedgerEntryChange) LedgerKey() LedgerKey {
+	key, err := change.GetLedgerKey()
+	if err != nil {
+		panic(err)
+	}
+	return key
+}
+
+// GetLedgerKey returns the key for the ledger entry changed in `change`,
+// or panics if it is unable to do so.
+func (change *LedgerEntryChange) GetLedgerKey() (LedgerKey, error) {
 	switch change.Type {
 	case LedgerEntryChangeTypeLedgerEntryCreated:
-		change := change.MustCreated()
-		return change.LedgerKey()
+		created, ok := change.GetCreated()
+		if !ok {
+			return LedgerKey{}, fmt.Errorf("could not get created")
+		}
+		return created.GetLedgerKey()
 	case LedgerEntryChangeTypeLedgerEntryRemoved:
-		return change.MustRemoved()
+		removed, ok := change.GetRemoved()
+		if !ok {
+			return LedgerKey{}, fmt.Errorf("could not get removed")
+		}
+		return removed, nil
 	case LedgerEntryChangeTypeLedgerEntryUpdated:
-		change := change.MustUpdated()
-		return change.LedgerKey()
+		updated, ok := change.GetUpdated()
+		if !ok {
+			return LedgerKey{}, fmt.Errorf("could not get updated")
+		}
+		return updated.GetLedgerKey()
 	case LedgerEntryChangeTypeLedgerEntryState:
-		change := change.MustState()
-		return change.LedgerKey()
+		state, ok := change.GetState()
+		if !ok {
+			return LedgerKey{}, fmt.Errorf("could not get state")
+		}
+		return state.GetLedgerKey()
 	default:
-		panic(fmt.Errorf("Unknown change type: %v", change.Type))
+		return LedgerKey{}, fmt.Errorf("unknown change type: %v", change.Type)
 	}
 }
 


### PR DESCRIPTION
### What

This PR creates panic-free versions of functions needed to extract `LedgerEntry`, `LedgerEntryType`, and other fields from `LedgerEntryChange`. 

### Why
In long-running, data-intensive applications, like the Hubble project, we want to avoid panics wherever possible. A panic on a single malformed input can abort the entire pipeline. A panic-free method to get various data from `xdr.LedgerEntryChange` helps reduce such possible failures.

### Known limitations
N/A