### PR TITLE
services/horizon/internal/httpx: Fix TLS configuration

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this
 file. This project adheres to [Semantic Versioning](http://semver.org/).x
 
+## v1.8.2
+
+* Fixed a bug which prevented Horizon from accepting TLS connections.
+
 ## v1.8.1
 
 * Fixed a bug in a code ingesting fee bump transactions.

--- a/services/horizon/internal/httpx/server.go
+++ b/services/horizon/internal/httpx/server.go
@@ -74,6 +74,7 @@ func NewServer(serverConfig ServerConfig, routerConfig RouterConfig) (*Server, e
 	result := &Server{
 		Router:  router,
 		Metrics: sm,
+		config:  serverConfig,
 		server: &http.Server{
 			Addr:        addr,
 			Handler:     router,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The `Server` struct was refactored in https://github.com/stellar/go/pull/2958/files so that the TLS configuration was stored in `ServerConfig`. However, the `ServerConfig` instance was never assigned in the `NewServer()` constructor. 

### Why

This bug prevents Horizon from accepting and serving TLS traffic.

### Known limitations

[N/A]
