### PR TITLE
services/horizon/internal: Replace StateReady() check

### DIFF
--- a/services/horizon/internal/actions_path_test.go
+++ b/services/horizon/internal/actions_path_test.go
@@ -49,9 +49,6 @@ func inMemoryPathFindingClient(
 		&ExperimentalIngestionMiddleware{
 			EnableExperimentalIngestion: true,
 			HorizonSession:              tt.HorizonSession(),
-			StateReady: func() bool {
-				return true
-			},
 		},
 	)
 	return test.NewRequestHelper(router)
@@ -87,9 +84,6 @@ func dbPathFindingClient(
 		&ExperimentalIngestionMiddleware{
 			EnableExperimentalIngestion: false,
 			HorizonSession:              tt.HorizonSession(),
-			StateReady: func() bool {
-				return false
-			},
 		},
 	)
 	return test.NewRequestHelper(router)

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -465,12 +465,6 @@ func (a *App) init() {
 	requiresExperimentalIngestion := &ExperimentalIngestionMiddleware{
 		EnableExperimentalIngestion: a.config.EnableExperimentalIngestion,
 		HorizonSession:              a.historyQ.Session,
-		StateReady: func() bool {
-			if !a.config.EnableExperimentalIngestion {
-				return false
-			}
-			return a.expingester.StateReady()
-		},
 	}
 	// web.actions
 	a.web.mustInstallActions(a.config, a.paths, orderBookGraph, requiresExperimentalIngestion)

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -122,8 +122,6 @@ type System struct {
 	historyQ         dbQ
 	historySession   dbSession
 	graph            *orderbook.OrderBookGraph
-	stateReady       bool
-	stateReadyLock   sync.RWMutex
 	maxStreamRetries int
 	wg               sync.WaitGroup
 	shutdown         chan struct{}
@@ -520,19 +518,6 @@ func (s *System) verifyRange() (state, error) {
 	}
 
 	return state{systemState: shutdownState, returnError: err}, err
-}
-
-// StateReady returns true if the ingestion system has finished running it's state pipelines
-func (s *System) StateReady() bool {
-	s.stateReadyLock.RLock()
-	defer s.stateReadyLock.RUnlock()
-	return s.stateReady
-}
-
-func (s *System) setStateReady() {
-	s.stateReadyLock.Lock()
-	defer s.stateReadyLock.Unlock()
-	s.stateReady = true
 }
 
 func (s *System) incrementStateVerificationErrors() int {

--- a/services/horizon/internal/expingest/pipeline_hooks_test.go
+++ b/services/horizon/internal/expingest/pipeline_hooks_test.go
@@ -54,7 +54,6 @@ func (s *PreProcessingHookTestSuite) TestStateHookSucceedsWithPreExistingTx() {
 	newCtx, err := preProcessingHook(s.ctx, statePipeline, s.system, s.historyQ)
 	s.Assert().NoError(err)
 	s.Assert().Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
-	s.Assert().False(s.system.StateReady())
 }
 
 func (s *PreProcessingHookTestSuite) TestStateHookSucceedsWithoutPreExistingTx() {
@@ -69,7 +68,6 @@ func (s *PreProcessingHookTestSuite) TestStateHookSucceedsWithoutPreExistingTx()
 	newCtx, err := preProcessingHook(s.ctx, statePipeline, s.system, s.historyQ)
 	s.Assert().NoError(err)
 	s.Assert().Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
-	s.Assert().False(s.system.StateReady())
 }
 
 func (s *PreProcessingHookTestSuite) TestStateHookRollsbackOnGetLastLedgerExpIngestError() {
@@ -79,7 +77,6 @@ func (s *PreProcessingHookTestSuite) TestStateHookRollsbackOnGetLastLedgerExpIng
 
 	newCtx, err := preProcessingHook(s.ctx, statePipeline, s.system, s.historyQ)
 	s.Assert().Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
-	s.Assert().False(s.system.StateReady())
 	s.Assert().EqualError(err, "Error getting last ledger: transient error")
 }
 
@@ -93,7 +90,6 @@ func (s *PreProcessingHookTestSuite) TestStateHookRollsbackOnRemoveExpIngestHist
 
 	newCtx, err := preProcessingHook(s.ctx, statePipeline, s.system, s.historyQ)
 	s.Assert().Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
-	s.Assert().False(s.system.StateReady())
 	s.Assert().EqualError(err, "Error removing exp ingest history: transient error")
 }
 
@@ -105,7 +101,6 @@ func (s *PreProcessingHookTestSuite) TestStateHookRollsbackOnBeginError() {
 
 	newCtx, err := preProcessingHook(s.ctx, statePipeline, s.system, s.historyQ)
 	s.Assert().Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
-	s.Assert().False(s.system.StateReady())
 	s.Assert().EqualError(err, "Error starting a transaction: transient error")
 }
 
@@ -117,7 +112,6 @@ func (s *PreProcessingHookTestSuite) TestLedgerHookSucceedsWithPreExistingTx() {
 	newCtx, err := preProcessingHook(s.ctx, ledgerPipeline, s.system, s.historyQ)
 	s.Assert().NoError(err)
 	s.Assert().Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
-	s.Assert().True(s.system.StateReady())
 }
 
 func (s *PreProcessingHookTestSuite) TestLedgerHookSucceedsWithoutPreExistingTx() {
@@ -130,7 +124,6 @@ func (s *PreProcessingHookTestSuite) TestLedgerHookSucceedsWithoutPreExistingTx(
 	newCtx, err := preProcessingHook(s.ctx, ledgerPipeline, s.system, s.historyQ)
 	s.Assert().NoError(err)
 	s.Assert().Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
-	s.Assert().True(s.system.StateReady())
 }
 
 func (s *PreProcessingHookTestSuite) TestLedgerHookSucceedsAsMaster() {
@@ -140,7 +133,6 @@ func (s *PreProcessingHookTestSuite) TestLedgerHookSucceedsAsMaster() {
 	newCtx, err := preProcessingHook(s.ctx, ledgerPipeline, s.system, s.historyQ)
 	s.Assert().NoError(err)
 	s.Assert().NotNil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
-	s.Assert().True(s.system.StateReady())
 }
 
 func (s *PreProcessingHookTestSuite) TestLedgerHookRollsbackOnGetLastLedgerExpIngestError() {
@@ -150,7 +142,6 @@ func (s *PreProcessingHookTestSuite) TestLedgerHookRollsbackOnGetLastLedgerExpIn
 
 	newCtx, err := preProcessingHook(s.ctx, ledgerPipeline, s.system, s.historyQ)
 	s.Assert().Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
-	s.Assert().False(s.system.StateReady())
 	s.Assert().EqualError(err, "Error getting last ledger: transient error")
 }
 
@@ -162,7 +153,6 @@ func (s *PreProcessingHookTestSuite) TestLedgerHookRollsbackOnBeginError() {
 
 	newCtx, err := preProcessingHook(s.ctx, ledgerPipeline, s.system, s.historyQ)
 	s.Assert().Nil(newCtx.Value(horizonProcessors.IngestUpdateDatabase))
-	s.Assert().False(s.system.StateReady())
 	s.Assert().EqualError(err, "Error starting a transaction: transient error")
 }
 

--- a/services/horizon/internal/expingest/pipelines.go
+++ b/services/horizon/internal/expingest/pipelines.go
@@ -209,18 +209,12 @@ func preProcessingHook(
 			return ctx, errors.Wrap(err, "Error removing exp ingest history")
 		}
 		log.WithField("historyRemoved", summary).Info("removed entries from historical ingestion tables")
-	} else {
-		// mark the system as ready because we have progressed to running
-		// the ledger pipeline
-		system.setStateReady()
-
-		if lastIngestedLedger+1 == ledgerSeq {
-			// lastIngestedLedger+1 == ledgerSeq what means that this instance
-			// is the main ingesting instance in this round and should update a
-			// database.
-			updateDatabase = true
-			ctx = context.WithValue(ctx, horizonProcessors.IngestUpdateDatabase, true)
-		}
+	} else if lastIngestedLedger+1 == ledgerSeq {
+		// lastIngestedLedger+1 == ledgerSeq what means that this instance
+		// is the main ingesting instance in this round and should update a
+		// database.
+		updateDatabase = true
+		ctx = context.WithValue(ctx, horizonProcessors.IngestUpdateDatabase, true)
 	}
 
 	// If we are not going to update a DB release a lock by rolling back a


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes https://github.com/stellar/go/issues/2110

* remove `StateReady()` and related functions in ingestion system
* update ingestion middleware to respond with status `StillIngesting` if the ingestion version is out of date, or the last ingested ledger is 0, or the last ingested ledger does not match the most recent ledger in the `history_ledger` table


### Why

When running a cluster of Horizon instances it is possible that some nodes will be
participating in ingestion and other nodes will only serve HTTP requests without
participating in ingestion. To support this case we need to replace the existing
`StateReady()` check because it assumes all Horizon nodes which serve HTTP requests
participate in ingestion.

### Known limitations

[N/A]
