### PR TITLE
services/horizon/internal/expingest: Dont log db.ErrCancelled errors

### DIFF
--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -298,7 +298,9 @@ func (s *System) run() error {
 
 	for {
 		nextState, err := s.runCurrentState()
-		if err != nil && errors.Cause(err) != context.Canceled {
+		if err != nil &&
+			errors.Cause(err) != context.Canceled &&
+			errors.Cause(err) != db.ErrCancelled {
 			log.WithFields(logpkg.F{
 				"error":         err,
 				"current_state": s.state,


### PR DESCRIPTION
The following log was emitted during shutdown:

```
ERRO[2020-01-31T14:42:51.443+01:00] Error in ingestion state machine              current_state="{buildState 0 28009855 0 0 false false false false}" error="Error ingesting history archive: Error streaming changes from HAS: could not process change: error in Commit: errors in UpsertTrustLines: canceling statement due to user request" next_state="{init 0 0 0 0 false false false false}" pid=13545 service=expingest

```

This commit makes sure `db.ErrCancelled` is also skipped when it comes to logging