### PR TITLE
exp/ingest: Use errors.Wrap to propagate errors

### DIFF
--- a/exp/ingest/adapters/history_archive_adapter.go
+++ b/exp/ingest/adapters/history_archive_adapter.go
@@ -2,7 +2,6 @@ package adapters
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/stellar/go/exp/ingest/io"
 	"github.com/stellar/go/support/errors"
@@ -30,9 +29,9 @@ func MakeHistoryArchiveAdapter(archive historyarchive.ArchiveInterface) HistoryA
 
 // GetLatestLedgerSequence returns the latest ledger sequence or an error
 func (haa *HistoryArchiveAdapter) GetLatestLedgerSequence() (uint32, error) {
-	has, e := haa.archive.GetRootHAS()
-	if e != nil {
-		return 0, fmt.Errorf("could not get root HAS: %s", e)
+	has, err := haa.archive.GetRootHAS()
+	if err != nil {
+		return 0, errors.Wrap(err, "could not get root HAS")
 	}
 
 	return has.CurrentLedger, nil
@@ -46,12 +45,12 @@ func (haa *HistoryArchiveAdapter) BucketListHash(sequence uint32) (xdr.Hash, err
 		return xdr.Hash{}, errors.Wrap(err, "error checking if category checkpoint exists")
 	}
 	if !exists {
-		return xdr.Hash{}, fmt.Errorf("history checkpoint does not exist for ledger %d", sequence)
+		return xdr.Hash{}, errors.Errorf("history checkpoint does not exist for ledger %d", sequence)
 	}
 
 	has, err := haa.archive.GetCheckpointHAS(sequence)
 	if err != nil {
-		return xdr.Hash{}, fmt.Errorf("unable to get checkpoint HAS at ledger sequence %d: %s", sequence, err)
+		return xdr.Hash{}, errors.Wrapf(err, "unable to get checkpoint HAS at ledger sequence %d", sequence)
 	}
 
 	return has.BucketListHash()
@@ -69,7 +68,7 @@ func (haa *HistoryArchiveAdapter) GetState(
 		return nil, errors.Wrap(err, "error checking if category checkpoint exists")
 	}
 	if !exists {
-		return nil, fmt.Errorf("history checkpoint does not exist for ledger %d", sequence)
+		return nil, errors.Errorf("history checkpoint does not exist for ledger %d", sequence)
 	}
 
 	sr, e := io.MakeSingleLedgerStateReader(ctx, haa.archive, tempSet, sequence, maxStreamRetries)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

There are several places in exp/ingest/adapters/history_archive_adapter.go and exp/ingest/io/single_ledger_state_reader.go where we forget to use `errors.Wrap()` to propagate errors.

It's important to wrap errors because the ingestion system uses `errors.Cause()` to check if an error was caused by a shutdown. This check is used to determine whether an error should be logged.

