### PR TITLE
xdr: update xdr definitions

### DIFF
--- a/network/main_test.go
+++ b/network/main_test.go
@@ -62,7 +62,7 @@ func TestHashTransaction(t *testing.T) {
 
 	feeBumpTx := xdr.FeeBumpTransaction{
 		Fee:       123456,
-		FeeSource: xdr.MustAddress("GCLOMB72ODBFUGK4E2BK7VMR3RNZ5WSTMEOGNA2YUVHFR3WMH2XBAB6H"),
+		FeeSource: xdr.MustMuxedAccountAddress("GCLOMB72ODBFUGK4E2BK7VMR3RNZ5WSTMEOGNA2YUVHFR3WMH2XBAB6H"),
 		InnerTx: xdr.FeeBumpTransactionInnerTx{
 			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
 			V1: &xdr.TransactionV1Envelope{

--- a/services/horizon/internal/db2/history/fee_bump_scenario.go
+++ b/services/horizon/internal/db2/history/fee_bump_scenario.go
@@ -119,8 +119,8 @@ func FeeBumpScenario(tt *test.T, q *Q, successful bool) FeeBumpFixture {
 		Type: xdr.EnvelopeTypeEnvelopeTypeTxFeeBump,
 		FeeBump: &xdr.FeeBumpTransactionEnvelope{
 			Tx: xdr.FeeBumpTransaction{
-				FeeSource: xdr.AccountId{
-					Type:    xdr.PublicKeyTypePublicKeyTypeEd25519,
+				FeeSource: xdr.MuxedAccount{
+					Type:    xdr.CryptoKeyTypeKeyTypeEd25519,
 					Ed25519: &xdr.Uint256{2, 2, 2},
 				},
 				Fee: 776,

--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
@@ -173,7 +173,7 @@ func transactionToMap(transaction io.LedgerTransaction, sequence uint32) (map[st
 	if transaction.Envelope.IsFeeBump() {
 		innerHash := transaction.Result.InnerHash()
 		m["inner_transaction_hash"] = hex.EncodeToString(innerHash[:])
-		feeAccount := transaction.Envelope.FeeBumpAccount()
+		feeAccount := transaction.Envelope.FeeBumpAccount().ToAccountId()
 		m["fee_account"] = feeAccount.Address()
 		m["new_max_fee"] = transaction.Envelope.FeeBumpFee()
 		m["inner_signatures"] = sqx.StringArray(signatures(transaction.Envelope.Signatures()))

--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder_test.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder_test.go
@@ -10,23 +10,47 @@ import (
 )
 
 func TestTransactionToMap_muxed(t *testing.T) {
-	muxed := xdr.MustMuxedAccountAddress("MCAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITKNOG")
+	innerSource := xdr.MuxedAccount{
+		Type: xdr.CryptoKeyTypeKeyTypeMuxedEd25519,
+		Med25519: &xdr.MuxedAccountMed25519{
+			Id:      1,
+			Ed25519: xdr.Uint256{3, 2, 1},
+		},
+	}
+	innerAccountID := innerSource.ToAccountId()
+	feeSource := xdr.MuxedAccount{
+		Type: xdr.CryptoKeyTypeKeyTypeMuxedEd25519,
+		Med25519: &xdr.MuxedAccountMed25519{
+			Id:      1,
+			Ed25519: xdr.Uint256{0, 1, 2},
+		},
+	}
+	feeSourceAccountID := feeSource.ToAccountId()
 	tx := io.LedgerTransaction{
 		Index: 1,
 		Envelope: xdr.TransactionEnvelope{
-			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
-			V1: &xdr.TransactionV1Envelope{
-				Tx: xdr.Transaction{
-					SourceAccount: muxed,
-					Operations: []xdr.Operation{
-						{
-							SourceAccount: &muxed,
-							Body: xdr.OperationBody{
-								Type: xdr.OperationTypePayment,
-								PaymentOp: &xdr.PaymentOp{
-									Destination: muxed,
-									Asset:       xdr.Asset{Type: xdr.AssetTypeAssetTypeNative},
-									Amount:      100,
+			Type: xdr.EnvelopeTypeEnvelopeTypeTxFeeBump,
+			FeeBump: &xdr.FeeBumpTransactionEnvelope{
+				Tx: xdr.FeeBumpTransaction{
+					FeeSource: feeSource,
+					Fee:       200,
+					InnerTx: xdr.FeeBumpTransactionInnerTx{
+						Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+						V1: &xdr.TransactionV1Envelope{
+							Tx: xdr.Transaction{
+								SourceAccount: innerSource,
+								Operations: []xdr.Operation{
+									{
+										SourceAccount: &innerSource,
+										Body: xdr.OperationBody{
+											Type: xdr.OperationTypePayment,
+											PaymentOp: &xdr.PaymentOp{
+												Destination: innerSource,
+												Asset:       xdr.Asset{Type: xdr.AssetTypeAssetTypeNative},
+												Amount:      100,
+											},
+										},
+									},
 								},
 							},
 						},
@@ -35,9 +59,12 @@ func TestTransactionToMap_muxed(t *testing.T) {
 			},
 		},
 		Result: xdr.TransactionResultPair{
+			TransactionHash: xdr.Hash{1, 2, 3},
 			Result: xdr.TransactionResult{
 				Result: xdr.TransactionResultResult{
+					Code: xdr.TransactionResultCodeTxFeeBumpInnerSuccess,
 					InnerResultPair: &xdr.InnerTransactionResultPair{
+						TransactionHash: xdr.Hash{3, 2, 1},
 						Result: xdr.InnerTransactionResult{
 							Result: xdr.InnerTransactionResultResult{
 								Results: &[]xdr.OperationResult{},
@@ -58,8 +85,12 @@ func TestTransactionToMap_muxed(t *testing.T) {
 		},
 	}
 	result, err := transactionToMap(tx, 20)
-	if assert.NoError(t, err) {
-		assert.Equal(t, "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ", result["account"])
-	}
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, innerSource.Address(), result["account"])
+	assert.Equal(t, innerAccountID.Address(), result["account"])
+
+	assert.NotEqual(t, feeSource.Address(), result["fee_account"])
+	assert.Equal(t, feeSourceAccountID.Address(), result["fee_account"])
 
 }

--- a/services/horizon/internal/expingest/processors/participants_processor.go
+++ b/services/horizon/internal/expingest/processors/participants_processor.go
@@ -143,7 +143,7 @@ func participantsForTransaction(
 		transaction.Envelope.SourceAccount().ToAccountId(),
 	}
 	if transaction.Envelope.IsFeeBump() {
-		participants = append(participants, transaction.Envelope.FeeBumpAccount())
+		participants = append(participants, transaction.Envelope.FeeBumpAccount().ToAccountId())
 	}
 
 	p, err := participantsForMeta(transaction.Meta)

--- a/services/horizon/internal/expingest/processors/participants_processor_test.go
+++ b/services/horizon/internal/expingest/processors/participants_processor_test.go
@@ -156,7 +156,7 @@ func (s *ParticipantsProcessorTestSuiteLedger) TestFeeBumptransaction() {
 	feeBumpTx.Envelope.V1.Tx.SourceAccount = xdr.MustMuxedAccountAddress(s.addresses[0])
 	feeBumpTx.Envelope.FeeBump = &xdr.FeeBumpTransactionEnvelope{
 		Tx: xdr.FeeBumpTransaction{
-			FeeSource: xdr.MustAddress(s.addresses[1]),
+			FeeSource: xdr.MustMuxedAccountAddress(s.addresses[1]),
 			Fee:       100,
 			InnerTx: xdr.FeeBumpTransactionInnerTx{
 				Type: xdr.EnvelopeTypeEnvelopeTypeTx,

--- a/services/horizon/internal/resourceadapter/transaction_test.go
+++ b/services/horizon/internal/resourceadapter/transaction_test.go
@@ -89,7 +89,7 @@ func TestPopulateTransaction_TextMemo(t *testing.T) {
 							},
 						},
 					},
-					FeeSource: xdr.MustAddress("GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU"),
+					FeeSource: xdr.MustMuxedAccountAddress("GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU"),
 				},
 			},
 		},

--- a/xdr/Stellar-ledger.x
+++ b/xdr/Stellar-ledger.x
@@ -366,7 +366,6 @@ struct LedgerCloseMetaV0
 union LedgerCloseMeta switch (int v)
 {
 case 0:
-     LedgerCloseMetaV0 v0;
+    LedgerCloseMetaV0 v0;
 };
-
 }

--- a/xdr/Stellar-overlay.x
+++ b/xdr/Stellar-overlay.x
@@ -172,8 +172,8 @@ struct TopologyResponseBody
 
 union SurveyResponseBody switch (SurveyMessageCommandType type)
 {
-    case SURVEY_TOPOLOGY:
-        TopologyResponseBody topologyResponseBody;
+case SURVEY_TOPOLOGY:
+    TopologyResponseBody topologyResponseBody;
 };
 
 union StellarMessage switch (MessageType type)
@@ -220,10 +220,10 @@ union AuthenticatedMessage switch (uint32 v)
 {
 case 0:
     struct
-{
-   uint64 sequence;
-   StellarMessage message;
-   HmacSha256Mac mac;
+    {
+        uint64 sequence;
+        StellarMessage message;
+        HmacSha256Mac mac;
     } v0;
 };
 }

--- a/xdr/Stellar-transaction.x
+++ b/xdr/Stellar-transaction.x
@@ -8,14 +8,16 @@ namespace stellar
 {
 
 // Source or destination of a payment operation
-union MuxedAccount switch (CryptoKeyType type) {
- case KEY_TYPE_ED25519:
-     uint256 ed25519;
- case KEY_TYPE_MUXED_ED25519:
-     struct {
-         uint64 id;
-         uint256 ed25519;
-     } med25519;
+union MuxedAccount switch (CryptoKeyType type)
+{
+case KEY_TYPE_ED25519:
+    uint256 ed25519;
+case KEY_TYPE_MUXED_ED25519:
+    struct
+    {
+        uint64 id;
+        uint256 ed25519;
+    } med25519;
 };
 
 struct DecoratedSignature
@@ -120,7 +122,6 @@ struct PathPaymentStrictSendOp
 
     Asset path<5>; // additional hops it must go through to get there
 };
-
 
 /* Creates, updates or deletes an offer
 
@@ -379,10 +380,12 @@ struct TransactionV0
     TimeBounds* timeBounds;
     Memo memo;
     Operation operations<MAX_OPS_PER_TX>;
-    union switch (int v) {
+    union switch (int v)
+    {
     case 0:
         void;
-    } ext;
+    }
+    ext;
 };
 
 struct TransactionV0Envelope
@@ -437,17 +440,20 @@ struct TransactionV1Envelope
 
 struct FeeBumpTransaction
 {
-    AccountID feeSource;
+    MuxedAccount feeSource;
     int64 fee;
     union switch (EnvelopeType type)
     {
     case ENVELOPE_TYPE_TX:
         TransactionV1Envelope v1;
-    } innerTx;
-    union switch (int v) {
+    }
+    innerTx;
+    union switch (int v)
+    {
     case 0:
         void;
-    } ext;
+    }
+    ext;
 };
 
 struct FeeBumpTransactionEnvelope
@@ -459,7 +465,8 @@ struct FeeBumpTransactionEnvelope
 };
 
 /* A TransactionEnvelope wraps a transaction with signatures. */
-union TransactionEnvelope switch (EnvelopeType type) {
+union TransactionEnvelope switch (EnvelopeType type)
+{
 case ENVELOPE_TYPE_TX_V0:
     TransactionV0Envelope v0;
 case ENVELOPE_TYPE_TX:
@@ -558,23 +565,32 @@ enum PathPaymentStrictReceiveResultCode
     PATH_PAYMENT_STRICT_RECEIVE_SUCCESS = 0, // success
 
     // codes considered as "failure" for the operation
-    PATH_PAYMENT_STRICT_RECEIVE_MALFORMED = -1,          // bad input
-    PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED = -2,        // not enough funds in source account
-    PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST = -3,       // no trust line on source account
-    PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
-    PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION = -5,     // destination account does not exist
-    PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST = -6,           // dest missing a trust line for asset
-    PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
-    PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL = -8,          // dest would go above their limit
-    PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER = -9,          // missing issuer on one asset
-    PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
-    PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
-    PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX = -12       // could not satisfy sendmax
+    PATH_PAYMENT_STRICT_RECEIVE_MALFORMED = -1, // bad input
+    PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED =
+        -2, // not enough funds in source account
+    PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST =
+        -3, // no trust line on source account
+    PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED =
+        -4, // source not authorized to transfer
+    PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION =
+        -5, // destination account does not exist
+    PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST =
+        -6, // dest missing a trust line for asset
+    PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED =
+        -7, // dest not authorized to hold asset
+    PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL =
+        -8, // dest would go above their limit
+    PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER = -9, // missing issuer on one asset
+    PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS =
+        -10, // not enough offers to satisfy path
+    PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF =
+        -11, // would cross one of its own offers
+    PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX = -12 // could not satisfy sendmax
 };
 
 struct SimplePaymentResult
 {
-    MuxedAccount destination;
+    AccountID destination;
     Asset asset;
     int64 amount;
 };
@@ -601,18 +617,26 @@ enum PathPaymentStrictSendResultCode
     PATH_PAYMENT_STRICT_SEND_SUCCESS = 0, // success
 
     // codes considered as "failure" for the operation
-    PATH_PAYMENT_STRICT_SEND_MALFORMED = -1,          // bad input
-    PATH_PAYMENT_STRICT_SEND_UNDERFUNDED = -2,        // not enough funds in source account
-    PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST = -3,       // no trust line on source account
-    PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
-    PATH_PAYMENT_STRICT_SEND_NO_DESTINATION = -5,     // destination account does not exist
-    PATH_PAYMENT_STRICT_SEND_NO_TRUST = -6,           // dest missing a trust line for asset
-    PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
-    PATH_PAYMENT_STRICT_SEND_LINE_FULL = -8,          // dest would go above their limit
-    PATH_PAYMENT_STRICT_SEND_NO_ISSUER = -9,          // missing issuer on one asset
-    PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
-    PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
-    PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN = -12      // could not satisfy destMin
+    PATH_PAYMENT_STRICT_SEND_MALFORMED = -1, // bad input
+    PATH_PAYMENT_STRICT_SEND_UNDERFUNDED =
+        -2, // not enough funds in source account
+    PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST =
+        -3, // no trust line on source account
+    PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED =
+        -4, // source not authorized to transfer
+    PATH_PAYMENT_STRICT_SEND_NO_DESTINATION =
+        -5, // destination account does not exist
+    PATH_PAYMENT_STRICT_SEND_NO_TRUST =
+        -6, // dest missing a trust line for asset
+    PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED =
+        -7, // dest not authorized to hold asset
+    PATH_PAYMENT_STRICT_SEND_LINE_FULL = -8, // dest would go above their limit
+    PATH_PAYMENT_STRICT_SEND_NO_ISSUER = -9, // missing issuer on one asset
+    PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS =
+        -10, // not enough offers to satisfy path
+    PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF =
+        -11, // would cross one of its own offers
+    PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN = -12 // could not satisfy destMin
 };
 
 union PathPaymentStrictSendResult switch (PathPaymentStrictSendResultCode code)
@@ -637,21 +661,25 @@ enum ManageSellOfferResultCode
     MANAGE_SELL_OFFER_SUCCESS = 0,
 
     // codes considered as "failure" for the operation
-    MANAGE_SELL_OFFER_MALFORMED = -1,     // generated offer would be invalid
-    MANAGE_SELL_OFFER_SELL_NO_TRUST = -2, // no trust line for what we're selling
-    MANAGE_SELL_OFFER_BUY_NO_TRUST = -3,  // no trust line for what we're buying
+    MANAGE_SELL_OFFER_MALFORMED = -1, // generated offer would be invalid
+    MANAGE_SELL_OFFER_SELL_NO_TRUST =
+        -2,                              // no trust line for what we're selling
+    MANAGE_SELL_OFFER_BUY_NO_TRUST = -3, // no trust line for what we're buying
     MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
     MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
-    MANAGE_SELL_OFFER_LINE_FULL = -6,      // can't receive more of what it's buying
-    MANAGE_SELL_OFFER_UNDERFUNDED = -7,    // doesn't hold what it's trying to sell
-    MANAGE_SELL_OFFER_CROSS_SELF = -8,     // would cross an offer from the same user
+    MANAGE_SELL_OFFER_LINE_FULL = -6, // can't receive more of what it's buying
+    MANAGE_SELL_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
+    MANAGE_SELL_OFFER_CROSS_SELF =
+        -8, // would cross an offer from the same user
     MANAGE_SELL_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
     MANAGE_SELL_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
 
     // update errors
-    MANAGE_SELL_OFFER_NOT_FOUND = -11, // offerID does not match an existing offer
+    MANAGE_SELL_OFFER_NOT_FOUND =
+        -11, // offerID does not match an existing offer
 
-    MANAGE_SELL_OFFER_LOW_RESERVE = -12 // not enough funds to create a new Offer
+    MANAGE_SELL_OFFER_LOW_RESERVE =
+        -12 // not enough funds to create a new Offer
 };
 
 enum ManageOfferEffect
@@ -698,14 +726,15 @@ enum ManageBuyOfferResultCode
     MANAGE_BUY_OFFER_BUY_NO_TRUST = -3,  // no trust line for what we're buying
     MANAGE_BUY_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
     MANAGE_BUY_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
-    MANAGE_BUY_OFFER_LINE_FULL = -6,      // can't receive more of what it's buying
-    MANAGE_BUY_OFFER_UNDERFUNDED = -7,    // doesn't hold what it's trying to sell
-    MANAGE_BUY_OFFER_CROSS_SELF = -8,     // would cross an offer from the same user
+    MANAGE_BUY_OFFER_LINE_FULL = -6,   // can't receive more of what it's buying
+    MANAGE_BUY_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
+    MANAGE_BUY_OFFER_CROSS_SELF = -8, // would cross an offer from the same user
     MANAGE_BUY_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
     MANAGE_BUY_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
 
     // update errors
-    MANAGE_BUY_OFFER_NOT_FOUND = -11, // offerID does not match an existing offer
+    MANAGE_BUY_OFFER_NOT_FOUND =
+        -11, // offerID does not match an existing offer
 
     MANAGE_BUY_OFFER_LOW_RESERVE = -12 // not enough funds to create a new Offer
 };
@@ -757,7 +786,7 @@ enum ChangeTrustResultCode
                                      // cannot create with a limit of 0
     CHANGE_TRUST_LOW_RESERVE =
         -4, // not enough funds to create a new trust line,
-    CHANGE_TRUST_SELF_NOT_ALLOWED = -5  // trusting self is not allowed
+    CHANGE_TRUST_SELF_NOT_ALLOWED = -5 // trusting self is not allowed
 };
 
 union ChangeTrustResult switch (ChangeTrustResultCode code)
@@ -885,9 +914,9 @@ enum OperationResultCode
 {
     opINNER = 0, // inner object result is valid
 
-    opBAD_AUTH = -1,     // too few valid signatures / wrong network
-    opNO_ACCOUNT = -2,   // source account was not found
-    opNOT_SUPPORTED = -3, // operation not supported at this time
+    opBAD_AUTH = -1,            // too few valid signatures / wrong network
+    opNO_ACCOUNT = -2,          // source account was not found
+    opNOT_SUPPORTED = -3,       // operation not supported at this time
     opTOO_MANY_SUBENTRIES = -4, // max number of subentries already reached
     opEXCEEDED_WORK_LIMIT = -5  // operation did too much work
 };
@@ -922,7 +951,7 @@ case opINNER:
     case BUMP_SEQUENCE:
         BumpSequenceResult bumpSeqResult;
     case MANAGE_BUY_OFFER:
-	ManageBuyOfferResult manageBuyOfferResult;
+        ManageBuyOfferResult manageBuyOfferResult;
     case PATH_PAYMENT_STRICT_SEND:
         PathPaymentStrictSendResult pathPaymentStrictSendResult;
     }
@@ -934,7 +963,7 @@ default:
 enum TransactionResultCode
 {
     txFEE_BUMP_INNER_SUCCESS = 1, // fee bump inner transaction succeeded
-    txSUCCESS = 0, // all operations succeeded
+    txSUCCESS = 0,                // all operations succeeded
 
     txFAILED = -1, // one of the operations failed (none were applied)
 
@@ -978,7 +1007,7 @@ struct InnerTransactionResult
     case txBAD_AUTH_EXTRA:
     case txINTERNAL_ERROR:
     case txNOT_SUPPORTED:
-    // txFEE_BUMP_INNER_FAILED is not included
+        // txFEE_BUMP_INNER_FAILED is not included
         void;
     }
     result;

--- a/xdr/Stellar-types.x
+++ b/xdr/Stellar-types.x
@@ -17,9 +17,11 @@ typedef hyper int64;
 enum CryptoKeyType
 {
     KEY_TYPE_ED25519 = 0,
-    KEY_TYPE_MUXED_ED25519 = 256,
     KEY_TYPE_PRE_AUTH_TX = 1,
-    KEY_TYPE_HASH_X = 2
+    KEY_TYPE_HASH_X = 2,
+    // MUXED enum values for supported type are derived from the enum values
+    // above by ORing them with 0x100
+    KEY_TYPE_MUXED_ED25519 = 0x100
 };
 
 enum PublicKeyType
@@ -61,22 +63,21 @@ typedef PublicKey NodeID;
 
 struct Curve25519Secret
 {
-        opaque key[32];
+    opaque key[32];
 };
 
 struct Curve25519Public
 {
-        opaque key[32];
+    opaque key[32];
 };
 
 struct HmacSha256Key
 {
-        opaque key[32];
+    opaque key[32];
 };
 
 struct HmacSha256Mac
 {
-        opaque mac[32];
+    opaque mac[32];
 };
-
 }

--- a/xdr/transaction_envelope.go
+++ b/xdr/transaction_envelope.go
@@ -6,7 +6,7 @@ func (e TransactionEnvelope) IsFeeBump() bool {
 }
 
 // FeeBumpAccount returns the account paying for the fee bump transaction
-func (e TransactionEnvelope) FeeBumpAccount() AccountId {
+func (e TransactionEnvelope) FeeBumpAccount() MuxedAccount {
 	return e.MustFeeBump().Tx.FeeSource
 }
 

--- a/xdr/transaction_envelope_test.go
+++ b/xdr/transaction_envelope_test.go
@@ -87,8 +87,8 @@ func createFeeBumpTx() TransactionEnvelope {
 		Type: EnvelopeTypeEnvelopeTypeTxFeeBump,
 		FeeBump: &FeeBumpTransactionEnvelope{
 			Tx: FeeBumpTransaction{
-				FeeSource: AccountId{
-					Type:    PublicKeyTypePublicKeyTypeEd25519,
+				FeeSource: MuxedAccount{
+					Type:    CryptoKeyTypeKeyTypeEd25519,
 					Ed25519: &Uint256{2, 2, 2},
 				},
 				Fee: 776,

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -5150,7 +5150,7 @@ var (
 //   union LedgerCloseMeta switch (int v)
 //    {
 //    case 0:
-//         LedgerCloseMetaV0 v0;
+//        LedgerCloseMetaV0 v0;
 //    };
 //
 type LedgerCloseMeta struct {
@@ -6117,8 +6117,8 @@ var (
 //
 //   union SurveyResponseBody switch (SurveyMessageCommandType type)
 //    {
-//        case SURVEY_TOPOLOGY:
-//            TopologyResponseBody topologyResponseBody;
+//    case SURVEY_TOPOLOGY:
+//        TopologyResponseBody topologyResponseBody;
 //    };
 //
 type SurveyResponseBody struct {
@@ -6783,10 +6783,10 @@ var (
 // AuthenticatedMessageV0 is an XDR NestedStruct defines as:
 //
 //   struct
-//    {
-//       uint64 sequence;
-//       StellarMessage message;
-//       HmacSha256Mac mac;
+//        {
+//            uint64 sequence;
+//            StellarMessage message;
+//            HmacSha256Mac mac;
 //        }
 //
 type AuthenticatedMessageV0 struct {
@@ -6819,10 +6819,10 @@ var (
 //    {
 //    case 0:
 //        struct
-//    {
-//       uint64 sequence;
-//       StellarMessage message;
-//       HmacSha256Mac mac;
+//        {
+//            uint64 sequence;
+//            StellarMessage message;
+//            HmacSha256Mac mac;
 //        } v0;
 //    };
 //
@@ -6907,10 +6907,11 @@ var (
 
 // MuxedAccountMed25519 is an XDR NestedStruct defines as:
 //
-//   struct {
-//             uint64 id;
-//             uint256 ed25519;
-//         }
+//   struct
+//        {
+//            uint64 id;
+//            uint256 ed25519;
+//        }
 //
 type MuxedAccountMed25519 struct {
 	Id      Uint64
@@ -6937,14 +6938,16 @@ var (
 
 // MuxedAccount is an XDR Union defines as:
 //
-//   union MuxedAccount switch (CryptoKeyType type) {
-//     case KEY_TYPE_ED25519:
-//         uint256 ed25519;
-//     case KEY_TYPE_MUXED_ED25519:
-//         struct {
-//             uint64 id;
-//             uint256 ed25519;
-//         } med25519;
+//   union MuxedAccount switch (CryptoKeyType type)
+//    {
+//    case KEY_TYPE_ED25519:
+//        uint256 ed25519;
+//    case KEY_TYPE_MUXED_ED25519:
+//        struct
+//        {
+//            uint64 id;
+//            uint256 ed25519;
+//        } med25519;
 //    };
 //
 type MuxedAccount struct {
@@ -8668,7 +8671,8 @@ const MaxOpsPerTx = 100
 
 // TransactionV0Ext is an XDR NestedUnion defines as:
 //
-//   union switch (int v) {
+//   union switch (int v)
+//        {
 //        case 0:
 //            void;
 //        }
@@ -8731,10 +8735,12 @@ var (
 //        TimeBounds* timeBounds;
 //        Memo memo;
 //        Operation operations<MAX_OPS_PER_TX>;
-//        union switch (int v) {
+//        union switch (int v)
+//        {
 //        case 0:
 //            void;
-//        } ext;
+//        }
+//        ext;
 //    };
 //
 type TransactionV0 struct {
@@ -9033,7 +9039,8 @@ var (
 
 // FeeBumpTransactionExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v) {
+//   union switch (int v)
+//        {
 //        case 0:
 //            void;
 //        }
@@ -9090,21 +9097,24 @@ var (
 //
 //   struct FeeBumpTransaction
 //    {
-//        AccountID feeSource;
+//        MuxedAccount feeSource;
 //        int64 fee;
 //        union switch (EnvelopeType type)
 //        {
 //        case ENVELOPE_TYPE_TX:
 //            TransactionV1Envelope v1;
-//        } innerTx;
-//        union switch (int v) {
+//        }
+//        innerTx;
+//        union switch (int v)
+//        {
 //        case 0:
 //            void;
-//        } ext;
+//        }
+//        ext;
 //    };
 //
 type FeeBumpTransaction struct {
-	FeeSource AccountId
+	FeeSource MuxedAccount
 	Fee       Int64
 	InnerTx   FeeBumpTransactionInnerTx
 	Ext       FeeBumpTransactionExt
@@ -9163,7 +9173,8 @@ var (
 
 // TransactionEnvelope is an XDR Union defines as:
 //
-//   union TransactionEnvelope switch (EnvelopeType type) {
+//   union TransactionEnvelope switch (EnvelopeType type)
+//    {
 //    case ENVELOPE_TYPE_TX_V0:
 //        TransactionV0Envelope v0;
 //    case ENVELOPE_TYPE_TX:
@@ -9801,18 +9812,27 @@ var (
 //        PATH_PAYMENT_STRICT_RECEIVE_SUCCESS = 0, // success
 //
 //        // codes considered as "failure" for the operation
-//        PATH_PAYMENT_STRICT_RECEIVE_MALFORMED = -1,          // bad input
-//        PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED = -2,        // not enough funds in source account
-//        PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST = -3,       // no trust line on source account
-//        PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
-//        PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION = -5,     // destination account does not exist
-//        PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST = -6,           // dest missing a trust line for asset
-//        PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
-//        PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL = -8,          // dest would go above their limit
-//        PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER = -9,          // missing issuer on one asset
-//        PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
-//        PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
-//        PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX = -12       // could not satisfy sendmax
+//        PATH_PAYMENT_STRICT_RECEIVE_MALFORMED = -1, // bad input
+//        PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED =
+//            -2, // not enough funds in source account
+//        PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST =
+//            -3, // no trust line on source account
+//        PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED =
+//            -4, // source not authorized to transfer
+//        PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION =
+//            -5, // destination account does not exist
+//        PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST =
+//            -6, // dest missing a trust line for asset
+//        PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED =
+//            -7, // dest not authorized to hold asset
+//        PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL =
+//            -8, // dest would go above their limit
+//        PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER = -9, // missing issuer on one asset
+//        PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS =
+//            -10, // not enough offers to satisfy path
+//        PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF =
+//            -11, // would cross one of its own offers
+//        PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX = -12 // could not satisfy sendmax
 //    };
 //
 type PathPaymentStrictReceiveResultCode int32
@@ -9884,13 +9904,13 @@ var (
 //
 //   struct SimplePaymentResult
 //    {
-//        MuxedAccount destination;
+//        AccountID destination;
 //        Asset asset;
 //        int64 amount;
 //    };
 //
 type SimplePaymentResult struct {
-	Destination MuxedAccount
+	Destination AccountId
 	Asset       Asset
 	Amount      Int64
 }
@@ -10085,18 +10105,26 @@ var (
 //        PATH_PAYMENT_STRICT_SEND_SUCCESS = 0, // success
 //
 //        // codes considered as "failure" for the operation
-//        PATH_PAYMENT_STRICT_SEND_MALFORMED = -1,          // bad input
-//        PATH_PAYMENT_STRICT_SEND_UNDERFUNDED = -2,        // not enough funds in source account
-//        PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST = -3,       // no trust line on source account
-//        PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
-//        PATH_PAYMENT_STRICT_SEND_NO_DESTINATION = -5,     // destination account does not exist
-//        PATH_PAYMENT_STRICT_SEND_NO_TRUST = -6,           // dest missing a trust line for asset
-//        PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
-//        PATH_PAYMENT_STRICT_SEND_LINE_FULL = -8,          // dest would go above their limit
-//        PATH_PAYMENT_STRICT_SEND_NO_ISSUER = -9,          // missing issuer on one asset
-//        PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
-//        PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
-//        PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN = -12      // could not satisfy destMin
+//        PATH_PAYMENT_STRICT_SEND_MALFORMED = -1, // bad input
+//        PATH_PAYMENT_STRICT_SEND_UNDERFUNDED =
+//            -2, // not enough funds in source account
+//        PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST =
+//            -3, // no trust line on source account
+//        PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED =
+//            -4, // source not authorized to transfer
+//        PATH_PAYMENT_STRICT_SEND_NO_DESTINATION =
+//            -5, // destination account does not exist
+//        PATH_PAYMENT_STRICT_SEND_NO_TRUST =
+//            -6, // dest missing a trust line for asset
+//        PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED =
+//            -7, // dest not authorized to hold asset
+//        PATH_PAYMENT_STRICT_SEND_LINE_FULL = -8, // dest would go above their limit
+//        PATH_PAYMENT_STRICT_SEND_NO_ISSUER = -9, // missing issuer on one asset
+//        PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS =
+//            -10, // not enough offers to satisfy path
+//        PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF =
+//            -11, // would cross one of its own offers
+//        PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN = -12 // could not satisfy destMin
 //    };
 //
 type PathPaymentStrictSendResultCode int32
@@ -10336,21 +10364,25 @@ var (
 //        MANAGE_SELL_OFFER_SUCCESS = 0,
 //
 //        // codes considered as "failure" for the operation
-//        MANAGE_SELL_OFFER_MALFORMED = -1,     // generated offer would be invalid
-//        MANAGE_SELL_OFFER_SELL_NO_TRUST = -2, // no trust line for what we're selling
-//        MANAGE_SELL_OFFER_BUY_NO_TRUST = -3,  // no trust line for what we're buying
+//        MANAGE_SELL_OFFER_MALFORMED = -1, // generated offer would be invalid
+//        MANAGE_SELL_OFFER_SELL_NO_TRUST =
+//            -2,                              // no trust line for what we're selling
+//        MANAGE_SELL_OFFER_BUY_NO_TRUST = -3, // no trust line for what we're buying
 //        MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
 //        MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
-//        MANAGE_SELL_OFFER_LINE_FULL = -6,      // can't receive more of what it's buying
-//        MANAGE_SELL_OFFER_UNDERFUNDED = -7,    // doesn't hold what it's trying to sell
-//        MANAGE_SELL_OFFER_CROSS_SELF = -8,     // would cross an offer from the same user
+//        MANAGE_SELL_OFFER_LINE_FULL = -6, // can't receive more of what it's buying
+//        MANAGE_SELL_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
+//        MANAGE_SELL_OFFER_CROSS_SELF =
+//            -8, // would cross an offer from the same user
 //        MANAGE_SELL_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
 //        MANAGE_SELL_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
 //
 //        // update errors
-//        MANAGE_SELL_OFFER_NOT_FOUND = -11, // offerID does not match an existing offer
+//        MANAGE_SELL_OFFER_NOT_FOUND =
+//            -11, // offerID does not match an existing offer
 //
-//        MANAGE_SELL_OFFER_LOW_RESERVE = -12 // not enough funds to create a new Offer
+//        MANAGE_SELL_OFFER_LOW_RESERVE =
+//            -12 // not enough funds to create a new Offer
 //    };
 //
 type ManageSellOfferResultCode int32
@@ -10720,14 +10752,15 @@ var (
 //        MANAGE_BUY_OFFER_BUY_NO_TRUST = -3,  // no trust line for what we're buying
 //        MANAGE_BUY_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
 //        MANAGE_BUY_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
-//        MANAGE_BUY_OFFER_LINE_FULL = -6,      // can't receive more of what it's buying
-//        MANAGE_BUY_OFFER_UNDERFUNDED = -7,    // doesn't hold what it's trying to sell
-//        MANAGE_BUY_OFFER_CROSS_SELF = -8,     // would cross an offer from the same user
+//        MANAGE_BUY_OFFER_LINE_FULL = -6,   // can't receive more of what it's buying
+//        MANAGE_BUY_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
+//        MANAGE_BUY_OFFER_CROSS_SELF = -8, // would cross an offer from the same user
 //        MANAGE_BUY_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
 //        MANAGE_BUY_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
 //
 //        // update errors
-//        MANAGE_BUY_OFFER_NOT_FOUND = -11, // offerID does not match an existing offer
+//        MANAGE_BUY_OFFER_NOT_FOUND =
+//            -11, // offerID does not match an existing offer
 //
 //        MANAGE_BUY_OFFER_LOW_RESERVE = -12 // not enough funds to create a new Offer
 //    };
@@ -11040,7 +11073,7 @@ var (
 //                                         // cannot create with a limit of 0
 //        CHANGE_TRUST_LOW_RESERVE =
 //            -4, // not enough funds to create a new trust line,
-//        CHANGE_TRUST_SELF_NOT_ALLOWED = -5  // trusting self is not allowed
+//        CHANGE_TRUST_SELF_NOT_ALLOWED = -5 // trusting self is not allowed
 //    };
 //
 type ChangeTrustResultCode int32
@@ -11864,9 +11897,9 @@ var (
 //    {
 //        opINNER = 0, // inner object result is valid
 //
-//        opBAD_AUTH = -1,     // too few valid signatures / wrong network
-//        opNO_ACCOUNT = -2,   // source account was not found
-//        opNOT_SUPPORTED = -3, // operation not supported at this time
+//        opBAD_AUTH = -1,            // too few valid signatures / wrong network
+//        opNO_ACCOUNT = -2,          // source account was not found
+//        opNOT_SUPPORTED = -3,       // operation not supported at this time
 //        opTOO_MANY_SUBENTRIES = -4, // max number of subentries already reached
 //        opEXCEEDED_WORK_LIMIT = -5  // operation did too much work
 //    };
@@ -11951,7 +11984,7 @@ var (
 //        case BUMP_SEQUENCE:
 //            BumpSequenceResult bumpSeqResult;
 //        case MANAGE_BUY_OFFER:
-//    	ManageBuyOfferResult manageBuyOfferResult;
+//            ManageBuyOfferResult manageBuyOfferResult;
 //        case PATH_PAYMENT_STRICT_SEND:
 //            PathPaymentStrictSendResult pathPaymentStrictSendResult;
 //        }
@@ -12522,7 +12555,7 @@ var (
 //        case BUMP_SEQUENCE:
 //            BumpSequenceResult bumpSeqResult;
 //        case MANAGE_BUY_OFFER:
-//    	ManageBuyOfferResult manageBuyOfferResult;
+//            ManageBuyOfferResult manageBuyOfferResult;
 //        case PATH_PAYMENT_STRICT_SEND:
 //            PathPaymentStrictSendResult pathPaymentStrictSendResult;
 //        }
@@ -12618,7 +12651,7 @@ var (
 //   enum TransactionResultCode
 //    {
 //        txFEE_BUMP_INNER_SUCCESS = 1, // fee bump inner transaction succeeded
-//        txSUCCESS = 0, // all operations succeeded
+//        txSUCCESS = 0,                // all operations succeeded
 //
 //        txFAILED = -1, // one of the operations failed (none were applied)
 //
@@ -12726,7 +12759,7 @@ var (
 //        case txBAD_AUTH_EXTRA:
 //        case txINTERNAL_ERROR:
 //        case txNOT_SUPPORTED:
-//        // txFEE_BUMP_INNER_FAILED is not included
+//            // txFEE_BUMP_INNER_FAILED is not included
 //            void;
 //        }
 //
@@ -12942,7 +12975,7 @@ var (
 //        case txBAD_AUTH_EXTRA:
 //        case txINTERNAL_ERROR:
 //        case txNOT_SUPPORTED:
-//        // txFEE_BUMP_INNER_FAILED is not included
+//            // txFEE_BUMP_INNER_FAILED is not included
 //            void;
 //        }
 //        result;
@@ -13427,25 +13460,27 @@ var (
 //   enum CryptoKeyType
 //    {
 //        KEY_TYPE_ED25519 = 0,
-//        KEY_TYPE_MUXED_ED25519 = 256,
 //        KEY_TYPE_PRE_AUTH_TX = 1,
-//        KEY_TYPE_HASH_X = 2
+//        KEY_TYPE_HASH_X = 2,
+//        // MUXED enum values for supported type are derived from the enum values
+//        // above by ORing them with 0x100
+//        KEY_TYPE_MUXED_ED25519 = 0x100
 //    };
 //
 type CryptoKeyType int32
 
 const (
 	CryptoKeyTypeKeyTypeEd25519      CryptoKeyType = 0
-	CryptoKeyTypeKeyTypeMuxedEd25519 CryptoKeyType = 256
 	CryptoKeyTypeKeyTypePreAuthTx    CryptoKeyType = 1
 	CryptoKeyTypeKeyTypeHashX        CryptoKeyType = 2
+	CryptoKeyTypeKeyTypeMuxedEd25519 CryptoKeyType = 256
 )
 
 var cryptoKeyTypeMap = map[int32]string{
 	0:   "CryptoKeyTypeKeyTypeEd25519",
-	256: "CryptoKeyTypeKeyTypeMuxedEd25519",
 	1:   "CryptoKeyTypeKeyTypePreAuthTx",
 	2:   "CryptoKeyTypeKeyTypeHashX",
+	256: "CryptoKeyTypeKeyTypeMuxedEd25519",
 }
 
 // ValidEnum validates a proposed value for this enum.  Implements
@@ -13948,7 +13983,7 @@ var (
 //
 //   struct Curve25519Secret
 //    {
-//            opaque key[32];
+//        opaque key[32];
 //    };
 //
 type Curve25519Secret struct {
@@ -13977,7 +14012,7 @@ var (
 //
 //   struct Curve25519Public
 //    {
-//            opaque key[32];
+//        opaque key[32];
 //    };
 //
 type Curve25519Public struct {
@@ -14006,7 +14041,7 @@ var (
 //
 //   struct HmacSha256Key
 //    {
-//            opaque key[32];
+//        opaque key[32];
 //    };
 //
 type HmacSha256Key struct {
@@ -14035,7 +14070,7 @@ var (
 //
 //   struct HmacSha256Mac
 //    {
-//            opaque mac[32];
+//        opaque mac[32];
 //    };
 //
 type HmacSha256Mac struct {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR updates the XDR definitions to match https://github.com/stellar/stellar-core/commit/b5dad7d2db7e2ad05e80a23a125569f70070b2d9 

The most significant update to the XDR definitions is that the `FeeSource` of a fee bump transaction is now a muxed account instead of an account id. I have updated ingestion to ensure that the fee source muxed account is converted to an account id address before inserting data into the horizon db.
