### PR TITLE
exp/services/recoverysigner: refactor how signers get built in responses

### DIFF
--- a/exp/services/recoverysigner/internal/serve/account_delete.go
+++ b/exp/services/recoverysigner/internal/serve/account_delete.go
@@ -53,15 +53,13 @@ func (h accountDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	signers := []accountResponseSigner{}
-	for _, signingAddress := range h.SigningAddresses {
-		signers = append(signers, accountResponseSigner{
-			Key: signingAddress.Address(),
-		})
-	}
 	resp := accountResponse{
 		Address: acc.Address,
-		Signers: signers,
+	}
+	for _, signingAddress := range h.SigningAddresses {
+		resp.Signers = append(resp.Signers, accountResponseSigner{
+			Key: signingAddress.Address(),
+		})
 	}
 
 	// Authorized if authenticated as the account.

--- a/exp/services/recoverysigner/internal/serve/account_get.go
+++ b/exp/services/recoverysigner/internal/serve/account_get.go
@@ -53,15 +53,13 @@ func (h accountGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	signers := []accountResponseSigner{}
-	for _, signingAddress := range h.SigningAddresses {
-		signers = append(signers, accountResponseSigner{
-			Key: signingAddress.Address(),
-		})
-	}
 	resp := accountResponse{
 		Address: acc.Address,
-		Signers: signers,
+	}
+	for _, signingAddress := range h.SigningAddresses {
+		resp.Signers = append(resp.Signers, accountResponseSigner{
+			Key: signingAddress.Address(),
+		})
 	}
 
 	// Authorized if authenticated as the account.

--- a/exp/services/recoverysigner/internal/serve/account_list.go
+++ b/exp/services/recoverysigner/internal/serve/account_list.go
@@ -48,15 +48,13 @@ func (h accountListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			serverError.Render(w)
 			return
 		} else {
-			signers := []accountResponseSigner{}
-			for _, signingAddress := range h.SigningAddresses {
-				signers = append(signers, accountResponseSigner{
-					Key: signingAddress.Address(),
-				})
-			}
 			accResp := accountResponse{
 				Address: acc.Address,
-				Signers: signers,
+			}
+			for _, signingAddress := range h.SigningAddresses {
+				accResp.Signers = append(accResp.Signers, accountResponseSigner{
+					Key: signingAddress.Address(),
+				})
 			}
 			for _, i := range acc.Identities {
 				accRespIdentity := accountResponseIdentity{
@@ -78,15 +76,13 @@ func (h accountListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		for _, acc := range accs {
-			signers := []accountResponseSigner{}
-			for _, signingAddress := range h.SigningAddresses {
-				signers = append(signers, accountResponseSigner{
-					Key: signingAddress.Address(),
-				})
-			}
 			accResp := accountResponse{
 				Address: acc.Address,
-				Signers: signers,
+			}
+			for _, signingAddress := range h.SigningAddresses {
+				accResp.Signers = append(accResp.Signers, accountResponseSigner{
+					Key: signingAddress.Address(),
+				})
 			}
 			for _, i := range acc.Identities {
 				accRespIdentity := accountResponseIdentity{

--- a/exp/services/recoverysigner/internal/serve/account_post.go
+++ b/exp/services/recoverysigner/internal/serve/account_post.go
@@ -106,8 +106,7 @@ func (h accountPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	authMethodCount := 0
 	acc := account.Account{
-		Address:    req.Address.Address(),
-		Identities: []account.Identity{},
+		Address: req.Address.Address(),
 	}
 	for _, i := range req.Identities {
 		accIdentity := account.Identity{
@@ -139,15 +138,13 @@ func (h accountPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	l.Info("Account registered.")
 
-	signers := []accountResponseSigner{}
-	for _, signingAddress := range h.SigningAddresses {
-		signers = append(signers, accountResponseSigner{
-			Key: signingAddress.Address(),
-		})
-	}
 	resp := accountResponse{
 		Address: acc.Address,
-		Signers: signers,
+	}
+	for _, signingAddress := range h.SigningAddresses {
+		resp.Signers = append(resp.Signers, accountResponseSigner{
+			Key: signingAddress.Address(),
+		})
 	}
 	for _, i := range acc.Identities {
 		respIdentity := accountResponseIdentity{

--- a/exp/services/recoverysigner/internal/serve/account_post.go
+++ b/exp/services/recoverysigner/internal/serve/account_post.go
@@ -106,7 +106,8 @@ func (h accountPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	authMethodCount := 0
 	acc := account.Account{
-		Address: req.Address.Address(),
+		Address:    req.Address.Address(),
+		Identities: []account.Identity{},
 	}
 	for _, i := range req.Identities {
 		accIdentity := account.Identity{

--- a/exp/services/recoverysigner/internal/serve/account_put.go
+++ b/exp/services/recoverysigner/internal/serve/account_put.go
@@ -165,15 +165,13 @@ func (h accountPutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	l.Info("Account updated.")
 
-	signers := []accountResponseSigner{}
-	for _, signingAddress := range h.SigningAddresses {
-		signers = append(signers, accountResponseSigner{
-			Key: signingAddress.Address(),
-		})
-	}
 	resp := accountResponse{
 		Address: accWithNewIdentiies.Address,
-		Signers: signers,
+	}
+	for _, signingAddress := range h.SigningAddresses {
+		resp.Signers = append(resp.Signers, accountResponseSigner{
+			Key: signingAddress.Address(),
+		})
 	}
 	for _, i := range accWithNewIdentiies.Identities {
 		resp.Identities = append(resp.Identities, accountResponseIdentity{


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Rearrange the code that builds signers for account responses so that
signers are built  into the account response after the account response
value is created.

### Why
This is a small thing but it causes the building of the signers to occur
in the same way that building identities does for the response, which
makes the code a bit clearer and will make the code read clearer
especially when we are building the signing addresses into the response
from the database.

This change should have no functional impact.

### Known limitations

N/A
