### PR TITLE
services/horizon/internal/expingest: Add missing invariant assertions in the beginning of resume and init

### DIFF
--- a/services/horizon/internal/expingest/init_state_test.go
+++ b/services/horizon/internal/expingest/init_state_test.go
@@ -2,6 +2,7 @@ package expingest
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stellar/go/exp/ingest/adapters"
@@ -79,6 +80,24 @@ func (s *InitStateTestSuite) TestGetExpIngestVersionReturnsError() {
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "Error getting exp ingest version: my error")
 	s.Assert().Equal(initState, nextState.systemState)
+}
+
+func (s *InitStateTestSuite) TestCurrentVersionIsOutdated() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(1), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion+1, nil).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(
+		err,
+		fmt.Sprintf(
+			"ingestion version in db %v is greater than current version %v",
+			CurrentVersion+1,
+			CurrentVersion,
+		),
+	)
+	s.Assert().Equal(shutdownState, nextState.systemState)
 }
 
 func (s *InitStateTestSuite) TestGetLatestLedgerReturnsError() {

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -354,7 +354,7 @@ func (s *System) init() (state, error) {
 	if ingestVersion > CurrentVersion {
 		return state{systemState: shutdownState},
 			errors.Errorf(
-				"ingestion version in db %v is greater than current version %v",
+				"ingestion version in db %d is greater than current version %d",
 				ingestVersion,
 				CurrentVersion,
 			)

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -351,6 +351,15 @@ func (s *System) init() (state, error) {
 		return state{systemState: initState}, errors.Wrap(err, getExpIngestVersionErrMsg)
 	}
 
+	if ingestVersion > CurrentVersion {
+		return state{systemState: shutdownState},
+			errors.Errorf(
+				"ingestion version in db %v is greater than current version %v",
+				ingestVersion,
+				CurrentVersion,
+			)
+	}
+
 	lastHistoryLedger, err := s.historyQ.GetLatestLedger()
 	if err != nil {
 		return state{systemState: initState}, errors.Wrap(err, "Error getting last history ledger sequence")
@@ -621,6 +630,35 @@ func (s *System) resume() (state, error) {
 		return state{systemState: initState},
 			errors.New("expected ingest ledger to be at most one greater " +
 				"than last ingested ledger in db")
+	}
+
+	ingestVersion, err := s.historyQ.GetExpIngestVersion()
+	if err != nil {
+		return s.state, errors.Wrap(err, getExpIngestVersionErrMsg)
+	}
+
+	if ingestVersion != CurrentVersion {
+		return state{systemState: initState},
+			errors.Errorf(
+				"ingestion version in db %v does not match expected version %v",
+				ingestVersion,
+				CurrentVersion,
+			)
+	}
+
+	lastHistoryLedger, err := s.historyQ.GetLatestLedger()
+	if err != nil {
+		return s.state,
+			errors.Wrap(err, "could not get latest history ledger")
+	}
+
+	if lastHistoryLedger != 0 && lastHistoryLedger != lastIngestedLedger {
+		return state{systemState: initState},
+			errors.Errorf(
+				"last history ledger %v does not match last ingested ledger %v",
+				lastHistoryLedger,
+				lastIngestedLedger,
+			)
 	}
 
 	// Check if ledger is closed

--- a/services/horizon/internal/expingest/resume_state_test.go
+++ b/services/horizon/internal/expingest/resume_state_test.go
@@ -2,6 +2,7 @@ package expingest
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stellar/go/exp/ingest/adapters"
@@ -116,9 +117,96 @@ func (s *ResumeTestTestSuite) TestGetLatestLedgerLessThanCurrent() {
 	s.Assert().Equal(initState, nextState.systemState)
 }
 
+func (s *ResumeTestTestSuite) TestGetIngestionVersionError() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(0, errors.New("my error")).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Error getting exp ingest version: my error")
+	s.Assert().Equal(resumeState, nextState.systemState)
+	s.Assert().Equal(uint32(100), nextState.latestSuccessfullyProcessedLedger)
+}
+
+func (s *ResumeTestTestSuite) TestIngestionVersionLessThanCurrentVersion() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion-1, nil).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(
+		err,
+		fmt.Sprintf(
+			"ingestion version in db %v does not match expected version %v",
+			CurrentVersion-1,
+			CurrentVersion,
+		),
+	)
+	s.Assert().Equal(initState, nextState.systemState)
+}
+
+func (s *ResumeTestTestSuite) TestIngestionVersionGreaterThanCurrentVersion() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion+1, nil).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(
+		err,
+		fmt.Sprintf(
+			"ingestion version in db %v does not match expected version %v",
+			CurrentVersion+1,
+			CurrentVersion,
+		),
+	)
+	s.Assert().Equal(initState, nextState.systemState)
+}
+
+func (s *ResumeTestTestSuite) TestGetLatestLedgerError() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(0), errors.New("my error"))
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "could not get latest history ledger: my error")
+	s.Assert().Equal(resumeState, nextState.systemState)
+	s.Assert().Equal(uint32(100), nextState.latestSuccessfullyProcessedLedger)
+}
+
+func (s *ResumeTestTestSuite) TestLatestHistoryLedgerLessThanIngestLedger() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil)
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "last history ledger 99 does not match last ingested ledger 100")
+	s.Assert().Equal(initState, nextState.systemState)
+}
+
+func (s *ResumeTestTestSuite) TestLatestHistoryLedgerGreaterThanIngestLedger() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "last history ledger 101 does not match last ingested ledger 100")
+	s.Assert().Equal(initState, nextState.systemState)
+}
+
 func (s *ResumeTestTestSuite) TestIngestOrderbookOnly() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(110), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
 	s.ledgeBackend.On("GetLatestLedgerSequence").Return(uint32(111), nil).Once()
 
@@ -140,6 +228,8 @@ func (s *ResumeTestTestSuite) TestIngestOrderbookOnly() {
 func (s *ResumeTestTestSuite) TestIngestOrderbookOnlyWhenLastLedgerExpEqualsCurrent() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(101), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
 
 	s.ledgeBackend.On("GetLatestLedgerSequence").Return(uint32(111), nil).Once()
 
@@ -158,6 +248,8 @@ func (s *ResumeTestTestSuite) TestIngestOrderbookOnlyWhenLastLedgerExpEqualsCurr
 func (s *ResumeTestTestSuite) TestIngestAllMasterNode() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
 	s.ledgeBackend.On("GetLatestLedgerSequence").Return(uint32(111), nil).Once()
 
@@ -185,6 +277,8 @@ func (s *ResumeTestTestSuite) TestIngestAllMasterNode() {
 func (s *ResumeTestTestSuite) TestErrorSettingCursorIgnored() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
 	s.ledgeBackend.On("GetLatestLedgerSequence").Return(uint32(111), nil).Once()
 
@@ -212,6 +306,8 @@ func (s *ResumeTestTestSuite) TestErrorSettingCursorIgnored() {
 func (s *ResumeTestTestSuite) TestNoNewLedgers() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
 	s.ledgeBackend.On("GetLatestLedgerSequence").Return(uint32(100), nil).Once()
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes https://github.com/stellar/go/issues/2204

* Add missing invariant assertions in the beginning of resume and init

### Why

https://github.com/stellar/go/issues/2204 provides some details on scenarios where we can have multiple versions of ingestion running at the same time during a rolling deployment.

If we have checks against the ingestion version found in the db during the init and resume state we can detect these cases and shutdown.

### Known limitations

[N/A]
