### PR TITLE
Revert "support/db: Support concurrent queries in a transaction (#2024)"

### DIFF
--- a/services/horizon/internal/expingest/main_test.go
+++ b/services/horizon/internal/expingest/main_test.go
@@ -73,14 +73,12 @@ func TestCheckVerifyStateVersion(t *testing.T) {
 func TestNewSystem(t *testing.T) {
 	config := Config{
 		CoreSession: &db.Session{
-			DB:           &sqlx.DB{},
-			Ctx:          context.Background(),
-			Synchronized: false,
+			DB:  &sqlx.DB{},
+			Ctx: context.Background(),
 		},
 		HistorySession: &db.Session{
-			DB:           &sqlx.DB{},
-			Ctx:          context.Background(),
-			Synchronized: false,
+			DB:  &sqlx.DB{},
+			Ctx: context.Background(),
 		},
 		DisableStateVerification: true,
 		HistoryArchiveURL:        "https://history.stellar.org/prd/core-live/core_live_001",

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -14,7 +14,6 @@ package db
 import (
 	"context"
 	"database/sql"
-	"sync"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/jmoiron/sqlx"
@@ -118,16 +117,7 @@ type Session struct {
 	// Ctx is the context in which the repo is operating under.
 	Ctx context.Context
 
-	// Synchronized is an EXPERIMENTAL flag that allows sending queries
-	// concurrently in a DB tx. When set to `true` all Exec and Select methods
-	// sent in a transaction are protected by mutex. It is not needed outside
-	// transaction context because then all queries are sent in a separate DB
-	// connections.
-	// Please note that Begin, Commit and Rollback must not be run in parallel.
-	// Also, Query methods are not available when in Synchronized transaction.
-	Synchronized bool
-	txMutex      sync.Mutex
-	tx           *sqlx.Tx
+	tx *sqlx.Tx
 }
 
 type SessionInterface interface {

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -67,8 +67,6 @@ func (s *Session) Clone() *Session {
 	return &Session{
 		DB:  s.DB,
 		Ctx: s.Ctx,
-
-		Synchronized: s.Synchronized,
 	}
 }
 
@@ -128,11 +126,6 @@ func (s *Session) GetRaw(dest interface{}, query string, args ...interface{}) er
 	query, err := s.ReplacePlaceholders(query)
 	if err != nil {
 		return errors.Wrap(err, "replace placeholders failed")
-	}
-
-	if s.Synchronized && s.tx != nil {
-		s.txMutex.Lock()
-		defer s.txMutex.Unlock()
 	}
 
 	start := time.Now()
@@ -204,11 +197,6 @@ func (s *Session) ExecRaw(query string, args ...interface{}) (sql.Result, error)
 		return nil, errors.Wrap(err, "replace placeholders failed")
 	}
 
-	if s.Synchronized && s.tx != nil {
-		s.txMutex.Lock()
-		defer s.txMutex.Unlock()
-	}
-
 	start := time.Now()
 	result, err := s.conn().ExecContext(s.Ctx, query, args...)
 	s.log("exec", start, query, args)
@@ -250,10 +238,6 @@ func (s *Session) Query(query sq.Sqlizer) (*sqlx.Rows, error) {
 
 // QueryRaw runs `query` with `args`
 func (s *Session) QueryRaw(query string, args ...interface{}) (*sqlx.Rows, error) {
-	if s.Synchronized && s.tx != nil {
-		return nil, errors.New("QueryRaw cannot be run in transaction when Synchronized is true")
-	}
-
 	query, err := s.ReplacePlaceholders(query)
 	if err != nil {
 		return nil, errors.Wrap(err, "replace placeholders failed")
@@ -321,11 +305,6 @@ func (s *Session) SelectRaw(
 	query, err := s.ReplacePlaceholders(query)
 	if err != nil {
 		return errors.Wrap(err, "replace placeholders failed")
-	}
-
-	if s.Synchronized && s.tx != nil {
-		s.txMutex.Lock()
-		defer s.txMutex.Unlock()
 	}
 
 	start := time.Now()

--- a/support/db/session_test.go
+++ b/support/db/session_test.go
@@ -2,56 +2,12 @@ package db
 
 import (
 	"context"
-	"fmt"
-	"sync"
 	"testing"
 
 	"github.com/stellar/go/support/db/dbtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestConcurrentQueriesTransaction(t *testing.T) {
-	db := dbtest.Postgres(t).Load(testSchema)
-	defer db.Close()
-
-	sess := &Session{
-		Ctx: context.Background(),
-		DB:  db.Open(),
-		// This test would fail for `Synchronized: false`
-		Synchronized: true,
-	}
-	defer sess.DB.Close()
-
-	err := sess.Begin()
-	assert.NoError(t, err)
-
-	var wg sync.WaitGroup
-	for i := 0; i < 1000; i++ {
-		wg.Add(1)
-		go func(i int) {
-			istr := fmt.Sprintf("%d", i)
-			var err2 error
-			if i%3 == 0 {
-				var names []string
-				err2 = sess.SelectRaw(&names, "SELECT name FROM people")
-			} else if i%3 == 1 {
-				var name string
-				err2 = sess.GetRaw(&name, "SELECT name FROM people LIMIT 1")
-			} else {
-				_, err2 = sess.ExecRaw(
-					"INSERT INTO people (name, hunger_level) VALUES ('bartek" + istr + "', " + istr + ")",
-				)
-			}
-			assert.NoError(t, err2)
-			wg.Done()
-		}(i)
-	}
-
-	wg.Wait()
-	err = sess.Rollback()
-	assert.NoError(t, err)
-}
 
 func TestSession(t *testing.T) {
 	db := dbtest.Postgres(t).Load(testSchema)


### PR DESCRIPTION
### What

This commit reverts 9bbfc3c81bdaab65bda5dc6d39f19d24e44e636b.

### Why

We decided to not use this experimental feature and it's no longer needed.