### PR TITLE
services/horizon: Add sponsored trustline/offer integration test and expand data test

### DIFF
--- a/services/horizon/internal/integration/protocol14_claimable_balance_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_claimable_balance_ops_test.go
@@ -3,14 +3,14 @@ package integration
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	sdk "github.com/stellar/go/clients/horizonclient"
-	"github.com/stellar/go/keypair"
 	hEffects "github.com/stellar/go/protocols/horizon/effects"
 	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestClaimableBalanceCreationOperationsAndEffects(t *testing.T) {
@@ -123,46 +123,4 @@ func TestClaimableBalanceCreationOperationsAndEffects(t *testing.T) {
 		effects := eResponse.Embedded.Records
 		tt.Len(effects, 0)
 	})
-}
-
-func TestCreateSponsoredClaimableBalance(t *testing.T) {
-	tt := assert.New(t)
-	itest := test.NewIntegrationTest(t, protocol14Config)
-	defer itest.Close()
-	master := itest.Master()
-
-	keys, accounts := itest.CreateAccounts(1, "50")
-	ops := []txnbuild.Operation{
-		&txnbuild.BeginSponsoringFutureReserves{
-			SourceAccount: &txnbuild.SimpleAccount{
-				AccountID: master.Address(),
-			},
-			SponsoredID: keys[0].Address(),
-		},
-		&txnbuild.CreateClaimableBalance{
-			SourceAccount: accounts[0],
-			Destinations: []txnbuild.Claimant{
-				txnbuild.NewClaimant(master.Address(), nil),
-			},
-			Amount: "20",
-			Asset:  txnbuild.NativeAsset{},
-		},
-		&txnbuild.EndSponsoringFutureReserves{},
-	}
-
-	txResp, err := itest.SubmitMultiSigOperations(accounts[0], []*keypair.Full{keys[0], master}, ops...)
-	tt.NoError(err)
-
-	var txResult xdr.TransactionResult
-	err = xdr.SafeUnmarshalBase64(txResp.ResultXdr, &txResult)
-	tt.NoError(err)
-	tt.Equal(xdr.TransactionResultCodeTxSuccess, txResult.Result.Code)
-
-	balances, err := itest.Client().ClaimableBalances(sdk.ClaimableBalanceRequest{})
-	tt.NoError(err)
-
-	claims := balances.Embedded.Records
-	tt.Len(claims, 1)
-	balance := claims[0]
-	tt.Equal(master.Address(), balance.Sponsor)
 }

--- a/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
@@ -516,7 +516,7 @@ func TestSponsoredTrustlineAndOffer(t *testing.T) {
 	}
 	revoke2 := txnbuild.RevokeSponsorship{
 		SponsorshipType: txnbuild.RevokeSponsorshipTypeTrustLine,
-		TrustLine: &txnbuild.TrustLineId{
+		TrustLine: &txnbuild.TrustLineID{
 			Account: newAccountPair.Address(),
 			Asset: txnbuild.CreditAsset{
 				Code:   "ABCD",

--- a/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
@@ -395,11 +395,7 @@ func TestSponsoredData(t *testing.T) {
 			DataName: "SponsoredData",
 		},
 	}
-	txResp, err = itest.SubmitOperations(itest.MasterAccount(), itest.Master(), &revoke)
-	tt.NoError(err)
-	err = xdr.SafeUnmarshalBase64(txResp.ResultXdr, &txResult)
-	tt.NoError(err)
-	tt.Equal(xdr.TransactionResultCodeTxSuccess, txResult.Result.Code)
+	itest.MustSubmitOperations(itest.MasterAccount(), itest.Master(), &revoke)
 
 	effectRecords, err := itest.Client().Effects(sdk.EffectRequest{
 		ForTransaction: txResp.ID,

--- a/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
@@ -395,10 +395,10 @@ func TestSponsoredData(t *testing.T) {
 			DataName: "SponsoredData",
 		},
 	}
-	itest.MustSubmitOperations(itest.MasterAccount(), itest.Master(), &revoke)
+	tx := itest.MustSubmitOperations(itest.MasterAccount(), itest.Master(), &revoke)
 
 	effectRecords, err := itest.Client().Effects(sdk.EffectRequest{
-		ForTransaction: txResp.ID,
+		ForTransaction: tx.ID,
 	})
 	tt.NoError(err)
 	tt.Len(effectRecords.Embedded.Records, 1)
@@ -524,10 +524,10 @@ func TestSponsoredTrustlineAndOffer(t *testing.T) {
 			},
 		},
 	}
-	itest.MustSubmitOperations(itest.MasterAccount(), itest.Master(), &revoke1, &revoke2)
+	tx := itest.MustSubmitOperations(itest.MasterAccount(), itest.Master(), &revoke1, &revoke2)
 
 	effectRecords, err := itest.Client().Effects(sdk.EffectRequest{
-		ForTransaction: txResp.ID,
+		ForTransaction: tx.ID,
 	})
 	tt.NoError(err)
 	tt.Len(effectRecords.Embedded.Records, 1)

--- a/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
@@ -17,7 +17,13 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-func getSimpleAccountCreationSandwich(tt *assert.Assertions) (*keypair.Full, []txnbuild.Operation) {
+func TestSponsoredAccount(t *testing.T) {
+	tt := assert.New(t)
+	itest := test.NewIntegrationTest(t, protocol14Config)
+	defer itest.Close()
+	sponsor := itest.MasterAccount()
+	sponsorPair := itest.Master()
+
 	// We will create the following operation structure:
 	// BeginSponsoringFutureReserves A
 	//   CreateAccount A
@@ -39,16 +45,6 @@ func getSimpleAccountCreationSandwich(tt *assert.Assertions) (*keypair.Full, []t
 			AccountID: newAccountPair.Address(),
 		},
 	}
-	return newAccountPair, ops
-}
-
-func TestSimpleSandwichHappyPath(t *testing.T) {
-	tt := assert.New(t)
-	itest := test.NewIntegrationTest(t, protocol14Config)
-	defer itest.Close()
-	sponsor := itest.MasterAccount()
-	sponsorPair := itest.Master()
-	newAccountPair, ops := getSimpleAccountCreationSandwich(tt)
 
 	signers := []*keypair.Full{sponsorPair, newAccountPair}
 	txResp, err := itest.SubmitMultiSigOperations(sponsor, signers, ops...)
@@ -114,24 +110,6 @@ func TestSimpleSandwichHappyPath(t *testing.T) {
 	tt.Len(effectRecords, 4)
 	tt.IsType(effects.AccountSponsorshipCreated{}, effectRecords[3])
 	tt.Equal(sponsorPair.Address(), effectRecords[3].(effects.AccountSponsorshipCreated).Sponsor)
-}
-
-func TestSimpleSandwichRevocation(t *testing.T) {
-	tt := assert.New(t)
-	itest := test.NewIntegrationTest(t, protocol14Config)
-	defer itest.Close()
-	sponsor := itest.MasterAccount()
-	sponsorPair := itest.Master()
-	newAccountPair, ops := getSimpleAccountCreationSandwich(tt)
-
-	signers := []*keypair.Full{sponsorPair, newAccountPair}
-	txResp, err := itest.SubmitMultiSigOperations(sponsor, signers, ops...)
-	tt.NoError(err)
-
-	var txResult xdr.TransactionResult
-	err = xdr.SafeUnmarshalBase64(txResp.ResultXdr, &txResult)
-	tt.NoError(err)
-	tt.Equal(xdr.TransactionResultCodeTxSuccess, txResult.Result.Code)
 
 	// Submit sponsorship revocation in a separate transaction
 	accountToRevoke := newAccountPair.Address()
@@ -147,10 +125,10 @@ func TestSimpleSandwichRevocation(t *testing.T) {
 	tt.Equal(xdr.TransactionResultCodeTxSuccess, txResult.Result.Code)
 
 	// Verify operation details
-	response, err := itest.Client().Operations(sdk.OperationRequest{
+	response, err = itest.Client().Operations(sdk.OperationRequest{
 		ForTransaction: txResp.Hash,
 	})
-	opRecords := response.Embedded.Records
+	opRecords = response.Embedded.Records
 	tt.NoError(err)
 	tt.Len(opRecords, 1)
 	tt.True(opRecords[0].IsTransactionSuccessful())
@@ -175,9 +153,9 @@ func TestSimpleSandwichRevocation(t *testing.T) {
 	tt.Condition(sponsorshipRevocationPresent)
 
 	// Check effects
-	eResponse, err := itest.Client().Effects(sdk.EffectRequest{ForOperation: revokeOp.ID})
+	eResponse, err = itest.Client().Effects(sdk.EffectRequest{ForOperation: revokeOp.ID})
 	tt.NoError(err)
-	effectRecords := eResponse.Embedded.Records
+	effectRecords = eResponse.Embedded.Records
 	tt.Len(effectRecords, 1)
 	tt.IsType(effects.AccountSponsorshipRemoved{}, effectRecords[0])
 	tt.Equal(sponsorPair.Address(), effectRecords[0].(effects.AccountSponsorshipRemoved).FormerSponsor)
@@ -331,7 +309,7 @@ func TestSponsorPreAuthSigner(t *testing.T) {
 
 }
 
-func TestSponsorData(t *testing.T) {
+func TestSponsoredData(t *testing.T) {
 	tt := assert.New(t)
 	itest := test.NewIntegrationTest(t, protocol14Config)
 	defer itest.Close()
@@ -408,5 +386,201 @@ func TestSponsorData(t *testing.T) {
 		tt.Equal(newAccountPair.Address(), dataSponsorshipEffect.Account)
 		tt.Equal("SponsoredData", dataSponsorshipEffect.DataName)
 	}
+
+	// Test revocation of sponsorship
+	revoke := txnbuild.RevokeSponsorship{
+		SponsorshipType: txnbuild.RevokeSponsorshipTypeData,
+		Data: &txnbuild.DataID{
+			Account:  newAccountPair.Address(),
+			DataName: "SponsoredData",
+		},
+	}
+	txResp, err = itest.SubmitOperations(itest.MasterAccount(), itest.Master(), &revoke)
+	tt.NoError(err)
+	err = xdr.SafeUnmarshalBase64(txResp.ResultXdr, &txResult)
+	tt.NoError(err)
+	tt.Equal(xdr.TransactionResultCodeTxSuccess, txResult.Result.Code)
+
+	effectRecords, err := itest.Client().Effects(sdk.EffectRequest{
+		ForTransaction: txResp.ID,
+	})
+	tt.NoError(err)
+	tt.Len(effectRecords.Embedded.Records, 1)
+	sponsorshipRemoved := effectRecords.Embedded.Records[0].(effects.DataSponsorshipRemoved)
+	tt.Equal(sponsorPair.Address(), sponsorshipRemoved.FormerSponsor)
+	tt.Equal("SponsoredData", sponsorshipRemoved.DataName)
+
+}
+
+func TestSponsoredTrustlineAndOffer(t *testing.T) {
+	tt := assert.New(t)
+	itest := test.NewIntegrationTest(t, protocol14Config)
+	defer itest.Close()
+	sponsorPair := itest.Master()
+	sponsor := func() txnbuild.Account { return itest.MasterAccount() }
+
+	// Let's create a new account
+	pairs, _ := itest.CreateAccounts(1, "1000")
+	newAccountPair := pairs[0]
+	newAccount := func() txnbuild.Account {
+		request := sdk.AccountRequest{AccountID: newAccountPair.Address()}
+		account, err := itest.Client().AccountDetail(request)
+		tt.NoError(err)
+		return &account
+	}
+
+	// Let's add a sponsored trustline and offer
+	//
+	// BeginSponsorship N (Source=sponsor)
+	//   Change Trust (ABC, sponsor) (Source=N)
+	//   ManageSellOffer Buying (ABC, sponsor) (Source=N)
+	// EndSponsorship (Source=N)
+	ops := make([]txnbuild.Operation, 4, 4)
+	ops[0] = &txnbuild.BeginSponsoringFutureReserves{
+		SponsoredID: newAccountPair.Address(),
+	}
+	ops[1] = &txnbuild.ChangeTrust{
+		SourceAccount: newAccount(),
+		Line:          txnbuild.CreditAsset{"ABCD", sponsorPair.Address()},
+		Limit:         txnbuild.MaxTrustlineLimit,
+	}
+	ops[2] = &txnbuild.ManageSellOffer{
+		SourceAccount: newAccount(),
+		Selling:       txnbuild.NativeAsset{},
+		Buying:        txnbuild.CreditAsset{"ABCD", sponsorPair.Address()},
+		Amount:        "3",
+		Price:         "1",
+	}
+	ops[3] = &txnbuild.EndSponsoringFutureReserves{
+		SourceAccount: newAccount(),
+	}
+
+	signers := []*keypair.Full{sponsorPair, newAccountPair}
+	txResp, err := itest.SubmitMultiSigOperations(sponsor(), signers, ops...)
+	tt.NoError(err)
+
+	var txResult xdr.TransactionResult
+	err = xdr.SafeUnmarshalBase64(txResp.ResultXdr, &txResult)
+	tt.NoError(err)
+	tt.Equal(xdr.TransactionResultCodeTxSuccess, txResult.Result.Code)
+
+	// Verify that the offer was incorporated correctly
+	trustlineAdded := func() bool {
+		for _, balance := range newAccount().(*protocol.Account).Balances {
+			if balance.Issuer == sponsorPair.Address() {
+				tt.Equal("ABCD", balance.Code)
+				tt.Equal(sponsorPair.Address(), balance.Sponsor)
+				return true
+			}
+		}
+		return false
+	}
+	tt.Eventually(trustlineAdded, time.Second*10, time.Millisecond*100)
+
+	// Check the details of the ManageSellOffer operation
+	// (there are no effects, which is intentional)
+	operationsResponse, err := itest.Client().Operations(sdk.OperationRequest{
+		ForTransaction: txResp.Hash,
+	})
+	tt.NoError(err)
+	tt.Len(operationsResponse.Embedded.Records, 4)
+	changeTrust := operationsResponse.Embedded.Records[1].(operations.ChangeTrust)
+	tt.Equal(sponsorPair.Address(), changeTrust.Sponsor)
+
+	// Verify that the offer was incorporated correctly
+	var offer protocol.Offer
+	offerAdded := func() bool {
+		offers, err := itest.Client().Offers(sdk.OfferRequest{
+			ForAccount: newAccountPair.Address(),
+		})
+		tt.NoError(err)
+		if len(offers.Embedded.Records) == 1 {
+			offer = offers.Embedded.Records[0]
+			tt.Equal(sponsorPair.Address(), offer.Buying.Issuer)
+			tt.Equal("ABCD", offer.Buying.Code)
+			tt.Equal(sponsorPair.Address(), offer.Sponsor)
+			return true
+		}
+		return false
+	}
+	tt.Eventually(offerAdded, time.Second*10, time.Millisecond*100)
+
+	// Check the details of the ManageSellOffer operation
+	// (there are no effects, which is intentional)
+	manageOffer := operationsResponse.Embedded.Records[2].(operations.ManageSellOffer)
+	tt.Equal(sponsorPair.Address(), manageOffer.Sponsor)
+
+	// Test revocation of sponsorships
+	revoke1 := txnbuild.RevokeSponsorship{
+		SponsorshipType: txnbuild.RevokeSponsorshipTypeOffer,
+		Offer: &txnbuild.OfferID{
+			SellerAccountAddress: offer.Seller,
+			OfferID:              offer.ID,
+		},
+	}
+	revoke2 := txnbuild.RevokeSponsorship{
+		SponsorshipType: txnbuild.RevokeSponsorshipTypeTrustLine,
+		TrustLine: &txnbuild.TrustLineId{
+			Account: newAccountPair.Address(),
+			Asset: txnbuild.CreditAsset{
+				Code:   "ABCD",
+				Issuer: sponsorPair.Address(),
+			},
+		},
+	}
+	txResp, err = itest.SubmitOperations(itest.MasterAccount(), itest.Master(), &revoke1, &revoke2)
+	tt.NoError(err)
+	err = xdr.SafeUnmarshalBase64(txResp.ResultXdr, &txResult)
+	tt.NoError(err)
+	tt.Equal(xdr.TransactionResultCodeTxSuccess, txResult.Result.Code)
+
+	effectRecords, err := itest.Client().Effects(sdk.EffectRequest{
+		ForTransaction: txResp.ID,
+	})
+	tt.NoError(err)
+	tt.Len(effectRecords.Embedded.Records, 1)
+	sponsorshipRemoved := effectRecords.Embedded.Records[0].(effects.TrustlineSponsorshipRemoved)
+	tt.Equal(sponsorPair.Address(), sponsorshipRemoved.FormerSponsor)
+	tt.Equal("ABCD:"+sponsorPair.Address(), sponsorshipRemoved.Asset)
+}
+
+func TestSponsoredClaimableBalance(t *testing.T) {
+	tt := assert.New(t)
+	itest := test.NewIntegrationTest(t, protocol14Config)
+	defer itest.Close()
+	master := itest.Master()
+
+	keys, accounts := itest.CreateAccounts(1, "50")
+	ops := []txnbuild.Operation{
+		&txnbuild.BeginSponsoringFutureReserves{
+			SourceAccount: itest.MasterAccount(),
+			SponsoredID:   keys[0].Address(),
+		},
+		&txnbuild.CreateClaimableBalance{
+			SourceAccount: accounts[0],
+			Destinations: []txnbuild.Claimant{
+				txnbuild.NewClaimant(master.Address(), nil),
+			},
+			Amount: "20",
+			Asset:  txnbuild.NativeAsset{},
+		},
+		&txnbuild.EndSponsoringFutureReserves{},
+	}
+
+	txResp, err := itest.SubmitMultiSigOperations(accounts[0], []*keypair.Full{keys[0], master}, ops...)
+	tt.NoError(err)
+
+	var txResult xdr.TransactionResult
+	err = xdr.SafeUnmarshalBase64(txResp.ResultXdr, &txResult)
+	tt.NoError(err)
+	tt.Equal(xdr.TransactionResultCodeTxSuccess, txResult.Result.Code)
+
+	balances, err := itest.Client().ClaimableBalances(sdk.ClaimableBalanceRequest{})
+	tt.NoError(err)
+
+	claims := balances.Embedded.Records
+	tt.Len(claims, 1)
+	balance := claims[0]
+	tt.Equal(master.Address(), balance.Sponsor)
 
 }

--- a/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
@@ -490,10 +490,10 @@ func TestSponsoredTrustlineAndOffer(t *testing.T) {
 	// Verify that the offer was incorporated correctly
 	var offer protocol.Offer
 	offerAdded := func() bool {
-		offers, err := itest.Client().Offers(sdk.OfferRequest{
+		offers, e := itest.Client().Offers(sdk.OfferRequest{
 			ForAccount: newAccountPair.Address(),
 		})
-		tt.NoError(err)
+		tt.NoError(e)
 		if len(offers.Embedded.Records) == 1 {
 			offer = offers.Embedded.Records[0]
 			tt.Equal(sponsorPair.Address(), offer.Buying.Issuer)

--- a/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
@@ -524,11 +524,7 @@ func TestSponsoredTrustlineAndOffer(t *testing.T) {
 			},
 		},
 	}
-	txResp, err = itest.SubmitOperations(itest.MasterAccount(), itest.Master(), &revoke1, &revoke2)
-	tt.NoError(err)
-	err = xdr.SafeUnmarshalBase64(txResp.ResultXdr, &txResult)
-	tt.NoError(err)
-	tt.Equal(xdr.TransactionResultCodeTxSuccess, txResult.Result.Code)
+	itest.MustSubmitOperations(itest.MasterAccount(), itest.Master(), &revoke1, &revoke2)
 
 	effectRecords, err := itest.Client().Effects(sdk.EffectRequest{
 		ForTransaction: txResp.ID,

--- a/txnbuild/revoke_sponsorship.go
+++ b/txnbuild/revoke_sponsorship.go
@@ -28,11 +28,11 @@ type RevokeSponsorship struct {
 	// Account Id (strkey)
 	Account   *string
 	TrustLine *TrustLineId
-	Offer     *OfferId
-	Data      *DataId
+	Offer     *OfferID
+	Data      *DataID
 	// Claimable Balance Id
 	ClaimableBalance *string
-	Signer           *SignerId
+	Signer           *SignerID
 }
 
 type TrustLineId struct {
@@ -40,18 +40,18 @@ type TrustLineId struct {
 	Asset   Asset
 }
 
-type OfferId struct {
+type OfferID struct {
 	SellerAccountAddress string
-	OfferId              int64
+	OfferID              int64
 }
 
-type DataId struct {
+type DataID struct {
 	Account  string
 	DataName string
 }
 
-type SignerId struct {
-	AccountId     string
+type SignerID struct {
+	AccountID     string
 	SignerAddress string
 }
 
@@ -97,7 +97,7 @@ func (r *RevokeSponsorship) BuildXDR() (xdr.Operation, error) {
 		if err := key.SellerId.SetAddress(r.Offer.SellerAccountAddress); err != nil {
 			return xdr.Operation{}, errors.Wrap(err, "incorrect Seller account address")
 		}
-		key.OfferId = xdr.Int64(r.Offer.OfferId)
+		key.OfferId = xdr.Int64(r.Offer.OfferID)
 		xdrOp.Type = xdr.RevokeSponsorshipTypeRevokeSponsorshipLedgerEntry
 		xdrOp.LedgerKey = &xdr.LedgerKey{
 			Type:  xdr.LedgerEntryTypeOffer,
@@ -136,7 +136,7 @@ func (r *RevokeSponsorship) BuildXDR() (xdr.Operation, error) {
 		if r.Signer == nil {
 			return xdr.Operation{}, errors.New("Signer can't be nil")
 		}
-		if err := signer.AccountId.SetAddress(r.Signer.AccountId); err != nil {
+		if err := signer.AccountId.SetAddress(r.Signer.AccountID); err != nil {
 			return xdr.Operation{}, errors.New("incorrect Account address")
 		}
 		if err := signer.SignerKey.SetAddress(r.Signer.SignerAddress); err != nil {
@@ -183,13 +183,13 @@ func (r *RevokeSponsorship) FromXDR(xdrOp xdr.Operation) error {
 			r.SponsorshipType = RevokeSponsorshipTypeTrustLine
 			r.TrustLine = &sponsorshipId
 		case xdr.LedgerEntryTypeOffer:
-			var sponsorshipId OfferId
+			var sponsorshipId OfferID
 			sponsorshipId.SellerAccountAddress = lkey.Offer.SellerId.Address()
-			sponsorshipId.OfferId = int64(lkey.Offer.OfferId)
+			sponsorshipId.OfferID = int64(lkey.Offer.OfferId)
 			r.SponsorshipType = RevokeSponsorshipTypeOffer
 			r.Offer = &sponsorshipId
 		case xdr.LedgerEntryTypeData:
-			var sponsorshipId DataId
+			var sponsorshipId DataID
 			sponsorshipId.Account = lkey.Data.AccountId.Address()
 			sponsorshipId.DataName = string(lkey.Data.DataName)
 			r.SponsorshipType = RevokeSponsorshipTypeData
@@ -211,8 +211,8 @@ func (r *RevokeSponsorship) FromXDR(xdrOp xdr.Operation) error {
 			return fmt.Errorf("unexpected LedgerEntryType: %d", lkey.Type)
 		}
 	case xdr.RevokeSponsorshipTypeRevokeSponsorshipSigner:
-		var sponsorshipId SignerId
-		sponsorshipId.AccountId = op.Signer.AccountId.Address()
+		var sponsorshipId SignerID
+		sponsorshipId.AccountID = op.Signer.AccountId.Address()
 		sponsorshipId.SignerAddress = op.Signer.SignerKey.Address()
 		r.SponsorshipType = RevokeSponsorshipTypeSigner
 		r.Signer = &sponsorshipId
@@ -266,7 +266,7 @@ func (r *RevokeSponsorship) Validate() error {
 		if r.Signer == nil {
 			return errors.New("Signer can't be nil")
 		}
-		if err := validateStellarPublicKey(r.Signer.AccountId); err != nil {
+		if err := validateStellarPublicKey(r.Signer.AccountID); err != nil {
 			return errors.New("invalid Account address")
 		}
 		if err := validateStellarSignerKey(r.Signer.SignerAddress); err != nil {

--- a/txnbuild/revoke_sponsorship.go
+++ b/txnbuild/revoke_sponsorship.go
@@ -35,7 +35,7 @@ type RevokeSponsorship struct {
 	Signer           *SignerID
 }
 
-type TrustLineId struct {
+type TrustLineID struct {
 	Account string
 	Asset   Asset
 }

--- a/txnbuild/revoke_sponsorship.go
+++ b/txnbuild/revoke_sponsorship.go
@@ -27,7 +27,7 @@ type RevokeSponsorship struct {
 	SponsorshipType RevokeSponsorshipType
 	// Account Id (strkey)
 	Account   *string
-	TrustLine *TrustLineId
+	TrustLine *TrustLineID
 	Offer     *OfferID
 	Data      *DataID
 	// Claimable Balance Id
@@ -173,7 +173,7 @@ func (r *RevokeSponsorship) FromXDR(xdrOp xdr.Operation) error {
 			r.SponsorshipType = RevokeSponsorshipTypeAccount
 			r.Account = &sponsorshipId
 		case xdr.LedgerEntryTypeTrustline:
-			var sponsorshipId TrustLineId
+			var sponsorshipId TrustLineID
 			sponsorshipId.Account = lkey.TrustLine.AccountId.Address()
 			asset, err := assetFromXDR(lkey.TrustLine.Asset)
 			if err != nil {

--- a/txnbuild/revoke_sponsorship_test.go
+++ b/txnbuild/revoke_sponsorship_test.go
@@ -56,9 +56,9 @@ func TestRevokeSponsorship(t *testing.T) {
 			name: "Offer",
 			op: RevokeSponsorship{
 				SponsorshipType: RevokeSponsorshipTypeOffer,
-				Offer: &OfferId{
+				Offer: &OfferID{
 					SellerAccountAddress: accountAddress,
-					OfferId:              0xdeadbeef,
+					OfferID:              0xdeadbeef,
 				},
 			},
 		},
@@ -66,7 +66,7 @@ func TestRevokeSponsorship(t *testing.T) {
 			name: "Data",
 			op: RevokeSponsorship{
 				SponsorshipType: RevokeSponsorshipTypeData,
-				Data: &DataId{
+				Data: &DataID{
 					Account:  accountAddress,
 					DataName: "foobar",
 				},
@@ -83,8 +83,8 @@ func TestRevokeSponsorship(t *testing.T) {
 			name: "Signer",
 			op: RevokeSponsorship{
 				SponsorshipType: RevokeSponsorshipTypeSigner,
-				Signer: &SignerId{
-					AccountId:     accountAddress,
+				Signer: &SignerID{
+					AccountID:     accountAddress,
 					SignerAddress: "XBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWGTOG",
 				},
 			},

--- a/txnbuild/revoke_sponsorship_test.go
+++ b/txnbuild/revoke_sponsorship_test.go
@@ -43,7 +43,7 @@ func TestRevokeSponsorship(t *testing.T) {
 			name: "TrustLine",
 			op: RevokeSponsorship{
 				SponsorshipType: RevokeSponsorshipTypeTrustLine,
-				TrustLine: &TrustLineId{
+				TrustLine: &TrustLineID{
 					Account: accountAddress,
 					Asset: CreditAsset{
 						Code:   "USD",


### PR DESCRIPTION
Also:

* Refactor sponsored Claimable Balance test.
* Refactor sponsored Account test.
* Rename `Id` suffixes to `ID`.

Part of #2939 