### PR TITLE
exp/services/webauth: update readme usage text

### DIFF
--- a/exp/services/webauth/README.md
+++ b/exp/services/webauth/README.md
@@ -42,13 +42,13 @@ Usage:
   webauth serve [flags]
 
 Flags:
-      --challenge-expires-in int    The time period in seconds after which the challenge transaction expires (default 300)
-      --horizon-url string          Horizon URL used for looking up account details (default "https://horizon-testnet.stellar.org/")
-      --jwt-expires-in int          The time period in seconds after which the JWT expires (default 300)
-      --jwt-key string              Base64 encoded ECDSA private key used for signing JWTs
-      --network-passphrase string   Network passphrase of the Stellar network transactions should be signed for (default "Test SDF Network ; September 2015")
-      --port int                    Port to listen and serve on (default 8000)
-      --signing-key string          Stellar signing key used for signing transactions
+      --challenge-expires-in int    The time period in seconds after which the challenge transaction expires (CHALLENGE_EXPIRES_IN) (default 300)
+      --horizon-url string          Horizon URL used for looking up account details (HORIZON_URL) (default "https://horizon-testnet.stellar.org/")
+      --jwt-expires-in int          The time period in seconds after which the JWT expires (JWT_EXPIRES_IN) (default 300)
+      --jwt-key string              Base64 encoded ECDSA private key used for signing JWTs (JWT_KEY)
+      --network-passphrase string   Network passphrase of the Stellar network transactions should be signed for (NETWORK_PASSPHRASE) (default "Test SDF Network ; September 2015")
+      --port int                    Port to listen and serve on (PORT) (default 8000)
+      --signing-key string          Stellar signing key used for signing transactions (SIGNING_KEY)
 ```
 
 [SEP-10]: https://github.com/stellar/stellar-protocol/blob/2be91ce8d8032ca9b2f368800d06b9fba346a147/ecosystem/sep-0010.md


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Update the `webauth`'s README usage text to match the usage text generated by the command, showing the environment variables that can be used to configure the application.

### Why

So that by looking at the README you can see what environment variables are available for configuring the application.

### Known limitations

N/A
