### PR TITLE
services/horizon: Change INTERNAL_PORT to ADMIN_PORT

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -49,7 +49,7 @@ The [testing guide](https://github.com/stellar/go/blob/release-horizon-v0.25.0/s
 
 ### Removed
 
-- `/metrics` endpoint is no longer part of the public API. It is now served on `INTERNAL_PORT/metrics`. `INTERNAL_PORT` can be set using env variable or `--internal-port` CLI param.
+- `/metrics` endpoint is no longer part of the public API. It is now served on `ADMIN_PORT/metrics`. `ADMIN_PORT` can be set using env variable or `--admin-port` CLI param.
 - Remove the following fields from [/fee_stats](https://www.stellar.org/developers/horizon/reference/endpoints/fee-stats.html):
 
     - `min_accepted_fee`

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -143,11 +143,11 @@ var configOpts = support.ConfigOptions{
 		Usage:       "tcp port to listen on for http requests",
 	},
 	&support.ConfigOption{
-		Name:        "internal-port",
-		ConfigKey:   &config.InternalPort,
+		Name:        "admin-port",
+		ConfigKey:   &config.AdminPort,
 		OptType:     types.Uint,
 		FlagDefault: uint(0),
-		Usage:       "WARNING: this should not be accessible from the Internet and does not use TLS, tcp port to listen on for internal http requests, 0 (default) disables the internal server",
+		Usage:       "WARNING: this should not be accessible from the Internet and does not use TLS, tcp port to listen on for admin http requests, 0 (default) disables the admin server",
 	},
 	&support.ConfigOption{
 		Name:        "max-db-connections",

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -95,13 +95,13 @@ func (a *App) Serve() {
 
 	log.Infof("Starting horizon on %s (ingest: %v)", addr, a.config.Ingest)
 
-	if a.config.InternalPort != 0 {
+	if a.config.AdminPort != 0 {
 		go func() {
-			internalAddr := fmt.Sprintf(":%d", a.config.InternalPort)
-			log.Infof("Starting internal server on %s", internalAddr)
+			adminAddr := fmt.Sprintf(":%d", a.config.AdminPort)
+			log.Infof("Starting internal server on %s", adminAddr)
 
 			internalSrv := &http.Server{
-				Addr:        internalAddr,
+				Addr:        adminAddr,
 				Handler:     a.web.internalRouter,
 				ReadTimeout: 5 * time.Second,
 			}

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	StellarCoreURL         string
 	HistoryArchiveURLs     []string
 	Port                   uint
-	InternalPort           uint
+	AdminPort              uint
 
 	// MaxDBConnections has a priority over all 4 values below.
 	MaxDBConnections            int

--- a/services/horizon/internal/docs/reference/endpoints/metrics.md
+++ b/services/horizon/internal/docs/reference/endpoints/metrics.md
@@ -4,7 +4,7 @@ title: Metrics
 
 The metrics endpoint returns a host of useful data points for monitoring the health of the underlying Horizon process. 
 
-Since Horizon 1.0.0 this endpoint is not part of the public API. It's available in the internal server (listening on the internal port set via `INTERNAL_PORT` env variable or `--internal-port` CLI param).
+Since Horizon 1.0.0 this endpoint is not part of the public API. It's available in the internal server (listening on the internal port set via `ADMIN_PORT` env variable or `--admin-port` CLI param).
 
 ## Request
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit changes `INTERNAL_PORT` to `ADMIN_PORT`.

### Why

The previous config name was confusing, ex. it could suggest that internal server is started on loopback interface only.
