### PR TITLE
services/friendbot: reduce friendbot minion creation batch to 50, allow for retries, add tests

### DIFF
--- a/services/friendbot/friendbot.cfg
+++ b/services/friendbot/friendbot.cfg
@@ -1,7 +1,7 @@
 port = 8000
-friendbot_secret = "SA6WAWCCMRZSEFD5PEN5GK5BHK347YEQ552XZM72NV553TAGWFVHW2G5"
+friendbot_secret = "SDLNA2YUQSFIWVEB57M6D3OOCJHFVCVQZJ33LPA656KJESVRK5DQUZOH"
 network_passphrase = "Test SDF Network ; September 2015"
 horizon_url = "https://horizon-testnet.stellar.org"
 starting_balance = "10000.00"
 num_minions = 1000
-base_fee = 300
+base_fee = 100000

--- a/services/friendbot/friendbot.cfg
+++ b/services/friendbot/friendbot.cfg
@@ -1,7 +1,10 @@
 port = 8000
-friendbot_secret = "SA6WAWCCMRZSEFD5PEN5GK5BHK347YEQ552XZM72NV553TAGWFVHW2G5"
+friendbot_secret = "SDANVB2UMNILW5UIMWO5BOZ4QYYEKQ34JNFCTDKTTLCBRG2ELDTNRGAM"
 network_passphrase = "Test SDF Network ; September 2015"
 horizon_url = "https://horizon-testnet.stellar.org"
 starting_balance = "10000.00"
 num_minions = 1000
 base_fee = 100000
+minion_batch_size = 50
+submit_tx_retries_allowed = 5
+

--- a/services/friendbot/friendbot.cfg
+++ b/services/friendbot/friendbot.cfg
@@ -1,5 +1,5 @@
 port = 8000
-friendbot_secret = "SDLNA2YUQSFIWVEB57M6D3OOCJHFVCVQZJ33LPA656KJESVRK5DQUZOH"
+friendbot_secret = "SA6WAWCCMRZSEFD5PEN5GK5BHK347YEQ552XZM72NV553TAGWFVHW2G5"
 network_passphrase = "Test SDF Network ; September 2015"
 horizon_url = "https://horizon-testnet.stellar.org"
 starting_balance = "10000.00"

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -130,12 +130,12 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 
 		resp, err := hclient.SubmitTransactionXDR(txe)
 		if err != nil {
-			log.Println(resp)
+			log.Printf("%+v\n", resp)
 			switch e := err.(type) {
 			case *horizonclient.Error:
 				problemString := fmt.Sprintf("Problem[Type=%s, Title=%s, Status=%d, Detail=%s, Extras=%v]", e.Problem.Type, e.Problem.Title, e.Problem.Status, e.Problem.Detail, e.Problem.Extras)
 				// If we hit an error here due to network congestion, try again until we hit max # of retries allowed
-				if e.Problem.Type == "timeout" {
+				if e.Problem.Status == http.StatusGatewayTimeout {
 					err = errors.Wrap(errors.Wrap(e, problemString), "submitting create accounts tx")
 					if currentsubmitTxRetry >= submitTxRetriesAllowed {
 						return minions, errors.Wrap(err, fmt.Sprintf("after retrying %d times", currentsubmitTxRetry))

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -45,9 +45,16 @@ func initFriendbot(
 	// already confirmed that friendbotSecret is a seed.
 	botKeypair := botKP.(*keypair.Full)
 	botAccount := internal.Account{AccountID: botKeypair.Address()}
+	// set default values
 	minionBalance := "101.00"
 	if numMinions == 0 {
 		numMinions = 1000
+	}
+	if minionBatchSize == 0 {
+		minionBatchSize = 50
+	}
+	if submitTxRetriesAllowed == 0 {
+		submitTxRetriesAllowed = 5
 	}
 	log.Printf("Found all valid params, now creating %d minions", numMinions)
 	minions, err := createMinionAccounts(botAccount, botKeypair, networkPassphrase, startingBalance, minionBalance, numMinions, minionBatchSize, submitTxRetriesAllowed, baseFee, hclient)

--- a/services/friendbot/init_friendbot_test.go
+++ b/services/friendbot/init_friendbot_test.go
@@ -38,8 +38,9 @@ func TestInitFriendbot_createMinionAccounts_success(t *testing.T) {
 		Return(horizon.Transaction{}, nil)
 
 	numMinion := 1000
-
-	createdMinions, err := createMinionAccounts(botAccount, botKeypair, "Test SDF Network ; September 2015", "10000", "101", numMinion, 1000, &horizonClientMock)
+	minionBatchSize := 50
+	submitTxRetriesAllowed := 5
+	createdMinions, err := createMinionAccounts(botAccount, botKeypair, "Test SDF Network ; September 2015", "10000", "101", numMinion, minionBatchSize, submitTxRetriesAllowed, 1000, &horizonClientMock)
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1000, len(createdMinions))
@@ -81,7 +82,9 @@ func TestInitFriendbot_createMinionAccounts_timeoutError(t *testing.T) {
 		Return(horizon.Transaction{}, hError)
 
 	numMinion := 1000
-	createdMinions, err := createMinionAccounts(botAccount, botKeypair, "Test SDF Network ; September 2015", "10000", "101", numMinion, 1000, &horizonClientMock)
+	minionBatchSize := 50
+	submitTxRetriesAllowed := 5
+	createdMinions, err := createMinionAccounts(botAccount, botKeypair, "Test SDF Network ; September 2015", "10000", "101", numMinion, minionBatchSize, submitTxRetriesAllowed, 1000, &horizonClientMock)
 	assert.Equal(t, 150, len(createdMinions))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "after retrying 5 times: submitting create accounts tx:")

--- a/services/friendbot/init_friendbot_test.go
+++ b/services/friendbot/init_friendbot_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/friendbot/internal"
+	"github.com/stellar/go/support/render/problem"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestInitFriendbot_createMinionAccounts_success(t *testing.T) {
+
+	randSecretKey := "SDLNA2YUQSFIWVEB57M6D3OOCJHFVCVQZJ33LPA656KJESVRK5DQUZOH"
+	botKP, err := keypair.Parse(randSecretKey)
+	assert.NoError(t, err)
+
+	botKeypair := botKP.(*keypair.Full)
+	botAccountID := botKeypair.Address()
+	botAccountMock := horizon.Account{
+		AccountID: botAccountID,
+		Sequence:  "1",
+	}
+	botAccount := internal.Account{AccountID: botAccountID, Sequence: 1}
+
+	horizonClientMock := horizonclient.MockClient{}
+	horizonClientMock.
+		On("AccountDetail", horizonclient.AccountRequest{
+			AccountID: botAccountID,
+		}).
+		Return(botAccountMock, nil)
+	horizonClientMock.
+		On("SubmitTransactionXDR", mock.Anything).
+		Return(horizon.Transaction{}, nil)
+
+	numMinion := 1000
+
+	createdMinions, err := createMinionAccounts(botAccount, botKeypair, "Test SDF Network ; September 2015", "10000", "101", numMinion, 1000, &horizonClientMock)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1000, len(createdMinions))
+}
+
+func TestInitFriendbot_createMinionAccounts_timeoutError(t *testing.T) {
+	randSecretKey := "SDLNA2YUQSFIWVEB57M6D3OOCJHFVCVQZJ33LPA656KJESVRK5DQUZOH"
+	botKP, err := keypair.Parse(randSecretKey)
+	assert.NoError(t, err)
+
+	botKeypair := botKP.(*keypair.Full)
+	botAccountID := botKeypair.Address()
+	botAccountMock := horizon.Account{
+		AccountID: botAccountID,
+		Sequence:  "1",
+	}
+	botAccount := internal.Account{AccountID: botAccountID, Sequence: 1}
+
+	horizonClientMock := horizonclient.MockClient{}
+	horizonClientMock.
+		On("AccountDetail", horizonclient.AccountRequest{
+			AccountID: botAccountID,
+		}).
+		Return(botAccountMock, nil)
+
+	// Successful on first 3 calls only, and then a timeout error occurs
+	horizonClientMock.
+		On("SubmitTransactionXDR", mock.Anything).
+		Return(horizon.Transaction{}, nil).Times(3)
+	hError := &horizonclient.Error{
+		Problem: problem.P{
+			Type:   "timeout",
+			Title:  "Timeout",
+			Status: http.StatusGatewayTimeout,
+		},
+	}
+	horizonClientMock.
+		On("SubmitTransactionXDR", mock.Anything).
+		Return(horizon.Transaction{}, hError)
+
+	numMinion := 1000
+	createdMinions, err := createMinionAccounts(botAccount, botKeypair, "Test SDF Network ; September 2015", "10000", "101", numMinion, 1000, &horizonClientMock)
+	assert.Equal(t, len(createdMinions), 75)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "after retrying 5 times: submitting create accounts tx:")
+}

--- a/services/friendbot/init_friendbot_test.go
+++ b/services/friendbot/init_friendbot_test.go
@@ -82,7 +82,7 @@ func TestInitFriendbot_createMinionAccounts_timeoutError(t *testing.T) {
 
 	numMinion := 1000
 	createdMinions, err := createMinionAccounts(botAccount, botKeypair, "Test SDF Network ; September 2015", "10000", "101", numMinion, 1000, &horizonClientMock)
-	assert.Equal(t, len(createdMinions), 75)
+	assert.Equal(t, 150, len(createdMinions))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "after retrying 5 times: submitting create accounts tx:")
 }

--- a/services/friendbot/internal/account.go
+++ b/services/friendbot/internal/account.go
@@ -30,7 +30,7 @@ func (a Account) GetSequenceNumber() (int64, error) {
 }
 
 // RefreshSequenceNumber gets an Account's correct in-memory sequence number from Horizon.
-func (a *Account) RefreshSequenceNumber(hclient *horizonclient.Client) error {
+func (a *Account) RefreshSequenceNumber(hclient horizonclient.ClientInterface) error {
 	accountRequest := horizonclient.AccountRequest{AccountID: a.GetAccountID()}
 	accountDetail, err := hclient.AccountDetail(accountRequest)
 	if err != nil {

--- a/services/friendbot/internal/friendbot_test.go
+++ b/services/friendbot/internal/friendbot_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestFriendbot_Pay(t *testing.T) {
-	mockSubmitTransaction := func(minion *Minion, hclient *horizonclient.Client, tx string) (*hProtocol.Transaction, error) {
+	mockSubmitTransaction := func(minion *Minion, hclient horizonclient.ClientInterface, tx string) (*hProtocol.Transaction, error) {
 		// Instead of submitting the tx, we emulate a success.
 		txSuccess := hProtocol.Transaction{EnvelopeXdr: tx, Successful: true}
 		return &txSuccess, nil

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -20,14 +20,14 @@ type Minion struct {
 	Keypair         *keypair.Full
 	BotAccount      txnbuild.Account
 	BotKeypair      *keypair.Full
-	Horizon         *horizonclient.Client
+	Horizon         horizonclient.ClientInterface
 	Network         string
 	StartingBalance string
 	BaseFee         int64
 
 	// Mockable functions
-	SubmitTransaction    func(minion *Minion, hclient *horizonclient.Client, tx string) (*hProtocol.Transaction, error)
-	CheckSequenceRefresh func(minion *Minion, hclient *horizonclient.Client) error
+	SubmitTransaction    func(minion *Minion, hclient horizonclient.ClientInterface, tx string) (*hProtocol.Transaction, error)
+	CheckSequenceRefresh func(minion *Minion, hclient horizonclient.ClientInterface) error
 
 	// Uninitialized.
 	forceRefreshSequence bool
@@ -60,7 +60,7 @@ func (minion *Minion) Run(destAddress string, resultChan chan SubmitResult) {
 }
 
 // SubmitTransaction should be passed to the Minion.
-func SubmitTransaction(minion *Minion, hclient *horizonclient.Client, tx string) (*hProtocol.Transaction, error) {
+func SubmitTransaction(minion *Minion, hclient horizonclient.ClientInterface, tx string) (*hProtocol.Transaction, error) {
 	result, err := hclient.SubmitTransactionXDR(tx)
 	if err != nil {
 		errStr := "submitting tx to horizon"
@@ -84,7 +84,7 @@ func SubmitTransaction(minion *Minion, hclient *horizonclient.Client, tx string)
 
 // CheckSequenceRefresh establishes the minion's initial sequence number, if needed.
 // This should also be passed to the minion.
-func CheckSequenceRefresh(minion *Minion, hclient *horizonclient.Client) error {
+func CheckSequenceRefresh(minion *Minion, hclient horizonclient.ClientInterface) error {
 	if minion.Account.Sequence != 0 && !minion.forceRefreshSequence {
 		return nil
 	}

--- a/services/friendbot/internal/minion_test.go
+++ b/services/friendbot/internal/minion_test.go
@@ -16,11 +16,11 @@ import (
 // in which Minion.Run() will try to send multiple messages to a channel that gets closed
 // immediately after receiving one message.
 func TestMinion_NoChannelErrors(t *testing.T) {
-	mockSubmitTransaction := func(minion *Minion, hclient *horizonclient.Client, tx string) (txn *hProtocol.Transaction, err error) {
+	mockSubmitTransaction := func(minion *Minion, hclient horizonclient.ClientInterface, tx string) (txn *hProtocol.Transaction, err error) {
 		return txn, nil
 	}
 
-	mockCheckSequenceRefresh := func(minion *Minion, hclient *horizonclient.Client) (err error) {
+	mockCheckSequenceRefresh := func(minion *Minion, hclient horizonclient.ClientInterface) (err error) {
 		return errors.New("could not refresh sequence")
 	}
 
@@ -78,14 +78,14 @@ func TestMinion_CorrectNumberOfTxSubmissions(t *testing.T) {
 		mux          sync.Mutex
 	)
 
-	mockSubmitTransaction := func(minion *Minion, hclient *horizonclient.Client, tx string) (txn *hProtocol.Transaction, err error) {
+	mockSubmitTransaction := func(minion *Minion, hclient horizonclient.ClientInterface, tx string) (txn *hProtocol.Transaction, err error) {
 		mux.Lock()
 		numTxSubmits++
 		mux.Unlock()
 		return txn, nil
 	}
 
-	mockCheckSequenceRefresh := func(minion *Minion, hclient *horizonclient.Client) (err error) {
+	mockCheckSequenceRefresh := func(minion *Minion, hclient horizonclient.ClientInterface) (err error) {
 		return nil
 	}
 

--- a/services/friendbot/main.go
+++ b/services/friendbot/main.go
@@ -19,14 +19,16 @@ import (
 
 // Config represents the configuration of a friendbot server
 type Config struct {
-	Port              int         `toml:"port" valid:"required"`
-	FriendbotSecret   string      `toml:"friendbot_secret" valid:"required"`
-	NetworkPassphrase string      `toml:"network_passphrase" valid:"required"`
-	HorizonURL        string      `toml:"horizon_url" valid:"required"`
-	StartingBalance   string      `toml:"starting_balance" valid:"required"`
-	TLS               *config.TLS `valid:"optional"`
-	NumMinions        int         `toml:"num_minions" valid:"optional"`
-	BaseFee           int64       `toml:"base_fee" valid:"optional"`
+	Port                   int         `toml:"port" valid:"required"`
+	FriendbotSecret        string      `toml:"friendbot_secret" valid:"required"`
+	NetworkPassphrase      string      `toml:"network_passphrase" valid:"required"`
+	HorizonURL             string      `toml:"horizon_url" valid:"required"`
+	StartingBalance        string      `toml:"starting_balance" valid:"required"`
+	TLS                    *config.TLS `valid:"optional"`
+	NumMinions             int         `toml:"num_minions" valid:"optional"`
+	BaseFee                int64       `toml:"base_fee" valid:"optional"`
+	MinionBatchSize        int         `toml:"minion_batch_size" valid:"required"`
+	SubmitTxRetriesAllowed int         `toml:"submit_tx_retries_allowed" valid:"required"`
 }
 
 func main() {
@@ -60,7 +62,8 @@ func run(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	fb, err := initFriendbot(cfg.FriendbotSecret, cfg.NetworkPassphrase, cfg.HorizonURL, cfg.StartingBalance, cfg.NumMinions, cfg.BaseFee)
+	fb, err := initFriendbot(cfg.FriendbotSecret, cfg.NetworkPassphrase, cfg.HorizonURL, cfg.StartingBalance,
+		cfg.NumMinions, cfg.BaseFee, cfg.MinionBatchSize, cfg.SubmitTxRetriesAllowed)
 	if err != nil {
 		log.Error(err)
 		os.Exit(1)

--- a/services/friendbot/main.go
+++ b/services/friendbot/main.go
@@ -27,8 +27,8 @@ type Config struct {
 	TLS                    *config.TLS `valid:"optional"`
 	NumMinions             int         `toml:"num_minions" valid:"optional"`
 	BaseFee                int64       `toml:"base_fee" valid:"optional"`
-	MinionBatchSize        int         `toml:"minion_batch_size" valid:"required"`
-	SubmitTxRetriesAllowed int         `toml:"submit_tx_retries_allowed" valid:"required"`
+	MinionBatchSize        int         `toml:"minion_batch_size" valid:"optional"`
+	SubmitTxRetriesAllowed int         `toml:"submit_tx_retries_allowed" valid:"optional"`
 }
 
 func main() {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR is reducing the friendbot minion (channel account) creation batch from 100 to 50, and allows for retries.

Also, it adds tests for the `createMinionAccounts` method  

closes https://github.com/stellar/nebula/issues/84

### Why

When network congestion was high on testnet 100 account creations/transaction threw a timeout error. See [slack alert here](https://stellarfoundation.slack.com/archives/CANJGG94K/p1609949425128800)

Reducing the # of accounts created per transaction + allowing for some retries should reduce the chances of the timeout error in case this method is run during high congestion in the future

### Known limitations

n/a
