### PR TITLE
services/horizon/internal: Fix captive core runner for windows.

### DIFF
--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -1,7 +1,9 @@
 package ledgerbackend
 
 import (
+	"fmt"
 	"io"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -79,6 +81,7 @@ type captiveStellarCore struct {
 //
 // Platform-specific pipe setup logic is in the .start() methods.
 func NewCaptive(executablePath, networkPassphrase string, historyURLs []string) *captiveStellarCore {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	return &captiveStellarCore{
 		networkPassphrase: networkPassphrase,
 		historyURLs:       historyURLs,
@@ -87,6 +90,7 @@ func NewCaptive(executablePath, networkPassphrase string, historyURLs []string) 
 			executablePath:    executablePath,
 			networkPassphrase: networkPassphrase,
 			historyURLs:       historyURLs,
+			nonce:             fmt.Sprintf("captive-stellar-core-%x", r.Uint64()),
 		},
 	}
 }

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -1,9 +1,7 @@
 package ledgerbackend
 
 import (
-	"fmt"
 	"io"
-	"math/rand"
 	"sync"
 	"time"
 
@@ -81,17 +79,11 @@ type captiveStellarCore struct {
 //
 // Platform-specific pipe setup logic is in the .start() methods.
 func NewCaptive(executablePath, networkPassphrase string, historyURLs []string) *captiveStellarCore {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	return &captiveStellarCore{
 		networkPassphrase: networkPassphrase,
 		historyURLs:       historyURLs,
 		nextLedger:        0,
-		stellarCoreRunner: &stellarCoreRunner{
-			executablePath:    executablePath,
-			networkPassphrase: networkPassphrase,
-			historyURLs:       historyURLs,
-			nonce:             fmt.Sprintf("captive-stellar-core-%x", r.Uint64()),
-		},
+		stellarCoreRunner: newStellarCoreRunner(executablePath, networkPassphrase, historyURLs),
 	}
 }
 

--- a/exp/ingest/ledgerbackend/stellar_core_runner.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner.go
@@ -30,6 +30,7 @@ type stellarCoreRunner struct {
 	cmd      *exec.Cmd
 	metaPipe io.Reader
 	tempDir  string
+	nonce    string
 }
 
 func (r *stellarCoreRunner) getConf() string {

--- a/exp/ingest/ledgerbackend/stellar_core_runner.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner.go
@@ -33,6 +33,16 @@ type stellarCoreRunner struct {
 	nonce    string
 }
 
+func newStellarCoreRunner(executablePath, networkPassphrase string, historyURLs []string) *stellarCoreRunner {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return &stellarCoreRunner{
+		executablePath:    executablePath,
+		networkPassphrase: networkPassphrase,
+		historyURLs:       historyURLs,
+		nonce:             fmt.Sprintf("captive-stellar-core-%x", r.Uint64()),
+	}
+}
+
 func (r *stellarCoreRunner) getConf() string {
 	lines := []string{
 		"# Generated file -- do not edit",

--- a/exp/ingest/ledgerbackend/stellar_core_runner_windows.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner_windows.go
@@ -45,7 +45,7 @@ func (c *stellarCoreRunner) start() error {
 	return nil
 }
 
-func (c *captiveStellarCore) processIsAlive() bool {
+func (c *stellarCoreRunner) processIsAlive() bool {
 	if c.cmd == nil {
 		return false
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes stellar core runner on Windows.

### Why

Some changes on the runner code broke the windows build, which we just find out since we didn't test the build on windows.

### Known limitations

[TODO or N/A]
