### PR TITLE
support/http/httpdecode: add decoding of path params

### DIFF
--- a/go.list
+++ b/go.list
@@ -29,7 +29,7 @@ github.com/fortytw2/leaktest v1.3.0
 github.com/fsnotify/fsnotify v1.4.7
 github.com/gavv/monotime v0.0.0-20161010190848-47d58efa6955
 github.com/getsentry/raven-go v0.0.0-20160805001729-c9d3cc542ad1
-github.com/go-chi/chi v3.1.5+incompatible
+github.com/go-chi/chi v4.0.3+incompatible
 github.com/go-errors/errors v0.0.0-20150906023321-a41850380601
 github.com/go-kit/kit v0.8.0
 github.com/go-logfmt/logfmt v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/fatih/structs v1.0.0 // indirect
 	github.com/gavv/monotime v0.0.0-20161010190848-47d58efa6955 // indirect
 	github.com/getsentry/raven-go v0.0.0-20160805001729-c9d3cc542ad1
-	github.com/go-chi/chi v3.1.5+incompatible
+	github.com/go-chi/chi v4.0.3+incompatible
 	github.com/go-errors/errors v0.0.0-20150906023321-a41850380601
 	github.com/gobuffalo/packr v1.12.1 // indirect
 	github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,6 @@ github.com/gavv/monotime v0.0.0-20161010190848-47d58efa6955 h1:gmtGRvSexPU4B1T/y
 github.com/gavv/monotime v0.0.0-20161010190848-47d58efa6955/go.mod h1:vmp8DIyckQMXOPl0AQVHt+7n5h7Gb7hS6CUydiV8QeA=
 github.com/getsentry/raven-go v0.0.0-20160805001729-c9d3cc542ad1 h1:qIqziX4EA/OBdmMgtaqdKBWWOZIfyXYClCoa56NgVEk=
 github.com/getsentry/raven-go v0.0.0-20160805001729-c9d3cc542ad1/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
-github.com/go-chi/chi v3.1.5+incompatible h1:TcUFIZz4n9dleJjD6lxsoqPJDiEVQEWcNjj3mevAEFQ=
-github.com/go-chi/chi v3.1.5+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/chi v4.0.3+incompatible h1:gakN3pDJnzZN5jqFV2TEdF66rTfKeITyR8qu6ekICEY=
 github.com/go-chi/chi v4.0.3+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-errors/errors v0.0.0-20150906023321-a41850380601 h1:jxTbmDuqQUTI6MscgbqB39vtxGfr2fi61nYIcFQUnlE=

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/getsentry/raven-go v0.0.0-20160805001729-c9d3cc542ad1 h1:qIqziX4EA/OB
 github.com/getsentry/raven-go v0.0.0-20160805001729-c9d3cc542ad1/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/go-chi/chi v3.1.5+incompatible h1:TcUFIZz4n9dleJjD6lxsoqPJDiEVQEWcNjj3mevAEFQ=
 github.com/go-chi/chi v3.1.5+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi v4.0.3+incompatible h1:gakN3pDJnzZN5jqFV2TEdF66rTfKeITyR8qu6ekICEY=
+github.com/go-chi/chi v4.0.3+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-errors/errors v0.0.0-20150906023321-a41850380601 h1:jxTbmDuqQUTI6MscgbqB39vtxGfr2fi61nYIcFQUnlE=
 github.com/go-errors/errors v0.0.0-20150906023321-a41850380601/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/support/http/httpdecode/httpdecode.go
+++ b/support/http/httpdecode/httpdecode.go
@@ -2,7 +2,6 @@ package httpdecode
 
 import (
 	"encoding/json"
-	"fmt"
 	"mime"
 	"net/http"
 

--- a/support/http/httpdecode/httpdecode.go
+++ b/support/http/httpdecode/httpdecode.go
@@ -27,7 +27,6 @@ func DecodePath(r *http.Request, v interface{}) error {
 		v := params.Values[i]
 		paramMap[k] = append(paramMap[k], v)
 	}
-	fmt.Println(params)
 	dec := schema.NewDecoder()
 	dec.SetAliasTag("path")
 	dec.IgnoreUnknownKeys(true)

--- a/support/http/httpdecode/httpdecode.go
+++ b/support/http/httpdecode/httpdecode.go
@@ -2,12 +2,37 @@ package httpdecode
 
 import (
 	"encoding/json"
+	"fmt"
 	"mime"
 	"net/http"
 
+	"github.com/go-chi/chi"
 	"github.com/gorilla/schema"
 	"github.com/stellar/go/support/errors"
 )
+
+// DecodePath decodes parameters from the path in a request used with the
+// github.com/go-chi/chi muxing module.
+func DecodePath(r *http.Request, v interface{}) error {
+	rctx := chi.RouteContext(r.Context())
+	if rctx == nil {
+		return nil
+	}
+	params := rctx.URLParams
+	paramMap := map[string][]string{}
+	for i, k := range params.Keys {
+		if i >= len(params.Values) {
+			break
+		}
+		v := params.Values[i]
+		paramMap[k] = append(paramMap[k], v)
+	}
+	fmt.Println(params)
+	dec := schema.NewDecoder()
+	dec.SetAliasTag("path")
+	dec.IgnoreUnknownKeys(true)
+	return dec.Decode(v, paramMap)
+}
 
 // DecodeQuery decodes the query string from r into v.
 func DecodeQuery(r *http.Request, v interface{}) error {
@@ -77,7 +102,11 @@ func DecodeForm(r *http.Request, v interface{}) error {
 // See DecodeForm and DecodeJSON for details about the types of errors that may
 // occur.
 func Decode(r *http.Request, v interface{}) error {
-	err := DecodeQuery(r, v)
+	err := DecodePath(r, v)
+	if err != nil {
+		return errors.Wrap(err, "path params could not be parsed")
+	}
+	err = DecodeQuery(r, v)
 	if err != nil {
 		return errors.Wrap(err, "query could not be parsed")
 	}

--- a/support/http/httpdecode/httpdecode.go
+++ b/support/http/httpdecode/httpdecode.go
@@ -9,6 +9,14 @@ import (
 	"github.com/stellar/go/support/errors"
 )
 
+// DecodeQuery decodes the query string from r into v.
+func DecodeQuery(r *http.Request, v interface{}) error {
+	dec := schema.NewDecoder()
+	dec.SetAliasTag("query")
+	dec.IgnoreUnknownKeys(true)
+	return dec.Decode(v, r.URL.Query())
+}
+
 // DecodeJSON decodes JSON request from r into v.
 func DecodeJSON(r *http.Request, v interface{}) error {
 	dec := json.NewDecoder(r.Body)
@@ -69,6 +77,10 @@ func DecodeForm(r *http.Request, v interface{}) error {
 // See DecodeForm and DecodeJSON for details about the types of errors that may
 // occur.
 func Decode(r *http.Request, v interface{}) error {
+	err := DecodeQuery(r, v)
+	if err != nil {
+		return errors.Wrap(err, "query could not be parsed")
+	}
 	contentType := r.Header.Get("Content-Type")
 	if contentType != "" {
 		mediaType, _, err := mime.ParseMediaType(contentType)

--- a/support/http/httpdecode/httpdecode.go
+++ b/support/http/httpdecode/httpdecode.go
@@ -84,7 +84,7 @@ func DecodeForm(r *http.Request, v interface{}) error {
 }
 
 // Decode decodes form URL encoded requests and JSON requests from r into v.
-// Also decodes query parameters.
+// Also decodes path (chi only) and query parameters.
 //
 // The requests Content-Type header informs if the request should be decoded
 // using a form URL encoded decoder or using a JSON decoder.
@@ -98,8 +98,8 @@ func DecodeForm(r *http.Request, v interface{}) error {
 // An error is returned if the Content-Type cannot be parsed by a mime
 // media-type parser.
 //
-// See DecodeQuery, DecodeForm and DecodeJSON for details about the types of
-// errors that may occur.
+// See DecodePath, DecodeQuery, DecodeForm and DecodeJSON for details about
+// the types of errors that may occur.
 func Decode(r *http.Request, v interface{}) error {
 	err := DecodePath(r, v)
 	if err != nil {

--- a/support/http/httpdecode/httpdecode_test.go
+++ b/support/http/httpdecode/httpdecode_test.go
@@ -1,6 +1,7 @@
 package httpdecode
 
 import (
+	"bufio"
 	"net/http"
 	"strings"
 	"testing"
@@ -8,6 +9,62 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDecodeQuery_valid(t *testing.T) {
+	q := "foo=bar&list=a&list=b&enc=%2B+-%2F"
+	r, _ := http.NewRequest("POST", "/?"+q, nil)
+
+	queryDecoded := struct {
+		Foo  string   `query:"foo"`
+		List []string `query:"list"`
+		Enc  string   `query:"enc"`
+	}{}
+	err := DecodeQuery(r, &queryDecoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "bar", queryDecoded.Foo)
+	assert.ElementsMatch(t, []string{"a", "b"}, queryDecoded.List)
+	assert.Equal(t, "+ -/", queryDecoded.Enc)
+}
+
+func TestDecodeQuery_validNone(t *testing.T) {
+	r, _ := http.NewRequest("POST", "/", nil)
+
+	queryDecoded := struct {
+		Foo  string   `query:"foo"`
+		List []string `query:"list"`
+		Enc  string   `query:"enc"`
+	}{}
+	err := DecodeQuery(r, &queryDecoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "", queryDecoded.Foo)
+	assert.Empty(t, queryDecoded.List)
+	assert.Equal(t, "", queryDecoded.Enc)
+}
+
+// Test that DecodeQuery ignores query parameters that are invalid in the same
+// way that reading out query parameters that are invalid is normally ignored
+// with the built-in net/http package.
+func TestDecodeQuery_invalid(t *testing.T) {
+	req := `GET /?far=baf&enc=%2%B+-%2F&foo=bar HTTP/1.1
+
+`
+	r, err := http.ReadRequest(bufio.NewReader(strings.NewReader(req)))
+	require.NoError(t, err)
+
+	queryDecoded := struct {
+		Far string `query:"far"`
+		Enc string `query:"enc"`
+		Foo string `query:"foo"`
+	}{}
+	err = DecodeQuery(r, &queryDecoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "baf", queryDecoded.Far)
+	assert.Equal(t, "", queryDecoded.Enc)
+	assert.Equal(t, "bar", queryDecoded.Foo)
+}
 
 func TestDecodeJSON_valid(t *testing.T) {
 	body := `{"foo":"bar"}`
@@ -236,4 +293,33 @@ func TestDecode_invalidForm(t *testing.T) {
 	err := Decode(r, &bodyDecoded)
 	assert.EqualError(t, err, `invalid URL escape "%=b"`)
 	assert.Equal(t, "", bodyDecoded.FooName)
+}
+
+func TestDecode_validFormAndQuery(t *testing.T) {
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/?far=boo&foo=ba2", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+		FarName string `query:"far"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.FooName)
+	assert.Equal(t, "boo", bodyDecoded.FarName)
+}
+
+func TestDecode_validJSONAndQuery(t *testing.T) {
+	body := `{"foo":"bar"}`
+	r, _ := http.NewRequest("POST", "/?far=boo&foo=ba2", strings.NewReader(body))
+
+	bodyDecoded := struct {
+		FooName string `json:"foo" form:"foo"`
+		FarName string `query:"far"`
+	}{}
+	err := Decode(r, &bodyDecoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", bodyDecoded.FooName)
+	assert.Equal(t, "boo", bodyDecoded.FarName)
 }

--- a/support/http/httpdecode/httpdecode_test.go
+++ b/support/http/httpdecode/httpdecode_test.go
@@ -409,3 +409,48 @@ func TestDecode_validJSONAndPath(t *testing.T) {
 	assert.Equal(t, "bar", decoded.FooName)
 	assert.Equal(t, "boo", decoded.FarName)
 }
+
+func TestDecode_validFormAndPathAndQuery(t *testing.T) {
+	decoded := struct {
+		FooName   string `json:"foo" form:"foo"`
+		FarName   string `path:"foo"`
+		QueryName string `query:"q"`
+	}{}
+
+	mux := chi.NewMux()
+	mux.Post("/path/{foo}/path", func(w http.ResponseWriter, r *http.Request) {
+		err := Decode(r, &decoded)
+		require.NoError(t, err)
+	})
+	w := httptest.NewRecorder()
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/path/boo/path?q=search+value", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	mux.ServeHTTP(w, r)
+
+	assert.Equal(t, "bar", decoded.FooName)
+	assert.Equal(t, "boo", decoded.FarName)
+	assert.Equal(t, "search value", decoded.QueryName)
+}
+
+func TestDecode_validJSONAndPathAndQuery(t *testing.T) {
+	decoded := struct {
+		FooName   string `json:"foo" form:"foo"`
+		FarName   string `path:"foo"`
+		QueryName string `query:"q"`
+	}{}
+
+	mux := chi.NewMux()
+	mux.Post("/path/{foo}/path", func(w http.ResponseWriter, r *http.Request) {
+		err := Decode(r, &decoded)
+		require.NoError(t, err)
+	})
+	w := httptest.NewRecorder()
+	body := `{"foo":"bar"}`
+	r, _ := http.NewRequest("POST", "/path/boo/path?q=search+value", strings.NewReader(body))
+	mux.ServeHTTP(w, r)
+
+	assert.Equal(t, "bar", decoded.FooName)
+	assert.Equal(t, "boo", decoded.FarName)
+	assert.Equal(t, "search value", decoded.QueryName)
+}

--- a/support/http/httpdecode/httpdecode_test.go
+++ b/support/http/httpdecode/httpdecode_test.go
@@ -3,12 +3,57 @@ package httpdecode
 import (
 	"bufio"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDecodePath_valid(t *testing.T) {
+	pathDecoded := struct {
+		Foo string `path:"foo"`
+	}{}
+	mux := chi.NewMux()
+	mux.Post("/path/{foo}/path", func(w http.ResponseWriter, r *http.Request) {
+		err := DecodePath(r, &pathDecoded)
+		require.NoError(t, err)
+	})
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("POST", "/path/bar/path", nil)
+	mux.ServeHTTP(w, r)
+
+	assert.Equal(t, "bar", pathDecoded.Foo)
+}
+
+func TestDecodePath_empty(t *testing.T) {
+	pathDecoded := struct {
+		Foo string `path:"foo"`
+	}{}
+	mux := chi.NewMux()
+	mux.Post("/path/{foo}/path", func(w http.ResponseWriter, r *http.Request) {
+		err := DecodePath(r, &pathDecoded)
+		require.NoError(t, err)
+	})
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("POST", "/path//path", nil)
+	mux.ServeHTTP(w, r)
+
+	assert.Equal(t, "", pathDecoded.Foo)
+}
+
+func TestDecodePath_notUsingChi(t *testing.T) {
+	pathDecoded := struct {
+		Foo string `path:"foo"`
+	}{}
+	r, _ := http.NewRequest("POST", "/path/bar/path", nil)
+	err := DecodePath(r, &pathDecoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "", pathDecoded.Foo)
+}
 
 func TestDecodeQuery_valid(t *testing.T) {
 	q := "foo=bar&list=a&list=b&enc=%2B+-%2F"
@@ -322,4 +367,45 @@ func TestDecode_validJSONAndQuery(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "bar", bodyDecoded.FooName)
 	assert.Equal(t, "boo", bodyDecoded.FarName)
+}
+
+func TestDecode_validFormAndPath(t *testing.T) {
+	decoded := struct {
+		FooName string `json:"foo" form:"foo"`
+		FarName string `path:"foo"`
+	}{}
+
+	mux := chi.NewMux()
+	mux.Post("/path/{foo}/path", func(w http.ResponseWriter, r *http.Request) {
+		err := Decode(r, &decoded)
+		require.NoError(t, err)
+	})
+	w := httptest.NewRecorder()
+	body := `foo=bar`
+	r, _ := http.NewRequest("POST", "/path/boo/path", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	mux.ServeHTTP(w, r)
+
+	assert.Equal(t, "bar", decoded.FooName)
+	assert.Equal(t, "boo", decoded.FarName)
+}
+
+func TestDecode_validJSONAndPath(t *testing.T) {
+	decoded := struct {
+		FooName string `json:"foo" form:"foo"`
+		FarName string `path:"foo"`
+	}{}
+
+	mux := chi.NewMux()
+	mux.Post("/path/{foo}/path", func(w http.ResponseWriter, r *http.Request) {
+		err := Decode(r, &decoded)
+		require.NoError(t, err)
+	})
+	w := httptest.NewRecorder()
+	body := `{"foo":"bar"}`
+	r, _ := http.NewRequest("POST", "/path/boo/path", strings.NewReader(body))
+	mux.ServeHTTP(w, r)
+
+	assert.Equal(t, "bar", decoded.FooName)
+	assert.Equal(t, "boo", decoded.FarName)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Add decoding of path parameters from requests into structs to the `httpdecode` package in a new `DecodePath` function and into the existing `Decode` function.

### Why
We use httpdecode to decode requests into structs and this works really well for JSON and form bodys, but we have the odd endpoint that also has request parameters provided via the path string. An example of this is where an endpoint is for an account. In some situations it might be convenient to use middleware to pick out those path parameters earlier on and provide it in the context. In other situations, which this PR addresses, it can keep our code more succinct if we include those path parameters into the request object that we're decoding the entire request into.

The hope is we can take this code into the `support/render/httpjson` package by having that package use `httpdecode.Decode` so that it is possible to capture all the request input in a single object for the handler.

This PR is a step towards that but that benefit won't be realized yet.

### Notes
This change includes an update to the version of chi that is in use. Version 4 of chi allows for retrieving the context safely even if it is not present.

### TODO
There are some outstanding things before this PR is ready for review:

- [x] This PR is intended to be merged after #2244 and contains the changes from that PR. After it is merged I need to merge master into this PR to remove them from the diff.
- [x] Check for any breaking changes in chi v4.0.3 that are meaningful to all our uses of chi.
- [x] Review the diff of chi v3.1.5 to v4.0.3.

### Known limitations

N/A
