### PR TITLE
services/horizon: Remove signer from revoke_sponsorship participants

### DIFF
--- a/services/horizon/internal/expingest/processors/operations_processor.go
+++ b/services/horizon/internal/expingest/processors/operations_processor.go
@@ -569,13 +569,8 @@ func (operation *transactionOperationWrapper) Participants() ([]xdr.AccountId, e
 			participants = append(participants, getLedgerKeyParticipants(*op.LedgerKey)...)
 		case xdr.RevokeSponsorshipTypeRevokeSponsorshipSigner:
 			participants = append(participants, op.Signer.AccountId)
-			if op.Signer.SignerKey.Type == xdr.SignerKeyTypeSignerKeyTypeEd25519 {
-				signerKeyID := xdr.PublicKey{
-					Type:    xdr.PublicKeyTypePublicKeyTypeEd25519,
-					Ed25519: op.Signer.SignerKey.Ed25519,
-				}
-				participants = append(participants, xdr.AccountId(signerKeyID))
-			}
+			// We don't add signer as a participant because a signer can be arbitrary account.
+			// This can spam successful operations history of any account.
 		}
 	default:
 		return participants, fmt.Errorf("Unknown operation type: %s", op.Body.Type)

--- a/services/horizon/internal/expingest/processors/transaction_operation_wrapper_test.go
+++ b/services/horizon/internal/expingest/processors/transaction_operation_wrapper_test.go
@@ -866,7 +866,6 @@ func TestTransactionOperationParticipants(t *testing.T) {
 			hash:          "a41d1c8cdf515203ac5a10d945d5023325076b23dbe7d65ae402cd5f8cd9f891",
 			index:         0,
 			expected: []xdr.AccountId{
-				xdr.MustAddress("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
 				xdr.MustAddress("GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY"),
 				xdr.MustAddress("GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2"),
 			},


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove signer from participants of `RevokeSponsorship` operation.

Close #3065.

### Why

Signer can be an arbitrary Stellar account. Because of that a special set of operations with `RevokeSponsorship` (creating a sponsored signer and then revoking sponsorship) can spam any account successful operations list.