### PR TITLE
services/horizon: Add re-ingestion and resume integration tests

### DIFF
--- a/services/horizon/internal/ingest/parallel.go
+++ b/services/horizon/internal/ingest/parallel.go
@@ -52,6 +52,7 @@ func newParallelSystems(config Config, workerCount uint, systemFactory func(Conf
 }
 
 func (ps *ParallelSystems) runReingestWorker(s System, stop <-chan struct{}, reingestJobQueue <-chan ledgerRange) rangeError {
+
 	for {
 		select {
 		case <-stop:

--- a/services/horizon/internal/integration/db_test.go
+++ b/services/horizon/internal/integration/db_test.go
@@ -1,0 +1,83 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	horizoncmd "github.com/stellar/go/services/horizon/cmd"
+	"github.com/stellar/go/services/horizon/internal/db2/schema"
+	"github.com/stellar/go/services/horizon/internal/test/integration"
+	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/support/db/dbtest"
+	"github.com/stellar/go/txnbuild"
+)
+
+func initializeDBIntegrationTest(t *testing.T) (itest *integration.Test, reachedLedger int32) {
+	itest = integration.NewTest(t, protocol15Config)
+	master := itest.Master()
+	tt := assert.New(t)
+
+	// Initialize the database with some ledgers including some transactions we submit
+	op := txnbuild.Payment{
+		Destination: master.Address(),
+		Amount:      "10",
+		Asset:       txnbuild.NativeAsset{},
+	}
+	// TODO: should we enforce certain number of ledgers to be ingested?
+	for i := 0; i < 8; i++ {
+		txResp := itest.MustSubmitOperations(itest.MasterAccount(), master, &op)
+		reachedLedger = txResp.Ledger
+	}
+
+	root, err := itest.Client().Root()
+	tt.NoError(err)
+	tt.LessOrEqual(reachedLedger, root.HorizonSequence)
+
+	return
+}
+
+func TestReingestDB(t *testing.T) {
+	itest, reachedLedger := initializeDBIntegrationTest(t)
+	tt := assert.New(t)
+
+	// Create a fresh Horizon database
+	newDB := dbtest.Postgres(t)
+	// TODO: Unfortunately Horizon's ingestion System leaves open sessions behind,leading to
+	//       a "database  is being accessed by other users" error when trying to drop it
+	// defer newDB.Close()
+	freshHorizonPostgresURL := newDB.DSN
+	horizonConfig := itest.GetHorizonConfig()
+	horizonConfig.DatabaseURL = freshHorizonPostgresURL
+	// Initialize the DB schema
+	dbConn, err := db.Open("postgres", freshHorizonPostgresURL)
+	defer dbConn.Close()
+	_, err = schema.Migrate(dbConn.DB.DB, schema.MigrateUp, 0)
+	tt.NoError(err)
+
+	// Reingest into the DB
+	err = horizoncmd.RunDBReingestRange(1, uint32(reachedLedger), false, 1, horizonConfig)
+	tt.NoError(err)
+}
+
+func TestResumeFromInitializedDB(t *testing.T) {
+	itest, reachedLedger := initializeDBIntegrationTest(t)
+	tt := assert.New(t)
+
+	// Stop the integration test, and restart it with the same database
+	oldDBURL := itest.GetHorizonConfig().DatabaseURL
+	itestConfig := protocol15Config
+	itestConfig.PostgresURL = oldDBURL
+	itest.Shutdown()
+
+	itest = integration.NewTest(t, itestConfig)
+
+	successfullyResumed := func() bool {
+		root, err := itest.Client().Root()
+		tt.NoError(err)
+		return root.HorizonSequence >= reachedLedger
+	}
+
+	tt.Eventually(successfullyResumed, 1*time.Minute, 1*time.Second)
+}

--- a/services/horizon/internal/integration/db_test.go
+++ b/services/horizon/internal/integration/db_test.go
@@ -76,7 +76,9 @@ func TestResumeFromInitializedDB(t *testing.T) {
 	successfullyResumed := func() bool {
 		root, err := itest.Client().Root()
 		tt.NoError(err)
-		return root.HorizonSequence >= reachedLedger
+		// It must be able to reach the ledger and surpass it
+		const ledgersPastStopPoint = 4
+		return root.HorizonSequence > (reachedLedger + ledgersPastStopPoint)
 	}
 
 	tt.Eventually(successfullyResumed, 1*time.Minute, 1*time.Second)


### PR DESCRIPTION
They required:

1. Adding new integration test infrastructure to:
   * Shutdown the integration test early (needed for resuming a Horizon session)
   * Obtain the Horizon configuration (in order to reuse it with the re-ingest command)

2. Modifying the `db reingest range` command (in order to make it testeable). The flag-parsing
   part and intialization logic have been split out and the latter is used by the integration test.

Fixes https://github.com/stellar/go/issues/3248