### PR TITLE
services/horizon: Add claimable_balances table to state tables to truncate

### DIFF
--- a/services/horizon/internal/db2/history/ingestion.go
+++ b/services/horizon/internal/db2/history/ingestion.go
@@ -10,6 +10,7 @@ func (q *Q) TruncateExpingestStateTables() error {
 		"accounts",
 		"accounts_data",
 		"accounts_signers",
+		"claimable_balances",
 		"exp_asset_stats",
 		"offers",
 		"trust_lines",

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -46,7 +46,9 @@ const (
 	// - 10: Fixes a bug in meta processing (fees are now processed before
 	//      everything else).
 	// - 11: Protocol 14: CAP-23 and CAP-33.
-	CurrentVersion = 11
+	// - 12: Trigger state rebuild due to `absTime` -> `abs_time` rename
+	//       in ClaimableBalances predicates.
+	CurrentVersion = 12
 
 	// MaxDBConnections is the size of the postgres connection pool dedicated to Horizon ingestion:
 	//  * Ledger ingestion,

--- a/services/horizon/internal/expingest/verify.go
+++ b/services/horizon/internal/expingest/verify.go
@@ -27,7 +27,7 @@ const assetStatsBatchSize = 500
 // check them.
 // There is a test that checks it, to fix it: update the actual `verifyState`
 // method instead of just updating this value!
-const stateVerifierExpectedIngestionVersion = 11
+const stateVerifierExpectedIngestionVersion = 12
 
 // verifyState is called as a go routine from pipeline post hook every 64
 // ledgers. It checks if the state is correct. If another go routine is already


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

Add `claimable_balances` table to state tables so it's truncated when rebuilding state.