### PR TITLE
exp/services/captivecore: Captive Core API fixes

### DIFF
--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -101,7 +101,7 @@ func main() {
 		Run: func(_ *cobra.Command, _ []string) {
 			configOpts.Require()
 			configOpts.SetValues()
-			logger.Level = logLevel
+			logger.SetLevel(logLevel)
 
 			captiveConfig := ledgerbackend.CaptiveCoreConfig{
 				StellarCoreBinaryPath: binaryPath,
@@ -124,7 +124,8 @@ func main() {
 			if err != nil {
 				logger.WithError(err).Fatal("Could not create captive core instance")
 			}
-			api := internal.NewCaptiveCoreAPI(core, logger)
+			core.SetStellarCoreLogger(logger.WithField("subservice", "stellar-core"))
+			api := internal.NewCaptiveCoreAPI(core, logger.WithField("subservice", "api"))
 
 			supporthttp.Run(supporthttp.Config{
 				ListenAddr: fmt.Sprintf(":%d", port),


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Close https://github.com/stellar/go/issues/3228
Close https://github.com/stellar/go/issues/3229

This commit correctly sets the log level in the captive core api logger. With this fix the captive core api logs are now visible and formatted correctly.

This commit also marks the active request as invalid whenever a captive core function returns an error. By marking the active request as invalid we ensure that the captive core subprocess is recreated the next time `POST /prepare-range` is invoked.

### Known limitations

[N/A]
