### PR TITLE
exp/tools/dump-ledger-state: Use @horizon-team in slack alert

### DIFF
--- a/exp/tools/dump-ledger-state/docker-entrypoint.sh
+++ b/exp/tools/dump-ledger-state/docker-entrypoint.sh
@@ -12,14 +12,23 @@ echo "using version $(stellar-core version)"
 
 if [ -z ${TESTNET+x} ]; then
     stellar-core --conf ./stellar-core.cfg new-db
-    export LATEST_LEDGER=`curl -v --max-time 10 --retry 3 --retry-connrefused --retry-delay 5 https://history.stellar.org/prd/core-live/core_live_001/.well-known/stellar-history.json | jq -r '.currentLedger'`
 else
     stellar-core --conf ./stellar-core-testnet.cfg new-db
-    export LATEST_LEDGER=`curl -v --max-time 10 --retry 3 --retry-connrefused --retry-delay 5 https://history.stellar.org/prd/core-testnet/core_testnet_001/.well-known/stellar-history.json | jq -r '.currentLedger'`
 fi
+
+if [ -z ${LATEST_LEDGER+x} ]; then
+    # Get latest ledger
+    echo "Getting latest checkpoint ledger..."
+    if [ -z ${TESTNET+x} ]; then
+        export LATEST_LEDGER=`curl -s http://history.stellar.org/prd/core-live/core_live_001/.well-known/stellar-history.json | jq -r '.currentLedger'`
+    else
+        export LATEST_LEDGER=`curl -s http://history.stellar.org/prd/core-testnet/core_testnet_001/.well-known/stellar-history.json | jq -r '.currentLedger'`
+    fi
+fi
+
 echo "Latest ledger: $LATEST_LEDGER"
 
 if ! ./run_test.sh; then
-    curl -X POST --data-urlencode "payload={ \"username\": \"ingestion-check\", \"text\": \"ingestion dump (git commit \`$GITCOMMIT\`) of ledger \`$LATEST_LEDGER\` does not match stellar core db.\"}" $SLACK_URL
+    curl -X POST --data-urlencode "payload={ \"username\": \"ingestion-check\", \"text\": \"@horizon-team ingestion dump (git commit \`$GITCOMMIT\`) of ledger \`$LATEST_LEDGER\` does not match stellar core db.\"}" $SLACK_URL
     exit 1
 fi


### PR DESCRIPTION
Also, do not override LATEST_LEDGER if the variable is already set

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

* Use @horizon-team in slack alert
* Only populate `LATEST_LEDGER` if it is not set

### Why

* `@horizon-team` will notify all members of the horizon team on slack
* It will be easier to test the script on a specific checkpoint ledger by running `docker run -e LATEST_LEDGER=27207615 stellar/ledger-state-diff:latest`

### Known limitations

[N/A]
