### PR TITLE
services/horizon: Refactor handling of stellar-core-binary-path

### DIFF
--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -215,12 +215,12 @@ var dbReingestRangeCmd = &cobra.Command{
 			HistoryArchiveURL:           config.HistoryArchiveURLs[0],
 			MaxReingestRetries:          int(retries),
 			ReingestRetryBackoffSeconds: int(retryBackoffSeconds),
+			EnableCaptiveCore:           config.EnableCaptiveCoreIngestion,
+			StellarCoreBinaryPath:       config.StellarCoreBinaryPath,
+			RemoteCaptiveCoreURL:        config.RemoteCaptiveCoreURL,
 		}
 
-		if config.EnableCaptiveCoreIngestion {
-			ingestConfig.StellarCoreBinaryPath = config.StellarCoreBinaryPath
-			ingestConfig.RemoteCaptiveCoreURL = config.RemoteCaptiveCoreURL
-		} else {
+		if !ingestConfig.EnableCaptiveCore {
 			if config.StellarCoreDatabaseURL == "" {
 				log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
 			}

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -98,14 +98,15 @@ var ingestVerifyRangeCmd = &cobra.Command{
 		}
 
 		ingestConfig := expingest.Config{
-			NetworkPassphrase: config.NetworkPassphrase,
-			HistorySession:    horizonSession,
-			HistoryArchiveURL: config.HistoryArchiveURLs[0],
+			NetworkPassphrase:     config.NetworkPassphrase,
+			HistorySession:        horizonSession,
+			HistoryArchiveURL:     config.HistoryArchiveURLs[0],
+			EnableCaptiveCore:     config.EnableCaptiveCoreIngestion,
+			StellarCoreBinaryPath: config.StellarCoreBinaryPath,
+			RemoteCaptiveCoreURL:  config.RemoteCaptiveCoreURL,
 		}
-		if config.EnableCaptiveCoreIngestion {
-			ingestConfig.StellarCoreBinaryPath = config.StellarCoreBinaryPath
-			ingestConfig.RemoteCaptiveCoreURL = config.RemoteCaptiveCoreURL
-		} else {
+
+		if !ingestConfig.EnableCaptiveCore {
 			if config.StellarCoreDatabaseURL == "" {
 				log.Fatalf("flag --%s cannot be empty", stellarCoreDBURLFlagName)
 			}

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -117,7 +117,7 @@ var configOpts = support.ConfigOptions{
 		OptType:     types.String,
 		FlagDefault: "",
 		Required:    false,
-		Usage:       "path to stellar core binary",
+		Usage:       "path to stellar core binary (--remote-captive-core-url has higher precedence)",
 		ConfigKey:   &config.StellarCoreBinaryPath,
 	},
 	&support.ConfigOption{
@@ -428,9 +428,6 @@ func initRootConfig() {
 		remoteURL := viper.GetString("remote-captive-core-url")
 		if binaryPath == "" && remoteURL == "" {
 			stdLog.Fatalf("Invalid config: captive core requires that either --stellar-core-binary-path or --remote-captive-core-url is set")
-		}
-		if binaryPath != "" && remoteURL != "" {
-			stdLog.Fatalf("Invalid config: --stellar-core-binary-path and --remote-captive-core-url cannot both be set.")
 		}
 	}
 	if config.Ingest {

--- a/services/horizon/internal/expingest/main.go
+++ b/services/horizon/internal/expingest/main.go
@@ -64,6 +64,7 @@ type Config struct {
 	CoreSession           *db.Session
 	StellarCoreURL        string
 	StellarCoreCursor     string
+	EnableCaptiveCore     bool
 	StellarCoreBinaryPath string
 	StellarCoreConfigPath string
 	RemoteCaptiveCoreURL  string
@@ -157,23 +158,25 @@ func NewSystem(config Config) (System, error) {
 	}
 
 	var ledgerBackend ledgerbackend.LedgerBackend
-	if len(config.RemoteCaptiveCoreURL) > 0 {
-		ledgerBackend, err = ledgerbackend.NewRemoteCaptive(config.RemoteCaptiveCoreURL)
-		if err != nil {
-			cancel()
-			return nil, errors.Wrap(err, "error creating captive core backend")
-		}
-	}
-	if len(config.StellarCoreBinaryPath) > 0 {
-		ledgerBackend, err = ledgerbackend.NewCaptive(
-			config.StellarCoreBinaryPath,
-			config.StellarCoreConfigPath,
-			config.NetworkPassphrase,
-			[]string{config.HistoryArchiveURL},
-		)
-		if err != nil {
-			cancel()
-			return nil, errors.Wrap(err, "error creating captive core backend")
+	if config.EnableCaptiveCore {
+		if len(config.RemoteCaptiveCoreURL) > 0 {
+			ledgerBackend, err = ledgerbackend.NewRemoteCaptive(config.RemoteCaptiveCoreURL)
+			if err != nil {
+				cancel()
+				return nil, errors.Wrap(err, "error creating captive core backend")
+			}
+		} else {
+			//
+			ledgerBackend, err = ledgerbackend.NewCaptive(
+				config.StellarCoreBinaryPath,
+				config.StellarCoreConfigPath,
+				config.NetworkPassphrase,
+				[]string{config.HistoryArchiveURL},
+			)
+			if err != nil {
+				cancel()
+				return nil, errors.Wrap(err, "error creating captive core backend")
+			}
 		}
 	} else {
 		coreSession := config.CoreSession.Clone()


### PR DESCRIPTION
Containers and configurations should be allowed to set `--stellar-core-binary-path` regardless of the behavior we want from Horizon.

1. Do not assume that a non-empty `--stellar-core-binary-path` (or `--remote-captive-core-url`) implies captive core should be used (use the pre-existing `--enable-captive-core-ingestion` as a tollgate instead).
2. Allow setting both `--remote-captive-core-url` and `--stellar-core-binary-path` simultaneously, associating a higher priority to the URL.

Fixes #2973 