### PR TITLE
keypair: add MustParseAddress, MustParseFull

### DIFF
--- a/keypair/main.go
+++ b/keypair/main.go
@@ -128,6 +128,26 @@ func MustParse(addressOrSeed string) KP {
 	return kp
 }
 
+// MustParseAddress is the panic-on-fail version of ParseAddress
+func MustParseAddress(address string) *FromAddress {
+	kp, err := ParseAddress(address)
+	if err != nil {
+		panic(err)
+	}
+
+	return kp
+}
+
+// MustParseFull is the panic-on-fail version of ParseFull
+func MustParseFull(seed string) *Full {
+	kp, err := ParseFull(seed)
+	if err != nil {
+		panic(err)
+	}
+
+	return kp
+}
+
 // MustRandom is the panic-on-fail version of Random.
 func MustRandom() *Full {
 	kp, err := Random()

--- a/keypair/main_test.go
+++ b/keypair/main_test.go
@@ -156,6 +156,48 @@ var _ = DescribeTable("keypair.ParseFull()",
 	}),
 )
 
+type MustParseFullCase struct {
+	Input    string
+	FullCase types.GomegaMatcher
+	FuncCase types.GomegaMatcher
+}
+
+var _ = DescribeTable("keypair.MustParseFull()",
+	func(c MustParseFullCase) {
+		f := func() {
+			kp := MustParseFull(c.Input)
+			Expect(kp).To(c.FullCase)
+		}
+		Expect(f).To(c.FuncCase)
+	},
+
+	Entry("a valid address", MustParseFullCase{
+		Input:    "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+		FullCase: BeNil(),
+		FuncCase: Panic(),
+	}),
+	Entry("a corrupted address", MustParseFullCase{
+		Input:    "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7O32H",
+		FullCase: BeNil(),
+		FuncCase: Panic(),
+	}),
+	Entry("a valid seed", MustParseFullCase{
+		Input:    "SDHOAMBNLGCE2MV5ZKIVZAQD3VCLGP53P3OBSBI6UN5L5XZI5TKHFQL4",
+		FullCase: Equal(&Full{seed: "SDHOAMBNLGCE2MV5ZKIVZAQD3VCLGP53P3OBSBI6UN5L5XZI5TKHFQL4"}),
+		FuncCase: Not(Panic()),
+	}),
+	Entry("a corrupted seed", MustParseFullCase{
+		Input:    "SDHOAMBNLGCE2MV5ZKIVZAQD3VCLGP53P3OBSBI6UN5L5XZI5TKHFQL3",
+		FullCase: BeNil(),
+		FuncCase: Panic(),
+	}),
+	Entry("a blank string", MustParseFullCase{
+		Input:    "",
+		FullCase: BeNil(),
+		FuncCase: Panic(),
+	}),
+)
+
 type ParseAddressCase struct {
 	Input       string
 	AddressCase types.GomegaMatcher
@@ -194,6 +236,44 @@ var _ = DescribeTable("keypair.ParseAddress()",
 		Input:       "",
 		AddressCase: BeNil(),
 		ErrCase:     HaveOccurred(),
+	}),
+)
+
+type MustParseAddressCase struct {
+	Input       string
+	AddressCase types.GomegaMatcher
+	FuncCase    types.GomegaMatcher
+}
+
+var _ = DescribeTable("keypair.MustParseAddress()",
+	func(c MustParseAddressCase) {
+		f := func() {
+			kp := MustParseAddress(c.Input)
+			Expect(kp).To(c.AddressCase)
+		}
+		Expect(f).To(c.FuncCase)
+	},
+
+	Entry("a valid address", MustParseAddressCase{
+		Input:       "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+		AddressCase: Equal(&FromAddress{address: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"}),
+		FuncCase:    Not(Panic()),
+	}),
+	Entry("a corrupted address", MustParseAddressCase{
+		Input:    "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7O32H",
+		FuncCase: Panic(),
+	}),
+	Entry("a valid seed", MustParseAddressCase{
+		Input:    "SDHOAMBNLGCE2MV5ZKIVZAQD3VCLGP53P3OBSBI6UN5L5XZI5TKHFQL4",
+		FuncCase: Panic(),
+	}),
+	Entry("a corrupted seed", MustParseAddressCase{
+		Input:    "SDHOAMBNLGCE2MV5ZKIVZAQD3VCLGP53P3OBSBI6UN5L5XZI5TKHFQL3",
+		FuncCase: Panic(),
+	}),
+	Entry("a blank string", MustParseAddressCase{
+		Input:    "",
+		FuncCase: Panic(),
 	}),
 )
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Add MustParseAddress and MustParseFull functions that are the
panic-on-fail versions of ParseAddress and ParseFull.

### Why
It is useful to be able to use functions that do not return an error,
especially in tests when we are often parsing constant strings that we
know are valid and where a panic would very okay. It keeps tests more
succinct so that error conditions that won't happen are not noise.

I hope to use these functions in tests I am writing outside this package.

### Known limitations

N/A
