### PR TITLE
services/horizon/docker: Remove RUN_STANDALONE=true from stellare-core-standalone.cfg

### DIFF
--- a/services/horizon/docker/stellar-core-standalone.cfg
+++ b/services/horizon/docker/stellar-core-standalone.cfg
@@ -1,8 +1,6 @@
 # simple configuration for a standalone test "network"
 # see stellar-core_example.cfg for a description of the configuration parameters
 
-RUN_STANDALONE=true
-
 NETWORK_PASSPHRASE="Standalone Network ; February 2017"
 
 PEER_PORT=11625


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove `RUN_STANDALONE=true` from the stand alone configuration for the docker compose setup. 

### Why

When `RUN_STANDALONE` is set to true it prevents stellar core from accepting any peer connections. This prevents you from running a stand alone network with multiple core nodes. This also makes it impossible to run horizon with captive core on the stand alone network.

### Known limitations

[N/A]
