### PR TITLE
services/horizon/docs: Adds migration/deployment guide for Captive Core.

### DIFF
--- a/services/horizon/internal/docs/captive_core_migration.md
+++ b/services/horizon/internal/docs/captive_core_migration.md
@@ -1,0 +1,99 @@
+**TODO:** This should be merged into `captive_core.md` once @fons and I wrap up our individual portions (or decide how break into separate files; maybe we need a `captive_core/` doc subdirectory).
+
+# Migration 
+In this section, we'll discuss migrating existing systems running the [latest](https://github.com/stellar/go/releases/latest) stable version of Horizon ([1.13](https://github.com/stellar/go/releases/tag/horizon-v1.13.0) as of this writing) to the new 2.0 beta. 
+
+**Environment assumptions**:
+
+  - For simplicity, we assume a single-machine Ubuntu setup running both Horizon and Core with a single local PostgreSQL server. The URI in the configs outlined later give further insight into the setup. Loosening this assumption is covered briefly in a [later section](#multi-machine-setup).
+
+  - We assume your machine has enough memory to hold Captive Core's in-memory database (~3GiB), which is a larger memory requirement than a traditional Core setup (which would have an on-disk database).
+
+  - We assume that your node joined the Stellar network recently (that is, it has a few thousand ledgers synced / ingeste), though this doesn't really matter. This assumption can be easily relaxed to any range, but we clarify it here so the chosen ledger ranges below make sense.
+
+
+## Installing
+The process for upgrading both Stellar Core and Horizon are covered [here](https://github.com/stellar/packages/blob/master/docs/upgrading.md#upgrading); the only difference is that since we're migrating to Horizon v2.0-beta, we need to first add the unstable repository. This is described [here](https://github.com/stellar/packages/blob/master/docs/adding-the-sdf-stable-repository-to-your-system.md#adding-the-bleeding-edge-unstable-repository), but in brief, you just need to add the URL:
+
+```bash
+echo "deb https://apt.stellar.org xenial unstable" | sudo tee -a /etc/apt/sources.list.d/SDF-unstable.list
+```
+
+Then, you can install the Captive Core packages:
+
+```bash
+sudo apt install stellar-captive-core
+```
+
+And you're ready to upgrade.
+
+
+## Upgrading
+At this point, all that is left to do is to:
+
+ - modify the Horizon configuration to enable Captive Core (we will assume it lives in `/etc/default/stellar-horizon`, the default)
+ - create a Captive Core configuration stub
+ - stop the existing Stellar Core instance
+ - restart Horizon
+
+
+### Configure Horizon
+First, add the following lines to the Horizon configuration to enable a Captive Core subprocess:
+
+```bash
+echo "STELLAR_CORE_BINARY_PATH=$(which stellar-core)
+CAPTIVE_CORE_CONFIG_APPEND_PATH=/etc/default/stellar-captive-core.cfg
+ENABLE_CAPTIVE_CORE_INGESTION=1" | sudo tee -a /etc/default/stellar-horizon
+```
+
+### Configure Captive Core
+Captive Core runs with a trimmed down configuration "stub": at minimum, it must contain enough info to set up a quorum. For example,
+
+```toml
+[[HOME_DOMAINS]]
+HOME_DOMAIN="testnet.stellar.org"
+QUALITY="HIGH"
+
+[[VALIDATORS]]
+NAME="sdf_testnet_1"
+HOME_DOMAIN="testnet.stellar.org"
+PUBLIC_KEY="GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y"
+ADDRESS="core-testnet1.stellar.org"
+HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_001/{0} -o {1}"
+
+[[VALIDATORS]]
+NAME="sdf_testnet_2"
+HOME_DOMAIN="testnet.stellar.org"
+PUBLIC_KEY="GCUCJTIYXSOXKBSNFGNFWW5MUQ54HKRPGJUTQFJ5RQXZXNOLNXYDHRAP"
+ADDRESS="core-testnet2.stellar.org"
+HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_002/{0} -o {1}"
+
+[[VALIDATORS]]
+NAME="sdf_testnet_3"
+HOME_DOMAIN="testnet.stellar.org"
+PUBLIC_KEY="GC2V2EFSXN6SQTWVYA5EPJPBWWIMSD2XQNKUOHGEKB535AQE2I6IXV2Z"
+ADDRESS="core-testnet3.stellar.org"
+HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_003/{0} -o {1}"
+
+```
+
+The rest of the configuration will be generated automagically at runtime.
+
+**Note:** Using your existing Stellar Core configuration will not work (**why not???**). Running Horizon will fail with the following error, or errors like it:
+
+    default: Config from /tmp/captive-stellar-core-38cff455ad3469ec/stellar-core.conf
+    default: Got an exception: Failed to parse '/tmp/captive-stellar-core-38cff455ad3469ec/stellar-core.conf' :Key HTTP_PORT already present at line 10 [CommandLine.cpp:1064]
+
+
+### Restarting Services
+Now, we can stop Core (which hopefully doesn't need an explanation) and restart Horizon:
+
+```bash
+stellar-horizon-cmd serve
+```
+
+The logs should show Captive Core running successfully as a subprocess, and eventually Horizon will be running as usual, except with Captive Core rapidly generating transaction metadata in-memory!
+
+
+## Multi-Machine Setup
+If you plan on running Horizon and Captive Core on separate machines, you'll need to change only a few things. Namely, rather than configuring the `STELLAR_CORE_BINARY` variable, you'll need to point Horizon at the Remote Captive Core instance via `REMOTE_CAPTIVE_CORE_URL`.

--- a/services/horizon/internal/docs/captive_core_migration.md
+++ b/services/horizon/internal/docs/captive_core_migration.md
@@ -7,9 +7,9 @@ In this section, we'll discuss migrating existing systems running the pre-2.0 ve
 
   - We assume your machine has **enough extra RAM** to hold Captive Core's in-memory database (~3GiB), which is a larger memory requirement than a traditional Core setup (which would have an on-disk database).
 
-  - The examples here refer to the testnet for safety; replace the appropriate references with the pubnet equivalents when you're ready.
+  - The examples here refer to the **testnet for safety**; replace the appropriate references with the pubnet equivalents when you're ready.
 
-  - In some places, packages need to be built from scratch. We assume a sane [Golang](https://golang.org/doc/install) development environment for this.
+  - In some places, bleeding-edge versions of packages can be built from scratch. We assume a sane **[Golang](https://golang.org/doc/install) development environment** for this.
 
 To start off simply, we assume a **single-machine Ubuntu setup** running both Horizon and Core with a single local PostgreSQL server. This assumption is loosened in a [later section](#multi-machine-setup).
 
@@ -189,10 +189,10 @@ At this point, you should be able to hit port 8000 on the above instance and wat
 # Reingestion
 If you need to manually reingest some ledgers (for example, you want history for some ledgers that closed before your asset got issued), you can still do this with Captive Core.
 
-For example, suppose we've ingested from ledger 811520, but would like another 1000 ledgers before it to be ingested as well.
+For example, suppose we've ingested from ledger 811520, but would like another 1000 ledgers before it to be ingested as well. Nothing really changes from the execution perspective relative to the "old" way (given the configuration updates [from before](#configure-horizon) are done):
 
 ```bash
 stellar-horizon-cmd db reingest range 810520 811520
 ```
 
-TODO: Finish this once Slack thread is resolved.
+The biggest change is simply how much faster this gets done! :fire: For example, a [full reingestion](#using-captive-core-to-reingest-the-full-public-network-history) of the entire network only takes ~1.5 days (as opposed to weeks previously) on an [m5.8xlarge](https://aws.amazon.com/ec2/pricing/on-demand/) instance.

--- a/services/horizon/internal/docs/captive_core_migration.md
+++ b/services/horizon/internal/docs/captive_core_migration.md
@@ -153,7 +153,7 @@ Returning to the Horizon instance that will be doing ingestion, we just need to 
 Suppose the above server can be resolved on the `captivecore.local` hostname; then, we need to configure Horizon accordingly:
 
 ```bash
-echo "DATABASE_URL='postgres://postgres@host.docker.internal:5432/horizon?sslmode=disable'
+echo "DATABASE_URL='postgres://postgres@db.local:5432/horizon?sslmode=disable'
 HISTORY_ARCHIVE_URLS='https://history.stellar.org/prd/core-testnet/core_testnet_001'
 NETWORK_PASSPHRASE='Test SDF Network ; September 2015'
 INGEST=true
@@ -172,7 +172,7 @@ stellar-horizon-cmd serve
 This configuration is almost identical, except we flip the ingestion parameters:
 
 ```bash
-echo "DATABASE_URL='postgres://postgres@host.docker.internal:5432/horizon?sslmode=disable'
+echo "DATABASE_URL='postgres://postgres@db.local:5432/horizon?sslmode=disable'
 HISTORY_ARCHIVE_URLS='https://history.stellar.org/prd/core-testnet/core_testnet_001'
 NETWORK_PASSPHRASE='Test SDF Network ; September 2015'
 INGEST=false

--- a/services/horizon/internal/docs/captive_core_migration.md
+++ b/services/horizon/internal/docs/captive_core_migration.md
@@ -36,18 +36,8 @@ At this point, all that is left to do is to:
  - stop the existing Stellar Core instance
  - restart Horizon
 
-
-### Configure Horizon
-First, add the following lines to the Horizon configuration to enable a Captive Core subprocess:
-
-```bash
-echo "STELLAR_CORE_BINARY_PATH=$(which stellar-core)
-CAPTIVE_CORE_CONFIG_APPEND_PATH=/etc/default/stellar-captive-core.cfg
-ENABLE_CAPTIVE_CORE_INGESTION=1" | sudo tee -a /etc/default/stellar-horizon
-```
-
 ### Configure Captive Core
-Captive Core runs with a trimmed down configuration "stub": at minimum, it must contain enough info to set up a quorum. For example,
+Captive Core runs with a trimmed down configuration "stub": at minimum, it must contain enough info to set up a quorum (see [above](#todo-fons-section-link)). For example, if relying exclusively on SDF's validators:
 
 ```toml
 [[HOME_DOMAINS]]
@@ -74,15 +64,27 @@ HOME_DOMAIN="testnet.stellar.org"
 PUBLIC_KEY="GC2V2EFSXN6SQTWVYA5EPJPBWWIMSD2XQNKUOHGEKB535AQE2I6IXV2Z"
 ADDRESS="core-testnet3.stellar.org"
 HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_003/{0} -o {1}"
-
 ```
 
-The rest of the configuration will be generated automagically at runtime.
+(We'll assume this stub lives at `/etc/default/stellar-captive-core.toml`.) The rest of the configuration will be generated automagically at runtime.
 
 **Note:** Using your existing Stellar Core configuration will not work (**why not???**). Running Horizon will fail with the following error, or errors like it:
 
     default: Config from /tmp/captive-stellar-core-38cff455ad3469ec/stellar-core.conf
     default: Got an exception: Failed to parse '/tmp/captive-stellar-core-38cff455ad3469ec/stellar-core.conf' :Key HTTP_PORT already present at line 10 [CommandLine.cpp:1064]
+
+### Configure Horizon
+First, add the following lines to the Horizon configuration to enable a Captive Core subprocess:
+
+```bash
+echo "STELLAR_CORE_BINARY_PATH=$(which stellar-core)
+CAPTIVE_CORE_CONFIG_APPEND_PATH=/etc/default/stellar-captive-core.toml" | sudo tee -a /etc/default/stellar-horizon
+```
+
+(Note that setting `ENABLE_CAPTIVE_CORE_INGESTION=1` is not necessary as of Horizon 2.0 because it's the default. TODO: This isn't true on master, so gotta make sure.)
+
+
+**Note**: There may be an additional step necessary here if you aren't coming from v1.13, depending on the changelog: manual reingestion. You can still accomplish this with Captive Core, see [below](#reingestion).
 
 
 ### Restarting Services

--- a/services/horizon/internal/docs/captive_core_migration.md
+++ b/services/horizon/internal/docs/captive_core_migration.md
@@ -44,7 +44,7 @@ At this point, all that is left to do is to:
  - restart Horizon
 
 ### Configure Captive Core
-Captive Core runs with a trimmed down configuration "stub": at minimum, it must contain enough info to set up a quorum (see [above](#configuration)). **Your old configuration cannot be used directly**: Horizon needs special settings for Captive Core. Running Horizon will fail with the following error, or errors like it:
+Captive Core runs with a trimmed down configuration "stub": at minimum, it must contain enough info to set up a quorum (see [above](#configuration)). **Your old configuration cannot be used directly**: Horizon needs special settings for Captive Core. Otherwise, running Horizon will fail with the following error, or errors like it:
 
     default: Config from /tmp/captive-stellar-core-38cff455ad3469ec/stellar-core.conf
     default: Got an exception: Failed to parse '/tmp/captive-stellar-core-38cff455ad3469ec/stellar-core.conf' :Key HTTP_PORT already present at line 10 [CommandLine.cpp:1064]
@@ -81,7 +81,6 @@ HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_003/{
 
 (We'll assume this stub lives at `/etc/default/stellar-captive-core.toml`.) The rest of the configuration will be generated automagically at runtime.
 
-
 ### Configure Horizon
 First, add the following lines to the Horizon configuration to enable a Captive Core subprocess:
 
@@ -90,11 +89,10 @@ echo "STELLAR_CORE_BINARY_PATH=$(which stellar-core)
 CAPTIVE_CORE_CONFIG_APPEND_PATH=/etc/default/stellar-captive-core.toml" | sudo tee -a /etc/default/stellar-horizon
 ```
 
-(Note that setting `ENABLE_CAPTIVE_CORE_INGESTION=1` is not necessary as of Horizon 2.0 because it's the default. TODO: This isn't true on master, so gotta make sure.)
+(Note that setting `ENABLE_CAPTIVE_CORE_INGESTION=true` is not necessary as of Horizon 2.0-beta because it's the default.)
 
 
 **Note**: Depending on the version you're migrating from, you may need to include an additional step here: manual reingestion. This can still be accomplished with Captive Core; see [below](#reingestion).
-
 
 ### Restarting Services
 Now, we can stop Core (which hopefully doesn't need an explanation) and restart Horizon:
@@ -107,14 +105,14 @@ The logs should show Captive Core running successfully as a subprocess, and even
 
 
 ## Multi-Machine Setup
-If you plan on running Horizon and Captive Core on separate machines, you'll need to change only a few things. Namely, rather than configuring the `STELLAR_CORE_BINARY` variable, you'll need to point Horizon at the Remote Captive Core instance via `REMOTE_CAPTIVE_CORE_URL`.
+If you plan on running Horizon and Captive Core on separate machines, you'll need to change only a few things. Namely, rather than configuring the `STELLAR_CORE_BINARY` variable, you'll need to point Horizon at the Remote Captive Core instance via `REMOTE_CAPTIVE_CORE_URL` (for the wrapper API) and `STELLAR_CORE_URL` (for the raw Core API).
 
 In this section, we'll work through a hypothetical architecture with two Horizon instances, one of which is an ingestion instance, and a single Captive Core instance.
 
 ### Remote Captive Core
 First, we need to start running the Captive Core server.
 
-The latest released (but experimental) version of the Captive Core API can be installed from the unstable repo:
+The latest released (but experimental) version of the Captive Core API can be installed from the [unstable repo](https://github.com/stellar/packages/blob/master/docs/adding-the-sdf-stable-repository-to-your-system.md#adding-the-bleeding-edge-unstable-repository):
 
 ```bash
 sudo apt install stellar-captive-core stellar-captive-core-api
@@ -139,7 +137,7 @@ export CAPTIVE_CORE_CONFIG_APPEND_PATH=/etc/default/stellar-captive-core.toml
 export STELLAR_CORE_BINARY_PATH=$(which stellar-core)
 ```
 
-(You can run these commands directly or `source` them into your shell from a script.) These parameters should all be familiar from earlier sections.
+(There's no `-cmd` wrapper à la Horizon/Core for this binary yet; you can run these commands directly or `source` them into your shell from a script.) The parameters should all be familiar from earlier sections.
 
 Finally, let's run the Captive Core instance:
 
@@ -159,7 +157,6 @@ echo "DATABASE_URL='postgres://postgres@host.docker.internal:5432/horizon?sslmod
 HISTORY_ARCHIVE_URLS='https://history.stellar.org/prd/core-testnet/core_testnet_001'
 NETWORK_PASSPHRASE='Test SDF Network ; September 2015'
 INGEST=true
-ENABLE_CAPTIVE_CORE_INGESTION=1
 STELLAR_CORE_URL='http://captivecore.local:11626'
 REMOTE_CAPTIVE_CORE_URL='http://captivecore.local:8000'
 " | sudo tee /etc/default/stellar-horizon
@@ -171,20 +168,18 @@ Then just run it as usual:
 stellar-horizon-cmd serve
 ```
 
-(We assume the other required parameters are configured appropriately in `/etc/default/stellar-horizon` as in a normal deployment.)
-
-
 ### Serving Instance
-This is the simplest instance, requiring none of the ingestion parameters:
+This configuration is almost identical, except we flip the ingestion parameters:
 
 ```bash
 echo "DATABASE_URL='postgres://postgres@host.docker.internal:5432/horizon?sslmode=disable'
 HISTORY_ARCHIVE_URLS='https://history.stellar.org/prd/core-testnet/core_testnet_001'
 NETWORK_PASSPHRASE='Test SDF Network ; September 2015'
+INGEST=false
+ENABLE_CAPTIVE_CORE_INGESTION=false
 STELLAR_CORE_URL='http://captivecore.local:11626'
 REMOTE_CAPTIVE_CORE_URL='http://captivecore.local:8000'
 " | sudo tee /etc/default/stellar-horizon
-
 stellar-horizon-cmd serve
 ```
 

--- a/services/horizon/internal/docs/captive_core_migration.md
+++ b/services/horizon/internal/docs/captive_core_migration.md
@@ -1,23 +1,21 @@
 # Migration 
-In this section, we'll discuss migrating existing systems running the [latest](https://github.com/stellar/go/releases/latest) stable version of Horizon ([1.13](https://github.com/stellar/go/releases/tag/horizon-v1.13.0) as of this writing) to the new 2.0 beta. 
+In this section, we'll discuss migrating existing systems running the pre-2.0 versions of Horizon to the new 2.x world.
 
 **Environment assumptions**:
 
   - We assume that the **PostgreSQL server** lives at the `db.local` hostname, and has a `horizon` database accessible by the `postgres:secret` username-password combo.
 
-  - We assume your machine has **enough memory** to hold Captive Core's in-memory database (~3GiB), which is a larger memory requirement than a traditional Core setup (which would have an on-disk database).
+  - We assume your machine has **enough extra RAM** to hold Captive Core's in-memory database (~3GiB), which is a larger memory requirement than a traditional Core setup (which would have an on-disk database).
 
   - The examples here refer to the testnet for safety; replace the appropriate references with the pubnet equivalents when you're ready.
 
-To start off simply, we assume a **single-machine Ubuntu setup** running both Horizon and Core with a single local PostgreSQL server. Then, this assumption is loosened in a [later section](#multi-machine-setup).
+  - In some places, packages need to be built from scratch. We assume a sane [Golang](https://golang.org/doc/install) development environment for this.
+
+To start off simply, we assume a **single-machine Ubuntu setup** running both Horizon and Core with a single local PostgreSQL server. This assumption is loosened in a [later section](#multi-machine-setup).
 
 
 ## Installing
-The process for upgrading both Stellar Core and Horizon are covered [here](https://github.com/stellar/packages/blob/master/docs/upgrading.md#upgrading); the only difference is that since we're migrating to Horizon v2.0-beta, we need to first add the unstable repository. This is described [here](https://github.com/stellar/packages/blob/master/docs/adding-the-sdf-stable-repository-to-your-system.md#adding-the-bleeding-edge-unstable-repository), but in brief, you just need to add the URL:
-
-```bash
-echo "deb https://apt.stellar.org xenial unstable" | sudo tee -a /etc/apt/sources.list.d/SDF-unstable.list
-```
+The process for upgrading both Stellar Core and Horizon are covered [here](https://github.com/stellar/packages/blob/master/docs/upgrading.md#upgrading). The only difference is that since we're migrating to a beta Horizon release, we need to first add the unstable repository; this is described [here](https://github.com/stellar/packages/blob/master/docs/adding-the-sdf-stable-repository-to-your-system.md#adding-the-bleeding-edge-unstable-repository).
 
 Then, you can install the Captive Core packages:
 
@@ -27,25 +25,32 @@ sudo apt install stellar-captive-core
 
 And you're ready to upgrade.
 
-**Note**: Until v2.0-beta is tagged & released, you'll need to build Horizon from master for this to actually render the latest binaries. That's done pretty simply, given a valid Go environment:
+**Note**: Until the v2.0-beta binaries are released, you'll need to build Horizon from the `release-horizon-v2.0.0-beta` branch. That's pretty simple, given a valid Go environment:
 
 ```bash
-git clone https://github.com/stellar/go && cd go
+git clone https://github.com/stellar/go monorepo && cd monorepo
+git checkout release-horizon-v2.0.0-beta
 go install -v ./services/horizon
-sudo cp $GOPATH/bin/horizon $(which stellar-horizon)
+sudo cp $(go env GOPATH)/bin/horizon $(which stellar-horizon)
 ```
 
 
 ## Upgrading
 At this point, all that is left to do is to:
 
- - modify the Horizon configuration to enable Captive Core (we will assume it lives in `/etc/default/stellar-horizon`, the default)
  - create a Captive Core configuration stub
+ - modify the Horizon configuration to enable Captive Core (we will assume it lives in `/etc/default/stellar-horizon`, the default)
  - stop the existing Stellar Core instance
  - restart Horizon
 
 ### Configure Captive Core
-Captive Core runs with a trimmed down configuration "stub": at minimum, it must contain enough info to set up a quorum (see [above](#todo-fons-section-link)). For example, if relying exclusively on SDF's validators:
+Captive Core runs with a trimmed down configuration "stub": at minimum, it must contain enough info to set up a quorum (see [above](#configuration)). **Your old configuration cannot be used directly**: Horizon needs special settings for Captive Core. Running Horizon will fail with the following error, or errors like it:
+
+    default: Config from /tmp/captive-stellar-core-38cff455ad3469ec/stellar-core.conf
+    default: Got an exception: Failed to parse '/tmp/captive-stellar-core-38cff455ad3469ec/stellar-core.conf' :Key HTTP_PORT already present at line 10 [CommandLine.cpp:1064]
+
+
+For example, if relying exclusively on SDF's validators:
 
 ```toml
 [[HOME_DOMAINS]]
@@ -76,10 +81,6 @@ HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_003/{
 
 (We'll assume this stub lives at `/etc/default/stellar-captive-core.toml`.) The rest of the configuration will be generated automagically at runtime.
 
-**Note:** Using your existing Stellar Core configuration will not work (**why not???**). Running Horizon will fail with the following error, or errors like it:
-
-    default: Config from /tmp/captive-stellar-core-38cff455ad3469ec/stellar-core.conf
-    default: Got an exception: Failed to parse '/tmp/captive-stellar-core-38cff455ad3469ec/stellar-core.conf' :Key HTTP_PORT already present at line 10 [CommandLine.cpp:1064]
 
 ### Configure Horizon
 First, add the following lines to the Horizon configuration to enable a Captive Core subprocess:
@@ -92,7 +93,7 @@ CAPTIVE_CORE_CONFIG_APPEND_PATH=/etc/default/stellar-captive-core.toml" | sudo t
 (Note that setting `ENABLE_CAPTIVE_CORE_INGESTION=1` is not necessary as of Horizon 2.0 because it's the default. TODO: This isn't true on master, so gotta make sure.)
 
 
-**Note**: There may be an additional step necessary here if you aren't coming from v1.13, depending on the changelog: manual reingestion. You can still accomplish this with Captive Core, see [below](#reingestion).
+**Note**: Depending on the version you're migrating from, you may need to include an additional step here: manual reingestion. This can still be accomplished with Captive Core; see [below](#reingestion).
 
 
 ### Restarting Services
@@ -113,59 +114,78 @@ In this section, we'll work through a hypothetical architecture with two Horizon
 ### Remote Captive Core
 First, we need to start running the Captive Core server.
 
-This must be installed from source, as it's not a published package yet (TODO: right?). These instructions presume a "sane" Golang environment (namely, one with `$GOPATH` defined):
+The latest released (but experimental) version of the Captive Core API can be installed from the unstable repo:
 
 ```bash
-git clone https://github.com/stellar/go && cd go
+sudo apt install stellar-captive-core stellar-captive-core-api
+```
+
+Alternatively, you can install the bleeding edge from source:
+
+```bash
+git clone https://github.com/stellar/go monorepo && cd monorepo
+git checkout release-horizon-v2.0.0-beta
 go install -v ./exp/services/captivecore
-sudo cp $GOPATH/bin/captivecore /usr/bin/stellar-captive-core
+sudo cp $(go env GOPATH)/bin/captivecore /usr/bin/stellar-captive-core-api
 ```
 
-Now, let's run a Captive Core instance:
+Now, let's configure the Captive Core environment:
 
 ```bash
-stellar-captive-core \
-  --network-passphrase='Test SDF Network ; September 2015' \
-  --history-archive-urls='https://history.stellar.org/prd/core-testnet/core_testnet_001' \
-  --db-url='postgres://postgres:secret@db.local:5432/horizon?sslmode=disable' \
-  --port=8080 \
-  --stellar-core-binary-path=$(which stellar-core) \
-  --captive-core-config-append-path=/etc/default/stellar-captive-core.cfg
+export NETWORK_PASSPHRASE='Test SDF Network ; September 2015'
+export HISTORY_ARCHIVE_URLS='https://history.stellar.org/prd/core-testnet/core_testnet_001'
+export DATABASE_URL='postgres://postgres:secret@db.local:5432/horizon?sslmode=disable'
+export CAPTIVE_CORE_CONFIG_APPEND_PATH=/etc/default/stellar-captive-core.toml
+export STELLAR_CORE_BINARY_PATH=$(which stellar-core)
 ```
 
-(We use CLI parameters over environmental variables as well as values from the earlier sections here to maximize clarity.)
+(You can run these commands directly or `source` them into your shell from a script.) These parameters should all be familiar from earlier sections.
 
-This will start serving *two* endpoints: a Captive Core HTTP server on port 8080, which serves up processed ledgers and can be queried by Horizon, and the underlying Core HTTP endpoint on port 11626 (the default).
+Finally, let's run the Captive Core instance:
+
+```bash
+stellar-captive-core-api
+```
+
+This will start serving *two* endpoints: a Captive Core HTTP server on port 8000 (by default), which serves up processed ledgers and can be queried by Horizon, and the underlying Core HTTP endpoint on port 11626 (by default). See the `--help` for how to configure these.
 
 ### Ingestion Instance
-Returning to the Horizon instance that will be doing ingestion, we just need to supply the appropriate URLs and ports. If the above server can be resolved on the `captive-core.local` hostname, running Horizon would look like:
+Returning to the Horizon instance that will be doing ingestion, we just need to supply the appropriate URLs and ports. 
+
+Suppose the above server can be resolved on the `captivecore.local` hostname; then, we need to configure Horizon accordingly:
 
 ```bash
-stellar-horizon \
-  --network-passphrase='Test SDF Network ; September 2015' \
-  --history-archive-urls='https://history.stellar.org/prd/core-testnet/core_testnet_001' \
-  --db-url='postgres://postgres:secret@db.local:5432/horizon?sslmode=disable' \
-  --remote-captive-core-url=http://captive-core.local:8080 \
-  --stellar-core-url=http://captive-core.local:11626 \
-  --port=8001 \
-  --ingest=true \
-  --enable-captive-core-ingestion=true
+echo "DATABASE_URL='postgres://postgres@host.docker.internal:5432/horizon?sslmode=disable'
+HISTORY_ARCHIVE_URLS='https://history.stellar.org/prd/core-testnet/core_testnet_001'
+NETWORK_PASSPHRASE='Test SDF Network ; September 2015'
+INGEST=true
+ENABLE_CAPTIVE_CORE_INGESTION=1
+STELLAR_CORE_URL='http://captivecore.local:11626'
+REMOTE_CAPTIVE_CORE_URL='http://captivecore.local:8000'
+" | sudo tee /etc/default/stellar-horizon
 ```
 
-(Again, we prefer CLI parameters to avoid conflating the `/etc/default/stellar-horizon` we defined earlier for the single-machine case.)
+Then just run it as usual:
+
+```
+stellar-horizon-cmd serve
+```
+
+(We assume the other required parameters are configured appropriately in `/etc/default/stellar-horizon` as in a normal deployment.)
 
 
 ### Serving Instance
 This is the simplest instance, requiring none of the ingestion parameters:
 
 ```bash
-stellar-horizon \
-  --network-passphrase='Test SDF Network ; September 2015' \
-  --history-archive-urls='https://history.stellar.org/prd/core-testnet/core_testnet_001' \
-  --db-url='postgres://postgres:secret@db.local:5432/horizon?sslmode=disable' \
-  --remote-captive-core-url=http://captive-core.local:8080 \
-  --stellar-core-url=http://captive-core.local:11626 \
-  --port=8000
+echo "DATABASE_URL='postgres://postgres@host.docker.internal:5432/horizon?sslmode=disable'
+HISTORY_ARCHIVE_URLS='https://history.stellar.org/prd/core-testnet/core_testnet_001'
+NETWORK_PASSPHRASE='Test SDF Network ; September 2015'
+STELLAR_CORE_URL='http://captivecore.local:11626'
+REMOTE_CAPTIVE_CORE_URL='http://captivecore.local:8000'
+" | sudo tee /etc/default/stellar-horizon
+
+stellar-horizon-cmd serve
 ```
 
 At this point, you should be able to hit port 8000 on the above instance and watch the `ingest_latest_ledger` value grow.

--- a/services/horizon/internal/docs/captive_core_migration.md
+++ b/services/horizon/internal/docs/captive_core_migration.md
@@ -107,3 +107,77 @@ The logs should show Captive Core running successfully as a subprocess, and even
 
 ## Multi-Machine Setup
 If you plan on running Horizon and Captive Core on separate machines, you'll need to change only a few things. Namely, rather than configuring the `STELLAR_CORE_BINARY` variable, you'll need to point Horizon at the Remote Captive Core instance via `REMOTE_CAPTIVE_CORE_URL`.
+
+In this section, we'll work through a hypothetical architecture with two Horizon instances, one of which is an ingestion instance, and a single Captive Core instance.
+
+### Remote Captive Core
+First, we need to start running the Captive Core server.
+
+This must be installed from source, as it's not a published package yet (TODO: right?). These instructions presume a "sane" Golang environment (namely, one with `$GOPATH` defined):
+
+```bash
+git clone https://github.com/stellar/go && cd go
+go install -v ./exp/services/captivecore
+sudo cp $GOPATH/bin/captivecore /usr/bin/stellar-captive-core
+```
+
+Now, let's run a Captive Core instance:
+
+```bash
+stellar-captive-core \
+  --network-passphrase='Test SDF Network ; September 2015' \
+  --history-archive-urls='https://history.stellar.org/prd/core-testnet/core_testnet_001' \
+  --db-url='postgres://postgres:secret@db.local:5432/horizon?sslmode=disable' \
+  --port=8080 \
+  --stellar-core-binary-path=$(which stellar-core) \
+  --captive-core-config-append-path=/etc/default/stellar-captive-core.cfg
+```
+
+(We use CLI parameters over environmental variables as well as values from the earlier sections here to maximize clarity.)
+
+This will start serving *two* endpoints: a Captive Core HTTP server on port 8080, which serves up processed ledgers and can be queried by Horizon, and the underlying Core HTTP endpoint on port 11626 (the default).
+
+### Ingestion Instance
+Returning to the Horizon instance that will be doing ingestion, we just need to supply the appropriate URLs and ports. If the above server can be resolved on the `captive-core.local` hostname, running Horizon would look like:
+
+```bash
+stellar-horizon \
+  --network-passphrase='Test SDF Network ; September 2015' \
+  --history-archive-urls='https://history.stellar.org/prd/core-testnet/core_testnet_001' \
+  --db-url='postgres://postgres:secret@db.local:5432/horizon?sslmode=disable' \
+  --remote-captive-core-url=http://captive-core.local:8080 \
+  --stellar-core-url=http://captive-core.local:11626 \
+  --port=8001 \
+  --ingest=true \
+  --enable-captive-core-ingestion=true
+```
+
+(Again, we prefer CLI parameters to avoid conflating the `/etc/default/stellar-horizon` we defined earlier for the single-machine case.)
+
+
+### Serving Instance
+This is the simplest instance, requiring none of the ingestion parameters:
+
+```bash
+stellar-horizon \
+  --network-passphrase='Test SDF Network ; September 2015' \
+  --history-archive-urls='https://history.stellar.org/prd/core-testnet/core_testnet_001' \
+  --db-url='postgres://postgres:secret@db.local:5432/horizon?sslmode=disable' \
+  --remote-captive-core-url=http://captive-core.local:8080 \
+  --stellar-core-url=http://captive-core.local:11626 \
+  --port=8000
+```
+
+At this point, you should be able to hit port 8000 on the above instance and watch the `ingest_latest_ledger` value grow.
+
+
+# Reingestion
+If you need to manually reingest some ledgers (for example, you want history for some ledgers that closed before your asset got issued), you can still do this with Captive Core.
+
+For example, suppose we've ingested from ledger 811520, but would like another 1000 ledgers before it to be ingested as well.
+
+```bash
+stellar-horizon-cmd db reingest range 810520 811520
+```
+
+TODO: Finish this once Slack thread is resolved.

--- a/services/horizon/internal/docs/captive_core_migration.md
+++ b/services/horizon/internal/docs/captive_core_migration.md
@@ -1,15 +1,15 @@
-**TODO:** This should be merged into `captive_core.md` once @fons and I wrap up our individual portions (or decide how break into separate files; maybe we need a `captive_core/` doc subdirectory).
-
 # Migration 
 In this section, we'll discuss migrating existing systems running the [latest](https://github.com/stellar/go/releases/latest) stable version of Horizon ([1.13](https://github.com/stellar/go/releases/tag/horizon-v1.13.0) as of this writing) to the new 2.0 beta. 
 
 **Environment assumptions**:
 
-  - For simplicity, we assume a single-machine Ubuntu setup running both Horizon and Core with a single local PostgreSQL server. The URI in the configs outlined later give further insight into the setup. Loosening this assumption is covered briefly in a [later section](#multi-machine-setup).
+  - We assume that the **PostgreSQL server** lives at the `db.local` hostname, and has a `horizon` database accessible by the `postgres:secret` username-password combo.
 
-  - We assume your machine has enough memory to hold Captive Core's in-memory database (~3GiB), which is a larger memory requirement than a traditional Core setup (which would have an on-disk database).
+  - We assume your machine has **enough memory** to hold Captive Core's in-memory database (~3GiB), which is a larger memory requirement than a traditional Core setup (which would have an on-disk database).
 
-  - We assume that your node joined the Stellar network recently (that is, it has a few thousand ledgers synced / ingeste), though this doesn't really matter. This assumption can be easily relaxed to any range, but we clarify it here so the chosen ledger ranges below make sense.
+  - The examples here refer to the testnet for safety; replace the appropriate references with the pubnet equivalents when you're ready.
+
+To start off simply, we assume a **single-machine Ubuntu setup** running both Horizon and Core with a single local PostgreSQL server. Then, this assumption is loosened in a [later section](#multi-machine-setup).
 
 
 ## Installing
@@ -26,6 +26,14 @@ sudo apt install stellar-captive-core
 ```
 
 And you're ready to upgrade.
+
+**Note**: Until v2.0-beta is tagged & released, you'll need to build Horizon from master for this to actually render the latest binaries. That's done pretty simply, given a valid Go environment:
+
+```bash
+git clone https://github.com/stellar/go && cd go
+go install -v ./services/horizon
+sudo cp $GOPATH/bin/horizon $(which stellar-horizon)
+```
 
 
 ## Upgrading

--- a/services/horizon/internal/docs/captive_core_migration.md
+++ b/services/horizon/internal/docs/captive_core_migration.md
@@ -89,7 +89,7 @@ echo "STELLAR_CORE_BINARY_PATH=$(which stellar-core)
 CAPTIVE_CORE_CONFIG_APPEND_PATH=/etc/default/stellar-captive-core.toml" | sudo tee -a /etc/default/stellar-horizon
 ```
 
-(Note that setting `ENABLE_CAPTIVE_CORE_INGESTION=true` is not necessary as of Horizon 2.0-beta because it's the default.)
+(Note that setting `ENABLE_CAPTIVE_CORE_INGESTION=true` is not necessary in 2.x because it's the new default.)
 
 
 **Note**: Depending on the version you're migrating from, you may need to include an additional step here: manual reingestion. This can still be accomplished with Captive Core; see [below](#reingestion).
@@ -107,7 +107,7 @@ The logs should show Captive Core running successfully as a subprocess, and even
 ## Multi-Machine Setup
 If you plan on running Horizon and Captive Core on separate machines, you'll need to change only a few things. Namely, rather than configuring the `STELLAR_CORE_BINARY` variable, you'll need to point Horizon at the Remote Captive Core instance via `REMOTE_CAPTIVE_CORE_URL` (for the wrapper API) and `STELLAR_CORE_URL` (for the raw Core API).
 
-In this section, we'll work through a hypothetical architecture with two Horizon instances, one of which is an ingestion instance, and a single Captive Core instance.
+In this section, we'll work through a hypothetical architecture with two Horizon instances (only one of which does ingestion) and a single Captive Core instance.
 
 ### Remote Captive Core
 First, we need to start running the Captive Core server.
@@ -118,7 +118,7 @@ The latest released (but experimental) version of the Captive Core API can be in
 sudo apt install stellar-captive-core stellar-captive-core-api
 ```
 
-Alternatively, you can install the bleeding edge from source:
+Alternatively, you can install the bleeding edge [from source](https://github.com/stellar/go/exp/services/captivecore):
 
 ```bash
 git clone https://github.com/stellar/go monorepo && cd monorepo
@@ -145,7 +145,7 @@ Finally, let's run the Captive Core instance:
 stellar-captive-core-api
 ```
 
-This will start serving *two* endpoints: a Captive Core HTTP server on port 8000 (by default), which serves up processed ledgers and can be queried by Horizon, and the underlying Core HTTP endpoint on port 11626 (by default). See the `--help` for how to configure these.
+This will start serving *two* endpoints: a Captive Core wrapper API on port 8000 (by default), which serves up processed ledgers and can be queried by Horizon, and the underlying Core API on port 11626 (by default). See the `--help` for how to configure the ports.
 
 ### Ingestion Instance
 Returning to the Horizon instance that will be doing ingestion, we just need to supply the appropriate URLs and ports. 
@@ -195,4 +195,4 @@ For example, suppose we've ingested from ledger 811520, but would like another 1
 stellar-horizon-cmd db reingest range 810520 811520
 ```
 
-The biggest change is simply how much faster this gets done! :fire: For example, a [full reingestion](#using-captive-core-to-reingest-the-full-public-network-history) of the entire network only takes ~1.5 days (as opposed to weeks previously) on an [m5.8xlarge](https://aws.amazon.com/ec2/pricing/on-demand/) instance.
+The biggest change is simply how much faster this gets done! For example, a [full reingestion](#using-captive-core-to-reingest-the-full-public-network-history) of the entire network only takes ~1.5 days (as opposed to weeks previously) on an [m5.8xlarge](https://aws.amazon.com/ec2/pricing/on-demand/) instance. :fire:


### PR DESCRIPTION
### What
This should walk a user to transitioning from Horizon v1.x -> v2.0-beta. There are two scenarios covered:
  - everything on a single machine, so essentially the user can drop Core and replace it w/ Captive Core
  - three machines: two Horizons (with only one of them ingesting, just for diversity) and one (remote) Captive Core. It should be relatively self-explanatory to readers that Captive Core just replaces their existing Core instance. Though I did test all of these on the same machine (just varied ports, etc.), it should still be accurate.

Here's a [direct link](https://github.com/stellar/go/blob/66f3bab24f30f9a7ece39ecb2ceb587b15302d45/services/horizon/internal/docs/captive_core_migration.md) to the rendered Markdown. This should be merged into `captive_core.md` once @2opremio's #3283 is merged. Then, that closes #3204 and #3205.