### PR TITLE
services/horizon: Wrap invalid cursor in claimable balances in problem.P

### DIFF
--- a/services/horizon/internal/actions/claimable_balance.go
+++ b/services/horizon/internal/actions/claimable_balance.go
@@ -155,6 +155,14 @@ func (handler GetClaimableBalancesHandler) GetResourcePage(
 		Claimant:  qp.claimant(),
 	}
 
+	_, _, err = query.Cursor()
+	if err != nil {
+		return nil, problem.MakeInvalidFieldProblem(
+			"cursor",
+			errors.New("First part should be higher than 0 and second part should be valid claimable balance ID"),
+		)
+	}
+
 	historyQ, err := horizonContext.HistoryQFromRequest(r)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Wrap invalid cursor in claimable balances in `problem.P`

### Why

We do cursor validation, however, if there is an error we return a
plain error instead of a `problem.P` -- this causes horizon to handle
the error as a `500` instead of a `400`.

This fix moves cursor parsing to its own method and then use it in the
query handler to return a `problem.P` error which causes horizon to
return the correct response.

I opted to create a new error instead of returning the inner error
since it exposes low-level details which are not relevant for the API
user, for example:

- `Invalid cursor - first value should be higher than 0: strconv.ParseInt: parsing \"\": invalid syntax`
- `Invalid cursor - second value should be a valid claimable balance id: xdr:decode: switch '67' is not valid enum value for union`


Fixes https://github.com/stellar/go/issues/3085.


### Known limitations