### PR TITLE
services/horizon/expingest: Revert buildState removal, add tests

### DIFF
--- a/services/horizon/internal/db2/history/effect.go
+++ b/services/horizon/internal/db2/history/effect.go
@@ -218,8 +218,8 @@ func (q *EffectsQ) orderBookFilter(a xdr.Asset, prefix string) {
 
 // QEffects defines history_effects related queries.
 type QEffects interface {
+	QCreateAccountsHistory
 	NewEffectBatchInsertBuilder(maxBatchSize int) EffectBatchInsertBuilder
-	CreateAccounts(addresses []string) (map[string]int64, error)
 }
 
 var selectEffect = sq.Select("heff.*, hacc.address").

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -253,6 +253,10 @@ type QAssetStats interface {
 	CountTrustLines() (int, error)
 }
 
+type QCreateAccountsHistory interface {
+	CreateAccounts(addresses []string) (map[string]int64, error)
+}
+
 // Effect is a row of data from the `history_effects` table
 type Effect struct {
 	HistoryAccountID   int64       `db:"history_account_id"`

--- a/services/horizon/internal/db2/history/participants.go
+++ b/services/horizon/internal/db2/history/participants.go
@@ -6,7 +6,7 @@ import (
 
 // QParticipants defines ingestion participant related queries.
 type QParticipants interface {
-	CreateAccounts(addresses []string) (map[string]int64, error)
+	QCreateAccountsHistory
 	NewTransactionParticipantsBatchInsertBuilder(maxBatchSize int) TransactionParticipantsBatchInsertBuilder
 	NewOperationParticipantBatchInsertBuilder(maxBatchSize int) OperationParticipantBatchInsertBuilder
 }

--- a/services/horizon/internal/db2/history/trade.go
+++ b/services/horizon/internal/db2/history/trade.go
@@ -334,7 +334,7 @@ func getCanonicalAssetOrder(assetId1 int64, assetId2 int64) (orderPreserved bool
 }
 
 type QTrades interface {
-	CreateAccounts(addresses []string) (map[string]int64, error)
+	QCreateAccountsHistory
 	NewTradeBatchInsertBuilder(maxBatchSize int) TradeBatchInsertBuilder
 	CreateAssets(assets []xdr.Asset) (map[string]Asset, error)
 }

--- a/services/horizon/internal/expingest/init_state_test.go
+++ b/services/horizon/internal/expingest/init_state_test.go
@@ -1,0 +1,240 @@
+package expingest
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stellar/go/exp/ingest/adapters"
+	"github.com/stellar/go/exp/orderbook"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestInitStateTestSuite(t *testing.T) {
+	suite.Run(t, new(InitStateTestSuite))
+}
+
+type InitStateTestSuite struct {
+	suite.Suite
+	graph          *orderbook.OrderBookGraph
+	historyQ       *mockDBQ
+	historyAdapter *adapters.MockHistoryArchiveAdapter
+	system         *System
+}
+
+func (s *InitStateTestSuite) SetupTest() {
+	s.graph = orderbook.NewOrderBookGraph()
+	s.historyQ = &mockDBQ{}
+	s.historyAdapter = &adapters.MockHistoryArchiveAdapter{}
+	s.system = &System{
+		state:          state{systemState: initState},
+		historyQ:       s.historyQ,
+		historyAdapter: s.historyAdapter,
+		graph:          s.graph,
+	}
+
+	s.Assert().Equal(initState, s.system.state.systemState)
+	// Checking if in tx in runCurrentState()
+	s.historyQ.On("GetTx").Return(nil).Once()
+	s.historyQ.On("Rollback").Return(nil).Once()
+}
+
+func (s *InitStateTestSuite) TearDownTest() {
+	t := s.T()
+	s.historyQ.AssertExpectations(t)
+}
+
+func (s *InitStateTestSuite) TestBeginReturnsError() {
+	// Recreate mock in this single test to remove Rollback assertion.
+	*s.historyQ = mockDBQ{}
+	s.historyQ.On("GetTx").Return(nil).Once()
+	s.historyQ.On("Begin").Return(errors.New("my error")).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Error starting a transaction: my error")
+	s.Assert().Equal(initState, nextState.systemState)
+}
+
+func (s *InitStateTestSuite) TestGetLastLedgerExpIngestReturnsError() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), errors.New("my error")).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Error getting last ingested ledger: my error")
+	s.Assert().Equal(initState, nextState.systemState)
+}
+
+func (s *InitStateTestSuite) TestGetExpIngestVersionReturnsError() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(0, errors.New("my error")).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Error getting exp ingest version: my error")
+	s.Assert().Equal(initState, nextState.systemState)
+}
+
+func (s *InitStateTestSuite) TestGetLatestLedgerReturnsError() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(0, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(0), errors.New("my error")).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Error getting last history ledger sequence: my error")
+	s.Assert().Equal(initState, nextState.systemState)
+}
+
+func (s *InitStateTestSuite) TestBuildStateEmptyDatabase() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(0, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil).Once()
+
+	s.historyAdapter.On("GetLatestLedgerSequence").Return(uint32(63), nil).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().NoError(err)
+	s.Assert().Equal(buildStateState, nextState.systemState)
+	s.Assert().Equal(uint32(63), nextState.checkpointLedger)
+}
+
+// TestBuildStateWait is testing the case when:
+// * the ingest system version has been incremented or no expingest ledger,
+// * the old system is in front of the latest checkpoint.
+func (s *InitStateTestSuite) TestBuildStateWait() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(0, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(100), nil).Once()
+
+	s.historyAdapter.On("GetLatestLedgerSequence").Return(uint32(63), nil).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().NoError(err)
+	s.Assert().Equal(waitForCheckpointState, nextState.systemState)
+}
+
+// TestBuildStateCatchup is testing the case when:
+// * the ingest system version has been incremented or no expingest ledger,
+// * the old system is behind the latest checkpoint.
+func (s *InitStateTestSuite) TestBuildStateCatchup() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(0, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(100), nil).Once()
+
+	s.historyAdapter.On("GetLatestLedgerSequence").Return(uint32(127), nil).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().NoError(err)
+	s.Assert().Equal(ingestHistoryRangeState, nextState.systemState)
+	s.Assert().Equal(uint32(101), nextState.rangeFromLedger)
+	s.Assert().Equal(uint32(127), nextState.rangeToLedger)
+}
+
+// TestBuildStateOldHistory is testing the case when:
+// * the ingest system version has been incremented or no expingest ledger,
+// * the old system latest ledger is equal to the latest checkpoint.
+func (s *InitStateTestSuite) TestBuildStateOldHistory() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(127), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(0, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(127), nil).Once()
+
+	s.historyAdapter.On("GetLatestLedgerSequence").Return(uint32(127), nil).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().NoError(err)
+	s.Assert().Equal(buildStateState, nextState.systemState)
+	s.Assert().Equal(uint32(127), nextState.checkpointLedger)
+}
+
+// TestResumeStateBehind is testing the case when:
+// * state doesn't need to be rebuilt,
+// * history is in front of expingest.
+func (s *InitStateTestSuite) TestResumeStateInFront() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(130), nil).Once()
+
+	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(0)).Return(nil).Once()
+	s.historyQ.On("Commit").Return(nil).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().NoError(err)
+	s.Assert().Equal(initState, nextState.systemState)
+}
+
+// TestResumeStateBehind is testing the case when:
+// * state doesn't need to be rebuilt,
+// * history is behind of expingest.
+func (s *InitStateTestSuite) TestResumeStateBehind() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(130), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(100), nil).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().NoError(err)
+	s.Assert().Equal(ingestHistoryRangeState, nextState.systemState)
+	s.Assert().Equal(uint32(101), nextState.rangeFromLedger)
+	s.Assert().Equal(uint32(130), nextState.rangeToLedger)
+}
+
+// TestResumeStateBehind is testing the case when:
+// * state doesn't need to be rebuilt,
+// * history is in sync with expingest.
+func (s *InitStateTestSuite) TestResumeStateSync() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(130), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(130), nil).Once()
+
+	s.historyQ.On("GetAllOffers").Return(
+		[]history.Offer{
+			history.Offer{
+				OfferID:      eurOffer.OfferId,
+				SellerID:     eurOffer.SellerId.Address(),
+				SellingAsset: eurOffer.Selling,
+				BuyingAsset:  eurOffer.Buying,
+				Amount:       eurOffer.Amount,
+				Pricen:       int32(eurOffer.Price.N),
+				Priced:       int32(eurOffer.Price.D),
+				Price:        float64(eurOffer.Price.N) / float64(eurOffer.Price.D),
+				Flags:        uint32(eurOffer.Flags),
+			},
+			history.Offer{
+				OfferID:      twoEurOffer.OfferId,
+				SellerID:     twoEurOffer.SellerId.Address(),
+				SellingAsset: twoEurOffer.Selling,
+				BuyingAsset:  twoEurOffer.Buying,
+				Amount:       twoEurOffer.Amount,
+				Pricen:       int32(twoEurOffer.Price.N),
+				Priced:       int32(twoEurOffer.Price.D),
+				Price:        float64(twoEurOffer.Price.N) / float64(twoEurOffer.Price.D),
+				Flags:        uint32(twoEurOffer.Flags),
+			},
+		},
+		nil,
+	).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().NoError(err)
+	s.Assert().Equal(resumeState, nextState.systemState)
+	s.Assert().Equal(uint32(130), nextState.latestSuccessfullyProcessedLedger)
+
+	// Also make sure offers are loaded
+	offers := s.graph.Offers()
+	sort.Slice(offers, func(i, j int) bool {
+		return offers[i].OfferId < offers[j].OfferId
+	})
+	s.Assert().Equal([]xdr.OfferEntry{eurOffer, twoEurOffer}, offers)
+}

--- a/services/horizon/internal/expingest/load_orderbook_graph_test.go
+++ b/services/horizon/internal/expingest/load_orderbook_graph_test.go
@@ -1,61 +1,55 @@
 package expingest
 
-// import (
-// 	"sort"
-// 	"testing"
+import (
+	"github.com/stellar/go/xdr"
+)
 
-// 	"github.com/stellar/go/exp/orderbook"
-// 	"github.com/stellar/go/services/horizon/internal/db2/history"
-// 	"github.com/stellar/go/xdr"
-// 	"github.com/stretchr/testify/suite"
-// )
+var (
+	issuer   = xdr.MustAddress("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	usdAsset = xdr.Asset{
+		Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AlphaNum4: &xdr.AssetAlphaNum4{
+			AssetCode: [4]byte{'u', 's', 'd', 0},
+			Issuer:    issuer,
+		},
+	}
 
-// var (
-// 	issuer   = xdr.MustAddress("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
-// 	usdAsset = xdr.Asset{
-// 		Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
-// 		AlphaNum4: &xdr.AssetAlphaNum4{
-// 			AssetCode: [4]byte{'u', 's', 'd', 0},
-// 			Issuer:    issuer,
-// 		},
-// 	}
+	nativeAsset = xdr.Asset{
+		Type: xdr.AssetTypeAssetTypeNative,
+	}
 
-// 	nativeAsset = xdr.Asset{
-// 		Type: xdr.AssetTypeAssetTypeNative,
-// 	}
-
-// 	eurAsset = xdr.Asset{
-// 		Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
-// 		AlphaNum4: &xdr.AssetAlphaNum4{
-// 			AssetCode: [4]byte{'e', 'u', 'r', 0},
-// 			Issuer:    issuer,
-// 		},
-// 	}
-// 	eurOffer = xdr.OfferEntry{
-// 		SellerId: issuer,
-// 		OfferId:  xdr.Int64(4),
-// 		Buying:   eurAsset,
-// 		Selling:  nativeAsset,
-// 		Price: xdr.Price{
-// 			N: 1,
-// 			D: 1,
-// 		},
-// 		Flags:  1,
-// 		Amount: xdr.Int64(500),
-// 	}
-// 	twoEurOffer = xdr.OfferEntry{
-// 		SellerId: issuer,
-// 		OfferId:  xdr.Int64(5),
-// 		Buying:   eurAsset,
-// 		Selling:  nativeAsset,
-// 		Price: xdr.Price{
-// 			N: 2,
-// 			D: 1,
-// 		},
-// 		Flags:  2,
-// 		Amount: xdr.Int64(500),
-// 	}
-// )
+	eurAsset = xdr.Asset{
+		Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AlphaNum4: &xdr.AssetAlphaNum4{
+			AssetCode: [4]byte{'e', 'u', 'r', 0},
+			Issuer:    issuer,
+		},
+	}
+	eurOffer = xdr.OfferEntry{
+		SellerId: issuer,
+		OfferId:  xdr.Int64(4),
+		Buying:   eurAsset,
+		Selling:  nativeAsset,
+		Price: xdr.Price{
+			N: 1,
+			D: 1,
+		},
+		Flags:  1,
+		Amount: xdr.Int64(500),
+	}
+	twoEurOffer = xdr.OfferEntry{
+		SellerId: issuer,
+		OfferId:  xdr.Int64(5),
+		Buying:   eurAsset,
+		Selling:  nativeAsset,
+		Price: xdr.Price{
+			N: 2,
+			D: 1,
+		},
+		Flags:  2,
+		Amount: xdr.Int64(500),
+	}
+)
 
 // type LoadOffersIntoMemoryTestSuite struct {
 // 	suite.Suite

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -492,7 +492,7 @@ func (s *System) buildState() (state, error) {
 	// Double check if we should proceed with state ingestion. It's possible that
 	// another ingesting instance will be redirected to this state from `init`
 	// but it's first to complete the task.
-	if !(ingestVersion != CurrentVersion || lastIngestedLedger == 0) {
+	if ingestVersion == CurrentVersion && lastIngestedLedger > 0 {
 		log.Info("Another instance completed `buildState`. Skipping...")
 		return state{systemState: initState}, nil
 	}

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -68,25 +68,37 @@ type Config struct {
 }
 
 type dbQ interface {
+	history.QAccounts
+	history.QAssetStats
+	history.QData
+	history.QEffects
+	history.QLedgers
+	history.QOffers
+	history.QOperations
+	// QParticipants
+	// Copy the small interfaces with shared methods directly, otherwise error:
+	// duplicate method CreateAccounts
+	NewTransactionParticipantsBatchInsertBuilder(maxBatchSize int) history.TransactionParticipantsBatchInsertBuilder
+	NewOperationParticipantBatchInsertBuilder(maxBatchSize int) history.OperationParticipantBatchInsertBuilder
+	history.QSigners
+	//QTrades
+	NewTradeBatchInsertBuilder(maxBatchSize int) history.TradeBatchInsertBuilder
+	CreateAssets(assets []xdr.Asset) (map[string]history.Asset, error)
+	history.QTransactions
+	history.QTrustLines
+
 	Begin() error
 	Commit() error
 	Clone() *db.Session
 	Rollback() error
 	GetTx() *sqlx.Tx
-	GetLastLedgerExpIngest() (uint32, error)
 	GetExpIngestVersion() (int, error)
-	UpdateLastLedgerExpIngest(uint32) error
 	UpdateExpStateInvalid(bool) error
 	UpdateExpIngestVersion(int) error
 	GetExpStateInvalid() (bool, error)
-	GetAllOffers() ([]history.Offer, error)
 	GetLatestLedger() (uint32, error)
 	TruncateExpingestStateTables() error
 	DeleteRangeAll(start, end int64) error
-}
-
-type dbSession interface {
-	Clone() *db.Session
 }
 
 type systemState string
@@ -95,6 +107,7 @@ const (
 	initState               systemState = "init"
 	ingestHistoryRangeState systemState = "ingestHistoryRange"
 	waitForCheckpointState  systemState = "waitForCheckpoint"
+	buildStateState         systemState = "buildState"
 	resumeState             systemState = "resume"
 	verifyRangeState        systemState = "verifyRange"
 	shutdownState           systemState = "shutdown"
@@ -103,6 +116,8 @@ const (
 type state struct {
 	systemState                       systemState
 	latestSuccessfullyProcessedLedger uint32
+
+	checkpointLedger uint32
 
 	rangeFromLedger   uint32
 	rangeToLedger     uint32
@@ -118,9 +133,8 @@ type System struct {
 	config Config
 	state  state
 
-	graph          *orderbook.OrderBookGraph
-	historyQ       *history.Q
-	historySession dbSession
+	graph    *orderbook.OrderBookGraph
+	historyQ dbQ
 
 	historyArchive *historyarchive.Archive
 	ledgerBackend  *ledgerbackend.DatabaseBackend
@@ -150,19 +164,13 @@ func NewSystem(config Config) (*System, error) {
 		return nil, errors.Wrap(err, "error creating ledger backend")
 	}
 
-	// Make historySession synchronized so it can be used in the pipeline
-	// (saving to DB in multiple goroutines at the same time).
-	historySession := config.HistorySession.Clone()
-	historySession.Synchronized = true
-
-	historyQ := &history.Q{historySession}
+	historyQ := &history.Q{config.HistorySession.Clone()}
 
 	system := &System{
 		historyArchive:           archive,
 		historyAdapter:           adapters.MakeHistoryArchiveAdapter(archive),
 		ledgerBackend:            ledgerBackend,
 		config:                   config,
-		historySession:           historySession,
 		historyQ:                 historyQ,
 		graph:                    config.OrderBookGraph,
 		disableStateVerification: config.DisableStateVerification,
@@ -289,6 +297,8 @@ func (s *System) runCurrentState() (state, error) {
 		nextState, err = s.ingestHistoryRange()
 	case waitForCheckpointState:
 		nextState, err = s.waitForCheckpoint()
+	case buildStateState:
+		nextState, err = s.buildState()
 	case resumeState:
 		nextState, err = s.resume()
 	case verifyRangeState:
@@ -308,7 +318,6 @@ func (s *System) init() (state, error) {
 		return state{systemState: initState}, errors.Wrap(err, "Error starting a transaction")
 	}
 	defer s.historyQ.Rollback()
-	defer s.graph.Discard()
 
 	// This will get the value `FOR UPDATE`, blocking it for other nodes.
 	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
@@ -333,15 +342,12 @@ func (s *System) init() (state, error) {
 		// `LastLedgerExpIngest` value is blocked for update and will always
 		// be updated when leading instance finishes processing state.
 		// In case of errors it will start `Init` from the beginning.
-		log.Info("Starting ingestion system from empty state...")
-
-		var lastCheckpoint uint32
-		lastCheckpoint, err = s.historyAdapter.GetLatestLedgerSequence()
+		lastCheckpoint, err := s.historyAdapter.GetLatestLedgerSequence()
 		if err != nil {
 			return state{systemState: initState}, errors.Wrap(err, "Error getting last checkpoint")
 		}
 
-		if lastHistoryLedger > 0 && lastHistoryLedger != lastCheckpoint {
+		if lastHistoryLedger != 0 {
 			// There are ledgers in history_ledgers table. This means that the
 			// old or new ingest system was running prior the upgrade. In both
 			// cases we need to:
@@ -351,58 +357,28 @@ func (s *System) init() (state, error) {
 			//   the latest checkpoint ledger.
 			// * Build state from the last checkpoint if the latest history ledger
 			//   is equal to the latest checkpoint ledger.
-
-			if lastHistoryLedger > lastCheckpoint {
+			switch {
+			case lastHistoryLedger > lastCheckpoint:
 				return state{systemState: waitForCheckpointState}, nil
-
+			case lastHistoryLedger < lastCheckpoint:
+				return state{
+					systemState:     ingestHistoryRangeState,
+					rangeFromLedger: lastHistoryLedger + 1,
+					rangeToLedger:   lastCheckpoint,
+				}, nil
+			default: // lastHistoryLedger == lastCheckpoint
+				// Build state but make sure it's using `lastCheckpoint`. It's possible
+				// that the new checkpoint will be created during state transition.
+				return state{
+					systemState:      buildStateState,
+					checkpointLedger: lastCheckpoint,
+				}, nil
 			}
-			// lastHistoryLedger < lastCheckpoint
-			return state{
-				systemState:     ingestHistoryRangeState,
-				rangeFromLedger: lastHistoryLedger + 1,
-				rangeToLedger:   lastCheckpoint,
-			}, nil
-		}
-
-		err = s.historyQ.TruncateExpingestStateTables()
-		if err != nil {
-			return state{systemState: initState},
-				errors.Wrap(err, "Error clearing ingest tables")
-		}
-
-		err = s.runHistoryArchiveIngestion(lastCheckpoint)
-		if err != nil {
-			return state{systemState: initState},
-				errors.Wrap(err, "Error ingesting history archive")
-		}
-
-		// Clear last_ingested_ledger in key value store
-		err = s.historyQ.UpdateLastLedgerExpIngest(lastCheckpoint)
-		if err != nil {
-			return state{systemState: initState},
-				errors.Wrap(err, "Error updating last ingested ledger")
-		}
-
-		// Clear invalid state in key value store. It's possible that upgraded
-		// ingestion is fixing it.
-		err = s.historyQ.UpdateExpStateInvalid(false)
-		if err != nil {
-			return state{systemState: initState},
-				errors.Wrap(err, "Error updating state invalid value")
-		}
-
-		if err = s.graph.Apply(lastCheckpoint); err != nil {
-			return state{systemState: initState},
-				errors.Wrap(err, "Error applying graph history archive changes")
-		}
-		if err = s.historyQ.Commit(); err != nil {
-			return state{systemState: initState},
-				errors.Wrap(err, "Error commiting history archive transaction")
 		}
 
 		return state{
-			systemState:                       resumeState,
-			latestSuccessfullyProcessedLedger: lastCheckpoint,
+			systemState:      buildStateState,
+			checkpointLedger: lastCheckpoint,
 		}, nil
 	}
 
@@ -489,7 +465,102 @@ func (s *System) loadOffersIntoMemory() error {
 	return nil
 }
 
+func (s *System) buildState() (state, error) {
+	if s.state.checkpointLedger == 0 {
+		return state{systemState: initState}, errors.New("unexpected checkpointLedger value")
+	}
+
+	if err := s.historyQ.Begin(); err != nil {
+		return state{systemState: initState}, errors.Wrap(err, "Error starting a transaction")
+	}
+	defer s.historyQ.Rollback()
+	defer s.graph.Discard()
+
+	// We need to get this value `FOR UPDATE` so all other instances
+	// are blocked.
+	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
+	if err != nil {
+		return state{systemState: initState}, errors.Wrap(err, "Error getting last ledger")
+	}
+
+	ingestVersion, err := s.historyQ.GetExpIngestVersion()
+	if err != nil {
+		return state{systemState: initState}, errors.Wrap(err, "Error getting exp ingest version")
+	}
+
+	// Double check if we should proceed with state ingestion. It's possible that
+	// another ingesting instance will be redirected to this state from `init`
+	// but it's first to complete the task.
+	if !(ingestVersion != CurrentVersion || lastIngestedLedger == 0) {
+		log.Info("Another instance completed `buildState`. Skipping...")
+		return state{systemState: initState}, nil
+	}
+
+	log.Info("Starting ingestion system from empty state...")
+
+	// Clear last_ingested_ledger in key value store
+	err = s.historyQ.UpdateLastLedgerExpIngest(0)
+	if err != nil {
+		return state{systemState: initState}, errors.Wrap(err, "Error updating last ingested ledger")
+	}
+
+	// Clear invalid state in key value store. It's possible that upgraded
+	// ingestion is fixing it.
+	err = s.historyQ.UpdateExpStateInvalid(false)
+	if err != nil {
+		return state{systemState: initState}, errors.Wrap(err, "Error updating state invalid value")
+	}
+
+	err = s.historyQ.TruncateExpingestStateTables()
+	if err != nil {
+		return state{systemState: initState}, errors.Wrap(err, "Error clearing ingest tables")
+	}
+
+	log.WithFields(logpkg.F{
+		"ledger": s.state.checkpointLedger,
+	}).Info("Processing state")
+	startTime := time.Now()
+
+	err = s.runHistoryArchiveIngestion(s.state.checkpointLedger)
+	if err != nil {
+		return state{systemState: initState}, errors.Wrap(err, "Error ingesting history archive")
+	}
+
+	if err = s.historyQ.UpdateLastLedgerExpIngest(s.state.checkpointLedger); err != nil {
+		return state{systemState: initState}, errors.Wrap(err, "Error updating last ingested ledger")
+	}
+
+	if err = s.historyQ.UpdateExpIngestVersion(CurrentVersion); err != nil {
+		return state{systemState: initState}, errors.Wrap(err, "Error updating expingest version")
+	}
+
+	err = s.historyQ.Commit()
+	if err != nil {
+		return state{systemState: initState}, errors.Wrap(err, "Error commiting db transaction")
+	}
+
+	err = s.graph.Apply(s.state.checkpointLedger)
+	if err != nil {
+		return state{systemState: initState}, errors.Wrap(err, "Error applying order book changes")
+	}
+
+	log.WithFields(logpkg.F{
+		"ledger":   s.state.checkpointLedger,
+		"duration": time.Since(startTime).Seconds(),
+	}).Info("Processed state")
+
+	// If successful, continue from the next ledger
+	return state{
+		systemState:                       resumeState,
+		latestSuccessfullyProcessedLedger: s.state.checkpointLedger,
+	}, nil
+}
+
 func (s *System) resume() (state, error) {
+	if s.state.latestSuccessfullyProcessedLedger == 0 {
+		return state{systemState: initState}, errors.New("unexpected latestSuccessfullyProcessedLedger value")
+	}
+
 	if err := s.historyQ.Begin(); err != nil {
 		return s.state,
 			errors.Wrap(err, "Error starting a transaction")
@@ -515,6 +586,9 @@ func (s *System) resume() (state, error) {
 			)
 	}
 
+	log.WithField("sequence", ingestLedger).Info("Processing ledger")
+	startTime := time.Now()
+
 	if ingestLedger < lastIngestedLedger {
 		// rollback because we will not be updating the DB
 		// so there is no need to hold on to the distributed lock
@@ -536,6 +610,15 @@ func (s *System) resume() (state, error) {
 			return s.state,
 				errors.Wrap(err, "Error applying graph changes from ledger")
 		}
+
+		log.WithFields(logpkg.F{
+			"sequence": ingestLedger,
+			"duration": time.Since(startTime).Seconds(),
+			"state":    false,
+			"ledger":   false,
+			"graph":    true,
+			"commit":   false,
+		}).Info("Processed ledger")
 
 		return state{
 			systemState:                       resumeState,
@@ -564,6 +647,15 @@ func (s *System) resume() (state, error) {
 		return s.state,
 			errors.Wrap(err, "Error commiting processor transaction")
 	}
+
+	log.WithFields(logpkg.F{
+		"sequence": ingestLedger,
+		"duration": time.Since(startTime).Seconds(),
+		"state":    true,
+		"ledger":   true,
+		"graph":    true,
+		"commit":   true,
+	}).Info("Processed ledger")
 
 	s.maybeVerifyState(ingestLedger)
 
@@ -668,9 +760,21 @@ func (s *System) ingestHistoryRange() (state, error) {
 	}
 
 	for cur := s.state.rangeFromLedger; cur <= s.state.rangeToLedger; cur++ {
+		log.WithField("sequence", cur).Info("Processing ledger")
+		startTime := time.Now()
+
 		if err := s.runTransactionProcessorsOnLedger(cur); err != nil {
 			return state{systemState: returnState}, err
 		}
+
+		log.WithFields(logpkg.F{
+			"sequence": cur,
+			"duration": time.Since(startTime).Seconds(),
+			"state":    false,
+			"ledger":   true,
+			"graph":    false,
+			"commit":   false,
+		}).Info("Processed ledger")
 	}
 
 	if err := s.historyQ.Commit(); err != nil {
@@ -692,6 +796,7 @@ func (s *System) verifyRange() (state, error) {
 		return state{systemState: shutdownState, returnError: err}, err
 	}
 	defer s.historyQ.Rollback()
+	defer s.graph.Discard()
 
 	// Simple check if DB clean
 	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
@@ -708,13 +813,23 @@ func (s *System) verifyRange() (state, error) {
 	log.WithFields(logpkg.F{
 		"ledger": s.state.rangeFromLedger,
 	}).Info("Processing state")
-
 	startTime := time.Now()
+
 	err = s.runHistoryArchiveIngestion(s.state.rangeFromLedger)
 	if err != nil {
 		err = errors.Wrap(err, "Error ingesting history archive")
 		return state{systemState: shutdownState, returnError: err}, err
+	}
 
+	if err = s.historyQ.Commit(); err != nil {
+		err = errors.Wrap(err, "Error commiting")
+		return state{systemState: shutdownState, returnError: err}, err
+	}
+
+	err = s.graph.Apply(s.state.checkpointLedger)
+	if err != nil {
+		err = errors.Wrap(err, "Error applying order book changes")
+		return state{systemState: shutdownState, returnError: err}, err
 	}
 
 	log.WithFields(logpkg.F{
@@ -722,16 +837,8 @@ func (s *System) verifyRange() (state, error) {
 		"duration": time.Since(startTime).Seconds(),
 	}).Info("Processed state")
 
-	if err = s.historyQ.Commit(); err != nil {
-		err = errors.Wrap(err, "Error commiting")
-		return state{systemState: shutdownState, returnError: err}, err
-	}
-
 	for sequence := s.state.rangeFromLedger + 1; sequence <= s.state.rangeToLedger; sequence++ {
-		log.WithFields(logpkg.F{
-			"ledger": sequence,
-		}).Info("Processing ledger")
-
+		log.WithField("sequence", sequence).Info("Processing ledger")
 		startTime := time.Now()
 
 		if err = s.historyQ.Begin(); err != nil {
@@ -762,8 +869,12 @@ func (s *System) verifyRange() (state, error) {
 		}
 
 		log.WithFields(logpkg.F{
-			"ledger":   sequence,
+			"sequence": sequence,
 			"duration": time.Since(startTime).Seconds(),
+			"state":    true,
+			"ledger":   true,
+			"graph":    true,
+			"commit":   true,
 		}).Info("Processed ledger")
 	}
 

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -342,7 +342,8 @@ func (s *System) init() (state, error) {
 		// `LastLedgerExpIngest` value is blocked for update and will always
 		// be updated when leading instance finishes processing state.
 		// In case of errors it will start `Init` from the beginning.
-		lastCheckpoint, err := s.historyAdapter.GetLatestLedgerSequence()
+		var lastCheckpoint uint32
+		lastCheckpoint, err = s.historyAdapter.GetLatestLedgerSequence()
 		if err != nil {
 			return state{systemState: initState}, errors.Wrap(err, "Error getting last checkpoint")
 		}

--- a/services/horizon/internal/expingest/main_test.go
+++ b/services/horizon/internal/expingest/main_test.go
@@ -3,7 +3,12 @@ package expingest
 import (
 	"testing"
 
+	"github.com/jmoiron/sqlx"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestCheckVerifyStateVersion(t *testing.T) {
@@ -13,4 +18,119 @@ func TestCheckVerifyStateVersion(t *testing.T) {
 		stateVerifierExpectedIngestionVersion,
 		"State verifier is outdated, update it, then update stateVerifierExpectedIngestionVersion value",
 	)
+}
+
+type mockDBQ struct {
+	mock.Mock
+
+	history.MockQAccounts
+	history.MockQAssetStats
+	history.MockQData
+	history.MockQEffects
+	history.MockQLedgers
+	history.MockQOffers
+	history.MockQOperations
+	history.MockQSigners
+	history.MockQTransactions
+	history.MockQTrustLines
+}
+
+func (m *mockDBQ) Begin() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockDBQ) Clone() *db.Session {
+	args := m.Called()
+	return args.Get(0).(*db.Session)
+}
+
+func (m *mockDBQ) Commit() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockDBQ) Rollback() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockDBQ) GetTx() *sqlx.Tx {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(*sqlx.Tx)
+}
+
+func (m *mockDBQ) GetLastLedgerExpIngest() (uint32, error) {
+	args := m.Called()
+	return args.Get(0).(uint32), args.Error(1)
+}
+
+func (m *mockDBQ) GetExpIngestVersion() (int, error) {
+	args := m.Called()
+	return args.Get(0).(int), args.Error(1)
+}
+
+func (m *mockDBQ) UpdateLastLedgerExpIngest(sequence uint32) error {
+	args := m.Called(sequence)
+	return args.Error(0)
+}
+
+func (m *mockDBQ) UpdateExpStateInvalid(invalid bool) error {
+	args := m.Called(invalid)
+	return args.Error(0)
+}
+
+func (m *mockDBQ) UpdateExpIngestVersion(version int) error {
+	args := m.Called(version)
+	return args.Error(0)
+}
+
+func (m *mockDBQ) GetExpStateInvalid() (bool, error) {
+	args := m.Called()
+	return args.Get(0).(bool), args.Error(1)
+}
+
+func (m *mockDBQ) GetAllOffers() ([]history.Offer, error) {
+	args := m.Called()
+	return args.Get(0).([]history.Offer), args.Error(1)
+}
+
+func (m *mockDBQ) GetLatestLedger() (uint32, error) {
+	args := m.Called()
+	return args.Get(0).(uint32), args.Error(1)
+}
+
+func (m *mockDBQ) TruncateExpingestStateTables() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockDBQ) DeleteRangeAll(start, end int64) error {
+	args := m.Called(start, end)
+	return args.Error(0)
+}
+
+// Methods from interfaces duplicating methods:
+
+func (m *mockDBQ) NewTransactionParticipantsBatchInsertBuilder(maxBatchSize int) history.TransactionParticipantsBatchInsertBuilder {
+	args := m.Called(maxBatchSize)
+	return args.Get(0).(history.TransactionParticipantsBatchInsertBuilder)
+}
+
+func (m *mockDBQ) NewOperationParticipantBatchInsertBuilder(maxBatchSize int) history.OperationParticipantBatchInsertBuilder {
+	args := m.Called(maxBatchSize)
+	return args.Get(0).(history.TransactionParticipantsBatchInsertBuilder)
+}
+
+func (m *mockDBQ) NewTradeBatchInsertBuilder(maxBatchSize int) history.TradeBatchInsertBuilder {
+	args := m.Called(maxBatchSize)
+	return args.Get(0).(history.TradeBatchInsertBuilder)
+}
+
+func (m *mockDBQ) CreateAssets(assets []xdr.Asset) (map[string]history.Asset, error) {
+	args := m.Called(assets)
+	return args.Get(0).(map[string]history.Asset), args.Error(1)
 }

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -51,7 +51,7 @@ func (s *System) verifyState(graphOffers map[xdr.Int64]xdr.OfferEntry) error {
 	}
 
 	startTime := time.Now()
-	session := s.historySession.Clone()
+	session := s.historyQ.Clone()
 
 	defer func() {
 		log.WithField("duration", time.Since(startTime).Seconds()).Info("State verification finished")


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit is reverting removal of `buildState` state and adds initial tests (starting with `init` state tests).

Close #2183.

### Why

With separate state that build state from history archives it will be easier to test and understand the ingestion state machine. 

### Known limitations

I had to update `dbQ` interface and `mockQ` to be able to use it in tests. As you can see it's much larger now and looks awkward (because some methods were duplicated in two or more interfaces). It will also make testing state machine harder: instead of checking if the correct set of processors is executed we'd need to mock all the calls of the processors.

To solve the problems above I propose to move all methods in `processors.go` (ex. `runAllProcessorsOnLedger`) to a new struct that can be mocked in tests. Then while testing state machine we only test if the correct function of the new struct was called and we can revert `dbQ` interface to it's previous, simple form.