### PR TITLE
clients/stellarcore: Add Manual Close endpoint to Core's client

### DIFF
--- a/clients/stellarcore/client_test.go
+++ b/clients/stellarcore/client_test.go
@@ -26,3 +26,31 @@ func TestSubmitTransaction(t *testing.T) {
 		assert.Equal(t, proto.TXStatusPending, resp.Status)
 	}
 }
+
+func TestManualClose(t *testing.T) {
+	hmock := httptest.NewClient()
+	c := &Client{HTTP: hmock, URL: "http://localhost:11626"}
+
+	// happy path - new transaction
+	hmock.On("GET", "http://localhost:11626/manualclose").
+		ReturnString(http.StatusOK, "Manually triggered a ledger close with sequence number 7")
+
+	err := c.ManualClose(context.Background())
+
+	assert.NoError(t, err)
+}
+
+func TestManualClose_NotAvailable(t *testing.T) {
+	hmock := httptest.NewClient()
+	c := &Client{HTTP: hmock, URL: "http://localhost:11626"}
+
+	// happy path - new transaction
+	hmock.On("GET", "http://localhost:11626/manualclose").
+		ReturnString(http.StatusOK,
+			`{"exception": "Set MANUAL_CLOSE=true"}`,
+		)
+
+	err := c.ManualClose(context.Background())
+
+	assert.EqualError(t, err, "exception in response: Set MANUAL_CLOSE=true")
+}


### PR DESCRIPTION
### What

Add support for `MANUAL_CLOSE` endpoint to the Stellar Core HTTP client.

### Why

We plan to use `MANUAL_CLOSE` in the Horizon Captive Core integration tests. In particular need to quickly close the first 64 ledgers in order to reach the first ledger endpoint and avoid waiting for 5 minutes in each test. More context here https://github.com/stellar/go/pull/3144#issuecomment-713754936

Later on this will come handy to close ledgers right after submitting a transaction, which will remove the remaining waiting time in integration tests.

### Known limitations

N/A