### PR TITLE
Update prototype to run captive on online ingestion mode.

### DIFF
--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -88,12 +88,14 @@ func initExpIngester(app *App, orderBookGraph *orderbook.OrderBookGraph) {
 		HistoryArchiveURL:        app.config.HistoryArchiveURLs[0],
 		StellarCoreURL:           app.config.StellarCoreURL,
 		StellarCoreCursor:        app.config.CursorName,
+		StellarCorePath:          app.config.StellarCoreBinaryPath,
 		OrderBookGraph:           orderBookGraph,
 		MaxStreamRetries:         3,
 		DisableStateVerification: app.config.IngestDisableStateVerification,
 		IngestFailedTransactions: app.config.IngestFailedTransactions,
 		IngestInMemoryOnly:       app.config.IngestInMemoryOnly,
 	})
+
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Just passing the config allow us to start using captive on online mode. It seems to work fine but it's very slow. 

