### PR TITLE
exp/ingest/io: Fix bug in LedgerTransactionReader

### DIFF
--- a/exp/ingest/io/ledger_change_reader.go
+++ b/exp/ingest/io/ledger_change_reader.go
@@ -45,8 +45,8 @@ var _ ChangeReader = (*LedgerChangeReader)(nil)
 // NewLedgerChangeReader constructs a new LedgerChangeReader instance bound to the given ledger.
 // Note that the returned LedgerChangeReader is not thread safe and should not be shared
 // by multiple goroutines.
-func NewLedgerChangeReader(backend ledgerbackend.LedgerBackend, sequence uint32) (*LedgerChangeReader, error) {
-	transactionReader, err := NewLedgerTransactionReader(backend, sequence)
+func NewLedgerChangeReader(backend ledgerbackend.LedgerBackend, networkPassphrase string, sequence uint32) (*LedgerChangeReader, error) {
+	transactionReader, err := NewLedgerTransactionReader(backend, networkPassphrase, sequence)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/expingest/processor_runner.go
+++ b/services/horizon/internal/expingest/processor_runner.go
@@ -220,7 +220,7 @@ func (s *ProcessorRunner) runChangeProcessorOnLedger(
 ) error {
 	var changeReader io.ChangeReader
 	var err error
-	changeReader, err = io.NewLedgerChangeReader(s.ledgerBackend, ledger)
+	changeReader, err = io.NewLedgerChangeReader(s.ledgerBackend, s.config.NetworkPassphrase, ledger)
 	if err != nil {
 		return errors.Wrap(err, "Error creating ledger change reader")
 	}
@@ -246,7 +246,7 @@ func (s *ProcessorRunner) runChangeProcessorOnLedger(
 func (s *ProcessorRunner) RunTransactionProcessorsOnLedger(ledger uint32) (io.StatsLedgerTransactionProcessorResults, error) {
 	ledgerTransactionStats := io.StatsLedgerTransactionProcessor{}
 
-	transactionReader, err := io.NewLedgerTransactionReader(s.ledgerBackend, ledger)
+	transactionReader, err := io.NewLedgerTransactionReader(s.ledgerBackend, s.config.NetworkPassphrase, ledger)
 	if err != nil {
 		return ledgerTransactionStats.GetResults(), errors.Wrap(err, "Error creating ledger reader")
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

https://github.com/stellar/go/pull/2710 introduced a bug in LedgerTransactionReader which had the effect that transactions were not returned in the correct order.

The bug occurs because transactions in `xdr.LedgerCloseMeta.V0.TxSet` are not ordered in the same way as `xdr.LedgerCloseMeta.V0.TxProcessing `. `TxProcessing` is sorted by the order in which transactions are applied to the ledger. `TxSet` is sorted lexicographically by transaction hash.

This commit ensures that each `LedgerTransaction` has the correct transaction envelope / transaction result pair.

