### PR TITLE
doc: update changelogs with drop of Go 1.12 support

### DIFF
--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -6,6 +6,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 - Add `IsNotFoundError`
+* Dropped support for Go 1.12.
 
 ## [v2.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v2.0.0) - 2020-01-13
 

--- a/services/bridge/CHANGELOG.md
+++ b/services/bridge/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 As this project is pre 1.0, breaking changes may happen for minor version bumps. A breaking change will get clearly notified in this log.
 
+## Unreleased
+
+* Dropped support for Go 1.12.
+
 ## 0.0.33
 
 * Add `ReadTimeout` to HTTP server configuration to fix potential DoS vector.

--- a/services/compliance/CHANGELOG.md
+++ b/services/compliance/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 As this project is pre 1.0, breaking changes may happen for minor version bumps. A breaking change will get clearly notified in this log.
 
+## Unreleased
+
+* Dropped support for Go 1.12.
+
 ## 0.0.33
 
 * Add `ReadTimeout` to HTTP server configuration to fix potential DoS vector.

--- a/services/federation/CHANGELOG.md
+++ b/services/federation/CHANGELOG.md
@@ -6,6 +6,10 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## Unreleased
+
+* Dropped support for Go 1.12.
+
 ## [v0.3.0] - 2019-11-20
 
 ### Changed

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -7,6 +7,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Fix `horizon db reap` bug which caused the command to exit without deleting any history table rows.
 * The horizon reap system now also deletes rows from `history_trades`. Previously, the reap system only deleted rows from `history_operation_participants`, `history_operations`, `history_transaction_participants`, `history_transactions`, `history_ledgers`, and `history_effects`.
+* Dropped support for Go 1.12.
 
 ## 1.0.0
 

--- a/services/keystore/CHANGELOG.md
+++ b/services/keystore/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Dropped support for Go 1.12.
+
 ## [v1.2.0] - 2019-11-20
 
 - Add `ReadTimeout` to Keystore HTTP server configuration to fix potential DoS vector.

--- a/services/ticker/CHANGELOG.md
+++ b/services/ticker/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Dropped support for Go 1.12.
+
+
 ## [v1.2.0] - 2019-11-20
 - Add `ReadTimeout` to Ticker HTTP server configuration to fix potential DoS vector.
 - Added nested `"issuer_detail"` field to `/assets.json`.

--- a/tools/stellar-archivist/CHANGELOG.md
+++ b/tools/stellar-archivist/CHANGELOG.md
@@ -9,7 +9,7 @@ bumps.  A breaking change will get clearly notified in this log.
 ## ???
 
 * Fix race condition in `mirror` command
-* Dropped support for Go 1.10, 1.11.
+* Dropped support for Go 1.10, 1.11, 1.12.
 * Add `log` command
 * Add `--recent` flag for `mirror` command
 

--- a/tools/stellar-hd-wallet/CHANGELOG.md
+++ b/tools/stellar-hd-wallet/CHANGELOG.md
@@ -8,7 +8,7 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ## Unreleased
 
-- Dropped support for Go 1.10, 1.11.
+- Dropped support for Go 1.10, 1.11, 1.12.
 
 ## [v0.0.1] - 2017-12-28
 

--- a/tools/stellar-sign/CHANGELOG.md
+++ b/tools/stellar-sign/CHANGELOG.md
@@ -8,7 +8,7 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ## Unreleased
 
-- Dropped support for Go 1.10, 1.11.
+- Dropped support for Go 1.10, 1.11, 1.12.
 
 ## [v0.2.0] - 2016-08-19
 

--- a/tools/stellar-vanity-gen/CHANGELOG.md
+++ b/tools/stellar-vanity-gen/CHANGELOG.md
@@ -8,7 +8,7 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ## Unreleased
 
-- Dropped support for Go 1.10, 1.11.
+- Dropped support for Go 1.10, 1.11, 1.12.
 
 ## [v0.1.0] - 2016-08-17
 

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -5,6 +5,8 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Dropped support for Go 1.12.
+
 ## [v1.5.0](https://github.com/stellar/go/releases/tag/horizonclient-v1.5.0) - 2019-10-09
 
 * Dropped support for Go 1.10, 1.11.


### PR DESCRIPTION


<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Update all CHANGELOG.md's mentioning that Go 1.12 support has been
dropped.

### Why
I dropped Go 1.12 support in #2325 but I overlooked adding a note to the
changelogs.
### Known limitations

N/A