### PR TITLE
support/http: propagate request id to all logs

### DIFF
--- a/support/http/logging_middleware.go
+++ b/support/http/logging_middleware.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"context"
 	stdhttp "net/http"
 	"time"
 
@@ -32,23 +31,24 @@ func LoggingMiddleware(next stdhttp.Handler) stdhttp.Handler {
 			})
 		})
 
-		logStartOfRequest(ctx, r)
+		r = r.WithContext(ctx)
+
+		logStartOfRequest(r)
 
 		then := time.Now()
 		next.ServeHTTP(mw, r)
 		duration := time.Since(then)
 
-		logEndOfRequest(ctx, r, duration, mw)
+		logEndOfRequest(r, duration, mw)
 	})
 }
 
 // logStartOfRequest emits the logline that reports that an http request is
 // beginning processing.
 func logStartOfRequest(
-	ctx context.Context,
 	r *stdhttp.Request,
 ) {
-	log.Ctx(ctx).WithFields(log.F{
+	log.Ctx(r.Context()).WithFields(log.F{
 		"subsys": "http",
 		"path":   r.URL.String(),
 		"method": r.Method,
@@ -59,12 +59,11 @@ func logStartOfRequest(
 
 // logEndOfRequest emits the logline for the end of the request
 func logEndOfRequest(
-	ctx context.Context,
 	r *stdhttp.Request,
 	duration time.Duration,
 	mw mutil.WriterProxy,
 ) {
-	log.Ctx(ctx).WithFields(log.F{
+	log.Ctx(r.Context()).WithFields(log.F{
 		"subsys":   "http",
 		"path":     r.URL.String(),
 		"method":   r.Method,

--- a/support/http/logging_middleware_test.go
+++ b/support/http/logging_middleware_test.go
@@ -19,6 +19,7 @@ func TestHTTPMiddleware(t *testing.T) {
 	mux.Use(LoggingMiddleware)
 
 	mux.Get("/", stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		log.Ctx(r.Context()).Info("handler log line")
 	}))
 	mux.Handle("/not_found", stdhttp.NotFoundHandler())
 
@@ -29,18 +30,35 @@ func TestHTTPMiddleware(t *testing.T) {
 	// get the log buffer and ensure it has both the start and end log lines for
 	// each request
 	logged := done()
-	if assert.Len(t, logged, 4, "unexpected log line count") {
+	if assert.Len(t, logged, 5, "unexpected log line count") {
 		assert.Equal(t, "starting request", logged[0].Message)
-		assert.Equal(t, "starting request", logged[2].Message)
-		assert.Equal(t, "finished request", logged[1].Message)
-		assert.Equal(t, "finished request", logged[3].Message)
-	}
+		assert.Equal(t, "http", logged[0].Data["subsys"])
+		assert.Equal(t, "GET", logged[0].Data["method"])
+		assert.NotEmpty(t, logged[0].Data["req"])
+		assert.NotEmpty(t, logged[0].Data["path"])
+		req1 := logged[0].Data["req"]
 
-	for _, line := range logged {
-		assert.Equal(t, "http", line.Data["subsys"])
-		assert.Equal(t, "GET", line.Data["method"])
-		assert.NotEmpty(t, line.Data["req"])
-		assert.NotEmpty(t, line.Data["path"])
+		assert.Equal(t, "handler log line", logged[1].Message)
+		assert.Equal(t, req1, logged[0].Data["req"])
+
+		assert.Equal(t, "finished request", logged[2].Message)
+		assert.Equal(t, "http", logged[2].Data["subsys"])
+		assert.Equal(t, "GET", logged[2].Data["method"])
+		assert.Equal(t, req1, logged[2].Data["req"])
+		assert.NotEmpty(t, logged[2].Data["path"])
+
+		assert.Equal(t, "starting request", logged[3].Message)
+		assert.Equal(t, "http", logged[3].Data["subsys"])
+		assert.Equal(t, "GET", logged[3].Data["method"])
+		assert.NotEmpty(t, logged[3].Data["req"])
+		assert.NotEmpty(t, logged[3].Data["path"])
+		req2 := logged[3].Data["req"]
+
+		assert.Equal(t, "finished request", logged[4].Message)
+		assert.Equal(t, "http", logged[4].Data["subsys"])
+		assert.Equal(t, "GET", logged[4].Data["method"])
+		assert.Equal(t, req2, logged[4].Data["req"])
+		assert.NotEmpty(t, logged[4].Data["path"])
 	}
 }
 
@@ -54,6 +72,7 @@ func TestHTTPMiddlewareWithLoggerSet(t *testing.T) {
 	mux.Use(LoggingMiddleware)
 
 	mux.Get("/", stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		log.Ctx(r.Context()).Info("handler log line")
 	}))
 	mux.Handle("/not_found", stdhttp.NotFoundHandler())
 
@@ -64,17 +83,34 @@ func TestHTTPMiddlewareWithLoggerSet(t *testing.T) {
 	// get the log buffer and ensure it has both the start and end log lines for
 	// each request
 	logged := done()
-	if assert.Len(t, logged, 4, "unexpected log line count") {
+	if assert.Len(t, logged, 5, "unexpected log line count") {
 		assert.Equal(t, "starting request", logged[0].Message)
-		assert.Equal(t, "starting request", logged[2].Message)
-		assert.Equal(t, "finished request", logged[1].Message)
-		assert.Equal(t, "finished request", logged[3].Message)
-	}
+		assert.Equal(t, "http", logged[0].Data["subsys"])
+		assert.Equal(t, "GET", logged[0].Data["method"])
+		assert.NotEmpty(t, logged[0].Data["req"])
+		assert.NotEmpty(t, logged[0].Data["path"])
+		req1 := logged[0].Data["req"]
 
-	for _, line := range logged {
-		assert.Equal(t, "http", line.Data["subsys"])
-		assert.Equal(t, "GET", line.Data["method"])
-		assert.NotEmpty(t, line.Data["req"])
-		assert.NotEmpty(t, line.Data["path"])
+		assert.Equal(t, "handler log line", logged[1].Message)
+		assert.Equal(t, req1, logged[0].Data["req"])
+
+		assert.Equal(t, "finished request", logged[2].Message)
+		assert.Equal(t, "http", logged[2].Data["subsys"])
+		assert.Equal(t, "GET", logged[2].Data["method"])
+		assert.Equal(t, req1, logged[2].Data["req"])
+		assert.NotEmpty(t, logged[2].Data["path"])
+
+		assert.Equal(t, "starting request", logged[3].Message)
+		assert.Equal(t, "http", logged[3].Data["subsys"])
+		assert.Equal(t, "GET", logged[3].Data["method"])
+		assert.NotEmpty(t, logged[3].Data["req"])
+		assert.NotEmpty(t, logged[3].Data["path"])
+		req2 := logged[3].Data["req"]
+
+		assert.Equal(t, "finished request", logged[4].Message)
+		assert.Equal(t, "http", logged[4].Data["subsys"])
+		assert.Equal(t, "GET", logged[4].Data["method"])
+		assert.Equal(t, req2, logged[4].Data["req"])
+		assert.NotEmpty(t, logged[4].Data["path"])
 	}
 }

--- a/support/http/logging_middleware_test.go
+++ b/support/http/logging_middleware_test.go
@@ -39,7 +39,7 @@ func TestHTTPMiddleware(t *testing.T) {
 		req1 := logged[0].Data["req"]
 
 		assert.Equal(t, "handler log line", logged[1].Message)
-		assert.Equal(t, req1, logged[0].Data["req"])
+		assert.Equal(t, req1, logged[1].Data["req"])
 
 		assert.Equal(t, "finished request", logged[2].Message)
 		assert.Equal(t, "http", logged[2].Data["subsys"])
@@ -92,7 +92,7 @@ func TestHTTPMiddlewareWithLoggerSet(t *testing.T) {
 		req1 := logged[0].Data["req"]
 
 		assert.Equal(t, "handler log line", logged[1].Message)
-		assert.Equal(t, req1, logged[0].Data["req"])
+		assert.Equal(t, req1, logged[1].Data["req"])
 
 		assert.Equal(t, "finished request", logged[2].Message)
 		assert.Equal(t, "http", logged[2].Data["subsys"])


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Propagate the request ID to the requests context logger making the request ID show up in all logs for a request.

### Why
For every request we receive in Friendbot, Webauth, Recoverysigner, and other applications are assigned a request ID which is logged at the beginning and end of the request. Matching the beginning and end of a request is one reason to use a request ID, but the main reason to log a request ID is to make it easier to identify all logs relating to that request, not just the beginning and end of the request. This allows us to look at the logs of a server and identify definitively which logs relate to the same request.

Horizon uses separate code that follows the same pattern and this fix was made to its version of this code in 2018: https://github.com/stellar/go/commit/36345f68ef6a30e55d8c1a02cb82613dc3d9b041#diff-3702689dfe4e807fe1e3ba73798bff50L32-R29

I also did a small refactoring of how the context is passed into the helper functions because while it is normally good practice to pass the context as the first parameter into subsequent functions it is duplicative to the request since the request contains the context. By only passing the request we are clearly signaling that the context in the request is the ultimate context that should be in use.

### Known limitations

N/A
