### PR TITLE
exp/ingest/ledgerbackend: Only allow non-decreasing calls to GetLedger

### DIFF
--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -288,7 +288,7 @@ func (c *CaptiveStellarCore) PrepareRange(ledgerRange Range) error {
 // GetLedger returns true when ledger is found and it's LedgerCloseMeta.
 // Call `PrepareRange` first to instruct the backend which ledgers to fetch.
 //
-// We assume that we'll be called repeatedly asking for ledgers in ascending
+// We assume that we'll be called repeatedly asking for ledgers in a non-decreasing
 // order, so when asked for ledger 23 we start a subprocess doing catchup
 // "100023/100000", which should replay 23, 24, 25, ... 100023. The wrinkle in
 // this is that core will actually replay from the _checkpoint before_
@@ -303,6 +303,14 @@ func (c *CaptiveStellarCore) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMe
 
 	if c.isClosed() {
 		return false, xdr.LedgerCloseMeta{}, errors.New("session is closed, call PrepareRange first")
+	}
+
+	if sequence < c.nextLedger {
+		return false, xdr.LedgerCloseMeta{}, errors.Errorf(
+			"requested ledger %d is behind the captive core stream (expected=%d)",
+			sequence,
+			c.nextLedger,
+		)
 	}
 
 	// Now loop along the range until we find the ledger we want.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Unlike `DatabaseBackend` instances, there is an implicit expectation that a`CaptiveStellarCore` instance should not be called on ledgers with a random access pattern. `CaptiveStellarCore` expects  `GetLedger()` to be called on a sequence of non decreasing ledgers. It is possible for a `CaptiveStellarCore` to seek ahead to a future ledger in the stream. However, `CaptiveStellarCore` does not support rewinding back several ledgers in history.

This commit adds an explicit check to `GetLedger()` which returns an error if `GetLedger()` is called using non-decreasing ledgers.
