### PR TITLE
txnbuild: Add ToXDR functions which do not return errors

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -6,6 +6,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * `txnbuild` now generates V1 transaction envelopes which are only supported by Protocol 13 ([#2640](https://github.com/stellar/go/pull/2640))
+* Add `ToXDR()` functions for `Transaction` and `FeeBumpTransaction` instances which return xdr transaction envelopes without errors ([#2651](https://github.com/stellar/go/pull/2651))
 
 ## [v3.1.0](https://github.com/stellar/go/releases/tag/horizonclient-v3.1.0) - 2020-05-14
 

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -319,6 +319,23 @@ func (t *Transaction) TxEnvelope() (xdr.TransactionEnvelope, error) {
 	return cloneEnvelope(t.envelope, t.signatures)
 }
 
+// ToXDR is like TxEnvelope except that the transaction envelope returned by ToXDR
+// should not be modified because any changes applied to the transaction envelope may
+// affect the internals of the Transaction instance.
+func (t *Transaction) ToXDR() xdr.TransactionEnvelope {
+	env := t.envelope
+	switch env.Type {
+	case xdr.EnvelopeTypeEnvelopeTypeTx:
+		env.V1.Signatures = t.signatures
+	case xdr.EnvelopeTypeEnvelopeTypeTxV0:
+		env.V0.Signatures = t.signatures
+	default:
+		panic("invalid transaction type: " + env.Type.String())
+	}
+
+	return env
+}
+
 // MarshalBinary returns the binary XDR representation of the transaction envelope.
 func (t *Transaction) MarshalBinary() ([]byte, error) {
 	return marshallBinary(t.envelope, t.signatures)
@@ -430,6 +447,21 @@ func (t *FeeBumpTransaction) AddSignatureBase64(network, publicKey, signature st
 // equivalent to this transaction.
 func (t *FeeBumpTransaction) TxEnvelope() (xdr.TransactionEnvelope, error) {
 	return cloneEnvelope(t.envelope, t.signatures)
+}
+
+// ToXDR is like TxEnvelope except that the transaction envelope returned by ToXDR
+// should not be modified because any changes applied to the transaction envelope may
+// affect the internals of the FeeBumpTransaction instance.
+func (t *FeeBumpTransaction) ToXDR() xdr.TransactionEnvelope {
+	env := t.envelope
+	switch env.Type {
+	case xdr.EnvelopeTypeEnvelopeTypeTxFeeBump:
+		env.FeeBump.Signatures = t.signatures
+	default:
+		panic("invalid transaction type: " + env.Type.String())
+	}
+
+	return env
 }
 
 // MarshalBinary returns the binary XDR representation of the transaction envelope.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add `ToXDR()` functions for `Transaction` and `FeeBumpTransaction` instances which return xdr transaction envelopes without errors.

### Why

The reason why `TxEnvelope()` returns an error is that it copies the internal transaction envelope by marshaling and unmarshaling the value. However, if we return a reference to the internal transaction we do not need to handle any error cases. Most users probably will not be modifying the contents of the returned transaction envelope. Having a function which returns a transaction envelope without a possible error is more ergonomic.

### Known limitations

[N/A]
