### PR TITLE
doc: Update basic example to use latest sdk version.

### DIFF
--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -57,24 +57,28 @@ func main() {
 	}
 
 	// Construct the transaction that will carry the operation
-	tx := txnbuild.Transaction{
-		SourceAccount: &hAccount0,
-		Operations:    []txnbuild.Operation{&createAccountOp},
-		Timebounds:    txnbuild.NewTimeout(300),
-		Network:       network.TestNetworkPassphrase,
+	txParams := txnbuild.TransactionParams{
+		SourceAccount:        &hAccount0,
+		IncrementSequenceNum: true,
+		Operations:           []txnbuild.Operation{&createAccountOp},
+		Timebounds:           txnbuild.NewTimeout(300),
+		BaseFee:              100,
 	}
+	tx, _ := txnbuild.NewTransaction(txParams)
 
-	// Sign the transaction, serialise it to XDR, and base 64 encode it
-	txeBase64, err := tx.BuildSignEncode(pair)
+	// Sign the transaction, and base 64 encode its XDR representation
+	signedTx, _ := tx.Sign(network.TestNetworkPassphrase, pair)
+	txeBase64, _ := signedTx.Base64()
 	log.Println("Transaction base64: ", txeBase64)
 
 	// Submit the transaction
 	resp, err := client.SubmitTransactionXDR(txeBase64)
 	if err != nil {
 		hError := err.(*horizonclient.Error)
-		log.Fatal("Error submitting transaction:", hError)
+		log.Fatal("Error submitting transaction:", hError.Problem)
 	}
 
 	log.Println("\nTransaction response: ", resp)
 }
+
 ```


### PR DESCRIPTION
Example was not working due changes to the sdk. Updated code to work with the recent changes to txnbuild.Transaction struct.
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixing published basic example as it wasn't working with latest version (downloaded sdk on may 21, 2020)

### Why

The idea is to provide an updated example.

### Known limitations

N/A
