### PR TITLE
txnbuild: Rename Simple() function to Transaction()

### DIFF
--- a/clients/horizonclient/examples_test.go
+++ b/clients/horizonclient/examples_test.go
@@ -1096,7 +1096,7 @@ func ExampleClient_StreamTransactions() {
 //	if err != nil {
 //		return nil, err
 //	}
-//	tx, _ = parsed.Simple()
+//	tx, _ = parsed.Transaction()
 //	return tx, nil
 //}
 //

--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -991,7 +991,7 @@ func convertToV1Tx(t *testing.T, tx *txnbuild.Transaction) *txnbuild.Transaction
 	innerTxEnvelopeB64, err := xdr.MarshalBase64(innerTxEnvelope)
 	require.NoError(t, err)
 	parsed, err := txnbuild.TransactionFromXDR(innerTxEnvelopeB64)
-	tx, _ = parsed.Simple()
+	tx, _ = parsed.Transaction()
 	return tx
 }
 

--- a/exp/services/recoverysigner/internal/serve/account_sign.go
+++ b/exp/services/recoverysigner/internal/serve/account_sign.go
@@ -107,7 +107,7 @@ func (h accountSignHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		badRequest.Render(w)
 		return
 	}
-	tx, ok := parsed.Simple()
+	tx, ok := parsed.Transaction()
 	if !ok {
 		badRequest.Render(w)
 		return

--- a/exp/services/recoverysigner/internal/serve/account_sign_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_sign_test.go
@@ -984,7 +984,7 @@ func TestAccountSign_rejectsFeeBumpTx(t *testing.T) {
 	innerTxEnvelopeB64, err := xdr.MarshalBase64(innerTxEnvelope)
 	require.NoError(t, err)
 	parsed, err := txnbuild.TransactionFromXDR(innerTxEnvelopeB64)
-	tx, _ = parsed.Simple()
+	tx, _ = parsed.Transaction()
 
 	feeBumpTx, err := txnbuild.NewFeeBumpTransaction(
 		txnbuild.FeeBumpTransactionParams{

--- a/txnbuild/fee_bump_test.go
+++ b/txnbuild/fee_bump_test.go
@@ -194,7 +194,7 @@ func TestFeeBumpRoundTrip(t *testing.T) {
 	assert.NoError(t, err)
 	parsedFeeBump, ok := parsed.FeeBump()
 	assert.True(t, ok)
-	_, ok = parsed.Simple()
+	_, ok = parsed.Transaction()
 	assert.False(t, ok)
 
 	assert.Equal(t, feeBumpTx.Signatures(), parsedFeeBump.Signatures())

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -394,10 +394,10 @@ type GenericTransaction struct {
 	feeBump *FeeBumpTransaction
 }
 
-// Simple unpacks the GenericTransaction instance into a Transaction.
+// Transaction unpacks the GenericTransaction instance into a Transaction.
 // The function also returns a boolean which is true if the GenericTransaction can be
 // unpacked into a Transaction.
-func (t GenericTransaction) Simple() (*Transaction, bool) {
+func (t GenericTransaction) Transaction() (*Transaction, bool) {
 	return t.simple, t.simple != nil
 }
 
@@ -783,7 +783,7 @@ func ReadChallengeTx(challengeTx, serverAccountID, network string) (tx *Transact
 	}
 
 	var isSimple bool
-	tx, isSimple = parsed.Simple()
+	tx, isSimple = parsed.Transaction()
 	if !isSimple {
 		return tx, clientAccountID, errors.New("challenge cannot be a fee bump transaction")
 	}

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1263,7 +1263,7 @@ func TestFromXDR(t *testing.T) {
 
 	tx, err := TransactionFromXDR(txeB64)
 	assert.NoError(t, err)
-	newTx, ok := tx.Simple()
+	newTx, ok := tx.Transaction()
 	assert.True(t, ok)
 	_, ok = tx.FeeBump()
 	assert.False(t, ok)
@@ -1284,7 +1284,7 @@ func TestFromXDR(t *testing.T) {
 
 	tx2, err := TransactionFromXDR(txeB64)
 	assert.NoError(t, err)
-	newTx2, ok := tx2.Simple()
+	newTx2, ok := tx2.Transaction()
 	assert.True(t, ok)
 	_, ok = tx2.FeeBump()
 	assert.False(t, ok)
@@ -1360,7 +1360,7 @@ func TestFromXDRBuildSignEncode(t *testing.T) {
 	// test signing transaction  without modification
 	tx, err := TransactionFromXDR(expectedUnsigned)
 	assert.NoError(t, err)
-	newTx, ok := tx.Simple()
+	newTx, ok := tx.Transaction()
 	assert.True(t, ok)
 	_, ok = tx.FeeBump()
 	assert.False(t, ok)
@@ -1376,7 +1376,7 @@ func TestFromXDRBuildSignEncode(t *testing.T) {
 	expectedSigned2 := "AAAAAODcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAiII0AAAAbAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAABW5ld3R4AAAAAAAAAQAAAAAAAAAAAAAAAITg3tq8G0kvnvoIhZPMYJsY+9KVV8xAA6NxhtKxIXZUAAAAAAX14QAAAAAAAAAAAeoucsUAAABADPbbXNzpC408WyYGQszN3VA9e41sNpsyZ2HcS62RXvUDsN0A+IXMPRMaCb+Wgn1OM6Ikam9ol0MJYNeK0BPxCg=="
 	tx, err = TransactionFromXDR(expectedUnsigned)
 	assert.NoError(t, err)
-	newTx, ok = tx.Simple()
+	newTx, ok = tx.Transaction()
 	assert.True(t, ok)
 	_, ok = tx.FeeBump()
 	assert.False(t, ok)


### PR DESCRIPTION
When I was working on https://github.com/stellar/go/pull/2495 I originally named the `Transaction` type as `SimpleTransaction`.
I eventually changed the name of the struct but I forgot to change the name of the Simple() function.