### PR TITLE
exp/services/recoverysigner: add encrypt and decrypt commands

### DIFF
--- a/exp/services/recoverysigner/README.md
+++ b/exp/services/recoverysigner/README.md
@@ -94,7 +94,7 @@ Available Commands:
 
 Flags:
       --encryption-kms-key-uri string   URI for a remote KMS key used to encrypt Tink keyset (ENCRYPTION_KMS_KEY_URI)
-      --encryption-tink-keyset string   Existing Tink keyset to rotate/encrypt/decrypt (ENCRYPTION_TINK_KEYSET)
+      --encryption-tink-keyset string   Tink keyset to rotate/encrypt/decrypt (ENCRYPTION_TINK_KEYSET)
 
 Use "recoverysigner encryption-tink-keyset [command] --help" for more information about a command.
 ```

--- a/exp/services/recoverysigner/README.md
+++ b/exp/services/recoverysigner/README.md
@@ -75,7 +75,7 @@ Available Commands:
 
 Flags:
       --encryption-kms-key-uri string   URI for a remote KMS key used to encrypt Tink keyset (ENCRYPTION_KMS_KEY_URI)
-      --encryption-tink-keyset string   Existing Tink keyset to rotate (ENCRYPTION_TINK_KEYSET)
+      --encryption-tink-keyset string   Existing Tink keyset to rotate/encrypt/decrypt (ENCRYPTION_TINK_KEYSET)
 
 Use "recoverysigner encryption-tink-keyset [command] --help" for more information about a command.
 ```

--- a/exp/services/recoverysigner/README.md
+++ b/exp/services/recoverysigner/README.md
@@ -28,8 +28,9 @@ Usage:
   recoverysigner [command]
 
 Available Commands:
-  db          Run database operations
-  serve       Run the SEP-30 Recovery Signer server
+  db                     Run database operations
+  encryption-tink-keyset Run Tink keyset operations
+  serve                  Run the SEP-30 Recovery Signer server
 
 Use "recoverysigner [command] --help" for more information about a command.
 ```
@@ -53,6 +54,30 @@ Flags:
       --sep10-jwks string            JSON Web Key Set (JWKS) containing one or more keys used to validate SEP-10 JWTs (if the key is an asymmetric key that has separate public and private key, the JWK need only contain the public key) (if multiple keys are provided they will all attempt verification the key ID will be ignored although logged) (SEP10_JWKS)
       --sep10-jwt-issuer string      JWT issuer to verify if in the SEP-10 JWT iss field (not checked if empty) (SEP10_JWT_ISSUER)
       --signing-key string           Stellar signing key(s) used for signing transactions comma separated (first key is preferred signer) (will be deprecated with per-account keys in the future) (SIGNING_KEY)
+```
+
+## Usage: encryption-tink-keyset
+
+The format of the --encryption-kms-key-uri configuration option should conform to the format stated in [Google Tink](https://github.com/google/tink/blob/040ac621b3e9ff7a240b1e596a423a30d32f9013/docs/KEY-MANAGEMENT.md#key-management-systems)
+```
+$ recoverysigner encryption-tink-keyset --help
+Run Tink keyset operations
+
+Usage:
+  recoverysigner encryption-tink-keyset [flags]
+  recoverysigner encryption-tink-keyset [command]
+
+Available Commands:
+  create      Create a new Tink keyset
+  decrypt     Decrypt the Tink keyset specified in encryption-tink-keyset with the KMS key specified in encryption-kms-key-uri
+  encrypt     Encrypt the Tink keyset specified in encryption-tink-keyset with the KMS key specified in encryption-kms-key-uri
+  rotate      Rotate the Tink keyset specified in encryption-tink-keyset by generating a new key, adding it to the keyset, and making it the primary key in the keyset
+
+Flags:
+      --encryption-kms-key-uri string   URI for a remote KMS key used to encrypt Tink keyset (ENCRYPTION_KMS_KEY_URI)
+      --encryption-tink-keyset string   Existing Tink keyset to rotate (ENCRYPTION_TINK_KEYSET)
+
+Use "recoverysigner encryption-tink-keyset [command] --help" for more information about a command.
 ```
 
 [SEP-30]: https://github.com/stellar/stellar-protocol/blob/600c326b210d71ee031d7f3a40ca88191b4cdf9c/ecosystem/sep-0030.md

--- a/exp/services/recoverysigner/README.md
+++ b/exp/services/recoverysigner/README.md
@@ -58,7 +58,7 @@ Flags:
 
 ## Usage: encryption-tink-keyset
 
-The format of the --encryption-kms-key-uri configuration option should conform to the format stated in [Google Tink](https://github.com/google/tink/blob/040ac621b3e9ff7a240b1e596a423a30d32f9013/docs/KEY-MANAGEMENT.md#key-management-systems)
+The format of the --encryption-kms-key-uri configuration option should conform to the format stated in [Google Tink](https://github.com/google/tink/blob/040ac621b3e9ff7a240b1e596a423a30d32f9013/docs/KEY-MANAGEMENT.md#key-management-systems).
 ```
 $ recoverysigner encryption-tink-keyset --help
 Run Tink keyset operations

--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -34,7 +34,7 @@ func (c *KeysetCommand) Command() *cobra.Command {
 		},
 		{
 			Name:        "encryption-tink-keyset",
-			Usage:       "Existing Tink keyset to rotate",
+			Usage:       "Existing Tink keyset to rotate/encrypt/decrypt",
 			OptType:     types.String,
 			ConfigKey:   &c.EncryptionTinkKeyset,
 			FlagDefault: "",

--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -17,9 +17,9 @@ import (
 )
 
 type KeysetCommand struct {
-	Logger               *supportlog.Entry
-	EncryptionKMSKeyURI  string
-	EncryptionTinkKeyset string
+	Logger                   *supportlog.Entry
+	EncryptionKMSKeyURI      string
+	EncryptionTinkKeysetJSON string
 }
 
 func (c *KeysetCommand) Command() *cobra.Command {
@@ -36,7 +36,7 @@ func (c *KeysetCommand) Command() *cobra.Command {
 			Name:        "encryption-tink-keyset",
 			Usage:       "Existing Tink keyset to rotate/encrypt/decrypt",
 			OptType:     types.String,
-			ConfigKey:   &c.EncryptionTinkKeyset,
+			ConfigKey:   &c.EncryptionTinkKeysetJSON,
 			FlagDefault: "",
 			Required:    false,
 		},
@@ -155,7 +155,7 @@ func createKeyset(kmsKeyURI string, keyTemplate *tinkpb.KeyTemplate) (publicClea
 }
 
 func (c *KeysetCommand) Rotate() {
-	keysetPublic, keysetPrivateCleartext, keysetPrivateEncrypted, err := rotateKeyset(c.EncryptionKMSKeyURI, c.EncryptionTinkKeyset, c.keyTemplate())
+	keysetPublic, keysetPrivateCleartext, keysetPrivateEncrypted, err := rotateKeyset(c.EncryptionKMSKeyURI, c.EncryptionTinkKeysetJSON, c.keyTemplate())
 	if err != nil {
 		c.Logger.Errorf("Error rotating keyset: %v", err)
 		return
@@ -240,7 +240,7 @@ func rotateKeyset(kmsKeyURI, keysetJSON string, keyTemplate *tinkpb.KeyTemplate)
 var errNoKMSKeyURI = errors.New("KMS Key URI is not configured")
 
 func (c *KeysetCommand) Decrypt() {
-	keysetPublic, keysetPrivateCleartext, err := decryptKeyset(c.EncryptionKMSKeyURI, c.EncryptionTinkKeyset)
+	keysetPublic, keysetPrivateCleartext, err := decryptKeyset(c.EncryptionKMSKeyURI, c.EncryptionTinkKeysetJSON)
 	if err != nil {
 		c.Logger.Errorf("Error decrypting keyset: %v", err)
 		return
@@ -291,7 +291,7 @@ func decryptKeyset(kmsKeyURI, keysetJSON string) (publicCleartext string, privat
 }
 
 func (c *KeysetCommand) Encrypt() {
-	keysetPublic, keysetPrivateEncrypted, err := encryptKeyset(c.EncryptionKMSKeyURI, c.EncryptionTinkKeyset)
+	keysetPublic, keysetPrivateEncrypted, err := encryptKeyset(c.EncryptionKMSKeyURI, c.EncryptionTinkKeysetJSON)
 	if err != nil {
 		c.Logger.Errorf("Error encrypting keyset: %v", err)
 		return

--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -69,15 +69,23 @@ func (c *KeysetCommand) Command() *cobra.Command {
 	}
 	decryptCmd := &cobra.Command{
 		Use:   "decrypt",
-		Short: "Decrypt the Tink keyset specified in encryption-tink-keyset specified by using the key specified in encryption-kms-key-uri",
+		Short: "Decrypt the Tink keyset specified in encryption-tink-keyset with the KMS key specified in encryption-kms-key-uri",
 		Run: func(_ *cobra.Command, _ []string) {
 			c.Decrypt()
+		},
+	}
+	encryptCmd := &cobra.Command{
+		Use:   "encrypt",
+		Short: "Encrypt the Tink keyset specified in encryption-tink-keyset with the KMS key specified in encryption-kms-key-uri",
+		Run: func(_ *cobra.Command, _ []string) {
+			c.Encrypt()
 		},
 	}
 
 	cmd.AddCommand(createCmd)
 	cmd.AddCommand(rotateCmd)
 	cmd.AddCommand(decryptCmd)
+	cmd.AddCommand(encryptCmd)
 
 	return cmd
 }
@@ -268,4 +276,43 @@ func decryptKeyset(kmsKeyURI, keysetJSON string) (string, error) {
 	}
 
 	return keysetPrivateCleartext.String(), nil
+}
+
+func (c *KeysetCommand) Encrypt() {
+	keysetPrivateEncrypted, err := encryptKeyset(c.EncryptionKMSKeyURI, c.EncryptionTinkKeyset)
+	if err != nil {
+		c.Logger.Errorf("Error encrypting keyset: %v", err)
+		return
+	}
+
+	c.Logger.Print("Encrypted keyset private:", keysetPrivateEncrypted)
+}
+
+func encryptKeyset(kmsKeyURI, keysetJSON string) (string, error) {
+	if kmsKeyURI == "" {
+		return "", errNoKMSKeyURI
+	}
+
+	kmsClient, err := awskms.NewClient(kmsKeyURI)
+	if err != nil {
+		return "", errors.Wrap(err, "initializing AWS KMS client")
+	}
+
+	aead, err := kmsClient.GetAEAD(kmsKeyURI)
+	if err != nil {
+		return "", errors.Wrap(err, "getting AEAD primitive from KMS")
+	}
+
+	khPriv, err := insecurecleartextkeyset.Read(keyset.NewJSONReader(strings.NewReader(keysetJSON)))
+	if err != nil {
+		return "", errors.Wrap(err, "getting key handle for private key")
+	}
+
+	keysetPrivateEncrypted := strings.Builder{}
+	err = khPriv.Write(keyset.NewJSONWriter(&keysetPrivateEncrypted), aead)
+	if err != nil {
+		return "", errors.Wrap(err, "writing encrypted keyset private")
+	}
+
+	return keysetPrivateEncrypted.String(), nil
 }

--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -67,9 +67,17 @@ func (c *KeysetCommand) Command() *cobra.Command {
 			c.Rotate()
 		},
 	}
+	decryptCmd := &cobra.Command{
+		Use:   "decrypt",
+		Short: "Decrypt the Tink keyset specified in encryption-tink-keyset specified by using the key specified in encryption-kms-key-uri",
+		Run: func(_ *cobra.Command, _ []string) {
+			c.Decrypt()
+		},
+	}
 
 	cmd.AddCommand(createCmd)
 	cmd.AddCommand(rotateCmd)
+	cmd.AddCommand(decryptCmd)
 
 	return cmd
 }
@@ -116,13 +124,13 @@ func createKeyset(kmsKeyURI string, keyTemplate *tinkpb.KeyTemplate) (publicClea
 
 		err = khPriv.Write(keyset.NewJSONWriter(&keysetPrivateEncrypted), aead)
 		if err != nil {
-			return "", "", "", errors.Wrap(err, "writing encrypted keyset containing private key")
+			return "", "", "", errors.Wrap(err, "writing encrypted keyset private")
 		}
 	}
 
 	err = insecurecleartextkeyset.Write(khPriv, keyset.NewJSONWriter(&keysetPrivateCleartext))
 	if err != nil {
-		return "", "", "", errors.Wrap(err, "writing cleartext keyset containing private key")
+		return "", "", "", errors.Wrap(err, "writing cleartext keyset private")
 	}
 
 	khPub, err := khPriv.Public()
@@ -132,7 +140,7 @@ func createKeyset(kmsKeyURI string, keyTemplate *tinkpb.KeyTemplate) (publicClea
 
 	err = khPub.WriteWithNoSecrets(keyset.NewJSONWriter(&keysetPublic))
 	if err != nil {
-		return "", "", "", errors.Wrap(err, "writing cleartext keyset containing public key")
+		return "", "", "", errors.Wrap(err, "writing cleartext keyset public")
 	}
 
 	return keysetPublic.String(), keysetPrivateCleartext.String(), keysetPrivateEncrypted.String(), nil
@@ -153,29 +161,29 @@ func (c *KeysetCommand) Rotate() {
 	}
 }
 
-func rotateKeyset(kmsKeyURI, currentTinkKeyset string, keyTemplate *tinkpb.KeyTemplate) (publicCleartext string, privateCleartext string, privateEncrypted string, err error) {
+func rotateKeyset(kmsKeyURI, keysetJSON string, keyTemplate *tinkpb.KeyTemplate) (publicCleartext string, privateCleartext string, privateEncrypted string, err error) {
 	var (
 		khPriv *keyset.Handle
 		aead   tink.AEAD
 	)
 
 	if kmsKeyURI != "" {
-		kmsClient, kmsErr := awskms.NewClient(kmsKeyURI)
-		if kmsErr != nil {
-			return "", "", "", errors.Wrap(kmsErr, "initializing AWS KMS client")
+		kmsClient, err := awskms.NewClient(kmsKeyURI)
+		if err != nil {
+			return "", "", "", errors.Wrap(err, "initializing AWS KMS client")
 		}
 
-		aead, kmsErr = kmsClient.GetAEAD(kmsKeyURI)
-		if kmsErr != nil {
-			return "", "", "", errors.Wrap(kmsErr, "getting AEAD primitive from KMS")
+		aead, err = kmsClient.GetAEAD(kmsKeyURI)
+		if err != nil {
+			return "", "", "", errors.Wrap(err, "getting AEAD primitive from KMS")
 		}
 
-		khPriv, err = keyset.Read(keyset.NewJSONReader(strings.NewReader(currentTinkKeyset)), aead)
+		khPriv, err = keyset.Read(keyset.NewJSONReader(strings.NewReader(keysetJSON)), aead)
 		if err != nil {
 			return "", "", "", errors.Wrap(err, "reading encrypted keyset")
 		}
 	} else {
-		khPriv, err = insecurecleartextkeyset.Read(keyset.NewJSONReader(strings.NewReader(currentTinkKeyset)))
+		khPriv, err = insecurecleartextkeyset.Read(keyset.NewJSONReader(strings.NewReader(keysetJSON)))
 		if err != nil {
 			return "", "", "", errors.Wrap(err, "getting key handle for private key")
 		}
@@ -199,13 +207,13 @@ func rotateKeyset(kmsKeyURI, currentTinkKeyset string, keyTemplate *tinkpb.KeyTe
 	if kmsKeyURI != "" {
 		err = khPriv.Write(keyset.NewJSONWriter(&keysetPrivateEncrypted), aead)
 		if err != nil {
-			return "", "", "", errors.Wrap(err, "writing encrypted keyset containing private keys")
+			return "", "", "", errors.Wrap(err, "writing encrypted keyset private")
 		}
 	}
 
 	err = insecurecleartextkeyset.Write(khPriv, keyset.NewJSONWriter(&keysetPrivateCleartext))
 	if err != nil {
-		return "", "", "", errors.Wrap(err, "writing cleartext keyset containing private keys")
+		return "", "", "", errors.Wrap(err, "writing cleartext keyset private")
 	}
 
 	khPub, err := khPriv.Public()
@@ -215,8 +223,49 @@ func rotateKeyset(kmsKeyURI, currentTinkKeyset string, keyTemplate *tinkpb.KeyTe
 
 	err = khPub.WriteWithNoSecrets(keyset.NewJSONWriter(&keysetPublic))
 	if err != nil {
-		return "", "", "", errors.Wrap(err, "writing cleartext keyset containing public keys")
+		return "", "", "", errors.Wrap(err, "writing cleartext keyset public")
 	}
 
 	return keysetPublic.String(), keysetPrivateCleartext.String(), keysetPrivateEncrypted.String(), nil
+}
+
+var errNoKMSKeyURI = errors.New("KMS Key URI is not configured")
+
+func (c *KeysetCommand) Decrypt() {
+	keysetPrivateCleartext, err := decryptKeyset(c.EncryptionKMSKeyURI, c.EncryptionTinkKeyset)
+	if err != nil {
+		c.Logger.Errorf("Error decrypting keyset: %v", err)
+		return
+	}
+
+	c.Logger.Print("Cleartext keyset private:", keysetPrivateCleartext)
+}
+
+func decryptKeyset(kmsKeyURI, keysetJSON string) (string, error) {
+	if kmsKeyURI == "" {
+		return "", errNoKMSKeyURI
+	}
+
+	kmsClient, err := awskms.NewClient(kmsKeyURI)
+	if err != nil {
+		return "", errors.Wrap(err, "initializing AWS KMS client")
+	}
+
+	aead, err := kmsClient.GetAEAD(kmsKeyURI)
+	if err != nil {
+		return "", errors.Wrap(err, "getting AEAD primitive from KMS")
+	}
+
+	khPriv, err := keyset.Read(keyset.NewJSONReader(strings.NewReader(keysetJSON)), aead)
+	if err != nil {
+		return "", errors.Wrap(err, "reading encrypted keyset")
+	}
+
+	keysetPrivateCleartext := strings.Builder{}
+	err = insecurecleartextkeyset.Write(khPriv, keyset.NewJSONWriter(&keysetPrivateCleartext))
+	if err != nil {
+		return "", errors.Wrap(err, "writing cleartext keyset private")
+	}
+
+	return keysetPrivateCleartext.String(), nil
 }

--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -240,79 +240,103 @@ func rotateKeyset(kmsKeyURI, keysetJSON string, keyTemplate *tinkpb.KeyTemplate)
 var errNoKMSKeyURI = errors.New("KMS Key URI is not configured")
 
 func (c *KeysetCommand) Decrypt() {
-	keysetPrivateCleartext, err := decryptKeyset(c.EncryptionKMSKeyURI, c.EncryptionTinkKeyset)
+	keysetPublic, keysetPrivateCleartext, err := decryptKeyset(c.EncryptionKMSKeyURI, c.EncryptionTinkKeyset)
 	if err != nil {
 		c.Logger.Errorf("Error decrypting keyset: %v", err)
 		return
 	}
 
+	c.Logger.Print("Cleartext keyset public:", keysetPublic)
 	c.Logger.Print("Cleartext keyset private:", keysetPrivateCleartext)
 }
 
-func decryptKeyset(kmsKeyURI, keysetJSON string) (string, error) {
+func decryptKeyset(kmsKeyURI, keysetJSON string) (publicCleartext string, privateCleartext string, err error) {
 	if kmsKeyURI == "" {
-		return "", errNoKMSKeyURI
+		return "", "", errNoKMSKeyURI
 	}
 
 	kmsClient, err := awskms.NewClient(kmsKeyURI)
 	if err != nil {
-		return "", errors.Wrap(err, "initializing AWS KMS client")
+		return "", "", errors.Wrap(err, "initializing AWS KMS client")
 	}
 
 	aead, err := kmsClient.GetAEAD(kmsKeyURI)
 	if err != nil {
-		return "", errors.Wrap(err, "getting AEAD primitive from KMS")
+		return "", "", errors.Wrap(err, "getting AEAD primitive from KMS")
 	}
 
 	khPriv, err := keyset.Read(keyset.NewJSONReader(strings.NewReader(keysetJSON)), aead)
 	if err != nil {
-		return "", errors.Wrap(err, "reading encrypted keyset")
+		return "", "", errors.Wrap(err, "reading encrypted keyset")
 	}
 
 	keysetPrivateCleartext := strings.Builder{}
 	err = insecurecleartextkeyset.Write(khPriv, keyset.NewJSONWriter(&keysetPrivateCleartext))
 	if err != nil {
-		return "", errors.Wrap(err, "writing cleartext keyset private")
+		return "", "", errors.Wrap(err, "writing cleartext keyset private")
 	}
 
-	return keysetPrivateCleartext.String(), nil
+	khPub, err := khPriv.Public()
+	if err != nil {
+		return "", "", errors.Wrap(err, "getting keyhandle for public keys")
+	}
+
+	keysetPublic := strings.Builder{}
+	err = khPub.WriteWithNoSecrets(keyset.NewJSONWriter(&keysetPublic))
+	if err != nil {
+		return "", "", errors.Wrap(err, "writing cleartext keyset public")
+	}
+
+	return keysetPublic.String(), keysetPrivateCleartext.String(), nil
 }
 
 func (c *KeysetCommand) Encrypt() {
-	keysetPrivateEncrypted, err := encryptKeyset(c.EncryptionKMSKeyURI, c.EncryptionTinkKeyset)
+	keysetPublic, keysetPrivateEncrypted, err := encryptKeyset(c.EncryptionKMSKeyURI, c.EncryptionTinkKeyset)
 	if err != nil {
 		c.Logger.Errorf("Error encrypting keyset: %v", err)
 		return
 	}
 
+	c.Logger.Print("Cleartext keyset public:", keysetPublic)
 	c.Logger.Print("Encrypted keyset private:", keysetPrivateEncrypted)
 }
 
-func encryptKeyset(kmsKeyURI, keysetJSON string) (string, error) {
+func encryptKeyset(kmsKeyURI, keysetJSON string) (publicCleartext string, privateEncrypted string, err error) {
 	if kmsKeyURI == "" {
-		return "", errNoKMSKeyURI
+		return "", "", errNoKMSKeyURI
 	}
 
 	kmsClient, err := awskms.NewClient(kmsKeyURI)
 	if err != nil {
-		return "", errors.Wrap(err, "initializing AWS KMS client")
+		return "", "", errors.Wrap(err, "initializing AWS KMS client")
 	}
 
 	aead, err := kmsClient.GetAEAD(kmsKeyURI)
 	if err != nil {
-		return "", errors.Wrap(err, "getting AEAD primitive from KMS")
+		return "", "", errors.Wrap(err, "getting AEAD primitive from KMS")
 	}
 
 	khPriv, err := insecurecleartextkeyset.Read(keyset.NewJSONReader(strings.NewReader(keysetJSON)))
 	if err != nil {
-		return "", errors.Wrap(err, "getting key handle for private key")
+		return "", "", errors.Wrap(err, "getting key handle for private key")
 	}
 
 	keysetPrivateEncrypted := strings.Builder{}
 	err = khPriv.Write(keyset.NewJSONWriter(&keysetPrivateEncrypted), aead)
 	if err != nil {
-		return "", errors.Wrap(err, "writing encrypted keyset private")
+		return "", "", errors.Wrap(err, "writing encrypted keyset private")
 	}
 
-	return keysetPrivateEncrypted.String(), nil
+	khPub, err := khPriv.Public()
+	if err != nil {
+		return "", "", errors.Wrap(err, "getting keyhandle for public keys")
+	}
+
+	keysetPublic := strings.Builder{}
+	err = khPub.WriteWithNoSecrets(keyset.NewJSONWriter(&keysetPublic))
+	if err != nil {
+		return "", "", errors.Wrap(err, "writing cleartext keyset public")
+	}
+
+	return keysetPublic.String(), keysetPrivateEncrypted.String(), nil
 }

--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -34,7 +34,7 @@ func (c *KeysetCommand) Command() *cobra.Command {
 		},
 		{
 			Name:        "encryption-tink-keyset",
-			Usage:       "Existing Tink keyset to rotate/encrypt/decrypt",
+			Usage:       "Tink keyset to rotate/encrypt/decrypt",
 			OptType:     types.String,
 			ConfigKey:   &c.EncryptionTinkKeysetJSON,
 			FlagDefault: "",

--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -176,14 +176,14 @@ func rotateKeyset(kmsKeyURI, keysetJSON string, keyTemplate *tinkpb.KeyTemplate)
 	)
 
 	if kmsKeyURI != "" {
-		kmsClient, err := awskms.NewClient(kmsKeyURI)
-		if err != nil {
-			return "", "", "", errors.Wrap(err, "initializing AWS KMS client")
+		kmsClient, kmsErr := awskms.NewClient(kmsKeyURI)
+		if kmsErr != nil {
+			return "", "", "", errors.Wrap(kmsErr, "initializing AWS KMS client")
 		}
 
-		aead, err = kmsClient.GetAEAD(kmsKeyURI)
-		if err != nil {
-			return "", "", "", errors.Wrap(err, "getting AEAD primitive from KMS")
+		aead, kmsErr = kmsClient.GetAEAD(kmsKeyURI)
+		if kmsErr != nil {
+			return "", "", "", errors.Wrap(kmsErr, "getting AEAD primitive from KMS")
 		}
 
 		khPriv, err = keyset.Read(keyset.NewJSONReader(strings.NewReader(keysetJSON)), aead)

--- a/exp/services/recoverysigner/cmd/keyset.go
+++ b/exp/services/recoverysigner/cmd/keyset.go
@@ -143,7 +143,7 @@ func createKeyset(kmsKeyURI string, keyTemplate *tinkpb.KeyTemplate) (publicClea
 
 	khPub, err := khPriv.Public()
 	if err != nil {
-		return "", "", "", errors.Wrap(err, "getting keyhandle for public key")
+		return "", "", "", errors.Wrap(err, "getting key handle for keyset public")
 	}
 
 	err = khPub.WriteWithNoSecrets(keyset.NewJSONWriter(&keysetPublic))
@@ -188,12 +188,12 @@ func rotateKeyset(kmsKeyURI, keysetJSON string, keyTemplate *tinkpb.KeyTemplate)
 
 		khPriv, err = keyset.Read(keyset.NewJSONReader(strings.NewReader(keysetJSON)), aead)
 		if err != nil {
-			return "", "", "", errors.Wrap(err, "reading encrypted keyset")
+			return "", "", "", errors.Wrap(err, "getting key handle for keyset private by reading an encrypted keyset")
 		}
 	} else {
 		khPriv, err = insecurecleartextkeyset.Read(keyset.NewJSONReader(strings.NewReader(keysetJSON)))
 		if err != nil {
-			return "", "", "", errors.Wrap(err, "getting key handle for private key")
+			return "", "", "", errors.Wrap(err, "getting key handle for keyset private by reading a cleartext keyset")
 		}
 	}
 
@@ -205,7 +205,7 @@ func rotateKeyset(kmsKeyURI, keysetJSON string, keyTemplate *tinkpb.KeyTemplate)
 
 	khPriv, err = m.Handle()
 	if err != nil {
-		return "", "", "", errors.Wrap(err, "creating handle for the new keyset")
+		return "", "", "", errors.Wrap(err, "creating key handle for the rotated keyset private")
 	}
 
 	keysetPrivateEncrypted := strings.Builder{}
@@ -226,7 +226,7 @@ func rotateKeyset(kmsKeyURI, keysetJSON string, keyTemplate *tinkpb.KeyTemplate)
 
 	khPub, err := khPriv.Public()
 	if err != nil {
-		return "", "", "", errors.Wrap(err, "getting keyhandle for public keys")
+		return "", "", "", errors.Wrap(err, "getting key handle for keyset public")
 	}
 
 	err = khPub.WriteWithNoSecrets(keyset.NewJSONWriter(&keysetPublic))
@@ -267,7 +267,7 @@ func decryptKeyset(kmsKeyURI, keysetJSON string) (publicCleartext string, privat
 
 	khPriv, err := keyset.Read(keyset.NewJSONReader(strings.NewReader(keysetJSON)), aead)
 	if err != nil {
-		return "", "", errors.Wrap(err, "reading encrypted keyset")
+		return "", "", errors.Wrap(err, "getting key handle for keyset private by reading an encrypted keyset")
 	}
 
 	keysetPrivateCleartext := strings.Builder{}
@@ -278,7 +278,7 @@ func decryptKeyset(kmsKeyURI, keysetJSON string) (publicCleartext string, privat
 
 	khPub, err := khPriv.Public()
 	if err != nil {
-		return "", "", errors.Wrap(err, "getting keyhandle for public keys")
+		return "", "", errors.Wrap(err, "getting key handle for keyset public")
 	}
 
 	keysetPublic := strings.Builder{}
@@ -318,7 +318,7 @@ func encryptKeyset(kmsKeyURI, keysetJSON string) (publicCleartext string, privat
 
 	khPriv, err := insecurecleartextkeyset.Read(keyset.NewJSONReader(strings.NewReader(keysetJSON)))
 	if err != nil {
-		return "", "", errors.Wrap(err, "getting key handle for private key")
+		return "", "", errors.Wrap(err, "getting key handle for keyset private by reading a cleartext keyset")
 	}
 
 	keysetPrivateEncrypted := strings.Builder{}
@@ -329,7 +329,7 @@ func encryptKeyset(kmsKeyURI, keysetJSON string) (publicCleartext string, privat
 
 	khPub, err := khPriv.Public()
 	if err != nil {
-		return "", "", errors.Wrap(err, "getting keyhandle for public keys")
+		return "", "", errors.Wrap(err, "getting key handle for keyset public")
 	}
 
 	keysetPublic := strings.Builder{}

--- a/exp/services/recoverysigner/cmd/keyset_test.go
+++ b/exp/services/recoverysigner/cmd/keyset_test.go
@@ -160,8 +160,19 @@ func TestRotateKeyset_invalidKMSKeyURI(t *testing.T) {
 	assert.Contains(t, err.Error(), "initializing AWS KMS client")
 }
 
-func TestRotateKeyset_noCurrentKeyset(t *testing.T) {
+func TestRotateKeyset_noEncryptionTinkKeyset(t *testing.T) {
 	_, _, _, err := rotateKeyset("", "", hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "getting key handle for private key")
+}
+
+func TestDecryptKeyset_invalidKMSKeyURI(t *testing.T) {
+	// encrption-kms-key-uri is not configured
+	_, err := decryptKeyset("", "keysetJSON")
+	require.Error(t, err)
+	assert.Equal(t, err, errNoKMSKeyURI)
+
+	_, err = decryptKeyset("invalid-uri", "keysetJSON")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "initializing AWS KMS client")
 }

--- a/exp/services/recoverysigner/cmd/keyset_test.go
+++ b/exp/services/recoverysigner/cmd/keyset_test.go
@@ -176,3 +176,14 @@ func TestDecryptKeyset_invalidKMSKeyURI(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "initializing AWS KMS client")
 }
+
+func TestEncryptKeyset_invalidKMSKeyURI(t *testing.T) {
+	// encrption-kms-key-uri is not configured
+	_, err := encryptKeyset("", "keysetJSON")
+	require.Error(t, err)
+	assert.Equal(t, err, errNoKMSKeyURI)
+
+	_, err = encryptKeyset("invalid-uri", "keysetJSON")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "initializing AWS KMS client")
+}

--- a/exp/services/recoverysigner/cmd/keyset_test.go
+++ b/exp/services/recoverysigner/cmd/keyset_test.go
@@ -163,27 +163,27 @@ func TestRotateKeyset_invalidKMSKeyURI(t *testing.T) {
 func TestRotateKeyset_noEncryptionTinkKeyset(t *testing.T) {
 	_, _, _, err := rotateKeyset("", "", hybrid.ECIESHKDFAES128GCMKeyTemplate())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "getting key handle for private key")
+	assert.Contains(t, err.Error(), "getting key handle for keyset private by reading a cleartext keyset")
 }
 
 func TestDecryptKeyset_invalidKMSKeyURI(t *testing.T) {
 	// encrption-kms-key-uri is not configured
-	_, err := decryptKeyset("", "keysetJSON")
+	_, _, err := decryptKeyset("", "keysetJSON")
 	require.Error(t, err)
 	assert.Equal(t, err, errNoKMSKeyURI)
 
-	_, err = decryptKeyset("invalid-uri", "keysetJSON")
+	_, _, err = decryptKeyset("invalid-uri", "keysetJSON")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "initializing AWS KMS client")
 }
 
 func TestEncryptKeyset_invalidKMSKeyURI(t *testing.T) {
 	// encrption-kms-key-uri is not configured
-	_, err := encryptKeyset("", "keysetJSON")
+	_, _, err := encryptKeyset("", "keysetJSON")
 	require.Error(t, err)
 	assert.Equal(t, err, errNoKMSKeyURI)
 
-	_, err = encryptKeyset("invalid-uri", "keysetJSON")
+	_, _, err = encryptKeyset("invalid-uri", "keysetJSON")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "initializing AWS KMS client")
 }

--- a/exp/services/recoverysigner/cmd/serve.go
+++ b/exp/services/recoverysigner/cmd/serve.go
@@ -89,7 +89,7 @@ func (c *ServeCommand) Command() *cobra.Command {
 		},
 		{
 			Name:        "encryption-kms-key-uri",
-			Usage:       "URI for a remote KMS key used to decrypt the Tink keyset provided in encryption-tink-keyset",
+			Usage:       "URI for a remote KMS key used to decrypt the Tink keyset specified in encryption-tink-keyset",
 			OptType:     types.String,
 			ConfigKey:   &opts.EncryptionKMSKeyURI,
 			FlagDefault: "",


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR adds two sub-commands `encrypt` and `decrypt` to `encryption-tink-keyset` to encrypt a cleartext keyset private or to decrypt an encrypted keyset private.

### Why

I was planning on adding a sub-command `reencrypt`. However,  I realized there's no way for someone who started the recovery signer with a cleartext keyset private without configuring `encryption-kms-key-uri` to encrypt the keyset later on, so I decided to add two sub-commands: `encrypt` and `decrypt`. 

For someone who wants to make the system more secure by configuring the `encryption-kms-key-uri` at a later point in time, she can use the `encrypt` command to do so; for someone who wants to re-encrypt the keyset after rotating the KMS key, she can first use `decrypt` to get the cleartext keyset if no backup is available, then use `encrypt` to get a new encrypted keyset.

### Known limitations

I could theoretically break this PR into two, one for the `encrypt` cmd and one for the `decrypt` cmd. But since they are closely related and are not too big in their own, I decided to put them together and tidy up the messages throughout the file.
