### PR TITLE
services/horizon/internal/expingest: Add Trades processor

### DIFF
--- a/services/horizon/internal/db2/history/asset_test.go
+++ b/services/horizon/internal/db2/history/asset_test.go
@@ -18,13 +18,13 @@ func TestCreateExpAssetIDs(t *testing.T) {
 	assets := []xdr.Asset{
 		nativeAsset, eurAsset,
 	}
-	rows, err := q.CreateExpAssets(assets)
+	assetMap, err := q.CreateExpAssets(assets)
 	tt.Assert.NoError(err)
-	tt.Assert.Len(rows, len(assets))
+	tt.Assert.Len(assetMap, len(assets))
 
 	set := map[int64]bool{}
-	for i, asset := range assets {
-		row := rows[i]
+	for _, asset := range assets {
+		row := assetMap[asset.String()]
 
 		tt.Assert.False(set[row.ID])
 		set[row.ID] = true
@@ -38,15 +38,15 @@ func TestCreateExpAssetIDs(t *testing.T) {
 	}
 
 	// CreateExpAssets handles duplicates
-	rows, err = q.CreateExpAssets([]xdr.Asset{
+	assetMap, err = q.CreateExpAssets([]xdr.Asset{
 		nativeAsset, nativeAsset, eurAsset, eurAsset,
 		nativeAsset, nativeAsset, eurAsset, eurAsset,
 	})
 	tt.Assert.NoError(err)
-	tt.Assert.Len(rows, 8)
+	tt.Assert.Len(assetMap, len(assets))
 
-	for i, row := range rows {
-		asset := assets[(i/2)%2]
+	for _, asset := range assets {
+		row := assetMap[asset.String()]
 
 		tt.Assert.True(set[row.ID])
 
@@ -60,15 +60,15 @@ func TestCreateExpAssetIDs(t *testing.T) {
 
 	// CreateExpAssets handles duplicates and new rows
 	assets = append(assets, usdAsset)
-	rows, err = q.CreateExpAssets(assets)
+	assetMap, err = q.CreateExpAssets(assets)
 	tt.Assert.NoError(err)
-	tt.Assert.Len(rows, 3)
+	tt.Assert.Len(assetMap, len(assets))
 
-	for i, row := range rows {
-		asset := assets[i]
+	for _, asset := range assets {
+		row := assetMap[asset.String()]
 
-		// only the last asset is new
-		tt.Assert.Equal(set[row.ID], i < 2)
+		inSet := !asset.Equals(usdAsset)
+		tt.Assert.Equal(inSet, set[row.ID])
 
 		var assetType, assetCode, assetIssuer string
 		asset.MustExtract(&assetType, &assetCode, &assetIssuer)

--- a/services/horizon/internal/db2/history/mock_q_trades.go
+++ b/services/horizon/internal/db2/history/mock_q_trades.go
@@ -1,0 +1,44 @@
+package history
+
+import (
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockQTrades struct {
+	mock.Mock
+}
+
+func (m *MockQTrades) CheckExpTrades(seq int32) (bool, error) {
+	a := m.Called(seq)
+	return a.Get(0).(bool), a.Error(1)
+}
+
+func (m *MockQTrades) CreateExpAccounts(addresses []string) (map[string]int64, error) {
+	a := m.Called(addresses)
+	return a.Get(0).(map[string]int64), a.Error(1)
+}
+
+func (m *MockQTrades) CreateExpAssets(assets []xdr.Asset) ([]Asset, error) {
+	a := m.Called(assets)
+	return a.Get(0).([]Asset), a.Error(1)
+}
+
+func (m *MockQTrades) NewTradeBatchInsertBuilder(maxBatchSize int) TradeBatchInsertBuilder {
+	a := m.Called(maxBatchSize)
+	return a.Get(0).(TradeBatchInsertBuilder)
+}
+
+type MockTradeBatchInsertBuilder struct {
+	mock.Mock
+}
+
+func (m *MockTradeBatchInsertBuilder) Add(entries ...InsertTrade) error {
+	a := m.Called(entries)
+	return a.Error(0)
+}
+
+func (m *MockTradeBatchInsertBuilder) Exec() error {
+	a := m.Called()
+	return a.Error(0)
+}

--- a/services/horizon/internal/db2/history/mock_q_trades.go
+++ b/services/horizon/internal/db2/history/mock_q_trades.go
@@ -19,9 +19,9 @@ func (m *MockQTrades) CreateExpAccounts(addresses []string) (map[string]int64, e
 	return a.Get(0).(map[string]int64), a.Error(1)
 }
 
-func (m *MockQTrades) CreateExpAssets(assets []xdr.Asset) ([]Asset, error) {
+func (m *MockQTrades) CreateExpAssets(assets []xdr.Asset) (map[string]Asset, error) {
 	a := m.Called(assets)
-	return a.Get(0).([]Asset), a.Error(1)
+	return a.Get(0).(map[string]Asset), a.Error(1)
 }
 
 func (m *MockQTrades) NewTradeBatchInsertBuilder(maxBatchSize int) TradeBatchInsertBuilder {

--- a/services/horizon/internal/db2/history/trade.go
+++ b/services/horizon/internal/db2/history/trade.go
@@ -347,6 +347,13 @@ func getCanonicalAssetOrder(assetId1 int64, assetId2 int64) (orderPreserved bool
 	}
 }
 
+type QTrades interface {
+	CreateExpAccounts(addresses []string) (map[string]int64, error)
+	NewTradeBatchInsertBuilder(maxBatchSize int) TradeBatchInsertBuilder
+	CheckExpTrades(seq int32) (bool, error)
+	CreateExpAssets(assets []xdr.Asset) ([]Asset, error)
+}
+
 // CheckExpTrades checks that the trades in exp_history_trades
 // for the given ledger matches the same transactions in history_trades
 func (q *Q) CheckExpTrades(seq int32) (bool, error) {

--- a/services/horizon/internal/db2/history/trade.go
+++ b/services/horizon/internal/db2/history/trade.go
@@ -351,7 +351,7 @@ type QTrades interface {
 	CreateExpAccounts(addresses []string) (map[string]int64, error)
 	NewTradeBatchInsertBuilder(maxBatchSize int) TradeBatchInsertBuilder
 	CheckExpTrades(seq int32) (bool, error)
-	CreateExpAssets(assets []xdr.Asset) ([]Asset, error)
+	CreateExpAssets(assets []xdr.Asset) (map[string]Asset, error)
 }
 
 // CheckExpTrades checks that the trades in exp_history_trades

--- a/services/horizon/internal/db2/history/trade_test.go
+++ b/services/horizon/internal/db2/history/trade_test.go
@@ -138,12 +138,12 @@ func createExpAccountsAndAssets(
 		accountIDs = append(accountIDs, addressToAccounts[account])
 	}
 
-	assetRows, err := q.CreateExpAssets(assets)
+	assetMap, err := q.CreateExpAssets(assets)
 	tt.Assert.NoError(err)
 
 	assetIDs := []int64{}
-	for _, row := range assetRows {
-		assetIDs = append(assetIDs, row.ID)
+	for _, asset := range assets {
+		assetIDs = append(assetIDs, assetMap[asset.String()].ID)
 	}
 
 	return accountIDs, assetIDs

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -150,6 +150,9 @@ func buildLedgerPipeline(
 							pipeline.LedgerNode(&horizonProcessors.EffectProcessor{
 								EffectsQ: historyQ,
 							}),
+							pipeline.LedgerNode(&horizonProcessors.TradeProcessor{
+								TradesQ: historyQ,
+							}),
 						),
 					),
 				orderBookGraphLedgerNode(graph),

--- a/services/horizon/internal/expingest/processors/trades_processor.go
+++ b/services/horizon/internal/expingest/processors/trades_processor.go
@@ -44,7 +44,7 @@ func (p *TradeProcessor) ProcessLedger(ctx context.Context, store *pipeline.Stor
 	var inserts []history.InsertTrade
 	var buyers []string
 	accountSet := map[string]int64{}
-	assetSet := map[string]xdr.Asset{}
+	assets := []xdr.Asset{}
 
 	for {
 		var transaction io.LedgerTransaction
@@ -72,8 +72,7 @@ func (p *TradeProcessor) ProcessLedger(ctx context.Context, store *pipeline.Stor
 			buyer := txBuyers[i]
 			accountSet[insert.Trade.SellerId.Address()] = 0
 			accountSet[buyer] = 0
-			assetSet[insert.Trade.AssetSold.String()] = insert.Trade.AssetSold
-			assetSet[insert.Trade.AssetBought.String()] = insert.Trade.AssetBought
+			assets = append(assets, insert.Trade.AssetSold, insert.Trade.AssetBought)
 
 			inserts = append(inserts, insert)
 			buyers = append(buyers, buyer)
@@ -89,28 +88,22 @@ func (p *TradeProcessor) ProcessLedger(ctx context.Context, store *pipeline.Stor
 
 	if len(inserts) > 0 {
 		batch := p.TradesQ.NewTradeBatchInsertBuilder(maxBatchSize)
-		accountSet, err = p.TradesQ.CreateExpAccounts(accountSetToList(accountSet))
+		accountSet, err = p.TradesQ.CreateExpAccounts(mapKeysToList(accountSet))
 		if err != nil {
 			return errors.Wrap(err, "Error creating account ids")
 		}
 
-		assetStrings, assets := assetSetToList(assetSet)
-		var assetRows []history.Asset
-		assetRows, err = p.TradesQ.CreateExpAssets(assets)
+		var assetMap map[string]history.Asset
+		assetMap, err = p.TradesQ.CreateExpAssets(assets)
 		if err != nil {
 			return errors.Wrap(err, "Error creating asset ids")
-		}
-
-		assetToID := map[string]int64{}
-		for i, row := range assetRows {
-			assetToID[assetStrings[i]] = row.ID
 		}
 
 		for i, insert := range inserts {
 			insert.BuyerAccountID = accountSet[buyers[i]]
 			insert.SellerAccountID = accountSet[insert.Trade.SellerId.Address()]
-			insert.SoldAssetID = assetToID[insert.Trade.AssetSold.String()]
-			insert.BoughtAssetID = assetToID[insert.Trade.AssetBought.String()]
+			insert.SoldAssetID = assetMap[insert.Trade.AssetSold.String()].ID
+			insert.BoughtAssetID = assetMap[insert.Trade.AssetBought.String()].ID
 			if err = batch.Add(insert); err != nil {
 				return errors.Wrap(err, "Error adding trade to batch")
 			}
@@ -281,22 +274,12 @@ func beforeAndAfter(m *meta.Bundle, target xdr.LedgerKey, opidx int) (
 	return before, after, nil
 }
 
-func accountSetToList(set map[string]int64) []string {
+func mapKeysToList(set map[string]int64) []string {
 	keys := make([]string, 0, len(set))
 	for key := range set {
 		keys = append(keys, key)
 	}
 	return keys
-}
-
-func assetSetToList(set map[string]xdr.Asset) ([]string, []xdr.Asset) {
-	values := make([]xdr.Asset, 0, len(set))
-	keys := make([]string, 0, len(set))
-	for key, value := range set {
-		keys = append(keys, key)
-		values = append(values, value)
-	}
-	return keys, values
 }
 
 // Name processor name

--- a/services/horizon/internal/expingest/processors/trades_processor.go
+++ b/services/horizon/internal/expingest/processors/trades_processor.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stellar/go/exp/ingest/io"
 	ingestpipeline "github.com/stellar/go/exp/ingest/pipeline"
 	"github.com/stellar/go/exp/support/pipeline"
-	"github.com/stellar/go/meta"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/toid"
 	"github.com/stellar/go/support/errors"
@@ -63,7 +62,7 @@ func (p *TradeProcessor) ProcessLedger(ctx context.Context, store *pipeline.Stor
 
 		var txInserts []history.InsertTrade
 		var txBuyers []string
-		txInserts, txBuyers, err = extractTrades(ledger, transaction)
+		txInserts, txBuyers, err = p.extractTrades(ledger, transaction)
 		if err != nil {
 			return err
 		}
@@ -147,16 +146,45 @@ func (p *TradeProcessor) checkTrades(ledger xdr.LedgerHeaderHistoryEntry) {
 	}
 }
 
-func extractTrades(
+func (p *TradeProcessor) findTradeSellPrice(
+	transaction io.LedgerTransaction,
+	opidx int,
+	trade xdr.ClaimOfferAtom,
+) (xdr.Price, error) {
+	var price xdr.Price
+	key := xdr.LedgerKey{}
+	key.SetOffer(trade.SellerId, uint64(trade.OfferId))
+
+	changes, err := transaction.GetOperationChanges(uint32(opidx))
+	if err != nil {
+		return price, errors.Wrap(err, "could not determine changes for operation")
+	}
+
+	found := false
+	var change io.Change
+	for i := len(changes) - 1; i >= 0; i-- {
+		change = changes[i]
+		if change.Pre != nil && key.Equals(change.Pre.LedgerKey()) {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return price, errors.Wrap(err, "could not find change for trade offer")
+	}
+
+	return change.Pre.Data.Offer.Price, nil
+}
+
+func (p *TradeProcessor) extractTrades(
 	ledger xdr.LedgerHeaderHistoryEntry,
 	transaction io.LedgerTransaction,
 ) ([]history.InsertTrade, []string, error) {
-	m := &meta.Bundle{
-		FeeMeta:         transaction.FeeChanges,
-		TransactionMeta: transaction.Meta,
-	}
 	var inserts []history.InsertTrade
 	var buyerAccounts []string
+
+	closeTime := time.Unix(int64(ledger.Header.ScpValue.CloseTime), 0).UTC()
 
 	opResults := transaction.Result.Result.Result.MustResults()
 	for opidx, op := range transaction.Envelope.Tx.Operations {
@@ -204,6 +232,9 @@ func extractTrades(
 			}
 		}
 
+		opID := toid.New(
+			int32(ledger.Header.LedgerSeq), int32(transaction.Index), int32(opidx+1),
+		).ToInt64()
 		for order, trade := range trades {
 			// stellar-core will opportunisticly garbage collect invalid offers (in the
 			// event that a trader spends down their balance).  These garbage collected
@@ -215,29 +246,19 @@ func extractTrades(
 				continue
 			}
 
-			//extract original offer price
-			key := xdr.LedgerKey{}
-			key.SetOffer(trade.SellerId, uint64(trade.OfferId))
-			before, _, err := beforeAndAfter(m, key, opidx)
+			sellOfferPrice, err := p.findTradeSellPrice(transaction, opidx, trade)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "beforeAndAfter error")
+				return nil, nil, err
 			}
-			sellOfferPrice := before.Data.Offer.Price
-
-			closeTime := time.Unix(int64(ledger.Header.ScpValue.CloseTime), 0).UTC()
 
 			inserts = append(inserts, history.InsertTrade{
-				HistoryOperationID: toid.New(
-					int32(ledger.Header.LedgerSeq),
-					int32(transaction.Index),
-					int32(opidx+1),
-				).ToInt64(),
-				Order:           int32(order),
-				LedgerCloseTime: closeTime,
-				BuyOfferExists:  buyOfferExists,
-				Trade:           trade,
-				SellPrice:       sellOfferPrice,
-				BuyOfferID:      int64(buyOffer.OfferId),
+				HistoryOperationID: opID,
+				Order:              int32(order),
+				LedgerCloseTime:    closeTime,
+				BuyOfferExists:     buyOfferExists,
+				Trade:              trade,
+				SellPrice:          sellOfferPrice,
+				BuyOfferID:         int64(buyOffer.OfferId),
 			})
 
 			var buyerAddress string
@@ -251,27 +272,6 @@ func extractTrades(
 	}
 
 	return inserts, buyerAccounts, nil
-}
-
-// beforeAndAfter loads the ledger entry for `target` before the current
-// operation was applied and after the operation was applied.
-func beforeAndAfter(m *meta.Bundle, target xdr.LedgerKey, opidx int) (
-	*xdr.LedgerEntry,
-	*xdr.LedgerEntry,
-	error,
-) {
-	before, err := m.StateBefore(target, opidx)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var after *xdr.LedgerEntry
-	after, err = m.StateAfter(target, opidx)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return before, after, nil
 }
 
 func mapKeysToList(set map[string]int64) []string {

--- a/services/horizon/internal/expingest/processors/trades_processor.go
+++ b/services/horizon/internal/expingest/processors/trades_processor.go
@@ -1,0 +1,310 @@
+package processors
+
+import (
+	"context"
+	stdio "io"
+	"time"
+
+	"github.com/stellar/go/exp/ingest/io"
+	ingestpipeline "github.com/stellar/go/exp/ingest/pipeline"
+	"github.com/stellar/go/exp/support/pipeline"
+	"github.com/stellar/go/meta"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/toid"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+// TradeProcessor operations processor
+type TradeProcessor struct {
+	TradesQ history.QTrades
+}
+
+// ProcessLedger process the given ledger
+func (p *TradeProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
+	defer func() {
+		// io.LedgerReader.Close() returns error if upgrade changes have not
+		// been processed so it's worth checking the error.
+		closeErr := r.Close()
+		// Do not overwrite the previous error
+		if err == nil {
+			err = closeErr
+		}
+	}()
+	defer w.Close()
+	r.IgnoreUpgradeChanges()
+
+	// Exit early if not ingesting into a DB
+	if v := ctx.Value(IngestUpdateDatabase); v == nil {
+		return nil
+	}
+
+	ledger := r.GetHeader()
+
+	var inserts []history.InsertTrade
+	var buyers []string
+	accountSet := map[string]int64{}
+	assetSet := map[string]xdr.Asset{}
+
+	for {
+		var transaction io.LedgerTransaction
+		transaction, err = r.Read()
+		if err != nil {
+			if err == stdio.EOF {
+				break
+			} else {
+				return err
+			}
+		}
+
+		if !transaction.Successful() {
+			continue
+		}
+
+		var txInserts []history.InsertTrade
+		var txBuyers []string
+		txInserts, txBuyers, err = extractTrades(ledger, transaction)
+		if err != nil {
+			return err
+		}
+
+		for i, insert := range txInserts {
+			buyer := txBuyers[i]
+			accountSet[insert.Trade.SellerId.Address()] = 0
+			accountSet[buyer] = 0
+			assetSet[insert.Trade.AssetSold.String()] = insert.Trade.AssetSold
+			assetSet[insert.Trade.AssetBought.String()] = insert.Trade.AssetBought
+
+			inserts = append(inserts, insert)
+			buyers = append(buyers, buyer)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			continue
+		}
+	}
+
+	if len(inserts) > 0 {
+		batch := p.TradesQ.NewTradeBatchInsertBuilder(maxBatchSize)
+		accountSet, err = p.TradesQ.CreateExpAccounts(accountSetToList(accountSet))
+		if err != nil {
+			return errors.Wrap(err, "Error creating account ids")
+		}
+
+		assetStrings, assets := assetSetToList(assetSet)
+		var assetRows []history.Asset
+		assetRows, err = p.TradesQ.CreateExpAssets(assets)
+		if err != nil {
+			return errors.Wrap(err, "Error creating asset ids")
+		}
+
+		assetToID := map[string]int64{}
+		for i, row := range assetRows {
+			assetToID[assetStrings[i]] = row.ID
+		}
+
+		for i, insert := range inserts {
+			insert.BuyerAccountID = accountSet[buyers[i]]
+			insert.SellerAccountID = accountSet[insert.Trade.SellerId.Address()]
+			insert.SoldAssetID = assetToID[insert.Trade.AssetSold.String()]
+			insert.BoughtAssetID = assetToID[insert.Trade.AssetBought.String()]
+			if err = batch.Add(insert); err != nil {
+				return errors.Wrap(err, "Error adding trade to batch")
+			}
+
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+				continue
+			}
+		}
+
+		if err = batch.Exec(); err != nil {
+			return errors.Wrap(err, "Error flushing operation batch")
+		}
+	}
+
+	p.checkTrades(ledger)
+
+	return nil
+}
+
+func (p *TradeProcessor) checkTrades(ledger xdr.LedgerHeaderHistoryEntry) {
+	// use an older lookup sequence because the experimental ingestion system and the
+	// legacy ingestion system might not be in sync
+	if sequence := ledger.Header.LedgerSeq; sequence > 10 {
+		checkSequence := int32(sequence - 10)
+		var valid bool
+		valid, err := p.TradesQ.CheckExpTrades(checkSequence)
+		if err != nil {
+			log.WithField("sequence", checkSequence).WithError(err).
+				Error("Could not compare trades for ledger")
+			return
+		}
+
+		if !valid {
+			log.WithField("sequence", checkSequence).
+				Error("rows for ledger in exp_history_trades does not match " +
+					"trades in history_trades")
+		}
+	}
+}
+
+func extractTrades(
+	ledger xdr.LedgerHeaderHistoryEntry,
+	transaction io.LedgerTransaction,
+) ([]history.InsertTrade, []string, error) {
+	m := &meta.Bundle{
+		FeeMeta:         transaction.FeeChanges,
+		TransactionMeta: transaction.Meta,
+	}
+	var inserts []history.InsertTrade
+	var buyerAccounts []string
+
+	opResults := transaction.Result.Result.Result.MustResults()
+	for opidx, op := range transaction.Envelope.Tx.Operations {
+		var trades []xdr.ClaimOfferAtom
+		var buyOfferExists bool
+		var buyOffer xdr.OfferEntry
+
+		switch op.Body.Type {
+		case xdr.OperationTypePathPaymentStrictReceive:
+			trades = opResults[opidx].MustTr().MustPathPaymentStrictReceiveResult().
+				MustSuccess().
+				Offers
+
+		case xdr.OperationTypePathPaymentStrictSend:
+			trades = opResults[opidx].MustTr().
+				MustPathPaymentStrictSendResult().
+				MustSuccess().
+				Offers
+
+		case xdr.OperationTypeManageBuyOffer:
+			manageOfferResult := opResults[opidx].MustTr().MustManageBuyOfferResult().
+				MustSuccess()
+			trades = manageOfferResult.OffersClaimed
+			buyOffer, buyOfferExists = manageOfferResult.Offer.GetOffer()
+
+		case xdr.OperationTypeManageSellOffer:
+			manageOfferResult := opResults[opidx].MustTr().MustManageSellOfferResult().
+				MustSuccess()
+			trades = manageOfferResult.OffersClaimed
+			buyOffer, buyOfferExists = manageOfferResult.Offer.GetOffer()
+
+		case xdr.OperationTypeCreatePassiveSellOffer:
+			result := opResults[opidx].MustTr()
+
+			// KNOWN ISSUE:  stellar-core creates results for CreatePassiveOffer operations
+			// with the wrong result arm set.
+			if result.Type == xdr.OperationTypeManageSellOffer {
+				manageOfferResult := result.MustManageSellOfferResult().MustSuccess()
+				trades = manageOfferResult.OffersClaimed
+				buyOffer, buyOfferExists = manageOfferResult.Offer.GetOffer()
+			} else {
+				passiveOfferResult := result.MustCreatePassiveSellOfferResult().MustSuccess()
+				trades = passiveOfferResult.OffersClaimed
+				buyOffer, buyOfferExists = passiveOfferResult.Offer.GetOffer()
+			}
+		}
+
+		for order, trade := range trades {
+			// stellar-core will opportunisticly garbage collect invalid offers (in the
+			// event that a trader spends down their balance).  These garbage collected
+			// offers get emitted in the result with the amount values set to zero.
+			//
+			// These zeroed ClaimOfferAtom values do not represent trades, and so we
+			// skip them.
+			if trade.AmountBought == 0 && trade.AmountSold == 0 {
+				continue
+			}
+
+			//extract original offer price
+			key := xdr.LedgerKey{}
+			key.SetOffer(trade.SellerId, uint64(trade.OfferId))
+			before, _, err := beforeAndAfter(m, key, opidx)
+			if err != nil {
+				return nil, nil, errors.Wrap(err, "beforeAndAfter error")
+			}
+			sellOfferPrice := before.Data.Offer.Price
+
+			closeTime := time.Unix(int64(ledger.Header.ScpValue.CloseTime), 0).UTC()
+
+			inserts = append(inserts, history.InsertTrade{
+				HistoryOperationID: toid.New(
+					int32(ledger.Header.LedgerSeq),
+					int32(transaction.Index),
+					int32(opidx+1),
+				).ToInt64(),
+				Order:           int32(order),
+				LedgerCloseTime: closeTime,
+				BuyOfferExists:  buyOfferExists,
+				Trade:           trade,
+				SellPrice:       sellOfferPrice,
+				BuyOfferID:      int64(buyOffer.OfferId),
+			})
+
+			var buyerAddress string
+			if buyer := op.SourceAccount; buyer != nil {
+				buyerAddress = buyer.Address()
+			} else {
+				buyerAddress = transaction.Envelope.Tx.SourceAccount.Address()
+			}
+			buyerAccounts = append(buyerAccounts, buyerAddress)
+		}
+	}
+
+	return inserts, buyerAccounts, nil
+}
+
+// beforeAndAfter loads the ledger entry for `target` before the current
+// operation was applied and after the operation was applied.
+func beforeAndAfter(m *meta.Bundle, target xdr.LedgerKey, opidx int) (
+	*xdr.LedgerEntry,
+	*xdr.LedgerEntry,
+	error,
+) {
+	before, err := m.StateBefore(target, opidx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var after *xdr.LedgerEntry
+	after, err = m.StateAfter(target, opidx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return before, after, nil
+}
+
+func accountSetToList(set map[string]int64) []string {
+	keys := make([]string, 0, len(set))
+	for key := range set {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func assetSetToList(set map[string]xdr.Asset) ([]string, []xdr.Asset) {
+	values := make([]xdr.Asset, 0, len(set))
+	keys := make([]string, 0, len(set))
+	for key, value := range set {
+		keys = append(keys, key)
+		values = append(values, value)
+	}
+	return keys, values
+}
+
+// Name processor name
+func (p *TradeProcessor) Name() string {
+	return "TradeProcessor"
+}
+
+// Reset resets processor
+func (p *TradeProcessor) Reset() {}
+
+var _ ingestpipeline.LedgerProcessor = &TradeProcessor{}

--- a/services/horizon/internal/expingest/processors/trades_processor_test.go
+++ b/services/horizon/internal/expingest/processors/trades_processor_test.go
@@ -473,38 +473,45 @@ func (s *TradeProcessorTestSuiteLedger) mockReadTradeTransactions(
 		Index:      1,
 		FeeChanges: []xdr.LedgerEntryChange{},
 		Meta: xdr.TransactionMeta{
-			V:          0,
-			Operations: &[]xdr.OperationMeta{},
+			V: 2,
+			V2: &xdr.TransactionMetaV2{
+				Operations: []xdr.OperationMeta{
+					xdr.OperationMeta{
+						Changes: xdr.LedgerEntryChanges{},
+					},
+				},
+			},
 		},
 	}
 
 	for i, trade := range s.allTrades {
-		tx.FeeChanges = append(
-			tx.FeeChanges,
-			xdr.LedgerEntryChange{
-				Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-				State: &xdr.LedgerEntry{
-					Data: xdr.LedgerEntryData{
+		tx.Meta.V2.Operations = append(tx.Meta.V2.Operations, xdr.OperationMeta{
+			Changes: xdr.LedgerEntryChanges{
+				xdr.LedgerEntryChange{
+					Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+					State: &xdr.LedgerEntry{
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeOffer,
+							Offer: &xdr.OfferEntry{
+								Price:    s.sellPrices[i],
+								SellerId: trade.SellerId,
+								OfferId:  trade.OfferId,
+							},
+						},
+					},
+				},
+				xdr.LedgerEntryChange{
+					Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+					Removed: &xdr.LedgerKey{
 						Type: xdr.LedgerEntryTypeOffer,
-						Offer: &xdr.OfferEntry{
-							Price:    s.sellPrices[i],
+						Offer: &xdr.LedgerKeyOffer{
 							SellerId: trade.SellerId,
 							OfferId:  trade.OfferId,
 						},
 					},
 				},
 			},
-			xdr.LedgerEntryChange{
-				Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-				Removed: &xdr.LedgerKey{
-					Type: xdr.LedgerEntryTypeOffer,
-					Offer: &xdr.LedgerKeyOffer{
-						SellerId: trade.SellerId,
-						OfferId:  trade.OfferId,
-					},
-				},
-			},
-		)
+		})
 	}
 
 	s.mockLedgerReader.

--- a/services/horizon/internal/expingest/processors/trades_processor_test.go
+++ b/services/horizon/internal/expingest/processors/trades_processor_test.go
@@ -1,0 +1,727 @@
+package processors
+
+import (
+	"context"
+	"fmt"
+	stdio "io"
+	"testing"
+	"time"
+
+	"github.com/stellar/go/exp/ingest/io"
+	supportPipeline "github.com/stellar/go/exp/support/pipeline"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/toid"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type TradeProcessorTestSuiteLedger struct {
+	suite.Suite
+	processor              *TradeProcessor
+	mockQ                  *history.MockQTrades
+	mockBatchInsertBuilder *history.MockTradeBatchInsertBuilder
+	mockLedgerReader       *io.MockLedgerReader
+	mockLedgerWriter       *io.MockLedgerWriter
+	context                context.Context
+
+	sourceAccount              xdr.AccountId
+	opSourceAccount            xdr.AccountId
+	strictReceiveTrade         xdr.ClaimOfferAtom
+	strictSendTrade            xdr.ClaimOfferAtom
+	buyOfferTrade              xdr.ClaimOfferAtom
+	sellOfferTrade             xdr.ClaimOfferAtom
+	passiveSellOfferTrade      xdr.ClaimOfferAtom
+	otherPassiveSellOfferTrade xdr.ClaimOfferAtom
+	allTrades                  []xdr.ClaimOfferAtom
+	sellPrices                 []xdr.Price
+
+	assets []xdr.Asset
+
+	accountToID map[string]int64
+	assetToID   map[string]history.Asset
+}
+
+func TestTradeProcessorTestSuiteLedger(t *testing.T) {
+	suite.Run(t, new(TradeProcessorTestSuiteLedger))
+}
+
+func (s *TradeProcessorTestSuiteLedger) SetupTest() {
+	s.mockQ = &history.MockQTrades{}
+	s.mockBatchInsertBuilder = &history.MockTradeBatchInsertBuilder{}
+	s.mockLedgerReader = &io.MockLedgerReader{}
+	s.mockLedgerWriter = &io.MockLedgerWriter{}
+	s.context = context.WithValue(context.Background(), IngestUpdateDatabase, true)
+
+	s.sourceAccount = xdr.MustAddress("GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY")
+	s.opSourceAccount = xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML")
+	s.strictReceiveTrade = xdr.ClaimOfferAtom{
+		SellerId:     xdr.MustAddress("GA2YS6YBWIBUMUJCNYROC5TXYTTUA4TCZF7A4MJ2O4TTGT3LFNWIOMY4"),
+		OfferId:      11,
+		AssetSold:    xdr.MustNewNativeAsset(),
+		AmountSold:   111,
+		AmountBought: 211,
+		AssetBought:  xdr.MustNewCreditAsset("HUF", s.sourceAccount.Address()),
+	}
+	s.strictSendTrade = xdr.ClaimOfferAtom{
+		SellerId:     xdr.MustAddress("GALOBQKDZUSAEUDE7F4OYUIQTUZBL62G6TRCXU2ED6SA7TL72MBUQSYJ"),
+		OfferId:      12,
+		AssetSold:    xdr.MustNewCreditAsset("USD", s.sourceAccount.Address()),
+		AmountSold:   112,
+		AmountBought: 212,
+		AssetBought:  xdr.MustNewCreditAsset("RUB", s.sourceAccount.Address()),
+	}
+	s.buyOfferTrade = xdr.ClaimOfferAtom{
+		SellerId:     xdr.MustAddress("GCWRLPH5X5A3GABFDLDILZ4RLY6O76AYOIIR5H2PAI6TNZZZNLZWBXSH"),
+		OfferId:      13,
+		AssetSold:    xdr.MustNewCreditAsset("EUR", s.sourceAccount.Address()),
+		AmountSold:   113,
+		AmountBought: 213,
+		AssetBought:  xdr.MustNewCreditAsset("NOK", s.sourceAccount.Address()),
+	}
+	s.sellOfferTrade = xdr.ClaimOfferAtom{
+		SellerId:     xdr.MustAddress("GAVOLNFXVVUJOELN4T3YVSH2FFA3VSP2XN4NJRYF2ZWVCHS77C5KXLHZ"),
+		OfferId:      14,
+		AssetSold:    xdr.MustNewCreditAsset("PLN", s.sourceAccount.Address()),
+		AmountSold:   114,
+		AmountBought: 214,
+		AssetBought:  xdr.MustNewCreditAsset("UAH", s.sourceAccount.Address()),
+	}
+	s.passiveSellOfferTrade = xdr.ClaimOfferAtom{
+		SellerId:     xdr.MustAddress("GDQWI6FKB72DPOJE4CGYCFQZKRPQQIOYXRMZ5KEVGXMG6UUTGJMBCASH"),
+		OfferId:      15,
+		AssetSold:    xdr.MustNewCreditAsset("SEK", s.sourceAccount.Address()),
+		AmountSold:   115,
+		AmountBought: 215,
+		AssetBought:  xdr.MustNewCreditAsset("GBP", s.sourceAccount.Address()),
+	}
+	s.otherPassiveSellOfferTrade = xdr.ClaimOfferAtom{
+		SellerId:     xdr.MustAddress("GCPZFOJON3PSSYUBNT7MCGEDSGP47UTSJSB4XGCVEWEJO4XQ6U4XN3N2"),
+		OfferId:      16,
+		AssetSold:    xdr.MustNewCreditAsset("CHF", s.sourceAccount.Address()),
+		AmountSold:   116,
+		AmountBought: 216,
+		AssetBought:  xdr.MustNewCreditAsset("JPY", s.sourceAccount.Address()),
+	}
+
+	s.accountToID = map[string]int64{
+		s.sourceAccount.Address():   1000,
+		s.opSourceAccount.Address(): 1001,
+	}
+	s.assetToID = map[string]history.Asset{}
+	s.allTrades = []xdr.ClaimOfferAtom{
+		s.strictReceiveTrade,
+		s.strictSendTrade,
+		s.buyOfferTrade,
+		s.sellOfferTrade,
+		s.passiveSellOfferTrade,
+		s.otherPassiveSellOfferTrade,
+	}
+
+	s.assets = []xdr.Asset{}
+	s.sellPrices = []xdr.Price{}
+	for i, trade := range s.allTrades {
+		s.accountToID[trade.SellerId.Address()] = int64(1002 + i)
+		s.assetToID[trade.AssetSold.String()] = history.Asset{ID: int64(10000 + i)}
+		s.assetToID[trade.AssetBought.String()] = history.Asset{ID: int64(100 + i)}
+		s.assets = append(s.assets, trade.AssetSold, trade.AssetBought)
+		n := xdr.Int32(i + 1)
+		s.sellPrices = append(s.sellPrices, xdr.Price{N: n, D: 100})
+	}
+
+	s.processor = &TradeProcessor{
+		TradesQ: s.mockQ,
+	}
+
+	s.mockLedgerReader.On("IgnoreUpgradeChanges").Once()
+	s.mockLedgerReader.
+		On("Close").
+		Return(nil).Once()
+
+	s.mockLedgerWriter.
+		On("Close").
+		Return(nil).Once()
+}
+
+func (s *TradeProcessorTestSuiteLedger) TearDownTest() {
+	s.mockQ.AssertExpectations(s.T())
+	s.mockBatchInsertBuilder.AssertExpectations(s.T())
+	s.mockLedgerReader.AssertExpectations(s.T())
+	s.mockLedgerWriter.AssertExpectations(s.T())
+}
+
+func (s *TradeProcessorTestSuiteLedger) TestIgnoreFailedTransactions() {
+	s.mockLedgerReader.
+		On("GetHeader").
+		Return(xdr.LedgerHeaderHistoryEntry{}).Once()
+	s.mockLedgerReader.
+		On("Read").
+		Return(createTransaction(false, 1), nil).Once()
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{}, stdio.EOF).Once()
+
+	err := s.processor.ProcessLedger(
+		s.context,
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().NoError(err)
+}
+
+func (s *TradeProcessorTestSuiteLedger) TestReturnIfNotUpdatingDB() {
+	err := s.processor.ProcessLedger(
+		context.Background(),
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().NoError(err)
+}
+
+func (s *TradeProcessorTestSuiteLedger) TestReadError() {
+	s.mockLedgerReader.
+		On("GetHeader").
+		Return(xdr.LedgerHeaderHistoryEntry{}).Once()
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{}, fmt.Errorf("transient read error")).Once()
+
+	err := s.processor.ProcessLedger(
+		s.context,
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().EqualError(err, "transient read error")
+}
+
+func (s *TradeProcessorTestSuiteLedger) mockReadTradeTransactions(
+	ledger xdr.LedgerHeaderHistoryEntry,
+) []history.InsertTrade {
+	closeTime := time.Unix(int64(ledger.Header.ScpValue.CloseTime), 0).UTC()
+	inserts := []history.InsertTrade{
+		history.InsertTrade{
+			HistoryOperationID: toid.New(int32(ledger.Header.LedgerSeq), 1, 2).ToInt64(),
+			Order:              1,
+			LedgerCloseTime:    closeTime,
+			BuyOfferExists:     false,
+			BuyOfferID:         0,
+			SellerAccountID:    s.accountToID[s.strictReceiveTrade.SellerId.Address()],
+			BuyerAccountID:     s.accountToID[s.opSourceAccount.Address()],
+			Trade:              s.strictReceiveTrade,
+			SoldAssetID:        s.assetToID[s.strictReceiveTrade.AssetSold.String()].ID,
+			BoughtAssetID:      s.assetToID[s.strictReceiveTrade.AssetBought.String()].ID,
+			SellPrice:          s.sellPrices[0],
+		},
+		history.InsertTrade{
+			HistoryOperationID: toid.New(int32(ledger.Header.LedgerSeq), 1, 3).ToInt64(),
+			Order:              0,
+			LedgerCloseTime:    closeTime,
+			BuyOfferExists:     false,
+			BuyOfferID:         0,
+			SellerAccountID:    s.accountToID[s.strictSendTrade.SellerId.Address()],
+			BuyerAccountID:     s.accountToID[s.opSourceAccount.Address()],
+			Trade:              s.strictSendTrade,
+			SoldAssetID:        s.assetToID[s.strictSendTrade.AssetSold.String()].ID,
+			BoughtAssetID:      s.assetToID[s.strictSendTrade.AssetBought.String()].ID,
+			SellPrice:          s.sellPrices[1],
+		},
+		history.InsertTrade{
+			HistoryOperationID: toid.New(int32(ledger.Header.LedgerSeq), 1, 4).ToInt64(),
+			Order:              1,
+			LedgerCloseTime:    closeTime,
+			BuyOfferExists:     true,
+			BuyOfferID:         879136,
+			SellerAccountID:    s.accountToID[s.buyOfferTrade.SellerId.Address()],
+			BuyerAccountID:     s.accountToID[s.opSourceAccount.Address()],
+			Trade:              s.buyOfferTrade,
+			SoldAssetID:        s.assetToID[s.buyOfferTrade.AssetSold.String()].ID,
+			BoughtAssetID:      s.assetToID[s.buyOfferTrade.AssetBought.String()].ID,
+			SellPrice:          s.sellPrices[2],
+		},
+		history.InsertTrade{
+			HistoryOperationID: toid.New(int32(ledger.Header.LedgerSeq), 1, 5).ToInt64(),
+			Order:              2,
+			LedgerCloseTime:    closeTime,
+			BuyOfferExists:     false,
+			BuyOfferID:         0,
+			SellerAccountID:    s.accountToID[s.sellOfferTrade.SellerId.Address()],
+			BuyerAccountID:     s.accountToID[s.opSourceAccount.Address()],
+			Trade:              s.sellOfferTrade,
+			SoldAssetID:        s.assetToID[s.sellOfferTrade.AssetSold.String()].ID,
+			BoughtAssetID:      s.assetToID[s.sellOfferTrade.AssetBought.String()].ID,
+			SellPrice:          s.sellPrices[3],
+		},
+		history.InsertTrade{
+			HistoryOperationID: toid.New(int32(ledger.Header.LedgerSeq), 1, 6).ToInt64(),
+			Order:              0,
+			LedgerCloseTime:    closeTime,
+			BuyOfferExists:     false,
+			BuyOfferID:         0,
+			SellerAccountID:    s.accountToID[s.passiveSellOfferTrade.SellerId.Address()],
+			BuyerAccountID:     s.accountToID[s.sourceAccount.Address()],
+			Trade:              s.passiveSellOfferTrade,
+			SoldAssetID:        s.assetToID[s.passiveSellOfferTrade.AssetSold.String()].ID,
+			BoughtAssetID:      s.assetToID[s.passiveSellOfferTrade.AssetBought.String()].ID,
+			SellPrice:          s.sellPrices[4],
+		},
+		history.InsertTrade{
+			HistoryOperationID: toid.New(int32(ledger.Header.LedgerSeq), 1, 7).ToInt64(),
+			Order:              0,
+			LedgerCloseTime:    closeTime,
+			BuyOfferExists:     false,
+			BuyOfferID:         0,
+			SellerAccountID:    s.accountToID[s.otherPassiveSellOfferTrade.SellerId.Address()],
+			BuyerAccountID:     s.accountToID[s.opSourceAccount.Address()],
+			Trade:              s.otherPassiveSellOfferTrade,
+			SoldAssetID:        s.assetToID[s.otherPassiveSellOfferTrade.AssetSold.String()].ID,
+			BoughtAssetID:      s.assetToID[s.otherPassiveSellOfferTrade.AssetBought.String()].ID,
+			SellPrice:          s.sellPrices[5],
+		},
+	}
+
+	emptyTrade := xdr.ClaimOfferAtom{
+		SellerId:     s.sourceAccount,
+		OfferId:      123,
+		AssetSold:    xdr.MustNewNativeAsset(),
+		AmountSold:   0,
+		AssetBought:  xdr.MustNewCreditAsset("EUR", s.sourceAccount.Address()),
+		AmountBought: 0,
+	}
+
+	operationResults := []xdr.OperationResult{
+		xdr.OperationResult{
+			Tr: &xdr.OperationResultTr{
+				Type: xdr.OperationTypeBumpSequence,
+				BumpSeqResult: &xdr.BumpSequenceResult{
+					Code: xdr.BumpSequenceResultCodeBumpSequenceSuccess,
+				},
+			},
+		},
+		xdr.OperationResult{
+			Tr: &xdr.OperationResultTr{
+				Type: xdr.OperationTypePathPaymentStrictReceive,
+				PathPaymentStrictReceiveResult: &xdr.PathPaymentStrictReceiveResult{
+					Code: xdr.PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSuccess,
+					Success: &xdr.PathPaymentStrictReceiveResultSuccess{
+						Offers: []xdr.ClaimOfferAtom{
+							emptyTrade,
+							s.strictReceiveTrade,
+						},
+					},
+				},
+			},
+		},
+		xdr.OperationResult{
+			Tr: &xdr.OperationResultTr{
+				Type: xdr.OperationTypePathPaymentStrictSend,
+				PathPaymentStrictSendResult: &xdr.PathPaymentStrictSendResult{
+					Code: xdr.PathPaymentStrictSendResultCodePathPaymentStrictSendSuccess,
+					Success: &xdr.PathPaymentStrictSendResultSuccess{
+						Offers: []xdr.ClaimOfferAtom{
+							s.strictSendTrade,
+							emptyTrade,
+						},
+					},
+				},
+			},
+		},
+		xdr.OperationResult{
+			Tr: &xdr.OperationResultTr{
+				Type: xdr.OperationTypeManageBuyOffer,
+				ManageBuyOfferResult: &xdr.ManageBuyOfferResult{
+					Code: xdr.ManageBuyOfferResultCodeManageBuyOfferSuccess,
+					Success: &xdr.ManageOfferSuccessResult{
+						OffersClaimed: []xdr.ClaimOfferAtom{
+							emptyTrade,
+							s.buyOfferTrade,
+							emptyTrade,
+						},
+						Offer: xdr.ManageOfferSuccessResultOffer{
+							Offer: &xdr.OfferEntry{
+								OfferId: 879136,
+							},
+						},
+					},
+				},
+			},
+		},
+		xdr.OperationResult{
+			Tr: &xdr.OperationResultTr{
+				Type: xdr.OperationTypeManageSellOffer,
+				ManageSellOfferResult: &xdr.ManageSellOfferResult{
+					Code: xdr.ManageSellOfferResultCodeManageSellOfferSuccess,
+					Success: &xdr.ManageOfferSuccessResult{
+						OffersClaimed: []xdr.ClaimOfferAtom{
+							emptyTrade,
+							emptyTrade,
+							s.sellOfferTrade,
+						},
+						Offer: xdr.ManageOfferSuccessResultOffer{
+							Effect: xdr.ManageOfferEffectManageOfferDeleted,
+						},
+					},
+				},
+			},
+		},
+		xdr.OperationResult{
+			Tr: &xdr.OperationResultTr{
+				Type: xdr.OperationTypeManageSellOffer,
+				ManageSellOfferResult: &xdr.ManageSellOfferResult{
+					Code: xdr.ManageSellOfferResultCodeManageSellOfferSuccess,
+					Success: &xdr.ManageOfferSuccessResult{
+						OffersClaimed: []xdr.ClaimOfferAtom{
+							s.passiveSellOfferTrade,
+							emptyTrade,
+							emptyTrade,
+						},
+						Offer: xdr.ManageOfferSuccessResultOffer{
+							Effect: xdr.ManageOfferEffectManageOfferDeleted,
+						},
+					},
+				},
+			},
+		},
+		xdr.OperationResult{
+			Tr: &xdr.OperationResultTr{
+				Type: xdr.OperationTypeCreatePassiveSellOffer,
+				CreatePassiveSellOfferResult: &xdr.ManageSellOfferResult{
+					Code: xdr.ManageSellOfferResultCodeManageSellOfferSuccess,
+					Success: &xdr.ManageOfferSuccessResult{
+						OffersClaimed: []xdr.ClaimOfferAtom{
+							s.otherPassiveSellOfferTrade,
+						},
+						Offer: xdr.ManageOfferSuccessResultOffer{
+							Effect: xdr.ManageOfferEffectManageOfferDeleted,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	operations := []xdr.Operation{
+		xdr.Operation{
+			Body: xdr.OperationBody{
+				Type:           xdr.OperationTypeBumpSequence,
+				BumpSequenceOp: &xdr.BumpSequenceOp{BumpTo: 30000},
+			},
+		},
+		xdr.Operation{
+			Body: xdr.OperationBody{
+				Type:                       xdr.OperationTypePathPaymentStrictReceive,
+				PathPaymentStrictReceiveOp: &xdr.PathPaymentStrictReceiveOp{},
+			},
+			SourceAccount: &s.opSourceAccount,
+		},
+		xdr.Operation{
+			Body: xdr.OperationBody{
+				Type:                    xdr.OperationTypePathPaymentStrictSend,
+				PathPaymentStrictSendOp: &xdr.PathPaymentStrictSendOp{},
+			},
+			SourceAccount: &s.opSourceAccount,
+		},
+		xdr.Operation{
+			Body: xdr.OperationBody{
+				Type:             xdr.OperationTypeManageBuyOffer,
+				ManageBuyOfferOp: &xdr.ManageBuyOfferOp{},
+			},
+			SourceAccount: &s.opSourceAccount,
+		},
+		xdr.Operation{
+			Body: xdr.OperationBody{
+				Type:              xdr.OperationTypeManageSellOffer,
+				ManageSellOfferOp: &xdr.ManageSellOfferOp{},
+			},
+			SourceAccount: &s.opSourceAccount,
+		},
+		xdr.Operation{
+			Body: xdr.OperationBody{
+				Type:                     xdr.OperationTypeCreatePassiveSellOffer,
+				CreatePassiveSellOfferOp: &xdr.CreatePassiveSellOfferOp{},
+			},
+		},
+		xdr.Operation{
+			Body: xdr.OperationBody{
+				Type:                     xdr.OperationTypeCreatePassiveSellOffer,
+				CreatePassiveSellOfferOp: &xdr.CreatePassiveSellOfferOp{},
+			},
+			SourceAccount: &s.opSourceAccount,
+		},
+	}
+
+	tx := io.LedgerTransaction{
+		Result: xdr.TransactionResultPair{
+			Result: xdr.TransactionResult{
+				Result: xdr.TransactionResultResult{
+					Code:    xdr.TransactionResultCodeTxSuccess,
+					Results: &operationResults,
+				},
+			},
+		},
+		Envelope: xdr.TransactionEnvelope{
+			Tx: xdr.Transaction{
+				SourceAccount: s.sourceAccount,
+				Operations:    operations,
+			},
+		},
+		Index:      1,
+		FeeChanges: []xdr.LedgerEntryChange{},
+		Meta: xdr.TransactionMeta{
+			V:          0,
+			Operations: &[]xdr.OperationMeta{},
+		},
+	}
+
+	for i, trade := range s.allTrades {
+		tx.FeeChanges = append(
+			tx.FeeChanges,
+			xdr.LedgerEntryChange{
+				Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+				State: &xdr.LedgerEntry{
+					Data: xdr.LedgerEntryData{
+						Type: xdr.LedgerEntryTypeOffer,
+						Offer: &xdr.OfferEntry{
+							Price:    s.sellPrices[i],
+							SellerId: trade.SellerId,
+							OfferId:  trade.OfferId,
+						},
+					},
+				},
+			},
+			xdr.LedgerEntryChange{
+				Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+				Removed: &xdr.LedgerKey{
+					Type: xdr.LedgerEntryTypeOffer,
+					Offer: &xdr.LedgerKeyOffer{
+						SellerId: trade.SellerId,
+						OfferId:  trade.OfferId,
+					},
+				},
+			},
+		)
+	}
+
+	s.mockLedgerReader.
+		On("GetHeader").
+		Return(ledger).Once()
+	s.mockLedgerReader.
+		On("Read").
+		Return(tx, nil).Once()
+	s.mockLedgerReader.
+		On("Read").
+		Return(io.LedgerTransaction{}, stdio.EOF).Once()
+	s.mockQ.On("NewTradeBatchInsertBuilder", maxBatchSize).
+		Return(s.mockBatchInsertBuilder).Once()
+
+	return inserts
+}
+
+func (s *TradeProcessorTestSuiteLedger) TestIngestTradesSucceeds() {
+	ledger := xdr.LedgerHeaderHistoryEntry{Header: xdr.LedgerHeader{LedgerSeq: 100}}
+	inserts := s.mockReadTradeTransactions(ledger)
+
+	s.mockQ.On("CreateExpAccounts", mock.AnythingOfType("[]string")).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(0).([]string)
+			s.Assert().ElementsMatch(
+				mapKeysToList(s.accountToID),
+				arg,
+			)
+		}).Return(s.accountToID, nil).Once()
+
+	s.mockQ.On("CreateExpAssets", mock.AnythingOfType("[]xdr.Asset")).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(0).([]xdr.Asset)
+			s.Assert().ElementsMatch(
+				s.assets,
+				arg,
+			)
+		}).Return(s.assetToID, nil).Once()
+
+	for _, insert := range inserts {
+		s.mockBatchInsertBuilder.On("Add", []history.InsertTrade{
+			insert,
+		}).Return(nil).Once()
+	}
+
+	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
+	s.mockQ.On("CheckExpTrades", int32(ledger.Header.LedgerSeq)-10).
+		Return(true, nil).Once()
+
+	err := s.processor.ProcessLedger(
+		s.context,
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().NoError(err)
+}
+
+func (s *TradeProcessorTestSuiteLedger) TestCreateExpAccountsError() {
+	ledger := xdr.LedgerHeaderHistoryEntry{Header: xdr.LedgerHeader{LedgerSeq: 100}}
+	s.mockReadTradeTransactions(ledger)
+
+	s.mockQ.On("CreateExpAccounts", mock.AnythingOfType("[]string")).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(0).([]string)
+			s.Assert().ElementsMatch(
+				mapKeysToList(s.accountToID),
+				arg,
+			)
+		}).Return(map[string]int64{}, fmt.Errorf("create accounts error")).Once()
+
+	err := s.processor.ProcessLedger(
+		s.context,
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().EqualError(err, "Error creating account ids: create accounts error")
+}
+
+func (s *TradeProcessorTestSuiteLedger) TestCreateExpAssetsError() {
+	ledger := xdr.LedgerHeaderHistoryEntry{Header: xdr.LedgerHeader{LedgerSeq: 100}}
+	s.mockReadTradeTransactions(ledger)
+
+	s.mockQ.On("CreateExpAccounts", mock.AnythingOfType("[]string")).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(0).([]string)
+			s.Assert().ElementsMatch(
+				mapKeysToList(s.accountToID),
+				arg,
+			)
+		}).Return(s.accountToID, nil).Once()
+
+	s.mockQ.On("CreateExpAssets", mock.AnythingOfType("[]xdr.Asset")).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(0).([]xdr.Asset)
+			s.Assert().ElementsMatch(
+				s.assets,
+				arg,
+			)
+		}).Return(s.assetToID, fmt.Errorf("create assets error")).Once()
+
+	err := s.processor.ProcessLedger(
+		s.context,
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().EqualError(err, "Error creating asset ids: create assets error")
+}
+
+func (s *TradeProcessorTestSuiteLedger) TestBatchAddError() {
+	ledger := xdr.LedgerHeaderHistoryEntry{Header: xdr.LedgerHeader{LedgerSeq: 100}}
+	s.mockReadTradeTransactions(ledger)
+
+	s.mockQ.On("CreateExpAccounts", mock.AnythingOfType("[]string")).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(0).([]string)
+			s.Assert().ElementsMatch(
+				mapKeysToList(s.accountToID),
+				arg,
+			)
+		}).Return(s.accountToID, nil).Once()
+
+	s.mockQ.On("CreateExpAssets", mock.AnythingOfType("[]xdr.Asset")).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(0).([]xdr.Asset)
+			s.Assert().ElementsMatch(
+				s.assets,
+				arg,
+			)
+		}).Return(s.assetToID, nil).Once()
+
+	s.mockBatchInsertBuilder.On("Add", mock.AnythingOfType("[]history.InsertTrade")).
+		Return(fmt.Errorf("batch add error")).Once()
+
+	err := s.processor.ProcessLedger(
+		s.context,
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().EqualError(err, "Error adding trade to batch: batch add error")
+}
+
+func (s *TradeProcessorTestSuiteLedger) TestBatchExecError() {
+	ledger := xdr.LedgerHeaderHistoryEntry{Header: xdr.LedgerHeader{LedgerSeq: 100}}
+	insert := s.mockReadTradeTransactions(ledger)
+
+	s.mockQ.On("CreateExpAccounts", mock.AnythingOfType("[]string")).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(0).([]string)
+			s.Assert().ElementsMatch(
+				mapKeysToList(s.accountToID),
+				arg,
+			)
+		}).Return(s.accountToID, nil).Once()
+
+	s.mockQ.On("CreateExpAssets", mock.AnythingOfType("[]xdr.Asset")).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(0).([]xdr.Asset)
+			s.Assert().ElementsMatch(
+				s.assets,
+				arg,
+			)
+		}).Return(s.assetToID, nil).Once()
+
+	s.mockBatchInsertBuilder.On("Add", mock.AnythingOfType("[]history.InsertTrade")).
+		Return(nil).Times(len(insert))
+	s.mockBatchInsertBuilder.On("Exec").Return(fmt.Errorf("exec error")).Once()
+
+	err := s.processor.ProcessLedger(
+		s.context,
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().EqualError(err, "Error flushing operation batch: exec error")
+}
+
+func (s *TradeProcessorTestSuiteLedger) TestIgnoreCheckIfSmallLedger() {
+	ledger := xdr.LedgerHeaderHistoryEntry{Header: xdr.LedgerHeader{LedgerSeq: 10}}
+	insert := s.mockReadTradeTransactions(ledger)
+
+	s.mockQ.On("CreateExpAccounts", mock.AnythingOfType("[]string")).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(0).([]string)
+			s.Assert().ElementsMatch(
+				mapKeysToList(s.accountToID),
+				arg,
+			)
+		}).Return(s.accountToID, nil).Once()
+
+	s.mockQ.On("CreateExpAssets", mock.AnythingOfType("[]xdr.Asset")).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(0).([]xdr.Asset)
+			s.Assert().ElementsMatch(
+				s.assets,
+				arg,
+			)
+		}).Return(s.assetToID, nil).Once()
+
+	s.mockBatchInsertBuilder.On("Add", mock.AnythingOfType("[]history.InsertTrade")).
+		Return(nil).Times(len(insert))
+	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
+
+	err := s.processor.ProcessLedger(
+		s.context,
+		&supportPipeline.Store{},
+		s.mockLedgerReader,
+		s.mockLedgerWriter,
+	)
+
+	s.Assert().NoError(err)
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add ingestion processor for trades.

### Why

We need to populate the historical trades table in order to serve trade endpoints.

### Known limitations

[N/A]
