### PR TITLE
exp/services/webauth: rename commands package to cmd

### DIFF
--- a/exp/services/webauth/cmd/genjwtkey.go
+++ b/exp/services/webauth/cmd/genjwtkey.go
@@ -1,4 +1,4 @@
-package commands
+package cmd
 
 import (
 	"github.com/spf13/cobra"

--- a/exp/services/webauth/cmd/serve.go
+++ b/exp/services/webauth/cmd/serve.go
@@ -1,4 +1,4 @@
-package commands
+package cmd
 
 import (
 	"go/types"

--- a/exp/services/webauth/main.go
+++ b/exp/services/webauth/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/stellar/go/exp/services/webauth/internal/commands"
+	"github.com/stellar/go/exp/services/webauth/cmd"
 	supportlog "github.com/stellar/go/support/log"
 )
 
@@ -19,8 +19,8 @@ func main() {
 		},
 	}
 
-	rootCmd.AddCommand((&commands.ServeCommand{Logger: logger}).Command())
-	rootCmd.AddCommand((&commands.GenJWTKeyCommand{Logger: logger}).Command())
+	rootCmd.AddCommand((&cmd.ServeCommand{Logger: logger}).Command())
+	rootCmd.AddCommand((&cmd.GenJWTKeyCommand{Logger: logger}).Command())
 
 	err := rootCmd.Execute()
 	if err != nil {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Rename the `exp/services/webauth/internal/commands` package to `exp/services/webauth/cmd`.

### Why

The cobra commands for the `webauth` app live in the `internal/commands` package but we have a couple apps that are using the convention to put commands in a top-level `cmd` package. E.g. Horizon, Ticker. This makes `webauth` more consistent with those applications.

This idea was discussed here: https://github.com/stellar/go/pull/2267#discussion_r379692099

### Known limitations

N/A
