### PR TITLE
services/horizon/docker/verify-range: Run `reingest range` instead of `verify-range` for base

### DIFF
--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -99,15 +99,13 @@ if [ ! -z "$VERIFY_HISTORY" ]; then
 	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "DROP SCHEMA public CASCADE;"
 	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "CREATE SCHEMA public;"
 
-	# sudo -u postgres dropdb horizon
-	# sudo -u postgres createdb horizon
-
 	git checkout "$BASE_BRANCH"
 
 	/usr/local/go/bin/go build -v ./services/horizon
 
 	./horizon db migrate up
-	./horizon expingest verify-range --from $FROM --to $TO --verify-state
+	REINGEST_FROM=$((FROM + 1)) # verify-range does not ingest starting ledger
+	./horizon db reingest range $REINGEST_FROM $TO
 
 	dump_horizon_db "legacy_history"
 	echo "Done dump_horizon_db legacy_history"


### PR DESCRIPTION
Use `horizon db reingest range` command when reingesting history using base Horizon version instead of `verify-range`. It is much faster.