### PR TITLE
services/horizon: Remove global ledger state

### DIFF
--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -120,7 +120,7 @@ func (q AccountsQuery) Asset() *xdr.Asset {
 
 // GetAccountsHandler is the action handler for the /accounts endpoint
 type GetAccountsHandler struct {
-	LedgerCache *ledger.Cache
+	LedgerState *ledger.State
 }
 
 // GetResourcePage returns a page containing the account records that have
@@ -130,7 +130,7 @@ func (handler GetAccountsHandler) GetResourcePage(
 	r *http.Request,
 ) ([]hal.Pageable, error) {
 	ctx := r.Context()
-	pq, err := GetPageQuery(handler.LedgerCache, r, DisableCursorValidation)
+	pq, err := GetPageQuery(handler.LedgerState, r, DisableCursorValidation)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -2,13 +2,13 @@ package actions
 
 import (
 	"context"
-	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 	"strings"
 
 	protocol "github.com/stellar/go/protocols/horizon"
 	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 	"strings"
 
@@ -118,7 +119,9 @@ func (q AccountsQuery) Asset() *xdr.Asset {
 }
 
 // GetAccountsHandler is the action handler for the /accounts endpoint
-type GetAccountsHandler struct{}
+type GetAccountsHandler struct {
+	LedgerCache *ledger.Cache
+}
 
 // GetResourcePage returns a page containing the account records that have
 // `signer` as a signer or have a trustline to the given asset.
@@ -127,7 +130,7 @@ func (handler GetAccountsHandler) GetResourcePage(
 	r *http.Request,
 ) ([]hal.Pageable, error) {
 	ctx := r.Context()
-	pq, err := GetPageQuery(r, DisableCursorValidation)
+	pq, err := GetPageQuery(handler.LedgerCache, r, DisableCursorValidation)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/asset.go
+++ b/services/horizon/internal/actions/asset.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"fmt"
-	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 	"strings"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"

--- a/services/horizon/internal/actions/asset.go
+++ b/services/horizon/internal/actions/asset.go
@@ -19,7 +19,7 @@ import (
 
 // AssetStatsHandler is the action handler for the /asset endpoint
 type AssetStatsHandler struct {
-	LedgerCache *ledger.Cache
+	LedgerState *ledger.State
 }
 
 func (handler AssetStatsHandler) validateAssetParams(code, issuer string, pq db2.PageQuery) error {
@@ -125,7 +125,7 @@ func (handler AssetStatsHandler) GetResourcePage(
 		return nil, err
 	}
 
-	pq, err := GetPageQuery(handler.LedgerCache, r, DisableCursorValidation)
+	pq, err := GetPageQuery(handler.LedgerState, r, DisableCursorValidation)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/asset.go
+++ b/services/horizon/internal/actions/asset.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"fmt"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 	"strings"
 
@@ -18,6 +19,7 @@ import (
 
 // AssetStatsHandler is the action handler for the /asset endpoint
 type AssetStatsHandler struct {
+	LedgerCache *ledger.Cache
 }
 
 func (handler AssetStatsHandler) validateAssetParams(code, issuer string, pq db2.PageQuery) error {
@@ -123,7 +125,7 @@ func (handler AssetStatsHandler) GetResourcePage(
 		return nil, err
 	}
 
-	pq, err := GetPageQuery(r, DisableCursorValidation)
+	pq, err := GetPageQuery(handler.LedgerCache, r, DisableCursorValidation)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/claimable_balance.go
+++ b/services/horizon/internal/actions/claimable_balance.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 	"fmt"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 	"strings"
 
@@ -129,6 +130,7 @@ func (q ClaimableBalancesQuery) URITemplate() string {
 }
 
 type GetClaimableBalancesHandler struct {
+	LedgerCache *ledger.Cache
 }
 
 // GetResourcePage returns a page of claimable balances.
@@ -143,7 +145,7 @@ func (handler GetClaimableBalancesHandler) GetResourcePage(
 		return nil, err
 	}
 
-	pq, err := GetPageQuery(r, DisableCursorValidation)
+	pq, err := GetPageQuery(handler.LedgerCache, r, DisableCursorValidation)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/claimable_balance.go
+++ b/services/horizon/internal/actions/claimable_balance.go
@@ -130,7 +130,7 @@ func (q ClaimableBalancesQuery) URITemplate() string {
 }
 
 type GetClaimableBalancesHandler struct {
-	LedgerCache *ledger.Cache
+	LedgerState *ledger.State
 }
 
 // GetResourcePage returns a page of claimable balances.
@@ -145,7 +145,7 @@ func (handler GetClaimableBalancesHandler) GetResourcePage(
 		return nil, err
 	}
 
-	pq, err := GetPageQuery(handler.LedgerCache, r, DisableCursorValidation)
+	pq, err := GetPageQuery(handler.LedgerState, r, DisableCursorValidation)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/claimable_balance.go
+++ b/services/horizon/internal/actions/claimable_balance.go
@@ -3,7 +3,6 @@ package actions
 import (
 	"context"
 	"fmt"
-	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 	"strings"
 
@@ -11,6 +10,7 @@ import (
 	protocol "github.com/stellar/go/protocols/horizon"
 	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"

--- a/services/horizon/internal/actions/effects.go
+++ b/services/horizon/internal/actions/effects.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 
 	"github.com/stellar/go/services/horizon/internal/context"
@@ -42,15 +43,17 @@ func (qp EffectsQuery) Validate() error {
 	return nil
 }
 
-type GetEffectsHandler struct{}
+type GetEffectsHandler struct {
+	LedgerCache *ledger.Cache
+}
 
 func (handler GetEffectsHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
-	pq, err := GetPageQuery(r)
+	pq, err := GetPageQuery(handler.LedgerCache, r)
 	if err != nil {
 		return nil, err
 	}
 
-	err = validateCursorWithinHistory(pq)
+	err = validateCursorWithinHistory(handler.LedgerCache, pq)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/effects.go
+++ b/services/horizon/internal/actions/effects.go
@@ -1,12 +1,12 @@
 package actions
 
 import (
-	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 
 	"github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"

--- a/services/horizon/internal/actions/effects.go
+++ b/services/horizon/internal/actions/effects.go
@@ -44,16 +44,16 @@ func (qp EffectsQuery) Validate() error {
 }
 
 type GetEffectsHandler struct {
-	LedgerCache *ledger.Cache
+	LedgerState *ledger.State
 }
 
 func (handler GetEffectsHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
-	pq, err := GetPageQuery(handler.LedgerCache, r)
+	pq, err := GetPageQuery(handler.LedgerState, r)
 	if err != nil {
 		return nil, err
 	}
 
-	err = validateCursorWithinHistory(handler.LedgerCache, pq)
+	err = validateCursorWithinHistory(handler.LedgerState, pq)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -58,7 +58,7 @@ func SetLastLedgerHeader(w HeaderWriter, lastLedger uint32) {
 
 // getCursor retrieves a string from either the URLParams, form or query string.
 // This method uses the priority (URLParams, Form, Query).
-func getCursor(ledgerCache *ledger.Cache, r *http.Request, name string) (string, error) {
+func getCursor(ledgerState *ledger.State, r *http.Request, name string) (string, error) {
 	cursor, err := getString(r, name)
 
 	if err != nil {
@@ -66,7 +66,7 @@ func getCursor(ledgerCache *ledger.Cache, r *http.Request, name string) (string,
 	}
 
 	if cursor == "now" {
-		tid := toid.AfterLedger(ledgerCache.CurrentState().HistoryLatest)
+		tid := toid.AfterLedger(ledgerState.CurrentStatus().HistoryLatest)
 		cursor = tid.String()
 	}
 
@@ -180,7 +180,7 @@ func getLimit(r *http.Request, name string, def uint64, max uint64) (uint64, err
 
 // GetPageQuery is a helper that returns a new db.PageQuery struct initialized
 // using the results from a call to GetPagingParams()
-func GetPageQuery(ledgerCache *ledger.Cache, r *http.Request, opts ...Opt) (db2.PageQuery, error) {
+func GetPageQuery(ledgerState *ledger.State, r *http.Request, opts ...Opt) (db2.PageQuery, error) {
 	disableCursorValidation := false
 	for _, opt := range opts {
 		if opt == DisableCursorValidation {
@@ -188,7 +188,7 @@ func GetPageQuery(ledgerCache *ledger.Cache, r *http.Request, opts ...Opt) (db2.
 		}
 	}
 
-	cursor, err := getCursor(ledgerCache, r, ParamCursor)
+	cursor, err := getCursor(ledgerState, r, ParamCursor)
 	if err != nil {
 		return db2.PageQuery{}, err
 	}
@@ -535,7 +535,7 @@ func validateAssetParams(aType, code, issuer, prefix string) error {
 // validateCursorWithinHistory compares the requested page of data against the
 // ledger state of the history database.  In the event that the cursor is
 // guaranteed to return no results, we return a 410 GONE http response.
-func validateCursorWithinHistory(ledgerCache *ledger.Cache, pq db2.PageQuery) error {
+func validateCursorWithinHistory(ledgerState *ledger.State, pq db2.PageQuery) error {
 	// an ascending query should never return a gone response:  An ascending query
 	// prior to known history should return results at the beginning of history,
 	// and an ascending query beyond the end of history should not error out but
@@ -560,7 +560,7 @@ func validateCursorWithinHistory(ledgerCache *ledger.Cache, pq db2.PageQuery) er
 		return problem.MakeInvalidFieldProblem("cursor", errors.New("invalid value"))
 	}
 
-	elder := toid.New(ledgerCache.CurrentState().HistoryElder, 0, 0)
+	elder := toid.New(ledgerState.CurrentStatus().HistoryElder, 0, 0)
 
 	if cursor <= elder.ToInt64() {
 		return &hProblem.BeforeHistory

--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -58,7 +58,7 @@ func SetLastLedgerHeader(w HeaderWriter, lastLedger uint32) {
 
 // getCursor retrieves a string from either the URLParams, form or query string.
 // This method uses the priority (URLParams, Form, Query).
-func getCursor(r *http.Request, name string) (string, error) {
+func getCursor(ledgerCache *ledger.Cache, r *http.Request, name string) (string, error) {
 	cursor, err := getString(r, name)
 
 	if err != nil {
@@ -66,7 +66,7 @@ func getCursor(r *http.Request, name string) (string, error) {
 	}
 
 	if cursor == "now" {
-		tid := toid.AfterLedger(ledger.CurrentState().HistoryLatest)
+		tid := toid.AfterLedger(ledgerCache.CurrentState().HistoryLatest)
 		cursor = tid.String()
 	}
 
@@ -180,7 +180,7 @@ func getLimit(r *http.Request, name string, def uint64, max uint64) (uint64, err
 
 // GetPageQuery is a helper that returns a new db.PageQuery struct initialized
 // using the results from a call to GetPagingParams()
-func GetPageQuery(r *http.Request, opts ...Opt) (db2.PageQuery, error) {
+func GetPageQuery(ledgerCache *ledger.Cache, r *http.Request, opts ...Opt) (db2.PageQuery, error) {
 	disableCursorValidation := false
 	for _, opt := range opts {
 		if opt == DisableCursorValidation {
@@ -188,7 +188,7 @@ func GetPageQuery(r *http.Request, opts ...Opt) (db2.PageQuery, error) {
 		}
 	}
 
-	cursor, err := getCursor(r, ParamCursor)
+	cursor, err := getCursor(ledgerCache, r, ParamCursor)
 	if err != nil {
 		return db2.PageQuery{}, err
 	}
@@ -535,7 +535,7 @@ func validateAssetParams(aType, code, issuer, prefix string) error {
 // validateCursorWithinHistory compares the requested page of data against the
 // ledger state of the history database.  In the event that the cursor is
 // guaranteed to return no results, we return a 410 GONE http response.
-func validateCursorWithinHistory(pq db2.PageQuery) error {
+func validateCursorWithinHistory(ledgerCache *ledger.Cache, pq db2.PageQuery) error {
 	// an ascending query should never return a gone response:  An ascending query
 	// prior to known history should return results at the beginning of history,
 	// and an ascending query beyond the end of history should not error out but
@@ -560,7 +560,7 @@ func validateCursorWithinHistory(pq db2.PageQuery) error {
 		return problem.MakeInvalidFieldProblem("cursor", errors.New("invalid value"))
 	}
 
-	elder := toid.New(ledger.CurrentState().HistoryElder, 0, 0)
+	elder := toid.New(ledgerCache.CurrentState().HistoryElder, 0, 0)
 
 	if cursor <= elder.ToInt64() {
 		return &hProblem.BeforeHistory

--- a/services/horizon/internal/actions/helpers_test.go
+++ b/services/horizon/internal/actions/helpers_test.go
@@ -66,19 +66,19 @@ func TestGetCursor(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
 
-	ledgerCache := &ledger.Cache{}
+	ledgerState := &ledger.State{}
 	// now uses the ledger state
 	r := makeTestActionRequest("/?cursor=now", nil)
-	cursor, err := getCursor(ledgerCache, r, "cursor")
+	cursor, err := getCursor(ledgerState, r, "cursor")
 	if tt.Assert.NoError(err) {
-		expected := toid.AfterLedger(ledgerCache.CurrentState().HistoryLatest).String()
+		expected := toid.AfterLedger(ledgerState.CurrentStatus().HistoryLatest).String()
 		tt.Assert.Equal(expected, cursor)
 	}
 
 	//Last-Event-ID overrides cursor
 	r = makeFooBarTestActionRequest()
 	r.Header.Set("Last-Event-ID", "from_header")
-	cursor, err = getCursor(ledgerCache, r, "cursor")
+	cursor, err = getCursor(ledgerState, r, "cursor")
 	if tt.Assert.NoError(err) {
 		tt.Assert.Equal("from_header", cursor)
 	}
@@ -136,7 +136,7 @@ func TestValidateCursorWithinHistory(t *testing.T) {
 		t.Run(fmt.Sprintf("cursor: %s", tc.cursor), func(t *testing.T) {
 			pq, err := db2.NewPageQuery(tc.cursor, false, tc.order, 10)
 			tt.NoError(err)
-			err = validateCursorWithinHistory(&ledger.Cache{}, pq)
+			err = validateCursorWithinHistory(&ledger.State{}, pq)
 
 			if tc.valid {
 				tt.NoError(err)
@@ -239,10 +239,10 @@ func TestActionGetPageQuery(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
 	r := makeFooBarTestActionRequest()
-	ledgerCache := &ledger.Cache{}
+	ledgerState := &ledger.State{}
 
 	// happy path
-	pq, err := GetPageQuery(ledgerCache, r)
+	pq, err := GetPageQuery(ledgerState, r)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal("123456", pq.Cursor)
 	tt.Assert.Equal(uint64(2), pq.Limit)
@@ -252,13 +252,13 @@ func TestActionGetPageQuery(t *testing.T) {
 	r = makeTestActionRequest("/?limit=foo", nil)
 	_, err = getLimit(r, "limit", 1, 200)
 	tt.Assert.Error(err)
-	_, err = GetPageQuery(ledgerCache, r)
+	_, err = GetPageQuery(ledgerState, r)
 	tt.Assert.Error(err)
 
 	// regression: https://github.com/stellar/go/services/horizon/internal/issues/372
 	// (limit of 0 turns into 10)
 	makeTestActionRequest("/?limit=0", nil)
-	_, err = GetPageQuery(ledgerCache, r)
+	_, err = GetPageQuery(ledgerState, r)
 	tt.Assert.Error(err)
 }
 
@@ -266,10 +266,10 @@ func TestGetPageQuery(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
 	r := makeFooBarTestActionRequest()
-	ledgerCache := &ledger.Cache{}
+	ledgerState := &ledger.State{}
 
 	// happy path
-	pq, err := GetPageQuery(ledgerCache, r)
+	pq, err := GetPageQuery(ledgerState, r)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal("123456", pq.Cursor)
 	tt.Assert.Equal(uint64(2), pq.Limit)
@@ -279,13 +279,13 @@ func TestGetPageQuery(t *testing.T) {
 	r = makeTestActionRequest("/?limit=foo", nil)
 	_, err = getLimit(r, "limit", 1, 200)
 	tt.Assert.Error(err)
-	_, err = GetPageQuery(ledgerCache, r)
+	_, err = GetPageQuery(ledgerState, r)
 	tt.Assert.Error(err)
 
 	// regression: https://github.com/stellar/go/services/horizon/internal/issues/372
 	// (limit of 0 turns into 10)
 	r = makeTestActionRequest("/?limit=0", nil)
-	_, err = GetPageQuery(ledgerCache, r)
+	_, err = GetPageQuery(ledgerState, r)
 	tt.Assert.Error(err)
 }
 

--- a/services/horizon/internal/actions/helpers_test.go
+++ b/services/horizon/internal/actions/helpers_test.go
@@ -66,18 +66,19 @@ func TestGetCursor(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
 
+	ledgerCache := &ledger.Cache{}
 	// now uses the ledger state
 	r := makeTestActionRequest("/?cursor=now", nil)
-	cursor, err := getCursor(r, "cursor")
+	cursor, err := getCursor(ledgerCache, r, "cursor")
 	if tt.Assert.NoError(err) {
-		expected := toid.AfterLedger(ledger.CurrentState().HistoryLatest).String()
+		expected := toid.AfterLedger(ledgerCache.CurrentState().HistoryLatest).String()
 		tt.Assert.Equal(expected, cursor)
 	}
 
 	//Last-Event-ID overrides cursor
 	r = makeFooBarTestActionRequest()
 	r.Header.Set("Last-Event-ID", "from_header")
-	cursor, err = getCursor(r, "cursor")
+	cursor, err = getCursor(ledgerCache, r, "cursor")
 	if tt.Assert.NoError(err) {
 		tt.Assert.Equal("from_header", cursor)
 	}
@@ -135,7 +136,7 @@ func TestValidateCursorWithinHistory(t *testing.T) {
 		t.Run(fmt.Sprintf("cursor: %s", tc.cursor), func(t *testing.T) {
 			pq, err := db2.NewPageQuery(tc.cursor, false, tc.order, 10)
 			tt.NoError(err)
-			err = validateCursorWithinHistory(pq)
+			err = validateCursorWithinHistory(&ledger.Cache{}, pq)
 
 			if tc.valid {
 				tt.NoError(err)
@@ -238,9 +239,10 @@ func TestActionGetPageQuery(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
 	r := makeFooBarTestActionRequest()
+	ledgerCache := &ledger.Cache{}
 
 	// happy path
-	pq, err := GetPageQuery(r)
+	pq, err := GetPageQuery(ledgerCache, r)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal("123456", pq.Cursor)
 	tt.Assert.Equal(uint64(2), pq.Limit)
@@ -250,13 +252,13 @@ func TestActionGetPageQuery(t *testing.T) {
 	r = makeTestActionRequest("/?limit=foo", nil)
 	_, err = getLimit(r, "limit", 1, 200)
 	tt.Assert.Error(err)
-	_, err = GetPageQuery(r)
+	_, err = GetPageQuery(ledgerCache, r)
 	tt.Assert.Error(err)
 
 	// regression: https://github.com/stellar/go/services/horizon/internal/issues/372
 	// (limit of 0 turns into 10)
 	makeTestActionRequest("/?limit=0", nil)
-	_, err = GetPageQuery(r)
+	_, err = GetPageQuery(ledgerCache, r)
 	tt.Assert.Error(err)
 }
 
@@ -264,9 +266,10 @@ func TestGetPageQuery(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
 	r := makeFooBarTestActionRequest()
+	ledgerCache := &ledger.Cache{}
 
 	// happy path
-	pq, err := GetPageQuery(r)
+	pq, err := GetPageQuery(ledgerCache, r)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal("123456", pq.Cursor)
 	tt.Assert.Equal(uint64(2), pq.Limit)
@@ -276,13 +279,13 @@ func TestGetPageQuery(t *testing.T) {
 	r = makeTestActionRequest("/?limit=foo", nil)
 	_, err = getLimit(r, "limit", 1, 200)
 	tt.Assert.Error(err)
-	_, err = GetPageQuery(r)
+	_, err = GetPageQuery(ledgerCache, r)
 	tt.Assert.Error(err)
 
 	// regression: https://github.com/stellar/go/services/horizon/internal/issues/372
 	// (limit of 0 turns into 10)
 	r = makeTestActionRequest("/?limit=0", nil)
-	_, err = GetPageQuery(r)
+	_, err = GetPageQuery(ledgerCache, r)
 	tt.Assert.Error(err)
 }
 

--- a/services/horizon/internal/actions/ledger.go
+++ b/services/horizon/internal/actions/ledger.go
@@ -13,16 +13,16 @@ import (
 )
 
 type GetLedgersHandler struct {
-	LedgerCache *ledger.Cache
+	LedgerState *ledger.State
 }
 
 func (handler GetLedgersHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
-	pq, err := GetPageQuery(handler.LedgerCache, r)
+	pq, err := GetPageQuery(handler.LedgerState, r)
 	if err != nil {
 		return nil, err
 	}
 
-	err = validateCursorWithinHistory(handler.LedgerCache, pq)
+	err = validateCursorWithinHistory(handler.LedgerState, pq)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ type LedgerByIDQuery struct {
 }
 
 type GetLedgerByIDHandler struct {
-	LedgerCache *ledger.Cache
+	LedgerState *ledger.State
 }
 
 func (handler GetLedgerByIDHandler) GetResource(w HeaderWriter, r *http.Request) (interface{}, error) {
@@ -65,7 +65,7 @@ func (handler GetLedgerByIDHandler) GetResource(w HeaderWriter, r *http.Request)
 	if err != nil {
 		return nil, err
 	}
-	if int32(qp.LedgerID) < handler.LedgerCache.CurrentState().HistoryElder {
+	if int32(qp.LedgerID) < handler.LedgerState.CurrentStatus().HistoryElder {
 		return nil, problem.BeforeHistory
 	}
 	historyQ, err := context.HistoryQFromRequest(r)

--- a/services/horizon/internal/actions/ledger.go
+++ b/services/horizon/internal/actions/ledger.go
@@ -12,15 +12,17 @@ import (
 	"github.com/stellar/go/support/render/hal"
 )
 
-type GetLedgersHandler struct{}
+type GetLedgersHandler struct {
+	LedgerCache *ledger.Cache
+}
 
 func (handler GetLedgersHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
-	pq, err := GetPageQuery(r)
+	pq, err := GetPageQuery(handler.LedgerCache, r)
 	if err != nil {
 		return nil, err
 	}
 
-	err = validateCursorWithinHistory(pq)
+	err = validateCursorWithinHistory(handler.LedgerCache, pq)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +55,9 @@ type LedgerByIDQuery struct {
 	LedgerID uint32 `schema:"ledger_id" valid:"-"`
 }
 
-type GetLedgerByIDHandler struct{}
+type GetLedgerByIDHandler struct {
+	LedgerCache *ledger.Cache
+}
 
 func (handler GetLedgerByIDHandler) GetResource(w HeaderWriter, r *http.Request) (interface{}, error) {
 	qp := LedgerByIDQuery{}
@@ -61,7 +65,7 @@ func (handler GetLedgerByIDHandler) GetResource(w HeaderWriter, r *http.Request)
 	if err != nil {
 		return nil, err
 	}
-	if int32(qp.LedgerID) < ledger.CurrentState().HistoryElder {
+	if int32(qp.LedgerID) < handler.LedgerCache.CurrentState().HistoryElder {
 		return nil, problem.BeforeHistory
 	}
 	historyQ, err := context.HistoryQFromRequest(r)

--- a/services/horizon/internal/actions/offer.go
+++ b/services/horizon/internal/actions/offer.go
@@ -76,7 +76,7 @@ func (q OffersQuery) Validate() error {
 
 // GetOffersHandler is the action handler for the /offers endpoint
 type GetOffersHandler struct {
-	LedgerCache *ledger.Cache
+	LedgerState *ledger.State
 }
 
 // GetResourcePage returns a page of offers.
@@ -91,7 +91,7 @@ func (handler GetOffersHandler) GetResourcePage(
 		return nil, err
 	}
 
-	pq, err := GetPageQuery(handler.LedgerCache, r)
+	pq, err := GetPageQuery(handler.LedgerState, r)
 	if err != nil {
 		return nil, err
 	}
@@ -134,11 +134,11 @@ type AccountOffersQuery struct {
 // GetAccountOffersHandler is the action handler for the
 // `/accounts/{account_id}/offers` endpoint when using experimental ingestion.
 type GetAccountOffersHandler struct {
-	LedgerCache *ledger.Cache
+	LedgerState *ledger.State
 }
 
 func (handler GetAccountOffersHandler) parseOffersQuery(r *http.Request) (history.OffersQuery, error) {
-	pq, err := GetPageQuery(handler.LedgerCache, r)
+	pq, err := GetPageQuery(handler.LedgerState, r)
 	if err != nil {
 		return history.OffersQuery{}, err
 	}

--- a/services/horizon/internal/actions/offer.go
+++ b/services/horizon/internal/actions/offer.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 
 	"github.com/stellar/go/protocols/horizon"
@@ -75,6 +76,7 @@ func (q OffersQuery) Validate() error {
 
 // GetOffersHandler is the action handler for the /offers endpoint
 type GetOffersHandler struct {
+	LedgerCache *ledger.Cache
 }
 
 // GetResourcePage returns a page of offers.
@@ -89,7 +91,7 @@ func (handler GetOffersHandler) GetResourcePage(
 		return nil, err
 	}
 
-	pq, err := GetPageQuery(r)
+	pq, err := GetPageQuery(handler.LedgerCache, r)
 	if err != nil {
 		return nil, err
 	}
@@ -132,10 +134,11 @@ type AccountOffersQuery struct {
 // GetAccountOffersHandler is the action handler for the
 // `/accounts/{account_id}/offers` endpoint when using experimental ingestion.
 type GetAccountOffersHandler struct {
+	LedgerCache *ledger.Cache
 }
 
 func (handler GetAccountOffersHandler) parseOffersQuery(r *http.Request) (history.OffersQuery, error) {
-	pq, err := GetPageQuery(r)
+	pq, err := GetPageQuery(handler.LedgerCache, r)
 	if err != nil {
 		return history.OffersQuery{}, err
 	}

--- a/services/horizon/internal/actions/offer.go
+++ b/services/horizon/internal/actions/offer.go
@@ -2,12 +2,12 @@ package actions
 
 import (
 	"context"
-	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 
 	"github.com/stellar/go/protocols/horizon"
 	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -59,7 +59,7 @@ func (qp OperationsQuery) Validate() error {
 
 // GetOperationsHandler is the action handler for all end-points returning a list of operations.
 type GetOperationsHandler struct {
-	LedgerCache  *ledger.Cache
+	LedgerState  *ledger.State
 	OnlyPayments bool
 }
 
@@ -67,12 +67,12 @@ type GetOperationsHandler struct {
 func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
 	ctx := r.Context()
 
-	pq, err := GetPageQuery(handler.LedgerCache, r)
+	pq, err := GetPageQuery(handler.LedgerState, r)
 	if err != nil {
 		return nil, err
 	}
 
-	err = validateCursorWithinHistory(handler.LedgerCache, pq)
+	err = validateCursorWithinHistory(handler.LedgerState, pq)
 	if err != nil {
 		return nil, err
 	}
@@ -123,12 +123,12 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 
 // GetOperationByIDHandler is the action handler for all end-points returning a list of operations.
 type GetOperationByIDHandler struct {
-	LedgerCache *ledger.Cache
+	LedgerState *ledger.State
 }
 
 // OperationQuery query struct for operation/id end-point
 type OperationQuery struct {
-	LedgerCache *ledger.Cache `valid:"-"`
+	LedgerState *ledger.State `valid:"-"`
 	Joinable    `valid:"optional"`
 	ID          uint64 `schema:"id" valid:"-"`
 }
@@ -136,7 +136,7 @@ type OperationQuery struct {
 // Validate runs extra validations on query parameters
 func (qp OperationQuery) Validate() error {
 	parsed := toid.Parse(int64(qp.ID))
-	if parsed.LedgerSequence < qp.LedgerCache.CurrentState().HistoryElder {
+	if parsed.LedgerSequence < qp.LedgerState.CurrentStatus().HistoryElder {
 		return problem.BeforeHistory
 	}
 	return nil
@@ -146,7 +146,7 @@ func (qp OperationQuery) Validate() error {
 func (handler GetOperationByIDHandler) GetResource(w HeaderWriter, r *http.Request) (interface{}, error) {
 	ctx := r.Context()
 	qp := OperationQuery{
-		LedgerCache: handler.LedgerCache,
+		LedgerState: handler.LedgerState,
 	}
 	err := getParams(&qp, r)
 	if err != nil {

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -59,6 +59,7 @@ func (qp OperationsQuery) Validate() error {
 
 // GetOperationsHandler is the action handler for all end-points returning a list of operations.
 type GetOperationsHandler struct {
+	LedgerCache  *ledger.Cache
 	OnlyPayments bool
 }
 
@@ -66,12 +67,12 @@ type GetOperationsHandler struct {
 func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
 	ctx := r.Context()
 
-	pq, err := GetPageQuery(r)
+	pq, err := GetPageQuery(handler.LedgerCache, r)
 	if err != nil {
 		return nil, err
 	}
 
-	err = validateCursorWithinHistory(pq)
+	err = validateCursorWithinHistory(handler.LedgerCache, pq)
 	if err != nil {
 		return nil, err
 	}
@@ -121,18 +122,21 @@ func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Requ
 }
 
 // GetOperationByIDHandler is the action handler for all end-points returning a list of operations.
-type GetOperationByIDHandler struct{}
+type GetOperationByIDHandler struct {
+	LedgerCache *ledger.Cache
+}
 
 // OperationQuery query struct for operation/id end-point
 type OperationQuery struct {
-	Joinable `valid:"optional"`
-	ID       uint64 `schema:"id" valid:"-"`
+	LedgerCache *ledger.Cache `valid:"-"`
+	Joinable    `valid:"optional"`
+	ID          uint64 `schema:"id" valid:"-"`
 }
 
 // Validate runs extra validations on query parameters
 func (qp OperationQuery) Validate() error {
 	parsed := toid.Parse(int64(qp.ID))
-	if parsed.LedgerSequence < ledger.CurrentState().HistoryElder {
+	if parsed.LedgerSequence < qp.LedgerCache.CurrentState().HistoryElder {
 		return problem.BeforeHistory
 	}
 	return nil
@@ -141,7 +145,9 @@ func (qp OperationQuery) Validate() error {
 // GetResource returns an operation page.
 func (handler GetOperationByIDHandler) GetResource(w HeaderWriter, r *http.Request) (interface{}, error) {
 	ctx := r.Context()
-	qp := OperationQuery{}
+	qp := OperationQuery{
+		LedgerCache: handler.LedgerCache,
+	}
 	err := getParams(&qp, r)
 	if err != nil {
 		return nil, err

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -517,7 +517,7 @@ func TestGetOperationsPagination(t *testing.T) {
 
 	q := &history.Q{tt.HorizonSession()}
 	handler := GetOperationsHandler{
-		LedgerCache: &ledger.Cache{},
+		LedgerState: &ledger.State{},
 	}
 
 	records, err := handler.GetResourcePage(
@@ -629,9 +629,9 @@ func TestGetOperation(t *testing.T) {
 	defer tt.Finish()
 
 	handler := GetOperationByIDHandler{
-		LedgerCache: &ledger.Cache{},
+		LedgerState: &ledger.State{},
 	}
-	handler.LedgerCache.SetState(tt.Scenario("base"))
+	handler.LedgerState.SetStatus(tt.Scenario("base"))
 
 	record, err := handler.GetResource(
 		httptest.NewRecorder(),
@@ -668,7 +668,7 @@ func TestOperation_IncludeTransaction(t *testing.T) {
 	tt.Scenario("kahuna")
 
 	handler := GetOperationByIDHandler{
-		LedgerCache: &ledger.Cache{},
+		LedgerState: &ledger.State{},
 	}
 	record, err := handler.GetResource(
 		httptest.NewRecorder(),

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"database/sql"
 	"fmt"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http/httptest"
 
 	"testing"
@@ -515,7 +516,9 @@ func TestGetOperationsPagination(t *testing.T) {
 	tt.Scenario("base")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{
+		LedgerCache: &ledger.Cache{},
+	}
 
 	records, err := handler.GetResourcePage(
 		httptest.NewRecorder(),
@@ -624,9 +627,11 @@ func TestGetOperations_IncludeTransactions(t *testing.T) {
 func TestGetOperation(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
-	tt.Scenario("base")
 
-	handler := GetOperationByIDHandler{}
+	handler := GetOperationByIDHandler{
+		LedgerCache: &ledger.Cache{},
+	}
+	handler.LedgerCache.SetState(tt.Scenario("base"))
 
 	record, err := handler.GetResource(
 		httptest.NewRecorder(),
@@ -662,7 +667,9 @@ func TestOperation_IncludeTransaction(t *testing.T) {
 	defer tt.Finish()
 	tt.Scenario("kahuna")
 
-	handler := GetOperationByIDHandler{}
+	handler := GetOperationByIDHandler{
+		LedgerCache: &ledger.Cache{},
+	}
 	record, err := handler.GetResource(
 		httptest.NewRecorder(),
 		makeRequest(

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -3,7 +3,6 @@ package actions
 import (
 	"database/sql"
 	"fmt"
-	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http/httptest"
 
 	"testing"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/services/horizon/internal/test"
 	supportProblem "github.com/stellar/go/support/render/problem"

--- a/services/horizon/internal/actions/root.go
+++ b/services/horizon/internal/actions/root.go
@@ -20,7 +20,7 @@ type CoreSettingsGetter interface {
 }
 
 type GetRootHandler struct {
-	LedgerCache *ledger.Cache
+	LedgerState *ledger.State
 	CoreSettingsGetter
 	NetworkPassphrase string
 	FriendbotURL      *url.URL
@@ -40,7 +40,7 @@ func (handler GetRootHandler) GetResource(w HeaderWriter, r *http.Request) (inte
 	resourceadapter.PopulateRoot(
 		r.Context(),
 		&res,
-		handler.LedgerCache.CurrentState(),
+		handler.LedgerState.CurrentStatus(),
 		handler.HorizonVersion,
 		coreSettings.CoreVersion,
 		handler.NetworkPassphrase,

--- a/services/horizon/internal/actions/root.go
+++ b/services/horizon/internal/actions/root.go
@@ -20,6 +20,7 @@ type CoreSettingsGetter interface {
 }
 
 type GetRootHandler struct {
+	LedgerCache *ledger.Cache
 	CoreSettingsGetter
 	NetworkPassphrase string
 	FriendbotURL      *url.URL
@@ -39,7 +40,7 @@ func (handler GetRootHandler) GetResource(w HeaderWriter, r *http.Request) (inte
 	resourceadapter.PopulateRoot(
 		r.Context(),
 		&res,
-		ledger.CurrentState(),
+		handler.LedgerCache.CurrentState(),
 		handler.HorizonVersion,
 		coreSettings.CoreVersion,
 		handler.NetworkPassphrase,

--- a/services/horizon/internal/actions/trade.go
+++ b/services/horizon/internal/actions/trade.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"fmt"
-	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 	"strconv"
 	gTime "time"
@@ -11,6 +10,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"

--- a/services/horizon/internal/actions/trade.go
+++ b/services/horizon/internal/actions/trade.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"fmt"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 	"strconv"
 	gTime "time"
@@ -102,18 +103,19 @@ func (q TradesQuery) Validate() error {
 
 // GetTradesHandler is the action handler for all end-points returning a list of trades.
 type GetTradesHandler struct {
+	LedgerCache *ledger.Cache
 }
 
 // GetResourcePage returns a page of trades.
 func (handler GetTradesHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
 	ctx := r.Context()
 
-	pq, err := GetPageQuery(r)
+	pq, err := GetPageQuery(handler.LedgerCache, r)
 	if err != nil {
 		return nil, err
 	}
 
-	err = validateCursorWithinHistory(pq)
+	err = validateCursorWithinHistory(handler.LedgerCache, pq)
 	if err != nil {
 		return nil, err
 	}
@@ -235,16 +237,17 @@ func (q TradeAggregationsQuery) Validate() error {
 
 // GetTradeAggregationsHandler is the action handler for trade_aggregations
 type GetTradeAggregationsHandler struct {
+	LedgerCache *ledger.Cache
 }
 
 // GetResourcePage returns a page of trade aggregations
 func (handler GetTradeAggregationsHandler) GetResource(w HeaderWriter, r *http.Request) (interface{}, error) {
 	ctx := r.Context()
-	pq, err := GetPageQuery(r)
+	pq, err := GetPageQuery(handler.LedgerCache, r)
 	if err != nil {
 		return nil, err
 	}
-	err = validateCursorWithinHistory(pq)
+	err = validateCursorWithinHistory(handler.LedgerCache, pq)
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +368,7 @@ func (handler GetTradeAggregationsHandler) fetchRecords(historyQ *history.Q, qp 
 // BuildPage builds a custom hal page for this handler
 func (handler GetTradeAggregationsHandler) buildPage(r *http.Request, records []horizon.TradeAggregation) (hal.Page, error) {
 	ctx := r.Context()
-	pageQuery, err := GetPageQuery(r, DisableCursorValidation)
+	pageQuery, err := GetPageQuery(handler.LedgerCache, r, DisableCursorValidation)
 	if err != nil {
 		return hal.Page{}, err
 	}

--- a/services/horizon/internal/actions/trade.go
+++ b/services/horizon/internal/actions/trade.go
@@ -103,19 +103,19 @@ func (q TradesQuery) Validate() error {
 
 // GetTradesHandler is the action handler for all end-points returning a list of trades.
 type GetTradesHandler struct {
-	LedgerCache *ledger.Cache
+	LedgerState *ledger.State
 }
 
 // GetResourcePage returns a page of trades.
 func (handler GetTradesHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
 	ctx := r.Context()
 
-	pq, err := GetPageQuery(handler.LedgerCache, r)
+	pq, err := GetPageQuery(handler.LedgerState, r)
 	if err != nil {
 		return nil, err
 	}
 
-	err = validateCursorWithinHistory(handler.LedgerCache, pq)
+	err = validateCursorWithinHistory(handler.LedgerState, pq)
 	if err != nil {
 		return nil, err
 	}
@@ -237,17 +237,17 @@ func (q TradeAggregationsQuery) Validate() error {
 
 // GetTradeAggregationsHandler is the action handler for trade_aggregations
 type GetTradeAggregationsHandler struct {
-	LedgerCache *ledger.Cache
+	LedgerState *ledger.State
 }
 
 // GetResourcePage returns a page of trade aggregations
 func (handler GetTradeAggregationsHandler) GetResource(w HeaderWriter, r *http.Request) (interface{}, error) {
 	ctx := r.Context()
-	pq, err := GetPageQuery(handler.LedgerCache, r)
+	pq, err := GetPageQuery(handler.LedgerState, r)
 	if err != nil {
 		return nil, err
 	}
-	err = validateCursorWithinHistory(handler.LedgerCache, pq)
+	err = validateCursorWithinHistory(handler.LedgerState, pq)
 	if err != nil {
 		return nil, err
 	}
@@ -368,7 +368,7 @@ func (handler GetTradeAggregationsHandler) fetchRecords(historyQ *history.Q, qp 
 // BuildPage builds a custom hal page for this handler
 func (handler GetTradeAggregationsHandler) buildPage(r *http.Request, records []horizon.TradeAggregation) (hal.Page, error) {
 	ctx := r.Context()
-	pageQuery, err := GetPageQuery(handler.LedgerCache, r, DisableCursorValidation)
+	pageQuery, err := GetPageQuery(handler.LedgerState, r, DisableCursorValidation)
 	if err != nil {
 		return hal.Page{}, err
 	}

--- a/services/horizon/internal/actions/transaction.go
+++ b/services/horizon/internal/actions/transaction.go
@@ -1,13 +1,13 @@
 package actions
 
 import (
-	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 
 	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/render/hal"

--- a/services/horizon/internal/actions/transaction.go
+++ b/services/horizon/internal/actions/transaction.go
@@ -84,19 +84,19 @@ func (qp TransactionsQuery) Validate() error {
 
 // GetTransactionsHandler is the action handler for all end-points returning a list of transactions.
 type GetTransactionsHandler struct {
-	LedgerCache *ledger.Cache
+	LedgerState *ledger.State
 }
 
 // GetResourcePage returns a page of transactions.
 func (handler GetTransactionsHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
 	ctx := r.Context()
 
-	pq, err := GetPageQuery(handler.LedgerCache, r)
+	pq, err := GetPageQuery(handler.LedgerState, r)
 	if err != nil {
 		return nil, err
 	}
 
-	err = validateCursorWithinHistory(handler.LedgerCache, pq)
+	err = validateCursorWithinHistory(handler.LedgerState, pq)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/transaction.go
+++ b/services/horizon/internal/actions/transaction.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 
 	"github.com/stellar/go/protocols/horizon"
@@ -83,18 +84,19 @@ func (qp TransactionsQuery) Validate() error {
 
 // GetTransactionsHandler is the action handler for all end-points returning a list of transactions.
 type GetTransactionsHandler struct {
+	LedgerCache *ledger.Cache
 }
 
 // GetResourcePage returns a page of transactions.
 func (handler GetTransactionsHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
 	ctx := r.Context()
 
-	pq, err := GetPageQuery(r)
+	pq, err := GetPageQuery(handler.LedgerCache, r)
 	if err != nil {
 		return nil, err
 	}
 
-	err = validateCursorWithinHistory(pq)
+	err = validateCursorWithinHistory(handler.LedgerCache, pq)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/transaction_test.go
+++ b/services/horizon/internal/actions/transaction_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestGetTransactionsHandler(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 
 	q := &history.Q{tt.HorizonSession()}

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -65,7 +65,7 @@ type App struct {
 	ingester        ingest.System
 	reaper          *reap.System
 	ticks           *time.Ticker
-	ledgerCache     *ledger.Cache
+	ledgerState     *ledger.State
 
 	// metrics
 	prometheusRegistry         *prometheus.Registry
@@ -89,7 +89,7 @@ func (a *App) GetCoreSettings() actions.CoreSettings {
 func NewApp(config Config) (*App, error) {
 	a := &App{
 		config:         config,
-		ledgerCache:    &ledger.Cache{},
+		ledgerState:    &ledger.State{},
 		horizonVersion: app.Version(),
 		ticks:          time.NewTicker(1 * time.Second),
 		done:           make(chan struct{}),
@@ -190,7 +190,7 @@ func (a *App) HorizonSession(ctx context.Context) *db.Session {
 // UpdateLedgerState triggers a refresh of several metrics gauges, such as open
 // db connections and ledger state
 func (a *App) UpdateLedgerState() {
-	var next ledger.State
+	var next ledger.Status
 
 	logErr := func(err error, msg string) {
 		log.WithStack(err).WithField("err", err.Error()).Error(msg)
@@ -226,7 +226,7 @@ func (a *App) UpdateLedgerState() {
 		return
 	}
 
-	a.ledgerCache.SetState(next)
+	a.ledgerState.SetStatus(next)
 }
 
 // UpdateFeeStatsState triggers a refresh of several operation fee metrics.
@@ -439,7 +439,7 @@ func (a *App) init() error {
 	initSubmissionSystem(a)
 
 	// reaper
-	a.reaper = reap.New(a.config.HistoryRetentionCount, a.HorizonSession(context.Background()), a.ledgerCache)
+	a.reaper = reap.New(a.config.HistoryRetentionCount, a.HorizonSession(context.Background()), a.ledgerState)
 
 	// metrics and log.metrics
 	a.prometheusRegistry = prometheus.NewRegistry()
@@ -489,7 +489,7 @@ func (a *App) init() error {
 			KeyPath:  a.config.TLSKey,
 		}
 	}
-	a.webServer, err = httpx.NewServer(config, routerConfig, a.ledgerCache)
+	a.webServer, err = httpx.NewServer(config, routerConfig, a.ledgerState)
 	if err != nil {
 		return err
 	}

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -65,6 +65,7 @@ type App struct {
 	ingester        ingest.System
 	reaper          *reap.System
 	ticks           *time.Ticker
+	ledgerCache     *ledger.Cache
 
 	// metrics
 	prometheusRegistry         *prometheus.Registry
@@ -88,6 +89,7 @@ func (a *App) GetCoreSettings() actions.CoreSettings {
 func NewApp(config Config) (*App, error) {
 	a := &App{
 		config:         config,
+		ledgerCache:    &ledger.Cache{},
 		horizonVersion: app.Version(),
 		ticks:          time.NewTicker(1 * time.Second),
 		done:           make(chan struct{}),
@@ -224,7 +226,7 @@ func (a *App) UpdateLedgerState() {
 		return
 	}
 
-	ledger.SetState(next)
+	a.ledgerCache.SetState(next)
 }
 
 // UpdateFeeStatsState triggers a refresh of several operation fee metrics.
@@ -437,7 +439,7 @@ func (a *App) init() error {
 	initSubmissionSystem(a)
 
 	// reaper
-	a.reaper = reap.New(a.config.HistoryRetentionCount, a.HorizonSession(context.Background()))
+	a.reaper = reap.New(a.config.HistoryRetentionCount, a.HorizonSession(context.Background()), a.ledgerCache)
 
 	// metrics and log.metrics
 	a.prometheusRegistry = prometheus.NewRegistry()
@@ -487,7 +489,7 @@ func (a *App) init() error {
 			KeyPath:  a.config.TLSKey,
 		}
 	}
-	a.webServer, err = httpx.NewServer(config, routerConfig)
+	a.webServer, err = httpx.NewServer(config, routerConfig, a.ledgerCache)
 	if err != nil {
 		return err
 	}

--- a/services/horizon/internal/db2/assets/asset_stat_test.go
+++ b/services/horizon/internal/db2/assets/asset_stat_test.go
@@ -83,7 +83,8 @@ func TestAssetsStatsQExec(t *testing.T) {
 
 	for i, kase := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			tt := test.Start(t).Scenario("ingest_asset_stats")
+			tt := test.Start(t)
+			tt.Scenario("ingest_asset_stats")
 			defer tt.Finish()
 
 			sql, err := kase.query.GetSQL()

--- a/services/horizon/internal/db2/history/account_signers_test.go
+++ b/services/horizon/internal/db2/history/account_signers_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestQueryEmptyAccountSigners(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
@@ -20,7 +21,8 @@ func TestQueryEmptyAccountSigners(t *testing.T) {
 }
 
 func TestInsertAccountSigner(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
@@ -48,7 +50,8 @@ func TestInsertAccountSigner(t *testing.T) {
 }
 
 func TestInsertAccountSignerSponsor(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
@@ -73,7 +76,8 @@ func TestInsertAccountSignerSponsor(t *testing.T) {
 }
 
 func TestMultipleAccountsForSigner(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
@@ -109,7 +113,8 @@ func TestMultipleAccountsForSigner(t *testing.T) {
 }
 
 func TestRemoveNonExistantAccountSigner(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
@@ -121,7 +126,8 @@ func TestRemoveNonExistantAccountSigner(t *testing.T) {
 }
 
 func TestRemoveAccountSigner(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
@@ -151,7 +157,8 @@ func TestRemoveAccountSigner(t *testing.T) {
 }
 
 func TestGetAccountSignersByAccountID(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 

--- a/services/horizon/internal/db2/history/ledger_cache_test.go
+++ b/services/horizon/internal/db2/history/ledger_cache_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 func TestLedgerCache(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 

--- a/services/horizon/internal/db2/history/ledger_test.go
+++ b/services/horizon/internal/db2/history/ledger_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestLedgerQueries(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 

--- a/services/horizon/internal/db2/history/main_test.go
+++ b/services/horizon/internal/db2/history/main_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 func TestLatestLedger(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
@@ -31,7 +32,8 @@ func TestGetLatestLedgerEmptyDB(t *testing.T) {
 }
 
 func TestElderLedger(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 

--- a/services/horizon/internal/db2/history/operation_test.go
+++ b/services/horizon/internal/db2/history/operation_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestOperationQueries(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
@@ -62,7 +63,8 @@ func TestOperationQueries(t *testing.T) {
 }
 
 func TestOperationQueryBuilder(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
@@ -90,7 +92,8 @@ func TestOperationQueryBuilder(t *testing.T) {
 // If it's not enclosed in brackets, it may return incorrect result when mixed
 // with `ForAccount` or `ForLedger` filters.
 func TestOperationSuccessfulOnly(t *testing.T) {
-	tt := test.Start(t).Scenario("failed_transactions")
+	tt := test.Start(t)
+	tt.Scenario("failed_transactions")
 	defer tt.Finish()
 
 	q := &Q{tt.HorizonSession()}
@@ -115,7 +118,8 @@ func TestOperationSuccessfulOnly(t *testing.T) {
 
 // TestOperationIncludeFailed tests `IncludeFailed` method.
 func TestOperationIncludeFailed(t *testing.T) {
-	tt := test.Start(t).Scenario("failed_transactions")
+	tt := test.Start(t)
+	tt.Scenario("failed_transactions")
 	defer tt.Finish()
 
 	q := &Q{tt.HorizonSession()}
@@ -149,7 +153,8 @@ func TestOperationIncludeFailed(t *testing.T) {
 // If it's not enclosed in brackets, it may return incorrect result when mixed
 // with `ForAccount` or `ForLedger` filters.
 func TestPaymentsSuccessfulOnly(t *testing.T) {
-	tt := test.Start(t).Scenario("failed_transactions")
+	tt := test.Start(t)
+	tt.Scenario("failed_transactions")
 	defer tt.Finish()
 
 	q := &Q{tt.HorizonSession()}
@@ -175,7 +180,8 @@ func TestPaymentsSuccessfulOnly(t *testing.T) {
 
 // TestPaymentsIncludeFailed tests `IncludeFailed` method.
 func TestPaymentsIncludeFailed(t *testing.T) {
-	tt := test.Start(t).Scenario("failed_transactions")
+	tt := test.Start(t)
+	tt.Scenario("failed_transactions")
 	defer tt.Finish()
 
 	q := &Q{tt.HorizonSession()}
@@ -206,7 +212,8 @@ func TestPaymentsIncludeFailed(t *testing.T) {
 }
 
 func TestExtraChecksOperationsTransactionSuccessfulTrueResultFalse(t *testing.T) {
-	tt := test.Start(t).Scenario("failed_transactions")
+	tt := test.Start(t)
+	tt.Scenario("failed_transactions")
 	defer tt.Finish()
 
 	// successful `true` but tx result `false`
@@ -226,7 +233,8 @@ func TestExtraChecksOperationsTransactionSuccessfulTrueResultFalse(t *testing.T)
 }
 
 func TestExtraChecksOperationsTransactionSuccessfulFalseResultTrue(t *testing.T) {
-	tt := test.Start(t).Scenario("failed_transactions")
+	tt := test.Start(t)
+	tt.Scenario("failed_transactions")
 	defer tt.Finish()
 
 	// successful `false` but tx result `true`
@@ -254,7 +262,8 @@ func assertOperationMatchesTransaction(tt *test.T, operation Operation, transact
 
 // TestOperationIncludeTransactions tests that transactions are included when fetching records from the db.
 func TestOperationIncludeTransactions(t *testing.T) {
-	tt := test.Start(t).Scenario("failed_transactions")
+	tt := test.Start(t)
+	tt.Scenario("failed_transactions")
 	defer tt.Finish()
 
 	accountID := "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2"
@@ -301,7 +310,8 @@ func TestOperationIncludeTransactions(t *testing.T) {
 }
 
 func TestValidateTransactionForOperation(t *testing.T) {
-	tt := test.Start(t).Scenario("failed_transactions")
+	tt := test.Start(t)
+	tt.Scenario("failed_transactions")
 	selectTransactionCopy := selectTransaction
 	defer func() {
 		selectTransaction = selectTransactionCopy

--- a/services/horizon/internal/db2/history/trade_test.go
+++ b/services/horizon/internal/db2/history/trade_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestTradeQueries(t *testing.T) {
-	tt := test.Start(t).Scenario("kahuna")
+	tt := test.Start(t)
+	tt.Scenario("kahuna")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 	var trades []Trade
@@ -315,7 +316,8 @@ func TestBatchInsertTrade(t *testing.T) {
 }
 
 func TestTradesQueryForAccount(t *testing.T) {
-	tt := test.Start(t).Scenario("kahuna")
+	tt := test.Start(t)
+	tt.Scenario("kahuna")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 	tradesQ := q.Trades()
@@ -362,7 +364,8 @@ func TestTradesQueryForAccount(t *testing.T) {
 }
 
 func TestTradesQueryForOffer(t *testing.T) {
-	tt := test.Start(t).Scenario("kahuna")
+	tt := test.Start(t)
+	tt.Scenario("kahuna")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 	tradesQ := q.Trades()

--- a/services/horizon/internal/db2/history/transaction_test.go
+++ b/services/horizon/internal/db2/history/transaction_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 func TestTransactionQueries(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
@@ -34,7 +35,8 @@ func TestTransactionQueries(t *testing.T) {
 // If it's not enclosed in brackets, it may return incorrect result when mixed
 // with `ForAccount` or `ForLedger` filters.
 func TestTransactionSuccessfulOnly(t *testing.T) {
-	tt := test.Start(t).Scenario("failed_transactions")
+	tt := test.Start(t)
+	tt.Scenario("failed_transactions")
 	defer tt.Finish()
 
 	var transactions []Transaction
@@ -60,7 +62,8 @@ func TestTransactionSuccessfulOnly(t *testing.T) {
 
 // TestTransactionIncludeFailed tests `IncludeFailed` method.
 func TestTransactionIncludeFailed(t *testing.T) {
-	tt := test.Start(t).Scenario("failed_transactions")
+	tt := test.Start(t)
+	tt.Scenario("failed_transactions")
 	defer tt.Finish()
 
 	var transactions []Transaction
@@ -91,7 +94,8 @@ func TestTransactionIncludeFailed(t *testing.T) {
 }
 
 func TestExtraChecksTransactionSuccessfulTrueResultFalse(t *testing.T) {
-	tt := test.Start(t).Scenario("failed_transactions")
+	tt := test.Start(t)
+	tt.Scenario("failed_transactions")
 	defer tt.Finish()
 
 	// successful `true` but tx result `false`
@@ -113,7 +117,8 @@ func TestExtraChecksTransactionSuccessfulTrueResultFalse(t *testing.T) {
 }
 
 func TestExtraChecksTransactionSuccessfulFalseResultTrue(t *testing.T) {
-	tt := test.Start(t).Scenario("failed_transactions")
+	tt := test.Start(t)
+	tt.Scenario("failed_transactions")
 	defer tt.Finish()
 
 	// successful `false` but tx result `true`

--- a/services/horizon/internal/httpx/handler.go
+++ b/services/horizon/internal/httpx/handler.go
@@ -156,23 +156,23 @@ type pageActionHandler struct {
 	streamable     bool
 	streamHandler  sse.StreamHandler
 	repeatableRead bool
-	ledgerCache    *ledger.Cache
+	ledgerState    *ledger.State
 }
 
-func restPageHandler(ledgerCache *ledger.Cache, action pageAction) pageActionHandler {
-	return pageActionHandler{action: action, ledgerCache: ledgerCache}
+func restPageHandler(ledgerState *ledger.State, action pageAction) pageActionHandler {
+	return pageActionHandler{action: action, ledgerState: ledgerState}
 }
 
 // streamableStatePageHandler creates a streamable page handler than generates
 // events within a REPEATABLE READ transaction.
 func streamableStatePageHandler(
-	ledgerCache *ledger.Cache,
+	ledgerState *ledger.State,
 	action pageAction,
 	streamHandler sse.StreamHandler,
 ) pageActionHandler {
 	return pageActionHandler{
 		action:         action,
-		ledgerCache:    ledgerCache,
+		ledgerState:    ledgerState,
 		streamable:     true,
 		streamHandler:  streamHandler,
 		repeatableRead: true,
@@ -182,13 +182,13 @@ func streamableStatePageHandler(
 // streamableStatePageHandler creates a streamable page handler than generates
 // events without starting a REPEATABLE READ transaction.
 func streamableHistoryPageHandler(
-	ledgerCache *ledger.Cache,
+	ledgerState *ledger.State,
 	action pageAction,
 	streamHandler sse.StreamHandler,
 ) pageActionHandler {
 	return pageActionHandler{
 		action:         action,
-		ledgerCache:    ledgerCache,
+		ledgerState:    ledgerState,
 		streamable:     true,
 		streamHandler:  streamHandler,
 		repeatableRead: false,
@@ -202,7 +202,7 @@ func (handler pageActionHandler) renderPage(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	page, err := buildPage(handler.ledgerCache, r, records)
+	page, err := buildPage(handler.ledgerState, r, records)
 
 	if err != nil {
 		problem.Render(r.Context(), w, err)
@@ -218,7 +218,7 @@ func (handler pageActionHandler) renderPage(w http.ResponseWriter, r *http.Reque
 
 func (handler pageActionHandler) renderStream(w http.ResponseWriter, r *http.Request) {
 	// Use pq to Get SSE limit.
-	pq, err := actions.GetPageQuery(handler.ledgerCache, r)
+	pq, err := actions.GetPageQuery(handler.ledgerState, r)
 	if err != nil {
 		problem.Render(r.Context(), w, err)
 		return
@@ -279,10 +279,10 @@ func (handler pageActionHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	problem.Render(r.Context(), w, hProblem.NotAcceptable)
 }
 
-func buildPage(ledgerCache *ledger.Cache, r *http.Request, records []hal.Pageable) (hal.Page, error) {
+func buildPage(ledgerState *ledger.State, r *http.Request, records []hal.Pageable) (hal.Page, error) {
 	// Always DisableCursorValidation - we can assume it's valid since the
 	// validation is done in GetResourcePage.
-	pageQuery, err := actions.GetPageQuery(ledgerCache, r, actions.DisableCursorValidation)
+	pageQuery, err := actions.GetPageQuery(ledgerState, r, actions.DisableCursorValidation)
 	if err != nil {
 		return hal.Page{}, err
 	}

--- a/services/horizon/internal/httpx/handler.go
+++ b/services/horizon/internal/httpx/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stellar/go/services/horizon/internal/actions"
 	horizonContext "github.com/stellar/go/services/horizon/internal/context"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/render"
 	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
@@ -155,20 +156,23 @@ type pageActionHandler struct {
 	streamable     bool
 	streamHandler  sse.StreamHandler
 	repeatableRead bool
+	ledgerCache    *ledger.Cache
 }
 
-func restPageHandler(action pageAction) pageActionHandler {
-	return pageActionHandler{action: action}
+func restPageHandler(ledgerCache *ledger.Cache, action pageAction) pageActionHandler {
+	return pageActionHandler{action: action, ledgerCache: ledgerCache}
 }
 
 // streamableStatePageHandler creates a streamable page handler than generates
 // events within a REPEATABLE READ transaction.
 func streamableStatePageHandler(
+	ledgerCache *ledger.Cache,
 	action pageAction,
 	streamHandler sse.StreamHandler,
 ) pageActionHandler {
 	return pageActionHandler{
 		action:         action,
+		ledgerCache:    ledgerCache,
 		streamable:     true,
 		streamHandler:  streamHandler,
 		repeatableRead: true,
@@ -178,11 +182,13 @@ func streamableStatePageHandler(
 // streamableStatePageHandler creates a streamable page handler than generates
 // events without starting a REPEATABLE READ transaction.
 func streamableHistoryPageHandler(
+	ledgerCache *ledger.Cache,
 	action pageAction,
 	streamHandler sse.StreamHandler,
 ) pageActionHandler {
 	return pageActionHandler{
 		action:         action,
+		ledgerCache:    ledgerCache,
 		streamable:     true,
 		streamHandler:  streamHandler,
 		repeatableRead: false,
@@ -196,7 +202,7 @@ func (handler pageActionHandler) renderPage(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	page, err := buildPage(r, records)
+	page, err := buildPage(handler.ledgerCache, r, records)
 
 	if err != nil {
 		problem.Render(r.Context(), w, err)
@@ -212,7 +218,7 @@ func (handler pageActionHandler) renderPage(w http.ResponseWriter, r *http.Reque
 
 func (handler pageActionHandler) renderStream(w http.ResponseWriter, r *http.Request) {
 	// Use pq to Get SSE limit.
-	pq, err := actions.GetPageQuery(r)
+	pq, err := actions.GetPageQuery(handler.ledgerCache, r)
 	if err != nil {
 		problem.Render(r.Context(), w, err)
 		return
@@ -273,10 +279,10 @@ func (handler pageActionHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	problem.Render(r.Context(), w, hProblem.NotAcceptable)
 }
 
-func buildPage(r *http.Request, records []hal.Pageable) (hal.Page, error) {
+func buildPage(ledgerCache *ledger.Cache, r *http.Request, records []hal.Pageable) (hal.Page, error) {
 	// Always DisableCursorValidation - we can assume it's valid since the
 	// validation is done in GetResourcePage.
-	pageQuery, err := actions.GetPageQuery(r, actions.DisableCursorValidation)
+	pageQuery, err := actions.GetPageQuery(ledgerCache, r, actions.DisableCursorValidation)
 	if err != nil {
 		return hal.Page{}, err
 	}

--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -33,7 +33,7 @@ func requestCacheHeadersMiddleware(h http.Handler) http.Handler {
 		// Before changing this read Stack Overflow answer about staled request
 		// in older versions of Chrome:
 		// https://stackoverflow.com/questions/27513994/chrome-stalls-when-making-multiple-requests-to-same-resource
-		w.Header().Set("State-Control", "no-cache, no-store, max-age=0")
+		w.Header().Set("Cache-Control", "no-cache, no-store, max-age=0")
 		h.ServeHTTP(w, r)
 	})
 }

--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -219,12 +219,12 @@ func recoverMiddleware(h http.Handler) http.Handler {
 // NewHistoryMiddleware adds session to the request context and ensures Horizon
 // is not in a stale state, which is when the difference between latest core
 // ledger and latest history ledger is higher than the given threshold
-func NewHistoryMiddleware(staleThreshold int32, session *db.Session) func(http.Handler) http.Handler {
+func NewHistoryMiddleware(ledgerCache *ledger.Cache, staleThreshold int32, session *db.Session) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if staleThreshold > 0 {
-				ls := ledger.CurrentState()
+				ls := ledgerCache.CurrentState()
 				isStale := (ls.CoreLatest - ls.HistoryLatest) > int32(staleThreshold)
 				if isStale {
 					err := hProblem.StaleHistory

--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -33,7 +33,7 @@ func requestCacheHeadersMiddleware(h http.Handler) http.Handler {
 		// Before changing this read Stack Overflow answer about staled request
 		// in older versions of Chrome:
 		// https://stackoverflow.com/questions/27513994/chrome-stalls-when-making-multiple-requests-to-same-resource
-		w.Header().Set("Cache-Control", "no-cache, no-store, max-age=0")
+		w.Header().Set("State-Control", "no-cache, no-store, max-age=0")
 		h.ServeHTTP(w, r)
 	})
 }
@@ -219,12 +219,12 @@ func recoverMiddleware(h http.Handler) http.Handler {
 // NewHistoryMiddleware adds session to the request context and ensures Horizon
 // is not in a stale state, which is when the difference between latest core
 // ledger and latest history ledger is higher than the given threshold
-func NewHistoryMiddleware(ledgerCache *ledger.Cache, staleThreshold int32, session *db.Session) func(http.Handler) http.Handler {
+func NewHistoryMiddleware(ledgerState *ledger.State, staleThreshold int32, session *db.Session) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if staleThreshold > 0 {
-				ls := ledgerCache.CurrentState()
+				ls := ledgerState.CurrentStatus()
 				isStale := (ls.CoreLatest - ls.HistoryLatest) > int32(staleThreshold)
 				if isStale {
 					err := hProblem.StaleHistory

--- a/services/horizon/internal/httpx/rate_limiter.go
+++ b/services/horizon/internal/httpx/rate_limiter.go
@@ -16,10 +16,11 @@ const lruCacheSize = 50000
 
 type historyLedgerSourceFactory struct {
 	updateFrequency time.Duration
+	ledgerCache     *ledger.Cache
 }
 
 func (f historyLedgerSourceFactory) Get() ledger.Source {
-	return ledger.NewHistoryDBSource(f.updateFrequency)
+	return ledger.NewHistoryDBSource(f.updateFrequency, f.ledgerCache)
 }
 
 func remoteAddrIP(r *http.Request) string {

--- a/services/horizon/internal/httpx/rate_limiter.go
+++ b/services/horizon/internal/httpx/rate_limiter.go
@@ -16,11 +16,11 @@ const lruCacheSize = 50000
 
 type historyLedgerSourceFactory struct {
 	updateFrequency time.Duration
-	ledgerCache     *ledger.Cache
+	ledgerState     *ledger.State
 }
 
 func (f historyLedgerSourceFactory) Get() ledger.Source {
-	return ledger.NewHistoryDBSource(f.updateFrequency, f.ledgerCache)
+	return ledger.NewHistoryDBSource(f.updateFrequency, f.ledgerState)
 }
 
 func remoteAddrIP(r *http.Request) string {

--- a/services/horizon/internal/httpx/router.go
+++ b/services/horizon/internal/httpx/router.go
@@ -3,7 +3,6 @@ package httpx
 import (
 	"compress/flate"
 	"fmt"
-	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 	"net/http/pprof"
 	"net/url"
@@ -18,6 +17,7 @@ import (
 	"github.com/stellar/throttled"
 
 	"github.com/stellar/go/services/horizon/internal/actions"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/paths"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/txsub"

--- a/services/horizon/internal/httpx/router.go
+++ b/services/horizon/internal/httpx/router.go
@@ -3,6 +3,7 @@ package httpx
 import (
 	"compress/flate"
 	"fmt"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 	"net/http/pprof"
 	"net/url"
@@ -48,7 +49,7 @@ type Router struct {
 	Internal *chi.Mux
 }
 
-func NewRouter(config *RouterConfig, serverMetrics *ServerMetrics) (*Router, error) {
+func NewRouter(config *RouterConfig, serverMetrics *ServerMetrics, ledgerCache *ledger.Cache) (*Router, error) {
 	result := Router{
 		Mux:      chi.NewMux(),
 		Internal: chi.NewMux(),
@@ -62,7 +63,7 @@ func NewRouter(config *RouterConfig, serverMetrics *ServerMetrics) (*Router, err
 		}
 	}
 	result.addMiddleware(config, rateLimiter, serverMetrics)
-	result.addRoutes(config, rateLimiter)
+	result.addRoutes(config, rateLimiter, ledgerCache)
 	return &result, nil
 }
 
@@ -98,12 +99,13 @@ func (r *Router) addMiddleware(config *RouterConfig,
 	r.Internal.Use(loggerMiddleware(serverMetrics))
 }
 
-func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRateLimiter) {
+func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRateLimiter, ledgerCache *ledger.Cache) {
 	stateMiddleware := StateMiddleware{
 		HorizonSession: config.DBSession,
 	}
 
 	r.Method(http.MethodGet, "/", ObjectActionHandler{Action: actions.GetRootHandler{
+		LedgerCache:        ledgerCache,
 		CoreSettingsGetter: config.CoreGetter,
 		NetworkPassphrase:  config.NetworkPassphrase,
 		FriendbotURL:       config.FriendbotURL,
@@ -112,17 +114,17 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 
 	streamHandler := sse.StreamHandler{
 		RateLimiter:         rateLimiter,
-		LedgerSourceFactory: historyLedgerSourceFactory{updateFrequency: config.SSEUpdateFrequency},
+		LedgerSourceFactory: historyLedgerSourceFactory{ledgerCache: ledgerCache, updateFrequency: config.SSEUpdateFrequency},
 	}
 
-	historyMiddleware := NewHistoryMiddleware(int32(config.StaleThreshold), config.DBSession)
+	historyMiddleware := NewHistoryMiddleware(ledgerCache, int32(config.StaleThreshold), config.DBSession)
 
 	// State endpoints behind stateMiddleware
 	r.Group(func(r chi.Router) {
 		r.Use(stateMiddleware.Wrap)
 
 		r.Route("/accounts", func(r chi.Router) {
-			r.Method(http.MethodGet, "/", restPageHandler(actions.GetAccountsHandler{}))
+			r.Method(http.MethodGet, "/", restPageHandler(ledgerCache, actions.GetAccountsHandler{LedgerCache: ledgerCache}))
 			r.Route("/{account_id}", func(r chi.Router) {
 				r.Method(
 					http.MethodGet,
@@ -137,21 +139,21 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 					streamableObjectActionHandler{streamHandler: streamHandler, action: accountData},
 					accountData,
 				))
-				r.Method(http.MethodGet, "/offers", streamableStatePageHandler(actions.GetAccountOffersHandler{}, streamHandler))
+				r.Method(http.MethodGet, "/offers", streamableStatePageHandler(ledgerCache, actions.GetAccountOffersHandler{LedgerCache: ledgerCache}, streamHandler))
 			})
 		})
 
 		r.Route("/claimable_balances", func(r chi.Router) {
-			r.Method(http.MethodGet, "/", restPageHandler(actions.GetClaimableBalancesHandler{}))
+			r.Method(http.MethodGet, "/", restPageHandler(ledgerCache, actions.GetClaimableBalancesHandler{LedgerCache: ledgerCache}))
 			r.Method(http.MethodGet, "/{id}", ObjectActionHandler{actions.GetClaimableBalanceByIDHandler{}})
 		})
 
 		r.Route("/offers", func(r chi.Router) {
-			r.Method(http.MethodGet, "/", restPageHandler(actions.GetOffersHandler{}))
+			r.Method(http.MethodGet, "/", restPageHandler(ledgerCache, actions.GetOffersHandler{LedgerCache: ledgerCache}))
 			r.Method(http.MethodGet, "/{offer_id}", ObjectActionHandler{actions.GetOfferByID{}})
 		})
 
-		r.Method(http.MethodGet, "/assets", restPageHandler(actions.AssetStatsHandler{}))
+		r.Method(http.MethodGet, "/assets", restPageHandler(ledgerCache, actions.AssetStatsHandler{LedgerCache: ledgerCache}))
 
 		findPaths := ObjectActionHandler{actions.FindPathsHandler{
 			StaleThreshold:       config.StaleThreshold,
@@ -186,29 +188,33 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 	// emptiness. Without it, requesting `/accounts//payments` return all payments!
 	r.Group(func(r chi.Router) {
 		r.Use(historyMiddleware)
-		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/effects", streamableHistoryPageHandler(actions.GetEffectsHandler{}, streamHandler))
-		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/operations", streamableHistoryPageHandler(actions.GetOperationsHandler{
+		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/effects", streamableHistoryPageHandler(ledgerCache, actions.GetEffectsHandler{LedgerCache: ledgerCache}, streamHandler))
+		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/operations", streamableHistoryPageHandler(ledgerCache, actions.GetOperationsHandler{
+			LedgerCache:  ledgerCache,
 			OnlyPayments: false,
 		}, streamHandler))
-		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/payments", streamableHistoryPageHandler(actions.GetOperationsHandler{
+		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/payments", streamableHistoryPageHandler(ledgerCache, actions.GetOperationsHandler{
+			LedgerCache:  ledgerCache,
 			OnlyPayments: true,
 		}, streamHandler))
-		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/trades", streamableHistoryPageHandler(actions.GetTradesHandler{}, streamHandler))
-		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/transactions", streamableHistoryPageHandler(actions.GetTransactionsHandler{}, streamHandler))
+		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/trades", streamableHistoryPageHandler(ledgerCache, actions.GetTradesHandler{LedgerCache: ledgerCache}, streamHandler))
+		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/transactions", streamableHistoryPageHandler(ledgerCache, actions.GetTransactionsHandler{LedgerCache: ledgerCache}, streamHandler))
 	})
 	// ledger actions
 	r.Route("/ledgers", func(r chi.Router) {
 		r.Use(historyMiddleware)
-		r.Method(http.MethodGet, "/", streamableHistoryPageHandler(actions.GetLedgersHandler{}, streamHandler))
+		r.Method(http.MethodGet, "/", streamableHistoryPageHandler(ledgerCache, actions.GetLedgersHandler{LedgerCache: ledgerCache}, streamHandler))
 		r.Route("/{ledger_id}", func(r chi.Router) {
-			r.Method(http.MethodGet, "/", ObjectActionHandler{actions.GetLedgerByIDHandler{}})
-			r.Method(http.MethodGet, "/transactions", streamableHistoryPageHandler(actions.GetTransactionsHandler{}, streamHandler))
+			r.Method(http.MethodGet, "/", ObjectActionHandler{actions.GetLedgerByIDHandler{LedgerCache: ledgerCache}})
+			r.Method(http.MethodGet, "/transactions", streamableHistoryPageHandler(ledgerCache, actions.GetTransactionsHandler{LedgerCache: ledgerCache}, streamHandler))
 			r.Group(func(r chi.Router) {
-				r.Method(http.MethodGet, "/effects", streamableHistoryPageHandler(actions.GetEffectsHandler{}, streamHandler))
-				r.Method(http.MethodGet, "/operations", streamableHistoryPageHandler(actions.GetOperationsHandler{
+				r.Method(http.MethodGet, "/effects", streamableHistoryPageHandler(ledgerCache, actions.GetEffectsHandler{LedgerCache: ledgerCache}, streamHandler))
+				r.Method(http.MethodGet, "/operations", streamableHistoryPageHandler(ledgerCache, actions.GetOperationsHandler{
+					LedgerCache:  ledgerCache,
 					OnlyPayments: false,
 				}, streamHandler))
-				r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(actions.GetOperationsHandler{
+				r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(ledgerCache, actions.GetOperationsHandler{
+					LedgerCache:  ledgerCache,
 					OnlyPayments: true,
 				}, streamHandler))
 			})
@@ -217,15 +223,17 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 
 	// transaction history actions
 	r.Route("/transactions", func(r chi.Router) {
-		r.With(historyMiddleware).Method(http.MethodGet, "/", streamableHistoryPageHandler(actions.GetTransactionsHandler{}, streamHandler))
+		r.With(historyMiddleware).Method(http.MethodGet, "/", streamableHistoryPageHandler(ledgerCache, actions.GetTransactionsHandler{LedgerCache: ledgerCache}, streamHandler))
 		r.Route("/{tx_id}", func(r chi.Router) {
 			r.Use(historyMiddleware)
 			r.Method(http.MethodGet, "/", ObjectActionHandler{actions.GetTransactionByHashHandler{}})
-			r.Method(http.MethodGet, "/effects", streamableHistoryPageHandler(actions.GetEffectsHandler{}, streamHandler))
-			r.Method(http.MethodGet, "/operations", streamableHistoryPageHandler(actions.GetOperationsHandler{
+			r.Method(http.MethodGet, "/effects", streamableHistoryPageHandler(ledgerCache, actions.GetEffectsHandler{LedgerCache: ledgerCache}, streamHandler))
+			r.Method(http.MethodGet, "/operations", streamableHistoryPageHandler(ledgerCache, actions.GetOperationsHandler{
+				LedgerCache:  ledgerCache,
 				OnlyPayments: false,
 			}, streamHandler))
-			r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(actions.GetOperationsHandler{
+			r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(ledgerCache, actions.GetOperationsHandler{
+				LedgerCache:  ledgerCache,
 				OnlyPayments: true,
 			}, streamHandler))
 		})
@@ -234,29 +242,31 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 	// operation actions
 	r.Route("/operations", func(r chi.Router) {
 		r.Use(historyMiddleware)
-		r.Method(http.MethodGet, "/", streamableHistoryPageHandler(actions.GetOperationsHandler{
+		r.Method(http.MethodGet, "/", streamableHistoryPageHandler(ledgerCache, actions.GetOperationsHandler{
+			LedgerCache:  ledgerCache,
 			OnlyPayments: false,
 		}, streamHandler))
-		r.Method(http.MethodGet, "/{id}", ObjectActionHandler{actions.GetOperationByIDHandler{}})
-		r.Method(http.MethodGet, "/{op_id}/effects", streamableHistoryPageHandler(actions.GetEffectsHandler{}, streamHandler))
+		r.Method(http.MethodGet, "/{id}", ObjectActionHandler{actions.GetOperationByIDHandler{LedgerCache: ledgerCache}})
+		r.Method(http.MethodGet, "/{op_id}/effects", streamableHistoryPageHandler(ledgerCache, actions.GetEffectsHandler{LedgerCache: ledgerCache}, streamHandler))
 	})
 
 	r.Group(func(r chi.Router) {
 		r.Use(historyMiddleware)
 		// payment actions
-		r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(actions.GetOperationsHandler{
+		r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(ledgerCache, actions.GetOperationsHandler{
+			LedgerCache:  ledgerCache,
 			OnlyPayments: true,
 		}, streamHandler))
 
 		// effect actions
-		r.Method(http.MethodGet, "/effects", streamableHistoryPageHandler(actions.GetEffectsHandler{}, streamHandler))
+		r.Method(http.MethodGet, "/effects", streamableHistoryPageHandler(ledgerCache, actions.GetEffectsHandler{LedgerCache: ledgerCache}, streamHandler))
 
 		// trading related endpoints
-		r.Method(http.MethodGet, "/trades", streamableHistoryPageHandler(actions.GetTradesHandler{}, streamHandler))
-		r.Method(http.MethodGet, "/trade_aggregations", ObjectActionHandler{actions.GetTradeAggregationsHandler{}})
+		r.Method(http.MethodGet, "/trades", streamableHistoryPageHandler(ledgerCache, actions.GetTradesHandler{LedgerCache: ledgerCache}, streamHandler))
+		r.Method(http.MethodGet, "/trade_aggregations", ObjectActionHandler{actions.GetTradeAggregationsHandler{LedgerCache: ledgerCache}})
 		// /offers/{offer_id} has been created above so we need to use absolute
 		// routes here.
-		r.Method(http.MethodGet, "/offers/{offer_id}/trades", streamableHistoryPageHandler(actions.GetTradesHandler{}, streamHandler))
+		r.Method(http.MethodGet, "/offers/{offer_id}/trades", streamableHistoryPageHandler(ledgerCache, actions.GetTradesHandler{LedgerCache: ledgerCache}, streamHandler))
 	})
 
 	// Transaction submission API

--- a/services/horizon/internal/httpx/router.go
+++ b/services/horizon/internal/httpx/router.go
@@ -119,7 +119,7 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 
 	historyMiddleware := NewHistoryMiddleware(ledgerState, int32(config.StaleThreshold), config.DBSession)
 
-	// Status endpoints behind stateMiddleware
+	// State endpoints behind stateMiddleware
 	r.Group(func(r chi.Router) {
 		r.Use(stateMiddleware.Wrap)
 

--- a/services/horizon/internal/httpx/router.go
+++ b/services/horizon/internal/httpx/router.go
@@ -49,7 +49,7 @@ type Router struct {
 	Internal *chi.Mux
 }
 
-func NewRouter(config *RouterConfig, serverMetrics *ServerMetrics, ledgerCache *ledger.Cache) (*Router, error) {
+func NewRouter(config *RouterConfig, serverMetrics *ServerMetrics, ledgerState *ledger.State) (*Router, error) {
 	result := Router{
 		Mux:      chi.NewMux(),
 		Internal: chi.NewMux(),
@@ -63,7 +63,7 @@ func NewRouter(config *RouterConfig, serverMetrics *ServerMetrics, ledgerCache *
 		}
 	}
 	result.addMiddleware(config, rateLimiter, serverMetrics)
-	result.addRoutes(config, rateLimiter, ledgerCache)
+	result.addRoutes(config, rateLimiter, ledgerState)
 	return &result, nil
 }
 
@@ -99,13 +99,13 @@ func (r *Router) addMiddleware(config *RouterConfig,
 	r.Internal.Use(loggerMiddleware(serverMetrics))
 }
 
-func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRateLimiter, ledgerCache *ledger.Cache) {
+func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRateLimiter, ledgerState *ledger.State) {
 	stateMiddleware := StateMiddleware{
 		HorizonSession: config.DBSession,
 	}
 
 	r.Method(http.MethodGet, "/", ObjectActionHandler{Action: actions.GetRootHandler{
-		LedgerCache:        ledgerCache,
+		LedgerState:        ledgerState,
 		CoreSettingsGetter: config.CoreGetter,
 		NetworkPassphrase:  config.NetworkPassphrase,
 		FriendbotURL:       config.FriendbotURL,
@@ -114,17 +114,17 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 
 	streamHandler := sse.StreamHandler{
 		RateLimiter:         rateLimiter,
-		LedgerSourceFactory: historyLedgerSourceFactory{ledgerCache: ledgerCache, updateFrequency: config.SSEUpdateFrequency},
+		LedgerSourceFactory: historyLedgerSourceFactory{ledgerState: ledgerState, updateFrequency: config.SSEUpdateFrequency},
 	}
 
-	historyMiddleware := NewHistoryMiddleware(ledgerCache, int32(config.StaleThreshold), config.DBSession)
+	historyMiddleware := NewHistoryMiddleware(ledgerState, int32(config.StaleThreshold), config.DBSession)
 
-	// State endpoints behind stateMiddleware
+	// Status endpoints behind stateMiddleware
 	r.Group(func(r chi.Router) {
 		r.Use(stateMiddleware.Wrap)
 
 		r.Route("/accounts", func(r chi.Router) {
-			r.Method(http.MethodGet, "/", restPageHandler(ledgerCache, actions.GetAccountsHandler{LedgerCache: ledgerCache}))
+			r.Method(http.MethodGet, "/", restPageHandler(ledgerState, actions.GetAccountsHandler{LedgerState: ledgerState}))
 			r.Route("/{account_id}", func(r chi.Router) {
 				r.Method(
 					http.MethodGet,
@@ -139,21 +139,21 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 					streamableObjectActionHandler{streamHandler: streamHandler, action: accountData},
 					accountData,
 				))
-				r.Method(http.MethodGet, "/offers", streamableStatePageHandler(ledgerCache, actions.GetAccountOffersHandler{LedgerCache: ledgerCache}, streamHandler))
+				r.Method(http.MethodGet, "/offers", streamableStatePageHandler(ledgerState, actions.GetAccountOffersHandler{LedgerState: ledgerState}, streamHandler))
 			})
 		})
 
 		r.Route("/claimable_balances", func(r chi.Router) {
-			r.Method(http.MethodGet, "/", restPageHandler(ledgerCache, actions.GetClaimableBalancesHandler{LedgerCache: ledgerCache}))
+			r.Method(http.MethodGet, "/", restPageHandler(ledgerState, actions.GetClaimableBalancesHandler{LedgerState: ledgerState}))
 			r.Method(http.MethodGet, "/{id}", ObjectActionHandler{actions.GetClaimableBalanceByIDHandler{}})
 		})
 
 		r.Route("/offers", func(r chi.Router) {
-			r.Method(http.MethodGet, "/", restPageHandler(ledgerCache, actions.GetOffersHandler{LedgerCache: ledgerCache}))
+			r.Method(http.MethodGet, "/", restPageHandler(ledgerState, actions.GetOffersHandler{LedgerState: ledgerState}))
 			r.Method(http.MethodGet, "/{offer_id}", ObjectActionHandler{actions.GetOfferByID{}})
 		})
 
-		r.Method(http.MethodGet, "/assets", restPageHandler(ledgerCache, actions.AssetStatsHandler{LedgerCache: ledgerCache}))
+		r.Method(http.MethodGet, "/assets", restPageHandler(ledgerState, actions.AssetStatsHandler{LedgerState: ledgerState}))
 
 		findPaths := ObjectActionHandler{actions.FindPathsHandler{
 			StaleThreshold:       config.StaleThreshold,
@@ -188,33 +188,33 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 	// emptiness. Without it, requesting `/accounts//payments` return all payments!
 	r.Group(func(r chi.Router) {
 		r.Use(historyMiddleware)
-		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/effects", streamableHistoryPageHandler(ledgerCache, actions.GetEffectsHandler{LedgerCache: ledgerCache}, streamHandler))
-		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/operations", streamableHistoryPageHandler(ledgerCache, actions.GetOperationsHandler{
-			LedgerCache:  ledgerCache,
+		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/effects", streamableHistoryPageHandler(ledgerState, actions.GetEffectsHandler{LedgerState: ledgerState}, streamHandler))
+		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/operations", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+			LedgerState:  ledgerState,
 			OnlyPayments: false,
 		}, streamHandler))
-		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/payments", streamableHistoryPageHandler(ledgerCache, actions.GetOperationsHandler{
-			LedgerCache:  ledgerCache,
+		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/payments", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+			LedgerState:  ledgerState,
 			OnlyPayments: true,
 		}, streamHandler))
-		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/trades", streamableHistoryPageHandler(ledgerCache, actions.GetTradesHandler{LedgerCache: ledgerCache}, streamHandler))
-		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/transactions", streamableHistoryPageHandler(ledgerCache, actions.GetTransactionsHandler{LedgerCache: ledgerCache}, streamHandler))
+		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/trades", streamableHistoryPageHandler(ledgerState, actions.GetTradesHandler{LedgerState: ledgerState}, streamHandler))
+		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/transactions", streamableHistoryPageHandler(ledgerState, actions.GetTransactionsHandler{LedgerState: ledgerState}, streamHandler))
 	})
 	// ledger actions
 	r.Route("/ledgers", func(r chi.Router) {
 		r.Use(historyMiddleware)
-		r.Method(http.MethodGet, "/", streamableHistoryPageHandler(ledgerCache, actions.GetLedgersHandler{LedgerCache: ledgerCache}, streamHandler))
+		r.Method(http.MethodGet, "/", streamableHistoryPageHandler(ledgerState, actions.GetLedgersHandler{LedgerState: ledgerState}, streamHandler))
 		r.Route("/{ledger_id}", func(r chi.Router) {
-			r.Method(http.MethodGet, "/", ObjectActionHandler{actions.GetLedgerByIDHandler{LedgerCache: ledgerCache}})
-			r.Method(http.MethodGet, "/transactions", streamableHistoryPageHandler(ledgerCache, actions.GetTransactionsHandler{LedgerCache: ledgerCache}, streamHandler))
+			r.Method(http.MethodGet, "/", ObjectActionHandler{actions.GetLedgerByIDHandler{LedgerState: ledgerState}})
+			r.Method(http.MethodGet, "/transactions", streamableHistoryPageHandler(ledgerState, actions.GetTransactionsHandler{LedgerState: ledgerState}, streamHandler))
 			r.Group(func(r chi.Router) {
-				r.Method(http.MethodGet, "/effects", streamableHistoryPageHandler(ledgerCache, actions.GetEffectsHandler{LedgerCache: ledgerCache}, streamHandler))
-				r.Method(http.MethodGet, "/operations", streamableHistoryPageHandler(ledgerCache, actions.GetOperationsHandler{
-					LedgerCache:  ledgerCache,
+				r.Method(http.MethodGet, "/effects", streamableHistoryPageHandler(ledgerState, actions.GetEffectsHandler{LedgerState: ledgerState}, streamHandler))
+				r.Method(http.MethodGet, "/operations", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+					LedgerState:  ledgerState,
 					OnlyPayments: false,
 				}, streamHandler))
-				r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(ledgerCache, actions.GetOperationsHandler{
-					LedgerCache:  ledgerCache,
+				r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+					LedgerState:  ledgerState,
 					OnlyPayments: true,
 				}, streamHandler))
 			})
@@ -223,17 +223,17 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 
 	// transaction history actions
 	r.Route("/transactions", func(r chi.Router) {
-		r.With(historyMiddleware).Method(http.MethodGet, "/", streamableHistoryPageHandler(ledgerCache, actions.GetTransactionsHandler{LedgerCache: ledgerCache}, streamHandler))
+		r.With(historyMiddleware).Method(http.MethodGet, "/", streamableHistoryPageHandler(ledgerState, actions.GetTransactionsHandler{LedgerState: ledgerState}, streamHandler))
 		r.Route("/{tx_id}", func(r chi.Router) {
 			r.Use(historyMiddleware)
 			r.Method(http.MethodGet, "/", ObjectActionHandler{actions.GetTransactionByHashHandler{}})
-			r.Method(http.MethodGet, "/effects", streamableHistoryPageHandler(ledgerCache, actions.GetEffectsHandler{LedgerCache: ledgerCache}, streamHandler))
-			r.Method(http.MethodGet, "/operations", streamableHistoryPageHandler(ledgerCache, actions.GetOperationsHandler{
-				LedgerCache:  ledgerCache,
+			r.Method(http.MethodGet, "/effects", streamableHistoryPageHandler(ledgerState, actions.GetEffectsHandler{LedgerState: ledgerState}, streamHandler))
+			r.Method(http.MethodGet, "/operations", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+				LedgerState:  ledgerState,
 				OnlyPayments: false,
 			}, streamHandler))
-			r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(ledgerCache, actions.GetOperationsHandler{
-				LedgerCache:  ledgerCache,
+			r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+				LedgerState:  ledgerState,
 				OnlyPayments: true,
 			}, streamHandler))
 		})
@@ -242,31 +242,31 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 	// operation actions
 	r.Route("/operations", func(r chi.Router) {
 		r.Use(historyMiddleware)
-		r.Method(http.MethodGet, "/", streamableHistoryPageHandler(ledgerCache, actions.GetOperationsHandler{
-			LedgerCache:  ledgerCache,
+		r.Method(http.MethodGet, "/", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+			LedgerState:  ledgerState,
 			OnlyPayments: false,
 		}, streamHandler))
-		r.Method(http.MethodGet, "/{id}", ObjectActionHandler{actions.GetOperationByIDHandler{LedgerCache: ledgerCache}})
-		r.Method(http.MethodGet, "/{op_id}/effects", streamableHistoryPageHandler(ledgerCache, actions.GetEffectsHandler{LedgerCache: ledgerCache}, streamHandler))
+		r.Method(http.MethodGet, "/{id}", ObjectActionHandler{actions.GetOperationByIDHandler{LedgerState: ledgerState}})
+		r.Method(http.MethodGet, "/{op_id}/effects", streamableHistoryPageHandler(ledgerState, actions.GetEffectsHandler{LedgerState: ledgerState}, streamHandler))
 	})
 
 	r.Group(func(r chi.Router) {
 		r.Use(historyMiddleware)
 		// payment actions
-		r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(ledgerCache, actions.GetOperationsHandler{
-			LedgerCache:  ledgerCache,
+		r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+			LedgerState:  ledgerState,
 			OnlyPayments: true,
 		}, streamHandler))
 
 		// effect actions
-		r.Method(http.MethodGet, "/effects", streamableHistoryPageHandler(ledgerCache, actions.GetEffectsHandler{LedgerCache: ledgerCache}, streamHandler))
+		r.Method(http.MethodGet, "/effects", streamableHistoryPageHandler(ledgerState, actions.GetEffectsHandler{LedgerState: ledgerState}, streamHandler))
 
 		// trading related endpoints
-		r.Method(http.MethodGet, "/trades", streamableHistoryPageHandler(ledgerCache, actions.GetTradesHandler{LedgerCache: ledgerCache}, streamHandler))
-		r.Method(http.MethodGet, "/trade_aggregations", ObjectActionHandler{actions.GetTradeAggregationsHandler{LedgerCache: ledgerCache}})
+		r.Method(http.MethodGet, "/trades", streamableHistoryPageHandler(ledgerState, actions.GetTradesHandler{LedgerState: ledgerState}, streamHandler))
+		r.Method(http.MethodGet, "/trade_aggregations", ObjectActionHandler{actions.GetTradeAggregationsHandler{LedgerState: ledgerState}})
 		// /offers/{offer_id} has been created above so we need to use absolute
 		// routes here.
-		r.Method(http.MethodGet, "/offers/{offer_id}/trades", streamableHistoryPageHandler(ledgerCache, actions.GetTradesHandler{LedgerCache: ledgerCache}, streamHandler))
+		r.Method(http.MethodGet, "/offers/{offer_id}/trades", streamableHistoryPageHandler(ledgerState, actions.GetTradesHandler{LedgerState: ledgerState}, streamHandler))
 	})
 
 	// Transaction submission API

--- a/services/horizon/internal/httpx/server.go
+++ b/services/horizon/internal/httpx/server.go
@@ -57,7 +57,7 @@ func init() {
 	problem.RegisterError(db.ErrCancelled, hProblem.ServiceUnavailable)
 }
 
-func NewServer(serverConfig ServerConfig, routerConfig RouterConfig, ledgerCache *ledger.Cache) (*Server, error) {
+func NewServer(serverConfig ServerConfig, routerConfig RouterConfig, ledgerState *ledger.State) (*Server, error) {
 	sm := &ServerMetrics{
 		RequestDurationSummary: prometheus.NewSummaryVec(
 			prometheus.SummaryOpts{
@@ -67,7 +67,7 @@ func NewServer(serverConfig ServerConfig, routerConfig RouterConfig, ledgerCache
 			[]string{"status", "route", "streaming", "method"},
 		),
 	}
-	router, err := NewRouter(&routerConfig, sm, ledgerCache)
+	router, err := NewRouter(&routerConfig, sm, ledgerState)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/httpx/server.go
+++ b/services/horizon/internal/httpx/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 	"sync"
 	"time"
@@ -56,7 +57,7 @@ func init() {
 	problem.RegisterError(db.ErrCancelled, hProblem.ServiceUnavailable)
 }
 
-func NewServer(serverConfig ServerConfig, routerConfig RouterConfig) (*Server, error) {
+func NewServer(serverConfig ServerConfig, routerConfig RouterConfig, ledgerCache *ledger.Cache) (*Server, error) {
 	sm := &ServerMetrics{
 		RequestDurationSummary: prometheus.NewSummaryVec(
 			prometheus.SummaryOpts{
@@ -66,7 +67,7 @@ func NewServer(serverConfig ServerConfig, routerConfig RouterConfig) (*Server, e
 			[]string{"status", "route", "streaming", "method"},
 		),
 	}
-	router, err := NewRouter(&routerConfig, sm)
+	router, err := NewRouter(&routerConfig, sm, ledgerCache)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/httpx/server.go
+++ b/services/horizon/internal/httpx/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/stellar/go/services/horizon/internal/ledger"
 	"net/http"
 	"sync"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stellar/go/services/horizon/internal/db2"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/services/horizon/internal/render/sse"
 	"github.com/stellar/go/services/horizon/internal/txsub/sequence"

--- a/services/horizon/internal/httpx/stream_handler_test.go
+++ b/services/horizon/internal/httpx/stream_handler_test.go
@@ -74,7 +74,7 @@ func NewStreamablePageTest(
 	ledgerSource := ledger.NewTestingSource(currentLedger)
 	action.ledgerSource = ledgerSource
 	streamHandler := sse.StreamHandler{LedgerSourceFactory: &testingFactory{ledgerSource}}
-	handler := streamableStatePageHandler(&ledger.Cache{}, action, streamHandler)
+	handler := streamableStatePageHandler(&ledger.State{}, action, streamHandler)
 
 	return newStreamTest(
 		handler.renderStream,

--- a/services/horizon/internal/httpx/stream_handler_test.go
+++ b/services/horizon/internal/httpx/stream_handler_test.go
@@ -74,7 +74,7 @@ func NewStreamablePageTest(
 	ledgerSource := ledger.NewTestingSource(currentLedger)
 	action.ledgerSource = ledgerSource
 	streamHandler := sse.StreamHandler{LedgerSourceFactory: &testingFactory{ledgerSource}}
-	handler := streamableStatePageHandler(action, streamHandler)
+	handler := streamableStatePageHandler(&ledger.Cache{}, action, streamHandler)
 
 	return newStreamTest(
 		handler.renderStream,

--- a/services/horizon/internal/ingest/database_backend_test.go
+++ b/services/horizon/internal/ingest/database_backend_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestGetLatestLedger(t *testing.T) {
-	tt := test.Start(t).ScenarioWithoutHorizon("base")
+	tt := test.Start(t)
+	tt.ScenarioWithoutHorizon("base")
 	defer tt.Finish()
 
 	backend, err := ledgerbackend.NewDatabaseBackendFromSession(tt.CoreSession(), network.TestNetworkPassphrase)
@@ -20,7 +21,8 @@ func TestGetLatestLedger(t *testing.T) {
 }
 
 func TestGetLatestLedgerNotFound(t *testing.T) {
-	tt := test.Start(t).ScenarioWithoutHorizon("base")
+	tt := test.Start(t)
+	tt.ScenarioWithoutHorizon("base")
 	defer tt.Finish()
 
 	_, err := tt.CoreDB.Exec(`DELETE FROM ledgerheaders`)

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stellar/go/exp/orderbook"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/ingest"
-	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/simplepath"
 	"github.com/stellar/go/services/horizon/internal/txsub"
 	"github.com/stellar/go/services/horizon/internal/txsub/sequence"
@@ -142,7 +141,7 @@ func initDbMetrics(app *App) {
 	app.historyLatestLedgerCounter = prometheus.NewCounterFunc(
 		prometheus.CounterOpts{Namespace: "horizon", Subsystem: "history", Name: "latest_ledger"},
 		func() float64 {
-			ls := ledger.CurrentState()
+			ls := app.ledgerCache.CurrentState()
 			return float64(ls.HistoryLatest)
 		},
 	)
@@ -151,7 +150,7 @@ func initDbMetrics(app *App) {
 	app.historyElderLedgerCounter = prometheus.NewCounterFunc(
 		prometheus.CounterOpts{Namespace: "horizon", Subsystem: "history", Name: "elder_ledger"},
 		func() float64 {
-			ls := ledger.CurrentState()
+			ls := app.ledgerCache.CurrentState()
 			return float64(ls.HistoryElder)
 		},
 	)
@@ -160,7 +159,7 @@ func initDbMetrics(app *App) {
 	app.coreLatestLedgerCounter = prometheus.NewCounterFunc(
 		prometheus.CounterOpts{Namespace: "horizon", Subsystem: "stellar_core", Name: "latest_ledger"},
 		func() float64 {
-			ls := ledger.CurrentState()
+			ls := app.ledgerCache.CurrentState()
 			return float64(ls.CoreLatest)
 		},
 	)

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -141,7 +141,7 @@ func initDbMetrics(app *App) {
 	app.historyLatestLedgerCounter = prometheus.NewCounterFunc(
 		prometheus.CounterOpts{Namespace: "horizon", Subsystem: "history", Name: "latest_ledger"},
 		func() float64 {
-			ls := app.ledgerCache.CurrentState()
+			ls := app.ledgerState.CurrentStatus()
 			return float64(ls.HistoryLatest)
 		},
 	)
@@ -150,7 +150,7 @@ func initDbMetrics(app *App) {
 	app.historyElderLedgerCounter = prometheus.NewCounterFunc(
 		prometheus.CounterOpts{Namespace: "horizon", Subsystem: "history", Name: "elder_ledger"},
 		func() float64 {
-			ls := app.ledgerCache.CurrentState()
+			ls := app.ledgerState.CurrentStatus()
 			return float64(ls.HistoryElder)
 		},
 	)
@@ -159,7 +159,7 @@ func initDbMetrics(app *App) {
 	app.coreLatestLedgerCounter = prometheus.NewCounterFunc(
 		prometheus.CounterOpts{Namespace: "horizon", Subsystem: "stellar_core", Name: "latest_ledger"},
 		func() float64 {
-			ls := app.ledgerCache.CurrentState()
+			ls := app.ledgerState.CurrentStatus()
 			return float64(ls.CoreLatest)
 		},
 	)

--- a/services/horizon/internal/ledger/ledger_source.go
+++ b/services/horizon/internal/ledger/ledger_source.go
@@ -18,24 +18,24 @@ type Source interface {
 // function to get the current ledger state.
 type HistoryDBSource struct {
 	updateFrequency time.Duration
-	cache           *State
+	state           *State
 
 	closedLock sync.Mutex
 	closed     bool
 }
 
 // NewHistoryDBSource constructs a new instance of HistoryDBSource
-func NewHistoryDBSource(updateFrequency time.Duration, cache *State) *HistoryDBSource {
+func NewHistoryDBSource(updateFrequency time.Duration, state *State) *HistoryDBSource {
 	return &HistoryDBSource{
 		updateFrequency: updateFrequency,
-		cache:           cache,
+		state:           state,
 		closedLock:      sync.Mutex{},
 	}
 }
 
 // CurrentLedger returns the current ledger.
 func (source *HistoryDBSource) CurrentLedger() uint32 {
-	return source.cache.CurrentStatus().ExpHistoryLatest
+	return source.state.CurrentStatus().ExpHistoryLatest
 }
 
 // NextLedger returns a channel which yields every time there is a new ledger with a sequence number larger than currentSequence.
@@ -57,7 +57,7 @@ func (source *HistoryDBSource) NextLedger(currentSequence uint32) chan uint32 {
 				return
 			}
 
-			currentLedgerState := source.cache.CurrentStatus()
+			currentLedgerState := source.state.CurrentStatus()
 			if currentLedgerState.ExpHistoryLatest > currentSequence {
 				newLedgers <- currentLedgerState.ExpHistoryLatest
 				return

--- a/services/horizon/internal/ledger/ledger_source.go
+++ b/services/horizon/internal/ledger/ledger_source.go
@@ -14,30 +14,28 @@ type Source interface {
 	Close()
 }
 
-type currentStateFunc func() State
-
 // HistoryDBSource utility struct to pass the SSE update frequency and a
 // function to get the current ledger state.
 type HistoryDBSource struct {
 	updateFrequency time.Duration
-	currentState    currentStateFunc
+	cache           *Cache
 
 	closedLock sync.Mutex
 	closed     bool
 }
 
 // NewHistoryDBSource constructs a new instance of HistoryDBSource
-func NewHistoryDBSource(updateFrequency time.Duration) *HistoryDBSource {
+func NewHistoryDBSource(updateFrequency time.Duration, cache *Cache) *HistoryDBSource {
 	return &HistoryDBSource{
 		updateFrequency: updateFrequency,
-		currentState:    CurrentState,
+		cache:           cache,
 		closedLock:      sync.Mutex{},
 	}
 }
 
 // CurrentLedger returns the current ledger.
 func (source *HistoryDBSource) CurrentLedger() uint32 {
-	return source.currentState().ExpHistoryLatest
+	return source.cache.CurrentState().ExpHistoryLatest
 }
 
 // NextLedger returns a channel which yields every time there is a new ledger with a sequence number larger than currentSequence.
@@ -59,7 +57,7 @@ func (source *HistoryDBSource) NextLedger(currentSequence uint32) chan uint32 {
 				return
 			}
 
-			currentLedgerState := source.currentState()
+			currentLedgerState := source.cache.CurrentState()
 			if currentLedgerState.ExpHistoryLatest > currentSequence {
 				newLedgers <- currentLedgerState.ExpHistoryLatest
 				return

--- a/services/horizon/internal/ledger/ledger_source.go
+++ b/services/horizon/internal/ledger/ledger_source.go
@@ -18,14 +18,14 @@ type Source interface {
 // function to get the current ledger state.
 type HistoryDBSource struct {
 	updateFrequency time.Duration
-	cache           *Cache
+	cache           *State
 
 	closedLock sync.Mutex
 	closed     bool
 }
 
 // NewHistoryDBSource constructs a new instance of HistoryDBSource
-func NewHistoryDBSource(updateFrequency time.Duration, cache *Cache) *HistoryDBSource {
+func NewHistoryDBSource(updateFrequency time.Duration, cache *State) *HistoryDBSource {
 	return &HistoryDBSource{
 		updateFrequency: updateFrequency,
 		cache:           cache,
@@ -35,7 +35,7 @@ func NewHistoryDBSource(updateFrequency time.Duration, cache *Cache) *HistoryDBS
 
 // CurrentLedger returns the current ledger.
 func (source *HistoryDBSource) CurrentLedger() uint32 {
-	return source.cache.CurrentState().ExpHistoryLatest
+	return source.cache.CurrentStatus().ExpHistoryLatest
 }
 
 // NextLedger returns a channel which yields every time there is a new ledger with a sequence number larger than currentSequence.
@@ -57,7 +57,7 @@ func (source *HistoryDBSource) NextLedger(currentSequence uint32) chan uint32 {
 				return
 			}
 
-			currentLedgerState := source.cache.CurrentState()
+			currentLedgerState := source.cache.CurrentStatus()
 			if currentLedgerState.ExpHistoryLatest > currentSequence {
 				newLedgers <- currentLedgerState.ExpHistoryLatest
 				return

--- a/services/horizon/internal/ledger/ledger_source_test.go
+++ b/services/horizon/internal/ledger/ledger_source_test.go
@@ -1,19 +1,19 @@
 package ledger
 
 import (
+	"sync"
 	"testing"
 )
 
 func Test_HistoryDBLedgerSourceCurrentLedger(t *testing.T) {
-	state := State{
-		ExpHistoryLatest: 3,
+	cache := &Cache{
+		RWMutex: sync.RWMutex{},
+		current: State{ExpHistoryLatest: 3},
 	}
 
 	ledgerSource := HistoryDBSource{
 		updateFrequency: 0,
-		currentState: func() State {
-			return state
-		},
+		cache:           cache,
 	}
 
 	currentLedger := ledgerSource.CurrentLedger()
@@ -23,15 +23,14 @@ func Test_HistoryDBLedgerSourceCurrentLedger(t *testing.T) {
 }
 
 func Test_HistoryDBLedgerSourceNextLedger(t *testing.T) {
-	state := State{
-		ExpHistoryLatest: 3,
+	cache := &Cache{
+		RWMutex: sync.RWMutex{},
+		current: State{ExpHistoryLatest: 3},
 	}
 
 	ledgerSource := HistoryDBSource{
 		updateFrequency: 0,
-		currentState: func() State {
-			return state
-		},
+		cache:           cache,
 	}
 
 	ledgerChan := ledgerSource.NextLedger(0)

--- a/services/horizon/internal/ledger/ledger_source_test.go
+++ b/services/horizon/internal/ledger/ledger_source_test.go
@@ -6,9 +6,9 @@ import (
 )
 
 func Test_HistoryDBLedgerSourceCurrentLedger(t *testing.T) {
-	cache := &Cache{
+	cache := &State{
 		RWMutex: sync.RWMutex{},
-		current: State{ExpHistoryLatest: 3},
+		current: Status{ExpHistoryLatest: 3},
 	}
 
 	ledgerSource := HistoryDBSource{
@@ -23,9 +23,9 @@ func Test_HistoryDBLedgerSourceCurrentLedger(t *testing.T) {
 }
 
 func Test_HistoryDBLedgerSourceNextLedger(t *testing.T) {
-	cache := &Cache{
+	cache := &State{
 		RWMutex: sync.RWMutex{},
-		current: State{ExpHistoryLatest: 3},
+		current: Status{ExpHistoryLatest: 3},
 	}
 
 	ledgerSource := HistoryDBSource{

--- a/services/horizon/internal/ledger/ledger_source_test.go
+++ b/services/horizon/internal/ledger/ledger_source_test.go
@@ -6,14 +6,14 @@ import (
 )
 
 func Test_HistoryDBLedgerSourceCurrentLedger(t *testing.T) {
-	cache := &State{
+	state := &State{
 		RWMutex: sync.RWMutex{},
 		current: Status{ExpHistoryLatest: 3},
 	}
 
 	ledgerSource := HistoryDBSource{
 		updateFrequency: 0,
-		cache:           cache,
+		state:           state,
 	}
 
 	currentLedger := ledgerSource.CurrentLedger()
@@ -23,14 +23,14 @@ func Test_HistoryDBLedgerSourceCurrentLedger(t *testing.T) {
 }
 
 func Test_HistoryDBLedgerSourceNextLedger(t *testing.T) {
-	cache := &State{
+	state := &State{
 		RWMutex: sync.RWMutex{},
 		current: Status{ExpHistoryLatest: 3},
 	}
 
 	ledgerSource := HistoryDBSource{
 		updateFrequency: 0,
-		cache:           cache,
+		state:           state,
 	}
 
 	ledgerChan := ledgerSource.NextLedger(0)

--- a/services/horizon/internal/ledger/main.go
+++ b/services/horizon/internal/ledger/main.go
@@ -9,32 +9,32 @@ import (
 	"sync"
 )
 
-// State represents a snapshot of both horizon's and stellar-core's view of the
+// Status represents a snapshot of both horizon's and stellar-core's view of the
 // ledger.
-type State struct {
+type Status struct {
 	CoreLatest       int32  `db:"core_latest"`
 	HistoryLatest    int32  `db:"history_latest"`
 	HistoryElder     int32  `db:"history_elder"`
 	ExpHistoryLatest uint32 `db:"exp_history_latest"`
 }
 
-// Cache is an in-memory data structure which holds a current snapshot of both
+// State is an in-memory data structure which holds a snapshot of both
 // horizon's and stellar-core's view of the the network
-type Cache struct {
+type State struct {
 	sync.RWMutex
-	current State
+	current Status
 }
 
-// CurrentState returns the cached snapshot of ledger state
-func (c *Cache) CurrentState() State {
+// CurrentStatus returns the cached snapshot of ledger state
+func (c *State) CurrentStatus() Status {
 	c.RLock()
 	defer c.RUnlock()
 	ret := c.current
 	return ret
 }
 
-// SetState updates the cached snapshot of the ledger state
-func (c *Cache) SetState(next State) {
+// SetStatus updates the cached snapshot of the ledger state
+func (c *State) SetStatus(next Status) {
 	c.Lock()
 	defer c.Unlock()
 	c.current = next

--- a/services/horizon/internal/ledger/main.go
+++ b/services/horizon/internal/ledger/main.go
@@ -18,20 +18,24 @@ type State struct {
 	ExpHistoryLatest uint32 `db:"exp_history_latest"`
 }
 
+// Cache is an in-memory data structure which holds a current snapshot of both
+// horizon's and stellar-core's view of the the network
+type Cache struct {
+	sync.RWMutex
+	current State
+}
+
 // CurrentState returns the cached snapshot of ledger state
-func CurrentState() State {
-	lock.RLock()
-	ret := current
-	lock.RUnlock()
+func (c *Cache) CurrentState() State {
+	c.RLock()
+	defer c.RUnlock()
+	ret := c.current
 	return ret
 }
 
 // SetState updates the cached snapshot of the ledger state
-func SetState(next State) {
-	lock.Lock()
-	current = next
-	lock.Unlock()
+func (c *Cache) SetState(next State) {
+	c.Lock()
+	defer c.Unlock()
+	c.current = next
 }
-
-var current State
-var lock sync.RWMutex

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -350,8 +350,9 @@ func TestCheckHistoryStaleMiddleware(t *testing.T) {
 				CoreLatest:    testCase.coreLatest,
 				HistoryLatest: testCase.historyLatest,
 			}
-			ledger.SetState(state)
-			historyMiddleware := httpx.NewHistoryMiddleware(testCase.staleThreshold, tt.HorizonSession())
+			ledgerCache := &ledger.Cache{}
+			ledgerCache.SetState(state)
+			historyMiddleware := httpx.NewHistoryMiddleware(ledgerCache, testCase.staleThreshold, tt.HorizonSession())
 			handler := historyMiddleware(http.HandlerFunc(endpoint))
 			w := httptest.NewRecorder()
 			handler.ServeHTTP(w, request)

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -346,13 +346,13 @@ func TestCheckHistoryStaleMiddleware(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			state := ledger.State{
+			state := ledger.Status{
 				CoreLatest:    testCase.coreLatest,
 				HistoryLatest: testCase.historyLatest,
 			}
-			ledgerCache := &ledger.Cache{}
-			ledgerCache.SetState(state)
-			historyMiddleware := httpx.NewHistoryMiddleware(ledgerCache, testCase.staleThreshold, tt.HorizonSession())
+			ledgerState := &ledger.State{}
+			ledgerState.SetStatus(state)
+			historyMiddleware := httpx.NewHistoryMiddleware(ledgerState, testCase.staleThreshold, tt.HorizonSession())
 			handler := historyMiddleware(http.HandlerFunc(endpoint))
 			w := httptest.NewRecorder()
 			handler.ServeHTTP(w, request)

--- a/services/horizon/internal/reap/main.go
+++ b/services/horizon/internal/reap/main.go
@@ -16,18 +16,18 @@ import (
 type System struct {
 	HistoryQ       *history.Q
 	RetentionCount uint
-	ledgerCache    *ledger.Cache
+	ledgerState    *ledger.State
 
 	nextRun time.Time
 }
 
 // New initializes the reaper, causing it to begin polling the stellar-core
 // database for now ledgers and ingesting data into the horizon database.
-func New(retention uint, dbSession *db.Session, ledgerCache *ledger.Cache) *System {
+func New(retention uint, dbSession *db.Session, ledgerState *ledger.State) *System {
 	r := &System{
 		HistoryQ:       &history.Q{dbSession},
 		RetentionCount: retention,
-		ledgerCache:    ledgerCache,
+		ledgerState:    ledgerState,
 	}
 
 	r.nextRun = time.Now().Add(1 * time.Hour)

--- a/services/horizon/internal/reap/main.go
+++ b/services/horizon/internal/reap/main.go
@@ -5,6 +5,7 @@
 package reap
 
 import (
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"time"
 
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -15,16 +16,18 @@ import (
 type System struct {
 	HistoryQ       *history.Q
 	RetentionCount uint
+	ledgerCache    *ledger.Cache
 
 	nextRun time.Time
 }
 
 // New initializes the reaper, causing it to begin polling the stellar-core
 // database for now ledgers and ingesting data into the horizon database.
-func New(retention uint, dbSession *db.Session) *System {
+func New(retention uint, dbSession *db.Session, ledgerCache *ledger.Cache) *System {
 	r := &System{
 		HistoryQ:       &history.Q{dbSession},
 		RetentionCount: retention,
+		ledgerCache:    ledgerCache,
 	}
 
 	r.nextRun = time.Now().Add(1 * time.Hour)

--- a/services/horizon/internal/reap/main.go
+++ b/services/horizon/internal/reap/main.go
@@ -5,10 +5,10 @@
 package reap
 
 import (
-	"github.com/stellar/go/services/horizon/internal/ledger"
 	"time"
 
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/support/db"
 )
 

--- a/services/horizon/internal/reap/system.go
+++ b/services/horizon/internal/reap/system.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/stellar/go/services/horizon/internal/errors"
-	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/toid"
 	"github.com/stellar/go/support/log"
 )
@@ -17,7 +16,7 @@ func (r *System) DeleteUnretainedHistory() error {
 	}
 
 	var (
-		latest      = ledger.CurrentState()
+		latest      = r.ledgerCache.CurrentState()
 		targetElder = (latest.HistoryLatest - int32(r.RetentionCount)) + 1
 	)
 

--- a/services/horizon/internal/reap/system.go
+++ b/services/horizon/internal/reap/system.go
@@ -16,7 +16,7 @@ func (r *System) DeleteUnretainedHistory() error {
 	}
 
 	var (
-		latest      = r.ledgerCache.CurrentState()
+		latest      = r.ledgerState.CurrentStatus()
 		targetElder = (latest.HistoryLatest - int32(r.RetentionCount)) + 1
 	)
 

--- a/services/horizon/internal/reap/system_test.go
+++ b/services/horizon/internal/reap/system_test.go
@@ -1,18 +1,21 @@
 package reap
 
 import (
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"testing"
 
 	"github.com/stellar/go/services/horizon/internal/test"
 )
 
 func TestDeleteUnretainedHistory(t *testing.T) {
-	tt := test.Start(t).Scenario("kahuna")
+	tt := test.Start(t)
 	defer tt.Finish()
+	ledgerCache := &ledger.Cache{}
+	ledgerCache.SetState(tt.Scenario("kahuna"))
 
 	db := tt.HorizonSession()
 
-	sys := New(0, db)
+	sys := New(0, db, ledgerCache)
 
 	var (
 		prev int
@@ -28,7 +31,7 @@ func TestDeleteUnretainedHistory(t *testing.T) {
 		tt.Assert.Equal(prev, cur, "Ledgers deleted when RetentionCount == 0")
 	}
 
-	tt.UpdateLedgerState()
+	ledgerCache.SetState(tt.LoadLedgerState())
 	sys.RetentionCount = 10
 	err = sys.DeleteUnretainedHistory()
 	if tt.Assert.NoError(err) {
@@ -37,7 +40,7 @@ func TestDeleteUnretainedHistory(t *testing.T) {
 		tt.Assert.Equal(10, cur)
 	}
 
-	tt.UpdateLedgerState()
+	ledgerCache.SetState(tt.LoadLedgerState())
 	sys.RetentionCount = 1
 	err = sys.DeleteUnretainedHistory()
 	if tt.Assert.NoError(err) {

--- a/services/horizon/internal/reap/system_test.go
+++ b/services/horizon/internal/reap/system_test.go
@@ -1,9 +1,9 @@
 package reap
 
 import (
-	"github.com/stellar/go/services/horizon/internal/ledger"
 	"testing"
 
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/test"
 )
 

--- a/services/horizon/internal/reap/system_test.go
+++ b/services/horizon/internal/reap/system_test.go
@@ -10,12 +10,12 @@ import (
 func TestDeleteUnretainedHistory(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
-	ledgerCache := &ledger.Cache{}
-	ledgerCache.SetState(tt.Scenario("kahuna"))
+	ledgerState := &ledger.State{}
+	ledgerState.SetStatus(tt.Scenario("kahuna"))
 
 	db := tt.HorizonSession()
 
-	sys := New(0, db, ledgerCache)
+	sys := New(0, db, ledgerState)
 
 	var (
 		prev int
@@ -31,7 +31,7 @@ func TestDeleteUnretainedHistory(t *testing.T) {
 		tt.Assert.Equal(prev, cur, "Ledgers deleted when RetentionCount == 0")
 	}
 
-	ledgerCache.SetState(tt.LoadLedgerState())
+	ledgerState.SetStatus(tt.LoadLedgerState())
 	sys.RetentionCount = 10
 	err = sys.DeleteUnretainedHistory()
 	if tt.Assert.NoError(err) {
@@ -40,7 +40,7 @@ func TestDeleteUnretainedHistory(t *testing.T) {
 		tt.Assert.Equal(10, cur)
 	}
 
-	ledgerCache.SetState(tt.LoadLedgerState())
+	ledgerState.SetStatus(tt.LoadLedgerState())
 	sys.RetentionCount = 1
 	err = sys.DeleteUnretainedHistory()
 	if tt.Assert.NoError(err) {

--- a/services/horizon/internal/reap/system_test.go
+++ b/services/horizon/internal/reap/system_test.go
@@ -31,7 +31,7 @@ func TestDeleteUnretainedHistory(t *testing.T) {
 		tt.Assert.Equal(prev, cur, "Ledgers deleted when RetentionCount == 0")
 	}
 
-	ledgerState.SetStatus(tt.LoadLedgerState())
+	ledgerState.SetStatus(tt.LoadLedgerStatus())
 	sys.RetentionCount = 10
 	err = sys.DeleteUnretainedHistory()
 	if tt.Assert.NoError(err) {
@@ -40,7 +40,7 @@ func TestDeleteUnretainedHistory(t *testing.T) {
 		tt.Assert.Equal(10, cur)
 	}
 
-	ledgerState.SetStatus(tt.LoadLedgerState())
+	ledgerState.SetStatus(tt.LoadLedgerStatus())
 	sys.RetentionCount = 1
 	err = sys.DeleteUnretainedHistory()
 	if tt.Assert.NoError(err) {

--- a/services/horizon/internal/resourceadapter/root.go
+++ b/services/horizon/internal/resourceadapter/root.go
@@ -14,7 +14,7 @@ import (
 func PopulateRoot(
 	ctx context.Context,
 	dest *horizon.Root,
-	ledgerState ledger.State,
+	ledgerState ledger.Status,
 	hVersion, cVersion string,
 	passphrase string,
 	currentProtocolVersion int32,

--- a/services/horizon/internal/resourceadapter/root_test.go
+++ b/services/horizon/internal/resourceadapter/root_test.go
@@ -22,7 +22,7 @@ func TestPopulateRoot(t *testing.T) {
 
 	PopulateRoot(context.Background(),
 		res,
-		ledger.State{CoreLatest: 1, HistoryLatest: 3, HistoryElder: 2},
+		ledger.Status{CoreLatest: 1, HistoryLatest: 3, HistoryElder: 2},
 		"hVersion",
 		"cVersion",
 		"passphrase",
@@ -44,7 +44,7 @@ func TestPopulateRoot(t *testing.T) {
 	res = &horizon.Root{}
 	PopulateRoot(context.Background(),
 		res,
-		ledger.State{CoreLatest: 1, HistoryLatest: 3, HistoryElder: 2},
+		ledger.Status{CoreLatest: 1, HistoryLatest: 3, HistoryElder: 2},
 		"hVersion",
 		"cVersion",
 		"passphrase",
@@ -65,7 +65,7 @@ func TestPopulateRoot(t *testing.T) {
 	res = &horizon.Root{}
 	PopulateRoot(context.Background(),
 		res,
-		ledger.State{CoreLatest: 1, HistoryLatest: 3, HistoryElder: 2},
+		ledger.Status{CoreLatest: 1, HistoryLatest: 3, HistoryElder: 2},
 		"hVersion",
 		"cVersion",
 		"passphrase",

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stellar/go/keypair"
 	proto "github.com/stellar/go/protocols/horizon"
 	horizon "github.com/stellar/go/services/horizon/internal"
-	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/support/db/dbtest"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/txnbuild"
@@ -97,9 +96,6 @@ func NewTest(t *testing.T, config Config) *Test {
 	cleanup := func() {
 		if i.app != nil {
 			i.app.Close()
-			// Clear the ledger state otherwise the root response
-			// will contain ledger information from the previous test run
-			ledger.SetState(ledger.State{})
 		}
 		runComposeCommand("down", "-v", "--remove-orphans")
 	}

--- a/services/horizon/internal/test/t.go
+++ b/services/horizon/internal/test/t.go
@@ -58,14 +58,14 @@ func (t *T) loadScenario(scenarioName string, includeHorizon bool) {
 func (t *T) Scenario(name string) ledger.Status {
 	clearHorizonDB(t.T, t.HorizonDB)
 	t.loadScenario(name, true)
-	return t.LoadLedgerState()
+	return t.LoadLedgerStatus()
 }
 
 // ScenarioWithoutHorizon loads the named sql scenario into the database
 func (t *T) ScenarioWithoutHorizon(name string) ledger.Status {
 	t.loadScenario(name, false)
 	ResetHorizonDB(t.T, t.HorizonDB)
-	return t.LoadLedgerState()
+	return t.LoadLedgerStatus()
 }
 
 // ResetHorizonDB sets up a new horizon database with empty tables
@@ -133,8 +133,8 @@ func (t *T) UnmarshalExtras(r io.Reader) map[string]string {
 	return resp.Extras
 }
 
-// LoadLedgerState loads ledger state from the core db(or panicing on failure).
-func (t *T) LoadLedgerState() ledger.Status {
+// LoadLedgerStatus loads ledger state from the core db(or panicing on failure).
+func (t *T) LoadLedgerStatus() ledger.Status {
 	var next ledger.Status
 
 	err := t.CoreSession().GetRaw(&next, `

--- a/services/horizon/internal/test/t.go
+++ b/services/horizon/internal/test/t.go
@@ -27,8 +27,6 @@ func (t *T) CoreSession() *db.Session {
 // output
 func (t *T) Finish() {
 	RestoreLogger()
-	// Reset cached ledger state
-	ledger.SetState(ledger.State{})
 	operationfeestats.ResetState()
 
 	if t.LogBuffer.Len() > 0 {
@@ -57,19 +55,17 @@ func (t *T) loadScenario(scenarioName string, includeHorizon bool) {
 }
 
 // Scenario loads the named sql scenario into the database
-func (t *T) Scenario(name string) *T {
+func (t *T) Scenario(name string) ledger.State {
 	clearHorizonDB(t.T, t.HorizonDB)
 	t.loadScenario(name, true)
-	t.UpdateLedgerState()
-	return t
+	return t.LoadLedgerState()
 }
 
 // ScenarioWithoutHorizon loads the named sql scenario into the database
-func (t *T) ScenarioWithoutHorizon(name string) *T {
+func (t *T) ScenarioWithoutHorizon(name string) ledger.State {
 	t.loadScenario(name, false)
 	ResetHorizonDB(t.T, t.HorizonDB)
-	t.UpdateLedgerState()
-	return t
+	return t.LoadLedgerState()
 }
 
 // ResetHorizonDB sets up a new horizon database with empty tables
@@ -137,8 +133,8 @@ func (t *T) UnmarshalExtras(r io.Reader) map[string]string {
 	return resp.Extras
 }
 
-// UpdateLedgerState updates the cached ledger state (or panicing on failure).
-func (t *T) UpdateLedgerState() {
+// LoadLedgerState loads ledger state from the core db(or panicing on failure).
+func (t *T) LoadLedgerState() ledger.State {
 	var next ledger.State
 
 	err := t.CoreSession().GetRaw(&next, `
@@ -162,5 +158,5 @@ func (t *T) UpdateLedgerState() {
 		panic(err)
 	}
 
-	ledger.SetState(next)
+	return next
 }

--- a/services/horizon/internal/test/t.go
+++ b/services/horizon/internal/test/t.go
@@ -55,14 +55,14 @@ func (t *T) loadScenario(scenarioName string, includeHorizon bool) {
 }
 
 // Scenario loads the named sql scenario into the database
-func (t *T) Scenario(name string) ledger.State {
+func (t *T) Scenario(name string) ledger.Status {
 	clearHorizonDB(t.T, t.HorizonDB)
 	t.loadScenario(name, true)
 	return t.LoadLedgerState()
 }
 
 // ScenarioWithoutHorizon loads the named sql scenario into the database
-func (t *T) ScenarioWithoutHorizon(name string) ledger.State {
+func (t *T) ScenarioWithoutHorizon(name string) ledger.Status {
 	t.loadScenario(name, false)
 	ResetHorizonDB(t.T, t.HorizonDB)
 	return t.LoadLedgerState()
@@ -134,8 +134,8 @@ func (t *T) UnmarshalExtras(r io.Reader) map[string]string {
 }
 
 // LoadLedgerState loads ledger state from the core db(or panicing on failure).
-func (t *T) LoadLedgerState() ledger.State {
-	var next ledger.State
+func (t *T) LoadLedgerState() ledger.Status {
+	var next ledger.Status
 
 	err := t.CoreSession().GetRaw(&next, `
 		SELECT

--- a/services/horizon/internal/txsub/results_test.go
+++ b/services/horizon/internal/txsub/results_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 func TestGetIngestedTx(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 	q := &history.Q{Session: tt.HorizonSession()}
 	hash := "2374e99349b9ef7dba9a5db3339b78fda8f34777b1af33ba468ad5c0df946d4d"
@@ -18,7 +19,8 @@ func TestGetIngestedTx(t *testing.T) {
 }
 
 func TestGetMissingTx(t *testing.T) {
-	tt := test.Start(t).Scenario("base")
+	tt := test.Start(t)
+	tt.Scenario("base")
 	defer tt.Finish()
 	q := &history.Q{Session: tt.HorizonSession()}
 	hash := "adf1efb9fd253f53cbbe6230c131d2af19830328e52b610464652d67d2fb7195"
@@ -28,7 +30,8 @@ func TestGetMissingTx(t *testing.T) {
 }
 
 func TestGetFailedTx(t *testing.T) {
-	tt := test.Start(t).Scenario("failed_transactions")
+	tt := test.Start(t)
+	tt.Scenario("failed_transactions")
 	defer tt.Finish()
 	q := &history.Q{Session: tt.HorizonSession()}
 	hash := "aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Close https://github.com/stellar/go/issues/3195

> horizon/ledger.State is a global variable. This is a bad pattern and caused some issues (see #3143). We should make the state local to horizon.App and pass a pointer to it to other parts of the system that need it.
