### PR TITLE
services/horizon: Fix docker-compose Postgres' auth

### DIFF
--- a/services/horizon/docker/docker-compose.yml
+++ b/services/horizon/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   core-postgres:
-    image: postgres:9.6-alpine
+    image: postgres:9.6.17-alpine
     restart: on-failure
     environment:
       - POSTGRES_PASSWORD=mysecretpassword
@@ -30,9 +30,10 @@ services:
     network_mode: '${NETWORK_MODE:-bridge}'
 
   horizon-postgres:
-    image: postgres:9.6-alpine
+    image: postgres:9.6.17-alpine
     restart: on-failure
     environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
       - POSTGRES_DB=horizon
     ports:
       - "5432:5432"


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fix the authentication of the Horizon container against the Postgres Horizon container at
`services/horizon/docker/docker-compose.yml`.

### Why/How

By not pinning the full Postgres version, authentication stopped working since now it requires either setting the Postgres password or an explicit  `POSTGRES_HOST_AUTH_METHOD=trust`:

```
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD for the superuser. Use
       "-e POSTGRES_PASSWORD=password" to set it in "docker run".

       You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all connections
       without a password. This is *not* recommended. See PostgreSQL
       documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html
```

Making this breaking change on a patch release is arguably a mistake on Postgres' end (see https://github.com/docker-library/postgres/issues/681#issuecomment-586511283 ) but ... it is what it is.

This PR sets `POSTGRES_HOST_AUTH_METHOD=trust` and also pins the patch number of Postgres to make it future-proof.


### Known limitations

N/A
