### PR TITLE
services/horizon: Change default of max-path-length to 3

### DIFF
--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -261,7 +261,7 @@ var configOpts = support.ConfigOptions{
 		Name:        "max-path-length",
 		ConfigKey:   &config.MaxPathLength,
 		OptType:     types.Uint,
-		FlagDefault: uint(4),
+		FlagDefault: uint(3),
 		Usage:       "the maximum number of assets on the path in `/paths` endpoint, warning: increasing this value will increase /paths response time",
 	},
 	&support.ConfigOption{


### PR DESCRIPTION
This commit changes the default value of `max-path-length` to `3`.