### PR TITLE
keypair: add SignBase64 that returns signatures strings

### DIFF
--- a/keypair/from_address.go
+++ b/keypair/from_address.go
@@ -46,6 +46,10 @@ func (kp *FromAddress) Sign(input []byte) ([]byte, error) {
 	return nil, ErrCannotSign
 }
 
+func (kp *FromAddress) SignBase64(input []byte) (string, error) {
+	return "", ErrCannotSign
+}
+
 func (kp *FromAddress) SignDecorated(input []byte) (xdr.DecoratedSignature, error) {
 	return xdr.DecoratedSignature{}, ErrCannotSign
 }

--- a/keypair/from_address_test.go
+++ b/keypair/from_address_test.go
@@ -21,6 +21,13 @@ var _ = Describe("keypair.FromAddress", func() {
 		})
 
 	})
+	Describe("SignBase64()", func() {
+		It("fails", func() {
+			_, err := subject.SignBase64(message)
+			Expect(err).To(HaveOccurred())
+		})
+
+	})
 	Describe("SignDecorated()", func() {
 		It("fails", func() {
 			_, err := subject.SignDecorated(message)

--- a/keypair/full.go
+++ b/keypair/full.go
@@ -2,6 +2,7 @@ package keypair
 
 import (
 	"bytes"
+	"encoding/base64"
 
 	"github.com/stellar/go/strkey"
 	"github.com/stellar/go/xdr"
@@ -45,6 +46,16 @@ func (kp *Full) Verify(input []byte, sig []byte) error {
 func (kp *Full) Sign(input []byte) ([]byte, error) {
 	_, priv := kp.keys()
 	return xdr.Signature(ed25519.Sign(priv, input)[:]), nil
+}
+
+// SignBase64 signs the input data and returns a base64 encoded string, the
+// common format signatures are exchanged.
+func (kp *Full) SignBase64(input []byte) (string, error) {
+	sig, err := kp.Sign(input)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(sig), nil
 }
 
 func (kp *Full) SignDecorated(input []byte) (xdr.DecoratedSignature, error) {

--- a/keypair/full.go
+++ b/keypair/full.go
@@ -49,7 +49,7 @@ func (kp *Full) Sign(input []byte) ([]byte, error) {
 }
 
 // SignBase64 signs the input data and returns a base64 encoded string, the
-// common format signatures are exchanged.
+// common format in which signatures are exchanged.
 func (kp *Full) SignBase64(input []byte) (string, error) {
 	sig, err := kp.Sign(input)
 	if err != nil {

--- a/keypair/full_test.go
+++ b/keypair/full_test.go
@@ -41,6 +41,24 @@ var _ = Describe("keypair.Full", func() {
 		}),
 	)
 
+	DescribeTable("SignBase64()",
+		func(c SignCase) {
+			sig, err := subject.SignBase64([]byte(c.Message))
+
+			Expect(sig).To(Equal(c.Signature))
+			Expect(err).To(BeNil())
+		},
+
+		Entry("hello", SignCase{
+			"hello",
+			"LnXMINUZERyqqt3fRku2UNLq8KXRjXRWk6FhAPKkk3vB3/qLCx9honaZbX7o3rLQ3Z7lEFVgd7At7BZ5LpFcCg==",
+		}),
+		Entry("this is a message", SignCase{
+			"this is a message",
+			"e36Z09ZgpTkTBk1dqWq8+gxCKojx3KfxTNvSIEW1UAMOYPzRqthf0Iu3Ql2VymkMj2MjGJX2sN18DHNyJwkqAA==",
+		}),
+	)
+
 	Describe("SignDecorated()", func() {
 		It("returns the correct xdr struct", func() {
 			sig, err := subject.SignDecorated(message)

--- a/keypair/main.go
+++ b/keypair/main.go
@@ -38,6 +38,7 @@ type KP interface {
 	Hint() [4]byte
 	Verify(input []byte, signature []byte) error
 	Sign(input []byte) ([]byte, error)
+	SignBase64(input []byte) (string, error)
 	SignDecorated(input []byte) (xdr.DecoratedSignature, error)
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] ~I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).~

### Release planning

* [x] ~I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.~
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

keypair: add SignBase64 that returns signatures strings

### What
Add `SignBase64` to the `keypair.KP`, `keypair.Full`, and
`keypair.FromAddress` types that performs the same operation as `Sign`
but returns the signature as a base64 encoded string.

### Why
In the ecosystem we exchange signatures as base64 strings. In the
Stellar Labratory we display signatures as base64 strings. In the
JavaScript SDK we have functions that add signatures to transactions,
and those accept base64 encoded strings.

I'm writing code that will generate signatures and hand them to other
systems, but right now I don't see any helpers we have for doing that in
a consistent way. This seems like the best place to add that.

### Known limitations

N/A
