### PR TITLE
services/horizon/internal/expingest: Refactor ingestion system to use explicit FSM

### DIFF
--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -1,0 +1,715 @@
+package expingest
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/stellar/go/services/horizon/internal/toid"
+	"github.com/stellar/go/support/errors"
+	logpkg "github.com/stellar/go/support/log"
+)
+
+type stateMachineNode interface {
+	run(*System) (transition, error)
+	String() string
+}
+
+type transition struct {
+	node          stateMachineNode
+	sleepDuration time.Duration
+}
+
+var defaultSleep = time.Second
+
+func stop() transition {
+	return transition{node: stopState{}, sleepDuration: 0}
+}
+
+func start() transition {
+	return transition{node: startState{}, sleepDuration: defaultSleep}
+}
+
+func rebuild(checkpointLedger uint32) transition {
+	return transition{
+		node: buildState{
+			checkpointLedger: checkpointLedger,
+		},
+		sleepDuration: defaultSleep,
+	}
+}
+
+func resume(latestSuccessfullyProcessedLedger uint32) transition {
+	return transition{
+		node: resumeState{
+			latestSuccessfullyProcessedLedger: latestSuccessfullyProcessedLedger,
+		},
+		sleepDuration: defaultSleep,
+	}
+}
+
+func resumeImmediately(latestSuccessfullyProcessedLedger uint32) transition {
+	return transition{
+		node: resumeState{
+			latestSuccessfullyProcessedLedger: latestSuccessfullyProcessedLedger,
+		},
+		sleepDuration: 0,
+	}
+}
+
+func retryResume(r resumeState) transition {
+	return transition{
+		node:          r,
+		sleepDuration: defaultSleep,
+	}
+}
+
+func historyRange(fromLedger, toLedger uint32) transition {
+	return transition{
+		node: historyRangeState{
+			fromLedger: fromLedger,
+			toLedger:   toLedger,
+		},
+		sleepDuration: defaultSleep,
+	}
+}
+
+func waitForCheckPoint() transition {
+	return transition{
+		node:          waitForCheckpointState{},
+		sleepDuration: 0,
+	}
+}
+
+type stopState struct{}
+
+func (stopState) String() string {
+	return "stop"
+}
+
+func (stopState) run(s *System) (transition, error) {
+	return stop(), errors.New("Cannot run terminal state")
+}
+
+type startState struct{}
+
+func (startState) String() string {
+	return "start"
+}
+
+func (startState) run(s *System) (transition, error) {
+	if err := s.historyQ.Begin(); err != nil {
+		return start(), errors.Wrap(err, "Error starting a transaction")
+	}
+	defer s.historyQ.Rollback()
+
+	// This will get the value `FOR UPDATE`, blocking it for other nodes.
+	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
+	if err != nil {
+		return start(), errors.Wrap(err, getLastIngestedErrMsg)
+	}
+
+	ingestVersion, err := s.historyQ.GetExpIngestVersion()
+	if err != nil {
+		return start(), errors.Wrap(err, getExpIngestVersionErrMsg)
+	}
+
+	if ingestVersion > CurrentVersion {
+		log.WithFields(logpkg.F{
+			"ingestVersion":  ingestVersion,
+			"currentVersion": CurrentVersion,
+		}).Info("ingestion version in db is greater than current version, going to terminate")
+		return stop(), nil
+	}
+
+	lastHistoryLedger, err := s.historyQ.GetLatestLedger()
+	if err != nil {
+		return start(), errors.Wrap(err, "Error getting last history ledger sequence")
+	}
+
+	if ingestVersion != CurrentVersion || lastIngestedLedger == 0 {
+		// This block is either starting from empty state or ingestion
+		// version upgrade.
+		// This will always run on a single instance due to the fact that
+		// `LastLedgerExpIngest` value is blocked for update and will always
+		// be updated when leading instance finishes processing state.
+		// In case of errors it will start `Init` from the beginning.
+		var lastCheckpoint uint32
+		lastCheckpoint, err = s.historyAdapter.GetLatestLedgerSequence()
+		if err != nil {
+			return start(), errors.Wrap(err, "Error getting last checkpoint")
+		}
+
+		if lastHistoryLedger != 0 {
+			// There are ledgers in history_ledgers table. This means that the
+			// old or new ingest system was running prior the upgrade. In both
+			// cases we need to:
+			// * Wait for the checkpoint ledger if the latest history ledger is
+			//   greater that the latest checkpoint ledger.
+			// * Catchup history data if the latest history ledger is less than
+			//   the latest checkpoint ledger.
+			// * Build state from the last checkpoint if the latest history ledger
+			//   is equal to the latest checkpoint ledger.
+			switch {
+			case lastHistoryLedger > lastCheckpoint:
+				return waitForCheckPoint(), nil
+			case lastHistoryLedger < lastCheckpoint:
+				return historyRange(lastHistoryLedger+1, lastCheckpoint), nil
+			default: // lastHistoryLedger == lastCheckpoint
+				// Build state but make sure it's using `lastCheckpoint`. It's possible
+				// that the new checkpoint will be created during state transition.
+				return rebuild(lastCheckpoint), nil
+			}
+		}
+
+		return rebuild(lastCheckpoint), nil
+	}
+
+	switch {
+	case lastHistoryLedger > lastIngestedLedger:
+		// Expingest was running at some point the past but was turned off.
+		// Now it's on by default but the latest history ledger is greater
+		// than the latest expingest ledger. We reset the exp ledger sequence
+		// so init state will rebuild the state correctly.
+		err = s.historyQ.UpdateLastLedgerExpIngest(0)
+		if err != nil {
+			return start(), errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
+		}
+		err = s.historyQ.Commit()
+		if err != nil {
+			return start(), errors.Wrap(err, commitErrMsg)
+		}
+		return start(), nil
+	// lastHistoryLedger != 0 check is here to check the case when one node ingested
+	// the state (so latest exp ingest is > 0) but no history has been ingested yet.
+	// In such case we execute default case and resume from the last ingested
+	// ledger.
+	case lastHistoryLedger != 0 && lastHistoryLedger < lastIngestedLedger:
+		// Expingest was running at some point the past but was turned off.
+		// Now it's on by default but the latest history ledger is less
+		// than the latest expingest ledger. We catchup history.
+		return historyRange(lastHistoryLedger+1, lastIngestedLedger), nil
+	default: // lastHistoryLedger == lastIngestedLedger
+		// The other node already ingested a state (just now or in the past)
+		// so we need to get offers from a DB, then resume session normally.
+		// State pipeline is NOT processed.
+		log.WithField("last_ledger", lastIngestedLedger).
+			Info("Resuming ingestion system from last processed ledger...")
+
+		if err = s.loadOffersIntoMemory(lastIngestedLedger); err != nil {
+			return start(), errors.Wrap(err, "Error loading offers into in memory graph")
+		}
+
+		return resume(lastIngestedLedger), nil
+	}
+}
+
+type buildState struct {
+	checkpointLedger uint32
+}
+
+func (b buildState) String() string {
+	return fmt.Sprintf("buildFromCheckpoint(checkpointLedger=%d)", b.checkpointLedger)
+}
+
+func (b buildState) run(s *System) (transition, error) {
+	if b.checkpointLedger == 0 {
+		return start(), errors.New("unexpected checkpointLedger value")
+	}
+
+	if err := s.historyQ.Begin(); err != nil {
+		return start(), errors.Wrap(err, "Error starting a transaction")
+	}
+	defer s.historyQ.Rollback()
+	defer s.graph.Discard()
+
+	// We need to get this value `FOR UPDATE` so all other instances
+	// are blocked.
+	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
+	if err != nil {
+		return start(), errors.Wrap(err, getLastIngestedErrMsg)
+	}
+
+	ingestVersion, err := s.historyQ.GetExpIngestVersion()
+	if err != nil {
+		return start(), errors.Wrap(err, getExpIngestVersionErrMsg)
+	}
+
+	// Double check if we should proceed with state ingestion. It's possible that
+	// another ingesting instance will be redirected to this state from `init`
+	// but it's first to complete the task.
+	if ingestVersion == CurrentVersion && lastIngestedLedger > 0 {
+		log.Info("Another instance completed `buildState`. Skipping...")
+		return start(), nil
+	}
+
+	if err = s.updateCursor(b.checkpointLedger - 1); err != nil {
+		// Don't return updateCursor error.
+		log.WithError(err).Warn("error updating stellar-core cursor")
+	}
+
+	log.Info("Starting ingestion system from empty state...")
+
+	// Clear last_ingested_ledger in key value store
+	err = s.historyQ.UpdateLastLedgerExpIngest(0)
+	if err != nil {
+		return start(), errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
+	}
+
+	// Clear invalid state in key value store. It's possible that upgraded
+	// ingestion is fixing it.
+	err = s.historyQ.UpdateExpStateInvalid(false)
+	if err != nil {
+		return start(), errors.Wrap(err, updateExpStateInvalidErrMsg)
+	}
+
+	// State tables should be empty.
+	err = s.historyQ.TruncateExpingestStateTables()
+	if err != nil {
+		return start(), errors.Wrap(err, "Error clearing ingest tables")
+	}
+
+	// Graph should be empty.
+	s.graph.Clear()
+
+	log.WithFields(logpkg.F{
+		"ledger": b.checkpointLedger,
+	}).Info("Processing state")
+	startTime := time.Now()
+
+	err = s.runner.RunHistoryArchiveIngestion(b.checkpointLedger)
+	if err != nil {
+		return start(), errors.Wrap(err, "Error ingesting history archive")
+	}
+
+	if err = s.historyQ.UpdateLastLedgerExpIngest(b.checkpointLedger); err != nil {
+		return start(), errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
+	}
+
+	if err = s.historyQ.UpdateExpIngestVersion(CurrentVersion); err != nil {
+		return start(), errors.Wrap(err, "Error updating expingest version")
+	}
+
+	err = s.historyQ.Commit()
+	if err != nil {
+		return start(), errors.Wrap(err, commitErrMsg)
+	}
+
+	err = s.graph.Apply(b.checkpointLedger)
+	if err != nil {
+		return start(), errors.Wrap(err, "Error applying order book changes")
+	}
+
+	log.WithFields(logpkg.F{
+		"ledger":   b.checkpointLedger,
+		"duration": time.Since(startTime).Seconds(),
+	}).Info("Processed state")
+
+	// If successful, continue from the next ledger
+	return resume(b.checkpointLedger), nil
+}
+
+type resumeState struct {
+	latestSuccessfullyProcessedLedger uint32
+}
+
+func (r resumeState) String() string {
+	return fmt.Sprintf("resume(latestSuccessfullyProcessedLedger=%d)", r.latestSuccessfullyProcessedLedger)
+}
+
+func (r resumeState) run(s *System) (transition, error) {
+	if r.latestSuccessfullyProcessedLedger == 0 {
+		return start(), errors.New("unexpected latestSuccessfullyProcessedLedger value")
+	}
+
+	if err := s.historyQ.Begin(); err != nil {
+		return retryResume(r),
+			errors.Wrap(err, "Error starting a transaction")
+	}
+	defer s.historyQ.Rollback()
+	defer s.graph.Discard()
+
+	// This will get the value `FOR UPDATE`, blocking it for other nodes.
+	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
+	if err != nil {
+		return retryResume(r), errors.Wrap(err, getLastIngestedErrMsg)
+	}
+
+	ingestLedger := r.latestSuccessfullyProcessedLedger + 1
+
+	if ingestLedger > lastIngestedLedger+1 {
+		return start(), errors.New("expected ingest ledger to be at most one greater " +
+			"than last ingested ledger in db")
+	}
+
+	ingestVersion, err := s.historyQ.GetExpIngestVersion()
+	if err != nil {
+		return retryResume(r), errors.Wrap(err, getExpIngestVersionErrMsg)
+	}
+
+	if ingestVersion != CurrentVersion {
+		log.WithFields(logpkg.F{
+			"ingestVersion":  ingestVersion,
+			"currentVersion": CurrentVersion,
+		}).Info("ingestion version in db is not current, going back to start state")
+		return start(), nil
+	}
+
+	lastHistoryLedger, err := s.historyQ.GetLatestLedger()
+	if err != nil {
+		return retryResume(r), errors.Wrap(err, "could not get latest history ledger")
+	}
+
+	if lastHistoryLedger != 0 && lastHistoryLedger != lastIngestedLedger {
+		log.WithFields(logpkg.F{
+			"lastHistoryLedger":  lastHistoryLedger,
+			"lastIngestedLedger": lastIngestedLedger,
+		}).Info(
+			"last history ledger does not match last ingested ledger, " +
+				"going back to start state",
+		)
+		return start(), nil
+	}
+
+	// Check if ledger is closed
+	latestLedgerCore, err := s.ledgerBackend.GetLatestLedgerSequence()
+	if err != nil {
+		return retryResume(r), errors.Wrap(err, "Error getting lastest ledger in stellar-core")
+	}
+
+	if latestLedgerCore < ingestLedger {
+		// Go to the next state, machine will wait for 1s. before continuing.
+		return retryResume(r), nil
+	}
+
+	startTime := time.Now()
+
+	if ingestLedger <= lastIngestedLedger {
+		// rollback because we will not be updating the DB
+		// so there is no need to hold on to the distributed lock
+		// and thereby block the other nodes from ingesting
+		if err = s.historyQ.Rollback(); err != nil {
+			return retryResume(r), errors.Wrap(err, "Error rolling back transaction")
+		}
+
+		log.WithFields(logpkg.F{
+			"sequence": ingestLedger,
+			"state":    false,
+			"ledger":   false,
+			"graph":    true,
+			"commit":   false,
+		}).Info("Processing ledger")
+
+		err = s.runner.RunOrderBookProcessorOnLedger(ingestLedger)
+		if err != nil {
+			return retryResume(r), errors.Wrap(err, "Error running change processor on ledger")
+
+		}
+
+		if err = s.graph.Apply(ingestLedger); err != nil {
+			return retryResume(r), errors.Wrap(err, "Error applying graph changes from ledger")
+		}
+
+		log.WithFields(logpkg.F{
+			"sequence": ingestLedger,
+			"duration": time.Since(startTime).Seconds(),
+			"state":    false,
+			"ledger":   false,
+			"graph":    true,
+			"commit":   false,
+		}).Info("Processed ledger")
+
+		return resumeImmediately(ingestLedger), nil
+	}
+
+	log.WithFields(logpkg.F{
+		"sequence": ingestLedger,
+		"state":    true,
+		"ledger":   true,
+		"graph":    true,
+		"commit":   true,
+	}).Info("Processing ledger")
+
+	err = s.runner.RunAllProcessorsOnLedger(ingestLedger)
+	if err != nil {
+		return retryResume(r), errors.Wrap(err, "Error running processors on ledger")
+	}
+
+	err = s.historyQ.UpdateLastLedgerExpIngest(ingestLedger)
+	if err != nil {
+		return retryResume(r), errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
+	}
+
+	if err = s.graph.Apply(ingestLedger); err != nil {
+		return retryResume(r), errors.Wrap(err, "Error applying graph changes from ledger")
+	}
+
+	if err = s.historyQ.Commit(); err != nil {
+		return retryResume(r), errors.Wrap(err, commitErrMsg)
+	}
+
+	if err = s.updateCursor(ingestLedger); err != nil {
+		// Don't return updateCursor error.
+		log.WithError(err).Warn("error updating stellar-core cursor")
+	}
+
+	log.WithFields(logpkg.F{
+		"sequence": ingestLedger,
+		"duration": time.Since(startTime).Seconds(),
+		"state":    true,
+		"ledger":   true,
+		"graph":    true,
+		"commit":   true,
+	}).Info("Processed ledger")
+
+	s.maybeVerifyState(ingestLedger)
+
+	return resumeImmediately(ingestLedger), nil
+}
+
+type historyRangeState struct {
+	fromLedger       uint32
+	toLedger         uint32
+	shutdownWhenDone bool
+	clearHistory     bool
+}
+
+func (h historyRangeState) String() string {
+	return fmt.Sprintf(
+		"historyRange(fromLedger=%d, toLedger=%d, shutdownWhenDone=%t, clearHistory=%t)",
+		h.fromLedger,
+		h.toLedger,
+		h.shutdownWhenDone,
+		h.clearHistory,
+	)
+}
+
+// historyRangeState is used when catching up history data and when reingesting
+// range.
+func (h historyRangeState) run(s *System) (transition, error) {
+	next := start()
+	validateStartLedger := true
+	// unless we're running the horizon reingest range command we should
+	// always check that the start ledger is equal to the last ledger
+	// in the db plus one
+	if h.shutdownWhenDone {
+		// Shutdown when done - used in `reingest range` command.
+		next = stop()
+		validateStartLedger = false
+	}
+
+	if h.fromLedger == 0 || h.toLedger == 0 ||
+		h.fromLedger > h.toLedger {
+		return next, errors.Errorf("invalid range: [%d, %d]", h.fromLedger, h.toLedger)
+	}
+
+	if err := s.historyQ.Begin(); err != nil {
+		return next, errors.Wrap(err, "Error starting a transaction")
+	}
+	defer s.historyQ.Rollback()
+
+	// acquire distributed lock so no one else can perform ingestion operations.
+	if _, err := s.historyQ.GetLastLedgerExpIngest(); err != nil {
+		return next, errors.Wrap(err, getLastIngestedErrMsg)
+	}
+
+	if h.clearHistory {
+		// Clear history data before ingesting - used in `reingest range` command.
+		start, end, err := toid.LedgerRangeInclusive(
+			int32(h.fromLedger),
+			int32(h.toLedger),
+		)
+
+		if err != nil {
+			return next, errors.Wrap(err, "Invalid range")
+		}
+
+		err = s.historyQ.DeleteRangeAll(start, end)
+		if err != nil {
+			return next, errors.Wrap(err, "error in DeleteRangeAll")
+		}
+	}
+
+	if validateStartLedger {
+		lastHistoryLedger, err := s.historyQ.GetLatestLedger()
+		if err != nil {
+			return next, errors.Wrap(err, "could not get latest history ledger")
+		}
+
+		// We should be ingesting the ledger which occurs after
+		// lastHistoryLedger. Otherwise, some other horizon node has
+		// already completed the ingest history range operation and
+		// we should go back to the init state
+		if lastHistoryLedger != h.fromLedger-1 {
+			return next, nil
+		}
+	}
+
+	for cur := h.fromLedger; cur <= h.toLedger; cur++ {
+		log.WithFields(logpkg.F{
+			"sequence": cur,
+			"state":    false,
+			"ledger":   true,
+			"graph":    false,
+			"commit":   false,
+		}).Info("Processing ledger")
+		startTime := time.Now()
+
+		if err := s.runner.RunTransactionProcessorsOnLedger(cur); err != nil {
+			return next,
+				errors.Wrap(err, fmt.Sprintf("error processing ledger sequence=%d", cur))
+		}
+
+		log.WithFields(logpkg.F{
+			"sequence": cur,
+			"duration": time.Since(startTime).Seconds(),
+			"state":    false,
+			"ledger":   true,
+			"graph":    false,
+			"commit":   false,
+		}).Info("Processed ledger")
+	}
+
+	if err := s.historyQ.Commit(); err != nil {
+		return next, errors.Wrap(err, commitErrMsg)
+	}
+
+	return next, nil
+}
+
+type waitForCheckpointState struct{}
+
+func (waitForCheckpointState) String() string {
+	return "waitForCheckpoint"
+}
+
+func (waitForCheckpointState) run(*System) (transition, error) {
+	log.Info("Waiting for the next checkpoint...")
+	time.Sleep(10 * time.Second)
+	return start(), nil
+}
+
+type verifyRangeState struct {
+	fromLedger  uint32
+	toLedger    uint32
+	verifyState bool
+}
+
+func (v verifyRangeState) String() string {
+	return fmt.Sprintf(
+		"verifyRange(fromLedger=%d, toLedger=%d, verifyState=%t)",
+		v.fromLedger,
+		v.toLedger,
+		v.verifyState,
+	)
+}
+
+func (v verifyRangeState) run(s *System) (transition, error) {
+	if v.fromLedger == 0 || v.toLedger == 0 ||
+		v.fromLedger > v.toLedger {
+		return stop(), errors.Errorf("invalid range: [%d, %d]", v.fromLedger, v.toLedger)
+	}
+
+	if err := s.historyQ.Begin(); err != nil {
+		err = errors.Wrap(err, "Error starting a transaction")
+		return stop(), err
+	}
+	defer s.historyQ.Rollback()
+	defer s.graph.Discard()
+
+	// Simple check if DB clean
+	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
+	if err != nil {
+		err = errors.Wrap(err, getLastIngestedErrMsg)
+		return stop(), err
+	}
+
+	if lastIngestedLedger != 0 {
+		err = errors.New("Database not empty")
+		return stop(), err
+	}
+
+	log.WithFields(logpkg.F{
+		"ledger": v.fromLedger,
+	}).Info("Processing state")
+	startTime := time.Now()
+
+	err = s.runner.RunHistoryArchiveIngestion(v.fromLedger)
+	if err != nil {
+		err = errors.Wrap(err, "Error ingesting history archive")
+		return stop(), err
+	}
+
+	err = s.historyQ.UpdateLastLedgerExpIngest(v.fromLedger)
+	if err != nil {
+		err = errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
+		return stop(), err
+	}
+
+	if err = s.historyQ.Commit(); err != nil {
+		err = errors.Wrap(err, commitErrMsg)
+		return stop(), err
+	}
+
+	err = s.graph.Apply(v.fromLedger)
+	if err != nil {
+		err = errors.Wrap(err, "Error applying order book changes")
+		return stop(), err
+	}
+
+	log.WithFields(logpkg.F{
+		"ledger":   v.fromLedger,
+		"duration": time.Since(startTime).Seconds(),
+	}).Info("Processed state")
+
+	for sequence := v.fromLedger + 1; sequence <= v.toLedger; sequence++ {
+		log.WithFields(logpkg.F{
+			"sequence": sequence,
+			"state":    true,
+			"ledger":   true,
+			"graph":    true,
+			"commit":   true,
+		}).Info("Processing ledger")
+		startTime := time.Now()
+
+		if err = s.historyQ.Begin(); err != nil {
+			err = errors.Wrap(err, "Error starting a transaction")
+			return stop(), err
+		}
+
+		err = s.runner.RunAllProcessorsOnLedger(sequence)
+		if err != nil {
+			err = errors.Wrap(err, "Error running processors on ledger")
+			return stop(), err
+		}
+
+		err = s.historyQ.UpdateLastLedgerExpIngest(sequence)
+		if err != nil {
+			err = errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
+			return stop(), err
+		}
+
+		if err = s.graph.Apply(sequence); err != nil {
+			err = errors.Wrap(err, "Error applying graph history archive changes")
+			return stop(), err
+		}
+
+		if err = s.historyQ.Commit(); err != nil {
+			return stop(), errors.Wrap(err, commitErrMsg)
+		}
+
+		log.WithFields(logpkg.F{
+			"sequence": sequence,
+			"duration": time.Since(startTime).Seconds(),
+			"state":    true,
+			"ledger":   true,
+			"graph":    true,
+			"commit":   true,
+		}).Info("Processed ledger")
+	}
+
+	if v.verifyState {
+		err = s.verifyState(s.graph.OffersMap(), false)
+	}
+
+	return stop(), err
+}

--- a/services/horizon/internal/expingest/ingest_history_range_state_test.go
+++ b/services/horizon/internal/expingest/ingest_history_range_state_test.go
@@ -27,18 +27,12 @@ func (s *IngestHistoryRangeStateTestSuite) SetupTest() {
 	s.historyAdapter = &adapters.MockHistoryArchiveAdapter{}
 	s.runner = &mockProcessorsRunner{}
 	s.system = &System{
-		ctx: context.Background(),
-		state: state{
-			systemState: ingestHistoryRangeState,
-		},
+		ctx:            context.Background(),
 		historyQ:       s.historyQ,
 		historyAdapter: s.historyAdapter,
 		runner:         s.runner,
 	}
 
-	s.Assert().Equal(ingestHistoryRangeState, s.system.state.systemState)
-	// Checking if in tx in runCurrentState()
-	s.historyQ.On("GetTx").Return(nil).Once()
 	s.historyQ.On("Rollback").Return(nil).Once()
 }
 
@@ -52,114 +46,86 @@ func (s *IngestHistoryRangeStateTestSuite) TearDownTest() {
 func (s *IngestHistoryRangeStateTestSuite) TestInvalidRange() {
 	// Recreate mock in this single test to remove Rollback assertion.
 	*s.historyQ = mockDBQ{}
-	s.historyQ.On("GetTx").Return(nil).Maybe()
 
-	s.system.state.rangeFromLedger = 0
-	s.system.state.rangeToLedger = 0
-	nextState, err := s.system.runCurrentState()
+	next, err := historyRangeState{fromLedger: 0, toLedger: 0}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "invalid range: [0, 0]")
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 
-	s.system.state.rangeFromLedger = 0
-	s.system.state.rangeToLedger = 100
-	nextState, err = s.system.runCurrentState()
+	next, err = historyRangeState{fromLedger: 0, toLedger: 100}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "invalid range: [0, 100]")
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 
-	s.system.state.rangeFromLedger = 100
-	s.system.state.rangeToLedger = 0
-	nextState, err = s.system.runCurrentState()
+	next, err = historyRangeState{fromLedger: 100, toLedger: 0}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "invalid range: [100, 0]")
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 
-	s.system.state.rangeFromLedger = 100
-	s.system.state.rangeToLedger = 99
-	nextState, err = s.system.runCurrentState()
+	next, err = historyRangeState{fromLedger: 100, toLedger: 99}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "invalid range: [100, 99]")
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
 func (s *IngestHistoryRangeStateTestSuite) TestBeginReturnsError() {
-	s.system.state.rangeFromLedger = 100
-	s.system.state.rangeToLedger = 200
-
 	// Recreate mock in this single test to remove Rollback assertion.
 	*s.historyQ = mockDBQ{}
-	s.historyQ.On("GetTx").Return(nil).Once()
 	s.historyQ.On("Begin").Return(errors.New("my error")).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := historyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "Error starting a transaction: my error")
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
 func (s *IngestHistoryRangeStateTestSuite) TestGetLastLedgerExpIngestReturnsError() {
-	s.system.state.rangeFromLedger = 100
-	s.system.state.rangeToLedger = 200
-
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), errors.New("my error")).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := historyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "Error getting last ingested ledger: my error")
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
 func (s *IngestHistoryRangeStateTestSuite) TestGetLatestLedgerReturnsError() {
-	s.system.state.rangeFromLedger = 100
-	s.system.state.rangeToLedger = 200
-
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), errors.New("my error")).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := historyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "could not get latest history ledger: my error")
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
 // TestAnotherNodeIngested tests the case when another node has ingested the range.
 // In such case we go back to `init` state without processing.
 func (s *IngestHistoryRangeStateTestSuite) TestAnotherNodeIngested() {
-	s.system.state.rangeFromLedger = 100
-	s.system.state.rangeToLedger = 200
-
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(200), nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := historyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
 func (s *IngestHistoryRangeStateTestSuite) TestRunTransactionProcessorsOnLedgerReturnsError() {
-	s.system.state.rangeFromLedger = 100
-	s.system.state.rangeToLedger = 200
-
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
 	s.runner.On("RunTransactionProcessorsOnLedger", uint32(100)).Return(errors.New("my error")).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := historyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "error processing ledger sequence=100: my error")
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
 func (s *IngestHistoryRangeStateTestSuite) TestSuccess() {
-	s.system.state.rangeFromLedger = 100
-	s.system.state.rangeToLedger = 200
-
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
@@ -170,15 +136,12 @@ func (s *IngestHistoryRangeStateTestSuite) TestSuccess() {
 
 	s.historyQ.On("Commit").Return(nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := historyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
 func (s *IngestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
-	s.system.state.rangeFromLedger = 100
-	s.system.state.rangeToLedger = 100
-
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
@@ -187,17 +150,13 @@ func (s *IngestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
 
 	s.historyQ.On("Commit").Return(nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := historyRangeState{fromLedger: 100, toLedger: 100}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
 // TestClearHistorySuccess tests clearing history before ingesting history range.
 func (s *IngestHistoryRangeStateTestSuite) TestClearHistorySuccess() {
-	s.system.state.rangeFromLedger = 100
-	s.system.state.rangeToLedger = 200
-	s.system.state.rangeClearHistory = true
-
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
@@ -222,16 +181,14 @@ func (s *IngestHistoryRangeStateTestSuite) TestClearHistorySuccess() {
 
 	s.historyQ.On("Commit").Return(nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := historyRangeState{
+		fromLedger: 100, toLedger: 200, shutdownWhenDone: false, clearHistory: true,
+	}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
 func (s *IngestHistoryRangeStateTestSuite) TestShutdownWhenDoneSuccess() {
-	s.system.state.rangeFromLedger = 100
-	s.system.state.rangeToLedger = 200
-	s.system.state.shutdownWhenDone = true
-
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 
@@ -241,16 +198,14 @@ func (s *IngestHistoryRangeStateTestSuite) TestShutdownWhenDoneSuccess() {
 
 	s.historyQ.On("Commit").Return(nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := historyRangeState{
+		fromLedger: 100, toLedger: 200, shutdownWhenDone: true,
+	}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(shutdownState, nextState.systemState)
+	s.Assert().Equal(transition{node: stopState{}, sleepDuration: 0}, next)
 }
 
 func (s *IngestHistoryRangeStateTestSuite) TestShutdownWhenDoneWithError() {
-	s.system.state.rangeFromLedger = 100
-	s.system.state.rangeToLedger = 200
-	s.system.state.shutdownWhenDone = true
-
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 
@@ -260,8 +215,10 @@ func (s *IngestHistoryRangeStateTestSuite) TestShutdownWhenDoneWithError() {
 
 	s.historyQ.On("Commit").Return(errors.New("my error")).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := historyRangeState{
+		fromLedger: 100, toLedger: 200, shutdownWhenDone: true,
+	}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "Error committing db transaction: my error")
-	s.Assert().Equal(shutdownState, nextState.systemState)
+	s.Assert().Equal(transition{node: stopState{}, sleepDuration: 0}, next)
 }

--- a/services/horizon/internal/expingest/init_state_test.go
+++ b/services/horizon/internal/expingest/init_state_test.go
@@ -2,7 +2,6 @@ package expingest
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stellar/go/exp/ingest/adapters"
@@ -30,15 +29,11 @@ func (s *InitStateTestSuite) SetupTest() {
 	s.historyAdapter = &adapters.MockHistoryArchiveAdapter{}
 	s.system = &System{
 		ctx:            context.Background(),
-		state:          state{systemState: initState},
 		historyQ:       s.historyQ,
 		historyAdapter: s.historyAdapter,
 		graph:          s.graph,
 	}
 
-	s.Assert().Equal(initState, s.system.state.systemState)
-	// Checking if in tx in runCurrentState()
-	s.historyQ.On("GetTx").Return(nil).Once()
 	s.historyQ.On("Rollback").Return(nil).Once()
 }
 
@@ -52,23 +47,22 @@ func (s *InitStateTestSuite) TearDownTest() {
 func (s *InitStateTestSuite) TestBeginReturnsError() {
 	// Recreate mock in this single test to remove Rollback assertion.
 	*s.historyQ = mockDBQ{}
-	s.historyQ.On("GetTx").Return(nil).Once()
 	s.historyQ.On("Begin").Return(errors.New("my error")).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := startState{}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "Error starting a transaction: my error")
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
 func (s *InitStateTestSuite) TestGetLastLedgerExpIngestReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), errors.New("my error")).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := startState{}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "Error getting last ingested ledger: my error")
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
 func (s *InitStateTestSuite) TestGetExpIngestVersionReturnsError() {
@@ -76,10 +70,10 @@ func (s *InitStateTestSuite) TestGetExpIngestVersionReturnsError() {
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetExpIngestVersion").Return(0, errors.New("my error")).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := startState{}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "Error getting exp ingest version: my error")
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
 func (s *InitStateTestSuite) TestCurrentVersionIsOutdated() {
@@ -87,17 +81,9 @@ func (s *InitStateTestSuite) TestCurrentVersionIsOutdated() {
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(1), nil).Once()
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion+1, nil).Once()
 
-	nextState, err := s.system.runCurrentState()
-	s.Assert().Error(err)
-	s.Assert().EqualError(
-		err,
-		fmt.Sprintf(
-			"ingestion version in db %v is greater than current version %v",
-			CurrentVersion+1,
-			CurrentVersion,
-		),
-	)
-	s.Assert().Equal(shutdownState, nextState.systemState)
+	next, err := startState{}.run(s.system)
+	s.Assert().NoError(err)
+	s.Assert().Equal(transition{node: stopState{}, sleepDuration: 0}, next)
 }
 
 func (s *InitStateTestSuite) TestGetLatestLedgerReturnsError() {
@@ -106,10 +92,10 @@ func (s *InitStateTestSuite) TestGetLatestLedgerReturnsError() {
 	s.historyQ.On("GetExpIngestVersion").Return(0, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), errors.New("my error")).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := startState{}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "Error getting last history ledger sequence: my error")
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
 func (s *InitStateTestSuite) TestBuildStateEmptyDatabase() {
@@ -120,10 +106,12 @@ func (s *InitStateTestSuite) TestBuildStateEmptyDatabase() {
 
 	s.historyAdapter.On("GetLatestLedgerSequence").Return(uint32(63), nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := startState{}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(buildStateState, nextState.systemState)
-	s.Assert().Equal(uint32(63), nextState.checkpointLedger)
+	s.Assert().Equal(
+		transition{node: buildState{checkpointLedger: 63}, sleepDuration: defaultSleep},
+		next,
+	)
 }
 
 // TestBuildStateWait is testing the case when:
@@ -137,9 +125,12 @@ func (s *InitStateTestSuite) TestBuildStateWait() {
 
 	s.historyAdapter.On("GetLatestLedgerSequence").Return(uint32(63), nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := startState{}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(waitForCheckpointState, nextState.systemState)
+	s.Assert().Equal(
+		transition{node: waitForCheckpointState{}, sleepDuration: 0},
+		next,
+	)
 }
 
 // TestBuildStateCatchup is testing the case when:
@@ -153,11 +144,15 @@ func (s *InitStateTestSuite) TestBuildStateCatchup() {
 
 	s.historyAdapter.On("GetLatestLedgerSequence").Return(uint32(127), nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := startState{}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(ingestHistoryRangeState, nextState.systemState)
-	s.Assert().Equal(uint32(101), nextState.rangeFromLedger)
-	s.Assert().Equal(uint32(127), nextState.rangeToLedger)
+	s.Assert().Equal(
+		transition{
+			node:          historyRangeState{fromLedger: 101, toLedger: 127},
+			sleepDuration: defaultSleep,
+		},
+		next,
+	)
 }
 
 // TestBuildStateOldHistory is testing the case when:
@@ -171,10 +166,15 @@ func (s *InitStateTestSuite) TestBuildStateOldHistory() {
 
 	s.historyAdapter.On("GetLatestLedgerSequence").Return(uint32(127), nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := startState{}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(buildStateState, nextState.systemState)
-	s.Assert().Equal(uint32(127), nextState.checkpointLedger)
+	s.Assert().Equal(
+		transition{
+			node:          buildState{checkpointLedger: 127},
+			sleepDuration: defaultSleep,
+		},
+		next,
+	)
 }
 
 // TestResumeStateBehind is testing the case when:
@@ -189,9 +189,9 @@ func (s *InitStateTestSuite) TestResumeStateInFront() {
 	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(0)).Return(nil).Once()
 	s.historyQ.On("Commit").Return(nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := startState{}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
 // TestResumeStateBehind is testing the case when:
@@ -203,11 +203,15 @@ func (s *InitStateTestSuite) TestResumeStateBehind() {
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(100), nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := startState{}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(ingestHistoryRangeState, nextState.systemState)
-	s.Assert().Equal(uint32(101), nextState.rangeFromLedger)
-	s.Assert().Equal(uint32(130), nextState.rangeToLedger)
+	s.Assert().Equal(
+		transition{
+			node:          historyRangeState{fromLedger: 101, toLedger: 130},
+			sleepDuration: defaultSleep,
+		},
+		next,
+	)
 }
 
 // TestResumeStateBehindHistory0 is testing the case when:
@@ -276,10 +280,15 @@ func (s *InitStateTestSuite) TestResumeStateBehindHistory0() {
 	s.graph.On("Apply", uint32(130)).Return(nil).Once()
 	s.graph.On("Discard").Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := startState{}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(resumeState, nextState.systemState)
-	s.Assert().Equal(uint32(130), nextState.latestSuccessfullyProcessedLedger)
+	s.Assert().Equal(
+		transition{
+			node:          resumeState{latestSuccessfullyProcessedLedger: 130},
+			sleepDuration: defaultSleep,
+		},
+		next,
+	)
 }
 
 // TestResumeStateBehind is testing the case when:
@@ -347,8 +356,13 @@ func (s *InitStateTestSuite) TestResumeStateSync() {
 	s.graph.On("Apply", uint32(130)).Return(nil).Once()
 	s.graph.On("Discard").Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := startState{}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(resumeState, nextState.systemState)
-	s.Assert().Equal(uint32(130), nextState.latestSuccessfullyProcessedLedger)
+	s.Assert().Equal(
+		transition{
+			node:          resumeState{latestSuccessfullyProcessedLedger: 130},
+			sleepDuration: defaultSleep,
+		},
+		next,
+	)
 }

--- a/services/horizon/internal/expingest/init_state_test.go
+++ b/services/horizon/internal/expingest/init_state_test.go
@@ -2,6 +2,7 @@ package expingest
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stellar/go/exp/ingest/adapters"
@@ -79,6 +80,24 @@ func (s *InitStateTestSuite) TestGetExpIngestVersionReturnsError() {
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "Error getting exp ingest version: my error")
 	s.Assert().Equal(initState, nextState.systemState)
+}
+
+func (s *InitStateTestSuite) TestCurrentVersionIsOutdated() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(1), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion+1, nil).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(
+		err,
+		fmt.Sprintf(
+			"ingestion version in db %v is greater than current version %v",
+			CurrentVersion+1,
+			CurrentVersion,
+		),
+	)
+	s.Assert().Equal(shutdownState, nextState.systemState)
 }
 
 func (s *InitStateTestSuite) TestGetLatestLedgerReturnsError() {

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -5,7 +5,6 @@ package expingest
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/stellar/go/exp/ingest/ledgerbackend"
 	"github.com/stellar/go/exp/orderbook"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/services/horizon/internal/toid"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/historyarchive"
@@ -70,18 +68,6 @@ type Config struct {
 	IngestFailedTransactions bool
 }
 
-type systemState string
-
-const (
-	initState               systemState = "init"
-	ingestHistoryRangeState systemState = "ingestHistoryRange"
-	waitForCheckpointState  systemState = "waitForCheckpoint"
-	buildStateState         systemState = "buildState"
-	resumeState             systemState = "resume"
-	verifyRangeState        systemState = "verifyRange"
-	shutdownState           systemState = "shutdown"
-)
-
 const (
 	getLastIngestedErrMsg           string = "Error getting last ingested ledger"
 	getExpIngestVersionErrMsg       string = "Error getting exp ingest version"
@@ -89,23 +75,6 @@ const (
 	commitErrMsg                    string = "Error committing db transaction"
 	updateExpStateInvalidErrMsg     string = "Error updating state invalid value"
 )
-
-type state struct {
-	systemState                       systemState
-	latestSuccessfullyProcessedLedger uint32
-
-	checkpointLedger uint32
-
-	rangeFromLedger   uint32
-	rangeToLedger     uint32
-	rangeVerifyState  bool
-	rangeClearHistory bool
-
-	shutdownWhenDone bool
-
-	// noSleep informs state machine to not sleep between state transitions
-	noSleep bool
-}
 
 type stellarCoreClient interface {
 	SetCursor(ctx context.Context, id string, cursor int32) error
@@ -116,7 +85,6 @@ type System struct {
 	cancel context.CancelFunc
 
 	config Config
-	state  state
 
 	graph    orderbook.OBGraph
 	historyQ history.IngestionQ
@@ -226,237 +194,75 @@ func NewSystem(config Config) (*System, error) {
 //   * If instances is a NOT leader, it runs ledger pipeline without updating a
 //     a database so order book graph is updated but database is not overwritten.
 func (s *System) Run() {
-	s.state = state{systemState: initState}
-	s.run()
+	s.runStateMachine(startState{})
 }
 
 // VerifyRange runs the ingestion pipeline on the range of ledgers. When
 // verifyState is true it verifies the state when ingestion is complete.
 func (s *System) VerifyRange(fromLedger, toLedger uint32, verifyState bool) error {
-	s.state = state{
-		systemState:      verifyRangeState,
-		rangeFromLedger:  fromLedger,
-		rangeToLedger:    toLedger,
-		rangeVerifyState: verifyState,
-	}
-	return s.run()
+	return s.runStateMachine(verifyRangeState{
+		fromLedger:  fromLedger,
+		toLedger:    toLedger,
+		verifyState: verifyState,
+	})
 }
 
 // ReingestRange runs the ingestion pipeline on the range of ledgers ingesting
 // history data only.
 func (s *System) ReingestRange(fromLedger, toLedger uint32) error {
-	s.state = state{
-		systemState:       ingestHistoryRangeState,
-		rangeFromLedger:   fromLedger,
-		rangeToLedger:     toLedger,
-		rangeClearHistory: true,
-		shutdownWhenDone:  true,
-	}
-	return s.run()
+	return s.runStateMachine(historyRangeState{
+		fromLedger:       fromLedger,
+		toLedger:         fromLedger,
+		shutdownWhenDone: true,
+		clearHistory:     true,
+	})
 }
 
-func (s *System) run() error {
+func (s *System) runStateMachine(cur stateMachineNode) error {
 	defer func() {
 		s.wg.Wait()
 	}()
 
-	log.WithFields(logpkg.F{"current_state": s.state}).Info("Ingestion system initial state")
+	log.WithFields(logpkg.F{"current_state": cur}).Info("Ingestion system initial state")
 
 	for {
-		nextState, err := s.runCurrentState()
-		if err != nil &&
-			errors.Cause(err) != context.Canceled &&
-			errors.Cause(err) != db.ErrCancelled {
+		// Every node in the state machine is responsible for
+		// creating and disposing its own transaction.
+		// We should never enter a new state with the transaction
+		// from the previous state.
+		if s.historyQ.GetTx() != nil {
+			panic("unexpected transaction")
+		}
+
+		next, err := cur.run(s)
+		if cause := errors.Cause(err); cause != nil &&
+			cause != context.Canceled &&
+			cause != db.ErrCancelled {
 			log.WithFields(logpkg.F{
 				"error":         err,
-				"current_state": s.state,
-				"next_state":    nextState,
+				"current_state": cur,
+				"next_state":    next.node,
 			}).Error("Error in ingestion state machine")
 		}
 
 		// Exit after processing shutdownState
-		if nextState.systemState == shutdownState {
+		if next.node == (stopState{}) {
 			log.Info("Shut down")
 			return err
-		}
-
-		sleepDuration := time.Second
-		if nextState.noSleep {
-			sleepDuration = 0
 		}
 
 		select {
 		case <-s.ctx.Done():
 			log.Info("Received shut down signal...")
-			nextState = state{systemState: shutdownState}
 			return nil
-		case <-time.After(sleepDuration):
+		case <-time.After(next.sleepDuration):
 		}
 
 		log.WithFields(logpkg.F{
-			"current_state": s.state,
-			"next_state":    nextState,
+			"current_state": cur,
+			"next_state":    next.node,
 		}).Info("Ingestion system state machine transition")
-
-		s.state = nextState
-	}
-}
-
-func (s *System) runCurrentState() (state, error) {
-	// Every node in the state machine is responsible for
-	// creating and disposing its own transaction.
-	// We should never enter a new state with the transaction
-	// from the previous state.
-	if s.historyQ.GetTx() != nil {
-		panic("unexpected transaction")
-	}
-
-	var nextState state
-	var err error
-
-	switch s.state.systemState {
-	case initState:
-		nextState, err = s.init()
-	case ingestHistoryRangeState:
-		nextState, err = s.ingestHistoryRange()
-	case waitForCheckpointState:
-		nextState, err = s.waitForCheckpoint()
-	case buildStateState:
-		nextState, err = s.buildState()
-	case resumeState:
-		nextState, err = s.resume()
-	case verifyRangeState:
-		nextState, err = s.verifyRange()
-	default:
-		panic(fmt.Sprintf("Unknown state %+v", s.state.systemState))
-	}
-
-	return nextState, err
-}
-
-func (s *System) init() (state, error) {
-	if err := s.historyQ.Begin(); err != nil {
-		return state{systemState: initState}, errors.Wrap(err, "Error starting a transaction")
-	}
-	defer s.historyQ.Rollback()
-
-	// This will get the value `FOR UPDATE`, blocking it for other nodes.
-	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
-	if err != nil {
-		return state{systemState: initState}, errors.Wrap(err, getLastIngestedErrMsg)
-	}
-
-	ingestVersion, err := s.historyQ.GetExpIngestVersion()
-	if err != nil {
-		return state{systemState: initState}, errors.Wrap(err, getExpIngestVersionErrMsg)
-	}
-
-	if ingestVersion > CurrentVersion {
-		return state{systemState: shutdownState},
-			errors.Errorf(
-				"ingestion version in db %v is greater than current version %v",
-				ingestVersion,
-				CurrentVersion,
-			)
-	}
-
-	lastHistoryLedger, err := s.historyQ.GetLatestLedger()
-	if err != nil {
-		return state{systemState: initState}, errors.Wrap(err, "Error getting last history ledger sequence")
-	}
-
-	if ingestVersion != CurrentVersion || lastIngestedLedger == 0 {
-		// This block is either starting from empty state or ingestion
-		// version upgrade.
-		// This will always run on a single instance due to the fact that
-		// `LastLedgerExpIngest` value is blocked for update and will always
-		// be updated when leading instance finishes processing state.
-		// In case of errors it will start `Init` from the beginning.
-		var lastCheckpoint uint32
-		lastCheckpoint, err = s.historyAdapter.GetLatestLedgerSequence()
-		if err != nil {
-			return state{systemState: initState}, errors.Wrap(err, "Error getting last checkpoint")
-		}
-
-		if lastHistoryLedger != 0 {
-			// There are ledgers in history_ledgers table. This means that the
-			// old or new ingest system was running prior the upgrade. In both
-			// cases we need to:
-			// * Wait for the checkpoint ledger if the latest history ledger is
-			//   greater that the latest checkpoint ledger.
-			// * Catchup history data if the latest history ledger is less than
-			//   the latest checkpoint ledger.
-			// * Build state from the last checkpoint if the latest history ledger
-			//   is equal to the latest checkpoint ledger.
-			switch {
-			case lastHistoryLedger > lastCheckpoint:
-				return state{systemState: waitForCheckpointState}, nil
-			case lastHistoryLedger < lastCheckpoint:
-				return state{
-					systemState:     ingestHistoryRangeState,
-					rangeFromLedger: lastHistoryLedger + 1,
-					rangeToLedger:   lastCheckpoint,
-				}, nil
-			default: // lastHistoryLedger == lastCheckpoint
-				// Build state but make sure it's using `lastCheckpoint`. It's possible
-				// that the new checkpoint will be created during state transition.
-				return state{
-					systemState:      buildStateState,
-					checkpointLedger: lastCheckpoint,
-				}, nil
-			}
-		}
-
-		return state{
-			systemState:      buildStateState,
-			checkpointLedger: lastCheckpoint,
-		}, nil
-	}
-
-	switch {
-	case lastHistoryLedger > lastIngestedLedger:
-		// Expingest was running at some point the past but was turned off.
-		// Now it's on by default but the latest history ledger is greater
-		// than the latest expingest ledger. We reset the exp ledger sequence
-		// so init state will rebuild the state correctly.
-		err = s.historyQ.UpdateLastLedgerExpIngest(0)
-		if err != nil {
-			return state{systemState: initState}, errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
-		}
-		err = s.historyQ.Commit()
-		if err != nil {
-			return state{systemState: initState}, errors.Wrap(err, commitErrMsg)
-		}
-		return state{systemState: initState}, nil
-	// lastHistoryLedger != 0 check is here to check the case when one node ingested
-	// the state (so latest exp ingest is > 0) but no history has been ingested yet.
-	// In such case we execute default case and resume from the last ingested
-	// ledger.
-	case lastHistoryLedger != 0 && lastHistoryLedger < lastIngestedLedger:
-		// Expingest was running at some point the past but was turned off.
-		// Now it's on by default but the latest history ledger is less
-		// than the latest expingest ledger. We catchup history.
-		return state{
-			systemState:     ingestHistoryRangeState,
-			rangeFromLedger: lastHistoryLedger + 1,
-			rangeToLedger:   lastIngestedLedger,
-		}, nil
-	default: // lastHistoryLedger == lastIngestedLedger
-		// The other node already ingested a state (just now or in the past)
-		// so we need to get offers from a DB, then resume session normally.
-		// State pipeline is NOT processed.
-		log.WithField("last_ledger", lastIngestedLedger).
-			Info("Resuming ingestion system from last processed ledger...")
-
-		if err = s.loadOffersIntoMemory(lastIngestedLedger); err != nil {
-			return state{systemState: initState},
-				errors.Wrap(err, "Error loading offers into in memory graph")
-		}
-
-		return state{
-			systemState:                       resumeState,
-			latestSuccessfullyProcessedLedger: lastIngestedLedger,
-		}, nil
+		cur = next.node
 	}
 }
 
@@ -502,281 +308,6 @@ func (s *System) loadOffersIntoMemory(sequence uint32) error {
 	return nil
 }
 
-func (s *System) buildState() (state, error) {
-	if s.state.checkpointLedger == 0 {
-		return state{systemState: initState}, errors.New("unexpected checkpointLedger value")
-	}
-
-	if err := s.historyQ.Begin(); err != nil {
-		return state{systemState: initState}, errors.Wrap(err, "Error starting a transaction")
-	}
-	defer s.historyQ.Rollback()
-	defer s.graph.Discard()
-
-	// We need to get this value `FOR UPDATE` so all other instances
-	// are blocked.
-	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
-	if err != nil {
-		return state{systemState: initState}, errors.Wrap(err, getLastIngestedErrMsg)
-	}
-
-	ingestVersion, err := s.historyQ.GetExpIngestVersion()
-	if err != nil {
-		return state{systemState: initState}, errors.Wrap(err, getExpIngestVersionErrMsg)
-	}
-
-	// Double check if we should proceed with state ingestion. It's possible that
-	// another ingesting instance will be redirected to this state from `init`
-	// but it's first to complete the task.
-	if ingestVersion == CurrentVersion && lastIngestedLedger > 0 {
-		log.Info("Another instance completed `buildState`. Skipping...")
-		return state{systemState: initState}, nil
-	}
-
-	if err = s.updateCursor(s.state.checkpointLedger - 1); err != nil {
-		// Don't return updateCursor error.
-		log.WithError(err).Warn("error updating stellar-core cursor")
-	}
-
-	log.Info("Starting ingestion system from empty state...")
-
-	// Clear last_ingested_ledger in key value store
-	err = s.historyQ.UpdateLastLedgerExpIngest(0)
-	if err != nil {
-		return state{systemState: initState}, errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
-	}
-
-	// Clear invalid state in key value store. It's possible that upgraded
-	// ingestion is fixing it.
-	err = s.historyQ.UpdateExpStateInvalid(false)
-	if err != nil {
-		return state{systemState: initState}, errors.Wrap(err, updateExpStateInvalidErrMsg)
-	}
-
-	// State tables should be empty.
-	err = s.historyQ.TruncateExpingestStateTables()
-	if err != nil {
-		return state{systemState: initState}, errors.Wrap(err, "Error clearing ingest tables")
-	}
-
-	// Graph should be empty.
-	s.graph.Clear()
-
-	log.WithFields(logpkg.F{
-		"ledger": s.state.checkpointLedger,
-	}).Info("Processing state")
-	startTime := time.Now()
-
-	err = s.runner.RunHistoryArchiveIngestion(s.state.checkpointLedger)
-	if err != nil {
-		return state{systemState: initState}, errors.Wrap(err, "Error ingesting history archive")
-	}
-
-	if err = s.historyQ.UpdateLastLedgerExpIngest(s.state.checkpointLedger); err != nil {
-		return state{systemState: initState}, errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
-	}
-
-	if err = s.historyQ.UpdateExpIngestVersion(CurrentVersion); err != nil {
-		return state{systemState: initState}, errors.Wrap(err, "Error updating expingest version")
-	}
-
-	err = s.historyQ.Commit()
-	if err != nil {
-		return state{systemState: initState}, errors.Wrap(err, commitErrMsg)
-	}
-
-	err = s.graph.Apply(s.state.checkpointLedger)
-	if err != nil {
-		return state{systemState: initState}, errors.Wrap(err, "Error applying order book changes")
-	}
-
-	log.WithFields(logpkg.F{
-		"ledger":   s.state.checkpointLedger,
-		"duration": time.Since(startTime).Seconds(),
-	}).Info("Processed state")
-
-	// If successful, continue from the next ledger
-	return state{
-		systemState:                       resumeState,
-		latestSuccessfullyProcessedLedger: s.state.checkpointLedger,
-	}, nil
-}
-
-func (s *System) resume() (state, error) {
-	if s.state.latestSuccessfullyProcessedLedger == 0 {
-		return state{systemState: initState}, errors.New("unexpected latestSuccessfullyProcessedLedger value")
-	}
-
-	// Remove noSleep if set before. This allows returning s.state in most cases.
-	s.state.noSleep = false
-
-	if err := s.historyQ.Begin(); err != nil {
-		return s.state,
-			errors.Wrap(err, "Error starting a transaction")
-	}
-	defer s.historyQ.Rollback()
-	defer s.graph.Discard()
-
-	// This will get the value `FOR UPDATE`, blocking it for other nodes.
-	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
-	if err != nil {
-		return s.state,
-			errors.Wrap(err, getLastIngestedErrMsg)
-	}
-
-	ingestLedger := s.state.latestSuccessfullyProcessedLedger + 1
-
-	if ingestLedger > lastIngestedLedger+1 {
-		return state{systemState: initState},
-			errors.New("expected ingest ledger to be at most one greater " +
-				"than last ingested ledger in db")
-	}
-
-	ingestVersion, err := s.historyQ.GetExpIngestVersion()
-	if err != nil {
-		return s.state, errors.Wrap(err, getExpIngestVersionErrMsg)
-	}
-
-	if ingestVersion != CurrentVersion {
-		return state{systemState: initState},
-			errors.Errorf(
-				"ingestion version in db %v does not match expected version %v",
-				ingestVersion,
-				CurrentVersion,
-			)
-	}
-
-	lastHistoryLedger, err := s.historyQ.GetLatestLedger()
-	if err != nil {
-		return s.state,
-			errors.Wrap(err, "could not get latest history ledger")
-	}
-
-	if lastHistoryLedger != 0 && lastHistoryLedger != lastIngestedLedger {
-		return state{systemState: initState},
-			errors.Errorf(
-				"last history ledger %v does not match last ingested ledger %v",
-				lastHistoryLedger,
-				lastIngestedLedger,
-			)
-	}
-
-	// Check if ledger is closed
-	latestLedgerCore, err := s.ledgerBackend.GetLatestLedgerSequence()
-	if err != nil {
-		return s.state,
-			errors.Wrap(err, "Error getting lastest ledger in stellar-core")
-	}
-
-	if latestLedgerCore < ingestLedger {
-		// Go to the next state, machine will wait for 1s. before continuing.
-		return s.state, nil
-	}
-
-	startTime := time.Now()
-
-	if ingestLedger <= lastIngestedLedger {
-		// rollback because we will not be updating the DB
-		// so there is no need to hold on to the distributed lock
-		// and thereby block the other nodes from ingesting
-		if err = s.historyQ.Rollback(); err != nil {
-			return s.state,
-				errors.Wrap(err, "Error rolling back transaction")
-		}
-
-		log.WithFields(logpkg.F{
-			"sequence": ingestLedger,
-			"state":    false,
-			"ledger":   false,
-			"graph":    true,
-			"commit":   false,
-		}).Info("Processing ledger")
-
-		err = s.runner.RunOrderBookProcessorOnLedger(ingestLedger)
-		if err != nil {
-			return s.state,
-				errors.Wrap(err, "Error running change processor on ledger")
-
-		}
-
-		if err = s.graph.Apply(ingestLedger); err != nil {
-			return s.state,
-				errors.Wrap(err, "Error applying graph changes from ledger")
-		}
-
-		log.WithFields(logpkg.F{
-			"sequence": ingestLedger,
-			"duration": time.Since(startTime).Seconds(),
-			"state":    false,
-			"ledger":   false,
-			"graph":    true,
-			"commit":   false,
-		}).Info("Processed ledger")
-
-		return state{
-			systemState:                       resumeState,
-			latestSuccessfullyProcessedLedger: ingestLedger,
-			// Catching up so don't wait before the next ledger because
-			// we are sure it's already there.
-			noSleep: true,
-		}, nil
-	}
-
-	log.WithFields(logpkg.F{
-		"sequence": ingestLedger,
-		"state":    true,
-		"ledger":   true,
-		"graph":    true,
-		"commit":   true,
-	}).Info("Processing ledger")
-
-	err = s.runner.RunAllProcessorsOnLedger(ingestLedger)
-	if err != nil {
-		return s.state,
-			errors.Wrap(err, "Error running processors on ledger")
-	}
-
-	err = s.historyQ.UpdateLastLedgerExpIngest(ingestLedger)
-	if err != nil {
-		return s.state,
-			errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
-	}
-
-	if err = s.graph.Apply(ingestLedger); err != nil {
-		return s.state,
-			errors.Wrap(err, "Error applying graph changes from ledger")
-	}
-
-	if err = s.historyQ.Commit(); err != nil {
-		return s.state,
-			errors.Wrap(err, commitErrMsg)
-	}
-
-	if err = s.updateCursor(ingestLedger); err != nil {
-		// Don't return updateCursor error.
-		log.WithError(err).Warn("error updating stellar-core cursor")
-	}
-
-	log.WithFields(logpkg.F{
-		"sequence": ingestLedger,
-		"duration": time.Since(startTime).Seconds(),
-		"state":    true,
-		"ledger":   true,
-		"graph":    true,
-		"commit":   true,
-	}).Info("Processed ledger")
-
-	s.maybeVerifyState(ingestLedger)
-
-	return state{
-		systemState:                       resumeState,
-		latestSuccessfullyProcessedLedger: ingestLedger,
-		// noSleep = false only when there are no more ledgers to ingest. We
-		// check this in top of this function.
-		noSleep: true,
-	}, nil
-}
-
 func (s *System) maybeVerifyState(lastIngestedLedger uint32) {
 	stateInvalid, err := s.historyQ.GetExpStateInvalid()
 	if err != nil {
@@ -791,7 +322,7 @@ func (s *System) maybeVerifyState(lastIngestedLedger uint32) {
 		go func(graphOffersMap map[xdr.Int64]xdr.OfferEntry) {
 			defer s.wg.Done()
 
-			err := s.verifyState(graphOffersMap)
+			err := s.verifyState(graphOffersMap, true)
 			if err != nil {
 				errorCount := s.incrementStateVerificationErrors()
 				switch errors.Cause(err).(type) {
@@ -809,211 +340,6 @@ func (s *System) maybeVerifyState(lastIngestedLedger uint32) {
 			}
 		}(s.graph.OffersMap())
 	}
-}
-
-// ingestHistoryRange is used when catching up history data and when reingesting
-// range.
-func (s *System) ingestHistoryRange() (state, error) {
-	returnState := initState
-	validateStartLedger := true
-	// unless we're running the horizon reingest range command we should
-	// always check that the start ledger is equal to the last ledger
-	// in the db plus one
-	if s.state.shutdownWhenDone {
-		// Shutdown when done - used in `reingest range` command.
-		returnState = shutdownState
-		validateStartLedger = false
-	}
-
-	if s.state.rangeFromLedger == 0 || s.state.rangeToLedger == 0 ||
-		s.state.rangeFromLedger > s.state.rangeToLedger {
-		return state{systemState: returnState},
-			errors.Errorf("invalid range: [%d, %d]", s.state.rangeFromLedger, s.state.rangeToLedger)
-	}
-
-	if err := s.historyQ.Begin(); err != nil {
-		return state{systemState: returnState},
-			errors.Wrap(err, "Error starting a transaction")
-	}
-	defer s.historyQ.Rollback()
-
-	// acquire distributed lock so no one else can perform ingestion operations.
-	if _, err := s.historyQ.GetLastLedgerExpIngest(); err != nil {
-		return state{systemState: returnState},
-			errors.Wrap(err, getLastIngestedErrMsg)
-	}
-
-	if s.state.rangeClearHistory {
-		// Clear history data before ingesting - used in `reingest range` command.
-		start, end, err := toid.LedgerRangeInclusive(
-			int32(s.state.rangeFromLedger),
-			int32(s.state.rangeToLedger),
-		)
-
-		if err != nil {
-			return state{systemState: returnState},
-				errors.Wrap(err, "Invalid range")
-		}
-
-		err = s.historyQ.DeleteRangeAll(start, end)
-		if err != nil {
-			return state{systemState: returnState},
-				errors.Wrap(err, "error in DeleteRangeAll")
-		}
-	}
-
-	if validateStartLedger {
-		lastHistoryLedger, err := s.historyQ.GetLatestLedger()
-		if err != nil {
-			return state{systemState: returnState},
-				errors.Wrap(err, "could not get latest history ledger")
-		}
-
-		// We should be ingesting the ledger which occurs after
-		// lastHistoryLedger. Otherwise, some other horizon node has
-		// already completed the ingest history range operation and
-		// we should go back to the init state
-		if lastHistoryLedger != s.state.rangeFromLedger-1 {
-			return state{systemState: returnState}, nil
-		}
-	}
-
-	for cur := s.state.rangeFromLedger; cur <= s.state.rangeToLedger; cur++ {
-		log.WithField("sequence", cur).Info("Processing ledger")
-		startTime := time.Now()
-
-		if err := s.runner.RunTransactionProcessorsOnLedger(cur); err != nil {
-			return state{systemState: returnState},
-				errors.Wrap(err, fmt.Sprintf("error processing ledger sequence=%d", cur))
-		}
-
-		log.WithFields(logpkg.F{
-			"sequence": cur,
-			"duration": time.Since(startTime).Seconds(),
-			"state":    false,
-			"ledger":   true,
-			"graph":    false,
-			"commit":   false,
-		}).Info("Processed ledger")
-	}
-
-	if err := s.historyQ.Commit(); err != nil {
-		return state{systemState: returnState}, errors.Wrap(err, commitErrMsg)
-	}
-
-	return state{systemState: returnState}, nil
-}
-
-func (s *System) waitForCheckpoint() (state, error) {
-	log.Info("Waiting for the next checkpoint...")
-	time.Sleep(10 * time.Second)
-	return state{systemState: initState}, nil
-}
-
-func (s *System) verifyRange() (state, error) {
-	if s.state.rangeFromLedger == 0 || s.state.rangeToLedger == 0 ||
-		s.state.rangeFromLedger > s.state.rangeToLedger {
-		return state{systemState: shutdownState},
-			errors.Errorf("invalid range: [%d, %d]", s.state.rangeFromLedger, s.state.rangeToLedger)
-	}
-
-	if err := s.historyQ.Begin(); err != nil {
-		err = errors.Wrap(err, "Error starting a transaction")
-		return state{systemState: shutdownState}, err
-	}
-	defer s.historyQ.Rollback()
-	defer s.graph.Discard()
-
-	// Simple check if DB clean
-	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
-	if err != nil {
-		err = errors.Wrap(err, getLastIngestedErrMsg)
-		return state{systemState: shutdownState}, err
-	}
-
-	if lastIngestedLedger != 0 {
-		err = errors.New("Database not empty")
-		return state{systemState: shutdownState}, err
-	}
-
-	log.WithFields(logpkg.F{
-		"ledger": s.state.rangeFromLedger,
-	}).Info("Processing state")
-	startTime := time.Now()
-
-	err = s.runner.RunHistoryArchiveIngestion(s.state.rangeFromLedger)
-	if err != nil {
-		err = errors.Wrap(err, "Error ingesting history archive")
-		return state{systemState: shutdownState}, err
-	}
-
-	err = s.historyQ.UpdateLastLedgerExpIngest(s.state.rangeFromLedger)
-	if err != nil {
-		err = errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
-		return state{systemState: shutdownState}, err
-	}
-
-	if err = s.historyQ.Commit(); err != nil {
-		err = errors.Wrap(err, commitErrMsg)
-		return state{systemState: shutdownState}, err
-	}
-
-	err = s.graph.Apply(s.state.rangeFromLedger)
-	if err != nil {
-		err = errors.Wrap(err, "Error applying order book changes")
-		return state{systemState: shutdownState}, err
-	}
-
-	log.WithFields(logpkg.F{
-		"ledger":   s.state.rangeFromLedger,
-		"duration": time.Since(startTime).Seconds(),
-	}).Info("Processed state")
-
-	for sequence := s.state.rangeFromLedger + 1; sequence <= s.state.rangeToLedger; sequence++ {
-		log.WithField("sequence", sequence).Info("Processing ledger")
-		startTime := time.Now()
-
-		if err = s.historyQ.Begin(); err != nil {
-			err = errors.Wrap(err, "Error starting a transaction")
-			return state{systemState: shutdownState}, err
-		}
-
-		err = s.runner.RunAllProcessorsOnLedger(sequence)
-		if err != nil {
-			err = errors.Wrap(err, "Error running processors on ledger")
-			return state{systemState: shutdownState}, err
-		}
-
-		err = s.historyQ.UpdateLastLedgerExpIngest(sequence)
-		if err != nil {
-			err = errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
-			return state{systemState: shutdownState}, err
-		}
-
-		if err = s.graph.Apply(sequence); err != nil {
-			err = errors.Wrap(err, "Error applying graph history archive changes")
-			return state{systemState: shutdownState}, err
-		}
-
-		if err = s.historyQ.Commit(); err != nil {
-			return state{systemState: shutdownState}, errors.Wrap(err, commitErrMsg)
-		}
-
-		log.WithFields(logpkg.F{
-			"sequence": sequence,
-			"duration": time.Since(startTime).Seconds(),
-			"state":    true,
-			"ledger":   true,
-			"graph":    true,
-			"commit":   true,
-		}).Info("Processed ledger")
-	}
-
-	if s.state.rangeVerifyState {
-		err = s.verifyState(s.graph.OffersMap())
-	}
-
-	return state{systemState: shutdownState}, err
 }
 
 func (s *System) incrementStateVerificationErrors() int {

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -351,6 +351,15 @@ func (s *System) init() (state, error) {
 		return state{systemState: initState}, errors.Wrap(err, getExpIngestVersionErrMsg)
 	}
 
+	if ingestVersion > CurrentVersion {
+		return state{systemState: shutdownState},
+			errors.Errorf(
+				"ingestion version in db %v is greater than current version %v",
+				ingestVersion,
+				CurrentVersion,
+			)
+	}
+
 	lastHistoryLedger, err := s.historyQ.GetLatestLedger()
 	if err != nil {
 		return state{systemState: initState}, errors.Wrap(err, "Error getting last history ledger sequence")
@@ -621,6 +630,35 @@ func (s *System) resume() (state, error) {
 		return state{systemState: initState},
 			errors.New("expected ingest ledger to be at most one greater " +
 				"than last ingested ledger in db")
+	}
+
+	ingestVersion, err := s.historyQ.GetExpIngestVersion()
+	if err != nil {
+		return s.state, errors.Wrap(err, getExpIngestVersionErrMsg)
+	}
+
+	if ingestVersion != CurrentVersion {
+		return state{systemState: initState},
+			errors.Errorf(
+				"ingestion version in db %v does not match expected version %v",
+				ingestVersion,
+				CurrentVersion,
+			)
+	}
+
+	lastHistoryLedger, err := s.historyQ.GetLatestLedger()
+	if err != nil {
+		return s.state,
+			errors.Wrap(err, "could not get latest history ledger")
+	}
+
+	if lastHistoryLedger != 0 && lastHistoryLedger != lastIngestedLedger {
+		return state{systemState: initState},
+			errors.Errorf(
+				"last history ledger %v does not match last ingested ledger %v",
+				lastHistoryLedger,
+				lastIngestedLedger,
+			)
 	}
 
 	// Check if ledger is closed

--- a/services/horizon/internal/expingest/main_test.go
+++ b/services/horizon/internal/expingest/main_test.go
@@ -136,16 +136,13 @@ func TestContextCancel(t *testing.T) {
 	system := &System{
 		historyQ: historyQ,
 		ctx:      ctx,
-		state: state{
-			systemState: initState,
-		},
 	}
 
 	historyQ.On("GetTx").Return(nil).Once()
 	historyQ.On("Begin").Return(errors.New("my error")).Once()
 
 	cancel()
-	assert.NoError(t, system.run())
+	assert.NoError(t, system.runStateMachine(startState{}))
 }
 
 // TestStateMachineRunReturnsErrorWhenNextStateIsShutdownWithError checks if the
@@ -156,17 +153,14 @@ func TestStateMachineRunReturnsErrorWhenNextStateIsShutdownWithError(t *testing.
 	historyQ := &mockDBQ{}
 	graph := &mockOrderBookGraph{}
 	system := &System{
-		ctx: context.Background(),
-		state: state{
-			systemState: verifyRangeState,
-		},
+		ctx:      context.Background(),
 		historyQ: historyQ,
 		graph:    graph,
 	}
 
 	historyQ.On("GetTx").Return(nil).Once()
 
-	err := system.run()
+	err := system.runStateMachine(verifyRangeState{})
 	assert.Error(t, err)
 	assert.EqualError(t, err, "invalid range: [0, 0]")
 }

--- a/services/horizon/internal/expingest/resume_state_test.go
+++ b/services/horizon/internal/expingest/resume_state_test.go
@@ -2,7 +2,6 @@ package expingest
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stellar/go/exp/ingest/adapters"
@@ -35,11 +34,7 @@ func (s *ResumeTestTestSuite) SetupTest() {
 	s.runner = &mockProcessorsRunner{}
 	s.stellarCoreClient = &mockStellarCoreClient{}
 	s.system = &System{
-		ctx: context.Background(),
-		state: state{
-			systemState:                       resumeState,
-			latestSuccessfullyProcessedLedger: 100,
-		},
+		ctx:               context.Background(),
 		historyQ:          s.historyQ,
 		historyAdapter:    s.historyAdapter,
 		runner:            s.runner,
@@ -48,9 +43,6 @@ func (s *ResumeTestTestSuite) SetupTest() {
 		stellarCoreClient: s.stellarCoreClient,
 	}
 
-	s.Assert().Equal(resumeState, s.system.state.systemState)
-	// Checking if in tx in runCurrentState()
-	s.historyQ.On("GetTx").Return(nil).Once()
 	s.historyQ.On("Rollback").Return(nil).Once()
 	s.graph.On("Discard").Once()
 }
@@ -68,53 +60,66 @@ func (s *ResumeTestTestSuite) TearDownTest() {
 func (s *ResumeTestTestSuite) TestInvalidParam() {
 	// Recreate mock in this single test to remove Rollback assertion.
 	*s.historyQ = mockDBQ{}
-	s.historyQ.On("GetTx").Return(nil).Maybe()
 
 	// Recreate orderbook graph to remove Discard assertion
 	*s.graph = mockOrderBookGraph{}
 
-	s.system.state.latestSuccessfullyProcessedLedger = 0
-	nextState, err := s.system.runCurrentState()
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 0}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "unexpected latestSuccessfullyProcessedLedger value")
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(
+		transition{node: startState{}, sleepDuration: defaultSleep},
+		next,
+	)
 }
 
 func (s *ResumeTestTestSuite) TestBeginReturnsError() {
 	// Recreate mock in this single test to remove Rollback assertion.
 	*s.historyQ = mockDBQ{}
-	s.historyQ.On("GetTx").Return(nil).Once()
 	s.historyQ.On("Begin").Return(errors.New("my error")).Once()
 
 	// Recreate orderbook graph to remove Discard assertion
 	*s.graph = mockOrderBookGraph{}
 
-	nextState, err := s.system.runCurrentState()
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "Error starting a transaction: my error")
-	s.Assert().Equal(resumeState, nextState.systemState)
-	s.Assert().Equal(uint32(100), nextState.latestSuccessfullyProcessedLedger)
+	s.Assert().Equal(
+		transition{
+			node:          resumeState{latestSuccessfullyProcessedLedger: 100},
+			sleepDuration: defaultSleep,
+		},
+		next,
+	)
 }
 
 func (s *ResumeTestTestSuite) TestGetLastLedgerExpIngestReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), errors.New("my error")).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "Error getting last ingested ledger: my error")
-	s.Assert().Equal(resumeState, nextState.systemState)
-	s.Assert().Equal(uint32(100), nextState.latestSuccessfullyProcessedLedger)
+	s.Assert().Equal(
+		transition{
+			node:          resumeState{latestSuccessfullyProcessedLedger: 100},
+			sleepDuration: defaultSleep,
+		},
+		next,
+	)
 }
 
 func (s *ResumeTestTestSuite) TestGetLatestLedgerLessThanCurrent() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(99), nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "expected ingest ledger to be at most one greater than last ingested ledger in db")
-	s.Assert().Equal(initState, nextState.systemState)
+	s.Assert().Equal(
+		transition{node: startState{}, sleepDuration: defaultSleep},
+		next,
+	)
 }
 
 func (s *ResumeTestTestSuite) TestGetIngestionVersionError() {
@@ -122,11 +127,16 @@ func (s *ResumeTestTestSuite) TestGetIngestionVersionError() {
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
 	s.historyQ.On("GetExpIngestVersion").Return(0, errors.New("my error")).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "Error getting exp ingest version: my error")
-	s.Assert().Equal(resumeState, nextState.systemState)
-	s.Assert().Equal(uint32(100), nextState.latestSuccessfullyProcessedLedger)
+	s.Assert().Equal(
+		transition{
+			node:          resumeState{latestSuccessfullyProcessedLedger: 100},
+			sleepDuration: defaultSleep,
+		},
+		next,
+	)
 }
 
 func (s *ResumeTestTestSuite) TestIngestionVersionLessThanCurrentVersion() {
@@ -134,17 +144,12 @@ func (s *ResumeTestTestSuite) TestIngestionVersionLessThanCurrentVersion() {
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion-1, nil).Once()
 
-	nextState, err := s.system.runCurrentState()
-	s.Assert().Error(err)
-	s.Assert().EqualError(
-		err,
-		fmt.Sprintf(
-			"ingestion version in db %v does not match expected version %v",
-			CurrentVersion-1,
-			CurrentVersion,
-		),
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
+	s.Assert().NoError(err)
+	s.Assert().Equal(
+		transition{node: startState{}, sleepDuration: defaultSleep},
+		next,
 	)
-	s.Assert().Equal(initState, nextState.systemState)
 }
 
 func (s *ResumeTestTestSuite) TestIngestionVersionGreaterThanCurrentVersion() {
@@ -152,17 +157,12 @@ func (s *ResumeTestTestSuite) TestIngestionVersionGreaterThanCurrentVersion() {
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion+1, nil).Once()
 
-	nextState, err := s.system.runCurrentState()
-	s.Assert().Error(err)
-	s.Assert().EqualError(
-		err,
-		fmt.Sprintf(
-			"ingestion version in db %v does not match expected version %v",
-			CurrentVersion+1,
-			CurrentVersion,
-		),
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
+	s.Assert().NoError(err)
+	s.Assert().Equal(
+		transition{node: startState{}, sleepDuration: defaultSleep},
+		next,
 	)
-	s.Assert().Equal(initState, nextState.systemState)
 }
 
 func (s *ResumeTestTestSuite) TestGetLatestLedgerError() {
@@ -171,11 +171,16 @@ func (s *ResumeTestTestSuite) TestGetLatestLedgerError() {
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), errors.New("my error"))
 
-	nextState, err := s.system.runCurrentState()
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "could not get latest history ledger: my error")
-	s.Assert().Equal(resumeState, nextState.systemState)
-	s.Assert().Equal(uint32(100), nextState.latestSuccessfullyProcessedLedger)
+	s.Assert().Equal(
+		transition{
+			node:          resumeState{latestSuccessfullyProcessedLedger: 100},
+			sleepDuration: defaultSleep,
+		},
+		next,
+	)
 }
 
 func (s *ResumeTestTestSuite) TestLatestHistoryLedgerLessThanIngestLedger() {
@@ -184,10 +189,12 @@ func (s *ResumeTestTestSuite) TestLatestHistoryLedgerLessThanIngestLedger() {
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil)
 
-	nextState, err := s.system.runCurrentState()
-	s.Assert().Error(err)
-	s.Assert().EqualError(err, "last history ledger 99 does not match last ingested ledger 100")
-	s.Assert().Equal(initState, nextState.systemState)
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
+	s.Assert().NoError(err)
+	s.Assert().Equal(
+		transition{node: startState{}, sleepDuration: defaultSleep},
+		next,
+	)
 }
 
 func (s *ResumeTestTestSuite) TestLatestHistoryLedgerGreaterThanIngestLedger() {
@@ -196,10 +203,12 @@ func (s *ResumeTestTestSuite) TestLatestHistoryLedgerGreaterThanIngestLedger() {
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
 
-	nextState, err := s.system.runCurrentState()
-	s.Assert().Error(err)
-	s.Assert().EqualError(err, "last history ledger 101 does not match last ingested ledger 100")
-	s.Assert().Equal(initState, nextState.systemState)
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
+	s.Assert().NoError(err)
+	s.Assert().Equal(
+		transition{node: startState{}, sleepDuration: defaultSleep},
+		next,
+	)
 }
 
 func (s *ResumeTestTestSuite) TestIngestOrderbookOnly() {
@@ -215,11 +224,15 @@ func (s *ResumeTestTestSuite) TestIngestOrderbookOnly() {
 	s.runner.On("RunOrderBookProcessorOnLedger", uint32(101)).Return(nil).Once()
 	s.graph.On("Apply", uint32(101)).Return(nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(resumeState, nextState.systemState)
-	s.Assert().Equal(uint32(101), nextState.latestSuccessfullyProcessedLedger)
-	s.Assert().True(nextState.noSleep)
+	s.Assert().Equal(
+		transition{
+			node:          resumeState{latestSuccessfullyProcessedLedger: 101},
+			sleepDuration: 0,
+		},
+		next,
+	)
 }
 
 // TestIngestOrderbookOnlyWhenLastLedgerExpEqualsCurrent is very similar to the test above
@@ -238,11 +251,15 @@ func (s *ResumeTestTestSuite) TestIngestOrderbookOnlyWhenLastLedgerExpEqualsCurr
 	s.runner.On("RunOrderBookProcessorOnLedger", uint32(101)).Return(nil).Once()
 	s.graph.On("Apply", uint32(101)).Return(nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(resumeState, nextState.systemState)
-	s.Assert().Equal(uint32(101), nextState.latestSuccessfullyProcessedLedger)
-	s.Assert().True(nextState.noSleep)
+	s.Assert().Equal(
+		transition{
+			node:          resumeState{latestSuccessfullyProcessedLedger: 101},
+			sleepDuration: 0,
+		},
+		next,
+	)
 }
 
 func (s *ResumeTestTestSuite) TestIngestAllMasterNode() {
@@ -267,11 +284,15 @@ func (s *ResumeTestTestSuite) TestIngestAllMasterNode() {
 
 	s.historyQ.On("GetExpStateInvalid").Return(false, nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(resumeState, nextState.systemState)
-	s.Assert().Equal(uint32(101), nextState.latestSuccessfullyProcessedLedger)
-	s.Assert().True(nextState.noSleep)
+	s.Assert().Equal(
+		transition{
+			node:          resumeState{latestSuccessfullyProcessedLedger: 101},
+			sleepDuration: 0,
+		},
+		next,
+	)
 }
 
 func (s *ResumeTestTestSuite) TestErrorSettingCursorIgnored() {
@@ -296,11 +317,15 @@ func (s *ResumeTestTestSuite) TestErrorSettingCursorIgnored() {
 
 	s.historyQ.On("GetExpStateInvalid").Return(false, nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(resumeState, nextState.systemState)
-	s.Assert().Equal(uint32(101), nextState.latestSuccessfullyProcessedLedger)
-	s.Assert().True(nextState.noSleep)
+	s.Assert().Equal(
+		transition{
+			node:          resumeState{latestSuccessfullyProcessedLedger: 101},
+			sleepDuration: 0,
+		},
+		next,
+	)
 }
 
 func (s *ResumeTestTestSuite) TestNoNewLedgers() {
@@ -311,11 +336,15 @@ func (s *ResumeTestTestSuite) TestNoNewLedgers() {
 
 	s.ledgeBackend.On("GetLatestLedgerSequence").Return(uint32(100), nil).Once()
 
-	nextState, err := s.system.runCurrentState()
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().NoError(err)
-	s.Assert().Equal(resumeState, nextState.systemState)
-	// Check the same ledger later
-	s.Assert().Equal(uint32(100), nextState.latestSuccessfullyProcessedLedger)
-	// Sleep because we learned the ledger is not there yet.
-	s.Assert().False(nextState.noSleep)
+	s.Assert().Equal(
+		transition{
+			// Check the same ledger later
+			node: resumeState{latestSuccessfullyProcessedLedger: 100},
+			// Sleep because we learned the ledger is not there yet.
+			sleepDuration: defaultSleep,
+		},
+		next,
+	)
 }

--- a/services/horizon/internal/expingest/resume_state_test.go
+++ b/services/horizon/internal/expingest/resume_state_test.go
@@ -2,6 +2,7 @@ package expingest
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stellar/go/exp/ingest/adapters"
@@ -116,9 +117,96 @@ func (s *ResumeTestTestSuite) TestGetLatestLedgerLessThanCurrent() {
 	s.Assert().Equal(initState, nextState.systemState)
 }
 
+func (s *ResumeTestTestSuite) TestGetIngestionVersionError() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(0, errors.New("my error")).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "Error getting exp ingest version: my error")
+	s.Assert().Equal(resumeState, nextState.systemState)
+	s.Assert().Equal(uint32(100), nextState.latestSuccessfullyProcessedLedger)
+}
+
+func (s *ResumeTestTestSuite) TestIngestionVersionLessThanCurrentVersion() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion-1, nil).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(
+		err,
+		fmt.Sprintf(
+			"ingestion version in db %v does not match expected version %v",
+			CurrentVersion-1,
+			CurrentVersion,
+		),
+	)
+	s.Assert().Equal(initState, nextState.systemState)
+}
+
+func (s *ResumeTestTestSuite) TestIngestionVersionGreaterThanCurrentVersion() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion+1, nil).Once()
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(
+		err,
+		fmt.Sprintf(
+			"ingestion version in db %v does not match expected version %v",
+			CurrentVersion+1,
+			CurrentVersion,
+		),
+	)
+	s.Assert().Equal(initState, nextState.systemState)
+}
+
+func (s *ResumeTestTestSuite) TestGetLatestLedgerError() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(0), errors.New("my error"))
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "could not get latest history ledger: my error")
+	s.Assert().Equal(resumeState, nextState.systemState)
+	s.Assert().Equal(uint32(100), nextState.latestSuccessfullyProcessedLedger)
+}
+
+func (s *ResumeTestTestSuite) TestLatestHistoryLedgerLessThanIngestLedger() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil)
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "last history ledger 99 does not match last ingested ledger 100")
+	s.Assert().Equal(initState, nextState.systemState)
+}
+
+func (s *ResumeTestTestSuite) TestLatestHistoryLedgerGreaterThanIngestLedger() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
+
+	nextState, err := s.system.runCurrentState()
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "last history ledger 101 does not match last ingested ledger 100")
+	s.Assert().Equal(initState, nextState.systemState)
+}
+
 func (s *ResumeTestTestSuite) TestIngestOrderbookOnly() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(110), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
 	s.ledgeBackend.On("GetLatestLedgerSequence").Return(uint32(111), nil).Once()
 
@@ -140,6 +228,8 @@ func (s *ResumeTestTestSuite) TestIngestOrderbookOnly() {
 func (s *ResumeTestTestSuite) TestIngestOrderbookOnlyWhenLastLedgerExpEqualsCurrent() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(101), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
 
 	s.ledgeBackend.On("GetLatestLedgerSequence").Return(uint32(111), nil).Once()
 
@@ -158,6 +248,8 @@ func (s *ResumeTestTestSuite) TestIngestOrderbookOnlyWhenLastLedgerExpEqualsCurr
 func (s *ResumeTestTestSuite) TestIngestAllMasterNode() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
 	s.ledgeBackend.On("GetLatestLedgerSequence").Return(uint32(111), nil).Once()
 
@@ -185,6 +277,8 @@ func (s *ResumeTestTestSuite) TestIngestAllMasterNode() {
 func (s *ResumeTestTestSuite) TestErrorSettingCursorIgnored() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
 	s.ledgeBackend.On("GetLatestLedgerSequence").Return(uint32(111), nil).Once()
 
@@ -212,6 +306,8 @@ func (s *ResumeTestTestSuite) TestErrorSettingCursorIgnored() {
 func (s *ResumeTestTestSuite) TestNoNewLedgers() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
 	s.ledgeBackend.On("GetLatestLedgerSequence").Return(uint32(100), nil).Once()
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The ingestion system uses a finite state machine to model its behaviors (see https://github.com/stellar/go/issues/1969 ). In the current implementation the state machine is represented by the following struct:

```golang
type systemState string

const (
	initState               systemState = "init"
	ingestHistoryRangeState systemState = "ingestHistoryRange"
	waitForCheckpointState  systemState = "waitForCheckpoint"
	buildStateState         systemState = "buildState"
	resumeState             systemState = "resume"
	verifyRangeState        systemState = "verifyRange"
	shutdownState           systemState = "shutdown"
)

type state struct {
	systemState                       systemState
	latestSuccessfullyProcessedLedger uint32

	checkpointLedger uint32

	rangeFromLedger   uint32
	rangeToLedger     uint32
	rangeVerifyState  bool
	rangeClearHistory bool

	shutdownWhenDone bool

	// noSleep informs state machine to not sleep between state transitions
	noSleep bool
}
```
This PR replaces this representation with following interface:

```golang
type stateMachineNode interface {
	run(*System) (transition, error)
}

type transition struct {
	node          stateMachineNode
	sleepDuration time.Duration
}
```

Every node in the state machine is represented by a struct which implements the `stateMachineNode` interface.

Note this PR is rebased on top of https://github.com/stellar/go/pull/2213 . Please ignore the commits belonging to https://github.com/stellar/go/pull/2213  when reviewing this PR.

Also, since this PR moves existing functions to a new file, it is easier to review this PR by reviewing each commit individually instead of looking at the overall diff.

### Why

There are two advantages to this approach:

* All the state machine structs are immutable. The structs do not need to mutate their own fields (none of the structs have functions with pointer receivers) or fields in `System` .

* The parameters for each node in the state machine are isolated. The previous implementation kept the parameters for all states in one `state` struct. In the old implementation it is possible for a state function to mistakenly use parameters that are not relevant to the sate.


### Known limitations

Having each state be represented by a separate struct adds some boilerplate. If there isn't consensus that this refactor is an improvement over the old version I will close the PR.
