### PR TITLE
services/horizon/internal/expingest: Fix OrderBookStream verification

### DIFF
--- a/services/horizon/internal/expingest/orderbook.go
+++ b/services/horizon/internal/expingest/orderbook.go
@@ -100,6 +100,7 @@ func addOfferToGraph(graph orderbook.OBGraph, offer history.Offer) {
 	})
 }
 
+// update returns true if the order book graph was reset
 func (o *OrderBookStream) update(status ingestionStatus) (bool, error) {
 	reset := o.lastLedger == 0
 	if status.StateInvalid || !status.HistoryConsistentWithState {

--- a/services/horizon/internal/expingest/orderbook.go
+++ b/services/horizon/internal/expingest/orderbook.go
@@ -33,7 +33,7 @@ type OrderBookStream struct {
 	// latest processed ledger
 	LatestLedgerGauge metrics.Gauge
 	lastLedger        uint32
-	lastUpdate        time.Time
+	lastVerification  time.Time
 }
 
 // NewOrderBookStream constructs and initializes an OrderBookStream instance
@@ -42,6 +42,7 @@ func NewOrderBookStream(historyQ history.IngestionQ, graph orderbook.OBGraph) *O
 		graph:             graph,
 		historyQ:          historyQ,
 		LatestLedgerGauge: metrics.NewGauge(),
+		lastVerification:  time.Now(),
 	}
 }
 
@@ -99,7 +100,7 @@ func addOfferToGraph(graph orderbook.OBGraph, offer history.Offer) {
 	})
 }
 
-func (o *OrderBookStream) update(status ingestionStatus) error {
+func (o *OrderBookStream) update(status ingestionStatus) (bool, error) {
 	reset := o.lastLedger == 0
 	if status.StateInvalid || !status.HistoryConsistentWithState {
 		log.WithField("status", status).Warn("ingestion state is invalid")
@@ -124,14 +125,14 @@ func (o *OrderBookStream) update(status ingestionStatus) error {
 		if status.StateInvalid || !status.HistoryConsistentWithState {
 			log.WithField("status", status).
 				Info("waiting for ingestion to update offers table")
-			return nil
+			return true, nil
 		}
 
 		defer o.graph.Discard()
 
 		offers, err := o.historyQ.GetAllOffers()
 		if err != nil {
-			return errors.Wrap(err, "Error from GetAllOffers")
+			return true, errors.Wrap(err, "Error from GetAllOffers")
 		}
 
 		for _, offer := range offers {
@@ -139,23 +140,23 @@ func (o *OrderBookStream) update(status ingestionStatus) error {
 		}
 
 		if err := o.graph.Apply(status.LastIngestedLedger); err != nil {
-			return errors.Wrap(err, "Error applying changes to order book")
+			return true, errors.Wrap(err, "Error applying changes to order book")
 		}
 
 		o.lastLedger = status.LastIngestedLedger
 		o.LatestLedgerGauge.Update(int64(status.LastIngestedLedger))
-		return nil
+		return true, nil
 	}
 
 	if status.LastIngestedLedger == o.lastLedger {
-		return nil
+		return false, nil
 	}
 
 	defer o.graph.Discard()
 
 	offers, err := o.historyQ.GetUpdatedOffers(o.lastLedger)
 	if err != nil {
-		return errors.Wrap(err, "Error from GetUpdatedOffers")
+		return false, errors.Wrap(err, "Error from GetUpdatedOffers")
 	}
 	for _, offer := range offers {
 		if offer.Deleted {
@@ -166,25 +167,23 @@ func (o *OrderBookStream) update(status ingestionStatus) error {
 	}
 
 	if err = o.graph.Apply(status.LastIngestedLedger); err != nil {
-		return errors.Wrap(err, "Error applying changes to order book")
+		return false, errors.Wrap(err, "Error applying changes to order book")
 	}
 
-	o.lastUpdate = time.Now()
 	o.lastLedger = status.LastIngestedLedger
 	o.LatestLedgerGauge.Update(int64(status.LastIngestedLedger))
-	return nil
+	return false, nil
 }
 
 func (o *OrderBookStream) verifyAllOffers() {
 	offers := o.graph.Offers()
 	ingestionOffers, err := o.historyQ.GetAllOffers()
 	if err != nil {
-		// reset last update so that we retry verification on next update
-		o.lastUpdate = time.Now().Add(verificationFrequency * -2)
 		log.WithError(err).Info("Could not verify offers because of error from GetAllOffers")
 		return
 	}
 
+	o.lastVerification = time.Now()
 	mismatch := len(offers) != len(ingestionOffers)
 
 	if !mismatch {
@@ -231,20 +230,22 @@ func (o *OrderBookStream) Update() error {
 	}
 	defer o.historyQ.Rollback()
 
-	// add 15 minute jitter so that not all horizon nodes are calling
-	// historyQ.GetAllOffers at the same time
-	jitter := time.Duration(rand.Int63n(int64(15 * time.Minute)))
-	requiresVerification := !o.lastUpdate.Equal(time.Time{}) &&
-		time.Since(o.lastUpdate) >= verificationFrequency+jitter
-
 	status, err := o.getIngestionStatus()
 	if err != nil {
 		return errors.Wrap(err, "Error obtaining ingestion status")
 	}
 
-	if err := o.update(status); err != nil {
+	if reset, err := o.update(status); err != nil {
 		return errors.Wrap(err, "Error updating")
+	} else if reset {
+		return nil
 	}
+
+	// add 15 minute jitter so that not all horizon nodes are calling
+	// historyQ.GetAllOffers at the same time
+	jitter := time.Duration(rand.Int63n(int64(15 * time.Minute)))
+	requiresVerification := o.lastLedger > 0 &&
+		time.Since(o.lastVerification) >= verificationFrequency+jitter
 
 	if requiresVerification {
 		o.verifyAllOffers()

--- a/services/horizon/internal/expingest/orderbook_test.go
+++ b/services/horizon/internal/expingest/orderbook_test.go
@@ -203,10 +203,9 @@ func (t *UpdateOrderBookStreamTestSuite) TestGetAllOffersError() {
 		Once()
 
 	t.stream.lastLedger = 300
-	err := t.stream.update(status)
+	_, err := t.stream.update(status)
 	t.Assert().EqualError(err, "Error from GetAllOffers: offers error")
 	t.Assert().Equal(uint32(0), t.stream.lastLedger)
-	t.Assert().True(t.stream.lastUpdate.Equal(time.Time{}))
 }
 
 func (t *UpdateOrderBookStreamTestSuite) TestResetApplyError() {
@@ -242,10 +241,9 @@ func (t *UpdateOrderBookStreamTestSuite) TestResetApplyError() {
 		Once()
 
 	t.stream.lastLedger = 300
-	err := t.stream.update(status)
+	_, err := t.stream.update(status)
 	t.Assert().EqualError(err, "Error applying changes to order book: apply error")
 	t.Assert().Equal(uint32(0), t.stream.lastLedger)
-	t.Assert().True(t.stream.lastUpdate.Equal(time.Time{}))
 }
 
 func (t *UpdateOrderBookStreamTestSuite) mockReset(status ingestionStatus) {
@@ -285,10 +283,10 @@ func (t *UpdateOrderBookStreamTestSuite) TestFirstUpdateSucceeds() {
 	}
 	t.mockReset(status)
 
-	err := t.stream.update(status)
+	reset, err := t.stream.update(status)
 	t.Assert().NoError(err)
 	t.Assert().Equal(uint32(201), t.stream.lastLedger)
-	t.Assert().True(t.stream.lastUpdate.Equal(time.Time{}))
+	t.Assert().True(reset)
 }
 
 func (t *UpdateOrderBookStreamTestSuite) TestInvalidState() {
@@ -300,18 +298,19 @@ func (t *UpdateOrderBookStreamTestSuite) TestInvalidState() {
 	}
 	t.graph.On("Clear").Return().Once()
 
-	err := t.stream.update(status)
+	reset, err := t.stream.update(status)
 	t.Assert().NoError(err)
 	t.Assert().Equal(uint32(0), t.stream.lastLedger)
+	t.Assert().True(reset)
 
 	t.stream.lastLedger = 123
 
 	t.graph.On("Clear").Return().Once()
 
-	err = t.stream.update(status)
+	reset, err = t.stream.update(status)
 	t.Assert().NoError(err)
 	t.Assert().Equal(uint32(0), t.stream.lastLedger)
-	t.Assert().True(t.stream.lastUpdate.Equal(time.Time{}))
+	t.Assert().True(reset)
 }
 
 func (t *UpdateOrderBookStreamTestSuite) TestHistoryInconsistentWithState() {
@@ -323,18 +322,19 @@ func (t *UpdateOrderBookStreamTestSuite) TestHistoryInconsistentWithState() {
 	}
 	t.graph.On("Clear").Return().Once()
 
-	err := t.stream.update(status)
+	reset, err := t.stream.update(status)
 	t.Assert().NoError(err)
 	t.Assert().Equal(uint32(0), t.stream.lastLedger)
+	t.Assert().True(reset)
 
 	t.stream.lastLedger = 123
 
 	t.graph.On("Clear").Return().Once()
 
-	err = t.stream.update(status)
+	reset, err = t.stream.update(status)
 	t.Assert().NoError(err)
 	t.Assert().Equal(uint32(0), t.stream.lastLedger)
-	t.Assert().True(t.stream.lastUpdate.Equal(time.Time{}))
+	t.Assert().True(reset)
 }
 
 func (t *UpdateOrderBookStreamTestSuite) TestLastIngestedLedgerBehindStream() {
@@ -347,10 +347,10 @@ func (t *UpdateOrderBookStreamTestSuite) TestLastIngestedLedgerBehindStream() {
 	t.mockReset(status)
 
 	t.stream.lastLedger = 300
-	err := t.stream.update(status)
+	reset, err := t.stream.update(status)
 	t.Assert().NoError(err)
 	t.Assert().Equal(uint32(201), t.stream.lastLedger)
-	t.Assert().True(t.stream.lastUpdate.Equal(time.Time{}))
+	t.Assert().True(reset)
 }
 
 func (t *UpdateOrderBookStreamTestSuite) TestStreamBehindLastCompactionLedger() {
@@ -363,10 +363,10 @@ func (t *UpdateOrderBookStreamTestSuite) TestStreamBehindLastCompactionLedger() 
 	t.mockReset(status)
 
 	t.stream.lastLedger = 99
-	err := t.stream.update(status)
+	reset, err := t.stream.update(status)
 	t.Assert().NoError(err)
 	t.Assert().Equal(uint32(201), t.stream.lastLedger)
-	t.Assert().True(t.stream.lastUpdate.Equal(time.Time{}))
+	t.Assert().True(reset)
 }
 
 func (t *UpdateOrderBookStreamTestSuite) TestStreamLedgerEqualsLastIngestedLedger() {
@@ -378,10 +378,10 @@ func (t *UpdateOrderBookStreamTestSuite) TestStreamLedgerEqualsLastIngestedLedge
 	}
 
 	t.stream.lastLedger = 201
-	err := t.stream.update(status)
+	reset, err := t.stream.update(status)
 	t.Assert().NoError(err)
 	t.Assert().Equal(uint32(201), t.stream.lastLedger)
-	t.Assert().True(t.stream.lastUpdate.Equal(time.Time{}))
+	t.Assert().False(reset)
 }
 
 func (t *UpdateOrderBookStreamTestSuite) TestGetUpdatedOffersError() {
@@ -398,10 +398,9 @@ func (t *UpdateOrderBookStreamTestSuite) TestGetUpdatedOffersError() {
 		Return([]history.Offer{}, fmt.Errorf("updated offers error")).
 		Once()
 
-	err := t.stream.update(status)
+	_, err := t.stream.update(status)
 	t.Assert().EqualError(err, "Error from GetUpdatedOffers: updated offers error")
 	t.Assert().Equal(uint32(100), t.stream.lastLedger)
-	t.Assert().True(t.stream.lastUpdate.Equal(time.Time{}))
 }
 
 func (t *UpdateOrderBookStreamTestSuite) mockUpdate() {
@@ -444,10 +443,9 @@ func (t *UpdateOrderBookStreamTestSuite) TestApplyUpdatesError() {
 		Return(fmt.Errorf("apply error")).
 		Once()
 
-	err := t.stream.update(status)
+	_, err := t.stream.update(status)
 	t.Assert().EqualError(err, "Error applying changes to order book: apply error")
 	t.Assert().Equal(uint32(100), t.stream.lastLedger)
-	t.Assert().True(t.stream.lastUpdate.Equal(time.Time{}))
 }
 
 func (t *UpdateOrderBookStreamTestSuite) TestApplyUpdatesSucceeds() {
@@ -464,17 +462,18 @@ func (t *UpdateOrderBookStreamTestSuite) TestApplyUpdatesSucceeds() {
 		Return(nil).
 		Once()
 
-	err := t.stream.update(status)
+	reset, err := t.stream.update(status)
 	t.Assert().NoError(err)
 	t.Assert().Equal(status.LastIngestedLedger, t.stream.lastLedger)
-	t.Assert().False(t.stream.lastUpdate.Equal(time.Time{}))
+	t.Assert().False(reset)
 }
 
 type VerifyOrderBookStreamTestSuite struct {
 	suite.Suite
-	historyQ *mockDBQ
-	graph    *mockOrderBookGraph
-	stream   *OrderBookStream
+	historyQ    *mockDBQ
+	graph       *mockOrderBookGraph
+	stream      *OrderBookStream
+	initialTime time.Time
 }
 
 func TestVerifyOrderBookStream(t *testing.T) {
@@ -485,6 +484,7 @@ func (t *VerifyOrderBookStreamTestSuite) SetupTest() {
 	t.historyQ = &mockDBQ{}
 	t.graph = &mockOrderBookGraph{}
 	t.stream = NewOrderBookStream(t.historyQ, t.graph)
+	t.initialTime = t.stream.lastVerification
 
 	sellerID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	otherSellerID := "GAXI33UCLQTCKM2NMRBS7XYBR535LLEVAHL5YBN4FTCB4HZHT7ZA5CVK"
@@ -531,8 +531,7 @@ func (t *VerifyOrderBookStreamTestSuite) TestGetAllOffersError() {
 	t.stream.lastLedger = 300
 	t.stream.verifyAllOffers()
 	t.Assert().Equal(uint32(300), t.stream.lastLedger)
-	t.Assert().False(t.stream.lastUpdate.Equal(time.Time{}))
-	t.Assert().True(t.stream.lastUpdate.Before(time.Now()))
+	t.Assert().True(t.stream.lastVerification.Equal(t.initialTime))
 }
 
 func (t *VerifyOrderBookStreamTestSuite) TestEmptyDBOffers() {
@@ -542,7 +541,7 @@ func (t *VerifyOrderBookStreamTestSuite) TestEmptyDBOffers() {
 	t.stream.lastLedger = 300
 	t.stream.verifyAllOffers()
 	t.Assert().Equal(uint32(0), t.stream.lastLedger)
-	t.Assert().True(t.stream.lastUpdate.Equal(time.Time{}))
+	t.Assert().False(t.stream.lastVerification.Equal(t.initialTime))
 }
 
 func (t *VerifyOrderBookStreamTestSuite) TestLengthMismatch() {
@@ -566,7 +565,7 @@ func (t *VerifyOrderBookStreamTestSuite) TestLengthMismatch() {
 	t.stream.lastLedger = 300
 	t.stream.verifyAllOffers()
 	t.Assert().Equal(uint32(0), t.stream.lastLedger)
-	t.Assert().True(t.stream.lastUpdate.Equal(time.Time{}))
+	t.Assert().False(t.stream.lastVerification.Equal(t.initialTime))
 }
 
 func (t *VerifyOrderBookStreamTestSuite) TestContentMismatch() {
@@ -603,7 +602,7 @@ func (t *VerifyOrderBookStreamTestSuite) TestContentMismatch() {
 	t.stream.lastLedger = 300
 	t.stream.verifyAllOffers()
 	t.Assert().Equal(uint32(0), t.stream.lastLedger)
-	t.Assert().True(t.stream.lastUpdate.Equal(time.Time{}))
+	t.Assert().False(t.stream.lastVerification.Equal(t.initialTime))
 }
 
 func (t *VerifyOrderBookStreamTestSuite) TestSuccess() {
@@ -640,5 +639,5 @@ func (t *VerifyOrderBookStreamTestSuite) TestSuccess() {
 	t.stream.lastLedger = 300
 	t.stream.verifyAllOffers()
 	t.Assert().Equal(uint32(300), t.stream.lastLedger)
-	t.Assert().True(t.stream.lastUpdate.Equal(time.Time{}))
+	t.Assert().False(t.stream.lastVerification.Equal(t.initialTime))
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The condition which triggers a call to `verifyAllOffers()` is broken because it is only true when there is at least an hour in between updates. The problem is that the order book is updated every two seconds. The condition should actually be triggered when there is an hour between calls to `verifyAllOffers()`.
 
### Known limitations

[N/A]
