### PR TITLE
exp/services/webauth: remove the stellar.toml domain checks

### DIFF
--- a/exp/services/webauth/README.md
+++ b/exp/services/webauth/README.md
@@ -51,7 +51,6 @@ Flags:
       --network-passphrase string          Network passphrase of the Stellar network transactions should be signed for (NETWORK_PASSPHRASE) (default "Test SDF Network ; September 2015")
       --port int                           Port to listen and serve on (PORT) (default 8000)
       --signing-key string                 Stellar signing key(s) used for signing transactions comma separated (first key is used for signing, others used for verifying challenges) (SIGNING_KEY)
-      --stellar-toml-domain string         Domain where stellar.toml is served. The private key counterpart of the SIGNING_KEY specified in the stellar.toml file has to be provided via signing-key (STELLAR_TOML_DOMAIN)
 ```
 
 [SEP-10]: https://github.com/stellar/stellar-protocol/blob/28c636b4ef5074ca0c3d46bbe9bf0f3f38095233/ecosystem/sep-0010.md

--- a/exp/services/webauth/cmd/serve.go
+++ b/exp/services/webauth/cmd/serve.go
@@ -52,13 +52,6 @@ func (c *ServeCommand) Command() *cobra.Command {
 			Required:  true,
 		},
 		{
-			Name:      "stellar-toml-domain",
-			Usage:     "Domain where stellar.toml is served. The private key counterpart of the SIGNING_KEY specified in the stellar.toml file has to be provided via signing-key",
-			OptType:   types.String,
-			ConfigKey: &opts.StellarTOMLDomain,
-			Required:  true,
-		},
-		{
 			Name:      "auth-home-domain",
 			Usage:     "Home domain(s) of the service(s) requiring SEP-10 authentication comma separated (first domain is the default domain)",
 			OptType:   types.String,

--- a/exp/services/webauth/internal/serve/serve.go
+++ b/exp/services/webauth/internal/serve/serve.go
@@ -3,12 +3,10 @@ package serve
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
 
-	"github.com/BurntSushi/toml"
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/support/errors"
@@ -26,7 +24,6 @@ type Options struct {
 	Port                        int
 	NetworkPassphrase           string
 	SigningKeys                 string
-	StellarTOMLDomain           string
 	AuthHomeDomains             string
 	ChallengeExpiresIn          time.Duration
 	JWK                         string
@@ -54,7 +51,7 @@ func Serve(opts Options) {
 }
 
 func handler(opts Options) (http.Handler, error) {
-	var signingKeyFull *keypair.Full
+	signingKeys := []*keypair.Full{}
 	signingKeyStrs := strings.Split(opts.SigningKeys, ",")
 	signingAddresses := make([]*keypair.FromAddress, 0, len(signingKeyStrs))
 
@@ -63,21 +60,7 @@ func handler(opts Options) (http.Handler, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "parsing signing key seed")
 		}
-
-		// Only the first key is used for signing. The rest is for verifying challenge transactions, if any.
-		if i == 0 {
-			var signingKeyPub string
-			signingKeyPub, err = getStellarTOMLSigningKey(opts.StellarTOMLDomain)
-			if err != nil {
-				opts.Logger.Errorf("Error reading SIGNING_KEY from domain %s: %v", opts.StellarTOMLDomain, err)
-			}
-
-			if err == nil && signingKey.Address() != signingKeyPub {
-				opts.Logger.Error("The configured signing key does not match the private key counterpart of the SIGNING_KEY in the stellar.toml file.")
-			}
-
-			signingKeyFull = signingKey
-		}
+		signingKeys = append(signingKeys, signingKey)
 		signingAddresses = append(signingAddresses, signingKey.FromAddress())
 		opts.Logger.Info("Signing key ", i, ": ", signingKey.Address())
 	}
@@ -117,7 +100,7 @@ func handler(opts Options) (http.Handler, error) {
 	mux.Get("/", challengeHandler{
 		Logger:             opts.Logger,
 		NetworkPassphrase:  opts.NetworkPassphrase,
-		SigningKey:         signingKeyFull,
+		SigningKey:         signingKeys[0],
 		ChallengeExpiresIn: opts.ChallengeExpiresIn,
 		HomeDomains:        trimmedHomeDomains,
 	}.ServeHTTP)
@@ -134,33 +117,4 @@ func handler(opts Options) (http.Handler, error) {
 	}.ServeHTTP)
 
 	return mux, nil
-}
-
-func getStellarTOMLSigningKey(domain string) (string, error) {
-	var signingKeyTOML struct {
-		SigningKey string `toml:"SIGNING_KEY"`
-	}
-
-	httpClient := &http.Client{
-		Timeout: 5 * time.Second,
-	}
-
-	domain = strings.TrimRight(domain, "./")
-	resp, err := httpClient.Get(fmt.Sprintf("https://%s/.well-known/stellar.toml", domain))
-	if err != nil {
-		return "", errors.Wrap(err, "sending http request")
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode/100 != 2 {
-		return "", errors.New("http request failed with non-200 status code")
-	}
-
-	safeResBody := io.LimitReader(resp.Body, stellarTomlMaxSize)
-	_, err = toml.DecodeReader(safeResBody, &signingKeyTOML)
-	if err != nil {
-		return "", errors.Wrap(err, "decoding signing key")
-	}
-
-	return signingKeyTOML.SigningKey, nil
 }

--- a/exp/services/webauth/internal/serve/serve.go
+++ b/exp/services/webauth/internal/serve/serve.go
@@ -16,8 +16,6 @@ import (
 	"gopkg.in/square/go-jose.v2"
 )
 
-const stellarTomlMaxSize = 100 * 1024
-
 type Options struct {
 	Logger                      *supportlog.Entry
 	HorizonURL                  string


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Remove the stellar.toml domain checks that occur on application start. Essentially revert the changes relating to this specific feature that were introduced in 5e82f16273b7ce97e50866cba207bc52f498e9c7.

### Why
SEP-10 v2.0.0 highlighted an existing feature that the `SIGNING_KEY` field in the `stellar.toml` be the key that the SEP-10 server use for signing. In 5e82f16273b7ce97e50866cba207bc52f498e9c7 we added the feature that the server would verify that the stellar.toml that references the SEP-10 server contains the correct key. This feature is inconvenient because not all SEP-10 services have a stellar.toml. It's also inconvenient when developing. It's also scope creep on what this SEP-10 server implementation is concerned with. It also delays service boot up time which ideally should not block on external services. If we need tools for validating or verifying stellar.toml's we should probably pursue that as a separate tool.

### Known limitations

This is a breaking change because it removes a config parameter, but the services is experimental and we can make breaking changes. For any service using environment variables to provide the config this will not be a breaking change and the additional config will be ignored.
