### PR TITLE
support/render/problem: add and update docs

### DIFF
--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -3,8 +3,8 @@
 //
 // RFC7807: https://tools.ietf.org/html/rfc7807
 //
-// The P type is used to defines application problems, and the Render function for
-// serializing problems in a HTTP response.
+// The P type is used to define application problems.
+// The Render function is used to serialize problems in a HTTP response.
 package problem
 
 import (

--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -3,7 +3,7 @@
 //
 // RFC7807: https://tools.ietf.org/html/rfc7807
 //
-// The P type is used to defins application problems, and the Render function for
+// The P type is used to defines application problems, and the Render function for
 // serializing problems in a HTTP response.
 package problem
 

--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -5,7 +5,6 @@
 //
 // The P type is used to defins application problems, and the Render function for
 // serializing problems in a HTTP response.
-
 package problem
 
 import (

--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -1,3 +1,11 @@
+// Package problem provides utility functions for rendering errors as RFC7807
+// compatible responses.
+//
+// RFC7807: https://tools.ietf.org/html/rfc7807
+//
+// The P type is used to defins application problems, and the Render function for
+// serializing problems in a HTTP response.
+
 package problem
 
 import (
@@ -117,8 +125,7 @@ func RegisterReportFunc(fn ReportFunc) {
 }
 
 // Render writes a http response to `w`, compliant with the "Problem
-// Details for HTTP APIs" RFC:
-// https://tools.ietf.org/html/draft-ietf-appsawg-http-problem-00
+// Details for HTTP APIs" RFC: https://www.rfc-editor.org/rfc/rfc7807.txt
 func Render(ctx context.Context, w http.ResponseWriter, err error) {
 	origErr := errors.Cause(err)
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add package documentation that clearly states that this package implements an RFC. Add a link to the RFC, now that the RFC has a number.

### Why

It isn't clear without digging into the code that this package implements an RFC. There is a common in the middle of one of the files stating it is for an RFC, but someone could easily make changes to this package that make it inconsistent with the RFC if they didn't see that buried comment.

The RFC has also been assigned a number since this code was first written, so we can use the RFC numbered link instead of its name.

### Known limitations

N/A