### PR TITLE
ingest/ledgerbackend: Clean up stellarCoreRunnerFactory

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -184,7 +184,7 @@ func TestCaptivePrepareRange(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -218,7 +218,7 @@ func TestCaptivePrepareRangeCrash(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -249,7 +249,7 @@ func TestCaptivePrepareRangeTerminated(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -330,7 +330,7 @@ func TestCaptivePrepareRange_ToIsAheadOfRootHAS(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -353,7 +353,7 @@ func TestCaptivePrepareRange_ErrCatchup(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -425,7 +425,7 @@ func TestCaptivePrepareRangeUnboundedRange_ErrRunFrom(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:          mockArchive,
 		configAppendPath: "foo",
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -486,7 +486,7 @@ func TestCaptivePrepareRangeUnboundedRange_ReuseSession(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:          mockArchive,
 		configAppendPath: "foo",
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -528,7 +528,7 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:          mockArchive,
 		configAppendPath: "foo",
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -584,7 +584,7 @@ func TestCaptiveGetLedger(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -648,7 +648,7 @@ func TestCaptiveGetLedger_NextLedgerIsDifferentToLedgerFromBuffer(t *testing.T) 
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -678,7 +678,7 @@ func TestCaptiveGetLedger_ErrReadingMetaResult(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -715,7 +715,7 @@ func TestCaptiveGetLedger_ErrClosingAfterLastLedger(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -755,7 +755,7 @@ func TestCaptiveGetLedger_BoundedGetLedgerAfterCoreExit(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -807,7 +807,7 @@ func TestCaptiveGetLedger_CloseBufferFull(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		archive:          mockArchive,
 		configAppendPath: "foo",
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -863,7 +863,7 @@ func TestGetLedgerBoundsCheck(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -933,7 +933,7 @@ func TestCaptiveGetLedgerTerminated(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 	}
@@ -1161,7 +1161,7 @@ func TestCaptivePreviousLedgerCheck(t *testing.T) {
 	captiveBackend := CaptiveStellarCore{
 		configAppendPath: "stellar-core.cfg",
 		archive:          mockArchive,
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode, _ string) (stellarCoreRunnerInterface, error) {
+		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 		ledgerHashStore: mockLedgerHashStore,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The stellarCoreRunnerFactory function can be simplified by removing the `captiveCoreConfigAppendPath string` argument. Also, I removed the `c.stellarCoreRunner == nil` check because it was not necessary.

### Known limitations

[N/A]
