### PR TITLE
services/horizon/internal/actions: Respond with error if core account does not match horizon account

### DIFF
--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -120,16 +120,15 @@ func AccountInfo(ctx context.Context, cq *core.Q, hq *history.Q, addr string) (*
 	}
 
 	if err == nil {
-		err = accountResourcesEqual(*resource, *otherResource)
-	}
-	if err != nil {
-		log.Ctx(ctx).WithFields(log.F{
-			"err":            err,
-			"accounts_check": true, // So it's easy to find all diffs
-		}).Warn("error comparing core and horizon accounts")
+		if err = accountResourcesEqual(*resource, *otherResource); err != nil {
+			log.Ctx(ctx).WithFields(log.F{
+				"err":            err,
+				"accounts_check": true, // So it's easy to find all diffs
+			}).Warn("error comparing core and horizon accounts")
+		}
 	}
 
-	return resource, nil
+	return resource, err
 }
 
 // accountResourcesEqual compares two protocol.Account objects and returns an

--- a/services/horizon/internal/actions/account_test.go
+++ b/services/horizon/internal/actions/account_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/xdr"
 )
@@ -252,6 +253,21 @@ func TestAccountInfo(t *testing.T) {
 	tt.Assert.Equal("8589934593", account.Sequence)
 	tt.Assert.Equal(uint32(5), account.LastModifiedLedger)
 	tt.Assert.Len(account.Signers, 2)
+
+	// Regression: no trades link
+	tt.Assert.Contains(account.Links.Trades.Href, "/trades")
+	// Regression: no data link
+	tt.Assert.Contains(account.Links.Data.Href, "/data/{key}")
+	tt.Assert.True(account.Links.Data.Templated)
+
+	// try to fetch account which does not exist
+	_, err = AccountInfo(
+		tt.Ctx,
+		&core.Q{tt.CoreSession()},
+		&history.Q{tt.HorizonSession()},
+		"GDBAPLDCAEJV6LSEDFEAUDAVFYSNFRUYZ4X75YYJJMMX5KFVUOHX46SQ",
+	)
+	tt.Assert.True(q.NoRows(errors.Cause(err)))
 }
 
 func TestGetAccountsHandlerPageNoResults(t *testing.T) {

--- a/services/horizon/internal/actions/account_test.go
+++ b/services/horizon/internal/actions/account_test.go
@@ -155,42 +155,103 @@ var (
 	}
 )
 
-func TestAccountFromExpIngest(t *testing.T) {
+func TestAccountInfo(t *testing.T) {
 	tt := test.Start(t).Scenario("allow_trust")
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
-
 	q := &history.Q{tt.HorizonSession()}
-	_, err := q.InsertAccount(account1, 1234)
-	tt.Assert.NoError(err)
-	_, err = q.InsertAccount(account2, 1234)
-	tt.Assert.NoError(err)
 
-	for _, row := range accountSigners {
-		_, err = q.CreateAccountSigner(row.Account, row.Signer, row.Weight)
-		tt.Assert.NoError(err)
+	var thresholds xdr.Thresholds
+	tt.Assert.NoError(
+		xdr.SafeUnmarshalBase64("AQAAAA==", &thresholds),
+	)
+	accountID := xdr.MustAddress(
+		"GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
+	)
+	accountEntry := xdr.AccountEntry{
+		AccountId:     accountID,
+		Balance:       9999999900,
+		SeqNum:        8589934593,
+		NumSubEntries: 1,
+		InflationDest: nil,
+		HomeDomain:    "",
+		Thresholds:    thresholds,
+		Flags:         0,
 	}
+	_, err := q.InsertAccount(accountEntry, 4)
+	tt.Assert.NoError(err)
 
-	_, err = q.InsertAccountData(data1, 1234)
-	assert.NoError(t, err)
-
-	_, err = q.InsertTrustLine(eurTrustLine, 1234)
+	_, err = q.InsertTrustLine(xdr.TrustLineEntry{
+		AccountId: accountID,
+		Asset: xdr.MustNewCreditAsset(
+			"USD",
+			"GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4",
+		),
+		Balance: 0,
+		Limit:   9223372036854775807,
+		Flags:   1,
+	}, 6)
 	assert.NoError(t, err)
 
 	account, err := AccountInfo(
 		tt.Ctx,
 		&core.Q{tt.CoreSession()},
-		q,
-		accountOne,
+		&history.Q{tt.HorizonSession()},
+		accountID.Address(),
 	)
 	tt.Assert.NoError(err)
 
-	tt.Assert.Equal(accountOne, account.AccountID)
-	tt.Assert.Equal(account.LastModifiedLedger, uint32(1234))
+	tt.Assert.Equal("8589934593", account.Sequence)
+	tt.Assert.Equal(uint32(4), account.LastModifiedLedger)
 	tt.Assert.Len(account.Balances, 2)
+
+	for _, balance := range account.Balances {
+		if balance.Type == "native" {
+			tt.Assert.Equal(uint32(0), balance.LastModifiedLedger)
+		} else {
+			tt.Assert.Equal("USD", balance.Code)
+			tt.Assert.Equal(
+				"GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4",
+				balance.Issuer,
+			)
+			tt.Assert.NotEqual(uint32(0), balance.LastModifiedLedger)
+		}
+	}
+
+	// core account and horizon ingestion account differ
+	// horizon ingestion account has a signer whereas core account
+	// has no signers
+	_, err = q.CreateAccountSigner(
+		accountID.Address(),
+		"GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON",
+		100,
+	)
+	tt.Assert.NoError(err)
+
+	_, err = AccountInfo(
+		tt.Ctx,
+		&core.Q{tt.CoreSession()},
+		&history.Q{tt.HorizonSession()},
+		accountID.Address(),
+	)
+	tt.Assert.EqualError(err, "Signer is different")
+
+	// even though horizon ingestion account differs from core account,
+	// no error is returned because they have different last modified ledgers
+	_, err = q.UpdateAccount(accountEntry, 5)
+	tt.Assert.NoError(err)
+
+	account, err = AccountInfo(
+		tt.Ctx,
+		&core.Q{tt.CoreSession()},
+		&history.Q{tt.HorizonSession()},
+		accountID.Address(),
+	)
+	tt.Assert.NoError(err)
+
+	tt.Assert.Equal("8589934593", account.Sequence)
+	tt.Assert.Equal(uint32(5), account.LastModifiedLedger)
 	tt.Assert.Len(account.Signers, 2)
-	_, ok := account.Data[string(data1.DataName)]
-	tt.Assert.True(ok)
 }
 
 func TestGetAccountsHandlerPageNoResults(t *testing.T) {

--- a/services/horizon/internal/actions_account_test.go
+++ b/services/horizon/internal/actions_account_test.go
@@ -1,81 +1,16 @@
 package horizon
 
-// import (
-// 	"encoding/json"
-// 	"testing"
+import (
+	"testing"
+)
 
-// 	"github.com/stellar/go/protocols/horizon"
-// 	"github.com/stellar/go/services/horizon/internal/test"
-// )
+func TestAccountActions_InvalidID(t *testing.T) {
+	ht := StartHTTPTestWithoutScenario(t)
+	defer ht.Finish()
 
-// func TestAccountActions_Show(t *testing.T) {
-// 	ht := StartHTTPTest(t, "allow_trust")
-// 	defer ht.Finish()
-// 	test.ResetHorizonDB(t, ht.HorizonDB)
-
-// 	// existing account
-// 	w := ht.Get(
-// 		"/accounts/GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
-// 	)
-// 	if ht.Assert.Equal(200, w.Code) {
-// 		var result horizon.Account
-// 		err := json.Unmarshal(w.Body.Bytes(), &result)
-// 		ht.Require.NoError(err)
-// 		ht.Assert.Equal("8589934593", result.Sequence)
-
-// 		ht.Assert.NotEqual(0, result.LastModifiedLedger)
-// 		for _, balance := range result.Balances {
-// 			if balance.Type == "native" {
-// 				ht.Assert.Equal(uint32(0), balance.LastModifiedLedger)
-// 				ht.Assert.Nil(balance.IsAuthorized)
-// 			} else {
-// 				ht.Assert.NotEqual(uint32(0), balance.LastModifiedLedger)
-// 			}
-// 		}
-// 	}
-
-// 	// missing account
-// 	w = ht.Get("/accounts/GDBAPLDCAEJV6LSEDFEAUDAVFYSNFRUYZ4X75YYJJMMX5KFVUOHX46SQ")
-// 	ht.Assert.Equal(404, w.Code)
-// }
-
-// func TestAccountActions_ShowRegressions(t *testing.T) {
-// 	ht := StartHTTPTest(t, "base")
-// 	defer ht.Finish()
-// 	test.ResetHorizonDB(t, ht.HorizonDB)
-
-// 	w := ht.Get(
-// 		"/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
-// 	)
-// 	var result horizon.Account
-// 	err := json.Unmarshal(w.Body.Bytes(), &result)
-// 	ht.Require.NoError(err)
-
-// 	// Regression: no trades link
-// 	ht.Assert.Contains(result.Links.Trades.Href, "/trades")
-
-// 	// Regression: no data link
-// 	ht.Assert.Contains(result.Links.Data.Href, "/data/{key}")
-// 	ht.Assert.True(result.Links.Data.Templated)
-
-// 	// Regression:  return 200 ok even when the history record cannot be found.
-
-// 	// overwrite history with blank
-// 	ht.T.ScenarioWithoutHorizon("base")
-// 	w = ht.Get(
-// 		"/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
-// 	)
-// 	ht.Assert.Equal(200, w.Code)
-
-// }
-
-// func TestAccountActions_InvalidID(t *testing.T) {
-// 	ht := StartHTTPTest(t, "base")
-// 	defer ht.Finish()
-
-// 	// existing account
-// 	w := ht.Get(
-// 		"/accounts/=cr%FF%98%CB%F3%AF%E72%D85%FE%28%15y%8Fz%C4Ng%CE%98h%02%2A:%B6%FF%B9%CF%92%88O%91%10d&S%7C%9Bi%D4%CFI%28%CFo",
-// 	)
-// 	ht.Assert.Equal(400, w.Code)
-// }
+	// existing account
+	w := ht.Get(
+		"/accounts/=cr%FF%98%CB%F3%AF%E72%D85%FE%28%15y%8Fz%C4Ng%CE%98h%02%2A:%B6%FF%B9%CF%92%88O%91%10d&S%7C%9Bi%D4%CFI%28%CFo",
+	)
+	ht.Assert.Equal(400, w.Code)
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes https://github.com/stellar/go/issues/2135

> When account data in Horizon table does not match Stellar-Core data, we should return (and log) error instead of returning invalid data.


### Why

The data account data populated by horizon ingestion should always match core assuming both systems are on the same ledger.

### Known limitations

[N/A]
