### PR TITLE
services/horizon: Fix separation of concerns related to offers ingestion

### DIFF
--- a/services/horizon/internal/action_offers_test.go
+++ b/services/horizon/internal/action_offers_test.go
@@ -37,41 +37,33 @@ func TestOfferActions_Show(t *testing.T) {
 	usdAsset := xdr.MustNewCreditAsset("USD", issuer.Address())
 	eurAsset := xdr.MustNewCreditAsset("EUR", issuer.Address())
 
-	eurOffer := xdr.LedgerEntry{
-		LastModifiedLedgerSeq: 4,
-		Data: xdr.LedgerEntryData{
-			Type: xdr.LedgerEntryTypeOffer,
-			Offer: &xdr.OfferEntry{
-				SellerId: issuer,
-				OfferId:  xdr.Int64(4),
-				Buying:   eurAsset,
-				Selling:  nativeAsset,
-				Price: xdr.Price{
-					N: 1,
-					D: 1,
-				},
-				Flags:  1,
-				Amount: xdr.Int64(500),
-			},
-		},
+	eurOffer := history.Offer{
+		SellerID: issuer.Address(),
+		OfferID:  int64(4),
+
+		BuyingAsset:  eurAsset,
+		SellingAsset: nativeAsset,
+
+		Amount:             int64(500),
+		Pricen:             int32(1),
+		Priced:             int32(1),
+		Price:              float64(1),
+		Flags:              1,
+		LastModifiedLedger: uint32(3),
 	}
-	usdOffer := xdr.LedgerEntry{
-		LastModifiedLedgerSeq: 3,
-		Data: xdr.LedgerEntryData{
-			Type: xdr.LedgerEntryTypeOffer,
-			Offer: &xdr.OfferEntry{
-				SellerId: issuer,
-				OfferId:  xdr.Int64(6),
-				Buying:   usdAsset,
-				Selling:  eurAsset,
-				Price: xdr.Price{
-					N: 1,
-					D: 1,
-				},
-				Flags:  1,
-				Amount: xdr.Int64(500),
-			},
-		},
+	usdOffer := history.Offer{
+		SellerID: issuer.Address(),
+		OfferID:  int64(6),
+
+		BuyingAsset:  usdAsset,
+		SellingAsset: eurAsset,
+
+		Amount:             int64(500),
+		Pricen:             int32(1),
+		Priced:             int32(1),
+		Price:              float64(1),
+		Flags:              1,
+		LastModifiedLedger: uint32(4),
 	}
 
 	batch := q.NewOffersBatchInsertBuilder(3)

--- a/services/horizon/internal/actions/orderbook_test.go
+++ b/services/horizon/internal/actions/orderbook_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	protocol "github.com/stellar/go/protocols/horizon"
-	"github.com/stellar/go/xdr"
 )
 
 type intObject int
@@ -491,105 +490,82 @@ func TestOrderbookGetResource(t *testing.T) {
 		},
 	}
 
-	sellEurOffer := xdr.LedgerEntry{
-		LastModifiedLedgerSeq: 4,
-		Data: xdr.LedgerEntryData{
-			Type: xdr.LedgerEntryTypeOffer,
-			Offer: &xdr.OfferEntry{
-				SellerId: seller,
-				OfferId:  xdr.Int64(15),
-				Buying:   nativeAsset,
-				Selling:  eurAsset,
-				Price: xdr.Price{
-					N: 2,
-					D: 1,
-				},
-				Flags:  2,
-				Amount: xdr.Int64(500),
-			},
-		},
+	sellEurOffer := history.Offer{
+		SellerID: seller.Address(),
+		OfferID:  int64(15),
+
+		BuyingAsset:  nativeAsset,
+		SellingAsset: eurAsset,
+
+		Amount:             int64(500),
+		Pricen:             int32(2),
+		Priced:             int32(1),
+		Price:              float64(2),
+		Flags:              2,
+		LastModifiedLedger: uint32(4),
 	}
 
-	otherEurOffer := xdr.LedgerEntry{
-		LastModifiedLedgerSeq: 16,
-		Data: xdr.LedgerEntryData{
-			Type: xdr.LedgerEntryTypeOffer,
-			Offer: &xdr.OfferEntry{
-				SellerId: seller,
-				OfferId:  xdr.Int64(6),
-				Buying:   eurAsset,
-				Selling:  nativeAsset,
-				Price: xdr.Price{
-					N: 2,
-					D: 1,
-				},
-				Flags:  2,
-				Amount: xdr.Int64(math.MaxInt64),
-			},
-		},
+	otherEurOffer := history.Offer{
+		SellerID: seller.Address(),
+		OfferID:  int64(16),
+
+		BuyingAsset:  eurAsset,
+		SellingAsset: nativeAsset,
+
+		Amount:             int64(math.MaxInt64),
+		Pricen:             int32(2),
+		Priced:             int32(1),
+		Price:              float64(2),
+		Flags:              2,
+		LastModifiedLedger: uint32(1234),
 	}
 
-	nonCanonicalPriceTwoEurOffer := xdr.LedgerEntry{
-		LastModifiedLedgerSeq: 30,
-		Data: xdr.LedgerEntryData{
-			Type: xdr.LedgerEntryTypeOffer,
-			Offer: &xdr.OfferEntry{
-				SellerId: seller,
-				OfferId:  xdr.Int64(7),
-				Buying:   eurAsset,
-				Selling:  nativeAsset,
-				Price: xdr.Price{
-					// Add a separate offer with the same price value, but
-					// using a non-canonical representation, to make sure
-					// they are coalesced into the same price level
-					N: 2 * 15,
-					D: 1 * 15,
-				},
-				Flags:  2,
-				Amount: xdr.Int64(500),
-			},
-		},
+	nonCanonicalPriceTwoEurOffer := history.Offer{
+		SellerID: seller.Address(),
+		OfferID:  int64(7),
+
+		BuyingAsset:  eurAsset,
+		SellingAsset: nativeAsset,
+
+		Amount:             int64(500),
+		Pricen:             int32(2 * 15),
+		Priced:             int32(1 * 15),
+		Price:              float64(2),
+		Flags:              2,
+		LastModifiedLedger: uint32(4),
 	}
 
-	threeEurOffer := xdr.LedgerEntry{
-		LastModifiedLedgerSeq: 4,
-		Data: xdr.LedgerEntryData{
-			Type: xdr.LedgerEntryTypeOffer,
-			Offer: &xdr.OfferEntry{
-				SellerId: seller,
-				OfferId:  xdr.Int64(20),
-				Buying:   eurAsset,
-				Selling:  nativeAsset,
-				Price: xdr.Price{
-					N: 3,
-					D: 1,
-				},
-				Flags:  2,
-				Amount: xdr.Int64(500),
-			},
-		},
+	threeEurOffer := history.Offer{
+		SellerID: seller.Address(),
+		OfferID:  int64(20),
+
+		BuyingAsset:  eurAsset,
+		SellingAsset: nativeAsset,
+
+		Amount:             int64(500),
+		Pricen:             int32(3),
+		Priced:             int32(1),
+		Price:              float64(3),
+		Flags:              2,
+		LastModifiedLedger: uint32(1234),
 	}
 
-	otherSellEurOffer := xdr.LedgerEntry{
-		LastModifiedLedgerSeq: 4,
-		Data: xdr.LedgerEntryData{
-			Type: xdr.LedgerEntryTypeOffer,
-			Offer: &xdr.OfferEntry{
-				SellerId: seller,
-				OfferId:  xdr.Int64(17),
-				Buying:   nativeAsset,
-				Selling:  eurAsset,
-				Price: xdr.Price{
-					N: 5,
-					D: 9,
-				},
-				Flags:  2,
-				Amount: xdr.Int64(500),
-			},
-		},
+	otherSellEurOffer := history.Offer{
+		SellerID: seller.Address(),
+		OfferID:  int64(17),
+
+		BuyingAsset:  nativeAsset,
+		SellingAsset: eurAsset,
+
+		Amount:             int64(500),
+		Pricen:             int32(5),
+		Priced:             int32(9),
+		Price:              float64(5) / float64(9),
+		Flags:              2,
+		LastModifiedLedger: uint32(1234),
 	}
 
-	offers := []xdr.LedgerEntry{
+	offers := []history.Offer{
 		twoEurOffer,
 		otherEurOffer,
 		nonCanonicalPriceTwoEurOffer,
@@ -615,24 +591,24 @@ func TestOrderbookGetResource(t *testing.T) {
 	fullResponse := empty
 	fullResponse.Asks = []protocol.PriceLevel{
 		{
-			PriceR: protocol.Price{N: int32(twoEurOffer.Data.Offer.Price.N), D: int32(twoEurOffer.Data.Offer.Price.D)},
+			PriceR: protocol.Price{N: int32(twoEurOffer.Pricen), D: int32(twoEurOffer.Priced)},
 			Price:  "2.0000000",
 			Amount: "922337203685.4776807",
 		},
 		{
-			PriceR: protocol.Price{N: int32(threeEurOffer.Data.Offer.Price.N), D: int32(threeEurOffer.Data.Offer.Price.D)},
+			PriceR: protocol.Price{N: int32(threeEurOffer.Pricen), D: int32(threeEurOffer.Priced)},
 			Price:  "3.0000000",
 			Amount: "0.0000500",
 		},
 	}
 	fullResponse.Bids = []protocol.PriceLevel{
 		{
-			PriceR: protocol.Price{N: int32(otherSellEurOffer.Data.Offer.Price.D), D: int32(otherSellEurOffer.Data.Offer.Price.N)},
+			PriceR: protocol.Price{N: int32(otherSellEurOffer.Priced), D: int32(otherSellEurOffer.Pricen)},
 			Price:  "1.8000000",
 			Amount: "0.0000500",
 		},
 		{
-			PriceR: protocol.Price{N: int32(sellEurOffer.Data.Offer.Price.D), D: int32(sellEurOffer.Data.Offer.Price.N)},
+			PriceR: protocol.Price{N: int32(sellEurOffer.Priced), D: int32(sellEurOffer.Pricen)},
 			Price:  "0.5000000",
 			Amount: "0.0000500",
 		},
@@ -641,14 +617,14 @@ func TestOrderbookGetResource(t *testing.T) {
 	limitResponse := empty
 	limitResponse.Asks = []protocol.PriceLevel{
 		{
-			PriceR: protocol.Price{N: int32(twoEurOffer.Data.Offer.Price.N), D: int32(twoEurOffer.Data.Offer.Price.D)},
+			PriceR: protocol.Price{N: int32(twoEurOffer.Pricen), D: int32(twoEurOffer.Priced)},
 			Price:  "2.0000000",
 			Amount: "922337203685.4776807",
 		},
 	}
 	limitResponse.Bids = []protocol.PriceLevel{
 		{
-			PriceR: protocol.Price{N: int32(otherSellEurOffer.Data.Offer.Price.D), D: int32(otherSellEurOffer.Data.Offer.Price.N)},
+			PriceR: protocol.Price{N: int32(otherSellEurOffer.Priced), D: int32(otherSellEurOffer.Pricen)},
 			Price:  "1.8000000",
 			Amount: "0.0000500",
 		},

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -493,13 +493,13 @@ type ManageOffer struct {
 
 // Offer is row of data from the `offers` table from horizon DB
 type Offer struct {
-	SellerID string    `db:"seller_id"`
-	OfferID  xdr.Int64 `db:"offer_id"`
+	SellerID string `db:"seller_id"`
+	OfferID  int64  `db:"offer_id"`
 
 	SellingAsset xdr.Asset `db:"selling_asset"`
 	BuyingAsset  xdr.Asset `db:"buying_asset"`
 
-	Amount             xdr.Int64   `db:"amount"`
+	Amount             int64       `db:"amount"`
 	Pricen             int32       `db:"pricen"`
 	Priced             int32       `db:"priced"`
 	Price              float64     `db:"price"`
@@ -510,7 +510,7 @@ type Offer struct {
 }
 
 type OffersBatchInsertBuilder interface {
-	Add(entry xdr.LedgerEntry) error
+	Add(offer Offer) error
 	Exec() error
 }
 

--- a/services/horizon/internal/db2/history/mock_offers_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_offers_batch_insert_builder.go
@@ -1,7 +1,6 @@
 package history
 
 import (
-	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -9,8 +8,8 @@ type MockOffersBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockOffersBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
-	a := m.Called(entry)
+func (m *MockOffersBatchInsertBuilder) Add(row Offer) error {
+	a := m.Called(row)
 	return a.Error(0)
 }
 

--- a/services/horizon/internal/db2/history/mock_q_offers.go
+++ b/services/horizon/internal/db2/history/mock_q_offers.go
@@ -2,8 +2,6 @@ package history
 
 import (
 	"github.com/stretchr/testify/mock"
-
-	"github.com/stellar/go/xdr"
 )
 
 // MockQOffers is a mock implementation of the QOffers interface
@@ -36,12 +34,12 @@ func (m *MockQOffers) NewOffersBatchInsertBuilder(maxBatchSize int) OffersBatchI
 	return a.Get(0).(OffersBatchInsertBuilder)
 }
 
-func (m *MockQOffers) UpdateOffer(entry xdr.LedgerEntry) (int64, error) {
-	a := m.Called(entry)
+func (m *MockQOffers) UpdateOffer(row Offer) (int64, error) {
+	a := m.Called(row)
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQOffers) RemoveOffer(offerID xdr.Int64, lastModifiedLedger uint32) (int64, error) {
+func (m *MockQOffers) RemoveOffer(offerID int64, lastModifiedLedger uint32) (int64, error) {
 	a := m.Called(offerID, lastModifiedLedger)
 	return a.Get(0).(int64), a.Error(1)
 }

--- a/services/horizon/internal/db2/history/offers.go
+++ b/services/horizon/internal/db2/history/offers.go
@@ -3,7 +3,6 @@ package history
 import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/stellar/go/support/errors"
-	"github.com/stellar/go/xdr"
 )
 
 // QOffers defines offer related queries.
@@ -13,8 +12,8 @@ type QOffers interface {
 	CountOffers() (int, error)
 	GetUpdatedOffers(newerThanSequence uint32) ([]Offer, error)
 	NewOffersBatchInsertBuilder(maxBatchSize int) OffersBatchInsertBuilder
-	UpdateOffer(entry xdr.LedgerEntry) (int64, error)
-	RemoveOffer(offerID xdr.Int64, lastModifiedLedger uint32) (int64, error)
+	UpdateOffer(offer Offer) (int64, error)
+	RemoveOffer(offerID int64, lastModifiedLedger uint32) (int64, error)
 	CompactOffers(cutOffSequence uint32) (int64, error)
 }
 
@@ -61,19 +60,11 @@ func (q *Q) GetOffers(query OffersQuery) ([]Offer, error) {
 	}
 
 	if query.Selling != nil {
-		sellingAsset, err := xdr.MarshalBase64(*query.Selling)
-		if err != nil {
-			return nil, errors.Wrap(err, "cannot marshal selling asset")
-		}
-		sql = sql.Where("offers.selling_asset = ?", sellingAsset)
+		sql = sql.Where("offers.selling_asset = ?", query.Selling)
 	}
 
 	if query.Buying != nil {
-		buyingAsset, err := xdr.MarshalBase64(*query.Buying)
-		if err != nil {
-			return nil, errors.Wrap(err, "cannot marshal Buying asset")
-		}
-		sql = sql.Where("offers.buying_asset = ?", buyingAsset)
+		sql = sql.Where("offers.buying_asset = ?", query.Buying)
 	}
 
 	if query.Sponsor != "" {
@@ -104,41 +95,18 @@ func (q *Q) GetUpdatedOffers(newerThanSequence uint32) ([]Offer, error) {
 
 // UpdateOffer updates a row in the offers table.
 // Returns number of rows affected and error.
-func (q *Q) UpdateOffer(entry xdr.LedgerEntry) (int64, error) {
-	offer := entry.Data.MustOffer()
-
-	var price float64
-	if offer.Price.N > 0 {
-		price = float64(offer.Price.N) / float64(offer.Price.D)
-	} else if offer.Price.D == 0 {
-		return 0, errors.New("offer price denominator is zero")
-	}
-
-	offerMap := map[string]interface{}{
-		"seller_id":            offer.SellerId.Address(),
-		"selling_asset":        offer.Selling,
-		"buying_asset":         offer.Buying,
-		"amount":               offer.Amount,
-		"pricen":               offer.Price.N,
-		"priced":               offer.Price.D,
-		"price":                price,
-		"flags":                offer.Flags,
-		"last_modified_ledger": entry.LastModifiedLedgerSeq,
-		"sponsor":              ledgerEntrySponsorToNullString(entry),
-	}
-
-	sql := sq.Update("offers").SetMap(offerMap).Where("offer_id = ?", offer.OfferId)
-	result, err := q.Exec(sql)
+func (q *Q) UpdateOffer(offer Offer) (int64, error) {
+	updateBuilder := q.GetTable("offers").Update()
+	result, err := updateBuilder.SetStruct(offer, []string{}).Where("offer_id = ?", offer.OfferID).Exec()
 	if err != nil {
 		return 0, err
 	}
-
 	return result.RowsAffected()
 }
 
 // RemoveOffer marks a row in the offers table as deleted.
 // Returns number of rows affected and error.
-func (q *Q) RemoveOffer(offerID xdr.Int64, lastModifiedLedger uint32) (int64, error) {
+func (q *Q) RemoveOffer(offerID int64, lastModifiedLedger uint32) (int64, error) {
 	sql := sq.Update("offers").
 		Set("deleted", true).
 		Set("last_modified_ledger", lastModifiedLedger).

--- a/services/horizon/internal/db2/history/offers_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/offers_batch_insert_builder.go
@@ -1,38 +1,8 @@
 package history
 
-import (
-	"github.com/stellar/go/support/errors"
-	"github.com/stellar/go/xdr"
-)
-
-// Add adds a new offer entry to the batch. `lastModifiedLedger` is another
-// parameter because `xdr.OfferEntry` does not have a field to hold this value.
-func (i *offersBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
-	offer := entry.Data.MustOffer()
-
-	var price float64
-	if offer.Price.D == 0 {
-		return errors.New("offer price denominator is zero")
-	} else if offer.Price.N > 0 {
-		price = float64(offer.Price.N) / float64(offer.Price.D)
-	}
-
-	row := Offer{
-		SellerID:           offer.SellerId.Address(),
-		OfferID:            offer.OfferId,
-		SellingAsset:       offer.Selling,
-		BuyingAsset:        offer.Buying,
-		Amount:             offer.Amount,
-		Pricen:             int32(offer.Price.N),
-		Priced:             int32(offer.Price.D),
-		Price:              price,
-		Flags:              uint32(offer.Flags),
-		Deleted:            false,
-		LastModifiedLedger: uint32(entry.LastModifiedLedgerSeq),
-		Sponsor:            ledgerEntrySponsorToNullString(entry),
-	}
-
-	return i.builder.RowStruct(row)
+// Add adds a new offer entry to the batch.
+func (i *offersBatchInsertBuilder) Add(offer Offer) error {
+	return i.builder.RowStruct(offer)
 }
 
 func (i *offersBatchInsertBuilder) Exec() error {

--- a/services/horizon/internal/db2/history/offers_test.go
+++ b/services/horizon/internal/db2/history/offers_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/guregu/null"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/xdr"
@@ -17,154 +18,52 @@ var (
 	eurAsset    = xdr.MustNewCreditAsset("EUR", issuer.Address())
 	usdAsset    = xdr.MustNewCreditAsset("USD", issuer.Address())
 
-	eurOffer = xdr.LedgerEntry{
-		LastModifiedLedgerSeq: 1234,
-		Data: xdr.LedgerEntryData{
-			Type: xdr.LedgerEntryTypeOffer,
-			Offer: &xdr.OfferEntry{
-				SellerId: issuer,
-				OfferId:  xdr.Int64(4),
-				Buying:   eurAsset,
-				Selling:  nativeAsset,
-				Price: xdr.Price{
-					N: 1,
-					D: 1,
-				},
-				Flags:  1,
-				Amount: xdr.Int64(500),
-			},
-		},
-		Ext: xdr.LedgerEntryExt{
-			V: 1,
-			V1: &xdr.LedgerEntryExtensionV1{
-				SponsoringId: &sponsor,
-			},
-		},
+	eurOffer = Offer{
+		SellerID: issuer.Address(),
+		OfferID:  int64(4),
+
+		BuyingAsset:  eurAsset,
+		SellingAsset: nativeAsset,
+
+		Amount:             int64(500),
+		Pricen:             int32(1),
+		Priced:             int32(1),
+		Price:              float64(1),
+		Flags:              1,
+		LastModifiedLedger: uint32(1234),
+		Sponsor:            null.StringFrom(sponsor.Address()),
 	}
-	twoEurOffer = xdr.LedgerEntry{
-		LastModifiedLedgerSeq: 1234,
-		Data: xdr.LedgerEntryData{
-			Type: xdr.LedgerEntryTypeOffer,
-			Offer: &xdr.OfferEntry{
-				SellerId: twoEurOfferSeller,
-				OfferId:  xdr.Int64(5),
-				Buying:   eurAsset,
-				Selling:  nativeAsset,
-				Price: xdr.Price{
-					N: 2,
-					D: 1,
-				},
-				Flags:  2,
-				Amount: xdr.Int64(500),
-			},
-		},
+	twoEurOffer = Offer{
+		SellerID: twoEurOfferSeller.Address(),
+		OfferID:  int64(5),
+
+		BuyingAsset:  eurAsset,
+		SellingAsset: nativeAsset,
+
+		Amount:             int64(500),
+		Pricen:             int32(2),
+		Priced:             int32(1),
+		Price:              float64(2),
+		Flags:              2,
+		LastModifiedLedger: uint32(1234),
 	}
-	threeEurOffer = xdr.LedgerEntry{
-		LastModifiedLedgerSeq: 1234,
-		Data: xdr.LedgerEntryData{
-			Type: xdr.LedgerEntryTypeOffer,
-			Offer: &xdr.OfferEntry{
-				SellerId: twoEurOfferSeller,
-				OfferId:  xdr.Int64(50),
-				Buying:   eurAsset,
-				Selling:  nativeAsset,
-				Price: xdr.Price{
-					N: 3,
-					D: 1,
-				},
-				Flags:  2,
-				Amount: xdr.Int64(500),
-			},
-		},
+	threeEurOffer = Offer{
+		SellerID: twoEurOfferSeller.Address(),
+		OfferID:  int64(50),
+
+		BuyingAsset:  eurAsset,
+		SellingAsset: nativeAsset,
+
+		Amount:             int64(500),
+		Pricen:             int32(3),
+		Priced:             int32(1),
+		Price:              float64(3),
+		Flags:              2,
+		LastModifiedLedger: uint32(1234),
 	}
 )
 
-func assertOfferEntryMatchesDBOffer(t *testing.T, entry xdr.LedgerEntry, offer Offer) {
-	offerEntry := entry.Data.MustOffer()
-
-	if offerEntry.SellerId.Address() != offer.SellerID {
-		t.Fatalf(
-			"seller id in offer entry %v does not equal to seller id in offer from db %v",
-			offerEntry.SellerId.Address(),
-			offer.SellerID,
-		)
-	}
-	if offerEntry.OfferId != offer.OfferID {
-		t.Fatalf(
-			"offer id in offer entry %v does not equal to offer id in offer from db %v",
-			offerEntry.OfferId,
-			offer.OfferID,
-		)
-	}
-	if offerEntry.Selling.String() != offer.SellingAsset.String() {
-		t.Fatalf(
-			"selling asset in offer entry %v does not equal to selling asset in offer from db %v",
-			offerEntry.Selling.String(),
-			offer.SellingAsset.String(),
-		)
-	}
-	if offerEntry.Buying.String() != offer.BuyingAsset.String() {
-		t.Fatalf(
-			"buying asset in offer entry %v does not equal to buying asset in offer from db %v",
-			offerEntry.Buying.String(),
-			offer.BuyingAsset.String(),
-		)
-	}
-	if offerEntry.Amount != offer.Amount {
-		t.Fatalf(
-			"amount in offer entry %v does not equal to amount in offer from db %v",
-			offerEntry.Amount,
-			offer.Amount,
-		)
-	}
-	if offerEntry.Price.N != xdr.Int32(offer.Pricen) {
-		t.Fatalf(
-			"price numerator in offer entry %v does not equal to price numerator in offer from db %v",
-			offerEntry.Price.N,
-			offer.Pricen,
-		)
-	}
-	if offerEntry.Price.D != xdr.Int32(offer.Priced) {
-		t.Fatalf(
-			"price denominator in offer entry %v does not equal to price denominator in offer from db %v",
-			offerEntry.Price.D,
-			offer.Priced,
-		)
-	}
-	if offerEntry.Flags != xdr.Uint32(offer.Flags) {
-		t.Fatalf(
-			"flags in offer entry %v does not equal to flags in offer from db %v",
-			offerEntry.Flags,
-			offer.Flags,
-		)
-	}
-	if entry.LastModifiedLedgerSeq != xdr.Uint32(offer.LastModifiedLedger) {
-		t.Fatalf(
-			"last_modified_ledger %v does not equal last_modified_ledger %v in offer from DB",
-			entry.LastModifiedLedgerSeq,
-			offer,
-		)
-	}
-	if entry.SponsoringID() == nil {
-		if offer.Sponsor.Valid {
-			t.Fatalf(
-				"sponsor is nil but %v in offer from DB",
-				offer,
-			)
-		}
-	} else {
-		accountID := xdr.AccountId(*entry.Ext.V1.SponsoringId)
-		if accountID.Address() != offer.Sponsor.String {
-			t.Fatalf(
-				"sponsor %s does not equal sponsor %v in offer from DB",
-				accountID.Address(),
-				offer,
-			)
-		}
-	}
-}
-
-func insertOffer(q *Q, offer xdr.LedgerEntry) error {
+func insertOffer(q *Q, offer Offer) error {
 	batch := q.NewOffersBatchInsertBuilder(0)
 	err := batch.Add(offer)
 	if err != nil {
@@ -181,9 +80,9 @@ func TestGetOfferByID(t *testing.T) {
 
 	err := insertOffer(q, eurOffer)
 	tt.Assert.NoError(err)
-	offer, err := q.GetOfferByID(int64(eurOffer.Data.Offer.OfferId))
+	offer, err := q.GetOfferByID(eurOffer.OfferID)
 	tt.Assert.NoError(err)
-	assertOfferEntryMatchesDBOffer(t, eurOffer, offer)
+	tt.Assert.Equal(offer, eurOffer)
 }
 
 func TestGetNonExistentOfferByID(t *testing.T) {
@@ -237,13 +136,13 @@ func TestInsertOffers(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.Len(offers, 2)
 
-	offersByID := map[xdr.Int64]Offer{
+	offersByID := map[int64]Offer{
 		offers[0].OfferID: offers[0],
 		offers[1].OfferID: offers[1],
 	}
 
-	assertOfferEntryMatchesDBOffer(t, eurOffer, offersByID[eurOffer.Data.Offer.OfferId])
-	assertOfferEntryMatchesDBOffer(t, twoEurOffer, offersByID[twoEurOffer.Data.Offer.OfferId])
+	tt.Assert.Equal(offersByID[eurOffer.OfferID], eurOffer)
+	tt.Assert.Equal(offersByID[twoEurOffer.OfferID], twoEurOffer)
 
 	count, err := q.CountOffers()
 	tt.Assert.NoError(err)
@@ -290,10 +189,10 @@ func TestUpdateOffer(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.Len(updatedOffers, 0)
 
-	assertOfferEntryMatchesDBOffer(t, eurOffer, offers[0])
+	tt.Assert.Equal(offers[0], eurOffer)
 
 	modifiedEurOffer := eurOffer
-	modifiedEurOffer.Data.Offer.Amount -= 10
+	modifiedEurOffer.Amount -= 10
 
 	rowsAffected, err := q.UpdateOffer(modifiedEurOffer)
 	tt.Assert.NoError(err)
@@ -311,7 +210,7 @@ func TestUpdateOffer(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.Len(updatedOffers, 0)
 
-	assertOfferEntryMatchesDBOffer(t, modifiedEurOffer, offers[0])
+	tt.Assert.Equal(offers[0], modifiedEurOffer)
 }
 
 func TestRemoveNonExistantOffer(t *testing.T) {
@@ -320,7 +219,7 @@ func TestRemoveNonExistantOffer(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	numAffected, err := q.RemoveOffer(xdr.Int64(12345), 1236)
+	numAffected, err := q.RemoveOffer(12345, 1236)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(int64(0), numAffected)
 }
@@ -336,10 +235,10 @@ func TestRemoveOffer(t *testing.T) {
 	offers, err := q.GetAllOffers()
 	tt.Assert.NoError(err)
 	tt.Assert.Len(offers, 1)
-	assertOfferEntryMatchesDBOffer(t, eurOffer, offers[0])
+	tt.Assert.Equal(offers[0], eurOffer)
 
 	expectedUpdates := offers
-	rowsAffected, err := q.RemoveOffer(eurOffer.Data.Offer.OfferId, 1236)
+	rowsAffected, err := q.RemoveOffer(eurOffer.OfferID, 1236)
 	tt.Assert.Equal(int64(1), rowsAffected)
 	tt.Assert.NoError(err)
 	expectedUpdates[0].LastModifiedLedger = 1236
@@ -394,7 +293,7 @@ func TestGetOffers(t *testing.T) {
 	// check removed offers aren't included in GetOffer queries
 	err = insertOffer(q, threeEurOffer)
 	tt.Assert.NoError(err)
-	count, err := q.RemoveOffer(threeEurOffer.Data.Offer.OfferId, 1235)
+	count, err := q.RemoveOffer(threeEurOffer.OfferID, 1235)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(int64(1), count)
 
@@ -460,7 +359,7 @@ func TestGetOffers(t *testing.T) {
 		tt.Assert.NoError(err)
 		tt.Assert.Len(offers, 1)
 
-		assertOfferEntryMatchesDBOffer(t, eurOffer, offers[0])
+		tt.Assert.Equal(offers[0], eurOffer)
 	})
 
 	t.Run("Filter by sponsor", func(t *testing.T) {
@@ -473,7 +372,7 @@ func TestGetOffers(t *testing.T) {
 		tt.Assert.NoError(err)
 		tt.Assert.Len(offers, 1)
 
-		assertOfferEntryMatchesDBOffer(t, eurOffer, offers[0])
+		tt.Assert.Equal(offers[0], eurOffer)
 	})
 
 	t.Run("PageQuery", func(t *testing.T) {
@@ -488,13 +387,13 @@ func TestGetOffers(t *testing.T) {
 		tt.Assert.NoError(err)
 		tt.Assert.Len(offers, 2)
 
-		offersByID := map[xdr.Int64]Offer{
+		offersByID := map[int64]Offer{
 			offers[0].OfferID: offers[0],
 			offers[1].OfferID: offers[1],
 		}
 
-		assertOfferEntryMatchesDBOffer(t, eurOffer, offersByID[eurOffer.Data.Offer.OfferId])
-		assertOfferEntryMatchesDBOffer(t, twoEurOffer, offersByID[twoEurOffer.Data.Offer.OfferId])
+		tt.Assert.Equal(offersByID[eurOffer.OfferID], eurOffer)
+		tt.Assert.Equal(offersByID[twoEurOffer.OfferID], twoEurOffer)
 
 		pageQuery, err = db2.NewPageQuery("", false, "asc", 1)
 		tt.Assert.NoError(err)
@@ -506,7 +405,7 @@ func TestGetOffers(t *testing.T) {
 		tt.Assert.NoError(err)
 		tt.Assert.Len(offers, 1)
 
-		assertOfferEntryMatchesDBOffer(t, eurOffer, offers[0])
+		tt.Assert.Equal(offers[0], eurOffer)
 
 		pageQuery, err = db2.NewPageQuery("", false, "desc", 1)
 		tt.Assert.NoError(err)
@@ -518,10 +417,10 @@ func TestGetOffers(t *testing.T) {
 		tt.Assert.NoError(err)
 		tt.Assert.Len(offers, 1)
 
-		assertOfferEntryMatchesDBOffer(t, twoEurOffer, offers[0])
+		tt.Assert.Equal(offers[0], twoEurOffer)
 
 		pageQuery, err = db2.NewPageQuery(
-			strconv.FormatInt(int64(eurOffer.Data.Offer.OfferId), 10),
+			strconv.FormatInt(int64(eurOffer.OfferID), 10),
 			false,
 			"",
 			10,
@@ -535,6 +434,6 @@ func TestGetOffers(t *testing.T) {
 		tt.Assert.NoError(err)
 		tt.Assert.Len(offers, 1)
 
-		assertOfferEntryMatchesDBOffer(t, twoEurOffer, offers[0])
+		tt.Assert.Equal(offers[0], twoEurOffer)
 	})
 }

--- a/services/horizon/internal/db2/history/orderbook_test.go
+++ b/services/horizon/internal/db2/history/orderbook_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stellar/go/services/horizon/internal/test"
-	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,110 +31,91 @@ func TestGetOrderBookSummary(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	asksButNoBids := []xdr.LedgerEntry{twoEurOffer}
+	asksButNoBids := []Offer{twoEurOffer}
 	asksButNoBidsResponse := OrderBookSummary{
 		Asks: []PriceLevel{
 			{
-				Pricen: int32(twoEurOffer.Data.Offer.Price.N),
-				Priced: int32(twoEurOffer.Data.Offer.Price.D),
+				Pricen: int32(twoEurOffer.Pricen),
+				Priced: int32(twoEurOffer.Priced),
 				Pricef: "2.0000000",
 				Amount: "0.0000500",
 			},
 		},
 	}
 
-	sellEurOffer := xdr.LedgerEntry{
-		LastModifiedLedgerSeq: 1234,
-		Data: xdr.LedgerEntryData{
-			Type: xdr.LedgerEntryTypeOffer,
-			Offer: &xdr.OfferEntry{
-				SellerId: twoEurOfferSeller,
-				OfferId:  xdr.Int64(15),
-				Buying:   nativeAsset,
-				Selling:  eurAsset,
-				Price: xdr.Price{
-					N: 2,
-					D: 1,
-				},
-				Flags:  2,
-				Amount: xdr.Int64(500),
-			},
-		},
+	sellEurOffer := Offer{
+		SellerID: twoEurOfferSeller.Address(),
+		OfferID:  int64(15),
+
+		BuyingAsset:  nativeAsset,
+		SellingAsset: eurAsset,
+
+		Amount:             int64(500),
+		Pricen:             int32(2),
+		Priced:             int32(1),
+		Price:              float64(2),
+		Flags:              2,
+		LastModifiedLedger: uint32(1234),
 	}
 
-	bidsButNoAsks := []xdr.LedgerEntry{sellEurOffer}
+	bidsButNoAsks := []Offer{sellEurOffer}
 	bidsButNoAsksResponse := OrderBookSummary{
 		Bids: []PriceLevel{
 			{
-				Pricen: int32(sellEurOffer.Data.Offer.Price.D),
-				Priced: int32(sellEurOffer.Data.Offer.Price.N),
+				Pricen: int32(sellEurOffer.Priced),
+				Priced: int32(sellEurOffer.Pricen),
 				Pricef: "0.5000000",
 				Amount: "0.0000500",
 			},
 		},
 	}
 
-	otherEurOffer := xdr.LedgerEntry{
-		LastModifiedLedgerSeq: 1234,
-		Data: xdr.LedgerEntryData{
-			Type: xdr.LedgerEntryTypeOffer,
-			Offer: &xdr.OfferEntry{
-				SellerId: twoEurOfferSeller,
-				OfferId:  xdr.Int64(6),
-				Buying:   eurAsset,
-				Selling:  nativeAsset,
-				Price: xdr.Price{
-					N: 2,
-					D: 1,
-				},
-				Flags:  2,
-				Amount: xdr.Int64(math.MaxInt64),
-			},
-		},
+	otherEurOffer := Offer{
+		SellerID: twoEurOfferSeller.Address(),
+		OfferID:  int64(6),
+
+		BuyingAsset:  eurAsset,
+		SellingAsset: nativeAsset,
+
+		Amount:             int64(math.MaxInt64),
+		Pricen:             int32(2),
+		Priced:             int32(1),
+		Price:              float64(2),
+		Flags:              2,
+		LastModifiedLedger: uint32(1234),
 	}
 
-	nonCanonicalPriceTwoEurOffer := xdr.LedgerEntry{
-		LastModifiedLedgerSeq: 1234,
-		Data: xdr.LedgerEntryData{
-			Type: xdr.LedgerEntryTypeOffer,
-			Offer: &xdr.OfferEntry{
-				SellerId: twoEurOfferSeller,
-				OfferId:  xdr.Int64(30),
-				Buying:   eurAsset,
-				Selling:  nativeAsset,
-				Price: xdr.Price{
-					// Add a separate offer with the same price value, but
-					// using a non-canonical representation, to make sure
-					// they are coalesced into the same price level
-					N: 2 * 15,
-					D: 1 * 15,
-				},
-				Flags:  2,
-				Amount: xdr.Int64(500),
-			},
-		},
+	nonCanonicalPriceTwoEurOffer := Offer{
+		SellerID: twoEurOfferSeller.Address(),
+		OfferID:  int64(30),
+
+		BuyingAsset:  eurAsset,
+		SellingAsset: nativeAsset,
+
+		Amount:             int64(500),
+		Pricen:             int32(2 * 15),
+		Priced:             int32(1 * 15),
+		Price:              float64(2),
+		Flags:              2,
+		LastModifiedLedger: uint32(1234),
 	}
 
-	otherSellEurOffer := xdr.LedgerEntry{
-		LastModifiedLedgerSeq: 1234,
-		Data: xdr.LedgerEntryData{
-			Type: xdr.LedgerEntryTypeOffer,
-			Offer: &xdr.OfferEntry{
-				SellerId: twoEurOfferSeller,
-				OfferId:  xdr.Int64(17),
-				Buying:   nativeAsset,
-				Selling:  eurAsset,
-				Price: xdr.Price{
-					N: 9,
-					D: 5,
-				},
-				Flags:  2,
-				Amount: xdr.Int64(500),
-			},
-		},
+	otherSellEurOffer := Offer{
+		SellerID: twoEurOfferSeller.Address(),
+		OfferID:  int64(17),
+
+		BuyingAsset:  nativeAsset,
+		SellingAsset: eurAsset,
+
+		Amount:             int64(500),
+		Pricen:             int32(9),
+		Priced:             int32(5),
+		Price:              float64(9) / float64(5),
+		Flags:              2,
+		LastModifiedLedger: uint32(1234),
 	}
 
-	fullOffers := []xdr.LedgerEntry{
+	fullOffers := []Offer{
 		twoEurOffer,
 		otherEurOffer,
 		nonCanonicalPriceTwoEurOffer,
@@ -147,28 +127,28 @@ func TestGetOrderBookSummary(t *testing.T) {
 	fullResponse := OrderBookSummary{
 		Asks: []PriceLevel{
 			{
-				Pricen: int32(twoEurOffer.Data.Offer.Price.N),
-				Priced: int32(twoEurOffer.Data.Offer.Price.D),
+				Pricen: int32(twoEurOffer.Pricen),
+				Priced: int32(twoEurOffer.Priced),
 				Pricef: "2.0000000",
 				Amount: "922337203685.4776807",
 			},
 			{
-				Pricen: int32(threeEurOffer.Data.Offer.Price.N),
-				Priced: int32(threeEurOffer.Data.Offer.Price.D),
+				Pricen: int32(threeEurOffer.Pricen),
+				Priced: int32(threeEurOffer.Priced),
 				Pricef: "3.0000000",
 				Amount: "0.0000500",
 			},
 		},
 		Bids: []PriceLevel{
 			{
-				Pricen: int32(otherSellEurOffer.Data.Offer.Price.D),
-				Priced: int32(otherSellEurOffer.Data.Offer.Price.N),
+				Pricen: int32(otherSellEurOffer.Priced),
+				Priced: int32(otherSellEurOffer.Pricen),
 				Pricef: "0.5555556",
 				Amount: "0.0000500",
 			},
 			{
-				Pricen: int32(sellEurOffer.Data.Offer.Price.D),
-				Priced: int32(sellEurOffer.Data.Offer.Price.N),
+				Pricen: int32(sellEurOffer.Priced),
+				Priced: int32(sellEurOffer.Pricen),
 				Pricef: "0.5000000",
 				Amount: "0.0000500",
 			},
@@ -178,16 +158,16 @@ func TestGetOrderBookSummary(t *testing.T) {
 	limitResponse := OrderBookSummary{
 		Asks: []PriceLevel{
 			{
-				Pricen: int32(twoEurOffer.Data.Offer.Price.N),
-				Priced: int32(twoEurOffer.Data.Offer.Price.D),
+				Pricen: int32(twoEurOffer.Pricen),
+				Priced: int32(twoEurOffer.Priced),
 				Pricef: "2.0000000",
 				Amount: "922337203685.4776807",
 			},
 		},
 		Bids: []PriceLevel{
 			{
-				Pricen: int32(otherSellEurOffer.Data.Offer.Price.D),
-				Priced: int32(otherSellEurOffer.Data.Offer.Price.N),
+				Pricen: int32(otherSellEurOffer.Priced),
+				Priced: int32(otherSellEurOffer.Pricen),
 				Pricef: "0.5555556",
 				Amount: "0.0000500",
 			},
@@ -196,13 +176,13 @@ func TestGetOrderBookSummary(t *testing.T) {
 
 	for _, testCase := range []struct {
 		name     string
-		offers   []xdr.LedgerEntry
+		offers   []Offer
 		limit    int
 		expected OrderBookSummary
 	}{
 		{
 			"empty orderbook",
-			[]xdr.LedgerEntry{},
+			[]Offer{},
 			10,
 			OrderBookSummary{},
 		},
@@ -259,26 +239,22 @@ func TestGetOrderBookSummaryExcludesRemovedOffers(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	sellEurOffer := xdr.LedgerEntry{
-		LastModifiedLedgerSeq: 1234,
-		Data: xdr.LedgerEntryData{
-			Type: xdr.LedgerEntryTypeOffer,
-			Offer: &xdr.OfferEntry{
-				SellerId: twoEurOfferSeller,
-				OfferId:  xdr.Int64(15),
-				Buying:   nativeAsset,
-				Selling:  eurAsset,
-				Price: xdr.Price{
-					N: 2,
-					D: 1,
-				},
-				Flags:  2,
-				Amount: xdr.Int64(500),
-			},
-		},
+	sellEurOffer := Offer{
+		SellerID: twoEurOfferSeller.Address(),
+		OfferID:  int64(15),
+
+		BuyingAsset:  nativeAsset,
+		SellingAsset: eurAsset,
+
+		Amount:             int64(500),
+		Pricen:             int32(2),
+		Priced:             int32(1),
+		Price:              float64(2),
+		Flags:              2,
+		LastModifiedLedger: uint32(1234),
 	}
 
-	offers := []xdr.LedgerEntry{
+	offers := []Offer{
 		twoEurOffer,
 		threeEurOffer,
 		sellEurOffer,
@@ -304,7 +280,7 @@ func TestGetOrderBookSummaryExcludesRemovedOffers(t *testing.T) {
 
 	for i, offer := range offers {
 		var count int64
-		count, err = q.RemoveOffer(offer.Data.Offer.OfferId, uint32(i+2))
+		count, err = q.RemoveOffer(offer.OfferID, uint32(i+2))
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1), count)
 	}

--- a/services/horizon/internal/expingest/orderbook.go
+++ b/services/horizon/internal/expingest/orderbook.go
@@ -90,10 +90,10 @@ func addOfferToGraph(graph orderbook.OBGraph, offer history.Offer) {
 	sellerID := xdr.MustAddress(offer.SellerID)
 	graph.AddOffer(xdr.OfferEntry{
 		SellerId: sellerID,
-		OfferId:  offer.OfferID,
+		OfferId:  xdr.Int64(offer.OfferID),
 		Selling:  offer.SellingAsset,
 		Buying:   offer.BuyingAsset,
-		Amount:   offer.Amount,
+		Amount:   xdr.Int64(offer.Amount),
 		Price: xdr.Price{
 			N: xdr.Int32(offer.Pricen),
 			D: xdr.Int32(offer.Priced),
@@ -165,7 +165,7 @@ func (o *OrderBookStream) update(status ingestionStatus) (bool, error) {
 	}
 	for _, offer := range offers {
 		if offer.Deleted {
-			o.graph.RemoveOffer(offer.OfferID)
+			o.graph.RemoveOffer(xdr.Int64(offer.OfferID))
 		} else {
 			addOfferToGraph(o.graph, offer)
 		}
@@ -203,8 +203,8 @@ func (o *OrderBookStream) verifyAllOffers() {
 
 		for i, offerRow := range ingestionOffers {
 			offerEntry := offers[i]
-			if offerRow.OfferID != offerEntry.OfferId ||
-				offerRow.Amount != offerEntry.Amount ||
+			if xdr.Int64(offerRow.OfferID) != offerEntry.OfferId ||
+				xdr.Int64(offerRow.Amount) != offerEntry.Amount ||
 				offerRow.Priced != int32(offerEntry.Price.D) ||
 				offerRow.Pricen != int32(offerEntry.Price.N) ||
 				!offerRow.BuyingAsset.Equals(offerEntry.Buying) ||

--- a/services/horizon/internal/expingest/orderbook_test.go
+++ b/services/horizon/internal/expingest/orderbook_test.go
@@ -3,11 +3,12 @@ package expingest
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/suite"
-	"testing"
-	"time"
 )
 
 type IngestionStatusTestSuite struct {
@@ -427,7 +428,7 @@ func (t *UpdateOrderBookStreamTestSuite) mockUpdate() {
 
 	t.graph.On("AddOffer", offerEntry).Return().Once()
 	t.graph.On("AddOffer", otherOfferEntry).Return().Once()
-	t.graph.On("RemoveOffer", deletedOffer.OfferID).Return(t.graph).Once()
+	t.graph.On("RemoveOffer", xdr.Int64(deletedOffer.OfferID)).Return(t.graph).Once()
 }
 
 func (t *UpdateOrderBookStreamTestSuite) TestApplyUpdatesError() {

--- a/services/horizon/internal/expingest/processors/main.go
+++ b/services/horizon/internal/expingest/processors/main.go
@@ -1,7 +1,22 @@
 package processors
 
-import logpkg "github.com/stellar/go/support/log"
+import (
+	"github.com/guregu/null"
+	logpkg "github.com/stellar/go/support/log"
+	"github.com/stellar/go/xdr"
+)
 
 var log = logpkg.DefaultLogger.WithField("service", "expingest")
 
 const maxBatchSize = 100000
+
+func ledgerEntrySponsorToNullString(entry xdr.LedgerEntry) null.String {
+	sponsoringID := entry.SponsoringID()
+
+	var sponsor null.String
+	if sponsoringID != nil {
+		sponsor.SetValid((*sponsoringID).Address())
+	}
+
+	return sponsor
+}

--- a/services/horizon/internal/expingest/processors/offers_processor_test.go
+++ b/services/horizon/internal/expingest/processors/offers_processor_test.go
@@ -60,7 +60,14 @@ func (s *OffersProcessorTestSuiteState) TestCreateOffer() {
 		LastModifiedLedgerSeq: lastModifiedLedgerSeq,
 	}
 
-	s.mockBatchInsertBuilder.On("Add", entry).Return(nil).Once()
+	s.mockBatchInsertBuilder.On("Add", history.Offer{
+		SellerID:           "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+		OfferID:            1,
+		Pricen:             int32(1),
+		Priced:             int32(2),
+		Price:              float64(0.5),
+		LastModifiedLedger: uint32(lastModifiedLedgerSeq),
+	}).Return(nil).Once()
 
 	err := s.processor.ProcessChange(io.Change{
 		Type: xdr.LedgerEntryTypeOffer,
@@ -165,7 +172,14 @@ func (s *OffersProcessorTestSuiteLedger) setupInsertOffer() {
 	s.Assert().NoError(err)
 
 	// We use LedgerEntryChangesCache so all changes are squashed
-	s.mockBatchInsertBuilder.On("Add", updatedEntry).Return(nil).Once()
+	s.mockBatchInsertBuilder.On("Add", history.Offer{
+		SellerID:           "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+		OfferID:            2,
+		Pricen:             int32(1),
+		Priced:             int32(6),
+		Price:              float64(1) / float64(6),
+		LastModifiedLedger: uint32(lastModifiedLedgerSeq),
+	}).Return(nil).Once()
 
 	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
 }
@@ -230,7 +244,14 @@ func (s *OffersProcessorTestSuiteLedger) TestUpdateOfferNoRowsAffected() {
 	})
 	s.Assert().NoError(err)
 
-	s.mockQ.On("UpdateOffer", updatedEntry).Return(int64(0), nil).Once()
+	s.mockQ.On("UpdateOffer", history.Offer{
+		SellerID:           "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+		OfferID:            2,
+		Pricen:             int32(1),
+		Priced:             int32(6),
+		Price:              float64(1) / float64(6),
+		LastModifiedLedger: uint32(lastModifiedLedgerSeq),
+	}).Return(int64(0), nil).Once()
 
 	err = s.processor.Commit()
 	s.Assert().Error(err)
@@ -255,11 +276,7 @@ func (s *OffersProcessorTestSuiteLedger) TestRemoveOffer() {
 	})
 	s.Assert().NoError(err)
 
-	s.mockQ.On(
-		"RemoveOffer",
-		xdr.Int64(3),
-		s.sequence,
-	).Return(int64(1), nil).Once()
+	s.mockQ.On("RemoveOffer", int64(3), s.sequence).Return(int64(1), nil).Once()
 
 	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
 	s.mockQ.On("CompactOffers", s.sequence-100).Return(int64(0), nil).Once()
@@ -315,7 +332,14 @@ func (s *OffersProcessorTestSuiteLedger) TestProcessUpgradeChange() {
 	s.Assert().NoError(err)
 
 	// We use LedgerEntryChangesCache so all changes are squashed
-	s.mockBatchInsertBuilder.On("Add", updatedEntry).Return(nil).Once()
+	s.mockBatchInsertBuilder.On("Add", history.Offer{
+		SellerID:           "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+		OfferID:            2,
+		Pricen:             int32(1),
+		Priced:             int32(6),
+		Price:              float64(1) / float64(6),
+		LastModifiedLedger: uint32(lastModifiedLedgerSeq),
+	}).Return(nil).Once()
 
 	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
 	s.mockQ.On("CompactOffers", s.sequence-100).Return(int64(0), nil).Once()
@@ -339,11 +363,7 @@ func (s *OffersProcessorTestSuiteLedger) TestRemoveOfferNoRowsAffected() {
 	})
 	s.Assert().NoError(err)
 
-	s.mockQ.On(
-		"RemoveOffer",
-		xdr.Int64(3),
-		s.sequence,
-	).Return(int64(0), nil).Once()
+	s.mockQ.On("RemoveOffer", int64(3), s.sequence).Return(int64(0), nil).Once()
 
 	err = s.processor.Commit()
 	s.Assert().Error(err)

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -458,10 +458,10 @@ func addOffersToStateVerifier(
 				Type: xdr.LedgerEntryTypeOffer,
 				Offer: &xdr.OfferEntry{
 					SellerId: xdr.MustAddress(row.SellerID),
-					OfferId:  row.OfferID,
+					OfferId:  xdr.Int64(row.OfferID),
 					Selling:  row.SellingAsset,
 					Buying:   row.BuyingAsset,
-					Amount:   row.Amount,
+					Amount:   xdr.Int64(row.Amount),
 					Price: xdr.Price{
 						N: xdr.Int32(row.Pricen),
 						D: xdr.Int32(row.Priced),

--- a/services/horizon/internal/expingest/verify_range_state_test.go
+++ b/services/horizon/internal/expingest/verify_range_state_test.go
@@ -370,10 +370,10 @@ func (s *VerifyRangeStateTestSuite) TestSuccessWithVerify() {
 	clonedQ.MockQSigners.On("CountAccounts").Return(1, nil).Once()
 	mockOffer := history.Offer{
 		SellerID:           eurOffer.SellerId.Address(),
-		OfferID:            eurOffer.OfferId,
+		OfferID:            int64(eurOffer.OfferId),
 		SellingAsset:       eurOffer.Selling,
 		BuyingAsset:        eurOffer.Buying,
-		Amount:             eurOffer.Amount,
+		Amount:             int64(eurOffer.Amount),
 		Pricen:             int32(eurOffer.Price.N),
 		Priced:             int32(eurOffer.Price.D),
 		Price:              float64(eurOffer.Price.N) / float64(eurOffer.Price.N),

--- a/services/horizon/internal/resourceadapter/offer.go
+++ b/services/horizon/internal/resourceadapter/offer.go
@@ -10,6 +10,7 @@ import (
 	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/render/hal"
+	"github.com/stellar/go/xdr"
 )
 
 // PopulateOffer constructs an offer response struct from an offer row extracted from the
@@ -18,7 +19,7 @@ func PopulateOffer(ctx context.Context, dest *protocol.Offer, row history.Offer,
 	dest.ID = int64(row.OfferID)
 	dest.PT = fmt.Sprintf("%d", row.OfferID)
 	dest.Seller = row.SellerID
-	dest.Amount = amount.String(row.Amount)
+	dest.Amount = amount.String(xdr.Int64(row.Amount))
 	dest.PriceR.N = row.Pricen
 	dest.PriceR.D = row.Priced
 	dest.Price = big.NewRat(int64(row.Pricen), int64(row.Priced)).FloatString(7)

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -84,8 +84,7 @@ type SelectBuilder struct {
 type UpdateBuilder struct {
 	Table *Table
 
-	source interface{}
-	sql    squirrel.UpdateBuilder
+	sql squirrel.UpdateBuilder
 }
 
 // Session provides helper methods for making queries against `DB` and provides

--- a/support/db/table.go
+++ b/support/db/table.go
@@ -78,20 +78,11 @@ func (tbl *Table) Select(
 	}
 }
 
-// Update returns a new query builder configured to update rows that match the
-// predicate with the values of the provided source struct.  See docs for
-// `UpdateBuildeExec` for more documentation.
-func (tbl *Table) Update(
-	source interface{},
-	pred interface{},
-	args ...interface{},
-) *UpdateBuilder {
-
-	sql := sq.Update(tbl.Name).Where(pred, args...)
-
+// Update returns a new query builder configured to update the table.
+// See docs for `UpdateBuilderExec` for more documentation.
+func (tbl *Table) Update() *UpdateBuilder {
 	return &UpdateBuilder{
-		Table:  tbl,
-		source: source,
-		sql:    sql,
+		Table: tbl,
+		sql:   sq.Update(tbl.Name),
 	}
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit aims to fix separation of concerns related to ingestion in Horizon: starting with offers. All methods in `QOffers` interface (and `OffersBatchInsertBuilder`) accept `services/horizon/db2/history.Offer` instead of `xdr.LedgerEntry`.

It also removes creating map used in `SetMap` using `xdr.LedgerEntry`. Instead, `support/db.UpdateBuilder.SetStruct` is used.

### Why

The DB package (`services/horizon/db2`) should have no knowledge about how to ingest `xdr` objects into database rows. Unfortunately, we are passing a lot of `xdr` objects like `xdr.LedgerEntry` to DB package methods. This makes it more complicated, duplicates code and makes tests confusing. By doing this the `assertOfferEntryMatchesDBOffer` could be removed simplifying DB tests.