### PR TITLE
txnbuild: Fix bug in parsing MangeData xdr operations

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+* Fix bug which occurs when parsing transactions with manage data operations containing nil values ([#2571](https://github.com/stellar/go/pull/2571))
+
 ## [v3.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v3.0.0) - 2020-04-28
 
 ### Breaking changes

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -5,7 +5,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-* Fix bug which occurs when parsing transactions with manage data operations containing nil values ([#2571](https://github.com/stellar/go/pull/2571))
+* Fix bug which occurs when parsing transactions with manage data operations containing nil values ([#2573](https://github.com/stellar/go/pull/2573))
 
 ## [v3.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v3.0.0) - 2020-04-28
 

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## [v3.0.1](https://github.com/stellar/go/releases/tag/horizonclient-v3.0.1) - 2020-05-11
 
 * Fix bug which occurs when parsing transactions with manage data operations containing nil values ([#2573](https://github.com/stellar/go/pull/2573))
 

--- a/txnbuild/manage_data.go
+++ b/txnbuild/manage_data.go
@@ -44,7 +44,11 @@ func (md *ManageData) FromXDR(xdrOp xdr.Operation) error {
 
 	md.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	md.Name = string(result.DataName)
-	md.Value = *result.DataValue
+	if result.DataValue != nil {
+		md.Value = *result.DataValue
+	} else {
+		md.Value = nil
+	}
 	return nil
 }
 

--- a/txnbuild/manage_data_test.go
+++ b/txnbuild/manage_data_test.go
@@ -53,3 +53,40 @@ func TestManageDataValidateValue(t *testing.T) {
 		assert.Contains(t, err.Error(), expected)
 	}
 }
+
+func TestManageDataNilValue(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(3556091187167235))
+
+	manageData := ManageData{
+		Name:  "key",
+		Value: nil,
+	}
+
+	tx, err := NewTransaction(
+		TransactionParams{
+			SourceAccount:        &sourceAccount,
+			IncrementSequenceNum: false,
+			Operations:           []Operation{&manageData},
+			BaseFee:              MinBaseFee,
+			Timebounds:           NewInfiniteTimeout(),
+		},
+	)
+	assert.NoError(t, err)
+
+	envelope, err := tx.TxEnvelope()
+	assert.NoError(t, err)
+	assert.Len(t, envelope.Operations(), 1)
+	assert.Nil(t, envelope.Operations()[0].Body.ManageDataOp.DataValue)
+
+	txe, err := tx.Base64()
+	if err != nil {
+		assert.NoError(t, err)
+	}
+
+	parsed, err := TransactionFromXDR(txe)
+	assert.NoError(t, err)
+
+	tx, _ = parsed.Transaction()
+	assert.Equal(t, []Operation{&manageData}, tx.Operations())
+}

--- a/txnbuild/manage_data_test.go
+++ b/txnbuild/manage_data_test.go
@@ -3,6 +3,7 @@ package txnbuild
 import (
 	"testing"
 
+	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -54,39 +55,74 @@ func TestManageDataValidateValue(t *testing.T) {
 	}
 }
 
-func TestManageDataNilValue(t *testing.T) {
+func TestManageDataRoundTrip(t *testing.T) {
 	kp0 := newKeypair0()
 	sourceAccount := NewSimpleAccount(kp0.Address(), int64(3556091187167235))
 
-	manageData := ManageData{
-		Name:  "key",
-		Value: nil,
-	}
-
-	tx, err := NewTransaction(
-		TransactionParams{
-			SourceAccount:        &sourceAccount,
-			IncrementSequenceNum: false,
-			Operations:           []Operation{&manageData},
-			BaseFee:              MinBaseFee,
-			Timebounds:           NewInfiniteTimeout(),
+	for _, testCase := range []struct {
+		name  string
+		value []byte
+	}{
+		{
+			"nil data",
+			nil,
 		},
-	)
-	assert.NoError(t, err)
+		{
+			"empty data slice",
+			[]byte{},
+		},
+		{
+			"non-empty data slice",
+			[]byte{1, 2, 3},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			manageData := ManageData{
+				Name:  "key",
+				Value: testCase.value,
+			}
 
-	envelope, err := tx.TxEnvelope()
-	assert.NoError(t, err)
-	assert.Len(t, envelope.Operations(), 1)
-	assert.Nil(t, envelope.Operations()[0].Body.ManageDataOp.DataValue)
+			tx, err := NewTransaction(
+				TransactionParams{
+					SourceAccount:        &sourceAccount,
+					IncrementSequenceNum: false,
+					Operations:           []Operation{&manageData},
+					BaseFee:              MinBaseFee,
+					Timebounds:           NewInfiniteTimeout(),
+				},
+			)
+			assert.NoError(t, err)
 
-	txe, err := tx.Base64()
-	if err != nil {
-		assert.NoError(t, err)
+			envelope, err := tx.TxEnvelope()
+			assert.NoError(t, err)
+			assert.Len(t, envelope.Operations(), 1)
+			assert.Equal(t, xdr.String64(manageData.Name), envelope.Operations()[0].Body.ManageDataOp.DataName)
+			if testCase.value == nil {
+				assert.Nil(t, envelope.Operations()[0].Body.ManageDataOp.DataValue)
+			} else {
+				assert.Len(t, []byte(*envelope.Operations()[0].Body.ManageDataOp.DataValue), len(testCase.value))
+				if len(testCase.value) > 0 {
+					assert.Equal(t, testCase.value, []byte(*envelope.Operations()[0].Body.ManageDataOp.DataValue))
+				}
+			}
+
+			txe, err := tx.Base64()
+			if err != nil {
+				assert.NoError(t, err)
+			}
+
+			parsed, err := TransactionFromXDR(txe)
+			assert.NoError(t, err)
+
+			tx, _ = parsed.Transaction()
+
+			assert.Len(t, tx.Operations(), 1)
+			op := tx.Operations()[0].(*ManageData)
+			assert.Equal(t, manageData.Name, op.Name)
+			assert.Len(t, op.Value, len(manageData.Value))
+			if len(manageData.Value) > 0 {
+				assert.Equal(t, manageData.Value, op.Value)
+			}
+		})
 	}
-
-	parsed, err := TransactionFromXDR(txe)
-	assert.NoError(t, err)
-
-	tx, _ = parsed.Transaction()
-	assert.Equal(t, []Operation{&manageData}, tx.Operations())
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Close https://github.com/stellar/go/issues/2572

Fix bug which occurs when parsing transactions with manage data operations containing nil values.

It seems like this bug has been present in older versions of txnbuild. I ran the following test case on versions 2.2.0, 2.1.0, 2.0.0, 1.50, and 1.4.0 and they all produced a panic similar to what's described in https://github.com/stellar/go/issues/2572:

```golang
func TestParseNil(t *testing.T) {
	op := ManageData{
		Name:  "key",
		Value: []byte(nil), // <<<<<<<<<<<<<<<<<<<<
	}
	tx := Transaction{
		SourceAccount: &SimpleAccount{AccountID: "GDYHQK7C2OMUMU3I6553YDQ56RUQL2JFL6FPYOYGLDKS3QGXDC4SRLOW"},
		Operations:    []Operation{&op},
		Timebounds:    NewInfiniteTimeout(),
		Network: network.TestNetworkPassphrase,
	}
	txe, err := tx.BuildSignEncode()
	assert.NoError(t, err)
	parsed, err := TransactionFromXDR(txe)
	assert.NoError(t, err)
	t.Log(parsed)
}
```

I checked if there were other potential nil dereferences in the txnbuild package by running this search:

```
Tamirs-MBP:go tamirsen$ grep "\*."  txnbuild/*.go | grep -v _test.go | grep -v func
txnbuild/manage_data.go:                md.Value = *result.DataValue
txnbuild/set_options.go:        InflationDestination *string
txnbuild/set_options.go:        MasterWeight         *Threshold
txnbuild/set_options.go:        LowThreshold         *Threshold
txnbuild/set_options.go:        MediumThreshold      *Threshold
txnbuild/set_options.go:        HighThreshold        *Threshold
txnbuild/set_options.go:        HomeDomain           *string
txnbuild/set_options.go:        Signer               *Signer
txnbuild/set_options.go:                err = xdrAccountID.SetAddress(*so.InflationDestination)
txnbuild/set_options.go:                        if f&AccountFlag(*flags) != 0 {
txnbuild/set_options.go:                        if f&AccountFlag(*flags) != 0 {
txnbuild/set_options.go:                xdrWeight := xdr.Uint32(*so.MasterWeight)
txnbuild/set_options.go:                mw := Threshold(uint32(*weight))
txnbuild/set_options.go:                xdrThreshold := xdr.Uint32(*so.LowThreshold)
txnbuild/set_options.go:                lt := Threshold(uint32(*weight))
txnbuild/set_options.go:                xdrThreshold := xdr.Uint32(*so.MediumThreshold)
txnbuild/set_options.go:                mt := Threshold(uint32(*weight))
txnbuild/set_options.go:                xdrThreshold := xdr.Uint32(*so.HighThreshold)
txnbuild/set_options.go:                ht := Threshold(uint32(*weight))
txnbuild/set_options.go:                if len(*so.HomeDomain) > 32 {
txnbuild/set_options.go:                xdrHomeDomain := xdr.String32(*so.HomeDomain)
txnbuild/set_options.go:                domain := string(*xDomain)
txnbuild/transaction.go:*/
txnbuild/transaction.go:        kps ...*keypair.Full,
txnbuild/transaction.go:        var signers []*keypair.Full
txnbuild/transaction.go:                kpf, ok := kp.(*keypair.Full)
txnbuild/transaction.go:        *newTx = *t
txnbuild/transaction.go:        *newTx = *t
txnbuild/transaction.go:        inner      *Transaction
txnbuild/transaction.go:        *newTx = *t
txnbuild/transaction.go:        *newTx = *t
txnbuild/transaction.go:        *innerCopy = *t.inner
txnbuild/transaction.go:        simple  *Transaction
txnbuild/transaction.go:        feeBump *FeeBumpTransaction
txnbuild/transaction.go:                var innerTx *GenericTransaction
txnbuild/transaction.go:        Inner      *Transaction
txnbuild/transaction.go:                maxFee:     params.BaseFee * int64(len(params.Inner.operations)+1),
txnbuild/transaction.go:        *tx.inner = *params.Inner
txnbuild/transaction.go:        tx, err = tx.Sign(network, serverKP.(*keypair.Full))
txnbuild/transaction.go:        op, ok := operations[0].(*ManageData)
```

Afterwards, I looked at all the cases in txnbuild/set_options.go. They seemed fine because the pointer derefrences were guarded by nil checks.
 
