### PR TITLE
services/horizon: Fix /metrics end-point.

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -476,9 +476,6 @@ func (a *App) init() {
 	// This parameter will be removed soon.
 	a.web.mustInstallMiddlewares(a, a.config.ConnectionTimeout)
 
-	// web.actions
-	a.web.mustInstallActions(a.config, a.paths, a.historyQ.Session, a.metrics)
-
 	// metrics and log.metrics
 	a.metrics = metrics.NewRegistry()
 	for level, meter := range *logmetrics.DefaultMetrics {
@@ -487,6 +484,9 @@ func (a *App) init() {
 
 	// db-metrics
 	initDbMetrics(a)
+
+	// web.actions
+	a.web.mustInstallActions(a.config, a.paths, a.historyQ.Session, a.metrics)
 
 	// ingest.metrics
 	initIngestMetrics(a)

--- a/services/horizon/internal/app_test.go
+++ b/services/horizon/internal/app_test.go
@@ -3,6 +3,8 @@ package horizon
 import (
 	"net/http"
 	"testing"
+
+	"github.com/stellar/go/services/horizon/internal/test"
 )
 
 func TestGenericHTTPFeatures(t *testing.T) {
@@ -36,6 +38,10 @@ func TestGenericHTTPFeatures(t *testing.T) {
 func TestMetrics(t *testing.T) {
 	ht := StartHTTPTest(t, "base")
 	defer ht.Finish()
+
+	adminRouterRH := test.NewRequestHelper(ht.App.web.internalRouter)
+	w := adminRouterRH.Get("/metrics")
+	ht.Assert.Equal(200, w.Code)
 
 	hl := ht.App.historyLatestLedgerGauge
 	he := ht.App.historyElderLedgerGauge


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fix `/metrics` end-point.

### Why

Running Horizon with `ADMIN_PORT` enabled will cause a panic when trying to fetch the metrics since it was being setup before initializing the metrics registry. 

Fix #2714 

### Known limitations

