### PR TITLE
all: make migration go-bindata files stable

### DIFF
--- a/services/bridge/internal/db/bindata.go
+++ b/services/bridge/internal/db/bindata.go
@@ -24,7 +24,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -32,7 +32,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 	if clErr != nil {
 		return nil, err
@@ -88,7 +88,7 @@ func latestSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "latest.sql", size: 5393, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "latest.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x8e, 0x1a, 0xb5, 0xc5, 0xcf, 0x93, 0xea, 0xf9, 0xfa, 0x2b, 0xff, 0xa4, 0x69, 0x26, 0xf6, 0xd2, 0x64, 0x1e, 0xe3, 0x4d, 0x3f, 0x33, 0x7a, 0xd7, 0x2e, 0xbc, 0xea, 0xbc, 0xa3, 0xc3, 0x9e, 0x32}}
 	return a, nil
 }
@@ -108,7 +108,7 @@ func migrations01_initSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/01_init.sql", size: 651, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/01_init.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1a, 0x1, 0x93, 0xc5, 0x97, 0xe2, 0xe7, 0x8c, 0xc5, 0x48, 0xdf, 0xc, 0x6f, 0xcf, 0x13, 0x1f, 0x7e, 0x4, 0xfb, 0x30, 0xb7, 0x8f, 0xd0, 0xa8, 0xd4, 0x94, 0x77, 0x28, 0xf, 0xe1, 0x3d, 0x77}}
 	return a, nil
 }
@@ -128,7 +128,7 @@ func migrations02_payment_idSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/02_payment_id.sql", size: 235, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/02_payment_id.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x4, 0xa9, 0x7f, 0xcb, 0x38, 0x71, 0x17, 0xf3, 0x1b, 0x22, 0x5c, 0x31, 0x2f, 0xee, 0x48, 0xca, 0xf6, 0x20, 0x5d, 0x1e, 0xc8, 0x19, 0x54, 0x5d, 0x6d, 0x5c, 0x56, 0x95, 0x5, 0x3c, 0xa, 0x2d}}
 	return a, nil
 }
@@ -148,7 +148,7 @@ func migrations03_transaction_idSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/03_transaction_id.sql", size: 156, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/03_transaction_id.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xf0, 0x8, 0x15, 0xf2, 0xc, 0x51, 0x90, 0x8, 0x9f, 0xc9, 0xac, 0x8, 0x24, 0xf9, 0x21, 0x7d, 0x7f, 0x19, 0xdf, 0x71, 0xcb, 0xff, 0xe8, 0xf7, 0x9, 0x6b, 0xe8, 0x10, 0x3, 0x17, 0x26, 0x28}}
 	return a, nil
 }
@@ -168,7 +168,7 @@ func migrations04_table_namesSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/04_table_names.sql", size: 257, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/04_table_names.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xdd, 0xc, 0xd1, 0x5d, 0x33, 0x1, 0x49, 0x15, 0x2, 0xca, 0x84, 0xdd, 0xcf, 0xea, 0xbe, 0x38, 0xa8, 0x7, 0xae, 0x43, 0x5b, 0xf5, 0x8b, 0xd3, 0xce, 0xf, 0x79, 0xcd, 0xa3, 0x7b, 0x0, 0xed}}
 	return a, nil
 }
@@ -264,15 +264,11 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"latest.sql": latestSql,
-
-	"migrations/01_init.sql": migrations01_initSql,
-
-	"migrations/02_payment_id.sql": migrations02_payment_idSql,
-
+	"latest.sql":                       latestSql,
+	"migrations/01_init.sql":           migrations01_initSql,
+	"migrations/02_payment_id.sql":     migrations02_payment_idSql,
 	"migrations/03_transaction_id.sql": migrations03_transaction_idSql,
-
-	"migrations/04_table_names.sql": migrations04_table_namesSql,
+	"migrations/04_table_names.sql":    migrations04_table_namesSql,
 }
 
 // AssetDir returns the file names below a certain

--- a/services/bridge/internal/db/main.go
+++ b/services/bridge/internal/db/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stellar/go/support/db"
 )
 
-//go:generate go-bindata -ignore .+\.go$ -pkg db -o bindata.go ./...
+//go:generate go-bindata -nometadata -ignore .+\.go$ -pkg db -o bindata.go ./...
 
 // Migrations represents all of the schema migration
 var Migrations migrate.MigrationSource = &migrate.AssetMigrationSource{

--- a/services/compliance/internal/db/bindata.go
+++ b/services/compliance/internal/db/bindata.go
@@ -23,7 +23,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -31,7 +31,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 	if clErr != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func latestSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "latest.sql", size: 7872, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "latest.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xe6, 0xa3, 0x40, 0x86, 0x73, 0xaf, 0xcc, 0xe4, 0xb8, 0x1a, 0x9e, 0xfd, 0x6f, 0xed, 0xe9, 0xe2, 0x34, 0x9d, 0xac, 0x24, 0x6d, 0xf5, 0xe4, 0xd8, 0xb, 0xca, 0xe8, 0xf9, 0x3f, 0xe1, 0x73, 0x36}}
 	return a, nil
 }
@@ -107,7 +107,7 @@ func migrations01_initSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/01_init.sql", size: 992, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/01_init.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1c, 0x1f, 0x65, 0xdd, 0x6e, 0xc, 0xa7, 0x34, 0x47, 0xb6, 0x79, 0x15, 0xe3, 0x89, 0x5, 0xce, 0xb2, 0x6d, 0x6a, 0xc3, 0xc3, 0xb7, 0xcd, 0x41, 0xe3, 0x70, 0x61, 0x88, 0x67, 0xe2, 0x14, 0x3e}}
 	return a, nil
 }
@@ -127,7 +127,7 @@ func migrations02_auth_dataSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/02_auth_data.sql", size: 272, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/02_auth_data.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x44, 0xe, 0xd, 0x9d, 0x9f, 0xc7, 0x29, 0x66, 0x52, 0x32, 0x41, 0x21, 0xaf, 0x86, 0xc0, 0x7e, 0x2d, 0xa9, 0x63, 0xfc, 0x67, 0x55, 0xc5, 0xca, 0xff, 0xe8, 0xca, 0x7d, 0x6a, 0x4c, 0x84, 0xaf}}
 	return a, nil
 }
@@ -147,7 +147,7 @@ func migrations03_table_namesSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/03_table_names.sql", size: 436, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/03_table_names.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd7, 0x1d, 0xf4, 0xb6, 0xa, 0xf9, 0xd2, 0x5b, 0xde, 0xed, 0xda, 0x7, 0xef, 0x14, 0x75, 0x5d, 0xc3, 0xa6, 0xa5, 0xfc, 0x57, 0x63, 0xcc, 0x25, 0xe0, 0x1a, 0x46, 0x57, 0x87, 0x74, 0xfc, 0x8}}
 	return a, nil
 }
@@ -243,12 +243,9 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"latest.sql": latestSql,
-
-	"migrations/01_init.sql": migrations01_initSql,
-
-	"migrations/02_auth_data.sql": migrations02_auth_dataSql,
-
+	"latest.sql":                    latestSql,
+	"migrations/01_init.sql":        migrations01_initSql,
+	"migrations/02_auth_data.sql":   migrations02_auth_dataSql,
 	"migrations/03_table_names.sql": migrations03_table_namesSql,
 }
 

--- a/services/compliance/internal/db/main.go
+++ b/services/compliance/internal/db/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stellar/go/support/db"
 )
 
-//go:generate go-bindata -ignore .+\.go$ -pkg db -o bindata.go ./...
+//go:generate go-bindata -nometadata -ignore .+\.go$ -pkg db -o bindata.go ./...
 
 // Migrations represents all of the schema migration
 var Migrations migrate.MigrationSource = &migrate.AssetMigrationSource{

--- a/services/horizon/internal/db2/schema/bindata.go
+++ b/services/horizon/internal/db2/schema/bindata.go
@@ -52,7 +52,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -60,7 +60,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 	if clErr != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func migrations10_add_trades_priceSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/10_add_trades_price.sql", size: 1220, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/10_add_trades_price.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x85, 0x1e, 0x7f, 0x86, 0xc2, 0x2c, 0xc9, 0x91, 0xe2, 0x3f, 0x1a, 0xb2, 0x15, 0xea, 0x6c, 0x5, 0xfa, 0x1f, 0x99, 0xd2, 0xbb, 0x1, 0x5e, 0x75, 0x91, 0x8b, 0xb, 0x46, 0xa, 0x6, 0xbc, 0x61}}
 	return a, nil
 }
@@ -136,7 +136,7 @@ func migrations11_add_trades_account_indexSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/11_add_trades_account_index.sql", size: 273, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/11_add_trades_account_index.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x98, 0xa4, 0x60, 0x40, 0x6b, 0xa6, 0x5e, 0xcc, 0x67, 0xb3, 0x85, 0x82, 0xce, 0x39, 0xc6, 0xbb, 0x2c, 0xa7, 0x2e, 0xb6, 0x9a, 0xd, 0xba, 0x91, 0x28, 0x80, 0x77, 0x46, 0x8c, 0x67, 0x55, 0x9f}}
 	return a, nil
 }
@@ -156,7 +156,7 @@ func migrations12_asset_stats_amount_stringSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/12_asset_stats_amount_string.sql", size: 197, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/12_asset_stats_amount_string.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3a, 0xd1, 0x4c, 0x37, 0xe7, 0xfd, 0xdb, 0x3a, 0xf2, 0x37, 0x9b, 0x8d, 0x77, 0x99, 0x61, 0x15, 0x10, 0x51, 0xe5, 0xe5, 0x7f, 0xec, 0x7e, 0x7, 0xe5, 0x18, 0x8a, 0xf2, 0xb4, 0x66, 0x17, 0x60}}
 	return a, nil
 }
@@ -176,7 +176,7 @@ func migrations13_trade_offer_idsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/13_trade_offer_ids.sql", size: 484, mode: os.FileMode(0644), modTime: time.Unix(1572426892, 0)}
+	info := bindataFileInfo{name: "migrations/13_trade_offer_ids.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x77, 0x71, 0x79, 0x45, 0x9b, 0x9e, 0x80, 0x36, 0x80, 0x5a, 0xc2, 0x1f, 0xb4, 0xba, 0xdd, 0x85, 0x65, 0xd0, 0x5c, 0x47, 0x47, 0xf, 0x4d, 0xc7, 0x9b, 0x92, 0x36, 0xd7, 0xe6, 0x57, 0x46, 0xa}}
 	return a, nil
 }
@@ -196,7 +196,7 @@ func migrations14_fix_asset_toml_fieldSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/14_fix_asset_toml_field.sql", size: 156, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/14_fix_asset_toml_field.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xdf, 0x28, 0x86, 0x8, 0xa5, 0xec, 0x44, 0x7b, 0xf7, 0x88, 0x3b, 0x6d, 0xf6, 0x5c, 0x6a, 0x17, 0x92, 0xbc, 0xd2, 0x88, 0x94, 0xd4, 0x42, 0xb1, 0xc2, 0xac, 0x97, 0xb6, 0xd0, 0xeb, 0xd8, 0xa7}}
 	return a, nil
 }
@@ -216,7 +216,7 @@ func migrations15_ledger_failed_txsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/15_ledger_failed_txs.sql", size: 333, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/15_ledger_failed_txs.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xeb, 0x7, 0xd7, 0xc9, 0x5d, 0xbe, 0xd2, 0x21, 0xc1, 0xb0, 0x20, 0xc8, 0x5f, 0x3a, 0xe9, 0x99, 0xba, 0x5d, 0x83, 0xb4, 0xe8, 0x9f, 0x2d, 0xc3, 0x9a, 0xe1, 0x46, 0xf2, 0xd1, 0x1b, 0x48, 0x7a}}
 	return a, nil
 }
@@ -236,7 +236,7 @@ func migrations16_ingest_failed_transactionsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/16_ingest_failed_transactions.sql", size: 509, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/16_ingest_failed_transactions.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xf9, 0x24, 0xd, 0x8a, 0x56, 0x1d, 0x41, 0x6a, 0x4, 0x7b, 0xe1, 0x9f, 0xfb, 0x78, 0x2, 0xec, 0xe2, 0x98, 0xac, 0xef, 0xc7, 0xc0, 0x96, 0xd1, 0xbf, 0x8f, 0xc6, 0x16, 0xa7, 0x3c, 0x4a, 0x33}}
 	return a, nil
 }
@@ -256,7 +256,7 @@ func migrations17_transaction_fee_paidSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/17_transaction_fee_paid.sql", size: 287, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/17_transaction_fee_paid.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x64, 0x93, 0x1c, 0x21, 0xf6, 0x63, 0xac, 0x5c, 0x8, 0x6b, 0xe9, 0x4f, 0xcb, 0xcb, 0xae, 0xdf, 0xa, 0x28, 0xa8, 0x6a, 0xfd, 0x61, 0x29, 0xc2, 0x60, 0xaf, 0xb7, 0x74, 0xfd, 0x0, 0x85, 0xb7}}
 	return a, nil
 }
@@ -276,7 +276,7 @@ func migrations18_account_for_signersSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/18_account_for_signers.sql", size: 481, mode: os.FileMode(0644), modTime: time.Unix(1566913223, 0)}
+	info := bindataFileInfo{name: "migrations/18_account_for_signers.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x37, 0xdc, 0xe4, 0xb4, 0xd5, 0xcc, 0x53, 0xd9, 0x42, 0x8c, 0x12, 0x37, 0xcf, 0x13, 0x2c, 0x47, 0xe, 0xc7, 0xba, 0xe5, 0xc2, 0x17, 0x73, 0xe2, 0xc, 0xd2, 0x4a, 0xb3, 0x62, 0x75, 0x54, 0x7f}}
 	return a, nil
 }
@@ -296,7 +296,7 @@ func migrations19_offersSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/19_offers.sql", size: 1064, mode: os.FileMode(0644), modTime: time.Unix(1572426892, 0)}
+	info := bindataFileInfo{name: "migrations/19_offers.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xbd, 0xff, 0xef, 0xfe, 0xb0, 0x5b, 0xa3, 0x92, 0xac, 0x9d, 0x98, 0x6c, 0xd4, 0x90, 0x9c, 0xe9, 0xae, 0x89, 0xfc, 0x54, 0x2b, 0xe3, 0x33, 0x1f, 0x0, 0xd6, 0x24, 0x9a, 0x1, 0xe1, 0xa6, 0x39}}
 	return a, nil
 }
@@ -316,7 +316,7 @@ func migrations1_initial_schemaSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/1_initial_schema.sql", size: 9977, mode: os.FileMode(0644), modTime: time.Unix(1576519637, 0)}
+	info := bindataFileInfo{name: "migrations/1_initial_schema.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x6d, 0xdd, 0xc3, 0x1d, 0x39, 0xb7, 0x5e, 0x6a, 0x64, 0x2b, 0xd5, 0x66, 0x83, 0x61, 0x79, 0xf7, 0x59, 0xce, 0x51, 0x66, 0x3c, 0xd0, 0xf3, 0x14, 0x35, 0xcd, 0x21, 0xc0, 0xae, 0x24, 0x84, 0x35}}
 	return a, nil
 }
@@ -336,7 +336,7 @@ func migrations20_account_for_signer_indexSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/20_account_for_signer_index.sql", size: 140, mode: os.FileMode(0644), modTime: time.Unix(1576519637, 0)}
+	info := bindataFileInfo{name: "migrations/20_account_for_signer_index.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7, 0xd5, 0x6a, 0x4f, 0x6a, 0x95, 0xe0, 0x16, 0xa8, 0x25, 0xd7, 0x4, 0xec, 0x85, 0xe9, 0x13, 0x33, 0x4c, 0x9a, 0xa8, 0x74, 0xf9, 0x63, 0x52, 0xa5, 0x18, 0xaa, 0xdb, 0x4, 0xb5, 0xf7, 0x6e}}
 	return a, nil
 }
@@ -356,7 +356,7 @@ func migrations21_trades_remove_zero_amount_constraintsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/21_trades_remove_zero_amount_constraints.sql", size: 765, mode: os.FileMode(0644), modTime: time.Unix(1572426892, 0)}
+	info := bindataFileInfo{name: "migrations/21_trades_remove_zero_amount_constraints.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x24, 0x1a, 0x4b, 0x15, 0xd5, 0xce, 0x4, 0xe9, 0x43, 0x61, 0x69, 0xce, 0xed, 0x82, 0x11, 0x4e, 0xc7, 0x58, 0xef, 0x4a, 0x46, 0xef, 0x2a, 0x28, 0x13, 0x5e, 0x59, 0xf0, 0x69, 0x50, 0x45, 0x84}}
 	return a, nil
 }
@@ -376,7 +376,7 @@ func migrations22_trust_linesSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/22_trust_lines.sql", size: 955, mode: os.FileMode(0644), modTime: time.Unix(1578941604, 0)}
+	info := bindataFileInfo{name: "migrations/22_trust_lines.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xe7, 0xd9, 0x90, 0x83, 0xc9, 0xb3, 0x1b, 0xc4, 0xe9, 0xc4, 0xbb, 0xcb, 0xb5, 0x92, 0x15, 0xaa, 0xef, 0x5d, 0x4e, 0xcf, 0x16, 0x6b, 0x49, 0xef, 0x85, 0x1a, 0xbf, 0xb6, 0x71, 0xb3, 0x92, 0x33}}
 	return a, nil
 }
@@ -396,7 +396,7 @@ func migrations23_exp_asset_statsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/23_exp_asset_stats.sql", size: 883, mode: os.FileMode(0644), modTime: time.Unix(1578941604, 0)}
+	info := bindataFileInfo{name: "migrations/23_exp_asset_stats.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x5f, 0x23, 0x96, 0xcb, 0x81, 0x52, 0xd5, 0xb, 0x3c, 0xd4, 0xb9, 0xd9, 0x24, 0xd3, 0x1a, 0x3d, 0x1a, 0xe0, 0xd2, 0x4, 0x40, 0xf5, 0x75, 0xe2, 0x1d, 0x26, 0xd3, 0x19, 0xcf, 0x70, 0xf, 0x36}}
 	return a, nil
 }
@@ -416,7 +416,7 @@ func migrations24_accountsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/24_accounts.sql", size: 1402, mode: os.FileMode(0644), modTime: time.Unix(1578941604, 0)}
+	info := bindataFileInfo{name: "migrations/24_accounts.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa5, 0xf8, 0xf7, 0xeb, 0xe2, 0x3d, 0xda, 0xe, 0xc2, 0x78, 0x88, 0x16, 0x22, 0xbf, 0x22, 0xa8, 0x5a, 0x17, 0x72, 0xd9, 0xab, 0x56, 0xa8, 0x55, 0x5a, 0x3f, 0x47, 0xf6, 0x18, 0xfa, 0x43, 0xa7}}
 	return a, nil
 }
@@ -436,7 +436,7 @@ func migrations25_expingest_rename_columnsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/25_expingest_rename_columns.sql", size: 641, mode: os.FileMode(0644), modTime: time.Unix(1578941604, 0)}
+	info := bindataFileInfo{name: "migrations/25_expingest_rename_columns.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x80, 0x44, 0x81, 0x62, 0xeb, 0xcf, 0x82, 0xaa, 0x9, 0x14, 0x4c, 0xb6, 0xd2, 0x2c, 0x41, 0x2d, 0xf0, 0x34, 0x4a, 0x18, 0x5a, 0x95, 0x3e, 0x8d, 0x60, 0xbe, 0x5, 0x10, 0xf5, 0xc2, 0x9c, 0x3a}}
 	return a, nil
 }
@@ -456,7 +456,7 @@ func migrations26_exp_history_ledgersSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/26_exp_history_ledgers.sql", size: 209, mode: os.FileMode(0644), modTime: time.Unix(1578941604, 0)}
+	info := bindataFileInfo{name: "migrations/26_exp_history_ledgers.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb0, 0xf9, 0xc6, 0xfd, 0xcb, 0x11, 0xc3, 0xc0, 0xbf, 0xac, 0x33, 0x8a, 0xc5, 0x8d, 0x47, 0xfd, 0x59, 0xd1, 0x1d, 0x69, 0x17, 0xba, 0xc7, 0xbb, 0xe6, 0x40, 0x58, 0x32, 0x14, 0x97, 0x96, 0x76}}
 	return a, nil
 }
@@ -476,7 +476,7 @@ func migrations27_exp_history_transactionsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/27_exp_history_transactions.sql", size: 630, mode: os.FileMode(0644), modTime: time.Unix(1579093592, 0)}
+	info := bindataFileInfo{name: "migrations/27_exp_history_transactions.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x13, 0xbf, 0x14, 0x32, 0x4a, 0xc, 0x39, 0x8a, 0xff, 0x9d, 0xaf, 0x3f, 0x8e, 0xb4, 0xe, 0xf2, 0x2b, 0x26, 0x67, 0xf6, 0xcd, 0x20, 0xe2, 0x5b, 0x98, 0x78, 0xc2, 0x10, 0xcc, 0x52, 0xd6, 0xc3}}
 	return a, nil
 }
@@ -496,7 +496,7 @@ func migrations28_exp_history_operationsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/28_exp_history_operations.sql", size: 439, mode: os.FileMode(0644), modTime: time.Unix(1578941604, 0)}
+	info := bindataFileInfo{name: "migrations/28_exp_history_operations.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x59, 0x2d, 0xc6, 0x70, 0x76, 0x72, 0xc5, 0xb1, 0xc6, 0xe7, 0xa0, 0xb2, 0xfc, 0x78, 0x71, 0xa, 0x43, 0x8e, 0x53, 0x9, 0x19, 0x10, 0xcb, 0x75, 0x3b, 0x66, 0x1, 0x57, 0x43, 0xd2, 0x8e, 0x89}}
 	return a, nil
 }
@@ -516,7 +516,7 @@ func migrations29_exp_history_assetsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/29_exp_history_assets.sql", size: 206, mode: os.FileMode(0644), modTime: time.Unix(1578941604, 0)}
+	info := bindataFileInfo{name: "migrations/29_exp_history_assets.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x25, 0xdf, 0x37, 0x6, 0x2c, 0x6e, 0x52, 0x9b, 0x16, 0x17, 0x9c, 0x29, 0x41, 0x41, 0xa6, 0x14, 0x59, 0xff, 0x29, 0xfa, 0x12, 0x2a, 0x8d, 0xce, 0x42, 0xad, 0xa6, 0x26, 0xef, 0x6f, 0x27, 0x17}}
 	return a, nil
 }
@@ -536,7 +536,7 @@ func migrations2_index_participants_by_toidSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/2_index_participants_by_toid.sql", size: 277, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/2_index_participants_by_toid.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xdd, 0x9f, 0x5c, 0xe6, 0xd0, 0x43, 0x82, 0xa3, 0x8d, 0xb3, 0x64, 0xb1, 0x2, 0x4b, 0xe1, 0x96, 0x3, 0x92, 0xb3, 0xea, 0x3c, 0x2e, 0xb2, 0xad, 0x47, 0xcd, 0x92, 0x4c, 0x6c, 0x5c, 0x46, 0xfd}}
 	return a, nil
 }
@@ -556,7 +556,7 @@ func migrations30_exp_history_tradesSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/30_exp_history_trades.sql", size: 2297, mode: os.FileMode(0644), modTime: time.Unix(1578941604, 0)}
+	info := bindataFileInfo{name: "migrations/30_exp_history_trades.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xaf, 0x32, 0xe, 0xc2, 0x9, 0x37, 0x62, 0x5f, 0x79, 0xfe, 0x3e, 0x11, 0x22, 0x66, 0x56, 0x36, 0x8, 0x0, 0x76, 0x70, 0xc3, 0x5c, 0x16, 0xe3, 0x2b, 0x73, 0x57, 0xe8, 0x38, 0x6c, 0x62, 0x1e}}
 	return a, nil
 }
@@ -576,7 +576,7 @@ func migrations31_exp_history_effectsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/31_exp_history_effects.sql", size: 209, mode: os.FileMode(0644), modTime: time.Unix(1578949976, 0)}
+	info := bindataFileInfo{name: "migrations/31_exp_history_effects.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xdf, 0x34, 0xf6, 0x6e, 0x86, 0x85, 0x4e, 0xfb, 0x74, 0xee, 0x7d, 0x4, 0xd2, 0xc7, 0x83, 0xae, 0x97, 0xab, 0xca, 0xe1, 0xb3, 0x7c, 0x25, 0xa8, 0x7f, 0x65, 0x2b, 0x1e, 0xdb, 0x88, 0x9b, 0xf}}
 	return a, nil
 }
@@ -596,7 +596,7 @@ func migrations32_drop_exp_history_tablesSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/32_drop_exp_history_tables.sql", size: 3826, mode: os.FileMode(0644), modTime: time.Unix(1579093894, 0)}
+	info := bindataFileInfo{name: "migrations/32_drop_exp_history_tables.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1d, 0xf2, 0xbb, 0xf, 0x6d, 0x53, 0xdf, 0x60, 0x63, 0x87, 0x3c, 0xe9, 0xdb, 0x18, 0x23, 0x51, 0x40, 0xa4, 0x38, 0xdf, 0xb2, 0x9a, 0xb, 0xa0, 0xe6, 0xbe, 0x91, 0x3b, 0x41, 0x53, 0x69, 0x9d}}
 	return a, nil
 }
@@ -616,7 +616,7 @@ func migrations3_use_sequence_in_history_accountsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/3_use_sequence_in_history_accounts.sql", size: 447, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/3_use_sequence_in_history_accounts.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x5, 0xcc, 0xcc, 0x51, 0xec, 0x12, 0x8, 0x85, 0x4d, 0x85, 0x25, 0x32, 0x18, 0x23, 0x54, 0xc5, 0x10, 0x42, 0x5b, 0x51, 0x28, 0xe4, 0x9, 0xa2, 0x56, 0xdc, 0xb5, 0xf8, 0x41, 0x1b, 0x28, 0x8}}
 	return a, nil
 }
@@ -636,7 +636,7 @@ func migrations4_add_protocol_versionSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/4_add_protocol_version.sql", size: 188, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/4_add_protocol_version.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x26, 0x7f, 0xb6, 0x87, 0x30, 0xa5, 0x8c, 0xee, 0x55, 0xbb, 0x12, 0x6, 0x1b, 0xee, 0xfc, 0x6a, 0xa0, 0x71, 0x60, 0xcc, 0xf7, 0x36, 0x56, 0xb3, 0x39, 0x1f, 0x1a, 0xd2, 0x6, 0xe4, 0x58, 0x8e}}
 	return a, nil
 }
@@ -656,7 +656,7 @@ func migrations5_create_trades_tableSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/5_create_trades_table.sql", size: 1100, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/5_create_trades_table.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x4f, 0x51, 0x6e, 0x49, 0x10, 0xd6, 0xf1, 0x48, 0xc6, 0x8d, 0xe5, 0xbe, 0x2, 0x94, 0xba, 0x20, 0x37, 0x7b, 0x10, 0x8b, 0x84, 0x7, 0xac, 0x1b, 0xb4, 0xac, 0xc3, 0x6d, 0xbc, 0x54, 0x81, 0xe3}}
 	return a, nil
 }
@@ -676,7 +676,7 @@ func migrations6_create_assets_tableSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/6_create_assets_table.sql", size: 366, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/6_create_assets_table.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb1, 0x3f, 0x47, 0xea, 0x8a, 0x5d, 0x60, 0xc8, 0x90, 0x36, 0xc8, 0x4f, 0x68, 0xc5, 0xd3, 0xa0, 0xcd, 0xae, 0x5a, 0xc3, 0x75, 0xbd, 0xb4, 0xbb, 0x51, 0xf2, 0x68, 0x54, 0x79, 0xac, 0xa2, 0x8a}}
 	return a, nil
 }
@@ -696,7 +696,7 @@ func migrations7_modify_trades_tableSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/7_modify_trades_table.sql", size: 2303, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/7_modify_trades_table.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb1, 0x2e, 0xba, 0x36, 0x5e, 0x3a, 0x3f, 0x3a, 0x8f, 0xe4, 0xfd, 0xc6, 0xb8, 0xeb, 0xbf, 0xda, 0x2b, 0xc6, 0xcd, 0xe3, 0xb5, 0x9a, 0x78, 0xf9, 0x9c, 0x2d, 0xcf, 0xe7, 0xb1, 0x6e, 0xa0, 0x3e}}
 	return a, nil
 }
@@ -716,7 +716,7 @@ func migrations8_add_aggregatorsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/8_add_aggregators.sql", size: 907, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/8_add_aggregators.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xae, 0xba, 0x87, 0x6f, 0x41, 0xf3, 0xf6, 0x28, 0x25, 0xc2, 0x19, 0xdf, 0x41, 0x9a, 0x4b, 0xf3, 0x8, 0x37, 0x29, 0x2b, 0x92, 0x12, 0x9f, 0xb5, 0x9f, 0x9d, 0x50, 0x82, 0x6, 0xa5, 0xbb, 0xf6}}
 	return a, nil
 }
@@ -736,7 +736,7 @@ func migrations8_create_asset_stats_tableSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/8_create_asset_stats_table.sql", size: 441, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/8_create_asset_stats_table.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x2d, 0x21, 0x5, 0xfc, 0x3f, 0xe0, 0xe1, 0xe6, 0x50, 0x2c, 0x25, 0xc0, 0x23, 0x87, 0xa3, 0x99, 0xad, 0xc8, 0xc1, 0x67, 0xca, 0x65, 0xc0, 0x91, 0xf6, 0x5c, 0x29, 0xab, 0x78, 0xbe, 0xe4, 0x5e}}
 	return a, nil
 }
@@ -756,7 +756,7 @@ func migrations9_add_header_xdrSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/9_add_header_xdr.sql", size: 161, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "migrations/9_add_header_xdr.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x44, 0xe5, 0x20, 0x47, 0xc8, 0x66, 0xd0, 0x16, 0xfa, 0xeb, 0xe, 0xba, 0x80, 0xbd, 0xc3, 0xa6, 0x0, 0x9e, 0xc, 0xb5, 0x45, 0xb9, 0x78, 0x26, 0x8, 0xef, 0x94, 0x23, 0xbe, 0x85, 0x2c, 0xe4}}
 	return a, nil
 }
@@ -852,71 +852,39 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"migrations/10_add_trades_price.sql": migrations10_add_trades_priceSql,
-
-	"migrations/11_add_trades_account_index.sql": migrations11_add_trades_account_indexSql,
-
-	"migrations/12_asset_stats_amount_string.sql": migrations12_asset_stats_amount_stringSql,
-
-	"migrations/13_trade_offer_ids.sql": migrations13_trade_offer_idsSql,
-
-	"migrations/14_fix_asset_toml_field.sql": migrations14_fix_asset_toml_fieldSql,
-
-	"migrations/15_ledger_failed_txs.sql": migrations15_ledger_failed_txsSql,
-
-	"migrations/16_ingest_failed_transactions.sql": migrations16_ingest_failed_transactionsSql,
-
-	"migrations/17_transaction_fee_paid.sql": migrations17_transaction_fee_paidSql,
-
-	"migrations/18_account_for_signers.sql": migrations18_account_for_signersSql,
-
-	"migrations/19_offers.sql": migrations19_offersSql,
-
-	"migrations/1_initial_schema.sql": migrations1_initial_schemaSql,
-
-	"migrations/20_account_for_signer_index.sql": migrations20_account_for_signer_indexSql,
-
+	"migrations/10_add_trades_price.sql":                      migrations10_add_trades_priceSql,
+	"migrations/11_add_trades_account_index.sql":              migrations11_add_trades_account_indexSql,
+	"migrations/12_asset_stats_amount_string.sql":             migrations12_asset_stats_amount_stringSql,
+	"migrations/13_trade_offer_ids.sql":                       migrations13_trade_offer_idsSql,
+	"migrations/14_fix_asset_toml_field.sql":                  migrations14_fix_asset_toml_fieldSql,
+	"migrations/15_ledger_failed_txs.sql":                     migrations15_ledger_failed_txsSql,
+	"migrations/16_ingest_failed_transactions.sql":            migrations16_ingest_failed_transactionsSql,
+	"migrations/17_transaction_fee_paid.sql":                  migrations17_transaction_fee_paidSql,
+	"migrations/18_account_for_signers.sql":                   migrations18_account_for_signersSql,
+	"migrations/19_offers.sql":                                migrations19_offersSql,
+	"migrations/1_initial_schema.sql":                         migrations1_initial_schemaSql,
+	"migrations/20_account_for_signer_index.sql":              migrations20_account_for_signer_indexSql,
 	"migrations/21_trades_remove_zero_amount_constraints.sql": migrations21_trades_remove_zero_amount_constraintsSql,
-
-	"migrations/22_trust_lines.sql": migrations22_trust_linesSql,
-
-	"migrations/23_exp_asset_stats.sql": migrations23_exp_asset_statsSql,
-
-	"migrations/24_accounts.sql": migrations24_accountsSql,
-
-	"migrations/25_expingest_rename_columns.sql": migrations25_expingest_rename_columnsSql,
-
-	"migrations/26_exp_history_ledgers.sql": migrations26_exp_history_ledgersSql,
-
-	"migrations/27_exp_history_transactions.sql": migrations27_exp_history_transactionsSql,
-
-	"migrations/28_exp_history_operations.sql": migrations28_exp_history_operationsSql,
-
-	"migrations/29_exp_history_assets.sql": migrations29_exp_history_assetsSql,
-
-	"migrations/2_index_participants_by_toid.sql": migrations2_index_participants_by_toidSql,
-
-	"migrations/30_exp_history_trades.sql": migrations30_exp_history_tradesSql,
-
-	"migrations/31_exp_history_effects.sql": migrations31_exp_history_effectsSql,
-
-	"migrations/32_drop_exp_history_tables.sql": migrations32_drop_exp_history_tablesSql,
-
-	"migrations/3_use_sequence_in_history_accounts.sql": migrations3_use_sequence_in_history_accountsSql,
-
-	"migrations/4_add_protocol_version.sql": migrations4_add_protocol_versionSql,
-
-	"migrations/5_create_trades_table.sql": migrations5_create_trades_tableSql,
-
-	"migrations/6_create_assets_table.sql": migrations6_create_assets_tableSql,
-
-	"migrations/7_modify_trades_table.sql": migrations7_modify_trades_tableSql,
-
-	"migrations/8_add_aggregators.sql": migrations8_add_aggregatorsSql,
-
-	"migrations/8_create_asset_stats_table.sql": migrations8_create_asset_stats_tableSql,
-
-	"migrations/9_add_header_xdr.sql": migrations9_add_header_xdrSql,
+	"migrations/22_trust_lines.sql":                           migrations22_trust_linesSql,
+	"migrations/23_exp_asset_stats.sql":                       migrations23_exp_asset_statsSql,
+	"migrations/24_accounts.sql":                              migrations24_accountsSql,
+	"migrations/25_expingest_rename_columns.sql":              migrations25_expingest_rename_columnsSql,
+	"migrations/26_exp_history_ledgers.sql":                   migrations26_exp_history_ledgersSql,
+	"migrations/27_exp_history_transactions.sql":              migrations27_exp_history_transactionsSql,
+	"migrations/28_exp_history_operations.sql":                migrations28_exp_history_operationsSql,
+	"migrations/29_exp_history_assets.sql":                    migrations29_exp_history_assetsSql,
+	"migrations/2_index_participants_by_toid.sql":             migrations2_index_participants_by_toidSql,
+	"migrations/30_exp_history_trades.sql":                    migrations30_exp_history_tradesSql,
+	"migrations/31_exp_history_effects.sql":                   migrations31_exp_history_effectsSql,
+	"migrations/32_drop_exp_history_tables.sql":               migrations32_drop_exp_history_tablesSql,
+	"migrations/3_use_sequence_in_history_accounts.sql":       migrations3_use_sequence_in_history_accountsSql,
+	"migrations/4_add_protocol_version.sql":                   migrations4_add_protocol_versionSql,
+	"migrations/5_create_trades_table.sql":                    migrations5_create_trades_tableSql,
+	"migrations/6_create_assets_table.sql":                    migrations6_create_assets_tableSql,
+	"migrations/7_modify_trades_table.sql":                    migrations7_modify_trades_tableSql,
+	"migrations/8_add_aggregators.sql":                        migrations8_add_aggregatorsSql,
+	"migrations/8_create_asset_stats_table.sql":               migrations8_create_asset_stats_tableSql,
+	"migrations/9_add_header_xdr.sql":                         migrations9_add_header_xdrSql,
 }
 
 // AssetDir returns the file names below a certain

--- a/services/horizon/internal/db2/schema/main.go
+++ b/services/horizon/internal/db2/schema/main.go
@@ -8,7 +8,7 @@ import (
 	migrate "github.com/rubenv/sql-migrate"
 )
 
-//go:generate go-bindata -pkg schema -o bindata.go migrations/
+//go:generate go-bindata -nometadata -pkg schema -o bindata.go migrations/
 
 // MigrateDir represents a direction in which to perform schema migrations.
 type MigrateDir string

--- a/services/horizon/internal/test/scenarios/bindata.go
+++ b/services/horizon/internal/test/scenarios/bindata.go
@@ -83,7 +83,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -91,7 +91,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 	if clErr != nil {
 		return nil, err
@@ -147,7 +147,7 @@ func account_mergeCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "account_merge-core.sql", size: 26849, mode: os.FileMode(0644), modTime: time.Unix(1582280708, 0)}
+	info := bindataFileInfo{name: "account_merge-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x33, 0x94, 0x5a, 0x86, 0xfc, 0x68, 0x89, 0x29, 0xf5, 0x4, 0x9e, 0x47, 0x87, 0xfb, 0x30, 0x69, 0xb, 0xab, 0x73, 0xe2, 0xf6, 0xe5, 0x6b, 0x70, 0x67, 0xf0, 0x2c, 0x48, 0x53, 0x41, 0x9e, 0x5c}}
 	return a, nil
 }
@@ -167,7 +167,7 @@ func account_mergeHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "account_merge-horizon.sql", size: 36385, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "account_merge-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x6a, 0x42, 0x81, 0x26, 0x5d, 0x26, 0xa6, 0x1d, 0xfe, 0x58, 0xa3, 0x33, 0xdf, 0x89, 0xc, 0x51, 0x78, 0x86, 0xa6, 0x67, 0x86, 0x3b, 0x81, 0x5d, 0x50, 0x17, 0x98, 0x2d, 0x50, 0x38, 0x62, 0xdf}}
 	return a, nil
 }
@@ -187,7 +187,7 @@ func allow_trustCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "allow_trust-core.sql", size: 43697, mode: os.FileMode(0644), modTime: time.Unix(1582280714, 0)}
+	info := bindataFileInfo{name: "allow_trust-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x95, 0x9, 0x9e, 0x40, 0xdb, 0x1c, 0x6c, 0xe1, 0x6c, 0xe5, 0x85, 0x12, 0x74, 0xfd, 0x5a, 0x81, 0x43, 0xb9, 0xc1, 0x6a, 0xee, 0xd4, 0xa9, 0xc7, 0x13, 0x94, 0x39, 0x18, 0x1, 0x51, 0xb3, 0xc}}
 	return a, nil
 }
@@ -207,7 +207,7 @@ func allow_trustHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "allow_trust-horizon.sql", size: 57667, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "allow_trust-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xcd, 0xf5, 0x95, 0x37, 0xf8, 0x65, 0x80, 0x8d, 0x5d, 0x12, 0xee, 0xb2, 0xa8, 0x5d, 0x1f, 0xf3, 0x93, 0x52, 0x51, 0x6, 0xb6, 0x3, 0x26, 0xa9, 0xae, 0x21, 0x9, 0xe8, 0x9f, 0xd5, 0x53, 0xb}}
 	return a, nil
 }
@@ -227,7 +227,7 @@ func asset_stat_accountCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_account-core.sql", size: 37928, mode: os.FileMode(0644), modTime: time.Unix(1582280725, 0)}
+	info := bindataFileInfo{name: "asset_stat_account-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x45, 0x9, 0xf5, 0x53, 0xcf, 0x8, 0xd0, 0xf8, 0x6, 0xf8, 0x22, 0xdb, 0x18, 0x2b, 0xef, 0x3a, 0xba, 0xd2, 0x49, 0xcf, 0x20, 0xd0, 0xd2, 0x2, 0x31, 0x7a, 0xb0, 0x4a, 0x3e, 0xaa, 0x84, 0x12}}
 	return a, nil
 }
@@ -247,7 +247,7 @@ func asset_stat_accountHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_account-horizon.sql", size: 50230, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "asset_stat_account-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xf7, 0xa8, 0xb, 0x52, 0x14, 0xea, 0x72, 0xb1, 0x31, 0x42, 0x61, 0x8, 0x11, 0x47, 0xa4, 0x23, 0xe8, 0x40, 0xb, 0xa8, 0x7c, 0xce, 0x5c, 0x49, 0x48, 0x16, 0xe2, 0xa7, 0x84, 0x5b, 0x61, 0xaa}}
 	return a, nil
 }
@@ -267,7 +267,7 @@ func asset_stat_operationsCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_operations-core.sql", size: 32058, mode: os.FileMode(0644), modTime: time.Unix(1582280731, 0)}
+	info := bindataFileInfo{name: "asset_stat_operations-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xfb, 0xa6, 0x32, 0xd9, 0xbd, 0x47, 0xfe, 0x7a, 0x51, 0x7f, 0x70, 0xfd, 0xd9, 0x48, 0x97, 0xb7, 0x6c, 0xc2, 0xc1, 0x8d, 0xda, 0x1, 0x75, 0x3b, 0xb0, 0xf5, 0x58, 0x7b, 0x65, 0xcf, 0xe, 0x6e}}
 	return a, nil
 }
@@ -287,7 +287,7 @@ func asset_stat_operationsHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_operations-horizon.sql", size: 44040, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "asset_stat_operations-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xfd, 0x37, 0xb2, 0xca, 0x86, 0xbf, 0x3b, 0x4a, 0x4f, 0x59, 0x7f, 0xa6, 0xd2, 0xf3, 0x93, 0x52, 0xd8, 0x3b, 0xf3, 0x83, 0x5b, 0xb0, 0x7f, 0xd2, 0x5a, 0xd1, 0xcd, 0xfe, 0xbb, 0xd8, 0x1e, 0x1a}}
 	return a, nil
 }
@@ -307,7 +307,7 @@ func asset_stat_trustlines_1CoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_trustlines_1-core.sql", size: 27224, mode: os.FileMode(0644), modTime: time.Unix(1582280736, 0)}
+	info := bindataFileInfo{name: "asset_stat_trustlines_1-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xdc, 0x1a, 0xe2, 0xd0, 0x43, 0xb2, 0xba, 0x66, 0x56, 0xad, 0xec, 0xc, 0x15, 0x96, 0x2a, 0xa2, 0x14, 0xcd, 0x99, 0xc7, 0xd9, 0x61, 0xfb, 0xea, 0x83, 0x4f, 0x34, 0xfb, 0xe6, 0x90, 0x40, 0x97}}
 	return a, nil
 }
@@ -327,7 +327,7 @@ func asset_stat_trustlines_1HorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_trustlines_1-horizon.sql", size: 36508, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "asset_stat_trustlines_1-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1c, 0xc8, 0x89, 0x76, 0x6f, 0xc3, 0xe9, 0x72, 0xcd, 0x1a, 0x85, 0x5f, 0x76, 0xc8, 0x79, 0xc2, 0xed, 0xdd, 0xeb, 0xcb, 0xe2, 0x5d, 0xec, 0xf4, 0x1b, 0xf0, 0xf5, 0x5d, 0xd5, 0x2a, 0xf4, 0x54}}
 	return a, nil
 }
@@ -347,7 +347,7 @@ func asset_stat_trustlines_2CoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_trustlines_2-core.sql", size: 29742, mode: os.FileMode(0644), modTime: time.Unix(1582280742, 0)}
+	info := bindataFileInfo{name: "asset_stat_trustlines_2-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x50, 0xa9, 0xf5, 0xe1, 0x9a, 0x6c, 0x6e, 0xa, 0x7a, 0xf2, 0xba, 0xb5, 0x44, 0xd6, 0x17, 0x66, 0xa9, 0x72, 0x53, 0x6e, 0x9e, 0xd2, 0x3e, 0x93, 0x10, 0xc3, 0xfd, 0x8, 0xd0, 0x41, 0xe6, 0x84}}
 	return a, nil
 }
@@ -367,7 +367,7 @@ func asset_stat_trustlines_2HorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_trustlines_2-horizon.sql", size: 39687, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "asset_stat_trustlines_2-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x92, 0x8d, 0x40, 0xca, 0xbe, 0xa3, 0x89, 0x15, 0x2, 0x2c, 0x76, 0xb0, 0x49, 0x86, 0x75, 0x73, 0xe, 0x1f, 0x27, 0x61, 0x20, 0xbe, 0x7d, 0x79, 0xdc, 0xa3, 0x28, 0x7d, 0x69, 0xd8, 0x4f, 0x4f}}
 	return a, nil
 }
@@ -387,7 +387,7 @@ func asset_stat_trustlines_3CoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_trustlines_3-core.sql", size: 29243, mode: os.FileMode(0644), modTime: time.Unix(1582280754, 0)}
+	info := bindataFileInfo{name: "asset_stat_trustlines_3-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc2, 0x79, 0xef, 0x37, 0xc2, 0x5a, 0x89, 0xc3, 0x5d, 0x2d, 0xe5, 0x45, 0x1a, 0x16, 0x8f, 0xa5, 0x61, 0xa8, 0xd6, 0xd3, 0x91, 0x6a, 0x5b, 0x6f, 0x72, 0x65, 0x72, 0x55, 0x61, 0x1b, 0x58, 0x1c}}
 	return a, nil
 }
@@ -407,7 +407,7 @@ func asset_stat_trustlines_3HorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_trustlines_3-horizon.sql", size: 39187, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "asset_stat_trustlines_3-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7f, 0x9f, 0x5f, 0x49, 0x4a, 0xc2, 0xe1, 0xa9, 0xdf, 0x24, 0x4f, 0xc, 0xf6, 0xc, 0x3, 0xe5, 0x1e, 0x90, 0xfd, 0xdf, 0x37, 0x98, 0xd5, 0x75, 0x56, 0x63, 0x47, 0x24, 0x3, 0xc5, 0x99, 0x42}}
 	return a, nil
 }
@@ -427,7 +427,7 @@ func asset_stat_trustlines_4CoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_trustlines_4-core.sql", size: 29240, mode: os.FileMode(0644), modTime: time.Unix(1582280759, 0)}
+	info := bindataFileInfo{name: "asset_stat_trustlines_4-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x99, 0x90, 0x4b, 0xfd, 0x36, 0xe8, 0x6c, 0x54, 0x63, 0x38, 0xf9, 0x80, 0x13, 0xa4, 0x89, 0x94, 0xb3, 0xbf, 0x36, 0x4, 0xbd, 0x3c, 0x64, 0x7c, 0x90, 0x57, 0xf1, 0x39, 0x1c, 0xcd, 0x89, 0xbb}}
 	return a, nil
 }
@@ -447,7 +447,7 @@ func asset_stat_trustlines_4HorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_trustlines_4-horizon.sql", size: 39180, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "asset_stat_trustlines_4-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x45, 0x56, 0x5c, 0xa3, 0x94, 0x24, 0x8, 0xe1, 0x88, 0xb2, 0x7d, 0xee, 0x23, 0x58, 0xc2, 0xb9, 0xa, 0x93, 0xbb, 0x6f, 0x29, 0x7d, 0xb9, 0x17, 0x3e, 0x6a, 0x66, 0x74, 0x6c, 0xbd, 0xa8, 0x52}}
 	return a, nil
 }
@@ -467,7 +467,7 @@ func asset_stat_trustlines_5CoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_trustlines_5-core.sql", size: 29926, mode: os.FileMode(0644), modTime: time.Unix(1582280764, 0)}
+	info := bindataFileInfo{name: "asset_stat_trustlines_5-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xe6, 0xc8, 0xbd, 0xe2, 0xaf, 0x2b, 0x28, 0xf7, 0x7e, 0xb, 0xc5, 0x83, 0x49, 0x5c, 0x39, 0x79, 0x1f, 0xfb, 0x87, 0x13, 0x10, 0xe8, 0xe1, 0x5, 0xad, 0xe5, 0x1d, 0xd3, 0xce, 0x8c, 0xf, 0x3e}}
 	return a, nil
 }
@@ -487,7 +487,7 @@ func asset_stat_trustlines_5HorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_trustlines_5-horizon.sql", size: 39887, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "asset_stat_trustlines_5-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x4c, 0x6, 0x91, 0x34, 0x61, 0xba, 0x8f, 0xef, 0xd6, 0x7, 0x77, 0x94, 0xd5, 0xd6, 0x97, 0x60, 0xa5, 0x4f, 0x1b, 0xf4, 0x64, 0x79, 0x33, 0xcb, 0xf9, 0xc4, 0x6f, 0xe1, 0xdf, 0xcd, 0x78, 0xd4}}
 	return a, nil
 }
@@ -507,7 +507,7 @@ func asset_stat_trustlines_6CoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_trustlines_6-core.sql", size: 29846, mode: os.FileMode(0644), modTime: time.Unix(1582280770, 0)}
+	info := bindataFileInfo{name: "asset_stat_trustlines_6-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa5, 0x34, 0x96, 0x3c, 0xb9, 0xf5, 0xae, 0xdc, 0xff, 0xb3, 0x8a, 0x77, 0xbd, 0x9f, 0x33, 0xec, 0x29, 0xf, 0x92, 0x72, 0x16, 0x33, 0xf9, 0xd0, 0xd9, 0x97, 0xf, 0xcc, 0x12, 0x52, 0xf9, 0xca}}
 	return a, nil
 }
@@ -527,7 +527,7 @@ func asset_stat_trustlines_6HorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_trustlines_6-horizon.sql", size: 40082, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "asset_stat_trustlines_6-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x4, 0x4c, 0x50, 0x7, 0xc6, 0x90, 0x59, 0x72, 0xba, 0x3c, 0xf, 0x5c, 0xd3, 0x4a, 0xc6, 0xc, 0x2a, 0x67, 0xad, 0x60, 0x8c, 0xe7, 0x41, 0x41, 0x93, 0xde, 0x5a, 0x0, 0x42, 0xa3, 0x1d, 0x38}}
 	return a, nil
 }
@@ -547,7 +547,7 @@ func asset_stat_trustlines_7CoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_trustlines_7-core.sql", size: 35896, mode: os.FileMode(0644), modTime: time.Unix(1582280774, 0)}
+	info := bindataFileInfo{name: "asset_stat_trustlines_7-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x40, 0x2a, 0x37, 0x68, 0x92, 0x30, 0x7e, 0x37, 0x45, 0x9, 0x4e, 0x9d, 0x3, 0xbb, 0x92, 0x8e, 0xc8, 0xd4, 0xca, 0xfc, 0x6f, 0xbf, 0x63, 0x2c, 0x62, 0x67, 0xb4, 0x6b, 0x47, 0x70, 0xab, 0x7f}}
 	return a, nil
 }
@@ -567,7 +567,7 @@ func asset_stat_trustlines_7HorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "asset_stat_trustlines_7-horizon.sql", size: 48894, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "asset_stat_trustlines_7-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xdb, 0xd4, 0x77, 0xbe, 0xee, 0xcc, 0x3c, 0xca, 0xea, 0xc4, 0xfa, 0xd4, 0x6b, 0xb3, 0x22, 0xf0, 0xab, 0x1e, 0x6a, 0xd8, 0x3f, 0x9f, 0x6b, 0x21, 0xf8, 0xd8, 0x55, 0xf2, 0xdf, 0x89, 0xa1, 0x4d}}
 	return a, nil
 }
@@ -587,7 +587,7 @@ func baseCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "base-core.sql", size: 29682, mode: os.FileMode(0644), modTime: time.Unix(1582279521, 0)}
+	info := bindataFileInfo{name: "base-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x0, 0x8a, 0xbb, 0x55, 0xdf, 0x5, 0x72, 0x31, 0x6b, 0x2b, 0x97, 0x6e, 0xb2, 0x8f, 0x30, 0xeb, 0x24, 0xce, 0xcf, 0x2c, 0xc9, 0xfa, 0xd0, 0xe9, 0x6a, 0xcd, 0xfc, 0xd5, 0x4, 0x74, 0xc8, 0xf1}}
 	return a, nil
 }
@@ -607,7 +607,7 @@ func baseHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "base-horizon.sql", size: 47813, mode: os.FileMode(0644), modTime: time.Unix(1579549172, 0)}
+	info := bindataFileInfo{name: "base-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x16, 0x5c, 0x14, 0xde, 0x13, 0xc4, 0x44, 0xaf, 0xdd, 0x2b, 0xcd, 0xeb, 0x61, 0x71, 0xa4, 0x80, 0xee, 0x80, 0x83, 0x49, 0x27, 0xd1, 0xb4, 0x51, 0xb6, 0x25, 0xf8, 0xde, 0xc2, 0xf4, 0x34, 0xa7}}
 	return a, nil
 }
@@ -627,7 +627,7 @@ func change_trustCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "change_trust-core.sql", size: 33073, mode: os.FileMode(0644), modTime: time.Unix(1582280791, 0)}
+	info := bindataFileInfo{name: "change_trust-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb8, 0xd6, 0xff, 0xe6, 0xf4, 0x97, 0x9d, 0x9b, 0x9a, 0xdd, 0x6e, 0x91, 0xe8, 0xcd, 0xd9, 0x21, 0xb, 0xf9, 0x76, 0x49, 0xb5, 0x6d, 0xb5, 0xf0, 0xed, 0xf6, 0x3d, 0x1b, 0x86, 0xe3, 0x10, 0xc0}}
 	return a, nil
 }
@@ -647,7 +647,7 @@ func change_trustHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "change_trust-horizon.sql", size: 43637, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "change_trust-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1d, 0x96, 0x8b, 0x86, 0xc7, 0x6e, 0xe1, 0x1d, 0x3f, 0xad, 0x87, 0x13, 0x5b, 0x2a, 0x75, 0xf6, 0x76, 0xcb, 0x1a, 0xf5, 0x10, 0x16, 0x27, 0xe8, 0x4f, 0xad, 0x45, 0xff, 0x8f, 0x83, 0x76, 0x7}}
 	return a, nil
 }
@@ -667,7 +667,7 @@ func core_database_schema_version_8CoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "core_database_schema_version_8-core.sql", size: 8369, mode: os.FileMode(0644), modTime: time.Unix(1582288477, 0)}
+	info := bindataFileInfo{name: "core_database_schema_version_8-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3c, 0xb2, 0xbe, 0x2b, 0xc5, 0xda, 0x4d, 0x87, 0x29, 0x0, 0xd6, 0xce, 0x75, 0x0, 0xf1, 0x66, 0x82, 0x9d, 0xe0, 0x3, 0x16, 0x1d, 0x3e, 0xf5, 0xbd, 0x2e, 0x23, 0x5a, 0x0, 0xf, 0x97, 0x45}}
 	return a, nil
 }
@@ -687,7 +687,7 @@ func core_database_schema_version_9CoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "core_database_schema_version_9-core.sql", size: 8029, mode: os.FileMode(0644), modTime: time.Unix(1582288483, 0)}
+	info := bindataFileInfo{name: "core_database_schema_version_9-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xcf, 0x88, 0x53, 0x36, 0x7b, 0x3, 0x68, 0x94, 0x19, 0xd7, 0x1e, 0x21, 0x32, 0x8b, 0x39, 0xb0, 0xcc, 0x38, 0x99, 0x5, 0x8b, 0x91, 0x78, 0x8, 0x7c, 0x74, 0x85, 0xdd, 0x4f, 0x60, 0x5c, 0xaa}}
 	return a, nil
 }
@@ -707,7 +707,7 @@ func failed_transactionsCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "failed_transactions-core.sql", size: 38723, mode: os.FileMode(0644), modTime: time.Unix(1582280798, 0)}
+	info := bindataFileInfo{name: "failed_transactions-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x71, 0xd6, 0x9, 0x26, 0x93, 0xa2, 0x88, 0x71, 0x30, 0x2b, 0xa6, 0x48, 0x4b, 0x5e, 0x63, 0xe7, 0x7, 0x3c, 0xd, 0x3a, 0x60, 0x28, 0xa4, 0x5a, 0x96, 0x20, 0x4f, 0x93, 0x22, 0xd0, 0x6, 0x85}}
 	return a, nil
 }
@@ -727,7 +727,7 @@ func failed_transactionsHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "failed_transactions-horizon.sql", size: 53068, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "failed_transactions-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x44, 0xa3, 0x77, 0x88, 0x74, 0xaf, 0xda, 0x48, 0xf7, 0x69, 0xce, 0x7, 0x1, 0x42, 0xd7, 0x87, 0x9d, 0xf, 0x21, 0x4c, 0x35, 0xc8, 0x1f, 0xa0, 0x53, 0x83, 0x79, 0x58, 0x87, 0x4a, 0x63, 0x17}}
 	return a, nil
 }
@@ -747,7 +747,7 @@ func ingest_asset_statsCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "ingest_asset_stats-core.sql", size: 61380, mode: os.FileMode(0644), modTime: time.Unix(1582280902, 0)}
+	info := bindataFileInfo{name: "ingest_asset_stats-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x2b, 0x45, 0xdc, 0x5f, 0xf9, 0xe2, 0xc2, 0x67, 0x7d, 0x36, 0x75, 0x28, 0x3a, 0xf5, 0xf6, 0x41, 0xd3, 0x51, 0xb, 0x88, 0x22, 0x87, 0x7b, 0x4c, 0xd9, 0x67, 0x8d, 0x94, 0x68, 0xa5, 0xb4, 0x4e}}
 	return a, nil
 }
@@ -767,7 +767,7 @@ func ingest_asset_statsHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "ingest_asset_stats-horizon.sql", size: 87473, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "ingest_asset_stats-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7c, 0xc3, 0x95, 0xa9, 0x3f, 0x82, 0xc5, 0xa, 0x14, 0x8e, 0x83, 0xe, 0x61, 0x73, 0x8e, 0x2e, 0x2e, 0xa3, 0xea, 0xaf, 0x66, 0x51, 0xf, 0x4b, 0x1f, 0x75, 0xf4, 0xf4, 0x60, 0xbe, 0x97, 0x77}}
 	return a, nil
 }
@@ -787,7 +787,7 @@ func kahuna2CoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "kahuna-2-core.sql", size: 29749, mode: os.FileMode(0644), modTime: time.Unix(1582280895, 0)}
+	info := bindataFileInfo{name: "kahuna-2-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd1, 0xdf, 0x34, 0xe8, 0xf4, 0xc8, 0x5c, 0xaf, 0xf1, 0xe4, 0xce, 0xe8, 0x8a, 0x3d, 0x82, 0x85, 0x81, 0x51, 0xef, 0x37, 0x5a, 0x94, 0xb7, 0xc2, 0xc5, 0xbe, 0xcd, 0x70, 0x48, 0x87, 0x52, 0xa5}}
 	return a, nil
 }
@@ -807,7 +807,7 @@ func kahuna2HorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "kahuna-2-horizon.sql", size: 37751, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "kahuna-2-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3, 0xfa, 0x9c, 0xf2, 0x8c, 0x24, 0x1b, 0xa9, 0xc2, 0x61, 0xd9, 0x3, 0xc8, 0x9b, 0xbd, 0x4d, 0x8b, 0xbb, 0xc1, 0xea, 0x79, 0xa9, 0x2a, 0xf2, 0xbe, 0x8f, 0xe5, 0xd9, 0x20, 0xe0, 0x50, 0x35}}
 	return a, nil
 }
@@ -827,7 +827,7 @@ func kahunaCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "kahuna-core.sql", size: 232639, mode: os.FileMode(0644), modTime: time.Unix(1582280890, 0)}
+	info := bindataFileInfo{name: "kahuna-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xfd, 0x62, 0x89, 0xc4, 0xf2, 0xd7, 0xac, 0xdb, 0xb2, 0xad, 0x87, 0xbf, 0x78, 0xf6, 0xb1, 0xe, 0x80, 0x32, 0xa, 0xa7, 0x60, 0x93, 0x97, 0x10, 0x2f, 0x93, 0x5b, 0x7f, 0x43, 0x3d, 0xed, 0xe2}}
 	return a, nil
 }
@@ -847,7 +847,7 @@ func kahunaHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "kahuna-horizon.sql", size: 300535, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "kahuna-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb4, 0x48, 0x50, 0x88, 0x16, 0xd7, 0x4e, 0x43, 0x58, 0x4e, 0x6c, 0x36, 0x6, 0xce, 0x9b, 0xd5, 0xa7, 0x49, 0xf6, 0x2, 0x4e, 0x20, 0xbe, 0xde, 0x65, 0x61, 0xdb, 0x92, 0xf4, 0xcd, 0x5d, 0x1e}}
 	return a, nil
 }
@@ -867,7 +867,7 @@ func non_native_paymentCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "non_native_payment-core.sql", size: 35893, mode: os.FileMode(0644), modTime: time.Unix(1582280885, 0)}
+	info := bindataFileInfo{name: "non_native_payment-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x51, 0x1a, 0xcf, 0x20, 0xe9, 0xa1, 0x9d, 0x8d, 0x64, 0xc3, 0x55, 0xad, 0x2d, 0xe8, 0x9f, 0xc3, 0x5e, 0x2d, 0xf1, 0x5a, 0x7e, 0xbe, 0xb1, 0x28, 0xd6, 0xe3, 0x62, 0x88, 0x78, 0x14, 0x39, 0xf4}}
 	return a, nil
 }
@@ -887,7 +887,7 @@ func non_native_paymentHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "non_native_payment-horizon.sql", size: 48887, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "non_native_payment-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x8, 0x16, 0x54, 0x57, 0x6c, 0x93, 0xcd, 0x35, 0xf6, 0x64, 0xf4, 0xf4, 0x2, 0xe5, 0xf0, 0x9b, 0x2, 0x63, 0xd1, 0xde, 0x6b, 0xf9, 0xb0, 0x57, 0x28, 0xd, 0xea, 0x95, 0x74, 0x8a, 0x1e, 0x79}}
 	return a, nil
 }
@@ -907,7 +907,7 @@ func offer_idsCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "offer_ids-core.sql", size: 61677, mode: os.FileMode(0644), modTime: time.Unix(1582280877, 0)}
+	info := bindataFileInfo{name: "offer_ids-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x92, 0x1b, 0xfb, 0xe, 0xea, 0x46, 0x2e, 0x96, 0x2a, 0x34, 0x8f, 0xac, 0xab, 0x46, 0xe, 0x62, 0x40, 0x4c, 0xbb, 0x7e, 0x7f, 0xce, 0xfd, 0xcc, 0xf3, 0xf, 0x8b, 0xed, 0xfb, 0x39, 0x96, 0xe8}}
 	return a, nil
 }
@@ -927,7 +927,7 @@ func offer_idsHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "offer_ids-horizon.sql", size: 84596, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "offer_ids-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x2f, 0xe4, 0xab, 0xb2, 0xe0, 0x6d, 0x60, 0x8, 0xb6, 0x5b, 0xe, 0xfd, 0xd, 0x36, 0xc0, 0x38, 0xf1, 0x98, 0xce, 0xb, 0xbb, 0x11, 0xf1, 0xf8, 0xa4, 0xd7, 0x66, 0xdc, 0x81, 0x27, 0x78, 0xc3}}
 	return a, nil
 }
@@ -947,7 +947,7 @@ func operation_fee_stats_1CoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "operation_fee_stats_1-core.sql", size: 48276, mode: os.FileMode(0644), modTime: time.Unix(1582280872, 0)}
+	info := bindataFileInfo{name: "operation_fee_stats_1-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc3, 0x9a, 0xb4, 0xd0, 0xf, 0x87, 0x5f, 0xa2, 0xfe, 0xd3, 0x59, 0xb0, 0x2e, 0xdd, 0x39, 0x30, 0x1c, 0xed, 0xb0, 0x10, 0x24, 0xad, 0x85, 0xb3, 0x5e, 0x67, 0xf3, 0x5, 0xb9, 0xcb, 0x5f, 0xf0}}
 	return a, nil
 }
@@ -967,7 +967,7 @@ func operation_fee_stats_1HorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "operation_fee_stats_1-horizon.sql", size: 65599, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "operation_fee_stats_1-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb2, 0x5b, 0x8b, 0x52, 0xf, 0x6f, 0x19, 0xb1, 0x1b, 0x6a, 0xe4, 0x80, 0x7, 0xc2, 0x46, 0x8a, 0xdf, 0xce, 0x59, 0x4a, 0x5a, 0xa8, 0xd8, 0x9c, 0x73, 0x9a, 0x79, 0xc2, 0x69, 0x44, 0x4b, 0x7f}}
 	return a, nil
 }
@@ -987,7 +987,7 @@ func operation_fee_stats_2CoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "operation_fee_stats_2-core.sql", size: 26671, mode: os.FileMode(0644), modTime: time.Unix(1582280866, 0)}
+	info := bindataFileInfo{name: "operation_fee_stats_2-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xdd, 0xc7, 0xd6, 0xbc, 0xfc, 0x17, 0xfe, 0x7d, 0x1e, 0x96, 0xdb, 0x72, 0x4, 0xb8, 0xee, 0x80, 0x8a, 0x8, 0xe8, 0xcc, 0x88, 0x26, 0x39, 0x0, 0xc2, 0x52, 0xf5, 0x18, 0xb9, 0x23, 0xb1, 0xf7}}
 	return a, nil
 }
@@ -1007,7 +1007,7 @@ func operation_fee_stats_2HorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "operation_fee_stats_2-horizon.sql", size: 31986, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "operation_fee_stats_2-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xaa, 0xba, 0xae, 0xf6, 0x67, 0xc5, 0xe9, 0x67, 0xf0, 0x37, 0xa8, 0x7e, 0x3d, 0x77, 0xb8, 0x1a, 0x80, 0x5, 0xfa, 0x42, 0xbd, 0x82, 0xe3, 0x80, 0x3e, 0x1b, 0xf3, 0x12, 0xe7, 0xf8, 0xe0, 0x10}}
 	return a, nil
 }
@@ -1027,7 +1027,7 @@ func operation_fee_stats_3CoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "operation_fee_stats_3-core.sql", size: 45051, mode: os.FileMode(0644), modTime: time.Unix(1582280861, 0)}
+	info := bindataFileInfo{name: "operation_fee_stats_3-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3d, 0xdd, 0xf, 0x58, 0x32, 0xe8, 0xc1, 0x6c, 0xc9, 0xc7, 0x4, 0x1b, 0xd3, 0xd0, 0xa0, 0x27, 0xfd, 0x2, 0xba, 0x15, 0xbe, 0xe5, 0xe, 0x92, 0x13, 0x93, 0xa7, 0x7e, 0xec, 0xaa, 0x98, 0x92}}
 	return a, nil
 }
@@ -1047,7 +1047,7 @@ func operation_fee_stats_3HorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "operation_fee_stats_3-horizon.sql", size: 58478, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "operation_fee_stats_3-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x80, 0x3b, 0xcf, 0x98, 0xf5, 0x64, 0xa2, 0xeb, 0x75, 0x3, 0xd7, 0xb0, 0xf8, 0xf6, 0xcd, 0x17, 0xc1, 0xd, 0xcf, 0x29, 0xfd, 0xcf, 0xa4, 0xb3, 0x99, 0x3b, 0x21, 0xb6, 0x70, 0x15, 0x7f, 0x94}}
 	return a, nil
 }
@@ -1067,7 +1067,7 @@ func order_booksCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "order_books-core.sql", size: 77742, mode: os.FileMode(0644), modTime: time.Unix(1582280851, 0)}
+	info := bindataFileInfo{name: "order_books-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x17, 0x90, 0xc0, 0x10, 0x33, 0xd8, 0x44, 0xd2, 0x10, 0x21, 0x24, 0xc, 0xed, 0xb6, 0xd6, 0x31, 0x5d, 0xec, 0xa8, 0x80, 0x3e, 0xd2, 0xb4, 0x5, 0x4a, 0x4e, 0x30, 0x71, 0x35, 0xc6, 0xf9, 0xeb}}
 	return a, nil
 }
@@ -1087,7 +1087,7 @@ func order_booksHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "order_books-horizon.sql", size: 99263, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "order_books-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x9a, 0xcd, 0x52, 0x9, 0x66, 0xea, 0xff, 0x38, 0x1b, 0x9f, 0xca, 0x42, 0x9f, 0x65, 0x1a, 0x26, 0xdd, 0x54, 0xc7, 0xc6, 0x41, 0xbb, 0xf7, 0x22, 0xc8, 0x2c, 0xfc, 0x37, 0xc8, 0xb, 0x75, 0xdf}}
 	return a, nil
 }
@@ -1107,7 +1107,7 @@ func order_books_310CoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "order_books_310-core.sql", size: 132118, mode: os.FileMode(0644), modTime: time.Unix(1582280856, 0)}
+	info := bindataFileInfo{name: "order_books_310-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x28, 0x94, 0x48, 0x4f, 0x7f, 0xf6, 0x68, 0xb5, 0x84, 0xf3, 0x47, 0xa8, 0x1f, 0x37, 0x37, 0x69, 0x9, 0xa7, 0x84, 0x48, 0xe6, 0xa2, 0x5, 0xa1, 0xeb, 0xad, 0x22, 0xa1, 0x2f, 0xa2, 0x3e, 0x82}}
 	return a, nil
 }
@@ -1127,7 +1127,7 @@ func order_books_310HorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "order_books_310-horizon.sql", size: 155941, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "order_books_310-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x34, 0x75, 0x19, 0xce, 0xa9, 0x7d, 0x80, 0x6b, 0xbf, 0x10, 0xcd, 0xf2, 0x8d, 0x80, 0x15, 0x25, 0xfc, 0xf3, 0xd3, 0x23, 0x30, 0x9, 0x62, 0x9c, 0x1e, 0x82, 0xfd, 0x92, 0x88, 0x3b, 0xec, 0x15}}
 	return a, nil
 }
@@ -1147,7 +1147,7 @@ func pathed_paymentCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "pathed_payment-core.sql", size: 52308, mode: os.FileMode(0644), modTime: time.Unix(1582280937, 0)}
+	info := bindataFileInfo{name: "pathed_payment-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x80, 0x88, 0xda, 0x2e, 0x31, 0x6, 0xa7, 0x5a, 0x61, 0xf6, 0x8, 0x67, 0x65, 0x55, 0x70, 0x60, 0xd1, 0x77, 0x3a, 0x68, 0xb3, 0x91, 0x3c, 0x4e, 0x18, 0x19, 0x6d, 0xed, 0x33, 0x65, 0xf7, 0x11}}
 	return a, nil
 }
@@ -1167,7 +1167,7 @@ func pathed_paymentHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "pathed_payment-horizon.sql", size: 74472, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "pathed_payment-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa1, 0x53, 0x38, 0xe, 0x6a, 0xea, 0x53, 0xb3, 0x51, 0x8c, 0x63, 0xc4, 0xc8, 0x43, 0x1b, 0xf7, 0x8b, 0x8c, 0x15, 0x3d, 0xba, 0x9, 0x8c, 0x3c, 0xf3, 0x46, 0xcf, 0xec, 0x6b, 0xc6, 0xc0, 0x3d}}
 	return a, nil
 }
@@ -1187,7 +1187,7 @@ func pathsCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "paths-core.sql", size: 119072, mode: os.FileMode(0644), modTime: time.Unix(1582280843, 0)}
+	info := bindataFileInfo{name: "paths-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x33, 0xc9, 0x9, 0x2e, 0xea, 0xe5, 0x46, 0x9, 0x75, 0x47, 0x49, 0x3d, 0xa7, 0xfe, 0x7c, 0xa2, 0xf3, 0xb, 0x4d, 0xab, 0x84, 0x3, 0x33, 0xd5, 0xf7, 0x84, 0x54, 0xc5, 0x2, 0x28, 0xf3, 0xf6}}
 	return a, nil
 }
@@ -1207,7 +1207,7 @@ func pathsHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "paths-horizon.sql", size: 159950, mode: os.FileMode(0644), modTime: time.Unix(1576519637, 0)}
+	info := bindataFileInfo{name: "paths-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xad, 0x8d, 0x3b, 0xfa, 0xb1, 0xa5, 0x25, 0x6d, 0x82, 0xa, 0x5, 0x31, 0xcf, 0x2b, 0xa6, 0x95, 0x18, 0x36, 0xf7, 0xbd, 0x67, 0xd6, 0x30, 0xed, 0x8f, 0x78, 0x9, 0xb3, 0x18, 0x4a, 0x65, 0x18}}
 	return a, nil
 }
@@ -1227,7 +1227,7 @@ func paths_strict_sendCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "paths_strict_send-core.sql", size: 70821, mode: os.FileMode(0644), modTime: time.Unix(1582280926, 0)}
+	info := bindataFileInfo{name: "paths_strict_send-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x8c, 0x85, 0x75, 0x4, 0x43, 0xc0, 0x16, 0x2b, 0x12, 0x7a, 0x4f, 0xcd, 0xc0, 0x70, 0xe5, 0x9c, 0xcc, 0xc9, 0xd3, 0xff, 0xd1, 0x9d, 0x32, 0xbb, 0xcc, 0x3c, 0xd1, 0xb0, 0x28, 0x7, 0xea, 0x89}}
 	return a, nil
 }
@@ -1247,7 +1247,7 @@ func paths_strict_sendHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "paths_strict_send-horizon.sql", size: 92631, mode: os.FileMode(0644), modTime: time.Unix(1576519637, 0)}
+	info := bindataFileInfo{name: "paths_strict_send-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x92, 0x78, 0x10, 0x66, 0x93, 0xbc, 0x69, 0x4e, 0xdb, 0x2f, 0x5d, 0xe1, 0x7b, 0x7d, 0x2c, 0xa5, 0xf7, 0x3d, 0x99, 0xd3, 0x9d, 0x54, 0x71, 0xe5, 0x90, 0xb9, 0x3, 0x3, 0xa9, 0x18, 0x89, 0x3}}
 	return a, nil
 }
@@ -1267,7 +1267,7 @@ func self_sendCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "self_send-core.sql", size: 25186, mode: os.FileMode(0644), modTime: time.Unix(1582280838, 0)}
+	info := bindataFileInfo{name: "self_send-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xab, 0x7b, 0x4c, 0x24, 0x3, 0x92, 0x60, 0xd9, 0xe, 0xd0, 0x74, 0x4c, 0xbd, 0x67, 0x8, 0x95, 0xf, 0xe7, 0x68, 0x62, 0x8e, 0x1d, 0xaf, 0x36, 0x99, 0x67, 0x72, 0x10, 0xfe, 0x47, 0xcd, 0xc3}}
 	return a, nil
 }
@@ -1287,7 +1287,7 @@ func self_sendHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "self_send-horizon.sql", size: 33348, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "self_send-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xcd, 0xcb, 0x5a, 0xd2, 0xdf, 0x14, 0xa8, 0xc3, 0x58, 0xcc, 0x9, 0xe2, 0x38, 0xf2, 0xc6, 0xe7, 0x3f, 0xb2, 0xfb, 0xa0, 0x1a, 0x21, 0xb4, 0x13, 0x5e, 0xee, 0xb1, 0xbc, 0x8, 0xcc, 0xe2, 0xb1}}
 	return a, nil
 }
@@ -1307,7 +1307,7 @@ func send_to_issuerCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "send_to_issuer-core.sql", size: 32414, mode: os.FileMode(0644), modTime: time.Unix(1582280833, 0)}
+	info := bindataFileInfo{name: "send_to_issuer-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xbe, 0xaf, 0xb3, 0x2c, 0xce, 0x7d, 0x4e, 0x8d, 0x65, 0xcf, 0x7c, 0xb8, 0xd4, 0xf1, 0xfe, 0xaf, 0xe3, 0x5b, 0x7b, 0xde, 0x1e, 0x2f, 0x45, 0xd7, 0x36, 0x89, 0x88, 0xf7, 0xeb, 0xee, 0x13, 0x1b}}
 	return a, nil
 }
@@ -1327,7 +1327,7 @@ func send_to_issuerHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "send_to_issuer-horizon.sql", size: 43662, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "send_to_issuer-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x6f, 0xa7, 0x64, 0x8, 0x60, 0xa3, 0x5a, 0x14, 0x35, 0xbe, 0x64, 0x93, 0xa1, 0x42, 0x4f, 0x1b, 0xf9, 0x41, 0xb2, 0x24, 0x56, 0x46, 0xa6, 0x5c, 0x5e, 0x45, 0xb0, 0xaa, 0x85, 0xb3, 0x3b, 0x2b}}
 	return a, nil
 }
@@ -1347,7 +1347,7 @@ func set_optionsCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "set_options-core.sql", size: 51466, mode: os.FileMode(0644), modTime: time.Unix(1582280822, 0)}
+	info := bindataFileInfo{name: "set_options-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x5b, 0x96, 0x60, 0x12, 0xa4, 0xa1, 0x5b, 0xe1, 0x7a, 0xc1, 0xe1, 0x79, 0x85, 0xe8, 0x98, 0x66, 0xba, 0x68, 0xd6, 0x80, 0x17, 0x32, 0xb3, 0x15, 0x45, 0x16, 0xb3, 0xf2, 0xc5, 0xfd, 0xb, 0xc0}}
 	return a, nil
 }
@@ -1367,7 +1367,7 @@ func set_optionsHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "set_options-horizon.sql", size: 63246, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "set_options-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x93, 0xbe, 0xeb, 0x77, 0xf6, 0xc, 0x4c, 0x7b, 0x2d, 0x28, 0x31, 0x9f, 0xc2, 0xf1, 0x51, 0xab, 0x3d, 0xec, 0xc, 0x49, 0xb7, 0x95, 0x9d, 0x4d, 0x2, 0xec, 0x27, 0xd3, 0xb2, 0xaf, 0x6, 0xd4}}
 	return a, nil
 }
@@ -1387,7 +1387,7 @@ func tradesCoreSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "trades-core.sql", size: 64752, mode: os.FileMode(0644), modTime: time.Unix(1582280674, 0)}
+	info := bindataFileInfo{name: "trades-core.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc4, 0xde, 0xb3, 0xd3, 0x7b, 0x3a, 0xd4, 0xf0, 0x49, 0x16, 0xa0, 0x61, 0xff, 0x88, 0x74, 0x6a, 0xce, 0xf9, 0x4, 0x30, 0x35, 0x69, 0x30, 0x58, 0xe, 0xd3, 0x5e, 0xf4, 0x60, 0xd9, 0x89, 0xfb}}
 	return a, nil
 }
@@ -1407,7 +1407,7 @@ func tradesHorizonSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "trades-horizon.sql", size: 84714, mode: os.FileMode(0644), modTime: time.Unix(1566825316, 0)}
+	info := bindataFileInfo{name: "trades-horizon.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc6, 0x86, 0xef, 0x76, 0xb6, 0xc3, 0x2, 0xd6, 0xdb, 0xeb, 0x43, 0x73, 0x26, 0x1c, 0x44, 0xc4, 0xb1, 0xfc, 0x9e, 0x25, 0x16, 0x54, 0x66, 0x42, 0x67, 0x19, 0xfe, 0x5f, 0xd3, 0xdc, 0x9e, 0x68}}
 	return a, nil
 }
@@ -1503,133 +1503,70 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"account_merge-core.sql": account_mergeCoreSql,
-
-	"account_merge-horizon.sql": account_mergeHorizonSql,
-
-	"allow_trust-core.sql": allow_trustCoreSql,
-
-	"allow_trust-horizon.sql": allow_trustHorizonSql,
-
-	"asset_stat_account-core.sql": asset_stat_accountCoreSql,
-
-	"asset_stat_account-horizon.sql": asset_stat_accountHorizonSql,
-
-	"asset_stat_operations-core.sql": asset_stat_operationsCoreSql,
-
-	"asset_stat_operations-horizon.sql": asset_stat_operationsHorizonSql,
-
-	"asset_stat_trustlines_1-core.sql": asset_stat_trustlines_1CoreSql,
-
-	"asset_stat_trustlines_1-horizon.sql": asset_stat_trustlines_1HorizonSql,
-
-	"asset_stat_trustlines_2-core.sql": asset_stat_trustlines_2CoreSql,
-
-	"asset_stat_trustlines_2-horizon.sql": asset_stat_trustlines_2HorizonSql,
-
-	"asset_stat_trustlines_3-core.sql": asset_stat_trustlines_3CoreSql,
-
-	"asset_stat_trustlines_3-horizon.sql": asset_stat_trustlines_3HorizonSql,
-
-	"asset_stat_trustlines_4-core.sql": asset_stat_trustlines_4CoreSql,
-
-	"asset_stat_trustlines_4-horizon.sql": asset_stat_trustlines_4HorizonSql,
-
-	"asset_stat_trustlines_5-core.sql": asset_stat_trustlines_5CoreSql,
-
-	"asset_stat_trustlines_5-horizon.sql": asset_stat_trustlines_5HorizonSql,
-
-	"asset_stat_trustlines_6-core.sql": asset_stat_trustlines_6CoreSql,
-
-	"asset_stat_trustlines_6-horizon.sql": asset_stat_trustlines_6HorizonSql,
-
-	"asset_stat_trustlines_7-core.sql": asset_stat_trustlines_7CoreSql,
-
-	"asset_stat_trustlines_7-horizon.sql": asset_stat_trustlines_7HorizonSql,
-
-	"base-core.sql": baseCoreSql,
-
-	"base-horizon.sql": baseHorizonSql,
-
-	"change_trust-core.sql": change_trustCoreSql,
-
-	"change_trust-horizon.sql": change_trustHorizonSql,
-
+	"account_merge-core.sql":                  account_mergeCoreSql,
+	"account_merge-horizon.sql":               account_mergeHorizonSql,
+	"allow_trust-core.sql":                    allow_trustCoreSql,
+	"allow_trust-horizon.sql":                 allow_trustHorizonSql,
+	"asset_stat_account-core.sql":             asset_stat_accountCoreSql,
+	"asset_stat_account-horizon.sql":          asset_stat_accountHorizonSql,
+	"asset_stat_operations-core.sql":          asset_stat_operationsCoreSql,
+	"asset_stat_operations-horizon.sql":       asset_stat_operationsHorizonSql,
+	"asset_stat_trustlines_1-core.sql":        asset_stat_trustlines_1CoreSql,
+	"asset_stat_trustlines_1-horizon.sql":     asset_stat_trustlines_1HorizonSql,
+	"asset_stat_trustlines_2-core.sql":        asset_stat_trustlines_2CoreSql,
+	"asset_stat_trustlines_2-horizon.sql":     asset_stat_trustlines_2HorizonSql,
+	"asset_stat_trustlines_3-core.sql":        asset_stat_trustlines_3CoreSql,
+	"asset_stat_trustlines_3-horizon.sql":     asset_stat_trustlines_3HorizonSql,
+	"asset_stat_trustlines_4-core.sql":        asset_stat_trustlines_4CoreSql,
+	"asset_stat_trustlines_4-horizon.sql":     asset_stat_trustlines_4HorizonSql,
+	"asset_stat_trustlines_5-core.sql":        asset_stat_trustlines_5CoreSql,
+	"asset_stat_trustlines_5-horizon.sql":     asset_stat_trustlines_5HorizonSql,
+	"asset_stat_trustlines_6-core.sql":        asset_stat_trustlines_6CoreSql,
+	"asset_stat_trustlines_6-horizon.sql":     asset_stat_trustlines_6HorizonSql,
+	"asset_stat_trustlines_7-core.sql":        asset_stat_trustlines_7CoreSql,
+	"asset_stat_trustlines_7-horizon.sql":     asset_stat_trustlines_7HorizonSql,
+	"base-core.sql":                           baseCoreSql,
+	"base-horizon.sql":                        baseHorizonSql,
+	"change_trust-core.sql":                   change_trustCoreSql,
+	"change_trust-horizon.sql":                change_trustHorizonSql,
 	"core_database_schema_version_8-core.sql": core_database_schema_version_8CoreSql,
-
 	"core_database_schema_version_9-core.sql": core_database_schema_version_9CoreSql,
-
-	"failed_transactions-core.sql": failed_transactionsCoreSql,
-
-	"failed_transactions-horizon.sql": failed_transactionsHorizonSql,
-
-	"ingest_asset_stats-core.sql": ingest_asset_statsCoreSql,
-
-	"ingest_asset_stats-horizon.sql": ingest_asset_statsHorizonSql,
-
-	"kahuna-2-core.sql": kahuna2CoreSql,
-
-	"kahuna-2-horizon.sql": kahuna2HorizonSql,
-
-	"kahuna-core.sql": kahunaCoreSql,
-
-	"kahuna-horizon.sql": kahunaHorizonSql,
-
-	"non_native_payment-core.sql": non_native_paymentCoreSql,
-
-	"non_native_payment-horizon.sql": non_native_paymentHorizonSql,
-
-	"offer_ids-core.sql": offer_idsCoreSql,
-
-	"offer_ids-horizon.sql": offer_idsHorizonSql,
-
-	"operation_fee_stats_1-core.sql": operation_fee_stats_1CoreSql,
-
-	"operation_fee_stats_1-horizon.sql": operation_fee_stats_1HorizonSql,
-
-	"operation_fee_stats_2-core.sql": operation_fee_stats_2CoreSql,
-
-	"operation_fee_stats_2-horizon.sql": operation_fee_stats_2HorizonSql,
-
-	"operation_fee_stats_3-core.sql": operation_fee_stats_3CoreSql,
-
-	"operation_fee_stats_3-horizon.sql": operation_fee_stats_3HorizonSql,
-
-	"order_books-core.sql": order_booksCoreSql,
-
-	"order_books-horizon.sql": order_booksHorizonSql,
-
-	"order_books_310-core.sql": order_books_310CoreSql,
-
-	"order_books_310-horizon.sql": order_books_310HorizonSql,
-
-	"pathed_payment-core.sql": pathed_paymentCoreSql,
-
-	"pathed_payment-horizon.sql": pathed_paymentHorizonSql,
-
-	"paths-core.sql": pathsCoreSql,
-
-	"paths-horizon.sql": pathsHorizonSql,
-
-	"paths_strict_send-core.sql": paths_strict_sendCoreSql,
-
-	"paths_strict_send-horizon.sql": paths_strict_sendHorizonSql,
-
-	"self_send-core.sql": self_sendCoreSql,
-
-	"self_send-horizon.sql": self_sendHorizonSql,
-
-	"send_to_issuer-core.sql": send_to_issuerCoreSql,
-
-	"send_to_issuer-horizon.sql": send_to_issuerHorizonSql,
-
-	"set_options-core.sql": set_optionsCoreSql,
-
-	"set_options-horizon.sql": set_optionsHorizonSql,
-
-	"trades-core.sql": tradesCoreSql,
-
-	"trades-horizon.sql": tradesHorizonSql,
+	"failed_transactions-core.sql":            failed_transactionsCoreSql,
+	"failed_transactions-horizon.sql":         failed_transactionsHorizonSql,
+	"ingest_asset_stats-core.sql":             ingest_asset_statsCoreSql,
+	"ingest_asset_stats-horizon.sql":          ingest_asset_statsHorizonSql,
+	"kahuna-2-core.sql":                       kahuna2CoreSql,
+	"kahuna-2-horizon.sql":                    kahuna2HorizonSql,
+	"kahuna-core.sql":                         kahunaCoreSql,
+	"kahuna-horizon.sql":                      kahunaHorizonSql,
+	"non_native_payment-core.sql":             non_native_paymentCoreSql,
+	"non_native_payment-horizon.sql":          non_native_paymentHorizonSql,
+	"offer_ids-core.sql":                      offer_idsCoreSql,
+	"offer_ids-horizon.sql":                   offer_idsHorizonSql,
+	"operation_fee_stats_1-core.sql":          operation_fee_stats_1CoreSql,
+	"operation_fee_stats_1-horizon.sql":       operation_fee_stats_1HorizonSql,
+	"operation_fee_stats_2-core.sql":          operation_fee_stats_2CoreSql,
+	"operation_fee_stats_2-horizon.sql":       operation_fee_stats_2HorizonSql,
+	"operation_fee_stats_3-core.sql":          operation_fee_stats_3CoreSql,
+	"operation_fee_stats_3-horizon.sql":       operation_fee_stats_3HorizonSql,
+	"order_books-core.sql":                    order_booksCoreSql,
+	"order_books-horizon.sql":                 order_booksHorizonSql,
+	"order_books_310-core.sql":                order_books_310CoreSql,
+	"order_books_310-horizon.sql":             order_books_310HorizonSql,
+	"pathed_payment-core.sql":                 pathed_paymentCoreSql,
+	"pathed_payment-horizon.sql":              pathed_paymentHorizonSql,
+	"paths-core.sql":                          pathsCoreSql,
+	"paths-horizon.sql":                       pathsHorizonSql,
+	"paths_strict_send-core.sql":              paths_strict_sendCoreSql,
+	"paths_strict_send-horizon.sql":           paths_strict_sendHorizonSql,
+	"self_send-core.sql":                      self_sendCoreSql,
+	"self_send-horizon.sql":                   self_sendHorizonSql,
+	"send_to_issuer-core.sql":                 send_to_issuerCoreSql,
+	"send_to_issuer-horizon.sql":              send_to_issuerHorizonSql,
+	"set_options-core.sql":                    set_optionsCoreSql,
+	"set_options-horizon.sql":                 set_optionsHorizonSql,
+	"trades-core.sql":                         tradesCoreSql,
+	"trades-horizon.sql":                      tradesHorizonSql,
 }
 
 // AssetDir returns the file names below a certain

--- a/services/horizon/internal/test/scenarios/main.go
+++ b/services/horizon/internal/test/scenarios/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-//go:generate go-bindata -ignore (go|rb)$ -pkg scenarios .
+//go:generate go-bindata -nometadata -ignore (go|rb)$ -pkg scenarios .
 
 // Load executes the sql script at `path` on postgres database at `url`
 func Load(url string, path string) {

--- a/services/ticker/internal/gql/static/bindata.go
+++ b/services/ticker/internal/gql/static/bindata.go
@@ -21,7 +21,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -29,7 +29,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 	if clErr != nil {
 		return nil, err
@@ -85,7 +85,7 @@ func graphiqlHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "graphiql.html", size: 1182, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "graphiql.html", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x76, 0x8, 0xb4, 0x3a, 0xe7, 0xdb, 0xc8, 0x3d, 0x2d, 0x1f, 0x1c, 0x2d, 0xd3, 0x9b, 0xf2, 0xd8, 0xe5, 0xd6, 0x5f, 0x3a, 0x7c, 0x6d, 0x80, 0xf7, 0x40, 0xdc, 0x58, 0xf1, 0x75, 0xbd, 0xf0, 0xa1}}
 	return a, nil
 }
@@ -105,7 +105,7 @@ func schemaGql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "schema.gql", size: 2400, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "schema.gql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xfd, 0x3d, 0xe4, 0xa2, 0xd5, 0x7, 0x41, 0x33, 0x61, 0xf8, 0x67, 0x0, 0xc5, 0x7a, 0xc, 0xa7, 0x4f, 0x6a, 0xed, 0x86, 0x2c, 0x82, 0xcf, 0x5d, 0x9e, 0xd, 0xa3, 0x1a, 0x5e, 0xd, 0xc2, 0x2f}}
 	return a, nil
 }
@@ -202,8 +202,7 @@ func AssetNames() []string {
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
 	"graphiql.html": graphiqlHtml,
-
-	"schema.gql": schemaGql,
+	"schema.gql":    schemaGql,
 }
 
 // AssetDir returns the file names below a certain

--- a/services/ticker/internal/gql/static/schema.go
+++ b/services/ticker/internal/gql/static/schema.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-//go:generate go-bindata -ignore=\.go -pkg=static -o=bindata.go ./...
+//go:generate go-bindata -nometadata -ignore=\.go -pkg=static -o=bindata.go ./...
 
 // Schema reads the .gql schema files from the generated _bindata.go file, concatenating the
 // files together into one string.

--- a/services/ticker/internal/tickerdb/main.go
+++ b/services/ticker/internal/tickerdb/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stellar/go/support/db"
 )
 
-//go:generate go-bindata -ignore .+\.go$ -pkg bdata -o migrations/bindata.go ./...
+//go:generate go-bindata -nometadata -ignore .+\.go$ -pkg bdata -o migrations/bindata.go ./...
 
 // TickerSession provides helper methods for making queries against `DB`.
 type TickerSession struct {

--- a/services/ticker/internal/tickerdb/migrations/bindata.go
+++ b/services/ticker/internal/tickerdb/migrations/bindata.go
@@ -29,7 +29,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -37,7 +37,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 	if clErr != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func migrations20190404184050InitialSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/20190404184050-initial.sql", size: 821, mode: os.FileMode(0644), modTime: time.Unix(1566474118, 0)}
+	info := bindataFileInfo{name: "migrations/20190404184050-initial.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x48, 0xaa, 0xc8, 0x33, 0x90, 0xe0, 0xbb, 0xf3, 0xa8, 0x5c, 0xb6, 0x9b, 0x50, 0xfb, 0xcb, 0x43, 0x16, 0x5d, 0x4d, 0xbd, 0x24, 0xec, 0xda, 0x11, 0x2d, 0x5c, 0x5f, 0xe, 0x7c, 0xaf, 0xd9, 0xb3}}
 	return a, nil
 }
@@ -113,7 +113,7 @@ func migrations20190405112544Increase_asset_code_sizeSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/20190405112544-increase_asset_code_size.sql", size: 366, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/20190405112544-increase_asset_code_size.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa1, 0x95, 0x4e, 0xf5, 0x5, 0xec, 0xe3, 0x22, 0x80, 0x7a, 0x8e, 0xdc, 0xda, 0x65, 0x26, 0x33, 0xea, 0x37, 0xb7, 0xd0, 0x59, 0x70, 0xe, 0x61, 0x6a, 0xe8, 0x44, 0x7e, 0x9, 0x1, 0x43, 0x46}}
 	return a, nil
 }
@@ -133,7 +133,7 @@ func migrations20190408115724Add_new_asset_fieldsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/20190408115724-add_new_asset_fields.sql", size: 1371, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/20190408115724-add_new_asset_fields.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc1, 0xe2, 0x30, 0xe, 0x77, 0x54, 0xdb, 0xeb, 0xc5, 0xb0, 0x0, 0xac, 0x7b, 0xf2, 0xc8, 0xc8, 0x77, 0xb8, 0xa3, 0x8f, 0x56, 0xf2, 0x7a, 0xa, 0x7f, 0x11, 0xa6, 0x76, 0x54, 0x87, 0x5, 0x80}}
 	return a, nil
 }
@@ -153,7 +153,7 @@ func migrations20190408155841Add_issuers_tableSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/20190408155841-add_issuers_table.sql", size: 950, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/20190408155841-add_issuers_table.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7b, 0xc6, 0x44, 0x9b, 0x7f, 0x20, 0x98, 0x1, 0xc2, 0x25, 0x17, 0x73, 0x3b, 0x41, 0xb1, 0xc4, 0xbe, 0xe4, 0x94, 0xd8, 0x54, 0x9c, 0x6e, 0x6e, 0xd0, 0x38, 0x7a, 0xbf, 0x24, 0xd9, 0x26, 0x6e}}
 	return a, nil
 }
@@ -173,7 +173,7 @@ func migrations20190409152216Add_trades_tableSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/20190409152216-add_trades_table.sql", size: 628, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/20190409152216-add_trades_table.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x47, 0xc1, 0xda, 0x1d, 0x61, 0x7c, 0xb6, 0x5d, 0x7d, 0xed, 0x2a, 0xd0, 0x8e, 0x4e, 0x24, 0x3d, 0x94, 0xd8, 0x88, 0x47, 0x2d, 0x5b, 0x65, 0xc1, 0x57, 0xf, 0xc6, 0x22, 0x39, 0xf7, 0xe9, 0x81}}
 	return a, nil
 }
@@ -193,7 +193,7 @@ func migrations20190409172610Rename_assets_desc_descriptionSql() (*asset, error)
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/20190409172610-rename_assets_desc_description.sql", size: 168, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/20190409172610-rename_assets_desc_description.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa7, 0x71, 0xc8, 0x2f, 0x71, 0x22, 0xa8, 0x42, 0x2b, 0xa, 0x0, 0x5, 0x51, 0x15, 0x9, 0x8b, 0xd6, 0x45, 0x72, 0x29, 0x8e, 0x38, 0x9d, 0x9f, 0x16, 0x84, 0x7b, 0xf, 0x29, 0x48, 0x3c, 0x3f}}
 	return a, nil
 }
@@ -213,7 +213,7 @@ func migrations20190410094830Add_assets_issuer_account_fieldSql() (*asset, error
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/20190410094830-add_assets_issuer_account_field.sql", size: 344, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/20190410094830-add_assets_issuer_account_field.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x2, 0xed, 0xce, 0xda, 0x59, 0x78, 0xcb, 0xa0, 0x4c, 0xd2, 0x4a, 0x45, 0x42, 0x10, 0x70, 0xc0, 0xbe, 0x2b, 0x11, 0x6c, 0x85, 0x92, 0x0, 0xdd, 0xd9, 0xb1, 0x74, 0x79, 0x30, 0x78, 0xfc, 0x4}}
 	return a, nil
 }
@@ -233,7 +233,7 @@ func migrations20190411165735Data_seed_and_indicesSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/20190411165735-data_seed_and_indices.sql", size: 1522, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/20190411165735-data_seed_and_indices.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa1, 0x54, 0x4a, 0x71, 0x6e, 0x9c, 0xc8, 0x5f, 0xd, 0xd6, 0xfc, 0x34, 0x65, 0x24, 0x53, 0xa1, 0x90, 0xf9, 0x33, 0x66, 0x76, 0x3a, 0x62, 0x69, 0xc6, 0x47, 0xea, 0x4f, 0xfd, 0x4c, 0xe, 0x96}}
 	return a, nil
 }
@@ -253,7 +253,7 @@ func migrations20190425110313Add_orderbook_statsSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/20190425110313-add_orderbook_stats.sql", size: 749, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/20190425110313-add_orderbook_stats.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x87, 0xb0, 0x88, 0x90, 0x9, 0x84, 0x2b, 0xf7, 0x33, 0xa4, 0x8c, 0x91, 0xc8, 0x6a, 0x90, 0x7b, 0x6b, 0x28, 0x70, 0x69, 0xf7, 0x1, 0x8c, 0x89, 0xa1, 0xe3, 0x11, 0xc0, 0x5e, 0x8f, 0x47, 0x0}}
 	return a, nil
 }
@@ -273,7 +273,7 @@ func migrations20190426092321Add_aggregated_orderbook_viewSql() (*asset, error) 
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/20190426092321-add_aggregated_orderbook_view.sql", size: 831, mode: os.FileMode(0644), modTime: time.Unix(1559692126, 0)}
+	info := bindataFileInfo{name: "migrations/20190426092321-add_aggregated_orderbook_view.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xca, 0xb7, 0xc5, 0x31, 0xb1, 0x11, 0xad, 0xf1, 0x3e, 0x39, 0x2, 0x77, 0x17, 0xb8, 0xb7, 0x6b, 0xb2, 0x37, 0x56, 0x71, 0x49, 0xc9, 0x56, 0x43, 0xc5, 0x18, 0x54, 0xae, 0xd1, 0xbb, 0xa4, 0x5e}}
 	return a, nil
 }
@@ -369,25 +369,16 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"migrations/20190404184050-initial.sql": migrations20190404184050InitialSql,
-
-	"migrations/20190405112544-increase_asset_code_size.sql": migrations20190405112544Increase_asset_code_sizeSql,
-
-	"migrations/20190408115724-add_new_asset_fields.sql": migrations20190408115724Add_new_asset_fieldsSql,
-
-	"migrations/20190408155841-add_issuers_table.sql": migrations20190408155841Add_issuers_tableSql,
-
-	"migrations/20190409152216-add_trades_table.sql": migrations20190409152216Add_trades_tableSql,
-
-	"migrations/20190409172610-rename_assets_desc_description.sql": migrations20190409172610Rename_assets_desc_descriptionSql,
-
+	"migrations/20190404184050-initial.sql":                         migrations20190404184050InitialSql,
+	"migrations/20190405112544-increase_asset_code_size.sql":        migrations20190405112544Increase_asset_code_sizeSql,
+	"migrations/20190408115724-add_new_asset_fields.sql":            migrations20190408115724Add_new_asset_fieldsSql,
+	"migrations/20190408155841-add_issuers_table.sql":               migrations20190408155841Add_issuers_tableSql,
+	"migrations/20190409152216-add_trades_table.sql":                migrations20190409152216Add_trades_tableSql,
+	"migrations/20190409172610-rename_assets_desc_description.sql":  migrations20190409172610Rename_assets_desc_descriptionSql,
 	"migrations/20190410094830-add_assets_issuer_account_field.sql": migrations20190410094830Add_assets_issuer_account_fieldSql,
-
-	"migrations/20190411165735-data_seed_and_indices.sql": migrations20190411165735Data_seed_and_indicesSql,
-
-	"migrations/20190425110313-add_orderbook_stats.sql": migrations20190425110313Add_orderbook_statsSql,
-
-	"migrations/20190426092321-add_aggregated_orderbook_view.sql": migrations20190426092321Add_aggregated_orderbook_viewSql,
+	"migrations/20190411165735-data_seed_and_indices.sql":           migrations20190411165735Data_seed_and_indicesSql,
+	"migrations/20190425110313-add_orderbook_stats.sql":             migrations20190425110313Add_orderbook_statsSql,
+	"migrations/20190426092321-add_aggregated_orderbook_view.sql":   migrations20190426092321Add_aggregated_orderbook_viewSql,
 }
 
 // AssetDir returns the file names below a certain


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Disable including file metadata in Go files that are generated using
the go-bindata tool.

### Why
The go-bindata tool takes files and puts them into Go files so that our
applications can be compiled with all their dependency files built
within them.

The go-bindata tool by default will store metadata alongside the
contents of files. The metadata includes the size of the file, the
permissions the file had, and the modified timestamp of the file. This
metadata is irrelevant to us because we only use go-bindata with
database migrations and the contents of the file is the only thing that
matters to us.

Because the metadata contains the modified timestamp everytime we do a
git checkout the modified timestamp changes and the generated files
change. This means that checking out the repo and running `go generate`
always results in a diff of more files than require updating.

Since we do not use the metadata disabling it is the simplest approach
to keeping our generated files stable. Once this change has been made we
will be able to run go generate without unnecessary diffs and we will be
able to add a go generate check to our CI build process to make sure
that PRs aren't merged without code generation being updated if they
need it.

### Known limitations

N/A