### PR TITLE
services/horizon: Add state verifier integration tests connected to Protocol 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,7 +347,7 @@ jobs:
           # Currently all integration tests are in a single directory.
           command: |
             cd ~/go/src/github.com/stellar/go
-            go test -v ./services/horizon/internal/integration/...
+            go test -timeout 20m -v ./services/horizon/internal/integration/...
 #-------------------------------------------------------------------------#
 # Workflows orchestrate jobs and make sure they run in the right sequence #
 #-------------------------------------------------------------------------#

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -287,6 +287,7 @@ type Root struct {
 		Account             hal.Link  `json:"account"`
 		Accounts            *hal.Link `json:"accounts,omitempty"`
 		AccountTransactions hal.Link  `json:"account_transactions"`
+		ClaimableBalances   *hal.Link `json:"claimable_balances"`
 		Assets              hal.Link  `json:"assets"`
 		Effects             hal.Link  `json:"effects"`
 		FeeStats            hal.Link  `json:"fee_stats"`

--- a/services/horizon/internal/actions/account_data.go
+++ b/services/horizon/internal/actions/account_data.go
@@ -36,7 +36,7 @@ func (handler GetAccountDataHandler) GetResource(w HeaderWriter, r *http.Request
 	}
 	response := accountDataResponse{Value: data.Value.Base64()}
 	if data.Sponsor.Valid {
-		response.Value = data.Sponsor.String
+		response.Sponsor = data.Sponsor.String
 	}
 	return response, nil
 }

--- a/services/horizon/internal/actions/root.go
+++ b/services/horizon/internal/actions/root.go
@@ -30,6 +30,7 @@ func (handler GetRootHandler) GetResource(w HeaderWriter, r *http.Request) (inte
 	var res horizon.Root
 	templates := map[string]string{
 		"accounts":           AccountsQuery{}.URITemplate(),
+		"claimableBalances":  ClaimableBalancesQuery{}.URITemplate(),
 		"offers":             OffersQuery{}.URITemplate(),
 		"strictReceivePaths": StrictReceivePathsQuery{}.URITemplate(),
 		"strictSendPaths":    FindFixedPathsQuery{}.URITemplate(),

--- a/services/horizon/internal/db2/history/account_data_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/account_data_batch_insert_builder.go
@@ -19,6 +19,7 @@ func (i *accountDataBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
 		"name":                 data.DataName,
 		"value":                AccountDataValue(data.DataValue),
 		"last_modified_ledger": entry.LastModifiedLedgerSeq,
+		"sponsor":              ledgerEntrySponsorToNullString(entry),
 	})
 }
 

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -142,7 +142,7 @@ func (q *Q) CountClaimableBalances() (int, error) {
 // GetClaimableBalancesByID finds all claimable balances by ClaimableBalanceId
 func (q *Q) GetClaimableBalancesByID(ids []xdr.ClaimableBalanceId) ([]ClaimableBalance, error) {
 	var cBalances []ClaimableBalance
-	sql := selectClaimableBalances.Where(map[string]interface{}{"claimable_balances.id": ids})
+	sql := selectClaimableBalances.Where(map[string]interface{}{"cb.id": ids})
 	err := q.Select(&cBalances, sql)
 	return cBalances, err
 }

--- a/services/horizon/internal/integration/protocol14_state_verifier_test.go
+++ b/services/horizon/internal/integration/protocol14_state_verifier_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/services/horizon/internal/txnbuild"
@@ -25,70 +24,49 @@ func TestProtocol14StateVerifier(t *testing.T) {
 		Sequence:  1,
 	}
 
-	// Transaction below creates a sponsorship sandwich sponsoring an account,
-	// it's trustline, offer, data and claimable balance created by it.
+	// The operations below create a sponsorship sandwich, sponsoring an
+	// account, its trustlines, offers, data, and claimable balances.
 	// TODO multiple signers and a sponsor at non-first position
-	master := itest.Master().(*keypair.Full)
-	tx, err := txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount: &txnbuild.SimpleAccount{
-				AccountID: master.Address(),
-				Sequence:  1,
-			},
-			Operations: []txnbuild.Operation{
-				&txnbuild.BeginSponsoringFutureReserves{
-					SponsoredID: sponsored.Address(),
-				},
-				&txnbuild.CreateAccount{
-					Destination: sponsored.Address(),
-					Amount:      "100",
-				},
-				&txnbuild.ChangeTrust{
-					SourceAccount: sponsoredSource,
-					Line:          txnbuild.CreditAsset{"ABCD", master.Address()},
-					Limit:         txnbuild.MaxTrustlineLimit,
-				},
-				&txnbuild.ManageSellOffer{
-					SourceAccount: sponsoredSource,
-					Selling:       txnbuild.NativeAsset{},
-					Buying:        txnbuild.CreditAsset{"ABCD", master.Address()},
-					Amount:        "3",
-					Price:         "1",
-				},
-				&txnbuild.ManageData{
-					SourceAccount: sponsoredSource,
-					Name:          "test",
-					Value:         []byte("test"),
-				},
-				&txnbuild.CreateClaimableBalance{
-					SourceAccount: sponsoredSource,
-					Amount:        "2",
-					Asset:         txnbuild.NativeAsset{},
-					Destinations:  []string{keypair.MustRandom().Address()},
-				},
-				&txnbuild.EndSponsoringFutureReserves{
-					SourceAccount: sponsoredSource,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
+	master := itest.Master()
+	ops := []txnbuild.Operation{
+		&txnbuild.BeginSponsoringFutureReserves{
+			SponsoredID: sponsored.Address(),
 		},
-	)
-	assert.NoError(t, err)
-	tx, err = tx.Sign(test.IntegrationNetworkPassphrase, master, sponsored)
-	assert.NoError(t, err)
-
-	txb64, err := tx.Base64()
-	assert.NoError(t, err)
-
-	txResp, err := itest.Client().SubmitTransactionXDR(txb64)
-	if !assert.NoError(t, err) {
-		horizonError := err.(*horizonclient.Error)
-		codes, _ := horizonError.ResultCodes()
-		envelope, _ := horizonError.EnvelopeXDR()
-		t.Logf("%+v", codes)
-		t.Logf("%+v", envelope)
+		&txnbuild.CreateAccount{
+			Destination: sponsored.Address(),
+			Amount:      "100",
+		},
+		&txnbuild.ChangeTrust{
+			SourceAccount: sponsoredSource,
+			Line:          txnbuild.CreditAsset{"ABCD", master.Address()},
+			Limit:         txnbuild.MaxTrustlineLimit,
+		},
+		&txnbuild.ManageSellOffer{
+			SourceAccount: sponsoredSource,
+			Selling:       txnbuild.NativeAsset{},
+			Buying:        txnbuild.CreditAsset{"ABCD", master.Address()},
+			Amount:        "3",
+			Price:         "1",
+		},
+		&txnbuild.ManageData{
+			SourceAccount: sponsoredSource,
+			Name:          "test",
+			Value:         []byte("test"),
+		},
+		&txnbuild.CreateClaimableBalance{
+			SourceAccount: sponsoredSource,
+			Amount:        "2",
+			Asset:         txnbuild.NativeAsset{},
+			Destinations: []txnbuild.Claimant{
+				txnbuild.NewClaimant(keypair.MustRandom().Address(), nil),
+			},
+		},
+		&txnbuild.EndSponsoringFutureReserves{
+			SourceAccount: sponsoredSource,
+		},
 	}
+	txResp, err := itest.SubmitMultiSigOperations(itest.MasterAccount(), []*keypair.Full{master, sponsored}, ops...)
+	assert.NoError(t, err)
 	assert.True(t, txResp.Successful)
 
 	// Wait for the first checkpoint ledger

--- a/services/horizon/internal/integration/protocol14_state_verifier_test.go
+++ b/services/horizon/internal/integration/protocol14_state_verifier_test.go
@@ -1,0 +1,126 @@
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/services/horizon/internal/txnbuild"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProtocol14StateVerifier(t *testing.T) {
+	itest := test.NewIntegrationTest(t, protocol14Config)
+	defer itest.Close()
+
+	sponsored := keypair.MustRandom()
+	sponsoredSource := &txnbuild.SimpleAccount{
+		AccountID: sponsored.Address(),
+		Sequence:  1,
+	}
+
+	// Transaction below creates a sponsorship sandwich sponsoring an account,
+	// it's trustline, offer, data and claimable balance created by it.
+	// TODO multiple signers and a sponsor at non-first position
+	master := itest.Master().(*keypair.Full)
+	tx, err := txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount: &txnbuild.SimpleAccount{
+				AccountID: master.Address(),
+				Sequence:  1,
+			},
+			Operations: []txnbuild.Operation{
+				&txnbuild.BeginSponsoringFutureReserves{
+					SponsoredID: sponsored.Address(),
+				},
+				&txnbuild.CreateAccount{
+					Destination: sponsored.Address(),
+					Amount:      "100",
+				},
+				&txnbuild.ChangeTrust{
+					SourceAccount: sponsoredSource,
+					Line:          txnbuild.CreditAsset{"ABCD", master.Address()},
+					Limit:         txnbuild.MaxTrustlineLimit,
+				},
+				&txnbuild.ManageSellOffer{
+					SourceAccount: sponsoredSource,
+					Selling:       txnbuild.NativeAsset{},
+					Buying:        txnbuild.CreditAsset{"ABCD", master.Address()},
+					Amount:        "3",
+					Price:         "1",
+				},
+				&txnbuild.ManageData{
+					SourceAccount: sponsoredSource,
+					Name:          "test",
+					Value:         []byte("test"),
+				},
+				&txnbuild.CreateClaimableBalance{
+					SourceAccount: sponsoredSource,
+					Amount:        "2",
+					Asset:         txnbuild.NativeAsset{},
+					Destinations:  []string{keypair.MustRandom().Address()},
+				},
+				&txnbuild.EndSponsoringFutureReserves{
+					SourceAccount: sponsoredSource,
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	assert.NoError(t, err)
+	tx, err = tx.Sign(test.IntegrationNetworkPassphrase, master, sponsored)
+	assert.NoError(t, err)
+
+	txb64, err := tx.Base64()
+	assert.NoError(t, err)
+
+	txResp, err := itest.Client().SubmitTransactionXDR(txb64)
+	if !assert.NoError(t, err) {
+		horizonError := err.(*horizonclient.Error)
+		codes, _ := horizonError.ResultCodes()
+		envelope, _ := horizonError.EnvelopeXDR()
+		t.Logf("%+v", codes)
+		t.Logf("%+v", envelope)
+	}
+	assert.True(t, txResp.Successful)
+
+	// Wait for the first checkpoint ledger
+	for !itest.LedgerIngested(63) {
+		fmt.Println("63 not closed yet...")
+		time.Sleep(5 * time.Second)
+	}
+
+	var metrics string
+
+	// Check metrics until state verification run
+	for i := 0; i < 60; i++ {
+		fmt.Printf("Checking metrics (%d attempt)\n", i)
+		res, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", itest.AdminPort()))
+		assert.NoError(t, err)
+
+		metricsBytes, err := ioutil.ReadAll(res.Body)
+		res.Body.Close()
+		assert.NoError(t, err)
+		metrics = string(metricsBytes)
+
+		stateInvalid := strings.Contains(metrics, "horizon_ingest_state_invalid 1")
+		assert.False(t, stateInvalid, "State is invalid!")
+
+		notVerifiedYet := strings.Contains(metrics, "horizon_ingest_state_verify_duration_seconds_count 0")
+		if notVerifiedYet {
+			time.Sleep(time.Second)
+			continue
+		}
+
+		return
+	}
+
+	t.Fatal("State verification not run...")
+}

--- a/services/horizon/internal/resourceadapter/balance.go
+++ b/services/horizon/internal/resourceadapter/balance.go
@@ -29,6 +29,9 @@ func PopulateBalance(dest *protocol.Balance, row history.TrustLine) (err error) 
 	if isAuthorizedToMaintainLiabilities {
 		dest.IsAuthorizedToMaintainLiabilities = &isAuthorizedToMaintainLiabilities
 	}
+	if row.Sponsor.Valid {
+		dest.Sponsor = row.Sponsor.String
+	}
 	return
 }
 

--- a/services/horizon/internal/resourceadapter/root.go
+++ b/services/horizon/internal/resourceadapter/root.go
@@ -53,11 +53,13 @@ func PopulateRoot(
 	dest.Links.Trades = lb.Link("/trades?base_asset_type={base_asset_type}&base_asset_code={base_asset_code}&base_asset_issuer={base_asset_issuer}&counter_asset_type={counter_asset_type}&counter_asset_code={counter_asset_code}&counter_asset_issuer={counter_asset_issuer}")
 
 	accountsLink := lb.Link(templates["accounts"])
+	claimableBalancesLink := lb.Link(templates["claimableBalances"])
 	offerLink := lb.Link("/offers/{offer_id}")
 	offersLink := lb.Link(templates["offers"])
 	strictReceivePaths := lb.Link(templates["strictReceivePaths"])
 	strictSendPaths := lb.Link(templates["strictSendPaths"])
 	dest.Links.Accounts = &accountsLink
+	dest.Links.ClaimableBalances = &claimableBalancesLink
 	dest.Links.Offer = &offerLink
 	dest.Links.Offers = &offersLink
 	dest.Links.StrictReceivePaths = &strictReceivePaths

--- a/services/horizon/internal/test/integration.go
+++ b/services/horizon/internal/test/integration.go
@@ -179,6 +179,22 @@ func (i *IntegrationTest) Client() *sdk.Client {
 	return i.hclient
 }
 
+// LedgerIngested returns true if the ledger with a given sequence has been
+// ingested by Horizon. Panics in case of errors.
+func (i *IntegrationTest) LedgerIngested(sequence uint32) bool {
+	root, err := i.Client().Root()
+	if err != nil {
+		panic(err)
+	}
+
+	return root.IngestSequence >= sequence
+}
+
+// AdminPort returns Horizon admin port.
+func (i *IntegrationTest) AdminPort() int {
+	return 6060
+}
+
 // Master returns a keypair of the network master account.
 func (i *IntegrationTest) Master() *keypair.Full {
 	return keypair.Master(IntegrationNetworkPassphrase).(*keypair.Full)
@@ -245,11 +261,12 @@ func createTestContainer(i *IntegrationTest, image string) error {
 				"--standalone",
 				"--protocol-version", strconv.FormatInt(int64(i.config.ProtocolVersion), 10),
 			},
-			ExposedPorts: nat.PortSet{"8000": struct{}{}},
+			ExposedPorts: nat.PortSet{"8000": struct{}{}, "6060": struct{}{}},
 		},
 		&container.HostConfig{
 			PortBindings: map[nat.Port][]nat.PortBinding{
 				nat.Port("8000"): {{HostIP: "127.0.0.1", HostPort: "8000"}},
+				nat.Port("6060"): {{HostIP: "127.0.0.1", HostPort: "6060"}},
 			},
 		},
 		nil,


### PR DESCRIPTION
### What

Adds a new integration tests checking if state is correctly verified when ledger entries have sponsors and a new entry type: `ClaimableBalance`. It adds ledger entries and then gets `:[admin_port]/metrics` to check if state verification is finished and state is correct.

Part of #2939.

While working on this I fixed some bugs:
* `/accounts/{id}/data/{name}` data value was incorrectly rendered (overwritten by a sponsor),
* Sponsor missing in account's balances.
* `accountDataBatchInsertBuilder` not adding sponsor,
* `GetClaimableBalancesByID` didn't work at all (invalid query).

### Why

We want to ensure that a new code added to state verifier is working correctly.

### Known limitations

* Currently it's not possible to speed ledger close times easily so test needs to wait until the first checkpoint ledger (63) is closed.
* No signer sponsorships added. Run out of time today.