### PR TITLE
ingest/ledgerbackend: Fix possible nil pointer when accessing captive core logger

### DIFF
--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -118,6 +118,7 @@ func main() {
 				NetworkPassphrase:  networkPassphrase,
 				HistoryArchiveURLs: historyArchiveURLs,
 				HTTPPort:           stellarCoreHTTPPort,
+				Log:                logger.WithField("subservice", "stellar-core"),
 			}
 
 			var dbConn *db.Session
@@ -134,7 +135,6 @@ func main() {
 			if err != nil {
 				logger.WithError(err).Fatal("Could not create captive core instance")
 			}
-			core.SetStellarCoreLogger(logger.WithField("subservice", "stellar-core"))
 			api := internal.NewCaptiveCoreAPI(core, logger.WithField("subservice", "api"))
 
 			supporthttp.Run(supporthttp.Config{

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/support/errors"
-	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -52,8 +51,6 @@ func (m *stellarCoreRunnerMock) close() error {
 	a := m.Called()
 	return a.Error(0)
 }
-
-func (m *stellarCoreRunnerMock) setLogger(*log.Entry) {}
 
 func buildLedgerCloseMeta(header testLedgerHeader) xdr.LedgerCloseMeta {
 	opResults := []xdr.OperationResult{}

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -175,8 +175,7 @@ func NewSystem(config Config) (System, error) {
 				return nil, errors.Wrap(err, "error creating captive core backend")
 			}
 		} else {
-			var captiveCoreBackend *ledgerbackend.CaptiveStellarCore
-			captiveCoreBackend, err = ledgerbackend.NewCaptive(
+			ledgerBackend, err = ledgerbackend.NewCaptive(
 				ledgerbackend.CaptiveCoreConfig{
 					BinaryPath:         config.CaptiveCoreBinaryPath,
 					ConfigAppendPath:   config.CaptiveCoreConfigAppendPath,
@@ -184,15 +183,13 @@ func NewSystem(config Config) (System, error) {
 					NetworkPassphrase:  config.NetworkPassphrase,
 					HistoryArchiveURLs: []string{config.HistoryArchiveURL},
 					LedgerHashStore:    ledgerbackend.NewHorizonDBLedgerHashStore(config.HistorySession),
+					Log:                log.WithField("subservice", "stellar-core"),
 				},
 			)
 			if err != nil {
 				cancel()
 				return nil, errors.Wrap(err, "error creating captive core backend")
 			}
-			captiveCoreBackend.SetStellarCoreLogger(
-				log.WithField("subservice", "stellar-core"))
-			ledgerBackend = captiveCoreBackend
 		}
 	} else {
 		coreSession := config.CoreSession.Clone()


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

There is a `log` field in the `stellarCoreRunner` struct. The field is considered optional and the intended behavior is that if `log` is nil then instead of using `log` to print a message we will print it to stdout using `fmt.Println()`.

However, when we generate the stellar core configuration file for captive core we print the file using `log.Debugf()`. This causes the code to panic because `log` can be nil.

To fix this bug I have refactored the code so that `log` is always non-nil. A custom logger can be provided to `stellarCoreRunner` via its constructor. And if the custom logger is omitted, the constructor will create a new logrus instance which is configured to print to standard out.

### Known limitations

[N/A]
