### PR TITLE
services/horizon: Remove expingest Session usage, refactor System

### DIFF
--- a/exp/ingest/io/ledger_transaction.go
+++ b/exp/ingest/io/ledger_transaction.go
@@ -15,6 +15,7 @@ import (
 // If an entry is updated: Pre is not nil and Post is not nil.
 // If an entry is removed: Pre is not nil and Post is nil.
 type Change struct {
+	// Type could be a method on Change
 	Type xdr.LedgerEntryType
 	Pre  *xdr.LedgerEntry
 	Post *xdr.LedgerEntry

--- a/exp/ingest/io/main.go
+++ b/exp/ingest/io/main.go
@@ -1,6 +1,10 @@
 package io
 
 import (
+	"context"
+	"fmt"
+	stdio "io"
+
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -35,13 +39,226 @@ type StateWriter interface {
 	Close() error
 }
 
+type StateProcessors []StateProcessor
+
+// StateProcessor defines methods required for state processing.
+type StateProcessor interface {
+	Init() error
+	ProcessState(Change) error
+	Commit() error
+}
+
+// ProcessStateReader runs state processing on a set of processors using StateReader.
+// If ctx WithCancel is passed the processing will stop and the function will return
+// context.Canceled.
+func (processors StateProcessors) ProcessStateReader(ctx context.Context, r StateReader) error {
+	// Init stage
+	for _, processor := range processors {
+		err := processor.Init()
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Error in Init in %T", processor))
+		}
+
+		select {
+		case <-ctx.Done():
+			return context.Canceled
+		default:
+			continue
+		}
+	}
+
+	// Process stage
+	for {
+		entryChange, err := r.Read()
+		if err != nil {
+			if err == stdio.EOF {
+				break
+			} else {
+				return errors.Wrap(err, "Error reading from state reader")
+			}
+		}
+
+		// Double check the type
+		if entryChange.Type != xdr.LedgerEntryChangeTypeLedgerEntryCreated {
+			return errors.Wrap(err, "DatabaseProcessor requires LedgerEntryChangeTypeLedgerEntryState changes only")
+		}
+
+		change := Change{
+			Type: entryChange.Created.Data.Type,
+			Post: entryChange.Created,
+		}
+
+		for _, processor := range processors {
+			err := processor.ProcessState(change)
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("Error in ProcessState in %T", processor))
+			}
+
+			select {
+			case <-ctx.Done():
+				return context.Canceled
+			default:
+				continue
+			}
+		}
+	}
+
+	// Commit stage
+	for _, processor := range processors {
+		err := processor.Commit()
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Error in Commit in %T", processor))
+		}
+
+		select {
+		case <-ctx.Done():
+			return context.Canceled
+		default:
+			continue
+		}
+	}
+
+	return nil
+}
+
+// ProcessLedgerReader runs state processing on a set of processors using LedgerReader.
+// Meta changes returned by LedgerReader must be processes in a correct order so it's
+// better to use this helper unless you need some special processing of low-level
+// meta structures.
+// If ctx WithCancel is passed the processing will stop and the function will return
+// context.Canceled.
+func (processors StateProcessors) ProcessLedgerReader(ctx context.Context, r LedgerReader) error {
+	// Init stage
+	for _, processor := range processors {
+		err := processor.Init()
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Error in Init in %T", processor))
+		}
+
+		select {
+		case <-ctx.Done():
+			return context.Canceled
+		default:
+			continue
+		}
+	}
+
+	// Fee meta before everything else
+	for {
+		transaction, err := r.Read()
+		if err != nil {
+			if err == stdio.EOF {
+				break
+			} else {
+				return errors.Wrap(err, "Error reading from ledger reader")
+			}
+		}
+
+		for _, change := range transaction.GetFeeChanges() {
+			for _, processor := range processors {
+				err := processor.ProcessState(change)
+				if err != nil {
+					return errors.Wrap(err, fmt.Sprintf("Error in ProcessState in %T", processor))
+				}
+
+				select {
+				case <-ctx.Done():
+					return context.Canceled
+				default:
+					continue
+				}
+			}
+		}
+	}
+
+	// Rewind reader to process meta from the first transaction.
+	err := r.Rewind()
+	if err != nil {
+		return errors.Wrap(err, "Error rewinding ledger reader")
+	}
+
+	// Tx meta
+	for {
+		transaction, err := r.Read()
+		if err != nil {
+			if err == stdio.EOF {
+				break
+			} else {
+				return errors.Wrap(err, "Error reading from ledger reader")
+			}
+		}
+
+		changes, err := transaction.GetChanges()
+		if err != nil {
+			return errors.Wrap(err, "Error getting transaction changes")
+		}
+
+		for _, change := range changes {
+			for _, processor := range processors {
+				err := processor.ProcessState(change)
+				if err != nil {
+					return errors.Wrap(err, fmt.Sprintf("Error in ProcessState in %T", processor))
+				}
+
+				select {
+				case <-ctx.Done():
+					return context.Canceled
+				default:
+					continue
+				}
+			}
+		}
+	}
+
+	// Upgrades
+	for {
+		change, err := r.ReadUpgradeChange()
+		if err != nil {
+			if err == stdio.EOF {
+				break
+			} else {
+				return err
+			}
+		}
+
+		for _, processor := range processors {
+			err := processor.ProcessState(change)
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("Error in ProcessState in %T", processor))
+			}
+
+			select {
+			case <-ctx.Done():
+				return context.Canceled
+			default:
+				continue
+			}
+		}
+	}
+
+	// Commit stage
+	for _, processor := range processors {
+		err := processor.Commit()
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Error in Commit in %T", processor))
+		}
+	}
+
+	return nil
+}
+
 // LedgerReader provides convenient, streaming access to the transactions within a ledger.
+// If processing meta, please use StateProcessors.ProcessLedgerReader method instead of
+// processing this once.
 type LedgerReader interface {
 	GetSequence() uint32
 	GetHeader() xdr.LedgerHeaderHistoryEntry
 	// Read should return the next transaction. If there are no more
 	// transactions it should return `io.EOF` error.
 	Read() (LedgerTransaction, error)
+	// Rewind rewinds reader to the beginning. The next Read() will return the
+	// first transaction in the ledger (or `io.EOF` if no transactions).
+	Rewind() error
 	// Read should return the next ledger entry change from ledger upgrades. If
 	// there are no more changes it should return `io.EOF` error.
 	// Ledger upgrades MUST be processed AFTER all transactions and only ONCE.
@@ -49,15 +266,9 @@ type LedgerReader interface {
 	// be updated with upgrade changes.
 	// Values returned by this method must not be modified.
 	ReadUpgradeChange() (Change, error)
-	// IgnoreLedgerEntryChanges will change `Close()`` behaviour to not error
-	// when changes returned by `ReadUpgradeChange` are not fully read.
-	IgnoreUpgradeChanges()
 	// Close should be called when reading is finished. This is especially
 	// helpful when there are still some transactions available so reader can stop
 	// streaming them.
-	// Close should return error if `ReadUpgradeChange` are not fully read or
-	// `ReadUpgradeChange` was not called even once. However, this behaviour can
-	// be disabled by calling `IgnoreUpgradeChanges()`.
 	Close() error
 }
 
@@ -89,4 +300,76 @@ type LedgerTransaction struct {
 	// entry changes.
 	FeeChanges xdr.LedgerEntryChanges
 	Meta       xdr.TransactionMeta
+}
+
+type TransactionProcessors []TransactionProcessor
+
+// TransactionProcessor defines methods required for transaction processing.
+type TransactionProcessor interface {
+	Init() error
+	ProcessTransaction(LedgerTransaction) error
+	Commit() error
+}
+
+// ProcessLedgerReader runs processing on a set of processors using LedgeReader.
+// If ctx WithCancel is passed the processing will stop and the function will return
+// context.Canceled.
+func (processors TransactionProcessors) ProcessLedgerReader(ctx context.Context, r LedgerReader) error {
+	// Init stage
+	for _, processor := range processors {
+		err := processor.Init()
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Error in Init in %T", processor))
+		}
+
+		select {
+		case <-ctx.Done():
+			return context.Canceled
+		default:
+			continue
+		}
+	}
+
+	// Process stage
+	for {
+		transaction, err := r.Read()
+		if err != nil {
+			if err == stdio.EOF {
+				break
+			} else {
+				return errors.Wrap(err, "Error reading from state reader")
+			}
+		}
+
+		for _, processor := range processors {
+			err := processor.ProcessTransaction(transaction)
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("Error in ProcessTransaction in %T", processor))
+			}
+
+			select {
+			case <-ctx.Done():
+				return context.Canceled
+			default:
+				continue
+			}
+		}
+	}
+
+	// Commit stage
+	for _, processor := range processors {
+		err := processor.Commit()
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Error in Commit in %T", processor))
+		}
+
+		select {
+		case <-ctx.Done():
+			return context.Canceled
+		default:
+			continue
+		}
+	}
+
+	return nil
 }

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -686,6 +686,10 @@ func (s *System) resume() (state, error) {
 	if updateDatabase {
 		// Add history data to a database
 		ledgerProcessors := s.getLedgerProcessors()
+
+		// TODO, if we're s.config.IngestFailedTransactions == false we can wrap
+		// LedgerReader to skip failed.
+
 		err = ledgerProcessors.ProcessLedgerReader(ledgerReader)
 		if err != nil {
 			// Context cancelled = shutdown

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -133,11 +133,6 @@ type state struct {
 	noSleep bool
 }
 
-type processingMode struct {
-	ingestState    bool
-	ingestDatabase bool
-}
-
 type System struct {
 	config Config
 	state  state
@@ -565,7 +560,8 @@ func (s *System) buildState() (state, error) {
 	}
 	defer stateReader.Close()
 
-	processors := s.getStateProcessors(true)
+	updateDatabase := true
+	processors := s.getStateProcessors(updateDatabase)
 	err = processors.ProcessStateReader(stateReader)
 	if err != nil {
 		// Context cancelled = shutdown
@@ -698,9 +694,7 @@ func (s *System) resume() (state, error) {
 			}
 			return defaultReturnState, err
 		}
-	}
 
-	if updateDatabase {
 		// If we're in a transaction we're updating database with new data.
 		// We get lastIngestedLedger from a DB here to do an extra check
 		// if the current node should really be updating a DB.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

This commit is refactoring proposal of the `exp/ingest` and `horizon/expingest/System`. It's mostly moving code from `LiveSession` and pipeline hooks to ingestion system in Horizon.

Here's a list of changes with explanation:
* Added new `StateProcessor` and `LedgerProcessor` (rename to `TransactionProcessor`?) in `exp/ingest/io`. `StateProcessor` operates on `io.Change` so it's not possible to process meta changes in a wrong order.
* Added methods on slice of processors (both state and ledger) that run a slice of processors using given reader type. It prevents boilerplate code (`Init`, `Commit`) and also ensures meta changes are processed in correct order. This is part of `exp/ingest` so future `ingest` users can use them to process ledgers/meta.
* Removed `LiveSession` usage from `expingest.System` in Horizon. The code is more clear and easier to test. `expingest/system.go` file is almost 1000 LOC now. We should probably move each machine state to a separate file to make it more readable.
* Added `Rewind()` method to `LedgerReader` to allow ingesting fee changes before tx meta changes.
* I changed `buildStateAndResumeIngestion` state to `buildState`. The state is now easier to understand and test.

Tests are not updated and the code doesn't compile. Will be fixed once the refactor is approved.