### PR TITLE
services/horizon: Add `horizon ingest init-genesis-state` command

### DIFF
--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -304,7 +304,8 @@ func (b buildState) run(s *system) (transition, error) {
 
 	// We don't need to prepare range for genesis checkpoint.
 	if b.checkpointLedger != 1 {
-		lockReleased, err := s.maybePrepareRange(b.checkpointLedger)
+		var lockReleased bool
+		lockReleased, err = s.maybePrepareRange(b.checkpointLedger)
 		if err != nil {
 			return nextFailState, err
 		} else if lockReleased {

--- a/services/horizon/internal/expingest/fsm.go
+++ b/services/horizon/internal/expingest/fsm.go
@@ -234,6 +234,7 @@ func (state startState) run(s *system) (transition, error) {
 
 type buildState struct {
 	checkpointLedger uint32
+	stop             bool
 }
 
 func (b buildState) String() string {
@@ -241,12 +242,17 @@ func (b buildState) String() string {
 }
 
 func (b buildState) run(s *system) (transition, error) {
+	var nextFailState = start()
+	if b.stop {
+		nextFailState = stop()
+	}
+
 	if b.checkpointLedger == 0 {
-		return start(), errors.New("unexpected checkpointLedger value")
+		return nextFailState, errors.New("unexpected checkpointLedger value")
 	}
 
 	if err := s.historyQ.Begin(); err != nil {
-		return start(), errors.Wrap(err, "Error starting a transaction")
+		return nextFailState, errors.Wrap(err, "Error starting a transaction")
 	}
 	defer s.historyQ.Rollback()
 
@@ -254,12 +260,12 @@ func (b buildState) run(s *system) (transition, error) {
 	// are blocked.
 	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
 	if err != nil {
-		return start(), errors.Wrap(err, getLastIngestedErrMsg)
+		return nextFailState, errors.Wrap(err, getLastIngestedErrMsg)
 	}
 
 	ingestVersion, err := s.historyQ.GetExpIngestVersion()
 	if err != nil {
-		return start(), errors.Wrap(err, getExpIngestVersionErrMsg)
+		return nextFailState, errors.Wrap(err, getExpIngestVersionErrMsg)
 	}
 
 	// Double check if we should proceed with state ingestion. It's possible that
@@ -267,7 +273,7 @@ func (b buildState) run(s *system) (transition, error) {
 	// but it's first to complete the task.
 	if ingestVersion == CurrentVersion && lastIngestedLedger > 0 {
 		log.Info("Another instance completed `buildState`. Skipping...")
-		return start(), nil
+		return nextFailState, nil
 	}
 
 	if err = s.updateCursor(b.checkpointLedger - 1); err != nil {
@@ -280,27 +286,30 @@ func (b buildState) run(s *system) (transition, error) {
 	// Clear last_ingested_ledger in key value store
 	err = s.historyQ.UpdateLastLedgerExpIngest(0)
 	if err != nil {
-		return start(), errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
+		return nextFailState, errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
 	}
 
 	// Clear invalid state in key value store. It's possible that upgraded
 	// ingestion is fixing it.
 	err = s.historyQ.UpdateExpStateInvalid(false)
 	if err != nil {
-		return start(), errors.Wrap(err, updateExpStateInvalidErrMsg)
+		return nextFailState, errors.Wrap(err, updateExpStateInvalidErrMsg)
 	}
 
 	// State tables should be empty.
 	err = s.historyQ.TruncateExpingestStateTables()
 	if err != nil {
-		return start(), errors.Wrap(err, "Error clearing ingest tables")
+		return nextFailState, errors.Wrap(err, "Error clearing ingest tables")
 	}
 
-	lockReleased, err := s.maybePrepareRange(b.checkpointLedger)
-	if err != nil {
-		return start(), err
-	} else if lockReleased {
-		return startSuggestedCheckpoint(b.checkpointLedger), nil
+	// We don't need to prepare range for genesis checkpoint.
+	if b.checkpointLedger != 1 {
+		lockReleased, err := s.maybePrepareRange(b.checkpointLedger)
+		if err != nil {
+			return nextFailState, err
+		} else if lockReleased {
+			return startSuggestedCheckpoint(b.checkpointLedger), nil
+		}
 	}
 
 	log.WithFields(logpkg.F{
@@ -310,15 +319,15 @@ func (b buildState) run(s *system) (transition, error) {
 
 	stats, err := s.runner.RunHistoryArchiveIngestion(b.checkpointLedger)
 	if err != nil {
-		return start(), errors.Wrap(err, "Error ingesting history archive")
+		return nextFailState, errors.Wrap(err, "Error ingesting history archive")
 	}
 
 	if err = s.historyQ.UpdateExpIngestVersion(CurrentVersion); err != nil {
-		return start(), errors.Wrap(err, "Error updating expingest version")
+		return nextFailState, errors.Wrap(err, "Error updating expingest version")
 	}
 
 	if err = s.completeIngestion(b.checkpointLedger); err != nil {
-		return start(), err
+		return nextFailState, err
 	}
 
 	log.
@@ -329,6 +338,9 @@ func (b buildState) run(s *system) (transition, error) {
 		}).
 		Info("Processed state")
 
+	if b.stop {
+		return stop(), nil
+	}
 	// If successful, continue from the next ledger
 	return resume(b.checkpointLedger), nil
 }

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -100,6 +100,7 @@ type System interface {
 	StressTest(numTransactions, changesPerTransaction int) error
 	VerifyRange(fromLedger, toLedger uint32, verifyState bool) error
 	ReingestRange(fromLedger, toLedger uint32, force bool) error
+	BuildGenesisState() error
 	Shutdown()
 }
 
@@ -284,6 +285,15 @@ func (s *system) ReingestRange(fromLedger, toLedger uint32, force bool) error {
 		err = run()
 	}
 	return err
+}
+
+// BuildGenesisState runs the ingestion pipeline on genesis ledger. Transitions
+// to stopState when done.
+func (s *system) BuildGenesisState() error {
+	return s.runStateMachine(buildState{
+		checkpointLedger: 1,
+		stop:             true,
+	})
 }
 
 func (s *system) runStateMachine(cur stateMachineNode) error {

--- a/services/horizon/internal/expingest/main_test.go
+++ b/services/horizon/internal/expingest/main_test.go
@@ -469,6 +469,11 @@ func (m *mockSystem) ReingestRange(fromLedger, toLedger uint32, force bool) erro
 	return args.Error(0)
 }
 
+func (m *mockSystem) BuildGenesisState() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 func (m *mockSystem) Shutdown() {
 	m.Called()
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Adds `horizon ingest init-genesis-state` command that ingest state as of genesis ledger (seq=1).

### Why

Horizon is using the latest History Archive State for checking the latest checkpoint ledger however Stellar-Core does not publish HAS until ledger which sequence equals 63. Because of this, when starting a standalone network Horizon needs to wait around 5 minutes/63 ledgers to start ingesting. This command should solve this issue by ingesting the genesis ledger of a given network so Horizon can start ingestion without waiting for Stellar-Core to publish the first checkpoint.

Required by https://github.com/stellar/go/issues/2812.

### Known limitations

There is a code that inits Stellar-Core setting so `ingest.System` can create a `ledgerbackend` however this is not needed because `ledgerbackend` is not used when ingesting genesis ledger. This problem also occurs in `stress-test`command. I didn't want to fix this here to make this PR simple. Should be fixed in another PR in the future.
