### PR TITLE
services/horizon: Change protocol version check error

### DIFF
--- a/services/horizon/internal/ingest/processor_runner.go
+++ b/services/horizon/internal/ingest/processor_runner.go
@@ -206,7 +206,7 @@ func (s *ProcessorRunner) RunHistoryArchiveIngestion(checkpointLedger uint32) (i
 		}
 	} else {
 		if err = s.checkIfProtocolVersionSupported(checkpointLedger); err != nil {
-			return changeStats.GetResults(), errors.Wrap(err, "Error checking protocol version is supported")
+			return changeStats.GetResults(), errors.Wrap(err, "Error while checking for supported protocol version")
 		}
 
 		if err = s.validateBucketList(checkpointLedger); err != nil {
@@ -279,7 +279,7 @@ func (s *ProcessorRunner) RunTransactionProcessorsOnLedger(ledger uint32) (io.St
 	}
 
 	if err = s.checkIfProtocolVersionSupported(ledger); err != nil {
-		return ledgerTransactionStats.GetResults(), errors.Wrap(err, "Error checking protocol version is supported")
+		return ledgerTransactionStats.GetResults(), errors.Wrap(err, "Error while checking for supported protocol version")
 	}
 
 	txProcessor := s.buildTransactionProcessor(&ledgerTransactionStats, transactionReader.GetHeader())
@@ -301,7 +301,7 @@ func (s *ProcessorRunner) RunAllProcessorsOnLedger(sequence uint32) (io.StatsCha
 	var statsLedgerTransactionProcessorResults io.StatsLedgerTransactionProcessorResults
 
 	if err := s.checkIfProtocolVersionSupported(sequence); err != nil {
-		return changeStats.GetResults(), statsLedgerTransactionProcessorResults, errors.Wrap(err, "Error checking protocol version is supported")
+		return changeStats.GetResults(), statsLedgerTransactionProcessorResults, errors.Wrap(err, "Error while checking for supported protocol version")
 	}
 
 	err := s.runChangeProcessorOnLedger(

--- a/services/horizon/internal/ingest/processor_runner.go
+++ b/services/horizon/internal/ingest/processor_runner.go
@@ -206,7 +206,7 @@ func (s *ProcessorRunner) RunHistoryArchiveIngestion(checkpointLedger uint32) (i
 		}
 	} else {
 		if err = s.checkIfProtocolVersionSupported(checkpointLedger); err != nil {
-			return changeStats.GetResults(), errors.Wrap(err, "Protocol version not supported")
+			return changeStats.GetResults(), errors.Wrap(err, "Error checking protocol version is supported")
 		}
 
 		if err = s.validateBucketList(checkpointLedger); err != nil {
@@ -279,7 +279,7 @@ func (s *ProcessorRunner) RunTransactionProcessorsOnLedger(ledger uint32) (io.St
 	}
 
 	if err = s.checkIfProtocolVersionSupported(ledger); err != nil {
-		return ledgerTransactionStats.GetResults(), errors.Wrap(err, "Protocol version not supported")
+		return ledgerTransactionStats.GetResults(), errors.Wrap(err, "Error checking protocol version is supported")
 	}
 
 	txProcessor := s.buildTransactionProcessor(&ledgerTransactionStats, transactionReader.GetHeader())
@@ -301,7 +301,7 @@ func (s *ProcessorRunner) RunAllProcessorsOnLedger(sequence uint32) (io.StatsCha
 	var statsLedgerTransactionProcessorResults io.StatsLedgerTransactionProcessorResults
 
 	if err := s.checkIfProtocolVersionSupported(sequence); err != nil {
-		return changeStats.GetResults(), statsLedgerTransactionProcessorResults, errors.Wrap(err, "Protocol version not supported")
+		return changeStats.GetResults(), statsLedgerTransactionProcessorResults, errors.Wrap(err, "Error checking protocol version is supported")
 	}
 
 	err := s.runChangeProcessorOnLedger(

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -249,7 +249,7 @@ func TestProcessorRunnerRunHistoryArchiveIngestionProtocolVersionNotSupported(t 
 	}
 
 	_, err := runner.RunHistoryArchiveIngestion(100)
-	assert.EqualError(t, err, "Error checking protocol version is supported: This Horizon version does not support protocol version 200. The latest supported protocol version is 15. Please upgrade to the latest Horizon version.")
+	assert.EqualError(t, err, "Error while checking for supported protocol version: This Horizon version does not support protocol version 200. The latest supported protocol version is 15. Please upgrade to the latest Horizon version.")
 }
 
 func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
@@ -487,5 +487,5 @@ func TestProcessorRunnerRunAllProcessorsOnLedgerProtocolVersionNotSupported(t *t
 	}
 
 	_, _, err := runner.RunAllProcessorsOnLedger(63)
-	assert.EqualError(t, err, "Error checking protocol version is supported: This Horizon version does not support protocol version 200. The latest supported protocol version is 15. Please upgrade to the latest Horizon version.")
+	assert.EqualError(t, err, "Error while checking for supported protocol version: This Horizon version does not support protocol version 200. The latest supported protocol version is 15. Please upgrade to the latest Horizon version.")
 }

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -249,7 +249,7 @@ func TestProcessorRunnerRunHistoryArchiveIngestionProtocolVersionNotSupported(t 
 	}
 
 	_, err := runner.RunHistoryArchiveIngestion(100)
-	assert.EqualError(t, err, "Protocol version not supported: This Horizon version does not support protocol version 200. The latest supported protocol version is 15. Please upgrade to the latest Horizon version.")
+	assert.EqualError(t, err, "Error checking protocol version is supported: This Horizon version does not support protocol version 200. The latest supported protocol version is 15. Please upgrade to the latest Horizon version.")
 }
 
 func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
@@ -487,5 +487,5 @@ func TestProcessorRunnerRunAllProcessorsOnLedgerProtocolVersionNotSupported(t *t
 	}
 
 	_, _, err := runner.RunAllProcessorsOnLedger(63)
-	assert.EqualError(t, err, "Protocol version not supported: This Horizon version does not support protocol version 200. The latest supported protocol version is 15. Please upgrade to the latest Horizon version.")
+	assert.EqualError(t, err, "Error checking protocol version is supported: This Horizon version does not support protocol version 200. The latest supported protocol version is 15. Please upgrade to the latest Horizon version.")
 }


### PR DESCRIPTION
Changed `Protocol version not supported` to `Error checking protocol version is supported` message because an error can be unrelated to protocol version mismatch (ex. error connecting to ledger backend).