### PR TITLE
exp/services/recoverysigner: do not set max idle db connections

### DIFF
--- a/exp/services/recoverysigner/internal/serve/serve.go
+++ b/exp/services/recoverysigner/internal/serve/serve.go
@@ -105,7 +105,6 @@ func getHandlerDeps(opts Options) (handlerDeps, error) {
 		return handlerDeps{}, errors.Wrap(err, "error parsing database url")
 	}
 	db.SetMaxOpenConns(opts.DatabaseMaxOpenConns)
-	db.SetMaxIdleConns(opts.DatabaseMaxOpenConns)
 
 	err = db.Ping()
 	if err != nil {


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Remove the setting of the max idle database connections that was added in 3ad0378.

### Why
To fix the issue that 3ad0378 was addressing we only needed to set the maximum number of total open connections. We set the max idle connections to the same value but sometimes keeping lots of idle connections open for long periods of time can cause issues if those idle connections get into a bad state. If a recoverysigner sees periods of low traffic its connections may sit idle for a long time. There's been no specific issue we've seen that is leading us to remove this, we just don't need it to be set to the same value.

We could also make the idle connections a parameter, and if anyone needs that we can add it.

If we see performance issues that require a higher max for idle connections we should address the issue then and can reintroduce it.

### Known limitations

There doesn't appear to be any tests reliant on the max number of idle connections available and therefore no tests to change.
