### PR TITLE
services/horizon: Move path finding end-points to new actions.

### DIFF
--- a/services/horizon/internal/actions/path.go
+++ b/services/horizon/internal/actions/path.go
@@ -109,6 +109,10 @@ var SourceAssetsOrSourceAccountProblem = problem.P{
 		"Both fields cannot be present.",
 }
 
+func (handler FindPathsHandler) BuildPage(r *http.Request, records []hal.Pageable) (interface{}, error) {
+	return buildBasePageFromRecords(records), nil
+}
+
 // GetResourcePage finds a list of strict receive paths
 func (handler FindPathsHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
 	var err error
@@ -270,6 +274,10 @@ func (q FindFixedPathsQuery) SourceAsset() xdr.Asset {
 	return asset
 }
 
+func (handler FindFixedPathsHandler) BuildPage(r *http.Request, records []hal.Pageable) (interface{}, error) {
+	return buildBasePageFromRecords(records), nil
+}
+
 // GetResourcePage returns a list of strict send paths
 func (handler FindFixedPathsHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
 	var err error
@@ -333,4 +341,13 @@ func assetsForAddress(r *http.Request, addy string) ([]xdr.Asset, []xdr.Int64, e
 		return nil, nil, err
 	}
 	return historyQ.AssetsForAddress(addy)
+}
+
+func buildBasePageFromRecords(records []hal.Pageable) hal.BasePage {
+	var page hal.BasePage
+	page.Init()
+	for _, record := range records {
+		page.Add(record)
+	}
+	return page
 }

--- a/services/horizon/internal/actions/path.go
+++ b/services/horizon/internal/actions/path.go
@@ -22,7 +22,6 @@ import (
 type FindPathsHandler struct {
 	StaleThreshold       uint
 	MaxPathLength        uint
-	CheckHistoryIsStale  bool
 	SetLastLedgerHeader  bool
 	MaxAssetsParamLength int
 	PathFinder           paths.Finder

--- a/services/horizon/internal/actions/trade.go
+++ b/services/horizon/internal/actions/trade.go
@@ -362,7 +362,7 @@ func (handler GetTradeAggregationsHandler) fetchRecords(historyQ *history.Q, qp 
 }
 
 // BuildPage builds a custom hal page for this handler
-func (handler GetTradeAggregationsHandler) BuildPage(r *http.Request, records []hal.Pageable) (hal.Page, error) {
+func (handler GetTradeAggregationsHandler) BuildPage(r *http.Request, records []hal.Pageable) (interface{}, error) {
 	ctx := r.Context()
 	pageQuery, err := GetPageQuery(r, DisableCursorValidation)
 	if err != nil {

--- a/services/horizon/internal/actions_path_test.go
+++ b/services/horizon/internal/actions_path_test.go
@@ -32,13 +32,13 @@ func mockPathFindingClient(
 	session *db.Session,
 ) test.RequestHelper {
 	router := chi.NewRouter()
-	findPaths := basePageHandler(actions.FindPathsHandler{
+	findPaths := restCustomBuiltPageHandler(actions.FindPathsHandler{
 		PathFinder:           finder,
 		MaxAssetsParamLength: maxAssetsParamLength,
 		MaxPathLength:        3,
 		SetLastLedgerHeader:  true,
 	})
-	findFixedPaths := basePageHandler(actions.FindFixedPathsHandler{
+	findFixedPaths := restCustomBuiltPageHandler(actions.FindFixedPathsHandler{
 		PathFinder:           finder,
 		MaxAssetsParamLength: maxAssetsParamLength,
 		MaxPathLength:        3,

--- a/services/horizon/internal/actions_root.go
+++ b/services/horizon/internal/actions_root.go
@@ -23,8 +23,8 @@ func (action *RootAction) JSON() error {
 	templates := map[string]string{
 		"accounts":           actions.AccountsQuery{}.URITemplate(),
 		"offers":             actions.OffersQuery{}.URITemplate(),
-		"strictReceivePaths": StrictReceivePathsQuery{}.URITemplate(),
-		"strictSendPaths":    FindFixedPathsQuery{}.URITemplate(),
+		"strictReceivePaths": actions.StrictReceivePathsQuery{}.URITemplate(),
+		"strictSendPaths":    actions.FindFixedPathsQuery{}.URITemplate(),
 	}
 	coreInfo := action.App.coreSettings.get()
 	resourceadapter.PopulateRoot(

--- a/services/horizon/internal/httpt_test.go
+++ b/services/horizon/internal/httpt_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 type HTTPT struct {
-	Assert     *Assertions
+	Assert     *test.Assertions
 	App        *App
 	RH         test.RequestHelper
 	coreServer *test.StaticMockServer
@@ -26,7 +26,7 @@ func startHTTPTest(t *testing.T, scenario string) *HTTPT {
 	}
 	ret.App = NewTestApp()
 	ret.RH = test.NewRequestHelper(ret.App.web.router)
-	ret.Assert = &Assertions{ret.T.Assert}
+	ret.Assert = &test.Assertions{ret.T.Assert}
 
 	ret.coreServer = test.NewStaticMockServer(`{
 		"info": {

--- a/services/horizon/internal/test/assertion.go
+++ b/services/horizon/internal/test/assertion.go
@@ -1,4 +1,4 @@
-package horizon
+package test
 
 import (
 	"bytes"
@@ -13,6 +13,7 @@ import (
 
 // Assertions provides an assertions helper.  Custom assertions for this package
 // can be defined as methods on this struct.
+// foo
 type Assertions struct {
 	*assert.Assertions
 }

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -178,7 +178,6 @@ func (w *web) mustInstallActions(config Config, pathFinder paths.Finder, session
 
 		findPaths := actions.FindPathsHandler{
 			StaleThreshold:       config.StaleThreshold,
-			CheckHistoryIsStale:  false,
 			SetLastLedgerHeader:  true,
 			MaxPathLength:        config.MaxPathLength,
 			MaxAssetsParamLength: maxAssetsForPathFinding,

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -176,19 +176,19 @@ func (w *web) mustInstallActions(config Config, pathFinder paths.Finder, session
 
 		r.Method(http.MethodGet, "/assets", restPageHandler(actions.AssetStatsHandler{}))
 
-		findPaths := actions.FindPathsHandler{
+		findPaths := basePageHandler(actions.FindPathsHandler{
 			StaleThreshold:       config.StaleThreshold,
 			SetLastLedgerHeader:  true,
 			MaxPathLength:        config.MaxPathLength,
 			MaxAssetsParamLength: maxAssetsForPathFinding,
 			PathFinder:           pathFinder,
-		}
-		findFixedPaths := actions.FindFixedPathsHandler{
+		})
+		findFixedPaths := basePageHandler(actions.FindFixedPathsHandler{
 			MaxPathLength:        config.MaxPathLength,
 			SetLastLedgerHeader:  true,
 			MaxAssetsParamLength: maxAssetsForPathFinding,
 			PathFinder:           pathFinder,
-		}
+		})
 
 		r.Method(http.MethodGet, "/paths", findPaths)
 		r.Method(http.MethodGet, "/paths/strict-receive", findPaths)

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -176,19 +176,19 @@ func (w *web) mustInstallActions(config Config, pathFinder paths.Finder, session
 
 		r.Method(http.MethodGet, "/assets", restPageHandler(actions.AssetStatsHandler{}))
 
-		findPaths := FindPathsHandler{
-			staleThreshold:       config.StaleThreshold,
-			checkHistoryIsStale:  false,
-			setLastLedgerHeader:  true,
-			maxPathLength:        config.MaxPathLength,
-			maxAssetsParamLength: maxAssetsForPathFinding,
-			pathFinder:           pathFinder,
+		findPaths := actions.FindPathsHandler{
+			StaleThreshold:       config.StaleThreshold,
+			CheckHistoryIsStale:  false,
+			SetLastLedgerHeader:  true,
+			MaxPathLength:        config.MaxPathLength,
+			MaxAssetsParamLength: maxAssetsForPathFinding,
+			PathFinder:           pathFinder,
 		}
-		findFixedPaths := FindFixedPathsHandler{
-			maxPathLength:        config.MaxPathLength,
-			setLastLedgerHeader:  true,
-			maxAssetsParamLength: maxAssetsForPathFinding,
-			pathFinder:           pathFinder,
+		findFixedPaths := actions.FindFixedPathsHandler{
+			MaxPathLength:        config.MaxPathLength,
+			SetLastLedgerHeader:  true,
+			MaxAssetsParamLength: maxAssetsForPathFinding,
+			PathFinder:           pathFinder,
 		}
 
 		r.Method(http.MethodGet, "/paths", findPaths)

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -176,14 +176,14 @@ func (w *web) mustInstallActions(config Config, pathFinder paths.Finder, session
 
 		r.Method(http.MethodGet, "/assets", restPageHandler(actions.AssetStatsHandler{}))
 
-		findPaths := basePageHandler(actions.FindPathsHandler{
+		findPaths := restCustomBuiltPageHandler(actions.FindPathsHandler{
 			StaleThreshold:       config.StaleThreshold,
 			SetLastLedgerHeader:  true,
 			MaxPathLength:        config.MaxPathLength,
 			MaxAssetsParamLength: maxAssetsForPathFinding,
 			PathFinder:           pathFinder,
 		})
-		findFixedPaths := basePageHandler(actions.FindFixedPathsHandler{
+		findFixedPaths := restCustomBuiltPageHandler(actions.FindFixedPathsHandler{
 			MaxPathLength:        config.MaxPathLength,
 			SetLastLedgerHeader:  true,
 			MaxAssetsParamLength: maxAssetsForPathFinding,

--- a/support/render/hal/paging_token.go
+++ b/support/render/hal/paging_token.go
@@ -1,6 +1,6 @@
 package hal
 
-// Pageable impementors can be added to hal.Page collections
+// Pageable implementors can be added to hal.Page collections
 type Pageable interface {
 	PagingToken() string
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Move path finding handler to /actions and move assertions helper to a share package.

### Why

This is part of https://github.com/stellar/go/issues/2582.

For this handler we need to use `ServerHTTP` since they don't follow the same page building pattern we use for other end-points. Maybe we could wrap it around `restPageHandler` but we'll need to land this first https://github.com/stellar/go/pull/2826/files?file-filters%5B%5D=#diff-b8d16027eadf970091bce20ac2f34450R418 which allow us to specify a page builder. 




### Known limitations


