### PR TITLE
services/horizon: Fix route query params for offers/:offer_id.

### DIFF
--- a/services/horizon/internal/action_offers_test.go
+++ b/services/horizon/internal/action_offers_test.go
@@ -1,0 +1,84 @@
+package horizon
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/expingest"
+	"github.com/stellar/go/xdr"
+)
+
+func TestOfferActions_Show(t *testing.T) {
+	ht := StartHTTPTestWithoutScenario(t)
+	defer ht.Finish()
+	q := &history.Q{ht.HorizonSession()}
+
+	err := q.UpdateLastLedgerExpIngest(100)
+	ht.Assert.NoError(err)
+	err = q.UpdateExpIngestVersion(expingest.CurrentVersion)
+	ht.Assert.NoError(err)
+
+	ledgerCloseTime := time.Now().Unix()
+	_, err = q.InsertLedger(xdr.LedgerHeaderHistoryEntry{
+		Header: xdr.LedgerHeader{
+			LedgerSeq: 100,
+			ScpValue: xdr.StellarValue{
+				CloseTime: xdr.TimePoint(ledgerCloseTime),
+			},
+		},
+	}, 0, 0, 0, 0, 0)
+	ht.Assert.NoError(err)
+
+	issuer := xdr.MustAddress("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	nativeAsset := xdr.MustNewNativeAsset()
+	usdAsset := xdr.MustNewCreditAsset("USD", issuer.Address())
+	eurAsset := xdr.MustNewCreditAsset("EUR", issuer.Address())
+
+	eurOffer := xdr.OfferEntry{
+		SellerId: issuer,
+		OfferId:  xdr.Int64(4),
+		Buying:   eurAsset,
+		Selling:  nativeAsset,
+		Price: xdr.Price{
+			N: 1,
+			D: 1,
+		},
+		Flags:  1,
+		Amount: xdr.Int64(500),
+	}
+	usdOffer := xdr.OfferEntry{
+		SellerId: issuer,
+		OfferId:  xdr.Int64(6),
+		Buying:   usdAsset,
+		Selling:  eurAsset,
+		Price: xdr.Price{
+			N: 1,
+			D: 1,
+		},
+		Flags:  1,
+		Amount: xdr.Int64(500),
+	}
+
+	batch := q.NewOffersBatchInsertBuilder(3)
+	err = batch.Add(eurOffer, 3)
+	ht.Assert.NoError(err)
+	err = batch.Add(usdOffer, 4)
+	ht.Assert.NoError(err)
+	ht.Assert.NoError(batch.Exec())
+
+	w := ht.Get("/offers")
+	if ht.Assert.Equal(200, w.Code) {
+		ht.Assert.PageOf(2, w.Body)
+	}
+
+	w = ht.Get("/offers/4")
+	if ht.Assert.Equal(200, w.Code) {
+		var response horizon.Offer
+		err = json.Unmarshal(w.Body.Bytes(), &response)
+		ht.Assert.NoError(err)
+		ht.Assert.Equal(int64(4), response.ID)
+	}
+}

--- a/services/horizon/internal/httpx/router.go
+++ b/services/horizon/internal/httpx/router.go
@@ -143,7 +143,7 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 
 		r.Route("/offers", func(r chi.Router) {
 			r.Method(http.MethodGet, "/", restPageHandler(actions.GetOffersHandler{}))
-			r.Method(http.MethodGet, "/{id}", ObjectActionHandler{actions.GetOfferByID{}})
+			r.Method(http.MethodGet, "/{offer_id}", ObjectActionHandler{actions.GetOfferByID{}})
 		})
 
 		r.Method(http.MethodGet, "/assets", restPageHandler(actions.AssetStatsHandler{}))


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fix route query params for `offers/:offer_id`.

### Why

The route was defining the ID query param as `:id` but the action handler was trying to find `:offer_id` -- making all request of type `/offers/XX` to return `404`. 

This bug was introduced in horizon-v1.7.0


### Known limitations

