### PR TITLE
services/horizon: Clone DB session for each history endpoint request

### DIFF
--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -266,7 +266,7 @@ func NewHistoryMiddleware(staleThreshold int32, session *db.Session) func(http.H
 				context.WithValue(
 					r.Context(),
 					&horizonContext.SessionContextKey,
-					session,
+					session.Clone(),
 				),
 			))
 		})

--- a/services/horizon/internal/stream_handler_test.go
+++ b/services/horizon/internal/stream_handler_test.go
@@ -73,7 +73,7 @@ func NewStreamablePageTest(
 	ledgerSource := ledger.NewTestingSource(currentLedger)
 	action.ledgerSource = ledgerSource
 	streamHandler := sse.StreamHandler{LedgerSourceFactory: &testingFactory{ledgerSource}}
-	handler := streamablePageHandler(action, streamHandler)
+	handler := streamableStatePageHandler(action, streamHandler)
 
 	return newStreamTest(
 		handler.renderStream,

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -169,7 +169,7 @@ func (w *web) mustInstallActions(config Config, pathFinder paths.Finder, session
 			r.Route("/{account_id}", func(r chi.Router) {
 				r.Get("/", w.streamShowActionHandler(w.getAccountInfo, true))
 				r.Get("/data/{key}", DataShowAction{}.Handle)
-				r.Method(http.MethodGet, "/offers", streamablePageHandler(actions.GetAccountOffersHandler{}, streamHandler))
+				r.Method(http.MethodGet, "/offers", streamableStatePageHandler(actions.GetAccountOffersHandler{}, streamHandler))
 			})
 		})
 
@@ -220,11 +220,11 @@ func (w *web) mustInstallActions(config Config, pathFinder paths.Finder, session
 		r.Get("/accounts/{account_id:\\w+}/trades", TradeIndexAction{}.Handle)
 		r.Group(func(r chi.Router) {
 			r.Use(historyMiddleware)
-			r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/operations", streamablePageHandler(actions.GetOperationsHandler{
+			r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/operations", streamableHistoryPageHandler(actions.GetOperationsHandler{
 				IngestingFailedTransactions: w.ingestFailedTx,
 				OnlyPayments:                false,
 			}, streamHandler))
-			r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/payments", streamablePageHandler(actions.GetOperationsHandler{
+			r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/payments", streamableHistoryPageHandler(actions.GetOperationsHandler{
 				IngestingFailedTransactions: w.ingestFailedTx,
 				OnlyPayments:                true,
 			}, streamHandler))
@@ -239,11 +239,11 @@ func (w *web) mustInstallActions(config Config, pathFinder paths.Finder, session
 			r.Get("/effects", EffectIndexAction{}.Handle)
 			r.Group(func(r chi.Router) {
 				r.Use(historyMiddleware)
-				r.Method(http.MethodGet, "/operations", streamablePageHandler(actions.GetOperationsHandler{
+				r.Method(http.MethodGet, "/operations", streamableHistoryPageHandler(actions.GetOperationsHandler{
 					IngestingFailedTransactions: w.ingestFailedTx,
 					OnlyPayments:                false,
 				}, streamHandler))
-				r.Method(http.MethodGet, "/payments", streamablePageHandler(actions.GetOperationsHandler{
+				r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(actions.GetOperationsHandler{
 					IngestingFailedTransactions: w.ingestFailedTx,
 					OnlyPayments:                true,
 				}, streamHandler))
@@ -259,11 +259,11 @@ func (w *web) mustInstallActions(config Config, pathFinder paths.Finder, session
 			r.Get("/effects", EffectIndexAction{}.Handle)
 			r.Group(func(r chi.Router) {
 				r.Use(historyMiddleware)
-				r.Method(http.MethodGet, "/operations", streamablePageHandler(actions.GetOperationsHandler{
+				r.Method(http.MethodGet, "/operations", streamableHistoryPageHandler(actions.GetOperationsHandler{
 					IngestingFailedTransactions: w.ingestFailedTx,
 					OnlyPayments:                false,
 				}, streamHandler))
-				r.Method(http.MethodGet, "/payments", streamablePageHandler(actions.GetOperationsHandler{
+				r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(actions.GetOperationsHandler{
 					IngestingFailedTransactions: w.ingestFailedTx,
 					OnlyPayments:                true,
 				}, streamHandler))
@@ -273,7 +273,7 @@ func (w *web) mustInstallActions(config Config, pathFinder paths.Finder, session
 
 	// operation actions
 	r.Route("/operations", func(r chi.Router) {
-		r.With(historyMiddleware).Method(http.MethodGet, "/", streamablePageHandler(actions.GetOperationsHandler{
+		r.With(historyMiddleware).Method(http.MethodGet, "/", streamableHistoryPageHandler(actions.GetOperationsHandler{
 			IngestingFailedTransactions: w.ingestFailedTx,
 			OnlyPayments:                false,
 		}, streamHandler))
@@ -283,7 +283,7 @@ func (w *web) mustInstallActions(config Config, pathFinder paths.Finder, session
 
 	r.Group(func(r chi.Router) {
 		// payment actions
-		r.With(historyMiddleware).Method(http.MethodGet, "/payments", streamablePageHandler(actions.GetOperationsHandler{
+		r.With(historyMiddleware).Method(http.MethodGet, "/payments", streamableHistoryPageHandler(actions.GetOperationsHandler{
 			IngestingFailedTransactions: w.ingestFailedTx,
 			OnlyPayments:                true,
 		}, streamHandler))


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit clones DB session for each history request that is using history middleware.

### Why

In https://github.com/stellar/go/pull/2597 operations handlers have been refactored to the new actions architecture. A new middleware used for history endpoints adds a DB session to request context without cloning it but it's later used to create a repeatable read transaction.

There are two issues with this approach:
* First, `db.Session` should not be using in parallel by multiple go routines when creating a db transaction.
* Second, starting a large number of repeatable read transactions can introduce performance issues so we shouldn't start it when it's not a must.

### Known limitations

This is a quick fix. We should probably create a separate middleware that adds a cloned session to context or reopen https://github.com/stellar/go/pull/1861.
