### PR TITLE
Fix panic on system creation failure from db command

### DIFF
--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -232,7 +232,7 @@ var dbReingestRangeCmd = &cobra.Command{
 
 		if parallelWorkers < 2 {
 			system, systemErr := expingest.NewSystem(ingestConfig)
-			if err != nil {
+			if systemErr != nil {
 				log.Fatal(systemErr)
 			}
 
@@ -243,7 +243,7 @@ var dbReingestRangeCmd = &cobra.Command{
 			)
 		} else {
 			system, systemErr := expingest.NewParallelSystems(ingestConfig, parallelWorkers)
-			if err != nil {
+			if systemErr != nil {
 				log.Fatal(systemErr)
 			}
 


### PR DESCRIPTION
Fixes #2867 

I introduced the unfortunate typo was introduced on #2724 , prompted by the `shadow` vet tool: https://github.com/stellar/go/pull/2724/files#diff-dd30f3045790051170cd58e06c2667b6L185-R250

`shadow` is right in many cases but in this case it would had been fine, I wonder if we can tune the tool to avoid situations like this.