### PR TITLE
protocols/horizon: Add last_modfied_time to claimable balance response

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -666,6 +666,7 @@ type ClaimableBalance struct {
 	Amount             string     `json:"amount"`
 	Sponsor            string     `json:"sponsor,omitempty"`
 	LastModifiedLedger uint32     `json:"last_modified_ledger"`
+	LastModifiedTime   *time.Time `json:"last_modified_time"`
 	Claimants          []Claimant `json:"claimants"`
 	PT                 string     `json:"paging_token"`
 }

--- a/services/horizon/internal/actions/claimable_balance.go
+++ b/services/horizon/internal/actions/claimable_balance.go
@@ -75,7 +75,7 @@ func (handler GetClaimableBalanceByIDHandler) GetResource(w HeaderWriter, r *htt
 	if historyQ.NoRows(err) {
 		ledger = nil
 	} else if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "LedgerBySequence error")
 	}
 
 	var resource protocol.ClaimableBalance

--- a/services/horizon/internal/actions/claimable_balance.go
+++ b/services/horizon/internal/actions/claimable_balance.go
@@ -11,6 +11,7 @@ import (
 	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"
 	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/xdr"
@@ -66,9 +67,19 @@ func (handler GetClaimableBalanceByIDHandler) GetResource(w HeaderWriter, r *htt
 	if err != nil {
 		return nil, err
 	}
+	ledger := &history.Ledger{}
+	err = historyQ.LedgerBySequence(
+		ledger,
+		int32(cb.LastModifiedLedger),
+	)
+	if historyQ.NoRows(err) {
+		ledger = nil
+	} else if err != nil {
+		return nil, err
+	}
 
 	var resource protocol.ClaimableBalance
-	err = resourceadapter.PopulateClaimableBalance(ctx, &resource, cb)
+	err = resourceadapter.PopulateClaimableBalance(ctx, &resource, cb, ledger)
 	if err != nil {
 		return nil, err
 	}
@@ -163,11 +174,24 @@ func getClaimableBalancesPage(ctx context.Context, historyQ *history.Q, query hi
 		return nil, err
 	}
 
+	ledgerCache := history.LedgerCache{}
+	for _, record := range records {
+		ledgerCache.Queue(int32(record.LastModifiedLedger))
+	}
+	if err := ledgerCache.Load(historyQ); err != nil {
+		return nil, errors.Wrap(err, "failed to load ledger batch")
+	}
+
 	var claimableBalances []hal.Pageable
 	for _, record := range records {
 		var response horizon.ClaimableBalance
 
-		resourceadapter.PopulateClaimableBalance(ctx, &response, record)
+		var ledger *history.Ledger
+		if l, ok := ledgerCache.Records[int32(record.LastModifiedLedger)]; ok {
+			ledger = &l
+		}
+
+		resourceadapter.PopulateClaimableBalance(ctx, &response, record, ledger)
 		claimableBalances = append(claimableBalances, response)
 	}
 

--- a/services/horizon/internal/resourceadapter/claimable_balances.go
+++ b/services/horizon/internal/resourceadapter/claimable_balances.go
@@ -18,6 +18,7 @@ func PopulateClaimableBalance(
 	ctx context.Context,
 	dest *protocol.ClaimableBalance,
 	claimableBalance history.ClaimableBalance,
+	ledger *history.Ledger,
 ) error {
 	balanceID, err := xdr.MarshalHex(claimableBalance.BalanceID)
 	if err != nil {
@@ -34,6 +35,10 @@ func PopulateClaimableBalance(
 	for i, c := range claimableBalance.Claimants {
 		dest.Claimants[i].Destination = c.Destination
 		dest.Claimants[i].Predicate = c.Predicate
+	}
+
+	if ledger != nil {
+		dest.LastModifiedTime = &ledger.ClosedAt
 	}
 
 	lb := hal.LinkBuilder{Base: horizonContext.BaseURL(ctx)}

--- a/services/horizon/internal/resourceadapter/claimable_balances_test.go
+++ b/services/horizon/internal/resourceadapter/claimable_balances_test.go
@@ -37,7 +37,7 @@ func TestPopulateClaimableBalance(t *testing.T) {
 		LastModifiedLedger: 123,
 	}
 
-	err := PopulateClaimableBalance(ctx, &resource, claimableBalance)
+	err := PopulateClaimableBalance(ctx, &resource, claimableBalance, nil)
 	tt.NoError(err)
 
 	tt.Equal("000000000102030000000000000000000000000000000000000000000000000000000000", resource.BalanceID)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add `last_modfied_time` to claimable balance response.

### Why

Whenever horizon includes a `last_modified_sequence` we should also have a corresponding `last_modfied_time` field in the response. API consumers should not need to send another request to convert a ledger sequence to a date.

### Known limitations

[N/A]
