### PR TITLE
historyarchive: Check archive's network passphrase when getting HAS

### DIFF
--- a/exp/ingest/ledgerbackend/captive_core_backend.go
+++ b/exp/ingest/ledgerbackend/captive_core_backend.go
@@ -114,7 +114,9 @@ type CaptiveStellarCore struct {
 func NewCaptive(executablePath, configPath, networkPassphrase string, historyURLs []string) (*CaptiveStellarCore, error) {
 	archive, err := historyarchive.Connect(
 		historyURLs[0],
-		historyarchive.ConnectOptions{},
+		historyarchive.ConnectOptions{
+			NetworkPassphrase: networkPassphrase,
+		},
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "error connecting to history archive")

--- a/historyarchive/history_archive_state.go
+++ b/historyarchive/history_archive_state.go
@@ -16,10 +16,13 @@ import (
 const NumLevels = 11
 
 type HistoryArchiveState struct {
-	Version        int    `json:"version"`
-	Server         string `json:"server"`
-	CurrentLedger  uint32 `json:"currentLedger"`
-	CurrentBuckets [NumLevels]struct {
+	Version       int    `json:"version"`
+	Server        string `json:"server"`
+	CurrentLedger uint32 `json:"currentLedger"`
+	// NetworkPassphrase was added in Stellar-Core v14.1.0. Can be missing
+	// in HAS created by previous versions.
+	NetworkPassphrase string `json:"networkPassphrase"`
+	CurrentBuckets    [NumLevels]struct {
 		Curr string `json:"curr"`
 		Snap string `json:"snap"`
 		Next struct {

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -143,7 +143,8 @@ func NewSystem(config Config) (System, error) {
 	archive, err := historyarchive.Connect(
 		config.HistoryArchiveURL,
 		historyarchive.ConnectOptions{
-			Context: ctx,
+			Context:           ctx,
+			NetworkPassphrase: config.NetworkPassphrase,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add a code comparing network passphrase in HAS with expected network passphrase.

### Why

Stellar-Core 14.1.0 started publishing network passphrase in HAS (https://github.com/stellar/stellar-core/issues/2579). Checking this value will help debug connecting to incorrect history archive faster. In the past one of Horizon users used pubnet config (connected to pubnet Stellar-Core) but testnet archive. Because of that Horizon was waiting indefinitely for a checkpoint ledger after a given pubnet ledger but it never appeared because testnet ledger sequence numbers are much smaller than in pubnet.

### Known limitations

The values are compared when getting HAS. Ideally, it should be checked in `Connect` but this would send an HTTP request.