### PR TITLE
services/ticker: increase db test time tolerance

### DIFF
--- a/services/ticker/internal/tickerdb/tickerdb_test/queries_market_test.go
+++ b/services/ticker/internal/tickerdb/tickerdb_test/queries_market_test.go
@@ -346,8 +346,8 @@ func TestRetrievePartialMarkets(t *testing.T) {
 	assert.Equal(t, -0.9, btceth1Mkt.Change)
 	assert.Equal(t, 1.0, btceth1Mkt.High)
 	assert.Equal(t, 0.1, btceth1Mkt.Low)
-	assert.WithinDuration(t, oneHourAgo.Local(), btceth1Mkt.FirstLedgerCloseTime.Local(), 20*time.Millisecond)
-	assert.WithinDuration(t, tenMinutesAgo.Local(), btceth1Mkt.LastLedgerCloseTime.Local(), 20*time.Millisecond)
+	assert.WithinDuration(t, oneHourAgo.Local(), btceth1Mkt.FirstLedgerCloseTime.Local(), 100*time.Millisecond)
+	assert.WithinDuration(t, tenMinutesAgo.Local(), btceth1Mkt.LastLedgerCloseTime.Local(), 100*time.Millisecond)
 	assert.Equal(t, 24.0, btceth2Mkt.BaseVolume)
 	assert.Equal(t, 26.0, btceth2Mkt.CounterVolume)
 	assert.Equal(t, int32(1), btceth2Mkt.TradeCount)
@@ -356,8 +356,8 @@ func TestRetrievePartialMarkets(t *testing.T) {
 	assert.Equal(t, 0.0, btceth2Mkt.Change)
 	assert.Equal(t, 0.92, btceth2Mkt.High)
 	assert.Equal(t, 0.92, btceth2Mkt.Low)
-	assert.WithinDuration(t, now.Local(), btceth2Mkt.FirstLedgerCloseTime.Local(), 20*time.Millisecond)
-	assert.WithinDuration(t, now.Local(), btceth2Mkt.LastLedgerCloseTime.Local(), 20*time.Millisecond)
+	assert.WithinDuration(t, now.Local(), btceth2Mkt.FirstLedgerCloseTime.Local(), 100*time.Millisecond)
+	assert.WithinDuration(t, now.Local(), btceth2Mkt.LastLedgerCloseTime.Local(), 100*time.Millisecond)
 
 	// Analyzing non-aggregated orderbook data
 	assert.Equal(t, 15, btceth1Mkt.NumBids)
@@ -400,8 +400,8 @@ func TestRetrievePartialMarkets(t *testing.T) {
 	assert.Equal(t, 0.92, partialAggMkt.Close)
 	assert.Equal(t, 1.0, partialAggMkt.High)
 	assert.Equal(t, 0.1, partialAggMkt.Low)
-	assert.WithinDuration(t, oneHourAgo.Local(), partialAggMkt.FirstLedgerCloseTime.Local(), 10*time.Millisecond)
-	assert.WithinDuration(t, now.Local(), partialAggMkt.LastLedgerCloseTime.Local(), 10*time.Millisecond)
+	assert.WithinDuration(t, oneHourAgo.Local(), partialAggMkt.FirstLedgerCloseTime.Local(), 100*time.Millisecond)
+	assert.WithinDuration(t, now.Local(), partialAggMkt.LastLedgerCloseTime.Local(), 100*time.Millisecond)
 
 	// There might be some floating point rounding issues, so this test
 	// needs to be a bit more flexible. Since the change is 0.08, an error


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What

This PR substantially increases the time tolerance for database testing of `services/ticker`. 

### Why

This fixes repeated flakiness observed in continuous integration for various pull requests. We cannot control the environment in which tests are run, so extending the testing time avoids intermittent failures that trigger CI failures and slow development.

### Known limitations

N/A
