### PR TITLE
ingest/ledgerbackend: Fix off-by-one in CaptiveStellarCore.runFromParams

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -326,9 +326,9 @@ func (c *CaptiveStellarCore) runFromParams(from uint32) (runFrom uint32, ledgerH
 	runFrom = from - 1
 	if c.ledgerHashStore != nil {
 		var exists bool
-		ledgerHash, exists, err = c.ledgerHashStore.GetLedgerHash(from)
+		ledgerHash, exists, err = c.ledgerHashStore.GetLedgerHash(runFrom)
 		if err != nil {
-			err = errors.Wrapf(err, "error trying to read ledger hash %d", from)
+			err = errors.Wrapf(err, "error trying to read ledger hash %d", runFrom)
 			return
 		}
 		if exists {

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -962,13 +962,13 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 		}, nil)
 
 	mockLedgerHashStore := &MockLedgerHashStore{}
-	mockLedgerHashStore.On("GetLedgerHash", uint32(1023)).
+	mockLedgerHashStore.On("GetLedgerHash", uint32(1022)).
 		Return("", false, fmt.Errorf("transient error")).Once()
-	mockLedgerHashStore.On("GetLedgerHash", uint32(255)).
+	mockLedgerHashStore.On("GetLedgerHash", uint32(254)).
 		Return("", false, nil).Once()
-	mockLedgerHashStore.On("GetLedgerHash", uint32(63)).
+	mockLedgerHashStore.On("GetLedgerHash", uint32(62)).
 		Return("cde", true, nil).Once()
-	mockLedgerHashStore.On("GetLedgerHash", uint32(127)).
+	mockLedgerHashStore.On("GetLedgerHash", uint32(126)).
 		Return("ghi", true, nil).Once()
 
 	captiveBackend := CaptiveStellarCore{
@@ -997,7 +997,7 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 	assert.Equal(t, uint32(64), nextLedger)
 
 	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(1050)
-	assert.EqualError(t, err, "error trying to read ledger hash 1023: transient error")
+	assert.EqualError(t, err, "error trying to read ledger hash 1022: transient error")
 
 	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(300)
 	assert.NoError(t, err)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

Fixes off-by-one bug in `CaptiveStellarCore.runFromParams`. In https://github.com/stellar/go/commit/21e076a9cc28a959ff3c97e71f9672097cbde4f6 a `TrustedLedgerHashStore` interface was added and used in `CaptiveStellarCore`. However, due to copy-paste the `GetLedgerHash` method was called with a wrong param (`from` instead of `from-1`). This happened because similar call to `archive.GetLedgerHeader` was copied however, in this call we use a `PreviousLedgerHash` instead.

Possibly fixes https://github.com/stellar/go/issues/3230 (not sure because no log was added to the issue).