### PR TITLE
services/horizon: Export horizon_build_info in /metrics

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -68,6 +68,7 @@ type App struct {
 
 	// metrics
 	prometheusRegistry         *prometheus.Registry
+	buildInfoGauge             *prometheus.GaugeVec
 	historyLatestLedgerCounter prometheus.CounterFunc
 	historyElderLedgerCounter  prometheus.CounterFunc
 	dbOpenConnectionsGauge     prometheus.GaugeFunc

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -3,6 +3,7 @@ package horizon
 import (
 	"context"
 	"net/http"
+	"runtime"
 
 	"github.com/getsentry/raven-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -119,6 +120,16 @@ func initLogglyLog(app *App) {
 }
 
 func initDbMetrics(app *App) {
+	app.buildInfoGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Namespace: "horizon", Subsystem: "build", Name: "info"},
+		[]string{"version", "goversion"},
+	)
+	app.prometheusRegistry.MustRegister(app.buildInfoGauge)
+	app.buildInfoGauge.With(prometheus.Labels{
+		"version":   app.horizonVersion,
+		"goversion": runtime.Version(),
+	}).Inc()
+
 	app.historyLatestLedgerCounter = prometheus.NewCounterFunc(
 		prometheus.CounterOpts{Namespace: "horizon", Subsystem: "history", Name: "latest_ledger"},
 		func() float64 {

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -29,7 +29,6 @@ func mustNewDBSession(databaseURL string, maxIdle, maxOpen int) *db.Session {
 	return session
 }
 
-
 func mustInitHorizonDB(app *App) {
 	maxIdle := app.config.HorizonDBMaxIdleConnections
 	maxOpen := app.config.HorizonDBMaxOpenConnections


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit adds `horizon_build_info` to `/metrics` with the Horizon and Go runtime versions.

### Why

The metric labels will be used in Horizon dashboard to ensure all nodes are running the same version.
