### PR TITLE
exp/ingest/ledgerbackend: Update HistoryArchiveBackend to use updated LedgerBackend interface

### DIFF
--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -32,8 +32,7 @@ var _ LedgerBackend = (*captiveStellarCore)(nil)
 const (
 	// In this (crude, initial) sketch, we replay ledgers in blocks of 17,280
 	// which is 24 hours worth of ledgers at 5 second intervals.
-	ledgersPerProcess    = 17280
-	ledgersPerCheckpoint = 64
+	ledgersPerProcess = 17280
 
 	// The number of checkpoints we're willing to scan over and ignore, without
 	// restarting a subprocess.

--- a/exp/ingest/ledgerbackend/history_archive_backend_test.go
+++ b/exp/ingest/ledgerbackend/history_archive_backend_test.go
@@ -102,12 +102,13 @@ func (s *HistoryArchiveBackendTestSuite) TestGetLedger() {
 		s.Require().NoError(err2)
 		s.Assert().True(exists)
 
-		s.Assert().Equal(sequence, uint32(ledger.LedgerHeader.Header.LedgerSeq))
-		s.Assert().Equal(sequence, uint32(ledger.TransactionEnvelope[0].Operations()[0].Body.BumpSequenceOp.BumpTo))
-		s.Assert().Equal(sequence, uint32(ledger.TransactionResult[0].Result.FeeCharged))
-		s.Assert().Empty(ledger.TransactionMeta)
-		s.Assert().Empty(ledger.TransactionFeeChanges)
-		s.Assert().Empty(ledger.UpgradesMeta)
+		s.Assert().Equal(sequence, uint32(ledger.V0.LedgerHeader.Header.LedgerSeq))
+		s.Assert().Equal(sequence, uint32(ledger.V0.TxSet.Txs[0].Operations()[0].Body.BumpSequenceOp.BumpTo))
+		s.Assert().Equal(sequence, uint32(ledger.V0.TxProcessing[0].Result.Result.FeeCharged))
+		s.Assert().Empty(ledger.V0.TxProcessing[0].FeeProcessing)
+		s.Assert().Empty(ledger.V0.TxProcessing[0].TxApplyProcessing)
+		s.Assert().Empty(ledger.V0.UpgradesProcessing)
+		s.Assert().Empty(ledger.V0.ScpInfo)
 	}
 
 	err = s.backend.Close()
@@ -175,12 +176,13 @@ func (s *HistoryArchiveBackendTestSuite) TestGetLedgerFirstCheckpoint() {
 		s.Require().NoError(err2)
 		s.Assert().True(exists)
 
-		s.Assert().Equal(sequence, uint32(ledger.LedgerHeader.Header.LedgerSeq))
-		s.Assert().Equal(sequence, uint32(ledger.TransactionEnvelope[0].Operations()[0].Body.BumpSequenceOp.BumpTo))
-		s.Assert().Equal(sequence, uint32(ledger.TransactionResult[0].Result.FeeCharged))
-		s.Assert().Empty(ledger.TransactionMeta)
-		s.Assert().Empty(ledger.TransactionFeeChanges)
-		s.Assert().Empty(ledger.UpgradesMeta)
+		s.Assert().Equal(sequence, uint32(ledger.V0.LedgerHeader.Header.LedgerSeq))
+		s.Assert().Equal(sequence, uint32(ledger.V0.TxSet.Txs[0].Operations()[0].Body.BumpSequenceOp.BumpTo))
+		s.Assert().Equal(sequence, uint32(ledger.V0.TxProcessing[0].Result.Result.FeeCharged))
+		s.Assert().Empty(ledger.V0.TxProcessing[0].FeeProcessing)
+		s.Assert().Empty(ledger.V0.TxProcessing[0].TxApplyProcessing)
+		s.Assert().Empty(ledger.V0.UpgradesProcessing)
+		s.Assert().Empty(ledger.V0.ScpInfo)
 	}
 
 	err = s.backend.Close()
@@ -193,7 +195,7 @@ func (s *HistoryArchiveBackendTestSuite) TestGetLedgerFirstCheckpoint() {
 func createXdrStream(entries []interface{}) *historyarchive.XdrStream {
 	b := &bytes.Buffer{}
 	for _, e := range entries {
-		err := historyarchive.WriteFramedXdr(b, e)
+		err := xdr.MarshalFramed(b, e)
 		if err != nil {
 			panic(err)
 		}

--- a/exp/ingest/ledgerbackend/ledger_backend.go
+++ b/exp/ingest/ledgerbackend/ledger_backend.go
@@ -4,6 +4,8 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
+const ledgersPerCheckpoint = 64
+
 // LedgerBackend represents the interface to a ledger data store.
 type LedgerBackend interface {
 	GetLatestLedgerSequence() (sequence uint32, err error)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit updates `ledgerbackend.HistoryArchiveBackend` to use updated `ledgerbackend.LedgerBackend` interface.

Unblocks https://github.com/stellar/go/pull/2756.

### Why

`ledgerbackend.LedgerBackend` has changed in `release-horizon-v1.5.0` branch:
* Added `PrepareRange` method (not useful in this backend because of history archives structure).
* `GetLedger` returns `xdr.LedgerCloseMeta`.