### PR TITLE
exp/services/webauth: fix the horizon timeout

### DIFF
--- a/exp/services/webauth/internal/serve/serve.go
+++ b/exp/services/webauth/internal/serve/serve.go
@@ -56,15 +56,15 @@ func handler(opts Options) (http.Handler, error) {
 		return nil, errors.Wrap(err, "parsing JWT private key")
 	}
 
+	horizonTimeout := 1 * time.Minute
 	httpClient := &http.Client{
-		Timeout: horizonclient.HorizonTimeOut,
+		Timeout: horizonTimeout,
 	}
-
 	horizonClient := &horizonclient.Client{
 		HorizonURL: opts.HorizonURL,
 		HTTP:       httpClient,
 	}
-	horizonClient.SetHorizonTimeOut(uint(horizonclient.HorizonTimeOut))
+	horizonClient.SetHorizonTimeOut(uint(horizonTimeout / time.Second))
 
 	mux := supporthttp.NewAPIMux()
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Set the Horizon timeout to 1 minute for both the HTTP client and the horizonclient SDK.

### Why

While it looks like the same timeout is being used by the HTTP client and the horizonclient SDK it is not. The horizonclient SDK uses units of seconds and the HTTP client uses nanoseconds and the value being passed in to both is 60s. This causes the HTTP client to terminate most outgoing requests before they complete.

### Known limitations

This doesn't address the confusion that is this horizonclient timeout value which is being addressed in #2310.