### PR TITLE
services/horizon/docker/verify-range: Update base branch for verify range job

### DIFF
--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -100,7 +100,7 @@ if [ ! -z "$VERIFY_HISTORY" ]; then
 	# sudo -u postgres dropdb horizon
 	# sudo -u postgres createdb horizon
 
-	git checkout verify_range_base_horizon_v1.0.0
+	git checkout horizon-v1.3.0
 
 	/usr/local/go/bin/go build -v ./services/horizon
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Update base branch for verify range job.

### Why

Recently we fixed a bug with how transaction fees were represented in postgres. Previously, we stored the fee as a 32 bit signed integer. But, it turns out that the range of fee values can reach the maximum unsigned 32 bit integer.

In the old code, when we ingested transactions those fee values would appear negative in the database. But, in the new code, the fee values are correctly represented as positive.

This PR updates the base branch to be the tag of the horizon 1.3.0 release which corresponds to the last release which was verified. When we use this base branch we will no longer get false alerts based on negative fee values like:

```diff
< e615a8f6bff5ab52e19e21ebcdd439859aaf1cb2a56a23289ac3e3d01500bd7f,27725805,22,GCV2OEQTIJ6G44SMANFOKBXBNWD7U7S4ZNTMS5I4G6SFLWBPSNPJHFPQ,68826288277684336,-1294967296,1,119081425730363392,AAAAAKunEhNCfG5yTANK5QbhbYf6flzLZsl1HDekVdgvk16TstBeAAD0hSUAAABwAAAAAQAAAAAAAAAAAAAAAF4bs98AAAACAAAAAEgwrs8AAAABAAAAAAAAAAEAAAAAO3QYHRfhN87XgfHmCTFk45G6R4+IVAWjhMUDm17TeGMAAAAAAAAAALLQXgAAAAAAAAAAAS+TXpMAAABAX7/x+qQklQ4erBVUCLtgl/o6om1pDdGYQBk56Z1x8XVDZ7JkUv8+y8kuRRtUQQUWP08D+fAJFx2skocwx8IEDQ==,AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=,AAAAAgAAAAIAAAADAacP7QAAAAAAAAAAq6cSE0J8bnJMA0rlBuFth/p+XMtmyXUcN6RV2C+TXpMAAAAAs2kPYAD0hSUAAABvAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAacP7QAAAAAAAAAAq6cSE0J8bnJMA0rlBuFth/p+XMtmyXUcN6RV2C+TXpMAAAAAs2kPYAD0hSUAAABwAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMBpw61AAAAAAAAAAA7dBgdF+E3zteB8eYJMWTjkbpHj4hUBaOExQObXtN4YwAHv4RKbVDDAAh91wACMjUAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBpw/tAAAAAAAAAAA7dBgdF+E3zteB8eYJMWTjkbpHj4hUBaOExQObXtN4YwAHv4T9Pa7DAAh91wACMjUAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMBpw/tAAAAAAAAAACrpxITQnxuckwDSuUG4W2H+n5cy2bJdRw3pFXYL5NekwAAAACzaQ9gAPSFJQAAAHAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBpw/tAAAAAAAAAACrpxITQnxuckwDSuUG4W2H+n5cy2bJdRw3pFXYL5NekwAAAAAAmLFgAPSFJQAAAHAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA=,AAAAAgAAAAMBpoeNAAAAAAAAAACrpxITQnxuckwDSuUG4W2H+n5cy2bJdRw3pFXYL5NekwAAAACzaQ/EAPSFJQAAAG8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBpw/tAAAAAAAAAACrpxITQnxuckwDSuUG4W2H+n5cy2bJdRw3pFXYL5NekwAAAACzaQ9gAPSFJQAAAG8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==,{X7/x+qQklQ4erBVUCLtgl/o6om1pDdGYQBk56Z1x8XVDZ7JkUv8+y8kuRRtUQQUWP08D+fAJFx2skocwx8IEDQ==},id,1211150031,[0,1578873823),t,100
-----
> e615a8f6bff5ab52e19e21ebcdd439859aaf1cb2a56a23289ac3e3d01500bd7f,27725805,22,GCV2OEQTIJ6G44SMANFOKBXBNWD7U7S4ZNTMS5I4G6SFLWBPSNPJHFPQ,68826288277684336,3000000000,1,119081425730363392,AAAAAKunEhNCfG5yTANK5QbhbYf6flzLZsl1HDekVdgvk16TstBeAAD0hSUAAABwAAAAAQAAAAAAAAAAAAAAAF4bs98AAAACAAAAAEgwrs8AAAABAAAAAAAAAAEAAAAAO3QYHRfhN87XgfHmCTFk45G6R4+IVAWjhMUDm17TeGMAAAAAAAAAALLQXgAAAAAAAAAAAS+TXpMAAABAX7/x+qQklQ4erBVUCLtgl/o6om1pDdGYQBk56Z1x8XVDZ7JkUv8+y8kuRRtUQQUWP08D+fAJFx2skocwx8IEDQ==,AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=,AAAAAgAAAAIAAAADAacP7QAAAAAAAAAAq6cSE0J8bnJMA0rlBuFth/p+XMtmyXUcN6RV2C+TXpMAAAAAs2kPYAD0hSUAAABvAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAacP7QAAAAAAAAAAq6cSE0J8bnJMA0rlBuFth/p+XMtmyXUcN6RV2C+TXpMAAAAAs2kPYAD0hSUAAABwAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMBpw61AAAAAAAAAAA7dBgdF+E3zteB8eYJMWTjkbpHj4hUBaOExQObXtN4YwAHv4RKbVDDAAh91wACMjUAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBpw/tAAAAAAAAAAA7dBgdF+E3zteB8eYJMWTjkbpHj4hUBaOExQObXtN4YwAHv4T9Pa7DAAh91wACMjUAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMBpw/tAAAAAAAAAACrpxITQnxuckwDSuUG4W2H+n5cy2bJdRw3pFXYL5NekwAAAACzaQ9gAPSFJQAAAHAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBpw/tAAAAAAAAAACrpxITQnxuckwDSuUG4W2H+n5cy2bJdRw3pFXYL5NekwAAAAAAmLFgAPSFJQAAAHAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA=,AAAAAgAAAAMBpoeNAAAAAAAAAACrpxITQnxuckwDSuUG4W2H+n5cy2bJdRw3pFXYL5NekwAAAACzaQ/EAPSFJQAAAG8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBpw/tAAAAAAAAAACrpxITQnxuckwDSuUG4W2H+n5cy2bJdRw3pFXYL5NekwAAAACzaQ9gAPSFJQAAAG8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==,{X7/x+qQklQ4erBVUCLtgl/o6om1pDdGYQBk56Z1x8XVDZ7JkUv8+y8kuRRtUQQUWP08D+fAJFx2skocwx8IEDQ==},id,1211150031,[0,1578873823),t,100
```



### Known limitations

[N/A]
