### PR TITLE
services/horizon: Remove ingest initialization code

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/expingest"
-	"github.com/stellar/go/services/horizon/internal/ingest"
 	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/logmetrics"
 	"github.com/stellar/go/services/horizon/internal/operationfeestats"
@@ -48,7 +47,6 @@ type App struct {
 	coreSupportedProtocolVersion int32
 	submitter                    *txsub.System
 	paths                        paths.Finder
-	ingester                     *ingest.System
 	expingester                  *expingest.System
 	reaper                       *reap.System
 	ticks                        *time.Ticker
@@ -405,10 +403,6 @@ func (a *App) Tick() {
 	go func() { a.UpdateStellarCoreInfo(); wg.Done() }()
 	wg.Wait()
 
-	if a.ingester != nil {
-		go a.ingester.Tick()
-	}
-
 	wg.Add(2)
 	go func() { a.reaper.Tick(); wg.Done() }()
 	go func() { a.submitter.Tick(a.ctx); wg.Done() }()
@@ -442,21 +436,17 @@ func (a *App) init() {
 	mustInitHorizonDB(a)
 	mustInitCoreDB(a)
 
-	// ingester
-	initIngester(a)
-
 	var orderBookGraph *orderbook.OrderBookGraph
-	if a.config.EnableExperimentalIngestion {
+	if a.config.Ingest {
 		orderBookGraph = orderbook.NewOrderBookGraph()
 		// expingester
 		initExpIngester(a, orderBookGraph)
+		// path-finder
+		initPathFinder(a, orderBookGraph)
 	}
 
 	// txsub
 	initSubmissionSystem(a)
-
-	// path-finder
-	initPathFinder(a, orderBookGraph)
 
 	// reaper
 	a.reaper = reap.New(a.config.HistoryRetentionCount, a.HorizonSession(context.Background()))
@@ -499,9 +489,6 @@ func (a *App) init() {
 
 	// txsub.metrics
 	initTxSubMetrics(a)
-
-	// ingester.metrics
-	initIngesterMetrics(a)
 
 	// redis
 	initRedis(a)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit removes `ingest` initialization code.

### Why

The new `expingest` system will become the default ingestion system in 0.25.0 so we remove the old system init code and start `expingest` when `INGEST` flag is set.

Starting `expingest` system when `INGEST` flag is set solves two problems:
* It allows running ingestion servers that are not hit with a large number of requests so CPU usage is easier to predict (note: `/paths` and `/order_book` will only work on ingesting machines, Horizon admins need to configure proxy to pass such requests to ingesting instances).
* It allows easier upgrade. If new ingestion was running on all instances it's possible that during the gradual deploy old ingesting instance (in the old system only one instance could ingest data) would still ingest data and this could lead to errors. 