### PR TITLE
services/horizon/internal/expingest: Log context cancelled errors using info level

### DIFF
--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -388,6 +388,10 @@ func (r resumeState) run(s *System) (transition, error) {
 	}
 
 	if latestLedgerCore < ingestLedger {
+		log.WithFields(logpkg.F{
+			"ingest_sequence": ingestLedger,
+			"core_sequence":   latestLedgerCore,
+		}).Info("Waiting for ledger to be available in stellar-core")
 		// Go to the next state, machine will wait for 1s. before continuing.
 		return retryResume(r), nil
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Log context cancelled errors using info level in the ingestion package.

### Why

These logs will help debug cases where ingestion is behaving unexpectedly.

### Known limitations

[N/A]
