### PR TITLE
exp/ingest/ledgerbackend: Fix getting ledgers before the first checkpoint in CaptiveStellarCore

### DIFF
--- a/exp/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend_test.go
@@ -119,10 +119,7 @@ func TestCaptivePrepareRange(t *testing.T) {
 	}
 
 	mockRunner := &stellarCoreRunnerMock{}
-	// We prepare [from-1, to] range because it's not possible to rewind the reader
-	// and there is no other way to check if stellar-core has built the state without
-	// reading actual ledger.
-	mockRunner.On("run", uint32(99), uint32(200)).Return(nil).Once()
+	mockRunner.On("run", uint32(100), uint32(200)).Return(nil).Once()
 	mockRunner.On("getMetaPipe").Return(&buf)
 	mockRunner.On("close").Return(nil).Once()
 

--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -572,6 +572,11 @@ func (h reingestHistoryRangeState) run(s *system) (transition, error) {
 		"duration": time.Since(startTime).Seconds(),
 	}).Info("Range ready")
 
+	if h.fromLedger == 1 {
+		log.Warn("Ledger 1 is pregenerated and not available, starting from ledger 2.")
+		h.fromLedger = 2
+	}
+
 	if h.force {
 		if err := s.historyQ.Begin(); err != nil {
 			return stop(), errors.Wrap(err, "Error starting a transaction")


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes getting ledgers before the first checkpoint. It changes `roundDownToFirstReplayAfterCheckpointStart` function to return 2 as an expected ledger sequence when getting data before the first checkpoint sequence and updates `PrepareRange` to determine Stellar-Core readiness using `metaC` channel length.

### Why

Before buffering was added in https://github.com/stellar/go/commit/936bc3adad5fd2abded25cbfcd404106e410caed it was possible to determine if Stellar-Core finished initialization stage (applying buckets). To solve this, in `PrepareRange` method we requested streaming from ledger `from-1`. When `from-1` was available, it meant that init stage is complete and `PrepareRange` could unblock. With buffering we can easily start streaming from `from` ledger and monitor `metaC` channel to determine if the data is available.

### Known limitations

Stellar-Core does not stream ledger 1, possibly because it was pregenerated. To solve this, we update the range to start with ledger 2 in such case and log a warning message when this happens. However, we should discuss if it's possible to fix in Stellar-Core code.
