### PR TITLE
services/horizon/expingest: Update ingestion state machine to not block when captive backend is used

### DIFF
--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -69,6 +69,10 @@ type CaptiveStellarCore struct {
 
 	nextLedger uint32  // next ledger expected, error w/ restart if not seen
 	lastLedger *uint32 // end of current segment if offline, nil if online
+
+	// waitIntervalPrepareRange defines a time to wait between checking if the buffer
+	// is empty. Default 1s, lower in tests to make them faster.
+	waitIntervalPrepareRange time.Duration
 }
 
 // NewCaptive returns a new CaptiveStellarCore that is not running. Will lazily start a subprocess
@@ -86,10 +90,11 @@ func NewCaptive(executablePath, networkPassphrase string, historyURLs []string) 
 	}
 
 	return &CaptiveStellarCore{
-		archive:           archive,
-		networkPassphrase: networkPassphrase,
-		nextLedger:        0,
-		stellarCoreRunner: newStellarCoreRunner(executablePath, networkPassphrase, historyURLs),
+		archive:                  archive,
+		networkPassphrase:        networkPassphrase,
+		nextLedger:               0,
+		stellarCoreRunner:        newStellarCoreRunner(executablePath, networkPassphrase, historyURLs),
+		waitIntervalPrepareRange: time.Second,
 	}, nil
 }
 
@@ -274,7 +279,7 @@ func (c *CaptiveStellarCore) PrepareRange(ledgerRange Range) error {
 		if len(c.metaC) > 0 {
 			break
 		}
-		time.Sleep(time.Second)
+		time.Sleep(c.waitIntervalPrepareRange)
 	}
 
 	return nil

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -288,11 +288,11 @@ func (c *CaptiveStellarCore) IsPrepared(ledgerRange Range) bool {
 	}
 
 	if ledgerRange.bounded {
-		return c.nextLedger >= ledgerRange.from &&
+		return c.nextLedger <= ledgerRange.from &&
 			c.nextLedger <= *c.lastLedger
 	}
 
-	return c.nextLedger >= ledgerRange.from
+	return c.nextLedger <= ledgerRange.from
 }
 
 // GetLedger returns true when ledger is found and it's LedgerCloseMeta.

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -250,8 +250,8 @@ func (c *CaptiveStellarCore) readLedgerMetaFromPipe() (*xdr.LedgerCloseMeta, err
 // able to stream ledgers.
 // Set `to` to 0 to stream starting from `from` but without limits.
 func (c *CaptiveStellarCore) PrepareRange(ledgerRange Range) error {
-	if c.nextLedger != 0 && c.nextLedger >= ledgerRange.from {
-		// Range already prepared
+	// Range already prepared
+	if c.IsPrepared(ledgerRange) {
 		return nil
 	}
 
@@ -279,6 +279,20 @@ func (c *CaptiveStellarCore) PrepareRange(ledgerRange Range) error {
 	}
 
 	return nil
+}
+
+// IsPrepared returns true if a given ledgerRange is prepared.
+func (c *CaptiveStellarCore) IsPrepared(ledgerRange Range) bool {
+	if c.nextLedger == 0 {
+		return false
+	}
+
+	if ledgerRange.bounded {
+		return c.nextLedger >= ledgerRange.from &&
+			c.nextLedger <= *c.lastLedger
+	}
+
+	return c.nextLedger >= ledgerRange.from
 }
 
 // GetLedger returns true when ledger is found and it's LedgerCloseMeta.

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -341,7 +341,7 @@ func (c *CaptiveStellarCore) IsPrepared(ledgerRange Range) bool {
 		return c.nextLedger <= ledgerRange.from
 	}
 
-	// c.lastLedger != nil: current range is bounded
+	// From now on: c.lastLedger != nil so current range is bounded
 
 	if ledgerRange.bounded {
 		return c.nextLedger <= ledgerRange.from &&

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -286,12 +286,19 @@ func (c *CaptiveStellarCore) IsPrepared(ledgerRange Range) bool {
 		return false
 	}
 
+	if c.lastLedger == nil {
+		return c.nextLedger <= ledgerRange.from
+	}
+
+	// c.lastLedger != nil: current range is bounded
+
 	if ledgerRange.bounded {
 		return c.nextLedger <= ledgerRange.from &&
 			c.nextLedger <= *c.lastLedger
 	}
 
-	return c.nextLedger <= ledgerRange.from
+	// Requested range is unbounded but current one is bounded
+	return false
 }
 
 // GetLedger returns true when ledger is found and it's LedgerCloseMeta.

--- a/exp/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend_test.go
@@ -172,7 +172,7 @@ func TestCaptivePrepareRange_ErrClosingSession(t *testing.T) {
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
 		stellarCoreRunner: mockRunner,
-		nextLedger:        1,
+		nextLedger:        300,
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))

--- a/exp/ingest/ledgerbackend/database_backend.go
+++ b/exp/ingest/ledgerbackend/database_backend.go
@@ -66,6 +66,11 @@ func (dbb *DatabaseBackend) PrepareRange(ledgerRange Range) error {
 	return nil
 }
 
+// IsPrepared returns true if a given ledgerRange is prepared.
+func (*DatabaseBackend) IsPrepared(ledgerRange Range) bool {
+	return true
+}
+
 // GetLatestLedgerSequence returns the most recent ledger sequence number present in the database.
 func (dbb *DatabaseBackend) GetLatestLedgerSequence() (uint32, error) {
 	var ledger []ledgerHeader

--- a/exp/ingest/ledgerbackend/history_archive_backend.go
+++ b/exp/ingest/ledgerbackend/history_archive_backend.go
@@ -73,6 +73,11 @@ func (hab *HistoryArchiveBackend) PrepareRange(ledgerRange Range) error {
 	return nil
 }
 
+// IsPrepared returns true if a given ledgerRange is prepared.
+func (hab *HistoryArchiveBackend) IsPrepared(ledgerRange Range) bool {
+	return true
+}
+
 // GetLedger returns the LedgerCloseMeta for the given ledger sequence number.
 // The first returned value is false when the ledger does not exist in the history archives.
 // Due to the history archives architecture the first request to get a ledger is slow because

--- a/exp/ingest/ledgerbackend/ledger_backend.go
+++ b/exp/ingest/ledgerbackend/ledger_backend.go
@@ -34,6 +34,8 @@ type LedgerBackend interface {
 	// Some backends (like captive stellar-core) need to initalize data to be
 	// able to stream ledgers.
 	PrepareRange(ledgerRange Range) error
+	// IsPrepared returns true if a given ledgerRange is prepared.
+	IsPrepared(ledgerRange Range) bool
 	Close() error
 }
 

--- a/exp/ingest/ledgerbackend/mock_database_backend.go
+++ b/exp/ingest/ledgerbackend/mock_database_backend.go
@@ -21,6 +21,11 @@ func (m *MockDatabaseBackend) PrepareRange(ledgerRange Range) error {
 	return args.Error(0)
 }
 
+func (m *MockDatabaseBackend) IsPrepared(ledgerRange Range) bool {
+	args := m.Called(ledgerRange)
+	return args.Bool(0)
+}
+
 func (m *MockDatabaseBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMeta, error) {
 	args := m.Called(sequence)
 	return args.Bool(0), args.Get(1).(xdr.LedgerCloseMeta), args.Error(2)

--- a/exp/ingest/ledgerbackend/stellar_core_runner.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner.go
@@ -136,10 +136,6 @@ func (r *stellarCoreRunner) writeConf() error {
 func (r *stellarCoreRunner) createCmd(params ...string) (*exec.Cmd, error) {
 	allParams := append([]string{"--conf", r.getConfFileName()}, params...)
 	cmd := exec.Command(r.executablePath, allParams...)
-	err := cmd.Start()
-	if err != nil {
-		return nil, errors.Wrapf(err, "error starting `stellar-core %v` subprocess", params)
-	}
 	cmd.Dir = r.getTmpDir()
 	cmd.Stdout = r.getLogLineWriter()
 	cmd.Stderr = r.getLogLineWriter()

--- a/exp/ingest/ledgerbackend/stellar_core_runner.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner.go
@@ -178,6 +178,9 @@ func (r *stellarCoreRunner) catchup(from, to uint32) error {
 		return errors.Wrap(err, "error starting `stellar-core catchup` subprocess")
 	}
 
+	// Do not remove bufio.Reader wrapping. Turns out that each read from a pipe
+	// adds an overhead time so it's better to preload data to a buffer.
+	r.metaPipe = bufio.NewReaderSize(r.metaPipe, 1024*1024)
 	return nil
 }
 
@@ -205,6 +208,9 @@ func (r *stellarCoreRunner) runFrom(from uint32) error {
 		return errors.Wrap(err, "error starting `stellar-core run` subprocess")
 	}
 
+	// Do not remove bufio.Reader wrapping. Turns out that each read from a pipe
+	// adds an overhead time so it's better to preload data to a buffer.
+	r.metaPipe = bufio.NewReaderSize(r.metaPipe, 1024*1024)
 	return nil
 }
 

--- a/exp/ingest/ledgerbackend/stellar_core_runner_posix.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner_posix.go
@@ -3,7 +3,6 @@
 package ledgerbackend
 
 import (
-	"bufio"
 	"io"
 	"os"
 	"syscall"
@@ -44,9 +43,7 @@ func (c *stellarCoreRunner) start() (io.Reader, error) {
 		return readFile, errors.Wrap(err, "error starting stellar-core")
 	}
 
-	// Do not remove bufio.Reader wrapping. Turns out that each read from a pipe
-	// adds an overhead time so it's better to preload data to a buffer.
-	return bufio.NewReaderSize(readFile, 1024*1024), nil
+	return readFile, nil
 }
 
 func (c *stellarCoreRunner) processIsAlive() bool {

--- a/exp/ingest/ledgerbackend/stellar_core_runner_windows.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner_windows.go
@@ -3,7 +3,6 @@
 package ledgerbackend
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -42,9 +41,7 @@ func (c *stellarCoreRunner) start() (io.Reader, error) {
 		return connection, err
 	}
 
-	// Do not remove bufio.Reader wrapping. Turns out that each read from a pipe
-	// adds an overhead time so it's better to preload data to a buffer.
-	return bufio.NewReaderSize(connection, 1024*1024), nil
+	return connection, nil
 }
 
 func (c *stellarCoreRunner) processIsAlive() bool {

--- a/services/horizon/internal/expingest/db_integration_test.go
+++ b/services/horizon/internal/expingest/db_integration_test.go
@@ -110,7 +110,7 @@ func (s *DBTestSuite) setupMocksForBuildState() {
 	s.historyAdapter.On("BucketListHash", s.sequence).
 		Return(checkpointHash, nil).Once()
 
-	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(s.sequence)).Return(nil).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(s.sequence)).Return(true).Once()
 	s.ledgerBackend.On("GetLedger", s.sequence).
 		Return(
 			true,

--- a/services/horizon/internal/expingest/fake_ledger_backend.go
+++ b/services/horizon/internal/expingest/fake_ledger_backend.go
@@ -20,6 +20,10 @@ func (fakeLedgerBackend) PrepareRange(r ledgerbackend.Range) error {
 	return nil
 }
 
+func (fakeLedgerBackend) IsPrepared(r ledgerbackend.Range) bool {
+	return true
+}
+
 func fakeAccount() xdr.LedgerEntryChange {
 	account := keypair.MustRandom().Address()
 	return xdr.LedgerEntryChange{

--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -37,6 +37,25 @@ func start() transition {
 	return transition{node: startState{}, sleepDuration: defaultSleep}
 }
 
+// startSuggestedCheckpoint is a transition to start `state` but with a suggested
+// checkpoint to use if the follow step is `buildState`.
+// This is required because some ledger backends (like captive core) require some
+// time to prepare a requested range and have a small buffer of ledgers available
+// to fetch using GetLedger.
+// It's possible that a new checkpoint will be created while a range is prepared.
+// Because ledgers are kept in a buffer `GetLatestLedgerSequence` returns the latest
+// sequence available in a buffer, not in a network. This would make bucket hash
+// verification failures because the code would wrongly assume that the ledger is
+// not available.
+func startSuggestedCheckpoint(checkpoint uint32) transition {
+	return transition{
+		node: startState{
+			suggestedCheckpoint: checkpoint,
+		},
+		sleepDuration: defaultSleep,
+	}
+}
+
 func rebuild(checkpointLedger uint32) transition {
 	return transition{
 		node: buildState{
@@ -98,13 +117,15 @@ func (stopState) run(s *system) (transition, error) {
 	return stop(), errors.New("Cannot run terminal state")
 }
 
-type startState struct{}
+type startState struct {
+	suggestedCheckpoint uint32
+}
 
 func (startState) String() string {
 	return "start"
 }
 
-func (startState) run(s *system) (transition, error) {
+func (state startState) run(s *system) (transition, error) {
 	if err := s.historyQ.Begin(); err != nil {
 		return start(), errors.Wrap(err, "Error starting a transaction")
 	}
@@ -142,9 +163,13 @@ func (startState) run(s *system) (transition, error) {
 		// be updated when leading instance finishes processing state.
 		// In case of errors it will start `Init` from the beginning.
 		var lastCheckpoint uint32
-		lastCheckpoint, err = s.historyAdapter.GetLatestLedgerSequence()
-		if err != nil {
-			return start(), errors.Wrap(err, "Error getting last checkpoint")
+		if state.suggestedCheckpoint != 0 {
+			lastCheckpoint = state.suggestedCheckpoint
+		} else {
+			lastCheckpoint, err = s.historyAdapter.GetLatestLedgerSequence()
+			if err != nil {
+				return start(), errors.Wrap(err, "Error getting last checkpoint")
+			}
 		}
 
 		if lastHistoryLedger != 0 {
@@ -384,12 +409,27 @@ func (r resumeState) run(s *system) (transition, error) {
 	}
 
 	if latestLedgerCore < ingestLedger {
-		log.WithFields(logpkg.F{
+		logger := log.WithFields(logpkg.F{
 			"ingest_sequence": ingestLedger,
 			"core_sequence":   latestLedgerCore,
-		}).Info("Waiting for ledger to be available in stellar-core")
-		// Go to the next state, machine will wait for 1s. before continuing.
-		return retryResume(r), nil
+		})
+
+		if latestLedgerCore == ingestLedger-1 {
+			logger.Info("Waiting for ledger to be available in stellar-core")
+			// Go to the next state, machine will wait for 1s. before continuing.
+			return retryResume(r), nil
+		}
+
+		// Will fast-forward to the latest ledger in a buffer in case of captive core.
+		_, _, err := s.ledgerBackend.GetLedger(latestLedgerCore)
+		if err != nil {
+			return retryResume(r), errors.Wrap(err, "Error fast-forwarding to the latest ledger in stellar-core")
+		}
+
+		logger.Info("Fast-forward to the latest ledger ingested in the cluster")
+		return retryResume(resumeState{
+			latestSuccessfullyProcessedLedger: latestLedgerCore,
+		}), nil
 	}
 
 	startTime := time.Now()
@@ -868,7 +908,7 @@ func (s *system) completeIngestion(ledger uint32) error {
 // checkPrepareRange checks if the range is prepared. If not, it releases
 // the distributed ingestion lock and prepares the range.
 // The first return value determines if the caller should follow the transition.
-func (s *System) checkPrepareRange(from uint32) (bool, transition, error) {
+func (s *system) checkPrepareRange(from uint32) (bool, transition, error) {
 	ledgerRange := ledgerbackend.UnboundedRange(from)
 
 	if !s.ledgerBackend.IsPrepared(ledgerRange) {
@@ -890,7 +930,7 @@ func (s *System) checkPrepareRange(from uint32) (bool, transition, error) {
 			}).
 			Info("Range prepared")
 
-		return true, start(), nil
+		return true, startSuggestedCheckpoint(from), nil
 	}
 
 	return false, start(), nil

--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -2,8 +2,9 @@ package expingest
 
 import (
 	"fmt"
-	"github.com/stellar/go/exp/ingest/ledgerbackend"
 	"time"
+
+	"github.com/stellar/go/exp/ingest/ledgerbackend"
 
 	"github.com/stellar/go/exp/ingest/io"
 	"github.com/stellar/go/services/horizon/internal/toid"
@@ -270,15 +271,15 @@ func (b buildState) run(s *system) (transition, error) {
 		return start(), errors.Wrap(err, "Error clearing ingest tables")
 	}
 
+	followTransition, transition, err := s.checkPrepareRange(b.checkpointLedger)
+	if followTransition {
+		return transition, err
+	}
+
 	log.WithFields(logpkg.F{
 		"ledger": b.checkpointLedger,
 	}).Info("Processing state")
 	startTime := time.Now()
-
-	err = s.ledgerBackend.PrepareRange(ledgerbackend.UnboundedRange(b.checkpointLedger))
-	if err != nil {
-		return stop(), errors.Wrap(err, "error preparing range")
-	}
 
 	stats, err := s.runner.RunHistoryArchiveIngestion(b.checkpointLedger)
 	if err != nil {
@@ -371,9 +372,9 @@ func (r resumeState) run(s *system) (transition, error) {
 		return start(), nil
 	}
 
-	err = s.ledgerBackend.PrepareRange(ledgerbackend.UnboundedRange(ingestLedger))
-	if err != nil {
-		return stop(), errors.Wrap(err, "error preparing range")
+	followTransition, transition, err := s.checkPrepareRange(ingestLedger)
+	if followTransition {
+		return transition, err
 	}
 
 	// Check if ledger is closed
@@ -474,6 +475,11 @@ func (h historyRangeState) run(s *system) (transition, error) {
 	// we should go back to the init state
 	if lastHistoryLedger != h.fromLedger-1 {
 		return start(), nil
+	}
+
+	followTransition, transition, err := s.checkPrepareRange(h.fromLedger)
+	if followTransition {
+		return transition, err
 	}
 
 	err = s.ledgerBackend.PrepareRange(ledgerbackend.UnboundedRange(h.fromLedger))
@@ -857,4 +863,35 @@ func (s *system) completeIngestion(ledger uint32) error {
 	}
 
 	return nil
+}
+
+// checkPrepareRange checks if the range is prepared. If not, it releases
+// the distributed ingestion lock and prepares the range.
+// The first return value determines if the caller should follow the transition.
+func (s *System) checkPrepareRange(from uint32) (bool, transition, error) {
+	ledgerRange := ledgerbackend.UnboundedRange(from)
+
+	if !s.ledgerBackend.IsPrepared(ledgerRange) {
+		// Release distributed ingestion lock and prepare the range
+		s.historyQ.Rollback()
+		log.Info("Released ingestion lock to prepare range")
+		log.WithFields(logpkg.F{"ledger": from}).Info("Preparing range")
+		startTime := time.Now()
+
+		err := s.ledgerBackend.PrepareRange(ledgerRange)
+		if err != nil {
+			return true, start(), errors.Wrap(err, "error preparing range")
+		}
+
+		log.
+			WithFields(logpkg.F{
+				"ledger":   from,
+				"duration": time.Since(startTime).Seconds(),
+			}).
+			Info("Range prepared")
+
+		return true, start(), nil
+	}
+
+	return false, start(), nil
 }

--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -296,7 +296,7 @@ func (b buildState) run(s *system) (transition, error) {
 		return start(), errors.Wrap(err, "Error clearing ingest tables")
 	}
 
-	followTransition, nextState, err := s.checkPrepareRange(b.checkpointLedger, true)
+	followTransition, nextState, err := s.maybePrepareRange(b.checkpointLedger, true)
 	if followTransition {
 		return nextState, err
 	}
@@ -397,7 +397,7 @@ func (r resumeState) run(s *system) (transition, error) {
 		return start(), nil
 	}
 
-	followTransition, nextState, err := s.checkPrepareRange(ingestLedger, false)
+	followTransition, nextState, err := s.maybePrepareRange(ingestLedger, false)
 	if followTransition {
 		return nextState, err
 	}
@@ -414,19 +414,18 @@ func (r resumeState) run(s *system) (transition, error) {
 			"core_sequence":   latestLedgerCore,
 		})
 
-		if latestLedgerCore == ingestLedger-1 {
-			logger.Info("Waiting for ledger to be available in stellar-core")
-			// Go to the next state, machine will wait for 1s. before continuing.
-			return retryResume(r), nil
-		}
-
 		// Will fast-forward to the latest ledger in a buffer in case of captive core.
 		_, _, err = s.ledgerBackend.GetLedger(latestLedgerCore)
 		if err != nil {
 			return retryResume(r), errors.Wrap(err, "Error fast-forwarding to the latest ledger in stellar-core")
 		}
 
-		logger.Info("Fast-forward to the latest ledger ingested in the cluster")
+		if latestLedgerCore == ingestLedger-1 {
+			logger.Info("Waiting for ledger to be available in stellar-core")
+		} else {
+			logger.Info("Fast-forward to the latest ledger ingested in the cluster")
+		}
+
 		return retryResume(resumeState{
 			latestSuccessfullyProcessedLedger: latestLedgerCore,
 		}), nil
@@ -517,7 +516,7 @@ func (h historyRangeState) run(s *system) (transition, error) {
 		return start(), nil
 	}
 
-	followTransition, nextState, err := s.checkPrepareRange(h.fromLedger, false)
+	followTransition, nextState, err := s.maybePrepareRange(h.fromLedger, false)
 	if followTransition {
 		return nextState, err
 	}
@@ -900,10 +899,10 @@ func (s *system) completeIngestion(ledger uint32) error {
 	return nil
 }
 
-// checkPrepareRange checks if the range is prepared. If not, it releases
+// maybePrepareRange checks if the range is prepared. If not, it releases
 // the distributed ingestion lock and prepares the range.
 // The first return value determines if the caller should follow the transition.
-func (s *system) checkPrepareRange(from uint32, suggestCheckpoint bool) (bool, transition, error) {
+func (s *system) maybePrepareRange(from uint32, suggestCheckpoint bool) (bool, transition, error) {
 	ledgerRange := ledgerbackend.UnboundedRange(from)
 
 	if !s.ledgerBackend.IsPrepared(ledgerRange) {
@@ -918,12 +917,10 @@ func (s *system) checkPrepareRange(from uint32, suggestCheckpoint bool) (bool, t
 			return true, start(), errors.Wrap(err, "error preparing range")
 		}
 
-		log.
-			WithFields(logpkg.F{
-				"ledger":   from,
-				"duration": time.Since(startTime).Seconds(),
-			}).
-			Info("Range prepared")
+		log.WithFields(logpkg.F{
+			"ledger":   from,
+			"duration": time.Since(startTime).Seconds(),
+		}).Info("Range prepared")
 
 		if suggestCheckpoint {
 			return true, startSuggestedCheckpoint(from), nil

--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -296,7 +296,7 @@ func (b buildState) run(s *system) (transition, error) {
 		return start(), errors.Wrap(err, "Error clearing ingest tables")
 	}
 
-	followTransition, transition, err := s.checkPrepareRange(b.checkpointLedger)
+	followTransition, transition, err := s.checkPrepareRange(b.checkpointLedger, true)
 	if followTransition {
 		return transition, err
 	}
@@ -397,7 +397,7 @@ func (r resumeState) run(s *system) (transition, error) {
 		return start(), nil
 	}
 
-	followTransition, transition, err := s.checkPrepareRange(ingestLedger)
+	followTransition, transition, err := s.checkPrepareRange(ingestLedger, false)
 	if followTransition {
 		return transition, err
 	}
@@ -517,14 +517,9 @@ func (h historyRangeState) run(s *system) (transition, error) {
 		return start(), nil
 	}
 
-	followTransition, transition, err := s.checkPrepareRange(h.fromLedger)
+	followTransition, transition, err := s.checkPrepareRange(h.fromLedger, false)
 	if followTransition {
 		return transition, err
-	}
-
-	err = s.ledgerBackend.PrepareRange(ledgerbackend.UnboundedRange(h.fromLedger))
-	if err != nil {
-		return stop(), errors.Wrap(err, "error preparing range")
 	}
 
 	for cur := h.fromLedger; cur <= h.toLedger; cur++ {
@@ -908,7 +903,7 @@ func (s *system) completeIngestion(ledger uint32) error {
 // checkPrepareRange checks if the range is prepared. If not, it releases
 // the distributed ingestion lock and prepares the range.
 // The first return value determines if the caller should follow the transition.
-func (s *system) checkPrepareRange(from uint32) (bool, transition, error) {
+func (s *system) checkPrepareRange(from uint32, suggestCheckpoint bool) (bool, transition, error) {
 	ledgerRange := ledgerbackend.UnboundedRange(from)
 
 	if !s.ledgerBackend.IsPrepared(ledgerRange) {
@@ -930,7 +925,10 @@ func (s *system) checkPrepareRange(from uint32) (bool, transition, error) {
 			}).
 			Info("Range prepared")
 
-		return true, startSuggestedCheckpoint(from), nil
+		if suggestCheckpoint {
+			return true, startSuggestedCheckpoint(from), nil
+		}
+		return true, start(), nil
 	}
 
 	return false, start(), nil

--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -296,9 +296,9 @@ func (b buildState) run(s *system) (transition, error) {
 		return start(), errors.Wrap(err, "Error clearing ingest tables")
 	}
 
-	followTransition, transition, err := s.checkPrepareRange(b.checkpointLedger, true)
+	followTransition, nextState, err := s.checkPrepareRange(b.checkpointLedger, true)
 	if followTransition {
-		return transition, err
+		return nextState, err
 	}
 
 	log.WithFields(logpkg.F{
@@ -397,9 +397,9 @@ func (r resumeState) run(s *system) (transition, error) {
 		return start(), nil
 	}
 
-	followTransition, transition, err := s.checkPrepareRange(ingestLedger, false)
+	followTransition, nextState, err := s.checkPrepareRange(ingestLedger, false)
 	if followTransition {
-		return transition, err
+		return nextState, err
 	}
 
 	// Check if ledger is closed
@@ -421,7 +421,7 @@ func (r resumeState) run(s *system) (transition, error) {
 		}
 
 		// Will fast-forward to the latest ledger in a buffer in case of captive core.
-		_, _, err := s.ledgerBackend.GetLedger(latestLedgerCore)
+		_, _, err = s.ledgerBackend.GetLedger(latestLedgerCore)
 		if err != nil {
 			return retryResume(r), errors.Wrap(err, "Error fast-forwarding to the latest ledger in stellar-core")
 		}
@@ -517,9 +517,9 @@ func (h historyRangeState) run(s *system) (transition, error) {
 		return start(), nil
 	}
 
-	followTransition, transition, err := s.checkPrepareRange(h.fromLedger, false)
+	followTransition, nextState, err := s.checkPrepareRange(h.fromLedger, false)
 	if followTransition {
-		return transition, err
+		return nextState, err
 	}
 
 	for cur := h.fromLedger; cur <= h.toLedger; cur++ {

--- a/services/horizon/internal/expingest/init_state_test.go
+++ b/services/horizon/internal/expingest/init_state_test.go
@@ -109,6 +109,20 @@ func (s *InitStateTestSuite) TestBuildStateEmptyDatabase() {
 	)
 }
 
+func (s *InitStateTestSuite) TestBuildStateEmptyDatabaseFromSuggestedCheckpoint() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(0, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil).Once()
+
+	next, err := startState{suggestedCheckpoint: 127}.run(s.system)
+	s.Assert().NoError(err)
+	s.Assert().Equal(
+		transition{node: buildState{checkpointLedger: 127}, sleepDuration: defaultSleep},
+		next,
+	)
+}
+
 // TestBuildStateWait is testing the case when:
 // * the ingest system version has been incremented or no expingest ledger,
 // * the old system is in front of the latest checkpoint.

--- a/services/horizon/internal/expingest/main_test.go
+++ b/services/horizon/internal/expingest/main_test.go
@@ -376,6 +376,11 @@ func (m *mockLedgerBackend) PrepareRange(ledgerRange ledgerbackend.Range) error 
 	return args.Error(0)
 }
 
+func (m *mockLedgerBackend) IsPrepared(ledgerRange ledgerbackend.Range) bool {
+	args := m.Called(ledgerRange)
+	return args.Bool(0)
+}
+
 func (m *mockLedgerBackend) Close() error {
 	args := m.Called()
 	return args.Error(0)

--- a/services/horizon/internal/expingest/resume_state_test.go
+++ b/services/horizon/internal/expingest/resume_state_test.go
@@ -371,6 +371,8 @@ func (s *ResumeTestTestSuite) TestNoNewLedgers() {
 
 	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(101)).Return(true).Once()
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(uint32(100), nil).Once()
+	// Fast forward the backend
+	s.ledgerBackend.On("GetLedger", uint32(100)).Return(true, xdr.LedgerCloseMeta{}, nil).Once()
 
 	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().NoError(err)
@@ -378,6 +380,30 @@ func (s *ResumeTestTestSuite) TestNoNewLedgers() {
 		transition{
 			// Check the same ledger later
 			node: resumeState{latestSuccessfullyProcessedLedger: 100},
+			// Sleep because we learned the ledger is not there yet.
+			sleepDuration: defaultSleep,
+		},
+		next,
+	)
+}
+
+func (s *ResumeTestTestSuite) TestFarBehind() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(200), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
+
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(201)).Return(true).Once()
+	s.ledgerBackend.On("GetLatestLedgerSequence").Return(uint32(102), nil).Once()
+	// Fast forward the backend
+	s.ledgerBackend.On("GetLedger", uint32(102)).Return(true, xdr.LedgerCloseMeta{}, nil).Once()
+
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 200}.run(s.system)
+	s.Assert().NoError(err)
+	s.Assert().Equal(
+		transition{
+			// Check the same ledger later
+			node: resumeState{latestSuccessfullyProcessedLedger: 102},
 			// Sleep because we learned the ledger is not there yet.
 			sleepDuration: defaultSleep,
 		},

--- a/services/horizon/internal/expingest/resume_state_test.go
+++ b/services/horizon/internal/expingest/resume_state_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stellar/go/exp/ingest/io"
 	"github.com/stellar/go/exp/ingest/ledgerbackend"
 	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
@@ -202,13 +203,76 @@ func (s *ResumeTestTestSuite) TestLatestHistoryLedgerGreaterThanIngestLedger() {
 	)
 }
 
+func (s *ResumeTestTestSuite) TestRangeNotPreparedFailPrepare() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(101), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
+
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(102)).Return(false).Once()
+	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(102)).Return(errors.New("my error")).Once()
+	// Rollback twice (first one mocked in SetupTest) because we want to release
+	// a distributed ingestion lock.
+	s.historyQ.On("Rollback").Return(nil).Once()
+
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
+	s.Assert().Error(err)
+	s.Assert().EqualError(err, "error preparing range: my error")
+	s.Assert().Equal(
+		transition{node: startState{}, sleepDuration: defaultSleep},
+		next,
+	)
+}
+
+func (s *ResumeTestTestSuite) TestRangeNotPreparedSuccessPrepare() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(101), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
+
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(102)).Return(false).Once()
+	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(102)).Return(nil).Once()
+	// Rollback twice (first one mocked in SetupTest) because we want to release
+	// a distributed ingestion lock.
+	s.historyQ.On("Rollback").Return(nil).Once()
+
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
+	s.Assert().NoError(err)
+	s.Assert().Equal(
+		transition{node: startState{}, sleepDuration: defaultSleep},
+		next,
+	)
+}
+
+func (s *ResumeTestTestSuite) TestFastForwardCaptiveCore() {
+	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(101), nil).Once()
+	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
+
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(102)).Return(true).Once()
+	s.ledgerBackend.On("GetLatestLedgerSequence").Return(uint32(99), nil).Once()
+	// GetLedger will fast-forward to the latest sequence in a backend
+	s.ledgerBackend.On("GetLedger", uint32(99)).Return(true, xdr.LedgerCloseMeta{}, nil).Once()
+
+	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
+	s.Assert().NoError(err)
+	s.Assert().Equal(
+		transition{
+			node:          resumeState{latestSuccessfullyProcessedLedger: 99},
+			sleepDuration: defaultSleep,
+		},
+		next,
+	)
+}
+
 func (s *ResumeTestTestSuite) mockSuccessfulIngestion() {
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(101), nil).Once()
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
 
-	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(102)).Return(nil).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(102)).Return(true).Once()
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(uint32(111), nil).Once()
 
 	s.runner.On("RunAllProcessorsOnLedger", uint32(102)).Return(io.StatsChangeProcessorResults{}, io.StatsLedgerTransactionProcessorResults{}, nil).Once()
@@ -272,7 +336,7 @@ func (s *ResumeTestTestSuite) TestErrorSettingCursorIgnored() {
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
-	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(101)).Return(nil).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(101)).Return(true).Once()
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(uint32(111), nil).Once()
 
 	s.runner.On("RunAllProcessorsOnLedger", uint32(101)).Return(io.StatsChangeProcessorResults{}, io.StatsLedgerTransactionProcessorResults{}, nil).Once()
@@ -305,7 +369,7 @@ func (s *ResumeTestTestSuite) TestNoNewLedgers() {
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
-	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(101)).Return(nil).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(101)).Return(true).Once()
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(uint32(100), nil).Once()
 
 	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit updates ingestion state machine to not block entire cluster ingestion when captive core backend is not prepared. Specifically:
* In `buildState`, `resumeState` and `historyRangeState` added a check that ensures a range is prepared. If not, it releases the distributed ingestion lock and prepares the selected range.
* In `resumeState` it adds the code that fast-forwards the captive core backend to the last ledger available in a backend buffer.
* Added `suggestedCheckpoint` to `startState` params that's set when transitioning from `buildState`.

Close #2703.

### Why

`CaptiveStellarCore` backend unlike `DatabaseBackend` does not allow _random-access_ to ledger data. To work it first need to prepare a range (using `PrepareRange` method) that can take a few minutes. Without changes in this PR, the node that is actively ingesting and preparing a range would block other nodes (potentially synced) from ingesting.

Another change compared to `DatabaseBackend` is that `GetLedger` method must be called in a non-decreasing order of ledger sequences. It also contains a small buffer of ledgers, `GetLatestLedgerSequence()` doesn't return the latest ledger sequence closed by the network (in case of a synced node) but the latest ledger available in a buffer (that can be also the latest ledger sequence closed by the network but that's not always true: ex. when catching up).

Because of the reasons above small changes to `resumeState` were required. With the changes in this commit, it fast-forwards to the latest ledger available in a backend to advance the buffer. Without it, the node would stay in an infinite loop asking for a ledger that is in front of the few ledgers in a buffer.

Finally, `suggestedCheckpoint` is required because a new checkpoint can be created when `buildState` is still preparing a range. When this happens, the code checking a bucket hash, would fail because `GetLatestLedgerSequence()` would return the previous checkpoint (plus a few ledgers in buffer) because it was used as a starting sequence in `PrepareRange`.