### PR TITLE
services/horizon/internal/actions: Serve /accounts/{id} using expingest data

### DIFF
--- a/services/horizon/internal/action.go
+++ b/services/horizon/internal/action.go
@@ -179,25 +179,22 @@ func (w *web) getAccountInfo(ctx context.Context, qp *showActionQueryParams) (in
 	// Use AppFromContext to prevent larger refactoring of actions code. Will
 	// be removed once this endpoint is migrated to use new actions design.
 	app := AppFromContext(ctx)
-	var historyQ *history.Q
 
-	if app.config.EnableExperimentalIngestion {
-		horizonSession, err := w.horizonSession(ctx)
-		if err != nil {
-			return nil, errors.Wrap(err, "getting horizon db session")
-		}
-
-		err = horizonSession.BeginTx(&sql.TxOptions{
-			Isolation: sql.LevelRepeatableRead,
-			ReadOnly:  true,
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "error starting transaction")
-		}
-
-		defer horizonSession.Rollback()
-		historyQ = &history.Q{horizonSession}
+	horizonSession, err := w.horizonSession(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting horizon db session")
 	}
+
+	err = horizonSession.BeginTx(&sql.TxOptions{
+		Isolation: sql.LevelRepeatableRead,
+		ReadOnly:  true,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "error starting transaction")
+	}
+
+	defer horizonSession.Rollback()
+	historyQ := &history.Q{horizonSession}
 
 	return actions.AccountInfo(ctx, &core.Q{w.coreSession(ctx)}, historyQ, qp.AccountID, app.config.EnableExperimentalIngestion)
 }

--- a/services/horizon/internal/actions_account_test.go
+++ b/services/horizon/internal/actions_account_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/test"
 )
 
 func TestAccountActions_Show(t *testing.T) {
 	ht := StartHTTPTest(t, "allow_trust")
 	defer ht.Finish()
+	test.ResetHorizonDB(t, ht.HorizonDB)
 
 	// existing account
 	w := ht.Get(
@@ -40,6 +42,7 @@ func TestAccountActions_Show(t *testing.T) {
 func TestAccountActions_ShowRegressions(t *testing.T) {
 	ht := StartHTTPTest(t, "base")
 	defer ht.Finish()
+	test.ResetHorizonDB(t, ht.HorizonDB)
 
 	w := ht.Get(
 		"/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes https://github.com/stellar/go/issues/2102

> Currently we still serve account data from the core DB and just compare the data to the new ingestion system. We should switch to the new ingestion data but keep the compare code there. It should emit ERROR if a difference is found.

### Known limitations

[N/A]
