### PR TITLE
services/horizon: Fix horizon_db_wait_duration_seconds_total metric

### DIFF
--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -179,7 +179,7 @@ func initDbMetrics(app *App) {
 			Help: "total time blocked waiting for a new connection",
 		},
 		func() float64 {
-			return float64(app.historyQ.Session.DB.Stats().WaitDuration)
+			return app.historyQ.Session.DB.Stats().WaitDuration.Seconds()
 		},
 	)
 	app.prometheusRegistry.MustRegister(app.dbWaitDurationCounter)


### PR DESCRIPTION
The name says `seconds` but `time.Duration` is in nanoseconds.

Close #2913.