### PR TITLE
[Doc] Adds the "balance.is_authorized" field in example

### DIFF
--- a/services/horizon/internal/docs/reference/endpoints/accounts-single.md
+++ b/services/horizon/internal/docs/reference/endpoints/accounts-single.md
@@ -113,6 +113,7 @@ This endpoint responds with the details of a single account for a given ID. See 
       "buying_liabilities": "0.0000000",
       "selling_liabilities": "0.0000000",
       "last_modified_ledger": 632070,
+      "is_authorized": true,
       "asset_type": "credit_alphanum4",
       "asset_code": "FOO",
       "asset_issuer": "GAGLYFZJMN5HEULSTH5CIGPOPAVUYPG5YSWIYDJMAPIECYEBPM2TA3QR"


### PR DESCRIPTION
Changing the [Account Details](https://www.stellar.org/developers/horizon/reference/endpoints/accounts-single.html) documentation page, in the example data of a REST read request.

Adds a field `is_authorized` in the `balances` section, missing on the page, and seen on https://www.stellar.org/laboratory/#explorer?resource=accounts&endpoint=single&network=test 

Also, in the documentation example, the `signers` there have a field `public_key`, always equals to the sibling `key`. Since they are several types of keys, maybe there here for a reason. But it's not here in the laboratory for a single-signing *ed25519_public_key* account.

