### PR TITLE
services/horizon/expingest: Fix Signers processor performace

### DIFF
--- a/services/horizon/internal/expingest/processors/signer_processor_test.go
+++ b/services/horizon/internal/expingest/processors/signer_processor_test.go
@@ -152,6 +152,32 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewAccount() {
 	s.Assert().NoError(s.processor.Commit())
 }
 
+func (s *AccountsSignerProcessorTestSuiteLedger) TestNoUpdatesWhenNoSignerChanges() {
+	err := s.processor.ProcessChange(io.Change{
+		Type: xdr.LedgerEntryTypeAccount,
+		Pre: &xdr.LedgerEntry{
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeAccount,
+				Account: &xdr.AccountEntry{
+					AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+					Thresholds: [4]byte{1, 1, 1, 1},
+				},
+			},
+		},
+		Post: &xdr.LedgerEntry{
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeAccount,
+				Account: &xdr.AccountEntry{
+					AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+					Thresholds: [4]byte{1, 1, 1, 1},
+				},
+			},
+		},
+	})
+	s.Assert().NoError(err)
+	s.Assert().NoError(s.processor.Commit())
+}
+
 func (s *AccountsSignerProcessorTestSuiteLedger) TestNewSigner() {
 	// Remove old signer
 	s.mockQ.

--- a/services/horizon/internal/expingest/processors/signers_processor.go
+++ b/services/horizon/internal/expingest/processors/signers_processor.go
@@ -82,6 +82,10 @@ func (p *SignersProcessor) Commit() error {
 
 	changes := p.cache.GetChanges()
 	for _, change := range changes {
+		if !change.AccountSignersChanged() {
+			continue
+		}
+
 		// The code below removes all Pre signers adds Post signers but
 		// can be improved by finding a diff (check performance first).
 		if change.Pre != nil {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit fixes performance issue in `Signers` processor.

### Why

While refactoring state processors #2176 I omitted the condition to check if signers on account have actually changed before updating a database. Without it, the signers table is updated every time there is any kind of change to account entry (ex. balance changed due to payment). This affected the performance of the ingestion for ledgers with many XLM payments between accounts.