### PR TITLE
services/horizon/internal/expingest/processors: Remove sort on addresses in ParticipantsProcessor

### DIFF
--- a/services/horizon/internal/expingest/processors/operations_processor_test.go
+++ b/services/horizon/internal/expingest/processors/operations_processor_test.go
@@ -50,6 +50,7 @@ func (s *OperationsProcessorTestSuiteLedger) SetupTest() {
 
 func (s *OperationsProcessorTestSuiteLedger) TearDownTest() {
 	s.mockQ.AssertExpectations(s.T())
+	s.mockBatchInsertBuilder.AssertExpectations(s.T())
 	s.mockLedgerReader.AssertExpectations(s.T())
 	s.mockLedgerWriter.AssertExpectations(s.T())
 }

--- a/services/horizon/internal/expingest/processors/participants_processor.go
+++ b/services/horizon/internal/expingest/processors/participants_processor.go
@@ -3,7 +3,6 @@ package processors
 import (
 	"context"
 	stdio "io"
-	"sort"
 
 	"github.com/stellar/go/exp/ingest/io"
 	ingestpipeline "github.com/stellar/go/exp/ingest/pipeline"
@@ -45,7 +44,6 @@ func (p *ParticipantsProcessor) loadAccountIDs(participantSet map[string]partici
 	for address := range participantSet {
 		addresses = append(addresses, address)
 	}
-	sort.Strings(addresses)
 
 	addressToID, err := p.ParticipantsQ.CreateExpAccounts(addresses)
 	if err != nil {

--- a/services/horizon/internal/expingest/processors/participants_processor_test.go
+++ b/services/horizon/internal/expingest/processors/participants_processor_test.go
@@ -99,6 +99,8 @@ func (s *ParticipantsProcessorTestSuiteLedger) SetupTest() {
 
 func (s *ParticipantsProcessorTestSuiteLedger) TearDownTest() {
 	s.mockQ.AssertExpectations(s.T())
+	s.mockBatchInsertBuilder.AssertExpectations(s.T())
+	s.mockOperationsBatchInsertBuilder.AssertExpectations(s.T())
 	s.mockLedgerReader.AssertExpectations(s.T())
 	s.mockLedgerWriter.AssertExpectations(s.T())
 }

--- a/services/horizon/internal/expingest/processors/participants_processor_test.go
+++ b/services/horizon/internal/expingest/processors/participants_processor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/toid"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -24,15 +25,15 @@ type ParticipantsProcessorTestSuiteLedger struct {
 	mockLedgerWriter                 *io.MockLedgerWriter
 	context                          context.Context
 
-	firstTx         io.LedgerTransaction
-	secondTx        io.LedgerTransaction
-	thirdTx         io.LedgerTransaction
-	firstTxID       int64
-	secondTxID      int64
-	thirdTxID       int64
-	sequence        uint32
-	sortedAddresses []string
-	addressToID     map[string]int64
+	firstTx     io.LedgerTransaction
+	secondTx    io.LedgerTransaction
+	thirdTx     io.LedgerTransaction
+	firstTxID   int64
+	secondTxID  int64
+	thirdTxID   int64
+	sequence    uint32
+	addresses   []string
+	addressToID map[string]int64
 }
 
 func TestParticipantsProcessorTestSuiteLedger(t *testing.T) {
@@ -49,7 +50,7 @@ func (s *ParticipantsProcessorTestSuiteLedger) SetupTest() {
 
 	s.sequence = uint32(20)
 
-	s.sortedAddresses = []string{
+	s.addresses = []string{
 		"GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
 		"GAXI33UCLQTCKM2NMRBS7XYBR535LLEVAHL5YBN4FTCB4HZHT7ZA5CVK",
 		"GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
@@ -57,7 +58,7 @@ func (s *ParticipantsProcessorTestSuiteLedger) SetupTest() {
 
 	s.firstTx = createTransaction(true, 1)
 	s.firstTx.Index = 1
-	s.firstTx.Envelope.Tx.SourceAccount = xdr.MustAddress(s.sortedAddresses[0])
+	s.firstTx.Envelope.Tx.SourceAccount = xdr.MustAddress(s.addresses[0])
 	s.firstTxID = toid.New(int32(s.sequence), 1, 0).ToInt64()
 
 	s.secondTx = createTransaction(true, 1)
@@ -65,21 +66,21 @@ func (s *ParticipantsProcessorTestSuiteLedger) SetupTest() {
 	s.secondTx.Envelope.Tx.Operations[0].Body = xdr.OperationBody{
 		Type: xdr.OperationTypeCreateAccount,
 		CreateAccountOp: &xdr.CreateAccountOp{
-			Destination: xdr.MustAddress(s.sortedAddresses[1]),
+			Destination: xdr.MustAddress(s.addresses[1]),
 		},
 	}
-	s.secondTx.Envelope.Tx.SourceAccount = xdr.MustAddress(s.sortedAddresses[2])
+	s.secondTx.Envelope.Tx.SourceAccount = xdr.MustAddress(s.addresses[2])
 	s.secondTxID = toid.New(int32(s.sequence), 2, 0).ToInt64()
 
 	s.thirdTx = createTransaction(true, 1)
 	s.thirdTx.Index = 3
-	s.thirdTx.Envelope.Tx.SourceAccount = xdr.MustAddress(s.sortedAddresses[0])
+	s.thirdTx.Envelope.Tx.SourceAccount = xdr.MustAddress(s.addresses[0])
 	s.thirdTxID = toid.New(int32(s.sequence), 3, 0).ToInt64()
 
 	s.addressToID = map[string]int64{
-		s.sortedAddresses[0]: 2,
-		s.sortedAddresses[1]: 20,
-		s.sortedAddresses[2]: 200,
+		s.addresses[0]: 2,
+		s.addresses[1]: 20,
+		s.addresses[2]: 200,
 	}
 
 	s.processor = &ParticipantsProcessor{
@@ -119,33 +120,33 @@ func (s *ParticipantsProcessorTestSuiteLedger) mockLedgerReads() {
 
 func (s *ParticipantsProcessorTestSuiteLedger) mockSuccessfulTransactionBatchAdds() {
 	s.mockBatchInsertBuilder.On(
-		"Add", s.firstTxID, s.addressToID[s.sortedAddresses[0]],
+		"Add", s.firstTxID, s.addressToID[s.addresses[0]],
 	).Return(nil).Once()
 
 	s.mockBatchInsertBuilder.On(
-		"Add", s.secondTxID, s.addressToID[s.sortedAddresses[1]],
+		"Add", s.secondTxID, s.addressToID[s.addresses[1]],
 	).Return(nil).Once()
 	s.mockBatchInsertBuilder.On(
-		"Add", s.secondTxID, s.addressToID[s.sortedAddresses[2]],
+		"Add", s.secondTxID, s.addressToID[s.addresses[2]],
 	).Return(nil).Once()
 
 	s.mockBatchInsertBuilder.On(
-		"Add", s.thirdTxID, s.addressToID[s.sortedAddresses[0]],
+		"Add", s.thirdTxID, s.addressToID[s.addresses[0]],
 	).Return(nil).Once()
 }
 
 func (s *ParticipantsProcessorTestSuiteLedger) mockSuccessfulOperationBatchAdds() {
 	s.mockOperationsBatchInsertBuilder.On(
-		"Add", s.firstTxID+1, s.addressToID[s.sortedAddresses[0]],
+		"Add", s.firstTxID+1, s.addressToID[s.addresses[0]],
 	).Return(nil).Once()
 	s.mockOperationsBatchInsertBuilder.On(
-		"Add", s.secondTxID+1, s.addressToID[s.sortedAddresses[1]],
+		"Add", s.secondTxID+1, s.addressToID[s.addresses[1]],
 	).Return(nil).Once()
 	s.mockOperationsBatchInsertBuilder.On(
-		"Add", s.secondTxID+1, s.addressToID[s.sortedAddresses[2]],
+		"Add", s.secondTxID+1, s.addressToID[s.addresses[2]],
 	).Return(nil).Once()
 	s.mockOperationsBatchInsertBuilder.On(
-		"Add", s.thirdTxID+1, s.addressToID[s.sortedAddresses[0]],
+		"Add", s.thirdTxID+1, s.addressToID[s.addresses[0]],
 	).Return(nil).Once()
 }
 func (s *ParticipantsProcessorTestSuiteLedger) TestNoIngestUpdateDatabase() {
@@ -220,7 +221,14 @@ func (s *ParticipantsProcessorTestSuiteLedger) TestIngestParticipantsSucceeds() 
 
 	s.mockLedgerReads()
 
-	s.mockQ.On("CreateExpAccounts", s.sortedAddresses).Return(s.addressToID, nil).Once()
+	s.mockQ.On("CreateExpAccounts", mock.AnythingOfType("[]string")).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(0).([]string)
+			s.Assert().ElementsMatch(
+				s.addresses,
+				arg,
+			)
+		}).Return(s.addressToID, nil).Once()
 	s.mockQ.On("NewTransactionParticipantsBatchInsertBuilder", maxBatchSize).
 		Return(s.mockBatchInsertBuilder).Once()
 	s.mockQ.On("NewOperationParticipantBatchInsertBuilder", maxBatchSize).
@@ -249,7 +257,7 @@ func (s *ParticipantsProcessorTestSuiteLedger) TestCreateExpAccountsFails() {
 
 	s.mockLedgerReads()
 
-	s.mockQ.On("CreateExpAccounts", s.sortedAddresses).
+	s.mockQ.On("CreateExpAccounts", mock.AnythingOfType("[]string")).
 		Return(s.addressToID, errors.New("transient error")).Once()
 
 	err := s.processor.ProcessLedger(
@@ -266,24 +274,30 @@ func (s *ParticipantsProcessorTestSuiteLedger) TestBatchAddFails() {
 
 	s.mockLedgerReads()
 
-	s.mockQ.On("CreateExpAccounts", s.sortedAddresses).
-		Return(s.addressToID, nil).Once()
+	s.mockQ.On("CreateExpAccounts", mock.AnythingOfType("[]string")).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(0).([]string)
+			s.Assert().ElementsMatch(
+				s.addresses,
+				arg,
+			)
+		}).Return(s.addressToID, nil).Once()
 	s.mockQ.On("NewTransactionParticipantsBatchInsertBuilder", maxBatchSize).
 		Return(s.mockBatchInsertBuilder).Once()
 
 	s.mockBatchInsertBuilder.On(
-		"Add", s.firstTxID, s.addressToID[s.sortedAddresses[0]],
+		"Add", s.firstTxID, s.addressToID[s.addresses[0]],
 	).Return(errors.New("transient error")).Once()
 
 	s.mockBatchInsertBuilder.On(
-		"Add", s.secondTxID, s.addressToID[s.sortedAddresses[1]],
+		"Add", s.secondTxID, s.addressToID[s.addresses[1]],
 	).Return(nil).Maybe()
 	s.mockBatchInsertBuilder.On(
-		"Add", s.secondTxID, s.addressToID[s.sortedAddresses[2]],
+		"Add", s.secondTxID, s.addressToID[s.addresses[2]],
 	).Return(nil).Maybe()
 
 	s.mockBatchInsertBuilder.On(
-		"Add", s.thirdTxID, s.addressToID[s.sortedAddresses[0]],
+		"Add", s.thirdTxID, s.addressToID[s.addresses[0]],
 	).Return(nil).Maybe()
 
 	err := s.processor.ProcessLedger(
@@ -300,8 +314,14 @@ func (s *ParticipantsProcessorTestSuiteLedger) TestOperationParticipantsBatchAdd
 
 	s.mockLedgerReads()
 
-	s.mockQ.On("CreateExpAccounts", s.sortedAddresses).
-		Return(s.addressToID, nil).Once()
+	s.mockQ.On("CreateExpAccounts", mock.AnythingOfType("[]string")).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(0).([]string)
+			s.Assert().ElementsMatch(
+				s.addresses,
+				arg,
+			)
+		}).Return(s.addressToID, nil).Once()
 	s.mockQ.On("NewTransactionParticipantsBatchInsertBuilder", maxBatchSize).
 		Return(s.mockBatchInsertBuilder).Once()
 	s.mockQ.On("NewOperationParticipantBatchInsertBuilder", maxBatchSize).
@@ -310,16 +330,16 @@ func (s *ParticipantsProcessorTestSuiteLedger) TestOperationParticipantsBatchAdd
 	s.mockSuccessfulTransactionBatchAdds()
 
 	s.mockOperationsBatchInsertBuilder.On(
-		"Add", s.firstTxID+1, s.addressToID[s.sortedAddresses[0]],
+		"Add", s.firstTxID+1, s.addressToID[s.addresses[0]],
 	).Return(errors.New("transient error")).Once()
 	s.mockOperationsBatchInsertBuilder.On(
-		"Add", s.secondTxID+1, s.addressToID[s.sortedAddresses[1]],
+		"Add", s.secondTxID+1, s.addressToID[s.addresses[1]],
 	).Return(nil).Maybe()
 	s.mockOperationsBatchInsertBuilder.On(
-		"Add", s.secondTxID+1, s.addressToID[s.sortedAddresses[2]],
+		"Add", s.secondTxID+1, s.addressToID[s.addresses[2]],
 	).Return(nil).Maybe()
 	s.mockOperationsBatchInsertBuilder.On(
-		"Add", s.thirdTxID+1, s.addressToID[s.sortedAddresses[0]],
+		"Add", s.thirdTxID+1, s.addressToID[s.addresses[0]],
 	).Return(nil).Maybe()
 
 	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
@@ -338,7 +358,14 @@ func (s *ParticipantsProcessorTestSuiteLedger) TestBatchAddExecFails() {
 
 	s.mockLedgerReads()
 
-	s.mockQ.On("CreateExpAccounts", s.sortedAddresses).Return(s.addressToID, nil).Once()
+	s.mockQ.On("CreateExpAccounts", mock.AnythingOfType("[]string")).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(0).([]string)
+			s.Assert().ElementsMatch(
+				s.addresses,
+				arg,
+			)
+		}).Return(s.addressToID, nil).Once()
 	s.mockQ.On("NewTransactionParticipantsBatchInsertBuilder", maxBatchSize).
 		Return(s.mockBatchInsertBuilder).Once()
 
@@ -360,7 +387,14 @@ func (s *ParticipantsProcessorTestSuiteLedger) TestOpeartionBatchAddExecFails() 
 
 	s.mockLedgerReads()
 
-	s.mockQ.On("CreateExpAccounts", s.sortedAddresses).Return(s.addressToID, nil).Once()
+	s.mockQ.On("CreateExpAccounts", mock.AnythingOfType("[]string")).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(0).([]string)
+			s.Assert().ElementsMatch(
+				s.addresses,
+				arg,
+			)
+		}).Return(s.addressToID, nil).Once()
 	s.mockQ.On("NewTransactionParticipantsBatchInsertBuilder", maxBatchSize).
 		Return(s.mockBatchInsertBuilder).Once()
 	s.mockQ.On("NewOperationParticipantBatchInsertBuilder", maxBatchSize).

--- a/services/horizon/internal/expingest/processors/transactions_processor_test.go
+++ b/services/horizon/internal/expingest/processors/transactions_processor_test.go
@@ -44,6 +44,7 @@ func (s *TransactionsProcessorTestSuiteLedger) SetupTest() {
 
 func (s *TransactionsProcessorTestSuiteLedger) TearDownTest() {
 	s.mockQ.AssertExpectations(s.T())
+	s.mockBatchInsertBuilder.AssertExpectations(s.T())
 	s.mockLedgerReader.AssertExpectations(s.T())
 	s.mockLedgerWriter.AssertExpectations(s.T())
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove sort on addresses in ParticipantsProcessor

### Why

Previously, we sorted addresses before calling `ParticipantsQ.CreateExpAccounts()`.
The only purpose of the sort was to make it easier to mock the expected arguments of
`ParticipantsQ.CreateExpAccounts()` in the ParticipantsProcessor tests.

However, it turns out you can use `mock.AnythingOfType()` and `Assert().ElementsMatch()`
to assert that a mock was called with a list of arguments without enforcing a specific
order. With this functionality we can remove the sort in ParticipantsProcessor.

### Known limitations

[N/A]
