### PR TITLE
services/horizon: Improve tests for account data sponsor and claimable balance helpers.

### DIFF
--- a/services/horizon/internal/actions_data_test.go
+++ b/services/horizon/internal/actions_data_test.go
@@ -25,6 +25,12 @@ var (
 				DataValue: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 			},
 		},
+		Ext: xdr.LedgerEntryExt{
+			V: 1,
+			V1: &xdr.LedgerEntryExtensionV1{
+				SponsoringId: xdr.MustAddressPtr("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+			},
+		},
 	}
 
 	data2 = xdr.LedgerEntry{
@@ -67,7 +73,7 @@ func TestDataActions_Show(t *testing.T) {
 	ht.Assert.Equal(int64(1), rows)
 
 	prefix := "/accounts/GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"
-	var result map[string]string
+	result := map[string]string{}
 
 	// json
 	w := ht.Get(prefix + "/data/name1")
@@ -77,6 +83,7 @@ func TestDataActions_Show(t *testing.T) {
 		decoded, err := base64.StdEncoding.DecodeString(result["value"])
 		ht.Assert.NoError(err)
 		ht.Assert.Equal([]byte(data1.Data.Data.DataValue), decoded)
+		ht.Assert.Equal("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", result["sponsor"])
 	}
 
 	// raw
@@ -85,6 +92,7 @@ func TestDataActions_Show(t *testing.T) {
 		ht.Assert.Equal([]byte(data1.Data.Data.DataValue), w.Body.Bytes())
 	}
 
+	result = map[string]string{}
 	// regression: https://github.com/stellar/horizon/issues/325
 	// names with special characters do not work
 	w = ht.Get(prefix + "/data/name%20")
@@ -95,6 +103,7 @@ func TestDataActions_Show(t *testing.T) {
 		decoded, err := base64.StdEncoding.DecodeString(result["value"])
 		ht.Assert.NoError(err)
 		ht.Assert.Equal([]byte(data2.Data.Data.DataValue), decoded)
+		ht.Assert.Equal("", result["sponsor"])
 	}
 
 	w = ht.Get(prefix+"/data/name%20", test.RequestHelperRaw)

--- a/services/horizon/internal/db2/history/account_data_batch_insert_builder_test.go
+++ b/services/horizon/internal/db2/history/account_data_batch_insert_builder_test.go
@@ -1,0 +1,52 @@
+package history
+
+import (
+	"testing"
+
+	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stellar/go/xdr"
+)
+
+func TestDataBatchInsertBuilderAdd(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	accountID := xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB")
+	data := xdr.DataEntry{
+		AccountId: accountID,
+		DataName:  "foo",
+		DataValue: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+	}
+	entry := xdr.LedgerEntry{
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeData,
+			Data: &data,
+		},
+		LastModifiedLedgerSeq: 1234,
+		Ext: xdr.LedgerEntryExt{
+			V: 1,
+			V1: &xdr.LedgerEntryExtensionV1{
+				SponsoringId: xdr.MustAddressPtr("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+			},
+		},
+	}
+
+	builder := q.NewAccountDataBatchInsertBuilder(2)
+
+	err := builder.Add(entry)
+	tt.Assert.NoError(err)
+
+	err = builder.Exec()
+	tt.Assert.NoError(err)
+
+	record, err := q.GetAccountDataByName(accountID.Address(), "foo")
+	tt.Assert.NoError(err)
+
+	tt.Assert.Equal(data.DataName, xdr.String64(record.Name))
+	tt.Assert.Equal([]byte(data.DataValue), []byte(record.Value))
+	tt.Assert.Equal(accountID.Address(), record.AccountID)
+	tt.Assert.Equal(uint32(1234), record.LastModifiedLedger)
+	tt.Assert.Equal("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", record.Sponsor.String)
+}

--- a/services/horizon/internal/db2/history/account_data_test.go
+++ b/services/horizon/internal/db2/history/account_data_test.go
@@ -32,6 +32,12 @@ var (
 			},
 		},
 		LastModifiedLedgerSeq: 1234,
+		Ext: xdr.LedgerEntryExt{
+			V: 1,
+			V1: &xdr.LedgerEntryExtensionV1{
+				SponsoringId: xdr.MustAddressPtr("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+			},
+		},
 	}
 )
 
@@ -60,9 +66,11 @@ func TestInsertAccountData(t *testing.T) {
 
 	tt.Assert.Equal(data1.Data.Data.DataName, xdr.String64(datas[0].Name))
 	tt.Assert.Equal([]byte(data1.Data.Data.DataValue), []byte(datas[0].Value))
+	tt.Assert.True(datas[0].Sponsor.IsZero())
 
 	tt.Assert.Equal(data2.Data.Data.DataName, xdr.String64(datas[1].Name))
 	tt.Assert.Equal([]byte(data2.Data.Data.DataValue), []byte(datas[1].Value))
+	tt.Assert.Equal("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", datas[1].Sponsor.String)
 }
 
 func TestUpdateAccountData(t *testing.T) {

--- a/services/horizon/internal/db2/history/claimable_balances_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_test.go
@@ -305,3 +305,60 @@ func TestFindClaimableBalance(t *testing.T) {
 		tt.Assert.Equal(xdrClaimant.Predicate, hClaimant.Predicate)
 	}
 }
+func TestGetClaimableBalancesByID(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
+	lastModifiedLedgerSeq := xdr.Uint32(123)
+	asset := xdr.MustNewCreditAsset("USD", accountID)
+	balanceID := xdr.ClaimableBalanceId{
+		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
+		V0:   &xdr.Hash{1, 2, 3},
+	}
+	cBalance := xdr.ClaimableBalanceEntry{
+		BalanceId: balanceID,
+		Claimants: []xdr.Claimant{
+			{
+				Type: xdr.ClaimantTypeClaimantTypeV0,
+				V0: &xdr.ClaimantV0{
+					Destination: xdr.MustAddress(accountID),
+					Predicate: xdr.ClaimPredicate{
+						Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
+					},
+				},
+			},
+		},
+		Asset:  asset,
+		Amount: 10,
+	}
+	entry := xdr.LedgerEntry{
+		Data: xdr.LedgerEntryData{
+			Type:             xdr.LedgerEntryTypeClaimableBalance,
+			ClaimableBalance: &cBalance,
+		},
+		LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+	}
+
+	builder := q.NewClaimableBalancesBatchInsertBuilder(2)
+
+	err := builder.Add(&entry)
+	tt.Assert.NoError(err)
+
+	err = builder.Exec()
+	tt.Assert.NoError(err)
+
+	r, err := q.GetClaimableBalancesByID([]xdr.ClaimableBalanceId{cBalance.BalanceId})
+	tt.Assert.NoError(err)
+	tt.Assert.Len(r, 1)
+
+	removed, err := q.RemoveClaimableBalance(cBalance)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal(int64(1), removed)
+
+	r, err = q.GetClaimableBalancesByID([]xdr.ClaimableBalanceId{cBalance.BalanceId})
+	tt.Assert.NoError(err)
+	tt.Assert.Len(r, 0)
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add missing tests for account data ingestion helpers and claimable balances query helpers.

### Why

Bartek found some bugs here https://github.com/stellar/go/pull/2998  - this adds regression tests for his fixes.

