### PR TITLE
txnbuild: Add unit test for zero-balance account creation

### DIFF
--- a/txnbuild/operation_test.go
+++ b/txnbuild/operation_test.go
@@ -34,7 +34,33 @@ func TestCreateAccountFromXDR(t *testing.T) {
 			assert.Equal(t, "198.0000000", ca.Amount, "starting balance should match")
 		}
 	}
+}
 
+func TestZeroBalanceAccount(t *testing.T) {
+	sponsor, sponsee := newKeypair0(), newKeypair1()
+	ops := []Operation{
+		&BeginSponsoringFutureReserves{SponsoredID: sponsee.Address()},
+		&CreateAccount{
+			Destination: sponsee.Address(),
+			Amount:      "0",
+		},
+		&EndSponsoringFutureReserves{
+			SourceAccount: &SimpleAccount{AccountID: sponsee.Address()},
+		},
+	}
+
+	sourceAccount := SimpleAccount{AccountID: sponsor.Address()}
+	_, err := NewTransaction(
+		TransactionParams{
+			SourceAccount:        &sourceAccount,
+			Operations:           ops,
+			IncrementSequenceNum: true,
+			BaseFee:              MinBaseFee,
+			Timebounds:           NewInfiniteTimeout(),
+		},
+	)
+
+	assert.NoErrorf(t, err, "zero-balance account creation should work")
 }
 
 func TestPaymentFromXDR(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Adds a unit test to confirm zero-balance account creation can be done through the SDK.

### Why
In response to #3141, rather than just confirming it works once, we can confirm that it'll always work with a real unit test.

