### PR TITLE
exp/services/recoverysigner: add basic logs

### DIFF
--- a/exp/services/recoverysigner/internal/serve/account_delete.go
+++ b/exp/services/recoverysigner/internal/serve/account_delete.go
@@ -92,13 +92,16 @@ func (h accountDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	err = h.AccountStore.Delete(req.Address.Address())
 	if err == account.ErrNotFound {
 		// It can happen if two authorized users are trying to delete the account at the same time.
+		l.Info("Account not found.")
 		notFound.Render(w)
 		return
 	} else if err != nil {
-		h.Logger.Error(err)
+		l.Error("Error deleting account:", err)
 		serverError.Render(w)
 		return
 	}
+
+	l.Info("Deleted account.")
 
 	httpjson.Render(w, resp, httpjson.JSON)
 }

--- a/exp/services/recoverysigner/internal/serve/account_delete.go
+++ b/exp/services/recoverysigner/internal/serve/account_delete.go
@@ -37,12 +37,18 @@ func (h accountDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	l := h.Logger.Ctx(ctx).
+		WithField("account", req.Address.Address())
+
+	l.Info("Request to delete account.")
+
 	acc, err := h.AccountStore.Get(req.Address.Address())
 	if err == account.ErrNotFound {
+		l.Info("Account not found.")
 		notFound.Render(w)
 		return
 	} else if err != nil {
-		h.Logger.Error(err)
+		l.Error(err)
 		serverError.Render(w)
 		return
 	}
@@ -54,6 +60,7 @@ func (h accountDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	// Authorized if authenticated as the account.
 	authorized := claims.Address == req.Address.Address()
+	l.Infof("Authorized with self: %v.", authorized)
 
 	// Authorized if authenticated as an identity registered with the account.
 	for _, i := range acc.Identities {
@@ -66,16 +73,21 @@ func (h accountDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 				(m.Type == account.AuthMethodTypeEmail && m.Value == claims.Email)) {
 				respIdentity.Authenticated = true
 				authorized = true
+				l.Infof("Authorized with %s.", m.Type)
 				break
 			}
 		}
 
 		resp.Identities = append(resp.Identities, respIdentity)
 	}
+
+	l.Infof("Authorized: %v.", authorized)
 	if !authorized {
 		notFound.Render(w)
 		return
 	}
+
+	l.Info("Deleting account.")
 
 	err = h.AccountStore.Delete(req.Address.Address())
 	if err == account.ErrNotFound {

--- a/exp/services/recoverysigner/internal/serve/account_get.go
+++ b/exp/services/recoverysigner/internal/serve/account_get.go
@@ -37,12 +37,18 @@ func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	l := h.Logger.Ctx(ctx).
+		WithField("account", req.Address.Address())
+
+	l.Info("Request to get account.")
+
 	acc, err := h.AccountStore.Get(req.Address.Address())
 	if err == account.ErrNotFound {
+		l.Info("Account not found.")
 		notFound.Render(w)
 		return
 	} else if err != nil {
-		h.Logger.Error(err)
+		l.Error(err)
 		serverError.Render(w)
 		return
 	}
@@ -54,6 +60,7 @@ func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Authorized if authenticated as the account.
 	authorized := claims.Address == req.Address.Address()
+	l.Infof("Authorized with self: %v.", authorized)
 
 	// Authorized if authenticated as an identity registered with the account.
 	for _, i := range acc.Identities {
@@ -66,16 +73,21 @@ func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				(m.Type == account.AuthMethodTypeEmail && m.Value == claims.Email)) {
 				respIdentity.Authenticated = true
 				authorized = true
+				l.Infof("Authorized with %s.", m.Type)
 				break
 			}
 		}
 
 		resp.Identities = append(resp.Identities, respIdentity)
 	}
+
+	l.Infof("Authorized: %v.", authorized)
 	if !authorized {
 		notFound.Render(w)
 		return
 	}
+
+	l.Info("Getting account.")
 
 	httpjson.Render(w, resp, httpjson.JSON)
 }

--- a/exp/services/recoverysigner/internal/serve/account_get.go
+++ b/exp/services/recoverysigner/internal/serve/account_get.go
@@ -87,7 +87,5 @@ func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	l.Info("Getting account.")
-
 	httpjson.Render(w, resp, httpjson.JSON)
 }

--- a/exp/services/recoverysigner/internal/serve/account_list.go
+++ b/exp/services/recoverysigner/internal/serve/account_list.go
@@ -2,6 +2,7 @@ package serve
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/stellar/go/exp/services/recoverysigner/internal/account"
 	"github.com/stellar/go/exp/services/recoverysigner/internal/serve/auth"
@@ -29,6 +30,21 @@ func (h accountListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	l := h.Logger.Ctx(ctx)
+
+	authMethodTypes := []string{}
+	if claims.Address != "" {
+		authMethodTypes = append(authMethodTypes, string(account.AuthMethodTypeAddress))
+	}
+	if claims.PhoneNumber != "" {
+		authMethodTypes = append(authMethodTypes, string(account.AuthMethodTypePhoneNumber))
+	}
+	if claims.Email != "" {
+		authMethodTypes = append(authMethodTypes, string(account.AuthMethodTypeEmail))
+	}
+	l.WithField("auth_method_types", strings.Join(authMethodTypes, ", ")).
+		Info("Request to get accounts with auth methods.")
+
 	resp := accountListResponse{
 		Accounts: []accountResponse{},
 	}
@@ -40,7 +56,7 @@ func (h accountListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if err == account.ErrNotFound {
 			// Do nothing.
 		} else if err != nil {
-			h.Logger.Error(err)
+			l.Error(err)
 			serverError.Render(w)
 			return
 		} else {
@@ -55,12 +71,15 @@ func (h accountListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				accResp.Identities = append(accResp.Identities, accRespIdentity)
 			}
 			resp.Accounts = append(resp.Accounts, accResp)
+			l.WithField("account", acc.Address).
+				WithField("auth_method_type", account.AuthMethodTypeAddress).
+				Info("Found account with auth method type as self.")
 		}
 
 		// Find accounts that have the address listed as an owner or other identity.
 		accs, err := h.AccountStore.FindWithIdentityAddress(claims.Address)
 		if err != nil {
-			h.Logger.Error(err)
+			l.Error(err)
 			serverError.Render(w)
 			return
 		}
@@ -82,6 +101,9 @@ func (h accountListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				accResp.Identities = append(accResp.Identities, accRespIdentity)
 			}
 			resp.Accounts = append(resp.Accounts, accResp)
+			l.WithField("account", acc.Address).
+				WithField("auth_method_type", account.AuthMethodTypeAddress).
+				Info("Found account with auth method type as identity.")
 		}
 	}
 
@@ -111,6 +133,9 @@ func (h accountListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				accResp.Identities = append(accResp.Identities, accRespIdentity)
 			}
 			resp.Accounts = append(resp.Accounts, accResp)
+			l.WithField("account", acc.Address).
+				WithField("auth_method_type", account.AuthMethodTypePhoneNumber).
+				Info("Found account with auth method type as identity.")
 		}
 	}
 
@@ -140,6 +165,9 @@ func (h accountListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				accResp.Identities = append(accResp.Identities, accRespIdentity)
 			}
 			resp.Accounts = append(resp.Accounts, accResp)
+			l.WithField("account", acc.Address).
+				WithField("auth_method_type", account.AuthMethodTypeEmail).
+				Info("Found account with auth method type as identity.")
 		}
 	}
 

--- a/exp/services/recoverysigner/internal/serve/account_list.go
+++ b/exp/services/recoverysigner/internal/serve/account_list.go
@@ -2,7 +2,6 @@ package serve
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/stellar/go/exp/services/recoverysigner/internal/account"
 	"github.com/stellar/go/exp/services/recoverysigner/internal/serve/auth"
@@ -32,18 +31,7 @@ func (h accountListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	l := h.Logger.Ctx(ctx)
 
-	authMethodTypes := []string{}
-	if claims.Address != "" {
-		authMethodTypes = append(authMethodTypes, string(account.AuthMethodTypeAddress))
-	}
-	if claims.PhoneNumber != "" {
-		authMethodTypes = append(authMethodTypes, string(account.AuthMethodTypePhoneNumber))
-	}
-	if claims.Email != "" {
-		authMethodTypes = append(authMethodTypes, string(account.AuthMethodTypeEmail))
-	}
-	l.WithField("auth_method_types", strings.Join(authMethodTypes, ", ")).
-		Info("Request to get accounts with auth methods.")
+	l.Info("Request to get accounts.")
 
 	resp := accountListResponse{
 		Accounts: []accountResponse{},

--- a/exp/services/recoverysigner/internal/serve/account_sign.go
+++ b/exp/services/recoverysigner/internal/serve/account_sign.go
@@ -48,55 +48,42 @@ func (h accountSignHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	l := h.Logger.Ctx(ctx).
+		WithField("account", req.Address.Address())
+
+	l.Info("Request to sign transaction.")
+
 	// Find the account that the request is for.
 	acc, err := h.AccountStore.Get(req.Address.Address())
 	if err == account.ErrNotFound {
+		l.Info("Account not found.")
 		notFound.Render(w)
 		return
 	} else if err != nil {
+		l.Error(err)
 		serverError.Render(w)
 		return
 	}
 
-	// Verify that the authenticated client has access to the account.
-	addressAuthenticated := false
-	if claims.Address != "" {
-		if claims.Address == acc.Address {
-			addressAuthenticated = true
-		} else {
-			for _, i := range acc.Identities {
-				for _, m := range i.AuthMethods {
-					if m.Type == account.AuthMethodTypeAddress && m.Value == claims.Address {
-						addressAuthenticated = true
-						break
-					}
-				}
+	// Authorized if authenticated as the account.
+	authorized := claims.Address == req.Address.Address()
+	l.Infof("Authorized with self: %v.", authorized)
+
+	// Authorized if authenticated as an identity registered with the account.
+	for _, i := range acc.Identities {
+		for _, m := range i.AuthMethods {
+			if m.Value != "" && ((m.Type == account.AuthMethodTypeAddress && m.Value == claims.Address) ||
+				(m.Type == account.AuthMethodTypePhoneNumber && m.Value == claims.PhoneNumber) ||
+				(m.Type == account.AuthMethodTypeEmail && m.Value == claims.Email)) {
+				authorized = true
+				l.Infof("Authorized with %s.", m.Type)
+				break
 			}
 		}
 	}
-	phoneNumberAuthenticated := false
-	if claims.PhoneNumber != "" {
-		for _, i := range acc.Identities {
-			for _, m := range i.AuthMethods {
-				if m.Type == account.AuthMethodTypePhoneNumber && m.Value == claims.PhoneNumber {
-					phoneNumberAuthenticated = true
-					break
-				}
-			}
-		}
-	}
-	emailAuthenticated := false
-	if claims.Email != "" {
-		for _, i := range acc.Identities {
-			for _, m := range i.AuthMethods {
-				if m.Type == account.AuthMethodTypeEmail && m.Value == claims.Email {
-					emailAuthenticated = true
-					break
-				}
-			}
-		}
-	}
-	if !addressAuthenticated && !phoneNumberAuthenticated && !emailAuthenticated {
+
+	l.Infof("Authorized: %v.", authorized)
+	if !authorized {
 		notFound.Render(w)
 		return
 	}
@@ -104,18 +91,32 @@ func (h accountSignHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Decode the request transaction.
 	parsed, err := txnbuild.TransactionFromXDR(req.Transaction)
 	if err != nil {
+		l.WithField("transaction", req.Transaction).
+			Info("Parsing transaction failed.")
 		badRequest.Render(w)
 		return
 	}
 	tx, ok := parsed.Transaction()
 	if !ok {
+		l.Info("Transaction is not at transaction.")
 		badRequest.Render(w)
 		return
 	}
+	hashHex, err := tx.HashHex(h.NetworkPassphrase)
+	if err != nil {
+		l.Error("Error hashing transaction:", err)
+		serverError.Render(w)
+		return
+	}
+
+	l = l.WithField("transaction_hash", hashHex)
+
+	l.Info("Signing transaction.")
 
 	// Check that the transaction's source account and any operations it
 	// contains references only to this account.
 	if tx.SourceAccount().AccountID != req.Address.Address() {
+		l.Info("Transaction's source account is not the account.")
 		badRequest.Render(w)
 		return
 	}
@@ -125,6 +126,7 @@ func (h accountSignHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		if op.GetSourceAccount().GetAccountID() != req.Address.Address() {
+			l.Info("Operation's source account is not the account.")
 			badRequest.Render(w)
 			return
 		}
@@ -133,16 +135,19 @@ func (h accountSignHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Sign the transaction.
 	hash, err := tx.Hash(h.NetworkPassphrase)
 	if err != nil {
-		h.Logger.Error(err)
+		l.Error("Error hashing transaction:", err)
 		serverError.Render(w)
 		return
 	}
 	sig, err := h.SigningKey.SignBase64(hash[:])
 	if err != nil {
-		h.Logger.Error(err)
+		l.Error("Error signing transaction:", err)
 		serverError.Render(w)
 		return
 	}
+
+	l.Info("Transaction signed.")
+
 	resp := accountSignResponse{
 		Signer:            h.SigningKey.Address(),
 		Signature:         sig,

--- a/exp/services/recoverysigner/internal/serve/account_sign.go
+++ b/exp/services/recoverysigner/internal/serve/account_sign.go
@@ -116,7 +116,7 @@ func (h accountSignHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Check that the transaction's source account and any operations it
 	// contains references only to this account.
 	if tx.SourceAccount().AccountID != req.Address.Address() {
-		l.Info("Transaction's source account is not the account.")
+		l.Info("Transaction's source account is not the account in the request.")
 		badRequest.Render(w)
 		return
 	}

--- a/exp/services/recoverysigner/internal/serve/account_sign.go
+++ b/exp/services/recoverysigner/internal/serve/account_sign.go
@@ -98,7 +98,7 @@ func (h accountSignHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	tx, ok := parsed.Transaction()
 	if !ok {
-		l.Info("Transaction is not at transaction.")
+		l.Info("Transaction is not a simple transaction.")
 		badRequest.Render(w)
 		return
 	}

--- a/exp/services/recoverysigner/internal/serve/auth/sep10.go
+++ b/exp/services/recoverysigner/internal/serve/auth/sep10.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/support/http/httpauthz"
+	"github.com/stellar/go/support/log"
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
@@ -19,6 +20,11 @@ func SEP10Middleware(issuer string, k jose.JSONWebKey) func(http.Handler) http.H
 				ctx := r.Context()
 				auth, _ := FromContext(ctx)
 				auth.Address = address
+
+				log.Ctx(ctx).
+					WithField("address", address).
+					Info("SEP-10 JWT verified.")
+
 				ctx = NewContext(ctx, auth)
 				r = r.WithContext(ctx)
 			}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add basic logs for each action the service can perform that describe what's happening to help with identifying issues. Also fixes logs so that all existing logs carry the request ID and account ID for the current request.

### Why

This is a young service and we're likely to run into issues that we will need logs to help us debug.

Close #2358

### Known limitations

1. The logs don't give visibility into exactly which authentication methods have been validated which seems like a pretty important thing to log to me. That's going to take a bit of work to add because the application code doesn't interact with the database identifiers for each authentication method and so I need to do some refactoring to add that.

2. The logs might be a little verbose for a service that runs at scale, but I think in the early days this will help and we can always pare the logs back once we identify which are useful.

### Examples

These are some examples of what the logs look like:

#### Registering a new account

```
INFO[2020-05-07T13:43:42.385-07:00] starting request                              host="localhost:8001" ip="127.0.0.1:52854" method=POST path=/accounts/GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=47458 req=devenv-0/Ec2Vvw7LV3-000003 subsys=http
INFO[2020-05-07T13:43:42.386-07:00] Request to register account.                  account=GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=47458 req=devenv-0/Ec2Vvw7LV3-000003
INFO[2020-05-07T13:43:42.386-07:00] Request validation failed.                    account=GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=47458 req=devenv-0/Ec2Vvw7LV3-000003
INFO[2020-05-07T13:43:42.386-07:00] finished request                              bytes=53 duration=1.1468ms method=POST path=/accounts/GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=47458 req=devenv-0/Ec2Vvw7LV3-000003 status=400 subsys=http
```
```
INFO[2020-05-07T13:44:27.443-07:00] starting request                              host="localhost:8001" ip="127.0.0.1:52856" method=POST path=/accounts/GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=47458 req=devenv-0/Ec2Vvw7LV3-000004 subsys=http
INFO[2020-05-07T13:44:27.443-07:00] Request to register account.                  account=GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=47458 req=devenv-0/Ec2Vvw7LV3-000004
INFO[2020-05-07T13:44:27.461-07:00] Account registered.                           account=GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 auth_methods_count=1 identities_count=1 pid=47458 req=devenv-0/Ec2Vvw7LV3-000004
INFO[2020-05-07T13:44:27.461-07:00] finished request                              bytes=201 duration=18.3943ms method=POST path=/accounts/GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=47458 req=devenv-0/Ec2Vvw7LV3-000004 status=200 subsys=http
```

### Getting an account
```
INFO[2020-05-07T13:47:14.236-07:00] starting request                              host="localhost:8001" ip="127.0.0.1:52866" method=GET path=/accounts/GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=47458 req=devenv-0/Ec2Vvw7LV3-000006 subsys=http                                                                                                                                                    INFO[2020-05-07T13:47:14.236-07:00] Request to get account.                       account=GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=47458 req=devenv-0/Ec2Vvw7LV3-000006
INFO[2020-05-07T13:47:14.238-07:00] Authorized with self: false.                  account=GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=47458 req=devenv-0/Ec2Vvw7LV3-000006
INFO[2020-05-07T13:47:14.238-07:00] Authorized with stellar_address.              account=GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=47458 req=devenv-0/Ec2Vvw7LV3-000006
INFO[2020-05-07T13:47:14.238-07:00] Authorized: true.                             account=GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=47458 req=devenv-0/Ec2Vvw7LV3-000006
INFO[2020-05-07T13:47:14.238-07:00] Getting account.                              account=GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=47458 req=devenv-0/Ec2Vvw7LV3-000006
INFO[2020-05-07T13:47:14.238-07:00] finished request                              bytes=230 duration=2.1827ms method=GET path=/accounts/GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=47458 req=devenv-0/Ec2Vvw7LV3-000006 status=200 subsys=http
```

#### Signing a transaction
```
INFO[2020-05-07T13:54:12.637-07:00] starting request                              host="localhost:8001" ip="127.0.0.1:52902" method=POST path=/accounts/GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7/sign pid=53075 req=devenv-0/9Kzzm4wGyN-000004 subsys=http
INFO[2020-05-07T13:54:12.637-07:00] Request to sign transaction.                  account=GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=53075 req=devenv-0/9Kzzm4wGyN-000004
INFO[2020-05-07T13:54:12.640-07:00] Authorized with self: false.                  account=GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=53075 req=devenv-0/9Kzzm4wGyN-000004
INFO[2020-05-07T13:54:12.640-07:00] Authorized with stellar_address.              account=GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=53075 req=devenv-0/9Kzzm4wGyN-000004
INFO[2020-05-07T13:54:12.640-07:00] Authorized: true.                             account=GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=53075 req=devenv-0/9Kzzm4wGyN-000004
INFO[2020-05-07T13:54:12.641-07:00] Signing transaction.                          account=GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=53075 req=devenv-0/9Kzzm4wGyN-000004 transaction_hash=e4bf5d3d7bda23091b1691ee429f0384606c918d12b80d873dd7a74c4a04e605
INFO[2020-05-07T13:54:12.641-07:00] Transaction signed.                           account=GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7 pid=53075 req=devenv-0/9Kzzm4wGyN-000004 transaction_hash=e4bf5d3d7bda23091b1691ee429f0384606c918d12b80d873dd7a74c4a04e605
INFO[2020-05-07T13:54:12.641-07:00] finished request                              bytes=242 duration=3.837ms method=POST path=/accounts/GAOGUZ55OPA2M5LMU6TMC5H546XFRMAJB3JS6IFVQ4QMGDAKI3VL5QF7/sign pid=53075 req=devenv-0/9Kzzm4wGyN-000004 status=200 subsys=http
```