### PR TITLE
services/horizon/internal: Fix stream handler tests

### DIFF
--- a/services/horizon/internal/handler.go
+++ b/services/horizon/internal/handler.go
@@ -376,7 +376,7 @@ func (handler objectActionHandler) ServeHTTP(
 	problem.Render(r.Context(), w, hProblem.NotAcceptable)
 }
 
-const singleObjectStreamLimit = 10
+const defaultObjectStreamLimit = 10
 
 type streamableObjectAction interface {
 	GetResource(
@@ -388,6 +388,7 @@ type streamableObjectAction interface {
 type streamableObjectActionHandler struct {
 	action        streamableObjectAction
 	streamHandler sse.StreamHandler
+	limit         int
 }
 
 func (handler streamableObjectActionHandler) ServeHTTP(
@@ -446,11 +447,15 @@ func (handler streamableObjectActionHandler) renderStream(
 	r *http.Request,
 ) {
 	var lastResponse actions.StreamableObjectResponse
+	limit := handler.limit
+	if limit == 0 {
+		limit = defaultObjectStreamLimit
+	}
 
 	handler.streamHandler.ServeStream(
 		w,
 		r,
-		singleObjectStreamLimit,
+		limit,
 		repeatableReadStream(r, func() ([]sse.Event, error) {
 			response, err := handler.action.GetResource(w, r)
 			if err != nil {

--- a/services/horizon/internal/ledger/ledger_source.go
+++ b/services/horizon/internal/ledger/ledger_source.go
@@ -1,7 +1,6 @@
 package ledger
 
 import (
-	"context"
 	"sync"
 	"time"
 )
@@ -86,27 +85,6 @@ func (source *TestingSource) CurrentLedger() uint32 {
 // will block until the new sequence is read
 func (source *TestingSource) AddLedger(nextSequence uint32) {
 	source.newLedgers <- nextSequence
-}
-
-// TryAddLedger sends a new sequence to the newLedgers channel. TryAddLedger()
-// will block until whichever of the following events occur first:
-// * the given ctx terminates
-// * timeout has elapsed
-// * the new sequence is read from the newLedgers channel
-// TryAddLedger() returns true if the new sequence was read from the newLedgers channel
-func (source *TestingSource) TryAddLedger(
-	ctx context.Context,
-	nextSequence uint32,
-	timeout time.Duration,
-) bool {
-	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(timeout))
-	defer cancel()
-	select {
-	case source.newLedgers <- nextSequence:
-		return true
-	case <-ctx.Done():
-		return false
-	}
 }
 
 // NextLedger returns a channel which yields every time there is a new ledger.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fix flakiness in `TestRepeatableReadStream/page_stream_creates_repeatable_read_tx`  (see https://github.com/stellar/go/pull/2460#issuecomment-610072451)
