### PR TITLE
services/horizon: Fix misc /metrics issues

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -290,7 +290,6 @@ type Root struct {
 		AccountTransactions hal.Link  `json:"account_transactions"`
 		Assets              hal.Link  `json:"assets"`
 		Friendbot           *hal.Link `json:"friendbot,omitempty"`
-		Metrics             hal.Link  `json:"metrics"`
 		Offer               *hal.Link `json:"offer,omitempty"`
 		Offers              *hal.Link `json:"offers,omitempty"`
 		OrderBook           hal.Link  `json:"order_book"`

--- a/services/horizon/internal/actions_metrics.go
+++ b/services/horizon/internal/actions_metrics.go
@@ -2,6 +2,7 @@ package horizon
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	metrics "github.com/rcrowley/go-metrics"
@@ -33,53 +34,56 @@ func (action *MetricsAction) JSON() error {
 // PrometheusFormat is a method for actions.PrometheusResponder
 func (action *MetricsAction) PrometheusFormat() error {
 	action.App.metrics.Each(func(name string, i interface{}) {
+		// Replace `.` with `_` to follow Prometheus metric name convention.
+		name = strings.ReplaceAll(name, ".", "_")
+
 		switch metric := i.(type) {
 		case metrics.Counter:
-			fmt.Fprintf(action.W, "%s %d\n", name, metric.Count())
+			fmt.Fprintf(action.W, "horizon_%s %d\n", name, metric.Count())
 		case metrics.Gauge:
-			fmt.Fprintf(action.W, "%s %d\n", name, metric.Value())
+			fmt.Fprintf(action.W, "horizon_%s %d\n", name, metric.Value())
 		case metrics.GaugeFloat64:
-			fmt.Fprintf(action.W, "%s %f\n", name, metric.Value())
+			fmt.Fprintf(action.W, "horizon_%s %f\n", name, metric.Value())
 		case metrics.Histogram:
 			h := metric.Snapshot()
 			ps := h.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
 
-			fmt.Fprintf(action.W, "%s_count %d\n", name, h.Count())
-			fmt.Fprintf(action.W, "%s_min %d\n", name, h.Min())
-			fmt.Fprintf(action.W, "%s_max %d\n", name, h.Max())
-			fmt.Fprintf(action.W, "%s_mean %f\n", name, h.Mean())
-			fmt.Fprintf(action.W, "%s_stddev %f\n", name, h.StdDev())
-			fmt.Fprintf(action.W, "%s_bucket{quantile=\"0.50\"} %f\n", name, ps[0])
-			fmt.Fprintf(action.W, "%s_bucket{quantile=\"0.75\"} %f\n", name, ps[1])
-			fmt.Fprintf(action.W, "%s_bucket{quantile=\"0.95\"} %f\n", name, ps[2])
-			fmt.Fprintf(action.W, "%s_bucket{quantile=\"0.99\"} %f\n", name, ps[3])
-			fmt.Fprintf(action.W, "%s_bucket{quantile=\"0.999\"} %f\n", name, ps[4])
+			fmt.Fprintf(action.W, "horizon_%s_count %d\n", name, h.Count())
+			fmt.Fprintf(action.W, "horizon_%s_min %d\n", name, h.Min())
+			fmt.Fprintf(action.W, "horizon_%s_max %d\n", name, h.Max())
+			fmt.Fprintf(action.W, "horizon_%s_mean %f\n", name, h.Mean())
+			fmt.Fprintf(action.W, "horizon_%s_stddev %f\n", name, h.StdDev())
+			fmt.Fprintf(action.W, "horizon_%s_bucket{quantile=\"0.50\"} %f\n", name, ps[0])
+			fmt.Fprintf(action.W, "horizon_%s_bucket{quantile=\"0.75\"} %f\n", name, ps[1])
+			fmt.Fprintf(action.W, "horizon_%s_bucket{quantile=\"0.95\"} %f\n", name, ps[2])
+			fmt.Fprintf(action.W, "horizon_%s_bucket{quantile=\"0.99\"} %f\n", name, ps[3])
+			fmt.Fprintf(action.W, "horizon_%s_bucket{quantile=\"0.999\"} %f\n", name, ps[4])
 		case metrics.Meter:
 			m := metric.Snapshot()
 
-			fmt.Fprintf(action.W, "%s_count %d\n", name, m.Count())
-			fmt.Fprintf(action.W, "%s_1m_rate %f\n", name, m.Rate1())
-			fmt.Fprintf(action.W, "%s_5m_rate %f\n", name, m.Rate5())
-			fmt.Fprintf(action.W, "%s_15m_rate %f\n", name, m.Rate15())
-			fmt.Fprintf(action.W, "%s_mean_rate %f\n", name, m.RateMean())
+			fmt.Fprintf(action.W, "horizon_%s_count %d\n", name, m.Count())
+			fmt.Fprintf(action.W, "horizon_%s_1m_rate %f\n", name, m.Rate1())
+			fmt.Fprintf(action.W, "horizon_%s_5m_rate %f\n", name, m.Rate5())
+			fmt.Fprintf(action.W, "horizon_%s_15m_rate %f\n", name, m.Rate15())
+			fmt.Fprintf(action.W, "horizon_%s_mean_rate %f\n", name, m.RateMean())
 		case metrics.Timer:
 			t := metric.Snapshot()
 			ps := t.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
 
-			fmt.Fprintf(action.W, "%s_count %d\n", name, t.Count())
-			fmt.Fprintf(action.W, "%s_min %f\n", name, time.Duration(t.Min()).Seconds())
-			fmt.Fprintf(action.W, "%s_max %f\n", name, time.Duration(t.Max()).Seconds())
-			fmt.Fprintf(action.W, "%s_mean %f\n", name, time.Duration(t.Mean()).Seconds())
-			fmt.Fprintf(action.W, "%s_stddev %f\n", name, time.Duration(t.StdDev()).Seconds())
-			fmt.Fprintf(action.W, "%s_bucket{quantile=\"0.50\"} %f\n", name, time.Duration(ps[0]).Seconds())
-			fmt.Fprintf(action.W, "%s_bucket{quantile=\"0.75\"} %f\n", name, time.Duration(ps[1]).Seconds())
-			fmt.Fprintf(action.W, "%s_bucket{quantile=\"0.95\"} %f\n", name, time.Duration(ps[2]).Seconds())
-			fmt.Fprintf(action.W, "%s_bucket{quantile=\"0.99\"} %f\n", name, time.Duration(ps[3]).Seconds())
-			fmt.Fprintf(action.W, "%s_bucket{quantile=\"0.999\"} %f\n", name, time.Duration(ps[4]).Seconds())
-			fmt.Fprintf(action.W, "%s_1m_rate %f\n", name, t.Rate1())
-			fmt.Fprintf(action.W, "%s_5m_rate %f\n", name, t.Rate5())
-			fmt.Fprintf(action.W, "%s_15m_rate %f\n", name, t.Rate15())
-			fmt.Fprintf(action.W, "%s_mean_rate %f\n", name, t.RateMean())
+			fmt.Fprintf(action.W, "horizon_%s_count %d\n", name, t.Count())
+			fmt.Fprintf(action.W, "horizon_%s_min %f\n", name, time.Duration(t.Min()).Seconds())
+			fmt.Fprintf(action.W, "horizon_%s_max %f\n", name, time.Duration(t.Max()).Seconds())
+			fmt.Fprintf(action.W, "horizon_%s_mean %f\n", name, time.Duration(t.Mean()).Seconds())
+			fmt.Fprintf(action.W, "horizon_%s_stddev %f\n", name, time.Duration(t.StdDev()).Seconds())
+			fmt.Fprintf(action.W, "horizon_%s_bucket{quantile=\"0.50\"} %f\n", name, time.Duration(ps[0]).Seconds())
+			fmt.Fprintf(action.W, "horizon_%s_bucket{quantile=\"0.75\"} %f\n", name, time.Duration(ps[1]).Seconds())
+			fmt.Fprintf(action.W, "horizon_%s_bucket{quantile=\"0.95\"} %f\n", name, time.Duration(ps[2]).Seconds())
+			fmt.Fprintf(action.W, "horizon_%s_bucket{quantile=\"0.99\"} %f\n", name, time.Duration(ps[3]).Seconds())
+			fmt.Fprintf(action.W, "horizon_%s_bucket{quantile=\"0.999\"} %f\n", name, time.Duration(ps[4]).Seconds())
+			fmt.Fprintf(action.W, "horizon_%s_1m_rate %f\n", name, t.Rate1())
+			fmt.Fprintf(action.W, "horizon_%s_5m_rate %f\n", name, t.Rate5())
+			fmt.Fprintf(action.W, "horizon_%s_15m_rate %f\n", name, t.Rate15())
+			fmt.Fprintf(action.W, "horizon_%s_mean_rate %f\n", name, t.RateMean())
 		}
 		fmt.Fprintf(action.W, "\n")
 	})

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -44,6 +44,9 @@ func (s *System) verifyState(
 	}
 	s.stateVerificationRunning = true
 	s.stateVerificationMutex.Unlock()
+
+	updateMetrics := false
+
 	if stateVerifierExpectedIngestionVersion != CurrentVersion {
 		log.Errorf(
 			"State verification expected version is %d but actual is: %d",
@@ -58,7 +61,9 @@ func (s *System) verifyState(
 
 	defer func() {
 		duration := time.Since(startTime)
-		s.Metrics.StateVerifyTimer.Update(duration)
+		if updateMetrics {
+			s.Metrics.StateVerifyTimer.Update(duration)
+		}
 		log.WithField("duration", duration.Seconds()).Info("State verification finished")
 		historyQ.Rollback()
 		s.stateVerificationMutex.Lock()
@@ -231,6 +236,7 @@ func (s *System) verifyState(
 	}
 
 	localLog.Info("State correct")
+	updateMetrics = true
 	return nil
 }
 

--- a/services/horizon/internal/resourceadapter/root.go
+++ b/services/horizon/internal/resourceadapter/root.go
@@ -42,7 +42,6 @@ func PopulateRoot(
 	dest.Links.Account = lb.Link("/accounts/{account_id}")
 	dest.Links.AccountTransactions = lb.PagedLink("/accounts/{account_id}/transactions")
 	dest.Links.Assets = lb.Link("/assets{?asset_code,asset_issuer,cursor,limit,order}")
-	dest.Links.Metrics = lb.Link("/metrics")
 
 	accountsLink := lb.Link(templates["accounts"])
 	offerLink := lb.Link("/offers/{offer_id}")


### PR DESCRIPTION
This commit fixes misc issues connected to `/metrics`:
* Fix metrics name to follow Prometheus metric name convention (thanks @jacekn).
* Remove `/metrics` from root resource `_links`. (fix #2268)
* Update `state_verify` metrics only when state was fully checked.