### PR TITLE
exp/ingest/ledgerbackend: Add buffered pipe to CaptiveStellarCore

### DIFF
--- a/exp/ingest/ledgerbackend/buffered_pipe.go
+++ b/exp/ingest/ledgerbackend/buffered_pipe.go
@@ -1,0 +1,41 @@
+package ledgerbackend
+
+type bufferedPipe struct {
+	buffer chan byte
+}
+
+func newBufferedPipe(cap int) *bufferedPipe {
+	return &bufferedPipe{
+		buffer: make(chan byte, cap),
+	}
+}
+
+func (b *bufferedPipe) Read(p []byte) (n int, err error) {
+	if len(b.buffer) == 0 {
+		return 0, nil
+	}
+
+	read := 0
+	for i := range p {
+		if len(b.buffer) == 0 {
+			break
+		}
+
+		p[i] = <-b.buffer
+		read++
+	}
+
+	return read, nil
+}
+
+func (b *bufferedPipe) Write(p []byte) (n int, err error) {
+	for _, by := range p {
+		b.buffer <- by
+	}
+
+	return len(p), nil
+}
+
+func (b *bufferedPipe) IsEmpty() bool {
+	return len(b.buffer) == 0
+}

--- a/exp/ingest/ledgerbackend/stellar_core_runner.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner.go
@@ -1,6 +1,7 @@
 package ledgerbackend
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -8,15 +9,18 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 )
 
+const pipeBufferSize = 1024 * 1024
+
 type stellarCoreRunnerInterface interface {
 	run(from, to uint32) error
-	getMetaPipe() io.Reader
+	getMetaPipe() *bufferedPipe
 	close() error
 }
 
@@ -26,7 +30,7 @@ type stellarCoreRunner struct {
 	historyURLs       []string
 
 	cmd      *exec.Cmd
-	metaPipe io.Reader
+	metaPipe *bufferedPipe
 	tempDir  string
 }
 
@@ -59,20 +63,20 @@ func (r *stellarCoreRunner) getConfFileName() string {
 }
 
 func (*stellarCoreRunner) getLogLineWriter() io.Writer {
-	_, w := io.Pipe()
-	// br := bufio.NewReader(r)
-	// // Strip timestamps from log lines from captive stellar-core. We emit our own.
-	// dateRx := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3} `)
-	// go func() {
-	// 	for {
-	// 		line, e := br.ReadString('\n')
-	// 		if e != nil {
-	// 			break
-	// 		}
-	// 		line = dateRx.ReplaceAllString(line, "")
-	// 		fmt.Print(line)
-	// 	}
-	// }()
+	r, w := io.Pipe()
+	br := bufio.NewReader(r)
+	// Strip timestamps from log lines from captive stellar-core. We emit our own.
+	dateRx := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3} `)
+	go func() {
+		for {
+			line, e := br.ReadString('\n')
+			if e != nil {
+				break
+			}
+			line = dateRx.ReplaceAllString(line, "")
+			fmt.Print(line)
+		}
+	}()
 	return w
 }
 
@@ -110,14 +114,25 @@ func (r *stellarCoreRunner) run(from, to uint32) error {
 	cmd.Stdout = r.getLogLineWriter()
 	cmd.Stderr = cmd.Stdout
 	r.cmd = cmd
-	err = r.start()
+	reader, err := r.start()
 	if err != nil {
 		return errors.Wrap(err, "error starting stellar-core subprocess")
 	}
+
+	r.metaPipe = newBufferedPipe(pipeBufferSize)
+	go func() {
+		for {
+			io.Copy(r.metaPipe, reader)
+			if !r.processIsAlive() {
+				return
+			}
+		}
+	}()
+
 	return nil
 }
 
-func (r *stellarCoreRunner) getMetaPipe() io.Reader {
+func (r *stellarCoreRunner) getMetaPipe() *bufferedPipe {
 	return r.metaPipe
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit adds buffering of meta stream via a buffered pipe built using a channel.

### Why

The first return value of `GetLedger` method of `LedgerBackend` specifies if a ledger is available in the backend. Currently `CaptiveStellarCore` ignores this value and always blocks until the ledger has been streamed. This is fine for the offline mode but in the online mode blocking is not acceptable.

To solve this we use a `bufferedPipe` that allows checking if there is new data in a stream (`IsEmpty` method). This way we can determine if ledger is available.

My first approach was to use `bufio.Reader` (previously used in `stellarCoreRunner`) that exposes a `Peek()` method, however there are several problems:
* `bufio.Reader` is not thread-safe and we need another go routine to constantly write read bytes to a pipe.
* Making `bufio.Reader` thread-safe by using `sync.Mutex` was much slower than `bufferedPipe`.
* Finally, it's not possible to bound an internal buffer in `bufio.Reader` which means that it can grow too much.

Finally, `CaptiveStellarCore` can be run in two modes: non-blocking (default) and blocking. In non-blocking mode `GetLedger` returns false when ledger is not available, in blocking mode it blocks. This is done to support fast reingestion. It turns out that Horizon is able to ingest history data faster that stellar-core can apply old ledger (probably because Horizon doesn't update state when reingesting). Without blocking mode we'd need to call `time.Sleep` when ledger is not available which is much slower than blocking.

### Known limitations

* Tests are not there yet - wanted to get an initial feedback.
* I didn't want to add `SetBlockingMode` to `LedgerBackend` interface because in the future `CaptiveStellarCore` will be the only ledger backend available.
* I uncommented the code that output stellar-core log to better understand why blocking mode is faster. Logging will be removed before merging.