### PR TITLE
exp/ingest/io: Add ChangeReader implementation

### DIFF
--- a/exp/ingest/cmd/main.go
+++ b/exp/ingest/cmd/main.go
@@ -81,7 +81,7 @@ func useAdapter() {
 	log.Infof("latest ledger is %d, closed at %s (%d)", ledgerSequence,
 		time.Unix(int64(h.Header.ScpValue.CloseTime), 0), h.Header.ScpValue.CloseTime)
 
-	lrc.Close()
+	// lrc.Close()
 	lba.Close()
 }
 

--- a/exp/ingest/io/change_reader.go
+++ b/exp/ingest/io/change_reader.go
@@ -68,10 +68,7 @@ func (r *changeReader) getNextFeeChange() (Change, error) {
 			}
 		}
 
-		var changes []Change
-		for _, change := range transaction.GetFeeChanges() {
-			changes = append(changes, change)
-		}
+		changes := transaction.GetFeeChanges()
 		if len(changes) >= 1 {
 			r.pending = append(r.pending, changes[1:]...)
 			return changes[0], nil

--- a/exp/ingest/io/change_reader.go
+++ b/exp/ingest/io/change_reader.go
@@ -25,7 +25,7 @@ type changeReader struct {
 	pendingIndex           int
 }
 
-// Ensure DBLedgerReader implements LedgerReader
+// Ensure changeReader implements ChangeReader
 var _ ChangeReader = (*changeReader)(nil)
 
 // NewChangeReader constructs a new ChangeReader instance bound to the given eldger

--- a/exp/ingest/io/change_reader.go
+++ b/exp/ingest/io/change_reader.go
@@ -1,0 +1,149 @@
+package io
+
+import (
+	"io"
+
+	"github.com/stellar/go/exp/ingest/ledgerbackend"
+	"github.com/stellar/go/xdr"
+)
+
+// ChangeReader provides convenient, streaming access to changes within a ledger.
+type ChangeReader interface {
+	GetSequence() uint32
+	GetHeader() xdr.LedgerHeaderHistoryEntry
+	// Read should return the next `Change` in the leader. If there are no more
+	// changes left it should return an `io.EOF` error.
+	Read() (Change, error)
+}
+
+type changeReader struct {
+	dbReader               DBLedgerReader
+	streamedFeeChanges     bool
+	streamedMetaChanges    bool
+	streamedUpgradeChanges bool
+	pending                []Change
+	pendingIndex           int
+}
+
+// Ensure DBLedgerReader implements LedgerReader
+var _ ChangeReader = (*changeReader)(nil)
+
+// NewChangeReader constructs a new ChangeReader instance bound to the given eldger
+func NewChangeReader(sequence uint32, backend ledgerbackend.LedgerBackend) (ChangeReader, error) {
+	reader, err := NewDBLedgerReader(sequence, backend)
+	if err != nil {
+		return nil, err
+	}
+
+	return &changeReader{dbReader: *reader}, nil
+}
+
+// GetSequence returns the ledger sequence for the reader
+func (r *changeReader) GetSequence() uint32 {
+	return r.dbReader.GetSequence()
+}
+
+// GetSequence returns the ledger header for the reader
+func (r *changeReader) GetHeader() xdr.LedgerHeaderHistoryEntry {
+	return r.dbReader.GetHeader()
+}
+
+func (r *changeReader) getNextFeeChange() (Change, error) {
+	if r.streamedFeeChanges {
+		return Change{}, io.EOF
+	}
+
+	// Remember that it's possible that transaction can remove a preauth
+	// tx signer even when it's a failed transaction so we need to check
+	// failed transactions too.
+	for {
+		transaction, err := r.dbReader.Read()
+		if err != nil {
+			if err == io.EOF {
+				r.dbReader.rewind()
+				r.streamedFeeChanges = true
+				return Change{}, io.EOF
+			} else {
+				return Change{}, err
+			}
+		}
+
+		var changes []Change
+		for _, change := range transaction.GetFeeChanges() {
+			changes = append(changes, change)
+		}
+		if len(changes) >= 1 {
+			r.pending = append(r.pending, changes[1:]...)
+			return changes[0], nil
+		}
+	}
+}
+
+func (r *changeReader) getNextMetaChange() (Change, error) {
+	if r.streamedMetaChanges {
+		return Change{}, io.EOF
+	}
+
+	for {
+		transaction, err := r.dbReader.Read()
+		if err != nil {
+			if err == io.EOF {
+				r.streamedMetaChanges = true
+				return Change{}, io.EOF
+			} else {
+				return Change{}, err
+			}
+		}
+
+		changes, err := transaction.GetChanges()
+		if err != nil {
+			return Change{}, err
+		}
+		if len(changes) >= 1 {
+			r.pending = append(r.pending, changes[1:]...)
+			return changes[0], nil
+		}
+	}
+}
+
+func (r *changeReader) getNextUpgradeChange() (Change, error) {
+	if r.streamedUpgradeChanges {
+		return Change{}, io.EOF
+	}
+
+	change, err := r.dbReader.readUpgradeChange()
+	if err != nil {
+		if err == io.EOF {
+			r.streamedUpgradeChanges = true
+			return Change{}, io.EOF
+		} else {
+			return Change{}, err
+		}
+	}
+
+	return change, nil
+}
+
+func (r *changeReader) Read() (Change, error) {
+	if r.pendingIndex < len(r.pending) {
+		next := r.pending[r.pendingIndex]
+		r.pendingIndex++
+		if r.pendingIndex == len(r.pending) {
+			r.pendingIndex = 0
+			r.pending = r.pending[:0]
+		}
+		return next, nil
+	}
+
+	change, err := r.getNextFeeChange()
+	if err == nil || err != io.EOF {
+		return change, err
+	}
+
+	change, err = r.getNextMetaChange()
+	if err == nil || err != io.EOF {
+		return change, err
+	}
+
+	return r.getNextUpgradeChange()
+}

--- a/exp/ingest/io/ledger_entry_change_cache.go
+++ b/exp/ingest/io/ledger_entry_change_cache.go
@@ -215,3 +215,11 @@ func (c *LedgerEntryChangeCache) GetChanges() []Change {
 
 	return changes
 }
+
+// Size returns the number of changes in the cache.
+func (c *LedgerEntryChangeCache) Size() int {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	return len(c.cache)
+}

--- a/exp/ingest/io/ledger_reader.go
+++ b/exp/ingest/io/ledger_reader.go
@@ -2,26 +2,31 @@ package io
 
 import (
 	"io"
-	"sync"
 
 	"github.com/stellar/go/exp/ingest/ledgerbackend"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 
+// LedgerReader provides convenient, streaming access to the transactions within a ledger.
+type LedgerReader interface {
+	GetSequence() uint32
+	GetHeader() xdr.LedgerHeaderHistoryEntry
+	// Read should return the next transaction. If there are no more
+	// transactions it should return `io.EOF` error.
+	Read() (LedgerTransaction, error)
+}
+
 // DBLedgerReader is a database-backed implementation of the io.LedgerReader interface.
 // Use NewDBLedgerReader to create a new instance.
 type DBLedgerReader struct {
-	sequence                uint32
-	backend                 ledgerbackend.LedgerBackend
-	header                  xdr.LedgerHeaderHistoryEntry
-	transactions            []LedgerTransaction
-	upgradeChanges          []Change
-	readMutex               sync.Mutex
-	readIdx                 int
-	upgradeReadIdx          int
-	readUpgradeChangeCalled bool
-	ignoreUpgradeChanges    bool
+	sequence       uint32
+	backend        ledgerbackend.LedgerBackend
+	header         xdr.LedgerHeaderHistoryEntry
+	transactions   []LedgerTransaction
+	upgradeChanges []Change
+	readIdx        int
+	upgradeReadIdx int
 }
 
 // Ensure DBLedgerReader implements LedgerReader
@@ -55,10 +60,6 @@ func (dblrc *DBLedgerReader) GetHeader() xdr.LedgerHeaderHistoryEntry {
 // Read returns the next transaction in the ledger, ordered by tx number, each time it is called. When there
 // are no more transactions to return, an EOF error is returned.
 func (dblrc *DBLedgerReader) Read() (LedgerTransaction, error) {
-	// Protect all accesses to dblrc.readIdx
-	dblrc.readMutex.Lock()
-	defer dblrc.readMutex.Unlock()
-
 	if dblrc.readIdx < len(dblrc.transactions) {
 		dblrc.readIdx++
 		return dblrc.transactions[dblrc.readIdx-1], nil
@@ -66,14 +67,9 @@ func (dblrc *DBLedgerReader) Read() (LedgerTransaction, error) {
 	return LedgerTransaction{}, io.EOF
 }
 
-// ReadUpgradeChange returns the next upgrade change in the ledger, each time it
+// readUpgradeChange returns the next upgrade change in the ledger, each time it
 // is called. When there are no more upgrades to return, an EOF error is returned.
-func (dblrc *DBLedgerReader) ReadUpgradeChange() (Change, error) {
-	// Protect all accesses to dblrc.upgradeReadIdx
-	dblrc.readMutex.Lock()
-	defer dblrc.readMutex.Unlock()
-	dblrc.readUpgradeChangeCalled = true
-
+func (dblrc *DBLedgerReader) readUpgradeChange() (Change, error) {
 	if dblrc.upgradeReadIdx < len(dblrc.upgradeChanges) {
 		dblrc.upgradeReadIdx++
 		return dblrc.upgradeChanges[dblrc.upgradeReadIdx-1], nil
@@ -81,26 +77,9 @@ func (dblrc *DBLedgerReader) ReadUpgradeChange() (Change, error) {
 	return Change{}, io.EOF
 }
 
-// GetUpgradeChanges returns all ledger upgrade changes.
-func (dblrc *DBLedgerReader) GetUpgradeChanges() []Change {
-	return dblrc.upgradeChanges
-}
-
-func (dblrc *DBLedgerReader) IgnoreUpgradeChanges() {
-	dblrc.ignoreUpgradeChanges = true
-}
-
-// Close moves the read pointer so that subsequent calls to Read() will return EOF.
-func (dblrc *DBLedgerReader) Close() error {
-	dblrc.readMutex.Lock()
-	dblrc.readIdx = len(dblrc.transactions)
-	if !dblrc.ignoreUpgradeChanges &&
-		(!dblrc.readUpgradeChangeCalled || dblrc.upgradeReadIdx != len(dblrc.upgradeChanges)) {
-		return errors.New("Ledger upgrade changes not read! Use ReadUpgradeChange() method.")
-	}
-	dblrc.readMutex.Unlock()
-
-	return nil
+// Rewind resets the reader back to the first transaction in the ledger
+func (dblrc *DBLedgerReader) rewind() {
+	dblrc.readIdx = 0
 }
 
 // Init pulls data from the backend to set this object up for use.

--- a/exp/ingest/io/main.go
+++ b/exp/ingest/io/main.go
@@ -35,36 +35,6 @@ type StateWriter interface {
 	Close() error
 }
 
-// LedgerReader provides convenient, streaming access to the transactions within a ledger.
-type LedgerReader interface {
-	GetSequence() uint32
-	GetHeader() xdr.LedgerHeaderHistoryEntry
-	// Read should return the next transaction. If there are no more
-	// transactions it should return `io.EOF` error.
-	Read() (LedgerTransaction, error)
-	// Read should return the next ledger entry change from ledger upgrades. If
-	// there are no more changes it should return `io.EOF` error.
-	// Ledger upgrades MUST be processed AFTER all transactions and only ONCE.
-	// If app is tracking state in more than one store, all of them need to
-	// be updated with upgrade changes.
-	// Values returned by this method must not be modified.
-	ReadUpgradeChange() (Change, error)
-	// IgnoreLedgerEntryChanges will change `Close()`` behaviour to not error
-	// when changes returned by `ReadUpgradeChange` are not fully read.
-	IgnoreUpgradeChanges()
-	// Close should be called when reading is finished. This is especially
-	// helpful when there are still some transactions available so reader can stop
-	// streaming them.
-	// Close should return error if `ReadUpgradeChange` are not fully read or
-	// `ReadUpgradeChange` was not called even once. However, this behaviour can
-	// be disabled by calling `IgnoreUpgradeChanges()`.
-	Close() error
-}
-
-type UpgradeChangesContainer interface {
-	GetUpgradeChanges() []Change
-}
-
 // LedgerWriter provides convenient, streaming access to the transactions within a ledger.
 type LedgerWriter interface {
 	// Write is used to pass a transaction to the next processor. It can return

--- a/exp/ingest/main.go
+++ b/exp/ingest/main.go
@@ -1,7 +1,6 @@
 package ingest
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/stellar/go/clients/stellarcore"
@@ -209,10 +208,10 @@ func (r reporterLedgerReader) Read() (io.LedgerTransaction, error) {
 
 func (r reporterLedgerReader) GetUpgradeChanges() []io.Change {
 	// upgradeChangesContainer is implemented by *io.DBLedgerReader and readerWrapperLedger.
-	reader, ok := r.LedgerReader.(io.UpgradeChangesContainer)
-	if !ok {
-		panic(fmt.Sprintf("Cannot get upgrade changes from unknown reader type: %T", r.LedgerReader))
-	}
+	// reader, ok := r.LedgerReader.(io.UpgradeChangesContainer)
+	// if !ok {
+	// 	panic(fmt.Sprintf("Cannot get upgrade changes from unknown reader type: %T", r.LedgerReader))
+	// }
 
-	return reader.GetUpgradeChanges()
+	return nil
 }

--- a/exp/ingest/pipeline/ledger_pipeline_test.go
+++ b/exp/ingest/pipeline/ledger_pipeline_test.go
@@ -65,26 +65,9 @@ type testLedgerProcessor struct {
 }
 
 func (p *testLedgerProcessor) ProcessLedger(ctx context.Context, store *supportPipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
-	defer func() {
-		// io.LedgerReader.Close() returns error if upgrade changes have not
-		// been processed so it's worth checking the error.
-		closeErr := r.Close()
-		// Do not overwrite the previous error
-		if err == nil {
-			err = closeErr
-		}
-	}()
 	defer w.Close()
 
 	_, err = r.Read()
-	assert.Error(p.t, err)
-	assert.Equal(p.t, stdio.EOF, err)
-
-	change, err := r.ReadUpgradeChange()
-	assert.NoError(p.t, err)
-	assert.Equal(p.t, change.Type, xdr.LedgerEntryTypeAccount)
-
-	_, err = r.ReadUpgradeChange()
 	assert.Error(p.t, err)
 	assert.Equal(p.t, stdio.EOF, err)
 

--- a/exp/ingest/pipeline/wrappers.go
+++ b/exp/ingest/pipeline/wrappers.go
@@ -2,7 +2,6 @@ package pipeline
 
 import (
 	"context"
-	"fmt"
 	stdio "io"
 
 	"github.com/stellar/go/exp/ingest/io"
@@ -51,16 +50,20 @@ func (w *ledgerReaderWrapper) GetContext() context.Context {
 	ctx = context.WithValue(ctx, LedgerSequenceContextKey, w.LedgerReader.GetSequence())
 	ctx = context.WithValue(ctx, LedgerHeaderContextKey, w.LedgerReader.GetHeader())
 
-	// Save upgrade changes in context. UpgradeChangesContainer is implemented by
-	// *io.DBLedgerReader and readerWrapperLedger.
-	reader, ok := w.LedgerReader.(io.UpgradeChangesContainer)
-	if !ok {
-		panic(fmt.Sprintf("Cannot get upgrade changes from unknown reader type: %T", w.LedgerReader))
-	}
+	// // Save upgrade changes in context. UpgradeChangesContainer is implemented by
+	// // *io.DBLedgerReader and readerWrapperLedger.
+	// reader, ok := w.LedgerReader.(io.UpgradeChangesContainer)
+	// if !ok {
+	// 	panic(fmt.Sprintf("Cannot get upgrade changes from unknown reader type: %T", w.LedgerReader))
+	// }
 
-	ctx = context.WithValue(ctx, LedgerUpgradeChangesContextKey, reader.GetUpgradeChanges())
+	// ctx = context.WithValue(ctx, LedgerUpgradeChangesContextKey, reader.GetUpgradeChanges())
 
 	return ctx
+}
+
+func (w *ledgerReaderWrapper) Close() error {
+	return nil
 }
 
 func (w *ledgerReaderWrapper) Read() (interface{}, error) {
@@ -131,12 +134,12 @@ func (w *readerWrapperLedger) Close() error {
 		return errors.New("Ledger upgrade changes not read! Use ReadUpgradeChange() method.")
 	}
 
-	// Call IgnoreUpgradeChanges on a wrapped reader because `readerWrapperLedger`
-	// is responsible for streaming ledger upgrade changes now.
-	wrapper, ok := w.Reader.(*ledgerReaderWrapper)
-	if ok {
-		wrapper.LedgerReader.IgnoreUpgradeChanges()
-	}
+	// // Call IgnoreUpgradeChanges on a wrapped reader because `readerWrapperLedger`
+	// // is responsible for streaming ledger upgrade changes now.
+	// wrapper, ok := w.Reader.(*ledgerReaderWrapper)
+	// if ok {
+	// 	wrapper.LedgerReader.IgnoreUpgradeChanges()
+	// }
 
 	return w.Reader.Close()
 }

--- a/exp/ingest/processors.go
+++ b/exp/ingest/processors.go
@@ -1,0 +1,88 @@
+package ingest
+
+import (
+	"github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/xdr"
+)
+
+type ChangeProcessor interface {
+	Init(sequence uint32) error
+	ProcessChange(change io.Change) error
+	Commit() error
+}
+
+type LedgerTransactionProcessor interface {
+	Init(header xdr.LedgerHeader) error
+	ProcessTransaction(transaction io.LedgerTransaction) error
+	Commit() error
+}
+
+type cpGroup []ChangeProcessor
+
+func (g cpGroup) Init(sequence uint32) error {
+	for _, p := range g {
+		if err := p.Init(sequence); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g cpGroup) ProcessChange(change io.Change) error {
+	for _, p := range g {
+		if err := p.ProcessChange(change); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g cpGroup) Commit() error {
+	for _, p := range g {
+		if err := p.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func GroupChangeProcessors(
+	processors ...ChangeProcessor,
+) ChangeProcessor {
+	return cpGroup(processors)
+}
+
+type ltGroup []LedgerTransactionProcessor
+
+func (g ltGroup) Init(header xdr.LedgerHeader) error {
+	for _, p := range g {
+		if err := p.Init(header); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g ltGroup) ProcessTransaction(transaction io.LedgerTransaction) error {
+	for _, p := range g {
+		if err := p.ProcessTransaction(transaction); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g ltGroup) Commit() error {
+	for _, p := range g {
+		if err := p.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func GroupLedgerTransactionProcessors(
+	processors ...LedgerTransactionProcessor,
+) LedgerTransactionProcessor {
+	return ltGroup(processors)
+}

--- a/exp/ingest/processors/csv_printer.go
+++ b/exp/ingest/processors/csv_printer.go
@@ -173,17 +173,8 @@ func (p *CSVPrinter) ProcessState(ctx context.Context, store *pipeline.Store, r 
 }
 
 func (p *CSVPrinter) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
-	defer func() {
-		// io.LedgerReader.Close() returns error if upgrade changes have not
-		// been processed so it's worth checking the error.
-		closeErr := r.Close()
-		// Do not overwrite the previous error
-		if err == nil {
-			err = closeErr
-		}
-	}()
 	defer w.Close()
-	r.IgnoreUpgradeChanges()
+	// r.IgnoreUpgradeChanges()
 
 	f, err := p.fileHandle()
 	if err != nil {

--- a/exp/ingest/processors/root_processor.go
+++ b/exp/ingest/processors/root_processor.go
@@ -43,17 +43,7 @@ func (p *RootProcessor) ProcessState(ctx context.Context, store *pipeline.Store,
 }
 
 func (p *RootProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
-	defer func() {
-		// io.LedgerReader.Close() returns error if upgrade changes have not
-		// been processed so it's worth checking the error.
-		closeErr := r.Close()
-		// Do not overwrite the previous error
-		if err == nil {
-			err = closeErr
-		}
-	}()
 	defer w.Close()
-	r.IgnoreUpgradeChanges()
 
 	for {
 		transaction, err := r.Read()

--- a/exp/tools/horizon-demo/database_processor.go
+++ b/exp/tools/horizon-demo/database_processor.go
@@ -78,7 +78,6 @@ func (p *DatabaseProcessor) ProcessState(ctx context.Context, store *pipeline.St
 }
 
 func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) error {
-	defer r.Close()
 	defer w.Close()
 
 	for {

--- a/exp/tools/horizon-demo/orderbook_processor.go
+++ b/exp/tools/horizon-demo/orderbook_processor.go
@@ -48,7 +48,6 @@ func (p *OrderbookProcessor) ProcessState(ctx context.Context, store *pipeline.S
 }
 
 func (p *OrderbookProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) error {
-	defer r.Close()
 	defer w.Close()
 
 	for {

--- a/services/horizon/internal/expingest/processors/account_data_processor.go
+++ b/services/horizon/internal/expingest/processors/account_data_processor.go
@@ -15,7 +15,7 @@ type AccountDataProcessor struct {
 	batch history.AccountDataBatchInsertBuilder
 }
 
-func (p *AccountDataProcessor) Init(header xdr.LedgerHeader) error {
+func (p *AccountDataProcessor) Init(sequence uint32) error {
 	p.batch = p.DataQ.NewAccountDataBatchInsertBuilder(maxBatchSize)
 	p.cache = io.NewLedgerEntryChangeCache()
 	return nil

--- a/services/horizon/internal/expingest/processors/accounts_data_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_data_processor_test.go
@@ -34,10 +34,7 @@ func (s *AccountsDataProcessorTestSuiteState) SetupTest() {
 		DataQ: s.mockQ,
 	}
 
-	header := xdr.LedgerHeader{
-		LedgerSeq: xdr.Uint32(63),
-	}
-	err := s.processor.Init(header)
+	err := s.processor.Init(63)
 	s.Assert().NoError(err)
 }
 
@@ -93,10 +90,7 @@ func (s *AccountsDataProcessorTestSuiteLedger) SetupTest() {
 		DataQ: s.mockQ,
 	}
 
-	header := xdr.LedgerHeader{
-		LedgerSeq: xdr.Uint32(63),
-	}
-	err := s.processor.Init(header)
+	err := s.processor.Init(63)
 	s.Assert().NoError(err)
 }
 

--- a/services/horizon/internal/expingest/processors/accounts_data_processor_test.go
+++ b/services/horizon/internal/expingest/processors/accounts_data_processor_test.go
@@ -37,7 +37,7 @@ func (s *AccountsDataProcessorTestSuiteState) SetupTest() {
 	header := xdr.LedgerHeader{
 		LedgerSeq: xdr.Uint32(63),
 	}
-	err := s.processor.Init(header, InitChangesMode)
+	err := s.processor.Init(header)
 	s.Assert().NoError(err)
 }
 
@@ -96,7 +96,7 @@ func (s *AccountsDataProcessorTestSuiteLedger) SetupTest() {
 	header := xdr.LedgerHeader{
 		LedgerSeq: xdr.Uint32(63),
 	}
-	err := s.processor.Init(header, LedgerChangesMode)
+	err := s.processor.Init(header)
 	s.Assert().NoError(err)
 }
 

--- a/services/horizon/internal/expingest/processors/context_filter.go
+++ b/services/horizon/internal/expingest/processors/context_filter.go
@@ -50,7 +50,6 @@ func (p *ContextFilter) ProcessState(ctx context.Context, store *pipeline.Store,
 }
 
 func (p *ContextFilter) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) error {
-	defer r.Close()
 	defer w.Close()
 
 	// Exit early if Key not found in `ctx`

--- a/services/horizon/internal/expingest/processors/database_processor.go
+++ b/services/horizon/internal/expingest/processors/database_processor.go
@@ -180,22 +180,12 @@ func (p *DatabaseProcessor) ProcessState(ctx context.Context, store *pipeline.St
 }
 
 func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
-	defer func() {
-		// io.LedgerReader.Close() returns error if upgrade changes have not
-		// been processed so it's worth checking the error.
-		closeErr := r.Close()
-		// Do not overwrite the previous error
-		if err == nil {
-			err = closeErr
-		}
-	}()
 	defer w.Close()
 
 	// Exit early if not ingesting state (history catchup). The filtering in parent
 	// processor should do it, unfortunately it won't work in case of meta upgrades.
 	// Should be fixed after ingest refactoring.
 	if v := ctx.Value(IngestUpdateState); !(v != nil && v.(bool)) {
-		r.IgnoreUpgradeChanges()
 		return nil
 	}
 
@@ -293,7 +283,6 @@ func (p *DatabaseProcessor) ProcessLedger(ctx context.Context, store *pipeline.S
 	// Process upgrades meta
 	for {
 		var change io.Change
-		change, err = r.ReadUpgradeChange()
 		if err != nil {
 			if err == stdio.EOF {
 				break

--- a/services/horizon/internal/expingest/processors/effects_processor.go
+++ b/services/horizon/internal/expingest/processors/effects_processor.go
@@ -103,17 +103,7 @@ func (p *EffectProcessor) insertDBOperationsEffects(effects []effect, accountSet
 }
 
 func (p *EffectProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
-	defer func() {
-		// io.LedgerReader.Close() returns error if upgrade changes have not
-		// been processed so it's worth checking the error.
-		closeErr := r.Close()
-		// Do not overwrite the previous error
-		if err == nil {
-			err = closeErr
-		}
-	}()
 	defer w.Close()
-	r.IgnoreUpgradeChanges()
 
 	// Exit early if not ingesting into a DB
 	if v := ctx.Value(IngestUpdateDatabase); !(v != nil && v.(bool)) {

--- a/services/horizon/internal/expingest/processors/ledgers_processor.go
+++ b/services/horizon/internal/expingest/processors/ledgers_processor.go
@@ -17,17 +17,7 @@ type LedgersProcessor struct {
 }
 
 func (p *LedgersProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
-	defer func() {
-		// io.LedgerReader.Close() returns error if upgrade changes have not
-		// been processed so it's worth checking the error.
-		closeErr := r.Close()
-		// Do not overwrite the previous error
-		if err == nil {
-			err = closeErr
-		}
-	}()
 	defer w.Close()
-	r.IgnoreUpgradeChanges()
 
 	// Exit early if not ingesting into a DB
 	if v := ctx.Value(IngestUpdateDatabase); !(v != nil && v.(bool)) {

--- a/services/horizon/internal/expingest/processors/new_transactions_processor.go
+++ b/services/horizon/internal/expingest/processors/new_transactions_processor.go
@@ -13,7 +13,7 @@ type NewTransactionProcessor struct {
 	batch    history.TransactionBatchInsertBuilder
 }
 
-func (p *NewTransactionProcessor) Init(header xdr.LedgerHeader, mode ChangesMode) error {
+func (p *NewTransactionProcessor) Init(header xdr.LedgerHeader) error {
 	p.sequence = uint32(header.LedgerSeq)
 	p.batch = p.TransactionsQ.NewTransactionBatchInsertBuilder(maxBatchSize)
 	return nil

--- a/services/horizon/internal/expingest/processors/operations_processor.go
+++ b/services/horizon/internal/expingest/processors/operations_processor.go
@@ -24,17 +24,7 @@ type OperationProcessor struct {
 
 // ProcessLedger process the given ledger
 func (p *OperationProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
-	defer func() {
-		// io.LedgerReader.Close() returns error if upgrade changes have not
-		// been processed so it's worth checking the error.
-		closeErr := r.Close()
-		// Do not overwrite the previous error
-		if err == nil {
-			err = closeErr
-		}
-	}()
 	defer w.Close()
-	r.IgnoreUpgradeChanges()
 
 	// Exit early if not ingesting into a DB
 	if v := ctx.Value(IngestUpdateDatabase); !(v != nil && v.(bool)) {

--- a/services/horizon/internal/expingest/processors/participants_processor.go
+++ b/services/horizon/internal/expingest/processors/participants_processor.go
@@ -251,17 +251,7 @@ func (p *ParticipantsProcessor) insertDBOperationsParticipants(participantSet ma
 }
 
 func (p *ParticipantsProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
-	defer func() {
-		// io.LedgerReader.Close() returns error if upgrade changes have not
-		// been processed so it's worth checking the error.
-		closeErr := r.Close()
-		// Do not overwrite the previous error
-		if err == nil {
-			err = closeErr
-		}
-	}()
 	defer w.Close()
-	r.IgnoreUpgradeChanges()
 
 	// Exit early if not ingesting into a DB
 	if v := ctx.Value(IngestUpdateDatabase); !(v != nil && v.(bool)) {

--- a/services/horizon/internal/expingest/processors/trades_processor.go
+++ b/services/horizon/internal/expingest/processors/trades_processor.go
@@ -21,17 +21,7 @@ type TradeProcessor struct {
 
 // ProcessLedger process the given ledger
 func (p *TradeProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
-	defer func() {
-		// io.LedgerReader.Close() returns error if upgrade changes have not
-		// been processed so it's worth checking the error.
-		closeErr := r.Close()
-		// Do not overwrite the previous error
-		if err == nil {
-			err = closeErr
-		}
-	}()
 	defer w.Close()
-	r.IgnoreUpgradeChanges()
 
 	// Exit early if not ingesting into a DB
 	if v := ctx.Value(IngestUpdateDatabase); !(v != nil && v.(bool)) {

--- a/services/horizon/internal/expingest/processors/transactions_filter_processor.go
+++ b/services/horizon/internal/expingest/processors/transactions_filter_processor.go
@@ -15,17 +15,7 @@ type TransactionFilterProcessor struct {
 }
 
 func (p *TransactionFilterProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
-	defer func() {
-		// io.LedgerReader.Close() returns error if upgrade changes have not
-		// been processed so it's worth checking the error.
-		closeErr := r.Close()
-		// Do not overwrite the previous error
-		if err == nil {
-			err = closeErr
-		}
-	}()
 	defer w.Close()
-	r.IgnoreUpgradeChanges()
 
 	for {
 		var transaction io.LedgerTransaction

--- a/services/horizon/internal/expingest/processors/transactions_processor.go
+++ b/services/horizon/internal/expingest/processors/transactions_processor.go
@@ -16,17 +16,7 @@ type TransactionProcessor struct {
 }
 
 func (p *TransactionProcessor) ProcessLedger(ctx context.Context, store *pipeline.Store, r io.LedgerReader, w io.LedgerWriter) (err error) {
-	defer func() {
-		// io.LedgerReader.Close() returns error if upgrade changes have not
-		// been processed so it's worth checking the error.
-		closeErr := r.Close()
-		// Do not overwrite the previous error
-		if err == nil {
-			err = closeErr
-		}
-	}()
 	defer w.Close()
-	r.IgnoreUpgradeChanges()
 
 	// Exit early if not ingesting into a DB
 	if v := ctx.Value(IngestUpdateDatabase); !(v != nil && v.(bool)) {

--- a/services/horizon/internal/expingest/processors/transactions_processor_test.go
+++ b/services/horizon/internal/expingest/processors/transactions_processor_test.go
@@ -35,7 +35,7 @@ func (s *TransactionsProcessorTestSuiteLedger) SetupTest() {
 	header := xdr.LedgerHeader{
 		LedgerSeq: xdr.Uint32(20),
 	}
-	err := s.processor.Init(header, LedgerChangesMode)
+	err := s.processor.Init(header)
 	s.Assert().NoError(err)
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

You can ignore commits before https://github.com/stellar/go/commit/83feb925453c108cf0bf1502bc4807784340c8b2 because those are part of this PR https://github.com/stellar/go/pull/2164

* Reduce scope of `LedgerReader` interface so that it's only responsible for streaming `io.LedgerTransactions`
* Add `ChangeReader` which is implemented using a `DBLedgerReader` to stream `io.Changes` in the correct order

### Why

Fixes https://github.com/stellar/go/issues/2168

> Our experience building out the ingestion system has showed us that there are essentially two types of data we need to extract from Stellar Core when ingesting new ledgers:


> * `[]io.Change` - changes from operations, fee meta, upgrades, etc 
> * `[]io.LedgerTransaction` - for each transaction in the ledger

> Although obtaining a list of `io,LedgerTransaction`s is straight forward using a `DBLedgerReader`, getting a list of `io.Change`s and applying them to processors in the correct order is not easy. To address this use case we should create a new reader built on top of `DatabaseBackend`.

### Known limitations

* `DBLedgerReader` and `changeReader` are no longer thread-safe. We do not intend to share `LeddgerReaders` or `ChangeReaders` with multiple goroutines so I think it's ok to remove thread-safety.
* The PR lacks tests. If the design looks good, I will add tests in a subsequent commit.