### PR TITLE
ingest/ledgerbackend: Fix captive core bug where --start-at-hash parameter is omitted

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -310,30 +310,28 @@ func (c *CaptiveStellarCore) runFromParams(from uint32) (runFrom uint32, ledgerH
 	}
 
 	if from <= 63 {
-		// For ledgers before (and including) first checkpoint, we start streaming
-		// without providing a hash, to avoid waiting for the checkpoint.
-		// It will always start streaming from ledger 2.
+		// For ledgers before (and including) first checkpoint, get/wait the first
+		// checkpoint to get the ledger header. It will always start streaming
+		// from ledger 2.
 		nextLedger = 2
-		runFrom = 2
 		// The line below is to support a special case for streaming ledger 2
 		// that works for all other ledgers <= 63 (fast-forward).
 		// We can't set from=2 because Stellar-Core will not allow starting from 1.
 		// To solve this we start from 3 and exploit the fast that Stellar-Core
 		// will stream data from 2 for the first checkpoint.
 		from = 3
-		return
-	}
-
-	// For ledgers after the first checkpoint, start at the previous checkpoint
-	// and fast-forward from there.
-	if !historyarchive.IsCheckpoint(from) {
-		from = historyarchive.PrevCheckpoint(from)
-	}
-	// Streaming will start from the previous checkpoint + 1
-	nextLedger = from - 63
-	if nextLedger < 2 {
-		// Stellar-Core always streams from ledger 2 at min.
-		nextLedger = 2
+	} else {
+		// For ledgers after the first checkpoint, start at the previous checkpoint
+		// and fast-forward from there.
+		if !historyarchive.IsCheckpoint(from) {
+			from = historyarchive.PrevCheckpoint(from)
+		}
+		// Streaming will start from the previous checkpoint + 1
+		nextLedger = from - 63
+		if nextLedger < 2 {
+			// Stellar-Core always streams from ledger 2 at min.
+			nextLedger = 2
+		}
 	}
 
 	runFrom = from - 1

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -254,26 +254,12 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 		}
 	}
 
-	var nextLedger uint32
-	if latestCheckpointSequence == 0 {
-		if c.log != nil {
-			c.log.Info("checkpoint ledger has not been published, attempting to run from genesis ledger")
-		}
-		// we haven't published the first checkpoint ledger yet
-		// so we can run stellar-core run --in-memory without providing a starting point
-		// and captive core will start streaming from the genesis ledger
-		err = c.stellarCoreRunner.run()
-		nextLedger = 2
-	} else {
-		var runFrom uint32
-		var ledgerHash string
-		runFrom, ledgerHash, nextLedger, err = c.runFromParams(from)
-		if err != nil {
-			return errors.Wrap(err, "error calculating ledger and hash for stelar-core run")
-		}
-
-		err = c.stellarCoreRunner.runFrom(runFrom, ledgerHash)
+	runFrom, ledgerHash, nextLedger, err := c.runFromParams(from)
+	if err != nil {
+		return errors.Wrap(err, "error calculating ledger and hash for stelar-core run")
 	}
+
+	err = c.stellarCoreRunner.runFrom(runFrom, ledgerHash)
 	if err != nil {
 		return errors.Wrap(err, "error running stellar-core")
 	}
@@ -282,7 +268,8 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 	c.lastLedger = nil
 
 	if c.ledgerHashStore != nil {
-		ledgerHash, exists, err := c.ledgerHashStore.GetLedgerHash(nextLedger - 1)
+		var exists bool
+		ledgerHash, exists, err = c.ledgerHashStore.GetLedgerHash(nextLedger - 1)
 		if err != nil {
 			return errors.Wrapf(err, "error trying to read ledger hash %d", nextLedger-1)
 		}

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -254,12 +254,26 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 		}
 	}
 
-	runFrom, ledgerHash, nextLedger, err := c.runFromParams(from)
-	if err != nil {
-		return errors.Wrap(err, "error calculating ledger and hash for stelar-core run")
-	}
+	var nextLedger uint32
+	if latestCheckpointSequence == 0 {
+		if c.log != nil {
+			c.log.Info("checkpoint ledger has not been published, attempting to run from genesis ledger")
+		}
+		// we haven't published the first checkpoint ledger yet
+		// so we can run stellar-core run --in-memory without providing a starting point
+		// and captive core will start streaming from the genesis ledger
+		err = c.stellarCoreRunner.run()
+		nextLedger = 2
+	} else {
+		var runFrom uint32
+		var ledgerHash string
+		runFrom, ledgerHash, nextLedger, err = c.runFromParams(from)
+		if err != nil {
+			return errors.Wrap(err, "error calculating ledger and hash for stelar-core run")
+		}
 
-	err = c.stellarCoreRunner.runFrom(runFrom, ledgerHash)
+		err = c.stellarCoreRunner.runFrom(runFrom, ledgerHash)
+	}
 	if err != nil {
 		return errors.Wrap(err, "error running stellar-core")
 	}
@@ -268,8 +282,7 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 	c.lastLedger = nil
 
 	if c.ledgerHashStore != nil {
-		var exists bool
-		ledgerHash, exists, err = c.ledgerHashStore.GetLedgerHash(nextLedger - 1)
+		ledgerHash, exists, err := c.ledgerHashStore.GetLedgerHash(nextLedger - 1)
 		if err != nil {
 			return errors.Wrapf(err, "error trying to read ledger hash %d", nextLedger-1)
 		}

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -28,11 +28,6 @@ func (m *stellarCoreRunnerMock) catchup(from, to uint32) error {
 	return a.Error(0)
 }
 
-func (m *stellarCoreRunnerMock) run() error {
-	a := m.Called()
-	return a.Error(0)
-}
-
 func (m *stellarCoreRunnerMock) runFrom(from uint32, hash string) error {
 	a := m.Called(from, hash)
 	return a.Error(0)
@@ -405,47 +400,6 @@ func TestCaptivePrepareRangeUnboundedRange_ErrGettingRootHAS(t *testing.T) {
 
 	err := captiveBackend.PrepareRange(UnboundedRange(100))
 	assert.EqualError(t, err, "opening subprocess: error getting latest checkpoint sequence: error getting root HAS: transient error")
-}
-
-func TestCaptivePrepareRangeUnboundedRange_LatestCheckPointIsZero(t *testing.T) {
-	var buf bytes.Buffer
-	for i := 2; i <= 65; i++ {
-		writeLedgerHeader(&buf, testLedgerHeader{sequence: uint32(i)})
-	}
-
-	mockRunner := &stellarCoreRunnerMock{}
-	mockRunner.On("run").Return(nil).Once()
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("getProcessExitChan").Return(make(chan struct{}))
-	mockRunner.On("close").Return(nil).Once()
-
-	mockArchive := &historyarchive.MockArchive{}
-	mockArchive.
-		On("GetRootHAS").
-		Return(historyarchive.HistoryArchiveState{
-			CurrentLedger: uint32(0),
-		}, nil).Twice()
-
-	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		configPath:        "foo",
-		networkPassphrase: network.PublicNetworkPassphrase,
-		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
-			return mockRunner, nil
-		},
-	}
-
-	err := captiveBackend.PrepareRange(UnboundedRange(2))
-	assert.NoError(t, err)
-
-	assert.NoError(t, captiveBackend.Close())
-
-	mockRunner.On("run").Return(fmt.Errorf("transient error")).Once()
-	err = captiveBackend.PrepareRange(UnboundedRange(2))
-	assert.EqualError(t, err, "opening subprocess: error running stellar-core: transient error")
-
-	mockArchive.AssertExpectations(t)
-	mockRunner.AssertExpectations(t)
 }
 
 func TestCaptivePrepareRangeUnboundedRange_FromIsTooFarAheadOfLatestHAS(t *testing.T) {
@@ -1045,10 +999,8 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 		Return("", false, fmt.Errorf("transient error")).Once()
 	mockLedgerHashStore.On("GetLedgerHash", uint32(254)).
 		Return("", false, nil).Once()
-	mockLedgerHashStore.On("GetLedgerHash", uint32(2)).
-		Return("cde", true, nil).Once()
 	mockLedgerHashStore.On("GetLedgerHash", uint32(62)).
-		Return("jkl", true, nil).Once()
+		Return("cde", true, nil).Once()
 	mockLedgerHashStore.On("GetLedgerHash", uint32(126)).
 		Return("ghi", true, nil).Once()
 
@@ -1062,13 +1014,13 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 	runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(24)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(2), runFrom)
-	assert.Equal(t, "cde", ledgerHash)
+	assert.Equal(t, "", ledgerHash)
 	assert.Equal(t, uint32(2), nextLedger)
 
 	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(86)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(62), runFrom)
-	assert.Equal(t, "jkl", ledgerHash)
+	assert.Equal(t, "cde", ledgerHash)
 	assert.Equal(t, uint32(2), nextLedger)
 
 	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(128)

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -1091,11 +1091,7 @@ func TestCaptiveRunFromParams(t *testing.T) {
 			runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(tc.from)
 			tt.NoError(err)
 			tt.Equal(tc.runFrom, runFrom, "runFrom")
-			if tc.from <= 63 {
-				tt.Empty(ledgerHash)
-			} else {
-				tt.Equal("0101010100000000000000000000000000000000000000000000000000000000", ledgerHash)
-			}
+			tt.Equal("0101010100000000000000000000000000000000000000000000000000000000", ledgerHash)
 			tt.Equal(tc.nextLedger, nextLedger, "nextLedger")
 		})
 	}

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -28,6 +28,11 @@ func (m *stellarCoreRunnerMock) catchup(from, to uint32) error {
 	return a.Error(0)
 }
 
+func (m *stellarCoreRunnerMock) run() error {
+	a := m.Called()
+	return a.Error(0)
+}
+
 func (m *stellarCoreRunnerMock) runFrom(from uint32, hash string) error {
 	a := m.Called(from, hash)
 	return a.Error(0)
@@ -400,6 +405,47 @@ func TestCaptivePrepareRangeUnboundedRange_ErrGettingRootHAS(t *testing.T) {
 
 	err := captiveBackend.PrepareRange(UnboundedRange(100))
 	assert.EqualError(t, err, "opening subprocess: error getting latest checkpoint sequence: error getting root HAS: transient error")
+}
+
+func TestCaptivePrepareRangeUnboundedRange_LatestCheckPointIsZero(t *testing.T) {
+	var buf bytes.Buffer
+	for i := 2; i <= 65; i++ {
+		writeLedgerHeader(&buf, testLedgerHeader{sequence: uint32(i)})
+	}
+
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("run").Return(nil).Once()
+	mockRunner.On("getMetaPipe").Return(&buf)
+	mockRunner.On("getProcessExitChan").Return(make(chan struct{}))
+	mockRunner.On("close").Return(nil).Once()
+
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.
+		On("GetRootHAS").
+		Return(historyarchive.HistoryArchiveState{
+			CurrentLedger: uint32(0),
+		}, nil).Twice()
+
+	captiveBackend := CaptiveStellarCore{
+		archive:           mockArchive,
+		configPath:        "foo",
+		networkPassphrase: network.PublicNetworkPassphrase,
+		stellarCoreRunnerFactory: func(configPath string) (stellarCoreRunnerInterface, error) {
+			return mockRunner, nil
+		},
+	}
+
+	err := captiveBackend.PrepareRange(UnboundedRange(2))
+	assert.NoError(t, err)
+
+	assert.NoError(t, captiveBackend.Close())
+
+	mockRunner.On("run").Return(fmt.Errorf("transient error")).Once()
+	err = captiveBackend.PrepareRange(UnboundedRange(2))
+	assert.EqualError(t, err, "opening subprocess: error running stellar-core: transient error")
+
+	mockArchive.AssertExpectations(t)
+	mockRunner.AssertExpectations(t)
 }
 
 func TestCaptivePrepareRangeUnboundedRange_FromIsTooFarAheadOfLatestHAS(t *testing.T) {
@@ -999,8 +1045,10 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 		Return("", false, fmt.Errorf("transient error")).Once()
 	mockLedgerHashStore.On("GetLedgerHash", uint32(254)).
 		Return("", false, nil).Once()
-	mockLedgerHashStore.On("GetLedgerHash", uint32(62)).
+	mockLedgerHashStore.On("GetLedgerHash", uint32(2)).
 		Return("cde", true, nil).Once()
+	mockLedgerHashStore.On("GetLedgerHash", uint32(62)).
+		Return("jkl", true, nil).Once()
 	mockLedgerHashStore.On("GetLedgerHash", uint32(126)).
 		Return("ghi", true, nil).Once()
 
@@ -1014,13 +1062,13 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 	runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(24)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(2), runFrom)
-	assert.Equal(t, "", ledgerHash)
+	assert.Equal(t, "cde", ledgerHash)
 	assert.Equal(t, uint32(2), nextLedger)
 
 	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(86)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(62), runFrom)
-	assert.Equal(t, "cde", ledgerHash)
+	assert.Equal(t, "jkl", ledgerHash)
 	assert.Equal(t, uint32(2), nextLedger)
 
 	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(128)

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -978,6 +978,8 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 		Return("cde", true, nil).Once()
 	mockLedgerHashStore.On("GetLedgerHash", uint32(126)).
 		Return("ghi", true, nil).Once()
+	mockLedgerHashStore.On("GetLedgerHash", uint32(2)).
+		Return("mnb", true, nil).Once()
 
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
@@ -988,7 +990,7 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 	runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(24)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(2), runFrom)
-	assert.Equal(t, "", ledgerHash)
+	assert.Equal(t, "mnb", ledgerHash)
 	assert.Equal(t, uint32(2), nextLedger)
 
 	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(86)

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -234,17 +234,13 @@ func (r *stellarCoreRunner) runFrom(from uint32, hash string) error {
 		return errors.New("runner already started")
 	}
 	var err error
-	args := []string{
+	r.cmd, err = r.createCmd(
 		"run",
 		"--in-memory",
 		"--start-at-ledger", fmt.Sprintf("%d", from),
+		"--start-at-hash", hash,
 		"--metadata-output-stream", r.getPipeName(),
-	}
-	if hash != "" {
-		args = append(args, "--start-at-hash", hash)
-	}
-
-	r.cmd, err = r.createCmd(args...)
+	)
 	if err != nil {
 		return errors.Wrap(err, "error creating `stellar-core run` subprocess")
 	}

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -20,6 +20,7 @@ import (
 
 type stellarCoreRunnerInterface interface {
 	catchup(from, to uint32) error
+	run() error
 	runFrom(from uint32, hash string) error
 	getMetaPipe() io.Reader
 	// getProcessExitChan returns a channel that closes on process exit
@@ -239,6 +240,28 @@ func (r *stellarCoreRunner) runFrom(from uint32, hash string) error {
 		"--in-memory",
 		"--start-at-ledger", fmt.Sprintf("%d", from),
 		"--start-at-hash", hash,
+		"--metadata-output-stream", r.getPipeName(),
+	)
+	if err != nil {
+		return errors.Wrap(err, "error creating `stellar-core run` subprocess")
+	}
+	r.metaPipe, err = r.start()
+	if err != nil {
+		return errors.Wrap(err, "error starting `stellar-core run` subprocess")
+	}
+	r.started = true
+
+	return nil
+}
+
+func (r *stellarCoreRunner) run() error {
+	if r.started {
+		return errors.New("runner already started")
+	}
+	var err error
+	r.cmd, err = r.createCmd(
+		"run",
+		"--in-memory",
 		"--metadata-output-stream", r.getPipeName(),
 	)
 	if err != nil {

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -20,7 +20,6 @@ import (
 
 type stellarCoreRunnerInterface interface {
 	catchup(from, to uint32) error
-	run() error
 	runFrom(from uint32, hash string) error
 	getMetaPipe() io.Reader
 	// getProcessExitChan returns a channel that closes on process exit
@@ -240,28 +239,6 @@ func (r *stellarCoreRunner) runFrom(from uint32, hash string) error {
 		"--in-memory",
 		"--start-at-ledger", fmt.Sprintf("%d", from),
 		"--start-at-hash", hash,
-		"--metadata-output-stream", r.getPipeName(),
-	)
-	if err != nil {
-		return errors.Wrap(err, "error creating `stellar-core run` subprocess")
-	}
-	r.metaPipe, err = r.start()
-	if err != nil {
-		return errors.Wrap(err, "error starting `stellar-core run` subprocess")
-	}
-	r.started = true
-
-	return nil
-}
-
-func (r *stellarCoreRunner) run() error {
-	if r.started {
-		return errors.New("runner already started")
-	}
-	var err error
-	r.cmd, err = r.createCmd(
-		"run",
-		"--in-memory",
 		"--metadata-output-stream", r.getPipeName(),
 	)
 	if err != nil {

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -215,9 +215,8 @@ func (i *Test) waitForHorizon() {
 			continue
 		}
 
-		if root.HorizonSequence < 2 ||
-			int(root.HorizonSequence) != int(root.IngestSequence) ||
-			root.HorizonSequence < root.CoreSequence {
+		if root.HorizonSequence < 3 ||
+			int(root.HorizonSequence) != int(root.IngestSequence) {
 			i.t.Logf("Horizon ingesting... %v", root)
 			time.Sleep(time.Second)
 			continue


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

In https://github.com/stellar/go/pull/3201 we assumed it was possible to omit the `--start-at-hash` parameter when starting from the genesis ledger. However, Stellar Core actually fails when attempting that command. The `--start-at-hash` parameter is always required when using `--start-at-ledger`.

This means that if we want to stream from the genesis ledger we need to determine the either the horizon db or the history archives. 

~~In the case that the first checkpoint has not been published we attempt to invoke `stellar-core run --in-memory` without any start parameters. The expected behavior from stellar core is that it will join the network and stream from the nearest checkpoint boundary, which in this case would be the genesis ledger since the first checkpoint has not been published yet.~~

[edit:] I tested the behavior of `stellar-core run --in-memory` on a stand alone network and unfortunately stellar core will keep buffering ledgers until the first checkpoint is published before it starts streaming any ledgers. Therefore it does not make any sense to use this work around.

### Known limitations

N / A
