### PR TITLE
services/horizon/expingest: Add verifyState tests

### DIFF
--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -3,12 +3,14 @@
 package history
 
 import (
+	"database/sql"
 	"fmt"
 	"sync"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/guregu/null"
+	"github.com/jmoiron/sqlx"
 
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/support/db"
@@ -152,9 +154,45 @@ type accountsBatchInsertBuilder struct {
 	builder db.BatchInsertBuilder
 }
 
+type IngestionQ interface {
+	QAccounts
+	QAssetStats
+	QData
+	QEffects
+	QLedgers
+	QOffers
+	QOperations
+	// QParticipants
+	// Copy the small interfaces with shared methods directly, otherwise error:
+	// duplicate method CreateAccounts
+	NewTransactionParticipantsBatchInsertBuilder(maxBatchSize int) TransactionParticipantsBatchInsertBuilder
+	NewOperationParticipantBatchInsertBuilder(maxBatchSize int) OperationParticipantBatchInsertBuilder
+	QSigners
+	//QTrades
+	NewTradeBatchInsertBuilder(maxBatchSize int) TradeBatchInsertBuilder
+	CreateAssets(assets []xdr.Asset) (map[string]Asset, error)
+	QTransactions
+	QTrustLines
+
+	Begin() error
+	BeginTx(*sql.TxOptions) error
+	Commit() error
+	CloneIngestionQ() IngestionQ
+	Rollback() error
+	GetTx() *sqlx.Tx
+	GetExpIngestVersion() (int, error)
+	UpdateExpStateInvalid(bool) error
+	UpdateExpIngestVersion(int) error
+	GetExpStateInvalid() (bool, error)
+	GetLatestLedger() (uint32, error)
+	TruncateExpingestStateTables() error
+	DeleteRangeAll(start, end int64) error
+}
+
 // QAccounts defines account related queries.
 type QAccounts interface {
 	NewAccountsBatchInsertBuilder(maxBatchSize int) AccountsBatchInsertBuilder
+	GetAccountsByIDs(ids []string) ([]AccountEntry, error)
 	InsertAccount(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) (int64, error)
 	UpdateAccount(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) (int64, error)
 	UpsertAccounts(accounts []xdr.LedgerEntry) error
@@ -201,6 +239,8 @@ type accountDataBatchInsertBuilder struct {
 // QData defines account data related queries.
 type QData interface {
 	NewAccountDataBatchInsertBuilder(maxBatchSize int) AccountDataBatchInsertBuilder
+	CountAccountsData() (int, error)
+	GetAccountDataByKeys(keys []xdr.LedgerKeyData) ([]Data, error)
 	InsertAccountData(data xdr.DataEntry, lastModifiedLedger xdr.Uint32) (int64, error)
 	UpdateAccountData(data xdr.DataEntry, lastModifiedLedger xdr.Uint32) (int64, error)
 	RemoveAccountData(key xdr.LedgerKeyData) (int64, error)
@@ -463,6 +503,7 @@ type QSigners interface {
 	NewAccountSignersBatchInsertBuilder(maxBatchSize int) AccountSignersBatchInsertBuilder
 	CreateAccountSigner(account, signer string, weight int32) (int64, error)
 	RemoveAccountSigner(account, signer string) (int64, error)
+	SignersForAccounts(accounts []string) ([]AccountSigner, error)
 	CountAccounts() (int, error)
 }
 
@@ -477,6 +518,8 @@ type OffersQuery struct {
 // QOffers defines offer related queries.
 type QOffers interface {
 	GetAllOffers() ([]Offer, error)
+	GetOffersByIDs(ids []int64) ([]Offer, error)
+	CountOffers() (int, error)
 	NewOffersBatchInsertBuilder(maxBatchSize int) OffersBatchInsertBuilder
 	InsertOffer(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) (int64, error)
 	UpdateOffer(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) (int64, error)
@@ -578,6 +621,7 @@ type TrustLine struct {
 // QTrustLines defines trust lines related queries.
 type QTrustLines interface {
 	NewTrustLinesBatchInsertBuilder(maxBatchSize int) TrustLinesBatchInsertBuilder
+	GetTrustLinesByKeys(keys []xdr.LedgerKeyTrustLine) ([]TrustLine, error)
 	InsertTrustLine(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr.Uint32) (int64, error)
 	UpdateTrustLine(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr.Uint32) (int64, error)
 	UpsertTrustLines(trustLines []xdr.LedgerEntry) error
@@ -676,6 +720,11 @@ func (q *Q) OldestOutdatedLedgers(dest interface{}, currentVersion int) error {
 		WHERE importer_version < $1
 		ORDER BY sequence ASC
 		LIMIT 1000000`, currentVersion)
+}
+
+// CloneIngestionQ clones underlying db.Session and returns IngestionQ
+func (q *Q) CloneIngestionQ() IngestionQ {
+	return &Q{q.Clone()}
 }
 
 // DeleteRangeAll deletes a range of rows from all history tables between

--- a/services/horizon/internal/db2/history/mock_q_data.go
+++ b/services/horizon/internal/db2/history/mock_q_data.go
@@ -16,6 +16,11 @@ func (m *MockQData) GetAccountDataByKeys(keys []xdr.LedgerKeyData) ([]Data, erro
 	return a.Get(0).([]Data), a.Error(1)
 }
 
+func (m *MockQData) CountAccountsData() (int, error) {
+	a := m.Called()
+	return a.Get(0).(int), a.Error(1)
+}
+
 func (m *MockQData) NewAccountDataBatchInsertBuilder(maxBatchSize int) AccountDataBatchInsertBuilder {
 	a := m.Called(maxBatchSize)
 	return a.Get(0).(AccountDataBatchInsertBuilder)

--- a/services/horizon/internal/db2/history/mock_q_offers.go
+++ b/services/horizon/internal/db2/history/mock_q_offers.go
@@ -16,6 +16,16 @@ func (m *MockQOffers) GetAllOffers() ([]Offer, error) {
 	return a.Get(0).([]Offer), a.Error(1)
 }
 
+func (m *MockQOffers) GetOffersByIDs(ids []int64) ([]Offer, error) {
+	a := m.Called(ids)
+	return a.Get(0).([]Offer), a.Error(1)
+}
+
+func (m *MockQOffers) CountOffers() (int, error) {
+	a := m.Called()
+	return a.Get(0).(int), a.Error(1)
+}
+
 func (m *MockQOffers) NewOffersBatchInsertBuilder(maxBatchSize int) OffersBatchInsertBuilder {
 	a := m.Called(maxBatchSize)
 	return a.Get(0).(OffersBatchInsertBuilder)

--- a/services/horizon/internal/db2/history/mock_q_signers.go
+++ b/services/horizon/internal/db2/history/mock_q_signers.go
@@ -44,6 +44,11 @@ func (m *MockQSigners) RemoveAccountSigner(account, signer string) (int64, error
 	return a.Get(0).(int64), a.Error(1)
 }
 
+func (m *MockQSigners) SignersForAccounts(accounts []string) ([]AccountSigner, error) {
+	a := m.Called(accounts)
+	return a.Get(0).([]AccountSigner), a.Error(1)
+}
+
 func (m *MockQSigners) CountAccounts() (int, error) {
 	a := m.Called()
 	return a.Get(0).(int), a.Error(1)

--- a/services/horizon/internal/db2/history/mock_q_trust_lines.go
+++ b/services/horizon/internal/db2/history/mock_q_trust_lines.go
@@ -16,6 +16,11 @@ func (m *MockQTrustLines) NewTrustLinesBatchInsertBuilder(maxBatchSize int) Trus
 	return a.Get(0).(TrustLinesBatchInsertBuilder)
 }
 
+func (m *MockQTrustLines) GetTrustLinesByKeys(keys []xdr.LedgerKeyTrustLine) ([]TrustLine, error) {
+	a := m.Called(keys)
+	return a.Get(0).([]TrustLine), a.Error(1)
+}
+
 func (m *MockQTrustLines) InsertTrustLine(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
 	a := m.Called(trustLine, lastModifiedLedger)
 	return a.Get(0).(int64), a.Error(1)

--- a/services/horizon/internal/expingest/ingest_history_range_state_test.go
+++ b/services/horizon/internal/expingest/ingest_history_range_state_test.go
@@ -43,6 +43,8 @@ func (s *IngestHistoryRangeStateTestSuite) SetupTest() {
 func (s *IngestHistoryRangeStateTestSuite) TearDownTest() {
 	t := s.T()
 	s.historyQ.AssertExpectations(t)
+	s.historyAdapter.AssertExpectations(t)
+	s.runner.AssertExpectations(t)
 }
 
 func (s *IngestHistoryRangeStateTestSuite) TestInvalidRange() {

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/stellar/go/clients/stellarcore"
 	"github.com/stellar/go/exp/ingest/adapters"
 	ingesterrors "github.com/stellar/go/exp/ingest/errors"
@@ -71,40 +70,6 @@ type Config struct {
 	IngestFailedTransactions bool
 }
 
-type dbQ interface {
-	history.QAccounts
-	history.QAssetStats
-	history.QData
-	history.QEffects
-	history.QLedgers
-	history.QOffers
-	history.QOperations
-	// QParticipants
-	// Copy the small interfaces with shared methods directly, otherwise error:
-	// duplicate method CreateAccounts
-	NewTransactionParticipantsBatchInsertBuilder(maxBatchSize int) history.TransactionParticipantsBatchInsertBuilder
-	NewOperationParticipantBatchInsertBuilder(maxBatchSize int) history.OperationParticipantBatchInsertBuilder
-	history.QSigners
-	//QTrades
-	NewTradeBatchInsertBuilder(maxBatchSize int) history.TradeBatchInsertBuilder
-	CreateAssets(assets []xdr.Asset) (map[string]history.Asset, error)
-	history.QTransactions
-	history.QTrustLines
-
-	Begin() error
-	Commit() error
-	Clone() *db.Session
-	Rollback() error
-	GetTx() *sqlx.Tx
-	GetExpIngestVersion() (int, error)
-	UpdateExpStateInvalid(bool) error
-	UpdateExpIngestVersion(int) error
-	GetExpStateInvalid() (bool, error)
-	GetLatestLedger() (uint32, error)
-	TruncateExpingestStateTables() error
-	DeleteRangeAll(start, end int64) error
-}
-
 type systemState string
 
 const (
@@ -151,7 +116,7 @@ type System struct {
 	state  state
 
 	graph    orderbook.OBGraph
-	historyQ dbQ
+	historyQ history.IngestionQ
 	runner   ProcessorRunnerInterface
 
 	historyArchive *historyarchive.Archive
@@ -888,6 +853,12 @@ func (s *System) waitForCheckpoint() (state, error) {
 }
 
 func (s *System) verifyRange() (state, error) {
+	if s.state.rangeFromLedger == 0 || s.state.rangeToLedger == 0 ||
+		s.state.rangeFromLedger > s.state.rangeToLedger {
+		return state{systemState: shutdownState},
+			errors.Errorf("invalid range: [%d, %d]", s.state.rangeFromLedger, s.state.rangeToLedger)
+	}
+
 	if err := s.historyQ.Begin(); err != nil {
 		err = errors.Wrap(err, "Error starting a transaction")
 		return state{systemState: shutdownState}, err
@@ -918,12 +889,18 @@ func (s *System) verifyRange() (state, error) {
 		return state{systemState: shutdownState}, err
 	}
 
+	err = s.historyQ.UpdateLastLedgerExpIngest(s.state.rangeFromLedger)
+	if err != nil {
+		err = errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
+		return state{systemState: shutdownState}, err
+	}
+
 	if err = s.historyQ.Commit(); err != nil {
 		err = errors.Wrap(err, commitErrMsg)
 		return state{systemState: shutdownState}, err
 	}
 
-	err = s.graph.Apply(s.state.checkpointLedger)
+	err = s.graph.Apply(s.state.rangeFromLedger)
 	if err != nil {
 		err = errors.Wrap(err, "Error applying order book changes")
 		return state{systemState: shutdownState}, err
@@ -1024,9 +1001,9 @@ func (s *System) Shutdown() {
 	close(s.shutdown)
 }
 
-func markStateInvalid(historyQ dbQ, err error) {
+func markStateInvalid(historyQ history.IngestionQ, err error) {
 	log.WithField("err", err).Error("STATE IS INVALID!")
-	q := &history.Q{historyQ.Clone()}
+	q := historyQ.CloneIngestionQ()
 	if err := q.UpdateExpStateInvalid(true); err != nil {
 		log.WithField("err", err).Error(updateExpStateInvalidErrMsg)
 	}

--- a/services/horizon/internal/expingest/main_test.go
+++ b/services/horizon/internal/expingest/main_test.go
@@ -2,11 +2,11 @@ package expingest
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
@@ -99,23 +99,24 @@ func TestStateMachineTransition(t *testing.T) {
 
 // TestStateMachineRunReturnsErrorWhenNextStateIsShutdownWithError checks if the
 // state that goes to shutdownState and returns an error will make `run` function
-// return that error. This is essential because some command rely on this to return
+// return that error. This is essential because some commands rely on this to return
 // non-zero exit code.
 func TestStateMachineRunReturnsErrorWhenNextStateIsShutdownWithError(t *testing.T) {
 	historyQ := &mockDBQ{}
+	graph := &mockOrderBookGraph{}
 	system := &System{
 		state: state{
 			systemState: verifyRangeState,
 		},
 		historyQ: historyQ,
+		graph:    graph,
 	}
 
 	historyQ.On("GetTx").Return(nil).Once()
-	historyQ.On("Begin").Return(errors.New("my error")).Once()
 
 	err := system.run()
 	assert.Error(t, err)
-	assert.EqualError(t, err, "Error starting a transaction: my error")
+	assert.EqualError(t, err, "invalid range: [0, 0]")
 }
 
 type mockDBQ struct {
@@ -138,9 +139,14 @@ func (m *mockDBQ) Begin() error {
 	return args.Error(0)
 }
 
-func (m *mockDBQ) Clone() *db.Session {
+func (m *mockDBQ) BeginTx(txOpts *sql.TxOptions) error {
+	args := m.Called(txOpts)
+	return args.Error(0)
+}
+
+func (m *mockDBQ) CloneIngestionQ() history.IngestionQ {
 	args := m.Called()
-	return args.Get(0).(*db.Session)
+	return args.Get(0).(history.IngestionQ)
 }
 
 func (m *mockDBQ) Commit() error {

--- a/services/horizon/internal/expingest/processors_runner.go
+++ b/services/horizon/internal/expingest/processors_runner.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stellar/go/exp/ingest/io"
 	"github.com/stellar/go/exp/ingest/ledgerbackend"
 	"github.com/stellar/go/exp/orderbook"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/expingest/processors"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/historyarchive"
@@ -41,7 +42,7 @@ type ProcessorRunner struct {
 	config Config
 
 	graph          *orderbook.OrderBookGraph
-	historyQ       dbQ
+	historyQ       history.IngestionQ
 	historyArchive *historyarchive.Archive
 	historyAdapter adapters.HistoryArchiveAdapterInterface
 	ledgerBackend  *ledgerbackend.DatabaseBackend

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -51,25 +51,23 @@ func (s *System) verifyState(graphOffers map[xdr.Int64]xdr.OfferEntry) error {
 	}
 
 	startTime := time.Now()
-	session := s.historyQ.Clone()
+	historyQ := s.historyQ.CloneIngestionQ()
 
 	defer func() {
 		log.WithField("duration", time.Since(startTime).Seconds()).Info("State verification finished")
-		session.Rollback()
+		historyQ.Rollback()
 		s.stateVerificationMutex.Lock()
 		s.stateVerificationRunning = false
 		s.stateVerificationMutex.Unlock()
 	}()
 
-	err := session.BeginTx(&sql.TxOptions{
+	err := historyQ.BeginTx(&sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	})
 	if err != nil {
 		return errors.Wrap(err, "Error starting transaction")
 	}
-
-	historyQ := &history.Q{session}
 
 	// Ensure the ledger is a checkpoint ledger
 	ledgerSequence, err := historyQ.GetLastLedgerExpIngestNonBlocking()
@@ -242,7 +240,7 @@ func (s *System) verifyState(graphOffers map[xdr.Int64]xdr.OfferEntry) error {
 	return nil
 }
 
-func checkAssetStats(set processors.AssetStatSet, q *history.Q) error {
+func checkAssetStats(set processors.AssetStatSet, q history.IngestionQ) error {
 	page := db2.PageQuery{
 		Order: "asc",
 		Limit: assetStatsBatchSize,
@@ -292,7 +290,7 @@ func checkAssetStats(set processors.AssetStatSet, q *history.Q) error {
 	return nil
 }
 
-func addAccountsToStateVerifier(verifier *verify.StateVerifier, q *history.Q, ids []string) error {
+func addAccountsToStateVerifier(verifier *verify.StateVerifier, q history.IngestionQ, ids []string) error {
 	if len(ids) == 0 {
 		return nil
 	}
@@ -378,7 +376,7 @@ func addAccountsToStateVerifier(verifier *verify.StateVerifier, q *history.Q, id
 	return nil
 }
 
-func addDataToStateVerifier(verifier *verify.StateVerifier, q *history.Q, keys []xdr.LedgerKeyData) error {
+func addDataToStateVerifier(verifier *verify.StateVerifier, q history.IngestionQ, keys []xdr.LedgerKeyData) error {
 	if len(keys) == 0 {
 		return nil
 	}
@@ -424,7 +422,7 @@ func offerEntryEquals(offer, other xdr.OfferEntry) (bool, error) {
 
 func addOffersToStateVerifier(
 	verifier *verify.StateVerifier,
-	q *history.Q,
+	q history.IngestionQ,
 	ids []int64,
 	graphOffers map[xdr.Int64]xdr.OfferEntry,
 ) error {
@@ -485,7 +483,7 @@ func addOffersToStateVerifier(
 func addTrustLinesToStateVerifier(
 	verifier *verify.StateVerifier,
 	assetStats processors.AssetStatSet,
-	q *history.Q,
+	q history.IngestionQ,
 	keys []xdr.LedgerKeyTrustLine,
 ) error {
 	if len(keys) == 0 {

--- a/services/horizon/internal/expingest/verify_range_state_test.go
+++ b/services/horizon/internal/expingest/verify_range_state_test.go
@@ -1,0 +1,235 @@
+package expingest
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stellar/go/exp/ingest/adapters"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestVerifyRangeStateTestSuite(t *testing.T) {
+	suite.Run(t, new(VerifyRangeStateTestSuite))
+}
+
+type VerifyRangeStateTestSuite struct {
+	suite.Suite
+	graph          *mockOrderBookGraph
+	historyQ       *mockDBQ
+	historyAdapter *adapters.MockHistoryArchiveAdapter
+	runner         *mockProcessorsRunner
+	system         *System
+}
+
+func (s *VerifyRangeStateTestSuite) SetupTest() {
+	s.graph = &mockOrderBookGraph{}
+	s.historyQ = &mockDBQ{}
+	s.historyAdapter = &adapters.MockHistoryArchiveAdapter{}
+	s.runner = &mockProcessorsRunner{}
+	s.system = &System{
+		state: state{
+			systemState: verifyRangeState,
+		},
+		historyQ:       s.historyQ,
+		historyAdapter: s.historyAdapter,
+		runner:         s.runner,
+		graph:          s.graph,
+	}
+
+	s.Assert().Equal(verifyRangeState, s.system.state.systemState)
+	// Checking if in tx in runCurrentState()
+	s.historyQ.On("GetTx").Return(nil).Once()
+	s.historyQ.On("Rollback").Return(nil).Once()
+	s.graph.On("Discard").Once()
+}
+
+func (s *VerifyRangeStateTestSuite) TearDownTest() {
+	t := s.T()
+	s.historyQ.AssertExpectations(t)
+	s.historyAdapter.AssertExpectations(t)
+	s.runner.AssertExpectations(t)
+	s.graph.AssertExpectations(t)
+}
+
+func (s *VerifyRangeStateTestSuite) TestInvalidRange() {
+	// Recreate mock in this single test to remove Rollback assertion.
+	*s.historyQ = mockDBQ{}
+	*s.graph = mockOrderBookGraph{}
+	s.historyQ.On("GetTx").Return(nil).Maybe()
+
+	s.system.state.rangeFromLedger = 0
+	s.system.state.rangeToLedger = 0
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "invalid range: [0, 0]")
+	s.Assert().Equal(shutdownState, nextState.systemState)
+
+	s.system.state.rangeFromLedger = 0
+	s.system.state.rangeToLedger = 100
+	nextState, err = s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "invalid range: [0, 100]")
+	s.Assert().Equal(shutdownState, nextState.systemState)
+
+	s.system.state.rangeFromLedger = 100
+	s.system.state.rangeToLedger = 0
+	nextState, err = s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "invalid range: [100, 0]")
+	s.Assert().Equal(shutdownState, nextState.systemState)
+
+	s.system.state.rangeFromLedger = 100
+	s.system.state.rangeToLedger = 99
+	nextState, err = s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "invalid range: [100, 99]")
+	s.Assert().Equal(shutdownState, nextState.systemState)
+}
+
+func (s *VerifyRangeStateTestSuite) TestBeginReturnsError() {
+	s.system.state.rangeFromLedger = 100
+	s.system.state.rangeToLedger = 200
+
+	// Recreate mock in this single test to remove Rollback assertion.
+	*s.historyQ = mockDBQ{}
+	*s.graph = mockOrderBookGraph{}
+	s.historyQ.On("GetTx").Return(nil).Once()
+	s.historyQ.On("Begin").Return(errors.New("my error")).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Error starting a transaction: my error")
+	s.Assert().Equal(shutdownState, nextState.systemState)
+}
+
+func (s *VerifyRangeStateTestSuite) TestGetLastLedgerExpIngestReturnsError() {
+	s.system.state.rangeFromLedger = 100
+	s.system.state.rangeToLedger = 200
+
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), errors.New("my error")).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Error getting last ingested ledger: my error")
+	s.Assert().Equal(shutdownState, nextState.systemState)
+}
+
+func (s *VerifyRangeStateTestSuite) TestGetLastLedgerExpIngestNonEmpty() {
+	s.system.state.rangeFromLedger = 100
+	s.system.state.rangeToLedger = 200
+
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Database not empty")
+	s.Assert().Equal(shutdownState, nextState.systemState)
+}
+
+func (s *VerifyRangeStateTestSuite) TestRunHistoryArchiveIngestionReturnsError() {
+	s.system.state.rangeFromLedger = 100
+	s.system.state.rangeToLedger = 200
+
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+
+	s.runner.On("RunHistoryArchiveIngestion", uint32(100)).Return(errors.New("my error")).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Error ingesting history archive: my error")
+	s.Assert().Equal(shutdownState, nextState.systemState)
+}
+
+func (s *VerifyRangeStateTestSuite) TestSuccess() {
+	s.system.state.rangeFromLedger = 100
+	s.system.state.rangeToLedger = 200
+
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.runner.On("RunHistoryArchiveIngestion", uint32(100)).Return(nil).Once()
+	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(100)).Return(nil).Once()
+	s.historyQ.On("Commit").Return(nil).Once()
+	s.graph.On("Apply", uint32(s.system.state.rangeFromLedger)).Return(nil).Once()
+
+	for i := uint32(101); i <= 200; i++ {
+		s.historyQ.On("Begin").Return(nil).Once()
+		s.runner.On("RunAllProcessorsOnLedger", i).Return(nil).Once()
+		s.historyQ.On("UpdateLastLedgerExpIngest", i).Return(nil).Once()
+		s.historyQ.On("Commit").Return(nil).Once()
+		s.graph.On("Apply", i).Return(nil).Once()
+	}
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().NoError(err)
+	s.Assert().Equal(shutdownState, nextState.systemState)
+}
+
+func (s *VerifyRangeStateTestSuite) TestSuccessWithVerify() {
+	s.system.state.rangeFromLedger = 100
+	s.system.state.rangeToLedger = 110
+	s.system.state.rangeVerifyState = true
+
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.runner.On("RunHistoryArchiveIngestion", uint32(100)).Return(nil).Once()
+	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(100)).Return(nil).Once()
+	s.historyQ.On("Commit").Return(nil).Once()
+	s.graph.On("Apply", uint32(s.system.state.rangeFromLedger)).Return(nil).Once()
+
+	for i := uint32(101); i <= 110; i++ {
+		s.historyQ.On("Begin").Return(nil).Once()
+		s.runner.On("RunAllProcessorsOnLedger", i).Return(nil).Once()
+		s.historyQ.On("UpdateLastLedgerExpIngest", i).Return(nil).Once()
+		s.historyQ.On("Commit").Return(nil).Once()
+		s.graph.On("Apply", i).Return(nil).Once()
+	}
+
+	s.graph.On("OffersMap").Return(map[xdr.Int64]xdr.OfferEntry{
+		eurOffer.OfferId: xdr.OfferEntry{
+			SellerId: eurOffer.SellerId,
+			OfferId:  eurOffer.OfferId,
+			Selling:  eurOffer.Selling,
+			Buying:   eurOffer.Buying,
+			Amount:   eurOffer.Amount,
+			Price: xdr.Price{
+				N: xdr.Int32(eurOffer.Price.N),
+				D: xdr.Int32(eurOffer.Price.D),
+			},
+			Flags: xdr.Uint32(eurOffer.Flags),
+		},
+		twoEurOffer.OfferId: xdr.OfferEntry{
+			SellerId: twoEurOffer.SellerId,
+			OfferId:  twoEurOffer.OfferId,
+			Selling:  twoEurOffer.Selling,
+			Buying:   twoEurOffer.Buying,
+			Amount:   twoEurOffer.Amount,
+			Price: xdr.Price{
+				N: xdr.Int32(twoEurOffer.Price.N),
+				D: xdr.Int32(twoEurOffer.Price.D),
+			},
+			Flags: xdr.Uint32(twoEurOffer.Flags),
+		},
+	}).Once()
+
+	clonedQ := &mockDBQ{}
+	s.historyQ.On("CloneIngestionQ").Return(clonedQ).Once()
+
+	clonedQ.On("BeginTx", mock.Anything).Run(func(args mock.Arguments) {
+		arg := args.Get(0).(*sql.TxOptions)
+		s.Assert().Equal(sql.LevelRepeatableRead, arg.Isolation)
+		s.Assert().True(arg.ReadOnly)
+	}).Return(errors.New("my error")).Once()
+	clonedQ.On("Rollback").Return(nil).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Error starting transaction: my error")
+	s.Assert().Equal(shutdownState, nextState.systemState)
+	clonedQ.AssertExpectations(s.T())
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

This commit adds tests to `verifyState` state and updates `IngestionQ` interface to allow cloning. More tests will be added in a separate PR.