### PR TITLE
services/horizon: Fix typo in Circle's horizon hash-tag image publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -475,9 +475,9 @@ workflows:
       - publish_commit_hash_horizon_docker_image:
           filters:
             tags:
-              only: master
-            branches:
               ignore: /.*/
+            branches:
+              only: master
       - publish_horizon_docker_image:
           filters:
               tags:


### PR DESCRIPTION
Followup to https://github.com/stellar/go/pull/3190