### PR TITLE
exp/ingest/ledgerbackend: Stream stellar-core logs to file

### DIFF
--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -249,6 +249,10 @@ func (c *CaptiveStellarCore) readLedgerMetaFromPipe() (*xdr.LedgerCloseMeta, err
 	return &xlcm, nil
 }
 
+func (c *CaptiveStellarCore) GetStellarCoreLogFilePath() string {
+	return c.stellarCoreRunner.getLogFilePath()
+}
+
 // PrepareRange prepares the given range (including from and to) to be loaded.
 // Some backends (like captive stellar-core) need to initalize data to be
 // able to stream ledgers.

--- a/exp/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend_test.go
@@ -30,6 +30,11 @@ func (m *stellarCoreRunnerMock) runFrom(from uint32) error {
 	return a.Error(0)
 }
 
+func (m *stellarCoreRunnerMock) getLogFilePath() string {
+	a := m.Called()
+	return a.Get(0).(string)
+}
+
 func (m *stellarCoreRunnerMock) getMetaPipe() io.Reader {
 	a := m.Called()
 	return a.Get(0).(io.Reader)

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -144,6 +144,10 @@ func NewSystem(config Config) (*System, error) {
 			config.NetworkPassphrase,
 			[]string{config.HistoryArchiveURL},
 		)
+		log.Infof(
+			"Logging stellar-core output to the file: %s",
+			ledgerBackend.(*ledgerbackend.CaptiveStellarCore).GetStellarCoreLogFilePath(),
+		)
 	} else {
 		ledgerBackend, err = ledgerbackend.NewDatabaseBackendFromSession(coreSession)
 		if err != nil {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Stream stellar-core logs to file.

### Why

Currently we stream logs to stdout what can be hard to read when also Horizon logs are streamed.
