### PR TITLE
support/http/httpdecode: add funcs for form and form+json decoding

### DIFF
--- a/support/http/httpdecode/httpdecode.go
+++ b/support/http/httpdecode/httpdecode.go
@@ -51,3 +51,33 @@ func DecodeForm(r *http.Request, v interface{}) error {
 	dec.IgnoreUnknownKeys(true)
 	return dec.Decode(v, r.PostForm)
 }
+
+// Decode decodes form URL encoded requests and JSON requests from r into v.
+//
+// The requests Content-Type header informs if the request should be decoded
+// using a form URL encoded decoder or using a JSON decoder.
+//
+// A Content-Type of application/x-www-form-urlencoded will result in form
+// decoding. Any other content type will result in JSON decoding because it is
+// common to make JSON requests without a Content-Type where-as correctly
+// formatted form URL encoded requests are more often accompanied by the
+// appropriate Content-Type.
+//
+// An error is returned if the Content-Type cannot be parsed by a mime
+// media-type parser.
+//
+// See DecodeForm and DecodeJSON for details about the types of errors that may
+// occur.
+func Decode(r *http.Request, v interface{}) error {
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "" {
+		mediaType, _, err := mime.ParseMediaType(contentType)
+		if err != nil {
+			return errors.Wrap(err, "content type could not be parsed")
+		}
+		if mediaType == "application/x-www-form-urlencoded" {
+			return DecodeForm(r, v)
+		}
+	}
+	return DecodeJSON(r, v)
+}

--- a/support/http/httpdecode/httpdecode.go
+++ b/support/http/httpdecode/httpdecode.go
@@ -2,7 +2,11 @@ package httpdecode
 
 import (
 	"encoding/json"
+	"mime"
 	"net/http"
+
+	"github.com/gorilla/schema"
+	"github.com/stellar/go/support/errors"
 )
 
 // DecodeJSON decodes JSON request from r into v.
@@ -10,4 +14,40 @@ func DecodeJSON(r *http.Request, v interface{}) error {
 	dec := json.NewDecoder(r.Body)
 	dec.UseNumber()
 	return dec.Decode(v)
+}
+
+// DecodeForm decodes form URL encoded requests from r into v.
+//
+// The type of the value given can use `form` tags on fields in the same way as
+// the `json` tag to name fields.
+//
+// An error will be returned if the request is not a POST, PUT, or PATCH
+// request.
+//
+// An error will be returned if the request has a media type in the
+// Content-Type not equal to application/x-www-form-urlencoded, or if the
+// Content-Type header cannot be parsed.
+func DecodeForm(r *http.Request, v interface{}) error {
+	if r.Method != "POST" && r.Method != "PUT" && r.Method != "PATCH" {
+		return errors.Errorf("method POST, PUT, or PATCH required for form decoding: request has method %q", r.Method)
+	}
+
+	contentType := r.Header.Get("Content-Type")
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return errors.Wrap(err, "content type application/x-www-form-urlencoded required for form decoding")
+	}
+	if mediaType != "application/x-www-form-urlencoded" {
+		return errors.Errorf("content type application/x-www-form-urlencoded required for form decoding: received content type %q", mediaType)
+	}
+
+	err = r.ParseForm()
+	if err != nil {
+		return err
+	}
+
+	dec := schema.NewDecoder()
+	dec.SetAliasTag("form")
+	dec.IgnoreUnknownKeys(true)
+	return dec.Decode(v, r.PostForm)
 }

--- a/support/http/httpdecode/httpdecode_test.go
+++ b/support/http/httpdecode/httpdecode_test.go
@@ -32,3 +32,106 @@ func TestDecodeJSON_invalid(t *testing.T) {
 	err := DecodeJSON(r, &bodyDecoded)
 	require.EqualError(t, err, "invalid character 'b' after object key")
 }
+
+func TestDecodeForm_valid(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	bodyDecoded := struct {
+		Foo string
+	}{}
+	err := DecodeForm(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.Foo)
+}
+
+func TestDecodeForm_validTags(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	bodyDecoded := struct {
+		FooName string `form:"foo"`
+	}{}
+	err := DecodeForm(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.FooName)
+}
+
+func TestDecodeForm_validIgnoresUnkownKeys(t *testing.T) {
+	body := `foo=bar&foz=baz`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+
+	bodyDecoded := struct {
+		Foo string
+	}{}
+	err := DecodeForm(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.Foo)
+}
+
+func TestDecodeForm_validContentTypeWithOptions(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+
+	bodyDecoded := struct {
+		Foo string
+	}{}
+	err := DecodeForm(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.Foo)
+}
+
+func TestDecodeForm_invalidBody(t *testing.T) {
+	body := `foo=%=`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	bodyDecoded := struct {
+		Foo string
+	}{}
+	err := DecodeForm(r, &bodyDecoded)
+	assert.EqualError(t, err, `invalid URL escape "%="`)
+	assert.Equal(t, "", bodyDecoded.Foo)
+}
+
+func TestDecodeForm_invalidNoContentType(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+
+	bodyDecoded := struct {
+		Foo string
+	}{}
+	err := DecodeForm(r, &bodyDecoded)
+	assert.EqualError(t, err, `content type application/x-www-form-urlencoded required for form decoding: mime: no media type`)
+	assert.Equal(t, "", bodyDecoded.Foo)
+}
+
+func TestDecodeForm_invalidUnrecognizedContentType(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/xwwwformurlencoded")
+
+	bodyDecoded := struct {
+		Foo string
+	}{}
+	err := DecodeForm(r, &bodyDecoded)
+	assert.EqualError(t, err, `content type application/x-www-form-urlencoded required for form decoding: received content type "application/xwwwformurlencoded"`)
+	assert.Equal(t, "", bodyDecoded.Foo)
+}
+
+func TestDecodeForm_invalidMethodType(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("GET", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	bodyDecoded := struct {
+		Foo string
+	}{}
+	err := DecodeForm(r, &bodyDecoded)
+	assert.EqualError(t, err, `method POST, PUT, or PATCH required for form decoding: request has method "GET"`)
+	assert.Equal(t, "", bodyDecoded.Foo)
+}

--- a/support/http/httpdecode/httpdecode_test.go
+++ b/support/http/httpdecode/httpdecode_test.go
@@ -135,3 +135,105 @@ func TestDecodeForm_invalidMethodType(t *testing.T) {
 	assert.EqualError(t, err, `method POST, PUT, or PATCH required for form decoding: request has method "GET"`)
 	assert.Equal(t, "", bodyDecoded.Foo)
 }
+
+func TestDecode_validJSONNoContentType(t *testing.T) {
+	body := `{"foo":"bar"}`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.FooName)
+}
+
+func TestDecode_validJSONWithContentType(t *testing.T) {
+	body := `{"foo":"bar"}`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.FooName)
+}
+
+func TestDecode_validJSONWithContentTypeOptions(t *testing.T) {
+	body := `{"foo":"bar"}`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.FooName)
+}
+
+func TestDecode_validForm(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.FooName)
+}
+
+func TestDecode_validFormWithContentTypeOptions(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.FooName)
+}
+
+func TestDecode_cannotParseContentType(t *testing.T) {
+	body := `{"foo":"bar"}`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application=json")
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.EqualError(t, err, "content type could not be parsed: mime: expected slash after first token")
+	assert.Equal(t, "", bodyDecoded.FooName)
+}
+
+func TestDecode_invalidJSON(t *testing.T) {
+	body := `{"foo""bar"}`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.EqualError(t, err, `invalid character '"' after object key`)
+	assert.Equal(t, "", bodyDecoded.FooName)
+}
+
+func TestDecode_invalidForm(t *testing.T) {
+	body := `foo=%=bar`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.EqualError(t, err, `invalid URL escape "%=b"`)
+	assert.Equal(t, "", bodyDecoded.FooName)
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add functions `DecodeForm` that decodes form URL encoded post bodies and `Decode` for combined decoding of requests that contain either form URL encoded or JSON bodies.

### Why

In some of our SEPs we are required to parse requests that can be either form URL encoded or JSON encoded. I'm writing two applications that will need to contain this same parsing logic. Writing this logic once has some benefits:

- This logic has subtleties that can make it difficult to get correct every time and writing it as a library in isolation to general application code means we're more likely to write extensive tests that cover the edge cases. The reasons this code can be hard to get correct:
   - The default form parsing built into the Go stdlib silently fails some error conditions. This makes it easy to write a http handler that looks like it receives form URL encoded data and decodes it correctly, but the code may continue on with invalid input unless it specifically checks the state of the request.
   - Parsing the `Content-Type` header is not as simple as comparing two strings because the header can contain optional parameters, like `charset=utf-8`.
- This will also mean when we find bugs with this logic we can fix it in one place and improve both applications.
- We can set some common defaults for consistency across all our applications that parse form URL encoded data. For example: we can configure decoding not to fail on unrecognized keys which is not the default in the most popular form parsing library, but that makes our form decoding consistent with our JSON decoding.

### Known limitations

N/A
