### PR TITLE
exp/ingest/io: Add StatsLedgerTransactionProcessor

### DIFF
--- a/exp/ingest/io/stats_change_processor.go
+++ b/exp/ingest/io/stats_change_processor.go
@@ -75,3 +75,23 @@ func (p *StatsChangeProcessor) ProcessChange(change Change) error {
 func (p *StatsChangeProcessor) GetResults() StatsChangeProcessorResults {
 	return p.results
 }
+
+func (stats *StatsChangeProcessorResults) Map() map[string]interface{} {
+	return map[string]interface{}{
+		"stats_accounts_created": stats.AccountsCreated,
+		"stats_accounts_updated": stats.AccountsUpdated,
+		"stats_accounts_removed": stats.AccountsRemoved,
+
+		"stats_data_created": stats.DataCreated,
+		"stats_data_updated": stats.DataUpdated,
+		"stats_data_removed": stats.DataRemoved,
+
+		"stats_offers_created": stats.OffersCreated,
+		"stats_offers_updated": stats.OffersUpdated,
+		"stats_offers_removed": stats.OffersRemoved,
+
+		"stats_trust_lines_created": stats.TrustLinesCreated,
+		"stats_trust_lines_updated": stats.TrustLinesUpdated,
+		"stats_trust_lines_removed": stats.TrustLinesRemoved,
+	}
+}

--- a/exp/ingest/io/stats_ledger_transaction_processor.go
+++ b/exp/ingest/io/stats_ledger_transaction_processor.go
@@ -93,3 +93,30 @@ func (p *StatsLedgerTransactionProcessor) ProcessTransaction(transaction LedgerT
 func (p *StatsLedgerTransactionProcessor) GetResults() StatsLedgerTransactionProcessorResults {
 	return p.results
 }
+
+func (stats *StatsLedgerTransactionProcessorResults) Map() map[string]interface{} {
+	return map[string]interface{}{
+		"stats_transactions":            stats.Transactions,
+		"stats_transactions_successful": stats.TransactionsSuccessful,
+		"stats_transactions_failed":     stats.TransactionsFailed,
+
+		"stats_operations":               stats.Operations,
+		"stats_operations_in_successful": stats.OperationsInSuccessful,
+		"stats_operations_in_failed":     stats.OperationsInFailed,
+
+		"stats_operations_create_account":              stats.OperationsCreateAccount,
+		"stats_operations_payment":                     stats.OperationsPayment,
+		"stats_operations_path_payment_strict_receive": stats.OperationsPathPaymentStrictReceive,
+		"stats_operations_manage_sell_offer":           stats.OperationsManageSellOffer,
+		"stats_operations_create_passive_sell_offer":   stats.OperationsCreatePassiveSellOffer,
+		"stats_operations_set_options":                 stats.OperationsSetOptions,
+		"stats_operations_change_trust":                stats.OperationsChangeTrust,
+		"stats_operations_allow_trust":                 stats.OperationsAllowTrust,
+		"stats_operations_account_merge":               stats.OperationsAccountMerge,
+		"stats_operations_inflation":                   stats.OperationsInflation,
+		"stats_operations_manage_data":                 stats.OperationsManageData,
+		"stats_operations_bump_sequence":               stats.OperationsBumpSequence,
+		"stats_operations_manage_buy_offer":            stats.OperationsManageBuyOffer,
+		"stats_operations_path_payment_strict_send":    stats.OperationsPathPaymentStrictSend,
+	}
+}

--- a/exp/ingest/io/stats_ledger_transaction_processor.go
+++ b/exp/ingest/io/stats_ledger_transaction_processor.go
@@ -1,0 +1,95 @@
+package io
+
+import (
+	"fmt"
+
+	"github.com/stellar/go/xdr"
+)
+
+// StatsLedgerTransactionProcessor is a state processors that counts number of changes types
+// and entry types.
+type StatsLedgerTransactionProcessor struct {
+	results StatsLedgerTransactionProcessorResults
+}
+
+// StatsLedgerTransactionProcessorResults contains results after running StatsLedgerTransactionProcessor.
+type StatsLedgerTransactionProcessorResults struct {
+	Transactions           int64
+	TransactionsSuccessful int64
+	TransactionsFailed     int64
+
+	Operations             int64
+	OperationsInSuccessful int64
+	OperationsInFailed     int64
+
+	OperationsCreateAccount            int64
+	OperationsPayment                  int64
+	OperationsPathPaymentStrictReceive int64
+	OperationsManageSellOffer          int64
+	OperationsCreatePassiveSellOffer   int64
+	OperationsSetOptions               int64
+	OperationsChangeTrust              int64
+	OperationsAllowTrust               int64
+	OperationsAccountMerge             int64
+	OperationsInflation                int64
+	OperationsManageData               int64
+	OperationsBumpSequence             int64
+	OperationsManageBuyOffer           int64
+	OperationsPathPaymentStrictSend    int64
+}
+
+func (p *StatsLedgerTransactionProcessor) ProcessTransaction(transaction LedgerTransaction) error {
+	p.results.Transactions++
+	ops := int64(len(transaction.Envelope.Tx.Operations))
+	p.results.Operations += ops
+
+	if transaction.Successful() {
+		p.results.TransactionsSuccessful++
+		p.results.OperationsInSuccessful += ops
+
+	} else {
+		p.results.TransactionsFailed++
+		p.results.OperationsInFailed += ops
+	}
+
+	for _, op := range transaction.Envelope.Tx.Operations {
+		switch op.Body.Type {
+		case xdr.OperationTypeCreateAccount:
+			p.results.OperationsCreateAccount++
+		case xdr.OperationTypePayment:
+			p.results.OperationsPayment++
+		case xdr.OperationTypePathPaymentStrictReceive:
+			p.results.OperationsPathPaymentStrictReceive++
+		case xdr.OperationTypeManageSellOffer:
+			p.results.OperationsManageSellOffer++
+		case xdr.OperationTypeCreatePassiveSellOffer:
+			p.results.OperationsCreatePassiveSellOffer++
+		case xdr.OperationTypeSetOptions:
+			p.results.OperationsSetOptions++
+		case xdr.OperationTypeChangeTrust:
+			p.results.OperationsChangeTrust++
+		case xdr.OperationTypeAllowTrust:
+			p.results.OperationsAllowTrust++
+		case xdr.OperationTypeAccountMerge:
+			p.results.OperationsAccountMerge++
+		case xdr.OperationTypeInflation:
+			p.results.OperationsInflation++
+		case xdr.OperationTypeManageData:
+			p.results.OperationsManageData++
+		case xdr.OperationTypeBumpSequence:
+			p.results.OperationsBumpSequence++
+		case xdr.OperationTypeManageBuyOffer:
+			p.results.OperationsManageBuyOffer++
+		case xdr.OperationTypePathPaymentStrictSend:
+			p.results.OperationsPathPaymentStrictSend++
+		default:
+			panic(fmt.Sprintf("Unkown operation type: %d", op.Body.Type))
+		}
+	}
+
+	return nil
+}
+
+func (p *StatsLedgerTransactionProcessor) GetResults() StatsLedgerTransactionProcessorResults {
+	return p.results
+}

--- a/exp/ingest/io/stats_ledger_transaction_processor_test.go
+++ b/exp/ingest/io/stats_ledger_transaction_processor_test.go
@@ -1,0 +1,99 @@
+package io
+
+import (
+	"testing"
+
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatsLedgerTransactionProcessor(t *testing.T) {
+	processor := &StatsLedgerTransactionProcessor{}
+
+	// Successful
+	assert.NoError(t, processor.ProcessTransaction(LedgerTransaction{
+		Result: xdr.TransactionResultPair{
+			Result: xdr.TransactionResult{
+				Result: xdr.TransactionResultResult{
+					Code: xdr.TransactionResultCodeTxSuccess,
+				},
+			},
+		},
+		Envelope: xdr.TransactionEnvelope{
+			Tx: xdr.Transaction{
+				Operations: []xdr.Operation{
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeCreateAccount}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypePayment}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypePathPaymentStrictReceive}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeManageSellOffer}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeCreatePassiveSellOffer}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeSetOptions}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeChangeTrust}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeAllowTrust}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeAccountMerge}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeInflation}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeManageData}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeBumpSequence}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeManageBuyOffer}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypePathPaymentStrictSend}},
+				},
+			},
+		},
+	}))
+
+	// Failed
+	assert.NoError(t, processor.ProcessTransaction(LedgerTransaction{
+		Result: xdr.TransactionResultPair{
+			Result: xdr.TransactionResult{
+				Result: xdr.TransactionResultResult{
+					Code: xdr.TransactionResultCodeTxFailed,
+				},
+			},
+		},
+		Envelope: xdr.TransactionEnvelope{
+			Tx: xdr.Transaction{
+				Operations: []xdr.Operation{
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeCreateAccount}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypePayment}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypePathPaymentStrictReceive}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeManageSellOffer}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeCreatePassiveSellOffer}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeSetOptions}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeChangeTrust}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeAllowTrust}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeAccountMerge}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeInflation}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeManageData}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeBumpSequence}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypeManageBuyOffer}},
+					{Body: xdr.OperationBody{Type: xdr.OperationTypePathPaymentStrictSend}},
+				},
+			},
+		},
+	}))
+
+	results := processor.GetResults()
+
+	assert.Equal(t, int64(2), results.Transactions)
+	assert.Equal(t, int64(1), results.TransactionsSuccessful)
+	assert.Equal(t, int64(1), results.TransactionsFailed)
+
+	assert.Equal(t, int64(14*2), results.Operations)
+	assert.Equal(t, int64(14), results.OperationsInSuccessful)
+	assert.Equal(t, int64(14), results.OperationsInFailed)
+
+	assert.Equal(t, int64(2), results.OperationsCreateAccount)
+	assert.Equal(t, int64(2), results.OperationsPayment)
+	assert.Equal(t, int64(2), results.OperationsPathPaymentStrictReceive)
+	assert.Equal(t, int64(2), results.OperationsManageSellOffer)
+	assert.Equal(t, int64(2), results.OperationsCreatePassiveSellOffer)
+	assert.Equal(t, int64(2), results.OperationsSetOptions)
+	assert.Equal(t, int64(2), results.OperationsChangeTrust)
+	assert.Equal(t, int64(2), results.OperationsAllowTrust)
+	assert.Equal(t, int64(2), results.OperationsAccountMerge)
+	assert.Equal(t, int64(2), results.OperationsInflation)
+	assert.Equal(t, int64(2), results.OperationsManageData)
+	assert.Equal(t, int64(2), results.OperationsBumpSequence)
+	assert.Equal(t, int64(2), results.OperationsManageBuyOffer)
+	assert.Equal(t, int64(2), results.OperationsPathPaymentStrictSend)
+}

--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -296,7 +296,7 @@ func (b buildState) run(s *System) (transition, error) {
 	}
 
 	log.
-		WithFields(changeStatsFields(stats)).
+		WithFields(stats.Map()).
 		WithFields(logpkg.F{
 			"ledger":   b.checkpointLedger,
 			"duration": time.Since(startTime).Seconds(),
@@ -412,7 +412,7 @@ func (r resumeState) run(s *System) (transition, error) {
 		duration := time.Since(startTime)
 		s.Metrics.LedgerInMemoryIngestionTimer.Update(duration)
 		log.
-			WithFields(changeStatsFields(stats)).
+			WithFields(stats.Map()).
 			WithFields(logpkg.F{
 				"sequence": ingestLedger,
 				"duration": duration.Seconds(),
@@ -451,8 +451,8 @@ func (r resumeState) run(s *System) (transition, error) {
 	duration := time.Since(startTime)
 	s.Metrics.LedgerIngestionTimer.Update(duration)
 	log.
-		WithFields(changeStatsFields(changeStats)).
-		WithFields(ledgerTransactionStatsFields(ledgerTransactionStats)).
+		WithFields(changeStats.Map()).
+		WithFields(ledgerTransactionStats.Map()).
 		WithFields(logpkg.F{
 			"sequence": ingestLedger,
 			"duration": duration.Seconds(),
@@ -539,7 +539,7 @@ func ingestHistoryRange(s *System, from, to uint32) error {
 		}
 
 		log.
-			WithFields(ledgerTransactionStatsFields(ledgerTransactionStats)).
+			WithFields(ledgerTransactionStats.Map()).
 			WithFields(logpkg.F{
 				"sequence": cur,
 				"duration": time.Since(startTime).Seconds(),
@@ -689,7 +689,7 @@ func (v verifyRangeState) run(s *System) (transition, error) {
 	}
 
 	log.
-		WithFields(changeStatsFields(stats)).
+		WithFields(stats.Map()).
 		WithFields(logpkg.F{
 			"ledger":   v.fromLedger,
 			"duration": time.Since(startTime).Seconds(),
@@ -724,8 +724,8 @@ func (v verifyRangeState) run(s *System) (transition, error) {
 		}
 
 		log.
-			WithFields(changeStatsFields(changeStats)).
-			WithFields(ledgerTransactionStatsFields(ledgerTransactionStats)).
+			WithFields(changeStats.Map()).
+			WithFields(ledgerTransactionStats.Map()).
 			WithFields(logpkg.F{
 				"sequence": sequence,
 				"duration": time.Since(startTime).Seconds(),
@@ -795,8 +795,8 @@ func (stressTestState) run(s *System) (transition, error) {
 
 	curHeap, sysHeap = getMemStats()
 	log.
-		WithFields(changeStatsFields(changeStats)).
-		WithFields(ledgerTransactionStatsFields(ledgerTransactionStats)).
+		WithFields(changeStats.Map()).
+		WithFields(ledgerTransactionStats.Map()).
 		WithFields(logpkg.F{
 			"currentHeapSizeMB": curHeap,
 			"systemHeapSizeMB":  sysHeap,
@@ -832,51 +832,4 @@ func (s *System) completeIngestion(ledger uint32) error {
 	}
 
 	return nil
-}
-
-func changeStatsFields(stats io.StatsChangeProcessorResults) logpkg.F {
-	return logpkg.F{
-		"stats_accounts_created": stats.AccountsCreated,
-		"stats_accounts_updated": stats.AccountsUpdated,
-		"stats_accounts_removed": stats.AccountsRemoved,
-
-		"stats_data_created": stats.DataCreated,
-		"stats_data_updated": stats.DataUpdated,
-		"stats_data_removed": stats.DataRemoved,
-
-		"stats_offers_created": stats.OffersCreated,
-		"stats_offers_updated": stats.OffersUpdated,
-		"stats_offers_removed": stats.OffersRemoved,
-
-		"stats_trust_lines_created": stats.TrustLinesCreated,
-		"stats_trust_lines_updated": stats.TrustLinesUpdated,
-		"stats_trust_lines_removed": stats.TrustLinesRemoved,
-	}
-}
-
-func ledgerTransactionStatsFields(stats io.StatsLedgerTransactionProcessorResults) logpkg.F {
-	return logpkg.F{
-		"stats_transactions":            stats.Transactions,
-		"stats_transactions_successful": stats.TransactionsSuccessful,
-		"stats_transactions_failed":     stats.TransactionsFailed,
-
-		"stats_operations":               stats.Operations,
-		"stats_operations_in_successful": stats.OperationsInSuccessful,
-		"stats_operations_in_failed":     stats.OperationsInFailed,
-
-		"stats_operations_create_account":              stats.OperationsCreateAccount,
-		"stats_operations_payment":                     stats.OperationsPayment,
-		"stats_operations_path_payment_strict_receive": stats.OperationsPathPaymentStrictReceive,
-		"stats_operations_manage_sell_offer":           stats.OperationsManageSellOffer,
-		"stats_operations_create_passive_sell_offer":   stats.OperationsCreatePassiveSellOffer,
-		"stats_operations_set_options":                 stats.OperationsSetOptions,
-		"stats_operations_change_trust":                stats.OperationsChangeTrust,
-		"stats_operations_allow_trust":                 stats.OperationsAllowTrust,
-		"stats_operations_account_merge":               stats.OperationsAccountMerge,
-		"stats_operations_inflation":                   stats.OperationsInflation,
-		"stats_operations_manage_data":                 stats.OperationsManageData,
-		"stats_operations_bump_sequence":               stats.OperationsBumpSequence,
-		"stats_operations_manage_buy_offer":            stats.OperationsManageBuyOffer,
-		"stats_operations_path_payment_strict_send":    stats.OperationsPathPaymentStrictSend,
-	}
 }

--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -295,10 +295,13 @@ func (b buildState) run(s *System) (transition, error) {
 		return start(), err
 	}
 
-	loggerWithChangeStats(stats).WithFields(logpkg.F{
-		"ledger":   b.checkpointLedger,
-		"duration": time.Since(startTime).Seconds(),
-	}).Info("Processed state")
+	log.
+		WithFields(changeStatsFields(stats)).
+		WithFields(logpkg.F{
+			"ledger":   b.checkpointLedger,
+			"duration": time.Since(startTime).Seconds(),
+		}).
+		Info("Processed state")
 
 	// If successful, continue from the next ledger
 	return resume(b.checkpointLedger), nil
@@ -408,14 +411,17 @@ func (r resumeState) run(s *System) (transition, error) {
 
 		duration := time.Since(startTime)
 		s.Metrics.LedgerInMemoryIngestionTimer.Update(duration)
-		loggerWithChangeStats(stats).WithFields(logpkg.F{
-			"sequence": ingestLedger,
-			"duration": duration.Seconds(),
-			"state":    false,
-			"ledger":   false,
-			"graph":    true,
-			"commit":   false,
-		}).Info("Processed ledger")
+		log.
+			WithFields(changeStatsFields(stats)).
+			WithFields(logpkg.F{
+				"sequence": ingestLedger,
+				"duration": duration.Seconds(),
+				"state":    false,
+				"ledger":   false,
+				"graph":    true,
+				"commit":   false,
+			}).
+			Info("Processed ledger")
 
 		return resumeImmediately(ingestLedger), nil
 	}
@@ -428,7 +434,7 @@ func (r resumeState) run(s *System) (transition, error) {
 		"commit":   true,
 	}).Info("Processing ledger")
 
-	stats, err := s.runner.RunAllProcessorsOnLedger(ingestLedger)
+	changeStats, ledgerTransactionStats, err := s.runner.RunAllProcessorsOnLedger(ingestLedger)
 	if err != nil {
 		return retryResume(r), errors.Wrap(err, "Error running processors on ledger")
 	}
@@ -444,14 +450,18 @@ func (r resumeState) run(s *System) (transition, error) {
 
 	duration := time.Since(startTime)
 	s.Metrics.LedgerIngestionTimer.Update(duration)
-	loggerWithChangeStats(stats).WithFields(logpkg.F{
-		"sequence": ingestLedger,
-		"duration": duration.Seconds(),
-		"state":    true,
-		"ledger":   true,
-		"graph":    true,
-		"commit":   true,
-	}).Info("Processed ledger")
+	log.
+		WithFields(changeStatsFields(changeStats)).
+		WithFields(ledgerTransactionStatsFields(ledgerTransactionStats)).
+		WithFields(logpkg.F{
+			"sequence": ingestLedger,
+			"duration": duration.Seconds(),
+			"state":    true,
+			"ledger":   true,
+			"graph":    true,
+			"commit":   true,
+		}).
+		Info("Processed ledger")
 
 	s.maybeVerifyState(ingestLedger)
 
@@ -523,18 +533,22 @@ func ingestHistoryRange(s *System, from, to uint32) error {
 		}).Info("Processing ledger")
 		startTime := time.Now()
 
-		if err := s.runner.RunTransactionProcessorsOnLedger(cur); err != nil {
+		ledgerTransactionStats, err := s.runner.RunTransactionProcessorsOnLedger(cur)
+		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("error processing ledger sequence=%d", cur))
 		}
 
-		log.WithFields(logpkg.F{
-			"sequence": cur,
-			"duration": time.Since(startTime).Seconds(),
-			"state":    false,
-			"ledger":   true,
-			"graph":    false,
-			"commit":   false,
-		}).Info("Processed ledger")
+		log.
+			WithFields(ledgerTransactionStatsFields(ledgerTransactionStats)).
+			WithFields(logpkg.F{
+				"sequence": cur,
+				"duration": time.Since(startTime).Seconds(),
+				"state":    false,
+				"ledger":   true,
+				"graph":    false,
+				"commit":   false,
+			}).
+			Info("Processed ledger")
 	}
 	return nil
 }
@@ -674,10 +688,13 @@ func (v verifyRangeState) run(s *System) (transition, error) {
 		return stop(), err
 	}
 
-	loggerWithChangeStats(stats).WithFields(logpkg.F{
-		"ledger":   v.fromLedger,
-		"duration": time.Since(startTime).Seconds(),
-	}).Info("Processed state")
+	log.
+		WithFields(changeStatsFields(stats)).
+		WithFields(logpkg.F{
+			"ledger":   v.fromLedger,
+			"duration": time.Since(startTime).Seconds(),
+		}).
+		Info("Processed state")
 
 	for sequence := v.fromLedger + 1; sequence <= v.toLedger; sequence++ {
 		log.WithFields(logpkg.F{
@@ -694,8 +711,9 @@ func (v verifyRangeState) run(s *System) (transition, error) {
 			return stop(), err
 		}
 
-		var stats io.StatsChangeProcessorResults
-		stats, err = s.runner.RunAllProcessorsOnLedger(sequence)
+		var changeStats io.StatsChangeProcessorResults
+		var ledgerTransactionStats io.StatsLedgerTransactionProcessorResults
+		changeStats, ledgerTransactionStats, err = s.runner.RunAllProcessorsOnLedger(sequence)
 		if err != nil {
 			err = errors.Wrap(err, "Error running processors on ledger")
 			return stop(), err
@@ -705,14 +723,18 @@ func (v verifyRangeState) run(s *System) (transition, error) {
 			return stop(), err
 		}
 
-		loggerWithChangeStats(stats).WithFields(logpkg.F{
-			"sequence": sequence,
-			"duration": time.Since(startTime).Seconds(),
-			"state":    true,
-			"ledger":   true,
-			"graph":    true,
-			"commit":   true,
-		}).Info("Processed ledger")
+		log.
+			WithFields(changeStatsFields(changeStats)).
+			WithFields(ledgerTransactionStatsFields(ledgerTransactionStats)).
+			WithFields(logpkg.F{
+				"sequence": sequence,
+				"duration": time.Since(startTime).Seconds(),
+				"state":    true,
+				"ledger":   true,
+				"graph":    true,
+				"commit":   true,
+			}).
+			Info("Processed ledger")
 	}
 
 	if v.verifyState {
@@ -761,7 +783,7 @@ func (stressTestState) run(s *System) (transition, error) {
 	}).Info("Processing ledger")
 	startTime := time.Now()
 
-	stats, err := s.runner.RunAllProcessorsOnLedger(sequence)
+	changeStats, ledgerTransactionStats, err := s.runner.RunAllProcessorsOnLedger(sequence)
 	if err != nil {
 		err = errors.Wrap(err, "Error running processors on ledger")
 		return stop(), err
@@ -772,16 +794,20 @@ func (stressTestState) run(s *System) (transition, error) {
 	}
 
 	curHeap, sysHeap = getMemStats()
-	loggerWithChangeStats(stats).WithFields(logpkg.F{
-		"currentHeapSizeMB": curHeap,
-		"systemHeapSizeMB":  sysHeap,
-		"sequence":          sequence,
-		"duration":          time.Since(startTime).Seconds(),
-		"state":             true,
-		"ledger":            true,
-		"graph":             true,
-		"commit":            true,
-	}).Info("Processed ledger")
+	log.
+		WithFields(changeStatsFields(changeStats)).
+		WithFields(ledgerTransactionStatsFields(ledgerTransactionStats)).
+		WithFields(logpkg.F{
+			"currentHeapSizeMB": curHeap,
+			"systemHeapSizeMB":  sysHeap,
+			"sequence":          sequence,
+			"duration":          time.Since(startTime).Seconds(),
+			"state":             true,
+			"ledger":            true,
+			"graph":             true,
+			"commit":            true,
+		}).
+		Info("Processed ledger")
 
 	return stop(), nil
 }
@@ -808,8 +834,8 @@ func (s *System) completeIngestion(ledger uint32) error {
 	return nil
 }
 
-func loggerWithChangeStats(stats io.StatsChangeProcessorResults) *logpkg.Entry {
-	return log.WithFields(logpkg.F{
+func changeStatsFields(stats io.StatsChangeProcessorResults) logpkg.F {
+	return logpkg.F{
 		"stats_accounts_created": stats.AccountsCreated,
 		"stats_accounts_updated": stats.AccountsUpdated,
 		"stats_accounts_removed": stats.AccountsRemoved,
@@ -825,5 +851,32 @@ func loggerWithChangeStats(stats io.StatsChangeProcessorResults) *logpkg.Entry {
 		"stats_trust_lines_created": stats.TrustLinesCreated,
 		"stats_trust_lines_updated": stats.TrustLinesUpdated,
 		"stats_trust_lines_removed": stats.TrustLinesRemoved,
-	})
+	}
+}
+
+func ledgerTransactionStatsFields(stats io.StatsLedgerTransactionProcessorResults) logpkg.F {
+	return logpkg.F{
+		"stats_transactions":            stats.Transactions,
+		"stats_transactions_successful": stats.TransactionsSuccessful,
+		"stats_transactions_failed":     stats.TransactionsFailed,
+
+		"stats_operations":               stats.Operations,
+		"stats_operations_in_successful": stats.OperationsInSuccessful,
+		"stats_operations_in_failed":     stats.OperationsInFailed,
+
+		"stats_operations_create_account":              stats.OperationsCreateAccount,
+		"stats_operations_payment":                     stats.OperationsPayment,
+		"stats_operations_path_payment_strict_receive": stats.OperationsPathPaymentStrictReceive,
+		"stats_operations_manage_sell_offer":           stats.OperationsManageSellOffer,
+		"stats_operations_create_passive_sell_offer":   stats.OperationsCreatePassiveSellOffer,
+		"stats_operations_set_options":                 stats.OperationsSetOptions,
+		"stats_operations_change_trust":                stats.OperationsChangeTrust,
+		"stats_operations_allow_trust":                 stats.OperationsAllowTrust,
+		"stats_operations_account_merge":               stats.OperationsAccountMerge,
+		"stats_operations_inflation":                   stats.OperationsInflation,
+		"stats_operations_manage_data":                 stats.OperationsManageData,
+		"stats_operations_bump_sequence":               stats.OperationsBumpSequence,
+		"stats_operations_manage_buy_offer":            stats.OperationsManageBuyOffer,
+		"stats_operations_path_payment_strict_send":    stats.OperationsPathPaymentStrictSend,
+	}
 }

--- a/services/horizon/internal/expingest/ingest_history_range_state_test.go
+++ b/services/horizon/internal/expingest/ingest_history_range_state_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stellar/go/exp/ingest/adapters"
+	"github.com/stellar/go/exp/ingest/io"
 	"github.com/stellar/go/services/horizon/internal/toid"
 	"github.com/stellar/go/support/errors"
 	"github.com/stretchr/testify/suite"
@@ -118,7 +119,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestRunTransactionProcessorsOnLedgerR
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
-	s.runner.On("RunTransactionProcessorsOnLedger", uint32(100)).Return(errors.New("my error")).Once()
+	s.runner.On("RunTransactionProcessorsOnLedger", uint32(100)).Return(io.StatsLedgerTransactionProcessorResults{}, errors.New("my error")).Once()
 
 	next, err := historyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
 	s.Assert().Error(err)
@@ -132,7 +133,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestSuccess() {
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
 	for i := 100; i <= 200; i++ {
-		s.runner.On("RunTransactionProcessorsOnLedger", uint32(i)).Return(nil).Once()
+		s.runner.On("RunTransactionProcessorsOnLedger", uint32(i)).Return(io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 	}
 
 	s.historyQ.On("Commit").Return(nil).Once()
@@ -147,7 +148,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
-	s.runner.On("RunTransactionProcessorsOnLedger", uint32(100)).Return(nil).Once()
+	s.runner.On("RunTransactionProcessorsOnLedger", uint32(100)).Return(io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 
 	s.historyQ.On("Commit").Return(nil).Once()
 
@@ -263,7 +264,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestRunTransactionProcessorsOnLedge
 	).Return(nil).Once()
 
 	s.runner.On("RunTransactionProcessorsOnLedger", uint32(100)).
-		Return(errors.New("my error")).Once()
+		Return(io.StatsLedgerTransactionProcessorResults{}, errors.New("my error")).Once()
 
 	err := s.system.ReingestRange(100, 200, false)
 	s.Assert().EqualError(err, "error processing ledger sequence=100: my error")
@@ -279,7 +280,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestCommitFails() {
 	).Return(nil).Once()
 
 	for i := 100; i <= 200; i++ {
-		s.runner.On("RunTransactionProcessorsOnLedger", uint32(i)).Return(nil).Once()
+		s.runner.On("RunTransactionProcessorsOnLedger", uint32(i)).Return(io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 	}
 
 	s.historyQ.On("Commit").Return(errors.New("my error")).Once()
@@ -298,7 +299,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestSuccess() {
 	).Return(nil).Once()
 
 	for i := 100; i <= 200; i++ {
-		s.runner.On("RunTransactionProcessorsOnLedger", uint32(i)).Return(nil).Once()
+		s.runner.On("RunTransactionProcessorsOnLedger", uint32(i)).Return(io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 	}
 
 	s.historyQ.On("Commit").Return(nil).Once()
@@ -316,7 +317,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
 		"DeleteRangeAll", toidFrom.ToInt64(), toidTo.ToInt64(),
 	).Return(nil).Once()
 
-	s.runner.On("RunTransactionProcessorsOnLedger", uint32(100)).Return(nil).Once()
+	s.runner.On("RunTransactionProcessorsOnLedger", uint32(100)).Return(io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 	s.historyQ.On("Commit").Return(nil).Once()
 
 	err := s.system.ReingestRange(100, 100, false)
@@ -340,7 +341,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeForce() {
 	).Return(nil).Once()
 
 	for i := 100; i <= 200; i++ {
-		s.runner.On("RunTransactionProcessorsOnLedger", uint32(i)).Return(nil).Once()
+		s.runner.On("RunTransactionProcessorsOnLedger", uint32(i)).Return(io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 	}
 
 	s.historyQ.On("Commit").Return(nil).Once()

--- a/services/horizon/internal/expingest/main_test.go
+++ b/services/horizon/internal/expingest/main_test.go
@@ -311,14 +311,16 @@ func (m *mockProcessorsRunner) RunHistoryArchiveIngestion(checkpointLedger uint3
 	return args.Get(0).(io.StatsChangeProcessorResults), args.Error(1)
 }
 
-func (m *mockProcessorsRunner) RunAllProcessorsOnLedger(sequence uint32) (io.StatsChangeProcessorResults, error) {
+func (m *mockProcessorsRunner) RunAllProcessorsOnLedger(sequence uint32) (io.StatsChangeProcessorResults, io.StatsLedgerTransactionProcessorResults, error) {
 	args := m.Called(sequence)
-	return args.Get(0).(io.StatsChangeProcessorResults), args.Error(1)
+	return args.Get(0).(io.StatsChangeProcessorResults),
+		args.Get(1).(io.StatsLedgerTransactionProcessorResults),
+		args.Error(2)
 }
 
-func (m *mockProcessorsRunner) RunTransactionProcessorsOnLedger(sequence uint32) error {
+func (m *mockProcessorsRunner) RunTransactionProcessorsOnLedger(sequence uint32) (io.StatsLedgerTransactionProcessorResults, error) {
 	args := m.Called(sequence)
-	return args.Error(0)
+	return args.Get(0).(io.StatsLedgerTransactionProcessorResults), args.Error(1)
 }
 
 func (m *mockProcessorsRunner) RunOrderBookProcessorOnLedger(sequence uint32) (io.StatsChangeProcessorResults, error) {

--- a/services/horizon/internal/expingest/resume_state_test.go
+++ b/services/horizon/internal/expingest/resume_state_test.go
@@ -272,7 +272,7 @@ func (s *ResumeTestTestSuite) TestIngestAllMasterNode() {
 
 	s.ledgeBackend.On("GetLatestLedgerSequence").Return(uint32(111), nil).Once()
 
-	s.runner.On("RunAllProcessorsOnLedger", uint32(101)).Return(io.StatsChangeProcessorResults{}, nil).Once()
+	s.runner.On("RunAllProcessorsOnLedger", uint32(101)).Return(io.StatsChangeProcessorResults{}, io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(101)).Return(nil).Once()
 	s.historyQ.On("Commit").Return(nil).Once()
 	s.graph.On("Apply", uint32(101)).Return(nil).Once()
@@ -305,7 +305,7 @@ func (s *ResumeTestTestSuite) TestErrorSettingCursorIgnored() {
 
 	s.ledgeBackend.On("GetLatestLedgerSequence").Return(uint32(111), nil).Once()
 
-	s.runner.On("RunAllProcessorsOnLedger", uint32(101)).Return(io.StatsChangeProcessorResults{}, nil).Once()
+	s.runner.On("RunAllProcessorsOnLedger", uint32(101)).Return(io.StatsChangeProcessorResults{}, io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(101)).Return(nil).Once()
 	s.historyQ.On("Commit").Return(nil).Once()
 	s.graph.On("Apply", uint32(101)).Return(nil).Once()

--- a/services/horizon/internal/expingest/stress_test.go
+++ b/services/horizon/internal/expingest/stress_test.go
@@ -98,7 +98,7 @@ func (s *StressTestStateTestSuite) TestGetLastLedgerExpIngestNonEmpty() {
 func (s *StressTestStateTestSuite) TestRunAllProcessorsOnLedgerReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
-	s.runner.On("RunAllProcessorsOnLedger", uint32(1)).Return(io.StatsChangeProcessorResults{}, errors.New("my error")).Once()
+	s.runner.On("RunAllProcessorsOnLedger", uint32(1)).Return(io.StatsChangeProcessorResults{}, io.StatsLedgerTransactionProcessorResults{}, errors.New("my error")).Once()
 
 	err := s.system.StressTest(10, 4)
 	s.Assert().EqualError(err, "Error running processors on ledger: my error")
@@ -107,7 +107,7 @@ func (s *StressTestStateTestSuite) TestRunAllProcessorsOnLedgerReturnsError() {
 func (s *StressTestStateTestSuite) TestUpdateLastLedgerExpIngestReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
-	s.runner.On("RunAllProcessorsOnLedger", uint32(1)).Return(io.StatsChangeProcessorResults{}, nil).Once()
+	s.runner.On("RunAllProcessorsOnLedger", uint32(1)).Return(io.StatsChangeProcessorResults{}, io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(1)).Return(errors.New("my error")).Once()
 
 	err := s.system.StressTest(10, 4)
@@ -117,7 +117,7 @@ func (s *StressTestStateTestSuite) TestUpdateLastLedgerExpIngestReturnsError() {
 func (s *StressTestStateTestSuite) TestApplyReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
-	s.runner.On("RunAllProcessorsOnLedger", uint32(1)).Return(io.StatsChangeProcessorResults{}, nil).Once()
+	s.runner.On("RunAllProcessorsOnLedger", uint32(1)).Return(io.StatsChangeProcessorResults{}, io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(1)).Return(nil).Once()
 	s.historyQ.On("Commit").Return(nil).Once()
 	s.graph.On("Apply", uint32(1)).Return(errors.New("my error")).Once()
@@ -129,7 +129,7 @@ func (s *StressTestStateTestSuite) TestApplyReturnsError() {
 func (s *StressTestStateTestSuite) TestCommitReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
-	s.runner.On("RunAllProcessorsOnLedger", uint32(1)).Return(io.StatsChangeProcessorResults{}, nil).Once()
+	s.runner.On("RunAllProcessorsOnLedger", uint32(1)).Return(io.StatsChangeProcessorResults{}, io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(1)).Return(nil).Once()
 	s.historyQ.On("Commit").Return(errors.New("my error")).Once()
 
@@ -140,7 +140,7 @@ func (s *StressTestStateTestSuite) TestCommitReturnsError() {
 func (s *StressTestStateTestSuite) TestSucceeds() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
-	s.runner.On("RunAllProcessorsOnLedger", uint32(1)).Return(io.StatsChangeProcessorResults{}, nil).Once()
+	s.runner.On("RunAllProcessorsOnLedger", uint32(1)).Return(io.StatsChangeProcessorResults{}, io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(1)).Return(nil).Once()
 	s.historyQ.On("Commit").Return(nil).Once()
 	s.graph.On("Apply", uint32(1)).Return(nil).Once()

--- a/services/horizon/internal/expingest/verify_range_state_test.go
+++ b/services/horizon/internal/expingest/verify_range_state_test.go
@@ -154,7 +154,7 @@ func (s *VerifyRangeStateTestSuite) TestSuccess() {
 
 	for i := uint32(101); i <= 200; i++ {
 		s.historyQ.On("Begin").Return(nil).Once()
-		s.runner.On("RunAllProcessorsOnLedger", i).Return(io.StatsChangeProcessorResults{}, nil).Once()
+		s.runner.On("RunAllProcessorsOnLedger", i).Return(io.StatsChangeProcessorResults{}, io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 		s.historyQ.On("UpdateLastLedgerExpIngest", i).Return(nil).Once()
 		s.historyQ.On("Commit").Return(nil).Once()
 		s.graph.On("Apply", i).Return(nil).Once()
@@ -178,7 +178,7 @@ func (s *VerifyRangeStateTestSuite) TestSuccessWithVerify() {
 
 	for i := uint32(101); i <= 110; i++ {
 		s.historyQ.On("Begin").Return(nil).Once()
-		s.runner.On("RunAllProcessorsOnLedger", i).Return(io.StatsChangeProcessorResults{}, nil).Once()
+		s.runner.On("RunAllProcessorsOnLedger", i).Return(io.StatsChangeProcessorResults{}, io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 		s.historyQ.On("UpdateLastLedgerExpIngest", i).Return(nil).Once()
 		s.historyQ.On("Commit").Return(nil).Once()
 		s.graph.On("Apply", i).Return(nil).Once()


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit adds `exp/ingest/io.StatsLedgerTransactionProcessor` struct responsible for reporting transactions stats and adds it to Horizon processors.

Close #2208

### Why

Transaction stats are essential to understanding possible performance issues in ingestion process (if/as they happen).