### PR TITLE
exp/services/recoverysigner: add validations for account post endpoint role, identities and auth methods

### DIFF
--- a/exp/services/recoverysigner/internal/account/account.go
+++ b/exp/services/recoverysigner/internal/account/account.go
@@ -1,7 +1,5 @@
 package account
 
-import "github.com/stellar/go/support/errors"
-
 type Account struct {
 	Address    string
 	Identities []Identity
@@ -14,18 +12,15 @@ type Identity struct {
 
 type AuthMethodType string
 
+func (t AuthMethodType) Valid() bool {
+	return AuthMethodTypes[t]
+}
+
 const (
 	AuthMethodTypeAddress     AuthMethodType = "stellar_address"
 	AuthMethodTypePhoneNumber AuthMethodType = "phone_number"
 	AuthMethodTypeEmail       AuthMethodType = "email"
 )
-
-func AuthMethodTypeFromString(s string) (AuthMethodType, error) {
-	if AuthMethodTypes[AuthMethodType(s)] {
-		return AuthMethodType(s), nil
-	}
-	return AuthMethodType(""), errors.Errorf("auth method type %q unrecognized", s)
-}
 
 var AuthMethodTypes = map[AuthMethodType]bool{
 	AuthMethodTypeAddress:     true,

--- a/exp/services/recoverysigner/internal/serve/account_post.go
+++ b/exp/services/recoverysigner/internal/serve/account_post.go
@@ -26,6 +26,9 @@ type accountPostRequest struct {
 }
 
 func (r accountPostRequest) Validate() error {
+	if len(r.Identities) == 0 {
+		return errors.Errorf("identities not provided at least one required")
+	}
 	for _, i := range r.Identities {
 		err := i.Validate()
 		if err != nil {

--- a/exp/services/recoverysigner/internal/serve/account_post.go
+++ b/exp/services/recoverysigner/internal/serve/account_post.go
@@ -27,7 +27,7 @@ type accountPostRequest struct {
 
 func (r accountPostRequest) Validate() error {
 	if len(r.Identities) == 0 {
-		return errors.Errorf("identities not provided at least one required")
+		return errors.Errorf("no identities provided but at least one is required")
 	}
 	for _, i := range r.Identities {
 		err := i.Validate()

--- a/exp/services/recoverysigner/internal/serve/account_post.go
+++ b/exp/services/recoverysigner/internal/serve/account_post.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stellar/go/exp/services/recoverysigner/internal/account"
 	"github.com/stellar/go/exp/services/recoverysigner/internal/serve/auth"
 	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/http/httpdecode"
 	supportlog "github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/httpjson"
@@ -24,9 +25,26 @@ type accountPostRequest struct {
 	Identities []accountPostRequestIdentity `json:"identities" form:"identities"`
 }
 
+func (r accountPostRequest) Validate() error {
+	for _, i := range r.Identities {
+		err := i.Validate()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 type accountPostRequestIdentity struct {
 	Role        string                                 `json:"role" form:"role"`
 	AuthMethods []accountPostRequestIdentityAuthMethod `json:"auth_methods" form:"auth_methods"`
+}
+
+func (i accountPostRequestIdentity) Validate() error {
+	if i.Role == "" {
+		return errors.Errorf("role is not set but required")
+	}
+	return nil
 }
 
 type accountPostRequestIdentityAuthMethod struct {
@@ -52,6 +70,11 @@ func (h accountPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if req.Address.Address() != claims.Address {
 		unauthorized.Render(w)
+		return
+	}
+
+	if req.Validate() != nil {
+		badRequest.Render(w)
 		return
 	}
 

--- a/exp/services/recoverysigner/internal/serve/account_post.go
+++ b/exp/services/recoverysigner/internal/serve/account_post.go
@@ -47,6 +47,9 @@ func (i accountPostRequestIdentity) Validate() error {
 	if i.Role == "" {
 		return errors.Errorf("role is not set but required")
 	}
+	if len(i.AuthMethods) == 0 {
+		return errors.Errorf("auth methods not provided for identity but required")
+	}
 	return nil
 }
 

--- a/exp/services/recoverysigner/internal/serve/account_post.go
+++ b/exp/services/recoverysigner/internal/serve/account_post.go
@@ -50,12 +50,25 @@ func (i accountPostRequestIdentity) Validate() error {
 	if len(i.AuthMethods) == 0 {
 		return errors.Errorf("auth methods not provided for identity but required")
 	}
+	for _, am := range i.AuthMethods {
+		err := am.Validate()
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
 type accountPostRequestIdentityAuthMethod struct {
 	Type  string `json:"type" form:"type"`
 	Value string `json:"value" form:"value"`
+}
+
+func (am accountPostRequestIdentityAuthMethod) Validate() error {
+	if !account.AuthMethodType(am.Type).Valid() {
+		return errors.Errorf("auth method type %q unrecognized", am.Type)
+	}
+	return nil
 }
 
 func (h accountPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -93,14 +106,8 @@ func (h accountPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Role: i.Role,
 		}
 		for _, m := range i.AuthMethods {
-			t, tErr := account.AuthMethodTypeFromString(m.Type)
-			if tErr != nil {
-				badRequest.Render(w)
-				return
-			}
-
 			accIdentity.AuthMethods = append(accIdentity.AuthMethods, account.AuthMethod{
-				Type:  t,
+				Type:  account.AuthMethodType(m.Type),
 				Value: m.Value,
 			})
 		}

--- a/exp/services/recoverysigner/internal/serve/account_post.go
+++ b/exp/services/recoverysigner/internal/serve/account_post.go
@@ -68,6 +68,7 @@ func (am accountPostRequestIdentityAuthMethod) Validate() error {
 	if !account.AuthMethodType(am.Type).Valid() {
 		return errors.Errorf("auth method type %q unrecognized", am.Type)
 	}
+	// TODO: Validate auth method values: Stellar address, phone number and email.
 	return nil
 }
 

--- a/exp/services/recoverysigner/internal/serve/account_post_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_post_test.go
@@ -358,7 +358,16 @@ func TestAccountPost_accountAlreadyExists(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = auth.NewContext(ctx, auth.Auth{Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N"})
-	req := `{}`
+	req := `{
+	"identities": [
+		{
+			"role": "owner",
+			"auth_methods": [
+				{ "type": "phone_number", "value": "+10000000000" }
+			]
+		}
+	]
+}`
 	r := httptest.NewRequest("POST", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", strings.NewReader(req))
 	r = r.WithContext(ctx)
 
@@ -385,6 +394,41 @@ func TestAccountPost_accountAlreadyExists(t *testing.T) {
 		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
 	}
 	assert.Equal(t, wantAcc, acc)
+}
+
+func TestAccountPost_identitiesNotProvided(t *testing.T) {
+	s := account.NewMemoryStore()
+	h := accountPostHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N"})
+	req := `{}`
+	r := httptest.NewRequest("POST", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", strings.NewReader(req))
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Post("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"error": "The request was invalid in some way."
+}`
+	assert.JSONEq(t, wantBody, string(body))
+
+	_, err = s.Get("GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N")
+	assert.Equal(t, account.ErrNotFound, err)
 }
 
 func TestAccountPost_roleNotProvided(t *testing.T) {

--- a/exp/services/recoverysigner/internal/serve/account_post_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_post_test.go
@@ -387,6 +387,51 @@ func TestAccountPost_accountAlreadyExists(t *testing.T) {
 	assert.Equal(t, wantAcc, acc)
 }
 
+func TestAccountPost_roleNotProvided(t *testing.T) {
+	s := account.NewMemoryStore()
+	h := accountPostHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N"})
+	req := `{
+	"identities": [
+		{
+			"auth_methods": [
+				{ "type": "stellar_address", "value": "GBF3XFXGBGNQDN3HOSZ7NVRF6TJ2JOD5U6ELIWJOOEI6T5WKMQT2YSXQ" },
+				{ "type": "phone_number", "value": "+10000000000" },
+				{ "type": "email", "value": "user1@example.com" }
+			]
+		}
+	]
+}`
+	r := httptest.NewRequest("POST", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", strings.NewReader(req))
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Post("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"error": "The request was invalid in some way."
+}`
+	assert.JSONEq(t, wantBody, string(body))
+
+	_, err = s.Get("GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N")
+	assert.Equal(t, account.ErrNotFound, err)
+}
+
 func TestAccountPost_authMethodTypeUnrecognized(t *testing.T) {
 	s := account.NewMemoryStore()
 	s.Add(account.Account{

--- a/exp/services/recoverysigner/internal/serve/account_post_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_post_test.go
@@ -476,6 +476,47 @@ func TestAccountPost_roleNotProvided(t *testing.T) {
 	assert.Equal(t, account.ErrNotFound, err)
 }
 
+func TestAccountPost_authMethodsNotProvided(t *testing.T) {
+	s := account.NewMemoryStore()
+	h := accountPostHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N"})
+	req := `{
+	"identities": [
+		{
+			"role": "owner"
+		}
+	]
+}`
+	r := httptest.NewRequest("POST", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", strings.NewReader(req))
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Post("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"error": "The request was invalid in some way."
+}`
+	assert.JSONEq(t, wantBody, string(body))
+
+	_, err = s.Get("GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N")
+	assert.Equal(t, account.ErrNotFound, err)
+}
+
 func TestAccountPost_authMethodTypeUnrecognized(t *testing.T) {
 	s := account.NewMemoryStore()
 	s.Add(account.Account{


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add some validations to the account post endpoint request body:
- Require at least one identity.
- Require a value for the `role` field.
- Require at least one authentication method for each identity.

The change also updates the authentication method type validation that already exists to use the same format.

### Why

There's no validation on most fields. It would be good to make sure that a client is at least passing the fields required for some success.

For #2388

### Known limitations

This doesn't do all the validation we could do. It doesn't validate the more complex fields like the authentication method values, but it does lay the ground work for where that validation can live.

### Reviewing

Each commit in this PR adds each validation and it may be easier to review each one in isolation. For some it might be easier to look at the changes as a whole as you get a clearer picture of how it all comes together. For this reason I opened this as one PR and not four.
