### PR TITLE
tools/horizon-cmp: Retry on Latest-Ledger header mismatch

### DIFF
--- a/tools/horizon-cmp/internal/response.go
+++ b/tools/horizon-cmp/internal/response.go
@@ -65,8 +65,9 @@ type Response struct {
 	Path   string
 	Stream bool
 
-	StatusCode int
-	Body       string
+	StatusCode   int
+	LatestLedger string
+	Body         string
 	// NormalizedBody is body without parts that identify a single
 	// server (ex. domain) and fields known to be different between
 	// instances (ex. `result_meta_xdr`).
@@ -125,6 +126,7 @@ func NewResponse(domain, path string, stream bool) *Response {
 		response.Body = fmt.Sprintf("Empty body [%d]", rand.Uint64())
 	}
 
+	response.LatestLedger = resp.Header.Get("Latest-Ledger")
 	response.Body = string(body)
 
 	normalizedBody := response.Body

--- a/tools/horizon-cmp/main.go
+++ b/tools/horizon-cmp/main.go
@@ -183,6 +183,16 @@ func run(cmd *cobra.Command) {
 
 			requestWg.Wait()
 
+			// Retry when LatestLedger not equal but only if not empty because
+			// older Horizon versions don't send this header.
+			if a.LatestLedger != "" && b.LatestLedger != "" &&
+				a.LatestLedger != b.LatestLedger {
+				visitedPaths[pl.ID()] = false
+				paths <- pl
+				log.Warnf("LatestLedger does not match, retry queued: %s", pl.Path)
+				return
+			}
+
 			var status string
 			if a.Equal(b) {
 				status = "ok"

--- a/tools/horizon-cmp/main.go
+++ b/tools/horizon-cmp/main.go
@@ -35,8 +35,10 @@ const timeFormat = "2006-01-02-15-04-05"
 var pathAccessLog = regexp.MustCompile(`([A-Z]+) https?://[^/]*(/[^ ]*)`)
 
 var (
-	paths        = make(chan cmp.Path, pathsQueueCap)
-	visitedPaths map[string]bool
+	paths = make(chan cmp.Path, pathsQueueCap)
+
+	visitedPathsMutex sync.Mutex
+	visitedPaths      map[string]bool
 )
 
 // CLI params
@@ -158,10 +160,13 @@ func run(cmd *cobra.Command) {
 			continue
 		}
 
+		visitedPathsMutex.Lock()
 		if visitedPaths[pl.ID()] {
+			visitedPathsMutex.Unlock()
 			continue
 		}
 		visitedPaths[pl.ID()] = true
+		visitedPathsMutex.Unlock()
 
 		time.Sleep(time.Second / time.Duration(requestsPerSecond))
 		wg.Add(1)
@@ -187,7 +192,9 @@ func run(cmd *cobra.Command) {
 			// older Horizon versions don't send this header.
 			if a.LatestLedger != "" && b.LatestLedger != "" &&
 				a.LatestLedger != b.LatestLedger {
+				visitedPathsMutex.Lock()
 				visitedPaths[pl.ID()] = false
+				visitedPathsMutex.Unlock()
 				paths <- pl
 				log.Warnf("LatestLedger does not match, retry queued: %s", pl.Path)
 				return


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit queues a path to retry later when `Latest-Ledger` header is not equal.

### Why

If `Latest-Ledger` is not equal horizon-cmp can report the given path even though it's fine if responses are not equal.

Close #2017.