### PR TITLE
services/horizon/docker: Upgrade Stellar Core docker container to protocol 13

### DIFF
--- a/services/horizon/docker/README.md
+++ b/services/horizon/docker/README.md
@@ -81,6 +81,9 @@ By default, the Docker Compose file configures Stellar Core to connect to the St
 Stellar public network, run `docker-compose -f docker-compose.yml -f docker-compose.pubnet.yml up -d --build`. 
 
 To run the containers on a private stand alone network, run `docker-compose -f docker-compose.yml -f docker-compose.standalone.yml up -d --build`.
+When you run Stellar Core on a private stand alone network, an account will be created which will hold 100 billion Lumens.
+The seed for the account can be found in [stellar-core-standalone.cfg](./stellar-core-standalone.cfg) (see `NODE_SEED` parameter). 
+The seed is also emitted in the Stellar Core logs.
 
 When you switch between different networks you will need to clear the Stellar Core and Stellar Horizon databases. You can wipe out the databases by running `docker-compose down -v`.
 

--- a/services/horizon/docker/core-start.sh
+++ b/services/horizon/docker/core-start.sh
@@ -10,7 +10,7 @@ cat stellar-core.cfg
 # initialize new db
 stellar-core new-db
 
-if [ $1 = "standalone" ]; then
+if [ "$1" = "standalone" ]; then
   # start a network from scratch
   stellar-core force-scp
 

--- a/services/horizon/docker/docker-compose.standalone.yml
+++ b/services/horizon/docker/docker-compose.standalone.yml
@@ -20,3 +20,4 @@ services:
     image: curlimages/curl:7.69.1
     command: ["-v", "-f", "http://host.docker.internal:11626/upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z&protocolversion=13"]
     network_mode: '${NETWORK_MODE:-bridge}'
+    

--- a/services/horizon/docker/docker-compose.standalone.yml
+++ b/services/horizon/docker/docker-compose.standalone.yml
@@ -1,6 +1,9 @@
 version: '3'
 services:
   core:
+    depends_on:
+      - core-postgres
+      - core-upgrade
     ports:
       # add extra port for history archive server
       - "1570:1570"
@@ -11,3 +14,9 @@ services:
     environment:
       - HISTORY_ARCHIVE_URLS=http://host.docker.internal:1570
       - NETWORK_PASSPHRASE=Standalone Network ; February 2017
+  # this container will invoke a request to upgrade stellar core to protocol 13
+  core-upgrade:
+    restart: on-failure
+    image: curlimages/curl:7.69.1
+    command: ["-v", "-f", "http://host.docker.internal:11626/upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z&protocolversion=13"]
+    network_mode: '${NETWORK_MODE:-bridge}'

--- a/services/horizon/docker/docker-compose.yml
+++ b/services/horizon/docker/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     image: stellar/stellar-core
     depends_on:
       - core-postgres
-    restart: always
+    restart: on-failure
     ports:
       - "11625:11625"
       - "11626:11626"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

When you start Stellar Core in standalone mode it defaults to generating ledgers with protocol version equal to 0.

To upgrade the Stellar Core protocol version you need to run an "upgrades" command:

https://github.com/stellar/stellar-core/blob/master/docs/software/commands.md#http-commands

This commit adds a container which automatically upgrades the Stellar Core container to run on protocol 13.

### Why

Generating protocol 0 ledgers isn't a good default because it will not be compatible with Horizon ingestion unless you set `SUPPORTED_META_VERSION` to 2 in the Stellar Core config file. 

### Known limitations

There could be a use case where someone wants to run an older version of the protocol. To make that change you should edit the `core-upgrade` container command and change the `protocolversion` parameter.
