### PR TITLE
services/horizon: Check more details when we test claiming a claimable balance.

### DIFF
--- a/services/horizon/internal/integration/protocol14_test.go
+++ b/services/horizon/internal/integration/protocol14_test.go
@@ -139,20 +139,16 @@ func runClaimingCBsTest(t *testing.T, assetType txnbuild.AssetType, predicate *x
 	assert.Equal(t, sender.Address(), claim.Sponsor)
 	assert.Equal(t, "42.0000000", claim.Amount)
 
-	// Claiming a balance when you aren't the recipient should fail.
+	// Claiming a balance when you aren't the recipient should fail...
 	t.Logf("Stealing balance (ID=%s)...", claim.BalanceID)
 	op2 := txnbuild.ClaimClaimableBalance{BalanceID: claim.BalanceID}
-
 	_, err = itest.SubmitOperations(aAccount, adversary, &op2)
 	assert.Error(t, err)
 	t.Log("  failed as expected")
 
+	// ...but if you are it should succeed.
 	t.Logf("Claiming balance (ID=%s)...", claim.BalanceID)
-	op3 := txnbuild.ClaimClaimableBalance{
-		BalanceID:     claim.BalanceID,
-		SourceAccount: rAccount,
-	}
-
+	op3 := txnbuild.ClaimClaimableBalance{BalanceID: claim.BalanceID}
 	_, err = itest.SubmitOperations(rAccount, recipient, &op3)
 	assert.NoError(t, err)
 	t.Log("  claimed")

--- a/services/horizon/internal/integration/protocol14_test.go
+++ b/services/horizon/internal/integration/protocol14_test.go
@@ -102,9 +102,9 @@ func runClaimingCBsTest(t *testing.T, assetType txnbuild.AssetType, predicate *x
 	client := itest.Client()
 
 	// Create a couple of accounts to test the interactions.
-	keypairs, accounts := itest.CreateAccounts(2, "1000")
-	sender, recipient := keypairs[0], keypairs[1]
-	sAccount, rAccount := accounts[0], accounts[1]
+	keypairs, accounts := itest.CreateAccounts(3, "1000")
+	sender, recipient, adversary := keypairs[0], keypairs[1], keypairs[2]
+	sAccount, rAccount, aAccount := accounts[0], accounts[1], accounts[2]
 
 	// Create an asset depending on the test parameter & trust it if need be.
 	var asset txnbuild.Asset = createAsset(assetType, sender.Address())
@@ -139,20 +139,57 @@ func runClaimingCBsTest(t *testing.T, assetType txnbuild.AssetType, predicate *x
 	assert.Equal(t, sender.Address(), claim.Sponsor)
 	assert.Equal(t, "42.0000000", claim.Amount)
 
-	t.Logf("Claiming balance (ID=%s)...", claim.BalanceID)
+	// Claiming a balance when you aren't the recipient should fail.
+	t.Logf("Stealing balance (ID=%s)...", claim.BalanceID)
+	op2 := txnbuild.ClaimClaimableBalance{BalanceID: claim.BalanceID}
 
-	op2 := txnbuild.ClaimClaimableBalance{
+	_, err = itest.SubmitOperations(aAccount, adversary, &op2)
+	assert.Error(t, err)
+	t.Log("  failed as expected")
+
+	t.Logf("Claiming balance (ID=%s)...", claim.BalanceID)
+	op3 := txnbuild.ClaimClaimableBalance{
 		BalanceID:     claim.BalanceID,
 		SourceAccount: rAccount,
 	}
-	_, err = itest.SubmitOperations(rAccount, recipient, &op2)
+
+	_, err = itest.SubmitOperations(rAccount, recipient, &op3)
 	assert.NoError(t, err)
 	t.Log("  claimed")
 
-	// Ensure the balance is gone now.
+	// Ensure the claimable balance is gone now.
 	balances, err = client.ClaimableBalances(sdk.ClaimableBalanceRequest{Sponsor: sender.Address()})
 	assert.NoError(t, err)
 	assert.Len(t, balances.Embedded.Records, 0)
+	t.Logf("  claims left: %d", len(balances.Embedded.Records))
+
+	// On success, we want the actual account to have a higher balance, too!
+	request := sdk.AccountRequest{AccountID: recipient.Address()}
+	details, err := client.AccountDetail(request)
+	assert.NoError(t, err)
+
+	// Ensure that the user's new balance includes the claimed balance, sans the
+	// transaction fee if applicable (this'll need to be updated if we change fees).
+	foundBalance := false
+	t.Logf("  balances: %+v", details.Balances)
+	for _, balance := range details.Balances {
+		if balance.Code != "" && asset.IsNative() {
+			continue
+		}
+
+		if balance.Issuer != asset.GetIssuer() || balance.Code != asset.GetCode() {
+			continue
+		}
+
+		if asset.IsNative() {
+			assert.Equal(t, "1041.9999900", balance.Balance)
+		} else {
+			assert.Equal(t, "42.0000000", balance.Balance)
+		}
+		foundBalance = true
+		break
+	}
+	assert.True(t, foundBalance)
 }
 
 func runFilteringTest(i *test.IntegrationTest, source *keypair.Full, dest *keypair.Full, asset txnbuild.Asset) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
This is a simple addition to existing tests. 
It adds checks to the "claiming a claimable balance" tests to ensure that:
  - a random account for whom a CB is not destined cannot claim the CB
  - the actual balance of an account updates after claiming a CB

### Why
The former is an important "unhappy path" check for security, and the latter is a "fuller" integration test.
