### PR TITLE
services/horizon: Refactor IngestionQ methods to use xdr.LedgerEntry

### DIFF
--- a/services/horizon/internal/actions/account_test.go
+++ b/services/horizon/internal/actions/account_test.go
@@ -24,107 +24,149 @@ var (
 	usd             = xdr.MustNewCreditAsset("USD", trustLineIssuer)
 	euro            = xdr.MustNewCreditAsset("EUR", trustLineIssuer)
 
-	account1 = xdr.AccountEntry{
-		AccountId:     xdr.MustAddress(accountOne),
-		Balance:       20000,
-		SeqNum:        223456789,
-		NumSubEntries: 10,
-		Flags:         1,
-		HomeDomain:    "stellar.org",
-		Thresholds:    xdr.Thresholds{1, 2, 3, 4},
-		Ext: xdr.AccountEntryExt{
-			V: 1,
-			V1: &xdr.AccountEntryExtensionV1{
-				Liabilities: xdr.Liabilities{
-					Buying:  3,
-					Selling: 4,
+	account1 = xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1234,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId:     xdr.MustAddress(accountOne),
+				Balance:       20000,
+				SeqNum:        223456789,
+				NumSubEntries: 10,
+				Flags:         1,
+				HomeDomain:    "stellar.org",
+				Thresholds:    xdr.Thresholds{1, 2, 3, 4},
+				Ext: xdr.AccountEntryExt{
+					V: 1,
+					V1: &xdr.AccountEntryExtensionV1{
+						Liabilities: xdr.Liabilities{
+							Buying:  3,
+							Selling: 4,
+						},
+					},
 				},
 			},
 		},
 	}
 
-	account2 = xdr.AccountEntry{
-		AccountId:     xdr.MustAddress(accountTwo),
-		Balance:       50000,
-		SeqNum:        648736,
-		NumSubEntries: 10,
-		Flags:         2,
-		HomeDomain:    "meridian.stellar.org",
-		Thresholds:    xdr.Thresholds{5, 6, 7, 8},
-		Ext: xdr.AccountEntryExt{
-			V: 1,
-			V1: &xdr.AccountEntryExtensionV1{
-				Liabilities: xdr.Liabilities{
-					Buying:  30,
-					Selling: 40,
+	account2 = xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1234,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId:     xdr.MustAddress(accountTwo),
+				Balance:       50000,
+				SeqNum:        648736,
+				NumSubEntries: 10,
+				Flags:         2,
+				HomeDomain:    "meridian.stellar.org",
+				Thresholds:    xdr.Thresholds{5, 6, 7, 8},
+				Ext: xdr.AccountEntryExt{
+					V: 1,
+					V1: &xdr.AccountEntryExtensionV1{
+						Liabilities: xdr.Liabilities{
+							Buying:  30,
+							Selling: 40,
+						},
+					},
 				},
 			},
 		},
 	}
 
-	account3 = xdr.AccountEntry{
-		AccountId:     xdr.MustAddress(signer),
-		Balance:       50000,
-		SeqNum:        648736,
-		NumSubEntries: 10,
-		Flags:         2,
-		Thresholds:    xdr.Thresholds{5, 6, 7, 8},
-		Ext: xdr.AccountEntryExt{
-			V: 1,
-			V1: &xdr.AccountEntryExtensionV1{
-				Liabilities: xdr.Liabilities{
-					Buying:  30,
-					Selling: 40,
+	account3 = xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1234,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId:     xdr.MustAddress(signer),
+				Balance:       50000,
+				SeqNum:        648736,
+				NumSubEntries: 10,
+				Flags:         2,
+				Thresholds:    xdr.Thresholds{5, 6, 7, 8},
+				Ext: xdr.AccountEntryExt{
+					V: 1,
+					V1: &xdr.AccountEntryExtensionV1{
+						Liabilities: xdr.Liabilities{
+							Buying:  30,
+							Selling: 40,
+						},
+					},
 				},
 			},
 		},
 	}
 
-	eurTrustLine = xdr.TrustLineEntry{
-		AccountId: xdr.MustAddress(accountOne),
-		Asset:     euro,
-		Balance:   20000,
-		Limit:     223456789,
-		Flags:     1,
-		Ext: xdr.TrustLineEntryExt{
-			V: 1,
-			V1: &xdr.TrustLineEntryV1{
-				Liabilities: xdr.Liabilities{
-					Buying:  3,
-					Selling: 4,
+	eurTrustLine = xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1234,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeTrustline,
+			TrustLine: &xdr.TrustLineEntry{
+				AccountId: xdr.MustAddress(accountOne),
+				Asset:     euro,
+				Balance:   20000,
+				Limit:     223456789,
+				Flags:     1,
+				Ext: xdr.TrustLineEntryExt{
+					V: 1,
+					V1: &xdr.TrustLineEntryV1{
+						Liabilities: xdr.Liabilities{
+							Buying:  3,
+							Selling: 4,
+						},
+					},
 				},
 			},
 		},
 	}
 
-	usdTrustLine = xdr.TrustLineEntry{
-		AccountId: xdr.MustAddress(accountTwo),
-		Asset:     usd,
-		Balance:   10000,
-		Limit:     123456789,
-		Flags:     0,
-		Ext: xdr.TrustLineEntryExt{
-			V: 1,
-			V1: &xdr.TrustLineEntryV1{
-				Liabilities: xdr.Liabilities{
-					Buying:  1,
-					Selling: 2,
+	usdTrustLine = xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1234,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeTrustline,
+			TrustLine: &xdr.TrustLineEntry{
+				AccountId: xdr.MustAddress(accountTwo),
+				Asset:     usd,
+				Balance:   10000,
+				Limit:     123456789,
+				Flags:     0,
+				Ext: xdr.TrustLineEntryExt{
+					V: 1,
+					V1: &xdr.TrustLineEntryV1{
+						Liabilities: xdr.Liabilities{
+							Buying:  1,
+							Selling: 2,
+						},
+					},
 				},
 			},
 		},
 	}
 
-	data1 = xdr.DataEntry{
-		AccountId: xdr.MustAddress(accountOne),
-		DataName:  "test data",
-		// This also tests if base64 encoding is working as 0 is invalid UTF-8 byte
-		DataValue: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+	data1 = xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 100,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeData,
+			Data: &xdr.DataEntry{
+				AccountId: xdr.MustAddress(accountOne),
+				DataName:  "test data",
+				// This also tests if base64 encoding is working as 0 is invalid UTF-8 byte
+				DataValue: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			},
+		},
 	}
 
-	data2 = xdr.DataEntry{
-		AccountId: xdr.MustAddress(accountTwo),
-		DataName:  "test data2",
-		DataValue: []byte{10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
+	data2 = xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 100,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeData,
+			Data: &xdr.DataEntry{
+				AccountId: xdr.MustAddress(accountTwo),
+				DataName:  "test data2",
+				DataValue: []byte{10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
+			},
+		},
 	}
 
 	accountSigners = []history.AccountSigner{
@@ -169,45 +211,63 @@ func TestAccountInfo(t *testing.T) {
 	accountID := xdr.MustAddress(
 		"GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
 	)
-	accountEntry := xdr.AccountEntry{
-		AccountId:     accountID,
-		Balance:       9999999900,
-		SeqNum:        8589934593,
-		NumSubEntries: 1,
-		InflationDest: nil,
-		HomeDomain:    "",
-		Thresholds:    thresholds,
-		Flags:         0,
+	accountEntry := xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 4,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId:     accountID,
+				Balance:       9999999900,
+				SeqNum:        8589934593,
+				NumSubEntries: 1,
+				InflationDest: nil,
+				HomeDomain:    "",
+				Thresholds:    thresholds,
+				Flags:         0,
+			},
+		},
 	}
 	batch := q.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(accountEntry, 4)
+	err := batch.Add(accountEntry)
 	assert.NoError(t, err)
 	assert.NoError(t, batch.Exec())
 
 	tt.Assert.NoError(err)
 
-	_, err = q.InsertTrustLine(xdr.TrustLineEntry{
-		AccountId: accountID,
-		Asset: xdr.MustNewCreditAsset(
-			"USD",
-			"GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4",
-		),
-		Balance: 0,
-		Limit:   9223372036854775807,
-		Flags:   1,
-	}, 6)
+	_, err = q.InsertTrustLine(xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 6,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeTrustline,
+			TrustLine: &xdr.TrustLineEntry{
+				AccountId: accountID,
+				Asset: xdr.MustNewCreditAsset(
+					"USD",
+					"GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4",
+				),
+				Balance: 0,
+				Limit:   9223372036854775807,
+				Flags:   1,
+			},
+		},
+	})
 	assert.NoError(t, err)
 
-	_, err = q.InsertTrustLine(xdr.TrustLineEntry{
-		AccountId: accountID,
-		Asset: xdr.MustNewCreditAsset(
-			"EUR",
-			"GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4",
-		),
-		Balance: 0,
-		Limit:   9223372036854775807,
-		Flags:   1,
-	}, 6)
+	_, err = q.InsertTrustLine(xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1234,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeTrustline,
+			TrustLine: &xdr.TrustLineEntry{
+				AccountId: accountID,
+				Asset: xdr.MustNewCreditAsset(
+					"EUR",
+					"GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4",
+				),
+				Balance: 0,
+				Limit:   9223372036854775807,
+				Flags:   1,
+			},
+		},
+	})
 	assert.NoError(t, err)
 
 	ledgerFourCloseTime := time.Now().Unix()
@@ -283,11 +343,11 @@ func TestGetAccountsHandlerPageResultsBySigner(t *testing.T) {
 	handler := &GetAccountsHandler{}
 
 	batch := q.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(account1, 1234)
+	err := batch.Add(account1)
 	assert.NoError(t, err)
-	err = batch.Add(account2, 1234)
+	err = batch.Add(account2)
 	assert.NoError(t, err)
-	err = batch.Add(account3, 1234)
+	err = batch.Add(account3)
 	assert.NoError(t, err)
 	assert.NoError(t, batch.Exec())
 
@@ -363,9 +423,9 @@ func TestGetAccountsHandlerPageResultsByAsset(t *testing.T) {
 	handler := &GetAccountsHandler{}
 
 	batch := q.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(account1, 1234)
+	err := batch.Add(account1)
 	assert.NoError(t, err)
-	err = batch.Add(account2, 1234)
+	err = batch.Add(account2)
 	assert.NoError(t, err)
 	assert.NoError(t, batch.Exec())
 	ledgerCloseTime := time.Now().Unix()
@@ -384,9 +444,9 @@ func TestGetAccountsHandlerPageResultsByAsset(t *testing.T) {
 		tt.Assert.NoError(err)
 	}
 
-	_, err = q.InsertAccountData(data1, 1234)
+	_, err = q.InsertAccountData(data1)
 	assert.NoError(t, err)
-	_, err = q.InsertAccountData(data2, 1234)
+	_, err = q.InsertAccountData(data2)
 	assert.NoError(t, err)
 
 	var assetType, code, issuer string
@@ -408,9 +468,9 @@ func TestGetAccountsHandlerPageResultsByAsset(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(0, len(records))
 
-	_, err = q.InsertTrustLine(eurTrustLine, 1234)
+	_, err = q.InsertTrustLine(eurTrustLine)
 	assert.NoError(t, err)
-	_, err = q.InsertTrustLine(usdTrustLine, 1235)
+	_, err = q.InsertTrustLine(usdTrustLine)
 	assert.NoError(t, err)
 
 	records, err = handler.GetResourcePage(
@@ -432,7 +492,7 @@ func TestGetAccountsHandlerPageResultsByAsset(t *testing.T) {
 	tt.Assert.Len(result.Balances, 2)
 	tt.Assert.Len(result.Signers, 2)
 
-	_, ok := result.Data[string(data2.DataName)]
+	_, ok := result.Data[string(data2.Data.Data.DataName)]
 	tt.Assert.True(ok)
 }
 

--- a/services/horizon/internal/actions/asset_test.go
+++ b/services/horizon/internal/actions/asset_test.go
@@ -212,15 +212,21 @@ func TestAssetStats(t *testing.T) {
 		issuer,
 		otherIssuer,
 	} {
-		accountEntry := xdr.AccountEntry{
-			Flags:      xdr.Uint32(account.Flags),
-			HomeDomain: xdr.String32(account.HomeDomain),
+		accountEntry := xdr.LedgerEntry{
+			LastModifiedLedgerSeq: 100,
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeAccount,
+				Account: &xdr.AccountEntry{
+					Flags:      xdr.Uint32(account.Flags),
+					HomeDomain: xdr.String32(account.HomeDomain),
+				},
+			},
 		}
-		if err := accountEntry.AccountId.SetAddress(account.AccountID); err != nil {
+		if err := accountEntry.Data.Account.AccountId.SetAddress(account.AccountID); err != nil {
 			t.Fatalf("unexpected error %v", err)
 		}
 		batch := q.NewAccountsBatchInsertBuilder(0)
-		err := batch.Add(accountEntry, 3)
+		err := batch.Add(accountEntry)
 		tt.Assert.NoError(err)
 		tt.Assert.NoError(batch.Exec())
 	}

--- a/services/horizon/internal/actions_data_test.go
+++ b/services/horizon/internal/actions_data_test.go
@@ -14,17 +14,29 @@ import (
 )
 
 var (
-	data1 = xdr.DataEntry{
-		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
-		DataName:  "name1",
-		// This also tests if base64 encoding is working as 0 is invalid UTF-8 byte
-		DataValue: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+	data1 = xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 100,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeData,
+			Data: &xdr.DataEntry{
+				AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+				DataName:  "name1",
+				// This also tests if base64 encoding is working as 0 is invalid UTF-8 byte
+				DataValue: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			},
+		},
 	}
 
-	data2 = xdr.DataEntry{
-		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
-		DataName:  "name ",
-		DataValue: []byte("it got spaces!"),
+	data2 = xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 100,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeData,
+			Data: &xdr.DataEntry{
+				AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+				DataName:  "name ",
+				DataValue: []byte("it got spaces!"),
+			},
+		},
 	}
 )
 
@@ -46,11 +58,11 @@ func TestDataActions_Show(t *testing.T) {
 	}, 0, 0, 0, 0, 0)
 	ht.Assert.NoError(err)
 
-	rows, err := q.InsertAccountData(data1, 1234)
+	rows, err := q.InsertAccountData(data1)
 	assert.NoError(t, err)
 	ht.Assert.Equal(int64(1), rows)
 
-	rows, err = q.InsertAccountData(data2, 1235)
+	rows, err = q.InsertAccountData(data2)
 	assert.NoError(t, err)
 	ht.Assert.Equal(int64(1), rows)
 
@@ -64,13 +76,13 @@ func TestDataActions_Show(t *testing.T) {
 		ht.Assert.NoError(err)
 		decoded, err := base64.StdEncoding.DecodeString(result["value"])
 		ht.Assert.NoError(err)
-		ht.Assert.Equal([]byte(data1.DataValue), decoded)
+		ht.Assert.Equal([]byte(data1.Data.Data.DataValue), decoded)
 	}
 
 	// raw
 	w = ht.Get(prefix+"/data/name1", test.RequestHelperRaw)
 	if ht.Assert.Equal(200, w.Code) {
-		ht.Assert.Equal([]byte(data1.DataValue), w.Body.Bytes())
+		ht.Assert.Equal([]byte(data1.Data.Data.DataValue), w.Body.Bytes())
 	}
 
 	// regression: https://github.com/stellar/horizon/issues/325
@@ -82,7 +94,7 @@ func TestDataActions_Show(t *testing.T) {
 
 		decoded, err := base64.StdEncoding.DecodeString(result["value"])
 		ht.Assert.NoError(err)
-		ht.Assert.Equal([]byte(data2.DataValue), decoded)
+		ht.Assert.Equal([]byte(data2.Data.Data.DataValue), decoded)
 	}
 
 	w = ht.Get(prefix+"/data/name%20", test.RequestHelperRaw)

--- a/services/horizon/internal/actions_path_test.go
+++ b/services/horizon/internal/actions_path_test.go
@@ -143,26 +143,32 @@ func TestPathActionsStrictReceive(t *testing.T) {
 
 	q := &history.Q{tt.HorizonSession()}
 
-	account := xdr.AccountEntry{
-		AccountId:     xdr.MustAddress(sourceAccount),
-		Balance:       20000,
-		SeqNum:        223456789,
-		NumSubEntries: 10,
-		Flags:         1,
-		Thresholds:    xdr.Thresholds{1, 2, 3, 4},
-		Ext: xdr.AccountEntryExt{
-			V: 1,
-			V1: &xdr.AccountEntryExtensionV1{
-				Liabilities: xdr.Liabilities{
-					Buying:  3,
-					Selling: 4,
+	account := xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1234,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId:     xdr.MustAddress(sourceAccount),
+				Balance:       20000,
+				SeqNum:        223456789,
+				NumSubEntries: 10,
+				Flags:         1,
+				Thresholds:    xdr.Thresholds{1, 2, 3, 4},
+				Ext: xdr.AccountEntryExt{
+					V: 1,
+					V1: &xdr.AccountEntryExtensionV1{
+						Liabilities: xdr.Liabilities{
+							Buying:  3,
+							Selling: 4,
+						},
+					},
 				},
 			},
 		},
 	}
 
 	batch := q.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(account, 1234)
+	err := batch.Add(account)
 	assert.NoError(t, err)
 	err = batch.Exec()
 	assert.NoError(t, err)
@@ -175,24 +181,30 @@ func TestPathActionsStrictReceive(t *testing.T) {
 		if code == "native" {
 			continue
 		}
-		trustline := xdr.TrustLineEntry{
-			AccountId: xdr.MustAddress(sourceAccount),
-			Asset:     asset,
-			Balance:   10000,
-			Limit:     123456789,
-			Flags:     0,
-			Ext: xdr.TrustLineEntryExt{
-				V: 1,
-				V1: &xdr.TrustLineEntryV1{
-					Liabilities: xdr.Liabilities{
-						Buying:  1,
-						Selling: 2,
+		trustline := xdr.LedgerEntry{
+			LastModifiedLedgerSeq: 1234,
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeTrustline,
+				TrustLine: &xdr.TrustLineEntry{
+					AccountId: xdr.MustAddress(sourceAccount),
+					Asset:     asset,
+					Balance:   10000,
+					Limit:     123456789,
+					Flags:     0,
+					Ext: xdr.TrustLineEntryExt{
+						V: 1,
+						V1: &xdr.TrustLineEntryV1{
+							Liabilities: xdr.Liabilities{
+								Buying:  1,
+								Selling: 2,
+							},
+						},
 					},
 				},
 			},
 		}
 
-		rows, err1 := q.InsertTrustLine(trustline, 1234)
+		rows, err1 := q.InsertTrustLine(trustline)
 		assert.NoError(t, err1)
 		assert.Equal(t, int64(1), rows)
 	}
@@ -489,26 +501,32 @@ func TestPathActionsStrictSend(t *testing.T) {
 		xdr.MustNewNativeAsset(),
 	}
 
-	account := xdr.AccountEntry{
-		AccountId:     xdr.MustAddress(destinationAccount),
-		Balance:       20000,
-		SeqNum:        223456789,
-		NumSubEntries: 10,
-		Flags:         1,
-		Thresholds:    xdr.Thresholds{1, 2, 3, 4},
-		Ext: xdr.AccountEntryExt{
-			V: 1,
-			V1: &xdr.AccountEntryExtensionV1{
-				Liabilities: xdr.Liabilities{
-					Buying:  3,
-					Selling: 4,
+	account := xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1234,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId:     xdr.MustAddress(destinationAccount),
+				Balance:       20000,
+				SeqNum:        223456789,
+				NumSubEntries: 10,
+				Flags:         1,
+				Thresholds:    xdr.Thresholds{1, 2, 3, 4},
+				Ext: xdr.AccountEntryExt{
+					V: 1,
+					V1: &xdr.AccountEntryExtensionV1{
+						Liabilities: xdr.Liabilities{
+							Buying:  3,
+							Selling: 4,
+						},
+					},
 				},
 			},
 		},
 	}
 
 	batch := historyQ.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(account, 1234)
+	err := batch.Add(account)
 	assert.NoError(t, err)
 	err = batch.Exec()
 	assert.NoError(t, err)
@@ -521,24 +539,30 @@ func TestPathActionsStrictSend(t *testing.T) {
 		if code == "native" {
 			continue
 		}
-		trustline := xdr.TrustLineEntry{
-			AccountId: xdr.MustAddress(destinationAccount),
-			Asset:     asset,
-			Balance:   10000,
-			Limit:     123456789,
-			Flags:     0,
-			Ext: xdr.TrustLineEntryExt{
-				V: 1,
-				V1: &xdr.TrustLineEntryV1{
-					Liabilities: xdr.Liabilities{
-						Buying:  1,
-						Selling: 2,
+		trustline := xdr.LedgerEntry{
+			LastModifiedLedgerSeq: 1234,
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeTrustline,
+				TrustLine: &xdr.TrustLineEntry{
+					AccountId: xdr.MustAddress(destinationAccount),
+					Asset:     asset,
+					Balance:   10000,
+					Limit:     123456789,
+					Flags:     0,
+					Ext: xdr.TrustLineEntryExt{
+						V: 1,
+						V1: &xdr.TrustLineEntryV1{
+							Liabilities: xdr.Liabilities{
+								Buying:  1,
+								Selling: 2,
+							},
+						},
 					},
 				},
 			},
 		}
 
-		rows, err := historyQ.InsertTrustLine(trustline, 1234)
+		rows, err := historyQ.InsertTrustLine(trustline)
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1), rows)
 	}

--- a/services/horizon/internal/db2/history/account_data_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/account_data_batch_insert_builder.go
@@ -5,9 +5,10 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-func (i *accountDataBatchInsertBuilder) Add(data xdr.DataEntry, lastModifiedLedger xdr.Uint32) error {
+func (i *accountDataBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
+	data := entry.Data.MustData()
 	// Add ledger_key only when inserting rows
-	key, err := dataEntryToLedgerKeyString(data)
+	key, err := dataEntryToLedgerKeyString(entry)
 	if err != nil {
 		return errors.Wrap(err, "Error running dataEntryToLedgerKeyString")
 	}
@@ -17,7 +18,7 @@ func (i *accountDataBatchInsertBuilder) Add(data xdr.DataEntry, lastModifiedLedg
 		"account_id":           data.AccountId.Address(),
 		"name":                 data.DataName,
 		"value":                AccountDataValue(data.DataValue),
-		"last_modified_ledger": lastModifiedLedger,
+		"last_modified_ledger": entry.LastModifiedLedgerSeq,
 	})
 }
 

--- a/services/horizon/internal/db2/history/accounts_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/accounts_batch_insert_builder.go
@@ -10,8 +10,8 @@ type accountsBatchInsertBuilder struct {
 	builder db.BatchInsertBuilder
 }
 
-func (i *accountsBatchInsertBuilder) Add(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) error {
-	return i.builder.Row(accountToMap(account, lastModifiedLedger))
+func (i *accountsBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
+	return i.builder.Row(accountToMap(entry))
 }
 
 func (i *accountsBatchInsertBuilder) Exec() error {

--- a/services/horizon/internal/db2/history/accounts_test.go
+++ b/services/horizon/internal/db2/history/accounts_test.go
@@ -12,60 +12,78 @@ import (
 var (
 	inflationDest = xdr.MustAddress("GBUH7T6U36DAVEKECMKN5YEBQYZVRBPNSZAAKBCO6P5HBMDFSQMQL4Z4")
 
-	account1 = xdr.AccountEntry{
-		AccountId:     xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
-		Balance:       20000,
-		SeqNum:        223456789,
-		NumSubEntries: 10,
-		InflationDest: &inflationDest,
-		Flags:         1,
-		HomeDomain:    "stellar.org",
-		Thresholds:    xdr.Thresholds{1, 2, 3, 4},
-		Ext: xdr.AccountEntryExt{
-			V: 1,
-			V1: &xdr.AccountEntryExtensionV1{
-				Liabilities: xdr.Liabilities{
-					Buying:  3,
-					Selling: 4,
+	account1 = xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1234,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId:     xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+				Balance:       20000,
+				SeqNum:        223456789,
+				NumSubEntries: 10,
+				InflationDest: &inflationDest,
+				Flags:         1,
+				HomeDomain:    "stellar.org",
+				Thresholds:    xdr.Thresholds{1, 2, 3, 4},
+				Ext: xdr.AccountEntryExt{
+					V: 1,
+					V1: &xdr.AccountEntryExtensionV1{
+						Liabilities: xdr.Liabilities{
+							Buying:  3,
+							Selling: 4,
+						},
+					},
 				},
 			},
 		},
 	}
 
-	account2 = xdr.AccountEntry{
-		AccountId:     xdr.MustAddress("GCT2NQM5KJJEF55NPMY444C6M6CA7T33HRNCMA6ZFBIIXKNCRO6J25K7"),
-		Balance:       50000,
-		SeqNum:        648736,
-		NumSubEntries: 10,
-		InflationDest: &inflationDest,
-		Flags:         2,
-		HomeDomain:    "meridian.stellar.org",
-		Thresholds:    xdr.Thresholds{5, 6, 7, 8},
-		Ext: xdr.AccountEntryExt{
-			V: 1,
-			V1: &xdr.AccountEntryExtensionV1{
-				Liabilities: xdr.Liabilities{
-					Buying:  30,
-					Selling: 40,
+	account2 = xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1235,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId:     xdr.MustAddress("GCT2NQM5KJJEF55NPMY444C6M6CA7T33HRNCMA6ZFBIIXKNCRO6J25K7"),
+				Balance:       50000,
+				SeqNum:        648736,
+				NumSubEntries: 10,
+				InflationDest: &inflationDest,
+				Flags:         2,
+				HomeDomain:    "meridian.stellar.org",
+				Thresholds:    xdr.Thresholds{5, 6, 7, 8},
+				Ext: xdr.AccountEntryExt{
+					V: 1,
+					V1: &xdr.AccountEntryExtensionV1{
+						Liabilities: xdr.Liabilities{
+							Buying:  30,
+							Selling: 40,
+						},
+					},
 				},
 			},
 		},
 	}
 
-	account3 = xdr.AccountEntry{
-		AccountId:     xdr.MustAddress("GDPGOMFSP4IF7A4P7UBKA4UC4QTRLEHGBD6IMDIS3W3KBDNBFAQ7FXDY"),
-		Balance:       50000,
-		SeqNum:        648736,
-		NumSubEntries: 10,
-		InflationDest: &inflationDest,
-		Flags:         2,
-		Thresholds:    xdr.Thresholds{5, 6, 7, 8},
-		Ext: xdr.AccountEntryExt{
-			V: 1,
-			V1: &xdr.AccountEntryExtensionV1{
-				Liabilities: xdr.Liabilities{
-					Buying:  30,
-					Selling: 40,
+	account3 = xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1235,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId:     xdr.MustAddress("GDPGOMFSP4IF7A4P7UBKA4UC4QTRLEHGBD6IMDIS3W3KBDNBFAQ7FXDY"),
+				Balance:       50000,
+				SeqNum:        648736,
+				NumSubEntries: 10,
+				InflationDest: &inflationDest,
+				Flags:         2,
+				Thresholds:    xdr.Thresholds{5, 6, 7, 8},
+				Ext: xdr.AccountEntryExt{
+					V: 1,
+					V1: &xdr.AccountEntryExtensionV1{
+						Liabilities: xdr.Liabilities{
+							Buying:  30,
+							Selling: 40,
+						},
+					},
 				},
 			},
 		},
@@ -79,9 +97,9 @@ func TestInsertAccount(t *testing.T) {
 	q := &Q{tt.HorizonSession()}
 
 	batch := q.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(account1, 1234)
+	err := batch.Add(account1)
 	assert.NoError(t, err)
-	err = batch.Add(account2, 1235)
+	err = batch.Add(account2)
 	assert.NoError(t, err)
 	assert.NoError(t, batch.Exec())
 
@@ -113,50 +131,52 @@ func TestUpsertAccount(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	ledgerEntries := []xdr.LedgerEntry{
-		xdr.LedgerEntry{
-			LastModifiedLedgerSeq: 1234,
-			Data: xdr.LedgerEntryData{
-				Type:    xdr.LedgerEntryTypeAccount,
-				Account: &account1,
-			},
-		},
-		xdr.LedgerEntry{
-			LastModifiedLedgerSeq: 1234,
-			Data: xdr.LedgerEntryData{
-				Type:    xdr.LedgerEntryTypeAccount,
-				Account: &account2,
-			},
-		},
-	}
+	ledgerEntries := []xdr.LedgerEntry{account1, account2}
 	err := q.UpsertAccounts(ledgerEntries)
 	assert.NoError(t, err)
 
-	modifiedAccount := account1
-	modifiedAccount.Balance = 32847893
-
-	err = q.UpsertAccounts([]xdr.LedgerEntry{{
-		LastModifiedLedgerSeq: 1235,
+	modifiedAccount := xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1234,
 		Data: xdr.LedgerEntryData{
-			Type:    xdr.LedgerEntryTypeAccount,
-			Account: &modifiedAccount,
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId:     xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+				Balance:       32847893,
+				SeqNum:        223456789,
+				NumSubEntries: 10,
+				InflationDest: &inflationDest,
+				Flags:         1,
+				HomeDomain:    "stellar.org",
+				Thresholds:    xdr.Thresholds{1, 2, 3, 4},
+				Ext: xdr.AccountEntryExt{
+					V: 1,
+					V1: &xdr.AccountEntryExtensionV1{
+						Liabilities: xdr.Liabilities{
+							Buying:  3,
+							Selling: 4,
+						},
+					},
+				},
+			},
 		},
-	}})
+	}
+
+	err = q.UpsertAccounts([]xdr.LedgerEntry{modifiedAccount})
 	assert.NoError(t, err)
 
 	keys := []string{
-		account1.AccountId.Address(),
-		account2.AccountId.Address(),
+		account1.Data.Account.AccountId.Address(),
+		account2.Data.Account.AccountId.Address(),
 	}
 	accounts, err := q.GetAccountsByIDs(keys)
 	assert.NoError(t, err)
 	assert.Len(t, accounts, 2)
 
-	accounts, err = q.GetAccountsByIDs([]string{account1.AccountId.Address()})
+	accounts, err = q.GetAccountsByIDs([]string{account1.Data.Account.AccountId.Address()})
 	assert.NoError(t, err)
 	assert.Len(t, accounts, 1)
 
-	expectedBinary, err := modifiedAccount.MarshalBinary()
+	expectedBinary, err := modifiedAccount.Data.Account.MarshalBinary()
 	assert.NoError(t, err)
 
 	dbEntry := xdr.AccountEntry{
@@ -187,13 +207,13 @@ func TestUpsertAccount(t *testing.T) {
 	actualBinary, err := dbEntry.MarshalBinary()
 	assert.NoError(t, err)
 	assert.Equal(t, expectedBinary, actualBinary)
-	assert.Equal(t, uint32(1235), accounts[0].LastModifiedLedger)
+	assert.Equal(t, uint32(1234), accounts[0].LastModifiedLedger)
 
-	accounts, err = q.GetAccountsByIDs([]string{account2.AccountId.Address()})
+	accounts, err = q.GetAccountsByIDs([]string{account2.Data.Account.AccountId.Address()})
 	assert.NoError(t, err)
 	assert.Len(t, accounts, 1)
 
-	expectedBinary, err = account2.MarshalBinary()
+	expectedBinary, err = account2.Data.Account.MarshalBinary()
 	assert.NoError(t, err)
 
 	dbEntry = xdr.AccountEntry{
@@ -224,7 +244,7 @@ func TestUpsertAccount(t *testing.T) {
 	actualBinary, err = dbEntry.MarshalBinary()
 	assert.NoError(t, err)
 	assert.Equal(t, expectedBinary, actualBinary)
-	assert.Equal(t, uint32(1234), accounts[0].LastModifiedLedger)
+	assert.Equal(t, uint32(1235), accounts[0].LastModifiedLedger)
 }
 
 func TestRemoveAccount(t *testing.T) {
@@ -234,7 +254,7 @@ func TestRemoveAccount(t *testing.T) {
 	q := &Q{tt.HorizonSession()}
 
 	batch := q.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(account1, 1234)
+	err := batch.Add(account1)
 	assert.NoError(t, err)
 	assert.NoError(t, batch.Exec())
 
@@ -259,19 +279,19 @@ func TestAccountsForAsset(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	eurTrustLine.AccountId = account1.AccountId
-	usdTrustLine.AccountId = account2.AccountId
+	eurTrustLine.Data.TrustLine.AccountId = account1.Data.Account.AccountId
+	usdTrustLine.Data.TrustLine.AccountId = account2.Data.Account.AccountId
 
 	batch := q.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(account1, 1234)
+	err := batch.Add(account1)
 	assert.NoError(t, err)
-	err = batch.Add(account2, 1235)
+	err = batch.Add(account2)
 	assert.NoError(t, err)
 	assert.NoError(t, batch.Exec())
 
-	_, err = q.InsertTrustLine(eurTrustLine, 1234)
+	_, err = q.InsertTrustLine(eurTrustLine)
 	tt.Assert.NoError(err)
-	_, err = q.InsertTrustLine(usdTrustLine, 1235)
+	_, err = q.InsertTrustLine(usdTrustLine)
 	tt.Assert.NoError(err)
 
 	pq := db2.PageQuery{
@@ -280,18 +300,18 @@ func TestAccountsForAsset(t *testing.T) {
 		Cursor: "",
 	}
 
-	accounts, err := q.AccountsForAsset(eurTrustLine.Asset, pq)
+	accounts, err := q.AccountsForAsset(eurTrustLine.Data.TrustLine.Asset, pq)
 	assert.NoError(t, err)
 	tt.Assert.Len(accounts, 1)
-	tt.Assert.Equal(account1.AccountId.Address(), accounts[0].AccountID)
+	tt.Assert.Equal(account1.Data.Account.AccountId.Address(), accounts[0].AccountID)
 
-	accounts, err = q.AccountsForAsset(usdTrustLine.Asset, pq)
+	accounts, err = q.AccountsForAsset(usdTrustLine.Data.TrustLine.Asset, pq)
 	assert.NoError(t, err)
 	tt.Assert.Len(accounts, 1)
-	tt.Assert.Equal(account2.AccountId.Address(), accounts[0].AccountID)
+	tt.Assert.Equal(account2.Data.Account.AccountId.Address(), accounts[0].AccountID)
 
-	pq.Cursor = account2.AccountId.Address()
-	accounts, err = q.AccountsForAsset(usdTrustLine.Asset, pq)
+	pq.Cursor = account2.Data.Account.AccountId.Address()
+	accounts, err = q.AccountsForAsset(usdTrustLine.Data.TrustLine.Asset, pq)
 	assert.NoError(t, err)
 	tt.Assert.Len(accounts, 0)
 
@@ -301,7 +321,7 @@ func TestAccountsForAsset(t *testing.T) {
 		Cursor: "",
 	}
 
-	accounts, err = q.AccountsForAsset(eurTrustLine.Asset, pq)
+	accounts, err = q.AccountsForAsset(eurTrustLine.Data.TrustLine.Asset, pq)
 	assert.NoError(t, err)
 	tt.Assert.Len(accounts, 1)
 }
@@ -312,32 +332,32 @@ func TestAccountEntriesForSigner(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	eurTrustLine.AccountId = account1.AccountId
-	usdTrustLine.AccountId = account2.AccountId
+	eurTrustLine.Data.TrustLine.AccountId = account1.Data.Account.AccountId
+	usdTrustLine.Data.TrustLine.AccountId = account2.Data.Account.AccountId
 
 	batch := q.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(account1, 1234)
+	err := batch.Add(account1)
 	assert.NoError(t, err)
-	err = batch.Add(account2, 1235)
+	err = batch.Add(account2)
 	assert.NoError(t, err)
-	err = batch.Add(account3, 1235)
+	err = batch.Add(account3)
 	assert.NoError(t, err)
 	assert.NoError(t, batch.Exec())
 
-	_, err = q.InsertTrustLine(eurTrustLine, 1234)
+	_, err = q.InsertTrustLine(eurTrustLine)
 	tt.Assert.NoError(err)
-	_, err = q.InsertTrustLine(usdTrustLine, 1235)
+	_, err = q.InsertTrustLine(usdTrustLine)
 	tt.Assert.NoError(err)
 
-	_, err = q.CreateAccountSigner(account1.AccountId.Address(), account1.AccountId.Address(), 1)
+	_, err = q.CreateAccountSigner(account1.Data.Account.AccountId.Address(), account1.Data.Account.AccountId.Address(), 1)
 	tt.Assert.NoError(err)
-	_, err = q.CreateAccountSigner(account2.AccountId.Address(), account2.AccountId.Address(), 1)
+	_, err = q.CreateAccountSigner(account2.Data.Account.AccountId.Address(), account2.Data.Account.AccountId.Address(), 1)
 	tt.Assert.NoError(err)
-	_, err = q.CreateAccountSigner(account3.AccountId.Address(), account3.AccountId.Address(), 1)
+	_, err = q.CreateAccountSigner(account3.Data.Account.AccountId.Address(), account3.Data.Account.AccountId.Address(), 1)
 	tt.Assert.NoError(err)
-	_, err = q.CreateAccountSigner(account1.AccountId.Address(), account3.AccountId.Address(), 1)
+	_, err = q.CreateAccountSigner(account1.Data.Account.AccountId.Address(), account3.Data.Account.AccountId.Address(), 1)
 	tt.Assert.NoError(err)
-	_, err = q.CreateAccountSigner(account2.AccountId.Address(), account3.AccountId.Address(), 1)
+	_, err = q.CreateAccountSigner(account2.Data.Account.AccountId.Address(), account3.Data.Account.AccountId.Address(), 1)
 	tt.Assert.NoError(err)
 
 	pq := db2.PageQuery{
@@ -346,23 +366,23 @@ func TestAccountEntriesForSigner(t *testing.T) {
 		Cursor: "",
 	}
 
-	accounts, err := q.AccountEntriesForSigner(account1.AccountId.Address(), pq)
+	accounts, err := q.AccountEntriesForSigner(account1.Data.Account.AccountId.Address(), pq)
 	assert.NoError(t, err)
 	tt.Assert.Len(accounts, 1)
-	tt.Assert.Equal(account1.AccountId.Address(), accounts[0].AccountID)
+	tt.Assert.Equal(account1.Data.Account.AccountId.Address(), accounts[0].AccountID)
 
-	accounts, err = q.AccountEntriesForSigner(account2.AccountId.Address(), pq)
+	accounts, err = q.AccountEntriesForSigner(account2.Data.Account.AccountId.Address(), pq)
 	assert.NoError(t, err)
 	tt.Assert.Len(accounts, 1)
-	tt.Assert.Equal(account2.AccountId.Address(), accounts[0].AccountID)
+	tt.Assert.Equal(account2.Data.Account.AccountId.Address(), accounts[0].AccountID)
 
 	want := map[string]bool{
-		account1.AccountId.Address(): true,
-		account2.AccountId.Address(): true,
-		account3.AccountId.Address(): true,
+		account1.Data.Account.AccountId.Address(): true,
+		account2.Data.Account.AccountId.Address(): true,
+		account3.Data.Account.AccountId.Address(): true,
 	}
 
-	accounts, err = q.AccountEntriesForSigner(account3.AccountId.Address(), pq)
+	accounts, err = q.AccountEntriesForSigner(account3.Data.Account.AccountId.Address(), pq)
 	assert.NoError(t, err)
 	tt.Assert.Len(accounts, 3)
 
@@ -374,12 +394,12 @@ func TestAccountEntriesForSigner(t *testing.T) {
 	tt.Assert.Len(want, 0)
 
 	pq.Cursor = accounts[len(accounts)-1].AccountID
-	accounts, err = q.AccountEntriesForSigner(account3.AccountId.Address(), pq)
+	accounts, err = q.AccountEntriesForSigner(account3.Data.Account.AccountId.Address(), pq)
 	assert.NoError(t, err)
 	tt.Assert.Len(accounts, 0)
 
 	pq.Order = "desc"
-	accounts, err = q.AccountEntriesForSigner(account3.AccountId.Address(), pq)
+	accounts, err = q.AccountEntriesForSigner(account3.Data.Account.AccountId.Address(), pq)
 	assert.NoError(t, err)
 	tt.Assert.Len(accounts, 2)
 
@@ -389,7 +409,7 @@ func TestAccountEntriesForSigner(t *testing.T) {
 		Cursor: "",
 	}
 
-	accounts, err = q.AccountEntriesForSigner(account1.AccountId.Address(), pq)
+	accounts, err = q.AccountEntriesForSigner(account1.Data.Account.AccountId.Address(), pq)
 	assert.NoError(t, err)
 	tt.Assert.Len(accounts, 1)
 }
@@ -401,11 +421,11 @@ func TestGetAccountByID(t *testing.T) {
 	q := &Q{tt.HorizonSession()}
 
 	batch := q.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(account1, 1234)
+	err := batch.Add(account1)
 	assert.NoError(t, err)
 	assert.NoError(t, batch.Exec())
 
-	resultAccount, err := q.GetAccountByID(account1.AccountId.Address())
+	resultAccount, err := q.GetAccountByID(account1.Data.Account.AccountId.Address())
 	assert.NoError(t, err)
 
 	assert.Equal(t, "GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB", resultAccount.AccountID)

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -152,7 +152,7 @@ type AccountEntry struct {
 }
 
 type AccountsBatchInsertBuilder interface {
-	Add(account xdr.AccountEntry, lastModifiedLedger xdr.Uint32) error
+	Add(entry xdr.LedgerEntry) error
 	Exec() error
 }
 
@@ -230,7 +230,7 @@ type Data struct {
 type AccountDataValue []byte
 
 type AccountDataBatchInsertBuilder interface {
-	Add(data xdr.DataEntry, lastModifiedLedger xdr.Uint32) error
+	Add(entry xdr.LedgerEntry) error
 	Exec() error
 }
 
@@ -244,8 +244,8 @@ type QData interface {
 	NewAccountDataBatchInsertBuilder(maxBatchSize int) AccountDataBatchInsertBuilder
 	CountAccountsData() (int, error)
 	GetAccountDataByKeys(keys []xdr.LedgerKeyData) ([]Data, error)
-	InsertAccountData(data xdr.DataEntry, lastModifiedLedger xdr.Uint32) (int64, error)
-	UpdateAccountData(data xdr.DataEntry, lastModifiedLedger xdr.Uint32) (int64, error)
+	InsertAccountData(entry xdr.LedgerEntry) (int64, error)
+	UpdateAccountData(entry xdr.LedgerEntry) (int64, error)
 	RemoveAccountData(key xdr.LedgerKeyData) (int64, error)
 }
 
@@ -473,7 +473,7 @@ type Offer struct {
 }
 
 type OffersBatchInsertBuilder interface {
-	Add(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) error
+	Add(entry xdr.LedgerEntry) error
 	Exec() error
 }
 
@@ -592,14 +592,14 @@ type TrustLine struct {
 type QTrustLines interface {
 	NewTrustLinesBatchInsertBuilder(maxBatchSize int) TrustLinesBatchInsertBuilder
 	GetTrustLinesByKeys(keys []xdr.LedgerKeyTrustLine) ([]TrustLine, error)
-	InsertTrustLine(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr.Uint32) (int64, error)
-	UpdateTrustLine(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr.Uint32) (int64, error)
-	UpsertTrustLines(trustLines []xdr.LedgerEntry) error
+	InsertTrustLine(entry xdr.LedgerEntry) (int64, error)
+	UpdateTrustLine(entry xdr.LedgerEntry) (int64, error)
+	UpsertTrustLines(entries []xdr.LedgerEntry) error
 	RemoveTrustLine(key xdr.LedgerKeyTrustLine) (int64, error)
 }
 
 type TrustLinesBatchInsertBuilder interface {
-	Add(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr.Uint32) error
+	Add(entry xdr.LedgerEntry) error
 	Exec() error
 }
 

--- a/services/horizon/internal/db2/history/mock_account_data_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_account_data_batch_insert_builder.go
@@ -9,8 +9,8 @@ type MockAccountDataBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockAccountDataBatchInsertBuilder) Add(data xdr.DataEntry, lastModifiedLedger xdr.Uint32) error {
-	a := m.Called(data, lastModifiedLedger)
+func (m *MockAccountDataBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
+	a := m.Called(entry)
 	return a.Error(0)
 }
 

--- a/services/horizon/internal/db2/history/mock_offers_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_offers_batch_insert_builder.go
@@ -9,8 +9,8 @@ type MockOffersBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockOffersBatchInsertBuilder) Add(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) error {
-	a := m.Called(offer, lastModifiedLedger)
+func (m *MockOffersBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
+	a := m.Called(entry)
 	return a.Error(0)
 }
 

--- a/services/horizon/internal/db2/history/mock_q_data.go
+++ b/services/horizon/internal/db2/history/mock_q_data.go
@@ -26,13 +26,13 @@ func (m *MockQData) NewAccountDataBatchInsertBuilder(maxBatchSize int) AccountDa
 	return a.Get(0).(AccountDataBatchInsertBuilder)
 }
 
-func (m *MockQData) InsertAccountData(data xdr.DataEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
-	a := m.Called(data, lastModifiedLedger)
+func (m *MockQData) InsertAccountData(entry xdr.LedgerEntry) (int64, error) {
+	a := m.Called(entry)
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQData) UpdateAccountData(data xdr.DataEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
-	a := m.Called(data, lastModifiedLedger)
+func (m *MockQData) UpdateAccountData(entry xdr.LedgerEntry) (int64, error) {
+	a := m.Called(entry)
 	return a.Get(0).(int64), a.Error(1)
 }
 

--- a/services/horizon/internal/db2/history/mock_q_offers.go
+++ b/services/horizon/internal/db2/history/mock_q_offers.go
@@ -41,8 +41,8 @@ func (m *MockQOffers) NewOffersBatchInsertBuilder(maxBatchSize int) OffersBatchI
 	return a.Get(0).(OffersBatchInsertBuilder)
 }
 
-func (m *MockQOffers) UpdateOffer(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
-	a := m.Called(offer, lastModifiedLedger)
+func (m *MockQOffers) UpdateOffer(entry xdr.LedgerEntry) (int64, error) {
+	a := m.Called(entry)
 	return a.Get(0).(int64), a.Error(1)
 }
 

--- a/services/horizon/internal/db2/history/mock_q_trust_lines.go
+++ b/services/horizon/internal/db2/history/mock_q_trust_lines.go
@@ -21,13 +21,13 @@ func (m *MockQTrustLines) GetTrustLinesByKeys(keys []xdr.LedgerKeyTrustLine) ([]
 	return a.Get(0).([]TrustLine), a.Error(1)
 }
 
-func (m *MockQTrustLines) InsertTrustLine(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
-	a := m.Called(trustLine, lastModifiedLedger)
+func (m *MockQTrustLines) InsertTrustLine(entry xdr.LedgerEntry) (int64, error) {
+	a := m.Called(entry)
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQTrustLines) UpdateTrustLine(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
-	a := m.Called(trustLine, lastModifiedLedger)
+func (m *MockQTrustLines) UpdateTrustLine(entry xdr.LedgerEntry) (int64, error) {
+	a := m.Called(entry)
 	return a.Get(0).(int64), a.Error(1)
 }
 

--- a/services/horizon/internal/db2/history/mock_trust_lines_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_trust_lines_batch_insert_builder.go
@@ -9,8 +9,8 @@ type MockTrustLinesBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockTrustLinesBatchInsertBuilder) Add(trustLines xdr.TrustLineEntry, lastModifiedLedger xdr.Uint32) error {
-	a := m.Called(trustLines, lastModifiedLedger)
+func (m *MockTrustLinesBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
+	a := m.Called(entry)
 	return a.Error(0)
 }
 

--- a/services/horizon/internal/db2/history/offers_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/offers_batch_insert_builder.go
@@ -7,7 +7,9 @@ import (
 
 // Add adds a new offer entry to the batch. `lastModifiedLedger` is another
 // parameter because `xdr.OfferEntry` does not have a field to hold this value.
-func (i *offersBatchInsertBuilder) Add(offer xdr.OfferEntry, lastModifiedLedger xdr.Uint32) error {
+func (i *offersBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
+	offer := entry.Data.MustOffer()
+
 	var price float64
 	if offer.Price.D == 0 {
 		return errors.New("offer price denominator is zero")
@@ -26,7 +28,7 @@ func (i *offersBatchInsertBuilder) Add(offer xdr.OfferEntry, lastModifiedLedger 
 		Price:              price,
 		Flags:              uint32(offer.Flags),
 		Deleted:            false,
-		LastModifiedLedger: uint32(lastModifiedLedger),
+		LastModifiedLedger: uint32(entry.LastModifiedLedgerSeq),
 	}
 
 	return i.builder.RowStruct(row)

--- a/services/horizon/internal/db2/history/sequence_provider_test.go
+++ b/services/horizon/internal/db2/history/sequence_provider_test.go
@@ -1,9 +1,10 @@
 package history
 
 import (
+	"testing"
+
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestSequenceProviderEmptyDB(t *testing.T) {
@@ -28,9 +29,9 @@ func TestSequenceProviderGet(t *testing.T) {
 	q := &Q{tt.HorizonSession()}
 
 	batch := q.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(account1, 1234)
+	err := batch.Add(account1)
 	assert.NoError(t, err)
-	err = batch.Add(account2, 1235)
+	err = batch.Add(account2)
 	assert.NoError(t, err)
 	assert.NoError(t, batch.Exec())
 
@@ -41,6 +42,6 @@ func TestSequenceProviderGet(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Len(t, results, 2)
-	assert.Equal(t, uint64(account1.SeqNum), results["GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"])
-	assert.Equal(t, uint64(account2.SeqNum), results["GCT2NQM5KJJEF55NPMY444C6M6CA7T33HRNCMA6ZFBIIXKNCRO6J25K7"])
+	assert.Equal(t, uint64(account1.Data.Account.SeqNum), results["GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"])
+	assert.Equal(t, uint64(account2.Data.Account.SeqNum), results["GCT2NQM5KJJEF55NPMY444C6M6CA7T33HRNCMA6ZFBIIXKNCRO6J25K7"])
 }

--- a/services/horizon/internal/db2/history/trust_lines.go
+++ b/services/horizon/internal/db2/history/trust_lines.go
@@ -94,11 +94,11 @@ func (q *Q) GetTrustLinesByKeys(keys []xdr.LedgerKeyTrustLine) ([]TrustLine, err
 
 // InsertTrustLine creates a row in the trust lines table.
 // Returns number of rows affected and error.
-func (q *Q) InsertTrustLine(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
-	m := trustLineToMap(trustLine, lastModifiedLedger)
+func (q *Q) InsertTrustLine(entry xdr.LedgerEntry) (int64, error) {
+	m := trustLineToMap(entry)
 
 	// Add lkey only when inserting rows
-	key, err := trustLineEntryToLedgerKeyString(trustLine)
+	key, err := trustLineEntryToLedgerKeyString(entry)
 	if err != nil {
 		return 0, errors.Wrap(err, "Error running trustLineEntryToLedgerKeyString")
 	}
@@ -115,20 +115,14 @@ func (q *Q) InsertTrustLine(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr
 
 // UpdateTrustLine updates a row in the trust lines table.
 // Returns number of rows affected and error.
-func (q *Q) UpdateTrustLine(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr.Uint32) (int64, error) {
-	ledgerKey := xdr.LedgerKey{}
-	err := ledgerKey.SetTrustline(trustLine.AccountId, trustLine.Asset)
-	if err != nil {
-		return 0, errors.Wrap(err, "Error creating ledger key")
-	}
-
-	key, err := trustLineEntryToLedgerKeyString(trustLine)
+func (q *Q) UpdateTrustLine(entry xdr.LedgerEntry) (int64, error) {
+	key, err := trustLineEntryToLedgerKeyString(entry)
 	if err != nil {
 		return 0, errors.Wrap(err, "Error running trustLineEntryToLedgerKeyString")
 	}
 
 	sql := sq.Update("trust_lines").
-		SetMap(trustLineToMap(trustLine, lastModifiedLedger)).
+		SetMap(trustLineToMap(entry)).
 		Where(map[string]interface{}{"ledger_key": key})
 	result, err := q.Exec(sql)
 	if err != nil {
@@ -153,13 +147,12 @@ func (q *Q) UpsertTrustLines(trustLines []xdr.LedgerEntry) error {
 			return errors.Errorf("Invalid entry type: %d", entry.Data.Type)
 		}
 
-		key, err := trustLineEntryToLedgerKeyString(entry.Data.MustTrustLine())
+		key, err := trustLineEntryToLedgerKeyString(entry)
 		if err != nil {
 			return errors.Wrap(err, "Error running trustLineEntryToLedgerKeyString")
 		}
 
-		m := trustLineToMap(entry.Data.MustTrustLine(), entry.LastModifiedLedgerSeq)
-
+		m := trustLineToMap(entry)
 		ledgerKey = append(ledgerKey, key)
 		accountID = append(accountID, m["account_id"].(string))
 		assetType = append(assetType, m["asset_type"].(xdr.AssetType))
@@ -256,12 +249,8 @@ func (q *Q) GetSortedTrustLinesByAccountIDs(id []string) ([]TrustLine, error) {
 	return data, err
 }
 
-func trustLineEntryToLedgerKeyString(trustLine xdr.TrustLineEntry) (string, error) {
-	ledgerKey := &xdr.LedgerKey{}
-	err := ledgerKey.SetTrustline(trustLine.AccountId, trustLine.Asset)
-	if err != nil {
-		return "", errors.Wrap(err, "Error running ledgerKey.SetTrustline")
-	}
+func trustLineEntryToLedgerKeyString(entry xdr.LedgerEntry) (string, error) {
+	ledgerKey := entry.LedgerKey()
 	key, err := ledgerKey.MarshalBinary()
 	if err != nil {
 		return "", errors.Wrap(err, "Error running MarshalBinaryCompress")
@@ -284,18 +273,14 @@ func ledgerKeyTrustLineToString(trustLineKey xdr.LedgerKeyTrustLine) (string, er
 	return base64.StdEncoding.EncodeToString(key), nil
 }
 
-func trustLineToMap(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr.Uint32) map[string]interface{} {
+func trustLineToMap(entry xdr.LedgerEntry) map[string]interface{} {
+	trustLine := entry.Data.MustTrustLine()
+
 	var assetType xdr.AssetType
 	var assetCode, assetIssuer string
 	trustLine.Asset.MustExtract(&assetType, &assetCode, &assetIssuer)
 
-	var buyingliabilities, sellingliabilities xdr.Int64
-	if trustLine.Ext.V1 != nil {
-		v1 := trustLine.Ext.V1
-		buyingliabilities = v1.Liabilities.Buying
-		sellingliabilities = v1.Liabilities.Selling
-	}
-
+	liabilities := trustLine.Liabilities()
 	return map[string]interface{}{
 		"account_id":           trustLine.AccountId.Address(),
 		"asset_type":           assetType,
@@ -303,10 +288,10 @@ func trustLineToMap(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr.Uint32)
 		"asset_code":           assetCode,
 		"balance":              trustLine.Balance,
 		"trust_line_limit":     trustLine.Limit,
-		"buying_liabilities":   buyingliabilities,
-		"selling_liabilities":  sellingliabilities,
+		"buying_liabilities":   liabilities.Buying,
+		"selling_liabilities":  liabilities.Selling,
 		"flags":                trustLine.Flags,
-		"last_modified_ledger": lastModifiedLedger,
+		"last_modified_ledger": entry.LastModifiedLedgerSeq,
 	}
 }
 

--- a/services/horizon/internal/db2/history/trust_lines_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/trust_lines_batch_insert_builder.go
@@ -7,11 +7,11 @@ import (
 
 // Add adds a new trust line entry to the batch. `lastModifiedLedger` is another
 // parameter because `xdr.TrustLineEntry` does not have a field to hold this value.
-func (i *trustLinesBatchInsertBuilder) Add(trustLine xdr.TrustLineEntry, lastModifiedLedger xdr.Uint32) error {
-	m := trustLineToMap(trustLine, lastModifiedLedger)
+func (i *trustLinesBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
+	m := trustLineToMap(entry)
 
 	// Add lkey only when inserting rows
-	key, err := trustLineEntryToLedgerKeyString(trustLine)
+	key, err := trustLineEntryToLedgerKeyString(entry)
 	if err != nil {
 		return errors.Wrap(err, "Error running trustLineEntryToLedgerKeyString")
 	}

--- a/services/horizon/internal/db2/history/trust_lines_test.go
+++ b/services/horizon/internal/db2/history/trust_lines_test.go
@@ -12,52 +12,70 @@ import (
 var (
 	trustLineIssuer = xdr.MustAddress("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
 
-	eurTrustLine = xdr.TrustLineEntry{
-		AccountId: account1.AccountId,
-		Asset:     xdr.MustNewCreditAsset("EUR", trustLineIssuer.Address()),
-		Balance:   30000,
-		Limit:     223456789,
-		Flags:     1,
-		Ext: xdr.TrustLineEntryExt{
-			V: 1,
-			V1: &xdr.TrustLineEntryV1{
-				Liabilities: xdr.Liabilities{
-					Buying:  3,
-					Selling: 4,
+	eurTrustLine = xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1234,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeTrustline,
+			TrustLine: &xdr.TrustLineEntry{
+				AccountId: account1.Data.Account.AccountId,
+				Asset:     xdr.MustNewCreditAsset("EUR", trustLineIssuer.Address()),
+				Balance:   30000,
+				Limit:     223456789,
+				Flags:     1,
+				Ext: xdr.TrustLineEntryExt{
+					V: 1,
+					V1: &xdr.TrustLineEntryV1{
+						Liabilities: xdr.Liabilities{
+							Buying:  3,
+							Selling: 4,
+						},
+					},
 				},
 			},
 		},
 	}
 
-	usdTrustLine = xdr.TrustLineEntry{
-		AccountId: xdr.MustAddress("GCYVFGI3SEQJGBNQQG7YCMFWEYOHK3XPVOVPA6C566PXWN4SN7LILZSM"),
-		Asset:     xdr.MustNewCreditAsset("USDUSD", trustLineIssuer.Address()),
-		Balance:   10000,
-		Limit:     123456789,
-		Flags:     0,
-		Ext: xdr.TrustLineEntryExt{
-			V: 1,
-			V1: &xdr.TrustLineEntryV1{
-				Liabilities: xdr.Liabilities{
-					Buying:  1,
-					Selling: 2,
+	usdTrustLine = xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1235,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeTrustline,
+			TrustLine: &xdr.TrustLineEntry{
+				AccountId: xdr.MustAddress("GCYVFGI3SEQJGBNQQG7YCMFWEYOHK3XPVOVPA6C566PXWN4SN7LILZSM"),
+				Asset:     xdr.MustNewCreditAsset("USDUSD", trustLineIssuer.Address()),
+				Balance:   10000,
+				Limit:     123456789,
+				Flags:     0,
+				Ext: xdr.TrustLineEntryExt{
+					V: 1,
+					V1: &xdr.TrustLineEntryV1{
+						Liabilities: xdr.Liabilities{
+							Buying:  1,
+							Selling: 2,
+						},
+					},
 				},
 			},
 		},
 	}
 
-	usdTrustLine2 = xdr.TrustLineEntry{
-		AccountId: xdr.MustAddress("GBYSBDAJZMHL5AMD7QXQ3JEP3Q4GLKADWIJURAAHQALNAWD6Z5XF2RAC"),
-		Asset:     xdr.MustNewCreditAsset("USDUSD", trustLineIssuer.Address()),
-		Balance:   10000,
-		Limit:     123456789,
-		Flags:     0,
-		Ext: xdr.TrustLineEntryExt{
-			V: 1,
-			V1: &xdr.TrustLineEntryV1{
-				Liabilities: xdr.Liabilities{
-					Buying:  1,
-					Selling: 2,
+	usdTrustLine2 = xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1234,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeTrustline,
+			TrustLine: &xdr.TrustLineEntry{
+				AccountId: xdr.MustAddress("GBYSBDAJZMHL5AMD7QXQ3JEP3Q4GLKADWIJURAAHQALNAWD6Z5XF2RAC"),
+				Asset:     xdr.MustNewCreditAsset("USDUSD", trustLineIssuer.Address()),
+				Balance:   10000,
+				Limit:     123456789,
+				Flags:     0,
+				Ext: xdr.TrustLineEntryExt{
+					V: 1,
+					V1: &xdr.TrustLineEntryV1{
+						Liabilities: xdr.Liabilities{
+							Buying:  1,
+							Selling: 2,
+						},
+					},
 				},
 			},
 		},
@@ -82,17 +100,17 @@ func TestInsertTrustLine(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	rows, err := q.InsertTrustLine(eurTrustLine, 1234)
+	rows, err := q.InsertTrustLine(eurTrustLine)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), rows)
 
-	rows, err = q.InsertTrustLine(usdTrustLine, 1235)
+	rows, err = q.InsertTrustLine(usdTrustLine)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), rows)
 
 	keys := []xdr.LedgerKeyTrustLine{
-		{Asset: eurTrustLine.Asset, AccountId: eurTrustLine.AccountId},
-		{Asset: usdTrustLine.Asset, AccountId: usdTrustLine.AccountId},
+		{Asset: eurTrustLine.Data.TrustLine.Asset, AccountId: eurTrustLine.Data.TrustLine.AccountId},
+		{Asset: usdTrustLine.Data.TrustLine.Asset, AccountId: usdTrustLine.Data.TrustLine.AccountId},
 	}
 
 	lines, err := q.GetTrustLinesByKeys(keys)
@@ -106,25 +124,25 @@ func TestUpdateTrustLine(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	rows, err := q.InsertTrustLine(eurTrustLine, 1234)
+	rows, err := q.InsertTrustLine(eurTrustLine)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), rows)
 
 	modifiedTrustLine := eurTrustLine
-	modifiedTrustLine.Balance = 30000
+	modifiedTrustLine.Data.TrustLine.Balance = 30000
 
-	rows, err = q.UpdateTrustLine(modifiedTrustLine, 1235)
+	rows, err = q.UpdateTrustLine(modifiedTrustLine)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), rows)
 
 	keys := []xdr.LedgerKeyTrustLine{
-		{Asset: eurTrustLine.Asset, AccountId: eurTrustLine.AccountId},
+		{Asset: eurTrustLine.Data.TrustLine.Asset, AccountId: eurTrustLine.Data.TrustLine.AccountId},
 	}
 	lines, err := q.GetTrustLinesByKeys(keys)
 	assert.NoError(t, err)
 	assert.Len(t, lines, 1)
 
-	expectedBinary, err := modifiedTrustLine.MarshalBinary()
+	expectedBinary, err := modifiedTrustLine.Data.TrustLine.MarshalBinary()
 	assert.NoError(t, err)
 
 	dbEntry := xdr.TrustLineEntry{
@@ -147,7 +165,7 @@ func TestUpdateTrustLine(t *testing.T) {
 	actualBinary, err := dbEntry.MarshalBinary()
 	assert.NoError(t, err)
 	assert.Equal(t, expectedBinary, actualBinary)
-	assert.Equal(t, uint32(1235), lines[0].LastModifiedLedger)
+	assert.Equal(t, uint32(1234), lines[0].LastModifiedLedger)
 }
 
 func TestUpsertTrustLines(t *testing.T) {
@@ -160,64 +178,41 @@ func TestUpsertTrustLines(t *testing.T) {
 	err := q.UpsertTrustLines([]xdr.LedgerEntry{})
 	assert.NoError(t, err)
 
-	ledgerEntries := []xdr.LedgerEntry{
-		{
-			LastModifiedLedgerSeq: 1,
-			Data: xdr.LedgerEntryData{
-				Type:      xdr.LedgerEntryTypeTrustline,
-				TrustLine: &eurTrustLine,
-			},
-		},
-		{
-			LastModifiedLedgerSeq: 2,
-			Data: xdr.LedgerEntryData{
-				Type:      xdr.LedgerEntryTypeTrustline,
-				TrustLine: &usdTrustLine,
-			},
-		},
-	}
+	ledgerEntries := []xdr.LedgerEntry{eurTrustLine, usdTrustLine}
 
 	err = q.UpsertTrustLines(ledgerEntries)
 	assert.NoError(t, err)
 
 	keys := []xdr.LedgerKeyTrustLine{
-		{Asset: eurTrustLine.Asset, AccountId: eurTrustLine.AccountId},
+		{Asset: eurTrustLine.Data.TrustLine.Asset, AccountId: eurTrustLine.Data.TrustLine.AccountId},
 	}
 	lines, err := q.GetTrustLinesByKeys(keys)
 	assert.NoError(t, err)
 	assert.Len(t, lines, 1)
 
 	keys = []xdr.LedgerKeyTrustLine{
-		{Asset: usdTrustLine.Asset, AccountId: usdTrustLine.AccountId},
+		{Asset: usdTrustLine.Data.TrustLine.Asset, AccountId: usdTrustLine.Data.TrustLine.AccountId},
 	}
 	lines, err = q.GetTrustLinesByKeys(keys)
 	assert.NoError(t, err)
 	assert.Len(t, lines, 1)
 
 	modifiedTrustLine := eurTrustLine
-	modifiedTrustLine.Balance = 30000
+	modifiedTrustLine.Data.TrustLine.Balance = 30000
 
-	ledgerEntries = []xdr.LedgerEntry{
-		{
-			LastModifiedLedgerSeq: 1000,
-			Data: xdr.LedgerEntryData{
-				Type:      xdr.LedgerEntryTypeTrustline,
-				TrustLine: &modifiedTrustLine,
-			},
-		},
-	}
+	ledgerEntries = []xdr.LedgerEntry{modifiedTrustLine}
 
 	err = q.UpsertTrustLines(ledgerEntries)
 	assert.NoError(t, err)
 
 	keys = []xdr.LedgerKeyTrustLine{
-		{Asset: eurTrustLine.Asset, AccountId: eurTrustLine.AccountId},
+		{Asset: eurTrustLine.Data.TrustLine.Asset, AccountId: eurTrustLine.Data.TrustLine.AccountId},
 	}
 	lines, err = q.GetTrustLinesByKeys(keys)
 	assert.NoError(t, err)
 	assert.Len(t, lines, 1)
 
-	expectedBinary, err := modifiedTrustLine.MarshalBinary()
+	expectedBinary, err := modifiedTrustLine.Data.TrustLine.MarshalBinary()
 	assert.NoError(t, err)
 
 	dbEntry := xdr.TrustLineEntry{
@@ -240,16 +235,16 @@ func TestUpsertTrustLines(t *testing.T) {
 	actualBinary, err := dbEntry.MarshalBinary()
 	assert.NoError(t, err)
 	assert.Equal(t, expectedBinary, actualBinary)
-	assert.Equal(t, uint32(1000), lines[0].LastModifiedLedger)
+	assert.Equal(t, uint32(1234), lines[0].LastModifiedLedger)
 
 	keys = []xdr.LedgerKeyTrustLine{
-		{Asset: usdTrustLine.Asset, AccountId: usdTrustLine.AccountId},
+		{Asset: usdTrustLine.Data.TrustLine.Asset, AccountId: usdTrustLine.Data.TrustLine.AccountId},
 	}
 	lines, err = q.GetTrustLinesByKeys(keys)
 	assert.NoError(t, err)
 	assert.Len(t, lines, 1)
 
-	expectedBinary, err = usdTrustLine.MarshalBinary()
+	expectedBinary, err = usdTrustLine.Data.TrustLine.MarshalBinary()
 	assert.NoError(t, err)
 
 	dbEntry = xdr.TrustLineEntry{
@@ -272,7 +267,7 @@ func TestUpsertTrustLines(t *testing.T) {
 	actualBinary, err = dbEntry.MarshalBinary()
 	assert.NoError(t, err)
 	assert.Equal(t, expectedBinary, actualBinary)
-	assert.Equal(t, uint32(2), lines[0].LastModifiedLedger)
+	assert.Equal(t, uint32(1235), lines[0].LastModifiedLedger)
 }
 
 func TestRemoveTrustLine(t *testing.T) {
@@ -281,11 +276,11 @@ func TestRemoveTrustLine(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	rows, err := q.InsertTrustLine(eurTrustLine, 1234)
+	rows, err := q.InsertTrustLine(eurTrustLine)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), rows)
 
-	key := xdr.LedgerKeyTrustLine{Asset: eurTrustLine.Asset, AccountId: eurTrustLine.AccountId}
+	key := xdr.LedgerKeyTrustLine{Asset: eurTrustLine.Data.TrustLine.Asset, AccountId: eurTrustLine.Data.TrustLine.AccountId}
 	rows, err = q.RemoveTrustLine(key)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), rows)
@@ -305,25 +300,25 @@ func TestGetSortedTrustLinesByAccountsID(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	_, err := q.InsertTrustLine(eurTrustLine, 1234)
+	_, err := q.InsertTrustLine(eurTrustLine)
 	tt.Assert.NoError(err)
-	_, err = q.InsertTrustLine(usdTrustLine, 1235)
+	_, err = q.InsertTrustLine(usdTrustLine)
 	tt.Assert.NoError(err)
-	_, err = q.InsertTrustLine(usdTrustLine2, 1235)
+	_, err = q.InsertTrustLine(usdTrustLine2)
 	tt.Assert.NoError(err)
 
 	ids := []string{
-		eurTrustLine.AccountId.Address(),
-		usdTrustLine.AccountId.Address(),
+		eurTrustLine.Data.TrustLine.AccountId.Address(),
+		usdTrustLine.Data.TrustLine.AccountId.Address(),
 	}
 
 	records, err := q.GetSortedTrustLinesByAccountIDs(ids)
 	tt.Assert.NoError(err)
 	tt.Assert.Len(records, 2)
 
-	m := map[string]xdr.TrustLineEntry{
-		eurTrustLine.AccountId.Address(): eurTrustLine,
-		usdTrustLine.AccountId.Address(): usdTrustLine,
+	m := map[string]xdr.LedgerEntry{
+		eurTrustLine.Data.TrustLine.AccountId.Address(): eurTrustLine,
+		usdTrustLine.Data.TrustLine.AccountId.Address(): usdTrustLine,
 	}
 
 	lastAssetCode := ""
@@ -336,8 +331,8 @@ func TestGetSortedTrustLinesByAccountsID(t *testing.T) {
 		xtl, ok := m[record.AccountID]
 		tt.Assert.True(ok)
 		asset := xdr.MustNewCreditAsset(record.AssetCode, record.AssetIssuer)
-		tt.Assert.Equal(xtl.Asset, asset)
-		tt.Assert.Equal(xtl.AccountId.Address(), record.AccountID)
+		tt.Assert.Equal(xtl.Data.TrustLine.Asset, asset)
+		tt.Assert.Equal(xtl.Data.TrustLine.AccountId.Address(), record.AccountID)
 		delete(m, record.AccountID)
 	}
 
@@ -350,20 +345,20 @@ func TestGetTrustLinesByAccountID(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	_, err := q.InsertTrustLine(eurTrustLine, 1234)
+	_, err := q.InsertTrustLine(eurTrustLine)
 	tt.Assert.NoError(err)
 
-	record, err := q.GetSortedTrustLinesByAccountID(eurTrustLine.AccountId.Address())
+	record, err := q.GetSortedTrustLinesByAccountID(eurTrustLine.Data.TrustLine.AccountId.Address())
 	tt.Assert.NoError(err)
 
 	asset := xdr.MustNewCreditAsset(record[0].AssetCode, record[0].AssetIssuer)
-	tt.Assert.Equal(eurTrustLine.Asset, asset)
-	tt.Assert.Equal(eurTrustLine.AccountId.Address(), record[0].AccountID)
-	tt.Assert.Equal(int64(eurTrustLine.Balance), record[0].Balance)
-	tt.Assert.Equal(int64(eurTrustLine.Limit), record[0].Limit)
-	tt.Assert.Equal(uint32(eurTrustLine.Flags), record[0].Flags)
-	tt.Assert.Equal(int64(eurTrustLine.Ext.V1.Liabilities.Buying), record[0].BuyingLiabilities)
-	tt.Assert.Equal(int64(eurTrustLine.Ext.V1.Liabilities.Selling), record[0].SellingLiabilities)
+	tt.Assert.Equal(eurTrustLine.Data.TrustLine.Asset, asset)
+	tt.Assert.Equal(eurTrustLine.Data.TrustLine.AccountId.Address(), record[0].AccountID)
+	tt.Assert.Equal(int64(eurTrustLine.Data.TrustLine.Balance), record[0].Balance)
+	tt.Assert.Equal(int64(eurTrustLine.Data.TrustLine.Limit), record[0].Limit)
+	tt.Assert.Equal(uint32(eurTrustLine.Data.TrustLine.Flags), record[0].Flags)
+	tt.Assert.Equal(int64(eurTrustLine.Data.TrustLine.Ext.V1.Liabilities.Buying), record[0].BuyingLiabilities)
+	tt.Assert.Equal(int64(eurTrustLine.Data.TrustLine.Ext.V1.Liabilities.Selling), record[0].SellingLiabilities)
 
 }
 
@@ -373,13 +368,13 @@ func TestAssetsForAddressRequiresTransaction(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	_, _, err := q.AssetsForAddress(eurTrustLine.AccountId.Address())
+	_, _, err := q.AssetsForAddress(eurTrustLine.Data.TrustLine.AccountId.Address())
 	assert.EqualError(t, err, "cannot be called outside of a transaction")
 
 	assert.NoError(t, q.Begin())
 	defer q.Rollback()
 
-	_, _, err = q.AssetsForAddress(eurTrustLine.AccountId.Address())
+	_, _, err = q.AssetsForAddress(eurTrustLine.Data.TrustLine.AccountId.Address())
 	assert.EqualError(t, err, "should only be called in a repeatable read transaction")
 }
 
@@ -389,40 +384,38 @@ func TestAssetsForAddress(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	ledgerEntries := []xdr.LedgerEntry{
-		xdr.LedgerEntry{
-			LastModifiedLedgerSeq: 1234,
-			Data: xdr.LedgerEntryData{
-				Type:    xdr.LedgerEntryTypeAccount,
-				Account: &account1,
-			},
-		},
-	}
+	ledgerEntries := []xdr.LedgerEntry{account1}
 
 	err := q.UpsertAccounts(ledgerEntries)
 	assert.NoError(t, err)
 
-	_, err = q.InsertTrustLine(eurTrustLine, 1234)
+	_, err = q.InsertTrustLine(eurTrustLine)
 	tt.Assert.NoError(err)
 
-	brlTrustLine := xdr.TrustLineEntry{
-		AccountId: account1.AccountId,
-		Asset:     xdr.MustNewCreditAsset("BRL", trustLineIssuer.Address()),
-		Balance:   1000,
-		Limit:     20000,
-		Flags:     1,
-		Ext: xdr.TrustLineEntryExt{
-			V: 1,
-			V1: &xdr.TrustLineEntryV1{
-				Liabilities: xdr.Liabilities{
-					Buying:  3,
-					Selling: 4,
+	brlTrustLine := xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1234,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeTrustline,
+			TrustLine: &xdr.TrustLineEntry{
+				AccountId: account1.Data.Account.AccountId,
+				Asset:     xdr.MustNewCreditAsset("BRL", trustLineIssuer.Address()),
+				Balance:   1000,
+				Limit:     20000,
+				Flags:     1,
+				Ext: xdr.TrustLineEntryExt{
+					V: 1,
+					V1: &xdr.TrustLineEntryV1{
+						Liabilities: xdr.Liabilities{
+							Buying:  3,
+							Selling: 4,
+						},
+					},
 				},
 			},
 		},
 	}
 
-	_, err = q.InsertTrustLine(brlTrustLine, 1234)
+	_, err = q.InsertTrustLine(brlTrustLine)
 	tt.Assert.NoError(err)
 
 	err = q.BeginTx(&sql.TxOptions{
@@ -432,12 +425,12 @@ func TestAssetsForAddress(t *testing.T) {
 	assert.NoError(t, err)
 	defer q.Rollback()
 
-	assets, balances, err := q.AssetsForAddress(usdTrustLine.AccountId.Address())
+	assets, balances, err := q.AssetsForAddress(usdTrustLine.Data.TrustLine.AccountId.Address())
 	tt.Assert.NoError(err)
 	tt.Assert.Empty(assets)
 	tt.Assert.Empty(balances)
 
-	assets, balances, err = q.AssetsForAddress(account1.AccountId.Address())
+	assets, balances, err = q.AssetsForAddress(account1.Data.Account.AccountId.Address())
 	tt.Assert.NoError(err)
 
 	assetsToBalance := map[string]xdr.Int64{}

--- a/services/horizon/internal/expingest/db_integration_test.go
+++ b/services/horizon/internal/expingest/db_integration_test.go
@@ -140,8 +140,8 @@ func (s *DBTestSuite) TestBuildState() {
 	s.Assert().Equal(s.sequence, build.checkpointLedger)
 
 	next, err = build.run(s.system)
-	resume := next.node.(resumeState)
 	s.Assert().NoError(err)
+	resume := next.node.(resumeState)
 	s.Assert().Equal(s.sequence, resume.latestSuccessfullyProcessedLedger)
 
 	s.mockChangeReader()

--- a/services/horizon/internal/expingest/processor_runner_test.go
+++ b/services/horizon/internal/expingest/processor_runner_test.go
@@ -35,7 +35,7 @@ func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
 		Return(mockAccountDataBatchInsertBuilder).Once()
 
 	q.MockQAccounts.On("UpsertAccounts", []xdr.LedgerEntry{
-		xdr.LedgerEntry{
+		{
 			LastModifiedLedgerSeq: 1,
 			Data: xdr.LedgerEntryData{
 				Type: xdr.LedgerEntryTypeAccount,

--- a/services/horizon/internal/expingest/processors/account_data_processor.go
+++ b/services/horizon/internal/expingest/processors/account_data_processor.go
@@ -60,10 +60,7 @@ func (p *AccountDataProcessor) Commit() error {
 		case change.Pre == nil && change.Post != nil:
 			// Created
 			action = "inserting"
-			err = batch.Add(
-				change.Post.Data.MustData(),
-				change.Post.LastModifiedLedgerSeq,
-			)
+			err = batch.Add(*change.Post)
 			rowsAffected = 1 // We don't track this when batch inserting
 		case change.Pre != nil && change.Post == nil:
 			// Removed
@@ -82,7 +79,7 @@ func (p *AccountDataProcessor) Commit() error {
 			if err != nil {
 				return errors.Wrap(err, "Error creating ledger key")
 			}
-			rowsAffected, err = p.dataQ.UpdateAccountData(data, change.Post.LastModifiedLedgerSeq)
+			rowsAffected, err = p.dataQ.UpdateAccountData(*change.Post)
 		}
 
 		if err != nil {

--- a/services/horizon/internal/expingest/processors/offers_processor.go
+++ b/services/horizon/internal/expingest/processors/offers_processor.go
@@ -62,10 +62,7 @@ func (p *OffersProcessor) flushCache() error {
 		case change.Pre == nil && change.Post != nil:
 			// Created
 			action = "inserting"
-			err = p.batch.Add(
-				change.Post.Data.MustOffer(),
-				change.Post.LastModifiedLedgerSeq,
-			)
+			err = p.batch.Add(*change.Post)
 			rowsAffected = 1 // We don't track this when batch inserting
 		case change.Pre != nil && change.Post == nil:
 			// Removed
@@ -78,7 +75,7 @@ func (p *OffersProcessor) flushCache() error {
 			action = "updating"
 			offer := change.Post.Data.MustOffer()
 			offerID = offer.OfferId
-			rowsAffected, err = p.offersQ.UpdateOffer(offer, change.Post.LastModifiedLedgerSeq)
+			rowsAffected, err = p.offersQ.UpdateOffer(*change.Post)
 		}
 
 		if err != nil {

--- a/services/horizon/internal/expingest/processors/offers_processor_test.go
+++ b/services/horizon/internal/expingest/processors/offers_processor_test.go
@@ -51,19 +51,20 @@ func (s *OffersProcessorTestSuiteState) TestCreateOffer() {
 		Price:    xdr.Price{1, 2},
 	}
 	lastModifiedLedgerSeq := xdr.Uint32(123)
-	s.mockBatchInsertBuilder.
-		On("Add", offer, lastModifiedLedgerSeq).Return(nil).Once()
+	entry := xdr.LedgerEntry{
+		Data: xdr.LedgerEntryData{
+			Type:  xdr.LedgerEntryTypeOffer,
+			Offer: &offer,
+		},
+		LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+	}
+
+	s.mockBatchInsertBuilder.On("Add", entry).Return(nil).Once()
 
 	err := s.processor.ProcessChange(io.Change{
 		Type: xdr.LedgerEntryTypeOffer,
 		Pre:  nil,
-		Post: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
-				Type:  xdr.LedgerEntryTypeOffer,
-				Offer: &offer,
-			},
-			LastModifiedLedgerSeq: lastModifiedLedgerSeq,
-		},
+		Post: &entry,
 	})
 	s.Assert().NoError(err)
 }
@@ -141,6 +142,14 @@ func (s *OffersProcessorTestSuiteLedger) setupInsertOffer() {
 		Price:    xdr.Price{1, 6},
 	}
 
+	updatedEntry := xdr.LedgerEntry{
+		LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+		Data: xdr.LedgerEntryData{
+			Type:  xdr.LedgerEntryTypeOffer,
+			Offer: &updatedOffer,
+		},
+	}
+
 	err = s.processor.ProcessChange(io.Change{
 		Type: xdr.LedgerEntryTypeOffer,
 		Pre: &xdr.LedgerEntry{
@@ -150,22 +159,12 @@ func (s *OffersProcessorTestSuiteLedger) setupInsertOffer() {
 				Offer: &offer,
 			},
 		},
-		Post: &xdr.LedgerEntry{
-			LastModifiedLedgerSeq: lastModifiedLedgerSeq,
-			Data: xdr.LedgerEntryData{
-				Type:  xdr.LedgerEntryTypeOffer,
-				Offer: &updatedOffer,
-			},
-		},
+		Post: &updatedEntry,
 	})
 	s.Assert().NoError(err)
 
 	// We use LedgerEntryChangesCache so all changes are squashed
-	s.mockBatchInsertBuilder.On(
-		"Add",
-		updatedOffer,
-		lastModifiedLedgerSeq,
-	).Return(nil).Once()
+	s.mockBatchInsertBuilder.On("Add", updatedEntry).Return(nil).Once()
 
 	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
 }
@@ -209,6 +208,14 @@ func (s *OffersProcessorTestSuiteLedger) TestUpdateOfferNoRowsAffected() {
 		Price:    xdr.Price{1, 6},
 	}
 
+	updatedEntry := xdr.LedgerEntry{
+		LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+		Data: xdr.LedgerEntryData{
+			Type:  xdr.LedgerEntryTypeOffer,
+			Offer: &updatedOffer,
+		},
+	}
+
 	err := s.processor.ProcessChange(io.Change{
 		Type: xdr.LedgerEntryTypeOffer,
 		Pre: &xdr.LedgerEntry{
@@ -218,21 +225,11 @@ func (s *OffersProcessorTestSuiteLedger) TestUpdateOfferNoRowsAffected() {
 				Offer: &offer,
 			},
 		},
-		Post: &xdr.LedgerEntry{
-			LastModifiedLedgerSeq: lastModifiedLedgerSeq,
-			Data: xdr.LedgerEntryData{
-				Type:  xdr.LedgerEntryTypeOffer,
-				Offer: &updatedOffer,
-			},
-		},
+		Post: &updatedEntry,
 	})
 	s.Assert().NoError(err)
 
-	s.mockQ.On(
-		"UpdateOffer",
-		updatedOffer,
-		lastModifiedLedgerSeq,
-	).Return(int64(0), nil).Once()
+	s.mockQ.On("UpdateOffer", updatedEntry).Return(int64(0), nil).Once()
 
 	err = s.processor.Commit()
 	s.Assert().Error(err)
@@ -295,6 +292,14 @@ func (s *OffersProcessorTestSuiteLedger) TestProcessUpgradeChange() {
 		Price:    xdr.Price{1, 6},
 	}
 
+	updatedEntry := xdr.LedgerEntry{
+		LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+		Data: xdr.LedgerEntryData{
+			Type:  xdr.LedgerEntryTypeOffer,
+			Offer: &updatedOffer,
+		},
+	}
+
 	err = s.processor.ProcessChange(io.Change{
 		Type: xdr.LedgerEntryTypeOffer,
 		Pre: &xdr.LedgerEntry{
@@ -304,22 +309,12 @@ func (s *OffersProcessorTestSuiteLedger) TestProcessUpgradeChange() {
 				Offer: &offer,
 			},
 		},
-		Post: &xdr.LedgerEntry{
-			LastModifiedLedgerSeq: lastModifiedLedgerSeq,
-			Data: xdr.LedgerEntryData{
-				Type:  xdr.LedgerEntryTypeOffer,
-				Offer: &updatedOffer,
-			},
-		},
+		Post: &updatedEntry,
 	})
 	s.Assert().NoError(err)
 
 	// We use LedgerEntryChangesCache so all changes are squashed
-	s.mockBatchInsertBuilder.On(
-		"Add",
-		updatedOffer,
-		lastModifiedLedgerSeq,
-	).Return(nil).Once()
+	s.mockBatchInsertBuilder.On("Add", updatedEntry).Return(nil).Once()
 
 	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
 	s.mockQ.On("CompactOffers", s.sequence-100).Return(int64(0), nil).Once()

--- a/services/horizon/internal/expingest/processors/signer_processor_test.go
+++ b/services/horizon/internal/expingest/processors/signer_processor_test.go
@@ -215,7 +215,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewSigner() {
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
 							Weight: 10,
 						},
@@ -229,11 +229,11 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewSigner() {
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
 							Weight: 10,
 						},
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS"),
 							Weight: 15,
 						},
@@ -351,11 +351,11 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestSignerPreAuthTxRemovedTxFai
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
 							Weight: 10,
 						},
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("TBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWHXL7"),
 							Weight: 15,
 						},
@@ -369,7 +369,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestSignerPreAuthTxRemovedTxFai
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
 							Weight: 10,
 						},
@@ -517,7 +517,7 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestProcessUpgradeChange() {
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
 							Weight: 10,
 						},
@@ -531,11 +531,11 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestProcessUpgradeChange() {
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
 							Weight: 10,
 						},
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS"),
 							Weight: 15,
 						},

--- a/services/horizon/internal/expingest/processors/signers_processor.go
+++ b/services/horizon/internal/expingest/processors/signers_processor.go
@@ -110,7 +110,11 @@ func (p *SignersProcessor) Commit() error {
 		if change.Post != nil {
 			postAccountEntry := change.Post.Data.MustAccount()
 			for signer, weight := range postAccountEntry.SignerSummary() {
-				rowsAffected, err := p.signersQ.CreateAccountSigner(postAccountEntry.AccountId.Address(), signer, weight)
+				rowsAffected, err := p.signersQ.CreateAccountSigner(
+					postAccountEntry.AccountId.Address(),
+					signer,
+					weight,
+				)
 				if err != nil {
 					return errors.Wrap(err, "Error inserting a signer")
 				}

--- a/xdr/account_entry.go
+++ b/xdr/account_entry.go
@@ -1,30 +1,39 @@
 package xdr
 
-func (a *AccountEntry) SignerSummary() map[string]int32 {
+func (account *AccountEntry) SignerSummary() map[string]int32 {
 	ret := map[string]int32{}
 
-	if a.MasterKeyWeight() > 0 {
-		ret[a.AccountId.Address()] = int32(a.Thresholds[0])
+	if account.MasterKeyWeight() > 0 {
+		ret[account.AccountId.Address()] = int32(account.Thresholds[0])
 	}
-	for _, signer := range a.Signers {
+	for _, signer := range account.Signers {
 		ret[signer.Key.Address()] = int32(signer.Weight)
 	}
 
 	return ret
 }
 
-func (a *AccountEntry) MasterKeyWeight() byte {
-	return a.Thresholds.MasterKeyWeight()
+func (account *AccountEntry) MasterKeyWeight() byte {
+	return account.Thresholds.MasterKeyWeight()
 }
 
-func (a *AccountEntry) ThresholdLow() byte {
-	return a.Thresholds.ThresholdLow()
+func (account *AccountEntry) ThresholdLow() byte {
+	return account.Thresholds.ThresholdLow()
 }
 
-func (a *AccountEntry) ThresholdMedium() byte {
-	return a.Thresholds.ThresholdMedium()
+func (account *AccountEntry) ThresholdMedium() byte {
+	return account.Thresholds.ThresholdMedium()
 }
 
-func (a *AccountEntry) ThresholdHigh() byte {
-	return a.Thresholds.ThresholdHigh()
+func (account *AccountEntry) ThresholdHigh() byte {
+	return account.Thresholds.ThresholdHigh()
+}
+
+// Liabilities returns AccountEntry's liabilities
+func (account *AccountEntry) Liabilities() Liabilities {
+	var liabilities Liabilities
+	if account.Ext.V1 != nil {
+		liabilities = account.Ext.V1.Liabilities
+	}
+	return liabilities
 }

--- a/xdr/trust_line_entry.go
+++ b/xdr/trust_line_entry.go
@@ -1,0 +1,10 @@
+package xdr
+
+// Liabilities returns TrustLineEntry's liabilities
+func (trustLine *TrustLineEntry) Liabilities() Liabilities {
+	var liabilities Liabilities
+	if trustLine.Ext.V1 != nil {
+		liabilities = trustLine.Ext.V1.Liabilities
+	}
+	return liabilities
+}


### PR DESCRIPTION
### What

Refactor all methods of `IngestionQ` interface to use `xdr.LedgerEntry`.

### Why

In Protocol 14 more information about the entry is stored in `xdr.LedgerEntry`. To make the code easier to read and limit number of arguments to insert/update methods we use this object as an argument to methods.

In general we should do https://github.com/stellar/go/issues/2578 but it requires a bigger refactoring that this one.