### PR TITLE
services/horizon/docker: Comment-out STELLAR_CORE_BINARY_PATH

### DIFF
--- a/services/horizon/docker/Dockerfile
+++ b/services/horizon/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN go install github.com/stellar/go/services/horizon
 FROM ubuntu:18.04
 
 ENV STELLAR_CORE_VERSION 13.0.0-1220-9ed3da29
-ENV STELLAR_CORE_BINARY_PATH /usr/local/bin/stellar-core
+#ENV STELLAR_CORE_BINARY_PATH /usr/local/bin/stellar-core
 
 # ca-certificates are required to make tls connections
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget


### PR DESCRIPTION
A quickfix for an issue found by @2opremio in https://github.com/stellar/go/pull/2821#issuecomment-680250393 so `stellar/horizon` image can start properly. The Horizon config code will be fixed in the next version.