### PR TITLE
exp/ingest/io: Add support for ingesting txmeta v2

### DIFF
--- a/exp/ingest/io/ledger_transaction.go
+++ b/exp/ingest/io/ledger_transaction.go
@@ -182,8 +182,22 @@ func (t *LedgerTransaction) GetChanges() []Change {
 			)
 			changes = append(changes, opChanges...)
 		}
+	case 2:
+		v2Meta := t.Meta.MustV2()
+		txChangesBefore := getChangesFromLedgerEntryChanges(v2Meta.TxChangesBefore)
+		changes = append(changes, txChangesBefore...)
+
+		for _, operationMeta := range v2Meta.Operations {
+			opChanges := getChangesFromLedgerEntryChanges(
+				operationMeta.Changes,
+			)
+			changes = append(changes, opChanges...)
+		}
+
+		txChangesAfter := getChangesFromLedgerEntryChanges(v2Meta.TxChangesAfter)
+		changes = append(changes, txChangesAfter...)
 	default:
-		panic("Unkown TransactionMeta version")
+		panic("Unsupported TransactionMeta version")
 	}
 
 	return changes

--- a/exp/ingest/io/ledger_transaction_test.go
+++ b/exp/ingest/io/ledger_transaction_test.go
@@ -89,6 +89,148 @@ func TestFeeAndMetaChangesSeparate(t *testing.T) {
 	assert.Equal(t, metaChanges[0].Post.Data.MustAccount().Balance, xdr.Int64(400))
 }
 
+func TestMetaV2Order(t *testing.T) {
+	tx := LedgerTransaction{
+		Meta: xdr.TransactionMeta{
+			V: 2,
+			V2: &xdr.TransactionMetaV2{
+				TxChangesBefore: xdr.LedgerEntryChanges{
+					xdr.LedgerEntryChange{
+						Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+						State: &xdr.LedgerEntry{
+							Data: xdr.LedgerEntryData{
+								Type: xdr.LedgerEntryTypeAccount,
+								Account: &xdr.AccountEntry{
+									AccountId: xdr.MustAddress("GACMZD5VJXTRLKVET72CETCYKELPNCOTTBDC6DHFEUPLG5DHEK534JQX"),
+									Balance:   100,
+								},
+							},
+						},
+					},
+					xdr.LedgerEntryChange{
+						Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
+						Updated: &xdr.LedgerEntry{
+							Data: xdr.LedgerEntryData{
+								Type: xdr.LedgerEntryTypeAccount,
+								Account: &xdr.AccountEntry{
+									AccountId: xdr.MustAddress("GACMZD5VJXTRLKVET72CETCYKELPNCOTTBDC6DHFEUPLG5DHEK534JQX"),
+									Balance:   200,
+								},
+							},
+						},
+					},
+					xdr.LedgerEntryChange{
+						Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+						State: &xdr.LedgerEntry{
+							Data: xdr.LedgerEntryData{
+								Type: xdr.LedgerEntryTypeAccount,
+								Account: &xdr.AccountEntry{
+									AccountId: xdr.MustAddress("GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A"),
+									Balance:   100,
+								},
+							},
+						},
+					},
+					xdr.LedgerEntryChange{
+						Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
+						Updated: &xdr.LedgerEntry{
+							Data: xdr.LedgerEntryData{
+								Type: xdr.LedgerEntryTypeAccount,
+								Account: &xdr.AccountEntry{
+									AccountId: xdr.MustAddress("GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A"),
+									Balance:   200,
+								},
+							},
+						},
+					},
+				},
+				Operations: []xdr.OperationMeta{
+					{
+						Changes: xdr.LedgerEntryChanges{
+							xdr.LedgerEntryChange{
+								Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+								State: &xdr.LedgerEntry{
+									Data: xdr.LedgerEntryData{
+										Type: xdr.LedgerEntryTypeAccount,
+										Account: &xdr.AccountEntry{
+											AccountId: xdr.MustAddress("GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A"),
+											Balance:   300,
+										},
+									},
+								},
+							},
+							xdr.LedgerEntryChange{
+								Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
+								Updated: &xdr.LedgerEntry{
+									Data: xdr.LedgerEntryData{
+										Type: xdr.LedgerEntryTypeAccount,
+										Account: &xdr.AccountEntry{
+											AccountId: xdr.MustAddress("GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A"),
+											Balance:   400,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				TxChangesAfter: xdr.LedgerEntryChanges{
+					xdr.LedgerEntryChange{
+						Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+						State: &xdr.LedgerEntry{
+							Data: xdr.LedgerEntryData{
+								Type: xdr.LedgerEntryTypeAccount,
+								Account: &xdr.AccountEntry{
+									AccountId: xdr.MustAddress("GACMZD5VJXTRLKVET72CETCYKELPNCOTTBDC6DHFEUPLG5DHEK534JQX"),
+									Balance:   300,
+								},
+							},
+						},
+					},
+					xdr.LedgerEntryChange{
+						Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
+						Updated: &xdr.LedgerEntry{
+							Data: xdr.LedgerEntryData{
+								Type: xdr.LedgerEntryTypeAccount,
+								Account: &xdr.AccountEntry{
+									AccountId: xdr.MustAddress("GACMZD5VJXTRLKVET72CETCYKELPNCOTTBDC6DHFEUPLG5DHEK534JQX"),
+									Balance:   400,
+								},
+							},
+						},
+					},
+				},
+			},
+		}}
+
+	metaChanges := tx.GetChanges()
+	assert.Len(t, metaChanges, 4)
+
+	change := metaChanges[0]
+	id := change.Pre.Data.MustAccount().AccountId
+	assert.Equal(t, id.Address(), "GACMZD5VJXTRLKVET72CETCYKELPNCOTTBDC6DHFEUPLG5DHEK534JQX")
+	assert.Equal(t, change.Pre.Data.MustAccount().Balance, xdr.Int64(100))
+	assert.Equal(t, change.Post.Data.MustAccount().Balance, xdr.Int64(200))
+
+	change = metaChanges[1]
+	id = change.Pre.Data.MustAccount().AccountId
+	assert.Equal(t, id.Address(), "GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A")
+	assert.Equal(t, change.Pre.Data.MustAccount().Balance, xdr.Int64(100))
+	assert.Equal(t, change.Post.Data.MustAccount().Balance, xdr.Int64(200))
+
+	change = metaChanges[2]
+	id = change.Pre.Data.MustAccount().AccountId
+	assert.Equal(t, id.Address(), "GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A")
+	assert.Equal(t, change.Pre.Data.MustAccount().Balance, xdr.Int64(300))
+	assert.Equal(t, change.Post.Data.MustAccount().Balance, xdr.Int64(400))
+
+	change = metaChanges[3]
+	id = change.Pre.Data.MustAccount().AccountId
+	assert.Equal(t, id.Address(), "GACMZD5VJXTRLKVET72CETCYKELPNCOTTBDC6DHFEUPLG5DHEK534JQX")
+	assert.Equal(t, change.Pre.Data.MustAccount().Balance, xdr.Int64(300))
+	assert.Equal(t, change.Post.Data.MustAccount().Balance, xdr.Int64(400))
+}
+
 func TestChangeAccountChangedExceptSignersLastModifiedLedgerSeq(t *testing.T) {
 	change := Change{
 		Type: xdr.LedgerEntryTypeAccount,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit adds support for ingesting `TransactionMeta` when `V=2` and updates XDR files.

Close #1902.

### Why

As explained by @MonsieurNicolas in #1902.

> There is some missing meta in protocol version older than version 10. This impacts transactions with one time signers (that get removed after operations in v9 and earlier; and during signature verification in v10 and later). Those changes are invisible in the meta which may confuse certain ingestion processors that keep track of signers on accounts.

### Known limitations

It's possible that users will use stellar-core without `SUPPORTED_META_VERSION=2` and in such case ingestion system can process meta incorrectly. I think we should check the protocol version of the ledger in `DatabaseBackend.GetLedger` and if it's <10 it should check if txmeta version is equal 2. Otherwise it should return error. Tracked in #2095.