### PR TITLE
all: Parameterize the checkpoint frequency

### DIFF
--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -110,7 +110,7 @@ func main() {
 			OptType:     types.Uint32,
 			FlagDefault: uint32(64),
 			Required:    false,
-			Usage:       "establishes how many ledgers exist between checkpoints, do NOT change this if you really know what you are doing",
+			Usage:       "establishes how many ledgers exist between checkpoints, do NOT change this unless you really know what you are doing",
 		},
 	}
 	cmd := &cobra.Command{

--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -23,6 +23,7 @@ func main() {
 	var networkPassphrase, binaryPath, configAppendPath, dbURL string
 	var historyArchiveURLs []string
 	var stellarCoreHTTPPort uint
+	var checkpointFrequency uint32
 	var logLevel logrus.Level
 	logger := supportlog.New()
 
@@ -103,6 +104,14 @@ func main() {
 			Required:    false,
 			Usage:       "HTTP port for captive core to listen on (0 disables the HTTP server)",
 		},
+		&config.ConfigOption{
+			Name:        "checkpoint-frequency",
+			ConfigKey:   &checkpointFrequency,
+			OptType:     types.Uint32,
+			FlagDefault: uint32(64),
+			Required:    false,
+			Usage:       "establishes how many ledgers exist between checkpoints, do NOT change this if you really know what you are doing",
+		},
 	}
 	cmd := &cobra.Command{
 		Use:   "captivecore",
@@ -113,12 +122,13 @@ func main() {
 			logger.SetLevel(logLevel)
 
 			captiveConfig := ledgerbackend.CaptiveCoreConfig{
-				BinaryPath:         binaryPath,
-				ConfigAppendPath:   configAppendPath,
-				NetworkPassphrase:  networkPassphrase,
-				HistoryArchiveURLs: historyArchiveURLs,
-				HTTPPort:           stellarCoreHTTPPort,
-				Log:                logger.WithField("subservice", "stellar-core"),
+				BinaryPath:          binaryPath,
+				ConfigAppendPath:    configAppendPath,
+				NetworkPassphrase:   networkPassphrase,
+				HistoryArchiveURLs:  historyArchiveURLs,
+				CheckpointFrequency: checkpointFrequency,
+				HTTPPort:            stellarCoreHTTPPort,
+				Log:                 logger.WithField("subservice", "stellar-core"),
 			}
 
 			var dbConn *db.Session

--- a/exp/tools/captive-core-start-tester/main.go
+++ b/exp/tools/captive-core-start-tester/main.go
@@ -25,10 +25,11 @@ func main() {
 func check(ledger uint32) bool {
 	c, err := ledgerbackend.NewCaptive(
 		ledgerbackend.CaptiveCoreConfig{
-			BinaryPath:         "stellar-core",
-			ConfigAppendPath:   "stellar-core-standalone2.cfg",
-			NetworkPassphrase:  "Standalone Network ; February 2017",
-			HistoryArchiveURLs: []string{"http://localhost:1570"},
+			BinaryPath:          "stellar-core",
+			ConfigAppendPath:    "stellar-core-standalone2.cfg",
+			NetworkPassphrase:   "Standalone Network ; February 2017",
+			HistoryArchiveURLs:  []string{"http://localhost:1570"},
+			CheckpointFrequency: 64,
 		},
 	)
 	if err != nil {

--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -44,6 +44,8 @@ type ConnectOptions struct {
 	S3Region          string
 	S3Endpoint        string
 	UnsignedRequests  bool
+	// The checkpoint frequency will be 64 unless you are using an exotic test setup.
+	CheckpointFrequency uint32
 }
 
 type ArchiveBackend interface {
@@ -71,6 +73,7 @@ type ArchiveInterface interface {
 	ListCategoryCheckpoints(cat string, pth string) (chan uint32, chan error)
 	GetXdrStreamForHash(hash Hash) (*XdrStream, error)
 	GetXdrStream(pth string) (*XdrStream, error)
+	GetCheckpointManager() CheckpointManager
 }
 
 var _ ArchiveInterface = &Archive{}
@@ -96,7 +99,13 @@ type Archive struct {
 	invalidTxSets       int
 	invalidTxResultSets int
 
+	checkpointManager CheckpointManager
+
 	backend ArchiveBackend
+}
+
+func (arch *Archive) GetCheckpointManager() CheckpointManager {
+	return arch.checkpointManager
 }
 
 func (a *Archive) GetPathHAS(path string) (HistoryArchiveState, error) {
@@ -153,8 +162,8 @@ func (a *Archive) CategoryCheckpointExists(cat string, chk uint32) (bool, error)
 
 func (a *Archive) GetLedgerHeader(ledger uint32) (xdr.LedgerHeaderHistoryEntry, error) {
 	checkpoint := ledger
-	if !IsCheckpoint(checkpoint) {
-		checkpoint = NextCheckpoint(ledger)
+	if !a.checkpointManager.IsCheckpoint(checkpoint) {
+		checkpoint = a.checkpointManager.NextCheckpoint(ledger)
 	}
 	path := CategoryCheckpointPath("ledger", checkpoint)
 	xdrStream, err := a.GetXdrStream(path)
@@ -275,6 +284,9 @@ func (a *Archive) GetXdrStream(pth string) (*XdrStream, error) {
 }
 
 func Connect(u string, opts ConnectOptions) (*Archive, error) {
+	if opts.CheckpointFrequency == 0 {
+		return nil, errors.New("uninitialized checkpoint frequency")
+	}
 	arch := Archive{
 		networkPassphrase:       opts.NetworkPassphrase,
 		checkpointFiles:         make(map[string](map[uint32]bool)),
@@ -286,6 +298,7 @@ func Connect(u string, opts ConnectOptions) (*Archive, error) {
 		actualTxSetHashes:       make(map[uint32]Hash),
 		expectTxResultSetHashes: make(map[uint32]Hash),
 		actualTxResultSetHashes: make(map[uint32]Hash),
+		checkpointManager:       NewCheckpointManager(opts.CheckpointFrequency),
 	}
 	for _, cat := range Categories() {
 		arch.checkpointFiles[cat] = make(map[uint32]bool)

--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -44,7 +44,8 @@ type ConnectOptions struct {
 	S3Region          string
 	S3Endpoint        string
 	UnsignedRequests  bool
-	// The checkpoint frequency will be 64 unless you are using an exotic test setup.
+	// CheckpointFrequency is the number of ledgers between checkpoints
+	// if unset, DefaultCheckpointFrequency will be used
 	CheckpointFrequency uint32
 }
 
@@ -284,9 +285,6 @@ func (a *Archive) GetXdrStream(pth string) (*XdrStream, error) {
 }
 
 func Connect(u string, opts ConnectOptions) (*Archive, error) {
-	if opts.CheckpointFrequency == 0 {
-		return nil, errors.New("uninitialized checkpoint frequency")
-	}
 	arch := Archive{
 		networkPassphrase:       opts.NetworkPassphrase,
 		checkpointFiles:         make(map[string](map[uint32]bool)),

--- a/historyarchive/archive_test.go
+++ b/historyarchive/archive_test.go
@@ -34,11 +34,11 @@ func GetTestS3Archive() *Archive {
 	if env_region := os.Getenv("ARCHIVIST_TEST_S3_REGION"); env_region != "" {
 		region = env_region
 	}
-	return MustConnect(bucket, ConnectOptions{S3Region: region})
+	return MustConnect(bucket, ConnectOptions{S3Region: region, CheckpointFrequency: 64})
 }
 
 func GetTestMockArchive() *Archive {
-	return MustConnect("mock://test", ConnectOptions{})
+	return MustConnect("mock://test", ConnectOptions{CheckpointFrequency: 64})
 }
 
 var tmpdirs []string
@@ -53,7 +53,7 @@ func GetTestFileArchive() *Archive {
 	} else {
 		tmpdirs = append(tmpdirs, d)
 	}
-	return MustConnect("file://"+d, ConnectOptions{})
+	return MustConnect("file://"+d, ConnectOptions{CheckpointFrequency: 64})
 }
 
 func cleanup() {
@@ -129,7 +129,7 @@ func (arch *Archive) AddRandomCheckpoint(chk uint32) error {
 }
 
 func (arch *Archive) PopulateRandomRange(rng Range) error {
-	for chk := range rng.GenerateCheckpoints() {
+	for chk := range rng.GenerateCheckpoints(arch.checkpointManager) {
 		if e := arch.AddRandomCheckpoint(chk); e != nil {
 			return e
 		}
@@ -162,7 +162,7 @@ func TestScanSize(t *testing.T) {
 	opts := testOptions()
 	arch := GetRandomPopulatedArchive()
 	arch.Scan(opts)
-	assert.Equal(t, opts.Range.SizeInCheckPoints(),
+	assert.Equal(t, opts.Range.SizeInCheckPoints(arch.checkpointManager),
 		len(arch.checkpointFiles["history"]))
 }
 
@@ -170,10 +170,10 @@ func TestScanSizeSubrange(t *testing.T) {
 	defer cleanup()
 	opts := testOptions()
 	arch := GetRandomPopulatedArchive()
-	opts.Range.Low = NextCheckpoint(opts.Range.Low)
-	opts.Range.High = PrevCheckpoint(opts.Range.High)
+	opts.Range.Low = arch.checkpointManager.NextCheckpoint(opts.Range.Low)
+	opts.Range.High = arch.checkpointManager.PrevCheckpoint(opts.Range.High)
 	arch.Scan(opts)
-	assert.Equal(t, opts.Range.SizeInCheckPoints(),
+	assert.Equal(t, opts.Range.SizeInCheckPoints(arch.checkpointManager),
 		len(arch.checkpointFiles["history"]))
 }
 
@@ -234,7 +234,7 @@ func TestMirrorThenRepair(t *testing.T) {
 	dst := GetTestArchive()
 	Mirror(src, dst, opts)
 	assert.Equal(t, 0, countMissing(dst, opts))
-	bad := opts.Range.Low + uint32(opts.Range.SizeInCheckPoints()/2)
+	bad := opts.Range.Low + uint32(opts.Range.SizeInCheckPoints(src.checkpointManager)/2)
 	src.AddRandomCheckpoint(bad)
 	copyFile("history", bad, src, dst)
 	assert.NotEqual(t, 0, countMissing(dst, opts))
@@ -258,7 +258,7 @@ func TestMirrorSubsetDoPointerUpdate(t *testing.T) {
 	Mirror(src, dst, opts)
 	oldHigh := opts.Range.High
 	assert.Equal(t, oldHigh, dst.MustGetRootHAS().CurrentLedger)
-	opts.Range.High = NextCheckpoint(oldHigh)
+	opts.Range.High = src.checkpointManager.NextCheckpoint(oldHigh)
 	src.AddRandomCheckpoint(opts.Range.High)
 	Mirror(src, dst, opts)
 	assert.Equal(t, opts.Range.High, dst.MustGetRootHAS().CurrentLedger)
@@ -272,7 +272,7 @@ func TestMirrorSubsetNoPointerUpdate(t *testing.T) {
 	Mirror(src, dst, opts)
 	oldHigh := opts.Range.High
 	assert.Equal(t, oldHigh, dst.MustGetRootHAS().CurrentLedger)
-	src.AddRandomCheckpoint(NextCheckpoint(oldHigh))
+	src.AddRandomCheckpoint(src.checkpointManager.NextCheckpoint(oldHigh))
 	opts.Range.Low = 0x7f
 	opts.Range.High = 0xff
 	Mirror(src, dst, opts)
@@ -286,7 +286,7 @@ func TestDryRunNoRepair(t *testing.T) {
 	dst := GetTestArchive()
 	Mirror(src, dst, opts)
 	assert.Equal(t, 0, countMissing(dst, opts))
-	bad := opts.Range.Low + uint32(opts.Range.SizeInCheckPoints()/2)
+	bad := opts.Range.Low + uint32(opts.Range.SizeInCheckPoints(src.checkpointManager)/2)
 	src.AddRandomCheckpoint(bad)
 	copyFile("history", bad, src, dst)
 	assert.NotEqual(t, 0, countMissing(dst, opts))
@@ -316,7 +316,7 @@ func TestNetworkPassphrase(t *testing.T) {
 	}
 
 	// No network passphrase set in options
-	archive := MustConnect("mock://test", ConnectOptions{})
+	archive := MustConnect("mock://test", ConnectOptions{CheckpointFrequency: 64})
 	err := archive.backend.PutFile("has.json", makeHASReader())
 	assert.NoError(t, err)
 	_, err = archive.GetPathHAS("has.json")
@@ -324,7 +324,8 @@ func TestNetworkPassphrase(t *testing.T) {
 
 	// No network passphrase set in HAS
 	archive = MustConnect("mock://test", ConnectOptions{
-		NetworkPassphrase: "Public Global Stellar Network ; September 2015",
+		NetworkPassphrase:   "Public Global Stellar Network ; September 2015",
+		CheckpointFrequency: 64,
 	})
 	err = archive.backend.PutFile("has.json", makeHASReaderNoNetwork())
 	assert.NoError(t, err)
@@ -333,7 +334,8 @@ func TestNetworkPassphrase(t *testing.T) {
 
 	// Correct network passphrase set in options
 	archive = MustConnect("mock://test", ConnectOptions{
-		NetworkPassphrase: "Public Global Stellar Network ; September 2015",
+		NetworkPassphrase:   "Public Global Stellar Network ; September 2015",
+		CheckpointFrequency: 64,
 	})
 	err = archive.backend.PutFile("has.json", makeHASReader())
 	assert.NoError(t, err)
@@ -342,7 +344,8 @@ func TestNetworkPassphrase(t *testing.T) {
 
 	// Incorrect network passphrase set in options
 	archive = MustConnect("mock://test", ConnectOptions{
-		NetworkPassphrase: "Test SDF Network ; September 2015",
+		NetworkPassphrase:   "Test SDF Network ; September 2015",
+		CheckpointFrequency: 64,
 	})
 	err = archive.backend.PutFile("has.json", makeHASReader())
 	assert.NoError(t, err)

--- a/historyarchive/archive_test.go
+++ b/historyarchive/archive_test.go
@@ -129,7 +129,7 @@ func (arch *Archive) AddRandomCheckpoint(chk uint32) error {
 }
 
 func (arch *Archive) PopulateRandomRange(rng Range) error {
-	for chk := range rng.Checkpoints() {
+	for chk := range rng.GenerateCheckpoints() {
 		if e := arch.AddRandomCheckpoint(chk); e != nil {
 			return e
 		}
@@ -162,7 +162,7 @@ func TestScanSize(t *testing.T) {
 	opts := testOptions()
 	arch := GetRandomPopulatedArchive()
 	arch.Scan(opts)
-	assert.Equal(t, opts.Range.Size(),
+	assert.Equal(t, opts.Range.SizeInCheckPoints(),
 		len(arch.checkpointFiles["history"]))
 }
 
@@ -173,7 +173,7 @@ func TestScanSizeSubrange(t *testing.T) {
 	opts.Range.Low = NextCheckpoint(opts.Range.Low)
 	opts.Range.High = PrevCheckpoint(opts.Range.High)
 	arch.Scan(opts)
-	assert.Equal(t, opts.Range.Size(),
+	assert.Equal(t, opts.Range.SizeInCheckPoints(),
 		len(arch.checkpointFiles["history"]))
 }
 
@@ -234,7 +234,7 @@ func TestMirrorThenRepair(t *testing.T) {
 	dst := GetTestArchive()
 	Mirror(src, dst, opts)
 	assert.Equal(t, 0, countMissing(dst, opts))
-	bad := opts.Range.Low + uint32(opts.Range.Size()/2)
+	bad := opts.Range.Low + uint32(opts.Range.SizeInCheckPoints()/2)
 	src.AddRandomCheckpoint(bad)
 	copyFile("history", bad, src, dst)
 	assert.NotEqual(t, 0, countMissing(dst, opts))
@@ -286,7 +286,7 @@ func TestDryRunNoRepair(t *testing.T) {
 	dst := GetTestArchive()
 	Mirror(src, dst, opts)
 	assert.Equal(t, 0, countMissing(dst, opts))
-	bad := opts.Range.Low + uint32(opts.Range.Size()/2)
+	bad := opts.Range.Low + uint32(opts.Range.SizeInCheckPoints()/2)
 	src.AddRandomCheckpoint(bad)
 	copyFile("history", bad, src, dst)
 	assert.NotEqual(t, 0, countMissing(dst, opts))

--- a/historyarchive/log.go
+++ b/historyarchive/log.go
@@ -94,7 +94,7 @@ func (arch *Archive) Log(opts *CommandOptions) error {
 	if e != nil {
 		return e
 	}
-	opts.Range = opts.Range.clamp(state.Range())
+	opts.Range = opts.Range.clamp(state.Range(), arch.checkpointManager)
 
 	log.SetFlags(0)
 	log.Printf("Log of checkpoint files in range: %s", opts.Range)
@@ -102,12 +102,12 @@ func (arch *Archive) Log(opts *CommandOptions) error {
 	log.Printf("%10s | %10s | %20s | %5s | %s",
 		"ledger", "hex", "close time", "txs", "buckets changed")
 
-	prevHas, err := arch.GetCheckpointHAS(PrevCheckpoint(opts.Range.Low))
+	prevHas, err := arch.GetCheckpointHAS(arch.checkpointManager.PrevCheckpoint(opts.Range.Low))
 	if err != nil {
 		return err
 	}
 
-	for chk := range opts.Range.Checkpoints() {
+	for chk := range opts.Range.GenerateCheckpoints(arch.checkpointManager) {
 		has, err := arch.GetCheckpointHAS(chk)
 		if err != nil {
 			return err

--- a/historyarchive/mocks.go
+++ b/historyarchive/mocks.go
@@ -11,7 +11,8 @@ type MockArchive struct {
 }
 
 func (m *MockArchive) GetCheckpointManager() CheckpointManager {
-	panic("implement me")
+	a := m.Called()
+	return a.Get(0).(CheckpointManager)
 }
 
 func (m *MockArchive) GetPathHAS(path string) (HistoryArchiveState, error) {

--- a/historyarchive/mocks.go
+++ b/historyarchive/mocks.go
@@ -10,6 +10,10 @@ type MockArchive struct {
 	mock.Mock
 }
 
+func (m *MockArchive) GetCheckpointManager() CheckpointManager {
+	panic("implement me")
+}
+
 func (m *MockArchive) GetPathHAS(path string) (HistoryArchiveState, error) {
 	a := m.Called(path)
 	return a.Get(0).(HistoryArchiveState), a.Error(1)

--- a/historyarchive/range.go
+++ b/historyarchive/range.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 )
 
+const DefaultCheckpointFrequency = uint32(64)
+
 type Range struct {
 	Low  uint32
 	High uint32
@@ -19,7 +21,13 @@ type CheckpointManager struct {
 	checkpointFreq uint32
 }
 
+// NewCheckpointManager creates a CheckpointManager based on a checkpoint frequency
+// (the number of ledgers between ledger checkpoints). If checkpointFrequency is
+// 0 DefaultCheckpointFrequency will be used.
 func NewCheckpointManager(checkpointFrequency uint32) CheckpointManager {
+	if checkpointFrequency == 0 {
+		checkpointFrequency = DefaultCheckpointFrequency
+	}
 	return CheckpointManager{checkpointFrequency}
 }
 

--- a/historyarchive/range.go
+++ b/historyarchive/range.go
@@ -10,30 +10,36 @@ import (
 	"strings"
 )
 
-const CheckpointFreq = uint32(64)
-
 type Range struct {
 	Low  uint32
 	High uint32
 }
 
-func IsCheckpoint(i uint32) bool {
-	return (i+1)%CheckpointFreq == 0
+type CheckpointManager struct {
+	checkpointFreq uint32
 }
 
-func PrevCheckpoint(i uint32) uint32 {
-	freq := CheckpointFreq
+func NewCheckpointManager(checkpointFrequency uint32) CheckpointManager {
+	return CheckpointManager{checkpointFrequency}
+}
+
+func (c CheckpointManager) IsCheckpoint(i uint32) bool {
+	return (i+1)%c.checkpointFreq == 0
+}
+
+func (c CheckpointManager) PrevCheckpoint(i uint32) uint32 {
+	freq := c.checkpointFreq
 	if i < freq {
 		return freq - 1
 	}
 	return (((i + 1) / freq) * freq) - 1
 }
 
-func NextCheckpoint(i uint32) uint32 {
+func (c CheckpointManager) NextCheckpoint(i uint32) uint32 {
 	if i == 0 {
-		return CheckpointFreq - 1
+		return c.checkpointFreq - 1
 	}
-	freq := uint64(CheckpointFreq)
+	freq := uint64(c.checkpointFreq)
 	v := uint64(i)
 	n := (((v + freq) / freq) * freq) - 1
 	if n >= 0xffffffff {
@@ -42,17 +48,31 @@ func NextCheckpoint(i uint32) uint32 {
 	return uint32(n)
 }
 
-func MakeRange(low uint32, high uint32) Range {
+// GetCheckPoint gets the checkpoint containing information about the given ledger sequence
+func (c CheckpointManager) GetCheckpoint(i uint32) uint32 {
+	return c.NextCheckpoint(i)
+}
+
+// GetCheckpointRange gets the range of the checkpoint containing information for the given ledger sequence
+func (c CheckpointManager) GetCheckpointRange(i uint32) Range {
+	checkpoint := c.GetCheckpoint(i)
+	return Range{
+		Low:  checkpoint - c.checkpointFreq + 1,
+		High: checkpoint,
+	}
+}
+
+func (c CheckpointManager) MakeRange(low uint32, high uint32) Range {
 	if high < low {
 		high = low
 	}
 	return Range{
-		Low:  PrevCheckpoint(low),
-		High: NextCheckpoint(high),
+		Low:  c.PrevCheckpoint(low),
+		High: c.NextCheckpoint(high),
 	}
 }
 
-func (r Range) clamp(other Range) Range {
+func (r Range) clamp(other Range, cManager CheckpointManager) Range {
 	low := r.Low
 	high := r.High
 	if low < other.Low {
@@ -61,17 +81,17 @@ func (r Range) clamp(other Range) Range {
 	if high > other.High {
 		high = other.High
 	}
-	return MakeRange(low, high)
+	return cManager.MakeRange(low, high)
 }
 
 func (r Range) String() string {
 	return fmt.Sprintf("[0x%8.8x, 0x%8.8x]", r.Low, r.High)
 }
 
-func (r Range) Checkpoints() chan uint32 {
+func (r Range) GenerateCheckpoints(cManager CheckpointManager) chan uint32 {
 	ch := make(chan uint32)
 	go func() {
-		for i := uint64(r.Low); i <= uint64(r.High); i += uint64(CheckpointFreq) {
+		for i := uint64(r.Low); i <= uint64(r.High); i += uint64(cManager.checkpointFreq) {
 			ch <- uint32(i)
 		}
 		close(ch)
@@ -79,8 +99,8 @@ func (r Range) Checkpoints() chan uint32 {
 	return ch
 }
 
-func (r Range) Size() int {
-	return 1 + (int(r.High-r.Low) / int(CheckpointFreq))
+func (r Range) SizeInCheckPoints(cManager CheckpointManager) int {
+	return 1 + (int(r.High-r.Low) / int(cManager.checkpointFreq))
 }
 
 func (r Range) collapsedString() string {
@@ -91,13 +111,17 @@ func (r Range) collapsedString() string {
 	}
 }
 
+func (r Range) InRange(sequence uint32) bool {
+	return sequence >= r.Low && sequence <= r.High
+}
+
 type byUint32 []uint32
 
 func (a byUint32) Len() int           { return len(a) }
 func (a byUint32) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a byUint32) Less(i, j int) bool { return a[i] < a[j] }
 
-func fmtRangeList(vs []uint32) string {
+func fmtRangeList(vs []uint32, cManager CheckpointManager) string {
 
 	sort.Sort(byUint32(vs))
 
@@ -106,7 +130,7 @@ func fmtRangeList(vs []uint32) string {
 
 	for _, t := range vs {
 		if curr != nil {
-			if curr.High+CheckpointFreq == t {
+			if curr.High+cManager.checkpointFreq == t {
 				curr.High = t
 				continue
 			} else {

--- a/historyarchive/range.go
+++ b/historyarchive/range.go
@@ -56,8 +56,13 @@ func (c CheckpointManager) GetCheckpoint(i uint32) uint32 {
 // GetCheckpointRange gets the range of the checkpoint containing information for the given ledger sequence
 func (c CheckpointManager) GetCheckpointRange(i uint32) Range {
 	checkpoint := c.GetCheckpoint(i)
+	low := checkpoint - c.checkpointFreq + 1
+	if low == 0 {
+		// ledger 0 does not exist
+		low++
+	}
 	return Range{
-		Low:  checkpoint - c.checkpointFreq + 1,
+		Low:  low,
 		High: checkpoint,
 	}
 }

--- a/historyarchive/range_test.go
+++ b/historyarchive/range_test.go
@@ -12,7 +12,7 @@ import (
 
 func (r Range) allCheckpoints() []uint32 {
 	var s []uint32
-	for chk := range r.Checkpoints() {
+	for chk := range r.GenerateCheckpoints() {
 		s = append(s, chk)
 	}
 	return s

--- a/historyarchive/range_test.go
+++ b/historyarchive/range_test.go
@@ -12,75 +12,83 @@ import (
 
 func (r Range) allCheckpoints() []uint32 {
 	var s []uint32
-	for chk := range r.GenerateCheckpoints() {
+	mgr := NewCheckpointManager(64)
+	for chk := range r.GenerateCheckpoints(mgr) {
 		s = append(s, chk)
 	}
 	return s
 }
 
 func TestRangeSize(t *testing.T) {
+	mgr := NewCheckpointManager(64)
+
 	assert.Equal(t, 1,
-		MakeRange(0x3f, 0x3f).Size())
+		mgr.MakeRange(0x3f, 0x3f).SizeInCheckPoints(mgr))
 
 	assert.Equal(t, 2,
-		MakeRange(0x3f, 0x7f).Size())
+		mgr.MakeRange(0x3f, 0x7f).SizeInCheckPoints(mgr))
 
 	assert.Equal(t, 2,
-		MakeRange(0, 100).Size())
+		mgr.MakeRange(0, 100).SizeInCheckPoints(mgr))
 
 	assert.Equal(t, 4,
-		MakeRange(0xff3f, 0xffff).Size())
+		mgr.MakeRange(0xff3f, 0xffff).SizeInCheckPoints(mgr))
 }
 
 func TestRangeEnumeration(t *testing.T) {
-	assert.Equal(t,
-		[]uint32{0x3f, 0x7f},
-		MakeRange(0x3f, 0x7f).allCheckpoints())
 
-	assert.Equal(t,
-		[]uint32{0x3f},
-		MakeRange(0x3f, 0x3f).allCheckpoints())
-
-	assert.Equal(t,
-		[]uint32{0x3f},
-		MakeRange(0, 0).allCheckpoints())
+	mgr := NewCheckpointManager(64)
 
 	assert.Equal(t,
 		[]uint32{0x3f, 0x7f},
-		MakeRange(0, 0x40).allCheckpoints())
+		mgr.MakeRange(0x3f, 0x7f).allCheckpoints())
+
+	assert.Equal(t,
+		[]uint32{0x3f},
+		mgr.MakeRange(0x3f, 0x3f).allCheckpoints())
+
+	assert.Equal(t,
+		[]uint32{0x3f},
+		mgr.MakeRange(0, 0).allCheckpoints())
+
+	assert.Equal(t,
+		[]uint32{0x3f, 0x7f},
+		mgr.MakeRange(0, 0x40).allCheckpoints())
 
 	assert.Equal(t,
 		[]uint32{0xff},
-		MakeRange(0xff, 0x40).allCheckpoints())
+		mgr.MakeRange(0xff, 0x40).allCheckpoints())
 }
 
 func TestFmtRangeList(t *testing.T) {
 
+	mgr := NewCheckpointManager(64)
+
 	assert.Equal(t,
 		"",
-		fmtRangeList([]uint32{}))
+		fmtRangeList([]uint32{}, mgr))
 
 	assert.Equal(t,
 		"0x0000003f",
-		fmtRangeList([]uint32{0x3f}))
+		fmtRangeList([]uint32{0x3f}, mgr))
 
 	assert.Equal(t,
 		"[0x0000003f-0x0000007f]",
-		fmtRangeList([]uint32{0x3f, 0x7f}))
+		fmtRangeList([]uint32{0x3f, 0x7f}, mgr))
 
 	assert.Equal(t,
 		"[0x0000003f-0x000000bf]",
-		fmtRangeList([]uint32{0x3f, 0x7f, 0xbf}))
+		fmtRangeList([]uint32{0x3f, 0x7f, 0xbf}, mgr))
 
 	assert.Equal(t,
 		"[0x0000003f-0x0000007f], 0x000000ff",
-		fmtRangeList([]uint32{0x3f, 0x7f, 0xff}))
+		fmtRangeList([]uint32{0x3f, 0x7f, 0xff}, mgr))
 
 	assert.Equal(t,
 		"[0x0000003f-0x0000007f], [0x000000ff-0x0000017f]",
-		fmtRangeList([]uint32{0x3f, 0x7f, 0xff, 0x13f, 0x17f}))
+		fmtRangeList([]uint32{0x3f, 0x7f, 0xff, 0x13f, 0x17f}, mgr))
 
 	assert.Equal(t,
 		"[0x0000003f-0x0000007f], 0x000000ff, [0x0000017f-0x000001bf]",
-		fmtRangeList([]uint32{0x3f, 0x7f, 0xff, 0x17f, 0x1bf}))
+		fmtRangeList([]uint32{0x3f, 0x7f, 0xff, 0x17f, 0x1bf}, mgr))
 }

--- a/historyarchive/repair.go
+++ b/historyarchive/repair.go
@@ -9,12 +9,14 @@ import (
 	"log"
 )
 
+// Repair repairs a destination archive based on a source archive, it assumes that the source and destination have the
+// same checkpoint ledger frequency
 func Repair(src *Archive, dst *Archive, opts *CommandOptions) error {
 	state, e := dst.GetRootHAS()
 	if e != nil {
 		return e
 	}
-	opts.Range = opts.Range.clamp(state.Range())
+	opts.Range = opts.Range.clamp(state.Range(), src.checkpointManager)
 
 	log.Printf("Starting scan for repair")
 	var errs uint32

--- a/ingest/adapters/history_archive_adapter_test.go
+++ b/ingest/adapters/history_archive_adapter_test.go
@@ -38,8 +38,9 @@ func getTestArchive() (*historyarchive.Archive, error) {
 	return historyarchive.Connect(
 		fmt.Sprintf("s3://history.stellar.org/prd/core-live/core_live_001/"),
 		historyarchive.ConnectOptions{
-			S3Region:         "eu-west-1",
-			UnsignedRequests: true,
+			S3Region:            "eu-west-1",
+			UnsignedRequests:    true,
+			CheckpointFrequency: 64,
 		},
 	)
 }

--- a/ingest/doc_test.go
+++ b/ingest/doc_test.go
@@ -104,10 +104,11 @@ func Example_changes() {
 	// Requires Stellar-Core 13.2.0+
 	backend, err := ledgerbackend.NewCaptive(
 		ledgerbackend.CaptiveCoreConfig{
-			BinaryPath:         "/bin/stellar-core",
-			ConfigAppendPath:   "/opt/stellar-core.cfg",
-			NetworkPassphrase:  networkPassphrase,
-			HistoryArchiveURLs: []string{archiveURL},
+			BinaryPath:          "/bin/stellar-core",
+			ConfigAppendPath:    "/opt/stellar-core.cfg",
+			NetworkPassphrase:   networkPassphrase,
+			HistoryArchiveURLs:  []string{archiveURL},
+			CheckpointFrequency: 64,
 		},
 	)
 	if err != nil {

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -14,14 +14,14 @@ import (
 // Ensure CaptiveStellarCore implements LedgerBackend
 var _ LedgerBackend = (*CaptiveStellarCore)(nil)
 
-func roundDownToFirstReplayAfterCheckpointStart(ledger uint32) uint32 {
-	v := (ledger / ledgersPerCheckpoint) * ledgersPerCheckpoint
-	if v == 0 {
+func (c *CaptiveStellarCore) roundDownToFirstReplayAfterCheckpointStart(ledger uint32) uint32 {
+	r := c.checkpointManager.GetCheckpointRange(ledger)
+	if r.Low == 0 {
 		// Stellar-Core doesn't stream ledger 1
 		return 2
 	}
 	// All other checkpoints start at the next multiple of 64
-	return v
+	return r.Low
 }
 
 // CaptiveStellarCore is a ledger backend that starts internal Stellar-Core
@@ -62,9 +62,10 @@ func roundDownToFirstReplayAfterCheckpointStart(ledger uint32) uint32 {
 //
 // Requires Stellar-Core v13.2.0+.
 type CaptiveStellarCore struct {
-	configAppendPath string
-	archive          historyarchive.ArchiveInterface
-	ledgerHashStore  TrustedLedgerHashStore
+	configAppendPath  string
+	archive           historyarchive.ArchiveInterface
+	checkpointManager historyarchive.CheckpointManager
+	ledgerHashStore   TrustedLedgerHashStore
 
 	// Quick note on how shutdown works:
 	// If Stellar-Core exits, the exit signal is "catched" by bufferedLedgerMetaReader
@@ -107,6 +108,8 @@ type CaptiveCoreConfig struct {
 	NetworkPassphrase string
 	// HistoryArchiveURLs are a list of history archive urls
 	HistoryArchiveURLs []string
+	// CheckpointFrequency is the number of ledgers between checkpoints
+	CheckpointFrequency uint32
 	// LedgerHashStore is an optional store used to obtain hashes for ledger sequences from a trusted source
 	LedgerHashStore TrustedLedgerHashStore
 	// HTTPPort is the TCP port to listen for requests (defaults to 0, which disables the HTTP server)
@@ -124,7 +127,8 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	archive, err := historyarchive.Connect(
 		config.HistoryArchiveURLs[0],
 		historyarchive.ConnectOptions{
-			NetworkPassphrase: config.NetworkPassphrase,
+			NetworkPassphrase:   config.NetworkPassphrase,
+			CheckpointFrequency: config.CheckpointFrequency,
 		},
 	)
 	if err != nil {
@@ -136,6 +140,7 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 		configAppendPath:         config.ConfigAppendPath,
 		waitIntervalPrepareRange: time.Second,
 		ledgerHashStore:          config.LedgerHashStore,
+		checkpointManager:        historyarchive.NewCheckpointManager(config.CheckpointFrequency),
 	}
 	c.stellarCoreRunnerFactory = func(mode stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 		return newStellarCoreRunner(config, mode)
@@ -185,7 +190,7 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 
 	// The next ledger should be the first ledger of the checkpoint containing
 	// the requested ledger
-	c.nextLedger = roundDownToFirstReplayAfterCheckpointStart(from)
+	c.nextLedger = c.roundDownToFirstReplayAfterCheckpointStart(from)
 	c.lastLedger = &to
 	c.blocking = true
 
@@ -216,7 +221,7 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 	// checkpoints from now. Such requests are likely buggy.
 	// We should allow only one checkpoint here but sometimes there are up to a
 	// minute delays when updating root HAS by stellar-core.
-	maxLedger := latestCheckpointSequence + 2*64
+	maxLedger := c.checkpointManager.NextCheckpoint(c.checkpointManager.NextCheckpoint(latestCheckpointSequence))
 	if from > maxLedger {
 		return errors.Errorf(
 			"trying to start online mode too far (latest checkpoint=%d), only two checkpoints in the future allowed",
@@ -298,8 +303,8 @@ func (c *CaptiveStellarCore) runFromParams(from uint32) (runFrom uint32, ledgerH
 	} else {
 		// For ledgers after the first checkpoint, start at the previous checkpoint
 		// and fast-forward from there.
-		if !historyarchive.IsCheckpoint(from) {
-			from = historyarchive.PrevCheckpoint(from)
+		if !c.checkpointManager.IsCheckpoint(from) {
+			from = c.checkpointManager.PrevCheckpoint(from)
 		}
 		// Streaming will start from the previous checkpoint + 1
 		nextLedger = from - 63

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -221,7 +221,8 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 	// checkpoints from now. Such requests are likely buggy.
 	// We should allow only one checkpoint here but sometimes there are up to a
 	// minute delays when updating root HAS by stellar-core.
-	maxLedger := c.checkpointManager.NextCheckpoint(c.checkpointManager.NextCheckpoint(latestCheckpointSequence))
+	twoCheckPointsLength := (c.checkpointManager.GetCheckpoint(0) + 1) * 2
+	maxLedger := latestCheckpointSequence + twoCheckPointsLength
 	if from > maxLedger {
 		return errors.Errorf(
 			"trying to start online mode too far (latest checkpoint=%d), only two checkpoints in the future allowed",

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -109,6 +109,7 @@ type CaptiveCoreConfig struct {
 	// HistoryArchiveURLs are a list of history archive urls
 	HistoryArchiveURLs []string
 	// CheckpointFrequency is the number of ledgers between checkpoints
+	// if unset, DefaultCheckpointFrequency will be used
 	CheckpointFrequency uint32
 	// LedgerHashStore is an optional store used to obtain hashes for ledger sequences from a trusted source
 	LedgerHashStore TrustedLedgerHashStore

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -145,10 +145,11 @@ func TestCaptiveNew(t *testing.T) {
 
 	captiveStellarCore, err := NewCaptive(
 		CaptiveCoreConfig{
-			BinaryPath:         executablePath,
-			ConfigAppendPath:   configPath,
-			NetworkPassphrase:  networkPassphrase,
-			HistoryArchiveURLs: historyURLs,
+			BinaryPath:          executablePath,
+			ConfigAppendPath:    configPath,
+			NetworkPassphrase:   networkPassphrase,
+			HistoryArchiveURLs:  historyURLs,
+			CheckpointFrequency: 64,
 		},
 	)
 

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -188,6 +188,7 @@ func TestCaptivePrepareRange(t *testing.T) {
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
@@ -222,6 +223,7 @@ func TestCaptivePrepareRangeCrash(t *testing.T) {
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
@@ -253,6 +255,7 @@ func TestCaptivePrepareRangeTerminated(t *testing.T) {
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
@@ -334,6 +337,7 @@ func TestCaptivePrepareRange_ToIsAheadOfRootHAS(t *testing.T) {
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
@@ -400,7 +404,8 @@ func TestCaptivePrepareRangeUnboundedRange_FromIsTooFarAheadOfLatestHAS(t *testi
 		}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive: mockArchive,
+		archive:           mockArchive,
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	err := captiveBackend.PrepareRange(UnboundedRange(193))
@@ -429,6 +434,7 @@ func TestCaptivePrepareRangeUnboundedRange_ErrRunFrom(t *testing.T) {
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	err := captiveBackend.PrepareRange(UnboundedRange(128))
@@ -455,6 +461,7 @@ func TestCaptivePrepareRangeUnboundedRange_ErrClosingExistingSession(t *testing.
 		nextLedger:        63,
 		lastLedger:        &last,
 		stellarCoreRunner: mockRunner,
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	err := captiveBackend.PrepareRange(UnboundedRange(64))
@@ -490,6 +497,7 @@ func TestCaptivePrepareRangeUnboundedRange_ReuseSession(t *testing.T) {
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	err := captiveBackend.PrepareRange(UnboundedRange(65))
@@ -532,6 +540,7 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	err := captiveBackend.PrepareRange(UnboundedRange(64))
@@ -588,6 +597,7 @@ func TestCaptiveGetLedger(t *testing.T) {
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	// requires PrepareRange
@@ -652,6 +662,7 @@ func TestCaptiveGetLedger_NextLedgerIsDifferentToLedgerFromBuffer(t *testing.T) 
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(65, 66))
@@ -682,6 +693,7 @@ func TestCaptiveGetLedger_ErrReadingMetaResult(t *testing.T) {
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(65, 66))
@@ -719,6 +731,7 @@ func TestCaptiveGetLedger_ErrClosingAfterLastLedger(t *testing.T) {
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(65, 66))
@@ -759,6 +772,7 @@ func TestCaptiveGetLedger_BoundedGetLedgerAfterCoreExit(t *testing.T) {
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(65, 70))
@@ -811,6 +825,7 @@ func TestCaptiveGetLedger_CloseBufferFull(t *testing.T) {
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	err := captiveBackend.PrepareRange(UnboundedRange(65))
@@ -867,6 +882,7 @@ func TestGetLedgerBoundsCheck(t *testing.T) {
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(128, 130))
@@ -937,6 +953,7 @@ func TestCaptiveGetLedgerTerminated(t *testing.T) {
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	go writeLedgerHeader(writer, testLedgerHeader{sequence: 64})
@@ -983,6 +1000,7 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 		archive:           mockArchive,
 		stellarCoreRunner: mockRunner,
 		ledgerHashStore:   mockLedgerHashStore,
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(24)
@@ -1059,6 +1077,7 @@ func TestCaptiveRunFromParams(t *testing.T) {
 			captiveBackend := CaptiveStellarCore{
 				archive:           mockArchive,
 				stellarCoreRunner: mockRunner,
+				checkpointManager: historyarchive.NewCheckpointManager(64),
 			}
 
 			runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(tc.from)
@@ -1165,7 +1184,8 @@ func TestCaptivePreviousLedgerCheck(t *testing.T) {
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
-		ledgerHashStore: mockLedgerHashStore,
+		ledgerHashStore:   mockLedgerHashStore,
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	err := captiveBackend.PrepareRange(UnboundedRange(300))

--- a/ingest/ledgerbackend/history_archive_backend.go
+++ b/ingest/ledgerbackend/history_archive_backend.go
@@ -31,7 +31,7 @@ const (
 
 // NewHistoryArchiveBackendFromURL builds a new HistoryArchiveBackend using
 // history archive URL.
-// The checkpoint frequency will be 64 unless you are using an exotic test setup.
+// If unsure, leave checkpointFrequency at 0, the DefaultCheckpointFrequency will be used
 func NewHistoryArchiveBackendFromURL(archiveURL string, checkpointFrequency uint32) (*HistoryArchiveBackend, error) {
 	archive, err := historyarchive.Connect(
 		archiveURL,

--- a/ingest/ledgerbackend/history_archive_backend.go
+++ b/ingest/ledgerbackend/history_archive_backend.go
@@ -17,9 +17,8 @@ import (
 type HistoryArchiveBackend struct {
 	archive historyarchive.ArchiveInterface
 
-	rangeFrom uint32
-	rangeTo   uint32
-	cache     map[uint32]*xdr.LedgerCloseMeta
+	cachedRange historyarchive.Range
+	cache       map[uint32]*xdr.LedgerCloseMeta
 }
 
 var _ LedgerBackend = (*HistoryArchiveBackend)(nil)
@@ -32,10 +31,14 @@ const (
 
 // NewHistoryArchiveBackendFromURL builds a new HistoryArchiveBackend using
 // history archive URL.
-func NewHistoryArchiveBackendFromURL(archiveURL string) (*HistoryArchiveBackend, error) {
+// The checkpoint frequency will be 64 unless you are using an exotic test setup.
+func NewHistoryArchiveBackendFromURL(archiveURL string, checkpointFrequency uint32) (*HistoryArchiveBackend, error) {
 	archive, err := historyarchive.Connect(
 		archiveURL,
-		historyarchive.ConnectOptions{Context: context.Background()},
+		historyarchive.ConnectOptions{
+			Context:             context.Background(),
+			CheckpointFrequency: checkpointFrequency,
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -85,9 +88,8 @@ func (hab *HistoryArchiveBackend) IsPrepared(ledgerRange Range) (bool, error) {
 // for other ledgers within the same checkpoint are fast, requesting another checkpoint is
 // slow again.
 func (hab *HistoryArchiveBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMeta, error) {
-	if !(sequence >= hab.rangeFrom && sequence <= hab.rangeTo) {
-		checkpointSequence := (sequence/ledgersPerCheckpoint)*ledgersPerCheckpoint + ledgersPerCheckpoint - 1
-		found, err := hab.loadTransactionsFromCheckpoint(checkpointSequence)
+	if !hab.cachedRange.InRange(sequence) {
+		found, err := hab.loadCheckpointTransactionsOf(sequence)
 		if err != nil {
 			return false, xdr.LedgerCloseMeta{}, err
 		}
@@ -103,9 +105,12 @@ func (hab *HistoryArchiveBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCl
 	return true, *meta, nil
 }
 
-func (hab *HistoryArchiveBackend) loadTransactionsFromCheckpoint(checkpointSequence uint32) (bool, error) {
-	hab.rangeFrom = 0
-	hab.rangeTo = 0
+func (hab *HistoryArchiveBackend) loadCheckpointTransactionsOf(sequence uint32) (bool, error) {
+	// reset range
+	hab.cachedRange = historyarchive.Range{}
+
+	checkpointRange := hab.archive.GetCheckpointManager().GetCheckpointRange(sequence)
+	checkpointSequence := checkpointRange.High
 
 	ledgerExists, err := hab.archive.CategoryCheckpointExists("ledger", checkpointSequence)
 	if err != nil {
@@ -128,7 +133,7 @@ func (hab *HistoryArchiveBackend) loadTransactionsFromCheckpoint(checkpointSeque
 		return false, errors.New("history archive broken, some categories do not exist")
 	}
 
-	// ledger must be fetched first because it initalizes LedgerCloseMeta for
+	// ledger must be fetched first because it initializes LedgerCloseMeta for
 	// a given sequence.
 	categories := []string{ledgerCategory, transactionsCategory, resultsCategory}
 	for _, category := range categories {
@@ -138,12 +143,7 @@ func (hab *HistoryArchiveBackend) loadTransactionsFromCheckpoint(checkpointSeque
 		}
 	}
 
-	if checkpointSequence >= ledgersPerCheckpoint {
-		hab.rangeFrom = checkpointSequence - ledgersPerCheckpoint + 1
-	} else {
-		hab.rangeFrom = 1
-	}
-	hab.rangeTo = checkpointSequence
+	hab.cachedRange = checkpointRange
 
 	return true, nil
 }
@@ -195,8 +195,7 @@ func (hab *HistoryArchiveBackend) fetchCategory(category string, checkpointSeque
 
 // Close clears and resets internal state.
 func (hab *HistoryArchiveBackend) Close() error {
-	hab.rangeFrom = 0
-	hab.rangeTo = 0
+	hab.cachedRange = historyarchive.Range{}
 	hab.cache = make(map[uint32]*xdr.LedgerCloseMeta)
 	return nil
 }

--- a/ingest/ledgerbackend/history_archive_backend_test.go
+++ b/ingest/ledgerbackend/history_archive_backend_test.go
@@ -82,6 +82,7 @@ func (s *HistoryArchiveBackendTestSuite) TestGetLedger() {
 		})
 	}
 
+	s.mockArchive.On("GetCheckpointManager").Return(historyarchive.NewCheckpointManager(64))
 	s.mockArchive.On("CategoryCheckpointExists", "ledger", uint32(127)).Return(true, nil).Once()
 	s.mockArchive.On("CategoryCheckpointExists", "transactions", uint32(127)).Return(true, nil).Once()
 	s.mockArchive.On("CategoryCheckpointExists", "results", uint32(127)).Return(true, nil).Once()
@@ -93,8 +94,8 @@ func (s *HistoryArchiveBackendTestSuite) TestGetLedger() {
 	exists, _, err := s.backend.GetLedger(100)
 	s.Require().NoError(err)
 	s.Assert().True(exists)
-	s.Assert().Equal(uint32(64), s.backend.rangeFrom)
-	s.Assert().Equal(uint32(127), s.backend.rangeTo)
+	s.Assert().Equal(uint32(64), s.backend.cachedRange.Low)
+	s.Assert().Equal(uint32(127), s.backend.cachedRange.High)
 
 	for sequence := uint32(64); sequence <= 127; sequence++ {
 		var err2 error
@@ -113,8 +114,8 @@ func (s *HistoryArchiveBackendTestSuite) TestGetLedger() {
 
 	err = s.backend.Close()
 	s.Require().NoError(err)
-	s.Assert().Zero(s.backend.rangeFrom)
-	s.Assert().Zero(s.backend.rangeTo)
+	s.Assert().Zero(s.backend.cachedRange.Low)
+	s.Assert().Zero(s.backend.cachedRange.High)
 	s.Assert().Empty(s.backend.cache)
 }
 
@@ -156,6 +157,7 @@ func (s *HistoryArchiveBackendTestSuite) TestGetLedgerFirstCheckpoint() {
 		})
 	}
 
+	s.mockArchive.On("GetCheckpointManager").Return(historyarchive.NewCheckpointManager(64))
 	s.mockArchive.On("CategoryCheckpointExists", "ledger", uint32(63)).Return(true, nil).Once()
 	s.mockArchive.On("CategoryCheckpointExists", "transactions", uint32(63)).Return(true, nil).Once()
 	s.mockArchive.On("CategoryCheckpointExists", "results", uint32(63)).Return(true, nil).Once()
@@ -167,8 +169,8 @@ func (s *HistoryArchiveBackendTestSuite) TestGetLedgerFirstCheckpoint() {
 	exists, _, err := s.backend.GetLedger(60)
 	s.Require().NoError(err)
 	s.Assert().True(exists)
-	s.Assert().Equal(uint32(1), s.backend.rangeFrom)
-	s.Assert().Equal(uint32(63), s.backend.rangeTo)
+	s.Assert().Equal(uint32(1), s.backend.cachedRange.Low)
+	s.Assert().Equal(uint32(63), s.backend.cachedRange.High)
 
 	for sequence := uint32(1); sequence <= 63; sequence++ {
 		var err2 error
@@ -187,8 +189,8 @@ func (s *HistoryArchiveBackendTestSuite) TestGetLedgerFirstCheckpoint() {
 
 	err = s.backend.Close()
 	s.Require().NoError(err)
-	s.Assert().Zero(s.backend.rangeFrom)
-	s.Assert().Zero(s.backend.rangeTo)
+	s.Assert().Zero(s.backend.cachedRange.Low)
+	s.Assert().Zero(s.backend.cachedRange.High)
 	s.Assert().Empty(s.backend.cache)
 }
 

--- a/ingest/ledgerbackend/ledger_backend.go
+++ b/ingest/ledgerbackend/ledger_backend.go
@@ -7,8 +7,6 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-const ledgersPerCheckpoint = 64
-
 // Range represents a range of ledger sequence numbers.
 type Range struct {
 	from    uint32

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -243,6 +243,7 @@ func RunDBReingestRange(from, to uint32, reingestForce bool, parallelWorkers uin
 		NetworkPassphrase:           config.NetworkPassphrase,
 		HistorySession:              horizonSession,
 		HistoryArchiveURL:           config.HistoryArchiveURLs[0],
+		CheckpointFrequency:         config.CheckpointFrequency,
 		MaxReingestRetries:          int(retries),
 		ReingestRetryBackoffSeconds: int(retryBackoffSeconds),
 		EnableCaptiveCore:           config.EnableCaptiveCoreIngestion,

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -89,12 +89,12 @@ var ingestVerifyRangeCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("cannot open Horizon DB: %v", err)
 		}
-
-		if !historyarchive.IsCheckpoint(ingestVerifyFrom) && ingestVerifyFrom != 1 {
+		mngr := historyarchive.NewCheckpointManager(config.CheckpointFrequency)
+		if !mngr.IsCheckpoint(ingestVerifyFrom) && ingestVerifyFrom != 1 {
 			log.Fatal("`--from` must be a checkpoint ledger")
 		}
 
-		if ingestVerifyState && !historyarchive.IsCheckpoint(ingestVerifyTo) {
+		if ingestVerifyState && !mngr.IsCheckpoint(ingestVerifyTo) {
 			log.Fatal("`--to` must be a checkpoint ledger when `--verify-state` is set.")
 		}
 
@@ -105,6 +105,7 @@ var ingestVerifyRangeCmd = &cobra.Command{
 			EnableCaptiveCore:     config.EnableCaptiveCoreIngestion,
 			CaptiveCoreBinaryPath: config.CaptiveCoreBinaryPath,
 			RemoteCaptiveCoreURL:  config.RemoteCaptiveCoreURL,
+			CheckpointFrequency:   config.CheckpointFrequency,
 		}
 
 		if !ingestConfig.EnableCaptiveCore {
@@ -266,10 +267,11 @@ var ingestInitGenesisStateCmd = &cobra.Command{
 		}
 
 		ingestConfig := ingest.Config{
-			NetworkPassphrase: config.NetworkPassphrase,
-			HistorySession:    horizonSession,
-			HistoryArchiveURL: config.HistoryArchiveURLs[0],
-			EnableCaptiveCore: config.EnableCaptiveCoreIngestion,
+			NetworkPassphrase:   config.NetworkPassphrase,
+			HistorySession:      horizonSession,
+			HistoryArchiveURL:   config.HistoryArchiveURLs[0],
+			EnableCaptiveCore:   config.EnableCaptiveCoreIngestion,
+			CheckpointFrequency: config.CheckpointFrequency,
 		}
 
 		if config.EnableCaptiveCoreIngestion {

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -71,4 +71,6 @@ type Config struct {
 	// ApplyMigrations will apply pending migrations to the horizon database
 	// before starting the horizon service
 	ApplyMigrations bool
+	// CheckpointFrequency establishes how many ledgers exist between checkpoints
+	CheckpointFrequency uint32
 }

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -368,7 +368,7 @@ func Flags() (*Config, support.ConfigOptions) {
 			OptType:     types.Uint32,
 			FlagDefault: uint32(64),
 			Required:    false,
-			Usage:       "establishes how many ledgers exist between checkpoints, do NOT change this if you really know what you are doing",
+			Usage:       "establishes how many ledgers exist between checkpoints, do NOT change this unless you really know what you are doing",
 		},
 	}
 

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -362,6 +362,14 @@ func Flags() (*Config, support.ConfigOptions) {
 			Required:    false,
 			Usage:       "applies pending migrations before starting horizon",
 		},
+		&support.ConfigOption{
+			Name:        "checkpoint-frequency",
+			ConfigKey:   &config.CheckpointFrequency,
+			OptType:     types.Uint32,
+			FlagDefault: uint32(64),
+			Required:    false,
+			Usage:       "establishes how many ledgers exist between checkpoints, do NOT change this if you really know what you are doing",
+		},
 	}
 
 	return config, flags

--- a/services/horizon/internal/ingest/db_integration_test.go
+++ b/services/horizon/internal/ingest/db_integration_test.go
@@ -83,6 +83,7 @@ func (s *DBTestSuite) SetupTest() {
 		HistorySession:           s.tt.HorizonSession(),
 		HistoryArchiveURL:        "http://ignore.test",
 		DisableStateVerification: false,
+		CheckpointFrequency:      64,
 	})
 	s.Assert().NoError(err)
 	s.system = sIface.(*system)

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -79,6 +79,9 @@ type Config struct {
 
 	MaxReingestRetries          int
 	ReingestRetryBackoffSeconds int
+
+	// The checkpoint frequency will be 64 unless you are using an exotic test setup.
+	CheckpointFrequency uint32
 }
 
 const (
@@ -149,16 +152,22 @@ type system struct {
 	stateVerificationErrors  int
 	stateVerificationRunning bool
 	disableStateVerification bool
+
+	checkpointManager historyarchive.CheckpointManager
 }
 
 func NewSystem(config Config) (System, error) {
+	if config.CheckpointFrequency == 0 {
+		return nil, errors.New("uninitialized checkpoint frequency")
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 
 	archive, err := historyarchive.Connect(
 		config.HistoryArchiveURL,
 		historyarchive.ConnectOptions{
-			Context:           ctx,
-			NetworkPassphrase: config.NetworkPassphrase,
+			Context:             ctx,
+			NetworkPassphrase:   config.NetworkPassphrase,
+			CheckpointFrequency: config.CheckpointFrequency,
 		},
 	)
 	if err != nil {
@@ -226,6 +235,7 @@ func NewSystem(config Config) (System, error) {
 			historyAdapter: historyAdapter,
 			ledgerBackend:  ledgerBackend,
 		},
+		checkpointManager: historyarchive.NewCheckpointManager(config.CheckpointFrequency),
 	}
 
 	system.initMetrics()
@@ -432,7 +442,7 @@ func (s *system) maybeVerifyState(lastIngestedLedger uint32) {
 	// Run verification routine only when...
 	if !stateInvalid && // state has not been proved to be invalid...
 		!s.disableStateVerification && // state verification is not disabled...
-		historyarchive.IsCheckpoint(lastIngestedLedger) { // it's a checkpoint ledger.
+		s.checkpointManager.IsCheckpoint(lastIngestedLedger) { // it's a checkpoint ledger.
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -157,9 +157,6 @@ type system struct {
 }
 
 func NewSystem(config Config) (System, error) {
-	if config.CheckpointFrequency == 0 {
-		return nil, errors.New("uninitialized checkpoint frequency")
-	}
 	ctx, cancel := context.WithCancel(context.Background())
 
 	archive, err := historyarchive.Connect(

--- a/services/horizon/internal/ingest/main_test.go
+++ b/services/horizon/internal/ingest/main_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest/adapters"
 	"github.com/stellar/go/ingest/io"
 	"github.com/stellar/go/ingest/ledgerbackend"
@@ -88,6 +89,7 @@ func TestNewSystem(t *testing.T) {
 		},
 		DisableStateVerification: true,
 		HistoryArchiveURL:        "https://history.stellar.org/prd/core-live/core_live_001",
+		CheckpointFrequency:      64,
 	}
 
 	sIface, err := NewSystem(config)
@@ -167,8 +169,9 @@ func TestStateMachineRunReturnsErrorWhenNextStateIsShutdownWithError(t *testing.
 func TestMaybeVerifyStateGetExpStateInvalidDBErrCancelOrContextCanceled(t *testing.T) {
 	historyQ := &mockDBQ{}
 	system := &system{
-		historyQ: historyQ,
-		ctx:      context.Background(),
+		historyQ:          historyQ,
+		ctx:               context.Background(),
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	var out bytes.Buffer
@@ -193,8 +196,9 @@ func TestMaybeVerifyStateGetExpStateInvalidDBErrCancelOrContextCanceled(t *testi
 func TestMaybeVerifyInternalDBErrCancelOrContextCanceled(t *testing.T) {
 	historyQ := &mockDBQ{}
 	system := &system{
-		historyQ: historyQ,
-		ctx:      context.Background(),
+		historyQ:          historyQ,
+		ctx:               context.Background(),
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
 	var out bytes.Buffer

--- a/services/horizon/internal/ingest/resume_state_test.go
+++ b/services/horizon/internal/ingest/resume_state_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest/adapters"
 	"github.com/stellar/go/ingest/io"
 	"github.com/stellar/go/ingest/ledgerbackend"
@@ -41,6 +42,7 @@ func (s *ResumeTestTestSuite) SetupTest() {
 		runner:            s.runner,
 		ledgerBackend:     s.ledgerBackend,
 		stellarCoreClient: s.stellarCoreClient,
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 	s.system.initMetrics()
 

--- a/services/horizon/internal/ingest/verify.go
+++ b/services/horizon/internal/ingest/verify.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/guregu/null"
-	"github.com/stellar/go/historyarchive"
+
 	ingesterrors "github.com/stellar/go/ingest/errors"
 	"github.com/stellar/go/ingest/verify"
 	"github.com/stellar/go/services/horizon/internal/db2"
@@ -79,7 +79,7 @@ func (s *system) verifyState(verifyAgainstLatestCheckpoint bool) error {
 		"ledger":     ledgerSequence,
 	})
 
-	if !historyarchive.IsCheckpoint(ledgerSequence) {
+	if !s.checkpointManager.IsCheckpoint(ledgerSequence) {
 		localLog.Info("Current ledger is not a checkpoint ledger. Cancelling...")
 		return nil
 	}

--- a/services/horizon/internal/ingest/verify_range_state_test.go
+++ b/services/horizon/internal/ingest/verify_range_state_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest/adapters"
 	ingestio "github.com/stellar/go/ingest/io"
 	"github.com/stellar/go/ingest/ledgerbackend"
@@ -39,11 +40,12 @@ func (s *VerifyRangeStateTestSuite) SetupTest() {
 	s.historyAdapter = &adapters.MockHistoryArchiveAdapter{}
 	s.runner = &mockProcessorsRunner{}
 	s.system = &system{
-		ctx:            context.Background(),
-		historyQ:       s.historyQ,
-		historyAdapter: s.historyAdapter,
-		ledgerBackend:  s.ledgerBackend,
-		runner:         s.runner,
+		ctx:               context.Background(),
+		historyQ:          s.historyQ,
+		historyAdapter:    s.historyAdapter,
+		ledgerBackend:     s.ledgerBackend,
+		runner:            s.runner,
+		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 	s.system.initMetrics()
 

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -65,6 +65,7 @@ func initExpIngester(app *App) {
 		// Use the first archive for now. We don't have a mechanism to
 		// use multiple archives at the same time currently.
 		HistoryArchiveURL:           app.config.HistoryArchiveURLs[0],
+		CheckpointFrequency:         app.config.CheckpointFrequency,
 		StellarCoreURL:              app.config.StellarCoreURL,
 		StellarCoreCursor:           app.config.CursorName,
 		CaptiveCoreBinaryPath:       app.config.CaptiveCoreBinaryPath,

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -181,6 +181,8 @@ of accounts, subscribe to event streams and more.`,
 		"--apply-migrations",
 		"--admin-port",
 		strconv.Itoa(i.AdminPort()),
+		"--checkpoint-frequency",
+		"8", // due to ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING
 	})
 	var err error
 	if err = configOpts.Init(cmd); err != nil {

--- a/tools/stellar-archivist/main_test.go
+++ b/tools/stellar-archivist/main_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestLastOption(t *testing.T) {
-	src_arch := historyarchive.MustConnect("mock://test", historyarchive.ConnectOptions{})
+	src_arch := historyarchive.MustConnect("mock://test", historyarchive.ConnectOptions{CheckpointFrequency: 64})
 	assert.NotEqual(t, nil, src_arch)
 
 	var src_has historyarchive.HistoryArchiveState
@@ -28,8 +28,8 @@ func TestLastOption(t *testing.T) {
 }
 
 func TestRecentOption(t *testing.T) {
-	src_arch := historyarchive.MustConnect("mock://test1", historyarchive.ConnectOptions{})
-	dst_arch := historyarchive.MustConnect("mock://test2", historyarchive.ConnectOptions{})
+	src_arch := historyarchive.MustConnect("mock://test1", historyarchive.ConnectOptions{CheckpointFrequency: 64})
+	dst_arch := historyarchive.MustConnect("mock://test2", historyarchive.ConnectOptions{CheckpointFrequency: 64})
 	assert.NotEqual(t, nil, src_arch)
 	assert.NotEqual(t, nil, dst_arch)
 


### PR DESCRIPTION
It used to be hardcoded to 64 (which is what _normal_ Stellar Core).

However, when using ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING in integration tests, the frequency is reduced to 8.

Followup to #3264 