### PR TITLE
services/horizon/internal: Create separate db connections for ingestion

### DIFF
--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -44,6 +44,9 @@ const (
 	//      everything else).
 	CurrentVersion = 10
 
+	// MaxDBConnections is the size of the postgres connection pool dedicated to Horizon ingestion
+	MaxDBConnections = 2
+
 	defaultCoreCursorName           = "HORIZON"
 	stateVerificationErrorThreshold = 3
 )

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -19,8 +19,6 @@ import (
 	"github.com/stellar/go/support/log"
 )
 
-const maxIngestionDBConnections = 2
-
 func mustNewDBSession(databaseURL string, maxIdle, maxOpen int) *db.Session {
 	session, err := db.Open("postgres", databaseURL)
 	if err != nil {
@@ -35,17 +33,17 @@ func mustNewDBSession(databaseURL string, maxIdle, maxOpen int) *db.Session {
 func mustInitHorizonDB(app *App) {
 	maxIdle := app.config.HorizonDBMaxIdleConnections
 	maxOpen := app.config.HorizonDBMaxOpenConnections
-	// There are two connection pools, one for serving requests to horizon
-	// and another pool for ingestion. Ideally the total connections in both
-	// pools should be bounded by HorizonDBMaxOpenConnections. But, if the ingestion
-	// pool consumes a significant quota of HorizonDBMaxOpenConnections then we will
-	// allow a total of HorizonDBMaxOpenConnections + maxIngestionDBConnections connections.
-	if maxIdle >= maxIngestionDBConnections*2 {
-		maxIdle -= maxIngestionDBConnections
+	if app.config.Ingest || app.config.IngestInMemoryOnly {
+		maxIdle -= expingest.MaxDBConnections
+		maxOpen -= expingest.MaxDBConnections
+		if maxIdle <= 0 {
+			log.Fatalf("max idle connections to horizon db must be greater than %d", expingest.MaxDBConnections)
+		}
+		if maxOpen <= 0 {
+			log.Fatalf("max open connections to horizon db must be greater than %d", expingest.MaxDBConnections)
+		}
 	}
-	if maxOpen >= maxIngestionDBConnections*2 {
-		maxOpen -= maxIngestionDBConnections
-	}
+
 	app.historyQ = &history.Q{mustNewDBSession(
 		app.config.DatabaseURL,
 		maxIdle,
@@ -56,17 +54,17 @@ func mustInitHorizonDB(app *App) {
 func mustInitCoreDB(app *App) {
 	maxIdle := app.config.CoreDBMaxIdleConnections
 	maxOpen := app.config.CoreDBMaxOpenConnections
-	// There are two connection pools, one for serving requests to horizon
-	// and another pool for ingestion. Ideally the total connections in both
-	// pools should be bounded by CoreDBMaxOpenConnections. But, if the ingestion
-	// pool consumes a significant quota of CoreDBMaxOpenConnections then we will
-	// allow a total of CoreDBMaxOpenConnections + maxIngestionDBConnections connections.
-	if maxIdle >= maxIngestionDBConnections*2 {
-		maxIdle -= maxIngestionDBConnections
+	if app.config.Ingest || app.config.IngestInMemoryOnly {
+		maxIdle -= expingest.MaxDBConnections
+		maxOpen -= expingest.MaxDBConnections
+		if maxIdle <= 0 {
+			log.Fatalf("max idle connections to stellar-core db must be greater than %d", expingest.MaxDBConnections)
+		}
+		if maxOpen <= 0 {
+			log.Fatalf("max open connections to stellar-core db must be greater than %d", expingest.MaxDBConnections)
+		}
 	}
-	if maxOpen >= maxIngestionDBConnections*2 {
-		maxOpen -= maxIngestionDBConnections
-	}
+
 	app.coreQ = &core.Q{mustNewDBSession(
 		app.config.StellarCoreDatabaseURL,
 		maxIdle,
@@ -78,10 +76,10 @@ func initExpIngester(app *App, orderBookGraph *orderbook.OrderBookGraph) {
 	var err error
 	app.expingester, err = expingest.NewSystem(expingest.Config{
 		CoreSession: mustNewDBSession(
-			app.config.StellarCoreDatabaseURL, maxIngestionDBConnections, maxIngestionDBConnections,
+			app.config.StellarCoreDatabaseURL, expingest.MaxDBConnections, expingest.MaxDBConnections,
 		),
 		HistorySession: mustNewDBSession(
-			app.config.DatabaseURL, maxIngestionDBConnections, maxIngestionDBConnections,
+			app.config.DatabaseURL, expingest.MaxDBConnections, expingest.MaxDBConnections,
 		),
 		NetworkPassphrase: app.config.NetworkPassphrase,
 		// TODO:

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -19,33 +19,70 @@ import (
 	"github.com/stellar/go/support/log"
 )
 
-func mustInitHorizonDB(app *App) {
-	session, err := db.Open("postgres", app.config.DatabaseURL)
+const maxIngestionDBConnections = 2
+
+func mustNewDBSession(databaseURL string, maxIdle, maxOpen int) *db.Session {
+	session, err := db.Open("postgres", databaseURL)
 	if err != nil {
 		log.Fatalf("cannot open Horizon DB: %v", err)
 	}
 
-	session.DB.SetMaxIdleConns(app.config.HorizonDBMaxIdleConnections)
-	session.DB.SetMaxOpenConns(app.config.HorizonDBMaxOpenConnections)
-	app.historyQ = &history.Q{session}
+	session.DB.SetMaxIdleConns(maxIdle)
+	session.DB.SetMaxOpenConns(maxOpen)
+	return session
+}
+
+func mustInitHorizonDB(app *App) {
+	maxIdle := app.config.HorizonDBMaxIdleConnections
+	maxOpen := app.config.HorizonDBMaxOpenConnections
+	// There are two connection pools, one for serving requests to horizon
+	// and another pool for ingestion. Ideally the total connections in both
+	// pools should be bounded by HorizonDBMaxOpenConnections. But, if the ingestion
+	// pool consumes a significant quota of HorizonDBMaxOpenConnections then we will
+	// allow a total of HorizonDBMaxOpenConnections + maxIngestionDBConnections connections.
+	if maxIdle >= maxIngestionDBConnections*2 {
+		maxIdle -= maxIngestionDBConnections
+	}
+	if maxOpen >= maxIngestionDBConnections*2 {
+		maxOpen -= maxIngestionDBConnections
+	}
+	app.historyQ = &history.Q{mustNewDBSession(
+		app.config.DatabaseURL,
+		maxIdle,
+		maxOpen,
+	)}
 }
 
 func mustInitCoreDB(app *App) {
-	session, err := db.Open("postgres", app.config.StellarCoreDatabaseURL)
-	if err != nil {
-		log.Fatalf("cannot open Core DB: %v", err)
+	maxIdle := app.config.CoreDBMaxIdleConnections
+	maxOpen := app.config.CoreDBMaxOpenConnections
+	// There are two connection pools, one for serving requests to horizon
+	// and another pool for ingestion. Ideally the total connections in both
+	// pools should be bounded by CoreDBMaxOpenConnections. But, if the ingestion
+	// pool consumes a significant quota of CoreDBMaxOpenConnections then we will
+	// allow a total of CoreDBMaxOpenConnections + maxIngestionDBConnections connections.
+	if maxIdle >= maxIngestionDBConnections*2 {
+		maxIdle -= maxIngestionDBConnections
 	}
-
-	session.DB.SetMaxIdleConns(app.config.CoreDBMaxIdleConnections)
-	session.DB.SetMaxOpenConns(app.config.CoreDBMaxOpenConnections)
-	app.coreQ = &core.Q{session}
+	if maxOpen >= maxIngestionDBConnections*2 {
+		maxOpen -= maxIngestionDBConnections
+	}
+	app.coreQ = &core.Q{mustNewDBSession(
+		app.config.StellarCoreDatabaseURL,
+		maxIdle,
+		maxOpen,
+	)}
 }
 
 func initExpIngester(app *App, orderBookGraph *orderbook.OrderBookGraph) {
 	var err error
 	app.expingester, err = expingest.NewSystem(expingest.Config{
-		CoreSession:       app.CoreSession(context.Background()),
-		HistorySession:    app.HorizonSession(context.Background()),
+		CoreSession: mustNewDBSession(
+			app.config.StellarCoreDatabaseURL, maxIngestionDBConnections, maxIngestionDBConnections,
+		),
+		HistorySession: mustNewDBSession(
+			app.config.DatabaseURL, maxIngestionDBConnections, maxIngestionDBConnections,
+		),
 		NetworkPassphrase: app.config.NetworkPassphrase,
 		// TODO:
 		// Use the first archive for now. We don't have a mechanism to


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes https://github.com/stellar/go/issues/2018

Create separate db connections to the horizon and stellar core databases for ingestion.

### Why

> Currently, all of the Horizon services share the same DB connection pool. In case of increased number of HTTP requests, it's possible that ingestion service will have to wait for an idle connection.

### Known limitations

[N/A]
