### PR TITLE
services/horizon: Check for --history-archive-urls flag when --ingest set

### DIFF
--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -394,9 +394,14 @@ func initRootConfig() {
 	checkMigrations()
 
 	// Validate options that should be provided together
-	validateBothOrNeither("ingest", "history-archive-urls")
 	validateBothOrNeither("tls-cert", "tls-key")
 	validateBothOrNeither("rate-limit-redis-key", "redis-url")
+
+	// config.HistoryArchiveURLs contains a single empty value when empty so using
+	// viper.GetString is easier.
+	if config.Ingest && viper.GetString("history-archive-urls") == "" {
+		stdLog.Fatalf("--history-archive-urls must be set when --ingest is set")
+	}
 
 	// Configure log file
 	if config.LogFile != "" {

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -394,6 +394,7 @@ func initRootConfig() {
 	checkMigrations()
 
 	// Validate options that should be provided together
+	validateBothOrNeither("ingest", "history-archive-urls")
 	validateBothOrNeither("tls-cert", "tls-key")
 	validateBothOrNeither("rate-limit-redis-key", "redis-url")
 


### PR DESCRIPTION
### What

Makes an error message about empty `--history-archive-urls` explicit.

### Why

The previous message was not clear enough:
```
error creating history archive: URL is empty
```
The new message is as follows:
```
--history-archive-urls must be set when --ingest is set
```