### PR TITLE
services/horizon/integration: Update binary name to match new stellar:quickstart image.

### DIFF
--- a/services/horizon/internal/test/integration.go
+++ b/services/horizon/internal/test/integration.go
@@ -119,7 +119,7 @@ func NewIntegrationTest(t *testing.T, config IntegrationConfig) *IntegrationTest
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
 	hdr := &tar.Header{
-		Name: "horizon",
+		Name: "stellar-horizon",
 		Mode: 0755,
 		Size: int64(len(horizonBinaryContents)),
 	}
@@ -133,10 +133,11 @@ func NewIntegrationTest(t *testing.T, config IntegrationConfig) *IntegrationTest
 		t.Fatal(errors.Wrap(err, "error closing tar archive"))
 	}
 
-	t.Log("Copying custom horizon binary...")
+	t.Logf("Copying custom horizon binary (%d bytes)...", len(horizonBinaryContents))
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	err = i.cli.CopyToContainer(ctx, i.container.ID, "/usr/local/bin", &buf, types.CopyToContainerOptions{})
+
+	err = i.cli.CopyToContainer(ctx, i.container.ID, "/usr/bin/", &buf, types.CopyToContainerOptions{})
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "error copying custom horizon binary"))
 	}

--- a/services/horizon/internal/test/integration.go
+++ b/services/horizon/internal/test/integration.go
@@ -133,10 +133,9 @@ func NewIntegrationTest(t *testing.T, config IntegrationConfig) *IntegrationTest
 		t.Fatal(errors.Wrap(err, "error closing tar archive"))
 	}
 
-	t.Logf("Copying custom horizon binary (%d bytes)...", len(horizonBinaryContents))
+	t.Log("Copying custom horizon binary...")
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-
 	err = i.cli.CopyToContainer(ctx, i.container.ID, "/usr/bin/", &buf, types.CopyToContainerOptions{})
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "error copying custom horizon binary"))


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Your local horizon binary is now copied to `/usr/bin/stellar-horizon` for integration testing.

### Why
Changes introduced in stellar/docker-stellar-core-horizon#201 make `stellar/quickstart:testing` look for a different binary name.