### PR TITLE
support/render/problem: Silent errors only when LogNoErrors set

### DIFF
--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -175,7 +175,7 @@ func (ps *Problem) Render(ctx context.Context, w http.ResponseWriter, err error)
 		// If this error is not a registered error
 		// log it and replace it with a 500 error
 		if !ok {
-			if ps.filter == LogUnknownErrors {
+			if ps.filter != LogNoErrors {
 				ps.log.Ctx(ctx).WithStack(err).Error(err)
 			}
 			if ps.reportFn != nil {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Silent errors in `Problem.Render` only when `LogNoErrors` set.

Close #3084.

### Why

We want to be notified about unknown errors with `error` level.