### PR TITLE
ingest/ledgerbackend: Fix nil pointer dereference in captive core close

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -544,9 +544,12 @@ func (c *CaptiveStellarCore) Close() error {
 			return errors.Wrap(err, "error closing stellar-core subprocess")
 		}
 
-		// Wait for bufferedLedgerMetaReader go routine to return.
-		c.ledgerBuffer.waitForClose()
-		c.ledgerBuffer = nil
+		// c.ledgerBuffer might be nil if stellarCoreRunner.runFrom / stellarCoreRunner.catchup responded with an error
+		if c.ledgerBuffer != nil {
+			// Wait for bufferedLedgerMetaReader go routine to return.
+			c.ledgerBuffer.waitForClose()
+			c.ledgerBuffer = nil
+		}
 	}
 
 	c.nextLedger = 0

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -330,7 +330,7 @@ func TestCaptivePrepareRange_ToIsAheadOfRootHAS(t *testing.T) {
 func TestCaptivePrepareRange_ErrCatchup(t *testing.T) {
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(100), uint32(192)).Return(errors.New("transient error")).Once()
-	mockRunner.On("close").Return(nil)
+	mockRunner.On("close").Return(nil).Once()
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -350,6 +350,10 @@ func TestCaptivePrepareRange_ErrCatchup(t *testing.T) {
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
 	assert.Error(t, err)
 	assert.EqualError(t, err, "opening subprocess: error running stellar-core: transient error")
+
+	// make sure we can Close without errors
+	assert.NoError(t, captiveBackend.Close())
+	mockRunner.AssertExpectations(t)
 }
 
 func TestCaptivePrepareRangeUnboundedRange_ErrGettingRootHAS(t *testing.T) {
@@ -396,7 +400,7 @@ func TestCaptivePrepareRangeUnboundedRange_FromIsTooFarAheadOfLatestHAS(t *testi
 func TestCaptivePrepareRangeUnboundedRange_ErrRunFrom(t *testing.T) {
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("runFrom", uint32(126), "0000000000000000000000000000000000000000000000000000000000000000").Return(errors.New("transient error")).Once()
-	mockRunner.On("close").Return(nil)
+	mockRunner.On("close").Return(nil).Once()
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -420,6 +424,10 @@ func TestCaptivePrepareRangeUnboundedRange_ErrRunFrom(t *testing.T) {
 
 	err := captiveBackend.PrepareRange(UnboundedRange(128))
 	assert.EqualError(t, err, "opening subprocess: error running stellar-core: transient error")
+
+	// make sure we can Close without errors
+	assert.NoError(t, captiveBackend.Close())
+	mockRunner.AssertExpectations(t)
 }
 
 func TestCaptivePrepareRangeUnboundedRange_ErrClosingExistingSession(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

While investigating https://github.com/stellar/go/pull/3253 I observed the following crash:

```
horizon_1   | time="2020-11-25T13:16:55.358Z" level=info msg="Preparing range" ledger=462783 pid=1 service=ingest
horizon_1   | panic: runtime error: invalid memory address or nil pointer dereference
horizon_1   | [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xc32b67]
horizon_1   | 
horizon_1   | goroutine 115 [running]:
horizon_1   | github.com/stellar/go/ingest/ledgerbackend.(*bufferedLedgerMetaReader).waitForClose(0x0)
horizon_1   | 	/go/src/github.com/stellar/go/ingest/ledgerbackend/buffered_meta_pipe_reader.go:135 +0x37
horizon_1   | github.com/stellar/go/ingest/ledgerbackend.(*CaptiveStellarCore).Close(0xc000446240, 0x0, 0x0)
horizon_1   | 	/go/src/github.com/stellar/go/ingest/ledgerbackend/captive_core_backend.go:548 +0xbb
horizon_1   | github.com/stellar/go/ingest/ledgerbackend.(*CaptiveStellarCore).openOnlineReplaySubprocess(0xc000446240, 0x70fbf, 0x48e000, 0x5fbe5900)
horizon_1   | 	/go/src/github.com/stellar/go/ingest/ledgerbackend/captive_core_backend.go:224 +0x40
horizon_1   | github.com/stellar/go/ingest/ledgerbackend.(*CaptiveStellarCore).PrepareRange(0xc000446240, 0x70fbf, 0x1ab4900, 0x1, 0x1)
horizon_1   | 	/go/src/github.com/stellar/go/ingest/ledgerbackend/captive_core_backend.go:369 +0x1a6
horizon_1   | github.com/stellar/go/services/horizon/internal/ingest.(*system).maybePrepareRange(0xc000602f00, 0x70fbf, 0x0, 0x0, 0x1)
horizon_1   | 	/go/src/github.com/stellar/go/services/horizon/internal/ingest/fsm.go:976 +0x32e
horizon_1   | github.com/stellar/go/services/horizon/internal/ingest.buildState.run(0x70fbf, 0xc000602f00, 0x0, 0x0, 0x0, 0x0, 0x0)
horizon_1   | 	/go/src/github.com/stellar/go/services/horizon/internal/ingest/fsm.go:310 +0x1720
horizon_1   | github.com/stellar/go/services/horizon/internal/ingest.(*system).runStateMachine(0xc000602f00, 0x12d4220, 0xc00045e1e0, 0x0, 0x0)
horizon_1   | 	/go/src/github.com/stellar/go/services/horizon/internal/ingest/main.go:390 +0x3c5
horizon_1   | github.com/stellar/go/services/horizon/internal/ingest.(*system).Run(0xc000602f00)
horizon_1   | 	/go/src/github.com/stellar/go/services/horizon/internal/ingest/main.go:317 +0x4d
horizon_1   | github.com/stellar/go/services/horizon/internal.(*App).Serve.func1(0xc0001d8300, 0xc0002f8000)
horizon_1   | 	/go/src/github.com/stellar/go/services/horizon/internal/app.go:124 +0x3a
horizon_1   | created by github.com/stellar/go/services/horizon/internal.(*App).Serve
horizon_1   | 	/go/src/github.com/stellar/go/services/horizon/internal/app.go:123 +0x447
deployment_horizon_1 exited with code 2

```

This crash occurs because we always assume that if `c.stellarCoreRunner` is non-nil then `c.ledgerBuffer` must also be non-nil. It turns out that assumption is not always valid. 

In `PrepareRange()` we first set `c.stellarCoreRunner` then we invoke a `catchup()` or `runFrom()` command on captive core. If the command does not return an error we proceed with creating `c.ledgerBuffer`. However, if the command returns an error we return early without creating `c.ledgerBuffer`.



