### PR TITLE
services/horizon: Check state rebuild in state verification integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,7 +408,7 @@ jobs:
           command: |
             cd ~/go/src/github.com/stellar/go
             docker pull stellar/quickstart:testing
-            go test -timeout 20m -v ./services/horizon/internal/integration/...
+            go test -timeout 25m -v ./services/horizon/internal/integration/...
 #-------------------------------------------------------------------------#
 # Workflows orchestrate jobs and make sure they run in the right sequence #
 #-------------------------------------------------------------------------#

--- a/services/horizon/internal/integration/protocol14_state_verifier_test.go
+++ b/services/horizon/internal/integration/protocol14_state_verifier_test.go
@@ -100,14 +100,39 @@ func TestProtocol14StateVerifier(t *testing.T) {
 
 	// Wait for the first checkpoint ledger
 	for !itest.LedgerIngested(63) {
-		t.Log("First checkpoint ledger (63) not closed yet...")
+		t.Log("First checkpoint ledger (63) not ingested yet...")
 		time.Sleep(5 * time.Second)
 	}
 
-	var metrics string
+	verified := waitForStateVerifications(t, itest, 1)
+	if !verified {
+		t.Fatal("State verification not run...")
+	}
 
+	// Trigger state rebuild to check if ingesting from history archive works
+	itest.RunHorizonCLICommand([]string{"expingest", "trigger-state-rebuild"})
+
+	// Wait for the second checkpoint ledger and state rebuild
+	for !itest.LedgerClosed(127) {
+		t.Log("First checkpoint ledger (127) not closed yet...")
+		time.Sleep(5 * time.Second)
+	}
+
+	// Wait for the third checkpoint ledger and state verification trigger
+	for !itest.LedgerIngested(191) {
+		t.Log("First checkpoint ledger (191) not ingested yet...")
+		time.Sleep(5 * time.Second)
+	}
+
+	verified = waitForStateVerifications(t, itest, 2)
+	if !verified {
+		t.Fatal("State verification not run...")
+	}
+}
+
+func waitForStateVerifications(t *testing.T, itest *test.IntegrationTest, count int) bool {
 	// Check metrics until state verification run
-	for i := 0; i < 60; i++ {
+	for i := 0; i < 120; i++ {
 		t.Logf("Checking metrics (%d attempt)\n", i)
 		res, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", itest.AdminPort()))
 		assert.NoError(t, err)
@@ -115,19 +140,22 @@ func TestProtocol14StateVerifier(t *testing.T) {
 		metricsBytes, err := ioutil.ReadAll(res.Body)
 		res.Body.Close()
 		assert.NoError(t, err)
-		metrics = string(metricsBytes)
+		metrics := string(metricsBytes)
 
 		stateInvalid := strings.Contains(metrics, "horizon_ingest_state_invalid 1")
 		assert.False(t, stateInvalid, "State is invalid!")
 
-		notVerifiedYet := strings.Contains(metrics, "horizon_ingest_state_verify_duration_seconds_count 0")
+		notVerifiedYet := strings.Contains(
+			metrics,
+			fmt.Sprintf("horizon_ingest_state_verify_duration_seconds_count %d", count-1),
+		)
 		if notVerifiedYet {
 			time.Sleep(time.Second)
 			continue
 		}
 
-		return
+		return true
 	}
 
-	t.Fatal("State verification not run...")
+	return false
 }

--- a/services/horizon/internal/test/integration.go
+++ b/services/horizon/internal/test/integration.go
@@ -208,6 +208,20 @@ func (i *IntegrationTest) LedgerIngested(sequence uint32) bool {
 	return root.IngestSequence >= sequence
 }
 
+// LedgerClosed returns true if the ledger with a given sequence has been
+// closed by Stellar-Core. Panics in case of errors. Note it's different
+// than LedgerIngested because it checks if the ledger was closed, not
+// necessarily ingested (ex. when rebuilding state Horizon does not ingest
+// recent ledgers).
+func (i *IntegrationTest) LedgerClosed(sequence uint32) bool {
+	root, err := i.Client().Root()
+	if err != nil {
+		panic(err)
+	}
+
+	return root.CoreSequence >= int32(sequence)
+}
+
 // AdminPort returns Horizon admin port.
 func (i *IntegrationTest) AdminPort() int {
 	return 6060
@@ -491,6 +505,20 @@ func (i *IntegrationTest) LogFailedTx(txResponse proto.Transaction, horizonResul
 	assert.NoErrorf(t, err, "Unmarshalling transaction failed.")
 	assert.Equalf(t, xdr.TransactionResultCodeTxSuccess, txResult.Result.Code,
 		"Transaction doesn't have success code.")
+}
+
+func (i *IntegrationTest) RunHorizonCLICommand(cmd []string) {
+	fullCmd := append([]string{"/stellar/horizon/bin/horizon"}, cmd...)
+	id, err := i.cli.ContainerExecCreate(
+		context.Background(),
+		i.container.ID,
+		types.ExecConfig{
+			Cmd: fullCmd,
+		},
+	)
+	panicIf(err)
+	err = i.cli.ContainerExecStart(context.Background(), id.ID, types.ExecStartCheck{})
+	panicIf(err)
 }
 
 // Cluttering code with if err != nil is absolute nonsense.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Check state rebuild in state verification integration test.

### Why

All integration tests start from empty state so we don't test building state from history archives. Extended state verification integration test to trigger state rebuild (`horizon expingest trigger-state-rebuild`) and verify rebuild state again. Such test would catch the bugs like https://github.com/stellar/go/pull/3100 and https://github.com/stellar/go/pull/3096.

### Known limitations

It will make the test 3x slower so let's merge it after moving integration tests to nightly runs.