### PR TITLE
exp/services/recoverysigner: update SEP number in usage

### DIFF
--- a/exp/services/recoverysigner/README.md
+++ b/exp/services/recoverysigner/README.md
@@ -17,14 +17,14 @@ Running this implementation in production is not recommended.
 
 ```
 $ recoverysigner --help
-SEP-XX Recovery Signer server
+SEP-30 Recovery Signer server
 
 Usage:
   recoverysigner [command] [flags]
   recoverysigner [command]
 
 Available Commands:
-  serve       Run the SEP-XX Recover Signer server
+  serve       Run the SEP-30 Recover Signer server
 
 Use "recoverysigner [command] --help" for more information about a command.
 ```
@@ -33,7 +33,7 @@ Use "recoverysigner [command] --help" for more information about a command.
 
 ```
 $ recoverysigner serve --help
-Run the SEP-XX Recover Signer server
+Run the SEP-30 Recover Signer server
 
 Usage:
   recoverysigner serve [flags]

--- a/exp/services/recoverysigner/cmd/serve.go
+++ b/exp/services/recoverysigner/cmd/serve.go
@@ -74,7 +74,7 @@ func (c *ServeCommand) Command() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "serve",
-		Short: "Run the SEP-XX Recover Signer server",
+		Short: "Run the SEP-30 Recover Signer server",
 		Run: func(_ *cobra.Command, _ []string) {
 			configOpts.Require()
 			configOpts.SetValues()

--- a/exp/services/recoverysigner/internal/serve/serve.go
+++ b/exp/services/recoverysigner/internal/serve/serve.go
@@ -43,7 +43,7 @@ func Serve(opts Options) {
 		ListenAddr: addr,
 		Handler:    handler,
 		OnStarting: func() {
-			opts.Logger.Info("Starting SEP-XX Recover Signer server")
+			opts.Logger.Info("Starting SEP-30 Recover Signer server")
 			opts.Logger.Infof("Listening on %s", addr)
 		},
 	})

--- a/exp/services/recoverysigner/main.go
+++ b/exp/services/recoverysigner/main.go
@@ -13,7 +13,7 @@ func main() {
 
 	rootCmd := &cobra.Command{
 		Use:   "recoverysigner [command]",
-		Short: "SEP-XX Recovery Signer server",
+		Short: "SEP-30 Recovery Signer server",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()
 		},


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Change `SEP-XX` to `SEP-30` in the usage text of recoversigner.

### Why

The recoverysigner code was written before the SEP was assigned a number. It has a number now.

### Known limitations

N/A
