### PR TITLE
clients/horizonclient: fix inconsistent units of time in HorizonTimeOut 

### DIFF
--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -5,6 +5,10 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Fixed a bug where HorizonTimeOut has misleading units of time by:
+  - Removed HorizonTimeOut (seconds)
+  - Added HorizonTimeout (nanoseconds)
+
 ## [v2.1.0](https://github.com/stellar/go/releases/tag/horizonclient-v2.1.0) - 2020-02-24
 
 ### Add

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -55,10 +55,10 @@ func (c *Client) sendRequestURL(requestURL string, method string, a interface{})
 	}
 	c.setClientAppHeaders(req)
 	c.setDefaultClient()
-	if c.horizonTimeOut == 0 {
-		c.horizonTimeOut = HorizonTimeOut
+	if c.horizonTimeout == 0 {
+		c.horizonTimeout = HorizonTimeout
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*c.horizonTimeOut)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*c.horizonTimeout)
 	resp, err := c.HTTP.Do(req.WithContext(ctx))
 	if err != nil {
 		cancel()
@@ -216,15 +216,16 @@ func (c *Client) fixHorizonURL() string {
 	return strings.TrimRight(c.HorizonURL, "/") + "/"
 }
 
-// SetHorizonTimeOut allows users to set the number of seconds before a horizon request is cancelled.
-func (c *Client) SetHorizonTimeOut(t uint) *Client {
-	c.horizonTimeOut = time.Duration(t)
+// SetHorizonTimeout allows users to set the timeout before a horizon request is cancelled.
+// The timeout is specified as a time.Duration which is in nanoseconds.
+func (c *Client) SetHorizonTimeout(t time.Duration) *Client {
+	c.horizonTimeout = t
 	return c
 }
 
-// HorizonTimeOut returns the current timeout for a horizon client
-func (c *Client) HorizonTimeOut() time.Duration {
-	return c.horizonTimeOut
+// HorizonTimeout returns the current timeout for a horizon client
+func (c *Client) HorizonTimeout() time.Duration {
+	return c.horizonTimeout
 }
 
 // Accounts returns accounts who have a given signer or

--- a/clients/horizonclient/examples_test.go
+++ b/clients/horizonclient/examples_test.go
@@ -870,14 +870,14 @@ func ExampleClient_Root() {
 	fmt.Print(root)
 }
 
-func ExampleClient_SetHorizonTimeOut() {
+func ExampleClient_SetHorizonTimeout() {
 	client := horizonclient.DefaultTestNetClient
 
 	// https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAABB90WssODNIgi6BHveqzxTRmIpvAFRyVNM%2BHm2GVuCcAAAAZAAABD0AAuV%2FAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAyTBGxOgfSApppsTnb%2FYRr6gOR8WT0LZNrhLh4y3FCgoAAAAXSHboAAAAAAAAAAABhlbgnAAAAEAivKe977CQCxMOKTuj%2BcWTFqc2OOJU8qGr9afrgu2zDmQaX5Q0cNshc3PiBwe0qw%2F%2BD%2FqJk5QqM5dYeSUGeDQP&type=TransactionEnvelope&network=test
 	txXdr := `AAAAABB90WssODNIgi6BHveqzxTRmIpvAFRyVNM+Hm2GVuCcAAAAZAAABD0AAuV/AAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAyTBGxOgfSApppsTnb/YRr6gOR8WT0LZNrhLh4y3FCgoAAAAXSHboAAAAAAAAAAABhlbgnAAAAEAivKe977CQCxMOKTuj+cWTFqc2OOJU8qGr9afrgu2zDmQaX5Q0cNshc3PiBwe0qw/+D/qJk5QqM5dYeSUGeDQP`
 
 	// test user timeout
-	client = client.SetHorizonTimeOut(30)
+	client = client.SetHorizonTimeout(30 * time.Second)
 	resp, err := client.SubmitTransactionXDR(txXdr)
 	if err != nil {
 		fmt.Println(err)

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -85,8 +85,8 @@ var (
 	// "result_xdr" extra field populated when it is expected to be.
 	ErrResultNotPopulated = errors.New("result_xdr not populated")
 
-	// HorizonTimeOut is the default number of seconds before a request to horizon times out.
-	HorizonTimeOut = time.Duration(60)
+	// HorizonTimeout is the default number of nanoseconds before a request to horizon times out.
+	HorizonTimeout = 60 * time.Second
 
 	// MinuteResolution represents 1 minute used as `resolution` parameter in trade aggregation
 	MinuteResolution = time.Duration(1 * time.Minute)
@@ -132,7 +132,7 @@ type Client struct {
 
 	// AppVersion is the version of the application using the horizonclient package
 	AppVersion     string
-	horizonTimeOut time.Duration
+	horizonTimeout time.Duration
 	isTestNet      bool
 
 	// clock is a Clock returning the current time.
@@ -198,7 +198,7 @@ type ClientInterface interface {
 var DefaultTestNetClient = &Client{
 	HorizonURL:     "https://horizon-testnet.stellar.org/",
 	HTTP:           http.DefaultClient,
-	horizonTimeOut: HorizonTimeOut,
+	horizonTimeout: HorizonTimeout,
 	isTestNet:      true,
 }
 
@@ -206,7 +206,7 @@ var DefaultTestNetClient = &Client{
 var DefaultPublicNetClient = &Client{
 	HorizonURL:     "https://horizon.stellar.org/",
 	HTTP:           http.DefaultClient,
-	horizonTimeOut: HorizonTimeOut,
+	horizonTimeout: HorizonTimeout,
 }
 
 // HorizonRequest contains methods implemented by request structs for horizon endpoints.

--- a/exp/services/recoverysigner/internal/serve/serve.go
+++ b/exp/services/recoverysigner/internal/serve/serve.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"net/http"
-	"time"
 
 	firebaseauth "firebase.google.com/go/auth"
 	"github.com/go-chi/chi"
@@ -75,7 +74,7 @@ func getHandlerDeps(opts Options) (handlerDeps, error) {
 	}
 	opts.Logger.Info("SEP-10 JWT Public key: ", sep10JWTPublicKey)
 
-	horizonTimeout := 1 * time.Minute
+	horizonTimeout := horizonclient.HorizonTimeout
 	httpClient := &http.Client{
 		Timeout: horizonTimeout,
 	}
@@ -83,7 +82,7 @@ func getHandlerDeps(opts Options) (handlerDeps, error) {
 		HorizonURL: opts.HorizonURL,
 		HTTP:       httpClient,
 	}
-	horizonClient.SetHorizonTimeOut(uint(horizonTimeout / time.Second))
+	horizonClient.SetHorizonTimeout(horizonTimeout)
 
 	// TODO: Replace this in-memory store with Postgres.
 	accountStore := account.NewMemoryStore()

--- a/exp/services/webauth/internal/serve/serve.go
+++ b/exp/services/webauth/internal/serve/serve.go
@@ -56,7 +56,7 @@ func handler(opts Options) (http.Handler, error) {
 		return nil, errors.Wrap(err, "parsing JWT private key")
 	}
 
-	horizonTimeout := 1 * time.Minute
+	horizonTimeout := horizonclient.HorizonTimeout
 	httpClient := &http.Client{
 		Timeout: horizonTimeout,
 	}
@@ -64,7 +64,7 @@ func handler(opts Options) (http.Handler, error) {
 		HorizonURL: opts.HorizonURL,
 		HTTP:       httpClient,
 	}
-	horizonClient.SetHorizonTimeOut(uint(horizonTimeout / time.Second))
+	horizonClient.SetHorizonTimeout(horizonTimeout)
 
 	mux := supporthttp.NewAPIMux(opts.Logger)
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Remove HorizonTimeOut and its related functions and fields that operate
on a value of seconds and replace with HorizonTimeout that operates on a
value of nanoseconds.

### Why
The HorizonTimeOut identifier is defined as a time.Duration, and by
using that type we are stating that any value it holds is in
nanoseconds. Right now the code uses the type incorrectly to hold
seconds and this is confusing and misleading.

There is no good way to fix this because to change the type or the units
it holds is a breaking change. If we simply change the type someone
might see compiler errors. If we change the units someone might
unexpectedly continue to pass in seconds when they should now be using
nanoseconds. Alternatively, we can break this in a way that will cause
compiler errors and we can correct the units at the same time, ensuring
that the problem is fixed, fixed well, and any surprise is maybe
warranted because anyone using this field may also have a bug in their
own system.

The least breaking approach is definitely the first option above and to
just change this type from a `time.Duration` to a `uint` and to have it
continue to be seconds. But, given the likely rare use of this field,
and that someone else who is using it could easily have misunderstood
its meaning, it might be better to just break it and consider this like
a bug rather than a feature deviation.

By removing the function we ensure that anyone using it reassess their
use of it. It's easy to rename this identifier because the word 'Timeout'
is actually one word so we can call the new so we can use the one word
name 'Timeout' instead of 'TimeOut'.

### Known limitations

N/A
