### PR TITLE
services/horizon: Add integration tests for predicates on claimable balances. 

### DIFF
--- a/services/horizon/internal/integration/protocol14_state_verifier_test.go
+++ b/services/horizon/internal/integration/protocol14_state_verifier_test.go
@@ -83,7 +83,7 @@ func TestProtocol14StateVerifier(t *testing.T) {
 
 	// Wait for the first checkpoint ledger
 	for !itest.LedgerIngested(63) {
-		fmt.Println("63 not closed yet...")
+		t.Log("First checkpoint ledger (63) not closed yet...")
 		time.Sleep(5 * time.Second)
 	}
 
@@ -91,7 +91,7 @@ func TestProtocol14StateVerifier(t *testing.T) {
 
 	// Check metrics until state verification run
 	for i := 0; i < 60; i++ {
-		fmt.Printf("Checking metrics (%d attempt)\n", i)
+		t.Logf("Checking metrics (%d attempt)\n", i)
 		res, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", itest.AdminPort()))
 		assert.NoError(t, err)
 

--- a/services/horizon/internal/txnbuild/transaction_challenge_example_test.go
+++ b/services/horizon/internal/txnbuild/transaction_challenge_example_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/protocols/horizon"
-	"github.com/stellar/go/txnbuild"
+	"github.com/stellar/go/services/horizon/internal/txnbuild"
 )
 
 var serverAccount, _ = keypair.ParseFull("SCDXPYDGKV5HOAGVZN3FQSS5FKUPP5BAVBWH4FXKTAWAC24AE4757JSI")


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
This adds tests for predicates on claimable balances. 

It first checks the happy paths, ensuring that all predicate types can be created and that valid predicates result in actually claimable balances. 

It also checks that predicates actually matter: both an unconditionally-false predicate and an expiring timer cause the claimabe balance to be irretrievable.

### Why
Further testing of CAP-23 (see #2939) and specifically of #3000.

_(sorry about the weird commit history... should go away w/ squash & merge)_