### PR TITLE
Merge master into release-horizon-v0.25.0

### DIFF
--- a/exp/ingest/io/single_ledger_state_reader.go
+++ b/exp/ingest/io/single_ledger_state_reader.go
@@ -179,9 +179,11 @@ func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrSt
 	currentPosition := stream.BytesRead()
 
 	for attempts := 0; ; attempts++ {
-		err = stream.ReadOne(&entry)
-		if err == nil || err == io.EOF {
-			break
+		if err == nil {
+			err = stream.ReadOne(&entry)
+			if err == nil || err == io.EOF {
+				break
+			}
 		}
 		if attempts >= msr.maxStreamRetries {
 			break
@@ -193,7 +195,7 @@ func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrSt
 		retryStream, err = msr.newXDRStream(hash)
 		if err != nil {
 			err = errors.Wrap(err, "Error creating new xdr stream")
-			break
+			continue
 		}
 
 		*stream = *retryStream
@@ -201,7 +203,7 @@ func (msr *SingleLedgerStateReader) readBucketEntry(stream *historyarchive.XdrSt
 		_, err = stream.Discard(currentPosition)
 		if err != nil {
 			err = errors.Wrap(err, "Error discarding from xdr stream")
-			break
+			continue
 		}
 	}
 

--- a/exp/services/webauth/README.md
+++ b/exp/services/webauth/README.md
@@ -1,0 +1,54 @@
+# webauth
+
+This is a [SEP-10] Web Authentication implementation based on SEP-10 v1.2.0
+that requires the master key have a high threshold for authentication to
+succeed.
+
+SEP-10 defines an endpoint for authenticating a user in possession of a Stellar
+account using their Stellar account as credentials. This implementation is a
+standalone microservice that implements the minimum requirements as defined by
+the SEP-10 protocol and will be adapted as the protocol evolves.
+
+This implementation is not polished and is still experimental.
+Running this implementation in production is not recommended.
+
+## Usage
+
+````
+$ webauth --help
+SEP-10 Web Authentication Server
+
+Usage:
+  webauth [command] [flags]
+  webauth [command]
+
+Available Commands:
+  genjwtkey   Generate a JWT ECDSA key
+  serve       Run the SEP-10 Web Authentication server
+
+Flags:
+  -h, --help   help for webauth
+
+Use "webauth [command] --help" for more information about a command.
+```
+
+## Usage: Serve
+
+```
+$ webauth serve --help
+Run the SEP-10 Web Authentication server
+
+Usage:
+  webauth serve [flags]
+
+Flags:
+      --challenge-expires-in int    The time period in seconds after which the challenge transaction expires (default 300)
+      --horizon-url string          Horizon URL used for looking up account details (default "https://horizon-testnet.stellar.org/")
+      --jwt-expires-in int          The time period in seconds after which the JWT expires (default 300)
+      --jwt-key string              Base64 encoded ECDSA private key used for signing JWTs
+      --network-passphrase string   Network passphrase of the Stellar network transactions should be signed for (default "Test SDF Network ; September 2015")
+      --port int                    Port to listen and serve on (default 8000)
+      --signing-key string          Stellar signing key used for signing transactions
+```
+
+[SEP-10]: https://github.com/stellar/stellar-protocol/blob/2be91ce8d8032ca9b2f368800d06b9fba346a147/ecosystem/sep-0010.md

--- a/exp/services/webauth/README.md
+++ b/exp/services/webauth/README.md
@@ -14,7 +14,7 @@ Running this implementation in production is not recommended.
 
 ## Usage
 
-````
+```
 $ webauth --help
 SEP-10 Web Authentication Server
 

--- a/exp/services/webauth/internal/commands/genjwtkey.go
+++ b/exp/services/webauth/internal/commands/genjwtkey.go
@@ -1,0 +1,41 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/stellar/go/exp/support/jwtkey"
+	supportlog "github.com/stellar/go/support/log"
+)
+
+type GenJWTKeyCommand struct {
+	Logger *supportlog.Entry
+}
+
+func (c *GenJWTKeyCommand) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "genjwtkey",
+		Short: "Generate a JWT ECDSA key",
+		Run: func(_ *cobra.Command, _ []string) {
+			c.Run()
+		},
+	}
+	return cmd
+}
+
+func (c *GenJWTKeyCommand) Run() {
+	k, err := jwtkey.GenerateKey()
+	if err != nil {
+		c.Logger.Fatal(err)
+	}
+
+	if public, err := jwtkey.PublicKeyToString(&k.PublicKey); err == nil {
+		c.Logger.Print("Public:", public)
+	} else {
+		c.Logger.Print("Public:", err)
+	}
+
+	if private, err := jwtkey.PrivateKeyToString(k); err == nil {
+		c.Logger.Print("Private:", private)
+	} else {
+		c.Logger.Print("Private:", err)
+	}
+}

--- a/exp/services/webauth/internal/commands/serve.go
+++ b/exp/services/webauth/internal/commands/serve.go
@@ -1,0 +1,95 @@
+package commands
+
+import (
+	"go/types"
+
+	"github.com/spf13/cobra"
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/exp/services/webauth/internal/serve"
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/support/config"
+	supportlog "github.com/stellar/go/support/log"
+)
+
+type ServeCommand struct {
+	Logger *supportlog.Entry
+}
+
+func (c *ServeCommand) Command() *cobra.Command {
+	opts := serve.Options{
+		Logger: c.Logger,
+	}
+	configOpts := config.ConfigOptions{
+		{
+			Name:        "port",
+			Usage:       "Port to listen and serve on",
+			OptType:     types.Int,
+			ConfigKey:   &opts.Port,
+			FlagDefault: 8000,
+			Required:    true,
+		},
+		{
+			Name:        "horizon-url",
+			Usage:       "Horizon URL used for looking up account details",
+			OptType:     types.String,
+			ConfigKey:   &opts.HorizonURL,
+			FlagDefault: horizonclient.DefaultTestNetClient.HorizonURL,
+			Required:    true,
+		},
+		{
+			Name:        "network-passphrase",
+			Usage:       "Network passphrase of the Stellar network transactions should be signed for",
+			OptType:     types.String,
+			ConfigKey:   &opts.NetworkPassphrase,
+			FlagDefault: network.TestNetworkPassphrase,
+			Required:    true,
+		},
+		{
+			Name:      "signing-key",
+			Usage:     "Stellar signing key used for signing transactions",
+			OptType:   types.String,
+			ConfigKey: &opts.SigningKey,
+			Required:  true,
+		},
+		{
+			Name:           "challenge-expires-in",
+			Usage:          "The time period in seconds after which the challenge transaction expires",
+			OptType:        types.Int,
+			CustomSetValue: config.SetDuration,
+			ConfigKey:      &opts.ChallengeExpiresIn,
+			FlagDefault:    300,
+			Required:       true,
+		},
+		{
+			Name:      "jwt-key",
+			Usage:     "Base64 encoded ECDSA private key used for signing JWTs",
+			OptType:   types.String,
+			ConfigKey: &opts.JWTPrivateKey,
+			Required:  true,
+		},
+		{
+			Name:           "jwt-expires-in",
+			Usage:          "The time period in seconds after which the JWT expires",
+			OptType:        types.Int,
+			CustomSetValue: config.SetDuration,
+			ConfigKey:      &opts.JWTExpiresIn,
+			FlagDefault:    300,
+			Required:       true,
+		},
+	}
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Run the SEP-10 Web Authentication server",
+		Run: func(_ *cobra.Command, _ []string) {
+			configOpts.Require()
+			configOpts.SetValues()
+			c.Run(opts)
+		},
+	}
+	configOpts.Init(cmd)
+	return cmd
+}
+
+func (c *ServeCommand) Run(opts serve.Options) {
+	serve.Serve(opts)
+}

--- a/exp/services/webauth/internal/serve/challenge.go
+++ b/exp/services/webauth/internal/serve/challenge.go
@@ -1,0 +1,56 @@
+package serve
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/strkey"
+	supportlog "github.com/stellar/go/support/log"
+	"github.com/stellar/go/support/render/httpjson"
+	"github.com/stellar/go/txnbuild"
+)
+
+// ChallengeHandler implements the SEP-10 challenge endpoint and handles
+// requests for a new challenge transaction.
+type challengeHandler struct {
+	Logger             *supportlog.Entry
+	ServerName         string
+	NetworkPassphrase  string
+	SigningKey         *keypair.Full
+	ChallengeExpiresIn time.Duration
+}
+
+type challengeResponse struct {
+	Transaction       string `json:"transaction"`
+	NetworkPassphrase string `json:"network_passphrase"`
+}
+
+func (h challengeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	account := r.URL.Query().Get("account")
+	if !strkey.IsValidEd25519PublicKey(account) {
+		badRequest.Render(w)
+		return
+	}
+
+	tx, err := txnbuild.BuildChallengeTx(
+		h.SigningKey.Seed(),
+		account,
+		h.ServerName,
+		h.NetworkPassphrase,
+		h.ChallengeExpiresIn,
+	)
+	if err != nil {
+		h.Logger.Ctx(ctx).WithStack(err).Error(err)
+		serverError.Render(w)
+		return
+	}
+
+	res := challengeResponse{
+		Transaction:       tx,
+		NetworkPassphrase: h.NetworkPassphrase,
+	}
+	httpjson.Render(w, res, httpjson.JSON)
+}

--- a/exp/services/webauth/internal/serve/challenge_test.go
+++ b/exp/services/webauth/internal/serve/challenge_test.go
@@ -1,0 +1,96 @@
+package serve
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/network"
+	supportlog "github.com/stellar/go/support/log"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChallenge(t *testing.T) {
+	serverKey := keypair.MustRandom()
+	account := keypair.MustRandom()
+
+	h := challengeHandler{
+		Logger:             supportlog.DefaultLogger,
+		ServerName:         "testserver",
+		NetworkPassphrase:  network.TestNetworkPassphrase,
+		SigningKey:         serverKey,
+		ChallengeExpiresIn: time.Minute,
+	}
+
+	r := httptest.NewRequest("GET", "/?account="+account.Address(), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	res := struct {
+		Transaction       string `json:"transaction"`
+		NetworkPassphrase string `json:"network_passphrase"`
+	}{}
+	err := json.NewDecoder(resp.Body).Decode(&res)
+	require.NoError(t, err)
+
+	var tx xdr.TransactionEnvelope
+	err = xdr.SafeUnmarshalBase64(res.Transaction, &tx)
+	require.NoError(t, err)
+
+	assert.Len(t, tx.Signatures, 1)
+	assert.Equal(t, serverKey.Address(), tx.Tx.SourceAccount.Address())
+	assert.Equal(t, tx.Tx.SeqNum, xdr.SequenceNumber(0))
+	assert.Equal(t, time.Unix(int64(tx.Tx.TimeBounds.MaxTime), 0).Sub(time.Unix(int64(tx.Tx.TimeBounds.MinTime), 0)), time.Minute)
+	assert.Len(t, tx.Tx.Operations, 1)
+	assert.Equal(t, account.Address(), tx.Tx.Operations[0].SourceAccount.Address())
+	assert.Equal(t, xdr.OperationTypeManageData, tx.Tx.Operations[0].Body.Type)
+	assert.Regexp(t, "^testserver auth", tx.Tx.Operations[0].Body.ManageDataOp.DataName)
+
+	hash, err := network.HashTransaction(&tx.Tx, res.NetworkPassphrase)
+	require.NoError(t, err)
+	assert.NoError(t, serverKey.FromAddress().Verify(hash[:], tx.Signatures[0].Signature))
+
+	assert.Equal(t, network.TestNetworkPassphrase, res.NetworkPassphrase)
+}
+
+func TestChallengeNoAccount(t *testing.T) {
+	h := challengeHandler{}
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"error":"The request was invalid in some way."}`, string(body))
+}
+
+func TestChallengeInvalidAccount(t *testing.T) {
+	h := challengeHandler{}
+
+	r := httptest.NewRequest("GET", "/?account=GREATACCOUNT", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"error":"The request was invalid in some way."}`, string(body))
+}

--- a/exp/services/webauth/internal/serve/errors.go
+++ b/exp/services/webauth/internal/serve/errors.go
@@ -1,0 +1,45 @@
+package serve
+
+import (
+	"net/http"
+
+	"github.com/stellar/go/support/render/httpjson"
+)
+
+var serverError = errorResponse{
+	Status: http.StatusInternalServerError,
+	Error:  "An error occurred while processing this request.",
+}
+var notFound = errorResponse{
+	Status: http.StatusNotFound,
+	Error:  "The resource at the url requested was not found.",
+}
+var methodNotAllowed = errorResponse{
+	Status: http.StatusMethodNotAllowed,
+	Error:  "The method is not allowed for resource at the url requested.",
+}
+var badRequest = errorResponse{
+	Status: http.StatusBadRequest,
+	Error:  "The request was invalid in some way.",
+}
+var unauthorized = errorResponse{
+	Status: http.StatusUnauthorized,
+	Error:  "The request could not be authenticated.",
+}
+
+type errorResponse struct {
+	Status int    `json:"-"`
+	Error  string `json:"error"`
+}
+
+func (e errorResponse) Render(w http.ResponseWriter) {
+	httpjson.RenderStatus(w, e.Status, e, httpjson.JSON)
+}
+
+type errorHandler struct {
+	Error errorResponse
+}
+
+func (h errorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.Error.Render(w)
+}

--- a/exp/services/webauth/internal/serve/errors_test.go
+++ b/exp/services/webauth/internal/serve/errors_test.go
@@ -1,0 +1,33 @@
+package serve
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorResponseRender(t *testing.T) {
+	w := httptest.NewRecorder()
+	serverError.Render(w)
+	resp := w.Result()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"error":"An error occurred while processing this request."}`, string(body))
+}
+
+func TestErrorHandler(t *testing.T) {
+	r := httptest.NewRequest("GET", "/404", nil)
+	w := httptest.NewRecorder()
+	handler := errorHandler{Error: notFound}
+	handler.ServeHTTP(w, r)
+	resp := w.Result()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"error":"The resource at the url requested was not found."}`, string(body))
+}

--- a/exp/services/webauth/internal/serve/serve.go
+++ b/exp/services/webauth/internal/serve/serve.go
@@ -1,0 +1,87 @@
+package serve
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/exp/support/jwtkey"
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/support/errors"
+	supporthttp "github.com/stellar/go/support/http"
+	supportlog "github.com/stellar/go/support/log"
+)
+
+type Options struct {
+	Logger             *supportlog.Entry
+	HorizonURL         string
+	Port               int
+	NetworkPassphrase  string
+	SigningKey         string
+	ChallengeExpiresIn time.Duration
+	JWTPrivateKey      string
+	JWTExpiresIn       time.Duration
+}
+
+func Serve(opts Options) {
+	handler, err := handler(opts)
+	if err != nil {
+		opts.Logger.Fatalf("Error: %v", err)
+		return
+	}
+
+	addr := fmt.Sprintf(":%d", opts.Port)
+	supporthttp.Run(supporthttp.Config{
+		ListenAddr: addr,
+		Handler:    handler,
+		OnStarting: func() {
+			opts.Logger.Info("Starting SEP-10 Web Authentication Server")
+			opts.Logger.Infof("Listening on %s", addr)
+		},
+	})
+}
+
+func handler(opts Options) (http.Handler, error) {
+	signingKey, err := keypair.ParseFull(opts.SigningKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing signing key seed")
+	}
+
+	jwtPrivateKey, err := jwtkey.PrivateKeyFromString(opts.JWTPrivateKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing JWT private key")
+	}
+
+	httpClient := &http.Client{
+		Timeout: horizonclient.HorizonTimeOut,
+	}
+
+	horizonClient := &horizonclient.Client{
+		HorizonURL: opts.HorizonURL,
+		HTTP:       httpClient,
+	}
+	horizonClient.SetHorizonTimeOut(uint(horizonclient.HorizonTimeOut))
+
+	mux := supporthttp.NewAPIMux()
+
+	mux.NotFound(errorHandler{Error: notFound}.ServeHTTP)
+	mux.MethodNotAllowed(errorHandler{Error: methodNotAllowed}.ServeHTTP)
+
+	mux.Get("/", challengeHandler{
+		Logger:             opts.Logger,
+		NetworkPassphrase:  opts.NetworkPassphrase,
+		SigningKey:         signingKey,
+		ChallengeExpiresIn: opts.ChallengeExpiresIn,
+	}.ServeHTTP)
+	mux.Post("/", tokenHandler{
+		Logger:            opts.Logger,
+		HorizonClient:     horizonClient,
+		NetworkPassphrase: opts.NetworkPassphrase,
+		SigningAddress:    signingKey.FromAddress(),
+		JWTPrivateKey:     jwtPrivateKey,
+		JWTExpiresIn:      opts.JWTExpiresIn,
+	}.ServeHTTP)
+
+	return mux, nil
+}

--- a/exp/services/webauth/internal/serve/token.go
+++ b/exp/services/webauth/internal/serve/token.go
@@ -1,0 +1,94 @@
+package serve
+
+import (
+	"crypto/ecdsa"
+	"net/http"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/support/http/httpdecode"
+	supportlog "github.com/stellar/go/support/log"
+
+	"github.com/stellar/go/support/render/httpjson"
+	"github.com/stellar/go/txnbuild"
+)
+
+type tokenHandler struct {
+	Logger            *supportlog.Entry
+	HorizonClient     horizonclient.ClientInterface
+	NetworkPassphrase string
+	SigningAddress    *keypair.FromAddress
+	JWTPrivateKey     *ecdsa.PrivateKey
+	JWTExpiresIn      time.Duration
+}
+
+type tokenRequest struct {
+	Transaction string `json:"transaction" form:"transaction"`
+}
+
+type tokenResponse struct {
+	Token string `json:"token"`
+}
+
+func (h tokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	req := tokenRequest{}
+
+	err := httpdecode.Decode(r, &req)
+	if err != nil {
+		badRequest.Render(w)
+		return
+	}
+
+	_, err = txnbuild.VerifyChallengeTx(req.Transaction, h.SigningAddress.Address(), h.NetworkPassphrase)
+	if err != nil {
+		unauthorized.Render(w)
+		return
+	}
+
+	tx, err := txnbuild.TransactionFromXDR(req.Transaction)
+	if err != nil {
+		serverError.Render(w)
+		return
+	}
+	clientAccountID := tx.Operations[0].(*txnbuild.ManageData).SourceAccount.GetAccountID()
+
+	clientAccount, err := h.HorizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: clientAccountID})
+	if err != nil {
+		serverError.Render(w)
+		return
+	}
+	verifiedWeight := false
+	for _, clientSigner := range clientAccount.Signers {
+		if clientSigner.Key == clientAccountID && clientSigner.Weight >= int32(clientAccount.Thresholds.HighThreshold) {
+			verifiedWeight = true
+			break
+		}
+	}
+	if !verifiedWeight {
+		unauthorized.Render(w)
+		return
+	}
+
+	now := time.Now().UTC()
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
+		"iss": h.SigningAddress.Address(),
+		"sub": clientAccountID,
+		"iat": now.Unix(),
+		"exp": now.Add(h.JWTExpiresIn).Unix(),
+	})
+	tokenStr, err := token.SignedString(h.JWTPrivateKey)
+	if err != nil {
+		h.Logger.Ctx(ctx).WithStack(err).Error(err)
+		serverError.Render(w)
+		return
+	}
+
+	res := tokenResponse{
+		Token: tokenStr,
+	}
+	httpjson.Render(w, res, httpjson.JSON)
+}

--- a/exp/services/webauth/internal/serve/token_test.go
+++ b/exp/services/webauth/internal/serve/token_test.go
@@ -1,0 +1,488 @@
+package serve
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/exp/support/jwtkey"
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/network"
+	supportlog "github.com/stellar/go/support/log"
+	"github.com/stellar/go/txnbuild"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToken_formInputSuccess(t *testing.T) {
+	serverKey := keypair.MustRandom()
+	t.Logf("Server signing key: %s", serverKey.Address())
+
+	jwtPrivateKey, err := jwtkey.GenerateKey()
+	require.NoError(t, err)
+
+	account := keypair.MustRandom()
+	t.Logf("Client account: %s", account.Address())
+
+	chTx, err := txnbuild.BuildChallengeTx(
+		serverKey.Seed(),
+		account.Address(),
+		"testserver",
+		network.TestNetworkPassphrase,
+		time.Minute,
+	)
+	require.NoError(t, err)
+	t.Logf("Tx: %s", chTx)
+
+	var tx xdr.TransactionEnvelope
+	err = xdr.SafeUnmarshalBase64(chTx, &tx)
+	require.NoError(t, err)
+	hash, err := network.HashTransaction(&tx.Tx, network.TestNetworkPassphrase)
+	require.NoError(t, err)
+	sigDec, err := account.SignDecorated(hash[:])
+	require.NoError(t, err)
+	tx.Signatures = append(tx.Signatures, sigDec)
+	txSigned, err := xdr.MarshalBase64(tx)
+	require.NoError(t, err)
+	t.Logf("Signed: %s", txSigned)
+
+	horizonClient := &horizonclient.MockClient{}
+	horizonClient.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: account.Address()}).
+		Return(
+			horizon.Account{
+				Thresholds: horizon.AccountThresholds{
+					LowThreshold:  1,
+					MedThreshold:  10,
+					HighThreshold: 100,
+				},
+				Signers: []horizon.Signer{
+					{
+						Key:    account.Address(),
+						Weight: 100,
+					},
+				}},
+			nil,
+		)
+
+	h := tokenHandler{
+		Logger:            supportlog.DefaultLogger,
+		HorizonClient:     horizonClient,
+		NetworkPassphrase: network.TestNetworkPassphrase,
+		SigningAddress:    serverKey.FromAddress(),
+		JWTPrivateKey:     jwtPrivateKey,
+		JWTExpiresIn:      time.Minute,
+	}
+
+	body := url.Values{}
+	body.Set("transaction", txSigned)
+	r := httptest.NewRequest("POST", "/", strings.NewReader(body.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	res := struct {
+		Token string `json:"token"`
+	}{}
+	err = json.NewDecoder(resp.Body).Decode(&res)
+	require.NoError(t, err)
+
+	t.Logf("JWT: %s", res.Token)
+
+	token, err := jwt.Parse(res.Token, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodECDSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return &jwtPrivateKey.PublicKey, nil
+	})
+	require.NoError(t, err)
+
+	claims := token.Claims.(jwt.MapClaims)
+	assert.Equal(t, serverKey.Address(), claims["iss"])
+	assert.Equal(t, account.Address(), claims["sub"])
+	assert.Equal(t, account.Address(), claims["sub"])
+	iat := time.Unix(int64(claims["iat"].(float64)), 0)
+	exp := time.Unix(int64(claims["exp"].(float64)), 0)
+	assert.True(t, iat.Before(time.Now()))
+	assert.True(t, exp.After(time.Now()))
+	assert.True(t, time.Now().Add(time.Minute).After(exp))
+	assert.Equal(t, exp.Sub(iat), time.Minute)
+}
+
+func TestToken_jsonInputSuccess(t *testing.T) {
+	serverKey := keypair.MustRandom()
+	t.Logf("Server signing key: %s", serverKey.Address())
+
+	jwtPrivateKey, err := jwtkey.GenerateKey()
+	require.NoError(t, err)
+
+	account := keypair.MustRandom()
+	t.Logf("Client account: %s", account.Address())
+
+	chTx, err := txnbuild.BuildChallengeTx(
+		serverKey.Seed(),
+		account.Address(),
+		"testserver",
+		network.TestNetworkPassphrase,
+		time.Minute,
+	)
+	require.NoError(t, err)
+	t.Logf("Tx: %s", chTx)
+
+	var tx xdr.TransactionEnvelope
+	err = xdr.SafeUnmarshalBase64(chTx, &tx)
+	require.NoError(t, err)
+	hash, err := network.HashTransaction(&tx.Tx, network.TestNetworkPassphrase)
+	require.NoError(t, err)
+	sigDec, err := account.SignDecorated(hash[:])
+	require.NoError(t, err)
+	tx.Signatures = append(tx.Signatures, sigDec)
+	txSigned, err := xdr.MarshalBase64(tx)
+	require.NoError(t, err)
+	t.Logf("Signed: %s", txSigned)
+
+	horizonClient := &horizonclient.MockClient{}
+	horizonClient.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: account.Address()}).
+		Return(
+			horizon.Account{
+				Thresholds: horizon.AccountThresholds{
+					LowThreshold:  1,
+					MedThreshold:  10,
+					HighThreshold: 100,
+				},
+				Signers: []horizon.Signer{
+					{
+						Key:    account.Address(),
+						Weight: 100,
+					},
+				}},
+			nil,
+		)
+
+	h := tokenHandler{
+		Logger:            supportlog.DefaultLogger,
+		HorizonClient:     horizonClient,
+		NetworkPassphrase: network.TestNetworkPassphrase,
+		SigningAddress:    serverKey.FromAddress(),
+		JWTPrivateKey:     jwtPrivateKey,
+		JWTExpiresIn:      time.Minute,
+	}
+
+	body := struct {
+		Transaction string `json:"transaction"`
+	}{
+		Transaction: txSigned,
+	}
+	bodyBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+	r := httptest.NewRequest("POST", "/", bytes.NewReader(bodyBytes))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	res := struct {
+		Token string `json:"token"`
+	}{}
+	err = json.NewDecoder(resp.Body).Decode(&res)
+	require.NoError(t, err)
+
+	t.Logf("JWT: %s", res.Token)
+
+	token, err := jwt.Parse(res.Token, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodECDSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return &jwtPrivateKey.PublicKey, nil
+	})
+	require.NoError(t, err)
+
+	claims := token.Claims.(jwt.MapClaims)
+	assert.Equal(t, serverKey.Address(), claims["iss"])
+	assert.Equal(t, account.Address(), claims["sub"])
+	assert.Equal(t, account.Address(), claims["sub"])
+	iat := time.Unix(int64(claims["iat"].(float64)), 0)
+	exp := time.Unix(int64(claims["exp"].(float64)), 0)
+	assert.True(t, iat.Before(time.Now()))
+	assert.True(t, exp.After(time.Now()))
+	assert.True(t, time.Now().Add(time.Minute).After(exp))
+	assert.Equal(t, exp.Sub(iat), time.Minute)
+}
+
+func TestToken_jsonInputValidMultipleSigners(t *testing.T) {
+	serverKey := keypair.MustRandom()
+	t.Logf("Server signing key: %s", serverKey.Address())
+
+	jwtPrivateKey, err := jwtkey.GenerateKey()
+	require.NoError(t, err)
+
+	account := keypair.MustRandom()
+	t.Logf("Client account: %s", account.Address())
+
+	accountSigner1 := keypair.MustRandom()
+	t.Logf("Client account signer 1: %s", accountSigner1.Address())
+
+	accountSigner2 := keypair.MustRandom()
+	t.Logf("Client account signer 2: %s", accountSigner2.Address())
+
+	chTx, err := txnbuild.BuildChallengeTx(
+		serverKey.Seed(),
+		account.Address(),
+		"testserver",
+		network.TestNetworkPassphrase,
+		time.Minute,
+	)
+	require.NoError(t, err)
+	t.Logf("Tx: %s", chTx)
+
+	var tx xdr.TransactionEnvelope
+	err = xdr.SafeUnmarshalBase64(chTx, &tx)
+	require.NoError(t, err)
+	hash, err := network.HashTransaction(&tx.Tx, network.TestNetworkPassphrase)
+	require.NoError(t, err)
+	sigDec1, err := accountSigner1.SignDecorated(hash[:])
+	require.NoError(t, err)
+	tx.Signatures = append(tx.Signatures, sigDec1)
+	sigDec2, err := accountSigner2.SignDecorated(hash[:])
+	require.NoError(t, err)
+	tx.Signatures = append(tx.Signatures, sigDec2)
+	txSigned, err := xdr.MarshalBase64(tx)
+	require.NoError(t, err)
+	t.Logf("Signed: %s", txSigned)
+
+	horizonClient := &horizonclient.MockClient{}
+	horizonClient.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: account.Address()}).
+		Return(
+			horizon.Account{
+				Thresholds: horizon.AccountThresholds{
+					LowThreshold:  1,
+					MedThreshold:  10,
+					HighThreshold: 100,
+				},
+				Signers: []horizon.Signer{
+					{
+						Key:    accountSigner1.Address(),
+						Weight: 40,
+					},
+					{
+						Key:    accountSigner2.Address(),
+						Weight: 60,
+					},
+				}},
+			nil,
+		)
+
+	h := tokenHandler{
+		Logger:            supportlog.DefaultLogger,
+		HorizonClient:     horizonClient,
+		NetworkPassphrase: network.TestNetworkPassphrase,
+		SigningAddress:    serverKey.FromAddress(),
+		JWTPrivateKey:     jwtPrivateKey,
+		JWTExpiresIn:      time.Minute,
+	}
+
+	body := struct {
+		Transaction string `json:"transaction"`
+	}{
+		Transaction: txSigned,
+	}
+	bodyBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+	r := httptest.NewRequest("POST", "/", bytes.NewReader(bodyBytes))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	respBodyBytes, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"error":"The request could not be authenticated."}`, string(respBodyBytes))
+}
+
+func TestToken_jsonInputNotEnoughWeight(t *testing.T) {
+	serverKey := keypair.MustRandom()
+	t.Logf("Server signing key: %s", serverKey.Address())
+
+	jwtPrivateKey, err := jwtkey.GenerateKey()
+	require.NoError(t, err)
+
+	account := keypair.MustRandom()
+	t.Logf("Client account: %s", account.Address())
+
+	chTx, err := txnbuild.BuildChallengeTx(
+		serverKey.Seed(),
+		account.Address(),
+		"testserver",
+		network.TestNetworkPassphrase,
+		time.Minute,
+	)
+	require.NoError(t, err)
+	t.Logf("Tx: %s", chTx)
+
+	var tx xdr.TransactionEnvelope
+	err = xdr.SafeUnmarshalBase64(chTx, &tx)
+	require.NoError(t, err)
+	hash, err := network.HashTransaction(&tx.Tx, network.TestNetworkPassphrase)
+	require.NoError(t, err)
+	sigDec, err := account.SignDecorated(hash[:])
+	require.NoError(t, err)
+	tx.Signatures = append(tx.Signatures, sigDec)
+	txSigned, err := xdr.MarshalBase64(tx)
+	require.NoError(t, err)
+	t.Logf("Signed: %s", txSigned)
+
+	horizonClient := &horizonclient.MockClient{}
+	horizonClient.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: account.Address()}).
+		Return(
+			horizon.Account{
+				Thresholds: horizon.AccountThresholds{
+					LowThreshold:  1,
+					MedThreshold:  10,
+					HighThreshold: 100,
+				},
+				Signers: []horizon.Signer{
+					{
+						Key:    account.Address(),
+						Weight: 10,
+					},
+				}},
+			nil,
+		)
+
+	h := tokenHandler{
+		Logger:            supportlog.DefaultLogger,
+		HorizonClient:     horizonClient,
+		NetworkPassphrase: network.TestNetworkPassphrase,
+		SigningAddress:    serverKey.FromAddress(),
+		JWTPrivateKey:     jwtPrivateKey,
+		JWTExpiresIn:      time.Minute,
+	}
+
+	body := struct {
+		Transaction string `json:"transaction"`
+	}{
+		Transaction: txSigned,
+	}
+	bodyBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+	r := httptest.NewRequest("POST", "/", bytes.NewReader(bodyBytes))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, 401, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	respBodyBytes, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"error":"The request could not be authenticated."}`, string(respBodyBytes))
+}
+
+func TestToken_jsonInputUnrecognizedSigner(t *testing.T) {
+	serverKey := keypair.MustRandom()
+	t.Logf("Server signing key: %s", serverKey.Address())
+
+	jwtPrivateKey, err := jwtkey.GenerateKey()
+	require.NoError(t, err)
+
+	account := keypair.MustRandom()
+	t.Logf("Client account: %s", account.Address())
+
+	chTx, err := txnbuild.BuildChallengeTx(
+		serverKey.Seed(),
+		account.Address(),
+		"testserver",
+		network.TestNetworkPassphrase,
+		time.Minute,
+	)
+	require.NoError(t, err)
+	t.Logf("Tx: %s", chTx)
+
+	var tx xdr.TransactionEnvelope
+	err = xdr.SafeUnmarshalBase64(chTx, &tx)
+	require.NoError(t, err)
+	hash, err := network.HashTransaction(&tx.Tx, network.TestNetworkPassphrase)
+	require.NoError(t, err)
+	sigDec, err := account.SignDecorated(hash[:])
+	require.NoError(t, err)
+	tx.Signatures = append(tx.Signatures, sigDec)
+	txSigned, err := xdr.MarshalBase64(tx)
+	require.NoError(t, err)
+	t.Logf("Signed: %s", txSigned)
+
+	horizonClient := &horizonclient.MockClient{}
+	horizonClient.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: account.Address()}).
+		Return(
+			horizon.Account{
+				Thresholds: horizon.AccountThresholds{
+					LowThreshold:  1,
+					MedThreshold:  10,
+					HighThreshold: 100,
+				},
+				Signers: []horizon.Signer{
+					{
+						Key:    keypair.MustRandom().Address(),
+						Weight: 100,
+					},
+				}},
+			nil,
+		)
+
+	h := tokenHandler{
+		Logger:            supportlog.DefaultLogger,
+		HorizonClient:     horizonClient,
+		NetworkPassphrase: network.TestNetworkPassphrase,
+		SigningAddress:    serverKey.FromAddress(),
+		JWTPrivateKey:     jwtPrivateKey,
+		JWTExpiresIn:      time.Minute,
+	}
+
+	body := struct {
+		Transaction string `json:"transaction"`
+	}{
+		Transaction: txSigned,
+	}
+	bodyBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+	r := httptest.NewRequest("POST", "/", bytes.NewReader(bodyBytes))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, 401, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	respBodyBytes, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"error":"The request could not be authenticated."}`, string(respBodyBytes))
+}

--- a/exp/services/webauth/main.go
+++ b/exp/services/webauth/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/stellar/go/exp/services/webauth/internal/commands"
+	supportlog "github.com/stellar/go/support/log"
+)
+
+func main() {
+	logger := supportlog.New()
+	logger.Logger.Level = logrus.TraceLevel
+
+	rootCmd := &cobra.Command{
+		Use:   "webauth [command]",
+		Short: "SEP-10 Web Authentication Server",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+		},
+	}
+
+	rootCmd.AddCommand((&commands.ServeCommand{Logger: logger}).Command())
+	rootCmd.AddCommand((&commands.GenJWTKeyCommand{Logger: logger}).Command())
+
+	err := rootCmd.Execute()
+	if err != nil {
+		logger.Fatal(err)
+	}
+}

--- a/exp/support/jwtkey/jwtkey.go
+++ b/exp/support/jwtkey/jwtkey.go
@@ -1,0 +1,80 @@
+// Package jwtkey provides utility functions for generating, serializing and
+// deserializing JWT ECDSA keys.
+//
+// TODO: Replace EC function usages with PKCS8 functions for supporting ECDSA
+// and RSA keys instead of only supporting ECDSA. The fact this package only
+// supports ECDSA is unnecessary.
+package jwtkey
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+
+	"github.com/stellar/go/support/errors"
+)
+
+// GenerateKey is a convenience function for generating an ECDSA key for use as
+// a JWT key. It uses the P256 curve. To use other curves use the crypto/ecdsa
+// package directly.
+func GenerateKey() (*ecdsa.PrivateKey, error) {
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, errors.Wrap(err, "generating ECDSA key")
+	}
+	return k, nil
+}
+
+// PrivateKeyToString converts a ECDSA private key into a ASN.1 DER and base64
+// encoded string.
+func PrivateKeyToString(k *ecdsa.PrivateKey) (string, error) {
+	b, err := x509.MarshalECPrivateKey(k)
+	if err != nil {
+		return "", errors.Wrap(err, "marshaling ECDSA private key")
+	}
+	return base64.StdEncoding.EncodeToString(b), nil
+}
+
+// PublicKeyToString converts a ECDSA public key into a ASN.1 DER and base64
+// encoded string.
+func PublicKeyToString(k *ecdsa.PublicKey) (string, error) {
+	b, err := x509.MarshalPKIXPublicKey(k)
+	if err != nil {
+		return "", errors.Wrap(err, "marshaling ECDSA public key")
+	}
+	return base64.StdEncoding.EncodeToString(b), nil
+}
+
+// PrivateKeyFromString converts a ECDSA private key from a ASN.1 DER and
+// base64 encoded string into a type.
+func PrivateKeyFromString(s string) (*ecdsa.PrivateKey, error) {
+	keyBytes, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, errors.Wrap(err, "base64 decoding ECDSA private key")
+	}
+	key, err := x509.ParseECPrivateKey(keyBytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshaling ECDSA private key")
+	}
+	return key, nil
+}
+
+// PublicKeyFromString converts a ECDSA public key from a ASN.1 DER and base64
+// encoded string into a type.
+func PublicKeyFromString(s string) (*ecdsa.PublicKey, error) {
+	keyBytes, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, errors.Wrap(err, "base64 decoding ECDSA public key")
+	}
+	keyI, err := x509.ParsePKIXPublicKey(keyBytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshaling ECDSA public key")
+	}
+	key, ok := keyI.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, errors.Wrap(err, "public key not ECDSA key")
+	}
+	return key, nil
+}

--- a/exp/support/jwtkey/jwtkey_test.go
+++ b/exp/support/jwtkey/jwtkey_test.go
@@ -1,0 +1,66 @@
+package jwtkey
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerate(t *testing.T) {
+	key, err := GenerateKey()
+	require.NoError(t, err)
+	assert.Equal(t, elliptic.P256(), key.Curve)
+}
+
+func TestToFromStringRoundTrip(t *testing.T) {
+	testCases := []struct {
+		Name  string
+		Curve elliptic.Curve
+	}{
+		{Name: "P224", Curve: elliptic.P224()},
+		{Name: "P256", Curve: elliptic.P256()},
+		{Name: "P384", Curve: elliptic.P384()},
+		{Name: "P521", Curve: elliptic.P521()},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			privateKey, err := ecdsa.GenerateKey(tc.Curve, rand.Reader)
+			require.NoError(t, err)
+
+			t.Run("private", func(t *testing.T) {
+				privateKeyStr, err := PrivateKeyToString(privateKey)
+				require.NoError(t, err)
+
+				// Private key as string should be valid standard base64
+				_, err = base64.StdEncoding.DecodeString(privateKeyStr)
+				require.NoError(t, err)
+
+				// Private key should decode back to the original
+				privateKeyRoundTripped, err := PrivateKeyFromString(privateKeyStr)
+				require.NoError(t, err)
+				assert.Equal(t, privateKey, privateKeyRoundTripped)
+			})
+
+			publicKey := &privateKey.PublicKey
+
+			t.Run("public", func(t *testing.T) {
+				publicKeyStr, err := PublicKeyToString(publicKey)
+				require.NoError(t, err)
+
+				// Public key as string should be valid standard base64
+				_, err = base64.StdEncoding.DecodeString(publicKeyStr)
+				require.NoError(t, err)
+
+				// Public key should decode back to the original
+				publicKeyRoundTripped, err := PublicKeyFromString(publicKeyStr)
+				require.NoError(t, err)
+				assert.Equal(t, publicKey, publicKeyRoundTripped)
+			})
+		})
+	}
+}

--- a/go.list
+++ b/go.list
@@ -14,6 +14,7 @@ github.com/aws/aws-sdk-go v1.25.25
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973
 github.com/client9/misspell v0.3.4
 github.com/davecgh/go-spew v1.1.1
+github.com/dgrijalva/jwt-go v3.2.0+incompatible
 github.com/eapache/go-resiliency v1.1.0
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21
 github.com/eapache/queue v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect
 	github.com/asaskevich/govalidator v0.0.0-20180319081651-7d2e70ef918f
 	github.com/aws/aws-sdk-go v1.25.25
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/elazarl/go-bindata-assetfs v1.0.0
 	github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51 // indirect
 	github.com/facebookgo/inject v0.0.0-20161006174721-cc1aa653e50f

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=

--- a/keypair/main.go
+++ b/keypair/main.go
@@ -74,9 +74,9 @@ func Master(networkPassphrase string) KP {
 // an address, or a seed.  If the provided input is a seed, the resulting KP
 // will have signing capabilities.
 func Parse(addressOrSeed string) (KP, error) {
-	_, err := strkey.Decode(strkey.VersionByteAccountID, addressOrSeed)
+	addr, err := ParseAddress(addressOrSeed)
 	if err == nil {
-		return &FromAddress{addressOrSeed}, nil
+		return addr, nil
 	}
 
 	if err != strkey.ErrInvalidVersionByte {
@@ -84,6 +84,17 @@ func Parse(addressOrSeed string) (KP, error) {
 	}
 
 	return ParseFull(addressOrSeed)
+}
+
+// ParseAddress constructs a new FromAddress keypair from the provided string,
+// which should be an address.
+func ParseAddress(address string) (*FromAddress, error) {
+	_, err := strkey.Decode(strkey.VersionByteAccountID, address)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FromAddress{address: address}, nil
 }
 
 // ParseFull constructs a new Full keypair from the provided string, which should

--- a/keypair/main_test.go
+++ b/keypair/main_test.go
@@ -156,6 +156,47 @@ var _ = DescribeTable("keypair.ParseFull()",
 	}),
 )
 
+type ParseAddressCase struct {
+	Input       string
+	AddressCase types.GomegaMatcher
+	ErrCase     types.GomegaMatcher
+}
+
+var _ = DescribeTable("keypair.ParseAddress()",
+	func(c ParseAddressCase) {
+		kp, err := ParseAddress(c.Input)
+
+		Expect(kp).To(c.AddressCase)
+		Expect(err).To(c.ErrCase)
+	},
+
+	Entry("a valid address", ParseAddressCase{
+		Input:       "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+		AddressCase: Equal(&FromAddress{address: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"}),
+		ErrCase:     BeNil(),
+	}),
+	Entry("a corrupted address", ParseAddressCase{
+		Input:       "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7O32H",
+		AddressCase: BeNil(),
+		ErrCase:     HaveOccurred(),
+	}),
+	Entry("a valid seed", ParseAddressCase{
+		Input:       "SDHOAMBNLGCE2MV5ZKIVZAQD3VCLGP53P3OBSBI6UN5L5XZI5TKHFQL4",
+		AddressCase: BeNil(),
+		ErrCase:     HaveOccurred(),
+	}),
+	Entry("a corrupted seed", ParseAddressCase{
+		Input:       "SDHOAMBNLGCE2MV5ZKIVZAQD3VCLGP53P3OBSBI6UN5L5XZI5TKHFQL3",
+		AddressCase: BeNil(),
+		ErrCase:     HaveOccurred(),
+	}),
+	Entry("a blank string", ParseAddressCase{
+		Input:       "",
+		AddressCase: BeNil(),
+		ErrCase:     HaveOccurred(),
+	}),
+)
+
 var _ = Describe("keypair.Random()", func() {
 	It("does not return the same value twice", func() {
 		seen := map[string]bool{}

--- a/services/keystore/api.go
+++ b/services/keystore/api.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rs/cors"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/httpjson"
@@ -182,8 +183,10 @@ func recoverHandler(next http.Handler) http.Handler {
 }
 
 func corsHandler(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		rw.Header().Set("Access-Control-Allow-Origin", "*")
-		next.ServeHTTP(rw, req)
+	cors := cors.New(cors.Options{
+		AllowedOrigins: []string{"*"},
+		AllowedHeaders: []string{"*"},
+		AllowedMethods: []string{"GET", "PUT", "POST", "PATCH", "DELETE", "HEAD", "OPTIONS"},
 	})
+	return cors.Handler(next)
 }

--- a/services/ticker/internal/tickerdb/queries_asset_test.go
+++ b/services/ticker/internal/tickerdb/queries_asset_test.go
@@ -53,6 +53,7 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 
 	// Creating first asset:
 	firstTime := time.Now()
+	t.Log("firstTime:", firstTime)
 	a := Asset{
 		Code:          code,
 		IssuerAccount: issuerAccount,
@@ -88,6 +89,7 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 
 	// Creating Seconde Asset:
 	secondTime := time.Now()
+	t.Log("secondTime:", secondTime)
 	a.LastValid = secondTime
 	a.LastChecked = secondTime
 	err = session.InsertOrUpdateAsset(&a, []string{"code", "issuer_account", "issuer_id"})
@@ -122,6 +124,7 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 
 	// Creating Third Asset:
 	thirdTime := time.Now()
+	t.Log("thirdTime:", thirdTime)
 	a.LastValid = thirdTime
 	a.LastChecked = thirdTime
 	err = session.InsertOrUpdateAsset(&a, []string{"code", "issuer_id", "last_valid", "last_checked", "issuer_account"})

--- a/support/http/httpdecode/httpdecode.go
+++ b/support/http/httpdecode/httpdecode.go
@@ -1,0 +1,13 @@
+package httpdecode
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// DecodeJSON decodes JSON request from r into v.
+func DecodeJSON(r *http.Request, v interface{}) error {
+	dec := json.NewDecoder(r.Body)
+	dec.UseNumber()
+	return dec.Decode(v)
+}

--- a/support/http/httpdecode/httpdecode.go
+++ b/support/http/httpdecode/httpdecode.go
@@ -2,7 +2,11 @@ package httpdecode
 
 import (
 	"encoding/json"
+	"mime"
 	"net/http"
+
+	"github.com/gorilla/schema"
+	"github.com/stellar/go/support/errors"
 )
 
 // DecodeJSON decodes JSON request from r into v.
@@ -10,4 +14,70 @@ func DecodeJSON(r *http.Request, v interface{}) error {
 	dec := json.NewDecoder(r.Body)
 	dec.UseNumber()
 	return dec.Decode(v)
+}
+
+// DecodeForm decodes form URL encoded requests from r into v.
+//
+// The type of the value given can use `form` tags on fields in the same way as
+// the `json` tag to name fields.
+//
+// An error will be returned if the request is not a POST, PUT, or PATCH
+// request.
+//
+// An error will be returned if the request has a media type in the
+// Content-Type not equal to application/x-www-form-urlencoded, or if the
+// Content-Type header cannot be parsed.
+func DecodeForm(r *http.Request, v interface{}) error {
+	if r.Method != "POST" && r.Method != "PUT" && r.Method != "PATCH" {
+		return errors.Errorf("method POST, PUT, or PATCH required for form decoding: request has method %q", r.Method)
+	}
+
+	contentType := r.Header.Get("Content-Type")
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return errors.Wrap(err, "content type application/x-www-form-urlencoded required for form decoding")
+	}
+	if mediaType != "application/x-www-form-urlencoded" {
+		return errors.Errorf("content type application/x-www-form-urlencoded required for form decoding: received content type %q", mediaType)
+	}
+
+	err = r.ParseForm()
+	if err != nil {
+		return err
+	}
+
+	dec := schema.NewDecoder()
+	dec.SetAliasTag("form")
+	dec.IgnoreUnknownKeys(true)
+	return dec.Decode(v, r.PostForm)
+}
+
+// Decode decodes form URL encoded requests and JSON requests from r into v.
+//
+// The requests Content-Type header informs if the request should be decoded
+// using a form URL encoded decoder or using a JSON decoder.
+//
+// A Content-Type of application/x-www-form-urlencoded will result in form
+// decoding. Any other content type will result in JSON decoding because it is
+// common to make JSON requests without a Content-Type where-as correctly
+// formatted form URL encoded requests are more often accompanied by the
+// appropriate Content-Type.
+//
+// An error is returned if the Content-Type cannot be parsed by a mime
+// media-type parser.
+//
+// See DecodeForm and DecodeJSON for details about the types of errors that may
+// occur.
+func Decode(r *http.Request, v interface{}) error {
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "" {
+		mediaType, _, err := mime.ParseMediaType(contentType)
+		if err != nil {
+			return errors.Wrap(err, "content type could not be parsed")
+		}
+		if mediaType == "application/x-www-form-urlencoded" {
+			return DecodeForm(r, v)
+		}
+	}
+	return DecodeJSON(r, v)
 }

--- a/support/http/httpdecode/httpdecode_test.go
+++ b/support/http/httpdecode/httpdecode_test.go
@@ -1,0 +1,34 @@
+package httpdecode
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeJSON_valid(t *testing.T) {
+	body := `{"foo":"bar"}`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+
+	bodyDecoded := struct {
+		Foo string `json:"foo"`
+	}{}
+	err := DecodeJSON(r, &bodyDecoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "bar", bodyDecoded.Foo)
+}
+
+func TestDecodeJSON_invalid(t *testing.T) {
+	body := `{"foo:"bar"}`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+
+	bodyDecoded := struct {
+		Foo string `json:"foo"`
+	}{}
+	err := DecodeJSON(r, &bodyDecoded)
+	require.EqualError(t, err, "invalid character 'b' after object key")
+}

--- a/support/http/httpdecode/httpdecode_test.go
+++ b/support/http/httpdecode/httpdecode_test.go
@@ -32,3 +32,208 @@ func TestDecodeJSON_invalid(t *testing.T) {
 	err := DecodeJSON(r, &bodyDecoded)
 	require.EqualError(t, err, "invalid character 'b' after object key")
 }
+
+func TestDecodeForm_valid(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	bodyDecoded := struct {
+		Foo string
+	}{}
+	err := DecodeForm(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.Foo)
+}
+
+func TestDecodeForm_validTags(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	bodyDecoded := struct {
+		FooName string `form:"foo"`
+	}{}
+	err := DecodeForm(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.FooName)
+}
+
+func TestDecodeForm_validIgnoresUnkownKeys(t *testing.T) {
+	body := `foo=bar&foz=baz`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+
+	bodyDecoded := struct {
+		Foo string
+	}{}
+	err := DecodeForm(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.Foo)
+}
+
+func TestDecodeForm_validContentTypeWithOptions(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+
+	bodyDecoded := struct {
+		Foo string
+	}{}
+	err := DecodeForm(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.Foo)
+}
+
+func TestDecodeForm_invalidBody(t *testing.T) {
+	body := `foo=%=`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	bodyDecoded := struct {
+		Foo string
+	}{}
+	err := DecodeForm(r, &bodyDecoded)
+	assert.EqualError(t, err, `invalid URL escape "%="`)
+	assert.Equal(t, "", bodyDecoded.Foo)
+}
+
+func TestDecodeForm_invalidNoContentType(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+
+	bodyDecoded := struct {
+		Foo string
+	}{}
+	err := DecodeForm(r, &bodyDecoded)
+	assert.EqualError(t, err, `content type application/x-www-form-urlencoded required for form decoding: mime: no media type`)
+	assert.Equal(t, "", bodyDecoded.Foo)
+}
+
+func TestDecodeForm_invalidUnrecognizedContentType(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/xwwwformurlencoded")
+
+	bodyDecoded := struct {
+		Foo string
+	}{}
+	err := DecodeForm(r, &bodyDecoded)
+	assert.EqualError(t, err, `content type application/x-www-form-urlencoded required for form decoding: received content type "application/xwwwformurlencoded"`)
+	assert.Equal(t, "", bodyDecoded.Foo)
+}
+
+func TestDecodeForm_invalidMethodType(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("GET", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	bodyDecoded := struct {
+		Foo string
+	}{}
+	err := DecodeForm(r, &bodyDecoded)
+	assert.EqualError(t, err, `method POST, PUT, or PATCH required for form decoding: request has method "GET"`)
+	assert.Equal(t, "", bodyDecoded.Foo)
+}
+
+func TestDecode_validJSONNoContentType(t *testing.T) {
+	body := `{"foo":"bar"}`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.FooName)
+}
+
+func TestDecode_validJSONWithContentType(t *testing.T) {
+	body := `{"foo":"bar"}`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.FooName)
+}
+
+func TestDecode_validJSONWithContentTypeOptions(t *testing.T) {
+	body := `{"foo":"bar"}`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.FooName)
+}
+
+func TestDecode_validForm(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.FooName)
+}
+
+func TestDecode_validFormWithContentTypeOptions(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.FooName)
+}
+
+func TestDecode_cannotParseContentType(t *testing.T) {
+	body := `{"foo":"bar"}`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application=json")
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.EqualError(t, err, "content type could not be parsed: mime: expected slash after first token")
+	assert.Equal(t, "", bodyDecoded.FooName)
+}
+
+func TestDecode_invalidJSON(t *testing.T) {
+	body := `{"foo""bar"}`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.EqualError(t, err, `invalid character '"' after object key`)
+	assert.Equal(t, "", bodyDecoded.FooName)
+}
+
+func TestDecode_invalidForm(t *testing.T) {
+	body := `foo=%=bar`
+	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.EqualError(t, err, `invalid URL escape "%=b"`)
+	assert.Equal(t, "", bodyDecoded.FooName)
+}

--- a/support/render/httpjson/handler.go
+++ b/support/render/httpjson/handler.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/http/httpdecode"
 	"github.com/stellar/go/support/render/problem"
 )
 
@@ -82,9 +83,9 @@ func (h *handler) executeFunc(ctx context.Context, req *http.Request) (interface
 	if h.inType != nil {
 		if h.readFromBody {
 			inPtr := reflect.New(h.inType)
-			err := read(req.Body, inPtr.Interface())
+			err := httpdecode.DecodeJSON(req, inPtr.Interface())
 			if err != nil {
-				return nil, err
+				return nil, ErrBadRequest
 			}
 			a = append(a, inPtr.Elem())
 		} else {

--- a/support/render/httpjson/io.go
+++ b/support/render/httpjson/io.go
@@ -27,6 +27,13 @@ func renderToString(data interface{}, pretty bool) ([]byte, error) {
 // Render write data to w, after marshalling to json. The response header is
 // set based on cType.
 func Render(w http.ResponseWriter, data interface{}, cType contentType) {
+	RenderStatus(w, http.StatusOK, data, cType)
+}
+
+// RenderStatus write data to w, after marshalling to json.
+// The response header is set based on cType.
+// The response status code is set to the statusCode.
+func RenderStatus(w http.ResponseWriter, statusCode int, data interface{}, cType contentType) {
 	js, err := renderToString(data, true)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -39,6 +46,7 @@ func Render(w http.ResponseWriter, data interface{}, cType contentType) {
 	} else {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	}
+	w.WriteHeader(statusCode)
 	w.Write(js)
 }
 

--- a/support/render/httpjson/io.go
+++ b/support/render/httpjson/io.go
@@ -2,7 +2,6 @@ package httpjson
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/stellar/go/support/errors"
@@ -51,15 +50,3 @@ func RenderStatus(w http.ResponseWriter, statusCode int, data interface{}, cType
 }
 
 var ErrBadRequest = errors.New("bad request")
-
-// read decodes a json text from r into v.
-func read(r io.Reader, v interface{}) error {
-	dec := json.NewDecoder(r)
-	dec.UseNumber()
-	err := dec.Decode(v)
-	if err != nil {
-		return ErrBadRequest
-	}
-
-	return nil
-}

--- a/support/render/httpjson/io_test.go
+++ b/support/render/httpjson/io_test.go
@@ -1,0 +1,88 @@
+package httpjson
+
+import (
+	"io/ioutil"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRender(t *testing.T) {
+	cases := []struct {
+		data            interface{}
+		contentType     contentType
+		wantContentType string
+		wantBody        string
+	}{
+		{
+			data:            map[string]interface{}{"key": "value"},
+			contentType:     JSON,
+			wantContentType: "application/json; charset=utf-8",
+			wantBody:        `{"key":"value"}`,
+		},
+		{
+			data:            map[string]interface{}{"key": "value"},
+			contentType:     HALJSON,
+			wantContentType: "application/hal+json; charset=utf-8",
+			wantBody:        `{"key":"value"}`,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			w := httptest.NewRecorder()
+			Render(w, tc.data, tc.contentType)
+			resp := w.Result()
+
+			assert.Equal(t, 200, resp.StatusCode)
+			assert.Equal(t, tc.wantContentType, resp.Header.Get("Content-Type"))
+
+			body, err := ioutil.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.wantBody, string(body))
+		})
+	}
+}
+
+func TestRenderStatus(t *testing.T) {
+	cases := []struct {
+		data            interface{}
+		status          int
+		contentType     contentType
+		wantContentType string
+		wantBody        string
+	}{
+		{
+			data:            map[string]interface{}{"key": "value"},
+			status:          200,
+			contentType:     JSON,
+			wantContentType: "application/json; charset=utf-8",
+			wantBody:        `{"key":"value"}`,
+		},
+		{
+			data:            map[string]interface{}{"key": "value"},
+			status:          400,
+			contentType:     HALJSON,
+			wantContentType: "application/hal+json; charset=utf-8",
+			wantBody:        `{"key":"value"}`,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			w := httptest.NewRecorder()
+			RenderStatus(w, tc.status, tc.data, tc.contentType)
+			resp := w.Result()
+
+			assert.Equal(t, tc.status, resp.StatusCode)
+			assert.Equal(t, tc.wantContentType, resp.Header.Get("Content-Type"))
+
+			body, err := ioutil.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.wantBody, string(body))
+		})
+	}
+}

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -477,32 +477,38 @@ func VerifyChallengeTx(challengeTx, serverAccountID, network string) (bool, erro
 	}
 
 	// verify signature from operation source
-	ok, err = verifyTxSignature(tx, op.SourceAccount.GetAccountID())
+	err = verifyTxSignature(tx, op.SourceAccount.GetAccountID())
 	if err != nil {
-		return ok, err
+		return false, err
 	}
 
 	// verify signature from server signing key
-	return verifyTxSignature(tx, serverAccountID)
+	err = verifyTxSignature(tx, serverAccountID)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 // verifyTxSignature checks if a transaction has been signed by the provided Stellar account.
-func verifyTxSignature(tx Transaction, accountID string) (bool, error) {
-	signerFound := false
+func verifyTxSignature(tx Transaction, accountID string) error {
 	txHash, err := tx.Hash()
 	if err != nil {
-		return signerFound, err
+		return err
 	}
 
 	kp, err := keypair.Parse(accountID)
 	if err != nil {
-		return signerFound, err
+		return err
 	}
 
 	// find and verify signatures
 	if tx.xdrEnvelope == nil {
-		return signerFound, errors.New("transaction has no signatures")
+		return errors.New("transaction has no signatures")
 	}
+
+	signerFound := false
 	for _, s := range tx.xdrEnvelope.Signatures {
 		e := kp.Verify(txHash[:], s.Signature)
 		if e == nil {
@@ -510,9 +516,9 @@ func verifyTxSignature(tx Transaction, accountID string) (bool, error) {
 			break
 		}
 	}
-
 	if !signerFound {
-		return signerFound, errors.Errorf("transaction not signed by %s", accountID)
+		return errors.Errorf("transaction not signed by %s", accountID)
 	}
-	return signerFound, nil
+
+	return nil
 }

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -493,6 +493,10 @@ func VerifyChallengeTx(challengeTx, serverAccountID, network string) (bool, erro
 
 // verifyTxSignature checks if a transaction has been signed by the provided Stellar account.
 func verifyTxSignature(tx Transaction, accountID string) error {
+	if tx.xdrEnvelope == nil {
+		return errors.New("transaction has no signatures")
+	}
+
 	txHash, err := tx.Hash()
 	if err != nil {
 		return err
@@ -504,10 +508,6 @@ func verifyTxSignature(tx Transaction, accountID string) error {
 	}
 
 	// find and verify signatures
-	if tx.xdrEnvelope == nil {
-		return errors.New("transaction has no signatures")
-	}
-
 	signerFound := false
 	for _, s := range tx.xdrEnvelope.Signatures {
 		e := kp.Verify(txHash[:], s.Signature)

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1183,11 +1183,10 @@ func TestVerifyTxSignatureUnsignedTx(t *testing.T) {
 	// verify unsigned tx
 	err := tx.Build()
 	assert.NoError(t, err)
-	ok, err := verifyTxSignature(tx, kp0.Address())
+	err = verifyTxSignature(tx, kp0.Address())
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "transaction not signed by GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3")
 	}
-	assert.Equal(t, false, ok)
 }
 
 func TestVerifyTxSignatureSingle(t *testing.T) {
@@ -1211,9 +1210,8 @@ func TestVerifyTxSignatureSingle(t *testing.T) {
 	assert.NoError(t, err)
 	err = tx.Sign(kp0)
 	assert.NoError(t, err)
-	ok, err := verifyTxSignature(tx, kp0.Address())
+	err = verifyTxSignature(tx, kp0.Address())
 	assert.NoError(t, err)
-	assert.Equal(t, true, ok)
 }
 
 func TestVerifyTxSignatureMultiple(t *testing.T) {
@@ -1237,12 +1235,10 @@ func TestVerifyTxSignatureMultiple(t *testing.T) {
 	assert.NoError(t, err)
 	err = tx.Sign(kp0, kp1)
 	assert.NoError(t, err)
-	ok, err := verifyTxSignature(tx, kp0.Address())
+	err = verifyTxSignature(tx, kp0.Address())
 	assert.NoError(t, err)
-	assert.Equal(t, true, ok)
-	ok, err = verifyTxSignature(tx, kp1.Address())
+	err = verifyTxSignature(tx, kp1.Address())
 	assert.NoError(t, err)
-	assert.Equal(t, true, ok)
 }
 func TestVerifyTxSignatureInvalid(t *testing.T) {
 	kp0 := newKeypair0()
@@ -1265,11 +1261,10 @@ func TestVerifyTxSignatureInvalid(t *testing.T) {
 	assert.NoError(t, err)
 	err = tx.Sign(kp0, kp1)
 	assert.NoError(t, err)
-	ok, err := verifyTxSignature(tx, "GATBMIXTHXYKSUZSZUEJKACZ2OS2IYUWP2AIF3CA32PIDLJ67CH6Y5UY")
+	err = verifyTxSignature(tx, "GATBMIXTHXYKSUZSZUEJKACZ2OS2IYUWP2AIF3CA32PIDLJ67CH6Y5UY")
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "transaction not signed by GATBMIXTHXYKSUZSZUEJKACZ2OS2IYUWP2AIF3CA32PIDLJ67CH6Y5UY")
 	}
-	assert.Equal(t, false, ok)
 }
 
 func TestVerifyChallengeTxInvalid(t *testing.T) {


### PR DESCRIPTION
While testing old ledgers I came across:
```
Error while reading from buckets: Error on XDR record 179999 of hash '8d2a036cfdf8da352aaa00bb0c9706906ee5c01563e1f348b92773e86330dc64': stream error: stream ID 59; PROTOCOL_ERROR
```
type of errors when downloading state from buckets. I wanted to cherry-pick https://github.com/stellar/go/commit/54d2e97fc84239192c91af22e7e89c5b4537beea that should fix it but it looks like the rest of the commits on `master` aren't changing anything related to Horizon.