### PR TITLE
services/horizon: Fix typo in GET /ledger(s) hal link

### DIFF
--- a/services/horizon/internal/resourceadapter/root.go
+++ b/services/horizon/internal/resourceadapter/root.go
@@ -44,7 +44,7 @@ func PopulateRoot(
 	dest.Links.Assets = lb.Link("/assets{?asset_code,asset_issuer,cursor,limit,order}")
 	dest.Links.Effects = lb.Link("/effects{?cursor,limit,order}")
 	dest.Links.Ledger = lb.Link("/ledger/{sequence}")
-	dest.Links.Ledger = lb.Link("/ledgers{?cursor,limit,order}")
+	dest.Links.Ledgers = lb.Link("/ledgers{?cursor,limit,order}")
 	dest.Links.FeeStats = lb.Link("/fee_stats")
 	dest.Links.Operation = lb.Link("/operations/{id}")
 	dest.Links.Operations = lb.Link("/operations{?cursor,limit,order,include_failed}")


### PR DESCRIPTION
Followup to #2407 

It fixes a problem found by @JakeUrban , see https://github.com/stellar/go/issues/2402#issuecomment-608014439

Fixes #2402 