### PR TITLE
services/horizon: Load /account/{id}/data from account_data table.

### DIFF
--- a/services/horizon/internal/actions_data_test.go
+++ b/services/horizon/internal/actions_data_test.go
@@ -5,41 +5,81 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	data1 = xdr.DataEntry{
+		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		DataName:  "name1",
+		// This also tests if base64 encoding is working as 0 is invalid UTF-8 byte
+		DataValue: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+	}
+
+	data2 = xdr.DataEntry{
+		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		DataName:  "name ",
+		DataValue: []byte("it got spaces!"),
+	}
 )
 
 func TestDataActions_Show(t *testing.T) {
-	ht := StartHTTPTest(t, "kahuna")
+	ht := StartHTTPTestWithoutScenario(t)
 	defer ht.Finish()
+	test.ResetHorizonDB(t, ht.HorizonDB)
+	q := &history.Q{ht.HorizonSession()}
 
-	prefix := "/accounts/GAYSCMKQY6EYLXOPTT6JPPOXDMVNBWITPTSZIVWW4LWARVBOTH5RTLAD"
+	rows, err := q.InsertAccountData(data1, 1234)
+	assert.NoError(t, err)
+	ht.Assert.Equal(int64(1), rows)
+
+	rows, err = q.InsertAccountData(data2, 1235)
+	assert.NoError(t, err)
+	ht.Assert.Equal(int64(1), rows)
+
+	prefix := "/accounts/GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"
+	var result map[string]string
+
 	// json
-
 	w := ht.Get(prefix + "/data/name1")
 	if ht.Assert.Equal(200, w.Code) {
-		var result map[string]string
 		err := json.Unmarshal(w.Body.Bytes(), &result)
-		ht.Require.NoError(err)
+		ht.Assert.NoError(err)
 		decoded, err := base64.StdEncoding.DecodeString(result["value"])
-		ht.Require.NoError(err)
-
-		ht.Assert.Equal("0000", string(decoded))
+		ht.Assert.NoError(err)
+		ht.Assert.Equal([]byte(data1.DataValue), decoded)
 	}
 
 	// raw
 	w = ht.Get(prefix+"/data/name1", test.RequestHelperRaw)
 	if ht.Assert.Equal(200, w.Code) {
-		ht.Assert.Equal("0000", w.Body.String())
+		ht.Assert.Equal([]byte(data1.DataValue), w.Body.Bytes())
 	}
-
-	// missing
-	w = ht.Get(prefix+"/data/missing", test.RequestHelperRaw)
-	ht.Assert.Equal(404, w.Code)
 
 	// regression: https://github.com/stellar/go/services/horizon/internal/issues/325
 	// names with special characters do not work
+	w = ht.Get(prefix + "/data/name%20")
+	if ht.Assert.Equal(200, w.Code) {
+		err := json.Unmarshal(w.Body.Bytes(), &result)
+		ht.Assert.NoError(err)
+
+		decoded, err := base64.StdEncoding.DecodeString(result["value"])
+		ht.Assert.NoError(err)
+		ht.Assert.Equal([]byte(data2.DataValue), decoded)
+	}
+
 	w = ht.Get(prefix+"/data/name%20", test.RequestHelperRaw)
 	if ht.Assert.Equal(200, w.Code) {
-		ht.Assert.Equal("its got spaces!", w.Body.String())
+		ht.Assert.Equal("it got spaces!", w.Body.String())
 	}
+
+	// missing
+	w = ht.Get(prefix + "/data/missing")
+	ht.Assert.Equal(404, w.Code)
+
+	w = ht.Get(prefix+"/data/missing", test.RequestHelperRaw)
+	ht.Assert.Equal(404, w.Code)
 }

--- a/services/horizon/internal/db2/history/account_data.go
+++ b/services/horizon/internal/db2/history/account_data.go
@@ -19,6 +19,17 @@ func (q *Q) CountAccountsData() (int, error) {
 	return count, nil
 }
 
+// GetAccountDataByName loads account data for a given account ID and data name
+func (q *Q) GetAccountDataByName(id, name string) (Data, error) {
+	var data Data
+	sql := selectAccountData.Where(sq.Eq{
+		"account_id": id,
+		"name":       name,
+	}).Limit(1)
+	err := q.Get(&data, sql)
+	return data, err
+}
+
 // GetAccountDataByAccountID loads account data for a given account ID
 func (q *Q) GetAccountDataByAccountID(id string) ([]Data, error) {
 	var data []Data

--- a/services/horizon/internal/db2/history/account_data_test.go
+++ b/services/horizon/internal/db2/history/account_data_test.go
@@ -154,3 +154,26 @@ func TestGetAccountDataByAccountID(t *testing.T) {
 	tt.Assert.Equal(data2.DataName, xdr.String64(records[1].Name))
 	tt.Assert.Equal([]byte(data2.DataValue), []byte(records[1].Value))
 }
+
+func TestGetAccountDataByName(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	_, err := q.InsertAccountData(data1, 1234)
+	assert.NoError(t, err)
+	_, err = q.InsertAccountData(data2, 1235)
+	assert.NoError(t, err)
+
+	record, err := q.GetAccountDataByName(data1.AccountId.Address(), string(data1.DataName))
+	assert.NoError(t, err)
+	tt.Assert.Equal(data1.DataName, xdr.String64(record.Name))
+	tt.Assert.Equal([]byte(data1.DataValue), []byte(record.Value))
+
+	record, err = q.GetAccountDataByName(data1.AccountId.Address(), string(data2.DataName))
+	assert.NoError(t, err)
+	tt.Assert.Equal(data2.DataName, xdr.String64(record.Name))
+	tt.Assert.Equal([]byte(data2.DataValue), []byte(record.Value))
+
+}


### PR DESCRIPTION
## What

Replace stellar-core as the data source and use Horizon's database instead.

Fixes #2137.


## Why

As part of the next release, we'll stop using stellar-core to serve
data in Horizon.