### PR TITLE
exp/ingest/io: Ignore operation and txChangesAfter meta if tx result is txInternalError.

### DIFF
--- a/exp/ingest/io/ledger_transaction.go
+++ b/exp/ingest/io/ledger_transaction.go
@@ -151,6 +151,11 @@ func (t *LedgerTransaction) Successful() bool {
 	return t.Result.Result.Result.Code == xdr.TransactionResultCodeTxSuccess
 }
 
+// TxInternalError returns true if the transaction result is TxInternalError
+func (t *LedgerTransaction) TxInternalError() bool {
+	return t.Result.Result.Result.Code == xdr.TransactionResultCodeTxInternalError
+}
+
 // GetFeeChanges returns a developer friendly representation of LedgerEntryChanges
 // connected to fees.
 func (t *LedgerTransaction) GetFeeChanges() []Change {
@@ -158,8 +163,9 @@ func (t *LedgerTransaction) GetFeeChanges() []Change {
 }
 
 // GetChanges returns a developer friendly representation of LedgerEntryChanges.
-// It contains transaction changes and operation changes in that order.
-// It doesn't support legacy TransactionMeta.V=0.
+// It contains transaction changes and operation changes in that order. If the
+// transaction failed with TxInternalError, operations and txChangesAfter are
+// omitted. It doesn't support legacy TransactionMeta.V=0.
 func (t *LedgerTransaction) GetChanges() ([]Change, error) {
 	var changes []Change
 
@@ -172,16 +178,28 @@ func (t *LedgerTransaction) GetChanges() ([]Change, error) {
 		txChanges := getChangesFromLedgerEntryChanges(v1Meta.TxChanges)
 		changes = append(changes, txChanges...)
 
+		// Ignore operations meta if txInternalError https://github.com/stellar/go/issues/2111
+		if t.TxInternalError() {
+			return changes, nil
+		}
+
 		for _, operationMeta := range v1Meta.Operations {
 			opChanges := getChangesFromLedgerEntryChanges(
 				operationMeta.Changes,
 			)
 			changes = append(changes, opChanges...)
 		}
+
 	case 2:
 		v2Meta := t.Meta.MustV2()
 		txChangesBefore := getChangesFromLedgerEntryChanges(v2Meta.TxChangesBefore)
 		changes = append(changes, txChangesBefore...)
+
+		// Ignore operations meta and txChangesAfter if txInternalError
+		// https://github.com/stellar/go/issues/2111
+		if t.TxInternalError() {
+			return changes, nil
+		}
 
 		for _, operationMeta := range v2Meta.Operations {
 			opChanges := getChangesFromLedgerEntryChanges(
@@ -202,7 +220,12 @@ func (t *LedgerTransaction) GetChanges() ([]Change, error) {
 // GetOperationChanges returns a developer friendly representation of LedgerEntryChanges.
 // It contains only operation changes.
 func (t *LedgerTransaction) GetOperationChanges(operationIndex uint32) ([]Change, error) {
-	var changes []Change
+	changes := []Change{}
+
+	// Ignore operations meta if txInternalError https://github.com/stellar/go/issues/2111
+	if t.Meta.V > 0 && t.TxInternalError() {
+		return changes, nil
+	}
 
 	// Transaction meta
 	switch t.Meta.V {

--- a/exp/ingest/io/ledger_transaction.go
+++ b/exp/ingest/io/ledger_transaction.go
@@ -222,19 +222,24 @@ func (t *LedgerTransaction) GetChanges() ([]Change, error) {
 func (t *LedgerTransaction) GetOperationChanges(operationIndex uint32) ([]Change, error) {
 	changes := []Change{}
 
-	// Ignore operations meta if txInternalError https://github.com/stellar/go/issues/2111
-	if t.Meta.V > 0 && t.TxInternalError() {
-		return changes, nil
-	}
-
 	// Transaction meta
 	switch t.Meta.V {
 	case 0:
 		return changes, errors.New("TransactionMeta.V=0 not supported")
 	case 1:
+		// Ignore operations meta if txInternalError https://github.com/stellar/go/issues/2111
+		if t.TxInternalError() {
+			return changes, nil
+		}
+
 		v1Meta := t.Meta.MustV1()
 		changes = operationChanges(v1Meta.Operations, operationIndex)
 	case 2:
+		// Ignore operations meta if txInternalError https://github.com/stellar/go/issues/2111
+		if t.TxInternalError() {
+			return changes, nil
+		}
+
 		v2Meta := t.Meta.MustV2()
 		changes = operationChanges(v2Meta.Operations, operationIndex)
 	default:

--- a/exp/ingest/io/ledger_transaction.go
+++ b/exp/ingest/io/ledger_transaction.go
@@ -146,14 +146,18 @@ func (c *Change) AccountSignersChanged() bool {
 	return false
 }
 
-// Successful returns true if the transaction succeeded
-func (t *LedgerTransaction) Successful() bool {
-	return t.Result.Result.Result.Code == xdr.TransactionResultCodeTxSuccess
+// TxResultCode returns the transaction result code
+func (t *LedgerTransaction) TxResultCode() xdr.TransactionResultCode {
+	return t.Result.Result.Result.Code
 }
 
-// TxInternalError returns true if the transaction result is TxInternalError
-func (t *LedgerTransaction) TxInternalError() bool {
-	return t.Result.Result.Result.Code == xdr.TransactionResultCodeTxInternalError
+// Successful returns true if the transaction succeeded
+func (t *LedgerTransaction) Successful() bool {
+	return t.TxResultCode() == xdr.TransactionResultCodeTxSuccess
+}
+
+func (t *LedgerTransaction) txInternalError() bool {
+	return t.TxResultCode() == xdr.TransactionResultCodeTxInternalError
 }
 
 // GetFeeChanges returns a developer friendly representation of LedgerEntryChanges
@@ -179,7 +183,7 @@ func (t *LedgerTransaction) GetChanges() ([]Change, error) {
 		changes = append(changes, txChanges...)
 
 		// Ignore operations meta if txInternalError https://github.com/stellar/go/issues/2111
-		if t.TxInternalError() {
+		if t.txInternalError() {
 			return changes, nil
 		}
 
@@ -197,7 +201,7 @@ func (t *LedgerTransaction) GetChanges() ([]Change, error) {
 
 		// Ignore operations meta and txChangesAfter if txInternalError
 		// https://github.com/stellar/go/issues/2111
-		if t.TxInternalError() {
+		if t.txInternalError() {
 			return changes, nil
 		}
 
@@ -228,7 +232,7 @@ func (t *LedgerTransaction) GetOperationChanges(operationIndex uint32) ([]Change
 		return changes, errors.New("TransactionMeta.V=0 not supported")
 	case 1:
 		// Ignore operations meta if txInternalError https://github.com/stellar/go/issues/2111
-		if t.TxInternalError() {
+		if t.txInternalError() {
 			return changes, nil
 		}
 
@@ -236,7 +240,7 @@ func (t *LedgerTransaction) GetOperationChanges(operationIndex uint32) ([]Change
 		changes = operationChanges(v1Meta.Operations, operationIndex)
 	case 2:
 		// Ignore operations meta if txInternalError https://github.com/stellar/go/issues/2111
-		if t.TxInternalError() {
+		if t.txInternalError() {
 			return changes, nil
 		}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Ignore operation and txChangesAfter meta if tx result is txInternalError.

### Why

Due to a tx meta generation bug in stellar-core (https://github.com/stellar/stellar-core/pull/2383) it's possible that tx meta is incorrect for transactions with `txInternalError` result code. For such transactions, operations meta should be ignored but we should still apply `TxChanges` in v1 and `txChangesBefore` in v2. See #2111  for more info.

### Known limitations

[TODO or N/A]
