### PR TITLE
services/horizon/internal/expingest: Close state reader in runHistoryArchiveIngestion()

### DIFF
--- a/services/horizon/internal/expingest/processors.go
+++ b/services/horizon/internal/expingest/processors.go
@@ -162,7 +162,7 @@ func (s *System) runHistoryArchiveIngestion(
 ) error {
 	changeProcessor := s.buildChangeProcessor(historyArchiveSource)
 
-	var stateReader io.ChangeReader
+	var stateReader io.StateReader
 	var err error
 
 	if checkpointLedger == 1 {
@@ -180,10 +180,11 @@ func (s *System) runHistoryArchiveIngestion(
 			checkpointLedger,
 			s.maxStreamRetries,
 		)
+		if err != nil {
+			return errors.Wrap(err, "Error creating HAS reader")
+		}
 	}
-	if err != nil {
-		return errors.Wrap(err, "Error creating HAS reader")
-	}
+	defer stateReader.Close()
 
 	err = io.StreamChanges(changeProcessor, stateReader)
 	if err != nil {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Close state reader in `runHistoryArchiveIngestion()`

### Why

The state reader needs to be closed to release the http connection to the history archives.

### Known limitations

[N/A]
