### PR TITLE
services/horizon/internal/expingest: Allow horizon db reingest range to run concurrently with Horizon

### DIFF
--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -106,7 +106,7 @@ var dbReapCmd = &cobra.Command{
 var dbReingestCmd = &cobra.Command{
 	Use:   "reingest",
 	Short: "reingest commands",
-	Long:  "reingest backfills historical ingestion data for every ledger or ledgers specified by subcommand",
+	Long:  "reingest ingests historical data for every ledger or ledgers specified by subcommand",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Use one of the subcomands...")
 		cmd.Usage()

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"database/sql"
 	"fmt"
+	"go/types"
 	"log"
 	"os"
 	"strconv"
@@ -11,7 +12,9 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stellar/go/services/horizon/internal/db2/schema"
 	"github.com/stellar/go/services/horizon/internal/expingest"
+	support "github.com/stellar/go/support/config"
 	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/support/errors"
 	hlog "github.com/stellar/go/support/log"
 )
 
@@ -103,11 +106,24 @@ var dbReapCmd = &cobra.Command{
 var dbReingestCmd = &cobra.Command{
 	Use:   "reingest",
 	Short: "reingest commands",
-	Long:  "reingest runs the ingestion pipeline over every ledger or ledgers specified by subcommand",
+	Long:  "reingest backfills historical ingestion data for every ledger or ledgers specified by subcommand",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Use one of the subcomands...")
 		cmd.Usage()
 		os.Exit(1)
+	},
+}
+
+var reingestForce bool
+var reingestRangeCmdOpts = []*support.ConfigOption{
+	&support.ConfigOption{
+		Name:        "force",
+		ConfigKey:   &reingestForce,
+		OptType:     types.Bool,
+		Required:    false,
+		FlagDefault: false,
+		Usage: "[optional] if this flag is set, horizon will be blocked " +
+			"from ingesting until the reingestion command completes",
 	},
 }
 
@@ -116,19 +132,24 @@ var dbReingestRangeCmd = &cobra.Command{
 	Short: "reingests ledgers within a range",
 	Long:  "reingests ledgers between X and Y sequence number (closed intervals)",
 	Run: func(cmd *cobra.Command, args []string) {
+		for _, co := range reingestRangeCmdOpts {
+			co.Require()
+			co.SetValue()
+		}
+
 		if len(args) != 2 {
 			cmd.Usage()
 			os.Exit(1)
 		}
 
-		argsInt32 := make([]uint32, 0, len(args))
-		for _, arg := range args {
+		argsInt32 := make([]uint32, 2)
+		for i, arg := range args {
 			seq, err := strconv.Atoi(arg)
 			if err != nil {
 				cmd.Usage()
 				log.Fatalf(`Invalid sequence number "%s"`, arg)
 			}
-			argsInt32 = append(argsInt32, uint32(seq))
+			argsInt32[i] = uint32(seq)
 		}
 
 		initRootConfig()
@@ -159,16 +180,39 @@ var dbReingestRangeCmd = &cobra.Command{
 		err = system.ReingestRange(
 			argsInt32[0],
 			argsInt32[1],
+			reingestForce,
 		)
-		if err != nil {
-			log.Fatal(err)
+		if err == nil {
+			hlog.Info("Range run successfully!")
+			return
 		}
 
-		hlog.Info("Range run successfully!")
+		if errors.Cause(err) == expingest.ErrReingestRangeConflict {
+			message := `
+			The range you have provided overlaps with Horizon's most recently ingested ledger.
+			It is not possible to run the reingest command on this range in parallel with
+			Horizon's ingestion system.
+			Either reduce the range so that it doesn't overlap with Horizon's ingestion system,
+			or, use the force flag to ensure that Horizon's ingestion system is blocked until
+			the reingest command completes.
+			`
+			log.Fatal(message)
+		}
+
+		log.Fatal(err)
 	},
 }
 
 func init() {
+	for _, co := range reingestRangeCmdOpts {
+		err := co.Init(dbReingestRangeCmd)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+	}
+
+	viper.BindPFlags(dbReingestRangeCmd.PersistentFlags())
+
 	rootCmd.AddCommand(dbCmd)
 	dbCmd.AddCommand(
 		dbInitCmd,

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -209,12 +209,11 @@ func (s *System) VerifyRange(fromLedger, toLedger uint32, verifyState bool) erro
 
 // ReingestRange runs the ingestion pipeline on the range of ledgers ingesting
 // history data only.
-func (s *System) ReingestRange(fromLedger, toLedger uint32) error {
-	return s.runStateMachine(historyRangeState{
-		fromLedger:       fromLedger,
-		toLedger:         fromLedger,
-		shutdownWhenDone: true,
-		clearHistory:     true,
+func (s *System) ReingestRange(fromLedger, toLedger uint32, force bool) error {
+	return s.runStateMachine(reingestHistoryRangeState{
+		fromLedger: fromLedger,
+		toLedger:   toLedger,
+		force:      force,
 	})
 }
 

--- a/services/horizon/internal/expingest/main_test.go
+++ b/services/horizon/internal/expingest/main_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/services/horizon/internal/toid"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
@@ -127,38 +126,6 @@ func TestStateMachineTransition(t *testing.T) {
 	assert.PanicsWithValue(t, "unexpected transaction", func() {
 		system.Run()
 	})
-}
-
-// TestReingestRange ensures that state params are correctly passed.
-func TestReingestRange(t *testing.T) {
-	historyQ := &mockDBQ{}
-	runner := &mockProcessorsRunner{}
-	system := &System{
-		historyQ: historyQ,
-		runner:   runner,
-		ctx:      context.Background(),
-	}
-
-	historyQ.On("GetTx").Return(nil).Once()
-
-	historyQ.On("Begin").Return(nil).Once()
-	historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
-
-	toidEnd := toid.New(11, 0, 0).ToInt64()
-	historyQ.On("DeleteRangeAll", int64(0), toidEnd).Return(nil).Once()
-	assert.Equal(t, int64(47244640256), toidEnd)
-
-	for i := 1; i <= 10; i++ {
-		runner.On("RunTransactionProcessorsOnLedger", uint32(i)).Return(nil).Once()
-	}
-
-	historyQ.On("Commit").Return(nil).Once()
-	historyQ.On("Rollback").Return(nil).Once()
-
-	system.ReingestRange(1, 10)
-
-	historyQ.AssertExpectations(t)
-	runner.AssertExpectations(t)
 }
 
 func TestContextCancel(t *testing.T) {

--- a/services/horizon/internal/expingest/main_test.go
+++ b/services/horizon/internal/expingest/main_test.go
@@ -216,6 +216,11 @@ func (m *mockDBQ) GetLastLedgerExpIngest() (uint32, error) {
 	return args.Get(0).(uint32), args.Error(1)
 }
 
+func (m *mockDBQ) GetLastLedgerExpIngestNonBlocking() (uint32, error) {
+	args := m.Called()
+	return args.Get(0).(uint32), args.Error(1)
+}
+
 func (m *mockDBQ) GetExpIngestVersion() (int, error) {
 	args := m.Called()
 	return args.Get(0).(int), args.Error(1)


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

* Separate `horizon db reingest range` code from `historyRangeState`
* Add a force flag to the `horizon db reingest range` command

Fixes https://github.com/stellar/go/issues/2231

### Why

Currently when you run `horizon db reingest range` horizon ingestion is effectively  paused until the command completes. This happens because all entry points into the ingestion system begin by acquiring a select for update lock. This lock prevents multiple actors from ingesting the same data at the same time. 

This PR modifies the behavior of `horizon db reingest range` so that it can run without the select for update lock. The reingest command is allowed to run ingestion without the lock on the condition that the last ingested ledger by horizon is either 0 or ahead of the range we want to reingest. We don't want the reingest range to overlap with horizon because in that case the reingest command and horizon will attempt to insert the same data and it will cause one of the two components to fail.

Note: there is a force flag which allows you to run the reingest command on a range which overlaps with horizon. When the force flag is applied, the reingest command will block horizon ingestion by acquiring the select for update lock.

 
### Known limitations

[N/A]
