### PR TITLE
services/horizon: Ignore ConnectionTimeout in txsub

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -12,6 +12,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).x
   - `core-db-max-open-connections`
   - `core-db-max-idle-connections`
 * HAL response population is implemented using Go `strings` package instead of `regexp`, improving its performance.  
+* The `--connection-timeout` param is ignored in `POST /transactions`. The requests sent to that endpoint will always timeout after 30 seconds.
 
 ## v1.5.0
 

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -206,7 +206,7 @@ var configOpts = support.ConfigOptions{
 		OptType:        types.Int,
 		FlagDefault:    55,
 		CustomSetValue: support.SetDuration,
-		Usage:          "defines the timeout of connection after which 504 response will be sent or stream will be closed, if Horizon is behind a load balancer with idle connection timeout, this should be set to a few seconds less that idle timeout",
+		Usage:          "defines the timeout of connection after which 504 response will be sent or stream will be closed, if Horizon is behind a load balancer with idle connection timeout, this should be set to a few seconds less that idle timeout, does not apply to POST /transactions",
 	},
 	&support.ConfigOption{
 		Name:        "per-hour-rate-limit",

--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -114,7 +114,10 @@ func timeoutMiddleware(timeout time.Duration) func(next http.Handler) http.Handl
 				}
 			}()
 
-			r = r.WithContext(ctx)
+			// txsub has a custom timeout
+			if r.Method != http.MethodPost {
+				r = r.WithContext(ctx)
+			}
 			next.ServeHTTP(mw, r)
 		}
 		return http.HandlerFunc(fn)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit changes the behaviour of `--connection-timeout` config param. Right now, it is ignored in `txsub` so if the value is less than 30s, `txsub` will still timeout after 30s.

### Why

If Horizon admin wants to set `--connection-timeout` to a small value it will likely affect `txsub` system because it requires at least 5 seconds on average to report the status of the transaction when it's included in the ledger.

### Known limitations

Currently the code ignores timeout for all `POST` requests to avoid having to parse the route from request URL.