### PR TITLE
protocols/horizon: Add Flags attribute to Balance resource.

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -197,7 +197,10 @@ type Balance struct {
 	BuyingLiabilities  string `json:"buying_liabilities"`
 	SellingLiabilities string `json:"selling_liabilities"`
 	LastModifiedLedger uint32 `json:"last_modified_ledger,omitempty"`
-	IsAuthorized       *bool  `json:"is_authorized,omitempty"`
+	// Action needed in release: horizon-v2.0.0
+	// remove IsAuthorized in favor of Flags
+	IsAuthorized *bool  `json:"is_authorized,omitempty"`
+	Flags        uint32 `json:"flags"`
 	base.Asset
 }
 

--- a/services/horizon/internal/resourceadapter/balance.go
+++ b/services/horizon/internal/resourceadapter/balance.go
@@ -23,6 +23,7 @@ func PopulateBalance(dest *protocol.Balance, row core.Trustline) (err error) {
 	dest.Issuer = row.Issuer
 	dest.Code = row.Assetcode
 	dest.LastModifiedLedger = row.LastModified
+	dest.Flags = uint32(row.Flags)
 	isAuthorized := row.IsAuthorized()
 	dest.IsAuthorized = &isAuthorized
 	return
@@ -41,6 +42,7 @@ func PopulateHistoryBalance(dest *protocol.Balance, row history.TrustLine) (err 
 	dest.Issuer = row.AssetIssuer
 	dest.Code = row.AssetCode
 	dest.LastModifiedLedger = row.LastModifiedLedger
+	dest.Flags = uint32(row.Flags)
 	isAuthorized := row.IsAuthorized()
 	dest.IsAuthorized = &isAuthorized
 	return

--- a/services/horizon/internal/resourceadapter/balance_test.go
+++ b/services/horizon/internal/resourceadapter/balance_test.go
@@ -41,6 +41,7 @@ func TestPopulateBalance(t *testing.T) {
 	assert.Equal(t, "", want.Issuer)
 	assert.Equal(t, testAssetCode1, want.Code)
 	assert.Equal(t, true, *want.IsAuthorized)
+	assert.Equal(t, uint32(1), want.Flags)
 
 	want = Balance{}
 	err = PopulateBalance(&want, unauthorizedTrustline)
@@ -51,6 +52,7 @@ func TestPopulateBalance(t *testing.T) {
 	assert.Equal(t, "", want.Issuer)
 	assert.Equal(t, testAssetCode2, want.Code)
 	assert.Equal(t, false, *want.IsAuthorized)
+	assert.Equal(t, uint32(2), want.Flags)
 }
 
 func TestPopulateHistoryBalance(t *testing.T) {
@@ -84,6 +86,7 @@ func TestPopulateHistoryBalance(t *testing.T) {
 	assert.Equal(t, "", want.Issuer)
 	assert.Equal(t, testAssetCode1, want.Code)
 	assert.Equal(t, true, *want.IsAuthorized)
+	assert.Equal(t, uint32(1), want.Flags)
 
 	want = Balance{}
 	err = PopulateHistoryBalance(&want, unauthorizedTrustline)
@@ -94,6 +97,7 @@ func TestPopulateHistoryBalance(t *testing.T) {
 	assert.Equal(t, "", want.Issuer)
 	assert.Equal(t, testAssetCode2, want.Code)
 	assert.Equal(t, false, *want.IsAuthorized)
+	assert.Equal(t, uint32(2), want.Flags)
 }
 
 func TestPopulateNativeBalance(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Extend the balance resource to expose a trust line's authorization flags and soft-deprecate `is_authorized`.

### Why

CAP18 adds a new authorization flags to trustline, instead of adding new attributes to the balance resource, we'll expose attribute`flags` and add helpers at the SDKs around this value like:

- `isAuthorized`
- `isAuthorizedToMaintainLiabilities`

Exposing the flags value instead of adding new helpers in the JSON response, give us enough flexibility to start rolling this out now and also support more flags in the future.

Fixes part of  #2357


### Known limitations

[TODO or N/A]
