### PR TITLE
services/horizon/internal/db2/history: Mitigate deadlock when running reingest range

### DIFF
--- a/services/horizon/internal/actions/asset_test.go
+++ b/services/horizon/internal/actions/asset_test.go
@@ -219,9 +219,10 @@ func TestAssetStats(t *testing.T) {
 		if err := accountEntry.AccountId.SetAddress(account.AccountID); err != nil {
 			t.Fatalf("unexpected error %v", err)
 		}
-		numChanged, err := q.InsertAccount(accountEntry, 3)
+		batch := q.NewAccountsBatchInsertBuilder(0)
+		err := batch.Add(accountEntry, 3)
 		tt.Assert.NoError(err)
-		tt.Assert.Equal(numChanged, int64(1))
+		tt.Assert.NoError(batch.Exec())
 	}
 
 	for _, testCase := range []struct {

--- a/services/horizon/internal/db2/history/account.go
+++ b/services/horizon/internal/db2/history/account.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"sort"
+
 	sq "github.com/Masterminds/squirrel"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/support/db"
@@ -59,6 +61,9 @@ func (q *Q) CreateAccounts(addresses []string, batchSize int) (map[string]int64,
 		Suffix:       "ON CONFLICT (address) DO NOTHING",
 	}
 
+	// sort assets before inserting rows into history_assets to prevent deadlocks on acquiring a ShareLock
+	// https://github.com/stellar/go/issues/2370
+	sort.Strings(addresses)
 	for _, address := range addresses {
 		err := builder.Row(map[string]interface{}{
 			"address": address,

--- a/services/horizon/internal/db2/history/account.go
+++ b/services/horizon/internal/db2/history/account.go
@@ -5,7 +5,6 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
-	"github.com/stellar/go/xdr"
 )
 
 // Accounts provides a helper to filter rows from the `history_accounts` table
@@ -20,12 +19,6 @@ func (q *Q) Accounts() *AccountsQ {
 // AccountByAddress loads a row from `history_accounts`, by address
 func (q *Q) AccountByAddress(dest interface{}, addy string) error {
 	sql := selectAccount.Limit(1).Where("ha.address = ?", addy)
-	return q.Get(dest, sql)
-}
-
-// AccountByID loads a row from `history_accounts`, by id
-func (q *Q) AccountByID(dest interface{}, id int64) error {
-	sql := selectAccount.Limit(1).Where("ha.id = ?", id)
 	return q.Get(dest, sql)
 }
 
@@ -101,37 +94,6 @@ func (q *Q) CreateAccounts(addresses []string, batchSize int) (map[string]int64,
 	}
 
 	return addressToID, nil
-}
-
-// Return id for account. If account doesn't exist, it will be created and the new id returned.
-// `ON CONFLICT` is required when running a distributed ingestion.
-func (q *Q) GetCreateAccountID(
-	aid xdr.AccountId,
-) (result int64, err error) {
-
-	var existing Account
-
-	err = q.AccountByAddress(&existing, aid.Address())
-
-	//account already exists, return id
-	if err == nil {
-		result = existing.ID
-		return
-	}
-
-	// unexpected error
-	if !q.NoRows(err) {
-		return
-	}
-
-	//insert account and return id
-	err = q.GetRaw(
-		&result,
-		`INSERT INTO history_accounts (address) VALUES (?) ON CONFLICT (address) DO UPDATE SET address=EXCLUDED.address RETURNING id`,
-		aid.Address(),
-	)
-
-	return
 }
 
 var selectAccount = sq.Select("ha.*").From("history_accounts ha")

--- a/services/horizon/internal/db2/history/accounts.go
+++ b/services/horizon/internal/db2/history/accounts.go
@@ -83,37 +83,6 @@ func accountToMap(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) map[s
 	}
 }
 
-// InsertAccount creates a row in the accounts table.
-// Returns number of rows affected and error.
-func (q *Q) InsertAccount(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
-	m := accountToMap(account, lastModifiedLedger)
-
-	sql := sq.Insert("accounts").SetMap(m)
-	result, err := q.Exec(sql)
-	if err != nil {
-		return 0, err
-	}
-
-	return result.RowsAffected()
-}
-
-// UpdateAccount updates a row in the offers table.
-// Returns number of rows affected and error.
-func (q *Q) UpdateAccount(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
-	m := accountToMap(account, lastModifiedLedger)
-
-	accountID := m["account_id"]
-	delete(m, "account_id")
-
-	sql := sq.Update("accounts").SetMap(m).Where(sq.Eq{"account_id": accountID})
-	result, err := q.Exec(sql)
-	if err != nil {
-		return 0, err
-	}
-
-	return result.RowsAffected()
-}
-
 // UpsertAccounts upserts a batch of accounts in the accounts table.
 // There's currently no limit of the number of accounts this method can
 // accept other than 2GB limit of the query string length what should be enough

--- a/services/horizon/internal/db2/history/accounts_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/accounts_batch_insert_builder.go
@@ -1,6 +1,14 @@
 package history
 
-import "github.com/stellar/go/xdr"
+import (
+	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/xdr"
+)
+
+// accountsBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
+type accountsBatchInsertBuilder struct {
+	builder db.BatchInsertBuilder
+}
 
 func (i *accountsBatchInsertBuilder) Add(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) error {
 	return i.builder.Row(accountToMap(account, lastModifiedLedger))

--- a/services/horizon/internal/db2/history/asset.go
+++ b/services/horizon/internal/db2/history/asset.go
@@ -7,29 +7,7 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-func (q *Q) GetAssetByID(dest interface{}, id int64) (err error) {
-	sql := sq.Select("id", "asset_type", "asset_code", "asset_issuer").From("history_assets").Limit(1).Where(sq.Eq{"id": id})
-	err = q.Get(dest, sql)
-	return
-}
-
-// GetAssetIDs fetches the ids for many Assets at once
-func (q *Q) GetAssetIDs(assets []xdr.Asset) ([]int64, error) {
-	list := make([]string, 0, len(assets))
-	for _, asset := range assets {
-		list = append(list, asset.String())
-	}
-
-	sql := sq.Select("id").From("history_assets").Where(sq.Eq{
-		"concat(asset_type, '/', asset_code, '/', asset_issuer)": list,
-	})
-
-	var ids []int64
-	err := q.Select(&ids, sql)
-	return ids, err
-}
-
-// GetAssetID fetches the id for an Asset. If fetching multiple values, look at GetAssetIDs
+// GetAssetID fetches the id for an Asset
 func (q *Q) GetAssetID(asset xdr.Asset) (id int64, err error) {
 	var (
 		assetType   string
@@ -48,42 +26,6 @@ func (q *Q) GetAssetID(asset xdr.Asset) (id int64, err error) {
 		"asset_issuer": assetIssuer})
 
 	err = q.Get(&id, sql)
-	return
-}
-
-// Get asset row id. If asset is first seen, it will be inserted and the new id returned.
-func (q *Q) GetCreateAssetID(
-	asset xdr.Asset,
-) (result int64, err error) {
-
-	result, err = q.GetAssetID(asset)
-
-	//asset exists, return id
-	if err == nil {
-		return
-	}
-
-	//unexpected error
-	if !q.NoRows(err) {
-		return
-	}
-
-	//insert asset and return id
-	var (
-		assetType   string
-		assetCode   string
-		assetIssuer string
-	)
-
-	err = asset.Extract(&assetType, &assetCode, &assetIssuer)
-	if err != nil {
-		return
-	}
-
-	err = q.GetRaw(&result,
-		`INSERT INTO history_assets (asset_type, asset_code, asset_issuer) VALUES (?,?,?) RETURNING id`,
-		assetType, assetCode, assetIssuer)
-
 	return
 }
 

--- a/services/horizon/internal/db2/history/asset.go
+++ b/services/horizon/internal/db2/history/asset.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"sort"
+
 	sq "github.com/Masterminds/squirrel"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
@@ -40,6 +42,11 @@ func (q *Q) CreateAssets(assets []xdr.Asset, batchSize int) (map[string]Asset, e
 		Suffix:       "ON CONFLICT (asset_code, asset_type, asset_issuer) DO NOTHING",
 	}
 
+	// sort assets before inserting rows into history_assets to prevent deadlocks on acquiring a ShareLock
+	// https://github.com/stellar/go/issues/2370
+	sort.Slice(assets, func(i, j int) bool {
+		return assets[i].String() < assets[j].String()
+	})
 	for _, asset := range assets {
 		var assetType, assetCode, assetIssuer string
 		err := asset.Extract(&assetType, &assetCode, &assetIssuer)

--- a/services/horizon/internal/db2/history/asset_test.go
+++ b/services/horizon/internal/db2/history/asset_test.go
@@ -1,11 +1,54 @@
 package history
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/xdr"
 )
+
+func TestCreateAssetsSortedOrder(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+
+	q := &Q{tt.HorizonSession()}
+	assets := []xdr.Asset{
+		usdAsset, nativeAsset, eurAsset,
+		xdr.MustNewCreditAsset("CNY", issuer.Address()),
+	}
+	assetMap, err := q.CreateAssets(
+		assets,
+		2,
+	)
+	tt.Assert.NoError(err)
+
+	idsToAsset := map[int64]string{}
+	sortedIDs := []int64{}
+	for assetString, asset := range assetMap {
+		idsToAsset[asset.ID] = assetString
+		sortedIDs = append(sortedIDs, asset.ID)
+	}
+
+	sort.Slice(assets, func(i, j int) bool {
+		return assets[i].String() < assets[j].String()
+	})
+	sort.Slice(sortedIDs, func(i, j int) bool {
+		return sortedIDs[i] < sortedIDs[j]
+	})
+
+	var assetStrings []string
+	for _, asset := range assets {
+		assetStrings = append(assetStrings, asset.String())
+	}
+
+	var values []string
+	for _, id := range sortedIDs {
+		values = append(values, idsToAsset[id])
+	}
+	tt.Assert.Equal(assetStrings, values)
+}
 
 func TestCreateAssets(t *testing.T) {
 	tt := test.Start(t)

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -149,11 +149,6 @@ type AccountsBatchInsertBuilder interface {
 	Exec() error
 }
 
-// accountsBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
-type accountsBatchInsertBuilder struct {
-	builder db.BatchInsertBuilder
-}
-
 type IngestionQ interface {
 	QAccounts
 	QAssetStats
@@ -193,8 +188,6 @@ type IngestionQ interface {
 type QAccounts interface {
 	NewAccountsBatchInsertBuilder(maxBatchSize int) AccountsBatchInsertBuilder
 	GetAccountsByIDs(ids []string) ([]AccountEntry, error)
-	InsertAccount(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) (int64, error)
-	UpdateAccount(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) (int64, error)
 	UpsertAccounts(accounts []xdr.LedgerEntry) error
 	RemoveAccount(accountID string) (int64, error)
 }

--- a/services/horizon/internal/db2/history/trade_test.go
+++ b/services/horizon/internal/db2/history/trade_test.go
@@ -313,28 +313,3 @@ func TestBatchInsertTrade(t *testing.T) {
 		)
 	}
 }
-
-func createTradeRows(
-	tt *test.T, q *Q,
-	idToAccount map[int64]xdr.AccountId,
-	idToAsset map[int64]xdr.Asset,
-	entries ...InsertTrade,
-) {
-	for _, entry := range entries {
-		entry.Trade.SellerId = idToAccount[entry.SellerAccountID]
-		entry.Trade.AssetSold = idToAsset[entry.SoldAssetID]
-		entry.Trade.AssetBought = idToAsset[entry.BoughtAssetID]
-
-		err := q.InsertTrade(
-			entry.HistoryOperationID,
-			entry.Order,
-			idToAccount[entry.BuyerAccountID],
-			entry.BuyOfferExists,
-			xdr.OfferEntry{OfferId: xdr.Int64(entry.BuyOfferID)},
-			entry.Trade,
-			entry.SellPrice,
-			supportTime.MillisFromSeconds(entry.LedgerCloseTime.Unix()),
-		)
-		tt.Assert.NoError(err)
-	}
-}

--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -535,8 +535,10 @@ func (h historyRangeState) run(s *System) (transition, error) {
 		return start(), nil
 	}
 
-	if err = ingestHistoryRange(s, h.fromLedger, h.toLedger); err != nil {
-		return start(), err
+	for cur := h.fromLedger; cur <= h.toLedger; cur++ {
+		if err = runTransactionProcessorsOnLedger(s, cur); err != nil {
+			return start(), err
+		}
 	}
 
 	if err = s.historyQ.Commit(); err != nil {
@@ -546,34 +548,32 @@ func (h historyRangeState) run(s *System) (transition, error) {
 	return start(), nil
 }
 
-func ingestHistoryRange(s *System, from, to uint32) error {
-	for cur := from; cur <= to; cur++ {
-		log.WithFields(logpkg.F{
-			"sequence": cur,
+func runTransactionProcessorsOnLedger(s *System, ledger uint32) error {
+	log.WithFields(logpkg.F{
+		"sequence": ledger,
+		"state":    false,
+		"ledger":   true,
+		"graph":    false,
+		"commit":   false,
+	}).Info("Processing ledger")
+	startTime := time.Now()
+
+	ledgerTransactionStats, err := s.runner.RunTransactionProcessorsOnLedger(ledger)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error processing ledger sequence=%d", ledger))
+	}
+
+	log.
+		WithFields(ledgerTransactionStats.Map()).
+		WithFields(logpkg.F{
+			"sequence": ledger,
+			"duration": time.Since(startTime).Seconds(),
 			"state":    false,
 			"ledger":   true,
 			"graph":    false,
 			"commit":   false,
-		}).Info("Processing ledger")
-		startTime := time.Now()
-
-		ledgerTransactionStats, err := s.runner.RunTransactionProcessorsOnLedger(cur)
-		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("error processing ledger sequence=%d", cur))
-		}
-
-		log.
-			WithFields(ledgerTransactionStats.Map()).
-			WithFields(logpkg.F{
-				"sequence": cur,
-				"duration": time.Since(startTime).Seconds(),
-				"state":    false,
-				"ledger":   true,
-				"graph":    false,
-				"commit":   false,
-			}).
-			Info("Processed ledger")
-	}
+		}).
+		Info("Processed ledger")
 	return nil
 }
 
@@ -592,6 +592,43 @@ func (h reingestHistoryRangeState) String() string {
 	)
 }
 
+func (h reingestHistoryRangeState) ingestRange(s *System, createTx bool, fromLedger, toLedger uint32) error {
+	if createTx {
+		if err := s.historyQ.Begin(); err != nil {
+			return errors.Wrap(err, "Error starting a transaction")
+		}
+		defer s.historyQ.Rollback()
+	}
+
+	// Clear history data before ingesting - used in `reingest range` command.
+	start, end, err := toid.LedgerRangeInclusive(
+		int32(fromLedger),
+		int32(toLedger),
+	)
+	if err != nil {
+		return errors.Wrap(err, "Invalid range")
+	}
+
+	err = s.historyQ.DeleteRangeAll(start, end)
+	if err != nil {
+		return errors.Wrap(err, "error in DeleteRangeAll")
+	}
+
+	for cur := fromLedger; cur <= toLedger; cur++ {
+		if err = runTransactionProcessorsOnLedger(s, cur); err != nil {
+			return err
+		}
+	}
+
+	if createTx {
+		if err := s.historyQ.Commit(); err != nil {
+			return errors.Wrap(err, commitErrMsg)
+		}
+	}
+
+	return nil
+}
+
 // reingestHistoryRangeState is used as a command to reingest historical data
 func (h reingestHistoryRangeState) run(s *System) (transition, error) {
 	if h.fromLedger == 0 || h.toLedger == 0 ||
@@ -599,15 +636,23 @@ func (h reingestHistoryRangeState) run(s *System) (transition, error) {
 		return stop(), errors.Errorf("invalid range: [%d, %d]", h.fromLedger, h.toLedger)
 	}
 
-	if err := s.historyQ.Begin(); err != nil {
-		return stop(), errors.Wrap(err, "Error starting a transaction")
-	}
-	defer s.historyQ.Rollback()
-
 	if h.force {
+		if err := s.historyQ.Begin(); err != nil {
+			return stop(), errors.Wrap(err, "Error starting a transaction")
+		}
+		defer s.historyQ.Rollback()
+
 		// acquire distributed lock so no one else can perform ingestion operations.
 		if _, err := s.historyQ.GetLastLedgerExpIngest(); err != nil {
 			return stop(), errors.Wrap(err, getLastIngestedErrMsg)
+		}
+
+		if err := h.ingestRange(s, false, h.fromLedger, h.toLedger); err != nil {
+			return stop(), err
+		}
+
+		if err := s.historyQ.Commit(); err != nil {
+			return stop(), errors.Wrap(err, commitErrMsg)
 		}
 	} else {
 		lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngestNonBlocking()
@@ -618,28 +663,14 @@ func (h reingestHistoryRangeState) run(s *System) (transition, error) {
 		if lastIngestedLedger > 0 && h.toLedger >= lastIngestedLedger {
 			return stop(), ErrReingestRangeConflict
 		}
-	}
 
-	// Clear history data before ingesting - used in `reingest range` command.
-	start, end, err := toid.LedgerRangeInclusive(
-		int32(h.fromLedger),
-		int32(h.toLedger),
-	)
-	if err != nil {
-		return stop(), errors.Wrap(err, "Invalid range")
-	}
-
-	err = s.historyQ.DeleteRangeAll(start, end)
-	if err != nil {
-		return stop(), errors.Wrap(err, "error in DeleteRangeAll")
-	}
-
-	if err = ingestHistoryRange(s, h.fromLedger, h.toLedger); err != nil {
-		return stop(), err
-	}
-
-	if err := s.historyQ.Commit(); err != nil {
-		return stop(), errors.Wrap(err, commitErrMsg)
+		for cur := h.fromLedger; cur <= h.toLedger; cur++ {
+			// ingest each ledger in a separate transaction to prevent deadlocks
+			// when acquiring ShareLocks from multiple parallel reingest range processes
+			if err := h.ingestRange(s, true, cur, cur); err != nil {
+				return stop(), err
+			}
+		}
 	}
 
 	return stop(), nil

--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -592,7 +592,7 @@ func (h reingestHistoryRangeState) String() string {
 	)
 }
 
-func (h reingestHistoryRangeState) ingestRange(s *System, createTx bool, fromLedger, toLedger uint32) error {
+func (h reingestHistoryRangeState) ingestRange(s *System, fromLedger, toLedger uint32) error {
 	if s.historyQ.GetTx() == nil {
 		return errors.New("expected transaction to be present")
 	}
@@ -638,7 +638,7 @@ func (h reingestHistoryRangeState) run(s *System) (transition, error) {
 			return stop(), errors.Wrap(err, getLastIngestedErrMsg)
 		}
 
-		if err := h.ingestRange(s, false, h.fromLedger, h.toLedger); err != nil {
+		if err := h.ingestRange(s, h.fromLedger, h.toLedger); err != nil {
 			return stop(), err
 		}
 
@@ -664,7 +664,7 @@ func (h reingestHistoryRangeState) run(s *System) (transition, error) {
 
 				// ingest each ledger in a separate transaction to prevent deadlocks
 				// when acquiring ShareLocks from multiple parallel reingest range processes
-				if err := h.ingestRange(s, true, ledger, ledger); err != nil {
+				if err := h.ingestRange(s, ledger, ledger); err != nil {
 					return err
 				}
 

--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -593,11 +593,8 @@ func (h reingestHistoryRangeState) String() string {
 }
 
 func (h reingestHistoryRangeState) ingestRange(s *System, createTx bool, fromLedger, toLedger uint32) error {
-	if createTx {
-		if err := s.historyQ.Begin(); err != nil {
-			return errors.Wrap(err, "Error starting a transaction")
-		}
-		defer s.historyQ.Rollback()
+	if s.historyQ.GetTx() == nil {
+		return errors.New("expected transaction to be present")
 	}
 
 	// Clear history data before ingesting - used in `reingest range` command.
@@ -617,12 +614,6 @@ func (h reingestHistoryRangeState) ingestRange(s *System, createTx bool, fromLed
 	for cur := fromLedger; cur <= toLedger; cur++ {
 		if err = runTransactionProcessorsOnLedger(s, cur); err != nil {
 			return err
-		}
-	}
-
-	if createTx {
-		if err := s.historyQ.Commit(); err != nil {
-			return errors.Wrap(err, commitErrMsg)
 		}
 	}
 
@@ -665,9 +656,25 @@ func (h reingestHistoryRangeState) run(s *System) (transition, error) {
 		}
 
 		for cur := h.fromLedger; cur <= h.toLedger; cur++ {
-			// ingest each ledger in a separate transaction to prevent deadlocks
-			// when acquiring ShareLocks from multiple parallel reingest range processes
-			if err := h.ingestRange(s, true, cur, cur); err != nil {
+			err := func(ledger uint32) error {
+				if err := s.historyQ.Begin(); err != nil {
+					return errors.Wrap(err, "Error starting a transaction")
+				}
+				defer s.historyQ.Rollback()
+
+				// ingest each ledger in a separate transaction to prevent deadlocks
+				// when acquiring ShareLocks from multiple parallel reingest range processes
+				if err := h.ingestRange(s, true, ledger, ledger); err != nil {
+					return err
+				}
+
+				if err := s.historyQ.Commit(); err != nil {
+					return errors.Wrap(err, commitErrMsg)
+				}
+
+				return nil
+			}(cur)
+			if err != nil {
 				return stop(), err
 			}
 		}

--- a/services/horizon/internal/expingest/ingest_history_range_state_test.go
+++ b/services/horizon/internal/expingest/ingest_history_range_state_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/stellar/go/exp/ingest/adapters"
 	"github.com/stellar/go/exp/ingest/io"
 	"github.com/stellar/go/services/horizon/internal/toid"
@@ -272,6 +273,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestClearHistoryFails() {
 	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
 
 	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
 	toidFrom := toid.New(100, 0, 0)
 	toidTo := toid.New(101, 0, 0)
 	s.historyQ.On(
@@ -290,6 +292,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestRunTransactionProcessorsOnLedge
 	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
 
 	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
 	toidFrom := toid.New(100, 0, 0)
 	toidTo := toid.New(101, 0, 0)
 	s.historyQ.On(
@@ -310,6 +313,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestCommitFails() {
 	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
 
 	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
 	toidFrom := toid.New(100, 0, 0)
 	toidTo := toid.New(101, 0, 0)
 	s.historyQ.On(
@@ -332,6 +336,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestSuccess() {
 
 	for i := uint32(100); i <= uint32(200); i++ {
 		s.historyQ.On("Begin").Return(nil).Once()
+		s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
 
 		toidFrom := toid.New(int32(i), 0, 0)
 		toidTo := toid.New(int32(i+1), 0, 0)
@@ -351,6 +356,8 @@ func (s *ReingestHistoryRangeStateTestSuite) TestSuccess() {
 
 func (s *ReingestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
 	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
+
+	s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
 
 	toidFrom := toid.New(100, 0, 0)
 	toidTo := toid.New(101, 0, 0)
@@ -374,6 +381,8 @@ func (s *ReingestHistoryRangeStateTestSuite) TestGetLastLedgerExpIngestError() {
 
 func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeForce() {
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(190), nil).Once()
+
+	s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
 
 	toidFrom := toid.New(100, 0, 0)
 	toidTo := toid.New(201, 0, 0)

--- a/services/horizon/internal/expingest/ingest_history_range_state_test.go
+++ b/services/horizon/internal/expingest/ingest_history_range_state_test.go
@@ -228,6 +228,8 @@ func (s *ReingestHistoryRangeStateTestSuite) TestBeginReturnsError() {
 	// Recreate mock in this single test to remove Rollback assertion.
 	*s.historyQ = mockDBQ{}
 	s.historyQ.On("GetTx").Return(nil)
+	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
+
 	s.historyQ.On("Begin").Return(errors.New("my error")).Once()
 
 	err := s.system.ReingestRange(100, 200, false)
@@ -235,6 +237,9 @@ func (s *ReingestHistoryRangeStateTestSuite) TestBeginReturnsError() {
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TestGetLastLedgerExpIngestNonBlockingError() {
+	*s.historyQ = mockDBQ{}
+	s.historyQ.On("GetTx").Return(nil).Once()
+
 	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), errors.New("my error")).Once()
 
 	err := s.system.ReingestRange(100, 200, false)
@@ -242,6 +247,9 @@ func (s *ReingestHistoryRangeStateTestSuite) TestGetLastLedgerExpIngestNonBlocki
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeOverlaps() {
+	*s.historyQ = mockDBQ{}
+	s.historyQ.On("GetTx").Return(nil).Once()
+
 	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(190), nil).Once()
 
 	err := s.system.ReingestRange(100, 200, false)
@@ -249,6 +257,9 @@ func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeOverlaps() {
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeOverlapsAtEnd() {
+	*s.historyQ = mockDBQ{}
+	s.historyQ.On("GetTx").Return(nil).Once()
+
 	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(200), nil).Once()
 
 	err := s.system.ReingestRange(100, 200, false)
@@ -256,67 +267,83 @@ func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeOverlapsAtEnd() {
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TestClearHistoryFails() {
+	*s.historyQ = mockDBQ{}
+	s.historyQ.On("GetTx").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
 
+	s.historyQ.On("Begin").Return(nil).Once()
 	toidFrom := toid.New(100, 0, 0)
-	toidTo := toid.New(201, 0, 0)
+	toidTo := toid.New(101, 0, 0)
 	s.historyQ.On(
 		"DeleteRangeAll", toidFrom.ToInt64(), toidTo.ToInt64(),
 	).Return(errors.New("my error")).Once()
+
+	s.historyQ.On("Rollback").Return(nil).Once()
 
 	err := s.system.ReingestRange(100, 200, false)
 	s.Assert().EqualError(err, "error in DeleteRangeAll: my error")
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TestRunTransactionProcessorsOnLedgerReturnsError() {
+	*s.historyQ = mockDBQ{}
+	s.historyQ.On("GetTx").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
 
+	s.historyQ.On("Begin").Return(nil).Once()
 	toidFrom := toid.New(100, 0, 0)
-	toidTo := toid.New(201, 0, 0)
+	toidTo := toid.New(101, 0, 0)
 	s.historyQ.On(
 		"DeleteRangeAll", toidFrom.ToInt64(), toidTo.ToInt64(),
 	).Return(nil).Once()
 
 	s.runner.On("RunTransactionProcessorsOnLedger", uint32(100)).
 		Return(io.StatsLedgerTransactionProcessorResults{}, errors.New("my error")).Once()
+	s.historyQ.On("Rollback").Return(nil).Once()
 
 	err := s.system.ReingestRange(100, 200, false)
 	s.Assert().EqualError(err, "error processing ledger sequence=100: my error")
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TestCommitFails() {
+	*s.historyQ = mockDBQ{}
+	s.historyQ.On("GetTx").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
 
+	s.historyQ.On("Begin").Return(nil).Once()
 	toidFrom := toid.New(100, 0, 0)
-	toidTo := toid.New(201, 0, 0)
+	toidTo := toid.New(101, 0, 0)
 	s.historyQ.On(
 		"DeleteRangeAll", toidFrom.ToInt64(), toidTo.ToInt64(),
 	).Return(nil).Once()
 
-	for i := 100; i <= 200; i++ {
-		s.runner.On("RunTransactionProcessorsOnLedger", uint32(i)).Return(io.StatsLedgerTransactionProcessorResults{}, nil).Once()
-	}
+	s.runner.On("RunTransactionProcessorsOnLedger", uint32(100)).Return(io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 
 	s.historyQ.On("Commit").Return(errors.New("my error")).Once()
+	s.historyQ.On("Rollback").Return(nil).Once()
 
 	err := s.system.ReingestRange(100, 200, false)
 	s.Assert().EqualError(err, "Error committing db transaction: my error")
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TestSuccess() {
+	*s.historyQ = mockDBQ{}
+	s.historyQ.On("GetTx").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
 
-	toidFrom := toid.New(100, 0, 0)
-	toidTo := toid.New(201, 0, 0)
-	s.historyQ.On(
-		"DeleteRangeAll", toidFrom.ToInt64(), toidTo.ToInt64(),
-	).Return(nil).Once()
+	for i := uint32(100); i <= uint32(200); i++ {
+		s.historyQ.On("Begin").Return(nil).Once()
 
-	for i := 100; i <= 200; i++ {
-		s.runner.On("RunTransactionProcessorsOnLedger", uint32(i)).Return(io.StatsLedgerTransactionProcessorResults{}, nil).Once()
+		toidFrom := toid.New(int32(i), 0, 0)
+		toidTo := toid.New(int32(i+1), 0, 0)
+		s.historyQ.On(
+			"DeleteRangeAll", toidFrom.ToInt64(), toidTo.ToInt64(),
+		).Return(nil).Once()
+
+		s.runner.On("RunTransactionProcessorsOnLedger", i).Return(io.StatsLedgerTransactionProcessorResults{}, nil).Once()
+
+		s.historyQ.On("Commit").Return(nil).Once()
+		s.historyQ.On("Rollback").Return(nil).Once()
 	}
-
-	s.historyQ.On("Commit").Return(nil).Once()
 
 	err := s.system.ReingestRange(100, 200, false)
 	s.Assert().NoError(err)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes https://github.com/stellar/go/issues/2370

* Remove database functions which were previously used by legacy ingestion but now are unused
* Sort assets before inserting rows into `history_assets` 
* Sort accounts before inserting rows into `history_accounts` 
* Ingest each ledger in reingest range in separate transaction

### Why

Running `horizon db reingest range` multiple times in parallel sometimes causes a deadlock in Postgres where multiple connections inserting into `history_accounts` are blocked trying to acquire a ShareLock.

> ShareLocks are row locks that are taken on each row as it is written by the transaction. ShareLock deadlocks occurs when two separate transactions try to write the same rows in opposite order.

That is why assets and accounts are sorted before insertion.

Another change in this PR which should mitigate against deadlocks is keeping transactions short lived. Previously, we reingested the entire range in just one transaction. If you have multiple reingesting processes which are running in parallel over very long ranges that increases the chances there will be a deadlock.

### Known limitations

[N/A]
