### PR TITLE
services/horizon: Expand CAP 33 integration tests and fix 500 error bug

### DIFF
--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -161,7 +161,7 @@ const (
 
 	// EffectClaimableBalanceSponsorshipRemoved occurs when the sponsorship of a claimable balance ledger entry
 	// is removed
-	EffectClaimableBalanceSponsorshipRemoved EffectType = 71 // from revoke_sponsorship
+	EffectClaimableBalanceSponsorshipRemoved EffectType = 71 // from claim_claimable_balance
 
 	// EffectSignerSponsorshipCreated occurs when the sponsorship of a signer is created
 	EffectSignerSponsorshipCreated EffectType = 72 // from set_options

--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -256,7 +256,7 @@ type RevokeSponsorship struct {
 	ClaimableBalanceID *string `json:"claimable_balance_id,omitempty"`
 	DataAccountID      *string `json:"data_account_id,omitempty"`
 	DataName           *string `json:"data_name,omitempty"`
-	OfferID            *int64  `json:"offer_id,omitempty"`
+	OfferID            *int64  `json:"offer_id,omitempty,string"`
 	TrustlineAccountID *string `json:"trustline_account_id,omitempty"`
 	TrustlineAsset     *string `json:"trustline_asset,omitempty"`
 	SignerAccountID    *string `json:"signer_account_id,omitempty"`

--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -256,7 +256,7 @@ type RevokeSponsorship struct {
 	ClaimableBalanceID *string `json:"claimable_balance_id,omitempty"`
 	DataAccountID      *string `json:"data_account_id,omitempty"`
 	DataName           *string `json:"data_name,omitempty"`
-	OfferID            *string `json:"offer_id,omitempty"`
+	OfferID            *int64  `json:"offer_id,omitempty"`
 	TrustlineAccountID *string `json:"trustline_account_id,omitempty"`
 	TrustlineAsset     *string `json:"trustline_asset,omitempty"`
 	SignerAccountID    *string `json:"signer_account_id,omitempty"`

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -163,7 +163,7 @@ const (
 
 	// EffectClaimableBalanceSponsorshipRemoved occurs when the sponsorship of a claimable balance ledger entry
 	// is removed
-	EffectClaimableBalanceSponsorshipRemoved EffectType = 71 // from revoke_sponsorship
+	EffectClaimableBalanceSponsorshipRemoved EffectType = 71 // from claim_claimable_balance
 
 	// EffectSignerSponsorshipCreated occurs when the sponsorship of a signer is created
 	EffectSignerSponsorshipCreated EffectType = 72 // from set_options

--- a/services/horizon/internal/expingest/processors/operations_processor.go
+++ b/services/horizon/internal/expingest/processors/operations_processor.go
@@ -489,7 +489,7 @@ func addLedgerKeyDetails(result map[string]interface{}, ledgerKey xdr.LedgerKey)
 		result["data_account_id"] = ledgerKey.Data.AccountId.Address()
 		result["data_name"] = ledgerKey.Data.DataName
 	case xdr.LedgerEntryTypeOffer:
-		result["offer_id"] = ledgerKey.Offer.OfferId
+		result["offer_id"] = fmt.Sprintf("%d", ledgerKey.Offer.OfferId)
 	case xdr.LedgerEntryTypeTrustline:
 		result["trustline_account_id"] = ledgerKey.TrustLine.AccountId.Address()
 		result["trustline_asset"] = ledgerKey.TrustLine.Asset.StringCanonical()

--- a/services/horizon/internal/resourceadapter/operations_test.go
+++ b/services/horizon/internal/resourceadapter/operations_test.go
@@ -230,12 +230,12 @@ func TestPopulateOperation_OperationTypeRevokeSponsorship_Offer(t *testing.T) {
 	tt := assert.New(t)
 
 	details := `{
-		"offer_id": 1000
+		"offer_id": "1000"
 	}`
 
 	resp, err := getJSONResponse(xdr.OperationTypeRevokeSponsorship, details)
 	tt.NoError(err)
-	tt.Equal(int64(1000), int64((resp["offer_id"]).(float64)))
+	tt.Equal("1000", resp["offer_id"])
 }
 
 func TestPopulateOperation_OperationTypeRevokeSponsorship_Trustline(t *testing.T) {
@@ -374,4 +374,28 @@ func TestFeeBumpOperation(t *testing.T) {
 	assert.Equal(t, []string{"d", "e", "f"}, dest.Transaction.InnerTransaction.Signatures)
 	assert.Equal(t, transactionRow.TransactionHash, dest.Transaction.FeeBumpTransaction.Hash)
 	assert.Equal(t, []string{"a", "b", "c"}, dest.Transaction.FeeBumpTransaction.Signatures)
+}
+
+func TestPopulateOperation_OperationTypeManageSellOffer(t *testing.T) {
+	tt := assert.New(t)
+
+	details := `{
+		"offer_id": 1000
+	}`
+
+	resp, err := getJSONResponse(xdr.OperationTypeManageSellOffer, details)
+	tt.NoError(err)
+	tt.Equal("1000", resp["offer_id"])
+}
+
+func TestPopulateOperation_OperationTypeManageBuyOffer(t *testing.T) {
+	tt := assert.New(t)
+
+	details := `{
+		"offer_id": 1000
+	}`
+
+	resp, err := getJSONResponse(xdr.OperationTypeManageBuyOffer, details)
+	tt.NoError(err)
+	tt.Equal("1000", resp["offer_id"])
 }

--- a/services/horizon/internal/resourceadapter/operations_test.go
+++ b/services/horizon/internal/resourceadapter/operations_test.go
@@ -230,12 +230,12 @@ func TestPopulateOperation_OperationTypeRevokeSponsorship_Offer(t *testing.T) {
 	tt := assert.New(t)
 
 	details := `{
-		"offer_id": "1000"
+		"offer_id": 1000
 	}`
 
 	resp, err := getJSONResponse(xdr.OperationTypeRevokeSponsorship, details)
 	tt.NoError(err)
-	tt.Equal("1000", resp["offer_id"])
+	tt.Equal(int64(1000), int64((resp["offer_id"]).(float64)))
 }
 
 func TestPopulateOperation_OperationTypeRevokeSponsorship_Trustline(t *testing.T) {

--- a/txnbuild/revoke_sponsorship.go
+++ b/txnbuild/revoke_sponsorship.go
@@ -25,12 +25,12 @@ const (
 type RevokeSponsorship struct {
 	SourceAccount   Account
 	SponsorshipType RevokeSponsorshipType
-	// Account Id (strkey)
+	// Account ID (strkey)
 	Account   *string
 	TrustLine *TrustLineID
 	Offer     *OfferID
 	Data      *DataID
-	// Claimable Balance Id
+	// Claimable Balance ID
 	ClaimableBalance *string
 	Signer           *SignerID
 }


### PR DESCRIPTION
* Add Sponsorhip update checks
* Expand Claimable Balance test
* Add Signer test
* Fix type for RevokeSponsorship's OfferID field, which was causing a 500 error on `/operations` due to an unmarshalling error.
