### PR TITLE
services/horizon/internal/actions: Wrap SSE handlers in repeatable read tx

### DIFF
--- a/support/db/main.go
+++ b/support/db/main.go
@@ -105,6 +105,7 @@ type Session struct {
 }
 
 type SessionInterface interface {
+	BeginTx(opts *sql.TxOptions) error
 	Begin() error
 	Rollback() error
 	TruncateTables(tables []string) error

--- a/support/db/mock_session.go
+++ b/support/db/mock_session.go
@@ -19,6 +19,11 @@ func (m *MockSession) Begin() error {
 	return args.Error(0)
 }
 
+func (m *MockSession) BeginTx(opts *sql.TxOptions) error {
+	args := m.Called(opts)
+	return args.Error(0)
+}
+
 func (m *MockSession) Rollback() error {
 	args := m.Called()
 	return args.Error(0)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

* Execute SSE handlers in repeatable read transactions
* Obtain account info from stellar core db using repeatable read transaction 

### Why

Close https://github.com/stellar/go/issues/2331

> I noticed Some extra balances error in /accounts/{id} stream. At first, I thought that it was the inconsistency issue propagated from stellar-core (we build Account object using a few DB queries without REPEATABLE READ transaction). But then I realized that we don't use REPEATABLE READ transaction in Horizon DB while streaming.

> We should update the streaming code to start a REPEATABLE READ transaction (if not in a transaction already) before calling an action function and then rollback (only if not in a previously started transaction).

...
> We've seen another instance today for non-streaming request and the reason is getting data from core in multiple requests. So we should probably add start a new REPEATABLE READ transaction when getting data from Stellar-Core.



### Known limitations

[N/A]
