### PR TITLE
services/horizon/txsub: Skip checking Core DB if Horizon is ingesting failed txs

### DIFF
--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -198,6 +198,37 @@ func dialRedis(redisURL *url.URL) func() (redis.Conn, error) {
 }
 
 func initSubmissionSystem(app *App) {
+	// Due to a delay between Stellar-Core closing a ledger and Horizon
+	// ingesting it, it's possible that results of transaction submitted to
+	// Stellar-Core via Horizon may not be immediately visible. This is
+	// happening because `txsub` package checks two sources when checking a
+	// transaction result: Stellar-Core and Horizon DB.
+	//
+	// The extreme case is https://github.com/stellar/go/issues/2272 where
+	// results of transaction creating an account are not visible: requesting
+	// account details in Horizon returns `404 Not Found`:
+	//
+	// ```
+	// 	 Horizon DB                  Core DB                  User
+	// 		 |                          |                      |
+	// 		 |                          |                      |
+	// 		 |                          | <------- Submit create_account op
+	// 		 |                          |                      |
+	// 		 |                  Insert transaction             |
+	// 		 |                          |                      |
+	// 		 |                     Tx found -----------------> |
+	// 		 |                          |                      |
+	// 		 |                          |                      |
+	// 		 | <--------------------------------------- Get account info
+	// 		 |                          |                      |
+	// 		 |                          |                      |
+	// Account NOT found ---------------------------------------> |
+	// 		 |                          |                      |
+	//    Insert account                   |                      |
+	// ```
+	//
+	// To fix this Skip checking Stellar-Core DB for transaction results if
+	// Horizon is ingesting failed transactions.
 	var cq *core.Q
 	if !app.config.IngestFailedTransactions {
 		cq = &core.Q{Session: app.CoreSession(context.Background())}

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -198,7 +198,10 @@ func dialRedis(redisURL *url.URL) func() (redis.Conn, error) {
 }
 
 func initSubmissionSystem(app *App) {
-	cq := &core.Q{Session: app.CoreSession(context.Background())}
+	var cq *core.Q
+	if !app.config.IngestFailedTransactions {
+		cq = &core.Q{Session: app.CoreSession(context.Background())}
+	}
 
 	app.submitter = &txsub.System{
 		Pending:         txsub.NewDefaultSubmissionList(),

--- a/services/horizon/internal/txsub/results/db/main.go
+++ b/services/horizon/internal/txsub/results/db/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 // DB provides transactio submission results by querying the
-// connected horizon and stellar core databases.
+// connected horizon and, if set, stellar core databases.
 type DB struct {
 	Core    *core.Q
 	History *history.Q
@@ -38,26 +38,28 @@ func (rp *DB) ResultByHash(ctx context.Context, hash string) txsub.Result {
 		return txsub.Result{Err: err}
 	}
 
-	// query core database
-	var cr core.Transaction
-	// In the past we were searching for the transaction in core DB *after* the
-	// latest ingested ledger. This was incorrect because history DB contains
-	// successful transactions only. So it was possible that the transaction was
-	// never found and clients were receiving Timeout errors.
-	// However we can't change it to simply find a transaction by hash because
-	// `txhistory` table does not have an index on `txid` field. Because of this
-	// we query the last 120 ledgers (~10 minutes) to not kill the DB by searching
-	// for a value on a table with millions of rows but also to support returning
-	// the failed tx result (when resubmitting) for 10 minutes (or before core
-	// clears `txhistory` table, whatever is first).
-	// If you are modifying the code here, please do not make this error again.
-	err = rp.Core.TransactionByHashAfterLedger(&cr, hash, historyLatest-120)
-	if err == nil {
-		return txResultFromCore(cr)
-	}
+	if rp.Core != nil {
+		// query core database
+		var cr core.Transaction
+		// In the past we were searching for the transaction in core DB *after* the
+		// latest ingested ledger. This was incorrect because history DB contains
+		// successful transactions only. So it was possible that the transaction was
+		// never found and clients were receiving Timeout errors.
+		// However we can't change it to simply find a transaction by hash because
+		// `txhistory` table does not have an index on `txid` field. Because of this
+		// we query the last 120 ledgers (~10 minutes) to not kill the DB by searching
+		// for a value on a table with millions of rows but also to support returning
+		// the failed tx result (when resubmitting) for 10 minutes (or before core
+		// clears `txhistory` table, whatever is first).
+		// If you are modifying the code here, please do not make this error again.
+		err = rp.Core.TransactionByHashAfterLedger(&cr, hash, historyLatest-120)
+		if err == nil {
+			return txResultFromCore(cr)
+		}
 
-	if !rp.Core.NoRows(err) {
-		return txsub.Result{Err: err}
+		if !rp.Core.NoRows(err) {
+			return txsub.Result{Err: err}
+		}
 	}
 
 	// if no result was found in either db, return ErrNoResults

--- a/services/horizon/internal/txsub/results/db/main_test.go
+++ b/services/horizon/internal/txsub/results/db/main_test.go
@@ -27,6 +27,24 @@ func TestResultProvider(t *testing.T) {
 	tt.Assert.Equal(hash, ret.Hash)
 }
 
+func TestResultProviderHorizonOnly(t *testing.T) {
+	tt := test.Start(t).Scenario("base")
+	defer tt.Finish()
+
+	rp := &DB{
+		History: &history.Q{Session: tt.HorizonSession()},
+	}
+
+	hash := "adf1efb9fd253f53cbbe6230c131d2af19830328e52b610464652d67d2fb7195"
+	_, err := tt.CoreSession().ExecRaw("INSERT INTO txhistory VALUES ('" + hash + "', 5, 1, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAArqN6LeOagjxMaUP96Bzfs9e0corNZXzBWJkFoK7kvkwAAAAAO5rKAAAAAAAAAAABVvwF9wAAAECDzqvkQBQoNAJifPRXDoLhvtycT3lFPCQ51gkdsFHaBNWw05S/VhW0Xgkr0CBPE4NaFV2Kmcs3ZwLmib4TRrML', 'I3Tpk0m57326ml2zM5t4/ajzR3exrzO6RorVwN+UbU0AAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAwAAAAMAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/7UAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrNryTTUAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAACuo3ot45qCPExpQ/3oHN+z17Ryis1lfMFYmQWgruS+TAAAAAA7msoAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');")
+	tt.Require.NoError(err)
+
+	ret := rp.ResultByHash(tt.Ctx, hash)
+
+	tt.Require.Equal(ret.Err, txsub.ErrNoResults)
+	tt.Assert.Empty(ret.Hash)
+}
+
 func TestResultFailed(t *testing.T) {
 	tt := test.Start(t).Scenario("failed_transactions")
 	defer tt.Finish()


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Skip checking Stellar-Core DB for transaction results if Horizon is ingesting failed transactions.

### Why

Due to a delay between Stellar-Core closing a ledger and Horizon ingesting it, it's possible that results of transaction submitted to Stellar-Core via Horizon may not be immediately visible. This is happening because `txsub` package checks two sources when checking a transaction result: Stellar-Core and Horizon DB.

The extreme case is https://github.com/stellar/go/issues/2272 where results of transaction creating an account are not visible: requesting account details in Horizon returns `404 Not Found`:

```
     Horizon DB                  Core DB                  User
         |                          |                      |
         |                          |                      |
         |                          | <------- Submit create_account op
         |                          |                      |
         |                  Insert transaction             |
         |                          |                      |
         |                     Tx found -----------------> |
         |                          |                      |
         |                          |                      |
         | <--------------------------------------- Get account info
         |                          |                      |
         |                          |                      |
Account NOT found ---------------------------------------> |
         |                          |                      |
   Insert account                   |                      |
```

### Known limitations

This is just a temporary solution. The long term fix needs to be properly tested before a release.