### PR TITLE
services/horizon: Batch Upsert Accounts and Trust Lines

### DIFF
--- a/services/horizon/internal/db2/history/accounts.go
+++ b/services/horizon/internal/db2/history/accounts.go
@@ -2,6 +2,7 @@ package history
 
 import (
 	sq "github.com/Masterminds/squirrel"
+	"github.com/lib/pq"
 
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/support/errors"
@@ -111,6 +112,107 @@ func (q *Q) UpdateAccount(account xdr.AccountEntry, lastModifiedLedger xdr.Uint3
 	}
 
 	return result.RowsAffected()
+}
+
+// UpsertAccounts upserts a batch of accounts in the accounts table.
+func (q *Q) UpsertAccounts(accounts []xdr.LedgerEntry) error {
+	var accountID, inflationDestination []string
+	var homeDomain []xdr.String32
+	var balance, buyingLiabilities, sellingLiabilities []xdr.Int64
+	var sequenceNumber []xdr.SequenceNumber
+	var numSubEntries, flags, lastModifiedLedger []xdr.Uint32
+	var masterWeight, thresholdLow, thresholdMedium, thresholdHigh []uint8
+
+	for _, entry := range accounts {
+		if entry.Data.Type != xdr.LedgerEntryTypeAccount {
+			return errors.Errorf("Invalid entry type: %d", entry.Data.Type)
+		}
+
+		m := accountToMap(entry.Data.MustAccount(), entry.LastModifiedLedgerSeq)
+
+		accountID = append(accountID, m["account_id"].(string))
+		balance = append(balance, m["balance"].(xdr.Int64))
+		buyingLiabilities = append(buyingLiabilities, m["buying_liabilities"].(xdr.Int64))
+		sellingLiabilities = append(sellingLiabilities, m["selling_liabilities"].(xdr.Int64))
+		sequenceNumber = append(sequenceNumber, m["sequence_number"].(xdr.SequenceNumber))
+		numSubEntries = append(numSubEntries, m["num_subentries"].(xdr.Uint32))
+		inflationDestination = append(inflationDestination, m["inflation_destination"].(string))
+		flags = append(flags, m["flags"].(xdr.Uint32))
+		homeDomain = append(homeDomain, m["home_domain"].(xdr.String32))
+		masterWeight = append(masterWeight, m["master_weight"].(uint8))
+		thresholdLow = append(thresholdLow, m["threshold_low"].(uint8))
+		thresholdMedium = append(thresholdMedium, m["threshold_medium"].(uint8))
+		thresholdHigh = append(thresholdHigh, m["threshold_high"].(uint8))
+		lastModifiedLedger = append(lastModifiedLedger, m["last_modified_ledger"].(xdr.Uint32))
+	}
+
+	sql := `
+	WITH r AS
+		(SELECT
+			unnest(?::text[]),   /* account_id */
+			unnest(?::bigint[]), /*	balance */
+			unnest(?::bigint[]), /*	buying_liabilities */
+			unnest(?::bigint[]), /*	selling_liabilities */
+			unnest(?::bigint[]), /*	sequence_number */
+			unnest(?::int[]),    /*	num_subentries */
+			unnest(?::text[]),   /*	inflation_destination */
+			unnest(?::int[]),    /*	flags */
+			unnest(?::text[]),   /*	home_domain */
+			unnest(?::int[]),    /*	master_weight */
+			unnest(?::int[]),    /*	threshold_low */
+			unnest(?::int[]),    /*	threshold_medium */
+			unnest(?::int[]),    /*	threshold_high */
+			unnest(?::int[])     /*	last_modified_ledger */
+		)
+	INSERT INTO accounts ( 
+		account_id,
+		balance,
+		buying_liabilities,
+		selling_liabilities,
+		sequence_number,
+		num_subentries,
+		inflation_destination,
+		flags,
+		home_domain,
+		master_weight,
+		threshold_low,
+		threshold_medium,
+		threshold_high,
+		last_modified_ledger
+	)
+	SELECT * from r 
+	ON CONFLICT (account_id) DO UPDATE SET 
+		account_id = excluded.account_id,
+		balance = excluded.balance,
+		buying_liabilities = excluded.buying_liabilities,
+		selling_liabilities = excluded.selling_liabilities,
+		sequence_number = excluded.sequence_number,
+		num_subentries = excluded.num_subentries,
+		inflation_destination = excluded.inflation_destination,
+		flags = excluded.flags,
+		home_domain = excluded.home_domain,
+		master_weight = excluded.master_weight,
+		threshold_low = excluded.threshold_low,
+		threshold_medium = excluded.threshold_medium,
+		threshold_high = excluded.threshold_high,
+		last_modified_ledger = excluded.last_modified_ledger`
+
+	_, err := q.ExecRaw(sql,
+		pq.Array(accountID),
+		pq.Array(balance),
+		pq.Array(buyingLiabilities),
+		pq.Array(sellingLiabilities),
+		pq.Array(sequenceNumber),
+		pq.Array(numSubEntries),
+		pq.Array(inflationDestination),
+		pq.Array(flags),
+		pq.Array(homeDomain),
+		pq.Array(masterWeight),
+		pq.Array(thresholdLow),
+		pq.Array(thresholdMedium),
+		pq.Array(thresholdHigh),
+		pq.Array(lastModifiedLedger))
+	return err
 }
 
 // RemoveAccount deletes a row in the offers table.

--- a/services/horizon/internal/db2/history/accounts.go
+++ b/services/horizon/internal/db2/history/accounts.go
@@ -115,6 +115,9 @@ func (q *Q) UpdateAccount(account xdr.AccountEntry, lastModifiedLedger xdr.Uint3
 }
 
 // UpsertAccounts upserts a batch of accounts in the accounts table.
+// There's currently no limit of the number of accounts this method can
+// accept other than 2GB limit of the query string length what should be enough
+// for each ledger with the current limits.
 func (q *Q) UpsertAccounts(accounts []xdr.LedgerEntry) error {
 	var accountID, inflationDestination []string
 	var homeDomain []xdr.String32

--- a/services/horizon/internal/db2/history/accounts_test.go
+++ b/services/horizon/internal/db2/history/accounts_test.go
@@ -248,6 +248,43 @@ func TestUpsertAccount(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedBinary, actualBinary)
 	assert.Equal(t, uint32(1235), accounts[0].LastModifiedLedger)
+
+	accounts, err = q.GetAccountsByIDs([]string{account2.AccountId.Address()})
+	assert.NoError(t, err)
+	assert.Len(t, accounts, 1)
+
+	expectedBinary, err = account2.MarshalBinary()
+	assert.NoError(t, err)
+
+	dbEntry = xdr.AccountEntry{
+		AccountId:     xdr.MustAddress(accounts[0].AccountID),
+		Balance:       xdr.Int64(accounts[0].Balance),
+		SeqNum:        xdr.SequenceNumber(accounts[0].SequenceNumber),
+		NumSubEntries: xdr.Uint32(accounts[0].NumSubEntries),
+		InflationDest: &inflationDest,
+		Flags:         xdr.Uint32(accounts[0].Flags),
+		HomeDomain:    xdr.String32(accounts[0].HomeDomain),
+		Thresholds: xdr.Thresholds{
+			accounts[0].MasterWeight,
+			accounts[0].ThresholdLow,
+			accounts[0].ThresholdMedium,
+			accounts[0].ThresholdHigh,
+		},
+		Ext: xdr.AccountEntryExt{
+			V: 1,
+			V1: &xdr.AccountEntryV1{
+				Liabilities: xdr.Liabilities{
+					Buying:  xdr.Int64(accounts[0].BuyingLiabilities),
+					Selling: xdr.Int64(accounts[0].SellingLiabilities),
+				},
+			},
+		},
+	}
+
+	actualBinary, err = dbEntry.MarshalBinary()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBinary, actualBinary)
+	assert.Equal(t, uint32(1234), accounts[0].LastModifiedLedger)
 }
 
 func TestRemoveAccount(t *testing.T) {

--- a/services/horizon/internal/db2/history/accounts_test.go
+++ b/services/horizon/internal/db2/history/accounts_test.go
@@ -167,6 +167,89 @@ func TestUpdateAccount(t *testing.T) {
 	assert.Equal(t, uint32(1235), accounts[0].LastModifiedLedger)
 }
 
+func TestUpsertAccount(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	ledgerEntries := []xdr.LedgerEntry{
+		xdr.LedgerEntry{
+			LastModifiedLedgerSeq: 1234,
+			Data: xdr.LedgerEntryData{
+				Type:    xdr.LedgerEntryTypeAccount,
+				Account: &account1,
+			},
+		},
+		xdr.LedgerEntry{
+			LastModifiedLedgerSeq: 1234,
+			Data: xdr.LedgerEntryData{
+				Type:    xdr.LedgerEntryTypeAccount,
+				Account: &account2,
+			},
+		},
+	}
+	err := q.UpsertAccounts(ledgerEntries)
+	assert.NoError(t, err)
+
+	modifiedAccount := account1
+	modifiedAccount.Balance = 32847893
+
+	err = q.UpsertAccounts([]xdr.LedgerEntry{{
+		LastModifiedLedgerSeq: 1235,
+		Data: xdr.LedgerEntryData{
+			Type:    xdr.LedgerEntryTypeAccount,
+			Account: &modifiedAccount,
+		},
+	}})
+	assert.NoError(t, err)
+
+	keys := []string{
+		account1.AccountId.Address(),
+		account2.AccountId.Address(),
+	}
+	accounts, err := q.GetAccountsByIDs(keys)
+	assert.NoError(t, err)
+	assert.Len(t, accounts, 2)
+
+	accounts, err = q.GetAccountsByIDs([]string{account1.AccountId.Address()})
+	assert.NoError(t, err)
+	assert.Len(t, accounts, 1)
+
+	expectedBinary, err := modifiedAccount.MarshalBinary()
+	assert.NoError(t, err)
+
+	dbEntry := xdr.AccountEntry{
+		AccountId:     xdr.MustAddress(accounts[0].AccountID),
+		Balance:       xdr.Int64(accounts[0].Balance),
+		SeqNum:        xdr.SequenceNumber(accounts[0].SequenceNumber),
+		NumSubEntries: xdr.Uint32(accounts[0].NumSubEntries),
+		InflationDest: &inflationDest,
+		Flags:         xdr.Uint32(accounts[0].Flags),
+		HomeDomain:    xdr.String32(accounts[0].HomeDomain),
+		Thresholds: xdr.Thresholds{
+			accounts[0].MasterWeight,
+			accounts[0].ThresholdLow,
+			accounts[0].ThresholdMedium,
+			accounts[0].ThresholdHigh,
+		},
+		Ext: xdr.AccountEntryExt{
+			V: 1,
+			V1: &xdr.AccountEntryV1{
+				Liabilities: xdr.Liabilities{
+					Buying:  xdr.Int64(accounts[0].BuyingLiabilities),
+					Selling: xdr.Int64(accounts[0].SellingLiabilities),
+				},
+			},
+		},
+	}
+
+	actualBinary, err := dbEntry.MarshalBinary()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBinary, actualBinary)
+	assert.Equal(t, uint32(1235), accounts[0].LastModifiedLedger)
+}
+
 func TestRemoveAccount(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -167,6 +167,7 @@ type QAccounts interface {
 	NewAccountsBatchInsertBuilder(maxBatchSize int) AccountsBatchInsertBuilder
 	InsertAccount(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) (int64, error)
 	UpdateAccount(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) (int64, error)
+	UpsertAccounts(accounts []xdr.LedgerEntry) error
 	RemoveAccount(accountID string) (int64, error)
 }
 
@@ -562,6 +563,7 @@ type QTrustLines interface {
 	NewTrustLinesBatchInsertBuilder(maxBatchSize int) TrustLinesBatchInsertBuilder
 	InsertTrustLine(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr.Uint32) (int64, error)
 	UpdateTrustLine(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr.Uint32) (int64, error)
+	UpsertTrustLines(trustLines []xdr.LedgerEntry) error
 	RemoveTrustLine(key xdr.LedgerKeyTrustLine) (int64, error)
 }
 

--- a/services/horizon/internal/db2/history/mock_q_accounts.go
+++ b/services/horizon/internal/db2/history/mock_q_accounts.go
@@ -31,6 +31,11 @@ func (m *MockQAccounts) UpdateAccount(account xdr.AccountEntry, lastModifiedLedg
 	return a.Get(0).(int64), a.Error(1)
 }
 
+func (m *MockQAccounts) UpsertAccounts(accounts []xdr.LedgerEntry) error {
+	a := m.Called(accounts)
+	return a.Error(0)
+}
+
 func (m *MockQAccounts) RemoveAccount(accountID string) (int64, error) {
 	a := m.Called(accountID)
 	return a.Get(0).(int64), a.Error(1)

--- a/services/horizon/internal/db2/history/mock_q_trust_lines.go
+++ b/services/horizon/internal/db2/history/mock_q_trust_lines.go
@@ -26,6 +26,11 @@ func (m *MockQTrustLines) UpdateTrustLine(trustLine xdr.TrustLineEntry, lastModi
 	return a.Get(0).(int64), a.Error(1)
 }
 
+func (m *MockQTrustLines) UpsertTrustLines(trustLines []xdr.LedgerEntry) error {
+	a := m.Called(trustLines)
+	return a.Error(0)
+}
+
 func (m *MockQTrustLines) RemoveTrustLine(key xdr.LedgerKeyTrustLine) (int64, error) {
 	a := m.Called(key)
 	return a.Get(0).(int64), a.Error(1)

--- a/services/horizon/internal/db2/history/trust_lines.go
+++ b/services/horizon/internal/db2/history/trust_lines.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 
 	sq "github.com/Masterminds/squirrel"
+	"github.com/lib/pq"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -92,6 +93,95 @@ func (q *Q) UpdateTrustLine(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr
 	}
 
 	return result.RowsAffected()
+}
+
+// UpsertTrustLines upserts a batch of trust lines in the trust lines table.
+func (q *Q) UpsertTrustLines(trustLines []xdr.LedgerEntry) error {
+	var ledgerKey, accountID, assetIssuer, assetCode []string
+	var balance, limit, buyingLiabilities, sellingLiabilities []xdr.Int64
+	var flags, lastModifiedLedger []xdr.Uint32
+	var assetType []xdr.AssetType
+
+	for _, entry := range trustLines {
+		if entry.Data.Type != xdr.LedgerEntryTypeTrustline {
+			return errors.Errorf("Invalid entry type: %d", entry.Data.Type)
+		}
+
+		key, err := trustLineEntryToLedgerKeyString(entry.Data.MustTrustLine())
+		if err != nil {
+			return errors.Wrap(err, "Error running trustLineEntryToLedgerKeyString")
+		}
+
+		m := trustLineToMap(entry.Data.MustTrustLine(), entry.LastModifiedLedgerSeq)
+
+		ledgerKey = append(ledgerKey, key)
+		accountID = append(accountID, m["account_id"].(string))
+		assetType = append(assetType, m["asset_type"].(xdr.AssetType))
+		assetIssuer = append(assetIssuer, m["asset_issuer"].(string))
+		assetCode = append(assetCode, m["asset_code"].(string))
+		balance = append(balance, m["balance"].(xdr.Int64))
+		limit = append(limit, m["trust_line_limit"].(xdr.Int64))
+		buyingLiabilities = append(buyingLiabilities, m["buying_liabilities"].(xdr.Int64))
+		sellingLiabilities = append(sellingLiabilities, m["selling_liabilities"].(xdr.Int64))
+		flags = append(flags, m["flags"].(xdr.Uint32))
+		lastModifiedLedger = append(lastModifiedLedger, m["last_modified_ledger"].(xdr.Uint32))
+	}
+
+	sql := `
+	WITH r AS
+		(SELECT
+			unnest(?::text[]),
+			unnest(?::text[]),
+			unnest(?::int[]),
+			unnest(?::text[]),
+			unnest(?::text[]),
+			unnest(?::bigint[]),
+			unnest(?::bigint[]),
+			unnest(?::bigint[]),
+			unnest(?::bigint[]),
+			unnest(?::int[]),
+			unnest(?::int[])
+		)
+	INSERT INTO trust_lines ( 
+		ledger_key,
+		account_id,
+		asset_type,
+		asset_issuer,
+		asset_code,
+		balance,
+		trust_line_limit,
+		buying_liabilities,
+		selling_liabilities,
+		flags,
+		last_modified_ledger
+	)
+	SELECT * from r 
+	ON CONFLICT (ledger_key) DO UPDATE SET 
+		ledger_key = excluded.ledger_key,
+		account_id = excluded.account_id,
+		asset_type = excluded.asset_type,
+		asset_issuer = excluded.asset_issuer,
+		asset_code = excluded.asset_code,
+		balance = excluded.balance,
+		trust_line_limit = excluded.trust_line_limit,
+		buying_liabilities = excluded.buying_liabilities,
+		selling_liabilities = excluded.selling_liabilities,
+		flags = excluded.flags,
+		last_modified_ledger = excluded.last_modified_ledger`
+
+	_, err := q.ExecRaw(sql,
+		pq.Array(ledgerKey),
+		pq.Array(accountID),
+		pq.Array(assetType),
+		pq.Array(assetIssuer),
+		pq.Array(assetCode),
+		pq.Array(balance),
+		pq.Array(limit),
+		pq.Array(buyingLiabilities),
+		pq.Array(sellingLiabilities),
+		pq.Array(flags),
+		pq.Array(lastModifiedLedger))
+	return err
 }
 
 // RemoveTrustLine deletes a row in the trust lines table.

--- a/services/horizon/internal/db2/history/trust_lines.go
+++ b/services/horizon/internal/db2/history/trust_lines.go
@@ -96,6 +96,9 @@ func (q *Q) UpdateTrustLine(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr
 }
 
 // UpsertTrustLines upserts a batch of trust lines in the trust lines table.
+// There's currently no limit of the number of trust lines this method can
+// accept other than 2GB limit of the query string length what should be enough
+// for each ledger with the current limits.
 func (q *Q) UpsertTrustLines(trustLines []xdr.LedgerEntry) error {
 	var ledgerKey, accountID, assetIssuer, assetCode []string
 	var balance, limit, buyingLiabilities, sellingLiabilities []xdr.Int64

--- a/services/horizon/internal/db2/history/trust_lines_test.go
+++ b/services/horizon/internal/db2/history/trust_lines_test.go
@@ -240,6 +240,38 @@ func TestUpsertTrustLines(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedBinary, actualBinary)
 	assert.Equal(t, uint32(1000), lines[0].LastModifiedLedger)
+
+	keys = []xdr.LedgerKeyTrustLine{
+		{Asset: usdTrustLine.Asset, AccountId: usdTrustLine.AccountId},
+	}
+	lines, err = q.GetTrustLinesByKeys(keys)
+	assert.NoError(t, err)
+	assert.Len(t, lines, 1)
+
+	expectedBinary, err = usdTrustLine.MarshalBinary()
+	assert.NoError(t, err)
+
+	dbEntry = xdr.TrustLineEntry{
+		AccountId: xdr.MustAddress(lines[0].AccountID),
+		Asset:     xdr.MustNewCreditAsset(lines[0].AssetCode, lines[0].AssetIssuer),
+		Balance:   xdr.Int64(lines[0].Balance),
+		Limit:     xdr.Int64(lines[0].Limit),
+		Flags:     xdr.Uint32(lines[0].Flags),
+		Ext: xdr.TrustLineEntryExt{
+			V: 1,
+			V1: &xdr.TrustLineEntryV1{
+				Liabilities: xdr.Liabilities{
+					Buying:  xdr.Int64(lines[0].BuyingLiabilities),
+					Selling: xdr.Int64(lines[0].SellingLiabilities),
+				},
+			},
+		},
+	}
+
+	actualBinary, err = dbEntry.MarshalBinary()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBinary, actualBinary)
+	assert.Equal(t, uint32(2), lines[0].LastModifiedLedger)
 }
 
 func TestRemoveTrustLine(t *testing.T) {

--- a/services/horizon/internal/db2/history/trust_lines_test.go
+++ b/services/horizon/internal/db2/history/trust_lines_test.go
@@ -149,6 +149,99 @@ func TestUpdateTrustLine(t *testing.T) {
 	assert.Equal(t, uint32(1235), lines[0].LastModifiedLedger)
 }
 
+func TestUpsertTrustLines(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	// Upserting nothing is no op
+	err := q.UpsertTrustLines([]xdr.LedgerEntry{})
+	assert.NoError(t, err)
+
+	ledgerEntries := []xdr.LedgerEntry{
+		xdr.LedgerEntry{
+			LastModifiedLedgerSeq: 1,
+			Data: xdr.LedgerEntryData{
+				Type:      xdr.LedgerEntryTypeTrustline,
+				TrustLine: &eurTrustLine,
+			},
+		},
+		xdr.LedgerEntry{
+			LastModifiedLedgerSeq: 2,
+			Data: xdr.LedgerEntryData{
+				Type:      xdr.LedgerEntryTypeTrustline,
+				TrustLine: &usdTrustLine,
+			},
+		},
+	}
+
+	err = q.UpsertTrustLines(ledgerEntries)
+	assert.NoError(t, err)
+
+	keys := []xdr.LedgerKeyTrustLine{
+		{Asset: eurTrustLine.Asset, AccountId: eurTrustLine.AccountId},
+	}
+	lines, err := q.GetTrustLinesByKeys(keys)
+	assert.NoError(t, err)
+	assert.Len(t, lines, 1)
+
+	keys = []xdr.LedgerKeyTrustLine{
+		{Asset: usdTrustLine.Asset, AccountId: usdTrustLine.AccountId},
+	}
+	lines, err = q.GetTrustLinesByKeys(keys)
+	assert.NoError(t, err)
+	assert.Len(t, lines, 1)
+
+	modifiedTrustLine := eurTrustLine
+	modifiedTrustLine.Balance = 30000
+
+	ledgerEntries = []xdr.LedgerEntry{
+		xdr.LedgerEntry{
+			LastModifiedLedgerSeq: 1000,
+			Data: xdr.LedgerEntryData{
+				Type:      xdr.LedgerEntryTypeTrustline,
+				TrustLine: &modifiedTrustLine,
+			},
+		},
+	}
+
+	err = q.UpsertTrustLines(ledgerEntries)
+	assert.NoError(t, err)
+
+	keys = []xdr.LedgerKeyTrustLine{
+		{Asset: eurTrustLine.Asset, AccountId: eurTrustLine.AccountId},
+	}
+	lines, err = q.GetTrustLinesByKeys(keys)
+	assert.NoError(t, err)
+	assert.Len(t, lines, 1)
+
+	expectedBinary, err := modifiedTrustLine.MarshalBinary()
+	assert.NoError(t, err)
+
+	dbEntry := xdr.TrustLineEntry{
+		AccountId: xdr.MustAddress(lines[0].AccountID),
+		Asset:     xdr.MustNewCreditAsset(lines[0].AssetCode, lines[0].AssetIssuer),
+		Balance:   xdr.Int64(lines[0].Balance),
+		Limit:     xdr.Int64(lines[0].Limit),
+		Flags:     xdr.Uint32(lines[0].Flags),
+		Ext: xdr.TrustLineEntryExt{
+			V: 1,
+			V1: &xdr.TrustLineEntryV1{
+				Liabilities: xdr.Liabilities{
+					Buying:  xdr.Int64(lines[0].BuyingLiabilities),
+					Selling: xdr.Int64(lines[0].SellingLiabilities),
+				},
+			},
+		},
+	}
+
+	actualBinary, err := dbEntry.MarshalBinary()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBinary, actualBinary)
+	assert.Equal(t, uint32(1000), lines[0].LastModifiedLedger)
+}
+
 func TestRemoveTrustLine(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()

--- a/services/horizon/internal/expingest/processors/database_processor.go
+++ b/services/horizon/internal/expingest/processors/database_processor.go
@@ -219,7 +219,8 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 	// Get all transactions
 	var transactions []io.LedgerTransaction
 	for {
-		transaction, err := r.Read()
+		var transaction io.LedgerTransaction
+		transaction, err = r.Read()
 		if err != nil {
 			if err == stdio.EOF {
 				break
@@ -246,7 +247,7 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 		// Fees are processed before everything else.
 		for _, transaction := range transactions {
 			for _, change := range transaction.GetFeeChanges() {
-				err := ledgerCache.AddChange(change)
+				err = ledgerCache.AddChange(change)
 				if err != nil {
 					return errors.Wrap(err, "error adding to ledgerCache")
 				}
@@ -263,7 +264,7 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 		// Tx meta
 		for _, transaction := range transactions {
 			for _, change := range transaction.GetChanges() {
-				err := ledgerCache.AddChange(change)
+				err = ledgerCache.AddChange(change)
 				if err != nil {
 					return errors.Wrap(err, "error adding to ledgerCache")
 				}
@@ -279,7 +280,8 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 
 		// Process upgrades meta
 		for {
-			change, err := r.ReadUpgradeChange()
+			var change io.Change
+			change, err = r.ReadUpgradeChange()
 			if err != nil {
 				if err == stdio.EOF {
 					break
@@ -310,7 +312,7 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 		}
 
 		for _, change := range changes {
-			err := handler(change)
+			err = handler(change)
 			if err != nil {
 				return errors.Wrap(
 					err,

--- a/services/horizon/internal/expingest/processors/database_processor.go
+++ b/services/horizon/internal/expingest/processors/database_processor.go
@@ -193,6 +193,8 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 
 	ledgerCache := io.NewLedgerEntryChangeCache()
 	p.AssetStatSet = AssetStatSet{}
+	p.batchUpsertTrustLines = []xdr.LedgerEntry{}
+	p.batchUpsertAccounts = []xdr.LedgerEntry{}
 
 	actionHandlers := map[DatabaseProcessorActionType]func(change io.Change) error{
 		Accounts:          p.processLedgerAccounts,
@@ -325,8 +327,26 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 		}
 	}
 
+	if p.Action == All || p.Action == Accounts {
+		// Upsert accounts
+		if len(p.batchUpsertAccounts) > 0 {
+			err = p.AccountsQ.UpsertAccounts(p.batchUpsertAccounts)
+			if err != nil {
+				return errors.Wrap(err, "errors in UpsertTrustLines")
+			}
+		}
+	}
+
 	// Asset stats
 	if p.Action == All || p.Action == TrustLines {
+		// Upsert trust lines
+		if len(p.batchUpsertTrustLines) > 0 {
+			err = p.TrustLinesQ.UpsertTrustLines(p.batchUpsertTrustLines)
+			if err != nil {
+				return errors.Wrap(err, "errors in UpsertTrustLines")
+			}
+		}
+
 		assetStatsDeltas := p.AssetStatSet.All()
 		for _, delta := range assetStatsDeltas {
 			var rowsAffected int64
@@ -498,42 +518,31 @@ func (p *DatabaseProcessor) processLedgerAccounts(change io.Change) error {
 		return nil
 	}
 
-	var rowsAffected int64
-	var action string
 	var accountID string
 
 	switch {
-	case change.Pre == nil && change.Post != nil:
-		// Created
-		action = "inserting"
-		account := change.Post.Data.MustAccount()
-		accountID = account.AccountId.Address()
-		rowsAffected, err = p.AccountsQ.InsertAccount(account, change.Post.LastModifiedLedgerSeq)
+	case change.Post != nil:
+		// Created and updated
+		p.batchUpsertAccounts = append(p.batchUpsertAccounts, *change.Post)
 	case change.Pre != nil && change.Post == nil:
 		// Removed
-		action = "removing"
 		account := change.Pre.Data.MustAccount()
 		accountID = account.AccountId.Address()
-		rowsAffected, err = p.AccountsQ.RemoveAccount(accountID)
+		rowsAffected, err := p.AccountsQ.RemoveAccount(accountID)
+
+		if err != nil {
+			return err
+		}
+
+		if rowsAffected != 1 {
+			return ingesterrors.NewStateError(errors.Errorf(
+				"%d No rows affected when removing account %s",
+				rowsAffected,
+				accountID,
+			))
+		}
 	default:
-		// Updated
-		action = "updating"
-		account := change.Post.Data.MustAccount()
-		accountID = account.AccountId.Address()
-		rowsAffected, err = p.AccountsQ.UpdateAccount(account, change.Post.LastModifiedLedgerSeq)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	if rowsAffected != 1 {
-		return ingesterrors.NewStateError(errors.Errorf(
-			"%d No rows affected when %s account %s",
-			rowsAffected,
-			action,
-			accountID,
-		))
+		return errors.New("Invalid io.Change: change.Pre == nil && change.Post == nil")
 	}
 
 	return nil
@@ -759,19 +768,19 @@ func (p *DatabaseProcessor) processLedgerTrustLines(change io.Change) error {
 	var ledgerKey xdr.LedgerKey
 
 	switch {
-	case change.Pre == nil && change.Post != nil:
-		// Created
-		action = "inserting"
-		trustLine := change.Post.Data.MustTrustLine()
-		err = ledgerKey.SetTrustline(trustLine.AccountId, trustLine.Asset)
-		if err != nil {
-			return errors.Wrap(err, "Error creating ledger key")
+	case change.Post != nil:
+		// Created and updated
+		postTrustLine := change.Post.Data.MustTrustLine()
+		p.batchUpsertTrustLines = append(p.batchUpsertTrustLines, *change.Post)
+		if change.Pre == nil {
+			err = p.adjustAssetStat(nil, &postTrustLine)
+		} else {
+			preTrustLine := change.Pre.Data.MustTrustLine()
+			err = p.adjustAssetStat(&preTrustLine, &postTrustLine)
 		}
-		err = p.adjustAssetStat(nil, &trustLine)
 		if err != nil {
 			return errors.Wrap(err, "Error adjusting asset stat")
 		}
-		rowsAffected, err = p.TrustLinesQ.InsertTrustLine(trustLine, change.Post.LastModifiedLedgerSeq)
 	case change.Pre != nil && change.Post == nil:
 		// Removed
 		action = "removing"
@@ -785,35 +794,23 @@ func (p *DatabaseProcessor) processLedgerTrustLines(change io.Change) error {
 			return errors.Wrap(err, "Error adjusting asset stat")
 		}
 		rowsAffected, err = p.TrustLinesQ.RemoveTrustLine(*ledgerKey.TrustLine)
+		if err != nil {
+			return err
+		}
+
+		if rowsAffected != 1 {
+			return ingesterrors.NewStateError(errors.Errorf(
+				"%d rows affected when %s trustline: %s %s",
+				rowsAffected,
+				action,
+				ledgerKey.TrustLine.AccountId.Address(),
+				ledgerKey.TrustLine.Asset.String(),
+			))
+		}
 	default:
-		// Updated
-		action = "updating"
-		preTrustLine := change.Pre.Data.MustTrustLine()
-		trustLine := change.Post.Data.MustTrustLine()
-		err = ledgerKey.SetTrustline(trustLine.AccountId, trustLine.Asset)
-		if err != nil {
-			return errors.Wrap(err, "Error creating ledger key")
-		}
-		err = p.adjustAssetStat(&preTrustLine, &trustLine)
-		if err != nil {
-			return errors.Wrap(err, "Error adjusting asset stat")
-		}
-		rowsAffected, err = p.TrustLinesQ.UpdateTrustLine(trustLine, change.Post.LastModifiedLedgerSeq)
+		return errors.New("Invalid io.Change: change.Pre == nil && change.Post == nil")
 	}
 
-	if err != nil {
-		return err
-	}
-
-	if rowsAffected != 1 {
-		return ingesterrors.NewStateError(errors.Errorf(
-			"%d rows affected when %s trustline: %s %s",
-			rowsAffected,
-			action,
-			ledgerKey.TrustLine.AccountId.Address(),
-			ledgerKey.TrustLine.Asset.String(),
-		))
-	}
 	return nil
 }
 

--- a/services/horizon/internal/expingest/processors/main.go
+++ b/services/horizon/internal/expingest/processors/main.go
@@ -3,6 +3,7 @@ package processors
 import (
 	"github.com/stellar/go/exp/orderbook"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/xdr"
 )
 
 type PipelineContextKey string
@@ -40,6 +41,10 @@ type DatabaseProcessor struct {
 	IngestVersion int
 	// AssetStatSet is used in TrustLines processor
 	AssetStatSet AssetStatSet
+	// batchUpsertTrustLines is a slice of trust lines to upsert in batch
+	batchUpsertTrustLines []xdr.LedgerEntry
+	// batchUpsertAccounts is a slice of accounts to upsert in batch
+	batchUpsertAccounts []xdr.LedgerEntry
 }
 
 // OrderbookProcessor is a processor (both state and ledger) that's responsible


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit changes `DatabaseProcessor` to insert/update (upsert) accounts and trust lines in batches.

### Why

In #2004 we added `LedgerEntryChangeCache` that aims to decrease number of DB updates: all the changes connected to a single ledger entry are squashed into just one DB query. Even though it gives a nice performance boost when large number of ops change a small number of ledger entries, it turns out this is not enough. When many ledger entries are changed in a new ledger, DB connection round trip time takes significant percentage of time in overall ledger processing time.

The SQL query was [borrowed](https://github.com/stellar/stellar-core/blob/21469f90da1eacc6845017a520e179afb3772e65/src/ledger/LedgerTxnAccountSQL.cpp#L306-L336) from stellar-core.

### Known limitations

* This code shouldn't be the final code that is released. The aim of this PR is to deploy it to stg environment to check it's performance.
* This is adding upsert queries for accounts and trust lines only. These types are the most common changes in the recent ledgers. The final solution should add batch upsert and batch delete for all ledger entries.
* There's a potential to improve the code: autogenerating upsert query for any ledger entry type, better tests. Will be done in a separate PR.
* It removes a code that check a number of rows affected by a query. Unfortunately, the performance of the current solution is too bad to leave it.