### PR TITLE
protocols/horizon/effects: Fix unmarshalling of TrustlineAuthorizedToMaintainLiabilities

### DIFF
--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -409,8 +409,14 @@ func UnmarshalEffect(effectType string, dataString []byte) (effects Effect, err 
 			return
 		}
 		effects = effect
-	case EffectTypeNames[EffectTrustlineAuthorized], EffectTypeNames[EffectTrustlineAuthorizedToMaintainLiabilities]:
+	case EffectTypeNames[EffectTrustlineAuthorized]:
 		var effect TrustlineAuthorized
+		if err = json.Unmarshal(dataString, &effect); err != nil {
+			return
+		}
+		effects = effect
+	case EffectTypeNames[EffectTrustlineAuthorizedToMaintainLiabilities]:
+		var effect TrustlineAuthorizedToMaintainLiabilities
 		if err = json.Unmarshal(dataString, &effect); err != nil {
 			return
 		}

--- a/services/horizon/internal/resourceadapter/balance.go
+++ b/services/horizon/internal/resourceadapter/balance.go
@@ -70,5 +70,6 @@ func PopulateNativeBalance(dest *protocol.Balance, stroops, buyingLiabilities, s
 	dest.Issuer = ""
 	dest.Code = ""
 	dest.IsAuthorized = nil
+	dest.IsAuthorizedToMaintainLiabilities = nil
 	return
 }

--- a/services/horizon/internal/resourceadapter/balance_test.go
+++ b/services/horizon/internal/resourceadapter/balance_test.go
@@ -152,4 +152,5 @@ func TestPopulateNativeBalance(t *testing.T) {
 	assert.Equal(t, "", want.Issuer)
 	assert.Equal(t, "", want.Code)
 	assert.Nil(t, want.IsAuthorized)
+	assert.Nil(t, want.IsAuthorizedToMaintainLiabilities)
 }

--- a/services/horizon/internal/resourceadapter/effects_test.go
+++ b/services/horizon/internal/resourceadapter/effects_test.go
@@ -1,11 +1,13 @@
 package resourceadapter
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/guregu/null"
 	"github.com/stellar/go/protocols/horizon/effects"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/render/hal"
 	"github.com/stellar/go/support/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -31,7 +33,18 @@ func TestNewEffect_EffectTrustlineAuthorizedToMaintainLiabilities(t *testing.T) 
 	resource, err := NewEffect(ctx, hEffect, history.Ledger{})
 	tt.NoError(err)
 
+	var resourcePage hal.Page
+	resourcePage.Add(resource)
+
 	effect, ok := resource.(effects.TrustlineAuthorizedToMaintainLiabilities)
 	tt.True(ok)
 	tt.Equal("trustline_authorized_to_maintain_liabilities", effect.Type)
+
+	binary, err := json.Marshal(resourcePage)
+	tt.NoError(err)
+
+	var page effects.EffectsPage
+	tt.NoError(json.Unmarshal(binary, &page))
+	tt.Len(page.Embedded.Records, 1)
+	tt.Equal(effect, page.Embedded.Records[0].(effects.TrustlineAuthorizedToMaintainLiabilities))
 }


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

`EffectTrustlineAuthorizedToMaintainLiabilities` was configured to unmarshal into a `TrustlineAuthorized` instance.

We should be unmarshalling into a `TrustlineAuthorizedToMaintainLiabilities` instance.
