### PR TITLE
services/horizon: Add more complex predicate tests.

### DIFF
--- a/services/horizon/internal/integration/protocol14_test.go
+++ b/services/horizon/internal/integration/protocol14_test.go
@@ -454,6 +454,12 @@ func TestComplexPredicates(t *testing.T) {
 			&txnbuild.ClaimClaimableBalance{BalanceID: claim2.BalanceID})
 		assert.NoError(t, err)
 		t.Log("  claimed")
+
+		// Ensure both are gone now
+		balances, err = client.ClaimableBalances(sdk.ClaimableBalanceRequest{})
+		assert.NoError(t, err)
+		assert.Len(t, balances.Embedded.Records, 0)
+		t.Log("All claimables gone.")
 	})
 
 	// In this one, we use absolute time to refine our conditions, instead. The
@@ -489,7 +495,7 @@ func TestComplexPredicates(t *testing.T) {
 			},
 		)
 
-		// Ensure it exists in the global list
+		// Ensure both exist in the global list
 		balances, err := client.ClaimableBalances(sdk.ClaimableBalanceRequest{})
 		assert.NoError(t, err)
 
@@ -528,6 +534,12 @@ func TestComplexPredicates(t *testing.T) {
 			&txnbuild.ClaimClaimableBalance{BalanceID: claim2.BalanceID})
 		assert.NoError(t, err)
 		t.Log("  success")
+
+		// Ensure both are gone now
+		balances, err = client.ClaimableBalances(sdk.ClaimableBalanceRequest{})
+		assert.NoError(t, err)
+		assert.Len(t, balances.Embedded.Records, 0)
+		t.Log("All claimables gone.")
 	})
 
 	//

--- a/services/horizon/internal/integration/protocol14_test.go
+++ b/services/horizon/internal/integration/protocol14_test.go
@@ -280,6 +280,16 @@ func TestHappyClaimableBalances(t *testing.T) {
 				txnbuild.BeforeAbsoluteTimePredicate(now+minute),
 				txnbuild.BeforeRelativeTimePredicate(minute),
 			),
+
+			// We should be able to always[^1] create & claim a balance even if
+			// there's a relative time predicate.
+			//
+			// [^1]: Almost* always is more accurate, since if it's a *really*
+			//       short timeline (see the TestComplexPredicates/Expire test)
+			//       there's not enough time to form & submit the request into a
+			//       new ledger before the previous one expires. Basically, all
+			//       bets are off for anything < $LEDGER_CLOSE_TIME.
+			"BeforeFast": txnbuild.BeforeRelativeTimePredicate(10),
 		} {
 			t.Run(description, func(t *testing.T) {
 				t.Logf("Creating claimable balance (asset=native).")
@@ -372,15 +382,162 @@ func TestComplexPredicates(t *testing.T) {
 	_, client := itest.Master(), itest.Client()
 
 	// Create a couple of accounts to test the interactions.
-	keys, accounts := itest.CreateAccounts(3, "1000")
-	a, b, _ := keys[0], keys[1], keys[2]
-	_, accountB, _ := accounts[0], accounts[1], accounts[2]
+	keys, accounts := itest.CreateAccounts(3, "10000")
+	a, b, c := keys[0], keys[1], keys[2]
+	_, accountB, accountC := accounts[0], accounts[1], accounts[2]
 
 	// reused a lot:
 	cantClaimResult, _ := codes.String(xdr.ClaimClaimableBalanceResultCodeClaimClaimableBalanceCannotClaim)
 
+	// This one can be claimed within X seconds or after Y seconds but NOT
+	// in-between; we check to make sure all conditions are upheld.
+	predicate := txnbuild.OrPredicate(
+		txnbuild.BeforeRelativeTimePredicate(30),
+		txnbuild.NotPredicate(txnbuild.BeforeRelativeTimePredicate(60)),
+	)
+
+	asset := txnbuild.NativeAsset{}
+	t.Run("BeforeOrAfter/Rel", func(t *testing.T) {
+		accountA := itest.MustGetAccount(a)
+
+		t.Log("Creating claimable balances...")
+		_ = itest.MustSubmitOperations(&accountA, a,
+			&txnbuild.CreateClaimableBalance{
+				Destinations: []txnbuild.Claimant{
+					txnbuild.NewClaimant(b.Address(), &predicate),
+				},
+				Asset:  asset,
+				Amount: "123",
+			},
+			&txnbuild.CreateClaimableBalance{
+				Destinations: []txnbuild.Claimant{
+					txnbuild.NewClaimant(c.Address(), &predicate),
+				},
+				Asset:  asset,
+				Amount: "456",
+			},
+		)
+
+		// Ensure it exists in the global list
+		balances, err := client.ClaimableBalances(sdk.ClaimableBalanceRequest{})
+		assert.NoError(t, err)
+
+		claims := balances.Embedded.Records
+		assert.Len(t, claims, 2)
+		claim1, claim2 := claims[0], claims[1]
+		t.Logf("   %s", claim1.BalanceID)
+		t.Logf("   %s", claim2.BalanceID)
+
+		// First try claiming immediately.
+		t.Logf("Claiming balance before expiration (ID=%s)...", claim1.BalanceID)
+		t.Log(time.Now().String())
+		_, err = itest.SubmitOperations(accountB, b,
+			&txnbuild.ClaimClaimableBalance{BalanceID: claim1.BalanceID})
+		assert.NoError(t, err)
+
+		// Should fail after the first predicate expires
+		time.Sleep(35 * time.Second)
+
+		t.Logf("Claiming balance during lull (ID=%s)...", claim2.BalanceID)
+		t.Logf("  %s", time.Now().String())
+		_, err = itest.SubmitOperations(accountC, c,
+			&txnbuild.ClaimClaimableBalance{BalanceID: claim2.BalanceID})
+		assert.Error(t, err)
+
+		assert.Equal(t, cantClaimResult, getOperationsError(err))
+		t.Log("  failed as expected")
+
+		// Shouldn't fail after the second predicate kicks in
+		time.Sleep(40 * time.Second)
+
+		t.Logf("Claiming balance after lull (ID=%s)...", claim2.BalanceID)
+		t.Log(time.Now().String())
+		_, err = itest.SubmitOperations(accountC, c,
+			&txnbuild.ClaimClaimableBalance{BalanceID: claim2.BalanceID})
+		assert.NoError(t, err)
+		t.Log("  success")
+	})
+
+	// In this one, we use absolute time to refine our conditions, instead. The
+	// reason why the times are still high is because the "preparation" ops
+	// themselves take time (creating CBs), so we need to pad for that.
+	twentySecFromNow := time.Now().Add(20 * time.Second)
+	thirtySecFromNow := twentySecFromNow.Add(10 * time.Second)
+	predicate = txnbuild.OrPredicate(
+		txnbuild.BeforeAbsoluteTimePredicate(twentySecFromNow.Unix()),
+		txnbuild.NotPredicate(
+			txnbuild.BeforeAbsoluteTimePredicate(thirtySecFromNow.Unix()),
+		),
+	)
+
+	t.Run("BeforeOrAfter/Abs", func(t *testing.T) {
+		accountA := itest.MustGetAccount(a)
+
+		t.Log("Creating claimable balances...")
+		_ = itest.MustSubmitOperations(&accountA, a,
+			&txnbuild.CreateClaimableBalance{
+				Destinations: []txnbuild.Claimant{
+					txnbuild.NewClaimant(b.Address(), &predicate),
+				},
+				Asset:  asset,
+				Amount: "123",
+			},
+			&txnbuild.CreateClaimableBalance{
+				Destinations: []txnbuild.Claimant{
+					txnbuild.NewClaimant(c.Address(), &predicate),
+				},
+				Asset:  asset,
+				Amount: "456",
+			},
+		)
+
+		// Ensure it exists in the global list
+		balances, err := client.ClaimableBalances(sdk.ClaimableBalanceRequest{})
+		assert.NoError(t, err)
+
+		claims := balances.Embedded.Records
+		assert.Len(t, claims, 2)
+		claim1, claim2 := claims[0], claims[1]
+		t.Logf("   %s", claim1.BalanceID)
+		t.Logf("   %s", claim2.BalanceID)
+
+		// First try claiming immediately.
+		t.Logf("Claiming balance before expiration (ID=%s)...", claim1.BalanceID)
+		t.Log(time.Now().String())
+		_, err = itest.SubmitOperations(accountB, b,
+			&txnbuild.ClaimClaimableBalance{BalanceID: claim1.BalanceID})
+		assert.NoError(t, err)
+
+		// Should fail after ~15-20s
+		time.Sleep(18 * time.Second)
+
+		t.Logf("Claiming balance during lull (ID=%s)...", claim2.BalanceID)
+		t.Log(time.Now().String())
+		_, err = itest.SubmitOperations(accountC, c,
+			&txnbuild.ClaimClaimableBalance{BalanceID: claim2.BalanceID})
+		assert.Error(t, err)
+
+		assert.Equal(t, cantClaimResult, getOperationsError(err))
+		t.Log("  failed as expected")
+
+		// Shouldn't fail after another ~10s
+		time.Sleep(9 * time.Second)
+
+		t.Logf("Claiming balance after lull (ID=%s)...", claim2.BalanceID)
+		t.Log(time.Now().String())
+		_, err = itest.SubmitOperations(accountC, c,
+			&txnbuild.ClaimClaimableBalance{BalanceID: claim2.BalanceID})
+		assert.NoError(t, err)
+		t.Log("  success")
+	})
+
+	//
+	// These two are done last because they don't clean up after themselves,
+	// making it harder to do exact length checks in a test.
+	//
+
 	// This is an easy fail.
-	predicate := txnbuild.NotPredicate(txnbuild.UnconditionalPredicate)
+	predicate = txnbuild.NotPredicate(txnbuild.UnconditionalPredicate)
 	t.Run("AlwaysFail", func(t *testing.T) {
 		t.Logf("Creating claimable balance (asset=native).")
 		t.Logf("  predicate: %+v", predicate.Type)
@@ -433,6 +590,9 @@ func TestComplexPredicates(t *testing.T) {
 		_, err = itest.SubmitOperations(accountB, b,
 			&txnbuild.ClaimClaimableBalance{BalanceID: claim.BalanceID})
 		assert.Error(t, err)
+
+		assert.Equal(t, cantClaimResult, getOperationsError(err))
+		t.Logf("  tx did fail w/ %s", cantClaimResult)
 	})
 }
 

--- a/services/horizon/internal/integration/protocol14_test.go
+++ b/services/horizon/internal/integration/protocol14_test.go
@@ -105,8 +105,6 @@ func TestHappyClaimableBalances(t *testing.T) {
 		// Ensure it shows up with the various filters (and *doesn't* show up with
 		// non-matching filters, of course).
 		//
-		// TODO: should we make these all subtests?
-		//
 		t.Log("Checking claimable balance filters")
 
 		// Ensure it exists in the global list
@@ -391,15 +389,14 @@ func TestComplexPredicates(t *testing.T) {
 
 	// This one can be claimed within X seconds or after Y seconds but NOT
 	// in-between; we check to make sure all conditions are upheld.
-	predicate := txnbuild.OrPredicate(
-		txnbuild.BeforeRelativeTimePredicate(30),
-		txnbuild.NotPredicate(txnbuild.BeforeRelativeTimePredicate(60)),
-	)
-
 	asset := txnbuild.NativeAsset{}
 	t.Run("BeforeOrAfter/Rel", func(t *testing.T) {
 		accountA := itest.MustGetAccount(a)
 
+		predicate := txnbuild.OrPredicate(
+			txnbuild.BeforeRelativeTimePredicate(30),
+			txnbuild.NotPredicate(txnbuild.BeforeRelativeTimePredicate(60)),
+		)
 		t.Log("Creating claimable balances...")
 		_ = itest.MustSubmitOperations(&accountA, a,
 			&txnbuild.CreateClaimableBalance{
@@ -430,15 +427,16 @@ func TestComplexPredicates(t *testing.T) {
 
 		// First try claiming immediately.
 		t.Logf("Claiming balance before expiration (ID=%s)...", claim1.BalanceID)
-		t.Log(time.Now().String())
+		t.Logf("  %s", time.Now().String())
 		_, err = itest.SubmitOperations(accountB, b,
 			&txnbuild.ClaimClaimableBalance{BalanceID: claim1.BalanceID})
 		assert.NoError(t, err)
+		t.Log("  claimed")
 
 		// Should fail after the first predicate expires
-		time.Sleep(35 * time.Second)
+		time.Sleep(40 * time.Second)
 
-		t.Logf("Claiming balance during lull (ID=%s)...", claim2.BalanceID)
+		t.Logf("Claiming balance DURING lull (ID=%s)...", claim2.BalanceID)
 		t.Logf("  %s", time.Now().String())
 		_, err = itest.SubmitOperations(accountC, c,
 			&txnbuild.ClaimClaimableBalance{BalanceID: claim2.BalanceID})
@@ -450,28 +448,28 @@ func TestComplexPredicates(t *testing.T) {
 		// Shouldn't fail after the second predicate kicks in
 		time.Sleep(40 * time.Second)
 
-		t.Logf("Claiming balance after lull (ID=%s)...", claim2.BalanceID)
+		t.Logf("Claiming balance AFTER lull (ID=%s)...", claim2.BalanceID)
 		t.Log(time.Now().String())
 		_, err = itest.SubmitOperations(accountC, c,
 			&txnbuild.ClaimClaimableBalance{BalanceID: claim2.BalanceID})
 		assert.NoError(t, err)
-		t.Log("  success")
+		t.Log("  claimed")
 	})
 
 	// In this one, we use absolute time to refine our conditions, instead. The
 	// reason why the times are still high is because the "preparation" ops
 	// themselves take time (creating CBs), so we need to pad for that.
-	twentySecFromNow := time.Now().Add(20 * time.Second)
-	thirtySecFromNow := twentySecFromNow.Add(10 * time.Second)
-	predicate = txnbuild.OrPredicate(
-		txnbuild.BeforeAbsoluteTimePredicate(twentySecFromNow.Unix()),
-		txnbuild.NotPredicate(
-			txnbuild.BeforeAbsoluteTimePredicate(thirtySecFromNow.Unix()),
-		),
-	)
-
 	t.Run("BeforeOrAfter/Abs", func(t *testing.T) {
 		accountA := itest.MustGetAccount(a)
+
+		twentySecFromNow := time.Now().Add(20 * time.Second)
+		thirtySecFromNow := twentySecFromNow.Add(10 * time.Second)
+		predicate := txnbuild.OrPredicate(
+			txnbuild.BeforeAbsoluteTimePredicate(twentySecFromNow.Unix()),
+			txnbuild.NotPredicate(
+				txnbuild.BeforeAbsoluteTimePredicate(thirtySecFromNow.Unix()),
+			),
+		)
 
 		t.Log("Creating claimable balances...")
 		_ = itest.MustSubmitOperations(&accountA, a,
@@ -496,7 +494,7 @@ func TestComplexPredicates(t *testing.T) {
 		assert.NoError(t, err)
 
 		claims := balances.Embedded.Records
-		assert.Len(t, claims, 2)
+		assert.Len(t, claims, 1)
 		claim1, claim2 := claims[0], claims[1]
 		t.Logf("   %s", claim1.BalanceID)
 		t.Logf("   %s", claim2.BalanceID)
@@ -507,11 +505,12 @@ func TestComplexPredicates(t *testing.T) {
 		_, err = itest.SubmitOperations(accountB, b,
 			&txnbuild.ClaimClaimableBalance{BalanceID: claim1.BalanceID})
 		assert.NoError(t, err)
+		t.Log("  claimed")
 
 		// Should fail after ~15-20s
-		time.Sleep(18 * time.Second)
+		time.Sleep(20 * time.Second)
 
-		t.Logf("Claiming balance during lull (ID=%s)...", claim2.BalanceID)
+		t.Logf("Claiming balance DURING lull (ID=%s)...", claim2.BalanceID)
 		t.Log(time.Now().String())
 		_, err = itest.SubmitOperations(accountC, c,
 			&txnbuild.ClaimClaimableBalance{BalanceID: claim2.BalanceID})
@@ -521,9 +520,9 @@ func TestComplexPredicates(t *testing.T) {
 		t.Log("  failed as expected")
 
 		// Shouldn't fail after another ~10s
-		time.Sleep(9 * time.Second)
+		time.Sleep(10 * time.Second)
 
-		t.Logf("Claiming balance after lull (ID=%s)...", claim2.BalanceID)
+		t.Logf("Claiming balance AFTER lull (ID=%s)...", claim2.BalanceID)
 		t.Log(time.Now().String())
 		_, err = itest.SubmitOperations(accountC, c,
 			&txnbuild.ClaimClaimableBalance{BalanceID: claim2.BalanceID})
@@ -537,7 +536,7 @@ func TestComplexPredicates(t *testing.T) {
 	//
 
 	// This is an easy fail.
-	predicate = txnbuild.NotPredicate(txnbuild.UnconditionalPredicate)
+	predicate := txnbuild.NotPredicate(txnbuild.UnconditionalPredicate)
 	t.Run("AlwaysFail", func(t *testing.T) {
 		t.Logf("Creating claimable balance (asset=native).")
 		t.Logf("  predicate: %+v", predicate.Type)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
This introduces two tests that validate complex predicates:
  - one uses relative time to sandwich a "can't claim" period between two "can"s
  - the other uses absolute time to the same end

### Why
Though we know simple predicates work, we haven't tested the limits of their complexity. This is a start.

### Known limitations
40% of the time, it works every time. I need to make the timing much more reliable before this can be merged; all advice is appreciated.
