### PR TITLE
services/horizon: Add horizon_db_max_open_connections metric

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -70,6 +70,7 @@ type App struct {
 	prometheusRegistry         *prometheus.Registry
 	historyLatestLedgerCounter prometheus.CounterFunc
 	historyElderLedgerCounter  prometheus.CounterFunc
+	dbMaxOpenConnectionsGauge  prometheus.GaugeFunc
 	dbOpenConnectionsGauge     prometheus.GaugeFunc
 	dbInUseConnectionsGauge    prometheus.GaugeFunc
 	dbWaitCountCounter         prometheus.CounterFunc

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -146,6 +146,17 @@ func initDbMetrics(app *App) {
 	)
 	app.prometheusRegistry.MustRegister(app.coreLatestLedgerCounter)
 
+	app.dbMaxOpenConnectionsGauge = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{Namespace: "horizon", Subsystem: "db", Name: "max_open_connections"},
+		func() float64 {
+			// Right now MaxOpenConnections in Horizon is static however it's possible that
+			// it will change one day. In such case, using GaugeFunc is very cheap and will
+			// prevent issues with this metric in the future.
+			return float64(app.historyQ.Session.DB.Stats().MaxOpenConnections)
+		},
+	)
+	app.prometheusRegistry.MustRegister(app.dbMaxOpenConnectionsGauge)
+
 	app.dbOpenConnectionsGauge = prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{Namespace: "horizon", Subsystem: "db", Name: "open_connections"},
 		func() float64 {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

This commit adds `horizon_db_max_open_connections` metric that indicates the max number of possible open DB connections. This is static right now but we want this to be exposed to create alert for in_use/max_open connections in Prometheus.