### PR TITLE
services/horizon: Add read-ahead buffer for decoded LedgerCloseMeta

### DIFF
--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -3,7 +3,6 @@ package ledgerbackend
 import (
 	"io"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -31,14 +30,18 @@ var _ LedgerBackend = (*captiveStellarCore)(nil)
 
 // TODO: switch from history URLs to history archive interface provided from support package, to permit mocking
 
-// In this (crude, initial) sketch, we replay ledgers in blocks of 17,280
-// which is 24 hours worth of ledgers at 5 second intervals.
-const ledgersPerProcess = 17280
-const ledgersPerCheckpoint = 64
+const (
+	// In this (crude, initial) sketch, we replay ledgers in blocks of 17,280
+	// which is 24 hours worth of ledgers at 5 second intervals.
+	ledgersPerProcess    = 17280
+	ledgersPerCheckpoint = 64
 
-// The number of checkpoints we're willing to scan over and ignore, without
-// restarting a subprocess.
-const numCheckpointsLeeway = 10
+	// The number of checkpoints we're willing to scan over and ignore, without
+	// restarting a subprocess.
+	numCheckpointsLeeway = 10
+
+	readAheadBufferSize = 2
+)
 
 func roundDownToFirstReplayAfterCheckpointStart(ledger uint32) uint32 {
 	v := (ledger / ledgersPerCheckpoint) * ledgersPerCheckpoint
@@ -49,17 +52,20 @@ func roundDownToFirstReplayAfterCheckpointStart(ledger uint32) uint32 {
 	return v
 }
 
+type metaResult struct {
+	*xdr.LedgerCloseMeta
+	err error
+}
+
 type captiveStellarCore struct {
 	networkPassphrase string
 	historyURLs       []string
 	lastLedger        *uint32 // end of current segment if offline, nil if online
 
 	// read-ahead buffer
-	readBufferOccupation uint32
-	stop                 chan struct{}
-	wait                 sync.WaitGroup
-	metaC                chan *xdr.LedgerCloseMeta
-	errC                 chan error
+	stop  chan struct{}
+	wait  sync.WaitGroup
+	metaC chan metaResult
 
 	stellarCoreRunner stellarCoreRunnerInterface
 
@@ -171,8 +177,7 @@ func (c *captiveStellarCore) openOfflineReplaySubprocess(nextLedger, lastLedger 
 	c.lastLedger = &lastLedger
 
 	// read-ahead buffer
-	c.metaC = make(chan *xdr.LedgerCloseMeta, 2)
-	c.errC = make(chan error)
+	c.metaC = make(chan metaResult, readAheadBufferSize)
 	c.stop = make(chan struct{})
 	c.wait.Add(1)
 	go c.sendLedgerMeta(lastLedger)
@@ -190,28 +195,27 @@ func (c *captiveStellarCore) sendLedgerMeta(untilSequence uint32) {
 		case <-c.stop:
 			return
 		case <-printBufferOccupation.C:
-			log.Debug("captive core read-ahead buffer occupation:", atomic.LoadUint32(&c.readBufferOccupation))
+			log.Debug("captive core read-ahead buffer occupation:", len(c.metaC))
 		default:
 		}
 		meta, err := c.readLedgerMetaFromPipe()
 		if err != nil {
 			select {
 			case <-c.stop:
-			case c.errC <- err:
+			case c.metaC <- metaResult{nil, err}:
 			}
 			return
 		}
 		select {
 		case <-c.stop:
 			return
-		case c.metaC <- meta:
+		case c.metaC <- metaResult{meta, nil}:
 		}
-		atomic.AddUint32(&c.readBufferOccupation, 1)
 		seq, err := peekLedgerSequence(meta)
 		if err != nil {
 			select {
 			case <-c.stop:
-			case c.errC <- err:
+			case c.metaC <- metaResult{nil, err}:
 			}
 			return
 		}
@@ -288,17 +292,13 @@ func (c *captiveStellarCore) GetLedger(sequence uint32) (bool, LedgerCloseMeta, 
 	var errOut error
 loop:
 	for {
-		var xlcm *xdr.LedgerCloseMeta
-		select {
-		case err := <-c.errC:
-			errOut = err
+		metaResult := <-c.metaC
+		if metaResult.err != nil {
+			errOut = metaResult.err
 			break loop
-		case xlcm = <-c.metaC:
-			// decrement counter
-			atomic.AddUint32(&c.readBufferOccupation, ^uint32(0))
 		}
 
-		seq, e1 := peekLedgerSequence(xlcm)
+		seq, e1 := peekLedgerSequence(metaResult.LedgerCloseMeta)
 		if e1 != nil {
 			errOut = e1
 			break
@@ -315,7 +315,7 @@ loop:
 		if seq == sequence {
 			// Found the requested seq
 			var lcm LedgerCloseMeta
-			e2 := c.copyLedgerCloseMeta(xlcm, &lcm)
+			e2 := c.copyLedgerCloseMeta(metaResult.LedgerCloseMeta, &lcm)
 			if e2 != nil {
 				errOut = e2
 				break
@@ -376,19 +376,13 @@ func (c *captiveStellarCore) Close() error {
 		close(c.stop)
 		// discard pending data in case the goroutine is blocked writing to the channel
 		select {
-		case <-c.errC:
 		case <-c.metaC:
 		default:
 		}
-		// Do not close the other channels until we know
+		// Do not close the communication channel until we know
 		// the goroutine is done
 		c.wait.Wait()
-	}
-	if c.metaC != nil {
 		close(c.metaC)
-	}
-	if c.errC != nil {
-		close(c.errC)
 	}
 
 	c.lastLedger = nil

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -192,32 +192,32 @@ func (c *captiveStellarCore) sendLedgerMeta(untilSequence uint32) {
 		case <-printBufferOccupation.C:
 			log.Debug("captive core read-ahead buffer occupation:", atomic.LoadUint32(&c.readBufferOccupation))
 		default:
-			meta, err := c.readLedgerMetaFromPipe()
-			if err != nil {
-				select {
-				case <-c.stop:
-				case c.errC <- err:
-				}
-				return
-			}
+		}
+		meta, err := c.readLedgerMetaFromPipe()
+		if err != nil {
 			select {
 			case <-c.stop:
-				return
-			case c.metaC <- meta:
+			case c.errC <- err:
 			}
-			atomic.AddUint32(&c.readBufferOccupation, 1)
-			seq, err := peekLedgerSequence(meta)
-			if err != nil {
-				select {
-				case <-c.stop:
-				case c.errC <- err:
-				}
-				return
+			return
+		}
+		select {
+		case <-c.stop:
+			return
+		case c.metaC <- meta:
+		}
+		atomic.AddUint32(&c.readBufferOccupation, 1)
+		seq, err := peekLedgerSequence(meta)
+		if err != nil {
+			select {
+			case <-c.stop:
+			case c.errC <- err:
 			}
-			if seq >= untilSequence {
-				// we are done
-				return
-			}
+			return
+		}
+		if seq >= untilSequence {
+			// we are done
+			return
 		}
 	}
 }

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -3,10 +3,14 @@ package ledgerbackend
 import (
 	"io"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/support/historyarchive"
+	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 )
 
@@ -49,6 +53,13 @@ type captiveStellarCore struct {
 	networkPassphrase string
 	historyURLs       []string
 	lastLedger        *uint32 // end of current segment if offline, nil if online
+
+	// read-ahead buffer
+	readBufferOccupation uint32
+	stop                 chan struct{}
+	wait                 sync.WaitGroup
+	metaC                chan *xdr.LedgerCloseMeta
+	errC                 chan error
 
 	stellarCoreRunner stellarCoreRunnerInterface
 
@@ -158,7 +169,64 @@ func (c *captiveStellarCore) openOfflineReplaySubprocess(nextLedger, lastLedger 
 	c.nextLedger = roundDownToFirstReplayAfterCheckpointStart(nextLedger)
 	c.nextLedgerMutex.Unlock()
 	c.lastLedger = &lastLedger
+
+	// read-ahead buffer
+	c.metaC = make(chan *xdr.LedgerCloseMeta, 2)
+	c.errC = make(chan error)
+	c.stop = make(chan struct{})
+	c.wait.Add(1)
+	go c.sendLedgerMeta(lastLedger)
 	return nil
+}
+
+// sendLedgerMeta reads from the captive core pipe, decodes the ledger metadata
+// and sends it to the metadata buffered channel
+func (c *captiveStellarCore) sendLedgerMeta(untilSequence uint32) {
+	defer c.wait.Done()
+	printBufferOccupation := time.NewTicker(5 * time.Second)
+	defer printBufferOccupation.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-printBufferOccupation.C:
+			log.Debug("captive core read-ahead buffer occupation:", atomic.LoadUint32(&c.readBufferOccupation))
+		default:
+			meta, err := c.readLedgerMetaFromPipe()
+			if err != nil {
+				c.errC <- err
+				return
+			}
+			c.metaC <- meta
+			atomic.AddUint32(&c.readBufferOccupation, 1)
+			seq, err := peekLedgerSequence(meta)
+			if err != nil {
+				c.errC <- err
+				return
+			}
+			if seq >= untilSequence {
+				// we are done
+				return
+			}
+		}
+	}
+}
+
+func (c *captiveStellarCore) readLedgerMetaFromPipe() (*xdr.LedgerCloseMeta, error) {
+	metaPipe := c.stellarCoreRunner.getMetaPipe()
+	if metaPipe == nil {
+		return nil, errors.New("missing metadata pipe")
+	}
+	var xlcm xdr.LedgerCloseMeta
+	_, e0 := xdr.UnmarshalFramed(metaPipe, &xlcm)
+	if e0 != nil {
+		if e0 == io.EOF {
+			return nil, errors.Wrap(e0, "got EOF from subprocess")
+		} else {
+			return nil, errors.Wrap(e0, "unmarshalling framed LedgerCloseMeta")
+		}
+	}
+	return &xlcm, nil
 }
 
 func (c *captiveStellarCore) PrepareRange(from uint32, to uint32) error {
@@ -206,27 +274,21 @@ func (c *captiveStellarCore) GetLedger(sequence uint32) (bool, LedgerCloseMeta, 
 		return false, LedgerCloseMeta{}, errors.New("unexpected subprocess next-ledger")
 	}
 
-	// ... and open
-	metaPipe := c.stellarCoreRunner.getMetaPipe()
-	if metaPipe == nil {
-		return false, LedgerCloseMeta{}, errors.New("missing metadata pipe")
-	}
-
 	// Now loop along the range until we find the ledger we want.
 	var errOut error
+loop:
 	for {
-		var xlcm xdr.LedgerCloseMeta
-		_, e0 := xdr.UnmarshalFramed(metaPipe, &xlcm)
-		if e0 != nil {
-			if e0 == io.EOF {
-				errOut = errors.Wrap(e0, "got EOF from subprocess")
-				break
-			} else {
-				errOut = errors.Wrap(e0, "unmarshalling framed LedgerCloseMeta")
-				break
-			}
+		var xlcm *xdr.LedgerCloseMeta
+		select {
+		case err := <-c.errC:
+			errOut = err
+			break loop
+		case xlcm = <-c.metaC:
+			// decrement counter
+			atomic.AddUint32(&c.readBufferOccupation, ^uint32(0))
 		}
-		seq, e1 := peekLedgerSequence(&xlcm)
+
+		seq, e1 := peekLedgerSequence(xlcm)
 		if e1 != nil {
 			errOut = e1
 			break
@@ -243,7 +305,7 @@ func (c *captiveStellarCore) GetLedger(sequence uint32) (bool, LedgerCloseMeta, 
 		if seq == sequence {
 			// Found the requested seq
 			var lcm LedgerCloseMeta
-			e2 := c.copyLedgerCloseMeta(&xlcm, &lcm)
+			e2 := c.copyLedgerCloseMeta(xlcm, &lcm)
 			if e2 != nil {
 				errOut = e2
 				break
@@ -299,6 +361,19 @@ func (c *captiveStellarCore) Close() error {
 	c.nextLedgerMutex.Lock()
 	c.nextLedger = 0
 	c.nextLedgerMutex.Unlock()
+
+	if c.stop != nil {
+		close(c.stop)
+		// Do not close the other channels until we know
+		// the goroutine is done
+		c.wait.Wait()
+	}
+	if c.metaC != nil {
+		close(c.metaC)
+	}
+	if c.errC != nil {
+		close(c.errC)
+	}
 
 	c.lastLedger = nil
 

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -194,14 +194,24 @@ func (c *captiveStellarCore) sendLedgerMeta(untilSequence uint32) {
 		default:
 			meta, err := c.readLedgerMetaFromPipe()
 			if err != nil {
-				c.errC <- err
+				select {
+				case <-c.stop:
+				case c.errC <- err:
+				}
 				return
 			}
-			c.metaC <- meta
+			select {
+			case <-c.stop:
+				return
+			case c.metaC <- meta:
+			}
 			atomic.AddUint32(&c.readBufferOccupation, 1)
 			seq, err := peekLedgerSequence(meta)
 			if err != nil {
-				c.errC <- err
+				select {
+				case <-c.stop:
+				case c.errC <- err:
+				}
 				return
 			}
 			if seq >= untilSequence {

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -364,6 +364,12 @@ func (c *captiveStellarCore) Close() error {
 
 	if c.stop != nil {
 		close(c.stop)
+		// discard pending data in case the goroutine is blocked writing to the channel
+		select {
+		case <-c.errC:
+		case <-c.metaC:
+		default:
+		}
 		// Do not close the other channels until we know
 		// the goroutine is done
 		c.wait.Wait()

--- a/exp/ingest/ledgerbackend/stellar_core_runner_posix.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner_posix.go
@@ -3,7 +3,6 @@
 package ledgerbackend
 
 import (
-	"bufio"
 	"os"
 	"syscall"
 
@@ -50,7 +49,7 @@ func (c *stellarCoreRunner) start() error {
 	cmd := c.cmd
 	go cmd.Wait()
 
-	c.metaPipe = bufio.NewReaderSize(readFile, 1024*1024)
+	c.metaPipe = readFile
 	return nil
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add read-ahead buffer for the metadata coming from captive core. Overrides #2664 , which is similar but doesn't contain decoded data structures.

### Why

It improves performance, metadata is decoded in parallel with the rest of the ingestion pipeline.

### Known limitations

N/A
