### PR TITLE
Sponsored claimable services/horizon: Ingest sponsor while ingesting claimable balances.

### DIFF
--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -190,7 +190,7 @@ func (i *claimableBalancesBatchInsertBuilder) Add(entry *xdr.LedgerEntry) error 
 		Claimants:          buildClaimants(cBalance.Claimants),
 		Asset:              cBalance.Asset,
 		Amount:             cBalance.Amount,
-		Sponsor:            null.StringFromPtr(nil), // TDB - we can add this later since there might be code from Bartek's PR which we can use to pull the sponsor,
+		Sponsor:            ledgerEntrySponsorToNullString(*entry),
 		LastModifiedLedger: uint32(entry.LastModifiedLedgerSeq),
 	}
 	return i.builder.RowStruct(row)

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -85,7 +85,7 @@ type ClaimableBalancesBatchInsertBuilder interface {
 // QClaimableBalances defines account related queries.
 type QClaimableBalances interface {
 	NewClaimableBalancesBatchInsertBuilder(maxBatchSize int) ClaimableBalancesBatchInsertBuilder
-	UpdateClaimableBalance(entry *xdr.LedgerEntry) (int64, error)
+	UpdateClaimableBalance(entry xdr.LedgerEntry) (int64, error)
 	RemoveClaimableBalance(cBalance xdr.ClaimableBalanceEntry) (int64, error)
 }
 
@@ -102,9 +102,24 @@ func (q *Q) NewClaimableBalancesBatchInsertBuilder(maxBatchSize int) ClaimableBa
 // UpdateClaimableBalance updates a row in the claimable_balances table.
 // The only updatable value on claimable_balances is sponsor
 // Returns number of rows affected and error.
-func (q *Q) UpdateClaimableBalance(entry *xdr.LedgerEntry) (int64, error) {
-	// mocking this for now - we can add the implemention upon landing https://github.com/stellar/go/pull/2897
-	return 1, nil
+func (q *Q) UpdateClaimableBalance(entry xdr.LedgerEntry) (int64, error) {
+	cBalance := entry.Data.MustClaimableBalance()
+	id, err := balanceIDToHex(cBalance.BalanceId)
+	if err != nil {
+		return 0, errors.Wrap(err, "encoding balanceID")
+	}
+	cBalanceMap := map[string]interface{}{
+		"last_modified_ledger": entry.LastModifiedLedgerSeq,
+		"sponsor":              ledgerEntrySponsorToNullString(entry),
+	}
+
+	sql := sq.Update("claimable_balances").SetMap(cBalanceMap).Where("id = ?", id)
+	result, err := q.Exec(sql)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.RowsAffected()
 }
 
 // RemoveClaimableBalance deletes a row in the claimable_balances table.

--- a/services/horizon/internal/db2/history/claimable_balances_batch_insert_builder_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_batch_insert_builder_test.go
@@ -24,7 +24,7 @@ func TestAddClaimableBalance(t *testing.T) {
 	cBalance := xdr.ClaimableBalanceEntry{
 		BalanceId: balanceID,
 		Claimants: []xdr.Claimant{
-			xdr.Claimant{
+			{
 				Type: xdr.ClaimantTypeClaimantTypeV0,
 				V0: &xdr.ClaimantV0{
 					Destination: xdr.MustAddress(accountID),
@@ -43,6 +43,12 @@ func TestAddClaimableBalance(t *testing.T) {
 			ClaimableBalance: &cBalance,
 		},
 		LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+		Ext: xdr.LedgerEntryExt{
+			V: 1,
+			V1: &xdr.LedgerEntryExtensionV1{
+				SponsoringId: xdr.MustAddressPtr("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+			},
+		},
 	}
 
 	builder := q.NewClaimableBalancesBatchInsertBuilder(2)
@@ -66,7 +72,7 @@ func TestAddClaimableBalance(t *testing.T) {
 		tt.Assert.Equal(accountID, cb.Claimants[0].Destination)
 		tt.Assert.Equal(cBalance.Claimants[0].MustV0().Predicate, cb.Claimants[0].Predicate)
 		tt.Assert.Equal(asset, cb.Asset)
-		tt.Assert.Equal(null.StringFromPtr(nil), cb.Sponsor)
+		tt.Assert.Equal(null.NewString("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", true), cb.Sponsor)
 		tt.Assert.Equal(uint32(lastModifiedLedgerSeq), cb.LastModifiedLedger)
 	}
 }

--- a/services/horizon/internal/db2/history/mock_q_claimable_balances.go
+++ b/services/horizon/internal/db2/history/mock_q_claimable_balances.go
@@ -15,7 +15,7 @@ func (m *MockQClaimableBalances) NewClaimableBalancesBatchInsertBuilder(maxBatch
 	return a.Get(0).(ClaimableBalancesBatchInsertBuilder)
 }
 
-func (m *MockQClaimableBalances) UpdateClaimableBalance(entry *xdr.LedgerEntry) (int64, error) {
+func (m *MockQClaimableBalances) UpdateClaimableBalance(entry xdr.LedgerEntry) (int64, error) {
 	a := m.Called(entry)
 	return a.Get(0).(int64), a.Error(1)
 }

--- a/services/horizon/internal/expingest/processors/claimable_balances_processor.go
+++ b/services/horizon/internal/expingest/processors/claimable_balances_processor.go
@@ -77,7 +77,7 @@ func (p *ClaimableBalancesProcessor) Commit() error {
 			if err != nil {
 				return errors.Wrap(err, "Error creating ledger key")
 			}
-			rowsAffected, err = p.qClaimableBalances.UpdateClaimableBalance(change.Post)
+			rowsAffected, err = p.qClaimableBalances.UpdateClaimableBalance(*change.Post)
 		}
 
 		if err != nil {

--- a/services/horizon/internal/expingest/processors/claimable_balances_processor_test.go
+++ b/services/horizon/internal/expingest/processors/claimable_balances_processor_test.go
@@ -219,7 +219,7 @@ func (s *ClaimableBalancesProcessorTestSuiteLedger) TestUpdateClaimableBalance()
 
 	s.mockQ.On(
 		"UpdateClaimableBalance",
-		&updated,
+		updated,
 	).Return(int64(1), nil).Once()
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Ingest sponsor when updating and creating claimable balances.

### Why

This add CAP33 support to CAP23 ingestion.

Fix https://github.com/stellar/go/issues/2912

### Known limitations
