### PR TITLE
Sort signers before creating event.

### DIFF
--- a/services/horizon/internal/expingest/processors/effects_processor.go
+++ b/services/horizon/internal/expingest/processors/effects_processor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	stdio "io"
 	"reflect"
+	"sort"
 
 	"github.com/stellar/go/amount"
 	"github.com/stellar/go/exp/ingest/io"
@@ -170,6 +171,7 @@ func (p *EffectProcessor) ProcessLedger(ctx context.Context, store *pipeline.Sto
 	// legacy ingestion system might not be in sync
 	if sequence > 10 {
 		checkSequence := int32(sequence - 10)
+
 		var valid bool
 		valid, err = p.EffectsQ.CheckExpOperationEffects(checkSequence)
 		if err != nil {
@@ -495,7 +497,13 @@ func (operation *transactionOperationWrapper) setOptionsEffects() ([]effect, err
 			continue
 		}
 
-		for addy := range before {
+		sortedSigners := []string{}
+		for signer := range before {
+			sortedSigners = append(sortedSigners, signer)
+		}
+		sort.Strings(sortedSigners)
+
+		for _, addy := range sortedSigners {
 			weight, ok := after[addy]
 			if !ok {
 				effects.add(source.Address(), history.EffectSignerRemoved, map[string]interface{}{
@@ -509,8 +517,15 @@ func (operation *transactionOperationWrapper) setOptionsEffects() ([]effect, err
 			})
 		}
 
+		sortedSigners = []string{}
+		for signer := range after {
+			sortedSigners = append(sortedSigners, signer)
+		}
+		sort.Strings(sortedSigners)
+
 		// Add the "created" effects
-		for addy, weight := range after {
+		for _, addy := range sortedSigners {
+			weight := after[addy]
 			// if `addy` is in before, the previous for loop should have recorded
 			// the update, so skip this key
 			if _, ok := before[addy]; ok {

--- a/services/horizon/internal/expingest/processors/effects_processor.go
+++ b/services/horizon/internal/expingest/processors/effects_processor.go
@@ -497,13 +497,13 @@ func (operation *transactionOperationWrapper) setOptionsEffects() ([]effect, err
 			continue
 		}
 
-		sortedSigners := []string{}
+		beforeSortedSigners := []string{}
 		for signer := range before {
-			sortedSigners = append(sortedSigners, signer)
+			beforeSortedSigners = append(beforeSortedSigners, signer)
 		}
-		sort.Strings(sortedSigners)
+		sort.Strings(beforeSortedSigners)
 
-		for _, addy := range sortedSigners {
+		for _, addy := range beforeSortedSigners {
 			weight, ok := after[addy]
 			if !ok {
 				effects.add(source.Address(), history.EffectSignerRemoved, map[string]interface{}{
@@ -517,14 +517,14 @@ func (operation *transactionOperationWrapper) setOptionsEffects() ([]effect, err
 			})
 		}
 
-		sortedSigners = []string{}
+		afterSortedSigners := []string{}
 		for signer := range after {
-			sortedSigners = append(sortedSigners, signer)
+			afterSortedSigners = append(afterSortedSigners, signer)
 		}
-		sort.Strings(sortedSigners)
+		sort.Strings(afterSortedSigners)
 
 		// Add the "created" effects
-		for _, addy := range sortedSigners {
+		for _, addy := range afterSortedSigners {
 			weight := after[addy]
 			// if `addy` is in before, the previous for loop should have recorded
 			// the update, so skip this key

--- a/services/horizon/internal/ingest/session.go
+++ b/services/horizon/internal/ingest/session.go
@@ -505,13 +505,13 @@ func (is *Session) ingestSignerEffects(effects *EffectIngestion, op xdr.SetOptio
 		return
 	}
 
-	sortedSigners := []string{}
+	beforeSortedSigners := []string{}
 	for signer := range before {
-		sortedSigners = append(sortedSigners, signer)
+		beforeSortedSigners = append(beforeSortedSigners, signer)
 	}
-	sort.Strings(sortedSigners)
+	sort.Strings(beforeSortedSigners)
 
-	for _, addy := range sortedSigners {
+	for _, addy := range beforeSortedSigners {
 		weight, ok := after[addy]
 		if !ok {
 			effects.Add(source, history.EffectSignerRemoved, map[string]interface{}{
@@ -525,14 +525,14 @@ func (is *Session) ingestSignerEffects(effects *EffectIngestion, op xdr.SetOptio
 		})
 	}
 
-	sortedSigners = []string{}
+	afterSortedSigners := []string{}
 	for signer := range after {
-		sortedSigners = append(sortedSigners, signer)
+		afterSortedSigners = append(afterSortedSigners, signer)
 	}
-	sort.Strings(sortedSigners)
+	sort.Strings(afterSortedSigners)
 
 	// Add the "created" effects
-	for _, addy := range sortedSigners {
+	for _, addy := range afterSortedSigners {
 		weight := after[addy]
 		// if `addy` is in before, the previous for loop should have recorded
 		// the update, so skip this key

--- a/services/horizon/internal/ingest/session.go
+++ b/services/horizon/internal/ingest/session.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"reflect"
+	"sort"
 	"time"
 
 	"github.com/stellar/go/clients/stellarcore"
@@ -504,7 +505,13 @@ func (is *Session) ingestSignerEffects(effects *EffectIngestion, op xdr.SetOptio
 		return
 	}
 
-	for addy := range before {
+	sortedSigners := []string{}
+	for signer := range before {
+		sortedSigners = append(sortedSigners, signer)
+	}
+	sort.Strings(sortedSigners)
+
+	for _, addy := range sortedSigners {
 		weight, ok := after[addy]
 		if !ok {
 			effects.Add(source, history.EffectSignerRemoved, map[string]interface{}{
@@ -517,8 +524,16 @@ func (is *Session) ingestSignerEffects(effects *EffectIngestion, op xdr.SetOptio
 			"weight":     weight,
 		})
 	}
+
+	sortedSigners = []string{}
+	for signer := range after {
+		sortedSigners = append(sortedSigners, signer)
+	}
+	sort.Strings(sortedSigners)
+
 	// Add the "created" effects
-	for addy, weight := range after {
+	for _, addy := range sortedSigners {
+		weight := after[addy]
 		// if `addy` is in before, the previous for loop should have recorded
 		// the update, so skip this key
 		if _, ok := before[addy]; ok {

--- a/services/horizon/internal/ingest/session_test.go
+++ b/services/horizon/internal/ingest/session_test.go
@@ -82,6 +82,23 @@ func Test_ingestOperationEffects(t *testing.T) {
 	err = effects[1].UnmarshalDetails(&ad)
 	tt.Require.NoError(err)
 	tt.Assert.Equal("100.0000000", ad.Amount)
+
+	err = q.Effects().ForOperation(137438961665).Page(pq).Select(&effects)
+	tt.Require.NoError(err)
+
+	// ensure signer updates are stored ordered by detail's public_key
+	if tt.Assert.Len(effects, 2) {
+		tt.Assert.Equal(history.EffectSignerRemoved, effects[0].Type)
+		tt.Assert.Equal(
+			"{\"public_key\": \"GB6J3WOLKYQE6KVDZEA4JDMFTTONUYP3PUHNDNZRWIKA6JQWIMJZATFE\"}",
+			effects[0].DetailsString.String,
+		)
+		tt.Assert.Equal(history.EffectSignerUpdated, effects[1].Type)
+		tt.Assert.Equal(
+			"{\"weight\": 2, \"public_key\": \"GCIFFRQKHMH6JD7CK5OI4XVCYCMNRNF6PYA7JTCR3FPHPJZQTYYFB5ES\"}",
+			effects[1].DetailsString.String,
+		)
+	}
 }
 
 func Test_ingestBumpSeq(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Save effect details order by address when ingesting set_option operations.

### Why

We got some failures when running `CheckExpOperationEffects`, however, after analyzing the data, we found out that  we have the desired result but the order was swapped:


```
horizon_prod=# select * from history_effects where history_operation_id=119137419218964481 ORDER BY "order";
select * from history_effects where history_operation_id=119137419218964481 ORDER BY "order";
 history_account_id | history_operation_id | order | type |                                         details
--------------------+----------------------+-------+------+-----------------------------------------------------------------------------------------
             192294 |   119137419218964481 |     1 |    4 | {"high_threshold": 0}
             192294 |   119137419218964481 |     2 |   12 | {"weight": 1, "public_key": "GDWTQTPLJRSPHEZQTXD7XBZM4URTR52Q7QYPQWWI35KXBT67Q4A7J3UQ"}
             192294 |   119137419218964481 |     3 |   11 | {"public_key": "GC7BWB2ME4LII3TVWTHUIT7KGJXU4D5M6JUNLQ57WA7JERDNSAEXLOAN"}

```
vs 

```
select * from exp_history_effects where history_operation_id=119137419218964481 ORDER BY "order";
 history_account_id | history_operation_id | order | type |                                         details
--------------------+----------------------+-------+------+-----------------------------------------------------------------------------------------
             198270 |   119137419218964481 |     1 |    4 | {"high_threshold": 0}
             198270 |   119137419218964481 |     2 |   11 | {"public_key": "GC7BWB2ME4LII3TVWTHUIT7KGJXU4D5M6JUNLQ57WA7JERDNSAEXLOAN"}
             198270 |   119137419218964481 |     3 |   12 | {"weight": 1, "public_key": "GDWTQTPLJRSPHEZQTXD7XBZM4URTR52Q7QYPQWWI35KXBT67Q4A7J3UQ"}
```

The reason for this is that doing a `for` in the result from `SignerSummary` can yield a different order each time because we are iterating over a map.

To fix this mismatch,  we are going to sort the addresses before saving them, allowing us to store the information in the same order in both the old and new ingestion system.

### Known limitations

N/A