### PR TITLE
services/horizon/ingest: Close LedgerBackend in Shutdown

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -158,7 +158,10 @@ func (a *App) waitForDone() {
 	a.webServer.Shutdown(webShutdownCtx)
 	a.cancel()
 	if a.ingester != nil {
-		a.ingester.Shutdown()
+		err := a.ingester.Shutdown()
+		if err != nil {
+			log.WithField("error", err).Warn("error in ingester.Shutdown()")
+		}
 	}
 	a.ticks.Stop()
 }

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -119,7 +119,7 @@ type System interface {
 	VerifyRange(fromLedger, toLedger uint32, verifyState bool) error
 	ReingestRange(fromLedger, toLedger uint32, force bool) error
 	BuildGenesisState() error
-	Shutdown()
+	Shutdown() error
 }
 
 type system struct {
@@ -495,7 +495,7 @@ func (s *system) updateCursor(ledgerSequence uint32) error {
 	return nil
 }
 
-func (s *system) Shutdown() {
+func (s *system) Shutdown() error {
 	log.Info("Shutting down ingestion system...")
 	s.stateVerificationMutex.Lock()
 	defer s.stateVerificationMutex.Unlock()
@@ -503,6 +503,13 @@ func (s *system) Shutdown() {
 		log.Info("Shutting down state verifier...")
 	}
 	s.cancel()
+
+	if s.ledgerBackend != nil {
+		err := s.ledgerBackend.Close()
+		return errors.Wrap(err, "error closing ledger backend")
+	}
+
+	return nil
 }
 
 func markStateInvalid(historyQ history.IngestionQ, err error) {

--- a/services/horizon/internal/ingest/main_test.go
+++ b/services/horizon/internal/ingest/main_test.go
@@ -146,6 +146,22 @@ func TestContextCancel(t *testing.T) {
 	assert.NoError(t, system.runStateMachine(startState{}))
 }
 
+func TestShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ledgerBackend := &mockLedgerBackend{}
+
+	system := &system{
+		cancel:        cancel,
+		ctx:           ctx,
+		ledgerBackend: ledgerBackend,
+	}
+
+	ledgerBackend.On("Close").Return(nil).Once()
+
+	err := system.Shutdown()
+	assert.NoError(t, err)
+}
+
 // TestStateMachineRunReturnsErrorWhenNextStateIsShutdownWithError checks if the
 // state that goes to shutdownState and returns an error will make `run` function
 // return that error. This is essential because some commands rely on this to return
@@ -483,8 +499,9 @@ func (m *mockSystem) BuildGenesisState() error {
 	return args.Error(0)
 }
 
-func (m *mockSystem) Shutdown() {
-	m.Called()
+func (m *mockSystem) Shutdown() error {
+	args := m.Called()
+	return args.Error(0)
 }
 
 var _ System = (*mockSystem)(nil)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

TODO check if it works correctly with https://github.com/stellar/go/pull/3258.

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
