### PR TITLE
Use --start-ledger and --start-hash in online captive core.

### DIFF
--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
 )
 
 const hexPrefixPat = "/[0-9a-f]{2}/[0-9a-f]{2}/[0-9a-f]{2}/"
@@ -59,6 +60,7 @@ type ArchiveInterface interface {
 	PutPathHAS(path string, has HistoryArchiveState, opts *CommandOptions) error
 	BucketExists(bucket Hash) (bool, error)
 	CategoryCheckpointExists(cat string, chk uint32) (bool, error)
+	GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, error)
 	GetRootHAS() (HistoryArchiveState, error)
 	GetCheckpointHAS(chk uint32) (HistoryArchiveState, error)
 	PutCheckpointHAS(chk uint32, has HistoryArchiveState, opts *CommandOptions) error
@@ -147,6 +149,28 @@ func (a *Archive) BucketExists(bucket Hash) (bool, error) {
 
 func (a *Archive) CategoryCheckpointExists(cat string, chk uint32) (bool, error) {
 	return a.backend.Exists(CategoryCheckpointPath(cat, chk))
+}
+
+func (a *Archive) GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, error) {
+	var ledgerHeader xdr.LedgerHeaderHistoryEntry
+	path := CategoryCheckpointPath("ledger", chk)
+	xdrStream, err := a.GetXdrStream(path)
+	if err != nil {
+		return ledgerHeader, errors.Wrap(err, "error opening ledger stream")
+	}
+	defer xdrStream.Close()
+
+	for {
+		err = xdrStream.ReadOne(&ledgerHeader)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return ledgerHeader, errors.Wrap(err, "error reading from ledger stream")
+		}
+	}
+
+	return ledgerHeader, nil
 }
 
 func (a *Archive) GetRootHAS() (HistoryArchiveState, error) {

--- a/historyarchive/mocks.go
+++ b/historyarchive/mocks.go
@@ -1,6 +1,7 @@
 package historyarchive
 
 import (
+	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -27,6 +28,11 @@ func (m *MockArchive) BucketExists(bucket Hash) (bool, error) {
 func (m *MockArchive) CategoryCheckpointExists(cat string, chk uint32) (bool, error) {
 	a := m.Called(cat, chk)
 	return a.Get(0).(bool), a.Error(1)
+}
+
+func (m *MockArchive) GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, error) {
+	a := m.Called(chk)
+	return a.Get(0).(xdr.LedgerHeaderHistoryEntry), a.Error(1)
 }
 
 func (m *MockArchive) GetRootHAS() (HistoryArchiveState, error) {

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -230,44 +230,7 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 		}
 	}
 
-	var runFrom uint32
-	var ledgerHash string
-	var nextLedger uint32
-
-	if (from+1)%ledgersPerCheckpoint == 0 {
-		// To start replaying ledger metadata from a checkpoint ledger
-		// (including that ledger), we need to start at the previous ledger
-		// which forces the stream to start at the first ledger in the
-		// checkpoint.
-		//
-		// If we start at the checkpoint ledger, then the first ledger metadata in the stream would be for L+1 (not L)
-		//
-		ledgerHeader, err := c.archive.GetLedgerHeader(from)
-		if err != nil {
-			return errors.Wrap(err, "error trying to read ledger header from HAS")
-		}
-		runFrom = runFrom - 1
-		ledgerHash = hex.EncodeToString(ledgerHeader.Header.PreviousLedgerHash[:])
-		nextLedger = roundDownToFirstReplayAfterCheckpointStart(runFrom)
-	} else {
-		// This is a workaround for now since we are not passing the ledger
-		// header hash.
-		//
-		// We need a way to get the hash from the previous ledger without having
-		// to rely on the history archive
-		//
-		// For now, we run stellar-core starting at the previous checkpoint
-		// ledger and then fast-forward to the desire ledger
-		//
-		//
-		runFrom = roundDownToFirstReplayAfterCheckpointStart(from) - 1
-		ledgerHeader, err := c.archive.GetLedgerHeader(runFrom)
-		if err != nil {
-			return errors.Wrap(err, "error trying to read ledger header from HAS")
-		}
-		ledgerHash = hex.EncodeToString(ledgerHeader.Hash[:])
-		nextLedger = runFrom + 1
-	}
+	runFrom, ledgerHash, nextLedger, err := c.runFromParams(from)
 
 	err = c.stellarCoreRunner.runFrom(runFrom, ledgerHash)
 	if err != nil {
@@ -289,10 +252,50 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 	// if nextLedger is behind - fast-forward until expected ledger
 	if c.nextLedger < from {
 		_, _, err := c.GetLedger(from)
-		return errors.Wrapf(err, "Error fast-forwarding to %s", from)
+		return errors.Wrapf(err, "Error fast-forwarding to %d", from)
 	}
 
 	return nil
+}
+
+// runFromParams receives a ledger and calculates the required values to call stellar-core run with --start-ledger and --start-hash
+func (c *CaptiveStellarCore) runFromParams(from uint32) (runFrom uint32, ledgerHash string, nextLedger uint32, err error) {
+	if (from+1)%ledgersPerCheckpoint == 0 {
+		// To start replaying ledger metadata from a checkpoint ledger
+		// (including that ledger), we need to start at the previous ledger
+		// which forces the stream to start at the first ledger in the
+		// checkpoint.
+		//
+		// If we start at the checkpoint ledger, then the first ledger metadata in the stream would be for L+1 (not L)
+		//
+		ledgerHeader, err := c.archive.GetLedgerHeader(from)
+		if err != nil {
+			return runFrom, ledgerHash, nextLedger, errors.Wrap(err, "error trying to read ledger header from HAS")
+		}
+		runFrom = runFrom - 1
+		ledgerHash = hex.EncodeToString(ledgerHeader.Header.PreviousLedgerHash[:])
+		nextLedger = roundDownToFirstReplayAfterCheckpointStart(runFrom)
+	} else {
+		// This is a workaround for now since we are not passing the ledger
+		// header hash.
+		//
+		// We need a way to get the hash from the previous ledger without having
+		// to rely on the history archive
+		//
+		// For now, we run stellar-core starting at the previous checkpoint
+		// ledger and then fast-forward to the desire ledger
+		//
+		//
+		runFrom = roundDownToFirstReplayAfterCheckpointStart(from) - 1
+		ledgerHeader, err := c.archive.GetLedgerHeader(runFrom)
+		if err != nil {
+			return runFrom, ledgerHash, nextLedger, errors.Wrap(err, "error trying to read ledger header from HAS")
+		}
+		ledgerHash = hex.EncodeToString(ledgerHeader.Hash[:])
+		nextLedger = runFrom + 1
+	}
+
+	return
 }
 
 // sendLedgerMeta reads from the captive core pipe, decodes the ledger metadata

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -263,7 +263,7 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 
 // runFromParams receives a ledger sequence and calculates the required values to call stellar-core run with --start-ledger and --start-hash
 func (c *CaptiveStellarCore) runFromParams(from uint32) (runFrom uint32, ledgerHash string, nextLedger uint32, err error) {
-	if (from+1)%ledgersPerCheckpoint == 0 {
+	if historyarchive.IsCheckpoint(from) {
 		// To start replaying ledger metadata from a checkpoint ledger
 		// (including that ledger), we need to start at the previous ledger
 		// which forces the stream to start at the first ledger in the

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -231,6 +231,9 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 	}
 
 	runFrom, ledgerHash, nextLedger, err := c.runFromParams(from)
+	if err != nil {
+		return errors.Wrap(err, "error calculating ledger and hash for stelar-core run")
+	}
 
 	err = c.stellarCoreRunner.runFrom(runFrom, ledgerHash)
 	if err != nil {
@@ -258,7 +261,7 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 	return nil
 }
 
-// runFromParams receives a ledger and calculates the required values to call stellar-core run with --start-ledger and --start-hash
+// runFromParams receives a ledger sequence and calculates the required values to call stellar-core run with --start-ledger and --start-hash
 func (c *CaptiveStellarCore) runFromParams(from uint32) (runFrom uint32, ledgerHash string, nextLedger uint32, err error) {
 	if (from+1)%ledgersPerCheckpoint == 0 {
 		// To start replaying ledger metadata from a checkpoint ledger
@@ -268,11 +271,12 @@ func (c *CaptiveStellarCore) runFromParams(from uint32) (runFrom uint32, ledgerH
 		//
 		// If we start at the checkpoint ledger, then the first ledger metadata in the stream would be for L+1 (not L)
 		//
-		ledgerHeader, err := c.archive.GetLedgerHeader(from)
-		if err != nil {
-			return runFrom, ledgerHash, nextLedger, errors.Wrap(err, "error trying to read ledger header from HAS")
+		ledgerHeader, err2 := c.archive.GetLedgerHeader(from)
+		if err2 != nil {
+			err = errors.Wrapf(err2, "error trying to read ledger header %d from HAS", from)
+			return
 		}
-		runFrom = runFrom - 1
+		runFrom = from - 1
 		ledgerHash = hex.EncodeToString(ledgerHeader.Header.PreviousLedgerHash[:])
 		nextLedger = roundDownToFirstReplayAfterCheckpointStart(runFrom)
 	} else {
@@ -287,9 +291,10 @@ func (c *CaptiveStellarCore) runFromParams(from uint32) (runFrom uint32, ledgerH
 		//
 		//
 		runFrom = roundDownToFirstReplayAfterCheckpointStart(from) - 1
-		ledgerHeader, err := c.archive.GetLedgerHeader(runFrom)
-		if err != nil {
-			return runFrom, ledgerHash, nextLedger, errors.Wrap(err, "error trying to read ledger header from HAS")
+		ledgerHeader, err2 := c.archive.GetLedgerHeader(runFrom)
+		if err2 != nil {
+			err = errors.Wrapf(err2, "error trying to read ledger header %d from HAS", runFrom)
+			return
 		}
 		ledgerHash = hex.EncodeToString(ledgerHeader.Hash[:])
 		nextLedger = runFrom + 1

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -1,6 +1,7 @@
 package ledgerbackend
 
 import (
+	"encoding/hex"
 	"io"
 	"sync"
 	"time"
@@ -228,14 +229,52 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 			return errors.Wrap(err, "error creating stellar-core runner")
 		}
 	}
-	err = c.stellarCoreRunner.runFrom(from)
+
+	var runFrom uint32
+	var ledgerHash string
+	var nextLedger uint32
+
+	if (from+1)%ledgersPerCheckpoint == 0 {
+		// To start replaying ledger metadata from a checkpoint ledger
+		// (including that ledger), we need to start at the previous ledger
+		// which forces the stream to start at the first ledger in the
+		// checkpoint.
+		//
+		// If we start at the checkpoint ledger, then the first ledger metadata in the stream would be for L+1 (not L)
+		//
+		ledgerHeader, err := c.archive.GetLedgerHeader(from)
+		if err != nil {
+			return errors.Wrap(err, "error trying to read ledger header from HAS")
+		}
+		runFrom = runFrom - 1
+		ledgerHash = hex.EncodeToString(ledgerHeader.Header.PreviousLedgerHash[:])
+		nextLedger = roundDownToFirstReplayAfterCheckpointStart(runFrom)
+	} else {
+		// This is a workaround for now since we are not passing the ledger
+		// header hash.
+		//
+		// We need a way to get the hash from the previous ledger without having
+		// to rely on the history archive
+		//
+		// For now, we run stellar-core starting at the previous checkpoint
+		// ledger and then fast-forward to the desire ledger
+		//
+		//
+		runFrom = roundDownToFirstReplayAfterCheckpointStart(from) - 1
+		ledgerHeader, err := c.archive.GetLedgerHeader(runFrom)
+		if err != nil {
+			return errors.Wrap(err, "error trying to read ledger header from HAS")
+		}
+		ledgerHash = hex.EncodeToString(ledgerHeader.Hash[:])
+		nextLedger = runFrom + 1
+	}
+
+	err = c.stellarCoreRunner.runFrom(runFrom, ledgerHash)
 	if err != nil {
 		return errors.Wrap(err, "error running stellar-core")
 	}
 
-	// The next ledger should be the ledger actually requested because
-	// we run `catchup X/0` command in the online mode.
-	c.nextLedger = from
+	c.nextLedger = nextLedger
 	c.lastLedger = nil
 	c.blocking = false
 	c.processExit = false
@@ -246,6 +285,13 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 	c.shutdown = make(chan struct{})
 	c.wait.Add(1)
 	go c.sendLedgerMeta(0)
+
+	// if nextLedger is behind - fast-forward until expected ledger
+	if c.nextLedger < from {
+		_, _, err := c.GetLedger(from)
+		return errors.Wrapf(err, "Error fast-forwarding to %s", from)
+	}
+
 	return nil
 }
 

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -27,8 +27,8 @@ func (m *stellarCoreRunnerMock) catchup(from, to uint32) error {
 	return a.Error(0)
 }
 
-func (m *stellarCoreRunnerMock) runFrom(from uint32) error {
-	a := m.Called(from)
+func (m *stellarCoreRunnerMock) runFrom(from uint32, hash string) error {
+	a := m.Called(from, hash)
 	return a.Error(0)
 }
 
@@ -384,15 +384,19 @@ func TestCaptivePrepareRangeUnboundedRange_FromIsTooFarAheadOfLatestHAS(t *testi
 
 func TestCaptivePrepareRangeUnboundedRange_ErrRunFrom(t *testing.T) {
 	mockRunner := &stellarCoreRunnerMock{}
-	mockRunner.On("runFrom", uint32(65)).Return(errors.New("transient error")).Once()
+	mockRunner.On("runFrom", uint32(127), "0000000000000000000000000000000000000000000000000000000000000000").Return(errors.New("transient error")).Once()
 	mockRunner.On("close").Return(nil)
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
 		On("GetRootHAS").
 		Return(historyarchive.HistoryArchiveState{
-			CurrentLedger: uint32(64),
+			CurrentLedger: uint32(127),
 		}, nil)
+
+	mockArchive.
+		On("GetLedgerHeader", uint32(127)).
+		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
@@ -400,7 +404,7 @@ func TestCaptivePrepareRangeUnboundedRange_ErrRunFrom(t *testing.T) {
 		stellarCoreRunner: mockRunner,
 	}
 
-	err := captiveBackend.PrepareRange(UnboundedRange(65))
+	err := captiveBackend.PrepareRange(UnboundedRange(128))
 	assert.EqualError(t, err, "opening subprocess: error running stellar-core: transient error")
 }
 
@@ -412,7 +416,7 @@ func TestCaptivePrepareRangeUnboundedRange_ErrClosingExistingSession(t *testing.
 	mockArchive.
 		On("GetRootHAS").
 		Return(historyarchive.HistoryArchiveState{
-			CurrentLedger: uint32(64),
+			CurrentLedger: uint32(127),
 		}, nil)
 
 	last := uint32(63)
@@ -435,7 +439,7 @@ func TestCaptivePrepareRangeUnboundedRange_ReuseSession(t *testing.T) {
 	}
 
 	mockRunner := &stellarCoreRunnerMock{}
-	mockRunner.On("runFrom", uint32(65)).Return(nil).Once()
+	mockRunner.On("runFrom", uint32(63), "0000000000000000000000000000000000000000000000000000000000000000").Return(nil).Once()
 	mockRunner.On("getMetaPipe").Return(&buf)
 	mockRunner.On("close").Return(nil)
 
@@ -445,6 +449,10 @@ func TestCaptivePrepareRangeUnboundedRange_ReuseSession(t *testing.T) {
 		Return(historyarchive.HistoryArchiveState{
 			CurrentLedger: uint32(129),
 		}, nil)
+	mockArchive.
+		On("GetLedgerHeader", uint32(63)).
+		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
+
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
@@ -467,7 +475,7 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 	}
 
 	mockRunner := &stellarCoreRunnerMock{}
-	mockRunner.On("runFrom", uint32(64)).Return(nil).Once()
+	mockRunner.On("runFrom", uint32(63), "0000000000000000000000000000000000000000000000000000000000000000").Return(nil).Once()
 	mockRunner.On("getMetaPipe").Return(&buf)
 	mockRunner.On("getProcessExitChan").Return(make(chan error))
 	mockRunner.On("close").Return(nil).Once()
@@ -478,6 +486,10 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 		Return(historyarchive.HistoryArchiveState{
 			CurrentLedger: uint32(200),
 		}, nil)
+
+	mockArchive.
+		On("GetLedgerHeader", uint32(63)).
+		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -793,3 +793,68 @@ func TestCaptiveGetLedgerTerminated(t *testing.T) {
 	assert.Error(t, err)
 	assert.EqualError(t, err, "stellar-core process exited without an error unexpectedly")
 }
+
+func TestCaptiveRunFromParams(t *testing.T) {
+	tt := assert.New(t)
+	mockRunner := &stellarCoreRunnerMock{}
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.
+		On("GetLedgerHeader", uint32(63)).
+		Return(xdr.LedgerHeaderHistoryEntry{
+			Hash: xdr.Hash{1, 1, 1, 1},
+		}, nil)
+
+	captiveBackend := CaptiveStellarCore{
+		archive:           mockArchive,
+		networkPassphrase: network.PublicNetworkPassphrase,
+		stellarCoreRunner: mockRunner,
+	}
+
+	runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(70)
+	tt.NoError(err)
+	tt.Equal(uint32(63), runFrom)
+	tt.Equal("0101010100000000000000000000000000000000000000000000000000000000", ledgerHash)
+	tt.Equal(uint32(64), nextLedger)
+
+	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(64)
+	tt.NoError(err)
+	tt.Equal(uint32(63), runFrom)
+	tt.Equal("0101010100000000000000000000000000000000000000000000000000000000", ledgerHash)
+	tt.Equal(uint32(64), nextLedger)
+
+	mockArchive.
+		On("GetLedgerHeader", uint32(127)).
+		Return(xdr.LedgerHeaderHistoryEntry{
+			Header: xdr.LedgerHeader{
+				PreviousLedgerHash: xdr.Hash{1},
+			},
+		}, nil)
+
+	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(127)
+	tt.NoError(err)
+	tt.Equal(uint32(126), runFrom)
+	tt.Equal("0100000000000000000000000000000000000000000000000000000000000000", ledgerHash)
+	tt.Equal(uint32(64), nextLedger)
+
+	mockArchive.
+		On("GetLedgerHeader", uint32(319)).
+		Return(xdr.LedgerHeaderHistoryEntry{
+			Header: xdr.LedgerHeader{
+				PreviousLedgerHash: xdr.Hash{1},
+			},
+		}, errors.New("missing ledger checkpoint"))
+
+	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(319)
+	tt.EqualError(err, "error trying to read ledger header 319 from HAS: missing ledger checkpoint")
+
+	mockArchive.
+		On("GetLedgerHeader", uint32(191)).
+		Return(xdr.LedgerHeaderHistoryEntry{
+			Header: xdr.LedgerHeader{
+				PreviousLedgerHash: xdr.Hash{1},
+			},
+		}, errors.New("missing ledger checkpoint"))
+
+	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(195)
+	tt.EqualError(err, "error trying to read ledger header 191 from HAS: missing ledger checkpoint")
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Use `--start-ledger` and `--start-hash` in captive core.

### Why

This allow us to do a fast catchup without having to call `new-db` and `catchup` before.

### Known limitations

For now we are relying on the history archive to get the ledger header hash. We need to refactor that next.  If we have previous ingested ledgers in Horizon DB, then we should read the hash and ledger sequence from there. 
