### PR TITLE
exp/services/recoverysigner: fix the usage text

### DIFF
--- a/exp/services/recoverysigner/README.md
+++ b/exp/services/recoverysigner/README.md
@@ -43,12 +43,15 @@ Usage:
   recoverysigner serve [flags]
 
 Flags:
+      --admin-port int               Port to listen and serve admin functionality including metrics (ADMIN_PORT)
       --db-url string                Database URL (DB_URL) (default "postgres://localhost:5432/?sslmode=disable")
       --firebase-project-id string   Firebase project ID to use for validating Firebase JWTs (FIREBASE_PROJECT_ID)
+      --metrics-namespace string     Namespace to use for metric names prefixed to metrics reported (METRICS_NAMESPACE) (default "recoverysigner")
       --network-passphrase string    Network passphrase of the Stellar network transactions should be signed for (NETWORK_PASSPHRASE) (default "Test SDF Network ; September 2015")
       --port int                     Port to listen and serve on (PORT) (default 8000)
-      --sep10-jwks string            JSON Web Key Set (JWKS) containing exactly one key, which will be used to validate SEP-10 JWTs (if the key is an asymmetric key that has separate public and private key, the JWK need only be the public key) (SEP10_JWKS)
-      --signing-key string           Stellar signing key used for signing transactions (will be deprecated with per-account keys in the future) (SIGNING_KEY)
+      --sep10-jwks string            JSON Web Key Set (JWKS) containing one or more keys used to validate SEP-10 JWTs (if the key is an asymmetric key that has separate public and private key, the JWK need only contain the public key) (if multiple keys are provided they will all attempt verification the key ID will be ignored although logged) (SEP10_JWKS)
+      --sep10-jwt-issuer string      JWT issuer to verify is in the SEP-10 JWT iss field (not checked if empty) (SEP10_JWT_ISSUER)
+      --signing-key string           Stellar signing key(s) used for signing transactions comma separated (first key is preferred signer) (will be deprecated with per-account keys in the future) (SIGNING_KEY)
 ```
 
 [SEP-30]: https://github.com/stellar/stellar-protocol/blob/600c326b210d71ee031d7f3a40ca88191b4cdf9c/ecosystem/sep-0030.md

--- a/exp/services/recoverysigner/README.md
+++ b/exp/services/recoverysigner/README.md
@@ -50,7 +50,7 @@ Flags:
       --network-passphrase string    Network passphrase of the Stellar network transactions should be signed for (NETWORK_PASSPHRASE) (default "Test SDF Network ; September 2015")
       --port int                     Port to listen and serve on (PORT) (default 8000)
       --sep10-jwks string            JSON Web Key Set (JWKS) containing one or more keys used to validate SEP-10 JWTs (if the key is an asymmetric key that has separate public and private key, the JWK need only contain the public key) (if multiple keys are provided they will all attempt verification the key ID will be ignored although logged) (SEP10_JWKS)
-      --sep10-jwt-issuer string      JWT issuer to verify is in the SEP-10 JWT iss field (not checked if empty) (SEP10_JWT_ISSUER)
+      --sep10-jwt-issuer string      JWT issuer to verify if in the SEP-10 JWT iss field (not checked if empty) (SEP10_JWT_ISSUER)
       --signing-key string           Stellar signing key(s) used for signing transactions comma separated (first key is preferred signer) (will be deprecated with per-account keys in the future) (SIGNING_KEY)
 ```
 

--- a/exp/services/recoverysigner/cmd/serve.go
+++ b/exp/services/recoverysigner/cmd/serve.go
@@ -52,7 +52,7 @@ func (c *ServeCommand) Command() *cobra.Command {
 		},
 		{
 			Name:      "sep10-jwks",
-			Usage:     "JSON Web Key Set (JWKS) containing exactly one key used to validate SEP-10 JWTs (if the key is an asymmetric key that has separate public and private key, the JWK need only contain the public key)",
+			Usage:     "JSON Web Key Set (JWKS) containing one or more keys used to validate SEP-10 JWTs (if the key is an asymmetric key that has separate public and private key, the JWK need only contain the public key) (if multiple keys are provided they will all attempt verification the key ID will be ignored although logged)",
 			OptType:   types.String,
 			ConfigKey: &opts.SEP10JWKS,
 			Required:  true,
@@ -90,7 +90,7 @@ func (c *ServeCommand) Command() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "serve",
-		Short: "Run the SEP-30 Recover Signer server",
+		Short: "Run the SEP-30 Recovery Signer server",
 		Run: func(_ *cobra.Command, _ []string) {
 			configOpts.Require()
 			configOpts.SetValues()

--- a/exp/services/recoverysigner/internal/serve/serve.go
+++ b/exp/services/recoverysigner/internal/serve/serve.go
@@ -56,7 +56,7 @@ func Serve(opts Options) {
 		ListenAddr: addr,
 		Handler:    handler,
 		OnStarting: func() {
-			deps.Logger.Infof("Starting SEP-30 Recover Signer server on %s", addr)
+			deps.Logger.Infof("Starting SEP-30 Recovery Signer server on %s", addr)
 		},
 	})
 }


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Fix a couple minor things in the usage text that were typos and out-dated or missing.

### Why
These things were changed or added recently and I failed to update the README and in some cases the usage text itself.

### Known limitations

N/A