### PR TITLE
services/horizon/cmd: Add configuration for captive core ingestion

### DIFF
--- a/exp/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend_test.go
@@ -13,8 +13,11 @@ import (
 
 func TestCaptiveCore(t *testing.T) {
 	log.SetLevel(logpkg.InfoLevel)
-	c := NewCaptive("Public Global Stellar Network ; September 2015",
-		[]string{"http://history.stellar.org/prd/core-live/core_live_001"})
+	c := NewCaptive(
+		"stellar-core",
+		"Public Global Stellar Network ; September 2015",
+		[]string{"http://history.stellar.org/prd/core-live/core_live_001"},
+	)
 	seq, e := c.GetLatestLedgerSequence()
 	assert.NoError(t, e)
 	assert.Greater(t, seq, uint32(0))

--- a/go.list
+++ b/go.list
@@ -4,6 +4,7 @@ cloud.google.com/go v0.34.0
 firebase.google.com/go v3.12.0+incompatible
 github.com/BurntSushi/toml v0.3.1
 github.com/Masterminds/squirrel v0.0.0-20161115235646-20f192218cf5
+github.com/Microsoft/go-winio v0.4.14
 github.com/Shopify/sarama v1.19.0
 github.com/Shopify/toxiproxy v2.1.4+incompatible
 github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f
@@ -98,7 +99,7 @@ github.com/sebest/xff v0.0.0-20150611211316-7a36e3a787b5
 github.com/segmentio/go-loggly v0.5.1-0.20171222203950-eb91657e62b2
 github.com/sergi/go-diff v0.0.0-20161205080420-83532ca1c1ca
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
-github.com/sirupsen/logrus v1.2.0
+github.com/sirupsen/logrus v1.4.1
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337
 github.com/spf13/cast v0.0.0-20150508191742-4d07383ffe94

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -179,6 +179,9 @@ var dbReingestRangeCmd = &cobra.Command{
 			HistoryArchiveURL:        config.HistoryArchiveURLs[0],
 			IngestFailedTransactions: config.IngestFailedTransactions,
 		}
+		if config.EnableCaptiveCoreIngestion {
+			ingestConfig.StellarCorePath = config.StellarCoreBinaryPath
+		}
 
 		system, err := expingest.NewSystem(ingestConfig)
 		if err != nil {

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -110,6 +110,9 @@ var ingestVerifyRangeCmd = &cobra.Command{
 			OrderBookGraph:           orderbook.NewOrderBookGraph(),
 			IngestFailedTransactions: config.IngestFailedTransactions,
 		}
+		if config.EnableCaptiveCoreIngestion {
+			ingestConfig.StellarCorePath = config.StellarCoreBinaryPath
+		}
 
 		system, err := expingest.NewSystem(ingestConfig)
 		if err != nil {
@@ -187,6 +190,9 @@ var ingestStressTestCmd = &cobra.Command{
 			HistoryArchiveURL:        config.HistoryArchiveURLs[0],
 			OrderBookGraph:           orderbook.NewOrderBookGraph(),
 			IngestFailedTransactions: config.IngestFailedTransactions,
+		}
+		if config.EnableCaptiveCoreIngestion {
+			ingestConfig.StellarCorePath = config.StellarCoreBinaryPath
 		}
 
 		system, err := expingest.NewSystem(ingestConfig)

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -109,6 +109,24 @@ var dbURLConfigOption = &support.ConfigOption{
 var configOpts = support.ConfigOptions{
 	dbURLConfigOption,
 	&support.ConfigOption{
+		Name:        "stellar-core-binary-path",
+		EnvVar:      "STELLAR_CORE_BINARY_PATH",
+		OptType:     types.String,
+		FlagDefault: "",
+		Required:    false,
+		Usage:       "path to stellar core binary",
+		ConfigKey:   &config.StellarCoreBinaryPath,
+	},
+	&support.ConfigOption{
+		Name:        "enable-captive-core-ingestion",
+		EnvVar:      "ENABLE_CAPTIVE_CORE_INGESTION",
+		OptType:     types.Bool,
+		FlagDefault: false,
+		Required:    false,
+		Usage:       "[experimental flag!] causes Horizon to ingest from a Stellar Core subprocess instead of a persistent Stellar Core database",
+		ConfigKey:   &config.EnableCaptiveCoreIngestion,
+	},
+	&support.ConfigOption{
 		Name:      "stellar-core-db-url",
 		EnvVar:    "STELLAR_CORE_DATABASE_URL",
 		ConfigKey: &config.StellarCoreDatabaseURL,
@@ -402,6 +420,10 @@ func initRootConfig() {
 	// viper.GetString is easier.
 	if config.Ingest && viper.GetString("history-archive-urls") == "" {
 		stdLog.Fatalf("--history-archive-urls must be set when --ingest is set")
+	}
+
+	if config.EnableCaptiveCoreIngestion && config.StellarCoreBinaryPath == "" {
+		stdLog.Fatalf("--stellar-core-binary-path must be set when --enable-captive-core-ingestion is set")
 	}
 
 	// Configure log file

--- a/services/horizon/docker/Dockerfile
+++ b/services/horizon/docker/Dockerfile
@@ -8,8 +8,15 @@ RUN go install github.com/stellar/go/services/horizon
 
 FROM ubuntu:16.04
 
+ENV STELLAR_CORE_VERSION 13.0.0-1220-9ed3da29
+ENV STELLAR_CORE_BINARY_PATH /usr/local/bin/stellar-core
+
 # ca-certificates are required to make tls connections
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget
+
+RUN wget -O stellar-core.deb https://s3.amazonaws.com/stellar.org/releases/stellar-core/stellar-core-${STELLAR_CORE_VERSION}_amd64.deb
+RUN dpkg -i stellar-core.deb
+RUN rm stellar-core.deb
 
 COPY --from=builder /go/bin/horizon ./
 

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -11,12 +11,14 @@ import (
 // Config is the configuration for horizon.  It gets populated by the
 // app's main function and is provided to NewApp.
 type Config struct {
-	DatabaseURL            string
-	StellarCoreDatabaseURL string
-	StellarCoreURL         string
-	HistoryArchiveURLs     []string
-	Port                   uint
-	AdminPort              uint
+	DatabaseURL                string
+	StellarCoreBinaryPath      string
+	StellarCoreDatabaseURL     string
+	StellarCoreURL             string
+	EnableCaptiveCoreIngestion bool
+	HistoryArchiveURLs         []string
+	Port                       uint
+	AdminPort                  uint
 
 	// MaxDBConnections has a priority over all 4 values below.
 	MaxDBConnections            int


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Close https://github.com/stellar/go/issues/2584

* add `StellarCoreBinaryPath` to config which stores the path to the stellar core binary
* add `EnableCaptiveCoreIngestion` to config which is a feature flag for using the captive core ingestion implementation
* Update horizon docker image to download and install stellar core
* set `STELLAR_CORE_BINARY_PATH` to the appropriate path in the horizon docker image

### Why

> Currently, the code in #2322 assume that stellar-core is present in the user's PATH. This can be a problem for some deployments. Instead, we should allow setting exact location of stellar-core binary via Horizon config. User should also be able decide whether they want to use experimental captive stellar-core in db reingesting range command.

### Known limitations

[N/A]
