### PR TITLE
services/horizon: Add ingestion processors run duration metrics

### DIFF
--- a/services/horizon/internal/ingest/fsm.go
+++ b/services/horizon/internal/ingest/fsm.go
@@ -457,7 +457,8 @@ func (r resumeState) run(s *system) (transition, error) {
 		"commit":   true,
 	}).Info("Processing ledger")
 
-	changeStats, ledgerTransactionStats, err := s.runner.RunAllProcessorsOnLedger(ingestLedger)
+	changeStats, changeDurations, transactionStats, transactionDurations, err :=
+		s.runner.RunAllProcessorsOnLedger(ingestLedger)
 	if err != nil {
 		return retryResume(r), errors.Wrap(err, "Error running processors on ledger")
 	}
@@ -477,13 +478,15 @@ func (r resumeState) run(s *system) (transition, error) {
 	// Update stats metrics
 	changeStatsMap := changeStats.Map()
 	r.addLedgerStatsMetricFromMap(s, "change", changeStatsMap)
+	r.addProcessorDurationsMetricFromMap(s, changeDurations)
 
-	ledgerTransactionStatsMap := ledgerTransactionStats.Map()
-	r.addLedgerStatsMetricFromMap(s, "ledger", ledgerTransactionStatsMap)
+	transactionStatsMap := transactionStats.Map()
+	r.addLedgerStatsMetricFromMap(s, "ledger", transactionStatsMap)
+	r.addProcessorDurationsMetricFromMap(s, transactionDurations)
 
 	log.
 		WithFields(changeStatsMap).
-		WithFields(ledgerTransactionStatsMap).
+		WithFields(transactionStatsMap).
 		WithFields(logpkg.F{
 			"sequence": ingestLedger,
 			"duration": duration,
@@ -503,6 +506,15 @@ func (r resumeState) addLedgerStatsMetricFromMap(s *system, prefix string, m map
 		stat = strings.Replace(stat, "stats_", prefix+"_", 1)
 		s.Metrics().LedgerStatsCounter.
 			With(prometheus.Labels{"type": stat}).Add(float64(value.(int64)))
+	}
+}
+
+func (r resumeState) addProcessorDurationsMetricFromMap(s *system, m map[string]time.Duration) {
+	for processorName, value := range m {
+		// * is not accepted in Prometheus labels
+		processorName = strings.Replace(processorName, "*", "", -1)
+		s.Metrics().ProcessorsRunDuration.
+			With(prometheus.Labels{"name": processorName}).Add(value.Seconds())
 	}
 }
 
@@ -576,7 +588,7 @@ func runTransactionProcessorsOnLedger(s *system, ledger uint32) error {
 	}).Info("Processing ledger")
 	startTime := time.Now()
 
-	ledgerTransactionStats, err := s.runner.RunTransactionProcessorsOnLedger(ledger)
+	ledgerTransactionStats, _, err := s.runner.RunTransactionProcessorsOnLedger(ledger)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("error processing ledger sequence=%d", ledger))
 	}
@@ -820,7 +832,7 @@ func (v verifyRangeState) run(s *system) (transition, error) {
 
 		var changeStats io.StatsChangeProcessorResults
 		var ledgerTransactionStats io.StatsLedgerTransactionProcessorResults
-		changeStats, ledgerTransactionStats, err = s.runner.RunAllProcessorsOnLedger(sequence)
+		changeStats, _, ledgerTransactionStats, _, err = s.runner.RunAllProcessorsOnLedger(sequence)
 		if err != nil {
 			err = errors.Wrap(err, "Error running processors on ledger")
 			return stop(), err
@@ -887,7 +899,7 @@ func (stressTestState) run(s *system) (transition, error) {
 	}).Info("Processing ledger")
 	startTime := time.Now()
 
-	changeStats, ledgerTransactionStats, err := s.runner.RunAllProcessorsOnLedger(sequence)
+	changeStats, _, ledgerTransactionStats, _, err := s.runner.RunAllProcessorsOnLedger(sequence)
 	if err != nil {
 		err = errors.Wrap(err, "Error running processors on ledger")
 		return stop(), err

--- a/services/horizon/internal/ingest/group_processors.go
+++ b/services/horizon/internal/ingest/group_processors.go
@@ -1,52 +1,83 @@
 package ingest
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/stellar/go/ingest/io"
 	"github.com/stellar/go/support/errors"
 )
 
-type horizonChangeProcessor interface {
-	io.ChangeProcessor
-	// TODO maybe rename to Flush()
-	Commit() error
+type processorsRunDurations map[string]time.Duration
+
+func (d processorsRunDurations) AddRunDuration(name string, startTime time.Time) {
+	d[name] += time.Since(startTime)
 }
 
-type groupChangeProcessors []horizonChangeProcessor
+type groupChangeProcessors struct {
+	processors []horizonChangeProcessor
+	processorsRunDurations
+}
+
+func newGroupChangeProcessors(processors []horizonChangeProcessor) *groupChangeProcessors {
+	return &groupChangeProcessors{
+		processors:             processors,
+		processorsRunDurations: make(map[string]time.Duration),
+	}
+}
 
 func (g groupChangeProcessors) ProcessChange(change io.Change) error {
-	for _, p := range g {
+	for _, p := range g.processors {
+		startTime := time.Now()
 		if err := p.ProcessChange(change); err != nil {
 			return errors.Wrapf(err, "error in %T.ProcessChange", p)
 		}
+		g.AddRunDuration(fmt.Sprintf("%T", p), startTime)
 	}
 	return nil
 }
 
 func (g groupChangeProcessors) Commit() error {
-	for _, p := range g {
+	for _, p := range g.processors {
+		startTime := time.Now()
 		if err := p.Commit(); err != nil {
 			return errors.Wrapf(err, "error in %T.Commit", p)
 		}
+		g.AddRunDuration(fmt.Sprintf("%T", p), startTime)
 	}
 	return nil
 }
 
-type groupTransactionProcessors []horizonTransactionProcessor
+type groupTransactionProcessors struct {
+	processors []horizonTransactionProcessor
+	processorsRunDurations
+}
+
+func newGroupTransactionProcessors(processors []horizonTransactionProcessor) *groupTransactionProcessors {
+	return &groupTransactionProcessors{
+		processors:             processors,
+		processorsRunDurations: make(map[string]time.Duration),
+	}
+}
 
 func (g groupTransactionProcessors) ProcessTransaction(tx io.LedgerTransaction) error {
-	for _, p := range g {
+	for _, p := range g.processors {
+		startTime := time.Now()
 		if err := p.ProcessTransaction(tx); err != nil {
 			return errors.Wrapf(err, "error in %T.ProcessTransaction", p)
 		}
+		g.AddRunDuration(fmt.Sprintf("%T", p), startTime)
 	}
 	return nil
 }
 
 func (g groupTransactionProcessors) Commit() error {
-	for _, p := range g {
+	for _, p := range g.processors {
+		startTime := time.Now()
 		if err := p.Commit(); err != nil {
 			return errors.Wrapf(err, "error in %T.Commit", p)
 		}
+		g.AddRunDuration(fmt.Sprintf("%T", p), startTime)
 	}
 	return nil
 }

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -107,6 +107,9 @@ type Metrics struct {
 
 	// LedgerStatsCounter exposes ledger stats counters (like number of ops/changes).
 	LedgerStatsCounter *prometheus.CounterVec
+
+	// ProcessorsRunDuration exposes processors run durations.
+	ProcessorsRunDuration *prometheus.CounterVec
 }
 
 type System interface {
@@ -263,6 +266,14 @@ func (s *system) initMetrics() {
 			Help: "counters of different ledger stats",
 		},
 		[]string{"type"},
+	)
+
+	s.metrics.ProcessorsRunDuration = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "horizon", Subsystem: "ingest", Name: "processor_run_duration_seconds_total",
+			Help: "run durations of ingestion processors",
+		},
+		[]string{"name"},
 	)
 }
 

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -244,6 +244,7 @@ func initIngestMetrics(app *App) {
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().StateVerifyDuration)
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().StateInvalidGauge)
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().LedgerStatsCounter)
+	app.prometheusRegistry.MustRegister(app.ingester.Metrics().ProcessorsRunDuration)
 }
 
 func initTxSubMetrics(app *App) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add ingestion processors run duration metrics.

### Why

To better understand performance bottlenecks.

### Known limitations

[TODO or N/A]
