### PR TITLE
services/horizon: Add /claimable_balances/:id.

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -659,3 +659,30 @@ type PathsPage struct {
 		Records []Path
 	} `json:"_embedded"`
 }
+
+// ClaimableBalance represents a claimable balance
+type ClaimableBalance struct {
+	Links struct {
+		Self hal.Link `json:"self"`
+	} `json:"_links"`
+
+	ID                 string     `json:"id"`
+	BalanceID          string     `json:"balance_id"`
+	Asset              string     `json:"asset"`
+	Amount             string     `json:"amount"`
+	Sponsor            string     `json:"sponsor"`
+	LastModifiedLedger uint32     `json:"last_modified_ledger"`
+	Claimants          []Claimant `json:"claimants"`
+	PT                 string     `json:"paging_token"`
+}
+
+// PagingToken implementation for hal.Pageable
+func (res ClaimableBalance) PagingToken() string {
+	return res.PT
+}
+
+// Claimant represents a claimable balance claimant
+type Claimant struct {
+	Destination string `json:"destination"`
+	Predicate   string `json:"predicate"`
+}

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -666,8 +666,7 @@ type ClaimableBalance struct {
 		Self hal.Link `json:"self"`
 	} `json:"_links"`
 
-	ID                 string     `json:"id"`
-	BalanceID          string     `json:"balance_id"`
+	BalanceID          string     `json:"id"`
 	Asset              string     `json:"asset"`
 	Amount             string     `json:"amount"`
 	Sponsor            string     `json:"sponsor"`

--- a/services/horizon/internal/actions/claimable_balance.go
+++ b/services/horizon/internal/actions/claimable_balance.go
@@ -1,0 +1,45 @@
+package actions
+
+import (
+	"net/http"
+
+	protocol "github.com/stellar/go/protocols/horizon"
+	horizonContext "github.com/stellar/go/services/horizon/internal/context"
+	"github.com/stellar/go/services/horizon/internal/resourceadapter"
+)
+
+// GetClaimableBalanceByIDHandler is the action handler for all end-points returning a claimable balance.
+type GetClaimableBalanceByIDHandler struct{}
+
+// ClaimableBalanceQuery query struct for claimables_balances/id end-point
+type ClaimableBalanceQuery struct {
+	// TODO add validation - let's postpone it until the final representation of ID is defined.
+	ID string `schema:"id" valid:"-"`
+}
+
+// GetResource returns an claimable balance page.
+func (handler GetClaimableBalanceByIDHandler) GetResource(w HeaderWriter, r *http.Request) (interface{}, error) {
+	ctx := r.Context()
+	qp := ClaimableBalanceQuery{}
+	err := getParams(&qp, r)
+	if err != nil {
+		return nil, err
+	}
+
+	historyQ, err := horizonContext.HistoryQFromRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	cb, err := historyQ.FindClaimableBalanceByID(qp.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	var resource protocol.ClaimableBalance
+	err = resourceadapter.PopulateClaimableBalance(ctx, &resource, cb)
+	if err != nil {
+		return nil, err
+	}
+
+	return resource, nil
+}

--- a/services/horizon/internal/actions/claimable_balance.go
+++ b/services/horizon/internal/actions/claimable_balance.go
@@ -1,11 +1,14 @@
 package actions
 
 import (
+	"fmt"
 	"net/http"
 
 	protocol "github.com/stellar/go/protocols/horizon"
 	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
+	"github.com/stellar/go/support/render/problem"
+	"github.com/stellar/go/xdr"
 )
 
 // GetClaimableBalanceByIDHandler is the action handler for all end-points returning a claimable balance.
@@ -13,8 +16,28 @@ type GetClaimableBalanceByIDHandler struct{}
 
 // ClaimableBalanceQuery query struct for claimables_balances/id end-point
 type ClaimableBalanceQuery struct {
-	// TODO add validation - let's postpone it until the final representation of ID is defined.
 	ID string `schema:"id" valid:"-"`
+}
+
+// Validate validates the balance id
+func (q ClaimableBalanceQuery) Validate() error {
+	if _, err := q.BalanceID(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// BalanceID returns the xdr.ClaimableBalanceId from the request query
+func (q ClaimableBalanceQuery) BalanceID() (xdr.ClaimableBalanceId, error) {
+	var balanceID xdr.ClaimableBalanceId
+	err := xdr.SafeUnmarshalHex(q.ID, &balanceID)
+	if err != nil {
+		return balanceID, problem.MakeInvalidFieldProblem(
+			"id",
+			fmt.Errorf("Invalid claimable balance ID"),
+		)
+	}
+	return balanceID, nil
 }
 
 // GetResource returns an claimable balance page.
@@ -30,7 +53,11 @@ func (handler GetClaimableBalanceByIDHandler) GetResource(w HeaderWriter, r *htt
 	if err != nil {
 		return nil, err
 	}
-	cb, err := historyQ.FindClaimableBalanceByID(qp.ID)
+	balanceID, err := qp.BalanceID()
+	if err != nil {
+		return nil, err
+	}
+	cb, err := historyQ.FindClaimableBalanceByID(balanceID)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/claimable_balance_test.go
+++ b/services/horizon/internal/actions/claimable_balance_test.go
@@ -1,0 +1,83 @@
+package actions
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	protocol "github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+func TestGetClaimableBalanceByID(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &history.Q{tt.HorizonSession()}
+
+	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
+	lastModifiedLedgerSeq := xdr.Uint32(123)
+	asset := xdr.MustNewCreditAsset("USD", accountID)
+	balanceID := xdr.ClaimableBalanceId{
+		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
+		V0:   &xdr.Hash{1, 2, 3},
+	}
+	cBalance := xdr.ClaimableBalanceEntry{
+		BalanceId: balanceID,
+		Claimants: []xdr.Claimant{
+			{
+				Type: xdr.ClaimantTypeClaimantTypeV0,
+				V0: &xdr.ClaimantV0{
+					Destination: xdr.MustAddress(accountID),
+					Predicate: xdr.ClaimPredicate{
+						Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
+					},
+				},
+			},
+		},
+		Asset:  asset,
+		Amount: 10,
+	}
+	entry := xdr.LedgerEntry{
+		Data: xdr.LedgerEntryData{
+			Type:             xdr.LedgerEntryTypeClaimableBalance,
+			ClaimableBalance: &cBalance,
+		},
+		LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+	}
+
+	builder := q.NewClaimableBalancesBatchInsertBuilder(2)
+
+	err := builder.Add(&entry)
+	tt.Assert.NoError(err)
+
+	err = builder.Exec()
+	tt.Assert.NoError(err)
+
+	tt.Assert.NoError(err)
+
+	handler := GetClaimableBalanceByIDHandler{}
+	id := "8f2fb9b32d46b3357f6d11ded015f470520ab81dd5386fc18ab7d33f5334c45b"
+	response, err := handler.GetResource(httptest.NewRecorder(), makeRequest(
+		t,
+		map[string]string{},
+		map[string]string{"id": id},
+		q.Session,
+	))
+	tt.Assert.NoError(err)
+
+	resource := response.(protocol.ClaimableBalance)
+	tt.Assert.Equal(id, resource.ID)
+
+	// try to fetch claimable balance which does not exist
+	_, err = handler.GetResource(httptest.NewRecorder(), makeRequest(
+		t,
+		map[string]string{},
+		map[string]string{"id": "8f2fb9b32d46b3357f6d11ded015f470520ab81dd5386fc18ab7d33f5334caaa"},
+		q.Session,
+	))
+	tt.Assert.Error(err)
+	tt.Assert.True(q.NoRows(errors.Cause(err)))
+}

--- a/services/horizon/internal/actions/claimable_balance_test.go
+++ b/services/horizon/internal/actions/claimable_balance_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/xdr"
 )
 
@@ -59,7 +60,8 @@ func TestGetClaimableBalanceByID(t *testing.T) {
 	tt.Assert.NoError(err)
 
 	handler := GetClaimableBalanceByIDHandler{}
-	id := "8f2fb9b32d46b3357f6d11ded015f470520ab81dd5386fc18ab7d33f5334c45b"
+	id, err := xdr.MarshalHex(cBalance.BalanceId)
+	tt.Assert.NoError(err)
 	response, err := handler.GetResource(httptest.NewRecorder(), makeRequest(
 		t,
 		map[string]string{},
@@ -69,15 +71,47 @@ func TestGetClaimableBalanceByID(t *testing.T) {
 	tt.Assert.NoError(err)
 
 	resource := response.(protocol.ClaimableBalance)
-	tt.Assert.Equal(id, resource.ID)
+	tt.Assert.Equal(id, resource.BalanceID)
 
 	// try to fetch claimable balance which does not exist
+	balanceID = xdr.ClaimableBalanceId{
+		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
+		V0:   &xdr.Hash{1, 1, 1},
+	}
+	id, err = xdr.MarshalHex(balanceID)
+	tt.Assert.NoError(err)
 	_, err = handler.GetResource(httptest.NewRecorder(), makeRequest(
 		t,
 		map[string]string{},
-		map[string]string{"id": "8f2fb9b32d46b3357f6d11ded015f470520ab81dd5386fc18ab7d33f5334caaa"},
+		map[string]string{"id": id},
 		q.Session,
 	))
 	tt.Assert.Error(err)
 	tt.Assert.True(q.NoRows(errors.Cause(err)))
+
+	// try to fetch a random invalid hex id
+	_, err = handler.GetResource(httptest.NewRecorder(), makeRequest(
+		t,
+		map[string]string{},
+		map[string]string{"id": "0000001112122"},
+		q.Session,
+	))
+	tt.Assert.Error(err)
+	p := err.(*problem.P)
+	tt.Assert.Equal("bad_request", p.Type)
+	tt.Assert.Equal("id", p.Extras["invalid_field"])
+	tt.Assert.Equal("Invalid claimable balance ID", p.Extras["reason"])
+
+	// try to fetch a random invalid hex id
+	_, err = handler.GetResource(httptest.NewRecorder(), makeRequest(
+		t,
+		map[string]string{},
+		map[string]string{"id": ""},
+		q.Session,
+	))
+	tt.Assert.Error(err)
+	p = err.(*problem.P)
+	tt.Assert.Equal("bad_request", p.Type)
+	tt.Assert.Equal("id", p.Extras["invalid_field"])
+	tt.Assert.Equal("Invalid claimable balance ID", p.Extras["reason"])
 }

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -164,7 +164,7 @@ func (q *Q) FindClaimableBalancesByDestination(accountID xdr.AccountId) ([]Claim
 }
 
 // FindClaimableBalanceByID returns a claimable balance.
-func (q *Q) FindClaimableBalanceByID(balanceID string) (ClaimableBalance, error) {
+func (q *Q) FindClaimableBalanceByID(balanceID xdr.ClaimableBalanceId) (ClaimableBalance, error) {
 	var claimableBalance ClaimableBalance
 	sql := selectClaimableBalances.Limit(1).Where("cb.id = ?", balanceID)
 	err := q.Get(&claimableBalance, sql)

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -163,6 +163,14 @@ func (q *Q) FindClaimableBalancesByDestination(accountID xdr.AccountId) ([]Claim
 	return results, nil
 }
 
+// FindClaimableBalanceByID returns a claimable balance.
+func (q *Q) FindClaimableBalanceByID(balanceID string) (ClaimableBalance, error) {
+	var claimableBalance ClaimableBalance
+	sql := selectClaimableBalances.Limit(1).Where("cb.id = ?", balanceID)
+	err := q.Get(&claimableBalance, sql)
+	return claimableBalance, err
+}
+
 type claimableBalancesBatchInsertBuilder struct {
 	builder db.BatchInsertBuilder
 }

--- a/services/horizon/internal/db2/history/claimable_balances_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_test.go
@@ -57,7 +57,7 @@ func TestRemoveClaimableBalance(t *testing.T) {
 
 	r, err := q.FindClaimableBalanceByID(id)
 	tt.Assert.NoError(err)
-	tt.Assert.Len(r, 1)
+	tt.Assert.NotNil(r)
 
 	removed, err := q.RemoveClaimableBalance(cBalance)
 	tt.Assert.NoError(err)

--- a/services/horizon/internal/db2/history/claimable_balances_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_test.go
@@ -52,10 +52,7 @@ func TestRemoveClaimableBalance(t *testing.T) {
 	err = builder.Exec()
 	tt.Assert.NoError(err)
 
-	id, err := balanceIDToHex(cBalance.BalanceId)
-	tt.Assert.NoError(err)
-
-	r, err := q.FindClaimableBalanceByID(id)
+	r, err := q.FindClaimableBalanceByID(cBalance.BalanceId)
 	tt.Assert.NoError(err)
 	tt.Assert.NotNil(r)
 
@@ -287,12 +284,9 @@ func TestFindClaimableBalance(t *testing.T) {
 	err = builder.Exec()
 	tt.Assert.NoError(err)
 
-	id, err := balanceIDToHex(cBalance.BalanceId)
-
-	cb, err := q.FindClaimableBalanceByID(id)
+	cb, err := q.FindClaimableBalanceByID(cBalance.BalanceId)
 	tt.Assert.NoError(err)
 
-	tt.Assert.Equal(id, cb.ID)
 	tt.Assert.Equal(cBalance.BalanceId, cb.BalanceID)
 	tt.Assert.Equal(cBalance.Asset, cb.Asset)
 	tt.Assert.Equal(cBalance.Amount, cb.Amount)

--- a/services/horizon/internal/httpx/router.go
+++ b/services/horizon/internal/httpx/router.go
@@ -139,6 +139,10 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 			})
 		})
 
+		r.Route("/claimable_balances", func(r chi.Router) {
+			r.Method(http.MethodGet, "/{id}", ObjectActionHandler{actions.GetClaimableBalanceByIDHandler{}})
+		})
+
 		r.Route("/offers", func(r chi.Router) {
 			r.Method(http.MethodGet, "/", restPageHandler(actions.GetOffersHandler{}))
 			r.Method(http.MethodGet, "/{id}", ObjectActionHandler{actions.GetOfferByID{}})

--- a/services/horizon/internal/resourceadapter/claimable_balances.go
+++ b/services/horizon/internal/resourceadapter/claimable_balances.go
@@ -1,0 +1,49 @@
+package resourceadapter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stellar/go/amount"
+	protocol "github.com/stellar/go/protocols/horizon"
+	horizonContext "github.com/stellar/go/services/horizon/internal/context"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/render/hal"
+	"github.com/stellar/go/xdr"
+)
+
+// PopulateClaimableBalance fills out the resource's fields
+func PopulateClaimableBalance(
+	ctx context.Context,
+	dest *protocol.ClaimableBalance,
+	claimableBalance history.ClaimableBalance,
+) error {
+	dest.ID = claimableBalance.ID
+	balanceID, err := xdr.MarshalBase64(claimableBalance.BalanceID)
+	if err != nil {
+		return errors.Wrap(err, "marshalling BalanceID")
+	}
+	dest.BalanceID = balanceID
+	dest.Asset = claimableBalance.Asset.StringCanonical()
+	dest.Amount = amount.StringFromInt64(int64(claimableBalance.Amount))
+	if claimableBalance.Sponsor.Valid {
+		dest.Sponsor = claimableBalance.Sponsor.String
+	}
+	dest.LastModifiedLedger = claimableBalance.LastModifiedLedger
+	dest.Claimants = make([]protocol.Claimant, len(claimableBalance.Claimants))
+	for i, c := range claimableBalance.Claimants {
+		predicate, err := xdr.MarshalBase64(c.Predicate)
+		if err != nil {
+			errors.Wrap(err, "failed to encode predicate to base64")
+		}
+		dest.Claimants[i].Destination = c.Destination
+		dest.Claimants[i].Predicate = predicate
+	}
+
+	lb := hal.LinkBuilder{Base: horizonContext.BaseURL(ctx)}
+	self := fmt.Sprintf("/claimable_balances/%s", claimableBalance.ID)
+	dest.Links.Self = lb.Link(self)
+	dest.PT = fmt.Sprintf("%d-%s", claimableBalance.LastModifiedLedger, claimableBalance.ID)
+	return nil
+}

--- a/services/horizon/internal/resourceadapter/claimable_balances.go
+++ b/services/horizon/internal/resourceadapter/claimable_balances.go
@@ -19,8 +19,7 @@ func PopulateClaimableBalance(
 	dest *protocol.ClaimableBalance,
 	claimableBalance history.ClaimableBalance,
 ) error {
-	dest.ID = claimableBalance.ID
-	balanceID, err := xdr.MarshalBase64(claimableBalance.BalanceID)
+	balanceID, err := xdr.MarshalHex(claimableBalance.BalanceID)
 	if err != nil {
 		return errors.Wrap(err, "marshalling BalanceID")
 	}
@@ -42,8 +41,8 @@ func PopulateClaimableBalance(
 	}
 
 	lb := hal.LinkBuilder{Base: horizonContext.BaseURL(ctx)}
-	self := fmt.Sprintf("/claimable_balances/%s", claimableBalance.ID)
+	self := fmt.Sprintf("/claimable_balances/%s", dest.BalanceID)
 	dest.Links.Self = lb.Link(self)
-	dest.PT = fmt.Sprintf("%d-%s", claimableBalance.LastModifiedLedger, claimableBalance.ID)
+	dest.PT = fmt.Sprintf("%d-%s", claimableBalance.LastModifiedLedger, dest.BalanceID)
 	return nil
 }

--- a/services/horizon/internal/resourceadapter/claimable_balances_test.go
+++ b/services/horizon/internal/resourceadapter/claimable_balances_test.go
@@ -1,0 +1,64 @@
+package resourceadapter
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/guregu/null"
+	. "github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/test"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPopulateClaimableBalance(t *testing.T) {
+	tt := assert.New(t)
+	ctx, _ := test.ContextWithLogBuffer()
+	resource := ClaimableBalance{}
+
+	balanceID := xdr.ClaimableBalanceId{
+		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
+		V0:   &xdr.Hash{1, 2, 3},
+	}
+	claimableBalance := history.ClaimableBalance{
+		ID:        "AAAAAAECAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		BalanceID: balanceID,
+		Asset:     xdr.MustNewNativeAsset(),
+		Amount:    100000000,
+		Sponsor:   null.StringFrom("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+		Claimants: history.Claimants{
+			{
+				Destination: "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+				Predicate: xdr.ClaimPredicate{
+					Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
+				},
+			},
+		},
+		LastModifiedLedger: 123,
+	}
+
+	err := PopulateClaimableBalance(ctx, &resource, claimableBalance)
+	tt.NoError(err)
+
+	tt.Equal("AAAAAAECAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", resource.ID)
+	tt.Equal("AAAAAAECAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", resource.BalanceID)
+	tt.Equal(claimableBalance.Asset.StringCanonical(), resource.Asset)
+	tt.Equal("10.0000000", resource.Amount)
+	tt.Equal("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", resource.Sponsor)
+	tt.Equal(uint32(123), resource.LastModifiedLedger)
+	tt.Len(resource.Claimants, 1)
+	tt.Equal("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", resource.Claimants[0].Destination)
+	tt.Equal("AAAAAA==", resource.Claimants[0].Predicate)
+	tt.Equal("123-AAAAAAECAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", resource.PagingToken())
+
+	links, err := json.Marshal(resource.Links)
+	want := `
+	{
+	  "self": {
+		"href": "/claimable_balances/AAAAAAECAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	  }
+	}
+	`
+	tt.JSONEq(want, string(links))
+}

--- a/services/horizon/internal/resourceadapter/claimable_balances_test.go
+++ b/services/horizon/internal/resourceadapter/claimable_balances_test.go
@@ -22,7 +22,6 @@ func TestPopulateClaimableBalance(t *testing.T) {
 		V0:   &xdr.Hash{1, 2, 3},
 	}
 	claimableBalance := history.ClaimableBalance{
-		ID:        "AAAAAAECAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
 		BalanceID: balanceID,
 		Asset:     xdr.MustNewNativeAsset(),
 		Amount:    100000000,
@@ -41,8 +40,7 @@ func TestPopulateClaimableBalance(t *testing.T) {
 	err := PopulateClaimableBalance(ctx, &resource, claimableBalance)
 	tt.NoError(err)
 
-	tt.Equal("AAAAAAECAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", resource.ID)
-	tt.Equal("AAAAAAECAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", resource.BalanceID)
+	tt.Equal("000000000102030000000000000000000000000000000000000000000000000000000000", resource.BalanceID)
 	tt.Equal(claimableBalance.Asset.StringCanonical(), resource.Asset)
 	tt.Equal("10.0000000", resource.Amount)
 	tt.Equal("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", resource.Sponsor)
@@ -50,13 +48,13 @@ func TestPopulateClaimableBalance(t *testing.T) {
 	tt.Len(resource.Claimants, 1)
 	tt.Equal("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", resource.Claimants[0].Destination)
 	tt.Equal("AAAAAA==", resource.Claimants[0].Predicate)
-	tt.Equal("123-AAAAAAECAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", resource.PagingToken())
+	tt.Equal("123-000000000102030000000000000000000000000000000000000000000000000000000000", resource.PagingToken())
 
 	links, err := json.Marshal(resource.Links)
 	want := `
 	{
 	  "self": {
-		"href": "/claimable_balances/AAAAAAECAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+		"href": "/claimable_balances/000000000102030000000000000000000000000000000000000000000000000000000000"
 	  }
 	}
 	`


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Introduce end-point to fetch a single claimable balance by ID `/claimable_balances/id.`


### Why

User should be able to fetch claimable balances from Horizon using the its ID.

