### PR TITLE
ingest/ledgerbackend: Use context to handle termination and cleanup of captive core

### DIFF
--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"go/types"
 	"strings"
@@ -121,7 +120,6 @@ func main() {
 			configOpts.Require()
 			configOpts.SetValues()
 			logger.SetLevel(logLevel)
-			ctx, cancel := context.WithCancel(context.Background())
 
 			captiveConfig := ledgerbackend.CaptiveCoreConfig{
 				BinaryPath:         binaryPath,
@@ -131,7 +129,6 @@ func main() {
 				CheckpointFrequency: checkpointFrequency,
 				HTTPPort:           stellarCoreHTTPPort,
 				Log:                logger.WithField("subservice", "stellar-core"),
-				Context:            ctx,
 			}
 
 			var dbConn *db.Session
@@ -157,7 +154,6 @@ func main() {
 					logger.Infof("Starting Captive Core server on %v", port)
 				},
 				OnStopping: func() {
-					cancel()
 					api.Shutdown()
 					if dbConn != nil {
 						dbConn.Close()

--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -122,13 +122,13 @@ func main() {
 			logger.SetLevel(logLevel)
 
 			captiveConfig := ledgerbackend.CaptiveCoreConfig{
-				BinaryPath:         binaryPath,
-				ConfigAppendPath:   configAppendPath,
-				NetworkPassphrase:  networkPassphrase,
-				HistoryArchiveURLs: historyArchiveURLs,
+				BinaryPath:          binaryPath,
+				ConfigAppendPath:    configAppendPath,
+				NetworkPassphrase:   networkPassphrase,
+				HistoryArchiveURLs:  historyArchiveURLs,
 				CheckpointFrequency: checkpointFrequency,
-				HTTPPort:           stellarCoreHTTPPort,
-				Log:                logger.WithField("subservice", "stellar-core"),
+				HTTPPort:            stellarCoreHTTPPort,
+				Log:                 logger.WithField("subservice", "stellar-core"),
 			}
 
 			var dbConn *db.Session

--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"go/types"
 	"strings"
@@ -120,15 +121,17 @@ func main() {
 			configOpts.Require()
 			configOpts.SetValues()
 			logger.SetLevel(logLevel)
+			ctx, cancel := context.WithCancel(context.Background())
 
 			captiveConfig := ledgerbackend.CaptiveCoreConfig{
-				BinaryPath:          binaryPath,
-				ConfigAppendPath:    configAppendPath,
-				NetworkPassphrase:   networkPassphrase,
-				HistoryArchiveURLs:  historyArchiveURLs,
+				BinaryPath:         binaryPath,
+				ConfigAppendPath:   configAppendPath,
+				NetworkPassphrase:  networkPassphrase,
+				HistoryArchiveURLs: historyArchiveURLs,
 				CheckpointFrequency: checkpointFrequency,
-				HTTPPort:            stellarCoreHTTPPort,
-				Log:                 logger.WithField("subservice", "stellar-core"),
+				HTTPPort:           stellarCoreHTTPPort,
+				Log:                logger.WithField("subservice", "stellar-core"),
+				Context:            ctx,
 			}
 
 			var dbConn *db.Session
@@ -154,6 +157,7 @@ func main() {
 					logger.Infof("Starting Captive Core server on %v", port)
 				},
 				OnStopping: func() {
+					cancel()
 					api.Shutdown()
 					if dbConn != nil {
 						dbConn.Close()

--- a/exp/tools/captive-core-start-tester/main.go
+++ b/exp/tools/captive-core-start-tester/main.go
@@ -29,7 +29,6 @@ func check(ledger uint32) bool {
 			ConfigAppendPath:   "stellar-core-standalone2.cfg",
 			NetworkPassphrase:  "Standalone Network ; February 2017",
 			HistoryArchiveURLs: []string{"http://localhost:1570"},
-			CheckpointFrequency: 64,
 		},
 	)
 	if err != nil {

--- a/exp/tools/captive-core-start-tester/main.go
+++ b/exp/tools/captive-core-start-tester/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/stellar/go/ingest/ledgerbackend"
@@ -31,7 +30,6 @@ func check(ledger uint32) bool {
 			NetworkPassphrase:  "Standalone Network ; February 2017",
 			HistoryArchiveURLs: []string{"http://localhost:1570"},
 			CheckpointFrequency: 64,
-			Context:            context.Background(),
 		},
 	)
 	if err != nil {

--- a/exp/tools/captive-core-start-tester/main.go
+++ b/exp/tools/captive-core-start-tester/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/stellar/go/ingest/ledgerbackend"
@@ -25,11 +26,12 @@ func main() {
 func check(ledger uint32) bool {
 	c, err := ledgerbackend.NewCaptive(
 		ledgerbackend.CaptiveCoreConfig{
-			BinaryPath:          "stellar-core",
-			ConfigAppendPath:    "stellar-core-standalone2.cfg",
-			NetworkPassphrase:   "Standalone Network ; February 2017",
-			HistoryArchiveURLs:  []string{"http://localhost:1570"},
+			BinaryPath:         "stellar-core",
+			ConfigAppendPath:   "stellar-core-standalone2.cfg",
+			NetworkPassphrase:  "Standalone Network ; February 2017",
+			HistoryArchiveURLs: []string{"http://localhost:1570"},
 			CheckpointFrequency: 64,
+			Context:            context.Background(),
 		},
 	)
 	if err != nil {

--- a/ingest/doc_test.go
+++ b/ingest/doc_test.go
@@ -109,7 +109,6 @@ func Example_changes() {
 			NetworkPassphrase:  networkPassphrase,
 			HistoryArchiveURLs: []string{archiveURL},
 			CheckpointFrequency: 64,
-			Context:            context.Background(),
 		},
 	)
 	if err != nil {

--- a/ingest/doc_test.go
+++ b/ingest/doc_test.go
@@ -104,11 +104,12 @@ func Example_changes() {
 	// Requires Stellar-Core 13.2.0+
 	backend, err := ledgerbackend.NewCaptive(
 		ledgerbackend.CaptiveCoreConfig{
-			BinaryPath:          "/bin/stellar-core",
-			ConfigAppendPath:    "/opt/stellar-core.cfg",
-			NetworkPassphrase:   networkPassphrase,
-			HistoryArchiveURLs:  []string{archiveURL},
+			BinaryPath:         "/bin/stellar-core",
+			ConfigAppendPath:   "/opt/stellar-core.cfg",
+			NetworkPassphrase:  networkPassphrase,
+			HistoryArchiveURLs: []string{archiveURL},
 			CheckpointFrequency: 64,
+			Context:            context.Background(),
 		},
 	)
 	if err != nil {

--- a/ingest/doc_test.go
+++ b/ingest/doc_test.go
@@ -108,7 +108,6 @@ func Example_changes() {
 			ConfigAppendPath:   "/opt/stellar-core.cfg",
 			NetworkPassphrase:  networkPassphrase,
 			HistoryArchiveURLs: []string{archiveURL},
-			CheckpointFrequency: 64,
 		},
 	)
 	if err != nil {

--- a/ingest/ledgerbackend/buffered_meta_pipe_reader.go
+++ b/ingest/ledgerbackend/buffered_meta_pipe_reader.go
@@ -2,6 +2,7 @@ package ledgerbackend
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"time"
 
@@ -62,20 +63,18 @@ type metaResult struct {
 // until xdr.LedgerCloseMeta objects channel is empty. This prevents memory
 // exhaustion when network closes a series a large ledgers.
 type bufferedLedgerMetaReader struct {
-	r      *bufio.Reader
-	c      chan metaResult
-	runner stellarCoreRunnerInterface
-	closed chan struct{}
+	r   *bufio.Reader
+	c   chan metaResult
+	ctx context.Context
 }
 
 // newBufferedLedgerMetaReader creates a new meta reader that will shutdown
 // when stellar-core terminates.
-func newBufferedLedgerMetaReader(runner stellarCoreRunnerInterface) *bufferedLedgerMetaReader {
+func newBufferedLedgerMetaReader(ctx context.Context, reader io.ReadCloser) *bufferedLedgerMetaReader {
 	return &bufferedLedgerMetaReader{
-		c:      make(chan metaResult, ledgerReadAheadBufferSize),
-		r:      bufio.NewReaderSize(runner.getMetaPipe(), metaPipeBufferSize),
-		runner: runner,
-		closed: make(chan struct{}),
+		c:   make(chan metaResult, ledgerReadAheadBufferSize),
+		r:   bufio.NewReaderSize(reader, metaPipeBufferSize),
+		ctx: ctx,
 	}
 }
 
@@ -84,33 +83,17 @@ func newBufferedLedgerMetaReader(runner stellarCoreRunnerInterface) *bufferedLed
 //   * Meta pipe buffer is full so it will wait until it refills.
 //   * The next ledger available in the buffer exceeds the meta pipe buffer size.
 //     In such case the method will block until LedgerCloseMeta buffer is empty.
-func (b *bufferedLedgerMetaReader) readLedgerMetaFromPipe(untilSequence uint32) (*xdr.LedgerCloseMeta, error) {
+func (b *bufferedLedgerMetaReader) readLedgerMetaFromPipe() (*xdr.LedgerCloseMeta, error) {
 	frameLength, err := xdr.ReadFrameLength(b.r)
 	if err != nil {
-		select {
-		case <-b.runner.getProcessExitChan():
-			return nil, wrapStellarCoreRunnerError(b.runner)
-		default:
-			return nil, errors.Wrap(err, "error reading frame length")
-		}
+		return nil, errors.Wrap(err, "error reading frame length")
 	}
 
 	for frameLength > metaPipeBufferSize && len(b.c) > 0 {
 		// Wait for LedgerCloseMeta buffer to be cleared to minimize memory usage.
 		select {
-		case <-b.runner.getProcessExitChan():
-			if untilSequence != 0 {
-				// If untilSequence != 0 it's possible that Stellar-Core process
-				// exits but there are still ledgers in a buffer (catchup). In such
-				// case we ignore cases when Stellar-Core exited with no errors.
-				processErr := b.runner.getProcessExitError()
-				if processErr != nil {
-					return nil, errors.Wrap(processErr, "stellar-core process exited with an error")
-				}
-				time.Sleep(time.Second)
-				continue
-			}
-			return nil, wrapStellarCoreRunnerError(b.runner)
+		case <-b.ctx.Done():
+			return nil, b.ctx.Err()
 		case <-time.After(time.Second):
 		}
 	}
@@ -118,17 +101,7 @@ func (b *bufferedLedgerMetaReader) readLedgerMetaFromPipe(untilSequence uint32) 
 	var xlcm xdr.LedgerCloseMeta
 	_, err = xdr.Unmarshal(b.r, &xlcm)
 	if err != nil {
-		if err == io.EOF {
-			err = errors.Wrap(err, "got EOF from subprocess")
-		}
-		err = errors.Wrap(err, "unmarshalling framed LedgerCloseMeta")
-
-		select {
-		case <-b.runner.getProcessExitChan():
-			return nil, wrapStellarCoreRunnerError(b.runner)
-		default:
-			return nil, err
-		}
+		return nil, errors.Wrap(err, "unmarshalling framed LedgerCloseMeta")
 	}
 	return &xlcm, nil
 }
@@ -137,52 +110,29 @@ func (b *bufferedLedgerMetaReader) getChannel() <-chan metaResult {
 	return b.c
 }
 
-func (b *bufferedLedgerMetaReader) waitForClose() {
-	// If buffer is full, keep reading to make sure it receives
-	// a shutdown signal from stellarCoreRunner.
-loop:
-	for {
-		select {
-		case <-b.c:
-		case <-b.closed:
-			break loop
-		}
-	}
-}
-
 // Start starts an internal go routine that reads binary ledger data into
-// internal buffers. The go routine returns when Stellar-Core process exits
-// however it won't happen instantly when data is read. A blocking method:
-// waitForClose() can be used to block until go routine returns.
-func (b *bufferedLedgerMetaReader) start(untilSequence uint32) {
+// internal buffers. The go routine returns when it encounters an error (including io.EOF)
+// or its context is terminated.
+func (b *bufferedLedgerMetaReader) start() {
 	printBufferOccupation := time.NewTicker(5 * time.Second)
-	defer func() {
-		printBufferOccupation.Stop()
-		close(b.closed)
-	}()
+	defer printBufferOccupation.Stop()
+	defer close(b.c)
 
 	for {
 		select {
 		case <-printBufferOccupation.C:
 			log.Debug("captive core read-ahead buffer occupation:", len(b.c))
+		case <-b.ctx.Done():
+			return
 		default:
 		}
 
-		meta, err := b.readLedgerMetaFromPipe(untilSequence)
+		meta, err := b.readLedgerMetaFromPipe()
 		if err != nil {
-			// When `GetLedger` sees the error it will close the backend. We shouldn't
-			// close it now because there may be some ledgers in a buffer.
 			b.c <- metaResult{nil, err}
 			return
 		}
 
 		b.c <- metaResult{meta, nil}
-
-		if untilSequence != 0 {
-			if meta.LedgerSequence() >= untilSequence {
-				// we are done
-				return
-			}
-		}
 	}
 }

--- a/ingest/ledgerbackend/buffered_meta_pipe_reader.go
+++ b/ingest/ledgerbackend/buffered_meta_pipe_reader.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 )
@@ -70,7 +71,7 @@ type bufferedLedgerMetaReader struct {
 
 // newBufferedLedgerMetaReader creates a new meta reader that will shutdown
 // when stellar-core terminates.
-func newBufferedLedgerMetaReader(ctx context.Context, reader io.ReadCloser) *bufferedLedgerMetaReader {
+func newBufferedLedgerMetaReader(ctx context.Context, reader io.Reader) *bufferedLedgerMetaReader {
 	return &bufferedLedgerMetaReader{
 		c:   make(chan metaResult, ledgerReadAheadBufferSize),
 		r:   bufio.NewReaderSize(reader, metaPipeBufferSize),
@@ -110,9 +111,8 @@ func (b *bufferedLedgerMetaReader) getChannel() <-chan metaResult {
 	return b.c
 }
 
-// Start starts an internal go routine that reads binary ledger data into
-// internal buffers. The go routine returns when it encounters an error (including io.EOF)
-// or its context is terminated.
+// Start starts a loop that reads binary ledger data into internal buffers.
+// The function returns when it encounters an error (including io.EOF) or its context is terminated.
 func (b *bufferedLedgerMetaReader) start() {
 	printBufferOccupation := time.NewTicker(5 * time.Second)
 	defer printBufferOccupation.Stop()

--- a/ingest/ledgerbackend/buffered_meta_pipe_reader.go
+++ b/ingest/ledgerbackend/buffered_meta_pipe_reader.go
@@ -89,9 +89,7 @@ func (b *bufferedLedgerMetaReader) readLedgerMetaFromPipe() (*xdr.LedgerCloseMet
 
 	for frameLength > metaPipeBufferSize && len(b.c) > 0 {
 		// Wait for LedgerCloseMeta buffer to be cleared to minimize memory usage.
-		select {
-		case <-time.After(time.Second):
-		}
+		<-time.After(time.Second)
 	}
 
 	var xlcm xdr.LedgerCloseMeta

--- a/ingest/ledgerbackend/buffered_meta_pipe_reader.go
+++ b/ingest/ledgerbackend/buffered_meta_pipe_reader.go
@@ -2,7 +2,6 @@ package ledgerbackend
 
 import (
 	"bufio"
-	"context"
 	"io"
 	"time"
 
@@ -64,18 +63,16 @@ type metaResult struct {
 // until xdr.LedgerCloseMeta objects channel is empty. This prevents memory
 // exhaustion when network closes a series a large ledgers.
 type bufferedLedgerMetaReader struct {
-	r   *bufio.Reader
-	c   chan metaResult
-	ctx context.Context
+	r *bufio.Reader
+	c chan metaResult
 }
 
 // newBufferedLedgerMetaReader creates a new meta reader that will shutdown
 // when stellar-core terminates.
-func newBufferedLedgerMetaReader(ctx context.Context, reader io.Reader) *bufferedLedgerMetaReader {
+func newBufferedLedgerMetaReader(reader io.Reader) *bufferedLedgerMetaReader {
 	return &bufferedLedgerMetaReader{
-		c:   make(chan metaResult, ledgerReadAheadBufferSize),
-		r:   bufio.NewReaderSize(reader, metaPipeBufferSize),
-		ctx: ctx,
+		c: make(chan metaResult, ledgerReadAheadBufferSize),
+		r: bufio.NewReaderSize(reader, metaPipeBufferSize),
 	}
 }
 
@@ -93,8 +90,6 @@ func (b *bufferedLedgerMetaReader) readLedgerMetaFromPipe() (*xdr.LedgerCloseMet
 	for frameLength > metaPipeBufferSize && len(b.c) > 0 {
 		// Wait for LedgerCloseMeta buffer to be cleared to minimize memory usage.
 		select {
-		case <-b.ctx.Done():
-			return nil, b.ctx.Err()
 		case <-time.After(time.Second):
 		}
 	}
@@ -112,7 +107,7 @@ func (b *bufferedLedgerMetaReader) getChannel() <-chan metaResult {
 }
 
 // Start starts a loop that reads binary ledger data into internal buffers.
-// The function returns when it encounters an error (including io.EOF) or its context is terminated.
+// The function returns when it encounters an error (including io.EOF).
 func (b *bufferedLedgerMetaReader) start() {
 	printBufferOccupation := time.NewTicker(5 * time.Second)
 	defer printBufferOccupation.Stop()
@@ -122,8 +117,6 @@ func (b *bufferedLedgerMetaReader) start() {
 		select {
 		case <-printBufferOccupation.C:
 			log.Debug("captive core read-ahead buffer occupation:", len(b.c))
-		case <-b.ctx.Done():
-			return
 		default:
 		}
 

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -3,11 +3,11 @@ package ledgerbackend
 import (
 	"context"
 	"encoding/hex"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"os"
 	"sync"
 
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -155,6 +155,7 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 		},
 	)
 	if err != nil {
+		cancel()
 		return nil, errors.Wrap(err, "error connecting to history archive")
 	}
 

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -3,10 +3,10 @@ package ledgerbackend
 import (
 	"context"
 	"encoding/hex"
-	"sync"
-	"time"
-
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"os"
+	"sync"
 
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/support/log"
@@ -64,10 +64,14 @@ func (c *CaptiveStellarCore) roundDownToFirstReplayAfterCheckpointStart(ledger u
 //
 // Requires Stellar-Core v13.2.0+.
 type CaptiveStellarCore struct {
-	configAppendPath  string
-	archive           historyarchive.ArchiveInterface
+	archive         historyarchive.ArchiveInterface
 	checkpointManager historyarchive.CheckpointManager
-	ledgerHashStore   TrustedLedgerHashStore
+	ledgerHashStore TrustedLedgerHashStore
+
+	// cancel is the CancelFunc for context which controls the lifetime of a CaptiveStellarCore instance.
+	// Once it is invoked CaptiveStellarCore will not be able to stream ledgers from Stellar Core or
+	// spawn new instances of Stellar Core.
+	cancel context.CancelFunc
 
 	stellarCoreRunner stellarCoreRunnerInterface
 	// stellarCoreLock protects access to stellarCoreRunner. When the read lock
@@ -91,10 +95,6 @@ type CaptiveStellarCore struct {
 	nextLedger         uint32  // next ledger expected, error w/ restart if not seen
 	lastLedger         *uint32 // end of current segment if offline, nil if online
 	previousLedgerHash *string
-
-	// waitIntervalPrepareRange defines a time to wait between checking if the buffer
-	// is empty. Default 1s, lower in tests to make them faster.
-	waitIntervalPrepareRange time.Duration
 }
 
 // CaptiveCoreConfig contains all the parameters required to create a CaptiveStellarCore instance
@@ -117,9 +117,9 @@ type CaptiveCoreConfig struct {
 	// Log is an (optional) custom logger which will capture any output from the Stellar Core process.
 	// If Log is omitted then all output will be printed to stdout.
 	Log *log.Entry
-	// Context is the context which controls the lifetime of a CaptiveStellarCore instance. Once the context is done
+	// Context is the (optional) context which controls the lifetime of a CaptiveStellarCore instance. Once the context is done
 	// the CaptiveStellarCore instance will not be able to stream ledgers from Stellar Core or spawn new
-	// instances of Stellar Core.
+	// instances of Stellar Core. If Context is omitted CaptiveStellarCore will default to using context.Background.
 	Context context.Context
 }
 
@@ -142,11 +142,23 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 
 	c := &CaptiveStellarCore{
 		archive:                  archive,
-		configAppendPath:         config.ConfigAppendPath,
-		waitIntervalPrepareRange: time.Second,
 		ledgerHashStore:          config.LedgerHashStore,
 		checkpointManager:        historyarchive.NewCheckpointManager(config.CheckpointFrequency),
 	}
+
+	// Here we set defaults in the config. Because config is not a pointer this code should
+	// not mutate the original CaptiveCoreConfig instance which was passed into NewCaptive()
+	if config.Log == nil {
+		config.Log = log.New()
+		config.Log.Logger.SetOutput(os.Stdout)
+		config.Log.SetLevel(logrus.InfoLevel)
+	}
+	parentCtx := config.Context
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	config.Context, c.cancel = context.WithCancel(parentCtx)
+
 	c.stellarCoreRunnerFactory = func(mode stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 		return newStellarCoreRunner(config, mode)
 	}
@@ -507,7 +519,7 @@ func (c *CaptiveStellarCore) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMe
 		}
 	}
 	// All paths above that break out of the loop (instead of return)
-	// set e to non-nil: there was an error and we should close and
+	// set errOut to non-nil: there was an error and we should close and
 	// reset state before retuning an error to our caller.
 	c.stellarCoreRunner.close()
 	return false, xdr.LedgerCloseMeta{}, errOut
@@ -569,11 +581,15 @@ func (c *CaptiveStellarCore) isClosed() bool {
 }
 
 // Close closes existing Stellar-Core process, streaming sessions and removes all
-// temporary files. Note, once a CaptiveStellarCore instance is closed it can still be used again
-// by calling PrepareRange().
+// temporary files. Note, once a CaptiveStellarCore instance is closed it can can no longer be used and
+// all subsequent calls to PrepareRange(), GetLedger(), etc will fail.
 func (c *CaptiveStellarCore) Close() error {
 	c.stellarCoreLock.RLock()
 	defer c.stellarCoreLock.RUnlock()
+
+	// after the CaptiveStellarCore context is canceled all subsequent calls to PrepareRange() will fail
+	c.cancel()
+
 	if c.stellarCoreRunner != nil {
 		return c.stellarCoreRunner.close()
 	}

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
@@ -36,11 +37,8 @@ func (c *CaptiveStellarCore) roundDownToFirstReplayAfterCheckpointStart(ledger u
 //     keep ledger state in RAM. It requires around 3GB of RAM as of August 2020.
 //   * When a UnboundedRange is prepared it runs Stellar-Core catchup mode to
 //     sync with the first ledger and then runs it in a normal mode. This
-//     requires the configAppendPath to be provided because a database connection is
-//     required and quorum set needs to be selected.
-//
-// The database requirement for UnboundedRange will soon be removed when some
-// changes are implemented in Stellar-Core.
+//     requires the configAppendPath to be provided because a quorum set needs to
+//     be selected.
 //
 // When running CaptiveStellarCore will create a temporary folder to store
 // bucket files and other temporary files. The folder is removed when Close is
@@ -101,12 +99,16 @@ type CaptiveStellarCore struct {
 type CaptiveCoreConfig struct {
 	// BinaryPath is the file path to the Stellar Core binary
 	BinaryPath string
-	// ConfigAppendPath is the file path to additional configuration for the Stellar Core configuration file used by captive core
+	// ConfigAppendPath is the file path to additional configuration for the Stellar Core configuration file used
+	// by captive core. This field is only required when ingesting in online mode (e.g. UnboundedRange).
 	ConfigAppendPath string
 	// NetworkPassphrase is the Stellar network passphrase used by captive core when connecting to the Stellar network
 	NetworkPassphrase string
 	// HistoryArchiveURLs are a list of history archive urls
 	HistoryArchiveURLs []string
+
+	// Optional fields
+
 	// CheckpointFrequency is the number of ledgers between checkpoints
 	// if unset, DefaultCheckpointFrequency will be used
 	CheckpointFrequency uint32
@@ -123,11 +125,22 @@ type CaptiveCoreConfig struct {
 	Context context.Context
 }
 
-// NewCaptive returns a new CaptiveStellarCore.
-//
-// All parameters are required, except configAppendPath which is not required when
-// working with BoundedRanges only.
+// NewCaptive returns a new CaptiveStellarCore instance.
 func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
+	// Here we set defaults in the config. Because config is not a pointer this code should
+	// not mutate the original CaptiveCoreConfig instance which was passed into NewCaptive()
+	if config.Log == nil {
+		config.Log = log.New()
+		config.Log.Logger.SetOutput(os.Stdout)
+		config.Log.SetLevel(logrus.InfoLevel)
+	}
+	parentCtx := config.Context
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	var cancel context.CancelFunc
+	config.Context, cancel = context.WithCancel(parentCtx)
+
 	archive, err := historyarchive.Connect(
 		config.HistoryArchiveURLs[0],
 		historyarchive.ConnectOptions{
@@ -143,21 +156,9 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	c := &CaptiveStellarCore{
 		archive:           archive,
 		ledgerHashStore:   config.LedgerHashStore,
+		cancel:            cancel,
 		checkpointManager: historyarchive.NewCheckpointManager(config.CheckpointFrequency),
 	}
-
-	// Here we set defaults in the config. Because config is not a pointer this code should
-	// not mutate the original CaptiveCoreConfig instance which was passed into NewCaptive()
-	if config.Log == nil {
-		config.Log = log.New()
-		config.Log.Logger.SetOutput(os.Stdout)
-		config.Log.SetLevel(logrus.InfoLevel)
-	}
-	parentCtx := config.Context
-	if parentCtx == nil {
-		parentCtx = context.Background()
-	}
-	config.Context, c.cancel = context.WithCancel(parentCtx)
 
 	c.stellarCoreRunnerFactory = func(mode stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 		return newStellarCoreRunner(config, mode)

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -514,20 +514,29 @@ func (c *CaptiveStellarCore) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMe
 }
 
 func (c *CaptiveStellarCore) checkMetaPipeResult(result metaResult, ok bool) error {
-	// check if stellar core was terminated by Close()
+	// There are 3 types of errors we check for:
+	// 1. User initiated shutdown by canceling the parent context or calling Close().
+	// 2. The stellar core process exited unexpectedly.
+	// 3. Some error was encountered while consuming the ledger stream emitted by captive core
 	if err := c.stellarCoreRunner.context().Err(); err != nil {
+		// Case 1 - User initiated shutdown by canceling the parent context or calling Close()
 		return err
 	}
 	if !ok || result.err != nil {
 		if exited, err := c.stellarCoreRunner.getProcessExitError(); exited {
+			// Case 2 - The stellar core process exited unexpectedly
 			if err == nil {
 				return errors.Errorf("stellar core exited unexpectedly")
 			} else {
 				return errors.Wrap(err, "stellar core exited unexpectedly")
 			}
 		} else if !ok {
+			// This case should never happen because the channel can only be closed
+			// if and only if the process exits or the context is cancelled.
+			// However, we add this check for the sake of completeness
 			return errors.Errorf("meta pipe closed unexpectedly")
 		} else {
+			// Case 3 - Some error was encountered while consuming the ledger stream emitted by captive core.
 			return result.err
 		}
 	}

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -192,9 +192,13 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 		to = latestCheckpointSequence
 	}
 
-	c.stellarCoreRunner, err = c.stellarCoreRunnerFactory(stellarCoreRunnerModeOffline)
-	if err != nil {
+	var runner stellarCoreRunnerInterface
+	if runner, err = c.stellarCoreRunnerFactory(stellarCoreRunnerModeOffline); err != nil {
 		return errors.Wrap(err, "error creating stellar-core runner")
+	} else {
+		// only assign c.stellarCoreRunner if runner is not nil to avoid nil interface check
+		// see https://golang.org/doc/faq#nil_error
+		c.stellarCoreRunner = runner
 	}
 
 	err = c.stellarCoreRunner.catchup(from, to)
@@ -231,9 +235,13 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 		)
 	}
 
-	c.stellarCoreRunner, err = c.stellarCoreRunnerFactory(stellarCoreRunnerModeOnline)
-	if err != nil {
+	var runner stellarCoreRunnerInterface
+	if runner, err = c.stellarCoreRunnerFactory(stellarCoreRunnerModeOnline); err != nil {
 		return errors.Wrap(err, "error creating stellar-core runner")
+	} else {
+		// only assign c.stellarCoreRunner if runner is not nil to avoid nil interface check
+		// see https://golang.org/doc/faq#nil_error
+		c.stellarCoreRunner = runner
 	}
 
 	runFrom, ledgerHash, nextLedger, err := c.runFromParams(from)

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -207,6 +207,7 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 	c.nextLedger = c.roundDownToFirstReplayAfterCheckpointStart(from)
 	c.lastLedger = &to
 	c.blocking = true
+	c.previousLedgerHash = nil
 
 	return nil
 }
@@ -247,6 +248,7 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 
 	c.nextLedger = nextLedger
 	c.lastLedger = nil
+	c.previousLedgerHash = nil
 
 	if c.ledgerHashStore != nil {
 		var exists bool

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -1,7 +1,9 @@
 package ledgerbackend
 
 import (
+	"context"
 	"encoding/hex"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -67,14 +69,11 @@ type CaptiveStellarCore struct {
 	checkpointManager historyarchive.CheckpointManager
 	ledgerHashStore   TrustedLedgerHashStore
 
-	// Quick note on how shutdown works:
-	// If Stellar-Core exits, the exit signal is "catched" by bufferedLedgerMetaReader
-	// (which ends it's go routine) and later propagated via metaResult to
-	// CaptiveStellarCore.
-	// If user calls CaptiveStellarCore.Close(), it kills Stellar-Core process
-	// and the rest is handles by the process explained above.
-	ledgerBuffer      *bufferedLedgerMetaReader
 	stellarCoreRunner stellarCoreRunnerInterface
+	// stellarCoreLock protects access to stellarCoreRunner. When the read lock
+	// is acquired stellarCoreRunner can be accessed. When the write lock is acquired
+	// stellarCoreRunner can be updated.
+	stellarCoreLock sync.RWMutex
 
 	// For testing
 	stellarCoreRunnerFactory func(mode stellarCoreRunnerMode) (stellarCoreRunnerInterface, error)
@@ -118,6 +117,10 @@ type CaptiveCoreConfig struct {
 	// Log is an (optional) custom logger which will capture any output from the Stellar Core process.
 	// If Log is omitted then all output will be printed to stdout.
 	Log *log.Entry
+	// Context is the context which controls the lifetime of a CaptiveStellarCore instance. Once the context is done
+	// the CaptiveStellarCore instance will not be able to stream ledgers from Stellar Core or spawn new
+	// instances of Stellar Core.
+	Context context.Context
 }
 
 // NewCaptive returns a new CaptiveStellarCore.
@@ -130,6 +133,7 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 		historyarchive.ConnectOptions{
 			NetworkPassphrase:   config.NetworkPassphrase,
 			CheckpointFrequency: config.CheckpointFrequency,
+			Context:           config.Context,
 		},
 	)
 	if err != nil {
@@ -159,15 +163,11 @@ func (c *CaptiveStellarCore) getLatestCheckpointSequence() (uint32, error) {
 }
 
 func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error {
-	err := c.Close()
-	if err != nil {
-		return errors.Wrap(err, "error closing existing session")
-	}
-
 	latestCheckpointSequence, err := c.getLatestCheckpointSequence()
 	if err != nil {
 		return errors.Wrap(err, "error getting latest checkpoint sequence")
 	}
+
 	if from > latestCheckpointSequence {
 		return errors.Errorf(
 			"sequence: %d is greater than max available in history archives: %d",
@@ -175,6 +175,7 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 			latestCheckpointSequence,
 		)
 	}
+
 	if to > latestCheckpointSequence {
 		to = latestCheckpointSequence
 	}
@@ -195,24 +196,10 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 	c.lastLedger = &to
 	c.blocking = true
 
-	// read-ahead buffer
-	c.ledgerBuffer = newBufferedLedgerMetaReader(c.stellarCoreRunner)
-	go c.ledgerBuffer.start(to)
 	return nil
 }
 
 func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
-	// Check if existing session works for this request
-	if c.lastLedger == nil && c.nextLedger != 0 && c.nextLedger <= from {
-		// Use existing session, GetLedger will fast-forward
-		return nil
-	}
-
-	err := c.Close()
-	if err != nil {
-		return errors.Wrap(err, "error closing existing session")
-	}
-
 	latestCheckpointSequence, err := c.getLatestCheckpointSequence()
 	if err != nil {
 		return errors.Wrap(err, "error getting latest checkpoint sequence")
@@ -261,21 +248,6 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 	}
 
 	c.blocking = false
-
-	// read-ahead buffer
-	c.ledgerBuffer = newBufferedLedgerMetaReader(c.stellarCoreRunner)
-	go c.ledgerBuffer.start(0)
-
-	// if nextLedger is behind - fast-forward until expected ledger
-	if c.nextLedger < from {
-		// make GetFrom blocking temporarily
-		c.blocking = true
-		_, _, err := c.GetLedger(from)
-		c.blocking = false
-		if err != nil {
-			return errors.Wrapf(err, "Error fast-forwarding to %d", from)
-		}
-	}
 
 	return nil
 }
@@ -338,6 +310,33 @@ func (c *CaptiveStellarCore) runFromParams(from uint32) (runFrom uint32, ledgerH
 	return
 }
 
+func (c *CaptiveStellarCore) startPreparingRange(ledgerRange Range) (bool, error) {
+	c.stellarCoreLock.Lock()
+	defer c.stellarCoreLock.Unlock()
+
+	if c.isPrepared(ledgerRange) {
+		return true, nil
+	}
+
+	if c.stellarCoreRunner != nil {
+		if err := c.stellarCoreRunner.close(); err != nil {
+			return false, errors.Wrap(err, "error closing existing session")
+		}
+	}
+
+	var err error
+	if ledgerRange.bounded {
+		err = c.openOfflineReplaySubprocess(ledgerRange.from, ledgerRange.to)
+	} else {
+		err = c.openOnlineReplaySubprocess(ledgerRange.from)
+	}
+	if err != nil {
+		return false, errors.Wrap(err, "opening subprocess")
+	}
+
+	return false, nil
+}
+
 // PrepareRange prepares the given range (including from and to) to be loaded.
 // Captive stellar-core backend needs to initalize Stellar-Core state to be
 // able to stream ledgers.
@@ -348,39 +347,19 @@ func (c *CaptiveStellarCore) runFromParams(from uint32) (runFrom uint32, ledgerH
 // Please note that using a BoundedRange, currently, requires a full-trust on
 // history archive. This issue is being fixed in Stellar-Core.
 func (c *CaptiveStellarCore) PrepareRange(ledgerRange Range) error {
-	// Range already prepared
-	if prepared, err := c.IsPrepared(ledgerRange); err != nil {
-		return errors.Wrap(err, "error in IsPrepared")
-	} else if prepared {
+	if alreadyPrepared, err := c.startPreparingRange(ledgerRange); err != nil {
+		return errors.Wrap(err, "error starting prepare range")
+	} else if alreadyPrepared {
 		return nil
 	}
 
-	var err error
-	if ledgerRange.bounded {
-		err = c.openOfflineReplaySubprocess(ledgerRange.from, ledgerRange.to)
-	} else {
-		err = c.openOnlineReplaySubprocess(ledgerRange.from)
-	}
-	if err != nil {
-		return errors.Wrap(err, "opening subprocess")
-	}
+	old := c.blocking
+	c.blocking = true
+	_, _, err := c.GetLedger(ledgerRange.from)
+	c.blocking = old
 
-	for {
-		select {
-		case <-c.stellarCoreRunner.getProcessExitChan():
-			// Return only in case of Stellar-Core process error. Normal exit
-			// is expected in catchup when all ledgers sent to a buffer.
-			processErr := c.stellarCoreRunner.getProcessExitError()
-			if processErr != nil {
-				return errors.Wrap(processErr, "stellar-core process exited with an error")
-			}
-		default:
-		}
-		// Wait for the first ledger or an error
-		if len(c.ledgerBuffer.getChannel()) > 0 {
-			break
-		}
-		time.Sleep(c.waitIntervalPrepareRange)
+	if err != nil {
+		return errors.Wrapf(err, "Error fast-forwarding to %d", ledgerRange.from)
 	}
 
 	return nil
@@ -388,6 +367,17 @@ func (c *CaptiveStellarCore) PrepareRange(ledgerRange Range) error {
 
 // IsPrepared returns true if a given ledgerRange is prepared.
 func (c *CaptiveStellarCore) IsPrepared(ledgerRange Range) (bool, error) {
+	c.stellarCoreLock.RLock()
+	defer c.stellarCoreLock.RUnlock()
+
+	return c.isPrepared(ledgerRange), nil
+}
+
+func (c *CaptiveStellarCore) isPrepared(ledgerRange Range) bool {
+	if c.isClosed() {
+		return false
+	}
+
 	lastLedger := uint32(0)
 	if c.lastLedger != nil {
 		lastLedger = *c.lastLedger
@@ -398,22 +388,18 @@ func (c *CaptiveStellarCore) IsPrepared(ledgerRange Range) (bool, error) {
 		cachedLedger = c.cachedMeta.LedgerSequence()
 	}
 
-	return c.isPrepared(c.nextLedger, lastLedger, cachedLedger, ledgerRange), nil
-}
-
-func (*CaptiveStellarCore) isPrepared(nextLedger, lastLedger, cachedLedger uint32, ledgerRange Range) bool {
-	if nextLedger == 0 {
+	if c.nextLedger == 0 {
 		return false
 	}
 
 	if lastLedger == 0 {
-		return nextLedger <= ledgerRange.from || cachedLedger == ledgerRange.from
+		return c.nextLedger <= ledgerRange.from || cachedLedger == ledgerRange.from
 	}
 
 	// From now on: lastLedger != 0 so current range is bounded
 
 	if ledgerRange.bounded {
-		return (nextLedger <= ledgerRange.from || cachedLedger == ledgerRange.from) &&
+		return (c.nextLedger <= ledgerRange.from || cachedLedger == ledgerRange.from) &&
 			lastLedger >= ledgerRange.to
 	}
 
@@ -439,6 +425,9 @@ func (*CaptiveStellarCore) isPrepared(nextLedger, lastLedger, cachedLedger uint3
 //     the first argument equal false.
 // This is done to provide maximum performance when streaming old ledgers.
 func (c *CaptiveStellarCore) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMeta, error) {
+	c.stellarCoreLock.RLock()
+	defer c.stellarCoreLock.RUnlock()
+
 	if c.cachedMeta != nil && sequence == c.cachedMeta.LedgerSequence() {
 		// GetLedger can be called multiple times using the same sequence, ex. to create
 		// change and transaction readers. If we have this ledger buffered, let's return it.
@@ -467,18 +456,14 @@ func (c *CaptiveStellarCore) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMe
 
 	// Now loop along the range until we find the ledger we want.
 	var errOut error
-loop:
 	for {
-		if !c.blocking && len(c.ledgerBuffer.getChannel()) == 0 {
+		if !c.blocking && len(c.stellarCoreRunner.getMetaPipe()) == 0 {
 			return false, xdr.LedgerCloseMeta{}, nil
 		}
 
-		// We don't have to handle getProcessExitChan() because this is handled
-		// in bufferedLedgerMetaReader (will send an error to the channel).
-		result := <-c.ledgerBuffer.getChannel()
-		if result.err != nil {
-			errOut = result.err
-			break loop
+		result, ok := <-c.stellarCoreRunner.getMetaPipe()
+		if errOut = c.checkMetaPipeResult(result, ok); errOut != nil {
+			break
 		}
 
 		seq := result.LedgerCloseMeta.LedgerSequence()
@@ -514,7 +499,7 @@ loop:
 
 			// If we got the _last_ ledger in a segment, close before returning.
 			if c.lastLedger != nil && *c.lastLedger == seq {
-				if err := c.Close(); err != nil {
+				if err := c.stellarCoreRunner.close(); err != nil {
 					return false, xdr.LedgerCloseMeta{}, errors.Wrap(err, "error closing session")
 				}
 			}
@@ -524,8 +509,29 @@ loop:
 	// All paths above that break out of the loop (instead of return)
 	// set e to non-nil: there was an error and we should close and
 	// reset state before retuning an error to our caller.
-	c.Close()
+	c.stellarCoreRunner.close()
 	return false, xdr.LedgerCloseMeta{}, errOut
+}
+
+func (c *CaptiveStellarCore) checkMetaPipeResult(result metaResult, ok bool) error {
+	// check if stellar core was terminated by Close()
+	if err := c.stellarCoreRunner.context().Err(); err != nil {
+		return err
+	}
+	if !ok || result.err != nil {
+		if exited, err := c.stellarCoreRunner.getProcessExitError(); exited {
+			if err == nil {
+				return errors.Errorf("stellar core exited unexpectedly")
+			} else {
+				return errors.Wrap(err, "stellar core exited unexpectedly")
+			}
+		} else if !ok {
+			return errors.Errorf("meta pipe closed unexpectedly")
+		} else {
+			return result.err
+		}
+	}
+	return nil
 }
 
 // GetLatestLedgerSequence returns the sequence of the latest ledger available
@@ -536,51 +542,31 @@ loop:
 // the latest sequence closed by the network. It's always the last value available
 // in the backend.
 func (c *CaptiveStellarCore) GetLatestLedgerSequence() (uint32, error) {
+	c.stellarCoreLock.RLock()
+	defer c.stellarCoreLock.RUnlock()
+
 	if c.isClosed() {
 		return 0, errors.New("stellar-core must be opened to return latest available sequence")
 	}
 
 	if c.lastLedger == nil {
-		return c.nextLedger - 1 + uint32(len(c.ledgerBuffer.getChannel())), nil
+		return c.nextLedger - 1 + uint32(len(c.stellarCoreRunner.getMetaPipe())), nil
 	}
 	return *c.lastLedger, nil
 }
 
 func (c *CaptiveStellarCore) isClosed() bool {
-	return c.nextLedger == 0
+	return c.nextLedger == 0 || c.stellarCoreRunner == nil || c.stellarCoreRunner.context().Err() != nil
 }
 
 // Close closes existing Stellar-Core process, streaming sessions and removes all
-// temporary files.
+// temporary files. Note, once a CaptiveStellarCore instance is closed it can still be used again
+// by calling PrepareRange().
 func (c *CaptiveStellarCore) Close() error {
+	c.stellarCoreLock.RLock()
+	defer c.stellarCoreLock.RUnlock()
 	if c.stellarCoreRunner != nil {
-		// Closing stellarCoreRunner will automatically close bufferedLedgerMetaReader
-		// because it's listening for getProcessExitChan().
-		err := c.stellarCoreRunner.close()
-		c.stellarCoreRunner = nil
-		if err != nil {
-			return errors.Wrap(err, "error closing stellar-core subprocess")
-		}
-
-		// c.ledgerBuffer might be nil if stellarCoreRunner.runFrom / stellarCoreRunner.catchup responded with an error
-		if c.ledgerBuffer != nil {
-			// Wait for bufferedLedgerMetaReader go routine to return.
-			c.ledgerBuffer.waitForClose()
-			c.ledgerBuffer = nil
-		}
+		return c.stellarCoreRunner.close()
 	}
-
-	c.nextLedger = 0
-	c.lastLedger = nil
-	c.previousLedgerHash = nil
-
 	return nil
-}
-
-func wrapStellarCoreRunnerError(r stellarCoreRunnerInterface) error {
-	processErr := r.getProcessExitError()
-	if processErr != nil {
-		return errors.Wrap(processErr, "stellar-core process exited with an error")
-	}
-	return errors.New("stellar-core process exited unexpectedly without an error")
 }

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -517,7 +517,7 @@ func (c *CaptiveStellarCore) checkMetaPipeResult(result metaResult, ok bool) err
 	// There are 3 types of errors we check for:
 	// 1. User initiated shutdown by canceling the parent context or calling Close().
 	// 2. The stellar core process exited unexpectedly.
-	// 3. Some error was encountered while consuming the ledger stream emitted by captive core
+	// 3. Some error was encountered while consuming the ledgers emitted by captive core (e.g. parsing invalid xdr)
 	if err := c.stellarCoreRunner.context().Err(); err != nil {
 		// Case 1 - User initiated shutdown by canceling the parent context or calling Close()
 		return err
@@ -531,7 +531,7 @@ func (c *CaptiveStellarCore) checkMetaPipeResult(result metaResult, ok bool) err
 				return errors.Wrap(err, "stellar core exited unexpectedly")
 			}
 		} else if !ok {
-			// This case should never happen because the channel can only be closed
+			// This case should never happen because the ledger buffer channel can only be closed
 			// if and only if the process exits or the context is cancelled.
 			// However, we add this check for the sake of completeness
 			return errors.Errorf("meta pipe closed unexpectedly")

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -60,6 +60,11 @@ func (c *CaptiveStellarCore) roundDownToFirstReplayAfterCheckpointStart(ledger u
 //     has a very small internal buffer and Stellar-Core will not close the new
 //     ledger if it's not read.
 //
+// Except for the Close function, CaptiveStellarCore is not thread-safe and should
+// not be accessed by multiple go routines. Close is thread-safe and can be called
+// from another go routine. Once Close is called it will interrupt and cancel any
+// pending operations.
+//
 // Requires Stellar-Core v13.2.0+.
 type CaptiveStellarCore struct {
 	archive           historyarchive.ArchiveInterface
@@ -594,6 +599,7 @@ func (c *CaptiveStellarCore) isClosed() bool {
 // Close closes existing Stellar-Core process, streaming sessions and removes all
 // temporary files. Note, once a CaptiveStellarCore instance is closed it can can no longer be used and
 // all subsequent calls to PrepareRange(), GetLedger(), etc will fail.
+// Close is thread-safe and can be called from another go routine.
 func (c *CaptiveStellarCore) Close() error {
 	c.stellarCoreLock.RLock()
 	defer c.stellarCoreLock.RUnlock()

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -64,9 +64,9 @@ func (c *CaptiveStellarCore) roundDownToFirstReplayAfterCheckpointStart(ledger u
 //
 // Requires Stellar-Core v13.2.0+.
 type CaptiveStellarCore struct {
-	archive         historyarchive.ArchiveInterface
+	archive           historyarchive.ArchiveInterface
 	checkpointManager historyarchive.CheckpointManager
-	ledgerHashStore TrustedLedgerHashStore
+	ledgerHashStore   TrustedLedgerHashStore
 
 	// cancel is the CancelFunc for context which controls the lifetime of a CaptiveStellarCore instance.
 	// Once it is invoked CaptiveStellarCore will not be able to stream ledgers from Stellar Core or
@@ -133,7 +133,7 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 		historyarchive.ConnectOptions{
 			NetworkPassphrase:   config.NetworkPassphrase,
 			CheckpointFrequency: config.CheckpointFrequency,
-			Context:           config.Context,
+			Context:             config.Context,
 		},
 	)
 	if err != nil {
@@ -141,9 +141,9 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	}
 
 	c := &CaptiveStellarCore{
-		archive:                  archive,
-		ledgerHashStore:          config.LedgerHashStore,
-		checkpointManager:        historyarchive.NewCheckpointManager(config.CheckpointFrequency),
+		archive:           archive,
+		ledgerHashStore:   config.LedgerHashStore,
+		checkpointManager: historyarchive.NewCheckpointManager(config.CheckpointFrequency),
 	}
 
 	// Here we set defaults in the config. Because config is not a pointer this code should

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -146,12 +146,12 @@ func TestCaptiveNew(t *testing.T) {
 
 	captiveStellarCore, err := NewCaptive(
 		CaptiveCoreConfig{
-			BinaryPath:         executablePath,
-			ConfigAppendPath:   configPath,
-			NetworkPassphrase:  networkPassphrase,
-			HistoryArchiveURLs: historyURLs,
+			BinaryPath:          executablePath,
+			ConfigAppendPath:    configPath,
+			NetworkPassphrase:   networkPassphrase,
+			HistoryArchiveURLs:  historyURLs,
 			CheckpointFrequency: 64,
-			Context:            context.Background(),
+			Context:             context.Background(),
 		},
 	)
 

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -1,19 +1,19 @@
 package ledgerbackend
 
 import (
-	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 // TODO: test frame decoding
@@ -146,12 +146,10 @@ func TestCaptiveNew(t *testing.T) {
 
 	captiveStellarCore, err := NewCaptive(
 		CaptiveCoreConfig{
-			BinaryPath:          executablePath,
-			ConfigAppendPath:    configPath,
-			NetworkPassphrase:   networkPassphrase,
-			HistoryArchiveURLs:  historyURLs,
-			CheckpointFrequency: 64,
-			Context:             context.Background(),
+			BinaryPath:         executablePath,
+			ConfigAppendPath:   configPath,
+			NetworkPassphrase:  networkPassphrase,
+			HistoryArchiveURLs: historyURLs,
 		},
 	)
 
@@ -161,21 +159,21 @@ func TestCaptiveNew(t *testing.T) {
 }
 
 func TestCaptivePrepareRange(t *testing.T) {
-	var buf bytes.Buffer
+	metaChan := make(chan metaResult, 100)
 
 	// Core will actually start with the last checkpoint before the from ledger
 	// and then rewind to the `from` ledger.
-	for i := 64; i <= 99; i++ {
-		writeLedgerHeader(&buf, testLedgerHeader{sequence: uint32(i)})
+	for i := 64; i <= 100; i++ {
+		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
+		metaChan <- metaResult{
+			LedgerCloseMeta: &meta,
+		}
 	}
 
-	exitChan := make(chan struct{})
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(100), uint32(200)).Return(nil).Once()
-	mockRunner.On("getProcessExitChan").Return(exitChan)
-	mockRunner.On("getProcessExitError").Return(nil)
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("close").Return(nil).Once()
+	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
+	mockRunner.On("context").Return(context.Background())
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -184,33 +182,37 @@ func TestCaptivePrepareRange(t *testing.T) {
 			CurrentLedger: uint32(200),
 		}, nil)
 
+	cancelCalled := false
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 		checkpointManager: historyarchive.NewCheckpointManager(64),
+		cancel: context.CancelFunc(func() {
+			cancelCalled = true
+		}),
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
 	assert.NoError(t, err)
 	mockRunner.On("close").Return(nil).Once()
-	close(exitChan)
 	err = captiveBackend.Close()
 	assert.NoError(t, err)
+	assert.True(t, cancelCalled)
+	mockRunner.AssertExpectations(t)
+	mockArchive.AssertExpectations(t)
 }
 
 func TestCaptivePrepareRangeCrash(t *testing.T) {
-	var buf bytes.Buffer
-
-	ch := make(chan struct{})
-	close(ch)
+	metaChan := make(chan metaResult)
+	close(metaChan)
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(100), uint32(200)).Return(nil).Once()
-	mockRunner.On("getProcessExitChan").Return(ch)
-	mockRunner.On("getProcessExitError").Return(errors.New("exit code -1"))
-	mockRunner.On("getMetaPipe").Return(&buf)
+	mockRunner.On("getProcessExitError").Return(true, errors.New("exit code -1"))
+	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
 	mockRunner.On("close").Return(nil).Once()
+	mockRunner.On("context").Return(context.Background())
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -228,21 +230,27 @@ func TestCaptivePrepareRangeCrash(t *testing.T) {
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
-	assert.Error(t, err)
-	assert.EqualError(t, err, "stellar-core process exited with an error: exit code -1")
+	assert.EqualError(t, err, "Error fast-forwarding to 100: stellar core exited unexpectedly: exit code -1")
+	mockRunner.AssertExpectations(t)
+	mockArchive.AssertExpectations(t)
 }
 
 func TestCaptivePrepareRangeTerminated(t *testing.T) {
-	var buf bytes.Buffer
+	metaChan := make(chan metaResult, 100)
 
-	ch := make(chan struct{})
-	close(ch)
+	// Core will actually start with the last checkpoint before the from ledger
+	// and then rewind to the `from` ledger.
+	for i := 64; i <= 100; i++ {
+		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
+		metaChan <- metaResult{
+			LedgerCloseMeta: &meta,
+		}
+	}
+	close(metaChan)
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(100), uint32(200)).Return(nil).Once()
-	mockRunner.On("getProcessExitChan").Return(ch)
-	mockRunner.On("getProcessExitError").Return(nil)
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("close").Return(nil).Once()
+	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
+	mockRunner.On("context").Return(context.Background())
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -261,11 +269,14 @@ func TestCaptivePrepareRangeTerminated(t *testing.T) {
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
 	assert.NoError(t, err)
+	mockRunner.AssertExpectations(t)
+	mockArchive.AssertExpectations(t)
 }
 
 func TestCaptivePrepareRange_ErrClosingSession(t *testing.T) {
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("close").Return(fmt.Errorf("transient error"))
+	mockRunner.On("context").Return(context.Background())
 
 	captiveBackend := CaptiveStellarCore{
 		nextLedger:        300,
@@ -273,16 +284,15 @@ func TestCaptivePrepareRange_ErrClosingSession(t *testing.T) {
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
-	assert.EqualError(t, err, "opening subprocess: error closing existing session: error closing stellar-core subprocess: transient error")
+	assert.EqualError(t, err, "error starting prepare range: error closing existing session: transient error")
+
+	err = captiveBackend.PrepareRange(UnboundedRange(64))
+	assert.EqualError(t, err, "error starting prepare range: error closing existing session: transient error")
+
+	mockRunner.AssertExpectations(t)
 }
 
 func TestCaptivePrepareRange_ErrGettingRootHAS(t *testing.T) {
-	var buf bytes.Buffer
-	mockRunner := &stellarCoreRunnerMock{}
-	mockRunner.On("catchup", uint32(100), uint32(200)).Return(nil).Once()
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("close").Return(nil)
-
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
 		On("GetRootHAS").
@@ -293,16 +303,15 @@ func TestCaptivePrepareRange_ErrGettingRootHAS(t *testing.T) {
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
-	assert.EqualError(t, err, "opening subprocess: error getting latest checkpoint sequence: error getting root HAS: transient error")
+	assert.EqualError(t, err, "error starting prepare range: opening subprocess: error getting latest checkpoint sequence: error getting root HAS: transient error")
+
+	err = captiveBackend.PrepareRange(UnboundedRange(100))
+	assert.EqualError(t, err, "error starting prepare range: opening subprocess: error getting latest checkpoint sequence: error getting root HAS: transient error")
+
+	mockArchive.AssertExpectations(t)
 }
 
 func TestCaptivePrepareRange_FromIsAheadOfRootHAS(t *testing.T) {
-	var buf bytes.Buffer
-	mockRunner := &stellarCoreRunnerMock{}
-	mockRunner.On("catchup", uint32(100), uint32(200)).Return(nil).Once()
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("close").Return(nil)
-
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
 		On("GetRootHAS").
@@ -315,16 +324,30 @@ func TestCaptivePrepareRange_FromIsAheadOfRootHAS(t *testing.T) {
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
-	assert.EqualError(t, err, "opening subprocess: sequence: 100 is greater than max available in history archives: 64")
+	assert.EqualError(t, err, "error starting prepare range: opening subprocess: sequence: 100 is greater than max available in history archives: 64")
+
+	err = captiveBackend.PrepareRange(UnboundedRange(100))
+	assert.EqualError(t, err, "error starting prepare range: opening subprocess: trying to start online mode too far (latest checkpoint=64), only two checkpoints in the future allowed")
+
+	mockArchive.AssertExpectations(t)
 }
 
 func TestCaptivePrepareRange_ToIsAheadOfRootHAS(t *testing.T) {
-	var buf bytes.Buffer
+	metaChan := make(chan metaResult, 100)
+
+	// Core will actually start with the last checkpoint before the from ledger
+	// and then rewind to the `from` ledger.
+	for i := 64; i <= 100; i++ {
+		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
+		metaChan <- metaResult{
+			LedgerCloseMeta: &meta,
+		}
+	}
+
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(100), uint32(192)).Return(nil).Once()
-	mockRunner.On("getProcessExitChan").Return(make(chan struct{}))
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("close").Return(nil)
+	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
+	mockRunner.On("context").Return(context.Background())
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -343,6 +366,9 @@ func TestCaptivePrepareRange_ToIsAheadOfRootHAS(t *testing.T) {
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
 	assert.NoError(t, err)
+
+	mockArchive.AssertExpectations(t)
+	mockRunner.AssertExpectations(t)
 }
 
 func TestCaptivePrepareRange_ErrCatchup(t *testing.T) {
@@ -357,60 +383,26 @@ func TestCaptivePrepareRange_ErrCatchup(t *testing.T) {
 			CurrentLedger: uint32(192),
 		}, nil)
 
+	cancelCalled := false
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
+		cancel: context.CancelFunc(func() {
+			cancelCalled = true
+		}),
 	}
 
 	err := captiveBackend.PrepareRange(BoundedRange(100, 200))
-	assert.Error(t, err)
-	assert.EqualError(t, err, "opening subprocess: error running stellar-core: transient error")
+	assert.EqualError(t, err, "error starting prepare range: opening subprocess: error running stellar-core: transient error")
 
 	// make sure we can Close without errors
 	assert.NoError(t, captiveBackend.Close())
+	assert.True(t, cancelCalled)
+
+	mockArchive.AssertExpectations(t)
 	mockRunner.AssertExpectations(t)
-}
-
-func TestCaptivePrepareRangeUnboundedRange_ErrGettingRootHAS(t *testing.T) {
-	var buf bytes.Buffer
-	mockRunner := &stellarCoreRunnerMock{}
-	mockRunner.On("catchup", uint32(100), uint32(192)).Return(nil).Once()
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("close").Return(nil)
-
-	mockArchive := &historyarchive.MockArchive{}
-	mockArchive.
-		On("GetRootHAS").
-		Return(historyarchive.HistoryArchiveState{}, errors.New("transient error"))
-
-	captiveBackend := CaptiveStellarCore{
-		archive: mockArchive,
-	}
-
-	err := captiveBackend.PrepareRange(UnboundedRange(100))
-	assert.EqualError(t, err, "opening subprocess: error getting latest checkpoint sequence: error getting root HAS: transient error")
-}
-
-func TestCaptivePrepareRangeUnboundedRange_FromIsTooFarAheadOfLatestHAS(t *testing.T) {
-	mockRunner := &stellarCoreRunnerMock{}
-	mockRunner.On("close").Return(nil)
-
-	mockArchive := &historyarchive.MockArchive{}
-	mockArchive.
-		On("GetRootHAS").
-		Return(historyarchive.HistoryArchiveState{
-			CurrentLedger: uint32(64),
-		}, nil)
-
-	captiveBackend := CaptiveStellarCore{
-		archive:           mockArchive,
-		checkpointManager: historyarchive.NewCheckpointManager(64),
-	}
-
-	err := captiveBackend.PrepareRange(UnboundedRange(193))
-	assert.EqualError(t, err, "opening subprocess: trying to start online mode too far (latest checkpoint=64), only two checkpoints in the future allowed")
 }
 
 func TestCaptivePrepareRangeUnboundedRange_ErrRunFrom(t *testing.T) {
@@ -429,57 +421,45 @@ func TestCaptivePrepareRangeUnboundedRange_ErrRunFrom(t *testing.T) {
 		On("GetLedgerHeader", uint32(127)).
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
+	cancelCalled := false
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
 		checkpointManager: historyarchive.NewCheckpointManager(64),
+		cancel: context.CancelFunc(func() {
+			cancelCalled = true
+		}),
 	}
 
 	err := captiveBackend.PrepareRange(UnboundedRange(128))
-	assert.EqualError(t, err, "opening subprocess: error running stellar-core: transient error")
+	assert.EqualError(t, err, "error starting prepare range: opening subprocess: error running stellar-core: transient error")
 
 	// make sure we can Close without errors
 	assert.NoError(t, captiveBackend.Close())
+	assert.True(t, cancelCalled)
+
+	mockArchive.AssertExpectations(t)
 	mockRunner.AssertExpectations(t)
 }
 
-func TestCaptivePrepareRangeUnboundedRange_ErrClosingExistingSession(t *testing.T) {
-	mockRunner := &stellarCoreRunnerMock{}
-	mockRunner.On("close").Return(errors.New("transient error"))
-
-	mockArchive := &historyarchive.MockArchive{}
-	mockArchive.
-		On("GetRootHAS").
-		Return(historyarchive.HistoryArchiveState{
-			CurrentLedger: uint32(127),
-		}, nil)
-
-	last := uint32(63)
-	captiveBackend := CaptiveStellarCore{
-		nextLedger:        63,
-		lastLedger:        &last,
-		stellarCoreRunner: mockRunner,
-		checkpointManager: historyarchive.NewCheckpointManager(64),
-	}
-
-	err := captiveBackend.PrepareRange(UnboundedRange(64))
-	assert.EqualError(t, err, "opening subprocess: error closing existing session: error closing stellar-core subprocess: transient error")
-}
 func TestCaptivePrepareRangeUnboundedRange_ReuseSession(t *testing.T) {
-	var buf bytes.Buffer
+	metaChan := make(chan metaResult, 100)
 
+	// Core will actually start with the last checkpoint before the from ledger
+	// and then rewind to the `from` ledger.
 	for i := 2; i <= 65; i++ {
-		writeLedgerHeader(&buf, testLedgerHeader{sequence: uint32(i)})
+		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
+		metaChan <- metaResult{
+			LedgerCloseMeta: &meta,
+		}
 	}
 
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("runFrom", uint32(62), "0000000000000000000000000000000000000000000000000000000000000000").Return(nil).Once()
-	mockRunner.On("runFrom", uint32(63), "0000000000000000000000000000000000000000000000000000000000000000").Return(nil).Once()
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("getProcessExitChan").Return(make(chan struct{}))
-	mockRunner.On("close").Return(nil)
+	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
+	mockRunner.On("context").Return(context.Background())
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -505,22 +485,27 @@ func TestCaptivePrepareRangeUnboundedRange_ReuseSession(t *testing.T) {
 	captiveBackend.nextLedger = 64
 	err = captiveBackend.PrepareRange(UnboundedRange(65))
 	assert.NoError(t, err)
+
+	mockArchive.AssertExpectations(t)
+	mockRunner.AssertExpectations(t)
 }
 
 func TestGetLatestLedgerSequence(t *testing.T) {
-	var buf bytes.Buffer
+	metaChan := make(chan metaResult, 300)
 
+	// Core will actually start with the last checkpoint before the from ledger
+	// and then rewind to the `from` ledger.
 	for i := 2; i <= 200; i++ {
-		writeLedgerHeader(&buf, testLedgerHeader{sequence: uint32(i)})
+		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
+		metaChan <- metaResult{
+			LedgerCloseMeta: &meta,
+		}
 	}
 
-	exitChan := make(chan struct{})
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("runFrom", uint32(62), "0000000000000000000000000000000000000000000000000000000000000000").Return(nil).Once()
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("getProcessExitChan").Return(exitChan)
-	mockRunner.On("getProcessExitError").Return(nil)
-	mockRunner.On("close").Return(nil).Once()
+	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
+	mockRunner.On("context").Return(context.Background())
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -544,44 +529,30 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 	err := captiveBackend.PrepareRange(UnboundedRange(64))
 	assert.NoError(t, err)
 
-	// To prevent flaky test runs wait for channel to fill.
-	waitForBufferToFill(&captiveBackend)
-
 	latest, err := captiveBackend.GetLatestLedgerSequence()
 	assert.NoError(t, err)
-	// This should be last read ledger + ledgerReadAheadBufferSize.
-	assert.Equal(t, uint32(64+ledgerReadAheadBufferSize), latest)
+	assert.Equal(t, uint32(200), latest)
 
-	exists, _, err := captiveBackend.GetLedger(64)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-
-	waitForBufferToFill(&captiveBackend)
-
-	latest, err = captiveBackend.GetLatestLedgerSequence()
-	assert.NoError(t, err)
-	// This should be last read ledger + ledgerReadAheadBufferSize.
-	assert.Equal(t, uint32(64+ledgerReadAheadBufferSize), latest)
-
-	mockRunner.On("close").Return(nil).Once()
-
-	close(exitChan)
-
-	err = captiveBackend.Close()
-	assert.NoError(t, err)
+	mockArchive.AssertExpectations(t)
+	mockRunner.AssertExpectations(t)
 }
+
 func TestCaptiveGetLedger(t *testing.T) {
 	tt := assert.New(t)
-	var buf bytes.Buffer
+	metaChan := make(chan metaResult, 300)
+
 	for i := 64; i <= 66; i++ {
-		writeLedgerHeader(&buf, testLedgerHeader{sequence: uint32(i)})
+		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
+		metaChan <- metaResult{
+			LedgerCloseMeta: &meta,
+		}
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(65), uint32(66)).Return(nil)
-	mockRunner.On("getProcessExitChan").Return(make(chan struct{}))
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("close").Return(nil)
+	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
+	mockRunner.On("context").Return(ctx)
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -605,22 +576,26 @@ func TestCaptiveGetLedger(t *testing.T) {
 	err = captiveBackend.PrepareRange(BoundedRange(65, 66))
 	assert.NoError(t, err)
 
+	_, _, err = captiveBackend.GetLedger(64)
+	tt.Error(err, "requested ledger 64 is behind the captive core stream (expected=66)")
+
 	// reads value from buffer
-	found, meta, err := captiveBackend.GetLedger(64)
+	found, meta, err := captiveBackend.GetLedger(65)
 	tt.NoError(err)
 	tt.True(found)
-	tt.Equal(xdr.Uint32(64), meta.V0.LedgerHeader.Header.LedgerSeq)
-
-	// advance to next sequence number
-	tt.Equal(uint32(65), captiveBackend.nextLedger)
+	tt.Equal(xdr.Uint32(65), meta.V0.LedgerHeader.Header.LedgerSeq)
 
 	// reads value from cachedMeta
-	_, cachedMeta, err := captiveBackend.GetLedger(64)
+	_, cachedMeta, err := captiveBackend.GetLedger(65)
 	tt.NoError(err)
 	tt.Equal(meta, cachedMeta)
 
 	// next sequence number didn't get consumed
-	tt.Equal(uint32(65), captiveBackend.nextLedger)
+	tt.Equal(uint32(66), captiveBackend.nextLedger)
+
+	mockRunner.On("close").Return(nil).Run(func(args mock.Arguments) {
+		cancel()
+	}).Once()
 
 	_, _, err = captiveBackend.GetLedger(66)
 	tt.NoError(err)
@@ -631,21 +606,32 @@ func TestCaptiveGetLedger(t *testing.T) {
 	// we should be able to call last ledger even after get ledger is closed
 	_, _, err = captiveBackend.GetLedger(66)
 	tt.NoError(err)
+
+	mockArchive.AssertExpectations(t)
+	mockRunner.AssertExpectations(t)
 }
 
 func TestCaptiveGetLedger_NextLedgerIsDifferentToLedgerFromBuffer(t *testing.T) {
 	tt := assert.New(t)
-	var buf bytes.Buffer
-	for i := 64; i <= 65; i++ {
-		writeLedgerHeader(&buf, testLedgerHeader{sequence: uint32(i)})
-	}
+	metaChan := make(chan metaResult, 100)
 
-	writeLedgerHeader(&buf, testLedgerHeader{sequence: uint32(68)})
+	for i := 64; i <= 65; i++ {
+		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
+		metaChan <- metaResult{
+			LedgerCloseMeta: &meta,
+		}
+	}
+	{
+		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(68)})
+		metaChan <- metaResult{
+			LedgerCloseMeta: &meta,
+		}
+	}
 
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(65), uint32(66)).Return(nil)
-	mockRunner.On("getProcessExitChan").Return(make(chan struct{}))
-	mockRunner.On("getMetaPipe").Return(&buf)
+	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
+	mockRunner.On("context").Return(context.Background())
 	mockRunner.On("close").Return(nil)
 
 	mockArchive := &historyarchive.MockArchive{}
@@ -668,16 +654,34 @@ func TestCaptiveGetLedger_NextLedgerIsDifferentToLedgerFromBuffer(t *testing.T) 
 
 	_, _, err = captiveBackend.GetLedger(66)
 	tt.EqualError(err, "unexpected ledger sequence (expected=66 actual=68)")
+
+	mockArchive.AssertExpectations(t)
+	mockRunner.AssertExpectations(t)
 }
+
 func TestCaptiveGetLedger_ErrReadingMetaResult(t *testing.T) {
 	tt := assert.New(t)
-	var buf bytes.Buffer
+	metaChan := make(chan metaResult, 100)
+
+	for i := 64; i <= 65; i++ {
+		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
+		metaChan <- metaResult{
+			LedgerCloseMeta: &meta,
+		}
+	}
+	metaChan <- metaResult{
+		err: fmt.Errorf("unmarshalling error"),
+	}
 
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(65), uint32(66)).Return(nil)
-	mockRunner.On("getProcessExitChan").Return(make(chan struct{}))
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("close").Return(nil)
+	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
+	ctx, cancel := context.WithCancel(context.Background())
+	mockRunner.On("context").Return(ctx)
+	mockRunner.On("getProcessExitError").Return(false, nil)
+	mockRunner.On("close").Return(nil).Run(func(args mock.Arguments) {
+		cancel()
+	}).Once()
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -697,25 +701,38 @@ func TestCaptiveGetLedger_ErrReadingMetaResult(t *testing.T) {
 	err := captiveBackend.PrepareRange(BoundedRange(65, 66))
 	assert.NoError(t, err)
 
+	found, meta, err := captiveBackend.GetLedger(65)
+	tt.NoError(err)
+	tt.True(found)
+	tt.Equal(xdr.Uint32(65), meta.V0.LedgerHeader.Header.LedgerSeq)
+
 	// try reading from an empty buffer
-	_, _, err = captiveBackend.GetLedger(64)
-	tt.EqualError(err, "error reading frame length: unmarshalling XDR frame header: xdr:DecodeUint: EOF while decoding 4 bytes - read: '[]'")
+	_, _, err = captiveBackend.GetLedger(66)
+	tt.EqualError(err, "unmarshalling error")
 
 	// closes if there is an error getting ledger
 	tt.True(captiveBackend.isClosed())
+
+	mockArchive.AssertExpectations(t)
+	mockRunner.AssertExpectations(t)
 }
+
 func TestCaptiveGetLedger_ErrClosingAfterLastLedger(t *testing.T) {
 	tt := assert.New(t)
-	var buf bytes.Buffer
+	metaChan := make(chan metaResult, 100)
+
 	for i := 64; i <= 66; i++ {
-		writeLedgerHeader(&buf, testLedgerHeader{sequence: uint32(i)})
+		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
+		metaChan <- metaResult{
+			LedgerCloseMeta: &meta,
+		}
 	}
 
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(65), uint32(66)).Return(nil)
-	mockRunner.On("getProcessExitChan").Return(make(chan struct{}))
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("close").Return(fmt.Errorf("transient error"))
+	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
+	mockRunner.On("context").Return(context.Background())
+	mockRunner.On("close").Return(fmt.Errorf("transient error")).Once()
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -736,136 +753,26 @@ func TestCaptiveGetLedger_ErrClosingAfterLastLedger(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, _, err = captiveBackend.GetLedger(66)
-	tt.EqualError(err, "error closing session: error closing stellar-core subprocess: transient error")
-}
+	tt.EqualError(err, "error closing session: transient error")
 
-// TestCaptiveGetLedger_BoundedGetLedgerAfterCoreExit tests if GetLedger return
-// ledgers in a buffer after Stellar-Core process exits gracefully (because range
-// ledgers already streamed). This is checked to ensure Stellar-Core process exit
-// signal does not cause errors before getting all the ledgers from the range.
-func TestCaptiveGetLedger_BoundedGetLedgerAfterCoreExit(t *testing.T) {
-	tt := assert.New(t)
-	var buf bytes.Buffer
-	for i := 64; i <= 70; i++ {
-		writeLedgerHeader(&buf, testLedgerHeader{sequence: uint32(i)})
-	}
-
-	mockRunner := &stellarCoreRunnerMock{}
-	exitChan := make(chan struct{})
-	mockRunner.On("catchup", uint32(65), uint32(70)).Return(nil)
-	mockRunner.On("getProcessExitChan").Return(exitChan)
-	mockRunner.On("getProcessExitError").Return(nil)
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("close").Return(nil)
-
-	mockArchive := &historyarchive.MockArchive{}
-	mockArchive.
-		On("GetRootHAS").
-		Return(historyarchive.HistoryArchiveState{
-			CurrentLedger: uint32(200),
-		}, nil)
-
-	captiveBackend := CaptiveStellarCore{
-		archive: mockArchive,
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
-			return mockRunner, nil
-		},
-		checkpointManager: historyarchive.NewCheckpointManager(64),
-	}
-
-	err := captiveBackend.PrepareRange(BoundedRange(65, 70))
-	assert.NoError(t, err)
-
-	waitForLedgersInBuffer(&captiveBackend, 70-64+1)
-
-	// All ledgers from bounded range buffered so Stellar-Core terminates.
-	close(exitChan)
-
-	for seq := uint32(66); seq <= 70; seq++ {
-		_, _, err = captiveBackend.GetLedger(seq)
-		tt.NoError(err)
-	}
-
-	err = captiveBackend.Close()
-	assert.NoError(t, err)
-}
-
-// TestCaptiveGetLedger_CloseBufferFull tests the case when ledger buffer is full
-// and waitForClose() reads items from a channel to make room so that go routine
-// can return.
-func TestCaptiveGetLedger_CloseBufferFull(t *testing.T) {
-	var buf bytes.Buffer
-	for i := 2; i <= 200; i++ {
-		writeLedgerHeader(&buf, testLedgerHeader{sequence: uint32(i)})
-	}
-
-	mockRunner := &stellarCoreRunnerMock{}
-	exitChan := make(chan struct{})
-	mockRunner.On("runFrom", uint32(62), "0000000000000000000000000000000000000000000000000000000000000000").Return(nil).Once()
-	mockRunner.On("getProcessExitChan").Return(exitChan)
-	mockRunner.On("getProcessExitError").Return(nil)
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("close").Return(nil)
-
-	mockArchive := &historyarchive.MockArchive{}
-	mockArchive.
-		On("GetRootHAS").
-		Return(historyarchive.HistoryArchiveState{
-			CurrentLedger: uint32(200),
-		}, nil)
-	mockArchive.
-		On("GetLedgerHeader", uint32(63)).
-		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
-
-	captiveBackend := CaptiveStellarCore{
-		archive: mockArchive,
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
-			return mockRunner, nil
-		},
-		checkpointManager: historyarchive.NewCheckpointManager(64),
-	}
-
-	err := captiveBackend.PrepareRange(UnboundedRange(65))
-	assert.NoError(t, err)
-
-	waitForBufferToFill(&captiveBackend)
-
-	// All ledgers from bounded range buffered so Stellar-Core terminates.
-	// close(exitChan)
-
-	err = captiveBackend.Close()
-	assert.NoError(t, err)
-}
-
-func waitForLedgersInBuffer(captiveBackend *CaptiveStellarCore, count int) {
-	for {
-		if len(captiveBackend.stellarCoreRunner.getMetaPipe()) == count {
-			break
-		}
-	}
-}
-
-func waitForBufferToFill(captiveBackend *CaptiveStellarCore) {
-	for {
-		if len(captiveBackend.stellarCoreRunner.getMetaPipe()) == ledgerReadAheadBufferSize {
-			break
-		}
-	}
+	mockArchive.AssertExpectations(t)
+	mockRunner.AssertExpectations(t)
 }
 
 func TestGetLedgerBoundsCheck(t *testing.T) {
-	var buf bytes.Buffer
-	writeLedgerHeader(&buf, testLedgerHeader{sequence: 128})
-	writeLedgerHeader(&buf, testLedgerHeader{sequence: 129})
-	writeLedgerHeader(&buf, testLedgerHeader{sequence: 130})
+	metaChan := make(chan metaResult, 100)
+
+	for i := 128; i <= 130; i++ {
+		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
+		metaChan <- metaResult{
+			LedgerCloseMeta: &meta,
+		}
+	}
 
 	mockRunner := &stellarCoreRunnerMock{}
-	exitChan := make(chan struct{})
 	mockRunner.On("catchup", uint32(128), uint32(130)).Return(nil).Once()
-	mockRunner.On("getProcessExitChan").Return(exitChan).Maybe()
-	mockRunner.On("getProcessExitError").Return(nil).Maybe()
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("close").Return(nil).Once()
+	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
+	mockRunner.On("context").Return(context.Background())
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -899,79 +806,110 @@ func TestGetLedgerBoundsCheck(t *testing.T) {
 	_, _, err = captiveBackend.GetLedger(64)
 	assert.EqualError(t, err, "requested ledger 64 is behind the captive core stream (expected=129)")
 
-	err = captiveBackend.Close()
-	assert.NoError(t, err)
-	mockRunner.AssertExpectations(t)
-
-	buf.Reset()
-	writeLedgerHeader(&buf, testLedgerHeader{sequence: 64})
-	writeLedgerHeader(&buf, testLedgerHeader{sequence: 65})
-	writeLedgerHeader(&buf, testLedgerHeader{sequence: 66})
-
-	mockRunner.On("catchup", uint32(64), uint32(66)).Return(nil).Once()
-	mockRunner.On("getProcessExitChan").Return(exitChan)
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("close").Return(nil).Once()
-
-	err = captiveBackend.PrepareRange(BoundedRange(64, 66))
-	assert.NoError(t, err)
-
-	exists, meta, err = captiveBackend.GetLedger(64)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.Equal(t, uint32(64), meta.LedgerSequence())
-
-	close(exitChan)
-	err = captiveBackend.Close()
-	assert.NoError(t, err)
+	mockArchive.AssertExpectations(t)
 	mockRunner.AssertExpectations(t)
 }
 
-func TestCaptiveGetLedgerTerminated(t *testing.T) {
-	reader, writer := io.Pipe()
+func TestCaptiveGetLedgerTerminatedUnexpectedly(t *testing.T) {
+	ledger64 := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(64)})
 
-	ch := make(chan struct{})
-	mockRunner := &stellarCoreRunnerMock{}
-	mockRunner.On("catchup", uint32(64), uint32(100)).Return(nil).Once()
-	mockRunner.On("getProcessExitChan").Return(ch)
-	mockRunner.On("getProcessExitError").Return(nil)
-	mockRunner.On("getMetaPipe").Return(reader)
-	mockRunner.On("close").Return(nil).Once()
-
-	mockArchive := &historyarchive.MockArchive{}
-	mockArchive.
-		On("GetRootHAS").
-		Return(historyarchive.HistoryArchiveState{
-			CurrentLedger: uint32(200),
-		}, nil)
-
-	captiveBackend := CaptiveStellarCore{
-		archive: mockArchive,
-		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
-			return mockRunner, nil
+	for _, testCase := range []struct {
+		name               string
+		ctx                context.Context
+		ledgers            []metaResult
+		processExited      bool
+		processExitedError error
+		expectedError      string
+	}{
+		{
+			"stellar core exited unexpectedly without error",
+			context.Background(),
+			[]metaResult{{LedgerCloseMeta: &ledger64}, {err: fmt.Errorf("transient error")}},
+			true,
+			nil,
+			"stellar core exited unexpectedly",
 		},
-		checkpointManager: historyarchive.NewCheckpointManager(64),
+		{
+			"stellar core exited unexpectedly with an error",
+			context.Background(),
+			[]metaResult{{LedgerCloseMeta: &ledger64}, {err: fmt.Errorf("transient error")}},
+			true,
+			fmt.Errorf("signal kill"),
+			"stellar core exited unexpectedly: signal kill",
+		},
+		{
+			"stellar core exited unexpectedly without error and closed channel",
+			context.Background(),
+			[]metaResult{{LedgerCloseMeta: &ledger64}},
+			true,
+			nil,
+			"stellar core exited unexpectedly",
+		},
+		{
+			"stellar core exited unexpectedly with an error and closed channel",
+			context.Background(),
+			[]metaResult{{LedgerCloseMeta: &ledger64}},
+			true,
+			fmt.Errorf("signal kill"),
+			"stellar core exited unexpectedly: signal kill",
+		},
+		{
+			"meta pipe closed unexpectedly",
+			context.Background(),
+			[]metaResult{{LedgerCloseMeta: &ledger64}},
+			false,
+			nil,
+			"meta pipe closed unexpectedly",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			metaChan := make(chan metaResult, 100)
+
+			for _, result := range testCase.ledgers {
+				metaChan <- result
+			}
+			close(metaChan)
+
+			mockRunner := &stellarCoreRunnerMock{}
+			mockRunner.On("catchup", uint32(64), uint32(100)).Return(nil).Once()
+			mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
+			mockRunner.On("context").Return(context.Background())
+			mockRunner.On("getProcessExitError").Return(testCase.processExited, testCase.processExitedError)
+			mockRunner.On("close").Return(nil).Once()
+
+			mockArchive := &historyarchive.MockArchive{}
+			mockArchive.
+				On("GetRootHAS").
+				Return(historyarchive.HistoryArchiveState{
+					CurrentLedger: uint32(200),
+				}, nil)
+
+			captiveBackend := CaptiveStellarCore{
+				archive: mockArchive,
+				stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
+					return mockRunner, nil
+				},
+				checkpointManager: historyarchive.NewCheckpointManager(64),
+			}
+
+			err := captiveBackend.PrepareRange(BoundedRange(64, 100))
+			assert.NoError(t, err)
+
+			exists, meta, err := captiveBackend.GetLedger(64)
+			assert.NoError(t, err)
+			assert.True(t, exists)
+			assert.Equal(t, uint32(64), meta.LedgerSequence())
+
+			_, _, err = captiveBackend.GetLedger(65)
+			assert.EqualError(t, err, testCase.expectedError)
+
+			mockArchive.AssertExpectations(t)
+			mockRunner.AssertExpectations(t)
+		})
 	}
-
-	go writeLedgerHeader(writer, testLedgerHeader{sequence: 64})
-	err := captiveBackend.PrepareRange(BoundedRange(64, 100))
-	assert.NoError(t, err)
-
-	exists, meta, err := captiveBackend.GetLedger(64)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.Equal(t, uint32(64), meta.LedgerSequence())
-
-	close(ch)
-	writer.Close()
-
-	_, _, err = captiveBackend.GetLedger(65)
-	assert.Error(t, err)
-	assert.EqualError(t, err, "stellar-core process exited unexpectedly without an error")
 }
 
 func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
-	mockRunner := &stellarCoreRunnerMock{}
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
 		On("GetLedgerHeader", uint32(255)).
@@ -995,7 +933,6 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
-		stellarCoreRunner: mockRunner,
 		ledgerHashStore:   mockLedgerHashStore,
 		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
@@ -1061,7 +998,6 @@ func TestCaptiveRunFromParams(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("from_%d", tc.from), func(t *testing.T) {
 			tt := assert.New(t)
-			mockRunner := &stellarCoreRunnerMock{}
 			mockArchive := &historyarchive.MockArchive{}
 			mockArchive.
 				On("GetLedgerHeader", uint32(tc.ledgerArchives)).
@@ -1073,7 +1009,6 @@ func TestCaptiveRunFromParams(t *testing.T) {
 
 			captiveBackend := CaptiveStellarCore{
 				archive:           mockArchive,
-				stellarCoreRunner: mockRunner,
 				checkpointManager: historyarchive.NewCheckpointManager(64),
 			}
 
@@ -1082,6 +1017,8 @@ func TestCaptiveRunFromParams(t *testing.T) {
 			tt.Equal(tc.runFrom, runFrom, "runFrom")
 			tt.Equal("0101010100000000000000000000000000000000000000000000000000000000", ledgerHash)
 			tt.Equal(tc.nextLedger, nextLedger, "nextLedger")
+
+			mockArchive.AssertExpectations(t)
 		})
 	}
 }
@@ -1107,15 +1044,25 @@ func TestCaptiveIsPrepared(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("next_%d_last_%d_cached_%d_range_%v", tc.nextLedger, tc.lastLedger, tc.cachedLedger, tc.ledgerRange), func(t *testing.T) {
-			//captiveBackend := CaptiveStellarCore{}
-			//
-			//result := captiveBackend.isPrepared(
-			//	tc.nextLedger,
-			//	tc.lastLedger,
-			//	tc.cachedLedger,
-			//	tc.ledgerRange,
-			//)
-			//assert.Equal(t, tc.result, result)
+			mockRunner := &stellarCoreRunnerMock{}
+			mockRunner.On("context").Return(context.Background()).Maybe()
+
+			captiveBackend := CaptiveStellarCore{
+				stellarCoreRunner: mockRunner,
+				nextLedger:        tc.nextLedger,
+			}
+			if tc.lastLedger > 0 {
+				captiveBackend.lastLedger = &tc.lastLedger
+			}
+			if tc.cachedLedger > 0 {
+				meta := buildLedgerCloseMeta(testLedgerHeader{
+					sequence: tc.cachedLedger,
+				})
+				captiveBackend.cachedMeta = &meta
+			}
+
+			result := captiveBackend.isPrepared(tc.ledgerRange)
+			assert.Equal(t, tc.result, result)
 		})
 	}
 }
@@ -1123,35 +1070,39 @@ func TestCaptiveIsPrepared(t *testing.T) {
 // TestCaptivePreviousLedgerCheck checks if previousLedgerHash is set in PrepareRange
 // and then checked and updated in GetLedger.
 func TestCaptivePreviousLedgerCheck(t *testing.T) {
-	var buf bytes.Buffer
+	metaChan := make(chan metaResult, 200)
 
 	h := 3
 	for i := 192; i <= 300; i++ {
-		writeLedgerHeader(&buf, testLedgerHeader{
+		meta := buildLedgerCloseMeta(testLedgerHeader{
 			sequence:           uint32(i),
 			hash:               fmt.Sprintf("%02x00000000000000000000000000000000000000000000000000000000000000", h),
 			previousLedgerHash: fmt.Sprintf("%02x00000000000000000000000000000000000000000000000000000000000000", h-1),
 		})
+		metaChan <- metaResult{
+			LedgerCloseMeta: &meta,
+		}
 		h++
 	}
 
-	// Write invalid hash
-	writeLedgerHeader(&buf, testLedgerHeader{
-		sequence:           301,
-		hash:               "0000000000000000000000000000000000000000000000000000000000000000",
-		previousLedgerHash: "0000000000000000000000000000000000000000000000000000000000000000",
-	})
+	{
+		// Write invalid hash
+		meta := buildLedgerCloseMeta(testLedgerHeader{
+			sequence:           301,
+			hash:               "0000000000000000000000000000000000000000000000000000000000000000",
+			previousLedgerHash: "0000000000000000000000000000000000000000000000000000000000000000",
+		})
+		metaChan <- metaResult{
+			LedgerCloseMeta: &meta,
+		}
 
-	ch := make(chan struct{})
+	}
+
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("runFrom", uint32(254), "0101010100000000000000000000000000000000000000000000000000000000").Return(nil).Once()
-	mockRunner.On("getMetaPipe").Return(&buf)
-	mockRunner.On("getProcessExitChan").Return(ch)
-	mockRunner.On("getProcessExitError").Return(nil).Maybe()
-	mockRunner.On("close").Run(func(args mock.Arguments) {
-		close(ch)
-	}).Return(nil)
-	defer mockRunner.AssertExpectations(t)
+	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
+	mockRunner.On("context").Return(context.Background())
+	mockRunner.On("close").Return(nil).Once()
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -1166,14 +1117,12 @@ func TestCaptivePreviousLedgerCheck(t *testing.T) {
 				PreviousLedgerHash: xdr.Hash{1, 1, 1, 1},
 			},
 		}, nil).Once()
-	defer mockArchive.AssertExpectations(t)
 
 	mockLedgerHashStore := &MockLedgerHashStore{}
 	mockLedgerHashStore.On("GetLedgerHash", uint32(254)).
 		Return("", false, nil).Once()
 	mockLedgerHashStore.On("GetLedgerHash", uint32(191)).
 		Return("0200000000000000000000000000000000000000000000000000000000000000", true, nil).Once()
-	defer mockLedgerHashStore.AssertExpectations(t)
 
 	captiveBackend := CaptiveStellarCore{
 		archive: mockArchive,
@@ -1197,6 +1146,7 @@ func TestCaptivePreviousLedgerCheck(t *testing.T) {
 	_, _, err = captiveBackend.GetLedger(301)
 	assert.EqualError(t, err, "unexpected previous ledger hash for ledger 301 (expected=6f00000000000000000000000000000000000000000000000000000000000000 actual=0000000000000000000000000000000000000000000000000000000000000000)")
 
-	err = captiveBackend.Close()
-	assert.NoError(t, err)
+	mockRunner.AssertExpectations(t)
+	mockArchive.AssertExpectations(t)
+	mockLedgerHashStore.AssertExpectations(t)
 }

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -2,6 +2,7 @@ package ledgerbackend
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -22,6 +23,11 @@ type stellarCoreRunnerMock struct {
 	mock.Mock
 }
 
+func (m *stellarCoreRunnerMock) context() context.Context {
+	a := m.Called()
+	return a.Get(0).(context.Context)
+}
+
 func (m *stellarCoreRunnerMock) catchup(from, to uint32) error {
 	a := m.Called(from, to)
 	return a.Error(0)
@@ -32,19 +38,14 @@ func (m *stellarCoreRunnerMock) runFrom(from uint32, hash string) error {
 	return a.Error(0)
 }
 
-func (m *stellarCoreRunnerMock) getMetaPipe() io.Reader {
+func (m *stellarCoreRunnerMock) getMetaPipe() <-chan metaResult {
 	a := m.Called()
-	return a.Get(0).(io.Reader)
+	return a.Get(0).(<-chan metaResult)
 }
 
-func (m *stellarCoreRunnerMock) getProcessExitChan() <-chan struct{} {
+func (m *stellarCoreRunnerMock) getProcessExitError() (bool, error) {
 	a := m.Called()
-	return a.Get(0).(chan struct{})
-}
-
-func (m *stellarCoreRunnerMock) getProcessExitError() error {
-	a := m.Called()
-	return a.Error(0)
+	return a.Bool(0), a.Error(1)
 }
 
 func (m *stellarCoreRunnerMock) close() error {
@@ -145,11 +146,12 @@ func TestCaptiveNew(t *testing.T) {
 
 	captiveStellarCore, err := NewCaptive(
 		CaptiveCoreConfig{
-			BinaryPath:          executablePath,
-			ConfigAppendPath:    configPath,
-			NetworkPassphrase:   networkPassphrase,
-			HistoryArchiveURLs:  historyURLs,
+			BinaryPath:         executablePath,
+			ConfigAppendPath:   configPath,
+			NetworkPassphrase:  networkPassphrase,
+			HistoryArchiveURLs: historyURLs,
 			CheckpointFrequency: 64,
+			Context:            context.Background(),
 		},
 	)
 
@@ -842,7 +844,7 @@ func TestCaptiveGetLedger_CloseBufferFull(t *testing.T) {
 
 func waitForLedgersInBuffer(captiveBackend *CaptiveStellarCore, count int) {
 	for {
-		if len(captiveBackend.ledgerBuffer.c) == count {
+		if len(captiveBackend.stellarCoreRunner.getMetaPipe()) == count {
 			break
 		}
 	}
@@ -850,7 +852,7 @@ func waitForLedgersInBuffer(captiveBackend *CaptiveStellarCore, count int) {
 
 func waitForBufferToFill(captiveBackend *CaptiveStellarCore) {
 	for {
-		if len(captiveBackend.ledgerBuffer.c) == ledgerReadAheadBufferSize {
+		if len(captiveBackend.stellarCoreRunner.getMetaPipe()) == ledgerReadAheadBufferSize {
 			break
 		}
 	}
@@ -1110,15 +1112,15 @@ func TestCaptiveIsPrepared(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("next_%d_last_%d_cached_%d_range_%v", tc.nextLedger, tc.lastLedger, tc.cachedLedger, tc.ledgerRange), func(t *testing.T) {
-			captiveBackend := CaptiveStellarCore{}
-
-			result := captiveBackend.isPrepared(
-				tc.nextLedger,
-				tc.lastLedger,
-				tc.cachedLedger,
-				tc.ledgerRange,
-			)
-			assert.Equal(t, tc.result, result)
+			//captiveBackend := CaptiveStellarCore{}
+			//
+			//result := captiveBackend.isPrepared(
+			//	tc.nextLedger,
+			//	tc.lastLedger,
+			//	tc.cachedLedger,
+			//	tc.ledgerRange,
+			//)
+			//assert.Equal(t, tc.result, result)
 		})
 	}
 }

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -156,7 +156,6 @@ func TestCaptiveNew(t *testing.T) {
 	)
 
 	assert.NoError(t, err)
-	assert.Equal(t, configPath, captiveStellarCore.configAppendPath)
 	assert.Equal(t, uint32(0), captiveStellarCore.nextLedger)
 	assert.NotNil(t, captiveStellarCore.archive)
 }
@@ -431,8 +430,7 @@ func TestCaptivePrepareRangeUnboundedRange_ErrRunFrom(t *testing.T) {
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:          mockArchive,
-		configAppendPath: "foo",
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -494,8 +492,7 @@ func TestCaptivePrepareRangeUnboundedRange_ReuseSession(t *testing.T) {
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:          mockArchive,
-		configAppendPath: "foo",
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -537,8 +534,7 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:          mockArchive,
-		configAppendPath: "foo",
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -822,8 +818,7 @@ func TestCaptiveGetLedger_CloseBufferFull(t *testing.T) {
 		Return(xdr.LedgerHeaderHistoryEntry{}, nil)
 
 	captiveBackend := CaptiveStellarCore{
-		archive:          mockArchive,
-		configAppendPath: "foo",
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},
@@ -1181,8 +1176,7 @@ func TestCaptivePreviousLedgerCheck(t *testing.T) {
 	defer mockLedgerHashStore.AssertExpectations(t)
 
 	captiveBackend := CaptiveStellarCore{
-		configAppendPath: "stellar-core.cfg",
-		archive:          mockArchive,
+		archive: mockArchive,
 		stellarCoreRunnerFactory: func(_ stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
 			return mockRunner, nil
 		},

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -544,7 +544,7 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 	err := captiveBackend.PrepareRange(UnboundedRange(64))
 	assert.NoError(t, err)
 
-	// To prevent flaky test runs handleExit for channel to fill.
+	// To prevent flaky test runs wait for channel to fill.
 	waitForBufferToFill(&captiveBackend)
 
 	latest, err := captiveBackend.GetLatestLedgerSequence()

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -544,7 +544,7 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 	err := captiveBackend.PrepareRange(UnboundedRange(64))
 	assert.NoError(t, err)
 
-	// To prevent flaky test runs wait for channel to fill.
+	// To prevent flaky test runs handleExit for channel to fill.
 	waitForBufferToFill(&captiveBackend)
 
 	latest, err := captiveBackend.GetLatestLedgerSequence()

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -274,7 +274,7 @@ func (r *stellarCoreRunner) catchup(from, to uint32) error {
 	}
 
 	r.started = true
-	r.ledgerBuffer = newBufferedLedgerMetaReader(r.ctx, r.pipe.Reader)
+	r.ledgerBuffer = newBufferedLedgerMetaReader(r.pipe.Reader)
 	go r.ledgerBuffer.start()
 	r.wg.Add(1)
 	go r.handleExit(cmd)
@@ -312,7 +312,7 @@ func (r *stellarCoreRunner) runFrom(from uint32, hash string) error {
 	}
 
 	r.started = true
-	r.ledgerBuffer = newBufferedLedgerMetaReader(r.ctx, r.pipe.Reader)
+	r.ledgerBuffer = newBufferedLedgerMetaReader(r.pipe.Reader)
 	go r.ledgerBuffer.start()
 	r.wg.Add(1)
 	go r.handleExit(cmd)

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -242,6 +242,11 @@ func (r *stellarCoreRunner) catchup(from, to uint32) error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
+	// check if we have already been closed
+	if r.ctx.Err() != nil {
+		return r.ctx.Err()
+	}
+
 	if r.started {
 		return errors.New("runner already started")
 	}
@@ -277,10 +282,15 @@ func (r *stellarCoreRunner) runFrom(from uint32, hash string) error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
+	// check if we have already been closed
+	if r.ctx.Err() != nil {
+		return r.ctx.Err()
+	}
+
 	if r.started {
 		return errors.New("runner already started")
 	}
-	var err error
+
 	r.cmd = r.createCmd(
 		"run",
 		"--in-memory",
@@ -288,6 +298,8 @@ func (r *stellarCoreRunner) runFrom(from uint32, hash string) error {
 		"--start-at-hash", hash,
 		"--metadata-output-stream", r.getPipeName(),
 	)
+
+	var err error
 	r.pipe, err = r.start()
 	if err != nil {
 		r.closeLogLineWriters()
@@ -351,11 +363,6 @@ func (r *stellarCoreRunner) close() error {
 	started := r.started
 	tempDir := r.tempDir
 
-	if !started {
-		r.lock.Unlock()
-		return errors.New("runner has not started")
-	}
-
 	r.tempDir = ""
 
 	// check if we have already closed
@@ -367,17 +374,21 @@ func (r *stellarCoreRunner) close() error {
 	r.cancel()
 	r.lock.Unlock()
 
-	// wait for the stellar core process to terminate
-	r.wg.Wait()
+	// only reap captive core sub process and related go routines if we've started
+	// otherwise, just cleanup the temp dir
+	if started {
+		// wait for the stellar core process to terminate
+		r.wg.Wait()
 
-	// drain meta pipe channel to make sure the ledger buffer goroutine exits
-	for range r.getMetaPipe() {
+		// drain meta pipe channel to make sure the ledger buffer goroutine exits
+		for range r.getMetaPipe() {
 
+		}
+
+		// now it's safe to close the pipe reader
+		// because the ledger buffer is no longer reading from it
+		r.pipe.Reader.Close()
 	}
-
-	// now it's safe to close the pipe reader
-	// because the ledger buffer is no longer reading from it
-	r.pipe.Reader.Close()
 
 	return os.RemoveAll(tempDir)
 }

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -16,8 +16,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-
 	"github.com/stellar/go/support/log"
 )
 
@@ -79,12 +77,6 @@ func newStellarCoreRunner(config CaptiveCoreConfig, mode stellarCoreRunnerMode) 
 		return nil, errors.Wrap(err, "error creating subprocess tmpdir")
 	}
 
-	coreLogger := config.Log
-	if coreLogger == nil {
-		coreLogger = log.New()
-		coreLogger.Logger.SetOutput(os.Stdout)
-		coreLogger.SetLevel(logrus.InfoLevel)
-	}
 	ctx, cancel := context.WithCancel(config.Context)
 
 	runner := &stellarCoreRunner{
@@ -98,7 +90,7 @@ func newStellarCoreRunner(config CaptiveCoreConfig, mode stellarCoreRunnerMode) 
 		cancel:            cancel,
 		tempDir:           tempDir,
 		nonce:             fmt.Sprintf("captive-stellar-core-%x", r.Uint64()),
-		log:               coreLogger,
+		log:               config.Log,
 	}
 
 	if err := runner.writeConf(); err != nil {

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -66,11 +66,8 @@ type stellarCoreRunner struct {
 }
 
 func newStellarCoreRunner(config CaptiveCoreConfig, mode stellarCoreRunnerMode) (*stellarCoreRunner, error) {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	// Create temp dir
-	random := rand.New(rand.NewSource(time.Now().UnixNano()))
-	tempDir := filepath.Join(os.TempDir(), fmt.Sprintf("captive-stellar-core-%x", random.Uint64()))
-	err := os.MkdirAll(tempDir, 0755)
+	tempDir, err := ioutil.TempDir("", "captive-stellar-core")
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating subprocess tmpdir")
 	}
@@ -87,8 +84,11 @@ func newStellarCoreRunner(config CaptiveCoreConfig, mode stellarCoreRunnerMode) 
 		ctx:               ctx,
 		cancel:            cancel,
 		tempDir:           tempDir,
-		nonce:             fmt.Sprintf("captive-stellar-core-%x", r.Uint64()),
-		log:               config.Log,
+		nonce: fmt.Sprintf(
+			"captive-stellar-core-%x",
+			rand.New(rand.NewSource(time.Now().UnixNano())).Uint64(),
+		),
+		log: config.Log,
 	}
 
 	if err := runner.writeConf(); err != nil {

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -220,7 +220,7 @@ func (r *stellarCoreRunner) createCmd(params ...string) *exec.Cmd {
 
 func (r *stellarCoreRunner) runCmd(params ...string) error {
 	cmd := r.createCmd(params...)
-	defer r.closeLogLineWriters()
+	defer r.closeLogLineWriters(cmd)
 
 	if err := cmd.Start(); err != nil {
 		return errors.Wrapf(err, "could not start `stellar-core %v` cmd", params)
@@ -264,7 +264,7 @@ func (r *stellarCoreRunner) catchup(from, to uint32) error {
 	var err error
 	r.pipe, err = r.start()
 	if err != nil {
-		r.closeLogLineWriters()
+		r.closeLogLineWriters(r.cmd)
 		return errors.Wrap(err, "error starting `stellar-core catchup` subprocess")
 	}
 
@@ -302,7 +302,7 @@ func (r *stellarCoreRunner) runFrom(from uint32, hash string) error {
 	var err error
 	r.pipe, err = r.start()
 	if err != nil {
-		r.closeLogLineWriters()
+		r.closeLogLineWriters(r.cmd)
 		return errors.Wrap(err, "error starting `stellar-core run` subprocess")
 	}
 
@@ -318,7 +318,7 @@ func (r *stellarCoreRunner) runFrom(from uint32, hash string) error {
 func (r *stellarCoreRunner) wait() {
 	defer r.wg.Done()
 	waitErr := r.cmd.Wait()
-	r.closeLogLineWriters()
+	r.closeLogLineWriters(r.cmd)
 
 	r.lock.Lock()
 	defer r.lock.Unlock()
@@ -336,9 +336,9 @@ func (r *stellarCoreRunner) wait() {
 }
 
 // closeLogLineWriters closes the go routines created by getLogLineWriter()
-func (r *stellarCoreRunner) closeLogLineWriters() {
-	r.cmd.Stdout.(*io.PipeWriter).Close()
-	r.cmd.Stderr.(*io.PipeWriter).Close()
+func (r *stellarCoreRunner) closeLogLineWriters(cmd *exec.Cmd) {
+	cmd.Stdout.(*io.PipeWriter).Close()
+	cmd.Stderr.(*io.PipeWriter).Close()
 }
 
 // getMetaPipe returns a channel which contains ledgers streamed from the captive core subprocess

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -358,12 +358,13 @@ func (r *stellarCoreRunner) close() error {
 	r.lock.Lock()
 	started := r.started
 	tempDir := r.tempDir
-	r.tempDir = ""
 
 	if !started {
 		r.lock.Unlock()
 		return errors.New("runner has not started")
 	}
+
+	r.tempDir = ""
 
 	// check if we have already closed
 	if tempDir == "" {

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -35,9 +35,16 @@ const (
 	stellarCoreRunnerModeOffline
 )
 
+// stellarCoreRunner uses a named pipe ( https://en.wikipedia.org/wiki/Named_pipe ) to stream ledgers directly
+// from Stellar Core
 type pipe struct {
+	// stellarCoreRunner will be reading ledgers emitted by Stellar Core from the pipe.
+	// After the Stellar Core process exits, stellarCoreRunner should eventually close the reader.
 	Reader io.ReadCloser
-	Writer io.Closer
+	// stellarCoreRunner is responsible for closing the named pipe file after the Stellar Core process exits.
+	// However, only the Stellar Core process will be writing to the pipe. stellarCoreRunner should not
+	// write anything to the named pipe file which is why the type of File is io.Closer.
+	File io.Closer
 }
 
 type stellarCoreRunner struct {
@@ -321,11 +328,10 @@ func (r *stellarCoreRunner) handleExit(cmd *exec.Cmd) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	// by closing the pipe writer we will send an EOF to the ledgerBuffer
-	// we need to do this operation with the lock to ensure that
-	// the processExitError is available when the ledgerBuffer channel
-	// is closed
-	if closeErr := r.pipe.Writer.Close(); closeErr != nil {
+	// By closing the pipe file we will send an EOF to the pipe reader used by ledgerBuffer.
+	// We need to do this operation with the lock to ensure that the processExitError is available
+	// when the ledgerBuffer channel is closed
+	if closeErr := r.pipe.File.Close(); closeErr != nil {
 		r.log.WithError(closeErr).Warn("could not close captive core write pipe")
 	}
 

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -2,6 +2,7 @@ package ledgerbackend
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -23,11 +24,9 @@ import (
 type stellarCoreRunnerInterface interface {
 	catchup(from, to uint32) error
 	runFrom(from uint32, hash string) error
-	getMetaPipe() io.Reader
-	// getProcessExitChan returns a channel that closes on process exit
-	getProcessExitChan() <-chan struct{}
-	// getProcessExitError returns an exit error of the process, can be nil
-	getProcessExitError() error
+	getMetaPipe() <-chan metaResult
+	context() context.Context
+	getProcessExitError() (bool, error)
 	close() error
 }
 
@@ -38,6 +37,11 @@ const (
 	stellarCoreRunnerModeOffline
 )
 
+type pipe struct {
+	Reader io.ReadCloser
+	Writer io.Closer
+}
+
 type stellarCoreRunner struct {
 	executablePath    string
 	configAppendPath  string
@@ -46,19 +50,21 @@ type stellarCoreRunner struct {
 	httpPort          uint
 	mode              stellarCoreRunnerMode
 
-	started  bool
-	wg       sync.WaitGroup
-	shutdown chan struct{}
+	started      bool
+	wg           sync.WaitGroup
+	ctx          context.Context
+	cancel       context.CancelFunc
+	ledgerBuffer *bufferedLedgerMetaReader
+	pipe         pipe
 
 	cmd *exec.Cmd
 
-	// processExit channel receives an error when the process exited with an error
-	// or nil if the process exited without an error.
-	processExit      chan struct{}
+	lock             sync.Mutex
+	processExited    bool
 	processExitError error
-	metaPipe         io.Reader
-	tempDir          string
-	nonce            string
+
+	tempDir string
+	nonce   string
 
 	log *log.Entry
 }
@@ -79,6 +85,7 @@ func newStellarCoreRunner(config CaptiveCoreConfig, mode stellarCoreRunnerMode) 
 		coreLogger.Logger.SetOutput(os.Stdout)
 		coreLogger.SetLevel(logrus.InfoLevel)
 	}
+	ctx, cancel := context.WithCancel(config.Context)
 
 	runner := &stellarCoreRunner{
 		executablePath:    config.BinaryPath,
@@ -87,9 +94,8 @@ func newStellarCoreRunner(config CaptiveCoreConfig, mode stellarCoreRunnerMode) 
 		historyURLs:       config.HistoryArchiveURLs,
 		httpPort:          config.HTTPPort,
 		mode:              mode,
-		shutdown:          make(chan struct{}),
-		processExit:       make(chan struct{}),
-		processExitError:  nil,
+		ctx:               ctx,
+		cancel:            cancel,
 		tempDir:           tempDir,
 		nonce:             fmt.Sprintf("captive-stellar-core-%x", r.Uint64()),
 		log:               coreLogger,
@@ -211,32 +217,39 @@ func (r *stellarCoreRunner) writeConf() error {
 	return ioutil.WriteFile(r.getConfFileName(), []byte(conf), 0644)
 }
 
-func (r *stellarCoreRunner) createCmd(params ...string) (*exec.Cmd, error) {
+func (r *stellarCoreRunner) createCmd(params ...string) *exec.Cmd {
 	allParams := append([]string{"--conf", r.getConfFileName()}, params...)
-	cmd := exec.Command(r.executablePath, allParams...)
+	cmd := exec.CommandContext(r.ctx, r.executablePath, allParams...)
 	cmd.Dir = r.tempDir
 	cmd.Stdout = r.getLogLineWriter()
 	cmd.Stderr = r.getLogLineWriter()
-	return cmd, nil
+	return cmd
 }
 
 func (r *stellarCoreRunner) runCmd(params ...string) error {
-	cmd, err := r.createCmd(params...)
-	if err != nil {
-		return errors.Wrapf(err, "could not create `stellar-core %v` cmd", params)
-	}
+	cmd := r.createCmd(params...)
+	defer r.closeLogLineWriters()
 
-	if err = cmd.Start(); err != nil {
+	if err := cmd.Start(); err != nil {
 		return errors.Wrapf(err, "could not start `stellar-core %v` cmd", params)
 	}
 
-	if err = cmd.Wait(); err != nil {
+	if err := cmd.Wait(); err != nil {
 		return errors.Wrapf(err, "error waiting for `stellar-core %v` subprocess", params)
 	}
 	return nil
 }
 
+// context returns the context.Context instance associated with the running captive core instance
+func (r *stellarCoreRunner) context() context.Context {
+	return r.ctx
+}
+
+// catchup executes the catchup command on the captive core subprocess
 func (r *stellarCoreRunner) catchup(from, to uint32) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
 	if r.started {
 		return errors.New("runner already started")
 	}
@@ -245,82 +258,133 @@ func (r *stellarCoreRunner) catchup(from, to uint32) error {
 	}
 
 	rangeArg := fmt.Sprintf("%d/%d", to, to-from+1)
-	cmd, err := r.createCmd(
+	r.cmd = r.createCmd(
 		"catchup", rangeArg,
 		"--metadata-output-stream", r.getPipeName(),
 		"--replay-in-memory",
 	)
+
+	var err error
+	r.pipe, err = r.start()
 	if err != nil {
-		return errors.Wrap(err, "error creating `stellar-core catchup` subprocess")
-	}
-	r.cmd = cmd
-	r.metaPipe, err = r.start()
-	if err != nil {
+		r.closeLogLineWriters()
 		return errors.Wrap(err, "error starting `stellar-core catchup` subprocess")
 	}
+
 	r.started = true
+	r.ledgerBuffer = newBufferedLedgerMetaReader(r.ctx, r.pipe.Reader)
+	go r.ledgerBuffer.start()
+	r.wg.Add(1)
+	go r.wait()
 
 	return nil
 }
 
+// runFrom executes the run command with a starting ledger on the captive core subprocess
 func (r *stellarCoreRunner) runFrom(from uint32, hash string) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
 	if r.started {
 		return errors.New("runner already started")
 	}
 	var err error
-	r.cmd, err = r.createCmd(
+	r.cmd = r.createCmd(
 		"run",
 		"--in-memory",
 		"--start-at-ledger", fmt.Sprintf("%d", from),
 		"--start-at-hash", hash,
 		"--metadata-output-stream", r.getPipeName(),
 	)
+	r.pipe, err = r.start()
 	if err != nil {
-		return errors.Wrap(err, "error creating `stellar-core run` subprocess")
-	}
-	r.metaPipe, err = r.start()
-	if err != nil {
+		r.closeLogLineWriters()
 		return errors.Wrap(err, "error starting `stellar-core run` subprocess")
 	}
+
 	r.started = true
+	r.ledgerBuffer = newBufferedLedgerMetaReader(r.ctx, r.pipe.Reader)
+	go r.ledgerBuffer.start()
+	r.wg.Add(1)
+	go r.wait()
 
 	return nil
 }
 
-func (r *stellarCoreRunner) getMetaPipe() io.Reader {
-	return r.metaPipe
-}
+func (r *stellarCoreRunner) wait() {
+	defer r.wg.Done()
+	waitErr := r.cmd.Wait()
+	r.closeLogLineWriters()
 
-func (r *stellarCoreRunner) getProcessExitChan() <-chan struct{} {
-	return r.processExit
-}
+	r.lock.Lock()
+	defer r.lock.Unlock()
 
-func (r *stellarCoreRunner) getProcessExitError() error {
-	return r.processExitError
-}
-
-func (r *stellarCoreRunner) close() error {
-	var err1, err2 error
-
-	if r.processIsAlive() {
-		err1 = r.cmd.Process.Kill()
-		r.cmd.Wait()
-		r.cmd = nil
+	// by closing the pipe writer we will send an EOF to the ledgerBuffer
+	// we need to do this operation with the lock to ensure that
+	// the processExitError is available when the ledgerBuffer channel
+	// is closed
+	if closeErr := r.pipe.Writer.Close(); closeErr != nil {
+		r.log.WithError(closeErr).Warn("could not close captive core write pipe")
 	}
-	err2 = os.RemoveAll(r.tempDir)
+
+	r.processExited = true
+	r.processExitError = waitErr
+}
+
+// closeLogLineWriters closes the go routines created by getLogLineWriter()
+func (r *stellarCoreRunner) closeLogLineWriters() {
+	r.cmd.Stdout.(*io.PipeWriter).Close()
+	r.cmd.Stderr.(*io.PipeWriter).Close()
+}
+
+// getMetaPipe returns a channel which contains ledgers streamed from the captive core subprocess
+func (r *stellarCoreRunner) getMetaPipe() <-chan metaResult {
+	return r.ledgerBuffer.getChannel()
+}
+
+// getProcessExitError returns an exit error (can be nil) of the process and a bool indicating
+// if the process has exited yet
+// getProcessExitError is thread safe
+func (r *stellarCoreRunner) getProcessExitError() (bool, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	return r.processExited, r.processExitError
+}
+
+// close kills the captive core process if it is still running and performs
+// the necessary cleanup on the resources associated with the captive core process
+// close is both thread safe and idempotent
+func (r *stellarCoreRunner) close() error {
+	r.lock.Lock()
+	started := r.started
+	tempDir := r.tempDir
 	r.tempDir = ""
 
-	if r.started {
-		close(r.shutdown)
-		r.wg.Wait()
+	if !started {
+		r.lock.Unlock()
+		return errors.New("runner has not started")
 	}
-	r.started = false
 
-	if err1 != nil {
-		return errors.Wrap(err1, "error killing subprocess")
+	// check if we have already closed
+	if tempDir == "" {
+		r.lock.Unlock()
+		return nil
 	}
-	if err2 != nil {
-		return errors.Wrap(err2, "error removing subprocess tmpdir")
+
+	r.cancel()
+	r.lock.Unlock()
+
+	// wait for the stellar core process to terminate
+	r.wg.Wait()
+
+	// drain meta pipe channel to make sure the ledger buffer goroutine exits
+	for range r.getMetaPipe() {
+
 	}
-	return nil
+
+	// now it's safe to close the pipe reader
+	// because the ledger buffer is no longer reading from it
+	r.pipe.Reader.Close()
+
+	return os.RemoveAll(tempDir)
 }

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -55,8 +55,6 @@ type stellarCoreRunner struct {
 	ledgerBuffer *bufferedLedgerMetaReader
 	pipe         pipe
 
-	cmd *exec.Cmd
-
 	lock             sync.Mutex
 	processExited    bool
 	processExitError error
@@ -255,16 +253,16 @@ func (r *stellarCoreRunner) catchup(from, to uint32) error {
 	}
 
 	rangeArg := fmt.Sprintf("%d/%d", to, to-from+1)
-	r.cmd = r.createCmd(
+	cmd := r.createCmd(
 		"catchup", rangeArg,
 		"--metadata-output-stream", r.getPipeName(),
 		"--replay-in-memory",
 	)
 
 	var err error
-	r.pipe, err = r.start()
+	r.pipe, err = r.start(cmd)
 	if err != nil {
-		r.closeLogLineWriters(r.cmd)
+		r.closeLogLineWriters(cmd)
 		return errors.Wrap(err, "error starting `stellar-core catchup` subprocess")
 	}
 
@@ -272,7 +270,7 @@ func (r *stellarCoreRunner) catchup(from, to uint32) error {
 	r.ledgerBuffer = newBufferedLedgerMetaReader(r.ctx, r.pipe.Reader)
 	go r.ledgerBuffer.start()
 	r.wg.Add(1)
-	go r.wait()
+	go r.handleExit(cmd)
 
 	return nil
 }
@@ -291,7 +289,7 @@ func (r *stellarCoreRunner) runFrom(from uint32, hash string) error {
 		return errors.New("runner already started")
 	}
 
-	r.cmd = r.createCmd(
+	cmd := r.createCmd(
 		"run",
 		"--in-memory",
 		"--start-at-ledger", fmt.Sprintf("%d", from),
@@ -300,9 +298,9 @@ func (r *stellarCoreRunner) runFrom(from uint32, hash string) error {
 	)
 
 	var err error
-	r.pipe, err = r.start()
+	r.pipe, err = r.start(cmd)
 	if err != nil {
-		r.closeLogLineWriters(r.cmd)
+		r.closeLogLineWriters(cmd)
 		return errors.Wrap(err, "error starting `stellar-core run` subprocess")
 	}
 
@@ -310,15 +308,15 @@ func (r *stellarCoreRunner) runFrom(from uint32, hash string) error {
 	r.ledgerBuffer = newBufferedLedgerMetaReader(r.ctx, r.pipe.Reader)
 	go r.ledgerBuffer.start()
 	r.wg.Add(1)
-	go r.wait()
+	go r.handleExit(cmd)
 
 	return nil
 }
 
-func (r *stellarCoreRunner) wait() {
+func (r *stellarCoreRunner) handleExit(cmd *exec.Cmd) {
 	defer r.wg.Done()
-	waitErr := r.cmd.Wait()
-	r.closeLogLineWriters(r.cmd)
+	exitErr := cmd.Wait()
+	r.closeLogLineWriters(cmd)
 
 	r.lock.Lock()
 	defer r.lock.Unlock()
@@ -332,7 +330,7 @@ func (r *stellarCoreRunner) wait() {
 	}
 
 	r.processExited = true
-	r.processExitError = waitErr
+	r.processExitError = exitErr
 }
 
 // closeLogLineWriters closes the go routines created by getLogLineWriter()

--- a/ingest/ledgerbackend/stellar_core_runner_posix.go
+++ b/ingest/ledgerbackend/stellar_core_runner_posix.go
@@ -3,11 +3,8 @@
 package ledgerbackend
 
 import (
-	"io"
-	"os"
-	"syscall"
-
 	"github.com/pkg/errors"
+	"os"
 )
 
 // Posix-specific methods for the StellarCoreRunner type.
@@ -19,42 +16,24 @@ func (c *stellarCoreRunner) getPipeName() string {
 	return "fd:3"
 }
 
-func (c *stellarCoreRunner) start() (io.Reader, error) {
+func (c *stellarCoreRunner) start() (pipe, error) {
 	// First make an anonymous pipe.
 	// Note io.File objects close-on-finalization.
 	readFile, writeFile, err := os.Pipe()
 	if err != nil {
-		return readFile, errors.Wrap(err, "error making a pipe")
+		return pipe{}, errors.Wrap(err, "error making a pipe")
 	}
-
-	defer writeFile.Close()
+	p := pipe{Reader: readFile, Writer: writeFile}
 
 	// Add the write-end to the set of inherited file handles. This is defined
 	// to be fd 3 on posix platforms.
 	c.cmd.ExtraFiles = []*os.File{writeFile}
 	err = c.cmd.Start()
 	if err != nil {
-		return readFile, errors.Wrap(err, "error starting stellar-core")
+		writeFile.Close()
+		readFile.Close()
+		return pipe{}, errors.Wrap(err, "error starting stellar-core")
 	}
 
-	c.wg.Add(1)
-	go func() {
-		err := make(chan error, 1)
-		select {
-		case err <- c.cmd.Wait():
-			c.processExitError = <-err
-			close(c.processExit)
-			close(err)
-		case <-c.shutdown:
-		}
-		c.wg.Done()
-	}()
-
-	return readFile, nil
-}
-
-func (c *stellarCoreRunner) processIsAlive() bool {
-	return c.cmd != nil &&
-		c.cmd.Process != nil &&
-		c.cmd.Process.Signal(syscall.Signal(0)) == nil
+	return p, nil
 }

--- a/ingest/ledgerbackend/stellar_core_runner_posix.go
+++ b/ingest/ledgerbackend/stellar_core_runner_posix.go
@@ -3,8 +3,10 @@
 package ledgerbackend
 
 import (
-	"github.com/pkg/errors"
 	"os"
+	"os/exec"
+
+	"github.com/pkg/errors"
 )
 
 // Posix-specific methods for the StellarCoreRunner type.
@@ -16,7 +18,7 @@ func (c *stellarCoreRunner) getPipeName() string {
 	return "fd:3"
 }
 
-func (c *stellarCoreRunner) start() (pipe, error) {
+func (c *stellarCoreRunner) start(cmd *exec.Cmd) (pipe, error) {
 	// First make an anonymous pipe.
 	// Note io.File objects close-on-finalization.
 	readFile, writeFile, err := os.Pipe()
@@ -27,8 +29,8 @@ func (c *stellarCoreRunner) start() (pipe, error) {
 
 	// Add the write-end to the set of inherited file handles. This is defined
 	// to be fd 3 on posix platforms.
-	c.cmd.ExtraFiles = []*os.File{writeFile}
-	err = c.cmd.Start()
+	cmd.ExtraFiles = []*os.File{writeFile}
+	err = cmd.Start()
 	if err != nil {
 		writeFile.Close()
 		readFile.Close()

--- a/ingest/ledgerbackend/stellar_core_runner_posix.go
+++ b/ingest/ledgerbackend/stellar_core_runner_posix.go
@@ -25,7 +25,7 @@ func (c *stellarCoreRunner) start(cmd *exec.Cmd) (pipe, error) {
 	if err != nil {
 		return pipe{}, errors.Wrap(err, "error making a pipe")
 	}
-	p := pipe{Reader: readFile, Writer: writeFile}
+	p := pipe{Reader: readFile, File: writeFile}
 
 	// Add the write-end to the set of inherited file handles. This is defined
 	// to be fd 3 on posix platforms.

--- a/ingest/ledgerbackend/stellar_core_runner_windows.go
+++ b/ingest/ledgerbackend/stellar_core_runner_windows.go
@@ -36,5 +36,5 @@ func (c *stellarCoreRunner) start(cmd *exec.Cmd) (pipe, error) {
 		return pipe{}, err
 	}
 
-	return pipe{Reader: connection, Writer: listener}, nil
+	return pipe{Reader: connection, File: listener}, nil
 }

--- a/ingest/ledgerbackend/stellar_core_runner_windows.go
+++ b/ingest/ledgerbackend/stellar_core_runner_windows.go
@@ -4,9 +4,6 @@ package ledgerbackend
 
 import (
 	"fmt"
-	"io"
-	"os"
-
 	"github.com/Microsoft/go-winio"
 )
 
@@ -16,51 +13,26 @@ func (c *stellarCoreRunner) getPipeName() string {
 	return fmt.Sprintf(`\\.\pipe\%s`, c.nonce)
 }
 
-func (c *stellarCoreRunner) start() (io.Reader, error) {
+func (c *stellarCoreRunner) start() (pipe, error) {
 	// First set up the server pipe.
 	listener, err := winio.ListenPipe(c.getPipeName(), nil)
 	if err != nil {
-		return io.Reader(nil), err
+		return pipe{}, err
 	}
 
 	// Then start the process.
 	err = c.cmd.Start()
 	if err != nil {
-		return io.Reader(nil), err
+		listener.Close()
+		return pipe{}, err
 	}
-
-	c.wg.Add(1)
-	go func() {
-		err := make(chan error, 1)
-		select {
-		case err <- c.cmd.Wait():
-			c.processExitError = <-err
-			close(c.processExit)
-			close(err)
-		case <-c.shutdown:
-		}
-		c.wg.Done()
-	}()
 
 	// Then accept on the server end.
 	connection, err := listener.Accept()
 	if err != nil {
-		return connection, err
+		listener.Close()
+		return pipe{}, err
 	}
 
-	return connection, nil
-}
-
-func (c *stellarCoreRunner) processIsAlive() bool {
-	if c.cmd == nil {
-		return false
-	}
-	if c.cmd.Process == nil {
-		return false
-	}
-	p, err := os.FindProcess(c.cmd.Process.Pid)
-	if err != nil || p == nil {
-		return false
-	}
-	return true
+	return pipe{Reader: connection, Writer: listener}, nil
 }

--- a/ingest/ledgerbackend/stellar_core_runner_windows.go
+++ b/ingest/ledgerbackend/stellar_core_runner_windows.go
@@ -4,6 +4,8 @@ package ledgerbackend
 
 import (
 	"fmt"
+	"os/exec"
+
 	"github.com/Microsoft/go-winio"
 )
 
@@ -13,7 +15,7 @@ func (c *stellarCoreRunner) getPipeName() string {
 	return fmt.Sprintf(`\\.\pipe\%s`, c.nonce)
 }
 
-func (c *stellarCoreRunner) start() (pipe, error) {
+func (c *stellarCoreRunner) start(cmd *exec.Cmd) (pipe, error) {
 	// First set up the server pipe.
 	listener, err := winio.ListenPipe(c.getPipeName(), nil)
 	if err != nil {
@@ -21,7 +23,7 @@ func (c *stellarCoreRunner) start() (pipe, error) {
 	}
 
 	// Then start the process.
-	err = c.cmd.Start()
+	err = cmd.Start()
 	if err != nil {
 		listener.Close()
 		return pipe{}, err

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -188,6 +188,7 @@ func NewSystem(config Config) (System, error) {
 					HTTPPort:           config.CaptiveCoreHTTPPort,
 					NetworkPassphrase:  config.NetworkPassphrase,
 					HistoryArchiveURLs: []string{config.HistoryArchiveURL},
+					CheckpointFrequency: config.CheckpointFrequency,
 					LedgerHashStore:    ledgerbackend.NewHorizonDBLedgerHashStore(config.HistorySession),
 					Log:                log.WithField("subservice", "stellar-core"),
 					Context:            ctx,

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -190,6 +190,7 @@ func NewSystem(config Config) (System, error) {
 					HistoryArchiveURLs: []string{config.HistoryArchiveURL},
 					LedgerHashStore:    ledgerbackend.NewHorizonDBLedgerHashStore(config.HistorySession),
 					Log:                log.WithField("subservice", "stellar-core"),
+					Context:            ctx,
 				},
 			)
 			if err != nil {
@@ -378,7 +379,9 @@ func (s *system) BuildGenesisState() error {
 }
 
 func (s *system) runStateMachine(cur stateMachineNode) error {
+	s.wg.Add(1)
 	defer func() {
+		s.wg.Done()
 		s.wg.Wait()
 	}()
 
@@ -491,7 +494,7 @@ func (s *system) updateCursor(ledgerSequence uint32) error {
 		cursor = s.config.StellarCoreCursor
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(s.ctx, time.Second)
 	defer cancel()
 	err := s.stellarCoreClient.SetCursor(ctx, cursor, int32(ledgerSequence))
 	if err != nil {
@@ -504,11 +507,16 @@ func (s *system) updateCursor(ledgerSequence uint32) error {
 func (s *system) Shutdown() {
 	log.Info("Shutting down ingestion system...")
 	s.stateVerificationMutex.Lock()
-	defer s.stateVerificationMutex.Unlock()
 	if s.stateVerificationRunning {
 		log.Info("Shutting down state verifier...")
 	}
+	s.stateVerificationMutex.Unlock()
 	s.cancel()
+	// wait for ingestion state machine to terminate
+	s.wg.Wait()
+	if err := s.ledgerBackend.Close(); err != nil {
+		log.WithError(err).Info("could not close ledger backend")
+	}
 }
 
 func markStateInvalid(historyQ history.IngestionQ, err error) {

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -183,15 +183,15 @@ func NewSystem(config Config) (System, error) {
 		} else {
 			ledgerBackend, err = ledgerbackend.NewCaptive(
 				ledgerbackend.CaptiveCoreConfig{
-					BinaryPath:         config.CaptiveCoreBinaryPath,
-					ConfigAppendPath:   config.CaptiveCoreConfigAppendPath,
-					HTTPPort:           config.CaptiveCoreHTTPPort,
-					NetworkPassphrase:  config.NetworkPassphrase,
-					HistoryArchiveURLs: []string{config.HistoryArchiveURL},
+					BinaryPath:          config.CaptiveCoreBinaryPath,
+					ConfigAppendPath:    config.CaptiveCoreConfigAppendPath,
+					HTTPPort:            config.CaptiveCoreHTTPPort,
+					NetworkPassphrase:   config.NetworkPassphrase,
+					HistoryArchiveURLs:  []string{config.HistoryArchiveURL},
 					CheckpointFrequency: config.CheckpointFrequency,
-					LedgerHashStore:    ledgerbackend.NewHorizonDBLedgerHashStore(config.HistorySession),
-					Log:                log.WithField("subservice", "stellar-core"),
-					Context:            ctx,
+					LedgerHashStore:     ledgerbackend.NewHorizonDBLedgerHashStore(config.HistorySession),
+					Log:                 log.WithField("subservice", "stellar-core"),
+					Context:             ctx,
 				},
 			)
 			if err != nil {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR implements robust shutdown behavior in `CaptiveStellarCore` by embedding a context in `stellarCoreRunner`.

`CaptiveStellarCore` exposes the following functions:

* `PrepareRange()`
* `IsPrepared()`
* `GetLedger()`
* `GetLatestLedgerSequence()`
* `Close()`

`PrepareRange()`, `IsPrepared()`, `GetLedger()`, and `GetLatestLedgerSequence()` cannot be called concurrently. Only one go routine should be calling those functions on a `CaptiveStellarCore` instance. If any of those functions are accessed concurrently then the behavior of `CaptiveStellarCore` will be undefined.

However, `Close()` can be called concurrently with any of the functions listed above. In other words,  it is safe for `Close()` to interrupt any pending `PrepareRange()`, `IsPrepared()`, `GetLedger()`, or `GetLatestLedgerSequence()` operation. Once `Close()` is called, any pending operation (e.g. `PrepareRange()` / `GetLedger()`) is expected to terminate quickly. The `Close()` operation should also complete in a timely manner.

After `Close()` is called, the captive core subprocess should be reaped, the captive core named pipe should be closed, the temporary directory used by captive core should be deleted, and all go routines related to buffering captive core logs or streaming ledgers from the named pipe should be terminated.

<del>Note that you can still use a `CaptiveStellarCore` instance after calling `Close()`. If you call `PrepareRange()` after calling `Close()` then `CaptiveStellarCore` will create a new captive core subprocess (along with the named pipe, buffering go routines, etc) and begin a new session.</del> [Edit: the behavior of `Close()` is now terminal. Once it is called the `CaptiveStellarCore` instance will fail on all subsequent operations]

The `CaptiveCoreConfig` struct has been extended to include an optional `Context` field. The context in `CaptiveCoreConfig` acts as a parent context for all `PrepareRange()` sessions. In other words, if the parent context is cancelled then, any pending `PrepareRange()` / `GetLedger()` operation will be terminated even though `Close()` was not called. Furthermore, once the parent context is terminated the `CaptiveStellarCore` instance will effectively be dead (e.g. it will not be possible start any more `PrepareRange()` sessions).

The behavior described above is implemented by embedding a context in the `stellarCoreRunner` struct. `stellarCoreRunner` will pass that context into `exec.CommandContext()` when spawning the captive core process. When we want to abort the running `stellarCoreRunner` instance we cancel the context associated with `stellarCoreRunner` which will kill the captive core subprocess (by calling os.Process.Kill) if the stellar core has not already exited on its own (see https://golang.org/pkg/os/exec/#CommandContext ). By using `exec.CommandContext()` we are able to remove some of the cleanup code from  `stellarCoreRunner` including the unix and windows implementations of `processIsAlive()`.

Previously, I mentioned that `CaptiveStellarCore.Close()` is able to safely interrupt any pending `CaptiveStellarCore` operation. This invariant is guaranteed because `CaptiveStellarCore` uses a read write lock to protect access to `stellarCoreRunner`. While the read lock is held, `CaptiveStellarCore` cannot assign its `stellarCoreRunner` field to a new value. `stellarCoreRunner.close()` is also thread safe and idempotent (so it doesn't matter if `CaptiveStellarCore.Close()` is called multiple times).

Once `stellarCoreRunner.close()` is invoked it will cancel the `stellarCoreRunner` context and it will also close the channel used by `CaptiveStellarCore` to read ledgers from captive core. At this point any blocking calls to `GetLedger()` will be able to terminate quickly.

The code which determines how `GetLedger()` terminates on error is encapsulated in the `checkMetaPipeResult()` function.
There are basically 3 types of errors which can arise in `GetLedger()`:

1. User initiated shutdown by canceling the parent context or calling Close().
2. The stellar core process exited unexpectedly.
3.  Some error was encountered while consuming the ledgers emitted by captive core (e.g. parsing invalid xdr)

All these cases are handled in `checkMetaPipeResult()`.  

Some other points to note while reading the PR:

* the implementation of `bufferedLedgerMetaReader` is now more decoupled from `CaptiveStellarCore` and `stellarCoreRunner`
* `bufferedLedgerMetaReader` is now created and owned by `stellarCoreRunner`. when `stellarCoreRunner` terminates, it will dispose of its `bufferedLedgerMetaReader` instance
*  `CaptiveStellarCore` does not have to listen to any exit channels. `CaptiveStellarCore` only needs to handle the case when the `stellarCoreRunner` meta pipe is exhausted.
* In the previous code the go routine created by `stellarCoreRunner` to consume stdout and stderr from captive core was never terminated. This PR fixes the go routine leak.
* The named pipe is now properly closed by `stellarCoreRunner`

### Known limitations

I need to fix the tests. I plan to do so once I receive approval on the overall approach of the PR.