### PR TITLE
services/horizon: Get rid of custom page builder abstraction

### DIFF
--- a/services/horizon/internal/actions/path.go
+++ b/services/horizon/internal/actions/path.go
@@ -109,12 +109,8 @@ var SourceAssetsOrSourceAccountProblem = problem.P{
 		"Both fields cannot be present.",
 }
 
-func (handler FindPathsHandler) BuildPage(r *http.Request, records []hal.Pageable) (interface{}, error) {
-	return buildBasePageFromRecords(records), nil
-}
-
-// GetResourcePage finds a list of strict receive paths
-func (handler FindPathsHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
+// GetResource finds a list of strict receive paths
+func (handler FindPathsHandler) GetResource(w HeaderWriter, r *http.Request) (interface{}, error) {
 	var err error
 	ctx := r.Context()
 	qp := StrictReceivePathsQuery{}
@@ -171,16 +167,17 @@ func (handler FindPathsHandler) GetResourcePage(w HeaderWriter, r *http.Request)
 	return renderPaths(ctx, records)
 }
 
-func renderPaths(ctx context.Context, records []paths.Path) ([]hal.Pageable, error) {
-	var response []hal.Pageable
+func renderPaths(ctx context.Context, records []paths.Path) (hal.BasePage, error) {
+	var page hal.BasePage
+	page.Init()
 	for _, p := range records {
 		var res horizon.Path
 		if err := resourceadapter.PopulatePath(ctx, &res, p); err != nil {
-			return nil, err
+			return hal.BasePage{}, err
 		}
-		response = append(response, res)
+		page.Add(res)
 	}
-	return response, nil
+	return page, nil
 }
 
 // FindFixedPathsHandler is the http handler for the find fixed payment paths endpoint
@@ -274,12 +271,8 @@ func (q FindFixedPathsQuery) SourceAsset() xdr.Asset {
 	return asset
 }
 
-func (handler FindFixedPathsHandler) BuildPage(r *http.Request, records []hal.Pageable) (interface{}, error) {
-	return buildBasePageFromRecords(records), nil
-}
-
-// GetResourcePage returns a list of strict send paths
-func (handler FindFixedPathsHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
+// GetResource returns a list of strict send paths
+func (handler FindFixedPathsHandler) GetResource(w HeaderWriter, r *http.Request) (interface{}, error) {
 	var err error
 	ctx := r.Context()
 	qp := FindFixedPathsQuery{}
@@ -341,13 +334,4 @@ func assetsForAddress(r *http.Request, addy string) ([]xdr.Asset, []xdr.Int64, e
 		return nil, nil, err
 	}
 	return historyQ.AssetsForAddress(addy)
-}
-
-func buildBasePageFromRecords(records []hal.Pageable) hal.BasePage {
-	var page hal.BasePage
-	page.Init()
-	for _, record := range records {
-		page.Add(record)
-	}
-	return page
 }

--- a/services/horizon/internal/actions_path_test.go
+++ b/services/horizon/internal/actions_path_test.go
@@ -32,18 +32,18 @@ func mockPathFindingClient(
 	session *db.Session,
 ) test.RequestHelper {
 	router := chi.NewRouter()
-	findPaths := restCustomBuiltPageHandler(actions.FindPathsHandler{
+	findPaths := objectActionHandler{actions.FindPathsHandler{
 		PathFinder:           finder,
 		MaxAssetsParamLength: maxAssetsParamLength,
 		MaxPathLength:        3,
 		SetLastLedgerHeader:  true,
-	})
-	findFixedPaths := restCustomBuiltPageHandler(actions.FindFixedPathsHandler{
+	}}
+	findFixedPaths := objectActionHandler{actions.FindFixedPathsHandler{
 		PathFinder:           finder,
 		MaxAssetsParamLength: maxAssetsParamLength,
 		MaxPathLength:        3,
 		SetLastLedgerHeader:  true,
-	})
+	}}
 
 	router.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -212,19 +212,19 @@ func (w *web) mustInstallActions(config Config,
 
 		r.Method(http.MethodGet, "/assets", restPageHandler(actions.AssetStatsHandler{}))
 
-		findPaths := restCustomBuiltPageHandler(actions.FindPathsHandler{
+		findPaths := objectActionHandler{actions.FindPathsHandler{
 			StaleThreshold:       config.StaleThreshold,
 			SetLastLedgerHeader:  true,
 			MaxPathLength:        config.MaxPathLength,
 			MaxAssetsParamLength: maxAssetsForPathFinding,
 			PathFinder:           pathFinder,
-		})
-		findFixedPaths := restCustomBuiltPageHandler(actions.FindFixedPathsHandler{
+		}}
+		findFixedPaths := objectActionHandler{actions.FindFixedPathsHandler{
 			MaxPathLength:        config.MaxPathLength,
 			SetLastLedgerHeader:  true,
 			MaxAssetsParamLength: maxAssetsForPathFinding,
 			PathFinder:           pathFinder,
-		})
+		}}
 
 		r.Method(http.MethodGet, "/paths", findPaths)
 		r.Method(http.MethodGet, "/paths/strict-receive", findPaths)
@@ -312,7 +312,7 @@ func (w *web) mustInstallActions(config Config,
 
 		// trading related endpoints
 		r.Method(http.MethodGet, "/trades", streamableHistoryPageHandler(actions.GetTradesHandler{}, streamHandler))
-		r.Method(http.MethodGet, "/trade_aggregations", restCustomBuiltPageHandler(actions.GetTradeAggregationsHandler{}))
+		r.Method(http.MethodGet, "/trade_aggregations", objectActionHandler{actions.GetTradeAggregationsHandler{}})
 		// /offers/{offer_id} has been created above so we need to use absolute
 		// routes here.
 		r.Method(http.MethodGet, "/offers/{offer_id}/trades", streamableHistoryPageHandler(actions.GetTradesHandler{}, streamHandler))


### PR DESCRIPTION
It just complicated things. If we are we are using a custom-rendered _thing_ we just return it as an object and
use `objectActionHandler`.

Leftover from #2582 