### PR TITLE
services/horizon/internal: Move operations end-points to new actions architecture.

### DIFF
--- a/services/horizon/internal/actions.go
+++ b/services/horizon/internal/actions.go
@@ -52,12 +52,6 @@ func (action FeeStatsAction) Handle(w http.ResponseWriter, r *http.Request) {
 	ap.Execute(&action)
 }
 
-func (action OperationIndexAction) Handle(w http.ResponseWriter, r *http.Request) {
-	ap := &action.Action
-	ap.Prepare(w, r)
-	ap.Execute(&action)
-}
-
 func (action OperationShowAction) Handle(w http.ResponseWriter, r *http.Request) {
 	ap := &action.Action
 	ap.Prepare(w, r)

--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -904,3 +904,28 @@ func ValidateCursorWithinHistory(pq db2.PageQuery) error {
 
 	return nil
 }
+
+func countNonEmpty(params ...interface{}) (int, error) {
+	count := 0
+
+	for _, param := range params {
+		switch param := param.(type) {
+		default:
+			return 0, errors.Errorf("unexpected type %T", param)
+		case int32:
+			if param != int32(0) {
+				count++
+			}
+		case int64:
+			if param != int64(0) {
+				count++
+			}
+		case string:
+			if param != "" {
+				count++
+			}
+		}
+	}
+
+	return count, nil
+}

--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -867,3 +867,40 @@ func ValidateAssetParams(aType, code, issuer, prefix string) error {
 
 	return nil
 }
+
+// ValidateCursorWithinHistory compares the requested page of data against the
+// ledger state of the history database.  In the event that the cursor is
+// guaranteed to return no results, we return a 410 GONE http response.
+func ValidateCursorWithinHistory(pq db2.PageQuery) error {
+	// an ascending query should never return a gone response:  An ascending query
+	// prior to known history should return results at the beginning of history,
+	// and an ascending query beyond the end of history should not error out but
+	// rather return an empty page (allowing code that tracks the procession of
+	// some resource more easily).
+	if pq.Order != "desc" {
+		return nil
+	}
+
+	var cursor int64
+	var err error
+
+	// Checking for the presence of "-" to see whether we should use CursorInt64
+	// or CursorInt64Pair
+	if strings.Contains(pq.Cursor, "-") {
+		cursor, _, err = pq.CursorInt64Pair("-")
+	} else {
+		cursor, err = pq.CursorInt64()
+	}
+
+	if err != nil {
+		return problem.MakeInvalidFieldProblem("cursor", errors.New("invalid value"))
+	}
+
+	elder := toid.New(ledger.CurrentState().HistoryElder, 0, 0)
+
+	if cursor <= elder.ToInt64() {
+		return &hProblem.BeforeHistory
+	}
+
+	return nil
+}

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -122,18 +122,11 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 	case qp.TransactionHash != "":
 		query.ForTransaction(qp.TransactionHash)
 	}
-	if query.Err != nil {
-		return nil, query.Err
-	}
-
 	// When querying operations for transaction return both successful
 	// and failed operations. We assume that because the user is querying
 	// this specific transactions, they knows its status.
 	if qp.TransactionHash != "" || qp.IncludeFailedTransactions() {
 		query.IncludeFailed()
-		if query.Err != nil {
-			return nil, query.Err
-		}
 	}
 
 	if qp.IncludeTransactions() {

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"
+	"github.com/stellar/go/support/render/problem"
 )
 
 // OperationsQuery query struct for offers end-point
@@ -16,6 +18,24 @@ type OperationsQuery struct {
 	AccountID       string `schema:"account_id" valid:"accountID,optional"`
 	TransactionHash string `schema:"tx_id" valid:"transactionHash,optional"`
 	IncludeFailed   bool   `schema:"include_failed"`
+	LedgerID        string `schema:"ledger_id" valid:"ledgerID,optional"`
+}
+
+// Ledger returns the ledger id from the query parameter as an integer
+func (qp OperationsQuery) Ledger() (int32, error) {
+	if qp.LedgerID == "" {
+		return 0, nil
+	}
+
+	ledger, err := strconv.ParseInt(qp.LedgerID, 10, 32)
+	if err != nil {
+		return 0, problem.MakeInvalidFieldProblem(
+			"ledger_id",
+			errors.Wrapf(err, "invalid ledger_id"),
+		)
+	}
+
+	return int32(ledger), nil
 }
 
 // GetOperationsHandler is the action handler for all end-points returning a list of operations.
@@ -62,6 +82,17 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 	// this specific transactions, she knows it's status.
 	if qp.TransactionHash != "" || qp.IncludeFailed {
 		query.IncludeFailed()
+		if query.Err != nil {
+			return nil, query.Err
+		}
+	}
+
+	ledgerID, err := qp.Ledger()
+	if err != nil {
+		return nil, err
+	}
+	if ledgerID > 0 {
+		query.ForLedger(ledgerID)
 		if query.Err != nil {
 			return nil, query.Err
 		}

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -46,7 +46,8 @@ func (qp OperationsQuery) Ledger() (int32, error) {
 
 // GetOperationsHandler is the action handler for all end-points returning a list of operations.
 type GetOperationsHandler struct {
-	OnlyPayments bool
+	OnlyPayments                bool
+	IngestingFailedTransactions bool
 }
 
 // GetResourcePage returns a page of operations.
@@ -87,6 +88,12 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 		if query.Err != nil {
 			return nil, query.Err
 		}
+	}
+
+	if qp.IncludeFailed && !handler.IngestingFailedTransactions {
+		err := errors.New("`include_failed` parameter is unavailable when Horizon is not ingesting failed " +
+			"transactions. Set `INGEST_FAILED_TRANSACTIONS=true` to start ingesting them.")
+		return nil, problem.MakeInvalidFieldProblem("include_failed", err)
 	}
 
 	// When querying operations for transaction return both successful

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -24,7 +24,7 @@ type OperationsQuery struct {
 
 // IncludeTransactions returns extra fields to include in the response
 func (qp OperationsQuery) IncludeTransactions() bool {
-	return qp.Join != ""
+	return qp.Join == "transactions"
 }
 
 // IncludeFailedTransactions returns whether to include failed transactions or not

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -19,6 +19,12 @@ type OperationsQuery struct {
 	TransactionHash string `schema:"tx_id" valid:"transactionHash,optional"`
 	IncludeFailed   bool   `schema:"include_failed"`
 	LedgerID        string `schema:"ledger_id" valid:"ledgerID,optional"`
+	Join            string `schema:"join" valid:"in(transactions),optional"`
+}
+
+// IncludeTransactions returns true if the join parameter is specified
+func (qp OperationsQuery) IncludeTransactions() bool {
+	return qp.Join != ""
 }
 
 // Ledger returns the ledger id from the query parameter as an integer
@@ -93,6 +99,10 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 		}
 	}
 
+	if qp.IncludeTransactions() {
+		query.IncludeTransactions()
+	}
+
 	ledgerID, err := qp.Ledger()
 	if err != nil {
 		return nil, err
@@ -111,6 +121,10 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 	ops, txs, err := query.Page(pq).Fetch()
 	if err != nil {
 		return nil, err
+	}
+
+	if qp.IncludeTransactions() && len(ops) != len(txs) {
+		return nil, errors.New("number of transactions doesn't match number of operations")
 	}
 
 	// TODO: add test and run this check
@@ -140,10 +154,10 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 	// 		}
 	// 	}
 	// }
-	return buildOperationsPage(ctx, historyQ, ops, txs)
+	return buildOperationsPage(ctx, historyQ, ops, txs, qp.IncludeTransactions())
 }
 
-func buildOperationsPage(ctx context.Context, historyQ *history.Q, operations []history.Operation, transactions []history.Transaction) ([]hal.Pageable, error) {
+func buildOperationsPage(ctx context.Context, historyQ *history.Q, operations []history.Operation, transactions []history.Transaction, includeTransactions bool) ([]hal.Pageable, error) {
 	ledgerCache := history.LedgerCache{}
 	for _, record := range operations {
 		ledgerCache.Queue(record.LedgerSequence())
@@ -163,21 +177,15 @@ func buildOperationsPage(ctx context.Context, historyQ *history.Q, operations []
 
 		var transactionRecord *history.Transaction
 
-		// TODO: fix -- maybe we should pass down the query?
-		// if action.IncludeTransactions {
-		if false {
+		if includeTransactions {
 			transactionRecord = &transactions[i]
 		}
 
 		var res hal.Pageable
-		transactionHash := "" // this doesn't make sense -- if we  are using the query then all tx will belong to the tx hash action.TransactionFilter
-		if len(transactionHash) == 0 {
-			transactionHash = operationRecord.TransactionHash
-		}
 		res, err := resourceadapter.NewOperation(
 			ctx,
 			operationRecord,
-			transactionHash,
+			operationRecord.TransactionHash,
 			transactionRecord,
 			ledger,
 		)

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -13,7 +13,8 @@ import (
 
 // OperationsQuery query struct for offers end-point
 type OperationsQuery struct {
-	AccountID string `schema:"account_id" valid:"accountID,optional"`
+	AccountID       string `schema:"account_id" valid:"accountID,optional"`
+	TransactionHash string `schema:"tx_id" valid:"transactionHash,optional"`
 }
 
 // GetOperationsHandler is the action handler for all end-points returning a list of operations.
@@ -44,6 +45,15 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 
 	if qp.AccountID != "" {
 		query.ForAccount(qp.AccountID)
+		if query.Err != nil {
+			return nil, query.Err
+		}
+	}
+	if qp.TransactionHash != "" {
+		query.ForTransaction(qp.TransactionHash)
+		if query.Err != nil {
+			return nil, query.Err
+		}
 	}
 
 	ops, txs, err := query.Page(pq).Fetch()

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -49,6 +49,28 @@ func (qp OperationsQuery) Ledger() (int32, error) {
 	return int32(ledger), nil
 }
 
+// Validate runs extra validations on query parameters
+func (qp OperationsQuery) Validate() error {
+	filters, err := countNonEmpty(
+		qp.AccountID,
+		qp.LedgerID,
+		qp.TransactionHash,
+	)
+
+	if err != nil {
+		return &problem.BadRequest
+	}
+
+	if filters > 1 {
+		return problem.MakeInvalidFieldProblem(
+			"filters",
+			errors.New("Use a single filter for operations, you can't combine tx_id, account_id, and ledger_id"),
+		)
+	}
+
+	return nil
+}
+
 // GetOperationsHandler is the action handler for all end-points returning a list of operations.
 type GetOperationsHandler struct {
 	OnlyPayments                bool

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -46,14 +46,19 @@ type GetOperationsHandler struct {
 // GetResourcePage returns a page of operations.
 func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
 	ctx := r.Context()
-	qp := OperationsQuery{}
 
-	err := GetParams(&qp, r)
+	pq, err := GetPageQuery(r)
 	if err != nil {
 		return nil, err
 	}
 
-	pq, err := GetPageQuery(r)
+	err = ValidateCursorWithinHistory(pq)
+	if err != nil {
+		return nil, err
+	}
+
+	qp := OperationsQuery{}
+	err = GetParams(&qp, r)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -15,6 +15,7 @@ import (
 type OperationsQuery struct {
 	AccountID       string `schema:"account_id" valid:"accountID,optional"`
 	TransactionHash string `schema:"tx_id" valid:"transactionHash,optional"`
+	IncludeFailed   bool   `schema:"include_failed"`
 }
 
 // GetOperationsHandler is the action handler for all end-points returning a list of operations.
@@ -51,6 +52,16 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 	}
 	if qp.TransactionHash != "" {
 		query.ForTransaction(qp.TransactionHash)
+		if query.Err != nil {
+			return nil, query.Err
+		}
+	}
+
+	// When querying operations for transaction return both successful
+	// and failed operations. We assume that because user is querying
+	// this specific transactions, she knows it's status.
+	if qp.TransactionHash != "" || qp.IncludeFailed {
+		query.IncludeFailed()
 		if query.Err != nil {
 			return nil, query.Err
 		}

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -40,6 +40,7 @@ func (qp OperationsQuery) Ledger() (int32, error) {
 
 // GetOperationsHandler is the action handler for all end-points returning a list of operations.
 type GetOperationsHandler struct {
+	OnlyPayments bool
 }
 
 // GetResourcePage returns a page of operations.
@@ -78,8 +79,8 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 	}
 
 	// When querying operations for transaction return both successful
-	// and failed operations. We assume that because user is querying
-	// this specific transactions, she knows it's status.
+	// and failed operations. We assume that because the user is querying
+	// this specific transactions, they knows its status.
 	if qp.TransactionHash != "" || qp.IncludeFailed {
 		query.IncludeFailed()
 		if query.Err != nil {
@@ -96,6 +97,10 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 		if query.Err != nil {
 			return nil, query.Err
 		}
+	}
+
+	if handler.OnlyPayments {
+		query.OnlyPayments()
 	}
 
 	ops, txs, err := query.Page(pq).Fetch()

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -17,14 +17,19 @@ import (
 type OperationsQuery struct {
 	AccountID       string `schema:"account_id" valid:"accountID,optional"`
 	TransactionHash string `schema:"tx_id" valid:"transactionHash,optional"`
-	IncludeFailed   bool   `schema:"include_failed" valid:"-"`
+	IncludeFailed   string `schema:"include_failed" valid:"in(true|false)~Filter should be true or false,optional"`
 	LedgerID        string `schema:"ledger_id" valid:"ledgerID,optional"`
-	Join            string `schema:"join" valid:"in(transactions),optional"`
+	Join            string `schema:"join" valid:"in(transactions)~Accepted values: transactions,optional"`
 }
 
-// IncludeTransactions returns true if the join parameter is specified
+// IncludeTransactions returns extra fields to include in the response
 func (qp OperationsQuery) IncludeTransactions() bool {
 	return qp.Join != ""
+}
+
+// IncludeFailedTransactions returns whether to include failed transactions or not
+func (qp OperationsQuery) IncludeFailedTransactions() bool {
+	return qp.IncludeFailed == "true"
 }
 
 // Ledger returns the ledger id from the query parameter as an integer
@@ -90,7 +95,7 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 		}
 	}
 
-	if qp.IncludeFailed && !handler.IngestingFailedTransactions {
+	if qp.IncludeFailedTransactions() && !handler.IngestingFailedTransactions {
 		err = errors.New("`include_failed` parameter is unavailable when Horizon is not ingesting failed " +
 			"transactions. Set `INGEST_FAILED_TRANSACTIONS=true` to start ingesting them.")
 		return nil, problem.MakeInvalidFieldProblem("include_failed", err)
@@ -99,7 +104,7 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 	// When querying operations for transaction return both successful
 	// and failed operations. We assume that because the user is querying
 	// this specific transactions, they knows its status.
-	if qp.TransactionHash != "" || qp.IncludeFailed {
+	if qp.TransactionHash != "" || qp.IncludeFailedTransactions() {
 		query.IncludeFailed()
 		if query.Err != nil {
 			return nil, query.Err

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -91,7 +91,7 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 	}
 
 	if qp.IncludeFailed && !handler.IngestingFailedTransactions {
-		err := errors.New("`include_failed` parameter is unavailable when Horizon is not ingesting failed " +
+		err = errors.New("`include_failed` parameter is unavailable when Horizon is not ingesting failed " +
 			"transactions. Set `INGEST_FAILED_TRANSACTIONS=true` to start ingesting them.")
 		return nil, problem.MakeInvalidFieldProblem("include_failed", err)
 	}

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -17,7 +17,7 @@ import (
 type OperationsQuery struct {
 	AccountID       string `schema:"account_id" valid:"accountID,optional"`
 	TransactionHash string `schema:"tx_id" valid:"transactionHash,optional"`
-	IncludeFailed   bool   `schema:"include_failed"`
+	IncludeFailed   bool   `schema:"include_failed" valid:"-"`
 	LedgerID        string `schema:"ledger_id" valid:"ledgerID,optional"`
 	Join            string `schema:"join" valid:"in(transactions),optional"`
 }

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -123,37 +123,6 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 		return nil, err
 	}
 
-	if qp.IncludeTransactions() && len(ops) != len(txs) {
-		return nil, errors.New("number of transactions doesn't match number of operations")
-	}
-
-	// TODO: add test and run this check
-	// for i, o := range action.OperationRecords {
-	// 	if !action.IncludeFailed && action.TransactionFilter == "" {
-	// 		if !o.TransactionSuccessful {
-	// 			action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction in /operations is failed: %s", o.TransactionHash)
-	// 			return
-	// 		}
-
-	// 		var resultXDR xdr.TransactionResult
-	// 		action.Err = xdr.SafeUnmarshalBase64(o.TxResult, &resultXDR)
-	// 		if action.Err != nil {
-	// 			return
-	// 		}
-
-	// 		if !resultXDR.Successful() {
-	// 			action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction /operations is failed: %s %s", o.TransactionHash, o.TxResult)
-	// 			return
-	// 		}
-	// 	}
-	// 	if action.IncludeTransactions {
-	// 		transaction := action.TransactionRecords[i]
-	// 		action.Err = validateTransactionForOperation(transaction, o)
-	// 		if action.Err != nil {
-	// 			return
-	// 		}
-	// 	}
-	// }
 	return buildOperationsPage(ctx, historyQ, ops, txs, qp.IncludeTransactions())
 }
 

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -75,6 +75,12 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 		return nil, err
 	}
 
+	if qp.IncludeFailedTransactions() && !handler.IngestingFailedTransactions {
+		err = errors.New("`include_failed` parameter is unavailable when Horizon is not ingesting failed " +
+			"transactions. Set `INGEST_FAILED_TRANSACTIONS=true` to start ingesting them.")
+		return nil, problem.MakeInvalidFieldProblem("include_failed", err)
+	}
+
 	historyQ, err := HistoryQFromRequest(r)
 	if err != nil {
 		return nil, err
@@ -82,23 +88,20 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 
 	query := historyQ.Operations()
 
-	if qp.AccountID != "" {
+	ledgerID, err := qp.Ledger()
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case qp.AccountID != "":
 		query.ForAccount(qp.AccountID)
-		if query.Err != nil {
-			return nil, query.Err
-		}
-	}
-	if qp.TransactionHash != "" {
+	case ledgerID > 0:
+		query.ForLedger(ledgerID)
+	case qp.TransactionHash != "":
 		query.ForTransaction(qp.TransactionHash)
-		if query.Err != nil {
-			return nil, query.Err
-		}
 	}
-
-	if qp.IncludeFailedTransactions() && !handler.IngestingFailedTransactions {
-		err = errors.New("`include_failed` parameter is unavailable when Horizon is not ingesting failed " +
-			"transactions. Set `INGEST_FAILED_TRANSACTIONS=true` to start ingesting them.")
-		return nil, problem.MakeInvalidFieldProblem("include_failed", err)
+	if query.Err != nil {
+		return nil, query.Err
 	}
 
 	// When querying operations for transaction return both successful
@@ -113,17 +116,6 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 
 	if qp.IncludeTransactions() {
 		query.IncludeTransactions()
-	}
-
-	ledgerID, err := qp.Ledger()
-	if err != nil {
-		return nil, err
-	}
-	if ledgerID > 0 {
-		query.ForLedger(ledgerID)
-		if query.Err != nil {
-			return nil, query.Err
-		}
 	}
 
 	if handler.OnlyPayments {

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -1,0 +1,129 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/resourceadapter"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/render/hal"
+)
+
+// OperationsQuery query struct for offers end-point
+type OperationsQuery struct {
+	AccountID string `schema:"account_id" valid:"accountID,optional"`
+}
+
+// GetOperationsHandler is the action handler for all end-points returning a list of operations.
+type GetOperationsHandler struct {
+}
+
+// GetResourcePage returns a page of operations.
+func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
+	ctx := r.Context()
+	qp := OperationsQuery{}
+
+	err := GetParams(&qp, r)
+	if err != nil {
+		return nil, err
+	}
+
+	pq, err := GetPageQuery(r)
+	if err != nil {
+		return nil, err
+	}
+
+	historyQ, err := HistoryQFromRequest(r)
+	if err != nil {
+		return nil, err
+	}
+
+	query := historyQ.Operations()
+
+	if qp.AccountID != "" {
+		query.ForAccount(qp.AccountID)
+	}
+
+	ops, txs, err := query.Page(pq).Fetch()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: add test and run this check
+	// for i, o := range action.OperationRecords {
+	// 	if !action.IncludeFailed && action.TransactionFilter == "" {
+	// 		if !o.TransactionSuccessful {
+	// 			action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction in /operations is failed: %s", o.TransactionHash)
+	// 			return
+	// 		}
+
+	// 		var resultXDR xdr.TransactionResult
+	// 		action.Err = xdr.SafeUnmarshalBase64(o.TxResult, &resultXDR)
+	// 		if action.Err != nil {
+	// 			return
+	// 		}
+
+	// 		if !resultXDR.Successful() {
+	// 			action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction /operations is failed: %s %s", o.TransactionHash, o.TxResult)
+	// 			return
+	// 		}
+	// 	}
+	// 	if action.IncludeTransactions {
+	// 		transaction := action.TransactionRecords[i]
+	// 		action.Err = validateTransactionForOperation(transaction, o)
+	// 		if action.Err != nil {
+	// 			return
+	// 		}
+	// 	}
+	// }
+	return buildOperationsPage(ctx, historyQ, ops, txs)
+}
+
+func buildOperationsPage(ctx context.Context, historyQ *history.Q, operations []history.Operation, transactions []history.Transaction) ([]hal.Pageable, error) {
+	ledgerCache := history.LedgerCache{}
+	for _, record := range operations {
+		ledgerCache.Queue(record.LedgerSequence())
+	}
+
+	if err := ledgerCache.Load(historyQ); err != nil {
+		return nil, errors.Wrap(err, "failed to load ledger batch")
+	}
+
+	var response []hal.Pageable
+	for i, operationRecord := range operations {
+		ledger, found := ledgerCache.Records[operationRecord.LedgerSequence()]
+		if !found {
+			msg := fmt.Sprintf("could not find ledger data for sequence %d", operationRecord.LedgerSequence())
+			return nil, errors.New(msg)
+		}
+
+		var transactionRecord *history.Transaction
+
+		// TODO: fix -- maybe we should pass down the query?
+		// if action.IncludeTransactions {
+		if false {
+			transactionRecord = &transactions[i]
+		}
+
+		var res hal.Pageable
+		transactionHash := "" // this doesn't make sense -- if we  are using the query then all tx will belong to the tx hash action.TransactionFilter
+		if len(transactionHash) == 0 {
+			transactionHash = operationRecord.TransactionHash
+		}
+		res, err := resourceadapter.NewOperation(
+			ctx,
+			operationRecord,
+			transactionHash,
+			transactionRecord,
+			ledger,
+		)
+		if err != nil {
+			return nil, err
+		}
+		response = append(response, res)
+	}
+
+	return response, nil
+}

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/support/render/problem"
@@ -125,6 +126,127 @@ func TestGetOperationsFilterByTxID(t *testing.T) {
 	}
 }
 
+func TestGetOperationsIncludeFailed(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	tt.Scenario("failed_transactions")
+
+	q := &history.Q{tt.HorizonSession()}
+	handler := GetOperationsHandler{}
+
+	records, err := handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"limit": "200",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+
+	successful := 0
+	failed := 0
+
+	for _, record := range records {
+		op := record.(operations.Operation)
+		if op.IsTransactionSuccessful() {
+			successful++
+		} else {
+			failed++
+		}
+	}
+
+	tt.Assert.Equal(8, successful)
+	tt.Assert.Equal(0, failed)
+
+	records, err = handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"include_failed": "true",
+				"limit":          "200",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+
+	successful = 0
+	failed = 0
+
+	for _, record := range records {
+		op := record.(operations.Operation)
+		if op.IsTransactionSuccessful() {
+			successful++
+		} else {
+			failed++
+		}
+	}
+
+	tt.Assert.Equal(8, successful)
+	tt.Assert.Equal(1, failed)
+
+	records, err = handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"tx_id": "aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(records, 1)
+	for _, record := range records {
+		op := record.(operations.Operation)
+		tt.Assert.False(op.IsTransactionSuccessful())
+	}
+
+	records, err = handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"tx_id": "56e3216045d579bea40f2d35a09406de3a894ecb5be70dbda5ec9c0427a0d5a1",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(records, 1)
+	for _, record := range records {
+		op := record.(operations.Operation)
+		tt.Assert.True(op.IsTransactionSuccessful())
+	}
+
+	// NULL value
+	_, err = tt.HorizonSession().ExecRaw(
+		`UPDATE history_transactions SET successful = NULL WHERE transaction_hash = ?`,
+		"56e3216045d579bea40f2d35a09406de3a894ecb5be70dbda5ec9c0427a0d5a1",
+	)
+	tt.Assert.NoError(err)
+
+	records, err = handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"tx_id": "56e3216045d579bea40f2d35a09406de3a894ecb5be70dbda5ec9c0427a0d5a1",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(records, 1)
+	for _, record := range records {
+		op := record.(operations.Operation)
+		tt.Assert.True(op.IsTransactionSuccessful())
+	}
+
+	// TODO: Move this one level up, this should be concern of the action handler
+	// should failed if failed txs are not ingested
+	// if action.IncludeFailed && !action.App.config.IngestFailedTransactions {
+	// 	err := errors.New("`include_failed` parameter is unavailable when Horizon is not ingesting failed " +
+	// 		"transactions. Set `INGEST_FAILED_TRANSACTIONS=true` to start ingesting them.")
+	// 	action.Err = supportProblem.MakeInvalidFieldProblem("include_failed", err)
+	// 	return
+	// }
+}
+
 func TestGetOperations(t *testing.T) {
 	t.Run("Validates cursor as default", func(t *testing.T) {})
 	t.Run("Validates cursor within history", func(t *testing.T) {})
@@ -132,16 +254,6 @@ func TestGetOperations(t *testing.T) {
 	t.Run("EnsureHistoryFreshness", func(t *testing.T) {})
 	t.Run("No filter", func(t *testing.T) {})
 	t.Run("Pagination", func(t *testing.T) {})
-	t.Run("Included failed", func(t *testing.T) {
-		// should failed if failed txs are not ingested
-		// if action.IncludeFailed && !action.App.config.IngestFailedTransactions {
-		// 	err := errors.New("`include_failed` parameter is unavailable when Horizon is not ingesting failed " +
-		// 		"transactions. Set `INGEST_FAILED_TRANSACTIONS=true` to start ingesting them.")
-		// 	action.Err = supportProblem.MakeInvalidFieldProblem("include_failed", err)
-		// 	return
-		// }
-
-	})
 	t.Run("Filter by ledger_id", func(t *testing.T) {})
 	t.Run("With includes(join)", func(t *testing.T) {})
 	t.Run("Filter by payments only", func(t *testing.T) {})

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -31,6 +31,61 @@ func TestGetOperationsWithoutFilter(t *testing.T) {
 	tt.Assert.Len(records, 4)
 }
 
+func TestGetOperationsExclusiveFilters(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	tt.Scenario("base")
+
+	q := &history.Q{tt.HorizonSession()}
+	handler := GetOperationsHandler{IngestingFailedTransactions: true}
+
+	testCases := []struct {
+		desc  string
+		query map[string]string
+	}{
+		{
+			desc: "tx_id & ledger_id",
+			query: map[string]string{
+				"tx_id":     "1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc292",
+				"ledger_id": "1",
+			},
+		},
+		{
+			desc: "tx_id & account_id",
+			query: map[string]string{
+				"tx_id":      "1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc292",
+				"account_id": "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+			},
+		},
+		{
+			desc: "account_id & ledger_id",
+			query: map[string]string{
+				"account_id": "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+				"ledger_id":  "1",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, err := handler.GetResourcePage(
+				httptest.NewRecorder(),
+				makeRequest(
+					t, tc.query, map[string]string{}, q.Session,
+				),
+			)
+			tt.Assert.IsType(&problem.P{}, err)
+			p := err.(*problem.P)
+			tt.Assert.Equal("bad_request", p.Type)
+			tt.Assert.Equal("filters", p.Extras["invalid_field"])
+			tt.Assert.Equal(
+				"Use a single filter for operations, you can't combine tx_id, account_id, and ledger_id",
+				p.Extras["reason"],
+			)
+		})
+	}
+
+}
+
 func TestGetOperationsFilterByAccountID(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -1,0 +1,78 @@
+package actions
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/test"
+)
+
+func TestGetOperations(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	tt.Scenario("base")
+
+	q := &history.Q{tt.HorizonSession()}
+
+	handler := GetOperationsHandler{}
+
+	t.Run("Filter by account_id", func(t *testing.T) {
+		testCases := []struct {
+			accountID string
+			expected  int
+		}{
+			{
+				accountID: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+				expected:  3,
+			},
+			{
+				accountID: "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+				expected:  1,
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(fmt.Sprintf("%s operations", tc.accountID), func(t *testing.T) {
+				records, err := handler.GetResourcePage(
+					httptest.NewRecorder(),
+					makeRequest(
+						t, map[string]string{
+							"account_id": tc.accountID,
+						}, map[string]string{}, q.Session,
+					),
+				)
+				tt.Assert.NoError(err)
+				tt.Assert.Len(records, tc.expected)
+			})
+		}
+
+	})
+
+	t.Run("Validates cursor as default", func(t *testing.T) {})
+	t.Run("Validates cursor within history", func(t *testing.T) {})
+	// should this be a middleware?
+	t.Run("EnsureHistoryFreshness", func(t *testing.T) {})
+	t.Run("No filter", func(t *testing.T) {})
+	t.Run("Pagination", func(t *testing.T) {})
+	t.Run("Included failed", func(t *testing.T) {
+		// should failed if failed txs are not ingested
+		// if action.IncludeFailed && !action.App.config.IngestFailedTransactions {
+		// 	err := errors.New("`include_failed` parameter is unavailable when Horizon is not ingesting failed " +
+		// 		"transactions. Set `INGEST_FAILED_TRANSACTIONS=true` to start ingesting them.")
+		// 	action.Err = supportProblem.MakeInvalidFieldProblem("include_failed", err)
+		// 	return
+		// }
+
+	})
+	t.Run("Filter by ledger_id", func(t *testing.T) {})
+	t.Run("Filter by tx_id", func(t *testing.T) {
+		// validates transaction hash
+		// if action.TransactionFilter != "" && !isValidTransactionHash(action.TransactionFilter) {
+		// 	action.Err = supportProblem.MakeInvalidFieldProblem("tx_id", errors.New("Invalid transaction hash"))
+		// 	return
+
+	})
+	t.Run("With includes(join)", func(t *testing.T) {})
+	t.Run("Filter by payments only", func(t *testing.T) {})
+}

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -503,6 +503,58 @@ func TestGetOperationsPagination(t *testing.T) {
 	tt.Assert.EqualError(err, "problem: before_history")
 }
 
-func TestGetOperations(t *testing.T) {
-	t.Run("With includes(join)", func(t *testing.T) {})
+func TestGetOperations_IncludeTransactions(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	tt.Scenario("failed_transactions")
+
+	q := &history.Q{tt.HorizonSession()}
+	handler := GetOperationsHandler{}
+
+	_, err := handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"join": "accounts",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.Error(err)
+	tt.Assert.IsType(&problem.P{}, err)
+	p := err.(*problem.P)
+	tt.Assert.Equal("bad_request", p.Type)
+	tt.Assert.Equal("join", p.Extras["invalid_field"])
+	tt.Assert.Equal(
+		"accounts does not validate as in(transactions)",
+		p.Extras["reason"],
+	)
+
+	records, err := handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"join":  "transactions",
+				"limit": "1",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+	for _, record := range records {
+		op := record.(operations.CreateAccount)
+		tt.Assert.NotNil(op.Transaction)
+	}
+
+	records, err = handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"limit": "1",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+	for _, record := range records {
+		op := record.(operations.CreateAccount)
+		tt.Assert.Nil(op.Transaction)
+	}
 }

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -19,7 +19,7 @@ func TestGetOperationsWithoutFilter(t *testing.T) {
 	tt.Scenario("base")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{IngestingFailedTransactions: true}
 
 	records, err := handler.GetResourcePage(
 		httptest.NewRecorder(),
@@ -37,7 +37,7 @@ func TestGetOperationsFilterByAccountID(t *testing.T) {
 	tt.Scenario("base")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{IngestingFailedTransactions: true}
 
 	testCases := []struct {
 		accountID string
@@ -78,7 +78,7 @@ func TestGetOperationsFilterByTxID(t *testing.T) {
 	tt.Scenario("base")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{IngestingFailedTransactions: true}
 
 	testCases := []struct {
 		desc          string
@@ -152,7 +152,7 @@ func TestGetOperationsIncludeFailed(t *testing.T) {
 	tt.Scenario("failed_transactions")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{IngestingFailedTransactions: true}
 
 	records, err := handler.GetResourcePage(
 		httptest.NewRecorder(),
@@ -257,14 +257,27 @@ func TestGetOperationsIncludeFailed(t *testing.T) {
 		tt.Assert.True(op.IsTransactionSuccessful())
 	}
 
-	// TODO: Move this one level up, this should be concern of the action handler
-	// should failed if failed txs are not ingested
-	// if action.IncludeFailed && !action.App.config.IngestFailedTransactions {
-	// 	err := errors.New("`include_failed` parameter is unavailable when Horizon is not ingesting failed " +
-	// 		"transactions. Set `INGEST_FAILED_TRANSACTIONS=true` to start ingesting them.")
-	// 	action.Err = supportProblem.MakeInvalidFieldProblem("include_failed", err)
-	// 	return
-	// }
+	handler = GetOperationsHandler{
+		IngestingFailedTransactions: false,
+	}
+
+	_, err = handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"include_failed": "true",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.Error(err)
+	tt.Assert.IsType(&problem.P{}, err)
+	p := err.(*problem.P)
+	tt.Assert.Equal("bad_request", p.Type)
+	tt.Assert.Equal("include_failed", p.Extras["invalid_field"])
+	tt.Assert.Equal(
+		"`include_failed` parameter is unavailable when Horizon is not ingesting failed transactions. Set `INGEST_FAILED_TRANSACTIONS=true` to start ingesting them.",
+		p.Extras["reason"],
+	)
 }
 
 func TestGetOperationsFilterByLedgerID(t *testing.T) {
@@ -273,7 +286,7 @@ func TestGetOperationsFilterByLedgerID(t *testing.T) {
 	tt.Scenario("base")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{IngestingFailedTransactions: true}
 
 	testCases := []struct {
 		ledgerID    string
@@ -348,7 +361,8 @@ func TestGetOperationsOnlyPayments(t *testing.T) {
 
 	q := &history.Q{tt.HorizonSession()}
 	handler := GetOperationsHandler{
-		OnlyPayments: true,
+		IngestingFailedTransactions: true,
+		OnlyPayments:                true,
 	}
 
 	records, err := handler.GetResourcePage(
@@ -427,7 +441,7 @@ func TestOperation_CreatedAt(t *testing.T) {
 	tt.Scenario("base")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{IngestingFailedTransactions: true}
 
 	records, err := handler.GetResourcePage(
 		httptest.NewRecorder(),
@@ -452,7 +466,7 @@ func TestGetOperationsPagination(t *testing.T) {
 	tt.Scenario("base")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{IngestingFailedTransactions: true}
 
 	records, err := handler.GetResourcePage(
 		httptest.NewRecorder(),
@@ -509,7 +523,7 @@ func TestGetOperations_IncludeTransactions(t *testing.T) {
 	tt.Scenario("failed_transactions")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{IngestingFailedTransactions: true}
 
 	_, err := handler.GetResourcePage(
 		httptest.NewRecorder(),

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -504,7 +504,5 @@ func TestGetOperationsPagination(t *testing.T) {
 }
 
 func TestGetOperations(t *testing.T) {
-	// should this be a middleware?
-	t.Run("EnsureHistoryFreshness", func(t *testing.T) {})
 	t.Run("With includes(join)", func(t *testing.T) {})
 }

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -13,6 +13,24 @@ import (
 	"github.com/stellar/go/support/render/problem"
 )
 
+func TestGetOperationsWithoutFilter(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	tt.Scenario("base")
+
+	q := &history.Q{tt.HorizonSession()}
+	handler := GetOperationsHandler{}
+
+	records, err := handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(records, 4)
+}
+
 func TestGetOperationsFilterByAccountID(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
@@ -355,9 +373,7 @@ func TestGetOperations(t *testing.T) {
 	t.Run("Validates cursor within history", func(t *testing.T) {})
 	// should this be a middleware?
 	t.Run("EnsureHistoryFreshness", func(t *testing.T) {})
-	t.Run("No filter", func(t *testing.T) {})
 	t.Run("Pagination", func(t *testing.T) {})
-	t.Run("Filter by ledger_id", func(t *testing.T) {})
 	t.Run("With includes(join)", func(t *testing.T) {})
 	t.Run("Filter by payments only", func(t *testing.T) {})
 }

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -489,11 +489,22 @@ func TestGetOperationsPagination(t *testing.T) {
 	)
 	tt.Assert.NoError(err)
 	tt.Assert.Len(records, 3)
+
+	records, err = handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"order":  "desc",
+				"cursor": "0",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.Error(err)
+	tt.Assert.EqualError(err, "problem: before_history")
 }
 
 func TestGetOperations(t *testing.T) {
 	t.Run("Validates cursor as default", func(t *testing.T) {})
-	t.Run("Validates cursor within history", func(t *testing.T) {})
 	// should this be a middleware?
 	t.Run("EnsureHistoryFreshness", func(t *testing.T) {})
 	t.Run("With includes(join)", func(t *testing.T) {})

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -504,7 +504,6 @@ func TestGetOperationsPagination(t *testing.T) {
 }
 
 func TestGetOperations(t *testing.T) {
-	t.Run("Validates cursor as default", func(t *testing.T) {})
 	// should this be a middleware?
 	t.Run("EnsureHistoryFreshness", func(t *testing.T) {})
 	t.Run("With includes(join)", func(t *testing.T) {})

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -7,48 +7,125 @@ import (
 
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/support/render/problem"
 )
 
-func TestGetOperations(t *testing.T) {
+func TestGetOperationsFilterByAccountID(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
 	tt.Scenario("base")
 
 	q := &history.Q{tt.HorizonSession()}
-
 	handler := GetOperationsHandler{}
 
-	t.Run("Filter by account_id", func(t *testing.T) {
-		testCases := []struct {
-			accountID string
-			expected  int
-		}{
-			{
-				accountID: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
-				expected:  3,
-			},
-			{
-				accountID: "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
-				expected:  1,
-			},
-		}
-		for _, tc := range testCases {
-			t.Run(fmt.Sprintf("%s operations", tc.accountID), func(t *testing.T) {
-				records, err := handler.GetResourcePage(
-					httptest.NewRecorder(),
-					makeRequest(
-						t, map[string]string{
-							"account_id": tc.accountID,
-						}, map[string]string{}, q.Session,
-					),
-				)
+	testCases := []struct {
+		accountID string
+		expected  int
+	}{
+		{
+			accountID: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+			expected:  3,
+		},
+		{
+			accountID: "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+			expected:  1,
+		},
+		{
+			accountID: "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
+			expected:  2,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("account %s operations", tc.accountID), func(t *testing.T) {
+			records, err := handler.GetResourcePage(
+				httptest.NewRecorder(),
+				makeRequest(
+					t, map[string]string{
+						"account_id": tc.accountID,
+					}, map[string]string{}, q.Session,
+				),
+			)
+			tt.Assert.NoError(err)
+			tt.Assert.Len(records, tc.expected)
+		})
+	}
+}
+
+func TestGetOperationsFilterByTxID(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	tt.Scenario("base")
+
+	q := &history.Q{tt.HorizonSession()}
+	handler := GetOperationsHandler{}
+
+	testCases := []struct {
+		desc          string
+		transactionID string
+		expected      int
+		expectedErr   string
+		notFound      bool
+	}{
+		{
+			desc:          "operations for 2374...6d4d",
+			transactionID: "2374e99349b9ef7dba9a5db3339b78fda8f34777b1af33ba468ad5c0df946d4d",
+			expected:      1,
+		},
+		{
+			desc:          "operations for 164a...33b6",
+			transactionID: "164a5064eba64f2cdbadb856bf3448485fc626247ada3ed39cddf0f6902133b6",
+			expected:      1,
+		},
+		{
+			desc:          "missing transaction",
+			transactionID: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			expectedErr:   "sql: no rows in result set",
+			notFound:      true,
+		},
+		{
+			desc:          "uppercase tx hash not accepted",
+			transactionID: "2374E99349B9EF7DBA9A5DB3339B78FDA8F34777B1AF33BA468AD5C0DF946D4D",
+			expectedErr:   "Transaction hash must be a hex-encoded, lowercase SHA-256 hash",
+		},
+		{
+			desc:          "badly formated tx hash not accepted",
+			transactionID: "%00%1E4%5E%EF%BF%BD%EF%BF%BD%EF%BF%BDpVP%EF%BF%BDI&R%0BK%EF%BF%BD%1D%EF%BF%BD%EF%BF%BD=%EF%BF%BD%3F%23%EF%BF%BD%EF%BF%BDl%EF%BF%BD%1El%EF%BF%BD%EF%BF%BD",
+			expectedErr:   "Transaction hash must be a hex-encoded, lowercase SHA-256 hash",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf(tc.transactionID), func(t *testing.T) {
+			records, err := handler.GetResourcePage(
+				httptest.NewRecorder(),
+				makeRequest(
+					t, map[string]string{
+						"tx_id": tc.transactionID,
+					}, map[string]string{}, q.Session,
+				),
+			)
+
+			if tc.expectedErr == "" {
 				tt.Assert.NoError(err)
 				tt.Assert.Len(records, tc.expected)
-			})
-		}
+			} else {
+				if tc.notFound {
+					tt.Assert.EqualError(err, tc.expectedErr)
+				} else {
+					tt.Assert.IsType(&problem.P{}, err)
+					p := err.(*problem.P)
+					tt.Assert.Equal("bad_request", p.Type)
+					tt.Assert.Equal("tx_id", p.Extras["invalid_field"])
+					tt.Assert.Equal(
+						tc.expectedErr,
+						p.Extras["reason"],
+					)
+				}
+			}
+		})
+	}
+}
 
-	})
-
+func TestGetOperations(t *testing.T) {
 	t.Run("Validates cursor as default", func(t *testing.T) {})
 	t.Run("Validates cursor within history", func(t *testing.T) {})
 	// should this be a middleware?
@@ -66,13 +143,6 @@ func TestGetOperations(t *testing.T) {
 
 	})
 	t.Run("Filter by ledger_id", func(t *testing.T) {})
-	t.Run("Filter by tx_id", func(t *testing.T) {
-		// validates transaction hash
-		// if action.TransactionFilter != "" && !isValidTransactionHash(action.TransactionFilter) {
-		// 	action.Err = supportProblem.MakeInvalidFieldProblem("tx_id", errors.New("Invalid transaction hash"))
-		// 	return
-
-	})
 	t.Run("With includes(join)", func(t *testing.T) {})
 	t.Run("Filter by payments only", func(t *testing.T) {})
 }

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -257,6 +257,24 @@ func TestGetOperationsIncludeFailed(t *testing.T) {
 		tt.Assert.True(op.IsTransactionSuccessful())
 	}
 
+	_, err = handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"include_failed": "1",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.Error(err)
+	tt.Assert.IsType(&problem.P{}, err)
+	p := err.(*problem.P)
+	tt.Assert.Equal("bad_request", p.Type)
+	tt.Assert.Equal("include_failed", p.Extras["invalid_field"])
+	tt.Assert.Equal(
+		"Filter should be true or false",
+		p.Extras["reason"],
+	)
+
 	handler = GetOperationsHandler{
 		IngestingFailedTransactions: false,
 	}
@@ -271,7 +289,7 @@ func TestGetOperationsIncludeFailed(t *testing.T) {
 	)
 	tt.Assert.Error(err)
 	tt.Assert.IsType(&problem.P{}, err)
-	p := err.(*problem.P)
+	p = err.(*problem.P)
 	tt.Assert.Equal("bad_request", p.Type)
 	tt.Assert.Equal("include_failed", p.Extras["invalid_field"])
 	tt.Assert.Equal(
@@ -539,7 +557,7 @@ func TestGetOperations_IncludeTransactions(t *testing.T) {
 	tt.Assert.Equal("bad_request", p.Type)
 	tt.Assert.Equal("join", p.Extras["invalid_field"])
 	tt.Assert.Equal(
-		"accounts does not validate as in(transactions)",
+		"Accepted values: transactions",
 		p.Extras["reason"],
 	)
 

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -341,6 +341,85 @@ func TestGetOperationsFilterByLedgerID(t *testing.T) {
 		})
 	}
 }
+func TestGetOperationsOnlyPayments(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	tt.Scenario("base")
+
+	q := &history.Q{tt.HorizonSession()}
+	handler := GetOperationsHandler{
+		OnlyPayments: true,
+	}
+
+	records, err := handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(records, 4)
+
+	records, err = handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"ledger_id": "1",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(records, 0)
+
+	records, err = handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"ledger_id": "3",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(records, 1)
+
+	records, err = handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"account_id": "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(records, 1)
+
+	tt.Scenario("pathed_payment")
+
+	records, err = handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"tx_id": "b52f16ffb98c047e33b9c2ec30880330cde71f85b3443dae2c5cb86c7d4d8452",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(records, 0)
+
+	records, err = handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"tx_id": "1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc292",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(records, 1)
+
+	record := records[0].(operations.PathPayment)
+	tt.Assert.Equal("10.0000000", record.SourceAmount)
+}
 
 func TestOperation_CreatedAt(t *testing.T) {
 	tt := test.Start(t)
@@ -375,5 +454,7 @@ func TestGetOperations(t *testing.T) {
 	t.Run("EnsureHistoryFreshness", func(t *testing.T) {})
 	t.Run("Pagination", func(t *testing.T) {})
 	t.Run("With includes(join)", func(t *testing.T) {})
-	t.Run("Filter by payments only", func(t *testing.T) {})
+	// // Regression: negative cursor
+	// w = ht.Get("/accounts/GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2/payments?cursor=-23667108046966785&order=asc&limit=100")
+	// ht.Assert.Equal(400, w.Code)
 }

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -446,15 +446,55 @@ func TestOperation_CreatedAt(t *testing.T) {
 
 	tt.Assert.WithinDuration(l.ClosedAt, record.LedgerCloseTime, 1*time.Second)
 }
+func TestGetOperationsPagination(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	tt.Scenario("base")
+
+	q := &history.Q{tt.HorizonSession()}
+	handler := GetOperationsHandler{}
+
+	records, err := handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"order": "asc",
+				"limit": "1",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(records, 1)
+
+	descRecords, err := handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"limit": "1",
+				"order": "desc",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+	tt.Assert.NotEqual(records, descRecords)
+
+	records, err = handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"order":  "desc",
+				"cursor": "12884905985",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(records, 3)
+}
 
 func TestGetOperations(t *testing.T) {
 	t.Run("Validates cursor as default", func(t *testing.T) {})
 	t.Run("Validates cursor within history", func(t *testing.T) {})
 	// should this be a middleware?
 	t.Run("EnsureHistoryFreshness", func(t *testing.T) {})
-	t.Run("Pagination", func(t *testing.T) {})
 	t.Run("With includes(join)", func(t *testing.T) {})
-	// // Regression: negative cursor
-	// w = ht.Get("/accounts/GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2/payments?cursor=-23667108046966785&order=asc&limit=100")
-	// ht.Assert.Equal(400, w.Code)
 }

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -3,7 +3,9 @@ package actions
 import (
 	"fmt"
 	"net/http/httptest"
+
 	"testing"
+	"time"
 
 	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -95,7 +97,7 @@ func TestGetOperationsFilterByTxID(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf(tc.transactionID), func(t *testing.T) {
+		t.Run(fmt.Sprintf(tc.desc), func(t *testing.T) {
 			records, err := handler.GetResourcePage(
 				httptest.NewRecorder(),
 				makeRequest(
@@ -245,6 +247,107 @@ func TestGetOperationsIncludeFailed(t *testing.T) {
 	// 	action.Err = supportProblem.MakeInvalidFieldProblem("include_failed", err)
 	// 	return
 	// }
+}
+
+func TestGetOperationsFilterByLedgerID(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	tt.Scenario("base")
+
+	q := &history.Q{tt.HorizonSession()}
+	handler := GetOperationsHandler{}
+
+	testCases := []struct {
+		ledgerID    string
+		expected    int
+		expectedErr string
+		notFound    bool
+	}{
+		{
+			ledgerID: "1",
+			expected: 0,
+		},
+		{
+			ledgerID: "2",
+			expected: 3,
+		},
+		{
+			ledgerID: "3",
+			expected: 1,
+		},
+		{
+			ledgerID:    "10000",
+			expectedErr: "sql: no rows in result set",
+			notFound:    true,
+		},
+		{
+			ledgerID:    "0",
+			expectedErr: "Ledger ID must be higher than 0",
+		},
+		{
+			ledgerID:    "-1",
+			expectedErr: "Ledger ID must be higher than 0",
+		},
+		{
+			ledgerID:    "one",
+			expectedErr: "Ledger ID must be higher than 0",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("ledger %s operations", tc.ledgerID), func(t *testing.T) {
+			records, err := handler.GetResourcePage(
+				httptest.NewRecorder(),
+				makeRequest(
+					t, map[string]string{
+						"ledger_id": tc.ledgerID,
+					}, map[string]string{}, q.Session,
+				),
+			)
+			if tc.expectedErr == "" {
+				tt.Assert.NoError(err)
+				tt.Assert.Len(records, tc.expected)
+			} else {
+				if tc.notFound {
+					tt.Assert.EqualError(err, tc.expectedErr)
+				} else {
+					tt.Assert.IsType(&problem.P{}, err)
+					p := err.(*problem.P)
+					tt.Assert.Equal("bad_request", p.Type)
+					tt.Assert.Equal("ledger_id", p.Extras["invalid_field"])
+					tt.Assert.Equal(
+						tc.expectedErr,
+						p.Extras["reason"],
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestOperation_CreatedAt(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	tt.Scenario("base")
+
+	q := &history.Q{tt.HorizonSession()}
+	handler := GetOperationsHandler{}
+
+	records, err := handler.GetResourcePage(
+		httptest.NewRecorder(),
+		makeRequest(
+			t, map[string]string{
+				"ledger_id": "3",
+			}, map[string]string{}, q.Session,
+		),
+	)
+	tt.Assert.NoError(err)
+
+	l := history.Ledger{}
+	tt.Assert.NoError(q.LedgerBySequence(&l, 3))
+
+	record := records[0].(operations.Payment)
+
+	tt.Assert.WithinDuration(l.ClosedAt, record.LedgerCloseTime, 1*time.Second)
 }
 
 func TestGetOperations(t *testing.T) {

--- a/services/horizon/internal/actions/validators.go
+++ b/services/horizon/internal/actions/validators.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"encoding/hex"
 	"strings"
 
 	"github.com/asaskevich/govalidator"
@@ -20,13 +21,15 @@ func init() {
 	govalidator.TagMap["amount"] = govalidator.Validator(isAmount)
 	govalidator.TagMap["assetType"] = govalidator.Validator(isAssetType)
 	govalidator.TagMap["asset"] = govalidator.Validator(isAsset)
+	govalidator.TagMap["transactionHash"] = govalidator.Validator(isTransactionHash)
 }
 
 var customTagsErrorMessages = map[string]string{
-	"accountID": "Account ID must start with `G` and contain 56 alphanum characters",
-	"amount":    "Amount must be positive",
-	"asset":     "Asset must be the string \"native\" or a string of the form \"Code:IssuerAccountID\" for issued assets.",
-	"assetType": "Asset type must be native, credit_alphanum4 or credit_alphanum12",
+	"accountID":       "Account ID must start with `G` and contain 56 alphanum characters",
+	"amount":          "Amount must be positive",
+	"asset":           "Asset must be the string \"native\" or a string of the form \"Code:IssuerAccountID\" for issued assets.",
+	"assetType":       "Asset type must be native, credit_alphanum4 or credit_alphanum12",
+	"transactionHash": "Transaction hash must be a hex-encoded, lowercase SHA-256 hash",
 }
 
 // isAsset validates if string contains a valid SEP11 asset
@@ -101,6 +104,15 @@ func isAccountID(str string) bool {
 	}
 
 	return true
+}
+
+func isTransactionHash(str string) bool {
+	decoded, err := hex.DecodeString(str)
+	if err != nil {
+		return false
+	}
+
+	return len(decoded) == 32 && strings.ToLower(str) == str
 }
 
 func isAmount(str string) bool {

--- a/services/horizon/internal/actions/validators.go
+++ b/services/horizon/internal/actions/validators.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"encoding/hex"
+	"strconv"
 	"strings"
 
 	"github.com/asaskevich/govalidator"
@@ -21,6 +22,7 @@ func init() {
 	govalidator.TagMap["amount"] = govalidator.Validator(isAmount)
 	govalidator.TagMap["assetType"] = govalidator.Validator(isAssetType)
 	govalidator.TagMap["asset"] = govalidator.Validator(isAsset)
+	govalidator.TagMap["ledgerID"] = govalidator.Validator(isLedgerID)
 	govalidator.TagMap["transactionHash"] = govalidator.Validator(isTransactionHash)
 }
 
@@ -29,6 +31,7 @@ var customTagsErrorMessages = map[string]string{
 	"amount":          "Amount must be positive",
 	"asset":           "Asset must be the string \"native\" or a string of the form \"Code:IssuerAccountID\" for issued assets.",
 	"assetType":       "Asset type must be native, credit_alphanum4 or credit_alphanum12",
+	"ledgerID":        "Ledger ID must be higher than 0",
 	"transactionHash": "Transaction hash must be a hex-encoded, lowercase SHA-256 hash",
 }
 
@@ -117,6 +120,18 @@ func isTransactionHash(str string) bool {
 
 func isAmount(str string) bool {
 	parsed, err := amount.Parse(str)
+	switch {
+	case err != nil:
+		return false
+	case parsed <= 0:
+		return false
+	}
+
+	return true
+}
+
+func isLedgerID(str string) bool {
+	parsed, err := strconv.ParseInt(str, 10, 32)
 	switch {
 	case err != nil:
 		return false

--- a/services/horizon/internal/actions/validators_test.go
+++ b/services/horizon/internal/actions/validators_test.go
@@ -211,3 +211,52 @@ func TestAmountValidator(t *testing.T) {
 		})
 	}
 }
+
+func TestTransactionHashValidator(t *testing.T) {
+	type Query struct {
+		TransactionHash string `valid:"transactionHash,optional"`
+	}
+
+	for _, testCase := range []struct {
+		name          string
+		value         string
+		expectedError string
+	}{
+		{
+			"uppercase hash",
+			"2374E99349B9EF7DBA9A5DB3339B78FDA8F34777B1AF33BA468AD5C0DF946D4D",
+			"TransactionHash: 2374E99349B9EF7DBA9A5DB3339B78FDA8F34777B1AF33BA468AD5C0DF946D4D does not validate as transactionHash",
+		},
+		{
+			"badly formated tx hash",
+			"%00%1E4%5E%EF%BF%BD%EF%BF%BD%EF%BF%BDpVP%EF%BF%BDI&R%0BK%EF%BF%BD%1D%EF%BF%BD%EF%BF%BD=%EF%BF%BD%3F%23%EF%BF%BD%EF%BF%BDl%EF%BF%BD%1El%EF%BF%BD%EF%BF%BD",
+			"TransactionHash: %00%1E4%5E%EF%BF%BD%EF%BF%BD%EF%BF%BDpVP%EF%BF%BDI&R%0BK%EF%BF%BD%1D%EF%BF%BD%EF%BF%BD=%EF%BF%BD%3F%23%EF%BF%BD%EF%BF%BDl%EF%BF%BD%1El%EF%BF%BD%EF%BF%BD does not validate as transactionHash",
+		},
+		{
+			"valid tx hash",
+			"2374e99349b9ef7dba9a5db3339b78fda8f34777b1af33ba468ad5c0df946d4d",
+			"",
+		},
+		{
+			"empty transaction hash should not be validated",
+			"",
+			"",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			tt := assert.New(t)
+
+			q := Query{
+				TransactionHash: testCase.value,
+			}
+
+			result, err := govalidator.ValidateStruct(q)
+			if testCase.expectedError == "" {
+				tt.NoError(err)
+				tt.True(result)
+			} else {
+				tt.Equal(testCase.expectedError, err.Error())
+			}
+		})
+	}
+}

--- a/services/horizon/internal/actions/validators_test.go
+++ b/services/horizon/internal/actions/validators_test.go
@@ -272,3 +272,48 @@ func TestTransactionHashValidator(t *testing.T) {
 		})
 	}
 }
+
+func TestLedgerIDValidator(t *testing.T) {
+	type Query struct {
+		LedgerID string `valid:"ledgerID,optional"`
+	}
+
+	for _, testCase := range []struct {
+		value string
+		valid bool
+	}{
+		{
+			"10",
+			true,
+		},
+		{
+			"0",
+			false,
+		},
+		{
+			"-1",
+			false,
+		},
+		{
+			"one",
+			false,
+		},
+	} {
+		t.Run(fmt.Sprintf("value: %s", testCase.value), func(t *testing.T) {
+			tt := assert.New(t)
+
+			q := Query{
+				LedgerID: testCase.value,
+			}
+
+			result, err := govalidator.ValidateStruct(q)
+			if testCase.valid {
+				tt.NoError(err)
+				tt.True(result)
+			} else {
+				expected := fmt.Sprintf("LedgerID: %s does not validate as ledgerID", testCase.value)
+				tt.Equal(expected, err.Error())
+			}
+		})
+	}
+}

--- a/services/horizon/internal/actions/validators_test.go
+++ b/services/horizon/internal/actions/validators_test.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/asaskevich/govalidator"
@@ -218,29 +219,39 @@ func TestTransactionHashValidator(t *testing.T) {
 	}
 
 	for _, testCase := range []struct {
-		name          string
-		value         string
-		expectedError string
+		name  string
+		value string
+		valid bool
 	}{
+		{
+			"length 63",
+			"1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc29",
+			false,
+		},
+		{
+			"length 66",
+			"1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc29222",
+			false,
+		},
 		{
 			"uppercase hash",
 			"2374E99349B9EF7DBA9A5DB3339B78FDA8F34777B1AF33BA468AD5C0DF946D4D",
-			"TransactionHash: 2374E99349B9EF7DBA9A5DB3339B78FDA8F34777B1AF33BA468AD5C0DF946D4D does not validate as transactionHash",
+			false,
 		},
 		{
 			"badly formated tx hash",
 			"%00%1E4%5E%EF%BF%BD%EF%BF%BD%EF%BF%BDpVP%EF%BF%BDI&R%0BK%EF%BF%BD%1D%EF%BF%BD%EF%BF%BD=%EF%BF%BD%3F%23%EF%BF%BD%EF%BF%BDl%EF%BF%BD%1El%EF%BF%BD%EF%BF%BD",
-			"TransactionHash: %00%1E4%5E%EF%BF%BD%EF%BF%BD%EF%BF%BDpVP%EF%BF%BDI&R%0BK%EF%BF%BD%1D%EF%BF%BD%EF%BF%BD=%EF%BF%BD%3F%23%EF%BF%BD%EF%BF%BDl%EF%BF%BD%1El%EF%BF%BD%EF%BF%BD does not validate as transactionHash",
+			false,
 		},
 		{
 			"valid tx hash",
 			"2374e99349b9ef7dba9a5db3339b78fda8f34777b1af33ba468ad5c0df946d4d",
-			"",
+			true,
 		},
 		{
 			"empty transaction hash should not be validated",
 			"",
-			"",
+			true,
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -251,11 +262,12 @@ func TestTransactionHashValidator(t *testing.T) {
 			}
 
 			result, err := govalidator.ValidateStruct(q)
-			if testCase.expectedError == "" {
+			if testCase.valid {
 				tt.NoError(err)
 				tt.True(result)
 			} else {
-				tt.Equal(testCase.expectedError, err.Error())
+				expected := fmt.Sprintf("TransactionHash: %s does not validate as transactionHash", testCase.value)
+				tt.Equal(expected, err.Error())
 			}
 		})
 	}

--- a/services/horizon/internal/actions/validators_test.go
+++ b/services/horizon/internal/actions/validators_test.go
@@ -253,6 +253,11 @@ func TestTransactionHashValidator(t *testing.T) {
 			"",
 			true,
 		},
+		{
+			"0x prefixed hash",
+			"0x2374e99349b9ef7dba9a5db3339b78fda8f34777b1af33ba468ad5c0df946d4d",
+			false,
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			tt := assert.New(t)

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -5,119 +5,19 @@ import (
 	"strings"
 
 	"github.com/stellar/go/services/horizon/internal/actions"
-	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/render/problem"
-	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 	"github.com/stellar/go/services/horizon/internal/toid"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"
 	supportProblem "github.com/stellar/go/support/render/problem"
-	"github.com/stellar/go/xdr"
 )
-
-// This file contains the actions:
-//
-// OperationIndexAction: pages of operations
-// OperationShowAction: single operation by id
-
-// Interface verifications
-var _ actions.JSONer = (*OperationIndexAction)(nil)
-var _ actions.EventStreamer = (*OperationIndexAction)(nil)
 
 const (
 	joinTransactions = "transactions"
 )
-
-// OperationIndexAction renders a page of operations resources, identified by
-// a normal page query and optionally filtered by an account, ledger, or
-// transaction.
-type OperationIndexAction struct {
-	Action
-	LedgerFilter        int32
-	AccountFilter       string
-	TransactionFilter   string
-	PagingParams        db2.PageQuery
-	OperationRecords    []history.Operation
-	TransactionRecords  []history.Transaction
-	Ledgers             *history.LedgerCache
-	Page                hal.Page
-	IncludeFailed       bool
-	IncludeTransactions bool
-	OnlyPayments        bool
-}
-
-// JSON is a method for actions.JSON
-func (action *OperationIndexAction) JSON() error {
-	action.Do(
-		action.EnsureHistoryFreshness, // replaced by checkHistoryStaleMiddleware.
-		action.loadParams,             // the following steps are done in the action handler
-		action.ValidateCursorWithinHistory,
-		action.loadRecords,
-		action.loadLedgers,
-		action.loadPage,
-		func() { hal.Render(action.W, action.Page) },
-	)
-	return action.Err
-}
-
-// SSE is a method for actions.SSE - TODO (move to action handler)
-func (action *OperationIndexAction) SSE(stream *sse.Stream) error {
-	action.Setup(
-		action.EnsureHistoryFreshness,
-		action.loadParams,
-		action.ValidateCursorWithinHistory,
-	)
-	action.Do(
-		action.loadRecords,
-		action.loadLedgers,
-		func() {
-			stream.SetLimit(int(action.PagingParams.Limit))
-			operationRecords := action.OperationRecords[stream.SentCount():]
-			var transactionRecords []history.Transaction
-			if action.IncludeTransactions {
-				transactionRecords = action.TransactionRecords[stream.SentCount():]
-			}
-			for i, operationRecord := range operationRecords {
-				ledger, found := action.Ledgers.Records[operationRecord.LedgerSequence()]
-				if !found {
-					action.Err = errors.New(fmt.Sprintf("could not find ledger data for sequence %d", operationRecord.LedgerSequence()))
-					return
-				}
-
-				var transactionRecord *history.Transaction
-				if action.IncludeTransactions {
-					transactionRecord = &transactionRecords[i]
-				}
-
-				transactionHash := action.TransactionFilter
-				if len(transactionHash) == 0 {
-					transactionHash = operationRecord.TransactionHash
-				}
-				res, err := resourceadapter.NewOperation(
-					action.R.Context(),
-					operationRecord,
-					transactionHash,
-					transactionRecord,
-					ledger,
-				)
-				if err != nil {
-					action.Err = err
-					return
-				}
-
-				stream.Send(sse.Event{
-					ID:   res.PagingToken(),
-					Data: res,
-				})
-			}
-		},
-	)
-
-	return action.Err
-}
 
 func parseJoinField(action *actions.Base) (map[string]bool, error) {
 	join := action.GetString("join")
@@ -135,55 +35,6 @@ func parseJoinField(action *actions.Base) (map[string]bool, error) {
 		}
 	}
 	return validJoins, nil
-}
-
-func (action *OperationIndexAction) loadParams() {
-	action.ValidateCursorAsDefault()
-	action.AccountFilter = action.GetAddress("account_id")
-	action.LedgerFilter = action.GetInt32("ledger_id")
-	var err error
-	action.TransactionFilter, err = actions.GetTransactionID(action.R, "tx_id")
-	if err != nil {
-		action.Err = err
-		return
-	}
-	action.PagingParams = action.GetPageQuery()
-	action.IncludeFailed = action.GetBool("include_failed")
-	parsed, err := parseJoinField(&action.Action.Base)
-	if err != nil {
-		action.Err = err
-		return
-	}
-	action.IncludeTransactions = parsed[joinTransactions]
-
-	filters, err := countNonEmpty(
-		action.AccountFilter,
-		action.LedgerFilter,
-		action.TransactionFilter,
-	)
-
-	if err != nil {
-		action.Err = errors.Wrap(err, "Error in countNonEmpty")
-		return
-	}
-
-	if filters > 1 {
-		action.Err = supportProblem.BadRequest
-		return
-	}
-
-	// Double check TransactionFilter as it's used to determine if failed txs should be returned
-	if action.TransactionFilter != "" && !isValidTransactionHash(action.TransactionFilter) {
-		action.Err = supportProblem.MakeInvalidFieldProblem("tx_id", errors.New("Invalid transaction hash"))
-		return
-	}
-
-	if action.IncludeFailed && !action.App.config.IngestFailedTransactions {
-		err := errors.New("`include_failed` parameter is unavailable when Horizon is not ingesting failed " +
-			"transactions. Set `INGEST_FAILED_TRANSACTIONS=true` to start ingesting them.")
-		action.Err = supportProblem.MakeInvalidFieldProblem("include_failed", err)
-		return
-	}
 }
 
 // This check has been moved to history/operation with unit test
@@ -218,123 +69,6 @@ func validateTransactionForOperation(transaction history.Transaction, operation 
 	}
 
 	return nil
-}
-
-func (action *OperationIndexAction) loadRecords() {
-	q := action.HistoryQ()
-	ops := q.Operations()
-
-	switch {
-	case action.AccountFilter != "":
-		ops.ForAccount(action.AccountFilter)
-	case action.LedgerFilter > 0:
-		ops.ForLedger(action.LedgerFilter)
-	case action.TransactionFilter != "":
-		ops.ForTransaction(action.TransactionFilter)
-	}
-
-	// When querying operations for transaction return both successful
-	// and failed operations. We assume that because user is querying
-	// this specific transactions, she knows it's status.
-	if action.TransactionFilter != "" || action.IncludeFailed {
-		ops.IncludeFailed()
-	}
-
-	if action.IncludeTransactions {
-		ops.IncludeTransactions()
-	}
-
-	if action.OnlyPayments {
-		ops.OnlyPayments()
-	}
-
-	action.OperationRecords, action.TransactionRecords, action.Err = ops.Page(action.PagingParams).Fetch()
-	if action.Err != nil {
-		return
-	}
-
-	// this check won't be reached if there are missing txs Fetch will fail if
-	// it can't find a tx for one of the operations in the result set
-	if action.IncludeTransactions && len(action.TransactionRecords) != len(action.OperationRecords) {
-		action.Err = errors.New("number of transactions doesn't match number of operations")
-		return
-	}
-
-	// This check for corrupted data is done already when loading the operations
-	for i, o := range action.OperationRecords {
-		if !action.IncludeFailed && action.TransactionFilter == "" {
-			if !o.TransactionSuccessful {
-				action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction in /operations is failed: %s", o.TransactionHash)
-				return
-			}
-
-			var resultXDR xdr.TransactionResult
-			action.Err = xdr.SafeUnmarshalBase64(o.TxResult, &resultXDR)
-			if action.Err != nil {
-				return
-			}
-
-			if !resultXDR.Successful() {
-				action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction /operations is failed: %s %s", o.TransactionHash, o.TxResult)
-				return
-			}
-		}
-		if action.IncludeTransactions {
-			transaction := action.TransactionRecords[i]
-			action.Err = validateTransactionForOperation(transaction, o)
-			if action.Err != nil {
-				return
-			}
-		}
-	}
-}
-
-// loadLedgers populates the ledger cache for this action
-func (action *OperationIndexAction) loadLedgers() {
-	action.Ledgers = &history.LedgerCache{}
-	for _, op := range action.OperationRecords {
-		action.Ledgers.Queue(op.LedgerSequence())
-	}
-	action.Err = action.Ledgers.Load(action.HistoryQ())
-}
-
-func (action *OperationIndexAction) loadPage() {
-	for i, operationRecord := range action.OperationRecords {
-		ledger, found := action.Ledgers.Records[operationRecord.LedgerSequence()]
-		if !found {
-			msg := fmt.Sprintf("could not find ledger data for sequence %d", operationRecord.LedgerSequence())
-			action.Err = errors.New(msg)
-			return
-		}
-
-		var transactionRecord *history.Transaction
-		if action.IncludeTransactions {
-			transactionRecord = &action.TransactionRecords[i]
-		}
-
-		var res hal.Pageable
-		transactionHash := action.TransactionFilter
-		if len(transactionHash) == 0 {
-			transactionHash = operationRecord.TransactionHash
-		}
-		res, action.Err = resourceadapter.NewOperation(
-			action.R.Context(),
-			operationRecord,
-			transactionHash,
-			transactionRecord,
-			ledger,
-		)
-		if action.Err != nil {
-			return
-		}
-		action.Page.Add(res)
-	}
-
-	action.Page.FullURL = action.FullURL()
-	action.Page.Limit = action.PagingParams.Limit
-	action.Page.Cursor = action.PagingParams.Cursor
-	action.Page.Order = action.PagingParams.Order
-	action.Page.PopulateLinks()
 }
 
 // Interface verification

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -110,8 +110,7 @@ func (action *OperationIndexAction) SSE(stream *sse.Stream) error {
 
 				stream.Send(sse.Event{
 					ID:   res.PagingToken(),
-					Data: re
-					s,
+					Data: res,
 				})
 			}
 		},
@@ -261,8 +260,8 @@ func (action *OperationIndexAction) loadRecords() {
 		return
 	}
 
+	// This check for corrupted data is done already when loading the operations
 	for i, o := range action.OperationRecords {
-		// This check for corrupted data is done already when loading the operations
 		if !action.IncludeFailed && action.TransactionFilter == "" {
 			if !o.TransactionSuccessful {
 				action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction in /operations is failed: %s", o.TransactionHash)

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -187,10 +187,7 @@ func (action *OperationIndexAction) loadParams() {
 	}
 }
 
-// Maybe I'm missing something but I don't think this test makes sense, since
-// when we fetch operations we pull the transaction details for both tx and op
-// from the same table. Also the ID can't be different since we do some
-// validation while fetching the txs
+// This check has been moved to history/operation with unit test
 func validateTransactionForOperation(transaction history.Transaction, operation history.Operation) error {
 	if transaction.ID != operation.TransactionID {
 		return errors.Errorf(
@@ -265,6 +262,7 @@ func (action *OperationIndexAction) loadRecords() {
 	}
 
 	for i, o := range action.OperationRecords {
+		// This check for corrupted data is done already when loading the operations
 		if !action.IncludeFailed && action.TransactionFilter == "" {
 			if !o.TransactionSuccessful {
 				action.Err = errors.Errorf("Corrupted data! `include_failed=false` but returned transaction in /operations is failed: %s", o.TransactionHash)

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -187,6 +187,10 @@ func (action *OperationIndexAction) loadParams() {
 	}
 }
 
+// Maybe I'm missing something but I don't think this test makes sense, since
+// when we fetch operations we pull the transaction details for both tx and op
+// from the same table. Also the ID can't be different since we do some
+// validation while fetching the txs
 func validateTransactionForOperation(transaction history.Transaction, operation history.Operation) error {
 	if transaction.ID != operation.TransactionID {
 		return errors.Errorf(
@@ -253,12 +257,13 @@ func (action *OperationIndexAction) loadRecords() {
 		return
 	}
 
+	// this check won't be reached if there are missing txs Fetch will fail if
+	// it can't find a tx for one of the operations in the result set
 	if action.IncludeTransactions && len(action.TransactionRecords) != len(action.OperationRecords) {
 		action.Err = errors.New("number of transactions doesn't match number of operations")
 		return
 	}
 
-	// TODO: migrate this to new actions handler
 	for i, o := range action.OperationRecords {
 		if !action.IncludeFailed && action.TransactionFilter == "" {
 			if !o.TransactionSuccessful {

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -110,7 +110,8 @@ func (action *OperationIndexAction) SSE(stream *sse.Stream) error {
 
 				stream.Send(sse.Event{
 					ID:   res.PagingToken(),
-					Data: res,
+					Data: re
+					s,
 				})
 			}
 		},

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -52,8 +52,8 @@ type OperationIndexAction struct {
 // JSON is a method for actions.JSON
 func (action *OperationIndexAction) JSON() error {
 	action.Do(
-		action.EnsureHistoryFreshness,
-		action.loadParams,
+		action.EnsureHistoryFreshness, // replaced by checkHistoryStaleMiddleware.
+		action.loadParams,             // the following steps are done in the action handler
 		action.ValidateCursorWithinHistory,
 		action.loadRecords,
 		action.loadLedgers,
@@ -63,7 +63,7 @@ func (action *OperationIndexAction) JSON() error {
 	return action.Err
 }
 
-// SSE is a method for actions.SSE
+// SSE is a method for actions.SSE - TODO (move to action handler)
 func (action *OperationIndexAction) SSE(stream *sse.Stream) error {
 	action.Setup(
 		action.EnsureHistoryFreshness,

--- a/services/horizon/internal/actions_operation.go
+++ b/services/horizon/internal/actions_operation.go
@@ -257,6 +257,7 @@ func (action *OperationIndexAction) loadRecords() {
 		return
 	}
 
+	// TODO: migrate this to new actions handler
 	for i, o := range action.OperationRecords {
 		if !action.IncludeFailed && action.TransactionFilter == "" {
 			if !o.TransactionSuccessful {

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -42,6 +42,8 @@ func TestOperationActions_Index(t *testing.T) {
 		ht.Assert.PageOf(1, w.Body)
 	}
 
+	// =============================
+	// Moved to TestGetOperationsFilterByAccountID
 	// filtered by account
 	w = ht.Get("/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H/operations")
 	if ht.Assert.Equal(200, w.Code) {
@@ -57,7 +59,10 @@ func TestOperationActions_Index(t *testing.T) {
 	if ht.Assert.Equal(200, w.Code) {
 		ht.Assert.PageOf(2, w.Body)
 	}
+	// =============================
 
+	// =============================
+	// Moved to TestGetOperationsFilterByTxID
 	// filtered by transaction
 	w = ht.Get("/transactions/2374e99349b9ef7dba9a5db3339b78fda8f34777b1af33ba468ad5c0df946d4d/operations")
 	if ht.Assert.Equal(200, w.Code) {
@@ -77,6 +82,7 @@ func TestOperationActions_Index(t *testing.T) {
 	if ht.Assert.Equal(200, w.Code) {
 		ht.Assert.PageOf(1, w.Body)
 	}
+	// =============================
 
 	// 400 for invalid tx hash
 	w = ht.Get("/transactions/ /operations")
@@ -85,9 +91,11 @@ func TestOperationActions_Index(t *testing.T) {
 	w = ht.Get("/transactions/invalid/operations")
 	ht.Assert.Equal(400, w.Code)
 
+	// Moved to query param validator
 	w = ht.Get("/transactions/1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc29/operations")
 	ht.Assert.Equal(400, w.Code)
 
+	// Moved to query param validator
 	w = ht.Get("/transactions/1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc29222/operations")
 	ht.Assert.Equal(400, w.Code)
 

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -20,15 +19,12 @@ func TestOperationActions_Index(t *testing.T) {
 	ht := StartHTTPTest(t, "base")
 	defer ht.Finish()
 
-	// Moved to TestGetOperationsWithoutFilter
 	// no filter
 	w := ht.Get("/operations")
 	if ht.Assert.Equal(200, w.Code) {
 		ht.Assert.PageOf(4, w.Body)
 	}
 
-	// =============================
-	// Moved to TestGetOperationsFilterByLedgerID
 	// filtered by ledger sequence
 	w = ht.Get("/ledgers/1/operations")
 	if ht.Assert.Equal(200, w.Code) {
@@ -44,10 +40,7 @@ func TestOperationActions_Index(t *testing.T) {
 	if ht.Assert.Equal(200, w.Code) {
 		ht.Assert.PageOf(1, w.Body)
 	}
-	// =============================
 
-	// =============================
-	// Moved to TestGetOperationsFilterByAccountID
 	// filtered by account
 	w = ht.Get("/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H/operations")
 	if ht.Assert.Equal(200, w.Code) {
@@ -63,49 +56,31 @@ func TestOperationActions_Index(t *testing.T) {
 	if ht.Assert.Equal(200, w.Code) {
 		ht.Assert.PageOf(2, w.Body)
 	}
-	// =============================
 
-	// =============================
-	// Moved to TestGetOperationsFilterByTxID
 	// filtered by transaction
 	w = ht.Get("/transactions/2374e99349b9ef7dba9a5db3339b78fda8f34777b1af33ba468ad5c0df946d4d/operations")
 	if ht.Assert.Equal(200, w.Code) {
 		ht.Assert.PageOf(1, w.Body)
 	}
-	// missing tx
-	w = ht.Get("/transactions/ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff/operations")
-	ht.Assert.Equal(404, w.Code)
-	// uppercase tx hash not accepted
-	w = ht.Get("/transactions/2374E99349B9EF7DBA9A5DB3339B78FDA8F34777B1AF33BA468AD5C0DF946D4D/operations")
-	ht.Assert.Equal(400, w.Code)
-	// badly formated tx hash not accepted
-	w = ht.Get("/transactions/%00%1E4%5E%EF%BF%BD%EF%BF%BD%EF%BF%BDpVP%EF%BF%BDI&R%0BK%EF%BF%BD%1D%EF%BF%BD%EF%BF%BD=%EF%BF%BD%3F%23%EF%BF%BD%EF%BF%BDl%EF%BF%BD%1El%EF%BF%BD%EF%BF%BD/operations")
-	ht.Assert.Equal(400, w.Code)
 
 	w = ht.Get("/transactions/164a5064eba64f2cdbadb856bf3448485fc626247ada3ed39cddf0f6902133b6/operations")
 	if ht.Assert.Equal(200, w.Code) {
 		ht.Assert.PageOf(1, w.Body)
 	}
-	// =============================
 
-	// TODO
 	// 400 for invalid tx hash
 	w = ht.Get("/transactions/ /operations")
 	ht.Assert.Equal(400, w.Code)
 
-	// TODO
 	w = ht.Get("/transactions/invalid/operations")
 	ht.Assert.Equal(400, w.Code)
 
-	// Moved to query param validator
 	w = ht.Get("/transactions/1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc29/operations")
 	ht.Assert.Equal(400, w.Code)
 
-	// Moved to query param validator
 	w = ht.Get("/transactions/1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc29222/operations")
 	ht.Assert.Equal(400, w.Code)
 
-	// Done in TestGetOperationsFilterByLedgerID
 	// filtered by ledger
 	w = ht.Get("/ledgers/3/operations")
 	if ht.Assert.Equal(200, w.Code) {
@@ -113,12 +88,10 @@ func TestOperationActions_Index(t *testing.T) {
 	}
 
 	// missing ledger
-	// TODO: add test for 404, this should not be in the actions test
 	w = ht.Get("/ledgers/100/operations")
 	ht.Assert.Equal(404, w.Code)
 }
 
-// Moved to TestGetOperationsIncludeFailed
 func TestOperationActions_Show_Failed(t *testing.T) {
 	ht := StartHTTPTest(t, "failed_transactions")
 	defer ht.Finish()
@@ -441,60 +414,4 @@ func TestOperationActions_Show_Extra_TxID(t *testing.T) {
 		ht.Assert.Equal(3, successful)
 		ht.Assert.Equal(0, failed)
 	}
-}
-
-func TestOperationsForFeeBumpTransaction(t *testing.T) {
-	ht := StartHTTPTestWithoutScenario(t)
-	defer ht.Finish()
-	test.ResetHorizonDB(t, ht.HorizonDB)
-	q := &history.Q{ht.HorizonSession()}
-	fixture := history.FeeBumpScenario(ht.T, q, true)
-
-	w := ht.Get("/transactions/" + fixture.OuterHash + "/operations")
-	ht.Assert.Equal(200, w.Code)
-	var byOuterHash []operations.Base
-	ht.UnmarshalPage(w.Body, &byOuterHash)
-	ht.Assert.Len(byOuterHash, 1)
-	ht.Assert.Equal(fixture.OuterHash, byOuterHash[0].TransactionHash)
-
-	w = ht.Get("/transactions/" + fixture.InnerHash + "/operations")
-	ht.Assert.Equal(200, w.Code)
-	var byInnerHash []operations.Base
-	ht.UnmarshalPage(w.Body, &byInnerHash)
-	ht.Assert.Len(byInnerHash, 1)
-	ht.Assert.Equal(fixture.InnerHash, byInnerHash[0].TransactionHash)
-
-	byInnerHash[0].TransactionHash = byOuterHash[0].TransactionHash
-	ht.Assert.Equal(byOuterHash, byInnerHash)
-
-	w = ht.Get("/transactions/" + fixture.OuterHash + "/operations?join=transactions")
-	ht.Assert.Equal(200, w.Code)
-	ht.UnmarshalPage(w.Body, &byOuterHash)
-	ht.Assert.Len(byOuterHash, 1)
-	ht.Assert.Equal(fixture.OuterHash, byOuterHash[0].TransactionHash)
-	tx := byOuterHash[0].Transaction
-	ht.Assert.Equal(fixture.OuterHash, tx.Hash)
-	ht.Assert.Equal(fixture.OuterHash, tx.ID)
-	ht.Assert.Equal(
-		strings.Split(fixture.Transaction.SignatureString, ","),
-		tx.Signatures,
-	)
-
-	w = ht.Get("/transactions/" + fixture.InnerHash + "/operations?join=transactions")
-	ht.Assert.Equal(200, w.Code)
-	ht.UnmarshalPage(w.Body, &byInnerHash)
-	ht.Assert.Len(byInnerHash, 1)
-	ht.Assert.Equal(fixture.InnerHash, byInnerHash[0].TransactionHash)
-	tx = byInnerHash[0].Transaction
-	ht.Assert.Equal(fixture.InnerHash, tx.Hash)
-	ht.Assert.Equal(fixture.InnerHash, tx.ID)
-	ht.Assert.Equal(
-		strings.Split(fixture.Transaction.InnerSignatureString.String, ","),
-		tx.Signatures,
-	)
-
-	ht.Assert.Equal(byInnerHash[0].ID, byOuterHash[0].ID)
-	ht.Assert.Equal(byInnerHash[0].SourceAccount, byOuterHash[0].SourceAccount)
-	ht.Assert.Equal(byInnerHash[0].TransactionSuccessful, byOuterHash[0].TransactionSuccessful)
-	ht.Assert.Equal(byInnerHash[0].Type, byOuterHash[0].Type)
 }

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -110,6 +110,7 @@ func TestOperationActions_Index(t *testing.T) {
 	ht.Assert.Equal(404, w.Code)
 }
 
+// Moved to TestGetOperationsIncludeFailed
 func TestOperationActions_Show_Failed(t *testing.T) {
 	ht := StartHTTPTest(t, "failed_transactions")
 	defer ht.Finish()

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -362,32 +362,3 @@ func TestOperation_IncludeTransaction(t *testing.T) {
 	ht.Require.NoError(err, "failed to parse body")
 	ht.Assert.Equal(transactionInOperationsResponse, getTransactionResponse)
 }
-
-// TestOperationActions_Show_Extra_TxID tests if failed transactions are not returned
-// when `tx_id` GET param is present. This was happening because `base.GetString()`
-// method retuns values from the query when URL param is not present.
-func TestOperationActions_Show_Extra_TxID(t *testing.T) {
-	ht := StartHTTPTest(t, "failed_transactions")
-	defer ht.Finish()
-
-	w := ht.Get("/accounts/GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON/operations?limit=200&tx_id=aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf")
-
-	if ht.Assert.Equal(200, w.Code) {
-		records := []operations.Base{}
-		ht.UnmarshalPage(w.Body, &records)
-
-		successful := 0
-		failed := 0
-
-		for _, op := range records {
-			if op.TransactionSuccessful {
-				successful++
-			} else {
-				failed++
-			}
-		}
-
-		ht.Assert.Equal(3, successful)
-		ht.Assert.Equal(0, failed)
-	}
-}

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -1,9 +1,7 @@
 package horizon
 
 import (
-	"context"
 	"encoding/json"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -11,7 +9,6 @@ import (
 	"github.com/stellar/go/protocols/horizon/effects"
 	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/test"
 )
 
@@ -213,27 +210,6 @@ func TestOperationActions_IncludeTransactions(t *testing.T) {
 	}
 
 	ht.Assert.Equal(withoutTransactions, withTransactions)
-}
-
-func TestOperationActions_SSE(t *testing.T) {
-	tt := test.Start(t).Scenario("failed_transactions")
-	defer tt.Finish()
-
-	ctx := context.Background()
-	stream := sse.NewStream(ctx, httptest.NewRecorder())
-	oa := OperationIndexAction{
-		Action: *NewTestAction(ctx, "/operations?account_id=GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2"),
-	}
-
-	oa.SSE(stream)
-	tt.Require.NoError(oa.Err)
-
-	streamWithTransactions := sse.NewStream(ctx, httptest.NewRecorder())
-	oaWithTransactions := OperationIndexAction{
-		Action: *NewTestAction(ctx, "/operations?account_id=GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2&join=transactions"),
-	}
-	oaWithTransactions.SSE(streamWithTransactions)
-	tt.Require.NoError(oaWithTransactions.Err)
 }
 
 func TestOperationActions_Show(t *testing.T) {

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -370,7 +370,7 @@ func TestOperationActions_Show_Extra_TxID(t *testing.T) {
 	ht := StartHTTPTest(t, "failed_transactions")
 	defer ht.Finish()
 
-	w := ht.Get("/accounts/GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON/operations?limit=200&tx_id=abc")
+	w := ht.Get("/accounts/GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON/operations?limit=200&tx_id=aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf")
 
 	if ht.Assert.Equal(200, w.Code) {
 		records := []operations.Base{}

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -26,6 +26,8 @@ func TestOperationActions_Index(t *testing.T) {
 		ht.Assert.PageOf(4, w.Body)
 	}
 
+	// =============================
+	// Moved to TestGetOperationsFilterByLedgerID
 	// filtered by ledger sequence
 	w = ht.Get("/ledgers/1/operations")
 	if ht.Assert.Equal(200, w.Code) {
@@ -41,6 +43,7 @@ func TestOperationActions_Index(t *testing.T) {
 	if ht.Assert.Equal(200, w.Code) {
 		ht.Assert.PageOf(1, w.Body)
 	}
+	// =============================
 
 	// =============================
 	// Moved to TestGetOperationsFilterByAccountID
@@ -84,10 +87,12 @@ func TestOperationActions_Index(t *testing.T) {
 	}
 	// =============================
 
+	// TODO
 	// 400 for invalid tx hash
 	w = ht.Get("/transactions/ /operations")
 	ht.Assert.Equal(400, w.Code)
 
+	// TODO
 	w = ht.Get("/transactions/invalid/operations")
 	ht.Assert.Equal(400, w.Code)
 
@@ -99,6 +104,7 @@ func TestOperationActions_Index(t *testing.T) {
 	w = ht.Get("/transactions/1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc29222/operations")
 	ht.Assert.Equal(400, w.Code)
 
+	// Done in TestGetOperationsFilterByLedgerID
 	// filtered by ledger
 	w = ht.Get("/ledgers/3/operations")
 	if ht.Assert.Equal(200, w.Code) {
@@ -106,6 +112,7 @@ func TestOperationActions_Index(t *testing.T) {
 	}
 
 	// missing ledger
+	// TODO: add test for 404, this should not be in the actions test
 	w = ht.Get("/ledgers/100/operations")
 	ht.Assert.Equal(404, w.Code)
 }

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -362,3 +362,17 @@ func TestOperation_IncludeTransaction(t *testing.T) {
 	ht.Require.NoError(err, "failed to parse body")
 	ht.Assert.Equal(transactionInOperationsResponse, getTransactionResponse)
 }
+func TestOperationActions_Show_Extra_TxID(t *testing.T) {
+	ht := StartHTTPTest(t, "failed_transactions")
+	defer ht.Finish()
+
+	w := ht.Get("/accounts/GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON/operations?limit=200&tx_id=aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf")
+
+	ht.Assert.Equal(400, w.Code)
+	payload := ht.UnmarshalExtras(w.Body)
+	ht.Assert.Equal("filters", payload["invalid_field"])
+	ht.Assert.Equal(
+		"Use a single filter for operations, you can't combine tx_id, account_id, and ledger_id",
+		payload["reason"],
+	)
+}

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -20,6 +20,7 @@ func TestOperationActions_Index(t *testing.T) {
 	ht := StartHTTPTest(t, "base")
 	defer ht.Finish()
 
+	// Moved to TestGetOperationsWithoutFilter
 	// no filter
 	w := ht.Get("/operations")
 	if ht.Assert.Equal(200, w.Code) {

--- a/services/horizon/internal/actions_payment_test.go
+++ b/services/horizon/internal/actions_payment_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/expingest"
 )
 
+// Moved to TestGetOperationsOnlyPayments
 func TestPaymentActions(t *testing.T) {
 	ht := StartHTTPTest(t, "base")
 	defer ht.Finish()

--- a/services/horizon/internal/actions_payment_test.go
+++ b/services/horizon/internal/actions_payment_test.go
@@ -246,35 +246,6 @@ func TestPayment_CreatedAt(t *testing.T) {
 	ht.Assert.WithinDuration(l.ClosedAt, records[0].LedgerCloseTime, 1*time.Second)
 }
 
-// TestPaymentActions_Show_Extra_TxID tests if failed transactions are not returned
-// when `tx_id` GET param is present. This was happening because `base.GetString()`
-// method retuns values from the query when URL param is not present.
-func TestPaymentActions_Show_Extra_TxID(t *testing.T) {
-	ht := StartHTTPTest(t, "failed_transactions")
-	defer ht.Finish()
-
-	w := ht.Get("/accounts/GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON/payments?limit=200&tx_id=abc")
-
-	if ht.Assert.Equal(200, w.Code) {
-		records := []operations.Base{}
-		ht.UnmarshalPage(w.Body, &records)
-
-		successful := 0
-		failed := 0
-
-		for _, op := range records {
-			if op.TransactionSuccessful {
-				successful++
-			} else {
-				failed++
-			}
-		}
-
-		ht.Assert.Equal(2, successful)
-		ht.Assert.Equal(0, failed)
-	}
-}
-
 func TestPaymentActionsPathPaymentStrictSend(t *testing.T) {
 	ht := StartHTTPTest(t, "paths_strict_send")
 	defer ht.Finish()

--- a/services/horizon/internal/actions_payment_test.go
+++ b/services/horizon/internal/actions_payment_test.go
@@ -246,6 +246,21 @@ func TestPayment_CreatedAt(t *testing.T) {
 	ht.Assert.WithinDuration(l.ClosedAt, records[0].LedgerCloseTime, 1*time.Second)
 }
 
+func TestPaymentActions_Show_Extra_TxID(t *testing.T) {
+	ht := StartHTTPTest(t, "failed_transactions")
+	defer ht.Finish()
+
+	w := ht.Get("/accounts/GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON/payments?limit=200&tx_id=aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf")
+
+	ht.Assert.Equal(400, w.Code)
+	payload := ht.UnmarshalExtras(w.Body)
+	ht.Assert.Equal("filters", payload["invalid_field"])
+	ht.Assert.Equal(
+		"Use a single filter for operations, you can't combine tx_id, account_id, and ledger_id",
+		payload["reason"],
+	)
+}
+
 func TestPaymentActionsPathPaymentStrictSend(t *testing.T) {
 	ht := StartHTTPTest(t, "paths_strict_send")
 	defer ht.Finish()

--- a/services/horizon/internal/actions_payment_test.go
+++ b/services/horizon/internal/actions_payment_test.go
@@ -60,6 +60,8 @@ func TestPaymentActions(t *testing.T) {
 	if ht.Assert.Equal(200, w.Code) {
 		ht.Assert.PageOf(0, w.Body)
 	}
+	// ===========================================
+	// The following scenarios are handled in the action test
 	// missing tx
 	w = ht.Get("/transactions/ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff/payments")
 	ht.Assert.Equal(404, w.Code)
@@ -69,17 +71,22 @@ func TestPaymentActions(t *testing.T) {
 	// badly formated tx hash not accepted
 	w = ht.Get("/transactions/%00%1E4%5E%EF%BF%BD%EF%BF%BD%EF%BF%BDpVP%EF%BF%BDI&R%0BK%EF%BF%BD%1D%EF%BF%BD%EF%BF%BD=%EF%BF%BD%3F%23%EF%BF%BD%EF%BF%BDl%EF%BF%BD%1El%EF%BF%BD%EF%BF%BD/payments")
 	ht.Assert.Equal(400, w.Code)
+	// ===========================================
 
+	// TODO: test at the routing level
 	// 400 for invalid tx hash
 	w = ht.Get("/transactions/ /payments")
 	ht.Assert.Equal(400, w.Code)
 
+	// this is handled in operations test, invalid will not match as a valid tx_id.
 	w = ht.Get("/transactions/invalid/payments")
 	ht.Assert.Equal(400, w.Code)
 
+	// This is already handled in operations test
 	w = ht.Get("/transactions/1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc29/payments")
 	ht.Assert.Equal(400, w.Code)
 
+	// This is already handled in operations test
 	w = ht.Get("/transactions/1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc29222/payments")
 	ht.Assert.Equal(400, w.Code)
 
@@ -94,6 +101,8 @@ func TestPaymentActions(t *testing.T) {
 	}
 
 	initializeStateMiddleware()
+
+	// This is tested in PageQueryTest
 	// Regression: negative cursor
 	w = ht.Get("/accounts/GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2/payments?cursor=-23667108046966785&order=asc&limit=100")
 	ht.Assert.Equal(400, w.Code)

--- a/services/horizon/internal/handler.go
+++ b/services/horizon/internal/handler.go
@@ -558,6 +558,11 @@ func (handler pageActionHandler) renderStream(w http.ResponseWriter, r *http.Req
 				// but otherwise, we'll have to edit r.URL, which is also a
 				// hack.
 				r.Header.Set("Last-Event-ID", events[len(events)-1].ID)
+			} else {
+				// If there are no records, use the cursor from pq as the
+				// Last-Event-ID, otherwise, we'll keep using `now` which
+				// will always resolve to the next ledger.
+				r.Header.Set("Last-Event-ID", pq.Cursor)
 			}
 
 			return events, nil

--- a/services/horizon/internal/handler.go
+++ b/services/horizon/internal/handler.go
@@ -558,10 +558,11 @@ func (handler pageActionHandler) renderStream(w http.ResponseWriter, r *http.Req
 				// but otherwise, we'll have to edit r.URL, which is also a
 				// hack.
 				r.Header.Set("Last-Event-ID", events[len(events)-1].ID)
-			} else {
-				// If there are no records, use the cursor from pq as the
-				// Last-Event-ID, otherwise, we'll keep using `now` which
-				// will always resolve to the next ledger.
+			} else if (len(r.Header.Get("Last-Event-ID")) == 0 {
+				// If there are no records and Last-Event-ID has not been set,
+				// use the cursor from pq as the Last-Event-ID, otherwise, we'll
+				// keep using `now` which will always resolve to the next
+				// ledger.
 				r.Header.Set("Last-Event-ID", pq.Cursor)
 			}
 

--- a/services/horizon/internal/handler.go
+++ b/services/horizon/internal/handler.go
@@ -558,7 +558,7 @@ func (handler pageActionHandler) renderStream(w http.ResponseWriter, r *http.Req
 				// but otherwise, we'll have to edit r.URL, which is also a
 				// hack.
 				r.Header.Set("Last-Event-ID", events[len(events)-1].ID)
-			} else if (len(r.Header.Get("Last-Event-ID")) == 0 {
+			} else if len(r.Header.Get("Last-Event-ID")) == 0 {
 				// If there are no records and Last-Event-ID has not been set,
 				// use the cursor from pq as the Last-Event-ID, otherwise, we'll
 				// keep using `now` which will always resolve to the next

--- a/services/horizon/internal/helpers.go
+++ b/services/horizon/internal/helpers.go
@@ -1,8 +1,6 @@
 package horizon
 
 import (
-	"encoding/hex"
-
 	"github.com/stellar/go/support/errors"
 )
 
@@ -29,13 +27,4 @@ func countNonEmpty(params ...interface{}) (int, error) {
 	}
 
 	return count, nil
-}
-
-func isValidTransactionHash(hash string) bool {
-	decoded, err := hex.DecodeString(hash)
-	if err != nil {
-		return false
-	}
-
-	return len(decoded) == 32
 }

--- a/services/horizon/internal/helpers.go
+++ b/services/horizon/internal/helpers.go
@@ -31,7 +31,6 @@ func countNonEmpty(params ...interface{}) (int, error) {
 	return count, nil
 }
 
-// TODO: delete me
 func isValidTransactionHash(hash string) bool {
 	decoded, err := hex.DecodeString(hash)
 	if err != nil {

--- a/services/horizon/internal/helpers.go
+++ b/services/horizon/internal/helpers.go
@@ -31,6 +31,7 @@ func countNonEmpty(params ...interface{}) (int, error) {
 	return count, nil
 }
 
+// TODO: delete me
 func isValidTransactionHash(hash string) bool {
 	decoded, err := hex.DecodeString(hash)
 	if err != nil {

--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -241,10 +241,12 @@ func requestMetricsMiddleware(h http.Handler) http.Handler {
 	})
 }
 
-// checkHistoryStaleMiddleware ensures the difference between latest core ledger and
-// latest history ledger is not higher than the given threshold
-func checkHistoryStaleMiddleware(staleThreshold int32) func(http.Handler) http.Handler {
+// NewHistoryMiddleware adds session to the request context and ensures Horizon
+// is not in a stale state, which is when the difference between latest core
+// ledger and latest history ledger is higher than the given threshold
+func NewHistoryMiddleware(staleThreshold int32, session *db.Session) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
+
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if staleThreshold > 0 {
 				ls := ledger.CurrentState()
@@ -260,7 +262,13 @@ func checkHistoryStaleMiddleware(staleThreshold int32) func(http.Handler) http.H
 				}
 			}
 
-			h.ServeHTTP(w, r)
+			h.ServeHTTP(w, r.WithContext(
+				context.WithValue(
+					r.Context(),
+					&horizonContext.SessionContextKey,
+					session,
+				),
+			))
 		})
 	}
 }

--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/expingest"
 	"github.com/stellar/go/services/horizon/internal/hchi"
 	"github.com/stellar/go/services/horizon/internal/httpx"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/render"
 	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/support/db"
@@ -238,6 +239,30 @@ func requestMetricsMiddleware(h http.Handler) http.Handler {
 			app.web.failureMeter.Mark(1)
 		}
 	})
+}
+
+// checkHistoryStaleMiddleware ensures the difference between latest core ledger and
+// latest history ledger is not higher than the given threshold
+func checkHistoryStaleMiddleware(staleThreshold int32) func(http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if staleThreshold > 0 {
+				ls := ledger.CurrentState()
+				isStale := (ls.CoreLatest - ls.HistoryLatest) > int32(staleThreshold)
+				if isStale {
+					err := hProblem.StaleHistory
+					err.Extras = map[string]interface{}{
+						"history_latest_ledger": ls.HistoryLatest,
+						"core_latest_ledger":    ls.CoreLatest,
+					}
+					problem.Render(r.Context(), w, err)
+					return
+				}
+			}
+
+			h.ServeHTTP(w, r)
+		})
+	}
 }
 
 // StateMiddleware is a middleware which enables a state handler if the state

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -10,6 +10,7 @@ import (
 	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/expingest"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/support/db"
@@ -281,6 +282,59 @@ func TestStateMiddleware(t *testing.T) {
 			} else {
 				tt.Assert.Equal(w.Header().Get(actions.LastLedgerHeaderName), "")
 			}
+		})
+	}
+}
+
+func TestCheckHistoryStaleMiddleware(t *testing.T) {
+	tt := assert.New(t)
+	request, err := http.NewRequest("GET", "http://localhost", nil)
+	tt.NoError(err)
+
+	endpoint := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+
+	for _, testCase := range []struct {
+		name           string
+		coreLatest     int32
+		historyLatest  int32
+		expectedStatus int
+		staleThreshold int32
+	}{
+		{
+			name:           "responds with a service unavailable if history is stale",
+			coreLatest:     4,
+			historyLatest:  2,
+			expectedStatus: http.StatusServiceUnavailable,
+			staleThreshold: 1,
+		},
+		{
+			name:           "succeeds",
+			coreLatest:     6,
+			historyLatest:  6,
+			expectedStatus: http.StatusOK,
+			staleThreshold: 1,
+		},
+		{
+			name:           "succeeds with threshold 0",
+			coreLatest:     6,
+			historyLatest:  5,
+			expectedStatus: http.StatusOK,
+			staleThreshold: 0,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			state := ledger.State{
+				CoreLatest:    testCase.coreLatest,
+				HistoryLatest: testCase.historyLatest,
+			}
+			ledger.SetState(state)
+			stateMiddleware := checkHistoryStaleMiddleware(testCase.staleThreshold)
+			handler := stateMiddleware(http.HandlerFunc(endpoint))
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, request)
+			tt.Equal(testCase.expectedStatus, w.Code)
 		})
 	}
 }

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -287,9 +287,10 @@ func TestStateMiddleware(t *testing.T) {
 }
 
 func TestCheckHistoryStaleMiddleware(t *testing.T) {
-	tt := assert.New(t)
+	tt := test.Start(t)
+	defer tt.Finish()
 	request, err := http.NewRequest("GET", "http://localhost", nil)
-	tt.NoError(err)
+	tt.Assert.NoError(err)
 
 	endpoint := func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -330,11 +331,11 @@ func TestCheckHistoryStaleMiddleware(t *testing.T) {
 				HistoryLatest: testCase.historyLatest,
 			}
 			ledger.SetState(state)
-			stateMiddleware := checkHistoryStaleMiddleware(testCase.staleThreshold)
-			handler := stateMiddleware(http.HandlerFunc(endpoint))
+			historyMiddleware := NewHistoryMiddleware(testCase.staleThreshold, tt.HorizonSession())
+			handler := historyMiddleware(http.HandlerFunc(endpoint))
 			w := httptest.NewRecorder()
 			handler.ServeHTTP(w, request)
-			tt.Equal(testCase.expectedStatus, w.Code)
+			tt.Assert.Equal(testCase.expectedStatus, w.Code)
 		})
 	}
 }

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -227,20 +227,19 @@ func (w *web) mustInstallActions(
 	// emptiness. Without it, requesting `/accounts//payments` return all payments!
 	r.Group(func(r chi.Router) {
 		r.Get("/accounts/{account_id:\\w+}/transactions", w.streamIndexActionHandler(w.getTransactionPage, w.streamTransactions))
+		r.Get("/accounts/{account_id:\\w+}/effects", EffectIndexAction{}.Handle)
+		r.Get("/accounts/{account_id:\\w+}/trades", TradeIndexAction{}.Handle)
 		r.Group(func(r chi.Router) {
 			r.Use(historyMiddleware)
-			r.Get("/accounts/{account_id:\\w+}/operations", OperationIndexAction{}.Handle)
-			// r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/operations", streamablePageHandler(actions.GetOperationsHandler{
-			// 	IngestingFailedTransactions: w.ingestFailedTx,
-			// 	OnlyPayments:                false,
-			// }, streamHandler))
+			r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/operations", streamablePageHandler(actions.GetOperationsHandler{
+				IngestingFailedTransactions: w.ingestFailedTx,
+				OnlyPayments:                false,
+			}, streamHandler))
 			r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/payments", streamablePageHandler(actions.GetOperationsHandler{
 				IngestingFailedTransactions: w.ingestFailedTx,
 				OnlyPayments:                true,
 			}, streamHandler))
 		})
-		r.Get("/accounts/{account_id:\\w+}/effects", EffectIndexAction{}.Handle)
-		r.Get("/accounts/{account_id:\\w+}/trades", TradeIndexAction{}.Handle)
 	})
 	// ledger actions
 	r.Route("/ledgers", func(r chi.Router) {
@@ -248,9 +247,18 @@ func (w *web) mustInstallActions(
 		r.Route("/{ledger_id}", func(r chi.Router) {
 			r.Get("/", LedgerShowAction{}.Handle)
 			r.Get("/transactions", w.streamIndexActionHandler(w.getTransactionPage, w.streamTransactions))
-			r.Get("/operations", OperationIndexAction{}.Handle)
-			r.Get("/payments", OperationIndexAction{OnlyPayments: true}.Handle)
 			r.Get("/effects", EffectIndexAction{}.Handle)
+			r.Group(func(r chi.Router) {
+				r.Use(historyMiddleware)
+				r.Method(http.MethodGet, "/operations", streamablePageHandler(actions.GetOperationsHandler{
+					IngestingFailedTransactions: w.ingestFailedTx,
+					OnlyPayments:                false,
+				}, streamHandler))
+				r.Method(http.MethodGet, "/payments", streamablePageHandler(actions.GetOperationsHandler{
+					IngestingFailedTransactions: w.ingestFailedTx,
+					OnlyPayments:                true,
+				}, streamHandler))
+			})
 		})
 	})
 
@@ -259,9 +267,18 @@ func (w *web) mustInstallActions(
 		r.Get("/", w.streamIndexActionHandler(w.getTransactionPage, w.streamTransactions))
 		r.Route("/{tx_id}", func(r chi.Router) {
 			r.Get("/", showActionHandler(w.getTransactionResource))
-			r.Get("/operations", OperationIndexAction{}.Handle)
-			r.Get("/payments", OperationIndexAction{OnlyPayments: true}.Handle)
 			r.Get("/effects", EffectIndexAction{}.Handle)
+			r.Group(func(r chi.Router) {
+				r.Use(historyMiddleware)
+				r.Method(http.MethodGet, "/operations", streamablePageHandler(actions.GetOperationsHandler{
+					IngestingFailedTransactions: w.ingestFailedTx,
+					OnlyPayments:                false,
+				}, streamHandler))
+				r.Method(http.MethodGet, "/payments", streamablePageHandler(actions.GetOperationsHandler{
+					IngestingFailedTransactions: w.ingestFailedTx,
+					OnlyPayments:                true,
+				}, streamHandler))
+			})
 		})
 	})
 

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -227,8 +227,18 @@ func (w *web) mustInstallActions(
 	// emptiness. Without it, requesting `/accounts//payments` return all payments!
 	r.Group(func(r chi.Router) {
 		r.Get("/accounts/{account_id:\\w+}/transactions", w.streamIndexActionHandler(w.getTransactionPage, w.streamTransactions))
-		r.Get("/accounts/{account_id:\\w+}/operations", OperationIndexAction{}.Handle)
-		r.Get("/accounts/{account_id:\\w+}/payments", OperationIndexAction{OnlyPayments: true}.Handle)
+		r.Group(func(r chi.Router) {
+			r.Use(historyMiddleware)
+			r.Get("/accounts/{account_id:\\w+}/operations", OperationIndexAction{}.Handle)
+			// r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/operations", streamablePageHandler(actions.GetOperationsHandler{
+			// 	IngestingFailedTransactions: w.ingestFailedTx,
+			// 	OnlyPayments:                false,
+			// }, streamHandler))
+			r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/payments", streamablePageHandler(actions.GetOperationsHandler{
+				IngestingFailedTransactions: w.ingestFailedTx,
+				OnlyPayments:                true,
+			}, streamHandler))
+		})
 		r.Get("/accounts/{account_id:\\w+}/effects", EffectIndexAction{}.Handle)
 		r.Get("/accounts/{account_id:\\w+}/trades", TradeIndexAction{}.Handle)
 	})

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -267,7 +267,10 @@ func (w *web) mustInstallActions(
 
 	r.Group(func(r chi.Router) {
 		// payment actions
-		r.Get("/payments", OperationIndexAction{OnlyPayments: true}.Handle)
+		r.With(historyMiddleware).Method(http.MethodGet, "/payments", streamablePageHandler(actions.GetOperationsHandler{
+			IngestingFailedTransactions: w.ingestFailedTx,
+			OnlyPayments:                true,
+		}, streamHandler))
 
 		// effect actions
 		r.Get("/effects", EffectIndexAction{}.Handle)

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -164,6 +164,8 @@ func (w *web) mustInstallActions(
 		LedgerSourceFactory: historyLedgerSourceFactory{updateFrequency: w.sseUpdateFrequency},
 	}
 
+	historyMiddleware := NewHistoryMiddleware(int32(w.staleThreshold), session)
+
 	// State endpoints behind stateMiddleware
 	r.Group(func(r chi.Router) {
 		r.Use(stateMiddleware.Wrap)
@@ -255,7 +257,10 @@ func (w *web) mustInstallActions(
 
 	// operation actions
 	r.Route("/operations", func(r chi.Router) {
-		r.Get("/", OperationIndexAction{}.Handle)
+		r.With(historyMiddleware).Method(http.MethodGet, "/", streamablePageHandler(actions.GetOperationsHandler{
+			IngestingFailedTransactions: w.ingestFailedTx,
+			OnlyPayments:                false,
+		}, streamHandler))
 		r.Get("/{id}", OperationShowAction{}.Handle)
 		r.Get("/{op_id}/effects", EffectIndexAction{}.Handle)
 	})


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Create a new action handler for fetching operations, using the new architecture for actions. 

### Why

We have different way to handle actions, as explained in #997 we want to use the same pattern across different routes to avoid code duplication and make it easier to reason about how different routes behave.

This PR also fixes multiple issues around filters, we only allow one filter `tx_id`, `ledger_id`, or `account_id`. We had some validations for that in the old code but it was inconsistent and wouldn't work all the time. This PR improves that logic and also returns a better explanation to the end user rather than just telling them that the request was invalid in some way.

### Known limitations
