### PR TITLE
services/horizon: (protocol 14) Fix various SponsoringID minor issues

### DIFF
--- a/services/horizon/internal/db2/history/accounts_test.go
+++ b/services/horizon/internal/db2/history/accounts_test.go
@@ -71,6 +71,7 @@ var (
 			},
 		},
 		Ext: xdr.LedgerEntryExt{
+			V: 1,
 			V1: &xdr.LedgerEntryExtensionV1{
 				SponsoringId: &sponsor,
 			},

--- a/services/horizon/internal/db2/history/sponsor.go
+++ b/services/horizon/internal/db2/history/sponsor.go
@@ -10,8 +10,7 @@ func ledgerEntrySponsorToNullString(entry xdr.LedgerEntry) null.String {
 
 	var sponsor null.String
 	if sponsoringID != nil {
-		accountID := xdr.AccountId(*sponsoringID)
-		sponsor.SetValid(accountID.Address())
+		sponsor.SetValid((*sponsoringID).Address())
 	}
 
 	return sponsor

--- a/services/horizon/internal/db2/history/trust_lines_test.go
+++ b/services/horizon/internal/db2/history/trust_lines_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/guregu/null"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/xdr"
-	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -35,6 +36,7 @@ var (
 			},
 		},
 		Ext: xdr.LedgerEntryExt{
+			V: 1,
 			V1: &xdr.LedgerEntryExtensionV1{
 				SponsoringId: &sponsor,
 			},
@@ -137,7 +139,10 @@ func TestUpdateTrustLine(t *testing.T) {
 	assert.Equal(t, int64(1), rows)
 
 	modifiedTrustLine := eurTrustLine
-	modifiedTrustLine.Ext.V1.SponsoringId = nil
+	// make sure we don't mutate eurTrustline
+	v1Copy := *eurTrustLine.Ext.V1
+	v1Copy.SponsoringId = nil
+	modifiedTrustLine.Ext.V1 = &v1Copy
 	modifiedTrustLine.Data.TrustLine.Balance = 30000
 
 	rows, err = q.UpdateTrustLine(modifiedTrustLine)
@@ -246,6 +251,7 @@ func TestUpsertTrustLines(t *testing.T) {
 			},
 		},
 		Ext: xdr.LedgerEntryExt{
+			V: 1,
 			V1: &xdr.LedgerEntryExtensionV1{
 				SponsoringId: &sponsor,
 			},
@@ -254,6 +260,7 @@ func TestUpsertTrustLines(t *testing.T) {
 
 	actualBinary, err := dbEntry.MarshalBinary()
 	assert.NoError(t, err)
+	assert.Equal(t, modifiedTrustLine, dbEntry)
 	assert.Equal(t, expectedBinary, actualBinary)
 	assert.Equal(t, uint32(1234), lines[0].LastModifiedLedger)
 

--- a/xdr/ledger_entry.go
+++ b/xdr/ledger_entry.go
@@ -50,7 +50,7 @@ func (entry *LedgerEntry) LedgerKey() LedgerKey {
 // SponsoringID return SponsorshipDescriptor for a given ledger entry
 func (entry *LedgerEntry) SponsoringID() SponsorshipDescriptor {
 	var sponsor SponsorshipDescriptor
-	if entry.Ext.V1 != nil {
+	if entry.Ext.V == 1 && entry.Ext.V1 != nil {
 		sponsor = entry.Ext.V1.SponsoringId
 	}
 	return sponsor

--- a/xdr/ledger_entry_test.go
+++ b/xdr/ledger_entry_test.go
@@ -16,6 +16,7 @@ func TestLedgerEntrySponsorship(t *testing.T) {
 
 	entry = LedgerEntry{
 		Ext: LedgerEntryExt{
+			V: 1,
 			V1: &LedgerEntryExtensionV1{
 				SponsoringId: desc,
 			},


### PR DESCRIPTION
* Avoid unnecessary casting
* Make sure we check for the version of the ledger entry extension
  (to make the code future-proof)
* Fix flakey `UpsertTrustlines` test
