### PR TITLE
exp/recoverysigner/serve: remove obsolete request field

### DIFF
--- a/exp/services/recoverysigner/internal/serve/account_post_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_post_test.go
@@ -30,7 +30,6 @@ func TestAccountPost_newWithRoleOwnerContentTypeJSON(t *testing.T) {
 	ctx := context.Background()
 	ctx = auth.NewContext(ctx, auth.Auth{Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N"})
 	req := `{
-	"type": "share",
 	"identities": [
 		{
 			"role": "owner",
@@ -158,7 +157,6 @@ func TestAccountPost_newWithRolesSenderReceiverContentTypeJSON(t *testing.T) {
 	ctx := context.Background()
 	ctx = auth.NewContext(ctx, auth.Auth{Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N"})
 	req := `{
-	"type": "share",
 	"identities": [
 		{
 			"role": "sender",
@@ -532,7 +530,6 @@ func TestAccountPost_authMethodTypeUnrecognized(t *testing.T) {
 	ctx := context.Background()
 	ctx = auth.NewContext(ctx, auth.Auth{Address: "GDIXCQJ2W2N6TAS6AYW4LW2EBV7XNRUCLNHQB37FARDEWBQXRWP47Q6N"})
 	req := `{
-	"type": "share",
 	"identities": [
 		{
 			"role": "owner",


### PR DESCRIPTION
### What

This PR removes an obsolete field `type` used in our account memory store prototype in the post requests in testing.

### Why

This makes the code read better. Reading test files is a good way to understand how the system behaves, so making it clear can boost the readability of our code base.

### Known limitations

N/A