### PR TITLE
services/horizon: Avoid waiting for the first checkpoint in captive-core online mode

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -269,28 +269,30 @@ func (c *CaptiveStellarCore) runFromParams(from uint32) (runFrom uint32, ledgerH
 	}
 
 	if from <= 63 {
-		// For ledgers before (and including) first checkpoint, get/wait the first
-		// checkpoint to get the ledger header. It will always start streaming
-		// from ledger 2.
+		// For ledgers before (and including) first checkpoint, we start streaming
+		// without providing a hash, to avoid waiting for the checkpoint.
+		// It will always start streaming from ledger 2.
 		nextLedger = 2
+		runFrom = 2
 		// The line below is to support a special case for streaming ledger 2
 		// that works for all other ledgers <= 63 (fast-forward).
 		// We can't set from=2 because Stellar-Core will not allow starting from 1.
 		// To solve this we start from 3 and exploit the fast that Stellar-Core
 		// will stream data from 2 for the first checkpoint.
 		from = 3
-	} else {
-		// For ledgers after the first checkpoint, start at the previous checkpoint
-		// and fast-forward from there.
-		if !historyarchive.IsCheckpoint(from) {
-			from = historyarchive.PrevCheckpoint(from)
-		}
-		// Streaming will start from the previous checkpoint + 1
-		nextLedger = from - 63
-		if nextLedger < 2 {
-			// Stellar-Core always streams from ledger 2 at min.
-			nextLedger = 2
-		}
+		return
+	}
+
+	// For ledgers after the first checkpoint, start at the previous checkpoint
+	// and fast-forward from there.
+	if !historyarchive.IsCheckpoint(from) {
+		from = historyarchive.PrevCheckpoint(from)
+	}
+	// Streaming will start from the previous checkpoint + 1
+	nextLedger = from - 63
+	if nextLedger < 2 {
+		// Stellar-Core always streams from ledger 2 at min.
+		nextLedger = 2
 	}
 
 	runFrom = from - 1

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -885,7 +885,11 @@ func TestCaptiveRunFromParams(t *testing.T) {
 			runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(tc.from)
 			tt.NoError(err)
 			tt.Equal(tc.runFrom, runFrom, "runFrom")
-			tt.Equal("0101010100000000000000000000000000000000000000000000000000000000", ledgerHash)
+			if tc.from <= 63 {
+				tt.Empty(ledgerHash)
+			} else {
+				tt.Equal("0101010100000000000000000000000000000000000000000000000000000000", ledgerHash)
+			}
 			tt.Equal(tc.nextLedger, nextLedger, "nextLedger")
 		})
 	}

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -229,13 +229,17 @@ func (r *stellarCoreRunner) runFrom(from uint32, hash string) error {
 		return errors.New("runner already started")
 	}
 	var err error
-	r.cmd, err = r.createCmd(
+	args := []string{
 		"run",
 		"--in-memory",
 		"--start-at-ledger", fmt.Sprintf("%d", from),
-		"--start-at-hash", hash,
 		"--metadata-output-stream", r.getPipeName(),
-	)
+	}
+	if hash != "" {
+		args = append(args, "--start-at-hash", hash)
+	}
+
+	r.cmd, err = r.createCmd(args...)
 	if err != nil {
 		return errors.Wrap(err, "error creating `stellar-core run` subprocess")
 	}


### PR DESCRIPTION
### What

As discussed with @rokopt and @graydon , there is no need to provide a ledger hash when streaming from ledger before the first checkpoint.

### Why

It allows Horizon to start ingesting before the first checkpoint is reached (which incurs in a ~5min wait when ingesting from the beginning).

### Known limitations
N/A
