### PR TITLE
exp/services/recoverysigner: add "encryption-tink-keyset create" cmd

### DIFF
--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -65,15 +65,15 @@ func (c *KeysetCommand) Create() {
 	keysetPublic := strings.Builder{}
 
 	if c.RemoteKEKURI != "" {
-		kmsClient, err := awskms.NewClient(c.RemoteKEKURI)
-		if err != nil {
-			c.Logger.Errorf("Error initializing AWS KMS client: %s", err.Error())
+		kmsClient, kmsErr := awskms.NewClient(c.RemoteKEKURI)
+		if kmsErr != nil {
+			c.Logger.Errorf("Error initializing AWS KMS client: %s", kmsErr.Error())
 			return
 		}
 
-		aead, err := kmsClient.GetAEAD(c.RemoteKEKURI)
-		if err != nil {
-			c.Logger.Errorf("Error getting AEAD primitive from KMS: %s", err.Error())
+		aead, kmsErr := kmsClient.GetAEAD(c.RemoteKEKURI)
+		if kmsErr != nil {
+			c.Logger.Errorf("Error getting AEAD primitive from KMS: %s", kmsErr.Error())
 			return
 		}
 

--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -70,7 +70,7 @@ func (c *KeysetCommand) Create() {
 }
 
 func createKeyset(kmsKeyURI string) (publicCleartext string, privateCleartext string, privateEncrypted string, err error) {
-	khPriv, err := keyset.NewHandle(hybrid.ECIESHKDFAES128CTRHMACSHA256KeyTemplate())
+	khPriv, err := keyset.NewHandle(hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	if err != nil {
 		return "", "", "", errors.Wrap(err, "generating a new keyset")
 	}

--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -10,12 +10,13 @@ import (
 	"github.com/google/tink/go/keyset"
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/support/config"
+	"github.com/stellar/go/support/errors"
 	supportlog "github.com/stellar/go/support/log"
 )
 
 type KeysetCommand struct {
-	Logger       *supportlog.Entry
-	RemoteKEKURI string
+	Logger              *supportlog.Entry
+	EncryptionKMSKeyURI string
 }
 
 func (c *KeysetCommand) Command() *cobra.Command {
@@ -24,7 +25,7 @@ func (c *KeysetCommand) Command() *cobra.Command {
 			Name:        "encryption-kms-key-uri",
 			Usage:       "URI for a remote KMS key used to encrypt Tink keyset",
 			OptType:     types.String,
-			ConfigKey:   &c.RemoteKEKURI,
+			ConfigKey:   &c.EncryptionKMSKeyURI,
 			FlagDefault: "",
 			Required:    false,
 		},
@@ -54,57 +55,61 @@ func (c *KeysetCommand) Command() *cobra.Command {
 }
 
 func (c *KeysetCommand) Create() {
+	keysetPublic, keysetPrivateCleartext, keysetPrivateEncrypted, err := createKeyset(c.EncryptionKMSKeyURI)
+	if err != nil {
+		c.Logger.Errorf("Error creating keyset: %v", err)
+		return
+	}
+
+	c.Logger.Print("Cleartext keyset public:", keysetPublic)
+	c.Logger.Print("Cleartext keyset private:", keysetPrivateCleartext)
+
+	if keysetPrivateEncrypted != "" {
+		c.Logger.Print("Encrypted keyset private:", keysetPrivateEncrypted)
+	}
+}
+
+func createKeyset(kmsKeyURI string) (public string, privateCleartext string, privateEncrypted string, err error) {
 	khPriv, err := keyset.NewHandle(hybrid.ECIESHKDFAES128CTRHMACSHA256KeyTemplate())
 	if err != nil {
-		c.Logger.Errorf("Error generating a new keyset: %s", err.Error())
-		return
+		return "", "", "", errors.Wrap(err, "generating a new keyset")
 	}
 
 	keysetPrivateEncrypted := strings.Builder{}
 	keysetPrivateCleartext := strings.Builder{}
 	keysetPublic := strings.Builder{}
 
-	if c.RemoteKEKURI != "" {
-		kmsClient, kmsErr := awskms.NewClient(c.RemoteKEKURI)
+	if kmsKeyURI != "" {
+		kmsClient, kmsErr := awskms.NewClient(kmsKeyURI)
 		if kmsErr != nil {
-			c.Logger.Errorf("Error initializing AWS KMS client: %s", kmsErr.Error())
-			return
+			return "", "", "", errors.Wrap(kmsErr, "initializing AWS KMS client")
 		}
 
-		aead, kmsErr := kmsClient.GetAEAD(c.RemoteKEKURI)
+		aead, kmsErr := kmsClient.GetAEAD(kmsKeyURI)
 		if kmsErr != nil {
-			c.Logger.Errorf("Error getting AEAD primitive from KMS: %s", kmsErr.Error())
-			return
+			return "", "", "", errors.Wrap(kmsErr, "getting AEAD primitive from KMS")
 		}
 
 		err = khPriv.Write(keyset.NewJSONWriter(&keysetPrivateEncrypted), aead)
 		if err != nil {
-			c.Logger.Errorf("Error writing encrypted keyset containing private key: %s", err.Error())
-			return
+			return "", "", "", errors.Wrap(err, "writing encrypted keyset containing private key")
 		}
 	}
 
 	err = insecurecleartextkeyset.Write(khPriv, keyset.NewJSONWriter(&keysetPrivateCleartext))
 	if err != nil {
-		c.Logger.Errorf("Error writing cleartext keyset containing private key: %s", err.Error())
-		return
+		return "", "", "", errors.Wrap(err, "writing cleartext keyset containing private key")
 	}
 
 	khPub, err := khPriv.Public()
 	if err != nil {
-		c.Logger.Errorf("Error getting keyhandle for public key: %s", err.Error())
-		return
+		return "", "", "", errors.Wrap(err, "getting keyhandle for public key")
 	}
 
 	err = khPub.WriteWithNoSecrets(keyset.NewJSONWriter(&keysetPublic))
 	if err != nil {
-		c.Logger.Errorf("Error writing cleartext keyset containing public key: %s", err.Error())
-		return
+		return "", "", "", errors.Wrap(err, "writing cleartext keyset containing public key")
 	}
 
-	c.Logger.Print("Cleartext keyset public:", keysetPublic.String())
-	c.Logger.Print("Cleartext keyset private:", keysetPrivateCleartext.String())
-	if c.RemoteKEKURI != "" {
-		c.Logger.Print("Encrypted keyset private:", keysetPrivateEncrypted.String())
-	}
+	return keysetPublic.String(), keysetPrivateCleartext.String(), keysetPrivateEncrypted.String(), nil
 }

--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -69,7 +69,7 @@ func (c *KeysetCommand) Create() {
 	}
 }
 
-func createKeyset(kmsKeyURI string) (public string, privateCleartext string, privateEncrypted string, err error) {
+func createKeyset(kmsKeyURI string) (publicCleartext string, privateCleartext string, privateEncrypted string, err error) {
 	khPriv, err := keyset.NewHandle(hybrid.ECIESHKDFAES128CTRHMACSHA256KeyTemplate())
 	if err != nil {
 		return "", "", "", errors.Wrap(err, "generating a new keyset")

--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"go/types"
+	"strings"
+
+	"github.com/google/tink/go/hybrid"
+	"github.com/google/tink/go/insecurecleartextkeyset"
+	"github.com/google/tink/go/integration/awskms"
+	"github.com/google/tink/go/keyset"
+	"github.com/spf13/cobra"
+	"github.com/stellar/go/support/config"
+	supportlog "github.com/stellar/go/support/log"
+)
+
+type KeysetCommand struct {
+	Logger       *supportlog.Entry
+	RemoteKEKURI string
+}
+
+func (c *KeysetCommand) Command() *cobra.Command {
+	configOpts := config.ConfigOptions{
+		{
+			Name:        "encryption-kms-key-uri",
+			Usage:       "URI for a remote KMS key used to encrypt Tink keyset",
+			OptType:     types.String,
+			ConfigKey:   &c.RemoteKEKURI,
+			FlagDefault: "",
+			Required:    false,
+		},
+	}
+	cmd := &cobra.Command{
+		Use:   "encryption-tink-keyset",
+		Short: "Run Tink keyset operations",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			configOpts.SetValues()
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+		},
+	}
+	configOpts.Init(cmd)
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new Tink keyset",
+		Run: func(_ *cobra.Command, _ []string) {
+			c.Create()
+		},
+	}
+	cmd.AddCommand(createCmd)
+
+	return cmd
+}
+
+func (c *KeysetCommand) Create() {
+	khPriv, err := keyset.NewHandle(hybrid.ECIESHKDFAES128CTRHMACSHA256KeyTemplate())
+	if err != nil {
+		c.Logger.Errorf("Error generating a new keyset: %s", err.Error())
+		return
+	}
+
+	keysetPrivateEncrypted := strings.Builder{}
+	keysetPrivateCleartext := strings.Builder{}
+	keysetPublic := strings.Builder{}
+
+	if c.RemoteKEKURI != "" {
+		kmsClient, err := awskms.NewClient(c.RemoteKEKURI)
+		if err != nil {
+			c.Logger.Errorf("Error initializing AWS KMS client: %s", err.Error())
+			return
+		}
+
+		aead, err := kmsClient.GetAEAD(c.RemoteKEKURI)
+		if err != nil {
+			c.Logger.Errorf("Error getting AEAD primitive from KMS: %s", err.Error())
+			return
+		}
+
+		err = khPriv.Write(keyset.NewJSONWriter(&keysetPrivateEncrypted), aead)
+		if err != nil {
+			c.Logger.Errorf("Error writing encrypted keyset containing private key: %s", err.Error())
+			return
+		}
+	}
+
+	err = insecurecleartextkeyset.Write(khPriv, keyset.NewJSONWriter(&keysetPrivateCleartext))
+	if err != nil {
+		c.Logger.Errorf("Error writing cleartext keyset containing private key: %s", err.Error())
+		return
+	}
+
+	khPub, err := khPriv.Public()
+	if err != nil {
+		c.Logger.Errorf("Error getting keyhandle for public key: %s", err.Error())
+		return
+	}
+
+	err = khPub.WriteWithNoSecrets(keyset.NewJSONWriter(&keysetPublic))
+	if err != nil {
+		c.Logger.Errorf("Error writing cleartext keyset containing public key: %s", err.Error())
+		return
+	}
+
+	c.Logger.Print("Cleartext keyset public:", keysetPublic.String())
+	c.Logger.Print("Cleartext keyset private:", keysetPrivateCleartext.String())
+	if c.RemoteKEKURI != "" {
+		c.Logger.Print("Encrypted keyset private:", keysetPrivateEncrypted.String())
+	}
+}

--- a/exp/services/recoverysigner/cmd/keyset_test.go
+++ b/exp/services/recoverysigner/cmd/keyset_test.go
@@ -49,7 +49,10 @@ func TestCreateKeyset(t *testing.T) {
 	// context info not matching will result in a failed decryption
 	_, err = hd.Decrypt(ciphertext, []byte("wrong info"))
 	assert.Error(t, err)
+}
 
-	_, _, _, err = createKeyset("invalid-uri")
-	assert.Error(t, err)
+func TestCreateKeyset_invalidKMSKeyURI(t *testing.T) {
+	_, _, _, err := createKeyset("invalid-uri")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "initializing AWS KMS client")
 }

--- a/exp/services/recoverysigner/cmd/keyset_test.go
+++ b/exp/services/recoverysigner/cmd/keyset_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/tink/go/hybrid"
+	"github.com/google/tink/go/insecurecleartextkeyset"
+	"github.com/google/tink/go/keyset"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateKeyset(t *testing.T) {
+	public, privateC, privateE, err := createKeyset("")
+	require.NoError(t, err)
+	assert.NotEmpty(t, public)
+	assert.NotEmpty(t, privateC)
+	assert.Empty(t, privateE)
+
+	khPriv, err := insecurecleartextkeyset.Read(keyset.NewJSONReader(strings.NewReader(privateC)))
+	require.NoError(t, err)
+
+	khPub, err := keyset.ReadWithNoSecrets(keyset.NewJSONReader(strings.NewReader(public)))
+	require.NoError(t, err)
+
+	// verify that one is able to get the same keyset public with keyset private
+	khPubv, err := khPriv.Public()
+	require.NoError(t, err)
+	assert.Equal(t, khPub.String(), khPubv.String())
+
+	hd, err := hybrid.NewHybridDecrypt(khPriv)
+	require.NoError(t, err)
+
+	he, err := hybrid.NewHybridEncrypt(khPub)
+	require.NoError(t, err)
+
+	// verify that one can use keyset private to decrypt what keyset public
+	// encrypts
+	plaintext := []byte("secure message")
+	contextInfo := []byte("context info")
+	ciphertext, err := he.Encrypt(plaintext, contextInfo)
+	require.NoError(t, err)
+
+	plaintext2, err := hd.Decrypt(ciphertext, contextInfo)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, plaintext2)
+
+	// context info not matching will result in a failed decryption
+	_, err = hd.Decrypt(ciphertext, []byte("wrong info"))
+	assert.Error(t, err)
+
+	_, _, _, err = createKeyset("invalid-uri")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR adds the `encryption-tink-keyset create` command to output three keysets in JSON:
1. the cleartext keyset containing the private key
2. the encrypted keyset containing the private key
3. the cleartext keyset containing the public key

### Why

This command generates the necessary keyset as the value to the  `encryption-tink-keyset` env to the recovery signer as a part of the feature of having unique signer keys per registered account.

Though we only need the encrypted keyset at this moment, the cleartext keyset containing the private key is used as a backup for devops and the cleartext keyset containing the public key will be used as the value of another env introduced later.

### Known limitations

I'm wondering whether this command should be merged into the master so that devops can generate a key and configure the `encryption-tink-keyset` as well as the KMS key uri before the rest of code gets in given that `encryption-tink-keyset` is a required config.
