### PR TITLE
services/horizon/internal/db2: Add exp_history_trades table

### DIFF
--- a/services/horizon/internal/db2/history/ingestion.go
+++ b/services/horizon/internal/db2/history/ingestion.go
@@ -29,6 +29,7 @@ type ExpIngestRemovalSummary struct {
 	TransactionParticipantsRemoved int64
 	OperationsRemoved              int64
 	OperationParticipantsRemoved   int64
+	TradesRemoved                  int64
 }
 
 // RemoveExpIngestHistory removes all rows in the experimental ingestion
@@ -97,6 +98,19 @@ func (q *Q) RemoveExpIngestHistory(newerThanSequence uint32) (ExpIngestRemovalSu
 	}
 
 	summary.OperationParticipantsRemoved, err = result.RowsAffected()
+	if err != nil {
+		return summary, err
+	}
+
+	result, err = q.Exec(
+		sq.Delete("exp_history_trades").
+			Where("history_operation_id >= ?", toid.ID{LedgerSequence: int32(newerThanSequence + 1)}.ToInt64()),
+	)
+	if err != nil {
+		return summary, err
+	}
+
+	summary.TradesRemoved, err = result.RowsAffected()
 
 	return summary, err
 }

--- a/services/horizon/internal/db2/history/trade.go
+++ b/services/horizon/internal/db2/history/trade.go
@@ -3,11 +3,13 @@ package history
 import (
 	"fmt"
 	"math"
+	"reflect"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/stellar/go/services/horizon/internal/db2"
+	"github.com/stellar/go/services/horizon/internal/toid"
 	"github.com/stellar/go/support/errors"
-	"github.com/stellar/go/support/time"
+	supportTime "github.com/stellar/go/support/time"
 	"github.com/stellar/go/xdr"
 )
 
@@ -24,21 +26,44 @@ func (r *Trade) HasPrice() bool {
 // Trades provides a helper to filter rows from the `history_trades` table
 // with pre-defined filters.  See `TradesQ` methods for the available filters.
 func (q *Q) Trades() *TradesQ {
-	trades := &TradesQ{
+	return &TradesQ{
 		parent: q,
-		sql:    selectTrade,
+		sql: joinTradeAssets(
+			joinTradeAccounts(
+				selectTradeFields.From("history_trades htrd"),
+				"history_accounts",
+			),
+			"history_assets",
+		),
 	}
-	return trades.JoinAccounts().JoinAssets()
+}
+
+func (q *Q) expTrades() *TradesQ {
+	return &TradesQ{
+		parent: q,
+		sql: joinTradeAssets(
+			joinTradeAccounts(
+				selectTradeFields.From("exp_history_trades htrd"),
+				"exp_history_accounts",
+			),
+			"exp_history_assets",
+		),
+	}
 }
 
 // ReverseTrades provides a helper to filter rows from the `history_trades` table
 // with pre-defined filters and reversed base/counter.  See `TradesQ` methods for the available filters.
 func (q *Q) ReverseTrades() *TradesQ {
-	trades := &TradesQ{
+	return &TradesQ{
 		parent: q,
-		sql:    selectReverseTrade,
+		sql: joinTradeAssets(
+			joinTradeAccounts(
+				selectReverseTradeFields.From("history_trades htrd"),
+				"history_accounts",
+			),
+			"history_assets",
+		),
 	}
-	return trades.JoinAccounts().JoinAssets()
 }
 
 // TradesForAssetPair provides a helper to filter rows from the `history_trades` table
@@ -66,7 +91,23 @@ func (q *TradesQ) forAssetPair(baseAssetId int64, counterAssetId int64) *TradesQ
 	return q
 }
 
-//filter Trades by account id
+// ForLedger adds a filter which only includes trades within the given ledger sequence
+func (q *TradesQ) ForLedger(sequence int32, order string) *TradesQ {
+	from := toid.ID{LedgerSequence: sequence}.ToInt64()
+	to := toid.ID{LedgerSequence: sequence + 1}.ToInt64()
+
+	q.sql = q.sql.Where(
+		"htrd.history_operation_id >= ? AND htrd.history_operation_id <= ? ",
+		from,
+		to,
+	).OrderBy(
+		"htrd.history_operation_id " + order + ", htrd.order " + order,
+	)
+
+	return q
+}
+
+// ForAccount filter Trades by account id
 func (q *TradesQ) ForAccount(aid string) *TradesQ {
 	var account Account
 	q.Err = q.parent.AccountByAddress(&account, aid)
@@ -134,21 +175,19 @@ func (q *TradesQ) Select(dest interface{}) error {
 	return q.Err
 }
 
-func (q *TradesQ) JoinAccounts() *TradesQ {
-	q.sql = q.sql.
-		Join("history_accounts base_accounts ON base_account_id = base_accounts.id").
-		Join("history_accounts counter_accounts ON counter_account_id = counter_accounts.id")
-	return q
+func joinTradeAccounts(selectBuilder sq.SelectBuilder, historyAccountsTable string) sq.SelectBuilder {
+	return selectBuilder.
+		Join(historyAccountsTable + " base_accounts ON base_account_id = base_accounts.id").
+		Join(historyAccountsTable + " counter_accounts ON counter_account_id = counter_accounts.id")
 }
 
-func (q *TradesQ) JoinAssets() *TradesQ {
-	q.sql = q.sql.
-		Join("history_assets base_assets ON base_asset_id = base_assets.id").
-		Join("history_assets counter_assets ON counter_asset_id = counter_assets.id")
-	return q
+func joinTradeAssets(selectBuilder sq.SelectBuilder, historyAssetsTable string) sq.SelectBuilder {
+	return selectBuilder.
+		Join(historyAssetsTable + " base_assets ON base_asset_id = base_assets.id").
+		Join(historyAssetsTable + " counter_assets ON counter_asset_id = counter_assets.id")
 }
 
-var selectTrade = sq.Select(
+var selectTradeFields = sq.Select(
 	"history_operation_id",
 	"htrd.\"order\"",
 	"htrd.ledger_closed_at",
@@ -168,9 +207,9 @@ var selectTrade = sq.Select(
 	"htrd.base_is_seller",
 	"htrd.price_n",
 	"htrd.price_d",
-).From("history_trades htrd")
+)
 
-var selectReverseTrade = sq.Select(
+var selectReverseTradeFields = sq.Select(
 	"history_operation_id",
 	"htrd.\"order\"",
 	"htrd.ledger_closed_at",
@@ -190,7 +229,7 @@ var selectReverseTrade = sq.Select(
 	"NOT(htrd.base_is_seller) as base_is_seller",
 	"htrd.price_d as price_n",
 	"htrd.price_n as price_d",
-).From("history_trades htrd")
+)
 
 var tradesInsert = sq.Insert("history_trades").Columns(
 	"history_operation_id",
@@ -219,7 +258,7 @@ func (q *Q) InsertTrade(
 	buyOffer xdr.OfferEntry,
 	trade xdr.ClaimOfferAtom,
 	sellPrice xdr.Price,
-	ledgerClosedAt time.Millis,
+	ledgerClosedAt supportTime.Millis,
 ) error {
 	sellerAccountId, err := q.GetCreateAccountID(trade.SellerId)
 	if err != nil {
@@ -306,4 +345,63 @@ func getCanonicalAssetOrder(assetId1 int64, assetId2 int64) (orderPreserved bool
 	} else {
 		return false, assetId2, assetId1
 	}
+}
+
+// CheckExpTrades checks that the trades in exp_history_trades
+// for the given ledger matches the same transactions in history_trades
+func (q *Q) CheckExpTrades(seq int32) (bool, error) {
+	var trades, expTrades []Trade
+
+	err := q.Trades().ForLedger(seq, "asc").Select(&trades)
+	if err != nil {
+		return false, err
+	}
+
+	err = q.expTrades().ForLedger(seq, "asc").Select(&expTrades)
+	if err != nil {
+		return false, err
+	}
+
+	// We only proceed with the comparison if we have trade data in both the
+	// legacy ingestion system and the experimental ingestion system.
+	// If there are no trades in either the legacy ingestion system or the
+	// experimental ingestion system we skip the check.
+	if len(trades) == 0 || len(expTrades) == 0 {
+		return true, nil
+	}
+
+	if len(trades) != len(expTrades) {
+		return false, nil
+	}
+
+	for i, trade := range trades {
+		expTrade := expTrades[i]
+
+		// compare LedgerCloseTime separately
+		expClosedAt := expTrade.LedgerCloseTime
+		expTrade.LedgerCloseTime = trade.LedgerCloseTime
+		if expClosedAt.Unix() != trade.LedgerCloseTime.Unix() {
+			return false, nil
+		}
+
+		// a given set of assets may not have the same ordering in history_assets and exp_history_assets
+		// the ordering affects the value of BaseIsSeller (see how getCanonicalAssetOrder() is used above)
+		if expTrade.BaseIsSeller != trade.BaseIsSeller {
+			expTrade.BaseOfferID, expTrade.CounterOfferID = expTrade.CounterOfferID, expTrade.BaseOfferID
+			expTrade.BaseAccount, expTrade.CounterAccount = expTrade.CounterAccount, expTrade.BaseAccount
+			expTrade.BaseAssetType, expTrade.CounterAssetType = expTrade.CounterAssetType, expTrade.BaseAssetType
+			expTrade.BaseAssetCode, expTrade.CounterAssetCode = expTrade.CounterAssetCode, expTrade.BaseAssetCode
+			expTrade.BaseAssetIssuer, expTrade.CounterAssetIssuer = expTrade.CounterAssetIssuer, expTrade.BaseAssetIssuer
+			expTrade.BaseAmount, expTrade.CounterAmount = expTrade.CounterAmount, expTrade.BaseAmount
+			expTrade.PriceN, expTrade.PriceD = expTrade.PriceD, expTrade.PriceN
+
+			expTrade.BaseIsSeller = trade.BaseIsSeller
+		}
+
+		if !reflect.DeepEqual(expTrade, trade) {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }

--- a/services/horizon/internal/db2/history/trade_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/trade_batch_insert_builder.go
@@ -108,7 +108,7 @@ func (i *tradeBatchInsertBuilder) Add(entries ...InsertTrade) error {
 			"price_d":              entry.SellPrice.D,
 		})
 		if err != nil {
-			return errors.Wrap(err, "failed to exec sql")
+			return errors.Wrap(err, "failed to add trade")
 		}
 	}
 

--- a/services/horizon/internal/db2/history/trade_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/trade_batch_insert_builder.go
@@ -1,0 +1,116 @@
+package history
+
+import (
+	"time"
+
+	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+// InsertTrade represents the arguments to TradeBatchInsertBuilder.Add() which is used to insert
+// rows into the exp_history_trades table
+type InsertTrade struct {
+	HistoryOperationID int64
+	Order              int32
+	LedgerCloseTime    time.Time
+	BuyOfferExists     bool
+	BuyOfferID         int64
+	SellerAccountID    int64
+	BuyerAccountID     int64
+	SoldAssetID        int64
+	BoughtAssetID      int64
+	Trade              xdr.ClaimOfferAtom
+	SellPrice          xdr.Price
+}
+
+// TradeBatchInsertBuilder is used to insert trades into the
+// exp_history_trades table
+type TradeBatchInsertBuilder interface {
+	Add(entries ...InsertTrade) error
+	Exec() error
+}
+
+// tradeBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
+type tradeBatchInsertBuilder struct {
+	builder db.BatchInsertBuilder
+}
+
+// NewTradeBatchInsertBuilder constructs a new TradeBatchInsertBuilder instance
+func (q *Q) NewTradeBatchInsertBuilder(maxBatchSize int) TradeBatchInsertBuilder {
+	return &tradeBatchInsertBuilder{
+		builder: db.BatchInsertBuilder{
+			Table:        q.GetTable("exp_history_trades"),
+			MaxBatchSize: maxBatchSize,
+		},
+	}
+}
+
+// Exec flushes all outstanding trades to the database
+func (i *tradeBatchInsertBuilder) Exec() error {
+	return i.builder.Exec()
+}
+
+// Add adds a new trade to the batch
+func (i *tradeBatchInsertBuilder) Add(entries ...InsertTrade) error {
+	for _, entry := range entries {
+		sellOfferID := EncodeOfferId(uint64(entry.Trade.OfferId), CoreOfferIDType)
+
+		// if the buy offer exists, encode the stellar core generated id as the offer id
+		// if not, encode the toid as the offer id
+		var buyOfferID int64
+		if entry.BuyOfferExists {
+			buyOfferID = EncodeOfferId(uint64(entry.BuyOfferID), CoreOfferIDType)
+		} else {
+			buyOfferID = EncodeOfferId(uint64(entry.HistoryOperationID), TOIDType)
+		}
+
+		orderPreserved, baseAssetID, counterAssetID := getCanonicalAssetOrder(
+			entry.SoldAssetID, entry.BoughtAssetID,
+		)
+
+		var baseAccountID, counterAccountID int64
+		var baseAmount, counterAmount xdr.Int64
+		var baseOfferID, counterOfferID int64
+
+		if orderPreserved {
+			baseAccountID = entry.SellerAccountID
+			baseAmount = entry.Trade.AmountSold
+			counterAccountID = entry.BuyerAccountID
+			counterAmount = entry.Trade.AmountBought
+			baseOfferID = sellOfferID
+			counterOfferID = buyOfferID
+		} else {
+			baseAccountID = entry.BuyerAccountID
+			baseAmount = entry.Trade.AmountBought
+			counterAccountID = entry.SellerAccountID
+			counterAmount = entry.Trade.AmountSold
+			baseOfferID = buyOfferID
+			counterOfferID = sellOfferID
+			entry.SellPrice.Invert()
+		}
+
+		err := i.builder.Row(map[string]interface{}{
+			"history_operation_id": entry.HistoryOperationID,
+			"\"order\"":            entry.Order,
+			"ledger_closed_at":     entry.LedgerCloseTime,
+			"offer_id":             entry.Trade.OfferId,
+			"base_offer_id":        baseOfferID,
+			"base_account_id":      baseAccountID,
+			"base_asset_id":        baseAssetID,
+			"base_amount":          baseAmount,
+			"counter_offer_id":     counterOfferID,
+			"counter_account_id":   counterAccountID,
+			"counter_asset_id":     counterAssetID,
+			"counter_amount":       counterAmount,
+			"base_is_seller":       orderPreserved,
+			"price_n":              entry.SellPrice.N,
+			"price_d":              entry.SellPrice.D,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to exec sql")
+		}
+	}
+
+	return nil
+}

--- a/services/horizon/internal/db2/history/trade_test.go
+++ b/services/horizon/internal/db2/history/trade_test.go
@@ -1,11 +1,14 @@
-package history_test
+package history
 
 import (
 	"testing"
+	"time"
 
+	sq "github.com/Masterminds/squirrel"
 	"github.com/stellar/go/services/horizon/internal/db2"
-	. "github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/services/horizon/internal/toid"
+	supportTime "github.com/stellar/go/support/time"
 	"github.com/stellar/go/xdr"
 )
 
@@ -68,4 +71,349 @@ func TestTradeQueries(t *testing.T) {
 	tt.Assert.Equal(xdr.Int64(1000000000), trades[0].BaseAmount)
 	tt.Assert.Equal(xdr.Int64(2000000000), trades[0].CounterAmount)
 	tt.Assert.Equal(false, trades[0].BaseIsSeller)
+}
+
+type tradeRow struct {
+	HistoryOperationID int64     `db:"history_operation_id"`
+	Order              int32     `db:"order"`
+	LedgerCloseTime    time.Time `db:"ledger_closed_at"`
+	OfferID            int64     `db:"offer_id"`
+	BaseOfferID        int64     `db:"base_offer_id"`
+	BaseAccountID      int64     `db:"base_account_id"`
+	BaseAssetID        int64     `db:"base_asset_id"`
+	BaseAmount         xdr.Int64 `db:"base_amount"`
+	CounterOfferID     int64     `db:"counter_offer_id"`
+	CounterAccountID   int64     `db:"counter_account_id"`
+	CounterAssetID     int64     `db:"counter_asset_id"`
+	CounterAmount      xdr.Int64 `db:"counter_amount"`
+	BaseIsSeller       bool      `db:"base_is_seller"`
+	PriceN             int       `db:"price_n"`
+	PriceD             int       `db:"price_d"`
+}
+
+func createInsertTrades(
+	accountIDs []int64, assetIDs []int64, ledger int32,
+) (InsertTrade, InsertTrade, InsertTrade) {
+	first := InsertTrade{
+		HistoryOperationID: toid.New(ledger, 1, 1).ToInt64(),
+		Order:              1,
+		LedgerCloseTime:    supportTime.MillisFromSeconds(time.Now().Unix()).ToTime(),
+		BuyOfferExists:     true,
+		BuyOfferID:         32145,
+		SellerAccountID:    accountIDs[0],
+		BuyerAccountID:     accountIDs[1],
+		SoldAssetID:        assetIDs[0],
+		BoughtAssetID:      assetIDs[1],
+		SellPrice: xdr.Price{
+			N: 1,
+			D: 3,
+		},
+		Trade: xdr.ClaimOfferAtom{
+			OfferId:      214515,
+			AmountSold:   7986,
+			AmountBought: 896,
+		},
+	}
+
+	second := first
+	second.BuyOfferExists = false
+	second.BuyOfferID = 89
+	second.Order = 2
+
+	third := InsertTrade{
+		HistoryOperationID: toid.New(ledger, 2, 1).ToInt64(),
+		Order:              1,
+		LedgerCloseTime:    time.Now().UTC(),
+		BuyOfferExists:     true,
+		BuyOfferID:         2,
+		SellerAccountID:    accountIDs[1],
+		BuyerAccountID:     accountIDs[0],
+		SoldAssetID:        assetIDs[2],
+		BoughtAssetID:      assetIDs[1],
+		SellPrice: xdr.Price{
+			N: 1156,
+			D: 3,
+		},
+		Trade: xdr.ClaimOfferAtom{
+			OfferId:      7,
+			AmountSold:   123,
+			AmountBought: 6,
+		},
+	}
+
+	return first, second, third
+}
+
+func createExpAccountsAndAssets(
+	tt *test.T, q *Q, accounts []string, assets []xdr.Asset,
+) ([]int64, []int64) {
+	addressToAccounts, err := q.CreateExpAccounts(accounts)
+	tt.Assert.NoError(err)
+
+	accountIDs := []int64{}
+	for _, account := range accounts {
+		accountIDs = append(accountIDs, addressToAccounts[account])
+	}
+
+	assetRows, err := q.CreateExpAssets(assets)
+	tt.Assert.NoError(err)
+
+	assetIDs := []int64{}
+	for _, row := range assetRows {
+		assetIDs = append(assetIDs, row.ID)
+	}
+
+	return accountIDs, assetIDs
+}
+
+func TestInsertExpTrade(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	accountIDs, assetIDs := createExpAccountsAndAssets(
+		tt, q,
+		[]string{
+			"GB2QIYT2IAUFMRXKLSLLPRECC6OCOGJMADSPTRK7TGNT2SFR2YGWDARD",
+			"GAXMF43TGZHW3QN3REOUA2U5PW5BTARXGGYJ3JIFHW3YT6QRKRL3CPPU",
+		},
+		[]xdr.Asset{eurAsset, usdAsset, nativeAsset},
+	)
+
+	first, second, third := createInsertTrades(accountIDs, assetIDs, 3)
+
+	builder := q.NewTradeBatchInsertBuilder(1)
+	tt.Assert.NoError(
+		builder.Add(first, second, third),
+	)
+	tt.Assert.NoError(builder.Exec())
+
+	var rows []tradeRow
+	err := q.Select(
+		&rows,
+		sq.Select("*").From("exp_history_trades").OrderBy("history_operation_id", "\"order\""),
+	)
+	tt.Assert.NoError(err)
+
+	expected := []tradeRow{
+		tradeRow{
+			HistoryOperationID: first.HistoryOperationID,
+			Order:              first.Order,
+			LedgerCloseTime:    first.LedgerCloseTime,
+			OfferID:            int64(first.Trade.OfferId),
+			BaseOfferID:        EncodeOfferId(uint64(first.Trade.OfferId), CoreOfferIDType),
+			BaseAccountID:      first.SellerAccountID,
+			BaseAssetID:        first.SoldAssetID,
+			BaseAmount:         first.Trade.AmountSold,
+			CounterOfferID:     first.BuyOfferID,
+			CounterAccountID:   first.BuyerAccountID,
+			CounterAssetID:     first.BoughtAssetID,
+			CounterAmount:      first.Trade.AmountBought,
+			BaseIsSeller:       true,
+			PriceN:             int(first.SellPrice.N),
+			PriceD:             int(first.SellPrice.D),
+		},
+		tradeRow{
+			HistoryOperationID: second.HistoryOperationID,
+			Order:              second.Order,
+			LedgerCloseTime:    second.LedgerCloseTime,
+			OfferID:            int64(second.Trade.OfferId),
+			BaseOfferID:        EncodeOfferId(uint64(second.Trade.OfferId), CoreOfferIDType),
+			BaseAccountID:      second.SellerAccountID,
+			BaseAssetID:        second.SoldAssetID,
+			BaseAmount:         second.Trade.AmountSold,
+			CounterOfferID:     EncodeOfferId(uint64(second.HistoryOperationID), TOIDType),
+			CounterAccountID:   second.BuyerAccountID,
+			CounterAssetID:     second.BoughtAssetID,
+			CounterAmount:      second.Trade.AmountBought,
+			BaseIsSeller:       true,
+			PriceN:             int(second.SellPrice.N),
+			PriceD:             int(second.SellPrice.D),
+		},
+		tradeRow{
+			HistoryOperationID: third.HistoryOperationID,
+			Order:              third.Order,
+			LedgerCloseTime:    third.LedgerCloseTime,
+			OfferID:            int64(third.Trade.OfferId),
+			BaseOfferID:        third.BuyOfferID,
+			BaseAccountID:      third.BuyerAccountID,
+			BaseAssetID:        third.BoughtAssetID,
+			BaseAmount:         third.Trade.AmountBought,
+			CounterOfferID:     EncodeOfferId(uint64(third.Trade.OfferId), CoreOfferIDType),
+			CounterAccountID:   third.SellerAccountID,
+			CounterAssetID:     third.SoldAssetID,
+			CounterAmount:      third.Trade.AmountSold,
+			BaseIsSeller:       false,
+			PriceN:             int(third.SellPrice.D),
+			PriceD:             int(third.SellPrice.N),
+		},
+	}
+	tt.Assert.Len(rows, len(expected))
+
+	for i := 0; i < len(rows); i++ {
+		tt.Assert.Equal(expected[i].LedgerCloseTime.Unix(), rows[i].LedgerCloseTime.Unix())
+		rows[i].LedgerCloseTime = expected[i].LedgerCloseTime
+		tt.Assert.Equal(
+			expected[i],
+			rows[i],
+		)
+	}
+}
+
+func createTradeRows(
+	tt *test.T, q *Q,
+	idToAccount map[int64]xdr.AccountId,
+	idToAsset map[int64]xdr.Asset,
+	entries ...InsertTrade,
+) {
+	for _, entry := range entries {
+		entry.Trade.SellerId = idToAccount[entry.SellerAccountID]
+		entry.Trade.AssetSold = idToAsset[entry.SoldAssetID]
+		entry.Trade.AssetBought = idToAsset[entry.BoughtAssetID]
+
+		err := q.InsertTrade(
+			entry.HistoryOperationID,
+			entry.Order,
+			idToAccount[entry.BuyerAccountID],
+			entry.BuyOfferExists,
+			xdr.OfferEntry{OfferId: xdr.Int64(entry.BuyOfferID)},
+			entry.Trade,
+			entry.SellPrice,
+			supportTime.MillisFromSeconds(entry.LedgerCloseTime.Unix()),
+		)
+		tt.Assert.NoError(err)
+	}
+}
+
+func TestCheckExpTrades(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	sequence := int32(56)
+	valid, err := q.CheckExpTrades(sequence)
+	tt.Assert.NoError(err)
+	tt.Assert.True(valid)
+
+	addresses := []string{
+		"GB2QIYT2IAUFMRXKLSLLPRECC6OCOGJMADSPTRK7TGNT2SFR2YGWDARD",
+		"GAXMF43TGZHW3QN3REOUA2U5PW5BTARXGGYJ3JIFHW3YT6QRKRL3CPPU",
+	}
+	assets := []xdr.Asset{
+		xdr.MustNewCreditAsset("CHF", issuer.Address()),
+		eurAsset, usdAsset, nativeAsset,
+		xdr.MustNewCreditAsset("BTC", issuer.Address()),
+	}
+
+	expAccountIDs, expAssetIDs := createExpAccountsAndAssets(
+		tt, q,
+		addresses,
+		assets,
+	)
+
+	chfAssetID, btcAssetID := expAssetIDs[0], expAssetIDs[4]
+	assets = assets[1:4]
+	expAssetIDs = expAssetIDs[1:4]
+
+	idToAccount := map[int64]xdr.AccountId{}
+	for i, id := range expAccountIDs {
+		idToAccount[id] = xdr.MustAddress(addresses[i])
+	}
+	idToAsset := map[int64]xdr.Asset{}
+	for i, id := range expAssetIDs {
+		idToAsset[id] = assets[i]
+	}
+
+	first, second, third := createInsertTrades(
+		expAccountIDs, expAssetIDs, sequence,
+	)
+
+	builder := q.NewTradeBatchInsertBuilder(1)
+	tt.Assert.NoError(
+		builder.Add(first, second, third),
+	)
+	tt.Assert.NoError(builder.Exec())
+
+	valid, err = q.CheckExpTrades(sequence)
+	tt.Assert.NoError(err)
+	tt.Assert.True(valid)
+
+	// create different asset id ordering in history_assets compared to exp_history_assets
+	_, err = q.GetCreateAssetID(assets[1])
+	tt.Assert.NoError(err)
+	_, err = q.GetCreateAssetID(assets[0])
+	tt.Assert.NoError(err)
+	_, err = q.GetCreateAssetID(assets[2])
+	tt.Assert.NoError(err)
+	createTradeRows(
+		tt, q, idToAccount, idToAsset, first, second, third,
+	)
+
+	valid, err = q.CheckExpTrades(sequence)
+	tt.Assert.NoError(err)
+	tt.Assert.True(valid)
+
+	tradeForOtherLedger, _, _ := createInsertTrades(
+		expAccountIDs, expAssetIDs, sequence+1,
+	)
+	tt.Assert.NoError(
+		builder.Add(tradeForOtherLedger),
+	)
+	tt.Assert.NoError(builder.Exec())
+
+	valid, err = q.CheckExpTrades(sequence)
+	tt.Assert.NoError(err)
+	tt.Assert.True(valid)
+
+	newAddress := "GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY"
+	newAccounts, err := q.CreateExpAccounts([]string{newAddress})
+	tt.Assert.NoError(err)
+	newAccountID := newAccounts[newAddress]
+
+	for fieldName, value := range map[string]interface{}{
+		"ledger_closed_at":   time.Now().Add(time.Hour),
+		"offer_id":           67,
+		"base_offer_id":      67,
+		"base_account_id":    newAccountID,
+		"base_asset_id":      chfAssetID,
+		"base_amount":        67,
+		"counter_offer_id":   67,
+		"counter_account_id": newAccountID,
+		"counter_asset_id":   btcAssetID,
+		"counter_amount":     67,
+		"base_is_seller":     second.SoldAssetID >= second.BoughtAssetID,
+		"price_n":            67,
+		"price_d":            67,
+	} {
+		updateSQL := sq.Update("exp_history_trades").
+			Set(fieldName, value).
+			Where(
+				"history_operation_id = ? AND \"order\" = ?",
+				second.HistoryOperationID, second.Order,
+			)
+		_, err = q.Exec(updateSQL)
+		tt.Assert.NoError(err)
+
+		valid, err = q.CheckExpTrades(sequence)
+		tt.Assert.NoError(err)
+		tt.Assert.False(valid)
+
+		_, err = q.Exec(sq.Delete("exp_history_trades").
+			Where(
+				"history_operation_id = ? AND \"order\" = ?",
+				second.HistoryOperationID, second.Order,
+			))
+		tt.Assert.NoError(err)
+
+		tt.Assert.NoError(
+			builder.Add(second),
+		)
+		tt.Assert.NoError(builder.Exec())
+
+		valid, err := q.CheckExpTrades(sequence)
+		tt.Assert.NoError(err)
+		tt.Assert.True(valid)
+	}
 }

--- a/services/horizon/internal/db2/history/trade_test.go
+++ b/services/horizon/internal/db2/history/trade_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
+	"github.com/guregu/null"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/services/horizon/internal/toid"
@@ -71,24 +72,6 @@ func TestTradeQueries(t *testing.T) {
 	tt.Assert.Equal(xdr.Int64(1000000000), trades[0].BaseAmount)
 	tt.Assert.Equal(xdr.Int64(2000000000), trades[0].CounterAmount)
 	tt.Assert.Equal(false, trades[0].BaseIsSeller)
-}
-
-type tradeRow struct {
-	HistoryOperationID int64     `db:"history_operation_id"`
-	Order              int32     `db:"order"`
-	LedgerCloseTime    time.Time `db:"ledger_closed_at"`
-	OfferID            int64     `db:"offer_id"`
-	BaseOfferID        int64     `db:"base_offer_id"`
-	BaseAccountID      int64     `db:"base_account_id"`
-	BaseAssetID        int64     `db:"base_asset_id"`
-	BaseAmount         xdr.Int64 `db:"base_amount"`
-	CounterOfferID     int64     `db:"counter_offer_id"`
-	CounterAccountID   int64     `db:"counter_account_id"`
-	CounterAssetID     int64     `db:"counter_asset_id"`
-	CounterAmount      xdr.Int64 `db:"counter_amount"`
-	BaseIsSeller       bool      `db:"base_is_seller"`
-	PriceN             int       `db:"price_n"`
-	PriceD             int       `db:"price_d"`
 }
 
 func createInsertTrades(
@@ -166,19 +149,46 @@ func createExpAccountsAndAssets(
 	return accountIDs, assetIDs
 }
 
+func newInt64(v int64) *int64 {
+	p := new(int64)
+	*p = v
+	return p
+}
+
+func buildIDtoAccountMapping(addresses []string, ids []int64) map[int64]xdr.AccountId {
+	idToAccount := map[int64]xdr.AccountId{}
+	for i, id := range ids {
+		account := xdr.MustAddress(addresses[i])
+		idToAccount[id] = account
+	}
+
+	return idToAccount
+}
+
+func buildIDtoAssetMapping(assets []xdr.Asset, ids []int64) map[int64]xdr.Asset {
+	idToAsset := map[int64]xdr.Asset{}
+	for i, id := range ids {
+		idToAsset[id] = assets[i]
+	}
+
+	return idToAsset
+}
+
 func TestInsertExpTrade(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
+	addresses := []string{
+		"GB2QIYT2IAUFMRXKLSLLPRECC6OCOGJMADSPTRK7TGNT2SFR2YGWDARD",
+		"GAXMF43TGZHW3QN3REOUA2U5PW5BTARXGGYJ3JIFHW3YT6QRKRL3CPPU",
+	}
+	assets := []xdr.Asset{eurAsset, usdAsset, nativeAsset}
 	accountIDs, assetIDs := createExpAccountsAndAssets(
 		tt, q,
-		[]string{
-			"GB2QIYT2IAUFMRXKLSLLPRECC6OCOGJMADSPTRK7TGNT2SFR2YGWDARD",
-			"GAXMF43TGZHW3QN3REOUA2U5PW5BTARXGGYJ3JIFHW3YT6QRKRL3CPPU",
-		},
-		[]xdr.Asset{eurAsset, usdAsset, nativeAsset},
+		addresses,
+		assets,
 	)
 
 	first, second, third := createInsertTrades(accountIDs, assetIDs, 3)
@@ -189,64 +199,108 @@ func TestInsertExpTrade(t *testing.T) {
 	)
 	tt.Assert.NoError(builder.Exec())
 
-	var rows []tradeRow
-	err := q.Select(
-		&rows,
-		sq.Select("*").From("exp_history_trades").OrderBy("history_operation_id", "\"order\""),
-	)
-	tt.Assert.NoError(err)
+	var rows []Trade
+	tt.Assert.NoError(q.expTrades().Select(&rows))
 
-	expected := []tradeRow{
-		tradeRow{
+	idToAccount := buildIDtoAccountMapping(addresses, accountIDs)
+	idToAsset := buildIDtoAssetMapping(assets, assetIDs)
+
+	firstSellerAccount := idToAccount[first.SellerAccountID]
+	firstBuyerAccount := idToAccount[first.BuyerAccountID]
+	var firstSoldAssetType, firstSoldAssetCode, firstSoldAssetIssuer string
+	idToAsset[first.SoldAssetID].MustExtract(
+		&firstSoldAssetType, &firstSoldAssetCode, &firstSoldAssetIssuer,
+	)
+	var firstBoughtAssetType, firstBoughtAssetCode, firstBoughtAssetIssuer string
+	idToAsset[first.BoughtAssetID].MustExtract(
+		&firstBoughtAssetType, &firstBoughtAssetCode, &firstBoughtAssetIssuer,
+	)
+
+	secondSellerAccount := idToAccount[second.SellerAccountID]
+	secondBuyerAccount := idToAccount[second.BuyerAccountID]
+	var secondSoldAssetType, secondSoldAssetCode, secondSoldAssetIssuer string
+	idToAsset[second.SoldAssetID].MustExtract(
+		&secondSoldAssetType, &secondSoldAssetCode, &secondSoldAssetIssuer,
+	)
+	var secondBoughtAssetType, secondBoughtAssetCode, secondBoughtAssetIssuer string
+	idToAsset[second.BoughtAssetID].MustExtract(
+		&secondBoughtAssetType, &secondBoughtAssetCode, &secondBoughtAssetIssuer,
+	)
+
+	thirdSellerAccount := idToAccount[third.SellerAccountID]
+	thirdBuyerAccount := idToAccount[third.BuyerAccountID]
+	var thirdSoldAssetType, thirdSoldAssetCode, thirdSoldAssetIssuer string
+	idToAsset[third.SoldAssetID].MustExtract(
+		&thirdSoldAssetType, &thirdSoldAssetCode, &thirdSoldAssetIssuer,
+	)
+	var thirdBoughtAssetType, thirdBoughtAssetCode, thirdBoughtAssetIssuer string
+	idToAsset[third.BoughtAssetID].MustExtract(
+		&thirdBoughtAssetType, &thirdBoughtAssetCode, &thirdBoughtAssetIssuer,
+	)
+
+	expected := []Trade{
+		Trade{
 			HistoryOperationID: first.HistoryOperationID,
 			Order:              first.Order,
 			LedgerCloseTime:    first.LedgerCloseTime,
 			OfferID:            int64(first.Trade.OfferId),
-			BaseOfferID:        EncodeOfferId(uint64(first.Trade.OfferId), CoreOfferIDType),
-			BaseAccountID:      first.SellerAccountID,
-			BaseAssetID:        first.SoldAssetID,
+			BaseOfferID:        newInt64(EncodeOfferId(uint64(first.Trade.OfferId), CoreOfferIDType)),
+			BaseAccount:        firstSellerAccount.Address(),
+			BaseAssetType:      firstSoldAssetType,
+			BaseAssetIssuer:    firstSoldAssetIssuer,
+			BaseAssetCode:      firstSoldAssetCode,
 			BaseAmount:         first.Trade.AmountSold,
-			CounterOfferID:     first.BuyOfferID,
-			CounterAccountID:   first.BuyerAccountID,
-			CounterAssetID:     first.BoughtAssetID,
+			CounterOfferID:     newInt64(first.BuyOfferID),
+			CounterAccount:     firstBuyerAccount.Address(),
+			CounterAssetType:   firstBoughtAssetType,
+			CounterAssetIssuer: firstBoughtAssetIssuer,
+			CounterAssetCode:   firstBoughtAssetCode,
 			CounterAmount:      first.Trade.AmountBought,
 			BaseIsSeller:       true,
-			PriceN:             int(first.SellPrice.N),
-			PriceD:             int(first.SellPrice.D),
+			PriceN:             null.NewInt(int64(first.SellPrice.N), true),
+			PriceD:             null.NewInt(int64(first.SellPrice.D), true),
 		},
-		tradeRow{
+		Trade{
 			HistoryOperationID: second.HistoryOperationID,
 			Order:              second.Order,
 			LedgerCloseTime:    second.LedgerCloseTime,
 			OfferID:            int64(second.Trade.OfferId),
-			BaseOfferID:        EncodeOfferId(uint64(second.Trade.OfferId), CoreOfferIDType),
-			BaseAccountID:      second.SellerAccountID,
-			BaseAssetID:        second.SoldAssetID,
+			BaseOfferID:        newInt64(EncodeOfferId(uint64(second.Trade.OfferId), CoreOfferIDType)),
+			BaseAccount:        secondSellerAccount.Address(),
+			BaseAssetType:      secondSoldAssetType,
+			BaseAssetIssuer:    secondSoldAssetIssuer,
+			BaseAssetCode:      secondSoldAssetCode,
 			BaseAmount:         second.Trade.AmountSold,
-			CounterOfferID:     EncodeOfferId(uint64(second.HistoryOperationID), TOIDType),
-			CounterAccountID:   second.BuyerAccountID,
-			CounterAssetID:     second.BoughtAssetID,
+			CounterOfferID:     newInt64(EncodeOfferId(uint64(second.HistoryOperationID), TOIDType)),
+			CounterAccount:     secondBuyerAccount.Address(),
+			CounterAssetType:   secondBoughtAssetType,
+			CounterAssetCode:   secondBoughtAssetCode,
+			CounterAssetIssuer: secondBoughtAssetIssuer,
 			CounterAmount:      second.Trade.AmountBought,
 			BaseIsSeller:       true,
-			PriceN:             int(second.SellPrice.N),
-			PriceD:             int(second.SellPrice.D),
+			PriceN:             null.NewInt(int64(second.SellPrice.N), true),
+			PriceD:             null.NewInt(int64(second.SellPrice.D), true),
 		},
-		tradeRow{
+		Trade{
 			HistoryOperationID: third.HistoryOperationID,
 			Order:              third.Order,
 			LedgerCloseTime:    third.LedgerCloseTime,
 			OfferID:            int64(third.Trade.OfferId),
-			BaseOfferID:        third.BuyOfferID,
-			BaseAccountID:      third.BuyerAccountID,
-			BaseAssetID:        third.BoughtAssetID,
+			BaseOfferID:        newInt64(third.BuyOfferID),
+			BaseAccount:        thirdBuyerAccount.Address(),
+			BaseAssetType:      thirdBoughtAssetType,
+			BaseAssetCode:      thirdBoughtAssetCode,
+			BaseAssetIssuer:    thirdBoughtAssetIssuer,
 			BaseAmount:         third.Trade.AmountBought,
-			CounterOfferID:     EncodeOfferId(uint64(third.Trade.OfferId), CoreOfferIDType),
-			CounterAccountID:   third.SellerAccountID,
-			CounterAssetID:     third.SoldAssetID,
+			CounterOfferID:     newInt64(EncodeOfferId(uint64(third.Trade.OfferId), CoreOfferIDType)),
+			CounterAccount:     thirdSellerAccount.Address(),
+			CounterAssetType:   thirdSoldAssetType,
+			CounterAssetCode:   thirdSoldAssetCode,
+			CounterAssetIssuer: thirdSoldAssetIssuer,
 			CounterAmount:      third.Trade.AmountSold,
 			BaseIsSeller:       false,
-			PriceN:             int(third.SellPrice.D),
-			PriceD:             int(third.SellPrice.N),
+			PriceN:             null.NewInt(int64(third.SellPrice.D), true),
+			PriceD:             null.NewInt(int64(third.SellPrice.N), true),
 		},
 	}
 	tt.Assert.Len(rows, len(expected))
@@ -317,14 +371,8 @@ func TestCheckExpTrades(t *testing.T) {
 	assets = assets[1:4]
 	expAssetIDs = expAssetIDs[1:4]
 
-	idToAccount := map[int64]xdr.AccountId{}
-	for i, id := range expAccountIDs {
-		idToAccount[id] = xdr.MustAddress(addresses[i])
-	}
-	idToAsset := map[int64]xdr.Asset{}
-	for i, id := range expAssetIDs {
-		idToAsset[id] = assets[i]
-	}
+	idToAccount := buildIDtoAccountMapping(addresses, expAccountIDs)
+	idToAsset := buildIDtoAssetMapping(assets, expAssetIDs)
 
 	first, second, third := createInsertTrades(
 		expAccountIDs, expAssetIDs, sequence,

--- a/services/horizon/internal/db2/schema/bindata.go
+++ b/services/horizon/internal/db2/schema/bindata.go
@@ -22,6 +22,7 @@
 // migrations/28_exp_history_operations.sql (439B)
 // migrations/29_exp_history_assets.sql (206B)
 // migrations/2_index_participants_by_toid.sql (277B)
+// migrations/30_exp_history_trades.sql (2.297kB)
 // migrations/3_use_sequence_in_history_accounts.sql (447B)
 // migrations/4_add_protocol_version.sql (188B)
 // migrations/5_create_trades_table.sql (1.1kB)
@@ -513,7 +514,7 @@ func migrations29_exp_history_assetsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/29_exp_history_assets.sql", size: 206, mode: os.FileMode(0644), modTime: time.Unix(1578465135, 0)}
+	info := bindataFileInfo{name: "migrations/29_exp_history_assets.sql", size: 206, mode: os.FileMode(0644), modTime: time.Unix(1578477173, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x25, 0xdf, 0x37, 0x6, 0x2c, 0x6e, 0x52, 0x9b, 0x16, 0x17, 0x9c, 0x29, 0x41, 0x41, 0xa6, 0x14, 0x59, 0xff, 0x29, 0xfa, 0x12, 0x2a, 0x8d, 0xce, 0x42, 0xad, 0xa6, 0x26, 0xef, 0x6f, 0x27, 0x17}}
 	return a, nil
 }
@@ -535,6 +536,26 @@ func migrations2_index_participants_by_toidSql() (*asset, error) {
 
 	info := bindataFileInfo{name: "migrations/2_index_participants_by_toid.sql", size: 277, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xdd, 0x9f, 0x5c, 0xe6, 0xd0, 0x43, 0x82, 0xa3, 0x8d, 0xb3, 0x64, 0xb1, 0x2, 0x4b, 0xe1, 0x96, 0x3, 0x92, 0xb3, 0xea, 0x3c, 0x2e, 0xb2, 0xad, 0x47, 0xcd, 0x92, 0x4c, 0x6c, 0x5c, 0x46, 0xfd}}
+	return a, nil
+}
+
+var _migrations30_exp_history_tradesSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xac\x96\x41\x8f\xda\x3c\x10\x86\xef\xf9\x15\xa3\x3d\x81\x3e\xf8\xd4\x73\xb7\xad\xb4\x65\xd3\x16\x2d\x0a\x2d\x0b\x52\x6f\x96\x63\x0f\xc4\xda\x60\x47\xf6\x44\xec\xf6\xd7\x57\x4e\x1a\x36\x09\x86\x0d\x6a\x39\xce\x8c\x9f\x79\xfd\x7a\x1c\x33\x9d\xc2\x7f\x7b\xb5\xb3\x9c\x10\x36\x45\x14\x4d\xa7\x70\x40\x10\x5c\x6b\x43\x20\x2c\xfa\x38\x3e\x17\x2c\x53\x8e\x8c\x7d\x61\x64\xb9\x44\x07\xdc\xbd\xaf\x6a\x67\xab\xf8\x6e\x1d\xc3\xfa\xee\xf3\x22\x0e\xd5\x8d\x7c\x91\xff\x2d\xe6\x0f\x31\x74\x93\x4d\x4a\x69\x91\x97\x52\xe9\x1d\x48\xdc\xf2\x32\xa7\x40\x46\x18\xed\xc8\x72\xa5\x43\x49\xa5\x25\x3e\xd7\xbc\xf1\x6d\x25\x2b\x45\xc1\x4b\x87\x40\x19\xf6\x9a\x02\xf1\x34\x47\xc8\xb8\x03\x8b\x5b\xb4\xa8\x05\xb6\xe9\x40\xe6\xb8\x82\x0b\x61\x4a\x1f\xe3\x5a\xbe\x06\x9d\xc3\x5a\x84\x8f\x1e\x10\xa4\x01\xef\xd5\x81\x6b\xf2\x8b\x85\x29\x5e\x80\x32\xe3\x3a\xd8\xff\x41\x69\x47\xc8\xe5\xc4\x2f\x69\x6a\x5f\x15\x50\x86\x1e\xd9\x76\xb0\xd3\xbd\x93\xa8\x14\xd4\x1b\x71\x51\xf4\xf6\x11\x78\xb7\x9a\xa0\x29\xd0\x72\x52\x46\x33\x25\x21\x55\x3b\xa5\x09\x92\xe5\x1a\x92\xcd\x62\x31\xa9\x2a\x6f\x8c\x95\x68\x6f\x40\x69\xc2\x1d\xda\x5e\x36\x47\xb9\x43\xcb\x44\x6e\x1c\x4a\xc6\x09\x48\xed\xd1\x11\xdf\x17\x70\x50\x94\x99\xb2\x8e\xc0\x2f\xa3\xb1\xb7\xd4\x6c\xb7\x68\xcf\xb6\x4d\xb9\xc3\x66\xcf\x81\x22\x58\xc5\x5f\xe2\x55\x9c\xcc\xe2\xc7\xa0\x4b\x23\x25\xc7\x6d\x90\xf7\xe8\x1a\x4c\xe5\x69\x1f\xb2\xf7\xe8\xb0\xdc\xaa\x2b\xda\x7f\xa2\xf8\xc8\xfa\x4b\xd1\x47\xce\x05\xdd\xd5\xc6\x94\x63\x0e\xf3\x1c\x2d\xa4\xc6\xe4\xc8\x75\x9d\x2b\xac\x12\xc8\xf4\x9f\x85\xed\x98\xec\xc4\x2a\x46\xef\x34\xbb\x0a\x82\xc9\xd9\x32\x79\x5c\xaf\xee\xe6\xc9\x3a\x30\xa6\xac\xe5\x38\x13\x19\x8a\x27\x98\x7d\x8b\x67\x0f\x30\x1a\xb5\xcf\xe2\xd3\x47\x78\x37\x1e\x0f\xe1\x85\x18\x8d\xbf\x1f\x4e\x2c\x1f\xc8\xec\x18\xdc\x6b\xd1\x73\xbf\x56\x1a\xf9\x0f\x52\x73\x45\xe7\xc9\x7d\xfc\xb3\xe6\x92\x95\x2c\x7d\x61\xed\xa1\x87\x65\x12\xba\xbe\x9b\xc7\x79\xf2\x15\x52\xb2\x88\x30\xea\x5d\x12\x0f\xbf\xcc\xae\x0e\x62\x30\xb9\x39\xb6\x8b\xdc\xde\xe4\x0f\x81\x9f\x5e\x96\x41\x1d\x06\x8b\xef\x8f\xdd\x45\xfa\x60\xea\xdb\xb4\xa6\x6f\x6e\xcc\x53\x59\x5c\xe5\x44\x33\x77\x67\xd9\x05\x57\x96\xf9\x4f\xe9\x15\xf4\xce\x94\x4f\x4e\x86\x7c\x72\xf2\xf5\x6e\xb5\xdf\x24\xf3\x1f\x9b\x53\x15\x4a\x0e\x69\x1c\x7a\x5d\x26\xcd\x4b\x72\x7e\x8f\x57\x6e\x2f\xa4\xbe\xfd\xff\xe5\xde\x1c\x74\x14\xdd\xaf\x96\xdf\xcf\xbf\x86\x82\x3b\xc1\x25\xde\x46\xbf\x03\x00\x00\xff\xff\xd4\x84\xb9\x21\xf9\x08\x00\x00")
+
+func migrations30_exp_history_tradesSqlBytes() ([]byte, error) {
+	return bindataRead(
+		_migrations30_exp_history_tradesSql,
+		"migrations/30_exp_history_trades.sql",
+	)
+}
+
+func migrations30_exp_history_tradesSql() (*asset, error) {
+	bytes, err := migrations30_exp_history_tradesSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "migrations/30_exp_history_trades.sql", size: 2297, mode: os.FileMode(0644), modTime: time.Unix(1578567404, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xaf, 0x32, 0xe, 0xc2, 0x9, 0x37, 0x62, 0x5f, 0x79, 0xfe, 0x3e, 0x11, 0x22, 0x66, 0x56, 0x36, 0x8, 0x0, 0x76, 0x70, 0xc3, 0x5c, 0x16, 0xe3, 0x2b, 0x73, 0x57, 0xe8, 0x38, 0x6c, 0x62, 0x1e}}
 	return a, nil
 }
 
@@ -833,6 +854,8 @@ var _bindata = map[string]func() (*asset, error){
 
 	"migrations/2_index_participants_by_toid.sql": migrations2_index_participants_by_toidSql,
 
+	"migrations/30_exp_history_trades.sql": migrations30_exp_history_tradesSql,
+
 	"migrations/3_use_sequence_in_history_accounts.sql": migrations3_use_sequence_in_history_accountsSql,
 
 	"migrations/4_add_protocol_version.sql": migrations4_add_protocol_versionSql,
@@ -914,6 +937,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"28_exp_history_operations.sql":                &bintree{migrations28_exp_history_operationsSql, map[string]*bintree{}},
 		"29_exp_history_assets.sql":                    &bintree{migrations29_exp_history_assetsSql, map[string]*bintree{}},
 		"2_index_participants_by_toid.sql":             &bintree{migrations2_index_participants_by_toidSql, map[string]*bintree{}},
+		"30_exp_history_trades.sql":                    &bintree{migrations30_exp_history_tradesSql, map[string]*bintree{}},
 		"3_use_sequence_in_history_accounts.sql":       &bintree{migrations3_use_sequence_in_history_accountsSql, map[string]*bintree{}},
 		"4_add_protocol_version.sql":                   &bintree{migrations4_add_protocol_versionSql, map[string]*bintree{}},
 		"5_create_trades_table.sql":                    &bintree{migrations5_create_trades_tableSql, map[string]*bintree{}},

--- a/services/horizon/internal/db2/schema/migrations/30_exp_history_trades.sql
+++ b/services/horizon/internal/db2/schema/migrations/30_exp_history_trades.sql
@@ -1,0 +1,58 @@
+-- +migrate Up
+
+-- we cannot create exp_history_trades as:
+
+-- CREATE TABLE exp_history_trades (
+--     LIKE history_trades
+--     including defaults
+--     including constraints
+--     including indexes
+-- );
+
+-- because the history_trades table has reference constraints to history_accounts and history_assets
+-- and we do not want to copy those constraints. instead, we want to reference the
+-- exp_history_accounts and exp_history_assets tables
+
+CREATE TABLE exp_history_trades (
+    history_operation_id bigint NOT NULL,
+    "order" integer NOT NULL,
+    ledger_closed_at timestamp without time zone NOT NULL,
+    offer_id bigint NOT NULL,
+    base_account_id bigint NOT NULL REFERENCES exp_history_accounts(id),
+    base_asset_id bigint NOT NULL REFERENCES exp_history_assets(id),
+    base_amount bigint NOT NULL,
+    counter_account_id bigint NOT NULL REFERENCES exp_history_accounts(id),
+    counter_asset_id bigint NOT NULL REFERENCES exp_history_assets(id),
+    counter_amount bigint NOT NULL,
+    base_is_seller boolean,
+    price_n bigint,
+    price_d bigint,
+    base_offer_id bigint,
+    counter_offer_id bigint,
+    CONSTRAINT exp_history_trades_base_amount_check CHECK ((base_amount >= 0)),
+    CONSTRAINT exp_history_trades_check CHECK ((base_asset_id < counter_asset_id)),
+    CONSTRAINT exp_history_trades_counter_amount_check CHECK ((counter_amount >= 0))
+);
+
+
+CREATE INDEX exp_htrd_by_base_account ON exp_history_trades USING btree (base_account_id);
+
+CREATE INDEX exp_htrd_by_base_offer ON exp_history_trades USING btree (base_offer_id);
+
+CREATE INDEX exp_htrd_by_counter_account ON exp_history_trades USING btree (counter_account_id);
+
+CREATE INDEX exp_htrd_by_counter_offer ON exp_history_trades USING btree (counter_offer_id);
+
+CREATE INDEX exp_htrd_by_offer ON exp_history_trades USING btree (offer_id);
+
+CREATE INDEX exp_htrd_counter_lookup ON exp_history_trades USING btree (counter_asset_id);
+
+CREATE INDEX exp_htrd_pair_time_lookup ON exp_history_trades USING btree (base_asset_id, counter_asset_id, ledger_closed_at);
+
+CREATE UNIQUE INDEX exp_htrd_pid ON exp_history_trades USING btree (history_operation_id, "order");
+
+CREATE INDEX exp_htrd_time_lookup ON exp_history_trades USING btree (ledger_closed_at);
+
+-- +migrate Down
+
+DROP TABLE exp_history_trades cascade;

--- a/services/horizon/internal/expingest/pipeline_hooks_test.go
+++ b/services/horizon/internal/expingest/pipeline_hooks_test.go
@@ -48,7 +48,7 @@ func (s *PreProcessingHookTestSuite) TestStateHookSucceedsWithPreExistingTx() {
 	s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("RemoveExpIngestHistory", s.ledgerSeqFromContext).Return(
-		history.ExpIngestRemovalSummary{3, 3, 3, 3, 3}, nil,
+		history.ExpIngestRemovalSummary{3, 3, 3, 3, 3, 3}, nil,
 	)
 
 	newCtx, err := preProcessingHook(s.ctx, statePipeline, s.system, s.historyQ)
@@ -63,7 +63,7 @@ func (s *PreProcessingHookTestSuite) TestStateHookSucceedsWithoutPreExistingTx()
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("RemoveExpIngestHistory", s.ledgerSeqFromContext).Return(
-		history.ExpIngestRemovalSummary{3, 3, 3, 3, 3}, nil,
+		history.ExpIngestRemovalSummary{3, 3, 3, 3, 3, 3}, nil,
 	)
 
 	newCtx, err := preProcessingHook(s.ctx, statePipeline, s.system, s.historyQ)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add a migration for the `exp_history_trades` table. Also add functions to insert and query the table. These functions will be used by the trades ingestion processor.

### Why

The trades processor in the experimental ingestion system will populate a new history trades table (following the same pattern we've used ledgers, transactions, and operations). The trades processor will use `TradeBatchInsertBuilder` to insert rows in the `exp_history_trades` table. The processor will use `CheckExpTrades()` to compare rows in `exp_history_trades` against rows in `history_trades` (populated by the legacy ingestion system).

### Known limitations

[N/A]
