### PR TITLE
exp/services/recoverysigner: add comment to make the tests approach clearer about closing the dbTx

### DIFF
--- a/exp/services/recoverysigner/internal/account/db_store_add_test.go
+++ b/exp/services/recoverysigner/internal/account/db_store_add_test.go
@@ -179,7 +179,11 @@ func TestAdd_conflict_properlyClosesDBConnections(t *testing.T) {
 	err := store.Add(a)
 	require.NoError(t, err)
 
-	for range [5]int{} {
+	for range [2]int{} {
+		// If the database transaction is not being properly closed when
+		// returning an error, the execution will get stuck in the following
+		// line of code when the `Add` method tries to start a new DB
+		// transaction through `s.DB.Beginx()`:
 		err = store.Add(a)
 		require.Equal(t, ErrAlreadyExists, err)
 	}

--- a/exp/services/recoverysigner/internal/account/db_store_update_test.go
+++ b/exp/services/recoverysigner/internal/account/db_store_update_test.go
@@ -313,7 +313,11 @@ func TestUpdate_notFound_properlyClosesDBConnections(t *testing.T) {
 		Address: "GCLLT3VG4F6EZAHZEBKWBWV5JGVPCVIKUCGTY3QEOAIZU5IJGMWCT2TT",
 	}
 
-	for range [5]int{} {
+	for range [2]int{} {
+		// If the database transaction is not being properly closed when
+		// returning an error, the execution will get stuck in the following
+		// line of code when the `Update` method tries to start a new DB
+		// transaction through `s.DB.Beginx()`:
 		err := store.Update(a)
 		assert.Equal(t, ErrNotFound, err)
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add comment to make the tests approach clearer about closing the database transaction.

### Why

It was pointed out in https://github.com/stellar/go/pull/3002#discussion_r488945239 that the test approach could be made clearer.

### Known limitations

[TODO or N/A]
