### PR TITLE
exp/services/recoverysigner: fix incorrect error wrapped

### DIFF
--- a/exp/services/recoverysigner/internal/serve/serve.go
+++ b/exp/services/recoverysigner/internal/serve/serve.go
@@ -73,13 +73,13 @@ func getHandlerDeps(opts Options) (handlerDeps, error) {
 	}
 	opts.Logger.Info("SEP-10 JWT Public key: ", sep10JWTPublicKey)
 
-	db, dbErr := db.Open(opts.DatabaseURL)
-	if dbErr != nil {
+	db, err := db.Open(opts.DatabaseURL)
+	if err != nil {
 		return handlerDeps{}, errors.Wrap(err, "error parsing database url")
 	}
-	dbErr = db.Ping()
-	if dbErr != nil {
-		opts.Logger.Warn("Error pinging to Database: ", dbErr)
+	err = db.Ping()
+	if err != nil {
+		opts.Logger.Warn("Error pinging to Database: ", err)
 	}
 	accountStore := &account.DBStore{DB: db}
 


### PR DESCRIPTION


<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Remove use of dbErr in code that is no longer nested.

### Why
In one of the `if dbErr != nil` blocks we are calling `errors.Wrap(err, ...)` when we should be calling `errors.Wrap(dbErr, ...)`. We have `dbErr` in this code because this code used to be nested and we had to give it another name because we use the go vet shadow command to disallow shadowing variables. It seems inside the function we have always been referencing the wrong error which is a problem because the Wrap function will return `nil` if given `nil`. So if a `dbErr` occurs, we return `nil` because `err` is `nil`.

I'm removing the use of `dbErr` instead of fixing the line that is using `err` because this code is no longer nested and we don't need to be using a different variable name for the database error.

### Known limitations

This specific function isn't going to fail unless we make an error somewhere else in the database loading code, so I'm not easily able to write a test for it so I haven't included one.
