### PR TITLE
Avoid nils in signer sponsorship map

### DIFF
--- a/services/horizon/internal/expingest/processors/signers_processor.go
+++ b/services/horizon/internal/expingest/processors/signers_processor.go
@@ -111,18 +111,14 @@ func (p *SignersProcessor) Commit() error {
 			postAccountEntry := change.Post.Data.MustAccount()
 			sponsorsPerSigner := postAccountEntry.SponsorPerSigner()
 			for signer, weight := range postAccountEntry.SignerSummary() {
-				var sponsorshipDescriptor xdr.SponsorshipDescriptor
 
 				// Ignore master key
-				if signer != postAccountEntry.AccountId.Address() {
-					sponsorshipDescriptor = sponsorsPerSigner[signer]
-				}
-
 				var sponsor *string
-				if sponsorshipDescriptor != nil {
-					accountID := xdr.AccountId(*sponsorshipDescriptor)
-					a := accountID.Address()
-					sponsor = &a
+				if signer != postAccountEntry.AccountId.Address() {
+					if s, ok := sponsorsPerSigner[signer]; ok {
+						a := s.Address()
+						sponsor = &a
+					}
 				}
 
 				rowsAffected, err := p.signersQ.CreateAccountSigner(

--- a/xdr/account_entry.go
+++ b/xdr/account_entry.go
@@ -72,13 +72,15 @@ func (account *AccountEntry) SignerSponsoringIDs() []SponsorshipDescriptor {
 }
 
 // SponsorPerSigner returns a mapping of signer to its sponsor
-func (account *AccountEntry) SponsorPerSigner() map[string]SponsorshipDescriptor {
+func (account *AccountEntry) SponsorPerSigner() map[string]AccountId {
 	ids := account.SignerSponsoringIDs()
 
-	signerToSponsor := map[string]SponsorshipDescriptor{}
+	signerToSponsor := map[string]AccountId{}
 
 	for i, signerEntry := range account.Signers {
-		signerToSponsor[signerEntry.Key.Address()] = ids[i]
+		if ids[i] != nil {
+			signerToSponsor[signerEntry.Key.Address()] = *ids[i]
+		}
 	}
 
 	return signerToSponsor

--- a/xdr/account_entry_test.go
+++ b/xdr/account_entry_test.go
@@ -104,8 +104,8 @@ func TestAccountEntrySponsorships(t *testing.T) {
 	sponsored = account.NumSponsored()
 	sponsoring = account.NumSponsoring()
 	signerIDs = account.SignerSponsoringIDs()
-	expectedSponsorsForSigners := map[string]SponsorshipDescriptor{
-		signer.Address(): SponsorshipDescriptor(&sponsor),
+	expectedSponsorsForSigners := map[string]AccountId{
+		signer.Address(): sponsor,
 	}
 	assert.Equal(t, Uint32(1), sponsored)
 	assert.Equal(t, Uint32(2), sponsoring)


### PR DESCRIPTION
Having two simultaneous mechanisms to check whether a map entry is empty (whether there is no entry and whether the entry is `nil`) leads to problems like:

https://github.com/stellar/go/blob/e3e145b5ed548fb7f19102b8853a9cba7cd05ac3/services/horizon/internal/expingest/processors/effects_processor.go#L284-L286

Note how the existence in the map is checked, but not whether the entry is nil.

I am not sure that causes an actual bug, but it could certainly have.