### PR TITLE
services/horizon: Fix empty route param bug

### DIFF
--- a/services/horizon/internal/actions_effects_test.go
+++ b/services/horizon/internal/actions_effects_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stellar/go/protocols/horizon/effects"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/expingest"
 	"github.com/stellar/go/services/horizon/internal/test"
 )
 
@@ -39,6 +40,17 @@ func TestEffectActions_Index(t *testing.T) {
 		if ht.Assert.Equal(200, w.Code) {
 			ht.Assert.PageOf(2, w.Body)
 		}
+
+		// Makes StateMiddleware happy
+		q := history.Q{ht.HorizonSession()}
+		err := q.UpdateLastLedgerExpIngest(3)
+		ht.Assert.NoError(err)
+		err = q.UpdateExpIngestVersion(expingest.CurrentVersion)
+		ht.Assert.NoError(err)
+
+		// checks if empty param returns 404 instead of all payments
+		w = ht.Get("/accounts//effects")
+		ht.Assert.NotEqual(404, w.Code)
 
 		// filtered by account
 		w = ht.Get("/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H/effects")

--- a/services/horizon/internal/actions_payment_test.go
+++ b/services/horizon/internal/actions_payment_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/expingest"
 )
 
 func TestPaymentActions(t *testing.T) {
@@ -29,6 +30,17 @@ func TestPaymentActions(t *testing.T) {
 	if ht.Assert.Equal(200, w.Code) {
 		ht.Assert.PageOf(1, w.Body)
 	}
+
+	// Makes StateMiddleware happy
+	q := history.Q{ht.HorizonSession()}
+	err := q.UpdateLastLedgerExpIngest(3)
+	ht.Assert.NoError(err)
+	err = q.UpdateExpIngestVersion(expingest.CurrentVersion)
+	ht.Assert.NoError(err)
+
+	// checks if empty param returns 404 instead of all payments
+	w = ht.Get("/accounts//payments")
+	ht.Assert.NotEqual(404, w.Code)
 
 	// filtered by account
 	w = ht.Get("/accounts/GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2/payments")

--- a/services/horizon/internal/actions_transaction_test.go
+++ b/services/horizon/internal/actions_transaction_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/expingest"
 	"github.com/stellar/go/services/horizon/internal/txsub"
 	"github.com/stellar/go/services/horizon/internal/txsub/sequence"
 )
@@ -178,6 +180,17 @@ func TestTransactionActions_Index(t *testing.T) {
 	// missing ledger
 	w = ht.Get("/ledgers/100/transactions")
 	ht.Assert.Equal(404, w.Code)
+
+	// Makes StateMiddleware happy
+	q := history.Q{ht.HorizonSession()}
+	err := q.UpdateLastLedgerExpIngest(100)
+	ht.Assert.NoError(err)
+	err = q.UpdateExpIngestVersion(expingest.CurrentVersion)
+	ht.Assert.NoError(err)
+
+	// checks if empty param returns 404 instead of all payments
+	w = ht.Get("/accounts//transactions")
+	ht.Assert.NotEqual(404, w.Code)
 
 	// filtering by account
 	w = ht.Get("/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H/transactions")

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -200,12 +200,13 @@ func (w *web) mustInstallActions(
 	})
 
 	// account actions - /accounts/{account_id} has been created above so we
-	// need to use absolute routes here.
-	r.Get("/accounts/{account_id}/transactions", w.streamIndexActionHandler(w.getTransactionPage, w.streamTransactions))
-	r.Get("/accounts/{account_id}/operations", OperationIndexAction{}.Handle)
-	r.Get("/accounts/{account_id}/payments", OperationIndexAction{OnlyPayments: true}.Handle)
-	r.Get("/accounts/{account_id}/effects", EffectIndexAction{}.Handle)
-	r.Get("/accounts/{account_id}/trades", TradeIndexAction{}.Handle)
+	// need to use absolute routes here. Make sure we use regexp check here for
+	// emptiness. Without it, requesting `/accounts//payments` return all payments!
+	r.Get("/accounts/{account_id:\\w+}/transactions", w.streamIndexActionHandler(w.getTransactionPage, w.streamTransactions))
+	r.Get("/accounts/{account_id:\\w+}/operations", OperationIndexAction{}.Handle)
+	r.Get("/accounts/{account_id:\\w+}/payments", OperationIndexAction{OnlyPayments: true}.Handle)
+	r.Get("/accounts/{account_id:\\w+}/effects", EffectIndexAction{}.Handle)
+	r.Get("/accounts/{account_id:\\w+}/trades", TradeIndexAction{}.Handle)
 
 	// ledger actions
 	r.Route("/ledgers", func(r chi.Router) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

Fixes a bug introduced in #2152. Paths like: `/accounts//payments` return all payments instead of 404. This can lead to dangerous bugs when account ID is omited in request by accident.