### PR TITLE
clients/horizonclient: make HorizonTimeOut a uint

### DIFF
--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -6,6 +6,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 - Add `IsNotFoundError`
+- Change `HorizonTimeOut` type from `time.Duration` to `uint`
 
 ## [v2.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v2.0.0) - 2020-01-13
 

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -57,7 +57,7 @@ func (c *Client) sendRequestURL(requestURL string, method string, a interface{})
 	if c.horizonTimeOut == 0 {
 		c.horizonTimeOut = HorizonTimeOut
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*c.horizonTimeOut)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(c.horizonTimeOut))
 	resp, err := c.HTTP.Do(req.WithContext(ctx))
 	if err != nil {
 		cancel()
@@ -217,12 +217,12 @@ func (c *Client) fixHorizonURL() string {
 
 // SetHorizonTimeOut allows users to set the number of seconds before a horizon request is cancelled.
 func (c *Client) SetHorizonTimeOut(t uint) *Client {
-	c.horizonTimeOut = time.Duration(t)
+	c.horizonTimeOut = t
 	return c
 }
 
 // HorizonTimeOut returns the current timeout for a horizon client
-func (c *Client) HorizonTimeOut() time.Duration {
+func (c *Client) HorizonTimeOut() uint {
 	return c.horizonTimeOut
 }
 

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -86,7 +86,7 @@ var (
 	ErrResultNotPopulated = errors.New("result_xdr not populated")
 
 	// HorizonTimeOut is the default number of seconds before a request to horizon times out.
-	HorizonTimeOut = time.Duration(60)
+	HorizonTimeOut = uint(60)
 
 	// MinuteResolution represents 1 minute used as `resolution` parameter in trade aggregation
 	MinuteResolution = time.Duration(1 * time.Minute)
@@ -131,8 +131,9 @@ type Client struct {
 	AppName string
 
 	// AppVersion is the version of the application using the horizonclient package
-	AppVersion     string
-	horizonTimeOut time.Duration
+	AppVersion string
+	// horizonTimeOut is the timeout in seconds
+	horizonTimeOut uint
 	isTestNet      bool
 
 	// clock is a Clock returning the current time.

--- a/exp/services/recoverysigner/internal/serve/serve.go
+++ b/exp/services/recoverysigner/internal/serve/serve.go
@@ -81,7 +81,7 @@ func getHandlerDeps(opts Options) (handlerDeps, error) {
 			Timeout: time.Second * time.Duration(horizonclient.HorizonTimeOut),
 		},
 	}
-	horizonClient.SetHorizonTimeOut(uint(horizonclient.HorizonTimeOut))
+	horizonClient.SetHorizonTimeOut(horizonclient.HorizonTimeOut)
 
 	// TODO: Replace this in-memory store with Postgres.
 	accountStore := account.NewMemoryStore()

--- a/exp/services/recoverysigner/internal/serve/serve.go
+++ b/exp/services/recoverysigner/internal/serve/serve.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"net/http"
+	"time"
 
 	firebaseauth "firebase.google.com/go/auth"
 	"github.com/go-chi/chi"
@@ -77,7 +78,7 @@ func getHandlerDeps(opts Options) (handlerDeps, error) {
 	horizonClient := &horizonclient.Client{
 		HorizonURL: opts.HorizonURL,
 		HTTP: &http.Client{
-			Timeout: horizonclient.HorizonTimeOut,
+			Timeout: time.Second * time.Duration(horizonclient.HorizonTimeOut),
 		},
 	}
 	horizonClient.SetHorizonTimeOut(uint(horizonclient.HorizonTimeOut))

--- a/exp/services/webauth/internal/serve/serve.go
+++ b/exp/services/webauth/internal/serve/serve.go
@@ -57,7 +57,7 @@ func handler(opts Options) (http.Handler, error) {
 	}
 
 	httpClient := &http.Client{
-		Timeout: horizonclient.HorizonTimeOut,
+		Timeout: time.Second * time.Duration(horizonclient.HorizonTimeOut),
 	}
 
 	horizonClient := &horizonclient.Client{

--- a/exp/services/webauth/internal/serve/serve.go
+++ b/exp/services/webauth/internal/serve/serve.go
@@ -64,7 +64,7 @@ func handler(opts Options) (http.Handler, error) {
 		HorizonURL: opts.HorizonURL,
 		HTTP:       httpClient,
 	}
-	horizonClient.SetHorizonTimeOut(uint(horizonclient.HorizonTimeOut))
+	horizonClient.SetHorizonTimeOut(horizonclient.HorizonTimeOut)
 
 	mux := supporthttp.NewAPIMux()
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Change the type of HorizonTimeOut and it's related functions and fields
from time.Duration to uint.

### Why
The value stored in the field is a count of seconds. The time.Duration
type explicitly stores a count of nanoseconds and so to use this type
with a different unit is confusing and misleading. I myself have used
the value thinking it was truly a time.Duration and had a unit of
nanoseconds. Other's may have made the same mistake.

While this is a breaking change I think it is fine to make in a patch
release as this is truly a bug. Any downstream breakages it causes is
probably warranted so that importers check that they are using the value
correctly in their own code.

Since the default clients come configured with a default timeout it is
also less likely people are using this field, so any impact from a
breaking change should be minimal.

### Known limitations

N/A