### PR TITLE
exp/services/webauth: add support for verifying accounts that do not exist

### DIFF
--- a/exp/services/webauth/README.md
+++ b/exp/services/webauth/README.md
@@ -42,13 +42,14 @@ Usage:
   webauth serve [flags]
 
 Flags:
-      --challenge-expires-in int    The time period in seconds after which the challenge transaction expires (CHALLENGE_EXPIRES_IN) (default 300)
-      --horizon-url string          Horizon URL used for looking up account details (HORIZON_URL) (default "https://horizon-testnet.stellar.org/")
-      --jwt-expires-in int          The time period in seconds after which the JWT expires (JWT_EXPIRES_IN) (default 300)
-      --jwt-key string              Base64 encoded ECDSA private key used for signing JWTs (JWT_KEY)
-      --network-passphrase string   Network passphrase of the Stellar network transactions should be signed for (NETWORK_PASSPHRASE) (default "Test SDF Network ; September 2015")
-      --port int                    Port to listen and serve on (PORT) (default 8000)
-      --signing-key string          Stellar signing key used for signing transactions (SIGNING_KEY)
+      --allow-accounts-that-do-not-exist   Allow accounts that do not exist (ALLOW_ACCOUNTS_THAT_DO_NOT_EXIST)
+      --challenge-expires-in int           The time period in seconds after which the challenge transaction expires (CHALLENGE_EXPIRES_IN) (default 300)
+      --horizon-url string                 Horizon URL used for looking up account details (HORIZON_URL) (default "https://horizon-testnet.stellar.org/")
+      --jwt-expires-in int                 The time period in seconds after which the JWT expires (JWT_EXPIRES_IN) (default 300)
+      --jwt-key string                     Base64 encoded ECDSA private key used for signing JWTs (JWT_KEY)
+      --network-passphrase string          Network passphrase of the Stellar network transactions should be signed for (NETWORK_PASSPHRASE) (default "Test SDF Network ; September 2015")
+      --port int                           Port to listen and serve on (PORT) (default 8000)
+      --signing-key string                 Stellar signing key used for signing transactions (SIGNING_KEY)
 ```
 
 [SEP-10]: https://github.com/stellar/stellar-protocol/blob/2be91ce8d8032ca9b2f368800d06b9fba346a147/ecosystem/sep-0010.md

--- a/exp/services/webauth/internal/commands/serve.go
+++ b/exp/services/webauth/internal/commands/serve.go
@@ -76,6 +76,13 @@ func (c *ServeCommand) Command() *cobra.Command {
 			FlagDefault:    300,
 			Required:       true,
 		},
+		{
+			Name:        "allow-accounts-that-do-not-exist",
+			Usage:       "Allow accounts that do not exist",
+			OptType:     types.Bool,
+			ConfigKey:   &opts.AllowAccountsThatDoNotExist,
+			FlagDefault: false,
+		},
 	}
 	cmd := &cobra.Command{
 		Use:   "serve",

--- a/exp/services/webauth/internal/serve/serve.go
+++ b/exp/services/webauth/internal/serve/serve.go
@@ -15,14 +15,15 @@ import (
 )
 
 type Options struct {
-	Logger             *supportlog.Entry
-	HorizonURL         string
-	Port               int
-	NetworkPassphrase  string
-	SigningKey         string
-	ChallengeExpiresIn time.Duration
-	JWTPrivateKey      string
-	JWTExpiresIn       time.Duration
+	Logger                      *supportlog.Entry
+	HorizonURL                  string
+	Port                        int
+	NetworkPassphrase           string
+	SigningKey                  string
+	ChallengeExpiresIn          time.Duration
+	JWTPrivateKey               string
+	JWTExpiresIn                time.Duration
+	AllowAccountsThatDoNotExist bool
 }
 
 func Serve(opts Options) {
@@ -77,12 +78,13 @@ func handler(opts Options) (http.Handler, error) {
 		ChallengeExpiresIn: opts.ChallengeExpiresIn,
 	}.ServeHTTP)
 	mux.Post("/", tokenHandler{
-		Logger:            opts.Logger,
-		HorizonClient:     horizonClient,
-		NetworkPassphrase: opts.NetworkPassphrase,
-		SigningAddress:    signingKey.FromAddress(),
-		JWTPrivateKey:     jwtPrivateKey,
-		JWTExpiresIn:      opts.JWTExpiresIn,
+		Logger:                      opts.Logger,
+		HorizonClient:               horizonClient,
+		NetworkPassphrase:           opts.NetworkPassphrase,
+		SigningAddress:              signingKey.FromAddress(),
+		JWTPrivateKey:               jwtPrivateKey,
+		JWTExpiresIn:                opts.JWTExpiresIn,
+		AllowAccountsThatDoNotExist: opts.AllowAccountsThatDoNotExist,
 	}.ServeHTTP)
 
 	return mux, nil

--- a/exp/services/webauth/internal/serve/token_test.go
+++ b/exp/services/webauth/internal/serve/token_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
 	supportlog "github.com/stellar/go/support/log"
+	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
@@ -485,6 +486,265 @@ func TestToken_jsonInputUnrecognizedSigner(t *testing.T) {
 		SigningAddress:    serverKey.FromAddress(),
 		JWTPrivateKey:     jwtPrivateKey,
 		JWTExpiresIn:      time.Minute,
+	}
+
+	body := struct {
+		Transaction string `json:"transaction"`
+	}{
+		Transaction: txSigned,
+	}
+	bodyBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+	r := httptest.NewRequest("POST", "/", bytes.NewReader(bodyBytes))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, 401, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	respBodyBytes, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"error":"The request could not be authenticated."}`, string(respBodyBytes))
+}
+
+func TestToken_jsonInputAccountNotExistSuccess(t *testing.T) {
+	serverKey := keypair.MustRandom()
+	t.Logf("Server signing key: %s", serverKey.Address())
+
+	jwtPrivateKey, err := jwtkey.GenerateKey()
+	require.NoError(t, err)
+
+	account := keypair.MustRandom()
+	t.Logf("Client account: %s", account.Address())
+
+	chTx, err := txnbuild.BuildChallengeTx(
+		serverKey.Seed(),
+		account.Address(),
+		"testserver",
+		network.TestNetworkPassphrase,
+		time.Minute,
+	)
+	require.NoError(t, err)
+	t.Logf("Tx: %s", chTx)
+
+	var tx xdr.TransactionEnvelope
+	err = xdr.SafeUnmarshalBase64(chTx, &tx)
+	require.NoError(t, err)
+	hash, err := network.HashTransaction(&tx.Tx, network.TestNetworkPassphrase)
+	require.NoError(t, err)
+	sigDec, err := account.SignDecorated(hash[:])
+	require.NoError(t, err)
+	tx.Signatures = append(tx.Signatures, sigDec)
+	txSigned, err := xdr.MarshalBase64(tx)
+	require.NoError(t, err)
+	t.Logf("Signed: %s", txSigned)
+
+	horizonClient := &horizonclient.MockClient{}
+	horizonClient.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: account.Address()}).
+		Return(
+			horizon.Account{},
+			&horizonclient.Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/not_found",
+					Title:  "Resource Missing",
+					Status: 404,
+				},
+			},
+		)
+
+	h := tokenHandler{
+		Logger:                      supportlog.DefaultLogger,
+		HorizonClient:               horizonClient,
+		NetworkPassphrase:           network.TestNetworkPassphrase,
+		SigningAddress:              serverKey.FromAddress(),
+		JWTPrivateKey:               jwtPrivateKey,
+		JWTExpiresIn:                time.Minute,
+		AllowAccountsThatDoNotExist: true,
+	}
+
+	body := struct {
+		Transaction string `json:"transaction"`
+	}{
+		Transaction: txSigned,
+	}
+	bodyBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+	r := httptest.NewRequest("POST", "/", bytes.NewReader(bodyBytes))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	res := struct {
+		Token string `json:"token"`
+	}{}
+	err = json.NewDecoder(resp.Body).Decode(&res)
+	require.NoError(t, err)
+
+	t.Logf("JWT: %s", res.Token)
+
+	token, err := jwt.Parse(res.Token, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodECDSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return &jwtPrivateKey.PublicKey, nil
+	})
+	require.NoError(t, err)
+
+	claims := token.Claims.(jwt.MapClaims)
+	assert.Equal(t, serverKey.Address(), claims["iss"])
+	assert.Equal(t, account.Address(), claims["sub"])
+	assert.Equal(t, account.Address(), claims["sub"])
+	iat := time.Unix(int64(claims["iat"].(float64)), 0)
+	exp := time.Unix(int64(claims["exp"].(float64)), 0)
+	assert.True(t, iat.Before(time.Now()))
+	assert.True(t, exp.After(time.Now()))
+	assert.True(t, time.Now().Add(time.Minute).After(exp))
+	assert.Equal(t, exp.Sub(iat), time.Minute)
+}
+
+func TestToken_jsonInputAccountNotExistFail(t *testing.T) {
+	serverKey := keypair.MustRandom()
+	t.Logf("Server signing key: %s", serverKey.Address())
+
+	jwtPrivateKey, err := jwtkey.GenerateKey()
+	require.NoError(t, err)
+
+	account := keypair.MustRandom()
+	t.Logf("Client account: %s", account.Address())
+
+	otherSigner := keypair.MustRandom()
+	t.Logf("Other signer: %s", otherSigner.Address())
+
+	chTx, err := txnbuild.BuildChallengeTx(
+		serverKey.Seed(),
+		account.Address(),
+		"testserver",
+		network.TestNetworkPassphrase,
+		time.Minute,
+	)
+	require.NoError(t, err)
+	t.Logf("Tx: %s", chTx)
+
+	var tx xdr.TransactionEnvelope
+	err = xdr.SafeUnmarshalBase64(chTx, &tx)
+	require.NoError(t, err)
+	hash, err := network.HashTransaction(&tx.Tx, network.TestNetworkPassphrase)
+	require.NoError(t, err)
+	sigDec, err := otherSigner.SignDecorated(hash[:])
+	require.NoError(t, err)
+	tx.Signatures = append(tx.Signatures, sigDec)
+	txSigned, err := xdr.MarshalBase64(tx)
+	require.NoError(t, err)
+	t.Logf("Signed: %s", txSigned)
+
+	horizonClient := &horizonclient.MockClient{}
+	horizonClient.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: account.Address()}).
+		Return(
+			horizon.Account{},
+			&horizonclient.Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/not_found",
+					Title:  "Resource Missing",
+					Status: 404,
+				},
+			},
+		)
+
+	h := tokenHandler{
+		Logger:                      supportlog.DefaultLogger,
+		HorizonClient:               horizonClient,
+		NetworkPassphrase:           network.TestNetworkPassphrase,
+		SigningAddress:              serverKey.FromAddress(),
+		JWTPrivateKey:               jwtPrivateKey,
+		JWTExpiresIn:                time.Minute,
+		AllowAccountsThatDoNotExist: true,
+	}
+
+	body := struct {
+		Transaction string `json:"transaction"`
+	}{
+		Transaction: txSigned,
+	}
+	bodyBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+	r := httptest.NewRequest("POST", "/", bytes.NewReader(bodyBytes))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, 401, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	respBodyBytes, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"error":"The request could not be authenticated."}`, string(respBodyBytes))
+}
+
+func TestToken_jsonInputAccountNotExistNotAllowed(t *testing.T) {
+	serverKey := keypair.MustRandom()
+	t.Logf("Server signing key: %s", serverKey.Address())
+
+	jwtPrivateKey, err := jwtkey.GenerateKey()
+	require.NoError(t, err)
+
+	account := keypair.MustRandom()
+	t.Logf("Client account: %s", account.Address())
+
+	chTx, err := txnbuild.BuildChallengeTx(
+		serverKey.Seed(),
+		account.Address(),
+		"testserver",
+		network.TestNetworkPassphrase,
+		time.Minute,
+	)
+	require.NoError(t, err)
+	t.Logf("Tx: %s", chTx)
+
+	var tx xdr.TransactionEnvelope
+	err = xdr.SafeUnmarshalBase64(chTx, &tx)
+	require.NoError(t, err)
+	hash, err := network.HashTransaction(&tx.Tx, network.TestNetworkPassphrase)
+	require.NoError(t, err)
+	sigDec, err := account.SignDecorated(hash[:])
+	require.NoError(t, err)
+	tx.Signatures = append(tx.Signatures, sigDec)
+	txSigned, err := xdr.MarshalBase64(tx)
+	require.NoError(t, err)
+	t.Logf("Signed: %s", txSigned)
+
+	horizonClient := &horizonclient.MockClient{}
+	horizonClient.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: account.Address()}).
+		Return(
+			horizon.Account{},
+			&horizonclient.Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/not_found",
+					Title:  "Resource Missing",
+					Status: 404,
+				},
+			},
+		)
+
+	h := tokenHandler{
+		Logger:                      supportlog.DefaultLogger,
+		HorizonClient:               horizonClient,
+		NetworkPassphrase:           network.TestNetworkPassphrase,
+		SigningAddress:              serverKey.FromAddress(),
+		JWTPrivateKey:               jwtPrivateKey,
+		JWTExpiresIn:                time.Minute,
+		AllowAccountsThatDoNotExist: false,
 	}
 
 	body := struct {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add support for verifying accounts that do not exist behind an application option. When enabled the webauth application will allow a client to authenticate with an account that has not been created using the accounts master key.

### Why

[SEP-10 v1.3.0] describes how to optionally authenticate an account that has not yet been created on the Stellar network using the master key. It'd be good if our reference implementation of SEP-10 captured this so that implementers have a reference of how to implement this. Anchors implementing SEP-10 need to support authentication of accounts that are not yet created.

### Known limitations

N/A
