### PR TITLE
tools/horizon-cmp: Add routes coverage and misc fixes

### DIFF
--- a/tools/horizon-cmp/init_routes.go
+++ b/tools/horizon-cmp/init_routes.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	cmp "github.com/stellar/go/tools/horizon-cmp/internal"
+)
+
+var routes = cmp.Routes{
+	List: []*cmp.Route{
+		// The order of the list is important because some regexps can match
+		// a wider route.
+		cmp.MakeRoute(`/accounts/*/effects`),
+		cmp.MakeRoute(`/accounts/*/payments`),
+		cmp.MakeRoute(`/accounts/*/operations`),
+		cmp.MakeRoute(`/accounts/*/trades`),
+		cmp.MakeRoute(`/accounts/*/transactions`),
+		cmp.MakeRoute(`/accounts/*/offers`),
+		cmp.MakeRoute(`/accounts/*/data/*`),
+		cmp.MakeRoute(`/accounts/*`),
+		cmp.MakeRoute(`/accounts`),
+
+		cmp.MakeRoute(`/ledgers/*/transactions`),
+		cmp.MakeRoute(`/ledgers/*/operations`),
+		cmp.MakeRoute(`/ledgers/*/payments`),
+		cmp.MakeRoute(`/ledgers/*/effects`),
+		cmp.MakeRoute(`/ledgers/*`),
+		cmp.MakeRoute(`/ledgers`),
+
+		cmp.MakeRoute(`/operations/*/effects`),
+		cmp.MakeRoute(`/operations/*`),
+		cmp.MakeRoute(`/operations`),
+
+		cmp.MakeRoute(`/transactions/*/effects`),
+		cmp.MakeRoute(`/transactions/*/operations`),
+		cmp.MakeRoute(`/transactions/*/payments`),
+		cmp.MakeRoute(`/transactions/*`),
+		cmp.MakeRoute(`/transactions`),
+
+		cmp.MakeRoute(`/offers/*/trades`),
+		cmp.MakeRoute(`/offers/*`),
+		cmp.MakeRoute(`/offers`),
+
+		cmp.MakeRoute(`/payments`),
+		cmp.MakeRoute(`/effects`),
+		cmp.MakeRoute(`/trades`),
+		cmp.MakeRoute(`/trade_aggregations`),
+		cmp.MakeRoute(`/order_book`),
+		cmp.MakeRoute(`/assets`),
+		cmp.MakeRoute(`/fee_stats`),
+
+		cmp.MakeRoute(`/paths/strict-receive`),
+		cmp.MakeRoute(`/paths/strict-send`),
+		cmp.MakeRoute(`/paths`),
+
+		cmp.MakeRoute(`/`),
+	},
+}

--- a/tools/horizon-cmp/internal/response.go
+++ b/tools/horizon-cmp/internal/response.go
@@ -125,7 +125,8 @@ func NewResponse(domain, path string, stream bool) *Response {
 		resp.StatusCode != http.StatusNotAcceptable &&
 		resp.StatusCode != http.StatusBadRequest &&
 		resp.StatusCode != http.StatusGatewayTimeout &&
-		resp.StatusCode != http.StatusGone {
+		resp.StatusCode != http.StatusGone &&
+		resp.StatusCode != http.StatusServiceUnavailable {
 		panic(resp.StatusCode)
 	}
 

--- a/tools/horizon-cmp/internal/route_counter.go
+++ b/tools/horizon-cmp/internal/route_counter.go
@@ -52,6 +52,8 @@ func (r *Routes) Count(path string) {
 }
 
 func (r *Routes) Print() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	fmt.Println("Routes coverage:")
 	for _, route := range r.List {
 		fmt.Println(route.counter, route.name)

--- a/tools/horizon-cmp/internal/route_counter.go
+++ b/tools/horizon-cmp/internal/route_counter.go
@@ -1,0 +1,64 @@
+package cmp
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// MakeRoute translates route with * wildcards into a regexp. It adds start/end
+// of line asserts, changes * into any characters except when in used for lists
+// (like /accounts/*) - in such case it ensures there is no more `/` characters.
+// This is not ideal and requires checking routes in correct order but is enough
+// for horizon-cmp.
+// More here: https://regex101.com/r/EhBRtS/1
+func MakeRoute(route string) *Route {
+	name := route
+	route = "^" + route
+	route = strings.ReplaceAll(route, "*", "[^?/]+") // everything except `/` and `?`
+	route = route + "[?/]?[^/]*$"                    // ? or / or nothing and then everything except `/``
+	return &Route{
+		name:   name,
+		regexp: regexp.MustCompile(route),
+	}
+}
+
+type Route struct {
+	name    string
+	regexp  *regexp.Regexp
+	counter int
+}
+
+type Routes struct {
+	List      []*Route
+	unmatched []string
+	mutex     sync.Mutex
+}
+
+func (r *Routes) Count(path string) {
+	for _, route := range r.List {
+		if route.regexp.Match([]byte(path)) {
+			r.mutex.Lock()
+			route.counter++
+			r.mutex.Unlock()
+			return
+		}
+	}
+
+	r.mutex.Lock()
+	r.unmatched = append(r.unmatched, path)
+	r.mutex.Unlock()
+}
+
+func (r *Routes) Print() {
+	fmt.Println("Routes coverage:")
+	for _, route := range r.List {
+		fmt.Println(route.counter, route.name)
+	}
+
+	fmt.Println("Unmatched paths:")
+	for _, path := range r.unmatched {
+		fmt.Println(path)
+	}
+}

--- a/tools/horizon-cmp/internal/route_counter_test.go
+++ b/tools/horizon-cmp/internal/route_counter_test.go
@@ -1,0 +1,25 @@
+package cmp
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeRoute(t *testing.T) {
+	var testCases = []struct {
+		Input  string
+		Output string
+	}{
+		{"/accounts/*/payments", "^/accounts/[^?/]+/payments[?/]?[^/]*$"},
+		{"/accounts/*", "^/accounts/[^?/]+[?/]?[^/]*$"},
+		{"/accounts", "^/accounts[?/]?[^/]*$"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s -> %s", tc.Input, tc.Output), func(t *testing.T) {
+			assert.Equal(t, tc.Output, MakeRoute(tc.Input).regexp.String())
+		})
+	}
+}


### PR DESCRIPTION
This commit adds routes coverage printed after `horizon-cmp` session. The list of routes is currently created manually because Horizon's router is in `internal` package. The routes are matches using a simple regexp (see `MakeRoute`) that seems to be working well.

I also fixed a misc issues:
* Retry when size of any response is 0 (connection issues).
* `log` variable overwrites by multiple go routines.
* Crash after `503` error code.