### PR TITLE
services/horizon/docker: Fix documentation for running stand alone network

### DIFF
--- a/services/horizon/docker/README.md
+++ b/services/horizon/docker/README.md
@@ -82,8 +82,11 @@ Stellar public network, run `docker-compose -f docker-compose.yml -f docker-comp
 
 To run the containers on a private stand alone network, run `docker-compose -f docker-compose.yml -f docker-compose.standalone.yml up -d --build`.
 When you run Stellar Core on a private stand alone network, an account will be created which will hold 100 billion Lumens.
-The seed for the account can be found in [stellar-core-standalone.cfg](./stellar-core-standalone.cfg) (see `NODE_SEED` parameter). 
-The seed is also emitted in the Stellar Core logs.
+The seed for the account will be emitted in the Stellar Core logs:
+
+```
+2020-04-22T18:39:19.248 GD5KD [Ledger INFO] Root account seed: SC5O7VZUXDJ6JBDSZ74DSERXL7W3Y5LTOAMRF7RQRL3TAGAPS7LUVG3L
+```
 
 When you switch between different networks you will need to clear the Stellar Core and Stellar Horizon databases. You can wipe out the databases by running `docker-compose down -v`.
 


### PR DESCRIPTION
The documentation stated that the root account seed was configured with the `NODE_SEED` variable in the stellar core config. That is incorrect. The `NODE_SEED` variable configures the seed for the validator account. The root account which holds the lumen supply is derived from the network passphrase and is printed in the stellar core logs.
