### PR TITLE
txnbuild: Allow fee bump transactions to bump v0 transactions

### DIFF
--- a/txnbuild/fee_bump_test.go
+++ b/txnbuild/fee_bump_test.go
@@ -38,30 +38,96 @@ func TestFeeBumpInvalidFeeSource(t *testing.T) {
 	assert.Contains(t, err.Error(), "fee account is not a valid address")
 }
 
-func TestFeeBumpInvalidInnerTxType(t *testing.T) {
+func TestFeeBumpUpgradesV0Transaction(t *testing.T) {
 	kp0 := newKeypair0()
 	sourceAccount := NewSimpleAccount(kp0.Address(), 1)
 
 	tx, err := NewTransaction(
 		TransactionParams{
-			SourceAccount: &sourceAccount,
-			Operations:    []Operation{&Inflation{}},
-			BaseFee:       MinBaseFee,
-			Timebounds:    NewInfiniteTimeout(),
+			SourceAccount:        &sourceAccount,
+			IncrementSequenceNum: false,
+			Operations:           []Operation{&Inflation{}},
+			BaseFee:              2 * MinBaseFee,
+			Memo:                 MemoText("test-memo"),
+			Timebounds:           NewInfiniteTimeout(),
 		},
 	)
 	assert.NoError(t, err)
 
+	tx, err = tx.Sign(network.TestNetworkPassphrase, kp0)
+	assert.NoError(t, err)
+
 	convertToV0(tx)
 
-	_, err = NewFeeBumpTransaction(
+	feeBump, err := NewFeeBumpTransaction(
 		FeeBumpTransactionParams{
 			FeeAccount: newKeypair1().Address(),
-			BaseFee:    MinBaseFee,
+			BaseFee:    3 * MinBaseFee,
 			Inner:      tx,
 		},
 	)
-	assert.EqualError(t, err, "EnvelopeTypeEnvelopeTypeTxV0 transactions cannot be fee bumped")
+	assert.NoError(t, err)
+
+	assert.Equal(t, xdr.EnvelopeTypeEnvelopeTypeTx, feeBump.InnerTransaction().envelope.Type)
+	assert.Equal(t, xdr.EnvelopeTypeEnvelopeTypeTxV0, tx.envelope.Type)
+
+	innerHash, err := feeBump.InnerTransaction().HashHex(network.TestNetworkPassphrase)
+	assert.NoError(t, err)
+	originalHash, err := tx.HashHex(network.TestNetworkPassphrase)
+	assert.NoError(t, err)
+	assert.Equal(t, originalHash, innerHash)
+
+	assert.Equal(t, tx.Signatures(), feeBump.InnerTransaction().Signatures())
+	assert.Equal(t, tx.Operations(), feeBump.InnerTransaction().Operations())
+	assert.Equal(t, tx.MaxFee(), feeBump.InnerTransaction().MaxFee())
+	assert.Equal(t, tx.BaseFee(), feeBump.InnerTransaction().BaseFee())
+	assert.Equal(t, tx.SourceAccount(), feeBump.InnerTransaction().SourceAccount())
+	assert.Equal(t, tx.Memo(), feeBump.InnerTransaction().Memo())
+	assert.Equal(t, tx.Timebounds(), feeBump.InnerTransaction().Timebounds())
+
+	innerBase64, err := feeBump.InnerTransaction().Base64()
+	assert.NoError(t, err)
+	originalBase64, err := tx.Base64()
+	assert.NoError(t, err)
+	assert.NotEqual(t, innerBase64, originalBase64)
+}
+
+func TestFeeBumpInvalidInnerTransactionType(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), 1)
+
+	tx, err := NewTransaction(
+		TransactionParams{
+			SourceAccount:        &sourceAccount,
+			IncrementSequenceNum: false,
+			Operations:           []Operation{&Inflation{}},
+			BaseFee:              2 * MinBaseFee,
+			Memo:                 MemoText("test-memo"),
+			Timebounds:           NewInfiniteTimeout(),
+		},
+	)
+	assert.NoError(t, err)
+
+	aid := xdr.MustAddress(kp0.Address())
+	tx.envelope.Type = xdr.EnvelopeTypeEnvelopeTypeTxFeeBump
+	tx.envelope.FeeBump = &xdr.FeeBumpTransactionEnvelope{
+		Tx: xdr.FeeBumpTransaction{
+			FeeSource: aid.ToMuxedAccount(),
+			InnerTx: xdr.FeeBumpTransactionInnerTx{
+				Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+				V1:   tx.envelope.V1,
+			},
+		},
+		Signatures: nil,
+	}
+	_, err = NewFeeBumpTransaction(
+		FeeBumpTransactionParams{
+			FeeAccount: newKeypair1().Address(),
+			BaseFee:    3 * MinBaseFee,
+			Inner:      tx,
+		},
+	)
+	assert.EqualError(t, err, "EnvelopeTypeEnvelopeTypeTxFeeBump transactions cannot be fee bumped")
 }
 
 // There is a use case for having a fee bump tx where the fee account is equal to the


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Currently when you try to create a fee bump transaction from a v0 transaction we return an error. This PR does not return an error and instead converts the v0 transaction to a v1 transaction before wrapping it with a fee bump transaction.

### Why

Consider the use case of a pre-signed transaction that was made in the distant past. You created the transaction as part of a smart contract, and now you want to execute it, but you need it to have a higher fee than you set back then.

### Known limitations

[N/A]
