### PR TITLE
exp/ingest/io: Check TxMeta version in LedgerTransactionReader

### DIFF
--- a/exp/ingest/io/ledger_transaction_reader.go
+++ b/exp/ingest/io/ledger_transaction_reader.go
@@ -81,6 +81,14 @@ func (reader *LedgerTransactionReader) storeTransactions(lcm xdr.LedgerCloseMeta
 			hexHash := hex.EncodeToString(result.TransactionHash[:])
 			return errors.Errorf("unknown tx hash in LedgerCloseMeta: %v", hexHash)
 		}
+
+		if lcm.V0.LedgerHeader.Header.LedgerVersion < 10 && lcm.V0.TxProcessing[i].TxApplyProcessing.V != 2 {
+			return errors.New(
+				"TransactionMeta.V=2 is required in protocol version older than version 10. " +
+					"Please process ledgers again using stellar-core with SUPPORTED_META_VERSION=2 in the config file.",
+			)
+		}
+
 		reader.transactions = append(reader.transactions, LedgerTransaction{
 			Index:      uint32(i + 1), // Transactions start at '1'
 			Envelope:   envelope,

--- a/exp/ingest/ledgerbackend/database_backend.go
+++ b/exp/ingest/ledgerbackend/database_backend.go
@@ -124,12 +124,6 @@ func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMet
 			Result:            tx.TXResult,
 			TxApplyProcessing: tx.TXMeta,
 		})
-
-		if lcm.V0.LedgerHeader.Header.LedgerVersion < 10 && tx.TXMeta.V != 2 {
-			return false, lcm,
-				errors.New("TransactionMeta.V=2 is required in protocol version older than version 10. " +
-					"Please process ledgers again using stellar-core with SUPPORTED_META_VERSION=2 in the config file.")
-		}
 	}
 
 	// Query - txfeehistory


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Move the transaction meta check from the database backend to the LedgerTransactionReader.

Fix https://github.com/stellar/go/issues/2715

### Why

LedgerBackend should just return data, it should not interpret it and process it.

### Known limitations

[N/A]
