### PR TITLE
services/horizon/expingest: Rewrite System to a state machine

### DIFF
--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -91,16 +91,27 @@ type liveSession interface {
 	Shutdown()
 }
 
-type retry interface {
-	onError(func() error)
+type systemState string
+
+const (
+	initState                 systemState = "init"
+	loadOffersIntoMemoryState             = "loadOffersIntoMemory"
+	buildStateAndResumeState              = "buildStateAndResume"
+	resumeState                           = "resume"
+	shutdownState                         = "shutdown"
+)
+
+type state struct {
+	systemState                       systemState
+	latestSuccessfullyProcessedLedger uint32
 }
 
 type System struct {
+	state            state
 	session          liveSession
 	historyQ         dbQ
 	historySession   dbSession
 	graph            *orderbook.OrderBookGraph
-	retry            retry
 	stateReady       bool
 	stateReadyLock   sync.RWMutex
 	maxStreamRetries int
@@ -114,22 +125,6 @@ type System struct {
 	stateVerificationErrors  int
 	stateVerificationRunning bool
 	disableStateVerification bool
-}
-
-type alwaysRetry struct {
-	backOff time.Duration
-}
-
-func (r alwaysRetry) onError(f func() error) {
-	for {
-		err := f()
-		if err != nil {
-			log.Error(err)
-			time.Sleep(r.backOff)
-			continue
-		}
-		break
-	}
 }
 
 func NewSystem(config Config) (*System, error) {
@@ -171,13 +166,16 @@ func NewSystem(config Config) (*System, error) {
 	}
 
 	system := &System{
+		state: state{
+			systemState: initState,
+		},
 		session:                  session,
 		historySession:           historySession,
 		historyQ:                 historyQ,
 		graph:                    config.OrderBookGraph,
-		retry:                    alwaysRetry{time.Second},
 		disableStateVerification: config.DisableStateVerification,
 		maxStreamRetries:         config.MaxStreamRetries,
+		shutdown:                 make(chan struct{}),
 	}
 
 	addPipelineHooks(
@@ -228,7 +226,6 @@ func NewSystem(config Config) (*System, error) {
 //   * If instances is a NOT leader, it runs ledger pipeline without updating a
 //     a database so order book graph is updated but database is not overwritten.
 func (s *System) Run() {
-	s.shutdown = make(chan struct{})
 	// Expingest is an experimental package so we don't want entire Horizon app
 	// to crash in case of unexpected errors.
 	// TODO: This should be removed when expingest is no longer experimental.
@@ -242,110 +239,129 @@ func (s *System) Run() {
 		}
 	}()
 
-	// retryOnError loop is needed only in case of initial state sync errors.
-	// If the state is successfully ingested `resumeFromLedger` method continues
-	// processing ledgers.
-	s.retry.onError(func() error {
-		// Transaction will be commited or rolled back in pipelines post hooks.
-		err := s.historyQ.Begin()
-		if err != nil {
-			return errors.Wrap(err, "Error starting a transaction")
-		}
-		// We rollback in pipelines post-hooks but the error can happen before
-		// pipeline starts processing.
-		defer s.historyQ.Rollback()
-
-		// This will get the value `FOR UPDATE`, blocking it for other nodes.
-		lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
-		if err != nil {
-			return errors.Wrap(err, "Error getting last ingested ledger")
-		}
-
-		ingestVersion, err := s.historyQ.GetExpIngestVersion()
-		if err != nil {
-			return errors.Wrap(err, "Error getting exp ingest version")
-		}
-
-		if ingestVersion != CurrentVersion || lastIngestedLedger == 0 {
-			// This block is either starting from empty state or ingestion
-			// version upgrade.
-			// This will always run on a single instance due to the fact that
-			// `LastLedgerExpIngest` value is blocked for update and will always
-			// be updated when leading instance finishes processing state.
-			// In case of errors it will start `Run` from the beginning.
-			log.Info("Starting ingestion system from empty state...")
-
-			// Clear last_ingested_ledger in key value store
-			if err = s.historyQ.UpdateLastLedgerExpIngest(0); err != nil {
-				return errors.Wrap(err, "Error updating last ingested ledger")
-			}
-
-			// Clear invalid state in key value store. It's possible that upgraded
-			// ingestion is fixing it.
-			if err = s.historyQ.UpdateExpStateInvalid(false); err != nil {
-				return errors.Wrap(err, "Error updating state invalid value")
-			}
-
-			err = s.historyQ.TruncateExpingestStateTables()
+	for {
+		// Transaction will be commited or rolled back in pipelines post hooks
+		// or below in case of errors.
+		var err error
+		if tx := s.historyQ.GetTx(); tx == nil {
+			err = s.historyQ.Begin()
 			if err != nil {
-				return errors.Wrap(err, "Error clearing ingest tables")
-			}
-
-			err = s.session.Run()
-			if err != nil {
-				// Check if session processed a state, if so, continue since the
-				// last processed ledger, otherwise start over.
-				var processed bool
-				lastIngestedLedger, processed = s.session.GetLatestSuccessfullyProcessedLedger()
-				if !processed {
-					return err
-				}
-
-				log.WithFields(logpkg.F{
-					"err":                  err,
-					"last_ingested_ledger": lastIngestedLedger,
-				}).Error("Error running session, resuming from the last ingested ledger")
-			} else {
-				// LiveSession.Run returns nil => shutdown
-				log.Info("Session shut down")
-				return nil
-			}
-		} else {
-			// The other node already ingested a state (just now or in the past)
-			// so we need to get offers from a DB, then resume session normally.
-			// State pipeline is NOT processed.
-			log.WithField("last_ledger", lastIngestedLedger).
-				Info("Resuming ingestion system from last processed ledger...")
-
-			err = loadOrderBookGraphFromDB(s.historyQ, s.graph, lastIngestedLedger)
-			if err != nil {
-				return errors.Wrap(err, "Error loading order book graph from db")
+				log.WithError(err).Error("Error starting a transaction")
+				time.Sleep(time.Second)
+				continue
 			}
 		}
 
-		s.resumeFromLedger(lastIngestedLedger)
-		return nil
-	})
+		var nextState state
+		switch s.state.systemState {
+		case initState:
+			nextState, err = s.init()
+		case loadOffersIntoMemoryState:
+			nextState, err = s.loadOffersIntoMemory()
+		case buildStateAndResumeState:
+			nextState, err = s.buildStateAndResume()
+		case resumeState:
+			nextState, err = s.resume()
+		case shutdownState:
+			s.historyQ.Rollback()
+			log.Info("Shut down")
+			return
+		default:
+			panic("Unknown state " + s.state.systemState)
+		}
+
+		if err != nil {
+			// We rollback in pipelines post-hooks but the error can happen before
+			// pipeline starts processing.
+			s.historyQ.Rollback()
+
+			log.WithFields(logpkg.F{
+				"error":         err,
+				"current_state": s.state,
+				"next_state":    nextState,
+			}).Error("Error in ingestion state machine")
+		}
+
+		select {
+		case <-s.shutdown:
+			log.Info("Received shut down signal...")
+			nextState = state{shutdownState, 0}
+		default:
+		}
+
+		log.WithFields(logpkg.F{
+			"current_state": s.state,
+			"next_state":    nextState,
+		}).Info("Ingestion system state machine transition")
+
+		s.state = nextState
+		time.Sleep(time.Second)
+	}
 }
 
-func loadOrderBookGraphFromDB(
-	historyQ dbQ,
-	graph *orderbook.OrderBookGraph,
-	lastIngestedLedger uint32,
-) error {
-	defer graph.Discard()
+func (s *System) init() (state, error) {
+	// This will get the value `FOR UPDATE`, blocking it for other nodes.
+	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
+	if err != nil {
+		return state{initState, 0}, errors.Wrap(err, "Error getting last ingested ledger")
+	}
+
+	ingestVersion, err := s.historyQ.GetExpIngestVersion()
+	if err != nil {
+		return state{initState, 0}, errors.Wrap(err, "Error getting exp ingest version")
+	}
+
+	if ingestVersion != CurrentVersion || lastIngestedLedger == 0 {
+		// This block is either starting from empty state or ingestion
+		// version upgrade.
+		// This will always run on a single instance due to the fact that
+		// `LastLedgerExpIngest` value is blocked for update and will always
+		// be updated when leading instance finishes processing state.
+		// In case of errors it will start `Init` from the beginning.
+		log.Info("Starting ingestion system from empty state...")
+
+		// Clear last_ingested_ledger in key value store
+		if err = s.historyQ.UpdateLastLedgerExpIngest(0); err != nil {
+			return state{initState, 0}, errors.Wrap(err, "Error updating last ingested ledger")
+		}
+
+		// Clear invalid state in key value store. It's possible that upgraded
+		// ingestion is fixing it.
+		if err = s.historyQ.UpdateExpStateInvalid(false); err != nil {
+			return state{initState, 0}, errors.Wrap(err, "Error updating state invalid value")
+		}
+
+		err = s.historyQ.TruncateExpingestStateTables()
+		if err != nil {
+			return state{initState, 0}, errors.Wrap(err, "Error clearing ingest tables")
+		}
+
+		return state{buildStateAndResumeState, 0}, nil
+	}
+
+	// The other node already ingested a state (just now or in the past)
+	// so we need to get offers from a DB, then resume session normally.
+	// State pipeline is NOT processed.
+	log.WithField("last_ledger", lastIngestedLedger).
+		Info("Resuming ingestion system from last processed ledger...")
+
+	return state{loadOffersIntoMemoryState, lastIngestedLedger}, nil
+}
+
+func (s *System) loadOffersIntoMemory() (state, error) {
+	defer s.graph.Discard()
 
 	log.Info("Loading offers from a database into memory store...")
 	start := time.Now()
 
-	offers, err := historyQ.GetAllOffers()
+	offers, err := s.historyQ.GetAllOffers()
 	if err != nil {
-		return err
+		return s.state, errors.Wrap(err, "GetAllOffers error")
 	}
 
 	for _, offer := range offers {
 		sellerID := xdr.MustAddress(offer.SellerID)
-		graph.AddOffer(xdr.OfferEntry{
+		s.graph.AddOffer(xdr.OfferEntry{
 			SellerId: sellerID,
 			OfferId:  offer.OfferID,
 			Selling:  offer.SellingAsset,
@@ -359,43 +375,57 @@ func loadOrderBookGraphFromDB(
 		})
 	}
 
-	err = graph.Apply(lastIngestedLedger)
-	if err == nil {
-		log.WithField(
-			"duration",
-			time.Since(start).Seconds(),
-		).Info("Finished loading offers from a database into memory store")
+	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
+	if err != nil {
+		return s.state, errors.Wrap(err, "Error getting last ingested ledger")
 	}
 
-	return err
+	err = s.graph.Apply(lastIngestedLedger)
+	if err != nil {
+		return s.state, errors.Wrap(err, "Error running graph.Apply")
+	}
+
+	log.WithField(
+		"duration",
+		time.Since(start).Seconds(),
+	).Info("Finished loading offers from a database into memory store")
+
+	return state{resumeState, s.state.latestSuccessfullyProcessedLedger}, nil
 }
 
-func (s *System) resumeFromLedger(lastIngestedLedger uint32) {
-	s.retry.onError(func() error {
-		err := s.session.Resume(lastIngestedLedger + 1)
-		if err != nil {
-			// If no ledgers processed so far, try again with the
-			// lastIngestedLedger+1 (do nothing).
-			// Otherwise, set lastIngestedLedger to the last successfully
-			// ingested ledger in the session.
-			sessionLastLedger, processed := s.session.GetLatestSuccessfullyProcessedLedger()
-			if processed {
-				lastIngestedLedger = sessionLastLedger
-			}
-
-			select {
-			case <-s.shutdown:
-				log.WithField("err", err).
-					Error("System shut down but error returned from ingest.LiveSession")
-				return nil
-			default:
-				return errors.Wrap(err, "Error returned from ingest.LiveSession")
-			}
+func (s *System) buildStateAndResume() (state, error) {
+	err := s.session.Run()
+	if err != nil {
+		// Check if session processed a state, if so, continue since the
+		// last processed ledger, otherwise start over.
+		latestSuccessfullyProcessedLedger, processed := s.session.GetLatestSuccessfullyProcessedLedger()
+		if !processed {
+			return state{initState, 0}, err
 		}
 
-		log.Info("Session shut down")
-		return nil
-	})
+		return state{resumeState, latestSuccessfullyProcessedLedger}, err
+	}
+
+	return state{shutdownState, 0}, nil
+}
+
+func (s *System) resume() (state, error) {
+	err := s.session.Resume(s.state.latestSuccessfullyProcessedLedger + 1)
+	if err != nil {
+		err = errors.Wrap(err, "Error returned from ingest.LiveSession")
+		// If no ledgers processed so far, try again with the
+		// latestSuccessfullyProcessedLedger+1 (do nothing).
+		// Otherwise, set latestSuccessfullyProcessedLedger to the last
+		// successfully ingested ledger in the machine state.
+		sessionLastLedger, processed := s.session.GetLatestSuccessfullyProcessedLedger()
+		if processed {
+			return state{resumeState, sessionLastLedger}, err
+		}
+
+		return s.state, err
+	}
+
+	return state{shutdownState, 0}, nil
 }
 
 // StateReady returns true if the ingestion system has finished running it's state pipelines

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -95,10 +95,10 @@ type systemState string
 
 const (
 	initState                 systemState = "init"
-	loadOffersIntoMemoryState             = "loadOffersIntoMemory"
-	buildStateAndResumeState              = "buildStateAndResume"
-	resumeState                           = "resume"
-	shutdownState                         = "shutdown"
+	loadOffersIntoMemoryState systemState = "loadOffersIntoMemory"
+	buildStateAndResumeState  systemState = "buildStateAndResume"
+	resumeState               systemState = "resume"
+	shutdownState             systemState = "shutdown"
 )
 
 type state struct {
@@ -166,9 +166,6 @@ func NewSystem(config Config) (*System, error) {
 	}
 
 	system := &System{
-		state: state{
-			systemState: initState,
-		},
 		session:                  session,
 		historySession:           historySession,
 		historyQ:                 historyQ,
@@ -239,42 +236,11 @@ func (s *System) Run() {
 		}
 	}()
 
+	s.state = state{initState, 0}
+
 	for {
-		// Transaction will be commited or rolled back in pipelines post hooks
-		// or below in case of errors.
-		var err error
-		if tx := s.historyQ.GetTx(); tx == nil {
-			err = s.historyQ.Begin()
-			if err != nil {
-				log.WithError(err).Error("Error starting a transaction")
-				time.Sleep(time.Second)
-				continue
-			}
-		}
-
-		var nextState state
-		switch s.state.systemState {
-		case initState:
-			nextState, err = s.init()
-		case loadOffersIntoMemoryState:
-			nextState, err = s.loadOffersIntoMemory()
-		case buildStateAndResumeState:
-			nextState, err = s.buildStateAndResume()
-		case resumeState:
-			nextState, err = s.resume()
-		case shutdownState:
-			s.historyQ.Rollback()
-			log.Info("Shut down")
-			return
-		default:
-			panic("Unknown state " + s.state.systemState)
-		}
-
+		nextState, err := s.runCurrentState()
 		if err != nil {
-			// We rollback in pipelines post-hooks but the error can happen before
-			// pipeline starts processing.
-			s.historyQ.Rollback()
-
 			log.WithFields(logpkg.F{
 				"error":         err,
 				"current_state": s.state,
@@ -282,11 +248,16 @@ func (s *System) Run() {
 			}).Error("Error in ingestion state machine")
 		}
 
+		// Exit after processing shutdownState
+		if s.state.systemState == shutdownState {
+			return
+		}
+
 		select {
 		case <-s.shutdown:
 			log.Info("Received shut down signal...")
 			nextState = state{shutdownState, 0}
-		default:
+		case <-time.After(time.Second):
 		}
 
 		log.WithFields(logpkg.F{
@@ -295,8 +266,46 @@ func (s *System) Run() {
 		}).Info("Ingestion system state machine transition")
 
 		s.state = nextState
-		time.Sleep(time.Second)
 	}
+}
+
+func (s *System) runCurrentState() (state, error) {
+	// Transaction will be commited or rolled back in pipelines post hooks
+	// or below in case of errors.
+	if tx := s.historyQ.GetTx(); tx == nil {
+		err := s.historyQ.Begin()
+		if err != nil {
+			return state{initState, 0}, errors.Wrap(err, "Error in Begin")
+		}
+	}
+
+	var nextState state
+	var err error
+
+	switch s.state.systemState {
+	case initState:
+		nextState, err = s.init()
+	case loadOffersIntoMemoryState:
+		nextState, err = s.loadOffersIntoMemory()
+	case buildStateAndResumeState:
+		nextState, err = s.buildStateAndResume()
+	case resumeState:
+		nextState, err = s.resume()
+	case shutdownState:
+		s.historyQ.Rollback()
+		log.Info("Shut down")
+		return s.state, nil
+	default:
+		panic("Unknown state " + s.state.systemState)
+	}
+
+	if err != nil {
+		// We rollback in pipelines post-hooks but the error can happen before
+		// pipeline starts processing.
+		s.historyQ.Rollback()
+	}
+
+	return nextState, err
 }
 
 func (s *System) init() (state, error) {
@@ -348,6 +357,9 @@ func (s *System) init() (state, error) {
 	return state{loadOffersIntoMemoryState, lastIngestedLedger}, nil
 }
 
+// loadOffersIntoMemory loads offers into memory. If successful, it changes the
+// state to `resumeState`. In case of errors it always changes the state to
+// `init` because state function returning errors rollback DB transaction.
 func (s *System) loadOffersIntoMemory() (state, error) {
 	defer s.graph.Discard()
 
@@ -356,7 +368,7 @@ func (s *System) loadOffersIntoMemory() (state, error) {
 
 	offers, err := s.historyQ.GetAllOffers()
 	if err != nil {
-		return s.state, errors.Wrap(err, "GetAllOffers error")
+		return state{initState, 0}, errors.Wrap(err, "GetAllOffers error")
 	}
 
 	for _, offer := range offers {
@@ -375,14 +387,9 @@ func (s *System) loadOffersIntoMemory() (state, error) {
 		})
 	}
 
-	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
+	err = s.graph.Apply(s.state.latestSuccessfullyProcessedLedger)
 	if err != nil {
-		return s.state, errors.Wrap(err, "Error getting last ingested ledger")
-	}
-
-	err = s.graph.Apply(lastIngestedLedger)
-	if err != nil {
-		return s.state, errors.Wrap(err, "Error running graph.Apply")
+		return state{initState, 0}, errors.Wrap(err, "Error running graph.Apply")
 	}
 
 	log.WithField(

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -4,6 +4,7 @@
 package expingest
 
 import (
+	"fmt"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -172,7 +173,6 @@ func NewSystem(config Config) (*System, error) {
 		graph:                    config.OrderBookGraph,
 		disableStateVerification: config.DisableStateVerification,
 		maxStreamRetries:         config.MaxStreamRetries,
-		shutdown:                 make(chan struct{}),
 	}
 
 	addPipelineHooks(
@@ -223,6 +223,7 @@ func NewSystem(config Config) (*System, error) {
 //   * If instances is a NOT leader, it runs ledger pipeline without updating a
 //     a database so order book graph is updated but database is not overwritten.
 func (s *System) Run() {
+	s.shutdown = make(chan struct{})
 	// Expingest is an experimental package so we don't want entire Horizon app
 	// to crash in case of unexpected errors.
 	// TODO: This should be removed when expingest is no longer experimental.
@@ -294,9 +295,9 @@ func (s *System) runCurrentState() (state, error) {
 	case shutdownState:
 		s.historyQ.Rollback()
 		log.Info("Shut down")
-		return s.state, nil
+		nextState, err = s.state, nil
 	default:
-		panic("Unknown state " + s.state.systemState)
+		panic(fmt.Sprintf("Unknown state %+v", s.state.systemState))
 	}
 
 	if err != nil {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR rewrites `System` to a state machine as described in #1969.

Close #1969.

### Why

The new code is easier to test because it's possible to start test from any state without having to add a bunch of mocked methods to reach the code we want to test. It's also easier to extend with new states. This will be very helpful when catchup states are added for history ingestion.
