### PR TITLE
expingest: Add placeholder for new operations and verifier

### DIFF
--- a/services/horizon/internal/expingest/processors/effects_processor.go
+++ b/services/horizon/internal/expingest/processors/effects_processor.go
@@ -203,6 +203,12 @@ func (operation *transactionOperationWrapper) effects() (effects []effect, err e
 		effects, err = operation.manageDataEffects()
 	case xdr.OperationTypeBumpSequence:
 		effects, err = operation.bumpSequenceEffects()
+	case xdr.OperationTypeCreateClaimableBalance,
+		xdr.OperationTypeClaimClaimableBalance,
+		xdr.OperationTypeBeginSponsoringFutureReserves,
+		xdr.OperationTypeEndSponsoringFutureReserves,
+		xdr.OperationTypeRevokeSponsorship:
+		// TBD
 	default:
 		return effects, fmt.Errorf("Unknown operation type: %s", op.Body.Type)
 	}

--- a/services/horizon/internal/expingest/processors/operations_processor.go
+++ b/services/horizon/internal/expingest/processors/operations_processor.go
@@ -283,6 +283,12 @@ func (operation *transactionOperationWrapper) Details() map[string]interface{} {
 	case xdr.OperationTypeBumpSequence:
 		op := operation.operation.Body.MustBumpSequenceOp()
 		details["bump_to"] = fmt.Sprintf("%d", op.BumpTo)
+	case xdr.OperationTypeCreateClaimableBalance,
+		xdr.OperationTypeClaimClaimableBalance,
+		xdr.OperationTypeBeginSponsoringFutureReserves,
+		xdr.OperationTypeEndSponsoringFutureReserves,
+		xdr.OperationTypeRevokeSponsorship:
+		// TBD
 	default:
 		panic(fmt.Errorf("Unknown operation type: %s", operation.OperationType()))
 	}
@@ -375,6 +381,12 @@ func (operation *transactionOperationWrapper) Participants() ([]xdr.AccountId, e
 		// the only direct participant is the source_account
 	case xdr.OperationTypeBumpSequence:
 		// the only direct participant is the source_account
+	case xdr.OperationTypeCreateClaimableBalance,
+		xdr.OperationTypeClaimClaimableBalance,
+		xdr.OperationTypeBeginSponsoringFutureReserves,
+		xdr.OperationTypeEndSponsoringFutureReserves,
+		xdr.OperationTypeRevokeSponsorship:
+		// TBD
 	default:
 		return participants, fmt.Errorf("Unknown operation type: %s", op.Body.Type)
 	}

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -531,6 +531,9 @@ func transformEntry(entry xdr.LedgerEntry) (bool, xdr.LedgerEntry) {
 	case xdr.LedgerEntryTypeData:
 		// Full check of data object
 		return false, entry
+	case xdr.LedgerEntryTypeClaimableBalance:
+		// TBD
+		return false, entry
 	default:
 		panic("Invalid type")
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add placeholders for new operations and entry in verifier.

### Why

Without this trying to ingest state or new transactions makes Horizon panic.

### Known limitations

