### PR TITLE
all: update version of rake from 12.3.1 to 13.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
-    rake (12.3.1)
+    rake (13.0.1)
     rbnacl (5.0.0)
       ffi
     rbnacl-libsodium (1.0.16)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Update versions of rake from 12.3.1 to 13.0.1.

### Why
CVE-2020-8130 outlines that there is an OS command injection vulnerability in Ruby Rake before 12.3.3 in Rake::FileList when supplying a filename that begins with the pipe character |.

I don't believe this in particular impacts our use here because we rarely run the rake commands here and when we do we're running them on our own code in this repository, but upgrading it here is one way we can help prevent the proliferation of a vulnerable version of rake, since upgrading it here ensures that anyone that is running the rake commands in this repository with bundler won't be installing a vulnerable version of rake on their system that may become exploitable through some other use case on their system.

I upgraded to the latest version including a major version change because the only breaking change noted in the [change logs](https://github.com/ruby/rake/blob/9b08384d4a797c42af2986e1262bc95bb9945975/History.rdoc) for rake was the removal of support for an older version of Ruby, 2.2.x, which we should not be using anyway.

### Testing
I tested this change locally by running the following command. The result was identical to the result of running the same commands on master. There was a diff when I ran the commands, but the diff looks the same in both cases.

```
bundle exec rake xdr:generate
```

### Known limitations

N/A
