### PR TITLE
support/db: Add timeout on horizon db ingestion statements

### DIFF
--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -47,6 +47,8 @@ const (
 	// MaxDBConnections is the size of the postgres connection pool dedicated to Horizon ingestion
 	MaxDBConnections = 2
 
+	dbSessionTimeout = 20 * time.Second
+
 	defaultCoreCursorName           = "HORIZON"
 	stateVerificationErrorThreshold = 3
 )
@@ -146,6 +148,7 @@ func NewSystem(config Config) (*System, error) {
 
 	coreSession := config.CoreSession.Clone()
 	coreSession.Ctx = ctx
+	coreSession.Timeout = dbSessionTimeout
 
 	ledgerBackend, err := ledgerbackend.NewDatabaseBackendFromSession(coreSession)
 	if err != nil {
@@ -155,6 +158,7 @@ func NewSystem(config Config) (*System, error) {
 
 	historyQ := &history.Q{config.HistorySession.Clone()}
 	historyQ.Ctx = ctx
+	historyQ.Timeout = dbSessionTimeout
 
 	historyAdapter := adapters.MakeHistoryArchiveAdapter(archive)
 

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/jmoiron/sqlx"
@@ -100,6 +101,11 @@ type Session struct {
 
 	// Ctx is the context in which the repo is operating under.
 	Ctx context.Context
+
+	// Timeout is a timeout applied on all SQL Select queries and Exec statements.
+	// If Timeout is 0 then no timeout is applied. Note that the timeout is not
+	// applied on BEGIN, COMMIT, or ROLLBACK statements.
+	Timeout time.Duration
 
 	tx *sqlx.Tx
 }

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -65,8 +65,9 @@ func (s *Session) GetTx() *sqlx.Tx {
 // source is currently within.
 func (s *Session) Clone() *Session {
 	return &Session{
-		DB:  s.DB,
-		Ctx: s.Ctx,
+		DB:      s.DB,
+		Ctx:     s.Ctx,
+		Timeout: s.Timeout,
 	}
 }
 
@@ -120,6 +121,17 @@ func (s *Session) Get(dest interface{}, query sq.Sqlizer) error {
 	return s.GetRaw(dest, sql, args...)
 }
 
+func noop() {
+
+}
+
+func (s *Session) contextWithTimeout() (context.Context, context.CancelFunc) {
+	if s.Timeout == 0 {
+		return s.Ctx, noop
+	}
+	return context.WithTimeout(s.Ctx, s.Timeout)
+}
+
 // GetRaw runs `query` with `args`, setting the first result found on
 // `dest`, if any.
 func (s *Session) GetRaw(dest interface{}, query string, args ...interface{}) error {
@@ -129,7 +141,9 @@ func (s *Session) GetRaw(dest interface{}, query string, args ...interface{}) er
 	}
 
 	start := time.Now()
-	err = s.conn().GetContext(s.Ctx, dest, query, args...)
+	ctx, cancel := s.contextWithTimeout()
+	defer cancel()
+	err = s.conn().GetContext(ctx, dest, query, args...)
 	s.log("get", start, query, args)
 
 	if err == nil {
@@ -198,7 +212,9 @@ func (s *Session) ExecRaw(query string, args ...interface{}) (sql.Result, error)
 	}
 
 	start := time.Now()
-	result, err := s.conn().ExecContext(s.Ctx, query, args...)
+	ctx, cancel := s.contextWithTimeout()
+	defer cancel()
+	result, err := s.conn().ExecContext(ctx, query, args...)
 	s.log("exec", start, query, args)
 
 	if err == nil {
@@ -244,7 +260,9 @@ func (s *Session) QueryRaw(query string, args ...interface{}) (*sqlx.Rows, error
 	}
 
 	start := time.Now()
-	result, err := s.conn().QueryxContext(s.Ctx, query, args...)
+	ctx, cancel := s.contextWithTimeout()
+	defer cancel()
+	result, err := s.conn().QueryxContext(ctx, query, args...)
 	s.log("query", start, query, args)
 
 	if err == nil {
@@ -308,7 +326,9 @@ func (s *Session) SelectRaw(
 	}
 
 	start := time.Now()
-	err = s.conn().SelectContext(s.Ctx, dest, query, args...)
+	ctx, cancel := s.contextWithTimeout()
+	defer cancel()
+	err = s.conn().SelectContext(ctx, dest, query, args...)
 	s.log("select", start, query, args)
 
 	if err == nil {

--- a/support/db/session_test.go
+++ b/support/db/session_test.go
@@ -3,11 +3,24 @@ package db
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stellar/go/support/db/dbtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestClone(t *testing.T) {
+	session := &Session{Ctx: context.Background()}
+	sessionClone := session.Clone()
+	assert.Equal(t, time.Duration(0), sessionClone.Timeout)
+	assert.Equal(t, session.Ctx, sessionClone.Ctx)
+
+	session.Timeout = time.Second
+	sessionClone = session.Clone()
+	assert.Equal(t, session.Timeout, sessionClone.Timeout)
+	assert.Equal(t, session.Ctx, sessionClone.Ctx)
+}
 
 func TestSession(t *testing.T) {
 	db := dbtest.Postgres(t).Load(testSchema)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add timeout on horizon db select and exec operations.

### Why

Currently there is no timeout on any of the horizon DB operations. That means a postgres query which hangs indefinitely could block ingestion from progressing. 

### Known limitations

[N/A]
