### PR TITLE
all: run go generate during ci builds to check all files updated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,14 @@ commands:
           name: Run gofmt
           command: ./gofmt.sh
 
+  # gogenerate validates that any generated code has been updated if needed.
+  gogenerate:
+    steps:
+      - checkout
+      - run:
+          name: Check generated code
+          command: ./gogenerate.sh
+
   # govet does govet checks in the entire codebase.
   govet:
     steps:
@@ -144,6 +152,7 @@ jobs:
       - install_go_deps
       - check_go_deps
       - gofmt
+      - gogenerate
       - govet
       - staticcheck
 

--- a/gogenerate.sh
+++ b/gogenerate.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+set -e
+
+# Check if go-bindata is installed, if not install it.
+command -v go-bindata >/dev/null 2>&1 || (
+  dir=$(mktemp -d)
+  pushd $dir
+  go mod init tool
+  go get github.com/kevinburke/go-bindata/go-bindata@v3.18.0+incompatible
+  popd
+)
+
+printf "Running go generate...\n"
+go generate ./...
+
+printf "Checking for no diff...\n"
+git diff --exit-code || (echo "Files changed after running go generate. Run go generate ./... locally and update generated files." && exit 1)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Run `go generate` during ci builds.

### Why
We use `go generate` to trigger builds of our bindata files for SQL
migrations but we don't have any broad checks on CI that ensure that the
generated files are up to date. This ensures whenever we make a change
to an input file to code generation that the generated file is updated
in the same change/pull-request.

We achieve this to some degree in some apps, like Horizon, where we have
a test that checks that the generated data bytes match the bytes on
disk, but this is only in one app, requires us to write a test in each
app, and doesn't prevent diffs caused by environmental changes like us
upgrading the version of the go-bindata tool.

### Known limitations

[TODO or N/A]
