### PR TITLE
txnbuild: add AddSignatureBase64 function

### DIFF
--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -76,7 +76,7 @@ func concatSignatures(
 	return extended, nil
 }
 
-func concatBase64Signature(e xdr.TransactionEnvelope, signatures []xdr.DecoratedSignature, networkStr, publicKey, signature string) ([]xdr.DecoratedSignature, error) {
+func concatSignatureBase64(e xdr.TransactionEnvelope, signatures []xdr.DecoratedSignature, networkStr, publicKey, signature string) ([]xdr.DecoratedSignature, error) {
 	if signature == "" {
 		return nil, errors.New("signature not presented")
 	}
@@ -302,7 +302,7 @@ func (t *Transaction) SignHashX(preimage []byte) (*Transaction, error) {
 // AddSignatureBase64 returns a new Transaction instance which extends the current instance
 // with an additional signature derived from the given base64-encoded signature.
 func (t *Transaction) AddSignatureBase64(network, publicKey, signature string) (*Transaction, error) {
-	extendedSignatures, err := concatBase64Signature(t.envelope, t.signatures, network, publicKey, signature)
+	extendedSignatures, err := concatSignatureBase64(t.envelope, t.signatures, network, publicKey, signature)
 	if err != nil {
 		return nil, err
 	}
@@ -415,7 +415,7 @@ func (t *FeeBumpTransaction) SignHashX(preimage []byte) (*FeeBumpTransaction, er
 // AddSignatureBase64 returns a new FeeBumpTransaction instance which extends the current instance
 // with an additional signature derived from the given base64-encoded signature.
 func (t *FeeBumpTransaction) AddSignatureBase64(network, publicKey, signature string) (*FeeBumpTransaction, error) {
-	extendedSignatures, err := concatBase64Signature(t.envelope, t.signatures, network, publicKey, signature)
+	extendedSignatures, err := concatSignatureBase64(t.envelope, t.signatures, network, publicKey, signature)
 	if err != nil {
 		return nil, err
 	}

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -76,6 +76,41 @@ func concatSignatures(
 	return extended, nil
 }
 
+func concatBase64Signature(e xdr.TransactionEnvelope, signatures []xdr.DecoratedSignature, networkStr, publicKey, signature string) ([]xdr.DecoratedSignature, error) {
+	if signature == "" {
+		return nil, errors.New("signature not presented")
+	}
+
+	kp, err := keypair.ParseAddress(publicKey)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse the public key %s", publicKey)
+	}
+
+	sigBytes, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to base64-decode the signature %s", signature)
+	}
+
+	h, err := network.HashTransactionInEnvelope(e, networkStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to hash transaction")
+	}
+
+	err = kp.Verify(h[:], sigBytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to verify the signature")
+	}
+
+	extended := make([]xdr.DecoratedSignature, len(signatures), len(signatures)+1)
+	copy(extended, signatures)
+	extended = append(extended, xdr.DecoratedSignature{
+		Hint:      xdr.SignatureHint(kp.Hint()),
+		Signature: xdr.Signature(sigBytes),
+	})
+
+	return extended, nil
+}
+
 func stringsToKP(keys ...string) ([]*keypair.Full, error) {
 	var signers []*keypair.Full
 	for _, k := range keys {
@@ -267,40 +302,14 @@ func (t *Transaction) SignHashX(preimage []byte) (*Transaction, error) {
 // AddSignatureBase64 returns a new Transaction instance which extends the current instance
 // with an additional signature derived from the given base64-encoded signature.
 func (t *Transaction) AddSignatureBase64(network, publicKey, signature string) (*Transaction, error) {
-	if signature == "" {
-		return nil, errors.New("signature not presented")
-	}
-
-	kp, err := keypair.ParseAddress(publicKey)
+	extendedSignatures, err := concatBase64Signature(t.envelope, t.signatures, network, publicKey, signature)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to parse the public key %s", publicKey)
+		return nil, err
 	}
-
-	sigBytes, err := base64.StdEncoding.DecodeString(signature)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to base64-decode the signature %s", signature)
-	}
-
-	txHash, err := t.Hash(network)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to hash the transaction")
-	}
-
-	err = kp.Verify(txHash[:], sigBytes)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to verify the signature")
-	}
-
-	extended := make([]xdr.DecoratedSignature, len(t.signatures), len(t.signatures)+1)
-	copy(extended, t.signatures)
-	extended = append(extended, xdr.DecoratedSignature{
-		Hint:      xdr.SignatureHint(kp.Hint()),
-		Signature: xdr.Signature(sigBytes),
-	})
 
 	newTx := new(Transaction)
 	*newTx = *t
-	newTx.signatures = extended
+	newTx.signatures = extendedSignatures
 	return newTx, nil
 }
 
@@ -365,7 +374,7 @@ func (t *FeeBumpTransaction) HashHex(network string) (string, error) {
 }
 
 // Sign returns a new FeeBumpTransaction instance which extends the current instance
-// with a additional signatures derived from the given list of keypair instances.
+// with additional signatures derived from the given list of keypair instances.
 func (t *FeeBumpTransaction) Sign(network string, kps ...*keypair.Full) (*FeeBumpTransaction, error) {
 	extendedSignatures, err := concatSignatures(t.envelope, network, t.signatures, kps...)
 	if err != nil {
@@ -379,7 +388,7 @@ func (t *FeeBumpTransaction) Sign(network string, kps ...*keypair.Full) (*FeeBum
 }
 
 // SignWithKeyString returns a new FeeBumpTransaction instance which extends the current instance
-// with a additional signatures derived from the given list of private key strings.
+// with additional signatures derived from the given list of private key strings.
 func (t *FeeBumpTransaction) SignWithKeyString(network string, keys ...string) (*FeeBumpTransaction, error) {
 	kps, err := stringsToKP(keys...)
 	if err != nil {
@@ -393,6 +402,20 @@ func (t *FeeBumpTransaction) SignWithKeyString(network string, keys ...string) (
 // See description here: https://www.stellar.org/developers/guides/concepts/multi-sig.html#hashx.
 func (t *FeeBumpTransaction) SignHashX(preimage []byte) (*FeeBumpTransaction, error) {
 	extendedSignatures, err := concatHashX(t.signatures, preimage)
+	if err != nil {
+		return nil, err
+	}
+
+	newTx := new(FeeBumpTransaction)
+	*newTx = *t
+	newTx.signatures = extendedSignatures
+	return newTx, nil
+}
+
+// AddSignatureBase64 returns a new FeeBumpTransaction instance which extends the current instance
+// with an additional signature derived from the given base64-encoded signature.
+func (t *FeeBumpTransaction) AddSignatureBase64(network, publicKey, signature string) (*FeeBumpTransaction, error) {
+	extendedSignatures, err := concatBase64Signature(t.envelope, t.signatures, network, publicKey, signature)
 	if err != nil {
 		return nil, err
 	}

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -226,7 +226,7 @@ func (t *Transaction) HashHex(network string) (string, error) {
 }
 
 // Sign returns a new Transaction instance which extends the current instance
-// with a additional signatures derived from the given list of keypair instances.
+// with additional signatures derived from the given list of keypair instances.
 func (t *Transaction) Sign(network string, kps ...*keypair.Full) (*Transaction, error) {
 	extendedSignatures, err := concatSignatures(t.envelope, network, t.signatures, kps...)
 	if err != nil {
@@ -240,7 +240,7 @@ func (t *Transaction) Sign(network string, kps ...*keypair.Full) (*Transaction, 
 }
 
 // SignWithKeyString returns a new Transaction instance which extends the current instance
-// with a additional signatures derived from the given list of private key strings.
+// with additional signatures derived from the given list of private key strings.
 func (t *Transaction) SignWithKeyString(network string, keys ...string) (*Transaction, error) {
 	kps, err := stringsToKP(keys...)
 	if err != nil {
@@ -261,6 +261,46 @@ func (t *Transaction) SignHashX(preimage []byte) (*Transaction, error) {
 	newTx := new(Transaction)
 	*newTx = *t
 	newTx.signatures = extendedSignatures
+	return newTx, nil
+}
+
+// AddSignatureBase64 returns a new Transaction instance which extends the current instance
+// with an additional signature derived from the given base64-encoded signature.
+func (t *Transaction) AddSignatureBase64(network, publicKey, signature string) (*Transaction, error) {
+	if signature == "" {
+		return nil, errors.New("signature not presented")
+	}
+
+	kp, err := keypair.ParseAddress(publicKey)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to parse the public key %s", publicKey)
+	}
+
+	sigBytes, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to base64-decode the signature %s", signature)
+	}
+
+	txHash, err := t.Hash(network)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to hash the transaction")
+	}
+
+	err = kp.Verify(txHash[:], sigBytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to verify the signature")
+	}
+
+	extended := make([]xdr.DecoratedSignature, len(t.signatures), len(t.signatures)+1)
+	copy(extended, t.signatures)
+	extended = append(extended, xdr.DecoratedSignature{
+		Hint:      xdr.SignatureHint(kp.Hint()),
+		Signature: xdr.Signature(sigBytes),
+	})
+
+	newTx := new(Transaction)
+	*newTx = *t
+	newTx.signatures = extended
 	return newTx, nil
 }
 

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1448,6 +1448,60 @@ func TestSignWithSecretKey(t *testing.T) {
 	assert.Equal(t, expected, actual, "base64 xdr should match")
 }
 
+func TestAddSignatureBase64(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	txSource := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
+	tx1Source := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
+	opSource := NewSimpleAccount(kp1.Address(), 0)
+	createAccount := CreateAccount{
+		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
+		Amount:        "10",
+		SourceAccount: &opSource,
+	}
+
+	expected, err := newSignedTransaction(
+		TransactionParams{
+			SourceAccount:        &txSource,
+			IncrementSequenceNum: true,
+			Operations:           []Operation{&createAccount},
+			BaseFee:              MinBaseFee,
+			Timebounds:           NewInfiniteTimeout(),
+		},
+		network.TestNetworkPassphrase,
+		kp0, kp1,
+	)
+	assert.NoError(t, err)
+
+	tx1, err := NewTransaction(
+		TransactionParams{
+			SourceAccount:        &tx1Source,
+			IncrementSequenceNum: true,
+			Operations:           []Operation{&createAccount},
+			BaseFee:              MinBaseFee,
+			Timebounds:           NewInfiniteTimeout(),
+		},
+	)
+	assert.NoError(t, err)
+
+	tx1, err = tx1.AddSignatureBase64(
+		network.TestNetworkPassphrase,
+		"GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3",
+		"TVogR6tbrWLnOc1BsP/j+Qrxpja2NWNgeRIwujECYscRdMG7AMtnb3dkCT7sqlbSM0TTzlRh7G+BcVocYBtqBw==",
+	)
+	assert.NoError(t, err)
+
+	tx1, err = tx1.AddSignatureBase64(
+		network.TestNetworkPassphrase,
+		"GAS4V4O2B7DW5T7IQRPEEVCRXMDZESKISR7DVIGKZQYYV3OSQ5SH5LVP",
+		"Iy77JteoW/FbeiuViZpgTyvrHP4BnBOeyVOjrdb5O/MpEMwcSlYXAkCBqPt4tBDil4jIcDDLhm7TsN6aUBkIBg==",
+	)
+
+	actual, err := tx1.Base64()
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual, "base64 xdr should match")
+}
+
 func TestReadChallengeTx_validSignedByServerAndClient(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR adds `AddSignatureBase64` function to both `Transaction` object and `FeeBumpTransaction` object.

### Why

In JS SDK, there is [addSignature](https://stellar.github.io/js-stellar-sdk/Transaction.html#addSignature) function to add a base64 signature to a transaction. However, there is nothing like this in Go SDK.

In SEP 30, the response of the sign [endpoint](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0030.md#post-accountsaddresssign) contains a signature in base64. It would be helpful if there is a function in txnbuild that adds a signature in base64 to the transaction.

### Known limitations

N/A

Close #2440 