### PR TITLE
services/horizon/internal/ingest/ingestion: Remove dead code from legacy ingestion system

### DIFF
--- a/services/horizon/internal/ingest/ingestion.go
+++ b/services/horizon/internal/ingest/ingestion.go
@@ -93,7 +93,6 @@ func (ingest *Ingestion) Flush() error {
 		LedgersTableName,
 		OperationParticipantsTableName,
 		OperationsTableName,
-		TradesTableName,
 		TransactionParticipantsTableName,
 		TransactionsTableName,
 	}
@@ -258,64 +257,6 @@ func (ingest *Ingestion) Start() (err error) {
 	return
 }
 
-// Trade records a trade into the history_trades table
-func (ingest *Ingestion) Trade(
-	opid int64,
-	order int32,
-	buyer xdr.AccountId,
-	trade xdr.ClaimOfferAtom,
-	ledgerClosedAt int64,
-) error {
-
-	q := history.Q{Session: ingest.DB}
-
-	sellerAccountId, err := q.GetCreateAccountID(trade.SellerId)
-	if err != nil {
-		return errors.Wrap(err, "failed to load seller account id")
-	}
-
-	buyerAccountId, err := q.GetCreateAccountID(buyer)
-	if err != nil {
-		return errors.Wrap(err, "failed to load buyer account id")
-	}
-	soldAssetId, err := q.GetCreateAssetID(trade.AssetSold)
-	if err != nil {
-		return errors.Wrap(err, "failed to get sold asset id")
-	}
-
-	boughtAssetId, err := q.GetCreateAssetID(trade.AssetBought)
-	if err != nil {
-		return errors.Wrap(err, "failed to get bought asset id")
-	}
-	var baseAssetId, counterAssetId int64
-	var baseAccountId, counterAccountId int64
-	var baseAmount, counterAmount xdr.Int64
-
-	//map seller and buyer to base and counter based on ordering of ids
-	if soldAssetId < boughtAssetId {
-		baseAccountId, baseAssetId, baseAmount, counterAccountId, counterAssetId, counterAmount =
-			sellerAccountId, soldAssetId, trade.AmountSold, buyerAccountId, boughtAssetId, trade.AmountBought
-	} else {
-		baseAccountId, baseAssetId, baseAmount, counterAccountId, counterAssetId, counterAmount =
-			buyerAccountId, boughtAssetId, trade.AmountBought, sellerAccountId, soldAssetId, trade.AmountSold
-	}
-
-	ingest.builders[TradesTableName].Values(
-		opid,
-		order,
-		time.Unix(ledgerClosedAt, 0).UTC(),
-		trade.OfferId,
-		baseAccountId,
-		baseAssetId,
-		baseAmount,
-		counterAccountId,
-		counterAssetId,
-		counterAmount,
-		soldAssetId < boughtAssetId,
-	)
-	return nil
-}
-
 // Transaction ingests the provided transaction data into a new row in the
 // `history_transactions` table
 func (ingest *Ingestion) Transaction(
@@ -450,23 +391,6 @@ func (ingest *Ingestion) createInsertBuilders() {
 			"\"order\"",
 			"type",
 			"details",
-		},
-	}
-
-	ingest.builders[TradesTableName] = &BatchInsertBuilder{
-		TableName: TradesTableName,
-		Columns: []string{
-			"history_operation_id",
-			"\"order\"",
-			"ledger_closed_at",
-			"offer_id",
-			"base_account_id",
-			"base_asset_id",
-			"base_amount",
-			"counter_account_id",
-			"counter_asset_id",
-			"counter_amount",
-			"base_is_seller",
 		},
 	}
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove dead code from legacy ingestion system.


### Why

The code which ingests trades is located here:

https://github.com/stellar/go/blob/54d2e97fc84239192c91af22e7e89c5b4537beea/services/horizon/internal/ingest/session.go#L536

As far as I can tell, `Ingestion.Trade()` is never called.

### Known limitations

[N/A]
