### PR TITLE
services/horizon: Add integration test for invalid claimable balance operation.

### DIFF
--- a/services/horizon/internal/integration/protocol14_claimable_balance_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_claimable_balance_ops_test.go
@@ -66,3 +66,42 @@ func TestCreateClaimableBalanceSuccessfulOperationsEffects(t *testing.T) {
 
 	tt.Equal("claimable_balance_sponsorship_created", effects[3].GetType())
 }
+
+func TestCreateClaimableBalanceInvalidOperationsEffects(t *testing.T) {
+	tt := assert.New(t)
+	itest := test.NewIntegrationTest(t, protocol14Config)
+	defer itest.Close()
+	master := itest.Master()
+
+	keys, accounts := itest.CreateAccounts(2, "50")
+	op := txnbuild.CreateClaimableBalance{
+		Destinations: []txnbuild.Claimant{
+			txnbuild.NewClaimant(master.Address(), nil),
+			txnbuild.NewClaimant(keys[1].Address(), nil),
+		},
+		Amount: "100",
+		Asset:  txnbuild.NativeAsset{},
+	}
+
+	_, err := itest.SubmitOperations(accounts[0], keys[0], &op)
+	tt.Error(err)
+
+	response, err := itest.Client().Operations(sdk.OperationRequest{
+		Order:         "desc",
+		Limit:         1,
+		IncludeFailed: true,
+	})
+	ops := response.Embedded.Records
+	tt.NoError(err)
+	tt.Len(ops, 1)
+	cb := ops[0].(operations.CreateClaimableBalance)
+	tt.False(cb.TransactionSuccessful)
+	tt.Equal("native", cb.Asset)
+	tt.Equal("100.0000000", cb.Amount)
+	tt.Equal(keys[0].Address(), cb.SourceAccount)
+	tt.Len(cb.Claimants, 2)
+
+	eResponse, err := itest.Client().Effects(sdk.EffectRequest{ForOperation: cb.ID})
+	effects := eResponse.Embedded.Records
+	tt.Len(effects, 0)
+}

--- a/services/horizon/internal/integration/protocol14_claimable_balance_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_claimable_balance_ops_test.go
@@ -83,6 +83,8 @@ func TestCreateClaimableBalanceInvalidOperationsEffects(t *testing.T) {
 		Asset:  txnbuild.NativeAsset{},
 	}
 
+	// this operation will fail because the claimable balance is trying to reserve
+	// 100 XLM but the account only has 50.
 	_, err := itest.SubmitOperations(accounts[0], keys[0], &op)
 	tt.Error(err)
 

--- a/services/horizon/internal/test/integration.go
+++ b/services/horizon/internal/test/integration.go
@@ -387,10 +387,10 @@ func (i *IntegrationTest) SubmitMultiSigOperations(
 
 	txResp, err = i.Client().SubmitTransactionXDR(txb64)
 	if err != nil {
-		i.t.Errorf("Submitting the transaction failed: %s\n", txb64)
+		i.t.Logf("Submitting the transaction failed: %s\n", txb64)
 		if prob := sdk.GetError(err); prob != nil {
-			i.t.Errorf("Problem: %s\n", prob.Problem.Detail)
-			i.t.Errorf("Extras: %s\n", prob.Problem.Extras["result_codes"])
+			i.t.Logf("Problem: %s\n", prob.Problem.Detail)
+			i.t.Logf("Extras: %s\n", prob.Problem.Extras["result_codes"])
 		}
 		return
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add a failing claimable balance and check the operation details and effects.

### Why

This help us test the scenario where a claimable balance operation fails and then:

1. Verify that the operation is ingested.
2. Check that no effects are produced.

### Known limitations


