### PR TITLE
txnbuild: Adds a helper function to determine asset type from string.

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-* Expose a new helper function `GetAssetType()`, making it easier to determine an asset type from a string in [canonical form](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md#asset) ([#3105](https://github.com/stellar/go/pull/3105)).
+* Expose a new helper function `ParseAssetString()`, making it easier to build an `Asset` structure from a string in [canonical form](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md#asset) and check its various properties ([#3105](https://github.com/stellar/go/pull/3105)).
 
 ## [v4.0.1](https://github.com/stellar/go/releases/tag/horizonclient-v4.0.1) - 2020-10-02
 

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-* A new helper function `getAssetType()` has been introduced to make it easier to determine an asset type from an string in [canonical form](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md#asset) ([insert PR number here](https://github.com/stellar/go/pull/xxxx)).
+* Expose a new helper function `GetAssetType()`, making it easier to determine an asset type from a string in [canonical form](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md#asset) ([#3105](https://github.com/stellar/go/pull/3105)).
 
 ## [v4.0.1](https://github.com/stellar/go/releases/tag/horizonclient-v4.0.1) - 2020-10-02
 

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-* Expose a new helper function `ParseAssetString()`, making it easier to build an `Asset` structure from a string in [canonical form](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md#asset) and check its various properties ([#3105](https://github.com/stellar/go/pull/3105)).
+* Add helper function `ParseAssetString()`, making it easier to build an `Asset` structure from a string in [canonical form](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md#asset) and check its various properties ([#3105](https://github.com/stellar/go/pull/3105)).
 
 ## [v4.0.1](https://github.com/stellar/go/releases/tag/horizonclient-v4.0.1) - 2020-10-02
 

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+* A new helper function `getAssetType()` has been introduced to make it easier to determine an asset type from an string in [canonical form](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md#asset) ([insert PR number here](https://github.com/stellar/go/pull/xxxx)).
+
 ## [v4.0.1](https://github.com/stellar/go/releases/tag/horizonclient-v4.0.1) - 2020-10-02
 
 * Fixed bug in `TransactionFromXDR()` which occurs when parsing transaction XDR envelopes which contain Protocol 14 operations.

--- a/txnbuild/helpers.go
+++ b/txnbuild/helpers.go
@@ -193,31 +193,19 @@ func NewValidationError(field, message string) *ValidationError {
 	}
 }
 
-// Determines the type of an asset string in canonical form (SEP-11).
-//
-// Example:
-//     getAssetType("native") -> txnbuild.AssetTypeNative
-//     getAssetType("ABCD:G0000..[rest of issuer]") -> AssetTypeCreditAlphanum4
-//     getAssetType("ABCD1234EFGH:G0000..[rest of issuer]") -> AssetTypeCreditAlphanum12
-//
-//lint:file-ignore U1000 Created as a helper in response to user feedback.
-func GetAssetType(canonical string) (AssetType, error) {
-	defaultType := AssetTypeNative
+// Parses an asset string in canonical form (SEP-11) into an Asset structure.
+// https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md#asset
+func ParseAssetString(canonical string) (Asset, error) {
 	assets, err := xdr.BuildAssets(canonical)
 	if err != nil {
-		return defaultType, errors.Wrap(err, "failed parsing: is it in canonical (SEP-11) form?")
+		return &NativeAsset{}, errors.Wrap(err, "failed parsing: is it in canonical (SEP-11) form?")
 	}
 
-	// It returns a list, so you'll need to grab the first element.
+	// It returns a list, so we'll need to grab the first element.
 	asset, err := assetFromXDR(assets[0])
 	if err != nil {
-		return defaultType, errors.Wrap(err, "failed to create Asset from XDR")
+		return &NativeAsset{}, errors.Wrap(err, "failed to create Asset from XDR")
 	}
 
-	t, err := asset.GetType()
-	if err != nil {
-		return t, errors.Wrap(err, "failed to determine asset type")
-	}
-
-	return t, nil
+	return asset, nil
 }

--- a/txnbuild/helpers.go
+++ b/txnbuild/helpers.go
@@ -200,7 +200,8 @@ func NewValidationError(field, message string) *ValidationError {
 //     getAssetType("ABCD:G0000..[rest of issuer]") -> AssetTypeCreditAlphanum4
 //     getAssetType("ABCD1234EFGH:G0000..[rest of issuer]") -> AssetTypeCreditAlphanum12
 //
-func getAssetType(canonical string) (AssetType, error) {
+//lint:file-ignore U1000 Created as a helper in response to user feedback.
+func GetAssetType(canonical string) (AssetType, error) {
 	defaultType := AssetTypeNative
 	assets, err := xdr.BuildAssets(canonical)
 	if err != nil {

--- a/txnbuild/helpers.go
+++ b/txnbuild/helpers.go
@@ -198,13 +198,13 @@ func NewValidationError(field, message string) *ValidationError {
 func ParseAssetString(canonical string) (Asset, error) {
 	assets, err := xdr.BuildAssets(canonical)
 	if err != nil {
-		return &NativeAsset{}, errors.Wrap(err, "failed parsing: is it in canonical (SEP-11) form?")
+		return &NativeAsset{}, errors.Wrap(err, "error parsing asset string")
 	}
 
 	// It returns a list, so we'll need to grab the first element.
 	asset, err := assetFromXDR(assets[0])
 	if err != nil {
-		return &NativeAsset{}, errors.Wrap(err, "failed to create Asset from XDR")
+		return &NativeAsset{}, errors.Wrap(err, "error parsing asset string via XDR types")
 	}
 
 	return asset, nil

--- a/txnbuild/helpers.go
+++ b/txnbuild/helpers.go
@@ -192,3 +192,31 @@ func NewValidationError(field, message string) *ValidationError {
 		Message: message,
 	}
 }
+
+// Determines the type of an asset string in canonical form (SEP-11).
+//
+// Example:
+//     getAssetType("native") -> txnbuild.AssetTypeNative
+//     getAssetType("ABCD:G0000..[rest of issuer]") -> AssetTypeCreditAlphanum4
+//     getAssetType("ABCD1234EFGH:G0000..[rest of issuer]") -> AssetTypeCreditAlphanum12
+//
+func getAssetType(canonical string) (AssetType, error) {
+	defaultType := AssetTypeNative
+	assets, err := xdr.BuildAssets(canonical)
+	if err != nil {
+		return defaultType, errors.Wrap(err, "failed parsing: is it in canonical (SEP-11) form?")
+	}
+
+	// It returns a list, so you'll need to grab the first element.
+	asset, err := assetFromXDR(assets[0])
+	if err != nil {
+		return defaultType, errors.Wrap(err, "failed to create Asset from XDR")
+	}
+
+	t, err := asset.GetType()
+	if err != nil {
+		return t, errors.Wrap(err, "failed to determine asset type")
+	}
+
+	return t, nil
+}

--- a/txnbuild/helpers.go
+++ b/txnbuild/helpers.go
@@ -197,8 +197,12 @@ func NewValidationError(field, message string) *ValidationError {
 // https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md#asset
 func ParseAssetString(canonical string) (Asset, error) {
 	assets, err := xdr.BuildAssets(canonical)
-	if err != nil || len(assets) != 1 {
+	if err != nil {
 		return nil, errors.Wrap(err, "error parsing asset string")
+	}
+
+	if len(assets) != 1 {
+		return nil, errors.New("error parsing out a single asset")
 	}
 
 	// The above returned a list, so we'll need to grab the first element.

--- a/txnbuild/helpers.go
+++ b/txnbuild/helpers.go
@@ -197,7 +197,7 @@ func NewValidationError(field, message string) *ValidationError {
 // https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md#asset
 func ParseAssetString(canonical string) (Asset, error) {
 	assets, err := xdr.BuildAssets(canonical)
-	if err != nil {
+	if err != nil || len(assets) != 1 {
 		return nil, errors.Wrap(err, "error parsing asset string")
 	}
 

--- a/txnbuild/helpers.go
+++ b/txnbuild/helpers.go
@@ -198,13 +198,13 @@ func NewValidationError(field, message string) *ValidationError {
 func ParseAssetString(canonical string) (Asset, error) {
 	assets, err := xdr.BuildAssets(canonical)
 	if err != nil {
-		return &NativeAsset{}, errors.Wrap(err, "error parsing asset string")
+		return nil, errors.Wrap(err, "error parsing asset string")
 	}
 
-	// It returns a list, so we'll need to grab the first element.
+	// The above returned a list, so we'll need to grab the first element.
 	asset, err := assetFromXDR(assets[0])
 	if err != nil {
-		return &NativeAsset{}, errors.Wrap(err, "error parsing asset string via XDR types")
+		return nil, errors.Wrap(err, "error parsing asset string via XDR types")
 	}
 
 	return asset, nil

--- a/txnbuild/helpers_test.go
+++ b/txnbuild/helpers_test.go
@@ -1,6 +1,7 @@
 package txnbuild
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stellar/go/keypair"
@@ -354,12 +355,13 @@ func TestValidateOfferManageSellOffer(t *testing.T) {
 }
 
 func TestAssetStringParsing(t *testing.T) {
-	kp0, kp1 := newKeypair0(), newKeypair1()
+	kp0 := newKeypair0()
 	cred4 := CreditAsset{Code: "ABCD", Issuer: kp0.Address()}
 	xdr, err := cred4.ToXDR()
 	assert.NoError(t, err)
 	cred4String := xdr.StringCanonical()
 
+	kp1 := newKeypair1()
 	cred12 := CreditAsset{Code: "ABCD1234EFGH", Issuer: kp1.Address()}
 	xdr, err = cred12.ToXDR()
 	assert.NoError(t, err)
@@ -395,7 +397,17 @@ func TestAssetStringParsing(t *testing.T) {
 	assert.True(t, compareAssets(cred4, assets[1]))
 	assert.True(t, compareAssets(cred12, assets[2]))
 
+	// Now sanity-check some basic error cases
+
 	result, err := ParseAssetString("erroneous:maximus")
+	assert.Error(t, err)
+	assert.Equal(t, nil, result)
+
+	result, err = ParseAssetString("erroneous:" + kp0.Address())
+	assert.Error(t, err)
+	assert.Equal(t, nil, result)
+
+	result, err = ParseAssetString(fmt.Sprintf("ABCD:%s,EFGH:%s", kp0.Address(), kp1.Address()))
 	assert.Error(t, err)
 	assert.Equal(t, nil, result)
 }

--- a/txnbuild/helpers_test.go
+++ b/txnbuild/helpers_test.go
@@ -394,4 +394,8 @@ func TestAssetStringParsing(t *testing.T) {
 	assert.True(t, compareAssets(native, assets[0]))
 	assert.True(t, compareAssets(cred4, assets[1]))
 	assert.True(t, compareAssets(cred12, assets[2]))
+
+	result, err := ParseAssetString("erroneous:maximus")
+	assert.Error(t, err)
+	assert.Equal(t, nil, result)
 }

--- a/txnbuild/helpers_test.go
+++ b/txnbuild/helpers_test.go
@@ -370,13 +370,28 @@ func TestAssetStringParsing(t *testing.T) {
 	assert.NoError(t, err)
 	nativeString := xdr.StringCanonical()
 
-	for input, expected := range map[string]AssetType{
-		nativeString: AssetTypeNative,
-		cred4String:  AssetTypeCreditAlphanum4,
-		cred12String: AssetTypeCreditAlphanum12,
-	} {
-		actual, err := GetAssetType(input)
+	assets := make([]Asset, 3)
+	for i, input := range []string{nativeString, cred4String, cred12String} {
+		actual, err := ParseAssetString(input)
 		assert.NoError(t, err)
-		assert.Equal(t, expected, actual)
+		assets[i] = actual
 	}
+
+	compareAssets := func(expected Asset, actual Asset) bool {
+		expXdr, err := expected.ToXDR()
+		if err != nil {
+			return false
+		}
+
+		actXdr, err := actual.ToXDR()
+		if err != nil {
+			return false
+		}
+
+		return expXdr.Equals(actXdr)
+	}
+
+	assert.True(t, compareAssets(native, assets[0]))
+	assert.True(t, compareAssets(cred4, assets[1]))
+	assert.True(t, compareAssets(cred12, assets[2]))
 }

--- a/txnbuild/helpers_test.go
+++ b/txnbuild/helpers_test.go
@@ -352,3 +352,30 @@ func TestValidateOfferManageSellOffer(t *testing.T) {
 	expectedErrMsg := "Field: OfferID, Error: amount can not be negative"
 	require.EqualError(t, err, expectedErrMsg, "valid offerID is required")
 }
+
+func TestAssetStringParsing(t *testing.T) {
+	kp0, kp1 := newKeypair0(), newKeypair1()
+	cred4 := CreditAsset{Code: "ABCD", Issuer: kp0.Address()}
+	xdr, err := cred4.ToXDR()
+	assert.NoError(t, err)
+	cred4String := xdr.StringCanonical()
+
+	cred12 := CreditAsset{Code: "ABCD1234EFGH", Issuer: kp1.Address()}
+	xdr, err = cred12.ToXDR()
+	assert.NoError(t, err)
+	cred12String := xdr.StringCanonical()
+
+	native := NativeAsset{}
+	xdr, err = native.ToXDR()
+	nativeString := xdr.StringCanonical()
+
+	for input, expected := range map[string]AssetType{
+		nativeString: AssetTypeNative,
+		cred4String:  AssetTypeCreditAlphanum4,
+		cred12String: AssetTypeCreditAlphanum12,
+	} {
+		actual, err := getAssetType(input)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	}
+}

--- a/txnbuild/helpers_test.go
+++ b/txnbuild/helpers_test.go
@@ -403,10 +403,6 @@ func TestAssetStringParsing(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, nil, result)
 
-	result, err = ParseAssetString("erroneous:" + kp0.Address())
-	assert.Error(t, err)
-	assert.Equal(t, nil, result)
-
 	result, err = ParseAssetString(fmt.Sprintf("ABCD:%s,EFGH:%s", kp0.Address(), kp1.Address()))
 	assert.Error(t, err)
 	assert.Equal(t, nil, result)

--- a/txnbuild/helpers_test.go
+++ b/txnbuild/helpers_test.go
@@ -372,19 +372,19 @@ func TestAssetStringParsing(t *testing.T) {
 
 	assets := make([]Asset, 3)
 	for i, input := range []string{nativeString, cred4String, cred12String} {
-		actual, err := ParseAssetString(input)
-		assert.NoError(t, err)
+		actual, innerErr := ParseAssetString(input)
+		assert.NoError(t, innerErr)
 		assets[i] = actual
 	}
 
 	compareAssets := func(expected Asset, actual Asset) bool {
-		expXdr, err := expected.ToXDR()
-		if err != nil {
+		expXdr, innerErr := expected.ToXDR()
+		if innerErr != nil {
 			return false
 		}
 
-		actXdr, err := actual.ToXDR()
-		if err != nil {
+		actXdr, innerErr := actual.ToXDR()
+		if innerErr != nil {
 			return false
 		}
 

--- a/txnbuild/helpers_test.go
+++ b/txnbuild/helpers_test.go
@@ -367,6 +367,7 @@ func TestAssetStringParsing(t *testing.T) {
 
 	native := NativeAsset{}
 	xdr, err = native.ToXDR()
+	assert.NoError(t, err)
 	nativeString := xdr.StringCanonical()
 
 	for input, expected := range map[string]AssetType{
@@ -374,7 +375,7 @@ func TestAssetStringParsing(t *testing.T) {
 		cred4String:  AssetTypeCreditAlphanum4,
 		cred12String: AssetTypeCreditAlphanum12,
 	} {
-		actual, err := getAssetType(input)
+		actual, err := GetAssetType(input)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Introduces `func ParseAssetString(string) txnbuild.Asset` and closes #2513.

### Why
Essentially, creating an asset from its string representation (and, specific to #2513, determining its type) should be easy and standardized. Refer to #2513 for more context. 

### Known limitations
The function uses `xdr.BuildAssets` internally, which states:
> Technically SEP-11 allows any string up to 12 characters not containing an unescaped colon to represent XLM 
> However, this function only accepts the string "native" to represent XLM.

meaning this technically isn't in full conformance of [SEP-11](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md#asset).