### PR TITLE
support/config: move viper bindpflag into init

### DIFF
--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -383,8 +383,6 @@ func init() {
 			stdLog.Fatal(err.Error())
 		}
 	}
-
-	viper.BindPFlags(rootCmd.PersistentFlags())
 }
 
 func initApp() *horizon.App {

--- a/support/config/config_option.go
+++ b/support/config/config_option.go
@@ -88,6 +88,10 @@ func (co *ConfigOption) setFlag(cmd *cobra.Command) error {
 		return errors.New("Unexpected OptType")
 	}
 
+	if err := viper.BindPFlag(co.Name, cmd.PersistentFlags().Lookup(co.Name)); err != nil {
+		return err
+	}
+
 	if err := viper.BindEnv(co.Name, co.EnvVar); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Move the call to `viper.BindPFlags` from our services that use the `support/config` package, into the config package `Init` function.

### Why

The `support/config` package does a good job of wrapping up cobra and viper functionality so that an application only needs to define one set of config and by calling a few functions can have that config provided by flags and environment variables in a consistent manner. While the package does most of the work to configure all the moving parts, it doesn't call the BindPFlags function and relies on the app to call this. It's really easy to miss that the app has to do this one thing, and I lost a good amount of time trying to understand why none of my configs were being populated. The package owns setting viper up, and so it should own this part of the process too.

We're only using this on Horizon right now but this package looks like a good starting point for us to have a common pattern to configure our services with environment variables and flags. On some of our services this doesn't matter because the configs are all non-sensitive values, but as we write services that need keys making use of flags and environment variables consistently will be ideal.

@bartekn originally proposed this change here https://github.com/stellar/go/pull/834#discussion_r252266777 and made the change in https://github.com/stellar/go/pull/834/commits/75b8658fd5662c321b7a1490f188edc17a287083. Before the PR was merged @ire-and-curses reverted the change in https://github.com/stellar/go/pull/834/commits/2a8354be887aaa05f0ab8736be82aab6423aebc7 because the first commit had broken the setting of values, but as it turned out only some of the code needed to be reverted.

### Known limitations

[TODO or N/A]
