### PR TITLE
services/horizon: Sort trustlines by asset code and issuer in `GET /acounts/{id}`

### DIFF
--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -39,7 +39,7 @@ func AccountInfo(ctx context.Context, hq *history.Q, addr string) (*protocol.Acc
 		return nil, errors.Wrap(err, "getting history signers")
 	}
 
-	trustlines, err = hq.GetTrustLinesByAccountID(addr)
+	trustlines, err = hq.GetSortedTrustLinesByAccountID(addr)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting history trustlines")
 	}

--- a/services/horizon/internal/db2/history/trust_lines.go
+++ b/services/horizon/internal/db2/history/trust_lines.go
@@ -32,11 +32,8 @@ func (q *Q) CountTrustLines() (int, error) {
 	return count, nil
 }
 
-func (q *Q) GetTrustLinesByAccountID(id string) ([]TrustLine, error) {
-	var trustLines []TrustLine
-	sql := selectTrustLines.Where(sq.Eq{"account_id": id})
-	err := q.Select(&trustLines, sql)
-	return trustLines, err
+func (q *Q) GetSortedTrustLinesByAccountID(id string) ([]TrustLine, error) {
+	return q.GetSortedTrustLinesByAccountIDs([]string{id})
 }
 
 // GetTrustLinesByKeys loads a row from the `trust_lines` table, selected by multiple keys.

--- a/services/horizon/internal/db2/history/trust_lines_test.go
+++ b/services/horizon/internal/db2/history/trust_lines_test.go
@@ -352,7 +352,7 @@ func TestGetTrustLinesByAccountID(t *testing.T) {
 	_, err := q.InsertTrustLine(eurTrustLine, 1234)
 	tt.Assert.NoError(err)
 
-	record, err := q.GetTrustLinesByAccountID(eurTrustLine.AccountId.Address())
+	record, err := q.GetSortedTrustLinesByAccountID(eurTrustLine.AccountId.Address())
 	tt.Assert.NoError(err)
 
 	asset := xdr.MustNewCreditAsset(record[0].AssetCode, record[0].AssetIssuer)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Followup from #2516 , Fixes #2447 

#2516 sorts the balances for `GET /accounts` but not `GET /accounts/{id}`. This PR ties the loop.

### Why

`horizon-cmp` outputs a large amount of false positives because of this, plus it's always a good idea to generate a stable output, independent of the Horizon server used.

### Known limitations

The DB query becomes slower. I pondered ordering it on the Horizon-side, but I figured a DB engine would be more efficient at this.
