### PR TITLE
clients/horizonclient: add IsNotFoundError

### DIFF
--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+- Add `IsNotFoundError`
+
 ## [v2.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v2.0.0) - 2020-01-13
 
 - Add custom `UnmarshalJSON()` implementations to Horizon protocol structs so `int64` fields can be parsed as JSON numbers or JSON strings

--- a/clients/horizonclient/error_helpers.go
+++ b/clients/horizonclient/error_helpers.go
@@ -1,0 +1,21 @@
+package horizonclient
+
+// IsNotFoundError returns true if the error is a horizonclient.Error with
+// a not_found problem indicating that the resource is not found on
+// Horizon.
+func IsNotFoundError(err error) bool {
+	var hErr *Error
+
+	switch err := err.(type) {
+	case *Error:
+		hErr = err
+	case Error:
+		hErr = &err
+	}
+
+	if hErr == nil {
+		return false
+	}
+
+	return hErr.Problem.Type == "https://stellar.org/horizon-errors/not_found"
+}

--- a/clients/horizonclient/error_helpers_test.go
+++ b/clients/horizonclient/error_helpers_test.go
@@ -1,0 +1,84 @@
+package horizonclient
+
+import (
+	"testing"
+
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/render/problem"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsNotFoundError(t *testing.T) {
+	testCases := []struct {
+		desc string
+		err  error
+		is   bool
+	}{
+		{
+			desc: "nil error",
+			err:  nil,
+			is:   false,
+		},
+		{
+			desc: "another Go type of error",
+			err:  errors.New("error"),
+			is:   false,
+		},
+		{
+			desc: "not found problem (pointer)",
+			err: &Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/not_found",
+					Title:  "Resource Missing",
+					Status: 404,
+				},
+			},
+			is: true,
+		},
+		{
+			desc: "not found problem (not a pointer)",
+			err: Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/not_found",
+					Title:  "Resource Missing",
+					Status: 404,
+				},
+			},
+			is: true,
+		},
+		{
+			desc: "some other problem (pointer)",
+			err: &Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/server_error",
+					Title:  "Server Error",
+					Status: 500,
+				},
+			},
+			is: false,
+		},
+		{
+			desc: "some other problem (not a pointer)",
+			err: Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/server_error",
+					Title:  "Server Error",
+					Status: 500,
+				},
+			},
+			is: false,
+		},
+		{
+			desc: "a nil *horizonclient.Error",
+			err:  (*Error)(nil),
+			is:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			is := IsNotFoundError(tc.err)
+			assert.Equal(t, tc.is, is)
+		})
+	}
+}

--- a/txnbuild/transaction_challenge_example_test.go
+++ b/txnbuild/transaction_challenge_example_test.go
@@ -80,15 +80,14 @@ func ExampleVerifyChallengeTxThreshold() {
 		// Server gets account
 		clientAccountExists := false
 		horizonClientAccount, err := horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: txClientAccountID})
-		if err == nil {
+		if horizonclient.IsNotFoundError(err) {
+			clientAccountExists = false
+			fmt.Println("Account does not exist, use master key to verify")
+		} else if err == nil {
 			clientAccountExists = true
 		} else {
-			if hErr, ok := err.(*horizonclient.Error); ok && hErr.Problem.Type == "https://stellar.org/horizon-errors/not_found" {
-				fmt.Println("Account does not exist, use master key to verify")
-			} else {
-				fmt.Println("Error:", err)
-				return
-			}
+			fmt.Println("Error:", err)
+			return
 		}
 
 		if clientAccountExists {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add `horizonclient.IsNotFoundError` that returns true if an `error` is a Horizon `not_found` problem error.

### Why

It is remarkably verbose and difficult to detect if an account exists in Horizon. The code to do so must unwrap the horizonclient.Error, know to do so as a pointer and not as the pointer-less type, and then check that the problem's type is a long URI. In application code this is very verbose and easy to get wrong.

I'm writing code that tests if an account is present in the `exp/services/webauth` service and attempting to simplifying it.

Closes #2194 

### Known limitations

N/A
