### PR TITLE
keypair: remove unnecessary cast

### DIFF
--- a/keypair/full.go
+++ b/keypair/full.go
@@ -44,7 +44,7 @@ func (kp *Full) Verify(input []byte, sig []byte) error {
 
 func (kp *Full) Sign(input []byte) ([]byte, error) {
 	_, priv := kp.keys()
-	return ed25519.Sign(priv, input)[:], nil
+	return ed25519.Sign(priv, input), nil
 }
 
 func (kp *Full) SignDecorated(input []byte) (xdr.DecoratedSignature, error) {

--- a/keypair/full.go
+++ b/keypair/full.go
@@ -44,7 +44,7 @@ func (kp *Full) Verify(input []byte, sig []byte) error {
 
 func (kp *Full) Sign(input []byte) ([]byte, error) {
 	_, priv := kp.keys()
-	return xdr.Signature(ed25519.Sign(priv, input)[:]), nil
+	return ed25519.Sign(priv, input)[:], nil
 }
 
 func (kp *Full) SignDecorated(input []byte) (xdr.DecoratedSignature, error) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove unnecessary cast of a `[]byte` to an `xdr.Signature` in the `keypair` packages `Sign` function.

### Why

The value is already a `[]byte` and doesn't need to be converted to an `xdr.Signature` and back to a `[]byte` again. The unnecessary casting makes it appear like the process of signing that is taking place here is specifically related to or controlled by the XDR package, but it isn't. The `Sign` function is a helper around taking a Stellar key and using it to perform standard ed25519 signing.

### Known limitations

N/A
