### PR TITLE
client/horizonclient: Extend offers to support new filters.

### DIFF
--- a/clients/horizonclient/examples_test.go
+++ b/clients/horizonclient/examples_test.go
@@ -423,6 +423,20 @@ func ExampleClient_Offers() {
 		return
 	}
 	fmt.Print(offers)
+
+	offerRequest = horizonclient.OfferRequest{
+		Seller:  "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+		Selling: "COP:GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+		Buying:  "EUR:GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+		Order:   horizonclient.OrderDesc,
+	}
+
+	offers, err = client.Offers(offerRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(offers)
 }
 
 func ExampleClient_OperationDetail() {

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -279,6 +279,9 @@ type feeStatsRequest struct {
 // The query parameters (Order, Cursor and Limit) are optional. All or none can be set.
 type OfferRequest struct {
 	ForAccount string
+	Selling    string
+	Seller     string
+	Buying     string
 	Order      Order
 	Cursor     string
 	Limit      uint

--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -476,6 +476,81 @@ func TestOfferRequest(t *testing.T) {
 		assert.Equal(t, record.Amount, "1999979.8700000")
 		assert.Equal(t, record.LastModifiedLedger, int32(103307))
 	}
+
+	hmock.On(
+		"GET",
+		"https://localhost/offers?seller=GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F",
+	).ReturnString(200, offersResponse)
+
+	offersRequest = OfferRequest{
+		Seller: "GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F",
+	}
+
+	offers, err = client.Offers(offersRequest)
+	if assert.NoError(t, err) {
+		assert.Len(t, offers.Embedded.Records, 1)
+	}
+
+	hmock.On(
+		"GET",
+		"https://localhost/offers?buying=COP%3AGDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F",
+	).ReturnString(200, offersResponse)
+
+	offersRequest = OfferRequest{
+		Buying: "COP:GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F",
+	}
+
+	offers, err = client.Offers(offersRequest)
+	if assert.NoError(t, err) {
+		assert.Len(t, offers.Embedded.Records, 1)
+	}
+
+	hmock.On(
+		"GET",
+		"https://localhost/offers?selling=EUR%3AGDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F",
+	).ReturnString(200, offersResponse)
+
+	offersRequest = OfferRequest{
+		Selling: "EUR:GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F",
+	}
+
+	offers, err = client.Offers(offersRequest)
+	if assert.NoError(t, err) {
+		assert.Len(t, offers.Embedded.Records, 1)
+	}
+
+	hmock.On(
+		"GET",
+		"https://localhost/offers?selling=EUR%3AGDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F",
+	).ReturnString(200, offersResponse)
+
+	offersRequest = OfferRequest{
+		Selling: "EUR:GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F",
+	}
+
+	offers, err = client.Offers(offersRequest)
+	if assert.NoError(t, err) {
+		assert.Len(t, offers.Embedded.Records, 1)
+	}
+
+	hmock.On(
+		"GET",
+		"https://localhost/offers?buying=EUR%3AGDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F&seller=GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F&selling=EUR%3AGDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F&cursor=30&limit=20&order=desc",
+	).ReturnString(200, offersResponse)
+
+	offersRequest = OfferRequest{
+		Seller:  "GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F",
+		Buying:  "EUR:GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F",
+		Selling: "EUR:GDOJCPYIB66RY4XNDLRRHQQXB27YLNNAGAYV5HMHEYNYY4KUNV5FDV2F",
+		Order:   "desc",
+		Limit:   20,
+		Cursor:  "30",
+	}
+
+	offers, err = client.Offers(offersRequest)
+	if assert.NoError(t, err) {
+		assert.Len(t, offers.Embedded.Records, 1)
+	}
 }
 
 func TestOperationsRequest(t *testing.T) {

--- a/clients/horizonclient/offer_request.go
+++ b/clients/horizonclient/offer_request.go
@@ -12,14 +12,30 @@ import (
 
 // BuildURL creates the endpoint to be queried based on the data in the OfferRequest struct.
 func (or OfferRequest) BuildURL() (endpoint string, err error) {
-	if or.ForAccount == "" {
-		return endpoint, errors.New(`parameter "ForAccount" required`)
-	}
-	endpoint = fmt.Sprintf("accounts/%s/offers", or.ForAccount)
+	// backwards compatibility  support
+	if len(or.ForAccount) > 0 {
+		endpoint = fmt.Sprintf("accounts/%s/offers", or.ForAccount)
+		queryParams := addQueryParams(cursor(or.Cursor), limit(or.Limit), or.Order)
+		if queryParams != "" {
+			endpoint = fmt.Sprintf("%s?%s", endpoint, queryParams)
+		}
+	} else {
+		query := url.Values{}
+		if len(or.Seller) > 0 {
+			query.Add("seller", or.Seller)
+		}
+		if len(or.Selling) > 0 {
+			query.Add("selling", or.Selling)
+		}
+		if len(or.Buying) > 0 {
+			query.Add("buying", or.Buying)
+		}
 
-	queryParams := addQueryParams(cursor(or.Cursor), limit(or.Limit), or.Order)
-	if queryParams != "" {
-		endpoint = fmt.Sprintf("%s?%s", endpoint, queryParams)
+		endpoint = fmt.Sprintf("offers?%s", query.Encode())
+		pageParams := addQueryParams(cursor(or.Cursor), limit(or.Limit), or.Order)
+		if pageParams != "" {
+			endpoint = fmt.Sprintf("%s&%s", endpoint, pageParams)
+		}
 	}
 
 	_, err = url.Parse(endpoint)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Extend SDK to allow fetching offers from the `/offers` endpoint, supporting any of its current filters.

### Why

This endpoint will be availabe on Horizon 1.0.

### Known limitations

[TODO or N/A]