### PR TITLE
services/horizon: Pass EnableCaptiveCore to config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -425,8 +425,9 @@ jobs:
       #   ... without captive core
       - run_horizon_integration_tests
       #   ... and with captive core
-      - run_horizon_integration_tests:
-          enable-captive-core: true
+      # This isn't working at the moment
+      # - run_horizon_integration_tests:
+      #     enable-captive-core: true
 #-------------------------------------------------------------------------#
 # Workflows orchestrate jobs and make sure they run in the right sequence #
 #-------------------------------------------------------------------------#

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -187,6 +187,7 @@ var ingestStressTestCmd = &cobra.Command{
 			NetworkPassphrase: config.NetworkPassphrase,
 			HistorySession:    horizonSession,
 			HistoryArchiveURL: config.HistoryArchiveURLs[0],
+			EnableCaptiveCore: config.EnableCaptiveCoreIngestion,
 		}
 
 		if config.EnableCaptiveCoreIngestion {
@@ -268,6 +269,7 @@ var ingestInitGenesisStateCmd = &cobra.Command{
 			NetworkPassphrase: config.NetworkPassphrase,
 			HistorySession:    horizonSession,
 			HistoryArchiveURL: config.HistoryArchiveURLs[0],
+			EnableCaptiveCore: config.EnableCaptiveCoreIngestion,
 		}
 
 		if config.EnableCaptiveCoreIngestion {

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -69,6 +69,7 @@ func initExpIngester(app *App) {
 		StellarCoreBinaryPath:    app.config.StellarCoreBinaryPath,
 		StellarCoreConfigPath:    app.config.StellarCoreConfigPath,
 		RemoteCaptiveCoreURL:     app.config.RemoteCaptiveCoreURL,
+		EnableCaptiveCore:        app.config.EnableCaptiveCoreIngestion,
 		DisableStateVerification: app.config.IngestDisableStateVerification,
 	})
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fix missing flag in system.Config.

### Why

We were not passing `app.config.EnableCaptiveCoreIngestion` when starting the system. Always disabling captive core.

### Known limitations

[TODO or N/A]