### PR TITLE
exp/ingest/ledgerbackend: Ensure tx meta is v2 when getting protocol version <10 ledgers

### DIFF
--- a/exp/ingest/ledgerbackend/database_backend.go
+++ b/exp/ingest/ledgerbackend/database_backend.go
@@ -98,6 +98,12 @@ func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, LedgerCloseMeta, e
 		lcm.TransactionEnvelope = append(lcm.TransactionEnvelope, tx.TXBody)
 		lcm.TransactionResult = append(lcm.TransactionResult, tx.TXResult)
 		lcm.TransactionMeta = append(lcm.TransactionMeta, tx.TXMeta)
+
+		if lcm.LedgerHeader.Header.LedgerVersion < 10 && tx.TXMeta.V != 2 {
+			return false, lcm,
+				errors.New("TransactionMeta.V=2 is required in protocol version older than version 10. " +
+					"Please process ledgers again using stellar-core with SUPPORTED_META_VERSION=2 in the config file.")
+		}
 	}
 
 	// Query - txfeehistory


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit adds a code that checks if tx meta version is v2 for protocol version <10 ledgers.

Close #2095.

### Why

As explained by @MonsieurNicolas in #1902:
> There is some missing meta in protocol version older than version 10. This impacts transactions with one time signers (that get removed after operations in v9 and earlier; and during signature verification in v10 and later). Those changes are invisible in the meta which may confuse certain ingestion processors that keep track of signers on accounts.

It's possible that users will use stellar-core without `SUPPORTED_META_VERSION=2` and in such case ingestion system can process state changes incorrectly.

### Known limitations

I realized we don't have tests in `exp/ingest/ledgerbackend`. Would be great to add them in a separate PR.
