### PR TITLE
services/horizon/internal/txsub: Add metrics to track which types of transaction Horizon is receiving

### DIFF
--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -134,6 +134,9 @@ func initTxSubMetrics(app *App) {
 	app.metrics.Register("txsub.open", app.submitter.Metrics.OpenSubmissionsGauge)
 	app.metrics.Register("txsub.succeeded", app.submitter.Metrics.SuccessfulSubmissionsMeter)
 	app.metrics.Register("txsub.failed", app.submitter.Metrics.FailedSubmissionsMeter)
+	app.metrics.Register("txsub.v0", app.submitter.Metrics.V0TransactionsMeter)
+	app.metrics.Register("txsub.v1", app.submitter.Metrics.V1TransactionsMeter)
+	app.metrics.Register("txsub.feebump", app.submitter.Metrics.FeeBumpTransactionsMeter)
 	app.metrics.Register("txsub.total", app.submitter.Metrics.SubmissionTimer)
 }
 

--- a/services/horizon/internal/txsub/system.go
+++ b/services/horizon/internal/txsub/system.go
@@ -49,6 +49,18 @@ type System struct {
 		// SuccessfulSubmissionsMeter tracks the rate of successful transactions that
 		// have been submitted to this process
 		SuccessfulSubmissionsMeter metrics.Meter
+
+		// V0TransactionsMeter tracks the rate of v0 transaction envelopes that
+		// have been submitted to this process
+		V0TransactionsMeter metrics.Meter
+
+		// V1TransactionsMeter tracks the rate of v1 transaction envelopes that
+		// have been submitted to this process
+		V1TransactionsMeter metrics.Meter
+
+		// FeeBumpTransactionsMeter tracks the rate of fee bump transaction envelopes that
+		// have been submitted to this process
+		FeeBumpTransactionsMeter metrics.Meter
 	}
 }
 
@@ -124,6 +136,7 @@ func (sys *System) Submit(
 		}
 
 		sr := sys.submitOnce(ctx, rawTx)
+		sys.updateTransactionTypeMetrics(envelope)
 
 		// if submission succeeded
 		if sr.Err == nil {
@@ -181,6 +194,17 @@ func (sys *System) submitOnce(ctx context.Context, env string) SubmissionResult 
 	}
 
 	return sr
+}
+
+func (sys *System) updateTransactionTypeMetrics(envelope xdr.TransactionEnvelope) {
+	switch envelope.Type {
+	case xdr.EnvelopeTypeEnvelopeTypeTxV0:
+		sys.Metrics.V0TransactionsMeter.Mark(1)
+	case xdr.EnvelopeTypeEnvelopeTypeTx:
+		sys.Metrics.V1TransactionsMeter.Mark(1)
+	case xdr.EnvelopeTypeEnvelopeTypeTxFeeBump:
+		sys.Metrics.FeeBumpTransactionsMeter.Mark(1)
+	}
 }
 
 // setTickInProgress sets `tickInProgress` to `true` if it's
@@ -275,6 +299,9 @@ func (sys *System) Init() {
 		sys.Metrics.SubmissionTimer = metrics.NewTimer()
 		sys.Metrics.OpenSubmissionsGauge = metrics.NewGauge()
 		sys.Metrics.BufferedSubmissionsGauge = metrics.NewGauge()
+		sys.Metrics.V0TransactionsMeter = metrics.NewMeter()
+		sys.Metrics.V1TransactionsMeter = metrics.NewMeter()
+		sys.Metrics.FeeBumpTransactionsMeter = metrics.NewMeter()
 
 		if sys.SubmissionTimeout == 0 {
 			// HTTP clients in SDKs usually timeout in 60 seconds. We want SubmissionTimeout

--- a/services/horizon/internal/txsub/system.go
+++ b/services/horizon/internal/txsub/system.go
@@ -77,8 +77,9 @@ func (sys *System) Submit(
 	result = response
 
 	sys.Log.Ctx(ctx).WithFields(log.F{
-		"hash": hash,
-		"tx":   rawTx,
+		"hash":    hash,
+		"tx_type": envelope.Type.String(),
+		"tx":      rawTx,
 	}).Info("Processing transaction")
 
 	// check the configured result provider for an existing result


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add metrics to track which types of transaction (v0, v1, or fee bump) Horizon is receiving.

### Why

Prior to protocol 13 there was only kind of transaction you could submit to Horizon. With these metrics we can monitor how many people actually use fee bump transactions and how many people are still submitting v0 transactions.

Note that we could also add hooks to ingestion which monitor the total number of fee bump transactions in a ledger. However, we will not be able to monitor the number of v0 transactions which were included in a ledger from the ingestion code because, once protocol 13 is enabled, Stellar Core will rewrite v0 transactions as v1 transactions.
 
### Known limitations

We shouldn't have a separate metrics for each transaction type. 

> When you have multiple metrics that you want to add/average/sum, they should usually be one metric with labels rather than multiple metrics.

>For example, rather than http_responses_500_total and http_responses_403_total, create a single metric called http_responses_total with a code label for the HTTP response code. You can then process the entire metric as one in rules and graphs.


From https://prometheus.io/docs/practices/instrumentation/#use-labels 

This issue also applies to many of the existing horizon metrics such as `txsub.succeeded` and `txsub.failed`. 

The go-metrics library does not support creating metrics with tags or labels, see https://github.com/rcrowley/go-metrics/issues/135 . We should consider using the prometheus client directly for metrics https://github.com/go-kit/kit/blob/master/metrics/prometheus/prometheus.go . Alternatively we could use a library like https://github.com/armon/go-metrics which does support creating metrics with labels.