### PR TITLE
horizonclient: add GetError func for retrieving a horizon error

### DIFF
--- a/clients/horizonclient/error_helpers.go
+++ b/clients/horizonclient/error_helpers.go
@@ -19,3 +19,19 @@ func IsNotFoundError(err error) bool {
 
 	return hErr.Problem.Type == "https://stellar.org/horizon-errors/not_found"
 }
+
+// GetError returns an error that can be interpreted as a horizon-specific
+// error. If err cannot be interpreted as a horizon-specific error, a nil error
+// is returned. The caller should still check whether err is nil.
+func GetError(err error) *Error {
+	var hErr *Error
+
+	switch e := err.(type) {
+	case *Error:
+		hErr = e
+	case Error:
+		hErr = &e
+	}
+
+	return hErr
+}

--- a/clients/horizonclient/error_helpers_test.go
+++ b/clients/horizonclient/error_helpers_test.go
@@ -82,3 +82,72 @@ func TestIsNotFoundError(t *testing.T) {
 		})
 	}
 }
+
+func TestGetError(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		err     error
+		wantErr error
+	}{
+		{
+			desc:    "nil error",
+			err:     nil,
+			wantErr: nil,
+		},
+		{
+			desc:    "another Go type of error",
+			err:     errors.New("error"),
+			wantErr: nil,
+		},
+		{
+			desc: "not found problem (pointer)",
+			err: &Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/not_found",
+					Title:  "Resource Missing",
+					Status: 404,
+				},
+			},
+			wantErr: &Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/not_found",
+					Title:  "Resource Missing",
+					Status: 404,
+				},
+			},
+		},
+		{
+			desc: "not found problem (not a pointer)",
+			err: Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/not_found",
+					Title:  "Resource Missing",
+					Status: 404,
+				},
+			},
+			wantErr: &Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/not_found",
+					Title:  "Resource Missing",
+					Status: 404,
+				},
+			},
+		},
+		{
+			desc:    "a nil *horizonclient.Error",
+			err:     (*Error)(nil),
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			gotErr := GetError(tc.err)
+			if tc.wantErr == nil {
+				assert.Nil(t, gotErr)
+			} else {
+				assert.Equal(t, tc.wantErr, gotErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What

This PR adds a helper function `GetError` to check whether if an error can be interpreted as a horizon-related error. If it can't, a nil error is returned.

### Why

People who use `horizonclient` to submit a transaction often need to check the error returned and look into what the problem is when something went wrong. However, there are two types of errors that can be returned by this package, one is Error, and the other is `*Error`. This function function makes it convenient to always get back a `*Error` even if the input is `Error`.

### Known limitations

N/A
