### PR TITLE
horizonclient: Merge remaining horizon 1.2.0 commits

### DIFF
--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -409,8 +409,14 @@ func UnmarshalEffect(effectType string, dataString []byte) (effects Effect, err 
 			return
 		}
 		effects = effect
-	case EffectTypeNames[EffectTrustlineAuthorized], EffectTypeNames[EffectTrustlineAuthorizedToMaintainLiabilities]:
+	case EffectTypeNames[EffectTrustlineAuthorized]:
 		var effect TrustlineAuthorized
+		if err = json.Unmarshal(dataString, &effect); err != nil {
+			return
+		}
+		effects = effect
+	case EffectTypeNames[EffectTrustlineAuthorizedToMaintainLiabilities]:
+		var effect TrustlineAuthorizedToMaintainLiabilities
 		if err = json.Unmarshal(dataString, &effect); err != nil {
 			return
 		}

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -487,7 +487,8 @@ type InnerTransaction struct {
 func (t Transaction) MarshalJSON() ([]byte, error) {
 	type Alias Transaction
 	v := &struct {
-		Memo *string `json:"memo,omitempty"`
+		Memo      *string `json:"memo,omitempty"`
+		MemoBytes *string `json:"memo_bytes,omitempty"`
 		*Alias
 	}{
 		Alias: (*Alias)(&t),
@@ -495,6 +496,11 @@ func (t Transaction) MarshalJSON() ([]byte, error) {
 	if t.MemoType != "none" {
 		v.Memo = &t.Memo
 	}
+
+	if t.MemoType == "text" {
+		v.MemoBytes = &t.MemoBytes
+	}
+
 	return json.Marshal(v)
 }
 

--- a/protocols/horizon/main_test.go
+++ b/protocols/horizon/main_test.go
@@ -66,16 +66,19 @@ func TestTransactionJSONMarshal(t *testing.T) {
 
 func TestTransactionEmptyMemoText(t *testing.T) {
 	transaction := Transaction{
-		MemoType: "text",
-		Memo:     "",
+		MemoType:  "text",
+		Memo:      "",
+		MemoBytes: "",
 	}
 	marshaledTransaction, marshalErr := json.Marshal(transaction)
 	assert.Nil(t, marshalErr)
 	var result struct {
-		Memo *string
+		Memo      *string
+		MemoBytes *string `json:"memo_bytes"`
 	}
 	json.Unmarshal(marshaledTransaction, &result)
 	assert.NotNil(t, result.Memo, "memo field is present even if input memo was empty string")
+	assert.NotNil(t, result.MemoBytes, "memo_bytes field is present even if input memo was empty string")
 }
 
 func TestTransactionMemoTypeNone(t *testing.T) {

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -5,14 +5,23 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v1.2.0
 
+### Scheduled Breaking Changes
+
+* The type for the following attributes will be changed from `int64` to `string` in 1.3.0:
+  - Attribute `fee_charged` in [Transaction](https://www.stellar.org/developers/horizon/reference/resources/transaction.html) resource.
+  - Attribute `max_fee` in [Transaction](https://www.stellar.org/developers/horizon/reference/resources/transaction.html) resource.
+
+The changes are required by [CAP-15](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0015.md).
+
 ### Changes
+
+* Added support for [CAP-27](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0027.md) and [SEP-23](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0023.md) [#2491](https://github.com/stellar/go/pull/2491).
 * The XDR definition of a transaction memo is a string.
 However, XDR strings are actually binary blobs with no enforced encoding. 
 It is possible to set the memo in a transaction envelope to a binary sequence which is not valid ASCII or unicode. 
 Previously, if you wanted to recover the original binary sequence for a transaction memo, you would have to decode the transaction's envelope.
-In this release, we have added a `memo_bytes` field to the Horizon transaction response.
-`memo_bytes` stores the base 64 encoding of the memo bytes set in the transaction envelope.
-
+In this release, we have added a `memo_bytes` field to the Horizon transaction response for transactions with `memo_type` equal `text`.
+`memo_bytes` stores the base 64 encoding of the memo bytes set in the transaction envelope [#2485](https://github.com/stellar/go/pull/2485).
 
 ## v1.1.0
 
@@ -20,7 +29,7 @@ In this release, we have added a `memo_bytes` field to the Horizon transaction r
 
 This version includes a significant database migration which changes the column types of `fee_charged` and `max_fee` in the `history_transactions` table from `integer` to `bigint`. This essential change paves the way for fee bump transactions ([CAP 15](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0015.md)), a major improvement that will be released soon in Stellar Protocol 13.
 
-This migration will run for a long time, especially if you have a Horizon database with full history. For reference, it took 20 hours to complete this migration on a AWS db.r4.xlarge instance with full transaction history.
+This migration will run for a long time, especially if you have a Horizon database with full history. For reference, it took around 8 hours and 42 minutes to complete this migration on a AWS db.r4.8xlarge instance with full transaction history.
 
 To execute the migration run `horizon db migrate up` using the Horizon v1.1.0 binary.
 

--- a/services/horizon/internal/resourceadapter/balance.go
+++ b/services/horizon/internal/resourceadapter/balance.go
@@ -70,5 +70,6 @@ func PopulateNativeBalance(dest *protocol.Balance, stroops, buyingLiabilities, s
 	dest.Issuer = ""
 	dest.Code = ""
 	dest.IsAuthorized = nil
+	dest.IsAuthorizedToMaintainLiabilities = nil
 	return
 }

--- a/services/horizon/internal/resourceadapter/balance_test.go
+++ b/services/horizon/internal/resourceadapter/balance_test.go
@@ -152,4 +152,5 @@ func TestPopulateNativeBalance(t *testing.T) {
 	assert.Equal(t, "", want.Issuer)
 	assert.Equal(t, "", want.Code)
 	assert.Nil(t, want.IsAuthorized)
+	assert.Nil(t, want.IsAuthorizedToMaintainLiabilities)
 }

--- a/services/horizon/internal/resourceadapter/effects_test.go
+++ b/services/horizon/internal/resourceadapter/effects_test.go
@@ -1,11 +1,13 @@
 package resourceadapter
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/guregu/null"
 	"github.com/stellar/go/protocols/horizon/effects"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/render/hal"
 	"github.com/stellar/go/support/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -31,7 +33,18 @@ func TestNewEffect_EffectTrustlineAuthorizedToMaintainLiabilities(t *testing.T) 
 	resource, err := NewEffect(ctx, hEffect, history.Ledger{})
 	tt.NoError(err)
 
+	var resourcePage hal.Page
+	resourcePage.Add(resource)
+
 	effect, ok := resource.(effects.TrustlineAuthorizedToMaintainLiabilities)
 	tt.True(ok)
 	tt.Equal("trustline_authorized_to_maintain_liabilities", effect.Type)
+
+	binary, err := json.Marshal(resourcePage)
+	tt.NoError(err)
+
+	var page effects.EffectsPage
+	tt.NoError(json.Unmarshal(binary, &page))
+	tt.Len(page.Embedded.Records, 1)
+	tt.Equal(effect, page.Embedded.Records[0].(effects.TrustlineAuthorizedToMaintainLiabilities))
 }

--- a/tools/horizon-cmp/internal/response.go
+++ b/tools/horizon-cmp/internal/response.go
@@ -34,11 +34,8 @@ var removeRegexps = []*regexp.Regexp{
 	// regexp.MustCompile(`\s*"last_modified_ledger": [0-9]+,`),
 	// regexp.MustCompile(`\s*"public_key": "G.*",`),
 	// regexp.MustCompile(`,\s*"paging_token": ?""`),
-	regexp.MustCompile(`\s*"fee_paid": ?[0-9]+,`),
-	// Removes fields added in Horizon 1.1.0.
-	regexp.MustCompile(`\s*"is_authorized_to_maintain_liabilities": ?(true|false),`),
-	regexp.MustCompile(`\s*"authorize_to_maintain_liabilities": ?(true|false),`),
-	regexp.MustCompile(`\s*"fee_account": ?"G\w{55}",`),
+	// Removes memo_bytes field, introduced in horizon 1.2.0
+	regexp.MustCompile(`\s*"memo_bytes": ?"[^"]*",`),
 }
 
 type replace struct {


### PR DESCRIPTION
Earlier I merged the horizon 1.2.0 release branch into the v3 horizonclient release branch: https://github.com/stellar/go/pull/2493.

Since then there have been a few commits that were added to the horizon 1.2.0 release. This PR adds all remaining commits from horizon 1.2.0 into the horizonclient release branch.