### PR TITLE
services/horizon/internal/test/integration: Use ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING in integration tests

### DIFF
--- a/services/horizon/docker/stellar-core-integration-tests.cfg
+++ b/services/horizon/docker/stellar-core-integration-tests.cfg
@@ -2,7 +2,7 @@
 # see stellar-core_example.cfg for a description of the configuration parameters
 
 RUN_STANDALONE=false
-MANUAL_CLOSE=true
+ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING=true
 
 NETWORK_PASSPHRASE="Standalone Network ; February 2017"
 

--- a/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
@@ -363,7 +363,7 @@ func TestSponsorships(t *testing.T) {
 		// Submit the preauthorized transaction
 		var txResult xdr.TransactionResult
 		tt.NoError(err)
-		txResp, err = itest.SubmitTransactionXDR(preAuthTxB64)
+		txResp, err = itest.Client().SubmitTransactionXDR(preAuthTxB64)
 		tt.NoError(err)
 		err = xdr.SafeUnmarshalBase64(txResp.ResultXdr, &txResult)
 		tt.NoError(err)

--- a/services/horizon/internal/integration/protocol14_state_verifier_test.go
+++ b/services/horizon/internal/integration/protocol14_state_verifier_test.go
@@ -14,12 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	firstCheckpoint = (64 * (iota + 1)) - 1
-	secondCheckpoint
-	thirdCheckpoint
-)
-
 func TestProtocol14StateVerifier(t *testing.T) {
 	itest := integration.NewTest(t, protocol15Config)
 
@@ -104,14 +98,6 @@ func TestProtocol14StateVerifier(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, txResp.Successful)
 
-	// Reach the first checkpoint ledger
-	// Core will push to history archives *after* checkpoint ledger
-	err = itest.CloseCoreLedgersUntilSequence(firstCheckpoint + 1)
-	assert.NoError(t, err)
-	for !itest.LedgerIngested(firstCheckpoint) {
-		time.Sleep(time.Second)
-	}
-
 	verified := waitForStateVerifications(itest, 1)
 	if !verified {
 		t.Fatal("State verification not run...")
@@ -120,19 +106,6 @@ func TestProtocol14StateVerifier(t *testing.T) {
 	// Trigger state rebuild to check if ingesting from history archive works
 	err = itest.Horizon().HistoryQ().UpdateExpIngestVersion(0)
 	assert.NoError(t, err)
-
-	// Wait for the second checkpoint ledger and state rebuild
-	// Core will push to history archives *after* checkpoint ledger
-	err = itest.CloseCoreLedgersUntilSequence(secondCheckpoint + 1)
-	assert.NoError(t, err)
-
-	// Wait for the third checkpoint ledger and state verification trigger
-	// Core will push to history archives *after* checkpoint ledger
-	err = itest.CloseCoreLedgersUntilSequence(thirdCheckpoint + 1)
-	assert.NoError(t, err)
-	for !itest.LedgerIngested(thirdCheckpoint) {
-		time.Sleep(time.Second)
-	}
 
 	verified = waitForStateVerifications(itest, 2)
 	if !verified {

--- a/services/horizon/internal/integration/protocol14_test.go
+++ b/services/horizon/internal/integration/protocol14_test.go
@@ -70,7 +70,7 @@ func TestProtocol15Basics(t *testing.T) {
 		predictions := []string{id1, id2}
 
 		var txResult xdr.TransactionResult
-		txResp, err := itest.SubmitTransaction(tx)
+		txResp, err := itest.Client().SubmitTransaction(tx)
 		tt.NoError(err)
 		xdr.SafeUnmarshalBase64(txResp.ResultXdr, &txResult)
 		opResults, ok := txResult.OperationResults()


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Use `ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING=true` in integration tests instead of manual close.

### Why

Running the horizon integration tests with captive core enabled has turned out to be very difficult due to issues with running Stellar Core in manual close mode (see https://github.com/stellar/stellar-core/issues/2778 for more details).

We use manual close mode to speed up our integration tests. Otherwise, we'd need to wait 5 seconds for every ledger close and that would result in our integration tests taking over 20 minutes to complete.

The Stellar Core team has suggested we use `ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING=true` instead of manual close in our integration tests because it would fix many of the issues we encountered when attempting to run the integration tests with captive core enabled.

I have verified that the execution time of our integration tests with `ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING=true` are still on par with running Stellar Core in manual close mode.


### Known limitations

ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING drops the time between ledger closes from ~5s to ~1s, and the number of ledgers between checkpoints from 64 to 8. Horizon assumes that each checkpoint spans 64 ledgers. In a follow up commit we should make the size of a checkpoint configurable because there is code exercised by captive core ingestion which relies on the assumption that a checkpoint spans 64 ledgers.