### PR TITLE
Issue #2350: historyarchive: Add ability to get HAS root with no cache

### DIFF
--- a/support/historyarchive/fs_archive.go
+++ b/support/historyarchive/fs_archive.go
@@ -19,6 +19,10 @@ func (b *FsArchiveBackend) GetFile(pth string) (io.ReadCloser, error) {
 	return os.Open(path.Join(b.prefix, pth))
 }
 
+func (b *FsArchiveBackend) GetFileNoCache(pth string) (io.ReadCloser, error) {
+	return b.GetFile(pth)
+}
+
 func (b *FsArchiveBackend) Exists(pth string) (bool, error) {
 	pth = path.Join(b.prefix, pth)
 	_, err := os.Stat(pth)

--- a/support/historyarchive/mock_archive.go
+++ b/support/historyarchive/mock_archive.go
@@ -47,6 +47,10 @@ func (b *MockArchiveBackend) GetFile(pth string) (io.ReadCloser, error) {
 	return ioutil.NopCloser(bytes.NewReader(buf)), nil
 }
 
+func (b *MockArchiveBackend) GetFileNoCache(pth string) (io.ReadCloser, error) {
+	return b.GetFile(pth)
+}
+
 func (b *MockArchiveBackend) PutFile(pth string, in io.ReadCloser) error {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()

--- a/support/historyarchive/mocks.go
+++ b/support/historyarchive/mocks.go
@@ -14,6 +14,10 @@ func (m *MockArchive) GetPathHAS(path string) (HistoryArchiveState, error) {
 	return a.Get(0).(HistoryArchiveState), a.Error(1)
 }
 
+func (m *MockArchive) GetPathHASNoCache(path string) (HistoryArchiveState, error) {
+	return m.GetPathHAS(path)
+}
+
 func (m *MockArchive) PutPathHAS(path string, has HistoryArchiveState, opts *CommandOptions) error {
 	a := m.Called(path, has, opts)
 	return a.Error(0)

--- a/support/historyarchive/s3_archive.go
+++ b/support/historyarchive/s3_archive.go
@@ -44,6 +44,10 @@ func (b *S3ArchiveBackend) GetFile(pth string) (io.ReadCloser, error) {
 	return resp.Body, nil
 }
 
+func (b *S3ArchiveBackend) GetFileNoCache(pth string) (io.ReadCloser, error) {
+	return b.GetFile(pth)
+}
+
 func (b *S3ArchiveBackend) Head(pth string) (*http.Response, error) {
 	params := &s3.HeadObjectInput{
 		Bucket: aws.String(b.bucket),


### PR DESCRIPTION
Towards Issue #2350
Append a simple timestamp to the URL when fetching `stellar-history.json`