### PR TITLE
services/horizon: Require all captive Stellar-Core params or none

### DIFF
--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -405,9 +405,7 @@ func initRootConfig() {
 		stdLog.Fatalf("--history-archive-urls must be set when --ingest is set")
 	}
 
-	if config.EnableCaptiveCoreIngestion && config.StellarCoreBinaryPath == "" {
-		stdLog.Fatalf("--stellar-core-binary-path must be set when --enable-captive-core-ingestion is set")
-	}
+	validateBothOrNeither("enable-captive-core-ingestion", "stellar-core-binary-path")
 
 	// Configure log file
 	if config.LogFile != "" {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Update config validation to require both captive core options to be set or unset. This is done because captive core is started when `--stellar-core-binary-path` is set, without checking `--enable-captive-core-ingestion` value:
https://github.com/stellar/go/blob/b74be4c0a9458382dd93f98ed57a61b35230e478/services/horizon/internal/init.go#L54-L71
So it's possible that Horizon user can accidentally start captive core ingestion without `--enable-captive-core-ingestion`.