### PR TITLE
services/horizon: Get rid of App context and middleware

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -10,11 +10,13 @@ import (
 	"sync"
 	"time"
 
-	metrics "github.com/rcrowley/go-metrics"
+	"github.com/rcrowley/go-metrics"
+	"github.com/stellar/throttled"
+	"gopkg.in/tylerb/graceful.v1"
+
 	"github.com/stellar/go/clients/stellarcore"
 	proto "github.com/stellar/go/protocols/stellarcore"
 	"github.com/stellar/go/services/horizon/internal/actions"
-	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/expingest"
 	"github.com/stellar/go/services/horizon/internal/ledger"
@@ -27,8 +29,6 @@ import (
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
-	"github.com/stellar/throttled"
-	graceful "gopkg.in/tylerb/graceful.v1"
 )
 
 type coreSettingsStore struct {
@@ -528,23 +528,7 @@ func (a *App) run() {
 	}
 }
 
-// withAppContext create a context on from the App type.
-func withAppContext(ctx context.Context, a *App) context.Context {
-	return context.WithValue(ctx, &horizonContext.AppContextKey, a)
-}
-
 // GetRateLimiter returns the HTTPRateLimiter of the App.
 func (a *App) GetRateLimiter() *throttled.HTTPRateLimiter {
 	return a.web.rateLimiter
-}
-
-// AppFromContext returns the set app, if one has been set, from the
-// provided context returns nil if no app has been set.
-func AppFromContext(ctx context.Context) *App {
-	if ctx == nil {
-		return nil
-	}
-
-	val, _ := ctx.Value(&horizonContext.AppContextKey).(*App)
-	return val
 }

--- a/services/horizon/internal/context/context_key.go
+++ b/services/horizon/internal/context/context_key.go
@@ -2,6 +2,5 @@ package context
 
 type CtxKey string
 
-var AppContextKey = CtxKey("app")
 var RequestContextKey = CtxKey("request")
 var SessionContextKey = CtxKey("session")

--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -26,17 +26,6 @@ import (
 	"github.com/stellar/go/support/render/problem"
 )
 
-// appContextMiddleware adds the "app" context into every request, so that subsequence appContextMiddleware
-// or handlers can retrieve a horizon.App instance
-func appContextMiddleware(app *App) func(http.Handler) http.Handler {
-	return func(h http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx := withAppContext(r.Context(), app)
-			h.ServeHTTP(w, r.WithContext(ctx))
-		})
-	}
-}
-
 // requestCacheHeadersMiddleware adds caching headers to each response.
 func requestCacheHeadersMiddleware(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -225,21 +214,20 @@ func recoverMiddleware(h http.Handler) http.Handler {
 }
 
 // requestMetricsMiddleware records success and failures using a meter, and times every request
-func requestMetricsMiddleware(h http.Handler) http.Handler {
+func requestMetricsMiddleware(h http.Handler, web *web) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		app := AppFromContext(r.Context())
 		mw := newWrapResponseWriter(w, r)
 
-		app.web.requestTimer.Time(func() {
+		web.requestTimer.Time(func() {
 			h.ServeHTTP(mw.(http.ResponseWriter), r)
 		})
 
 		if 200 <= mw.Status() && mw.Status() < 400 {
 			// a success is in [200, 400)
-			app.web.successMeter.Mark(1)
+			web.successMeter.Mark(1)
 		} else if 400 <= mw.Status() && mw.Status() < 600 {
 			// a success is in [400, 600)
-			app.web.failureMeter.Mark(1)
+			web.failureMeter.Mark(1)
 		}
 	})
 }

--- a/services/horizon/internal/middleware.go
+++ b/services/horizon/internal/middleware.go
@@ -214,22 +214,24 @@ func recoverMiddleware(h http.Handler) http.Handler {
 }
 
 // requestMetricsMiddleware records success and failures using a meter, and times every request
-func requestMetricsMiddleware(h http.Handler, web *web) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		mw := newWrapResponseWriter(w, r)
+func requestMetricsMiddleware(web *web) func(http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mw := newWrapResponseWriter(w, r)
 
-		web.requestTimer.Time(func() {
-			h.ServeHTTP(mw.(http.ResponseWriter), r)
+			web.requestTimer.Time(func() {
+				h.ServeHTTP(mw.(http.ResponseWriter), r)
+			})
+
+			if 200 <= mw.Status() && mw.Status() < 400 {
+				// a success is in [200, 400)
+				web.successMeter.Mark(1)
+			} else if 400 <= mw.Status() && mw.Status() < 600 {
+				// a success is in [400, 600)
+				web.failureMeter.Mark(1)
+			}
 		})
-
-		if 200 <= mw.Status() && mw.Status() < 400 {
-			// a success is in [200, 400)
-			web.successMeter.Mark(1)
-		} else if 400 <= mw.Status() && mw.Status() < 600 {
-			// a success is in [400, 600)
-			web.failureMeter.Mark(1)
-		}
-	})
+	}
 }
 
 // NewHistoryMiddleware adds session to the request context and ensures Horizon

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -122,16 +122,14 @@ func (w *web) mustInstallMiddlewares(app *App, connTimeout time.Duration) {
 	r := w.router
 	r.Use(chimiddleware.StripSlashes)
 
-	//TODO: remove this middleware
-	r.Use(appContextMiddleware(app))
-
 	r.Use(requestCacheHeadersMiddleware)
 	r.Use(chimiddleware.RequestID)
 	r.Use(contextMiddleware)
 	r.Use(xff.Handler)
 	r.Use(loggerMiddleware)
 	r.Use(timeoutMiddleware(connTimeout))
-	r.Use(requestMetricsMiddleware)
+	metricsMiddleware := func(next http.Handler) http.Handler { return requestMetricsMiddleware(next, w) }
+	r.Use(metricsMiddleware)
 	r.Use(recoverMiddleware)
 	r.Use(chimiddleware.Compress(flate.DefaultCompression, "application/hal+json"))
 
@@ -146,7 +144,6 @@ func (w *web) mustInstallMiddlewares(app *App, connTimeout time.Duration) {
 
 	// Internal middlewares
 	w.internalRouter.Use(chimiddleware.StripSlashes)
-	w.internalRouter.Use(appContextMiddleware(app))
 	w.internalRouter.Use(chimiddleware.RequestID)
 	w.internalRouter.Use(loggerMiddleware)
 }

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -128,8 +128,7 @@ func (w *web) mustInstallMiddlewares(app *App, connTimeout time.Duration) {
 	r.Use(xff.Handler)
 	r.Use(loggerMiddleware)
 	r.Use(timeoutMiddleware(connTimeout))
-	metricsMiddleware := func(next http.Handler) http.Handler { return requestMetricsMiddleware(next, w) }
-	r.Use(metricsMiddleware)
+	r.Use(requestMetricsMiddleware(w))
 	r.Use(recoverMiddleware)
 	r.Use(chimiddleware.Compress(flate.DefaultCompression, "application/hal+json"))
 


### PR DESCRIPTION
It is not needed. It removes a context variable (which is implicit and ugly)
and reduces the dependecnies between App and http/web handling (which I plan to split into
a separate package but right now has a cyclic dependency due App).

I will help wrap up #2582 