### PR TITLE
keypair: add check that FromAddress implements encoding.Unmarshaler

### DIFF
--- a/keypair/from_address.go
+++ b/keypair/from_address.go
@@ -61,6 +61,7 @@ func (kp *FromAddress) publicKey() ed25519.PublicKey {
 }
 
 var _ = encoding.TextMarshaler(&FromAddress{})
+var _ = encoding.TextUnmarshaler(&FromAddress{})
 
 func (kp *FromAddress) UnmarshalText(text []byte) error {
 	textKP, err := ParseAddress(string(text))


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Add check that FromAddress implements encoding.Unmarshaler.

### Why
We check that it implements Marshaler, but not Unmarshaler, and we have
it implementing both so it is worthwhile adding the check to ensure if
we were cause the type to not implement the marshaler building the
keypair package will fail so that we know it breaks before we try and
build any other package that imports it.

Thanks @howardtw for pointing this out on https://github.com/stellar/go/pull/2294#discussion_r382238975.

### Known limitations

N/A
