### PR TITLE
Fix sponsor ingestion bug and add Sponsored preauth signer integration test

### DIFF
--- a/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
@@ -2,11 +2,13 @@ package integration
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	sdk "github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
+	protocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/protocols/horizon/effects"
 	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/services/horizon/internal/test"
@@ -178,4 +180,152 @@ func TestSimpleSandwichRevocation(t *testing.T) {
 	tt.Len(effectRecords, 1)
 	tt.IsType(effects.AccountSponsorshipRemoved{}, effectRecords[0])
 	tt.Equal(sponsorPair.Address(), effectRecords[0].(effects.AccountSponsorshipRemoved).FormerSponsor)
+}
+
+func TestSponsorPreAuthSigner(t *testing.T) {
+	tt := assert.New(t)
+	itest := test.NewIntegrationTest(t, protocol14Config)
+	defer itest.Close()
+	sponsorPair := itest.Master()
+	sponsor := func() txnbuild.Account { return itest.MasterAccount() }
+
+	// Let's create a new account
+	pairs, _ := itest.CreateAccounts(1, "1000")
+	newAccountPair := pairs[0]
+	newAccount := func() txnbuild.Account {
+		request := sdk.AccountRequest{AccountID: newAccountPair.Address()}
+		account, err := itest.Client().AccountDetail(request)
+		tt.NoError(err)
+		return &account
+	}
+
+	// Let's create a preauthorized transaction for the new account
+	// to add a signer
+	preAuthOp := &txnbuild.SetOptions{
+		Signer: &txnbuild.Signer{
+			// unspecific signer
+			Address: "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+			Weight:  1,
+		},
+	}
+	txParams := txnbuild.TransactionParams{
+		SourceAccount:        newAccount(),
+		Operations:           []txnbuild.Operation{preAuthOp},
+		BaseFee:              txnbuild.MinBaseFee,
+		Timebounds:           txnbuild.NewInfiniteTimeout(),
+		IncrementSequenceNum: true,
+	}
+	preaAuthTx, err := txnbuild.NewTransaction(txParams)
+	tt.NoError(err)
+	preAuthHash, err := preaAuthTx.Hash(test.IntegrationNetworkPassphrase)
+	tt.NoError(err)
+
+	// Let's add a sponsored preauth signer with the following transaction:
+	//
+	// BeginSponsorship N (Source=sponsor)
+	//   SetOptionsSigner preAuthHash (Source=N)
+	// EndSponsorship (Source=N)
+	ops := make([]txnbuild.Operation, 3, 3)
+	ops[0] = &txnbuild.BeginSponsoringFutureReserves{
+		SponsoredID: newAccountPair.Address(),
+	}
+	preAuthSignerKey := xdr.SignerKey{
+		Type:      xdr.SignerKeyTypeSignerKeyTypePreAuthTx,
+		PreAuthTx: (*xdr.Uint256)(&preAuthHash),
+	}
+	ops[1] = &txnbuild.SetOptions{
+		SourceAccount: newAccount(),
+		Signer: &txnbuild.Signer{
+			Address: preAuthSignerKey.Address(),
+			Weight:  1,
+		},
+	}
+	ops[2] = &txnbuild.EndSponsoringFutureReserves{
+		SourceAccount: newAccount(),
+	}
+
+	signers := []*keypair.Full{sponsorPair, newAccountPair}
+	txResp, err := itest.SubmitMultiSigOperations(sponsor(), signers, ops...)
+	tt.NoError(err)
+
+	var txResult xdr.TransactionResult
+	err = xdr.SafeUnmarshalBase64(txResp.ResultXdr, &txResult)
+	tt.NoError(err)
+	tt.Equal(xdr.TransactionResultCodeTxSuccess, txResult.Result.Code)
+
+	// Verify that the preauth signer was incorporated
+	preAuthSignerAdded := func() bool {
+		for _, signer := range newAccount().(*protocol.Account).Signers {
+			if preAuthSignerKey.Address() == signer.Key {
+				return true
+			}
+		}
+		return false
+	}
+	tt.Eventually(preAuthSignerAdded, time.Second*10, time.Millisecond*100)
+
+	// Check effects and details of the SetOptions operation
+	operationsResponse, err := itest.Client().Operations(sdk.OperationRequest{
+		ForTransaction: txResp.Hash,
+	})
+	tt.NoError(err)
+	tt.Len(operationsResponse.Embedded.Records, 3)
+	setOptionsOp := operationsResponse.Embedded.Records[1].(operations.SetOptions)
+	tt.Equal(sponsorPair.Address(), setOptionsOp.Sponsor)
+
+	effectsResponse, err := itest.Client().Effects(sdk.EffectRequest{
+		ForOperation: setOptionsOp.GetID(),
+	})
+	tt.NoError(err)
+	if tt.Len(effectsResponse.Embedded.Records, 2) {
+		signerSponsorshipEffect := effectsResponse.Embedded.Records[1].(effects.SignerSponsorshipCreated)
+		tt.Equal(sponsorPair.Address(), signerSponsorshipEffect.Sponsor)
+		tt.Equal(preAuthSignerKey.Address(), signerSponsorshipEffect.Signer)
+	}
+
+	// Submit the preauthorized transaction
+	preAuthTxB64, err := preaAuthTx.Base64()
+	tt.NoError(err)
+	txResp, err = itest.Client().SubmitTransactionXDR(preAuthTxB64)
+	tt.NoError(err)
+	err = xdr.SafeUnmarshalBase64(txResp.ResultXdr, &txResult)
+	tt.NoError(err)
+	tt.Equal(xdr.TransactionResultCodeTxSuccess, txResult.Result.Code)
+
+	// Verify that the new signer was incorporated and that the preauth signer was removed
+	preAuthSignerAdded = func() bool {
+		signers := newAccount().(*protocol.Account).Signers
+		if len(signers) != 2 {
+			return false
+		}
+		for _, signer := range signers {
+			if "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML" == signer.Key {
+				return true
+			}
+		}
+		return false
+	}
+	tt.Eventually(preAuthSignerAdded, time.Second*10, time.Millisecond*100)
+
+	// Check effects
+	// Disabled since the effects processor doesn't process transaction-level changes
+	// See https://github.com/stellar/go/pull/3050#discussion_r493651644
+	/*
+			operationsResponse, err = itest.Client().Operations(sdk.OperationRequest{
+				ForTransaction: txResp.Hash,
+			})
+			tt.Len(operationsResponse.Embedded.Records, 1)
+			setOptionsOp = operationsResponse.Embedded.Records[0].(operations.SetOptions)
+
+		    effectsResponse, err = itest.Client().Effects(sdk.EffectRequest{
+				ForTransaction: txResp.Hash,
+		    })
+			tt.NoError(err)
+			if tt.Len(effectsResponse.Embedded.Records, 2) {
+				signerSponsorshipEffect := effectsResponse.Embedded.Records[1].(effects.SignerSponsorshipRemoved)
+				tt.Equal(sponsorPair.Address(), signerSponsorshipEffect.FormerSponsor)
+				tt.Equal("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", signerSponsorshipEffect.Signer)
+			}
+	*/
+
 }


### PR DESCRIPTION
We were not obtaining the signer sponsor detail (we were only obtaining it for ledger key sponsors)