### PR TITLE
services/horizon/docker: Fix STELLAR_CORE_BINARY_PATH in horizon docker image

### DIFF
--- a/services/horizon/docker/Dockerfile
+++ b/services/horizon/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN go install github.com/stellar/go/exp/services/captivecore
 FROM ubuntu:18.04
 
 ENV STELLAR_CORE_VERSION 15.0.0-40
-ENV STELLAR_CORE_BINARY_PATH /usr/local/bin/stellar-core
+ENV STELLAR_CORE_BINARY_PATH /usr/bin/stellar-core
 
 ENV DEBIAN_FRONTEND=noninteractive
 # ca-certificates are required to make tls connections


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The `STELLAR_CORE_BINARY_PATH` environment variable in the horizon docker image is currently misconfigured. If you try to run the horizon docker image without overriding `STELLAR_CORE_BINARY_PATH` the container will crash with the following error message:

```
horizon_1   | time="2020-11-25T13:16:52.135Z" level=error msg="Error in ingestion state machine" current_state="buildFromCheckpoint(checkpointLedger=462783)" error="error preparing range: opening subprocess: error running stellar-core: error starting `stellar-core run` subprocess: error starting stellar-core: fork/exec /usr/local/bin/stellar-core: no such file or directory" next_state=start pid=1 service=ingest
```