### PR TITLE
services/horizon: Rename all expingest references to ingest

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -5,6 +5,8 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Breaking change: The `expingest` command has been renamed to `ingest` since the ingestion system is not experimental anymore.
+
 ## v2.0.0 Beta
 
 **THIS IS A BETA RELEASE! DO NOT USE IN PRODUCTION. The release may contain critical bugs. It's not suitable for production use.**
@@ -38,7 +40,7 @@ This version may contain bugs. If you run into issues please check [Known Issues
 
 ## v1.11.0
 
-* The `service` field emitted in ingestion logs has been changed from `expingest` to  `ingest` ([#3118](https://github.com/stellar/go/pull/3118)).
+* The `service` field emitted in ingestion logs has been changed from `expingest` to `ingest` ([#3118](https://github.com/stellar/go/pull/3118)).
 * Ledger stats are now exported in `/metrics` in `horizon_ingest_ledger_stats_total` metric ([#3148](https://github.com/stellar/go/pull/3148)).
 * Stellar Core database URL is no longer required when running in captive mode ([#3150](https://github.com/stellar/go/pull/3150)).
 * xdr: Add a custom marshaller for claim predicate timestamp  ([#3183](https://github.com/stellar/go/pull/3183)).

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -18,7 +18,7 @@ import (
 )
 
 var ingestCmd = &cobra.Command{
-	Use:   "expingest",
+	Use:   "ingest",
 	Short: "ingestion related commands",
 }
 
@@ -235,7 +235,7 @@ var ingestTriggerStateRebuildCmd = &cobra.Command{
 		}
 
 		historyQ := &history.Q{horizonSession}
-		err = historyQ.UpdateExpIngestVersion(0)
+		err = historyQ.UpdateIngestVersion(0)
 		if err != nil {
 			log.Fatalf("cannot trigger state rebuild: %v", err)
 		}
@@ -257,7 +257,7 @@ var ingestInitGenesisStateCmd = &cobra.Command{
 
 		historyQ := &history.Q{horizonSession}
 
-		lastIngestedLedger, err := historyQ.GetLastLedgerExpIngestNonBlocking()
+		lastIngestedLedger, err := historyQ.GetLastLedgerIngestNonBlocking()
 		if err != nil {
 			log.Fatalf("cannot get last ledger value: %v", err)
 		}

--- a/services/horizon/docker/verify-range/README.md
+++ b/services/horizon/docker/verify-range/README.md
@@ -1,6 +1,6 @@
 # `stellar/expingest-verify-range`
 
-This docker image allows running multiple instances of `horizon expingest verify-command` on a single machine or running it in [AWS Batch](https://aws.amazon.com/batch/).
+This docker image allows running multiple instances of `horizon ingest verify-command` on a single machine or running it in [AWS Batch](https://aws.amazon.com/batch/).
 
 ## Env variables
 

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -72,7 +72,7 @@ git log -1
 
 /usr/local/go/bin/go build -v ./services/horizon
 ./horizon db migrate up
-./horizon expingest verify-range --from $FROM --to $TO --verify-state
+./horizon ingest verify-range --from $FROM --to $TO --verify-state
 
 function compare() {
   local expected="$1"

--- a/services/horizon/internal/action_offers_test.go
+++ b/services/horizon/internal/action_offers_test.go
@@ -16,9 +16,9 @@ func TestOfferActions_Show(t *testing.T) {
 	defer ht.Finish()
 	q := &history.Q{ht.HorizonSession()}
 
-	err := q.UpdateLastLedgerExpIngest(100)
+	err := q.UpdateLastLedgerIngest(100)
 	ht.Assert.NoError(err)
-	err = q.UpdateExpIngestVersion(ingest.CurrentVersion)
+	err = q.UpdateIngestVersion(ingest.CurrentVersion)
 	ht.Assert.NoError(err)
 
 	ledgerCloseTime := time.Now().Unix()

--- a/services/horizon/internal/actions_account_test.go
+++ b/services/horizon/internal/actions_account_test.go
@@ -14,9 +14,9 @@ func TestAccountActions_InvalidID(t *testing.T) {
 
 	// Makes StateMiddleware happy
 	q := history.Q{ht.HorizonSession()}
-	err := q.UpdateLastLedgerExpIngest(100)
+	err := q.UpdateLastLedgerIngest(100)
 	ht.Assert.NoError(err)
-	err = q.UpdateExpIngestVersion(ingest.CurrentVersion)
+	err = q.UpdateIngestVersion(ingest.CurrentVersion)
 	ht.Assert.NoError(err)
 	_, err = q.InsertLedger(xdr.LedgerHeaderHistoryEntry{
 		Header: xdr.LedgerHeader{

--- a/services/horizon/internal/actions_data_test.go
+++ b/services/horizon/internal/actions_data_test.go
@@ -53,9 +53,9 @@ func TestDataActions_Show(t *testing.T) {
 	q := &history.Q{ht.HorizonSession()}
 
 	// Makes StateMiddleware happy
-	err := q.UpdateLastLedgerExpIngest(100)
+	err := q.UpdateLastLedgerIngest(100)
 	ht.Assert.NoError(err)
-	err = q.UpdateExpIngestVersion(ingest.CurrentVersion)
+	err = q.UpdateIngestVersion(ingest.CurrentVersion)
 	ht.Assert.NoError(err)
 	_, err = q.InsertLedger(xdr.LedgerHeaderHistoryEntry{
 		Header: xdr.LedgerHeader{

--- a/services/horizon/internal/actions_effects_test.go
+++ b/services/horizon/internal/actions_effects_test.go
@@ -43,9 +43,9 @@ func TestEffectActions_Index(t *testing.T) {
 
 		// Makes StateMiddleware happy
 		q := history.Q{ht.HorizonSession()}
-		err := q.UpdateLastLedgerExpIngest(3)
+		err := q.UpdateLastLedgerIngest(3)
 		ht.Assert.NoError(err)
-		err = q.UpdateExpIngestVersion(ingest.CurrentVersion)
+		err = q.UpdateIngestVersion(ingest.CurrentVersion)
 		ht.Assert.NoError(err)
 
 		// checks if empty param returns 404 instead of all payments

--- a/services/horizon/internal/actions_payment_test.go
+++ b/services/horizon/internal/actions_payment_test.go
@@ -35,9 +35,9 @@ func TestPaymentActions(t *testing.T) {
 	// Makes StateMiddleware happy
 	initializeStateMiddleware := func() {
 		q := history.Q{ht.HorizonSession()}
-		err := q.UpdateLastLedgerExpIngest(3)
+		err := q.UpdateLastLedgerIngest(3)
 		ht.Assert.NoError(err)
-		err = q.UpdateExpIngestVersion(ingest.CurrentVersion)
+		err = q.UpdateIngestVersion(ingest.CurrentVersion)
 		ht.Assert.NoError(err)
 	}
 	initializeStateMiddleware()

--- a/services/horizon/internal/actions_transaction_test.go
+++ b/services/horizon/internal/actions_transaction_test.go
@@ -193,9 +193,9 @@ func TestTransactionActions_Index(t *testing.T) {
 
 	// Makes StateMiddleware happy
 	q := history.Q{ht.HorizonSession()}
-	err := q.UpdateLastLedgerExpIngest(100)
+	err := q.UpdateLastLedgerIngest(100)
 	ht.Assert.NoError(err)
-	err = q.UpdateExpIngestVersion(ingest.CurrentVersion)
+	err = q.UpdateIngestVersion(ingest.CurrentVersion)
 	ht.Assert.NoError(err)
 
 	// checks if empty param returns 404 instead of all payments

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -222,7 +222,7 @@ func (a *App) UpdateLedgerState() {
 		return
 	}
 
-	next.ExpHistoryLatest, err = a.HistoryQ().GetLastLedgerExpIngestNonBlocking()
+	next.ExpHistoryLatest, err = a.HistoryQ().GetLastLedgerIngestNonBlocking()
 	if err != nil {
 		logErr(err, "failed to load the oldest known exp ledger state from history DB")
 		return
@@ -433,7 +433,7 @@ func (a *App) init() error {
 
 	if a.config.Ingest {
 		// ingester
-		initExpIngester(a)
+		initIngester(a)
 	}
 	initPathFinder(a)
 

--- a/services/horizon/internal/db2/history/ingestion.go
+++ b/services/horizon/internal/db2/history/ingestion.go
@@ -1,11 +1,11 @@
 package history
 
-// TruncateExpingestStateTables clears out ingestion state tables.
+// TruncateIngestStateTables clears out ingestion state tables.
 // Ingestion state tables are horizon database tables populated by
 // the ingestion system using history archive snapshots.
 // Any horizon database tables which cannot be populated using
 // history archive snapshots will not be truncated.
-func (q *Q) TruncateExpingestStateTables() error {
+func (q *Q) TruncateIngestStateTables() error {
 	return q.TruncateTables([]string{
 		"accounts",
 		"accounts_data",

--- a/services/horizon/internal/db2/history/key_value.go
+++ b/services/horizon/internal/db2/history/key_value.go
@@ -18,11 +18,11 @@ const (
 	offerCompactionSequence = "offer_compaction_sequence"
 )
 
-// GetLastLedgerExpIngestNonBlocking works like GetLastLedgerExpIngest but
+// GetLastLedgerIngestNonBlocking works like GetLastLedgerIngest but
 // it does not block the value and does not return error if the value
 // has not been previously set.
 // This is used in status reporting (ex. in root resource of Horizon).
-func (q *Q) GetLastLedgerExpIngestNonBlocking() (uint32, error) {
+func (q *Q) GetLastLedgerIngestNonBlocking() (uint32, error) {
 	lastIngestedLedger, err := q.getValueFromStore(lastLedgerKey, false)
 	if err != nil {
 		return 0, err
@@ -40,13 +40,13 @@ func (q *Q) GetLastLedgerExpIngestNonBlocking() (uint32, error) {
 	}
 }
 
-// GetLastLedgerExpIngest returns the last ledger ingested by ingest system
+// GetLastLedgerIngest returns the last ledger ingested by ingest system
 // in Horizon. Returns ErrKeyNotFound error if no value has been previously set.
 // This is using `SELECT ... FOR UPDATE` what means it's blocking the row for all other
 // transactions.This behaviour is critical in distributed ingestion so do not change
 // it unless you know what you are doing.
-// The value can be set using UpdateLastLedgerExpIngest.
-func (q *Q) GetLastLedgerExpIngest() (uint32, error) {
+// The value can be set using UpdateLastLedgerIngest.
+func (q *Q) GetLastLedgerIngest() (uint32, error) {
 	lastIngestedLedger, err := q.getValueFromStore(lastLedgerKey, true)
 	if err != nil {
 		return 0, err
@@ -66,18 +66,18 @@ func (q *Q) GetLastLedgerExpIngest() (uint32, error) {
 	}
 }
 
-// UpdateLastLedgerExpIngest updates the last ledger ingested by ingest system.
+// UpdateLastLedgerIngest updates the last ledger ingested by ingest system.
 // Can be read using GetLastLedgerExpIngest.
-func (q *Q) UpdateLastLedgerExpIngest(ledgerSequence uint32) error {
+func (q *Q) UpdateLastLedgerIngest(ledgerSequence uint32) error {
 	return q.updateValueInStore(
 		lastLedgerKey,
 		strconv.FormatUint(uint64(ledgerSequence), 10),
 	)
 }
 
-// GetExpIngestVersion returns the exp ingest version. Returns zero
+// GetIngestVersion returns the ingestion version. Returns zero
 // if there is no value.
-func (q *Q) GetExpIngestVersion() (int, error) {
+func (q *Q) GetIngestVersion() (int, error) {
 	expVersion, err := q.getValueFromStore(ingestVersion, false)
 	if err != nil {
 		return 0, err
@@ -95,8 +95,8 @@ func (q *Q) GetExpIngestVersion() (int, error) {
 	}
 }
 
-// UpdateExpIngestVersion updates the exp ingest version.
-func (q *Q) UpdateExpIngestVersion(version int) error {
+// UpdateIngestVersion updates the ingestion version.
+func (q *Q) UpdateIngestVersion(version int) error {
 	return q.updateValueInStore(
 		ingestVersion,
 		strconv.FormatUint(uint64(version), 10),

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -234,13 +234,13 @@ type IngestionQ interface {
 	CloneIngestionQ() IngestionQ
 	Rollback() error
 	GetTx() *sqlx.Tx
-	GetExpIngestVersion() (int, error)
+	GetIngestVersion() (int, error)
 	UpdateExpStateInvalid(bool) error
-	UpdateExpIngestVersion(int) error
+	UpdateIngestVersion(int) error
 	GetExpStateInvalid() (bool, error)
 	GetLatestLedger() (uint32, error)
 	GetOfferCompactionSequence() (uint32, error)
-	TruncateExpingestStateTables() error
+	TruncateIngestStateTables() error
 	DeleteRangeAll(start, end int64) error
 }
 
@@ -538,9 +538,9 @@ type Q struct {
 
 // QSigners defines signer related queries.
 type QSigners interface {
-	GetLastLedgerExpIngestNonBlocking() (uint32, error)
-	GetLastLedgerExpIngest() (uint32, error)
-	UpdateLastLedgerExpIngest(ledgerSequence uint32) error
+	GetLastLedgerIngestNonBlocking() (uint32, error)
+	GetLastLedgerIngest() (uint32, error)
+	UpdateLastLedgerIngest(ledgerSequence uint32) error
 	AccountsForSigner(signer string, page db2.PageQuery) ([]AccountSigner, error)
 	NewAccountSignersBatchInsertBuilder(maxBatchSize int) AccountSignersBatchInsertBuilder
 	CreateAccountSigner(account, signer string, weight int32, sponsor *string) (int64, error)

--- a/services/horizon/internal/db2/history/mock_q_signers.go
+++ b/services/horizon/internal/db2/history/mock_q_signers.go
@@ -9,17 +9,17 @@ type MockQSigners struct {
 	mock.Mock
 }
 
-func (m *MockQSigners) GetLastLedgerExpIngestNonBlocking() (uint32, error) {
+func (m *MockQSigners) GetLastLedgerIngestNonBlocking() (uint32, error) {
 	a := m.Called()
 	return a.Get(0).(uint32), a.Error(1)
 }
 
-func (m *MockQSigners) GetLastLedgerExpIngest() (uint32, error) {
+func (m *MockQSigners) GetLastLedgerIngest() (uint32, error) {
 	a := m.Called()
 	return a.Get(0).(uint32), a.Error(1)
 }
 
-func (m *MockQSigners) UpdateLastLedgerExpIngest(ledgerSequence uint32) error {
+func (m *MockQSigners) UpdateLastLedgerIngest(ledgerSequence uint32) error {
 	a := m.Called(ledgerSequence)
 	return a.Error(0)
 }

--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -261,17 +261,17 @@ type StateMiddleware struct {
 }
 
 func ingestionStatus(q *history.Q) (uint32, bool, error) {
-	version, err := q.GetExpIngestVersion()
+	version, err := q.GetIngestVersion()
 	if err != nil {
 		return 0, false, supportErrors.Wrap(
-			err, "Error running GetExpIngestVersion",
+			err, "Error running GetIngestVersion",
 		)
 	}
 
-	lastIngestedLedger, err := q.GetLastLedgerExpIngestNonBlocking()
+	lastIngestedLedger, err := q.GetLastLedgerIngestNonBlocking()
 	if err != nil {
 		return 0, false, supportErrors.Wrap(
-			err, "Error running GetLastLedgerExpIngestNonBlocking",
+			err, "Error running GetLastLedgerIngestNonBlocking",
 		)
 	}
 
@@ -306,7 +306,7 @@ func (m *StateMiddleware) WrapFunc(h http.HandlerFunc) http.HandlerFunc {
 			ReadOnly:  true,
 		})
 		if err != nil {
-			err = supportErrors.Wrap(err, "Error starting exp ingestion read transaction")
+			err = supportErrors.Wrap(err, "Error starting ingestion read transaction")
 			problem.Render(r.Context(), w, err)
 			return
 		}

--- a/services/horizon/internal/ingest/TESTING.md
+++ b/services/horizon/internal/ingest/TESTING.md
@@ -65,38 +65,38 @@ If you were running the new system in the past (`ENABLE_EXPERIMENTAL_INGESTION` 
 
 ## Reading the logs
 
-In order to check the progress and the status of experimental ingestion you should check the logs. All logs connected to experimental ingestion are tagged with `service=expingest`.
+In order to check the progress and the status of ingestion you should check the logs. All logs connected to experimental ingestion are tagged with `service=ingest`.
 
 It starts with informing you about state ingestion:
 ```
-INFO[2019-08-29T13:04:13.473+02:00] Starting ingestion system from empty state...  pid=5965 service=expingest temp_set="*io.MemoryTempSet"
-INFO[2019-08-29T13:04:15.263+02:00] Reading from History Archive Snapshot         ledger=25565887 pid=5965 service=expingest
+INFO[2019-08-29T13:04:13.473+02:00] Starting ingestion system from empty state...  pid=5965 service=ingest temp_set="*io.MemoryTempSet"
+INFO[2019-08-29T13:04:15.263+02:00] Reading from History Archive Snapshot         ledger=25565887 pid=5965 service=ingest
 ```
 During state ingestion, Horizon will log number of processed entries every 100,000 entries (there are currently around 7M entries in the public network):
 ```
-INFO[2019-08-29T13:04:34.652+02:00] Processing entries from History Archive Snapshot  ledger=25565887 numEntries=100000 pid=5965 service=expingest
-INFO[2019-08-29T13:04:38.487+02:00] Processing entries from History Archive Snapshot  ledger=25565887 numEntries=200000 pid=5965 service=expingest
-INFO[2019-08-29T13:04:41.322+02:00] Processing entries from History Archive Snapshot  ledger=25565887 numEntries=300000 pid=5965 service=expingest
-INFO[2019-08-29T13:04:48.429+02:00] Processing entries from History Archive Snapshot  ledger=25565887 numEntries=400000 pid=5965 service=expingest
-INFO[2019-08-29T13:05:00.306+02:00] Processing entries from History Archive Snapshot  ledger=25565887 numEntries=500000 pid=5965 service=expingest
+INFO[2019-08-29T13:04:34.652+02:00] Processing entries from History Archive Snapshot  ledger=25565887 numEntries=100000 pid=5965 service=ingest
+INFO[2019-08-29T13:04:38.487+02:00] Processing entries from History Archive Snapshot  ledger=25565887 numEntries=200000 pid=5965 service=ingest
+INFO[2019-08-29T13:04:41.322+02:00] Processing entries from History Archive Snapshot  ledger=25565887 numEntries=300000 pid=5965 service=ingest
+INFO[2019-08-29T13:04:48.429+02:00] Processing entries from History Archive Snapshot  ledger=25565887 numEntries=400000 pid=5965 service=ingest
+INFO[2019-08-29T13:05:00.306+02:00] Processing entries from History Archive Snapshot  ledger=25565887 numEntries=500000 pid=5965 service=ingest
 ```
 When state ingestion is finished it will proceed to ledger ingestion starting from the next ledger after checkpoint ledger (25565887+1 in this example) to update the state using transaction meta:
 ```
-INFO[2019-08-29T13:39:41.590+02:00] Processing entries from History Archive Snapshot  ledger=25565887 numEntries=5300000 pid=5965 service=expingest
-INFO[2019-08-29T13:39:44.518+02:00] Processing entries from History Archive Snapshot  ledger=25565887 numEntries=5400000 pid=5965 service=expingest
-INFO[2019-08-29T13:39:47.488+02:00] Processing entries from History Archive Snapshot  ledger=25565887 numEntries=5500000 pid=5965 service=expingest
-INFO[2019-08-29T13:40:00.670+02:00] Processed ledger                              ledger=25565887 pid=5965 service=expingest type=state_pipeline
-INFO[2019-08-29T13:40:00.670+02:00] Finished processing History Archive Snapshot  duration=2145.337575904 ledger=25565887 numEntries=5529931 pid=5965 service=expingest shutdown=false
-INFO[2019-08-29T13:40:00.693+02:00] Reading new ledger                            ledger=25565888 pid=5965 service=expingest
-INFO[2019-08-29T13:40:00.694+02:00] Processing ledger                             ledger=25565888 pid=5965 service=expingest type=ledger_pipeline updating_database=true
-INFO[2019-08-29T13:40:00.779+02:00] Processed ledger                              ledger=25565888 pid=5965 service=expingest type=ledger_pipeline
-INFO[2019-08-29T13:40:00.779+02:00] Finished processing ledger                    duration=0.086024492 ledger=25565888 pid=5965 service=expingest shutdown=false transactions=14
-INFO[2019-08-29T13:40:00.815+02:00] Reading new ledger                            ledger=25565889 pid=5965 service=expingest
-INFO[2019-08-29T13:40:00.816+02:00] Processing ledger                             ledger=25565889 pid=5965 service=expingest type=ledger_pipeline updating_database=true
-INFO[2019-08-29T13:40:00.881+02:00] Processed ledger                              ledger=25565889 pid=5965 service=expingest type=ledger_pipeline
-INFO[2019-08-29T13:40:00.881+02:00] Finished processing ledger                    duration=0.06619956 ledger=25565889 pid=5965 service=expingest shutdown=false transactions=29
-INFO[2019-08-29T13:40:00.901+02:00] Reading new ledger                            ledger=25565890 pid=5965 service=expingest
-INFO[2019-08-29T13:40:00.902+02:00] Processing ledger                             ledger=25565890 pid=5965 service=expingest type=ledger_pipeline updating_database=true
-INFO[2019-08-29T13:40:00.972+02:00] Processed ledger                              ledger=25565890 pid=5965 service=expingest type=ledger_pipeline
-INFO[2019-08-29T13:40:00.972+02:00] Finished processing ledger                    duration=0.071039012 ledger=25565890 pid=5965 service=expingest shutdown=false transactions=20
+INFO[2019-08-29T13:39:41.590+02:00] Processing entries from History Archive Snapshot  ledger=25565887 numEntries=5300000 pid=5965 service=ingest
+INFO[2019-08-29T13:39:44.518+02:00] Processing entries from History Archive Snapshot  ledger=25565887 numEntries=5400000 pid=5965 service=ingest
+INFO[2019-08-29T13:39:47.488+02:00] Processing entries from History Archive Snapshot  ledger=25565887 numEntries=5500000 pid=5965 service=ingest
+INFO[2019-08-29T13:40:00.670+02:00] Processed ledger                              ledger=25565887 pid=5965 service=ingest type=state_pipeline
+INFO[2019-08-29T13:40:00.670+02:00] Finished processing History Archive Snapshot  duration=2145.337575904 ledger=25565887 numEntries=5529931 pid=5965 service=ingest shutdown=false
+INFO[2019-08-29T13:40:00.693+02:00] Reading new ledger                            ledger=25565888 pid=5965 service=ingest
+INFO[2019-08-29T13:40:00.694+02:00] Processing ledger                             ledger=25565888 pid=5965 service=ingest type=ledger_pipeline updating_database=true
+INFO[2019-08-29T13:40:00.779+02:00] Processed ledger                              ledger=25565888 pid=5965 service=ingest type=ledger_pipeline
+INFO[2019-08-29T13:40:00.779+02:00] Finished processing ledger                    duration=0.086024492 ledger=25565888 pid=5965 service=ingest shutdown=false transactions=14
+INFO[2019-08-29T13:40:00.815+02:00] Reading new ledger                            ledger=25565889 pid=5965 service=ingest
+INFO[2019-08-29T13:40:00.816+02:00] Processing ledger                             ledger=25565889 pid=5965 service=ingest type=ledger_pipeline updating_database=true
+INFO[2019-08-29T13:40:00.881+02:00] Processed ledger                              ledger=25565889 pid=5965 service=ingest type=ledger_pipeline
+INFO[2019-08-29T13:40:00.881+02:00] Finished processing ledger                    duration=0.06619956 ledger=25565889 pid=5965 service=ingest shutdown=false transactions=29
+INFO[2019-08-29T13:40:00.901+02:00] Reading new ledger                            ledger=25565890 pid=5965 service=ingest
+INFO[2019-08-29T13:40:00.902+02:00] Processing ledger                             ledger=25565890 pid=5965 service=ingest type=ledger_pipeline updating_database=true
+INFO[2019-08-29T13:40:00.972+02:00] Processed ledger                              ledger=25565890 pid=5965 service=ingest type=ledger_pipeline
+INFO[2019-08-29T13:40:00.972+02:00] Finished processing ledger                    duration=0.071039012 ledger=25565890 pid=5965 service=ingest shutdown=false transactions=20
 ```

--- a/services/horizon/internal/ingest/build_state_test.go
+++ b/services/horizon/internal/ingest/build_state_test.go
@@ -61,11 +61,11 @@ func (s *BuildStateTestSuite) TearDownTest() {
 }
 
 func (s *BuildStateTestSuite) mockCommonHistoryQ() {
-	s.historyQ.On("GetLastLedgerExpIngest").Return(s.lastLedger, nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", s.lastLedger).Return(nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(s.lastLedger, nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("UpdateLastLedgerIngest", s.lastLedger).Return(nil).Once()
 	s.historyQ.On("UpdateExpStateInvalid", false).Return(nil).Once()
-	s.historyQ.On("TruncateExpingestStateTables").Return(nil).Once()
+	s.historyQ.On("TruncateIngestStateTables").Return(nil).Once()
 	s.stellarCoreClient.On(
 		"SetCursor",
 		mock.AnythingOfType("*context.timerCtx"),
@@ -96,37 +96,37 @@ func (s *BuildStateTestSuite) TestBeginReturnsError() {
 	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
-func (s *BuildStateTestSuite) TestGetLastLedgerExpIngestReturnsError() {
-	s.historyQ.On("GetLastLedgerExpIngest").Return(s.lastLedger, errors.New("my error")).Once()
+func (s *BuildStateTestSuite) TestGetLastLedgerIngestReturnsError() {
+	s.historyQ.On("GetLastLedgerIngest").Return(s.lastLedger, errors.New("my error")).Once()
 
 	next, err := buildState{checkpointLedger: s.checkpointLedger}.run(s.system)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "Error getting last ingested ledger: my error")
 	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
-func (s *BuildStateTestSuite) TestGetExpIngestVersionReturnsError() {
-	s.historyQ.On("GetLastLedgerExpIngest").Return(s.lastLedger, nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, errors.New("my error")).Once()
+func (s *BuildStateTestSuite) TestGetIngestVersionReturnsError() {
+	s.historyQ.On("GetLastLedgerIngest").Return(s.lastLedger, nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, errors.New("my error")).Once()
 
 	next, err := buildState{checkpointLedger: s.checkpointLedger}.run(s.system)
 	s.Assert().Error(err)
-	s.Assert().EqualError(err, "Error getting exp ingest version: my error")
+	s.Assert().EqualError(err, "Error getting ingestion version: my error")
 	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
 func (s *BuildStateTestSuite) TestAnotherInstanceHasCompletedBuildState() {
-	s.historyQ.On("GetLastLedgerExpIngest").Return(s.checkpointLedger, nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(s.checkpointLedger, nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
 
 	next, err := buildState{checkpointLedger: s.checkpointLedger}.run(s.system)
 	s.Assert().NoError(err)
 	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
-func (s *BuildStateTestSuite) TestUpdateLastLedgerExpIngestReturnsError() {
-	s.historyQ.On("GetLastLedgerExpIngest").Return(s.lastLedger, nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", s.lastLedger).Return(errors.New("my error")).Once()
+func (s *BuildStateTestSuite) TestUpdateLastLedgerIngestReturnsError() {
+	s.historyQ.On("GetLastLedgerIngest").Return(s.lastLedger, nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("UpdateLastLedgerIngest", s.lastLedger).Return(errors.New("my error")).Once()
 	s.stellarCoreClient.On(
 		"SetCursor",
 		mock.AnythingOfType("*context.timerCtx"),
@@ -142,9 +142,9 @@ func (s *BuildStateTestSuite) TestUpdateLastLedgerExpIngestReturnsError() {
 }
 
 func (s *BuildStateTestSuite) TestUpdateExpStateInvalidReturnsError() {
-	s.historyQ.On("GetLastLedgerExpIngest").Return(s.lastLedger, nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", s.lastLedger).Return(nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(s.lastLedger, nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("UpdateLastLedgerIngest", s.lastLedger).Return(nil).Once()
 	s.historyQ.On("UpdateExpStateInvalid", false).Return(errors.New("my error")).Once()
 	s.stellarCoreClient.On(
 		"SetCursor",
@@ -160,12 +160,12 @@ func (s *BuildStateTestSuite) TestUpdateExpStateInvalidReturnsError() {
 	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
-func (s *BuildStateTestSuite) TestTruncateExpingestStateTablesReturnsError() {
-	s.historyQ.On("GetLastLedgerExpIngest").Return(s.lastLedger, nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", s.lastLedger).Return(nil).Once()
+func (s *BuildStateTestSuite) TestTruncateIngestStateTablesReturnsError() {
+	s.historyQ.On("GetLastLedgerIngest").Return(s.lastLedger, nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("UpdateLastLedgerIngest", s.lastLedger).Return(nil).Once()
 	s.historyQ.On("UpdateExpStateInvalid", false).Return(nil).Once()
-	s.historyQ.On("TruncateExpingestStateTables").Return(errors.New("my error")).Once()
+	s.historyQ.On("TruncateIngestStateTables").Return(errors.New("my error")).Once()
 
 	s.stellarCoreClient.On(
 		"SetCursor",
@@ -182,11 +182,11 @@ func (s *BuildStateTestSuite) TestTruncateExpingestStateTablesReturnsError() {
 }
 
 func (s *BuildStateTestSuite) TestRangeNotPreparedFailPrepare() {
-	s.historyQ.On("GetLastLedgerExpIngest").Return(s.lastLedger, nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", s.lastLedger).Return(nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(s.lastLedger, nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("UpdateLastLedgerIngest", s.lastLedger).Return(nil).Once()
 	s.historyQ.On("UpdateExpStateInvalid", false).Return(nil).Once()
-	s.historyQ.On("TruncateExpingestStateTables").Return(nil).Once()
+	s.historyQ.On("TruncateIngestStateTables").Return(nil).Once()
 
 	s.stellarCoreClient.On(
 		"SetCursor",
@@ -209,11 +209,11 @@ func (s *BuildStateTestSuite) TestRangeNotPreparedFailPrepare() {
 }
 
 func (s *BuildStateTestSuite) TestRangeNotPreparedSuccessPrepare() {
-	s.historyQ.On("GetLastLedgerExpIngest").Return(s.lastLedger, nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", s.lastLedger).Return(nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(s.lastLedger, nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("UpdateLastLedgerIngest", s.lastLedger).Return(nil).Once()
 	s.historyQ.On("UpdateExpStateInvalid", false).Return(nil).Once()
-	s.historyQ.On("TruncateExpingestStateTables").Return(nil).Once()
+	s.historyQ.On("TruncateIngestStateTables").Return(nil).Once()
 
 	s.stellarCoreClient.On(
 		"SetCursor",
@@ -250,16 +250,16 @@ func (s *BuildStateTestSuite) TestRunHistoryArchiveIngestionReturnsError() {
 	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
-func (s *BuildStateTestSuite) TestUpdateLastLedgerExpIngestAfterIngestReturnsError() {
+func (s *BuildStateTestSuite) TestUpdateLastLedgerIngestAfterIngestReturnsError() {
 	s.mockCommonHistoryQ()
 	s.runner.
 		On("RunHistoryArchiveIngestion", s.checkpointLedger).
 		Return(io.StatsChangeProcessorResults{}, nil).
 		Once()
-	s.historyQ.On("UpdateExpIngestVersion", CurrentVersion).
+	s.historyQ.On("UpdateIngestVersion", CurrentVersion).
 		Return(nil).
 		Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", s.checkpointLedger).
+	s.historyQ.On("UpdateLastLedgerIngest", s.checkpointLedger).
 		Return(errors.New("my error")).
 		Once()
 	next, err := buildState{checkpointLedger: s.checkpointLedger}.run(s.system)
@@ -269,19 +269,19 @@ func (s *BuildStateTestSuite) TestUpdateLastLedgerExpIngestAfterIngestReturnsErr
 	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
-func (s *BuildStateTestSuite) TestUpdateExpIngestVersionIngestReturnsError() {
+func (s *BuildStateTestSuite) TestUpdateIngestVersionIngestReturnsError() {
 	s.mockCommonHistoryQ()
 	s.runner.
 		On("RunHistoryArchiveIngestion", s.checkpointLedger).
 		Return(io.StatsChangeProcessorResults{}, nil).
 		Once()
-	s.historyQ.On("UpdateExpIngestVersion", CurrentVersion).
+	s.historyQ.On("UpdateIngestVersion", CurrentVersion).
 		Return(errors.New("my error")).
 		Once()
 	next, err := buildState{checkpointLedger: s.checkpointLedger}.run(s.system)
 
 	s.Assert().Error(err)
-	s.Assert().EqualError(err, "Error updating ingest version: my error")
+	s.Assert().EqualError(err, "Error updating ingestion version: my error")
 	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
@@ -291,10 +291,10 @@ func (s *BuildStateTestSuite) TestUpdateCommitReturnsError() {
 		On("RunHistoryArchiveIngestion", s.checkpointLedger).
 		Return(io.StatsChangeProcessorResults{}, nil).
 		Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", s.checkpointLedger).
+	s.historyQ.On("UpdateLastLedgerIngest", s.checkpointLedger).
 		Return(nil).
 		Once()
-	s.historyQ.On("UpdateExpIngestVersion", CurrentVersion).
+	s.historyQ.On("UpdateIngestVersion", CurrentVersion).
 		Return(nil).
 		Once()
 	s.historyQ.On("Commit").
@@ -313,10 +313,10 @@ func (s *BuildStateTestSuite) TestBuildStateSucceeds() {
 		On("RunHistoryArchiveIngestion", s.checkpointLedger).
 		Return(io.StatsChangeProcessorResults{}, nil).
 		Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", s.checkpointLedger).
+	s.historyQ.On("UpdateLastLedgerIngest", s.checkpointLedger).
 		Return(nil).
 		Once()
-	s.historyQ.On("UpdateExpIngestVersion", CurrentVersion).
+	s.historyQ.On("UpdateIngestVersion", CurrentVersion).
 		Return(nil).
 		Once()
 	s.historyQ.On("Commit").
@@ -341,10 +341,10 @@ func (s *BuildStateTestSuite) TestUpdateCommitReturnsErrorStop() {
 		On("RunHistoryArchiveIngestion", s.checkpointLedger).
 		Return(io.StatsChangeProcessorResults{}, nil).
 		Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", s.checkpointLedger).
+	s.historyQ.On("UpdateLastLedgerIngest", s.checkpointLedger).
 		Return(nil).
 		Once()
-	s.historyQ.On("UpdateExpIngestVersion", CurrentVersion).
+	s.historyQ.On("UpdateIngestVersion", CurrentVersion).
 		Return(nil).
 		Once()
 	s.historyQ.On("Commit").
@@ -363,10 +363,10 @@ func (s *BuildStateTestSuite) TestBuildStateSucceedStop() {
 		On("RunHistoryArchiveIngestion", s.checkpointLedger).
 		Return(io.StatsChangeProcessorResults{}, nil).
 		Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", s.checkpointLedger).
+	s.historyQ.On("UpdateLastLedgerIngest", s.checkpointLedger).
 		Return(nil).
 		Once()
-	s.historyQ.On("UpdateExpIngestVersion", CurrentVersion).
+	s.historyQ.On("UpdateIngestVersion", CurrentVersion).
 		Return(nil).
 		Once()
 	s.historyQ.On("Commit").

--- a/services/horizon/internal/ingest/db_integration_test.go
+++ b/services/horizon/internal/ingest/db_integration_test.go
@@ -154,7 +154,7 @@ func (s *DBTestSuite) TestVersionMismatchTriggersRebuild() {
 	s.TestBuildState()
 
 	s.Assert().NoError(
-		s.system.historyQ.UpdateExpIngestVersion(CurrentVersion - 1),
+		s.system.historyQ.UpdateIngestVersion(CurrentVersion - 1),
 	)
 
 	s.setupMocksForBuildState()

--- a/services/horizon/internal/ingest/fsm.go
+++ b/services/horizon/internal/ingest/fsm.go
@@ -134,14 +134,14 @@ func (state startState) run(s *system) (transition, error) {
 	defer s.historyQ.Rollback()
 
 	// This will get the value `FOR UPDATE`, blocking it for other nodes.
-	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
+	lastIngestedLedger, err := s.historyQ.GetLastLedgerIngest()
 	if err != nil {
 		return start(), errors.Wrap(err, getLastIngestedErrMsg)
 	}
 
-	ingestVersion, err := s.historyQ.GetExpIngestVersion()
+	ingestVersion, err := s.historyQ.GetIngestVersion()
 	if err != nil {
-		return start(), errors.Wrap(err, getExpIngestVersionErrMsg)
+		return start(), errors.Wrap(err, getIngestVersionErrMsg)
 	}
 
 	if ingestVersion > CurrentVersion {
@@ -161,7 +161,7 @@ func (state startState) run(s *system) (transition, error) {
 		// This block is either starting from empty state or ingestion
 		// version upgrade.
 		// This will always run on a single instance due to the fact that
-		// `LastLedgerExpIngest` value is blocked for update and will always
+		// `LastLedgerIngest` value is blocked for update and will always
 		// be updated when leading instance finishes processing state.
 		// In case of errors it will start `Init` from the beginning.
 		var lastCheckpoint uint32
@@ -201,13 +201,13 @@ func (state startState) run(s *system) (transition, error) {
 
 	switch {
 	case lastHistoryLedger > lastIngestedLedger:
-		// Expingest was running at some point the past but was turned off.
+		// Ingestion was running at some point the past but was turned off.
 		// Now it's on by default but the latest history ledger is greater
 		// than the latest ingest ledger. We reset the exp ledger sequence
 		// so init state will rebuild the state correctly.
-		err = s.historyQ.UpdateLastLedgerExpIngest(0)
+		err = s.historyQ.UpdateLastLedgerIngest(0)
 		if err != nil {
-			return start(), errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
+			return start(), errors.Wrap(err, updateLastLedgerIngestErrMsg)
 		}
 		err = s.historyQ.Commit()
 		if err != nil {
@@ -215,11 +215,11 @@ func (state startState) run(s *system) (transition, error) {
 		}
 		return start(), nil
 	// lastHistoryLedger != 0 check is here to check the case when one node ingested
-	// the state (so latest exp ingest is > 0) but no history has been ingested yet.
+	// the state (so latest ingestion is > 0) but no history has been ingested yet.
 	// In such case we execute default case and resume from the last ingested
 	// ledger.
 	case lastHistoryLedger != 0 && lastHistoryLedger < lastIngestedLedger:
-		// Expingest was running at some point the past but was turned off.
+		// Ingestion was running at some point the past but was turned off.
 		// Now it's on by default but the latest history ledger is less
 		// than the latest ingest ledger. We catchup history.
 		return historyRange(lastHistoryLedger+1, lastIngestedLedger), nil
@@ -260,14 +260,14 @@ func (b buildState) run(s *system) (transition, error) {
 
 	// We need to get this value `FOR UPDATE` so all other instances
 	// are blocked.
-	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
+	lastIngestedLedger, err := s.historyQ.GetLastLedgerIngest()
 	if err != nil {
 		return nextFailState, errors.Wrap(err, getLastIngestedErrMsg)
 	}
 
-	ingestVersion, err := s.historyQ.GetExpIngestVersion()
+	ingestVersion, err := s.historyQ.GetIngestVersion()
 	if err != nil {
-		return nextFailState, errors.Wrap(err, getExpIngestVersionErrMsg)
+		return nextFailState, errors.Wrap(err, getIngestVersionErrMsg)
 	}
 
 	// Double check if we should proceed with state ingestion. It's possible that
@@ -286,9 +286,9 @@ func (b buildState) run(s *system) (transition, error) {
 	log.Info("Starting ingestion system from empty state...")
 
 	// Clear last_ingested_ledger in key value store
-	err = s.historyQ.UpdateLastLedgerExpIngest(0)
+	err = s.historyQ.UpdateLastLedgerIngest(0)
 	if err != nil {
-		return nextFailState, errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
+		return nextFailState, errors.Wrap(err, updateLastLedgerIngestErrMsg)
 	}
 
 	// Clear invalid state in key value store. It's possible that upgraded
@@ -299,7 +299,7 @@ func (b buildState) run(s *system) (transition, error) {
 	}
 
 	// State tables should be empty.
-	err = s.historyQ.TruncateExpingestStateTables()
+	err = s.historyQ.TruncateIngestStateTables()
 	if err != nil {
 		return nextFailState, errors.Wrap(err, "Error clearing ingest tables")
 	}
@@ -325,8 +325,8 @@ func (b buildState) run(s *system) (transition, error) {
 		return nextFailState, errors.Wrap(err, "Error ingesting history archive")
 	}
 
-	if err = s.historyQ.UpdateExpIngestVersion(CurrentVersion); err != nil {
-		return nextFailState, errors.Wrap(err, "Error updating ingest version")
+	if err = s.historyQ.UpdateIngestVersion(CurrentVersion); err != nil {
+		return nextFailState, errors.Wrap(err, "Error updating ingestion version")
 	}
 
 	if err = s.completeIngestion(b.checkpointLedger); err != nil {
@@ -368,7 +368,7 @@ func (r resumeState) run(s *system) (transition, error) {
 	defer s.historyQ.Rollback()
 
 	// This will get the value `FOR UPDATE`, blocking it for other nodes.
-	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
+	lastIngestedLedger, err := s.historyQ.GetLastLedgerIngest()
 	if err != nil {
 		return retryResume(r), errors.Wrap(err, getLastIngestedErrMsg)
 	}
@@ -385,9 +385,9 @@ func (r resumeState) run(s *system) (transition, error) {
 		ingestLedger = lastIngestedLedger + 1
 	}
 
-	ingestVersion, err := s.historyQ.GetExpIngestVersion()
+	ingestVersion, err := s.historyQ.GetIngestVersion()
 	if err != nil {
-		return retryResume(r), errors.Wrap(err, getExpIngestVersionErrMsg)
+		return retryResume(r), errors.Wrap(err, getIngestVersionErrMsg)
 	}
 
 	if ingestVersion != CurrentVersion {
@@ -544,7 +544,7 @@ func (h historyRangeState) run(s *system) (transition, error) {
 	defer s.historyQ.Rollback()
 
 	// acquire distributed lock so no one else can perform ingestion operations.
-	if _, err := s.historyQ.GetLastLedgerExpIngest(); err != nil {
+	if _, err := s.historyQ.GetLastLedgerIngest(); err != nil {
 		return start(), errors.Wrap(err, getLastIngestedErrMsg)
 	}
 
@@ -687,7 +687,7 @@ func (h reingestHistoryRangeState) run(s *system) (transition, error) {
 		defer s.historyQ.Rollback()
 
 		// acquire distributed lock so no one else can perform ingestion operations.
-		if _, err := s.historyQ.GetLastLedgerExpIngest(); err != nil {
+		if _, err := s.historyQ.GetLastLedgerIngest(); err != nil {
 			return stop(), errors.Wrap(err, getLastIngestedErrMsg)
 		}
 
@@ -699,7 +699,7 @@ func (h reingestHistoryRangeState) run(s *system) (transition, error) {
 			return stop(), errors.Wrap(err, commitErrMsg)
 		}
 	} else {
-		lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngestNonBlocking()
+		lastIngestedLedger, err := s.historyQ.GetLastLedgerIngestNonBlocking()
 		if err != nil {
 			return stop(), errors.Wrap(err, getLastIngestedErrMsg)
 		}
@@ -782,7 +782,7 @@ func (v verifyRangeState) run(s *system) (transition, error) {
 	defer s.historyQ.Rollback()
 
 	// Simple check if DB clean
-	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
+	lastIngestedLedger, err := s.historyQ.GetLastLedgerIngest()
 	if err != nil {
 		err = errors.Wrap(err, getLastIngestedErrMsg)
 		return stop(), err
@@ -887,7 +887,7 @@ func (stressTestState) run(s *system) (transition, error) {
 	defer s.historyQ.Rollback()
 
 	// Simple check if DB clean
-	lastIngestedLedger, err := s.historyQ.GetLastLedgerExpIngest()
+	lastIngestedLedger, err := s.historyQ.GetLastLedgerIngest()
 	if err != nil {
 		err = errors.Wrap(err, getLastIngestedErrMsg)
 		return stop(), err
@@ -943,8 +943,8 @@ func (s *system) completeIngestion(ledger uint32) error {
 		return errors.New("ledger must be positive")
 	}
 
-	if err := s.historyQ.UpdateLastLedgerExpIngest(ledger); err != nil {
-		err = errors.Wrap(err, updateLastLedgerExpIngestErrMsg)
+	if err := s.historyQ.UpdateLastLedgerIngest(ledger); err != nil {
+		err = errors.Wrap(err, updateLastLedgerIngestErrMsg)
 		return err
 	}
 

--- a/services/horizon/internal/ingest/ingest_history_range_state_test.go
+++ b/services/horizon/internal/ingest/ingest_history_range_state_test.go
@@ -88,9 +88,9 @@ func (s *IngestHistoryRangeStateTestSuite) TestBeginReturnsError() {
 	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
-func (s *IngestHistoryRangeStateTestSuite) TestGetLastLedgerExpIngestReturnsError() {
+func (s *IngestHistoryRangeStateTestSuite) TestGetLastLedgerIngestReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), errors.New("my error")).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), errors.New("my error")).Once()
 
 	next, err := historyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
 	s.Assert().Error(err)
@@ -100,7 +100,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestGetLastLedgerExpIngestReturnsErro
 
 func (s *IngestHistoryRangeStateTestSuite) TestGetLatestLedgerReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), errors.New("my error")).Once()
 
 	next, err := historyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
@@ -113,7 +113,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestGetLatestLedgerReturnsError() {
 // In such case we go back to `init` state without processing.
 func (s *IngestHistoryRangeStateTestSuite) TestAnotherNodeIngested() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(200), nil).Once()
 
 	next, err := historyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
@@ -123,7 +123,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestAnotherNodeIngested() {
 
 func (s *IngestHistoryRangeStateTestSuite) TestRunTransactionProcessorsOnLedgerReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
 	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(100)).Return(true, nil).Once()
@@ -141,7 +141,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestRunTransactionProcessorsOnLedgerR
 
 func (s *IngestHistoryRangeStateTestSuite) TestRangeNotPreparedFailPrepare() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
 	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(100)).Return(false, nil).Once()
@@ -158,7 +158,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestRangeNotPreparedFailPrepare() {
 
 func (s *IngestHistoryRangeStateTestSuite) TestRangeNotPreparedSuccessPrepare() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
 	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(100)).Return(false, nil).Once()
@@ -174,7 +174,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestRangeNotPreparedSuccessPrepare() 
 
 func (s *IngestHistoryRangeStateTestSuite) TestSuccess() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
 	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(100)).Return(true, nil).Once()
@@ -196,7 +196,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestSuccess() {
 
 func (s *IngestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil).Once()
 
 	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(100)).Return(true, nil).Once()
@@ -275,7 +275,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestBeginReturnsError() {
 	// Recreate mock in this single test to remove Rollback assertion.
 	*s.historyQ = mockDBQ{}
 	s.historyQ.On("GetTx").Return(nil)
-	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngestNonBlocking").Return(uint32(0), nil).Once()
 
 	s.historyQ.On("Begin").Return(errors.New("my error")).Once()
 
@@ -283,11 +283,11 @@ func (s *ReingestHistoryRangeStateTestSuite) TestBeginReturnsError() {
 	s.Assert().EqualError(err, "Error starting a transaction: my error")
 }
 
-func (s *ReingestHistoryRangeStateTestSuite) TestGetLastLedgerExpIngestNonBlockingError() {
+func (s *ReingestHistoryRangeStateTestSuite) TestGetLastLedgerIngestNonBlockingError() {
 	*s.historyQ = mockDBQ{}
 	s.historyQ.On("GetTx").Return(nil).Once()
 
-	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), errors.New("my error")).Once()
+	s.historyQ.On("GetLastLedgerIngestNonBlocking").Return(uint32(0), errors.New("my error")).Once()
 
 	err := s.system.ReingestRange(100, 200, false)
 	s.Assert().EqualError(err, "Error getting last ingested ledger: my error")
@@ -297,7 +297,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeOverlaps() {
 	*s.historyQ = mockDBQ{}
 	s.historyQ.On("GetTx").Return(nil).Once()
 
-	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(190), nil).Once()
+	s.historyQ.On("GetLastLedgerIngestNonBlocking").Return(uint32(190), nil).Once()
 
 	err := s.system.ReingestRange(100, 200, false)
 	s.Assert().Equal(err, ErrReingestRangeConflict)
@@ -307,7 +307,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeOverlapsAtEnd() {
 	*s.historyQ = mockDBQ{}
 	s.historyQ.On("GetTx").Return(nil).Once()
 
-	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(200), nil).Once()
+	s.historyQ.On("GetLastLedgerIngestNonBlocking").Return(uint32(200), nil).Once()
 
 	err := s.system.ReingestRange(100, 200, false)
 	s.Assert().Equal(err, ErrReingestRangeConflict)
@@ -316,7 +316,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeOverlapsAtEnd() {
 func (s *ReingestHistoryRangeStateTestSuite) TestClearHistoryFails() {
 	*s.historyQ = mockDBQ{}
 	s.historyQ.On("GetTx").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngestNonBlocking").Return(uint32(0), nil).Once()
 
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
@@ -335,7 +335,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestClearHistoryFails() {
 func (s *ReingestHistoryRangeStateTestSuite) TestRunTransactionProcessorsOnLedgerReturnsError() {
 	*s.historyQ = mockDBQ{}
 	s.historyQ.On("GetTx").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngestNonBlocking").Return(uint32(0), nil).Once()
 
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
@@ -360,7 +360,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestRunTransactionProcessorsOnLedge
 func (s *ReingestHistoryRangeStateTestSuite) TestCommitFails() {
 	*s.historyQ = mockDBQ{}
 	s.historyQ.On("GetTx").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngestNonBlocking").Return(uint32(0), nil).Once()
 
 	s.historyQ.On("Begin").Return(nil).Once()
 	s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
@@ -386,7 +386,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestCommitFails() {
 func (s *ReingestHistoryRangeStateTestSuite) TestSuccess() {
 	*s.historyQ = mockDBQ{}
 	s.historyQ.On("GetTx").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngestNonBlocking").Return(uint32(0), nil).Once()
 
 	for i := uint32(100); i <= uint32(200); i++ {
 		s.historyQ.On("Begin").Return(nil).Once()
@@ -413,7 +413,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestSuccess() {
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
-	s.historyQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngestNonBlocking").Return(uint32(0), nil).Once()
 	s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
 
 	toidFrom := toid.New(100, 0, 0)
@@ -437,15 +437,15 @@ func (s *ReingestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
 	s.Assert().NoError(err)
 }
 
-func (s *ReingestHistoryRangeStateTestSuite) TestGetLastLedgerExpIngestError() {
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), errors.New("my error")).Once()
+func (s *ReingestHistoryRangeStateTestSuite) TestGetLastLedgerIngestError() {
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), errors.New("my error")).Once()
 
 	err := s.system.ReingestRange(100, 200, true)
 	s.Assert().EqualError(err, "Error getting last ingested ledger: my error")
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeForce() {
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(190), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(190), nil).Once()
 
 	s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
 

--- a/services/horizon/internal/ingest/init_state_test.go
+++ b/services/horizon/internal/ingest/init_state_test.go
@@ -51,9 +51,9 @@ func (s *InitStateTestSuite) TestBeginReturnsError() {
 	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
-func (s *InitStateTestSuite) TestGetLastLedgerExpIngestReturnsError() {
+func (s *InitStateTestSuite) TestGetLastLedgerIngestReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), errors.New("my error")).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), errors.New("my error")).Once()
 
 	next, err := startState{}.run(s.system)
 	s.Assert().Error(err)
@@ -61,21 +61,21 @@ func (s *InitStateTestSuite) TestGetLastLedgerExpIngestReturnsError() {
 	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
-func (s *InitStateTestSuite) TestGetExpIngestVersionReturnsError() {
+func (s *InitStateTestSuite) TestGetIngestVersionReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(0, errors.New("my error")).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(0, errors.New("my error")).Once()
 
 	next, err := startState{}.run(s.system)
 	s.Assert().Error(err)
-	s.Assert().EqualError(err, "Error getting exp ingest version: my error")
+	s.Assert().EqualError(err, "Error getting ingestion version: my error")
 	s.Assert().Equal(transition{node: startState{}, sleepDuration: defaultSleep}, next)
 }
 
 func (s *InitStateTestSuite) TestCurrentVersionIsOutdated() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(1), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion+1, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(1), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion+1, nil).Once()
 
 	next, err := startState{}.run(s.system)
 	s.Assert().NoError(err)
@@ -84,8 +84,8 @@ func (s *InitStateTestSuite) TestCurrentVersionIsOutdated() {
 
 func (s *InitStateTestSuite) TestGetLatestLedgerReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(0, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(0, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), errors.New("my error")).Once()
 
 	next, err := startState{}.run(s.system)
@@ -96,8 +96,8 @@ func (s *InitStateTestSuite) TestGetLatestLedgerReturnsError() {
 
 func (s *InitStateTestSuite) TestBuildStateEmptyDatabase() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(0, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(0, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil).Once()
 
 	s.historyAdapter.On("GetLatestLedgerSequence").Return(uint32(63), nil).Once()
@@ -112,8 +112,8 @@ func (s *InitStateTestSuite) TestBuildStateEmptyDatabase() {
 
 func (s *InitStateTestSuite) TestBuildStateEmptyDatabaseFromSuggestedCheckpoint() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(0, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(0, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil).Once()
 
 	next, err := startState{suggestedCheckpoint: 127}.run(s.system)
@@ -129,8 +129,8 @@ func (s *InitStateTestSuite) TestBuildStateEmptyDatabaseFromSuggestedCheckpoint(
 // * the old system is in front of the latest checkpoint.
 func (s *InitStateTestSuite) TestBuildStateWait() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(0, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(0, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(100), nil).Once()
 
 	s.historyAdapter.On("GetLatestLedgerSequence").Return(uint32(63), nil).Once()
@@ -148,8 +148,8 @@ func (s *InitStateTestSuite) TestBuildStateWait() {
 // * the old system is behind the latest checkpoint.
 func (s *InitStateTestSuite) TestBuildStateCatchup() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(0, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(0, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(100), nil).Once()
 
 	s.historyAdapter.On("GetLatestLedgerSequence").Return(uint32(127), nil).Once()
@@ -170,8 +170,8 @@ func (s *InitStateTestSuite) TestBuildStateCatchup() {
 // * the old system latest ledger is equal to the latest checkpoint.
 func (s *InitStateTestSuite) TestBuildStateOldHistory() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(127), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(0, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(127), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(0, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(127), nil).Once()
 
 	s.historyAdapter.On("GetLatestLedgerSequence").Return(uint32(127), nil).Once()
@@ -192,11 +192,11 @@ func (s *InitStateTestSuite) TestBuildStateOldHistory() {
 // * history is in front of ingest.
 func (s *InitStateTestSuite) TestResumeStateInFront() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(130), nil).Once()
 
-	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(0)).Return(nil).Once()
+	s.historyQ.On("UpdateLastLedgerIngest", uint32(0)).Return(nil).Once()
 	s.historyQ.On("Commit").Return(nil).Once()
 
 	next, err := startState{}.run(s.system)
@@ -209,8 +209,8 @@ func (s *InitStateTestSuite) TestResumeStateInFront() {
 // * history is behind of ingest.
 func (s *InitStateTestSuite) TestResumeStateBehind() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(130), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(130), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(100), nil).Once()
 
 	next, err := startState{}.run(s.system)
@@ -230,8 +230,8 @@ func (s *InitStateTestSuite) TestResumeStateBehind() {
 // In such case we load offers and continue ingesting the next ledger.
 func (s *InitStateTestSuite) TestResumeStateBehindHistory0() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(130), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(130), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil).Once()
 
 	next, err := startState{}.run(s.system)
@@ -250,8 +250,8 @@ func (s *InitStateTestSuite) TestResumeStateBehindHistory0() {
 // * history is in sync with ingest.
 func (s *InitStateTestSuite) TestResumeStateSync() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(130), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(130), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(130), nil).Once()
 
 	next, err := startState{}.run(s.system)

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -85,11 +85,11 @@ type Config struct {
 }
 
 const (
-	getLastIngestedErrMsg           string = "Error getting last ingested ledger"
-	getExpIngestVersionErrMsg       string = "Error getting exp ingest version"
-	updateLastLedgerExpIngestErrMsg string = "Error updating last ingested ledger"
-	commitErrMsg                    string = "Error committing db transaction"
-	updateExpStateInvalidErrMsg     string = "Error updating state invalid value"
+	getLastIngestedErrMsg        string = "Error getting last ingested ledger"
+	getIngestVersionErrMsg       string = "Error getting ingestion version"
+	updateLastLedgerIngestErrMsg string = "Error updating last ingested ledger"
+	commitErrMsg                 string = "Error committing db transaction"
+	updateExpStateInvalidErrMsg  string = "Error updating state invalid value"
 )
 
 type stellarCoreClient interface {
@@ -305,7 +305,7 @@ func (s *system) Metrics() Metrics {
 // included in 1a.
 //
 // We ensure that only one instance is a leader because in each round instances
-// try to acquire a lock on `LastLedgerExpIngest value in key value store and only
+// try to acquire a lock on `LastLedgerIngest value in key value store and only
 // one instance will be able to acquire it. This happens in both initial processing
 // and ledger processing. So this solves 3a and 3b in both 1a and 1b.
 //

--- a/services/horizon/internal/ingest/main_test.go
+++ b/services/horizon/internal/ingest/main_test.go
@@ -279,7 +279,7 @@ func (m *mockDBQ) GetTx() *sqlx.Tx {
 	return args.Get(0).(*sqlx.Tx)
 }
 
-func (m *mockDBQ) GetLastLedgerExpIngest() (uint32, error) {
+func (m *mockDBQ) GetLastLedgerIngest() (uint32, error) {
 	args := m.Called()
 	return args.Get(0).(uint32), args.Error(1)
 }
@@ -289,17 +289,17 @@ func (m *mockDBQ) GetOfferCompactionSequence() (uint32, error) {
 	return args.Get(0).(uint32), args.Error(1)
 }
 
-func (m *mockDBQ) GetLastLedgerExpIngestNonBlocking() (uint32, error) {
+func (m *mockDBQ) GetLastLedgerIngestNonBlocking() (uint32, error) {
 	args := m.Called()
 	return args.Get(0).(uint32), args.Error(1)
 }
 
-func (m *mockDBQ) GetExpIngestVersion() (int, error) {
+func (m *mockDBQ) GetIngestVersion() (int, error) {
 	args := m.Called()
 	return args.Get(0).(int), args.Error(1)
 }
 
-func (m *mockDBQ) UpdateLastLedgerExpIngest(sequence uint32) error {
+func (m *mockDBQ) UpdateLastLedgerIngest(sequence uint32) error {
 	args := m.Called(sequence)
 	return args.Error(0)
 }
@@ -309,7 +309,7 @@ func (m *mockDBQ) UpdateExpStateInvalid(invalid bool) error {
 	return args.Error(0)
 }
 
-func (m *mockDBQ) UpdateExpIngestVersion(version int) error {
+func (m *mockDBQ) UpdateIngestVersion(version int) error {
 	args := m.Called(version)
 	return args.Error(0)
 }
@@ -329,7 +329,7 @@ func (m *mockDBQ) GetLatestLedger() (uint32, error) {
 	return args.Get(0).(uint32), args.Error(1)
 }
 
-func (m *mockDBQ) TruncateExpingestStateTables() error {
+func (m *mockDBQ) TruncateIngestStateTables() error {
 	args := m.Called()
 	return args.Error(0)
 }

--- a/services/horizon/internal/ingest/orderbook.go
+++ b/services/horizon/internal/ingest/orderbook.go
@@ -69,9 +69,9 @@ func (o *OrderBookStream) getIngestionStatus() (ingestionStatus, error) {
 	if err != nil {
 		return status, errors.Wrap(err, "Error from GetLatestLedger")
 	}
-	status.LastIngestedLedger, err = o.historyQ.GetLastLedgerExpIngestNonBlocking()
+	status.LastIngestedLedger, err = o.historyQ.GetLastLedgerIngestNonBlocking()
 	if err != nil {
-		return status, errors.Wrap(err, "Error from GetLastLedgerExpIngestNonBlocking")
+		return status, errors.Wrap(err, "Error from GetLastLedgerIngestNonBlocking")
 	}
 	status.LastOfferCompactionLedger, err = o.historyQ.GetOfferCompactionSequence()
 	if err != nil {

--- a/services/horizon/internal/ingest/orderbook_test.go
+++ b/services/horizon/internal/ingest/orderbook_test.go
@@ -50,7 +50,7 @@ func (t *IngestionStatusTestSuite) TestGetLatestLedgerError() {
 	t.Assert().EqualError(err, "Error from GetLatestLedger: latest ledger error")
 }
 
-func (t *IngestionStatusTestSuite) TestGetLastLedgerExpIngestNonBlockingError() {
+func (t *IngestionStatusTestSuite) TestGetLastLedgerIngestNonBlockingError() {
 	t.historyQ.On("GetExpStateInvalid").
 		Return(false, nil).
 		Once()
@@ -59,12 +59,12 @@ func (t *IngestionStatusTestSuite) TestGetLastLedgerExpIngestNonBlockingError() 
 		Return(uint32(200), nil).
 		Once()
 
-	t.historyQ.On("GetLastLedgerExpIngestNonBlocking").
-		Return(uint32(0), fmt.Errorf("exp ingest error")).
+	t.historyQ.On("GetLastLedgerIngestNonBlocking").
+		Return(uint32(0), fmt.Errorf("ingest error")).
 		Once()
 
 	_, err := t.stream.getIngestionStatus()
-	t.Assert().EqualError(err, "Error from GetLastLedgerExpIngestNonBlocking: exp ingest error")
+	t.Assert().EqualError(err, "Error from GetLastLedgerIngestNonBlocking: ingest error")
 }
 
 func (t *IngestionStatusTestSuite) TestGetOfferCompactionSequenceError() {
@@ -76,7 +76,7 @@ func (t *IngestionStatusTestSuite) TestGetOfferCompactionSequenceError() {
 		Return(uint32(200), nil).
 		Once()
 
-	t.historyQ.On("GetLastLedgerExpIngestNonBlocking").
+	t.historyQ.On("GetLastLedgerIngestNonBlocking").
 		Return(uint32(200), nil).
 		Once()
 
@@ -97,7 +97,7 @@ func (t *IngestionStatusTestSuite) TestStateInvalid() {
 		Return(uint32(200), nil).
 		Once()
 
-	t.historyQ.On("GetLastLedgerExpIngestNonBlocking").
+	t.historyQ.On("GetLastLedgerIngestNonBlocking").
 		Return(uint32(200), nil).
 		Once()
 
@@ -124,7 +124,7 @@ func (t *IngestionStatusTestSuite) TestHistoryInconsistentWithState() {
 		Return(uint32(200), nil).
 		Once()
 
-	t.historyQ.On("GetLastLedgerExpIngestNonBlocking").
+	t.historyQ.On("GetLastLedgerIngestNonBlocking").
 		Return(uint32(201), nil).
 		Once()
 
@@ -151,7 +151,7 @@ func (t *IngestionStatusTestSuite) TestHistoryLatestLedgerZero() {
 		Return(uint32(0), nil).
 		Once()
 
-	t.historyQ.On("GetLastLedgerExpIngestNonBlocking").
+	t.historyQ.On("GetLastLedgerIngestNonBlocking").
 		Return(uint32(201), nil).
 		Once()
 

--- a/services/horizon/internal/ingest/resume_state_test.go
+++ b/services/horizon/internal/ingest/resume_state_test.go
@@ -88,9 +88,9 @@ func (s *ResumeTestTestSuite) TestBeginReturnsError() {
 	)
 }
 
-func (s *ResumeTestTestSuite) TestGetLastLedgerExpIngestReturnsError() {
+func (s *ResumeTestTestSuite) TestGetLastLedgerIngestReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), errors.New("my error")).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), errors.New("my error")).Once()
 
 	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().Error(err)
@@ -106,7 +106,7 @@ func (s *ResumeTestTestSuite) TestGetLastLedgerExpIngestReturnsError() {
 
 func (s *ResumeTestTestSuite) TestGetLatestLedgerLessThanCurrent() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(99), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(99), nil).Once()
 
 	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().Error(err)
@@ -119,12 +119,12 @@ func (s *ResumeTestTestSuite) TestGetLatestLedgerLessThanCurrent() {
 
 func (s *ResumeTestTestSuite) TestGetIngestionVersionError() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(0, errors.New("my error")).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(0, errors.New("my error")).Once()
 
 	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().Error(err)
-	s.Assert().EqualError(err, "Error getting exp ingest version: my error")
+	s.Assert().EqualError(err, "Error getting ingestion version: my error")
 	s.Assert().Equal(
 		transition{
 			node:          resumeState{latestSuccessfullyProcessedLedger: 100},
@@ -136,8 +136,8 @@ func (s *ResumeTestTestSuite) TestGetIngestionVersionError() {
 
 func (s *ResumeTestTestSuite) TestIngestionVersionLessThanCurrentVersion() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion-1, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion-1, nil).Once()
 
 	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().NoError(err)
@@ -149,8 +149,8 @@ func (s *ResumeTestTestSuite) TestIngestionVersionLessThanCurrentVersion() {
 
 func (s *ResumeTestTestSuite) TestIngestionVersionGreaterThanCurrentVersion() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion+1, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion+1, nil).Once()
 
 	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().NoError(err)
@@ -162,8 +162,8 @@ func (s *ResumeTestTestSuite) TestIngestionVersionGreaterThanCurrentVersion() {
 
 func (s *ResumeTestTestSuite) TestGetLatestLedgerError() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), errors.New("my error"))
 
 	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
@@ -180,8 +180,8 @@ func (s *ResumeTestTestSuite) TestGetLatestLedgerError() {
 
 func (s *ResumeTestTestSuite) TestLatestHistoryLedgerLessThanIngestLedger() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(99), nil)
 
 	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
@@ -194,8 +194,8 @@ func (s *ResumeTestTestSuite) TestLatestHistoryLedgerLessThanIngestLedger() {
 
 func (s *ResumeTestTestSuite) TestLatestHistoryLedgerGreaterThanIngestLedger() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
 
 	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
@@ -208,8 +208,8 @@ func (s *ResumeTestTestSuite) TestLatestHistoryLedgerGreaterThanIngestLedger() {
 
 func (s *ResumeTestTestSuite) TestRangeNotPreparedFailPrepare() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(101), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(101), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
 
 	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(102)).Return(false, nil).Once()
@@ -229,8 +229,8 @@ func (s *ResumeTestTestSuite) TestRangeNotPreparedFailPrepare() {
 
 func (s *ResumeTestTestSuite) TestRangeNotPreparedSuccessPrepare() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(101), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(101), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
 
 	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(102)).Return(false, nil).Once()
@@ -249,8 +249,8 @@ func (s *ResumeTestTestSuite) TestRangeNotPreparedSuccessPrepare() {
 
 func (s *ResumeTestTestSuite) TestFastForwardCaptiveCore() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(101), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(101), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
 
 	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(102)).Return(true, nil).Once()
@@ -271,8 +271,8 @@ func (s *ResumeTestTestSuite) TestFastForwardCaptiveCore() {
 
 func (s *ResumeTestTestSuite) mockSuccessfulIngestion() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(101), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(101), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(101), nil)
 
 	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(102)).Return(true, nil).Once()
@@ -285,7 +285,7 @@ func (s *ResumeTestTestSuite) mockSuccessfulIngestion() {
 		processorsRunDurations{},
 		nil,
 	).Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(102)).Return(nil).Once()
+	s.historyQ.On("UpdateLastLedgerIngest", uint32(102)).Return(nil).Once()
 	s.historyQ.On("Commit").Return(nil).Once()
 
 	s.stellarCoreClient.On(
@@ -311,7 +311,7 @@ func (s *ResumeTestTestSuite) TestBumpIngestLedger() {
 	)
 }
 
-func (s *ResumeTestTestSuite) TestBumpIngestLedgerWhenIngestLedgerEqualsLastLedgerExpIngest() {
+func (s *ResumeTestTestSuite) TestBumpIngestLedgerWhenIngestLedgerEqualsLastLedgerIngest() {
 	s.mockSuccessfulIngestion()
 
 	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
@@ -341,8 +341,8 @@ func (s *ResumeTestTestSuite) TestIngestAllMasterNode() {
 
 func (s *ResumeTestTestSuite) TestErrorSettingCursorIgnored() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
 	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(101)).Return(true, nil).Once()
@@ -355,7 +355,7 @@ func (s *ResumeTestTestSuite) TestErrorSettingCursorIgnored() {
 		processorsRunDurations{},
 		nil,
 	).Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(101)).Return(nil).Once()
+	s.historyQ.On("UpdateLastLedgerIngest", uint32(101)).Return(nil).Once()
 	s.historyQ.On("Commit").Return(nil).Once()
 
 	s.stellarCoreClient.On(
@@ -380,8 +380,8 @@ func (s *ResumeTestTestSuite) TestErrorSettingCursorIgnored() {
 
 func (s *ResumeTestTestSuite) TestNoNewLedgers() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
 	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(101)).Return(true, nil).Once()
@@ -404,8 +404,8 @@ func (s *ResumeTestTestSuite) TestNoNewLedgers() {
 
 func (s *ResumeTestTestSuite) TestFarBehind() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(200), nil).Once()
-	s.historyQ.On("GetExpIngestVersion").Return(CurrentVersion, nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(200), nil).Once()
+	s.historyQ.On("GetIngestVersion").Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestLedger").Return(uint32(0), nil)
 
 	s.ledgerBackend.On("IsPrepared", ledgerbackend.UnboundedRange(201)).Return(true, nil).Once()

--- a/services/horizon/internal/ingest/stress_test.go
+++ b/services/horizon/internal/ingest/stress_test.go
@@ -73,17 +73,17 @@ func (s *StressTestStateTestSuite) TestBeginReturnsError() {
 	s.Assert().EqualError(err, "Error starting a transaction: my error")
 }
 
-func (s *StressTestStateTestSuite) TestGetLastLedgerExpIngestReturnsError() {
+func (s *StressTestStateTestSuite) TestGetLastLedgerIngestReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), errors.New("my error")).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), errors.New("my error")).Once()
 
 	err := s.system.StressTest(10, 4)
 	s.Assert().EqualError(err, "Error getting last ingested ledger: my error")
 }
 
-func (s *StressTestStateTestSuite) TestGetLastLedgerExpIngestNonEmpty() {
+func (s *StressTestStateTestSuite) TestGetLastLedgerIngestNonEmpty() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(100), nil).Once()
 
 	err := s.system.StressTest(10, 4)
 	s.Assert().EqualError(err, "Database not empty")
@@ -91,7 +91,7 @@ func (s *StressTestStateTestSuite) TestGetLastLedgerExpIngestNonEmpty() {
 
 func (s *StressTestStateTestSuite) TestRunAllProcessorsOnLedgerReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
 	s.runner.On("RunAllProcessorsOnLedger", uint32(1)).Return(
 		io.StatsChangeProcessorResults{},
 		processorsRunDurations{},
@@ -104,9 +104,9 @@ func (s *StressTestStateTestSuite) TestRunAllProcessorsOnLedgerReturnsError() {
 	s.Assert().EqualError(err, "Error running processors on ledger: my error")
 }
 
-func (s *StressTestStateTestSuite) TestUpdateLastLedgerExpIngestReturnsError() {
+func (s *StressTestStateTestSuite) TestUpdateLastLedgerIngestReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
 	s.runner.On("RunAllProcessorsOnLedger", uint32(1)).Return(
 		io.StatsChangeProcessorResults{},
 		processorsRunDurations{},
@@ -114,7 +114,7 @@ func (s *StressTestStateTestSuite) TestUpdateLastLedgerExpIngestReturnsError() {
 		processorsRunDurations{},
 		nil,
 	).Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(1)).Return(errors.New("my error")).Once()
+	s.historyQ.On("UpdateLastLedgerIngest", uint32(1)).Return(errors.New("my error")).Once()
 
 	err := s.system.StressTest(10, 4)
 	s.Assert().EqualError(err, "Error updating last ingested ledger: my error")
@@ -122,7 +122,7 @@ func (s *StressTestStateTestSuite) TestUpdateLastLedgerExpIngestReturnsError() {
 
 func (s *StressTestStateTestSuite) TestCommitReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
 	s.runner.On("RunAllProcessorsOnLedger", uint32(1)).Return(
 		io.StatsChangeProcessorResults{},
 		processorsRunDurations{},
@@ -130,7 +130,7 @@ func (s *StressTestStateTestSuite) TestCommitReturnsError() {
 		processorsRunDurations{},
 		nil,
 	).Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(1)).Return(nil).Once()
+	s.historyQ.On("UpdateLastLedgerIngest", uint32(1)).Return(nil).Once()
 	s.historyQ.On("Commit").Return(errors.New("my error")).Once()
 
 	err := s.system.StressTest(10, 4)
@@ -139,7 +139,7 @@ func (s *StressTestStateTestSuite) TestCommitReturnsError() {
 
 func (s *StressTestStateTestSuite) TestSucceeds() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
 	s.runner.On("RunAllProcessorsOnLedger", uint32(1)).Return(
 		io.StatsChangeProcessorResults{},
 		processorsRunDurations{},
@@ -147,7 +147,7 @@ func (s *StressTestStateTestSuite) TestSucceeds() {
 		processorsRunDurations{},
 		nil,
 	).Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(1)).Return(nil).Once()
+	s.historyQ.On("UpdateLastLedgerIngest", uint32(1)).Return(nil).Once()
 	s.historyQ.On("Commit").Return(nil).Once()
 
 	err := s.system.StressTest(10, 4)

--- a/services/horizon/internal/ingest/verify.go
+++ b/services/horizon/internal/ingest/verify.go
@@ -69,9 +69,9 @@ func (s *system) verifyState(verifyAgainstLatestCheckpoint bool) error {
 	}
 
 	// Ensure the ledger is a checkpoint ledger
-	ledgerSequence, err := historyQ.GetLastLedgerExpIngestNonBlocking()
+	ledgerSequence, err := historyQ.GetLastLedgerIngestNonBlocking()
 	if err != nil {
-		return errors.Wrap(err, "Error running historyQ.GetLastLedgerExpIngestNonBlocking")
+		return errors.Wrap(err, "Error running historyQ.GetLastLedgerIngestNonBlocking")
 	}
 
 	localLog := log.WithFields(logpkg.F{

--- a/services/horizon/internal/ingest/verify_range_state_test.go
+++ b/services/horizon/internal/ingest/verify_range_state_test.go
@@ -110,9 +110,9 @@ func (s *VerifyRangeStateTestSuite) TestBeginReturnsError() {
 	)
 }
 
-func (s *VerifyRangeStateTestSuite) TestGetLastLedgerExpIngestReturnsError() {
+func (s *VerifyRangeStateTestSuite) TestGetLastLedgerIngestReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), errors.New("my error")).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), errors.New("my error")).Once()
 
 	next, err := verifyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
 	s.Assert().Error(err)
@@ -123,9 +123,9 @@ func (s *VerifyRangeStateTestSuite) TestGetLastLedgerExpIngestReturnsError() {
 	)
 }
 
-func (s *VerifyRangeStateTestSuite) TestGetLastLedgerExpIngestNonEmpty() {
+func (s *VerifyRangeStateTestSuite) TestGetLastLedgerIngestNonEmpty() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(100), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(100), nil).Once()
 
 	next, err := verifyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
 	s.Assert().Error(err)
@@ -138,7 +138,7 @@ func (s *VerifyRangeStateTestSuite) TestGetLastLedgerExpIngestNonEmpty() {
 
 func (s *VerifyRangeStateTestSuite) TestRunHistoryArchiveIngestionReturnsError() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
 	s.ledgerBackend.On("PrepareRange", ledgerbackend.BoundedRange(100, 200)).Return(nil).Once()
 
 	s.runner.On("RunHistoryArchiveIngestion", uint32(100)).Return(ingestio.StatsChangeProcessorResults{}, errors.New("my error")).Once()
@@ -154,10 +154,10 @@ func (s *VerifyRangeStateTestSuite) TestRunHistoryArchiveIngestionReturnsError()
 
 func (s *VerifyRangeStateTestSuite) TestSuccess() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
 	s.ledgerBackend.On("PrepareRange", ledgerbackend.BoundedRange(100, 200)).Return(nil).Once()
 	s.runner.On("RunHistoryArchiveIngestion", uint32(100)).Return(ingestio.StatsChangeProcessorResults{}, nil).Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(100)).Return(nil).Once()
+	s.historyQ.On("UpdateLastLedgerIngest", uint32(100)).Return(nil).Once()
 	s.historyQ.On("Commit").Return(nil).Once()
 
 	for i := uint32(101); i <= 200; i++ {
@@ -169,7 +169,7 @@ func (s *VerifyRangeStateTestSuite) TestSuccess() {
 			processorsRunDurations{},
 			nil,
 		).Once()
-		s.historyQ.On("UpdateLastLedgerExpIngest", i).Return(nil).Once()
+		s.historyQ.On("UpdateLastLedgerIngest", i).Return(nil).Once()
 		s.historyQ.On("Commit").Return(nil).Once()
 	}
 
@@ -183,10 +183,10 @@ func (s *VerifyRangeStateTestSuite) TestSuccess() {
 
 func (s *VerifyRangeStateTestSuite) TestSuccessWithVerify() {
 	s.historyQ.On("Begin").Return(nil).Once()
-	s.historyQ.On("GetLastLedgerExpIngest").Return(uint32(0), nil).Once()
+	s.historyQ.On("GetLastLedgerIngest").Return(uint32(0), nil).Once()
 	s.ledgerBackend.On("PrepareRange", ledgerbackend.BoundedRange(100, 110)).Return(nil).Once()
 	s.runner.On("RunHistoryArchiveIngestion", uint32(100)).Return(ingestio.StatsChangeProcessorResults{}, nil).Once()
-	s.historyQ.On("UpdateLastLedgerExpIngest", uint32(100)).Return(nil).Once()
+	s.historyQ.On("UpdateLastLedgerIngest", uint32(100)).Return(nil).Once()
 	s.historyQ.On("Commit").Return(nil).Once()
 
 	for i := uint32(101); i <= 110; i++ {
@@ -198,7 +198,7 @@ func (s *VerifyRangeStateTestSuite) TestSuccessWithVerify() {
 			processorsRunDurations{},
 			nil,
 		).Once()
-		s.historyQ.On("UpdateLastLedgerExpIngest", i).Return(nil).Once()
+		s.historyQ.On("UpdateLastLedgerIngest", i).Return(nil).Once()
 		s.historyQ.On("Commit").Return(nil).Once()
 	}
 
@@ -211,7 +211,7 @@ func (s *VerifyRangeStateTestSuite) TestSuccessWithVerify() {
 		s.Assert().True(arg.ReadOnly)
 	}).Return(nil).Once()
 	clonedQ.On("Rollback").Return(nil).Once()
-	clonedQ.On("GetLastLedgerExpIngestNonBlocking").Return(uint32(63), nil).Once()
+	clonedQ.On("GetLastLedgerIngestNonBlocking").Return(uint32(63), nil).Once()
 	mockChangeReader := &ingestio.MockChangeReader{}
 	mockChangeReader.On("Close").Return(nil).Once()
 	mockAccountID := "GACMZD5VJXTRLKVET72CETCYKELPNCOTTBDC6DHFEUPLG5DHEK534JQX"

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -50,7 +50,7 @@ func mustInitHorizonDB(app *App) {
 	)}
 }
 
-func initExpIngester(app *App) {
+func initIngester(app *App) {
 	var err error
 	var coreSession *db.Session
 	if !app.config.EnableCaptiveCoreIngestion {

--- a/services/horizon/internal/integration/protocol14_state_verifier_test.go
+++ b/services/horizon/internal/integration/protocol14_state_verifier_test.go
@@ -104,7 +104,7 @@ func TestProtocol14StateVerifier(t *testing.T) {
 	}
 
 	// Trigger state rebuild to check if ingesting from history archive works
-	err = itest.Horizon().HistoryQ().UpdateExpIngestVersion(0)
+	err = itest.Horizon().HistoryQ().UpdateIngestVersion(0)
 	assert.NoError(t, err)
 
 	verified = waitForStateVerifications(itest, 2)

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -282,8 +282,8 @@ func TestStateMiddleware(t *testing.T) {
 				},
 			}, 0, 0, 0, 0, 0)
 			tt.Assert.NoError(err)
-			tt.Assert.NoError(q.UpdateLastLedgerExpIngest(testCase.lastIngestedLedger))
-			tt.Assert.NoError(q.UpdateExpIngestVersion(testCase.ingestionVersion))
+			tt.Assert.NoError(q.UpdateLastLedgerIngest(testCase.lastIngestedLedger))
+			tt.Assert.NoError(q.UpdateIngestVersion(testCase.ingestionVersion))
 
 			if testCase.sseRequest {
 				request.Header.Set("Accept", "text/event-stream")


### PR DESCRIPTION
### What

Rename all expingest references to ingest

In particular, rename the `expingest` command to `ingest`.

### Why

The ingestion system is not experimental anymore,  also because of #3110 

### Known limitations

Renaming the command is a harsh breaking change and I considered pacing it (with a deprecation period), but I think we shouldn't miss the the opportunity of a major version release.
