### PR TITLE
services/horizon: Add basic integration test scenario for CAP23.

### DIFF
--- a/services/horizon/internal/integration/protocol14_claimable_balance_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_claimable_balance_ops_test.go
@@ -1,0 +1,66 @@
+package integration
+
+import (
+	"testing"
+
+	sdk "github.com/stellar/go/clients/horizonclient"
+	hEffects "github.com/stellar/go/protocols/horizon/effects"
+	"github.com/stellar/go/protocols/horizon/operations"
+	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/services/horizon/internal/txnbuild"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateClaimableBalanceSuccessfulOperationsEffects(t *testing.T) {
+	tt := assert.New(t)
+	itest := test.NewIntegrationTest(t, protocol14Config)
+	defer itest.Close()
+	master := itest.Master()
+
+	op := txnbuild.CreateClaimableBalance{
+		Destinations: []string{master.Address()},
+		Amount:       "10",
+		Asset:        txnbuild.NativeAsset{},
+	}
+
+	txResp, err := itest.SubmitOperations(itest.MasterAccount(), master, &op)
+	assert.NoError(t, err)
+
+	var txResult xdr.TransactionResult
+	err = xdr.SafeUnmarshalBase64(txResp.ResultXdr, &txResult)
+	assert.NoError(t, err)
+	assert.Equal(t, xdr.TransactionResultCodeTxSuccess, txResult.Result.Code)
+
+	response, err := itest.Client().Operations(sdk.OperationRequest{})
+	ops := response.Embedded.Records
+	tt.NoError(err)
+	tt.Len(ops, 1)
+	cb := ops[0].(operations.CreateClaimableBalance)
+	tt.Equal("native", cb.Asset)
+	tt.Equal("10.0000000", cb.Amount)
+	tt.Equal(itest.MasterAccount().GetAccountID(), cb.SourceAccount)
+	tt.Len(cb.Claimants, 1)
+
+	claimant := cb.Claimants[0]
+	tt.Equal(itest.MasterAccount().GetAccountID(), claimant.Destination)
+	tt.Equal(xdr.ClaimPredicateTypeClaimPredicateUnconditional, claimant.Predicate.Type)
+
+	eResponse, err := itest.Client().Effects(sdk.EffectRequest{ForOperation: cb.ID})
+	effects := eResponse.Embedded.Records
+	tt.Len(effects, 4)
+
+	tt.Equal("claimable_balance_created", effects[0].GetType())
+	tt.Equal("claimable_balance_claimant_created", effects[1].GetType())
+
+	accountDebitedEffect := effects[2].(hEffects.AccountDebited)
+	tt.Equal("10.0000000", accountDebitedEffect.Amount)
+	tt.Equal("native", accountDebitedEffect.Asset.Type)
+	tt.Equal(itest.MasterAccount().GetAccountID(), accountDebitedEffect.Account)
+
+	tt.Equal("10.0000000", accountDebitedEffect.Amount)
+	tt.Equal("native", accountDebitedEffect.Asset.Type)
+	tt.Equal(itest.MasterAccount().GetAccountID(), accountDebitedEffect.Account)
+
+	tt.Equal("claimable_balance_sponsorship_created", effects[3].GetType())
+}

--- a/services/horizon/internal/integration/protocol14_claimable_balance_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_claimable_balance_ops_test.go
@@ -19,9 +19,11 @@ func TestCreateClaimableBalanceSuccessfulOperationsEffects(t *testing.T) {
 	master := itest.Master()
 
 	op := txnbuild.CreateClaimableBalance{
-		Destinations: []string{master.Address()},
-		Amount:       "10",
-		Asset:        txnbuild.NativeAsset{},
+		Destinations: []txnbuild.Claimant{
+			txnbuild.NewClaimant(master.Address(), nil),
+		},
+		Amount: "10",
+		Asset:  txnbuild.NativeAsset{},
 	}
 
 	txResp, err := itest.SubmitOperations(itest.MasterAccount(), master, &op)

--- a/services/horizon/internal/integration/protocol14_test.go
+++ b/services/horizon/internal/integration/protocol14_test.go
@@ -42,9 +42,11 @@ func TestCreateClaimableBalance(t *testing.T) {
 
 	// Submit a self-referencing claimable balance
 	op := txnbuild.CreateClaimableBalance{
-		Destinations: []string{master.Address()},
-		Amount:       "10",
-		Asset:        txnbuild.NativeAsset{},
+		Destinations: []txnbuild.Claimant{
+			txnbuild.NewClaimant(master.Address(), nil),
+		},
+		Amount: "10",
+		Asset:  txnbuild.NativeAsset{},
 	}
 
 	txResp, err := itest.SubmitOperations(itest.MasterAccount(), master, &op)
@@ -90,9 +92,11 @@ func runFilteringTest(i *test.IntegrationTest, source *keypair.Full, dest *keypa
 	assert.NoError(t, err)
 
 	op := txnbuild.CreateClaimableBalance{
-		Destinations: []string{dest.Address()},
-		Amount:       "10",
-		Asset:        asset,
+		Destinations: []txnbuild.Claimant{
+			txnbuild.NewClaimant(dest.Address(), nil),
+		},
+		Amount: "10",
+		Asset:  asset,
 	}
 
 	// Submit a simple claimable balance from A -> B.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add a simple scenario testing CAP23 operations and effects.

### Why

It adds e2e testing for new features of Horizon and Stellar.




### Important

This is done on top of #2991 - the relevant commit here is 40dace2f16b5b75273aaa547846126416dfca62a