### PR TITLE
exp/services/recoverysigner: require email_verified true in email authenticated JWT

### DIFF
--- a/exp/services/recoverysigner/internal/serve/auth/firebase.go
+++ b/exp/services/recoverysigner/internal/serve/auth/firebase.go
@@ -28,7 +28,9 @@ func FirebaseMiddleware(v FirebaseTokenVerifier) func(http.Handler) http.Handler
 				ctx := r.Context()
 				auth, _ := FromContext(ctx)
 				auth.PhoneNumber, _ = token.Claims["phone_number"].(string)
-				auth.Email, _ = token.Claims["email"].(string)
+				if emailVerified, _ := token.Claims["email_verified"].(bool); emailVerified {
+					auth.Email, _ = token.Claims["email"].(string)
+				}
 				ctx = NewContext(ctx, auth)
 				r = r.WithContext(ctx)
 			}

--- a/exp/services/recoverysigner/internal/serve/auth/firebase_test.go
+++ b/exp/services/recoverysigner/internal/serve/auth/firebase_test.go
@@ -39,12 +39,14 @@ func TestFirebase_tokenWithPhoneNumber(t *testing.T) {
 }
 
 // Test that if the token verifier says there is a Firebase token that contains
-// an email claim, the claims stored in the context should contain it.
-func TestFirebase_tokenWithEmail(t *testing.T) {
+// an email and email_verified=true claim, the claims stored in the context
+// should contain it.
+func TestFirebase_tokenWithEmailVerifiedTrue(t *testing.T) {
 	tokenVerifier := FirebaseTokenVerifierFunc(func(_ *http.Request) (*firebaseauth.Token, bool) {
 		token := &firebaseauth.Token{
 			Claims: map[string]interface{}{
-				"email": "user@example.com",
+				"email":          "user@example.com",
+				"email_verified": true,
 			},
 		}
 		return token, true
@@ -67,6 +69,63 @@ func TestFirebase_tokenWithEmail(t *testing.T) {
 	assert.Equal(t, true, claimsOK)
 }
 
+// Test that if the token verifier says there is a Firebase token that contains
+// an email claim and email_verified=false, the claims stored in the context
+// should contain it.
+func TestFirebase_tokenWithEmailVerifiedFalse(t *testing.T) {
+	tokenVerifier := FirebaseTokenVerifierFunc(func(_ *http.Request) (*firebaseauth.Token, bool) {
+		token := &firebaseauth.Token{
+			Claims: map[string]interface{}{
+				"email":          "user@example.com",
+				"email_verified": false,
+			},
+		}
+		return token, true
+	})
+
+	claims := Auth{}
+	claimsOK := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		claims, claimsOK = FromContext(r.Context())
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	FirebaseMiddleware(tokenVerifier)(next).ServeHTTP(w, r)
+
+	wantClaims := Auth{}
+	assert.Equal(t, wantClaims, claims)
+	assert.Equal(t, true, claimsOK)
+}
+
+// Test that if the token verifier says there is a Firebase token that contains
+// an email claim without email_verified, the claims stored in the context
+// should not contain the email.
+func TestFirebase_tokenWithEmail(t *testing.T) {
+	tokenVerifier := FirebaseTokenVerifierFunc(func(_ *http.Request) (*firebaseauth.Token, bool) {
+		token := &firebaseauth.Token{
+			Claims: map[string]interface{}{
+				"email": "user@example.com",
+			},
+		}
+		return token, true
+	})
+
+	claims := Auth{}
+	claimsOK := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		claims, claimsOK = FromContext(r.Context())
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	FirebaseMiddleware(tokenVerifier)(next).ServeHTTP(w, r)
+
+	wantClaims := Auth{}
+	assert.Equal(t, wantClaims, claims)
+	assert.Equal(t, true, claimsOK)
+}
+
 // Test that if the token verifier says there is a Firebase token that
 // contains a phone number and an email claim, the claims stored in the
 // context should contain both.
@@ -74,8 +133,9 @@ func TestFirebase_tokenWithPhoneNumberAndEmail(t *testing.T) {
 	tokenVerifier := FirebaseTokenVerifierFunc(func(_ *http.Request) (*firebaseauth.Token, bool) {
 		token := &firebaseauth.Token{
 			Claims: map[string]interface{}{
-				"phone_number": "+10000000000",
-				"email":        "user@example.com",
+				"phone_number":   "+10000000000",
+				"email":          "user@example.com",
+				"email_verified": true,
 			},
 		}
 		return token, true
@@ -106,8 +166,9 @@ func TestFirebase_tokenWithPhoneNumberAndEmailAppendsToOtherClaims(t *testing.T)
 	tokenVerifier := FirebaseTokenVerifierFunc(func(_ *http.Request) (*firebaseauth.Token, bool) {
 		token := &firebaseauth.Token{
 			Claims: map[string]interface{}{
-				"phone_number": "+10000000000",
-				"email":        "user@example.com",
+				"phone_number":   "+10000000000",
+				"email":          "user@example.com",
+				"email_verified": true,
 			},
 		}
 		return token, true

--- a/exp/services/recoverysigner/internal/serve/auth/firebase_test.go
+++ b/exp/services/recoverysigner/internal/serve/auth/firebase_test.go
@@ -71,7 +71,7 @@ func TestFirebase_tokenWithEmailVerifiedTrue(t *testing.T) {
 
 // Test that if the token verifier says there is a Firebase token that contains
 // an email claim and email_verified=false, the claims stored in the context
-// should contain it.
+// shouldn't contain it.
 func TestFirebase_tokenWithEmailVerifiedFalse(t *testing.T) {
 	tokenVerifier := FirebaseTokenVerifierFunc(func(_ *http.Request) (*firebaseauth.Token, bool) {
 		token := &firebaseauth.Token{

--- a/exp/services/recoverysigner/internal/serve/auth/firebase_test.go
+++ b/exp/services/recoverysigner/internal/serve/auth/firebase_test.go
@@ -71,7 +71,7 @@ func TestFirebase_tokenWithEmailVerifiedTrue(t *testing.T) {
 
 // Test that if the token verifier says there is a Firebase token that contains
 // an email claim and email_verified=false, the claims stored in the context
-// shouldn't contain it.
+// should not contain the email.
 func TestFirebase_tokenWithEmailVerifiedFalse(t *testing.T) {
 	tokenVerifier := FirebaseTokenVerifierFunc(func(_ *http.Request) (*firebaseauth.Token, bool) {
 		token := &firebaseauth.Token{


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Require the `email_verified` field to be present in the JWT used for validating the email address of the authenticated client. Treat the a non-verified email as if the token does not satisfy the claim of owning the email.

### Why
If an email address is not verified then there is no guarantee that the email is owned by the user. Firebase with email authentication enabled allows the creation of user accounts and JWTs that have an email address in the JWT that hasn't been verified. The `email_verified` field is listed in the [IANA's list of JWT Claims] and is used by Firebase and has the `true` value when the email has been verified by the Firebase user.

[IANA's list of JWT Claims]: https://www.iana.org/assignments/jwt/jwt.xhtml