### PR TITLE
xdr: Return RelBefore as a String instead of Number when representing in JSON.

### DIFF
--- a/services/horizon/internal/resourceadapter/operations_test.go
+++ b/services/horizon/internal/resourceadapter/operations_test.go
@@ -143,7 +143,7 @@ func TestPopulateOperation_CreateClaimableBalance(t *testing.T) {
 					"and": [
 						{
 							"or": [
-								{"relBefore":12},
+								{"relBefore":"12"},
 								{"absBefore": "2020-08-26T11:15:39Z"}
 							]
 						},

--- a/xdr/json.go
+++ b/xdr/json.go
@@ -12,7 +12,7 @@ type claimPredicateJSON struct {
 	Not           *claimPredicateJSON   `json:"not,omitempty"`
 	Unconditional bool                  `json:"unconditional,omitempty"`
 	AbsBefore     *time.Time            `json:"absBefore,omitempty"`
-	RelBefore     *int64                `json:"relBefore,omitempty"`
+	RelBefore     *int64                `json:"relBefore,string,omitempty"`
 }
 
 func convertPredicatesToXDR(input []claimPredicateJSON) ([]ClaimPredicate, error) {

--- a/xdr/json_test.go
+++ b/xdr/json_test.go
@@ -41,7 +41,7 @@ func TestClaimPredicateJSON(t *testing.T) {
 	assert.NoError(t, err)
 	assert.JSONEq(
 		t,
-		`{"and":[{"or":[{"relBefore":12},{"absBefore":"2020-08-26T11:15:39Z"}]},{"not":{"unconditional":true}}]}`,
+		`{"and":[{"or":[{"relBefore":"12"},{"absBefore":"2020-08-26T11:15:39Z"}]},{"not":{"unconditional":true}}]}`,
 		string(serialized),
 	)
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Marshal int64 value in JSON Predicate as a string instead of a number.

### Why

Since this can be an `int64`, it can cause an overflow when reading it in JavaScript.

### Known limitations

[TODO or N/A]
