### PR TITLE
exp/recoverysigner: add PUT /accounts/{address} endpoint

### DIFF
--- a/exp/services/recoverysigner/internal/account/db_store_update.go
+++ b/exp/services/recoverysigner/internal/account/db_store_update.go
@@ -13,6 +13,8 @@ func (s *DBStore) Update(a Account) error {
 	}
 
 	var accountID int64
+	// Delete an identity will delete the associated auth methods because of the ON DELETE CASCADE reference.
+	// https://github.com/stellar/go/blob/b3e0a353a901ce0babad5b4953330e55f2c674a1/exp/services/recoverysigner/internal/db/dbmigrate/migrations/20200311000002-create-auth-methods.sql#L11
 	err = tx.Get(&accountID, `
 		WITH deleted_identities AS (
 			DELETE FROM identities

--- a/exp/services/recoverysigner/internal/account/db_store_update.go
+++ b/exp/services/recoverysigner/internal/account/db_store_update.go
@@ -1,0 +1,54 @@
+package account
+
+import (
+	"database/sql"
+
+	"github.com/lib/pq"
+)
+
+func (s *DBStore) Update(a Account) error {
+	tx, err := s.DB.Beginx()
+	if err != nil {
+		return err
+	}
+
+	var accountID int64
+	err = tx.Get(&accountID, `
+		WITH deleted_identities AS (
+			DELETE FROM identities
+			USING accounts
+			WHERE identities.account_id = accounts.id AND accounts.address = $1
+			RETURNING identities.account_id AS account_id
+		)
+		SELECT DISTINCT account_id FROM deleted_identities
+	`, a.Address)
+	if err == sql.ErrNoRows {
+		return ErrNotFound
+	}
+	if err != nil {
+		return err
+	}
+
+	for _, i := range a.Identities {
+		var authTypes, authValues pq.StringArray
+		for _, m := range i.AuthMethods {
+			authTypes = append(authTypes, string(m.Type))
+			authValues = append(authValues, m.Value)
+		}
+		_, err = tx.Exec(`
+			WITH new_identity AS (
+				INSERT INTO identities (account_id, role)
+				VALUES ($1, $2)
+				RETURNING account_id, id
+			)
+			INSERT INTO auth_methods (account_id, identity_id, type_, value)
+			SELECT account_id, id, unnest($3::auth_method_type[]), unnest($4::text[])
+			FROM new_identity
+		`, accountID, i.Role, authTypes, authValues)
+		if err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}

--- a/exp/services/recoverysigner/internal/account/db_store_update_test.go
+++ b/exp/services/recoverysigner/internal/account/db_store_update_test.go
@@ -1,0 +1,300 @@
+package account
+
+import (
+	"testing"
+
+	"github.com/stellar/go/exp/services/recoverysigner/internal/db/dbtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdate(t *testing.T) {
+	db := dbtest.Open(t)
+	session := db.Open()
+
+	store := DBStore{
+		DB: session,
+	}
+
+	address := "GCLLT3VG4F6EZAHZEBKWBWV5JGVPCVIKUCGTY3QEOAIZU5IJGMWCT2TT"
+
+	// Store the account
+	a := Account{
+		Address: address,
+		Identities: []Identity{
+			{
+				Role: "sender",
+				AuthMethods: []AuthMethod{
+					{Type: AuthMethodTypeAddress, Value: "GD4NGMOTV4QOXWA6PGPIGVWZYMRCJAKLQJKZIP55C5DGB3GBHHET3YC6"},
+					{Type: AuthMethodTypePhoneNumber, Value: "+10000000000"},
+					{Type: AuthMethodTypeEmail, Value: "user1@example.com"},
+				},
+			},
+			{
+				Role: "receiver",
+				AuthMethods: []AuthMethod{
+					{Type: AuthMethodTypeAddress, Value: "GBJCOYGKIJYX3VUEOZ6GVMFP522UO4OEBI5KB5HHWZAZ2DEJTHS6VOHP"},
+					{Type: AuthMethodTypePhoneNumber, Value: "+20000000000"},
+					{Type: AuthMethodTypeEmail, Value: "user2@example.com"},
+				},
+			},
+		},
+	}
+	err := store.Add(a)
+	require.NoError(t, err)
+
+	// Update the identities on the account
+	b := Account{
+		Address: address,
+		Identities: []Identity{
+			{
+				Role: "owner",
+				AuthMethods: []AuthMethod{
+					{Type: AuthMethodTypeAddress, Value: "GAUZVLZUTB3SE4MTQ6CFAQXOCMMVCG6LCUZNPM4ZS5X3HZ4BZB4RJM2S"},
+					{Type: AuthMethodTypePhoneNumber, Value: "+30000000000"},
+					{Type: AuthMethodTypeEmail, Value: "user3@example.com"},
+				},
+			},
+		},
+	}
+
+	err = store.Update(b)
+	require.NoError(t, err)
+
+	updatedAcc, err := store.Get(address)
+	require.NoError(t, err)
+	assert.Equal(t, b, updatedAcc)
+
+	// Check the account row has not been changed.
+	{
+		type row struct {
+			ID      int64  `db:"id"`
+			Address string `db:"address"`
+		}
+		rows := []row{}
+		err = session.Select(&rows, `SELECT id, address FROM accounts`)
+		require.NoError(t, err)
+		wantRows := []row{
+			{
+				ID:      1,
+				Address: "GCLLT3VG4F6EZAHZEBKWBWV5JGVPCVIKUCGTY3QEOAIZU5IJGMWCT2TT",
+			},
+		}
+		assert.Equal(t, wantRows, rows)
+	}
+
+	// Check the identity rows have been updated.
+	{
+		type row struct {
+			AccountID int64  `db:"account_id"`
+			ID        int64  `db:"id"`
+			Role      string `db:"role"`
+		}
+		rows := []row{}
+		err = session.Select(&rows, `SELECT account_id, id, role FROM identities`)
+		require.NoError(t, err)
+		wantRows := []row{
+			{
+				AccountID: 1,
+				ID:        3,
+				Role:      "owner",
+			},
+		}
+		assert.Equal(t, wantRows, rows)
+	}
+
+	// Check the auth method rows have been updated.
+	{
+		type row struct {
+			AccountID  int64  `db:"account_id"`
+			IdentityID int64  `db:"identity_id"`
+			ID         int64  `db:"id"`
+			Type       string `db:"type_"`
+			Value      string `db:"value"`
+		}
+		rows := []row{}
+		err = session.Select(&rows, `SELECT account_id, identity_id, id, type_, value FROM auth_methods`)
+		require.NoError(t, err)
+		wantRows := []row{
+			{
+				AccountID:  1,
+				IdentityID: 3,
+				ID:         7,
+				Type:       "stellar_address",
+				Value:      "GAUZVLZUTB3SE4MTQ6CFAQXOCMMVCG6LCUZNPM4ZS5X3HZ4BZB4RJM2S",
+			},
+			{
+				AccountID:  1,
+				IdentityID: 3,
+				ID:         8,
+				Type:       "phone_number",
+				Value:      "+30000000000",
+			},
+			{
+				AccountID:  1,
+				IdentityID: 3,
+				ID:         9,
+				Type:       "email",
+				Value:      "user3@example.com",
+			},
+		}
+		assert.Equal(t, wantRows, rows)
+	}
+}
+
+func TestUpdate_removeIdentities(t *testing.T) {
+	db := dbtest.Open(t)
+	session := db.Open()
+
+	store := DBStore{
+		DB: session,
+	}
+
+	address := "GCLLT3VG4F6EZAHZEBKWBWV5JGVPCVIKUCGTY3QEOAIZU5IJGMWCT2TT"
+
+	// Store the account
+	a := Account{
+		Address: address,
+		Identities: []Identity{
+			{
+				Role: "sender",
+				AuthMethods: []AuthMethod{
+					{Type: AuthMethodTypeAddress, Value: "GD4NGMOTV4QOXWA6PGPIGVWZYMRCJAKLQJKZIP55C5DGB3GBHHET3YC6"},
+					{Type: AuthMethodTypePhoneNumber, Value: "+10000000000"},
+					{Type: AuthMethodTypeEmail, Value: "user1@example.com"},
+				},
+			},
+			{
+				Role: "receiver",
+				AuthMethods: []AuthMethod{
+					{Type: AuthMethodTypeAddress, Value: "GBJCOYGKIJYX3VUEOZ6GVMFP522UO4OEBI5KB5HHWZAZ2DEJTHS6VOHP"},
+					{Type: AuthMethodTypePhoneNumber, Value: "+20000000000"},
+					{Type: AuthMethodTypeEmail, Value: "user2@example.com"},
+				},
+			},
+		},
+	}
+	err := store.Add(a)
+	require.NoError(t, err)
+
+	// Remove the identities on the account
+	b := Account{
+		Address: address,
+	}
+
+	err = store.Update(b)
+	require.NoError(t, err)
+
+	updatedAcc, err := store.Get(address)
+	require.NoError(t, err)
+	assert.Equal(t, b, updatedAcc)
+
+	{
+		type row struct {
+			AccountID int64  `db:"account_id"`
+			ID        int64  `db:"id"`
+			Role      string `db:"role"`
+		}
+		rows := []row{}
+		err = session.Select(&rows, `SELECT account_id, id, role FROM identities`)
+		require.NoError(t, err)
+		assert.Equal(t, []row{}, rows)
+	}
+	{
+		type row struct {
+			AccountID  int64  `db:"account_id"`
+			IdentityID int64  `db:"identity_id"`
+			ID         int64  `db:"id"`
+			Type       string `db:"type_"`
+			Value      string `db:"value"`
+		}
+		rows := []row{}
+		err = session.Select(&rows, `SELECT account_id, identity_id, id, type_, value FROM auth_methods`)
+		require.NoError(t, err)
+		assert.Equal(t, []row{}, rows)
+	}
+}
+
+func TestUpdate_noAuthMethods(t *testing.T) {
+	db := dbtest.Open(t)
+	session := db.Open()
+
+	store := DBStore{
+		DB: session,
+	}
+
+	address := "GCLLT3VG4F6EZAHZEBKWBWV5JGVPCVIKUCGTY3QEOAIZU5IJGMWCT2TT"
+
+	// Store the account
+	a := Account{
+		Address: address,
+		Identities: []Identity{
+			{
+				Role: "sender",
+				AuthMethods: []AuthMethod{
+					{Type: AuthMethodTypeAddress, Value: "GD4NGMOTV4QOXWA6PGPIGVWZYMRCJAKLQJKZIP55C5DGB3GBHHET3YC6"},
+					{Type: AuthMethodTypePhoneNumber, Value: "+10000000000"},
+					{Type: AuthMethodTypeEmail, Value: "user1@example.com"},
+				},
+			},
+			{
+				Role: "receiver",
+				AuthMethods: []AuthMethod{
+					{Type: AuthMethodTypeAddress, Value: "GBJCOYGKIJYX3VUEOZ6GVMFP522UO4OEBI5KB5HHWZAZ2DEJTHS6VOHP"},
+					{Type: AuthMethodTypePhoneNumber, Value: "+20000000000"},
+					{Type: AuthMethodTypeEmail, Value: "user2@example.com"},
+				},
+			},
+		},
+	}
+	err := store.Add(a)
+	require.NoError(t, err)
+
+	b := Account{
+		Address: address,
+		Identities: []Identity{
+			{
+				Role: "sender",
+			},
+			{
+				Role: "receiver",
+			},
+		},
+	}
+
+	err = store.Update(b)
+	require.NoError(t, err)
+
+	updatedAcc, err := store.Get(address)
+	require.NoError(t, err)
+	assert.Equal(t, b, updatedAcc)
+
+	// check there is no row in auth_methods
+	type row struct {
+		AccountID  int64  `db:"account_id"`
+		IdentityID int64  `db:"identity_id"`
+		ID         int64  `db:"id"`
+		Type       string `db:"type_"`
+		Value      string `db:"value"`
+	}
+	rows := []row{}
+	err = session.Select(&rows, `SELECT account_id, identity_id, id, type_, value FROM auth_methods`)
+	require.NoError(t, err)
+	assert.Equal(t, []row{}, rows)
+}
+
+func TestUpdate_notFound(t *testing.T) {
+	db := dbtest.Open(t)
+	session := db.Open()
+
+	store := DBStore{
+		DB: session,
+	}
+
+	a := Account{
+		Address: "GCLLT3VG4F6EZAHZEBKWBWV5JGVPCVIKUCGTY3QEOAIZU5IJGMWCT2TT",
+	}
+
+	err := store.Update(a)
+	assert.Equal(t, ErrNotFound, err)
+}

--- a/exp/services/recoverysigner/internal/account/store.go
+++ b/exp/services/recoverysigner/internal/account/store.go
@@ -6,6 +6,7 @@ type Store interface {
 	Add(a Account) error
 	Delete(address string) error
 	Get(address string) (Account, error)
+	Update(a Account) error
 	FindWithIdentityAddress(address string) ([]Account, error)
 	FindWithIdentityPhoneNumber(phoneNumber string) ([]Account, error)
 	FindWithIdentityEmail(email string) ([]Account, error)

--- a/exp/services/recoverysigner/internal/serve/account_put.go
+++ b/exp/services/recoverysigner/internal/serve/account_put.go
@@ -1,0 +1,157 @@
+package serve
+
+import (
+	"net/http"
+
+	"github.com/stellar/go/exp/services/recoverysigner/internal/account"
+	"github.com/stellar/go/exp/services/recoverysigner/internal/serve/auth"
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/http/httpdecode"
+	supportlog "github.com/stellar/go/support/log"
+	"github.com/stellar/go/support/render/httpjson"
+)
+
+type accountPutHandler struct {
+	Logger         *supportlog.Entry
+	SigningAddress *keypair.FromAddress
+	AccountStore   account.Store
+}
+
+type accountPutRequest struct {
+	Address    *keypair.FromAddress        `path:"address"`
+	Identities []accountPutRequestIdentity `json:"identities" form:"identities"`
+}
+
+func (r accountPutRequest) Validate() error {
+	if len(r.Identities) == 0 {
+		return errors.Errorf("no identities provided but at least one is required")
+	}
+	for _, i := range r.Identities {
+		err := i.Validate()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type accountPutRequestIdentity struct {
+	Role        string                                `json:"role" form:"role"`
+	AuthMethods []accountPutRequestIdentityAuthMethod `json:"auth_methods" form:"auth_methods"`
+}
+
+func (i accountPutRequestIdentity) Validate() error {
+	if i.Role == "" {
+		return errors.Errorf("role is not set but required")
+	}
+	if len(i.AuthMethods) == 0 {
+		return errors.Errorf("auth methods not provided for identity but required")
+	}
+	for _, am := range i.AuthMethods {
+		err := am.Validate()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type accountPutRequestIdentityAuthMethod struct {
+	Type  string `json:"type" form:"type"`
+	Value string `json:"value" form:"value"`
+}
+
+func (am accountPutRequestIdentityAuthMethod) Validate() error {
+	if !account.AuthMethodType(am.Type).Valid() {
+		return errors.Errorf("auth method type %q unrecognized", am.Type)
+	}
+	// TODO: Validate auth method values: Stellar address, phone number and email.
+	return nil
+}
+
+func (h accountPutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	claims, _ := auth.FromContext(ctx)
+	if claims.Address == "" && claims.PhoneNumber == "" && claims.Email == "" {
+		unauthorized.Render(w)
+		return
+	}
+
+	req := accountPutRequest{}
+	err := httpdecode.Decode(r, &req)
+	if err != nil || req.Address == nil || req.Validate() != nil {
+		badRequest.Render(w)
+		return
+	}
+
+	acc, err := h.AccountStore.Get(req.Address.Address())
+	if err == account.ErrNotFound {
+		notFound.Render(w)
+		return
+	} else if err != nil {
+		h.Logger.Error(err)
+		serverError.Render(w)
+		return
+	}
+
+	// Authorized if authenticated as the account.
+	authorized := claims.Address == req.Address.Address()
+
+	// Authorized if authenticated as an identity registered with the account.
+	for _, i := range acc.Identities {
+		for _, m := range i.AuthMethods {
+			if m.Value != "" && ((m.Type == account.AuthMethodTypeAddress && m.Value == claims.Address) ||
+				(m.Type == account.AuthMethodTypePhoneNumber && m.Value == claims.PhoneNumber) ||
+				(m.Type == account.AuthMethodTypeEmail && m.Value == claims.Email)) {
+				authorized = true
+				break
+			}
+		}
+	}
+	if !authorized {
+		notFound.Render(w)
+		return
+	}
+
+	accWithNewIdentiies := account.Account{
+		Address:    req.Address.Address(),
+		Identities: []account.Identity{},
+	}
+	for _, i := range req.Identities {
+		accIdentity := account.Identity{
+			Role: i.Role,
+		}
+		for _, m := range i.AuthMethods {
+			accIdentity.AuthMethods = append(accIdentity.AuthMethods, account.AuthMethod{
+				Type:  account.AuthMethodType(m.Type),
+				Value: m.Value,
+			})
+		}
+		accWithNewIdentiies.Identities = append(accWithNewIdentiies.Identities, accIdentity)
+	}
+
+	err = h.AccountStore.Update(accWithNewIdentiies)
+	if err == account.ErrNotFound {
+		// It can happen if another authorized user is trying to delete the account at the same time.
+		notFound.Render(w)
+		return
+	} else if err != nil {
+		h.Logger.Error(err)
+		serverError.Render(w)
+		return
+	}
+
+	resp := accountResponse{
+		Address: accWithNewIdentiies.Address,
+		Signer:  h.SigningAddress.Address(),
+	}
+	for _, i := range accWithNewIdentiies.Identities {
+		resp.Identities = append(resp.Identities, accountResponseIdentity{
+			Role: i.Role,
+		})
+	}
+
+	httpjson.Render(w, resp, httpjson.JSON)
+}

--- a/exp/services/recoverysigner/internal/serve/account_put_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_put_test.go
@@ -18,6 +18,128 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAccountPut_authenticatedNotAuthorized(t *testing.T) {
+	s := &account.DBStore{DB: dbtest.Open(t).Open()}
+	s.Add(account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "sender",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypePhoneNumber, Value: "+11000000000"},
+				},
+			},
+			{
+				Role: "receiver",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypePhoneNumber, Value: "+10000000000"},
+				},
+			},
+		},
+	})
+	h := accountPutHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{Address: "GCNPATZQVSFGGSAHR4T54WNELPHYEBTSKH4IIKUTC7CHPLG6EPPC4PJL"})
+	req := `{
+	"identities": [
+		{
+			"role": "owner",
+			"auth_methods": [
+				{ "type": "stellar_address", "value": "GBF3XFXGBGNQDN3HOSZ7NVRF6TJ2JOD5U6ELIWJOOEI6T5WKMQT2YSXQ" },
+				{ "type": "phone_number", "value": "+10000000000" },
+				{ "type": "email", "value": "user1@example.com" }
+			]
+		}
+	]
+}`
+	r := httptest.NewRequest("PUT", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", strings.NewReader(req))
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Put("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"error": "The resource at the url requested was not found."
+}`
+
+	assert.JSONEq(t, wantBody, string(body))
+}
+
+func TestAccountPut_notAuthenticated(t *testing.T) {
+	s := &account.DBStore{DB: dbtest.Open(t).Open()}
+	s.Add(account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "sender",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypePhoneNumber, Value: "+11000000000"},
+				},
+			},
+			{
+				Role: "receiver",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypePhoneNumber, Value: "+10000000000"},
+				},
+			},
+		},
+	})
+	h := accountPutHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{})
+	req := `{
+	"identities": [
+		{
+			"role": "owner",
+			"auth_methods": [
+				{ "type": "stellar_address", "value": "GBF3XFXGBGNQDN3HOSZ7NVRF6TJ2JOD5U6ELIWJOOEI6T5WKMQT2YSXQ" },
+				{ "type": "phone_number", "value": "+10000000000" },
+				{ "type": "email", "value": "user1@example.com" }
+			]
+		}
+	]
+}`
+	r := httptest.NewRequest("PUT", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", strings.NewReader(req))
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Put("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"error": "The request could not be authenticated."
+}`
+
+	assert.JSONEq(t, wantBody, string(body))
+}
+
 func TestAccountPut_authenticatedByAccountAddress(t *testing.T) {
 	s := &account.DBStore{DB: dbtest.Open(t).Open()}
 	s.Add(account.Account{
@@ -45,6 +167,258 @@ func TestAccountPut_authenticatedByAccountAddress(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = auth.NewContext(ctx, auth.Auth{Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N"})
+	req := `{
+	"identities": [
+		{
+			"role": "owner",
+			"auth_methods": [
+				{ "type": "stellar_address", "value": "GBF3XFXGBGNQDN3HOSZ7NVRF6TJ2JOD5U6ELIWJOOEI6T5WKMQT2YSXQ" },
+				{ "type": "phone_number", "value": "+10000000000" },
+				{ "type": "email", "value": "user1@example.com" }
+			]
+		}
+	]
+}`
+	r := httptest.NewRequest("PUT", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", strings.NewReader(req))
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Put("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"address": "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+	"identities": [
+		{
+			"role": "owner"
+		}
+	],
+	"signer": "GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"
+}`
+
+	assert.JSONEq(t, wantBody, string(body))
+
+	acc, err := s.Get("GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N")
+	require.NoError(t, err)
+	wantAcc := account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "owner",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypeAddress, Value: "GBF3XFXGBGNQDN3HOSZ7NVRF6TJ2JOD5U6ELIWJOOEI6T5WKMQT2YSXQ"},
+					{Type: account.AuthMethodTypePhoneNumber, Value: "+10000000000"},
+					{Type: account.AuthMethodTypeEmail, Value: "user1@example.com"},
+				},
+			},
+		},
+	}
+	assert.Equal(t, wantAcc, acc)
+}
+
+func TestAccountPut_authenticatedByIdentityAddress(t *testing.T) {
+	s := &account.DBStore{DB: dbtest.Open(t).Open()}
+	s.Add(account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "sender",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypeAddress, Value: "GCGZ3CNBE47IWAA5YIKDZL2XYYLA2UKJPS55P5EJ4VOMLK523PF3G7EM"},
+				},
+			},
+			{
+				Role: "receiver",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypePhoneNumber, Value: "+10000000000"},
+				},
+			},
+		},
+	})
+	h := accountPutHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{Address: "GCGZ3CNBE47IWAA5YIKDZL2XYYLA2UKJPS55P5EJ4VOMLK523PF3G7EM"})
+	req := `{
+	"identities": [
+		{
+			"role": "owner",
+			"auth_methods": [
+				{ "type": "stellar_address", "value": "GBF3XFXGBGNQDN3HOSZ7NVRF6TJ2JOD5U6ELIWJOOEI6T5WKMQT2YSXQ" },
+				{ "type": "phone_number", "value": "+10000000000" },
+				{ "type": "email", "value": "user1@example.com" }
+			]
+		}
+	]
+}`
+	r := httptest.NewRequest("PUT", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", strings.NewReader(req))
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Put("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"address": "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+	"identities": [
+		{
+			"role": "owner"
+		}
+	],
+	"signer": "GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"
+}`
+
+	assert.JSONEq(t, wantBody, string(body))
+
+	acc, err := s.Get("GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N")
+	require.NoError(t, err)
+	wantAcc := account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "owner",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypeAddress, Value: "GBF3XFXGBGNQDN3HOSZ7NVRF6TJ2JOD5U6ELIWJOOEI6T5WKMQT2YSXQ"},
+					{Type: account.AuthMethodTypePhoneNumber, Value: "+10000000000"},
+					{Type: account.AuthMethodTypeEmail, Value: "user1@example.com"},
+				},
+			},
+		},
+	}
+	assert.Equal(t, wantAcc, acc)
+}
+
+func TestAccountPut_authenticatedByPhoneNumber(t *testing.T) {
+	s := &account.DBStore{DB: dbtest.Open(t).Open()}
+	s.Add(account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "sender",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypeAddress, Value: "GCGZ3CNBE47IWAA5YIKDZL2XYYLA2UKJPS55P5EJ4VOMLK523PF3G7EM"},
+				},
+			},
+			{
+				Role: "receiver",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypePhoneNumber, Value: "+10000000000"},
+				},
+			},
+		},
+	})
+	h := accountPutHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{PhoneNumber: "+10000000000"})
+	req := `{
+	"identities": [
+		{
+			"role": "owner",
+			"auth_methods": [
+				{ "type": "stellar_address", "value": "GBF3XFXGBGNQDN3HOSZ7NVRF6TJ2JOD5U6ELIWJOOEI6T5WKMQT2YSXQ" },
+				{ "type": "phone_number", "value": "+10000000000" },
+				{ "type": "email", "value": "user1@example.com" }
+			]
+		}
+	]
+}`
+	r := httptest.NewRequest("PUT", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", strings.NewReader(req))
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Put("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"address": "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+	"identities": [
+		{
+			"role": "owner"
+		}
+	],
+	"signer": "GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"
+}`
+
+	assert.JSONEq(t, wantBody, string(body))
+
+	acc, err := s.Get("GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N")
+	require.NoError(t, err)
+	wantAcc := account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "owner",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypeAddress, Value: "GBF3XFXGBGNQDN3HOSZ7NVRF6TJ2JOD5U6ELIWJOOEI6T5WKMQT2YSXQ"},
+					{Type: account.AuthMethodTypePhoneNumber, Value: "+10000000000"},
+					{Type: account.AuthMethodTypeEmail, Value: "user1@example.com"},
+				},
+			},
+		},
+	}
+	assert.Equal(t, wantAcc, acc)
+}
+
+func TestAccountPut_authenticatedByEmail(t *testing.T) {
+	s := &account.DBStore{DB: dbtest.Open(t).Open()}
+	s.Add(account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "sender",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypeAddress, Value: "GCGZ3CNBE47IWAA5YIKDZL2XYYLA2UKJPS55P5EJ4VOMLK523PF3G7EM"},
+				},
+			},
+			{
+				Role: "receiver",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypeEmail, Value: "user1@example.com"},
+				},
+			},
+		},
+	})
+	h := accountPutHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{Email: "user1@example.com"})
 	req := `{
 	"identities": [
 		{

--- a/exp/services/recoverysigner/internal/serve/account_put_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_put_test.go
@@ -1,0 +1,103 @@
+package serve
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi"
+	"github.com/stellar/go/exp/services/recoverysigner/internal/account"
+	"github.com/stellar/go/exp/services/recoverysigner/internal/db/dbtest"
+	"github.com/stellar/go/exp/services/recoverysigner/internal/serve/auth"
+	"github.com/stellar/go/keypair"
+	supportlog "github.com/stellar/go/support/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountPut_authenticatedByAccountAddress(t *testing.T) {
+	s := &account.DBStore{DB: dbtest.Open(t).Open()}
+	s.Add(account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "sender",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypePhoneNumber, Value: "+11000000000"},
+				},
+			},
+			{
+				Role: "receiver",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypePhoneNumber, Value: "+10000000000"},
+				},
+			},
+		},
+	})
+	h := accountPutHandler{
+		Logger:         supportlog.DefaultLogger,
+		AccountStore:   s,
+		SigningAddress: keypair.MustParseAddress("GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"),
+	}
+
+	ctx := context.Background()
+	ctx = auth.NewContext(ctx, auth.Auth{Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N"})
+	req := `{
+	"identities": [
+		{
+			"role": "owner",
+			"auth_methods": [
+				{ "type": "stellar_address", "value": "GBF3XFXGBGNQDN3HOSZ7NVRF6TJ2JOD5U6ELIWJOOEI6T5WKMQT2YSXQ" },
+				{ "type": "phone_number", "value": "+10000000000" },
+				{ "type": "email", "value": "user1@example.com" }
+			]
+		}
+	]
+}`
+	r := httptest.NewRequest("PUT", "/GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N", strings.NewReader(req))
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	m := chi.NewMux()
+	m.Put("/{address}", h.ServeHTTP)
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	wantBody := `{
+	"address": "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+	"identities": [
+		{
+			"role": "owner"
+		}
+	],
+	"signer": "GCAPXRXSU7P6D353YGXMP6ROJIC744HO5OZCIWTXZQK2X757YU5KCHUE"
+}`
+
+	assert.JSONEq(t, wantBody, string(body))
+
+	acc, err := s.Get("GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N")
+	require.NoError(t, err)
+	wantAcc := account.Account{
+		Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N",
+		Identities: []account.Identity{
+			{
+				Role: "owner",
+				AuthMethods: []account.AuthMethod{
+					{Type: account.AuthMethodTypeAddress, Value: "GBF3XFXGBGNQDN3HOSZ7NVRF6TJ2JOD5U6ELIWJOOEI6T5WKMQT2YSXQ"},
+					{Type: account.AuthMethodTypePhoneNumber, Value: "+10000000000"},
+					{Type: account.AuthMethodTypeEmail, Value: "user1@example.com"},
+				},
+			},
+		},
+	}
+	assert.Equal(t, wantAcc, acc)
+}

--- a/exp/services/recoverysigner/internal/serve/serve.go
+++ b/exp/services/recoverysigner/internal/serve/serve.go
@@ -128,7 +128,11 @@ func handler(deps handlerDeps) http.Handler {
 				SigningAddress: deps.SigningKey.FromAddress(),
 				AccountStore:   deps.AccountStore,
 			}.ServeHTTP)
-			// TODO: mux.Put("/", accountPutHandler{}.ServeHTTP)
+			mux.Put("/", accountPutHandler{
+				Logger:         deps.Logger,
+				SigningAddress: deps.SigningKey.FromAddress(),
+				AccountStore:   deps.AccountStore,
+			}.ServeHTTP)
 			mux.Get("/", accountGetHandler{
 				Logger:         deps.Logger,
 				SigningAddress: deps.SigningKey.FromAddress(),


### PR DESCRIPTION
### What

This PR implements the PUT /accounts/{address} endpoint specified [here](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0030.md#put-accountsaddress).

Note that this endpoint replaces the original identities with the identities provided in the request, and not merged.

`db_store_update.go` and its test file are added to support this PR.

Though 996+, 1- seems intimidating, 777+ of it are for testing.

### Why

This PR adds the final endpoint in the spec that is not yet implemented.

### Known limitations

N/A

Close https://github.com/stellar/go/issues/2340