### PR TITLE
exp/services/recoverysigner: add tests for starting with a rotated keyset

### DIFF
--- a/exp/services/recoverysigner/internal/crypto/crypto_test.go
+++ b/exp/services/recoverysigner/internal/crypto/crypto_test.go
@@ -8,22 +8,22 @@ import (
 )
 
 func TestNewEncrypterDecrypter(t *testing.T) {
-	ksPrivOriginal := generateKeysetCleartext(t, keyTemplateHybridGCM())
-	enc, dec, err := NewEncrypterDecrypter("", ksPrivOriginal)
+	ksPriv1 := generateKeysetCleartext(t, keyTemplateHybridGCM())
+	enc, dec, err := NewEncrypterDecrypter("", ksPriv1)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
 	assert.NotNil(t, dec)
 
 	// add an additional ECIESHKDFAES128GCM Key
-	ksPriv1 := generateRotatedKeysetCleartext(t, ksPrivOriginal, keyTemplateHybridGCM())
-	enc, dec, err = NewEncrypterDecrypter("", ksPriv1)
+	ksPriv2 := generateRotatedKeysetCleartext(t, ksPriv1, keyTemplateHybridGCM())
+	enc, dec, err = NewEncrypterDecrypter("", ksPriv2)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
 	assert.NotNil(t, dec)
 
-	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of a ECIESHKDFAES128GCM Key
-	ksPriv2 := generateRotatedKeysetCleartext(t, ksPrivOriginal, keyTemplateHybridCTRHMACSHA256())
-	enc, dec, err = NewEncrypterDecrypter("", ksPriv2)
+	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of the current ECIESHKDFAES128GCM Key
+	ksPriv3 := generateRotatedKeysetCleartext(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
+	enc, dec, err = NewEncrypterDecrypter("", ksPriv3)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
 	assert.NotNil(t, dec)

--- a/exp/services/recoverysigner/internal/crypto/crypto_test.go
+++ b/exp/services/recoverysigner/internal/crypto/crypto_test.go
@@ -3,26 +3,27 @@ package crypto
 import (
 	"testing"
 
+	"github.com/google/tink/go/hybrid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewEncrypterDecrypter(t *testing.T) {
-	ksPriv1 := generateKeysetCleartext(t, keyTemplateHybridGCM())
+	ksPriv1 := generateKeysetCleartext(t, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	enc, dec, err := NewEncrypterDecrypter("", ksPriv1)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
 	assert.NotNil(t, dec)
 
 	// add an additional ECIESHKDFAES128GCM Key
-	ksPriv2 := rotateKeysetCleartext(t, ksPriv1, keyTemplateHybridGCM())
+	ksPriv2 := rotateKeysetCleartext(t, ksPriv1, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	enc, dec, err = NewEncrypterDecrypter("", ksPriv2)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
 	assert.NotNil(t, dec)
 
 	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of the current ECIESHKDFAES128GCM Key
-	ksPriv3 := rotateKeysetCleartext(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
+	ksPriv3 := rotateKeysetCleartext(t, ksPriv1, hybrid.ECIESHKDFAES128CTRHMACSHA256KeyTemplate())
 	enc, dec, err = NewEncrypterDecrypter("", ksPriv3)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
@@ -30,7 +31,7 @@ func TestNewEncrypterDecrypter(t *testing.T) {
 }
 
 func TestNewEncrypterDecrypter_invalidKMSKeyURI(t *testing.T) {
-	ksPriv := generateKeysetCleartext(t, keyTemplateHybridGCM())
+	ksPriv := generateKeysetCleartext(t, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 
 	// URI with a valid prefix but bad invalid identifier
 	enc, dec, err := NewEncrypterDecrypter("aws-kms://invalid-key-arn", ksPriv)

--- a/exp/services/recoverysigner/internal/crypto/crypto_test.go
+++ b/exp/services/recoverysigner/internal/crypto/crypto_test.go
@@ -8,14 +8,22 @@ import (
 )
 
 func TestNewEncrypterDecrypter(t *testing.T) {
-	ksPriv := generateKeysetCleartext(t, keyTemplateHybridGCM())
-	enc, dec, err := NewEncrypterDecrypter("", ksPriv)
+	ksPrivOriginal := generateKeysetCleartext(t, keyTemplateHybridGCM())
+	enc, dec, err := NewEncrypterDecrypter("", ksPrivOriginal)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
 	assert.NotNil(t, dec)
 
-	ksPriv = generateRotatedKeysetCleartext(t, ksPriv, keyTemplateHybridGCM())
-	enc, dec, err = NewEncrypterDecrypter("", ksPriv)
+	// add an additional ECIESHKDFAES128GCM Key
+	ksPriv1 := generateRotatedKeysetCleartext(t, ksPrivOriginal, keyTemplateHybridGCM())
+	enc, dec, err = NewEncrypterDecrypter("", ksPriv1)
+	require.NoError(t, err)
+	assert.NotNil(t, enc)
+	assert.NotNil(t, dec)
+
+	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of a ECIESHKDFAES128GCM Key
+	ksPriv2 := generateRotatedKeysetCleartext(t, ksPrivOriginal, keyTemplateHybridCTRHMACSHA256())
+	enc, dec, err = NewEncrypterDecrypter("", ksPriv2)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
 	assert.NotNil(t, dec)

--- a/exp/services/recoverysigner/internal/crypto/crypto_test.go
+++ b/exp/services/recoverysigner/internal/crypto/crypto_test.go
@@ -15,14 +15,14 @@ func TestNewEncrypterDecrypter(t *testing.T) {
 	assert.NotNil(t, dec)
 
 	// add an additional ECIESHKDFAES128GCM Key
-	ksPriv2 := generateRotatedKeysetCleartext(t, ksPriv1, keyTemplateHybridGCM())
+	ksPriv2 := rotateKeysetCleartext(t, ksPriv1, keyTemplateHybridGCM())
 	enc, dec, err = NewEncrypterDecrypter("", ksPriv2)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
 	assert.NotNil(t, dec)
 
 	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of the current ECIESHKDFAES128GCM Key
-	ksPriv3 := generateRotatedKeysetCleartext(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
+	ksPriv3 := rotateKeysetCleartext(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
 	enc, dec, err = NewEncrypterDecrypter("", ksPriv3)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)

--- a/exp/services/recoverysigner/internal/crypto/crypto_test.go
+++ b/exp/services/recoverysigner/internal/crypto/crypto_test.go
@@ -8,15 +8,21 @@ import (
 )
 
 func TestNewEncrypterDecrypter(t *testing.T) {
-	ksPriv := generateHybridKeysetCleartext(t)
+	ksPriv := generateKeysetCleartext(t, keyTemplateHybridGCM())
 	enc, dec, err := NewEncrypterDecrypter("", ksPriv)
+	require.NoError(t, err)
+	assert.NotNil(t, enc)
+	assert.NotNil(t, dec)
+
+	ksPriv = generateRotatedKeysetCleartext(t, ksPriv, keyTemplateHybridGCM())
+	enc, dec, err = NewEncrypterDecrypter("", ksPriv)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
 	assert.NotNil(t, dec)
 }
 
 func TestNewEncrypterDecrypter_invalidKMSKeyURI(t *testing.T) {
-	ksPriv := generateHybridKeysetCleartext(t)
+	ksPriv := generateKeysetCleartext(t, keyTemplateHybridGCM())
 
 	// URI with a valid prefix but bad invalid identifier
 	enc, dec, err := NewEncrypterDecrypter("aws-kms://invalid-key-arn", ksPriv)

--- a/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_insecure_test.go
+++ b/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_insecure_test.go
@@ -3,12 +3,13 @@ package crypto
 import (
 	"testing"
 
+	"github.com/google/tink/go/hybrid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewInsecureEncrypterDecrypter(t *testing.T) {
-	ksPriv := generateKeysetCleartext(t, keyTemplateHybridGCM())
+	ksPriv := generateKeysetCleartext(t, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	enc, dec, err := newInsecureEncrypterDecrypter(ksPriv)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
@@ -21,7 +22,7 @@ func TestNewInsecureEncrypterDecrypter(t *testing.T) {
 	assert.Nil(t, dec)
 
 	// encrypted keyset is preset
-	ksPrivEncrypted := generateKeysetEncrypted(t, keyTemplateHybridGCM())
+	ksPrivEncrypted := generateKeysetEncrypted(t, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	enc, dec, err = newInsecureEncrypterDecrypter(ksPrivEncrypted)
 	assert.Error(t, err)
 	assert.Nil(t, enc)
@@ -29,7 +30,7 @@ func TestNewInsecureEncrypterDecrypter(t *testing.T) {
 }
 
 func TestInsecureEncrypterDecrypter_encryptDecrypt(t *testing.T) {
-	ksPriv := generateKeysetCleartext(t, keyTemplateHybridGCM())
+	ksPriv := generateKeysetCleartext(t, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	enc, dec, err := newInsecureEncrypterDecrypter(ksPriv)
 	require.NoError(t, err)
 
@@ -48,17 +49,17 @@ func TestInsecureEncrypterDecrypter_encryptDecrypt(t *testing.T) {
 }
 
 func TestNewInsecureEncrypterDecrypter_rotatedKeyset(t *testing.T) {
-	ksPriv1 := generateKeysetCleartext(t, keyTemplateHybridGCM())
+	ksPriv1 := generateKeysetCleartext(t, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 
 	// add an additional ECIESHKDFAES128GCM Key
-	ksPriv2 := rotateKeysetCleartext(t, ksPriv1, keyTemplateHybridGCM())
+	ksPriv2 := rotateKeysetCleartext(t, ksPriv1, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	enc, dec, err := newInsecureEncrypterDecrypter(ksPriv2)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
 	assert.NotNil(t, dec)
 
 	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of the current ECIESHKDFAES128GCM Key
-	ksPriv3 := rotateKeysetCleartext(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
+	ksPriv3 := rotateKeysetCleartext(t, ksPriv1, hybrid.ECIESHKDFAES128CTRHMACSHA256KeyTemplate())
 	enc, dec, err = newInsecureEncrypterDecrypter(ksPriv3)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
@@ -66,12 +67,12 @@ func TestNewInsecureEncrypterDecrypter_rotatedKeyset(t *testing.T) {
 }
 
 func TestInsecureEncrypterDecrypter_rotatedKeysetEncryptDecrypt(t *testing.T) {
-	ksPriv1 := generateKeysetCleartext(t, keyTemplateHybridGCM())
+	ksPriv1 := generateKeysetCleartext(t, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	enc1, dec1, err := newInsecureEncrypterDecrypter(ksPriv1)
 	require.NoError(t, err)
 
 	// add an additional ECIESHKDFAES128GCM Key
-	ksPriv2 := rotateKeysetCleartext(t, ksPriv1, keyTemplateHybridGCM())
+	ksPriv2 := rotateKeysetCleartext(t, ksPriv1, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	enc2, dec2, err := newInsecureEncrypterDecrypter(ksPriv2)
 	require.NoError(t, err)
 
@@ -111,12 +112,12 @@ func TestInsecureEncrypterDecrypter_rotatedKeysetEncryptDecrypt(t *testing.T) {
 }
 
 func TestInsecureEncrypterDecrypter_rotatedKeysetMixedKeysEncryptDecrypt(t *testing.T) {
-	ksPriv1 := generateKeysetCleartext(t, keyTemplateHybridGCM())
+	ksPriv1 := generateKeysetCleartext(t, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	enc1, dec1, err := newInsecureEncrypterDecrypter(ksPriv1)
 	require.NoError(t, err)
 
 	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of the current ECIESHKDFAES128GCM Key
-	ksPriv2 := rotateKeysetCleartext(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
+	ksPriv2 := rotateKeysetCleartext(t, ksPriv1, hybrid.ECIESHKDFAES128CTRHMACSHA256KeyTemplate())
 	enc2, dec2, err := newInsecureEncrypterDecrypter(ksPriv2)
 	require.NoError(t, err)
 

--- a/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_insecure_test.go
+++ b/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_insecure_test.go
@@ -46,3 +46,111 @@ func TestInsecureEncrypterDecrypter_encryptDecrypt(t *testing.T) {
 	_, err = dec.Decrypt(ciphertext, []byte("wrong info"))
 	assert.Error(t, err)
 }
+
+func TestNewInsecureEncrypterDecrypter_rotatedKeyset(t *testing.T) {
+	ksPriv1 := generateKeysetCleartext(t, keyTemplateHybridGCM())
+
+	// add an additional ECIESHKDFAES128GCM Key
+	ksPriv2 := generateRotatedKeysetCleartext(t, ksPriv1, keyTemplateHybridGCM())
+	enc, dec, err := newInsecureEncrypterDecrypter(ksPriv2)
+	require.NoError(t, err)
+	assert.NotNil(t, enc)
+	assert.NotNil(t, dec)
+
+	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of the current ECIESHKDFAES128GCM Key
+	ksPriv3 := generateRotatedKeysetCleartext(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
+	enc, dec, err = newInsecureEncrypterDecrypter(ksPriv3)
+	require.NoError(t, err)
+	assert.NotNil(t, enc)
+	assert.NotNil(t, dec)
+}
+
+func TestInsecureEncrypterDecrypter_rotatedKeysetEncryptDecrypt(t *testing.T) {
+	ksPriv1 := generateKeysetCleartext(t, keyTemplateHybridGCM())
+	enc1, dec1, err := newInsecureEncrypterDecrypter(ksPriv1)
+	require.NoError(t, err)
+
+	// add an additional ECIESHKDFAES128GCM Key
+	ksPriv2 := generateRotatedKeysetCleartext(t, ksPriv1, keyTemplateHybridGCM())
+	enc2, dec2, err := newInsecureEncrypterDecrypter(ksPriv2)
+	require.NoError(t, err)
+
+	plaintext := []byte("secure message")
+	contextInfo := []byte("context info")
+
+	// verify that the new keyset private is able to decrypt what the new keyset public encrypts
+	ciphertext, err := enc2.Encrypt(plaintext, contextInfo)
+	require.NoError(t, err)
+
+	plaintext2, err := dec2.Decrypt(ciphertext, contextInfo)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, plaintext2)
+
+	// context info not matching will result in a failed decryption
+	_, err = dec2.Decrypt(ciphertext, []byte("wrong info"))
+	assert.Error(t, err)
+
+	// verify that the new keyset is able to decrypt what the old keyset encrypts
+	ciphertext, err = enc1.Encrypt(plaintext, contextInfo)
+	require.NoError(t, err)
+
+	plaintext2, err = dec2.Decrypt(ciphertext, contextInfo)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, plaintext2)
+
+	// context info not matching will still result in a failed decryption
+	_, err = dec2.Decrypt(ciphertext, []byte("wrong info"))
+	assert.Error(t, err)
+
+	// verify that the old keyset is not able to decrypt what the new keyset encrypts
+	ciphertext, err = enc2.Encrypt(plaintext, contextInfo)
+	require.NoError(t, err)
+
+	_, err = dec1.Decrypt(ciphertext, contextInfo)
+	assert.Error(t, err)
+}
+
+func TestInsecureEncrypterDecrypter_rotatedKeysetMixedKeysEncryptDecrypt(t *testing.T) {
+	ksPriv1 := generateKeysetCleartext(t, keyTemplateHybridGCM())
+	enc1, dec1, err := newInsecureEncrypterDecrypter(ksPriv1)
+	require.NoError(t, err)
+
+	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of the current ECIESHKDFAES128GCM Key
+	ksPriv2 := generateRotatedKeysetCleartext(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
+	enc2, dec2, err := newInsecureEncrypterDecrypter(ksPriv2)
+	require.NoError(t, err)
+
+	plaintext := []byte("secure message")
+	contextInfo := []byte("context info")
+
+	// verify that the new keyset private is able to decrypt what the new keyset public encrypts
+	ciphertext, err := enc2.Encrypt(plaintext, contextInfo)
+	require.NoError(t, err)
+
+	plaintext2, err := dec2.Decrypt(ciphertext, contextInfo)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, plaintext2)
+
+	// context info not matching will result in a failed decryption
+	_, err = dec2.Decrypt(ciphertext, []byte("wrong info"))
+	assert.Error(t, err)
+
+	// verify that the new keyset is able to decrypt what the old keyset encrypts
+	ciphertext, err = enc1.Encrypt(plaintext, contextInfo)
+	require.NoError(t, err)
+
+	plaintext2, err = dec2.Decrypt(ciphertext, contextInfo)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, plaintext2)
+
+	// context info not matching will still result in a failed decryption
+	_, err = dec2.Decrypt(ciphertext, []byte("wrong info"))
+	assert.Error(t, err)
+
+	// verify that the old keyset is not able to decrypt what the new keyset encrypts
+	ciphertext, err = enc2.Encrypt(plaintext, contextInfo)
+	require.NoError(t, err)
+
+	_, err = dec1.Decrypt(ciphertext, contextInfo)
+	assert.Error(t, err)
+}

--- a/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_insecure_test.go
+++ b/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_insecure_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNewInsecureEncrypterDecrypter(t *testing.T) {
-	ksPriv := generateHybridKeysetCleartext(t)
+	ksPriv := generateKeysetCleartext(t, keyTemplateHybridGCM())
 	enc, dec, err := newInsecureEncrypterDecrypter(ksPriv)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
@@ -21,7 +21,7 @@ func TestNewInsecureEncrypterDecrypter(t *testing.T) {
 	assert.Nil(t, dec)
 
 	// encrypted keyset is preset
-	ksPrivEncrypted := generateHybridKeysetEncrypted(t)
+	ksPrivEncrypted := generateKeysetEncrypted(t, keyTemplateHybridGCM())
 	enc, dec, err = newInsecureEncrypterDecrypter(ksPrivEncrypted)
 	assert.Error(t, err)
 	assert.Nil(t, enc)
@@ -29,7 +29,7 @@ func TestNewInsecureEncrypterDecrypter(t *testing.T) {
 }
 
 func TestInsecureEncrypterDecrypter_encryptDecrypt(t *testing.T) {
-	ksPriv := generateHybridKeysetCleartext(t)
+	ksPriv := generateKeysetCleartext(t, keyTemplateHybridGCM())
 	enc, dec, err := newInsecureEncrypterDecrypter(ksPriv)
 	require.NoError(t, err)
 

--- a/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_insecure_test.go
+++ b/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_insecure_test.go
@@ -51,14 +51,14 @@ func TestNewInsecureEncrypterDecrypter_rotatedKeyset(t *testing.T) {
 	ksPriv1 := generateKeysetCleartext(t, keyTemplateHybridGCM())
 
 	// add an additional ECIESHKDFAES128GCM Key
-	ksPriv2 := generateRotatedKeysetCleartext(t, ksPriv1, keyTemplateHybridGCM())
+	ksPriv2 := rotateKeysetCleartext(t, ksPriv1, keyTemplateHybridGCM())
 	enc, dec, err := newInsecureEncrypterDecrypter(ksPriv2)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
 	assert.NotNil(t, dec)
 
 	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of the current ECIESHKDFAES128GCM Key
-	ksPriv3 := generateRotatedKeysetCleartext(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
+	ksPriv3 := rotateKeysetCleartext(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
 	enc, dec, err = newInsecureEncrypterDecrypter(ksPriv3)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
@@ -71,7 +71,7 @@ func TestInsecureEncrypterDecrypter_rotatedKeysetEncryptDecrypt(t *testing.T) {
 	require.NoError(t, err)
 
 	// add an additional ECIESHKDFAES128GCM Key
-	ksPriv2 := generateRotatedKeysetCleartext(t, ksPriv1, keyTemplateHybridGCM())
+	ksPriv2 := rotateKeysetCleartext(t, ksPriv1, keyTemplateHybridGCM())
 	enc2, dec2, err := newInsecureEncrypterDecrypter(ksPriv2)
 	require.NoError(t, err)
 
@@ -116,7 +116,7 @@ func TestInsecureEncrypterDecrypter_rotatedKeysetMixedKeysEncryptDecrypt(t *test
 	require.NoError(t, err)
 
 	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of the current ECIESHKDFAES128GCM Key
-	ksPriv2 := generateRotatedKeysetCleartext(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
+	ksPriv2 := rotateKeysetCleartext(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
 	enc2, dec2, err := newInsecureEncrypterDecrypter(ksPriv2)
 	require.NoError(t, err)
 

--- a/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_secure_test.go
+++ b/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_secure_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNewSecureEncrypterDecrypter(t *testing.T) {
-	ksPriv := generateHybridKeysetEncrypted(t)
+	ksPriv := generateKeysetEncrypted(t, keyTemplateHybridGCM())
 	enc, dec, err := newSecureEncrypterDecrypter(mockKMSClient{}, "aws-kms://key-uri", ksPriv)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
@@ -21,7 +21,7 @@ func TestNewSecureEncrypterDecrypter(t *testing.T) {
 }
 
 func TestSecureEncrypterDecrypter_encryptDecrypt(t *testing.T) {
-	ksPriv := generateHybridKeysetEncrypted(t)
+	ksPriv := generateKeysetEncrypted(t, keyTemplateHybridGCM())
 	enc, dec, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv)
 	require.NoError(t, err)
 

--- a/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_secure_test.go
+++ b/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_secure_test.go
@@ -44,14 +44,14 @@ func TestNewSecureEncrypterDecrypter_rotatedKeyset(t *testing.T) {
 	ksPriv1 := generateKeysetEncrypted(t, keyTemplateHybridGCM())
 
 	// add an additional ECIESHKDFAES128GCM Key
-	ksPriv2 := generateRotatedKeysetEncrypted(t, ksPriv1, keyTemplateHybridGCM())
+	ksPriv2 := rotateKeysetEncrypted(t, ksPriv1, keyTemplateHybridGCM())
 	enc, dec, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv2)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
 	assert.NotNil(t, dec)
 
 	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of the current ECIESHKDFAES128GCM Key
-	ksPriv3 := generateRotatedKeysetEncrypted(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
+	ksPriv3 := rotateKeysetEncrypted(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
 	enc, dec, err = newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv3)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
@@ -64,7 +64,7 @@ func TestSecureEncrypterDecrypter_rotatedKeysetEncryptDecrypt(t *testing.T) {
 	require.NoError(t, err)
 
 	// add an additional ECIESHKDFAES128GCM Key
-	ksPriv2 := generateRotatedKeysetEncrypted(t, ksPriv1, keyTemplateHybridGCM())
+	ksPriv2 := rotateKeysetEncrypted(t, ksPriv1, keyTemplateHybridGCM())
 	enc2, dec2, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv2)
 	require.NoError(t, err)
 
@@ -109,7 +109,7 @@ func TestSecureEncrypterDecrypter_rotatedKeysetMixedKeysEncryptDecrypt(t *testin
 	require.NoError(t, err)
 
 	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of the current ECIESHKDFAES128GCM Key
-	ksPriv2 := generateRotatedKeysetEncrypted(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
+	ksPriv2 := rotateKeysetEncrypted(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
 	enc2, dec2, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv2)
 	require.NoError(t, err)
 

--- a/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_secure_test.go
+++ b/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_secure_test.go
@@ -3,12 +3,13 @@ package crypto
 import (
 	"testing"
 
+	"github.com/google/tink/go/hybrid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewSecureEncrypterDecrypter(t *testing.T) {
-	ksPriv := generateKeysetEncrypted(t, keyTemplateHybridGCM())
+	ksPriv := generateKeysetEncrypted(t, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	enc, dec, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
@@ -22,7 +23,7 @@ func TestNewSecureEncrypterDecrypter(t *testing.T) {
 }
 
 func TestSecureEncrypterDecrypter_encryptDecrypt(t *testing.T) {
-	ksPriv := generateKeysetEncrypted(t, keyTemplateHybridGCM())
+	ksPriv := generateKeysetEncrypted(t, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	enc, dec, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv)
 	require.NoError(t, err)
 
@@ -41,17 +42,17 @@ func TestSecureEncrypterDecrypter_encryptDecrypt(t *testing.T) {
 }
 
 func TestNewSecureEncrypterDecrypter_rotatedKeyset(t *testing.T) {
-	ksPriv1 := generateKeysetEncrypted(t, keyTemplateHybridGCM())
+	ksPriv1 := generateKeysetEncrypted(t, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 
 	// add an additional ECIESHKDFAES128GCM Key
-	ksPriv2 := rotateKeysetEncrypted(t, ksPriv1, keyTemplateHybridGCM())
+	ksPriv2 := rotateKeysetEncrypted(t, ksPriv1, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	enc, dec, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv2)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
 	assert.NotNil(t, dec)
 
 	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of the current ECIESHKDFAES128GCM Key
-	ksPriv3 := rotateKeysetEncrypted(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
+	ksPriv3 := rotateKeysetEncrypted(t, ksPriv1, hybrid.ECIESHKDFAES128CTRHMACSHA256KeyTemplate())
 	enc, dec, err = newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv3)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
@@ -59,12 +60,12 @@ func TestNewSecureEncrypterDecrypter_rotatedKeyset(t *testing.T) {
 }
 
 func TestSecureEncrypterDecrypter_rotatedKeysetEncryptDecrypt(t *testing.T) {
-	ksPriv1 := generateKeysetEncrypted(t, keyTemplateHybridGCM())
+	ksPriv1 := generateKeysetEncrypted(t, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	enc1, dec1, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv1)
 	require.NoError(t, err)
 
 	// add an additional ECIESHKDFAES128GCM Key
-	ksPriv2 := rotateKeysetEncrypted(t, ksPriv1, keyTemplateHybridGCM())
+	ksPriv2 := rotateKeysetEncrypted(t, ksPriv1, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	enc2, dec2, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv2)
 	require.NoError(t, err)
 
@@ -104,12 +105,12 @@ func TestSecureEncrypterDecrypter_rotatedKeysetEncryptDecrypt(t *testing.T) {
 }
 
 func TestSecureEncrypterDecrypter_rotatedKeysetMixedKeysEncryptDecrypt(t *testing.T) {
-	ksPriv1 := generateKeysetEncrypted(t, keyTemplateHybridGCM())
+	ksPriv1 := generateKeysetEncrypted(t, hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	enc1, dec1, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv1)
 	require.NoError(t, err)
 
 	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of the current ECIESHKDFAES128GCM Key
-	ksPriv2 := rotateKeysetEncrypted(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
+	ksPriv2 := rotateKeysetEncrypted(t, ksPriv1, hybrid.ECIESHKDFAES128CTRHMACSHA256KeyTemplate())
 	enc2, dec2, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv2)
 	require.NoError(t, err)
 

--- a/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_secure_test.go
+++ b/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_secure_test.go
@@ -9,13 +9,14 @@ import (
 
 func TestNewSecureEncrypterDecrypter(t *testing.T) {
 	ksPriv := generateKeysetEncrypted(t, keyTemplateHybridGCM())
-	enc, dec, err := newSecureEncrypterDecrypter(mockKMSClient{}, "aws-kms://key-uri", ksPriv)
+	enc, dec, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv)
 	require.NoError(t, err)
 	assert.NotNil(t, enc)
 	assert.NotNil(t, dec)
 
 	enc, dec, err = newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", "")
-	assert.Error(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading encrypted keyset")
 	assert.Nil(t, enc)
 	assert.Nil(t, dec)
 }
@@ -36,5 +37,113 @@ func TestSecureEncrypterDecrypter_encryptDecrypt(t *testing.T) {
 
 	// context info not matching will result in a failed decryption
 	_, err = dec.Decrypt(ciphertext, []byte("wrong info"))
+	assert.Error(t, err)
+}
+
+func TestNewSecureEncrypterDecrypter_rotatedKeyset(t *testing.T) {
+	ksPriv1 := generateKeysetEncrypted(t, keyTemplateHybridGCM())
+
+	// add an additional ECIESHKDFAES128GCM Key
+	ksPriv2 := generateRotatedKeysetEncrypted(t, ksPriv1, keyTemplateHybridGCM())
+	enc, dec, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv2)
+	require.NoError(t, err)
+	assert.NotNil(t, enc)
+	assert.NotNil(t, dec)
+
+	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of the current ECIESHKDFAES128GCM Key
+	ksPriv3 := generateRotatedKeysetEncrypted(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
+	enc, dec, err = newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv3)
+	require.NoError(t, err)
+	assert.NotNil(t, enc)
+	assert.NotNil(t, dec)
+}
+
+func TestSecureEncrypterDecrypter_rotatedKeysetEncryptDecrypt(t *testing.T) {
+	ksPriv1 := generateKeysetEncrypted(t, keyTemplateHybridGCM())
+	enc1, dec1, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv1)
+	require.NoError(t, err)
+
+	// add an additional ECIESHKDFAES128GCM Key
+	ksPriv2 := generateRotatedKeysetEncrypted(t, ksPriv1, keyTemplateHybridGCM())
+	enc2, dec2, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv2)
+	require.NoError(t, err)
+
+	plaintext := []byte("secure message")
+	contextInfo := []byte("context info")
+
+	// verify that the new keyset private is able to decrypt what the new keyset public encrypts
+	ciphertext, err := enc2.Encrypt(plaintext, contextInfo)
+	require.NoError(t, err)
+
+	plaintext2, err := dec2.Decrypt(ciphertext, contextInfo)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, plaintext2)
+
+	// context info not matching will result in a failed decryption
+	_, err = dec2.Decrypt(ciphertext, []byte("wrong info"))
+	assert.Error(t, err)
+
+	// verify that the new keyset is able to decrypt what the old keyset encrypts
+	ciphertext, err = enc1.Encrypt(plaintext, contextInfo)
+	require.NoError(t, err)
+
+	plaintext2, err = dec2.Decrypt(ciphertext, contextInfo)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, plaintext2)
+
+	// context info not matching will still result in a failed decryption
+	_, err = dec2.Decrypt(ciphertext, []byte("wrong info"))
+	assert.Error(t, err)
+
+	// verify that the old keyset is not able to decrypt what the new keyset encrypts
+	ciphertext, err = enc2.Encrypt(plaintext, contextInfo)
+	require.NoError(t, err)
+
+	_, err = dec1.Decrypt(ciphertext, contextInfo)
+	assert.Error(t, err)
+}
+
+func TestSecureEncrypterDecrypter_rotatedKeysetMixedKeysEncryptDecrypt(t *testing.T) {
+	ksPriv1 := generateKeysetEncrypted(t, keyTemplateHybridGCM())
+	enc1, dec1, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv1)
+	require.NoError(t, err)
+
+	// add a new ECIESHKDFAES128CTRHMACSHA256 Key on top of the current ECIESHKDFAES128GCM Key
+	ksPriv2 := generateRotatedKeysetEncrypted(t, ksPriv1, keyTemplateHybridCTRHMACSHA256())
+	enc2, dec2, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv2)
+	require.NoError(t, err)
+
+	plaintext := []byte("secure message")
+	contextInfo := []byte("context info")
+
+	// verify that the new keyset private is able to decrypt what the new keyset public encrypts
+	ciphertext, err := enc2.Encrypt(plaintext, contextInfo)
+	require.NoError(t, err)
+
+	plaintext2, err := dec2.Decrypt(ciphertext, contextInfo)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, plaintext2)
+
+	// context info not matching will result in a failed decryption
+	_, err = dec2.Decrypt(ciphertext, []byte("wrong info"))
+	assert.Error(t, err)
+
+	// verify that the new keyset is able to decrypt what the old keyset encrypts
+	ciphertext, err = enc1.Encrypt(plaintext, contextInfo)
+	require.NoError(t, err)
+
+	plaintext2, err = dec2.Decrypt(ciphertext, contextInfo)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, plaintext2)
+
+	// context info not matching will still result in a failed decryption
+	_, err = dec2.Decrypt(ciphertext, []byte("wrong info"))
+	assert.Error(t, err)
+
+	// verify that the old keyset is not able to decrypt what the new keyset encrypts
+	ciphertext, err = enc2.Encrypt(plaintext, contextInfo)
+	require.NoError(t, err)
+
+	_, err = dec1.Decrypt(ciphertext, contextInfo)
 	assert.Error(t, err)
 }

--- a/exp/services/recoverysigner/internal/crypto/keygen_test.go
+++ b/exp/services/recoverysigner/internal/crypto/keygen_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/tink/go/hybrid"
 	"github.com/google/tink/go/insecurecleartextkeyset"
 	"github.com/google/tink/go/keyset"
 	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
@@ -67,12 +66,4 @@ func rotateKeysetEncrypted(t *testing.T, keysetEncryptedJSON string, keyTemplate
 	require.NoError(t, err)
 
 	return keysetPrivateEncrypted.String()
-}
-
-func keyTemplateHybridGCM() *tinkpb.KeyTemplate {
-	return hybrid.ECIESHKDFAES128GCMKeyTemplate()
-}
-
-func keyTemplateHybridCTRHMACSHA256() *tinkpb.KeyTemplate {
-	return hybrid.ECIESHKDFAES128CTRHMACSHA256KeyTemplate()
 }

--- a/exp/services/recoverysigner/internal/crypto/keygen_test.go
+++ b/exp/services/recoverysigner/internal/crypto/keygen_test.go
@@ -33,7 +33,7 @@ func generateKeysetEncrypted(t *testing.T, keyTemplate *tinkpb.KeyTemplate) stri
 	return keysetPrivateEncrypted.String()
 }
 
-func generateRotatedKeysetCleartext(t *testing.T, keysetCleartextJSON string, keyTemplate *tinkpb.KeyTemplate) string {
+func rotateKeysetCleartext(t *testing.T, keysetCleartextJSON string, keyTemplate *tinkpb.KeyTemplate) string {
 	khPriv, err := insecurecleartextkeyset.Read(keyset.NewJSONReader(strings.NewReader(keysetCleartextJSON)))
 	require.NoError(t, err)
 
@@ -51,7 +51,7 @@ func generateRotatedKeysetCleartext(t *testing.T, keysetCleartextJSON string, ke
 	return keysetPrivateCleartext.String()
 }
 
-func generateRotatedKeysetEncrypted(t *testing.T, keysetEncryptedJSON string, keyTemplate *tinkpb.KeyTemplate) string {
+func rotateKeysetEncrypted(t *testing.T, keysetEncryptedJSON string, keyTemplate *tinkpb.KeyTemplate) string {
 	khPriv, err := keyset.Read(keyset.NewJSONReader(strings.NewReader(keysetEncryptedJSON)), mockAEAD{})
 	require.NoError(t, err)
 

--- a/exp/services/recoverysigner/internal/crypto/keygen_test.go
+++ b/exp/services/recoverysigner/internal/crypto/keygen_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/google/tink/go/hybrid"
 	"github.com/google/tink/go/insecurecleartextkeyset"
 	"github.com/google/tink/go/keyset"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
 	"github.com/stretchr/testify/require"
 )
 
-func generateHybridKeysetCleartext(t *testing.T) string {
-	khPriv, err := keyset.NewHandle(hybrid.ECIESHKDFAES128CTRHMACSHA256KeyTemplate())
+func generateKeysetCleartext(t *testing.T, keyTemplate *tinkpb.KeyTemplate) string {
+	khPriv, err := keyset.NewHandle(keyTemplate)
 	require.NoError(t, err)
 
 	keysetPrivateCleartext := strings.Builder{}
@@ -21,8 +22,8 @@ func generateHybridKeysetCleartext(t *testing.T) string {
 	return keysetPrivateCleartext.String()
 }
 
-func generateHybridKeysetEncrypted(t *testing.T) string {
-	khPriv, err := keyset.NewHandle(hybrid.ECIESHKDFAES128CTRHMACSHA256KeyTemplate())
+func generateKeysetEncrypted(t *testing.T, keyTemplate *tinkpb.KeyTemplate) string {
+	khPriv, err := keyset.NewHandle(keyTemplate)
 	require.NoError(t, err)
 
 	keysetPrivateEncrypted := strings.Builder{}
@@ -30,4 +31,26 @@ func generateHybridKeysetEncrypted(t *testing.T) string {
 	require.NoError(t, err)
 
 	return keysetPrivateEncrypted.String()
+}
+
+func generateRotatedKeysetCleartext(t *testing.T, keysetCleartextJSON string, keyTemplate *tinkpb.KeyTemplate) string {
+	khPriv, err := insecurecleartextkeyset.Read(keyset.NewJSONReader(strings.NewReader(keysetCleartextJSON)))
+	require.NoError(t, err)
+
+	m := keyset.NewManagerFromHandle(khPriv)
+	err = m.Rotate(keyTemplate)
+	require.NoError(t, err)
+
+	khPriv, err = m.Handle()
+	require.NoError(t, err)
+
+	keysetPrivateCleartext := strings.Builder{}
+	err = insecurecleartextkeyset.Write(khPriv, keyset.NewJSONWriter(&keysetPrivateCleartext))
+	require.NoError(t, err)
+
+	return keysetPrivateCleartext.String()
+}
+
+func keyTemplateHybridGCM() *tinkpb.KeyTemplate {
+	return hybrid.ECIESHKDFAES128GCMKeyTemplate()
 }

--- a/exp/services/recoverysigner/internal/crypto/keygen_test.go
+++ b/exp/services/recoverysigner/internal/crypto/keygen_test.go
@@ -51,6 +51,24 @@ func generateRotatedKeysetCleartext(t *testing.T, keysetCleartextJSON string, ke
 	return keysetPrivateCleartext.String()
 }
 
+func generateRotatedKeysetEncrypted(t *testing.T, keysetEncryptedJSON string, keyTemplate *tinkpb.KeyTemplate) string {
+	khPriv, err := keyset.Read(keyset.NewJSONReader(strings.NewReader(keysetEncryptedJSON)), mockAEAD{})
+	require.NoError(t, err)
+
+	m := keyset.NewManagerFromHandle(khPriv)
+	err = m.Rotate(keyTemplate)
+	require.NoError(t, err)
+
+	khPriv, err = m.Handle()
+	require.NoError(t, err)
+
+	keysetPrivateEncrypted := strings.Builder{}
+	err = khPriv.Write(keyset.NewJSONWriter(&keysetPrivateEncrypted), mockAEAD{})
+	require.NoError(t, err)
+
+	return keysetPrivateEncrypted.String()
+}
+
 func keyTemplateHybridGCM() *tinkpb.KeyTemplate {
 	return hybrid.ECIESHKDFAES128GCMKeyTemplate()
 }

--- a/exp/services/recoverysigner/internal/crypto/keygen_test.go
+++ b/exp/services/recoverysigner/internal/crypto/keygen_test.go
@@ -54,3 +54,7 @@ func generateRotatedKeysetCleartext(t *testing.T, keysetCleartextJSON string, ke
 func keyTemplateHybridGCM() *tinkpb.KeyTemplate {
 	return hybrid.ECIESHKDFAES128GCMKeyTemplate()
 }
+
+func keyTemplateHybridCTRHMACSHA256() *tinkpb.KeyTemplate {
+	return hybrid.ECIESHKDFAES128CTRHMACSHA256KeyTemplate()
+}


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR adds tests to make sure that the system is able to be booted with a keyset that has been rotated, is able to do encryption and decryption correctly, even if the keyset contains the keys from different tink hybrid encryption templates.

This can reassure us that if we decide to switch to `ECIESHKDFAES128CTRHMACSHA256KeyTemplate`, the system will continue to work and is backward compatible.

This PR does a little refactoring to our test helper functions used to generate tink keyset to make it more versatile.

### Why

See above.

### Known limitations

N/A
