### PR TITLE
exp/ingest/ledgerbackend: Use provided stellar-core.cfg file in an online mode

### DIFF
--- a/exp/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend_test.go
@@ -108,17 +108,20 @@ func writeLedgerHeader(w io.Writer, sequence uint32) {
 
 func TestCaptiveNew(t *testing.T) {
 	executablePath := "/etc/stellar-core"
+	configPath := "/etc/stellar-core.cfg"
 	networkPassphrase := network.PublicNetworkPassphrase
 	historyURLs := []string{"http://history.stellar.org/prd/core-live/core_live_001"}
 
 	captiveStellarCore, err := NewCaptive(
 		executablePath,
+		configPath,
 		networkPassphrase,
 		historyURLs,
 	)
 
 	assert.NoError(t, err)
 	assert.Equal(t, executablePath, captiveStellarCore.executablePath)
+	assert.Equal(t, configPath, captiveStellarCore.configPath)
 	assert.Equal(t, networkPassphrase, captiveStellarCore.networkPassphrase)
 	assert.Equal(t, historyURLs, captiveStellarCore.historyURLs)
 	assert.Equal(t, uint32(0), captiveStellarCore.nextLedger)

--- a/exp/ingest/ledgerbackend/stellar_core_runner_posix.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner_posix.go
@@ -29,12 +29,6 @@ func (c *stellarCoreRunner) start() (io.Reader, error) {
 
 	defer writeFile.Close()
 
-	// Then write config file pointing to it.
-	err = c.writeConf()
-	if err != nil {
-		return readFile, errors.Wrap(err, "error writing conf")
-	}
-
 	// Add the write-end to the set of inherited file handles. This is defined
 	// to be fd 3 on posix platforms.
 	c.cmd.ExtraFiles = []*os.File{writeFile}

--- a/exp/ingest/ledgerbackend/stellar_core_runner_windows.go
+++ b/exp/ingest/ledgerbackend/stellar_core_runner_windows.go
@@ -23,12 +23,6 @@ func (c *stellarCoreRunner) start() (io.Reader, error) {
 		return io.Reader(nil), err
 	}
 
-	// Then write config file pointing to it.
-	err = c.writeConf()
-	if err != nil {
-		return io.Reader(nil), err
-	}
-
 	// Then start the process.
 	err = c.cmd.Start()
 	if err != nil {

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -19,7 +19,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).x
 
 * Add experimental support for live ingestion using a Stellar Core subprocess instead of a persistent Stellar Core database.
 
-  [Stellar Core v12.3.0](https://github.com/stellar/stellar-core/releases/tag/v12.3.0) added an experimental feature which allows replaying ledger's metadata in-memory. This feature starts paving the way to remove the dependency between Stellar Core's database and Horizon.
+  Stellar-core now contains an experimental feature which allows replaying ledger's metadata in-memory. This feature starts paving the way to remove the dependency between Stellar Core's database and Horizon. Requires [Stellar Core v13.2.0](https://github.com/stellar/stellar-core/releases/tag/v13.2.0).
 
   To try out this new experimental feature, you need to specify the following parameters when starting ingesting Horizon instance:
 

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -218,7 +218,7 @@ var dbReingestRangeCmd = &cobra.Command{
 		}
 
 		if config.EnableCaptiveCoreIngestion {
-			ingestConfig.StellarCorePath = config.StellarCoreBinaryPath
+			ingestConfig.StellarCoreBinaryPath = config.StellarCoreBinaryPath
 		} else {
 			if config.StellarCoreDatabaseURL == "" {
 				log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -102,7 +102,7 @@ var ingestVerifyRangeCmd = &cobra.Command{
 			HistoryArchiveURL: config.HistoryArchiveURLs[0],
 		}
 		if config.EnableCaptiveCoreIngestion {
-			ingestConfig.StellarCorePath = config.StellarCoreBinaryPath
+			ingestConfig.StellarCoreBinaryPath = config.StellarCoreBinaryPath
 		} else {
 			if config.StellarCoreDatabaseURL == "" {
 				log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
@@ -186,7 +186,7 @@ var ingestStressTestCmd = &cobra.Command{
 		}
 
 		if config.EnableCaptiveCoreIngestion {
-			ingestConfig.StellarCorePath = config.StellarCoreBinaryPath
+			ingestConfig.StellarCoreBinaryPath = config.StellarCoreBinaryPath
 		} else {
 			if config.StellarCoreDatabaseURL == "" {
 				log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -114,7 +114,6 @@ var configOpts = support.ConfigOptions{
 	dbURLConfigOption,
 	&support.ConfigOption{
 		Name:        "stellar-core-binary-path",
-		EnvVar:      "STELLAR_CORE_BINARY_PATH",
 		OptType:     types.String,
 		FlagDefault: "",
 		Required:    false,
@@ -122,8 +121,15 @@ var configOpts = support.ConfigOptions{
 		ConfigKey:   &config.StellarCoreBinaryPath,
 	},
 	&support.ConfigOption{
+		Name:        "stellar-core-config-path",
+		OptType:     types.String,
+		FlagDefault: "",
+		Required:    false,
+		Usage:       "path to stellar core config file",
+		ConfigKey:   &config.StellarCoreConfigPath,
+	},
+	&support.ConfigOption{
 		Name:        "enable-captive-core-ingestion",
-		EnvVar:      "ENABLE_CAPTIVE_CORE_INGESTION",
 		OptType:     types.Bool,
 		FlagDefault: false,
 		Required:    false,
@@ -406,6 +412,10 @@ func initRootConfig() {
 	}
 
 	validateBothOrNeither("enable-captive-core-ingestion", "stellar-core-binary-path")
+	if config.Ingest {
+		// When running live ingestion a config file is required too
+		validateBothOrNeither("enable-captive-core-ingestion", "stellar-core-config-path")
+	}
 
 	// Configure log file
 	if config.LogFile != "" {

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -11,14 +11,16 @@ import (
 // Config is the configuration for horizon.  It gets populated by the
 // app's main function and is provided to NewApp.
 type Config struct {
-	DatabaseURL                string
+	DatabaseURL        string
+	HistoryArchiveURLs []string
+	Port               uint
+	AdminPort          uint
+
+	EnableCaptiveCoreIngestion bool
 	StellarCoreBinaryPath      string
+	StellarCoreConfigPath      string
 	StellarCoreDatabaseURL     string
 	StellarCoreURL             string
-	EnableCaptiveCoreIngestion bool
-	HistoryArchiveURLs         []string
-	Port                       uint
-	AdminPort                  uint
 
 	// MaxDBConnections has a priority over all 4 values below.
 	MaxDBConnections            int

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -53,11 +53,12 @@ const (
 var log = logpkg.DefaultLogger.WithField("service", "expingest")
 
 type Config struct {
-	CoreSession       *db.Session
-	StellarCoreURL    string
-	StellarCoreCursor string
-	StellarCorePath   string
-	NetworkPassphrase string
+	CoreSession           *db.Session
+	StellarCoreURL        string
+	StellarCoreCursor     string
+	StellarCoreBinaryPath string
+	StellarCoreConfigPath string
+	NetworkPassphrase     string
 
 	HistorySession           *db.Session
 	HistoryArchiveURL        string
@@ -150,9 +151,10 @@ func NewSystem(config Config) (System, error) {
 	}
 
 	var ledgerBackend ledgerbackend.LedgerBackend
-	if len(config.StellarCorePath) > 0 {
+	if len(config.StellarCoreBinaryPath) > 0 {
 		ledgerBackend, err = ledgerbackend.NewCaptive(
-			config.StellarCorePath,
+			config.StellarCoreBinaryPath,
+			config.StellarCoreConfigPath,
 			config.NetworkPassphrase,
 			[]string{config.HistoryArchiveURL},
 		)

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -65,7 +65,8 @@ func initExpIngester(app *App) {
 		HistoryArchiveURL:        app.config.HistoryArchiveURLs[0],
 		StellarCoreURL:           app.config.StellarCoreURL,
 		StellarCoreCursor:        app.config.CursorName,
-		StellarCorePath:          app.config.StellarCoreBinaryPath,
+		StellarCoreBinaryPath:    app.config.StellarCoreBinaryPath,
+		StellarCoreConfigPath:    app.config.StellarCoreConfigPath,
 		MaxStreamRetries:         3,
 		DisableStateVerification: app.config.IngestDisableStateVerification,
 	})


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Adds `--stellar-core-config-path` config option to allow user to provide `stellar-core.cfg` file in an online mode.

Close #2706.

### Why

In an online mode Stellar-Core connects to the Stellar network so it requires quorum sets. Previously we generated the file with SDFs validators but users should be able to select validators themselves. Also, online mode cannot use in-memory mode of Stellar-Core so database connection params need to be provided.