### PR TITLE
services/horizon/docker/verify-range: Use S3 domain in verify-range

### DIFF
--- a/services/horizon/docker/verify-range/stellar-core.cfg
+++ b/services/horizon/docker/verify-range/stellar-core.cfg
@@ -51,10 +51,10 @@ VALIDATORS=[
 
 # Stellar.org history store
 [HISTORY.sdf1]
-get="curl -sf http://history.stellar.org/prd/core-live/core_live_001/{0} -o {1}"
+get="curl -sf http://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-live/core_live_001/{0} -o {1}"
 
 [HISTORY.sdf2]
-get="curl -sf http://history.stellar.org/prd/core-live/core_live_002/{0} -o {1}"
+get="curl -sf http://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-live/core_live_002/{0} -o {1}"
 
 [HISTORY.sdf3]
-get="curl -sf http://history.stellar.org/prd/core-live/core_live_003/{0} -o {1}"
+get="curl -sf http://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-live/core_live_003/{0} -o {1}"


### PR DESCRIPTION
### What

Updates `stellar-core.cfg` in `verify-range` tests to use s3 domain.

### Why

We run `verify-range` in AWS and it's cheaper to use S3 directly.