### PR TITLE
ingest/ledgerbackend: Remove returning error on Stellar-Core process exit during catchup

### DIFF
--- a/ingest/ledgerbackend/buffered_meta_pipe_reader.go
+++ b/ingest/ledgerbackend/buffered_meta_pipe_reader.go
@@ -100,6 +100,13 @@ func (b *bufferedLedgerMetaReader) readLedgerMetaFromPipe(untilSequence uint32) 
 		select {
 		case <-b.runner.getProcessExitChan():
 			if untilSequence != 0 {
+				// If untilSequence != 0 it's possible that Stellar-Core process
+				// exits but there are still ledgers in a buffer (catchup). In such
+				// case we ignore cases when Stellar-Core exited with no errors.
+				processErr := b.runner.getProcessExitError()
+				if processErr != nil {
+					return nil, errors.Wrap(processErr, "stellar-core process exited with an error")
+				}
 				time.Sleep(time.Second)
 				continue
 			}

--- a/ingest/ledgerbackend/buffered_meta_pipe_reader.go
+++ b/ingest/ledgerbackend/buffered_meta_pipe_reader.go
@@ -84,7 +84,7 @@ func newBufferedLedgerMetaReader(runner stellarCoreRunnerInterface) *bufferedLed
 //   * Meta pipe buffer is full so it will wait until it refills.
 //   * The next ledger available in the buffer exceeds the meta pipe buffer size.
 //     In such case the method will block until LedgerCloseMeta buffer is empty.
-func (b *bufferedLedgerMetaReader) readLedgerMetaFromPipe() (*xdr.LedgerCloseMeta, error) {
+func (b *bufferedLedgerMetaReader) readLedgerMetaFromPipe(untilSequence uint32) (*xdr.LedgerCloseMeta, error) {
 	frameLength, err := xdr.ReadFrameLength(b.r)
 	if err != nil {
 		select {
@@ -99,6 +99,10 @@ func (b *bufferedLedgerMetaReader) readLedgerMetaFromPipe() (*xdr.LedgerCloseMet
 		// Wait for LedgerCloseMeta buffer to be cleared to minimize memory usage.
 		select {
 		case <-b.runner.getProcessExitChan():
+			if untilSequence != 0 {
+				time.Sleep(time.Second)
+				continue
+			}
 			return nil, wrapStellarCoreRunnerError(b.runner)
 		case <-time.After(time.Second):
 		}
@@ -152,15 +156,12 @@ func (b *bufferedLedgerMetaReader) start(untilSequence uint32) {
 
 	for {
 		select {
-		case <-b.runner.getProcessExitChan():
-			b.c <- metaResult{nil, wrapStellarCoreRunnerError(b.runner)}
-			return
 		case <-printBufferOccupation.C:
 			log.Debug("captive core read-ahead buffer occupation:", len(b.c))
 		default:
 		}
 
-		meta, err := b.readLedgerMetaFromPipe()
+		meta, err := b.readLedgerMetaFromPipe(untilSequence)
 		if err != nil {
 			// When `GetLedger` sees the error it will close the backend. We shouldn't
 			// close it now because there may be some ledgers in a buffer.
@@ -168,12 +169,7 @@ func (b *bufferedLedgerMetaReader) start(untilSequence uint32) {
 			return
 		}
 
-		select {
-		case b.c <- metaResult{meta, nil}:
-		case <-b.runner.getProcessExitChan():
-			b.c <- metaResult{nil, wrapStellarCoreRunnerError(b.runner)}
-			return
-		}
+		b.c <- metaResult{meta, nil}
 
 		if untilSequence != 0 {
 			if meta.LedgerSequence() >= untilSequence {

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -388,7 +388,12 @@ func (c *CaptiveStellarCore) PrepareRange(ledgerRange Range) error {
 	for {
 		select {
 		case <-c.stellarCoreRunner.getProcessExitChan():
-			return wrapStellarCoreRunnerError(c.stellarCoreRunner)
+			// Return only in case of Stellar-Core process error. Normal exit
+			// is expected in catchup when all ledgers sent to a buffer.
+			processErr := c.stellarCoreRunner.getProcessExitError()
+			if processErr != nil {
+				return errors.Wrap(processErr, "stellar-core process exited with an error")
+			}
 		default:
 		}
 		// Wait for the first ledger or an error

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -264,8 +264,7 @@ func TestCaptivePrepareRangeTerminated(t *testing.T) {
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
-	assert.Error(t, err)
-	assert.EqualError(t, err, "stellar-core process exited unexpectedly without an error")
+	assert.NoError(t, err)
 }
 
 func TestCaptivePrepareRange_ErrClosingSession(t *testing.T) {

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -140,7 +140,7 @@ func (r *stellarCoreRunner) getLogLineWriter() io.Writer {
 			// If there's a logger, we attempt to extract metadata about the log
 			// entry, then redirect it to the logger. Otherwise, we just use stdout.
 			if r.Log == nil {
-				fmt.Print(line)
+				fmt.Println(line)
 				continue
 			}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

Fixes a bug introduced in https://github.com/stellar/go/commit/a10c00015768d34d017b454254ab45377187848f because of which `PrepareRange` and `GetLedger` methods could return an error after Stellar-Core process exit but before all ledgers are read from the buffer. To fix it we now handle process exit in `bufferedLedgerMetaReader` only and only in case of errors. In `PrepareRange` we return error only on Stellar-Core exit with error. This won't work with user initiated shutdown, it will be fixed in #3258.

Thanks for the report, @Isaiah-Turner!