### PR TITLE
exp/services/webauth: remove duplicate test expectation

### DIFF
--- a/exp/services/webauth/internal/serve/token_test.go
+++ b/exp/services/webauth/internal/serve/token_test.go
@@ -337,7 +337,6 @@ func TestToken_jsonInputValidMultipleSigners(t *testing.T) {
 	claims := token.Claims.(jwt.MapClaims)
 	assert.Equal(t, serverKey.Address(), claims["iss"])
 	assert.Equal(t, account.Address(), claims["sub"])
-	assert.Equal(t, account.Address(), claims["sub"])
 	iat := time.Unix(int64(claims["iat"].(float64)), 0)
 	exp := time.Unix(int64(claims["exp"].(float64)), 0)
 	assert.True(t, iat.Before(time.Now()))


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] ~This PR adds tests for the most critical parts of the new functionality or fixes.~
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove duplicate expectation from test.

### Why

The line was duplicated seemingly by accident.

### Known limitations

N/A
