### PR TITLE
exp/services/recoverysigner: make how signers are built in api responses consistent

### DIFF
--- a/exp/services/recoverysigner/internal/serve/account_list.go
+++ b/exp/services/recoverysigner/internal/serve/account_list.go
@@ -112,15 +112,13 @@ func (h accountListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		for _, acc := range accs {
-			signers := []accountResponseSigner{}
-			for _, signingAddress := range h.SigningAddresses {
-				signers = append(signers, accountResponseSigner{
-					Key: signingAddress.Address(),
-				})
-			}
 			accResp := accountResponse{
 				Address: acc.Address,
-				Signers: signers,
+			}
+			for _, signingAddress := range h.SigningAddresses {
+				accResp.Signers = append(accResp.Signers, accountResponseSigner{
+					Key: signingAddress.Address(),
+				})
 			}
 			for _, i := range acc.Identities {
 				accRespIdentity := accountResponseIdentity{
@@ -150,15 +148,13 @@ func (h accountListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		for _, acc := range accs {
-			signers := []accountResponseSigner{}
-			for _, signingAddress := range h.SigningAddresses {
-				signers = append(signers, accountResponseSigner{
-					Key: signingAddress.Address(),
-				})
-			}
 			accResp := accountResponse{
 				Address: acc.Address,
-				Signers: signers,
+			}
+			for _, signingAddress := range h.SigningAddresses {
+				accResp.Signers = append(accResp.Signers, accountResponseSigner{
+					Key: signingAddress.Address(),
+				})
 			}
 			for _, i := range acc.Identities {
 				accRespIdentity := accountResponseIdentity{


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Make some repetitive code look similar that builds the signers into the API responses of registered accounts.

### Why

This was done in most places in 6643a542d1dc8c4f277fa070654282cea9b4ae53 but I missed these two places.

### Known limitations

This repetitive code should be cleaned up so it lives in one place and we have an issue to do that in the future.