### PR TITLE
exp/recoverysigner: add GET /accounts/{address} endpoint

### DIFF
--- a/exp/services/recoverysigner/internal/serve/account_get.go
+++ b/exp/services/recoverysigner/internal/serve/account_get.go
@@ -70,7 +70,7 @@ func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		resp.Identities = append(resp.Identities, respIdentity)
 	}
 	if !authorized {
-		notAuthorized.Render(w)
+		notFound.Render(w)
 		return
 	}
 	httpjson.Render(w, resp, httpjson.JSON)

--- a/exp/services/recoverysigner/internal/serve/account_get.go
+++ b/exp/services/recoverysigner/internal/serve/account_get.go
@@ -58,9 +58,9 @@ func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Role: i.Role,
 		}
 		for _, m := range i.AuthMethods {
-			if (m.Type == account.AuthMethodTypeAddress && m.Value == claims.Address) ||
+			if m.Value != "" && ((m.Type == account.AuthMethodTypeAddress && m.Value == claims.Address) ||
 				(m.Type == account.AuthMethodTypePhoneNumber && m.Value == claims.PhoneNumber) ||
-				(m.Type == account.AuthMethodTypeEmail && m.Value == claims.Email) {
+				(m.Type == account.AuthMethodTypeEmail && m.Value == claims.Email)) {
 				respIdentity.Authenticated = true
 				authorized = true
 				break

--- a/exp/services/recoverysigner/internal/serve/account_get.go
+++ b/exp/services/recoverysigner/internal/serve/account_get.go
@@ -1,7 +1,9 @@
 package serve
 
 import (
+	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/stellar/go/exp/services/recoverysigner/internal/account"
 	"github.com/stellar/go/exp/services/recoverysigner/internal/serve/auth"
@@ -33,6 +35,7 @@ func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	req := accountGetRequest{}
 	err := httpdecode.Decode(r, &req)
 	if err != nil || req.Address == nil {
+		fmt.Fprintf(os.Stderr, "bad request: %v\n", err)
 		badRequest.Render(w)
 		return
 	}
@@ -52,7 +55,7 @@ func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Signer:  h.SigningAddress.Address(),
 	}
 
-	authenticated := false
+	authorized := false
 	for _, i := range acc.Identities {
 		respIdentity := accountResponseIdentity{
 			Role: i.Role,
@@ -62,15 +65,15 @@ func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				(m.Type == account.AuthMethodTypePhoneNumber && m.Value == claims.PhoneNumber) ||
 				(m.Type == account.AuthMethodTypeEmail && m.Value == claims.Email) {
 				respIdentity.Authenticated = true
-				authenticated = true
+				authorized = true
 				break
 			}
 		}
 
 		resp.Identities = append(resp.Identities, respIdentity)
 	}
-	if !authenticated {
-		unauthorized.Render(w)
+	if !authorized {
+		notPermitted.Render(w)
 		return
 	}
 	httpjson.Render(w, resp, httpjson.JSON)

--- a/exp/services/recoverysigner/internal/serve/account_get.go
+++ b/exp/services/recoverysigner/internal/serve/account_get.go
@@ -52,7 +52,7 @@ func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Signer:  h.SigningAddress.Address(),
 	}
 
-	authorized := false
+	authorizedIdentity := false
 	for _, i := range acc.Identities {
 		respIdentity := accountResponseIdentity{
 			Role: i.Role,
@@ -62,16 +62,17 @@ func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				(m.Type == account.AuthMethodTypePhoneNumber && m.Value == claims.PhoneNumber) ||
 				(m.Type == account.AuthMethodTypeEmail && m.Value == claims.Email)) {
 				respIdentity.Authenticated = true
-				authorized = true
+				authorizedIdentity = true
 				break
 			}
 		}
 
 		resp.Identities = append(resp.Identities, respIdentity)
 	}
-	if !authorized {
+	if claims.Address != req.Address.Address() && !authorizedIdentity {
 		notFound.Render(w)
 		return
 	}
+
 	httpjson.Render(w, resp, httpjson.JSON)
 }

--- a/exp/services/recoverysigner/internal/serve/account_get.go
+++ b/exp/services/recoverysigner/internal/serve/account_get.go
@@ -73,7 +73,7 @@ func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		resp.Identities = append(resp.Identities, respIdentity)
 	}
 	if !authorized {
-		notPermitted.Render(w)
+		notAuthorized.Render(w)
 		return
 	}
 	httpjson.Render(w, resp, httpjson.JSON)

--- a/exp/services/recoverysigner/internal/serve/account_get.go
+++ b/exp/services/recoverysigner/internal/serve/account_get.go
@@ -1,0 +1,77 @@
+package serve
+
+import (
+	"net/http"
+
+	"github.com/stellar/go/exp/services/recoverysigner/internal/account"
+	"github.com/stellar/go/exp/services/recoverysigner/internal/serve/auth"
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/support/http/httpdecode"
+	supportlog "github.com/stellar/go/support/log"
+	"github.com/stellar/go/support/render/httpjson"
+)
+
+type accountGetHandler struct {
+	Logger         *supportlog.Entry
+	SigningAddress *keypair.FromAddress
+	AccountStore   account.Store
+}
+
+type accountGetRequest struct {
+	Address *keypair.FromAddress `path:"address"`
+}
+
+func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	claims, _ := auth.FromContext(ctx)
+	if claims.Address == "" && claims.PhoneNumber == "" && claims.Email == "" {
+		unauthorized.Render(w)
+		return
+	}
+
+	req := accountGetRequest{}
+	err := httpdecode.Decode(r, &req)
+	if err != nil || req.Address == nil {
+		badRequest.Render(w)
+		return
+	}
+
+	acc, err := h.AccountStore.Get(req.Address.Address())
+	if err == account.ErrNotFound {
+		notFound.Render(w)
+		return
+	} else if err != nil {
+		h.Logger.Error(err)
+		serverError.Render(w)
+		return
+	}
+
+	resp := accountResponse{
+		Address: acc.Address,
+		Signer:  h.SigningAddress.Address(),
+	}
+
+	authenticated := false
+	for _, i := range acc.Identities {
+		respIdentity := accountResponseIdentity{
+			Role: i.Role,
+		}
+		for _, m := range i.AuthMethods {
+			if (m.Type == account.AuthMethodTypeAddress && m.Value == claims.Address) ||
+				(m.Type == account.AuthMethodTypePhoneNumber && m.Value == claims.PhoneNumber) ||
+				(m.Type == account.AuthMethodTypeEmail && m.Value == claims.Email) {
+				respIdentity.Authenticated = true
+				authenticated = true
+				break
+			}
+		}
+
+		resp.Identities = append(resp.Identities, respIdentity)
+	}
+	if !authenticated {
+		unauthorized.Render(w)
+		return
+	}
+	httpjson.Render(w, resp, httpjson.JSON)
+}

--- a/exp/services/recoverysigner/internal/serve/account_get.go
+++ b/exp/services/recoverysigner/internal/serve/account_get.go
@@ -52,7 +52,10 @@ func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Signer:  h.SigningAddress.Address(),
 	}
 
-	authorizedIdentity := false
+	// Authorized if authenticated as the account.
+	authorized := claims.Address == req.Address.Address()
+
+	// Authorized if authenticated as an identity registered with the account.
 	for _, i := range acc.Identities {
 		respIdentity := accountResponseIdentity{
 			Role: i.Role,
@@ -62,14 +65,14 @@ func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				(m.Type == account.AuthMethodTypePhoneNumber && m.Value == claims.PhoneNumber) ||
 				(m.Type == account.AuthMethodTypeEmail && m.Value == claims.Email)) {
 				respIdentity.Authenticated = true
-				authorizedIdentity = true
+				authorized = true
 				break
 			}
 		}
 
 		resp.Identities = append(resp.Identities, respIdentity)
 	}
-	if claims.Address != req.Address.Address() && !authorizedIdentity {
+	if !authorized {
 		notFound.Render(w)
 		return
 	}

--- a/exp/services/recoverysigner/internal/serve/account_get.go
+++ b/exp/services/recoverysigner/internal/serve/account_get.go
@@ -1,9 +1,7 @@
 package serve
 
 import (
-	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/stellar/go/exp/services/recoverysigner/internal/account"
 	"github.com/stellar/go/exp/services/recoverysigner/internal/serve/auth"
@@ -35,7 +33,6 @@ func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	req := accountGetRequest{}
 	err := httpdecode.Decode(r, &req)
 	if err != nil || req.Address == nil {
-		fmt.Fprintf(os.Stderr, "bad request: %v\n", err)
 		badRequest.Render(w)
 		return
 	}

--- a/exp/services/recoverysigner/internal/serve/account_get_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_get_test.go
@@ -56,7 +56,7 @@ func TestAccountGet_authenticatedNotAuthorized(t *testing.T) {
 	require.NoError(t, err)
 
 	wantBody := `{
-	"error": "The request was not authorized to access the resource."
+	"error": "The request was not authorized to perform the action."
 }`
 
 	assert.JSONEq(t, wantBody, string(body))

--- a/exp/services/recoverysigner/internal/serve/account_get_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_get_test.go
@@ -49,14 +49,14 @@ func TestAccountGet_authenticatedNotAuthorized(t *testing.T) {
 	m.ServeHTTP(w, r)
 	resp := w.Result()
 
-	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
 
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	wantBody := `{
-	"error": "The request was not authorized to perform the action."
+	"error": "The resource at the url requested was not found."
 }`
 
 	assert.JSONEq(t, wantBody, string(body))

--- a/exp/services/recoverysigner/internal/serve/account_get_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_get_test.go
@@ -61,3 +61,266 @@ func TestAccountGet_authenticatedNotAuthorized(t *testing.T) {
 
 	assert.JSONEq(t, wantBody, string(body))
 }
+
+func TestAccountGet_notAuthenticated(t *testing.T) {
+	s := &account.DBStore{DB: dbtest.Open(t).Open()}
+	s.Add(account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "sender",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypeAddress, Value: "GCGZ3CNBE47IWAA5YIKDZL2XYYLA2UKJPS55P5EJ4VOMLK523PF3G7EM"},
+				},
+			},
+		},
+	})
+	h := accountGetHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{})
+	r := httptest.NewRequest("GET", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", nil)
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Get("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"error": "The request could not be authenticated."
+}`
+
+	assert.JSONEq(t, wantBody, string(body))
+}
+
+func TestAccountGet_notFound(t *testing.T) {
+	s := &account.DBStore{DB: dbtest.Open(t).Open()}
+	s.Add(account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "sender",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypeAddress, Value: "GCGZ3CNBE47IWAA5YIKDZL2XYYLA2UKJPS55P5EJ4VOMLK523PF3G7EM"},
+				},
+			},
+		},
+	})
+	h := accountGetHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{Address: "GCGZ3CNBE47IWAA5YIKDZL2XYYLA2UKJPS55P5EJ4VOMLK523PF3G7EM"})
+	r := httptest.NewRequest("GET", "/GCGZ3CNBE47IWAA5YIKDZL2XYYLA2UKJPS55P5EJ4VOMLK523PF3G7EM", nil)
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Get("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"error": "The resource at the url requested was not found."
+}`
+
+	assert.JSONEq(t, wantBody, string(body))
+}
+
+func TestAccountGet_authenticatedByAddress(t *testing.T) {
+	s := &account.DBStore{DB: dbtest.Open(t).Open()}
+	s.Add(account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "sender",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypeAddress, Value: "GCGZ3CNBE47IWAA5YIKDZL2XYYLA2UKJPS55P5EJ4VOMLK523PF3G7EM"},
+				},
+			},
+			{
+				Role: "receiver",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypePhoneNumber, Value: "+10000000000"},
+				},
+			},
+		},
+	})
+	h := accountGetHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{Address: "GCGZ3CNBE47IWAA5YIKDZL2XYYLA2UKJPS55P5EJ4VOMLK523PF3G7EM"})
+	r := httptest.NewRequest("GET", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", nil)
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Get("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"address": "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+	"identities": [
+		{
+			"role": "sender",
+			"authenticated": true
+		},
+		{
+			"role": "receiver"
+		}
+	],
+	"signer": "GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"
+}`
+
+	assert.JSONEq(t, wantBody, string(body))
+}
+
+func TestAccountGet_authenticatedByPhoneNumber(t *testing.T) {
+	s := &account.DBStore{DB: dbtest.Open(t).Open()}
+	s.Add(account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "sender",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypeAddress, Value: "GCGZ3CNBE47IWAA5YIKDZL2XYYLA2UKJPS55P5EJ4VOMLK523PF3G7EM"},
+				},
+			},
+			{
+				Role: "receiver",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypePhoneNumber, Value: "+10000000000"},
+				},
+			},
+		},
+	})
+	h := accountGetHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{PhoneNumber: "+10000000000"})
+	r := httptest.NewRequest("GET", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", nil)
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Get("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"address": "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+	"identities": [
+		{
+			"role": "sender"
+		},
+		{
+			"role": "receiver",
+			"authenticated": true
+		}
+	],
+	"signer": "GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"
+}`
+
+	assert.JSONEq(t, wantBody, string(body))
+}
+
+func TestAccountGet_authenticatedByEmail(t *testing.T) {
+	s := &account.DBStore{DB: dbtest.Open(t).Open()}
+	s.Add(account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "sender",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypeAddress, Value: "GCGZ3CNBE47IWAA5YIKDZL2XYYLA2UKJPS55P5EJ4VOMLK523PF3G7EM"},
+				},
+			},
+			{
+				Role: "receiver",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypeEmail, Value: "user1@example.com"},
+				},
+			},
+		},
+	})
+	h := accountGetHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{Email: "user1@example.com"})
+	r := httptest.NewRequest("GET", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", nil)
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Get("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"address": "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+	"identities": [
+		{
+			"role": "sender"
+		},
+		{
+			"role": "receiver",
+			"authenticated": true
+		}
+	],
+	"signer": "GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"
+}`
+
+	assert.JSONEq(t, wantBody, string(body))
+}

--- a/exp/services/recoverysigner/internal/serve/account_get_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_get_test.go
@@ -1,0 +1,63 @@
+package serve
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi"
+	"github.com/stellar/go/exp/services/recoverysigner/internal/account"
+	"github.com/stellar/go/exp/services/recoverysigner/internal/db/dbtest"
+	"github.com/stellar/go/exp/services/recoverysigner/internal/serve/auth"
+	"github.com/stellar/go/keypair"
+	supportlog "github.com/stellar/go/support/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test that when authenticated with an account, but querying the wrong account,
+// an error is returned.
+func TestAccountGet_authenticatedNotAuthorized(t *testing.T) {
+	s := &account.DBStore{DB: dbtest.Open(t).Open()}
+	s.Add(account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "sender",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypeAddress, Value: "GCGZ3CNBE47IWAA5YIKDZL2XYYLA2UKJPS55P5EJ4VOMLK523PF3G7EM"},
+				},
+			},
+		},
+	})
+	h := accountGetHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{Address: "GCNPATZQVSFGGSAHR4T54WNELPHYEBTSKH4IIKUTC7CHPLG6EPPC4PJL"})
+	r := httptest.NewRequest("GET", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", nil)
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Get("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"error": "The request was not authorized to access the resource."
+}`
+
+	assert.JSONEq(t, wantBody, string(body))
+}

--- a/exp/services/recoverysigner/internal/serve/account_get_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_get_test.go
@@ -148,7 +148,7 @@ func TestAccountGet_notFound(t *testing.T) {
 	assert.JSONEq(t, wantBody, string(body))
 }
 
-func TestAccountGet_authenticatedByAddress(t *testing.T) {
+func TestAccountGet_authenticatedByIdentityAddress(t *testing.T) {
 	s := &account.DBStore{DB: dbtest.Open(t).Open()}
 	s.Add(account.Account{
 		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
@@ -196,6 +196,64 @@ func TestAccountGet_authenticatedByAddress(t *testing.T) {
 		{
 			"role": "sender",
 			"authenticated": true
+		},
+		{
+			"role": "receiver"
+		}
+	],
+	"signer": "GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"
+}`
+
+	assert.JSONEq(t, wantBody, string(body))
+}
+
+func TestAccountGet_authenticatedByAccountAddress(t *testing.T) {
+	s := &account.DBStore{DB: dbtest.Open(t).Open()}
+	s.Add(account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "sender",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypePhoneNumber, Value: "+11000000000"},
+				},
+			},
+			{
+				Role: "receiver",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypePhoneNumber, Value: "+10000000000"},
+				},
+			},
+		},
+	})
+	h := accountGetHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N"})
+	r := httptest.NewRequest("GET", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", nil)
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Get("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"address": "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+	"identities": [
+		{
+			"role": "sender"
 		},
 		{
 			"role": "receiver"

--- a/exp/services/recoverysigner/internal/serve/errors.go
+++ b/exp/services/recoverysigner/internal/serve/errors.go
@@ -31,6 +31,11 @@ var unauthorized = errorResponse{
 	Error:  "The request could not be authenticated.",
 }
 
+var notPermitted = errorResponse{
+	Status: http.StatusForbidden,
+	Error:  "The request was not authorized to access the resource.",
+}
+
 type errorResponse struct {
 	Status int    `json:"-"`
 	Error  string `json:"error"`

--- a/exp/services/recoverysigner/internal/serve/errors.go
+++ b/exp/services/recoverysigner/internal/serve/errors.go
@@ -30,10 +30,9 @@ var unauthorized = errorResponse{
 	Status: http.StatusUnauthorized,
 	Error:  "The request could not be authenticated.",
 }
-
-var notPermitted = errorResponse{
+var notAuthorized = errorResponse{
 	Status: http.StatusForbidden,
-	Error:  "The request was not authorized to access the resource.",
+	Error:  "The request was not authorized to perform the action.",
 }
 
 type errorResponse struct {

--- a/exp/services/recoverysigner/internal/serve/errors.go
+++ b/exp/services/recoverysigner/internal/serve/errors.go
@@ -30,10 +30,6 @@ var unauthorized = errorResponse{
 	Status: http.StatusUnauthorized,
 	Error:  "The request could not be authenticated.",
 }
-var notAuthorized = errorResponse{
-	Status: http.StatusForbidden,
-	Error:  "The request was not authorized to perform the action.",
-}
 
 type errorResponse struct {
 	Status int    `json:"-"`

--- a/exp/services/recoverysigner/internal/serve/serve.go
+++ b/exp/services/recoverysigner/internal/serve/serve.go
@@ -122,7 +122,11 @@ func handler(deps handlerDeps) http.Handler {
 				AccountStore:   deps.AccountStore,
 			}.ServeHTTP)
 			// TODO: mux.Put("/", accountPutHandler{}.ServeHTTP)
-			mux.Get("/", accountGetHandler{}.ServeHTTP)
+			mux.Get("/", accountGetHandler{
+				Logger:         deps.Logger,
+				SigningAddress: deps.SigningKey.FromAddress(),
+				AccountStore:   deps.AccountStore,
+			}.ServeHTTP)
 			// TODO: mux.Delete("/", accountDeleteHandler{}.ServeHTTP)
 			mux.Post("/sign", accountSignHandler{
 				Logger:            deps.Logger,

--- a/exp/services/recoverysigner/internal/serve/serve.go
+++ b/exp/services/recoverysigner/internal/serve/serve.go
@@ -122,7 +122,7 @@ func handler(deps handlerDeps) http.Handler {
 				AccountStore:   deps.AccountStore,
 			}.ServeHTTP)
 			// TODO: mux.Put("/", accountPutHandler{}.ServeHTTP)
-			// TODO: mux.Get("/", accountGetHandler{}.ServeHTTP)
+			mux.Get("/", accountGetHandler{}.ServeHTTP)
 			// TODO: mux.Delete("/", accountDeleteHandler{}.ServeHTTP)
 			mux.Post("/sign", accountSignHandler{
 				Logger:            deps.Logger,


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

</details>

### What

This PR adds GET /accounts/{address} endpoint specified in the [spec](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0030.md#get-accountsaddress). This PR also adds `notPermitted` error for the case where a user is authenticated, but her credential does not match any of the identities in the requested account. 

### Why

This PR implements the missing endpoint.

### Known limitations

N/A
