### PR TITLE
txnbuild: updated CHANGELOG.md for v5.0.0

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v5.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v5.0.0) - 2020-11-12
+
+### Breaking changes
+
+* Updates the SEP-10 helper function parameters and return values to support [SEP-10 v3.0](https://github.com/stellar/stellar-protocol/commit/9d121f98fd2201a5edfe0ed2befe92f4bf88bfe4)
+  * The following functions replaced the `homeDomain` parameter with `homeDomains` (note: plural):
+    * `ReadChallengeTx()`
+    * `VerifyChallengeTxThreshold()`
+    * `VerifyChallengeTxSigners()`
+  * `ReadChallengeTx()` now returns a third non-error value: `matchedHomeDomain`
+
 ## [v4.2.0](https://github.com/stellar/go/releases/tag/horizonclient-v4.2.0) - 2020-11-11
 
 * Add `HashHex()`, `SignWithKeyString()`, `SignHashX()`, and `AddSignatureBase64()` functions back to `FeeBumpTransaction`  ([#3199](https://github.com/stellar/go/pull/3199)).


### PR DESCRIPTION
# PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Adds a new version to the `txnbuild` changelog (v5.0.0) describing the breaking changes made to the SEP-10 helper functions.

### Why

To make the Go SDK compatible with SEP-10 v3.0 (adding back the homeDomain matching constraint)
