### PR TITLE
services/horizon: Add Golang version to horizon version output

### DIFF
--- a/services/horizon/cmd/version.go
+++ b/services/horizon/cmd/version.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/spf13/cobra"
 	apkg "github.com/stellar/go/support/app"
@@ -9,10 +10,11 @@ import (
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "print horizon version",
+	Short: "print horizon and Golang runtime version",
 	Long:  "",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(apkg.Version())
+		fmt.Println(runtime.Version())
 	},
 }
 


### PR DESCRIPTION
Adds Golang runtime version to `horizon version` output. Will be helpful to debug potential issues in the future.