### PR TITLE
services/horizon/internal/expingest/processors: Remove dependency on legacy ingestion package

### DIFF
--- a/services/horizon/internal/expingest/processors/participants_processor.go
+++ b/services/horizon/internal/expingest/processors/participants_processor.go
@@ -2,7 +2,6 @@ package processors
 
 import (
 	"context"
-	"fmt"
 	stdio "io"
 
 	"github.com/stellar/go/exp/ingest/io"
@@ -83,7 +82,7 @@ func participantsForChanges(
 		case xdr.LedgerEntryChangeTypeLedgerEntryState:
 			participant = participantsForLedgerEntry(c.MustState())
 		default:
-			return nil, fmt.Errorf("Unknown change type: %s", c.Type)
+			return nil, errors.Errorf("Unknown change type: %s", c.Type)
 		}
 
 		if participant != nil {

--- a/services/horizon/internal/expingest/processors/participants_processor.go
+++ b/services/horizon/internal/expingest/processors/participants_processor.go
@@ -2,15 +2,16 @@ package processors
 
 import (
 	"context"
+	"fmt"
 	stdio "io"
 
 	"github.com/stellar/go/exp/ingest/io"
 	ingestpipeline "github.com/stellar/go/exp/ingest/pipeline"
 	"github.com/stellar/go/exp/support/pipeline"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/services/horizon/internal/ingest/participants"
 	"github.com/stellar/go/services/horizon/internal/toid"
 	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
 )
 
 // ParticipantsProcessor is a processor which ingests various participants
@@ -64,16 +65,121 @@ func (p *ParticipantsProcessor) loadAccountIDs(participantSet map[string]partici
 	return nil
 }
 
+func participantsForChanges(
+	changes xdr.LedgerEntryChanges,
+) ([]xdr.AccountId, error) {
+	var participants []xdr.AccountId
+
+	for _, c := range changes {
+		var participant *xdr.AccountId
+
+		switch c.Type {
+		case xdr.LedgerEntryChangeTypeLedgerEntryCreated:
+			participant = participantsForLedgerEntry(c.MustCreated())
+		case xdr.LedgerEntryChangeTypeLedgerEntryRemoved:
+			participant = participantsForLedgerKey(c.MustRemoved())
+		case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
+			participant = participantsForLedgerEntry(c.MustUpdated())
+		case xdr.LedgerEntryChangeTypeLedgerEntryState:
+			participant = participantsForLedgerEntry(c.MustState())
+		default:
+			return nil, fmt.Errorf("Unknown change type: %s", c.Type)
+		}
+
+		if participant != nil {
+			participants = append(participants, *participant)
+		}
+	}
+
+	return participants, nil
+}
+
+func participantsForLedgerEntry(le xdr.LedgerEntry) *xdr.AccountId {
+	if le.Data.Type != xdr.LedgerEntryTypeAccount {
+		return nil
+	}
+	aid := le.Data.MustAccount().AccountId
+	return &aid
+}
+
+func participantsForLedgerKey(lk xdr.LedgerKey) *xdr.AccountId {
+	if lk.Type != xdr.LedgerEntryTypeAccount {
+		return nil
+	}
+	aid := lk.MustAccount().AccountId
+	return &aid
+}
+
+func participantsForMeta(
+	meta xdr.TransactionMeta,
+) ([]xdr.AccountId, error) {
+	var participants []xdr.AccountId
+	if meta.Operations == nil {
+		return participants, nil
+	}
+
+	for _, op := range *meta.Operations {
+		var accounts []xdr.AccountId
+		accounts, err := participantsForChanges(op.Changes)
+		if err != nil {
+			return nil, err
+		}
+
+		participants = append(participants, accounts...)
+	}
+
+	return participants, nil
+}
+
+func participantsForTransaction(
+	sequence uint32,
+	transaction io.LedgerTransaction,
+) ([]xdr.AccountId, error) {
+	participants := []xdr.AccountId{
+		transaction.Envelope.Tx.SourceAccount,
+	}
+
+	p, err := participantsForMeta(transaction.Meta)
+	if err != nil {
+		return nil, err
+	}
+	participants = append(participants, p...)
+
+	p, err = participantsForChanges(transaction.FeeChanges)
+	if err != nil {
+		return nil, err
+	}
+	participants = append(participants, p...)
+
+	for opi, op := range transaction.Envelope.Tx.Operations {
+		operation := transactionOperationWrapper{
+			index:          uint32(opi),
+			transaction:    transaction,
+			operation:      op,
+			ledgerSequence: sequence,
+		}
+
+		p, err := operation.Participants()
+		if err != nil {
+			return nil, errors.Wrapf(
+				err, "could not determin operation %v participants", operation.ID(),
+			)
+		}
+		participants = append(participants, p...)
+	}
+
+	return dedupe(participants), nil
+}
+
 func (p *ParticipantsProcessor) addTransactionParticipants(
 	participantSet map[string]participant,
 	sequence uint32,
 	transaction io.LedgerTransaction,
 ) error {
 	transactionID := toid.New(int32(sequence), int32(transaction.Index), 0).ToInt64()
-	transactionParticipants, err := participants.ForTransaction(
-		&transaction.Envelope.Tx,
-		&transaction.Meta,
-		&transaction.FeeChanges,
+	transactionParticipants, err := participantsForTransaction(
+		sequence,
+		transaction,
 	)
 	if err != nil {
 		return errors.Wrap(err, "Could not determine participants for transaction")

--- a/services/horizon/internal/expingest/processors/participants_test.go
+++ b/services/horizon/internal/expingest/processors/participants_test.go
@@ -1,0 +1,65 @@
+package processors
+
+import "testing"
+
+import "github.com/stellar/go/exp/ingest/io"
+
+import "github.com/stretchr/testify/assert"
+
+import "github.com/stellar/go/xdr"
+
+func TestParticipantsForTransaction(t *testing.T) {
+	var envelope xdr.TransactionEnvelope
+	var meta xdr.TransactionMeta
+	var feeChanges xdr.LedgerEntryChanges
+	assert.NoError(
+		t,
+		xdr.SafeUnmarshalBase64(
+			"AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAABAAAAAQAAAAAAAABkAAAAAF4L0vAAAAAAAAAAAQAAAAAAAAAAAAAAAC6N7oJcJiUzTWRDL98Bj3fVrJUB19wFvCzEHh8nn/IOAAAAAlQL5AAAAAAAAAAAAVb8BfcAAABA8CyjzEXXVTMwnZTAbHfJeq2HCFzAWkU98ds2ZXFqjXR4EiN0YDSAb/pJwXc0TjMa//SiX83UvUFSqLa8hOXICQ==",
+			&envelope,
+		),
+	)
+	assert.NoError(
+		t,
+		xdr.SafeUnmarshalBase64(
+			"AAAAAQAAAAIAAAADAAAAAwAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcN4Lazp2P/nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcN4Lazp2P/nAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMAAAADAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/+cAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrFTWBucAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAAuje6CXCYlM01kQy/fAY931ayVAdfcBbwsxB4fJ5/yDgAAAAJUC+QAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+			&meta,
+		),
+	)
+	assert.NoError(
+		t,
+		xdr.SafeUnmarshalBase64(
+			"AAAAAgAAAAMAAAABAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/+cAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+			&feeChanges,
+		),
+	)
+
+	particpants, err := participantsForTransaction(
+		3,
+		io.LedgerTransaction{
+			Index:      1,
+			Envelope:   envelope,
+			FeeChanges: feeChanges,
+			Meta:       meta,
+			Result: xdr.TransactionResultPair{
+				Result: xdr.TransactionResult{
+					Result: xdr.TransactionResultResult{
+						Code: xdr.TransactionResultCodeTxSuccess,
+					},
+				},
+			},
+		},
+	)
+	assert.NoError(t, err)
+	assert.Len(t, particpants, 2)
+	assert.Contains(
+		t,
+		particpants,
+		xdr.MustAddress("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"),
+	)
+	assert.Contains(
+		t,
+		particpants,
+		xdr.MustAddress("GAXI33UCLQTCKM2NMRBS7XYBR535LLEVAHL5YBN4FTCB4HZHT7ZA5CVK"),
+	)
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes https://github.com/stellar/go/issues/2145

The `ParticipantsProcessor` uses the ingest/participants package to extract participants from a transaction.

This commit copies the code from the ingest/participants package to the processors package because the ingest package will be removed in an upcoming pull request.

### Known limitations

[N/A]
