### PR TITLE
services/horizon: Sort trustlines by asset code and issuer

### DIFF
--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -401,7 +401,7 @@ func (handler GetAccountsHandler) loadData(historyQ *history.Q, accounts []strin
 func (handler GetAccountsHandler) loadTrustlines(historyQ *history.Q, accounts []string) (map[string][]history.TrustLine, error) {
 	trustLines := make(map[string][]history.TrustLine)
 
-	records, err := historyQ.GetTrustLinesByAccountsID(accounts)
+	records, err := historyQ.GetSortedTrustLinesByAccountIDs(accounts)
 	if err != nil {
 		return trustLines, errors.Wrap(err, "loading trustline records by accounts")
 	}

--- a/services/horizon/internal/db2/history/trust_lines.go
+++ b/services/horizon/internal/db2/history/trust_lines.go
@@ -205,10 +205,10 @@ func (q *Q) RemoveTrustLine(ledgerKey xdr.LedgerKeyTrustLine) (int64, error) {
 	return result.RowsAffected()
 }
 
-// GetTrustLinesByAccountsID loads trust lines for a list of accounts ID
-func (q *Q) GetTrustLinesByAccountsID(id []string) ([]TrustLine, error) {
+// GetSortedTrustLinesByAccountIDs loads trust lines for a list of accounts ID, ordered by asset and issuer
+func (q *Q) GetSortedTrustLinesByAccountIDs(id []string) ([]TrustLine, error) {
 	var data []TrustLine
-	sql := selectTrustLines.Where(sq.Eq{"account_id": id})
+	sql := selectTrustLines.Where(sq.Eq{"account_id": id}).OrderBy("asset_code", "asset_issuer")
 	err := q.Select(&data, sql)
 	return data, err
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

When obtaining trustlines from the DB, for rendering into the `GET /accounts` endpoint, order them by asset code (and issuer) so that the output is stable (postgres doesn't guarantee a consistent ordering).

### Why

`horizon-cmp` outputs a large amount of false positives because of this, plus it's always a good idea to generate a stable output, independent of the Horizon server used.

### Known limitations

The DB query becomes slower. I pondered ordering it on the Horizon-side, but I figured a DB engine would be more efficient at this.
