### PR TITLE
exp/orderbook: Allow updates to the order book graph which span multiple ledgers

### DIFF
--- a/exp/orderbook/batch.go
+++ b/exp/orderbook/batch.go
@@ -60,7 +60,7 @@ func (tx *orderBookBatchedUpdates) apply(ledger uint32) error {
 	}
 	tx.committed = true
 
-	if tx.orderbook.lastLedger > 0 && ledger != tx.orderbook.lastLedger+1 {
+	if tx.orderbook.lastLedger > 0 && ledger <= tx.orderbook.lastLedger {
 		return errUnexpectedLedger
 	}
 
@@ -71,6 +71,9 @@ func (tx *orderBookBatchedUpdates) apply(ledger uint32) error {
 				panic(errors.Wrap(err, "could not apply update in batch"))
 			}
 		case removeOfferOperationType:
+			if _, ok := tx.orderbook.tradingPairForOffer[operation.offerID]; !ok {
+				continue
+			}
 			if err := tx.orderbook.remove(operation.offerID); err != nil {
 				panic(errors.Wrap(err, "could not apply update in batch"))
 			}

--- a/exp/orderbook/graph_test.go
+++ b/exp/orderbook/graph_test.go
@@ -328,12 +328,22 @@ func TestApplyOutdatedLedger(t *testing.T) {
 	graph.Discard()
 
 	graph.AddOffer(eurOffer)
-	err = graph.Apply(4)
+	err = graph.Apply(2)
 	if err != errUnexpectedLedger {
 		t.Fatalf("expected error %v but got %v", errUnexpectedLedger, err)
 	}
 	if graph.lastLedger != 2 {
 		t.Fatalf("expected last ledger to be %v but got %v", 2, graph.lastLedger)
+	}
+
+	graph.Discard()
+
+	err = graph.Apply(4)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if graph.lastLedger != 4 {
+		t.Fatalf("expected last ledger to be %v but got %v", 4, graph.lastLedger)
 	}
 }
 
@@ -812,6 +822,17 @@ func TestRemoveOfferOrderBook(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 	if graph.lastLedger != 3 {
+		t.Fatalf("expected last ledger to be %v but got %v", 3, graph.lastLedger)
+	}
+
+	// Skip over offer ids which are not present in the graph
+	err = graph.
+		RemoveOffer(988888).
+		Apply(5)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if graph.lastLedger != 5 {
 		t.Fatalf("expected last ledger to be %v but got %v", 3, graph.lastLedger)
 	}
 

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -12,7 +12,6 @@ import (
 
 	metrics "github.com/rcrowley/go-metrics"
 	"github.com/stellar/go/clients/stellarcore"
-	"github.com/stellar/go/exp/orderbook"
 	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/db2/core"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -458,12 +457,7 @@ func (a *App) init() {
 		// expingester
 		initExpIngester(a)
 	}
-	orderBookGraph := orderbook.NewOrderBookGraph()
-	a.orderBookStream = &expingest.OrderBookStream{
-		OrderBookGraph: orderBookGraph,
-		HistoryQ:       &history.Q{a.HorizonSession(a.ctx)},
-	}
-	initPathFinder(a, orderBookGraph)
+	initPathFinder(a)
 
 	// txsub
 	initSubmissionSystem(a)

--- a/services/horizon/internal/expingest/orderbook_test.go
+++ b/services/horizon/internal/expingest/orderbook_test.go
@@ -21,7 +21,7 @@ func TestIngestionStatus(t *testing.T) {
 
 func (t *IngestionStatusTestSuite) SetupTest() {
 	t.historyQ = &mockDBQ{}
-	t.stream = &OrderBookStream{HistoryQ: t.historyQ}
+	t.stream = NewOrderBookStream(t.historyQ, &mockOrderBookGraph{})
 }
 
 func (t *IngestionStatusTestSuite) TearDownTest() {
@@ -181,7 +181,7 @@ func TestUpdateOrderBookStream(t *testing.T) {
 func (t *UpdateOrderBookStreamTestSuite) SetupTest() {
 	t.historyQ = &mockDBQ{}
 	t.graph = &mockOrderBookGraph{}
-	t.stream = &OrderBookStream{OrderBookGraph: t.graph, HistoryQ: t.historyQ}
+	t.stream = NewOrderBookStream(t.historyQ, t.graph)
 }
 
 func (t *UpdateOrderBookStreamTestSuite) TearDownTest() {
@@ -484,7 +484,7 @@ func TestVerifyOrderBookStream(t *testing.T) {
 func (t *VerifyOrderBookStreamTestSuite) SetupTest() {
 	t.historyQ = &mockDBQ{}
 	t.graph = &mockOrderBookGraph{}
-	t.stream = &OrderBookStream{OrderBookGraph: t.graph, HistoryQ: t.historyQ}
+	t.stream = NewOrderBookStream(t.historyQ, t.graph)
 
 	sellerID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	otherSellerID := "GAXI33UCLQTCKM2NMRBS7XYBR535LLEVAHL5YBN4FTCB4HZHT7ZA5CVK"

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -97,7 +97,13 @@ func initExpIngester(app *App) {
 	}
 }
 
-func initPathFinder(app *App, orderBookGraph *orderbook.OrderBookGraph) {
+func initPathFinder(app *App) {
+	orderBookGraph := orderbook.NewOrderBookGraph()
+	app.orderBookStream = expingest.NewOrderBookStream(
+		&history.Q{app.HorizonSession(app.ctx)},
+		orderBookGraph,
+	)
+
 	app.paths = simplepath.NewInMemoryFinder(orderBookGraph)
 }
 
@@ -144,6 +150,7 @@ func initDbMetrics(app *App) {
 	app.metrics.Register("history.latest_ledger", app.historyLatestLedgerGauge)
 	app.metrics.Register("history.elder_ledger", app.historyElderLedgerGauge)
 	app.metrics.Register("stellar_core.latest_ledger", app.coreLatestLedgerGauge)
+	app.metrics.Register("order_book_stream.latest_ledger", app.orderBookStream.LatestLedgerGauge)
 	app.metrics.Register("history.open_connections", app.horizonConnGauge)
 	app.metrics.Register("stellar_core.open_connections", app.coreConnGauge)
 	app.metrics.Register("goroutines", app.goroutineGauge)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Before https://github.com/stellar/go/pull/2639 we were updating the order book graph via ingestion on every single ledger. The order book graph was implemented with the expectation that you must apply changes for every single ledger and no ledgers should be skipped.

However, we can no longer maintain that invariant because now we are applying updates to the order book graph via the `OrderBookStream`. The `OrderBookStream` periodically polls for new / updated offers from the Horizon DB. It is possible that ingestion has advanced by more than one ledger since the last time `OrderBookStream` updated the order book graph.

Therefore we must relax the restrictions for how updates are applied to an order book graph. We still require ledgers to be strictly increasing when applying updates to an order book graph. However, now we allow updates to span multiple ledgers.

We also allow you to remove an offer which is not present in the order book. Consider the case where you apply updates from ledger `x`. Let's say the next time we update the order book graph ingestion has already advanced to `x+2`. It is possible that an offer was created in ledger `x+1` and in ledger `x+2` we are removing the offer. However, our graph was last updated at ledger `x`, so when we try to remove the offer which was created in ledger `x+1` we will panic unless we deliberately skip over offers which are not present in the order book.

### Why

We observed the following errors when deploying the https://github.com/stellar/go/pull/2639 to staging.

```
ERRO[2020-06-02T00:46:31.192+02:00] could not apply updates from order book stream  error="Error updating: Error applying changes to order book: cannot apply unexpected ledger" pid=12576 service=expingest
```

The changes included in this PR should fix these errors.

### Known limitations

[N/A]
