### PR TITLE
txbuild/data: Add NewManageDataMemoRequired to txbuild.

### DIFF
--- a/txnbuild/data/main.go
+++ b/txnbuild/data/main.go
@@ -1,0 +1,15 @@
+package data
+
+import "github.com/stellar/go/txnbuild"
+
+// NewManageDataMemoRequired returns a valid txnbuild.ManageData operation setting memo required to 1 or 0.
+func NewManageDataMemoRequired(b bool) *txnbuild.ManageData {
+	value := "0"
+	if b {
+		value = "1"
+	}
+	return &txnbuild.ManageData{
+		Name:  "config.memo_required",
+		Value: []byte(value),
+	}
+}

--- a/txnbuild/data/main_test.go
+++ b/txnbuild/data/main_test.go
@@ -1,0 +1,20 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewManageDataMemoRequired(t *testing.T) {
+	tt := assert.New(t)
+	manageData := NewManageDataMemoRequired(true)
+	tt.NoError(manageData.Validate())
+	tt.Equal("config.memo_required", manageData.Name)
+	tt.Equal([]byte("1"), manageData.Value)
+
+	manageData = NewManageDataMemoRequired(false)
+	tt.NoError(manageData.Validate())
+	tt.Equal("config.memo_required", manageData.Name)
+	tt.Equal([]byte("0"), manageData.Value)
+}

--- a/txnbuild/example_test.go
+++ b/txnbuild/example_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
+	"github.com/stellar/go/txnbuild/data"
 	horizonclient "github.com/stellar/go/txnbuild/examplehorizonclient"
 )
 
@@ -184,6 +185,29 @@ func ExampleManageData() {
 		Name:  "Fruit preference",
 		Value: []byte("Apple"),
 	}
+
+	tx := Transaction{
+		SourceAccount: &sourceAccount,
+		Operations:    []Operation{&op},
+		Timebounds:    NewInfiniteTimeout(), // Use a real timeout in production!
+		Network:       network.TestNetworkPassphrase,
+	}
+
+	txe, err := tx.BuildSignEncode(kp.(*keypair.Full))
+	check(err)
+	fmt.Println(txe)
+
+	// Output: AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAMoj8AAAAEAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAKAAAAEEZydWl0IHByZWZlcmVuY2UAAAABAAAABUFwcGxlAAAAAAAAAAAAAAHqLnLFAAAAQO1ELJBEoqBDyIsS7uSJwe1LOimV/E+09MyF1G/+yrxSggFVPEjD5LXcm/6POze3IsMuIYJU1et5Q2Vt9f73zQo=
+}
+
+func ExampleNewManageDataMemoRequired() {
+	kp, _ := keypair.Parse("SBPQUZ6G4FZNWFHKUWC5BEYWF6R52E3SEP7R3GWYSM2XTKGF5LNTWW4R")
+	client := horizonclient.DefaultTestNetClient
+	ar := horizonclient.AccountRequest{AccountID: kp.Address()}
+	sourceAccount, err := client.AccountDetail(ar)
+	check(err)
+
+	op := data.NewManageDataMemoRequired(true)
 
 	tx := Transaction{
 		SourceAccount: &sourceAccount,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add helper function to set `config.memo_required` to `1` or `0`.

Fix #2378.


### Why

This will help as a reference and helper for SEP29.

### Known limitations