### PR TITLE
services/horizon/expingest: ProcessorRunner tests

### DIFF
--- a/exp/orderbook/graph.go
+++ b/exp/orderbook/graph.go
@@ -39,6 +39,7 @@ type OBGraph interface {
 	Discard()
 	Offers() []xdr.OfferEntry
 	OffersMap() map[xdr.Int64]xdr.OfferEntry
+	RemoveOffer(xdr.Int64) OBGraph
 	Clear()
 }
 
@@ -88,7 +89,7 @@ func (graph *OrderBookGraph) AddOffer(offer xdr.OfferEntry) {
 // RemoveOffer will queue an operation to remove the given offer from the order book in
 // the internal batch.
 // You need to run Apply() to apply all enqueued operations.
-func (graph *OrderBookGraph) RemoveOffer(offerID xdr.Int64) *OrderBookGraph {
+func (graph *OrderBookGraph) RemoveOffer(offerID xdr.Int64) OBGraph {
 	graph.batchedUpdates.removeOffer(offerID)
 	return graph
 }

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -170,7 +170,6 @@ func NewSystem(config Config) (*System, error) {
 			config:         config,
 			graph:          config.OrderBookGraph,
 			historyQ:       historyQ,
-			historyArchive: archive,
 			historyAdapter: historyAdapter,
 			ledgerBackend:  ledgerBackend,
 		},

--- a/services/horizon/internal/expingest/mock_orderbook_graph.go
+++ b/services/horizon/internal/expingest/mock_orderbook_graph.go
@@ -35,6 +35,11 @@ func (m *mockOrderBookGraph) OffersMap() map[xdr.Int64]xdr.OfferEntry {
 	return args.Get(0).(map[xdr.Int64]xdr.OfferEntry)
 }
 
+func (m *mockOrderBookGraph) RemoveOffer(id xdr.Int64) orderbook.OBGraph {
+	args := m.Called(id)
+	return args.Get(0).(orderbook.OBGraph)
+}
+
 func (m *mockOrderBookGraph) Clear() {
 	m.Called()
 }

--- a/services/horizon/internal/expingest/processor_runner.go
+++ b/services/horizon/internal/expingest/processor_runner.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/expingest/processors"
 	"github.com/stellar/go/support/errors"
-	"github.com/stellar/go/support/historyarchive"
 	"github.com/stellar/go/xdr"
 )
 
@@ -67,9 +66,8 @@ type ProcessorRunner struct {
 	config Config
 
 	ctx            context.Context
-	graph          *orderbook.OrderBookGraph
+	graph          orderbook.OBGraph
 	historyQ       history.IngestionQ
-	historyArchive *historyarchive.Archive
 	historyAdapter adapters.HistoryArchiveAdapterInterface
 	ledgerBackend  ledgerbackend.LedgerBackend
 	logMemoryStats bool

--- a/services/horizon/internal/expingest/processor_runner_test.go
+++ b/services/horizon/internal/expingest/processor_runner_test.go
@@ -1,0 +1,420 @@
+package expingest
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stellar/go/exp/ingest/adapters"
+	"github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/exp/ingest/ledgerbackend"
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/expingest/processors"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
+	maxBatchSize := 100000
+
+	graph := &mockOrderBookGraph{}
+	q := &mockDBQ{}
+
+	// Batches
+	mockOffersBatchInsertBuilder := &history.MockOffersBatchInsertBuilder{}
+	defer mock.AssertExpectationsForObjects(t, mockOffersBatchInsertBuilder)
+	mockOffersBatchInsertBuilder.On("Exec").Return(nil).Once()
+	q.MockQOffers.On("NewOffersBatchInsertBuilder", maxBatchSize).
+		Return(mockOffersBatchInsertBuilder).Once()
+
+	mockAccountDataBatchInsertBuilder := &history.MockAccountDataBatchInsertBuilder{}
+	defer mock.AssertExpectationsForObjects(t, mockAccountDataBatchInsertBuilder)
+	mockAccountDataBatchInsertBuilder.On("Exec").Return(nil).Once()
+	q.MockQData.On("NewAccountDataBatchInsertBuilder", maxBatchSize).
+		Return(mockAccountDataBatchInsertBuilder).Once()
+
+	q.MockQAccounts.On("UpsertAccounts", []xdr.LedgerEntry{
+		xdr.LedgerEntry{
+			LastModifiedLedgerSeq: 1,
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeAccount,
+				Account: &xdr.AccountEntry{
+					AccountId:  xdr.MustAddress("GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7"),
+					Balance:    xdr.Int64(1000000000000000000),
+					SeqNum:     xdr.SequenceNumber(0),
+					Thresholds: [4]byte{1, 0, 0, 0},
+				},
+			},
+		},
+	}).Return(nil).Once()
+
+	mockAccountSignersBatchInsertBuilder := &history.MockAccountSignersBatchInsertBuilder{}
+	defer mock.AssertExpectationsForObjects(t, mockAccountSignersBatchInsertBuilder)
+	mockAccountSignersBatchInsertBuilder.On("Add", history.AccountSigner{
+		Account: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+		Signer:  "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+		Weight:  1,
+	}).Return(nil).Once()
+	mockAccountSignersBatchInsertBuilder.On("Exec").Return(nil).Once()
+	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
+		Return(mockAccountSignersBatchInsertBuilder).Once()
+
+	q.MockQAssetStats.On("InsertAssetStats", []history.ExpAssetStat{}, 100000).
+		Return(nil)
+
+	runner := ProcessorRunner{
+		config: Config{
+			NetworkPassphrase: network.PublicNetworkPassphrase,
+		},
+		graph:    graph,
+		historyQ: q,
+	}
+
+	_, err := runner.RunHistoryArchiveIngestion(1)
+	assert.NoError(t, err)
+}
+
+func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
+	maxBatchSize := 100000
+
+	config := Config{
+		NetworkPassphrase: network.PublicNetworkPassphrase,
+		MaxStreamRetries:  3,
+	}
+
+	graph := &mockOrderBookGraph{}
+	defer mock.AssertExpectationsForObjects(t, graph)
+	q := &mockDBQ{}
+	defer mock.AssertExpectationsForObjects(t, q)
+	historyAdapter := &adapters.MockHistoryArchiveAdapter{}
+	defer mock.AssertExpectationsForObjects(t, historyAdapter)
+	ledgerBackend := &ledgerbackend.MockDatabaseBackend{}
+	defer mock.AssertExpectationsForObjects(t, ledgerBackend)
+
+	historyAdapter.On("BucketListHash", uint32(63)).
+		Return(xdr.Hash([32]byte{0, 1, 2}), nil).Once()
+
+	historyAdapter.
+		On(
+			"GetState",
+			mock.AnythingOfType("*context.emptyCtx"),
+			uint32(63),
+			&io.MemoryTempSet{},
+			config.MaxStreamRetries,
+		).
+		Return(
+			&io.GenesisLedgerStateReader{
+				NetworkPassphrase: network.PublicNetworkPassphrase,
+			},
+			nil,
+		).Once()
+
+	ledgerBackend.On("GetLedger", uint32(63)).
+		Return(
+			true,
+			ledgerbackend.LedgerCloseMeta{
+				LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+					Header: xdr.LedgerHeader{
+						BucketListHash: xdr.Hash([32]byte{0, 1, 2}),
+					},
+				},
+			},
+			nil,
+		).Once()
+
+	// Batches
+	mockOffersBatchInsertBuilder := &history.MockOffersBatchInsertBuilder{}
+	defer mock.AssertExpectationsForObjects(t, mockOffersBatchInsertBuilder)
+	mockOffersBatchInsertBuilder.On("Exec").Return(nil).Once()
+	q.MockQOffers.On("NewOffersBatchInsertBuilder", maxBatchSize).
+		Return(mockOffersBatchInsertBuilder).Once()
+
+	mockAccountDataBatchInsertBuilder := &history.MockAccountDataBatchInsertBuilder{}
+	defer mock.AssertExpectationsForObjects(t, mockAccountDataBatchInsertBuilder)
+	mockAccountDataBatchInsertBuilder.On("Exec").Return(nil).Once()
+	q.MockQData.On("NewAccountDataBatchInsertBuilder", maxBatchSize).
+		Return(mockAccountDataBatchInsertBuilder).Once()
+
+	q.MockQAccounts.On("UpsertAccounts", []xdr.LedgerEntry{
+		xdr.LedgerEntry{
+			LastModifiedLedgerSeq: 1,
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeAccount,
+				Account: &xdr.AccountEntry{
+					AccountId:  xdr.MustAddress("GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7"),
+					Balance:    xdr.Int64(1000000000000000000),
+					SeqNum:     xdr.SequenceNumber(0),
+					Thresholds: [4]byte{1, 0, 0, 0},
+				},
+			},
+		},
+	}).Return(nil).Once()
+
+	mockAccountSignersBatchInsertBuilder := &history.MockAccountSignersBatchInsertBuilder{}
+	defer mock.AssertExpectationsForObjects(t, mockAccountSignersBatchInsertBuilder)
+	mockAccountSignersBatchInsertBuilder.On("Add", history.AccountSigner{
+		Account: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+		Signer:  "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+		Weight:  1,
+	}).Return(nil).Once()
+	mockAccountSignersBatchInsertBuilder.On("Exec").Return(nil).Once()
+	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
+		Return(mockAccountSignersBatchInsertBuilder).Once()
+
+	q.MockQAssetStats.On("InsertAssetStats", []history.ExpAssetStat{}, 100000).
+		Return(nil)
+
+	runner := ProcessorRunner{
+		ctx:            context.Background(),
+		config:         config,
+		graph:          graph,
+		historyQ:       q,
+		historyAdapter: historyAdapter,
+		ledgerBackend:  ledgerBackend,
+	}
+
+	_, err := runner.RunHistoryArchiveIngestion(63)
+	assert.NoError(t, err)
+}
+
+func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
+	maxBatchSize := 100000
+
+	q := &mockDBQ{}
+	defer mock.AssertExpectationsForObjects(t, q)
+
+	// Twice = checking ledgerSource and historyArchiveSource
+	q.MockQOffers.On("NewOffersBatchInsertBuilder", maxBatchSize).
+		Return(&history.MockOffersBatchInsertBuilder{}).Twice()
+	q.MockQData.On("NewAccountDataBatchInsertBuilder", maxBatchSize).
+		Return(&history.MockAccountDataBatchInsertBuilder{}).Twice()
+	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
+		Return(&history.MockAccountSignersBatchInsertBuilder{}).Twice()
+
+	runner := ProcessorRunner{
+		historyQ: q,
+	}
+
+	stats := &io.StatsChangeProcessor{}
+	processor := runner.buildChangeProcessor(stats, ledgerSource)
+	assert.IsType(t, groupChangeProcessors{}, processor)
+
+	assert.IsType(t, &statsChangeProcessor{}, processor.(groupChangeProcessors)[0])
+	assert.IsType(t, &processors.OrderbookProcessor{}, processor.(groupChangeProcessors)[1])
+	assert.IsType(t, &processors.AccountDataProcessor{}, processor.(groupChangeProcessors)[2])
+	assert.IsType(t, &processors.AccountsProcessor{}, processor.(groupChangeProcessors)[3])
+	assert.IsType(t, &processors.OffersProcessor{}, processor.(groupChangeProcessors)[4])
+	assert.IsType(t, &processors.AssetStatsProcessor{}, processor.(groupChangeProcessors)[5])
+	assert.True(t, reflect.ValueOf(processor.(groupChangeProcessors)[5]).
+		Elem().FieldByName("useLedgerEntryCache").Bool())
+	assert.IsType(t, &processors.SignersProcessor{}, processor.(groupChangeProcessors)[6])
+	assert.True(t, reflect.ValueOf(processor.(groupChangeProcessors)[6]).
+		Elem().FieldByName("useLedgerEntryCache").Bool())
+	assert.IsType(t, &processors.TrustLinesProcessor{}, processor.(groupChangeProcessors)[7])
+
+	runner = ProcessorRunner{
+		historyQ: q,
+	}
+
+	processor = runner.buildChangeProcessor(stats, historyArchiveSource)
+	assert.IsType(t, groupChangeProcessors{}, processor)
+
+	assert.IsType(t, &statsChangeProcessor{}, processor.(groupChangeProcessors)[0])
+	assert.IsType(t, &processors.OrderbookProcessor{}, processor.(groupChangeProcessors)[1])
+	assert.IsType(t, &processors.AccountDataProcessor{}, processor.(groupChangeProcessors)[2])
+	assert.IsType(t, &processors.AccountsProcessor{}, processor.(groupChangeProcessors)[3])
+	assert.IsType(t, &processors.OffersProcessor{}, processor.(groupChangeProcessors)[4])
+	assert.IsType(t, &processors.AssetStatsProcessor{}, processor.(groupChangeProcessors)[5])
+	assert.False(t, reflect.ValueOf(processor.(groupChangeProcessors)[5]).
+		Elem().FieldByName("useLedgerEntryCache").Bool())
+	assert.IsType(t, &processors.SignersProcessor{}, processor.(groupChangeProcessors)[6])
+	assert.False(t, reflect.ValueOf(processor.(groupChangeProcessors)[6]).
+		Elem().FieldByName("useLedgerEntryCache").Bool())
+	assert.IsType(t, &processors.TrustLinesProcessor{}, processor.(groupChangeProcessors)[7])
+}
+
+func TestProcessorRunnerBuildTransactionProcessor(t *testing.T) {
+	maxBatchSize := 100000
+
+	q := &mockDBQ{}
+	defer mock.AssertExpectationsForObjects(t, q)
+
+	q.MockQOperations.On("NewOperationBatchInsertBuilder", maxBatchSize).
+		Return(&history.MockOperationsBatchInsertBuilder{}).Twice() // Twice = with/without failed
+	q.MockQTransactions.On("NewTransactionBatchInsertBuilder", maxBatchSize).
+		Return(&history.MockTransactionsBatchInsertBuilder{}).Twice()
+
+	runner := ProcessorRunner{
+		config: Config{
+			IngestFailedTransactions: true,
+		},
+		historyQ: q,
+	}
+
+	stats := &io.StatsLedgerTransactionProcessor{}
+	ledger := xdr.LedgerHeaderHistoryEntry{}
+	processor := runner.buildTransactionProcessor(stats, ledger)
+	assert.IsType(t, groupTransactionProcessors{}, processor)
+
+	assert.IsType(t, &statsLedgerTransactionProcessor{}, processor.(groupTransactionProcessors)[0])
+	assert.IsType(t, &processors.EffectProcessor{}, processor.(groupTransactionProcessors)[1])
+	assert.IsType(t, &processors.LedgersProcessor{}, processor.(groupTransactionProcessors)[2])
+	assert.IsType(t, &processors.OperationProcessor{}, processor.(groupTransactionProcessors)[3])
+	assert.IsType(t, &processors.TradeProcessor{}, processor.(groupTransactionProcessors)[4])
+	assert.IsType(t, &processors.ParticipantsProcessor{}, processor.(groupTransactionProcessors)[5])
+	assert.IsType(t, &processors.TransactionProcessor{}, processor.(groupTransactionProcessors)[6])
+
+	runner = ProcessorRunner{
+		config: Config{
+			IngestFailedTransactions: false,
+		},
+		historyQ: q,
+	}
+
+	processor = runner.buildTransactionProcessor(stats, ledger)
+	assert.IsType(t, skipFailedTransactions{}, processor)
+}
+
+func TestProcessorRunnerRunAllProcessorsOnLedger(t *testing.T) {
+	maxBatchSize := 100000
+
+	config := Config{
+		NetworkPassphrase: network.PublicNetworkPassphrase,
+		MaxStreamRetries:  3,
+	}
+
+	graph := &mockOrderBookGraph{}
+	defer mock.AssertExpectationsForObjects(t, graph)
+	q := &mockDBQ{}
+	defer mock.AssertExpectationsForObjects(t, q)
+	ledgerBackend := &ledgerbackend.MockDatabaseBackend{}
+	defer mock.AssertExpectationsForObjects(t, ledgerBackend)
+
+	ledger := xdr.LedgerHeaderHistoryEntry{
+		Header: xdr.LedgerHeader{
+			BucketListHash: xdr.Hash([32]byte{0, 1, 2}),
+		},
+	}
+
+	ledgerBackend.On("GetLedger", uint32(63)).
+		Return(
+			true,
+			ledgerbackend.LedgerCloseMeta{
+				LedgerHeader: ledger,
+			},
+			nil,
+		).Twice() // Twice = changes then transactions
+
+	// Batches
+	mockOffersBatchInsertBuilder := &history.MockOffersBatchInsertBuilder{}
+	defer mock.AssertExpectationsForObjects(t, mockOffersBatchInsertBuilder)
+	mockOffersBatchInsertBuilder.On("Exec").Return(nil).Once()
+	q.MockQOffers.On("NewOffersBatchInsertBuilder", maxBatchSize).
+		Return(mockOffersBatchInsertBuilder).Once()
+
+	mockAccountDataBatchInsertBuilder := &history.MockAccountDataBatchInsertBuilder{}
+	defer mock.AssertExpectationsForObjects(t, mockAccountDataBatchInsertBuilder)
+	mockAccountDataBatchInsertBuilder.On("Exec").Return(nil).Once()
+	q.MockQData.On("NewAccountDataBatchInsertBuilder", maxBatchSize).
+		Return(mockAccountDataBatchInsertBuilder).Once()
+
+	mockAccountSignersBatchInsertBuilder := &history.MockAccountSignersBatchInsertBuilder{}
+	defer mock.AssertExpectationsForObjects(t, mockAccountSignersBatchInsertBuilder)
+	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
+		Return(mockAccountSignersBatchInsertBuilder).Once()
+
+	mockOperationsBatchInsertBuilder := &history.MockOperationsBatchInsertBuilder{}
+	defer mock.AssertExpectationsForObjects(t, mockOperationsBatchInsertBuilder)
+	mockOperationsBatchInsertBuilder.On("Exec").Return(nil).Once()
+	q.MockQOperations.On("NewOperationBatchInsertBuilder", maxBatchSize).
+		Return(mockOperationsBatchInsertBuilder).Twice()
+
+	mockTransactionsBatchInsertBuilder := &history.MockTransactionsBatchInsertBuilder{}
+	defer mock.AssertExpectationsForObjects(t, mockTransactionsBatchInsertBuilder)
+	mockTransactionsBatchInsertBuilder.On("Exec").Return(nil).Once()
+	q.MockQTransactions.On("NewTransactionBatchInsertBuilder", maxBatchSize).
+		Return(mockTransactionsBatchInsertBuilder).Twice()
+
+	q.MockQLedgers.On("InsertLedger", ledger, 0, 0, 0, CurrentVersion).
+		Return(int64(1), nil).Once()
+
+	runner := ProcessorRunner{
+		ctx:           context.Background(),
+		config:        config,
+		graph:         graph,
+		historyQ:      q,
+		ledgerBackend: ledgerBackend,
+	}
+
+	_, _, err := runner.RunAllProcessorsOnLedger(63)
+	assert.NoError(t, err)
+}
+
+func TestProcessorRunnerRunOrderBookProcessorOnLedger(t *testing.T) {
+	config := Config{
+		NetworkPassphrase: network.PublicNetworkPassphrase,
+		MaxStreamRetries:  3,
+	}
+
+	graph := &mockOrderBookGraph{}
+	defer mock.AssertExpectationsForObjects(t, graph)
+	ledgerBackend := &ledgerbackend.MockDatabaseBackend{}
+	defer mock.AssertExpectationsForObjects(t, ledgerBackend)
+
+	ledger := xdr.LedgerHeaderHistoryEntry{
+		Header: xdr.LedgerHeader{
+			BucketListHash: xdr.Hash([32]byte{0, 1, 2}),
+		},
+	}
+
+	ledgerBackend.On("GetLedger", uint32(63)).
+		Return(
+			true,
+			ledgerbackend.LedgerCloseMeta{
+				LedgerHeader: ledger,
+			},
+			nil,
+		).Once()
+
+	runner := ProcessorRunner{
+		ctx:           context.Background(),
+		config:        config,
+		graph:         graph,
+		ledgerBackend: ledgerBackend,
+	}
+
+	_, err := runner.RunOrderBookProcessorOnLedger(63)
+	assert.NoError(t, err)
+}
+
+func TestSkipFailedTransactions(t *testing.T) {
+	mockProcessor := &mockHorizonTransactionProcessor{}
+	successfulTx := io.LedgerTransaction{
+		Result: xdr.TransactionResultPair{
+			Result: xdr.TransactionResult{
+				Result: xdr.TransactionResultResult{
+					Code: xdr.TransactionResultCodeTxSuccess,
+				},
+			},
+		},
+	}
+	mockProcessor.On("ProcessTransaction", successfulTx).Return(nil)
+	defer mock.AssertExpectationsForObjects(t, mockProcessor)
+
+	processor := skipFailedTransactions{mockProcessor}
+	err := processor.ProcessTransaction(io.LedgerTransaction{
+		Result: xdr.TransactionResultPair{
+			Result: xdr.TransactionResult{
+				Result: xdr.TransactionResultResult{
+					Code: xdr.TransactionResultCodeTxBadAuth,
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	err = processor.ProcessTransaction(successfulTx)
+	assert.NoError(t, err)
+}

--- a/services/horizon/internal/expingest/processors/new_orderbook_processor.go
+++ b/services/horizon/internal/expingest/processors/new_orderbook_processor.go
@@ -11,12 +11,12 @@ import (
 // for updating orderbook graph with new/updated/removed offers. Orderbook graph
 // can be later used for path finding.
 type OrderbookProcessor struct {
-	graph *orderbook.OrderBookGraph
+	graph orderbook.OBGraph
 
 	cache *io.LedgerEntryChangeCache
 }
 
-func NewOrderbookProcessor(graph *orderbook.OrderBookGraph) *OrderbookProcessor {
+func NewOrderbookProcessor(graph orderbook.OBGraph) *OrderbookProcessor {
 	return &OrderbookProcessor{
 		graph: graph,
 		cache: io.NewLedgerEntryChangeCache(),

--- a/tools/horizon-cmp/history.go
+++ b/tools/horizon-cmp/history.go
@@ -72,7 +72,6 @@ func checkPaths(paths []string) {
 			log.Info(path)
 		} else {
 			log.Error("DIFF " + path)
-			a.SaveDiff(".", b)
 			os.Exit(1)
 		}
 	}

--- a/tools/horizon-cmp/history.go
+++ b/tools/horizon-cmp/history.go
@@ -72,6 +72,7 @@ func checkPaths(paths []string) {
 			log.Info(path)
 		} else {
 			log.Error("DIFF " + path)
+			a.SaveDiff(".", b)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

This commit is adding tests to `ProcessorRunner`.