### PR TITLE
services/horizon: Add integration test to ensure double-claiming a CB won't work.

### DIFF
--- a/services/horizon/internal/test/integration.go
+++ b/services/horizon/internal/test/integration.go
@@ -380,7 +380,8 @@ func (i *IntegrationTest) MustCreateClaimableBalance(
 		panic(-1)
 	}
 
-	claim = claims[0]
+	claim = claims[len(claims)-1] // latest one
+	i.t.Logf("Created claimable balance w/ id=%s", claim.BalanceID)
 	return
 }
 

--- a/services/horizon/internal/txnbuild/create_claimable_balance.go
+++ b/services/horizon/internal/txnbuild/create_claimable_balance.go
@@ -60,10 +60,11 @@ func OrPredicate(left xdr.ClaimPredicate, right xdr.ClaimPredicate) xdr.ClaimPre
 }
 
 // NotPredicate returns a new predicate inverting the passed in predicate
-func NotPredicate(pred *xdr.ClaimPredicate) xdr.ClaimPredicate {
+func NotPredicate(pred xdr.ClaimPredicate) xdr.ClaimPredicate {
+	innerPred := &pred // workaround to keep API the same as Or/And
 	return xdr.ClaimPredicate{
 		Type:         xdr.ClaimPredicateTypeClaimPredicateNot,
-		NotPredicate: &pred,
+		NotPredicate: &innerPred,
 	}
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Add tests to try claiming a claimable balance (CB) twice within both a separate and the same transaction. 

### Why
Double-claim would be a problem.
