### PR TITLE
support/http: log user agent header at request start

### DIFF
--- a/services/federation/CHANGELOG.md
+++ b/services/federation/CHANGELOG.md
@@ -9,6 +9,7 @@ bumps.  A breaking change will get clearly notified in this log.
 ## Unreleased
 
 * Dropped support for Go 1.12.
+* Log User-Agent header in request logs.
 
 ## [v0.3.0] - 2019-11-20
 

--- a/services/friendbot/CHANGELOG.md
+++ b/services/friendbot/CHANGELOG.md
@@ -6,6 +6,10 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## Unreleased
+
+* Log User-Agent header in request logs.
+
 ## [v0.0.2] - 2019-11-20
 
 ### Changed

--- a/support/http/logging_middleware.go
+++ b/support/http/logging_middleware.go
@@ -49,11 +49,12 @@ func logStartOfRequest(
 	r *stdhttp.Request,
 ) {
 	log.Ctx(r.Context()).WithFields(log.F{
-		"subsys": "http",
-		"path":   r.URL.String(),
-		"method": r.Method,
-		"ip":     r.RemoteAddr,
-		"host":   r.Host,
+		"subsys":    "http",
+		"path":      r.URL.String(),
+		"method":    r.Method,
+		"ip":        r.RemoteAddr,
+		"host":      r.Host,
+		"useragent": r.Header.Get("User-Agent"),
 	}).Info("starting request")
 }
 

--- a/support/http/logging_middleware_test.go
+++ b/support/http/logging_middleware_test.go
@@ -36,6 +36,7 @@ func TestHTTPMiddleware(t *testing.T) {
 		assert.Equal(t, "GET", logged[0].Data["method"])
 		assert.NotEmpty(t, logged[0].Data["req"])
 		assert.NotEmpty(t, logged[0].Data["path"])
+		assert.Equal(t, "Go-http-client/1.1", logged[0].Data["useragent"])
 		req1 := logged[0].Data["req"]
 
 		assert.Equal(t, "handler log line", logged[1].Message)
@@ -52,6 +53,7 @@ func TestHTTPMiddleware(t *testing.T) {
 		assert.Equal(t, "GET", logged[3].Data["method"])
 		assert.NotEmpty(t, logged[3].Data["req"])
 		assert.NotEmpty(t, logged[3].Data["path"])
+		assert.Equal(t, "Go-http-client/1.1", logged[3].Data["useragent"])
 		req2 := logged[3].Data["req"]
 
 		assert.Equal(t, "finished request", logged[4].Message)
@@ -89,6 +91,7 @@ func TestHTTPMiddlewareWithLoggerSet(t *testing.T) {
 		assert.Equal(t, "GET", logged[0].Data["method"])
 		assert.NotEmpty(t, logged[0].Data["req"])
 		assert.NotEmpty(t, logged[0].Data["path"])
+		assert.Equal(t, "Go-http-client/1.1", logged[0].Data["useragent"])
 		req1 := logged[0].Data["req"]
 
 		assert.Equal(t, "handler log line", logged[1].Message)
@@ -105,6 +108,7 @@ func TestHTTPMiddlewareWithLoggerSet(t *testing.T) {
 		assert.Equal(t, "GET", logged[3].Data["method"])
 		assert.NotEmpty(t, logged[3].Data["req"])
 		assert.NotEmpty(t, logged[3].Data["path"])
+		assert.Equal(t, "Go-http-client/1.1", logged[3].Data["useragent"])
 		req2 := logged[3].Data["req"]
 
 		assert.Equal(t, "finished request", logged[4].Message)


### PR DESCRIPTION


<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Log the `User-Agent` header at request start.

### Why
Identifying which agent sent a request can be useful in the reference
implementations that accept inbound requests. It can be useful for
debugging strange issues, understanding broad usage patterns, and if a
service is deployed in use with a specific client and that client uses
the User-Agent header to communicate its version it can help an operator
understand what versions of its client are accessing the service. This
can help make decisions about upgrade plans, etc.

The specific use case I have is that we are deploying webauth and
recoverysigner with a client and I want to be able to know which version
of the client is accessing these services.

Horizon and the Horizon SDKs actually use some custom headers to achieve
this specific goal but I am not repeating that pattern since it is more
common to communicate this information in the user agent header.

The header does not normally contain any personally identifiable
information or sensitive information and so I believe there are no
concerns on that front.

This change impacts these services inside this repo:
 - `exp/services/webauth`
 - `exp/services/recoverysigner`
 - `services/friendbot`
 - `services/federation`

### Known limitations

N/A
