### PR TITLE
protocols/horizon: Display memo_bytes even when memo text is an empty string

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -488,7 +488,8 @@ type InnerTransaction struct {
 func (t Transaction) MarshalJSON() ([]byte, error) {
 	type Alias Transaction
 	v := &struct {
-		Memo *string `json:"memo,omitempty"`
+		Memo      *string `json:"memo,omitempty"`
+		MemoBytes *string `json:"memo_bytes,omitempty"`
 		*Alias
 	}{
 		Alias: (*Alias)(&t),
@@ -496,6 +497,11 @@ func (t Transaction) MarshalJSON() ([]byte, error) {
 	if t.MemoType != "none" {
 		v.Memo = &t.Memo
 	}
+
+	if t.MemoType == "text" {
+		v.MemoBytes = &t.MemoBytes
+	}
+
 	return json.Marshal(v)
 }
 

--- a/protocols/horizon/main_test.go
+++ b/protocols/horizon/main_test.go
@@ -67,16 +67,19 @@ func TestTransactionJSONMarshal(t *testing.T) {
 
 func TestTransactionEmptyMemoText(t *testing.T) {
 	transaction := Transaction{
-		MemoType: "text",
-		Memo:     "",
+		MemoType:  "text",
+		Memo:      "",
+		MemoBytes: "",
 	}
 	marshaledTransaction, marshalErr := json.Marshal(transaction)
 	assert.Nil(t, marshalErr)
 	var result struct {
-		Memo *string
+		Memo      *string
+		MemoBytes *string `json:"memo_bytes"`
 	}
 	json.Unmarshal(marshaledTransaction, &result)
 	assert.NotNil(t, result.Memo, "memo field is present even if input memo was empty string")
+	assert.NotNil(t, result.MemoBytes, "memo_bytes field is present even if input memo was empty string")
 }
 
 func TestTransactionMemoTypeNone(t *testing.T) {

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -10,7 +10,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 However, XDR strings are actually binary blobs with no enforced encoding. 
 It is possible to set the memo in a transaction envelope to a binary sequence which is not valid ASCII or unicode. 
 Previously, if you wanted to recover the original binary sequence for a transaction memo, you would have to decode the transaction's envelope.
-In this release, we have added a `memo_bytes` field to the Horizon transaction response.
+In this release, we have added a `memo_bytes` field to the Horizon transaction response for transactions with `memo_type` equal `text`.
 `memo_bytes` stores the base 64 encoding of the memo bytes set in the transaction envelope.
 
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

This PR fixes a problem similar to https://github.com/stellar/go/issues/149: `memo_bytes` was not present in transaction response for empty string memo.