### PR TITLE
services/horizon/internal: Fix data race in root endpoint

### DIFF
--- a/services/horizon/internal/actions_root.go
+++ b/services/horizon/internal/actions_root.go
@@ -26,15 +26,16 @@ func (action *RootAction) JSON() error {
 		"strictReceivePaths": StrictReceivePathsQuery{}.URITemplate(),
 		"strictSendPaths":    FindFixedPathsQuery{}.URITemplate(),
 	}
+	coreInfo := action.App.coreSettings.get()
 	resourceadapter.PopulateRoot(
 		action.R.Context(),
 		&res,
 		ledger.CurrentState(),
 		action.App.horizonVersion,
-		action.App.coreVersion,
+		coreInfo.coreVersion,
 		action.App.config.NetworkPassphrase,
-		action.App.currentProtocolVersion,
-		action.App.coreSupportedProtocolVersion,
+		coreInfo.currentProtocolVersion,
+		coreInfo.coreSupportedProtocolVersion,
 		action.App.config.FriendbotURL,
 		templates,
 	)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes https://github.com/stellar/go/issues/2737
There is a data race in the root endpoint when the action accesses `action.App.coreVersion` and other properties from `action.App`. These properties are updated in the `App.Tick()` goroutine. This commit fixes the data race by wrapping these properties in a read write lock. Whenever the properties are updated the write lock is acquired. Similarly, whenever the properties are read the read lock is acquired.
