### PR TITLE
services/ticker: reduce parallelism on asset ingestion

### DIFF
--- a/services/ticker/internal/actions_asset.go
+++ b/services/ticker/internal/actions_asset.go
@@ -18,7 +18,7 @@ func RefreshAssets(s *tickerdb.TickerSession, c *horizonclient.Client, l *hlog.E
 		Client: c,
 		Logger: l,
 	}
-	finalAssetList, err := sc.FetchAllAssets(0, 500)
+	finalAssetList, err := sc.FetchAllAssets(0, 10)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Reduce the number of parallel requests to fetch `stellar.toml` files.

### Why

This is mostly empirical, but with `parallelism = 500,` I've noticed fetching `stellar.toml` files for some assets is always timing out (probably because the requests are queueing up). If we reduce that value to `10`, the timeout problem disappears, and the ingestion speed is minimally impacted (as in it still runs in under a minute).

I've also tried increasing the timeout (even up to 1 minute, instead of the original 10 seconds), but the problem persisted.

### Known limitations

There are probably more clever ways to fix this, but empirically this change yields satisfactory results with just a config change.