### PR TITLE
support/render/httpjson: add RenderStatus for rendering with non-200 status codes

### DIFF
--- a/support/render/httpjson/io.go
+++ b/support/render/httpjson/io.go
@@ -27,6 +27,13 @@ func renderToString(data interface{}, pretty bool) ([]byte, error) {
 // Render write data to w, after marshalling to json. The response header is
 // set based on cType.
 func Render(w http.ResponseWriter, data interface{}, cType contentType) {
+	RenderStatus(w, http.StatusOK, data, cType)
+}
+
+// RenderStatus write data to w, after marshalling to json.
+// The response header is set based on cType.
+// The response status code is set to the statusCode.
+func RenderStatus(w http.ResponseWriter, statusCode int, data interface{}, cType contentType) {
 	js, err := renderToString(data, true)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -39,6 +46,7 @@ func Render(w http.ResponseWriter, data interface{}, cType contentType) {
 	} else {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	}
+	w.WriteHeader(statusCode)
 	w.Write(js)
 }
 

--- a/support/render/httpjson/io_test.go
+++ b/support/render/httpjson/io_test.go
@@ -46,3 +46,43 @@ func TestRender(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderStatus(t *testing.T) {
+	cases := []struct {
+		data            interface{}
+		status          int
+		contentType     contentType
+		wantContentType string
+		wantBody        string
+	}{
+		{
+			data:            map[string]interface{}{"key": "value"},
+			status:          200,
+			contentType:     JSON,
+			wantContentType: "application/json; charset=utf-8",
+			wantBody:        `{"key":"value"}`,
+		},
+		{
+			data:            map[string]interface{}{"key": "value"},
+			status:          400,
+			contentType:     HALJSON,
+			wantContentType: "application/hal+json; charset=utf-8",
+			wantBody:        `{"key":"value"}`,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			w := httptest.NewRecorder()
+			RenderStatus(w, tc.status, tc.data, tc.contentType)
+			resp := w.Result()
+
+			assert.Equal(t, tc.status, resp.StatusCode)
+			assert.Equal(t, tc.wantContentType, resp.Header.Get("Content-Type"))
+
+			body, err := ioutil.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.wantBody, string(body))
+		})
+	}
+}

--- a/support/render/httpjson/io_test.go
+++ b/support/render/httpjson/io_test.go
@@ -1,0 +1,48 @@
+package httpjson
+
+import (
+	"io/ioutil"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRender(t *testing.T) {
+	cases := []struct {
+		data            interface{}
+		contentType     contentType
+		wantContentType string
+		wantBody        string
+	}{
+		{
+			data:            map[string]interface{}{"key": "value"},
+			contentType:     JSON,
+			wantContentType: "application/json; charset=utf-8",
+			wantBody:        `{"key":"value"}`,
+		},
+		{
+			data:            map[string]interface{}{"key": "value"},
+			contentType:     HALJSON,
+			wantContentType: "application/hal+json; charset=utf-8",
+			wantBody:        `{"key":"value"}`,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			w := httptest.NewRecorder()
+			Render(w, tc.data, tc.contentType)
+			resp := w.Result()
+
+			assert.Equal(t, 200, resp.StatusCode)
+			assert.Equal(t, tc.wantContentType, resp.Header.Get("Content-Type"))
+
+			body, err := ioutil.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.wantBody, string(body))
+		})
+	}
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add `RenderStatus` function to `support/render/httpjson` that behaves exactly the same as `Render` but allows setting a non-`200 OK` status code for the response.

### Why

It is not possible to use `Render` to render a response that doesn't have a `200 OK` response. e.g. It is not possible to use it to render a `201 CREATED` that we should be using in some cases in response to `POST` methods, or for error responses.

The only way to set the status code on a `http.ResponseWriter` is to call its `WriteHeader` method passing the status code. Unfortunately once `WriteHeader` is called any changes to the response headers are ignored because the headers have already been written. The `Render` sets content type headers and if a user of this package calls `WriteHeader` before calling `Render` the headers set by `Render` are ignored.

This commit also adds tests for the existing `Render` function.

### Known limitations

N/A
