### PR TITLE
ingest: Introduce a new error for invalid checkpoint sequences

### DIFF
--- a/historyarchive/range.go
+++ b/historyarchive/range.go
@@ -31,6 +31,10 @@ func NewCheckpointManager(checkpointFrequency uint32) CheckpointManager {
 	return CheckpointManager{checkpointFrequency}
 }
 
+func (c CheckpointManager) GetCheckpointFrequency() uint32 {
+	return c.checkpointFreq
+}
+
 func (c CheckpointManager) IsCheckpoint(i uint32) bool {
 	return (i+1)%c.checkpointFreq == 0
 }

--- a/ingest/checkpoint_change_reader.go
+++ b/ingest/checkpoint_change_reader.go
@@ -81,8 +81,14 @@ func NewCheckpointChangeReader(
 	archive historyarchive.ArchiveInterface,
 	sequence uint32,
 ) (*CheckpointChangeReader, error) {
-	if !archive.GetCheckpointManager().IsCheckpoint(sequence) {
-		return nil, NewCheckpointError(sequence, archive.GetCheckpointManager())
+	manager := archive.GetCheckpointManager()
+
+	// The nth ledger is a checkpoint ledger iff: n+1 mod f == 0, where f is the
+	// checkpoint frequency (64 by default).
+	if !manager.IsCheckpoint(sequence) {
+		return nil, errors.Errorf("%d is not a checkpoint ledger, try %d or %d",
+			sequence, manager.PrevCheckpoint(sequence),
+			manager.NextCheckpoint(sequence))
 	}
 
 	has, err := archive.GetCheckpointHAS(sequence)

--- a/ingest/checkpoint_change_reader.go
+++ b/ingest/checkpoint_change_reader.go
@@ -86,9 +86,12 @@ func NewCheckpointChangeReader(
 	// The nth ledger is a checkpoint ledger iff: n+1 mod f == 0, where f is the
 	// checkpoint frequency (64 by default).
 	if !manager.IsCheckpoint(sequence) {
-		return nil, errors.Errorf("%d is not a checkpoint ledger, try %d or %d",
+		return nil, errors.Errorf(
+			"%d is not a checkpoint ledger, try %d or %d "+
+				"(in general, try n where n+1 mod %d == 0)",
 			sequence, manager.PrevCheckpoint(sequence),
-			manager.NextCheckpoint(sequence))
+			manager.NextCheckpoint(sequence),
+			manager.GetCheckpointFrequency())
 	}
 
 	has, err := archive.GetCheckpointHAS(sequence)

--- a/ingest/checkpoint_change_reader.go
+++ b/ingest/checkpoint_change_reader.go
@@ -81,6 +81,10 @@ func NewCheckpointChangeReader(
 	archive historyarchive.ArchiveInterface,
 	sequence uint32,
 ) (*CheckpointChangeReader, error) {
+	if !archive.GetCheckpointManager().IsCheckpoint(sequence) {
+		return nil, NewCheckpointError(sequence, archive.GetCheckpointManager())
+	}
+
 	has, err := archive.GetCheckpointHAS(sequence)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to get checkpoint HAS at ledger sequence %d", sequence)

--- a/ingest/checkpoint_change_reader_test.go
+++ b/ingest/checkpoint_change_reader_test.go
@@ -702,6 +702,32 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryRetrySucceedsAfterDiscardError()
 	s.Require().Equal(io.EOF, err)
 }
 
+func TestCheckpointLedgersTestSuite(t *testing.T) {
+	suite.Run(t, new(CheckpointLedgersTestSuite))
+}
+
+type CheckpointLedgersTestSuite struct {
+	suite.Suite
+}
+
+// TestNonCheckpointLedger ensures that the reader errors on a non-checkpoint ledger
+func (s *CheckpointLedgersTestSuite) TestNonCheckpointLedger() {
+	mockArchive := &historyarchive.MockArchive{}
+	ledgerSeq := uint32(123456)
+
+	for _, freq := range []uint32{historyarchive.DefaultCheckpointFrequency, 5} {
+		mockArchive.
+			On("GetCheckpointManager").
+			Return(historyarchive.NewCheckpointManager(freq))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		_, err := NewCheckpointChangeReader(ctx, mockArchive, ledgerSeq)
+		s.Require().Error(err)
+	}
+}
+
 func metaEntry(version uint32) xdr.BucketEntry {
 	return xdr.BucketEntry{
 		Type: xdr.BucketEntryTypeMetaentry,

--- a/ingest/checkpoint_change_reader_test.go
+++ b/ingest/checkpoint_change_reader_test.go
@@ -46,6 +46,11 @@ func (s *SingleLedgerStateReaderTestSuite) SetupTest() {
 		On("BucketExists", mock.AnythingOfType("historyarchive.Hash")).
 		Return(true, nil).Times(21)
 
+	s.mockArchive.
+		On("GetCheckpointManager").
+		Return(historyarchive.NewCheckpointManager(
+			historyarchive.DefaultCheckpointFrequency))
+
 	s.reader, err = NewCheckpointChangeReader(
 		context.Background(),
 		s.mockArchive,
@@ -278,6 +283,11 @@ func (s *BucketExistsTestSuite) SetupTest() {
 		On("GetCheckpointHAS", ledgerSeq).
 		Return(historyarchive.HistoryArchiveState{}, nil)
 
+	s.mockArchive.
+		On("GetCheckpointManager").
+		Return(historyarchive.NewCheckpointManager(
+			historyarchive.DefaultCheckpointFrequency))
+
 	ctx, cancel := context.WithCancel(context.Background())
 	var err error
 	s.reader, err = NewCheckpointChangeReader(
@@ -362,6 +372,11 @@ func (s *ReadBucketEntryTestSuite) SetupTest() {
 	s.mockArchive.
 		On("GetCheckpointHAS", ledgerSeq).
 		Return(historyarchive.HistoryArchiveState{}, nil)
+
+	s.mockArchive.
+		On("GetCheckpointManager").
+		Return(historyarchive.NewCheckpointManager(
+			historyarchive.DefaultCheckpointFrequency))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var err error

--- a/ingest/errors.go
+++ b/ingest/errors.go
@@ -1,36 +1,11 @@
 package ingest
 
 import (
-	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/support/errors"
 )
 
 // ErrNotFound is returned when the requested ledger is not found
 var ErrNotFound = errors.New("ledger not found")
-
-// ErrNotCheckpoint is returned when the requested ledger sequence number does
-// not correspond to a checkpoint ledger.
-//
-// You can use the fields within the parent `CheckpointError` object (below) to
-// resolve to an accurate checkpoint.
-//
-// The nth ledger n is a checkpoint ledger iff: n+1 mod f == 0, where f is the
-// checkpoint frequency (64 by default).
-var ErrNotCheckpoint = errors.New("sequence number is not a checkpoint ledger")
-
-type CheckpointError struct {
-	error
-	precedingCheckpoint uint32
-	followingCheckpoint uint32
-}
-
-func NewCheckpointError(sequence uint32, checkpointMgr historyarchive.CheckpointManager) CheckpointError {
-	return CheckpointError{
-		ErrNotCheckpoint,
-		checkpointMgr.PrevCheckpoint(sequence),
-		checkpointMgr.NextCheckpoint(sequence),
-	}
-}
 
 // StateError is a fatal error indicating that the Change stream
 // produced a result which violates fundamental invariants (e.g. an account

--- a/ingest/errors.go
+++ b/ingest/errors.go
@@ -1,11 +1,36 @@
 package ingest
 
 import (
+	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/support/errors"
 )
 
 // ErrNotFound is returned when the requested ledger is not found
 var ErrNotFound = errors.New("ledger not found")
+
+// ErrNotCheckpoint is returned when the requested ledger sequence number does
+// not correspond to a checkpoint ledger.
+//
+// You can use the fields within the parent `CheckpointError` object (below) to
+// resolve to an accurate checkpoint.
+//
+// The nth ledger n is a checkpoint ledger iff: n+1 mod f == 0, where f is the
+// checkpoint frequency (64 by default).
+var ErrNotCheckpoint = errors.New("sequence number is not a checkpoint ledger")
+
+type CheckpointError struct {
+	error
+	precedingCheckpoint uint32
+	followingCheckpoint uint32
+}
+
+func NewCheckpointError(sequence uint32, checkpointMgr historyarchive.CheckpointManager) CheckpointError {
+	return CheckpointError{
+		ErrNotCheckpoint,
+		checkpointMgr.PrevCheckpoint(sequence),
+		checkpointMgr.NextCheckpoint(sequence),
+	}
+}
 
 // StateError is a fatal error indicating that the Change stream
 // produced a result which violates fundamental invariants (e.g. an account


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Introduces a new error for when users pass a sequence number that doesn't correspond to a checkpoint ledger.


### Why
This may end up being a common issue for consumers of the ingestion library since checkpoint frequency is a subtle point mostly documented within the code itself. Right now, when passing a non-checkpoint sequence number to `ingest.NewCheckpointChangeReader`, the following error occurs:

```
unable to get checkpoint HAS at ledger sequence 123450: Bad HTTP response '404 Not Found' for GET 'https://history.stellar.org/prd/core-testnet/core_testnet_001/history/00/01/e2/history-0001e23a.json'
```

This is pretty vague. The new error would be:

```
123456 is not a checkpoint ledger, try 123455 or 123519 (in general, try n where n+1 mod 64 == 0)
```

### Known limitations
n/a