### PR TITLE
exp/ingest/ledgerbackend: Cache LedgerCloseMeta in captiveStellarCore

### DIFF
--- a/exp/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend_test.go
@@ -43,6 +43,7 @@ func writeLedgerHeader(w io.Writer, sequence uint32) error {
 	var hash [32]byte
 	copy(hash[:], tmpHash)
 
+	source := xdr.MustAddress("GAEJJMDDCRYF752PKIJICUVL7MROJBNXDV2ZB455T7BAFHU2LCLSE2LW")
 	ledgerCloseMeta := xdr.LedgerCloseMeta{
 		V: 0,
 		V0: &xdr.LedgerCloseMetaV0{
@@ -57,7 +58,7 @@ func writeLedgerHeader(w io.Writer, sequence uint32) error {
 						Type: xdr.EnvelopeTypeEnvelopeTypeTx,
 						V1: &xdr.TransactionV1Envelope{
 							Tx: xdr.Transaction{
-								SourceAccount: xdr.MustMuxedAccountAddress("GAEJJMDDCRYF752PKIJICUVL7MROJBNXDV2ZB455T7BAFHU2LCLSE2LW"),
+								SourceAccount: source.ToMuxedAccount(),
 								Fee:           xdr.Uint32(sequence),
 							},
 						},


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit caches `LedgerCloseMeta` of the latest ledger fetched using `GetLedger`.

### Why

`GetLedger` is called multiple times while ingesting a single ledger (to get `ChangeReader` and `TransactionReader`). Because it's not possible to rewind the meta stream we need a cache.
