### PR TITLE
services/horizon: Tweak the copy of the 500-error problem

### DIFF
--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -26,9 +26,8 @@ var (
 		Status: http.StatusInternalServerError,
 		Detail: "An error occurred while processing this request.  This is usually due " +
 			"to a bug within the server software.  Trying this request again may " +
-			"succeed if the bug is transient, otherwise please report this issue " +
-			"to the issue tracker at: https://github.com/stellar/go/issues." +
-			" Please include this response in your issue.",
+			"succeed if the bug is transient. Otherwise, please contact the system" +
+			"administrator.",
 	}
 
 	// NotFound is a well-known problem type.  Use it as a shortcut in your actions


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Tweak the text returned when a HTTP 500 error occurs to stop encouraging users to create an issue at https://github.com/stellar/go

### Why

Prompting users to create GitHub issues has shown to add noise, particularly when the Horizon instances are not managed by SDF. Fixes #2034 

### Known limitations

N/A
