### PR TITLE
services/horizon: Relax requirement on Core URL flags

### DIFF
--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -204,26 +204,30 @@ var dbReingestRangeCmd = &cobra.Command{
 
 		initRootConfig()
 
-		coreSession, err := db.Open("postgres", config.StellarCoreDatabaseURL)
-		if err != nil {
-			log.Fatalf("cannot open Core DB: %v", err)
-		}
-
 		horizonSession, err := db.Open("postgres", config.DatabaseURL)
 		if err != nil {
 			log.Fatalf("cannot open Horizon DB: %v", err)
 		}
 
 		ingestConfig := expingest.Config{
-			CoreSession:                coreSession,
 			NetworkPassphrase:          config.NetworkPassphrase,
 			HistorySession:             horizonSession,
 			HistoryArchiveURL:          config.HistoryArchiveURLs[0],
 			MaxReingestRetries:         int(retries),
 			ReingesRetryBackoffSeconds: int(retryBackoffSeconds),
 		}
+
 		if config.EnableCaptiveCoreIngestion {
 			ingestConfig.StellarCorePath = config.StellarCoreBinaryPath
+		} else {
+			if config.StellarCoreDatabaseURL == "" {
+				log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
+			}
+			coreSession, err := db.Open("postgres", config.StellarCoreDatabaseURL)
+			if err != nil {
+				log.Fatalf("cannot open Core DB: %v", err)
+			}
+			ingestConfig.CoreSession = coreSession
 		}
 
 		if parallelWorkers < 2 {

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -223,9 +223,9 @@ var dbReingestRangeCmd = &cobra.Command{
 			if config.StellarCoreDatabaseURL == "" {
 				log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
 			}
-			coreSession, err := db.Open("postgres", config.StellarCoreDatabaseURL)
-			if err != nil {
-				log.Fatalf("cannot open Core DB: %v", err)
+			coreSession, dbErr := db.Open("postgres", config.StellarCoreDatabaseURL)
+			if dbErr != nil {
+				log.Fatalf("cannot open Core DB: %v", dbErr)
 			}
 			ingestConfig.CoreSession = coreSession
 		}

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -24,7 +24,7 @@ var ingestVerifyFrom, ingestVerifyTo, ingestVerifyDebugServerPort uint32
 var ingestVerifyState bool
 
 var ingestVerifyRangeCmdOpts = []*support.ConfigOption{
-	&support.ConfigOption{
+	{
 		Name:        "from",
 		ConfigKey:   &ingestVerifyFrom,
 		OptType:     types.Uint32,
@@ -32,7 +32,7 @@ var ingestVerifyRangeCmdOpts = []*support.ConfigOption{
 		FlagDefault: uint32(0),
 		Usage:       "first ledger of the range to ingest",
 	},
-	&support.ConfigOption{
+	{
 		Name:        "to",
 		ConfigKey:   &ingestVerifyTo,
 		OptType:     types.Uint32,
@@ -40,7 +40,7 @@ var ingestVerifyRangeCmdOpts = []*support.ConfigOption{
 		FlagDefault: uint32(0),
 		Usage:       "last ledger of the range to ingest",
 	},
-	&support.ConfigOption{
+	{
 		Name:        "verify-state",
 		ConfigKey:   &ingestVerifyState,
 		OptType:     types.Bool,
@@ -48,7 +48,7 @@ var ingestVerifyRangeCmdOpts = []*support.ConfigOption{
 		FlagDefault: false,
 		Usage:       "[optional] verifies state at the last ledger of the range when true",
 	},
-	&support.ConfigOption{
+	{
 		Name:        "debug-server-port",
 		ConfigKey:   &ingestVerifyDebugServerPort,
 		OptType:     types.Uint32,
@@ -83,11 +83,6 @@ var ingestVerifyRangeCmd = &cobra.Command{
 			}()
 		}
 
-		coreSession, err := db.Open("postgres", config.StellarCoreDatabaseURL)
-		if err != nil {
-			log.Fatalf("cannot open Core DB: %v", err)
-		}
-
 		horizonSession, err := db.Open("postgres", config.DatabaseURL)
 		if err != nil {
 			log.Fatalf("cannot open Horizon DB: %v", err)
@@ -102,13 +97,22 @@ var ingestVerifyRangeCmd = &cobra.Command{
 		}
 
 		ingestConfig := expingest.Config{
-			CoreSession:       coreSession,
 			NetworkPassphrase: config.NetworkPassphrase,
 			HistorySession:    horizonSession,
 			HistoryArchiveURL: config.HistoryArchiveURLs[0],
 		}
 		if config.EnableCaptiveCoreIngestion {
 			ingestConfig.StellarCorePath = config.StellarCoreBinaryPath
+		} else {
+			if config.StellarCoreDatabaseURL == "" {
+				log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
+			}
+
+			coreSession, err := db.Open("postgres", config.StellarCoreDatabaseURL)
+			if err != nil {
+				log.Fatalf("cannot open Core DB: %v", err)
+			}
+			ingestConfig.CoreSession = coreSession
 		}
 
 		system, err := expingest.NewSystem(ingestConfig)
@@ -132,7 +136,7 @@ var ingestVerifyRangeCmd = &cobra.Command{
 var stressTestNumTransactions, stressTestChangesPerTransaction int
 
 var stressTestCmdOpts = []*support.ConfigOption{
-	&support.ConfigOption{
+	{
 		Name:        "transactions",
 		ConfigKey:   &stressTestNumTransactions,
 		OptType:     types.Int,
@@ -140,7 +144,7 @@ var stressTestCmdOpts = []*support.ConfigOption{
 		FlagDefault: int(1000),
 		Usage:       "total number of transactions to ingest (at most 1000)",
 	},
-	&support.ConfigOption{
+	{
 		Name:        "changes",
 		ConfigKey:   &stressTestChangesPerTransaction,
 		OptType:     types.Int,
@@ -162,11 +166,6 @@ var ingestStressTestCmd = &cobra.Command{
 
 		initRootConfig()
 
-		coreSession, err := db.Open("postgres", config.StellarCoreDatabaseURL)
-		if err != nil {
-			log.Fatalf("cannot open Core DB: %v", err)
-		}
-
 		horizonSession, err := db.Open("postgres", config.DatabaseURL)
 		if err != nil {
 			log.Fatalf("cannot open Horizon DB: %v", err)
@@ -181,13 +180,23 @@ var ingestStressTestCmd = &cobra.Command{
 		}
 
 		ingestConfig := expingest.Config{
-			CoreSession:       coreSession,
 			NetworkPassphrase: config.NetworkPassphrase,
 			HistorySession:    horizonSession,
 			HistoryArchiveURL: config.HistoryArchiveURLs[0],
 		}
+
 		if config.EnableCaptiveCoreIngestion {
 			ingestConfig.StellarCorePath = config.StellarCoreBinaryPath
+		} else {
+			if config.StellarCoreDatabaseURL == "" {
+				log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
+			}
+
+			coreSession, err := db.Open("postgres", config.StellarCoreDatabaseURL)
+			if err != nil {
+				log.Fatalf("cannot open Core DB: %v", err)
+			}
+			ingestConfig.CoreSession = coreSession
 		}
 
 		system, err := expingest.NewSystem(ingestConfig)

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -108,9 +108,9 @@ var ingestVerifyRangeCmd = &cobra.Command{
 				log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
 			}
 
-			coreSession, err := db.Open("postgres", config.StellarCoreDatabaseURL)
-			if err != nil {
-				log.Fatalf("cannot open Core DB: %v", err)
+			coreSession, dbErr := db.Open("postgres", config.StellarCoreDatabaseURL)
+			if dbErr != nil {
+				log.Fatalf("cannot open Core DB: %v", dbErr)
 			}
 			ingestConfig.CoreSession = coreSession
 		}
@@ -192,9 +192,9 @@ var ingestStressTestCmd = &cobra.Command{
 				log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
 			}
 
-			coreSession, err := db.Open("postgres", config.StellarCoreDatabaseURL)
-			if err != nil {
-				log.Fatalf("cannot open Core DB: %v", err)
+			coreSession, dbErr := db.Open("postgres", config.StellarCoreDatabaseURL)
+			if dbErr != nil {
+				log.Fatalf("cannot open Core DB: %v", dbErr)
 			}
 			ingestConfig.CoreSession = coreSession
 		}

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -34,10 +34,10 @@ var (
 		Short: "client-facing api server for the stellar network",
 		Long:  "client-facing api server for the stellar network. It acts as the interface between Stellar Core and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.",
 		Run: func(cmd *cobra.Command, args []string) {
+			if config.StellarCoreURL == "" {
+				log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
+			}
 			if config.Ingest {
-				if config.StellarCoreURL == "" {
-					log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
-				}
 				if config.StellarCoreDatabaseURL == "" {
 					log.Fatalf("flag --%s cannot be empty", stellarCoreURLFlagName)
 				}

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -34,14 +34,6 @@ var (
 		Short: "client-facing api server for the stellar network",
 		Long:  "client-facing api server for the stellar network. It acts as the interface between Stellar Core and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.",
 		Run: func(cmd *cobra.Command, args []string) {
-			if config.StellarCoreURL == "" {
-				log.Fatalf("flag --%s cannot be empty", stellarCoreURLFlagName)
-			}
-			if config.Ingest {
-				if config.StellarCoreDatabaseURL == "" {
-					log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
-				}
-			}
 			initApp().Serve()
 		},
 	}
@@ -380,6 +372,15 @@ func init() {
 
 func initApp() *horizon.App {
 	initRootConfig()
+	// Validate app-specific arguments
+	if config.StellarCoreURL == "" {
+		log.Fatalf("flag --%s cannot be empty", stellarCoreURLFlagName)
+	}
+	if config.Ingest {
+		if config.StellarCoreDatabaseURL == "" {
+			log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
+		}
+	}
 	return horizon.NewApp(config)
 }
 

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -35,11 +35,11 @@ var (
 		Long:  "client-facing api server for the stellar network. It acts as the interface between Stellar Core and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.",
 		Run: func(cmd *cobra.Command, args []string) {
 			if config.StellarCoreURL == "" {
-				log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
+				log.Fatalf("flag --%s cannot be empty", stellarCoreURLFlagName)
 			}
 			if config.Ingest {
 				if config.StellarCoreDatabaseURL == "" {
-					log.Fatalf("flag --%s cannot be empty", stellarCoreURLFlagName)
+					log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
 				}
 			}
 			initApp().Serve()

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -20,6 +20,12 @@ import (
 	"github.com/stellar/throttled"
 )
 
+const (
+	maxDBPingAttempts        = 30
+	stellarCoreDBURLFlagName = "stellar-core-db-url"
+	stellarCoreURLFlagName   = "stellar-core-url"
+)
+
 var (
 	config horizon.Config
 
@@ -28,12 +34,18 @@ var (
 		Short: "client-facing api server for the stellar network",
 		Long:  "client-facing api server for the stellar network. It acts as the interface between Stellar Core and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.",
 		Run: func(cmd *cobra.Command, args []string) {
+			if config.Ingest {
+				if config.StellarCoreURL == "" {
+					log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
+				}
+				if config.StellarCoreDatabaseURL == "" {
+					log.Fatalf("flag --%s cannot be empty", stellarCoreURLFlagName)
+				}
+			}
 			initApp().Serve()
 		},
 	}
 )
-
-const maxDBPingAttempts = 30
 
 // validateBothOrNeither ensures that both options are provided, if either is provided.
 func validateBothOrNeither(option1, option2 string) {
@@ -127,18 +139,16 @@ var configOpts = support.ConfigOptions{
 		ConfigKey:   &config.EnableCaptiveCoreIngestion,
 	},
 	&support.ConfigOption{
-		Name:      "stellar-core-db-url",
+		Name:      stellarCoreDBURLFlagName,
 		EnvVar:    "STELLAR_CORE_DATABASE_URL",
 		ConfigKey: &config.StellarCoreDatabaseURL,
 		OptType:   types.String,
-		Required:  true,
 		Usage:     "stellar-core postgres database to connect with",
 	},
 	&support.ConfigOption{
-		Name:      "stellar-core-url",
+		Name:      stellarCoreURLFlagName,
 		ConfigKey: &config.StellarCoreURL,
 		OptType:   types.String,
-		Required:  true,
 		Usage:     "stellar-core to connect with (for http commands)",
 	},
 	&support.ConfigOption{

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -149,9 +149,6 @@ func NewSystem(config Config) (System, error) {
 		return nil, errors.Wrap(err, "error creating history archive")
 	}
 
-	coreSession := config.CoreSession.Clone()
-	coreSession.Ctx = ctx
-
 	var ledgerBackend ledgerbackend.LedgerBackend
 	if len(config.StellarCorePath) > 0 {
 		ledgerBackend = ledgerbackend.NewCaptive(
@@ -160,6 +157,8 @@ func NewSystem(config Config) (System, error) {
 			[]string{config.HistoryArchiveURL},
 		)
 	} else {
+		coreSession := config.CoreSession.Clone()
+		coreSession.Ctx = ctx
 		ledgerBackend, err = ledgerbackend.NewDatabaseBackendFromSession(coreSession, config.NetworkPassphrase)
 		if err != nil {
 			cancel()


### PR DESCRIPTION
They shouldn't be required when captive core is used

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ x This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Only require `--stellar-core-db-url` and `--stellar-core-url` explicitly when they are really needed.

Fixes https://github.com/stellar/go/issues/2779

### Why

An external Core instance is not required when using Captive Core, imposing artificial restrictions

### Known limitations

The message printed out won't be identical to the one printed by Cobra.
