### PR TITLE
ingest/ledgerbackend: Place history section at the end of the captive core config file

### DIFF
--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -115,10 +115,7 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 		// We don't need consensus when catching up
 		lines = append(lines, "UNSAFE_QUORUM=true")
 	}
-	for i, val := range r.historyURLs {
-		lines = append(lines, fmt.Sprintf("[HISTORY.h%d]", i))
-		lines = append(lines, fmt.Sprintf(`get="curl -sf %s/{0} -o {1}"`, val))
-	}
+
 	if r.mode == stellarCoreRunnerModeOffline && r.configAppendPath == "" {
 		// Add a fictional quorum -- necessary to convince core to start up;
 		// but not used at all for our purposes. Pubkey here is just random.
@@ -127,14 +124,23 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 			"THRESHOLD_PERCENT=100",
 			`VALIDATORS=["GCZBOIAY4HLKAJVNJORXZOZRAY2BJDBZHKPBHZCRAIUR5IHC2UHBGCQR"]`)
 	}
+
 	result := strings.ReplaceAll(strings.Join(lines, "\n"), "\\", "\\\\")
 	if r.configAppendPath != "" {
 		appendConfigContents, err := ioutil.ReadFile(r.configAppendPath)
 		if err != nil {
 			return "", errors.Wrap(err, "reading quorum config file")
 		}
-		result = result + "\n" + string(appendConfigContents)
+		result = result + "\n" + string(appendConfigContents) + "\n\n"
 	}
+
+	lines = []string{}
+	for i, val := range r.historyURLs {
+		lines = append(lines, fmt.Sprintf("[HISTORY.h%d]", i))
+		lines = append(lines, fmt.Sprintf(`get="curl -sf %s/{0} -o {1}"`, val))
+	}
+	result += strings.Join(lines, "\n")
+
 	return result, nil
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

When using a captive core append file consisting of:

```
PEER_PORT=11725

UNSAFE_QUORUM=true
FAILURE_SAFETY=0

[[VALIDATORS]]
NAME="local_core"
HOME_DOMAIN="core.local"
# From "SACJC372QBSSKJYTV5A7LWT4NXWHTQO6GHG4QDAVC2XDPX6CNNXFZ4JK"
PUBLIC_KEY="GD5KD2KEZJIGTC63IGW6UMUSMVUVG5IHG64HUTFWCHVZH2N2IBOQN7PS"
ADDRESS="localhost"
QUALITY="MEDIUM"
```


Captive core crashes with the following error:

```
ERRO[2020-12-08T10:13:56.544+01:00] default: Got an exception: Failed to parse '/var/folders/kp/q0h17t117h98gz5lf4cqtylm0000gp/T/captive-stellar-core-4b1cf0c8a1267703/stellar-core.conf' :Unknown HISTORY-table entry: 'FAILURE_SAFETY', within [HISTORY.h0] [CommandLine.cpp:1064]  pid=55182 service=ingest subservice=stellar-core
```

To fix this, I moved the history section at the end of the generated captive core configuration file.

### Known limitations

[N/A]
