### PR TITLE
services/horizon: Run integration tests on each PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,19 +362,12 @@ workflows:
       - test_code_1_13_postgres10
       - test_code_1_14
       - test_code_1_14_postgres10
+      - test_horizon_integration
       - publish_state_diff_docker_image:
           filters:
               branches:
                 only:
                   - master
-
-  run_horizon_integration_tests:
-    jobs:
-      - start_horizon_integration_tests:
-          type: approval
-      - test_horizon_integration:
-          requires:
-           - start_horizon_integration_tests
 
   build_and_deploy:
     jobs:


### PR DESCRIPTION
As noticed by @2opremio the problem with `approve` job is that it makes the overall PR status to be pending until approved. Unfortunately, this is still an open feature request in [Circle-CI tracker](https://ideas.circleci.com/ideas/CCI-I-445).

This PR changes the Circle-CI config to run integration tests on each PR because it takes just 2 minutes to complete. When it's too slow we can switch to a schedule trigger in Circle-CI (ex. run integration tests once a day).