### PR TITLE
services/horizon/ingest: Store balance_id as HEX in details and effects.

### DIFF
--- a/services/horizon/internal/expingest/processors/effects_processor.go
+++ b/services/horizon/internal/expingest/processors/effects_processor.go
@@ -703,7 +703,7 @@ func (operation *transactionOperationWrapper) createClaimableBalanceEffects() ([
 	}
 
 	result := operation.OperationResult().MustCreateClaimableBalanceResult()
-	balanceID, err := xdr.MarshalBase64(result.BalanceId)
+	balanceID, err := xdr.MarshalHex(result.BalanceId)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Invalid balanceId in op: %d", operation.index)
 	}
@@ -756,7 +756,7 @@ func (operation *transactionOperationWrapper) claimClaimableBalanceEffects() ([]
 		operation: operation,
 	}
 
-	balanceID, err := xdr.MarshalBase64(op.BalanceId)
+	balanceID, err := xdr.MarshalHex(op.BalanceId)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid balanceId in op: %d", operation.index)
 	}

--- a/services/horizon/internal/expingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/expingest/processors/effects_processor_test.go
@@ -1531,7 +1531,7 @@ func (s *CreateClaimableBalanceEffectsTestSuite) TestEffects() {
 					details: map[string]interface{}{
 						"asset":      "native",
 						"amount":     "10.0000000",
-						"balance_id": "AAAAANoNV9p9SFDn/BDSqdDrxzH3r7QFdMAzlbF9SRSbkfW+",
+						"balance_id": "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
 					},
 					effectType:  history.EffectClaimableBalanceCreated,
 					operationID: int64(4294967297),
@@ -1542,7 +1542,7 @@ func (s *CreateClaimableBalanceEffectsTestSuite) TestEffects() {
 					details: map[string]interface{}{
 						"asset":      "native",
 						"amount":     "10.0000000",
-						"balance_id": "AAAAANoNV9p9SFDn/BDSqdDrxzH3r7QFdMAzlbF9SRSbkfW+",
+						"balance_id": "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
 						"predicate":  "AAAAAA==",
 					},
 					effectType:  history.EffectClaimableBalanceClaimantCreated,
@@ -1570,7 +1570,7 @@ func (s *CreateClaimableBalanceEffectsTestSuite) TestEffects() {
 					details: map[string]interface{}{
 						"asset":      "USD:GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
 						"amount":     "20.0000000",
-						"balance_id": "AAAAALHcX0PDa9UefSAzitC6vQOUr802phH8OF2ahLzg6j1D",
+						"balance_id": "00000000b1dc5f43c36bd51e7d20338ad0babd0394afcd36a611fc385d9a84bce0ea3d43",
 					},
 					effectType:  history.EffectClaimableBalanceCreated,
 					operationID: int64(4294967298),
@@ -1581,7 +1581,7 @@ func (s *CreateClaimableBalanceEffectsTestSuite) TestEffects() {
 					details: map[string]interface{}{
 						"asset":      "USD:GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
 						"amount":     "20.0000000",
-						"balance_id": "AAAAALHcX0PDa9UefSAzitC6vQOUr802phH8OF2ahLzg6j1D",
+						"balance_id": "00000000b1dc5f43c36bd51e7d20338ad0babd0394afcd36a611fc385d9a84bce0ea3d43",
 						"predicate":  "AAAAAA==",
 					},
 					effectType:  history.EffectClaimableBalanceClaimantCreated,
@@ -1593,7 +1593,7 @@ func (s *CreateClaimableBalanceEffectsTestSuite) TestEffects() {
 					details: map[string]interface{}{
 						"asset":      "USD:GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
 						"amount":     "20.0000000",
-						"balance_id": "AAAAALHcX0PDa9UefSAzitC6vQOUr802phH8OF2ahLzg6j1D",
+						"balance_id": "00000000b1dc5f43c36bd51e7d20338ad0babd0394afcd36a611fc385d9a84bce0ea3d43",
 						"predicate":  "AAAAAA==",
 					},
 					effectType:  history.EffectClaimableBalanceClaimantCreated,
@@ -1818,7 +1818,7 @@ func (s *ClaimClaimableBalanceEffectsTestSuite) TestEffects() {
 					details: map[string]interface{}{
 						"asset":      "native",
 						"amount":     "10.0000000",
-						"balance_id": "AAAAANoNV9p9SFDn/BDSqdDrxzH3r7QFdMAzlbF9SRSbkfW+",
+						"balance_id": "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
 					},
 					effectType:  history.EffectClaimableBalanceClaimed,
 					operationID: int64(4294967297),
@@ -1845,7 +1845,7 @@ func (s *ClaimClaimableBalanceEffectsTestSuite) TestEffects() {
 					details: map[string]interface{}{
 						"asset":      "USD:GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
 						"amount":     "20.0000000",
-						"balance_id": "AAAAALHcX0PDa9UefSAzitC6vQOUr802phH8OF2ahLzg6j1D",
+						"balance_id": "00000000b1dc5f43c36bd51e7d20338ad0babd0394afcd36a611fc385d9a84bce0ea3d43",
 					},
 					effectType:  history.EffectClaimableBalanceClaimed,
 					operationID: int64(4294967298),

--- a/services/horizon/internal/expingest/processors/operations_processor.go
+++ b/services/horizon/internal/expingest/processors/operations_processor.go
@@ -298,7 +298,7 @@ func (operation *transactionOperationWrapper) Details() map[string]interface{} {
 		details["claimants"] = claimants
 	case xdr.OperationTypeClaimClaimableBalance:
 		op := operation.operation.Body.MustClaimClaimableBalanceOp()
-		balanceID, err := xdr.MarshalBase64(op.BalanceId)
+		balanceID, err := xdr.MarshalHex(op.BalanceId)
 		if err != nil {
 			panic(fmt.Errorf("Invalid balanceId in op: %d", operation.index))
 		}

--- a/services/horizon/internal/expingest/processors/transaction_operation_wrapper_test.go
+++ b/services/horizon/internal/expingest/processors/transaction_operation_wrapper_test.go
@@ -1140,11 +1140,11 @@ type ClaimClaimableBalanceOpTestSuite struct {
 }
 
 func (s *ClaimClaimableBalanceOpTestSuite) SetupTest() {
-	s.balanceID = "AAAAANoNV9p9SFDn/BDSqdDrxzH3r7QFdMAzlbF9SRSbkfW+"
+	s.balanceID = "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be"
 	aid := xdr.MustAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD")
 	source := aid.ToMuxedAccount()
 	var balanceID xdr.ClaimableBalanceId
-	xdr.SafeUnmarshalBase64(s.balanceID, &balanceID)
+	xdr.SafeUnmarshalHex(s.balanceID, &balanceID)
 	s.op = xdr.Operation{
 		SourceAccount: &source,
 		Body: xdr.OperationBody{


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Store `balance_id` as a hex value, which allows navigating from details or effects page to the resource.

### Why

People should be able to fetch the associated balance_id from the operations or effects page.

### Known limitations

[TODO or N/A]
