### PR TITLE
exp/services/captivecore/internal: Implement RemoteCaptiveCore HTTP client

### DIFF
--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -323,7 +323,7 @@ func (c *CaptiveStellarCore) readLedgerMetaFromPipe() (*xdr.LedgerCloseMeta, err
 func (c *CaptiveStellarCore) PrepareRange(ledgerRange Range) error {
 	// Range already prepared
 	if prepared, err := c.IsPrepared(ledgerRange); err != nil {
-		return err
+		return errors.Wrap(err, "error in IsPrepared")
 	} else if prepared {
 		return nil
 	}

--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -322,7 +322,9 @@ func (c *CaptiveStellarCore) readLedgerMetaFromPipe() (*xdr.LedgerCloseMeta, err
 // history archive. This issue is being fixed in Stellar-Core.
 func (c *CaptiveStellarCore) PrepareRange(ledgerRange Range) error {
 	// Range already prepared
-	if c.IsPrepared(ledgerRange) {
+	if prepared, err := c.IsPrepared(ledgerRange); err != nil {
+		return err
+	} else if prepared {
 		return nil
 	}
 
@@ -371,24 +373,24 @@ func (c *CaptiveStellarCore) PrepareRange(ledgerRange Range) error {
 }
 
 // IsPrepared returns true if a given ledgerRange is prepared.
-func (c *CaptiveStellarCore) IsPrepared(ledgerRange Range) bool {
+func (c *CaptiveStellarCore) IsPrepared(ledgerRange Range) (bool, error) {
 	if c.nextLedger == 0 {
-		return false
+		return false, nil
 	}
 
 	if c.lastLedger == nil {
-		return c.nextLedger <= ledgerRange.from
+		return c.nextLedger <= ledgerRange.from, nil
 	}
 
 	// From now on: c.lastLedger != nil so current range is bounded
 
 	if ledgerRange.bounded {
 		return c.nextLedger <= ledgerRange.from &&
-			c.nextLedger <= *c.lastLedger
+			c.nextLedger <= *c.lastLedger, nil
 	}
 
 	// Requested range is unbounded but current one is bounded
-	return false
+	return false, nil
 }
 
 // GetLedger returns true when ledger is found and it's LedgerCloseMeta.

--- a/exp/ingest/ledgerbackend/database_backend.go
+++ b/exp/ingest/ledgerbackend/database_backend.go
@@ -67,8 +67,8 @@ func (dbb *DatabaseBackend) PrepareRange(ledgerRange Range) error {
 }
 
 // IsPrepared returns true if a given ledgerRange is prepared.
-func (*DatabaseBackend) IsPrepared(ledgerRange Range) bool {
-	return true
+func (*DatabaseBackend) IsPrepared(ledgerRange Range) (bool, error) {
+	return true, nil
 }
 
 // GetLatestLedgerSequence returns the most recent ledger sequence number present in the database.

--- a/exp/ingest/ledgerbackend/history_archive_backend.go
+++ b/exp/ingest/ledgerbackend/history_archive_backend.go
@@ -74,8 +74,8 @@ func (hab *HistoryArchiveBackend) PrepareRange(ledgerRange Range) error {
 }
 
 // IsPrepared returns true if a given ledgerRange is prepared.
-func (hab *HistoryArchiveBackend) IsPrepared(ledgerRange Range) bool {
-	return true
+func (hab *HistoryArchiveBackend) IsPrepared(ledgerRange Range) (bool, error) {
+	return true, nil
 }
 
 // GetLedger returns the LedgerCloseMeta for the given ledger sequence number.

--- a/exp/ingest/ledgerbackend/ledger_backend.go
+++ b/exp/ingest/ledgerbackend/ledger_backend.go
@@ -87,7 +87,7 @@ type LedgerBackend interface {
 	// able to stream ledgers.
 	PrepareRange(ledgerRange Range) error
 	// IsPrepared returns true if a given ledgerRange is prepared.
-	IsPrepared(ledgerRange Range) bool
+	IsPrepared(ledgerRange Range) (bool, error)
 	Close() error
 }
 

--- a/exp/ingest/ledgerbackend/mock_database_backend.go
+++ b/exp/ingest/ledgerbackend/mock_database_backend.go
@@ -21,9 +21,9 @@ func (m *MockDatabaseBackend) PrepareRange(ledgerRange Range) error {
 	return args.Error(0)
 }
 
-func (m *MockDatabaseBackend) IsPrepared(ledgerRange Range) bool {
+func (m *MockDatabaseBackend) IsPrepared(ledgerRange Range) (bool, error) {
 	args := m.Called(ledgerRange)
-	return args.Bool(0)
+	return args.Bool(0), args.Error(1)
 }
 
 func (m *MockDatabaseBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMeta, error) {

--- a/exp/ingest/ledgerbackend/remote_captive_core.go
+++ b/exp/ingest/ledgerbackend/remote_captive_core.go
@@ -1,0 +1,277 @@
+package ledgerbackend
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+// PrepareRangeResponse describes the status of the pending PrepareRange operation.
+type PrepareRangeResponse struct {
+	LedgerRange   Range     `json:"ledgerRange"`
+	StartTime     time.Time `json:"startTime"`
+	Ready         bool      `json:"ready"`
+	ReadyDuration int       `json:"readyDuration"`
+}
+
+// LatestLedgerSequenceResponse is the response for the GetLatestLedgerSequence command.
+type LatestLedgerSequenceResponse struct {
+	Sequence uint32 `json:"sequence"`
+}
+
+// LedgerResponse is the response for the GetLedger command.
+type LedgerResponse struct {
+	Present bool         `json:"present"`
+	Ledger  Base64Ledger `json:"ledger"`
+}
+
+// Base64Ledger extends xdr.LedgerCloseMeta with JSON encoding and decoding
+type Base64Ledger xdr.LedgerCloseMeta
+
+func (r *Base64Ledger) UnmarshalJSON(b []byte) error {
+	var base64 string
+	if err := json.Unmarshal(b, &base64); err != nil {
+		return err
+	}
+
+	var parsed xdr.LedgerCloseMeta
+	if err := xdr.SafeUnmarshalBase64(base64, &parsed); err != nil {
+		return err
+	}
+	*r = Base64Ledger(parsed)
+
+	return nil
+}
+
+func (r Base64Ledger) MarshalJSON() ([]byte, error) {
+	base64, err := xdr.MarshalBase64(xdr.LedgerCloseMeta(r))
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(base64)
+}
+
+// RemoteCaptiveStellarCore is an http client for interacting with a remote captive core server.
+type RemoteCaptiveStellarCore struct {
+	url                      *url.URL
+	client                   *http.Client
+	lock                     *sync.Mutex
+	cancel                   context.CancelFunc
+	prepareRangePollInterval time.Duration
+}
+
+// RemoteCaptiveOption values can be passed into NewRemoteCaptive to customize a RemoteCaptiveStellarCore instance.
+type RemoteCaptiveOption func(c *RemoteCaptiveStellarCore)
+
+// PrepareRangePollInterval configures how often the captive core server will be polled when blocking
+// on the PrepareRange operation.
+func PrepareRangePollInterval(d time.Duration) RemoteCaptiveOption {
+	return func(c *RemoteCaptiveStellarCore) {
+		c.prepareRangePollInterval = d
+	}
+}
+
+// NewRemoteCaptive returns a new RemoteCaptiveStellarCore instance.
+//
+// Only the captiveCoreURL parameter is required.
+func NewRemoteCaptive(captiveCoreURL string, options ...RemoteCaptiveOption) (RemoteCaptiveStellarCore, error) {
+	u, err := url.Parse(captiveCoreURL)
+	if err != nil {
+		return RemoteCaptiveStellarCore{}, errors.Wrap(err, "unparseable url")
+	}
+
+	client := RemoteCaptiveStellarCore{
+		prepareRangePollInterval: time.Second,
+		url:                      u,
+		client:                   &http.Client{Timeout: 5 * time.Second},
+		lock:                     &sync.Mutex{},
+	}
+	for _, option := range options {
+		option(&client)
+	}
+	return client, nil
+}
+
+func decodeResponse(response *http.Response, payload interface{}) error {
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		body, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			return errors.Wrap(err, "failed to read response body")
+		}
+
+		return errors.New(string(body))
+	}
+
+	if err := json.NewDecoder(response.Body).Decode(payload); err != nil {
+		return errors.Wrap(err, "failed to decode json payload")
+	}
+	return nil
+}
+
+// GetLatestLedgerSequence returns the sequence of the latest ledger available
+// in the backend. This method returns an error if not in a session (start with
+// PrepareRange).
+//
+// Note that for UnboundedRange the returned sequence number is not necessarily
+// the latest sequence closed by the network. It's always the last value available
+// in the backend.
+func (c RemoteCaptiveStellarCore) GetLatestLedgerSequence() (sequence uint32, err error) {
+	u := *c.url
+	u.Path = path.Join(u.Path, "latest-sequence")
+
+	response, err := c.client.Get(u.String())
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to execute request")
+	}
+
+	var parsed LatestLedgerSequenceResponse
+	if err = decodeResponse(response, &parsed); err != nil {
+		return 0, err
+	}
+
+	return parsed.Sequence, nil
+}
+
+// Close cancels any pending PrepareRange requests.
+func (c RemoteCaptiveStellarCore) Close() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.cancel != nil {
+		c.cancel()
+	}
+	return nil
+}
+
+func (c RemoteCaptiveStellarCore) createContext() context.Context {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.cancel != nil {
+		c.cancel()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c.cancel = cancel
+	return ctx
+}
+
+// PrepareRange prepares the given range (including from and to) to be loaded.
+// Captive stellar-core backend needs to initalize Stellar-Core state to be
+// able to stream ledgers.
+// Stellar-Core mode depends on the provided ledgerRange:
+//   * For BoundedRange it will start Stellar-Core in catchup mode.
+//   * For UnboundedRange it will first catchup to starting ledger and then run
+//     it normally (including connecting to the Stellar network).
+// Please note that using a BoundedRange, currently, requires a full-trust on
+// history archive. This issue is being fixed in Stellar-Core.
+func (c RemoteCaptiveStellarCore) PrepareRange(ledgerRange Range) error {
+	ctx := c.createContext()
+	u := *c.url
+	u.Path = path.Join(u.Path, "prepare-range")
+	rangeBytes, err := json.Marshal(ledgerRange)
+	if err != nil {
+		return errors.Wrap(err, "cannot serialize range")
+	}
+
+	timer := time.NewTimer(c.prepareRangePollInterval)
+	defer timer.Stop()
+
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(rangeBytes))
+		if err != nil {
+			return errors.Wrap(err, "cannot construct http request")
+		}
+
+		var response *http.Response
+		response, err = c.client.Do(req)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute request")
+		}
+
+		var parsed PrepareRangeResponse
+		if err = decodeResponse(response, &parsed); err != nil {
+			return err
+		}
+
+		if parsed.Ready {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return errors.Wrap(ctx.Err(), "shutting down")
+		case <-timer.C:
+			timer.Reset(c.prepareRangePollInterval)
+		}
+	}
+}
+
+// IsPrepared returns true if a given ledgerRange is prepared.
+func (c RemoteCaptiveStellarCore) IsPrepared(ledgerRange Range) (bool, error) {
+	u := *c.url
+	u.Path = path.Join(u.Path, "prepare-range")
+	rangeBytes, err := json.Marshal(ledgerRange)
+	if err != nil {
+		return false, errors.Wrap(err, "cannot serialize range")
+	}
+	body := bytes.NewReader(rangeBytes)
+
+	var response *http.Response
+	response, err = c.client.Post(u.String(), "application/json; charset=utf-8", body)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to execute request")
+	}
+
+	var parsed PrepareRangeResponse
+	if err = decodeResponse(response, &parsed); err != nil {
+		return false, err
+	}
+
+	return parsed.Ready, nil
+}
+
+// GetLedger returns true when ledger is found and it's LedgerCloseMeta.
+// Call PrepareRange first to instruct the backend which ledgers to fetch.
+//
+// CaptiveStellarCore requires PrepareRange call first to initialize Stellar-Core.
+// Requesting a ledger on non-prepared backend will return an error.
+//
+// Because data is streamed from Stellar-Core ledger after ledger user should
+// request sequences in a non-decreasing order. If the requested sequence number
+// is less than the last requested sequence number, an error will be returned.
+//
+// This function behaves differently for bounded and unbounded ranges:
+//   * BoundedRange makes GetLedger blocking if the requested ledger is not yet
+//     available in the ledger. After getting the last ledger in a range this
+//     method will also Close() the backend.
+//   * UnboundedRange makes GetLedger non-blocking. The method will return with
+//     the first argument equal false.
+// This is done to provide maximum performance when streaming old ledgers.
+func (c RemoteCaptiveStellarCore) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMeta, error) {
+	u := *c.url
+	u.Path = path.Join(u.Path, "ledger", strconv.FormatUint(uint64(sequence), 10))
+
+	response, err := c.client.Get(u.String())
+	if err != nil {
+		return false, xdr.LedgerCloseMeta{}, errors.Wrap(err, "failed to execute request")
+	}
+
+	var parsed LedgerResponse
+	if err = decodeResponse(response, &parsed); err != nil {
+		return false, xdr.LedgerCloseMeta{}, err
+	}
+
+	return parsed.Present, xdr.LedgerCloseMeta(parsed.Ledger), nil
+}

--- a/exp/services/captivecore/internal/api_test.go
+++ b/exp/services/captivecore/internal/api_test.go
@@ -113,7 +113,7 @@ func (s *APITestSuite) TestLatestSeqSucceeds() {
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(expectedSeq, nil).Once()
 	seq, err := s.api.GetLatestLedgerSequence()
 	s.Assert().NoError(err)
-	s.Assert().Equal(seq, LatestLedgerSequenceResponse{Sequence: expectedSeq})
+	s.Assert().Equal(seq, ledgerbackend.LatestLedgerSequenceResponse{Sequence: expectedSeq})
 }
 
 func (s *APITestSuite) TestGetLedgerSucceeds() {
@@ -133,9 +133,9 @@ func (s *APITestSuite) TestGetLedgerSucceeds() {
 	seq, err := s.api.GetLedger(64)
 
 	s.Assert().NoError(err)
-	s.Assert().Equal(seq, LedgerResponse{
+	s.Assert().Equal(seq, ledgerbackend.LedgerResponse{
 		Present: true,
-		Ledger:  Base64Ledger(expectedLedger),
+		Ledger:  ledgerbackend.Base64Ledger(expectedLedger),
 	})
 }
 

--- a/exp/services/captivecore/internal/server_test.go
+++ b/exp/services/captivecore/internal/server_test.go
@@ -1,15 +1,13 @@
 package internal
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/suite"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/stretchr/testify/suite"
+	"time"
 
 	"github.com/stellar/go/exp/ingest/ledgerbackend"
 	"github.com/stellar/go/support/log"
@@ -25,16 +23,27 @@ type ServerTestSuite struct {
 	ledgerBackend *ledgerbackend.MockDatabaseBackend
 	api           CaptiveCoreAPI
 	handler       http.Handler
+	server        *httptest.Server
+	client        ledgerbackend.RemoteCaptiveStellarCore
 }
 
 func (s *ServerTestSuite) SetupTest() {
 	s.ledgerBackend = &ledgerbackend.MockDatabaseBackend{}
 	s.api = NewCaptiveCoreAPI(s.ledgerBackend, log.New())
 	s.handler = Handler(s.api)
+	s.server = httptest.NewServer(s.handler)
+	var err error
+	s.client, err = ledgerbackend.NewRemoteCaptive(
+		s.server.URL,
+		ledgerbackend.PrepareRangePollInterval(time.Millisecond),
+	)
+	s.Assert().NoError(err)
 }
 
 func (s *ServerTestSuite) TearDownTest() {
 	s.ledgerBackend.AssertExpectations(s.T())
+	s.server.Close()
+	s.client.Close()
 }
 
 func (s *ServerTestSuite) TestLatestSequence() {
@@ -44,21 +53,9 @@ func (s *ServerTestSuite) TestLatestSequence() {
 	expectedSeq := uint32(100)
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(expectedSeq, nil).Once()
 
-	req := httptest.NewRequest("GET", "/latest-sequence", nil)
-	w := httptest.NewRecorder()
-
-	s.handler.ServeHTTP(w, req)
-
-	resp := w.Result()
-	body, err := ioutil.ReadAll(resp.Body)
+	seq, err := s.client.GetLatestLedgerSequence()
 	s.Assert().NoError(err)
-
-	s.Assert().Equal(http.StatusOK, resp.StatusCode)
-	s.Assert().Equal("application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-
-	var parsed LatestLedgerSequenceResponse
-	s.Assert().NoError(json.Unmarshal(body, &parsed))
-	s.Assert().Equal(LatestLedgerSequenceResponse{Sequence: expectedSeq}, parsed)
+	s.Assert().Equal(expectedSeq, seq)
 }
 
 func (s *ServerTestSuite) TestLatestSequenceError() {
@@ -67,71 +64,44 @@ func (s *ServerTestSuite) TestLatestSequenceError() {
 
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(uint32(100), fmt.Errorf("test error")).Once()
 
-	req := httptest.NewRequest("GET", "/latest-sequence", nil)
-	w := httptest.NewRecorder()
-
-	s.handler.ServeHTTP(w, req)
-
-	resp := w.Result()
-	body, err := ioutil.ReadAll(resp.Body)
-	s.Assert().NoError(err)
-
-	s.Assert().Equal(http.StatusInternalServerError, resp.StatusCode)
-	s.Assert().Equal("test error", string(body))
-}
-
-func (s *ServerTestSuite) testPrepareRange(ledgerRange ledgerbackend.Range) {
-	s.ledgerBackend.On("PrepareRange", ledgerRange).
-		Return(nil).Once()
-
-	body, err := json.Marshal(ledgerRange)
-	s.Assert().NoError(err)
-
-	req := httptest.NewRequest("POST", "/prepare-range", bytes.NewReader(body))
-	w := httptest.NewRecorder()
-
-	s.handler.ServeHTTP(w, req)
-
-	resp := w.Result()
-	body, err = ioutil.ReadAll(resp.Body)
-	s.Assert().NoError(err)
-
-	s.Assert().Equal(http.StatusOK, resp.StatusCode)
-	s.Assert().Equal("application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-
-	var parsed RangeResponse
-	s.Assert().NoError(json.Unmarshal(body, &parsed))
-	s.Assert().Equal(ledgerRange, parsed.LedgerRange)
-	s.Assert().False(parsed.Ready)
-	s.api.wg.Wait()
+	_, err := s.client.GetLatestLedgerSequence()
+	s.Assert().EqualError(err, "test error")
 }
 
 func (s *ServerTestSuite) TestPrepareBoundedRange() {
-	s.testPrepareRange(ledgerbackend.BoundedRange(10, 30))
+	ledgerRange := ledgerbackend.BoundedRange(10, 30)
+	s.ledgerBackend.On("PrepareRange", ledgerRange).
+		Return(nil).Once()
+
+	s.Assert().NoError(s.client.PrepareRange(ledgerRange))
+	s.Assert().True(s.api.activeRequest.ready)
+
+	prepared, err := s.client.IsPrepared(ledgerRange)
+	s.Assert().NoError(err)
+	s.Assert().True(prepared)
 }
 
 func (s *ServerTestSuite) TestPrepareUnboundedRange() {
-	s.testPrepareRange(ledgerbackend.UnboundedRange(100))
+	ledgerRange := ledgerbackend.UnboundedRange(100)
+	s.ledgerBackend.On("PrepareRange", ledgerRange).
+		Return(nil).Once()
+
+	s.Assert().NoError(s.client.PrepareRange(ledgerRange))
+	s.Assert().True(s.api.activeRequest.ready)
+
+	prepared, err := s.client.IsPrepared(ledgerRange)
+	s.Assert().NoError(err)
+	s.Assert().True(prepared)
 }
 
 func (s *ServerTestSuite) TestPrepareError() {
 	s.ledgerBackend.On("Close").Return(nil).Once()
 	s.api.Shutdown()
 
-	body, err := json.Marshal(ledgerbackend.UnboundedRange(100))
-	s.Assert().NoError(err)
-
-	req := httptest.NewRequest("POST", "/prepare-range", bytes.NewReader(body))
-	w := httptest.NewRecorder()
-
-	s.handler.ServeHTTP(w, req)
-
-	resp := w.Result()
-	body, err = ioutil.ReadAll(resp.Body)
-	s.Assert().NoError(err)
-
-	s.Assert().Equal(http.StatusInternalServerError, resp.StatusCode)
-	s.Assert().Equal("Cannot prepare range when shut down", string(body))
+	s.Assert().EqualError(
+		s.client.PrepareRange(ledgerbackend.UnboundedRange(100)),
+		"Cannot prepare range when shut down",
+	)
 }
 
 func (s *ServerTestSuite) TestGetLedgerInvalidSequence() {
@@ -156,17 +126,8 @@ func (s *ServerTestSuite) TestGetLedgerError() {
 	s.ledgerBackend.On("GetLedger", uint32(64)).
 		Return(false, xdr.LedgerCloseMeta{}, expectedErr).Once()
 
-	req := httptest.NewRequest("GET", "/ledger/64", nil)
-	w := httptest.NewRecorder()
-
-	s.handler.ServeHTTP(w, req)
-
-	resp := w.Result()
-	body, err := ioutil.ReadAll(resp.Body)
-	s.Assert().NoError(err)
-
-	s.Assert().Equal(http.StatusInternalServerError, resp.StatusCode)
-	s.Assert().Equal("test error", string(body))
+	_, _, err := s.client.GetLedger(64)
+	s.Assert().EqualError(err, "test error")
 }
 
 func (s *ServerTestSuite) TestGetLedgerSucceeds() {
@@ -185,22 +146,8 @@ func (s *ServerTestSuite) TestGetLedgerSucceeds() {
 	s.ledgerBackend.On("GetLedger", uint32(64)).
 		Return(true, expectedLedger, nil).Once()
 
-	req := httptest.NewRequest("GET", "/ledger/64", nil)
-	w := httptest.NewRecorder()
-
-	s.handler.ServeHTTP(w, req)
-
-	resp := w.Result()
-	body, err := ioutil.ReadAll(resp.Body)
+	present, ledger, err := s.client.GetLedger(64)
 	s.Assert().NoError(err)
-
-	s.Assert().Equal(http.StatusOK, resp.StatusCode)
-	s.Assert().Equal("application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-
-	var parsed LedgerResponse
-	s.Assert().NoError(json.Unmarshal(body, &parsed))
-	s.Assert().Equal(LedgerResponse{
-		Present: true,
-		Ledger:  Base64Ledger(expectedLedger),
-	}, parsed)
+	s.Assert().True(present)
+	s.Assert().Equal(expectedLedger, ledger)
 }

--- a/exp/services/captivecore/internal/server_test.go
+++ b/exp/services/captivecore/internal/server_test.go
@@ -2,12 +2,13 @@ package internal
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/suite"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/suite"
 
 	"github.com/stellar/go/exp/ingest/ledgerbackend"
 	"github.com/stellar/go/support/log"

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -219,6 +219,7 @@ var dbReingestRangeCmd = &cobra.Command{
 
 		if config.EnableCaptiveCoreIngestion {
 			ingestConfig.StellarCoreBinaryPath = config.StellarCoreBinaryPath
+			ingestConfig.RemoteCaptiveCoreURL = config.RemoteCaptiveCoreURL
 		} else {
 			if config.StellarCoreDatabaseURL == "" {
 				log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -104,6 +104,7 @@ var ingestVerifyRangeCmd = &cobra.Command{
 		}
 		if config.EnableCaptiveCoreIngestion {
 			ingestConfig.StellarCoreBinaryPath = config.StellarCoreBinaryPath
+			ingestConfig.RemoteCaptiveCoreURL = config.RemoteCaptiveCoreURL
 		} else {
 			if config.StellarCoreDatabaseURL == "" {
 				log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
@@ -188,6 +189,7 @@ var ingestStressTestCmd = &cobra.Command{
 
 		if config.EnableCaptiveCoreIngestion {
 			ingestConfig.StellarCoreBinaryPath = config.StellarCoreBinaryPath
+			ingestConfig.RemoteCaptiveCoreURL = config.RemoteCaptiveCoreURL
 		} else {
 			if config.StellarCoreDatabaseURL == "" {
 				log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -423,10 +423,19 @@ func initRootConfig() {
 		stdLog.Fatalf("--history-archive-urls must be set when --ingest is set")
 	}
 
-	validateBothOrNeither("enable-captive-core-ingestion", "stellar-core-binary-path")
+	if config.EnableCaptiveCoreIngestion {
+		binaryPath := viper.GetString("stellar-core-binary-path")
+		remoteURL := viper.GetString("remote-captive-core-url")
+		if binaryPath == "" && remoteURL == "" {
+			stdLog.Fatalf("Invalid config: captive core requires that either --stellar-core-binary-path or --remote-captive-core-url is set")
+		}
+		if binaryPath != "" && remoteURL != "" {
+			stdLog.Fatalf("Invalid config: --stellar-core-binary-path and --remote-captive-core-url cannot both be set.")
+		}
+	}
 	if config.Ingest {
 		// When running live ingestion a config file is required too
-		validateBothOrNeither("enable-captive-core-ingestion", "stellar-core-config-path")
+		validateBothOrNeither("stellar-core-binary-path", "stellar-core-config-path")
 	}
 
 	// Configure log file

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -121,6 +121,14 @@ var configOpts = support.ConfigOptions{
 		ConfigKey:   &config.StellarCoreBinaryPath,
 	},
 	&support.ConfigOption{
+		Name:        "remote-captive-core-url",
+		OptType:     types.String,
+		FlagDefault: "",
+		Required:    false,
+		Usage:       "url to access the remote captive core server",
+		ConfigKey:   &config.RemoteCaptiveCoreURL,
+	},
+	&support.ConfigOption{
 		Name:        "stellar-core-config-path",
 		OptType:     types.String,
 		FlagDefault: "",

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	StellarCoreConfigPath      string
 	StellarCoreDatabaseURL     string
 	StellarCoreURL             string
+	RemoteCaptiveCoreURL       string
 
 	// MaxDBConnections has a priority over all 4 values below.
 	MaxDBConnections            int

--- a/services/horizon/internal/expingest/build_state_test.go
+++ b/services/horizon/internal/expingest/build_state_test.go
@@ -72,7 +72,7 @@ func (s *BuildStateTestSuite) mockCommonHistoryQ() {
 		defaultCoreCursorName,
 		int32(62),
 	).Return(nil).Once()
-	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(63)).Return(true).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(63)).Return(true, nil).Once()
 }
 
 func (s *BuildStateTestSuite) TestCheckPointLedgerIsZero() {
@@ -195,7 +195,7 @@ func (s *BuildStateTestSuite) TestRangeNotPreparedFailPrepare() {
 		int32(62),
 	).Return(nil).Once()
 
-	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(63)).Return(false).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(63)).Return(false, nil).Once()
 	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(63)).Return(errors.New("my error")).Once()
 	// Rollback twice (first one mocked in SetupTest) because we want to release
 	// a distributed ingestion lock.
@@ -222,7 +222,7 @@ func (s *BuildStateTestSuite) TestRangeNotPreparedSuccessPrepare() {
 		int32(62),
 	).Return(nil).Once()
 
-	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(63)).Return(false).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(63)).Return(false, nil).Once()
 	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(63)).Return(nil).Once()
 	// Rollback twice (first one mocked in SetupTest) because we want to release
 	// a distributed ingestion lock.

--- a/services/horizon/internal/expingest/db_integration_test.go
+++ b/services/horizon/internal/expingest/db_integration_test.go
@@ -110,7 +110,7 @@ func (s *DBTestSuite) setupMocksForBuildState() {
 	s.historyAdapter.On("BucketListHash", s.sequence).
 		Return(checkpointHash, nil).Once()
 
-	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(s.sequence)).Return(true).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(s.sequence)).Return(true, nil).Once()
 	s.ledgerBackend.On("GetLedger", s.sequence).
 		Return(
 			true,

--- a/services/horizon/internal/expingest/fake_ledger_backend.go
+++ b/services/horizon/internal/expingest/fake_ledger_backend.go
@@ -20,8 +20,8 @@ func (fakeLedgerBackend) PrepareRange(r ledgerbackend.Range) error {
 	return nil
 }
 
-func (fakeLedgerBackend) IsPrepared(r ledgerbackend.Range) bool {
-	return true
+func (fakeLedgerBackend) IsPrepared(r ledgerbackend.Range) (bool, error) {
+	return true, nil
 }
 
 func fakeAccount() xdr.LedgerEntryChange {

--- a/services/horizon/internal/expingest/ingest_history_range_state_test.go
+++ b/services/horizon/internal/expingest/ingest_history_range_state_test.go
@@ -126,7 +126,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestRunTransactionProcessorsOnLedgerR
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
-	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(100)).Return(true).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(100)).Return(true, nil).Once()
 	s.runner.On("RunTransactionProcessorsOnLedger", uint32(100)).Return(io.StatsLedgerTransactionProcessorResults{}, errors.New("my error")).Once()
 
 	next, err := historyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
@@ -140,7 +140,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestRangeNotPreparedFailPrepare() {
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
-	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(100)).Return(false).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(100)).Return(false, nil).Once()
 	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(100)).Return(errors.New("my error")).Once()
 	// Rollback twice (first one mocked in SetupTest) because we want to release
 	// a distributed ingestion lock.
@@ -157,7 +157,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestRangeNotPreparedSuccessPrepare() 
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
-	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(100)).Return(false).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(100)).Return(false, nil).Once()
 	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(100)).Return(nil).Once()
 	// Rollback twice (first one mocked in SetupTest) because we want to release
 	// a distributed ingestion lock.
@@ -173,7 +173,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestSuccess() {
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
-	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(100)).Return(true).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(100)).Return(true, nil).Once()
 	for i := 100; i <= 200; i++ {
 		s.runner.On("RunTransactionProcessorsOnLedger", uint32(i)).Return(io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 	}
@@ -190,7 +190,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
 	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
-	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(100)).Return(true).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(100)).Return(true, nil).Once()
 	s.runner.On("RunTransactionProcessorsOnLedger", uint32(100)).Return(io.StatsLedgerTransactionProcessorResults{}, nil).Once()
 
 	s.historyQ.On("Commit").Return(nil).Once()

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -58,6 +58,7 @@ type Config struct {
 	StellarCoreCursor     string
 	StellarCoreBinaryPath string
 	StellarCoreConfigPath string
+	RemoteCaptiveCoreURL  string
 	NetworkPassphrase     string
 
 	HistorySession           *db.Session
@@ -142,6 +143,13 @@ func NewSystem(config Config) (System, error) {
 	}
 
 	var ledgerBackend ledgerbackend.LedgerBackend
+	if len(config.RemoteCaptiveCoreURL) > 0 {
+		ledgerBackend, err = ledgerbackend.NewRemoteCaptive(config.RemoteCaptiveCoreURL)
+		if err != nil {
+			cancel()
+			return nil, errors.Wrap(err, "error creating captive core backend")
+		}
+	}
 	if len(config.StellarCoreBinaryPath) > 0 {
 		ledgerBackend, err = ledgerbackend.NewCaptive(
 			config.StellarCoreBinaryPath,

--- a/services/horizon/internal/expingest/main_test.go
+++ b/services/horizon/internal/expingest/main_test.go
@@ -375,9 +375,9 @@ func (m *mockLedgerBackend) PrepareRange(ledgerRange ledgerbackend.Range) error 
 	return args.Error(0)
 }
 
-func (m *mockLedgerBackend) IsPrepared(ledgerRange ledgerbackend.Range) bool {
+func (m *mockLedgerBackend) IsPrepared(ledgerRange ledgerbackend.Range) (bool, error) {
 	args := m.Called(ledgerRange)
-	return args.Bool(0)
+	return args.Get(0).(bool), args.Error(1)
 }
 
 func (m *mockLedgerBackend) Close() error {

--- a/services/horizon/internal/expingest/resume_state_test.go
+++ b/services/horizon/internal/expingest/resume_state_test.go
@@ -210,7 +210,7 @@ func (s *ResumeTestTestSuite) TestRangeNotPreparedFailPrepare() {
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
 
-	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(102)).Return(false).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(102)).Return(false, nil).Once()
 	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(102)).Return(errors.New("my error")).Once()
 	// Rollback twice (first one mocked in SetupTest) because we want to release
 	// a distributed ingestion lock.
@@ -231,7 +231,7 @@ func (s *ResumeTestTestSuite) TestRangeNotPreparedSuccessPrepare() {
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
 
-	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(102)).Return(false).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(102)).Return(false, nil).Once()
 	s.ledgerBackend.On("PrepareRange", ledgerbackend.UnboundedRange(102)).Return(nil).Once()
 	// Rollback twice (first one mocked in SetupTest) because we want to release
 	// a distributed ingestion lock.
@@ -251,7 +251,7 @@ func (s *ResumeTestTestSuite) TestFastForwardCaptiveCore() {
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
 
-	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(102)).Return(true).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(102)).Return(true, nil).Once()
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(uint32(99), nil).Once()
 	// GetLedger will fast-forward to the latest sequence in a backend
 	s.ledgerBackend.On("GetLedger", uint32(99)).Return(true, xdr.LedgerCloseMeta{}, nil).Once()
@@ -273,7 +273,7 @@ func (s *ResumeTestTestSuite) mockSuccessfulIngestion() {
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
 
-	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(102)).Return(true).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(102)).Return(true, nil).Once()
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(uint32(111), nil).Once()
 
 	s.runner.On("RunAllProcessorsOnLedger", uint32(102)).Return(io.StatsChangeProcessorResults{}, io.StatsLedgerTransactionProcessorResults{}, nil).Once()
@@ -337,7 +337,7 @@ func (s *ResumeTestTestSuite) TestErrorSettingCursorIgnored() {
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
-	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(101)).Return(true).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(101)).Return(true, nil).Once()
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(uint32(111), nil).Once()
 
 	s.runner.On("RunAllProcessorsOnLedger", uint32(101)).Return(io.StatsChangeProcessorResults{}, io.StatsLedgerTransactionProcessorResults{}, nil).Once()
@@ -370,7 +370,7 @@ func (s *ResumeTestTestSuite) TestNoNewLedgers() {
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
-	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(101)).Return(true).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(101)).Return(true, nil).Once()
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(uint32(100), nil).Once()
 	// Fast forward the backend
 	s.ledgerBackend.On("GetLedger", uint32(100)).Return(true, xdr.LedgerCloseMeta{}, nil).Once()
@@ -394,7 +394,7 @@ func (s *ResumeTestTestSuite) TestFarBehind() {
 	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
-	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(201)).Return(true).Once()
+	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(201)).Return(true, nil).Once()
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(uint32(102), nil).Once()
 	// Fast forward the backend
 	s.ledgerBackend.On("GetLedger", uint32(102)).Return(true, xdr.LedgerCloseMeta{}, nil).Once()

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -67,6 +67,7 @@ func initExpIngester(app *App) {
 		StellarCoreCursor:        app.config.CursorName,
 		StellarCoreBinaryPath:    app.config.StellarCoreBinaryPath,
 		StellarCoreConfigPath:    app.config.StellarCoreConfigPath,
+		RemoteCaptiveCoreURL:     app.config.RemoteCaptiveCoreURL,
 		DisableStateVerification: app.config.IngestDisableStateVerification,
 	})
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Close https://github.com/stellar/go/issues/2841

This PR is a follow up to https://github.com/stellar/go/pull/2896 . In https://github.com/stellar/go/pull/2896 we added an http server wrapper around stellar core so that we could run a captive core instance on a separate machine from horizon.

This PR adds the corresponding HTTP client for the captive core server. The client satisfies the `LedgerBackend` interface and can be plugged into Horizon's ingestion system.

### Why

See https://github.com/stellar/go/issues/2841

### Known limitations

[N/A]
