### PR TITLE
exp/services/recoverysigner: call database transaction `.Rollback()` when returning an error

### DIFF
--- a/exp/services/recoverysigner/internal/account/db_store_add.go
+++ b/exp/services/recoverysigner/internal/account/db_store_add.go
@@ -15,6 +15,7 @@ func (s *DBStore) Add(a Account) error {
 		RETURNING id
 	`, a.Address)
 	if err != nil {
+		tx.Rollback()
 		// 23505 is the PostgreSQL error for Unique Violation.
 		// See https://www.postgresql.org/docs/9.2/errcodes-appendix.html.
 		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "23505" {
@@ -31,6 +32,7 @@ func (s *DBStore) Add(a Account) error {
 			RETURNING id
 		`, accountID, i.Role)
 		if err != nil {
+			tx.Rollback()
 			return err
 		}
 
@@ -40,6 +42,7 @@ func (s *DBStore) Add(a Account) error {
 				VALUES ($1, $2, $3, $4)
 			`, accountID, identityID, m.Type, m.Value)
 			if err != nil {
+				tx.Rollback()
 				return err
 			}
 		}

--- a/exp/services/recoverysigner/internal/account/db_store_add.go
+++ b/exp/services/recoverysigner/internal/account/db_store_add.go
@@ -7,6 +7,7 @@ func (s *DBStore) Add(a Account) error {
 	if err != nil {
 		return err
 	}
+	defer tx.Rollback()
 
 	accountID := int64(0)
 	err = tx.Get(&accountID, `
@@ -15,7 +16,6 @@ func (s *DBStore) Add(a Account) error {
 		RETURNING id
 	`, a.Address)
 	if err != nil {
-		tx.Rollback()
 		// 23505 is the PostgreSQL error for Unique Violation.
 		// See https://www.postgresql.org/docs/9.2/errcodes-appendix.html.
 		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "23505" {
@@ -32,7 +32,6 @@ func (s *DBStore) Add(a Account) error {
 			RETURNING id
 		`, accountID, i.Role)
 		if err != nil {
-			tx.Rollback()
 			return err
 		}
 
@@ -42,7 +41,6 @@ func (s *DBStore) Add(a Account) error {
 				VALUES ($1, $2, $3, $4)
 			`, accountID, identityID, m.Type, m.Value)
 			if err != nil {
-				tx.Rollback()
 				return err
 			}
 		}

--- a/exp/services/recoverysigner/internal/account/db_store_add_test.go
+++ b/exp/services/recoverysigner/internal/account/db_store_add_test.go
@@ -161,3 +161,26 @@ func TestAdd_conflict(t *testing.T) {
 	err = store.Add(a)
 	assert.Equal(t, ErrAlreadyExists, err)
 }
+
+func TestAdd_conflictProperlyClosesTheConnections(t *testing.T) {
+	db := dbtest.Open(t)
+	session := db.Open()
+	session.SetMaxIdleConns(1)
+	session.SetMaxOpenConns(1)
+
+	store := DBStore{
+		DB: session,
+	}
+
+	a := Account{
+		Address: "GCLLT3VG4F6EZAHZEBKWBWV5JGVPCVIKUCGTY3QEOAIZU5IJGMWCT2TT",
+	}
+
+	err := store.Add(a)
+	require.NoError(t, err)
+
+	for range [5]int{} {
+		err = store.Add(a)
+		require.Equal(t, ErrAlreadyExists, err)
+	}
+}


### PR DESCRIPTION


<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Call `tx.Rollback()` when returning an error from `func (s *DBStore) Add(a Account) error`.

### Why

You need to call `tx.Rollback()` in order to abort the database transaction. Without calling it, the transactions may stack up indefinitely until they reach the max limit.

### Known limitations

We still need to review the other usages of database transactions to make sure it's being rolled back properly.
