### PR TITLE
ingest: Conform processor implementations to their interfaces

### DIFF
--- a/ingest/stats_change_processor.go
+++ b/ingest/stats_change_processor.go
@@ -112,3 +112,6 @@ func (stats *StatsChangeProcessorResults) Map() map[string]interface{} {
 		"stats_trust_lines_removed": stats.TrustLinesRemoved,
 	}
 }
+
+// Ensure the StatsChangeProcessor conforms to the ChangeProcessor interface.
+var _ ChangeProcessor = (*StatsChangeProcessor)(nil)

--- a/ingest/stats_ledger_transaction_processor.go
+++ b/ingest/stats_ledger_transaction_processor.go
@@ -140,3 +140,6 @@ func (stats *StatsLedgerTransactionProcessorResults) Map() map[string]interface{
 		"stats_operations_revoke_sponsorship":               stats.OperationsRevokeSponsorship,
 	}
 }
+
+// Ensure the StatsChangeProcessor conforms to the ChangeProcessor interface.
+var _ LedgerTransactionProcessor = (*StatsLedgerTransactionProcessor)(nil)


### PR DESCRIPTION
### What
Ensure that `StatsLedgerTransactionProcessor` conforms to `LedgerTransactionProcessor` and `StatsChangeProcessor` conforms to `ChangeProcessor`.

### Why
This is our convention everywhere else.