### PR TITLE
services/horizon: Update state verify metrics

### DIFF
--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -88,6 +88,10 @@ type Metrics struct {
 	// StateVerifyDuration exposes timing metrics about the rate and
 	// duration of state verification.
 	StateVerifyDuration prometheus.Summary
+
+	// StateInvalidGauge exposes state invalid metric. 1 if state is invalid,
+	// 0 otherwise.
+	StateInvalidGauge prometheus.GaugeFunc
 }
 
 type System interface {
@@ -204,6 +208,25 @@ func (s *system) initMetrics() {
 		Namespace: "horizon", Subsystem: "ingest", Name: "state_verify_duration_seconds",
 		Help: "state verification durations, sliding window = 10m",
 	})
+
+	s.metrics.StateInvalidGauge = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: "horizon", Subsystem: "ingest", Name: "state_invalid",
+			Help: "equals 1 if state invalid, 0 otherwise",
+		},
+		func() float64 {
+			invalid, err := s.historyQ.GetExpStateInvalid()
+			if err != nil {
+				log.WithError(err).Error("Error in initMetrics/GetExpStateInvalid")
+				return 0
+			}
+			invalidFloat := float64(0)
+			if invalid {
+				invalidFloat = 1
+			}
+			return invalidFloat
+		},
+	)
 }
 
 func (s *system) Metrics() Metrics {

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -1,6 +1,7 @@
 package expingest
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"time"
@@ -57,7 +58,10 @@ func (s *system) verifyState(verifyAgainstLatestCheckpoint bool) error {
 	defer func() {
 		duration := time.Since(startTime).Seconds()
 		if updateMetrics {
-			s.Metrics().StateVerifyDuration.Observe(float64(duration))
+			// Don't update metrics if context cancelled.
+			if s.ctx.Err() != context.Canceled {
+				s.Metrics().StateVerifyDuration.Observe(float64(duration))
+			}
 		}
 		log.WithField("duration", duration).Info("State verification finished")
 		historyQ.Rollback()

--- a/services/horizon/internal/expingest/verify_range_state_test.go
+++ b/services/horizon/internal/expingest/verify_range_state_test.go
@@ -2,6 +2,7 @@
 package expingest
 
 import (
+	"context"
 	"database/sql"
 	"io"
 	"testing"
@@ -34,6 +35,7 @@ func (s *VerifyRangeStateTestSuite) SetupTest() {
 	s.historyAdapter = &adapters.MockHistoryArchiveAdapter{}
 	s.runner = &mockProcessorsRunner{}
 	s.system = &system{
+		ctx:            context.Background(),
 		historyQ:       s.historyQ,
 		historyAdapter: s.historyAdapter,
 		runner:         s.runner,
@@ -223,7 +225,7 @@ func (s *VerifyRangeStateTestSuite) TestSuccessWithVerify() {
 	mockChangeReader.On("Read").Return(offerChange, nil).Once()
 	mockChangeReader.On("Read").Return(ingestio.Change{}, io.EOF).Once()
 	mockChangeReader.On("Read").Return(ingestio.Change{}, io.EOF).Once()
-	s.historyAdapter.On("GetState", nil, uint32(63)).Return(mockChangeReader, nil).Once()
+	s.historyAdapter.On("GetState", mock.AnythingOfType("*context.emptyCtx"), uint32(63)).Return(mockChangeReader, nil).Once()
 	mockAccount := history.AccountEntry{
 		AccountID:          mockAccountID,
 		Balance:            600,

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -196,6 +196,7 @@ func initIngestMetrics(app *App) {
 
 	app.prometheusRegistry.MustRegister(app.expingester.Metrics().LedgerIngestionDuration)
 	app.prometheusRegistry.MustRegister(app.expingester.Metrics().StateVerifyDuration)
+	app.prometheusRegistry.MustRegister(app.expingester.Metrics().StateInvalidGauge)
 }
 
 func initTxSubMetrics(app *App) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

Update state verification metrics:
* Do not update `horizon_ingest_state_verify_duration_seconds` in case of shutdown.
* Add `horizon_ingest_state_invalid` gauge: 1 if state is invalid, 0 otherwise.