### PR TITLE
services/horizon: Add HISTORY_ARCHIVE_URLS to docker-compose

### DIFF
--- a/services/horizon/docker/docker-compose.yml
+++ b/services/horizon/docker/docker-compose.yml
@@ -57,6 +57,9 @@ services:
       - STELLAR_CORE_DATABASE_URL=postgres://postgres:mysecretpassword@host.docker.internal:5641/stellar?sslmode=disable
       # to connect to the public stellar network
       # - NETWORK_PASSPHRASE=Public Global Stellar Network ; September 2015
+      - HISTORY_ARCHIVE_URLS=https://history.stellar.org/prd/core-testnet/core_testnet_001
+      # to connect to the public stellar network
+      # - HISTORY_ARCHIVE_URLS=https://history.stellar.org/prd/core-live/core_live_001
       - NETWORK_PASSPHRASE=Test SDF Network ; September 2015
       - STELLAR_CORE_URL=http://host.docker.internal:11626
       - INGEST=true


### PR DESCRIPTION
Followup from https://github.com/stellar/go/pull/2306

Running `docker/start.sh` led to error `--history-archive-urls must be set when --ingest is set`
