### PR TITLE
exp/services/recoverysigner: make the db migrate invalid count error simpler

### DIFF
--- a/exp/services/recoverysigner/cmd/db.go
+++ b/exp/services/recoverysigner/cmd/db.go
@@ -82,7 +82,7 @@ func (c *DBCommand) Migrate(cmd *cobra.Command, args []string) {
 	if len(args) >= 2 {
 		count, err = strconv.Atoi(args[1])
 		if err != nil {
-			c.Logger.Errorf("Invalid migration count, must be a number or not provided.")
+			c.Logger.Errorf("Invalid migration count, must be a number.")
 			return
 		}
 	}

--- a/exp/services/recoverysigner/cmd/db_test.go
+++ b/exp/services/recoverysigner/cmd/db_test.go
@@ -201,8 +201,8 @@ func TestDBCommand_Migrate_invalidCount(t *testing.T) {
 		messages = append(messages, l.Message)
 	}
 	wantMessages := []string{
-		"Invalid migration count, must be a number or not provided.",
-		"Invalid migration count, must be a number or not provided.",
+		"Invalid migration count, must be a number.",
+		"Invalid migration count, must be a number.",
 	}
 	assert.Equal(t, wantMessages, messages)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Change the error outputted when an invalid value is provided to the
recoverysigner's `db migrate [up|down] [count]` command as hte count
value from:
```
Invalid migration count, must be a number or not provided.
```
To:
```
Invalid migration count, must be a number.
```

### Why
The error message makes a suggestion to the user about something they
alternatively could do, remove the number, but this might not be what
they need to do and makes assumptions about what a user is doing. For
example, if the user saw this message and removed the invalid value and
were running a down migration it would be destructive. Separate to the
issue that it is too easy to migrate down all the way, this message goes
beyond just telling the user what is wrong and it's unnecessary for the
tool to go further than that.

I noticed this message while I was working on #2380.

### Known limitations

N/A
