### PR TITLE
ingest/ledgerbackend: Fix CaptiveStellarCore.IsPrepared to include cached ledger

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -361,24 +361,37 @@ func (c *CaptiveStellarCore) PrepareRange(ledgerRange Range) error {
 
 // IsPrepared returns true if a given ledgerRange is prepared.
 func (c *CaptiveStellarCore) IsPrepared(ledgerRange Range) (bool, error) {
-	if c.nextLedger == 0 {
-		return false, nil
+	lastLedger := uint32(0)
+	if c.lastLedger != nil {
+		lastLedger = *c.lastLedger
 	}
 
-	if c.lastLedger == nil {
-		return c.nextLedger <= ledgerRange.from ||
-			(c.cachedMeta != nil && c.cachedMeta.LedgerSequence() == ledgerRange.from), nil
+	cachedLedger := uint32(0)
+	if c.cachedMeta != nil {
+		cachedLedger = c.cachedMeta.LedgerSequence()
 	}
 
-	// From now on: c.lastLedger != nil so current range is bounded
+	return c.isPrepared(c.nextLedger, lastLedger, cachedLedger, ledgerRange), nil
+}
+
+func (*CaptiveStellarCore) isPrepared(nextLedger, lastLedger, cachedLedger uint32, ledgerRange Range) bool {
+	if nextLedger == 0 {
+		return false
+	}
+
+	if lastLedger == 0 {
+		return nextLedger <= ledgerRange.from || cachedLedger == ledgerRange.from
+	}
+
+	// From now on: lastLedger != 0 so current range is bounded
 
 	if ledgerRange.bounded {
-		return c.nextLedger <= ledgerRange.from &&
-			c.nextLedger <= *c.lastLedger, nil
+		return (nextLedger <= ledgerRange.from || cachedLedger == ledgerRange.from) &&
+			lastLedger >= ledgerRange.to
 	}
 
 	// Requested range is unbounded but current one is bounded
-	return false, nil
+	return false
 }
 
 // GetLedger returns true when ledger is found and it's LedgerCloseMeta.

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -366,7 +366,8 @@ func (c *CaptiveStellarCore) IsPrepared(ledgerRange Range) (bool, error) {
 	}
 
 	if c.lastLedger == nil {
-		return c.nextLedger <= ledgerRange.from, nil
+		return c.nextLedger <= ledgerRange.from ||
+			(c.cachedMeta != nil && c.cachedMeta.LedgerSequence() == ledgerRange.from), nil
 	}
 
 	// From now on: c.lastLedger != nil so current range is bounded

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -894,3 +894,37 @@ func TestCaptiveRunFromParams(t *testing.T) {
 		})
 	}
 }
+
+func TestCaptiveIsPrepared(t *testing.T) {
+	var tests = []struct {
+		nextLedger   uint32
+		lastLedger   uint32
+		cachedLedger uint32
+		ledgerRange  Range
+		result       bool
+	}{
+		{0, 0, 0, UnboundedRange(100), false},
+		{100, 0, 0, UnboundedRange(101), true},
+		{101, 0, 100, UnboundedRange(100), true},
+		{100, 200, 0, UnboundedRange(100), false},
+
+		{100, 200, 0, BoundedRange(100, 200), true},
+		{100, 200, 0, BoundedRange(100, 201), false},
+		{100, 201, 0, BoundedRange(100, 200), true},
+		{101, 200, 100, BoundedRange(100, 200), true},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("next_%d_last_%d_cached_%d_range_%v", tc.nextLedger, tc.lastLedger, tc.cachedLedger, tc.ledgerRange), func(t *testing.T) {
+			captiveBackend := CaptiveStellarCore{}
+
+			result := captiveBackend.isPrepared(
+				tc.nextLedger,
+				tc.lastLedger,
+				tc.cachedLedger,
+				tc.ledgerRange,
+			)
+			assert.Equal(t, tc.result, result)
+		})
+	}
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

Fixed `CaptiveStellarCore.IsPrepared` method and added tests. There were two issues:
- Cached ledger meta was not checked,
- Bounded range condition was invalid (last ledger not checked).