### PR TITLE
exp/recoverysigner/account: add comments for the cascade delete

### DIFF
--- a/exp/services/recoverysigner/internal/account/db_store_delete.go
+++ b/exp/services/recoverysigner/internal/account/db_store_delete.go
@@ -2,8 +2,6 @@ package account
 
 func (s *DBStore) Delete(address string) error {
 	// Delete an account will delete the associated identities and auth methods because of the ON DELETE CASCADE references.
-	// https://github.com/stellar/go/blob/b3e0a353a901ce0babad5b4953330e55f2c674a1/exp/services/recoverysigner/internal/db/dbmigrate/migrations/20200311000001-create-identities.sql#L4
-	// https://github.com/stellar/go/blob/b3e0a353a901ce0babad5b4953330e55f2c674a1/exp/services/recoverysigner/internal/db/dbmigrate/migrations/20200311000002-create-auth-methods.sql#L10
 	result, err := s.DB.Exec(
 		`DELETE FROM accounts
 		WHERE address = $1`,

--- a/exp/services/recoverysigner/internal/account/db_store_delete.go
+++ b/exp/services/recoverysigner/internal/account/db_store_delete.go
@@ -1,6 +1,9 @@
 package account
 
 func (s *DBStore) Delete(address string) error {
+	// Delete an account will delete the associated identities and auth methods because of the ON DELETE CASCADE references.
+	// https://github.com/stellar/go/blob/b3e0a353a901ce0babad5b4953330e55f2c674a1/exp/services/recoverysigner/internal/db/dbmigrate/migrations/20200311000001-create-identities.sql#L4
+	// https://github.com/stellar/go/blob/b3e0a353a901ce0babad5b4953330e55f2c674a1/exp/services/recoverysigner/internal/db/dbmigrate/migrations/20200311000002-create-auth-methods.sql#L10
 	result, err := s.DB.Exec(
 		`DELETE FROM accounts
 		WHERE address = $1`,


### PR DESCRIPTION
### What

This PR adds comments to explain the ON DETETE CASCADE effect when deleting an account to avoid confusion.

### Why

Make the code more readable.

### Known limitations

N/A
