### PR TITLE
services/horizon/txsub: Add Protocol 14 ops in ForOperationResult

### DIFF
--- a/services/horizon/internal/codes/main.go
+++ b/services/horizon/internal/codes/main.go
@@ -440,6 +440,16 @@ func ForOperationResult(opr xdr.OperationResult) (string, error) {
 		ic = ir.MustBumpSeqResult().Code
 	case xdr.OperationTypePathPaymentStrictSend:
 		ic = ir.MustPathPaymentStrictSendResult().Code
+	case xdr.OperationTypeCreateClaimableBalance:
+		ic = ir.MustCreateClaimableBalanceResult().Code
+	case xdr.OperationTypeClaimClaimableBalance:
+		ic = ir.MustClaimClaimableBalanceResult().Code
+	case xdr.OperationTypeBeginSponsoringFutureReserves:
+		ic = ir.MustBeginSponsoringFutureReservesResult().Code
+	case xdr.OperationTypeEndSponsoringFutureReserves:
+		ic = ir.MustEndSponsoringFutureReservesResult().Code
+	case xdr.OperationTypeRevokeSponsorship:
+		ic = ir.MustRevokeSponsorshipResult().Code
 	}
 
 	return String(ic)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

I forgot to add new ops to `ForOperationResult` in https://github.com/stellar/go/pull/2981. Now, the codes are correctly returned. I'm sorry for two similar PRs.