### PR TITLE
services/horizon/internal: Add test for invalid buying/selling asset.

### DIFF
--- a/services/horizon/internal/actions/query_params_test.go
+++ b/services/horizon/internal/actions/query_params_test.go
@@ -281,6 +281,22 @@ func TestSellingBuyingAssetQueryParamsWithCanonicalRepresenation(t *testing.T) {
 			expectedInvalidField: "selling_asset_type",
 			expectedErr:          "Ambiguous parameter, you can't include both `selling` and `selling_asset_type`. Remove all parameters of the form `selling_`",
 		},
+		{
+			desc: "invalid selling asset",
+			urlParams: map[string]string{
+				"selling": "LOLUSD",
+			},
+			expectedInvalidField: "selling",
+			expectedErr:          "Asset must be the string \"native\" or a string of the form \"Code:IssuerAccountID\" for issued assets.",
+		},
+		{
+			desc: "invalid buying asset",
+			urlParams: map[string]string{
+				"buying": "LOLEUR:",
+			},
+			expectedInvalidField: "buying",
+			expectedErr:          "Asset must be the string \"native\" or a string of the form \"Code:IssuerAccountID\" for issued assets.",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add a regression test to make sure we validate selilng and buying via
validation tags.

### Why

This can help us catch regressions. For example, someone removes or
edits the validation tag by mistake.

### Known limitations