### PR TITLE
exp/services/recoverysigner: remove line of code that has no effect

### DIFF
--- a/exp/services/recoverysigner/internal/serve/account_post.go
+++ b/exp/services/recoverysigner/internal/serve/account_post.go
@@ -106,8 +106,7 @@ func (h accountPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	authMethodCount := 0
 	acc := account.Account{
-		Address:    req.Address.Address(),
-		Identities: []account.Identity{},
+		Address: req.Address.Address(),
 	}
 	for _, i := range req.Identities {
 		accIdentity := account.Identity{


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Remove a line of code that has no effect.

### Why
This line of code sets the identifies field to be an empty slice. This was probably done at one point in time when we allowed empty identities to make sure the slice was instantiated but we don't allow empty identities anymore and there's no need to set this. It's not harmful to keep it but the code is more identical to other similar code if we remove it.

### Known limitations

N/A
