### PR TITLE
support/http/httpdecode: add decoding of querys

### DIFF
--- a/support/http/httpdecode/httpdecode.go
+++ b/support/http/httpdecode/httpdecode.go
@@ -61,6 +61,7 @@ func DecodeForm(r *http.Request, v interface{}) error {
 }
 
 // Decode decodes form URL encoded requests and JSON requests from r into v.
+// Also decodes query parameters.
 //
 // The requests Content-Type header informs if the request should be decoded
 // using a form URL encoded decoder or using a JSON decoder.
@@ -74,8 +75,8 @@ func DecodeForm(r *http.Request, v interface{}) error {
 // An error is returned if the Content-Type cannot be parsed by a mime
 // media-type parser.
 //
-// See DecodeForm and DecodeJSON for details about the types of errors that may
-// occur.
+// See DecodeQuery, DecodeForm and DecodeJSON for details about the types of
+// errors that may occur.
 func Decode(r *http.Request, v interface{}) error {
 	err := DecodeQuery(r, v)
 	if err != nil {

--- a/support/http/httpdecode/httpdecode.go
+++ b/support/http/httpdecode/httpdecode.go
@@ -9,6 +9,14 @@ import (
 	"github.com/stellar/go/support/errors"
 )
 
+// DecodeQuery decodes the query string from r into v.
+func DecodeQuery(r *http.Request, v interface{}) error {
+	dec := schema.NewDecoder()
+	dec.SetAliasTag("query")
+	dec.IgnoreUnknownKeys(true)
+	return dec.Decode(v, r.URL.Query())
+}
+
 // DecodeJSON decodes JSON request from r into v.
 func DecodeJSON(r *http.Request, v interface{}) error {
 	dec := json.NewDecoder(r.Body)
@@ -69,6 +77,10 @@ func DecodeForm(r *http.Request, v interface{}) error {
 // See DecodeForm and DecodeJSON for details about the types of errors that may
 // occur.
 func Decode(r *http.Request, v interface{}) error {
+	err := DecodeQuery(r, v)
+	if err != nil {
+		return errors.Wrap(err, "query could not be parsed")
+	}
 	contentType := r.Header.Get("Content-Type")
 	if contentType != "" {
 		mediaType, _, err := mime.ParseMediaType(contentType)

--- a/support/http/httpdecode/httpdecode_test.go
+++ b/support/http/httpdecode/httpdecode_test.go
@@ -1,6 +1,7 @@
 package httpdecode
 
 import (
+	"bufio"
 	"net/http"
 	"strings"
 	"testing"
@@ -8,6 +9,62 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDecodeQuery_valid(t *testing.T) {
+	q := "foo=bar&list=a&list=b&enc=%2B+-%2F"
+	r, _ := http.NewRequest("POST", "/?"+q, nil)
+
+	queryDecoded := struct {
+		Foo  string   `query:"foo"`
+		List []string `query:"list"`
+		Enc  string   `query:"enc"`
+	}{}
+	err := DecodeQuery(r, &queryDecoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "bar", queryDecoded.Foo)
+	assert.ElementsMatch(t, []string{"a", "b"}, queryDecoded.List)
+	assert.Equal(t, "+ -/", queryDecoded.Enc)
+}
+
+func TestDecodeQuery_validNone(t *testing.T) {
+	r, _ := http.NewRequest("POST", "/", nil)
+
+	queryDecoded := struct {
+		Foo  string   `query:"foo"`
+		List []string `query:"list"`
+		Enc  string   `query:"enc"`
+	}{}
+	err := DecodeQuery(r, &queryDecoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "", queryDecoded.Foo)
+	assert.Empty(t, queryDecoded.List)
+	assert.Equal(t, "", queryDecoded.Enc)
+}
+
+// Test that DecodeQuery ignores query parameters that are invalid in the same
+// way that reading out query parameters that are invalid is normally ignored
+// with the built-in net/http package.
+func TestDecodeQuery_invalid(t *testing.T) {
+	req := `GET /?far=baf&enc=%2%B+-%2F&foo=bar HTTP/1.1
+
+`
+	r, err := http.ReadRequest(bufio.NewReader(strings.NewReader(req)))
+	require.NoError(t, err)
+
+	queryDecoded := struct {
+		Far string `query:"far"`
+		Enc string `query:"enc"`
+		Foo string `query:"foo"`
+	}{}
+	err = DecodeQuery(r, &queryDecoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "baf", queryDecoded.Far)
+	assert.Equal(t, "", queryDecoded.Enc)
+	assert.Equal(t, "bar", queryDecoded.Foo)
+}
 
 func TestDecodeJSON_valid(t *testing.T) {
 	body := `{"foo":"bar"}`
@@ -236,4 +293,33 @@ func TestDecode_invalidForm(t *testing.T) {
 	err := Decode(r, &bodyDecoded)
 	assert.EqualError(t, err, `invalid URL escape "%=b"`)
 	assert.Equal(t, "", bodyDecoded.FooName)
+}
+
+func TestDecode_validFormAndQuery(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/?far=boo&foo=ba2", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+		FarName string `query:"far"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.FooName)
+	assert.Equal(t, "boo", bodyDecoded.FarName)
+}
+
+func TestDecode_validJSONAndQuery(t *testing.T) {
+	body := `{"foo":"bar"}`
+	r, _ := http.NewRequest("POST", "/?far=boo&foo=ba2", strings.NewReader(body))
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+		FarName string `query:"far"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.FooName)
+	assert.Equal(t, "boo", bodyDecoded.FarName)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Add decoding of queries from requests into structs to the `httpdecode` package in a new `DecodeQuery` function and into the existing `Decode` function.

### Why
We use httpdecode to decode requests into structs and this works really well for JSON and form bodys, but we have the odd endpoint that also has request parameters provided via the query string. In Horizon internals we have some code that works similar to this and pulls out the query parameters and upgrades them into the struct alongside other body parameters.

This change pulls some of that concept into a place we can use in more apps and maybe if it works well we can take this code back into Horizon via using `httpdecode.Decode` in the `support/render/httpjson` package.

This PR is a step towards that but that benefit won't be realized yet.

### Known limitations

N/A
