### PR TITLE
all: run tests on postgres v10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,8 +177,8 @@ jobs:
       - install_go_deps
       - test_packages
 
-  # test_code_1_13_postgres10 performs all package tests using Go 1.13 and Postgres 10.
-  test_code_1_13_postgres10:
+  # test_code_1_13_postgres11 performs all package tests using Go 1.13 and Postgres 11.
+  test_code_1_13_postgres11:
     working_directory: /go/src/github.com/stellar/go
     docker:
       - image: circleci/golang:1.13-stretch
@@ -190,7 +190,7 @@ jobs:
           PGDATABASE: circle_test
           MYSQL_HOST: 127.0.0.1
           MYSQL_PORT: 3306
-      - image: circleci/postgres:10-alpine
+      - image: circleci/postgres:11-alpine
         environment:
           POSTGRES_USER: circleci
       - image: circleci/redis:5.0-alpine
@@ -220,8 +220,8 @@ jobs:
       - test_packages
       - send_coverage_report
 
-  # test_code_1_14 performs all package tests using Go 1.14 and Postgres 10.
-  test_code_1_14_postgres10:
+  # test_code_1_14 performs all package tests using Go 1.14 and Postgres 11.
+  test_code_1_14_postgres11:
     working_directory: /go/src/github.com/stellar/go
     docker:
       - image: circleci/golang:1.14-stretch
@@ -233,7 +233,7 @@ jobs:
           PGDATABASE: circle_test
           MYSQL_HOST: 127.0.0.1
           MYSQL_PORT: 3306
-      - image: circleci/postgres:10-alpine
+      - image: circleci/postgres:11-alpine
         environment:
           POSTGRES_USER: circleci
       - image: circleci/redis:5.0-alpine
@@ -322,9 +322,9 @@ workflows:
     jobs:
       - check_code_1_14
       - test_code_1_13
-      - test_code_1_13_postgres10
+      - test_code_1_13_postgres11
       - test_code_1_14
-      - test_code_1_14_postgres10
+      - test_code_1_14_postgres11
       - publish_state_diff_docker_image:
           filters:
               branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,6 @@ jobs:
     steps:
       - install_go_deps
       - test_packages
-      - send_coverage_report
 
   # test_code_1_14 performs all package tests using Go 1.14 and Postgres 11.
   test_code_1_14_postgres11:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,27 @@ jobs:
       - install_go_deps
       - test_packages
 
+  # test_code_1_13_postgres10 performs all package tests using Go 1.13 and Postgres 10.
+  test_code_1_13_postgres10:
+    working_directory: /go/src/github.com/stellar/go
+    docker:
+      - image: circleci/golang:1.13-stretch
+        environment:
+          GO111MODULE: "on"
+          PGHOST: localhost
+          PGPORT: 5432
+          PGUSER: circleci
+          PGDATABASE: circle_test
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_PORT: 3306
+      - image: circleci/postgres:10-alpine
+        environment:
+          POSTGRES_USER: circleci
+      - image: circleci/redis:5.0-alpine
+    steps:
+      - install_go_deps
+      - test_packages
+
   # test_code_1_14 performs all package tests using Go 1.14.
   test_code_1_14:
     working_directory: /go/src/github.com/stellar/go
@@ -191,6 +212,28 @@ jobs:
           MYSQL_HOST: 127.0.0.1
           MYSQL_PORT: 3306
       - image: circleci/postgres:9.6.5-alpine-ram
+        environment:
+          POSTGRES_USER: circleci
+      - image: circleci/redis:5.0-alpine
+    steps:
+      - install_go_deps
+      - test_packages
+      - send_coverage_report
+
+  # test_code_1_14 performs all package tests using Go 1.14 and Postgres 10.
+  test_code_1_14_postgres10:
+    working_directory: /go/src/github.com/stellar/go
+    docker:
+      - image: circleci/golang:1.14-stretch
+        environment:
+          GO111MODULE: "on"
+          PGHOST: localhost
+          PGPORT: 5432
+          PGUSER: circleci
+          PGDATABASE: circle_test
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_PORT: 3306
+      - image: circleci/postgres:10-alpine
         environment:
           POSTGRES_USER: circleci
       - image: circleci/redis:5.0-alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,8 +177,8 @@ jobs:
       - install_go_deps
       - test_packages
 
-  # test_code_1_13_postgres11 performs all package tests using Go 1.13 and Postgres 11.
-  test_code_1_13_postgres11:
+  # test_code_1_13_postgres10 performs all package tests using Go 1.13 and Postgres 10.
+  test_code_1_13_postgres10:
     working_directory: /go/src/github.com/stellar/go
     docker:
       - image: circleci/golang:1.13-stretch
@@ -190,7 +190,7 @@ jobs:
           PGDATABASE: circle_test
           MYSQL_HOST: 127.0.0.1
           MYSQL_PORT: 3306
-      - image: circleci/postgres:11-alpine-ram
+      - image: circleci/postgres:10-alpine-ram
         environment:
           POSTGRES_USER: circleci
       - image: circleci/redis:5.0-alpine
@@ -219,8 +219,8 @@ jobs:
       - install_go_deps
       - test_packages
 
-  # test_code_1_14 performs all package tests using Go 1.14 and Postgres 11.
-  test_code_1_14_postgres11:
+  # test_code_1_14 performs all package tests using Go 1.14 and Postgres 10.
+  test_code_1_14_postgres10:
     working_directory: /go/src/github.com/stellar/go
     docker:
       - image: circleci/golang:1.14-stretch
@@ -232,7 +232,7 @@ jobs:
           PGDATABASE: circle_test
           MYSQL_HOST: 127.0.0.1
           MYSQL_PORT: 3306
-      - image: circleci/postgres:11-alpine-ram
+      - image: circleci/postgres:10-alpine-ram
         environment:
           POSTGRES_USER: circleci
       - image: circleci/redis:5.0-alpine
@@ -321,9 +321,9 @@ workflows:
     jobs:
       - check_code_1_14
       - test_code_1_13
-      - test_code_1_13_postgres11
+      - test_code_1_13_postgres10
       - test_code_1_14
-      - test_code_1_14_postgres11
+      - test_code_1_14_postgres10
       - publish_state_diff_docker_image:
           filters:
               branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,8 +177,8 @@ jobs:
       - install_go_deps
       - test_packages
 
-  # test_code_1_13_postgres10 performs all package tests using Go 1.13 and Postgres 10.
-  test_code_1_13_postgres10:
+  # test_code_1_13_postgres11 performs all package tests using Go 1.13 and Postgres 11.
+  test_code_1_13_postgres11:
     working_directory: /go/src/github.com/stellar/go
     docker:
       - image: circleci/golang:1.13-stretch
@@ -190,7 +190,7 @@ jobs:
           PGDATABASE: circle_test
           MYSQL_HOST: 127.0.0.1
           MYSQL_PORT: 3306
-      - image: circleci/postgres:10-alpine-ram
+      - image: circleci/postgres:11-alpine-ram
         environment:
           POSTGRES_USER: circleci
       - image: circleci/redis:5.0-alpine
@@ -219,8 +219,8 @@ jobs:
       - install_go_deps
       - test_packages
 
-  # test_code_1_14 performs all package tests using Go 1.14 and Postgres 10.
-  test_code_1_14_postgres10:
+  # test_code_1_14 performs all package tests using Go 1.14 and Postgres 11.
+  test_code_1_14_postgres11:
     working_directory: /go/src/github.com/stellar/go
     docker:
       - image: circleci/golang:1.14-stretch
@@ -232,7 +232,7 @@ jobs:
           PGDATABASE: circle_test
           MYSQL_HOST: 127.0.0.1
           MYSQL_PORT: 3306
-      - image: circleci/postgres:10-alpine-ram
+      - image: circleci/postgres:11-alpine-ram
         environment:
           POSTGRES_USER: circleci
       - image: circleci/redis:5.0-alpine
@@ -321,9 +321,9 @@ workflows:
     jobs:
       - check_code_1_14
       - test_code_1_13
-      - test_code_1_13_postgres10
+      - test_code_1_13_postgres11
       - test_code_1_14
-      - test_code_1_14_postgres10
+      - test_code_1_14_postgres11
       - publish_state_diff_docker_image:
           filters:
               branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
           PGDATABASE: circle_test
           MYSQL_HOST: 127.0.0.1
           MYSQL_PORT: 3306
-      - image: circleci/postgres:11-alpine
+      - image: circleci/postgres:11-alpine-ram
         environment:
           POSTGRES_USER: circleci
       - image: circleci/redis:5.0-alpine
@@ -232,7 +232,7 @@ jobs:
           PGDATABASE: circle_test
           MYSQL_HOST: 127.0.0.1
           MYSQL_PORT: 3306
-      - image: circleci/postgres:11-alpine
+      - image: circleci/postgres:11-alpine-ram
         environment:
           POSTGRES_USER: circleci
       - image: circleci/redis:5.0-alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,9 @@ workflows:
     jobs:
       - check_code_1_14
       - test_code_1_13
+      - test_code_1_13_postgres10
       - test_code_1_14
+      - test_code_1_14_postgres10
       - publish_state_diff_docker_image:
           filters:
               branches:

--- a/support/db/dbtest/db.go
+++ b/support/db/dbtest/db.go
@@ -5,6 +5,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/jmoiron/sqlx"
@@ -81,6 +83,22 @@ func (db *DB) Open() *sqlx.DB {
 	require.NoError(db.t, err)
 
 	return conn
+}
+
+func (db *DB) Version() (major int) {
+	conn := db.Open()
+	defer conn.Close()
+
+	versionFull := ""
+	err := conn.Get(&versionFull, "SHOW server_version")
+	require.NoError(db.t, err)
+
+	version := strings.Fields(versionFull)
+	parts := strings.Split(version[0], ".")
+	major, err = strconv.Atoi(parts[0])
+	require.NoError(db.t, err)
+
+	return major
 }
 
 func execStatement(t *testing.T, pguser, query string) {

--- a/support/db/dbtest/postgres_test.go
+++ b/support/db/dbtest/postgres_test.go
@@ -41,3 +41,9 @@ func TestPostgres_clientTimezone(t *testing.T) {
 	wantTimestamp := time.Date(2020, 3, 19, 16, 56, 0, 0, time.UTC)
 	assert.Equal(t, wantTimestamp, timestamp)
 }
+
+func TestPostgres_Version(t *testing.T) {
+	db := Postgres(t)
+	majorVersion := db.Version()
+	assert.GreaterOrEqual(t, majorVersion, 9)
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Run tests on Postgres v10 and add function to `support/db/dbtest` that exposes the current version of Postgres that's running.

### Why
Recoverysigner (`exp/services/recoverysigner`) is going to be using the IDENTITY feature of Postgres that was introduced in v10 which makes it easier and safer to copy records into an audit table, as well as being the recommended way of doing auto-incrementing primary keys now. Recoverysigner's tests are going to use the new version function to skip themselves if the tests are being run against an older version of Postgres.

Also I heard that at some point we'll be wanting to support Postgres v11 on Horizon and run tests for it, and so now seems like a good time to start running tests for a newer version of Postgres against to provide some confidence towards that in the future.

### Known limitations

This will increase build times a little because more builds will need to finish.

### Alternative approaches considered

We could use Go build tags so that the tests that require Postgres 10 are separated and only run in certain cases, but it's really annoying on developers to need to add build tags when running Go commands and it will be easy to accidentally not run the tests. Skipping is much simpler for a developer to interact with. Tests that are skipped will output a special message saying why they were skipped.