### PR TITLE
services/horizon: Get rid of unused App parameter

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -490,7 +490,7 @@ func (a *App) init() {
 	// web.middleware
 	// Note that we passed in `a` here for putting the whole App in the context.
 	// This parameter will be removed soon.
-	a.web.mustInstallMiddlewares(a, a.config.ConnectionTimeout)
+	a.web.mustInstallMiddlewares(a.config.ConnectionTimeout)
 
 	// metrics and log.metrics
 	a.metrics = metrics.NewRegistry()

--- a/services/horizon/internal/web.go
+++ b/services/horizon/internal/web.go
@@ -114,7 +114,7 @@ func (w *web) getAccountInfo(ctx context.Context, qp *showActionQueryParams) (in
 // mustInstallMiddlewares installs the middleware stack used for horizon onto the
 // provided app.
 // Note that a request will go through the middlewares from top to bottom.
-func (w *web) mustInstallMiddlewares(app *App, connTimeout time.Duration) {
+func (w *web) mustInstallMiddlewares(connTimeout time.Duration) {
 	if w == nil {
 		log.Fatal("missing web instance for installing middlewares")
 	}


### PR DESCRIPTION
Leftover of #2848