### PR TITLE
services/horizon: Use strings.Contains() instead of regex.Match() when populating HAL links.

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -11,6 +11,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).x
   The following config parameters were removed:
   - `core-db-max-open-connections`
   - `core-db-max-idle-connections`
+* HAL response population is implemented using Go `strings` package instead of `regexp`, improving its performance.  
 
 ## v1.5.0
 

--- a/support/render/hal/link.go
+++ b/support/render/hal/link.go
@@ -1,7 +1,7 @@
 package hal
 
 import (
-	"regexp"
+	"strings"
 )
 
 type Link struct {
@@ -10,11 +10,7 @@ type Link struct {
 }
 
 func (l *Link) PopulateTemplated() {
-	var err error
-	l.Templated, err = regexp.Match("{.*}", []byte(l.Href))
-	if err != nil {
-		panic(err)
-	}
+	l.Templated = strings.Contains(l.Href, "{")
 }
 
 func NewLink(href string) Link {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Improve the performance of HAL response construction using `PopulateTemplated()` without involving calling Go regexp package. This improves response performance.

This is an updated version of https://github.com/stellar/go/pull/1582

