### PR TITLE
exp/services/recoverysigner: add a test expectation to check that signers remain unchanged after updating an account

### DIFF
--- a/exp/services/recoverysigner/internal/account/db_store_update_test.go
+++ b/exp/services/recoverysigner/internal/account/db_store_update_test.go
@@ -152,6 +152,28 @@ func TestUpdate(t *testing.T) {
 		}
 		assert.Equal(t, wantRows, rows)
 	}
+
+	// Check the signer rows remain unchanged.
+	{
+		type row struct {
+			AccountID          int64  `db:"account_id"`
+			ID                 int64  `db:"id"`
+			PublicKey          string `db:"public_key"`
+			EncryptedSecretKey []byte `db:"encrypted_secret_key"`
+		}
+		rows := []row{}
+		err = session.Select(&rows, `SELECT account_id, id, public_key, encrypted_secret_key FROM signers ORDER BY id`)
+		require.NoError(t, err)
+		wantRows := []row{
+			{
+				AccountID:          1,
+				ID:                 1,
+				PublicKey:          "GDPLSCUPCZY3DU24E5AKNTGPMIODO57MXMMCNP242SVQIXPL7ZWQBWGF",
+				EncryptedSecretKey: []byte("encrypted(SCYT3GTACLWCEKMRJVUH5QNGWIT2CBGGDJBUVVANNDGQDCJAMO77WGLU)"),
+			},
+		}
+		assert.Equal(t, wantRows, rows)
+	}
 }
 
 func TestUpdate_removeIdentities(t *testing.T) {


### PR DESCRIPTION
### What
Add missing test to check that updates to an account do not change the
signers that are stored on the account.

### Why
Updates to an account should never change the signers and it's
important enough to test.

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add a test expectation to check that signers remain unchanged after updating an account.

### Why

When we update accounts their signers should remain unchanged, it seems important enough to have an expectation for.

### Known limitations

[TODO or N/A]
