### PR TITLE
exp/services/recoverysigner: fix db error logged

### DIFF
--- a/exp/services/recoverysigner/internal/serve/serve.go
+++ b/exp/services/recoverysigner/internal/serve/serve.go
@@ -99,7 +99,7 @@ func getHandlerDeps(opts Options) (handlerDeps, error) {
 
 		dbErr = db.Ping()
 		if dbErr != nil {
-			opts.Logger.Warn("Error pinging to Database: ", err)
+			opts.Logger.Warn("Error pinging to Database: ", dbErr)
 		}
 
 		accountStore = &account.DBStore{DB: db}


### PR DESCRIPTION


<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Correct which value is included in the log line that is outputting the
database error, so that we're printing the database error and not some
prior error.

### Why
Looks like we're printing the wrong error. We're printing `err`, but
`dbErr` is the error in this moment we're wanting to log.

### Known limitations

N/A
