### PR TITLE
services/horizon: verify-range command

### DIFF
--- a/exp/ingest/io/genesis_ledger_state_reader.go
+++ b/exp/ingest/io/genesis_ledger_state_reader.go
@@ -1,0 +1,64 @@
+package io
+
+import (
+	"io"
+	"sync"
+
+	"github.com/stellar/go/amount"
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/xdr"
+)
+
+// GenesisLedgerStateReader is a streaming ledger entries for genesis ledger
+// (ledgerseq = 1) for of the network with the given passphrase.
+type GenesisLedgerStateReader struct {
+	NetworkPassphrase string
+
+	mutex sync.Mutex
+	done  bool
+}
+
+// Ensure GenesisLedgerStateReader implements StateReader
+var _ StateReader = &GenesisLedgerStateReader{}
+
+// GetSequence returns the sequence of the ledger.
+func (r *GenesisLedgerStateReader) GetSequence() uint32 {
+	return 1
+}
+
+// Read returns a new ledger entry change on each call, returning io.EOF when the stream ends.
+func (r *GenesisLedgerStateReader) Read() (xdr.LedgerEntryChange, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if r.done {
+		return xdr.LedgerEntryChange{}, io.EOF
+	}
+
+	masterKeyPair := keypair.Master(r.NetworkPassphrase)
+
+	masterAccountEntry := xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId: xdr.MustAddress(masterKeyPair.Address()),
+				// 100B
+				Balance:    amount.MustParse("100000000000"),
+				SeqNum:     0,
+				Thresholds: xdr.Thresholds{1, 0, 0, 0},
+			},
+		},
+	}
+
+	r.done = true
+	return xdr.LedgerEntryChange{
+		Type:  xdr.LedgerEntryChangeTypeLedgerEntryState,
+		State: &masterAccountEntry,
+	}, nil
+}
+
+// Close should be called when reading is finished.
+func (r *GenesisLedgerStateReader) Close() error {
+	return nil
+}

--- a/exp/ingest/io/genesis_ledger_state_reader_test.go
+++ b/exp/ingest/io/genesis_ledger_state_reader_test.go
@@ -1,0 +1,29 @@
+package io
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenesisLeaderStateReader(t *testing.T) {
+	stateReader := GenesisLedgerStateReader{
+		NetworkPassphrase: "Public Global Stellar Network ; September 2015",
+	}
+
+	ledgerEntryChange, err := stateReader.Read()
+	assert.NoError(t, err)
+	assert.Equal(t, xdr.LedgerEntryChangeTypeLedgerEntryState, ledgerEntryChange.Type)
+	assert.Equal(t, xdr.Uint32(1), ledgerEntryChange.State.LastModifiedLedgerSeq)
+	account := ledgerEntryChange.State.Data.MustAccount()
+	assert.Equal(t, "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7", account.AccountId.Address())
+	assert.Equal(t, xdr.SequenceNumber(0), account.SeqNum)
+	assert.Equal(t, xdr.Int64(1000000000000000000), account.Balance)
+	assert.Equal(t, xdr.Thresholds{1, 0, 0, 0}, account.Thresholds)
+
+	_, err = stateReader.Read()
+	assert.Error(t, err)
+	assert.Equal(t, io.EOF, err)
+}

--- a/exp/ingest/main.go
+++ b/exp/ingest/main.go
@@ -60,6 +60,8 @@ type RangeSession struct {
 	// ToLedger at which ledger processing should stop. ToLedger will be the
 	// last processed ledger.
 	ToLedger uint32
+	// NetworkPassphrase is a passphrase of the network this session is using.
+	NetworkPassphrase string
 
 	Archive       historyarchive.ArchiveInterface
 	LedgerBackend ledgerbackend.LedgerBackend

--- a/exp/ingest/main.go
+++ b/exp/ingest/main.go
@@ -48,6 +48,38 @@ type LiveSession struct {
 	latestSuccessfullyProcessedLedger uint32
 }
 
+// RangeSession runs ingestion between `FromLedger` and `ToLedger` ledgers
+// (inclusive).
+// It does not update cursors in stellar-core.
+type RangeSession struct {
+	standardSession
+
+	// FromLedger indicates session starting ledger. If StatePipeline is not nil
+	// this must be a checkpoint ledger.
+	FromLedger uint32
+	// ToLedger at which ledger processing should stop. ToLedger will be the
+	// last processed ledger.
+	ToLedger uint32
+
+	Archive       historyarchive.ArchiveInterface
+	LedgerBackend ledgerbackend.LedgerBackend
+	// StatePipeline can be nil. In such case state is not processed and Archive
+	// can be nil as well.
+	StatePipeline  *pipeline.StatePipeline
+	StateReporter  StateReporter
+	LedgerPipeline *pipeline.LedgerPipeline
+	LedgerReporter LedgerReporter
+	// TempSet is a store used to hold temporary objects generated during
+	// state processing. If nil, defaults to io.MemoryTempSet.
+	TempSet io.TempSet
+	// MaxStreamRetries determines how many times the reader will retry when encountering
+	// errors while streaming xdr bucket entries from the history archive.
+	// Default MaxStreamRetries value (0) means that there should be no retry attempts
+	MaxStreamRetries int
+
+	latestSuccessfullyProcessedLedger uint32
+}
+
 // SingleLedgerSession initializes the ledger state using `Archive` and `StatePipeline`
 // and terminates. Useful for finding stats for a single ledger. Set `LedgerSequence`
 // to `0` to process the latest checkpoint.

--- a/exp/ingest/range_session.go
+++ b/exp/ingest/range_session.go
@@ -243,6 +243,8 @@ func (s *RangeSession) validate() error {
 		return errors.New("Archive not set but required by StatePipeline")
 	case s.LedgerPipeline == nil:
 		return errors.New("Ledger pipeline not set")
+	case s.NetworkPassphrase == "":
+		return errors.New("Network passphrase not set")
 	}
 
 	return nil

--- a/exp/ingest/range_session.go
+++ b/exp/ingest/range_session.go
@@ -35,13 +35,7 @@ func (s *RangeSession) Run() error {
 	}
 
 	if s.StatePipeline != nil {
-		// Validate bucket list hash
-		err = s.validateBucketList(currentLedger, historyAdapter, ledgerAdapter)
-		if err != nil {
-			return errors.Wrap(err, "Error validating bucket list hash")
-		}
-
-		err = s.initState(historyAdapter, currentLedger)
+		err = s.initState(historyAdapter, ledgerAdapter, currentLedger)
 		if err != nil {
 			return errors.Wrap(err, "initState error")
 		}
@@ -241,7 +235,7 @@ func (s *RangeSession) validate() error {
 		return errors.New("FromLedger and ToLedger must be set")
 	case s.FromLedger > s.ToLedger:
 		return errors.New("FromLedger must be less than of equal to ToLedger")
-	case s.StatePipeline != nil && !historyarchive.IsCheckpoint(s.FromLedger):
+	case s.StatePipeline != nil && !historyarchive.IsCheckpoint(s.FromLedger) && s.FromLedger != 1:
 		return errors.New("FromLedger must be a checkpoint ledger if StatePipeline is not nil")
 	case s.LedgerBackend == nil:
 		return errors.New("LedgerBackend not set")
@@ -254,15 +248,34 @@ func (s *RangeSession) validate() error {
 	return nil
 }
 
-func (s *RangeSession) initState(historyAdapter *adapters.HistoryArchiveAdapter, sequence uint32) error {
-	var tempSet io.TempSet = &io.MemoryTempSet{}
-	if s.TempSet != nil {
-		tempSet = s.TempSet
-	}
+func (s *RangeSession) initState(
+	historyAdapter *adapters.HistoryArchiveAdapter,
+	ledgerAdapter *adapters.LedgerBackendAdapter,
+	sequence uint32,
+) error {
+	var stateReader io.StateReader
+	var err error
 
-	stateReader, err := historyAdapter.GetState(sequence, tempSet, s.MaxStreamRetries)
-	if err != nil {
-		return errors.Wrap(err, "Error getting state from history archive")
+	if sequence == 1 {
+		stateReader = &io.GenesisLedgerStateReader{
+			NetworkPassphrase: s.NetworkPassphrase,
+		}
+	} else {
+		// Validate bucket list hash
+		err = s.validateBucketList(sequence, historyAdapter, ledgerAdapter)
+		if err != nil {
+			return errors.Wrap(err, "Error validating bucket list hash")
+		}
+
+		var tempSet io.TempSet = &io.MemoryTempSet{}
+		if s.TempSet != nil {
+			tempSet = s.TempSet
+		}
+
+		stateReader, err = historyAdapter.GetState(sequence, tempSet, s.MaxStreamRetries)
+		if err != nil {
+			return errors.Wrap(err, "Error getting state from history archive")
+		}
 	}
 	if s.StateReporter != nil {
 		s.StateReporter.OnStartState(sequence)

--- a/exp/ingest/range_session.go
+++ b/exp/ingest/range_session.go
@@ -1,0 +1,315 @@
+package ingest
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/stellar/go/exp/ingest/adapters"
+	"github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/exp/support/pipeline"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/historyarchive"
+)
+
+var _ Session = &RangeSession{}
+
+// Run runs the session starting from the last checkpoint ledger.
+// Returns nil when session has been shutdown.
+func (s *RangeSession) Run() error {
+	s.standardSession.shutdown = make(chan bool)
+
+	err := s.validate()
+	if err != nil {
+		return errors.Wrap(err, "Validation error")
+	}
+
+	s.setRunningState(true)
+	defer s.setRunningState(false)
+
+	historyAdapter := adapters.MakeHistoryArchiveAdapter(s.Archive)
+	currentLedger := s.FromLedger
+
+	ledgerAdapter := &adapters.LedgerBackendAdapter{
+		Backend: s.LedgerBackend,
+	}
+
+	if s.StatePipeline != nil {
+		// Validate bucket list hash
+		err = s.validateBucketList(currentLedger, historyAdapter, ledgerAdapter)
+		if err != nil {
+			return errors.Wrap(err, "Error validating bucket list hash")
+		}
+
+		err = s.initState(historyAdapter, currentLedger)
+		if err != nil {
+			return errors.Wrap(err, "initState error")
+		}
+
+		s.latestSuccessfullyProcessedLedger = currentLedger
+	}
+
+	// Exit early if Shutdown() was called.
+	select {
+	case <-s.standardSession.shutdown:
+		return nil
+	default:
+		// Continue
+	}
+
+	// `currentLedger` is incremented because applied state is AFTER the
+	// current value of `currentLedger`
+	currentLedger++
+
+	return s.resume(currentLedger, ledgerAdapter)
+}
+
+// GetArchive returns the archive configured for the current session
+func (s *RangeSession) GetArchive() historyarchive.ArchiveInterface {
+	return s.Archive
+}
+
+// Resume resumes the session from `ledgerSequence`.
+// Returns nil when session has been shutdown.
+//
+// WARNING: it's likely that developers will use `GetLatestSuccessfullyProcessedLedger()`
+// to get the latest successfuly processed ledger after `Resume` returns error.
+// It's critical to understand that `GetLatestSuccessfullyProcessedLedger()` will
+// return `(0, false)` when no ledgers have been successfully processed, ex.
+// error while trying to process a ledger after application restart.
+// You should always check if the second returned value is equal `false` before
+// overwriting your local variable.
+func (s *RangeSession) Resume(ledgerSequence uint32) error {
+	s.standardSession.shutdown = make(chan bool)
+
+	err := s.validate()
+	if err != nil {
+		return errors.Wrap(err, "Validation error")
+	}
+
+	s.setRunningState(true)
+	defer s.setRunningState(false)
+
+	ledgerAdapter := &adapters.LedgerBackendAdapter{
+		Backend: s.LedgerBackend,
+	}
+
+	return s.resume(ledgerSequence, ledgerAdapter)
+}
+
+// validateBucketList validates if the bucket list hash in history archive
+// matches the one in corresponding ledger header in stellar-core backend.
+// This gives you full security if data in stellar-core backend can be trusted
+// (ex. you run it in your infrastructure).
+// The hashes of actual buckets of this HAS file are checked using
+// historyarchive.XdrStream.SetExpectedHash (this is done in
+// SingleLedgerStateReader).
+func (s *RangeSession) validateBucketList(
+	ledgerSequence uint32,
+	historyAdapter *adapters.HistoryArchiveAdapter,
+	ledgerAdapter *adapters.LedgerBackendAdapter,
+) error {
+	historyBucketListHash, err := historyAdapter.BucketListHash(ledgerSequence)
+	if err != nil {
+		return errors.Wrap(err, "Error getting bucket list hash")
+	}
+
+	ledgerReader, err := ledgerAdapter.GetLedger(ledgerSequence)
+	if err != nil {
+		if err == io.ErrNotFound {
+			return fmt.Errorf(
+				"Cannot validate bucket hash list. Checkpoint ledger (%d) must exist in Stellar-Core database.",
+				ledgerSequence,
+			)
+		} else {
+			return errors.Wrap(err, "Error getting ledger")
+		}
+	}
+
+	ledgerHeader := ledgerReader.GetHeader()
+	ledgerBucketHashList := ledgerHeader.Header.BucketListHash
+
+	if !bytes.Equal(historyBucketListHash[:], ledgerBucketHashList[:]) {
+		return fmt.Errorf(
+			"Bucket list hash of history archive and ledger header does not match: %#x %#x",
+			historyBucketListHash,
+			ledgerBucketHashList,
+		)
+	}
+
+	return nil
+}
+
+func (s *RangeSession) resume(ledgerSequence uint32, ledgerAdapter *adapters.LedgerBackendAdapter) error {
+	if ledgerSequence < s.FromLedger {
+		return errors.New("Trying to resume from ledger before range start")
+	}
+
+	if ledgerSequence > s.ToLedger {
+		return nil
+	}
+
+	for {
+		ledgerReader, err := ledgerAdapter.GetLedger(ledgerSequence)
+		if err != nil {
+			if err == io.ErrNotFound {
+				// Ensure that there are no gaps. This is "just in case". There shouldn't
+				// be any gaps if CURSOR in core is updated and core version is v11.2.0+.
+				var latestLedger uint32
+				latestLedger, err = ledgerAdapter.GetLatestLedgerSequence()
+				if err != nil {
+					return err
+				}
+
+				if latestLedger > ledgerSequence {
+					return errors.Errorf("Gap detected (ledger %d does not exist but %d is latest)", ledgerSequence, latestLedger)
+				}
+
+				select {
+				case <-s.standardSession.shutdown:
+					return nil
+				case <-time.After(time.Second):
+					// TODO make the idle time smaller
+				}
+
+				continue
+			}
+
+			return errors.Wrap(err, "Error getting ledger")
+		}
+
+		if s.LedgerReporter != nil {
+			s.LedgerReporter.OnNewLedger(ledgerSequence)
+			ledgerReader = reporterLedgerReader{ledgerReader, s.LedgerReporter}
+		}
+
+		err = <-s.LedgerPipeline.Process(ledgerReader)
+		if err != nil {
+			// Return with no errors if pipeline shutdown
+			if err == pipeline.ErrShutdown {
+				if s.LedgerReporter != nil {
+					s.LedgerReporter.OnEndLedger(nil, true)
+				}
+				return nil
+			}
+
+			if s.LedgerReporter != nil {
+				s.LedgerReporter.OnEndLedger(err, false)
+			}
+			return errors.Wrap(err, "Ledger pipeline errored")
+		}
+
+		if s.LedgerReporter != nil {
+			s.LedgerReporter.OnEndLedger(nil, false)
+		}
+		s.latestSuccessfullyProcessedLedger = ledgerSequence
+
+		// We reached the final ledger.
+		if ledgerSequence == s.ToLedger {
+			return nil
+		}
+
+		ledgerSequence++
+
+		// Exit early if Shutdown() was called.
+		select {
+		case <-s.standardSession.shutdown:
+			return nil
+		default:
+			// Continue
+		}
+	}
+
+	return nil
+}
+
+// GetLatestSuccessfullyProcessedLedger returns the last SUCCESSFULLY processed
+// ledger. Returns (0, false) if no ledgers have been successfully processed yet
+// to prevent situations where `GetLatestSuccessfullyProcessedLedger()` value is
+// not properly checked in a loop resulting in ingesting ledger 0+1=1.
+// Please check `Resume` godoc to understand possible implications.
+func (s *RangeSession) GetLatestSuccessfullyProcessedLedger() (ledgerSequence uint32, processed bool) {
+	if s.latestSuccessfullyProcessedLedger == 0 {
+		return 0, false
+	}
+	return s.latestSuccessfullyProcessedLedger, true
+}
+
+func (s *RangeSession) validate() error {
+	switch {
+	case s.FromLedger == 0 || s.ToLedger == 0:
+		return errors.New("FromLedger and ToLedger must be set")
+	case s.FromLedger > s.ToLedger:
+		return errors.New("FromLedger must be less than of equal to ToLedger")
+	case s.StatePipeline != nil && !historyarchive.IsCheckpoint(s.FromLedger):
+		return errors.New("FromLedger must be a checkpoint ledger if StatePipeline is not nil")
+	case s.LedgerBackend == nil:
+		return errors.New("LedgerBackend not set")
+	case s.StatePipeline != nil && s.Archive == nil:
+		return errors.New("Archive not set but required by StatePipeline")
+	case s.LedgerPipeline == nil:
+		return errors.New("Ledger pipeline not set")
+	}
+
+	return nil
+}
+
+func (s *RangeSession) initState(historyAdapter *adapters.HistoryArchiveAdapter, sequence uint32) error {
+	var tempSet io.TempSet = &io.MemoryTempSet{}
+	if s.TempSet != nil {
+		tempSet = s.TempSet
+	}
+
+	stateReader, err := historyAdapter.GetState(sequence, tempSet, s.MaxStreamRetries)
+	if err != nil {
+		return errors.Wrap(err, "Error getting state from history archive")
+	}
+	if s.StateReporter != nil {
+		s.StateReporter.OnStartState(sequence)
+		stateReader = reporterStateReader{stateReader, s.StateReporter}
+	}
+
+	err = <-s.StatePipeline.Process(stateReader)
+	if err != nil {
+		// Return with no errors if pipeline shutdown
+		if err == pipeline.ErrShutdown {
+			if s.StateReporter != nil {
+				s.StateReporter.OnEndState(nil, true)
+			}
+			return nil
+		}
+
+		if s.StateReporter != nil {
+			s.StateReporter.OnEndState(err, false)
+		}
+		return errors.Wrap(err, "State pipeline errored")
+	}
+
+	if s.StateReporter != nil {
+		s.StateReporter.OnEndState(nil, false)
+	}
+	return nil
+}
+
+// Shutdown gracefully stops the pipelines and the session. This method blocks
+// until pipelines are gracefully shutdown.
+func (s *RangeSession) Shutdown() {
+	// Send shutdown signal
+	s.standardSession.Shutdown()
+
+	// Shutdown pipelines
+	s.StatePipeline.Shutdown()
+	s.LedgerPipeline.Shutdown()
+
+	// Shutdown signals sent, block/wait until pipelines are done
+	// shutting down.
+	for {
+		stateRunning := s.StatePipeline.IsRunning()
+		ledgerRunning := s.LedgerPipeline.IsRunning()
+		if stateRunning || ledgerRunning {
+			time.Sleep(time.Second)
+			continue
+		}
+		break
+	}
+}

--- a/exp/ingest/range_session.go
+++ b/exp/ingest/range_session.go
@@ -298,13 +298,20 @@ func (s *RangeSession) Shutdown() {
 	s.standardSession.Shutdown()
 
 	// Shutdown pipelines
-	s.StatePipeline.Shutdown()
+	if s.StatePipeline != nil {
+		s.StatePipeline.Shutdown()
+	}
 	s.LedgerPipeline.Shutdown()
 
 	// Shutdown signals sent, block/wait until pipelines are done
 	// shutting down.
 	for {
-		stateRunning := s.StatePipeline.IsRunning()
+		var stateRunning bool
+		if s.StatePipeline != nil {
+			stateRunning = s.StatePipeline.IsRunning()
+		} else {
+			stateRunning = false
+		}
 		ledgerRunning := s.LedgerPipeline.IsRunning()
 		if stateRunning || ledgerRunning {
 			time.Sleep(time.Second)

--- a/exp/orderbook/graph.go
+++ b/exp/orderbook/graph.go
@@ -113,6 +113,19 @@ func (graph *OrderBookGraph) Offers() []xdr.OfferEntry {
 	return offers
 }
 
+// OffersMap returns a ID => OfferEntry map of offers contained in the order
+// book.
+func (graph *OrderBookGraph) OffersMap() map[xdr.Int64]xdr.OfferEntry {
+	offers := graph.Offers()
+	m := make(map[xdr.Int64]xdr.OfferEntry, len(offers))
+
+	for _, entry := range offers {
+		m[entry.OfferId] = entry
+	}
+
+	return m
+}
+
 // Batch creates a new batch of order book updates which can be applied
 // on this graph
 func (graph *OrderBookGraph) batch() *orderBookBatchedUpdates {

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -63,7 +63,7 @@ var dbInitAssetStatsCmd = &cobra.Command{
 	Use:   "init-asset-stats",
 	Short: "initializes values for assets stats",
 	Run: func(cmd *cobra.Command, args []string) {
-		initConfig()
+		initRootConfig()
 
 		hdb, err := db.Open("postgres", config.DatabaseURL)
 		if err != nil {
@@ -102,7 +102,7 @@ var dbClearCmd = &cobra.Command{
 	Use:   "clear",
 	Short: "clears all imported historical data",
 	Run: func(cmd *cobra.Command, args []string) {
-		initConfig()
+		initRootConfig()
 
 		err := ingestSystem(ingest.Config{
 			IngestFailedTransactions: config.IngestFailedTransactions,
@@ -198,7 +198,7 @@ var dbRebaseCmd = &cobra.Command{
 	Short: "rebases clears the horizon db and ingests the latest ledger segment from stellar-core",
 	Long:  "...",
 	Run: func(cmd *cobra.Command, args []string) {
-		initConfig()
+		initRootConfig()
 
 		i := ingestSystem(ingest.Config{
 			IngestFailedTransactions: config.IngestFailedTransactions,
@@ -307,7 +307,7 @@ func ingestSystem(ingestConfig ingest.Config) *ingest.System {
 }
 
 func reingest(cmd reingestType, args ...int32) {
-	initConfig()
+	initRootConfig()
 
 	i := ingestSystem(ingest.Config{
 		IngestFailedTransactions: config.IngestFailedTransactions,

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -94,7 +94,7 @@ var ingestVerifyRangeCmd = &cobra.Command{
 			log.Fatalf("cannot open Horizon DB: %v", err)
 		}
 
-		if !historyarchive.IsCheckpoint(ingestVerifyFrom) {
+		if !historyarchive.IsCheckpoint(ingestVerifyFrom) && ingestVerifyFrom != 1 {
 			log.Fatal("`--from` must be a checkpoint ledger")
 		}
 
@@ -104,6 +104,7 @@ var ingestVerifyRangeCmd = &cobra.Command{
 
 		ingestConfig := expingest.Config{
 			CoreSession:              coreSession,
+			NetworkPassphrase:        config.NetworkPassphrase,
 			HistorySession:           horizonSession,
 			HistoryArchiveURL:        config.HistoryArchiveURLs[0],
 			OrderBookGraph:           orderbook.NewOrderBookGraph(),

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"fmt"
+	"go/types"
+	"net/http"
+	_ "net/http/pprof"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stellar/go/exp/orderbook"
+	"github.com/stellar/go/services/horizon/internal/expingest"
+	support "github.com/stellar/go/support/config"
+	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/support/historyarchive"
+	"github.com/stellar/go/support/log"
+)
+
+var ingestCmd = &cobra.Command{
+	Use:   "expingest",
+	Short: "ingestion related commands",
+}
+
+var ingestVerifyFrom, ingestVerifyTo, ingestVerifyDebugServerPort uint32
+var ingestVerifyState bool
+
+var ingestVerifyRangeCmdOpts = []*support.ConfigOption{
+	&support.ConfigOption{
+		Name:        "from",
+		ConfigKey:   &ingestVerifyFrom,
+		OptType:     types.Uint32,
+		Required:    true,
+		FlagDefault: uint32(0),
+		Usage:       "first ledger of the range to ingest",
+	},
+	&support.ConfigOption{
+		Name:        "to",
+		ConfigKey:   &ingestVerifyTo,
+		OptType:     types.Uint32,
+		Required:    true,
+		FlagDefault: uint32(0),
+		Usage:       "last ledger of the range to ingest",
+	},
+	&support.ConfigOption{
+		Name:        "verify-state",
+		ConfigKey:   &ingestVerifyState,
+		OptType:     types.Bool,
+		Required:    false,
+		FlagDefault: false,
+		Usage:       "[optional] verifies state at the last ledger of the range when true",
+	},
+	&support.ConfigOption{
+		Name:        "debug-server-port",
+		ConfigKey:   &ingestVerifyDebugServerPort,
+		OptType:     types.Uint32,
+		Required:    false,
+		FlagDefault: uint32(0),
+		Usage:       "[optional] opens a net/http/pprof server at given port",
+	},
+}
+
+var ingestVerifyRangeCmd = &cobra.Command{
+	Use:   "verify-range",
+	Short: "[experimental] runs ingestion pipeline within a range. warning! requires clean DB.",
+	Long:  "runs ingestion pipeline between X and Y sequence number (inclusive)",
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, co := range ingestVerifyRangeCmdOpts {
+			co.Require()
+			co.SetValue()
+		}
+
+		initRootConfig()
+
+		if ingestVerifyDebugServerPort != 0 {
+			go func() {
+				log.Infof("Starting debug server at: %d", ingestVerifyDebugServerPort)
+				err := http.ListenAndServe(
+					fmt.Sprintf("localhost:%d", ingestVerifyDebugServerPort),
+					nil,
+				)
+				if err != nil {
+					log.Error(err)
+				}
+			}()
+		}
+
+		coreSession, err := db.Open("postgres", config.StellarCoreDatabaseURL)
+		if err != nil {
+			log.Fatalf("cannot open Core DB: %v", err)
+		}
+
+		horizonSession, err := db.Open("postgres", config.DatabaseURL)
+		if err != nil {
+			log.Fatalf("cannot open Horizon DB: %v", err)
+		}
+
+		if !historyarchive.IsCheckpoint(ingestVerifyFrom) {
+			log.Fatal("`--from` must be a checkpoint ledger")
+		}
+
+		if ingestVerifyState && !historyarchive.IsCheckpoint(ingestVerifyTo) {
+			log.Fatal("`--to` must be a checkpoint ledger when `--verify-state` is set.")
+		}
+
+		ingestConfig := expingest.Config{
+			CoreSession:              coreSession,
+			HistorySession:           horizonSession,
+			HistoryArchiveURL:        config.HistoryArchiveURLs[0],
+			OrderBookGraph:           orderbook.NewOrderBookGraph(),
+			IngestFailedTransactions: config.IngestFailedTransactions,
+		}
+
+		system, err := expingest.NewSystem(ingestConfig)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = system.VerifyRange(
+			ingestVerifyFrom,
+			ingestVerifyTo,
+			ingestVerifyState,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		log.Info("Range run successfully!")
+	},
+}
+
+func init() {
+	for _, co := range ingestVerifyRangeCmdOpts {
+		err := co.Init(ingestVerifyRangeCmd)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+	}
+
+	viper.BindPFlags(ingestVerifyRangeCmd.PersistentFlags())
+
+	rootCmd.AddCommand(ingestCmd)
+	ingestCmd.AddCommand(ingestVerifyRangeCmd)
+}

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -384,11 +384,11 @@ func init() {
 }
 
 func initApp() *horizon.App {
-	initConfig()
+	initRootConfig()
 	return horizon.NewApp(config)
 }
 
-func initConfig() {
+func initRootConfig() {
 	// Verify required options and load the config struct
 	configOpts.Require()
 	configOpts.SetValues()

--- a/services/horizon/internal/expingest/load_orderbook_graph_test.go
+++ b/services/horizon/internal/expingest/load_orderbook_graph_test.go
@@ -71,7 +71,7 @@ func (s *LoadOffersIntoMemoryTestSuite) SetupTest() {
 	s.session = &mockDBSession{}
 	s.historyQ = &mockDBQ{}
 	s.system = &System{
-		state:          state{loadOffersIntoMemoryState, 1},
+		state:          state{systemState: loadOffersIntoMemoryState, latestSuccessfullyProcessedLedger: 1},
 		historySession: s.session,
 		historyQ:       s.historyQ,
 		graph:          s.graph,

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -99,17 +99,25 @@ const (
 	loadOffersIntoMemoryState systemState = "loadOffersIntoMemory"
 	buildStateAndResumeState  systemState = "buildStateAndResume"
 	resumeState               systemState = "resume"
+	verifyRangeState          systemState = "verifyRange"
 	shutdownState             systemState = "shutdown"
 )
 
 type state struct {
 	systemState                       systemState
 	latestSuccessfullyProcessedLedger uint32
+
+	rangeFromLedger  uint32
+	rangeToLedger    uint32
+	rangeVerifyState bool
+
+	returnError error
 }
 
 type System struct {
 	state            state
 	session          liveSession
+	rangeSession     *ingest.RangeSession
 	historyQ         dbQ
 	historySession   dbSession
 	graph            *orderbook.OrderBookGraph
@@ -146,16 +154,19 @@ func NewSystem(config Config) (*System, error) {
 
 	historyQ := &history.Q{historySession}
 
+	statePipeline := buildStatePipeline(historyQ, config.OrderBookGraph)
+	ledgerPipeline := buildLedgerPipeline(
+		historyQ,
+		config.OrderBookGraph,
+		config.IngestFailedTransactions,
+	)
+
 	session := &ingest.LiveSession{
 		Archive:          archive,
 		MaxStreamRetries: config.MaxStreamRetries,
 		LedgerBackend:    ledgerBackend,
-		StatePipeline:    buildStatePipeline(historyQ, config.OrderBookGraph),
-		LedgerPipeline: buildLedgerPipeline(
-			historyQ,
-			config.OrderBookGraph,
-			config.IngestFailedTransactions,
-		),
+		StatePipeline:    statePipeline,
+		LedgerPipeline:   ledgerPipeline,
 		StellarCoreClient: &stellarcore.Client{
 			URL: config.StellarCoreURL,
 		},
@@ -166,8 +177,22 @@ func NewSystem(config Config) (*System, error) {
 		TempSet: config.TempSet,
 	}
 
+	rangeSession := &ingest.RangeSession{
+		Archive:          archive,
+		MaxStreamRetries: config.MaxStreamRetries,
+		LedgerBackend:    ledgerBackend,
+		StatePipeline:    statePipeline,
+		LedgerPipeline:   ledgerPipeline,
+
+		StateReporter:  &LoggingStateReporter{Log: log, Interval: 100000},
+		LedgerReporter: &LoggingLedgerReporter{Log: log},
+
+		TempSet: config.TempSet,
+	}
+
 	system := &System{
 		session:                  session,
+		rangeSession:             rangeSession,
 		historySession:           historySession,
 		historyQ:                 historyQ,
 		graph:                    config.OrderBookGraph,
@@ -223,6 +248,23 @@ func NewSystem(config Config) (*System, error) {
 //   * If instances is a NOT leader, it runs ledger pipeline without updating a
 //     a database so order book graph is updated but database is not overwritten.
 func (s *System) Run() {
+	s.state = state{systemState: initState}
+	s.run()
+}
+
+// VerifyRange runs the ingestion pipeline on the range of ledgers. When
+// verifyState is true it verifies the state when ingestion is complete.
+func (s *System) VerifyRange(fromLedger, toLedger uint32, verifyState bool) error {
+	s.state = state{
+		systemState:      verifyRangeState,
+		rangeFromLedger:  fromLedger,
+		rangeToLedger:    toLedger,
+		rangeVerifyState: verifyState,
+	}
+	return s.run()
+}
+
+func (s *System) run() error {
 	s.shutdown = make(chan struct{})
 	// Expingest is an experimental package so we don't want entire Horizon app
 	// to crash in case of unexpected errors.
@@ -237,7 +279,7 @@ func (s *System) Run() {
 		}
 	}()
 
-	s.state = state{initState, 0}
+	log.WithFields(logpkg.F{"current_state": s.state}).Info("Ingestion system initial state")
 
 	for {
 		nextState, err := s.runCurrentState()
@@ -251,13 +293,13 @@ func (s *System) Run() {
 
 		// Exit after processing shutdownState
 		if s.state.systemState == shutdownState {
-			return
+			return s.state.returnError
 		}
 
 		select {
 		case <-s.shutdown:
 			log.Info("Received shut down signal...")
-			nextState = state{shutdownState, 0}
+			nextState = state{systemState: shutdownState}
 		case <-time.After(time.Second):
 		}
 
@@ -276,7 +318,7 @@ func (s *System) runCurrentState() (state, error) {
 	if tx := s.historyQ.GetTx(); tx == nil {
 		err := s.historyQ.Begin()
 		if err != nil {
-			return state{initState, 0}, errors.Wrap(err, "Error in Begin")
+			return state{systemState: initState}, errors.Wrap(err, "Error in Begin")
 		}
 	}
 
@@ -292,6 +334,8 @@ func (s *System) runCurrentState() (state, error) {
 		nextState, err = s.buildStateAndResume()
 	case resumeState:
 		nextState, err = s.resume()
+	case verifyRangeState:
+		nextState, err = s.verifyRange()
 	case shutdownState:
 		s.historyQ.Rollback()
 		log.Info("Shut down")
@@ -313,12 +357,12 @@ func (s *System) init() (state, error) {
 	// This will get the value `FOR UPDATE`, blocking it for other nodes.
 	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
 	if err != nil {
-		return state{initState, 0}, errors.Wrap(err, "Error getting last ingested ledger")
+		return state{systemState: initState}, errors.Wrap(err, "Error getting last ingested ledger")
 	}
 
 	ingestVersion, err := s.historyQ.GetExpIngestVersion()
 	if err != nil {
-		return state{initState, 0}, errors.Wrap(err, "Error getting exp ingest version")
+		return state{systemState: initState}, errors.Wrap(err, "Error getting exp ingest version")
 	}
 
 	if ingestVersion != CurrentVersion || lastIngestedLedger == 0 {
@@ -332,21 +376,21 @@ func (s *System) init() (state, error) {
 
 		// Clear last_ingested_ledger in key value store
 		if err = s.historyQ.UpdateLastLedgerExpIngest(0); err != nil {
-			return state{initState, 0}, errors.Wrap(err, "Error updating last ingested ledger")
+			return state{systemState: initState}, errors.Wrap(err, "Error updating last ingested ledger")
 		}
 
 		// Clear invalid state in key value store. It's possible that upgraded
 		// ingestion is fixing it.
 		if err = s.historyQ.UpdateExpStateInvalid(false); err != nil {
-			return state{initState, 0}, errors.Wrap(err, "Error updating state invalid value")
+			return state{systemState: initState}, errors.Wrap(err, "Error updating state invalid value")
 		}
 
 		err = s.historyQ.TruncateExpingestStateTables()
 		if err != nil {
-			return state{initState, 0}, errors.Wrap(err, "Error clearing ingest tables")
+			return state{systemState: initState}, errors.Wrap(err, "Error clearing ingest tables")
 		}
 
-		return state{buildStateAndResumeState, 0}, nil
+		return state{systemState: buildStateAndResumeState}, nil
 	}
 
 	// The other node already ingested a state (just now or in the past)
@@ -355,7 +399,10 @@ func (s *System) init() (state, error) {
 	log.WithField("last_ledger", lastIngestedLedger).
 		Info("Resuming ingestion system from last processed ledger...")
 
-	return state{loadOffersIntoMemoryState, lastIngestedLedger}, nil
+	return state{
+		systemState:                       loadOffersIntoMemoryState,
+		latestSuccessfullyProcessedLedger: lastIngestedLedger,
+	}, nil
 }
 
 // loadOffersIntoMemory loads offers into memory. If successful, it changes the
@@ -369,7 +416,7 @@ func (s *System) loadOffersIntoMemory() (state, error) {
 
 	offers, err := s.historyQ.GetAllOffers()
 	if err != nil {
-		return state{initState, 0}, errors.Wrap(err, "GetAllOffers error")
+		return state{systemState: initState}, errors.Wrap(err, "GetAllOffers error")
 	}
 
 	for _, offer := range offers {
@@ -390,7 +437,7 @@ func (s *System) loadOffersIntoMemory() (state, error) {
 
 	err = s.graph.Apply(s.state.latestSuccessfullyProcessedLedger)
 	if err != nil {
-		return state{initState, 0}, errors.Wrap(err, "Error running graph.Apply")
+		return state{systemState: initState}, errors.Wrap(err, "Error running graph.Apply")
 	}
 
 	log.WithField(
@@ -398,7 +445,10 @@ func (s *System) loadOffersIntoMemory() (state, error) {
 		time.Since(start).Seconds(),
 	).Info("Finished loading offers from a database into memory store")
 
-	return state{resumeState, s.state.latestSuccessfullyProcessedLedger}, nil
+	return state{
+		systemState:                       resumeState,
+		latestSuccessfullyProcessedLedger: s.state.latestSuccessfullyProcessedLedger,
+	}, nil
 }
 
 func (s *System) buildStateAndResume() (state, error) {
@@ -408,13 +458,16 @@ func (s *System) buildStateAndResume() (state, error) {
 		// last processed ledger, otherwise start over.
 		latestSuccessfullyProcessedLedger, processed := s.session.GetLatestSuccessfullyProcessedLedger()
 		if !processed {
-			return state{initState, 0}, err
+			return state{systemState: initState}, err
 		}
 
-		return state{resumeState, latestSuccessfullyProcessedLedger}, err
+		return state{
+			systemState:                       resumeState,
+			latestSuccessfullyProcessedLedger: latestSuccessfullyProcessedLedger,
+		}, err
 	}
 
-	return state{shutdownState, 0}, nil
+	return state{systemState: shutdownState}, nil
 }
 
 func (s *System) resume() (state, error) {
@@ -427,13 +480,33 @@ func (s *System) resume() (state, error) {
 		// successfully ingested ledger in the machine state.
 		sessionLastLedger, processed := s.session.GetLatestSuccessfullyProcessedLedger()
 		if processed {
-			return state{resumeState, sessionLastLedger}, err
+			return state{
+				systemState:                       resumeState,
+				latestSuccessfullyProcessedLedger: sessionLastLedger,
+			}, err
 		}
 
 		return s.state, err
 	}
 
-	return state{shutdownState, 0}, nil
+	return state{systemState: shutdownState}, nil
+}
+
+func (s *System) verifyRange() (state, error) {
+	s.rangeSession.FromLedger = s.state.rangeFromLedger
+	s.rangeSession.ToLedger = s.state.rangeToLedger
+	// It's fine to change System settings because the next state of verifyRange
+	// is always shut down.
+	s.disableStateVerification = true
+
+	err := s.rangeSession.Run()
+	if err == nil {
+		if s.state.rangeVerifyState {
+			err = s.verifyState(s.graph.OffersMap())
+		}
+	}
+
+	return state{systemState: shutdownState, returnError: err}, err
 }
 
 // StateReady returns true if the ingestion system has finished running it's state pipelines

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -495,13 +495,24 @@ func (s *System) resume() (state, error) {
 }
 
 func (s *System) verifyRange() (state, error) {
+	// Simple check if DB clean
+	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
+	if err != nil {
+		err = errors.Wrap(err, "Error getting last ledger")
+		return state{systemState: shutdownState, returnError: err}, err
+	}
+
+	if lastIngestedLedger != 0 {
+		return state{systemState: shutdownState, returnError: errors.New("Database not empty")}, err
+	}
+
 	s.rangeSession.FromLedger = s.state.rangeFromLedger
 	s.rangeSession.ToLedger = s.state.rangeToLedger
 	// It's fine to change System settings because the next state of verifyRange
 	// is always shut down.
 	s.disableStateVerification = true
 
-	err := s.rangeSession.Run()
+	err = s.rangeSession.Run()
 	if err == nil {
 		if s.state.rangeVerifyState {
 			err = s.verifyState(s.graph.OffersMap())

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -49,8 +49,9 @@ const (
 var log = logpkg.DefaultLogger.WithField("service", "expingest")
 
 type Config struct {
-	CoreSession    *db.Session
-	StellarCoreURL string
+	CoreSession       *db.Session
+	StellarCoreURL    string
+	NetworkPassphrase string
 
 	HistorySession           *db.Session
 	HistoryArchiveURL        string
@@ -178,11 +179,12 @@ func NewSystem(config Config) (*System, error) {
 	}
 
 	rangeSession := &ingest.RangeSession{
-		Archive:          archive,
-		MaxStreamRetries: config.MaxStreamRetries,
-		LedgerBackend:    ledgerBackend,
-		StatePipeline:    statePipeline,
-		LedgerPipeline:   ledgerPipeline,
+		Archive:           archive,
+		MaxStreamRetries:  config.MaxStreamRetries,
+		LedgerBackend:     ledgerBackend,
+		StatePipeline:     statePipeline,
+		LedgerPipeline:    ledgerPipeline,
+		NetworkPassphrase: config.NetworkPassphrase,
 
 		StateReporter:  &LoggingStateReporter{Log: log, Interval: 100000},
 		LedgerReporter: &LoggingLedgerReporter{Log: log},

--- a/services/horizon/internal/expingest/processors/operations_processor.go
+++ b/services/horizon/internal/expingest/processors/operations_processor.go
@@ -95,19 +95,21 @@ func (p *OperationProcessor) ProcessLedger(ctx context.Context, store *pipeline.
 
 	// use an older lookup sequence because the experimental ingestion system and the
 	// legacy ingestion system might not be in sync
-	checkSequence := int32(sequence - 10)
-	var valid bool
-	valid, err = p.OperationsQ.CheckExpOperations(checkSequence)
-	if err != nil {
-		log.WithField("sequence", checkSequence).WithError(err).
-			Error("Could not compare operations for ledger")
-		return nil
-	}
+	if sequence > 10 {
+		checkSequence := int32(sequence - 10)
+		var valid bool
+		valid, err = p.OperationsQ.CheckExpOperations(checkSequence)
+		if err != nil {
+			log.WithField("sequence", checkSequence).WithError(err).
+				Error("Could not compare operations for ledger")
+			return nil
+		}
 
-	if !valid {
-		log.WithField("sequence", checkSequence).
-			Error("rows for ledger in exp_history_operations does not match " +
-				"operations in history_operations")
+		if !valid {
+			log.WithField("sequence", checkSequence).
+				Error("rows for ledger in exp_history_operations does not match " +
+					"operations in history_operations")
+		}
 	}
 
 	return nil

--- a/services/horizon/internal/expingest/processors/participants_processor.go
+++ b/services/horizon/internal/expingest/processors/participants_processor.go
@@ -213,18 +213,20 @@ func (p *ParticipantsProcessor) ProcessLedger(ctx context.Context, store *pipeli
 
 	// use an older lookup sequence because the experimental ingestion system and the
 	// legacy ingestion system might not be in sync
-	checkSequence := int32(sequence - 10)
-	var valid bool
-	valid, err = p.ParticipantsQ.CheckExpParticipants(checkSequence)
-	if err != nil {
-		log.WithField("sequence", checkSequence).WithError(err).
-			Error("Could not compare participants for ledger")
-		return nil
-	}
+	if sequence > 10 {
+		checkSequence := int32(sequence - 10)
+		var valid bool
+		valid, err = p.ParticipantsQ.CheckExpParticipants(checkSequence)
+		if err != nil {
+			log.WithField("sequence", checkSequence).WithError(err).
+				Error("Could not compare participants for ledger")
+			return nil
+		}
 
-	if !valid {
-		log.WithField("sequence", checkSequence).
-			Error("participants do not match")
+		if !valid {
+			log.WithField("sequence", checkSequence).
+				Error("participants do not match")
+		}
 	}
 
 	return nil

--- a/services/horizon/internal/expingest/processors/transactions_processor.go
+++ b/services/horizon/internal/expingest/processors/transactions_processor.go
@@ -65,19 +65,21 @@ func (p *TransactionProcessor) ProcessLedger(ctx context.Context, store *pipelin
 
 	// use an older lookup sequence because the experimental ingestion system and the
 	// legacy ingestion system might not be in sync
-	checkSequence := int32(sequence - 10)
-	var valid bool
-	valid, err = p.TransactionsQ.CheckExpTransactions(checkSequence)
-	if err != nil {
-		log.WithField("sequence", checkSequence).WithError(err).
-			Error("Could not compare transactions for ledger")
-		return nil
-	}
+	if sequence > 10 {
+		checkSequence := int32(sequence - 10)
+		var valid bool
+		valid, err = p.TransactionsQ.CheckExpTransactions(checkSequence)
+		if err != nil {
+			log.WithField("sequence", checkSequence).WithError(err).
+				Error("Could not compare transactions for ledger")
+			return nil
+		}
 
-	if !valid {
-		log.WithField("sequence", checkSequence).
-			Error("rows for ledger in exp_history_transactions does not match " +
-				"transactions in history_transactions")
+		if !valid {
+			log.WithField("sequence", checkSequence).
+				Error("rows for ledger in exp_history_transactions does not match " +
+					"transactions in history_transactions")
+		}
 	}
 
 	return nil

--- a/services/horizon/internal/expingest/run_ingestion_test.go
+++ b/services/horizon/internal/expingest/run_ingestion_test.go
@@ -132,7 +132,7 @@ func (s *RunIngestionTestSuite) SetupTest() {
 	s.historyQ = &mockDBQ{}
 	s.ingestSession = &mockIngestSession{}
 	s.system = &System{
-		state:          state{initState, 0},
+		state:          state{systemState: initState},
 		session:        s.ingestSession,
 		historySession: s.session,
 		historyQ:       s.historyQ,
@@ -411,7 +411,7 @@ func (s *ResumeIngestionTestSuite) SetupTest() {
 	s.historyQ = &mockDBQ{}
 	s.ingestSession = &mockIngestSession{}
 	s.system = &System{
-		state:          state{resumeState, 1},
+		state:          state{systemState: resumeState, latestSuccessfullyProcessedLedger: 1},
 		session:        s.ingestSession,
 		historySession: s.session,
 		historyQ:       s.historyQ,

--- a/support/config/config_option.go
+++ b/support/config/config_option.go
@@ -94,6 +94,8 @@ func (co *ConfigOption) setSimpleValue() {
 			*(co.ConfigKey.(*bool)) = viper.GetBool(co.Name)
 		case types.Uint:
 			*(co.ConfigKey.(*uint)) = uint(viper.GetInt(co.Name))
+		case types.Uint32:
+			*(co.ConfigKey.(*uint32)) = uint32(viper.GetInt(co.Name))
 		}
 	}
 }
@@ -113,6 +115,8 @@ func (co *ConfigOption) setFlag(cmd *cobra.Command) error {
 		cmd.PersistentFlags().Bool(co.Name, co.FlagDefault.(bool), co.Usage)
 	case types.Uint:
 		cmd.PersistentFlags().Uint(co.Name, co.FlagDefault.(uint), co.Usage)
+	case types.Uint32:
+		cmd.PersistentFlags().Uint32(co.Name, co.FlagDefault.(uint32), co.Usage)
 	default:
 		return errors.New("Unexpected OptType")
 	}

--- a/xdr/db.go
+++ b/xdr/db.go
@@ -81,6 +81,11 @@ func (t *Hash) Scan(src interface{}) error {
 	return nil
 }
 
+// Scan reads from src into an LedgerUpgrade struct
+func (t *LedgerUpgrade) Scan(src interface{}) error {
+	return safeBase64Scan(src, t)
+}
+
 // Scan reads from src into an LedgerEntryChanges struct
 func (t *LedgerEntryChanges) Scan(src interface{}) error {
 	return safeBase64Scan(src, t)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Adds `horizon expingest verify-range` command and `exp/ingest.RangeSession`. It also adds `GenesisLedgerStateReader` to that streams master account in a given network to allow ingesting ledger entry changes from ledger 1.

Close #1848.
Close #2087.

### Why

In order to ensure that new ingestion system works correctly we plan to reingest pubnet history from the first ledger. In order to achieve this we add `horizon expingest verify-range` command that accepts required two params: `--from` and `--to` that describe the ledger range. When started it:
* It ingests ledger entries of `from` ledger (must be a checkpoint ledger).
* Ingests ledgers `[from+1, to]`.
* If `--verify-state` is set, it runs state verifier on `to` ledger  (must be a checkpoint ledger).

When merged we can start multiple workers ingesting full history in parallel like:
```
horizon expingest verify-range --from 9983 --to 16383 --verify-state
horizon expingest verify-range --from 16383 --to 22783 --verify-state
...
```

Internally, it's using a new `RangeSession` from `exp/ingest` package that process a given range of ledger. `RangeSession` will be also used in `horizon reingest` commands.

It's also helpful for finding performance issues as it's easy to reingest a given range with a debug server enabled.

```
runs ingestion pipeline between X and Y sequence number (inclusive)

Usage:
  horizon expingest verify-range [flags]

Flags:
      --debug-server-port uint32   [optional] opens a net/http/pprof server at given port
      --from uint32                first ledger of the range to ingest
      --to uint32                  last ledger of the range to ingest
      --verify-state               [optional] verifies state at the last ledger of the range when true
```

### Known limitations

`LiveSession` and `RangeSession` have a shared code that can be extracted to a shared function. Should be done in a separate PR to not decrease readability of this PR.