### PR TITLE
services/horizon/internal/docs: Document tx_set_operation_count.

### DIFF
--- a/services/horizon/internal/docs/reference/endpoints/ledgers-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/ledgers-all.md
@@ -102,6 +102,7 @@ This endpoint responds with a list of ledgers.  See [ledger resource](../resourc
         "successful_transaction_count": 0,
         "failed_transaction_count": 0,
         "operation_count": 0,
+        "tx_set_operation_count": 0,
         "closed_at": "1970-01-01T00:00:00Z",
         "total_coins": "100000000000.0000000",
         "fee_pool": "0.0000000",

--- a/services/horizon/internal/docs/reference/endpoints/ledgers-single.md
+++ b/services/horizon/internal/docs/reference/endpoints/ledgers-single.md
@@ -75,6 +75,7 @@ This endpoint responds with a single Ledger.  See [ledger resource](../resources
   "successful_transaction_count": 0,
   "failed_transaction_count": 0,
   "operation_count": 0,
+  "tx_set_operation_count": 0,
   "closed_at": "2015-07-20T15:51:52Z",
   "total_coins": "100000000000.0000000",
   "fee_pool": "0.0025600",

--- a/services/horizon/internal/docs/reference/resources/ledger.md
+++ b/services/horizon/internal/docs/reference/resources/ledger.md
@@ -18,6 +18,7 @@ To learn more about the concept of ledgers in the Stellar network, take a look a
 | successful_transaction_count | number | The number of successful transactions in this ledger.                                                                        |
 | failed_transaction_count     | number | The number of failed transactions in this ledger.                                                                            |
 | operation_count              | number | The number of operations applied in this ledger.                                                                             |
+| tx_set_operation_count       | number | The number of operations in this ledger. This number includes operations from failed and successful transactions.            |
 | closed_at                    | string | An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formatted string of when this ledger was closed.                       |
 | total_coins                  | string | The total number of lumens in circulation.                                                                                   |
 | fee_pool                     | string | The sum of all transaction fees *(in lumens)* since the last inflation operation. They are redistributed during [inflation]. |
@@ -68,6 +69,7 @@ To learn more about the concept of ledgers in the Stellar network, take a look a
   "successful_transaction_count": 0,
   "failed_transaction_count": 0,
   "operation_count": 0,
+  "tx_set_operation_count": 0,
   "closed_at": "2015-07-09T21:39:28Z",
   "total_coins": "100000000000.0000000",
   "fee_pool": "0.0025600",


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Document new field on `ledger` resource.