### PR TITLE
horizonclient: use root error to check horizon error

### DIFF
--- a/clients/horizonclient/error_helpers.go
+++ b/clients/horizonclient/error_helpers.go
@@ -1,11 +1,14 @@
 package horizonclient
 
+import "github.com/stellar/go/support/errors"
+
 // IsNotFoundError returns true if the error is a horizonclient.Error with
 // a not_found problem indicating that the resource is not found on
 // Horizon.
 func IsNotFoundError(err error) bool {
 	var hErr *Error
 
+	err = errors.Cause(err)
 	switch err := err.(type) {
 	case *Error:
 		hErr = err
@@ -26,6 +29,7 @@ func IsNotFoundError(err error) bool {
 func GetError(err error) *Error {
 	var hErr *Error
 
+	err = errors.Cause(err)
 	switch e := err.(type) {
 	case *Error:
 		hErr = e

--- a/clients/horizonclient/error_helpers_test.go
+++ b/clients/horizonclient/error_helpers_test.go
@@ -36,6 +36,17 @@ func TestIsNotFoundError(t *testing.T) {
 			is: true,
 		},
 		{
+			desc: "wrapped not found problem (pointer)",
+			err: errors.Wrap(&Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/not_found",
+					Title:  "Resource Missing",
+					Status: 404,
+				},
+			}, "wrap message"),
+			is: true,
+		},
+		{
 			desc: "not found problem (not a pointer)",
 			err: Error{
 				Problem: problem.P{
@@ -44,6 +55,17 @@ func TestIsNotFoundError(t *testing.T) {
 					Status: 404,
 				},
 			},
+			is: true,
+		},
+		{
+			desc: "wrapped not found problem (not a pointer)",
+			err: errors.Wrap(Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/not_found",
+					Title:  "Resource Missing",
+					Status: 404,
+				},
+			}, "wrap message"),
 			is: true,
 		},
 		{
@@ -58,6 +80,17 @@ func TestIsNotFoundError(t *testing.T) {
 			is: false,
 		},
 		{
+			desc: "wrapped some other problem (pointer)",
+			err: errors.Wrap(&Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/server_error",
+					Title:  "Server Error",
+					Status: 500,
+				},
+			}, "wrap message"),
+			is: false,
+		},
+		{
 			desc: "some other problem (not a pointer)",
 			err: Error{
 				Problem: problem.P{
@@ -66,6 +99,17 @@ func TestIsNotFoundError(t *testing.T) {
 					Status: 500,
 				},
 			},
+			is: false,
+		},
+		{
+			desc: "wrapped some other problem (not a pointer)",
+			err: errors.Wrap(Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/server_error",
+					Title:  "Server Error",
+					Status: 500,
+				},
+			}, "wrap message"),
 			is: false,
 		},
 		{
@@ -117,6 +161,23 @@ func TestGetError(t *testing.T) {
 			},
 		},
 		{
+			desc: "wrapped not found problem (pointer)",
+			err: errors.Wrap(&Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/not_found",
+					Title:  "Resource Missing",
+					Status: 404,
+				},
+			}, "wrap message"),
+			wantErr: &Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/not_found",
+					Title:  "Resource Missing",
+					Status: 404,
+				},
+			},
+		},
+		{
 			desc: "not found problem (not a pointer)",
 			err: Error{
 				Problem: problem.P{
@@ -125,6 +186,23 @@ func TestGetError(t *testing.T) {
 					Status: 404,
 				},
 			},
+			wantErr: &Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/not_found",
+					Title:  "Resource Missing",
+					Status: 404,
+				},
+			},
+		},
+		{
+			desc: "wrapped not found problem (not a pointer)",
+			err: errors.Wrap(Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/not_found",
+					Title:  "Resource Missing",
+					Status: 404,
+				},
+			}, "wrap message"),
 			wantErr: &Error{
 				Problem: problem.P{
 					Type:   "https://stellar.org/horizon-errors/not_found",


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
 
This PR changes two error checking helpers `IsNotFoundError` and `GetError` to use the root error for horizon error checking.

### Why

When clients use these helper functions, they intended to supply the error directly to them regardless whether the error has been wrapped or not. When client use a wrapped error, these helper functions will not work.

### Known limitations

N/A
