### PR TITLE
exp/services/recoverysigner: log the key id of the jwk that successfully verified the jwt

### DIFF
--- a/exp/services/recoverysigner/internal/serve/auth/sep10.go
+++ b/exp/services/recoverysigner/internal/serve/auth/sep10.go
@@ -16,12 +16,13 @@ import (
 func SEP10Middleware(issuer string, ks jose.JSONWebKeySet) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if address, ok := sep10ClaimsFromRequest(r, issuer, ks); ok {
+			if address, k, ok := sep10ClaimsFromRequest(r, issuer, ks); ok {
 				ctx := r.Context()
 				auth, _ := FromContext(ctx)
 				auth.Address = address
 
 				log.Ctx(ctx).
+					WithField("jwkkid", k.KeyID).
 					WithField("address", address).
 					Info("SEP-10 JWT verified.")
 
@@ -51,36 +52,38 @@ func (c sep10JWTClaims) Validate(issuer string) error {
 	return c.Claims.Validate(expectedClaims)
 }
 
-func sep10ClaimsFromRequest(r *http.Request, issuer string, ks jose.JSONWebKeySet) (address string, ok bool) {
+func sep10ClaimsFromRequest(r *http.Request, issuer string, ks jose.JSONWebKeySet) (address string, k jose.JSONWebKey, ok bool) {
 	authHeader := r.Header.Get("Authorization")
 	tokenEncoded := httpauthz.ParseBearerToken(authHeader)
 	if tokenEncoded == "" {
-		return "", false
+		return "", jose.JSONWebKey{}, false
 	}
 	token, err := jwt.ParseSigned(tokenEncoded)
 	if err != nil {
-		return "", false
+		return "", jose.JSONWebKey{}, false
 	}
 	tokenClaims := sep10JWTClaims{}
 	verified := false
+	verifiedWithKey := jose.JSONWebKey{}
 	for _, k := range ks.Keys {
 		err = token.Claims(k, &tokenClaims)
 		if err == nil {
 			verified = true
+			verifiedWithKey = k
 			break
 		}
 	}
 	if !verified {
-		return "", false
+		return "", jose.JSONWebKey{}, false
 	}
 	err = tokenClaims.Validate(issuer)
 	if err != nil {
-		return "", false
+		return "", jose.JSONWebKey{}, false
 	}
 	address = tokenClaims.Subject
 	_, err = keypair.ParseAddress(address)
 	if err != nil {
-		return "", false
+		return "", jose.JSONWebKey{}, false
 	}
-	return address, true
+	return address, verifiedWithKey, true
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Log the key id (`kid`) of the JSON Web Key (JWK) that successfully verifed the JSON Web Token (JWT).

### Why

In #2647 I added support for multiple JWKs and it would be useful if in the logs outputted when a JWT is verified included which key verified the JWT. It might be useful for debugging an issue or for understanding usage of an old JWT key as we transition away from it during a key rotation. It's not critical functionality.

### Known limitations

If the keys configured do not have a `kid` parameters then the value logged will be an empty string. I don't think it is worth requiring that the JWK have a `kid` because it is only used for logging in this application.
