### PR TITLE
exp/services/recoverysigner: tidy the usage text of the encryption-tink-keyset commands

### DIFF
--- a/exp/services/recoverysigner/README.md
+++ b/exp/services/recoverysigner/README.md
@@ -31,8 +31,6 @@ Available Commands:
   db                     Run database operations
   encryption-tink-keyset Run Tink keyset operations
   serve                  Run the SEP-30 Recovery Signer server
-
-Use "recoverysigner [command] --help" for more information about a command.
 ```
 
 ## Usage: serve
@@ -71,13 +69,10 @@ Available Commands:
 
 Flags:
       --db-url string   Database URL (DB_URL) (default "postgres://localhost:5432/?sslmode=disable")
-
-Use "recoverysigner db [command] --help" for more information about a command.
 ```
 
 ## Usage: encryption-tink-keyset
 
-The format of the --encryption-kms-key-uri configuration option should conform to the format stated in [Google Tink](https://github.com/google/tink/blob/040ac621b3e9ff7a240b1e596a423a30d32f9013/docs/KEY-MANAGEMENT.md#key-management-systems).
 ```
 $ recoverysigner encryption-tink-keyset --help
 Run Tink keyset operations
@@ -87,16 +82,10 @@ Usage:
   recoverysigner encryption-tink-keyset [command]
 
 Available Commands:
-  create      Create a new Tink keyset
-  decrypt     Decrypt the Tink keyset specified in encryption-tink-keyset with the KMS key specified in encryption-kms-key-uri
-  encrypt     Encrypt the Tink keyset specified in encryption-tink-keyset with the KMS key specified in encryption-kms-key-uri
-  rotate      Rotate the Tink keyset specified in encryption-tink-keyset by generating a new key, adding it to the keyset, and making it the primary key in the keyset
-
-Flags:
-      --encryption-kms-key-uri string   URI for a remote KMS key used to encrypt Tink keyset (ENCRYPTION_KMS_KEY_URI)
-      --encryption-tink-keyset string   Tink keyset to rotate/encrypt/decrypt (ENCRYPTION_TINK_KEYSET)
-
-Use "recoverysigner encryption-tink-keyset [command] --help" for more information about a command.
+  create      Create a new Tink keyset containing a single key
+  decrypt     Decrypt a Tink keyset
+  encrypt     Encrypt a Tink keyset
+  rotate      Rotate a Tink keyset
 ```
 
 [SEP-30]: https://github.com/stellar/stellar-protocol/blob/600c326b210d71ee031d7f3a40ca88191b4cdf9c/ecosystem/sep-0030.md

--- a/exp/services/recoverysigner/cmd/keyset_create.go
+++ b/exp/services/recoverysigner/cmd/keyset_create.go
@@ -24,7 +24,7 @@ func (c *KeysetCreateCommand) Command() *cobra.Command {
 	configOpts := config.ConfigOptions{
 		{
 			Name:        "encryption-kms-key-uri",
-			Usage:       "URI for a remote KMS key used to encrypt the Tink keyset",
+			Usage:       "URI for a remote KMS key used to encrypt the Tink keyset (format: aws-kms://arn:aws:kms:<region>:<account-id>:key/<key-id>)",
 			OptType:     types.String,
 			ConfigKey:   &c.EncryptionKMSKeyURI,
 			FlagDefault: "",

--- a/exp/services/recoverysigner/cmd/keyset_decrypt.go
+++ b/exp/services/recoverysigner/cmd/keyset_decrypt.go
@@ -23,7 +23,7 @@ func (c *KeysetDecryptCommand) Command() *cobra.Command {
 	configOpts := config.ConfigOptions{
 		{
 			Name:        "encryption-kms-key-uri",
-			Usage:       "URI for a remote KMS key used to decrypt the Tink keyset",
+			Usage:       "URI for a remote KMS key used to decrypt the Tink keyset (format: aws-kms://arn:aws:kms:<region>:<account-id>:key/<key-id>)",
 			OptType:     types.String,
 			ConfigKey:   &c.EncryptionKMSKeyURI,
 			FlagDefault: "",
@@ -31,7 +31,7 @@ func (c *KeysetDecryptCommand) Command() *cobra.Command {
 		},
 		{
 			Name:        "encryption-tink-keyset",
-			Usage:       "Tink keyset to decrypt",
+			Usage:       "Tink keyset to decrypt in JSON format",
 			OptType:     types.String,
 			ConfigKey:   &c.EncryptionTinkKeysetJSON,
 			FlagDefault: "",
@@ -41,7 +41,7 @@ func (c *KeysetDecryptCommand) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "decrypt",
 		Short: "Decrypt a Tink keyset",
-		Long:  "Decrypt a Tink keyset specified in encryption-tink-keyset with the KMS key specified in encryption-kms-key-uri",
+		Long:  "Decrypt a Tink keyset specified in encryption-tink-keyset with the KMS key specified in encryption-kms-key-uri.",
 		Run: func(cmd *cobra.Command, args []string) {
 			configOpts.Require()
 			configOpts.SetValues()

--- a/exp/services/recoverysigner/cmd/keyset_decrypt.go
+++ b/exp/services/recoverysigner/cmd/keyset_decrypt.go
@@ -40,7 +40,8 @@ func (c *KeysetDecryptCommand) Command() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "decrypt",
-		Short: "Decrypt the Tink keyset specified in encryption-tink-keyset with the KMS key specified in encryption-kms-key-uri",
+		Short: "Decrypt a Tink keyset",
+		Long:  "Decrypt a Tink keyset specified in encryption-tink-keyset with the KMS key specified in encryption-kms-key-uri",
 		Run: func(cmd *cobra.Command, args []string) {
 			configOpts.Require()
 			configOpts.SetValues()

--- a/exp/services/recoverysigner/cmd/keyset_decrypt.go
+++ b/exp/services/recoverysigner/cmd/keyset_decrypt.go
@@ -31,7 +31,7 @@ func (c *KeysetDecryptCommand) Command() *cobra.Command {
 		},
 		{
 			Name:        "encryption-tink-keyset",
-			Usage:       "Tink keyset to decrypt in JSON format",
+			Usage:       "Tink keyset in JSON format to be decrypted",
 			OptType:     types.String,
 			ConfigKey:   &c.EncryptionTinkKeysetJSON,
 			FlagDefault: "",

--- a/exp/services/recoverysigner/cmd/keyset_encrypt.go
+++ b/exp/services/recoverysigner/cmd/keyset_encrypt.go
@@ -31,7 +31,7 @@ func (c *KeysetEncryptCommand) Command() *cobra.Command {
 		},
 		{
 			Name:        "encryption-tink-keyset",
-			Usage:       "Tink keyset to encrypt in JSON format",
+			Usage:       "Tink keyset in JSON format to be encrypted",
 			OptType:     types.String,
 			ConfigKey:   &c.EncryptionTinkKeysetJSON,
 			FlagDefault: "",

--- a/exp/services/recoverysigner/cmd/keyset_encrypt.go
+++ b/exp/services/recoverysigner/cmd/keyset_encrypt.go
@@ -23,7 +23,7 @@ func (c *KeysetEncryptCommand) Command() *cobra.Command {
 	configOpts := config.ConfigOptions{
 		{
 			Name:        "encryption-kms-key-uri",
-			Usage:       "URI for a remote KMS key used to encrypt the Tink keyset",
+			Usage:       "URI for a remote KMS key used to encrypt the Tink keyset (format: aws-kms://arn:aws:kms:<region>:<account-id>:key/<key-id>)",
 			OptType:     types.String,
 			ConfigKey:   &c.EncryptionKMSKeyURI,
 			FlagDefault: "",
@@ -31,7 +31,7 @@ func (c *KeysetEncryptCommand) Command() *cobra.Command {
 		},
 		{
 			Name:        "encryption-tink-keyset",
-			Usage:       "Tink keyset to encrypt",
+			Usage:       "Tink keyset to encrypt in JSON format",
 			OptType:     types.String,
 			ConfigKey:   &c.EncryptionTinkKeysetJSON,
 			FlagDefault: "",

--- a/exp/services/recoverysigner/cmd/keyset_encrypt.go
+++ b/exp/services/recoverysigner/cmd/keyset_encrypt.go
@@ -40,7 +40,8 @@ func (c *KeysetEncryptCommand) Command() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "encrypt",
-		Short: "Encrypt the Tink keyset specified in encryption-tink-keyset with the KMS key specified in encryption-kms-key-uri",
+		Short: "Encrypt a Tink keyset",
+		Long:  "Encrypt a Tink keyset specified in encryption-tink-keyset with the KMS key specified in encryption-kms-key-uri",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		},
 		Run: func(cmd *cobra.Command, args []string) {

--- a/exp/services/recoverysigner/cmd/keyset_rotate.go
+++ b/exp/services/recoverysigner/cmd/keyset_rotate.go
@@ -34,7 +34,7 @@ func (c *KeysetRotateCommand) Command() *cobra.Command {
 		},
 		{
 			Name:        "encryption-tink-keyset",
-			Usage:       "Tink keyset to rotate in JSON format",
+			Usage:       "Tink keyset in JSON format to be rotated",
 			OptType:     types.String,
 			ConfigKey:   &c.EncryptionTinkKeysetJSON,
 			FlagDefault: "",

--- a/exp/services/recoverysigner/cmd/keyset_rotate.go
+++ b/exp/services/recoverysigner/cmd/keyset_rotate.go
@@ -43,7 +43,8 @@ func (c *KeysetRotateCommand) Command() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "rotate",
-		Short: "Rotate the Tink keyset specified in encryption-tink-keyset by generating a new key, adding it to the keyset, and making it the primary key in the keyset",
+		Short: "Rotate a Tink keyset",
+		Long:  "Rotate a Tink keyset specified in encryption-tink-keyset by generating a new key, adding it to the keyset, and making it the primary key in the keyset",
 		Run: func(cmd *cobra.Command, args []string) {
 			configOpts.Require()
 			configOpts.SetValues()

--- a/exp/services/recoverysigner/cmd/keyset_rotate.go
+++ b/exp/services/recoverysigner/cmd/keyset_rotate.go
@@ -26,7 +26,7 @@ func (c *KeysetRotateCommand) Command() *cobra.Command {
 	configOpts := config.ConfigOptions{
 		{
 			Name:        "encryption-kms-key-uri",
-			Usage:       "URI for a remote KMS key used to decrypt/encrypt Tink keyset during rotation",
+			Usage:       "URI for a remote KMS key used to decrypt/encrypt the Tink keyset (format: aws-kms://arn:aws:kms:<region>:<account-id>:key/<key-id>)",
 			OptType:     types.String,
 			ConfigKey:   &c.EncryptionKMSKeyURI,
 			FlagDefault: "",
@@ -34,7 +34,7 @@ func (c *KeysetRotateCommand) Command() *cobra.Command {
 		},
 		{
 			Name:        "encryption-tink-keyset",
-			Usage:       "Tink keyset to rotate",
+			Usage:       "Tink keyset to rotate in JSON format",
 			OptType:     types.String,
 			ConfigKey:   &c.EncryptionTinkKeysetJSON,
 			FlagDefault: "",


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Move the long descriptions in the encryption-tink-keyset commands so that they display when viewing the help for each command, and make other small improvements to the usage text so that they contain all the information needed to use the commands.

### Why
To tidy the usage text and make it easier to digest and use on its own without referring to the README. The top level command usage is easier to skim over as it focuses on what each subcommand does, and then the individual help for each command will discuss how that command works. The URI format is only discussed in the README but it should be discussed in the usage text instead.

### Known limitations

N/A
