### PR TITLE
exp/tools/dump-ledger-state: Abort early if request to populate LATEST_LEDGER fails

### DIFF
--- a/exp/tools/dump-ledger-state/docker-entrypoint.sh
+++ b/exp/tools/dump-ledger-state/docker-entrypoint.sh
@@ -26,6 +26,11 @@ if [ -z ${LATEST_LEDGER+x} ]; then
     fi
 fi
 
+if [ -z ${LATEST_LEDGER+x} ]; then
+  echo "could not obtain latest ledger"
+  exit 1
+fi
+
 echo "Latest ledger: $LATEST_LEDGER"
 
 if ! ./run_test.sh; then


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The dump ledger state job begins by requesting the latest snapshot ledger.
https://github.com/stellar/go/blob/master/exp/tools/dump-ledger-state/run_test.sh#L12

When this request fails `LATEST_LEDGER` is set to the empty string which causes the job to fail and trigger an alert.

We should abort the job without triggering an alert if LATEST_LEDGER is empty.

