### PR TITLE
service/horizon: Add horizon_ingest_enabled metric

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -68,6 +68,7 @@ type App struct {
 
 	// metrics
 	prometheusRegistry         *prometheus.Registry
+	ingestingGauge             prometheus.Gauge
 	historyLatestLedgerCounter prometheus.CounterFunc
 	historyElderLedgerCounter  prometheus.CounterFunc
 	dbOpenConnectionsGauge     prometheus.GaugeFunc

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -120,6 +120,11 @@ func initLogglyLog(app *App) {
 }
 
 func initDbMetrics(app *App) {
+	app.ingestingGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{Namespace: "horizon", Subsystem: "ingest", Name: "enabled"},
+	)
+	app.prometheusRegistry.MustRegister(app.ingestingGauge)
+
 	app.historyLatestLedgerCounter = prometheus.NewCounterFunc(
 		prometheus.CounterOpts{Namespace: "horizon", Subsystem: "history", Name: "latest_ledger"},
 		func() float64 {
@@ -195,6 +200,7 @@ func initIngestMetrics(app *App) {
 		return
 	}
 
+	app.ingestingGauge.Inc()
 	app.prometheusRegistry.MustRegister(app.expingester.Metrics().LedgerIngestionDuration)
 	app.prometheusRegistry.MustRegister(app.expingester.Metrics().StateVerifyDuration)
 	app.prometheusRegistry.MustRegister(app.expingester.Metrics().StateInvalidGauge)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

Adds `horizon_ingest_enabled` useful for limiting metrics to ingesting/non-ingesting instances.