### PR TITLE
exp/ingest/io: Replace ledgerbackend.LedgerCloseMeta with xdr.LedgerCloseMeta

### DIFF
--- a/exp/ingest/io/ledger_change_reader.go
+++ b/exp/ingest/io/ledger_change_reader.go
@@ -107,9 +107,9 @@ func (r *LedgerChangeReader) Read() (Change, error) {
 		return r.Read()
 	case upgradeChangesState:
 		// Get upgrade changes
-		if r.upgradeIndex < len(r.LedgerTransactionReader.ledgerCloseMeta.UpgradesMeta) {
+		if r.upgradeIndex < len(r.LedgerTransactionReader.ledgerCloseMeta.V0.UpgradesProcessing) {
 			changes := GetChangesFromLedgerEntryChanges(
-				r.LedgerTransactionReader.ledgerCloseMeta.UpgradesMeta[r.upgradeIndex],
+				r.LedgerTransactionReader.ledgerCloseMeta.V0.UpgradesProcessing[r.upgradeIndex].Changes,
 			)
 			r.pending = append(r.pending, changes...)
 			r.upgradeIndex++

--- a/exp/ingest/io/ledger_transaction_reader.go
+++ b/exp/ingest/io/ledger_transaction_reader.go
@@ -11,7 +11,7 @@ import (
 // LedgerTransactionReader reads transactions for a given ledger sequence from a backend.
 // Use NewTransactionReader to create a new instance.
 type LedgerTransactionReader struct {
-	ledgerCloseMeta ledgerbackend.LedgerCloseMeta
+	ledgerCloseMeta xdr.LedgerCloseMeta
 	transactions    []LedgerTransaction
 	readIdx         int
 }
@@ -35,12 +35,12 @@ func NewLedgerTransactionReader(backend ledgerbackend.LedgerBackend, sequence ui
 
 // GetSequence returns the sequence number of the ledger data stored by this object.
 func (reader *LedgerTransactionReader) GetSequence() uint32 {
-	return uint32(reader.ledgerCloseMeta.LedgerHeader.Header.LedgerSeq)
+	return uint32(reader.ledgerCloseMeta.V0.LedgerHeader.Header.LedgerSeq)
 }
 
 // GetHeader returns the XDR Header data associated with the stored ledger.
 func (reader *LedgerTransactionReader) GetHeader() xdr.LedgerHeaderHistoryEntry {
-	return reader.ledgerCloseMeta.LedgerHeader
+	return reader.ledgerCloseMeta.V0.LedgerHeader
 }
 
 // Read returns the next transaction in the ledger, ordered by tx number, each time
@@ -60,14 +60,14 @@ func (reader *LedgerTransactionReader) Rewind() {
 
 // storeTransactions maps the close meta data into a slice of LedgerTransaction structs, to provide
 // a per-transaction view of the data when Read() is called.
-func (reader *LedgerTransactionReader) storeTransactions(lcm ledgerbackend.LedgerCloseMeta) {
-	for i := range lcm.TransactionEnvelope {
+func (reader *LedgerTransactionReader) storeTransactions(lcm xdr.LedgerCloseMeta) {
+	for i := range lcm.V0.TxSet.Txs {
 		reader.transactions = append(reader.transactions, LedgerTransaction{
 			Index:      uint32(i + 1), // Transactions start at '1'
-			Envelope:   lcm.TransactionEnvelope[i],
-			Result:     lcm.TransactionResult[i],
-			Meta:       lcm.TransactionMeta[i],
-			FeeChanges: lcm.TransactionFeeChanges[i],
+			Envelope:   lcm.V0.TxSet.Txs[i],
+			Result:     lcm.V0.TxProcessing[i].Result,
+			Meta:       lcm.V0.TxProcessing[i].TxApplyProcessing,
+			FeeChanges: lcm.V0.TxProcessing[i].FeeProcessing,
 		})
 	}
 }

--- a/exp/ingest/io/ledger_transaction_reader.go
+++ b/exp/ingest/io/ledger_transaction_reader.go
@@ -35,7 +35,7 @@ func NewLedgerTransactionReader(backend ledgerbackend.LedgerBackend, sequence ui
 
 // GetSequence returns the sequence number of the ledger data stored by this object.
 func (reader *LedgerTransactionReader) GetSequence() uint32 {
-	return uint32(reader.ledgerCloseMeta.V0.LedgerHeader.Header.LedgerSeq)
+	return reader.ledgerCloseMeta.LedgerSequence()
 }
 
 // GetHeader returns the XDR Header data associated with the stored ledger.

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -167,15 +167,7 @@ func (c *captiveStellarCore) sendLedgerMeta(untilSequence uint32) {
 			return
 		case c.metaC <- metaResult{meta, nil}:
 		}
-		seq, err := meta.LedgerSequence()
-		if err != nil {
-			select {
-			case <-c.stop:
-			case c.metaC <- metaResult{nil, err}:
-			}
-			return
-		}
-		if seq >= untilSequence {
+		if meta.LedgerSequence() >= untilSequence {
 			// we are done
 			return
 		}
@@ -227,7 +219,7 @@ func (c *captiveStellarCore) PrepareRange(from uint32, to uint32) error {
 // the implicit start ledger, so we might need to skip a few ledgers until
 // we hit the one requested (this routine does so transparently if needed).
 func (c *captiveStellarCore) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMeta, error) {
-	if c.cachedMeta != nil && sequence == uint32(c.cachedMeta.V0.LedgerHeader.Header.LedgerSeq) {
+	if c.cachedMeta != nil && sequence == c.cachedMeta.LedgerSequence() {
 		// GetLedger can be called multiple times using the same sequence, ex. to create
 		// change and transaction readers. If we have this ledger buffered, let's return it.
 		return true, *c.cachedMeta, nil
@@ -260,11 +252,7 @@ loop:
 			break loop
 		}
 
-		seq, e1 := metaResult.LedgerCloseMeta.LedgerSequence()
-		if e1 != nil {
-			errOut = e1
-			break
-		}
+		seq := metaResult.LedgerCloseMeta.LedgerSequence()
 		c.nextLedgerMutex.Lock()
 		if seq != c.nextLedger {
 			// We got something unexpected; close and reset

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -105,17 +105,6 @@ func (c *captiveStellarCore) IsInOnlineTrackingMode() bool {
 	return c.lastLedger == nil
 }
 
-// Returns the sequence number of an LCM, returning an error if the LCM is of
-// an unknown version.
-func peekLedgerSequence(xlcm *xdr.LedgerCloseMeta) (uint32, error) {
-	v0, ok := xlcm.GetV0()
-	if !ok {
-		err := errors.New("unexpected XDR LedgerCloseMeta version")
-		return 0, err
-	}
-	return uint32(v0.LedgerHeader.Header.LedgerSeq), nil
-}
-
 func (c *captiveStellarCore) openOfflineReplaySubprocess(nextLedger, lastLedger uint32) error {
 	c.Close()
 	maxLedger, e := c.GetLatestLedgerSequence()
@@ -178,7 +167,7 @@ func (c *captiveStellarCore) sendLedgerMeta(untilSequence uint32) {
 			return
 		case c.metaC <- metaResult{meta, nil}:
 		}
-		seq, err := peekLedgerSequence(meta)
+		seq, err := meta.LedgerSequence()
 		if err != nil {
 			select {
 			case <-c.stop:
@@ -271,7 +260,7 @@ loop:
 			break loop
 		}
 
-		seq, e1 := peekLedgerSequence(metaResult.LedgerCloseMeta)
+		seq, e1 := metaResult.LedgerCloseMeta.LedgerSequence()
 		if e1 != nil {
 			errOut = e1
 			break

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/stellar/go/network"
 	"github.com/stellar/go/support/historyarchive"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
@@ -68,7 +67,7 @@ type captiveStellarCore struct {
 	metaC chan metaResult
 
 	stellarCoreRunner stellarCoreRunnerInterface
-	cachedMeta        *LedgerCloseMeta
+	cachedMeta        *xdr.LedgerCloseMeta
 
 	nextLedgerMutex sync.Mutex
 	nextLedger      uint32 // next ledger expected, error w/ restart if not seen
@@ -115,39 +114,6 @@ func peekLedgerSequence(xlcm *xdr.LedgerCloseMeta) (uint32, error) {
 		return 0, err
 	}
 	return uint32(v0.LedgerHeader.Header.LedgerSeq), nil
-}
-
-// Note: the xdr.LedgerCloseMeta structure is _not_ the same as
-// the ledgerbackend.LedgerCloseMeta structure; the latter should
-// probably migrate to the former eventually.
-func (c *captiveStellarCore) copyLedgerCloseMeta(xlcm *xdr.LedgerCloseMeta, lcm *LedgerCloseMeta) error {
-	v0, ok := xlcm.GetV0()
-	if !ok {
-		return errors.New("unexpected XDR LedgerCloseMeta version")
-	}
-	lcm.LedgerHeader = v0.LedgerHeader
-	envelopes := make(map[xdr.Hash]xdr.TransactionEnvelope)
-	for _, tx := range v0.TxSet.Txs {
-		hash, e := network.HashTransactionInEnvelope(tx, c.networkPassphrase)
-		if e != nil {
-			return errors.Wrap(e, "error hashing tx in LedgerCloseMeta")
-		}
-		envelopes[hash] = tx
-	}
-	for _, trm := range v0.TxProcessing {
-		txe, ok := envelopes[trm.Result.TransactionHash]
-		if !ok {
-			return errors.New("unknown tx hash in LedgerCloseMeta")
-		}
-		lcm.TransactionEnvelope = append(lcm.TransactionEnvelope, txe)
-		lcm.TransactionResult = append(lcm.TransactionResult, trm.Result)
-		lcm.TransactionMeta = append(lcm.TransactionMeta, trm.TxApplyProcessing)
-		lcm.TransactionFeeChanges = append(lcm.TransactionFeeChanges, trm.FeeProcessing)
-	}
-	for _, urm := range v0.UpgradesProcessing {
-		lcm.UpgradesMeta = append(lcm.UpgradesMeta, urm.Changes)
-	}
-	return nil
 }
 
 func (c *captiveStellarCore) openOfflineReplaySubprocess(nextLedger, lastLedger uint32) error {
@@ -271,8 +237,8 @@ func (c *captiveStellarCore) PrepareRange(from uint32, to uint32) error {
 // this is that core will actually replay from the _checkpoint before_
 // the implicit start ledger, so we might need to skip a few ledgers until
 // we hit the one requested (this routine does so transparently if needed).
-func (c *captiveStellarCore) GetLedger(sequence uint32) (bool, LedgerCloseMeta, error) {
-	if c.cachedMeta != nil && sequence == uint32(c.cachedMeta.LedgerHeader.Header.LedgerSeq) {
+func (c *captiveStellarCore) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMeta, error) {
+	if c.cachedMeta != nil && sequence == uint32(c.cachedMeta.V0.LedgerHeader.Header.LedgerSeq) {
 		// GetLedger can be called multiple times using the same sequence, ex. to create
 		// change and transaction readers. If we have this ledger buffered, let's return it.
 		return true, *c.cachedMeta, nil
@@ -286,13 +252,13 @@ func (c *captiveStellarCore) GetLedger(sequence uint32) (bool, LedgerCloseMeta, 
 	// Next, if we're closed, open.
 	if c.IsClosed() {
 		if e := c.openOfflineReplaySubprocess(sequence, sequence+ledgersPerProcess); e != nil {
-			return false, LedgerCloseMeta{}, errors.Wrap(e, "opening subprocess")
+			return false, xdr.LedgerCloseMeta{}, errors.Wrap(e, "opening subprocess")
 		}
 	}
 
 	// Check that we're where we expect to be: in range ...
 	if !c.LedgerWithinCheckpoints(sequence, 1) {
-		return false, LedgerCloseMeta{}, errors.New("unexpected subprocess next-ledger")
+		return false, xdr.LedgerCloseMeta{}, errors.New("unexpected subprocess next-ledger")
 	}
 
 	// Now loop along the range until we find the ledger we want.
@@ -321,27 +287,20 @@ loop:
 		c.nextLedgerMutex.Unlock()
 		if seq == sequence {
 			// Found the requested seq
-			var lcm LedgerCloseMeta
-			e2 := c.copyLedgerCloseMeta(metaResult.LedgerCloseMeta, &lcm)
-			if e2 != nil {
-				errOut = e2
-				break
-			}
-
-			c.cachedMeta = &lcm
+			c.cachedMeta = metaResult.LedgerCloseMeta
 
 			// If we got the _last_ ledger in a segment, close before returning.
 			if c.lastLedger != nil && *c.lastLedger == seq {
 				c.Close()
 			}
-			return true, lcm, nil
+			return true, *c.cachedMeta, nil
 		}
 	}
 	// All paths above that break out of the loop (instead of return)
 	// set e to non-nil: there was an error and we should close and
 	// reset state before retuning an error to our caller.
 	c.Close()
-	return false, LedgerCloseMeta{}, errOut
+	return false, xdr.LedgerCloseMeta{}, errOut
 }
 
 func (c *captiveStellarCore) GetLatestLedgerSequence() (uint32, error) {

--- a/exp/ingest/ledgerbackend/database_backend.go
+++ b/exp/ingest/ledgerbackend/database_backend.go
@@ -77,8 +77,10 @@ func (dbb *DatabaseBackend) GetLatestLedgerSequence() (uint32, error) {
 
 // GetLedger returns the LedgerCloseMeta for the given ledger sequence number.
 // The first returned value is false when the ledger does not exist in the database.
-func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, LedgerCloseMeta, error) {
-	lcm := LedgerCloseMeta{}
+func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMeta, error) {
+	lcm := xdr.LedgerCloseMeta{
+		V0: &xdr.LedgerCloseMetaV0{},
+	}
 
 	// Query - ledgerheader
 	var lRow ledgerHeaderHistory
@@ -89,14 +91,14 @@ func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, LedgerCloseMeta, e
 		switch err {
 		case sql.ErrNoRows:
 			// Ledger was not found
-			return false, LedgerCloseMeta{}, nil
+			return false, xdr.LedgerCloseMeta{}, nil
 		default:
-			return false, LedgerCloseMeta{}, errors.Wrap(err, "Error getting ledger header")
+			return false, xdr.LedgerCloseMeta{}, errors.Wrap(err, "Error getting ledger header")
 		}
 	}
 
 	// ...otherwise store the header
-	lcm.LedgerHeader = xdr.LedgerHeaderHistoryEntry{
+	lcm.V0.LedgerHeader = xdr.LedgerHeaderHistoryEntry{
 		Hash:   lRow.Hash,
 		Header: lRow.Header,
 		Ext:    xdr.LedgerHeaderHistoryEntryExt{},
@@ -114,14 +116,16 @@ func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, LedgerCloseMeta, e
 	for i, tx := range txhRows {
 		// Sanity check index. Note that first TXIndex in a ledger is 1
 		if i != int(tx.TXIndex)-1 {
-			return false, LedgerCloseMeta{}, errors.New("transactions read from DB history table are misordered")
+			return false, xdr.LedgerCloseMeta{}, errors.New("transactions read from DB history table are misordered")
 		}
 
-		lcm.TransactionEnvelope = append(lcm.TransactionEnvelope, tx.TXBody)
-		lcm.TransactionResult = append(lcm.TransactionResult, tx.TXResult)
-		lcm.TransactionMeta = append(lcm.TransactionMeta, tx.TXMeta)
+		lcm.V0.TxSet.Txs = append(lcm.V0.TxSet.Txs, tx.TXBody)
+		lcm.V0.TxProcessing = append(lcm.V0.TxProcessing, xdr.TransactionResultMeta{
+			Result:            tx.TXResult,
+			TxApplyProcessing: tx.TXMeta,
+		})
 
-		if lcm.LedgerHeader.Header.LedgerVersion < 10 && tx.TXMeta.V != 2 {
+		if lcm.V0.LedgerHeader.Header.LedgerVersion < 10 && tx.TXMeta.V != 2 {
 			return false, lcm,
 				errors.New("TransactionMeta.V=2 is required in protocol version older than version 10. " +
 					"Please process ledgers again using stellar-core with SUPPORTED_META_VERSION=2 in the config file.")
@@ -140,9 +144,9 @@ func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, LedgerCloseMeta, e
 	for i, tx := range txfhRows {
 		// Sanity check index. Note that first TXIndex in a ledger is 1
 		if i != int(tx.TXIndex)-1 {
-			return false, LedgerCloseMeta{}, errors.New("transactions read from DB fee history table are misordered")
+			return false, xdr.LedgerCloseMeta{}, errors.New("transactions read from DB fee history table are misordered")
 		}
-		lcm.TransactionFeeChanges = append(lcm.TransactionFeeChanges, tx.TXChanges)
+		lcm.V0.TxProcessing[i].FeeProcessing = tx.TXChanges
 	}
 
 	// Query - upgradehistory
@@ -154,11 +158,13 @@ func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, LedgerCloseMeta, e
 	}
 
 	// ...otherwise store the data
-	var upgradesMeta []xdr.LedgerEntryChanges
-	for _, upgradeHistoryRow := range upgradeHistoryRows {
-		upgradesMeta = append(upgradesMeta, upgradeHistoryRow.Changes)
+	lcm.V0.UpgradesProcessing = make([]xdr.UpgradeEntryMeta, len(upgradeHistoryRows))
+	for i, upgradeHistoryRow := range upgradeHistoryRows {
+		lcm.V0.UpgradesProcessing[i] = xdr.UpgradeEntryMeta{
+			Upgrade: upgradeHistoryRow.Upgrade,
+			Changes: upgradeHistoryRow.Changes,
+		}
 	}
-	lcm.UpgradesMeta = upgradesMeta
 
 	return true, lcm, nil
 }

--- a/exp/ingest/ledgerbackend/ledger_backend.go
+++ b/exp/ingest/ledgerbackend/ledger_backend.go
@@ -8,7 +8,7 @@ import (
 type LedgerBackend interface {
 	GetLatestLedgerSequence() (sequence uint32, err error)
 	// The first returned value is false when the ledger does not exist in a backend.
-	GetLedger(sequence uint32) (bool, LedgerCloseMeta, error)
+	GetLedger(sequence uint32) (bool, xdr.LedgerCloseMeta, error)
 	// Prepares the given range (including from and to) to be loaded. Some backends
 	// (like captive stellar-core) need to process data before being able to stream
 	// ledgers.
@@ -22,16 +22,6 @@ type session interface {
 	GetRaw(dest interface{}, query string, args ...interface{}) error
 	SelectRaw(dest interface{}, query string, args ...interface{}) error
 	Close() error
-}
-
-// LedgerCloseMeta is the information needed to reconstruct the history of transactions in a given ledger.
-type LedgerCloseMeta struct {
-	LedgerHeader          xdr.LedgerHeaderHistoryEntry
-	TransactionEnvelope   []xdr.TransactionEnvelope
-	TransactionResult     []xdr.TransactionResultPair
-	TransactionMeta       []xdr.TransactionMeta
-	TransactionFeeChanges []xdr.LedgerEntryChanges
-	UpgradesMeta          []xdr.LedgerEntryChanges
 }
 
 // ledgerHeaderHistory is a helper struct used to unmarshall header fields from a stellar-core DB.

--- a/exp/ingest/ledgerbackend/mock_database_backend.go
+++ b/exp/ingest/ledgerbackend/mock_database_backend.go
@@ -1,6 +1,7 @@
 package ledgerbackend
 
 import (
+	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -20,9 +21,9 @@ func (m *MockDatabaseBackend) PrepareRange(from uint32, to uint32) error {
 	return args.Error(1)
 }
 
-func (m *MockDatabaseBackend) GetLedger(sequence uint32) (bool, LedgerCloseMeta, error) {
+func (m *MockDatabaseBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMeta, error) {
 	args := m.Called(sequence)
-	return args.Bool(0), args.Get(1).(LedgerCloseMeta), args.Error(2)
+	return args.Bool(0), args.Get(1).(xdr.LedgerCloseMeta), args.Error(2)
 }
 
 func (m *MockDatabaseBackend) Close() error {

--- a/services/horizon/internal/expingest/db_integration_test.go
+++ b/services/horizon/internal/expingest/db_integration_test.go
@@ -111,10 +111,12 @@ func (s *DBTestSuite) setupMocksForBuildState() {
 	s.ledgerBackend.On("GetLedger", s.sequence).
 		Return(
 			true,
-			ledgerbackend.LedgerCloseMeta{
-				LedgerHeader: xdr.LedgerHeaderHistoryEntry{
-					Header: xdr.LedgerHeader{
-						BucketListHash: checkpointHash,
+			xdr.LedgerCloseMeta{
+				V0: &xdr.LedgerCloseMetaV0{
+					LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+						Header: xdr.LedgerHeader{
+							BucketListHash: checkpointHash,
+						},
 					},
 				},
 			},

--- a/services/horizon/internal/expingest/main_test.go
+++ b/services/horizon/internal/expingest/main_test.go
@@ -364,9 +364,9 @@ func (m *mockLedgerBackend) GetLatestLedgerSequence() (sequence uint32, err erro
 	return args.Get(0).(uint32), args.Error(1)
 }
 
-func (m *mockLedgerBackend) GetLedger(sequence uint32) (bool, ledgerbackend.LedgerCloseMeta, error) {
+func (m *mockLedgerBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMeta, error) {
 	args := m.Called(sequence)
-	return args.Get(0).(bool), args.Get(1).(ledgerbackend.LedgerCloseMeta), args.Error(2)
+	return args.Get(0).(bool), args.Get(1).(xdr.LedgerCloseMeta), args.Error(2)
 }
 
 func (m *mockLedgerBackend) PrepareRange(from uint32, to uint32) error {

--- a/services/horizon/internal/expingest/processor_runner.go
+++ b/services/horizon/internal/expingest/processor_runner.go
@@ -153,7 +153,7 @@ func (s *ProcessorRunner) validateBucketList(ledgerSequence uint32) error {
 		)
 	}
 
-	ledgerBucketHashList := ledgerCloseMeta.LedgerHeader.Header.BucketListHash
+	ledgerBucketHashList := ledgerCloseMeta.V0.LedgerHeader.Header.BucketListHash
 
 	if !bytes.Equal(historyBucketListHash[:], ledgerBucketHashList[:]) {
 		return fmt.Errorf(

--- a/services/horizon/internal/expingest/processor_runner_test.go
+++ b/services/horizon/internal/expingest/processor_runner_test.go
@@ -109,10 +109,12 @@ func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
 	ledgerBackend.On("GetLedger", uint32(63)).
 		Return(
 			true,
-			ledgerbackend.LedgerCloseMeta{
-				LedgerHeader: xdr.LedgerHeaderHistoryEntry{
-					Header: xdr.LedgerHeader{
-						BucketListHash: xdr.Hash([32]byte{0, 1, 2}),
+			xdr.LedgerCloseMeta{
+				V0: &xdr.LedgerCloseMetaV0{
+					LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+						Header: xdr.LedgerHeader{
+							BucketListHash: xdr.Hash([32]byte{0, 1, 2}),
+						},
 					},
 				},
 			},
@@ -279,8 +281,10 @@ func TestProcessorRunnerRunAllProcessorsOnLedger(t *testing.T) {
 	ledgerBackend.On("GetLedger", uint32(63)).
 		Return(
 			true,
-			ledgerbackend.LedgerCloseMeta{
-				LedgerHeader: ledger,
+			xdr.LedgerCloseMeta{
+				V0: &xdr.LedgerCloseMetaV0{
+					LedgerHeader: ledger,
+				},
 			},
 			nil,
 		).Twice() // Twice = changes then transactions

--- a/xdr/ledger_close_meta.go
+++ b/xdr/ledger_close_meta.go
@@ -1,11 +1,5 @@
 package xdr
 
-import "fmt"
-
-func (l LedgerCloseMeta) LedgerSequence() (uint32, error) {
-	v0, ok := l.GetV0()
-	if !ok {
-		return 0, fmt.Errorf("unexpected XDR LedgerCloseMeta version: %v", l.V)
-	}
-	return uint32(v0.LedgerHeader.Header.LedgerSeq), nil
+func (l LedgerCloseMeta) LedgerSequence() uint32 {
+	return uint32(l.MustV0().LedgerHeader.Header.LedgerSeq)
 }

--- a/xdr/ledger_close_meta.go
+++ b/xdr/ledger_close_meta.go
@@ -1,0 +1,11 @@
+package xdr
+
+import "fmt"
+
+func (l LedgerCloseMeta) LedgerSequence() (uint32, error) {
+	v0, ok := l.GetV0()
+	if !ok {
+		return 0, fmt.Errorf("unexpected XDR LedgerCloseMeta version: %v", l.V)
+	}
+	return uint32(v0.LedgerHeader.Header.LedgerSeq), nil
+}

--- a/xdr/ledger_close_meta_test.go
+++ b/xdr/ledger_close_meta_test.go
@@ -1,0 +1,24 @@
+package xdr
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestLedgerSequence(t *testing.T) {
+	l := LedgerCloseMeta{
+		V0: &LedgerCloseMetaV0{
+			LedgerHeader: LedgerHeaderHistoryEntry{
+				Header: LedgerHeader{LedgerSeq: 23},
+			},
+		},
+	}
+
+	seq, err := l.LedgerSequence()
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(23), seq)
+
+	l.V = 1
+	_, err = l.LedgerSequence()
+	assert.EqualError(t, err, "unexpected XDR LedgerCloseMeta version: 1")
+}

--- a/xdr/ledger_close_meta_test.go
+++ b/xdr/ledger_close_meta_test.go
@@ -13,12 +13,5 @@ func TestLedgerSequence(t *testing.T) {
 			},
 		},
 	}
-
-	seq, err := l.LedgerSequence()
-	assert.NoError(t, err)
-	assert.Equal(t, uint32(23), seq)
-
-	l.V = 1
-	_, err = l.LedgerSequence()
-	assert.EqualError(t, err, "unexpected XDR LedgerCloseMeta version: 1")
+	assert.Equal(t, uint32(23), l.LedgerSequence())
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Replace ledgerbackend.LedgerCloseMeta with xdr.LedgerCloseMeta.

Fixes https://github.com/stellar/go/issues/2633

### Why

> When exp/ingest prototype was created Stellar-Core didn't have LedgerCloseMeta type so we created a temporary LedgerCloseMeta in ledgerbackend package. Now, when the required type is there, we should remove ledgerbackend.LedgerCloseMeta and replace it with xdr.LedgerCloseMeta.


### Known limitations

[N/A]
