### PR TITLE
exp/services/recoverysigner: add tests for JWT confirming if sub is missing or invalid it will be considered invalid

### DIFF
--- a/exp/services/recoverysigner/internal/serve/auth/sep10.go
+++ b/exp/services/recoverysigner/internal/serve/auth/sep10.go
@@ -32,7 +32,6 @@ type sep10JWTClaims struct {
 
 func (c sep10JWTClaims) Validate() error {
 	// TODO: Verify that iat and exp are present.
-	// TODO: Verify that sub is a G... strkey.
 	// TODO: Verify that iss is as expected.
 	return c.Claims.Validate(jwt.Expected{Time: time.Now()})
 }

--- a/exp/services/recoverysigner/internal/serve/auth/sep10_test.go
+++ b/exp/services/recoverysigner/internal/serve/auth/sep10_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/assert"
@@ -175,6 +176,67 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTExpired(t *testing.T) {
 	jwtClaims := jwt.MapClaims{
 		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
 		"exp": 1,
+	}
+	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k)
+	require.NoError(t, err)
+	r.Header.Set("Authorization", "Bearer "+jwtToken)
+	handler.ServeHTTP(nil, r)
+
+	assert.NotNil(t, ctx)
+	claims, ok := FromContext(ctx)
+	assert.Equal(t, false, ok)
+
+	wantClaims := Auth{}
+	assert.Equal(t, wantClaims, claims)
+}
+
+func TestSEP10_doesNotAddAddressToClaimIfJWTMissingSUB(t *testing.T) {
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: &k.PublicKey}
+
+	ctx := context.Context(nil)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx = r.Context()
+	})
+	middleware := SEP10Middleware(jwk)
+	handler := middleware(next)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	jwtClaims := jwt.MapClaims{
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k)
+	require.NoError(t, err)
+	r.Header.Set("Authorization", "Bearer "+jwtToken)
+	handler.ServeHTTP(nil, r)
+
+	assert.NotNil(t, ctx)
+	claims, ok := FromContext(ctx)
+	assert.Equal(t, false, ok)
+
+	wantClaims := Auth{}
+	assert.Equal(t, wantClaims, claims)
+}
+
+func TestSEP10_doesNotAddAddressToClaimIfJWTHasSUBNotContainingGStrkey(t *testing.T) {
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: &k.PublicKey}
+
+	ctx := context.Context(nil)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx = r.Context()
+	})
+	middleware := SEP10Middleware(jwk)
+	handler := middleware(next)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	jwtClaims := jwt.MapClaims{
+		"sub": "SBAZWVXOQ5LWT5PJSVOA62PVIYZIV3T3HQ3GFC2RUZ6K43QFNF5BLLDE",
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(time.Hour).Unix(),
 	}
 	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k)
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add tests for JWT confirming if the `sub` field is missing or invalid it will be considered invalid.

### Why

We had a TODO in the code to add the check, but the code already does the check we were just missing tests. The code lives in another area of the code.

For #2442

### Known limitations

N/A
