### PR TITLE
exp/ingest/ledgerbackend: Update captive GetLatestLedgerSequence to return correct value

### DIFF
--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -350,22 +350,16 @@ loop:
 
 // GetLatestLedgerSequence returns the sequence of the latest ledger available
 // in the backend.
-// Will return error if not in session (start with `PrepareRange`).
+// Will return error if not in a session (start with `PrepareRange`).
 func (c *CaptiveStellarCore) GetLatestLedgerSequence() (uint32, error) {
 	if c.isClosed() {
 		return 0, errors.New("stellar-core must be opened to return latest available sequence")
 	}
 
 	if c.lastLedger == nil {
-		// TODO Get latest buffered ledger when XDR buffer is ready
-		if len(c.metaC) > 0 {
-			return c.nextLedger, nil
-		} else {
-			return c.nextLedger - 1, nil
-		}
-	} else {
-		return *c.lastLedger, nil
+		return c.nextLedger - 1 + uint32(len(c.metaC)), nil
 	}
+	return *c.lastLedger, nil
 }
 
 func (c *CaptiveStellarCore) isClosed() bool {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Update `CaptiveStellarCore.GetLatestLedgerSequence` the latest sequence available in a buffer.

Close #2704.

### Why

Currently `CaptiveStellarCore` backend returns `nextLedger` (when meta channel is not empty) or `nextLedger-1` (when meta channel is empty). After #2693 we can return the exact value of a sequence of the latest ledger in a buffer.