### PR TITLE
exp/services/recoverysigner: add JWT exp, iat as required

### DIFF
--- a/exp/services/recoverysigner/internal/serve/auth/sep10.go
+++ b/exp/services/recoverysigner/internal/serve/auth/sep10.go
@@ -38,7 +38,7 @@ func (c sep10JWTClaims) Validate() error {
 	if c.Claims.Expiry == nil {
 		return errors.New("validation failed, no expiry (exp) in token")
 	}
-	// TODO: Verify that sub is a G... strkey
+	// TODO: Verify that sub is a G... strkey.
 	// TODO: Verify that iss is as expected.
 	return c.Claims.Validate(jwt.Expected{Time: time.Now()})
 }

--- a/exp/services/recoverysigner/internal/serve/auth/sep10.go
+++ b/exp/services/recoverysigner/internal/serve/auth/sep10.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
@@ -31,8 +32,13 @@ type sep10JWTClaims struct {
 }
 
 func (c sep10JWTClaims) Validate() error {
-	// TODO: Verify that iat and exp are present.
-	// TODO: Verify that sub is a G... strkey.
+	if c.Claims.IssuedAt == nil {
+		return errors.New("validation failed, no issued at (iat) in token")
+	}
+	if c.Claims.Expiry == nil {
+		return errors.New("validation failed, no expiry (exp) in token")
+	}
+	// TODO: Verify that sub is a G... strkey
 	// TODO: Verify that iss is as expected.
 	return c.Claims.Validate(jwt.Expected{Time: time.Now()})
 }

--- a/exp/services/recoverysigner/internal/serve/auth/sep10_test.go
+++ b/exp/services/recoverysigner/internal/serve/auth/sep10_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,8 @@ func TestSEP10_addsAddressToClaimIfJWTValid(t *testing.T) {
 	r := httptest.NewRequest("GET", "/", nil)
 	jwtClaims := jwt.MapClaims{
 		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(time.Hour).Unix(),
 	}
 	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k)
 	require.NoError(t, err)
@@ -84,6 +87,8 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTNoSignature(t *testing.T) {
 	r := httptest.NewRequest("GET", "/", nil)
 	jwtClaims := jwt.MapClaims{
 		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(time.Hour).Unix(),
 	}
 	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SigningString()
 	require.NoError(t, err)
@@ -113,6 +118,8 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTWrongAlg(t *testing.T) {
 	r := httptest.NewRequest("GET", "/", nil)
 	jwtClaims := jwt.MapClaims{
 		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(time.Hour).Unix(),
 	}
 	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodNone, jwtClaims).SignedString(jwt.UnsafeAllowNoneSignatureType)
 	require.NoError(t, err)
@@ -145,6 +152,8 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTInvalidSignature(t *testing.T) {
 	r := httptest.NewRequest("GET", "/", nil)
 	jwtClaims := jwt.MapClaims{
 		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(time.Hour).Unix(),
 	}
 	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k2)
 	require.NoError(t, err)
@@ -174,7 +183,68 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTExpired(t *testing.T) {
 	r := httptest.NewRequest("GET", "/", nil)
 	jwtClaims := jwt.MapClaims{
 		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
+		"iat": 1,
 		"exp": 1,
+	}
+	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k)
+	require.NoError(t, err)
+	r.Header.Set("Authorization", "Bearer "+jwtToken)
+	handler.ServeHTTP(nil, r)
+
+	assert.NotNil(t, ctx)
+	claims, ok := FromContext(ctx)
+	assert.Equal(t, false, ok)
+
+	wantClaims := Auth{}
+	assert.Equal(t, wantClaims, claims)
+}
+
+func TestSEP10_doesNotAddAddressToClaimIfJWTMissingIAT(t *testing.T) {
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: &k.PublicKey}
+
+	ctx := context.Context(nil)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx = r.Context()
+	})
+	middleware := SEP10Middleware(jwk)
+	handler := middleware(next)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	jwtClaims := jwt.MapClaims{
+		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k)
+	require.NoError(t, err)
+	r.Header.Set("Authorization", "Bearer "+jwtToken)
+	handler.ServeHTTP(nil, r)
+
+	assert.NotNil(t, ctx)
+	claims, ok := FromContext(ctx)
+	assert.Equal(t, false, ok)
+
+	wantClaims := Auth{}
+	assert.Equal(t, wantClaims, claims)
+}
+
+func TestSEP10_doesNotAddAddressToClaimIfJWTMissingEXP(t *testing.T) {
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: &k.PublicKey}
+
+	ctx := context.Context(nil)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx = r.Context()
+	})
+	middleware := SEP10Middleware(jwk)
+	handler := middleware(next)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	jwtClaims := jwt.MapClaims{
+		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
+		"iat": time.Now().Unix(),
 	}
 	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k)
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add validation that SEP-10 JWTs contain an `exp` and `iat` field.

### Why

To ensure if there was ever an upstream issue with the generation of JWTs and a field was missing but the JWT was otherwise valid, we'd disregard the JWT since it's validity as a whole would be questionable.

For #2442

### Known limitations

N/A
