### PR TITLE
support/http/httpdecode: move http decoding to its own package

### DIFF
--- a/support/http/httpdecode/httpdecode.go
+++ b/support/http/httpdecode/httpdecode.go
@@ -1,0 +1,18 @@
+package httpdecode
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Decode decodes JSON request from r into v.
+func DecodeJSON(r *http.Request, v interface{}) error {
+	dec := json.NewDecoder(r.Body)
+	dec.UseNumber()
+	err := dec.Decode(v)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/support/http/httpdecode/httpdecode.go
+++ b/support/http/httpdecode/httpdecode.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 )
 
-// Decode decodes JSON request from r into v.
+// DecodeJSON decodes JSON request from r into v.
 func DecodeJSON(r *http.Request, v interface{}) error {
 	dec := json.NewDecoder(r.Body)
 	dec.UseNumber()

--- a/support/http/httpdecode/httpdecode.go
+++ b/support/http/httpdecode/httpdecode.go
@@ -9,10 +9,5 @@ import (
 func DecodeJSON(r *http.Request, v interface{}) error {
 	dec := json.NewDecoder(r.Body)
 	dec.UseNumber()
-	err := dec.Decode(v)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return dec.Decode(v)
 }

--- a/support/http/httpdecode/httpdecode_test.go
+++ b/support/http/httpdecode/httpdecode_test.go
@@ -1,0 +1,34 @@
+package httpdecode
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeValidJSON(t *testing.T) {
+	body := `{"Foo":"bar"}`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+
+	bodyDecoded := struct {
+		Foo string `json:"foo"`
+	}{}
+	err := DecodeJSON(r, &bodyDecoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "bar", bodyDecoded.Foo)
+}
+
+func TestDecodeInvalidJSON(t *testing.T) {
+	body := `{"Foo:"bar"}`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+
+	bodyDecoded := struct {
+		Foo string `json:"foo"`
+	}{}
+	err := DecodeJSON(r, &bodyDecoded)
+	require.EqualError(t, err, "invalid character 'b' after object key")
+}

--- a/support/http/httpdecode/httpdecode_test.go
+++ b/support/http/httpdecode/httpdecode_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDecodeValidJSON(t *testing.T) {
+func TestDecodeJSON_valid(t *testing.T) {
 	body := `{"Foo":"bar"}`
 	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
 
@@ -22,7 +22,7 @@ func TestDecodeValidJSON(t *testing.T) {
 	assert.Equal(t, "bar", bodyDecoded.Foo)
 }
 
-func TestDecodeInvalidJSON(t *testing.T) {
+func TestDecodeJSON_invalid(t *testing.T) {
 	body := `{"Foo:"bar"}`
 	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
 

--- a/support/http/httpdecode/httpdecode_test.go
+++ b/support/http/httpdecode/httpdecode_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestDecodeJSON_valid(t *testing.T) {
-	body := `{"Foo":"bar"}`
+	body := `{"foo":"bar"}`
 	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
 
 	bodyDecoded := struct {
@@ -23,7 +23,7 @@ func TestDecodeJSON_valid(t *testing.T) {
 }
 
 func TestDecodeJSON_invalid(t *testing.T) {
-	body := `{"Foo:"bar"}`
+	body := `{"foo:"bar"}`
 	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
 
 	bodyDecoded := struct {

--- a/support/render/httpjson/handler.go
+++ b/support/render/httpjson/handler.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/http/httpdecode"
 	"github.com/stellar/go/support/render/problem"
 )
 
@@ -82,9 +83,9 @@ func (h *handler) executeFunc(ctx context.Context, req *http.Request) (interface
 	if h.inType != nil {
 		if h.readFromBody {
 			inPtr := reflect.New(h.inType)
-			err := read(req.Body, inPtr.Interface())
+			err := httpdecode.DecodeJSON(req, inPtr.Interface())
 			if err != nil {
-				return nil, err
+				return nil, ErrBadRequest
 			}
 			a = append(a, inPtr.Elem())
 		} else {

--- a/support/render/httpjson/io.go
+++ b/support/render/httpjson/io.go
@@ -2,7 +2,6 @@ package httpjson
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/stellar/go/support/errors"
@@ -51,15 +50,3 @@ func RenderStatus(w http.ResponseWriter, statusCode int, data interface{}, cType
 }
 
 var ErrBadRequest = errors.New("bad request")
-
-// read decodes a json text from r into v.
-func read(r io.Reader, v interface{}) error {
-	dec := json.NewDecoder(r)
-	dec.UseNumber()
-	err := dec.Decode(v)
-	if err != nil {
-		return ErrBadRequest
-	}
-
-	return nil
-}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Move the http decoding logic we use for decoding JSON messages to its own package.

### Why

This logic is at the moment buried as an not-exported function in the `support/render/httpjson` package. I think it belongs in its own package because:
- I'd like to use this function directly to decode some messages that do not use the handler that is exposed by the httpjson package.
- The `support/render/httpjson` is in the `render` package that implies it is primarily for rendering responses. To break this function out to call separately just for decoding feels a little out of place in render.
- I'd like to add functionality in another decode function to do both decoding of form urlencoded requests as well as JSON. @howardtw mentioned it's a little odd for that logic to live in httpjson, and so I plan to add a decode function alongside this one to do form urlencoded decoding, and then a third function that does both and forks based on the content type.

I've changed the inputs to this function to be a `http.Request` instead of a `io.Reader` because the other functions I'll add will use a request to fork based on the content-type and I think it is easier to understand if they are all consistent. I don't feel strongly about this last part though.

### Known limitations

N/A
