### PR TITLE
services/horizon/docs: Remove `db backfill` command from admin guide

### DIFF
--- a/services/horizon/internal/docs/admin.md
+++ b/services/horizon/internal/docs/admin.md
@@ -99,10 +99,6 @@ Horizon provides most of its utility through ingested data.  Your Horizon server
 To enable ingestion, you must either pass `--ingest=true` on the command line or set the `INGEST`
 environment variable to "true". Since version 1.0.0 you can start multiple ingesting machines in your cluster.
 
-### Ingesting historical data
-
-To enable ingestion of historical data from stellar-core you need to run `horizon db backfill NUM_LEDGERS`. If you're running a full validator with published history archive, for example, you might want to ingest all of history. In this case your `NUM_LEDGERS` should be slightly higher than the current ledger id on the network. You can run this process in the background while your Horizon server is up. This continuously decrements the `history.elder_ledger` in your /metrics endpoint until `NUM_LEDGERS` is reached and the backfill is complete.
-
 ### Ingesting historical data and reingesting Ledgers
 
 To reingest older ledgers (due to a version upgrade) or to ingest ledgers closed by the network before you


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes #2561 

### Why

`horizon db backfill` doesn't exist anymore (it was removed in https://github.com/stellar/go/pull/2147 )

### Known limitations

N/A