### PR TITLE
exp/services/recoverysigner: disallow db migrate with a zero count

### DIFF
--- a/exp/services/recoverysigner/cmd/db.go
+++ b/exp/services/recoverysigner/cmd/db.go
@@ -85,6 +85,10 @@ func (c *DBCommand) Migrate(cmd *cobra.Command, args []string) {
 			c.Logger.Errorf("Invalid migration count, must be a number or not provided.")
 			return
 		}
+		if count < 1 {
+			c.Logger.Errorf("Invalid migration count, must be a number greater than zero.")
+			return
+		}
 	}
 
 	migrations, err := dbmigrate.PlanMigration(db, dir, count)

--- a/exp/services/recoverysigner/cmd/db_test.go
+++ b/exp/services/recoverysigner/cmd/db_test.go
@@ -206,3 +206,36 @@ func TestDBCommand_Migrate_invalidCount(t *testing.T) {
 	}
 	assert.Equal(t, wantMessages, messages)
 }
+
+func TestDBCommand_Migrate_zeroCount(t *testing.T) {
+	db := dbtest.Postgres(t)
+	log := log.New()
+
+	dbCommand := DBCommand{
+		Logger:      log,
+		DatabaseURL: db.DSN,
+	}
+
+	logsGet := log.StartTest(logrus.InfoLevel)
+
+	dbCommand.Migrate(&cobra.Command{}, []string{"down", "0"})
+	dbCommand.Migrate(&cobra.Command{}, []string{"up", "0"})
+
+	session, err := dbpkg.Open(db.DSN)
+	require.NoError(t, err)
+	tables := []string{}
+	err = session.Select(&tables, `SELECT table_name FROM information_schema.tables WHERE table_schema='public'`)
+	require.NoError(t, err)
+	assert.Empty(t, tables)
+
+	logs := logsGet()
+	messages := []string{}
+	for _, l := range logs {
+		messages = append(messages, l.Message)
+	}
+	wantMessages := []string{
+		"Invalid migration count, must be a number greater than zero.",
+		"Invalid migration count, must be a number greater than zero.",
+	}
+	assert.Equal(t, wantMessages, messages)
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Disallow the recoverysigner's `db migrate [up|down] [count]` command with a zero (`0`) count.

### Why

If you pass zero as the count value to the command the command will run all possible migrations up or down. This isn't intuitive even though it's the behavior of the migration library we're using. We don't really need to expose this in our API since the count is optional and this is the behavior if no count is provided.

Thanks for the feedback @howardtw on https://github.com/stellar/go/pull/2374#discussion_r391170652.

### Known limitations

N/A
