### PR TITLE
services/horizon/docker: Update verify-range to use 1.0.0 as base.

### DIFF
--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -59,7 +59,6 @@ export NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 export HISTORY_ARCHIVE_URLS="https://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-live/core_live_001"
 export DATABASE_URL="postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable"
 export INGEST="false"
-export ENABLE_EXPERIMENTAL_INGESTION="true"
 export INGEST_FAILED_TRANSACTIONS=true
 export STELLAR_CORE_URL="http://localhost:11626"
 export STELLAR_CORE_DATABASE_URL="postgres://postgres:postgres@localhost:5432/core?sslmode=disable"
@@ -86,19 +85,12 @@ if [ ! -z "$VERIFY_HISTORY" ]; then
 	# sudo -u postgres dropdb horizon
 	# sudo -u postgres createdb horizon
 
-	git checkout h_0.24.1_v2_meta
+	git checkout verify_range_base_horizon_v1.0.0
 
 	/usr/local/go/bin/go build -v ./services/horizon
 
-	export INGEST="true"
-	export ENABLE_EXPERIMENTAL_INGESTION="false"
-
 	./horizon db migrate up
-	# We ignore the first ledger when reingesting using legacy ingestion because
-	# verify range doesn't ingest history for the first ledger. $FROM ledger from
-	# this job will be checked because it's $TO of the previous job.
-	export FROM_LEGACY=`expr "$FROM" + "1"`
-	./horizon db reingest range $FROM_LEGACY $TO
+	./horizon expingest verify-range --from $FROM --to $TO --verify-state
 
 	dump_horizon_db "legacy_history"
 	echo "Done dump_horizon_db legacy_history"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Update verify-range to use Horizon 1.0.0 as the base. We'll use a special branch with ingestion related changes cherry-picked into it. 

Fix #2389 

### Why

Now that we have 2 release of Horizon 1.0.0, we can move to Horizon 1.0.0 as the base. This will make easier testing since we can cherry-pick easily ingestion related changes into 1.0.0 than 0.24.0

Running this right now against our protocol-13 branch yields

```
docker run  -e BRANCH=protocol-13 -e FROM=5772543 -e TO=5772607 -e VERIFY_HISTORY=true  verify-range 
...
< 24792947824267266,24792947824267264,2,7,{"trustee": "GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U", "trustor": "GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK", "authorize": true, "asset_code": "XBT", "asset_type": "credit_alphanum4", "asset_issuer": "GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U"},GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U
---
> 24792947824267266,24792947824267264,2,7,{"trustee": "GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U", "trustor": "GC2BQYBXFOVPRDH35D5HT2AFVCDGXJM5YVTAF5THFSAISYOWAJQKRESK", "authorize": true, "asset_code": "XBT", "asset_type": "credit_alphanum4", "asset_issuer": "GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U", "authorize_to_maintain_liabilities": true},GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U
```

Which is correct since we haven't cherry-picked changes  in ingestion yet. 


### Known limitations

[TODO or N/A]
