### PR TITLE
support/render/problem: make problem package in an isolated instance without globals

### DIFF
--- a/services/horizon/internal/assertions_test.go
+++ b/services/horizon/internal/assertions_test.go
@@ -50,7 +50,7 @@ func (a *Assertions) Problem(body *bytes.Buffer, expected problem.P) bool {
 		return false
 	}
 
-	actual.Type = strings.TrimPrefix(actual.Type, problem.ServiceHost)
+	actual.Type = strings.TrimPrefix(actual.Type, problem.Default.ServiceHost())
 	if expected.Type != "" && a.Equal(expected.Type, actual.Type, "problem type didn't match") {
 		return false
 	}

--- a/support/render/problem/default.go
+++ b/support/render/problem/default.go
@@ -1,0 +1,65 @@
+package problem
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/stellar/go/support/log"
+)
+
+// DefaultServiceHost is the default service host used with the default problem
+// instance.
+var DefaultServiceHost = "https://stellar.org/horizon-errors/"
+
+// DefaultLogger is the default logger used with the default problem instance.
+var DefaultLogger = log.DefaultLogger
+
+// Default is the problem instance used by the package functions providing a
+// global state registry and rendering of problems for an application. For a
+// non-global state registry instantiate a new Problem with New.
+var Default = New(DefaultServiceHost, DefaultLogger)
+
+// RegisterError records an error -> P mapping, allowing the app to register
+// specific errors that may occur in other packages to be rendered as a specific
+// P instance.
+//
+// For example, you might want to render any sql.ErrNoRows errors as a
+// problem.NotFound, and you would do so by calling:
+//
+// problem.RegisterError(sql.ErrNoRows, problem.NotFound) in you application
+// initialization sequence
+func RegisterError(err error, p P) {
+	Default.RegisterError(err, p)
+}
+
+// IsKnownError maps an error to a list of known errors
+func IsKnownError(err error) error {
+	return Default.IsKnownError(err)
+}
+
+// UnRegisterErrors removes all registered errors
+func UnRegisterErrors() {
+	Default.UnRegisterErrors()
+}
+
+// RegisterHost registers the service host url. It is used to prepend the host
+// url to the error type. If you don't wish to prepend anything to the error
+// type, register host as an empty string.
+// The default service host points to `https://stellar.org/horizon-errors/`.
+func RegisterHost(host string) {
+	Default.RegisterHost(host)
+}
+
+// RegisterReportFunc registers the report function that you want to use to
+// report errors. Once reportFn is initialzied, it will be used to report
+// unexpected errors.
+func RegisterReportFunc(fn ReportFunc) {
+	Default.RegisterReportFunc(fn)
+}
+
+// Render writes a http response to `w`, compliant with the "Problem
+// Details for HTTP APIs" RFC:
+// https://tools.ietf.org/html/draft-ietf-appsawg-http-problem-00
+func Render(ctx context.Context, w http.ResponseWriter, err error) {
+	Default.Render(ctx, w, err)
+}

--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -19,11 +19,6 @@ import (
 )
 
 var (
-	ServiceHost     = "https://stellar.org/horizon-errors/"
-	errToProblemMap = map[error]P{}
-)
-
-var (
 	// ServerError is a well-known problem type. Use it as a shortcut.
 	ServerError = P{
 		Type:   "server_error",
@@ -70,6 +65,28 @@ func (p P) Error() string {
 	return fmt.Sprintf("problem: %s", p.Type)
 }
 
+// Problem is an instance of the functionality served by the problem package.
+type Problem struct {
+	serviceHost     string
+	log             *log.Entry
+	errToProblemMap map[error]P
+	reportFn        ReportFunc
+}
+
+// New returns a new instance of Problem.
+func New(serviceHost string, log *log.Entry) *Problem {
+	return &Problem{
+		serviceHost:     serviceHost,
+		log:             log,
+		errToProblemMap: map[error]P{},
+	}
+}
+
+// ServiceHost returns the service host the Problem instance is configured with.
+func (ps *Problem) ServiceHost() string {
+	return ps.serviceHost
+}
+
 // RegisterError records an error -> P mapping, allowing the app to register
 // specific errors that may occur in other packages to be rendered as a specific
 // P instance.
@@ -79,17 +96,17 @@ func (p P) Error() string {
 //
 // problem.RegisterError(sql.ErrNoRows, problem.NotFound) in you application
 // initialization sequence
-func RegisterError(err error, p P) {
-	errToProblemMap[err] = p
+func (ps *Problem) RegisterError(err error, p P) {
+	ps.errToProblemMap[err] = p
 }
 
 // IsKnownError maps an error to a list of known errors
-func IsKnownError(err error) error {
+func (ps *Problem) IsKnownError(err error) error {
 	origErr := errors.Cause(err)
 
 	switch origErr.(type) {
 	case error:
-		if err, ok := errToProblemMap[origErr]; ok {
+		if err, ok := ps.errToProblemMap[origErr]; ok {
 			return err
 		}
 		return nil
@@ -99,33 +116,30 @@ func IsKnownError(err error) error {
 }
 
 // UnRegisterErrors removes all registered errors
-func UnRegisterErrors() {
-	errToProblemMap = map[error]P{}
+func (ps *Problem) UnRegisterErrors() {
+	ps.errToProblemMap = map[error]P{}
 }
 
 // RegisterHost registers the service host url. It is used to prepend the host
 // url to the error type. If you don't wish to prepend anything to the error
 // type, register host as an empty string.
-// The default service host points to `https://stellar.org/horizon-errors/`.
-func RegisterHost(host string) {
-	ServiceHost = host
+func (ps *Problem) RegisterHost(host string) {
+	ps.serviceHost = host
 }
 
 // ReportFunc is a function type used to report unexpected errors.
 type ReportFunc func(context.Context, error)
 
-var reportFn ReportFunc
-
 // RegisterReportFunc registers the report function that you want to use to
 // report errors. Once reportFn is initialzied, it will be used to report
 // unexpected errors.
-func RegisterReportFunc(fn ReportFunc) {
-	reportFn = fn
+func (ps *Problem) RegisterReportFunc(fn ReportFunc) {
+	ps.reportFn = fn
 }
 
 // Render writes a http response to `w`, compliant with the "Problem
 // Details for HTTP APIs" RFC: https://www.rfc-editor.org/rfc/rfc7807.txt
-func Render(ctx context.Context, w http.ResponseWriter, err error) {
+func (ps *Problem) Render(ctx context.Context, w http.ResponseWriter, err error) {
 	origErr := errors.Cause(err)
 
 	var problem P
@@ -136,25 +150,25 @@ func Render(ctx context.Context, w http.ResponseWriter, err error) {
 		problem = *p
 	case error:
 		var ok bool
-		problem, ok = errToProblemMap[origErr]
+		problem, ok = ps.errToProblemMap[origErr]
 
 		// If this error is not a registered error
 		// log it and replace it with a 500 error
 		if !ok {
-			log.Ctx(ctx).WithStack(err).Error(err)
-			if reportFn != nil {
-				reportFn(ctx, err)
+			ps.log.Ctx(ctx).WithStack(err).Error(err)
+			if ps.reportFn != nil {
+				ps.reportFn(ctx, err)
 			}
 			problem = ServerError
 		}
 	}
 
-	renderProblem(ctx, w, problem)
+	ps.renderProblem(ctx, w, problem)
 }
 
-func renderProblem(ctx context.Context, w http.ResponseWriter, p P) {
-	if ServiceHost != "" && !strings.HasPrefix(p.Type, ServiceHost) {
-		p.Type = ServiceHost + p.Type
+func (ps *Problem) renderProblem(ctx context.Context, w http.ResponseWriter, p P) {
+	if ps.serviceHost != "" && !strings.HasPrefix(p.Type, ps.serviceHost) {
+		p.Type = ps.serviceHost + p.Type
 	}
 
 	w.Header().Set("Content-Type", "application/problem+json; charset=utf-8")
@@ -162,7 +176,7 @@ func renderProblem(ctx context.Context, w http.ResponseWriter, p P) {
 	js, err := json.MarshalIndent(p, "", "  ")
 	if err != nil {
 		err = errors.Wrap(err, "failed to encode problem")
-		log.Ctx(ctx).WithStack(err).Error(err)
+		ps.log.Ctx(ctx).WithStack(err).Error(err)
 		http.Error(w, "error rendering problem", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Make the `problem` package usable without needing to use a single global state.

Move all package functionality into a new type that has the same interface as the package and can be instantiated with `New` and used and tested in isolation. Keep the package functions, but have them call a single default instance.

The interface of this package remains identical and unchanged, except for the removal of the exported global variable `ServiceHost`.

### Why

I'd like to extract the error rendering logic out of this package and separate it from the logic that is specific to rendering problem errors. It's easier to layer packages if they aren't using globals, and so the first step is to make this package work optionally without a global registry.

This pattern of exporting both package-level functionality that operates on a global instance and a type that can be instantiated for isolated use is very common in Go applications and in the Go stdlib. It allows for the use of functionality without global state and register patterns that can make an application difficult to understand over time.

We already use this package with global state in a few applications, and this PR doesn't change that, but it gives us the option to use it without global state in new applications, and in an application I am writing, and makes it possible for me to extract the general error rendering logic.

### Known limitations

N/A

cc @howardtw 