### PR TITLE
services/keystore: use cors handler like our other apps

### DIFF
--- a/services/keystore/api.go
+++ b/services/keystore/api.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rs/cors"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/httpjson"
@@ -182,8 +183,10 @@ func recoverHandler(next http.Handler) http.Handler {
 }
 
 func corsHandler(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		rw.Header().Set("Access-Control-Allow-Origin", "*")
-		next.ServeHTTP(rw, req)
+	cors := cors.New(cors.Options{
+		AllowedOrigins: []string{"*"},
+		AllowedHeaders: []string{"*"},
+		AllowedMethods: []string{"GET", "PUT", "POST", "PATCH", "DELETE", "HEAD", "OPTIONS"},
 	})
+	return cors.Handler(next)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Use CORS handler we use in other apps that implements CORS more completely.

### Why

The frontend folks are saying their seeing issues with the CORS OPTIONS handshake with the keystore.

I think our implementation of CORS is missing a step because the keystore is returning a 401 on an OPTIONS request. An OPTIONS request shouldn't be hitting an auth handler. Own implementation is passing through to the other middleware and the final handler of the endpoint and in those handler the 401 status code is being set when the user hasn't included credentials.

The implementation of CORS we use in our other apps won't pass through to the next handler for an OPTIONS request, which is how the preflight requests is supposed to be handled.

### Known limitations

N/A
