### PR TITLE
exp/ingest/pipeline: Fix pipeline data race during shutdown

### DIFF
--- a/exp/support/pipeline/pipeline.go
+++ b/exp/support/pipeline/pipeline.go
@@ -86,6 +86,14 @@ func (p *Pipeline) setRunning(setRunning bool) error {
 	return nil
 }
 
+// IsRunning returns true if pipeline is running
+func (p *Pipeline) IsRunning() bool {
+	// Protects internal fields
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	return p.running
+}
+
 // reset resets internal state of the pipeline and all the nodes and processors.
 func (p *Pipeline) reset() {
 	p.cancelled = false
@@ -259,7 +267,10 @@ func (p *Pipeline) Shutdown() {
 	}
 	p.shutDown = true
 	p.cancelled = true
-	p.cancelFunc()
+	// It's possible that Shutdown will be called before first run.
+	if p.cancelFunc != nil {
+		p.cancelFunc()
+	}
 }
 
 func (p *Pipeline) updateStats(node *PipelineNode, reader Reader, writer *multiWriter) chan<- bool {

--- a/exp/support/pipeline/pipeline.go
+++ b/exp/support/pipeline/pipeline.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/stellar/go/support/errors"
 )
@@ -200,8 +199,6 @@ func (p *Pipeline) processStateNode(ctx context.Context, store *Store, node *Pip
 		}
 	}()
 
-	// finishUpdatingStats := p.updateStats(node, reader, writer)
-
 	for i, child := range node.Children {
 		wg.Add(1)
 		go func(i int, child *PipelineNode) {
@@ -217,8 +214,6 @@ func (p *Pipeline) processStateNode(ctx context.Context, store *Store, node *Pip
 
 	go func() {
 		wg.Wait()
-		// finishUpdatingStats <- true
-
 		if node == p.root {
 			// If pipeline processing is finished run post-hooks and send error
 			// if not already sent.
@@ -271,39 +266,4 @@ func (p *Pipeline) Shutdown() {
 	if p.cancelFunc != nil {
 		p.cancelFunc()
 	}
-}
-
-func (p *Pipeline) updateStats(node *PipelineNode, reader Reader, writer *multiWriter) chan<- bool {
-	// Update stats
-	interval := time.Second
-	done := make(chan bool)
-	ticker := time.NewTicker(interval)
-
-	go func() {
-		defer ticker.Stop()
-
-		for {
-			// This is not thread-safe: check if Mutex slows it down a lot...
-			readBuffer, readBufferIsBufferedReadWriter := reader.(*BufferedReadWriter)
-
-			node.writesPerSecond = (writer.wroteEntries - node.wroteEntries) * int(time.Second/interval)
-			node.wroteEntries = writer.wroteEntries
-
-			if readBufferIsBufferedReadWriter {
-				node.readsPerSecond = (readBuffer.readEntries - node.readEntries) * int(time.Second/interval)
-				node.readEntries = readBuffer.readEntries
-				node.queuedEntries = readBuffer.QueuedEntries()
-			}
-
-			select {
-			case <-ticker.C:
-				continue
-			case <-done:
-				// Pipeline done
-				return
-			}
-		}
-	}()
-
-	return done
 }

--- a/exp/support/pipeline/pipeline.go
+++ b/exp/support/pipeline/pipeline.go
@@ -200,7 +200,7 @@ func (p *Pipeline) processStateNode(ctx context.Context, store *Store, node *Pip
 		}
 	}()
 
-	finishUpdatingStats := p.updateStats(node, reader, writer)
+	// finishUpdatingStats := p.updateStats(node, reader, writer)
 
 	for i, child := range node.Children {
 		wg.Add(1)
@@ -217,7 +217,7 @@ func (p *Pipeline) processStateNode(ctx context.Context, store *Store, node *Pip
 
 	go func() {
 		wg.Wait()
-		finishUpdatingStats <- true
+		// finishUpdatingStats <- true
 
 		if node == p.root {
 			// If pipeline processing is finished run post-hooks and send error

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -297,6 +297,9 @@ func (s *System) Run() {
 					"err":                  err,
 					"last_ingested_ledger": lastIngestedLedger,
 				}).Error("Error running session, resuming from the last ingested ledger")
+			} else {
+				// LiveSession.Run returns nil => shutdown
+				return nil
 			}
 		} else {
 			// The other node already ingested a state (just now or in the past)

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -299,6 +299,7 @@ func (s *System) Run() {
 				}).Error("Error running session, resuming from the last ingested ledger")
 			} else {
 				// LiveSession.Run returns nil => shutdown
+				log.Info("Session shut down")
 				return nil
 			}
 		} else {

--- a/services/horizon/internal/expingest/run_ingestion_test.go
+++ b/services/horizon/internal/expingest/run_ingestion_test.go
@@ -253,7 +253,6 @@ func (s *RunIngestionTestSuite) TestOutdatedIngestVersion() {
 	s.session.On("TruncateTables", history.ExperimentalIngestionTables).Return(nil).Once()
 	s.ingestSession.On("Run").Return(nil).Once()
 	s.historyQ.On("Rollback").Return(nil).Once()
-	s.ingestSession.On("Resume", uint32(4)).Return(nil).Once()
 	s.system.retry = expectError(s.Assert(), "")
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit fixes data race in `exp/ingest/pipeline` that can occur when `LiveSession` (and Horizon) is shut down.

It also removes `updateStats` method that was known to have a data race (see comment in that method). It is not actively used right now but was being reported by race detector.

Fix #2046.

### Why

Previous code handling shutdown signal in `LiveSession` can be found below:
https://github.com/stellar/go/blob/5e4d247fd1d8e1f6a8ff364de0954de07d0fd6b7/exp/ingest/live_session.go#L196-L217

The problem is when shutdown signal is received, `Resume` returns `nil` so Horizon starts it's shutdown code which calls `Rollback()` (using internal `tx` object) but at the same time pipeline is still running until the code receiving from `ctx.Done` channel is executed. It means that pipeline processors can execute transactions using `tx` transaction object in DB session. See #2046 for examples.

To fix this:
1. We don't `select` ingest session shutdown signal when waiting for pipeline to finish processing.
2. Instead we call `Shutdown` on pipelines inside `LiveSession.Shutdown`.
3. Then we wait/block until pipelines gracefully shutdown by calling `Pipeline.IsRunning` method.
4. Finally we `close(s.shutdown)` inside `expingest/System.Shutdown()`.

So the components now shut down exactly in the following order:
1. Pipelines.
2. Session.
3. Horizon Expingest System.

One comment on `-1` change in tests. When `ingestSession.Run()` returns `nil` we shouldn't continue to `ingestSession.Resume()` because `nil` value means that session ended. I updated the comment in `LiveSession` and also fixed Horizon code.

### Known limitations

Pipeline design is very powerful but it's also very easy to introduce data races like this one. We may want to refactor this as noted previously in #2050.
