### PR TITLE
services/horizon: Gracefully handle incorrect assets in `GET /offers`

### DIFF
--- a/services/horizon/internal/actions/helpers_test.go
+++ b/services/horizon/internal/actions/helpers_test.go
@@ -697,7 +697,10 @@ func TestGetParams(t *testing.T) {
 
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(account, qp.Account)
-	tt.Assert.True(usd.Equals(*qp.Selling()))
+	selling, err := qp.Selling()
+	tt.Assert.NoError(err)
+	tt.Assert.NotNil(selling)
+	tt.Assert.True(usd.Equals(*selling))
 
 	urlParams = map[string]string{
 		"account_id":         account,
@@ -710,7 +713,10 @@ func TestGetParams(t *testing.T) {
 
 	tt.Assert.NoError(err)
 	native := xdr.MustNewNativeAsset()
-	tt.Assert.True(native.Equals(*qp.Selling()))
+	selling, err = qp.Selling()
+	tt.Assert.NoError(err)
+	tt.Assert.NotNil(selling)
+	tt.Assert.True(native.Equals(*selling))
 
 	urlParams = map[string]string{"account_id": "1"}
 	r = makeAction("/transactions?limit=2&cursor=123456&order=desc", urlParams).R

--- a/services/horizon/internal/actions/offer.go
+++ b/services/horizon/internal/actions/offer.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/stellar/go/protocols/horizon"
@@ -10,7 +9,6 @@ import (
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"
-	"github.com/stellar/go/support/render/problem"
 )
 
 // GetOfferByID is the action handler for the /offers/{id} endpoint
@@ -94,15 +92,11 @@ func (handler GetOffersHandler) GetResourcePage(
 
 	selling, err := qp.Selling()
 	if err != nil {
-		p := problem.BadRequest
-		p.Extras = map[string]interface{}{"reason": fmt.Sprintf("bad selling asset: %s", err.Error())}
-		return nil, p
+		return nil, err
 	}
 	buying, err := qp.Buying()
 	if err != nil {
-		p := problem.BadRequest
-		p.Extras = map[string]interface{}{"reason": fmt.Sprintf("bad buying asset: %s", err.Error())}
-		return nil, p
+		return nil, err
 	}
 
 	query := history.OffersQuery{

--- a/services/horizon/internal/actions/offer_test.go
+++ b/services/horizon/internal/actions/offer_test.go
@@ -393,6 +393,31 @@ func TestGetOffersHandler(t *testing.T) {
 			tt.Assert.Equal(asset, offer.Buying)
 		}
 	})
+
+	t.Run("Wrong buying query parameter", func(t *testing.T) {
+		asset := horizon.Asset{}
+		eurAsset.Extract(&asset.Type, &asset.Code, &asset.Issuer)
+
+		_, err := handler.GetResourcePage(
+			httptest.NewRecorder(),
+			makeRequest(
+				t,
+				map[string]string{
+					"buying": `native\\u0026cursor=\\u0026limit=10\\u0026order=asc\\u0026selling=BTC:GAEDZ7BHMDYEMU6IJT3CTTGDUSLZWS5CQWZHGP4XUOIDG5ISH3AFAEK2`,
+				},
+				map[string]string{},
+				q.Session,
+			),
+		)
+		tt.Assert.Error(err)
+		p, ok := err.(*problem.P)
+		if tt.Assert.True(ok) {
+			tt.Assert.Equal(400, p.Status)
+			tt.Assert.NotNil(p.Extras)
+			tt.Assert.Equal(p.Extras["invalid_field"], "buying")
+			tt.Assert.Equal(p.Extras["reason"], "Asset code length is invalid")
+		}
+	})
 }
 
 func TestGetAccountOffersHandler(t *testing.T) {

--- a/services/horizon/internal/actions/query_params.go
+++ b/services/horizon/internal/actions/query_params.go
@@ -70,7 +70,10 @@ func (q SellingBuyingAssetQueryParams) Selling() (*xdr.Asset, error) {
 			}
 			asset, err := xdr.NewCreditAsset(parts[0], parts[1])
 			if err != nil {
-				return nil, err
+				return nil, problem.MakeInvalidFieldProblem(
+					"selling",
+					err,
+				)
 			}
 			return &asset, err
 		}
@@ -87,7 +90,9 @@ func (q SellingBuyingAssetQueryParams) Selling() (*xdr.Asset, error) {
 	)
 
 	if err != nil {
-		return nil, err
+		p := problem.BadRequest
+		p.Extras = map[string]interface{}{"reason": fmt.Sprintf("bad selling asset: %s", err.Error())}
+		return nil, p
 	}
 
 	return &selling, nil
@@ -110,7 +115,10 @@ func (q SellingBuyingAssetQueryParams) Buying() (*xdr.Asset, error) {
 			}
 			asset, err := xdr.NewCreditAsset(parts[0], parts[1])
 			if err != nil {
-				return nil, err
+				return nil, problem.MakeInvalidFieldProblem(
+					"buying",
+					err,
+				)
 			}
 			return &asset, err
 		}
@@ -127,7 +135,9 @@ func (q SellingBuyingAssetQueryParams) Buying() (*xdr.Asset, error) {
 	)
 
 	if err != nil {
-		return nil, err
+		p := problem.BadRequest
+		p.Extras = map[string]interface{}{"reason": fmt.Sprintf("bad buying asset: %s", err.Error())}
+		return nil, p
 	}
 
 	return &buying, nil

--- a/services/horizon/internal/actions/query_params.go
+++ b/services/horizon/internal/actions/query_params.go
@@ -54,22 +54,30 @@ func (q SellingBuyingAssetQueryParams) Validate() error {
 }
 
 // Selling returns an xdr.Asset representing the selling side of the offer.
-func (q SellingBuyingAssetQueryParams) Selling() *xdr.Asset {
+func (q SellingBuyingAssetQueryParams) Selling() (*xdr.Asset, error) {
 	if len(q.SellingAsset) > 0 {
 		switch q.SellingAsset {
 		case "native":
 			asset := xdr.MustNewNativeAsset()
-			return &asset
+			return &asset, nil
 		default:
 			parts := strings.Split(q.SellingAsset, ":")
-			asset := xdr.MustNewCreditAsset(parts[0], parts[1])
-
-			return &asset
+			if len(parts) != 2 {
+				return nil, problem.MakeInvalidFieldProblem(
+					"selling",
+					errors.New("missing colon"),
+				)
+			}
+			asset, err := xdr.NewCreditAsset(parts[0], parts[1])
+			if err != nil {
+				return nil, err
+			}
+			return &asset, err
 		}
 	}
 
 	if len(q.SellingAssetType) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	selling, err := xdr.BuildAsset(
@@ -79,29 +87,37 @@ func (q SellingBuyingAssetQueryParams) Selling() *xdr.Asset {
 	)
 
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return &selling
+	return &selling, nil
 }
 
 // Buying returns an *xdr.Asset representing the buying side of the offer.
-func (q SellingBuyingAssetQueryParams) Buying() *xdr.Asset {
+func (q SellingBuyingAssetQueryParams) Buying() (*xdr.Asset, error) {
 	if len(q.BuyingAsset) > 0 {
 		switch q.BuyingAsset {
 		case "native":
 			asset := xdr.MustNewNativeAsset()
-			return &asset
+			return &asset, nil
 		default:
 			parts := strings.Split(q.BuyingAsset, ":")
-			asset := xdr.MustNewCreditAsset(parts[0], parts[1])
-
-			return &asset
+			if len(parts) != 2 {
+				return nil, problem.MakeInvalidFieldProblem(
+					"buying",
+					errors.New("missing colon"),
+				)
+			}
+			asset, err := xdr.NewCreditAsset(parts[0], parts[1])
+			if err != nil {
+				return nil, err
+			}
+			return &asset, err
 		}
 	}
 
 	if len(q.BuyingAssetType) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	buying, err := xdr.BuildAsset(
@@ -111,8 +127,8 @@ func (q SellingBuyingAssetQueryParams) Buying() *xdr.Asset {
 	)
 
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return &buying
+	return &buying, nil
 }

--- a/services/horizon/internal/actions/query_params_test.go
+++ b/services/horizon/internal/actions/query_params_test.go
@@ -307,8 +307,12 @@ func TestSellingBuyingAssetQueryParamsWithCanonicalRepresenation(t *testing.T) {
 
 			if len(tc.expectedInvalidField) == 0 {
 				tt.NoError(err)
-				tt.Equal(tc.expectedBuying, qp.Buying())
-				tt.Equal(tc.expectedSelling, qp.Selling())
+				selling, sellingErr := qp.Selling()
+				tt.NoError(sellingErr)
+				buying, buyingErr := qp.Buying()
+				tt.NoError(buyingErr)
+				tt.Equal(tc.expectedBuying, buying)
+				tt.Equal(tc.expectedSelling, selling)
 			} else {
 				if tt.IsType(&problem.P{}, err) {
 					p := err.(*problem.P)

--- a/xdr/asset.go
+++ b/xdr/asset.go
@@ -37,17 +37,24 @@ func MustNewNativeAsset() Asset {
 
 // MustNewCreditAsset returns a new general asset, panicking if it can't.
 func MustNewCreditAsset(code string, issuer string) Asset {
-	a := Asset{}
-	accountID := AccountId{}
-	err := accountID.SetAddress(issuer)
-	if err != nil {
-		panic(err)
-	}
-	err = a.SetCredit(code, accountID)
+	a, err := NewCreditAsset(code, issuer)
 	if err != nil {
 		panic(err)
 	}
 	return a
+}
+
+// NewCreditAsset returns a new general asset, returning an error if it can't.
+func NewCreditAsset(code string, issuer string) (Asset, error) {
+	a := Asset{}
+	accountID := AccountId{}
+	if err := accountID.SetAddress(issuer); err != nil {
+		return Asset{}, err
+	}
+	if err := a.SetCredit(code, accountID); err != nil {
+		return Asset{}, err
+	}
+	return a, nil
 }
 
 // BuildAsset creates a new asset from a given `assetType`, `code`, and `issuer`.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes #2466 

Gracefully handle incorrect assets in the query parameters of `GET /offers`.

Before this change, a panic happened and a ` 500` HTTP error was returned.

### Why

A `500` is incorrect and not helpful for the end user.

### Known limitations

N/A
