### PR TITLE
Fix horizon db reap command

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this
 file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.0
+
+* Fix `horizon db reap` bug which caused the command to exit without deleting any history table rows.
+* The horizon reap system now also deletes rows from `history_effects`. Previously, the reap system only deleted rows from `history_operation_participants`, `history_operations`, `history_transaction_participants`, `history_transactions`, `history_ledgers`, and `history_trades`.
+
 ## 1.0.0
 
 ### Before you upgrade

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this
 file. This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.1.0
+## Unreleased
 
 * Fix `horizon db reap` bug which caused the command to exit without deleting any history table rows.
 * The horizon reap system now also deletes rows from `history_trades`. Previously, the reap system only deleted rows from `history_operation_participants`, `history_operations`, `history_transaction_participants`, `history_transactions`, `history_ledgers`, and `history_effects`.

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,7 +6,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.1.0
 
 * Fix `horizon db reap` bug which caused the command to exit without deleting any history table rows.
-* The horizon reap system now also deletes rows from `history_effects`. Previously, the reap system only deleted rows from `history_operation_participants`, `history_operations`, `history_transaction_participants`, `history_transactions`, `history_ledgers`, and `history_trades`.
+* The horizon reap system now also deletes rows from `history_trades`. Previously, the reap system only deleted rows from `history_operation_participants`, `history_operations`, `history_transaction_participants`, `history_transactions`, `history_ledgers`, and `history_effects`.
 
 ## 1.0.0
 

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -96,7 +96,9 @@ var dbReapCmd = &cobra.Command{
 	Short: "reaps (i.e. removes) any reapable history data",
 	Long:  "reap removes any historical data that is earlier than the configured retention cutoff",
 	Run: func(cmd *cobra.Command, args []string) {
-		err := initApp().DeleteUnretainedHistory()
+		app := initApp()
+		app.UpdateLedgerState()
+		err := app.DeleteUnretainedHistory()
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/services/horizon/internal/reap/main.go
+++ b/services/horizon/internal/reap/main.go
@@ -7,12 +7,13 @@ package reap
 import (
 	"time"
 
+	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/db"
 )
 
 // System represents the history reaping subsystem of horizon.
 type System struct {
-	HorizonDB      *db.Session
+	HistoryQ       *history.Q
 	RetentionCount uint
 
 	nextRun time.Time
@@ -20,9 +21,9 @@ type System struct {
 
 // New initializes the reaper, causing it to begin polling the stellar-core
 // database for now ledgers and ingesting data into the horizon database.
-func New(retention uint, horizon *db.Session) *System {
+func New(retention uint, dbSession *db.Session) *System {
 	r := &System{
-		HorizonDB:      horizon,
+		HistoryQ:       &history.Q{dbSession},
 		RetentionCount: retention,
 	}
 


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Close https://github.com/stellar/go/issues/2307

When the db reap command is called, `ledger.CurrentState()` returns an uninitialized struct where the latest history ledger sequence is set to 0. Consequently, the reap system always concludes that there are no ledgers preceding the cutoff point. To fix this bug we need to call `app.UpdateLedgerState()` to ensure that ledger.CurrentState() is properly initialized.

Another problem with the reap command is that it does not delete from all history tables (e.g. history_trades). This commit fixes this issue by calling `DeleteRangeAll()` which is used by the ingestion system to clear history tables prior to running a reingest range command.


### Known limitations

[N/A]
