### PR TITLE
exp/services/recoverysigner: call database transaction `.Rollback()` when returning an error from db_store_update

### DIFF
--- a/exp/services/recoverysigner/internal/account/db_store_add_test.go
+++ b/exp/services/recoverysigner/internal/account/db_store_add_test.go
@@ -162,7 +162,7 @@ func TestAdd_conflict(t *testing.T) {
 	assert.Equal(t, ErrAlreadyExists, err)
 }
 
-func TestAdd_conflictProperlyClosesTheConnections(t *testing.T) {
+func TestAdd_conflict_properlyClosesDBConnections(t *testing.T) {
 	db := dbtest.Open(t)
 	session := db.Open()
 	session.SetMaxIdleConns(1)

--- a/exp/services/recoverysigner/internal/account/db_store_update.go
+++ b/exp/services/recoverysigner/internal/account/db_store_update.go
@@ -53,5 +53,10 @@ func (s *DBStore) Update(a Account) error {
 		}
 	}
 
-	return tx.Commit()
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/exp/services/recoverysigner/internal/account/db_store_update.go
+++ b/exp/services/recoverysigner/internal/account/db_store_update.go
@@ -11,6 +11,7 @@ func (s *DBStore) Update(a Account) error {
 	if err != nil {
 		return err
 	}
+	defer tx.Rollback()
 
 	var accountID int64
 	// Delete an identity will delete the associated auth methods because of the ON DELETE CASCADE reference.

--- a/exp/services/recoverysigner/internal/account/db_store_update_test.go
+++ b/exp/services/recoverysigner/internal/account/db_store_update_test.go
@@ -299,7 +299,7 @@ func TestUpdate_notFound(t *testing.T) {
 	assert.Equal(t, ErrNotFound, err)
 }
 
-func TestUpdate_notFoundProperlyClosesTheConnections(t *testing.T) {
+func TestUpdate_notFound_properlyClosesDBConnections(t *testing.T) {
 	db := dbtest.Open(t)
 	session := db.Open()
 	session.SetMaxIdleConns(1)

--- a/exp/services/recoverysigner/internal/account/db_store_update_test.go
+++ b/exp/services/recoverysigner/internal/account/db_store_update_test.go
@@ -298,3 +298,23 @@ func TestUpdate_notFound(t *testing.T) {
 	err := store.Update(a)
 	assert.Equal(t, ErrNotFound, err)
 }
+
+func TestUpdate_notFoundProperlyClosesTheConnections(t *testing.T) {
+	db := dbtest.Open(t)
+	session := db.Open()
+	session.SetMaxIdleConns(1)
+	session.SetMaxOpenConns(1)
+
+	store := DBStore{
+		DB: session,
+	}
+
+	a := Account{
+		Address: "GCLLT3VG4F6EZAHZEBKWBWV5JGVPCVIKUCGTY3QEOAIZU5IJGMWCT2TT",
+	}
+
+	for range [5]int{} {
+		err := store.Update(a)
+		assert.Equal(t, ErrNotFound, err)
+	}
+}


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Call `tx.Rollback()` when returning an error from `func (s *DBStore) Update(a Account) error`.

### Why

We need to call `tx.Rollback()` in order to abort the database transaction. Without calling it, the transactions may stack up indefinitely until they reach the max limit.

### Known limitations

[N/A]
