### PR TITLE
exp/ingest: RangeSession return error when ledger not found

### DIFF
--- a/exp/ingest/main.go
+++ b/exp/ingest/main.go
@@ -51,6 +51,8 @@ type LiveSession struct {
 // RangeSession runs ingestion between `FromLedger` and `ToLedger` ledgers
 // (inclusive).
 // It does not update cursors in stellar-core.
+// It assumes ledgers within the range exist in LedgerBackend. If ledger is not
+// found an error will be returned.
 type RangeSession struct {
 	standardSession
 

--- a/exp/ingest/range_session.go
+++ b/exp/ingest/range_session.go
@@ -146,30 +146,7 @@ func (s *RangeSession) resume(ledgerSequence uint32, ledgerAdapter *adapters.Led
 	for {
 		ledgerReader, err := ledgerAdapter.GetLedger(ledgerSequence)
 		if err != nil {
-			if err == io.ErrNotFound {
-				// Ensure that there are no gaps. This is "just in case". There shouldn't
-				// be any gaps if CURSOR in core is updated and core version is v11.2.0+.
-				var latestLedger uint32
-				latestLedger, err = ledgerAdapter.GetLatestLedgerSequence()
-				if err != nil {
-					return err
-				}
-
-				if latestLedger > ledgerSequence {
-					return errors.Errorf("Gap detected (ledger %d does not exist but %d is latest)", ledgerSequence, latestLedger)
-				}
-
-				select {
-				case <-s.standardSession.shutdown:
-					return nil
-				case <-time.After(time.Second):
-					// TODO make the idle time smaller
-				}
-
-				continue
-			}
-
-			return errors.Wrap(err, "Error getting ledger")
+			return errors.Wrap(err, fmt.Sprintf("Error getting ledger %d", ledgerSequence))
 		}
 
 		if s.LedgerReporter != nil {


### PR DESCRIPTION
### What

This commit changes `RangeSession` to return error when ledger not found.

### Why

Contrary to `LiveSession` that needs to wait for next ledger closed by the network `RangeSession` assumes that all ledgers within a range exist. Instead of waiting it should just return error if ledger is not found.