### PR TITLE
services/horizon: Refactor Captive Core configuration flags

### DIFF
--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -20,7 +20,7 @@ import (
 
 func main() {
 	var port int
-	var networkPassphrase, binaryPath, quorumConfigPath, dbURL string
+	var networkPassphrase, binaryPath, configAddendumPath, dbURL string
 	var historyArchiveURLs []string
 	var stellarCoreHTTPPort uint16
 	var logLevel logrus.Level
@@ -52,12 +52,12 @@ func main() {
 			ConfigKey:   &binaryPath,
 		},
 		&config.ConfigOption{
-			Name:        "stellar-captive-core-quorum-path",
+			Name:        "captive-core-addendum-path",
 			OptType:     types.String,
 			FlagDefault: "",
 			Required:    false,
-			Usage:       "path to stellar core quorum config file (i.e. a stellar core config file with [QUORUM_SET] entries)",
-			ConfigKey:   &quorumConfigPath,
+			Usage:       "path to an addendum for the Stellar Core configuration file used by captive core. It must, at least, include enough details to define a quorum set",
+			ConfigKey:   &configAddendumPath,
 		},
 		&config.ConfigOption{
 			Name:        "history-archive-urls",
@@ -113,11 +113,11 @@ func main() {
 			logger.SetLevel(logLevel)
 
 			captiveConfig := ledgerbackend.CaptiveCoreConfig{
-				StellarCoreBinaryPath: binaryPath,
-				QuorumConfigPath:      quorumConfigPath,
-				NetworkPassphrase:     networkPassphrase,
-				HistoryArchiveURLs:    historyArchiveURLs,
-				HTTPPort:              stellarCoreHTTPPort,
+				StellarCoreBinaryPath:  binaryPath,
+				CoreConfigAddendumPath: configAddendumPath,
+				NetworkPassphrase:      networkPassphrase,
+				HistoryArchiveURLs:     historyArchiveURLs,
+				HTTPPort:               stellarCoreHTTPPort,
 			}
 
 			var dbConn *db.Session

--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -113,11 +113,11 @@ func main() {
 			logger.SetLevel(logLevel)
 
 			captiveConfig := ledgerbackend.CaptiveCoreConfig{
-				StellarCoreBinaryPath:  binaryPath,
-				CoreConfigAddendumPath: configAddendumPath,
-				NetworkPassphrase:      networkPassphrase,
-				HistoryArchiveURLs:     historyArchiveURLs,
-				HTTPPort:               stellarCoreHTTPPort,
+				BinaryPath:         binaryPath,
+				AddendumPath:       configAddendumPath,
+				NetworkPassphrase:  networkPassphrase,
+				HistoryArchiveURLs: historyArchiveURLs,
+				HTTPPort:           stellarCoreHTTPPort,
 			}
 
 			var dbConn *db.Session

--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -22,7 +22,7 @@ func main() {
 	var port int
 	var networkPassphrase, binaryPath, configAddendumPath, dbURL string
 	var historyArchiveURLs []string
-	var stellarCoreHTTPPort uint16
+	var stellarCoreHTTPPort uint
 	var logLevel logrus.Level
 	logger := supportlog.New()
 
@@ -98,8 +98,8 @@ func main() {
 		&config.ConfigOption{
 			Name:        "stellar-captive-core-http-port",
 			ConfigKey:   &stellarCoreHTTPPort,
-			OptType:     types.Uint16,
-			FlagDefault: uint16(11626),
+			OptType:     types.Uint,
+			FlagDefault: uint(11626),
 			Required:    false,
 			Usage:       "HTTP port for captive core to listen on (0 disables the HTTP server)",
 		},

--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -20,7 +20,7 @@ import (
 
 func main() {
 	var port int
-	var networkPassphrase, binaryPath, configAddendumPath, dbURL string
+	var networkPassphrase, binaryPath, configAppendPath, dbURL string
 	var historyArchiveURLs []string
 	var stellarCoreHTTPPort uint
 	var logLevel logrus.Level
@@ -52,12 +52,12 @@ func main() {
 			ConfigKey:   &binaryPath,
 		},
 		&config.ConfigOption{
-			Name:        "captive-core-addendum-path",
+			Name:        "captive-core-config-append-path",
 			OptType:     types.String,
 			FlagDefault: "",
 			Required:    false,
-			Usage:       "path to an addendum for the Stellar Core configuration file used by captive core. It must, at least, include enough details to define a quorum set",
-			ConfigKey:   &configAddendumPath,
+			Usage:       "path to additional configuration for the Stellar Core configuration file used by captive core. It must, at least, include enough details to define a quorum set",
+			ConfigKey:   &configAppendPath,
 		},
 		&config.ConfigOption{
 			Name:        "history-archive-urls",
@@ -114,7 +114,7 @@ func main() {
 
 			captiveConfig := ledgerbackend.CaptiveCoreConfig{
 				BinaryPath:         binaryPath,
-				AddendumPath:       configAddendumPath,
+				ConfigAppendPath:   configAppendPath,
 				NetworkPassphrase:  networkPassphrase,
 				HistoryArchiveURLs: historyArchiveURLs,
 				HTTPPort:           stellarCoreHTTPPort,

--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -101,7 +101,7 @@ func main() {
 			OptType:     types.Uint16,
 			FlagDefault: uint16(11626),
 			Required:    false,
-			Usage:       "HTTP port for captive core to listen on (0 disables the http server)",
+			Usage:       "HTTP port for captive core to listen on (0 disables the HTTP server)",
 		},
 	}
 	cmd := &cobra.Command{

--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -20,8 +20,9 @@ import (
 
 func main() {
 	var port int
-	var networkPassphrase, binaryPath, configPath, dbURL string
+	var networkPassphrase, binaryPath, quorumConfigPath, dbURL string
 	var historyArchiveURLs []string
+	var stellarCoreHTTPPort uint16
 	var logLevel logrus.Level
 	logger := supportlog.New()
 
@@ -51,12 +52,12 @@ func main() {
 			ConfigKey:   &binaryPath,
 		},
 		&config.ConfigOption{
-			Name:        "stellar-core-config-path",
+			Name:        "stellar-captive-core-quorum-path",
 			OptType:     types.String,
 			FlagDefault: "",
 			Required:    false,
-			Usage:       "path to stellar core config file",
-			ConfigKey:   &configPath,
+			Usage:       "path to stellar core quorum config file (i.e. a stellar core config file with [QUORUM_SET] entries)",
+			ConfigKey:   &quorumConfigPath,
 		},
 		&config.ConfigOption{
 			Name:        "history-archive-urls",
@@ -94,6 +95,14 @@ func main() {
 			Required:  false,
 			Usage:     "horizon postgres database to connect with",
 		},
+		&config.ConfigOption{
+			Name:        "stellar-captive-core-http-port",
+			ConfigKey:   &stellarCoreHTTPPort,
+			OptType:     types.Uint16,
+			FlagDefault: uint16(11626),
+			Required:    false,
+			Usage:       "HTTP port for captive core to listen on (0 disables the http server)",
+		},
 	}
 	cmd := &cobra.Command{
 		Use:   "captivecore",
@@ -105,9 +114,10 @@ func main() {
 
 			captiveConfig := ledgerbackend.CaptiveCoreConfig{
 				StellarCoreBinaryPath: binaryPath,
-				StellarCoreConfigPath: configPath,
+				QuorumConfigPath:      quorumConfigPath,
 				NetworkPassphrase:     networkPassphrase,
 				HistoryArchiveURLs:    historyArchiveURLs,
+				HTTPPort:              stellarCoreHTTPPort,
 			}
 
 			var dbConn *db.Session

--- a/exp/tools/captive-core-start-tester/main.go
+++ b/exp/tools/captive-core-start-tester/main.go
@@ -25,10 +25,10 @@ func main() {
 func check(ledger uint32) bool {
 	c, err := ledgerbackend.NewCaptive(
 		ledgerbackend.CaptiveCoreConfig{
-			StellarCoreBinaryPath:  "stellar-core",
-			CoreConfigAddendumPath: "stellar-core-standalone2.cfg",
-			NetworkPassphrase:      "Standalone Network ; February 2017",
-			HistoryArchiveURLs:     []string{"http://localhost:1570"},
+			BinaryPath:         "stellar-core",
+			AddendumPath:       "stellar-core-standalone2.cfg",
+			NetworkPassphrase:  "Standalone Network ; February 2017",
+			HistoryArchiveURLs: []string{"http://localhost:1570"},
 		},
 	)
 	if err != nil {

--- a/exp/tools/captive-core-start-tester/main.go
+++ b/exp/tools/captive-core-start-tester/main.go
@@ -26,7 +26,7 @@ func check(ledger uint32) bool {
 	c, err := ledgerbackend.NewCaptive(
 		ledgerbackend.CaptiveCoreConfig{
 			BinaryPath:         "stellar-core",
-			AddendumPath:       "stellar-core-standalone2.cfg",
+			ConfigAppendPath:   "stellar-core-standalone2.cfg",
 			NetworkPassphrase:  "Standalone Network ; February 2017",
 			HistoryArchiveURLs: []string{"http://localhost:1570"},
 		},

--- a/exp/tools/captive-core-start-tester/main.go
+++ b/exp/tools/captive-core-start-tester/main.go
@@ -25,10 +25,10 @@ func main() {
 func check(ledger uint32) bool {
 	c, err := ledgerbackend.NewCaptive(
 		ledgerbackend.CaptiveCoreConfig{
-			StellarCoreBinaryPath: "stellar-core",
-			QuorumConfigPath:      "stellar-core-standalone2.cfg",
-			NetworkPassphrase:     "Standalone Network ; February 2017",
-			HistoryArchiveURLs:    []string{"http://localhost:1570"},
+			StellarCoreBinaryPath:  "stellar-core",
+			CoreConfigAddendumPath: "stellar-core-standalone2.cfg",
+			NetworkPassphrase:      "Standalone Network ; February 2017",
+			HistoryArchiveURLs:     []string{"http://localhost:1570"},
 		},
 	)
 	if err != nil {

--- a/exp/tools/captive-core-start-tester/main.go
+++ b/exp/tools/captive-core-start-tester/main.go
@@ -26,7 +26,7 @@ func check(ledger uint32) bool {
 	c, err := ledgerbackend.NewCaptive(
 		ledgerbackend.CaptiveCoreConfig{
 			StellarCoreBinaryPath: "stellar-core",
-			StellarCoreConfigPath: "stellar-core-standalone2.cfg",
+			QuorumConfigPath:      "stellar-core-standalone2.cfg",
 			NetworkPassphrase:     "Standalone Network ; February 2017",
 			HistoryArchiveURLs:    []string{"http://localhost:1570"},
 		},

--- a/ingest/doc_test.go
+++ b/ingest/doc_test.go
@@ -105,7 +105,7 @@ func Example_changes() {
 	backend, err := ledgerbackend.NewCaptive(
 		ledgerbackend.CaptiveCoreConfig{
 			BinaryPath:         "/bin/stellar-core",
-			AddendumPath:       "/opt/stellar-core.cfg",
+			ConfigAppendPath:   "/opt/stellar-core.cfg",
 			NetworkPassphrase:  networkPassphrase,
 			HistoryArchiveURLs: []string{archiveURL},
 		},

--- a/ingest/doc_test.go
+++ b/ingest/doc_test.go
@@ -104,10 +104,10 @@ func Example_changes() {
 	// Requires Stellar-Core 13.2.0+
 	backend, err := ledgerbackend.NewCaptive(
 		ledgerbackend.CaptiveCoreConfig{
-			StellarCoreBinaryPath:  "/bin/stellar-core",
-			CoreConfigAddendumPath: "/opt/stellar-core.cfg",
-			NetworkPassphrase:      networkPassphrase,
-			HistoryArchiveURLs:     []string{archiveURL},
+			BinaryPath:         "/bin/stellar-core",
+			AddendumPath:       "/opt/stellar-core.cfg",
+			NetworkPassphrase:  networkPassphrase,
+			HistoryArchiveURLs: []string{archiveURL},
 		},
 	)
 	if err != nil {

--- a/ingest/doc_test.go
+++ b/ingest/doc_test.go
@@ -105,7 +105,7 @@ func Example_changes() {
 	backend, err := ledgerbackend.NewCaptive(
 		ledgerbackend.CaptiveCoreConfig{
 			StellarCoreBinaryPath: "/bin/stellar-core",
-			StellarCoreConfigPath: "/opt/stellar-core.cfg",
+			QuorumConfigPath:      "/opt/stellar-core.cfg",
 			NetworkPassphrase:     networkPassphrase,
 			HistoryArchiveURLs:    []string{archiveURL},
 		},

--- a/ingest/doc_test.go
+++ b/ingest/doc_test.go
@@ -104,10 +104,10 @@ func Example_changes() {
 	// Requires Stellar-Core 13.2.0+
 	backend, err := ledgerbackend.NewCaptive(
 		ledgerbackend.CaptiveCoreConfig{
-			StellarCoreBinaryPath: "/bin/stellar-core",
-			QuorumConfigPath:      "/opt/stellar-core.cfg",
-			NetworkPassphrase:     networkPassphrase,
-			HistoryArchiveURLs:    []string{archiveURL},
+			StellarCoreBinaryPath:  "/bin/stellar-core",
+			CoreConfigAddendumPath: "/opt/stellar-core.cfg",
+			NetworkPassphrase:      networkPassphrase,
+			HistoryArchiveURLs:     []string{archiveURL},
 		},
 	)
 	if err != nil {

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -76,7 +76,7 @@ type CaptiveStellarCore struct {
 	stellarCoreRunner stellarCoreRunnerInterface
 
 	// For testing
-	stellarCoreRunnerFactory func(captiveCoreAddendumPath string) (stellarCoreRunnerInterface, error)
+	stellarCoreRunnerFactory func(mode stellarCoreRunnerMode, captiveCoreAddendumPath string) (stellarCoreRunnerInterface, error)
 
 	// Defines if the blocking mode (off by default) is on or off. In blocking mode,
 	// calling GetLedger blocks until the requested ledger is available. This is useful
@@ -137,13 +137,14 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 		waitIntervalPrepareRange: time.Second,
 		ledgerHashStore:          config.LedgerHashStore,
 	}
-	c.stellarCoreRunnerFactory = func(addendumPath string) (stellarCoreRunnerInterface, error) {
+	c.stellarCoreRunnerFactory = func(mode stellarCoreRunnerMode, addendumPath string) (stellarCoreRunnerInterface, error) {
 		runner, innerErr := newStellarCoreRunner(
 			config.BinaryPath,
 			addendumPath,
 			config.NetworkPassphrase,
 			config.HTTPPort,
 			config.HistoryArchiveURLs,
+			mode,
 		)
 		if innerErr != nil {
 			return runner, innerErr
@@ -190,7 +191,7 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 
 	if c.stellarCoreRunner == nil {
 		// coreConfigAddendumPath is empty in an offline mode because it's generated
-		c.stellarCoreRunner, err = c.stellarCoreRunnerFactory("")
+		c.stellarCoreRunner, err = c.stellarCoreRunnerFactory(stellarCoreRunnerModeOffline, "")
 		if err != nil {
 			return errors.Wrap(err, "error creating stellar-core runner")
 		}
@@ -242,10 +243,7 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 	}
 
 	if c.stellarCoreRunner == nil {
-		if c.coreConfigAddendumPath == "" {
-			return errors.New("stellar-core addendum config file path cannot be empty in online mode")
-		}
-		c.stellarCoreRunner, err = c.stellarCoreRunnerFactory(c.coreConfigAddendumPath)
+		c.stellarCoreRunner, err = c.stellarCoreRunnerFactory(stellarCoreRunnerModeOnline, c.coreConfigAddendumPath)
 		if err != nil {
 			return errors.Wrap(err, "error creating stellar-core runner")
 		}

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -34,7 +34,7 @@ func roundDownToFirstReplayAfterCheckpointStart(ledger uint32) uint32 {
 //     keep ledger state in RAM. It requires around 3GB of RAM as of August 2020.
 //   * When a UnboundedRange is prepared it runs Stellar-Core catchup mode to
 //     sync with the first ledger and then runs it in a normal mode. This
-//     requires the coreConfigAddendumPath to be provided because a database connection is
+//     requires the configAppendPath to be provided because a database connection is
 //     required and quorum set needs to be selected.
 //
 // The database requirement for UnboundedRange will soon be removed when some
@@ -62,9 +62,9 @@ func roundDownToFirstReplayAfterCheckpointStart(ledger uint32) uint32 {
 //
 // Requires Stellar-Core v13.2.0+.
 type CaptiveStellarCore struct {
-	coreConfigAddendumPath string
-	archive                historyarchive.ArchiveInterface
-	ledgerHashStore        TrustedLedgerHashStore
+	configAppendPath string
+	archive          historyarchive.ArchiveInterface
+	ledgerHashStore  TrustedLedgerHashStore
 
 	// Quick note on how shutdown works:
 	// If Stellar-Core exits, the exit signal is "catched" by bufferedLedgerMetaReader
@@ -76,7 +76,7 @@ type CaptiveStellarCore struct {
 	stellarCoreRunner stellarCoreRunnerInterface
 
 	// For testing
-	stellarCoreRunnerFactory func(mode stellarCoreRunnerMode, captiveCoreAddendumPath string) (stellarCoreRunnerInterface, error)
+	stellarCoreRunnerFactory func(mode stellarCoreRunnerMode, captiveCoreConfigAppendPath string) (stellarCoreRunnerInterface, error)
 
 	// Defines if the blocking mode (off by default) is on or off. In blocking mode,
 	// calling GetLedger blocks until the requested ledger is available. This is useful
@@ -104,8 +104,8 @@ type CaptiveStellarCore struct {
 type CaptiveCoreConfig struct {
 	// BinaryPath is the file path to the Stellar Core binary
 	BinaryPath string
-	// AddendumPath is the file path to an addendum for the Stellar Core configuration file used by captive core
-	AddendumPath string
+	// ConfigAppendPath is the file path to additional configuration for the Stellar Core configuration file used by captive core
+	ConfigAppendPath string
 	// NetworkPassphrase is the Stellar network passphrase used by captive core when connecting to the Stellar network
 	NetworkPassphrase string
 	// HistoryArchiveURLs are a list of history archive urls
@@ -118,7 +118,7 @@ type CaptiveCoreConfig struct {
 
 // NewCaptive returns a new CaptiveStellarCore.
 //
-// All parameters are required, except coreConfigAddendumPath which is not required when
+// All parameters are required, except configAppendPath which is not required when
 // working with BoundedRanges only.
 func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	archive, err := historyarchive.Connect(
@@ -133,14 +133,14 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 
 	c := &CaptiveStellarCore{
 		archive:                  archive,
-		coreConfigAddendumPath:   config.AddendumPath,
+		configAppendPath:         config.ConfigAppendPath,
 		waitIntervalPrepareRange: time.Second,
 		ledgerHashStore:          config.LedgerHashStore,
 	}
-	c.stellarCoreRunnerFactory = func(mode stellarCoreRunnerMode, addendumPath string) (stellarCoreRunnerInterface, error) {
+	c.stellarCoreRunnerFactory = func(mode stellarCoreRunnerMode, appendConfigPath string) (stellarCoreRunnerInterface, error) {
 		runner, innerErr := newStellarCoreRunner(
 			config.BinaryPath,
-			addendumPath,
+			appendConfigPath,
 			config.NetworkPassphrase,
 			config.HTTPPort,
 			config.HistoryArchiveURLs,
@@ -190,7 +190,7 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 	}
 
 	if c.stellarCoreRunner == nil {
-		// coreConfigAddendumPath is empty in an offline mode because it's generated
+		// configAppendPath is empty in an offline mode because it's generated
 		c.stellarCoreRunner, err = c.stellarCoreRunnerFactory(stellarCoreRunnerModeOffline, "")
 		if err != nil {
 			return errors.Wrap(err, "error creating stellar-core runner")
@@ -243,7 +243,7 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 	}
 
 	if c.stellarCoreRunner == nil {
-		c.stellarCoreRunner, err = c.stellarCoreRunnerFactory(stellarCoreRunnerModeOnline, c.coreConfigAddendumPath)
+		c.stellarCoreRunner, err = c.stellarCoreRunnerFactory(stellarCoreRunnerModeOnline, c.configAppendPath)
 		if err != nil {
 			return errors.Wrap(err, "error creating stellar-core runner")
 		}

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -113,7 +113,7 @@ type CaptiveCoreConfig struct {
 	// LedgerHashStore is an optional store used to obtain hashes for ledger sequences from a trusted source
 	LedgerHashStore TrustedLedgerHashStore
 	// HTTPPort is the TCP port to listen for requests (defaults to 0, which disables the HTTP server)
-	HTTPPort uint16
+	HTTPPort uint
 }
 
 // NewCaptive returns a new CaptiveStellarCore.

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -34,7 +34,7 @@ func roundDownToFirstReplayAfterCheckpointStart(ledger uint32) uint32 {
 //     keep ledger state in RAM. It requires around 3GB of RAM as of August 2020.
 //   * When a UnboundedRange is prepared it runs Stellar-Core catchup mode to
 //     sync with the first ledger and then runs it in a normal mode. This
-//     requires the quorumConfigPath to be provided because a database connection is
+//     requires the coreConfigAddendumPath to be provided because a database connection is
 //     required and quorum set needs to be selected.
 //
 // The database requirement for UnboundedRange will soon be removed when some
@@ -62,9 +62,9 @@ func roundDownToFirstReplayAfterCheckpointStart(ledger uint32) uint32 {
 //
 // Requires Stellar-Core v13.2.0+.
 type CaptiveStellarCore struct {
-	quorumConfigPath string
-	archive          historyarchive.ArchiveInterface
-	ledgerHashStore  TrustedLedgerHashStore
+	coreConfigAddendumPath string
+	archive                historyarchive.ArchiveInterface
+	ledgerHashStore        TrustedLedgerHashStore
 
 	// Quick note on how shutdown works:
 	// If Stellar-Core exits, the exit signal is "catched" by bufferedLedgerMetaReader
@@ -104,8 +104,8 @@ type CaptiveStellarCore struct {
 type CaptiveCoreConfig struct {
 	// StellarCoreBinaryPath is the file path to the Stellar Core binary
 	StellarCoreBinaryPath string
-	// QuorumConfigPath is the file path to the Stellar Core configuration file used by captive core
-	QuorumConfigPath string
+	// CoreConfigAddendumPath is the file path to an addendum for the Stellar Core configuration file used by captive core
+	CoreConfigAddendumPath string
 	// NetworkPassphrase is the Stellar network passphrase used by captive core when connecting to the Stellar network
 	NetworkPassphrase string
 	// HistoryArchiveURLs are a list of history archive urls
@@ -118,7 +118,7 @@ type CaptiveCoreConfig struct {
 
 // NewCaptive returns a new CaptiveStellarCore.
 //
-// All parameters are required, except quorumConfigPath which is not required when
+// All parameters are required, except coreConfigAddendumPath which is not required when
 // working with BoundedRanges only.
 func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	archive, err := historyarchive.Connect(
@@ -133,14 +133,14 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 
 	c := &CaptiveStellarCore{
 		archive:                  archive,
-		quorumConfigPath:         config.QuorumConfigPath,
+		coreConfigAddendumPath:   config.CoreConfigAddendumPath,
 		waitIntervalPrepareRange: time.Second,
 		ledgerHashStore:          config.LedgerHashStore,
 	}
-	c.stellarCoreRunnerFactory = func(configPath2 string) (stellarCoreRunnerInterface, error) {
+	c.stellarCoreRunnerFactory = func(coreConfigAddendumPath string) (stellarCoreRunnerInterface, error) {
 		runner, innerErr := newStellarCoreRunner(
 			config.StellarCoreBinaryPath,
-			configPath2,
+			coreConfigAddendumPath,
 			config.NetworkPassphrase,
 			config.HTTPPort,
 			config.HistoryArchiveURLs,
@@ -189,7 +189,7 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 	}
 
 	if c.stellarCoreRunner == nil {
-		// quorumConfigPath is empty in an offline mode because it's generated
+		// coreConfigAddendumPath is empty in an offline mode because it's generated
 		c.stellarCoreRunner, err = c.stellarCoreRunnerFactory("")
 		if err != nil {
 			return errors.Wrap(err, "error creating stellar-core runner")
@@ -242,10 +242,10 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 	}
 
 	if c.stellarCoreRunner == nil {
-		if c.quorumConfigPath == "" {
-			return errors.New("stellar-core quorum config file path cannot be empty in online mode")
+		if c.coreConfigAddendumPath == "" {
+			return errors.New("stellar-core addendum config file path cannot be empty in online mode")
 		}
-		c.stellarCoreRunner, err = c.stellarCoreRunnerFactory(c.quorumConfigPath)
+		c.stellarCoreRunner, err = c.stellarCoreRunnerFactory(c.coreConfigAddendumPath)
 		if err != nil {
 			return errors.Wrap(err, "error creating stellar-core runner")
 		}

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -76,7 +76,7 @@ type CaptiveStellarCore struct {
 	stellarCoreRunner stellarCoreRunnerInterface
 
 	// For testing
-	stellarCoreRunnerFactory func(quorumConfigPath string) (stellarCoreRunnerInterface, error)
+	stellarCoreRunnerFactory func(captiveCoreAddendumPath string) (stellarCoreRunnerInterface, error)
 
 	// Defines if the blocking mode (off by default) is on or off. In blocking mode,
 	// calling GetLedger blocks until the requested ledger is available. This is useful
@@ -102,10 +102,10 @@ type CaptiveStellarCore struct {
 
 // CaptiveCoreConfig contains all the parameters required to create a CaptiveStellarCore instance
 type CaptiveCoreConfig struct {
-	// StellarCoreBinaryPath is the file path to the Stellar Core binary
-	StellarCoreBinaryPath string
-	// CoreConfigAddendumPath is the file path to an addendum for the Stellar Core configuration file used by captive core
-	CoreConfigAddendumPath string
+	// BinaryPath is the file path to the Stellar Core binary
+	BinaryPath string
+	// AddendumPath is the file path to an addendum for the Stellar Core configuration file used by captive core
+	AddendumPath string
 	// NetworkPassphrase is the Stellar network passphrase used by captive core when connecting to the Stellar network
 	NetworkPassphrase string
 	// HistoryArchiveURLs are a list of history archive urls
@@ -133,14 +133,14 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 
 	c := &CaptiveStellarCore{
 		archive:                  archive,
-		coreConfigAddendumPath:   config.CoreConfigAddendumPath,
+		coreConfigAddendumPath:   config.AddendumPath,
 		waitIntervalPrepareRange: time.Second,
 		ledgerHashStore:          config.LedgerHashStore,
 	}
-	c.stellarCoreRunnerFactory = func(coreConfigAddendumPath string) (stellarCoreRunnerInterface, error) {
+	c.stellarCoreRunnerFactory = func(addendumPath string) (stellarCoreRunnerInterface, error) {
 		runner, innerErr := newStellarCoreRunner(
-			config.StellarCoreBinaryPath,
-			coreConfigAddendumPath,
+			config.BinaryPath,
+			addendumPath,
 			config.NetworkPassphrase,
 			config.HTTPPort,
 			config.HistoryArchiveURLs,

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -34,7 +34,7 @@ func roundDownToFirstReplayAfterCheckpointStart(ledger uint32) uint32 {
 //     keep ledger state in RAM. It requires around 3GB of RAM as of August 2020.
 //   * When a UnboundedRange is prepared it runs Stellar-Core catchup mode to
 //     sync with the first ledger and then runs it in a normal mode. This
-//     requires the configPath to be provided because a database connection is
+//     requires the quorumConfigPath to be provided because a database connection is
 //     required and quorum set needs to be selected.
 //
 // The database requirement for UnboundedRange will soon be removed when some
@@ -62,12 +62,9 @@ func roundDownToFirstReplayAfterCheckpointStart(ledger uint32) uint32 {
 //
 // Requires Stellar-Core v13.2.0+.
 type CaptiveStellarCore struct {
-	executablePath    string
-	configPath        string
-	networkPassphrase string
-	historyURLs       []string
-	archive           historyarchive.ArchiveInterface
-	ledgerHashStore   TrustedLedgerHashStore
+	quorumConfigPath string
+	archive          historyarchive.ArchiveInterface
+	ledgerHashStore  TrustedLedgerHashStore
 
 	// Quick note on how shutdown works:
 	// If Stellar-Core exits, the exit signal is "catched" by bufferedLedgerMetaReader
@@ -79,7 +76,7 @@ type CaptiveStellarCore struct {
 	stellarCoreRunner stellarCoreRunnerInterface
 
 	// For testing
-	stellarCoreRunnerFactory func(configPath string) (stellarCoreRunnerInterface, error)
+	stellarCoreRunnerFactory func(quorumConfigPath string) (stellarCoreRunnerInterface, error)
 
 	// Defines if the blocking mode (off by default) is on or off. In blocking mode,
 	// calling GetLedger blocks until the requested ledger is available. This is useful
@@ -107,19 +104,21 @@ type CaptiveStellarCore struct {
 type CaptiveCoreConfig struct {
 	// StellarCoreBinaryPath is the file path to the Stellar Core binary
 	StellarCoreBinaryPath string
-	// StellarCoreConfigPath is the file path to the Stellar Core configuration file used by captive core
-	StellarCoreConfigPath string
+	// QuorumConfigPath is the file path to the Stellar Core configuration file used by captive core
+	QuorumConfigPath string
 	// NetworkPassphrase is the Stellar network passphrase used by captive core when connecting to the Stellar network
 	NetworkPassphrase string
 	// HistoryArchiveURLs are a list of history archive urls
 	HistoryArchiveURLs []string
 	// LedgerHashStore is an optional store used to obtain hashes for ledger sequences from a trusted source
 	LedgerHashStore TrustedLedgerHashStore
+	// HTTPPort is the TCP port to listen for requests (defaults to 0, which disables the HTTP server)
+	HTTPPort uint16
 }
 
 // NewCaptive returns a new CaptiveStellarCore.
 //
-// All parameters are required, except configPath which is not required when
+// All parameters are required, except quorumConfigPath which is not required when
 // working with BoundedRanges only.
 func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	archive, err := historyarchive.Connect(
@@ -134,10 +133,7 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 
 	c := &CaptiveStellarCore{
 		archive:                  archive,
-		executablePath:           config.StellarCoreBinaryPath,
-		configPath:               config.StellarCoreConfigPath,
-		historyURLs:              config.HistoryArchiveURLs,
-		networkPassphrase:        config.NetworkPassphrase,
+		quorumConfigPath:         config.QuorumConfigPath,
 		waitIntervalPrepareRange: time.Second,
 		ledgerHashStore:          config.LedgerHashStore,
 	}
@@ -146,6 +142,7 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 			config.StellarCoreBinaryPath,
 			configPath2,
 			config.NetworkPassphrase,
+			config.HTTPPort,
 			config.HistoryArchiveURLs,
 		)
 		if innerErr != nil {
@@ -192,7 +189,7 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 	}
 
 	if c.stellarCoreRunner == nil {
-		// configPath is empty in an offline mode because it's generated
+		// quorumConfigPath is empty in an offline mode because it's generated
 		c.stellarCoreRunner, err = c.stellarCoreRunnerFactory("")
 		if err != nil {
 			return errors.Wrap(err, "error creating stellar-core runner")
@@ -245,10 +242,10 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 	}
 
 	if c.stellarCoreRunner == nil {
-		if c.configPath == "" {
-			return errors.New("stellar-core config file path cannot be empty in an online mode")
+		if c.quorumConfigPath == "" {
+			return errors.New("stellar-core quorum config file path cannot be empty in online mode")
 		}
-		c.stellarCoreRunner, err = c.stellarCoreRunnerFactory(c.configPath)
+		c.stellarCoreRunner, err = c.stellarCoreRunnerFactory(c.quorumConfigPath)
 		if err != nil {
 			return errors.Wrap(err, "error creating stellar-core runner")
 		}

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -149,14 +149,14 @@ func TestCaptiveNew(t *testing.T) {
 	captiveStellarCore, err := NewCaptive(
 		CaptiveCoreConfig{
 			BinaryPath:         executablePath,
-			AddendumPath:       configPath,
+			ConfigAppendPath:   configPath,
 			NetworkPassphrase:  networkPassphrase,
 			HistoryArchiveURLs: historyURLs,
 		},
 	)
 
 	assert.NoError(t, err)
-	assert.Equal(t, configPath, captiveStellarCore.coreConfigAddendumPath)
+	assert.Equal(t, configPath, captiveStellarCore.configAppendPath)
 	assert.Equal(t, uint32(0), captiveStellarCore.nextLedger)
 	assert.NotNil(t, captiveStellarCore.archive)
 }
@@ -426,8 +426,8 @@ func TestCaptivePrepareRangeUnboundedRange_ErrRunFrom(t *testing.T) {
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:                mockArchive,
-		coreConfigAddendumPath: "foo",
+		archive:          mockArchive,
+		configAppendPath: "foo",
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -487,8 +487,8 @@ func TestCaptivePrepareRangeUnboundedRange_ReuseSession(t *testing.T) {
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:                mockArchive,
-		coreConfigAddendumPath: "foo",
+		archive:          mockArchive,
+		configAppendPath: "foo",
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -529,8 +529,8 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:                mockArchive,
-		coreConfigAddendumPath: "foo",
+		archive:          mockArchive,
+		configAppendPath: "foo",
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -808,8 +808,8 @@ func TestCaptiveGetLedger_CloseBufferFull(t *testing.T) {
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:                mockArchive,
-		coreConfigAddendumPath: "foo",
+		archive:          mockArchive,
+		configAppendPath: "foo",
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -1164,8 +1164,8 @@ func TestCaptivePreviousLedgerCheck(t *testing.T) {
 	defer mockLedgerHashStore.AssertExpectations(t)
 
 	captiveBackend := CaptiveStellarCore{
-		coreConfigAddendumPath: "stellar-core.cfg",
-		archive:                mockArchive,
+		configAppendPath: "stellar-core.cfg",
+		archive:          mockArchive,
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -148,15 +148,15 @@ func TestCaptiveNew(t *testing.T) {
 
 	captiveStellarCore, err := NewCaptive(
 		CaptiveCoreConfig{
-			StellarCoreBinaryPath: executablePath,
-			QuorumConfigPath:      configPath,
-			NetworkPassphrase:     networkPassphrase,
-			HistoryArchiveURLs:    historyURLs,
+			StellarCoreBinaryPath:  executablePath,
+			CoreConfigAddendumPath: configPath,
+			NetworkPassphrase:      networkPassphrase,
+			HistoryArchiveURLs:     historyURLs,
 		},
 	)
 
 	assert.NoError(t, err)
-	assert.Equal(t, configPath, captiveStellarCore.quorumConfigPath)
+	assert.Equal(t, configPath, captiveStellarCore.coreConfigAddendumPath)
 	assert.Equal(t, uint32(0), captiveStellarCore.nextLedger)
 	assert.NotNil(t, captiveStellarCore.archive)
 }
@@ -426,8 +426,8 @@ func TestCaptivePrepareRangeUnboundedRange_ErrRunFrom(t *testing.T) {
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:          mockArchive,
-		quorumConfigPath: "foo",
+		archive:                mockArchive,
+		coreConfigAddendumPath: "foo",
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -487,8 +487,8 @@ func TestCaptivePrepareRangeUnboundedRange_ReuseSession(t *testing.T) {
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:          mockArchive,
-		quorumConfigPath: "foo",
+		archive:                mockArchive,
+		coreConfigAddendumPath: "foo",
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -529,8 +529,8 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:          mockArchive,
-		quorumConfigPath: "foo",
+		archive:                mockArchive,
+		coreConfigAddendumPath: "foo",
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -808,8 +808,8 @@ func TestCaptiveGetLedger_CloseBufferFull(t *testing.T) {
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:          mockArchive,
-		quorumConfigPath: "foo",
+		archive:                mockArchive,
+		coreConfigAddendumPath: "foo",
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -1164,8 +1164,8 @@ func TestCaptivePreviousLedgerCheck(t *testing.T) {
 	defer mockLedgerHashStore.AssertExpectations(t)
 
 	captiveBackend := CaptiveStellarCore{
-		quorumConfigPath: "stellar-core.cfg",
-		archive:          mockArchive,
+		coreConfigAddendumPath: "stellar-core.cfg",
+		archive:                mockArchive,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -148,10 +148,10 @@ func TestCaptiveNew(t *testing.T) {
 
 	captiveStellarCore, err := NewCaptive(
 		CaptiveCoreConfig{
-			StellarCoreBinaryPath:  executablePath,
-			CoreConfigAddendumPath: configPath,
-			NetworkPassphrase:      networkPassphrase,
-			HistoryArchiveURLs:     historyURLs,
+			BinaryPath:         executablePath,
+			AddendumPath:       configPath,
+			NetworkPassphrase:  networkPassphrase,
+			HistoryArchiveURLs: historyURLs,
 		},
 	)
 

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -149,17 +149,14 @@ func TestCaptiveNew(t *testing.T) {
 	captiveStellarCore, err := NewCaptive(
 		CaptiveCoreConfig{
 			StellarCoreBinaryPath: executablePath,
-			StellarCoreConfigPath: configPath,
+			QuorumConfigPath:      configPath,
 			NetworkPassphrase:     networkPassphrase,
 			HistoryArchiveURLs:    historyURLs,
 		},
 	)
 
 	assert.NoError(t, err)
-	assert.Equal(t, executablePath, captiveStellarCore.executablePath)
-	assert.Equal(t, configPath, captiveStellarCore.configPath)
-	assert.Equal(t, networkPassphrase, captiveStellarCore.networkPassphrase)
-	assert.Equal(t, historyURLs, captiveStellarCore.historyURLs)
+	assert.Equal(t, configPath, captiveStellarCore.quorumConfigPath)
 	assert.Equal(t, uint32(0), captiveStellarCore.nextLedger)
 	assert.NotNil(t, captiveStellarCore.archive)
 }
@@ -189,8 +186,7 @@ func TestCaptivePrepareRange(t *testing.T) {
 		}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -224,8 +220,7 @@ func TestCaptivePrepareRangeCrash(t *testing.T) {
 		}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -256,8 +251,7 @@ func TestCaptivePrepareRangeTerminated(t *testing.T) {
 		}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -272,7 +266,6 @@ func TestCaptivePrepareRange_ErrClosingSession(t *testing.T) {
 	mockRunner.On("close").Return(fmt.Errorf("transient error"))
 
 	captiveBackend := CaptiveStellarCore{
-		networkPassphrase: network.PublicNetworkPassphrase,
 		nextLedger:        300,
 		stellarCoreRunner: mockRunner,
 	}
@@ -294,8 +287,7 @@ func TestCaptivePrepareRange_ErrGettingRootHAS(t *testing.T) {
 		Return(historyarchive.HistoryArchiveState{}, errors.New("transient error"))
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive: mockArchive,
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
@@ -317,8 +309,7 @@ func TestCaptivePrepareRange_FromIsAheadOfRootHAS(t *testing.T) {
 		}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive: mockArchive,
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
@@ -341,8 +332,7 @@ func TestCaptivePrepareRange_ToIsAheadOfRootHAS(t *testing.T) {
 		}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -365,8 +355,7 @@ func TestCaptivePrepareRange_ErrCatchup(t *testing.T) {
 		}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -394,8 +383,7 @@ func TestCaptivePrepareRangeUnboundedRange_ErrGettingRootHAS(t *testing.T) {
 		Return(historyarchive.HistoryArchiveState{}, errors.New("transient error"))
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive: mockArchive,
 	}
 
 	err := captiveBackend.PrepareRange(UnboundedRange(100))
@@ -414,8 +402,7 @@ func TestCaptivePrepareRangeUnboundedRange_FromIsTooFarAheadOfLatestHAS(t *testi
 		}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive: mockArchive,
 	}
 
 	err := captiveBackend.PrepareRange(UnboundedRange(193))
@@ -439,9 +426,8 @@ func TestCaptivePrepareRangeUnboundedRange_ErrRunFrom(t *testing.T) {
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
-		configPath:        "foo",
+		archive:          mockArchive,
+		quorumConfigPath: "foo",
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -468,7 +454,6 @@ func TestCaptivePrepareRangeUnboundedRange_ErrClosingExistingSession(t *testing.
 
 	last := uint32(63)
 	captiveBackend := CaptiveStellarCore{
-		networkPassphrase: network.PublicNetworkPassphrase,
 		nextLedger:        63,
 		lastLedger:        &last,
 		stellarCoreRunner: mockRunner,
@@ -502,9 +487,8 @@ func TestCaptivePrepareRangeUnboundedRange_ReuseSession(t *testing.T) {
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
-		configPath:        "foo",
+		archive:          mockArchive,
+		quorumConfigPath: "foo",
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -545,9 +529,8 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
-		configPath:        "foo",
+		archive:          mockArchive,
+		quorumConfigPath: "foo",
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -603,8 +586,7 @@ func TestCaptiveGetLedger(t *testing.T) {
 		}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -668,8 +650,7 @@ func TestCaptiveGetLedger_NextLedgerIsDifferentToLedgerFromBuffer(t *testing.T) 
 		}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -699,8 +680,7 @@ func TestCaptiveGetLedger_ErrReadingMetaResult(t *testing.T) {
 		}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -737,8 +717,7 @@ func TestCaptiveGetLedger_ErrClosingAfterLastLedger(t *testing.T) {
 		}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -778,8 +757,7 @@ func TestCaptiveGetLedger_BoundedGetLedgerAfterCoreExit(t *testing.T) {
 		}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -830,9 +808,8 @@ func TestCaptiveGetLedger_CloseBufferFull(t *testing.T) {
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		configPath:        "foo",
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive:          mockArchive,
+		quorumConfigPath: "foo",
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -888,8 +865,7 @@ func TestGetLedgerBoundsCheck(t *testing.T) {
 		}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -959,8 +935,7 @@ func TestCaptiveGetLedgerTerminated(t *testing.T) {
 		}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -1006,7 +981,6 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
 		stellarCoreRunner: mockRunner,
 		ledgerHashStore:   mockLedgerHashStore,
 	}
@@ -1084,7 +1058,6 @@ func TestCaptiveRunFromParams(t *testing.T) {
 
 			captiveBackend := CaptiveStellarCore{
 				archive:           mockArchive,
-				networkPassphrase: network.PublicNetworkPassphrase,
 				stellarCoreRunner: mockRunner,
 			}
 
@@ -1191,9 +1164,8 @@ func TestCaptivePreviousLedgerCheck(t *testing.T) {
 	defer mockLedgerHashStore.AssertExpectations(t)
 
 	captiveBackend := CaptiveStellarCore{
-		configPath:        "stellar-core.cfg",
-		archive:           mockArchive,
-		networkPassphrase: network.PublicNetworkPassphrase,
+		quorumConfigPath: "stellar-core.cfg",
+		archive:          mockArchive,
 		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -187,7 +187,7 @@ func TestCaptivePrepareRange(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -221,7 +221,7 @@ func TestCaptivePrepareRangeCrash(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -252,7 +252,7 @@ func TestCaptivePrepareRangeTerminated(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -333,7 +333,7 @@ func TestCaptivePrepareRange_ToIsAheadOfRootHAS(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -356,7 +356,7 @@ func TestCaptivePrepareRange_ErrCatchup(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -428,7 +428,7 @@ func TestCaptivePrepareRangeUnboundedRange_ErrRunFrom(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:                mockArchive,
 		coreConfigAddendumPath: "foo",
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -489,7 +489,7 @@ func TestCaptivePrepareRangeUnboundedRange_ReuseSession(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:                mockArchive,
 		coreConfigAddendumPath: "foo",
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -531,7 +531,7 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:                mockArchive,
 		coreConfigAddendumPath: "foo",
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -587,7 +587,7 @@ func TestCaptiveGetLedger(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -651,7 +651,7 @@ func TestCaptiveGetLedger_NextLedgerIsDifferentToLedgerFromBuffer(t *testing.T) 
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -681,7 +681,7 @@ func TestCaptiveGetLedger_ErrReadingMetaResult(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -718,7 +718,7 @@ func TestCaptiveGetLedger_ErrClosingAfterLastLedger(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -758,7 +758,7 @@ func TestCaptiveGetLedger_BoundedGetLedgerAfterCoreExit(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -810,7 +810,7 @@ func TestCaptiveGetLedger_CloseBufferFull(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:                mockArchive,
 		coreConfigAddendumPath: "foo",
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -866,7 +866,7 @@ func TestGetLedgerBoundsCheck(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -936,7 +936,7 @@ func TestCaptiveGetLedgerTerminated(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -1166,7 +1166,7 @@ func TestCaptivePreviousLedgerCheck(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		coreConfigAddendumPath: "stellar-core.cfg",
 		archive:                mockArchive,
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 		ledgerHashStore: mockLedgerHashStore,

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -31,12 +31,20 @@ type stellarCoreRunnerInterface interface {
 	close() error
 }
 
+type stellarCoreRunnerMode int
+
+const (
+	stellarCoreRunnerModeOnline stellarCoreRunnerMode = iota
+	stellarCoreRunnerModeOffline
+)
+
 type stellarCoreRunner struct {
 	executablePath         string
 	coreConfigAddendumPath string
 	networkPassphrase      string
 	historyURLs            []string
 	httpPort               uint
+	mode                   stellarCoreRunnerMode
 
 	started  bool
 	wg       sync.WaitGroup
@@ -56,7 +64,7 @@ type stellarCoreRunner struct {
 	Log *log.Entry
 }
 
-func newStellarCoreRunner(executablePath, coreConfigAddendumPath, networkPassphrase string, httpPort uint, historyURLs []string) (*stellarCoreRunner, error) {
+func newStellarCoreRunner(executablePath, coreConfigAddendumPath, networkPassphrase string, httpPort uint, historyURLs []string, mode stellarCoreRunnerMode) (*stellarCoreRunner, error) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	// Create temp dir
@@ -73,6 +81,7 @@ func newStellarCoreRunner(executablePath, coreConfigAddendumPath, networkPassphr
 		networkPassphrase:      networkPassphrase,
 		historyURLs:            historyURLs,
 		httpPort:               httpPort,
+		mode:                   mode,
 		shutdown:               make(chan struct{}),
 		processExit:            make(chan struct{}),
 		processExitError:       nil,
@@ -88,6 +97,9 @@ func newStellarCoreRunner(executablePath, coreConfigAddendumPath, networkPassphr
 }
 
 func (r *stellarCoreRunner) generateConfig() (string, error) {
+	if r.mode == stellarCoreRunnerModeOnline && r.coreConfigAddendumPath == "" {
+		return "", errors.New("stellar-core addendum config file path cannot be empty in online mode")
+	}
 	lines := []string{
 		"# Generated file -- do not edit",
 		"RUN_STANDALONE=true",
@@ -103,7 +115,6 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 		lines = append(lines, fmt.Sprintf(`get="curl -sf %s/{0} -o {1}"`, val))
 	}
 	if r.coreConfigAddendumPath == "" {
-
 		// Add a fictional quorum -- necessary to convince core to start up;
 		// but not used at all for our purposes. Pubkey here is just random.
 		lines = append(lines,

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -32,9 +32,10 @@ type stellarCoreRunnerInterface interface {
 
 type stellarCoreRunner struct {
 	executablePath    string
-	configPath        string
+	quorumConfigPath  string
 	networkPassphrase string
 	historyURLs       []string
+	httpPort          uint16
 
 	started  bool
 	wg       sync.WaitGroup
@@ -54,7 +55,7 @@ type stellarCoreRunner struct {
 	Log *log.Entry
 }
 
-func newStellarCoreRunner(executablePath, configPath, networkPassphrase string, historyURLs []string) (*stellarCoreRunner, error) {
+func newStellarCoreRunner(executablePath, quorumConfigPath, networkPassphrase string, httpPort uint16, historyURLs []string) (*stellarCoreRunner, error) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	// Create temp dir
@@ -67,9 +68,10 @@ func newStellarCoreRunner(executablePath, configPath, networkPassphrase string, 
 
 	runner := &stellarCoreRunner{
 		executablePath:    executablePath,
-		configPath:        configPath,
+		quorumConfigPath:  quorumConfigPath,
 		networkPassphrase: networkPassphrase,
 		historyURLs:       historyURLs,
+		httpPort:          httpPort,
 		shutdown:          make(chan struct{}),
 		processExit:       make(chan struct{}),
 		processExitError:  nil,
@@ -77,17 +79,14 @@ func newStellarCoreRunner(executablePath, configPath, networkPassphrase string, 
 		nonce:             fmt.Sprintf("captive-stellar-core-%x", r.Uint64()),
 	}
 
-	if configPath == "" {
-		err := runner.writeConf()
-		if err != nil {
-			return nil, errors.Wrap(err, "error writing configuration")
-		}
+	if err := runner.writeConf(); err != nil {
+		return nil, errors.Wrap(err, "error writing configuration")
 	}
 
 	return runner, nil
 }
 
-func (r *stellarCoreRunner) generateConfig() string {
+func (r *stellarCoreRunner) generateConfig() (string, error) {
 	lines := []string{
 		"# Generated file -- do not edit",
 		"RUN_STANDALONE=true",
@@ -96,24 +95,34 @@ func (r *stellarCoreRunner) generateConfig() string {
 		"UNSAFE_QUORUM=true",
 		fmt.Sprintf(`NETWORK_PASSPHRASE="%s"`, r.networkPassphrase),
 		fmt.Sprintf(`BUCKET_DIR_PATH="%s"`, filepath.Join(r.tempDir, "buckets")),
+		fmt.Sprintf(`HTTP_PORT="%d"`, r.httpPort),
 	}
 	for i, val := range r.historyURLs {
 		lines = append(lines, fmt.Sprintf("[HISTORY.h%d]", i))
 		lines = append(lines, fmt.Sprintf(`get="curl -sf %s/{0} -o {1}"`, val))
 	}
-	// Add a fictional quorum -- necessary to convince core to start up;
-	// but not used at all for our purposes. Pubkey here is just random.
-	lines = append(lines,
-		"[QUORUM_SET]",
-		"THRESHOLD_PERCENT=100",
-		`VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]`)
-	return strings.ReplaceAll(strings.Join(lines, "\n"), "\\", "\\\\")
+	if r.quorumConfigPath == "" {
+
+		// Add a fictional quorum -- necessary to convince core to start up;
+		// but not used at all for our purposes. Pubkey here is just random.
+		lines = append(lines,
+			"[QUORUM_SET]",
+			"THRESHOLD_PERCENT=100",
+			`VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]`)
+	}
+	result := strings.ReplaceAll(strings.Join(lines, "\n"), "\\", "\\\\")
+	if r.quorumConfigPath != "" {
+		// TODO: parse toml file and ensure it is a correct quorum config file
+		quorumConfigContents, err := ioutil.ReadFile(r.quorumConfigPath)
+		if err != nil {
+			return "", errors.Wrap(err, "reading quorum config file")
+		}
+		result = result + "\n" + string(quorumConfigContents)
+	}
+	return result, nil
 }
 
 func (r *stellarCoreRunner) getConfFileName() string {
-	if r.configPath != "" {
-		return r.configPath
-	}
 	return filepath.Join(r.tempDir, "stellar-core.conf")
 }
 
@@ -173,7 +182,10 @@ func (r *stellarCoreRunner) getLogLineWriter() io.Writer {
 // Makes the temp directory and writes the config file to it; called by the
 // platform-specific captiveStellarCore.Start() methods.
 func (r *stellarCoreRunner) writeConf() error {
-	conf := r.generateConfig()
+	conf, err := r.generateConfig()
+	if err != nil {
+		return err
+	}
 	return ioutil.WriteFile(r.getConfFileName(), []byte(conf), 0644)
 }
 

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -36,7 +36,7 @@ type stellarCoreRunner struct {
 	coreConfigAddendumPath string
 	networkPassphrase      string
 	historyURLs            []string
-	httpPort               uint16
+	httpPort               uint
 
 	started  bool
 	wg       sync.WaitGroup
@@ -56,7 +56,7 @@ type stellarCoreRunner struct {
 	Log *log.Entry
 }
 
-func newStellarCoreRunner(executablePath, coreConfigAddendumPath, networkPassphrase string, httpPort uint16, historyURLs []string) (*stellarCoreRunner, error) {
+func newStellarCoreRunner(executablePath, coreConfigAddendumPath, networkPassphrase string, httpPort uint, historyURLs []string) (*stellarCoreRunner, error) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	// Create temp dir

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -102,7 +102,6 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 	}
 	lines := []string{
 		"# Generated file -- do not edit",
-		"RUN_STANDALONE=true",
 		"NODE_IS_VALIDATOR=false",
 		"DISABLE_XDR_FSYNC=true",
 		fmt.Sprintf(`NETWORK_PASSPHRASE="%s"`, r.networkPassphrase),
@@ -111,6 +110,8 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 	}
 
 	if r.mode == stellarCoreRunnerModeOffline {
+		// In offline mode, there is no need to connect to peers
+		lines = append(lines, "RUN_STANDALONE=true")
 		// We don't need consensus when catching up
 		lines = append(lines, "UNSAFE_QUORUM=true")
 	}

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -2,6 +2,7 @@ package ledgerbackend
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -14,7 +15,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/BurntSushi/toml"
 	"github.com/pkg/errors"
+
 	"github.com/stellar/go/support/log"
 )
 
@@ -117,6 +120,16 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 		if err != nil {
 			return "", errors.Wrap(err, "reading quorum config file")
 		}
+		var entries map[string]interface{}
+		if _, err := toml.DecodeReader(bytes.NewBuffer(quorumConfigContents), &entries); err != nil {
+			return "", errors.Wrap(err, "cannot parse quorum config file (make sure it only contains [QUORUM_SET] entries")
+		}
+		for k := range entries {
+			if k != "QUORUM_SET" {
+				return "", fmt.Errorf("incorrect quorum config file (%s entry found but only [QUORUM_SET] entries are accepted)", k)
+			}
+		}
+
 		result = result + "\n" + string(quorumConfigContents)
 	}
 	return result, nil

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -96,7 +96,7 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 		"UNSAFE_QUORUM=true",
 		fmt.Sprintf(`NETWORK_PASSPHRASE="%s"`, r.networkPassphrase),
 		fmt.Sprintf(`BUCKET_DIR_PATH="%s"`, filepath.Join(r.tempDir, "buckets")),
-		fmt.Sprintf(`HTTP_PORT="%d"`, r.httpPort),
+		fmt.Sprintf(`HTTP_PORT=%d`, r.httpPort),
 	}
 	for i, val := range r.historyURLs {
 		lines = append(lines, fmt.Sprintf("[HISTORY.h%d]", i))

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -39,12 +39,12 @@ const (
 )
 
 type stellarCoreRunner struct {
-	executablePath         string
-	coreConfigAddendumPath string
-	networkPassphrase      string
-	historyURLs            []string
-	httpPort               uint
-	mode                   stellarCoreRunnerMode
+	executablePath    string
+	configAppendPath  string
+	networkPassphrase string
+	historyURLs       []string
+	httpPort          uint
+	mode              stellarCoreRunnerMode
 
 	started  bool
 	wg       sync.WaitGroup
@@ -64,7 +64,7 @@ type stellarCoreRunner struct {
 	Log *log.Entry
 }
 
-func newStellarCoreRunner(executablePath, coreConfigAddendumPath, networkPassphrase string, httpPort uint, historyURLs []string, mode stellarCoreRunnerMode) (*stellarCoreRunner, error) {
+func newStellarCoreRunner(executablePath, coreConfigAppendPath, networkPassphrase string, httpPort uint, historyURLs []string, mode stellarCoreRunnerMode) (*stellarCoreRunner, error) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	// Create temp dir
@@ -76,17 +76,17 @@ func newStellarCoreRunner(executablePath, coreConfigAddendumPath, networkPassphr
 	}
 
 	runner := &stellarCoreRunner{
-		executablePath:         executablePath,
-		coreConfigAddendumPath: coreConfigAddendumPath,
-		networkPassphrase:      networkPassphrase,
-		historyURLs:            historyURLs,
-		httpPort:               httpPort,
-		mode:                   mode,
-		shutdown:               make(chan struct{}),
-		processExit:            make(chan struct{}),
-		processExitError:       nil,
-		tempDir:                tempDir,
-		nonce:                  fmt.Sprintf("captive-stellar-core-%x", r.Uint64()),
+		executablePath:    executablePath,
+		configAppendPath:  coreConfigAppendPath,
+		networkPassphrase: networkPassphrase,
+		historyURLs:       historyURLs,
+		httpPort:          httpPort,
+		mode:              mode,
+		shutdown:          make(chan struct{}),
+		processExit:       make(chan struct{}),
+		processExitError:  nil,
+		tempDir:           tempDir,
+		nonce:             fmt.Sprintf("captive-stellar-core-%x", r.Uint64()),
 	}
 
 	if err := runner.writeConf(); err != nil {
@@ -97,8 +97,8 @@ func newStellarCoreRunner(executablePath, coreConfigAddendumPath, networkPassphr
 }
 
 func (r *stellarCoreRunner) generateConfig() (string, error) {
-	if r.mode == stellarCoreRunnerModeOnline && r.coreConfigAddendumPath == "" {
-		return "", errors.New("stellar-core addendum config file path cannot be empty in online mode")
+	if r.mode == stellarCoreRunnerModeOnline && r.configAppendPath == "" {
+		return "", errors.New("stellar-core append config file path cannot be empty in online mode")
 	}
 	lines := []string{
 		"# Generated file -- do not edit",
@@ -118,7 +118,7 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 		lines = append(lines, fmt.Sprintf("[HISTORY.h%d]", i))
 		lines = append(lines, fmt.Sprintf(`get="curl -sf %s/{0} -o {1}"`, val))
 	}
-	if r.mode == stellarCoreRunnerModeOffline && r.coreConfigAddendumPath == "" {
+	if r.mode == stellarCoreRunnerModeOffline && r.configAppendPath == "" {
 		// Add a fictional quorum -- necessary to convince core to start up;
 		// but not used at all for our purposes. Pubkey here is just random.
 		lines = append(lines,
@@ -127,12 +127,12 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 			`VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]`)
 	}
 	result := strings.ReplaceAll(strings.Join(lines, "\n"), "\\", "\\\\")
-	if r.coreConfigAddendumPath != "" {
-		addendumContents, err := ioutil.ReadFile(r.coreConfigAddendumPath)
+	if r.configAppendPath != "" {
+		appendConfigContents, err := ioutil.ReadFile(r.configAppendPath)
 		if err != nil {
 			return "", errors.Wrap(err, "reading quorum config file")
 		}
-		result = result + "\n" + string(addendumContents)
+		result = result + "\n" + string(appendConfigContents)
 	}
 	return result, nil
 }

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -105,16 +105,20 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 		"RUN_STANDALONE=true",
 		"NODE_IS_VALIDATOR=false",
 		"DISABLE_XDR_FSYNC=true",
-		"UNSAFE_QUORUM=true",
 		fmt.Sprintf(`NETWORK_PASSPHRASE="%s"`, r.networkPassphrase),
 		fmt.Sprintf(`BUCKET_DIR_PATH="%s"`, filepath.Join(r.tempDir, "buckets")),
 		fmt.Sprintf(`HTTP_PORT=%d`, r.httpPort),
+	}
+
+	if r.mode == stellarCoreRunnerModeOffline {
+		// We don't need consensus when catching up
+		lines = append(lines, "UNSAFE_QUORUM=true")
 	}
 	for i, val := range r.historyURLs {
 		lines = append(lines, fmt.Sprintf("[HISTORY.h%d]", i))
 		lines = append(lines, fmt.Sprintf(`get="curl -sf %s/{0} -o {1}"`, val))
 	}
-	if r.coreConfigAddendumPath == "" {
+	if r.mode == stellarCoreRunnerModeOffline && r.coreConfigAddendumPath == "" {
 		// Add a fictional quorum -- necessary to convince core to start up;
 		// but not used at all for our purposes. Pubkey here is just random.
 		lines = append(lines,
@@ -197,6 +201,7 @@ func (r *stellarCoreRunner) writeConf() error {
 	if err != nil {
 		return err
 	}
+	r.Log.Debugf("captive core config file contents:\n%s", conf)
 	return ioutil.WriteFile(r.getConfFileName(), []byte(conf), 0644)
 }
 

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -2,7 +2,6 @@ package ledgerbackend
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -15,7 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/BurntSushi/toml"
 	"github.com/pkg/errors"
 
 	"github.com/stellar/go/support/log"
@@ -34,11 +32,11 @@ type stellarCoreRunnerInterface interface {
 }
 
 type stellarCoreRunner struct {
-	executablePath    string
-	quorumConfigPath  string
-	networkPassphrase string
-	historyURLs       []string
-	httpPort          uint16
+	executablePath         string
+	coreConfigAddendumPath string
+	networkPassphrase      string
+	historyURLs            []string
+	httpPort               uint16
 
 	started  bool
 	wg       sync.WaitGroup
@@ -58,7 +56,7 @@ type stellarCoreRunner struct {
 	Log *log.Entry
 }
 
-func newStellarCoreRunner(executablePath, quorumConfigPath, networkPassphrase string, httpPort uint16, historyURLs []string) (*stellarCoreRunner, error) {
+func newStellarCoreRunner(executablePath, coreConfigAddendumPath, networkPassphrase string, httpPort uint16, historyURLs []string) (*stellarCoreRunner, error) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	// Create temp dir
@@ -70,16 +68,16 @@ func newStellarCoreRunner(executablePath, quorumConfigPath, networkPassphrase st
 	}
 
 	runner := &stellarCoreRunner{
-		executablePath:    executablePath,
-		quorumConfigPath:  quorumConfigPath,
-		networkPassphrase: networkPassphrase,
-		historyURLs:       historyURLs,
-		httpPort:          httpPort,
-		shutdown:          make(chan struct{}),
-		processExit:       make(chan struct{}),
-		processExitError:  nil,
-		tempDir:           tempDir,
-		nonce:             fmt.Sprintf("captive-stellar-core-%x", r.Uint64()),
+		executablePath:         executablePath,
+		coreConfigAddendumPath: coreConfigAddendumPath,
+		networkPassphrase:      networkPassphrase,
+		historyURLs:            historyURLs,
+		httpPort:               httpPort,
+		shutdown:               make(chan struct{}),
+		processExit:            make(chan struct{}),
+		processExitError:       nil,
+		tempDir:                tempDir,
+		nonce:                  fmt.Sprintf("captive-stellar-core-%x", r.Uint64()),
 	}
 
 	if err := runner.writeConf(); err != nil {
@@ -104,7 +102,7 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 		lines = append(lines, fmt.Sprintf("[HISTORY.h%d]", i))
 		lines = append(lines, fmt.Sprintf(`get="curl -sf %s/{0} -o {1}"`, val))
 	}
-	if r.quorumConfigPath == "" {
+	if r.coreConfigAddendumPath == "" {
 
 		// Add a fictional quorum -- necessary to convince core to start up;
 		// but not used at all for our purposes. Pubkey here is just random.
@@ -114,23 +112,12 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 			`VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]`)
 	}
 	result := strings.ReplaceAll(strings.Join(lines, "\n"), "\\", "\\\\")
-	if r.quorumConfigPath != "" {
-		// TODO: parse toml file and ensure it is a correct quorum config file
-		quorumConfigContents, err := ioutil.ReadFile(r.quorumConfigPath)
+	if r.coreConfigAddendumPath != "" {
+		addendumContents, err := ioutil.ReadFile(r.coreConfigAddendumPath)
 		if err != nil {
 			return "", errors.Wrap(err, "reading quorum config file")
 		}
-		var entries map[string]interface{}
-		if _, err := toml.DecodeReader(bytes.NewBuffer(quorumConfigContents), &entries); err != nil {
-			return "", errors.Wrap(err, "cannot parse quorum config file (make sure it only contains [QUORUM_SET] entries")
-		}
-		for k := range entries {
-			if k != "QUORUM_SET" {
-				return "", fmt.Errorf("incorrect quorum config file (%s entry found but only [QUORUM_SET] entries are accepted)", k)
-			}
-		}
-
-		result = result + "\n" + string(quorumConfigContents)
+		result = result + "\n" + string(addendumContents)
 	}
 	return result, nil
 }

--- a/ingest/ledgerbackend/stellar_core_runner_test.go
+++ b/ingest/ledgerbackend/stellar_core_runner_test.go
@@ -1,7 +1,6 @@
 package ledgerbackend
 
 import (
-	"io"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -14,48 +13,21 @@ func TestGenerateConfig(t *testing.T) {
 	assert.NoError(t, err)
 	defer tmpFile.Close()
 	defer os.Remove(tmpFile.Name())
-	resetTmpFile := func() {
-		err := tmpFile.Truncate(0)
-		assert.NoError(t, err)
-		_, err = tmpFile.Seek(0, io.SeekStart)
-		assert.NoError(t, err)
-
-	}
 
 	r := stellarCoreRunner{
-		quorumConfigPath: tmpFile.Name(),
+		coreConfigAddendumPath: tmpFile.Name(),
 	}
 
-	tmpFile.WriteString(`[QUORUM_SET]
-THRESHOLD_PERCENT=100
-VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]
+	tmpFile.WriteString(`[[HOME_DOMAINS]]
+HOME_DOMAIN="testnet.stellar.org"
+QUALITY="HIGH"
+
+[[VALIDATORS]]
+NAME="sdf_testnet_1"
+HOME_DOMAIN="testnet.stellar.org"
+PUBLIC_KEY="GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y"
+ADDRESS="core-testnet1.stellar.org"
 `)
 	_, err = r.generateConfig()
 	assert.NoError(t, err)
-
-	resetTmpFile()
-	tmpFile.WriteString(`QUORUM_SET=foo
-`)
-	_, err = r.generateConfig()
-	assert.Error(t, err)
-
-	resetTmpFile()
-	tmpFile.WriteString(`[QUORUM_SET.foo]
-THRESHOLD_PERCENT=100
-VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]
-
-[QUORUM_SET.bar]
-THRESHOLD_PERCENT=100
-VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]
-`)
-	_, err = r.generateConfig()
-	assert.NoError(t, err)
-
-	resetTmpFile()
-	tmpFile.WriteString(`[FOO]
-THRESHOLD_PERCENT=100
-VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]
-`)
-	_, err = r.generateConfig()
-	assert.Error(t, err)
 }

--- a/ingest/ledgerbackend/stellar_core_runner_test.go
+++ b/ingest/ledgerbackend/stellar_core_runner_test.go
@@ -1,0 +1,61 @@
+package ledgerbackend
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateConfig(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "test-generate-config")
+	assert.NoError(t, err)
+	defer tmpFile.Close()
+	defer os.Remove(tmpFile.Name())
+	resetTmpFile := func() {
+		err := tmpFile.Truncate(0)
+		assert.NoError(t, err)
+		_, err = tmpFile.Seek(0, io.SeekStart)
+		assert.NoError(t, err)
+
+	}
+
+	r := stellarCoreRunner{
+		quorumConfigPath: tmpFile.Name(),
+	}
+
+	tmpFile.WriteString(`[QUORUM_SET]
+THRESHOLD_PERCENT=100
+VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]
+`)
+	_, err = r.generateConfig()
+	assert.NoError(t, err)
+
+	resetTmpFile()
+	tmpFile.WriteString(`QUORUM_SET=foo
+`)
+	_, err = r.generateConfig()
+	assert.Error(t, err)
+
+	resetTmpFile()
+	tmpFile.WriteString(`[QUORUM_SET.foo]
+THRESHOLD_PERCENT=100
+VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]
+
+[QUORUM_SET.bar]
+THRESHOLD_PERCENT=100
+VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]
+`)
+	_, err = r.generateConfig()
+	assert.NoError(t, err)
+
+	resetTmpFile()
+	tmpFile.WriteString(`[FOO]
+THRESHOLD_PERCENT=100
+VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]
+`)
+	_, err = r.generateConfig()
+	assert.Error(t, err)
+}

--- a/ingest/ledgerbackend/stellar_core_runner_test.go
+++ b/ingest/ledgerbackend/stellar_core_runner_test.go
@@ -15,7 +15,7 @@ func TestGenerateConfig(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 
 	r := stellarCoreRunner{
-		coreConfigAddendumPath: tmpFile.Name(),
+		configAppendPath: tmpFile.Name(),
 	}
 
 	tmpFile.WriteString(`[[HOME_DOMAINS]]

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -225,7 +225,7 @@ var dbReingestRangeCmd = &cobra.Command{
 			MaxReingestRetries:          int(retries),
 			ReingestRetryBackoffSeconds: int(retryBackoffSeconds),
 			EnableCaptiveCore:           config.EnableCaptiveCoreIngestion,
-			StellarCoreBinaryPath:       config.StellarCoreBinaryPath,
+			CaptiveCoreBinaryPath:       config.CaptiveCoreBinaryPath,
 			RemoteCaptiveCoreURL:        config.RemoteCaptiveCoreURL,
 		}
 

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -103,7 +103,7 @@ var ingestVerifyRangeCmd = &cobra.Command{
 			HistorySession:        horizonSession,
 			HistoryArchiveURL:     config.HistoryArchiveURLs[0],
 			EnableCaptiveCore:     config.EnableCaptiveCoreIngestion,
-			StellarCoreBinaryPath: config.StellarCoreBinaryPath,
+			CaptiveCoreBinaryPath: config.CaptiveCoreBinaryPath,
 			RemoteCaptiveCoreURL:  config.RemoteCaptiveCoreURL,
 		}
 
@@ -191,7 +191,7 @@ var ingestStressTestCmd = &cobra.Command{
 		}
 
 		if config.EnableCaptiveCoreIngestion {
-			ingestConfig.StellarCoreBinaryPath = config.StellarCoreBinaryPath
+			ingestConfig.CaptiveCoreBinaryPath = config.CaptiveCoreBinaryPath
 			ingestConfig.RemoteCaptiveCoreURL = config.RemoteCaptiveCoreURL
 		} else {
 			if config.StellarCoreDatabaseURL == "" {
@@ -273,7 +273,7 @@ var ingestInitGenesisStateCmd = &cobra.Command{
 		}
 
 		if config.EnableCaptiveCoreIngestion {
-			ingestConfig.StellarCoreBinaryPath = config.StellarCoreBinaryPath
+			ingestConfig.CaptiveCoreBinaryPath = config.CaptiveCoreBinaryPath
 		} else {
 			if config.StellarCoreDatabaseURL == "" {
 				log.Fatalf("flag --%s cannot be empty", horizon.StellarCoreDBURLFlagName)

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	StellarCoreDatabaseURL      string
 	StellarCoreURL              string
 	RemoteCaptiveCoreURL        string
-	CaptiveCoreHTTPPort         uint16
+	CaptiveCoreHTTPPort         uint
 
 	// MaxDBConnections has a priority over all 4 values below.
 	MaxDBConnections            int

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -16,13 +16,14 @@ type Config struct {
 	Port               uint
 	AdminPort          uint
 
-	EnableCaptiveCoreIngestion  bool
-	StellarCoreBinaryPath       string
-	CaptiveCoreQuorumConfigPath string
-	StellarCoreDatabaseURL      string
-	StellarCoreURL              string
-	RemoteCaptiveCoreURL        string
-	CaptiveCoreHTTPPort         uint
+	EnableCaptiveCoreIngestion bool
+	CaptiveCoreBinaryPath      string
+	CaptiveCoreAddendumPath    string
+	RemoteCaptiveCoreURL       string
+	CaptiveCoreHTTPPort        uint
+
+	StellarCoreDatabaseURL string
+	StellarCoreURL         string
 
 	// MaxDBConnections has a priority over all 4 values below.
 	MaxDBConnections            int

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -16,11 +16,11 @@ type Config struct {
 	Port               uint
 	AdminPort          uint
 
-	EnableCaptiveCoreIngestion bool
-	CaptiveCoreBinaryPath      string
-	CaptiveCoreAddendumPath    string
-	RemoteCaptiveCoreURL       string
-	CaptiveCoreHTTPPort        uint
+	EnableCaptiveCoreIngestion  bool
+	CaptiveCoreBinaryPath       string
+	CaptiveCoreConfigAppendPath string
+	RemoteCaptiveCoreURL        string
+	CaptiveCoreHTTPPort         uint
 
 	StellarCoreDatabaseURL string
 	StellarCoreURL         string

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -16,12 +16,13 @@ type Config struct {
 	Port               uint
 	AdminPort          uint
 
-	EnableCaptiveCoreIngestion bool
-	StellarCoreBinaryPath      string
-	StellarCoreConfigPath      string
-	StellarCoreDatabaseURL     string
-	StellarCoreURL             string
-	RemoteCaptiveCoreURL       string
+	EnableCaptiveCoreIngestion  bool
+	StellarCoreBinaryPath       string
+	CaptiveCoreQuorumConfigPath string
+	StellarCoreDatabaseURL      string
+	StellarCoreURL              string
+	RemoteCaptiveCoreURL        string
+	CaptiveCoreHTTPPort         uint16
 
 	// MaxDBConnections has a priority over all 4 values below.
 	MaxDBConnections            int

--- a/services/horizon/internal/docs/captive_core.md
+++ b/services/horizon/internal/docs/captive_core.md
@@ -13,13 +13,20 @@ Captive Stellar-Core can be used in both reingestion and normal Horizon operatio
 To enable captive mode three feature config variables are required:
 * `ENABLE_CAPTIVE_CORE_INGESTION=true`,
 * `STELLAR_CORE_BINARY_PATH` - defines a path to the `stellar-core` binary,
-* `STELLAR_CAPTIVE_CORE_QUORUM_PATH` - (not required when reingesting) defines a path to a stellar-core configuration file containing `[QUORUM_SET]` entries. For instance:
+* `CAPTIVE_CORE_ADDENDUM_PATH` - (not required when reingesting) defines a path to an addendum for the Stellar Core configuration file used by captive core. It must, at least, include enough details to define a quorum set. For instance, to connect to testnet through `core-testnet1.stellar.org`:
   ```
-  [QUORUM_SET]
-  THRESHOLD_PERCENT=100
-  VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]
+  [[HOME_DOMAINS]]
+  HOME_DOMAIN="testnet.stellar.org"
+  QUALITY="HIGH"
+
+  [[VALIDATORS]]
+  NAME="sdf_testnet_1"
+  HOME_DOMAIN="testnet.stellar.org"
+  PUBLIC_KEY="GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y"
+  ADDRESS="core-testnet1.stellar.org"
   ```
-* (optional) `STELLAR_CAPTIVE_CORE_HTTP_PORT` - HTTP port for Captive Core to listen on (0 disables the HTTP server)
+  
+* (optional) `CAPTIVE_CORE_HTTP_PORT` - HTTP port for Captive Core to listen on (0 disables the HTTP server)
 
 ### Requirements
 

--- a/services/horizon/internal/docs/captive_core.md
+++ b/services/horizon/internal/docs/captive_core.md
@@ -13,7 +13,7 @@ Captive Stellar-Core can be used in both reingestion and normal Horizon operatio
 To enable captive mode three feature config variables are required:
 * `ENABLE_CAPTIVE_CORE_INGESTION=true`,
 * `STELLAR_CORE_BINARY_PATH` - defines a path to the `stellar-core` binary,
-* `CAPTIVE_CORE_ADDENDUM_PATH` - (not required when running `horizon db reingest range`) defines a path to an addendum for the Stellar Core configuration file used by captive core. It must, at least, include enough details to define a quorum set. For instance, to connect to the Stellar testnet through `core-testnet1.stellar.org`:
+* `CAPTIVE_CORE_CONFIG_APPEND_PATH` - (not required when running `horizon db reingest range`) defines a path to a file to append to the Stellar Core configuration file used by captive core. It must, at least, include enough details to define a quorum set. For instance, to connect to the Stellar testnet through `core-testnet1.stellar.org`:
   ```
   [[HOME_DOMAINS]]
   HOME_DOMAIN="testnet.stellar.org"

--- a/services/horizon/internal/docs/captive_core.md
+++ b/services/horizon/internal/docs/captive_core.md
@@ -26,19 +26,7 @@ To enable captive mode three feature config variables are required:
   ADDRESS="core-testnet1.stellar.org"
   ```
   
-  The base config file the addendum will be appended to is:
-  ```
-  # Generated file -- do not edit"
-  RUN_STANDALONE=true
-  NODE_IS_VALIDATOR=false
-  DISABLE_XDR_FSYNC=true
-  UNSAFE_QUORUM=true
-  NETWORK_PASSPHRASE=<value of --network-passphrase flag>
-  BUCKET_DIR_PATH=<temporary_directory_created_by_horizon>
-  HTTP_PORT=<value of --captive-core-http-port flag>
-  [HISTORY.hX]
-  get="curl -sf <Xth url in --history-archive-urls>/{0} -o {1}"
-  ```
+  The full configuration to be used will be printed out by Horizon when runnign horizon with `--log-level debug`
   
 * (optional) `CAPTIVE_CORE_HTTP_PORT` - HTTP port for Captive Core to listen on (0 disables the HTTP server)
 

--- a/services/horizon/internal/docs/captive_core.md
+++ b/services/horizon/internal/docs/captive_core.md
@@ -13,7 +13,13 @@ Captive Stellar-Core can be used in both reingestion and normal Horizon operatio
 To enable captive mode three feature config variables are required:
 * `ENABLE_CAPTIVE_CORE_INGESTION=true`,
 * `STELLAR_CORE_BINARY_PATH` - defines a path to the `stellar-core` binary,
-* `STELLAR_CORE_CONFIG_PATH` - defines a path to the `stellar-core.cfg` file (not required when reingesting).
+* `STELLAR_CAPTIVE_CORE_QUORUM_PATH` - (not required when reingesting) defines a path to a stellar-core configuration file containing `[QUORUM_SET]` entries. For instance:
+  ```
+  [QUORUM_SET]
+  THRESHOLD_PERCENT=100
+  VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]
+  ```
+* (optional) `STELLAR_CAPTIVE_CORE_HTTP_PORT` - HTTP port for Captive Core to listen on (0 disables the HTTP server)
 
 ### Requirements
 

--- a/services/horizon/internal/docs/captive_core.md
+++ b/services/horizon/internal/docs/captive_core.md
@@ -13,17 +13,29 @@ Captive Stellar-Core can be used in both reingestion and normal Horizon operatio
 To enable captive mode three feature config variables are required:
 * `ENABLE_CAPTIVE_CORE_INGESTION=true`,
 * `STELLAR_CORE_BINARY_PATH` - defines a path to the `stellar-core` binary,
-* `CAPTIVE_CORE_ADDENDUM_PATH` - (not required when reingesting) defines a path to an addendum for the Stellar Core configuration file used by captive core. It must, at least, include enough details to define a quorum set. For instance, to connect to testnet through `core-testnet1.stellar.org`:
+* `CAPTIVE_CORE_ADDENDUM_PATH` - (not required when reingesting) defines a path to an addendum for the Stellar Core configuration file used by captive core. It must, at least, include enough details to define a quorum set. For instance, to connect to teh Stellar testnet through `core-testnet1.stellar.org`:
   ```
   [[HOME_DOMAINS]]
   HOME_DOMAIN="testnet.stellar.org"
-  QUALITY="HIGH"
+  QUALITY="MEDIUM"
 
   [[VALIDATORS]]
   NAME="sdf_testnet_1"
   HOME_DOMAIN="testnet.stellar.org"
   PUBLIC_KEY="GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y"
   ADDRESS="core-testnet1.stellar.org"
+  ```
+  
+  The base config file the addendum will be appended to is:
+  ```
+  # Generated file -- do not edit"
+  RUN_STANDALONE=true
+  NODE_IS_VALIDATOR=false
+  DISABLE_XDR_FSYNC=true
+  UNSAFE_QUORUM=true
+  NETWORK_PASSPHRASE=<value of --network-passphrase flag>
+  BUCKET_DIR_PATH=<temporary_directory_created_by_horizon>
+  HTTP_PORT=<value of --captive-core-http-port flag>
   ```
   
 * (optional) `CAPTIVE_CORE_HTTP_PORT` - HTTP port for Captive Core to listen on (0 disables the HTTP server)

--- a/services/horizon/internal/docs/captive_core.md
+++ b/services/horizon/internal/docs/captive_core.md
@@ -13,7 +13,7 @@ Captive Stellar-Core can be used in both reingestion and normal Horizon operatio
 To enable captive mode three feature config variables are required:
 * `ENABLE_CAPTIVE_CORE_INGESTION=true`,
 * `STELLAR_CORE_BINARY_PATH` - defines a path to the `stellar-core` binary,
-* `CAPTIVE_CORE_ADDENDUM_PATH` - (not required when reingesting) defines a path to an addendum for the Stellar Core configuration file used by captive core. It must, at least, include enough details to define a quorum set. For instance, to connect to teh Stellar testnet through `core-testnet1.stellar.org`:
+* `CAPTIVE_CORE_ADDENDUM_PATH` - (not required when running `horizon db reingest range`) defines a path to an addendum for the Stellar Core configuration file used by captive core. It must, at least, include enough details to define a quorum set. For instance, to connect to the Stellar testnet through `core-testnet1.stellar.org`:
   ```
   [[HOME_DOMAINS]]
   HOME_DOMAIN="testnet.stellar.org"
@@ -36,6 +36,8 @@ To enable captive mode three feature config variables are required:
   NETWORK_PASSPHRASE=<value of --network-passphrase flag>
   BUCKET_DIR_PATH=<temporary_directory_created_by_horizon>
   HTTP_PORT=<value of --captive-core-http-port flag>
+  [HISTORY.hX]
+  get="curl -sf <Xth url in --history-archive-urls>/{0} -o {1}"
   ```
   
 * (optional) `CAPTIVE_CORE_HTTP_PORT` - HTTP port for Captive Core to listen on (0 disables the HTTP server)

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -1,6 +1,7 @@
 package horizon
 
 import (
+	"fmt"
 	"go/types"
 	stdLog "log"
 	"os"
@@ -102,20 +103,28 @@ func Flags() (*Config, support.ConfigOptions) {
 			ConfigKey:   &config.RemoteCaptiveCoreURL,
 		},
 		&support.ConfigOption{
-			Name:        "stellar-core-config-path",
+			Name:        "stellar-captive-core-quorum-path",
 			OptType:     types.String,
 			FlagDefault: "",
 			Required:    false,
-			Usage:       "path to stellar core config file",
-			ConfigKey:   &config.StellarCoreConfigPath,
+			Usage:       "path to stellar core quorum config file (i.e. a stellar core config file with [QUORUM_SET] entries)",
+			ConfigKey:   &config.CaptiveCoreQuorumConfigPath,
 		},
 		&support.ConfigOption{
 			Name:        "enable-captive-core-ingestion",
 			OptType:     types.Bool,
 			FlagDefault: false,
 			Required:    false,
-			Usage:       "[experimental flag!] causes Horizon to ingest from a Stellar Core subprocess instead of a persistent Stellar Core database",
+			Usage:       "[experimental flag!] causes Horizon to ingest from a Stellar Core process instead of a persistent Stellar Core database",
 			ConfigKey:   &config.EnableCaptiveCoreIngestion,
+		},
+		&support.ConfigOption{
+			Name:        "stellar-captive-core-http-port",
+			OptType:     types.Uint16,
+			FlagDefault: uint16(11626),
+			Required:    false,
+			Usage:       "HTTP port for Captive Core to listen on (0 disables the http server)",
+			ConfigKey:   &config.CaptiveCoreHTTPPort,
 		},
 		&support.ConfigOption{
 			Name:      StellarCoreDBURLFlagName,
@@ -129,7 +138,7 @@ func Flags() (*Config, support.ConfigOptions) {
 			Name:      StellarCoreURLFlagName,
 			ConfigKey: &config.StellarCoreURL,
 			OptType:   types.String,
-			Usage:     "stellar-core to connect with (for http commands)",
+			Usage:     "stellar-core to connect with (for http commands). If unset and the local Captive core is enabled, it will use http://localhost:<stellar_captive_core_http_port>",
 		},
 		&support.ConfigOption{
 			Name:        "history-archive-urls",
@@ -398,6 +407,11 @@ func ApplyFlags(config *Config, flags support.ConfigOptions) {
 		remoteURL := viper.GetString("remote-captive-core-url")
 		if binaryPath == "" && remoteURL == "" {
 			stdLog.Fatalf("Invalid config: captive core requires that either --stellar-core-binary-path or --remote-captive-core-url is set")
+		}
+		if config.StellarCoreURL == "" && config.RemoteCaptiveCoreURL == "" && config.CaptiveCoreHTTPPort != 0 {
+			// If we don't supply an explicit core URL and we are running a local captive core process
+			// with the http port enabled, point to it.
+			config.StellarCoreURL = fmt.Sprintf("http://localhost:%d", config.CaptiveCoreHTTPPort)
 		}
 	}
 	if config.Ingest {

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -26,8 +26,8 @@ const (
 	StellarCoreURLFlagName = "stellar-core-url"
 	// StellarCoreBinaryPathName is the command line flag for configuring the path to the stellar core binary
 	StellarCoreBinaryPathName = "stellar-core-binary-path"
-	// CaptiveCoreAdddendumPathName is the command line flag for configuring the path to the captive core configuration addendum
-	CaptiveCoreAdddendumPathName = "captive-core-addendum-path"
+	// CaptiveCoreConfigAppendPathName is the command line flag for configuring the path to the captive core additional configuration
+	CaptiveCoreConfigAppendPathName = "captive-core-config-append-path"
 )
 
 // validateBothOrNeither ensures that both options are provided, if either is provided.
@@ -107,12 +107,12 @@ func Flags() (*Config, support.ConfigOptions) {
 			ConfigKey:   &config.RemoteCaptiveCoreURL,
 		},
 		&support.ConfigOption{
-			Name:        CaptiveCoreAdddendumPathName,
+			Name:        CaptiveCoreConfigAppendPathName,
 			OptType:     types.String,
 			FlagDefault: "",
 			Required:    false,
-			Usage:       "path to an addendum for the Stellar Core configuration file used by captive core. It must, at least, include enough details to define a quorum set",
-			ConfigKey:   &config.CaptiveCoreAddendumPath,
+			Usage:       "path to additional configuration for the Stellar Core configuration file used by captive core. It must, at least, include enough details to define a quorum set",
+			ConfigKey:   &config.CaptiveCoreConfigAppendPath,
 		},
 		&support.ConfigOption{
 			Name:        "enable-captive-core-ingestion",
@@ -420,7 +420,7 @@ func ApplyFlags(config *Config, flags support.ConfigOptions) {
 	}
 	if config.Ingest {
 		// When running live ingestion a config file is required too
-		validateBothOrNeither(StellarCoreBinaryPathName, CaptiveCoreAdddendumPathName)
+		validateBothOrNeither(StellarCoreBinaryPathName, CaptiveCoreConfigAppendPathName)
 	}
 
 	// Configure log file

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -103,11 +103,11 @@ func Flags() (*Config, support.ConfigOptions) {
 			ConfigKey:   &config.RemoteCaptiveCoreURL,
 		},
 		&support.ConfigOption{
-			Name:        "stellar-captive-core-quorum-path",
+			Name:        "captive-core-addendum-path",
 			OptType:     types.String,
 			FlagDefault: "",
 			Required:    false,
-			Usage:       "path to stellar core quorum config file (i.e. a stellar core config file with [QUORUM_SET] entries)",
+			Usage:       "path to an addendum for the Stellar Core configuration file used by captive core. It must, at least, include enough details to define a quorum set",
 			ConfigKey:   &config.CaptiveCoreQuorumConfigPath,
 		},
 		&support.ConfigOption{
@@ -119,7 +119,7 @@ func Flags() (*Config, support.ConfigOptions) {
 			ConfigKey:   &config.EnableCaptiveCoreIngestion,
 		},
 		&support.ConfigOption{
-			Name:        "stellar-captive-core-http-port",
+			Name:        "captive-core-http-port",
 			OptType:     types.Uint16,
 			FlagDefault: uint16(11626),
 			Required:    false,

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -123,7 +123,7 @@ func Flags() (*Config, support.ConfigOptions) {
 			OptType:     types.Uint16,
 			FlagDefault: uint16(11626),
 			Required:    false,
-			Usage:       "HTTP port for Captive Core to listen on (0 disables the http server)",
+			Usage:       "HTTP port for Captive Core to listen on (0 disables the HTTP server)",
 			ConfigKey:   &config.CaptiveCoreHTTPPort,
 		},
 		&support.ConfigOption{

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -124,8 +124,8 @@ func Flags() (*Config, support.ConfigOptions) {
 		},
 		&support.ConfigOption{
 			Name:        "captive-core-http-port",
-			OptType:     types.Uint16,
-			FlagDefault: uint16(11626),
+			OptType:     types.Uint,
+			FlagDefault: uint(11626),
 			Required:    false,
 			Usage:       "HTTP port for Captive Core to listen on (0 disables the HTTP server)",
 			ConfigKey:   &config.CaptiveCoreHTTPPort,

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -96,7 +96,7 @@ func Flags() (*Config, support.ConfigOptions) {
 			FlagDefault: "",
 			Required:    false,
 			Usage:       "path to stellar core binary (--remote-captive-core-url has higher precedence)",
-			ConfigKey:   &config.StellarCoreBinaryPath,
+			ConfigKey:   &config.CaptiveCoreBinaryPath,
 		},
 		&support.ConfigOption{
 			Name:        "remote-captive-core-url",
@@ -112,7 +112,7 @@ func Flags() (*Config, support.ConfigOptions) {
 			FlagDefault: "",
 			Required:    false,
 			Usage:       "path to an addendum for the Stellar Core configuration file used by captive core. It must, at least, include enough details to define a quorum set",
-			ConfigKey:   &config.CaptiveCoreQuorumConfigPath,
+			ConfigKey:   &config.CaptiveCoreAddendumPath,
 		},
 		&support.ConfigOption{
 			Name:        "enable-captive-core-ingestion",

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -24,6 +24,10 @@ const (
 	StellarCoreDBURLFlagName = "stellar-core-db-url"
 	// StellarCoreDBURLFlagName is the command line flag for configuring the URL fore Stellar Core HTTP endpoint
 	StellarCoreURLFlagName = "stellar-core-url"
+	// StellarCoreBinaryPathName is the command line flag for configuring the path to the stellar core binary
+	StellarCoreBinaryPathName = "stellar-core-binary-path"
+	// CaptiveCoreAdddendumPathName is the command line flag for configuring the path to the captive core configuration addendum
+	CaptiveCoreAdddendumPathName = "captive-core-addendum-path"
 )
 
 // validateBothOrNeither ensures that both options are provided, if either is provided.
@@ -87,7 +91,7 @@ func Flags() (*Config, support.ConfigOptions) {
 			Usage:     "horizon postgres database to connect with",
 		},
 		&support.ConfigOption{
-			Name:        "stellar-core-binary-path",
+			Name:        StellarCoreBinaryPathName,
 			OptType:     types.String,
 			FlagDefault: "",
 			Required:    false,
@@ -103,7 +107,7 @@ func Flags() (*Config, support.ConfigOptions) {
 			ConfigKey:   &config.RemoteCaptiveCoreURL,
 		},
 		&support.ConfigOption{
-			Name:        "captive-core-addendum-path",
+			Name:        CaptiveCoreAdddendumPathName,
 			OptType:     types.String,
 			FlagDefault: "",
 			Required:    false,
@@ -403,7 +407,7 @@ func ApplyFlags(config *Config, flags support.ConfigOptions) {
 	}
 
 	if config.EnableCaptiveCoreIngestion {
-		binaryPath := viper.GetString("stellar-core-binary-path")
+		binaryPath := viper.GetString(StellarCoreBinaryPathName)
 		remoteURL := viper.GetString("remote-captive-core-url")
 		if binaryPath == "" && remoteURL == "" {
 			stdLog.Fatalf("Invalid config: captive core requires that either --stellar-core-binary-path or --remote-captive-core-url is set")
@@ -416,7 +420,7 @@ func ApplyFlags(config *Config, flags support.ConfigOptions) {
 	}
 	if config.Ingest {
 		// When running live ingestion a config file is required too
-		validateBothOrNeither("stellar-core-binary-path", "stellar-core-config-path")
+		validateBothOrNeither(StellarCoreBinaryPathName, CaptiveCoreAdddendumPathName)
 	}
 
 	// Configure log file

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -63,15 +63,15 @@ const (
 var log = logpkg.DefaultLogger.WithField("service", "ingest")
 
 type Config struct {
-	CoreSession                 *db.Session
-	StellarCoreURL              string
-	StellarCoreCursor           string
-	EnableCaptiveCore           bool
-	StellarCoreBinaryPath       string
-	CaptiveCoreQuorumConfigPath string
-	CaptiveCoreHTTPPort         uint
-	RemoteCaptiveCoreURL        string
-	NetworkPassphrase           string
+	CoreSession             *db.Session
+	StellarCoreURL          string
+	StellarCoreCursor       string
+	EnableCaptiveCore       bool
+	CaptiveCoreBinaryPath   string
+	CaptiveCoreAddendumPath string
+	CaptiveCoreHTTPPort     uint
+	RemoteCaptiveCoreURL    string
+	NetworkPassphrase       string
 
 	HistorySession           *db.Session
 	HistoryArchiveURL        string
@@ -178,12 +178,12 @@ func NewSystem(config Config) (System, error) {
 			var captiveCoreBackend *ledgerbackend.CaptiveStellarCore
 			captiveCoreBackend, err = ledgerbackend.NewCaptive(
 				ledgerbackend.CaptiveCoreConfig{
-					StellarCoreBinaryPath:  config.StellarCoreBinaryPath,
-					CoreConfigAddendumPath: config.CaptiveCoreQuorumConfigPath,
-					HTTPPort:               config.CaptiveCoreHTTPPort,
-					NetworkPassphrase:      config.NetworkPassphrase,
-					HistoryArchiveURLs:     []string{config.HistoryArchiveURL},
-					LedgerHashStore:        ledgerbackend.NewHorizonDBLedgerHashStore(config.HistorySession),
+					BinaryPath:         config.CaptiveCoreBinaryPath,
+					AddendumPath:       config.CaptiveCoreAddendumPath,
+					HTTPPort:           config.CaptiveCoreHTTPPort,
+					NetworkPassphrase:  config.NetworkPassphrase,
+					HistoryArchiveURLs: []string{config.HistoryArchiveURL},
+					LedgerHashStore:    ledgerbackend.NewHorizonDBLedgerHashStore(config.HistorySession),
 				},
 			)
 			if err != nil {

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -178,12 +178,12 @@ func NewSystem(config Config) (System, error) {
 			var captiveCoreBackend *ledgerbackend.CaptiveStellarCore
 			captiveCoreBackend, err = ledgerbackend.NewCaptive(
 				ledgerbackend.CaptiveCoreConfig{
-					StellarCoreBinaryPath: config.StellarCoreBinaryPath,
-					QuorumConfigPath:      config.CaptiveCoreQuorumConfigPath,
-					HTTPPort:              config.CaptiveCoreHTTPPort,
-					NetworkPassphrase:     config.NetworkPassphrase,
-					HistoryArchiveURLs:    []string{config.HistoryArchiveURL},
-					LedgerHashStore:       ledgerbackend.NewHorizonDBLedgerHashStore(config.HistorySession),
+					StellarCoreBinaryPath:  config.StellarCoreBinaryPath,
+					CoreConfigAddendumPath: config.CaptiveCoreQuorumConfigPath,
+					HTTPPort:               config.CaptiveCoreHTTPPort,
+					NetworkPassphrase:      config.NetworkPassphrase,
+					HistoryArchiveURLs:     []string{config.HistoryArchiveURL},
+					LedgerHashStore:        ledgerbackend.NewHorizonDBLedgerHashStore(config.HistorySession),
 				},
 			)
 			if err != nil {

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -63,14 +63,15 @@ const (
 var log = logpkg.DefaultLogger.WithField("service", "ingest")
 
 type Config struct {
-	CoreSession           *db.Session
-	StellarCoreURL        string
-	StellarCoreCursor     string
-	EnableCaptiveCore     bool
-	StellarCoreBinaryPath string
-	StellarCoreConfigPath string
-	RemoteCaptiveCoreURL  string
-	NetworkPassphrase     string
+	CoreSession                 *db.Session
+	StellarCoreURL              string
+	StellarCoreCursor           string
+	EnableCaptiveCore           bool
+	StellarCoreBinaryPath       string
+	CaptiveCoreQuorumConfigPath string
+	CaptiveCoreHTTPPort         uint16
+	RemoteCaptiveCoreURL        string
+	NetworkPassphrase           string
 
 	HistorySession           *db.Session
 	HistoryArchiveURL        string
@@ -178,7 +179,8 @@ func NewSystem(config Config) (System, error) {
 			captiveCoreBackend, err = ledgerbackend.NewCaptive(
 				ledgerbackend.CaptiveCoreConfig{
 					StellarCoreBinaryPath: config.StellarCoreBinaryPath,
-					StellarCoreConfigPath: config.StellarCoreConfigPath,
+					QuorumConfigPath:      config.CaptiveCoreQuorumConfigPath,
+					HTTPPort:              config.CaptiveCoreHTTPPort,
 					NetworkPassphrase:     config.NetworkPassphrase,
 					HistoryArchiveURLs:    []string{config.HistoryArchiveURL},
 					LedgerHashStore:       ledgerbackend.NewHorizonDBLedgerHashStore(config.HistorySession),

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -69,7 +69,7 @@ type Config struct {
 	EnableCaptiveCore           bool
 	StellarCoreBinaryPath       string
 	CaptiveCoreQuorumConfigPath string
-	CaptiveCoreHTTPPort         uint16
+	CaptiveCoreHTTPPort         uint
 	RemoteCaptiveCoreURL        string
 	NetworkPassphrase           string
 

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -63,15 +63,15 @@ const (
 var log = logpkg.DefaultLogger.WithField("service", "ingest")
 
 type Config struct {
-	CoreSession             *db.Session
-	StellarCoreURL          string
-	StellarCoreCursor       string
-	EnableCaptiveCore       bool
-	CaptiveCoreBinaryPath   string
-	CaptiveCoreAddendumPath string
-	CaptiveCoreHTTPPort     uint
-	RemoteCaptiveCoreURL    string
-	NetworkPassphrase       string
+	CoreSession                 *db.Session
+	StellarCoreURL              string
+	StellarCoreCursor           string
+	EnableCaptiveCore           bool
+	CaptiveCoreBinaryPath       string
+	CaptiveCoreConfigAppendPath string
+	CaptiveCoreHTTPPort         uint
+	RemoteCaptiveCoreURL        string
+	NetworkPassphrase           string
 
 	HistorySession           *db.Session
 	HistoryArchiveURL        string
@@ -179,7 +179,7 @@ func NewSystem(config Config) (System, error) {
 			captiveCoreBackend, err = ledgerbackend.NewCaptive(
 				ledgerbackend.CaptiveCoreConfig{
 					BinaryPath:         config.CaptiveCoreBinaryPath,
-					AddendumPath:       config.CaptiveCoreAddendumPath,
+					ConfigAppendPath:   config.CaptiveCoreConfigAppendPath,
 					HTTPPort:           config.CaptiveCoreHTTPPort,
 					NetworkPassphrase:  config.NetworkPassphrase,
 					HistoryArchiveURLs: []string{config.HistoryArchiveURL},

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -64,15 +64,15 @@ func initExpIngester(app *App) {
 		// TODO:
 		// Use the first archive for now. We don't have a mechanism to
 		// use multiple archives at the same time currently.
-		HistoryArchiveURL:        app.config.HistoryArchiveURLs[0],
-		StellarCoreURL:           app.config.StellarCoreURL,
-		StellarCoreCursor:        app.config.CursorName,
-		CaptiveCoreBinaryPath:    app.config.CaptiveCoreBinaryPath,
-		CaptiveCoreAddendumPath:  app.config.CaptiveCoreAddendumPath,
-		CaptiveCoreHTTPPort:      app.config.CaptiveCoreHTTPPort,
-		RemoteCaptiveCoreURL:     app.config.RemoteCaptiveCoreURL,
-		EnableCaptiveCore:        app.config.EnableCaptiveCoreIngestion,
-		DisableStateVerification: app.config.IngestDisableStateVerification,
+		HistoryArchiveURL:           app.config.HistoryArchiveURLs[0],
+		StellarCoreURL:              app.config.StellarCoreURL,
+		StellarCoreCursor:           app.config.CursorName,
+		CaptiveCoreBinaryPath:       app.config.CaptiveCoreBinaryPath,
+		CaptiveCoreConfigAppendPath: app.config.CaptiveCoreConfigAppendPath,
+		CaptiveCoreHTTPPort:         app.config.CaptiveCoreHTTPPort,
+		RemoteCaptiveCoreURL:        app.config.RemoteCaptiveCoreURL,
+		EnableCaptiveCore:           app.config.EnableCaptiveCoreIngestion,
+		DisableStateVerification:    app.config.IngestDisableStateVerification,
 	})
 
 	if err != nil {

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -64,14 +64,15 @@ func initExpIngester(app *App) {
 		// TODO:
 		// Use the first archive for now. We don't have a mechanism to
 		// use multiple archives at the same time currently.
-		HistoryArchiveURL:        app.config.HistoryArchiveURLs[0],
-		StellarCoreURL:           app.config.StellarCoreURL,
-		StellarCoreCursor:        app.config.CursorName,
-		StellarCoreBinaryPath:    app.config.StellarCoreBinaryPath,
-		StellarCoreConfigPath:    app.config.StellarCoreConfigPath,
-		RemoteCaptiveCoreURL:     app.config.RemoteCaptiveCoreURL,
-		EnableCaptiveCore:        app.config.EnableCaptiveCoreIngestion,
-		DisableStateVerification: app.config.IngestDisableStateVerification,
+		HistoryArchiveURL:           app.config.HistoryArchiveURLs[0],
+		StellarCoreURL:              app.config.StellarCoreURL,
+		StellarCoreCursor:           app.config.CursorName,
+		StellarCoreBinaryPath:       app.config.StellarCoreBinaryPath,
+		CaptiveCoreQuorumConfigPath: app.config.CaptiveCoreQuorumConfigPath,
+		CaptiveCoreHTTPPort:         app.config.CaptiveCoreHTTPPort,
+		RemoteCaptiveCoreURL:        app.config.RemoteCaptiveCoreURL,
+		EnableCaptiveCore:           app.config.EnableCaptiveCoreIngestion,
+		DisableStateVerification:    app.config.IngestDisableStateVerification,
 	})
 
 	if err != nil {

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -64,15 +64,15 @@ func initExpIngester(app *App) {
 		// TODO:
 		// Use the first archive for now. We don't have a mechanism to
 		// use multiple archives at the same time currently.
-		HistoryArchiveURL:           app.config.HistoryArchiveURLs[0],
-		StellarCoreURL:              app.config.StellarCoreURL,
-		StellarCoreCursor:           app.config.CursorName,
-		StellarCoreBinaryPath:       app.config.StellarCoreBinaryPath,
-		CaptiveCoreQuorumConfigPath: app.config.CaptiveCoreQuorumConfigPath,
-		CaptiveCoreHTTPPort:         app.config.CaptiveCoreHTTPPort,
-		RemoteCaptiveCoreURL:        app.config.RemoteCaptiveCoreURL,
-		EnableCaptiveCore:           app.config.EnableCaptiveCoreIngestion,
-		DisableStateVerification:    app.config.IngestDisableStateVerification,
+		HistoryArchiveURL:        app.config.HistoryArchiveURLs[0],
+		StellarCoreURL:           app.config.StellarCoreURL,
+		StellarCoreCursor:        app.config.CursorName,
+		CaptiveCoreBinaryPath:    app.config.CaptiveCoreBinaryPath,
+		CaptiveCoreAddendumPath:  app.config.CaptiveCoreAddendumPath,
+		CaptiveCoreHTTPPort:      app.config.CaptiveCoreHTTPPort,
+		RemoteCaptiveCoreURL:     app.config.RemoteCaptiveCoreURL,
+		EnableCaptiveCore:        app.config.EnableCaptiveCoreIngestion,
+		DisableStateVerification: app.config.IngestDisableStateVerification,
 	})
 
 	if err != nil {

--- a/support/config/config_option.go
+++ b/support/config/config_option.go
@@ -134,8 +134,6 @@ func (co *ConfigOption) setFlag(cmd *cobra.Command) error {
 		cmd.PersistentFlags().Bool(co.Name, co.FlagDefault.(bool), co.UsageText())
 	case types.Uint:
 		cmd.PersistentFlags().Uint(co.Name, co.FlagDefault.(uint), co.UsageText())
-	case types.Uint16:
-		cmd.PersistentFlags().Uint16(co.Name, co.FlagDefault.(uint16), co.UsageText())
 	case types.Uint32:
 		cmd.PersistentFlags().Uint32(co.Name, co.FlagDefault.(uint32), co.UsageText())
 	default:

--- a/support/config/config_option.go
+++ b/support/config/config_option.go
@@ -134,6 +134,8 @@ func (co *ConfigOption) setFlag(cmd *cobra.Command) error {
 		cmd.PersistentFlags().Bool(co.Name, co.FlagDefault.(bool), co.UsageText())
 	case types.Uint:
 		cmd.PersistentFlags().Uint(co.Name, co.FlagDefault.(uint), co.UsageText())
+	case types.Uint16:
+		cmd.PersistentFlags().Uint16(co.Name, co.FlagDefault.(uint16), co.UsageText())
 	case types.Uint32:
 		cmd.PersistentFlags().Uint32(co.Name, co.FlagDefault.(uint32), co.UsageText())
 	default:


### PR DESCRIPTION
* Rename `--stellar-core-config-path` to `--stellar-captive-core-quorum-path`.
  The core config path is automatically generated in captive-core online mode.
  `--stellar-captive-core-quorum-path` should point to a toml config file containing
  `[QUORUM_SET]` entries, with the same semantics as in the stellar core configuration.

* Add `--stellar-captive-core-http-port` to indicate what port (if any) captive core
  shoulf listen on. If `--stellar-core-url` is unset and the local Captive core is enabled,
  `--stellar-core-url` will be implicitly use `http://localhost:<stellar_captive_core_http_port>`

* Remove unused entries in `CaptiveStellarCore`

Closes #3211 