### PR TITLE
exp/recoverysigner: separate authentication and authorization errors

### DIFF
--- a/exp/services/recoverysigner/internal/serve/account_list.go
+++ b/exp/services/recoverysigner/internal/serve/account_list.go
@@ -25,7 +25,7 @@ func (h accountListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	claims, _ := auth.FromContext(ctx)
 	if claims.Address == "" && claims.PhoneNumber == "" && claims.Email == "" {
-		unauthorized.Render(w)
+		notAuthenticated.Render(w)
 		return
 	}
 

--- a/exp/services/recoverysigner/internal/serve/account_post.go
+++ b/exp/services/recoverysigner/internal/serve/account_post.go
@@ -75,7 +75,7 @@ func (h accountPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	claims, _ := auth.FromContext(ctx)
 	if claims.Address == "" {
-		unauthorized.Render(w)
+		notAuthenticated.Render(w)
 		return
 	}
 
@@ -87,7 +87,7 @@ func (h accountPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Address.Address() != claims.Address {
-		unauthorized.Render(w)
+		notAuthorized.Render(w)
 		return
 	}
 

--- a/exp/services/recoverysigner/internal/serve/account_post_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_post_test.go
@@ -573,7 +573,7 @@ func TestAccountPost_authMethodTypeUnrecognized(t *testing.T) {
 	assert.Equal(t, wantAcc, acc)
 }
 
-func TestAccountPost_notAuthenticatedForAccount(t *testing.T) {
+func TestAccountPost_notAuthorizedForAccount(t *testing.T) {
 	s := &account.DBStore{DB: dbtest.Open(t).Open()}
 	h := accountPostHandler{
 		Logger:         supportlog.DefaultLogger,
@@ -593,14 +593,14 @@ func TestAccountPost_notAuthenticatedForAccount(t *testing.T) {
 	m.ServeHTTP(w, r)
 	resp := w.Result()
 
-	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
 
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	wantBody := `{
-	"error": "The request could not be authenticated."
+	"error": "The request was not authorized to perform the action."
 }`
 	assert.JSONEq(t, wantBody, string(body))
 

--- a/exp/services/recoverysigner/internal/serve/account_sign.go
+++ b/exp/services/recoverysigner/internal/serve/account_sign.go
@@ -36,7 +36,7 @@ func (h accountSignHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Check that the client is authenticated in some bare minimum way.
 	claims, _ := auth.FromContext(ctx)
 	if claims.Address == "" && claims.PhoneNumber == "" && claims.Email == "" {
-		unauthorized.Render(w)
+		notAuthenticated.Render(w)
 		return
 	}
 

--- a/exp/services/recoverysigner/internal/serve/errors.go
+++ b/exp/services/recoverysigner/internal/serve/errors.go
@@ -26,9 +26,13 @@ var conflict = errorResponse{
 	Status: http.StatusConflict,
 	Error:  "The request could not be completed because the resource already exists.",
 }
-var unauthorized = errorResponse{
+var notAuthenticated = errorResponse{
 	Status: http.StatusUnauthorized,
 	Error:  "The request could not be authenticated.",
+}
+var notAuthorized = errorResponse{
+	Status: http.StatusForbidden,
+	Error:  "The request was not authorized to perform the action.",
 }
 
 type errorResponse struct {


### PR DESCRIPTION
### What

This PR renames the `unauthorized` error to `notAuthenticated`. `notAuthenticated` is used when there's nothing in the claim.

This PR adds the `notAuthorized` error. `notAuthorized` error is used when the credential does not match the resource of the requested action.

### Why

`The HTTP 403 Forbidden client error status response code indicates that the server understood the request but refuses to authorize it.`

We named the error `unauthorized` but the error message says `not authenticated`, which is confusing. I understand that http 401 error is named `NotAuthorized`, but it's used when having problems in authentication, not authorization. For authorization errors, 403 can be more appropriate. 

### Known limitations

N/A

### Notes

The new `notAuthorized` error is going to be used in https://github.com/stellar/go/pull/2463/
