### PR TITLE
Add replacements urls to docs

### DIFF
--- a/services/horizon/internal/docs/admin.md
+++ b/services/horizon/internal/docs/admin.md
@@ -1,5 +1,6 @@
 ---
 title: Horizon Administration Guide
+replacement: https://developers.stellar.org/docs/run-api-server/
 ---
 ## Horizon Administration Guide
 

--- a/services/horizon/internal/docs/quickstart.md
+++ b/services/horizon/internal/docs/quickstart.md
@@ -1,5 +1,6 @@
 ---
 title: Horizon Quickstart
+replacement: https://developers.stellar.org/docs/run-api-server/quickstart/
 ---
 ## Horizon Quickstart
 This document describes how to quickly set up a **test** Stellar Core + Horizon node, that you can play around with to get a feel for how a stellar node operates. **This configuration is not secure!** It is **not** intended as a guide for production administration.

--- a/services/horizon/internal/docs/readme.md
+++ b/services/horizon/internal/docs/readme.md
@@ -1,5 +1,6 @@
 ---
 title: Horizon
+replacement: https://developers.stellar.org/docs/run-api-server/
 ---
 
 Horizon is the server for the client facing API for the Stellar ecosystem.  It acts as the interface between [stellar-core](https://www.stellar.org/developers/software/#stellar-core) and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams, etc. See [an overview of the Stellar ecosystem](https://www.stellar.org/developers/guides/) for more details.

--- a/services/horizon/internal/docs/reference/endpoints/accounts-single.md
+++ b/services/horizon/internal/docs/reference/endpoints/accounts-single.md
@@ -2,6 +2,7 @@
 title: Account Details
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=accounts&endpoint=single
+replacement: https://developers.stellar.org/api/resources/accounts/single/
 ---
 
 Returns information and links relating to a single [account](../resources/account.md).

--- a/services/horizon/internal/docs/reference/endpoints/accounts.md
+++ b/services/horizon/internal/docs/reference/endpoints/accounts.md
@@ -1,5 +1,6 @@
 ---
 title: Accounts
+replacement: https://developers.stellar.org/api/resources/accounts/
 ---
 
 This endpoint allows filtering accounts who have a given `signer` or have a trustline to an `asset`. The result is a list of [accounts](../resources/account.md).

--- a/services/horizon/internal/docs/reference/endpoints/assets-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/assets-all.md
@@ -2,6 +2,7 @@
 title: All Assets
 clientData:
   laboratoryUrl:
+replacement: https://developers.stellar.org/api/resources/assets/
 ---
 
 This endpoint represents all [assets](../resources/asset.md).

--- a/services/horizon/internal/docs/reference/endpoints/data-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/data-for-account.md
@@ -2,6 +2,7 @@
 title: Data for Account
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=data&endpoint=for_account
+replacement: https://developers.stellar.org/api/resources/accounts/data/
 ---
 
 This endpoint represents a single [data](../resources/data.md) associated with a given [account](../resources/account.md).

--- a/services/horizon/internal/docs/reference/endpoints/effects-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/effects-all.md
@@ -2,6 +2,7 @@
 title: All Effects
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=effects&endpoint=all
+replacement: https://developers.stellar.org/api/resources/effects/list/
 ---
 
 This endpoint represents all [effects](../resources/effect.md).

--- a/services/horizon/internal/docs/reference/endpoints/effects-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/effects-for-account.md
@@ -2,6 +2,7 @@
 title: Effects for Account
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=effects&endpoint=for_account
+replacement: https://developers.stellar.org/api/resources/accounts/effects/
 ---
 
 This endpoint represents all [effects](../resources/effect.md) that changed a given

--- a/services/horizon/internal/docs/reference/endpoints/effects-for-operation.md
+++ b/services/horizon/internal/docs/reference/endpoints/effects-for-operation.md
@@ -2,6 +2,7 @@
 title: Effects for Operation
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=effects&endpoint=for_operation
+replacement: https://developers.stellar.org/api/resources/operations/effects/
 ---
 
 This endpoint represents all [effects](../resources/effect.md) that occurred as a result of a given [operation](../resources/operation.md).

--- a/services/horizon/internal/docs/reference/endpoints/effects-for-transaction.md
+++ b/services/horizon/internal/docs/reference/endpoints/effects-for-transaction.md
@@ -2,6 +2,7 @@
 title: Effects for Transaction
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=effects&endpoint=for_transaction
+replacement: https://developers.stellar.org/api/resources/transactions/effects/
 ---
 
 This endpoint represents all [effects](../resources/effect.md) that occurred as a result of a given [transaction](../resources/transaction.md).

--- a/services/horizon/internal/docs/reference/endpoints/fee-stats.md
+++ b/services/horizon/internal/docs/reference/endpoints/fee-stats.md
@@ -2,6 +2,7 @@
 title: Fee Stats
 clientData:
   laboratoryUrl:
+replacement: https://developers.stellar.org/api/aggregations/fee-stats/
 ---
 
 This endpoint gives useful information about per-operation fee stats in the last 5 ledgers. It can be used to

--- a/services/horizon/internal/docs/reference/endpoints/ledgers-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/ledgers-all.md
@@ -2,6 +2,7 @@
 title: All Ledgers
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=ledgers&endpoint=all
+replacement: https://developers.stellar.org/api/resources/ledgers/
 ---
 
 This endpoint represents all [ledgers](../resources/ledger.md).

--- a/services/horizon/internal/docs/reference/endpoints/ledgers-single.md
+++ b/services/horizon/internal/docs/reference/endpoints/ledgers-single.md
@@ -2,6 +2,7 @@
 title: Ledger Details
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=ledgers&endpoint=single
+replacement: https://developers.stellar.org/api/resources/ledgers/single/
 ---
 
 The ledger details endpoint provides information on a single [ledger](../resources/ledger.md).

--- a/services/horizon/internal/docs/reference/endpoints/offer-details.md
+++ b/services/horizon/internal/docs/reference/endpoints/offer-details.md
@@ -1,5 +1,6 @@
 ---
 title: Offer Details
+replacement: https://developers.stellar.org/api/resources/offers/
 ---
 
 Returns information and links relating to a single [offer](../resources/offer.md).

--- a/services/horizon/internal/docs/reference/endpoints/offers-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/offers-for-account.md
@@ -2,6 +2,7 @@
 title: Offers for Account
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=offers&endpoint=for_account
+replacement: https://developers.stellar.org/api/resources/accounts/offers/
 ---
 
 People on the Stellar network can make [offers](../resources/offer.md) to buy or sell assets. This

--- a/services/horizon/internal/docs/reference/endpoints/offers.md
+++ b/services/horizon/internal/docs/reference/endpoints/offers.md
@@ -1,5 +1,6 @@
 ---
 title: Offers
+replacement: https://developers.stellar.org/api/resources/offers/list/
 ---
 
 People on the Stellar network can make [offers](../resources/offer.md) to buy or sell assets. This

--- a/services/horizon/internal/docs/reference/endpoints/operations-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/operations-all.md
@@ -2,6 +2,7 @@
 title: All Operations
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=operations&endpoint=all
+replacement: https://developers.stellar.org/api/resources/operations/
 ---
 
 This endpoint represents [operations](../resources/operation.md) that are part of successfully validated [transactions](../resources/transaction.md).

--- a/services/horizon/internal/docs/reference/endpoints/operations-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/operations-for-account.md
@@ -2,6 +2,7 @@
 title: Operations for Account
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=operations&endpoint=for_account
+replacement: https://developers.stellar.org/api/resources/accounts/offers/
 ---
 
 This endpoint represents successful [operations](../resources/operation.md) that were included in valid [transactions](../resources/transaction.md) that affected a particular [account](../resources/account.md).

--- a/services/horizon/internal/docs/reference/endpoints/operations-for-ledger.md
+++ b/services/horizon/internal/docs/reference/endpoints/operations-for-ledger.md
@@ -2,6 +2,7 @@
 title: Operations for Ledger
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=operations&endpoint=for_ledger
+replacement: https://developers.stellar.org/api/resources/ledgers/operations/
 ---
 
 This endpoint returns successful [operations](../resources/operation.md) that occurred in a given [ledger](../resources/ledger.md).

--- a/services/horizon/internal/docs/reference/endpoints/operations-for-transaction.md
+++ b/services/horizon/internal/docs/reference/endpoints/operations-for-transaction.md
@@ -2,6 +2,7 @@
 title: Operations for Transaction
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=operations&endpoint=for_transaction
+replacement: https://developers.stellar.org/api/resources/transactions/operations/
 ---
 
 This endpoint represents successful [operations](../resources/operation.md) that are part of a given [transaction](../resources/transaction.md).

--- a/services/horizon/internal/docs/reference/endpoints/operations-single.md
+++ b/services/horizon/internal/docs/reference/endpoints/operations-single.md
@@ -2,6 +2,7 @@
 title: Operation Details
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=operations&endpoint=single
+replacement: https://developers.stellar.org/api/resources/operations/single/
 ---
 
 The operation details endpoint provides information on a single

--- a/services/horizon/internal/docs/reference/endpoints/orderbook-details.md
+++ b/services/horizon/internal/docs/reference/endpoints/orderbook-details.md
@@ -2,6 +2,7 @@
 title: Orderbook Details
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=order_book&endpoint=details
+replacement: https://developers.stellar.org/api/aggregations/order-books/
 ---
 
 People on the Stellar network can make [offers](../resources/offer.md) to buy or sell assets.

--- a/services/horizon/internal/docs/reference/endpoints/path-finding-strict-receive.md
+++ b/services/horizon/internal/docs/reference/endpoints/path-finding-strict-receive.md
@@ -2,6 +2,7 @@
 title: Strict Receive Payment Paths
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=paths&endpoint=all
+replacement: https://developers.stellar.org/api/aggregations/paths/strict-receive/
 ---
 
 The Stellar Network allows payments to be made across assets through _path payments_.  A path

--- a/services/horizon/internal/docs/reference/endpoints/path-finding-strict-send.md
+++ b/services/horizon/internal/docs/reference/endpoints/path-finding-strict-send.md
@@ -2,6 +2,7 @@
 title: Strict Send Payment Paths
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=paths&endpoint=all
+replacement: https://developers.stellar.org/api/aggregations/paths/strict-send/
 ---
 
 The Stellar Network allows payments to be made across assets through _path payments_.  A path

--- a/services/horizon/internal/docs/reference/endpoints/path-finding.md
+++ b/services/horizon/internal/docs/reference/endpoints/path-finding.md
@@ -2,6 +2,7 @@
 title: Find Payment Paths
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=paths&endpoint=all
+replacement: https://developers.stellar.org/api/aggregations/paths/
 ---
 
 **Note**: This endpoint will be deprecated, use [/path/strict-receive](./path-finding-strict-receive.md) instead. There are no differences between both endpoints, `/paths` is an alias for `/path/strict-receive`.

--- a/services/horizon/internal/docs/reference/endpoints/payments-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/payments-for-account.md
@@ -2,6 +2,7 @@
 title: Payments for Account
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=payments&endpoint=for_account
+replacement: https://developers.stellar.org/api/resources/accounts/payments/
 ---
 
 This endpoint responds with a collection of payment-related operations where the given

--- a/services/horizon/internal/docs/reference/endpoints/payments-for-ledger.md
+++ b/services/horizon/internal/docs/reference/endpoints/payments-for-ledger.md
@@ -2,6 +2,7 @@
 title: Payments for Ledger
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=payments&endpoint=for_ledger
+replacement: https://developers.stellar.org/api/resources/ledgers/payments/
 ---
 
 This endpoint represents all payment-related [operations](../resources/operation.md) that are part

--- a/services/horizon/internal/docs/reference/endpoints/trade_aggregations.md
+++ b/services/horizon/internal/docs/reference/endpoints/trade_aggregations.md
@@ -1,5 +1,6 @@
 ---
 title: Trade Aggregations
+replacement: https://developers.stellar.org/api/aggregations/trade-aggregations/
 ---
 
 Trade Aggregations are catered specifically for developers of trading clients. They facilitate

--- a/services/horizon/internal/docs/reference/endpoints/trades-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/trades-for-account.md
@@ -2,6 +2,7 @@
 title: Trades for Account
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=trades&endpoint=for_account
+replacement: https://developers.stellar.org/api/resources/accounts/trades/
 ---
 
 This endpoint represents all [trades](../resources/trade.md) that affect a given [account](../resources/account.md).

--- a/services/horizon/internal/docs/reference/endpoints/trades.md
+++ b/services/horizon/internal/docs/reference/endpoints/trades.md
@@ -1,5 +1,6 @@
 ---
 title: Trades
+replacement: https://developers.stellar.org/api/resources/trades/
 ---
 
 People on the Stellar network can make [offers](../resources/offer.md) to buy or sell assets. When

--- a/services/horizon/internal/docs/reference/endpoints/transactions-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/transactions-all.md
@@ -2,6 +2,7 @@
 title: All Transactions
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=transactions&endpoint=all
+replacement: https://developers.stellar.org/api/resources/transactions/single/
 ---
 
 This endpoint represents all successful [transactions](../resources/transaction.md).

--- a/services/horizon/internal/docs/reference/endpoints/transactions-create.md
+++ b/services/horizon/internal/docs/reference/endpoints/transactions-create.md
@@ -2,6 +2,7 @@
 title: Post Transaction
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=transactions&endpoint=create
+replacement: https://developers.stellar.org/api/resources/transactions/post/
 ---
 
 Posts a new [transaction](../resources/transaction.md) to the Stellar Network.

--- a/services/horizon/internal/docs/reference/endpoints/transactions-for-account.md
+++ b/services/horizon/internal/docs/reference/endpoints/transactions-for-account.md
@@ -2,6 +2,7 @@
 title: Transactions for Account
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=transactions&endpoint=for_account
+replacement: https://developers.stellar.org/api/resources/accounts/transactions/
 ---
 
 This endpoint represents successful [transactions](../resources/transaction.md) that affected a

--- a/services/horizon/internal/docs/reference/endpoints/transactions-for-ledger.md
+++ b/services/horizon/internal/docs/reference/endpoints/transactions-for-ledger.md
@@ -2,6 +2,7 @@
 title: Transactions for Ledger
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=transactions&endpoint=for_ledger
+replacement: https://developers.stellar.org/api/resources/ledgers/transactions/
 ---
 
 This endpoint represents successful [transactions](../resources/transaction.md) in a given [ledger](../resources/ledger.md).

--- a/services/horizon/internal/docs/reference/endpoints/transactions-single.md
+++ b/services/horizon/internal/docs/reference/endpoints/transactions-single.md
@@ -2,6 +2,7 @@
 title: Transaction Details
 clientData:
   laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=transactions&endpoint=single
+replacement: https://developers.stellar.org/api/resources/transactions/single/
 ---
 
 The transaction details endpoint provides information on a single

--- a/services/horizon/internal/docs/reference/errors.md
+++ b/services/horizon/internal/docs/reference/errors.md
@@ -1,5 +1,6 @@
 ---
 title: Errors
+replacement: https://developers.stellar.org/api/errors/
 ---
 
 In the event that an error occurs while processing a request to horizon, an

--- a/services/horizon/internal/docs/reference/errors/bad-request.md
+++ b/services/horizon/internal/docs/reference/errors/bad-request.md
@@ -1,5 +1,6 @@
 ---
 title: Bad Request
+replacement: https://developers.stellar.org/api/errors/http-status-codes/standard/
 ---
 
 If Horizon cannot understand a request due to invalid parameters, it will return a `bad_request`

--- a/services/horizon/internal/docs/reference/errors/before-history.md
+++ b/services/horizon/internal/docs/reference/errors/before-history.md
@@ -1,5 +1,6 @@
 ---
 title: Before History
+replacement: https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/
 ---
 
 A horizon server may be configured to only keep a portion of the stellar network's history stored

--- a/services/horizon/internal/docs/reference/errors/not-acceptable.md
+++ b/services/horizon/internal/docs/reference/errors/not-acceptable.md
@@ -1,5 +1,6 @@
 ---
 title: Not Acceptable
+replacement: https://developers.stellar.org/api/errors/http-status-codes/standard/
 ---
 
 When your client only accepts certain formats of data from Horizon and Horizon cannot fulfill that

--- a/services/horizon/internal/docs/reference/errors/not-found.md
+++ b/services/horizon/internal/docs/reference/errors/not-found.md
@@ -1,5 +1,6 @@
 ---
 title: Not Found
+replacement: https://developers.stellar.org/api/errors/http-status-codes/standard/
 ---
 
 When Horizon can't find whatever data you are requesting, it will return a `not_found` error. This

--- a/services/horizon/internal/docs/reference/errors/not-implemented.md
+++ b/services/horizon/internal/docs/reference/errors/not-implemented.md
@@ -1,5 +1,6 @@
 ---
 title: Not Implemented
+replacement: https://developers.stellar.org/api/errors/http-status-codes/standard/
 ---
 
 If your [request method](http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html) is not supported by

--- a/services/horizon/internal/docs/reference/errors/rate-limit-exceeded.md
+++ b/services/horizon/internal/docs/reference/errors/rate-limit-exceeded.md
@@ -1,5 +1,6 @@
 ---
 title: Rate Limit Exceeded
+replacement: https://developers.stellar.org/api/errors/http-status-codes/standard/
 ---
 
 When a single user makes too many requests to Horizon in a one hour time frame, Horizon returns a

--- a/services/horizon/internal/docs/reference/errors/server-error.md
+++ b/services/horizon/internal/docs/reference/errors/server-error.md
@@ -1,5 +1,6 @@
 ---
 title: Internal Server Error
+replacement: https://developers.stellar.org/api/errors/http-status-codes/standard/
 ---
 
 If there's an internal error within Horizon, Horizon will return a

--- a/services/horizon/internal/docs/reference/errors/stale-history.md
+++ b/services/horizon/internal/docs/reference/errors/stale-history.md
@@ -1,5 +1,6 @@
 ---
 title: Stale History
+replacement: https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/
 ---
 
 A horizon server may be configured to reject historical requests when the history is known to be

--- a/services/horizon/internal/docs/reference/errors/timeout.md
+++ b/services/horizon/internal/docs/reference/errors/timeout.md
@@ -1,5 +1,6 @@
 ---
 title: Timeout
+replacement: https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/
 ---
 
 If you are encountering this error it means that either:

--- a/services/horizon/internal/docs/reference/errors/transaction-failed.md
+++ b/services/horizon/internal/docs/reference/errors/transaction-failed.md
@@ -1,5 +1,6 @@
 ---
 title: Transaction Failed
+replacement: https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/
 ---
 
 The `transaction_failed` error occurs when a client submits a transaction that was well-formed but

--- a/services/horizon/internal/docs/reference/errors/transaction-malformed.md
+++ b/services/horizon/internal/docs/reference/errors/transaction-malformed.md
@@ -1,5 +1,6 @@
 ---
 title: Transaction Malformed
+replacement: https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/
 ---
 
 When you submit a malformed transaction to Horizon, Horizon will return a `transaction_malformed`

--- a/services/horizon/internal/docs/reference/paging.md
+++ b/services/horizon/internal/docs/reference/paging.md
@@ -1,5 +1,6 @@
 ---
 title: Paging
+replacement: https://developers.stellar.org/api/introduction/pagination/
 ---
 
 The Stellar network contains a lot of data and it would be infeasible to return it all at once. The paging system allows

--- a/services/horizon/internal/docs/reference/rate-limiting.md
+++ b/services/horizon/internal/docs/reference/rate-limiting.md
@@ -1,5 +1,6 @@
 ---
 title: Rate Limiting
+replacement: https://developers.stellar.org/api/introduction/rate-limiting/
 ---
 
 In order to provide service stability, Horizon limits the number of requests a

--- a/services/horizon/internal/docs/reference/resources/account.md
+++ b/services/horizon/internal/docs/reference/resources/account.md
@@ -1,5 +1,6 @@
 ---
 title: Account
+replacement: https://developers.stellar.org/api/resources/accounts/
 ---
 
 In the Stellar network, users interact using **accounts** which can be controlled by a corresponding keypair that can authorize transactions. One can create a new account with the [Create Account](./operation.md#create-account) operation.

--- a/services/horizon/internal/docs/reference/resources/asset.md
+++ b/services/horizon/internal/docs/reference/resources/asset.md
@@ -1,5 +1,6 @@
 ---
 title: Asset
+replacement: https://developers.stellar.org/api/resources/assets/
 ---
 
 **Assets** are the units that are traded on the Stellar Network.

--- a/services/horizon/internal/docs/reference/resources/data.md
+++ b/services/horizon/internal/docs/reference/resources/data.md
@@ -1,5 +1,6 @@
 ---
 title: Data
+replacement: https://developers.stellar.org/api/resources/accounts/data/
 ---
 
 Each account in Stellar network can contain multiple key/value pairs associated with it. Horizon can be used to retrieve value of each data key.

--- a/services/horizon/internal/docs/reference/resources/effect.md
+++ b/services/horizon/internal/docs/reference/resources/effect.md
@@ -1,5 +1,6 @@
 ---
 title: Effect
+replacement: https://developers.stellar.org/api/resources/effects/
 ---
 
 A successful operation will yield zero or more **effects**.  These effects

--- a/services/horizon/internal/docs/reference/resources/ledger.md
+++ b/services/horizon/internal/docs/reference/resources/ledger.md
@@ -1,5 +1,6 @@
 ---
 title: Ledger
+replacement: https://developers.stellar.org/api/resources/ledgers/
 ---
 
 A **ledger** resource contains information about a given ledger.

--- a/services/horizon/internal/docs/reference/resources/offer.md
+++ b/services/horizon/internal/docs/reference/resources/offer.md
@@ -1,5 +1,6 @@
 ---
 title: Offer
+replacement: https://developers.stellar.org/api/resources/offers/
 ---
 
 Accounts on the Stellar network can make [offers](http://stellar.org/developers/learn/concepts/exchange.html) to buy or sell assets.  Users can create offers with the [Manage Offer](http://stellar.org/developers/learn/concepts/list-of-operations.html) operation.

--- a/services/horizon/internal/docs/reference/resources/operation.md
+++ b/services/horizon/internal/docs/reference/resources/operation.md
@@ -1,5 +1,6 @@
 ---
 title: Operation
+replacement: https://developers.stellar.org/api/resources/operations/
 ---
 
 [Operations](https://www.stellar.org/developers/learn/concepts/operations.html) are objects that represent a desired change to the ledger: payments,

--- a/services/horizon/internal/docs/reference/resources/orderbook.md
+++ b/services/horizon/internal/docs/reference/resources/orderbook.md
@@ -1,5 +1,6 @@
 ---
 title: Orderbook
+replacement: https://developers.stellar.org/api/aggregations/order-books/
 ---
 
 [Orderbooks](https://www.stellar.org/developers/learn/concepts/exchange.html) are collections of offers for each issuer and currency pairs.  Let's say you wanted to exchange EUR issued by a particular bank for BTC issued by a particular exchange.  You would look at the orderbook and see who is buying `foo_bank/EUR` and selling `baz_exchange/BTC` and at what prices.

--- a/services/horizon/internal/docs/reference/resources/page.md
+++ b/services/horizon/internal/docs/reference/resources/page.md
@@ -1,5 +1,6 @@
 ---
 title: Page
+replacement: https://developers.stellar.org/api/introduction/pagination/page-arguments/
 ---
 
 Pages represent a subset of a larger collection of objects.

--- a/services/horizon/internal/docs/reference/resources/path.md
+++ b/services/horizon/internal/docs/reference/resources/path.md
@@ -1,5 +1,6 @@
 ---
 title: Payment Path
+replacement: https://developers.stellar.org/api/aggregations/paths/
 ---
 
 A **path** resource contains information about a payment path.  A path can be used by code to populate necessary fields on path payment operation, such as `path` and `sendMax`.

--- a/services/horizon/internal/docs/reference/resources/trade_aggregation.md
+++ b/services/horizon/internal/docs/reference/resources/trade_aggregation.md
@@ -1,5 +1,6 @@
 ---
 title: Trade Aggregation
+replacement: https://developers.stellar.org/api/aggregations/trade-aggregations/
 ---
 
 A Trade Aggregation represents aggregated statistics on an asset pair (`base` and `counter`) for a specific time period.

--- a/services/horizon/internal/docs/reference/resources/transaction.md
+++ b/services/horizon/internal/docs/reference/resources/transaction.md
@@ -1,5 +1,6 @@
 ---
 title: Transaction
+replacement: https://developers.stellar.org/api/resources/transactions/
 ---
 
 **Transactions** are the basic unit of change in the Stellar Network.

--- a/services/horizon/internal/docs/reference/responses.md
+++ b/services/horizon/internal/docs/reference/responses.md
@@ -1,5 +1,6 @@
 ---
 title: Response Format
+replacement: https://developers.stellar.org/api/introduction/response-format/
 ---
 
 Rather than using a fully custom way of representing the resources we expose in

--- a/services/horizon/internal/docs/reference/streaming.md
+++ b/services/horizon/internal/docs/reference/streaming.md
@@ -1,5 +1,6 @@
 ---
 title: Streaming
+replacement: https://developers.stellar.org/api/introduction/streaming/
 ---
 
 ## Streaming

--- a/services/horizon/internal/docs/reference/xdr.md
+++ b/services/horizon/internal/docs/reference/xdr.md
@@ -1,5 +1,6 @@
 ---
 title: XDR
+replacement: https://developers.stellar.org/api/introduction/xdr/
 ---
 
 **XDR**, also known as _External Data Representation_, is used extensively in


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Adds a `replacement` property to the frontmatter of docs markdown files.

### Why

The current `stellar.org/developers/*` pages are being replaced with new content, currently in beta. We're preparing to flip the switch on making them the recommended documentation, and part of the transition plan is directing docs visitors to the new content. Later on, these pages will redirect all traffic automatically.

### Known limitations

N/A
