### PR TITLE
Add friendbot Dockerfile and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ keystore:
 ticker:
 	$(MAKE) -C services/ticker/ docker-build
 
+friendbot:
+	$(MAKE) -C services/friendbot/ docker-build
+
 webauth:
 	$(MAKE) -C exp/services/webauth/ docker-build
 

--- a/services/friendbot/Makefile
+++ b/services/friendbot/Makefile
@@ -1,0 +1,13 @@
+# Check if we need to prepend docker commands with sudo
+SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
+
+# If TAG is not provided set default value
+TAG ?= stellar/friendbot:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
+
+docker-build:
+	cd ../../ && \
+	$(SUDO) docker build -f services/friendbot/docker/Dockerfile -t $(TAG) .
+
+docker-push:
+	cd ../../ && \
+	$(SUDO) docker push $(TAG)

--- a/services/friendbot/docker/Dockerfile
+++ b/services/friendbot/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.14-stretch as build
+
+ADD . /src/friendbot
+WORKDIR /src/friendbot
+RUN go mod vendor
+RUN go build -o /bin/friendbot -mod=vendor ./services/friendbot
+
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+COPY --from=build /bin/friendbot /app/
+EXPOSE 8004
+ENTRYPOINT ["/app/friendbot"]

--- a/services/friendbot/docker/Dockerfile
+++ b/services/friendbot/docker/Dockerfile
@@ -2,8 +2,7 @@ FROM golang:1.14-stretch as build
 
 ADD . /src/friendbot
 WORKDIR /src/friendbot
-RUN go mod vendor
-RUN go build -o /bin/friendbot -mod=vendor ./services/friendbot
+RUN go build -o /bin/friendbot ./services/friendbot
 
 FROM ubuntu:16.04
 


### PR DESCRIPTION
### What
Add friendbot Dockerfile and Makefile

### Why
Copying the existing patterns we have in other applications. The
Dockerfile and Makefile were based on other services in the repository