### PR TITLE
protocols/horizon: fix trade aggregation paging token

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -416,7 +416,7 @@ type TradeAggregation struct {
 
 // PagingToken implementation for hal.Pageable. Not actually used
 func (res TradeAggregation) PagingToken() string {
-	return string(res.Timestamp)
+	return strconv.FormatInt(res.Timestamp, 10)
 }
 
 // Transaction represents a single, successful transaction

--- a/protocols/horizon/main_test.go
+++ b/protocols/horizon/main_test.go
@@ -233,3 +233,8 @@ func TestTransactionUnmarshalJSON(t *testing.T) {
 	assert.Equal(t, int64(2500000000), parsedFeesAsInts.MaxFee)
 	assert.Equal(t, int64(3000000000), parsedFeesAsInts.FeeCharged)
 }
+
+func TestTradeAggregation_PagingToken(t *testing.T) {
+	ta := TradeAggregation{Timestamp: 64}
+	assert.Equal(t, "64", ta.PagingToken())
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Change the paging token for trade aggregations (that isn't actually used) from being a single character that matches the unicode value of the timestamp, to being a string format of the timestamp integer.

For timestamp: `64`
Before: `"@"`
After: `"64"`

### Why
The paging token function isn't used for trade aggregations according to @tomerweller, but needed to be provided to satisfy the interface. The code there errors in Go 1.15 because Go 1.15 doesn't let you convert an integer to a string because in most cases, like the case here, it's a bug.

To compile on Go 1.15 we either need to change this to convert to a rune first to tell the compiler this is intentional, or we need to fix this to convert the integer to a string correctly. This PR does the latter.

### Known limitations

It's possible there is something dependent on this existing behavior, but I don't see it. Given the comment on the function saying it is not used (thank you @tomerweller!) I think we can assume there isn't any meaningful impact of changing this function.

FYI @stellar/horizon-committers 