### PR TITLE
support/config: append env var to usage text of options

### DIFF
--- a/support/config/config_option.go
+++ b/support/config/config_option.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"go/types"
 	stdLog "log"
 	"net/url"
@@ -82,6 +83,13 @@ func (co *ConfigOption) SetValue() {
 	}
 }
 
+// UsageText returns the string to use for the usage text of the option. The
+// string returned will be the Usage defined on the ConfigOption, along with
+// the environment variable.
+func (co *ConfigOption) UsageText() string {
+	return fmt.Sprintf("%s (%s)", co.Usage, co.EnvVar)
+}
+
 // setSimpleValue sets the value of a ConfigOption's configKey, based on the ConfigOption's default type.
 func (co *ConfigOption) setSimpleValue() {
 	if co.ConfigKey != nil {
@@ -106,13 +114,13 @@ func (co *ConfigOption) setFlag(cmd *cobra.Command) error {
 		if co.FlagDefault == nil {
 			co.FlagDefault = ""
 		}
-		cmd.PersistentFlags().String(co.Name, co.FlagDefault.(string), co.Usage)
+		cmd.PersistentFlags().String(co.Name, co.FlagDefault.(string), co.UsageText())
 	case types.Int:
-		cmd.PersistentFlags().Int(co.Name, co.FlagDefault.(int), co.Usage)
+		cmd.PersistentFlags().Int(co.Name, co.FlagDefault.(int), co.UsageText())
 	case types.Bool:
-		cmd.PersistentFlags().Bool(co.Name, co.FlagDefault.(bool), co.Usage)
+		cmd.PersistentFlags().Bool(co.Name, co.FlagDefault.(bool), co.UsageText())
 	case types.Uint:
-		cmd.PersistentFlags().Uint(co.Name, co.FlagDefault.(uint), co.Usage)
+		cmd.PersistentFlags().Uint(co.Name, co.FlagDefault.(uint), co.UsageText())
 	default:
 		return errors.New("Unexpected OptType")
 	}

--- a/support/config/config_option_test.go
+++ b/support/config/config_option_test.go
@@ -1,0 +1,15 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigOption_UsageText(t *testing.T) {
+	configOpt := ConfigOption{
+		Usage:  "Port to listen and serve on",
+		EnvVar: "PORT",
+	}
+	assert.Equal(t, "Port to listen and serve on (PORT)", configOpt.UsageText())
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Append the environment variable for config options to their usage text.

### Why

The first dozen times I ran Horizon I had no idea that I could use environment variables to configure it. I was hand building options on the command line. I only discovered that I could use environment variables when I dug into the config options code for something else.

The Horizon command line help text is very useful and it would be great if folks using it could discover the environment variable names for configs in the usage text.

I would also like to have this for the `exp/services/webauth` service that also uses the same config options functionality.

I've made no changes to changelogs because this seems sufficiently unimportant and makes no significant functional change.

### Known limitations

N/A