### PR TITLE
txnbuild: Provide option to still generate V0 transaction envelopes

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -5,7 +5,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-* `txnbuild` now generates V1 transaction envelopes which are only supported by Protocol 13 ([#2640](https://github.com/stellar/go/pull/2640))
+* `txnbuild` now generates V1 transaction envelopes by default which are only supported by Protocol 13. To generate V0 transaction envelopes, set the `V0` field in `TransactionParams` to true. ([#2640](https://github.com/stellar/go/pull/2640))
 * Add `ToXDR()` functions for `Transaction` and `FeeBumpTransaction` instances which return xdr transaction envelopes without errors ([#2651](https://github.com/stellar/go/pull/2651))
 
 ## [v3.1.0](https://github.com/stellar/go/releases/tag/horizonclient-v3.1.0) - 2020-05-14

--- a/txnbuild/fee_bump_test.go
+++ b/txnbuild/fee_bump_test.go
@@ -50,7 +50,7 @@ func TestFeeBumpUpgradesV0Transaction(t *testing.T) {
 			BaseFee:              2 * MinBaseFee,
 			Memo:                 MemoText("test-memo"),
 			Timebounds:           NewInfiniteTimeout(),
-			V0:                   true,
+			Version:              TransactionVersion0,
 		},
 	)
 	assert.NoError(t, err)

--- a/txnbuild/fee_bump_test.go
+++ b/txnbuild/fee_bump_test.go
@@ -50,14 +50,13 @@ func TestFeeBumpUpgradesV0Transaction(t *testing.T) {
 			BaseFee:              2 * MinBaseFee,
 			Memo:                 MemoText("test-memo"),
 			Timebounds:           NewInfiniteTimeout(),
+			V0:                   true,
 		},
 	)
 	assert.NoError(t, err)
 
 	tx, err = tx.Sign(network.TestNetworkPassphrase, kp0)
 	assert.NoError(t, err)
-
-	convertToV0(tx)
 
 	feeBump, err := NewFeeBumpTransaction(
 		FeeBumpTransactionParams{

--- a/txnbuild/helpers_test.go
+++ b/txnbuild/helpers_test.go
@@ -101,21 +101,6 @@ func newSignedFeeBumpTransaction(
 	return txeBase64, err
 }
 
-func convertToV0(tx *Transaction) {
-	tx.envelope.V0 = &xdr.TransactionV0Envelope{
-		Tx: xdr.TransactionV0{
-			SourceAccountEd25519: *tx.envelope.SourceAccount().Ed25519,
-			Fee:                  xdr.Uint32(tx.envelope.Fee()),
-			SeqNum:               xdr.SequenceNumber(tx.envelope.SeqNum()),
-			TimeBounds:           tx.envelope.V1.Tx.TimeBounds,
-			Memo:                 tx.envelope.Memo(),
-			Operations:           tx.envelope.Operations(),
-		},
-	}
-	tx.envelope.V1 = nil
-	tx.envelope.Type = xdr.EnvelopeTypeEnvelopeTypeTxV0
-}
-
 func TestValidateStellarPublicKey(t *testing.T) {
 	validKey := "GDWZCOEQRODFCH6ISYQPWY67L3ULLWS5ISXYYL5GH43W7YFMTLB65PYM"
 	err := validateStellarPublicKey(validKey)

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -586,6 +586,14 @@ func transactionFromParsedXDR(xdrEnv xdr.TransactionEnvelope) (*GenericTransacti
 	return newTx, nil
 }
 
+type TransactionVersion int
+
+const (
+	TransactionVersionLatest TransactionVersion = iota
+	TransactionVersion0
+	TransactionVersion1
+)
+
 // TransactionParams is a container for parameters
 // which are used to construct new Transaction instances
 type TransactionParams struct {
@@ -595,11 +603,11 @@ type TransactionParams struct {
 	BaseFee              int64
 	Memo                 Memo
 	Timebounds           Timebounds
-	// V0 should be set to true if you want to generate V0 transaction envelopes
+	// Version should be set to TransactionVersion1 if you want to generate V0 transaction envelopes
 	// V0 transactions are protocol 12 transactions which can also be consumed by protocol 13 clients.
-	// If V0 is false, NewTransaction() will generate a V1 transaction envelope which is
+	// By default, NewTransaction() will generate a V1 transaction envelope which is
 	// only supported by protocol 13 or higher
-	V0 bool
+	Version TransactionVersion
 }
 
 // NewTransaction returns a new Transaction instance
@@ -664,7 +672,7 @@ func NewTransaction(params TransactionParams) (*Transaction, error) {
 
 	var envelope xdr.TransactionEnvelope
 
-	if params.V0 {
+	if params.Version == TransactionVersion0 {
 		ed25519, ok := accountID.GetEd25519()
 		if !ok {
 			return nil, errors.Errorf(
@@ -711,7 +719,7 @@ func NewTransaction(params TransactionParams) (*Transaction, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "couldn't build memo XDR")
 		}
-		if params.V0 {
+		if params.Version == TransactionVersion0 {
 			envelope.V0.Tx.Memo = xdrMemo
 		} else {
 			envelope.V1.Tx.Memo = xdrMemo
@@ -727,7 +735,7 @@ func NewTransaction(params TransactionParams) (*Transaction, error) {
 		if err2 != nil {
 			return nil, errors.Wrap(err2, fmt.Sprintf("failed to build operation %T", op))
 		}
-		if params.V0 {
+		if params.Version == TransactionVersion0 {
 			envelope.V0.Tx.Operations = append(envelope.V0.Tx.Operations, xdrOperation)
 		} else {
 			envelope.V1.Tx.Operations = append(envelope.V1.Tx.Operations, xdrOperation)
@@ -746,7 +754,7 @@ type FeeBumpTransactionParams struct {
 	BaseFee    int64
 }
 
-func convertTx(tx *Transaction, v0 bool) (*Transaction, error) {
+func convertTx(tx *Transaction, version TransactionVersion) (*Transaction, error) {
 	sourceAccount := tx.SourceAccount()
 	signatures := tx.Signatures()
 	tx, err := NewTransaction(TransactionParams{
@@ -756,7 +764,7 @@ func convertTx(tx *Transaction, v0 bool) (*Transaction, error) {
 		BaseFee:              tx.BaseFee(),
 		Memo:                 tx.Memo(),
 		Timebounds:           tx.Timebounds(),
-		V0:                   v0,
+		Version:              version,
 	})
 	if err != nil {
 		return tx, err
@@ -776,7 +784,7 @@ func NewFeeBumpTransaction(params FeeBumpTransactionParams) (*FeeBumpTransaction
 		return nil, errors.Wrap(err, "inner transaction envelope not found")
 	}
 	if innerEnv.Type == xdr.EnvelopeTypeEnvelopeTypeTxV0 {
-		inner, err = convertTx(inner, false)
+		inner, err = convertTx(inner, TransactionVersionLatest)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not upgrade transaction from v0 to v1")
 		}

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -595,6 +595,11 @@ type TransactionParams struct {
 	BaseFee              int64
 	Memo                 Memo
 	Timebounds           Timebounds
+	// V0 should be set to true if you want to generate V0 transaction envelopes
+	// V0 transactions are protocol 12 transactions which can also be consumed by protocol 13 clients.
+	// If V0 is false, NewTransaction() will generate a V1 transaction envelope which is
+	// only supported by protocol 13 or higher
+	V0 bool
 }
 
 // NewTransaction returns a new Transaction instance
@@ -657,20 +662,47 @@ func NewTransaction(params TransactionParams) (*Transaction, error) {
 		return nil, errors.Wrap(err, "invalid time bounds")
 	}
 
-	envelope := xdr.TransactionEnvelope{
-		Type: xdr.EnvelopeTypeEnvelopeTypeTx,
-		V1: &xdr.TransactionV1Envelope{
-			Tx: xdr.Transaction{
-				SourceAccount: accountID.ToMuxedAccount(),
-				Fee:           xdr.Uint32(tx.maxFee),
-				SeqNum:        xdr.SequenceNumber(sequence),
-				TimeBounds: &xdr.TimeBounds{
-					MinTime: xdr.TimePoint(tx.timebounds.MinTime),
-					MaxTime: xdr.TimePoint(tx.timebounds.MaxTime),
+	var envelope xdr.TransactionEnvelope
+
+	if params.V0 {
+		ed25519, ok := accountID.GetEd25519()
+		if !ok {
+			return nil, errors.Errorf(
+				"%s is not a valid source account",
+				params.SourceAccount.GetAccountID(),
+			)
+		}
+		envelope = xdr.TransactionEnvelope{
+			Type: xdr.EnvelopeTypeEnvelopeTypeTxV0,
+			V0: &xdr.TransactionV0Envelope{
+				Tx: xdr.TransactionV0{
+					SourceAccountEd25519: ed25519,
+					Fee:                  xdr.Uint32(tx.maxFee),
+					SeqNum:               xdr.SequenceNumber(sequence),
+					TimeBounds: &xdr.TimeBounds{
+						MinTime: xdr.TimePoint(tx.timebounds.MinTime),
+						MaxTime: xdr.TimePoint(tx.timebounds.MaxTime),
+					},
 				},
+				Signatures: nil,
 			},
-			Signatures: nil,
-		},
+		}
+	} else {
+		envelope = xdr.TransactionEnvelope{
+			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+			V1: &xdr.TransactionV1Envelope{
+				Tx: xdr.Transaction{
+					SourceAccount: accountID.ToMuxedAccount(),
+					Fee:           xdr.Uint32(tx.maxFee),
+					SeqNum:        xdr.SequenceNumber(sequence),
+					TimeBounds: &xdr.TimeBounds{
+						MinTime: xdr.TimePoint(tx.timebounds.MinTime),
+						MaxTime: xdr.TimePoint(tx.timebounds.MaxTime),
+					},
+				},
+				Signatures: nil,
+			},
+		}
 	}
 
 	// Handle the memo, if one is present
@@ -679,7 +711,11 @@ func NewTransaction(params TransactionParams) (*Transaction, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "couldn't build memo XDR")
 		}
-		envelope.V1.Tx.Memo = xdrMemo
+		if params.V0 {
+			envelope.V0.Tx.Memo = xdrMemo
+		} else {
+			envelope.V1.Tx.Memo = xdrMemo
+		}
 	}
 
 	for _, op := range tx.operations {
@@ -691,7 +727,11 @@ func NewTransaction(params TransactionParams) (*Transaction, error) {
 		if err2 != nil {
 			return nil, errors.Wrap(err2, fmt.Sprintf("failed to build operation %T", op))
 		}
-		envelope.V1.Tx.Operations = append(envelope.V1.Tx.Operations, xdrOperation)
+		if params.V0 {
+			envelope.V0.Tx.Operations = append(envelope.V0.Tx.Operations, xdrOperation)
+		} else {
+			envelope.V1.Tx.Operations = append(envelope.V1.Tx.Operations, xdrOperation)
+		}
 	}
 
 	tx.envelope = envelope
@@ -706,7 +746,7 @@ type FeeBumpTransactionParams struct {
 	BaseFee    int64
 }
 
-func convertToV1(tx *Transaction) (*Transaction, error) {
+func convertTx(tx *Transaction, v0 bool) (*Transaction, error) {
 	sourceAccount := tx.SourceAccount()
 	signatures := tx.Signatures()
 	tx, err := NewTransaction(TransactionParams{
@@ -716,6 +756,7 @@ func convertToV1(tx *Transaction) (*Transaction, error) {
 		BaseFee:              tx.BaseFee(),
 		Memo:                 tx.Memo(),
 		Timebounds:           tx.Timebounds(),
+		V0:                   v0,
 	})
 	if err != nil {
 		return tx, err
@@ -735,7 +776,7 @@ func NewFeeBumpTransaction(params FeeBumpTransactionParams) (*FeeBumpTransaction
 		return nil, errors.Wrap(err, "inner transaction envelope not found")
 	}
 	if innerEnv.Type == xdr.EnvelopeTypeEnvelopeTypeTxV0 {
-		inner, err = convertToV1(inner)
+		inner, err = convertTx(inner, false)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not upgrade transaction from v0 to v1")
 		}

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1094,7 +1094,7 @@ func TestTransactionVersions(t *testing.T) {
 
 	v1Env := tx.ToXDR()
 
-	params.V0 = true
+	params.Version = TransactionVersion0
 	v0Tx, err := NewTransaction(params)
 	assert.NoError(t, err)
 	v0Tx, err = v0Tx.Sign(network.TestNetworkPassphrase, kp0)
@@ -2003,7 +2003,7 @@ func TestReadChallengeTx_acceptsV0AndV1Transactions(t *testing.T) {
 	v1Challenge, err := marshallBase64(tx.envelope, tx.Signatures())
 	assert.NoError(t, err)
 
-	v0Tx, err := convertTx(tx, true)
+	v0Tx, err := convertTx(tx, TransactionVersion0)
 	assert.NoError(t, err)
 	v0Challenge, err := marshallBase64(v0Tx.envelope, tx.Signatures())
 	assert.NoError(t, err)

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1064,6 +1064,63 @@ func TestHashHex(t *testing.T) {
 	assert.Len(t, txEnv.Operations(), 1)
 }
 
+func TestTransactionVersions(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
+
+	createAccount := CreateAccount{
+		Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
+		Amount:      "10",
+	}
+	params := TransactionParams{
+		SourceAccount:        &sourceAccount,
+		IncrementSequenceNum: false,
+		Operations:           []Operation{&createAccount},
+		BaseFee:              MinBaseFee,
+		Timebounds:           NewInfiniteTimeout(),
+		Memo:                 MemoText("test memo"),
+	}
+
+	tx, err := NewTransaction(params)
+	assert.NoError(t, err)
+	tx, err = tx.Sign(network.TestNetworkPassphrase, kp0)
+	assert.NoError(t, err)
+
+	v1Hash, err := tx.HashHex(network.TestNetworkPassphrase)
+	assert.NoError(t, err)
+
+	v1Base64, err := tx.Base64()
+	assert.NoError(t, err)
+
+	v1Env := tx.ToXDR()
+
+	params.V0 = true
+	v0Tx, err := NewTransaction(params)
+	assert.NoError(t, err)
+	v0Tx, err = v0Tx.Sign(network.TestNetworkPassphrase, kp0)
+	assert.NoError(t, err)
+
+	v0Hash, err := v0Tx.HashHex(network.TestNetworkPassphrase)
+	assert.NoError(t, err)
+
+	v0Base64, err := v0Tx.Base64()
+	assert.NoError(t, err)
+
+	v0Env := v0Tx.ToXDR()
+
+	assert.Equal(t, v0Hash, v1Hash)
+	assert.NotEqual(t, v0Base64, v1Base64)
+
+	assert.Equal(t, xdr.EnvelopeTypeEnvelopeTypeTxV0, v0Env.Type)
+	assert.Equal(t, xdr.EnvelopeTypeEnvelopeTypeTx, v1Env.Type)
+	assert.Equal(t, v1Env.Fee(), v0Env.Fee())
+	assert.Equal(t, v1Env.Memo(), v0Env.Memo())
+	assert.Equal(t, v1Env.SourceAccount().MustEd25519(), v0Env.SourceAccount().MustEd25519())
+	assert.Equal(t, v1Env.Memo(), v0Env.Memo())
+	assert.Equal(t, v1Env.Operations(), v0Env.Operations())
+	assert.Equal(t, v1Env.TimeBounds(), v0Env.TimeBounds())
+}
+
 func TestTransactionFee(t *testing.T) {
 	kp0 := newKeypair0()
 	sourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
@@ -1946,8 +2003,9 @@ func TestReadChallengeTx_acceptsV0AndV1Transactions(t *testing.T) {
 	v1Challenge, err := marshallBase64(tx.envelope, tx.Signatures())
 	assert.NoError(t, err)
 
-	convertToV0(tx)
-	v0Challenge, err := marshallBase64(tx.envelope, tx.Signatures())
+	v0Tx, err := convertTx(tx, true)
+	assert.NoError(t, err)
+	v0Challenge, err := marshallBase64(v0Tx.envelope, tx.Signatures())
 	assert.NoError(t, err)
 
 	for _, challenge := range []string{v1Challenge, v0Challenge} {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Provide option to still generate V0 transaction envelopes.

### Why

A developer may still want to generate v0 transactions. For example, if you need to generate a transaction and sign it with a hardware wallet. The hardware wallet may still be stuck on protocol 12. So, having the option to generate v0 transactions is convenient in this case.


### Known limitations

[N/A]
