### PR TITLE
ingest/ledgerbackend: Dont automatically close after reading last ledger in range

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -609,6 +609,45 @@ func TestCaptiveGetLedger(t *testing.T) {
 	mockRunner.AssertExpectations(t)
 }
 
+func TestCaptiveStellarCore_PrepareRangeAfterClose(t *testing.T) {
+	executablePath := "/etc/stellar-core"
+	networkPassphrase := network.PublicNetworkPassphrase
+	historyURLs := []string{"http://localhost"}
+
+	captiveStellarCore, err := NewCaptive(
+		CaptiveCoreConfig{
+			BinaryPath:         executablePath,
+			NetworkPassphrase:  networkPassphrase,
+			HistoryArchiveURLs: historyURLs,
+		},
+	)
+	assert.NoError(t, err)
+
+	assert.NoError(t, captiveStellarCore.Close())
+
+	assert.EqualError(
+		t,
+		captiveStellarCore.PrepareRange(BoundedRange(65, 66)),
+		"error starting prepare range: opening subprocess: error getting latest checkpoint sequence: "+
+			"error getting root HAS: Get \"http://localhost/.well-known/stellar-history.json\": context canceled",
+	)
+
+	// even if the request to fetch the latest checkpoint succeeds, we should fail at creating the subprocess
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.
+		On("GetRootHAS").
+		Return(historyarchive.HistoryArchiveState{
+			CurrentLedger: uint32(200),
+		}, nil)
+	captiveStellarCore.archive = mockArchive
+	assert.EqualError(
+		t,
+		captiveStellarCore.PrepareRange(BoundedRange(65, 66)),
+		"error starting prepare range: opening subprocess: error running stellar-core: context canceled",
+	)
+	mockArchive.AssertExpectations(t)
+}
+
 func TestCaptiveGetLedger_NextLedgerIsDifferentToLedgerFromBuffer(t *testing.T) {
 	tt := assert.New(t)
 	metaChan := make(chan metaResult, 100)

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -129,13 +128,6 @@ type testLedgerHeader struct {
 	sequence           uint32
 	hash               string
 	previousLedgerHash string
-}
-
-func writeLedgerHeader(w io.Writer, header testLedgerHeader) {
-	err := xdr.MarshalFramed(w, buildLedgerCloseMeta(header))
-	if err != nil {
-		panic(err)
-	}
 }
 
 func TestCaptiveNew(t *testing.T) {
@@ -548,11 +540,10 @@ func TestCaptiveGetLedger(t *testing.T) {
 		}
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(65), uint32(66)).Return(nil)
 	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
-	mockRunner.On("context").Return(ctx)
+	mockRunner.On("context").Return(context.Background())
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -593,19 +584,26 @@ func TestCaptiveGetLedger(t *testing.T) {
 	// next sequence number didn't get consumed
 	tt.Equal(uint32(66), captiveBackend.nextLedger)
 
-	mockRunner.On("close").Return(nil).Run(func(args mock.Arguments) {
-		cancel()
-	}).Once()
-
-	_, _, err = captiveBackend.GetLedger(66)
+	found, meta, err = captiveBackend.GetLedger(66)
 	tt.NoError(err)
+	tt.True(found)
+	tt.Equal(xdr.Uint32(66), meta.V0.LedgerHeader.Header.LedgerSeq)
 
-	// closes after last ledger is consumed
-	tt.True(captiveBackend.isClosed())
+	_, _, err = captiveBackend.GetLedger(67)
+	tt.Errorf(err, "reading past bounded range (requested sequence=67, last ledger in range=66)")
 
-	// we should be able to call last ledger even after get ledger is closed
-	_, _, err = captiveBackend.GetLedger(66)
+	// despite reading the last ledger, captiveBackend should *NOT* be closed
+	tt.False(captiveBackend.isClosed())
+
+	var latest uint32
+	latest, err = captiveBackend.GetLatestLedgerSequence()
 	tt.NoError(err)
+	tt.Equal(latest, uint32(66))
+
+	var prepared bool
+	prepared, err = captiveBackend.IsPrepared(BoundedRange(66, 66))
+	tt.NoError(err)
+	tt.True(prepared)
 
 	mockArchive.AssertExpectations(t)
 	mockRunner.AssertExpectations(t)
@@ -717,8 +715,7 @@ func TestCaptiveGetLedger_ErrReadingMetaResult(t *testing.T) {
 	mockRunner.AssertExpectations(t)
 }
 
-func TestCaptiveGetLedger_ErrClosingAfterLastLedger(t *testing.T) {
-	tt := assert.New(t)
+func TestCaptiveAfterClose(t *testing.T) {
 	metaChan := make(chan metaResult, 100)
 
 	for i := 64; i <= 66; i++ {
@@ -729,10 +726,11 @@ func TestCaptiveGetLedger_ErrClosingAfterLastLedger(t *testing.T) {
 	}
 
 	mockRunner := &stellarCoreRunnerMock{}
+	ctx, cancel := context.WithCancel(context.Background())
 	mockRunner.On("catchup", uint32(65), uint32(66)).Return(nil)
 	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
-	mockRunner.On("context").Return(context.Background())
-	mockRunner.On("close").Return(fmt.Errorf("transient error")).Once()
+	mockRunner.On("context").Return(ctx)
+	mockRunner.On("close").Return(nil).Once()
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -747,13 +745,25 @@ func TestCaptiveGetLedger_ErrClosingAfterLastLedger(t *testing.T) {
 			return mockRunner, nil
 		},
 		checkpointManager: historyarchive.NewCheckpointManager(64),
+		cancel:            cancel,
 	}
 
-	err := captiveBackend.PrepareRange(BoundedRange(65, 66))
+	boundedRange := BoundedRange(65, 66)
+	err := captiveBackend.PrepareRange(boundedRange)
 	assert.NoError(t, err)
 
-	_, _, err = captiveBackend.GetLedger(66)
-	tt.EqualError(err, "error closing session: transient error")
+	assert.NoError(t, captiveBackend.Close())
+
+	_, _, err = captiveBackend.GetLedger(boundedRange.to)
+	assert.EqualError(t, err, "session is closed, call PrepareRange first")
+
+	var prepared bool
+	prepared, err = captiveBackend.IsPrepared(boundedRange)
+	assert.False(t, prepared)
+	assert.NoError(t, err)
+
+	_, err = captiveBackend.GetLatestLedgerSequence()
+	assert.EqualError(t, err, "stellar-core must be opened to return latest available sequence")
 
 	mockArchive.AssertExpectations(t)
 	mockRunner.AssertExpectations(t)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove the behavior in `CaptiveStellarCore` where the instance is automatically closed after reading the last ledger in the range.

### Why

Once `CaptiveStellarCore` is closed functions like `GetLatestLedgerSequence()` return errors like "session is closed, call PrepareRange first." 

So if `GetLatestLedgerSequence()` is called  after `PrepareRange(ledgerbackend.BoundedRange(1000, 1000))` it will return a "session is closed" error, which is bizarre because `CaptiveStellarCore` was never explicitly closed.


### Known limitations

[N/A]
