### PR TITLE
support/http: add ReadTimeout, WriteTimeout, IdleTimeout configs

### DIFF
--- a/support/http/main.go
+++ b/support/http/main.go
@@ -22,19 +22,17 @@ import (
 // on a `Config` struct.
 const defaultListenAddr = "0.0.0.0:8080"
 
-const (
-	// defaultShutdownGracePeriod represents the default time in which the running
-	// process will allow outstanding http requests to complete before aborting
-	// them.  It will be used when a grace period of 0 is used, which normally
-	// signifies "no timeout" to our graceful shutdown package.  We choose not to
-	// provide a "no timeout" mode at present.  Feel free to set the value to a year
-	// or something if you need a timeout that is effectively "no timeout"; We
-	// believe that most servers should use a sane timeout and prefer one for the
-	// default configuration.
-	defaultShutdownGracePeriod = 10 * time.Second
+// defaultShutdownGracePeriod represents the default time in which the running
+// process will allow outstanding http requests to complete before aborting
+// them.  It will be used when a grace period of 0 is used, which normally
+// signifies "no timeout" to our graceful shutdown package.  We choose not to
+// provide a "no timeout" mode at present.  Feel free to set the value to a year
+// or something if you need a timeout that is effectively "no timeout"; We
+// believe that most servers should use a sane timeout and prefer one for the
+// default configuration.
+const defaultShutdownGracePeriod = 10 * time.Second
 
-	defaultReadTimeout = 5 * time.Second
-)
+const defaultReadTimeout = 5 * time.Second
 
 // SimpleHTTPClientInterface helps mocking http.Client in tests
 type SimpleHTTPClientInterface interface {
@@ -99,11 +97,11 @@ func setup(conf Config) *graceful.Server {
 		conf.ListenAddr = defaultListenAddr
 	}
 
-	if conf.ShutdownGracePeriod == 0 {
+	if conf.ShutdownGracePeriod == time.Duration(0) {
 		conf.ShutdownGracePeriod = defaultShutdownGracePeriod
 	}
 
-	if conf.ReadTimeout == 0 {
+	if conf.ReadTimeout == time.Duration(0) {
 		conf.ReadTimeout = defaultReadTimeout
 	}
 

--- a/support/http/main.go
+++ b/support/http/main.go
@@ -17,20 +17,24 @@ import (
 	"gopkg.in/tylerb/graceful.v1"
 )
 
-// DefaultListenAddr represents the default address and port on which a server
+// defaultListenAddr represents the default address and port on which a server
 // will listen, provided it is not overridden by setting the `ListenAddr` field
 // on a `Config` struct.
-const DefaultListenAddr = "0.0.0.0:8080"
+const defaultListenAddr = "0.0.0.0:8080"
 
-// DefaultShutdownGracePeriod represents the default time in which the running
-// process will allow outstanding http requests to complete before aborting
-// them.  It will be used when a grace period of 0 is used, which normally
-// signifies "no timeout" to our graceful shutdown package.  We choose not to
-// provide a "no timeout" mode at present.  Feel free to set the value to a year
-// or something if you need a timeout that is effectively "no timeout"; We
-// believe that most servers should use a sane timeout and prefer one for the
-// default configuration.
-const DefaultShutdownGracePeriod = 10 * time.Second
+const (
+	// defaultShutdownGracePeriod represents the default time in which the running
+	// process will allow outstanding http requests to complete before aborting
+	// them.  It will be used when a grace period of 0 is used, which normally
+	// signifies "no timeout" to our graceful shutdown package.  We choose not to
+	// provide a "no timeout" mode at present.  Feel free to set the value to a year
+	// or something if you need a timeout that is effectively "no timeout"; We
+	// believe that most servers should use a sane timeout and prefer one for the
+	// default configuration.
+	defaultShutdownGracePeriod = 10 * time.Second
+
+	defaultReadTimeout = 5 * time.Second
+)
 
 // SimpleHTTPClientInterface helps mocking http.Client in tests
 type SimpleHTTPClientInterface interface {
@@ -45,6 +49,9 @@ type Config struct {
 	ListenAddr          string
 	TLS                 *config.TLS
 	ShutdownGracePeriod time.Duration
+	ReadTimeout         time.Duration
+	WriteTimeout        time.Duration
+	IdleTimeout         time.Duration
 	OnStarting          func()
 	OnStopping          func()
 	OnStopped           func()
@@ -89,21 +96,26 @@ func setup(conf Config) *graceful.Server {
 	}
 
 	if conf.ListenAddr == "" {
-		conf.ListenAddr = DefaultListenAddr
+		conf.ListenAddr = defaultListenAddr
 	}
 
-	timeout := DefaultShutdownGracePeriod
-	if conf.ShutdownGracePeriod != 0 {
-		timeout = conf.ShutdownGracePeriod
+	if conf.ShutdownGracePeriod == 0 {
+		conf.ShutdownGracePeriod = defaultShutdownGracePeriod
+	}
+
+	if conf.ReadTimeout == 0 {
+		conf.ReadTimeout = defaultReadTimeout
 	}
 
 	return &graceful.Server{
-		Timeout: timeout,
+		Timeout: conf.ShutdownGracePeriod,
 
 		Server: &stdhttp.Server{
-			Addr:        conf.ListenAddr,
-			Handler:     conf.Handler,
-			ReadTimeout: 5 * time.Second,
+			Addr:         conf.ListenAddr,
+			Handler:      conf.Handler,
+			ReadTimeout:  conf.ReadTimeout,
+			WriteTimeout: conf.WriteTimeout,
+			IdleTimeout:  conf.IdleTimeout,
 		},
 
 		ShutdownInitiated: func() {

--- a/support/http/main_test.go
+++ b/support/http/main_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	stdhttp "net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -23,5 +24,7 @@ func TestRun_setup(t *testing.T) {
 
 	assert.Equal(t, defaultShutdownGracePeriod, srv.Timeout)
 	assert.Equal(t, defaultReadTimeout, srv.ReadTimeout)
+	assert.Equal(t, time.Duration(0), srv.WriteTimeout)
+	assert.Equal(t, time.Duration(0), srv.IdleTimeout)
 	assert.Equal(t, defaultListenAddr, srv.Server.Addr)
 }

--- a/support/http/main_test.go
+++ b/support/http/main_test.go
@@ -21,6 +21,7 @@ func TestRun_setup(t *testing.T) {
 		Handler: stdhttp.NotFoundHandler(),
 	})
 
-	assert.Equal(t, DefaultShutdownGracePeriod, srv.Timeout)
-	assert.Equal(t, DefaultListenAddr, srv.Server.Addr)
+	assert.Equal(t, defaultShutdownGracePeriod, srv.Timeout)
+	assert.Equal(t, defaultReadTimeout, srv.ReadTimeout)
+	assert.Equal(t, defaultListenAddr, srv.Server.Addr)
 }


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR adds the ability to configure ReadTimeout, WriteTimout, IdleTimeout on the http server.

### Why

We want to apply timeout to have a better control over our resources. A default http server comes with zero timeout. It's good that we have been setting the default `ReadTimeout` to 5 seconds. However, there was no way for the client of this package to set it to a different duration. And we are not currently setting `WriteTimeout` and `IdleTimeout`. 

### Known limitations

N/A
