### PR TITLE
services/horizon: Move /metrics to internal server

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this
 file. This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.0.0 Alpha
+## 1.0.0 Beta
 
 ### New Ingestion System
 
@@ -49,6 +49,7 @@ The [testing guide](https://github.com/stellar/go/blob/release-horizon-v0.25.0/s
 
 ### Removed
 
+- `/metrics` endpoint is no longer part of the public API. It is now served on `INTERNAL_PORT/metrics`. `INTERNAL_PORT` can be set using env variable or `--internal-port` CLI param.
 - Remove the following fields from [/fee_stats](https://www.stellar.org/developers/horizon/reference/endpoints/fee-stats.html):
 
     - `min_accepted_fee`

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -147,7 +147,7 @@ var configOpts = support.ConfigOptions{
 		ConfigKey:   &config.InternalPort,
 		OptType:     types.Uint,
 		FlagDefault: uint(0),
-		Usage:       "WARNING: this should not be accesible from the Internet, tcp port to listen on for internal http requests, 0 (default) disables the internal server",
+		Usage:       "WARNING: this should not be accessible from the Internet and does not use TLS, tcp port to listen on for internal http requests, 0 (default) disables the internal server",
 	},
 	&support.ConfigOption{
 		Name:        "max-db-connections",

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -143,6 +143,13 @@ var configOpts = support.ConfigOptions{
 		Usage:       "tcp port to listen on for http requests",
 	},
 	&support.ConfigOption{
+		Name:        "internal-port",
+		ConfigKey:   &config.InternalPort,
+		OptType:     types.Uint,
+		FlagDefault: uint(0),
+		Usage:       "WARNING: this should not be accesible from the Internet, tcp port to listen on for internal http requests, 0 (default) disables the internal server",
+	},
+	&support.ConfigOption{
 		Name:        "max-db-connections",
 		ConfigKey:   &config.MaxDBConnections,
 		OptType:     types.Int,

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -95,6 +95,24 @@ func (a *App) Serve() {
 
 	log.Infof("Starting horizon on %s (ingest: %v)", addr, a.config.Ingest)
 
+	if a.config.InternalPort != 0 {
+		go func() {
+			internalAddr := fmt.Sprintf(":%d", a.config.InternalPort)
+			log.Infof("Starting internal server on %s", internalAddr)
+
+			internalSrv := &http.Server{
+				Addr:        internalAddr,
+				Handler:     a.web.internalRouter,
+				ReadTimeout: 5 * time.Second,
+			}
+
+			err := internalSrv.ListenAndServe()
+			if err != nil {
+				log.Warn(errors.Wrap(err, "error in internalSrv.ListenAndServe()"))
+			}
+		}()
+	}
+
 	go a.run()
 
 	// WaitGroup for all go routines. Makes sure that DB is closed when

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	StellarCoreURL         string
 	HistoryArchiveURLs     []string
 	Port                   uint
+	InternalPort           uint
 
 	// MaxDBConnections has a priority over all 4 values below.
 	MaxDBConnections            int

--- a/services/horizon/internal/docs/reference/endpoints/metrics.md
+++ b/services/horizon/internal/docs/reference/endpoints/metrics.md
@@ -4,6 +4,8 @@ title: Metrics
 
 The metrics endpoint returns a host of useful data points for monitoring the health of the underlying Horizon process. 
 
+Since Horizon 1.0.0 this endpoint is not part of the public API. It's available in the internal server (listening on the internal port set via `INTERNAL_PORT` env variable or `--internal-port` CLI param).
+
 ## Request
 
 ```


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit moves `/metrics` endpoint to the new internal server running on `INTERNAL_PORT`.

### Why

After reviewing metrics exposed in `/metrics` it seems that none of the values should be exposed publicly. It will also allow us to expose more internal metrics.