### PR TITLE
services/horizon/cmd: Fix db-url flag parsing in horizon db commands

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -5,6 +5,10 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).x
 
 ## Unreleased
 
+## v1.11.1
+
+* Fix bug in parsing `db-url` parameter in `horizon db migrate` and `horizon db init` commands ([#3192](https://github.com/stellar/go/pull/3192)).
+
 ## v1.11.0
 
 * The `service` field emitted in ingestion logs has been changed from `expingest` to  `ingest` ([#3118](https://github.com/stellar/go/pull/3118)).

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -17,6 +17,8 @@ import (
 )
 
 const (
+	// DatabaseURLFlagName is the command line flag for configuring the Horizon postgres URL
+	DatabaseURLFlagName = "db-url"
 	// StellarCoreDBURLFlagName is the command line flag for configuring the postgres Stellar Core URL
 	StellarCoreDBURLFlagName = "stellar-core-db-url"
 	// StellarCoreDBURLFlagName is the command line flag for configuring the URL fore Stellar Core HTTP endpoint
@@ -71,19 +73,18 @@ func checkMigrations(config Config) {
 // Flags returns a Config instance and a list of commandline flags which modify the Config instance
 func Flags() (*Config, support.ConfigOptions) {
 	config := &Config{}
-	var dbURLConfigOption = &support.ConfigOption{
-		Name:      "db-url",
-		EnvVar:    "DATABASE_URL",
-		ConfigKey: &config.DatabaseURL,
-		OptType:   types.String,
-		Required:  true,
-		Usage:     "horizon postgres database to connect with",
-	}
 
 	// flags defines the complete flag configuration for horizon.
 	// Add a new entry here to connect a new field in the horizon.Config struct
 	var flags = support.ConfigOptions{
-		dbURLConfigOption,
+		&support.ConfigOption{
+			Name:      DatabaseURLFlagName,
+			EnvVar:    "DATABASE_URL",
+			ConfigKey: &config.DatabaseURL,
+			OptType:   types.String,
+			Required:  true,
+			Usage:     "horizon postgres database to connect with",
+		},
 		&support.ConfigOption{
 			Name:        "stellar-core-binary-path",
 			OptType:     types.String,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Close https://github.com/stellar/go/issues/3191

The `horizon db migrate` and `horizon db init` commands share the `db-url` command line parameter with the horizon service flags defined in services/horizon/cmd/root.go. The horizon service flags are also initialized in root.go:

```golang
func init() {
	err := flags.Init(rootCmd)
	if err != nil {
		stdLog.Fatal(err.Error())
	}
}
```

To parse the `db-url` param in the migrate and init commands, we need to call `flag.Require()` and `flag.SetValue()`.

The reason why this code wasn't working before is because we were calling on `Require()` and `SetValue()` on `dbURLConfigOption` which was never initialized against any of the db commands or the root command.

### Known limitations

[N/A]
