### PR TITLE
services/horizon: Add port specification to work on host network mode

### DIFF
--- a/services/horizon/docker/docker-compose.yml
+++ b/services/horizon/docker/docker-compose.yml
@@ -7,7 +7,8 @@ services:
       - POSTGRES_PASSWORD=mysecretpassword
       - POSTGRES_DB=stellar
     ports:
-      - "5641:5432"
+      - "5641:5641"
+    command: ["-p", "5641"]
     volumes:
       - "core-db-data:/var/lib/postgresql/data"
     network_mode: '${NETWORK_MODE:-bridge}'


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Specifies the port for the core PostgreSQL database so that `docker-compose` works on Linux.

### Why
Docker uses the `host` networking mode on Linux when setting up Horizon (see the [startup guide](https://github.com/stellar/go/blob/master/services/horizon/docker/README.md)). This means there is no port mapping made, so the core container cannot access its respective database. 

This change makes the database use the "host-facing" port and not map to the default (5432) internally.

### Known limitations
Its possible that [someone, somewhere](https://xkcd.com/1172/) is relying on the core database docker container to use the default port 5432, but this port is *only* seen from **within** said container, so that seems unlikely.