### PR TITLE
all: use Go 1.14 for building in docker images

### DIFF
--- a/exp/services/recoverysigner/docker/Dockerfile
+++ b/exp/services/recoverysigner/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-stretch as build
+FROM golang:1.14-stretch as build
 
 ADD . /src/recoverysigner
 WORKDIR /src/recoverysigner

--- a/exp/services/webauth/docker/Dockerfile
+++ b/exp/services/webauth/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-stretch as build
+FROM golang:1.14-stretch as build
 
 ADD . /src/webauth
 WORKDIR /src/webauth

--- a/services/horizon/docker/Dockerfile
+++ b/services/horizon/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-stretch AS builder
+FROM golang:1.14-stretch AS builder
 
 WORKDIR /go/src/github.com/stellar/go
 COPY go.mod go.sum ./

--- a/services/keystore/docker/Dockerfile
+++ b/services/keystore/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-stretch as build
+FROM golang:1.14-stretch as build
 
 ADD . /src/keystore
 WORKDIR /src/keystore

--- a/services/ticker/docker/Dockerfile
+++ b/services/ticker/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-stretch as build
+FROM golang:1.14-stretch as build
 
 ADD . /src/ticker
 WORKDIR /src/ticker


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Use Go 1.14 for building in docker images.

### Why
We recently switched to building with Go 1.13 and 1.14 in #2325 and we should use the latest version for our builds.

### Known limitations
N/A