### PR TITLE
tools/horizon-cmp: Remove fields added in Horizon 1.1.0

### DIFF
--- a/tools/horizon-cmp/internal/response.go
+++ b/tools/horizon-cmp/internal/response.go
@@ -62,7 +62,7 @@ var replaceRegexps = []replace{
 	},
 }
 
-var accountDetailsPathRegexp = regexp.MustCompile(`^/accounts/[A-Z]+[^/]+$`)
+var newAccountDetailsPathWithLastestLedger = regexp.MustCompile(`^/accounts/[A-Z]+/(transactions|operations|payments|effects|trades)/?`)
 
 type Response struct {
 	Domain string
@@ -147,8 +147,15 @@ func NewResponse(domain, path string, stream bool) *Response {
 		normalizedBody = reg.regexp.ReplaceAllString(normalizedBody, reg.repl)
 	}
 
-	// 1.0.0-alpha - skip Latest-Ledger in /accounts/{id}
-	if !accountDetailsPathRegexp.Match([]byte(path)) {
+	// 1.1.0 - skip Latest-Ledger header in newly incorporated endpoints
+	if !(newAccountDetailsPathWithLastestLedger.Match([]byte(path)) ||
+		strings.HasPrefix(path, "/ledgers") ||
+		strings.HasPrefix(path, "/transactions") ||
+		strings.HasPrefix(path, "/operations") ||
+		strings.HasPrefix(path, "/payments") ||
+		strings.HasPrefix(path, "/effects") ||
+		strings.HasPrefix(path, "/transactions") ||
+		strings.Contains(path, "/trade")) {
 		response.NormalizedBody = fmt.Sprintf("Latest-Ledger: %s\n%s", resp.Header.Get("Latest-Ledger"), normalizedBody)
 	}
 	return response

--- a/tools/horizon-cmp/internal/response.go
+++ b/tools/horizon-cmp/internal/response.go
@@ -35,6 +35,10 @@ var removeRegexps = []*regexp.Regexp{
 	// regexp.MustCompile(`\s*"public_key": "G.*",`),
 	// regexp.MustCompile(`,\s*"paging_token": ?""`),
 	regexp.MustCompile(`\s*"fee_paid": ?[0-9]+,`),
+	// Removes fields added in Horizon 1.1.0.
+	regexp.MustCompile(`\s*"is_authorized_to_maintain_liabilities": ?(true|false),`),
+	regexp.MustCompile(`\s*"authorize_to_maintain_liabilities": ?(true|false),`),
+	regexp.MustCompile(`\s*"fee_account": ?"G\w{55}",`),
 }
 
 type replace struct {

--- a/tools/horizon-cmp/internal/response.go
+++ b/tools/horizon-cmp/internal/response.go
@@ -62,7 +62,7 @@ var replaceRegexps = []replace{
 	},
 }
 
-var newAccountDetailsPathWithLastestLedger = regexp.MustCompile(`^/accounts/[A-Z]+/(transactions|operations|payments|effects|trades)/?`)
+var newAccountDetailsPathWithLastestLedger = regexp.MustCompile(`^/accounts/[A-Z0-9]+/(transactions|operations|payments|effects|trades)/?`)
 
 type Response struct {
 	Domain string


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove fields added in Horizon 1.1.0 to avoid false positives.

### Why

Horizon 1.1.0 adds a couple of new fields, if we were to run horizon-cmp  between 1.0.1 and 1.1.0, then we'll get failures on new fields. 


### Known limitations

[TODO or N/A]
