### PR TITLE
exp/ingest/ledgerbackend: Fix ordering of transaction envelopes in TxSet

### DIFF
--- a/exp/ingest/ledgerbackend/hash_order_test.go
+++ b/exp/ingest/ledgerbackend/hash_order_test.go
@@ -1,0 +1,68 @@
+package ledgerbackend
+
+import (
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestHashOrder(t *testing.T) {
+	source := xdr.MustAddress("GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU")
+	account := source.ToMuxedAccount()
+	original := []xdr.TransactionEnvelope{
+		{
+			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+			V1: &xdr.TransactionV1Envelope{
+				Tx: xdr.Transaction{
+					SourceAccount: account,
+					SeqNum:        1,
+				},
+			},
+		},
+		{
+			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+			V1: &xdr.TransactionV1Envelope{
+				Tx: xdr.Transaction{
+					SourceAccount: account,
+					SeqNum:        2,
+				},
+			},
+		},
+		{
+			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+			V1: &xdr.TransactionV1Envelope{
+				Tx: xdr.Transaction{
+					SourceAccount: account,
+					SeqNum:        3,
+				},
+			},
+		},
+	}
+
+	sortByHash(original, network.TestNetworkPassphrase)
+	hashes := map[int]xdr.Hash{}
+
+	for i, tx := range original {
+		var err error
+		hashes[i], err = network.HashTransactionInEnvelope(tx, network.TestNetworkPassphrase)
+		if err != nil {
+			assert.NoError(t, err)
+		}
+	}
+
+	for i := range original {
+		if i == 0 {
+			continue
+		}
+		prev := hashes[i-1]
+		cur := hashes[i]
+		for j := range prev {
+			if !assert.True(t, prev[j] < cur[j]) {
+				break
+			} else {
+				break
+			}
+		}
+	}
+}

--- a/services/horizon/internal/expingest/database_backend_test.go
+++ b/services/horizon/internal/expingest/database_backend_test.go
@@ -1,6 +1,7 @@
 package expingest
 
 import (
+	"github.com/stellar/go/network"
 	"testing"
 
 	"github.com/stellar/go/exp/ingest/ledgerbackend"
@@ -12,7 +13,7 @@ func TestGetLatestLedger(t *testing.T) {
 	tt := test.Start(t).ScenarioWithoutHorizon("base")
 	defer tt.Finish()
 
-	backend, err := ledgerbackend.NewDatabaseBackendFromSession(tt.CoreSession())
+	backend, err := ledgerbackend.NewDatabaseBackendFromSession(tt.CoreSession(), network.TestNetworkPassphrase)
 	tt.Assert.NoError(err)
 	seq, err := backend.GetLatestLedgerSequence()
 	tt.Assert.NoError(err)
@@ -27,7 +28,7 @@ func TestGetLatestLedgerNotFound(t *testing.T) {
 	_, err := tt.CoreDB.Exec(`DELETE FROM ledgerheaders`)
 	tt.Assert.NoError(err, "failed to remove ledgerheaders")
 
-	backend, err := ledgerbackend.NewDatabaseBackendFromSession(q.Session)
+	backend, err := ledgerbackend.NewDatabaseBackendFromSession(q.Session, network.TestNetworkPassphrase)
 	tt.Assert.NoError(err)
 	_, err = backend.GetLatestLedgerSequence()
 	tt.Assert.EqualError(err, "no ledgers exist in ledgerheaders table")

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -145,7 +145,7 @@ func NewSystem(config Config) (*System, error) {
 			[]string{config.HistoryArchiveURL},
 		)
 	} else {
-		ledgerBackend, err = ledgerbackend.NewDatabaseBackendFromSession(coreSession)
+		ledgerBackend, err = ledgerbackend.NewDatabaseBackendFromSession(coreSession, config.NetworkPassphrase)
 		if err != nil {
 			cancel()
 			return nil, errors.Wrap(err, "error creating ledger backend")


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes https://github.com/stellar/go/issues/2721
Stellar core sorts the transaction envelopes in `LedgerCloseMetaV0.TxSet` by hash order. Hash order is defined as lexicographical byte-wise comparison (of the transaction hash) based on https://en.cppreference.com/w/cpp/container/array/operator_cmp where the template parameter T = std::uint8_t 

### Why

The `LedgerCloseMetaV0` value returned by the DatabaseBackend implementation should match the captive core implementation.

### Known limitations

[N/A]
