### PR TITLE
services/horizon: Improve integration test framework

### DIFF
--- a/services/horizon/internal/test/integration.go
+++ b/services/horizon/internal/test/integration.go
@@ -13,13 +13,17 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
+
 	sdk "github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	proto "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/txnbuild"
 	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
 )
 
 const IntegrationNetworkPassphrase = "Standalone Network ; February 2017"
@@ -238,12 +242,23 @@ func createTestContainer(i *IntegrationTest, image string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
+	// If your Internet (or docker.io) is down, integration tests should still try to run.
 	reader, err := i.cli.ImagePull(ctx, "docker.io/"+image, types.ImagePullOptions{})
 	if err != nil {
-		t.Fatal(errors.Wrap(err, "error pulling docker image"))
+		t.Log("error pulling docker image")
+		t.Log("  trying to find local image, but you should note this")
+
+		args := filters.NewArgs()
+		args.Add("reference", "stellar/quickstart:testing")
+		list, innerErr := i.cli.ImageList(ctx, types.ImageListOptions{All: false, Filters: args})
+		if innerErr != nil || len(list) == 0 {
+			t.Fatal(errors.Wrap(err, "failed to find local image"))
+		}
+		t.Log("  using local", image)
+	} else {
+		defer reader.Close()
+		io.Copy(os.Stdout, reader)
 	}
-	defer reader.Close()
-	io.Copy(os.Stdout, reader)
 
 	t.Log("Creating container...")
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Minute)
@@ -446,16 +461,25 @@ func (i *IntegrationTest) SubmitMultiSigOperations(
 		return proto.Transaction{}, err
 	}
 
-	txResp, err := i.Client().SubmitTransactionXDR(txb64)
-	if err != nil {
-		i.t.Logf("Submitting the transaction failed: %s\n", txb64)
-		if prob := sdk.GetError(err); prob != nil {
-			i.t.Logf("Problem: %s\n", prob.Problem.Detail)
-			i.t.Logf("Extras: %s\n", prob.Problem.Extras["result_codes"])
-		}
+	return i.Client().SubmitTransactionXDR(txb64)
+}
+
+// A convenience function to provide verbose information about a failing
+// transaction to the test output log, if it's expected to succeed.
+func (i *IntegrationTest) LogFailedTx(txResponse proto.Transaction, horizonResult error) {
+	t := i.CurrentTest()
+	assert.NoErrorf(t, horizonResult, "Submitting the transaction failed")
+	if prob := sdk.GetError(horizonResult); prob != nil {
+		t.Logf("  problem: %s\n", prob.Problem.Detail)
+		t.Logf("  extras: %s\n", prob.Problem.Extras["result_codes"])
+		return
 	}
 
-	return txResp, err
+	var txResult xdr.TransactionResult
+	err := xdr.SafeUnmarshalBase64(txResponse.ResultXdr, &txResult)
+	assert.NoErrorf(t, err, "Unmarshalling transaction failed.")
+	assert.Equalf(t, xdr.TransactionResultCodeTxSuccess, txResult.Result.Code,
+		"Transaction doesn't have success code.")
 }
 
 // Cluttering code with if err != nil is absolute nonsense.

--- a/services/horizon/internal/test/integration.go
+++ b/services/horizon/internal/test/integration.go
@@ -244,11 +244,11 @@ func createTestContainer(i *IntegrationTest, image string) error {
 	reader, err := i.cli.ImagePull(ctx, "docker.io/"+image, types.ImagePullOptions{})
 	if err != nil {
 		t.Log("error pulling docker image")
-		t.Log("  trying to find local image, but you should note this")
+		t.Log("  trying to find local image (might be out-dated)")
 
 		args := filters.NewArgs()
 		args.Add("reference", "stellar/quickstart:testing")
-		list, innerErr := i.cli.ImageList(ctx, types.ImageListOptions{All: false, Filters: args})
+		list, innerErr := i.cli.ImageList(ctx, types.ImageListOptions{Filters: args})
 		if innerErr != nil || len(list) == 0 {
 			t.Fatal(errors.Wrap(err, "failed to find local image"))
 		}

--- a/services/horizon/internal/test/integration.go
+++ b/services/horizon/internal/test/integration.go
@@ -22,8 +22,6 @@ import (
 	proto "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/txnbuild"
 	"github.com/stellar/go/support/errors"
-	"github.com/stellar/go/xdr"
-	"github.com/stretchr/testify/assert"
 )
 
 const IntegrationNetworkPassphrase = "Standalone Network ; February 2017"
@@ -462,24 +460,6 @@ func (i *IntegrationTest) SubmitMultiSigOperations(
 	}
 
 	return i.Client().SubmitTransactionXDR(txb64)
-}
-
-// A convenience function to provide verbose information about a failing
-// transaction to the test output log, if it's expected to succeed.
-func (i *IntegrationTest) LogFailedTx(txResponse proto.Transaction, horizonResult error) {
-	t := i.CurrentTest()
-	assert.NoErrorf(t, horizonResult, "Submitting the transaction failed")
-	if prob := sdk.GetError(horizonResult); prob != nil {
-		t.Logf("  problem: %s\n", prob.Problem.Detail)
-		t.Logf("  extras: %s\n", prob.Problem.Extras["result_codes"])
-		return
-	}
-
-	var txResult xdr.TransactionResult
-	err := xdr.SafeUnmarshalBase64(txResponse.ResultXdr, &txResult)
-	assert.NoErrorf(t, err, "Unmarshalling transaction failed.")
-	assert.Equalf(t, xdr.TransactionResultCodeTxSuccess, txResult.Result.Code,
-		"Transaction doesn't have success code.")
 }
 
 // Cluttering code with if err != nil is absolute nonsense.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Add several integration test framework improvements:
  - add ability to run tests offline (for ex. if your Internet goes out or [docker.io](https://docker.io) dies)
  - remove noisy messages on (possibly intentionally) failing TXs (see [discussion](https://github.com/stellar/go/pull/3049#discussion_r493093534) w/ @2opremio)
  - add convenience function for printing above errors, instead

### Why
This should make the framework more flexible.

### Known limitations
n/a