### PR TITLE
all: require at least v0.3.3 of golang.org/x/text

### DIFF
--- a/go.list
+++ b/go.list
@@ -129,7 +129,7 @@ golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
 golang.org/x/sync v0.0.0-20190423024810-112230192c58
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c
-golang.org/x/text v0.3.2
+golang.org/x/text v0.3.3
 golang.org/x/tools v0.0.0-20190624180213-70d37148ca0c
 google.golang.org/api v0.3.1
 google.golang.org/appengine v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708
 	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297 // indirect
+	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/tools v0.0.0-20190624180213-70d37148ca0c // indirect
 	google.golang.org/api v0.3.1
 	google.golang.org/appengine v1.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -281,6 +281,8 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Require at least `v0.3.3` of `golang.org/x/text`.

### Why
According to https://groups.google.com/d/topic/golang-announce/bXVeAmGOqz0 v0.3.3 which was released today contains a security fix for the `golang.org/x/text/transform` package.

The `hash` package within this repository is the only code we have here that I can see is using the `golang.org/x/text/transform` package but only in its tests indirectly through the gomega framework, so there's no real need to do this upgrade other than to make sure that any code we write in the future that either directly or indirectly uses the transform package doesn't unknowingly use the vulnerable version of the dependency in a meaningful way.

### Known limitations

 N/A
