### PR TITLE
strkey: bitshift with unsigned int for Go 1.12 compatibility

### DIFF
--- a/strkey/main.go
+++ b/strkey/main.go
@@ -203,7 +203,8 @@ func decodeString(src string) ([]byte, error) {
 	if leftoverBits > 0 {
 		lastChar := srcBytes[len(srcBytes)-1]
 		decodedLastChar := decodingTable[lastChar]
-		leftoverBitsMask := byte(0x0f) >> (4 - leftoverBits)
+		// Cast to unsigned int to be compatible with Go versions older than 1.13
+		leftoverBitsMask := byte(0x0f) >> uint64(4-leftoverBits)
 		if decodedLastChar&leftoverBitsMask != 0 {
 			return nil, errors.New("non-canonical strkey; unused bits should be set to 0")
 		}


### PR DESCRIPTION
### What

Use unsigned int bitshift to be compatible with Go 1.12.

Quote from 1.13 release:

_Per the signed shift counts proposal Go 1.13 removes the restriction that a shift count must be unsigned. This change eliminates the need for many artificial uint conversions, solely introduced to satisfy this (now removed) restriction of the << and >> operators._

### Why

Go 1.12 is the most recent version used in Google App Engine.
To be able to use Stellar SDK with App Engine, this needs to be merged.

### Note

A convenient way to test with the older Go version:

```bash
docker run --rm -ti -v "$PWD":/app -w /app golang:1.12-alpine sh -c "apk --update add git build-base && go test ./strkey"
```