### PR TITLE
exp/ingest/captive_stellar_core_backend: Update backend to receive an archive interface.

### DIFF
--- a/exp/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend_test.go
@@ -192,11 +192,82 @@ func TestCaptivePrepareRange_ErrGettingRootHAS(t *testing.T) {
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
 		stellarCoreRunner: mockRunner,
-		nextLedger:        1,
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
 	assert.EqualError(t, err, "opening subprocess: error getting latest checkpoint sequence: error getting root HAS: transient error")
+}
+
+func TestCaptivePrepareRange_FromIsAheadOfRootHAS(t *testing.T) {
+	var buf bytes.Buffer
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("catchup", uint32(100), uint32(200)).Return(nil).Once()
+	mockRunner.On("getMetaPipe").Return(&buf)
+	mockRunner.On("close").Return(nil)
+
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.
+		On("GetRootHAS").
+		Return(historyarchive.HistoryArchiveState{
+			CurrentLedger: uint32(64),
+		}, nil)
+
+	captiveBackend := CaptiveStellarCore{
+		archive:           mockArchive,
+		networkPassphrase: network.PublicNetworkPassphrase,
+		stellarCoreRunner: mockRunner,
+	}
+
+	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
+	assert.EqualError(t, err, "opening subprocess: sequence: 100 is greater than max available in history archives: 64")
+}
+
+func TestCaptivePrepareRange_ToIsAheadOfRootHAS(t *testing.T) {
+	var buf bytes.Buffer
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("catchup", uint32(100), uint32(192)).Return(nil).Once()
+	mockRunner.On("getMetaPipe").Return(&buf)
+	mockRunner.On("close").Return(nil)
+
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.
+		On("GetRootHAS").
+		Return(historyarchive.HistoryArchiveState{
+			CurrentLedger: uint32(192),
+		}, nil)
+
+	captiveBackend := CaptiveStellarCore{
+		archive:           mockArchive,
+		networkPassphrase: network.PublicNetworkPassphrase,
+		stellarCoreRunner: mockRunner,
+	}
+
+	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
+	assert.NoError(t, err)
+}
+
+func TestCaptivePrepareRange_ErrCatchup(t *testing.T) {
+	var buf bytes.Buffer
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("catchup", uint32(100), uint32(192)).Return(errors.New("transient error")).Once()
+	mockRunner.On("getMetaPipe").Return(&buf)
+	mockRunner.On("close").Return(nil)
+
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.
+		On("GetRootHAS").
+		Return(historyarchive.HistoryArchiveState{
+			CurrentLedger: uint32(192),
+		}, nil)
+
+	captiveBackend := CaptiveStellarCore{
+		archive:           mockArchive,
+		networkPassphrase: network.PublicNetworkPassphrase,
+		stellarCoreRunner: mockRunner,
+	}
+
+	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
+	assert.EqualError(t, err, "opening subprocess: error running stellar-core: transient error")
 }
 
 func TestGetLatestLedgerSequence(t *testing.T) {

--- a/exp/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend_test.go
@@ -3,10 +3,13 @@ package ledgerbackend
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
+	"fmt"
 	"io"
 	"testing"
 
 	"github.com/stellar/go/network"
+	"github.com/stellar/go/support/historyarchive"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -100,15 +103,15 @@ func TestCaptiveNew(t *testing.T) {
 	networkPassphrase := network.PublicNetworkPassphrase
 	historyURLs := []string{"http://history.stellar.org/prd/core-live/core_live_001"}
 
-	captiveStellarCore := NewCaptive(
+	captiveStellarCore, err := NewCaptive(
 		executablePath,
 		networkPassphrase,
 		historyURLs,
 	)
-
+	assert.NoError(t, err)
 	assert.Equal(t, networkPassphrase, captiveStellarCore.networkPassphrase)
-	assert.Equal(t, historyURLs, captiveStellarCore.historyURLs)
 	assert.Equal(t, uint32(0), captiveStellarCore.nextLedger)
+	assert.NotNil(t, captiveStellarCore.archive)
 
 	assert.Equal(t, executablePath, captiveStellarCore.stellarCoreRunner.(*stellarCoreRunner).executablePath)
 	assert.Equal(t, networkPassphrase, captiveStellarCore.stellarCoreRunner.(*stellarCoreRunner).networkPassphrase)
@@ -129,9 +132,16 @@ func TestCaptivePrepareRange(t *testing.T) {
 	mockRunner.On("getMetaPipe").Return(&buf)
 	mockRunner.On("close").Return(nil).Once()
 
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.
+		On("GetRootHAS").
+		Return(historyarchive.HistoryArchiveState{
+			CurrentLedger: uint32(200),
+		}, nil)
+
 	captiveBackend := CaptiveStellarCore{
+		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		historyURLs:       []string{"http://history.stellar.org/prd/core-live/core_live_001"},
 		stellarCoreRunner: mockRunner,
 	}
 
@@ -139,6 +149,54 @@ func TestCaptivePrepareRange(t *testing.T) {
 	assert.NoError(t, err)
 	err = captiveBackend.Close()
 	assert.NoError(t, err)
+}
+
+func TestCaptivePrepareRange_ErrClosingSession(t *testing.T) {
+	var buf bytes.Buffer
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("catchup", uint32(100), uint32(200)).Return(nil).Once()
+	mockRunner.On("getMetaPipe").Return(&buf)
+	mockRunner.On("close").Return(fmt.Errorf("transient error"))
+
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.
+		On("GetRootHAS").
+		Return(historyarchive.HistoryArchiveState{
+			CurrentLedger: uint32(200),
+		}, nil)
+
+	captiveBackend := CaptiveStellarCore{
+		archive:           mockArchive,
+		networkPassphrase: network.PublicNetworkPassphrase,
+		stellarCoreRunner: mockRunner,
+		nextLedger:        1,
+	}
+
+	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
+	assert.EqualError(t, err, "opening subprocess: error closing existing session: error closing stellar-core subprocess: transient error")
+}
+
+func TestCaptivePrepareRange_ErrGettingRootHAS(t *testing.T) {
+	var buf bytes.Buffer
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("catchup", uint32(100), uint32(200)).Return(nil).Once()
+	mockRunner.On("getMetaPipe").Return(&buf)
+	mockRunner.On("close").Return(nil)
+
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.
+		On("GetRootHAS").
+		Return(historyarchive.HistoryArchiveState{}, errors.New("transient error"))
+
+	captiveBackend := CaptiveStellarCore{
+		archive:           mockArchive,
+		networkPassphrase: network.PublicNetworkPassphrase,
+		stellarCoreRunner: mockRunner,
+		nextLedger:        1,
+	}
+
+	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
+	assert.EqualError(t, err, "opening subprocess: error getting latest checkpoint sequence: error getting root HAS: transient error")
 }
 
 func TestGetLatestLedgerSequence(t *testing.T) {
@@ -153,9 +211,16 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 	mockRunner.On("getMetaPipe").Return(&buf)
 	mockRunner.On("close").Return(nil).Once()
 
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.
+		On("GetRootHAS").
+		Return(historyarchive.HistoryArchiveState{
+			CurrentLedger: uint32(200),
+		}, nil)
+
 	captiveBackend := CaptiveStellarCore{
+		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		historyURLs:       []string{"http://history.stellar.org/prd/core-live/core_live_001"},
 		stellarCoreRunner: mockRunner,
 	}
 
@@ -204,9 +269,16 @@ func TestGetLedgerBoundsCheck(t *testing.T) {
 	mockRunner.On("getMetaPipe").Return(&buf)
 	mockRunner.On("close").Return(nil).Once()
 
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.
+		On("GetRootHAS").
+		Return(historyarchive.HistoryArchiveState{
+			CurrentLedger: uint32(200),
+		}, nil)
+
 	captiveBackend := CaptiveStellarCore{
+		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		historyURLs:       []string{"http://history.stellar.org/prd/core-live/core_live_001"},
 		stellarCoreRunner: mockRunner,
 	}
 

--- a/exp/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend_test.go
@@ -247,10 +247,8 @@ func TestCaptivePrepareRange_ToIsAheadOfRootHAS(t *testing.T) {
 }
 
 func TestCaptivePrepareRange_ErrCatchup(t *testing.T) {
-	var buf bytes.Buffer
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(100), uint32(192)).Return(errors.New("transient error")).Once()
-	mockRunner.On("getMetaPipe").Return(&buf)
 	mockRunner.On("close").Return(nil)
 
 	mockArchive := &historyarchive.MockArchive{}
@@ -268,6 +266,126 @@ func TestCaptivePrepareRange_ErrCatchup(t *testing.T) {
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
 	assert.EqualError(t, err, "opening subprocess: error running stellar-core: transient error")
+}
+
+func TestCaptivePrepareRangeUnboundedRange_ErrGettingRootHAS(t *testing.T) {
+	var buf bytes.Buffer
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("catchup", uint32(100), uint32(192)).Return(nil).Once()
+	mockRunner.On("getMetaPipe").Return(&buf)
+	mockRunner.On("close").Return(nil)
+
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.
+		On("GetRootHAS").
+		Return(historyarchive.HistoryArchiveState{}, errors.New("transient error"))
+
+	captiveBackend := CaptiveStellarCore{
+		archive:           mockArchive,
+		networkPassphrase: network.PublicNetworkPassphrase,
+		stellarCoreRunner: mockRunner,
+	}
+
+	err := captiveBackend.PrepareRange(UnboundedRange(100))
+	assert.EqualError(t, err, "opening subprocess: error getting latest checkpoint sequence: error getting root HAS: transient error")
+}
+
+func TestCaptivePrepareRangeUnboundedRange_FromIsTooFarAheadOfLatestHAS(t *testing.T) {
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("close").Return(nil)
+
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.
+		On("GetRootHAS").
+		Return(historyarchive.HistoryArchiveState{
+			CurrentLedger: uint32(64),
+		}, nil)
+
+	captiveBackend := CaptiveStellarCore{
+		archive:           mockArchive,
+		networkPassphrase: network.PublicNetworkPassphrase,
+		stellarCoreRunner: mockRunner,
+	}
+
+	err := captiveBackend.PrepareRange(UnboundedRange(193))
+	assert.EqualError(t, err, "opening subprocess: trying to start online mode too far (latest checkpoint=64), only two checkpoints in the future allowed")
+}
+
+func TestCaptivePrepareRangeUnboundedRange_ErrRunFrom(t *testing.T) {
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("runFrom", uint32(65)).Return(errors.New("transient error")).Once()
+	mockRunner.On("close").Return(nil)
+
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.
+		On("GetRootHAS").
+		Return(historyarchive.HistoryArchiveState{
+			CurrentLedger: uint32(64),
+		}, nil)
+
+	captiveBackend := CaptiveStellarCore{
+		archive:           mockArchive,
+		networkPassphrase: network.PublicNetworkPassphrase,
+		stellarCoreRunner: mockRunner,
+	}
+
+	err := captiveBackend.PrepareRange(UnboundedRange(65))
+	assert.EqualError(t, err, "opening subprocess: error running stellar-core: transient error")
+}
+
+func TestCaptivePrepareRangeUnboundedRange_ErrClosingExistingSession(t *testing.T) {
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("close").Return(errors.New("transient error"))
+
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.
+		On("GetRootHAS").
+		Return(historyarchive.HistoryArchiveState{
+			CurrentLedger: uint32(64),
+		}, nil)
+
+	last := uint32(63)
+	captiveBackend := CaptiveStellarCore{
+		archive:           mockArchive,
+		networkPassphrase: network.PublicNetworkPassphrase,
+		stellarCoreRunner: mockRunner,
+		nextLedger:        63,
+		lastLedger:        &last,
+	}
+
+	err := captiveBackend.PrepareRange(UnboundedRange(64))
+	assert.EqualError(t, err, "opening subprocess: error closing existing session: error closing stellar-core subprocess: transient error")
+}
+func TestCaptivePrepareRangeUnboundedRange_ReuseSession(t *testing.T) {
+	var buf bytes.Buffer
+
+	for i := 60; i <= 65; i++ {
+		writeLedgerHeader(&buf, uint32(i))
+	}
+
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("runFrom", uint32(65)).Return(nil).Once()
+	mockRunner.On("getMetaPipe").Return(&buf)
+	mockRunner.On("close").Return(nil)
+
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.
+		On("GetRootHAS").
+		Return(historyarchive.HistoryArchiveState{
+			CurrentLedger: uint32(129),
+		}, nil)
+	captiveBackend := CaptiveStellarCore{
+		archive:           mockArchive,
+		networkPassphrase: network.PublicNetworkPassphrase,
+		stellarCoreRunner: mockRunner,
+	}
+
+	err := captiveBackend.PrepareRange(UnboundedRange(65))
+	assert.NoError(t, err)
+
+	captiveBackend.nextLedger = 64
+	err = captiveBackend.PrepareRange(UnboundedRange(65))
+	assert.NoError(t, err)
 }
 
 func TestGetLatestLedgerSequence(t *testing.T) {

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -151,11 +151,15 @@ func NewSystem(config Config) (System, error) {
 
 	var ledgerBackend ledgerbackend.LedgerBackend
 	if len(config.StellarCorePath) > 0 {
-		ledgerBackend = ledgerbackend.NewCaptive(
+		ledgerBackend, err = ledgerbackend.NewCaptive(
 			config.StellarCorePath,
 			config.NetworkPassphrase,
 			[]string{config.HistoryArchiveURL},
 		)
+		if err != nil {
+			cancel()
+			return nil, errors.Wrap(err, "error creating captive core backend")
+		}
 	} else {
 		coreSession := config.CoreSession.Clone()
 		coreSession.Ctx = ctx


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Change the code to receive an archive interface instead of building it inside `getLatestCheckpointSequence`.

### Why

The previous version of the code would make a real connection to the given URL -- with this new design we can mock the archive interface and test all the different paths. We can also move the responsibility of creating the archive to the constructor without changing the functionality. 

Improves coverage for online and offline setup:

<img width="1298" alt="Screen Shot 2020-07-09 at 5 35 38 PM" src="https://user-images.githubusercontent.com/21772/87097396-b5931c00-c20a-11ea-9379-dbdc96d19d9a.png">



### Known limitations

