### PR TITLE
Backfill fee stats data to make the  client compatible with horizon 1.X and 0.X.

### DIFF
--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -311,9 +311,30 @@ func (c *Client) Metrics() (metrics hProtocol.Metrics, err error) {
 
 // FeeStats returns information about fees in the last 5 ledgers.
 // See https://www.stellar.org/developers/horizon/reference/endpoints/fee-stats.html
-func (c *Client) FeeStats() (feestats hProtocol.FeeStats, err error) {
+func (c *Client) FeeStats() (feeStats hProtocol.FeeStats, err error) {
 	request := feeStatsRequest{endpoint: "fee_stats"}
-	err = c.sendRequest(request, &feestats)
+	err = c.sendRequest(request, &feeStats)
+	if err != nil {
+		return
+	}
+
+	// Action needed in release: horizonclient-v3.0.0
+	// Remove this back-fill, this is done to allow people to use this client
+	// with horizon < 1.0 or >= 1.0
+	feeStats.MinAcceptedFee = int(feeStats.MaxFee.Min)
+	feeStats.ModeAcceptedFee = int(feeStats.MaxFee.Mode)
+	feeStats.P10AcceptedFee = int(feeStats.MaxFee.P10)
+	feeStats.P20AcceptedFee = int(feeStats.MaxFee.P20)
+	feeStats.P30AcceptedFee = int(feeStats.MaxFee.P30)
+	feeStats.P40AcceptedFee = int(feeStats.MaxFee.P40)
+	feeStats.P50AcceptedFee = int(feeStats.MaxFee.P50)
+	feeStats.P60AcceptedFee = int(feeStats.MaxFee.P60)
+	feeStats.P70AcceptedFee = int(feeStats.MaxFee.P70)
+	feeStats.P80AcceptedFee = int(feeStats.MaxFee.P80)
+	feeStats.P90AcceptedFee = int(feeStats.MaxFee.P90)
+	feeStats.P95AcceptedFee = int(feeStats.MaxFee.P95)
+	feeStats.P99AcceptedFee = int(feeStats.MaxFee.P99)
+
 	return
 }
 

--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -418,6 +418,36 @@ func TestFeeStats(t *testing.T) {
 		assert.Equal(t, fees.P90AcceptedFee, 4000)
 		assert.Equal(t, fees.P95AcceptedFee, 5000)
 		assert.Equal(t, fees.P99AcceptedFee, 8000)
+
+		assert.Equal(t, fees.MaxFee.Min, int64(130))
+		assert.Equal(t, fees.MaxFee.Max, int64(8000))
+		assert.Equal(t, fees.MaxFee.Mode, int64(250))
+		assert.Equal(t, fees.MaxFee.P10, int64(150))
+		assert.Equal(t, fees.MaxFee.P20, int64(200))
+		assert.Equal(t, fees.MaxFee.P30, int64(300))
+		assert.Equal(t, fees.MaxFee.P40, int64(400))
+		assert.Equal(t, fees.MaxFee.P50, int64(500))
+		assert.Equal(t, fees.MaxFee.P60, int64(1000))
+		assert.Equal(t, fees.MaxFee.P70, int64(2000))
+		assert.Equal(t, fees.MaxFee.P80, int64(3000))
+		assert.Equal(t, fees.MaxFee.P90, int64(4000))
+		assert.Equal(t, fees.MaxFee.P95, int64(5000))
+		assert.Equal(t, fees.MaxFee.P99, int64(8000))
+
+		assert.Equal(t, fees.FeeCharged.Min, int64(100))
+		assert.Equal(t, fees.FeeCharged.Max, int64(199))
+		assert.Equal(t, fees.FeeCharged.Mode, int64(140))
+		assert.Equal(t, fees.FeeCharged.P10, int64(100))
+		assert.Equal(t, fees.FeeCharged.P20, int64(120))
+		assert.Equal(t, fees.FeeCharged.P30, int64(130))
+		assert.Equal(t, fees.FeeCharged.P40, int64(140))
+		assert.Equal(t, fees.FeeCharged.P50, int64(150))
+		assert.Equal(t, fees.FeeCharged.P60, int64(160))
+		assert.Equal(t, fees.FeeCharged.P70, int64(170))
+		assert.Equal(t, fees.FeeCharged.P80, int64(180))
+		assert.Equal(t, fees.FeeCharged.P90, int64(190))
+		assert.Equal(t, fees.FeeCharged.P95, int64(195))
+		assert.Equal(t, fees.FeeCharged.P99, int64(199))
 	}
 
 	// connection error
@@ -1364,23 +1394,24 @@ var feesResponse = `{
   "last_ledger_base_fee": "100",
   "ledger_capacity_usage": "0.97",
   "fee_charged": {
-    "max": "100",
+    "max": "199",
     "min": "100",
-    "mode": "100",
+    "mode": "140",
     "p10": "100",
-    "p20": "100",
-    "p30": "100",
-    "p40": "100",
-    "p50": "100",
-    "p60": "100",
-    "p70": "100",
-    "p80": "100",
-    "p90": "100",
-    "p95": "100",
-    "p99": "100"
+    "p20": "120",
+    "p30": "130",
+    "p40": "140",
+    "p50": "150",
+    "p60": "160",
+    "p70": "170",
+    "p80": "180",
+    "p90": "190",
+    "p95": "195",
+    "p99": "199"
   },
   "max_fee": {
     "min": "130",
+    "max": "8000",
     "mode": "250",
     "p10": "150",
     "p20": "200",

--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -1363,19 +1363,37 @@ var feesResponse = `{
   "last_ledger": "22606298",
   "last_ledger_base_fee": "100",
   "ledger_capacity_usage": "0.97",
-  "min_accepted_fee": "130",
-  "mode_accepted_fee": "250",
-  "p10_accepted_fee": "150",
-  "p20_accepted_fee": "200",
-  "p30_accepted_fee": "300",
-  "p40_accepted_fee": "400",
-  "p50_accepted_fee": "500",
-  "p60_accepted_fee": "1000",
-  "p70_accepted_fee": "2000",
-  "p80_accepted_fee": "3000",
-  "p90_accepted_fee": "4000",
-  "p95_accepted_fee": "5000",
-  "p99_accepted_fee": "8000"
+  "fee_charged": {
+    "max": "100",
+    "min": "100",
+    "mode": "100",
+    "p10": "100",
+    "p20": "100",
+    "p30": "100",
+    "p40": "100",
+    "p50": "100",
+    "p60": "100",
+    "p70": "100",
+    "p80": "100",
+    "p90": "100",
+    "p95": "100",
+    "p99": "100"
+  },
+  "max_fee": {
+    "min": "130",
+    "mode": "250",
+    "p10": "150",
+    "p20": "200",
+    "p30": "300",
+    "p40": "400",
+    "p50": "500",
+    "p60": "1000",
+    "p70": "2000",
+    "p80": "3000",
+    "p90": "4000",
+    "p95": "5000",
+    "p99": "8000"
+  }
 }`
 
 var offersResponse = `{


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Make the client compatible with fee stats data from Horizon 1.X or 0.X.

### Why

There are a couple of breaking changes in the Horizon response which we are handling in horizonclient 2.0 in a backward compatibility manner, for example, being able to read a `number` or a `string` in some of the response fields. It allows a smooth transition between the new and old versions of Horizon. 

This PR follows the same approach for fee stats, Horizon is dropping all the `_accepted_fee` fields in `fee_stats` but instead of adding this breaking change in the next release of the client, we'll make it backward compatible, so people can still use `p99_accepted_fields` in their code and have time to upgrade up to horizonclient 3.0.

### Known limitations

[TODO or N/A]
