### PR TITLE
services/horizon: Improve testing of verify.go

### DIFF
--- a/services/horizon/internal/db2/history/mock_q_accounts.go
+++ b/services/horizon/internal/db2/history/mock_q_accounts.go
@@ -12,7 +12,7 @@ type MockQAccounts struct {
 }
 
 func (m *MockQAccounts) GetAccountsByIDs(ids []string) ([]AccountEntry, error) {
-	a := m.Called()
+	a := m.Called(ids)
 	return a.Get(0).([]AccountEntry), a.Error(1)
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

Addresses part of #2264 

There isn't full coverage yet (I left a TODO), but accounts and offers are now tested.

This increases the coverage of verify.go to 60% from 9% .

