### PR TITLE
exp/services/recoverysigner: rename public_key to signer

### DIFF
--- a/exp/services/recoverysigner/internal/serve/account_sign.go
+++ b/exp/services/recoverysigner/internal/serve/account_sign.go
@@ -25,7 +25,7 @@ type accountSignRequest struct {
 }
 
 type accountSignResponse struct {
-	PublicKey         string `json:"public_key"`
+	Signer            string `json:"signer"`
 	Signature         string `json:"signature"`
 	NetworkPassphrase string `json:"network_passphrase"`
 }
@@ -119,7 +119,7 @@ func (h accountSignHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := accountSignResponse{
-		PublicKey:         h.SigningKey.Address(),
+		Signer:            h.SigningKey.Address(),
 		Signature:         sig,
 		NetworkPassphrase: h.NetworkPassphrase,
 	}

--- a/exp/services/recoverysigner/internal/serve/account_sign_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_sign_test.go
@@ -323,7 +323,7 @@ func TestAccountSign_accountAuthenticatedTxSourceAccountValid(t *testing.T) {
 	require.NoError(t, err)
 
 	wantBody := `{
-	"public_key": "GBOG4KF66M4AFRBUHOTJQJRO7BGGFCSGIICTI5BHXHKXCWV2C67QRN5H",
+	"signer": "GBOG4KF66M4AFRBUHOTJQJRO7BGGFCSGIICTI5BHXHKXCWV2C67QRN5H",
 	"signature": "okp0ISR/hjU6ItsfXie6ArlQ3YWkBBqEAM5TJrthALdawV5DzcpuwBKi0QE/iBgoU7eY0hY3RPdxm8mXGNYfCQ==",
 	"network_passphrase": "Test SDF Network ; September 2015"
 }`
@@ -386,7 +386,7 @@ func TestAccountSign_accountAuthenticatedTxAndOpSourceAccountValid(t *testing.T)
 	require.NoError(t, err)
 
 	wantBody := `{
-	"public_key": "GBOG4KF66M4AFRBUHOTJQJRO7BGGFCSGIICTI5BHXHKXCWV2C67QRN5H",
+	"signer": "GBOG4KF66M4AFRBUHOTJQJRO7BGGFCSGIICTI5BHXHKXCWV2C67QRN5H",
 	"signature": "MKAkl+R3VT5DJw6Qed8jO8ERD4RcQ4dJlN+UR2n7nT6AVBXnKBk0zqBZnDuB153zfTYmuA5kmsRiNr5terHVBg==",
 	"network_passphrase": "Test SDF Network ; September 2015"
 }`
@@ -624,7 +624,7 @@ func TestAccountSign_phoneNumberOwnerAuthenticated(t *testing.T) {
 	require.NoError(t, err)
 
 	wantBody := `{
-	"public_key": "GBOG4KF66M4AFRBUHOTJQJRO7BGGFCSGIICTI5BHXHKXCWV2C67QRN5H",
+	"signer": "GBOG4KF66M4AFRBUHOTJQJRO7BGGFCSGIICTI5BHXHKXCWV2C67QRN5H",
 	"signature": "okp0ISR/hjU6ItsfXie6ArlQ3YWkBBqEAM5TJrthALdawV5DzcpuwBKi0QE/iBgoU7eY0hY3RPdxm8mXGNYfCQ==",
 	"network_passphrase": "Test SDF Network ; September 2015"
 }`
@@ -687,7 +687,7 @@ func TestAccountSign_phoneNumberOtherAuthenticated(t *testing.T) {
 	require.NoError(t, err)
 
 	wantBody := `{
-	"public_key": "GBOG4KF66M4AFRBUHOTJQJRO7BGGFCSGIICTI5BHXHKXCWV2C67QRN5H",
+	"signer": "GBOG4KF66M4AFRBUHOTJQJRO7BGGFCSGIICTI5BHXHKXCWV2C67QRN5H",
 	"signature": "okp0ISR/hjU6ItsfXie6ArlQ3YWkBBqEAM5TJrthALdawV5DzcpuwBKi0QE/iBgoU7eY0hY3RPdxm8mXGNYfCQ==",
 	"network_passphrase": "Test SDF Network ; September 2015"
 }`
@@ -750,7 +750,7 @@ func TestAccountSign_emailOwnerAuthenticated(t *testing.T) {
 	require.NoError(t, err)
 
 	wantBody := `{
-	"public_key": "GBOG4KF66M4AFRBUHOTJQJRO7BGGFCSGIICTI5BHXHKXCWV2C67QRN5H",
+	"signer": "GBOG4KF66M4AFRBUHOTJQJRO7BGGFCSGIICTI5BHXHKXCWV2C67QRN5H",
 	"signature": "okp0ISR/hjU6ItsfXie6ArlQ3YWkBBqEAM5TJrthALdawV5DzcpuwBKi0QE/iBgoU7eY0hY3RPdxm8mXGNYfCQ==",
 	"network_passphrase": "Test SDF Network ; September 2015"
 }`
@@ -813,7 +813,7 @@ func TestAccountSign_emailOtherAuthenticated(t *testing.T) {
 	require.NoError(t, err)
 
 	wantBody := `{
-	"public_key": "GBOG4KF66M4AFRBUHOTJQJRO7BGGFCSGIICTI5BHXHKXCWV2C67QRN5H",
+	"signer": "GBOG4KF66M4AFRBUHOTJQJRO7BGGFCSGIICTI5BHXHKXCWV2C67QRN5H",
 	"signature": "okp0ISR/hjU6ItsfXie6ArlQ3YWkBBqEAM5TJrthALdawV5DzcpuwBKi0QE/iBgoU7eY0hY3RPdxm8mXGNYfCQ==",
 	"network_passphrase": "Test SDF Network ; September 2015"
 }`


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Rename response field `public_key` to `signer` for the
`/accounts/<account-id>/sign` endpoint.

### Why
The `public_key` field contains the address of the signer that has
generated the signature. Elsewhere in the API we use the term `signer`
for this address because it is more specific and would be really
ambiguous elsewhere in the API to what it meant. For the signing
endpoint it is less ambiguous, but it would be valuable if we used the
same field name and same concept to refer to the signer as it is easier
to join-the-dots and realize they are the same thing if we use the same
name for them.

### Known limitations

N/A