### PR TITLE
exp/ingest/io: Fix LedgerTransactionReader tx meta check

### DIFF
--- a/exp/ingest/io/ledger_change_reader_test.go
+++ b/exp/ingest/io/ledger_change_reader_test.go
@@ -259,9 +259,25 @@ func TestLedgerChangeReaderOrder(t *testing.T) {
 		t,
 		err,
 		"error extracting transactions from ledger close meta: TransactionMeta.V=2 is required in protocol"+
-			" version older than version 10. Please process ledgers again using stellar-core with "+
-			"SUPPORTED_META_VERSION=2 in the config file.",
+			" version older than version 10. Please process ledgers again using the latest stellar-core version.",
 	)
+	mock.AssertExpectations(t)
+
+	ledger.V0.LedgerHeader.Header.LedgerVersion = 9
+	ledger.V0.TxProcessing[0].FeeProcessing = xdr.LedgerEntryChanges{}
+	ledger.V0.TxProcessing[1].FeeProcessing = xdr.LedgerEntryChanges{}
+	mock.On("GetLedger", seq).Return(true, ledger, nil).Once()
+
+	assertChangesEqual(t, seq, mock, []balanceEntry{
+		{metaAddress, 300},
+		{metaAddress, 400},
+		{metaAddress, 600},
+		{metaAddress, 700},
+		{metaAddress, 800},
+		{metaAddress, 900},
+		{upgradeAddress, 2},
+		{upgradeAddress, 3},
+	})
 	mock.AssertExpectations(t)
 
 	ledger.V0.LedgerHeader.Header.LedgerVersion = 10

--- a/exp/ingest/io/ledger_transaction_reader.go
+++ b/exp/ingest/io/ledger_transaction_reader.go
@@ -82,10 +82,13 @@ func (reader *LedgerTransactionReader) storeTransactions(lcm xdr.LedgerCloseMeta
 			return errors.Errorf("unknown tx hash in LedgerCloseMeta: %v", hexHash)
 		}
 
-		if lcm.V0.LedgerHeader.Header.LedgerVersion < 10 && lcm.V0.TxProcessing[i].TxApplyProcessing.V != 2 {
+		// We check the version only if FeeProcessing are non empty because some backends
+		// (like HistoryArchiveBackend) do not return meta.
+		if lcm.V0.LedgerHeader.Header.LedgerVersion < 10 && lcm.V0.TxProcessing[i].TxApplyProcessing.V != 2 &&
+			len(lcm.V0.TxProcessing[i].FeeProcessing) > 0 {
 			return errors.New(
 				"TransactionMeta.V=2 is required in protocol version older than version 10. " +
-					"Please process ledgers again using stellar-core with SUPPORTED_META_VERSION=2 in the config file.",
+					"Please process ledgers again using the latest stellar-core version.",
 			)
 		}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

Due to a bug in Stellar-Core (more info in https://github.com/stellar/go/pull/2099) we check if the meta version is at least 2 for protocol version < 10. However, some backend like `HistoryArchiveBackend` do not return tx meta. For such backends we should skip the check. The check is safe because each transaction has fee changes associated with it so it will be empty if no meta is available.