### PR TITLE
services/horizon/internal/expingest: Ingest CAP23 Operations details and participants.

### DIFF
--- a/services/horizon/internal/expingest/processors/operations_processor.go
+++ b/services/horizon/internal/expingest/processors/operations_processor.go
@@ -296,8 +296,15 @@ func (operation *transactionOperationWrapper) Details() map[string]interface{} {
 			})
 		}
 		details["claimants"] = claimants
-	case xdr.OperationTypeClaimClaimableBalance,
-		xdr.OperationTypeBeginSponsoringFutureReserves,
+	case xdr.OperationTypeClaimClaimableBalance:
+		op := operation.operation.Body.MustClaimClaimableBalanceOp()
+		balanceID, err := xdr.MarshalBase64(op.BalanceId)
+		if err != nil {
+			panic(fmt.Errorf("Invalid balanceId in op: %d", operation.index))
+		}
+		details["balance_id"] = balanceID
+		details["claimant"] = source.Address()
+	case xdr.OperationTypeBeginSponsoringFutureReserves,
 		xdr.OperationTypeEndSponsoringFutureReserves,
 		xdr.OperationTypeRevokeSponsorship:
 		// TBD
@@ -397,8 +404,9 @@ func (operation *transactionOperationWrapper) Participants() ([]xdr.AccountId, e
 		for _, c := range op.Body.MustCreateClaimableBalanceOp().Claimants {
 			participants = append(participants, c.MustV0().Destination)
 		}
-	case xdr.OperationTypeClaimClaimableBalance,
-		xdr.OperationTypeBeginSponsoringFutureReserves,
+	case xdr.OperationTypeClaimClaimableBalance:
+		// the only direct participant is the source_account
+	case xdr.OperationTypeBeginSponsoringFutureReserves,
 		xdr.OperationTypeEndSponsoringFutureReserves,
 		xdr.OperationTypeRevokeSponsorship:
 		// TBD

--- a/services/horizon/internal/expingest/processors/operations_processor.go
+++ b/services/horizon/internal/expingest/processors/operations_processor.go
@@ -283,8 +283,20 @@ func (operation *transactionOperationWrapper) Details() map[string]interface{} {
 	case xdr.OperationTypeBumpSequence:
 		op := operation.operation.Body.MustBumpSequenceOp()
 		details["bump_to"] = fmt.Sprintf("%d", op.BumpTo)
-	case xdr.OperationTypeCreateClaimableBalance,
-		xdr.OperationTypeClaimClaimableBalance,
+	case xdr.OperationTypeCreateClaimableBalance:
+		op := operation.operation.Body.MustCreateClaimableBalanceOp()
+		details["asset"] = op.Asset.StringCanonical()
+		details["amount"] = amount.String(op.Amount)
+		var claimants history.Claimants
+		for _, c := range op.Claimants {
+			cv0 := c.MustV0()
+			claimants = append(claimants, history.Claimant{
+				Destination: cv0.Destination.Address(),
+				Predicate:   cv0.Predicate,
+			})
+		}
+		details["claimants"] = claimants
+	case xdr.OperationTypeClaimClaimableBalance,
 		xdr.OperationTypeBeginSponsoringFutureReserves,
 		xdr.OperationTypeEndSponsoringFutureReserves,
 		xdr.OperationTypeRevokeSponsorship:

--- a/services/horizon/internal/expingest/processors/operations_processor.go
+++ b/services/horizon/internal/expingest/processors/operations_processor.go
@@ -393,8 +393,11 @@ func (operation *transactionOperationWrapper) Participants() ([]xdr.AccountId, e
 		// the only direct participant is the source_account
 	case xdr.OperationTypeBumpSequence:
 		// the only direct participant is the source_account
-	case xdr.OperationTypeCreateClaimableBalance,
-		xdr.OperationTypeClaimClaimableBalance,
+	case xdr.OperationTypeCreateClaimableBalance:
+		for _, c := range op.Body.MustCreateClaimableBalanceOp().Claimants {
+			participants = append(participants, c.MustV0().Destination)
+		}
+	case xdr.OperationTypeClaimClaimableBalance,
 		xdr.OperationTypeBeginSponsoringFutureReserves,
 		xdr.OperationTypeEndSponsoringFutureReserves,
 		xdr.OperationTypeRevokeSponsorship:

--- a/services/horizon/internal/expingest/processors/transaction_operation_wrapper_test.go
+++ b/services/horizon/internal/expingest/processors/transaction_operation_wrapper_test.go
@@ -977,7 +977,8 @@ func (s *CreateClaimableBalanceOpTestSuite) SetupTest() {
 						{
 							Type: xdr.ClaimantTypeClaimantTypeV0,
 							V0: &xdr.ClaimantV0{
-								Destination: xdr.MustAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
+								Destination: xdr.MustAddress("GD5OVB6FKDV7P7SOJ5UB2BPLBL4XGSHPYHINR5355SY3RSXLT2BZWAKY"),
+
 								Predicate: xdr.ClaimPredicate{
 									Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
 								},
@@ -998,7 +999,7 @@ func (s *CreateClaimableBalanceOpTestSuite) SetupTest() {
 						{
 							Type: xdr.ClaimantTypeClaimantTypeV0,
 							V0: &xdr.ClaimantV0{
-								Destination: xdr.MustAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
+								Destination: xdr.MustAddress("GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2"),
 								Predicate: xdr.ClaimPredicate{
 									Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
 								},
@@ -1007,7 +1008,7 @@ func (s *CreateClaimableBalanceOpTestSuite) SetupTest() {
 						{
 							Type: xdr.ClaimantTypeClaimantTypeV0,
 							V0: &xdr.ClaimantV0{
-								Destination: xdr.MustAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
+								Destination: xdr.MustAddress("GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3"),
 								Predicate: xdr.ClaimPredicate{
 									Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
 								},
@@ -1019,7 +1020,7 @@ func (s *CreateClaimableBalanceOpTestSuite) SetupTest() {
 		},
 	}
 }
-func (s *CreateClaimableBalanceOpTestSuite) TestOperationDetails() {
+func (s *CreateClaimableBalanceOpTestSuite) TestDetails() {
 	testCases := []struct {
 		desc     string
 		op       xdr.Operation
@@ -1033,7 +1034,7 @@ func (s *CreateClaimableBalanceOpTestSuite) TestOperationDetails() {
 				"amount": "10.0000000",
 				"claimants": history.Claimants{
 					history.Claimant{
-						Destination: "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+						Destination: "GD5OVB6FKDV7P7SOJ5UB2BPLBL4XGSHPYHINR5355SY3RSXLT2BZWAKY",
 						Predicate: xdr.ClaimPredicate{
 							Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
 						},
@@ -1049,13 +1050,13 @@ func (s *CreateClaimableBalanceOpTestSuite) TestOperationDetails() {
 				"amount": "20.0000000",
 				"claimants": history.Claimants{
 					history.Claimant{
-						Destination: "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+						Destination: "GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2",
 						Predicate: xdr.ClaimPredicate{
 							Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
 						},
 					},
 					history.Claimant{
-						Destination: "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+						Destination: "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3",
 						Predicate: xdr.ClaimPredicate{
 							Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
 						},
@@ -1074,6 +1075,57 @@ func (s *CreateClaimableBalanceOpTestSuite) TestOperationDetails() {
 			}
 
 			s.Assert().Equal(tc.expected, operation.Details())
+		})
+	}
+}
+
+func (s *CreateClaimableBalanceOpTestSuite) TestParticipants() {
+	testCases := []struct {
+		desc     string
+		op       xdr.Operation
+		expected []xdr.AccountId
+	}{
+		{
+			desc: "claimable balance with a single claimant",
+			op:   s.ops[0],
+			expected: []xdr.AccountId{
+				xdr.MustAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
+				xdr.MustAddress("GD5OVB6FKDV7P7SOJ5UB2BPLBL4XGSHPYHINR5355SY3RSXLT2BZWAKY"),
+			},
+		},
+		{
+			desc: "claimable balance with a multiple claimants",
+			op:   s.ops[1],
+			expected: []xdr.AccountId{
+				xdr.MustAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
+				xdr.MustAddress("GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2"),
+				xdr.MustAddress("GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3"),
+			},
+		},
+	}
+	for _, tc := range testCases {
+		s.T().Run(tc.desc, func(t *testing.T) {
+			operation := transactionOperationWrapper{
+				index:          0,
+				transaction:    io.LedgerTransaction{},
+				operation:      tc.op,
+				ledgerSequence: 1,
+			}
+
+			participants, err := operation.Participants()
+			s.Assert().Greater(len(participants), 1)
+			s.Assert().NoError(err)
+
+			result := map[string]xdr.AccountId{}
+
+			for _, account := range participants {
+				result[account.Address()] = account
+			}
+			for _, account := range tc.expected {
+				delete(result, account.Address())
+			}
+
+			s.Assert().Empty(result)
 		})
 	}
 }

--- a/services/horizon/internal/expingest/processors/transaction_operation_wrapper_test.go
+++ b/services/horizon/internal/expingest/processors/transaction_operation_wrapper_test.go
@@ -1129,7 +1129,63 @@ func (s *CreateClaimableBalanceOpTestSuite) TestParticipants() {
 		})
 	}
 }
-
 func TestCreateClaimableBalanceOpTestSuite(t *testing.T) {
 	suite.Run(t, new(CreateClaimableBalanceOpTestSuite))
+}
+
+type ClaimClaimableBalanceOpTestSuite struct {
+	suite.Suite
+	op        xdr.Operation
+	balanceID string
+}
+
+func (s *ClaimClaimableBalanceOpTestSuite) SetupTest() {
+	s.balanceID = "AAAAANoNV9p9SFDn/BDSqdDrxzH3r7QFdMAzlbF9SRSbkfW+"
+	aid := xdr.MustAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD")
+	source := aid.ToMuxedAccount()
+	var balanceID xdr.ClaimableBalanceId
+	xdr.SafeUnmarshalBase64(s.balanceID, &balanceID)
+	s.op = xdr.Operation{
+		SourceAccount: &source,
+		Body: xdr.OperationBody{
+			Type: xdr.OperationTypeClaimClaimableBalance,
+			ClaimClaimableBalanceOp: &xdr.ClaimClaimableBalanceOp{
+				BalanceId: balanceID,
+			},
+		},
+	}
+}
+func (s *ClaimClaimableBalanceOpTestSuite) TestDetails() {
+	expected := map[string]interface{}{
+		"claimant":   "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+		"balance_id": s.balanceID,
+	}
+
+	operation := transactionOperationWrapper{
+		index:          0,
+		transaction:    io.LedgerTransaction{},
+		operation:      s.op,
+		ledgerSequence: 1,
+	}
+
+	s.Assert().Equal(expected, operation.Details())
+}
+
+func (s *ClaimClaimableBalanceOpTestSuite) TestParticipants() {
+	operation := transactionOperationWrapper{
+		index:          0,
+		transaction:    io.LedgerTransaction{},
+		operation:      s.op,
+		ledgerSequence: 1,
+	}
+
+	participants, err := operation.Participants()
+	s.Assert().NoError(err)
+	s.Assert().Equal([]xdr.AccountId{
+		xdr.MustAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
+	}, participants)
+}
+
+func TestClaimClaimableBalanceOpTestSuite(t *testing.T) {
+	suite.Run(t, new(ClaimClaimableBalanceOpTestSuite))
 }

--- a/xdr/asset.go
+++ b/xdr/asset.go
@@ -254,6 +254,20 @@ func (a Asset) String() string {
 	return fmt.Sprintf("%s/%s/%s", t, c, i)
 }
 
+// StringCanonical returns a display friendly form of the asset following its
+// canonical representation
+func (a Asset) StringCanonical() string {
+	var t, c, i string
+
+	a.MustExtract(&t, &c, &i)
+
+	if a.Type == AssetTypeAssetTypeNative {
+		return t
+	}
+
+	return fmt.Sprintf("%s:%s", c, i)
+}
+
 // MarshalBinaryCompress marshals Asset to []byte but unlike
 // MarshalBinary() it removes all unnecessary bytes, exploting the fact
 // that XDR is padding data to 4 bytes in union discriminants etc.

--- a/xdr/asset_test.go
+++ b/xdr/asset_test.go
@@ -104,6 +104,39 @@ var _ = Describe("xdr.Asset#String()", func() {
 	})
 })
 
+var _ = Describe("xdr.Asset#StringCanonical()", func() {
+	var asset Asset
+
+	Context("asset is native", func() {
+		BeforeEach(func() {
+			var err error
+			asset, err = NewAsset(AssetTypeAssetTypeNative, nil)
+			Expect(err).To(BeNil())
+		})
+
+		It("returns 'native'", func() {
+			Expect(asset.StringCanonical()).To(Equal("native"))
+		})
+	})
+
+	Context("asset is credit_alphanum4", func() {
+		BeforeEach(func() {
+			var err error
+			an := AssetAlphaNum4{}
+			err = an.Issuer.SetAddress("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+			Expect(err).To(BeNil())
+			copy(an.AssetCode[:], []byte("USD"))
+
+			asset, err = NewAsset(AssetTypeAssetTypeCreditAlphanum4, an)
+			Expect(err).To(BeNil())
+		})
+
+		It("returns 'type/code/issuer'", func() {
+			Expect(asset.StringCanonical()).To(Equal("USD:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"))
+		})
+	})
+})
+
 var _ = Describe("xdr.Asset#Equals()", func() {
 	var (
 		issuer1       AccountId

--- a/xdr/asset_test.go
+++ b/xdr/asset_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/stellar/go/xdr"
 	. "github.com/stellar/go/xdr"
 )
 
@@ -105,33 +106,16 @@ var _ = Describe("xdr.Asset#String()", func() {
 })
 
 var _ = Describe("xdr.Asset#StringCanonical()", func() {
-	var asset Asset
-
 	Context("asset is native", func() {
-		BeforeEach(func() {
-			var err error
-			asset, err = NewAsset(AssetTypeAssetTypeNative, nil)
-			Expect(err).To(BeNil())
-		})
-
 		It("returns 'native'", func() {
+			asset := xdr.MustNewNativeAsset()
 			Expect(asset.StringCanonical()).To(Equal("native"))
 		})
 	})
 
-	Context("asset is credit_alphanum4", func() {
-		BeforeEach(func() {
-			var err error
-			an := AssetAlphaNum4{}
-			err = an.Issuer.SetAddress("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
-			Expect(err).To(BeNil())
-			copy(an.AssetCode[:], []byte("USD"))
-
-			asset, err = NewAsset(AssetTypeAssetTypeCreditAlphanum4, an)
-			Expect(err).To(BeNil())
-		})
-
-		It("returns 'type/code/issuer'", func() {
+	Context("asset is issued", func() {
+		It("returns 'code:issuer'", func() {
+			asset := xdr.MustNewCreditAsset("USD", "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
 			Expect(asset.StringCanonical()).To(Equal("USD:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"))
 		})
 	})

--- a/xdr/asset_test.go
+++ b/xdr/asset_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/stellar/go/xdr"
 	. "github.com/stellar/go/xdr"
 )
 
@@ -105,21 +105,13 @@ var _ = Describe("xdr.Asset#String()", func() {
 	})
 })
 
-var _ = Describe("xdr.Asset#StringCanonical()", func() {
-	Context("asset is native", func() {
-		It("returns 'native'", func() {
-			asset := xdr.MustNewNativeAsset()
-			Expect(asset.StringCanonical()).To(Equal("native"))
-		})
-	})
+func TestStringCanonical(t *testing.T) {
+	asset := MustNewNativeAsset()
+	require.Equal(t, "native", asset.StringCanonical())
 
-	Context("asset is issued", func() {
-		It("returns 'code:issuer'", func() {
-			asset := xdr.MustNewCreditAsset("USD", "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
-			Expect(asset.StringCanonical()).To(Equal("USD:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"))
-		})
-	})
-})
+	asset = MustNewCreditAsset("USD", "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	require.Equal(t, "USD:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H", asset.StringCanonical())
+}
 
 var _ = Describe("xdr.Asset#Equals()", func() {
 	var (


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Ingest details and participants involved in `CreateClaimableBalanceOp` and `ClaimClaimableBalanceOp`.

### Why

CAP23 introduces 2 new operations, we need to ingest the details and participants involved in each operation. 

Fix #2886.



### Known limitations

[TODO or N/A]
