### PR TITLE
services/horizon: Trivial improvements to Stellar Core log parsing

### DIFF
--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -162,7 +162,7 @@ func (r *stellarCoreRunner) getLogLineWriter() io.Writer {
 				} else {
 					r.Log.Info(line)
 				}
-			} else if len(line) > 1 { // non-empty
+			} else {
 				r.Log.Info(line)
 			}
 		}

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -160,10 +160,10 @@ func (r *stellarCoreRunner) getLogLineWriter() io.Writer {
 				if writer, ok := levelMapping[strings.ToUpper(level)]; ok {
 					writer("%s: %s", category, line)
 				} else {
-					r.Log.Infof(line)
+					r.Log.Info(line)
 				}
 			} else {
-				r.Log.Infof(line)
+				r.Log.Info(line)
 			}
 		}
 	}()

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -124,7 +124,7 @@ func (r *stellarCoreRunner) getLogLineWriter() io.Writer {
 	// Strip timestamps from log lines from captive stellar-core. We emit our own.
 	dateRx := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3} `)
 	go func() {
-		levelRx := regexp.MustCompile(`G[A-Z0-9]{4} \[(\w+) ([A-Z]+)\] (.*)`)
+		levelRx := regexp.MustCompile(`\[(\w+) ([A-Z]+)\] (.*)`)
 		for {
 			line, err := br.ReadString('\n')
 			if err != nil {
@@ -162,7 +162,7 @@ func (r *stellarCoreRunner) getLogLineWriter() io.Writer {
 				} else {
 					r.Log.Info(line)
 				}
-			} else {
+			} else if len(line) > 1 { // non-empty
 				r.Log.Info(line)
 			}
 		}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Improves log output:
 - `Infof` -> `Info` for non-formatted strings
 - Lines w/o pubkey prefix are parsed correctly

### Why
When the line from Stellar Core's logs contains `%`, it's interpreted as a formatting directive by the output function (e.g. `Infof`), causing extraneous output. It should just use `Info` to avoid this.

Not all Core lines begin with a public key prefix `G[AB12]` (e.g. ones that begin with `<startup>` instead), so we shouldn't enforce this in the regex.