### PR TITLE
services/horizon: Export ledger stats in /metrics, add claimable_balance to change stats

### DIFF
--- a/ingest/io/stats_change_processor.go
+++ b/ingest/io/stats_change_processor.go
@@ -16,6 +16,10 @@ type StatsChangeProcessorResults struct {
 	AccountsUpdated int64
 	AccountsRemoved int64
 
+	ClaimableBalancesCreated int64
+	ClaimableBalancesUpdated int64
+	ClaimableBalancesRemoved int64
+
 	DataCreated int64
 	DataUpdated int64
 	DataRemoved int64
@@ -39,6 +43,15 @@ func (p *StatsChangeProcessor) ProcessChange(change Change) error {
 			p.results.AccountsUpdated++
 		case xdr.LedgerEntryChangeTypeLedgerEntryRemoved:
 			p.results.AccountsRemoved++
+		}
+	case xdr.LedgerEntryTypeClaimableBalance:
+		switch change.LedgerEntryChangeType() {
+		case xdr.LedgerEntryChangeTypeLedgerEntryCreated:
+			p.results.ClaimableBalancesCreated++
+		case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
+			p.results.ClaimableBalancesUpdated++
+		case xdr.LedgerEntryChangeTypeLedgerEntryRemoved:
+			p.results.ClaimableBalancesRemoved++
 		}
 	case xdr.LedgerEntryTypeData:
 		switch change.LedgerEntryChangeType() {
@@ -81,6 +94,10 @@ func (stats *StatsChangeProcessorResults) Map() map[string]interface{} {
 		"stats_accounts_created": stats.AccountsCreated,
 		"stats_accounts_updated": stats.AccountsUpdated,
 		"stats_accounts_removed": stats.AccountsRemoved,
+
+		"stats_claimable_balances_created": stats.ClaimableBalancesCreated,
+		"stats_claimable_balances_updated": stats.ClaimableBalancesUpdated,
+		"stats_claimable_balances_removed": stats.ClaimableBalancesRemoved,
 
 		"stats_data_created": stats.DataCreated,
 		"stats_data_updated": stats.DataUpdated,

--- a/ingest/io/stats_change_processor_test.go
+++ b/ingest/io/stats_change_processor_test.go
@@ -18,6 +18,12 @@ func TestStatsChangeProcessor(t *testing.T) {
 	}))
 
 	assert.NoError(t, processor.ProcessChange(Change{
+		Type: xdr.LedgerEntryTypeClaimableBalance,
+		Pre:  nil,
+		Post: &xdr.LedgerEntry{},
+	}))
+
+	assert.NoError(t, processor.ProcessChange(Change{
 		Type: xdr.LedgerEntryTypeData,
 		Pre:  nil,
 		Post: &xdr.LedgerEntry{},
@@ -38,6 +44,12 @@ func TestStatsChangeProcessor(t *testing.T) {
 	// Updated
 	assert.NoError(t, processor.ProcessChange(Change{
 		Type: xdr.LedgerEntryTypeAccount,
+		Pre:  &xdr.LedgerEntry{},
+		Post: &xdr.LedgerEntry{},
+	}))
+
+	assert.NoError(t, processor.ProcessChange(Change{
+		Type: xdr.LedgerEntryTypeClaimableBalance,
 		Pre:  &xdr.LedgerEntry{},
 		Post: &xdr.LedgerEntry{},
 	}))
@@ -68,6 +80,12 @@ func TestStatsChangeProcessor(t *testing.T) {
 	}))
 
 	assert.NoError(t, processor.ProcessChange(Change{
+		Type: xdr.LedgerEntryTypeClaimableBalance,
+		Pre:  &xdr.LedgerEntry{},
+		Post: nil,
+	}))
+
+	assert.NoError(t, processor.ProcessChange(Change{
 		Type: xdr.LedgerEntryTypeData,
 		Pre:  &xdr.LedgerEntry{},
 		Post: nil,
@@ -88,16 +106,19 @@ func TestStatsChangeProcessor(t *testing.T) {
 	results := processor.GetResults()
 
 	assert.Equal(t, int64(1), results.AccountsCreated)
+	assert.Equal(t, int64(1), results.ClaimableBalancesCreated)
 	assert.Equal(t, int64(1), results.DataCreated)
 	assert.Equal(t, int64(1), results.OffersCreated)
 	assert.Equal(t, int64(1), results.TrustLinesCreated)
 
 	assert.Equal(t, int64(1), results.AccountsUpdated)
+	assert.Equal(t, int64(1), results.ClaimableBalancesUpdated)
 	assert.Equal(t, int64(1), results.DataUpdated)
 	assert.Equal(t, int64(1), results.OffersUpdated)
 	assert.Equal(t, int64(1), results.TrustLinesUpdated)
 
 	assert.Equal(t, int64(1), results.AccountsRemoved)
+	assert.Equal(t, int64(1), results.ClaimableBalancesRemoved)
 	assert.Equal(t, int64(1), results.DataRemoved)
 	assert.Equal(t, int64(1), results.OffersRemoved)
 	assert.Equal(t, int64(1), results.TrustLinesRemoved)

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,6 +6,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).x
 ## Unreleased
 
 * The `service` field emitted in ingestion logs has been changed from `expingest` to `ingest`.
+* Ledger stats are now exported in `/metrics` in `horizon_ingest_ledger_stats_total` metric.
 
 ## v1.10.1
 

--- a/services/horizon/internal/ingest/fsm.go
+++ b/services/horizon/internal/ingest/fsm.go
@@ -2,8 +2,10 @@ package ingest
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stellar/go/ingest/ledgerbackend"
 
 	"github.com/stellar/go/ingest/io"
@@ -471,9 +473,25 @@ func (r resumeState) run(s *system) (transition, error) {
 
 	duration := time.Since(startTime).Seconds()
 	s.Metrics().LedgerIngestionDuration.Observe(float64(duration))
+
+	// Update stats metrics
+	changeStatsMap := changeStats.Map()
+	for stat, value := range changeStatsMap {
+		stat = strings.Replace(stat, "stats_", "change_", 1)
+		s.Metrics().LedgerStatsCounter.
+			With(prometheus.Labels{"type": stat}).Add(float64(value.(int64)))
+	}
+
+	ledgerTransactionStatsMap := ledgerTransactionStats.Map()
+	for stat, value := range ledgerTransactionStatsMap {
+		stat = strings.Replace(stat, "stats_", "ledger_", 1)
+		s.Metrics().LedgerStatsCounter.
+			With(prometheus.Labels{"type": stat}).Add(float64(value.(int64)))
+	}
+
 	log.
-		WithFields(changeStats.Map()).
-		WithFields(ledgerTransactionStats.Map()).
+		WithFields(changeStatsMap).
+		WithFields(ledgerTransactionStatsMap).
 		WithFields(logpkg.F{
 			"sequence": ingestLedger,
 			"duration": duration,

--- a/services/horizon/internal/ingest/fsm.go
+++ b/services/horizon/internal/ingest/fsm.go
@@ -476,18 +476,10 @@ func (r resumeState) run(s *system) (transition, error) {
 
 	// Update stats metrics
 	changeStatsMap := changeStats.Map()
-	for stat, value := range changeStatsMap {
-		stat = strings.Replace(stat, "stats_", "change_", 1)
-		s.Metrics().LedgerStatsCounter.
-			With(prometheus.Labels{"type": stat}).Add(float64(value.(int64)))
-	}
+	r.addLedgerStatsMetricFromMap(s, "change", changeStatsMap)
 
 	ledgerTransactionStatsMap := ledgerTransactionStats.Map()
-	for stat, value := range ledgerTransactionStatsMap {
-		stat = strings.Replace(stat, "stats_", "ledger_", 1)
-		s.Metrics().LedgerStatsCounter.
-			With(prometheus.Labels{"type": stat}).Add(float64(value.(int64)))
-	}
+	r.addLedgerStatsMetricFromMap(s, "ledger", ledgerTransactionStatsMap)
 
 	log.
 		WithFields(changeStatsMap).
@@ -504,6 +496,14 @@ func (r resumeState) run(s *system) (transition, error) {
 	s.maybeVerifyState(ingestLedger)
 
 	return resumeImmediately(ingestLedger), nil
+}
+
+func (r resumeState) addLedgerStatsMetricFromMap(s *system, prefix string, m map[string]interface{}) {
+	for stat, value := range m {
+		stat = strings.Replace(stat, "stats_", prefix+"_", 1)
+		s.Metrics().LedgerStatsCounter.
+			With(prometheus.Labels{"type": stat}).Add(float64(value.(int64)))
+	}
 }
 
 type historyRangeState struct {

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -104,6 +104,9 @@ type Metrics struct {
 	// StateInvalidGauge exposes state invalid metric. 1 if state is invalid,
 	// 0 otherwise.
 	StateInvalidGauge prometheus.GaugeFunc
+
+	// LedgerStatsCounter exposes ledger stats counters (like number of ops/changes).
+	LedgerStatsCounter *prometheus.CounterVec
 }
 
 type System interface {
@@ -249,6 +252,14 @@ func (s *system) initMetrics() {
 			}
 			return invalidFloat
 		},
+	)
+
+	s.metrics.LedgerStatsCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "horizon", Subsystem: "ingest", Name: "ledger_stats_total",
+			Help: "counters of different ledger stats",
+		},
+		[]string{"type"},
 	)
 }
 

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -242,6 +242,7 @@ func initIngestMetrics(app *App) {
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().LedgerIngestionDuration)
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().StateVerifyDuration)
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().StateInvalidGauge)
+	app.prometheusRegistry.MustRegister(app.ingester.Metrics().LedgerStatsCounter)
 }
 
 func initTxSubMetrics(app *App) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Export ledger stats (number of ops and changes) in `/metrics`. Add claimable balances to changes stats.

Close #3133.

### Why

To be able to correlate slow ledger with network activitity.