### PR TITLE
exp/services/recoverysigner: add encryption-tink-keyset rotate cmd

### DIFF
--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/tink/go/insecurecleartextkeyset"
 	"github.com/google/tink/go/integration/awskms"
 	"github.com/google/tink/go/keyset"
+	"github.com/google/tink/go/tink"
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/support/config"
 	"github.com/stellar/go/support/errors"
@@ -17,6 +18,7 @@ import (
 type KeysetCommand struct {
 	Logger              *supportlog.Entry
 	EncryptionKMSKeyURI string
+	CurrentTinkKeyset   string
 }
 
 func (c *KeysetCommand) Command() *cobra.Command {
@@ -26,6 +28,14 @@ func (c *KeysetCommand) Command() *cobra.Command {
 			Usage:       "URI for a remote KMS key used to encrypt Tink keyset",
 			OptType:     types.String,
 			ConfigKey:   &c.EncryptionKMSKeyURI,
+			FlagDefault: "",
+			Required:    false,
+		},
+		{
+			Name:        "current-tink-keyset",
+			Usage:       "Current Tink keyset to rotate",
+			OptType:     types.String,
+			ConfigKey:   &c.CurrentTinkKeyset,
 			FlagDefault: "",
 			Required:    false,
 		},
@@ -49,7 +59,16 @@ func (c *KeysetCommand) Command() *cobra.Command {
 			c.Create()
 		},
 	}
+	rotateCmd := &cobra.Command{
+		Use:   "rotate",
+		Short: "Rotate an existing Tink keyset",
+		Run: func(_ *cobra.Command, _ []string) {
+			c.Rotate()
+		},
+	}
+
 	cmd.AddCommand(createCmd)
+	cmd.AddCommand(rotateCmd)
 
 	return cmd
 }
@@ -109,6 +128,89 @@ func createKeyset(kmsKeyURI string) (publicCleartext string, privateCleartext st
 	err = khPub.WriteWithNoSecrets(keyset.NewJSONWriter(&keysetPublic))
 	if err != nil {
 		return "", "", "", errors.Wrap(err, "writing cleartext keyset containing public key")
+	}
+
+	return keysetPublic.String(), keysetPrivateCleartext.String(), keysetPrivateEncrypted.String(), nil
+}
+
+func (c *KeysetCommand) Rotate() {
+	keysetPublic, keysetPrivateCleartext, keysetPrivateEncrypted, err := rotateKeyset(c.EncryptionKMSKeyURI, c.CurrentTinkKeyset)
+	if err != nil {
+		c.Logger.Errorf("Error rotating keyset: %v", err)
+		return
+	}
+
+	c.Logger.Print("Cleartext keyset public:", keysetPublic)
+	c.Logger.Print("Cleartext keyset private:", keysetPrivateCleartext)
+
+	if keysetPrivateEncrypted != "" {
+		c.Logger.Print("Encrypted keyset private:", keysetPrivateEncrypted)
+	}
+}
+
+func rotateKeyset(kmsKeyURI, currentTinkKeyset string) (publicCleartext string, privateCleartext string, privateEncrypted string, err error) {
+	var (
+		khPriv *keyset.Handle
+		aead   tink.AEAD
+	)
+
+	if kmsKeyURI != "" {
+		kmsClient, kmsErr := awskms.NewClient(kmsKeyURI)
+		if kmsErr != nil {
+			return "", "", "", errors.Wrap(kmsErr, "initializing AWS KMS client")
+		}
+
+		aead, kmsErr = kmsClient.GetAEAD(kmsKeyURI)
+		if kmsErr != nil {
+			return "", "", "", errors.Wrap(kmsErr, "getting AEAD primitive from KMS")
+		}
+
+		khPriv, err = keyset.Read(keyset.NewJSONReader(strings.NewReader(currentTinkKeyset)), aead)
+		if err != nil {
+			return "", "", "", errors.Wrap(err, "reading encrypted keyset")
+		}
+	} else {
+		khPriv, err = insecurecleartextkeyset.Read(keyset.NewJSONReader(strings.NewReader(currentTinkKeyset)))
+		if err != nil {
+			return "", "", "", errors.Wrap(err, "getting key handle for private key")
+		}
+	}
+
+	m := keyset.NewManagerFromHandle(khPriv)
+	err = m.Rotate(hybrid.ECIESHKDFAES128GCMKeyTemplate())
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "rotating keyset")
+	}
+
+	khPriv, err = m.Handle()
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "creating handle for the new keyset")
+	}
+
+	keysetPrivateEncrypted := strings.Builder{}
+	keysetPrivateCleartext := strings.Builder{}
+	keysetPublic := strings.Builder{}
+
+	if kmsKeyURI != "" {
+		err = khPriv.Write(keyset.NewJSONWriter(&keysetPrivateEncrypted), aead)
+		if err != nil {
+			return "", "", "", errors.Wrap(err, "writing encrypted keyset containing private keys")
+		}
+	}
+
+	err = insecurecleartextkeyset.Write(khPriv, keyset.NewJSONWriter(&keysetPrivateCleartext))
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "writing cleartext keyset containing private keys")
+	}
+
+	khPub, err := khPriv.Public()
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "getting keyhandle for public keys")
+	}
+
+	err = khPub.WriteWithNoSecrets(keyset.NewJSONWriter(&keysetPublic))
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "writing cleartext keyset containing public keys")
 	}
 
 	return keysetPublic.String(), keysetPrivateCleartext.String(), keysetPrivateEncrypted.String(), nil

--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/tink/go/insecurecleartextkeyset"
 	"github.com/google/tink/go/integration/awskms"
 	"github.com/google/tink/go/keyset"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
 	"github.com/google/tink/go/tink"
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/support/config"
@@ -73,8 +74,12 @@ func (c *KeysetCommand) Command() *cobra.Command {
 	return cmd
 }
 
+func (c *KeysetCommand) keyTemplate() *tinkpb.KeyTemplate {
+	return hybrid.ECIESHKDFAES128GCMKeyTemplate()
+}
+
 func (c *KeysetCommand) Create() {
-	keysetPublic, keysetPrivateCleartext, keysetPrivateEncrypted, err := createKeyset(c.EncryptionKMSKeyURI)
+	keysetPublic, keysetPrivateCleartext, keysetPrivateEncrypted, err := createKeyset(c.EncryptionKMSKeyURI, c.keyTemplate())
 	if err != nil {
 		c.Logger.Errorf("Error creating keyset: %v", err)
 		return
@@ -88,8 +93,8 @@ func (c *KeysetCommand) Create() {
 	}
 }
 
-func createKeyset(kmsKeyURI string) (publicCleartext string, privateCleartext string, privateEncrypted string, err error) {
-	khPriv, err := keyset.NewHandle(hybrid.ECIESHKDFAES128GCMKeyTemplate())
+func createKeyset(kmsKeyURI string, keyTemplate *tinkpb.KeyTemplate) (publicCleartext string, privateCleartext string, privateEncrypted string, err error) {
+	khPriv, err := keyset.NewHandle(keyTemplate)
 	if err != nil {
 		return "", "", "", errors.Wrap(err, "generating a new keyset")
 	}
@@ -134,7 +139,7 @@ func createKeyset(kmsKeyURI string) (publicCleartext string, privateCleartext st
 }
 
 func (c *KeysetCommand) Rotate() {
-	keysetPublic, keysetPrivateCleartext, keysetPrivateEncrypted, err := rotateKeyset(c.EncryptionKMSKeyURI, c.CurrentTinkKeyset)
+	keysetPublic, keysetPrivateCleartext, keysetPrivateEncrypted, err := rotateKeyset(c.EncryptionKMSKeyURI, c.CurrentTinkKeyset, c.keyTemplate())
 	if err != nil {
 		c.Logger.Errorf("Error rotating keyset: %v", err)
 		return
@@ -148,7 +153,7 @@ func (c *KeysetCommand) Rotate() {
 	}
 }
 
-func rotateKeyset(kmsKeyURI, currentTinkKeyset string) (publicCleartext string, privateCleartext string, privateEncrypted string, err error) {
+func rotateKeyset(kmsKeyURI, currentTinkKeyset string, keyTemplate *tinkpb.KeyTemplate) (publicCleartext string, privateCleartext string, privateEncrypted string, err error) {
 	var (
 		khPriv *keyset.Handle
 		aead   tink.AEAD
@@ -177,7 +182,7 @@ func rotateKeyset(kmsKeyURI, currentTinkKeyset string) (publicCleartext string, 
 	}
 
 	m := keyset.NewManagerFromHandle(khPriv)
-	err = m.Rotate(hybrid.ECIESHKDFAES128GCMKeyTemplate())
+	err = m.Rotate(keyTemplate)
 	if err != nil {
 		return "", "", "", errors.Wrap(err, "rotating keyset")
 	}

--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -61,7 +61,7 @@ func (c *KeysetCommand) Command() *cobra.Command {
 	}
 	rotateCmd := &cobra.Command{
 		Use:   "rotate",
-		Short: "Rotate an existing Tink keyset",
+		Short: "Rotate the Tink keyset by generating a new key, adding it to the keyset, and making it the primary key in the keyset",
 		Run: func(_ *cobra.Command, _ []string) {
 			c.Rotate()
 		},

--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -17,9 +17,9 @@ import (
 )
 
 type KeysetCommand struct {
-	Logger              *supportlog.Entry
-	EncryptionKMSKeyURI string
-	CurrentTinkKeyset   string
+	Logger               *supportlog.Entry
+	EncryptionKMSKeyURI  string
+	EncryptionTinkKeyset string
 }
 
 func (c *KeysetCommand) Command() *cobra.Command {
@@ -33,10 +33,10 @@ func (c *KeysetCommand) Command() *cobra.Command {
 			Required:    false,
 		},
 		{
-			Name:        "current-tink-keyset",
-			Usage:       "Current Tink keyset to rotate",
+			Name:        "encryption-tink-keyset",
+			Usage:       "Existing Tink keyset to rotate",
 			OptType:     types.String,
-			ConfigKey:   &c.CurrentTinkKeyset,
+			ConfigKey:   &c.EncryptionTinkKeyset,
 			FlagDefault: "",
 			Required:    false,
 		},
@@ -62,7 +62,7 @@ func (c *KeysetCommand) Command() *cobra.Command {
 	}
 	rotateCmd := &cobra.Command{
 		Use:   "rotate",
-		Short: "Rotate the Tink keyset by generating a new key, adding it to the keyset, and making it the primary key in the keyset",
+		Short: "Rotate the Tink keyset specified in encryption-tink-keyset by generating a new key, adding it to the keyset, and making it the primary key in the keyset",
 		Run: func(_ *cobra.Command, _ []string) {
 			c.Rotate()
 		},
@@ -139,7 +139,7 @@ func createKeyset(kmsKeyURI string, keyTemplate *tinkpb.KeyTemplate) (publicClea
 }
 
 func (c *KeysetCommand) Rotate() {
-	keysetPublic, keysetPrivateCleartext, keysetPrivateEncrypted, err := rotateKeyset(c.EncryptionKMSKeyURI, c.CurrentTinkKeyset, c.keyTemplate())
+	keysetPublic, keysetPrivateCleartext, keysetPrivateEncrypted, err := rotateKeyset(c.EncryptionKMSKeyURI, c.EncryptionTinkKeyset, c.keyTemplate())
 	if err != nil {
 		c.Logger.Errorf("Error rotating keyset: %v", err)
 		return

--- a/exp/services/recoverysigner/cmd/keyset_test.go
+++ b/exp/services/recoverysigner/cmd/keyset_test.go
@@ -56,3 +56,102 @@ func TestCreateKeyset_invalidKMSKeyURI(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "initializing AWS KMS client")
 }
+
+func TestRotateKeyset(t *testing.T) {
+	public1, privateC1, _, err := createKeyset("")
+	require.NoError(t, err)
+
+	khPriv1, err := insecurecleartextkeyset.Read(keyset.NewJSONReader(strings.NewReader(privateC1)))
+	require.NoError(t, err)
+
+	exportedPriv1 := &keyset.MemReaderWriter{}
+	err = insecurecleartextkeyset.Write(khPriv1, exportedPriv1)
+	require.NoError(t, err)
+	assert.Len(t, exportedPriv1.Keyset.Key, 1)
+
+	khPub1, err := keyset.ReadWithNoSecrets(keyset.NewJSONReader(strings.NewReader(public1)))
+	require.NoError(t, err)
+
+	public2, privateC2, _, err := rotateKeyset("", privateC1)
+	require.NoError(t, err)
+
+	khPriv2, err := insecurecleartextkeyset.Read(keyset.NewJSONReader(strings.NewReader(privateC2)))
+	require.NoError(t, err)
+
+	exportedPriv2 := &keyset.MemReaderWriter{}
+	err = insecurecleartextkeyset.Write(khPriv2, exportedPriv2)
+	require.NoError(t, err)
+
+	// rotation will add a new key to the keyset and make the new key the primary key
+	assert.Len(t, exportedPriv2.Keyset.Key, 2)
+	assert.NotEqual(t, exportedPriv2.Keyset.PrimaryKeyId, exportedPriv1.Keyset.PrimaryKeyId)
+
+	khPub2, err := keyset.ReadWithNoSecrets(keyset.NewJSONReader(strings.NewReader(public2)))
+	require.NoError(t, err)
+
+	// verify that one is able to get the same keyset public with keyset private
+	khPubv2, err := khPriv2.Public()
+	require.NoError(t, err)
+	assert.Equal(t, khPub2.String(), khPubv2.String())
+
+	hd1, err := hybrid.NewHybridDecrypt(khPriv1)
+	require.NoError(t, err)
+
+	he1, err := hybrid.NewHybridEncrypt(khPub1)
+	require.NoError(t, err)
+
+	hd2, err := hybrid.NewHybridDecrypt(khPriv2)
+	require.NoError(t, err)
+
+	he2, err := hybrid.NewHybridEncrypt(khPub2)
+	require.NoError(t, err)
+
+	plaintext := []byte("secure message")
+	contextInfo := []byte("context info")
+
+	// verify that the new keyset private is able to decrypt what the new keyset public encrypts
+	ciphertext, err := he2.Encrypt(plaintext, contextInfo)
+	require.NoError(t, err)
+
+	plaintext2, err := hd2.Decrypt(ciphertext, contextInfo)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, plaintext2)
+
+	// context info not matching will result in a failed decryption
+	_, err = hd2.Decrypt(ciphertext, []byte("wrong info"))
+	assert.Error(t, err)
+
+	// verify that the new keyset is able to decrypt what the old keyset encrypts
+	ciphertext, err = he1.Encrypt(plaintext, contextInfo)
+	require.NoError(t, err)
+
+	plaintext2, err = hd2.Decrypt(ciphertext, contextInfo)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, plaintext2)
+
+	// context info not matching will still result in a failed decryption
+	_, err = hd2.Decrypt(ciphertext, []byte("wrong info"))
+	assert.Error(t, err)
+
+	// verify that the old keyset is not able to decrypt what the new keyset encrypts
+	ciphertext, err = he2.Encrypt(plaintext, contextInfo)
+	require.NoError(t, err)
+
+	_, err = hd1.Decrypt(ciphertext, contextInfo)
+	assert.Error(t, err)
+}
+
+func TestRotateKeyset_invalidKMSKeyURI(t *testing.T) {
+	_, privateC, _, err := createKeyset("")
+	require.NoError(t, err)
+
+	_, _, _, err = rotateKeyset("invalid-uri", privateC)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "initializing AWS KMS client")
+}
+
+func TestRotateKeyset_noCurrentKeyset(t *testing.T) {
+	_, _, _, err := rotateKeyset("", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "getting key handle for private key")
+}

--- a/exp/services/recoverysigner/cmd/keyset_test.go
+++ b/exp/services/recoverysigner/cmd/keyset_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCreateKeyset(t *testing.T) {
-	public, privateC, privateE, err := createKeyset("")
+	public, privateC, privateE, err := createKeyset("", hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	require.NoError(t, err)
 	assert.NotEmpty(t, public)
 	assert.NotEmpty(t, privateC)
@@ -52,13 +52,14 @@ func TestCreateKeyset(t *testing.T) {
 }
 
 func TestCreateKeyset_invalidKMSKeyURI(t *testing.T) {
-	_, _, _, err := createKeyset("invalid-uri")
+	_, _, _, err := createKeyset("invalid-uri", hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "initializing AWS KMS client")
 }
 
 func TestRotateKeyset(t *testing.T) {
-	public1, privateC1, _, err := createKeyset("")
+	keyTemplate := hybrid.ECIESHKDFAES128GCMKeyTemplate()
+	public1, privateC1, _, err := createKeyset("", keyTemplate)
 	require.NoError(t, err)
 
 	khPriv1, err := insecurecleartextkeyset.Read(keyset.NewJSONReader(strings.NewReader(privateC1)))
@@ -72,7 +73,7 @@ func TestRotateKeyset(t *testing.T) {
 	khPub1, err := keyset.ReadWithNoSecrets(keyset.NewJSONReader(strings.NewReader(public1)))
 	require.NoError(t, err)
 
-	public2, privateC2, _, err := rotateKeyset("", privateC1)
+	public2, privateC2, _, err := rotateKeyset("", privateC1, keyTemplate)
 	require.NoError(t, err)
 
 	khPriv2, err := insecurecleartextkeyset.Read(keyset.NewJSONReader(strings.NewReader(privateC2)))
@@ -142,16 +143,17 @@ func TestRotateKeyset(t *testing.T) {
 }
 
 func TestRotateKeyset_invalidKMSKeyURI(t *testing.T) {
-	_, privateC, _, err := createKeyset("")
+	keyTemplate := hybrid.ECIESHKDFAES128GCMKeyTemplate()
+	_, privateC, _, err := createKeyset("", keyTemplate)
 	require.NoError(t, err)
 
-	_, _, _, err = rotateKeyset("invalid-uri", privateC)
+	_, _, _, err = rotateKeyset("invalid-uri", privateC, keyTemplate)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "initializing AWS KMS client")
 }
 
 func TestRotateKeyset_noCurrentKeyset(t *testing.T) {
-	_, _, _, err := rotateKeyset("", "")
+	_, _, _, err := rotateKeyset("", "", hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "getting key handle for private key")
 }

--- a/exp/services/recoverysigner/cmd/keyset_test.go
+++ b/exp/services/recoverysigner/cmd/keyset_test.go
@@ -68,7 +68,10 @@ func TestRotateKeyset(t *testing.T) {
 	exportedPriv1 := &keyset.MemReaderWriter{}
 	err = insecurecleartextkeyset.Write(khPriv1, exportedPriv1)
 	require.NoError(t, err)
-	assert.Len(t, exportedPriv1.Keyset.Key, 1)
+
+	ksPriv1 := exportedPriv1.Keyset
+	assert.Len(t, ksPriv1.Key, 1)
+	assert.Equal(t, ksPriv1.PrimaryKeyId, ksPriv1.Key[0].KeyId)
 
 	khPub1, err := keyset.ReadWithNoSecrets(keyset.NewJSONReader(strings.NewReader(public1)))
 	require.NoError(t, err)
@@ -84,8 +87,10 @@ func TestRotateKeyset(t *testing.T) {
 	require.NoError(t, err)
 
 	// rotation will add a new key to the keyset and make the new key the primary key
-	assert.Len(t, exportedPriv2.Keyset.Key, 2)
-	assert.NotEqual(t, exportedPriv2.Keyset.PrimaryKeyId, exportedPriv1.Keyset.PrimaryKeyId)
+	ksPriv2 := exportedPriv2.Keyset
+	assert.Len(t, ksPriv2.Key, 2)
+	assert.Equal(t, ksPriv2.PrimaryKeyId, ksPriv2.Key[1].KeyId)
+	assert.NotEqual(t, ksPriv2.PrimaryKeyId, ksPriv1.PrimaryKeyId)
 
 	khPub2, err := keyset.ReadWithNoSecrets(keyset.NewJSONReader(strings.NewReader(public2)))
 	require.NoError(t, err)

--- a/exp/services/recoverysigner/cmd/keyset_test.go
+++ b/exp/services/recoverysigner/cmd/keyset_test.go
@@ -76,8 +76,11 @@ func TestRotateKeyset(t *testing.T) {
 	khPub1, err := keyset.ReadWithNoSecrets(keyset.NewJSONReader(strings.NewReader(public1)))
 	require.NoError(t, err)
 
-	public2, privateC2, _, err := rotateKeyset("", privateC1, keyTemplate)
+	public2, privateC2, privateE2, err := rotateKeyset("", privateC1, keyTemplate)
 	require.NoError(t, err)
+	assert.NotEmpty(t, public2)
+	assert.NotEmpty(t, privateC2)
+	assert.Empty(t, privateE2)
 
 	khPriv2, err := insecurecleartextkeyset.Read(keyset.NewJSONReader(strings.NewReader(privateC2)))
 	require.NoError(t, err)

--- a/exp/services/recoverysigner/main.go
+++ b/exp/services/recoverysigner/main.go
@@ -21,6 +21,7 @@ func main() {
 
 	rootCmd.AddCommand((&cmd.ServeCommand{Logger: logger}).Command())
 	rootCmd.AddCommand((&cmd.DBCommand{Logger: logger}).Command())
+	rootCmd.AddCommand((&cmd.KeysetCommand{Logger: logger}).Command())
 
 	err := rootCmd.Execute()
 	if err != nil {


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR adds a new sub-command `rotate` to `encryption-tink-keyset` to rotate the current keyset. The current keyset is taken as a new config `encryption-tink-keyset`. 

The key rotation will add a new key to the current keyset while making the existing key still available. That is, we can use the new keyset to decrypt what the original keyset encrypted because the original key in the keyset is not disabled or destroyed as a result of the rotation.

### Why

The system administrator might find the need to rotate the current tink keyset periodically.

### Known limitations

This PR let system administrator rotate the tink keyset. However, tink does not has the ability to rotate the remote KMS Key.

To rotate the KMS key, we will have to add a new sub-command to `encryption-tink-keyset`. I plan on calling that `reencrypt`. `reencrypt` will need to take two KMS Key URIs, the original `kms-key-uri` and a new `new-kms-key-uri` to decrypt the keyset and re-encrypt it with the new kms key.

To perform the re-encryption more safely, we can use the aws sdk and use the built-in [Reencrypt](https://docs.aws.amazon.com/sdk-for-go/api/service/kms/#KMS.ReEncrypt) function so that the decrypted keyset is never exposed.

Close #2732
