### PR TITLE
services/horizon/internal/expingest: Ingest CAP23 Operations effects.

### DIFF
--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -119,6 +119,9 @@ const (
 
 	// EffectClaimableBalanceClaimantCreated occurs when a claimable balance is created
 	EffectClaimableBalanceClaimantCreated EffectType = 51 // from create_claimable_balance
+
+	// EffectClaimableBalanceClaimed occurs when a claimable balance is claimed
+	EffectClaimableBalanceClaimed EffectType = 52 // from claim_claimable_balance
 )
 
 // Account is a row of data from the `history_accounts` table

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -114,6 +114,11 @@ const (
 	// EffectSequenceBumped occurs when an account bumps their sequence number
 	EffectSequenceBumped EffectType = 43 // from bump_sequence
 
+	// EffectClaimableBalanceCreated occurs when a claimable balance is created
+	EffectClaimableBalanceCreated EffectType = 50 // from create_claimable_balance
+
+	// EffectClaimableBalanceClaimantCreated occurs when a claimable balance is created
+	EffectClaimableBalanceClaimantCreated EffectType = 51 // from create_claimable_balance
 )
 
 // Account is a row of data from the `history_accounts` table

--- a/services/horizon/internal/expingest/processors/effects_processor.go
+++ b/services/horizon/internal/expingest/processors/effects_processor.go
@@ -203,8 +203,9 @@ func (operation *transactionOperationWrapper) effects() (effects []effect, err e
 		effects, err = operation.manageDataEffects()
 	case xdr.OperationTypeBumpSequence:
 		effects, err = operation.bumpSequenceEffects()
-	case xdr.OperationTypeCreateClaimableBalance,
-		xdr.OperationTypeClaimClaimableBalance,
+	case xdr.OperationTypeCreateClaimableBalance:
+		effects, err = operation.createClaimableBalanceEffects()
+	case xdr.OperationTypeClaimClaimableBalance,
 		xdr.OperationTypeBeginSponsoringFutureReserves,
 		xdr.OperationTypeEndSponsoringFutureReserves,
 		xdr.OperationTypeRevokeSponsorship:
@@ -688,6 +689,50 @@ func (operation *transactionOperationWrapper) bumpSequenceEffects() ([]effect, e
 		}
 
 		break
+	}
+
+	return effects.effects, nil
+}
+
+func (operation *transactionOperationWrapper) createClaimableBalanceEffects() ([]effect, error) {
+	op := operation.operation.Body.MustCreateClaimableBalanceOp()
+	effects := effectsWrapper{
+		effects:   []effect{},
+		operation: operation,
+	}
+
+	result := operation.OperationResult().MustCreateClaimableBalanceResult()
+	balanceID, err := xdr.MarshalBase64(result.BalanceId)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid balanceId in op: %d", operation.index)
+	}
+
+	effects.add(
+		operation.SourceAccount().Address(),
+		history.EffectClaimableBalanceCreated,
+		map[string]interface{}{
+			"balance_id": balanceID,
+			"amount":     amount.String(op.Amount),
+			"asset":      op.Asset.StringCanonical(),
+		},
+	)
+
+	for _, c := range op.Claimants {
+		cv0 := c.MustV0()
+		predicate, err := xdr.MarshalBase64(cv0.Predicate)
+		if err != nil {
+			panic(fmt.Errorf("Invalid predicate in op: %d", operation.index))
+		}
+		effects.add(
+			cv0.Destination.Address(),
+			history.EffectClaimableBalanceClaimantCreated,
+			map[string]interface{}{
+				"balance_id": balanceID,
+				"amount":     amount.String(op.Amount),
+				"asset":      op.Asset.StringCanonical(),
+				"predicate":  predicate,
+			},
+		)
 	}
 
 	return effects.effects, nil

--- a/services/horizon/internal/expingest/processors/effects_processor.go
+++ b/services/horizon/internal/expingest/processors/effects_processor.go
@@ -736,6 +736,16 @@ func (operation *transactionOperationWrapper) createClaimableBalanceEffects() ([
 		)
 	}
 
+	details := map[string]interface{}{
+		"amount": amount.String(op.Amount),
+	}
+	assetDetails(details, op.Asset, "")
+	effects.add(
+		operation.SourceAccount().Address(),
+		history.EffectAccountDebited,
+		details,
+	)
+
 	return effects.effects, nil
 }
 

--- a/services/horizon/internal/expingest/processors/effects_processor.go
+++ b/services/horizon/internal/expingest/processors/effects_processor.go
@@ -705,7 +705,7 @@ func (operation *transactionOperationWrapper) createClaimableBalanceEffects() ([
 	result := operation.OperationResult().MustCreateClaimableBalanceResult()
 	balanceID, err := xdr.MarshalBase64(result.BalanceId)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid balanceId in op: %d", operation.index)
+		return nil, errors.Wrapf(err, "Invalid balanceId in op: %d", operation.index)
 	}
 
 	effects.add(
@@ -722,7 +722,7 @@ func (operation *transactionOperationWrapper) createClaimableBalanceEffects() ([
 		cv0 := c.MustV0()
 		predicate, err := xdr.MarshalBase64(cv0.Predicate)
 		if err != nil {
-			panic(fmt.Errorf("Invalid predicate in op: %d", operation.index))
+			panic(errors.Wrapf(err, "Invalid predicate in op: %d", operation.index))
 		}
 		effects.add(
 			cv0.Destination.Address(),

--- a/services/horizon/internal/expingest/processors/effects_processor.go
+++ b/services/horizon/internal/expingest/processors/effects_processor.go
@@ -205,8 +205,9 @@ func (operation *transactionOperationWrapper) effects() (effects []effect, err e
 		effects, err = operation.bumpSequenceEffects()
 	case xdr.OperationTypeCreateClaimableBalance:
 		effects, err = operation.createClaimableBalanceEffects()
-	case xdr.OperationTypeClaimClaimableBalance,
-		xdr.OperationTypeBeginSponsoringFutureReserves,
+	case xdr.OperationTypeClaimClaimableBalance:
+		effects, err = operation.claimClaimableBalanceEffects()
+	case xdr.OperationTypeBeginSponsoringFutureReserves,
 		xdr.OperationTypeEndSponsoringFutureReserves,
 		xdr.OperationTypeRevokeSponsorship:
 		// TBD
@@ -734,6 +735,66 @@ func (operation *transactionOperationWrapper) createClaimableBalanceEffects() ([
 			},
 		)
 	}
+
+	return effects.effects, nil
+}
+
+func (operation *transactionOperationWrapper) claimClaimableBalanceEffects() ([]effect, error) {
+	op := operation.operation.Body.MustClaimClaimableBalanceOp()
+	effects := effectsWrapper{
+		effects:   []effect{},
+		operation: operation,
+	}
+
+	balanceID, err := xdr.MarshalBase64(op.BalanceId)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid balanceId in op: %d", operation.index)
+	}
+
+	changes, err := operation.transaction.GetOperationChanges(operation.index)
+	if err != nil {
+		return effects.effects, err
+	}
+
+	var cBalance xdr.ClaimableBalanceEntry
+	found := false
+
+	for _, change := range changes {
+		if change.Type != xdr.LedgerEntryTypeClaimableBalance {
+			continue
+		}
+
+		if change.Pre != nil && change.Post == nil {
+			cBalance = change.Pre.Data.MustClaimableBalance()
+			if cBalance.BalanceId == op.BalanceId {
+				found = true
+				break
+			}
+		}
+	}
+
+	if !found {
+		return nil, fmt.Errorf("Change not found for balanceId : %s", balanceID)
+	}
+
+	effects.add(
+		operation.SourceAccount().Address(),
+		history.EffectClaimableBalanceClaimed,
+		map[string]interface{}{
+			"amount":     amount.String(cBalance.Amount),
+			"asset":      cBalance.Asset.StringCanonical(),
+			"balance_id": balanceID,
+		},
+	)
+	details := map[string]interface{}{
+		"amount": amount.String(cBalance.Amount),
+	}
+	assetDetails(details, cBalance.Asset, "")
+	effects.add(
+		operation.SourceAccount().Address(),
+		history.EffectAccountCredited,
+		details,
+	)
 
 	return effects.effects, nil
 }

--- a/services/horizon/internal/expingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/expingest/processors/effects_processor_test.go
@@ -1612,3 +1612,254 @@ func (s *CreateClaimableBalanceEffectsTestSuite) TestEffects() {
 func TestCreateClaimableBalanceEffectsTestSuite(t *testing.T) {
 	suite.Run(t, new(CreateClaimableBalanceEffectsTestSuite))
 }
+
+type ClaimClaimableBalanceEffectsTestSuite struct {
+	suite.Suite
+	ops []xdr.Operation
+	tx  io.LedgerTransaction
+}
+
+func (s *ClaimClaimableBalanceEffectsTestSuite) SetupTest() {
+	var balanceIDOp1, balanceIDOp2 xdr.ClaimableBalanceId
+	xdr.SafeUnmarshalBase64("AAAAANoNV9p9SFDn/BDSqdDrxzH3r7QFdMAzlbF9SRSbkfW+", &balanceIDOp1)
+	xdr.SafeUnmarshalBase64("AAAAALHcX0PDa9UefSAzitC6vQOUr802phH8OF2ahLzg6j1D", &balanceIDOp2)
+
+	aid := xdr.MustAddress("GD5OVB6FKDV7P7SOJ5UB2BPLBL4XGSHPYHINR5355SY3RSXLT2BZWAKY")
+	claimant1 := aid.ToMuxedAccount()
+	aid = xdr.MustAddress("GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2")
+	claimant2 := aid.ToMuxedAccount()
+	s.ops = []xdr.Operation{
+		{
+			SourceAccount: &claimant1,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypeClaimClaimableBalance,
+				ClaimClaimableBalanceOp: &xdr.ClaimClaimableBalanceOp{
+					BalanceId: balanceIDOp1,
+				},
+			},
+		},
+		{
+			SourceAccount: &claimant2,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypeClaimClaimableBalance,
+				ClaimClaimableBalanceOp: &xdr.ClaimClaimableBalanceOp{
+					BalanceId: balanceIDOp2,
+				},
+			},
+		},
+	}
+
+	s.tx = io.LedgerTransaction{
+		Index: 0,
+		Envelope: xdr.TransactionEnvelope{
+			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+			V1: &xdr.TransactionV1Envelope{
+				Tx: xdr.Transaction{
+					Operations: s.ops,
+				},
+			},
+		},
+		Result: xdr.TransactionResultPair{
+			Result: xdr.TransactionResult{
+				Result: xdr.TransactionResultResult{
+					Results: &[]xdr.OperationResult{
+						{
+							Code: xdr.OperationResultCodeOpInner,
+							Tr: &xdr.OperationResultTr{
+								Type: xdr.OperationTypeClaimClaimableBalance,
+								ClaimClaimableBalanceResult: &xdr.ClaimClaimableBalanceResult{
+									Code: xdr.ClaimClaimableBalanceResultCodeClaimClaimableBalanceSuccess,
+								},
+							},
+						},
+						{
+							Code: xdr.OperationResultCodeOpInner,
+							Tr: &xdr.OperationResultTr{
+								Type: xdr.OperationTypeClaimClaimableBalance,
+								ClaimClaimableBalanceResult: &xdr.ClaimClaimableBalanceResult{
+									Code: xdr.ClaimClaimableBalanceResultCodeClaimClaimableBalanceSuccess,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		FeeChanges: xdr.LedgerEntryChanges{},
+		Meta: xdr.TransactionMeta{
+			V: 2,
+			V2: &xdr.TransactionMetaV2{
+				Operations: []xdr.OperationMeta{
+					// op1
+					{
+						Changes: xdr.LedgerEntryChanges{
+							xdr.LedgerEntryChange{
+								Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+								State: &xdr.LedgerEntry{
+									Data: xdr.LedgerEntryData{
+										Type: xdr.LedgerEntryTypeClaimableBalance,
+										ClaimableBalance: &xdr.ClaimableBalanceEntry{
+											BalanceId: balanceIDOp1,
+											Amount:    xdr.Int64(100000000),
+											Asset:     xdr.MustNewNativeAsset(),
+											Claimants: []xdr.Claimant{
+												{
+													Type: xdr.ClaimantTypeClaimantTypeV0,
+													V0: &xdr.ClaimantV0{
+														Destination: xdr.MustAddress("GD5OVB6FKDV7P7SOJ5UB2BPLBL4XGSHPYHINR5355SY3RSXLT2BZWAKY"),
+
+														Predicate: xdr.ClaimPredicate{
+															Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							xdr.LedgerEntryChange{
+								Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+								Removed: &xdr.LedgerKey{
+									Type: xdr.LedgerEntryTypeClaimableBalance,
+									ClaimableBalance: &xdr.LedgerKeyClaimableBalance{
+										BalanceId: balanceIDOp1,
+									},
+								},
+							},
+						},
+					},
+					// op2
+					{
+						Changes: xdr.LedgerEntryChanges{
+							xdr.LedgerEntryChange{
+								Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+								State: &xdr.LedgerEntry{
+									Data: xdr.LedgerEntryData{
+										Type: xdr.LedgerEntryTypeClaimableBalance,
+										ClaimableBalance: &xdr.ClaimableBalanceEntry{
+											BalanceId: balanceIDOp2,
+											Amount:    xdr.Int64(200000000),
+											Asset:     xdr.MustNewCreditAsset("USD", "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
+											Claimants: []xdr.Claimant{
+												{
+													Type: xdr.ClaimantTypeClaimantTypeV0,
+													V0: &xdr.ClaimantV0{
+														Destination: xdr.MustAddress("GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2"),
+														Predicate: xdr.ClaimPredicate{
+															Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
+														},
+													},
+												},
+												{
+													Type: xdr.ClaimantTypeClaimantTypeV0,
+													V0: &xdr.ClaimantV0{
+														Destination: xdr.MustAddress("GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3"),
+														Predicate: xdr.ClaimPredicate{
+															Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							xdr.LedgerEntryChange{
+								Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+								Removed: &xdr.LedgerKey{
+									Type: xdr.LedgerEntryTypeClaimableBalance,
+									ClaimableBalance: &xdr.LedgerKeyClaimableBalance{
+										BalanceId: balanceIDOp2,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func (s *ClaimClaimableBalanceEffectsTestSuite) TestEffects() {
+	testCases := []struct {
+		desc     string
+		op       xdr.Operation
+		expected []effect
+	}{
+		{
+			desc: "claimable balance with native asset",
+			op:   s.ops[0],
+			expected: []effect{
+				{
+					address: "GD5OVB6FKDV7P7SOJ5UB2BPLBL4XGSHPYHINR5355SY3RSXLT2BZWAKY",
+					details: map[string]interface{}{
+						"asset":      "native",
+						"amount":     "10.0000000",
+						"balance_id": "AAAAANoNV9p9SFDn/BDSqdDrxzH3r7QFdMAzlbF9SRSbkfW+",
+					},
+					effectType:  history.EffectClaimableBalanceClaimed,
+					operationID: int64(4294967297),
+					order:       uint32(1),
+				},
+				{
+					address: "GD5OVB6FKDV7P7SOJ5UB2BPLBL4XGSHPYHINR5355SY3RSXLT2BZWAKY",
+					details: map[string]interface{}{
+						"asset_type": "native",
+						"amount":     "10.0000000",
+					},
+					effectType:  history.EffectAccountCredited,
+					operationID: int64(4294967297),
+					order:       uint32(2),
+				},
+			},
+		},
+		{
+			desc: "claimable balance with issued asset",
+			op:   s.ops[1],
+			expected: []effect{
+				{
+					address: "GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2",
+					details: map[string]interface{}{
+						"asset":      "USD:GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+						"amount":     "20.0000000",
+						"balance_id": "AAAAALHcX0PDa9UefSAzitC6vQOUr802phH8OF2ahLzg6j1D",
+					},
+					effectType:  history.EffectClaimableBalanceClaimed,
+					operationID: int64(4294967298),
+					order:       uint32(1),
+				},
+				{
+					address: "GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2",
+					details: map[string]interface{}{
+						"asset_code":   "USD",
+						"asset_type":   "credit_alphanum4",
+						"asset_issuer": "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+						"amount":       "20.0000000",
+					},
+					effectType:  history.EffectAccountCredited,
+					operationID: int64(4294967298),
+					order:       uint32(2),
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		s.T().Run(tc.desc, func(t *testing.T) {
+			operation := transactionOperationWrapper{
+				index:          uint32(i),
+				transaction:    s.tx,
+				operation:      tc.op,
+				ledgerSequence: 1,
+			}
+
+			effects, err := operation.effects()
+			s.Assert().NoError(err)
+			s.Assert().Equal(tc.expected, effects)
+		})
+	}
+}
+
+func TestClaimClaimableBalanceEffectsTestSuite(t *testing.T) {
+	suite.Run(t, new(ClaimClaimableBalanceEffectsTestSuite))
+}

--- a/services/horizon/internal/expingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/expingest/processors/effects_processor_test.go
@@ -1549,6 +1549,16 @@ func (s *CreateClaimableBalanceEffectsTestSuite) TestEffects() {
 					operationID: int64(4294967297),
 					order:       uint32(2),
 				},
+				{
+					address: "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+					details: map[string]interface{}{
+						"amount":     "10.0000000",
+						"asset_type": "native",
+					},
+					effectType:  history.EffectAccountDebited,
+					operationID: int64(4294967297),
+					order:       uint32(3),
+				},
 			},
 		},
 		{
@@ -1589,6 +1599,18 @@ func (s *CreateClaimableBalanceEffectsTestSuite) TestEffects() {
 					effectType:  history.EffectClaimableBalanceClaimantCreated,
 					operationID: int64(4294967298),
 					order:       uint32(3),
+				},
+				{
+					address: "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+					details: map[string]interface{}{
+						"amount":       "20.0000000",
+						"asset_code":   "USD",
+						"asset_type":   "credit_alphanum4",
+						"asset_issuer": "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+					},
+					effectType:  history.EffectAccountDebited,
+					operationID: int64(4294967298),
+					order:       uint32(4),
 				},
 			},
 		},

--- a/services/horizon/internal/expingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/expingest/processors/effects_processor_test.go
@@ -1406,3 +1406,209 @@ func TestOperationEffectsAllowTrustAuthorizedToMaintainLiabilities(t *testing.T)
 	}
 	tt.Equal(expected, effects)
 }
+
+type CreateClaimableBalanceEffectsTestSuite struct {
+	suite.Suite
+	ops []xdr.Operation
+	tx  io.LedgerTransaction
+}
+
+func (s *CreateClaimableBalanceEffectsTestSuite) SetupTest() {
+	aid := xdr.MustAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD")
+	source := aid.ToMuxedAccount()
+	s.ops = []xdr.Operation{
+		{
+			SourceAccount: &source,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypeCreateClaimableBalance,
+				CreateClaimableBalanceOp: &xdr.CreateClaimableBalanceOp{
+					Amount: xdr.Int64(100000000),
+					Asset:  xdr.MustNewNativeAsset(),
+					Claimants: []xdr.Claimant{
+						{
+							Type: xdr.ClaimantTypeClaimantTypeV0,
+							V0: &xdr.ClaimantV0{
+								Destination: xdr.MustAddress("GD5OVB6FKDV7P7SOJ5UB2BPLBL4XGSHPYHINR5355SY3RSXLT2BZWAKY"),
+
+								Predicate: xdr.ClaimPredicate{
+									Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			SourceAccount: &source,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypeCreateClaimableBalance,
+				CreateClaimableBalanceOp: &xdr.CreateClaimableBalanceOp{
+					Amount: xdr.Int64(200000000),
+					Asset:  xdr.MustNewCreditAsset("USD", "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
+					Claimants: []xdr.Claimant{
+						{
+							Type: xdr.ClaimantTypeClaimantTypeV0,
+							V0: &xdr.ClaimantV0{
+								Destination: xdr.MustAddress("GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2"),
+								Predicate: xdr.ClaimPredicate{
+									Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
+								},
+							},
+						},
+						{
+							Type: xdr.ClaimantTypeClaimantTypeV0,
+							V0: &xdr.ClaimantV0{
+								Destination: xdr.MustAddress("GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3"),
+								Predicate: xdr.ClaimPredicate{
+									Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	var balanceIDOp1, balanceIDOp2 xdr.ClaimableBalanceId
+	xdr.SafeUnmarshalBase64("AAAAANoNV9p9SFDn/BDSqdDrxzH3r7QFdMAzlbF9SRSbkfW+", &balanceIDOp1)
+	xdr.SafeUnmarshalBase64("AAAAALHcX0PDa9UefSAzitC6vQOUr802phH8OF2ahLzg6j1D", &balanceIDOp2)
+
+	s.tx = io.LedgerTransaction{
+		Index: 0,
+		Envelope: xdr.TransactionEnvelope{
+			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+			V1: &xdr.TransactionV1Envelope{
+				Tx: xdr.Transaction{
+					Operations: s.ops,
+				},
+			},
+		},
+		Result: xdr.TransactionResultPair{
+			Result: xdr.TransactionResult{
+				Result: xdr.TransactionResultResult{
+					Results: &[]xdr.OperationResult{
+						{
+							Code: xdr.OperationResultCodeOpInner,
+							Tr: &xdr.OperationResultTr{
+								Type: xdr.OperationTypeCreateClaimableBalance,
+								CreateClaimableBalanceResult: &xdr.CreateClaimableBalanceResult{
+									Code:      xdr.CreateClaimableBalanceResultCodeCreateClaimableBalanceSuccess,
+									BalanceId: &balanceIDOp1,
+								},
+							},
+						},
+						{
+							Code: xdr.OperationResultCodeOpInner,
+							Tr: &xdr.OperationResultTr{
+								Type: xdr.OperationTypeCreateClaimableBalance,
+								CreateClaimableBalanceResult: &xdr.CreateClaimableBalanceResult{
+									Code:      xdr.CreateClaimableBalanceResultCodeCreateClaimableBalanceSuccess,
+									BalanceId: &balanceIDOp2,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		FeeChanges: xdr.LedgerEntryChanges{},
+		Meta:       xdr.TransactionMeta{},
+	}
+}
+func (s *CreateClaimableBalanceEffectsTestSuite) TestEffects() {
+	testCases := []struct {
+		desc     string
+		op       xdr.Operation
+		expected []effect
+	}{
+		{
+			desc: "claimable balance with native asset",
+			op:   s.ops[0],
+			expected: []effect{
+				{
+					address: "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+					details: map[string]interface{}{
+						"asset":      "native",
+						"amount":     "10.0000000",
+						"balance_id": "AAAAANoNV9p9SFDn/BDSqdDrxzH3r7QFdMAzlbF9SRSbkfW+",
+					},
+					effectType:  history.EffectClaimableBalanceCreated,
+					operationID: int64(4294967297),
+					order:       uint32(1),
+				},
+				{
+					address: "GD5OVB6FKDV7P7SOJ5UB2BPLBL4XGSHPYHINR5355SY3RSXLT2BZWAKY",
+					details: map[string]interface{}{
+						"asset":      "native",
+						"amount":     "10.0000000",
+						"balance_id": "AAAAANoNV9p9SFDn/BDSqdDrxzH3r7QFdMAzlbF9SRSbkfW+",
+						"predicate":  "AAAAAA==",
+					},
+					effectType:  history.EffectClaimableBalanceClaimantCreated,
+					operationID: int64(4294967297),
+					order:       uint32(2),
+				},
+			},
+		},
+		{
+			desc: "claimable balance with issued asset",
+			op:   s.ops[1],
+			expected: []effect{
+				{
+					address: "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+					details: map[string]interface{}{
+						"asset":      "USD:GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+						"amount":     "20.0000000",
+						"balance_id": "AAAAALHcX0PDa9UefSAzitC6vQOUr802phH8OF2ahLzg6j1D",
+					},
+					effectType:  history.EffectClaimableBalanceCreated,
+					operationID: int64(4294967298),
+					order:       uint32(1),
+				},
+				{
+					address: "GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2",
+					details: map[string]interface{}{
+						"asset":      "USD:GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+						"amount":     "20.0000000",
+						"balance_id": "AAAAALHcX0PDa9UefSAzitC6vQOUr802phH8OF2ahLzg6j1D",
+						"predicate":  "AAAAAA==",
+					},
+					effectType:  history.EffectClaimableBalanceClaimantCreated,
+					operationID: int64(4294967298),
+					order:       uint32(2),
+				},
+				{
+					address: "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3",
+					details: map[string]interface{}{
+						"asset":      "USD:GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+						"amount":     "20.0000000",
+						"balance_id": "AAAAALHcX0PDa9UefSAzitC6vQOUr802phH8OF2ahLzg6j1D",
+						"predicate":  "AAAAAA==",
+					},
+					effectType:  history.EffectClaimableBalanceClaimantCreated,
+					operationID: int64(4294967298),
+					order:       uint32(3),
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		s.T().Run(tc.desc, func(t *testing.T) {
+			operation := transactionOperationWrapper{
+				index:          uint32(i),
+				transaction:    s.tx,
+				operation:      tc.op,
+				ledgerSequence: 1,
+			}
+
+			effects, err := operation.effects()
+			s.Assert().NoError(err)
+			s.Assert().Equal(tc.expected, effects)
+		})
+	}
+}
+
+func TestCreateClaimableBalanceEffectsTestSuite(t *testing.T) {
+	suite.Run(t, new(CreateClaimableBalanceEffectsTestSuite))
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Ingest effects for `CreateClaimableBalanceOp` and `ClaimClaimableBalanceOp`.

### Why

CAP23 introduces 2 new operations, we need to effects from each operation. 

Fix #2885 

### Known limitations

[TODO or N/A]
