### PR TITLE
exp/services/recoverysigner: validate JWT iss field optionally has specific value

### DIFF
--- a/exp/services/recoverysigner/cmd/serve.go
+++ b/exp/services/recoverysigner/cmd/serve.go
@@ -58,6 +58,13 @@ func (c *ServeCommand) Command() *cobra.Command {
 			Required:  true,
 		},
 		{
+			Name:      "sep10-jwt-issuer",
+			Usage:     "JWT issuer to verify is in the SEP-10 JWT iss field (not checked if empty)",
+			OptType:   types.String,
+			ConfigKey: &opts.SEP10JWTIssuer,
+			Required:  false,
+		},
+		{
 			Name:      "firebase-project-id",
 			Usage:     "Firebase project ID to use for validating Firebase JWTs",
 			OptType:   types.String,

--- a/exp/services/recoverysigner/internal/serve/auth/sep10.go
+++ b/exp/services/recoverysigner/internal/serve/auth/sep10.go
@@ -11,10 +11,10 @@ import (
 )
 
 // SEP10Middleware provides middleware for handling an authentication SEP-10 JWT.
-func SEP10Middleware(k jose.JSONWebKey) func(http.Handler) http.Handler {
+func SEP10Middleware(issuer string, k jose.JSONWebKey) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if address, ok := sep10ClaimsFromRequest(r, k); ok {
+			if address, ok := sep10ClaimsFromRequest(r, issuer, k); ok {
 				ctx := r.Context()
 				auth, _ := FromContext(ctx)
 				auth.Address = address
@@ -30,14 +30,17 @@ type sep10JWTClaims struct {
 	jwt.Claims
 }
 
-func (c sep10JWTClaims) Validate() error {
+func (c sep10JWTClaims) Validate(issuer string) error {
 	// TODO: Verify that iat and exp are present.
 	// TODO: Verify that sub is a G... strkey.
-	// TODO: Verify that iss is as expected.
-	return c.Claims.Validate(jwt.Expected{Time: time.Now()})
+	expectedClaims := jwt.Expected{
+		Issuer: issuer,
+		Time:   time.Now(),
+	}
+	return c.Claims.Validate(expectedClaims)
 }
 
-func sep10ClaimsFromRequest(r *http.Request, k jose.JSONWebKey) (address string, ok bool) {
+func sep10ClaimsFromRequest(r *http.Request, issuer string, k jose.JSONWebKey) (address string, ok bool) {
 	authHeader := r.Header.Get("Authorization")
 	tokenEncoded := httpauthz.ParseBearerToken(authHeader)
 	if tokenEncoded == "" {
@@ -52,7 +55,7 @@ func sep10ClaimsFromRequest(r *http.Request, k jose.JSONWebKey) (address string,
 	if err != nil {
 		return "", false
 	}
-	err = tokenClaims.Validate()
+	err = tokenClaims.Validate(issuer)
 	if err != nil {
 		return "", false
 	}

--- a/exp/services/recoverysigner/internal/serve/auth/sep10_test.go
+++ b/exp/services/recoverysigner/internal/serve/auth/sep10_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/assert"
@@ -16,6 +17,8 @@ import (
 )
 
 func TestSEP10_addsAddressToClaimIfJWTValid(t *testing.T) {
+	issuer := "https://webauth.example.com"
+
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	jwk := jose.JSONWebKey{Key: &k.PublicKey}
@@ -24,11 +27,12 @@ func TestSEP10_addsAddressToClaimIfJWTValid(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx = r.Context()
 	})
-	middleware := SEP10Middleware(jwk)
+	middleware := SEP10Middleware(issuer, jwk)
 	handler := middleware(next)
 
 	r := httptest.NewRequest("GET", "/", nil)
 	jwtClaims := jwt.MapClaims{
+		"iss": "https://webauth.example.com",
 		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
 	}
 	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k)
@@ -47,6 +51,8 @@ func TestSEP10_addsAddressToClaimIfJWTValid(t *testing.T) {
 }
 
 func TestSEP10_doesNotAddAddressToClaimIfJWTNotPresent(t *testing.T) {
+	issuer := "https://webauth.example.com"
+
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	jwk := jose.JSONWebKey{Key: &k.PublicKey}
@@ -55,7 +61,7 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTNotPresent(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx = r.Context()
 	})
-	middleware := SEP10Middleware(jwk)
+	middleware := SEP10Middleware(issuer, jwk)
 	handler := middleware(next)
 
 	r := httptest.NewRequest("GET", "/", nil)
@@ -70,6 +76,8 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTNotPresent(t *testing.T) {
 }
 
 func TestSEP10_doesNotAddAddressToClaimIfJWTNoSignature(t *testing.T) {
+	issuer := "https://webauth.example.com"
+
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	jwk := jose.JSONWebKey{Key: &k.PublicKey}
@@ -78,11 +86,12 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTNoSignature(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx = r.Context()
 	})
-	middleware := SEP10Middleware(jwk)
+	middleware := SEP10Middleware(issuer, jwk)
 	handler := middleware(next)
 
 	r := httptest.NewRequest("GET", "/", nil)
 	jwtClaims := jwt.MapClaims{
+		"iss": "https://webauth.example.com",
 		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
 	}
 	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SigningString()
@@ -99,6 +108,8 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTNoSignature(t *testing.T) {
 }
 
 func TestSEP10_doesNotAddAddressToClaimIfJWTWrongAlg(t *testing.T) {
+	issuer := "https://webauth.example.com"
+
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	jwk := jose.JSONWebKey{Key: &k.PublicKey}
@@ -107,11 +118,12 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTWrongAlg(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx = r.Context()
 	})
-	middleware := SEP10Middleware(jwk)
+	middleware := SEP10Middleware(issuer, jwk)
 	handler := middleware(next)
 
 	r := httptest.NewRequest("GET", "/", nil)
 	jwtClaims := jwt.MapClaims{
+		"iss": "https://webauth.example.com",
 		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
 	}
 	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodNone, jwtClaims).SignedString(jwt.UnsafeAllowNoneSignatureType)
@@ -128,6 +140,8 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTWrongAlg(t *testing.T) {
 }
 
 func TestSEP10_doesNotAddAddressToClaimIfJWTInvalidSignature(t *testing.T) {
+	issuer := "https://webauth.example.com"
+
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	jwk := jose.JSONWebKey{Key: &k.PublicKey}
@@ -139,11 +153,12 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTInvalidSignature(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx = r.Context()
 	})
-	middleware := SEP10Middleware(jwk)
+	middleware := SEP10Middleware(issuer, jwk)
 	handler := middleware(next)
 
 	r := httptest.NewRequest("GET", "/", nil)
 	jwtClaims := jwt.MapClaims{
+		"iss": "https://webauth.example.com",
 		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
 	}
 	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k2)
@@ -160,6 +175,8 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTInvalidSignature(t *testing.T) {
 }
 
 func TestSEP10_doesNotAddAddressToClaimIfJWTExpired(t *testing.T) {
+	issuer := "https://webauth.example.com"
+
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	jwk := jose.JSONWebKey{Key: &k.PublicKey}
@@ -168,11 +185,12 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTExpired(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx = r.Context()
 	})
-	middleware := SEP10Middleware(jwk)
+	middleware := SEP10Middleware(issuer, jwk)
 	handler := middleware(next)
 
 	r := httptest.NewRequest("GET", "/", nil)
 	jwtClaims := jwt.MapClaims{
+		"iss": "https://webauth.example.com",
 		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
 		"exp": 1,
 	}
@@ -186,5 +204,143 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTExpired(t *testing.T) {
 	assert.Equal(t, false, ok)
 
 	wantClaims := Auth{}
+	assert.Equal(t, wantClaims, claims)
+}
+
+func TestSEP10_doesNotAddAddressToClaimIfJWTMissingISSButRequired(t *testing.T) {
+	issuer := "https://webauth.example.com"
+
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: &k.PublicKey}
+
+	ctx := context.Context(nil)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx = r.Context()
+	})
+	middleware := SEP10Middleware(issuer, jwk)
+	handler := middleware(next)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	jwtClaims := jwt.MapClaims{
+		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k)
+	require.NoError(t, err)
+	r.Header.Set("Authorization", "Bearer "+jwtToken)
+	handler.ServeHTTP(nil, r)
+
+	assert.NotNil(t, ctx)
+	claims, ok := FromContext(ctx)
+	assert.Equal(t, false, ok)
+
+	wantClaims := Auth{}
+	assert.Equal(t, wantClaims, claims)
+}
+
+func TestSEP10_doesNotAddAddressToClaimIfJWTHasISSButUnexpectedValue(t *testing.T) {
+	issuer := "https://webauth.example.com"
+
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: &k.PublicKey}
+
+	ctx := context.Context(nil)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx = r.Context()
+	})
+	middleware := SEP10Middleware(issuer, jwk)
+	handler := middleware(next)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	jwtClaims := jwt.MapClaims{
+		"iss": "otherissuer",
+		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k)
+	require.NoError(t, err)
+	r.Header.Set("Authorization", "Bearer "+jwtToken)
+	handler.ServeHTTP(nil, r)
+
+	assert.NotNil(t, ctx)
+	claims, ok := FromContext(ctx)
+	assert.Equal(t, false, ok)
+
+	wantClaims := Auth{}
+	assert.Equal(t, wantClaims, claims)
+}
+
+func TestSEP10_doesNotAddAddressToClaimIfJWTMissingISSButNotRequired(t *testing.T) {
+	issuer := ""
+
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: &k.PublicKey}
+
+	ctx := context.Context(nil)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx = r.Context()
+	})
+	middleware := SEP10Middleware(issuer, jwk)
+	handler := middleware(next)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	jwtClaims := jwt.MapClaims{
+		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k)
+	require.NoError(t, err)
+	r.Header.Set("Authorization", "Bearer "+jwtToken)
+	handler.ServeHTTP(nil, r)
+
+	assert.NotNil(t, ctx)
+	claims, ok := FromContext(ctx)
+	assert.Equal(t, true, ok)
+
+	wantClaims := Auth{
+		Address: "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
+	}
+	assert.Equal(t, wantClaims, claims)
+}
+
+func TestSEP10_doesNotAddAddressToClaimIfJWTHasISSButNotRequired(t *testing.T) {
+	issuer := ""
+
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: &k.PublicKey}
+
+	ctx := context.Context(nil)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx = r.Context()
+	})
+	middleware := SEP10Middleware(issuer, jwk)
+	handler := middleware(next)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	jwtClaims := jwt.MapClaims{
+		"iss": "otherservice",
+		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k)
+	require.NoError(t, err)
+	r.Header.Set("Authorization", "Bearer "+jwtToken)
+	handler.ServeHTTP(nil, r)
+
+	assert.NotNil(t, ctx)
+	claims, ok := FromContext(ctx)
+	assert.Equal(t, true, ok)
+
+	wantClaims := Auth{
+		Address: "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
+	}
 	assert.Equal(t, wantClaims, claims)
 }

--- a/exp/services/recoverysigner/internal/serve/auth/sep10_test.go
+++ b/exp/services/recoverysigner/internal/serve/auth/sep10_test.go
@@ -266,8 +266,8 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTMissingEXP(t *testing.T) {
 	r := httptest.NewRequest("GET", "/", nil)
 	jwtClaims := jwt.MapClaims{
 		"iss": "https://webauth.example.com",
-		"iat": time.Now().Unix(),
 		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
+		"iat": time.Now().Unix(),
 	}
 	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k)
 	require.NoError(t, err)

--- a/exp/services/recoverysigner/internal/serve/auth/sep10_test.go
+++ b/exp/services/recoverysigner/internal/serve/auth/sep10_test.go
@@ -416,7 +416,7 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTHasISSButUnexpectedValue(t *testing.
 	assert.Equal(t, wantClaims, claims)
 }
 
-func TestSEP10_doesNotAddAddressToClaimIfJWTMissingISSButNotRequired(t *testing.T) {
+func TestSEP10_addAddressToClaimIfJWTMissingISSButNotRequired(t *testing.T) {
 	issuer := ""
 
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -451,7 +451,7 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTMissingISSButNotRequired(t *testing.
 	assert.Equal(t, wantClaims, claims)
 }
 
-func TestSEP10_doesNotAddAddressToClaimIfJWTHasISSButNotRequired(t *testing.T) {
+func TestSEP10_addAddressToClaimIfJWTHasISSButNotRequired(t *testing.T) {
 	issuer := ""
 
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/exp/services/recoverysigner/internal/serve/auth/sep10_test.go
+++ b/exp/services/recoverysigner/internal/serve/auth/sep10_test.go
@@ -216,6 +216,72 @@ func TestSEP10_doesNotAddAddressToClaimIfJWTExpired(t *testing.T) {
 	assert.Equal(t, wantClaims, claims)
 }
 
+func TestSEP10_doesNotAddAddressToClaimIfJWTMissingIAT(t *testing.T) {
+	issuer := "https://webauth.example.com"
+
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: &k.PublicKey}
+
+	ctx := context.Context(nil)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx = r.Context()
+	})
+	middleware := SEP10Middleware(issuer, jwk)
+	handler := middleware(next)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	jwtClaims := jwt.MapClaims{
+		"iss": "https://webauth.example.com",
+		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k)
+	require.NoError(t, err)
+	r.Header.Set("Authorization", "Bearer "+jwtToken)
+	handler.ServeHTTP(nil, r)
+
+	assert.NotNil(t, ctx)
+	claims, ok := FromContext(ctx)
+	assert.Equal(t, false, ok)
+
+	wantClaims := Auth{}
+	assert.Equal(t, wantClaims, claims)
+}
+
+func TestSEP10_doesNotAddAddressToClaimIfJWTMissingEXP(t *testing.T) {
+	issuer := "https://webauth.example.com"
+
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	jwk := jose.JSONWebKey{Key: &k.PublicKey}
+
+	ctx := context.Context(nil)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx = r.Context()
+	})
+	middleware := SEP10Middleware(issuer, jwk)
+	handler := middleware(next)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	jwtClaims := jwt.MapClaims{
+		"iss": "https://webauth.example.com",
+		"iat": time.Now().Unix(),
+		"sub": "GDKABHI4LTLG7UCE6O7Y4D6REHJVS4DLXTVVXTE3BPRRLXPASHSOKG2D",
+	}
+	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwtClaims).SignedString(k)
+	require.NoError(t, err)
+	r.Header.Set("Authorization", "Bearer "+jwtToken)
+	handler.ServeHTTP(nil, r)
+
+	assert.NotNil(t, ctx)
+	claims, ok := FromContext(ctx)
+	assert.Equal(t, false, ok)
+
+	wantClaims := Auth{}
+	assert.Equal(t, wantClaims, claims)
+}
+
 func TestSEP10_doesNotAddAddressToClaimIfJWTMissingSUB(t *testing.T) {
 	issuer := "https://webauth.example.com"
 

--- a/exp/services/recoverysigner/internal/serve/serve.go
+++ b/exp/services/recoverysigner/internal/serve/serve.go
@@ -25,6 +25,7 @@ type Options struct {
 	NetworkPassphrase string
 	SigningKey        string
 	SEP10JWKS         string
+	SEP10JWTIssuer    string
 	FirebaseProjectID string
 }
 
@@ -54,6 +55,7 @@ type handlerDeps struct {
 	SigningKey         *keypair.Full
 	AccountStore       account.Store
 	SEP10JWK           jose.JSONWebKey
+	SEP10JWTIssuer     string
 	FirebaseAuthClient *firebaseauth.Client
 }
 
@@ -101,6 +103,7 @@ func getHandlerDeps(opts Options) (handlerDeps, error) {
 		SigningKey:         signingKey,
 		AccountStore:       accountStore,
 		SEP10JWK:           sep10JWK,
+		SEP10JWTIssuer:     opts.SEP10JWTIssuer,
 		FirebaseAuthClient: firebaseAuthClient,
 	}
 
@@ -115,7 +118,7 @@ func handler(deps handlerDeps) http.Handler {
 
 	mux.Get("/health", health.PassHandler{}.ServeHTTP)
 	mux.Route("/accounts", func(mux chi.Router) {
-		mux.Use(auth.SEP10Middleware(deps.SEP10JWK))
+		mux.Use(auth.SEP10Middleware(deps.SEP10JWTIssuer, deps.SEP10JWK))
 		mux.Use(auth.FirebaseMiddleware(auth.FirebaseTokenVerifierLive{AuthClient: deps.FirebaseAuthClient}))
 		mux.Get("/", accountListHandler{
 			Logger:         deps.Logger,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Validate JWT `iss` field has a specific value if the service is run with an expected value defined with the new `--sep10-jwt-issuer` (`SEP10_JWT_ISSUER`) config option.

### Why

In some setups it can be important to verify the issuer within the JWT and not just the signature.

For #2442

### Known limitations

N/A
