### PR TITLE
txnbuild: ignore txhash (preauth) and xhash signers in sep-10

### DIFF
--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -667,9 +667,7 @@ func verifyTxSignature(tx Transaction, signer string) error {
 
 // verifyTxSignature checks if a transaction has been signed by one or more of
 // the signers, returning a list of signers that were found to have signed the
-// transaction. Signers that are not prefixed as an address/account ID strkey
-// will be ignored, however signers that that are prefixed but are corrupted in
-// some other way will cause an error to be returned.
+// transaction.
 func verifyTxSignatures(tx Transaction, signers ...string) ([]string, error) {
 	if tx.xdrEnvelope == nil {
 		return nil, errors.New("transaction has no signatures")

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -578,12 +578,14 @@ func VerifyChallengeTxSigners(challengeTx, serverAccountID, network string, sign
 		if signer == serverKP.Address() {
 			continue
 		}
+		// Deduplicate.
 		if _, seen := clientSignersSeen[signer]; seen {
 			continue
 		}
+		// Ignore non-G... account/address signers.
 		strkeyVersionByte, err := strkey.Version(signer)
 		if err != nil {
-			return nil, errors.Wrap(err, "signer not strkey")
+			continue
 		}
 		if strkeyVersionByte != strkey.VersionByteAccountID {
 			continue

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -501,8 +501,7 @@ func ReadChallengeTx(challengeTx, serverAccountID, network string) (tx Transacti
 // account.
 //
 // Signers that are not prefixed as an address/account ID strkey (G...) will be
-// ignored, however signers that that are prefixed but are corrupted in some
-// other way will cause an error to be returned.
+// ignored.
 //
 // Errors will be raised if:
 //  - The transaction is invalid according to ReadChallengeTx.
@@ -542,8 +541,7 @@ func VerifyChallengeTxThreshold(challengeTx, serverAccountID, network string, th
 // signers that were found is returned, excluding the server account ID.
 //
 // Signers that are not prefixed as an address/account ID strkey (G...) will be
-// ignored, however signers that that are prefixed but are corrupted in some
-// other way will cause an error to be returned.
+// ignored.
 //
 // Errors will be raised if:
 //  - The transaction is invalid according to ReadChallengeTx.

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -553,10 +553,6 @@ func VerifyChallengeTxThreshold(challengeTx, serverAccountID, network string, th
 //    server account or one of the signers provided in the arguments.
 //  - Any signers appearing to be an accountID/address strkey (start with G) are corrupt.
 func VerifyChallengeTxSigners(challengeTx, serverAccountID, network string, signers ...string) ([]string, error) {
-	if len(signers) == 0 {
-		return nil, errors.New("no signers provided")
-	}
-
 	// Read the transaction which validates its structure.
 	tx, _, err := ReadChallengeTx(challengeTx, serverAccountID, network)
 	if err != nil {
@@ -585,8 +581,20 @@ func VerifyChallengeTxSigners(challengeTx, serverAccountID, network string, sign
 		if _, seen := clientSignersSeen[signer]; seen {
 			continue
 		}
+		strkeyVersionByte, err := strkey.Version(signer)
+		if err != nil {
+			return nil, errors.Wrap(err, "signer not strkey")
+		}
+		if strkeyVersionByte != strkey.VersionByteAccountID {
+			continue
+		}
 		clientSigners = append(clientSigners, signer)
 		clientSignersSeen[signer] = struct{}{}
+	}
+
+	// Don't continue if none of the signers provided are in the final list.
+	if len(clientSigners) == 0 {
+		return nil, errors.New("no verifiable signers provided, at least one G... address must be provided")
 	}
 
 	// Verify all the transaction's signers (server and client) in one
@@ -676,13 +684,6 @@ func verifyTxSignatures(tx Transaction, signers ...string) ([]string, error) {
 	signatureUsed := map[int]bool{}
 	signersFound := map[string]struct{}{}
 	for _, signer := range signers {
-		strkeyVersionByte, err := strkey.Version(signer)
-		if err != nil {
-			return nil, errors.Wrap(err, "signer not strkey")
-		}
-		if strkeyVersionByte != strkey.VersionByteAccountID {
-			continue
-		}
 		kp, err := keypair.ParseAddress(signer)
 		if err != nil {
 			return nil, errors.Wrap(err, "signer not address")

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
+	"github.com/stellar/go/strkey"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -499,12 +500,17 @@ func ReadChallengeTx(challengeTx, serverAccountID, network string) (tx Transacti
 // provided as an argument, and those signatures meet a threshold on the
 // account.
 //
+// Signers that are not prefixed as an address/account ID strkey (G...) will be
+// ignored, however signers that that are prefixed but are corrupted in some
+// other way will cause an error to be returned.
+//
 // Errors will be raised if:
 //  - The transaction is invalid according to ReadChallengeTx.
 //  - No client signatures are found on the transaction.
 //  - One or more signatures in the transaction are not identifiable as the
 //    server account or one of the signers provided in the arguments.
 //  - The signatures are all valid but do not meet the threshold.
+//  - Any signers appearing to be an accountID/address strkey (start with G) are corrupt.
 func VerifyChallengeTxThreshold(challengeTx, serverAccountID, network string, threshold Threshold, signerSummary SignerSummary) (signersFound []string, err error) {
 	signers := make([]string, 0, len(signerSummary))
 	for s := range signerSummary {
@@ -536,11 +542,16 @@ func VerifyChallengeTxThreshold(challengeTx, serverAccountID, network string, th
 // to a signer for verification to succeed. If verification succeeds a list of
 // signers that were found is returned, excluding the server account ID.
 //
+// Signers that are not prefixed as an address/account ID strkey (G...) will be
+// ignored, however signers that that are prefixed but are corrupted in some
+// other way will cause an error to be returned.
+//
 // Errors will be raised if:
 //  - The transaction is invalid according to ReadChallengeTx.
 //  - No client signatures are found on the transaction.
 //  - One or more signatures in the transaction are not identifiable as the
 //    server account or one of the signers provided in the arguments.
+//  - Any signers appearing to be an accountID/address strkey (start with G) are corrupt.
 func VerifyChallengeTxSigners(challengeTx, serverAccountID, network string, signers ...string) ([]string, error) {
 	if len(signers) == 0 {
 		return nil, errors.New("no signers provided")
@@ -648,7 +659,9 @@ func verifyTxSignature(tx Transaction, signer string) error {
 
 // verifyTxSignature checks if a transaction has been signed by one or more of
 // the signers, returning a list of signers that were found to have signed the
-// transaction.
+// transaction. Signers that are not prefixed as an address/account ID strkey
+// will be ignored, however signers that that are prefixed but are corrupted in
+// some other way will cause an error to be returned.
 func verifyTxSignatures(tx Transaction, signers ...string) ([]string, error) {
 	if tx.xdrEnvelope == nil {
 		return nil, errors.New("transaction has no signatures")
@@ -663,6 +676,13 @@ func verifyTxSignatures(tx Transaction, signers ...string) ([]string, error) {
 	signatureUsed := map[int]bool{}
 	signersFound := map[string]struct{}{}
 	for _, signer := range signers {
+		strkeyVersionByte, err := strkey.Version(signer)
+		if err != nil {
+			return nil, errors.Wrap(err, "signer not strkey")
+		}
+		if strkeyVersionByte != strkey.VersionByteAccountID {
+			continue
+		}
 		kp, err := keypair.ParseAddress(signer)
 		if err != nil {
 			return nil, errors.Wrap(err, "signer not address")

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -510,7 +510,6 @@ func ReadChallengeTx(challengeTx, serverAccountID, network string) (tx Transacti
 //  - One or more signatures in the transaction are not identifiable as the
 //    server account or one of the signers provided in the arguments.
 //  - The signatures are all valid but do not meet the threshold.
-//  - Any signers appearing to be an accountID/address strkey (start with G) are corrupt.
 func VerifyChallengeTxThreshold(challengeTx, serverAccountID, network string, threshold Threshold, signerSummary SignerSummary) (signersFound []string, err error) {
 	signers := make([]string, 0, len(signerSummary))
 	for s := range signerSummary {
@@ -551,7 +550,6 @@ func VerifyChallengeTxThreshold(challengeTx, serverAccountID, network string, th
 //  - No client signatures are found on the transaction.
 //  - One or more signatures in the transaction are not identifiable as the
 //    server account or one of the signers provided in the arguments.
-//  - Any signers appearing to be an accountID/address strkey (start with G) are corrupt.
 func VerifyChallengeTxSigners(challengeTx, serverAccountID, network string, signers ...string) ([]string, error) {
 	// Read the transaction which validates its structure.
 	tx, _, err := ReadChallengeTx(challengeTx, serverAccountID, network)

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -583,8 +583,8 @@ func VerifyChallengeTxSigners(challengeTx, serverAccountID, network string, sign
 			continue
 		}
 		// Ignore non-G... account/address signers.
-		strkeyVersionByte, err := strkey.Version(signer)
-		if err != nil {
+		strkeyVersionByte, strkeyErr := strkey.Version(signer)
+		if strkeyErr != nil {
 			continue
 		}
 		if strkeyVersionByte != strkey.VersionByteAccountID {

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1719,6 +1719,7 @@ func TestVerifyChallengeTxThreshold_validServerAndMultipleClientKeyMeetingThresh
 	clientKP3 := keypair.MustRandom()
 	preauthTxHash := "TAQCSRX2RIDJNHFIFHWD63X7D7D6TRT5Y2S6E3TEMXTG5W3OECHZ2OG4"
 	xHash := "XDRPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD"
+	unknownSignerType := "?ARPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD"
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
 	opSource := NewSimpleAccount(clientKP1.Address(), 0)
 	op := ManageData{
@@ -1739,6 +1740,7 @@ func TestVerifyChallengeTxThreshold_validServerAndMultipleClientKeyMeetingThresh
 		clientKP3.Address(): 2,
 		preauthTxHash:       10,
 		xHash:               10,
+		unknownSignerType:   10,
 	}
 	wantSigners := []string{
 		clientKP1.Address(),
@@ -2187,6 +2189,7 @@ func TestVerifyChallengeTxSigners_validIgnorePreauthTxHashAndXHash(t *testing.T)
 	clientKP2 := newKeypair2()
 	preauthTxHash := "TAQCSRX2RIDJNHFIFHWD63X7D7D6TRT5Y2S6E3TEMXTG5W3OECHZ2OG4"
 	xHash := "XDRPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD"
+	unknownSignerType := "?ARPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD"
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
@@ -2207,7 +2210,7 @@ func TestVerifyChallengeTxSigners_validIgnorePreauthTxHashAndXHash(t *testing.T)
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, clientKP2.Address(), preauthTxHash, xHash)
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, clientKP2.Address(), preauthTxHash, xHash, unknownSignerType)
 	assert.Equal(t, []string{clientKP2.Address()}, signersFound)
 	assert.NoError(t, err)
 }

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1712,6 +1712,50 @@ func TestVerifyChallengeTxThreshold_validServerAndMultipleClientKeyMeetingThresh
 	assert.NoError(t, err)
 }
 
+func TestVerifyChallengeTxThreshold_validServerAndMultipleClientKeyMeetingThresholdSomeUnusedIgnorePreauthTxHashAndXHash(t *testing.T) {
+	serverKP := newKeypair0()
+	clientKP1 := newKeypair1()
+	clientKP2 := newKeypair2()
+	clientKP3 := keypair.MustRandom()
+	preauthTxHash := "TAQCSRX2RIDJNHFIFHWD63X7D7D6TRT5Y2S6E3TEMXTG5W3OECHZ2OG4"
+	xHash := "XDRPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD"
+	txSource := NewSimpleAccount(serverKP.Address(), -1)
+	opSource := NewSimpleAccount(clientKP1.Address(), 0)
+	op := ManageData{
+		SourceAccount: &opSource,
+		Name:          "testserver auth",
+		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
+	}
+	tx := Transaction{
+		SourceAccount: &txSource,
+		Operations:    []Operation{&op},
+		Timebounds:    NewTimeout(1000),
+		Network:       network.TestNetworkPassphrase,
+	}
+	threshold := Threshold(3)
+	signerSummary := SignerSummary{
+		clientKP1.Address(): 1,
+		clientKP2.Address(): 2,
+		clientKP3.Address(): 2,
+		preauthTxHash:       10,
+		xHash:               10,
+	}
+	wantSigners := []string{
+		clientKP1.Address(),
+		clientKP2.Address(),
+	}
+
+	err := tx.Build()
+	require.NoError(t, err)
+	err = tx.Sign(serverKP, clientKP1, clientKP2)
+	assert.NoError(t, err)
+	tx64, err := tx.Base64()
+	require.NoError(t, err)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, threshold, signerSummary)
+	assert.ElementsMatch(t, wantSigners, signersFound)
+	assert.NoError(t, err)
+}
+
 func TestVerifyChallengeTxThreshold_invalidServerAndMultipleClientKeyNotMeetingThreshold(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP1 := newKeypair1()
@@ -2133,6 +2177,37 @@ func TestVerifyChallengeTxSigners_validServerAndClientSignersIgnoresDuplicateSig
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
 	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, clientKP2.Address(), clientKP2.Address())
+	assert.Equal(t, []string{clientKP2.Address()}, signersFound)
+	assert.NoError(t, err)
+}
+
+func TestVerifyChallengeTxSigners_validIgnorePreauthTxHashAndXHash(t *testing.T) {
+	serverKP := newKeypair0()
+	clientKP := newKeypair1()
+	clientKP2 := newKeypair2()
+	preauthTxHash := "TAQCSRX2RIDJNHFIFHWD63X7D7D6TRT5Y2S6E3TEMXTG5W3OECHZ2OG4"
+	xHash := "XDRPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD"
+	txSource := NewSimpleAccount(serverKP.Address(), -1)
+	opSource := NewSimpleAccount(clientKP.Address(), 0)
+	op := ManageData{
+		SourceAccount: &opSource,
+		Name:          "testserver auth",
+		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
+	}
+	tx := Transaction{
+		SourceAccount: &txSource,
+		Operations:    []Operation{&op},
+		Timebounds:    NewTimeout(1000),
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	err := tx.Build()
+	require.NoError(t, err)
+	err = tx.Sign(serverKP, clientKP2)
+	assert.NoError(t, err)
+	tx64, err := tx.Base64()
+	require.NoError(t, err)
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, clientKP2.Address(), preauthTxHash, xHash)
 	assert.Equal(t, []string{clientKP2.Address()}, signersFound)
 	assert.NoError(t, err)
 }

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1853,7 +1853,7 @@ func TestVerifyChallengeTxThreshold_invalidNoSigners(t *testing.T) {
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
 	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, threshold, signerSummary)
-	assert.EqualError(t, err, "no signers provided")
+	assert.EqualError(t, err, "no verifiable signers provided, at least one G... address must be provided")
 }
 
 func TestVerifyChallengeTxThreshold_weightsAddToMoreThan8Bits(t *testing.T) {
@@ -2296,7 +2296,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndClientSignersFailsSignerSeed(t
 	require.NoError(t, err)
 	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, clientKP2.Seed())
 	assert.Empty(t, signersFound)
-	assert.EqualError(t, err, "signer not address: invalid version byte")
+	assert.EqualError(t, err, "no verifiable signers provided, at least one G... address must be provided")
 }
 
 func TestVerifyChallengeTxSigners_invalidNoSigners(t *testing.T) {
@@ -2323,7 +2323,7 @@ func TestVerifyChallengeTxSigners_invalidNoSigners(t *testing.T) {
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
 	_, err = VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase)
-	assert.EqualError(t, err, "no signers provided")
+	assert.EqualError(t, err, "no verifiable signers provided, at least one G... address must be provided")
 }
 
 func TestVerifyTxSignatureUnsignedTx(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Ignore txhash (T...) signers, used for preauth transactions, xhash (X...)
signers, and other future types of signers the server might not know
about, during SEP-10 verification.

### Why
Developers will likely pass through to the verification functions the
signers on accounts as provided by Horizon. Accounts can have other
non-ed25519 signers and they're likely going to be passed through
verbatim. The verification logic's goal is to confirm the transaction
has been signed by the signers and so ignoring unsupported types like
txhash and xhash seems like a safe thing to do given that the
verification function will also ignore ed25519 signers that don't match
a signature.

Without this in a typical SEP-10 implementation any account with a
txhash or xhash signer will likely fail SEP-10 verification.

Issues that might be caused by this new behavior is if a user passes in
an account seed (S...) or some other string they won't see an error.
I think that's unlikely and hopefully a smaller impact than is worth
making this solution more complex.

This issue was first identified by @overcat in stellar/java-stellar-sdk#264,
but solved in a way that depends on data from Horizon. This solution
does not depend on data from Horizon and should be portable to all our
SDKs. This was previously discussed at:
https://github.com/stellar/java-stellar-sdk/pull/264#discussion_r373720425.

### Known limitations

N/A

### CC

@overcat @tamirms @ire-and-curses