### PR TITLE
support/db/dbtest: log the name of the database in use for the each test

### DIFF
--- a/support/db/dbtest/db.go
+++ b/support/db/dbtest/db.go
@@ -96,11 +96,10 @@ func execStatement(t *testing.T, pguser, query string) {
 // default port, have the command line postgres tools installed, and that the
 // current user has access to the server.  It panics on the event of a failure.
 func Postgres(t *testing.T) *DB {
-	db := DB{
-		dbName:  randomName(),
-		Dialect: "postgres",
-		t:       t,
-	}
+	var result DB
+	result.dbName = randomName()
+	result.Dialect = "postgres"
+	result.t = t
 
 	t.Log("Test Database:", dbName)
 
@@ -110,12 +109,12 @@ func Postgres(t *testing.T) *DB {
 	}
 
 	// create the db
-	execStatement(t, pgUser, "CREATE DATABASE "+pq.QuoteIdentifier(db.dbName))
+	execStatement(t, pgUser, "CREATE DATABASE "+pq.QuoteIdentifier(result.dbName))
 
-	result.DSN = fmt.Sprintf("postgres://%s@localhost/%s?sslmode=disable", pgUser, db.dbName)
+	result.DSN = fmt.Sprintf("postgres://%s@localhost/%s?sslmode=disable", pgUser, result.dbName)
 
 	result.closer = func() {
-		execStatement(t, pgUser, "DROP DATABASE "+pq.QuoteIdentifier(db.dbName))
+		execStatement(t, pgUser, "DROP DATABASE "+pq.QuoteIdentifier(result.dbName))
 	}
 
 	return &result

--- a/support/db/dbtest/db.go
+++ b/support/db/dbtest/db.go
@@ -101,7 +101,7 @@ func Postgres(t *testing.T) *DB {
 	result.Dialect = "postgres"
 	result.t = t
 
-	t.Log("Test Database:", dbName)
+	t.Log("Test Database:", result.dbName)
 
 	pgUser := os.Getenv("PGUSER")
 	if len(pgUser) == 0 {

--- a/support/db/dbtest/db.go
+++ b/support/db/dbtest/db.go
@@ -96,10 +96,13 @@ func execStatement(t *testing.T, pguser, query string) {
 // default port, have the command line postgres tools installed, and that the
 // current user has access to the server.  It panics on the event of a failure.
 func Postgres(t *testing.T) *DB {
-	var result DB
-	result.dbName = randomName()
-	result.Dialect = "postgres"
-	result.t = t
+	db := DB{
+		dbName:  randomName(),
+		Dialect: "postgres",
+		t:       t,
+	}
+
+	t.Log("Test Database:", dbName)
 
 	pgUser := os.Getenv("PGUSER")
 	if len(pgUser) == 0 {
@@ -107,12 +110,12 @@ func Postgres(t *testing.T) *DB {
 	}
 
 	// create the db
-	execStatement(t, pgUser, "CREATE DATABASE "+pq.QuoteIdentifier(result.dbName))
+	execStatement(t, pgUser, "CREATE DATABASE "+pq.QuoteIdentifier(db.dbName))
 
-	result.DSN = fmt.Sprintf("postgres://%s@localhost/%s?sslmode=disable", pgUser, result.dbName)
+	result.DSN = fmt.Sprintf("postgres://%s@localhost/%s?sslmode=disable", pgUser, db.dbName)
 
 	result.closer = func() {
-		execStatement(t, pgUser, "DROP DATABASE "+pq.QuoteIdentifier(result.dbName))
+		execStatement(t, pgUser, "DROP DATABASE "+pq.QuoteIdentifier(db.dbName))
 	}
 
 	return &result


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Log the name of the database in use for the each test.

### Why
We can add logs to tests to make the self describe what they are
testing. The logs are only visible when the test is run in verbose mode,
or when the test fails. Each test that uses the DB creates a database to
use in isolation for that test. Sometimes when iterating on code
relating to the database I find myself wanting to go and look at what
the resulting data is. Especially in cases a test is failing and the
code looks right, or if a new migration is failing to be applied during
tests. If this happens today we have to manually add some logs or open
psql and try and guess at which database it is.

### Why not
This might not be useful to enough people to warrant including it in the
verbose logs of every test that uses the database.

### Known limitations

N/A