### PR TITLE
horizonclient: Update SEP29 implementation to skip checks on memo id destinations

### DIFF
--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -914,6 +914,31 @@ func TestSubmitTransactionXDRRequest(t *testing.T) {
 	}
 }
 
+func TestCheckMemoRequiredSkipsMemoIDAddress(t *testing.T) {
+	client := &Client{HorizonURL: "https://localhost/"}
+
+	kp := keypair.MustParseFull("SA26PHIKZM6CXDGR472SSGUQQRYXM6S437ZNHZGRM6QA4FOPLLLFRGDX")
+	sourceAccount := txnbuild.NewSimpleAccount(kp.Address(), int64(0))
+
+	payment := txnbuild.Payment{
+		Destination: "MCAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITKNOG",
+		Amount:      "10",
+		Asset:       txnbuild.NativeAsset{},
+	}
+
+	tx, err := txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount:        &sourceAccount,
+			IncrementSequenceNum: true,
+			Operations:           []txnbuild.Operation{&payment},
+			BaseFee:              txnbuild.MinBaseFee,
+			Timebounds:           txnbuild.NewTimebounds(0, 10),
+		},
+	)
+	assert.NoError(t, err)
+	assert.NoError(t, client.checkMemoRequired(tx))
+}
+
 func TestSubmitTransactionRequest(t *testing.T) {
 	hmock := httptest.NewClient()
 	client := &Client{

--- a/txnbuild/account_merge.go
+++ b/txnbuild/account_merge.go
@@ -48,7 +48,7 @@ func (am *AccountMerge) FromXDR(xdrOp xdr.Operation) error {
 // Validate for AccountMerge validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
 func (am *AccountMerge) Validate() error {
-	err := validateStellarPublicKey(am.Destination)
+	_, err := xdr.AddressToMuxedAccount(am.Destination)
 	if err != nil {
 		return NewValidationError("Destination", err.Error())
 	}

--- a/txnbuild/account_merge_test.go
+++ b/txnbuild/account_merge_test.go
@@ -23,7 +23,26 @@ func TestAccountMergeValidate(t *testing.T) {
 		},
 	)
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.AccountMerge operation: Field: Destination, Error: GBAV is not a valid stellar public key"
+		expected := "validation failed for *txnbuild.AccountMerge operation: Field: Destination, Error: invalid address"
 		assert.Contains(t, err.Error(), expected)
 	}
+}
+
+func TestAccountMergeValidateAcceptsMuxedAccountDestination(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(40385577484298))
+
+	accountMerge := AccountMerge{
+		Destination: "MCAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITKNOG",
+	}
+
+	_, err := NewTransaction(
+		TransactionParams{
+			SourceAccount: &sourceAccount,
+			Operations:    []Operation{&accountMerge},
+			Timebounds:    NewInfiniteTimeout(),
+			BaseFee:       MinBaseFee,
+		},
+	)
+	assert.NoError(t, err)
 }

--- a/txnbuild/helpers.go
+++ b/txnbuild/helpers.go
@@ -2,7 +2,6 @@ package txnbuild
 
 import (
 	"fmt"
-
 	"github.com/stellar/go/amount"
 	"github.com/stellar/go/strkey"
 	"github.com/stellar/go/support/errors"

--- a/txnbuild/path_payment.go
+++ b/txnbuild/path_payment.go
@@ -131,7 +131,7 @@ func (pp *PathPaymentStrictReceive) FromXDR(xdrOp xdr.Operation) error {
 // Validate for PathPaymentStrictReceive validates the required struct fields. It returns an error if any
 // of the fields are invalid. Otherwise, it returns nil.
 func (pp *PathPaymentStrictReceive) Validate() error {
-	err := validateStellarPublicKey(pp.Destination)
+	_, err := xdr.AddressToMuxedAccount(pp.Destination)
 	if err != nil {
 		return NewValidationError("Destination", err.Error())
 	}

--- a/txnbuild/path_payment_strict_send.go
+++ b/txnbuild/path_payment_strict_send.go
@@ -125,7 +125,7 @@ func (pp *PathPaymentStrictSend) FromXDR(xdrOp xdr.Operation) error {
 // Validate for PathPaymentStrictSend validates the required struct fields. It returns an error if any
 // of the fields are invalid. Otherwise, it returns nil.
 func (pp *PathPaymentStrictSend) Validate() error {
-	err := validateStellarPublicKey(pp.Destination)
+	_, err := xdr.AddressToMuxedAccount(pp.Destination)
 	if err != nil {
 		return NewValidationError("Destination", err.Error())
 	}

--- a/txnbuild/path_payment_strict_send_test.go
+++ b/txnbuild/path_payment_strict_send_test.go
@@ -91,9 +91,36 @@ func TestPathPaymentStrictSendValidateDestination(t *testing.T) {
 		},
 	)
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.PathPaymentStrictSend operation: Field: Destination, Error: SASND3NRUY5K43PN3H3HOP5JNTIDXJFLOKKNSCZQQAFBRSEIRD5OJKXZ is not a valid stellar public key"
+		expected := "validation failed for *txnbuild.PathPaymentStrictSend operation: Field: Destination"
 		assert.Contains(t, err.Error(), expected)
 	}
+}
+
+func TestPathPaymentStrictSendValidateDestinationAcceptsMuxedACcount(t *testing.T) {
+	kp0 := newKeypair0()
+	kp2 := newKeypair2()
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(187316408680450))
+
+	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
+	pathPayment := PathPaymentStrictSend{
+		SendAsset:   NativeAsset{},
+		SendAmount:  "10",
+		Destination: "MCAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITKNOG",
+		DestAsset:   CreditAsset{"ABCD", kp0.Address()},
+		DestMin:     "1",
+		Path:        []Asset{abcdAsset},
+	}
+
+	_, err := NewTransaction(
+		TransactionParams{
+			SourceAccount:        &sourceAccount,
+			IncrementSequenceNum: false,
+			Operations:           []Operation{&pathPayment},
+			BaseFee:              MinBaseFee,
+			Timebounds:           NewInfiniteTimeout(),
+		},
+	)
+	assert.NoError(t, err)
 }
 
 func TestPathPaymentStrictSendValidateSendMax(t *testing.T) {

--- a/txnbuild/path_payment_test.go
+++ b/txnbuild/path_payment_test.go
@@ -92,9 +92,36 @@ func TestPathPaymentValidateDestination(t *testing.T) {
 		},
 	)
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.PathPaymentStrictReceive operation: Field: Destination, Error: SASND3NRUY5K43PN3H3HOP5JNTIDXJFLOKKNSCZQQAFBRSEIRD5OJKXZ is not a valid stellar public key"
+		expected := "validation failed for *txnbuild.PathPaymentStrictReceive operation: Field: Destination"
 		assert.Contains(t, err.Error(), expected)
 	}
+}
+
+func TestPathPaymentValidateDestinationAcceptsMuxedAccount(t *testing.T) {
+	kp0 := newKeypair0()
+	kp2 := newKeypair2()
+	sourceAccount := NewSimpleAccount(kp2.Address(), int64(187316408680450))
+
+	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
+	pathPayment := PathPayment{
+		SendAsset:   NativeAsset{},
+		SendMax:     "10",
+		Destination: "MCAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITKNOG",
+		DestAsset:   CreditAsset{"ABCD", kp0.Address()},
+		DestAmount:  "1",
+		Path:        []Asset{abcdAsset},
+	}
+
+	_, err := NewTransaction(
+		TransactionParams{
+			SourceAccount:        &sourceAccount,
+			IncrementSequenceNum: false,
+			Operations:           []Operation{&pathPayment},
+			BaseFee:              MinBaseFee,
+			Timebounds:           NewInfiniteTimeout(),
+		},
+	)
+	assert.NoError(t, err)
 }
 
 func TestPathPaymentValidateSendMax(t *testing.T) {

--- a/txnbuild/payment.go
+++ b/txnbuild/payment.go
@@ -75,7 +75,7 @@ func (p *Payment) FromXDR(xdrOp xdr.Operation) error {
 // Validate for Payment validates the required struct fields. It returns an error if any
 // of the fields are invalid. Otherwise, it returns nil.
 func (p *Payment) Validate() error {
-	err := validateStellarPublicKey(p.Destination)
+	_, err := xdr.AddressToMuxedAccount(p.Destination)
 	if err != nil {
 		return NewValidationError("Destination", err.Error())
 	}

--- a/txnbuild/payment_test.go
+++ b/txnbuild/payment_test.go
@@ -26,9 +26,31 @@ func TestPaymentValidateDestination(t *testing.T) {
 		},
 	)
 	if assert.Error(t, err) {
-		expected := "validation failed for *txnbuild.Payment operation: Field: Destination, Error: public key is undefined"
+		expected := "validation failed for *txnbuild.Payment operation: Field: Destination"
 		assert.Contains(t, err.Error(), expected)
 	}
+}
+
+func TestPaymentValidateDestinationAcceptsMuxedAddress(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
+
+	payment := Payment{
+		Destination: "MCAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITKNOG",
+		Amount:      "10",
+		Asset:       NativeAsset{},
+	}
+
+	_, err := NewTransaction(
+		TransactionParams{
+			SourceAccount:        &sourceAccount,
+			IncrementSequenceNum: false,
+			Operations:           []Operation{&payment},
+			BaseFee:              MinBaseFee,
+			Timebounds:           NewInfiniteTimeout(),
+		},
+	)
+	assert.NoError(t, err)
 }
 
 func TestPaymentValidateAmount(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Update SEP29 implementation to skip checks on muxed account addresses which contain a memo id.

### Why

We should skip the check if the destination is an M address since M addresses essentially encode a memo within them.

### Known limitations

[N/A]
