### PR TITLE
services/horizon/internal/db2: Fix page query in descending order with empty string.

### DIFF
--- a/services/horizon/internal/db2/history/accounts_test.go
+++ b/services/horizon/internal/db2/history/accounts_test.go
@@ -350,6 +350,16 @@ func TestAccountsForAsset(t *testing.T) {
 	accounts, err = q.AccountsForAsset(usdTrustLine.Asset, pq)
 	assert.NoError(t, err)
 	tt.Assert.Len(accounts, 0)
+
+	pq = db2.PageQuery{
+		Order:  db2.OrderDescending,
+		Limit:  db2.DefaultPageSize,
+		Cursor: "",
+	}
+
+	accounts, err = q.AccountsForAsset(eurTrustLine.Asset, pq)
+	assert.NoError(t, err)
+	tt.Assert.Len(accounts, 1)
 }
 
 func TestAccountEntriesForSigner(t *testing.T) {
@@ -426,6 +436,16 @@ func TestAccountEntriesForSigner(t *testing.T) {
 	accounts, err = q.AccountEntriesForSigner(account3.AccountId.Address(), pq)
 	assert.NoError(t, err)
 	tt.Assert.Len(accounts, 2)
+
+	pq = db2.PageQuery{
+		Order:  db2.OrderDescending,
+		Limit:  db2.DefaultPageSize,
+		Cursor: "",
+	}
+
+	accounts, err = q.AccountEntriesForSigner(account1.AccountId.Address(), pq)
+	assert.NoError(t, err)
+	tt.Assert.Len(accounts, 1)
 }
 
 func TestGetAccountByID(t *testing.T) {

--- a/services/horizon/internal/db2/page_query.go
+++ b/services/horizon/internal/db2/page_query.go
@@ -76,13 +76,23 @@ func (p PageQuery) ApplyToUsingCursor(
 
 	switch p.Order {
 	case "asc":
-		sql = sql.
-			Where(fmt.Sprintf("%s > ?", col), cursor).
-			OrderBy(fmt.Sprintf("%s asc", col))
+		if cursor == "" {
+			sql = sql.
+				OrderBy(fmt.Sprintf("%s asc", col))
+		} else {
+			sql = sql.
+				Where(fmt.Sprintf("%s > ?", col), cursor).
+				OrderBy(fmt.Sprintf("%s asc", col))
+		}
 	case "desc":
-		sql = sql.
-			Where(fmt.Sprintf("%s < ?", col), cursor).
-			OrderBy(fmt.Sprintf("%s desc", col))
+		if cursor == "" {
+			sql = sql.
+				OrderBy(fmt.Sprintf("%s desc", col))
+		} else {
+			sql = sql.
+				Where(fmt.Sprintf("%s < ?", col), cursor).
+				OrderBy(fmt.Sprintf("%s desc", col))
+		}
 	default:
 		return sql, errors.Errorf("invalid order: %s", p.Order)
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fix page query in descending order with empty string. 

### Why

When using a string as a cursor and without cursor validation, sorting in descending order will produce a SQL which will always return 0 results, as seen https://github.com/stellar/go/issues/2084

For both scenarios `asc` and `desc` we shouldn't include the cursor if it is empty, since it might lead to unexpected behaviors.

This was also affecting the end-point when filtering by signer. 

### Known limitations

[TODO or N/A]
