### PR TITLE
txnbuild: remove redundant ok from internal verify functions

### DIFF
--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -477,32 +477,38 @@ func VerifyChallengeTx(challengeTx, serverAccountID, network string) (bool, erro
 	}
 
 	// verify signature from operation source
-	ok, err = verifyTxSignature(tx, op.SourceAccount.GetAccountID())
+	err = verifyTxSignature(tx, op.SourceAccount.GetAccountID())
 	if err != nil {
-		return ok, err
+		return false, err
 	}
 
 	// verify signature from server signing key
-	return verifyTxSignature(tx, serverAccountID)
+	err = verifyTxSignature(tx, serverAccountID)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 // verifyTxSignature checks if a transaction has been signed by the provided Stellar account.
-func verifyTxSignature(tx Transaction, accountID string) (bool, error) {
-	signerFound := false
+func verifyTxSignature(tx Transaction, accountID string) error {
 	txHash, err := tx.Hash()
 	if err != nil {
-		return signerFound, err
+		return err
 	}
 
 	kp, err := keypair.Parse(accountID)
 	if err != nil {
-		return signerFound, err
+		return err
 	}
 
 	// find and verify signatures
 	if tx.xdrEnvelope == nil {
-		return signerFound, errors.New("transaction has no signatures")
+		return errors.New("transaction has no signatures")
 	}
+
+	signerFound := false
 	for _, s := range tx.xdrEnvelope.Signatures {
 		e := kp.Verify(txHash[:], s.Signature)
 		if e == nil {
@@ -510,9 +516,9 @@ func verifyTxSignature(tx Transaction, accountID string) (bool, error) {
 			break
 		}
 	}
-
 	if !signerFound {
-		return signerFound, errors.Errorf("transaction not signed by %s", accountID)
+		return errors.Errorf("transaction not signed by %s", accountID)
 	}
-	return signerFound, nil
+
+	return nil
 }

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1183,11 +1183,10 @@ func TestVerifyTxSignatureUnsignedTx(t *testing.T) {
 	// verify unsigned tx
 	err := tx.Build()
 	assert.NoError(t, err)
-	ok, err := verifyTxSignature(tx, kp0.Address())
+	err = verifyTxSignature(tx, kp0.Address())
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "transaction not signed by GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3")
 	}
-	assert.Equal(t, false, ok)
 }
 
 func TestVerifyTxSignatureSingle(t *testing.T) {
@@ -1211,9 +1210,8 @@ func TestVerifyTxSignatureSingle(t *testing.T) {
 	assert.NoError(t, err)
 	err = tx.Sign(kp0)
 	assert.NoError(t, err)
-	ok, err := verifyTxSignature(tx, kp0.Address())
+	err = verifyTxSignature(tx, kp0.Address())
 	assert.NoError(t, err)
-	assert.Equal(t, true, ok)
 }
 
 func TestVerifyTxSignatureMultiple(t *testing.T) {
@@ -1237,12 +1235,10 @@ func TestVerifyTxSignatureMultiple(t *testing.T) {
 	assert.NoError(t, err)
 	err = tx.Sign(kp0, kp1)
 	assert.NoError(t, err)
-	ok, err := verifyTxSignature(tx, kp0.Address())
+	err = verifyTxSignature(tx, kp0.Address())
 	assert.NoError(t, err)
-	assert.Equal(t, true, ok)
-	ok, err = verifyTxSignature(tx, kp1.Address())
+	err = verifyTxSignature(tx, kp1.Address())
 	assert.NoError(t, err)
-	assert.Equal(t, true, ok)
 }
 func TestVerifyTxSignatureInvalid(t *testing.T) {
 	kp0 := newKeypair0()
@@ -1265,11 +1261,10 @@ func TestVerifyTxSignatureInvalid(t *testing.T) {
 	assert.NoError(t, err)
 	err = tx.Sign(kp0, kp1)
 	assert.NoError(t, err)
-	ok, err := verifyTxSignature(tx, "GATBMIXTHXYKSUZSZUEJKACZ2OS2IYUWP2AIF3CA32PIDLJ67CH6Y5UY")
+	err = verifyTxSignature(tx, "GATBMIXTHXYKSUZSZUEJKACZ2OS2IYUWP2AIF3CA32PIDLJ67CH6Y5UY")
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "transaction not signed by GATBMIXTHXYKSUZSZUEJKACZ2OS2IYUWP2AIF3CA32PIDLJ67CH6Y5UY")
 	}
-	assert.Equal(t, false, ok)
 }
 
 func TestVerifyChallengeTxInvalid(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove the `ok` bool value that the `verifyTxSignature` function returns alongside its `error` value.

### Why

The `bool` is redundant.

The `verifyTxSignature` function returns both a `bool` and an `error` but both are communicating the same result. The bool is only ever true when there is no error, and only ever false when there is an error. I'm refactoring some of this code and plan to use this function in a new function and it makes that reuse more difficult if this function returns bool and error.

In my new function I won't be passing on the bool to the caller, and so the question remains in my new function should I handle the bool and error separately so that if bool ever returns false without an error I generate some type of new error. I'd like to not have to solve this problem since it isn't important and instead remove the redundant bool.

### Known limitations

N/A
