### PR TITLE
services/horizon: Make stellar core database URL optional if captive core is enabled.

### DIFF
--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -121,6 +121,7 @@ func Flags() (*Config, support.ConfigOptions) {
 			EnvVar:    "STELLAR_CORE_DATABASE_URL",
 			ConfigKey: &config.StellarCoreDatabaseURL,
 			OptType:   types.String,
+			Required:  false,
 			Usage:     "stellar-core postgres database to connect with",
 		},
 		&support.ConfigOption{
@@ -359,10 +360,8 @@ func NewAppFromFlags(config *Config, flags support.ConfigOptions) *App {
 	if config.StellarCoreURL == "" {
 		log.Fatalf("flag --%s cannot be empty", StellarCoreURLFlagName)
 	}
-	if config.Ingest {
-		if config.StellarCoreDatabaseURL == "" {
-			log.Fatalf("flag --%s cannot be empty", StellarCoreDBURLFlagName)
-		}
+	if config.Ingest && !config.EnableCaptiveCoreIngestion && config.StellarCoreDatabaseURL == "" {
+		log.Fatalf("flag --%s cannot be empty", StellarCoreDBURLFlagName)
 	}
 	app, err := NewApp(*config)
 	if err != nil {

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -52,10 +52,12 @@ func mustInitHorizonDB(app *App) {
 
 func initExpIngester(app *App) {
 	var err error
+	var coreSession *db.Session
+	if !app.config.EnableCaptiveCoreIngestion {
+		coreSession = mustNewDBSession(app.config.StellarCoreDatabaseURL, ingest.MaxDBConnections, ingest.MaxDBConnections)
+	}
 	app.ingester, err = ingest.NewSystem(ingest.Config{
-		CoreSession: mustNewDBSession(
-			app.config.StellarCoreDatabaseURL, ingest.MaxDBConnections, ingest.MaxDBConnections,
-		),
+		CoreSession: coreSession,
 		HistorySession: mustNewDBSession(
 			app.config.DatabaseURL, ingest.MaxDBConnections, ingest.MaxDBConnections,
 		),


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Disable stellar core database URL validation if captive core is enabled.

### Why

Fix #3129

### Known limitations

[TODO or N/A]
