### PR TITLE
services/horizon/internal: Load Core Latest Ledger from core's http info end-point.

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -208,11 +208,17 @@ func (a *App) UpdateLedgerState() {
 		log.WithStack(err).WithField("err", err.Error()).Error(msg)
 	}
 
-	err := a.CoreQ().LatestLedger(&next.CoreLatest)
+	coreClient := &stellarcore.Client{
+		HTTP: http.DefaultClient,
+		URL:  a.config.StellarCoreURL,
+	}
+
+	coreInfo, err := coreClient.Info(a.ctx)
 	if err != nil {
 		logErr(err, "failed to load the latest known ledger state from core DB")
 		return
 	}
+	next.CoreLatest = int32(coreInfo.Info.Ledger.Num)
 
 	err = a.HistoryQ().LatestLedger(&next.HistoryLatest)
 	if err != nil {

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -215,7 +215,7 @@ func (a *App) UpdateLedgerState() {
 
 	coreInfo, err := coreClient.Info(a.ctx)
 	if err != nil {
-		logErr(err, "failed to load the latest known ledger state from core DB")
+		logErr(err, "failed to load the stellar-core info")
 		return
 	}
 	next.CoreLatest = int32(coreInfo.Info.Ledger.Num)

--- a/services/horizon/internal/app_test.go
+++ b/services/horizon/internal/app_test.go
@@ -49,5 +49,5 @@ func TestMetrics(t *testing.T) {
 
 	ht.Require.EqualValues(3, hl.Value())
 	ht.Require.EqualValues(1, he.Value())
-	ht.Require.EqualValues(3, cl.Value())
+	ht.Require.EqualValues(64, cl.Value())
 }

--- a/services/horizon/internal/app_test.go
+++ b/services/horizon/internal/app_test.go
@@ -32,7 +32,6 @@ func TestGenericHTTPFeatures(t *testing.T) {
 	w = ht.Get("/ledgers/")
 	ht.Assert.Equal(200, w.Code)
 }
-
 func TestMetrics(t *testing.T) {
 	ht := StartHTTPTest(t, "base")
 	defer ht.Finish()


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Use core's http end-point instead of core's db to load the latest ledger in core.

### Why

Horizon should not use Core DB outside of the ingestion package. This will help us remove the coupling between non-ingesting Horizon instances and Core's DB.

Fixes #2725

### Known limitations

[TODO or N/A]
