### PR TITLE
Update horizon-cmp for 1.2 release

### DIFF
--- a/tools/horizon-cmp/internal/response.go
+++ b/tools/horizon-cmp/internal/response.go
@@ -36,7 +36,6 @@ var removeRegexps = []*regexp.Regexp{
 	// regexp.MustCompile(`,\s*"paging_token": ?""`),
 	// Removes memo_bytes field, introduced in horizon 1.2.0
 	regexp.MustCompile(`\s*"memo_bytes": ?"[^"]*",`),
-	regexp.MustCompile(`\s*"fee_paid": ?[0-9]+,`),
 }
 
 type replace struct {

--- a/tools/horizon-cmp/internal/response.go
+++ b/tools/horizon-cmp/internal/response.go
@@ -34,6 +34,8 @@ var removeRegexps = []*regexp.Regexp{
 	// regexp.MustCompile(`\s*"last_modified_ledger": [0-9]+,`),
 	// regexp.MustCompile(`\s*"public_key": "G.*",`),
 	// regexp.MustCompile(`,\s*"paging_token": ?""`),
+	// Removes memo_bytes field, introduced in horizon 1.2.0
+	regexp.MustCompile(`\s*"memo_bytes": ?"[^"]*",`),
 	regexp.MustCompile(`\s*"fee_paid": ?[0-9]+,`),
 }
 


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove new field "memo_bytes"

### Why

It was introduced in horizon 1.2, causing false positives in horizon-cmp when comparing the out of requests with that of horizon 1.1

### Known limitations

N/A
