### PR TITLE
services/horizon: Write captive-core logs to /dev/null when discarding them

### DIFF
--- a/exp/ingest/ledgerbackend/stellar_core_runner.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner.go
@@ -60,7 +60,7 @@ func (r *stellarCoreRunner) getConfFileName() string {
 	return filepath.Join(r.getTmpDir(), "stellar-core.conf")
 }
 
-func (*stellarCoreRunner) getLogLineWriter() io.Writer {
+func (*stellarCoreRunner) GetLogLineWriter() io.Writer {
 	r, w := io.Pipe()
 	br := bufio.NewReader(r)
 	// Strip timestamps from log lines from captive stellar-core. We emit our own.
@@ -110,7 +110,7 @@ func (r *stellarCoreRunner) run(from, to uint32) error {
 	cmd := exec.Command(r.executablePath, args...)
 	cmd.Dir = r.getTmpDir()
 	// In order to get the full stellar core logs:
-	// cmd.Stdout = r.getLogLineWriter()
+	// cmd.Stdout = r.GetLogLineWriter()
 	cmd.Stderr = cmd.Stdout
 	r.cmd = cmd
 	err = r.start()

--- a/exp/ingest/ledgerbackend/stellar_core_runner.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner.go
@@ -1,6 +1,7 @@
 package ledgerbackend
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -59,20 +61,20 @@ func (r *stellarCoreRunner) getConfFileName() string {
 }
 
 func (*stellarCoreRunner) getLogLineWriter() io.Writer {
-	_, w := io.Pipe()
-	// br := bufio.NewReader(r)
-	// // Strip timestamps from log lines from captive stellar-core. We emit our own.
-	// dateRx := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3} `)
-	// go func() {
-	// 	for {
-	// 		line, e := br.ReadString('\n')
-	// 		if e != nil {
-	// 			break
-	// 		}
-	// 		line = dateRx.ReplaceAllString(line, "")
-	// 		fmt.Print(line)
-	// 	}
-	// }()
+	r, w := io.Pipe()
+	br := bufio.NewReader(r)
+	// Strip timestamps from log lines from captive stellar-core. We emit our own.
+	dateRx := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3} `)
+	go func() {
+		for {
+			line, e := br.ReadString('\n')
+			if e != nil {
+				break
+			}
+			line = dateRx.ReplaceAllString(line, "")
+			fmt.Print(line)
+		}
+	}()
 	return w
 }
 
@@ -107,7 +109,8 @@ func (r *stellarCoreRunner) run(from, to uint32) error {
 	args := []string{"--conf", r.getConfFileName(), "catchup", rangeArg, "--replay-in-memory"}
 	cmd := exec.Command(r.executablePath, args...)
 	cmd.Dir = r.getTmpDir()
-	cmd.Stdout = r.getLogLineWriter()
+	// In order to get the full stellar core logs:
+	// cmd.Stdout = r.getLogLineWriter()
 	cmd.Stderr = cmd.Stdout
 	r.cmd = cmd
 	err = r.start()


### PR DESCRIPTION
In macOS, captive-core blocks when writing to a pipe which isn't read from.
