### PR TITLE
services/horizon: Clone a DB session in System.initMetrics/GetExpStateInvalid

### DIFF
--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -43,8 +43,11 @@ const (
 	//      everything else).
 	CurrentVersion = 10
 
-	// MaxDBConnections is the size of the postgres connection pool dedicated to Horizon ingestion
-	MaxDBConnections = 2
+	// MaxDBConnections is the size of the postgres connection pool dedicated to Horizon ingestion:
+	//  * Ledger ingestion,
+	//  * State verifications,
+	//  * Metrics updates.
+	MaxDBConnections = 3
 
 	defaultCoreCursorName           = "HORIZON"
 	stateVerificationErrorThreshold = 3
@@ -223,7 +226,7 @@ func (s *system) initMetrics() {
 			Help: "equals 1 if state invalid, 0 otherwise",
 		},
 		func() float64 {
-			invalid, err := s.historyQ.GetExpStateInvalid()
+			invalid, err := s.historyQ.CloneIngestionQ().GetExpStateInvalid()
 			if err != nil {
 				log.WithError(err).Error("Error in initMetrics/GetExpStateInvalid")
 				return 0


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Clone a DB session before using in `initMetrics/GetExpStateInvalid`.

### Why

The same session is used in ledgers ingestion in a different go routine what can result in connection errors.