### PR TITLE
historyarchive: Update Archive.GetLedgerHeader to get non-checkpoint headers

### DIFF
--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -156,16 +156,15 @@ func (a *Archive) GetLedgerHeader(ledger uint32) (xdr.LedgerHeaderHistoryEntry, 
 	if !IsCheckpoint(checkpoint) {
 		checkpoint = NextCheckpoint(ledger)
 	}
-	var ledgerHeader xdr.LedgerHeaderHistoryEntry
 	path := CategoryCheckpointPath("ledger", checkpoint)
 	xdrStream, err := a.GetXdrStream(path)
 	if err != nil {
-		return ledgerHeader, errors.Wrap(err, "error opening ledger stream")
+		return xdr.LedgerHeaderHistoryEntry{}, errors.Wrap(err, "error opening ledger stream")
 	}
 	defer xdrStream.Close()
 
-	found := false
 	for {
+		var ledgerHeader xdr.LedgerHeaderHistoryEntry
 		err = xdrStream.ReadOne(&ledgerHeader)
 		if err != nil {
 			if err == io.EOF {
@@ -175,16 +174,11 @@ func (a *Archive) GetLedgerHeader(ledger uint32) (xdr.LedgerHeaderHistoryEntry, 
 		}
 
 		if uint32(ledgerHeader.Header.LedgerSeq) == ledger {
-			found = true
-			break
+			return ledgerHeader, nil
 		}
 	}
 
-	if !found {
-		return ledgerHeader, errors.New("ledger header not found in checkpoint")
-	}
-
-	return ledgerHeader, nil
+	return xdr.LedgerHeaderHistoryEntry{}, errors.New("ledger header not found in checkpoint")
 }
 
 func (a *Archive) GetRootHAS() (HistoryArchiveState, error) {

--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -151,15 +151,20 @@ func (a *Archive) CategoryCheckpointExists(cat string, chk uint32) (bool, error)
 	return a.backend.Exists(CategoryCheckpointPath(cat, chk))
 }
 
-func (a *Archive) GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, error) {
+func (a *Archive) GetLedgerHeader(ledger uint32) (xdr.LedgerHeaderHistoryEntry, error) {
+	checkpoint := ledger
+	if !IsCheckpoint(checkpoint) {
+		checkpoint = NextCheckpoint(ledger)
+	}
 	var ledgerHeader xdr.LedgerHeaderHistoryEntry
-	path := CategoryCheckpointPath("ledger", chk)
+	path := CategoryCheckpointPath("ledger", checkpoint)
 	xdrStream, err := a.GetXdrStream(path)
 	if err != nil {
 		return ledgerHeader, errors.Wrap(err, "error opening ledger stream")
 	}
 	defer xdrStream.Close()
 
+	found := false
 	for {
 		err = xdrStream.ReadOne(&ledgerHeader)
 		if err != nil {
@@ -168,6 +173,15 @@ func (a *Archive) GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, err
 			}
 			return ledgerHeader, errors.Wrap(err, "error reading from ledger stream")
 		}
+
+		if uint32(ledgerHeader.Header.LedgerSeq) == ledger {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return ledgerHeader, errors.New("ledger header not found in checkpoint")
 	}
 
 	return ledgerHeader, nil


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Update `Archive.GetLedgerHeader` to get non-checkpoint ledgers.

### Why

History archives contain headers for all ledgers (not just checkpoints) so we should allow getting them. This is also required to sync in standalone network (ledgers <63). Close #3155.

### Known limitations

N/A
