### PR TITLE
support/http: add option for adding tcp keep alive to server

### DIFF
--- a/support/http/main.go
+++ b/support/http/main.go
@@ -50,6 +50,7 @@ type Config struct {
 	ReadTimeout         time.Duration
 	WriteTimeout        time.Duration
 	IdleTimeout         time.Duration
+	TCPKeepAlive        time.Duration
 	OnStarting          func()
 	OnStopping          func()
 	OnStopped           func()
@@ -106,7 +107,8 @@ func setup(conf Config) *graceful.Server {
 	}
 
 	return &graceful.Server{
-		Timeout: conf.ShutdownGracePeriod,
+		Timeout:      conf.ShutdownGracePeriod,
+		TCPKeepAlive: conf.TCPKeepAlive,
 
 		Server: &stdhttp.Server{
 			Addr:         conf.ListenAddr,

--- a/support/http/main_test.go
+++ b/support/http/main_test.go
@@ -27,4 +27,5 @@ func TestRun_setup(t *testing.T) {
 	assert.Equal(t, time.Duration(0), srv.WriteTimeout)
 	assert.Equal(t, time.Duration(0), srv.IdleTimeout)
 	assert.Equal(t, defaultListenAddr, srv.Server.Addr)
+	assert.Equal(t, time.Duration(0), srv.TCPKeepAlive)
 }

--- a/support/http/main_test.go
+++ b/support/http/main_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"fmt"
 	stdhttp "net/http"
 	"testing"
 	"time"
@@ -8,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRun_setup(t *testing.T) {
+func TestRun_setupDefault(t *testing.T) {
 
 	// test that using no handler panics
 	assert.Panics(t, func() {
@@ -28,4 +29,39 @@ func TestRun_setup(t *testing.T) {
 	assert.Equal(t, time.Duration(0), srv.IdleTimeout)
 	assert.Equal(t, defaultListenAddr, srv.Server.Addr)
 	assert.Equal(t, time.Duration(0), srv.TCPKeepAlive)
+}
+
+func TestRun_setupNonDefault(t *testing.T) {
+
+	testHandler := stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {})
+
+	onStarting := func() {
+		fmt.Println("starting server")
+	}
+	onStopping := func() {
+		fmt.Println("stopping server")
+	}
+	onStopped := func() {
+		fmt.Println("stopped server")
+	}
+
+	srv := setup(Config{
+		Handler:             testHandler,
+		ListenAddr:          "1234",
+		ShutdownGracePeriod: 25 * time.Second,
+		ReadTimeout:         5 * time.Second,
+		WriteTimeout:        35 * time.Second,
+		IdleTimeout:         2 * time.Minute,
+		TCPKeepAlive:        3 * time.Minute,
+		OnStarting:          onStarting,
+		OnStopping:          onStopping,
+		OnStopped:           onStopped,
+	})
+
+	assert.Equal(t, "1234", srv.Addr)
+	assert.Equal(t, 25*time.Second, srv.Timeout)
+	assert.Equal(t, 5*time.Second, srv.ReadTimeout)
+	assert.Equal(t, 35*time.Second, srv.WriteTimeout)
+	assert.Equal(t, 2*time.Minute, srv.IdleTimeout)
+	assert.Equal(t, 3*time.Minute, srv.TCPKeepAlive)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Adding the field `TCPKeepAlive` to support/http Config

### Why

Gives the option to specify a tcp keep alive timeout for the graceful server. Otherwise it always defaults to 0s

### Known limitations

n/a
