### PR TITLE
services/horizon/internal/expingest: Report number of processed entries in state ingestion.

### DIFF
--- a/exp/ingest/io/processors_test.go
+++ b/exp/ingest/io/processors_test.go
@@ -1,0 +1,42 @@
+package io
+
+import (
+	"testing"
+
+	"github.com/stellar/go/support/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStreamReaderError(t *testing.T) {
+	tt := assert.New(t)
+
+	mockChangeReader := &MockChangeReader{}
+	mockChangeReader.
+		On("Read").
+		Return(Change{}, errors.New("transient error")).Once()
+	mockChangeProcessor := &MockChangeProcessor{}
+
+	err := StreamChanges(mockChangeProcessor, mockChangeReader)
+	tt.EqualError(err, "could not read transaction: transient error")
+}
+
+func TestStreamChangeProcessorError(t *testing.T) {
+	tt := assert.New(t)
+
+	change := Change{}
+	mockChangeReader := &MockChangeReader{}
+	mockChangeReader.
+		On("Read").
+		Return(change, nil).Once()
+
+	mockChangeProcessor := &MockChangeProcessor{}
+	mockChangeProcessor.
+		On(
+			"ProcessChange",
+			change,
+		).
+		Return(errors.New("transient error")).Once()
+
+	err := StreamChanges(mockChangeProcessor, mockChangeReader)
+	tt.EqualError(err, "could not process change: transient error")
+}

--- a/services/horizon/internal/expingest/logger_state_reader.go
+++ b/services/horizon/internal/expingest/logger_state_reader.go
@@ -9,17 +9,17 @@ import (
 //
 type loggerStateReader struct {
 	io.StateReader
-	logger      *logpkg.Entry
-	readChanges int
+	logger     *logpkg.Entry
+	entryCount int
 	// how often should the logger report
-	every int
+	frequency int
 }
 
 func newLoggerStateReader(reader io.StateReader, logger *logpkg.Entry, every int) *loggerStateReader {
 	return &loggerStateReader{
 		StateReader: reader,
 		logger:      logger,
-		every:       every,
+		frequency:   every,
 	}
 }
 
@@ -31,10 +31,12 @@ func (lsr *loggerStateReader) Read() (io.Change, error) {
 	change, err := lsr.StateReader.Read()
 
 	if err == nil {
-		lsr.readChanges++
+		lsr.entryCount++
 
-		if lsr.readChanges%lsr.every == 0 {
-			lsr.logger.Infof("Entries processed from HAS: %d", lsr.readChanges)
+		if lsr.entryCount%lsr.frequency == 0 {
+			lsr.logger.WithField("ledger", lsr.GetSequence()).
+				WithField("numEntries", lsr.entryCount).
+				Info("Processing entries from History Archive Snapshot")
 		}
 	}
 

--- a/services/horizon/internal/expingest/logger_state_reader.go
+++ b/services/horizon/internal/expingest/logger_state_reader.go
@@ -5,22 +5,21 @@ import (
 	logpkg "github.com/stellar/go/support/log"
 )
 
-// loggerStateReader decorates a state reader, reporting the number of processed
-// entries from the history archive.
+// loggerStateReader extends io.StateReader with logging capabilities.
 //
 type loggerStateReader struct {
-	reader      io.ChangeReader
+	io.StateReader
 	logger      *logpkg.Entry
 	readChanges int
 	// how often should the logger report
 	every int
 }
 
-func newLoggerStateReader(reader io.ChangeReader, logger *logpkg.Entry, every int) *loggerStateReader {
+func newLoggerStateReader(reader io.StateReader, logger *logpkg.Entry, every int) *loggerStateReader {
 	return &loggerStateReader{
-		reader: reader,
-		logger: logger,
-		every:  every,
+		StateReader: reader,
+		logger:      logger,
+		every:       every,
 	}
 }
 
@@ -29,7 +28,7 @@ var _ io.ChangeReader = &loggerStateReader{}
 
 // Read returns a new ledger entry change on each call, returning io.EOF when the stream ends.
 func (lsr *loggerStateReader) Read() (io.Change, error) {
-	change, err := lsr.reader.Read()
+	change, err := lsr.StateReader.Read()
 
 	if err == nil {
 		lsr.readChanges++

--- a/services/horizon/internal/expingest/logger_state_reader.go
+++ b/services/horizon/internal/expingest/logger_state_reader.go
@@ -23,8 +23,8 @@ func newLoggerStateReader(reader io.StateReader, logger *logpkg.Entry, every int
 	}
 }
 
-// Ensure loggerStateReader implements ChangeReader
-var _ io.ChangeReader = &loggerStateReader{}
+// Ensure loggerStateReader implements StateReader
+var _ io.StateReader = &loggerStateReader{}
 
 // Read returns a new ledger entry change on each call, returning io.EOF when the stream ends.
 func (lsr *loggerStateReader) Read() (io.Change, error) {

--- a/services/horizon/internal/expingest/logger_state_reader.go
+++ b/services/horizon/internal/expingest/logger_state_reader.go
@@ -1,0 +1,43 @@
+package expingest
+
+import (
+	"github.com/stellar/go/exp/ingest/io"
+	logpkg "github.com/stellar/go/support/log"
+)
+
+// loggerStateReader decorates a state reader, reporting the number of processed
+// entries from the history archive.
+//
+type loggerStateReader struct {
+	reader      io.ChangeReader
+	logger      *logpkg.Entry
+	readChanges int
+	// how often should the logger report
+	every int
+}
+
+func newLoggerStateReader(reader io.ChangeReader, logger *logpkg.Entry, every int) *loggerStateReader {
+	return &loggerStateReader{
+		reader: reader,
+		logger: logger,
+		every:  every,
+	}
+}
+
+// Ensure loggerStateReader implements ChangeReader
+var _ io.ChangeReader = &loggerStateReader{}
+
+// Read returns a new ledger entry change on each call, returning io.EOF when the stream ends.
+func (lsr *loggerStateReader) Read() (io.Change, error) {
+	change, err := lsr.reader.Read()
+
+	if err == nil {
+		lsr.readChanges++
+
+		if lsr.readChanges%lsr.every == 0 {
+			lsr.logger.Infof("Entries processed from HAS: %d", lsr.readChanges)
+		}
+	}
+
+	return change, err
+}

--- a/services/horizon/internal/expingest/logger_state_reader_test.go
+++ b/services/horizon/internal/expingest/logger_state_reader_test.go
@@ -18,6 +18,9 @@ func TestLoggerStateReader(t *testing.T) {
 	mockStateReader.
 		On("Read").
 		Return(io.Change{}, stdio.EOF).Once()
+	mockStateReader.
+		On("GetSequence").
+		Return(uint32(23)).Twice()
 
 	var out bytes.Buffer
 	logger := logpkg.New()
@@ -40,8 +43,13 @@ func TestLoggerStateReader(t *testing.T) {
 	logged := done()
 
 	if assert.Len(t, logged, 2) {
-		assert.Equal(t, "Entries processed from HAS: 2", logged[0].Message)
-		assert.Equal(t, "Entries processed from HAS: 4", logged[1].Message)
+		assert.Equal(t, uint32(23), logged[0].Data["ledger"])
+		assert.Equal(t, 2, logged[0].Data["numEntries"])
+		assert.Equal(t, "Processing entries from History Archive Snapshot", logged[0].Message)
+
+		assert.Equal(t, uint32(23), logged[1].Data["ledger"])
+		assert.Equal(t, 4, logged[1].Data["numEntries"])
+		assert.Equal(t, "Processing entries from History Archive Snapshot", logged[1].Message)
 	}
 
 	mockStateReader.AssertExpectations(t)

--- a/services/horizon/internal/expingest/logger_state_reader_test.go
+++ b/services/horizon/internal/expingest/logger_state_reader_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 func TestLoggerStateReader(t *testing.T) {
-	mockChangeReader := &io.MockChangeReader{}
-	mockChangeReader.
+	mockStateReader := &io.MockStateReader{}
+	mockStateReader.
 		On("Read").
 		Return(io.Change{}, nil).Times(5)
-	mockChangeReader.
+	mockStateReader.
 		On("Read").
 		Return(io.Change{}, stdio.EOF).Once()
 
@@ -25,7 +25,7 @@ func TestLoggerStateReader(t *testing.T) {
 	done := logger.StartTest(logpkg.InfoLevel)
 
 	loggerStateReader := newLoggerStateReader(
-		mockChangeReader,
+		mockStateReader,
 		logger,
 		2,
 	)
@@ -44,5 +44,5 @@ func TestLoggerStateReader(t *testing.T) {
 		assert.Equal(t, "Entries processed from HAS: 4", logged[1].Message)
 	}
 
-	mockChangeReader.AssertExpectations(t)
+	mockStateReader.AssertExpectations(t)
 }

--- a/services/horizon/internal/expingest/logger_state_reader_test.go
+++ b/services/horizon/internal/expingest/logger_state_reader_test.go
@@ -1,0 +1,48 @@
+package expingest
+
+import (
+	"bytes"
+	stdio "io"
+	"testing"
+
+	"github.com/stellar/go/exp/ingest/io"
+	logpkg "github.com/stellar/go/support/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoggerStateReader(t *testing.T) {
+	mockChangeReader := &io.MockChangeReader{}
+	mockChangeReader.
+		On("Read").
+		Return(io.Change{}, nil).Times(5)
+	mockChangeReader.
+		On("Read").
+		Return(io.Change{}, stdio.EOF).Once()
+
+	var out bytes.Buffer
+	logger := logpkg.New()
+	logger.Logger.Out = &out
+	done := logger.StartTest(logpkg.InfoLevel)
+
+	loggerStateReader := newLoggerStateReader(
+		mockChangeReader,
+		logger,
+		2,
+	)
+
+	for {
+		_, err := loggerStateReader.Read()
+		if err == stdio.EOF {
+			break
+		}
+	}
+
+	logged := done()
+
+	if assert.Len(t, logged, 2) {
+		assert.Equal(t, "Entries processed from HAS: 2", logged[0].Message)
+		assert.Equal(t, "Entries processed from HAS: 4", logged[1].Message)
+	}
+
+	mockChangeReader.AssertExpectations(t)
+}

--- a/services/horizon/internal/expingest/processors.go
+++ b/services/horizon/internal/expingest/processors.go
@@ -186,7 +186,15 @@ func (s *System) runHistoryArchiveIngestion(
 	}
 	defer stateReader.Close()
 
+	log.Info("Ingesting entries from HAS")
+	stateReader = newLoggerStateReader(
+		stateReader,
+		log,
+		100000,
+	)
+
 	err = io.StreamChanges(changeProcessor, stateReader)
+
 	if err != nil {
 		return errors.Wrap(err, "Error streaming changes from HAS")
 	}
@@ -206,6 +214,8 @@ func (s *System) runChangeProcessorOnLedger(
 	if err != nil {
 		return errors.Wrap(err, "Error creating ledger change reader")
 	}
+
+	log.Info("Ingesting entries from HAS")
 	if err = io.StreamChanges(changeProcessor, changeReader); err != nil {
 		return errors.Wrap(err, "Error streaming changes from ledger")
 	}

--- a/services/horizon/internal/expingest/processors.go
+++ b/services/horizon/internal/expingest/processors.go
@@ -186,7 +186,9 @@ func (s *System) runHistoryArchiveIngestion(
 	}
 	defer stateReader.Close()
 
-	log.Info("Ingesting entries from HAS")
+	log.WithField("ledger", checkpointLedger).
+		Info("Processing entries from History Archive Snapshot")
+
 	stateReader = newLoggerStateReader(
 		stateReader,
 		log,
@@ -215,7 +217,6 @@ func (s *System) runChangeProcessorOnLedger(
 		return errors.Wrap(err, "Error creating ledger change reader")
 	}
 
-	log.Info("Ingesting entries from HAS")
 	if err = io.StreamChanges(changeProcessor, changeReader); err != nil {
 		return errors.Wrap(err, "Error streaming changes from ledger")
 	}

--- a/services/horizon/internal/expingest/processors.go
+++ b/services/horizon/internal/expingest/processors.go
@@ -196,7 +196,6 @@ func (s *System) runHistoryArchiveIngestion(
 	)
 
 	err = io.StreamChanges(changeProcessor, stateReader)
-
 	if err != nil {
 		return errors.Wrap(err, "Error streaming changes from HAS")
 	}
@@ -216,7 +215,6 @@ func (s *System) runChangeProcessorOnLedger(
 	if err != nil {
 		return errors.Wrap(err, "Error creating ledger change reader")
 	}
-
 	if err = io.StreamChanges(changeProcessor, changeReader); err != nil {
 		return errors.Wrap(err, "Error streaming changes from ledger")
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Report number of processed entries in state processing every 100k entries. Fix #2182

### Why

Ingesting from the history archives can take 15-20 minutes. We need a mechanism for logging the current progress of reading through the history archives.

### Known limitations


