### PR TITLE
support/http: allow services to specify the logger used by the logging middleware

### DIFF
--- a/exp/services/recoverysigner/internal/serve/serve.go
+++ b/exp/services/recoverysigner/internal/serve/serve.go
@@ -107,7 +107,9 @@ func getHandlerDeps(opts Options) (handlerDeps, error) {
 }
 
 func handler(deps handlerDeps) http.Handler {
-	mux := supporthttp.NewAPIMux()
+	mux := supporthttp.NewAPIMux(
+		supporthttp.WithMuxOptionLogger(deps.Logger),
+	)
 
 	mux.NotFound(errorHandler{Error: notFound}.ServeHTTP)
 	mux.MethodNotAllowed(errorHandler{Error: methodNotAllowed}.ServeHTTP)

--- a/exp/services/recoverysigner/internal/serve/serve.go
+++ b/exp/services/recoverysigner/internal/serve/serve.go
@@ -107,9 +107,7 @@ func getHandlerDeps(opts Options) (handlerDeps, error) {
 }
 
 func handler(deps handlerDeps) http.Handler {
-	mux := supporthttp.NewAPIMux(
-		supporthttp.WithMuxOptionLogger(deps.Logger),
-	)
+	mux := supporthttp.NewAPIMux(deps.Logger)
 
 	mux.NotFound(errorHandler{Error: notFound}.ServeHTTP)
 	mux.MethodNotAllowed(errorHandler{Error: methodNotAllowed}.ServeHTTP)

--- a/exp/services/webauth/internal/serve/serve.go
+++ b/exp/services/webauth/internal/serve/serve.go
@@ -66,9 +66,7 @@ func handler(opts Options) (http.Handler, error) {
 	}
 	horizonClient.SetHorizonTimeOut(uint(horizonTimeout / time.Second))
 
-	mux := supporthttp.NewAPIMux(
-		supporthttp.WithMuxOptionLogger(opts.Logger),
-	)
+	mux := supporthttp.NewAPIMux(opts.Logger)
 
 	mux.NotFound(errorHandler{Error: notFound}.ServeHTTP)
 	mux.MethodNotAllowed(errorHandler{Error: methodNotAllowed}.ServeHTTP)

--- a/exp/services/webauth/internal/serve/serve.go
+++ b/exp/services/webauth/internal/serve/serve.go
@@ -66,7 +66,9 @@ func handler(opts Options) (http.Handler, error) {
 	}
 	horizonClient.SetHorizonTimeOut(uint(horizonTimeout / time.Second))
 
-	mux := supporthttp.NewAPIMux()
+	mux := supporthttp.NewAPIMux(
+		supporthttp.WithMuxOptionLogger(opts.Logger),
+	)
 
 	mux.NotFound(errorHandler{Error: notFound}.ServeHTTP)
 	mux.MethodNotAllowed(errorHandler{Error: methodNotAllowed}.ServeHTTP)

--- a/services/bridge/main.go
+++ b/services/bridge/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stellar/go/support/db/schema"
 	"github.com/stellar/go/support/errors"
 	supportHttp "github.com/stellar/go/support/http"
+	supportLog "github.com/stellar/go/support/log"
 )
 
 var app *App
@@ -231,7 +232,7 @@ func NewApp(config config.Config, migrateFlag bool, versionFlag bool, version st
 
 // Serve starts the server
 func (a *App) Serve() {
-	mux := supportHttp.NewAPIMux()
+	mux := supportHttp.NewAPIMux(supportLog.DefaultLogger)
 
 	// Middlewares
 	headers := make(http.Header)

--- a/services/compliance/main.go
+++ b/services/compliance/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stellar/go/support/db/schema"
 	"github.com/stellar/go/support/errors"
 	supportHttp "github.com/stellar/go/support/http"
+	supportLog "github.com/stellar/go/support/log"
 )
 
 var app *App
@@ -170,7 +171,7 @@ func NewApp(config config.Config, migrateFlag bool, versionFlag bool, version st
 // Serve starts the server
 func (a *App) Serve() {
 	// External endpoints
-	external := supportHttp.NewAPIMux()
+	external := supportHttp.NewAPIMux(supportLog.DefaultLogger)
 
 	// Middlewares
 	headers := http.Header{}
@@ -195,7 +196,7 @@ func (a *App) Serve() {
 	}()
 
 	// Internal endpoints
-	internal := supportHttp.NewAPIMux()
+	internal := supportHttp.NewAPIMux(supportLog.DefaultLogger)
 
 	internal.Use(supportHttp.StripTrailingSlashMiddleware("/admin"))
 	internal.Use(supportHttp.HeadersMiddleware(headers, "/admin/"))

--- a/services/federation/main.go
+++ b/services/federation/main.go
@@ -126,7 +126,7 @@ func initDriver(cfg Config) (federation.Driver, error) {
 }
 
 func initMux(driver federation.Driver) *chi.Mux {
-	mux := http.NewAPIMux()
+	mux := http.NewAPIMux(log.DefaultLogger)
 
 	fed := &federation.Handler{
 		Driver: driver,

--- a/services/friendbot/main.go
+++ b/services/friendbot/main.go
@@ -82,7 +82,7 @@ func run(cmd *cobra.Command, args []string) {
 }
 
 func initRouter(fb *internal.Bot) *chi.Mux {
-	mux := http.NewAPIMux()
+	mux := http.NewAPIMux(log.DefaultLogger)
 
 	handler := &internal.FriendbotHandler{Friendbot: fb}
 	mux.Get("/", handler.Handle)

--- a/support/http/logging_middleware.go
+++ b/support/http/logging_middleware.go
@@ -10,6 +10,18 @@ import (
 	"github.com/stellar/go/support/log"
 )
 
+// SetLogger is a middleware that sets a logger on the context.
+func SetLoggerMiddleware(l *log.Entry) func(stdhttp.Handler) stdhttp.Handler {
+	return func(next stdhttp.Handler) stdhttp.Handler {
+		return stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+			ctx := r.Context()
+			ctx = log.Set(ctx, l)
+			r = r.WithContext(ctx)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // LoggingMiddleware is a middleware that logs requests to the logger.
 func LoggingMiddleware(next stdhttp.Handler) stdhttp.Handler {
 	return stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {

--- a/support/http/logging_middleware_test.go
+++ b/support/http/logging_middleware_test.go
@@ -43,3 +43,38 @@ func TestHTTPMiddleware(t *testing.T) {
 		assert.NotEmpty(t, line.Data["path"])
 	}
 }
+
+func TestHTTPMiddlewareWithLoggerSet(t *testing.T) {
+	logger := log.New()
+	done := logger.StartTest(log.InfoLevel)
+	mux := chi.NewMux()
+
+	mux.Use(middleware.RequestID)
+	mux.Use(SetLoggerMiddleware(logger))
+	mux.Use(LoggingMiddleware)
+
+	mux.Get("/", stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	}))
+	mux.Handle("/not_found", stdhttp.NotFoundHandler())
+
+	src := httptest.NewServer(t, mux)
+	src.GET("/").Expect().Status(stdhttp.StatusOK)
+	src.GET("/not_found").Expect().Status(stdhttp.StatusNotFound)
+
+	// get the log buffer and ensure it has both the start and end log lines for
+	// each request
+	logged := done()
+	if assert.Len(t, logged, 4, "unexpected log line count") {
+		assert.Equal(t, "starting request", logged[0].Message)
+		assert.Equal(t, "starting request", logged[2].Message)
+		assert.Equal(t, "finished request", logged[1].Message)
+		assert.Equal(t, "finished request", logged[3].Message)
+	}
+
+	for _, line := range logged {
+		assert.Equal(t, "http", line.Data["subsys"])
+		assert.Equal(t, "GET", line.Data["method"])
+		assert.NotEmpty(t, line.Data["req"])
+		assert.NotEmpty(t, line.Data["path"])
+	}
+}

--- a/support/http/mux.go
+++ b/support/http/mux.go
@@ -4,15 +4,21 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
 	"github.com/rs/cors"
+	"github.com/stellar/go/support/log"
 )
 
 // NewMux returns a new server mux configured with the common defaults used across all
 // stellar services.
-func NewMux() *chi.Mux {
+func NewMux(options ...MuxOption) *chi.Mux {
+	muxOptions := NewMuxOptions(options...)
+
 	mux := chi.NewMux()
 
 	mux.Use(middleware.RequestID)
 	mux.Use(middleware.Recoverer)
+	if muxOptions.Logger != nil {
+		mux.Use(SetLoggerMiddleware(muxOptions.Logger))
+	}
 	mux.Use(LoggingMiddleware)
 
 	return mux
@@ -20,8 +26,8 @@ func NewMux() *chi.Mux {
 
 // NewAPIMux returns a new server mux configured with the common defaults used for a web API in
 // stellar.
-func NewAPIMux() *chi.Mux {
-	mux := NewMux()
+func NewAPIMux(options ...MuxOption) *chi.Mux {
+	mux := NewMux(options...)
 
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},
@@ -31,4 +37,30 @@ func NewAPIMux() *chi.Mux {
 
 	mux.Use(c.Handler)
 	return mux
+}
+
+// MuxOptions is a set of options that can be optionally set when calling
+// NewMux or NewAPIMux.
+type MuxOptions struct {
+	Logger *log.Entry
+}
+
+// NewMuxOptions creates a MuxOptions from a set of MuxOption.
+func NewMuxOptions(options ...MuxOption) MuxOptions {
+	mo := MuxOptions{}
+	for _, o := range options {
+		mo = o(mo)
+	}
+	return mo
+}
+
+// MuxOption is a function that sets mux options.
+type MuxOption func(options MuxOptions) MuxOptions
+
+// WithMuxOptionLogger sets a logger when instantiating a mux.
+func WithMuxOptionLogger(l *log.Entry) func(MuxOptions) MuxOptions {
+	return func(options MuxOptions) MuxOptions {
+		options.Logger = l
+		return options
+	}
 }

--- a/support/http/mux.go
+++ b/support/http/mux.go
@@ -14,9 +14,7 @@ func NewMux(l *log.Entry) *chi.Mux {
 
 	mux.Use(middleware.RequestID)
 	mux.Use(middleware.Recoverer)
-	if l != nil {
-		mux.Use(SetLoggerMiddleware(l))
-	}
+	mux.Use(SetLoggerMiddleware(l))
 	mux.Use(LoggingMiddleware)
 
 	return mux

--- a/support/http/mux.go
+++ b/support/http/mux.go
@@ -9,15 +9,13 @@ import (
 
 // NewMux returns a new server mux configured with the common defaults used across all
 // stellar services.
-func NewMux(options ...MuxOption) *chi.Mux {
-	muxOptions := NewMuxOptions(options...)
-
+func NewMux(l *log.Entry) *chi.Mux {
 	mux := chi.NewMux()
 
 	mux.Use(middleware.RequestID)
 	mux.Use(middleware.Recoverer)
-	if muxOptions.Logger != nil {
-		mux.Use(SetLoggerMiddleware(muxOptions.Logger))
+	if l != nil {
+		mux.Use(SetLoggerMiddleware(l))
 	}
 	mux.Use(LoggingMiddleware)
 
@@ -26,8 +24,8 @@ func NewMux(options ...MuxOption) *chi.Mux {
 
 // NewAPIMux returns a new server mux configured with the common defaults used for a web API in
 // stellar.
-func NewAPIMux(options ...MuxOption) *chi.Mux {
-	mux := NewMux(options...)
+func NewAPIMux(l *log.Entry) *chi.Mux {
+	mux := NewMux(l)
 
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},
@@ -37,30 +35,4 @@ func NewAPIMux(options ...MuxOption) *chi.Mux {
 
 	mux.Use(c.Handler)
 	return mux
-}
-
-// MuxOptions is a set of options that can be optionally set when calling
-// NewMux or NewAPIMux.
-type MuxOptions struct {
-	Logger *log.Entry
-}
-
-// NewMuxOptions creates a MuxOptions from a set of MuxOption.
-func NewMuxOptions(options ...MuxOption) MuxOptions {
-	mo := MuxOptions{}
-	for _, o := range options {
-		mo = o(mo)
-	}
-	return mo
-}
-
-// MuxOption is a function that sets mux options.
-type MuxOption func(options MuxOptions) MuxOptions
-
-// WithMuxOptionLogger sets a logger when instantiating a mux.
-func WithMuxOptionLogger(l *log.Entry) func(MuxOptions) MuxOptions {
-	return func(options MuxOptions) MuxOptions {
-		options.Logger = l
-		return options
-	}
 }

--- a/support/render/health/example_test.go
+++ b/support/render/health/example_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func ExampleResponse() {
-	mux := supporthttp.NewAPIMux()
+	mux := supporthttp.NewAPIMux(nil)
 
 	mux.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		healthCheckResult := false
@@ -44,7 +44,7 @@ func ExampleResponse() {
 }
 
 func ExampleHandler() {
-	mux := supporthttp.NewAPIMux()
+	mux := supporthttp.NewAPIMux(nil)
 
 	mux.Get("/health", health.PassHandler{}.ServeHTTP)
 

--- a/support/render/health/example_test.go
+++ b/support/render/health/example_test.go
@@ -7,12 +7,13 @@ import (
 	"net/http/httptest"
 
 	supporthttp "github.com/stellar/go/support/http"
+	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/health"
 	"github.com/stellar/go/support/render/httpjson"
 )
 
 func ExampleResponse() {
-	mux := supporthttp.NewAPIMux(nil)
+	mux := supporthttp.NewAPIMux(log.DefaultLogger)
 
 	mux.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		healthCheckResult := false
@@ -44,7 +45,7 @@ func ExampleResponse() {
 }
 
 func ExampleHandler() {
-	mux := supporthttp.NewAPIMux(nil)
+	mux := supporthttp.NewAPIMux(log.DefaultLogger)
 
 	mux.Get("/health", health.PassHandler{}.ServeHTTP)
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Allow services to specify the logger used by the logging middleware.

### Why

`LoggingMiddleware` gets the logger from the context using `"support/log".Ctx(...)`. If none is specified in the context the `"support/log".DefaultLogger` is used. Because the `LoggingMiddleware` is placed into the `chi.Mux` in the `NewMux` and `NewAPIMux` functions a service using these functions has no opportunity to set a logger on the context because a middleware cannot be inserted earlier. This means by using `NewMux` and `NewAPIMux` you are stuck with the default logger.

### Why Behind the Why

The reason I'm wanting this is because `webauth` and `recoverysigner` are similar to `ticker` in that they explicitly define all their dependencies and pass them down to the code using them as explicitly as possible. Because of this both of those applications define their own logger. Because we have some code like the LoggingMiddleware that magically pulls the logger out of the context setting it in the context is the only way to fully use a custom logger.

### Alternative Implementations

If you look at the commits on this PR I attempted to implement this one way first using functional options. It seems pretty cool 😎 but more complicated that is necessary so I dropped it.

### Known limitations

N/A
