### PR TITLE
services/horizon: Add machine-readable comment for Redis flag removal

### DIFF
--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -218,12 +218,14 @@ var configOpts = support.ConfigOptions{
 		},
 		Usage: "max count of requests allowed in a one hour period, by remote ip address",
 	},
-	&support.ConfigOption{ // To be removed in Horizon 2.0.0
+	&support.ConfigOption{ // Action needed in release: horizon-v2.0.0
+		// remove deprecated flag
 		Name:    "rate-limit-redis-key",
 		OptType: types.String,
 		Usage:   "deprecated, do not use",
 	},
-	&support.ConfigOption{ // To be removed in horizon 2.0.0
+	&support.ConfigOption{ // Action needed in release: horizon-v2.0.0
+		// remove deprecated flag
 		Name:    "redis-url",
 		OptType: types.String,
 		Usage:   "deprecated, do not use",


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

Followup from #2409 (see https://github.com/stellar/go/pull/2409#discussion_r397416598 )

To be merged into master in a later PR
