### PR TITLE
exp/services/recoverysigner: remove type, add identities

### DIFF
--- a/exp/services/recoverysigner/internal/account/account.go
+++ b/exp/services/recoverysigner/internal/account/account.go
@@ -2,7 +2,6 @@ package account
 
 type Account struct {
 	Address         string
-	Type            string
 	OwnerIdentities Identities
 	OtherIdentities Identities
 }
@@ -11,4 +10,10 @@ type Identities struct {
 	Address     string
 	PhoneNumber string
 	Email       string
+}
+
+// Present indicates if the Identities contains at least one identity. Returns
+// false if it is an empty/zero value.
+func (i Identities) Present() bool {
+	return i != Identities{}
 }

--- a/exp/services/recoverysigner/internal/account/account_test.go
+++ b/exp/services/recoverysigner/internal/account/account_test.go
@@ -1,0 +1,46 @@
+package account
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIdentities_Present(t *testing.T) {
+	testCases := []struct {
+		Identities  Identities
+		WantPresent bool
+	}{
+		{
+			Identities:  Identities{},
+			WantPresent: false,
+		},
+		{
+			Identities:  Identities{Address: "GD2UO6ADC3SY3UWL7BU32NFI3Q6MSP4BNVG2TTIGAJE44VTJ53EGNWOM"},
+			WantPresent: true,
+		},
+		{
+			Identities:  Identities{Email: "user@example.com"},
+			WantPresent: true,
+		},
+		{
+			Identities:  Identities{PhoneNumber: "+10000000000"},
+			WantPresent: true,
+		},
+		{
+			Identities: Identities{
+				Address:     "GD2UO6ADC3SY3UWL7BU32NFI3Q6MSP4BNVG2TTIGAJE44VTJ53EGNWOM",
+				Email:       "user@example.com",
+				PhoneNumber: "+10000000000",
+			},
+			WantPresent: true,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			present := tc.Identities.Present()
+			assert.Equal(t, tc.WantPresent, present)
+		})
+	}
+}

--- a/exp/services/recoverysigner/internal/serve/account_list.go
+++ b/exp/services/recoverysigner/internal/serve/account_list.go
@@ -45,8 +45,15 @@ func (h accountListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		} else {
 			accResp := accountResponse{
-				Address:  acc.Address,
-				Type:     acc.Type,
+				Address: acc.Address,
+				Identities: accountResponseIdentities{
+					Owner: accountResponseIdentity{
+						Present: acc.OwnerIdentities.Present(),
+					},
+					Other: accountResponseIdentity{
+						Present: acc.OtherIdentities.Present(),
+					},
+				},
 				Identity: "account",
 				Signer:   h.SigningAddress.Address(),
 			}
@@ -69,8 +76,15 @@ func (h accountListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				identity = "other"
 			}
 			accResp := accountResponse{
-				Address:  acc.Address,
-				Type:     acc.Type,
+				Address: acc.Address,
+				Identities: accountResponseIdentities{
+					Owner: accountResponseIdentity{
+						Present: acc.OwnerIdentities.Present(),
+					},
+					Other: accountResponseIdentity{
+						Present: acc.OtherIdentities.Present(),
+					},
+				},
 				Identity: identity,
 				Signer:   h.SigningAddress.Address(),
 			}
@@ -95,8 +109,15 @@ func (h accountListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				identity = "other"
 			}
 			accResp := accountResponse{
-				Address:  acc.Address,
-				Type:     acc.Type,
+				Address: acc.Address,
+				Identities: accountResponseIdentities{
+					Owner: accountResponseIdentity{
+						Present: acc.OwnerIdentities.Present(),
+					},
+					Other: accountResponseIdentity{
+						Present: acc.OtherIdentities.Present(),
+					},
+				},
 				Identity: identity,
 				Signer:   h.SigningAddress.Address(),
 			}
@@ -121,8 +142,15 @@ func (h accountListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				identity = "other"
 			}
 			accResp := accountResponse{
-				Address:  acc.Address,
-				Type:     acc.Type,
+				Address: acc.Address,
+				Identities: accountResponseIdentities{
+					Owner: accountResponseIdentity{
+						Present: acc.OwnerIdentities.Present(),
+					},
+					Other: accountResponseIdentity{
+						Present: acc.OtherIdentities.Present(),
+					},
+				},
 				Identity: identity,
 				Signer:   h.SigningAddress.Address(),
 			}

--- a/exp/services/recoverysigner/internal/serve/account_list_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_list_test.go
@@ -21,18 +21,15 @@ func TestAccountList_authenticatedButNonePermitted(t *testing.T) {
 	s := account.NewMemoryStore()
 	s.Add(account.Account{
 		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
-		Type:    "personal",
 	})
 	s.Add(account.Account{
 		Address: "GDU2CH4V3QYQB2BLMX45XQLVBEKSIN2EZLP37I6MZZ7NAR5U3TLZDQEY",
-		Type:    "share",
 		OwnerIdentities: account.Identities{
 			Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
 		},
 	})
 	s.Add(account.Account{
 		Address: "GCS4CVAAX7MVUNHP24655TNHIJ4YFN7GW5V3RFDC2BXVVMVDTB3GYH5U",
-		Type:    "share",
 		OtherIdentities: account.Identities{
 			Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
 		},
@@ -68,21 +65,18 @@ func TestAccountList_authenticatedByPhoneNumber(t *testing.T) {
 	s := account.NewMemoryStore()
 	s.Add(account.Account{
 		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
-		Type:    "personal",
 		OwnerIdentities: account.Identities{
 			PhoneNumber: "+10000000000",
 		},
 	})
 	s.Add(account.Account{
 		Address: "GDU2CH4V3QYQB2BLMX45XQLVBEKSIN2EZLP37I6MZZ7NAR5U3TLZDQEY",
-		Type:    "share",
 		OtherIdentities: account.Identities{
 			PhoneNumber: "+10000000000",
 		},
 	})
 	s.Add(account.Account{
 		Address: "GCS4CVAAX7MVUNHP24655TNHIJ4YFN7GW5V3RFDC2BXVVMVDTB3GYH5U",
-		Type:    "share",
 		OtherIdentities: account.Identities{
 			PhoneNumber: "+20000000000",
 		},
@@ -112,13 +106,19 @@ func TestAccountList_authenticatedByPhoneNumber(t *testing.T) {
 	"accounts": [
 		{
 			"address": "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
-			"type": "personal",
+			"identities": {
+				"owner": { "present": true },
+				"other": { "present": false }
+			},
 			"identity": "owner",
 			"signer": "GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"
 		},
 		{
 			"address": "GDU2CH4V3QYQB2BLMX45XQLVBEKSIN2EZLP37I6MZZ7NAR5U3TLZDQEY",
-			"type": "share",
+			"identities": {
+				"owner": { "present": false },
+				"other": { "present": true }
+			},
 			"identity": "other",
 			"signer": "GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"
 		}
@@ -131,21 +131,18 @@ func TestAccountList_authenticatedByEmail(t *testing.T) {
 	s := account.NewMemoryStore()
 	s.Add(account.Account{
 		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
-		Type:    "personal",
 		OwnerIdentities: account.Identities{
 			Email: "user1@example.com",
 		},
 	})
 	s.Add(account.Account{
 		Address: "GDU2CH4V3QYQB2BLMX45XQLVBEKSIN2EZLP37I6MZZ7NAR5U3TLZDQEY",
-		Type:    "share",
 		OtherIdentities: account.Identities{
 			Email: "user1@example.com",
 		},
 	})
 	s.Add(account.Account{
 		Address: "GCS4CVAAX7MVUNHP24655TNHIJ4YFN7GW5V3RFDC2BXVVMVDTB3GYH5U",
-		Type:    "share",
 		OtherIdentities: account.Identities{
 			Email: "user2@example.com",
 		},
@@ -175,13 +172,19 @@ func TestAccountList_authenticatedByEmail(t *testing.T) {
 	"accounts": [
 		{
 			"address": "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
-			"type": "personal",
+			"identities": {
+				"owner": { "present": true },
+				"other": { "present": false }
+			},
 			"identity": "owner",
 			"signer": "GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"
 		},
 		{
 			"address": "GDU2CH4V3QYQB2BLMX45XQLVBEKSIN2EZLP37I6MZZ7NAR5U3TLZDQEY",
-			"type": "share",
+			"identities": {
+				"owner": { "present": false },
+				"other": { "present": true }
+			},
 			"identity": "other",
 			"signer": "GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"
 		}
@@ -194,21 +197,18 @@ func TestAccountList_notAuthenticated(t *testing.T) {
 	s := account.NewMemoryStore()
 	s.Add(account.Account{
 		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
-		Type:    "personal",
 		OwnerIdentities: account.Identities{
 			Email: "user1@example.com",
 		},
 	})
 	s.Add(account.Account{
 		Address: "GDU2CH4V3QYQB2BLMX45XQLVBEKSIN2EZLP37I6MZZ7NAR5U3TLZDQEY",
-		Type:    "share",
 		OtherIdentities: account.Identities{
 			Email: "user1@example.com",
 		},
 	})
 	s.Add(account.Account{
 		Address: "GCS4CVAAX7MVUNHP24655TNHIJ4YFN7GW5V3RFDC2BXVVMVDTB3GYH5U",
-		Type:    "share",
 		OtherIdentities: account.Identities{
 			Email: "user2@example.com",
 		},

--- a/exp/services/recoverysigner/internal/serve/account_post_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_post_test.go
@@ -29,15 +29,17 @@ func TestAccountPost_new(t *testing.T) {
 	ctx = auth.NewContext(ctx, auth.Auth{Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N"})
 	req := `{
 	"type": "share",
-	"owner_identities": {
-		"account": "GBF3XFXGBGNQDN3HOSZ7NVRF6TJ2JOD5U6ELIWJOOEI6T5WKMQT2YSXQ",
-		"phone_number": "+10000000000",
-		"email": "user1@example.com"
-	},
-	"other_identities": {
-		"account": "GB5VOTKJ3IPGIYQBJ6GVJMUVEAIYGXZUJE4WYLPBJSHOTKLZTETBYOBI",
-		"phone_number": "+20000000000",
-		"email": "user2@example.com"
+	"identities": {
+		"owner": {
+			"account": "GBF3XFXGBGNQDN3HOSZ7NVRF6TJ2JOD5U6ELIWJOOEI6T5WKMQT2YSXQ",
+			"phone_number": "+10000000000",
+			"email": "user1@example.com"
+		},
+		"other": {
+			"account": "GB5VOTKJ3IPGIYQBJ6GVJMUVEAIYGXZUJE4WYLPBJSHOTKLZTETBYOBI",
+			"phone_number": "+20000000000",
+			"email": "user2@example.com"
+		}
 	}
 }`
 	r := httptest.NewRequest("POST", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", strings.NewReader(req))
@@ -57,7 +59,10 @@ func TestAccountPost_new(t *testing.T) {
 
 	wantBody := `{
 	"address": "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
-	"type": "share",
+	"identities": {
+		"owner": { "present": true },
+		"other": { "present": true }
+	},
 	"identity": "account",
 	"signer": "GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"
 }`
@@ -67,7 +72,6 @@ func TestAccountPost_new(t *testing.T) {
 	require.NoError(t, err)
 	wantAcc := account.Account{
 		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
-		Type:    "share",
 		OwnerIdentities: account.Identities{
 			Address:     "GBF3XFXGBGNQDN3HOSZ7NVRF6TJ2JOD5U6ELIWJOOEI6T5WKMQT2YSXQ",
 			PhoneNumber: "+10000000000",
@@ -86,7 +90,6 @@ func TestAccountPost_accountAddressInvalid(t *testing.T) {
 	s := account.NewMemoryStore()
 	s.Add(account.Account{
 		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
-		Type:    "personal",
 	})
 	h := accountPostHandler{
 		Logger:         supportlog.DefaultLogger,
@@ -96,9 +99,7 @@ func TestAccountPost_accountAddressInvalid(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = auth.NewContext(ctx, auth.Auth{Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N"})
-	req := `{
-	"type": "share"
-}`
+	req := `{}`
 	r := httptest.NewRequest("POST", "/ZDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", strings.NewReader(req))
 	r = r.WithContext(ctx)
 
@@ -127,7 +128,6 @@ func TestAccountPost_accountAlreadyExists(t *testing.T) {
 	s := account.NewMemoryStore()
 	s.Add(account.Account{
 		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
-		Type:    "personal",
 	})
 	h := accountPostHandler{
 		Logger:         supportlog.DefaultLogger,
@@ -137,9 +137,7 @@ func TestAccountPost_accountAlreadyExists(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = auth.NewContext(ctx, auth.Auth{Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N"})
-	req := `{
-	"type": "share"
-}`
+	req := `{}`
 	r := httptest.NewRequest("POST", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", strings.NewReader(req))
 	r = r.WithContext(ctx)
 
@@ -164,7 +162,6 @@ func TestAccountPost_accountAlreadyExists(t *testing.T) {
 	require.NoError(t, err)
 	wantAcc := account.Account{
 		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
-		Type:    "personal",
 	}
 	assert.Equal(t, wantAcc, acc)
 }
@@ -179,9 +176,7 @@ func TestAccountPost_notAuthenticatedForAccount(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = auth.NewContext(ctx, auth.Auth{Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N"})
-	req := `{
-	"type": "personal"
-}`
+	req := `{}`
 	r := httptest.NewRequest("POST", "/GDUKTYDY3RDNTNOUFJ2GPL5PIZTMTRD5P2CT274SYH67Q5J3NYI7XKYB", strings.NewReader(req))
 	r = r.WithContext(ctx)
 

--- a/exp/services/recoverysigner/internal/serve/account_response.go
+++ b/exp/services/recoverysigner/internal/serve/account_response.go
@@ -1,8 +1,18 @@
 package serve
 
 type accountResponse struct {
-	Address  string `json:"address"`
-	Type     string `json:"type"`
-	Identity string `json:"identity"`
-	Signer   string `json:"signer"`
+	Address    string                    `json:"address"`
+	Type       string                    `json:"-"`
+	Identities accountResponseIdentities `json:"identities"`
+	Identity   string                    `json:"identity"`
+	Signer     string                    `json:"signer"`
+}
+
+type accountResponseIdentities struct {
+	Owner accountResponseIdentity `json:"owner"`
+	Other accountResponseIdentity `json:"other"`
+}
+
+type accountResponseIdentity struct {
+	Present bool `json:"present"`
 }

--- a/exp/services/recoverysigner/internal/serve/account_response.go
+++ b/exp/services/recoverysigner/internal/serve/account_response.go
@@ -2,7 +2,6 @@ package serve
 
 type accountResponse struct {
 	Address    string                    `json:"address"`
-	Type       string                    `json:"-"`
 	Identities accountResponseIdentities `json:"identities"`
 	Identity   string                    `json:"identity"`
 	Signer     string                    `json:"signer"`


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Remove the `type` parameter stored alongside registered accounts and replace it with exposing information about which identities are set on an account to clients.

Remove the `type` request and response parameters. Add the `identities` response parameter, and replace `owner_identities` and `other_identities` with `identities.owner` and `identities.other`.

### Why
The `type` existed purely for clients to get some sense of what purpose an account was registered, but it's really meta data about how a client is using the service and isn't necessarily a core concept for the
service.

The value was also synonymous with which identities are configured for an account. A `type` of `personal` will always have only an `owner` identity, and a `type` of `share` was always going to have an `other` identity alone or in addition to `owner`.

By removing the concept of `type` and instead just giving a client visibility into which identities are set on the account we reduce the number of concepts a client has to learn and know about which makes the API simpler, even if the change appears to make the API slightly more complex.

The reason I replaced `owner_identities` and `other_identities` is while thinking about the right way to expose the identities to the client it occurred to me the simplest method for a JavaScript client would be to have the identities be keys of an object, and so I structured the response that way, and it made sense to also modify the request to match.

### Known limitations

This is a breaking change to the API, but there are no consumers and the API is experimental.
