### PR TITLE
clients/horizonclient: Support paths/strict-send and paths/strict-receive requests.

### DIFF
--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -410,8 +410,15 @@ func (c *Client) OrderBook(request OrderBookRequest) (obs hProtocol.OrderBookSum
 	return
 }
 
-// Paths returns the available paths to make a payment. See https://www.stellar.org/developers/horizon/reference/endpoints/path-finding.html
+// Paths returns the available paths to make a strict receive path payment. See https://www.stellar.org/developers/horizon/reference/endpoints/path-finding-strict-receive.html
+// This function is an alias for `client.StrictReceivePaths` and will be deprecated, use `client.StrictReceivePaths` instead.
 func (c *Client) Paths(request PathsRequest) (paths hProtocol.PathsPage, err error) {
+	paths, err = c.StrictReceivePaths(request)
+	return
+}
+
+// StrictReceivePaths returns the available paths to make a strict receive path payment. See https://www.stellar.org/developers/horizon/reference/endpoints/path-finding-strict-receive.html
+func (c *Client) StrictReceivePaths(request PathsRequest) (paths hProtocol.PathsPage, err error) {
 	err = c.sendRequest(request, &paths)
 	return
 }

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -416,6 +416,12 @@ func (c *Client) Paths(request PathsRequest) (paths hProtocol.PathsPage, err err
 	return
 }
 
+// StrictSendPaths returns the available paths to make a strict send path payment. See https://www.stellar.org/developers/horizon/reference/endpoints/path-finding-strict-send.html
+func (c *Client) StrictSendPaths(request StrictSendPathsRequest) (paths hProtocol.PathsPage, err error) {
+	err = c.sendRequest(request, &paths)
+	return
+}
+
 // Payments returns stellar account_merge, create_account, path payment and payment operations.
 // It can be used to return payments for an account, a ledger, a transaction and all payments on the network.
 func (c *Client) Payments(request OperationRequest) (ops operations.OperationsPage, err error) {

--- a/clients/horizonclient/examples_test.go
+++ b/clients/horizonclient/examples_test.go
@@ -513,7 +513,7 @@ func ExampleClient_Paths() {
 		DestinationAssetType:   horizonclient.AssetType4,
 		SourceAccount:          "GDZST3XVCDTUJ76ZAV2HA72KYQODXXZ5PTMAPZGDHZ6CS7RO7MGG3DBM",
 	}
-	paths, err := client.Paths(pr)
+	paths, err := client.StrictReceivePaths(pr)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/clients/horizonclient/examples_test.go
+++ b/clients/horizonclient/examples_test.go
@@ -521,6 +521,24 @@ func ExampleClient_Paths() {
 	fmt.Print(paths)
 }
 
+func ExampleClient_StrictSendPaths() {
+	client := horizonclient.DefaultPublicNetClient
+	// Find paths for USD->EUR
+	pr := horizonclient.StrictSendPathsRequest{
+		SourceAmount:      "20",
+		SourceAssetCode:   "USD",
+		SourceAssetIssuer: "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX",
+		SourceAssetType:   horizonclient.AssetType4,
+		DestinationAssets: "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+	}
+	paths, err := client.StrictSendPaths(pr)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(paths)
+}
+
 func ExampleClient_Payments() {
 	client := horizonclient.DefaultPublicNetClient
 	// payments for an account

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -346,6 +346,17 @@ type PathsRequest struct {
 	SourceAccount          string
 }
 
+// StrictSendPathsRequest struct contains data for getting available payment paths from a horizon server.
+// All parameters are required.
+type StrictSendPathsRequest struct {
+	DestinationAccount string
+	DestinationAssets  string
+	SourceAssetType    AssetType
+	SourceAssetCode    string
+	SourceAssetIssuer  string
+	SourceAmount       string
+}
+
 // TradeRequest struct contains data for getting trade details from a horizon server.
 // "ForAccount", "ForOfferID": Only one of these can be set at a time. If none are provided, the
 // default is to return all trades.

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -346,8 +346,10 @@ type PathsRequest struct {
 	SourceAccount          string
 }
 
-// StrictSendPathsRequest struct contains data for getting available payment paths from a horizon server.
-// All parameters are required.
+// StrictSendPathsRequest struct contains data for getting available strict send paths from a horizon server.
+// All the Source related parameters are required and you need to include either
+// DestinationAccount or DestinationAssets.
+// See https://www.stellar.org/developers/horizon/reference/endpoints/path-finding-strict-send.html
 type StrictSendPathsRequest struct {
 	DestinationAccount string
 	DestinationAssets  string

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -335,8 +335,10 @@ type OrderBookRequest struct {
 	Limit              uint
 }
 
-// PathsRequest struct contains data for getting available payment paths from a horizon server.
-// All parameters are required.
+// PathsRequest struct contains data for getting available strict receive path payments from a horizon server.
+// All the Destination related parameters are required and you need to include either
+// SourceAccount or SourceAssets.
+// See https://www.stellar.org/developers/horizon/reference/endpoints/path-finding-strict-receive.html
 type PathsRequest struct {
 	DestinationAccount     string
 	DestinationAssetType   AssetType
@@ -344,9 +346,10 @@ type PathsRequest struct {
 	DestinationAssetIssuer string
 	DestinationAmount      string
 	SourceAccount          string
+	SourceAssets           string
 }
 
-// StrictSendPathsRequest struct contains data for getting available strict send paths from a horizon server.
+// StrictSendPathsRequest struct contains data for getting available strict send path payments from a horizon server.
 // All the Source related parameters are required and you need to include either
 // DestinationAccount or DestinationAssets.
 // See https://www.stellar.org/developers/horizon/reference/endpoints/path-finding-strict-send.html

--- a/clients/horizonclient/paths_request.go
+++ b/clients/horizonclient/paths_request.go
@@ -20,6 +20,7 @@ func (pr PathsRequest) BuildURL() (endpoint string, err error) {
 	paramMap["destination_asset_issuer"] = pr.DestinationAssetIssuer
 	paramMap["destination_amount"] = pr.DestinationAmount
 	paramMap["source_account"] = pr.SourceAccount
+	paramMap["source_assets"] = pr.SourceAssets
 
 	queryParams := addQueryParams(paramMap)
 	if queryParams != "" {

--- a/clients/horizonclient/strict_send_paths_request.go
+++ b/clients/horizonclient/strict_send_paths_request.go
@@ -1,0 +1,35 @@
+package horizonclient
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/stellar/go/support/errors"
+)
+
+// BuildURL creates the endpoint to be queried based on the data in the PathsRequest struct.
+func (pr StrictSendPathsRequest) BuildURL() (endpoint string, err error) {
+	endpoint = "paths/strict-send"
+
+	// add the parameters to a map here so it is easier for addQueryParams to populate the parameter list
+	// We can't use assetCode and assetIssuer types here because the paremeter names are different
+	paramMap := make(map[string]string)
+	paramMap["destination_assets"] = pr.DestinationAssets
+	paramMap["destination_account"] = pr.DestinationAccount
+	paramMap["source_asset_type"] = string(pr.SourceAssetType)
+	paramMap["source_asset_code"] = pr.SourceAssetCode
+	paramMap["source_asset_issuer"] = pr.SourceAssetIssuer
+	paramMap["source_amount"] = pr.SourceAmount
+
+	queryParams := addQueryParams(paramMap)
+	if queryParams != "" {
+		endpoint = fmt.Sprintf("%s?%s", endpoint, queryParams)
+	}
+
+	_, err = url.Parse(endpoint)
+	if err != nil {
+		err = errors.Wrap(err, "failed to parse endpoint")
+	}
+
+	return endpoint, err
+}

--- a/clients/horizonclient/strict_send_paths_request.go
+++ b/clients/horizonclient/strict_send_paths_request.go
@@ -12,7 +12,7 @@ func (pr StrictSendPathsRequest) BuildURL() (endpoint string, err error) {
 	endpoint = "paths/strict-send"
 
 	// add the parameters to a map here so it is easier for addQueryParams to populate the parameter list
-	// We can't use assetCode and assetIssuer types here because the paremeter names are different
+	// We can't use assetCode and assetIssuer types here because the parameter names are different
 	paramMap := make(map[string]string)
 	paramMap["destination_assets"] = pr.DestinationAssets
 	paramMap["destination_account"] = pr.DestinationAccount

--- a/clients/horizonclient/strict_send_paths_request_test.go
+++ b/clients/horizonclient/strict_send_paths_request_test.go
@@ -1,0 +1,117 @@
+package horizonclient
+
+import (
+	"testing"
+
+	"github.com/stellar/go/support/http/httptest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStrictSendPathsRequestBuildUrl(t *testing.T) {
+	pr := StrictSendPathsRequest{}
+	endpoint, err := pr.BuildURL()
+
+	// It should return no errors and paths endpoint
+	// Horizon will return an error though because there are no parameters
+	require.NoError(t, err)
+	assert.Equal(t, "paths/strict-send", endpoint)
+
+	pr = StrictSendPathsRequest{
+		SourceAmount:       "100",
+		SourceAssetCode:    "NGN",
+		SourceAssetIssuer:  "GDZST3XVCDTUJ76ZAV2HA72KYQODXXZ5PTMAPZGDHZ6CS7RO7MGG3DBM",
+		SourceAssetType:    AssetType4,
+		DestinationAccount: "GDZST3XVCDTUJ76ZAV2HA72KYQODXXZ5PTMAPZGDHZ6CS7RO7MGG3DBM",
+	}
+
+	endpoint, err = pr.BuildURL()
+
+	// It should return a valid endpoint and no errors
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"paths/strict-send?destination_account=GDZST3XVCDTUJ76ZAV2HA72KYQODXXZ5PTMAPZGDHZ6CS7RO7MGG3DBM&source_amount=100&source_asset_code=NGN&source_asset_issuer=GDZST3XVCDTUJ76ZAV2HA72KYQODXXZ5PTMAPZGDHZ6CS7RO7MGG3DBM&source_asset_type=credit_alphanum4",
+		endpoint,
+	)
+
+	pr = StrictSendPathsRequest{
+		SourceAmount:      "100",
+		SourceAssetCode:   "USD",
+		SourceAssetIssuer: "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX",
+		SourceAssetType:   AssetType4,
+		DestinationAssets: "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S,native",
+	}
+
+	endpoint, err = pr.BuildURL()
+
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"paths/strict-send?destination_assets=EURT%3AGAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S%2Cnative&source_amount=100&source_asset_code=USD&source_asset_issuer=GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX&source_asset_type=credit_alphanum4",
+		endpoint,
+	)
+}
+func TestStrictSendPathsRequest(t *testing.T) {
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	pr := StrictSendPathsRequest{
+		SourceAmount:       "20",
+		SourceAssetCode:    "USD",
+		SourceAssetIssuer:  "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+		SourceAssetType:    AssetType4,
+		DestinationAccount: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+	}
+
+	hmock.On(
+		"GET",
+		"https://localhost/paths/strict-send?destination_account=GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU&source_amount=20&source_asset_code=USD&source_asset_issuer=GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN&source_asset_type=credit_alphanum4",
+	).ReturnString(200, pathsResponse)
+
+	paths, err := client.StrictSendPaths(pr)
+	assert.NoError(t, err)
+	assert.Len(t, paths.Embedded.Records, 3)
+
+	pr = StrictSendPathsRequest{
+		SourceAmount:      "20",
+		SourceAssetCode:   "USD",
+		SourceAssetIssuer: "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+		SourceAssetType:   AssetType4,
+		DestinationAssets: "EUR:GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+	}
+
+	hmock.On(
+		"GET",
+		"https://localhost/paths/strict-send?destination_assets=EUR%3AGDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN&source_amount=20&source_asset_code=USD&source_asset_issuer=GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN&source_asset_type=credit_alphanum4",
+	).ReturnString(200, pathsResponse)
+
+	paths, err = client.StrictSendPaths(pr)
+	assert.NoError(t, err)
+	assert.Len(t, paths.Embedded.Records, 3)
+
+	pr = StrictSendPathsRequest{
+		SourceAmount:       "20",
+		SourceAssetCode:    "USD",
+		SourceAssetIssuer:  "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+		SourceAssetType:    AssetType4,
+		DestinationAssets:  "EUR:GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+		DestinationAccount: "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+	}
+
+	hmock.On(
+		"GET",
+		"https://localhost/paths/strict-send?destination_account=GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN&destination_assets=EUR%3AGDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN&source_amount=20&source_asset_code=USD&source_asset_issuer=GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN&source_asset_type=credit_alphanum4",
+	).ReturnString(400, badRequestResponse)
+
+	_, err = client.StrictSendPaths(pr)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "horizon error")
+		horizonError, ok := err.(*Error)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, horizonError.Problem.Title, "Bad Request")
+	}
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Extend horizonclient to support request to [/paths/strict-send](https://www.stellar.org/developers/horizon/reference/endpoints/path-finding-strict-send.html)  and [/paths/strict-receive](https://www.stellar.org/developers/horizon/reference/endpoints/path-finding-strict-receive.html) 

This PR also changes `client.Paths` to be an alias for `client.StrictReceivePaths`. 

### Why

This is a new end-point in Horizon 1.0

### Known limitations

[TODO or N/A]
