### PR TITLE
services/horizon: Add missing Core dependencies in Dockefile

### DIFF
--- a/services/horizon/docker/Dockerfile
+++ b/services/horizon/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN go mod download
 COPY . ./
 RUN go install github.com/stellar/go/services/horizon
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV STELLAR_CORE_VERSION 13.0.0-1220-9ed3da29
 ENV STELLAR_CORE_BINARY_PATH /usr/local/bin/stellar-core
@@ -14,9 +14,13 @@ ENV STELLAR_CORE_BINARY_PATH /usr/local/bin/stellar-core
 # ca-certificates are required to make tls connections
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget
 
+
+RUN apt-get install -y --no-install-recommends libpqxx-4.0v5 curl
 RUN wget -O stellar-core.deb https://s3.amazonaws.com/stellar.org/releases/stellar-core/stellar-core-${STELLAR_CORE_VERSION}_amd64.deb
 RUN dpkg -i stellar-core.deb
 RUN rm stellar-core.deb
+
+RUN apt-get clean
 
 COPY --from=builder /go/bin/horizon ./
 


### PR DESCRIPTION
Also, upgrade the container to ubuntu 18.04 (16.04 didn't have a compatible libstdc++ library)

