### PR TITLE
services/horizon: Fix typo on cursor error and improve message.

### DIFF
--- a/services/horizon/internal/actions/claimable_balance.go
+++ b/services/horizon/internal/actions/claimable_balance.go
@@ -159,7 +159,7 @@ func (handler GetClaimableBalancesHandler) GetResourcePage(
 	if err != nil {
 		return nil, problem.MakeInvalidFieldProblem(
 			"cursor",
-			errors.New("First part should be higher than 0 and second part should be valid claimable balance ID"),
+			errors.New("The first part should be a number higher than 0 and the second part should be a valid claimable balance ID"),
 		)
 	}
 

--- a/services/horizon/internal/actions/claimable_balance_test.go
+++ b/services/horizon/internal/actions/claimable_balance_test.go
@@ -544,7 +544,7 @@ func TestCursorAndOrderValidation(t *testing.T) {
 	p := err.(*problem.P)
 	tt.Assert.Equal("bad_request", p.Type)
 	tt.Assert.Equal("cursor", p.Extras["invalid_field"])
-	tt.Assert.Equal("First part should be higher than 0 and second part should be valid claimable balance ID", p.Extras["reason"])
+	tt.Assert.Equal("The first part should be a number higher than 0 and the second part should be a valid claimable balance ID", p.Extras["reason"])
 
 	_, err = handler.GetResourcePage(httptest.NewRecorder(), makeRequest(
 		t,
@@ -557,7 +557,7 @@ func TestCursorAndOrderValidation(t *testing.T) {
 	p = err.(*problem.P)
 	tt.Assert.Equal("bad_request", p.Type)
 	tt.Assert.Equal("cursor", p.Extras["invalid_field"])
-	tt.Assert.Equal("First part should be higher than 0 and second part should be valid claimable balance ID", p.Extras["reason"])
+	tt.Assert.Equal("The first part should be a number higher than 0 and the second part should be a valid claimable balance ID", p.Extras["reason"])
 
 	_, err = handler.GetResourcePage(httptest.NewRecorder(), makeRequest(
 		t,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Re-write error message when cursor is invalid.

### Why

There was a typo on the first message.

### Known limitations

[TODO or N/A]