### PR TITLE
change Ruby SDK links to point to new astroband org

### DIFF
--- a/services/horizon/internal/docs/readme.md
+++ b/services/horizon/internal/docs/readme.md
@@ -15,10 +15,10 @@ SDF maintained libraries:<br />
 - [Go](https://github.com/stellar/go/tree/master/clients/horizonclient)
 - [Java](https://github.com/stellar/java-stellar-sdk)
 
-Community maintained libraries (in various states of completeness) for interacting with Horizon in other languages:<br>
+Community maintained libraries for interacting with Horizon in other languages:<br>
 - [Python](https://github.com/StellarCN/py-stellar-base)
 - [C# .NET Core 2.x](https://github.com/elucidsoft/dotnetcore-stellar-sdk)
-- [Ruby](https://github.com/bloom-solutions/ruby-stellar-sdk)
+- [Ruby](https://github.com/astroband/ruby-stellar-sdk)
 - [iOS and macOS](https://github.com/Soneso/stellar-ios-mac-sdk)
 - [Scala SDK](https://github.com/synesso/scala-stellar-sdk)
 - [C++ SDK](https://github.com/bnogalm/StellarQtSDK)

--- a/services/horizon/internal/docs/reference/readme.md
+++ b/services/horizon/internal/docs/reference/readme.md
@@ -17,10 +17,10 @@ SDF maintained libraries:<br />
 - [Go](https://github.com/stellar/go/tree/master/clients/horizonclient)
 - [Java](https://github.com/stellar/java-stellar-sdk)
 
-Community maintained libraries (in various states of completeness) for interacting with Horizon in other languages:<br>
+Community maintained libraries for interacting with Horizon in other languages:<br>
 - [Python](https://github.com/StellarCN/py-stellar-base)
 - [C# .NET Core 2.x](https://github.com/elucidsoft/dotnetcore-stellar-sdk)
-- [Ruby](https://github.com/bloom-solutions/ruby-stellar-sdk)
+- [Ruby](https://github.com/astroband/ruby-stellar-sdk)
 - [iOS and macOS](https://github.com/Soneso/stellar-ios-mac-sdk)
 - [Scala SDK](https://github.com/synesso/scala-stellar-sdk)
 - [C++ SDK](https://github.com/bnogalm/StellarQtSDK)


### PR DESCRIPTION
Evil Martians (https://github.com/astroband/) have now taken ownership of the Ruby SDK. Update links to point at the [new repo location](https://github.com/astroband/ruby-stellar-sdk).

Note: this content is duplicated in these files and also in the docs repo (https://github.com/stellar/docs/pull/565). For now I'm just fixing the links, but there's a need to do a pass over all these docs once the new SDK site is live and remove the redundancy.