### PR TITLE
services/horizon/ledger: Fix memory leak in HistoryDBSource

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -7,6 +7,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Add `last_modified_time` to account responses. `last_modified_time` is the
  closing time of the most recent ledger in which the account was modified.
+* Fix a memory leak in the code responsible for streaming [#2548](https://github.com/stellar/go/pull/2548).
 
 ## v1.2.1
 

--- a/services/horizon/internal/ledger/ledger_source.go
+++ b/services/horizon/internal/ledger/ledger_source.go
@@ -21,7 +21,9 @@ type currentStateFunc func() State
 type HistoryDBSource struct {
 	updateFrequency time.Duration
 	currentState    currentStateFunc
-	closed          bool
+
+	closedLock sync.Mutex
+	closed     bool
 }
 
 // NewHistoryDBSource constructs a new instance of HistoryDBSource
@@ -29,6 +31,7 @@ func NewHistoryDBSource(updateFrequency time.Duration) *HistoryDBSource {
 	return &HistoryDBSource{
 		updateFrequency: updateFrequency,
 		currentState:    CurrentState,
+		closedLock:      sync.Mutex{},
 	}
 }
 
@@ -49,7 +52,10 @@ func (source *HistoryDBSource) NextLedger(currentSequence uint32) chan uint32 {
 				time.Sleep(source.updateFrequency)
 			}
 
-			if source.closed {
+			source.closedLock.Lock()
+			closed := source.closed
+			source.closedLock.Unlock()
+			if closed {
 				return
 			}
 
@@ -66,6 +72,8 @@ func (source *HistoryDBSource) NextLedger(currentSequence uint32) chan uint32 {
 
 // Close closes the internal go routines.
 func (source *HistoryDBSource) Close() {
+	source.closedLock.Lock()
+	defer source.closedLock.Unlock()
 	source.closed = true
 }
 

--- a/services/horizon/internal/ledger/ledger_source.go
+++ b/services/horizon/internal/ledger/ledger_source.go
@@ -6,10 +6,12 @@ import (
 )
 
 // Source exposes two helpers methods to help you find out the current
-// ledger and yield every time there is a new ledger.
+// ledger and yield every time there is a new ledger. Call `Close` when
+// source is no longer used.
 type Source interface {
 	CurrentLedger() uint32
 	NextLedger(currentSequence uint32) chan uint32
+	Close()
 }
 
 type currentStateFunc func() State
@@ -19,23 +21,24 @@ type currentStateFunc func() State
 type HistoryDBSource struct {
 	updateFrequency time.Duration
 	currentState    currentStateFunc
+	closed          bool
 }
 
 // NewHistoryDBSource constructs a new instance of HistoryDBSource
-func NewHistoryDBSource(updateFrequency time.Duration) HistoryDBSource {
-	return HistoryDBSource{
+func NewHistoryDBSource(updateFrequency time.Duration) *HistoryDBSource {
+	return &HistoryDBSource{
 		updateFrequency: updateFrequency,
 		currentState:    CurrentState,
 	}
 }
 
 // CurrentLedger returns the current ledger.
-func (source HistoryDBSource) CurrentLedger() uint32 {
+func (source *HistoryDBSource) CurrentLedger() uint32 {
 	return source.currentState().ExpHistoryLatest
 }
 
 // NextLedger returns a channel which yields every time there is a new ledger with a sequence number larger than currentSequence.
-func (source HistoryDBSource) NextLedger(currentSequence uint32) chan uint32 {
+func (source *HistoryDBSource) NextLedger(currentSequence uint32) chan uint32 {
 	// Make sure this is buffered channel of size 1. Otherwise, the go routine below
 	// will never return if `newLedgers` channel is not read. From Effective Go:
 	// > If the channel is unbuffered, the sender blocks until the receiver has received the value.
@@ -44,6 +47,10 @@ func (source HistoryDBSource) NextLedger(currentSequence uint32) chan uint32 {
 		for {
 			if source.updateFrequency > 0 {
 				time.Sleep(source.updateFrequency)
+			}
+
+			if source.closed {
+				return
 			}
 
 			currentLedgerState := source.currentState()
@@ -55,6 +62,11 @@ func (source HistoryDBSource) NextLedger(currentSequence uint32) chan uint32 {
 	}()
 
 	return newLedgers
+}
+
+// Close closes the internal go routines.
+func (source *HistoryDBSource) Close() {
+	source.closed = true
 }
 
 // TestingSource is helper struct which implements the LedgerSource
@@ -106,3 +118,5 @@ func (source *TestingSource) NextLedger(currentSequence uint32) chan uint32 {
 
 	return response
 }
+
+func (source *TestingSource) Close() {}

--- a/services/horizon/internal/render/sse/stream_handler_test.go
+++ b/services/horizon/internal/render/sse/stream_handler_test.go
@@ -9,11 +9,17 @@ import (
 	"github.com/stellar/go/services/horizon/internal/ledger"
 )
 
+type testingFactory struct {
+	ledgerSource ledger.Source
+}
+
+func (f *testingFactory) Get() ledger.Source {
+	return f.ledgerSource
+}
+
 func TestSendByeByeOnContextDone(t *testing.T) {
 	ledgerSource := ledger.NewTestingSource(1)
-	handler := StreamHandler{
-		LedgerSource: ledgerSource,
-	}
+	handler := StreamHandler{LedgerSourceFactory: &testingFactory{ledgerSource}}
 
 	r, err := http.NewRequest("GET", "http://localhost", nil)
 	if err != nil {

--- a/services/horizon/internal/stream_handler_test.go
+++ b/services/horizon/internal/stream_handler_test.go
@@ -21,6 +21,14 @@ import (
 	"github.com/stellar/go/support/render/hal"
 )
 
+type testingFactory struct {
+	ledgerSource ledger.Source
+}
+
+func (f *testingFactory) Get() ledger.Source {
+	return f.ledgerSource
+}
+
 // StreamTest utility struct to wrap SSE related tests.
 type StreamTest struct {
 	ledgerSource  *ledger.TestingSource
@@ -64,7 +72,7 @@ func NewStreamablePageTest(
 ) *StreamTest {
 	ledgerSource := ledger.NewTestingSource(currentLedger)
 	action.ledgerSource = ledgerSource
-	streamHandler := sse.StreamHandler{LedgerSource: ledgerSource}
+	streamHandler := sse.StreamHandler{LedgerSourceFactory: &testingFactory{ledgerSource}}
 	handler := streamablePageHandler(action, streamHandler)
 
 	return newStreamTest(
@@ -85,7 +93,7 @@ func NewStreamableObjectTest(
 ) *StreamTest {
 	ledgerSource := ledger.NewTestingSource(currentLedger)
 	action.ledgerSource = ledgerSource
-	streamHandler := sse.StreamHandler{LedgerSource: ledgerSource}
+	streamHandler := sse.StreamHandler{LedgerSourceFactory: &testingFactory{ledgerSource}}
 	handler := streamableObjectActionHandler{action: action, limit: limit, streamHandler: streamHandler}
 
 	return newStreamTest(

--- a/txnbuild/README.md
+++ b/txnbuild/README.md
@@ -5,51 +5,63 @@
 This project is maintained by the Stellar Development Foundation.
 
 ```golang
-  import (
-	"log"
-
-	"github.com/stellar/go/clients/horizonclient"
-	"github.com/stellar/go/keypair"
-	"github.com/stellar/go/network"
-	"github.com/stellar/go/txnbuild"
-	)
-
-	// Make a keypair for a known account from a secret seed
-	kp, _ := keypair.Parse("SBPQUZ6G4FZNWFHKUWC5BEYWF6R52E3SEP7R3GWYSM2XTKGF5LNTWW4R")
-
-	// Get the current state of the account from the network
-	client := horizonclient.DefaultTestNetClient
-	ar := horizonclient.AccountRequest{AccountID: kp.Address()}
-	sourceAccount, err := client.AccountDetail(ar)
-  	if err != nil {
-    		log.Println(err)
-  	}
-
-	// Build an operation to create and fund a new account
-	op := txnbuild.CreateAccount{
-		Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
-		Amount:      "10",
-	}
-
-	// Construct the transaction that holds the operations to execute on the network
-	tx := txnbuild.Transaction{
-		SourceAccount: &sourceAccount,
-		Operations:    []txnbuild.Operation{&op},
-		Timebounds:    txnbuild.NewTimeout(300),
-		Network:       network.TestNetworkPassphrase,
-	}
-
-	// Serialise, sign and encode the transaction
-	txe, err := tx.BuildSignEncode(kp.(*keypair.Full))
-  	if err != nil {
-    		log.Println(err)
-  	}
-
-	// Send the transaction to the network
-	resp, err := client.SubmitTransactionXDR(txe)
-  	if err != nil {
-    		log.Println(err)
-  	}
+    import (
+        "log"
+        
+        "github.com/stellar/go/clients/horizonclient"
+        "github.com/stellar/go/keypair"
+        "github.com/stellar/go/network"
+        "github.com/stellar/go/txnbuild"
+    )
+    
+    // Make a keypair for a known account from a secret seed
+    kp, _ := keypair.Parse("SBPQUZ6G4FZNWFHKUWC5BEYWF6R52E3SEP7R3GWYSM2XTKGF5LNTWW4R")
+    
+    // Get the current state of the account from the network
+    client := horizonclient.DefaultTestNetClient
+    ar := horizonclient.AccountRequest{AccountID: kp.Address()}
+    sourceAccount, err := client.AccountDetail(ar)
+    if err != nil {
+        log.Fatalln(err)
+    }
+    
+    // Build an operation to create and fund a new account
+    op := txnbuild.CreateAccount{
+        Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
+        Amount:      "10",
+    }
+    
+    // Construct the transaction that holds the operations to execute on the network
+    tx, err := txnbuild.NewTransaction(
+        txnbuild.TransactionParams{
+            SourceAccount:        &sourceAccount,
+            IncrementSequenceNum: true,
+            Operations:           []txnbuild.Operation{&op},
+            BaseFee:              txnbuild.MinBaseFee,
+            Timebounds:           txnbuild.NewTimeout(300),
+        },
+    )
+    if err != nil {
+        log.Fatalln(err)
+    )
+    
+    // Sign the transaction
+    tx, err = tx.Sign(network.TestNetworkPassphrase, kp.(*keypair.Full))
+    if err != nil {
+        log.Fatalln(err)
+    )
+    
+    // Get the base 64 encoded transaction envelope
+    txe, err := tx.Base64()
+    if err != nil {
+        log.Fatalln(err)
+    }
+    
+    // Send the transaction to the network
+    resp, err := client.SubmitTransactionXDR(txe)
+    if err != nil {
+        log.Fatalln(err)
+    }
 ```
 
 ## Getting Started


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit fixes a memory leak in `HistoryDBSource.NextLedger` method. The method is usually used like in `stream_handler.go`:
https://github.com/stellar/go/blob/00d7d2f8600e5389b20c3142b5b90550e9b75168/services/horizon/internal/render/sse/stream_handler.go#L73-L79
When streaming connection is closed but the are no new ledgers (ex. due to database or network issues) the goroutines started in `HistoryDBSource.NextLedger` will not be closed.

To fix this `ledger.Source` interface was updated with `Close()` method that should be called when a ledger source is no longer used and it exist internal goroutine. The code was refactored to create a new `HistoryDBSource` for each streaming request (so it can be closed when handler execution ends).

### Why

When there are no new ledgers, the goroutines started in `HistoryDBSource.NextLedger` will leak and will eventually consume all available memory, like in https://github.com/stellar/go/issues/2535.

### Known limitations

The new code creates a new `HistoryDBSource` for each streaming request (instead of reusing a single `HistoryDBSource` in all streaming requests). This should have a really minimal impact on memory usage.
