### PR TITLE
services/ticker: add test logs to identify inputs that make test flaky

### DIFF
--- a/services/ticker/internal/tickerdb/queries_asset_test.go
+++ b/services/ticker/internal/tickerdb/queries_asset_test.go
@@ -53,6 +53,7 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 
 	// Creating first asset:
 	firstTime := time.Now()
+	t.Log("firstTime:", firstTime)
 	a := Asset{
 		Code:          code,
 		IssuerAccount: issuerAccount,
@@ -88,6 +89,7 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 
 	// Creating Seconde Asset:
 	secondTime := time.Now()
+	t.Log("secondTime:", secondTime)
 	a.LastValid = secondTime
 	a.LastChecked = secondTime
 	err = session.InsertOrUpdateAsset(&a, []string{"code", "issuer_account", "issuer_id"})
@@ -122,6 +124,7 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 
 	// Creating Third Asset:
 	thirdTime := time.Now()
+	t.Log("thirdTime:", thirdTime)
 	a.LastValid = thirdTime
 	a.LastChecked = thirdTime
 	err = session.InsertOrUpdateAsset(&a, []string{"code", "issuer_id", "last_valid", "last_checked", "issuer_account"})


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add logs to the `TestInsertOrUpdateAsset` that print out the exact times that are being used.

### Why

The test has been reported as flaky a couple times, first in #1733 then in #2063. There was an imperfect fix put in place in 3e23070 but we've seen another test failure. Previously when I debugged this I wrote some test cases to try long series of inputs to find an input that caused a failure. This time I think it will be a better use of our time if we improve the test logs in this test so that the next time it fails we know exactly what inputs are being used for time and then we can address the continued flakyness.

For #2063 

### Known limitations

This doesn't fix the issue reported, just gives us more visibility into a set of inputs we can reproduce with so that when we spend time fixing it we can be confident if we have fixed it or not.
