### PR TITLE
support/httpdecode: check for http.NoBody before calling DecodeJSON

### DIFF
--- a/support/http/httpdecode/httpdecode.go
+++ b/support/http/httpdecode/httpdecode.go
@@ -122,7 +122,7 @@ func Decode(r *http.Request, v interface{}) error {
 
 	// A nil body means the request has no body, such as a GET request.
 	// Calling DecodeJSON when receiving GET requests will result in EOF.
-	if r.Body != nil {
+	if r.Body != nil && r.Body != http.NoBody {
 		return DecodeJSON(r, v)
 	}
 

--- a/support/http/httpdecode/httpdecode_test.go
+++ b/support/http/httpdecode/httpdecode_test.go
@@ -327,7 +327,7 @@ func TestDecode_invalidJSON(t *testing.T) {
 	assert.Equal(t, "", bodyDecoded.FooName)
 }
 
-func TestDecode_emptyBody(t *testing.T) {
+func TestDecode_clientReqNoBody(t *testing.T) {
 	pathDecoded := struct {
 		Foo string `path:"foo"`
 	}{}
@@ -338,6 +338,22 @@ func TestDecode_emptyBody(t *testing.T) {
 	})
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest("GET", "/path/bar/path", nil)
+	mux.ServeHTTP(w, r)
+
+	assert.Equal(t, "bar", pathDecoded.Foo)
+}
+
+func TestDecode_serverReqNoBody(t *testing.T) {
+	pathDecoded := struct {
+		Foo string `path:"foo"`
+	}{}
+	mux := chi.NewMux()
+	mux.Get("/path/{foo}/path", func(w http.ResponseWriter, r *http.Request) {
+		err := Decode(r, &pathDecoded)
+		require.NoError(t, err)
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/path/bar/path", nil)
 	mux.ServeHTTP(w, r)
 
 	assert.Equal(t, "bar", pathDecoded.Foo)


### PR DESCRIPTION
### What

Add a check for `http.NoBody` before calling `DecodeJSON`.

### Why

`For server requests, the Request Body is always non-nil but will return EOF immediately when no body is present.`. We use `httptest.NewRequest` extensively throughout the codebase for testing, and that function returns a serve request with non-nil body. Without this change, use the request returned from `httptest.NewRequest` as a param of `Decode` or `DecodeJSON` will cause the `EOF` error.

### Known limitations

N/A
