### PR TITLE
clients/horizonclient: make HorizonTimeOut actually 60s

### DIFF
--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -6,6 +6,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 - Add `IsNotFoundError`
+- Change HorizonTimeOut to 60 seconds, which was set to 60 nanoseconds contrary to its documentation.
 
 ## [v2.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v2.0.0) - 2020-01-13
 

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -89,22 +89,22 @@ var (
 	HorizonTimeOut = 60 * time.Second
 
 	// MinuteResolution represents 1 minute used as `resolution` parameter in trade aggregation
-	MinuteResolution = 1 * time.Minute
+	MinuteResolution = time.Duration(1 * time.Minute)
 
 	// FiveMinuteResolution represents 5 minutes used as `resolution` parameter in trade aggregation
-	FiveMinuteResolution = 5 * time.Minute
+	FiveMinuteResolution = time.Duration(5 * time.Minute)
 
 	// FifteenMinuteResolution represents 15 minutes used as `resolution` parameter in trade aggregation
-	FifteenMinuteResolution = 15 * time.Minute
+	FifteenMinuteResolution = time.Duration(15 * time.Minute)
 
 	// HourResolution represents 1 hour used as `resolution` parameter in trade aggregation
-	HourResolution = 1 * time.Hour
+	HourResolution = time.Duration(1 * time.Hour)
 
 	// DayResolution represents 1 day used as `resolution` parameter in trade aggregation
-	DayResolution = 24 * time.Hour
+	DayResolution = time.Duration(24 * time.Hour)
 
 	// WeekResolution represents 1 week used as `resolution` parameter in trade aggregation
-	WeekResolution = 168 * time.Hour
+	WeekResolution = time.Duration(168 * time.Hour)
 )
 
 // HTTP represents the HTTP client that a horizon client uses to communicate

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -89,22 +89,22 @@ var (
 	HorizonTimeOut = 60 * time.Second
 
 	// MinuteResolution represents 1 minute used as `resolution` parameter in trade aggregation
-	MinuteResolution = time.Duration(1 * time.Minute)
+	MinuteResolution = 1 * time.Minute
 
 	// FiveMinuteResolution represents 5 minutes used as `resolution` parameter in trade aggregation
-	FiveMinuteResolution = time.Duration(5 * time.Minute)
+	FiveMinuteResolution = 5 * time.Minute
 
 	// FifteenMinuteResolution represents 15 minutes used as `resolution` parameter in trade aggregation
-	FifteenMinuteResolution = time.Duration(15 * time.Minute)
+	FifteenMinuteResolution = 15 * time.Minute
 
 	// HourResolution represents 1 hour used as `resolution` parameter in trade aggregation
-	HourResolution = time.Duration(1 * time.Hour)
+	HourResolution = 1 * time.Hour
 
 	// DayResolution represents 1 day used as `resolution` parameter in trade aggregation
-	DayResolution = time.Duration(24 * time.Hour)
+	DayResolution = 24 * time.Hour
 
 	// WeekResolution represents 1 week used as `resolution` parameter in trade aggregation
-	WeekResolution = time.Duration(168 * time.Hour)
+	WeekResolution = 168 * time.Hour
 )
 
 // HTTP represents the HTTP client that a horizon client uses to communicate

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -86,7 +86,7 @@ var (
 	ErrResultNotPopulated = errors.New("result_xdr not populated")
 
 	// HorizonTimeOut is the default number of seconds before a request to horizon times out.
-	HorizonTimeOut = time.Duration(60)
+	HorizonTimeOut = 60 * time.Second
 
 	// MinuteResolution represents 1 minute used as `resolution` parameter in trade aggregation
 	MinuteResolution = time.Duration(1 * time.Minute)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Set the HorizonTimeOut time.Duration constant to 60 seconds.

Also remove some unnecessary casts to time.Duration because the values are already time.Durations.

### Why

It is currently set to 60 nanoseconds, but the comments claim it should be 60 seconds.

### Known limitations

N/A
