### PR TITLE
exp/services/webauth: change JWT key config option to a JWK

### DIFF
--- a/exp/services/webauth/README.md
+++ b/exp/services/webauth/README.md
@@ -25,8 +25,9 @@ Usage:
   webauth [command]
 
 Available Commands:
-  genjwtkey   Generate a JWT ECDSA key
-  serve       Run the SEP-10 Web Authentication server
+  convjwtkey2jwk Convert a JWT ECDSA private key ASN.1 DER Base64 encoded that was generated with the old genjwtkey command to a JSON Web Key
+  genjwk         Generate a JSON Web Key (ECDSA/ES256) for JWT issuing
+  serve          Run the SEP-10 Web Authentication server
 
 Flags:
   -h, --help   help for webauth
@@ -47,9 +48,9 @@ Flags:
       --allow-accounts-that-do-not-exist   Allow accounts that do not exist (ALLOW_ACCOUNTS_THAT_DO_NOT_EXIST)
       --challenge-expires-in int           The time period in seconds after which the challenge transaction expires (CHALLENGE_EXPIRES_IN) (default 300)
       --horizon-url string                 Horizon URL used for looking up account details (HORIZON_URL) (default "https://horizon-testnet.stellar.org/")
+      --jwk string                         JSON Web Key (JWK) used for signing JWTs (if the key is an asymmetric key that has separate public and private key, the JWK must contain the private key) (JWK)
       --jwt-expires-in int                 The time period in seconds after which the JWT expires (JWT_EXPIRES_IN) (default 300)
       --jwt-issuer string                  The issuer to set in the JWT iss claim (JWT_ISSUER)
-      --jwt-key string                     Base64 encoded ECDSA private key used for signing JWTs (JWT_KEY)
       --network-passphrase string          Network passphrase of the Stellar network transactions should be signed for (NETWORK_PASSPHRASE) (default "Test SDF Network ; September 2015")
       --port int                           Port to listen and serve on (PORT) (default 8000)
       --signing-key string                 Stellar signing key used for signing transactions (SIGNING_KEY)

--- a/exp/services/webauth/cmd/convjwt2jwk.go
+++ b/exp/services/webauth/cmd/convjwt2jwk.go
@@ -9,14 +9,14 @@ import (
 	"gopkg.in/square/go-jose.v2"
 )
 
-type ConvJWTKeyCommand struct {
+type ConvJWTKeyToJWKCommand struct {
 	Logger *supportlog.Entry
 }
 
-func (c *ConvJWTKeyCommand) Command() *cobra.Command {
+func (c *ConvJWTKeyToJWKCommand) Command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "convjwtkey [key]",
-		Short: "Convert a JWT ECDSA key ASN.1 DER Base64 encoded to a JSON Web Key",
+		Use:   "convjwtkey2jwk [jwt-key]",
+		Short: "Convert a JWT ECDSA private key ASN.1 DER Base64 encoded that was generated with the old genjwtkey command to a JSON Web Key",
 		Run: func(_ *cobra.Command, args []string) {
 			c.Run(args)
 		},
@@ -24,7 +24,7 @@ func (c *ConvJWTKeyCommand) Command() *cobra.Command {
 	return cmd
 }
 
-func (c *ConvJWTKeyCommand) Run(args []string) {
+func (c *ConvJWTKeyToJWKCommand) Run(args []string) {
 	if len(args) != 1 {
 		c.Logger.Fatal("One key (ASN.1 DER Base64 encoded) must be provided.")
 	}

--- a/exp/services/webauth/cmd/convjwtkey.go
+++ b/exp/services/webauth/cmd/convjwtkey.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"encoding/json"
+
+	"github.com/spf13/cobra"
+	"github.com/stellar/go/exp/support/jwtkey"
+	supportlog "github.com/stellar/go/support/log"
+	"gopkg.in/square/go-jose.v2"
+)
+
+type ConvJWTKeyCommand struct {
+	Logger *supportlog.Entry
+}
+
+func (c *ConvJWTKeyCommand) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "convjwtkey [key]",
+		Short: "Convert a JWT ECDSA key ASN.1 DER Base64 encoded to a JSON Web Key",
+		Run: func(_ *cobra.Command, args []string) {
+			c.Run(args)
+		},
+	}
+	return cmd
+}
+
+func (c *ConvJWTKeyCommand) Run(args []string) {
+	if len(args) != 1 {
+		c.Logger.Fatal("One key (ASN.1 DER Base64 encoded) must be provided.")
+	}
+
+	k, err := jwtkey.PrivateKeyFromString(args[0])
+	if err != nil {
+		c.Logger.Fatal(err)
+	}
+
+	alg := jose.ES256
+
+	{
+		jwk := jose.JSONWebKey{Key: &k.PublicKey, Algorithm: string(alg)}
+		bytes, err := json.Marshal(jwk)
+		if err == nil {
+			c.Logger.Print("Public:", string(bytes))
+		} else {
+			c.Logger.Print("Public:", err)
+		}
+	}
+
+	{
+		jwk := jose.JSONWebKey{Key: k, Algorithm: string(alg)}
+		bytes, err := json.Marshal(jwk)
+		if err == nil {
+			c.Logger.Print("Private:", string(bytes))
+		} else {
+			c.Logger.Print("Private:", err)
+		}
+	}
+}

--- a/exp/services/webauth/cmd/genjwk.go
+++ b/exp/services/webauth/cmd/genjwk.go
@@ -9,13 +9,13 @@ import (
 	"gopkg.in/square/go-jose.v2"
 )
 
-type GenJWTKeyCommand struct {
+type GenJWKCommand struct {
 	Logger *supportlog.Entry
 }
 
-func (c *GenJWTKeyCommand) Command() *cobra.Command {
+func (c *GenJWKCommand) Command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "genjwtkey",
+		Use:   "genjwk",
 		Short: "Generate a JSON Web Key (ECDSA/ES256) for JWT issuing",
 		Run: func(_ *cobra.Command, _ []string) {
 			c.Run()
@@ -24,7 +24,7 @@ func (c *GenJWTKeyCommand) Command() *cobra.Command {
 	return cmd
 }
 
-func (c *GenJWTKeyCommand) Run() {
+func (c *GenJWKCommand) Run() {
 	k, err := jwtkey.GenerateKey()
 	if err != nil {
 		c.Logger.Fatal(err)

--- a/exp/services/webauth/cmd/genjwtkey.go
+++ b/exp/services/webauth/cmd/genjwtkey.go
@@ -16,7 +16,7 @@ type GenJWTKeyCommand struct {
 func (c *GenJWTKeyCommand) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "genjwtkey",
-		Short: "Generate a JWT ECDSA key",
+		Short: "Generate a JSON Web Key (ECDSA/ES256) for JWT issuing",
 		Run: func(_ *cobra.Command, _ []string) {
 			c.Run()
 		},

--- a/exp/services/webauth/cmd/genjwtkey.go
+++ b/exp/services/webauth/cmd/genjwtkey.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"encoding/json"
+
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/exp/support/jwtkey"
 	supportlog "github.com/stellar/go/support/log"
+	"gopkg.in/square/go-jose.v2"
 )
 
 type GenJWTKeyCommand struct {
@@ -27,15 +30,25 @@ func (c *GenJWTKeyCommand) Run() {
 		c.Logger.Fatal(err)
 	}
 
-	if public, err := jwtkey.PublicKeyToString(&k.PublicKey); err == nil {
-		c.Logger.Print("Public:", public)
-	} else {
-		c.Logger.Print("Public:", err)
+	alg := jose.ES256
+
+	{
+		jwk := jose.JSONWebKey{Key: &k.PublicKey, Algorithm: string(alg)}
+		bytes, err := json.Marshal(jwk)
+		if err == nil {
+			c.Logger.Print("Public:", string(bytes))
+		} else {
+			c.Logger.Print("Public:", err)
+		}
 	}
 
-	if private, err := jwtkey.PrivateKeyToString(k); err == nil {
-		c.Logger.Print("Private:", private)
-	} else {
-		c.Logger.Print("Private:", err)
+	{
+		jwk := jose.JSONWebKey{Key: k, Algorithm: string(alg)}
+		bytes, err := json.Marshal(jwk)
+		if err == nil {
+			c.Logger.Print("Private:", string(bytes))
+		} else {
+			c.Logger.Print("Private:", err)
+		}
 	}
 }

--- a/exp/services/webauth/cmd/serve.go
+++ b/exp/services/webauth/cmd/serve.go
@@ -62,7 +62,7 @@ func (c *ServeCommand) Command() *cobra.Command {
 		},
 		{
 			Name:      "jwk",
-			Usage:     "JSON Web Key (JWK) used for signing JWTs",
+			Usage:     "JSON Web Key (JWK) used for signing JWTs (if the key is an asymmetric key that has separate public and private key, the JWK must contain the private key)",
 			OptType:   types.String,
 			ConfigKey: &opts.JWK,
 			Required:  true,

--- a/exp/services/webauth/cmd/serve.go
+++ b/exp/services/webauth/cmd/serve.go
@@ -61,10 +61,10 @@ func (c *ServeCommand) Command() *cobra.Command {
 			Required:       true,
 		},
 		{
-			Name:      "jwt-key",
-			Usage:     "Base64 encoded ECDSA private key used for signing JWTs",
+			Name:      "jwk",
+			Usage:     "JSON Web Key (JWK) used for signing JWTs",
 			OptType:   types.String,
-			ConfigKey: &opts.JWTPrivateKey,
+			ConfigKey: &opts.JWK,
 			Required:  true,
 		},
 		{

--- a/exp/services/webauth/internal/serve/serve.go
+++ b/exp/services/webauth/internal/serve/serve.go
@@ -57,6 +57,9 @@ func handler(opts Options) (http.Handler, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing JSON Web Key (JWK)")
 	}
+	if jwk.Algorithm == "" {
+		return nil, errors.New("algorithm (alg) field must be set")
+	}
 
 	horizonTimeout := 1 * time.Minute
 	httpClient := &http.Client{

--- a/exp/services/webauth/internal/serve/serve.go
+++ b/exp/services/webauth/internal/serve/serve.go
@@ -1,17 +1,18 @@
 package serve
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/stellar/go/clients/horizonclient"
-	"github.com/stellar/go/exp/support/jwtkey"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/support/errors"
 	supporthttp "github.com/stellar/go/support/http"
 	supportlog "github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/health"
+	"gopkg.in/square/go-jose.v2"
 )
 
 type Options struct {
@@ -21,7 +22,7 @@ type Options struct {
 	NetworkPassphrase           string
 	SigningKey                  string
 	ChallengeExpiresIn          time.Duration
-	JWTPrivateKey               string
+	JWK                         string
 	JWTIssuer                   string
 	JWTExpiresIn                time.Duration
 	AllowAccountsThatDoNotExist bool
@@ -51,9 +52,10 @@ func handler(opts Options) (http.Handler, error) {
 		return nil, errors.Wrap(err, "parsing signing key seed")
 	}
 
-	jwtPrivateKey, err := jwtkey.PrivateKeyFromString(opts.JWTPrivateKey)
+	jwk := jose.JSONWebKey{}
+	err = json.Unmarshal([]byte(opts.JWK), jwk)
 	if err != nil {
-		return nil, errors.Wrap(err, "parsing JWT private key")
+		return nil, errors.Wrap(err, "parsing JSON Web Key (JWK)")
 	}
 
 	horizonTimeout := 1 * time.Minute
@@ -83,7 +85,7 @@ func handler(opts Options) (http.Handler, error) {
 		HorizonClient:               horizonClient,
 		NetworkPassphrase:           opts.NetworkPassphrase,
 		SigningAddress:              signingKey.FromAddress(),
-		JWTPrivateKey:               jwtPrivateKey,
+		JWK:                         jwk,
 		JWTIssuer:                   opts.JWTIssuer,
 		JWTExpiresIn:                opts.JWTExpiresIn,
 		AllowAccountsThatDoNotExist: opts.AllowAccountsThatDoNotExist,

--- a/exp/services/webauth/internal/serve/serve.go
+++ b/exp/services/webauth/internal/serve/serve.go
@@ -53,7 +53,7 @@ func handler(opts Options) (http.Handler, error) {
 	}
 
 	jwk := jose.JSONWebKey{}
-	err = json.Unmarshal([]byte(opts.JWK), jwk)
+	err = json.Unmarshal([]byte(opts.JWK), &jwk)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing JSON Web Key (JWK)")
 	}

--- a/exp/services/webauth/internal/serve/token_test.go
+++ b/exp/services/webauth/internal/serve/token_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/square/go-jose.v2"
 )
 
 func TestToken_formInputSuccess(t *testing.T) {
@@ -32,6 +33,7 @@ func TestToken_formInputSuccess(t *testing.T) {
 
 	jwtPrivateKey, err := jwtkey.GenerateKey()
 	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: jwtPrivateKey, Algorithm: string(jose.ES256)}
 
 	account := keypair.MustRandom()
 	t.Logf("Client account: %s", account.Address())
@@ -82,7 +84,7 @@ func TestToken_formInputSuccess(t *testing.T) {
 		HorizonClient:     horizonClient,
 		NetworkPassphrase: network.TestNetworkPassphrase,
 		SigningAddress:    serverKey.FromAddress(),
-		JWTPrivateKey:     jwtPrivateKey,
+		JWK:               jwk,
 		JWTIssuer:         "https://example.com",
 		JWTExpiresIn:      time.Minute,
 	}
@@ -132,6 +134,7 @@ func TestToken_jsonInputSuccess(t *testing.T) {
 
 	jwtPrivateKey, err := jwtkey.GenerateKey()
 	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: jwtPrivateKey, Algorithm: string(jose.ES256)}
 
 	account := keypair.MustRandom()
 	t.Logf("Client account: %s", account.Address())
@@ -182,7 +185,7 @@ func TestToken_jsonInputSuccess(t *testing.T) {
 		HorizonClient:     horizonClient,
 		NetworkPassphrase: network.TestNetworkPassphrase,
 		SigningAddress:    serverKey.FromAddress(),
-		JWTPrivateKey:     jwtPrivateKey,
+		JWK:               jwk,
 		JWTIssuer:         "https://example.com",
 		JWTExpiresIn:      time.Minute,
 	}
@@ -237,6 +240,7 @@ func TestToken_jsonInputValidMultipleSigners(t *testing.T) {
 
 	jwtPrivateKey, err := jwtkey.GenerateKey()
 	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: jwtPrivateKey, Algorithm: string(jose.ES256)}
 
 	account := keypair.MustRandom()
 	t.Logf("Client account: %s", account.Address())
@@ -300,7 +304,7 @@ func TestToken_jsonInputValidMultipleSigners(t *testing.T) {
 		HorizonClient:     horizonClient,
 		NetworkPassphrase: network.TestNetworkPassphrase,
 		SigningAddress:    serverKey.FromAddress(),
-		JWTPrivateKey:     jwtPrivateKey,
+		JWK:               jwk,
 		JWTIssuer:         "https://example.com",
 		JWTExpiresIn:      time.Minute,
 	}
@@ -354,6 +358,7 @@ func TestToken_jsonInputNotEnoughWeight(t *testing.T) {
 
 	jwtPrivateKey, err := jwtkey.GenerateKey()
 	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: jwtPrivateKey, Algorithm: string(jose.ES256)}
 
 	account := keypair.MustRandom()
 	t.Logf("Client account: %s", account.Address())
@@ -404,7 +409,7 @@ func TestToken_jsonInputNotEnoughWeight(t *testing.T) {
 		HorizonClient:     horizonClient,
 		NetworkPassphrase: network.TestNetworkPassphrase,
 		SigningAddress:    serverKey.FromAddress(),
-		JWTPrivateKey:     jwtPrivateKey,
+		JWK:               jwk,
 		JWTIssuer:         "https://example.com",
 		JWTExpiresIn:      time.Minute,
 	}
@@ -437,6 +442,7 @@ func TestToken_jsonInputUnrecognizedSigner(t *testing.T) {
 
 	jwtPrivateKey, err := jwtkey.GenerateKey()
 	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: jwtPrivateKey, Algorithm: string(jose.ES256)}
 
 	account := keypair.MustRandom()
 	t.Logf("Client account: %s", account.Address())
@@ -487,7 +493,7 @@ func TestToken_jsonInputUnrecognizedSigner(t *testing.T) {
 		HorizonClient:     horizonClient,
 		NetworkPassphrase: network.TestNetworkPassphrase,
 		SigningAddress:    serverKey.FromAddress(),
-		JWTPrivateKey:     jwtPrivateKey,
+		JWK:               jwk,
 		JWTIssuer:         "https://example.com",
 		JWTExpiresIn:      time.Minute,
 	}
@@ -520,6 +526,7 @@ func TestToken_jsonInputAccountNotExistSuccess(t *testing.T) {
 
 	jwtPrivateKey, err := jwtkey.GenerateKey()
 	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: jwtPrivateKey, Algorithm: string(jose.ES256)}
 
 	account := keypair.MustRandom()
 	t.Logf("Client account: %s", account.Address())
@@ -565,7 +572,7 @@ func TestToken_jsonInputAccountNotExistSuccess(t *testing.T) {
 		HorizonClient:               horizonClient,
 		NetworkPassphrase:           network.TestNetworkPassphrase,
 		SigningAddress:              serverKey.FromAddress(),
-		JWTPrivateKey:               jwtPrivateKey,
+		JWK:                         jwk,
 		JWTIssuer:                   "https://example.com",
 		JWTExpiresIn:                time.Minute,
 		AllowAccountsThatDoNotExist: true,
@@ -621,6 +628,7 @@ func TestToken_jsonInputAccountNotExistFail(t *testing.T) {
 
 	jwtPrivateKey, err := jwtkey.GenerateKey()
 	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: jwtPrivateKey, Algorithm: string(jose.ES256)}
 
 	account := keypair.MustRandom()
 	t.Logf("Client account: %s", account.Address())
@@ -669,7 +677,7 @@ func TestToken_jsonInputAccountNotExistFail(t *testing.T) {
 		HorizonClient:               horizonClient,
 		NetworkPassphrase:           network.TestNetworkPassphrase,
 		SigningAddress:              serverKey.FromAddress(),
-		JWTPrivateKey:               jwtPrivateKey,
+		JWK:                         jwk,
 		JWTIssuer:                   "https://example.com",
 		JWTExpiresIn:                time.Minute,
 		AllowAccountsThatDoNotExist: true,
@@ -703,6 +711,7 @@ func TestToken_jsonInputAccountNotExistNotAllowed(t *testing.T) {
 
 	jwtPrivateKey, err := jwtkey.GenerateKey()
 	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: jwtPrivateKey, Algorithm: string(jose.ES256)}
 
 	account := keypair.MustRandom()
 	t.Logf("Client account: %s", account.Address())
@@ -748,7 +757,7 @@ func TestToken_jsonInputAccountNotExistNotAllowed(t *testing.T) {
 		HorizonClient:               horizonClient,
 		NetworkPassphrase:           network.TestNetworkPassphrase,
 		SigningAddress:              serverKey.FromAddress(),
-		JWTPrivateKey:               jwtPrivateKey,
+		JWK:                         jwk,
 		JWTIssuer:                   "https://example.com",
 		JWTExpiresIn:                time.Minute,
 		AllowAccountsThatDoNotExist: false,

--- a/exp/services/webauth/main.go
+++ b/exp/services/webauth/main.go
@@ -20,8 +20,8 @@ func main() {
 	}
 
 	rootCmd.AddCommand((&cmd.ServeCommand{Logger: logger}).Command())
-	rootCmd.AddCommand((&cmd.GenJWTKeyCommand{Logger: logger}).Command())
-	rootCmd.AddCommand((&cmd.ConvJWTKeyCommand{Logger: logger}).Command())
+	rootCmd.AddCommand((&cmd.GenJWKCommand{Logger: logger}).Command())
+	rootCmd.AddCommand((&cmd.ConvJWTKeyToJWKCommand{Logger: logger}).Command())
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/exp/services/webauth/main.go
+++ b/exp/services/webauth/main.go
@@ -21,6 +21,7 @@ func main() {
 
 	rootCmd.AddCommand((&cmd.ServeCommand{Logger: logger}).Command())
 	rootCmd.AddCommand((&cmd.GenJWTKeyCommand{Logger: logger}).Command())
+	rootCmd.AddCommand((&cmd.ConvJWTKeyCommand{Logger: logger}).Command())
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/go.list
+++ b/go.list
@@ -147,6 +147,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 gopkg.in/fsnotify.v1 v1.4.7
 gopkg.in/gavv/httpexpect.v1 v1.0.0-20170111145843-40724cf1e4a0
 gopkg.in/gorp.v1 v1.7.1
+gopkg.in/square/go-jose.v2 v2.4.1
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 gopkg.in/tylerb/graceful.v1 v1.2.13
 gopkg.in/yaml.v2 v2.2.2

--- a/go.mod
+++ b/go.mod
@@ -93,5 +93,6 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/gavv/httpexpect.v1 v1.0.0-20170111145843-40724cf1e4a0
 	gopkg.in/gorp.v1 v1.7.1 // indirect
+	gopkg.in/square/go-jose.v2 v2.4.1
 	gopkg.in/tylerb/graceful.v1 v1.2.13
 )

--- a/go.sum
+++ b/go.sum
@@ -320,6 +320,8 @@ gopkg.in/gavv/httpexpect.v1 v1.0.0-20170111145843-40724cf1e4a0 h1:r5ptJ1tBxVAeqw
 gopkg.in/gavv/httpexpect.v1 v1.0.0-20170111145843-40724cf1e4a0/go.mod h1:WtiW9ZA1LdaWqtQRo1VbIL/v4XZ8NDta+O/kSpGgVek=
 gopkg.in/gorp.v1 v1.7.1 h1:GBB9KrWRATQZh95HJyVGUZrWwOPswitEYEyqlK8JbAA=
 gopkg.in/gorp.v1 v1.7.1/go.mod h1:Wo3h+DBQZIxATwftsglhdD/62zRFPhGhTiu5jUJmCaw=
+gopkg.in/square/go-jose.v2 v2.4.1 h1:H0TmLt7/KmzlrDOpa1F+zr0Tk90PbJYBfsVUmRLrf9Y=
+gopkg.in/square/go-jose.v2 v2.4.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/tylerb/graceful.v1 v1.2.13 h1:UWJlWJHZepntB0PJ9RTgW3X+zVLjfmWbx/V1X/V/XoA=


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Change to using the JSON Web Key (JWK) format for configuring the JWK key used by the webauth service to sign JWTs.

### Why
The JSON Web Key (JWK) format is defined in [RFC7517] and makes it easy to configure a web service in a standard way without the service needing to know ahead of time the type of key or algorithm that will be used.  Today the service uses only an ECDSA key and the ES256 algorithm and to change that would require changes to code, but this config will allow us to specify any key and algorithm supported by the `gopkg.in/square/go-jose.v2` package.

This change is an accompanying change to #2450.

Related to #2443.

[RFC7517]: https://tools.ietf.org/html/rfc7517

### Known limitations

This change is a breaking change for the service, but since the service is in the `exp` experimental package we have the capability to make breaking changes.
