### PR TITLE
services/horizon: Add sponsored signer to state verifier integration test.

### DIFF
--- a/services/horizon/internal/integration/protocol14_state_verifier_test.go
+++ b/services/horizon/internal/integration/protocol14_state_verifier_test.go
@@ -23,6 +23,7 @@ func TestProtocol14StateVerifier(t *testing.T) {
 		AccountID: sponsored.Address(),
 		Sequence:  1,
 	}
+	signer := keypair.MustRandom()
 
 	// The operations below create a sponsorship sandwich, sponsoring an
 	// account, its trustlines, offers, data, and claimable balances.
@@ -34,6 +35,10 @@ func TestProtocol14StateVerifier(t *testing.T) {
 		},
 		&txnbuild.CreateAccount{
 			Destination: sponsored.Address(),
+			Amount:      "100",
+		},
+		&txnbuild.CreateAccount{
+			Destination: signer.Address(),
 			Amount:      "100",
 		},
 		&txnbuild.ChangeTrust{
@@ -59,6 +64,13 @@ func TestProtocol14StateVerifier(t *testing.T) {
 			Asset:         txnbuild.NativeAsset{},
 			Destinations: []txnbuild.Claimant{
 				txnbuild.NewClaimant(keypair.MustRandom().Address(), nil),
+			},
+		},
+		&txnbuild.SetOptions{
+			SourceAccount: sponsoredSource,
+			Signer: &txnbuild.Signer{
+				Address: signer.Address(),
+				Weight:  3,
 			},
 		},
 		&txnbuild.EndSponsoringFutureReserves{


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add a sponsored signer to the state verifier integration tests.

### Why

This help us confirm that state verification works when a signer is being sponsored.