### PR TITLE
Update Makefiles to label images with timestamps

### DIFF
--- a/exp/services/recoverysigner/Makefile
+++ b/exp/services/recoverysigner/Makefile
@@ -3,10 +3,13 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 
 # If TAG is not provided set default value
 TAG ?= stellar/recoverysigner:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+BUILD_DATE := $(shell date --rfc-3339=seconds)
 
 docker-build:
 	cd ../../../ && \
-	$(SUDO) docker build -f exp/services/recoverysigner/docker/Dockerfile -t $(TAG) .
+	$(SUDO) docker build --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	-f exp/services/recoverysigner/docker/Dockerfile -t $(TAG) .
 
 docker-push:
 	cd ../../../ && \

--- a/exp/services/recoverysigner/Makefile
+++ b/exp/services/recoverysigner/Makefile
@@ -4,7 +4,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # If TAG is not provided set default value
 TAG ?= stellar/recoverysigner:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date --rfc-3339=seconds)
+BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
 
 docker-build:
 	cd ../../../ && \

--- a/exp/services/webauth/Makefile
+++ b/exp/services/webauth/Makefile
@@ -4,7 +4,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # If TAG is not provided set default value
 TAG ?= stellar/webauth:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date --rfc-3339=seconds)
+BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
 
 docker-build:
 	cd ../../../ && \

--- a/exp/services/webauth/Makefile
+++ b/exp/services/webauth/Makefile
@@ -3,10 +3,13 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 
 # If TAG is not provided set default value
 TAG ?= stellar/webauth:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+BUILD_DATE := $(shell date --rfc-3339=seconds)
 
 docker-build:
 	cd ../../../ && \
-	$(SUDO) docker build -f exp/services/webauth/docker/Dockerfile -t $(TAG) .
+	$(SUDO) docker build --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	-f exp/services/webauth/docker/Dockerfile -t $(TAG) .
 
 docker-push:
 	cd ../../../ && \

--- a/services/friendbot/Makefile
+++ b/services/friendbot/Makefile
@@ -3,10 +3,13 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 
 # If TAG is not provided set default value
 TAG ?= stellar/friendbot:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+BUILD_DATE := $(shell date --rfc-3339=seconds)
 
 docker-build:
 	cd ../../ && \
-	$(SUDO) docker build -f services/friendbot/docker/Dockerfile -t $(TAG) .
+	$(SUDO) docker build --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	-f services/friendbot/docker/Dockerfile -t $(TAG) .
 
 docker-push:
 	cd ../../ && \

--- a/services/friendbot/Makefile
+++ b/services/friendbot/Makefile
@@ -4,7 +4,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # If TAG is not provided set default value
 TAG ?= stellar/friendbot:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date --rfc-3339=seconds)
+BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
 
 docker-build:
 	cd ../../ && \

--- a/services/keystore/Makefile
+++ b/services/keystore/Makefile
@@ -4,7 +4,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # If TAG is not provided set default value
 TAG ?= stellar/keystore:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date --rfc-3339=seconds)
+BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
 
 docker-build:
 	cd ../../ && \

--- a/services/keystore/Makefile
+++ b/services/keystore/Makefile
@@ -3,10 +3,13 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 
 # If TAG is not provided set default value
 TAG ?= stellar/keystore:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+BUILD_DATE := $(shell date --rfc-3339=seconds)
 
 docker-build:
 	cd ../../ && \
-	$(SUDO) docker build -f services/keystore/docker/Dockerfile -t $(TAG) .
+	$(SUDO) docker build --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	-f services/keystore/docker/Dockerfile -t $(TAG) .
 
 docker-push:
 	cd ../../ && \

--- a/services/ticker/Makefile
+++ b/services/ticker/Makefile
@@ -3,14 +3,18 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 
 # If TAG is not provided set default value
 TAG ?= stellar/ticker:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+BUILD_DATE := $(shell date --rfc-3339=seconds)
 
 docker-build:
 	cd ../../ && \
-	$(SUDO) docker build -f services/ticker/docker/Dockerfile -t $(TAG) .
+	$(SUDO) docker build --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	-f services/ticker/docker/Dockerfile -t $(TAG) .
 
 docker-push:
 	cd ../../ && \
 	$(SUDO) docker push $(TAG)
 
 docker-build-dev:
-	$(SUDO) docker build -f docker/Dockerfile-dev -t $(TAG) .
+	$(SUDO) docker build --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	-f docker/Dockerfile-dev -t $(TAG) .

--- a/services/ticker/Makefile
+++ b/services/ticker/Makefile
@@ -4,7 +4,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # If TAG is not provided set default value
 TAG ?= stellar/ticker:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date --rfc-3339=seconds)
+BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
 
 docker-build:
 	cd ../../ && \


### PR DESCRIPTION
### What

This change adds org.opencontainers.image.created label to all
docker images.

### Why

The label can be used to determine build timestamp which can be
different from image tag or layer push timestamp.