### PR TITLE
clients/horizonclient: add missing NextAccountsPage

### DIFF
--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -6,6 +6,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * Remove JSON variant of `GET /metrics`, both in the server and client code. It's using Prometheus format by default now.
+* Add `NextAccountsPage`.
 
 ## [v3.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v3.0.0) - 2020-04-28
 

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -681,6 +681,12 @@ func (c *Client) Version() string {
 	return version
 }
 
+// NextAccountsPage returns the next page of accounts.
+func (c *Client) NextAccountsPage(page hProtocol.AccountsPage) (accounts hProtocol.AccountsPage, err error) {
+	err = c.sendRequestURL(page.Links.Next.Href, "get", &accounts)
+	return
+}
+
 // NextAssetsPage returns the next page of assets.
 func (c *Client) NextAssetsPage(page hProtocol.AssetsPage) (assets hProtocol.AssetsPage, err error) {
 	err = c.sendRequestURL(page.Links.Next.Href, "get", &assets)

--- a/clients/horizonclient/examples_test.go
+++ b/clients/horizonclient/examples_test.go
@@ -125,6 +125,33 @@ func ExampleClient_LedgerDetail() {
 
 }
 
+func ExampleClient_NextAccountsPage() {
+	client := horizonclient.DefaultPublicNetClient
+	// accounts with signer
+	accountsRequest := horizonclient.AccountsRequest{Signer: "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU",
+		Limit: 20}
+	accounts, err := client.Accounts(accountsRequest)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println("Page 1:")
+	for _, a := range accounts.Embedded.Records {
+		fmt.Println(a.ID)
+	}
+
+	// next page
+	accounts2, err := client.NextAccountsPage(accounts)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println("Page 2:")
+	for _, a := range accounts2.Embedded.Records {
+		fmt.Println(a.ID)
+	}
+}
+
 func ExampleClient_NextAssetsPage() {
 	client := horizonclient.DefaultPublicNetClient
 	// assets for asset issuer

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -187,6 +187,7 @@ type ClientInterface interface {
 	StreamLedgers(ctx context.Context, request LedgerRequest, handler LedgerHandler) error
 	StreamOrderBooks(ctx context.Context, request OrderBookRequest, handler OrderBookHandler) error
 	Root() (hProtocol.Root, error)
+	NextAccountsPage(hProtocol.AccountsPage) (hProtocol.AccountsPage, error)
 	NextAssetsPage(hProtocol.AssetsPage) (hProtocol.AssetsPage, error)
 	PrevAssetsPage(hProtocol.AssetsPage) (hProtocol.AssetsPage, error)
 	NextLedgersPage(hProtocol.LedgersPage) (hProtocol.LedgersPage, error)

--- a/clients/horizonclient/mocks.go
+++ b/clients/horizonclient/mocks.go
@@ -211,6 +211,12 @@ func (m *MockClient) Root() (hProtocol.Root, error) {
 	return a.Get(0).(hProtocol.Root), a.Error(1)
 }
 
+// NextAccountsPage is a mocking method
+func (m *MockClient) NextAccountsPage(page hProtocol.AccountsPage) (hProtocol.AccountsPage, error) {
+	a := m.Called(page)
+	return a.Get(0).(hProtocol.AccountsPage), a.Error(1)
+}
+
 // NextAssetsPage is a mocking method
 func (m *MockClient) NextAssetsPage(page hProtocol.AssetsPage) (hProtocol.AssetsPage, error) {
 	a := m.Called(page)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Add NextAccountsPage function to Horizon Client.

### Why
It is not easy to iterate on pages of the `Accounts` function because there is no function to help get the next page. All the other entities have a next page function, but it looks like the `Accounts` is missing their companion next pager.

This is being merged directly to master and can be released in a patch release because this change, while it adds a new function that could be considered a new feature, it is really a bugfix because paging over accounts is broken without it.

### Known limitations

I opted to add an example rather than a test because that seems to be the pattern of the other next paging functions.