### PR TITLE
services/horizon: Improve /accounts/{id}/transactions|payments|operations performance

### DIFF
--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -375,6 +375,14 @@ var configOpts = support.ConfigOptions{
 		Required:    false,
 		Usage:       "applies pending migrations before starting horizon",
 	},
+	&support.ConfigOption{
+		Name:        "exp-use-extra-participants-fields",
+		ConfigKey:   &config.UseExtraParticipantsFields,
+		OptType:     types.Bool,
+		FlagDefault: false,
+		Required:    false,
+		Usage:       "makes Horizon use extra fields on hopp table, this is much faster but requires a full history reingestion so it's behind a feature flag",
+	},
 }
 
 func init() {

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -59,7 +59,8 @@ func (qp OperationsQuery) Validate() error {
 
 // GetOperationsHandler is the action handler for all end-points returning a list of operations.
 type GetOperationsHandler struct {
-	OnlyPayments bool
+	OnlyPayments                 bool
+	UseDBExtraParticipantsFields bool
 }
 
 // GetResourcePage returns a page of operations.
@@ -87,7 +88,7 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 		return nil, err
 	}
 
-	query := historyQ.Operations()
+	query := historyQ.Operations(handler.UseDBExtraParticipantsFields)
 
 	switch {
 	case qp.AccountID != "":

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -447,19 +447,20 @@ func (a *App) init() error {
 	initTxSubMetrics(a)
 
 	webConfig := &httpx.RouterConfig{
-		DBSession:          a.historyQ.Session,
-		TxSubmitter:        a.submitter,
-		RateQuota:          a.config.RateQuota,
-		SSEUpdateFrequency: a.config.SSEUpdateFrequency,
-		StaleThreshold:     a.config.StaleThreshold,
-		ConnectionTimeout:  a.config.ConnectionTimeout,
-		NetworkPassphrase:  a.config.NetworkPassphrase,
-		MaxPathLength:      a.config.MaxPathLength,
-		PathFinder:         a.paths,
-		PrometheusRegistry: a.prometheusRegistry,
-		CoreGetter:         a,
-		HorizonVersion:     a.horizonVersion,
-		FriendbotURL:       a.config.FriendbotURL,
+		DBSession:                    a.historyQ.Session,
+		TxSubmitter:                  a.submitter,
+		RateQuota:                    a.config.RateQuota,
+		SSEUpdateFrequency:           a.config.SSEUpdateFrequency,
+		StaleThreshold:               a.config.StaleThreshold,
+		ConnectionTimeout:            a.config.ConnectionTimeout,
+		NetworkPassphrase:            a.config.NetworkPassphrase,
+		MaxPathLength:                a.config.MaxPathLength,
+		PathFinder:                   a.paths,
+		PrometheusRegistry:           a.prometheusRegistry,
+		CoreGetter:                   a,
+		HorizonVersion:               a.horizonVersion,
+		FriendbotURL:                 a.config.FriendbotURL,
+		UseDBExtraParticipantsFields: a.config.UseExtraParticipantsFields,
 	}
 
 	var err error

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -69,4 +69,8 @@ type Config struct {
 	// ApplyMigrations will apply pending migrations to the horizon database
 	// before starting the horizon service
 	ApplyMigrations bool
+	// UseExtraParticipantsFields makes Horizon use extra fields on hopp table.
+	// This is much faster but requires a full history reingestion so it's behind
+	// a feature flag.
+	UseExtraParticipantsFields bool
 }

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -456,9 +456,16 @@ type offersBatchInsertBuilder struct {
 // OperationsQ is a helper struct to aid in configuring queries that loads
 // slices of Operation structs.
 type OperationsQ struct {
+	// UseExtraParticipantsFields makes OperationsQ to use hopp.successful and
+	// hopp.payment fields when querying operations for account. This is much
+	// faster but requires a full history reingestion so it's behind a feature
+	// flag.
+	UseExtraParticipantsFields bool
+
 	Err                 error
 	parent              *Q
 	sql                 sq.SelectBuilder
+	forAccount          bool
 	opIdCol             string
 	includeFailed       bool
 	includeTransactions bool

--- a/services/horizon/internal/db2/history/mock_operation_participant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_operation_participant_batch_insert_builder.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -10,8 +11,8 @@ type MockOperationParticipantBatchInsertBuilder struct {
 }
 
 // Add mock
-func (m *MockOperationParticipantBatchInsertBuilder) Add(operationID int64, accountID int64) error {
-	a := m.Called(operationID, accountID)
+func (m *MockOperationParticipantBatchInsertBuilder) Add(operationID int64, accountID int64, successful bool, opType xdr.OperationType) error {
+	a := m.Called(operationID, accountID, successful, opType)
 	return a.Error(0)
 }
 

--- a/services/horizon/internal/db2/history/mock_q_participants.go
+++ b/services/horizon/internal/db2/history/mock_q_participants.go
@@ -31,8 +31,8 @@ type MockTransactionParticipantsBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockTransactionParticipantsBatchInsertBuilder) Add(transactionID, accountID int64) error {
-	a := m.Called(transactionID, accountID)
+func (m *MockTransactionParticipantsBatchInsertBuilder) Add(transactionID, accountID int64, successful bool) error {
+	a := m.Called(transactionID, accountID, successful)
 	return a.Error(0)
 }
 

--- a/services/horizon/internal/db2/history/operation_participant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/operation_participant_batch_insert_builder.go
@@ -2,15 +2,13 @@ package history
 
 import (
 	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/xdr"
 )
 
 // OperationParticipantBatchInsertBuilder is used to insert a transaction's operations into the
 // history_operations table
 type OperationParticipantBatchInsertBuilder interface {
-	Add(
-		operationID int64,
-		accountID int64,
-	) error
+	Add(operationID, accountID int64, successful bool, opType xdr.OperationType) error
 	Exec() error
 }
 
@@ -31,12 +29,14 @@ func (q *Q) NewOperationParticipantBatchInsertBuilder(maxBatchSize int) Operatio
 
 // Add adds an operation participant to the batch
 func (i *operationParticipantBatchInsertBuilder) Add(
-	operationID int64,
-	accountID int64,
+	operationID, accountID int64, successful bool, opType xdr.OperationType,
 ) error {
+	payment := isPaymentFamilyOperation(opType)
 	return i.builder.Row(map[string]interface{}{
 		"history_operation_id": operationID,
 		"history_account_id":   accountID,
+		"successful":           successful,
+		"payment":              payment,
 	})
 }
 

--- a/services/horizon/internal/db2/history/operation_participant_batch_insert_builder_test.go
+++ b/services/horizon/internal/db2/history/operation_participant_batch_insert_builder_test.go
@@ -5,6 +5,7 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/xdr"
 )
 
 func TestAddOperationParticipants(t *testing.T) {
@@ -14,7 +15,10 @@ func TestAddOperationParticipants(t *testing.T) {
 	q := &Q{tt.HorizonSession()}
 
 	builder := q.NewOperationParticipantBatchInsertBuilder(1)
-	err := builder.Add(240518172673, 1)
+	err := builder.Add(240518172673, 1, false, xdr.OperationTypeManageBuyOffer)
+	err = builder.Add(240518172674, 1, false, xdr.OperationTypePayment)
+	err = builder.Add(240518172675, 1, true, xdr.OperationTypeManageSellOffer)
+	err = builder.Add(240518172676, 1, true, xdr.OperationTypeCreateAccount)
 	tt.Assert.NoError(err)
 
 	err = builder.Exec()
@@ -23,20 +27,43 @@ func TestAddOperationParticipants(t *testing.T) {
 	type hop struct {
 		OperationID int64 `db:"history_operation_id"`
 		AccountID   int64 `db:"history_account_id"`
+		Payment     bool  `db:"payment"`
+		Successful  bool  `db:"successful"`
 	}
 
 	ops := []hop{}
 	err = q.Select(&ops, sq.Select(
-		"hopp.history_operation_id, "+
-			"hopp.history_account_id").
+		"hopp.history_operation_id, hopp.history_account_id, hopp.payment, hopp.successful").
 		From("history_operation_participants hopp"),
 	)
 
 	if tt.Assert.NoError(err) {
-		tt.Assert.Len(ops, 1)
+		tt.Assert.Len(ops, 4)
 
-		op := ops[0]
+		var op hop
+
+		op = ops[0]
 		tt.Assert.Equal(int64(240518172673), op.OperationID)
 		tt.Assert.Equal(int64(1), op.AccountID)
+		tt.Assert.Equal(false, op.Successful)
+		tt.Assert.Equal(false, op.Payment)
+
+		op = ops[1]
+		tt.Assert.Equal(int64(240518172674), op.OperationID)
+		tt.Assert.Equal(int64(1), op.AccountID)
+		tt.Assert.Equal(false, op.Successful)
+		tt.Assert.Equal(true, op.Payment)
+
+		op = ops[2]
+		tt.Assert.Equal(int64(240518172675), op.OperationID)
+		tt.Assert.Equal(int64(1), op.AccountID)
+		tt.Assert.Equal(true, op.Successful)
+		tt.Assert.Equal(false, op.Payment)
+
+		op = ops[3]
+		tt.Assert.Equal(int64(240518172676), op.OperationID)
+		tt.Assert.Equal(int64(1), op.AccountID)
+		tt.Assert.Equal(true, op.Successful)
+		tt.Assert.Equal(true, op.Payment)
 	}
 }

--- a/services/horizon/internal/db2/history/participants.go
+++ b/services/horizon/internal/db2/history/participants.go
@@ -14,7 +14,7 @@ type QParticipants interface {
 // TransactionParticipantsBatchInsertBuilder is used to insert transaction participants into the
 // history_transaction_participants table
 type TransactionParticipantsBatchInsertBuilder interface {
-	Add(transactionID, accountID int64) error
+	Add(transactionID, accountID int64, successful bool) error
 	Exec() error
 }
 
@@ -33,10 +33,11 @@ func (q *Q) NewTransactionParticipantsBatchInsertBuilder(maxBatchSize int) Trans
 }
 
 // Add adds a new transaction participant to the batch
-func (i *transactionParticipantsBatchInsertBuilder) Add(transactionID, accountID int64) error {
+func (i *transactionParticipantsBatchInsertBuilder) Add(transactionID, accountID int64, successful bool) error {
 	return i.builder.Row(map[string]interface{}{
 		"history_transaction_id": transactionID,
 		"history_account_id":     accountID,
+		"successful":             successful,
 	})
 }
 

--- a/services/horizon/internal/db2/history/participants_test.go
+++ b/services/horizon/internal/db2/history/participants_test.go
@@ -10,11 +10,12 @@ import (
 type transactionParticipant struct {
 	TransactionID int64 `db:"history_transaction_id"`
 	AccountID     int64 `db:"history_account_id"`
+	Successful    bool  `db:"successful"`
 }
 
 func getTransactionParticipants(tt *test.T, q *Q) []transactionParticipant {
 	var participants []transactionParticipant
-	sql := sq.Select("history_transaction_id", "history_account_id").
+	sql := sq.Select("history_transaction_id", "history_account_id", "successful").
 		From("history_transaction_participants").
 		OrderBy("(history_transaction_id, history_account_id) asc")
 
@@ -39,19 +40,23 @@ func TestTransactionParticipantsBatch(t *testing.T) {
 	accountID := int64(100)
 
 	for i := int64(0); i < 3; i++ {
-		tt.Assert.NoError(batch.Add(transactionID, accountID+i))
+		successful := true
+		if i%2 == 0 {
+			successful = false
+		}
+		tt.Assert.NoError(batch.Add(transactionID, accountID+i, successful))
 	}
 
-	tt.Assert.NoError(batch.Add(otherTransactionID, accountID))
+	tt.Assert.NoError(batch.Add(otherTransactionID, accountID, true))
 	tt.Assert.NoError(batch.Exec())
 
 	participants := getTransactionParticipants(tt, q)
 	tt.Assert.Equal(
 		[]transactionParticipant{
-			transactionParticipant{TransactionID: 1, AccountID: 100},
-			transactionParticipant{TransactionID: 1, AccountID: 101},
-			transactionParticipant{TransactionID: 1, AccountID: 102},
-			transactionParticipant{TransactionID: 2, AccountID: 100},
+			transactionParticipant{TransactionID: 1, AccountID: 100, Successful: false},
+			transactionParticipant{TransactionID: 1, AccountID: 101, Successful: true},
+			transactionParticipant{TransactionID: 1, AccountID: 102, Successful: false},
+			transactionParticipant{TransactionID: 2, AccountID: 100, Successful: true},
 		},
 		participants,
 	)

--- a/services/horizon/internal/db2/history/transaction_test.go
+++ b/services/horizon/internal/db2/history/transaction_test.go
@@ -728,13 +728,13 @@ func TestFetchFeeBumpTransaction(t *testing.T) {
 	tt.Assert.Equal(byOuterhash, byInnerHash)
 	tt.Assert.Equal(byOuterhash, fixture.Transaction)
 
-	outerOps, outerTransactions, err := q.Operations().IncludeTransactions().
+	outerOps, outerTransactions, err := q.Operations(false).IncludeTransactions().
 		ForTransaction(fixture.OuterHash).Fetch()
 	tt.Assert.NoError(err)
 	tt.Assert.Len(outerTransactions, 1)
 	tt.Assert.Len(outerOps, 1)
 
-	innerOps, innerTransactions, err := q.Operations().IncludeTransactions().
+	innerOps, innerTransactions, err := q.Operations(false).IncludeTransactions().
 		ForTransaction(fixture.InnerHash).Fetch()
 	tt.Assert.NoError(err)
 	tt.Assert.Len(innerTransactions, 1)

--- a/services/horizon/internal/db2/schema/bindata.go
+++ b/services/horizon/internal/db2/schema/bindata.go
@@ -33,6 +33,7 @@
 // migrations/38_add_constraints.sql (7.33kB)
 // migrations/39_history_trades_indices.sql (183B)
 // migrations/3_use_sequence_in_history_accounts.sql (447B)
+// migrations/40_history_operation_participants_is_payment_successful.sql (494B)
 // migrations/4_add_protocol_version.sql (188B)
 // migrations/5_create_trades_table.sql (1.1kB)
 // migrations/6_create_assets_table.sql (366B)
@@ -768,6 +769,26 @@ func migrations3_use_sequence_in_history_accountsSql() (*asset, error) {
 	return a, nil
 }
 
+var _migrations40_history_operation_participants_is_payment_successfulSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xa4\xd0\xb1\x0a\xc2\x30\x10\xc6\xf1\xbd\x4f\x71\xbb\xf4\x09\x9c\xa2\xa9\x53\x6c\xa5\x34\x73\x39\x43\xd4\x40\x9b\x0b\xb9\x2b\xd2\xb7\x77\xb4\x08\x0e\xd1\x07\xb8\x3f\xf7\xfd\xea\x1a\x76\x73\xb8\x67\x14\x0f\x36\x55\x95\x32\x43\xd3\xc3\xa0\x0e\xa6\x81\x47\x60\xa1\xbc\x8e\x94\x7c\x46\x09\x14\xc7\x84\x59\x82\x0b\x09\xa3\x30\x28\xad\xe1\xd8\x19\x7b\x6e\x21\xe1\x3a\xfb\x28\x70\x25\x9a\x3c\x46\xd0\xcd\x49\x59\x33\x40\x6b\x8d\xd9\xff\xd8\xe4\xc5\x39\xcf\x7c\x5b\xa6\x82\xac\x64\x8c\x8c\xee\xbf\x70\xb5\x45\xd1\xf4\x8c\x45\x2c\xba\xef\x2e\x1f\x2e\x45\x04\xdb\xfb\xf7\xab\x85\x73\xbf\x44\x5e\x01\x00\x00\xff\xff\x2e\x97\xb6\xb8\xee\x01\x00\x00")
+
+func migrations40_history_operation_participants_is_payment_successfulSqlBytes() ([]byte, error) {
+	return bindataRead(
+		_migrations40_history_operation_participants_is_payment_successfulSql,
+		"migrations/40_history_operation_participants_is_payment_successful.sql",
+	)
+}
+
+func migrations40_history_operation_participants_is_payment_successfulSql() (*asset, error) {
+	bytes, err := migrations40_history_operation_participants_is_payment_successfulSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "migrations/40_history_operation_participants_is_payment_successful.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa9, 0xda, 0x6f, 0xb0, 0x31, 0x64, 0x1f, 0x67, 0xe9, 0x94, 0x0, 0x31, 0x76, 0x58, 0xc1, 0x54, 0xe4, 0x6f, 0x73, 0x46, 0x95, 0xa6, 0x53, 0xed, 0x84, 0x39, 0x78, 0xc5, 0xbb, 0x7, 0xe8, 0x23}}
+	return a, nil
+}
+
 var _migrations4_add_protocol_versionSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x84\xcd\xb1\x0a\xc2\x30\x10\x06\xe0\x3d\x4f\xf1\xef\x52\x70\xef\x14\x4d\x9d\xce\x44\x4a\x32\x38\x15\xd1\xa3\x06\x6a\xae\x5c\x82\xe2\xdb\xbb\xba\x88\x4f\xf0\x75\x1d\x36\x8f\x3c\xeb\xa5\x31\xd2\x6a\x2c\xc5\x61\x44\xb4\x3b\x1a\x10\x3c\x9d\x71\xcf\xb5\x89\xbe\xa7\x85\x6f\x33\x6b\x85\x01\xac\x73\xd8\x07\x4a\x47\x8f\x55\xa5\xc9\x55\x96\xe9\xc9\x5a\xb3\x14\xe4\xd2\x78\x66\x85\x1b\x0e\x36\x51\xc4\x16\x3e\x44\xf8\x44\xd4\x1b\xf3\x6d\x39\x79\x95\xff\x9a\x1b\xc3\xe9\x97\xd5\x9b\x4f\x00\x00\x00\xff\xff\x83\xbb\x30\x2e\xbc\x00\x00\x00")
 
 func migrations4_add_protocol_versionSqlBytes() ([]byte, error) {
@@ -999,47 +1020,51 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"migrations/10_add_trades_price.sql":                      migrations10_add_trades_priceSql,
-	"migrations/11_add_trades_account_index.sql":              migrations11_add_trades_account_indexSql,
-	"migrations/12_asset_stats_amount_string.sql":             migrations12_asset_stats_amount_stringSql,
-	"migrations/13_trade_offer_ids.sql":                       migrations13_trade_offer_idsSql,
-	"migrations/14_fix_asset_toml_field.sql":                  migrations14_fix_asset_toml_fieldSql,
-	"migrations/15_ledger_failed_txs.sql":                     migrations15_ledger_failed_txsSql,
-	"migrations/16_ingest_failed_transactions.sql":            migrations16_ingest_failed_transactionsSql,
-	"migrations/17_transaction_fee_paid.sql":                  migrations17_transaction_fee_paidSql,
-	"migrations/18_account_for_signers.sql":                   migrations18_account_for_signersSql,
-	"migrations/19_offers.sql":                                migrations19_offersSql,
-	"migrations/1_initial_schema.sql":                         migrations1_initial_schemaSql,
-	"migrations/20_account_for_signer_index.sql":              migrations20_account_for_signer_indexSql,
-	"migrations/21_trades_remove_zero_amount_constraints.sql": migrations21_trades_remove_zero_amount_constraintsSql,
-	"migrations/22_trust_lines.sql":                           migrations22_trust_linesSql,
-	"migrations/23_exp_asset_stats.sql":                       migrations23_exp_asset_statsSql,
-	"migrations/24_accounts.sql":                              migrations24_accountsSql,
-	"migrations/25_expingest_rename_columns.sql":              migrations25_expingest_rename_columnsSql,
-	"migrations/26_exp_history_ledgers.sql":                   migrations26_exp_history_ledgersSql,
-	"migrations/27_exp_history_transactions.sql":              migrations27_exp_history_transactionsSql,
-	"migrations/28_exp_history_operations.sql":                migrations28_exp_history_operationsSql,
-	"migrations/29_exp_history_assets.sql":                    migrations29_exp_history_assetsSql,
-	"migrations/2_index_participants_by_toid.sql":             migrations2_index_participants_by_toidSql,
-	"migrations/30_exp_history_trades.sql":                    migrations30_exp_history_tradesSql,
-	"migrations/31_exp_history_effects.sql":                   migrations31_exp_history_effectsSql,
-	"migrations/32_drop_exp_history_tables.sql":               migrations32_drop_exp_history_tablesSql,
-	"migrations/33_remove_unused.sql":                         migrations33_remove_unusedSql,
-	"migrations/34_fee_bump_transactions.sql":                 migrations34_fee_bump_transactionsSql,
-	"migrations/35_drop_participant_id.sql":                   migrations35_drop_participant_idSql,
-	"migrations/36_deleted_offers.sql":                        migrations36_deleted_offersSql,
-	"migrations/37_add_tx_set_operation_count_to_ledgers.sql": migrations37_add_tx_set_operation_count_to_ledgersSql,
-	"migrations/38_add_constraints.sql":                       migrations38_add_constraintsSql,
-	"migrations/39_history_trades_indices.sql":                migrations39_history_trades_indicesSql,
-	"migrations/3_use_sequence_in_history_accounts.sql":       migrations3_use_sequence_in_history_accountsSql,
-	"migrations/4_add_protocol_version.sql":                   migrations4_add_protocol_versionSql,
-	"migrations/5_create_trades_table.sql":                    migrations5_create_trades_tableSql,
-	"migrations/6_create_assets_table.sql":                    migrations6_create_assets_tableSql,
-	"migrations/7_modify_trades_table.sql":                    migrations7_modify_trades_tableSql,
-	"migrations/8_add_aggregators.sql":                        migrations8_add_aggregatorsSql,
-	"migrations/8_create_asset_stats_table.sql":               migrations8_create_asset_stats_tableSql,
-	"migrations/9_add_header_xdr.sql":                         migrations9_add_header_xdrSql,
+	"migrations/10_add_trades_price.sql":                                     migrations10_add_trades_priceSql,
+	"migrations/11_add_trades_account_index.sql":                             migrations11_add_trades_account_indexSql,
+	"migrations/12_asset_stats_amount_string.sql":                            migrations12_asset_stats_amount_stringSql,
+	"migrations/13_trade_offer_ids.sql":                                      migrations13_trade_offer_idsSql,
+	"migrations/14_fix_asset_toml_field.sql":                                 migrations14_fix_asset_toml_fieldSql,
+	"migrations/15_ledger_failed_txs.sql":                                    migrations15_ledger_failed_txsSql,
+	"migrations/16_ingest_failed_transactions.sql":                           migrations16_ingest_failed_transactionsSql,
+	"migrations/17_transaction_fee_paid.sql":                                 migrations17_transaction_fee_paidSql,
+	"migrations/18_account_for_signers.sql":                                  migrations18_account_for_signersSql,
+	"migrations/19_offers.sql":                                               migrations19_offersSql,
+	"migrations/1_initial_schema.sql":                                        migrations1_initial_schemaSql,
+	"migrations/20_account_for_signer_index.sql":                             migrations20_account_for_signer_indexSql,
+	"migrations/21_trades_remove_zero_amount_constraints.sql":                migrations21_trades_remove_zero_amount_constraintsSql,
+	"migrations/22_trust_lines.sql":                                          migrations22_trust_linesSql,
+	"migrations/23_exp_asset_stats.sql":                                      migrations23_exp_asset_statsSql,
+	"migrations/24_accounts.sql":                                             migrations24_accountsSql,
+	"migrations/25_expingest_rename_columns.sql":                             migrations25_expingest_rename_columnsSql,
+	"migrations/26_exp_history_ledgers.sql":                                  migrations26_exp_history_ledgersSql,
+	"migrations/27_exp_history_transactions.sql":                             migrations27_exp_history_transactionsSql,
+	"migrations/28_exp_history_operations.sql":                               migrations28_exp_history_operationsSql,
+	"migrations/29_exp_history_assets.sql":                                   migrations29_exp_history_assetsSql,
+	"migrations/2_index_participants_by_toid.sql":                            migrations2_index_participants_by_toidSql,
+	"migrations/30_exp_history_trades.sql":                                   migrations30_exp_history_tradesSql,
+	"migrations/31_exp_history_effects.sql":                                  migrations31_exp_history_effectsSql,
+	"migrations/32_drop_exp_history_tables.sql":                              migrations32_drop_exp_history_tablesSql,
+	"migrations/33_remove_unused.sql":                                        migrations33_remove_unusedSql,
+	"migrations/34_fee_bump_transactions.sql":                                migrations34_fee_bump_transactionsSql,
+	"migrations/35_drop_participant_id.sql":                                  migrations35_drop_participant_idSql,
+	"migrations/36_deleted_offers.sql":                                       migrations36_deleted_offersSql,
+	"migrations/37_add_tx_set_operation_count_to_ledgers.sql":                migrations37_add_tx_set_operation_count_to_ledgersSql,
+	"migrations/38_add_constraints.sql":                                      migrations38_add_constraintsSql,
+	"migrations/39_history_trades_indices.sql":                               migrations39_history_trades_indicesSql,
+	"migrations/3_use_sequence_in_history_accounts.sql":                      migrations3_use_sequence_in_history_accountsSql,
+	"migrations/40_history_operation_participants_is_payment_successful.sql": migrations40_history_operation_participants_is_payment_successfulSql,
+	"migrations/4_add_protocol_version.sql":                                  migrations4_add_protocol_versionSql,
+	"migrations/5_create_trades_table.sql":                                   migrations5_create_trades_tableSql,
+	"migrations/6_create_assets_table.sql":                                   migrations6_create_assets_tableSql,
+	"migrations/7_modify_trades_table.sql":                                   migrations7_modify_trades_tableSql,
+	"migrations/8_add_aggregators.sql":                                       migrations8_add_aggregatorsSql,
+	"migrations/8_create_asset_stats_table.sql":                              migrations8_create_asset_stats_tableSql,
+	"migrations/9_add_header_xdr.sql":                                        migrations9_add_header_xdrSql,
 }
+
+// AssetDebug is true if the assets were built with the debug flag enabled.
+const AssetDebug = false
 
 // AssetDir returns the file names below a certain
 // directory embedded in the file by go-bindata.
@@ -1083,46 +1108,47 @@ type bintree struct {
 
 var _bintree = &bintree{nil, map[string]*bintree{
 	"migrations": &bintree{nil, map[string]*bintree{
-		"10_add_trades_price.sql":                      &bintree{migrations10_add_trades_priceSql, map[string]*bintree{}},
-		"11_add_trades_account_index.sql":              &bintree{migrations11_add_trades_account_indexSql, map[string]*bintree{}},
-		"12_asset_stats_amount_string.sql":             &bintree{migrations12_asset_stats_amount_stringSql, map[string]*bintree{}},
-		"13_trade_offer_ids.sql":                       &bintree{migrations13_trade_offer_idsSql, map[string]*bintree{}},
-		"14_fix_asset_toml_field.sql":                  &bintree{migrations14_fix_asset_toml_fieldSql, map[string]*bintree{}},
-		"15_ledger_failed_txs.sql":                     &bintree{migrations15_ledger_failed_txsSql, map[string]*bintree{}},
-		"16_ingest_failed_transactions.sql":            &bintree{migrations16_ingest_failed_transactionsSql, map[string]*bintree{}},
-		"17_transaction_fee_paid.sql":                  &bintree{migrations17_transaction_fee_paidSql, map[string]*bintree{}},
-		"18_account_for_signers.sql":                   &bintree{migrations18_account_for_signersSql, map[string]*bintree{}},
-		"19_offers.sql":                                &bintree{migrations19_offersSql, map[string]*bintree{}},
-		"1_initial_schema.sql":                         &bintree{migrations1_initial_schemaSql, map[string]*bintree{}},
-		"20_account_for_signer_index.sql":              &bintree{migrations20_account_for_signer_indexSql, map[string]*bintree{}},
-		"21_trades_remove_zero_amount_constraints.sql": &bintree{migrations21_trades_remove_zero_amount_constraintsSql, map[string]*bintree{}},
-		"22_trust_lines.sql":                           &bintree{migrations22_trust_linesSql, map[string]*bintree{}},
-		"23_exp_asset_stats.sql":                       &bintree{migrations23_exp_asset_statsSql, map[string]*bintree{}},
-		"24_accounts.sql":                              &bintree{migrations24_accountsSql, map[string]*bintree{}},
-		"25_expingest_rename_columns.sql":              &bintree{migrations25_expingest_rename_columnsSql, map[string]*bintree{}},
-		"26_exp_history_ledgers.sql":                   &bintree{migrations26_exp_history_ledgersSql, map[string]*bintree{}},
-		"27_exp_history_transactions.sql":              &bintree{migrations27_exp_history_transactionsSql, map[string]*bintree{}},
-		"28_exp_history_operations.sql":                &bintree{migrations28_exp_history_operationsSql, map[string]*bintree{}},
-		"29_exp_history_assets.sql":                    &bintree{migrations29_exp_history_assetsSql, map[string]*bintree{}},
-		"2_index_participants_by_toid.sql":             &bintree{migrations2_index_participants_by_toidSql, map[string]*bintree{}},
-		"30_exp_history_trades.sql":                    &bintree{migrations30_exp_history_tradesSql, map[string]*bintree{}},
-		"31_exp_history_effects.sql":                   &bintree{migrations31_exp_history_effectsSql, map[string]*bintree{}},
-		"32_drop_exp_history_tables.sql":               &bintree{migrations32_drop_exp_history_tablesSql, map[string]*bintree{}},
-		"33_remove_unused.sql":                         &bintree{migrations33_remove_unusedSql, map[string]*bintree{}},
-		"34_fee_bump_transactions.sql":                 &bintree{migrations34_fee_bump_transactionsSql, map[string]*bintree{}},
-		"35_drop_participant_id.sql":                   &bintree{migrations35_drop_participant_idSql, map[string]*bintree{}},
-		"36_deleted_offers.sql":                        &bintree{migrations36_deleted_offersSql, map[string]*bintree{}},
-		"37_add_tx_set_operation_count_to_ledgers.sql": &bintree{migrations37_add_tx_set_operation_count_to_ledgersSql, map[string]*bintree{}},
-		"38_add_constraints.sql":                       &bintree{migrations38_add_constraintsSql, map[string]*bintree{}},
-		"39_history_trades_indices.sql":                &bintree{migrations39_history_trades_indicesSql, map[string]*bintree{}},
-		"3_use_sequence_in_history_accounts.sql":       &bintree{migrations3_use_sequence_in_history_accountsSql, map[string]*bintree{}},
-		"4_add_protocol_version.sql":                   &bintree{migrations4_add_protocol_versionSql, map[string]*bintree{}},
-		"5_create_trades_table.sql":                    &bintree{migrations5_create_trades_tableSql, map[string]*bintree{}},
-		"6_create_assets_table.sql":                    &bintree{migrations6_create_assets_tableSql, map[string]*bintree{}},
-		"7_modify_trades_table.sql":                    &bintree{migrations7_modify_trades_tableSql, map[string]*bintree{}},
-		"8_add_aggregators.sql":                        &bintree{migrations8_add_aggregatorsSql, map[string]*bintree{}},
-		"8_create_asset_stats_table.sql":               &bintree{migrations8_create_asset_stats_tableSql, map[string]*bintree{}},
-		"9_add_header_xdr.sql":                         &bintree{migrations9_add_header_xdrSql, map[string]*bintree{}},
+		"10_add_trades_price.sql":                                     &bintree{migrations10_add_trades_priceSql, map[string]*bintree{}},
+		"11_add_trades_account_index.sql":                             &bintree{migrations11_add_trades_account_indexSql, map[string]*bintree{}},
+		"12_asset_stats_amount_string.sql":                            &bintree{migrations12_asset_stats_amount_stringSql, map[string]*bintree{}},
+		"13_trade_offer_ids.sql":                                      &bintree{migrations13_trade_offer_idsSql, map[string]*bintree{}},
+		"14_fix_asset_toml_field.sql":                                 &bintree{migrations14_fix_asset_toml_fieldSql, map[string]*bintree{}},
+		"15_ledger_failed_txs.sql":                                    &bintree{migrations15_ledger_failed_txsSql, map[string]*bintree{}},
+		"16_ingest_failed_transactions.sql":                           &bintree{migrations16_ingest_failed_transactionsSql, map[string]*bintree{}},
+		"17_transaction_fee_paid.sql":                                 &bintree{migrations17_transaction_fee_paidSql, map[string]*bintree{}},
+		"18_account_for_signers.sql":                                  &bintree{migrations18_account_for_signersSql, map[string]*bintree{}},
+		"19_offers.sql":                                               &bintree{migrations19_offersSql, map[string]*bintree{}},
+		"1_initial_schema.sql":                                        &bintree{migrations1_initial_schemaSql, map[string]*bintree{}},
+		"20_account_for_signer_index.sql":                             &bintree{migrations20_account_for_signer_indexSql, map[string]*bintree{}},
+		"21_trades_remove_zero_amount_constraints.sql":                &bintree{migrations21_trades_remove_zero_amount_constraintsSql, map[string]*bintree{}},
+		"22_trust_lines.sql":                                          &bintree{migrations22_trust_linesSql, map[string]*bintree{}},
+		"23_exp_asset_stats.sql":                                      &bintree{migrations23_exp_asset_statsSql, map[string]*bintree{}},
+		"24_accounts.sql":                                             &bintree{migrations24_accountsSql, map[string]*bintree{}},
+		"25_expingest_rename_columns.sql":                             &bintree{migrations25_expingest_rename_columnsSql, map[string]*bintree{}},
+		"26_exp_history_ledgers.sql":                                  &bintree{migrations26_exp_history_ledgersSql, map[string]*bintree{}},
+		"27_exp_history_transactions.sql":                             &bintree{migrations27_exp_history_transactionsSql, map[string]*bintree{}},
+		"28_exp_history_operations.sql":                               &bintree{migrations28_exp_history_operationsSql, map[string]*bintree{}},
+		"29_exp_history_assets.sql":                                   &bintree{migrations29_exp_history_assetsSql, map[string]*bintree{}},
+		"2_index_participants_by_toid.sql":                            &bintree{migrations2_index_participants_by_toidSql, map[string]*bintree{}},
+		"30_exp_history_trades.sql":                                   &bintree{migrations30_exp_history_tradesSql, map[string]*bintree{}},
+		"31_exp_history_effects.sql":                                  &bintree{migrations31_exp_history_effectsSql, map[string]*bintree{}},
+		"32_drop_exp_history_tables.sql":                              &bintree{migrations32_drop_exp_history_tablesSql, map[string]*bintree{}},
+		"33_remove_unused.sql":                                        &bintree{migrations33_remove_unusedSql, map[string]*bintree{}},
+		"34_fee_bump_transactions.sql":                                &bintree{migrations34_fee_bump_transactionsSql, map[string]*bintree{}},
+		"35_drop_participant_id.sql":                                  &bintree{migrations35_drop_participant_idSql, map[string]*bintree{}},
+		"36_deleted_offers.sql":                                       &bintree{migrations36_deleted_offersSql, map[string]*bintree{}},
+		"37_add_tx_set_operation_count_to_ledgers.sql":                &bintree{migrations37_add_tx_set_operation_count_to_ledgersSql, map[string]*bintree{}},
+		"38_add_constraints.sql":                                      &bintree{migrations38_add_constraintsSql, map[string]*bintree{}},
+		"39_history_trades_indices.sql":                               &bintree{migrations39_history_trades_indicesSql, map[string]*bintree{}},
+		"3_use_sequence_in_history_accounts.sql":                      &bintree{migrations3_use_sequence_in_history_accountsSql, map[string]*bintree{}},
+		"40_history_operation_participants_is_payment_successful.sql": &bintree{migrations40_history_operation_participants_is_payment_successfulSql, map[string]*bintree{}},
+		"4_add_protocol_version.sql":                                  &bintree{migrations4_add_protocol_versionSql, map[string]*bintree{}},
+		"5_create_trades_table.sql":                                   &bintree{migrations5_create_trades_tableSql, map[string]*bintree{}},
+		"6_create_assets_table.sql":                                   &bintree{migrations6_create_assets_tableSql, map[string]*bintree{}},
+		"7_modify_trades_table.sql":                                   &bintree{migrations7_modify_trades_tableSql, map[string]*bintree{}},
+		"8_add_aggregators.sql":                                       &bintree{migrations8_add_aggregatorsSql, map[string]*bintree{}},
+		"8_create_asset_stats_table.sql":                              &bintree{migrations8_create_asset_stats_tableSql, map[string]*bintree{}},
+		"9_add_header_xdr.sql":                                        &bintree{migrations9_add_header_xdrSql, map[string]*bintree{}},
 	}},
 }}
 

--- a/services/horizon/internal/db2/schema/bindata.go
+++ b/services/horizon/internal/db2/schema/bindata.go
@@ -1063,9 +1063,6 @@ var _bindata = map[string]func() (*asset, error){
 	"migrations/9_add_header_xdr.sql":                                        migrations9_add_header_xdrSql,
 }
 
-// AssetDebug is true if the assets were built with the debug flag enabled.
-const AssetDebug = false
-
 // AssetDir returns the file names below a certain
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the

--- a/services/horizon/internal/db2/schema/migrations/40_history_operation_participants_is_payment_successful.sql
+++ b/services/horizon/internal/db2/schema/migrations/40_history_operation_participants_is_payment_successful.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+
+ALTER TABLE history_operation_participants ADD COLUMN payment boolean DEFAULT NULL;
+ALTER TABLE history_operation_participants ADD COLUMN successful boolean DEFAULT NULL;
+ALTER TABLE history_transaction_participants ADD COLUMN successful boolean DEFAULT NULL;
+
+-- +migrate Down
+
+ALTER TABLE history_operation_participants DROP COLUMN payment;
+ALTER TABLE history_operation_participants DROP COLUMN successful;
+ALTER TABLE history_transaction_participants DROP COLUMN successful;

--- a/services/horizon/internal/expingest/main_test.go
+++ b/services/horizon/internal/expingest/main_test.go
@@ -343,7 +343,7 @@ func (m *mockDBQ) NewTransactionParticipantsBatchInsertBuilder(maxBatchSize int)
 
 func (m *mockDBQ) NewOperationParticipantBatchInsertBuilder(maxBatchSize int) history.OperationParticipantBatchInsertBuilder {
 	args := m.Called(maxBatchSize)
-	return args.Get(0).(history.TransactionParticipantsBatchInsertBuilder)
+	return args.Get(0).(history.OperationParticipantBatchInsertBuilder)
 }
 
 func (m *mockDBQ) NewTradeBatchInsertBuilder(maxBatchSize int) history.TradeBatchInsertBuilder {

--- a/services/horizon/internal/expingest/processors/operations_processor.go
+++ b/services/horizon/internal/expingest/processors/operations_processor.go
@@ -396,8 +396,8 @@ func dedupe(in []xdr.AccountId) (out []xdr.AccountId) {
 }
 
 // OperationsParticipants returns a map with all participants per operation
-func operationsParticipants(transaction io.LedgerTransaction, sequence uint32) (map[int64][]xdr.AccountId, error) {
-	participants := map[int64][]xdr.AccountId{}
+func operationsParticipants(transaction io.LedgerTransaction, sequence uint32) (map[uint32][]xdr.AccountId, error) {
+	participants := map[uint32][]xdr.AccountId{}
 
 	for opi, op := range transaction.Envelope.Operations() {
 		operation := transactionOperationWrapper{
@@ -411,7 +411,7 @@ func operationsParticipants(transaction io.LedgerTransaction, sequence uint32) (
 		if err != nil {
 			return participants, errors.Wrapf(err, "reading operation %v participants", operation.ID())
 		}
-		participants[operation.ID()] = p
+		participants[uint32(opi)] = p
 	}
 
 	return participants, nil

--- a/services/horizon/internal/expingest/processors/participants_processor_test.go
+++ b/services/horizon/internal/expingest/processors/participants_processor_test.go
@@ -98,33 +98,33 @@ func (s *ParticipantsProcessorTestSuiteLedger) TearDownTest() {
 
 func (s *ParticipantsProcessorTestSuiteLedger) mockSuccessfulTransactionBatchAdds() {
 	s.mockBatchInsertBuilder.On(
-		"Add", s.firstTxID, s.addressToID[s.addresses[0]],
+		"Add", s.firstTxID, s.addressToID[s.addresses[0]], true,
 	).Return(nil).Once()
 
 	s.mockBatchInsertBuilder.On(
-		"Add", s.secondTxID, s.addressToID[s.addresses[1]],
+		"Add", s.secondTxID, s.addressToID[s.addresses[1]], true,
 	).Return(nil).Once()
 	s.mockBatchInsertBuilder.On(
-		"Add", s.secondTxID, s.addressToID[s.addresses[2]],
+		"Add", s.secondTxID, s.addressToID[s.addresses[2]], true,
 	).Return(nil).Once()
 
 	s.mockBatchInsertBuilder.On(
-		"Add", s.thirdTxID, s.addressToID[s.addresses[0]],
+		"Add", s.thirdTxID, s.addressToID[s.addresses[0]], true,
 	).Return(nil).Once()
 }
 
 func (s *ParticipantsProcessorTestSuiteLedger) mockSuccessfulOperationBatchAdds() {
 	s.mockOperationsBatchInsertBuilder.On(
-		"Add", s.firstTxID+1, s.addressToID[s.addresses[0]],
+		"Add", s.firstTxID+1, s.addressToID[s.addresses[0]], true, xdr.OperationTypeBumpSequence,
 	).Return(nil).Once()
 	s.mockOperationsBatchInsertBuilder.On(
-		"Add", s.secondTxID+1, s.addressToID[s.addresses[1]],
+		"Add", s.secondTxID+1, s.addressToID[s.addresses[1]], true, xdr.OperationTypeCreateAccount,
 	).Return(nil).Once()
 	s.mockOperationsBatchInsertBuilder.On(
-		"Add", s.secondTxID+1, s.addressToID[s.addresses[2]],
+		"Add", s.secondTxID+1, s.addressToID[s.addresses[2]], true, xdr.OperationTypeCreateAccount,
 	).Return(nil).Once()
 	s.mockOperationsBatchInsertBuilder.On(
-		"Add", s.thirdTxID+1, s.addressToID[s.addresses[0]],
+		"Add", s.thirdTxID+1, s.addressToID[s.addresses[0]], true, xdr.OperationTypeBumpSequence,
 	).Return(nil).Once()
 }
 func (s *ParticipantsProcessorTestSuiteLedger) TestEmptyParticipants() {
@@ -181,10 +181,10 @@ func (s *ParticipantsProcessorTestSuiteLedger) TestFeeBumptransaction() {
 		Return(s.mockOperationsBatchInsertBuilder).Once()
 
 	s.mockBatchInsertBuilder.On(
-		"Add", feeBumpTxID, addressToID[addresses[0]],
+		"Add", feeBumpTxID, addressToID[addresses[0]], true,
 	).Return(nil).Once()
 	s.mockBatchInsertBuilder.On(
-		"Add", feeBumpTxID, addressToID[addresses[1]],
+		"Add", feeBumpTxID, addressToID[addresses[1]], true,
 	).Return(nil).Once()
 
 	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
@@ -246,18 +246,18 @@ func (s *ParticipantsProcessorTestSuiteLedger) TestBatchAddFails() {
 		Return(s.mockBatchInsertBuilder).Once()
 
 	s.mockBatchInsertBuilder.On(
-		"Add", s.firstTxID, s.addressToID[s.addresses[0]],
+		"Add", s.firstTxID, s.addressToID[s.addresses[0]], true,
 	).Return(errors.New("transient error")).Once()
 
 	s.mockBatchInsertBuilder.On(
-		"Add", s.secondTxID, s.addressToID[s.addresses[1]],
+		"Add", s.secondTxID, s.addressToID[s.addresses[1]], true,
 	).Return(nil).Maybe()
 	s.mockBatchInsertBuilder.On(
-		"Add", s.secondTxID, s.addressToID[s.addresses[2]],
+		"Add", s.secondTxID, s.addressToID[s.addresses[2]], true,
 	).Return(nil).Maybe()
 
 	s.mockBatchInsertBuilder.On(
-		"Add", s.thirdTxID, s.addressToID[s.addresses[0]],
+		"Add", s.thirdTxID, s.addressToID[s.addresses[0]], true,
 	).Return(nil).Maybe()
 	for _, tx := range s.txs {
 		err := s.processor.ProcessTransaction(tx)
@@ -284,16 +284,16 @@ func (s *ParticipantsProcessorTestSuiteLedger) TestOperationParticipantsBatchAdd
 	s.mockSuccessfulTransactionBatchAdds()
 
 	s.mockOperationsBatchInsertBuilder.On(
-		"Add", s.firstTxID+1, s.addressToID[s.addresses[0]],
+		"Add", s.firstTxID+1, s.addressToID[s.addresses[0]], true, xdr.OperationTypeBumpSequence,
 	).Return(errors.New("transient error")).Once()
 	s.mockOperationsBatchInsertBuilder.On(
-		"Add", s.secondTxID+1, s.addressToID[s.addresses[1]],
+		"Add", s.secondTxID+1, s.addressToID[s.addresses[1]], true, xdr.OperationTypeCreateAccount,
 	).Return(nil).Maybe()
 	s.mockOperationsBatchInsertBuilder.On(
-		"Add", s.secondTxID+1, s.addressToID[s.addresses[2]],
+		"Add", s.secondTxID+1, s.addressToID[s.addresses[2]], true, xdr.OperationTypeCreateAccount,
 	).Return(nil).Maybe()
 	s.mockOperationsBatchInsertBuilder.On(
-		"Add", s.thirdTxID+1, s.addressToID[s.addresses[0]],
+		"Add", s.thirdTxID+1, s.addressToID[s.addresses[0]], true, xdr.OperationTypeBumpSequence,
 	).Return(nil).Maybe()
 
 	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()

--- a/services/horizon/internal/httpx/router.go
+++ b/services/horizon/internal/httpx/router.go
@@ -31,16 +31,17 @@ type RouterConfig struct {
 	TxSubmitter *txsub.System
 	RateQuota   *throttled.RateQuota
 
-	SSEUpdateFrequency time.Duration
-	StaleThreshold     uint
-	ConnectionTimeout  time.Duration
-	NetworkPassphrase  string
-	MaxPathLength      uint
-	PathFinder         paths.Finder
-	PrometheusRegistry *prometheus.Registry
-	CoreGetter         actions.CoreSettingsGetter
-	HorizonVersion     string
-	FriendbotURL       *url.URL
+	SSEUpdateFrequency           time.Duration
+	StaleThreshold               uint
+	ConnectionTimeout            time.Duration
+	NetworkPassphrase            string
+	MaxPathLength                uint
+	PathFinder                   paths.Finder
+	PrometheusRegistry           *prometheus.Registry
+	CoreGetter                   actions.CoreSettingsGetter
+	HorizonVersion               string
+	FriendbotURL                 *url.URL
+	UseDBExtraParticipantsFields bool
 }
 
 type Router struct {
@@ -183,10 +184,12 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 		r.Use(historyMiddleware)
 		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/effects", streamableHistoryPageHandler(actions.GetEffectsHandler{}, streamHandler))
 		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/operations", streamableHistoryPageHandler(actions.GetOperationsHandler{
-			OnlyPayments: false,
+			OnlyPayments:                 false,
+			UseDBExtraParticipantsFields: config.UseDBExtraParticipantsFields,
 		}, streamHandler))
 		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/payments", streamableHistoryPageHandler(actions.GetOperationsHandler{
-			OnlyPayments: true,
+			OnlyPayments:                 true,
+			UseDBExtraParticipantsFields: config.UseDBExtraParticipantsFields,
 		}, streamHandler))
 		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/trades", streamableHistoryPageHandler(actions.GetTradesHandler{}, streamHandler))
 		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/transactions", streamableHistoryPageHandler(actions.GetTransactionsHandler{}, streamHandler))


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit improves the performance of `/accounts/{id}/transactions|payments|operations` endpoints by denormalizing `history_operation_participants` and `history_transaction_participants`. The feature is behind a feature flag because to work correctly a new set of indexes and full history reingestion are required.

### Why

As explained in https://github.com/stellar/go/issues/1808 the set of queries made by "Transactions/Operations/Payments For Account" endpoints require denormalization of `history_operation_participants` and `history_transaction_participants` tables to include information about a transaction status (`successful`) and operation type (`payment`). This makes queries related to accounts with unusual operation distributions (ex. an account with a lot of offer operations but a few payment operations) fast.

### Known limitations

* This feature is experimental and behind a feature flag because it requires a full DB reingestion.
* Indexes using new columns must be created manually (migration would be super slow on full history DBs and they wouldn't be able to use new feature without reingestion).
* It adds new columns on participant tables that are set when new participants are inserted but ignored when reading data fro a DB if the feature flag is not set.