### PR TITLE
services/horizon/internal: Include request context when cloning session for request

### DIFF
--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -262,11 +262,13 @@ func NewHistoryMiddleware(staleThreshold int32, session *db.Session) func(http.H
 				}
 			}
 
+			requestSession := session.Clone()
+			requestSession.Ctx = r.Context()
 			h.ServeHTTP(w, r.WithContext(
 				context.WithValue(
 					r.Context(),
 					&horizonContext.SessionContextKey,
-					session.Clone(),
+					requestSession,
 				),
 			))
 		})


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Include request context when cloning session for request

### Why

The context of a db session is used to cancel a db query. When you set the context of the db session to the request context you ensure that if there are any db queries still pending after the request is cancelled or terminated those db queries also get cancelled.

### Known limitations

[N/A]
