### PR TITLE
services/horizon: Ignore db.ErrCanceled and ctx.Canceled returned by verifyState.

### DIFF
--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -434,9 +434,5 @@ func markStateInvalid(historyQ history.IngestionQ, err error) {
 
 func isCancelledError(err error) bool {
 	cause := errors.Cause(err)
-	if err == nil {
-		return false
-	}
-
 	return cause == context.Canceled || cause == db.ErrCancelled
 }

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -347,9 +347,7 @@ func (s *System) loadOffersIntoMemory(sequence uint32) error {
 
 func (s *System) maybeVerifyState(lastIngestedLedger uint32) {
 	stateInvalid, err := s.historyQ.GetExpStateInvalid()
-	if cause := errors.Cause(err); cause != nil &&
-		cause != context.Canceled &&
-		cause != db.ErrCancelled {
+	if err != nil && !isCancelledError(err) {
 		log.WithField("err", err).Error("Error getting state invalid value")
 	}
 
@@ -363,13 +361,12 @@ func (s *System) maybeVerifyState(lastIngestedLedger uint32) {
 
 			err := s.verifyState(graphOffersMap, true)
 			if err != nil {
-				cause := errors.Cause(err)
-				if cause == context.Canceled || cause == db.ErrCancelled {
+				if isCancelledError(err) {
 					return
 				}
 
 				errorCount := s.incrementStateVerificationErrors()
-				switch cause.(type) {
+				switch errors.Cause(err).(type) {
 				case ingesterrors.StateError:
 					markStateInvalid(s.historyQ, err)
 				default:
@@ -435,4 +432,13 @@ func markStateInvalid(historyQ history.IngestionQ, err error) {
 	if err := q.UpdateExpStateInvalid(true); err != nil {
 		log.WithField("err", err).Error(updateExpStateInvalidErrMsg)
 	}
+}
+
+func isCancelledError(err error) bool {
+	cause := errors.Cause(err)
+	if err == nil {
+		return false
+	}
+
+	return cause == context.Canceled || cause == db.ErrCancelled
 }

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -272,9 +272,7 @@ func (s *System) runStateMachine(cur stateMachineNode) error {
 		}
 
 		next, err := cur.run(s)
-		if cause := errors.Cause(err); cause != nil &&
-			cause != context.Canceled &&
-			cause != db.ErrCancelled {
+		if err != nil && !isCancelledError(err) {
 			log.WithFields(logpkg.F{
 				"error":         err,
 				"current_state": cur,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Ignore db.ErrCanceled and ctx.Canceled returned by verifyState.

Fix #2224

### Why

If the system is shutdown during state verification, there is a warning inthe log showing

``` WARN[2020-02-04T18:14:19.987+01:00] State verification errored
err="addAccountsToStateVerifier failed: Error running history.Q.GetAccountsByIDs: select failed: context canceled" pid=99452 service=expingest
```

If the system is being shutdown gracefully which is the case when we
get this errors, then we shouldn't log an error.

Fix #2224

### Known limitations

[TODO or N/A]