### PR TITLE
SEP10 v3.0: Add back homeDomain matching constraint for SEP-10 helpers

### DIFF
--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -898,7 +898,8 @@ func generateRandomNonce(n int) ([]byte, error) {
 // service's homeDomain passed, malicious web services will not be able to use the
 // challenge transaction POSTed back to the authentication endpoint.
 //
-// The homeDomain field is reserved for future use and not used.
+// The challenge's first Manage Data operation is expected to contain the homeDomain
+// parameter passed to the function.
 //
 // It does not verify that the transaction has been signed by the client or
 // that any signatures other than the servers on the transaction are valid. Use
@@ -955,6 +956,11 @@ func ReadChallengeTx(challengeTx, serverAccountID, network, homeDomain string) (
 	if op.SourceAccount == nil {
 		return tx, clientAccountID, errors.New("operation should have a source account")
 	}
+	if strings.Split(op.Name, " ")[0] != homeDomain {
+		return tx, clientAccountID, errors.Errorf("operation key should contain homeDomain (homeDomain=\"%s\", key=\"%s\")",
+			homeDomain, op.Name)
+	}
+
 	clientAccountID = op.SourceAccount.GetAccountID()
 	rawOperations := tx.envelope.Operations()
 	if len(rawOperations) > 0 && rawOperations[0].SourceAccount.Type == xdr.CryptoKeyTypeKeyTypeMuxedEd25519 {

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -957,8 +957,7 @@ func ReadChallengeTx(challengeTx, serverAccountID, network, homeDomain string) (
 		return tx, clientAccountID, errors.New("operation should have a source account")
 	}
 	if strings.Split(op.Name, " ")[0] != homeDomain {
-		return tx, clientAccountID, errors.Errorf("operation key should contain homeDomain (homeDomain=\"%s\", key=\"%s\")",
-			homeDomain, op.Name)
+		return tx, clientAccountID, errors.Errorf("operation key should contain homeDomain (key=%q, homeDomain=%q)", homeDomain, op.Name)
 	}
 
 	clientAccountID = op.SourceAccount.GetAccountID()

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -957,7 +957,7 @@ func ReadChallengeTx(challengeTx, serverAccountID, network string, homeDomains [
 		return tx, clientAccountID, matchedHomeDomain, errors.New("operation should have a source account")
 	}
 	for _, homeDomain := range homeDomains {
-		if op.Name == fmt.Sprintf("%s auth", homeDomain) {
+		if op.Name == homeDomain + " auth" {
 			matchedHomeDomain = homeDomain
 			break
 		}

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -957,7 +957,7 @@ func ReadChallengeTx(challengeTx, serverAccountID, network string, homeDomains [
 		return tx, clientAccountID, matchedHomeDomain, errors.New("operation should have a source account")
 	}
 	for _, homeDomain := range homeDomains {
-		if op.Name == homeDomain + " auth" {
+		if op.Name == homeDomain+" auth" {
 			matchedHomeDomain = homeDomain
 			break
 		}

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -957,7 +957,7 @@ func ReadChallengeTx(challengeTx, serverAccountID, network, homeDomain string) (
 		return tx, clientAccountID, errors.New("operation should have a source account")
 	}
 	if strings.Split(op.Name, " ")[0] != homeDomain {
-		return tx, clientAccountID, errors.Errorf("operation key should contain homeDomain (key=%q, homeDomain=%q)", homeDomain, op.Name)
+		return tx, clientAccountID, errors.Errorf("operation key should contain homeDomain (key=%q, homeDomain=%q)", op.Name, homeDomain)
 	}
 
 	clientAccountID = op.SourceAccount.GetAccountID()

--- a/txnbuild/transaction_challenge_example_test.go
+++ b/txnbuild/transaction_challenge_example_test.go
@@ -52,7 +52,7 @@ func ExampleVerifyChallengeTxThreshold() {
 	// Client reads and signs challenge transaction
 	var signedChallengeTx string
 	{
-		tx, txClientAccountID, err := txnbuild.ReadChallengeTx(challengeTx, serverAccount.Address(), network.TestNetworkPassphrase, "test")
+		tx, txClientAccountID, _, err := txnbuild.ReadChallengeTx(challengeTx, serverAccount.Address(), network.TestNetworkPassphrase, []string{"test"})
 		if err != nil {
 			fmt.Println("Error:", err)
 			return
@@ -75,7 +75,7 @@ func ExampleVerifyChallengeTxThreshold() {
 
 	// Server verifies signed challenge transaction
 	{
-		_, txClientAccountID, err := txnbuild.ReadChallengeTx(challengeTx, serverAccount.Address(), network.TestNetworkPassphrase, "test")
+		_, txClientAccountID, _, err := txnbuild.ReadChallengeTx(challengeTx, serverAccount.Address(), network.TestNetworkPassphrase, []string{"test"})
 		if err != nil {
 			fmt.Println("Error:", err)
 			return
@@ -102,7 +102,7 @@ func ExampleVerifyChallengeTxThreshold() {
 			threshold := txnbuild.Threshold(horizonClientAccount.Thresholds.MedThreshold)
 
 			// Server verifies threshold is met
-			signers, err := txnbuild.VerifyChallengeTxThreshold(signedChallengeTx, serverAccount.Address(), network.TestNetworkPassphrase, "test", threshold, signerSummary)
+			signers, err := txnbuild.VerifyChallengeTxThreshold(signedChallengeTx, serverAccount.Address(), network.TestNetworkPassphrase, []string{"test"}, threshold, signerSummary)
 			if err != nil {
 				fmt.Println("Error:", err)
 				return
@@ -114,7 +114,7 @@ func ExampleVerifyChallengeTxThreshold() {
 			}
 		} else {
 			// Server verifies that master key has signed challenge transaction
-			signersFound, err := txnbuild.VerifyChallengeTxSigners(signedChallengeTx, serverAccount.Address(), network.TestNetworkPassphrase, txClientAccountID)
+			signersFound, err := txnbuild.VerifyChallengeTxSigners(signedChallengeTx, serverAccount.Address(), network.TestNetworkPassphrase, []string{"test"}, txClientAccountID)
 			if err != nil {
 				fmt.Println("Error:", err)
 				return

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -973,7 +973,7 @@ func TestBuildChallengeTx(t *testing.T) {
 
 	{
 		// 1 minute timebound
-		tx, err := BuildChallengeTx(kp0.Seed(), kp0.Address(), "SDF", network.TestNetworkPassphrase, time.Minute)
+		tx, err := BuildChallengeTx(kp0.Seed(), kp0.Address(), "testanchor.stellar.org", network.TestNetworkPassphrase, time.Minute)
 		assert.NoError(t, err)
 		txeBase64, err := tx.Base64()
 		assert.NoError(t, err)
@@ -987,14 +987,14 @@ func TestBuildChallengeTx(t *testing.T) {
 		assert.Equal(t, int64(60), int64(timeDiff), "time difference should be 300 seconds")
 		op := txXDR.Operations()[0]
 		assert.Equal(t, xdr.OperationTypeManageData, op.Body.Type, "operation type should be manage data")
-		assert.Equal(t, xdr.String64("SDF auth"), op.Body.ManageDataOp.DataName, "DataName should be 'SDF auth'")
+		assert.Equal(t, xdr.String64("testanchor.stellar.org auth"), op.Body.ManageDataOp.DataName, "DataName should be 'testanchor.stellar.org auth'")
 		assert.Equal(t, 64, len(*op.Body.ManageDataOp.DataValue), "DataValue should be 64 bytes")
 
 	}
 
 	{
 		// 5 minutes timebound
-		tx, err := BuildChallengeTx(kp0.Seed(), kp0.Address(), "SDF1", network.TestNetworkPassphrase, time.Duration(5*time.Minute))
+		tx, err := BuildChallengeTx(kp0.Seed(), kp0.Address(), "testanchor.stellar.org", network.TestNetworkPassphrase, time.Duration(5*time.Minute))
 		assert.NoError(t, err)
 		txeBase64, err := tx.Base64()
 		assert.NoError(t, err)
@@ -1009,7 +1009,7 @@ func TestBuildChallengeTx(t *testing.T) {
 		assert.Equal(t, int64(300), int64(timeDiff), "time difference should be 300 seconds")
 		op1 := txXDR1.Operations()[0]
 		assert.Equal(t, xdr.OperationTypeManageData, op1.Body.Type, "operation type should be manage data")
-		assert.Equal(t, xdr.String64("SDF1 auth"), op1.Body.ManageDataOp.DataName, "DataName should be 'SDF1 auth'")
+		assert.Equal(t, xdr.String64("testanchor.stellar.org auth"), op1.Body.ManageDataOp.DataName, "DataName should be 'testanchor.stellar.org auth'")
 		assert.Equal(t, 64, len(*op1.Body.ManageDataOp.DataValue), "DataValue should be 64 bytes")
 	}
 
@@ -1503,7 +1503,7 @@ func TestReadChallengeTx_validSignedByServerAndClient(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 
@@ -1522,7 +1522,7 @@ func TestReadChallengeTx_validSignedByServerAndClient(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.NoError(t, err)
@@ -1535,7 +1535,7 @@ func TestReadChallengeTx_validSignedByServer(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx, err := NewTransaction(
@@ -1553,7 +1553,7 @@ func TestReadChallengeTx_validSignedByServer(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.NoError(t, err)
@@ -1566,7 +1566,7 @@ func TestReadChallengeTx_invalidNotSignedByServer(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx, err := NewTransaction(
@@ -1582,7 +1582,7 @@ func TestReadChallengeTx_invalidNotSignedByServer(t *testing.T) {
 
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.EqualError(t, err, "transaction not signed by "+serverKP.Address())
@@ -1595,7 +1595,7 @@ func TestReadChallengeTx_invalidCorrupted(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx, err := NewTransaction(
@@ -1614,7 +1614,7 @@ func TestReadChallengeTx_invalidCorrupted(t *testing.T) {
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
 	tx64 = strings.ReplaceAll(tx64, "A", "B")
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.Nil(t, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.EqualError(
@@ -1632,7 +1632,7 @@ func TestReadChallengeTx_invalidServerAccountIDMismatch(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx, err := NewTransaction(
@@ -1650,7 +1650,7 @@ func TestReadChallengeTx_invalidServerAccountIDMismatch(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.EqualError(t, err, "transaction source account is not equal to server's account")
@@ -1663,7 +1663,7 @@ func TestReadChallengeTx_invalidSeqNoNotZero(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx, err := NewTransaction(
@@ -1681,7 +1681,7 @@ func TestReadChallengeTx_invalidSeqNoNotZero(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.EqualError(t, err, "transaction sequence number must be 0")
@@ -1694,7 +1694,7 @@ func TestReadChallengeTx_invalidTimeboundsInfinite(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx, err := NewTransaction(
@@ -1712,7 +1712,7 @@ func TestReadChallengeTx_invalidTimeboundsInfinite(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.EqualError(t, err, "transaction requires non-infinite timebounds")
@@ -1725,7 +1725,7 @@ func TestReadChallengeTx_invalidTimeboundsOutsideRange(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx, err := NewTransaction(
@@ -1743,7 +1743,7 @@ func TestReadChallengeTx_invalidTimeboundsOutsideRange(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.Error(t, err)
@@ -1774,7 +1774,7 @@ func TestReadChallengeTx_invalidOperationWrongType(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.EqualError(t, err, "operation type should be manage_data")
@@ -1784,7 +1784,7 @@ func TestReadChallengeTx_invalidOperationNoSourceAccount(t *testing.T) {
 	serverKP := newKeypair0()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
 	op := ManageData{
-		Name:  "testserver auth",
+		Name:  "testanchor.stellar.org auth",
 		Value: []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx, err := NewTransaction(
@@ -1802,7 +1802,7 @@ func TestReadChallengeTx_invalidOperationNoSourceAccount(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	_, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	_, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.EqualError(t, err, "operation should have a source account")
 }
 
@@ -1813,7 +1813,7 @@ func TestReadChallengeTx_invalidDataValueWrongEncodedLength(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 45))),
 	}
 	tx, err := NewTransaction(
@@ -1831,7 +1831,7 @@ func TestReadChallengeTx_invalidDataValueWrongEncodedLength(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.EqualError(t, err, "random nonce encoded as base64 should be 64 bytes long")
@@ -1844,7 +1844,7 @@ func TestReadChallengeTx_invalidDataValueCorruptBase64(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA?AAAAAAAAAAAAAAAAAAAAAAAAAA"),
 	}
 	tx, err := NewTransaction(
@@ -1862,7 +1862,7 @@ func TestReadChallengeTx_invalidDataValueCorruptBase64(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.EqualError(t, err, "failed to decode random nonce provided in manage_data operation: illegal base64 data at input byte 37")
@@ -1875,7 +1875,7 @@ func TestReadChallengeTx_invalidDataValueWrongByteLength(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 47))),
 	}
 	tx, err := NewTransaction(
@@ -1894,7 +1894,7 @@ func TestReadChallengeTx_invalidDataValueWrongByteLength(t *testing.T) {
 	tx64, err := tx.Base64()
 	assert.NoError(t, err)
 
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.EqualError(t, err, "random nonce before encoding as base64 should be 48 bytes long")
@@ -1905,7 +1905,7 @@ func TestReadChallengeTx_acceptsV0AndV1Transactions(t *testing.T) {
 	tx, err := BuildChallengeTx(
 		kp0.Seed(),
 		kp0.Address(),
-		"SDF",
+		"testanchor.stellar.org",
 		network.TestNetworkPassphrase,
 		time.Hour,
 	)
@@ -1926,7 +1926,7 @@ func TestReadChallengeTx_acceptsV0AndV1Transactions(t *testing.T) {
 			challenge,
 			kp0.Address(),
 			network.TestNetworkPassphrase,
-			"SDF",
+			"testanchor.stellar.org",
 		)
 		assert.NoError(t, err)
 
@@ -1943,7 +1943,7 @@ func TestReadChallengeTx_forbidsFeeBumpTransactions(t *testing.T) {
 	tx, err := BuildChallengeTx(
 		kp0.Seed(),
 		kp0.Address(),
-		"SDF",
+		"testanchor.stellar.org",
 		network.TestNetworkPassphrase,
 		time.Hour,
 	)
@@ -1968,7 +1968,7 @@ func TestReadChallengeTx_forbidsFeeBumpTransactions(t *testing.T) {
 		challenge,
 		kp0.Address(),
 		network.TestNetworkPassphrase,
-		"SDF",
+		"testanchor.stellar.org",
 	)
 	assert.EqualError(t, err, "challenge cannot be a fee bump transaction")
 }
@@ -1978,7 +1978,7 @@ func TestReadChallengeTx_forbidsMuxedAccounts(t *testing.T) {
 	tx, err := BuildChallengeTx(
 		kp0.Seed(),
 		kp0.Address(),
-		"SDF",
+		"testanchor.stellar.org",
 		network.TestNetworkPassphrase,
 		time.Hour,
 	)
@@ -2002,20 +2002,20 @@ func TestReadChallengeTx_forbidsMuxedAccounts(t *testing.T) {
 		challenge,
 		kp0.Address(),
 		network.TestNetworkPassphrase,
-		"SDF",
+		"testanchor.stellar.org",
 	)
 	errorMessage := "only valid Ed25519 accounts are allowed in challenge transactions"
 	assert.Contains(t, err.Error(), errorMessage)
 }
 
-func TestReadChallengeTx_doesNotVerifyHomeDomain(t *testing.T) {
+func TestReadChallengeTx_doesVerifyHomeDomainFailure(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx, err := NewTransaction(
@@ -2033,10 +2033,37 @@ func TestReadChallengeTx_doesNotVerifyHomeDomain(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "notvalidated")
-	assert.Equal(t, tx, readTx)
-	assert.Equal(t, clientKP.Address(), readClientAccountID)
+	_, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "willfail")
+	assert.EqualError(t, err, "operation key should contain homeDomain (homeDomain=\"willfail\", key=\"testanchor.stellar.org auth\")")
+}
+
+func TestReadChallengeTx_doesVerifyHomeDomainSuccess(t *testing.T) {
+	serverKP := newKeypair0()
+	clientKP := newKeypair1()
+	txSource := NewSimpleAccount(serverKP.Address(), -1)
+	opSource := NewSimpleAccount(clientKP.Address(), 0)
+	op := ManageData{
+		SourceAccount: &opSource,
+		Name:          "testanchor.stellar.org auth",
+		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
+	}
+	tx, err := NewTransaction(
+		TransactionParams{
+			SourceAccount:        &txSource,
+			IncrementSequenceNum: true,
+			Operations:           []Operation{&op},
+			BaseFee:              MinBaseFee,
+			Timebounds:           NewTimeout(1000),
+		},
+	)
 	assert.NoError(t, err)
+
+	tx, err = tx.Sign(network.TestNetworkPassphrase, serverKP)
+	assert.NoError(t, err)
+	tx64, err := tx.Base64()
+	require.NoError(t, err)
+	_, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	assert.Equal(t, nil, err)
 }
 
 func TestReadChallengeTx_allowsAdditionalManageDataOpsWithSourceAccountSetToServerAccount(t *testing.T) {
@@ -2046,12 +2073,12 @@ func TestReadChallengeTx_allowsAdditionalManageDataOpsWithSourceAccountSetToServ
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op1 := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := ManageData{
 		SourceAccount: &txSource,
-		Name:          "a key",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte("a value"),
 	}
 	tx, err := NewTransaction(
@@ -2069,7 +2096,7 @@ func TestReadChallengeTx_allowsAdditionalManageDataOpsWithSourceAccountSetToServ
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.NoError(t, err)
@@ -2082,7 +2109,7 @@ func TestReadChallengeTx_disallowsAdditionalManageDataOpsWithoutSourceAccountSet
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op1 := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := ManageData{
@@ -2105,7 +2132,7 @@ func TestReadChallengeTx_disallowsAdditionalManageDataOpsWithoutSourceAccountSet
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	_, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	_, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.EqualError(t, err, "subsequent operations are unrecognized")
 }
 
@@ -2116,7 +2143,7 @@ func TestReadChallengeTx_disallowsAdditionalOpsOfOtherTypes(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op1 := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := BumpSequence{
@@ -2138,7 +2165,7 @@ func TestReadChallengeTx_disallowsAdditionalOpsOfOtherTypes(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.EqualError(t, err, "operation type should be manage_data")
@@ -2151,7 +2178,7 @@ func TestVerifyChallengeTxThreshold_invalidServer(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 
@@ -2172,7 +2199,7 @@ func TestVerifyChallengeTxThreshold_invalidServer(t *testing.T) {
 	signerSummary := SignerSummary{
 		clientKP.Address(): 1,
 	}
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "transaction not signed by "+serverKP.Address())
 }
@@ -2184,7 +2211,7 @@ func TestVerifyChallengeTxThreshold_validServerAndClientKeyMeetingThreshold(t *t
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -2208,7 +2235,7 @@ func TestVerifyChallengeTxThreshold_validServerAndClientKeyMeetingThreshold(t *t
 		clientKP.Address(),
 	}
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
 	assert.ElementsMatch(t, wantSigners, signersFound)
 	assert.NoError(t, err)
 }
@@ -2221,7 +2248,7 @@ func TestVerifyChallengeTxThreshold_validServerAndMultipleClientKeyMeetingThresh
 	opSource := NewSimpleAccount(clientKP1.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -2247,7 +2274,7 @@ func TestVerifyChallengeTxThreshold_validServerAndMultipleClientKeyMeetingThresh
 		clientKP2.Address(),
 	}
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
 	assert.ElementsMatch(t, wantSigners, signersFound)
 	assert.NoError(t, err)
 }
@@ -2261,7 +2288,7 @@ func TestVerifyChallengeTxThreshold_validServerAndMultipleClientKeyMeetingThresh
 	opSource := NewSimpleAccount(clientKP1.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	threshold := Threshold(3)
@@ -2288,7 +2315,7 @@ func TestVerifyChallengeTxThreshold_validServerAndMultipleClientKeyMeetingThresh
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
 	assert.ElementsMatch(t, wantSigners, signersFound)
 	assert.NoError(t, err)
 }
@@ -2305,7 +2332,7 @@ func TestVerifyChallengeTxThreshold_validServerAndMultipleClientKeyMeetingThresh
 	opSource := NewSimpleAccount(clientKP1.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	threshold := Threshold(3)
@@ -2335,7 +2362,7 @@ func TestVerifyChallengeTxThreshold_validServerAndMultipleClientKeyMeetingThresh
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
 	assert.ElementsMatch(t, wantSigners, signersFound)
 	assert.NoError(t, err)
 }
@@ -2349,7 +2376,7 @@ func TestVerifyChallengeTxThreshold_invalidServerAndMultipleClientKeyNotMeetingT
 	opSource := NewSimpleAccount(clientKP1.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	threshold := Threshold(10)
@@ -2372,7 +2399,7 @@ func TestVerifyChallengeTxThreshold_invalidServerAndMultipleClientKeyNotMeetingT
 	)
 	assert.NoError(t, err)
 
-	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", threshold, signerSummary)
+	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
 	assert.EqualError(t, err, "signers with weight 3 do not meet threshold 10")
 }
 
@@ -2385,7 +2412,7 @@ func TestVerifyChallengeTxThreshold_invalidClientKeyUnrecognized(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP1.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	threshold := Threshold(10)
@@ -2407,7 +2434,7 @@ func TestVerifyChallengeTxThreshold_invalidClientKeyUnrecognized(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", threshold, signerSummary)
+	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
 	assert.EqualError(t, err, "transaction has unrecognized signatures")
 }
 
@@ -2420,7 +2447,7 @@ func TestVerifyChallengeTxThreshold_invalidNoSigners(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP1.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	threshold := Threshold(10)
@@ -2439,7 +2466,7 @@ func TestVerifyChallengeTxThreshold_invalidNoSigners(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", threshold, signerSummary)
+	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
 	assert.EqualError(t, err, "no verifiable signers provided, at least one G... address must be provided")
 }
 
@@ -2451,7 +2478,7 @@ func TestVerifyChallengeTxThreshold_weightsAddToMoreThan8Bits(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP1.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -2477,19 +2504,51 @@ func TestVerifyChallengeTxThreshold_weightsAddToMoreThan8Bits(t *testing.T) {
 		clientKP2.Address(),
 	}
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
 	assert.ElementsMatch(t, wantSigners, signersFound)
 	assert.NoError(t, err)
 }
 
-func TestVerifyChallengeTxThreshold_doesNotVerifyHomeDomain(t *testing.T) {
+func TestVerifyChallengeTxThreshold_doesVerifyHomeDomainFailure(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "will fail auth",
+		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
+	}
+	tx64, err := newSignedTransaction(
+		TransactionParams{
+			SourceAccount:        &txSource,
+			IncrementSequenceNum: true,
+			Operations:           []Operation{&op},
+			BaseFee:              MinBaseFee,
+			Timebounds:           NewTimeout(1000),
+		},
+		network.TestNetworkPassphrase,
+		serverKP, clientKP,
+	)
+	assert.NoError(t, err)
+
+	threshold := Threshold(1)
+	signerSummary := SignerSummary{
+		clientKP.Address(): 1,
+	}
+
+	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
+	assert.EqualError(t, err, "operation key should contain homeDomain (homeDomain=\"testanchor.stellar.org\", key=\"will fail auth\")")
+}
+
+func TestVerifyChallengeTxThreshold_doesVerifyHomeDomainSuccess(t *testing.T) {
+	serverKP := newKeypair0()
+	clientKP := newKeypair1()
+	txSource := NewSimpleAccount(serverKP.Address(), -1)
+	opSource := NewSimpleAccount(clientKP.Address(), 0)
+	op := ManageData{
+		SourceAccount: &opSource,
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -2513,9 +2572,9 @@ func TestVerifyChallengeTxThreshold_doesNotVerifyHomeDomain(t *testing.T) {
 		clientKP.Address(),
 	}
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "notvalidated", threshold, signerSummary)
-	assert.ElementsMatch(t, wantSigners, signersFound)
-	assert.NoError(t, err)
+	signers, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, signers, wantSigners)
 }
 
 func TestVerifyChallengeTxThreshold_allowsAdditionalManageDataOpsWithSourceAccountSetToServerAccount(t *testing.T) {
@@ -2525,7 +2584,7 @@ func TestVerifyChallengeTxThreshold_allowsAdditionalManageDataOpsWithSourceAccou
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op1 := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := ManageData{
@@ -2554,7 +2613,7 @@ func TestVerifyChallengeTxThreshold_allowsAdditionalManageDataOpsWithSourceAccou
 		clientKP.Address(),
 	}
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
 	assert.ElementsMatch(t, wantSigners, signersFound)
 	assert.NoError(t, err)
 }
@@ -2566,7 +2625,7 @@ func TestVerifyChallengeTxThreshold_disallowsAdditionalManageDataOpsWithoutSourc
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op1 := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := ManageData{
@@ -2592,7 +2651,7 @@ func TestVerifyChallengeTxThreshold_disallowsAdditionalManageDataOpsWithoutSourc
 		clientKP.Address(): 1,
 	}
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "subsequent operations are unrecognized")
 }
@@ -2604,7 +2663,7 @@ func TestVerifyChallengeTxThreshold_disallowsAdditionalOpsOfOtherTypes(t *testin
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op1 := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := BumpSequence{
@@ -2629,7 +2688,7 @@ func TestVerifyChallengeTxThreshold_disallowsAdditionalOpsOfOtherTypes(t *testin
 		clientKP.Address(): 1,
 	}
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "operation type should be manage_data")
 }
@@ -2641,7 +2700,7 @@ func TestVerifyChallengeTxSigners_invalidServer(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -2657,7 +2716,7 @@ func TestVerifyChallengeTxSigners_invalidServer(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", clientKP.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address())
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "transaction not signed by "+serverKP.Address())
 }
@@ -2669,7 +2728,7 @@ func TestVerifyChallengeTxSigners_validServerAndClientMasterKey(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -2685,7 +2744,7 @@ func TestVerifyChallengeTxSigners_validServerAndClientMasterKey(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", clientKP.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address())
 	assert.Equal(t, []string{clientKP.Address()}, signersFound)
 	assert.NoError(t, err)
 }
@@ -2697,7 +2756,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndNoClient(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -2713,7 +2772,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndNoClient(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", clientKP.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address())
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "transaction not signed by "+clientKP.Address())
 }
@@ -2726,7 +2785,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndUnrecognizedClient(t *testing.
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -2742,7 +2801,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndUnrecognizedClient(t *testing.
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", clientKP.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address())
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "transaction not signed by "+clientKP.Address())
 }
@@ -2755,7 +2814,7 @@ func TestVerifyChallengeTxSigners_validServerAndMultipleClientSigners(t *testing
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -2771,7 +2830,7 @@ func TestVerifyChallengeTxSigners_validServerAndMultipleClientSigners(t *testing
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", clientKP.Address(), clientKP2.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address(), clientKP2.Address())
 	assert.Equal(t, []string{clientKP.Address(), clientKP2.Address()}, signersFound)
 	assert.NoError(t, err)
 }
@@ -2784,7 +2843,7 @@ func TestVerifyChallengeTxSigners_validServerAndMultipleClientSignersReverseOrde
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -2800,7 +2859,7 @@ func TestVerifyChallengeTxSigners_validServerAndMultipleClientSignersReverseOrde
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", clientKP.Address(), clientKP2.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address(), clientKP2.Address())
 	assert.Equal(t, []string{clientKP.Address(), clientKP2.Address()}, signersFound)
 	assert.NoError(t, err)
 }
@@ -2813,7 +2872,7 @@ func TestVerifyChallengeTxSigners_validServerAndClientSignersNotMasterKey(t *tes
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -2829,7 +2888,7 @@ func TestVerifyChallengeTxSigners_validServerAndClientSignersNotMasterKey(t *tes
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", clientKP2.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP2.Address())
 	assert.Equal(t, []string{clientKP2.Address()}, signersFound)
 	assert.NoError(t, err)
 }
@@ -2842,7 +2901,7 @@ func TestVerifyChallengeTxSigners_validServerAndClientSignersIgnoresServerSigner
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -2858,7 +2917,7 @@ func TestVerifyChallengeTxSigners_validServerAndClientSignersIgnoresServerSigner
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", serverKP.Address(), clientKP2.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", serverKP.Address(), clientKP2.Address())
 	assert.Equal(t, []string{clientKP2.Address()}, signersFound)
 	assert.NoError(t, err)
 }
@@ -2871,7 +2930,7 @@ func TestVerifyChallengeTxSigners_invalidServerNoClientSignersIgnoresServerSigne
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -2887,7 +2946,7 @@ func TestVerifyChallengeTxSigners_invalidServerNoClientSignersIgnoresServerSigne
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", serverKP.Address(), clientKP2.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", serverKP.Address(), clientKP2.Address())
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "transaction not signed by "+clientKP2.Address())
 }
@@ -2900,7 +2959,7 @@ func TestVerifyChallengeTxSigners_validServerAndClientSignersIgnoresDuplicateSig
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -2916,7 +2975,7 @@ func TestVerifyChallengeTxSigners_validServerAndClientSignersIgnoresDuplicateSig
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", clientKP2.Address(), clientKP2.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP2.Address(), clientKP2.Address())
 	assert.Equal(t, []string{clientKP2.Address()}, signersFound)
 	assert.NoError(t, err)
 }
@@ -2932,7 +2991,7 @@ func TestVerifyChallengeTxSigners_validIgnorePreauthTxHashAndXHash(t *testing.T)
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -2948,7 +3007,7 @@ func TestVerifyChallengeTxSigners_validIgnorePreauthTxHashAndXHash(t *testing.T)
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", clientKP2.Address(), preauthTxHash, xHash, unknownSignerType)
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP2.Address(), preauthTxHash, xHash, unknownSignerType)
 	assert.Equal(t, []string{clientKP2.Address()}, signersFound)
 	assert.NoError(t, err)
 }
@@ -2961,7 +3020,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndClientSignersIgnoresDuplicateS
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -2977,7 +3036,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndClientSignersIgnoresDuplicateS
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", clientKP.Address(), clientKP.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address(), clientKP.Address())
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "transaction not signed by "+clientKP.Address())
 }
@@ -2990,7 +3049,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndClientSignersFailsDuplicateSig
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -3006,7 +3065,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndClientSignersFailsDuplicateSig
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", clientKP2.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP2.Address())
 	assert.Equal(t, []string{clientKP2.Address()}, signersFound)
 	assert.EqualError(t, err, "transaction has unrecognized signatures")
 }
@@ -3019,7 +3078,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndClientSignersFailsSignerSeed(t
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -3035,7 +3094,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndClientSignersFailsSignerSeed(t
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", clientKP2.Seed())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP2.Seed())
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "no verifiable signers provided, at least one G... address must be provided")
 }
@@ -3047,7 +3106,7 @@ func TestVerifyChallengeTxSigners_invalidNoSigners(t *testing.T) {
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -3063,18 +3122,18 @@ func TestVerifyChallengeTxSigners_invalidNoSigners(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	_, err = VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver")
+	_, err = VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
 	assert.EqualError(t, err, "no verifiable signers provided, at least one G... address must be provided")
 }
 
-func TestVerifyChallengeTxSigners_doesNotVerifyHomeDomain(t *testing.T) {
+func TestVerifyChallengeTxSigners_doesVerifyHomeDomainFailure(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	tx64, err := newSignedTransaction(
@@ -3090,9 +3149,35 @@ func TestVerifyChallengeTxSigners_doesNotVerifyHomeDomain(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "notvalidated", clientKP.Address())
-	assert.Equal(t, []string{clientKP.Address()}, signersFound)
+	_, err = VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "validation failed", clientKP.Address())
+	assert.EqualError(t, err, "operation key should contain homeDomain (homeDomain=\"validation failed\", key=\"testanchor.stellar.org auth\")")
+}
+
+func TestVerifyChallengeTxSigners_doesVerifyHomeDomainSuccess(t *testing.T) {
+	serverKP := newKeypair0()
+	clientKP := newKeypair1()
+	txSource := NewSimpleAccount(serverKP.Address(), -1)
+	opSource := NewSimpleAccount(clientKP.Address(), 0)
+	op := ManageData{
+		SourceAccount: &opSource,
+		Name:          "testanchor.stellar.org auth",
+		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
+	}
+	tx64, err := newSignedTransaction(
+		TransactionParams{
+			SourceAccount:        &txSource,
+			IncrementSequenceNum: true,
+			Operations:           []Operation{&op},
+			BaseFee:              MinBaseFee,
+			Timebounds:           NewTimeout(1000),
+		},
+		network.TestNetworkPassphrase,
+		serverKP, clientKP,
+	)
 	assert.NoError(t, err)
+
+	_, err = VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address())
+	assert.Equal(t, nil, err)
 }
 
 func TestVerifyChallengeTxSigners_allowsAdditionalManageDataOpsWithSourceAccountSetToServerAccount(t *testing.T) {
@@ -3102,7 +3187,7 @@ func TestVerifyChallengeTxSigners_allowsAdditionalManageDataOpsWithSourceAccount
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op1 := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := ManageData{
@@ -3123,7 +3208,7 @@ func TestVerifyChallengeTxSigners_allowsAdditionalManageDataOpsWithSourceAccount
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", clientKP.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address())
 	assert.Equal(t, []string{clientKP.Address()}, signersFound)
 	assert.NoError(t, err)
 }
@@ -3135,7 +3220,7 @@ func TestVerifyChallengeTxSigners_disallowsAdditionalManageDataOpsWithoutSourceA
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op1 := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := ManageData{
@@ -3156,7 +3241,7 @@ func TestVerifyChallengeTxSigners_disallowsAdditionalManageDataOpsWithoutSourceA
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", clientKP.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address())
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "subsequent operations are unrecognized")
 }
@@ -3168,7 +3253,7 @@ func TestVerifyChallengeTxSigners_disallowsAdditionalOpsOfOtherTypes(t *testing.
 	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op1 := ManageData{
 		SourceAccount: &opSource,
-		Name:          "testserver auth",
+		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := BumpSequence{
@@ -3188,7 +3273,7 @@ func TestVerifyChallengeTxSigners_disallowsAdditionalOpsOfOtherTypes(t *testing.
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testserver", clientKP.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address())
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "operation type should be manage_data")
 }

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1522,7 +1522,7 @@ func TestReadChallengeTx_validSignedByServerAndClient(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.NoError(t, err)
@@ -1553,7 +1553,7 @@ func TestReadChallengeTx_validSignedByServer(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.NoError(t, err)
@@ -1582,7 +1582,7 @@ func TestReadChallengeTx_invalidNotSignedByServer(t *testing.T) {
 
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.EqualError(t, err, "transaction not signed by "+serverKP.Address())
@@ -1614,7 +1614,7 @@ func TestReadChallengeTx_invalidCorrupted(t *testing.T) {
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
 	tx64 = strings.ReplaceAll(tx64, "A", "B")
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.Nil(t, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.EqualError(
@@ -1650,7 +1650,7 @@ func TestReadChallengeTx_invalidServerAccountIDMismatch(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.EqualError(t, err, "transaction source account is not equal to server's account")
@@ -1681,7 +1681,7 @@ func TestReadChallengeTx_invalidSeqNoNotZero(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.EqualError(t, err, "transaction sequence number must be 0")
@@ -1712,7 +1712,7 @@ func TestReadChallengeTx_invalidTimeboundsInfinite(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.EqualError(t, err, "transaction requires non-infinite timebounds")
@@ -1743,7 +1743,7 @@ func TestReadChallengeTx_invalidTimeboundsOutsideRange(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.Error(t, err)
@@ -1774,7 +1774,7 @@ func TestReadChallengeTx_invalidOperationWrongType(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.EqualError(t, err, "operation type should be manage_data")
@@ -1802,7 +1802,7 @@ func TestReadChallengeTx_invalidOperationNoSourceAccount(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	_, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	_, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.EqualError(t, err, "operation should have a source account")
 }
 
@@ -1831,7 +1831,7 @@ func TestReadChallengeTx_invalidDataValueWrongEncodedLength(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.EqualError(t, err, "random nonce encoded as base64 should be 64 bytes long")
@@ -1862,7 +1862,7 @@ func TestReadChallengeTx_invalidDataValueCorruptBase64(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.EqualError(t, err, "failed to decode random nonce provided in manage_data operation: illegal base64 data at input byte 37")
@@ -1894,7 +1894,7 @@ func TestReadChallengeTx_invalidDataValueWrongByteLength(t *testing.T) {
 	tx64, err := tx.Base64()
 	assert.NoError(t, err)
 
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.EqualError(t, err, "random nonce before encoding as base64 should be 48 bytes long")
@@ -1922,11 +1922,11 @@ func TestReadChallengeTx_acceptsV0AndV1Transactions(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, challenge := range []string{v1Challenge, v0Challenge} {
-		parsedTx, clientAccountID, err := ReadChallengeTx(
+		parsedTx, clientAccountID, _, err := ReadChallengeTx(
 			challenge,
 			kp0.Address(),
 			network.TestNetworkPassphrase,
-			"testanchor.stellar.org",
+			[]string{"testanchor.stellar.org"},
 		)
 		assert.NoError(t, err)
 
@@ -1964,11 +1964,11 @@ func TestReadChallengeTx_forbidsFeeBumpTransactions(t *testing.T) {
 
 	challenge, err := feeBumpTx.Base64()
 	assert.NoError(t, err)
-	_, _, err = ReadChallengeTx(
+	_, _, _, err = ReadChallengeTx(
 		challenge,
 		kp0.Address(),
 		network.TestNetworkPassphrase,
-		"testanchor.stellar.org",
+		[]string{"testanchor.stellar.org"},
 	)
 	assert.EqualError(t, err, "challenge cannot be a fee bump transaction")
 }
@@ -1998,11 +1998,11 @@ func TestReadChallengeTx_forbidsMuxedAccounts(t *testing.T) {
 	challenge, err := marshallBase64(env, env.Signatures())
 	assert.NoError(t, err)
 
-	_, _, err = ReadChallengeTx(
+	_, _, _, err = ReadChallengeTx(
 		challenge,
 		kp0.Address(),
 		network.TestNetworkPassphrase,
-		"testanchor.stellar.org",
+		[]string{"testanchor.stellar.org"},
 	)
 	errorMessage := "only valid Ed25519 accounts are allowed in challenge transactions"
 	assert.Contains(t, err.Error(), errorMessage)
@@ -2033,8 +2033,8 @@ func TestReadChallengeTx_doesVerifyHomeDomainFailure(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	_, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "willfail")
-	assert.EqualError(t, err, "operation key should contain homeDomain (key=\"testanchor.stellar.org auth\", homeDomain=\"willfail\")")
+	_, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"willfail"})
+	assert.EqualError(t, err, "operation key does not match any homeDomains passed (key=\"testanchor.stellar.org auth\", homeDomains=[willfail])")
 }
 
 func TestReadChallengeTx_doesVerifyHomeDomainSuccess(t *testing.T) {
@@ -2062,7 +2062,7 @@ func TestReadChallengeTx_doesVerifyHomeDomainSuccess(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	_, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	_, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.Equal(t, nil, err)
 }
 
@@ -2096,7 +2096,7 @@ func TestReadChallengeTx_allowsAdditionalManageDataOpsWithSourceAccountSetToServ
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.NoError(t, err)
@@ -2132,7 +2132,7 @@ func TestReadChallengeTx_disallowsAdditionalManageDataOpsWithoutSourceAccountSet
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	_, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	_, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.EqualError(t, err, "subsequent operations are unrecognized")
 }
 
@@ -2165,7 +2165,7 @@ func TestReadChallengeTx_disallowsAdditionalOpsOfOtherTypes(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.EqualError(t, err, "operation type should be manage_data")
@@ -2199,7 +2199,7 @@ func TestVerifyChallengeTxThreshold_invalidServer(t *testing.T) {
 	signerSummary := SignerSummary{
 		clientKP.Address(): 1,
 	}
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, threshold, signerSummary)
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "transaction not signed by "+serverKP.Address())
 }
@@ -2235,7 +2235,7 @@ func TestVerifyChallengeTxThreshold_validServerAndClientKeyMeetingThreshold(t *t
 		clientKP.Address(),
 	}
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, threshold, signerSummary)
 	assert.ElementsMatch(t, wantSigners, signersFound)
 	assert.NoError(t, err)
 }
@@ -2274,7 +2274,7 @@ func TestVerifyChallengeTxThreshold_validServerAndMultipleClientKeyMeetingThresh
 		clientKP2.Address(),
 	}
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, threshold, signerSummary)
 	assert.ElementsMatch(t, wantSigners, signersFound)
 	assert.NoError(t, err)
 }
@@ -2315,7 +2315,7 @@ func TestVerifyChallengeTxThreshold_validServerAndMultipleClientKeyMeetingThresh
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, threshold, signerSummary)
 	assert.ElementsMatch(t, wantSigners, signersFound)
 	assert.NoError(t, err)
 }
@@ -2362,7 +2362,7 @@ func TestVerifyChallengeTxThreshold_validServerAndMultipleClientKeyMeetingThresh
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, threshold, signerSummary)
 	assert.ElementsMatch(t, wantSigners, signersFound)
 	assert.NoError(t, err)
 }
@@ -2399,7 +2399,7 @@ func TestVerifyChallengeTxThreshold_invalidServerAndMultipleClientKeyNotMeetingT
 	)
 	assert.NoError(t, err)
 
-	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
+	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, threshold, signerSummary)
 	assert.EqualError(t, err, "signers with weight 3 do not meet threshold 10")
 }
 
@@ -2434,7 +2434,7 @@ func TestVerifyChallengeTxThreshold_invalidClientKeyUnrecognized(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
+	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, threshold, signerSummary)
 	assert.EqualError(t, err, "transaction has unrecognized signatures")
 }
 
@@ -2466,7 +2466,7 @@ func TestVerifyChallengeTxThreshold_invalidNoSigners(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
+	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, threshold, signerSummary)
 	assert.EqualError(t, err, "no verifiable signers provided, at least one G... address must be provided")
 }
 
@@ -2504,7 +2504,7 @@ func TestVerifyChallengeTxThreshold_weightsAddToMoreThan8Bits(t *testing.T) {
 		clientKP2.Address(),
 	}
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, threshold, signerSummary)
 	assert.ElementsMatch(t, wantSigners, signersFound)
 	assert.NoError(t, err)
 }
@@ -2537,8 +2537,8 @@ func TestVerifyChallengeTxThreshold_doesVerifyHomeDomainFailure(t *testing.T) {
 		clientKP.Address(): 1,
 	}
 
-	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
-	assert.EqualError(t, err, "operation key should contain homeDomain (key=\"will fail auth\", homeDomain=\"testanchor.stellar.org\")")
+	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, threshold, signerSummary)
+	assert.EqualError(t, err, "operation key does not match any homeDomains passed (key=\"will fail auth\", homeDomains=[testanchor.stellar.org])")
 }
 
 func TestVerifyChallengeTxThreshold_doesVerifyHomeDomainSuccess(t *testing.T) {
@@ -2572,7 +2572,7 @@ func TestVerifyChallengeTxThreshold_doesVerifyHomeDomainSuccess(t *testing.T) {
 		clientKP.Address(),
 	}
 
-	signers, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
+	signers, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, threshold, signerSummary)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, signers, wantSigners)
 }
@@ -2613,7 +2613,7 @@ func TestVerifyChallengeTxThreshold_allowsAdditionalManageDataOpsWithSourceAccou
 		clientKP.Address(),
 	}
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, threshold, signerSummary)
 	assert.ElementsMatch(t, wantSigners, signersFound)
 	assert.NoError(t, err)
 }
@@ -2651,7 +2651,7 @@ func TestVerifyChallengeTxThreshold_disallowsAdditionalManageDataOpsWithoutSourc
 		clientKP.Address(): 1,
 	}
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, threshold, signerSummary)
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "subsequent operations are unrecognized")
 }
@@ -2688,7 +2688,7 @@ func TestVerifyChallengeTxThreshold_disallowsAdditionalOpsOfOtherTypes(t *testin
 		clientKP.Address(): 1,
 	}
 
-	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
+	signersFound, err := VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, threshold, signerSummary)
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "operation type should be manage_data")
 }
@@ -2716,7 +2716,7 @@ func TestVerifyChallengeTxSigners_invalidServer(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, clientKP.Address())
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "transaction not signed by "+serverKP.Address())
 }
@@ -2744,7 +2744,7 @@ func TestVerifyChallengeTxSigners_validServerAndClientMasterKey(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, clientKP.Address())
 	assert.Equal(t, []string{clientKP.Address()}, signersFound)
 	assert.NoError(t, err)
 }
@@ -2772,7 +2772,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndNoClient(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, clientKP.Address())
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "transaction not signed by "+clientKP.Address())
 }
@@ -2801,7 +2801,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndUnrecognizedClient(t *testing.
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, clientKP.Address())
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "transaction not signed by "+clientKP.Address())
 }
@@ -2830,7 +2830,7 @@ func TestVerifyChallengeTxSigners_validServerAndMultipleClientSigners(t *testing
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address(), clientKP2.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, clientKP.Address(), clientKP2.Address())
 	assert.Equal(t, []string{clientKP.Address(), clientKP2.Address()}, signersFound)
 	assert.NoError(t, err)
 }
@@ -2859,7 +2859,7 @@ func TestVerifyChallengeTxSigners_validServerAndMultipleClientSignersReverseOrde
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address(), clientKP2.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, clientKP.Address(), clientKP2.Address())
 	assert.Equal(t, []string{clientKP.Address(), clientKP2.Address()}, signersFound)
 	assert.NoError(t, err)
 }
@@ -2888,7 +2888,7 @@ func TestVerifyChallengeTxSigners_validServerAndClientSignersNotMasterKey(t *tes
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP2.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, clientKP2.Address())
 	assert.Equal(t, []string{clientKP2.Address()}, signersFound)
 	assert.NoError(t, err)
 }
@@ -2917,7 +2917,7 @@ func TestVerifyChallengeTxSigners_validServerAndClientSignersIgnoresServerSigner
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", serverKP.Address(), clientKP2.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, serverKP.Address(), clientKP2.Address())
 	assert.Equal(t, []string{clientKP2.Address()}, signersFound)
 	assert.NoError(t, err)
 }
@@ -2946,7 +2946,7 @@ func TestVerifyChallengeTxSigners_invalidServerNoClientSignersIgnoresServerSigne
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", serverKP.Address(), clientKP2.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, serverKP.Address(), clientKP2.Address())
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "transaction not signed by "+clientKP2.Address())
 }
@@ -2975,7 +2975,7 @@ func TestVerifyChallengeTxSigners_validServerAndClientSignersIgnoresDuplicateSig
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP2.Address(), clientKP2.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, clientKP2.Address(), clientKP2.Address())
 	assert.Equal(t, []string{clientKP2.Address()}, signersFound)
 	assert.NoError(t, err)
 }
@@ -3007,7 +3007,7 @@ func TestVerifyChallengeTxSigners_validIgnorePreauthTxHashAndXHash(t *testing.T)
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP2.Address(), preauthTxHash, xHash, unknownSignerType)
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, clientKP2.Address(), preauthTxHash, xHash, unknownSignerType)
 	assert.Equal(t, []string{clientKP2.Address()}, signersFound)
 	assert.NoError(t, err)
 }
@@ -3036,7 +3036,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndClientSignersIgnoresDuplicateS
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address(), clientKP.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, clientKP.Address(), clientKP.Address())
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "transaction not signed by "+clientKP.Address())
 }
@@ -3065,7 +3065,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndClientSignersFailsDuplicateSig
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP2.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, clientKP2.Address())
 	assert.Equal(t, []string{clientKP2.Address()}, signersFound)
 	assert.EqualError(t, err, "transaction has unrecognized signatures")
 }
@@ -3094,7 +3094,7 @@ func TestVerifyChallengeTxSigners_invalidServerAndClientSignersFailsSignerSeed(t
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP2.Seed())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, clientKP2.Seed())
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "no verifiable signers provided, at least one G... address must be provided")
 }
@@ -3122,7 +3122,7 @@ func TestVerifyChallengeTxSigners_invalidNoSigners(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	_, err = VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org")
+	_, err = VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"})
 	assert.EqualError(t, err, "no verifiable signers provided, at least one G... address must be provided")
 }
 
@@ -3149,8 +3149,8 @@ func TestVerifyChallengeTxSigners_doesVerifyHomeDomainFailure(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	_, err = VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "validation failed", clientKP.Address())
-	assert.EqualError(t, err, "operation key should contain homeDomain (key=\"testanchor.stellar.org auth\", homeDomain=\"validation failed\")")
+	_, err = VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"validation failed"}, clientKP.Address())
+	assert.EqualError(t, err, "operation key does not match any homeDomains passed (key=\"testanchor.stellar.org auth\", homeDomains=[validation failed])")
 }
 
 func TestVerifyChallengeTxSigners_doesVerifyHomeDomainSuccess(t *testing.T) {
@@ -3176,7 +3176,7 @@ func TestVerifyChallengeTxSigners_doesVerifyHomeDomainSuccess(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	_, err = VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address())
+	_, err = VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, clientKP.Address())
 	assert.Equal(t, nil, err)
 }
 
@@ -3208,7 +3208,7 @@ func TestVerifyChallengeTxSigners_allowsAdditionalManageDataOpsWithSourceAccount
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, clientKP.Address())
 	assert.Equal(t, []string{clientKP.Address()}, signersFound)
 	assert.NoError(t, err)
 }
@@ -3241,7 +3241,7 @@ func TestVerifyChallengeTxSigners_disallowsAdditionalManageDataOpsWithoutSourceA
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, clientKP.Address())
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "subsequent operations are unrecognized")
 }
@@ -3273,7 +3273,7 @@ func TestVerifyChallengeTxSigners_disallowsAdditionalOpsOfOtherTypes(t *testing.
 	)
 	assert.NoError(t, err)
 
-	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", clientKP.Address())
+	signersFound, err := VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, []string{"testanchor.stellar.org"}, clientKP.Address())
 	assert.Empty(t, signersFound)
 	assert.EqualError(t, err, "operation type should be manage_data")
 }

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -2034,7 +2034,7 @@ func TestReadChallengeTx_doesVerifyHomeDomainFailure(t *testing.T) {
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
 	_, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "willfail")
-	assert.EqualError(t, err, "operation key should contain homeDomain (homeDomain=\"willfail\", key=\"testanchor.stellar.org auth\")")
+	assert.EqualError(t, err, "operation key should contain homeDomain (key=\"testanchor.stellar.org auth\", homeDomain=\"willfail\")")
 }
 
 func TestReadChallengeTx_doesVerifyHomeDomainSuccess(t *testing.T) {
@@ -2538,7 +2538,7 @@ func TestVerifyChallengeTxThreshold_doesVerifyHomeDomainFailure(t *testing.T) {
 	}
 
 	_, err = VerifyChallengeTxThreshold(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testanchor.stellar.org", threshold, signerSummary)
-	assert.EqualError(t, err, "operation key should contain homeDomain (homeDomain=\"testanchor.stellar.org\", key=\"will fail auth\")")
+	assert.EqualError(t, err, "operation key should contain homeDomain (key=\"will fail auth\", homeDomain=\"testanchor.stellar.org\")")
 }
 
 func TestVerifyChallengeTxThreshold_doesVerifyHomeDomainSuccess(t *testing.T) {
@@ -3150,7 +3150,7 @@ func TestVerifyChallengeTxSigners_doesVerifyHomeDomainFailure(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = VerifyChallengeTxSigners(tx64, serverKP.Address(), network.TestNetworkPassphrase, "validation failed", clientKP.Address())
-	assert.EqualError(t, err, "operation key should contain homeDomain (homeDomain=\"validation failed\", key=\"testanchor.stellar.org auth\")")
+	assert.EqualError(t, err, "operation key should contain homeDomain (key=\"testanchor.stellar.org auth\", homeDomain=\"validation failed\")")
 }
 
 func TestVerifyChallengeTxSigners_doesVerifyHomeDomainSuccess(t *testing.T) {


### PR DESCRIPTION
resolves stellar/go#3176

Updates tests and `readChallengeTx` function to check for the `homeDomain` parameter within the first Manage Data op key.