### PR TITLE
Add Range type with bounded and unbounded constructors

### DIFF
--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -253,17 +253,17 @@ func (c *CaptiveStellarCore) readLedgerMetaFromPipe() (*xdr.LedgerCloseMeta, err
 // Some backends (like captive stellar-core) need to initalize data to be
 // able to stream ledgers.
 // Set `to` to 0 to stream starting from `from` but without limits.
-func (c *CaptiveStellarCore) PrepareRange(from uint32, to uint32) error {
-	if c.nextLedger != 0 && c.nextLedger >= from {
+func (c *CaptiveStellarCore) PrepareRange(ledgerRange Range) error {
+	if c.nextLedger != 0 && c.nextLedger >= ledgerRange.from {
 		// Range already prepared
 		return nil
 	}
 
 	var err error
-	if to == 0 {
-		err = c.openOnlineReplaySubprocess(from)
+	if ledgerRange.bounded {
+		err = c.openOfflineReplaySubprocess(ledgerRange.from, ledgerRange.to)
 	} else {
-		err = c.openOfflineReplaySubprocess(from, to)
+		err = c.openOnlineReplaySubprocess(ledgerRange.from)
 	}
 	if err != nil {
 		return errors.Wrap(err, "opening subprocess")

--- a/exp/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend_test.go
@@ -134,7 +134,7 @@ func TestCaptivePrepareRange(t *testing.T) {
 		stellarCoreRunner: mockRunner,
 	}
 
-	err := captiveBackend.PrepareRange(100, 200)
+	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
 	assert.NoError(t, err)
 	err = captiveBackend.Close()
 	assert.NoError(t, err)

--- a/exp/ingest/ledgerbackend/database_backend.go
+++ b/exp/ingest/ledgerbackend/database_backend.go
@@ -39,8 +39,8 @@ func NewDatabaseBackendFromSession(session *db.Session) (*DatabaseBackend, error
 	return &DatabaseBackend{session: session}, nil
 }
 
-func (dbb *DatabaseBackend) PrepareRange(from uint32, to uint32) error {
-	fromExists, _, err := dbb.GetLedger(from)
+func (dbb *DatabaseBackend) PrepareRange(ledgerRange Range) error {
+	fromExists, _, err := dbb.GetLedger(ledgerRange.from)
 	if err != nil {
 		return errors.Wrap(err, "error getting ledger")
 	}
@@ -49,8 +49,8 @@ func (dbb *DatabaseBackend) PrepareRange(from uint32, to uint32) error {
 		return errors.New("`from` ledger does not exist")
 	}
 
-	if to != 0 {
-		toExists, _, err := dbb.GetLedger(to)
+	if ledgerRange.bounded {
+		toExists, _, err := dbb.GetLedger(ledgerRange.to)
 		if err != nil {
 			return errors.Wrap(err, "error getting ledger")
 		}

--- a/exp/ingest/ledgerbackend/ledger_backend.go
+++ b/exp/ingest/ledgerbackend/ledger_backend.go
@@ -4,6 +4,23 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
+// Range represents a range of ledger sequence numbers.
+type Range struct {
+	from    uint32
+	to      uint32
+	bounded bool
+}
+
+// BoundedRange constructs a bounded range of ledgers with a fixed starting ledger and ending ledger.
+func BoundedRange(from uint32, to uint32) Range {
+	return Range{from: from, to: to, bounded: true}
+}
+
+// BoundedRange constructs a unbounded range of ledgers with a fixed starting ledger.
+func UnboundedRange(from uint32) Range {
+	return Range{from: from, bounded: false}
+}
+
 // LedgerBackend represents the interface to a ledger data store.
 type LedgerBackend interface {
 	// GetLatestLedgerSequence returns the sequence of the latest ledger available
@@ -14,7 +31,7 @@ type LedgerBackend interface {
 	// PrepareRange prepares the given range (including from and to) to be loaded.
 	// Some backends (like captive stellar-core) need to initalize data to be
 	// able to stream ledgers.
-	PrepareRange(from uint32, to uint32) error
+	PrepareRange(ledgerRange Range) error
 	Close() error
 }
 

--- a/exp/ingest/ledgerbackend/mock_database_backend.go
+++ b/exp/ingest/ledgerbackend/mock_database_backend.go
@@ -16,8 +16,8 @@ func (m *MockDatabaseBackend) GetLatestLedgerSequence() (uint32, error) {
 	return args.Get(0).(uint32), args.Error(1)
 }
 
-func (m *MockDatabaseBackend) PrepareRange(from uint32, to uint32) error {
-	args := m.Called(from, to)
+func (m *MockDatabaseBackend) PrepareRange(ledgerRange Range) error {
+	args := m.Called(ledgerRange)
 	return args.Error(0)
 }
 

--- a/services/horizon/internal/expingest/build_state_test.go
+++ b/services/horizon/internal/expingest/build_state_test.go
@@ -180,7 +180,7 @@ func (s *BuildStateTestSuite) TestTruncateExpingestStateTablesReturnsError() {
 
 func (s *BuildStateTestSuite) TestRunHistoryArchiveIngestionReturnsError() {
 	s.mockCommonHistoryQ()
-	s.ledgerBackend.On("PrepareRange", uint32(63), uint32(0)).Return(nil).Once()
+	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(63)).Return(nil).Once()
 	s.runner.
 		On("RunHistoryArchiveIngestion", s.checkpointLedger).
 		Return(io.StatsChangeProcessorResults{}, errors.New("my error")).
@@ -194,7 +194,7 @@ func (s *BuildStateTestSuite) TestRunHistoryArchiveIngestionReturnsError() {
 
 func (s *BuildStateTestSuite) TestUpdateLastLedgerExpIngestAfterIngestReturnsError() {
 	s.mockCommonHistoryQ()
-	s.ledgerBackend.On("PrepareRange", uint32(63), uint32(0)).Return(nil).Once()
+	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(63)).Return(nil).Once()
 	s.runner.
 		On("RunHistoryArchiveIngestion", s.checkpointLedger).
 		Return(io.StatsChangeProcessorResults{}, nil).
@@ -214,7 +214,7 @@ func (s *BuildStateTestSuite) TestUpdateLastLedgerExpIngestAfterIngestReturnsErr
 
 func (s *BuildStateTestSuite) TestUpdateExpIngestVersionIngestReturnsError() {
 	s.mockCommonHistoryQ()
-	s.ledgerBackend.On("PrepareRange", uint32(63), uint32(0)).Return(nil).Once()
+	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(63)).Return(nil).Once()
 	s.runner.
 		On("RunHistoryArchiveIngestion", s.checkpointLedger).
 		Return(io.StatsChangeProcessorResults{}, nil).
@@ -231,7 +231,7 @@ func (s *BuildStateTestSuite) TestUpdateExpIngestVersionIngestReturnsError() {
 
 func (s *BuildStateTestSuite) TestUpdateCommitReturnsError() {
 	s.mockCommonHistoryQ()
-	s.ledgerBackend.On("PrepareRange", uint32(63), uint32(0)).Return(nil).Once()
+	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(63)).Return(nil).Once()
 	s.runner.
 		On("RunHistoryArchiveIngestion", s.checkpointLedger).
 		Return(io.StatsChangeProcessorResults{}, nil).
@@ -254,7 +254,7 @@ func (s *BuildStateTestSuite) TestUpdateCommitReturnsError() {
 
 func (s *BuildStateTestSuite) TestBuildStateSucceeds() {
 	s.mockCommonHistoryQ()
-	s.ledgerBackend.On("PrepareRange", uint32(63), uint32(0)).Return(nil).Once()
+	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(63)).Return(nil).Once()
 	s.runner.
 		On("RunHistoryArchiveIngestion", s.checkpointLedger).
 		Return(io.StatsChangeProcessorResults{}, nil).

--- a/services/horizon/internal/expingest/db_integration_test.go
+++ b/services/horizon/internal/expingest/db_integration_test.go
@@ -109,7 +109,7 @@ func (s *DBTestSuite) setupMocksForBuildState() {
 	s.historyAdapter.On("BucketListHash", s.sequence).
 		Return(checkpointHash, nil).Once()
 
-	s.ledgerBackend.On("PrepareRange", s.sequence, uint32(0)).Return(nil).Once()
+	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(s.sequence)).Return(nil).Once()
 	s.ledgerBackend.On("GetLedger", s.sequence).
 		Return(
 			true,

--- a/services/horizon/internal/expingest/fake_ledger_backend.go
+++ b/services/horizon/internal/expingest/fake_ledger_backend.go
@@ -1,6 +1,7 @@
 package expingest
 
 import (
+	"github.com/stellar/go/exp/ingest/ledgerbackend"
 	"github.com/stellar/go/keypair"
 	logpkg "github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
@@ -15,7 +16,7 @@ func (fakeLedgerBackend) GetLatestLedgerSequence() (uint32, error) {
 	return 1, nil
 }
 
-func (fakeLedgerBackend) PrepareRange(from uint32, to uint32) error {
+func (fakeLedgerBackend) PrepareRange(r ledgerbackend.Range) error {
 	return nil
 }
 

--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -2,6 +2,7 @@ package expingest
 
 import (
 	"fmt"
+	"github.com/stellar/go/exp/ingest/ledgerbackend"
 	"time"
 
 	"github.com/stellar/go/exp/ingest/io"
@@ -274,7 +275,7 @@ func (b buildState) run(s *System) (transition, error) {
 	}).Info("Processing state")
 	startTime := time.Now()
 
-	err = s.ledgerBackend.PrepareRange(b.checkpointLedger, 0)
+	err = s.ledgerBackend.PrepareRange(ledgerbackend.UnboundedRange(b.checkpointLedger))
 	if err != nil {
 		return stop(), errors.Wrap(err, "error preparing range")
 	}
@@ -370,7 +371,7 @@ func (r resumeState) run(s *System) (transition, error) {
 		return start(), nil
 	}
 
-	err = s.ledgerBackend.PrepareRange(ingestLedger, 0)
+	err = s.ledgerBackend.PrepareRange(ledgerbackend.UnboundedRange(ingestLedger))
 	if err != nil {
 		return stop(), errors.Wrap(err, "error preparing range")
 	}
@@ -475,7 +476,7 @@ func (h historyRangeState) run(s *System) (transition, error) {
 		return start(), nil
 	}
 
-	err = s.ledgerBackend.PrepareRange(h.fromLedger, 0)
+	err = s.ledgerBackend.PrepareRange(ledgerbackend.UnboundedRange(h.fromLedger))
 	if err != nil {
 		return stop(), errors.Wrap(err, "error preparing range")
 	}
@@ -576,7 +577,7 @@ func (h reingestHistoryRangeState) run(s *System) (transition, error) {
 	}).Info("Preparing ledger backend to retrieve range")
 	startTime := time.Now()
 
-	err := s.ledgerBackend.PrepareRange(h.fromLedger, h.toLedger)
+	err := s.ledgerBackend.PrepareRange(ledgerbackend.BoundedRange(h.fromLedger, h.toLedger))
 	if err != nil {
 		return stop(), errors.Wrap(err, "error preparing range")
 	}

--- a/services/horizon/internal/expingest/ingest_history_range_state_test.go
+++ b/services/horizon/internal/expingest/ingest_history_range_state_test.go
@@ -124,7 +124,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestRunTransactionProcessorsOnLedgerR
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
-	s.ledgerBackend.On("PrepareRange", uint32(100), uint32(0)).Return(nil).Once()
+	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(100)).Return(nil).Once()
 	s.runner.On("RunTransactionProcessorsOnLedger", uint32(100)).Return(io.StatsLedgerTransactionProcessorResults{}, errors.New("my error")).Once()
 
 	next, err := historyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
@@ -138,7 +138,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestSuccess() {
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
-	s.ledgerBackend.On("PrepareRange", uint32(100), uint32(0)).Return(nil).Once()
+	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(100)).Return(nil).Once()
 	for i := 100; i <= 200; i++ {
 		s.runner.On("RunTransactionProcessorsOnLedger", uint32(i)).Return(io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 	}
@@ -155,7 +155,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
-	s.ledgerBackend.On("PrepareRange", uint32(100), uint32(0)).Return(nil).Once()
+	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(100)).Return(nil).Once()
 	s.runner.On("RunTransactionProcessorsOnLedger", uint32(100)).Return(io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 
 	s.historyQ.On("Commit").Return(nil).Once()
@@ -195,7 +195,7 @@ func (s *ReingestHistoryRangeStateTestSuite) SetupTest() {
 	s.historyQ.On("Rollback").Return(nil).Once()
 	s.historyQ.On("Begin").Return(nil).Once()
 
-	s.ledgerBackend.On("PrepareRange", uint32(100), uint32(200)).Return(nil).Once()
+	s.ledgerBackend.On("PrepareRange", ledgerbackend.BoundedRange(100, 200)).Return(nil).Once()
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TearDownTest() {
@@ -367,7 +367,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
 
 	// Recreate mock in this single test to remove previous assertion.
 	*s.ledgerBackend = mockLedgerBackend{}
-	s.ledgerBackend.On("PrepareRange", uint32(100), uint32(100)).Return(nil).Once()
+	s.ledgerBackend.On("PrepareRange", ledgerbackend.BoundedRange(100, 100)).Return(nil).Once()
 
 	err := s.system.ReingestRange(100, 100, false)
 	s.Assert().NoError(err)

--- a/services/horizon/internal/expingest/main_test.go
+++ b/services/horizon/internal/expingest/main_test.go
@@ -369,8 +369,8 @@ func (m *mockLedgerBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMet
 	return args.Get(0).(bool), args.Get(1).(xdr.LedgerCloseMeta), args.Error(2)
 }
 
-func (m *mockLedgerBackend) PrepareRange(from uint32, to uint32) error {
-	args := m.Called(from, to)
+func (m *mockLedgerBackend) PrepareRange(ledgerRange ledgerbackend.Range) error {
+	args := m.Called(ledgerRange)
 	return args.Error(0)
 }
 

--- a/services/horizon/internal/expingest/resume_state_test.go
+++ b/services/horizon/internal/expingest/resume_state_test.go
@@ -208,7 +208,7 @@ func (s *ResumeTestTestSuite) mockSuccessfulIngestion() {
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
 
-	s.ledgerBackend.On("PrepareRange", uint32(102), uint32(0)).Return(nil).Once()
+	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(102)).Return(nil).Once()
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(uint32(111), nil).Once()
 
 	s.runner.On("RunAllProcessorsOnLedger", uint32(102)).Return(io.StatsChangeProcessorResults{}, io.StatsLedgerTransactionProcessorResults{}, nil).Once()
@@ -272,7 +272,7 @@ func (s *ResumeTestTestSuite) TestErrorSettingCursorIgnored() {
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
-	s.ledgerBackend.On("PrepareRange", uint32(101), uint32(0)).Return(nil).Once()
+	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(101)).Return(nil).Once()
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(uint32(111), nil).Once()
 
 	s.runner.On("RunAllProcessorsOnLedger", uint32(101)).Return(io.StatsChangeProcessorResults{}, io.StatsLedgerTransactionProcessorResults{}, nil).Once()
@@ -305,7 +305,7 @@ func (s *ResumeTestTestSuite) TestNoNewLedgers() {
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
-	s.ledgerBackend.On("PrepareRange", uint32(101), uint32(0)).Return(nil).Once()
+	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(101)).Return(nil).Once()
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(uint32(100), nil).Once()
 
 	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add Range type with bounded and unbounded constructors.

Fixes https://github.com/stellar/go/issues/2711

Addresses the following comment from https://github.com/stellar/go/pull/2694
>Could you document the special meaning of 0.
>Even better, would be using something more self-explanatory and explicit instead of using a special value (e.g. a specialized method called PrepareFullRangeFrom(from uint32))

