### PR TITLE
services/horizon/internal: Support filtering offers by `buying` or `selling`.

### DIFF
--- a/services/horizon/internal/actions/helpers_test.go
+++ b/services/horizon/internal/actions/helpers_test.go
@@ -598,7 +598,6 @@ func TestGetParams(t *testing.T) {
 	}
 
 	account := "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
-	usd := xdr.MustNewCreditAsset("USD", account)
 
 	// Simulate chi's URL params. The following would be equivalent to having a
 	// chi route like the following `/accounts/{account_id}`

--- a/services/horizon/internal/actions/helpers_test.go
+++ b/services/horizon/internal/actions/helpers_test.go
@@ -780,6 +780,8 @@ func TestGetURIParams(t *testing.T) {
 		"buying_asset_type",
 		"buying_asset_issuer",
 		"buying_asset_code",
+		"selling",
+		"buying",
 		"account_id",
 	}
 

--- a/services/horizon/internal/actions/offer.go
+++ b/services/horizon/internal/actions/offer.go
@@ -3,7 +3,6 @@ package actions
 import (
 	"context"
 	"net/http"
-	"strings"
 
 	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -61,7 +60,8 @@ type OffersQuery struct {
 
 // URITemplate returns a rfc6570 URI template the query struct
 func (q OffersQuery) URITemplate() string {
-	return "/offers{?" + strings.Join(GetURIParams(&q, true), ",") + "}"
+	// building this manually since we don't want to include all the params in SellingBuyingAssetQueryParams
+	return "/offers{?selling,buying,seller,cursor,limit,order}"
 }
 
 // Validate runs custom validations.

--- a/services/horizon/internal/actions/offer_test.go
+++ b/services/horizon/internal/actions/offer_test.go
@@ -446,7 +446,7 @@ func pageableToOffers(t *testing.T, page []hal.Pageable) []horizon.Offer {
 
 func TestOffersQueryURLTemplate(t *testing.T) {
 	tt := assert.New(t)
-	expected := "/offers{?selling_asset_type,selling_asset_issuer,selling_asset_code,buying_asset_type,buying_asset_issuer,buying_asset_code,seller,cursor,limit,order}"
+	expected := "/offers{?selling,buying,seller,cursor,limit,order}"
 	offersQuery := OffersQuery{}
 	tt.Equal(expected, offersQuery.URITemplate())
 }

--- a/services/horizon/internal/actions/offer_test.go
+++ b/services/horizon/internal/actions/offer_test.go
@@ -302,6 +302,23 @@ func TestGetOffersHandler(t *testing.T) {
 
 		offers = pageableToOffers(t, records)
 		tt.Assert.Equal(asset, offers[0].Selling)
+
+		records, err = handler.GetResourcePage(
+			httptest.NewRecorder(),
+			makeRequest(
+				t,
+				map[string]string{
+					"selling": asset.Code + ":" + asset.Issuer,
+				},
+				map[string]string{},
+				q.Session,
+			),
+		)
+		tt.Assert.NoError(err)
+		tt.Assert.Len(records, 1)
+
+		offers = pageableToOffers(t, records)
+		tt.Assert.Equal(asset, offers[0].Selling)
 	})
 
 	t.Run("Filter by buying asset", func(t *testing.T) {
@@ -340,6 +357,25 @@ func TestGetOffersHandler(t *testing.T) {
 					"buying_asset_type":   asset.Type,
 					"buying_asset_code":   asset.Code,
 					"buying_asset_issuer": asset.Issuer,
+				},
+				map[string]string{},
+				q.Session,
+			),
+		)
+		tt.Assert.NoError(err)
+		tt.Assert.Len(records, 1)
+
+		offers = pageableToOffers(t, records)
+		for _, offer := range offers {
+			tt.Assert.Equal(asset, offer.Buying)
+		}
+
+		records, err = handler.GetResourcePage(
+			httptest.NewRecorder(),
+			makeRequest(
+				t,
+				map[string]string{
+					"buying": asset.Code + ":" + asset.Issuer,
 				},
 				map[string]string{},
 				q.Session,

--- a/services/horizon/internal/actions/query_params.go
+++ b/services/horizon/internal/actions/query_params.go
@@ -66,23 +66,23 @@ func (q SellingBuyingAssetQueryParams) Selling() *xdr.Asset {
 
 			return &asset
 		}
-	} else {
-		if len(q.SellingAssetType) == 0 {
-			return nil
-		}
-
-		selling, err := xdr.BuildAsset(
-			q.SellingAssetType,
-			q.SellingAssetIssuer,
-			q.SellingAssetCode,
-		)
-
-		if err != nil {
-			panic(err)
-		}
-
-		return &selling
 	}
+
+	if len(q.SellingAssetType) == 0 {
+		return nil
+	}
+
+	selling, err := xdr.BuildAsset(
+		q.SellingAssetType,
+		q.SellingAssetIssuer,
+		q.SellingAssetCode,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return &selling
 }
 
 // Buying returns an *xdr.Asset representing the buying side of the offer.
@@ -98,21 +98,21 @@ func (q SellingBuyingAssetQueryParams) Buying() *xdr.Asset {
 
 			return &asset
 		}
-	} else {
-		if len(q.BuyingAssetType) == 0 {
-			return nil
-		}
-
-		buying, err := xdr.BuildAsset(
-			q.BuyingAssetType,
-			q.BuyingAssetIssuer,
-			q.BuyingAssetCode,
-		)
-
-		if err != nil {
-			panic(err)
-		}
-
-		return &buying
 	}
+
+	if len(q.BuyingAssetType) == 0 {
+		return nil
+	}
+
+	buying, err := xdr.BuildAsset(
+		q.BuyingAssetType,
+		q.BuyingAssetIssuer,
+		q.BuyingAssetCode,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return &buying
 }

--- a/services/horizon/internal/actions/query_params.go
+++ b/services/horizon/internal/actions/query_params.go
@@ -1,6 +1,11 @@
 package actions
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/xdr"
 )
 
@@ -13,13 +18,33 @@ type SellingBuyingAssetQueryParams struct {
 	BuyingAssetType    string `schema:"buying_asset_type" valid:"assetType,optional"`
 	BuyingAssetIssuer  string `schema:"buying_asset_issuer" valid:"accountID,optional"`
 	BuyingAssetCode    string `schema:"buying_asset_code" valid:"-"`
+
+	// allow selling and buying using an asset's canonical representation. We
+	// are keeping the former selling_* and buying_* for backwards compatibility
+	// but it should not be documented.
+	SellingAsset string `schema:"selling" valid:"asset,optional"`
+	BuyingAsset  string `schema:"buying" valid:"asset,optional"`
 }
 
 // Validate runs custom validations buying and selling
 func (q SellingBuyingAssetQueryParams) Validate() error {
+	ambiguousErr := "Ambiguous parameter, you can't include both `%[1]s` and `%[1]s_asset_type`. Remove all parameters of the form `%[1]s_`"
+	if len(q.SellingAssetType) > 0 && len(q.SellingAsset) > 0 {
+		return problem.MakeInvalidFieldProblem(
+			"selling_asset_type",
+			errors.New(fmt.Sprintf(ambiguousErr, "selling")),
+		)
+	}
 	err := ValidateAssetParams(q.SellingAssetType, q.SellingAssetCode, q.SellingAssetIssuer, "selling_")
 	if err != nil {
 		return err
+	}
+
+	if len(q.BuyingAssetType) > 0 && len(q.BuyingAsset) > 0 {
+		return problem.MakeInvalidFieldProblem(
+			"buying_asset_type",
+			errors.New(fmt.Sprintf(ambiguousErr, "buying")),
+		)
 	}
 	err = ValidateAssetParams(q.BuyingAssetType, q.BuyingAssetCode, q.BuyingAssetIssuer, "buying_")
 	if err != nil {
@@ -30,38 +55,64 @@ func (q SellingBuyingAssetQueryParams) Validate() error {
 
 // Selling returns an xdr.Asset representing the selling side of the offer.
 func (q SellingBuyingAssetQueryParams) Selling() *xdr.Asset {
-	if len(q.SellingAssetType) == 0 {
-		return nil
+	if len(q.SellingAsset) > 0 {
+		switch q.SellingAsset {
+		case "native":
+			asset := xdr.MustNewNativeAsset()
+			return &asset
+		default:
+			parts := strings.Split(q.SellingAsset, ":")
+			asset := xdr.MustNewCreditAsset(parts[0], parts[1])
+
+			return &asset
+		}
+	} else {
+		if len(q.SellingAssetType) == 0 {
+			return nil
+		}
+
+		selling, err := xdr.BuildAsset(
+			q.SellingAssetType,
+			q.SellingAssetIssuer,
+			q.SellingAssetCode,
+		)
+
+		if err != nil {
+			panic(err)
+		}
+
+		return &selling
 	}
-
-	selling, err := xdr.BuildAsset(
-		q.SellingAssetType,
-		q.SellingAssetIssuer,
-		q.SellingAssetCode,
-	)
-
-	if err != nil {
-		panic(err)
-	}
-
-	return &selling
 }
 
 // Buying returns an *xdr.Asset representing the buying side of the offer.
 func (q SellingBuyingAssetQueryParams) Buying() *xdr.Asset {
-	if len(q.BuyingAssetType) == 0 {
-		return nil
+	if len(q.BuyingAsset) > 0 {
+		switch q.BuyingAsset {
+		case "native":
+			asset := xdr.MustNewNativeAsset()
+			return &asset
+		default:
+			parts := strings.Split(q.BuyingAsset, ":")
+			asset := xdr.MustNewCreditAsset(parts[0], parts[1])
+
+			return &asset
+		}
+	} else {
+		if len(q.BuyingAssetType) == 0 {
+			return nil
+		}
+
+		buying, err := xdr.BuildAsset(
+			q.BuyingAssetType,
+			q.BuyingAssetIssuer,
+			q.BuyingAssetCode,
+		)
+
+		if err != nil {
+			panic(err)
+		}
+
+		return &buying
 	}
-
-	buying, err := xdr.BuildAsset(
-		q.BuyingAssetType,
-		q.BuyingAssetIssuer,
-		q.BuyingAssetCode,
-	)
-
-	if err != nil {
-		panic(err)
-	}
-
-	return &buying
 }

--- a/services/horizon/internal/actions/query_params_test.go
+++ b/services/horizon/internal/actions/query_params_test.go
@@ -6,6 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/stellar/go/support/render/problem"
+	"github.com/stellar/go/xdr"
+)
+
+var (
+	native = xdr.MustNewNativeAsset()
 )
 
 func TestSellingBuyingAssetQueryParams(t *testing.T) {
@@ -184,6 +189,13 @@ func TestSellingBuyingAssetQueryParams(t *testing.T) {
 				"selling_asset_issuer": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 			},
 		},
+		{
+			desc: "Valid parameters with canonical representation",
+			urlParams: map[string]string{
+				"buying":  "USD:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+				"selling": "EUR:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -194,6 +206,93 @@ func TestSellingBuyingAssetQueryParams(t *testing.T) {
 
 			if len(tc.expectedInvalidField) == 0 {
 				tt.NoError(err)
+			} else {
+				if tt.IsType(&problem.P{}, err) {
+					p := err.(*problem.P)
+					tt.Equal("bad_request", p.Type)
+					tt.Equal(tc.expectedInvalidField, p.Extras["invalid_field"])
+					tt.Equal(
+						tc.expectedErr,
+						p.Extras["reason"],
+					)
+				}
+			}
+
+		})
+	}
+}
+
+func TestSellingBuyingAssetQueryParamsWithCanonicalRepresenation(t *testing.T) {
+
+	testCases := []struct {
+		desc                 string
+		urlParams            map[string]string
+		expectedSelling      *xdr.Asset
+		expectedBuying       *xdr.Asset
+		expectedInvalidField string
+		expectedErr          string
+	}{
+		{
+			desc: "selling native and buying issued asset",
+			urlParams: map[string]string{
+				"buying":  "native",
+				"selling": "EUR:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+			},
+			expectedBuying:  &native,
+			expectedSelling: &euro,
+		},
+		{
+			desc: "selling issued and buying native asset",
+			urlParams: map[string]string{
+				"buying":  "USD:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+				"selling": "native",
+			},
+			expectedBuying:  &usd,
+			expectedSelling: &native,
+		},
+		{
+			desc: "selling and buying issued assets",
+			urlParams: map[string]string{
+				"buying":  "USD:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+				"selling": "EUR:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+			},
+			expectedBuying:  &usd,
+			expectedSelling: &euro,
+		},
+		{
+			desc: "new and old format for buying",
+			urlParams: map[string]string{
+				"buying":              "USD:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+				"buying_asset_type":   "credit_alphanum4",
+				"buying_asset_code":   "USD",
+				"buying_asset_issuer": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+			},
+			expectedInvalidField: "buying_asset_type",
+			expectedErr:          "Ambiguous parameter, you can't include both `buying` and `buying_asset_type`. Remove all parameters of the form `buying_`",
+		},
+		{
+			desc: "new and old format for selling",
+			urlParams: map[string]string{
+				"selling":              "USD:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+				"selling_asset_type":   "credit_alphanum4",
+				"selling_asset_code":   "USD",
+				"selling_asset_issuer": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+			},
+			expectedInvalidField: "selling_asset_type",
+			expectedErr:          "Ambiguous parameter, you can't include both `selling` and `selling_asset_type`. Remove all parameters of the form `selling_`",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			tt := assert.New(t)
+			r := makeAction("/", tc.urlParams).R
+			qp := SellingBuyingAssetQueryParams{}
+			err := GetParams(&qp, r)
+
+			if len(tc.expectedInvalidField) == 0 {
+				tt.NoError(err)
+				tt.Equal(tc.expectedBuying, qp.Buying())
+				tt.Equal(tc.expectedSelling, qp.Selling())
 			} else {
 				if tt.IsType(&problem.P{}, err) {
 					p := err.(*problem.P)

--- a/services/horizon/internal/actions_root_test.go
+++ b/services/horizon/internal/actions_root_test.go
@@ -75,7 +75,7 @@ func TestRootActionWithIngestion(t *testing.T) {
 			actual.Links.Accounts.Href,
 		)
 		ht.Assert.Equal(
-			"http://localhost/offers{?selling_asset_type,selling_asset_issuer,selling_asset_code,buying_asset_type,buying_asset_issuer,buying_asset_code,seller,cursor,limit,order}",
+			"http://localhost/offers{?selling,buying,seller,cursor,limit,order}",
 			actual.Links.Offers.Href,
 		)
 

--- a/services/horizon/internal/actions_root_test.go
+++ b/services/horizon/internal/actions_root_test.go
@@ -40,35 +40,8 @@ func TestRootAction(t *testing.T) {
 		ht.Assert.Equal("test-core", actual.StellarCoreVersion)
 		ht.Assert.Equal(int32(4), actual.CoreSupportedProtocolVersion)
 		ht.Assert.Equal(int32(3), actual.CurrentProtocolVersion)
-	}
-}
 
-func TestRootActionWithIngestion(t *testing.T) {
-	ht := StartHTTPTest(t, "base")
-	defer ht.Finish()
-
-	server := test.NewStaticMockServer(`{
-			"info": {
-				"network": "test",
-				"build": "test-core",
-				"ledger": {
-					"version": 3
-				},
-				"protocol_version": 4
-			}
-		}`)
-	defer server.Close()
-
-	ht.App.horizonVersion = "test-horizon"
-	ht.App.config.StellarCoreURL = server.URL
-	ht.App.config.NetworkPassphrase = "test"
-	ht.App.UpdateStellarCoreInfo()
-
-	w := ht.Get("/")
-
-	if ht.Assert.Equal(200, w.Code) {
-		var actual horizon.Root
-		err := json.Unmarshal(w.Body.Bytes(), &actual)
+		err = json.Unmarshal(w.Body.Bytes(), &actual)
 		ht.Require.NoError(err)
 		ht.Assert.Equal(
 			"http://localhost/accounts{?signer,asset,cursor,limit,order}",

--- a/services/horizon/internal/docs/reference/endpoints/offers.md
+++ b/services/horizon/internal/docs/reference/endpoints/offers.md
@@ -18,12 +18,8 @@ GET /offers{?selling_asset_type,selling_asset_issuer,selling_asset_code,buying_a
 | name | notes | description | example |
 | ---- | ----- | ----------- | ------- |
 | `?seller` | optional, string | Account ID of the offer creator  | `GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36` |
-| `?selling_asset_type` | required, string | Type of the Asset being sold | `native` |
-| `?selling_asset_code` | required if `selling_asset_type` is not `native`, string | Code of the Asset being sold | `USD` |
-| `?selling_asset_issuer` | required if `selling_asset_type` is not `native`, string | Account ID of the issuer of the Asset being sold | `GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36` |
-| `?buying_asset_type` | required, string | Type of the Asset being bought | `credit_alphanum4` |
-| `?buying_asset_code` |   required if buying_asset_type is not `native`, string | Code of the Asset being bought | `BTC` |
-| `?buying_asset_issuer` | required if buying_asset_type is not `native`, string | Account ID of the issuer of the Asset being bought | `GD6VWBXI6NY3AOOR55RLVQ4MNIDSXE5JSAVXUTF35FRRI72LYPI3WL6Z` |
+| `?selling` | optional, string | Asset being sold | `native` or `EUR:GD6VWBXI6NY3AOOR55RLVQ4MNIDSXE5JSAVXUTF35FRRI72LYPI3WL6Z` |
+| `?buying` | optional, string | Asset being bought | `native` or `USD:GD6VWBXI6NY3AOOR55RLVQ4MNIDSXE5JSAVXUTF35FRRI72LYPI3WL6Z` |
 | `?cursor` | optional, any, default _null_ | A paging token, specifying where to start returning records from. | `12884905984` |
 | `?order`  | optional, string, default `asc` | The order in which to return rows, "asc" or "desc". | `asc` |
 | `?limit`  | optional, number, default: `10` | Maximum number of records to return. | `200` |


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Extend the offer end-point to support filtering using the canonical representation of an asset in the `selling` and `buying` query parameter.

Fix #2225.

### Why

Using `native` for Lumens or `AssetCode:AssetIssuer` for issued, brings a better developer experience than having to specify three different
query parameters to represent an asset.


### Known limitations