### PR TITLE
services/horizon: Cleanup routes in webserver init code

### DIFF
--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -690,6 +690,9 @@ func GetParams(dst interface{}, r *http.Request) error {
 	// contain `account_id` and URL Query params will contain `foo`.
 	if rctx := chi.RouteContext(r.Context()); rctx != nil {
 		for _, key := range rctx.URLParams.Keys {
+			if key == "*" {
+				continue
+			}
 			val := query.Get(key)
 			if len(val) > 0 {
 				return problem.MakeInvalidFieldProblem(

--- a/services/horizon/internal/actions_account_test.go
+++ b/services/horizon/internal/actions_account_test.go
@@ -2,11 +2,28 @@ package horizon
 
 import (
 	"testing"
+
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/expingest"
+	"github.com/stellar/go/xdr"
 )
 
 func TestAccountActions_InvalidID(t *testing.T) {
 	ht := StartHTTPTestWithoutScenario(t)
 	defer ht.Finish()
+
+	// Makes StateMiddleware happy
+	q := history.Q{ht.HorizonSession()}
+	err := q.UpdateLastLedgerExpIngest(100)
+	ht.Assert.NoError(err)
+	err = q.UpdateExpIngestVersion(expingest.CurrentVersion)
+	ht.Assert.NoError(err)
+	_, err = q.InsertLedger(xdr.LedgerHeaderHistoryEntry{
+		Header: xdr.LedgerHeader{
+			LedgerSeq: 100,
+		},
+	}, 0, 0, 0, 0)
+	ht.Assert.NoError(err)
 
 	// existing account
 	w := ht.Get(

--- a/services/horizon/internal/actions_data_test.go
+++ b/services/horizon/internal/actions_data_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/expingest"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,18 @@ func TestDataActions_Show(t *testing.T) {
 	defer ht.Finish()
 	test.ResetHorizonDB(t, ht.HorizonDB)
 	q := &history.Q{ht.HorizonSession()}
+
+	// Makes StateMiddleware happy
+	err := q.UpdateLastLedgerExpIngest(100)
+	ht.Assert.NoError(err)
+	err = q.UpdateExpIngestVersion(expingest.CurrentVersion)
+	ht.Assert.NoError(err)
+	_, err = q.InsertLedger(xdr.LedgerHeaderHistoryEntry{
+		Header: xdr.LedgerHeader{
+			LedgerSeq: 100,
+		},
+	}, 0, 0, 0, 0)
+	ht.Assert.NoError(err)
 
 	rows, err := q.InsertAccountData(data1, 1234)
 	assert.NoError(t, err)

--- a/services/horizon/internal/actions_path_test.go
+++ b/services/horizon/internal/actions_path_test.go
@@ -42,10 +42,6 @@ func inMemoryPathFindingClient(
 	}
 
 	router.Group(func(r chi.Router) {
-		// requiresExperimentalIngestion := &ExperimentalIngestionMiddleware{
-		// 	HorizonSession: tt.HorizonSession(),
-		// }
-		// router.Use(requiresExperimentalIngestion.Wrap)
 		router.Method("GET", "/paths", findPaths)
 		router.Method("GET", "/paths/strict-receive", findPaths)
 		router.Method("GET", "/paths/strict-send", findFixedPaths)
@@ -77,10 +73,6 @@ func dbPathFindingClient(
 	}
 
 	router.Group(func(r chi.Router) {
-		// requiresExperimentalIngestion := &ExperimentalIngestionMiddleware{
-		// 	HorizonSession: tt.HorizonSession(),
-		// }
-		// router.Use(requiresExperimentalIngestion.Wrap)
 		router.Method("GET", "/paths", findPaths)
 		router.Method("GET", "/paths/strict-receive", findPaths)
 		router.Method("GET", "/paths/strict-send", findFixedPaths)

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -462,7 +462,7 @@ func (a *App) init() {
 	// This parameter will be removed soon.
 	a.web.mustInstallMiddlewares(a, a.config.ConnectionTimeout)
 
-	requiresExperimentalIngestion := &ExperimentalIngestionMiddleware{
+	requiresExperimentalIngestion := &StateMiddleware{
 		HorizonSession: a.historyQ.Session,
 	}
 	// web.actions

--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -241,20 +241,6 @@ func requestMetricsMiddleware(h http.Handler) http.Handler {
 	})
 }
 
-// acceptOnlyJSON inspects the accept header of the request and responds with
-// an error if the content type is not JSON
-func acceptOnlyJSON(h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		contentType := render.Negotiate(r)
-		if contentType != render.MimeHal && contentType != render.MimeJSON {
-			problem.Render(r.Context(), w, hProblem.NotAcceptable)
-			return
-		}
-
-		h.ServeHTTP(w, r)
-	})
-}
-
 // StateMiddleware is a middleware which enables a state handler if the state
 // has been initialized.
 // It also ensures that state (ledger entries) has been verified and are

--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -255,12 +255,12 @@ func acceptOnlyJSON(h http.Handler) http.Handler {
 	})
 }
 
-// ExperimentalIngestionMiddleware is a middleware which enables a handler
-// if the experimental ingestion system is enabled and initialized.
+// StateMiddleware is a middleware which enables a state handler if the state
+// has been initialized.
 // It also ensures that state (ledger entries) has been verified and are
 // correct. Otherwise returns `500 Internal Server Error` to prevent
 // returning invalid data to the user.
-type ExperimentalIngestionMiddleware struct {
+type StateMiddleware struct {
 	HorizonSession *db.Session
 }
 
@@ -293,7 +293,7 @@ func ingestionStatus(q *history.Q) (uint32, bool, error) {
 }
 
 // Wrap executes the middleware on a given http handler
-func (m *ExperimentalIngestionMiddleware) Wrap(h http.Handler) http.Handler {
+func (m *StateMiddleware) Wrap(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		session := m.HorizonSession.Clone()
 		q := &history.Q{session}

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -152,7 +152,7 @@ func TestRateLimit_Redis(t *testing.T) {
 	assert.Equal(t, 200, w.Code)
 }
 
-func TestRequiresExperimentalIngestion(t *testing.T) {
+func TestStateMiddleware(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
@@ -173,10 +173,10 @@ func TestRequiresExperimentalIngestion(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}
 
-	requiresExperimentalIngestion := &ExperimentalIngestionMiddleware{
+	stateMiddleware := &StateMiddleware{
 		HorizonSession: tt.HorizonSession(),
 	}
-	handler := requiresExperimentalIngestion.Wrap(http.HandlerFunc(endpoint))
+	handler := stateMiddleware.Wrap(http.HandlerFunc(endpoint))
 
 	for i, testCase := range []struct {
 		name                string


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit cleans the code responsible for Horizon webserver init.

### Why

* Moved all routes using the `StateMiddleware` (previously `ExperimentalIngestionMiddleware`) to avoid code duplication.
* Start routes using order book graph only if the instance is ingesting.