### PR TITLE
service/horizon: Add protocol version support check

### DIFF
--- a/services/horizon/internal/expingest/db_integration_test.go
+++ b/services/horizon/internal/expingest/db_integration_test.go
@@ -124,7 +124,7 @@ func (s *DBTestSuite) setupMocksForBuildState() {
 				},
 			},
 			nil,
-		).Once()
+		).Twice()
 }
 
 func (s *DBTestSuite) TearDownTest() {

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -22,6 +22,10 @@ import (
 )
 
 const (
+	// MaxSupportedProtocolVersion defines the maximum supported version of
+	// the Stellar protocol.
+	MaxSupportedProtocolVersion = 14
+
 	// CurrentVersion reflects the latest version of the ingestion
 	// algorithm. This value is stored in KV store and is used to decide
 	// if there's a need to reprocess the ledger state or reingest data.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Check if Horizon version supports the protocol version in a ledger header.

### Why

Right now, when Horizon does not support the upcoming protocol version it prints ugly errors connected to errors in XDR unmarshalling. Checking a protocol version before ingestion allows printing an user friendly message asking to upgrade Horizon.