### PR TITLE
/services/horizon: Fix stats return value in RunOrderBookProcessorOnLedger

### DIFF
--- a/services/horizon/internal/expingest/processors_runner.go
+++ b/services/horizon/internal/expingest/processors_runner.go
@@ -291,5 +291,10 @@ func (s *ProcessorRunner) RunOrderBookProcessorOnLedger(ledger uint32) (io.Stats
 		processors.NewOrderbookProcessor(s.graph),
 	}
 
-	return changeStats.GetResults(), s.runChangeProcessorOnLedger(groupProcessor, ledger)
+	err := s.runChangeProcessorOnLedger(groupProcessor, ledger)
+	if err != nil {
+		return changeStats.GetResults(), err
+	}
+
+	return changeStats.GetResults(), nil
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit fixes the return value in `ProcessorRunner.RunOrderBookProcessorOnLedger`.

### Why

The value of `changeStats.GetResults()` was calculated before running the processors (`s.runChangeProcessorOnLedger` call) so all the stats were equal to 0.

### Known limitations

Tests will be added in #2263.