### PR TITLE
services/horizon/internal: Only use repeatable read transactions on state endpoints

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -82,7 +82,6 @@ Note that Horizon should not be serving requests or ingesting while the migratio
 * The following attributes are now included in the transaction resource: `fee_account` (the account which paid the transaction fees), `fee_bump_transaction` (only present in fee bump transactions),  `inner_transaction` (only present in fee bump transactions) ([#2406](https://github.com/stellar/go/pull/2406)).
 * It is no longer possible to use Redis as mechanism for rate limiting requests ([#2409](https://github.com/stellar/go/pull/2409))
 * Added missing top-level HAL links to the `GET /` response ([#2407](https://github.com/stellar/go/pull/2407))
-* Add Last-Ledger header to GET endpoints which are not immutable ([#2416](https://github.com/stellar/go/pull/2416))
 
 ## v1.0.1
 


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

In https://github.com/stellar/go/pull/2416 we extended the Last-Ledger header to cover additional endpoints which were not immutable.

@2opremio raised the following point before working on the PR:

> After giving this quite a bit of thought, isn't it overkill to set that header (and in turn access the DB for all endpoints) to make horizon-cmp happy?

After testing the 1.1.0 release candidate on staging we found evidence to confirm this hypothesis. The overhead of wrapping each request in a repeatable read transaction proved to significantly hinder performance.

We should remove this change from the 1.1.0 release. We can always reintroduce this change later on but at this point it would be better to explore other solutions to the underlying problem we are trying to solve (verifying correctness of a horizon release) that have less of a negative impact on performance.

Here are some graphs which display the performance hit:

![image](https://user-images.githubusercontent.com/1445829/78552820-77035500-7808-11ea-839b-23ddd0d1eb4a.png)

The first half of the graph covers a period where the Last-Ledger header was enabled and the second half of the graph covers a period where the header was disabled.
