### PR TITLE
services/horizon/internal/expingest: Fix claim claimable balances effects processor.

### DIFF
--- a/services/horizon/internal/expingest/processors/effects_processor.go
+++ b/services/horizon/internal/expingest/processors/effects_processor.go
@@ -777,7 +777,12 @@ func (e *effectsWrapper) addClaimClaimableBalanceEffects() error {
 
 		if change.Pre != nil && change.Post == nil {
 			cBalance = change.Pre.Data.MustClaimableBalance()
-			if cBalance.BalanceId == op.BalanceId {
+			preBalanceID, err := xdr.MarshalHex(cBalance.BalanceId)
+			if err != nil {
+				return fmt.Errorf("Invalid balanceId in meta changes for op: %d", e.operation.index)
+			}
+
+			if preBalanceID == balanceID {
 				found = true
 				break
 			}

--- a/services/horizon/internal/expingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/expingest/processors/effects_processor_test.go
@@ -1894,9 +1894,11 @@ type ClaimClaimableBalanceEffectsTestSuite struct {
 }
 
 func (s *ClaimClaimableBalanceEffectsTestSuite) SetupTest() {
-	var balanceIDOp1, balanceIDOp2 xdr.ClaimableBalanceId
+	var balanceIDOp1, balanceIDOp1Meta, balanceIDOp2, balanceIDOp2Meta xdr.ClaimableBalanceId
 	xdr.SafeUnmarshalBase64("AAAAANoNV9p9SFDn/BDSqdDrxzH3r7QFdMAzlbF9SRSbkfW+", &balanceIDOp1)
+	xdr.SafeUnmarshalBase64("AAAAANoNV9p9SFDn/BDSqdDrxzH3r7QFdMAzlbF9SRSbkfW+", &balanceIDOp1Meta)
 	xdr.SafeUnmarshalBase64("AAAAALHcX0PDa9UefSAzitC6vQOUr802phH8OF2ahLzg6j1D", &balanceIDOp2)
+	xdr.SafeUnmarshalBase64("AAAAALHcX0PDa9UefSAzitC6vQOUr802phH8OF2ahLzg6j1D", &balanceIDOp2Meta)
 
 	aid := xdr.MustAddress("GD5OVB6FKDV7P7SOJ5UB2BPLBL4XGSHPYHINR5355SY3RSXLT2BZWAKY")
 	claimant1 := aid.ToMuxedAccount()
@@ -1973,7 +1975,7 @@ func (s *ClaimClaimableBalanceEffectsTestSuite) SetupTest() {
 									Data: xdr.LedgerEntryData{
 										Type: xdr.LedgerEntryTypeClaimableBalance,
 										ClaimableBalance: &xdr.ClaimableBalanceEntry{
-											BalanceId: balanceIDOp1,
+											BalanceId: balanceIDOp1Meta,
 											Amount:    xdr.Int64(100000000),
 											Asset:     xdr.MustNewNativeAsset(),
 											Claimants: []xdr.Claimant{
@@ -1997,7 +1999,7 @@ func (s *ClaimClaimableBalanceEffectsTestSuite) SetupTest() {
 								Removed: &xdr.LedgerKey{
 									Type: xdr.LedgerEntryTypeClaimableBalance,
 									ClaimableBalance: &xdr.LedgerKeyClaimableBalance{
-										BalanceId: balanceIDOp1,
+										BalanceId: balanceIDOp1Meta,
 									},
 								},
 							},
@@ -2012,7 +2014,7 @@ func (s *ClaimClaimableBalanceEffectsTestSuite) SetupTest() {
 									Data: xdr.LedgerEntryData{
 										Type: xdr.LedgerEntryTypeClaimableBalance,
 										ClaimableBalance: &xdr.ClaimableBalanceEntry{
-											BalanceId: balanceIDOp2,
+											BalanceId: balanceIDOp2Meta,
 											Amount:    xdr.Int64(200000000),
 											Asset:     xdr.MustNewCreditAsset("USD", "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
 											Claimants: []xdr.Claimant{
@@ -2044,7 +2046,7 @@ func (s *ClaimClaimableBalanceEffectsTestSuite) SetupTest() {
 								Removed: &xdr.LedgerKey{
 									Type: xdr.LedgerEntryTypeClaimableBalance,
 									ClaimableBalance: &xdr.LedgerKeyClaimableBalance{
-										BalanceId: balanceIDOp2,
+										BalanceId: balanceIDOp2Meta,
 									},
 								},
 							},


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fix bug when trying to ingest claim claimable balances operations. 

### Why

We can't rely on a 1:1 comparison between claimable balances since the discriminant value might not be the same in memory.  A safer approach would be to convert to hex and then make sure they are the same value. Alternatively, we could also force the discriminant but then we'll need to change the code when a new one appears.


### Known limitations

[TODO or N/A]
