### PR TITLE
exp/ingest: Add package godoc and examples

### DIFF
--- a/exp/ingest/doc.go
+++ b/exp/ingest/doc.go
@@ -1,0 +1,56 @@
+/*
+
+Package ingest provides primitives for building custom ingestion engines.
+
+Very often developers need features that are outside of scope of the Horizon: API
+server for building apps on Stellar network. While it provides APIs for building
+the  most common apps, it's not possible to add all possible features. This is
+why this package was created.
+
+Ledger Backend
+
+Ledger backends are sources of information about Stellar network ledgers. This
+can be either Stellar-Core DB (deprecated), Captive Stellar-Core or History
+Archives. Please consult the ledgerbackend package docs for more information
+about each backend.
+
+Warning: Please note that provide low-level xdr.LedgerCloseMeta that should not
+be used directly unless developer really understand this data structure. Read on
+to understand how to use ledger backend in higher level objects.
+
+Readers
+
+Readers are objects that wrap ledger backend and provide higher level, developer
+friendly APIs for reading ledger data.
+
+Currently there are three types of readers (all in ingest/io package):
+  * SingleLedgerStateReader reads ledger entries from history buckets for a
+    given checkpoint ledger. Allow building state (all accounts, trust lines
+    etc.) at any checkpoint ledger.
+  * LedgerTransactionReader reads transactions for a given ledger sequence.
+  * LedgerChangeReader reads all changes to ledger entries created as a result
+    of transactions (fees and meta) and protocol upgrades in a given ledger.
+
+Warning: Please note that readers stream both successful and failed transactions.
+Please check transactions status in your application (if required).
+
+Processors
+
+Processors allow building pipelines for ledger processing. This allows better
+separation of concerns in ingestion engines: some processors can be responsible
+for trading operations, other for payments, etc. This also allows easier
+configurations of pipelines. Some features can be turned off by simply disabling
+a single processor.
+
+There are two types of processors (ingest/io package):
+  * ChangeProcessor responsible for processing changes to ledger entries
+    (io.Change).
+  * TransactionProcessor reponsible for processing transactions
+    (io.LedgerTransaction).
+
+For an object to be a processor, it needs to implement a single method:
+ProcessChange or ProcessTransaction. This is a very simple yet powerful interface
+that allows building any kind of features.
+
+*/
+package ingest

--- a/exp/ingest/doc_test.go
+++ b/exp/ingest/doc_test.go
@@ -1,0 +1,165 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/exp/ingest/ledgerbackend"
+	"github.com/stellar/go/historyarchive"
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/xdr"
+)
+
+// Example_ledgerentrieshistoryarchive is explaining how to stream all ledger
+// entries live at specific checkpoint ledger from history archives.
+func Example_ledgerentrieshistoryarchive() {
+	archiveURL := "http://history.stellar.org/prd/core-live/core_live_001"
+
+	archive, err := historyarchive.Connect(
+		archiveURL,
+		historyarchive.ConnectOptions{Context: context.TODO()},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	// Ledger must be a checkpoint ledger: (100031+1) mod 64 == 0.
+	reader, err := io.MakeSingleLedgerStateReader(context.TODO(), archive, 100031)
+	if err != nil {
+		panic(err)
+	}
+
+	var accounts, data, trustlines, offers int
+	for {
+		entry, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			panic(err)
+		}
+
+		switch entry.Type {
+		case xdr.LedgerEntryTypeAccount:
+			accounts++
+		case xdr.LedgerEntryTypeData:
+			data++
+		case xdr.LedgerEntryTypeTrustline:
+			trustlines++
+		case xdr.LedgerEntryTypeOffer:
+			offers++
+		default:
+			panic("Unknown type")
+		}
+	}
+
+	fmt.Println("accounts", accounts)
+	fmt.Println("data", data)
+	fmt.Println("trustlines", trustlines)
+	fmt.Println("offers", offers)
+}
+
+// Example_transactionshistoryarchive is explaining how to stream transactions
+// for a specific ledger from history archives. Please note that transaction
+// meta IS NOT available in history archives.
+func Example_transactionshistoryarchive() {
+	archiveURL := "http://history.stellar.org/prd/core-live/core_live_001"
+	networkPassphrase := network.PublicNetworkPassphrase
+
+	archive, err := historyarchive.Connect(
+		archiveURL,
+		historyarchive.ConnectOptions{Context: context.TODO()},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	backend := ledgerbackend.NewHistoryArchiveBackendFromArchive(archive)
+	txReader, err := io.NewLedgerTransactionReader(backend, networkPassphrase, 30000000)
+	if err != nil {
+		panic(err)
+	}
+
+	for {
+		tx, err := txReader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Printf("%d: %x (%d ops)\n", tx.Index, tx.Result.TransactionHash, len(tx.Envelope.Operations()))
+	}
+}
+
+// Example_changes is explaining how to stream ledger entry changes
+// for a specific ledger using captive stellar-core. Please note that transaction
+// meta IS available when using this backend.
+func Example_changes() {
+	archiveURL := "http://history.stellar.org/prd/core-live/core_live_001"
+	networkPassphrase := network.PublicNetworkPassphrase
+
+	// Requires Stellar-Core 13.2.0+
+	backend, err := ledgerbackend.NewCaptive(
+		"/bin/stellar-core",
+		"/opt/stellar-core.cfg",
+		networkPassphrase,
+		[]string{archiveURL},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	sequence := uint32(3)
+
+	err = backend.PrepareRange(ledgerbackend.SingleLedgerRange(sequence))
+	if err != nil {
+		panic(err)
+	}
+
+	changeReader, err := io.NewLedgerChangeReader(backend, networkPassphrase, sequence)
+	if err != nil {
+		panic(err)
+	}
+
+	for {
+		change, err := changeReader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			panic(err)
+		}
+
+		var action string
+		switch {
+		case change.Pre == nil && change.Post != nil:
+			action = "created"
+		case change.Pre != nil && change.Post != nil:
+			action = "updated"
+		case change.Pre != nil && change.Post == nil:
+			action = "removed"
+		}
+
+		switch change.Type {
+		case xdr.LedgerEntryTypeAccount:
+			var accountEntry xdr.AccountEntry
+			if change.Pre != nil {
+				accountEntry = change.Pre.Data.MustAccount()
+			} else {
+				accountEntry = change.Post.Data.MustAccount()
+			}
+			fmt.Println("account", accountEntry.AccountId.Address(), action)
+		case xdr.LedgerEntryTypeData:
+			fmt.Println("data", action)
+		case xdr.LedgerEntryTypeTrustline:
+			fmt.Println("trustline", action)
+		case xdr.LedgerEntryTypeOffer:
+			fmt.Println("offer", action)
+		default:
+			panic("Unknown type")
+		}
+	}
+}

--- a/exp/ingest/io/main.go
+++ b/exp/ingest/io/main.go
@@ -1,0 +1,8 @@
+package io
+
+import (
+	stdio "io"
+)
+
+// EOF represents end of stream and equals standard io.EOF.
+var EOF = stdio.EOF

--- a/exp/ingest/ledgerbackend/ledger_backend.go
+++ b/exp/ingest/ledgerbackend/ledger_backend.go
@@ -13,6 +13,11 @@ type Range struct {
 	bounded bool
 }
 
+// SingleLedgerRange constructs a bounded range containing a single ledger.
+func SingleLedgerRange(ledger uint32) Range {
+	return Range{from: ledger, to: ledger, bounded: true}
+}
+
 // BoundedRange constructs a bounded range of ledgers with a fixed starting ledger and ending ledger.
 func BoundedRange(from uint32, to uint32) Range {
 	return Range{from: from, to: to, bounded: true}

--- a/exp/ingest/main.go
+++ b/exp/ingest/main.go
@@ -1,1 +1,0 @@
-package ingest


### PR DESCRIPTION
* Add simple summary of `ingest` package features.
* Add usage examples.
* Add `ingest/io.EOF` equal to `io.EOF` so users don't need to include standard `io` package just for `EOF` variable.
* Add `ledgerbackend.SingleLedgerRange` in case user wants to prepare a single ledger range.