### PR TITLE
services/horizon: Add compressed representation of claimable balance ID as a HEX.

### DIFF
--- a/services/horizon/internal/actions/claimable_balance_test.go
+++ b/services/horizon/internal/actions/claimable_balance_test.go
@@ -61,7 +61,7 @@ func TestGetClaimableBalanceByID(t *testing.T) {
 	tt.Assert.NoError(err)
 
 	handler := GetClaimableBalanceByIDHandler{}
-	id, err := xdr.MarshalHex(cBalance.BalanceId)
+	id, err := cBalance.BalanceId.String()
 	tt.Assert.NoError(err)
 	response, err := handler.GetResource(httptest.NewRecorder(), makeRequest(
 		t,
@@ -79,7 +79,7 @@ func TestGetClaimableBalanceByID(t *testing.T) {
 		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
 		V0:   &xdr.Hash{1, 1, 1},
 	}
-	id, err = xdr.MarshalHex(balanceID)
+	id, err = balanceID.String()
 	tt.Assert.NoError(err)
 	_, err = handler.GetResource(httptest.NewRecorder(), makeRequest(
 		t,
@@ -220,7 +220,7 @@ func TestGetClaimableBalances(t *testing.T) {
 	// check response is sorted in ascending order
 	for entriesIndex, responseIndex := len(entries)-1, 0; entriesIndex >= 0; entriesIndex, responseIndex = entriesIndex-1, responseIndex+1 {
 		entry := entries[entriesIndex]
-		expectedID, _ := xdr.MarshalHex(entry.Data.ClaimableBalance.BalanceId)
+		expectedID, _ := entry.Data.ClaimableBalance.BalanceId.String()
 		tt.Assert.Equal(expectedID, response[responseIndex].(protocol.ClaimableBalance).BalanceID)
 	}
 
@@ -248,7 +248,7 @@ func TestGetClaimableBalances(t *testing.T) {
 	// response should be the last 2 elements of entries sorted by ID
 	for entriesIndex, responseIndex := len(entries)-1, 0; entriesIndex >= 2; entriesIndex, responseIndex = entriesIndex-1, responseIndex+1 {
 		entry := entries[entriesIndex]
-		expectedID, _ := xdr.MarshalHex(entry.Data.ClaimableBalance.BalanceId)
+		expectedID, _ := entry.Data.ClaimableBalance.BalanceId.String()
 		tt.Assert.Equal(expectedID, response[responseIndex].(protocol.ClaimableBalance).BalanceID)
 	}
 
@@ -268,7 +268,7 @@ func TestGetClaimableBalances(t *testing.T) {
 	// response should be the first 2 elements of entries sorted by ID
 	for entriesIndex, responseIndex := len(entries)-3, 0; entriesIndex >= 0; entriesIndex, responseIndex = entriesIndex-1, responseIndex+1 {
 		entry := entries[entriesIndex]
-		expectedID, _ := xdr.MarshalHex(entry.Data.ClaimableBalance.BalanceId)
+		expectedID, _ := entry.Data.ClaimableBalance.BalanceId.String()
 		tt.Assert.Equal(expectedID, response[responseIndex].(protocol.ClaimableBalance).BalanceID)
 	}
 
@@ -350,7 +350,7 @@ func TestGetClaimableBalances(t *testing.T) {
 
 	// response should be the first 2 elements of entries
 	for i, entry := range entries {
-		expectedID, _ := xdr.MarshalHex(entry.Data.ClaimableBalance.BalanceId)
+		expectedID, _ := entry.Data.ClaimableBalance.BalanceId.String()
 		tt.Assert.Equal(expectedID, response[i].(protocol.ClaimableBalance).BalanceID)
 	}
 
@@ -367,7 +367,7 @@ func TestGetClaimableBalances(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.Len(response, 1)
 
-	expectedID, err := xdr.MarshalHex(entryToBeUpdated.Data.ClaimableBalance.BalanceId)
+	expectedID, err := entryToBeUpdated.Data.ClaimableBalance.BalanceId.String()
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(expectedID, response[0].(protocol.ClaimableBalance).BalanceID)
 
@@ -398,11 +398,11 @@ func TestGetClaimableBalances(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.Len(response, 2)
 
-	expectedID, err = xdr.MarshalHex(entryToBeUpdated.Data.ClaimableBalance.BalanceId)
+	expectedID, err = entryToBeUpdated.Data.ClaimableBalance.BalanceId.String()
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(expectedID, response[0].(protocol.ClaimableBalance).BalanceID)
 
-	expectedID, err = xdr.MarshalHex(entries[1].Data.ClaimableBalance.BalanceId)
+	expectedID, err = entries[1].Data.ClaimableBalance.BalanceId.String()
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(expectedID, response[1].(protocol.ClaimableBalance).BalanceID)
 
@@ -420,7 +420,7 @@ func TestGetClaimableBalances(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.Len(response, 1)
 
-	expectedID, err = xdr.MarshalHex(entries[0].Data.ClaimableBalance.BalanceId)
+	expectedID, err = entries[0].Data.ClaimableBalance.BalanceId.String()
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(expectedID, response[0].(protocol.ClaimableBalance).BalanceID)
 

--- a/services/horizon/internal/expingest/processors/effects_processor.go
+++ b/services/horizon/internal/expingest/processors/effects_processor.go
@@ -373,7 +373,7 @@ func (e *effectsWrapper) addLedgerEntrySponsorshipEffects(change io.Change) erro
 	case xdr.LedgerEntryTypeClaimableBalance:
 		accountAddress = e.operation.SourceAccount().Address()
 		var err error
-		details["balance_id"], err = xdr.MarshalHex(data.MustClaimableBalance().BalanceId)
+		details["balance_id"], err = data.MustClaimableBalance().BalanceId.String()
 		if err != nil {
 			return errors.Wrapf(err, "Invalid balanceId in change from op: %d", e.operation.index)
 		}
@@ -785,7 +785,7 @@ func (e *effectsWrapper) addCreateClaimableBalanceEffects() error {
 	op := e.operation.operation.Body.MustCreateClaimableBalanceOp()
 
 	result := e.operation.OperationResult().MustCreateClaimableBalanceResult()
-	balanceID, err := xdr.MarshalHex(result.BalanceId)
+	balanceID, err := result.BalanceId.String()
 	if err != nil {
 		return errors.Wrapf(err, "Invalid balanceId in op: %d", e.operation.index)
 	}
@@ -830,7 +830,7 @@ func (e *effectsWrapper) addCreateClaimableBalanceEffects() error {
 func (e *effectsWrapper) addClaimClaimableBalanceEffects() error {
 	op := e.operation.operation.Body.MustClaimClaimableBalanceOp()
 
-	balanceID, err := xdr.MarshalHex(op.BalanceId)
+	balanceID, err := op.BalanceId.String()
 	if err != nil {
 		return fmt.Errorf("Invalid balanceId in op: %d", e.operation.index)
 	}
@@ -850,7 +850,7 @@ func (e *effectsWrapper) addClaimClaimableBalanceEffects() error {
 
 		if change.Pre != nil && change.Post == nil {
 			cBalance = change.Pre.Data.MustClaimableBalance()
-			preBalanceID, err := xdr.MarshalHex(cBalance.BalanceId)
+			preBalanceID, err := cBalance.BalanceId.String()
 			if err != nil {
 				return fmt.Errorf("Invalid balanceId in meta changes for op: %d", e.operation.index)
 			}

--- a/services/horizon/internal/expingest/processors/operations_processor.go
+++ b/services/horizon/internal/expingest/processors/operations_processor.go
@@ -386,7 +386,7 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 		details["claimants"] = claimants
 	case xdr.OperationTypeClaimClaimableBalance:
 		op := operation.operation.Body.MustClaimClaimableBalanceOp()
-		balanceID, err := xdr.MarshalHex(op.BalanceId)
+		balanceID, err := op.BalanceId.String()
 		if err != nil {
 			panic(fmt.Errorf("Invalid balanceId in op: %d", operation.index))
 		}
@@ -480,11 +480,11 @@ func addLedgerKeyDetails(result map[string]interface{}, ledgerKey xdr.LedgerKey)
 	case xdr.LedgerEntryTypeAccount:
 		result["account_id"] = ledgerKey.Account.AccountId.Address()
 	case xdr.LedgerEntryTypeClaimableBalance:
-		marshalHex, err := xdr.MarshalHex(ledgerKey.ClaimableBalance.BalanceId)
+		balanceID, err := ledgerKey.ClaimableBalance.BalanceId.String()
 		if err != nil {
 			return errors.Wrapf(err, "in claimable balance")
 		}
-		result["claimable_balance_id"] = marshalHex
+		result["claimable_balance_id"] = balanceID
 	case xdr.LedgerEntryTypeData:
 		result["data_account_id"] = ledgerKey.Data.AccountId.Address()
 		result["data_name"] = ledgerKey.Data.DataName

--- a/services/horizon/internal/integration/protocol14_claimable_balance_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_claimable_balance_ops_test.go
@@ -36,7 +36,7 @@ func TestCreateClaimableBalanceSuccessfulOperationsEffects(t *testing.T) {
 	tt.Equal(xdr.TransactionResultCodeTxSuccess, txResult.Result.Code)
 
 	opResults, _ := txResult.OperationResults()
-	expectedBalanceID, err := xdr.MarshalHex(opResults[0].MustTr().CreateClaimableBalanceResult.BalanceId)
+	expectedBalanceID, err := opResults[0].MustTr().CreateClaimableBalanceResult.BalanceId.String()
 	tt.NoError(err)
 
 	response, err := itest.Client().Operations(sdk.OperationRequest{})

--- a/services/horizon/internal/resourceadapter/claimable_balances.go
+++ b/services/horizon/internal/resourceadapter/claimable_balances.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"
-	"github.com/stellar/go/xdr"
 )
 
 // PopulateClaimableBalance fills out the resource's fields
@@ -19,7 +18,7 @@ func PopulateClaimableBalance(
 	dest *protocol.ClaimableBalance,
 	claimableBalance history.ClaimableBalance,
 ) error {
-	balanceID, err := xdr.MarshalHex(claimableBalance.BalanceID)
+	balanceID, err := claimableBalance.BalanceID.String()
 	if err != nil {
 		return errors.Wrap(err, "marshalling BalanceID")
 	}

--- a/services/horizon/internal/txnbuild/claim_claimable_balance.go
+++ b/services/horizon/internal/txnbuild/claim_claimable_balance.go
@@ -42,7 +42,7 @@ func (cb *ClaimClaimableBalance) FromXDR(xdrOp xdr.Operation) error {
 	}
 
 	cb.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
-	balanceID, err := xdr.MarshalHex(result.BalanceId)
+	balanceID, err := result.BalanceId.String()
 	if err != nil {
 		return errors.New("error parsing BalanceID in claim_claimable_balance operation from xdr")
 	}

--- a/services/horizon/internal/txnbuild/revoke_sponsorship.go
+++ b/services/horizon/internal/txnbuild/revoke_sponsorship.go
@@ -201,7 +201,7 @@ func (r *RevokeSponsorship) FromXDR(xdrOp xdr.Operation) error {
 					lkey.ClaimableBalance.BalanceId.Type,
 				)
 			}
-			claimableBalanceId, err := xdr.MarshalHex(&lkey.ClaimableBalance.BalanceId)
+			claimableBalanceId, err := &lkey.ClaimableBalance.BalanceId.String()
 			if err != nil {
 				return errors.Wrap(err, "cannot generate Claimable Balance Id")
 			}

--- a/services/horizon/internal/txnbuild/revoke_sponsorship_test.go
+++ b/services/horizon/internal/txnbuild/revoke_sponsorship_test.go
@@ -11,10 +11,10 @@ import (
 func TestRevokeSponsorship(t *testing.T) {
 	accountAddress := "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z"
 	accountAddress2 := "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU"
-	claimableBalanceId, err := xdr.MarshalHex(xdr.ClaimableBalanceId{
+	claimableBalanceId, err := xdr.ClaimableBalanceId{
 		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
 		V0:   &xdr.Hash{0xca, 0xfe, 0xba, 0xbe, 0xde, 0xad, 0xbe, 0xef},
-	})
+	}.String()
 	assert.NoError(t, err)
 	for _, testcase := range []struct {
 		name string

--- a/xdr/claimable_balance_id.go
+++ b/xdr/claimable_balance_id.go
@@ -1,5 +1,10 @@
 package xdr
 
+import (
+	"errors"
+	"fmt"
+)
+
 // MarshalBinaryCompress marshals ClaimableBalanceId to []byte but unlike
 // MarshalBinary() it removes all unnecessary bytes, exploting the fact
 // that XDR is padding data to 4 bytes in union discriminants etc.
@@ -22,4 +27,24 @@ func (cb ClaimableBalanceId) MarshalBinaryCompress() ([]byte, error) {
 	}
 
 	return m, nil
+}
+
+// String returns a display friendly version of the balanceID.
+// The first digit represents the union discriminant and the rest is the hex
+// encoded value of the union's body.
+func (cb ClaimableBalanceId) String() (string, error) {
+	var balanceID string
+	switch cb.Type {
+	case ClaimableBalanceIdTypeClaimableBalanceIdTypeV0:
+		body, err := MarshalHex(cb.V0)
+		if err != nil {
+			return "", err
+		}
+
+		balanceID = fmt.Sprintf("%x%s", int(ClaimableBalanceIdTypeClaimableBalanceIdTypeV0), body)
+	default:
+		return "", errors.New("Unknown type")
+	}
+
+	return balanceID, nil
 }

--- a/xdr/claimable_balance_id_test.go
+++ b/xdr/claimable_balance_id_test.go
@@ -1,0 +1,21 @@
+package xdr_test
+
+import (
+	"testing"
+
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClaimableBalanceIdString(t *testing.T) {
+	tt := assert.New(t)
+
+	balanceID := xdr.ClaimableBalanceId{}
+	err := xdr.SafeUnmarshalHex("00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be", &balanceID)
+	tt.NoError(err)
+	expected := "0da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be"
+
+	id, err := balanceID.String()
+	tt.NoError(err)
+	tt.Equal(expected, id)
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

[TODO: Short statement about what is changing.]

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
