### PR TITLE
exp/services/recoverysigner: add form url-encoded tests

### DIFF
--- a/exp/services/recoverysigner/internal/serve/account_post_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_post_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -17,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAccountPost_new(t *testing.T) {
+func TestAccountPost_newContentTypeJSON(t *testing.T) {
 	s := account.NewMemoryStore()
 	h := accountPostHandler{
 		Logger:         supportlog.DefaultLogger,
@@ -44,6 +45,70 @@ func TestAccountPost_new(t *testing.T) {
 }`
 	r := httptest.NewRequest("POST", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", strings.NewReader(req))
 	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Post("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"address": "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+	"identities": {
+		"owner": { "present": true },
+		"other": { "present": true }
+	},
+	"identity": "account",
+	"signer": "GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"
+}`
+	assert.JSONEq(t, wantBody, string(body))
+
+	acc, err := s.Get("GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N")
+	require.NoError(t, err)
+	wantAcc := account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		OwnerIdentities: account.Identities{
+			Address:     "GBF3XFXGBGNQDN3HOSZ7NVRF6TJ2JOD5U6ELIWJOOEI6T5WKMQT2YSXQ",
+			PhoneNumber: "+10000000000",
+			Email:       "user1@example.com",
+		},
+		OtherIdentities: account.Identities{
+			Address:     "GB5VOTKJ3IPGIYQBJ6GVJMUVEAIYGXZUJE4WYLPBJSHOTKLZTETBYOBI",
+			PhoneNumber: "+20000000000",
+			Email:       "user2@example.com",
+		},
+	}
+	assert.Equal(t, wantAcc, acc)
+}
+
+func TestAccountPost_newContentTypeForm(t *testing.T) {
+	s := account.NewMemoryStore()
+	h := accountPostHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N"})
+	reqValues := url.Values{}
+	reqValues.Set("identities.owner.account", "GBF3XFXGBGNQDN3HOSZ7NVRF6TJ2JOD5U6ELIWJOOEI6T5WKMQT2YSXQ")
+	reqValues.Set("identities.owner.phone_number", "+10000000000")
+	reqValues.Set("identities.owner.email", "user1@example.com")
+	reqValues.Set("identities.other.account", "GB5VOTKJ3IPGIYQBJ6GVJMUVEAIYGXZUJE4WYLPBJSHOTKLZTETBYOBI")
+	reqValues.Set("identities.other.phone_number", "+20000000000")
+	reqValues.Set("identities.other.email", "user2@example.com")
+	req := reqValues.Encode()
+	t.Log("Request Body:", req)
+	r := httptest.NewRequest("POST", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", strings.NewReader(req))
+	r = r.WithContext(ctx)
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	w := httptest.NewRecorder()
 	m := chi.NewMux()


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Add tests that test that form url-encoded requests are supported.

### Why
The application is intended to support both form url-encoded and JSON request bodies, and actually does support it because our `support/http/httpdecode` package supports it, but no tests exist exercising the former.

### Known limitations

[TODO or N/A]
