### PR TITLE
exp/services/webauth: make jwt issuer a uri and configurable

### DIFF
--- a/exp/services/webauth/README.md
+++ b/exp/services/webauth/README.md
@@ -48,6 +48,7 @@ Flags:
       --challenge-expires-in int           The time period in seconds after which the challenge transaction expires (CHALLENGE_EXPIRES_IN) (default 300)
       --horizon-url string                 Horizon URL used for looking up account details (HORIZON_URL) (default "https://horizon-testnet.stellar.org/")
       --jwt-expires-in int                 The time period in seconds after which the JWT expires (JWT_EXPIRES_IN) (default 300)
+      --jwt-issuer string                  The issuer to set in the JWT iss claim (JWT_ISSUER)
       --jwt-key string                     Base64 encoded ECDSA private key used for signing JWTs (JWT_KEY)
       --network-passphrase string          Network passphrase of the Stellar network transactions should be signed for (NETWORK_PASSPHRASE) (default "Test SDF Network ; September 2015")
       --port int                           Port to listen and serve on (PORT) (default 8000)

--- a/exp/services/webauth/internal/commands/serve.go
+++ b/exp/services/webauth/internal/commands/serve.go
@@ -68,6 +68,13 @@ func (c *ServeCommand) Command() *cobra.Command {
 			Required:  true,
 		},
 		{
+			Name:      "jwt-issuer",
+			Usage:     "The issuer to set in the JWT iss claim",
+			OptType:   types.String,
+			ConfigKey: &opts.JWTIssuer,
+			Required:  true,
+		},
+		{
 			Name:           "jwt-expires-in",
 			Usage:          "The time period in seconds after which the JWT expires",
 			OptType:        types.Int,

--- a/exp/services/webauth/internal/serve/serve.go
+++ b/exp/services/webauth/internal/serve/serve.go
@@ -22,6 +22,7 @@ type Options struct {
 	SigningKey                  string
 	ChallengeExpiresIn          time.Duration
 	JWTPrivateKey               string
+	JWTIssuer                   string
 	JWTExpiresIn                time.Duration
 	AllowAccountsThatDoNotExist bool
 }
@@ -83,6 +84,7 @@ func handler(opts Options) (http.Handler, error) {
 		NetworkPassphrase:           opts.NetworkPassphrase,
 		SigningAddress:              signingKey.FromAddress(),
 		JWTPrivateKey:               jwtPrivateKey,
+		JWTIssuer:                   opts.JWTIssuer,
 		JWTExpiresIn:                opts.JWTExpiresIn,
 		AllowAccountsThatDoNotExist: opts.AllowAccountsThatDoNotExist,
 	}.ServeHTTP)

--- a/exp/services/webauth/internal/serve/token.go
+++ b/exp/services/webauth/internal/serve/token.go
@@ -21,6 +21,7 @@ type tokenHandler struct {
 	NetworkPassphrase           string
 	SigningAddress              *keypair.FromAddress
 	JWTPrivateKey               *ecdsa.PrivateKey
+	JWTIssuer                   string
 	JWTExpiresIn                time.Duration
 	AllowAccountsThatDoNotExist bool
 }
@@ -84,7 +85,7 @@ func (h tokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	now := time.Now().UTC()
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
-		"iss": h.SigningAddress.Address(),
+		"iss": h.JWTIssuer,
 		"sub": clientAccountID,
 		"iat": now.Unix(),
 		"exp": now.Add(h.JWTExpiresIn).Unix(),

--- a/exp/services/webauth/internal/serve/token_test.go
+++ b/exp/services/webauth/internal/serve/token_test.go
@@ -83,6 +83,7 @@ func TestToken_formInputSuccess(t *testing.T) {
 		NetworkPassphrase: network.TestNetworkPassphrase,
 		SigningAddress:    serverKey.FromAddress(),
 		JWTPrivateKey:     jwtPrivateKey,
+		JWTIssuer:         "https://example.com",
 		JWTExpiresIn:      time.Minute,
 	}
 
@@ -114,7 +115,7 @@ func TestToken_formInputSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	claims := token.Claims.(jwt.MapClaims)
-	assert.Equal(t, serverKey.Address(), claims["iss"])
+	assert.Equal(t, "https://example.com", claims["iss"])
 	assert.Equal(t, account.Address(), claims["sub"])
 	assert.Equal(t, account.Address(), claims["sub"])
 	iat := time.Unix(int64(claims["iat"].(float64)), 0)
@@ -182,6 +183,7 @@ func TestToken_jsonInputSuccess(t *testing.T) {
 		NetworkPassphrase: network.TestNetworkPassphrase,
 		SigningAddress:    serverKey.FromAddress(),
 		JWTPrivateKey:     jwtPrivateKey,
+		JWTIssuer:         "https://example.com",
 		JWTExpiresIn:      time.Minute,
 	}
 
@@ -218,7 +220,7 @@ func TestToken_jsonInputSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	claims := token.Claims.(jwt.MapClaims)
-	assert.Equal(t, serverKey.Address(), claims["iss"])
+	assert.Equal(t, "https://example.com", claims["iss"])
 	assert.Equal(t, account.Address(), claims["sub"])
 	assert.Equal(t, account.Address(), claims["sub"])
 	iat := time.Unix(int64(claims["iat"].(float64)), 0)
@@ -299,6 +301,7 @@ func TestToken_jsonInputValidMultipleSigners(t *testing.T) {
 		NetworkPassphrase: network.TestNetworkPassphrase,
 		SigningAddress:    serverKey.FromAddress(),
 		JWTPrivateKey:     jwtPrivateKey,
+		JWTIssuer:         "https://example.com",
 		JWTExpiresIn:      time.Minute,
 	}
 
@@ -335,7 +338,7 @@ func TestToken_jsonInputValidMultipleSigners(t *testing.T) {
 	require.NoError(t, err)
 
 	claims := token.Claims.(jwt.MapClaims)
-	assert.Equal(t, serverKey.Address(), claims["iss"])
+	assert.Equal(t, "https://example.com", claims["iss"])
 	assert.Equal(t, account.Address(), claims["sub"])
 	iat := time.Unix(int64(claims["iat"].(float64)), 0)
 	exp := time.Unix(int64(claims["exp"].(float64)), 0)
@@ -402,6 +405,7 @@ func TestToken_jsonInputNotEnoughWeight(t *testing.T) {
 		NetworkPassphrase: network.TestNetworkPassphrase,
 		SigningAddress:    serverKey.FromAddress(),
 		JWTPrivateKey:     jwtPrivateKey,
+		JWTIssuer:         "https://example.com",
 		JWTExpiresIn:      time.Minute,
 	}
 
@@ -484,6 +488,7 @@ func TestToken_jsonInputUnrecognizedSigner(t *testing.T) {
 		NetworkPassphrase: network.TestNetworkPassphrase,
 		SigningAddress:    serverKey.FromAddress(),
 		JWTPrivateKey:     jwtPrivateKey,
+		JWTIssuer:         "https://example.com",
 		JWTExpiresIn:      time.Minute,
 	}
 
@@ -561,6 +566,7 @@ func TestToken_jsonInputAccountNotExistSuccess(t *testing.T) {
 		NetworkPassphrase:           network.TestNetworkPassphrase,
 		SigningAddress:              serverKey.FromAddress(),
 		JWTPrivateKey:               jwtPrivateKey,
+		JWTIssuer:                   "https://example.com",
 		JWTExpiresIn:                time.Minute,
 		AllowAccountsThatDoNotExist: true,
 	}
@@ -598,7 +604,7 @@ func TestToken_jsonInputAccountNotExistSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	claims := token.Claims.(jwt.MapClaims)
-	assert.Equal(t, serverKey.Address(), claims["iss"])
+	assert.Equal(t, "https://example.com", claims["iss"])
 	assert.Equal(t, account.Address(), claims["sub"])
 	assert.Equal(t, account.Address(), claims["sub"])
 	iat := time.Unix(int64(claims["iat"].(float64)), 0)
@@ -664,6 +670,7 @@ func TestToken_jsonInputAccountNotExistFail(t *testing.T) {
 		NetworkPassphrase:           network.TestNetworkPassphrase,
 		SigningAddress:              serverKey.FromAddress(),
 		JWTPrivateKey:               jwtPrivateKey,
+		JWTIssuer:                   "https://example.com",
 		JWTExpiresIn:                time.Minute,
 		AllowAccountsThatDoNotExist: true,
 	}
@@ -742,6 +749,7 @@ func TestToken_jsonInputAccountNotExistNotAllowed(t *testing.T) {
 		NetworkPassphrase:           network.TestNetworkPassphrase,
 		SigningAddress:              serverKey.FromAddress(),
 		JWTPrivateKey:               jwtPrivateKey,
+		JWTIssuer:                   "https://example.com",
 		JWTExpiresIn:                time.Minute,
 		AllowAccountsThatDoNotExist: false,
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Add a parameter to configure the value of the JWT issuer that is
included in the `iss` claim of JWTs issued by the webauth service.

### Why
The issuer is hardcoded as the server signing key, but @JakeUrban
pointed out that the SEP-10 specification defines that the `iss` claim
be a URI. If it is a URI it needs to be configurable and set by the
people hosting the server and there is no need to prescribe the value
in the service so it is purely a configuration driven value now.

The change does not validate that the value is a URI because there is
no URI parsing code in the Go SDK, only URL parsing code. It's likely that
code would be sufficient in parsing the code but it would also
communicate that we expect the value to be a URL which is incorrect.
Given that there is little impact to parsing the value I've left it out.

### Known limitations

N/A
