### PR TITLE
services/horizon: (Protocol 14) Fix nil dereference on EndSponsorship details/participants

### DIFF
--- a/services/horizon/internal/expingest/processors/operations_processor.go
+++ b/services/horizon/internal/expingest/processors/operations_processor.go
@@ -343,8 +343,9 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 		if beginSponsoringOp == nil {
 			return nil, fmt.Errorf("prior Begin operation not found for EndSponsoringFutureReserves")
 		}
-		beginSponsor := beginSponsoringOp.SourceAccount.ToAccountId()
-		details["begin_sponsor"] = beginSponsor.Address()
+		beginSponsorWrapper := *operation
+		beginSponsorWrapper.operation = *beginSponsoringOp
+		details["begin_sponsor"] = beginSponsorWrapper.SourceAccount().Address()
 	case xdr.OperationTypeRevokeSponsorship:
 		op := operation.operation.Body.MustRevokeSponsorshipOp()
 		switch op.Type {
@@ -490,8 +491,10 @@ func (operation *transactionOperationWrapper) Participants() ([]xdr.AccountId, e
 		if beginSponsoringOp == nil {
 			return nil, fmt.Errorf("prior Begin operation not found for EndSponsoringFutureReserves")
 		}
-		beginSponsor := beginSponsoringOp.SourceAccount.ToAccountId()
-		participants = append(participants, beginSponsor)
+		beginSponsorWrapper := *operation
+		beginSponsorWrapper.operation = *beginSponsoringOp
+		beginSponsorSource := beginSponsorWrapper.SourceAccount()
+		participants = append(participants, *beginSponsorSource)
 	case xdr.OperationTypeRevokeSponsorship:
 		// the only direct participant is the source_account
 	default:

--- a/services/horizon/internal/expingest/processors/transaction_operation_wrapper_test.go
+++ b/services/horizon/internal/expingest/processors/transaction_operation_wrapper_test.go
@@ -1323,8 +1323,13 @@ func getSponsoredSandwichWrappers() []*transactionOperationWrapper {
 			SponsoredId: sponsoree,
 		},
 	}
+
 	sponsorMuxed := sponsor.ToMuxedAccount()
-	tx.Envelope.Operations()[0].SourceAccount = &sponsorMuxed
+	// Do not provide the source explicitly so that the transaction source is used
+	// It tests https://github.com/stellar/go/issues/2982 .
+	// tx.Envelope.Operations()[0].SourceAccount = &sponsorMuxed
+	tx.Envelope.Operations()[0].SourceAccount = nil
+	tx.Envelope.V1.Tx.SourceAccount = sponsorMuxed
 
 	// sponsored operation
 	tx.Envelope.Operations()[1].Body = xdr.OperationBody{


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The new Protocol-14 code for the EndSponsorship details/participants incorrectly assumed that the matching, initial BeginSponsorhip operation had a non-nil source. This PR fixes that.

### Why

We don't like panics :)

### Known limitations

N/A
