### PR TITLE
support/config: simplify initing and setting multiple ConfigOptions

### DIFF
--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -97,7 +97,7 @@ func checkMigrations() {
 
 // configOpts defines the complete flag configuration for horizon.
 // Add a new entry here to connect a new field in the horizon.Config struct
-var configOpts = []*support.ConfigOption{
+var configOpts = support.ConfigOptions{
 	&support.ConfigOption{
 		Name:      "db-url",
 		EnvVar:    "DATABASE_URL",
@@ -377,11 +377,9 @@ var configOpts = []*support.ConfigOption{
 }
 
 func init() {
-	for _, co := range configOpts {
-		err := co.Init(rootCmd)
-		if err != nil {
-			stdLog.Fatal(err.Error())
-		}
+	err := configOpts.Init(rootCmd)
+	if err != nil {
+		stdLog.Fatal(err.Error())
 	}
 
 	viper.BindPFlags(rootCmd.PersistentFlags())
@@ -394,10 +392,8 @@ func initApp() *horizon.App {
 
 func initConfig() {
 	// Verify required options and load the config struct
-	for _, co := range configOpts {
-		co.Require()
-		co.SetValue()
-	}
+	configOpts.Require()
+	configOpts.SetValues()
 
 	if config.ApplyMigrations {
 		applyMigrations()

--- a/support/config/config_option.go
+++ b/support/config/config_option.go
@@ -12,6 +12,35 @@ import (
 	"github.com/stellar/go/support/strutils"
 )
 
+// ConfigOptions is a group of ConfigOptions that can be for convenience
+// initialized and set at the same time.
+type ConfigOptions []*ConfigOption
+
+// Init calls Init on each ConfigOption passing on the cobra.Command.
+func (cos ConfigOptions) Init(cmd *cobra.Command) error {
+	for _, co := range cos {
+		err := co.Init(cmd)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Require calls Require on each ConfigOption.
+func (cos ConfigOptions) Require() {
+	for _, co := range cos {
+		co.Require()
+	}
+}
+
+// SetValues calls SetValue on each ConfigOption.
+func (cos ConfigOptions) SetValues() {
+	for _, co := range cos {
+		co.SetValue()
+	}
+}
+
 // ConfigOption is a complete description of the configuration of a command line option
 type ConfigOption struct {
 	Name           string              // e.g. "db-url"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Adds a `ConfigOptions` type that is a slice of `ConfigOptions`, and wraps up initializing and setting the values of all the options. Also updates Horizon to use those new functions.

### Why

I had a go of using the `ConfigOption` type and following the same pattern in Horizon in some new code and I lost a lot of time to a silly mistake when defining the slice of options that caused none of the options to ever be set (I forgot to use a pointer type). I think this code will help prevent that, but also this code reduces the repetitiveness of using this code in another application.

I think it's great that we have some code to help us setup flags and environment variables in a common format. I think this is one small thing we can do to improve this code, there's another in #2041.

### Known limitations

I've chosen not to add tests for `config.ConfigOptions` because the code I'm adding is very thin and is just pass through code to the `config.ConfigOption` type.
