### PR TITLE
services/horizon: Update integration tests to use MANUAL_CLOSE

### DIFF
--- a/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
@@ -363,7 +363,7 @@ func TestSponsorships(t *testing.T) {
 		// Submit the preauthorized transaction
 		var txResult xdr.TransactionResult
 		tt.NoError(err)
-		txResp, err = client.SubmitTransactionXDR(preAuthTxB64)
+		txResp, err = itest.SubmitTransactionXDR(preAuthTxB64)
 		tt.NoError(err)
 		err = xdr.SafeUnmarshalBase64(txResp.ResultXdr, &txResult)
 		tt.NoError(err)
@@ -716,11 +716,11 @@ func TestSponsorships(t *testing.T) {
 
 		// Check that effects populate.
 		expectedEffects := map[string][]uint{
-			effects.EffectTypeNames[effects.EffectClaimableBalanceSponsorshipCreated]: []uint{0, 1},
-			effects.EffectTypeNames[effects.EffectClaimableBalanceCreated]:            []uint{0, 1},
-			effects.EffectTypeNames[effects.EffectClaimableBalanceClaimantCreated]:    []uint{0, 2},
-			effects.EffectTypeNames[effects.EffectClaimableBalanceSponsorshipRemoved]: []uint{0, 1},
-			effects.EffectTypeNames[effects.EffectClaimableBalanceClaimed]:            []uint{0, 1},
+			effects.EffectTypeNames[effects.EffectClaimableBalanceSponsorshipCreated]: {0, 1},
+			effects.EffectTypeNames[effects.EffectClaimableBalanceCreated]:            {0, 1},
+			effects.EffectTypeNames[effects.EffectClaimableBalanceClaimantCreated]:    {0, 2},
+			effects.EffectTypeNames[effects.EffectClaimableBalanceSponsorshipRemoved]: {0, 1},
+			effects.EffectTypeNames[effects.EffectClaimableBalanceClaimed]:            {0, 1},
 		}
 
 		effectsPage, err := client.Effects(sdk.EffectRequest{Order: "desc", Limit: 100})

--- a/services/horizon/internal/integration/protocol14_state_verifier_test.go
+++ b/services/horizon/internal/integration/protocol14_state_verifier_test.go
@@ -98,10 +98,11 @@ func TestProtocol14StateVerifier(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, txResp.Successful)
 
-	// Wait for the first checkpoint ledger
+	// Reach the first checkpoint ledger
 	for !itest.LedgerIngested(63) {
-		t.Log("First checkpoint ledger (63) not closed yet...")
-		time.Sleep(5 * time.Second)
+		err := itest.CloseCoreLedger()
+		assert.NoError(t, err)
+		time.Sleep(50 * time.Millisecond)
 	}
 
 	var metrics string


### PR DESCRIPTION
### What

Use Core's `MANUAL_CLOSE` mode in integration tests  so that we don't have to wait for ledgers to be closed (we close them explicitly).

### Why

It considerably reduces the execution time of integration tests (From ~13min to ~5min).

Also, it paves the way for enabling integration tests for Captive Core (https://github.com/stellar/go/issues/3153) and contributes towards #3037 .

### Known limitations

We are changing the timing in which the production network operates, which makes the tests deviate from a production scenario.
