### PR TITLE
exp/ingest/ledgerbackend: Add captiveStellarCore tests

### DIFF
--- a/exp/ingest/io/single_ledger_state_reader_test.go
+++ b/exp/ingest/io/single_ledger_state_reader_test.go
@@ -607,7 +607,7 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryRetrySucceedsWithDiscard() {
 	secondEntry := metaEntry(2)
 
 	b := &bytes.Buffer{}
-	s.Require().NoError(historyarchive.WriteFramedXdr(b, firstEntry))
+	s.Require().NoError(xdr.MarshalFramed(b, firstEntry))
 	writeInvalidFrame(b)
 
 	s.mockArchive.
@@ -643,7 +643,7 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryRetryFailsWithDiscardError() {
 	firstEntry := metaEntry(1)
 
 	b := &bytes.Buffer{}
-	s.Require().NoError(historyarchive.WriteFramedXdr(b, firstEntry))
+	s.Require().NoError(xdr.MarshalFramed(b, firstEntry))
 	writeInvalidFrame(b)
 
 	s.mockArchive.
@@ -679,7 +679,7 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryRetrySucceedsAfterDiscardError()
 	secondEntry := metaEntry(2)
 
 	b := &bytes.Buffer{}
-	s.Require().NoError(historyarchive.WriteFramedXdr(b, firstEntry))
+	s.Require().NoError(xdr.MarshalFramed(b, firstEntry))
 	writeInvalidFrame(b)
 
 	s.mockArchive.
@@ -765,7 +765,7 @@ func createInvalidXdrStream(closeError error) *historyarchive.XdrStream {
 
 func writeInvalidFrame(b *bytes.Buffer) {
 	bufferSize := b.Len()
-	err := historyarchive.WriteFramedXdr(b, metaEntry(1))
+	err := xdr.MarshalFramed(b, metaEntry(1))
 	if err != nil {
 		panic(err)
 	}
@@ -776,7 +776,7 @@ func writeInvalidFrame(b *bytes.Buffer) {
 func createXdrStream(entries ...xdr.BucketEntry) *historyarchive.XdrStream {
 	b := &bytes.Buffer{}
 	for _, e := range entries {
-		err := historyarchive.WriteFramedXdr(b, e)
+		err := xdr.MarshalFramed(b, e)
 		if err != nil {
 			panic(err)
 		}

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -1,18 +1,8 @@
 package ledgerbackend
 
 import (
-	"bufio"
-	"fmt"
 	"io"
-	"io/ioutil"
-	"math/rand"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"regexp"
-	"strings"
 	"sync"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stellar/go/network"
@@ -56,13 +46,11 @@ func roundDownToFirstReplayAfterCheckpointStart(ledger uint32) uint32 {
 }
 
 type captiveStellarCore struct {
-	nonce             string
 	networkPassphrase string
 	historyURLs       []string
 	lastLedger        *uint32 // end of current segment if offline, nil if online
-	cmd               *exec.Cmd
-	executablePath    string
-	metaPipe          io.Reader
+
+	stellarCoreRunner stellarCoreRunnerInterface
 
 	nextLedgerMutex sync.Mutex
 	nextLedger      uint32 // next ledger expected, error w/ restart if not seen
@@ -74,13 +62,15 @@ type captiveStellarCore struct {
 //
 // Platform-specific pipe setup logic is in the .start() methods.
 func NewCaptive(executablePath, networkPassphrase string, historyURLs []string) *captiveStellarCore {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	return &captiveStellarCore{
-		nonce:             fmt.Sprintf("captive-stellar-core-%x", r.Uint64()),
 		networkPassphrase: networkPassphrase,
-		executablePath:    executablePath,
 		historyURLs:       historyURLs,
 		nextLedger:        0,
+		stellarCoreRunner: &stellarCoreRunner{
+			executablePath:    executablePath,
+			networkPassphrase: networkPassphrase,
+			historyURLs:       historyURLs,
+		},
 	}
 }
 
@@ -187,19 +177,12 @@ func (c *captiveStellarCore) openOfflineReplaySubprocess(nextLedger, lastLedger 
 	if lastLedger > maxLedger {
 		lastLedger = maxLedger
 	}
-	rangeArg := fmt.Sprintf("%d/%d", lastLedger, (lastLedger-nextLedger)+1)
-	args := []string{"--conf", c.getConfFileName(), "catchup", rangeArg,
-		"--replay-in-memory"}
-	cmd := exec.Command(c.executablePath, args...)
-	cmd.Dir = c.getTmpDir()
-	cmd.Stdout = c.getLogLineWriter()
-	cmd.Stderr = cmd.Stdout
-	c.cmd = cmd
-	e = c.start()
-	if e != nil {
-		err := errors.Wrap(e, "starting stellar-core subprocess")
-		return err
+
+	err := c.stellarCoreRunner.run(nextLedger, lastLedger)
+	if err != nil {
+		return errors.Wrap(err, "error running stellar-core")
 	}
+
 	// The next ledger should be the first ledger of the checkpoint containing
 	// the requested ledger
 	c.nextLedgerMutex.Lock()
@@ -218,7 +201,7 @@ func (c *captiveStellarCore) PrepareRange(from uint32, to uint32) error {
 		return errors.Wrap(e, "opening subprocess")
 	}
 
-	if c.metaPipe == nil {
+	if c.stellarCoreRunner.getMetaPipe() == nil {
 		return errors.New("missing metadata pipe")
 	}
 
@@ -255,7 +238,7 @@ func (c *captiveStellarCore) GetLedger(sequence uint32) (bool, LedgerCloseMeta, 
 	}
 
 	// ... and open
-	if c.metaPipe == nil {
+	if c.stellarCoreRunner.getMetaPipe() == nil {
 		return false, LedgerCloseMeta{}, errors.New("missing metadata pipe")
 	}
 
@@ -263,7 +246,7 @@ func (c *captiveStellarCore) GetLedger(sequence uint32) (bool, LedgerCloseMeta, 
 	var errOut error
 	for {
 		var xlcm xdr.LedgerCloseMeta
-		_, e0 := unmarshalFramed(c.metaPipe, &xlcm)
+		_, e0 := unmarshalFramed(c.stellarCoreRunner.getMetaPipe(), &xlcm)
 		if e0 != nil {
 			if e0 == io.EOF {
 				errOut = errors.Wrap(e0, "got EOF from subprocess")
@@ -348,84 +331,10 @@ func (c *captiveStellarCore) Close() error {
 	c.nextLedgerMutex.Unlock()
 
 	c.lastLedger = nil
-	var e1, e2 error
-	if c.metaPipe != nil {
-		c.metaPipe = nil
-	}
-	if c.processIsAlive() {
-		e1 = c.cmd.Process.Kill()
-		c.cmd.Wait()
-		c.cmd = nil
-	}
-	e2 = os.RemoveAll(c.getTmpDir())
-	if e1 != nil {
-		return errors.Wrap(e1, "error killing subprocess")
-	}
-	if e2 != nil {
-		return errors.Wrap(e2, "error removing subprocess tmpdir")
+
+	err := c.stellarCoreRunner.close()
+	if err != nil {
+		return errors.Wrap(err, "error closing stellar-core subprocess")
 	}
 	return nil
-}
-
-func (c *captiveStellarCore) getTmpDir() string {
-	return filepath.Join(os.TempDir(), c.nonce)
-}
-
-func (c *captiveStellarCore) getConfFileName() string {
-	return filepath.Join(c.getTmpDir(), "stellar-core.conf")
-}
-
-func (c *captiveStellarCore) getConf() string {
-	lines := []string{
-		"# Generated file -- do not edit",
-		"RUN_STANDALONE=true",
-		"NODE_IS_VALIDATOR=false",
-		"DISABLE_XDR_FSYNC=true",
-		"UNSAFE_QUORUM=true",
-		fmt.Sprintf(`NETWORK_PASSPHRASE="%s"`, c.networkPassphrase),
-		fmt.Sprintf(`BUCKET_DIR_PATH="%s"`, filepath.Join(c.getTmpDir(), "buckets")),
-		fmt.Sprintf(`METADATA_OUTPUT_STREAM="%s"`, c.getPipeName()),
-	}
-	for i, val := range c.historyURLs {
-		lines = append(lines, fmt.Sprintf("[HISTORY.h%d]", i))
-		lines = append(lines, fmt.Sprintf(`get="curl -sf %s/{0} -o {1}"`, val))
-	}
-	// Add a fictional quorum -- necessary to convince core to start up;
-	// but not used at all for our purposes. Pubkey here is just random.
-	lines = append(lines,
-		"[QUORUM_SET]",
-		"THRESHOLD_PERCENT=100",
-		`VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]`)
-	return strings.ReplaceAll(strings.Join(lines, "\n"), "\\", "\\\\")
-}
-
-func (c *captiveStellarCore) getLogLineWriter() io.Writer {
-	r, w := io.Pipe()
-	br := bufio.NewReader(r)
-	// Strip timestamps from log lines from captive stellar-core. We emit our own.
-	dateRx := regexp.MustCompile("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3} ")
-	go func() {
-		for {
-			line, e := br.ReadString('\n')
-			if e != nil {
-				break
-			}
-			line = dateRx.ReplaceAllString(line, "")
-			// Leaving for debug purposes:
-			// fmt.Print(line)
-		}
-	}()
-	return w
-}
-
-// Makes the temp directory and writes the config file to it; called by the
-// platform-specific captiveStellarCore.Start() methods.
-func (c *captiveStellarCore) writeConf() error {
-	dir := c.getTmpDir()
-	e := os.MkdirAll(dir, 0755)
-	if e != nil {
-		return errors.Wrap(e, "error creating subprocess tmpdir")
-	}
-	conf := c.getConf()
-	return ioutil.WriteFile(c.getConfFileName(), []byte(conf), 0644)
 }

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -88,37 +88,6 @@ func (c *captiveStellarCore) IsInOnlineTrackingMode() bool {
 	return c.lastLedger == nil
 }
 
-// XDR and RPC define a (minimal) framing format which our metadata arrives in: a 4-byte
-// big-endian length header that has the high bit set, followed by that length worth of
-// XDR data. Decoding this involves just a little more work than xdr.Unmarshal.
-func unmarshalFramed(r io.Reader, v interface{}) (int, error) {
-	var frameLen uint32
-	n, e := xdr.Unmarshal(r, &frameLen)
-	if e != nil {
-		err := errors.Wrap(e, "unmarshalling XDR frame header")
-		return n, err
-	}
-	if n != 4 {
-		err := errors.New("bad length of XDR frame header")
-		return n, err
-	}
-	if (frameLen & 0x80000000) != 0x80000000 {
-		err := errors.New("malformed XDR frame header")
-		return n, err
-	}
-	frameLen &= 0x7fffffff
-	m, e := xdr.Unmarshal(r, v)
-	if e != nil {
-		err := errors.Wrap(e, "unmarshalling framed XDR")
-		return n + m, err
-	}
-	if int64(m) != int64(frameLen) {
-		err := errors.New("bad length of XDR frame body")
-		return n + m, err
-	}
-	return m + n, nil
-}
-
 // Returns the sequence number of an LCM, returning an error if the LCM is of
 // an unknown version.
 func peekLedgerSequence(xlcm *xdr.LedgerCloseMeta) (uint32, error) {
@@ -238,7 +207,8 @@ func (c *captiveStellarCore) GetLedger(sequence uint32) (bool, LedgerCloseMeta, 
 	}
 
 	// ... and open
-	if c.stellarCoreRunner.getMetaPipe() == nil {
+	metaPipe := c.stellarCoreRunner.getMetaPipe()
+	if metaPipe == nil {
 		return false, LedgerCloseMeta{}, errors.New("missing metadata pipe")
 	}
 
@@ -246,7 +216,7 @@ func (c *captiveStellarCore) GetLedger(sequence uint32) (bool, LedgerCloseMeta, 
 	var errOut error
 	for {
 		var xlcm xdr.LedgerCloseMeta
-		_, e0 := unmarshalFramed(c.stellarCoreRunner.getMetaPipe(), &xlcm)
+		_, e0 := xdr.UnmarshalFramed(metaPipe, &xlcm)
 		if e0 != nil {
 			if e0 == io.EOF {
 				errOut = errors.Wrap(e0, "got EOF from subprocess")
@@ -264,7 +234,7 @@ func (c *captiveStellarCore) GetLedger(sequence uint32) (bool, LedgerCloseMeta, 
 		c.nextLedgerMutex.Lock()
 		if seq != c.nextLedger {
 			// We got something unexpected; close and reset
-			errOut = errors.Errorf("unexpected ledger %d", seq)
+			errOut = errors.Errorf("unexpected ledger (expected=%d actual=%d)", c.nextLedger, seq)
 			c.nextLedgerMutex.Unlock()
 			break
 		}

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -1,8 +1,6 @@
 package ledgerbackend
 
 import (
-	"encoding/hex"
-	"fmt"
 	"io"
 	"sync"
 
@@ -117,8 +115,6 @@ func (c *captiveStellarCore) copyLedgerCloseMeta(xlcm *xdr.LedgerCloseMeta, lcm 
 			return errors.Wrap(e, "error hashing tx in LedgerCloseMeta")
 		}
 		envelopes[hash] = tx
-		a := hex.EncodeToString(hash[:])
-		fmt.Println(a)
 	}
 	for _, trm := range v0.TxProcessing {
 		txe, ok := envelopes[trm.Result.TransactionHash]

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -1,6 +1,8 @@
 package ledgerbackend
 
 import (
+	"encoding/hex"
+	"fmt"
 	"io"
 	"sync"
 
@@ -115,6 +117,8 @@ func (c *captiveStellarCore) copyLedgerCloseMeta(xlcm *xdr.LedgerCloseMeta, lcm 
 			return errors.Wrap(e, "error hashing tx in LedgerCloseMeta")
 		}
 		envelopes[hash] = tx
+		a := hex.EncodeToString(hash[:])
+		fmt.Println(a)
 	}
 	for _, trm := range v0.TxProcessing {
 		txe, ok := envelopes[trm.Result.TransactionHash]

--- a/exp/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend_test.go
@@ -1,31 +1,76 @@
 package ledgerbackend
 
 import (
+	"bytes"
+	"io"
 	"testing"
 
-	"github.com/stellar/go/support/log"
-	logpkg "github.com/stellar/go/support/log"
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 // TODO: test frame decoding
 // TODO: test from static base64-encoded data
 
-func TestCaptiveCore(t *testing.T) {
-	log.SetLevel(logpkg.InfoLevel)
-	c := NewCaptive(
-		"stellar-core",
-		"Public Global Stellar Network ; September 2015",
-		[]string{"http://history.stellar.org/prd/core-live/core_live_001"},
-	)
-	seq, e := c.GetLatestLedgerSequence()
-	assert.NoError(t, e)
-	assert.Greater(t, seq, uint32(0))
-	ok, lcm, e := c.GetLedger(seq - 200)
-	assert.NoError(t, e)
-	assert.Equal(t, true, ok)
-	assert.Equal(t, uint32(lcm.LedgerHeader.Header.LedgerSeq), seq-200)
-	assert.DirExists(t, c.getTmpDir())
-	e = c.Close()
-	assert.NoError(t, e)
+type stellarCoreRunnerMock struct {
+	mock.Mock
+}
+
+func (m *stellarCoreRunnerMock) run(from, to uint32) error {
+	a := m.Called(from, to)
+	return a.Error(0)
+}
+
+func (m *stellarCoreRunnerMock) getMetaPipe() io.Reader {
+	a := m.Called()
+	return a.Get(0).(io.Reader)
+}
+
+func (m *stellarCoreRunnerMock) close() error {
+	a := m.Called()
+	return a.Error(0)
+}
+
+func writeLedgerHeader(w io.Writer, sequence uint32) error {
+	ledgerCloseMeta := xdr.LedgerCloseMeta{
+		V: 0,
+		V0: &xdr.LedgerCloseMetaV0{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					LedgerSeq: xdr.Uint32(sequence),
+				},
+			},
+		},
+	}
+
+	return xdr.MarshalFramed(w, ledgerCloseMeta)
+}
+
+func TestPrepareRange(t *testing.T) {
+	var buf bytes.Buffer
+
+	// Core will actually start with the last checkpoint before the from ledger
+	// and then rewind to the `from` ledger.
+	for i := 64; i <= 99; i++ {
+		writeLedgerHeader(&buf, uint32(i))
+	}
+
+	mockRunner := &stellarCoreRunnerMock{}
+	// We prepare [from-1, to] range because it's not possible to rewind the reader
+	// and there is no other way to check if stellar-core has built the state without
+	// reading actual ledger.
+	mockRunner.On("run", uint32(99), uint32(200)).Return(nil).Once()
+	mockRunner.On("getMetaPipe").Return(&buf)
+	mockRunner.On("close").Return(nil).Once()
+
+	captiveBackend := captiveStellarCore{
+		networkPassphrase: network.PublicNetworkPassphrase,
+		historyURLs:       []string{"http://history.stellar.org/prd/core-live/core_live_001"},
+		stellarCoreRunner: mockRunner,
+	}
+
+	err := captiveBackend.PrepareRange(100, 200)
+	assert.NoError(t, err)
 }

--- a/exp/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend_test.go
@@ -2,6 +2,7 @@ package ledgerbackend
 
 import (
 	"bytes"
+	"encoding/hex"
 	"io"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // TODO: test frame decoding
@@ -34,6 +36,13 @@ func (m *stellarCoreRunnerMock) close() error {
 }
 
 func writeLedgerHeader(w io.Writer, sequence uint32) error {
+	opResults := []xdr.OperationResult{}
+	opMeta := []xdr.OperationMeta{}
+
+	tmpHash, _ := hex.DecodeString("cde54da3901f5b9c0331d24fbb06ac9c5c5de76de9fb2d4a7b86c09e46f11d8c")
+	var hash [32]byte
+	copy(hash[:], tmpHash)
+
 	ledgerCloseMeta := xdr.LedgerCloseMeta{
 		V: 0,
 		V0: &xdr.LedgerCloseMetaV0{
@@ -42,19 +51,70 @@ func writeLedgerHeader(w io.Writer, sequence uint32) error {
 					LedgerSeq: xdr.Uint32(sequence),
 				},
 			},
+			TxSet: xdr.TransactionSet{
+				Txs: []xdr.TransactionEnvelope{
+					{
+						Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+						V1: &xdr.TransactionV1Envelope{
+							Tx: xdr.Transaction{
+								SourceAccount: xdr.MustMuxedAccountAddress("GAEJJMDDCRYF752PKIJICUVL7MROJBNXDV2ZB455T7BAFHU2LCLSE2LW"),
+								Fee:           xdr.Uint32(sequence),
+							},
+						},
+					},
+				},
+			},
+			TxProcessing: []xdr.TransactionResultMeta{
+				{
+					Result: xdr.TransactionResultPair{
+						TransactionHash: xdr.Hash(hash),
+						Result: xdr.TransactionResult{
+							FeeCharged: xdr.Int64(sequence),
+							Result: xdr.TransactionResultResult{
+								Code:    xdr.TransactionResultCodeTxSuccess,
+								Results: &opResults,
+							},
+						},
+					},
+					TxApplyProcessing: xdr.TransactionMeta{
+						Operations: &opMeta,
+					},
+				},
+			},
 		},
 	}
 
 	return xdr.MarshalFramed(w, ledgerCloseMeta)
 }
 
-func TestPrepareRange(t *testing.T) {
+func TestCaptiveNew(t *testing.T) {
+	executablePath := "/etc/stellar-core"
+	networkPassphrase := network.PublicNetworkPassphrase
+	historyURLs := []string{"http://history.stellar.org/prd/core-live/core_live_001"}
+
+	captiveStellarCore := NewCaptive(
+		executablePath,
+		networkPassphrase,
+		historyURLs,
+	)
+
+	assert.Equal(t, networkPassphrase, captiveStellarCore.networkPassphrase)
+	assert.Equal(t, historyURLs, captiveStellarCore.historyURLs)
+	assert.Equal(t, uint32(0), captiveStellarCore.nextLedger)
+
+	assert.Equal(t, executablePath, captiveStellarCore.stellarCoreRunner.(*stellarCoreRunner).executablePath)
+	assert.Equal(t, networkPassphrase, captiveStellarCore.stellarCoreRunner.(*stellarCoreRunner).networkPassphrase)
+	assert.Equal(t, historyURLs, captiveStellarCore.stellarCoreRunner.(*stellarCoreRunner).historyURLs)
+}
+
+func TestCaptivePrepareRange(t *testing.T) {
 	var buf bytes.Buffer
 
 	// Core will actually start with the last checkpoint before the from ledger
 	// and then rewind to the `from` ledger.
 	for i := 64; i <= 99; i++ {
-		writeLedgerHeader(&buf, uint32(i))
+		err := writeLedgerHeader(&buf, uint32(i))
+		require.NoError(t, err)
 	}
 
 	mockRunner := &stellarCoreRunnerMock{}
@@ -72,5 +132,7 @@ func TestPrepareRange(t *testing.T) {
 	}
 
 	err := captiveBackend.PrepareRange(100, 200)
+	assert.NoError(t, err)
+	err = captiveBackend.Close()
 	assert.NoError(t, err)
 }

--- a/exp/ingest/ledgerbackend/stellar_core_runner.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner.go
@@ -1,0 +1,143 @@
+package ledgerbackend
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type stellarCoreRunnerInterface interface {
+	run(from, to uint32) error
+	getMetaPipe() io.Reader
+	close() error
+}
+
+type stellarCoreRunner struct {
+	executablePath    string
+	networkPassphrase string
+	historyURLs       []string
+
+	cmd      *exec.Cmd
+	metaPipe io.Reader
+	tempDir  string
+}
+
+func (r *stellarCoreRunner) getConf() string {
+	lines := []string{
+		"# Generated file -- do not edit",
+		"RUN_STANDALONE=true",
+		"NODE_IS_VALIDATOR=false",
+		"DISABLE_XDR_FSYNC=true",
+		"UNSAFE_QUORUM=true",
+		fmt.Sprintf(`NETWORK_PASSPHRASE="%s"`, r.networkPassphrase),
+		fmt.Sprintf(`BUCKET_DIR_PATH="%s"`, filepath.Join(r.getTmpDir(), "buckets")),
+		fmt.Sprintf(`METADATA_OUTPUT_STREAM="%s"`, r.getPipeName()),
+	}
+	for i, val := range r.historyURLs {
+		lines = append(lines, fmt.Sprintf("[HISTORY.h%d]", i))
+		lines = append(lines, fmt.Sprintf(`get="curl -sf %s/{0} -o {1}"`, val))
+	}
+	// Add a fictional quorum -- necessary to convince core to start up;
+	// but not used at all for our purposes. Pubkey here is just random.
+	lines = append(lines,
+		"[QUORUM_SET]",
+		"THRESHOLD_PERCENT=100",
+		`VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]`)
+	return strings.ReplaceAll(strings.Join(lines, "\n"), "\\", "\\\\")
+}
+
+func (r *stellarCoreRunner) getConfFileName() string {
+	return filepath.Join(r.getTmpDir(), "stellar-core.conf")
+}
+
+func (*stellarCoreRunner) getLogLineWriter() io.Writer {
+	r, w := io.Pipe()
+	br := bufio.NewReader(r)
+	// Strip timestamps from log lines from captive stellar-core. We emit our own.
+	dateRx := regexp.MustCompile("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3} ")
+	go func() {
+		for {
+			line, e := br.ReadString('\n')
+			if e != nil {
+				break
+			}
+			line = dateRx.ReplaceAllString(line, "")
+			// Leaving for debug purposes:
+			// fmt.Print(line)
+		}
+	}()
+	return w
+}
+
+func (r *stellarCoreRunner) getTmpDir() string {
+	if r.tempDir != "" {
+		return r.tempDir
+	}
+	random := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r.tempDir = filepath.Join(os.TempDir(), fmt.Sprintf("captive-stellar-core-%x", random.Uint64()))
+	return r.tempDir
+}
+
+// Makes the temp directory and writes the config file to it; called by the
+// platform-specific captiveStellarCore.Start() methods.
+func (r *stellarCoreRunner) writeConf() error {
+	dir := r.getTmpDir()
+	e := os.MkdirAll(dir, 0755)
+	if e != nil {
+		return errors.Wrap(e, "error creating subprocess tmpdir")
+	}
+	conf := r.getConf()
+	return ioutil.WriteFile(r.getConfFileName(), []byte(conf), 0644)
+}
+
+func (r *stellarCoreRunner) run(from, to uint32) error {
+	err := r.writeConf()
+	if err != nil {
+		return errors.Wrap(err, "error writing configuration")
+	}
+
+	rangeArg := fmt.Sprintf("%d/%d", to, to-from+1)
+	args := []string{"--conf", r.getConfFileName(), "catchup", rangeArg, "--replay-in-memory"}
+	cmd := exec.Command(r.executablePath, args...)
+	cmd.Dir = r.getTmpDir()
+	cmd.Stdout = r.getLogLineWriter()
+	cmd.Stderr = cmd.Stdout
+	r.cmd = cmd
+	err = r.start()
+	if err != nil {
+		return errors.Wrap(err, "error starting stellar-core subprocess")
+	}
+	return nil
+}
+
+func (r *stellarCoreRunner) getMetaPipe() io.Reader {
+	return r.metaPipe
+}
+
+func (r *stellarCoreRunner) close() error {
+	var err1, err2 error
+
+	if r.processIsAlive() {
+		err1 = r.cmd.Process.Kill()
+		r.cmd.Wait()
+		r.cmd = nil
+	}
+	err2 = os.RemoveAll(r.getTmpDir())
+	if err1 != nil {
+		return errors.Wrap(err1, "error killing subprocess")
+	}
+	if err2 != nil {
+		return errors.Wrap(err2, "error removing subprocess tmpdir")
+	}
+	return nil
+}

--- a/exp/ingest/ledgerbackend/stellar_core_runner.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner.go
@@ -1,7 +1,6 @@
 package ledgerbackend
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -9,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -61,21 +59,20 @@ func (r *stellarCoreRunner) getConfFileName() string {
 }
 
 func (*stellarCoreRunner) getLogLineWriter() io.Writer {
-	r, w := io.Pipe()
-	br := bufio.NewReader(r)
-	// Strip timestamps from log lines from captive stellar-core. We emit our own.
-	dateRx := regexp.MustCompile("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3} ")
-	go func() {
-		for {
-			line, e := br.ReadString('\n')
-			if e != nil {
-				break
-			}
-			line = dateRx.ReplaceAllString(line, "")
-			// Leaving for debug purposes:
-			// fmt.Print(line)
-		}
-	}()
+	_, w := io.Pipe()
+	// br := bufio.NewReader(r)
+	// // Strip timestamps from log lines from captive stellar-core. We emit our own.
+	// dateRx := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3} `)
+	// go func() {
+	// 	for {
+	// 		line, e := br.ReadString('\n')
+	// 		if e != nil {
+	// 			break
+	// 		}
+	// 		line = dateRx.ReplaceAllString(line, "")
+	// 		fmt.Print(line)
+	// 	}
+	// }()
 	return w
 }
 

--- a/exp/ingest/ledgerbackend/stellar_core_runner_posix.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner_posix.go
@@ -10,9 +10,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Posix-specific methods for the captiveStellarCore type.
+// Posix-specific methods for the stellarCoreRunner type.
 
-func (c *captiveStellarCore) getPipeName() string {
+func (c *stellarCoreRunner) getPipeName() string {
 	// The exec.Cmd.ExtraFiles field carries *io.File values that are assigned
 	// to child process fds counting from 3, and we'll be passing exactly one
 	// fd: the write end of the anonymous pipe below.
@@ -20,8 +20,7 @@ func (c *captiveStellarCore) getPipeName() string {
 }
 
 // Starts the subprocess and sets the c.metaPipe field
-func (c *captiveStellarCore) start() error {
-
+func (c *stellarCoreRunner) start() error {
 	// First make an anonymous pipe.
 	// Note io.File objects close-on-finalization.
 	readFile, writeFile, e := os.Pipe()
@@ -55,7 +54,7 @@ func (c *captiveStellarCore) start() error {
 	return nil
 }
 
-func (c *captiveStellarCore) processIsAlive() bool {
+func (c *stellarCoreRunner) processIsAlive() bool {
 	if c.cmd == nil {
 		return false
 	}

--- a/exp/ingest/ledgerbackend/stellar_core_runner_windows.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner_windows.go
@@ -5,17 +5,18 @@ package ledgerbackend
 import (
 	"bufio"
 	"fmt"
-	"github.com/Microsoft/go-winio"
 	"os"
+
+	"github.com/Microsoft/go-winio"
 )
 
-// Windows-specific methods for the captiveStellarCore type.
+// Windows-specific methods for the stellarCoreRunner type.
 
-func (c *captiveStellarCore) getPipeName() string {
+func (c *stellarCoreRunner) getPipeName() string {
 	return fmt.Sprintf(`\\.\pipe\%s`, c.nonce)
 }
 
-func (c *captiveStellarCore) start() error {
+func (c *stellarCoreRunner) start() error {
 	// First set up the server pipe.
 	listener, e := winio.ListenPipe(c.getPipeName(), nil)
 	if e != nil {

--- a/services/horizon/internal/expingest/ingest_history_range_state_test.go
+++ b/services/horizon/internal/expingest/ingest_history_range_state_test.go
@@ -180,6 +180,7 @@ type ReingestHistoryRangeStateTestSuite struct {
 	suite.Suite
 	historyQ       *mockDBQ
 	historyAdapter *adapters.MockHistoryArchiveAdapter
+	ledgerBackend  *mockLedgerBackend
 	runner         *mockProcessorsRunner
 	system         *System
 }
@@ -187,17 +188,21 @@ type ReingestHistoryRangeStateTestSuite struct {
 func (s *ReingestHistoryRangeStateTestSuite) SetupTest() {
 	s.historyQ = &mockDBQ{}
 	s.historyAdapter = &adapters.MockHistoryArchiveAdapter{}
+	s.ledgerBackend = &mockLedgerBackend{}
 	s.runner = &mockProcessorsRunner{}
 	s.system = &System{
 		ctx:            context.Background(),
 		historyQ:       s.historyQ,
 		historyAdapter: s.historyAdapter,
+		ledgerBackend:  s.ledgerBackend,
 		runner:         s.runner,
 	}
 
 	s.historyQ.On("GetTx").Return(nil).Once()
 	s.historyQ.On("Rollback").Return(nil).Once()
 	s.historyQ.On("Begin").Return(nil).Once()
+
+	s.ledgerBackend.On("PrepareRange", uint32(100), uint32(200)).Return(nil).Once()
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TearDownTest() {
@@ -356,7 +361,6 @@ func (s *ReingestHistoryRangeStateTestSuite) TestSuccess() {
 
 func (s *ReingestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
 	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
-
 	s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
 
 	toidFrom := toid.New(100, 0, 0)
@@ -367,6 +371,10 @@ func (s *ReingestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
 
 	s.runner.On("RunTransactionProcessorsOnLedger", uint32(100)).Return(io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 	s.historyQ.On("Commit").Return(nil).Once()
+
+	// Recreate mock in this single test to remove previous assertion.
+	*s.ledgerBackend = mockLedgerBackend{}
+	s.ledgerBackend.On("PrepareRange", uint32(100), uint32(100)).Return(nil).Once()
 
 	err := s.system.ReingestRange(100, 100, false)
 	s.Assert().NoError(err)

--- a/services/horizon/internal/expingest/main_test.go
+++ b/services/horizon/internal/expingest/main_test.go
@@ -359,6 +359,30 @@ func (m *mockDBQ) CreateAssets(assets []xdr.Asset, batchSize int) (map[string]hi
 	return args.Get(0).(map[string]history.Asset), args.Error(1)
 }
 
+type mockLedgerBackend struct {
+	mock.Mock
+}
+
+func (m *mockLedgerBackend) GetLatestLedgerSequence() (sequence uint32, err error) {
+	args := m.Called()
+	return args.Get(0).(uint32), args.Error(1)
+}
+
+func (m *mockLedgerBackend) GetLedger(sequence uint32) (bool, ledgerbackend.LedgerCloseMeta, error) {
+	args := m.Called(sequence)
+	return args.Get(0).(bool), args.Get(1).(ledgerbackend.LedgerCloseMeta), args.Error(2)
+}
+
+func (m *mockLedgerBackend) PrepareRange(from uint32, to uint32) error {
+	args := m.Called(from, to)
+	return args.Error(0)
+}
+
+func (m *mockLedgerBackend) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 type mockProcessorsRunner struct {
 	mock.Mock
 }

--- a/support/historyarchive/verify.go
+++ b/support/historyarchive/verify.go
@@ -228,7 +228,7 @@ func (arch *Archive) VerifyBucketEntries(h Hash) error {
 		var entry xdr.BucketEntry
 		err = rdr.ReadOne(&entry)
 		if err == nil {
-			err2 := WriteFramedXdr(hsh, &entry)
+			err2 := xdr.MarshalFramed(hsh, &entry)
 			if err2 != nil {
 				return err2
 			}

--- a/support/historyarchive/xdrstream.go
+++ b/support/historyarchive/xdrstream.go
@@ -189,23 +189,3 @@ func (x *XdrStream) BytesRead() int64 {
 func (x *XdrStream) Discard(n int64) (int64, error) {
 	return io.CopyN(ioutil.Discard, x.rdr, n)
 }
-
-func WriteFramedXdr(out io.Writer, in interface{}) error {
-	var tmp bytes.Buffer
-	n, err := xdr.Marshal(&tmp, in)
-	if err != nil {
-		return err
-	}
-	un := uint32(n)
-	if un > 0x7fffffff {
-		return fmt.Errorf("Overlong write: %d bytes", n)
-	}
-
-	un = un | 0x80000000
-	binary.Write(out, binary.BigEndian, &un)
-	k, err := tmp.WriteTo(out)
-	if int64(n) != k {
-		return fmt.Errorf("Mismatched write length: %d vs. %d", n, k)
-	}
-	return err
-}

--- a/support/historyarchive/xdrstream_test.go
+++ b/support/historyarchive/xdrstream_test.go
@@ -35,7 +35,7 @@ func TestXdrStreamHash(t *testing.T) {
 	// - uint32 representing the number of bytes of a structure,
 	// - xdr-encoded `BucketEntry` above.
 	b := &bytes.Buffer{}
-	err := WriteFramedXdr(b, bucketEntry)
+	err := xdr.MarshalFramed(b, bucketEntry)
 	require.NoError(t, err)
 
 	expectedHash := sha256.Sum256(b.Bytes())
@@ -82,8 +82,8 @@ func TestXdrStreamDiscard(t *testing.T) {
 
 	fullStream := createXdrStream(firstEntry, secondEntry)
 	b := &bytes.Buffer{}
-	require.NoError(t, WriteFramedXdr(b, firstEntry))
-	require.NoError(t, WriteFramedXdr(b, secondEntry))
+	require.NoError(t, xdr.MarshalFramed(b, firstEntry))
+	require.NoError(t, xdr.MarshalFramed(b, secondEntry))
 	expectedHash := sha256.Sum256(b.Bytes())
 	fullStream.SetExpectedHash(expectedHash)
 
@@ -121,7 +121,7 @@ func TestXdrStreamDiscard(t *testing.T) {
 func createXdrStream(entries ...xdr.BucketEntry) *XdrStream {
 	b := &bytes.Buffer{}
 	for _, e := range entries {
-		err := WriteFramedXdr(b, e)
+		err := xdr.MarshalFramed(b, e)
 		if err != nil {
 			panic(err)
 		}

--- a/xdr/main.go
+++ b/xdr/main.go
@@ -5,9 +5,13 @@ package xdr
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"strings"
+
+	xdr "github.com/stellar/go-xdr/xdr3"
+	"github.com/stellar/go/support/errors"
 )
 
 // Keyer represents a type that can be converted into a LedgerKey
@@ -67,6 +71,55 @@ func MarshalBase64(v interface{}) (string, error) {
 	}
 
 	return base64.StdEncoding.EncodeToString(raw.Bytes()), nil
+}
+
+func MarshalFramed(w io.Writer, v interface{}) error {
+	var tmp bytes.Buffer
+	n, err := Marshal(&tmp, v)
+	if err != nil {
+		return err
+	}
+	un := uint32(n)
+	if un > 0x7fffffff {
+		return fmt.Errorf("Overlong write: %d bytes", n)
+	}
+
+	un = un | 0x80000000
+	err = binary.Write(w, binary.BigEndian, &un)
+	if err != nil {
+		return errors.Wrap(err, "error in binary.Write")
+	}
+	k, err := tmp.WriteTo(w)
+	if int64(n) != k {
+		return fmt.Errorf("Mismatched write length: %d vs. %d", n, k)
+	}
+	return err
+}
+
+// XDR and RPC define a (minimal) framing format which our metadata arrives in: a 4-byte
+// big-endian length header that has the high bit set, followed by that length worth of
+// XDR data. Decoding this involves just a little more work than xdr.Unmarshal.
+func UnmarshalFramed(r io.Reader, v interface{}) (int, error) {
+	var frameLen uint32
+	n, e := Unmarshal(r, &frameLen)
+	if e != nil {
+		return n, errors.Wrap(e, "unmarshalling XDR frame header")
+	}
+	if n != 4 {
+		return n, errors.New("bad length of XDR frame header")
+	}
+	if (frameLen & 0x80000000) != 0x80000000 {
+		return n, errors.New("malformed XDR frame header")
+	}
+	frameLen &= 0x7fffffff
+	m, err := xdr.Unmarshal(r, v)
+	if err != nil {
+		return n + m, errors.Wrap(err, "unmarshalling framed XDR")
+	}
+	if int64(m) != int64(frameLen) {
+		return n + m, errors.New("bad length of XDR frame body")
+	}
+	return m + n, nil
 }
 
 type countWriter struct {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit refactors `captiveStellarCore` ledger backend and adds tests.

Close #2585.

### Why

`stellarCoreRunner` has been extracted from `captiveStellarCore` to allow mocking stellar-core runs. This makes it possible to write tests that do not execute `stellar-core` binary.

Functions marshalling and unmarshalling _framed_ XDR have been moved to `xdr` package.

### Known limitations

* This change was added to be able to write any tests. Integration tests should follow at some point in time in the future.
