### PR TITLE
horizon/internal/ingest:Add Claimable Balances to state verifier.

### DIFF
--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -88,7 +88,7 @@ type QClaimableBalances interface {
 	UpdateClaimableBalance(entry xdr.LedgerEntry) (int64, error)
 	RemoveClaimableBalance(cBalance xdr.ClaimableBalanceEntry) (int64, error)
 	GetClaimableBalancesByID(ids []xdr.ClaimableBalanceId) ([]ClaimableBalance, error)
-	CountClaimableBalances() (int64, error)
+	CountClaimableBalances() (int, error)
 }
 
 // NewClaimableBalancesBatchInsertBuilder constructs a new ClaimableBalancesBatchInsertBuilder instance
@@ -102,10 +102,10 @@ func (q *Q) NewClaimableBalancesBatchInsertBuilder(maxBatchSize int) ClaimableBa
 }
 
 // CountClaimableBalances returns the total number of claimable balances in the DB
-func (q *Q) CountClaimableBalances() (int64, error) {
+func (q *Q) CountClaimableBalances() (int, error) {
 	sql := sq.Select("count(*)").From("claimable_balances")
 
-	var count int64
+	var count int
 	if err := q.Get(&count, sql); err != nil {
 		return 0, errors.Wrap(err, "could not run select query")
 	}

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -87,6 +87,8 @@ type QClaimableBalances interface {
 	NewClaimableBalancesBatchInsertBuilder(maxBatchSize int) ClaimableBalancesBatchInsertBuilder
 	UpdateClaimableBalance(entry xdr.LedgerEntry) (int64, error)
 	RemoveClaimableBalance(cBalance xdr.ClaimableBalanceEntry) (int64, error)
+	GetClaimableBalancesByID(ids []xdr.ClaimableBalanceId) ([]ClaimableBalance, error)
+	CountClaimableBalances() (int64, error)
 }
 
 // NewClaimableBalancesBatchInsertBuilder constructs a new ClaimableBalancesBatchInsertBuilder instance
@@ -97,6 +99,34 @@ func (q *Q) NewClaimableBalancesBatchInsertBuilder(maxBatchSize int) ClaimableBa
 			MaxBatchSize: maxBatchSize,
 		},
 	}
+}
+
+// CountClaimableBalances returns the total number of claimable balances in the DB
+func (q *Q) CountClaimableBalances() (int64, error) {
+	sql := sq.Select("count(*)").From("claimable_balances")
+
+	var count int64
+	if err := q.Get(&count, sql); err != nil {
+		return 0, errors.Wrap(err, "could not run select query")
+	}
+
+	return count, nil
+}
+
+// GetClaimableBalancesByID finds all claimable balances by ClaimableBalanceId
+func (q *Q) GetClaimableBalancesByID(ids []xdr.ClaimableBalanceId) ([]ClaimableBalance, error) {
+	var cBalances []ClaimableBalance
+	hexIDs := make([]string, 0, len(ids))
+	for _, id := range ids {
+		hexID, err := balanceIDToHex(id)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error running balanceIDToHex")
+		}
+		hexIDs = append(hexIDs, hexID)
+	}
+	sql := selectClaimableBalances.Where(map[string]interface{}{"claimable_balances.id": hexIDs})
+	err := q.Select(&cBalances, sql)
+	return cBalances, err
 }
 
 // UpdateClaimableBalance updates a row in the claimable_balances table.

--- a/services/horizon/internal/db2/history/mock_q_claimable_balances.go
+++ b/services/horizon/internal/db2/history/mock_q_claimable_balances.go
@@ -15,9 +15,9 @@ func (m *MockQClaimableBalances) NewClaimableBalancesBatchInsertBuilder(maxBatch
 	return a.Get(0).(ClaimableBalancesBatchInsertBuilder)
 }
 
-func (m *MockQClaimableBalances) CountClaimableBalances() (int64, error) {
+func (m *MockQClaimableBalances) CountClaimableBalances() (int, error) {
 	a := m.Called()
-	return a.Get(0).(int64), a.Error(1)
+	return a.Get(0).(int), a.Error(1)
 }
 
 func (m *MockQClaimableBalances) GetClaimableBalancesByID(ids []xdr.ClaimableBalanceId) ([]ClaimableBalance, error) {

--- a/services/horizon/internal/db2/history/mock_q_claimable_balances.go
+++ b/services/horizon/internal/db2/history/mock_q_claimable_balances.go
@@ -15,6 +15,16 @@ func (m *MockQClaimableBalances) NewClaimableBalancesBatchInsertBuilder(maxBatch
 	return a.Get(0).(ClaimableBalancesBatchInsertBuilder)
 }
 
+func (m *MockQClaimableBalances) CountClaimableBalances() (int64, error) {
+	a := m.Called()
+	return a.Get(0).(int64), a.Error(1)
+}
+
+func (m *MockQClaimableBalances) GetClaimableBalancesByID(ids []xdr.ClaimableBalanceId) ([]ClaimableBalance, error) {
+	a := m.Called(ids)
+	return a.Get(0).([]ClaimableBalance), a.Error(1)
+}
+
 func (m *MockQClaimableBalances) UpdateClaimableBalance(entry xdr.LedgerEntry) (int64, error) {
 	a := m.Called(entry)
 	return a.Get(0).(int64), a.Error(1)

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -145,6 +145,7 @@ func (s *system) verifyState(verifyAgainstLatestCheckpoint bool) error {
 		data := make([]xdr.LedgerKeyData, 0, verifyBatchSize)
 		offers := make([]int64, 0, verifyBatchSize)
 		trustLines := make([]xdr.LedgerKeyTrustLine, 0, verifyBatchSize)
+		cBalances := make([]xdr.ClaimableBalanceId, 0, verifyBatchSize)
 		for _, key := range keys {
 			switch key.Type {
 			case xdr.LedgerEntryTypeAccount:
@@ -155,6 +156,8 @@ func (s *system) verifyState(verifyAgainstLatestCheckpoint bool) error {
 				offers = append(offers, int64(key.Offer.OfferId))
 			case xdr.LedgerEntryTypeTrustline:
 				trustLines = append(trustLines, *key.TrustLine)
+			case xdr.LedgerEntryTypeClaimableBalance:
+				cBalances = append(cBalances, key.ClaimableBalance.BalanceId)
 			default:
 				return errors.New("GetLedgerKeys return unexpected type")
 			}
@@ -176,6 +179,11 @@ func (s *system) verifyState(verifyAgainstLatestCheckpoint bool) error {
 		}
 
 		err = addTrustLinesToStateVerifier(verifier, assetStats, historyQ, trustLines)
+		if err != nil {
+			return errors.Wrap(err, "addTrustLinesToStateVerifier failed")
+		}
+
+		err = addClaimableBalanceToStateVerifier(verifier, assetStats, historyQ, cBalances)
 		if err != nil {
 			return errors.Wrap(err, "addTrustLinesToStateVerifier failed")
 		}
@@ -206,7 +214,12 @@ func (s *system) verifyState(verifyAgainstLatestCheckpoint bool) error {
 		return errors.Wrap(err, "Error running historyQ.CountTrustLines")
 	}
 
-	err = verifier.Verify(countAccounts + countData + countOffers + countTrustLines)
+	countClaimableBalances, err := historyQ.CountClaimableBalances()
+	if err != nil {
+		return errors.Wrap(err, "Error running historyQ.CountClaimableBalances")
+	}
+
+	err = verifier.Verify(countAccounts + countData + countOffers + countTrustLines + countClaimableBalances)
 	if err != nil {
 		return errors.Wrap(err, "verifier.Verify failed")
 	}
@@ -491,6 +504,53 @@ func addTrustLinesToStateVerifier(
 	return nil
 }
 
+func addClaimableBalanceToStateVerifier(
+	verifier *verify.StateVerifier,
+	assetStats processors.AssetStatSet,
+	q history.IngestionQ,
+	ids []xdr.ClaimableBalanceId,
+) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	cBalances, err := q.GetClaimableBalancesByID(ids)
+	if err != nil {
+		return errors.Wrap(err, "Error running history.Q.GetClaimableBalancesByID")
+	}
+
+	for _, row := range cBalances {
+		claimants := []xdr.Claimant{}
+		for _, claimant := range row.Claimants {
+			claimants = append(claimants, xdr.Claimant{
+				Type: xdr.ClaimantTypeClaimantTypeV0,
+				V0: &xdr.ClaimantV0{
+					Destination: xdr.MustAddress(claimant.Destination),
+					Predicate:   claimant.Predicate,
+				},
+			})
+		}
+		cBalance := xdr.ClaimableBalanceEntry{
+			BalanceId: row.BalanceID,
+			Claimants: claimants,
+			Asset:     row.Asset,
+			Amount:    xdr.Int64(row.Amount),
+		}
+		entry := xdr.LedgerEntry{
+			LastModifiedLedgerSeq: xdr.Uint32(row.LastModifiedLedger),
+			Data: xdr.LedgerEntryData{
+				Type:             xdr.LedgerEntryTypeClaimableBalance,
+				ClaimableBalance: &cBalance,
+			},
+		}
+		if err := verifier.Write(entry); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func transformEntry(entry xdr.LedgerEntry) (bool, xdr.LedgerEntry) {
 	switch entry.Data.Type {
 	case xdr.LedgerEntryTypeAccount:
@@ -532,7 +592,7 @@ func transformEntry(entry xdr.LedgerEntry) (bool, xdr.LedgerEntry) {
 		// Full check of data object
 		return false, entry
 	case xdr.LedgerEntryTypeClaimableBalance:
-		// TBD
+		// Full check of claimable balance object
 		return false, entry
 	default:
 		panic("Invalid type")

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -530,6 +530,7 @@ func addClaimableBalanceToStateVerifier(
 				},
 			})
 		}
+		claimants = xdr.SortClaimantsByDestination(claimants)
 		cBalance := xdr.ClaimableBalanceEntry{
 			BalanceId: row.BalanceID,
 			Claimants: claimants,
@@ -592,7 +593,9 @@ func transformEntry(entry xdr.LedgerEntry) (bool, xdr.LedgerEntry) {
 		// Full check of data object
 		return false, entry
 	case xdr.LedgerEntryTypeClaimableBalance:
-		// Full check of claimable balance object
+		cBalance := entry.Data.ClaimableBalance
+		cBalance.Claimants = xdr.SortClaimantsByDestination(cBalance.Claimants)
+
 		return false, entry
 	default:
 		panic("Invalid type")

--- a/xdr/claimant.go
+++ b/xdr/claimant.go
@@ -1,0 +1,27 @@
+package xdr
+
+import (
+	"sort"
+)
+
+// SortClaimantsByDestination returns a new []Claimant array sorted by destination.
+func SortClaimantsByDestination(claimants []Claimant) []Claimant {
+	keys := make([]string, 0, len(claimants))
+	keysMap := make(map[string]Claimant)
+	newClaimants := make([]Claimant, 0, len(claimants))
+
+	for _, claimant := range claimants {
+		v0 := claimant.MustV0()
+		key := v0.Destination.Address()
+		keys = append(keys, key)
+		keysMap[key] = claimant
+	}
+
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		newClaimants = append(newClaimants, keysMap[key])
+	}
+
+	return newClaimants
+}

--- a/xdr/claimant_test.go
+++ b/xdr/claimant_test.go
@@ -1,0 +1,43 @@
+package xdr_test
+
+import (
+	"testing"
+
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortClaimantsByDestination(t *testing.T) {
+	tt := assert.New(t)
+
+	a := xdr.MustAddress("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	b := xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML")
+
+	claimants := []xdr.Claimant{
+		{
+			Type: xdr.ClaimantTypeClaimantTypeV0,
+			V0: &xdr.ClaimantV0{
+				Destination: b,
+				Predicate: xdr.ClaimPredicate{
+					Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
+				},
+			},
+		},
+		{
+			Type: xdr.ClaimantTypeClaimantTypeV0,
+			V0: &xdr.ClaimantV0{
+				Destination: a,
+				Predicate: xdr.ClaimPredicate{
+					Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
+				},
+			},
+		},
+	}
+
+	expected := []xdr.AccountId{a, b}
+
+	sorted := xdr.SortClaimantsByDestination(claimants)
+	for i, c := range sorted {
+		tt.Equal(expected[i], c.MustV0().Destination)
+	}
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add Claimable Balance entries to state verifier.

### Why

We have a new ledger entry type and we need to check that we have the correct state.

Fixes https://github.com/stellar/go/issues/2882

### Known limitations

