### PR TITLE
exp/ingest/io: Extend SingleLedgerStateReader retry logic

### DIFF
--- a/exp/ingest/io/single_ledger_state_reader.go
+++ b/exp/ingest/io/single_ledger_state_reader.go
@@ -179,9 +179,11 @@ func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrSt
 	currentPosition := stream.BytesRead()
 
 	for attempts := 0; ; attempts++ {
-		err = stream.ReadOne(&entry)
-		if err == nil || err == io.EOF {
-			break
+		if err == nil {
+			err = stream.ReadOne(&entry)
+			if err == nil || err == io.EOF {
+				break
+			}
 		}
 		if attempts >= msr.maxStreamRetries {
 			break
@@ -193,7 +195,7 @@ func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrSt
 		retryStream, err = msr.newXDRStream(hash)
 		if err != nil {
 			err = errors.Wrap(err, "Error creating new xdr stream")
-			break
+			continue
 		}
 
 		*stream = *retryStream
@@ -201,7 +203,7 @@ func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrSt
 		_, err = stream.Discard(currentPosition)
 		if err != nil {
 			err = errors.Wrap(err, "Error discarding from xdr stream")
-			break
+			continue
 		}
 	}
 


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

If creating a new xdr stream or discarding from the new stream fails the retry process aborts.
This commit extends the retry logic to cover these failures.

### Why

We encountered failures caused by `stream.Discard(currentPosition)` which resulted in false positive alerts.

### Known limitations

[N/A]
