### PR TITLE
Processor Interfaces for new ingestion design 

### DIFF
--- a/exp/ingest/io/ledger_entry_change_cache.go
+++ b/exp/ingest/io/ledger_entry_change_cache.go
@@ -215,3 +215,11 @@ func (c *LedgerEntryChangeCache) GetChanges() []Change {
 
 	return changes
 }
+
+// Size returns the number of changes in the cache.
+func (c *LedgerEntryChangeCache) Size() int {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	return len(c.cache)
+}

--- a/exp/ingest/processors.go
+++ b/exp/ingest/processors.go
@@ -1,0 +1,88 @@
+package ingest
+
+import (
+	"github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/xdr"
+)
+
+type ChangeProcessor interface {
+	Init(sequence uint32) error
+	ProcessChange(change io.Change) error
+	Commit() error
+}
+
+type LedgerTransactionProcessor interface {
+	Init(header xdr.LedgerHeader) error
+	ProcessTransaction(transaction io.LedgerTransaction) error
+	Commit() error
+}
+
+type cpGroup []ChangeProcessor
+
+func (g cpGroup) Init(sequence uint32) error {
+	for _, p := range g {
+		if err := p.Init(sequence); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g cpGroup) ProcessChange(change io.Change) error {
+	for _, p := range g {
+		if err := p.ProcessChange(change); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g cpGroup) Commit() error {
+	for _, p := range g {
+		if err := p.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func GroupChangeProcessors(
+	processors ...ChangeProcessor,
+) ChangeProcessor {
+	return cpGroup(processors)
+}
+
+type ltGroup []LedgerTransactionProcessor
+
+func (g ltGroup) Init(header xdr.LedgerHeader) error {
+	for _, p := range g {
+		if err := p.Init(header); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g ltGroup) ProcessTransaction(transaction io.LedgerTransaction) error {
+	for _, p := range g {
+		if err := p.ProcessTransaction(transaction); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g ltGroup) Commit() error {
+	for _, p := range g {
+		if err := p.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func GroupLedgerTransactionProcessors(
+	processors ...LedgerTransactionProcessor,
+) LedgerTransactionProcessor {
+	return ltGroup(processors)
+}

--- a/services/horizon/internal/expingest/processors/account_data_processor.go
+++ b/services/horizon/internal/expingest/processors/account_data_processor.go
@@ -15,7 +15,7 @@ type AccountDataProcessor struct {
 	batch history.AccountDataBatchInsertBuilder
 }
 
-func (p *AccountDataProcessor) Init(header xdr.LedgerHeader) error {
+func (p *AccountDataProcessor) Init(sequence uint32) error {
 	p.batch = p.DataQ.NewAccountDataBatchInsertBuilder(maxBatchSize)
 	p.cache = io.NewLedgerEntryChangeCache()
 	return nil

--- a/services/horizon/internal/expingest/processors/accounts_data_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_data_processor_test.go
@@ -34,10 +34,7 @@ func (s *AccountsDataProcessorTestSuiteState) SetupTest() {
 		DataQ: s.mockQ,
 	}
 
-	header := xdr.LedgerHeader{
-		LedgerSeq: xdr.Uint32(63),
-	}
-	err := s.processor.Init(header)
+	err := s.processor.Init(63)
 	s.Assert().NoError(err)
 }
 
@@ -93,10 +90,7 @@ func (s *AccountsDataProcessorTestSuiteLedger) SetupTest() {
 		DataQ: s.mockQ,
 	}
 
-	header := xdr.LedgerHeader{
-		LedgerSeq: xdr.Uint32(63),
-	}
-	err := s.processor.Init(header)
+	err := s.processor.Init(63)
 	s.Assert().NoError(err)
 }
 

--- a/services/horizon/internal/expingest/processors/accounts_data_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_data_processor_test.go
@@ -37,7 +37,7 @@ func (s *AccountsDataProcessorTestSuiteState) SetupTest() {
 	header := xdr.LedgerHeader{
 		LedgerSeq: xdr.Uint32(63),
 	}
-	err := s.processor.Init(header, InitChangesMode)
+	err := s.processor.Init(header)
 	s.Assert().NoError(err)
 }
 
@@ -96,7 +96,7 @@ func (s *AccountsDataProcessorTestSuiteLedger) SetupTest() {
 	header := xdr.LedgerHeader{
 		LedgerSeq: xdr.Uint32(63),
 	}
-	err := s.processor.Init(header, LedgerChangesMode)
+	err := s.processor.Init(header)
 	s.Assert().NoError(err)
 }
 

--- a/services/horizon/internal/expingest/processors/new_transactions_processor.go
+++ b/services/horizon/internal/expingest/processors/new_transactions_processor.go
@@ -13,7 +13,7 @@ type NewTransactionProcessor struct {
 	batch    history.TransactionBatchInsertBuilder
 }
 
-func (p *NewTransactionProcessor) Init(header xdr.LedgerHeader, mode ChangesMode) error {
+func (p *NewTransactionProcessor) Init(header xdr.LedgerHeader) error {
 	p.sequence = uint32(header.LedgerSeq)
 	p.batch = p.TransactionsQ.NewTransactionBatchInsertBuilder(maxBatchSize)
 	return nil

--- a/services/horizon/internal/expingest/processors/transactions_processor_test.go
+++ b/services/horizon/internal/expingest/processors/transactions_processor_test.go
@@ -35,7 +35,7 @@ func (s *TransactionsProcessorTestSuiteLedger) SetupTest() {
 	header := xdr.LedgerHeader{
 		LedgerSeq: xdr.Uint32(20),
 	}
-	err := s.processor.Init(header, LedgerChangesMode)
+	err := s.processor.Init(header)
 	s.Assert().NoError(err)
 }
 


### PR DESCRIPTION
exp/ingest/processors.go has all the interfaces for the new ingestion design.'
All processors in the `services/horizon/internal/expingest/processors` package should implement `ChangeProcessor` or `LedgerTransactionProcessor`