### PR TITLE
support/http: remove behind proxy option for muxes

### DIFF
--- a/services/bridge/main.go
+++ b/services/bridge/main.go
@@ -231,7 +231,7 @@ func NewApp(config config.Config, migrateFlag bool, versionFlag bool, version st
 
 // Serve starts the server
 func (a *App) Serve() {
-	mux := supportHttp.NewAPIMux(false)
+	mux := supportHttp.NewAPIMux()
 
 	// Middlewares
 	headers := make(http.Header)

--- a/services/compliance/main.go
+++ b/services/compliance/main.go
@@ -170,7 +170,7 @@ func NewApp(config config.Config, migrateFlag bool, versionFlag bool, version st
 // Serve starts the server
 func (a *App) Serve() {
 	// External endpoints
-	external := supportHttp.NewAPIMux(false)
+	external := supportHttp.NewAPIMux()
 
 	// Middlewares
 	headers := http.Header{}
@@ -195,7 +195,7 @@ func (a *App) Serve() {
 	}()
 
 	// Internal endpoints
-	internal := supportHttp.NewAPIMux(false)
+	internal := supportHttp.NewAPIMux()
 
 	internal.Use(supportHttp.StripTrailingSlashMiddleware("/admin"))
 	internal.Use(supportHttp.HeadersMiddleware(headers, "/admin/"))

--- a/services/federation/main.go
+++ b/services/federation/main.go
@@ -126,7 +126,7 @@ func initDriver(cfg Config) (federation.Driver, error) {
 }
 
 func initMux(driver federation.Driver) *chi.Mux {
-	mux := http.NewAPIMux(false)
+	mux := http.NewAPIMux()
 
 	fed := &federation.Handler{
 		Driver: driver,

--- a/services/friendbot/main.go
+++ b/services/friendbot/main.go
@@ -82,7 +82,7 @@ func run(cmd *cobra.Command, args []string) {
 }
 
 func initRouter(fb *internal.Bot) *chi.Mux {
-	mux := http.NewAPIMux(false)
+	mux := http.NewAPIMux()
 
 	handler := &internal.FriendbotHandler{Friendbot: fb}
 	mux.Get("/", handler.Handle)

--- a/support/http/mux.go
+++ b/support/http/mux.go
@@ -8,12 +8,8 @@ import (
 
 // NewMux returns a new server mux configured with the common defaults used across all
 // stellar services.
-func NewMux(behindProxy bool) *chi.Mux {
+func NewMux() *chi.Mux {
 	mux := chi.NewMux()
-
-	if behindProxy {
-		mux.Use(middleware.RealIP)
-	}
 
 	mux.Use(middleware.RequestID)
 	mux.Use(middleware.Recoverer)
@@ -24,8 +20,8 @@ func NewMux(behindProxy bool) *chi.Mux {
 
 // NewAPIMux returns a new server mux configured with the common defaults used for a web API in
 // stellar.
-func NewAPIMux(behindProxy bool) *chi.Mux {
-	mux := NewMux(behindProxy)
+func NewAPIMux() *chi.Mux {
+	mux := NewMux()
 
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove the ability to configure `support/http` muxes/routers with the behind proxy flag.

### Why

We use these mux functions in five places across four applications, but always with behind proxy as false. We never offer a way to configure it, it's always hardcoded. The middleware that behind proxy adds is the chi `RealIP` middleware, and even in Horizon we don't use it. It seems like something we added for a specific use case but never used. Removing it to make this code simpler.

### Known limitations

This is a non-breaking change for the applications in the repo because I'm updating all the callers to not pass the value, but this is a breaking change for anyone outside this repository who might be importing `github.com/stellar/go/support/http`. As I understand it the code that lives under the `support` package is primarily intended for use by services within this repository and so the likelihood of this being a breaking change for anyone is small. According to [GoDoc.org there are no importers](https://godoc.org/github.com/stellar/go/support/http?importers) of `support/http` who aren't a fork of this repository.

We'd benefit from a formal backwards compatibility statement that classified each package and what its compatibility promise is. If we ever decide one I think we should keep the support package outside any compatibility promise.