### PR TITLE
keypair: add ParseAddress

### DIFF
--- a/keypair/main.go
+++ b/keypair/main.go
@@ -74,9 +74,9 @@ func Master(networkPassphrase string) KP {
 // an address, or a seed.  If the provided input is a seed, the resulting KP
 // will have signing capabilities.
 func Parse(addressOrSeed string) (KP, error) {
-	_, err := strkey.Decode(strkey.VersionByteAccountID, addressOrSeed)
+	addr, err := ParseAddress(addressOrSeed)
 	if err == nil {
-		return &FromAddress{addressOrSeed}, nil
+		return addr, nil
 	}
 
 	if err != strkey.ErrInvalidVersionByte {
@@ -84,6 +84,17 @@ func Parse(addressOrSeed string) (KP, error) {
 	}
 
 	return ParseFull(addressOrSeed)
+}
+
+// ParseAddress constructs a new FromAddress keypair from the provided string,
+// which should be an address.
+func ParseAddress(address string) (*FromAddress, error) {
+	_, err := strkey.Decode(strkey.VersionByteAccountID, address)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FromAddress{address: address}, nil
 }
 
 // ParseFull constructs a new Full keypair from the provided string, which should

--- a/keypair/main_test.go
+++ b/keypair/main_test.go
@@ -156,6 +156,47 @@ var _ = DescribeTable("keypair.ParseFull()",
 	}),
 )
 
+type ParseAddressCase struct {
+	Input       string
+	AddressCase types.GomegaMatcher
+	ErrCase     types.GomegaMatcher
+}
+
+var _ = DescribeTable("keypair.ParseAddress()",
+	func(c ParseAddressCase) {
+		kp, err := ParseAddress(c.Input)
+
+		Expect(kp).To(c.AddressCase)
+		Expect(err).To(c.ErrCase)
+	},
+
+	Entry("a valid address", ParseAddressCase{
+		Input:       "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+		AddressCase: Equal(&FromAddress{address: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"}),
+		ErrCase:     BeNil(),
+	}),
+	Entry("a corrupted address", ParseAddressCase{
+		Input:       "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7O32H",
+		AddressCase: BeNil(),
+		ErrCase:     HaveOccurred(),
+	}),
+	Entry("a valid seed", ParseAddressCase{
+		Input:       "SDHOAMBNLGCE2MV5ZKIVZAQD3VCLGP53P3OBSBI6UN5L5XZI5TKHFQL4",
+		AddressCase: BeNil(),
+		ErrCase:     HaveOccurred(),
+	}),
+	Entry("a corrupted seed", ParseAddressCase{
+		Input:       "SDHOAMBNLGCE2MV5ZKIVZAQD3VCLGP53P3OBSBI6UN5L5XZI5TKHFQL3",
+		AddressCase: BeNil(),
+		ErrCase:     HaveOccurred(),
+	}),
+	Entry("a blank string", ParseAddressCase{
+		Input:       "",
+		AddressCase: BeNil(),
+		ErrCase:     HaveOccurred(),
+	}),
+)
+
 var _ = Describe("keypair.Random()", func() {
 	It("does not return the same value twice", func() {
 		seen := map[string]bool{}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add `ParseAddress` function to `keypair` package.

### Why

Similar to why we recently added the `ParseFull` function sometimes we want to parse a keypair and we specifically only want an address. Encouraging use of `Parse` that does both seeds and addresses is advantegous because in some situations the developer shouldn't care whether it is a seed of an address and they can operate with either. But in other situations the code we write will better communicate intent if we ensure that we're only receiving an address. In some situations we may want to prevent the user from entering a seed and parsing explicitly with an address is a way to achieve this.

### Known limitations

N/A
