### PR TITLE
services/horizon/internal/expingest: Fix deadlock in experimental ingestion

### DIFF
--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -173,14 +173,14 @@ func NewSystem(config Config) (*System, error) {
 	addPipelineHooks(
 		system,
 		session.StatePipeline,
-		config.HistorySession,
+		historySession,
 		session,
 		config.OrderBookGraph,
 	)
 	addPipelineHooks(
 		system,
 		session.LedgerPipeline,
-		config.HistorySession,
+		historySession,
 		session,
 		config.OrderBookGraph,
 	)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

@abuiles could not run the experimental ingestion system locally because there was a deadlock which prevented ingestion from starting. Adolfo was able to isolate the commit which caused the deadlock to http://github.com/stellar/go/pull/2024.

The cause of the deadlock was that the db session used in the ingestion system and pipelines was different from the db session used in the pipeline hooks.

### Why

When starting the ingestion system, System.Run() creates a transaction for the pipeline
and does a select for update when calling historyQ.GetLastLedgerExpIngest().

Eventually, the pipeline preprocessing hook is invoked. preProcessingHook()
checks if there is a transaction attached to the db session. Because the db
session in the pipeline hook is distinct from the db session used by System.Run(),
preProcessingHook() finds there is no transaction attached to the session.

preProcessingHook() then creates a new transaction and also calls historyQ.GetLastLedgerExpIngest()
which triggers a select for update. Now, preProcessingHook() is stuck because the select for update
will only terminate when the other transaction in the System db session is rolled back or committed.

To fix the deadlock, the pipeline hook should share the same db session as the other ingestion
components.

### Known limitations

[N/A]
