### PR TITLE
services/horizon: Improves test cleanup process in case of subtest panics.

### DIFF
--- a/services/horizon/internal/integration/protocol14_claimable_balance_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_claimable_balance_ops_test.go
@@ -16,7 +16,6 @@ import (
 func TestClaimableBalanceCreationOperationsAndEffects(t *testing.T) {
 	tt := assert.New(t)
 	itest := test.NewIntegrationTest(t, protocol14Config)
-	defer itest.Close()
 	master := itest.Master()
 
 	t.Run("Successful", func(t *testing.T) {

--- a/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
@@ -214,7 +214,6 @@ func TestSponsoredAccount(t *testing.T) {
 func TestSponsoredSigner(t *testing.T) {
 	tt := assert.New(t)
 	itest := test.NewIntegrationTest(t, protocol14Config)
-	defer itest.Close()
 	sponsorPair := itest.Master()
 	sponsor := itest.MasterAccount
 

--- a/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
@@ -20,7 +20,6 @@ import (
 func TestSponsoredAccount(t *testing.T) {
 	tt := assert.New(t)
 	itest := test.NewIntegrationTest(t, protocol14Config)
-	defer itest.Close()
 	sponsor := itest.MasterAccount
 	sponsorPair := itest.Master()
 
@@ -375,7 +374,6 @@ func TestSponsoredSigner(t *testing.T) {
 func TestSponsoredPreAuthSigner(t *testing.T) {
 	tt := assert.New(t)
 	itest := test.NewIntegrationTest(t, protocol14Config)
-	defer itest.Close()
 	sponsorPair := itest.Master()
 	sponsor := itest.MasterAccount
 
@@ -525,7 +523,6 @@ func TestSponsoredPreAuthSigner(t *testing.T) {
 func TestSponsoredData(t *testing.T) {
 	tt := assert.New(t)
 	itest := test.NewIntegrationTest(t, protocol14Config)
-	defer itest.Close()
 	sponsorPair := itest.Master()
 	sponsor := itest.MasterAccount
 
@@ -682,7 +679,6 @@ func TestSponsoredData(t *testing.T) {
 func TestSponsoredTrustlineAndOffer(t *testing.T) {
 	tt := assert.New(t)
 	itest := test.NewIntegrationTest(t, protocol14Config)
-	defer itest.Close()
 	sponsorPair := itest.Master()
 	sponsor := itest.MasterAccount
 
@@ -883,7 +879,6 @@ func TestSponsoredTrustlineAndOffer(t *testing.T) {
 func TestSponsoredClaimableBalance(t *testing.T) {
 	tt := assert.New(t)
 	itest := test.NewIntegrationTest(t, protocol14Config)
-	defer itest.Close()
 	sponsorPair := itest.Master()
 	sponsor := itest.MasterAccount
 

--- a/services/horizon/internal/integration/protocol14_state_verifier_test.go
+++ b/services/horizon/internal/integration/protocol14_state_verifier_test.go
@@ -16,7 +16,6 @@ import (
 
 func TestProtocol14StateVerifier(t *testing.T) {
 	itest := test.NewIntegrationTest(t, protocol14Config)
-	defer itest.Close()
 
 	sponsored := keypair.MustRandom()
 	sponsoredSource := &txnbuild.SimpleAccount{

--- a/services/horizon/internal/integration/protocol14_test.go
+++ b/services/horizon/internal/integration/protocol14_test.go
@@ -22,7 +22,6 @@ func TestProtocol14Basics(t *testing.T) {
 	tt := assert.New(t)
 
 	itest := test.NewIntegrationTest(t, protocol14Config)
-	defer itest.Close()
 	master := itest.Master()
 
 	root, err := itest.Client().Root()
@@ -44,8 +43,6 @@ func TestProtocol14Basics(t *testing.T) {
 
 func TestHappyClaimableBalances(t *testing.T) {
 	itest := test.NewIntegrationTest(t, protocol14Config)
-	defer itest.Close()
-
 	master, client := itest.Master(), itest.Client()
 
 	keys, accounts := itest.CreateAccounts(3, "1000")
@@ -238,7 +235,6 @@ func TestHappyClaimableBalances(t *testing.T) {
 // We want to ensure that users can't claim the same claimable balance twice.
 func TestDoubleClaim(t *testing.T) {
 	itest := test.NewIntegrationTest(t, protocol14Config)
-	defer itest.Close()
 	client := itest.Client()
 
 	// Create a couple of accounts to test the interactions.
@@ -299,7 +295,6 @@ func TestDoubleClaim(t *testing.T) {
 
 func TestClaimableBalancePredicates(t *testing.T) {
 	itest := test.NewIntegrationTest(t, protocol14Config)
-	defer itest.Close()
 	_, client := itest.Master(), itest.Client()
 
 	// Create a couple of accounts to test the interactions.

--- a/services/horizon/internal/test/integration.go
+++ b/services/horizon/internal/test/integration.go
@@ -235,19 +235,16 @@ func (i *IntegrationTest) Close() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	var err error
 	skipCreation := os.Getenv("HORIZON_SKIP_CREATION") != ""
 	if !skipCreation {
 		i.t.Logf("Removing container %s\n", i.container.ID)
-		err = i.cli.ContainerRemove(
+		i.cli.ContainerRemove(
 			ctx, i.container.ID,
 			types.ContainerRemoveOptions{Force: true})
 	} else {
 		i.t.Logf("Stopping container %s\n", i.container.ID)
-		err = i.cli.ContainerStop(ctx, i.container.ID, nil)
+		i.cli.ContainerStop(ctx, i.container.ID, nil)
 	}
-
-	panicIf(err)
 }
 
 func createTestContainer(i *IntegrationTest, image string) error {

--- a/services/horizon/internal/test/integration.go
+++ b/services/horizon/internal/test/integration.go
@@ -156,6 +156,7 @@ func NewIntegrationTest(t *testing.T, config IntegrationConfig) *IntegrationTest
 	doCleanup = false
 	i.hclient = &sdk.Client{HorizonURL: "http://localhost:8000"}
 	i.waitForIngestionAndUpgrade()
+	i.t.Cleanup(i.Close)
 	return i
 }
 

--- a/services/horizon/internal/test/integration.go
+++ b/services/horizon/internal/test/integration.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"testing"
 	"time"
 
@@ -155,8 +157,19 @@ func NewIntegrationTest(t *testing.T, config IntegrationConfig) *IntegrationTest
 
 	doCleanup = false
 	i.hclient = &sdk.Client{HorizonURL: "http://localhost:8000"}
-	i.waitForIngestionAndUpgrade()
+
+	// Register cleanup handlers (on panic and ctrl+c) so the container is
+	// removed even if ingestion or testing fails.
 	i.t.Cleanup(i.Close)
+	c := make(chan os.Signal)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-c
+		i.Close()
+		os.Exit(0)
+	}()
+
+	i.waitForIngestionAndUpgrade()
 	return i
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Uses `testing.T.Cleanup` to shut down the container rather than `defer`. 

Shoutout to @leighmcculloch for the pro-tip :1st_place_medal:! 

### Why
If a sub-test panics, the outer `defer itest.Close()` will not execute, leaving behind a `horizon-integration` container that will fail subsequent runs. By registering the cleanup function correctly, we can avoid this issue. :tada:

### Known limitations
We'll need to merge `master` into `protocol-14` to drop all of the Go 1.13 tests prior to merging this, since `T.Cleanup()` was only [introduced](https://www.gopherguides.com/articles/test-cleanup-in-go-1-14/) in 1.14.