### PR TITLE
keypair: make simple to get FromAddress from any KP

### DIFF
--- a/keypair/from_address.go
+++ b/keypair/from_address.go
@@ -21,6 +21,12 @@ func (kp *FromAddress) Address() string {
 	return kp.address
 }
 
+// FromAddress gets the address-only representation, or public key, of this
+// keypair, which is itself.
+func (kp *FromAddress) FromAddress() *FromAddress {
+	return kp
+}
+
 func (kp *FromAddress) Hint() (r [4]byte) {
 	copy(r[:], kp.publicKey()[28:])
 	return

--- a/keypair/full.go
+++ b/keypair/full.go
@@ -17,6 +17,12 @@ func (kp *Full) Address() string {
 	return strkey.MustEncode(strkey.VersionByteAccountID, kp.publicKey()[:])
 }
 
+// FromAddress gets the address-only representation, or public key, of this
+// Full keypair.
+func (kp *Full) FromAddress() *FromAddress {
+	return &FromAddress{address: kp.Address()}
+}
+
 func (kp *Full) Hint() (r [4]byte) {
 	copy(r[:], kp.publicKey()[28:])
 	return

--- a/keypair/main.go
+++ b/keypair/main.go
@@ -34,6 +34,7 @@ const (
 // KP is the main interface for this package
 type KP interface {
 	Address() string
+	FromAddress() *FromAddress
 	Hint() [4]byte
 	Verify(input []byte, signature []byte) error
 	Sign(input []byte) ([]byte, error)

--- a/keypair/main_test.go
+++ b/keypair/main_test.go
@@ -43,6 +43,13 @@ func ItBehavesLikeAKP(subject *KP) {
 		})
 	})
 
+	Describe("FromAddress()", func() {
+		It("returns an address-only representation, or public key, of this key", func() {
+			fromAddress := (*subject).FromAddress()
+			Expect(fromAddress.Address()).To(Equal(address))
+		})
+	})
+
 	Describe("Hint()", func() {
 		It("returns the correct hint", func() {
 			Expect((*subject).Hint()).To(Equal(hint))


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add a `FromAddress()` function to all `KP` implementers that returns the public key, or address only, version of the keypair.

### Why

I have an application that will use a Stellar account seed/key, and some of the handlers in that application need the full key, and some only need the address for verification. It's common to use variable types in code to communicate intent and to limit the code that is given a private key to reduce the risk in a bug accidentally exposing the key.

It's not convenient to load a full keypair and then to split it into its public and private components. The developer is required to get the address string, then reparse that address string. The full keypair should know how to get the address-only version.

This is common in the stdlib's crypto classes where private key types provide direct access to the public key.

### Known limitations

N/A
