### PR TITLE
exp/ingest/io: Remove support for TransactionMeta.V=0

### DIFF
--- a/exp/ingest/io/ledger_transaction_test.go
+++ b/exp/ingest/io/ledger_transaction_test.go
@@ -46,29 +46,32 @@ func TestFeeAndMetaChangesSeparate(t *testing.T) {
 			},
 		},
 		Meta: xdr.TransactionMeta{
-			Operations: &[]xdr.OperationMeta{
-				{
-					Changes: xdr.LedgerEntryChanges{
-						xdr.LedgerEntryChange{
-							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-							State: &xdr.LedgerEntry{
-								Data: xdr.LedgerEntryData{
-									Type: xdr.LedgerEntryTypeAccount,
-									Account: &xdr.AccountEntry{
-										AccountId: xdr.MustAddress("GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A"),
-										Balance:   300,
+			V: 1,
+			V1: &xdr.TransactionMetaV1{
+				Operations: []xdr.OperationMeta{
+					{
+						Changes: xdr.LedgerEntryChanges{
+							xdr.LedgerEntryChange{
+								Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+								State: &xdr.LedgerEntry{
+									Data: xdr.LedgerEntryData{
+										Type: xdr.LedgerEntryTypeAccount,
+										Account: &xdr.AccountEntry{
+											AccountId: xdr.MustAddress("GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A"),
+											Balance:   300,
+										},
 									},
 								},
 							},
-						},
-						xdr.LedgerEntryChange{
-							Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
-							Updated: &xdr.LedgerEntry{
-								Data: xdr.LedgerEntryData{
-									Type: xdr.LedgerEntryTypeAccount,
-									Account: &xdr.AccountEntry{
-										AccountId: xdr.MustAddress("GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A"),
-										Balance:   400,
+							xdr.LedgerEntryChange{
+								Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
+								Updated: &xdr.LedgerEntry{
+									Data: xdr.LedgerEntryData{
+										Type: xdr.LedgerEntryTypeAccount,
+										Account: &xdr.AccountEntry{
+											AccountId: xdr.MustAddress("GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A"),
+											Balance:   400,
+										},
 									},
 								},
 							},
@@ -83,7 +86,8 @@ func TestFeeAndMetaChangesSeparate(t *testing.T) {
 	assert.Equal(t, feeChanges[0].Pre.Data.MustAccount().Balance, xdr.Int64(100))
 	assert.Equal(t, feeChanges[0].Post.Data.MustAccount().Balance, xdr.Int64(200))
 
-	metaChanges := tx.GetChanges()
+	metaChanges, err := tx.GetChanges()
+	assert.NoError(t, err)
 	assert.Len(t, metaChanges, 1)
 	assert.Equal(t, metaChanges[0].Pre.Data.MustAccount().Balance, xdr.Int64(300))
 	assert.Equal(t, metaChanges[0].Post.Data.MustAccount().Balance, xdr.Int64(400))
@@ -203,7 +207,8 @@ func TestMetaV2Order(t *testing.T) {
 			},
 		}}
 
-	metaChanges := tx.GetChanges()
+	metaChanges, err := tx.GetChanges()
+	assert.NoError(t, err)
 	assert.Len(t, metaChanges, 4)
 
 	change := metaChanges[0]

--- a/exp/ingest/io/ledger_transaction_test.go
+++ b/exp/ingest/io/ledger_transaction_test.go
@@ -236,6 +236,17 @@ func TestMetaV2Order(t *testing.T) {
 	assert.Equal(t, change.Post.Data.MustAccount().Balance, xdr.Int64(400))
 }
 
+func TestMetaV0(t *testing.T) {
+	tx := LedgerTransaction{
+		Meta: xdr.TransactionMeta{
+			V: 0,
+		}}
+
+	_, err := tx.GetChanges()
+	assert.Error(t, err)
+	assert.EqualError(t, err, "TransactionMeta.V=0 not supported")
+}
+
 func TestChangeAccountChangedExceptSignersLastModifiedLedgerSeq(t *testing.T) {
 	change := Change{
 		Type: xdr.LedgerEntryTypeAccount,

--- a/exp/tools/horizon-demo/database_processor.go
+++ b/exp/tools/horizon-demo/database_processor.go
@@ -119,7 +119,11 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 }
 
 func (p *DatabaseProcessor) processLedgerAccountsForSigner(transaction io.LedgerTransaction) error {
-	for _, change := range transaction.GetChanges() {
+	changes, err := transaction.GetChanges()
+	if err != nil {
+		return err
+	}
+	for _, change := range changes {
 		if change.Type != xdr.LedgerEntryTypeAccount {
 			continue
 		}

--- a/exp/tools/horizon-demo/orderbook_processor.go
+++ b/exp/tools/horizon-demo/orderbook_processor.go
@@ -65,7 +65,12 @@ func (p *OrderbookProcessor) ProcessLedger(ctx context.Context, store *pipeline.
 			continue
 		}
 
-		for _, change := range transaction.GetChanges() {
+		changes, err := transaction.GetChanges()
+		if err != nil {
+			return err
+		}
+
+		for _, change := range changes {
 			if change.Type != xdr.LedgerEntryTypeOffer {
 				continue
 			}

--- a/services/horizon/internal/expingest/processors/accounts_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_processor_test.go
@@ -489,7 +489,10 @@ func (s *AccountsProcessorTestSuiteLedger) TestFeeProcessedBeforeEverythingElse(
 				},
 			},
 			Meta: xdr.TransactionMeta{
-				Operations: &[]xdr.OperationMeta{},
+				V: 1,
+				V1: &xdr.TransactionMetaV1{
+					Operations: []xdr.OperationMeta{},
+				},
 			},
 		}, nil).Once()
 

--- a/services/horizon/internal/expingest/processors/database_processor.go
+++ b/services/horizon/internal/expingest/processors/database_processor.go
@@ -263,7 +263,11 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 
 		// Tx meta
 		for _, transaction := range transactions {
-			for _, change := range transaction.GetChanges() {
+			changes, err := transaction.GetChanges()
+			if err != nil {
+				return errors.Wrap(err, "Error in transaction.GetChanges()")
+			}
+			for _, change := range changes {
 				err = ledgerCache.AddChange(change)
 				if err != nil {
 					return errors.Wrap(err, "error adding to ledgerCache")

--- a/services/horizon/internal/expingest/processors/database_processor.go
+++ b/services/horizon/internal/expingest/processors/database_processor.go
@@ -263,7 +263,8 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 
 		// Tx meta
 		for _, transaction := range transactions {
-			changes, err := transaction.GetChanges()
+			var changes []io.Change
+			changes, err = transaction.GetChanges()
 			if err != nil {
 				return errors.Wrap(err, "Error in transaction.GetChanges()")
 			}

--- a/services/horizon/internal/expingest/processors/offers_processor_test.go
+++ b/services/horizon/internal/expingest/processors/offers_processor_test.go
@@ -159,9 +159,9 @@ func (s *OffersProcessorTestSuiteLedger) TestInsertOffer() {
 		}),
 	}
 	// should be ignored because it's not an offer type
-	s.Assert().NoError(
-		s.processor.processLedgerOffers(accountTransaction.GetChanges()[0]),
-	)
+	changes, err := accountTransaction.GetChanges()
+	s.Assert().NoError(err)
+	s.Assert().NoError(s.processor.processLedgerOffers(changes[0]))
 
 	// add offer
 	offer := xdr.OfferEntry{
@@ -239,7 +239,7 @@ func (s *OffersProcessorTestSuiteLedger) TestInsertOffer() {
 		On("Read").
 		Return(io.LedgerTransaction{}, stdio.EOF).Once()
 
-	err := s.processor.ProcessLedger(
+	err = s.processor.ProcessLedger(
 		context.Background(),
 		&supportPipeline.Store{},
 		s.mockLedgerReader,

--- a/services/horizon/internal/expingest/processors/orderbook_processor.go
+++ b/services/horizon/internal/expingest/processors/orderbook_processor.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stellar/go/exp/ingest/io"
 	ingestpipeline "github.com/stellar/go/exp/ingest/pipeline"
 	"github.com/stellar/go/exp/support/pipeline"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 
@@ -65,7 +66,11 @@ func (p *OrderbookProcessor) ProcessLedger(ctx context.Context, store *pipeline.
 			continue
 		}
 
-		for _, change := range transaction.GetChanges() {
+		changes, err := transaction.GetChanges()
+		if err != nil {
+			return errors.Wrap(err, "Error in transaction.GetChanges()")
+		}
+		for _, change := range changes {
 			p.processChange(change)
 		}
 

--- a/services/horizon/internal/expingest/processors/trust_lines_processor_test.go
+++ b/services/horizon/internal/expingest/processors/trust_lines_processor_test.go
@@ -224,9 +224,9 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestInsertTrustLine() {
 		}),
 	}
 	// should be ignored because it's not an trust line type
-	s.Assert().NoError(
-		s.processor.processLedgerTrustLines(accountTransaction.GetChanges()[0]),
-	)
+	changes, err := accountTransaction.GetChanges()
+	s.Assert().NoError(err)
+	s.Assert().NoError(s.processor.processLedgerTrustLines(changes[0]))
 
 	// add trust line
 	trustLine := xdr.TrustLineEntry{
@@ -378,7 +378,7 @@ func (s *TrustLinesProcessorTestSuiteLedger) TestInsertTrustLine() {
 		On("Read").
 		Return(io.LedgerTransaction{}, stdio.EOF).Once()
 
-	err := s.processor.ProcessLedger(
+	err = s.processor.ProcessLedger(
 		context.Background(),
 		&supportPipeline.Store{},
 		s.mockLedgerReader,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit removes support for ingesting `TransactionMeta.V=0` in `io.LedgerTransaction.GetChanges`.

Close #2097.

### Why

The code generating V0 meta was changed in stellar-core but without upgrading the V param. Some V0 meta has only one `LEDGER_ENTRY_STATE` emitted only when a ledger entry is first modified in a ledger but others add it before every `LEDGER_ENTRY_UPDATE` and `LEDGER_ENTRY_REMOVED`. It looks like the code to parse meta to support both cases should be possible but since transaction meta in protocol version <10 can be incomplete (see https://github.com/stellar/go/issues/1902) users still need to switch to V2 to be able to parse it.

See:
* https://github.com/stellar/stellar-core/pull/944
* https://github.com/stellar/stellar-core/pull/1441

### Known limitations

`TransactionMeta` generated by the older versions of stellar-core will not be supported but the current code is in `LedgerTransaction.GetChanges` is broken anyway.