### PR TITLE
services/horizon/internal/db2/history: Add AssetsForAddress.

### DIFF
--- a/services/horizon/internal/db2/history/trust_lines_test.go
+++ b/services/horizon/internal/db2/history/trust_lines_test.go
@@ -12,9 +12,9 @@ var (
 	trustLineIssuer = xdr.MustAddress("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
 
 	eurTrustLine = xdr.TrustLineEntry{
-		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		AccountId: account1.AccountId,
 		Asset:     xdr.MustNewCreditAsset("EUR", trustLineIssuer.Address()),
-		Balance:   20000,
+		Balance:   30000,
 		Limit:     223456789,
 		Flags:     1,
 		Ext: xdr.TrustLineEntryExt{
@@ -364,4 +364,68 @@ func TestGetTrustLinesByAccountID(t *testing.T) {
 	tt.Assert.Equal(int64(eurTrustLine.Ext.V1.Liabilities.Buying), record[0].BuyingLiabilities)
 	tt.Assert.Equal(int64(eurTrustLine.Ext.V1.Liabilities.Selling), record[0].SellingLiabilities)
 
+}
+
+func TestAssetsForAddress(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	assets, balances, err := q.AssetsForAddress(eurTrustLine.AccountId.Address())
+	tt.Assert.NoError(err)
+	tt.Assert.Empty(assets)
+	tt.Assert.Empty(balances)
+
+	ledgerEntries := []xdr.LedgerEntry{
+		xdr.LedgerEntry{
+			LastModifiedLedgerSeq: 1234,
+			Data: xdr.LedgerEntryData{
+				Type:    xdr.LedgerEntryTypeAccount,
+				Account: &account1,
+			},
+		},
+	}
+
+	err = q.UpsertAccounts(ledgerEntries)
+	assert.NoError(t, err)
+
+	_, err = q.InsertTrustLine(eurTrustLine, 1234)
+	tt.Assert.NoError(err)
+
+	brlTrustLine := xdr.TrustLineEntry{
+		AccountId: account1.AccountId,
+		Asset:     xdr.MustNewCreditAsset("BRL", trustLineIssuer.Address()),
+		Balance:   1000,
+		Limit:     20000,
+		Flags:     1,
+		Ext: xdr.TrustLineEntryExt{
+			V: 1,
+			V1: &xdr.TrustLineEntryV1{
+				Liabilities: xdr.Liabilities{
+					Buying:  3,
+					Selling: 4,
+				},
+			},
+		},
+	}
+
+	_, err = q.InsertTrustLine(brlTrustLine, 1234)
+	tt.Assert.NoError(err)
+
+	assets, balances, err = q.AssetsForAddress(account1.AccountId.Address())
+	tt.Assert.NoError(err)
+
+	assetsToBalance := map[string]xdr.Int64{}
+	for i, symbol := range assets {
+		assetsToBalance[symbol.String()] = balances[i]
+	}
+
+	expected := map[string]xdr.Int64{
+		"credit_alphanum4/BRL/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H": 1000,
+		"credit_alphanum4/EUR/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H": 30000,
+		"native": 20000,
+	}
+
+	tt.Assert.Equal(expected, assetsToBalance)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add `AssetForAddress` to `db2/history`.

### Why

The path finding action handler rely on core to load assets and balances for a given address. This PR adds the same method which returns `xdr.Assets` and their matching balances but using Horizon DB as the source.

This is part of the initial work to drop db2/core (#2643 ).

### Known limitations

[TODO or N/A]
