### PR TITLE
Update Gemfile.lock.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/stellar/stellar_core_commander.git
-  revision: 154c81daae1ae9acd41e81e1740e8e961124d8bd
+  revision: 59cde2af715c9c264dacb77e608a5d61b7d41a88
   branch: master
   specs:
     stellar_core_commander (0.0.13)
-      activesupport (>= 5.2.0)
+      activesupport (~> 6)
       contracts (~> 0.16)
       faraday (~> 0.9.1)
       faraday_middleware (~> 0.9.1)
@@ -18,11 +18,11 @@ GIT
 
 GIT
   remote: https://github.com/stellar/xdrgen.git
-  revision: c56e3ff84b325e2c28b3668a8c98be89886adf2a
+  revision: d30a909ff8d782dee7eadc0b4e02a89e4195eb79
   branch: master
   specs:
     xdrgen (0.0.1)
-      activesupport (~> 5)
+      activesupport (~> 6)
       memoist (~> 0.11.0)
       slop (~> 3.4)
       treetop (~> 1.5.3)
@@ -30,80 +30,79 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.1)
-      activesupport (= 5.2.1)
-    activesupport (5.2.1)
+    activemodel (6.0.3.1)
+      activesupport (= 6.0.3.1)
+    activesupport (6.0.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     base32 (0.3.2)
     citrus (3.0.2)
     coderay (1.1.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.6)
     contracts (0.16.0)
-    digest-crc (0.4.1)
-    ethon (0.11.0)
+    digest-crc (0.5.1)
+    ethon (0.12.0)
       ffi (>= 1.3.0)
-    excon (0.71.0)
+    excon (0.73.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    faraday-digestauth (0.3.0)
-      faraday (~> 0.7)
+    faraday-digestauth (0.4.1)
+      faraday (>= 0.7)
       net-http-digest_auth (~> 1.4)
-    faraday_hal_middleware (0.1.0)
-      faraday_middleware (~> 0.9)
+    faraday_hal_middleware (0.1.1)
+      faraday_middleware (>= 0.9)
     faraday_middleware (0.9.2)
       faraday (>= 0.7.4, < 0.10)
-    ffi (1.9.25)
-    hyperclient (0.9.0)
+    ffi (1.12.2)
+    hyperclient (0.9.3)
+      addressable
       faraday (>= 0.9.0)
-      faraday-digestauth
+      faraday-digestauth (>= 0.3.0)
       faraday_hal_middleware
       faraday_middleware
       net-http-digest_auth
-      uri_template
-    i18n (1.1.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     memoist (0.11.0)
-    method_source (0.9.0)
-    minitest (5.11.3)
-    multipart-post (2.0.0)
+    method_source (0.9.2)
+    minitest (5.14.1)
+    multipart-post (2.1.1)
     net-http-digest_auth (1.4.1)
     netrc (0.11.0)
-    octokit (4.12.0)
+    octokit (4.18.0)
+      faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     pg (0.18.4)
     polyglot (0.3.5)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (3.0.3)
+    public_suffix (4.0.5)
     rake (13.0.1)
-    rbnacl (5.0.0)
+    rbnacl (7.1.1)
       ffi
-    rbnacl-libsodium (1.0.16)
-      rbnacl (>= 3.0.1)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
     sequel (5.5.0)
     slop (3.6.0)
-    stellar-base (0.17.0)
-      activesupport (>= 5.2.0)
+    stellar-base (0.22.0)
+      activesupport (>= 5.0.0)
       base32
       digest-crc
-      rbnacl
-      rbnacl-libsodium (~> 1.0.16)
+      rbnacl (>= 6.0)
       xdr (~> 3.0.0)
-    stellar-sdk (0.5.0)
-      activesupport (>= 5.2.0)
+    stellar-sdk (0.8.0)
+      activesupport (>= 5.0)
       contracts (~> 0.16)
       excon (~> 0.44, >= 0.44.4)
       hyperclient (~> 0.7)
-      stellar-base (>= 0.16.0)
+      stellar-base (>= 0.22.0)
       toml-rb (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
     toml-rb (1.1.2)
@@ -112,12 +111,12 @@ GEM
       polyglot (~> 0.3)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
-    tzinfo (1.2.5)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
-    uri_template (0.7.0)
     xdr (3.0.0)
       activemodel (>= 5.2.0)
       activesupport (>= 5.2.0)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
@@ -131,4 +130,4 @@ DEPENDENCIES
   xdrgen!
 
 BUNDLED WITH
-   1.16.5
+   1.17.2


### PR DESCRIPTION
Re-run bundle update to pick the latest version of `activesupport` via `xdrgen` and `stellar_ruby_commander`.