### PR TITLE
Fix TransactionBatchInsertBuilder

### DIFF
--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
@@ -179,6 +179,10 @@ func transactionToMap(transaction io.LedgerTransaction, sequence uint32) (map[st
 		m["inner_signatures"] = sqx.StringArray(signatures(transaction.Envelope.Signatures()))
 		m["signatures"] = sqx.StringArray(signatures(transaction.Envelope.FeeBumpSignatures()))
 	} else {
+		m["inner_transaction_hash"] = nil
+		m["fee_account"] = nil
+		m["new_max_fee"] = nil
+		m["inner_signatures"] = nil
 		m["signatures"] = sqx.StringArray(signatures(transaction.Envelope.Signatures()))
 	}
 


### PR DESCRIPTION
Fix for error:
```
Error running processors on ledger: Error streaming changes from ledger: could not process transaction 2: error in *processors.TransactionProcessor.ProcessTransaction: Error batch inserting transaction rows: invalid number of columns (expected=20, actual=24)
```