### PR TITLE
services/horizon/internal/actions: Remove GetCreateAssetID usage from actions.

### DIFF
--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"
+	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/support/time"
 	"github.com/stellar/go/xdr"
 )
@@ -196,20 +197,42 @@ func (action *TradeAggregateIndexAction) loadRecords() {
 	historyQ := action.HistoryQ()
 
 	//get asset ids
-	baseAssetId, err := historyQ.GetCreateAssetID(action.BaseAssetFilter)
+	baseAssetID, err := historyQ.GetAssetID(action.BaseAssetFilter)
 	if err != nil {
-		action.Err = err
+		if historyQ.NoRows(err) {
+			notFound := problem.NotFound
+			problem.AddInvalidField(
+				&notFound,
+				"base_asset",
+				errors.New("not found"),
+			)
+			action.Err = notFound
+		} else {
+			action.Err = err
+		}
+
 		return
 	}
-	counterAssetId, err := historyQ.GetCreateAssetID(action.CounterAssetFilter)
+	counterAssetID, err := historyQ.GetAssetID(action.CounterAssetFilter)
 	if err != nil {
-		action.Err = err
+		if historyQ.NoRows(err) {
+			notFound := problem.NotFound
+			problem.AddInvalidField(
+				&notFound,
+				"counter_asset",
+				errors.New("not found"),
+			)
+			action.Err = notFound
+		} else {
+			action.Err = err
+		}
+
 		return
 	}
 
 	//initialize the query builder with required params
 	tradeAggregationsQ, err := historyQ.GetTradeAggregationsQ(
-		baseAssetId, counterAssetId, action.ResolutionFilter, action.OffsetFilter, action.PagingParams)
+		baseAssetID, counterAssetID, action.ResolutionFilter, action.OffsetFilter, action.PagingParams)
 	if err != nil {
 		action.Err = err
 		return

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -200,13 +200,11 @@ func (action *TradeAggregateIndexAction) loadRecords() {
 	baseAssetID, err := historyQ.GetAssetID(action.BaseAssetFilter)
 	if err != nil {
 		if historyQ.NoRows(err) {
-			notFound := problem.NotFound
-			problem.SetInvalidField(
-				&notFound,
+			action.Err = problem.NewProblemWithInvalidField(
+				problem.NotFound,
 				"base_asset",
 				errors.New("not found"),
 			)
-			action.Err = notFound
 		} else {
 			action.Err = err
 		}
@@ -216,13 +214,11 @@ func (action *TradeAggregateIndexAction) loadRecords() {
 	counterAssetID, err := historyQ.GetAssetID(action.CounterAssetFilter)
 	if err != nil {
 		if historyQ.NoRows(err) {
-			notFound := problem.NotFound
-			problem.SetInvalidField(
-				&notFound,
+			action.Err = problem.NewProblemWithInvalidField(
+				problem.NotFound,
 				"counter_asset",
 				errors.New("not found"),
 			)
-			action.Err = notFound
 		} else {
 			action.Err = err
 		}

--- a/services/horizon/internal/actions_trade.go
+++ b/services/horizon/internal/actions_trade.go
@@ -201,7 +201,7 @@ func (action *TradeAggregateIndexAction) loadRecords() {
 	if err != nil {
 		if historyQ.NoRows(err) {
 			notFound := problem.NotFound
-			problem.AddInvalidField(
+			problem.SetInvalidField(
 				&notFound,
 				"base_asset",
 				errors.New("not found"),
@@ -217,7 +217,7 @@ func (action *TradeAggregateIndexAction) loadRecords() {
 	if err != nil {
 		if historyQ.NoRows(err) {
 			notFound := problem.NotFound
-			problem.AddInvalidField(
+			problem.SetInvalidField(
 				&notFound,
 				"counter_asset",
 				errors.New("not found"),

--- a/services/horizon/internal/render/problem/problem_test.go
+++ b/services/horizon/internal/render/problem/problem_test.go
@@ -2,6 +2,7 @@ package problem
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"testing"
 
@@ -32,4 +33,45 @@ func TestCommonProblems(t *testing.T) {
 			assert.Equal(t, tc.expectedCode, w.Code)
 		})
 	}
+}
+
+func TestMakeProblemWithInvalidField(t *testing.T) {
+	tt := assert.New(t)
+
+	p := problem.NewProblemWithInvalidField(
+		problem.NotFound,
+		"key",
+		errors.New("not found"),
+	)
+
+	expectedErr := map[string]interface{}{
+		"invalid_field": "key",
+		"reason":        "not found",
+	}
+
+	tt.Equal(expectedErr, p.Extras)
+	tt.Equal(p.Type, "not_found")
+
+	// it doesn't add keys to source problem
+	tt.Len(problem.NotFound.Extras, 0)
+}
+
+func TestMakeInvalidFieldProblem(t *testing.T) {
+	tt := assert.New(t)
+
+	p := problem.MakeInvalidFieldProblem(
+		"key",
+		errors.New("not found"),
+	)
+
+	expectedErr := map[string]interface{}{
+		"invalid_field": "key",
+		"reason":        "not found",
+	}
+
+	tt.Equal(expectedErr, p.Extras)
+	tt.Equal(p.Type, "bad_request")
+
+	// it doesn't add keys to source problem
+	tt.Len(problem.BadRequest.Extras, 0)
 }

--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -188,9 +188,14 @@ func (ps *Problem) renderProblem(ctx context.Context, w http.ResponseWriter, p P
 // MakeInvalidFieldProblem is a helper function to make a BadRequest with extras
 func MakeInvalidFieldProblem(name string, reason error) *P {
 	br := BadRequest
-	br.Extras = map[string]interface{}{
+	AddInvalidField(&br, name, reason)
+	return &br
+}
+
+// AddInvalidField adds invalid field extras to a given P
+func AddInvalidField(p *P, name string, reason error) {
+	p.Extras = map[string]interface{}{
 		"invalid_field": name,
 		"reason":        reason.Error(),
 	}
-	return &br
 }

--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -192,7 +192,7 @@ func MakeInvalidFieldProblem(name string, reason error) *P {
 	return &br
 }
 
-// SetInvalidField adds invalid field extras to a given P
+// SetInvalidField sets the invalid_field key in extras with the given reason.
 func SetInvalidField(p *P, name string, reason error) {
 	p.Extras = map[string]interface{}{
 		"invalid_field": name,

--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -188,12 +188,12 @@ func (ps *Problem) renderProblem(ctx context.Context, w http.ResponseWriter, p P
 // MakeInvalidFieldProblem is a helper function to make a BadRequest with extras
 func MakeInvalidFieldProblem(name string, reason error) *P {
 	br := BadRequest
-	AddInvalidField(&br, name, reason)
+	SetInvalidField(&br, name, reason)
 	return &br
 }
 
-// AddInvalidField adds invalid field extras to a given P
-func AddInvalidField(p *P, name string, reason error) {
+// SetInvalidField adds invalid field extras to a given P
+func SetInvalidField(p *P, name string, reason error) {
 	p.Extras = map[string]interface{}{
 		"invalid_field": name,
 		"reason":        reason.Error(),

--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -187,15 +187,19 @@ func (ps *Problem) renderProblem(ctx context.Context, w http.ResponseWriter, p P
 
 // MakeInvalidFieldProblem is a helper function to make a BadRequest with extras
 func MakeInvalidFieldProblem(name string, reason error) *P {
-	br := BadRequest
-	SetInvalidField(&br, name, reason)
-	return &br
+	return NewProblemWithInvalidField(
+		BadRequest,
+		name,
+		reason,
+	)
 }
 
-// SetInvalidField sets the invalid_field key in extras with the given reason.
-func SetInvalidField(p *P, name string, reason error) {
+// NewProblemWithInvalidField creates a copy of the given problem, setting the
+// invalid_field key in extras with the given reason.
+func NewProblemWithInvalidField(p P, name string, reason error) *P {
 	p.Extras = map[string]interface{}{
 		"invalid_field": name,
 		"reason":        reason.Error(),
 	}
+	return &p
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

 Remove `GetCreateAssetID` usage from actions. Fix #2061

### Why
`GetCreateAssetID` writes data to the DB when an asset is not found, but Horizon shouldn't need write access to a DB outside `ingest` package, this also causes some errors as described in #2061. 

This PR updates the action to use `GetAssetID`  and returns `404` if the user is trying to fetch data for an asset which doesn't exist.

### Known limitations

[TODO or N/A]
