### PR TITLE
exp/ingest/ledgerbackend: Handle Stellar-Core process exit gracefully

### DIFF
--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -49,13 +49,16 @@ type metaResult struct {
 }
 
 type CaptiveStellarCore struct {
+	executablePath    string
 	networkPassphrase string
 	historyURLs       []string
 
-	// read-ahead buffer
-	stop  chan struct{}
-	wait  sync.WaitGroup
+	// shutdown is a channel that triggers the backend shutdown by the user.
+	shutdown chan struct{}
+	// metaC is a read-ahead buffer.
 	metaC chan metaResult
+	// wait is a waiting group waiting for a read-ahead buffer to return.
+	wait sync.WaitGroup
 
 	stellarCoreRunner stellarCoreRunnerInterface
 	cachedMeta        *xdr.LedgerCloseMeta
@@ -78,10 +81,9 @@ type CaptiveStellarCore struct {
 // Platform-specific pipe setup logic is in the .start() methods.
 func NewCaptive(executablePath, networkPassphrase string, historyURLs []string) *CaptiveStellarCore {
 	return &CaptiveStellarCore{
+		executablePath:    executablePath,
 		networkPassphrase: networkPassphrase,
 		historyURLs:       historyURLs,
-		nextLedger:        0,
-		stellarCoreRunner: newStellarCoreRunner(executablePath, networkPassphrase, historyURLs),
 	}
 }
 
@@ -124,6 +126,7 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 		to = latestCheckpointSequence
 	}
 
+	c.stellarCoreRunner = newStellarCoreRunner(c.executablePath, c.networkPassphrase, c.historyURLs)
 	err = c.stellarCoreRunner.catchup(from, to)
 	if err != nil {
 		return errors.Wrap(err, "error running stellar-core")
@@ -137,7 +140,7 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 
 	// read-ahead buffer
 	c.metaC = make(chan metaResult, readAheadBufferSize)
-	c.stop = make(chan struct{})
+	c.shutdown = make(chan struct{})
 	c.wait.Add(1)
 	go c.sendLedgerMeta(to)
 	return nil
@@ -172,6 +175,7 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 		)
 	}
 
+	c.stellarCoreRunner = newStellarCoreRunner(c.executablePath, c.networkPassphrase, c.historyURLs)
 	err = c.stellarCoreRunner.runFrom(from)
 	if err != nil {
 		return errors.Wrap(err, "error running stellar-core")
@@ -185,7 +189,7 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 
 	// read-ahead buffer
 	c.metaC = make(chan metaResult, readAheadBufferSize)
-	c.stop = make(chan struct{})
+	c.shutdown = make(chan struct{})
 	c.wait.Add(1)
 	go c.sendLedgerMeta(0)
 	return nil
@@ -199,25 +203,31 @@ func (c *CaptiveStellarCore) sendLedgerMeta(untilSequence uint32) {
 	defer printBufferOccupation.Stop()
 	for {
 		select {
-		case <-c.stop:
+		case <-c.shutdown:
+			return
+		case err := <-c.stellarCoreRunner.getProcessExitChan():
+			if err != nil {
+				err = errors.Wrap(err, "stellar-core process exited with an error")
+			} else {
+				err = errors.New("stellar-core process exited without an error unexpectedly")
+			}
+			// When `GetLedger` sees the error it will close the backend. We shouldn't
+			// close it now because there may be some ledgers in a buffer.
+			c.metaC <- metaResult{nil, err}
 			return
 		case <-printBufferOccupation.C:
 			log.Debug("captive core read-ahead buffer occupation:", len(c.metaC))
 		default:
 		}
+
 		meta, err := c.readLedgerMetaFromPipe()
 		if err != nil {
-			select {
-			case <-c.stop:
-			case c.metaC <- metaResult{nil, err}:
-			}
+			// When `GetLedger` sees the error it will close the backend. We shouldn't
+			// close it now because there may be some ledgers in a buffer.
+			c.metaC <- metaResult{nil, err}
 			return
 		}
-		select {
-		case <-c.stop:
-			return
-		case c.metaC <- metaResult{meta, nil}:
-		}
+		c.metaC <- metaResult{meta, nil}
 
 		if untilSequence != 0 {
 			if meta.LedgerSequence() >= untilSequence {
@@ -271,6 +281,20 @@ func (c *CaptiveStellarCore) PrepareRange(ledgerRange Range) error {
 	}
 
 	for {
+		select {
+		case <-c.shutdown:
+			return nil
+		case err := <-c.stellarCoreRunner.getProcessExitChan():
+			if err != nil {
+				err = errors.Wrap(err, "stellar-core process exited with an error")
+			} else {
+				err = errors.New("stellar-core process exited without an error unexpectedly")
+			}
+			// We close the backend to reset it's state to be able to prepare again.
+			c.Close()
+			return err
+		default:
+		}
 		// Wait for the first ledger
 		if len(c.metaC) > 0 {
 			break
@@ -378,9 +402,10 @@ func (c *CaptiveStellarCore) Close() error {
 	c.nextLedger = 0
 	c.lastLedger = nil
 
-	if c.stop != nil {
-		close(c.stop)
-		// discard pending data in case the goroutine is blocked writing to the channel
+	if c.shutdown != nil {
+		close(c.shutdown)
+		// discard pending data in case the goroutine is blocked writing to the channel,
+		// see: `sendLedgerMeta`.
 		select {
 		case <-c.metaC:
 		default:
@@ -391,9 +416,11 @@ func (c *CaptiveStellarCore) Close() error {
 		close(c.metaC)
 	}
 
-	err := c.stellarCoreRunner.close()
-	if err != nil {
-		return errors.Wrap(err, "error closing stellar-core subprocess")
+	if c.stellarCoreRunner != nil {
+		err := c.stellarCoreRunner.close()
+		if err != nil {
+			return errors.Wrap(err, "error closing stellar-core subprocess")
+		}
 	}
 	return nil
 }

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -126,7 +126,9 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 		to = latestCheckpointSequence
 	}
 
-	c.stellarCoreRunner = newStellarCoreRunner(c.executablePath, c.networkPassphrase, c.historyURLs)
+	if c.stellarCoreRunner == nil {
+		c.stellarCoreRunner = newStellarCoreRunner(c.executablePath, c.networkPassphrase, c.historyURLs)
+	}
 	err = c.stellarCoreRunner.catchup(from, to)
 	if err != nil {
 		return errors.Wrap(err, "error running stellar-core")
@@ -175,7 +177,9 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 		)
 	}
 
-	c.stellarCoreRunner = newStellarCoreRunner(c.executablePath, c.networkPassphrase, c.historyURLs)
+	if c.stellarCoreRunner == nil {
+		c.stellarCoreRunner = newStellarCoreRunner(c.executablePath, c.networkPassphrase, c.historyURLs)
+	}
 	err = c.stellarCoreRunner.runFrom(from)
 	if err != nil {
 		return errors.Wrap(err, "error running stellar-core")

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -72,6 +72,10 @@ type CaptiveStellarCore struct {
 
 	nextLedger uint32  // next ledger expected, error w/ restart if not seen
 	lastLedger *uint32 // end of current segment if offline, nil if online
+
+	processExitMutex sync.Mutex
+	processExit      bool
+	processErr       error
 }
 
 // NewCaptive returns a new CaptiveStellarCore that is not running. Will lazily start a subprocess
@@ -139,6 +143,8 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 	c.nextLedger = roundDownToFirstReplayAfterCheckpointStart(from)
 	c.lastLedger = &to
 	c.blocking = true
+	c.processExit = false
+	c.processErr = nil
 
 	// read-ahead buffer
 	c.metaC = make(chan metaResult, readAheadBufferSize)
@@ -190,6 +196,8 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 	c.nextLedger = from
 	c.lastLedger = nil
 	c.blocking = false
+	c.processExit = false
+	c.processErr = nil
 
 	// read-ahead buffer
 	c.metaC = make(chan metaResult, readAheadBufferSize)
@@ -209,17 +217,6 @@ func (c *CaptiveStellarCore) sendLedgerMeta(untilSequence uint32) {
 		select {
 		case <-c.shutdown:
 			return
-		case processErr := <-c.stellarCoreRunner.getProcessExitChan():
-			// First, check if this is an error caused by a process exit.
-			if processErr != nil {
-				processErr = errors.Wrap(processErr, "stellar-core process exited with an error")
-			} else {
-				processErr = errors.New("stellar-core process exited without an error unexpectedly")
-			}
-			// When `GetLedger` sees the error it will close the backend. We shouldn't
-			// close it now because there may be some ledgers in a buffer.
-			c.metaC <- metaResult{nil, processErr}
-			return
 		case <-printBufferOccupation.C:
 			log.Debug("captive core read-ahead buffer occupation:", len(c.metaC))
 		default:
@@ -227,6 +224,20 @@ func (c *CaptiveStellarCore) sendLedgerMeta(untilSequence uint32) {
 
 		meta, err := c.readLedgerMetaFromPipe()
 		if err != nil {
+			select {
+			case processErr := <-c.stellarCoreRunner.getProcessExitChan():
+				// First, check if this is an error caused by a process exit.
+				c.processExitMutex.Lock()
+				c.processExit = true
+				c.processErr = processErr
+				c.processExitMutex.Unlock()
+				if processErr != nil {
+					err = errors.Wrap(processErr, "stellar-core process exited with an error")
+				} else {
+					err = errors.New("stellar-core process exited without an error unexpectedly")
+				}
+			default:
+			}
 			// When `GetLedger` sees the error it will close the backend. We shouldn't
 			// close it now because there may be some ledgers in a buffer.
 			c.metaC <- metaResult{nil, err}
@@ -289,19 +300,23 @@ func (c *CaptiveStellarCore) PrepareRange(ledgerRange Range) error {
 		select {
 		case <-c.shutdown:
 			return nil
-		case err := <-c.stellarCoreRunner.getProcessExitChan():
-			if err != nil {
-				err = errors.Wrap(err, "stellar-core process exited with an error")
-			} else {
-				err = errors.New("stellar-core process exited without an error unexpectedly")
-			}
-			// We close the backend to reset it's state to be able to prepare again.
-			c.Close()
-			return err
 		default:
 		}
-		// Wait for the first ledger
+		// Wait for the first ledger or an error
 		if len(c.metaC) > 0 {
+			// If process exited return an error
+			c.processExitMutex.Lock()
+			if c.processExit {
+				if c.processErr != nil {
+					err = errors.Wrap(c.processErr, "stellar-core process exited with an error")
+				} else {
+					err = errors.New("stellar-core process exited without an error unexpectedly")
+				}
+			}
+			c.processExitMutex.Unlock()
+			if err != nil {
+				return err
+			}
 			break
 		}
 		time.Sleep(time.Second)

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -209,15 +209,16 @@ func (c *CaptiveStellarCore) sendLedgerMeta(untilSequence uint32) {
 		select {
 		case <-c.shutdown:
 			return
-		case err := <-c.stellarCoreRunner.getProcessExitChan():
-			if err != nil {
-				err = errors.Wrap(err, "stellar-core process exited with an error")
+		case processErr := <-c.stellarCoreRunner.getProcessExitChan():
+			// First, check if this is an error caused by a process exit.
+			if processErr != nil {
+				processErr = errors.Wrap(processErr, "stellar-core process exited with an error")
 			} else {
-				err = errors.New("stellar-core process exited without an error unexpectedly")
+				processErr = errors.New("stellar-core process exited without an error unexpectedly")
 			}
 			// When `GetLedger` sees the error it will close the backend. We shouldn't
 			// close it now because there may be some ledgers in a buffer.
-			c.metaC <- metaResult{nil, err}
+			c.metaC <- metaResult{nil, processErr}
 			return
 		case <-printBufferOccupation.C:
 			log.Debug("captive core read-ahead buffer occupation:", len(c.metaC))

--- a/exp/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend_test.go
@@ -34,6 +34,11 @@ func (m *stellarCoreRunnerMock) getMetaPipe() io.Reader {
 	return a.Get(0).(io.Reader)
 }
 
+func (m *stellarCoreRunnerMock) getProcessExitChan() chan error {
+	a := m.Called()
+	return a.Get(0).(chan error)
+}
+
 func (m *stellarCoreRunnerMock) close() error {
 	a := m.Called()
 	return a.Error(0)
@@ -106,13 +111,10 @@ func TestCaptiveNew(t *testing.T) {
 		historyURLs,
 	)
 
+	assert.Equal(t, executablePath, captiveStellarCore.executablePath)
 	assert.Equal(t, networkPassphrase, captiveStellarCore.networkPassphrase)
 	assert.Equal(t, historyURLs, captiveStellarCore.historyURLs)
 	assert.Equal(t, uint32(0), captiveStellarCore.nextLedger)
-
-	assert.Equal(t, executablePath, captiveStellarCore.stellarCoreRunner.(*stellarCoreRunner).executablePath)
-	assert.Equal(t, networkPassphrase, captiveStellarCore.stellarCoreRunner.(*stellarCoreRunner).networkPassphrase)
-	assert.Equal(t, historyURLs, captiveStellarCore.stellarCoreRunner.(*stellarCoreRunner).historyURLs)
 }
 
 func TestCaptivePrepareRange(t *testing.T) {
@@ -126,6 +128,7 @@ func TestCaptivePrepareRange(t *testing.T) {
 
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(100), uint32(200)).Return(nil).Once()
+	mockRunner.On("getProcessExitChan").Return(make(chan error))
 	mockRunner.On("getMetaPipe").Return(&buf)
 	mockRunner.On("close").Return(nil).Once()
 
@@ -151,6 +154,7 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("runFrom", uint32(64)).Return(nil).Once()
 	mockRunner.On("getMetaPipe").Return(&buf)
+	mockRunner.On("getProcessExitChan").Return(make(chan error))
 	mockRunner.On("close").Return(nil).Once()
 
 	captiveBackend := CaptiveStellarCore{
@@ -202,6 +206,7 @@ func TestGetLedgerBoundsCheck(t *testing.T) {
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(128), uint32(130)).Return(nil).Once()
 	mockRunner.On("getMetaPipe").Return(&buf)
+	mockRunner.On("getProcessExitChan").Return(make(chan error))
 	mockRunner.On("close").Return(nil).Once()
 
 	captiveBackend := CaptiveStellarCore{

--- a/exp/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend_test.go
@@ -167,7 +167,7 @@ func TestCaptivePrepareRangeCrash(t *testing.T) {
 	assert.EqualError(t, err, "stellar-core process exited with an error: exit code -1")
 }
 
-func TestCaptivePrepareRangeTerrminated(t *testing.T) {
+func TestCaptivePrepareRangeTerminated(t *testing.T) {
 	var buf bytes.Buffer
 
 	ch := make(chan error, 1) // we use buffered channel in tests only
@@ -251,7 +251,6 @@ func TestGetLedgerBoundsCheck(t *testing.T) {
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(128), uint32(130)).Return(nil).Once()
 	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("getProcessExitChan").Return(make(chan error))
 	mockRunner.On("close").Return(nil).Once()
 
 	captiveBackend := CaptiveStellarCore{
@@ -300,4 +299,37 @@ func TestGetLedgerBoundsCheck(t *testing.T) {
 	err = captiveBackend.Close()
 	assert.NoError(t, err)
 	mockRunner.AssertExpectations(t)
+}
+
+func TestCaptiveGetLedgerTerminated(t *testing.T) {
+	reader, writer := io.Pipe()
+
+	ch := make(chan error, 1) // we use buffered channel in tests only
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("catchup", uint32(64), uint32(100)).Return(nil).Once()
+	mockRunner.On("getProcessExitChan").Return(ch)
+	mockRunner.On("getMetaPipe").Return(reader)
+	mockRunner.On("close").Return(nil).Once()
+
+	captiveBackend := CaptiveStellarCore{
+		networkPassphrase: network.PublicNetworkPassphrase,
+		historyURLs:       []string{"http://history.stellar.org/prd/core-live/core_live_001"},
+		stellarCoreRunner: mockRunner,
+	}
+
+	go writeLedgerHeader(writer, 64)
+	err := captiveBackend.PrepareRange(BoundedRange(64, 100))
+	assert.NoError(t, err)
+
+	ch <- nil
+	writer.Close()
+
+	exists, meta, err := captiveBackend.GetLedger(64)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, uint32(64), meta.LedgerSequence())
+
+	_, _, err = captiveBackend.GetLedger(65)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "stellar-core process exited without an error unexpectedly")
 }

--- a/exp/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
@@ -34,7 +35,7 @@ func (m *stellarCoreRunnerMock) getMetaPipe() io.Reader {
 	return a.Get(0).(io.Reader)
 }
 
-func (m *stellarCoreRunnerMock) getProcessExitChan() chan error {
+func (m *stellarCoreRunnerMock) getProcessExitChan() <-chan error {
 	a := m.Called()
 	return a.Get(0).(chan error)
 }
@@ -142,6 +143,50 @@ func TestCaptivePrepareRange(t *testing.T) {
 	assert.NoError(t, err)
 	err = captiveBackend.Close()
 	assert.NoError(t, err)
+}
+
+func TestCaptivePrepareRangeCrash(t *testing.T) {
+	var buf bytes.Buffer
+
+	ch := make(chan error, 1) // we use buffered channel in tests only
+	ch <- errors.New("exit code -1")
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("catchup", uint32(100), uint32(200)).Return(nil).Once()
+	mockRunner.On("getProcessExitChan").Return(ch)
+	mockRunner.On("getMetaPipe").Return(&buf)
+	mockRunner.On("close").Return(nil).Once()
+
+	captiveBackend := CaptiveStellarCore{
+		networkPassphrase: network.PublicNetworkPassphrase,
+		historyURLs:       []string{"http://history.stellar.org/prd/core-live/core_live_001"},
+		stellarCoreRunner: mockRunner,
+	}
+
+	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
+	assert.Error(t, err)
+	assert.EqualError(t, err, "stellar-core process exited with an error: exit code -1")
+}
+
+func TestCaptivePrepareRangeTerrminated(t *testing.T) {
+	var buf bytes.Buffer
+
+	ch := make(chan error, 1) // we use buffered channel in tests only
+	ch <- nil
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("catchup", uint32(100), uint32(200)).Return(nil).Once()
+	mockRunner.On("getProcessExitChan").Return(ch)
+	mockRunner.On("getMetaPipe").Return(&buf)
+	mockRunner.On("close").Return(nil).Once()
+
+	captiveBackend := CaptiveStellarCore{
+		networkPassphrase: network.PublicNetworkPassphrase,
+		historyURLs:       []string{"http://history.stellar.org/prd/core-live/core_live_001"},
+		stellarCoreRunner: mockRunner,
+	}
+
+	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
+	assert.Error(t, err)
+	assert.EqualError(t, err, "stellar-core process exited without an error unexpectedly")
 }
 
 func TestGetLatestLedgerSequence(t *testing.T) {

--- a/exp/ingest/ledgerbackend/stellar_core_runner.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner.go
@@ -20,7 +20,7 @@ type stellarCoreRunnerInterface interface {
 	catchup(from, to uint32) error
 	runFrom(from uint32) error
 	getMetaPipe() io.Reader
-	getProcessExitChan() chan error
+	getProcessExitChan() <-chan error
 	close() error
 }
 
@@ -217,7 +217,7 @@ func (r *stellarCoreRunner) getMetaPipe() io.Reader {
 	return r.metaPipe
 }
 
-func (r *stellarCoreRunner) getProcessExitChan() chan error {
+func (r *stellarCoreRunner) getProcessExitChan() <-chan error {
 	return r.processExit
 }
 

--- a/exp/ingest/ledgerbackend/stellar_core_runner.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner.go
@@ -20,6 +20,7 @@ type stellarCoreRunnerInterface interface {
 	catchup(from, to uint32) error
 	runFrom(from uint32) error
 	getMetaPipe() io.Reader
+	getProcessExitChan() chan error
 	close() error
 }
 
@@ -28,10 +29,13 @@ type stellarCoreRunner struct {
 	networkPassphrase string
 	historyURLs       []string
 
-	cmd      *exec.Cmd
-	metaPipe io.Reader
-	tempDir  string
-	nonce    string
+	cmd *exec.Cmd
+	// processExit channel receives an error when the process exited with an error
+	// or nil if the process exited without an error.
+	processExit chan error
+	metaPipe    io.Reader
+	tempDir     string
+	nonce       string
 }
 
 func newStellarCoreRunner(executablePath, networkPassphrase string, historyURLs []string) *stellarCoreRunner {
@@ -40,6 +44,7 @@ func newStellarCoreRunner(executablePath, networkPassphrase string, historyURLs 
 		executablePath:    executablePath,
 		networkPassphrase: networkPassphrase,
 		historyURLs:       historyURLs,
+		processExit:       make(chan error),
 		nonce:             fmt.Sprintf("captive-stellar-core-%x", r.Uint64()),
 	}
 }
@@ -136,10 +141,6 @@ func (r *stellarCoreRunner) writeConf() error {
 func (r *stellarCoreRunner) createCmd(params ...string) (*exec.Cmd, error) {
 	allParams := append([]string{"--conf", r.getConfFileName()}, params...)
 	cmd := exec.Command(r.executablePath, allParams...)
-	err := cmd.Start()
-	if err != nil {
-		return nil, errors.Wrapf(err, "error starting `stellar-core %v` subprocess", params)
-	}
 	cmd.Dir = r.getTmpDir()
 	cmd.Stdout = r.getLogLineWriter()
 	cmd.Stderr = r.getLogLineWriter()
@@ -214,6 +215,10 @@ func (r *stellarCoreRunner) runFrom(from uint32) error {
 
 func (r *stellarCoreRunner) getMetaPipe() io.Reader {
 	return r.metaPipe
+}
+
+func (r *stellarCoreRunner) getProcessExitChan() chan error {
+	return r.processExit
 }
 
 func (r *stellarCoreRunner) close() error {

--- a/exp/ingest/ledgerbackend/stellar_core_runner_posix.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner_posix.go
@@ -44,6 +44,11 @@ func (c *stellarCoreRunner) start() (io.Reader, error) {
 		return readFile, errors.Wrap(err, "error starting stellar-core")
 	}
 
+	go func() {
+		c.processExit <- c.cmd.Wait()
+		close(c.processExit)
+	}()
+
 	// Do not remove bufio.Reader wrapping. Turns out that each read from a pipe
 	// adds an overhead time so it's better to preload data to a buffer.
 	return bufio.NewReaderSize(readFile, 1024*1024), nil

--- a/exp/ingest/ledgerbackend/stellar_core_runner_windows.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner_windows.go
@@ -36,6 +36,11 @@ func (c *stellarCoreRunner) start() (io.Reader, error) {
 		return io.Reader(nil), err
 	}
 
+	go func() {
+		c.processExit <- c.cmd.Wait()
+		close(c.processExit)
+	}()
+
 	// Then accept on the server end.
 	connection, err := listener.Accept()
 	if err != nil {

--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -2,8 +2,9 @@ package expingest
 
 import (
 	"fmt"
-	"github.com/stellar/go/exp/ingest/ledgerbackend"
 	"time"
+
+	"github.com/stellar/go/exp/ingest/ledgerbackend"
 
 	"github.com/stellar/go/exp/ingest/io"
 	"github.com/stellar/go/services/horizon/internal/toid"
@@ -277,7 +278,7 @@ func (b buildState) run(s *system) (transition, error) {
 
 	err = s.ledgerBackend.PrepareRange(ledgerbackend.UnboundedRange(b.checkpointLedger))
 	if err != nil {
-		return stop(), errors.Wrap(err, "error preparing range")
+		return start(), errors.Wrap(err, "error preparing range")
 	}
 
 	stats, err := s.runner.RunHistoryArchiveIngestion(b.checkpointLedger)
@@ -373,7 +374,7 @@ func (r resumeState) run(s *system) (transition, error) {
 
 	err = s.ledgerBackend.PrepareRange(ledgerbackend.UnboundedRange(ingestLedger))
 	if err != nil {
-		return stop(), errors.Wrap(err, "error preparing range")
+		return start(), errors.Wrap(err, "error preparing range")
 	}
 
 	// Check if ledger is closed
@@ -478,7 +479,7 @@ func (h historyRangeState) run(s *system) (transition, error) {
 
 	err = s.ledgerBackend.PrepareRange(ledgerbackend.UnboundedRange(h.fromLedger))
 	if err != nil {
-		return stop(), errors.Wrap(err, "error preparing range")
+		return start(), errors.Wrap(err, "error preparing range")
 	}
 
 	for cur := h.fromLedger; cur <= h.toLedger; cur++ {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit adds a code that handles Stellar-Core process exit gracefully. Added `processExit` unbuffered channel to `stellarCoreRunner` that receives the error in case Stellar-Core crashed or was terminated with an error or nil error if it was shutdown gracefully. The channel is later used in `PrepareRange` that returns an error if the process was stopped while prepare was running and in `sendLedgerMeta` that adds error to a meta channel that will be read by one of the following `GetLedger` calls.

Close #2705.

### Why

Right now when Stellar-Core crashes, `CaptiveStellarCore` simply wait for the next ledger without restarting it.