### PR TITLE
services/horizon: Update the usage message of `--max-path-length`

### DIFF
--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -255,7 +255,7 @@ var configOpts = support.ConfigOptions{
 		ConfigKey:   &config.MaxPathLength,
 		OptType:     types.Uint,
 		FlagDefault: uint(4),
-		Usage:       "the maximum number of assets on the path in `/paths` endpoint",
+		Usage:       "the maximum number of assets on the path in `/paths` endpoint, warning: increasing this value will increase /paths response time",
 	},
 	&support.ConfigOption{
 		Name:      "network-passphrase",


### PR DESCRIPTION
After talking with one of Horizon users I realized that the usage message of `--max-path-length` is missing the information about the performance implications of changing the value.