### PR TITLE
services/horizon: Get historyQ from request, making sure that we use a clone of db.Session.

### DIFF
--- a/services/horizon/internal/actions_path_test.go
+++ b/services/horizon/internal/actions_path_test.go
@@ -1,6 +1,7 @@
 package horizon
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -10,11 +11,13 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/actions"
+	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/paths"
 	horizonProblem "github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/services/horizon/internal/simplepath"
 	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
@@ -25,6 +28,7 @@ func mockPathFindingClient(
 	tt *test.T,
 	finder paths.Finder,
 	maxAssetsParamLength int,
+	session *db.Session,
 ) test.RequestHelper {
 	router := chi.NewRouter()
 	findPaths := FindPathsHandler{
@@ -32,15 +36,24 @@ func mockPathFindingClient(
 		maxAssetsParamLength: maxAssetsParamLength,
 		maxPathLength:        3,
 		setLastLedgerHeader:  true,
-		historyQ:             &history.Q{tt.HorizonSession()},
 	}
 	findFixedPaths := FindFixedPathsHandler{
 		pathFinder:           finder,
 		maxAssetsParamLength: maxAssetsParamLength,
 		maxPathLength:        3,
 		setLastLedgerHeader:  true,
-		historyQ:             &history.Q{tt.HorizonSession()},
 	}
+
+	router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := context.WithValue(
+				r.Context(),
+				&horizonContext.SessionContextKey,
+				session,
+			)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	})
 
 	router.Group(func(r chi.Router) {
 		router.Method("GET", "/paths", findPaths)
@@ -67,6 +80,7 @@ func TestPathActionsStillIngesting(t *testing.T) {
 		tt,
 		&finder,
 		2,
+		tt.HorizonSession(),
 	)
 
 	var q = make(url.Values)
@@ -206,6 +220,7 @@ func TestPathActionsStrictReceive(t *testing.T) {
 		tt,
 		&finder,
 		len(sourceAssets),
+		tt.HorizonSession(),
 	)
 
 	var withSourceAccount = make(url.Values)
@@ -257,6 +272,7 @@ func TestPathActionsEmptySourceAcount(t *testing.T) {
 		tt,
 		&finder,
 		2,
+		tt.HorizonSession(),
 	)
 	var q = make(url.Values)
 
@@ -297,6 +313,7 @@ func TestPathActionsSourceAssetsValidation(t *testing.T) {
 		tt,
 		&finder,
 		2,
+		tt.HorizonSession(),
 	)
 
 	missingSourceAccountAndAssets := make(url.Values)
@@ -376,6 +393,7 @@ func TestPathActionsDestinationAssetsValidation(t *testing.T) {
 		tt,
 		&finder,
 		2,
+		tt.HorizonSession(),
 	)
 	missingDestinationAccountAndAssets := make(url.Values)
 	missingDestinationAccountAndAssets.Add(
@@ -538,6 +556,7 @@ func TestPathActionsStrictSend(t *testing.T) {
 		tt,
 		&finder,
 		len(destinationAssets),
+		tt.HorizonSession(),
 	)
 
 	var q = make(url.Values)

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -179,14 +179,12 @@ func (w *web) mustInstallActions(config Config, pathFinder paths.Finder, session
 			maxPathLength:        config.MaxPathLength,
 			maxAssetsParamLength: maxAssetsForPathFinding,
 			pathFinder:           pathFinder,
-			historyQ:             w.historyQ,
 		}
 		findFixedPaths := FindFixedPathsHandler{
 			maxPathLength:        config.MaxPathLength,
 			setLastLedgerHeader:  true,
 			maxAssetsParamLength: maxAssetsForPathFinding,
 			pathFinder:           pathFinder,
-			historyQ:             w.historyQ,
 		}
 
 		r.Method(http.MethodGet, "/paths", findPaths)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Get `historyQ` from `request`, which clones `db.Session`.

### Why

We noticed the following errors while testing the release candidate: 


```

  | Time | horizon_msg | horizon_level
-- | -- | -- | --
  | June 24th 2020, 22:10:46.238 | failed to load the oldest known ledger state from history DB | error

  | June 24th 2020, 22:10:27.989 | failed to load the latest known ledger state from history DB | error

  | June 24th 2020, 22:10:27.989 | failed to load the latest known ledger's base fee and sequence number | error

  | June 24th 2020, 22:10:26.371 | failed to load ledger capacity usage stats | error

  | June 24th 2020, 22:10:26.369 | failed to load the oldest known exp ledger state from history DB | error

  | June 24th 2020, 22:10:10.988 | failed to load the latest known ledger state from history DB | error

  | June 24th 2020, 22:09:56.854 | failed to load the latest known ledger's base fee and sequence number | error

  | June 24th 2020, 22:09:56.854 | failed to load the latest known ledger state from history DB | error

  | June 24th 2020, 22:09:55.237 | failed to load the latest known ledger's base fee and sequence number | error

  | June 24th 2020, 22:09:55.237 | failed to load the latest known ledger state from history DB | error

  | June 24th 2020, 22:09:50.729 | failed to load the latest known ledger's base fee and sequence number | error

  | June 24th 2020, 22:09:50.729 | failed to load the latest known ledger state from history DB | error

  | June 24th 2020, 22:09:32.239 | failed to load the latest known ledger state from history DB | error

  | June 24th 2020, 17:44:24.137 | failed to load the oldest known exp ledger state from history DB | error

  | June 24th 2020, 17:33:55.408 | failed to load the latest known ledger state from history DB | error

  | June 24th 2020, 17:33:55.408 | failed to load the latest known ledger's base fee and sequence number | error

  | June 24th 2020, 17:32:39.369 | failed to load the oldest known exp ledger state from history DB | error

```

@bartekn pointed out that this could happen when `db.Session` in a transaction is used by multiple go routines.

Upon further investigation we find out that the updates here  https://github.com/stellar/go/pull/2675/files#diff-600af5a51faa4f13ce7d1ed697db07f1R214 could cause such errors.

To avoid this issue from being introduced again in the path finding handlers, I removed `historyQ` from the params and read it from the request which clones the session. This is consistent with how we do it under the new action handling architecture.

### Known limitations

