### PR TITLE
services/horizon: Protocol 14 operations' resource adapters

### DIFF
--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -251,15 +251,15 @@ type EndSponsoringFutureReserves struct {
 // RevokeSponsorship.
 type RevokeSponsorship struct {
 	Base
-	AccountID          *string `json:"account_id"`
-	ClaimableBalanceID *string `json:"claimable_balance_id"`
-	DataAccountID      *string `json:"data_account_id"`
-	DataName           *string `json:"data_name"`
-	OfferID            *string `json:"offer_id"`
-	TrustlineAccountID *string `json:"trustline_account_id"`
-	TrustlineAsset     *string `json:"trustline_asset"`
-	SignerAccountID    *string `json:"signer_account_id"`
-	SignerKey          *string `json:"signer_key"`
+	AccountID          *string `json:"account_id,omitempty"`
+	ClaimableBalanceID *string `json:"claimable_balance_id,omitempty"`
+	DataAccountID      *string `json:"data_account_id,omitempty"`
+	DataName           *string `json:"data_name,omitempty"`
+	OfferID            *string `json:"offer_id,omitempty"`
+	TrustlineAccountID *string `json:"trustline_account_id,omitempty"`
+	TrustlineAsset     *string `json:"trustline_asset,omitempty"`
+	SignerAccountID    *string `json:"signer_account_id,omitempty"`
+	SignerKey          *string `json:"signer_key,omitempty"`
 }
 
 // Operation interface contains methods implemented by the operation types

--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -216,6 +216,52 @@ type Inflation struct {
 	Base
 }
 
+// CreateClaimableBalance is the json resource representing a single operation whose type is
+// CreateClaimableBalance.
+type CreateClaimableBalance struct {
+	Base
+	Asset     string             `json:"asset"`
+	Amount    string             `json:"amount"`
+	Claimants []horizon.Claimant `json:"claimants"`
+}
+
+// ClaimClaimableBalance is the json resource representing a single operation whose type is
+// ClaimClaimableBalance.
+type ClaimClaimableBalance struct {
+	Base
+	BalanceID string `json:"balance_id"`
+	Claimant  string `json:"claimant"`
+}
+
+// BeginSponsoringFutureReserves is the json resource representing a single operation whose type is
+// BeginSponsoringFutureReserves.
+type BeginSponsoringFutureReserves struct {
+	Base
+	SponsoredID string `json:"sponsored_id"`
+}
+
+// EndSponsoringFutureReserves is the json resource representing a single operation whose type is
+// EndSponsoringFutureReserves.
+type EndSponsoringFutureReserves struct {
+	Base
+	BeginSponsor string `json:"begin_sponsor"`
+}
+
+// RevokeSponsorship is the json resource representing a single operation whose type is
+// RevokeSponsorship.
+type RevokeSponsorship struct {
+	Base
+	AccountID          *string `json:"account_id"`
+	ClaimableBalanceID *string `json:"claimable_balance_id"`
+	DataAccountID      *string `json:"data_account_id"`
+	DataName           *string `json:"data_name"`
+	OfferID            *string `json:"offer_id"`
+	TrustlineAccountID *string `json:"trustline_account_id"`
+	TrustlineAsset     *string `json:"trustline_asset"`
+	SignerAccountID    *string `json:"signer_account_id"`
+	SignerKey          *string `json:"signer_key"`
+}
+
 // Operation interface contains methods implemented by the operation types
 type Operation interface {
 	PagingToken() string
@@ -373,6 +419,36 @@ func UnmarshalOperation(operationTypeID int32, dataString []byte) (ops Operation
 		ops = op
 	case xdr.OperationTypePathPaymentStrictSend:
 		var op PathPaymentStrictSend
+		if err = json.Unmarshal(dataString, &op); err != nil {
+			return
+		}
+		ops = op
+	case xdr.OperationTypeCreateClaimableBalance:
+		var op CreateClaimableBalance
+		if err = json.Unmarshal(dataString, &op); err != nil {
+			return
+		}
+		ops = op
+	case xdr.OperationTypeClaimClaimableBalance:
+		var op ClaimClaimableBalance
+		if err = json.Unmarshal(dataString, &op); err != nil {
+			return
+		}
+		ops = op
+	case xdr.OperationTypeBeginSponsoringFutureReserves:
+		var op BeginSponsoringFutureReserves
+		if err = json.Unmarshal(dataString, &op); err != nil {
+			return
+		}
+		ops = op
+	case xdr.OperationTypeEndSponsoringFutureReserves:
+		var op EndSponsoringFutureReserves
+		if err = json.Unmarshal(dataString, &op); err != nil {
+			return
+		}
+		ops = op
+	case xdr.OperationTypeRevokeSponsorship:
+		var op RevokeSponsorship
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return
 		}

--- a/services/horizon/internal/expingest/processors/operations_processor.go
+++ b/services/horizon/internal/expingest/processors/operations_processor.go
@@ -349,7 +349,7 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 		op := operation.operation.Body.MustRevokeSponsorshipOp()
 		switch op.Type {
 		case xdr.RevokeSponsorshipTypeRevokeSponsorshipLedgerEntry:
-			if err := addLedgerKeyDetails(details, *op.LedgerKey, ""); err != nil {
+			if err := addLedgerKeyDetails(details, *op.LedgerKey); err != nil {
 				return nil, err
 			}
 		case xdr.RevokeSponsorshipTypeRevokeSponsorshipSigner:
@@ -420,24 +420,24 @@ func operationFlagDetails(result map[string]interface{}, f int32, prefix string)
 	result[prefix+"_flags_s"] = s
 }
 
-func addLedgerKeyDetails(result map[string]interface{}, ledgerKey xdr.LedgerKey, prefix string) error {
+func addLedgerKeyDetails(result map[string]interface{}, ledgerKey xdr.LedgerKey) error {
 	switch ledgerKey.Type {
 	case xdr.LedgerEntryTypeAccount:
-		result[prefix+"account_id"] = ledgerKey.Account.AccountId.Address()
+		result["account_id"] = ledgerKey.Account.AccountId.Address()
 	case xdr.LedgerEntryTypeClaimableBalance:
 		marshalHex, err := xdr.MarshalHex(ledgerKey.ClaimableBalance.BalanceId)
 		if err != nil {
 			return errors.Wrapf(err, "in claimable balance")
 		}
-		result[prefix+"claimable_balance_id"] = marshalHex
+		result["claimable_balance_id"] = marshalHex
 	case xdr.LedgerEntryTypeData:
-		result[prefix+"account_id"] = ledgerKey.Data.AccountId.Address()
-		result[prefix+"data_name"] = ledgerKey.Data.DataName
+		result["data_account_id"] = ledgerKey.Data.AccountId.Address()
+		result["data_name"] = ledgerKey.Data.DataName
 	case xdr.LedgerEntryTypeOffer:
-		result[prefix+"offer_id"] = ledgerKey.Offer.OfferId
+		result["offer_id"] = ledgerKey.Offer.OfferId
 	case xdr.LedgerEntryTypeTrustline:
-		result[prefix+"account_id"] = ledgerKey.TrustLine.AccountId.Address()
-		addAssetDetails(result, ledgerKey.TrustLine.Asset, prefix)
+		result["trustline_account_id"] = ledgerKey.TrustLine.AccountId.Address()
+		result["trustline_asset"] = ledgerKey.TrustLine.Asset.StringCanonical()
 	}
 	return nil
 }

--- a/services/horizon/internal/resourceadapter/operations.go
+++ b/services/horizon/internal/resourceadapter/operations.go
@@ -108,6 +108,26 @@ func NewOperation(
 		e.Payment.Base = base
 		err = operationRow.UnmarshalDetails(&e)
 		result = e
+	case xdr.OperationTypeCreateClaimableBalance:
+		e := operations.CreateClaimableBalance{}
+		err = operationRow.UnmarshalDetails(&e)
+		result = e
+	case xdr.OperationTypeClaimClaimableBalance:
+		e := operations.ClaimClaimableBalance{}
+		err = operationRow.UnmarshalDetails(&e)
+		result = e
+	case xdr.OperationTypeBeginSponsoringFutureReserves:
+		e := operations.BeginSponsoringFutureReserves{}
+		err = operationRow.UnmarshalDetails(&e)
+		result = e
+	case xdr.OperationTypeEndSponsoringFutureReserves:
+		e := operations.EndSponsoringFutureReserves{}
+		err = operationRow.UnmarshalDetails(&e)
+		result = e
+	case xdr.OperationTypeRevokeSponsorship:
+		e := operations.RevokeSponsorship{}
+		err = operationRow.UnmarshalDetails(&e)
+		result = e
 	default:
 		result = base
 	}

--- a/services/horizon/internal/resourceadapter/operations_test.go
+++ b/services/horizon/internal/resourceadapter/operations_test.go
@@ -94,7 +94,7 @@ func TestPopulateOperation_AllowTrust(t *testing.T) {
 		"trustor":                           "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3"
 	}`
 
-	rsp, err := getJSONResponse(details)
+	rsp, err := getJSONResponse(xdr.OperationTypeAllowTrust, details)
 	tt.NoError(err)
 	tt.Equal(false, rsp["authorize"])
 	tt.Equal(true, rsp["authorize_to_maintain_liabilities"])
@@ -109,7 +109,7 @@ func TestPopulateOperation_AllowTrust(t *testing.T) {
 		"trustor":                           "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3"
 	}`
 
-	rsp, err = getJSONResponse(details)
+	rsp, err = getJSONResponse(xdr.OperationTypeAllowTrust, details)
 	tt.NoError(err)
 	tt.Equal(true, rsp["authorize"])
 	tt.Equal(true, rsp["authorize_to_maintain_liabilities"])
@@ -124,13 +124,135 @@ func TestPopulateOperation_AllowTrust(t *testing.T) {
 		"trustor":                           "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3"
 	}`
 
-	rsp, err = getJSONResponse(details)
+	rsp, err = getJSONResponse(xdr.OperationTypeAllowTrust, details)
 	tt.NoError(err)
 	tt.Equal(false, rsp["authorize"])
 	tt.Equal(false, rsp["authorize_to_maintain_liabilities"])
 }
 
-func getJSONResponse(details string) (rsp map[string]interface{}, err error) {
+func TestPopulateOperation_CreateClaimableBalance(t *testing.T) {
+	tt := assert.New(t)
+
+	details := `{
+		"asset":  "COP:GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+		"amount": "10.0000000",
+		"claimants": [
+			{
+				"destination": "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+				"predicate": {
+					"and": [
+						{
+							"or": [
+								{"relBefore":12},
+								{"absBefore": "2020-08-26T11:15:39Z"}
+							]
+						},
+						{
+							"not": {"unconditional": true}
+						}
+					]
+				}
+			}
+		]
+	}`
+
+	resp, err := getJSONResponse(xdr.OperationTypeCreateClaimableBalance, details)
+	tt.NoError(err)
+	tt.Equal("COP:GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD", resp["asset"])
+	tt.Equal("10.0000000", resp["amount"])
+}
+
+func TestPopulateOperation_ClaimClaimableBalance(t *testing.T) {
+	tt := assert.New(t)
+
+	details := `{
+		"balance_id": "abc",
+		"claimant": "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"
+	}`
+
+	resp, err := getJSONResponse(xdr.OperationTypeClaimClaimableBalance, details)
+	tt.NoError(err)
+	tt.Equal("abc", resp["balance_id"])
+	tt.Equal("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD", resp["claimant"])
+}
+
+func TestPopulateOperation_BeginSponsoringFutureReserves(t *testing.T) {
+	tt := assert.New(t)
+
+	details := `{
+		"sponsored_id": "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"
+	}`
+
+	resp, err := getJSONResponse(xdr.OperationTypeBeginSponsoringFutureReserves, details)
+	tt.NoError(err)
+	tt.Equal("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD", resp["sponsored_id"])
+}
+
+func TestPopulateOperation_EndSponsoringFutureReserves(t *testing.T) {
+	tt := assert.New(t)
+
+	details := `{
+		"begin_sponsor": "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"
+	}`
+
+	resp, err := getJSONResponse(xdr.OperationTypeEndSponsoringFutureReserves, details)
+	tt.NoError(err)
+	tt.Equal("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD", resp["begin_sponsor"])
+}
+
+func TestPopulateOperation_OperationTypeRevokeSponsorship_Account(t *testing.T) {
+	tt := assert.New(t)
+
+	details := `{
+		"account_id": "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"
+	}`
+
+	resp, err := getJSONResponse(xdr.OperationTypeRevokeSponsorship, details)
+	tt.NoError(err)
+	tt.Equal("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD", resp["account_id"])
+}
+
+func TestPopulateOperation_OperationTypeRevokeSponsorship_Data(t *testing.T) {
+	tt := assert.New(t)
+
+	details := `{
+		"data_account_id": "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+		"data_name": "name"
+	}`
+
+	resp, err := getJSONResponse(xdr.OperationTypeRevokeSponsorship, details)
+	tt.NoError(err)
+	tt.Equal("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD", resp["data_account_id"])
+	tt.Equal("name", resp["data_name"])
+}
+
+func TestPopulateOperation_OperationTypeRevokeSponsorship_Offer(t *testing.T) {
+	tt := assert.New(t)
+
+	details := `{
+		"offer_id": "1000"
+	}`
+
+	resp, err := getJSONResponse(xdr.OperationTypeRevokeSponsorship, details)
+	tt.NoError(err)
+	tt.Equal("1000", resp["offer_id"])
+}
+
+func TestPopulateOperation_OperationTypeRevokeSponsorship_Trustline(t *testing.T) {
+	tt := assert.New(t)
+
+	details := `{
+		"trustline_account_id": "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+		"trustline_asset": "COP:GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"
+	}`
+
+	resp, err := getJSONResponse(xdr.OperationTypeRevokeSponsorship, details)
+	tt.NoError(err)
+	tt.Equal("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD", resp["trustline_account_id"])
+	tt.Equal("COP:GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD", resp["trustline_asset"])
+}
+
+func getJSONResponse(typ xdr.OperationType, details string) (rsp map[string]interface{}, err error) {
 	ctx, _ := test.ContextWithLogBuffer()
 	transactionRow := history.Transaction{
 		TransactionWithoutLedger: history.TransactionWithoutLedger{
@@ -141,7 +263,7 @@ func getJSONResponse(details string) (rsp map[string]interface{}, err error) {
 	}
 	operationsRow := history.Operation{
 		TransactionSuccessful: true,
-		Type:                  xdr.OperationTypeAllowTrust,
+		Type:                  typ,
 		DetailsString:         null.StringFrom(details),
 	}
 	resource, err := NewOperation(ctx, operationsRow, "", &transactionRow, history.Ledger{})

--- a/xdr/json_test.go
+++ b/xdr/json_test.go
@@ -2,8 +2,9 @@ package xdr
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClaimPredicateJSON(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

Implements new operations and its' resource adapters.

Close #2940.
Close #2941.

### Known limitations

Unit tests are really simple and don't really check if claimants are rendered correctly. Let's check it out in integration tests.