### PR TITLE
txnbuild: remove superfluous signing key in challenge txn test

### DIFF
--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -2293,7 +2293,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndClientSignersFailsSignerSeed(t
 
 	err := tx.Build()
 	require.NoError(t, err)
-	err = tx.Sign(serverKP, clientKP2, clientKP2)
+	err = tx.Sign(serverKP, clientKP2)
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove superfluous signing key in challenge transaction test that is used to sign the transaction twice when it only needs to sign the transaction once.

### Why

The key is added twice which was probably the result of a copy and paste from another tests where we test the behavior of signing a transaction twice. It's unnecessary to sign it twice here and having it sign the transaction twice is noise that is irrelevant to the scenario being tested in this test.

This was reported by @overcat: https://github.com/stellar/java-stellar-sdk/pull/264#issuecomment-583365448.

### Known limitations

N/A