### PR TITLE
exp/services/recoverysigner: make tests more resilient by ordering test queries

### DIFF
--- a/exp/services/recoverysigner/internal/account/db_store_add_test.go
+++ b/exp/services/recoverysigner/internal/account/db_store_add_test.go
@@ -161,7 +161,7 @@ func TestAdd(t *testing.T) {
 			EncryptedSecretKey []byte `db:"encrypted_secret_key"`
 		}
 		rows := []row{}
-		err = session.Select(&rows, `SELECT account_id, id, public_key, encrypted_secret_key FROM signers`)
+		err = session.Select(&rows, `SELECT account_id, id, public_key, encrypted_secret_key FROM signers ORDER BY id`)
 		require.NoError(t, err)
 		wantRows := []row{
 			{

--- a/exp/services/recoverysigner/internal/account/db_store_delete_test.go
+++ b/exp/services/recoverysigner/internal/account/db_store_delete_test.go
@@ -217,7 +217,7 @@ func TestDelete(t *testing.T) {
 			PublicKey string `db:"public_key"`
 		}
 		rows := []row{}
-		err = session.Select(&rows, `SELECT public_key FROM signers`)
+		err = session.Select(&rows, `SELECT public_key FROM signers ORDER BY id`)
 		require.NoError(t, err)
 		wantRows := []row{
 			// Signers for account 2
@@ -233,7 +233,7 @@ func TestDelete(t *testing.T) {
 			PublicKey string `db:"public_key"`
 		}
 		rows := []row{}
-		err = session.Select(&rows, `SELECT audit_op, public_key FROM signers_audit`)
+		err = session.Select(&rows, `SELECT audit_op, public_key FROM signers_audit ORDER BY audit_id`)
 		require.NoError(t, err)
 		wantRows := []row{
 			// Signers for account 1


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Add an ORDER BY to all SQL queries used in recoverysigner tests.

### Why
@howardtw pointed out that Postgres doesn't guarantee any particular
order in query results and the tests assume the results are ordered by
their primary key. We've never seen a test fail because in practice the
results being small are likely stored contiguously on disk and have
simple execution plans resulting in primary key ordering, even though it
isn't guaranteed by the Postgres specification. However, it doesn't hurt
to add the ORDER BY and therefore prevent some future possible
intermittent test failure.

Related to #2773 which changes all tests on master and this PR
changes tests that have been added on this feature branch.

### Known limitations

N/A
