### PR TITLE
services/ticker: handle invalid TOML urls gracefully

### DIFF
--- a/services/ticker/internal/scraper/asset_scraper.go
+++ b/services/ticker/internal/scraper/asset_scraper.go
@@ -1,7 +1,7 @@
 package scraper
 
 import (
-	"errors"
+	// "errors"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -17,6 +17,7 @@ import (
 	horizonclient "github.com/stellar/go/clients/horizonclient"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/ticker/internal/utils"
+	"github.com/stellar/go/support/errors"
 )
 
 // shouldDiscardAsset maps the criteria for discarding an asset from the asset index
@@ -76,7 +77,7 @@ func fetchTOMLData(asset hProtocol.AssetStat) (data string, err error) {
 
 	req, err := http.NewRequest("GET", tomlURL, nil)
 	if err != nil {
-		err = errors.New("Invalid URL or request")
+		err = errors.Wrap(err, "invalid URL or request")
 		return
 	}
 

--- a/services/ticker/internal/scraper/asset_scraper.go
+++ b/services/ticker/internal/scraper/asset_scraper.go
@@ -69,6 +69,12 @@ func fetchTOMLData(asset hProtocol.AssetStat) (data string, err error) {
 		return
 	}
 
+	_, err = url.ParseRequestURI(tomlURL)
+	if err != nil {
+		err = errors.New("Asset has an invalid TOML URL")
+		return
+	}
+
 	timeout := time.Duration(10 * time.Second)
 	client := http.Client{
 		Timeout: timeout,

--- a/services/ticker/internal/scraper/asset_scraper.go
+++ b/services/ticker/internal/scraper/asset_scraper.go
@@ -1,7 +1,6 @@
 package scraper
 
 import (
-	// "errors"
 	"fmt"
 	"io/ioutil"
 	"math"

--- a/services/ticker/internal/scraper/asset_scraper.go
+++ b/services/ticker/internal/scraper/asset_scraper.go
@@ -69,20 +69,18 @@ func fetchTOMLData(asset hProtocol.AssetStat) (data string, err error) {
 		return
 	}
 
-	_, err = url.ParseRequestURI(tomlURL)
-	if err != nil {
-		err = errors.New("Asset has an invalid TOML URL")
-		return
-	}
-
 	timeout := time.Duration(10 * time.Second)
 	client := http.Client{
 		Timeout: timeout,
 	}
 
 	req, err := http.NewRequest("GET", tomlURL, nil)
-	req.Header.Set("User-Agent", "Stellar Ticker v1.0")
+	if err != nil {
+		err = errors.New("Invalid URL or request")
+		return
+	}
 
+	req.Header.Set("User-Agent", "Stellar Ticker v1.0")
 	resp, err := client.Do(req)
 	if err != nil {
 		return

--- a/services/ticker/internal/scraper/asset_scraper_test.go
+++ b/services/ticker/internal/scraper/asset_scraper_test.go
@@ -137,5 +137,5 @@ func TestIgnoreInvalidTOMLUrls(t *testing.T) {
 	assetStat.Links.Toml = hal.Link{Href: invalidURL}
 
 	_, err := fetchTOMLData(assetStat)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "invalid URL or request: parse https:// there is something wrong here.com/stellar.toml: invalid character \" \" in host name")
 }

--- a/services/ticker/internal/scraper/asset_scraper_test.go
+++ b/services/ticker/internal/scraper/asset_scraper_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/support/render/hal"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -128,4 +129,13 @@ func TestIsDomainVerified(t *testing.T) {
 	orgURL = "https://stellar.com/"
 	hasCurrency = true
 	assert.False(t, isDomainVerified(orgURL, tomlURL, hasCurrency))
+}
+
+func TestIgnoreInvalidTOMLUrls(t *testing.T) {
+	invalidURL := "https:// there is something wrong here.com/stellar.toml"
+	assetStat := hProtocol.AssetStat{}
+	assetStat.Links.Toml = hal.Link{Href: invalidURL}
+
+	_, err := fetchTOMLData(assetStat)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
### What

Ensure the Ticker can gracefully handle invalid TOML urls.

### Why

This PR fixes #2326. We were missing an error check after creating an HTTP request to catch invalid URLs / requests.