### PR TITLE
.circleci: Fix circleci publish_latest_horizon_docker_image job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,10 +328,20 @@ workflows:
               branches:
                 ignore: /.*/
       - hold: # <<< A job that will require manual approval in the CircleCI web application.
+          filters:
+              tags:
+                only: /^horizon-v.*/
+              branches:
+                ignore: /.*/
           type: approval # <<< This key-value pair will set your workflow to a status of "On Hold"
           requires: # We only run the "hold" job when publish_horizon_docker_image has succeeded
            - publish_horizon_docker_image
-      # Pushing stellar/horizon:latest to docker hub requires manual approval
       - publish_latest_horizon_docker_image:
+          filters:
+              tags:
+                only: /^horizon-v.*/
+              branches:
+                ignore: /.*/
+          # Pushing stellar/horizon:latest to docker hub requires manual approval
           requires:
             - hold


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Because CircleCI does not build tags by default, any child jobs that rely on a job that only builds on tags will also require the tag filter. In this case, the `hold` and `publish_latest_horizon_docker_image` jobs will need the filter for `/^horizon-v.*/` tags as well, otherwise, they will not be picked up for running.
