### PR TITLE
exp/ingest/ledgerbackend: Fix data race in stellar_core_runner. 

### DIFF
--- a/exp/ingest/ledgerbackend/stellar_core_runner_posix.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner_posix.go
@@ -43,12 +43,6 @@ func (c *stellarCoreRunner) start() error {
 		return errors.Wrap(e, "error starting stellar-core")
 	}
 
-	// Launch a goroutine to reap immediately on exit (I think this is right,
-	// as we do not want zombies and we might abruptly forget / kill / close
-	// the process, but I'm not certain).
-	cmd := c.cmd
-	go cmd.Wait()
-
 	c.metaPipe = readFile
 	return nil
 }

--- a/exp/ingest/ledgerbackend/stellar_core_runner_windows.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner_windows.go
@@ -35,12 +35,6 @@ func (c *stellarCoreRunner) start() error {
 		return e
 	}
 
-	// Launch a goroutine to reap immediately on exit (I think this is right,
-	// as we do not want zombies and we might abruptly forget / kill / close
-	// the process, but I'm not certain).
-	cmd := c.cmd
-	go cmd.Wait()
-
 	// Then accept on the server end.
 	connection, e := listener.Accept()
 	if e != nil {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove unnecessary `cmd.Wait` call, fixing a data race.

### Why

This fixes the problem reported here #2738, based on Bartek's comment, we don't need to call Wait in both places since it waits for stdin, stdout, or stderr to complete.

### Known limitations

[TODO or N/A]
