### PR TITLE
support/httpdecode: avoid calling DecodeJSON for GET requests

### DIFF
--- a/support/http/httpdecode/httpdecode.go
+++ b/support/http/httpdecode/httpdecode.go
@@ -119,5 +119,12 @@ func Decode(r *http.Request, v interface{}) error {
 			return DecodeForm(r, v)
 		}
 	}
-	return DecodeJSON(r, v)
+
+	// A nil body means the request has no body, such as a GET request.
+	// Calling DecodeJSON when receiving GET requests will result in EOF.
+	if r.Body != nil {
+		return DecodeJSON(r, v)
+	}
+
+	return nil
 }

--- a/support/http/httpdecode/httpdecode_test.go
+++ b/support/http/httpdecode/httpdecode_test.go
@@ -327,6 +327,22 @@ func TestDecode_invalidJSON(t *testing.T) {
 	assert.Equal(t, "", bodyDecoded.FooName)
 }
 
+func TestDecode_emptyBody(t *testing.T) {
+	pathDecoded := struct {
+		Foo string `path:"foo"`
+	}{}
+	mux := chi.NewMux()
+	mux.Get("/path/{foo}/path", func(w http.ResponseWriter, r *http.Request) {
+		err := Decode(r, &pathDecoded)
+		require.NoError(t, err)
+	})
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/path/bar/path", nil)
+	mux.ServeHTTP(w, r)
+
+	assert.Equal(t, "bar", pathDecoded.Foo)
+}
+
 func TestDecode_invalidForm(t *testing.T) {
 	body := `foo=%=bar`
 	r, _ := http.NewRequest("POST", "/", strings.NewReader(body))


### PR DESCRIPTION
### What

Check request body before calling DecodeJSON in `Decode`.

### Why

`Decode` calls `DecodePath`, `DecodeQuery`, and `DecodeJSON` unconditionally. However, GET requests don't usually have a request body, so calling `DecodeJSON` is problematic since it uses the request body for unmarshaling. This PR simply adds a check before calling `DecodeJSON`.

### Known limitations

N/A
