### PR TITLE
services/horizon/txsub: Use CoreDB for SequenceProvider

### DIFF
--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -222,9 +222,9 @@ func initSubmissionSystem(app *App) {
 	// 		 | <--------------------------------------- Get account info
 	// 		 |                          |                      |
 	// 		 |                          |                      |
-	// Account NOT found ------------------------------------> |
+	//         Account NOT found ------------------------------------> |
 	// 		 |                          |                      |
-	// Insert account                   |                      |
+	//         Insert account                   |                      |
 	// ```
 	//
 	// To fix this skip checking Stellar-Core DB for transaction results if

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -222,25 +222,23 @@ func initSubmissionSystem(app *App) {
 	// 		 | <--------------------------------------- Get account info
 	// 		 |                          |                      |
 	// 		 |                          |                      |
-	// Account NOT found ---------------------------------------> |
+	// Account NOT found ------------------------------------> |
 	// 		 |                          |                      |
-	//    Insert account                   |                      |
+	// Insert account                   |                      |
 	// ```
 	//
-	// To fix this Skip checking Stellar-Core DB for transaction results if
+	// To fix this skip checking Stellar-Core DB for transaction results if
 	// Horizon is ingesting failed transactions.
-	var cq *core.Q
-	if !app.config.IngestFailedTransactions {
-		cq = &core.Q{Session: app.CoreSession(context.Background())}
-	}
+	cq := &core.Q{Session: app.CoreSession(context.Background())}
 
 	app.submitter = &txsub.System{
 		Pending:         txsub.NewDefaultSubmissionList(),
 		Submitter:       txsub.NewDefaultSubmitter(http.DefaultClient, app.config.StellarCoreURL),
 		SubmissionQueue: sequence.NewManager(),
 		Results: &results.DB{
-			Core:    cq,
-			History: &history.Q{Session: app.HorizonSession(context.Background())},
+			Core:           &core.Q{Session: app.CoreSession(context.Background())},
+			History:        &history.Q{Session: app.HorizonSession(context.Background())},
+			SkipCoreChecks: app.config.IngestFailedTransactions,
 		},
 		Sequences:         cq.SequenceProvider(),
 		NetworkPassphrase: app.config.NetworkPassphrase,

--- a/services/horizon/internal/txsub/results/db/main.go
+++ b/services/horizon/internal/txsub/results/db/main.go
@@ -19,6 +19,8 @@ import (
 type DB struct {
 	Core    *core.Q
 	History *history.Q
+	// SkipCoreChecks makes DB skip checking transaction result in Core DB if `true`.
+	SkipCoreChecks bool
 }
 
 var _ txsub.ResultProvider = &DB{}
@@ -38,7 +40,7 @@ func (rp *DB) ResultByHash(ctx context.Context, hash string) txsub.Result {
 		return txsub.Result{Err: err}
 	}
 
-	if rp.Core != nil {
+	if !rp.SkipCoreChecks {
 		// query core database
 		var cr core.Transaction
 		// In the past we were searching for the transaction in core DB *after* the

--- a/services/horizon/internal/txsub/results/db/main_test.go
+++ b/services/horizon/internal/txsub/results/db/main_test.go
@@ -32,7 +32,9 @@ func TestResultProviderHorizonOnly(t *testing.T) {
 	defer tt.Finish()
 
 	rp := &DB{
-		History: &history.Q{Session: tt.HorizonSession()},
+		Core:           &core.Q{Session: tt.CoreSession()},
+		History:        &history.Q{Session: tt.HorizonSession()},
+		SkipCoreChecks: true,
 	}
 
 	hash := "adf1efb9fd253f53cbbe6230c131d2af19830328e52b610464652d67d2fb7195"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit fixes a bug introduced in https://github.com/stellar/go/pull/2277. It adds `core.Q` back to `txsub/results.DB` and uses a new `SkipCoreChecks` fields to decide if core DB should be used or not.

### Why

`core.Q` is also needed to provide `SequenceProvider` to `txsub` system. In the future we can use Horizon DB as a `SequenceProvider` but it requires more tests.