### PR TITLE
services/horizon: Fix tests mocking UpsertTrustLines

### DIFF
--- a/services/horizon/internal/expingest/processors/trust_lines_processor_test.go
+++ b/services/horizon/internal/expingest/processors/trust_lines_processor_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -337,23 +338,29 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestInsertTrustLine() {
 		}, nil).Once()
 	s.mockQ.On(
 		"UpsertTrustLines",
-		[]xdr.LedgerEntry{
-			xdr.LedgerEntry{
-				LastModifiedLedgerSeq: lastModifiedLedgerSeq,
-				Data: xdr.LedgerEntryData{
-					Type:      xdr.LedgerEntryTypeTrustline,
-					TrustLine: &updatedTrustLine,
+		mock.AnythingOfType("[]xdr.LedgerEntry"),
+	).Run(func(args mock.Arguments) {
+		arg := args.Get(0).([]xdr.LedgerEntry)
+		s.Assert().ElementsMatch(
+			[]xdr.LedgerEntry{
+				xdr.LedgerEntry{
+					LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+					Data: xdr.LedgerEntryData{
+						Type:      xdr.LedgerEntryTypeTrustline,
+						TrustLine: &updatedTrustLine,
+					},
+				},
+				xdr.LedgerEntry{
+					LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+					Data: xdr.LedgerEntryData{
+						Type:      xdr.LedgerEntryTypeTrustline,
+						TrustLine: &updatedUnauthorizedTrustline,
+					},
 				},
 			},
-			xdr.LedgerEntry{
-				LastModifiedLedgerSeq: lastModifiedLedgerSeq,
-				Data: xdr.LedgerEntryData{
-					Type:      xdr.LedgerEntryTypeTrustline,
-					TrustLine: &updatedUnauthorizedTrustline,
-				},
-			},
-		},
-	).Return(nil).Once()
+			arg,
+		)
+	}).Return(nil).Once()
 	s.mockAssetStatsQ.On("GetAssetStat",
 		xdr.AssetTypeAssetTypeCreditAlphanum4,
 		"EUR",
@@ -565,23 +572,29 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestUpdateTrustLineAuthorization() 
 
 	s.mockQ.On(
 		"UpsertTrustLines",
-		[]xdr.LedgerEntry{
-			xdr.LedgerEntry{
-				LastModifiedLedgerSeq: lastModifiedLedgerSeq,
-				Data: xdr.LedgerEntryData{
-					Type:      xdr.LedgerEntryTypeTrustline,
-					TrustLine: &updatedTrustLine,
+		mock.AnythingOfType("[]xdr.LedgerEntry"),
+	).Run(func(args mock.Arguments) {
+		arg := args.Get(0).([]xdr.LedgerEntry)
+		s.Assert().ElementsMatch(
+			[]xdr.LedgerEntry{
+				xdr.LedgerEntry{
+					LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+					Data: xdr.LedgerEntryData{
+						Type:      xdr.LedgerEntryTypeTrustline,
+						TrustLine: &updatedTrustLine,
+					},
+				},
+				xdr.LedgerEntry{
+					LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+					Data: xdr.LedgerEntryData{
+						Type:      xdr.LedgerEntryTypeTrustline,
+						TrustLine: &otherUpdatedTrustLine,
+					},
 				},
 			},
-			xdr.LedgerEntry{
-				LastModifiedLedgerSeq: lastModifiedLedgerSeq,
-				Data: xdr.LedgerEntryData{
-					Type:      xdr.LedgerEntryTypeTrustline,
-					TrustLine: &otherUpdatedTrustLine,
-				},
-			},
-		},
-	).Return(nil).Once()
+			arg,
+		)
+	}).Return(nil).Once()
 
 	s.mockAssetStatsQ.On("GetAssetStat",
 		xdr.AssetTypeAssetTypeCreditAlphanum4,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes a but in tests that are mocking `UpsertTrustLines` method.

### Why

Because all of the ledger entry changes are cached using `LedgerEntryChangeCache` it's possible that the order of trustlines in `UpsertTrustLines` will be different between calls if more than one trust line is updated. `LedgerEntryChangeCache` is using map inside which, when iterating, returns elements in random order.