### PR TITLE
services/horizon: Extend CreateAccounts to take initial balance.

### DIFF
--- a/services/horizon/internal/integration/protocol14_test.go
+++ b/services/horizon/internal/integration/protocol14_test.go
@@ -74,7 +74,7 @@ func TestFilteringClaimableBalances(t *testing.T) {
 		itest := test.NewIntegrationTest(t, protocol14Config)
 		defer itest.Close()
 
-		keys, _ := itest.CreateAccounts(2)
+		keys, _ := itest.CreateAccounts(2, "1000")
 		runFilteringTest(itest, keys[0], keys[1],
 			createAsset(assetType, keys[0].Address()))
 	}
@@ -102,7 +102,7 @@ func runClaimingCBsTest(t *testing.T, assetType txnbuild.AssetType, predicate *x
 	client := itest.Client()
 
 	// Create a couple of accounts to test the interactions.
-	keypairs, accounts := itest.CreateAccounts(2)
+	keypairs, accounts := itest.CreateAccounts(2, "1000")
 	sender, recipient := keypairs[0], keypairs[1]
 	sAccount, rAccount := accounts[0], accounts[1]
 

--- a/services/horizon/internal/test/integration.go
+++ b/services/horizon/internal/test/integration.go
@@ -263,21 +263,19 @@ func createTestContainer(i *IntegrationTest, image string) error {
 
 // Creates new accounts via the master account.
 //
-// It funds each account with 10000 XLM (just change the source if you want
-// more, since this hasn't needed to be configurable) then queries the API to
+// It funds each account with the given balance and then queries the API to
 // find the randomized sequence number for future operations.
 //
 // Returns: The slice of created keypairs and account objects.
 //
 // Note: panics on any errors, since we assume that tests cannot proceed without
 // this method succeeding.
-func (i *IntegrationTest) CreateAccounts(count int) ([]*keypair.Full, []txnbuild.Account) {
+func (i *IntegrationTest) CreateAccounts(count int, initialBalance string) ([]*keypair.Full, []txnbuild.Account) {
 	client := i.Client()
 	master := i.Master()
 
 	pairs := make([]*keypair.Full, count)
 	ops := make([]txnbuild.Operation, count)
-	amount := "10000"
 
 	// Two paths here: either caller already did some stuff with the master
 	// account so we should retrieve the sequence number, or caller hasn't and
@@ -302,7 +300,7 @@ func (i *IntegrationTest) CreateAccounts(count int) ([]*keypair.Full, []txnbuild
 		ops[i] = &txnbuild.CreateAccount{
 			SourceAccount: &masterAccount,
 			Destination:   pair.Address(),
-			Amount:        amount,
+			Amount:        initialBalance,
 		}
 	}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Extend ` CreateAccounts` to receive initial balance.

### Why

This would allow us to create accounts with a custom balance and test scenarios like not having enough reserve. 

### Known limitations

[TODO or N/A]
