### PR TITLE
services/horizon: Consolidate two tests into one so that runtime is faster.

### DIFF
--- a/services/horizon/internal/integration/protocol14_claimable_balance_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_claimable_balance_ops_test.go
@@ -13,119 +13,116 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateClaimableBalanceSuccessfulOperationsEffects(t *testing.T) {
+func TestClaimableBalanceCreationOperationsAndEffects(t *testing.T) {
 	tt := assert.New(t)
 	itest := test.NewIntegrationTest(t, protocol14Config)
 	defer itest.Close()
 	master := itest.Master()
 
-	op := txnbuild.CreateClaimableBalance{
-		Destinations: []txnbuild.Claimant{
-			txnbuild.NewClaimant(master.Address(), nil),
-		},
-		Amount: "10",
-		Asset:  txnbuild.NativeAsset{},
-	}
+	t.Run("Successful", func(t *testing.T) {
+		op := txnbuild.CreateClaimableBalance{
+			Destinations: []txnbuild.Claimant{
+				txnbuild.NewClaimant(master.Address(), nil),
+			},
+			Amount: "10",
+			Asset:  txnbuild.NativeAsset{},
+		}
 
-	txResp, err := itest.SubmitOperations(itest.MasterAccount(), master, &op)
-	tt.NoError(err)
+		txResp, err := itest.SubmitOperations(itest.MasterAccount(), master, &op)
+		tt.NoError(err)
 
-	var txResult xdr.TransactionResult
-	err = xdr.SafeUnmarshalBase64(txResp.ResultXdr, &txResult)
-	tt.NoError(err)
-	tt.Equal(xdr.TransactionResultCodeTxSuccess, txResult.Result.Code)
+		var txResult xdr.TransactionResult
+		err = xdr.SafeUnmarshalBase64(txResp.ResultXdr, &txResult)
+		tt.NoError(err)
+		tt.Equal(xdr.TransactionResultCodeTxSuccess, txResult.Result.Code)
 
-	opResults, _ := txResult.OperationResults()
-	expectedBalanceID, err := xdr.MarshalHex(opResults[0].MustTr().CreateClaimableBalanceResult.BalanceId)
-	tt.NoError(err)
+		opResults, _ := txResult.OperationResults()
+		expectedBalanceID, err := xdr.MarshalHex(opResults[0].MustTr().CreateClaimableBalanceResult.BalanceId)
+		tt.NoError(err)
 
-	response, err := itest.Client().Operations(sdk.OperationRequest{})
-	ops := response.Embedded.Records
-	tt.NoError(err)
-	tt.Len(ops, 1)
-	cb := ops[0].(operations.CreateClaimableBalance)
-	tt.Equal("native", cb.Asset)
-	tt.Equal("10.0000000", cb.Amount)
-	tt.Equal(itest.MasterAccount().GetAccountID(), cb.SourceAccount)
-	tt.Len(cb.Claimants, 1)
+		response, err := itest.Client().Operations(sdk.OperationRequest{})
+		ops := response.Embedded.Records
+		tt.NoError(err)
+		tt.Len(ops, 1)
+		cb := ops[0].(operations.CreateClaimableBalance)
+		tt.Equal("native", cb.Asset)
+		tt.Equal("10.0000000", cb.Amount)
+		tt.Equal(itest.MasterAccount().GetAccountID(), cb.SourceAccount)
+		tt.Len(cb.Claimants, 1)
 
-	claimant := cb.Claimants[0]
-	tt.Equal(itest.MasterAccount().GetAccountID(), claimant.Destination)
-	tt.Equal(xdr.ClaimPredicateTypeClaimPredicateUnconditional, claimant.Predicate.Type)
+		claimant := cb.Claimants[0]
+		tt.Equal(itest.MasterAccount().GetAccountID(), claimant.Destination)
+		tt.Equal(xdr.ClaimPredicateTypeClaimPredicateUnconditional, claimant.Predicate.Type)
 
-	eResponse, err := itest.Client().Effects(sdk.EffectRequest{ForOperation: cb.ID})
-	effects := eResponse.Embedded.Records
-	tt.Len(effects, 4)
+		eResponse, err := itest.Client().Effects(sdk.EffectRequest{ForOperation: cb.ID})
+		effects := eResponse.Embedded.Records
+		tt.Len(effects, 4)
 
-	claimableBalanceCreatedEffect := effects[0].(hEffects.ClaimableBalanceCreated)
-	tt.Equal("claimable_balance_created", claimableBalanceCreatedEffect.Type)
-	tt.Equal("10.0000000", claimableBalanceCreatedEffect.Amount)
-	tt.Equal("native", claimableBalanceCreatedEffect.Asset)
-	tt.Equal(expectedBalanceID, claimableBalanceCreatedEffect.BalanceID)
-	tt.Equal(master.Address(), claimableBalanceCreatedEffect.Account)
+		claimableBalanceCreatedEffect := effects[0].(hEffects.ClaimableBalanceCreated)
+		tt.Equal("claimable_balance_created", claimableBalanceCreatedEffect.Type)
+		tt.Equal("10.0000000", claimableBalanceCreatedEffect.Amount)
+		tt.Equal("native", claimableBalanceCreatedEffect.Asset)
+		tt.Equal(expectedBalanceID, claimableBalanceCreatedEffect.BalanceID)
+		tt.Equal(master.Address(), claimableBalanceCreatedEffect.Account)
 
-	claimableBalanceClaimantCreatedEffect := effects[1].(hEffects.ClaimableBalanceClaimantCreated)
-	tt.Equal("claimable_balance_claimant_created", claimableBalanceClaimantCreatedEffect.Type)
-	tt.Equal(master.Address(), claimableBalanceClaimantCreatedEffect.Account)
-	tt.Equal(expectedBalanceID, claimableBalanceClaimantCreatedEffect.BalanceID)
-	tt.Equal("10.0000000", claimableBalanceClaimantCreatedEffect.Amount)
-	tt.Equal("native", claimableBalanceClaimantCreatedEffect.Asset)
-	tt.Equal(
-		xdr.ClaimPredicateTypeClaimPredicateUnconditional,
-		claimableBalanceClaimantCreatedEffect.Predicate.Type,
-	)
+		claimableBalanceClaimantCreatedEffect := effects[1].(hEffects.ClaimableBalanceClaimantCreated)
+		tt.Equal("claimable_balance_claimant_created", claimableBalanceClaimantCreatedEffect.Type)
+		tt.Equal(master.Address(), claimableBalanceClaimantCreatedEffect.Account)
+		tt.Equal(expectedBalanceID, claimableBalanceClaimantCreatedEffect.BalanceID)
+		tt.Equal("10.0000000", claimableBalanceClaimantCreatedEffect.Amount)
+		tt.Equal("native", claimableBalanceClaimantCreatedEffect.Asset)
+		tt.Equal(
+			xdr.ClaimPredicateTypeClaimPredicateUnconditional,
+			claimableBalanceClaimantCreatedEffect.Predicate.Type,
+		)
 
-	accountDebitedEffect := effects[2].(hEffects.AccountDebited)
-	tt.Equal("10.0000000", accountDebitedEffect.Amount)
-	tt.Equal("native", accountDebitedEffect.Asset.Type)
-	tt.Equal(master.Address(), accountDebitedEffect.Account)
+		accountDebitedEffect := effects[2].(hEffects.AccountDebited)
+		tt.Equal("10.0000000", accountDebitedEffect.Amount)
+		tt.Equal("native", accountDebitedEffect.Asset.Type)
+		tt.Equal(master.Address(), accountDebitedEffect.Account)
 
-	claimableBalanceSponsorshipCreated := effects[3].(hEffects.ClaimableBalanceSponsorshipCreated)
-	tt.Equal("claimable_balance_sponsorship_created", claimableBalanceSponsorshipCreated.Type)
-	tt.Equal(master.Address(), claimableBalanceSponsorshipCreated.Sponsor)
-	tt.Equal(master.Address(), claimableBalanceSponsorshipCreated.Account)
-	tt.Equal(expectedBalanceID, claimableBalanceSponsorshipCreated.BalanceID)
-}
-
-func TestCreateClaimableBalanceInvalidOperationsEffects(t *testing.T) {
-	tt := assert.New(t)
-	itest := test.NewIntegrationTest(t, protocol14Config)
-	defer itest.Close()
-	master := itest.Master()
-
-	keys, accounts := itest.CreateAccounts(2, "50")
-	op := txnbuild.CreateClaimableBalance{
-		Destinations: []txnbuild.Claimant{
-			txnbuild.NewClaimant(master.Address(), nil),
-			txnbuild.NewClaimant(keys[1].Address(), nil),
-		},
-		Amount: "100",
-		Asset:  txnbuild.NativeAsset{},
-	}
-
-	// this operation will fail because the claimable balance is trying to reserve
-	// 100 XLM but the account only has 50.
-	_, err := itest.SubmitOperations(accounts[0], keys[0], &op)
-	tt.Error(err)
-
-	response, err := itest.Client().Operations(sdk.OperationRequest{
-		Order:         "desc",
-		Limit:         1,
-		IncludeFailed: true,
+		claimableBalanceSponsorshipCreated := effects[3].(hEffects.ClaimableBalanceSponsorshipCreated)
+		tt.Equal("claimable_balance_sponsorship_created", claimableBalanceSponsorshipCreated.Type)
+		tt.Equal(master.Address(), claimableBalanceSponsorshipCreated.Sponsor)
+		tt.Equal(master.Address(), claimableBalanceSponsorshipCreated.Account)
+		tt.Equal(expectedBalanceID, claimableBalanceSponsorshipCreated.BalanceID)
 	})
-	ops := response.Embedded.Records
-	tt.NoError(err)
-	tt.Len(ops, 1)
-	cb := ops[0].(operations.CreateClaimableBalance)
-	tt.False(cb.TransactionSuccessful)
-	tt.Equal("native", cb.Asset)
-	tt.Equal("100.0000000", cb.Amount)
-	tt.Equal(keys[0].Address(), cb.SourceAccount)
-	tt.Len(cb.Claimants, 2)
 
-	eResponse, err := itest.Client().Effects(sdk.EffectRequest{ForOperation: cb.ID})
-	effects := eResponse.Embedded.Records
-	tt.Len(effects, 0)
+	t.Run("Invalid", func(t *testing.T) {
+		keys, accounts := itest.CreateAccounts(2, "50")
+		op := txnbuild.CreateClaimableBalance{
+			Destinations: []txnbuild.Claimant{
+				txnbuild.NewClaimant(master.Address(), nil),
+				txnbuild.NewClaimant(keys[1].Address(), nil),
+			},
+			Amount: "100",
+			Asset:  txnbuild.NativeAsset{},
+		}
+
+		// this operation will fail because the claimable balance is trying to
+		// reserve 100 XLM but the account only has 50.
+		_, err := itest.SubmitOperations(accounts[0], keys[0], &op)
+		tt.Error(err)
+
+		response, err := itest.Client().Operations(sdk.OperationRequest{
+			Order:         "desc",
+			Limit:         1,
+			IncludeFailed: true,
+		})
+		ops := response.Embedded.Records
+		tt.NoError(err)
+		tt.Len(ops, 1)
+		cb := ops[0].(operations.CreateClaimableBalance)
+		tt.False(cb.TransactionSuccessful)
+		tt.Equal("native", cb.Asset)
+		tt.Equal("100.0000000", cb.Amount)
+		tt.Equal(keys[0].Address(), cb.SourceAccount)
+		tt.Len(cb.Claimants, 2)
+
+		eResponse, err := itest.Client().Effects(sdk.EffectRequest{ForOperation: cb.ID})
+		effects := eResponse.Embedded.Records
+		tt.Len(effects, 0)
+	})
 }
 
 func TestCreateSponsoredClaimableBalance(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Combines two similar tests into one via subtests to avoid unnecessary container startup/teardown.

**Note**: If you view the [diff with whitespace disabled](https://github.com/stellar/go/pull/3058/files?diff=unified&w=1), it should be clear that nothing changed about the tests themselves.

### Why
Any time we avoid container startup (ingestion takes a _while_), we can save ~10-15s.

### Known limitations
n/a