### PR TITLE
txnbuild: check tx.xdrEnvelope first before other checks

### DIFF
--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -493,6 +493,10 @@ func VerifyChallengeTx(challengeTx, serverAccountID, network string) (bool, erro
 
 // verifyTxSignature checks if a transaction has been signed by the provided Stellar account.
 func verifyTxSignature(tx Transaction, accountID string) error {
+	if tx.xdrEnvelope == nil {
+		return errors.New("transaction has no signatures")
+	}
+
 	txHash, err := tx.Hash()
 	if err != nil {
 		return err
@@ -504,10 +508,6 @@ func verifyTxSignature(tx Transaction, accountID string) error {
 	}
 
 	// find and verify signatures
-	if tx.xdrEnvelope == nil {
-		return errors.New("transaction has no signatures")
-	}
-
 	signerFound := false
 	for _, s := range tx.xdrEnvelope.Signatures {
 		e := kp.Verify(txHash[:], s.Signature)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Check that a transaction has an xdrEnvelope before calculating the transactions hash or doing any other tasks when verifying a challenge transaction has a signature.

### Why

This check is really inexpensive and simple but we don't do it until after generating a hash for the transaction and parsing the account. We shouldn’t bother hashing a transaction and parsing an account ID if the transaction passed in has no XDR envelope since no XDR envelope means the transaction can’t be verified.

_I wouldn't normally make small performance optimizations like this, because from small optimizations like this are typically a waste of time, but I'm refactoring this code to support multiple signers and moving these few lines up makes the diff of the refactor easier to understand and it seems like a safe change to make in isolation. If we were to make the change in isolation the why above is the only reason I could see justifying it._

This should have no functional impact.

### Known limitations

N/A
