### PR TITLE
services/horizon/internal/expingest: Exclude shutdown errors from logs in OrderBookStream

### DIFF
--- a/services/horizon/internal/expingest/orderbook.go
+++ b/services/horizon/internal/expingest/orderbook.go
@@ -184,7 +184,9 @@ func (o *OrderBookStream) verifyAllOffers() {
 	offers := o.graph.Offers()
 	ingestionOffers, err := o.historyQ.GetAllOffers()
 	if err != nil {
-		log.WithError(err).Info("Could not verify offers because of error from GetAllOffers")
+		if !isCancelledError(err) {
+			log.WithError(err).Info("Could not verify offers because of error from GetAllOffers")
+		}
 		return
 	}
 
@@ -266,7 +268,7 @@ func (o *OrderBookStream) Run(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			if err := o.Update(); err != nil {
+			if err := o.Update(); err != nil && !isCancelledError(err) {
 				log.WithError(err).Error("could not apply updates from order book stream")
 			}
 		case <-ctx.Done():


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Close https://github.com/stellar/go/issues/2960

When horizon is shutting down we expect that the context embedded in the db connection to be cancelled. When that happens any pending calls to the db will return context cancelled errors. We should not log these errors because they are expected to occur during shutdown.

### Known limitations

[N/A]
