### PR TITLE
recoverysigner: set max db open conns to 20

### DIFF
--- a/exp/services/recoverysigner/cmd/serve.go
+++ b/exp/services/recoverysigner/cmd/serve.go
@@ -36,6 +36,14 @@ func (c *ServeCommand) Command() *cobra.Command {
 			Required:    false,
 		},
 		{
+			Name:        "db-max-open-conns",
+			Usage:       "Database max open connections",
+			OptType:     types.Int,
+			ConfigKey:   &opts.DatabaseMaxOpenConns,
+			FlagDefault: 20,
+			Required:    false,
+		},
+		{
 			Name:        "network-passphrase",
 			Usage:       "Network passphrase of the Stellar network transactions should be signed for",
 			OptType:     types.String,

--- a/exp/services/recoverysigner/internal/serve/serve.go
+++ b/exp/services/recoverysigner/internal/serve/serve.go
@@ -21,14 +21,15 @@ import (
 )
 
 type Options struct {
-	Logger            *supportlog.Entry
-	DatabaseURL       string
-	Port              int
-	NetworkPassphrase string
-	SigningKeys       string
-	SEP10JWKS         string
-	SEP10JWTIssuer    string
-	FirebaseProjectID string
+	Logger               *supportlog.Entry
+	DatabaseURL          string
+	DatabaseMaxOpenConns int
+	Port                 int
+	NetworkPassphrase    string
+	SigningKeys          string
+	SEP10JWKS            string
+	SEP10JWTIssuer       string
+	FirebaseProjectID    string
 
 	AdminPort        int
 	MetricsNamespace string
@@ -103,6 +104,9 @@ func getHandlerDeps(opts Options) (handlerDeps, error) {
 	if err != nil {
 		return handlerDeps{}, errors.Wrap(err, "error parsing database url")
 	}
+	db.SetMaxOpenConns(opts.DatabaseMaxOpenConns)
+	db.SetMaxIdleConns(opts.DatabaseMaxOpenConns)
+
 	err = db.Ping()
 	if err != nil {
 		opts.Logger.Warn("Error pinging to Database: ", err)


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR sets the max database open connections and idle connections to 20. If we find it problematic, we can just the flag `-db-max-open-conns`  or the env `DB_MAX_OPEN_CONNS` to adjust the number.

### Why

We had a problem where all connections in the same environment were consumed.

### Known limitations

[N/A]
