### PR TITLE
ingest: Move the `Range` object to its own file.

### DIFF
--- a/ingest/ledgerbackend/ledger_backend.go
+++ b/ingest/ledgerbackend/ledger_backend.go
@@ -1,77 +1,8 @@
 package ledgerbackend
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/stellar/go/xdr"
 )
-
-// Range represents a range of ledger sequence numbers.
-type Range struct {
-	from    uint32
-	to      uint32
-	bounded bool
-}
-
-type jsonRange struct {
-	From    uint32 `json:"from"`
-	To      uint32 `json:"to"`
-	Bounded bool   `json:"bounded"`
-}
-
-func (r *Range) UnmarshalJSON(b []byte) error {
-	var s jsonRange
-	if err := json.Unmarshal(b, &s); err != nil {
-		return err
-	}
-
-	r.from = s.From
-	r.to = s.To
-	r.bounded = s.Bounded
-
-	return nil
-}
-
-func (r Range) MarshalJSON() ([]byte, error) {
-	return json.Marshal(jsonRange{
-		From:    r.from,
-		To:      r.to,
-		Bounded: r.bounded,
-	})
-}
-
-func (r Range) String() string {
-	if r.bounded {
-		return fmt.Sprintf("[%d,%d]", r.from, r.to)
-	}
-	return fmt.Sprintf("[%d,latest)", r.from)
-}
-
-func (r Range) Contains(other Range) bool {
-	if r.bounded && !other.bounded {
-		return false
-	}
-	if r.bounded && other.bounded {
-		return r.from <= other.from && r.to >= other.to
-	}
-	return r.from <= other.from
-}
-
-// SingleLedgerRange constructs a bounded range containing a single ledger.
-func SingleLedgerRange(ledger uint32) Range {
-	return Range{from: ledger, to: ledger, bounded: true}
-}
-
-// BoundedRange constructs a bounded range of ledgers with a fixed starting ledger and ending ledger.
-func BoundedRange(from uint32, to uint32) Range {
-	return Range{from: from, to: to, bounded: true}
-}
-
-// BoundedRange constructs a unbounded range of ledgers with a fixed starting ledger.
-func UnboundedRange(from uint32) Range {
-	return Range{from: from, bounded: false}
-}
 
 // LedgerBackend represents the interface to a ledger data store.
 type LedgerBackend interface {

--- a/ingest/ledgerbackend/range.go
+++ b/ingest/ledgerbackend/range.go
@@ -1,0 +1,72 @@
+package ledgerbackend
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Range represents a range of ledger sequence numbers.
+type Range struct {
+	from    uint32
+	to      uint32
+	bounded bool
+}
+
+type jsonRange struct {
+	From    uint32 `json:"from"`
+	To      uint32 `json:"to"`
+	Bounded bool   `json:"bounded"`
+}
+
+func (r *Range) UnmarshalJSON(b []byte) error {
+	var s jsonRange
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+
+	r.from = s.From
+	r.to = s.To
+	r.bounded = s.Bounded
+
+	return nil
+}
+
+func (r Range) MarshalJSON() ([]byte, error) {
+	return json.Marshal(jsonRange{
+		From:    r.from,
+		To:      r.to,
+		Bounded: r.bounded,
+	})
+}
+
+func (r Range) String() string {
+	if r.bounded {
+		return fmt.Sprintf("[%d,%d]", r.from, r.to)
+	}
+	return fmt.Sprintf("[%d,latest)", r.from)
+}
+
+func (r Range) Contains(other Range) bool {
+	if r.bounded && !other.bounded {
+		return false
+	}
+	if r.bounded && other.bounded {
+		return r.from <= other.from && r.to >= other.to
+	}
+	return r.from <= other.from
+}
+
+// SingleLedgerRange constructs a bounded range containing a single ledger.
+func SingleLedgerRange(ledger uint32) Range {
+	return Range{from: ledger, to: ledger, bounded: true}
+}
+
+// BoundedRange constructs a bounded range of ledgers with a fixed starting ledger and ending ledger.
+func BoundedRange(from uint32, to uint32) Range {
+	return Range{from: from, to: to, bounded: true}
+}
+
+// BoundedRange constructs a unbounded range of ledgers with a fixed starting ledger.
+func UnboundedRange(from uint32) Range {
+	return Range{from: from, bounded: false}
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Moves `ingest.Range` to its own `range.go` rather than keeping it around in `ledger_backend.go`.

### Why
When I open a file called `ledger_backend.go`, I would expect the first thing I see to be, well, `type LedgerBackend ...` (cc #3110).