### PR TITLE
services/horizon: Make captive core runner more robust

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -497,14 +497,12 @@ func (c *CaptiveStellarCore) isClosed() bool {
 // Close closes existing Stellar-Core process, streaming sessions and removes all
 // temporary files.
 func (c *CaptiveStellarCore) Close() error {
-	if c.isClosed() {
-		return nil
-	}
 	c.nextLedger = 0
 	c.lastLedger = nil
 
 	if c.shutdown != nil {
 		close(c.shutdown)
+		c.shutdown = nil
 		// discard pending data in case the goroutine is blocked writing to the channel,
 		// see: `sendLedgerMeta`.
 		select {
@@ -519,6 +517,7 @@ func (c *CaptiveStellarCore) Close() error {
 
 	if c.stellarCoreRunner != nil {
 		err := c.stellarCoreRunner.close()
+		c.stellarCoreRunner = nil
 		if err != nil {
 			return errors.Wrap(err, "error closing stellar-core subprocess")
 		}

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -85,6 +85,9 @@ type CaptiveStellarCore struct {
 	// wait is a waiting group waiting for a read-ahead buffer to return.
 	wait sync.WaitGroup
 
+	// For testing
+	stellarCoreRunnerFactory func(configPath string) (stellarCoreRunnerInterface, error)
+
 	stellarCoreRunner stellarCoreRunnerInterface
 	cachedMeta        *xdr.LedgerCloseMeta
 
@@ -123,11 +126,14 @@ func NewCaptive(executablePath, configPath, networkPassphrase string, historyURL
 	}
 
 	return &CaptiveStellarCore{
-		archive:                  archive,
-		executablePath:           executablePath,
-		configPath:               configPath,
-		historyURLs:              historyURLs,
-		networkPassphrase:        networkPassphrase,
+		archive:           archive,
+		executablePath:    executablePath,
+		configPath:        configPath,
+		historyURLs:       historyURLs,
+		networkPassphrase: networkPassphrase,
+		stellarCoreRunnerFactory: func(configPath2 string) (stellarCoreRunnerInterface, error) {
+			return newStellarCoreRunner(executablePath, configPath2, networkPassphrase, historyURLs)
+		},
 		waitIntervalPrepareRange: time.Second,
 	}, nil
 }
@@ -164,7 +170,7 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 
 	if c.stellarCoreRunner == nil {
 		// configPath is empty in an offline mode because it's generated
-		c.stellarCoreRunner, err = newStellarCoreRunner(c.executablePath, "", c.networkPassphrase, c.historyURLs)
+		c.stellarCoreRunner, err = c.stellarCoreRunnerFactory("")
 		if err != nil {
 			return errors.Wrap(err, "error creating stellar-core runner")
 		}
@@ -223,7 +229,7 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 		if c.configPath == "" {
 			return errors.New("stellar-core config file path cannot be empty in an online mode")
 		}
-		c.stellarCoreRunner, err = newStellarCoreRunner(c.executablePath, c.configPath, c.networkPassphrase, c.historyURLs)
+		c.stellarCoreRunner, err = c.stellarCoreRunnerFactory(c.configPath)
 		if err != nil {
 			return errors.Wrap(err, "error creating stellar-core runner")
 		}
@@ -282,10 +288,17 @@ func (c *CaptiveStellarCore) sendLedgerMeta(untilSequence uint32) {
 			}
 			// When `GetLedger` sees the error it will close the backend. We shouldn't
 			// close it now because there may be some ledgers in a buffer.
-			c.metaC <- metaResult{nil, err}
+			select {
+			case c.metaC <- metaResult{nil, err}:
+			case <-c.shutdown:
+			}
 			return
 		}
-		c.metaC <- metaResult{meta, nil}
+		select {
+		case c.metaC <- metaResult{meta, nil}:
+		case <-c.shutdown:
+			return
+		}
 
 		if untilSequence != 0 {
 			if meta.LedgerSequence() >= untilSequence {
@@ -502,17 +515,11 @@ func (c *CaptiveStellarCore) Close() error {
 
 	if c.shutdown != nil {
 		close(c.shutdown)
-		c.shutdown = nil
-		// discard pending data in case the goroutine is blocked writing to the channel,
-		// see: `sendLedgerMeta`.
-		select {
-		case <-c.metaC:
-		default:
-		}
 		// Do not close the communication channel until we know
 		// the goroutine is done
 		c.wait.Wait()
 		close(c.metaC)
+		c.shutdown = nil
 	}
 
 	if c.stellarCoreRunner != nil {
@@ -522,5 +529,6 @@ func (c *CaptiveStellarCore) Close() error {
 			return errors.Wrap(err, "error closing stellar-core subprocess")
 		}
 	}
+
 	return nil
 }

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -154,10 +154,14 @@ func TestCaptivePrepareRange(t *testing.T) {
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
 		stellarCoreRunner: mockRunner,
+		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+			return mockRunner, nil
+		},
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
 	assert.NoError(t, err)
+	mockRunner.On("close").Return(nil).Once()
 	err = captiveBackend.Close()
 	assert.NoError(t, err)
 }
@@ -184,6 +188,9 @@ func TestCaptivePrepareRangeCrash(t *testing.T) {
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
 		stellarCoreRunner: mockRunner,
+		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+			return mockRunner, nil
+		},
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
@@ -213,6 +220,9 @@ func TestCaptivePrepareRangeTerminated(t *testing.T) {
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
 		stellarCoreRunner: mockRunner,
+		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+			return mockRunner, nil
+		},
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
@@ -310,6 +320,9 @@ func TestCaptivePrepareRange_ToIsAheadOfRootHAS(t *testing.T) {
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
 		stellarCoreRunner: mockRunner,
+		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+			return mockRunner, nil
+		},
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -153,7 +153,6 @@ func TestCaptivePrepareRange(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -187,7 +186,6 @@ func TestCaptivePrepareRangeCrash(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -219,7 +217,6 @@ func TestCaptivePrepareRangeTerminated(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -231,24 +228,13 @@ func TestCaptivePrepareRangeTerminated(t *testing.T) {
 }
 
 func TestCaptivePrepareRange_ErrClosingSession(t *testing.T) {
-	var buf bytes.Buffer
 	mockRunner := &stellarCoreRunnerMock{}
-	mockRunner.On("catchup", uint32(100), uint32(200)).Return(nil).Once()
-	mockRunner.On("getMetaPipe").Return(&buf)
 	mockRunner.On("close").Return(fmt.Errorf("transient error"))
 
-	mockArchive := &historyarchive.MockArchive{}
-	mockArchive.
-		On("GetRootHAS").
-		Return(historyarchive.HistoryArchiveState{
-			CurrentLedger: uint32(200),
-		}, nil)
-
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
 		nextLedger:        300,
+		stellarCoreRunner: mockRunner,
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
@@ -270,7 +256,6 @@ func TestCaptivePrepareRange_ErrGettingRootHAS(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
@@ -294,7 +279,6 @@ func TestCaptivePrepareRange_FromIsAheadOfRootHAS(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
@@ -319,7 +303,6 @@ func TestCaptivePrepareRange_ToIsAheadOfRootHAS(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -344,7 +327,6 @@ func TestCaptivePrepareRange_ErrCatchup(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -370,7 +352,6 @@ func TestCaptivePrepareRangeUnboundedRange_ErrGettingRootHAS(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
 	}
 
 	err := captiveBackend.PrepareRange(UnboundedRange(100))
@@ -391,7 +372,6 @@ func TestCaptivePrepareRangeUnboundedRange_FromIsTooFarAheadOfLatestHAS(t *testi
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
 	}
 
 	err := captiveBackend.PrepareRange(UnboundedRange(193))
@@ -413,7 +393,10 @@ func TestCaptivePrepareRangeUnboundedRange_ErrRunFrom(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
+		configPath:        "foo",
+		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+			return mockRunner, nil
+		},
 	}
 
 	err := captiveBackend.PrepareRange(UnboundedRange(65))
@@ -424,20 +407,12 @@ func TestCaptivePrepareRangeUnboundedRange_ErrClosingExistingSession(t *testing.
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("close").Return(errors.New("transient error"))
 
-	mockArchive := &historyarchive.MockArchive{}
-	mockArchive.
-		On("GetRootHAS").
-		Return(historyarchive.HistoryArchiveState{
-			CurrentLedger: uint32(64),
-		}, nil)
-
 	last := uint32(63)
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
 		nextLedger:        63,
 		lastLedger:        &last,
+		stellarCoreRunner: mockRunner,
 	}
 
 	err := captiveBackend.PrepareRange(UnboundedRange(64))
@@ -464,7 +439,10 @@ func TestCaptivePrepareRangeUnboundedRange_ReuseSession(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
+		configPath:        "foo",
+		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+			return mockRunner, nil
+		},
 	}
 
 	err := captiveBackend.PrepareRange(UnboundedRange(65))
@@ -498,7 +476,10 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
+		configPath:        "foo",
+		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+			return mockRunner, nil
+		},
 	}
 
 	err := captiveBackend.PrepareRange(UnboundedRange(64))
@@ -523,6 +504,7 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 	// readAheadBufferSize is 2 so 2 ledgers are buffered: 65 and 66
 	assert.Equal(t, uint32(66), latest)
 
+	mockRunner.On("close").Return(nil).Once()
 	err = captiveBackend.Close()
 	assert.NoError(t, err)
 }
@@ -548,7 +530,9 @@ func TestCaptiveGetLedger(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
+		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+			return mockRunner, nil
+		},
 	}
 
 	// requires PrepareRange
@@ -610,7 +594,9 @@ func TestCaptiveGetLedger_NextLedgerIsDifferentToLedgerFromBuffer(t *testing.T) 
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
+		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+			return mockRunner, nil
+		},
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(65, 66))
@@ -639,7 +625,9 @@ func TestCaptiveGetLedger_ErrReadingMetaResult(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
+		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+			return mockRunner, nil
+		},
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(65, 66))
@@ -674,7 +662,9 @@ func TestCaptiveGetLedger_ErrClosingAfterLastLedger(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
+		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+			return mockRunner, nil
+		},
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(65, 66))
@@ -713,7 +703,9 @@ func TestGetLedgerBoundsCheck(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
+		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+			return mockRunner, nil
+		},
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(128, 130))
@@ -778,7 +770,9 @@ func TestCaptiveGetLedgerTerminated(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunner: mockRunner,
+		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+			return mockRunner, nil
+		},
 	}
 
 	go writeLedgerHeader(writer, 64)

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -345,6 +345,9 @@ func TestCaptivePrepareRange_ErrCatchup(t *testing.T) {
 		archive:           mockArchive,
 		networkPassphrase: network.PublicNetworkPassphrase,
 		stellarCoreRunner: mockRunner,
+		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+			return mockRunner, nil
+		},
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -30,6 +31,10 @@ type stellarCoreRunner struct {
 	networkPassphrase string
 	historyURLs       []string
 
+	started  bool
+	wg       sync.WaitGroup
+	shutdown chan struct{}
+
 	cmd *exec.Cmd
 	// processExit channel receives an error when the process exited with an error
 	// or nil if the process exited without an error.
@@ -42,20 +47,23 @@ type stellarCoreRunner struct {
 func newStellarCoreRunner(executablePath, configPath, networkPassphrase string, historyURLs []string) (*stellarCoreRunner, error) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
+	// Create temp dir
+	random := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tempDir := filepath.Join(os.TempDir(), fmt.Sprintf("captive-stellar-core-%x", random.Uint64()))
+	err := os.MkdirAll(tempDir, 0755)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating subprocess tmpdir")
+	}
+
 	runner := &stellarCoreRunner{
 		executablePath:    executablePath,
 		configPath:        configPath,
 		networkPassphrase: networkPassphrase,
 		historyURLs:       historyURLs,
+		shutdown:          make(chan struct{}),
 		processExit:       make(chan error),
+		tempDir:           tempDir,
 		nonce:             fmt.Sprintf("captive-stellar-core-%x", r.Uint64()),
-	}
-
-	// Create temp dir
-	dir := runner.getTmpDir()
-	err := os.MkdirAll(dir, 0755)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating subprocess tmpdir")
 	}
 
 	if configPath == "" {
@@ -76,7 +84,7 @@ func (r *stellarCoreRunner) generateConfig() string {
 		"DISABLE_XDR_FSYNC=true",
 		"UNSAFE_QUORUM=true",
 		fmt.Sprintf(`NETWORK_PASSPHRASE="%s"`, r.networkPassphrase),
-		fmt.Sprintf(`BUCKET_DIR_PATH="%s"`, filepath.Join(r.getTmpDir(), "buckets")),
+		fmt.Sprintf(`BUCKET_DIR_PATH="%s"`, filepath.Join(r.tempDir, "buckets")),
 	}
 	for i, val := range r.historyURLs {
 		lines = append(lines, fmt.Sprintf("[HISTORY.h%d]", i))
@@ -95,7 +103,7 @@ func (r *stellarCoreRunner) getConfFileName() string {
 	if r.configPath != "" {
 		return r.configPath
 	}
-	return filepath.Join(r.getTmpDir(), "stellar-core.conf")
+	return filepath.Join(r.tempDir, "stellar-core.conf")
 }
 
 func (*stellarCoreRunner) getLogLineWriter() io.Writer {
@@ -116,15 +124,6 @@ func (*stellarCoreRunner) getLogLineWriter() io.Writer {
 	return w
 }
 
-func (r *stellarCoreRunner) getTmpDir() string {
-	if r.tempDir != "" {
-		return r.tempDir
-	}
-	random := rand.New(rand.NewSource(time.Now().UnixNano()))
-	r.tempDir = filepath.Join(os.TempDir(), fmt.Sprintf("captive-stellar-core-%x", random.Uint64()))
-	return r.tempDir
-}
-
 // Makes the temp directory and writes the config file to it; called by the
 // platform-specific captiveStellarCore.Start() methods.
 func (r *stellarCoreRunner) writeConf() error {
@@ -135,7 +134,7 @@ func (r *stellarCoreRunner) writeConf() error {
 func (r *stellarCoreRunner) createCmd(params ...string) (*exec.Cmd, error) {
 	allParams := append([]string{"--conf", r.getConfFileName()}, params...)
 	cmd := exec.Command(r.executablePath, allParams...)
-	cmd.Dir = r.getTmpDir()
+	cmd.Dir = r.tempDir
 	cmd.Stdout = r.getLogLineWriter()
 	cmd.Stderr = r.getLogLineWriter()
 	return cmd, nil
@@ -158,6 +157,9 @@ func (r *stellarCoreRunner) runCmd(params ...string) error {
 }
 
 func (r *stellarCoreRunner) catchup(from, to uint32) error {
+	if r.started {
+		return errors.New("runner already started")
+	}
 	if err := r.runCmd("new-db"); err != nil {
 		return errors.Wrap(err, "error waiting for `stellar-core new-db` subprocess")
 	}
@@ -176,6 +178,7 @@ func (r *stellarCoreRunner) catchup(from, to uint32) error {
 	if err != nil {
 		return errors.Wrap(err, "error starting `stellar-core catchup` subprocess")
 	}
+	r.started = true
 
 	// Do not remove bufio.Reader wrapping. Turns out that each read from a pipe
 	// adds an overhead time so it's better to preload data to a buffer.
@@ -184,6 +187,9 @@ func (r *stellarCoreRunner) catchup(from, to uint32) error {
 }
 
 func (r *stellarCoreRunner) runFrom(from uint32) error {
+	if r.started {
+		return errors.New("runner already started")
+	}
 	var err error
 	if err = r.runCmd("new-db"); err != nil {
 		return errors.Wrap(err, "error waiting for `stellar-core new-db` subprocess")
@@ -205,6 +211,7 @@ func (r *stellarCoreRunner) runFrom(from uint32) error {
 	if err != nil {
 		return errors.Wrap(err, "error starting `stellar-core run` subprocess")
 	}
+	r.started = true
 
 	// Do not remove bufio.Reader wrapping. Turns out that each read from a pipe
 	// adds an overhead time so it's better to preload data to a buffer.
@@ -228,12 +235,20 @@ func (r *stellarCoreRunner) close() error {
 		r.cmd.Wait()
 		r.cmd = nil
 	}
-	err2 = os.RemoveAll(r.getTmpDir())
+	err2 = os.RemoveAll(r.tempDir)
+	r.tempDir = ""
+
 	if err1 != nil {
 		return errors.Wrap(err1, "error killing subprocess")
 	}
 	if err2 != nil {
 		return errors.Wrap(err2, "error removing subprocess tmpdir")
 	}
+	if r.started {
+		close(r.shutdown)
+		r.wg.Wait()
+		close(r.processExit)
+	}
+	r.started = false
 	return nil
 }

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -238,17 +238,18 @@ func (r *stellarCoreRunner) close() error {
 	err2 = os.RemoveAll(r.tempDir)
 	r.tempDir = ""
 
-	if err1 != nil {
-		return errors.Wrap(err1, "error killing subprocess")
-	}
-	if err2 != nil {
-		return errors.Wrap(err2, "error removing subprocess tmpdir")
-	}
 	if r.started {
 		close(r.shutdown)
 		r.wg.Wait()
 		close(r.processExit)
 	}
 	r.started = false
+
+	if err1 != nil {
+		return errors.Wrap(err1, "error killing subprocess")
+	}
+	if err2 != nil {
+		return errors.Wrap(err2, "error removing subprocess tmpdir")
+	}
 	return nil
 }

--- a/ingest/ledgerbackend/stellar_core_runner_windows.go
+++ b/ingest/ledgerbackend/stellar_core_runner_windows.go
@@ -29,9 +29,13 @@ func (c *stellarCoreRunner) start() (io.Reader, error) {
 		return io.Reader(nil), err
 	}
 
+	c.wg.Add(1)
 	go func() {
-		c.processExit <- c.cmd.Wait()
-		close(c.processExit)
+		select {
+		case c.processExit <- c.cmd.Wait():
+		case <-c.shutdown:
+		}
+		c.wg.Done()
 	}()
 
 	// Then accept on the server end.


### PR DESCRIPTION
### What

1. Make sure we reset the runner properly (the backend caller was checking whether the runner was nil to re-create it, but it never set it to nil on `CaptiveCoreBackend.Close()`)
2. Avoid potential go-routine leaks by making sure the `start()` goroutine is done in `close()`
3. Guard callers from launching multiple core instances through the same runner.
4. Remove unnecesary generation of the tempdir path on demand (generate it once in the constructor). I think this was done as a workaround to (1)

Overrides #3154 

### Why

Fixes #3145 #3159 

### Known limitations

N/A
