### PR TITLE
[CAP 35] Add support for new Claimable Balance clawback flag

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -660,7 +660,7 @@ type PathsPage struct {
 
 // ClaimableBalanceFlags represents the state of a claimable balance's flags
 type ClaimableBalanceFlags struct {
-	ClaimableBalanceClawbackEnabled bool `json:"claimable_balance_clawback_enabled"`
+	ClawbackEnabled bool `json:"clawback_enabled"`
 }
 
 // ClaimableBalance represents a claimable balance

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -658,20 +658,26 @@ type PathsPage struct {
 	} `json:"_embedded"`
 }
 
+// ClaimableBalanceFlags represents the state of a claimable balance's flags
+type ClaimableBalanceFlags struct {
+	ClaimableBalanceClawbackEnabled bool `json:"claimable_balance_clawback_enabled"`
+}
+
 // ClaimableBalance represents a claimable balance
 type ClaimableBalance struct {
 	Links struct {
 		Self hal.Link `json:"self"`
 	} `json:"_links"`
 
-	BalanceID          string     `json:"id"`
-	Asset              string     `json:"asset"`
-	Amount             string     `json:"amount"`
-	Sponsor            string     `json:"sponsor,omitempty"`
-	LastModifiedLedger uint32     `json:"last_modified_ledger"`
-	LastModifiedTime   *time.Time `json:"last_modified_time"`
-	Claimants          []Claimant `json:"claimants"`
-	PT                 string     `json:"paging_token"`
+	BalanceID          string                `json:"id"`
+	Asset              string                `json:"asset"`
+	Amount             string                `json:"amount"`
+	Sponsor            string                `json:"sponsor,omitempty"`
+	LastModifiedLedger uint32                `json:"last_modified_ledger"`
+	LastModifiedTime   *time.Time            `json:"last_modified_time"`
+	Claimants          []Claimant            `json:"claimants"`
+	Flags              ClaimableBalanceFlags `json:"flags"`
+	PT                 string                `json:"paging_token"`
 }
 
 type ClaimableBalances struct {

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -92,6 +92,7 @@ type ClaimableBalance struct {
 	Amount             xdr.Int64              `db:"amount"`
 	Sponsor            null.String            `db:"sponsor"`
 	LastModifiedLedger uint32                 `db:"last_modified_ledger"`
+	Flags              uint32                 `db:"flags"`
 }
 
 type Claimants []Claimant
@@ -262,6 +263,7 @@ func (i *claimableBalancesBatchInsertBuilder) Add(entry *xdr.LedgerEntry) error 
 		Amount:             cBalance.Amount,
 		Sponsor:            ledgerEntrySponsorToNullString(*entry),
 		LastModifiedLedger: uint32(entry.LastModifiedLedgerSeq),
+		Flags:              uint32(cBalance.Flags()),
 	}
 	return i.builder.RowStruct(row)
 }
@@ -275,6 +277,7 @@ var claimableBalancesSelectStatement = "cb.id, " +
 	"cb.asset, " +
 	"cb.amount, " +
 	"cb.sponsor, " +
-	"cb.last_modified_ledger"
+	"cb.last_modified_ledger, " +
+	"cb.flags"
 
 var selectClaimableBalances = sq.Select(claimableBalancesSelectStatement).From("claimable_balances cb")

--- a/services/horizon/internal/db2/history/claimable_balances_batch_insert_builder_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_batch_insert_builder_test.go
@@ -36,6 +36,12 @@ func TestAddClaimableBalance(t *testing.T) {
 		},
 		Asset:  asset,
 		Amount: 10,
+		Ext: xdr.ClaimableBalanceEntryExt{
+			V: 1,
+			V1: &xdr.ClaimableBalanceEntryExtensionV1{
+				Flags: xdr.Uint32(xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag),
+			},
+		},
 	}
 	entry := xdr.LedgerEntry{
 		Data: xdr.LedgerEntryData{
@@ -73,5 +79,6 @@ func TestAddClaimableBalance(t *testing.T) {
 		tt.Assert.Equal(asset, cb.Asset)
 		tt.Assert.Equal(null.NewString("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", true), cb.Sponsor)
 		tt.Assert.Equal(uint32(lastModifiedLedgerSeq), cb.LastModifiedLedger)
+		tt.Assert.Equal(uint32(xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag), cb.Flags)
 	}
 }

--- a/services/horizon/internal/db2/schema/bindata.go
+++ b/services/horizon/internal/db2/schema/bindata.go
@@ -37,6 +37,7 @@
 // migrations/40_fix_inner_tx_max_fee_constraint.sql (392B)
 // migrations/41_add_sponsor_to_state_tables.sql (800B)
 // migrations/42_add_num_sponsored_and_num_sponsoring_to_accounts.sql (276B)
+// migrations/43_add_claimable_balances_flags.sql (135B)
 // migrations/4_add_protocol_version.sql (188B)
 // migrations/5_create_trades_table.sql (1.1kB)
 // migrations/6_create_assets_table.sql (366B)
@@ -852,6 +853,26 @@ func migrations42_add_num_sponsored_and_num_sponsoring_to_accountsSql() (*asset,
 	return a, nil
 }
 
+var _migrations43_add_claimable_balances_flagsSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xd2\xd5\x55\xd0\xce\xcd\x4c\x2f\x4a\x2c\x49\x55\x08\x2d\xe0\xe2\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\xce\x49\xcc\xcc\x4d\x4c\xca\x49\x8d\x4f\x4a\xcc\x49\xcc\x4b\x4e\x2d\x56\x70\x74\x71\x51\x48\xcb\x49\x4c\x2f\x56\xc8\xcc\x2b\x51\xf0\xf3\x0f\x51\xf0\x0b\xf5\xf1\xb1\xe6\xe2\x42\x36\xc8\x25\xbf\x3c\x8f\xa0\x49\x2e\x41\xfe\x01\x10\xa3\xac\xb9\xb8\x00\x01\x00\x00\xff\xff\xb7\xf0\x2e\x26\x87\x00\x00\x00")
+
+func migrations43_add_claimable_balances_flagsSqlBytes() ([]byte, error) {
+	return bindataRead(
+		_migrations43_add_claimable_balances_flagsSql,
+		"migrations/43_add_claimable_balances_flags.sql",
+	)
+}
+
+func migrations43_add_claimable_balances_flagsSql() (*asset, error) {
+	bytes, err := migrations43_add_claimable_balances_flagsSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "migrations/43_add_claimable_balances_flags.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd, 0x81, 0x29, 0x92, 0x69, 0x66, 0xd, 0xcd, 0x77, 0x2a, 0xe7, 0x6a, 0x73, 0x12, 0x8d, 0x77, 0xc0, 0x20, 0x6b, 0x35, 0x44, 0x7e, 0x3c, 0x77, 0x46, 0x8f, 0xa9, 0xd1, 0x77, 0x7e, 0xc, 0xdc}}
+	return a, nil
+}
+
 var _migrations4_add_protocol_versionSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x84\xcd\xb1\x0a\xc2\x30\x10\x06\xe0\x3d\x4f\xf1\xef\x52\x70\xef\x14\x4d\x9d\xce\x44\x4a\x32\x38\x15\xd1\xa3\x06\x6a\xae\x5c\x82\xe2\xdb\xbb\xba\x88\x4f\xf0\x75\x1d\x36\x8f\x3c\xeb\xa5\x31\xd2\x6a\x2c\xc5\x61\x44\xb4\x3b\x1a\x10\x3c\x9d\x71\xcf\xb5\x89\xbe\xa7\x85\x6f\x33\x6b\x85\x01\xac\x73\xd8\x07\x4a\x47\x8f\x55\xa5\xc9\x55\x96\xe9\xc9\x5a\xb3\x14\xe4\xd2\x78\x66\x85\x1b\x0e\x36\x51\xc4\x16\x3e\x44\xf8\x44\xd4\x1b\xf3\x6d\x39\x79\x95\xff\x9a\x1b\xc3\xe9\x97\xd5\x9b\x4f\x00\x00\x00\xff\xff\x83\xbb\x30\x2e\xbc\x00\x00\x00")
 
 func migrations4_add_protocol_versionSqlBytes() ([]byte, error) {
@@ -1120,6 +1141,7 @@ var _bindata = map[string]func() (*asset, error){
 	"migrations/40_fix_inner_tx_max_fee_constraint.sql":                  migrations40_fix_inner_tx_max_fee_constraintSql,
 	"migrations/41_add_sponsor_to_state_tables.sql":                      migrations41_add_sponsor_to_state_tablesSql,
 	"migrations/42_add_num_sponsored_and_num_sponsoring_to_accounts.sql": migrations42_add_num_sponsored_and_num_sponsoring_to_accountsSql,
+	"migrations/43_add_claimable_balances_flags.sql":                     migrations43_add_claimable_balances_flagsSql,
 	"migrations/4_add_protocol_version.sql":                              migrations4_add_protocol_versionSql,
 	"migrations/5_create_trades_table.sql":                               migrations5_create_trades_tableSql,
 	"migrations/6_create_assets_table.sql":                               migrations6_create_assets_tableSql,
@@ -1208,6 +1230,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"40_fix_inner_tx_max_fee_constraint.sql":                  &bintree{migrations40_fix_inner_tx_max_fee_constraintSql, map[string]*bintree{}},
 		"41_add_sponsor_to_state_tables.sql":                      &bintree{migrations41_add_sponsor_to_state_tablesSql, map[string]*bintree{}},
 		"42_add_num_sponsored_and_num_sponsoring_to_accounts.sql": &bintree{migrations42_add_num_sponsored_and_num_sponsoring_to_accountsSql, map[string]*bintree{}},
+		"43_add_claimable_balances_flags.sql":                     &bintree{migrations43_add_claimable_balances_flagsSql, map[string]*bintree{}},
 		"4_add_protocol_version.sql":                              &bintree{migrations4_add_protocol_versionSql, map[string]*bintree{}},
 		"5_create_trades_table.sql":                               &bintree{migrations5_create_trades_tableSql, map[string]*bintree{}},
 		"6_create_assets_table.sql":                               &bintree{migrations6_create_assets_tableSql, map[string]*bintree{}},

--- a/services/horizon/internal/db2/schema/migrations/43_add_claimable_balances_flags.sql
+++ b/services/horizon/internal/db2/schema/migrations/43_add_claimable_balances_flags.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+
+
+ALTER TABLE claimable_balances ADD flags int NOT NULL;
+
+-- +migrate Down
+
+ALTER TABLE claimable_balances DROP flags;
+

--- a/services/horizon/internal/ingest/processors/effects_processor.go
+++ b/services/horizon/internal/ingest/processors/effects_processor.go
@@ -788,15 +788,14 @@ func (e *effectsWrapper) addBumpSequenceEffects() error {
 			details := map[string]interface{}{"new_seq": afterAccount.SeqNum}
 			e.add(source.Address(), history.EffectSequenceBumped, details)
 		}
-
 		break
 	}
 
 	return nil
 }
 
-func setClaimableBalanceFlagDetails(details map[string]interface{}, flags xdr.Uint32) {
-	if xdr.ClaimableBalanceFlags(flags)&xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag != 0 {
+func setClaimableBalanceFlagDetails(details map[string]interface{}, flags xdr.ClaimableBalanceFlags) {
+	if flags.IsClawbackEnabled() {
 		details["claimable_balance_clawback_enabled_flag"] = true
 		return
 	}
@@ -866,7 +865,6 @@ func (e *effectsWrapper) addClaimClaimableBalanceEffects(changes []ingest.Change
 
 	var cBalance xdr.ClaimableBalanceEntry
 	found := false
-	flags := xdr.Uint32(0)
 	for _, change := range changes {
 		if change.Type != xdr.LedgerEntryTypeClaimableBalance {
 			continue
@@ -878,7 +876,6 @@ func (e *effectsWrapper) addClaimClaimableBalanceEffects(changes []ingest.Change
 			if err != nil {
 				return fmt.Errorf("Invalid balanceId in meta changes for op: %d", e.operation.index)
 			}
-			flags = cBalance.Flags()
 
 			if preBalanceID == balanceID {
 				found = true
@@ -896,7 +893,7 @@ func (e *effectsWrapper) addClaimClaimableBalanceEffects(changes []ingest.Change
 		"balance_id": balanceID,
 		"asset":      cBalance.Asset.StringCanonical(),
 	}
-	setClaimableBalanceFlagDetails(details, flags)
+	setClaimableBalanceFlagDetails(details, cBalance.Flags())
 	e.add(
 		e.operation.SourceAccount().Address(),
 		history.EffectClaimableBalanceClaimed,

--- a/services/horizon/internal/ingest/processors/effects_processor.go
+++ b/services/horizon/internal/ingest/processors/effects_processor.go
@@ -161,6 +161,11 @@ func (operation *transactionOperationWrapper) effects() ([]effect, error) {
 		err error
 	)
 
+	changes, err := operation.transaction.GetOperationChanges(operation.index)
+	if err != nil {
+		return nil, err
+	}
+
 	wrapper := &effectsWrapper{
 		effects:   []effect{},
 		operation: operation,
@@ -196,19 +201,14 @@ func (operation *transactionOperationWrapper) effects() ([]effect, error) {
 	case xdr.OperationTypeBumpSequence:
 		err = wrapper.addBumpSequenceEffects()
 	case xdr.OperationTypeCreateClaimableBalance:
-		err = wrapper.addCreateClaimableBalanceEffects()
+		err = wrapper.addCreateClaimableBalanceEffects(changes)
 	case xdr.OperationTypeClaimClaimableBalance:
-		err = wrapper.addClaimClaimableBalanceEffects()
+		err = wrapper.addClaimClaimableBalanceEffects(changes)
 	case xdr.OperationTypeBeginSponsoringFutureReserves, xdr.OperationTypeEndSponsoringFutureReserves, xdr.OperationTypeRevokeSponsorship:
 		// The effects of these operations are obtained  indirectly from the ledger entries
 	default:
 		return nil, fmt.Errorf("Unknown operation type: %s", op.Body.Type)
 	}
-	if err != nil {
-		return nil, err
-	}
-
-	changes, err := operation.transaction.GetOperationChanges(operation.index)
 	if err != nil {
 		return nil, err
 	}
@@ -546,8 +546,8 @@ func (e *effectsWrapper) addSetOptionsEffects() error {
 	}
 
 	flagDetails := map[string]interface{}{}
-	setEffectFlagDetails(flagDetails, op.SetFlags, true)
-	setEffectFlagDetails(flagDetails, op.ClearFlags, false)
+	setAuthFlagDetails(flagDetails, op.SetFlags, true)
+	setAuthFlagDetails(flagDetails, op.ClearFlags, false)
 
 	if len(flagDetails) > 0 {
 		e.add(source.Address(), history.EffectAccountFlagsUpdated, flagDetails)
@@ -795,7 +795,14 @@ func (e *effectsWrapper) addBumpSequenceEffects() error {
 	return nil
 }
 
-func (e *effectsWrapper) addCreateClaimableBalanceEffects() error {
+func setClaimableBalanceFlagDetails(details map[string]interface{}, flags xdr.Uint32) {
+	if xdr.ClaimableBalanceFlags(flags)&xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag != 0 {
+		details["claimable_balance_clawback_enabled_flag"] = true
+		return
+	}
+}
+
+func (e *effectsWrapper) addCreateClaimableBalanceEffects(changes []ingest.Change) error {
 	op := e.operation.operation.Body.MustCreateClaimableBalanceOp()
 
 	result := e.operation.OperationResult().MustCreateClaimableBalanceResult()
@@ -804,14 +811,22 @@ func (e *effectsWrapper) addCreateClaimableBalanceEffects() error {
 		return errors.Wrapf(err, "Invalid balanceId in op: %d", e.operation.index)
 	}
 
+	details := map[string]interface{}{
+		"balance_id": balanceID,
+		"amount":     amount.String(op.Amount),
+		"asset":      op.Asset.StringCanonical(),
+	}
+	for _, change := range changes {
+		if change.Type != xdr.LedgerEntryTypeClaimableBalance || change.Post == nil {
+			continue
+		}
+		setClaimableBalanceFlagDetails(details, change.Post.Data.ClaimableBalance.Flags())
+		break
+	}
 	e.add(
 		e.operation.SourceAccount().Address(),
 		history.EffectClaimableBalanceCreated,
-		map[string]interface{}{
-			"balance_id": balanceID,
-			"amount":     amount.String(op.Amount),
-			"asset":      op.Asset.StringCanonical(),
-		},
+		details,
 	)
 
 	for _, c := range op.Claimants {
@@ -828,7 +843,7 @@ func (e *effectsWrapper) addCreateClaimableBalanceEffects() error {
 		)
 	}
 
-	details := map[string]interface{}{
+	details = map[string]interface{}{
 		"amount": amount.String(op.Amount),
 	}
 	addAssetDetails(details, op.Asset, "")
@@ -841,7 +856,7 @@ func (e *effectsWrapper) addCreateClaimableBalanceEffects() error {
 	return nil
 }
 
-func (e *effectsWrapper) addClaimClaimableBalanceEffects() error {
+func (e *effectsWrapper) addClaimClaimableBalanceEffects(changes []ingest.Change) error {
 	op := e.operation.operation.Body.MustClaimClaimableBalanceOp()
 
 	balanceID, err := xdr.MarshalHex(op.BalanceId)
@@ -849,14 +864,9 @@ func (e *effectsWrapper) addClaimClaimableBalanceEffects() error {
 		return fmt.Errorf("Invalid balanceId in op: %d", e.operation.index)
 	}
 
-	changes, err := e.operation.transaction.GetOperationChanges(e.operation.index)
-	if err != nil {
-		return err
-	}
-
 	var cBalance xdr.ClaimableBalanceEntry
 	found := false
-
+	flags := xdr.Uint32(0)
 	for _, change := range changes {
 		if change.Type != xdr.LedgerEntryTypeClaimableBalance {
 			continue
@@ -868,6 +878,7 @@ func (e *effectsWrapper) addClaimClaimableBalanceEffects() error {
 			if err != nil {
 				return fmt.Errorf("Invalid balanceId in meta changes for op: %d", e.operation.index)
 			}
+			flags = cBalance.Flags()
 
 			if preBalanceID == balanceID {
 				found = true
@@ -880,17 +891,19 @@ func (e *effectsWrapper) addClaimClaimableBalanceEffects() error {
 		return fmt.Errorf("Change not found for balanceId : %s", balanceID)
 	}
 
+	details := map[string]interface{}{
+		"amount":     amount.String(cBalance.Amount),
+		"balance_id": balanceID,
+		"asset":      cBalance.Asset.StringCanonical(),
+	}
+	setClaimableBalanceFlagDetails(details, flags)
 	e.add(
 		e.operation.SourceAccount().Address(),
 		history.EffectClaimableBalanceClaimed,
-		map[string]interface{}{
-			"amount":     amount.String(cBalance.Amount),
-			"balance_id": balanceID,
-			"asset":      cBalance.Asset.StringCanonical(),
-		},
+		details,
 	)
 
-	details := map[string]interface{}{
+	details = map[string]interface{}{
 		"amount": amount.String(cBalance.Amount),
 	}
 	addAssetDetails(details, cBalance.Asset, "")
@@ -926,7 +939,7 @@ func (e *effectsWrapper) addIngestTradeEffects(buyer xdr.AccountId, claims []xdr
 	}
 }
 
-func setEffectFlagDetails(flagDetails map[string]interface{}, flagPtr *xdr.Uint32, setValue bool) {
+func setAuthFlagDetails(flagDetails map[string]interface{}, flagPtr *xdr.Uint32, setValue bool) {
 	if flagPtr != nil {
 		flags := xdr.AccountFlags(*flagPtr)
 

--- a/services/horizon/internal/ingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/ingest/processors/effects_processor_test.go
@@ -1925,8 +1925,35 @@ func (s *CreateClaimableBalanceEffectsTestSuite) SetupTest() {
 		},
 		FeeChanges: xdr.LedgerEntryChanges{},
 		Meta: xdr.TransactionMeta{
-			V:  2,
-			V2: &xdr.TransactionMetaV2{},
+			V: 2,
+			V2: &xdr.TransactionMetaV2{
+				Operations: []xdr.OperationMeta{
+					{
+						Changes: []xdr.LedgerEntryChange{
+							{
+								Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+								Created: &xdr.LedgerEntry{
+									Data: xdr.LedgerEntryData{
+										Type: xdr.LedgerEntryTypeClaimableBalance,
+										ClaimableBalance: &xdr.ClaimableBalanceEntry{
+											BalanceId: balanceIDOp1,
+											Ext: xdr.ClaimableBalanceEntryExt{
+												V: 1,
+												V1: &xdr.ClaimableBalanceEntryExtensionV1{
+													Flags: xdr.Uint32(xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						// Not used for the test
+					},
+				},
+			},
 		},
 	}
 }
@@ -1946,6 +1973,7 @@ func (s *CreateClaimableBalanceEffectsTestSuite) TestEffects() {
 						"asset":      "native",
 						"amount":     "10.0000000",
 						"balance_id": "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
+						"claimable_balance_clawback_enabled_flag": true,
 					},
 					effectType:  history.EffectClaimableBalanceCreated,
 					operationID: int64(4294967297),
@@ -2152,6 +2180,12 @@ func (s *ClaimClaimableBalanceEffectsTestSuite) SetupTest() {
 													},
 												},
 											},
+											Ext: xdr.ClaimableBalanceEntryExt{
+												V: 1,
+												V1: &xdr.ClaimableBalanceEntryExtensionV1{
+													Flags: xdr.Uint32(xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag),
+												},
+											},
 										},
 									},
 								},
@@ -2235,6 +2269,7 @@ func (s *ClaimClaimableBalanceEffectsTestSuite) TestEffects() {
 						"asset":      "native",
 						"amount":     "10.0000000",
 						"balance_id": "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
+						"claimable_balance_clawback_enabled_flag": true,
 					},
 					effectType:  history.EffectClaimableBalanceClaimed,
 					operationID: int64(4294967297),

--- a/services/horizon/internal/ingest/verify.go
+++ b/services/horizon/internal/ingest/verify.go
@@ -577,11 +577,17 @@ func addClaimableBalanceToStateVerifier(
 			})
 		}
 		claimants = xdr.SortClaimantsByDestination(claimants)
-		cBalance := xdr.ClaimableBalanceEntry{
+		var cBalance = xdr.ClaimableBalanceEntry{
 			BalanceId: row.BalanceID,
 			Claimants: claimants,
 			Asset:     row.Asset,
-			Amount:    xdr.Int64(row.Amount),
+			Amount:    row.Amount,
+			Ext: xdr.ClaimableBalanceEntryExt{
+				V: 1,
+				V1: &xdr.ClaimableBalanceEntryExtensionV1{
+					Flags: xdr.Uint32(row.Flags),
+				},
+			},
 		}
 		entry := xdr.LedgerEntry{
 			LastModifiedLedgerSeq: xdr.Uint32(row.LastModifiedLedger),

--- a/services/horizon/internal/ingest/verify.go
+++ b/services/horizon/internal/ingest/verify.go
@@ -699,6 +699,7 @@ func transformEntry(entry xdr.LedgerEntry) (bool, xdr.LedgerEntry) {
 	case xdr.LedgerEntryTypeClaimableBalance:
 		cBalance := entry.Data.ClaimableBalance
 		cBalance.Claimants = xdr.SortClaimantsByDestination(cBalance.Claimants)
+		cBalance.Ext = xdr.NormalizeClaimableBalanceExtension(cBalance.Ext)
 
 		return false, entry
 	default:

--- a/services/horizon/internal/ingest/verify.go
+++ b/services/horizon/internal/ingest/verify.go
@@ -582,12 +582,14 @@ func addClaimableBalanceToStateVerifier(
 			Claimants: claimants,
 			Asset:     row.Asset,
 			Amount:    row.Amount,
-			Ext: xdr.ClaimableBalanceEntryExt{
+		}
+		if row.Flags != 0 {
+			cBalance.Ext = xdr.ClaimableBalanceEntryExt{
 				V: 1,
 				V1: &xdr.ClaimableBalanceEntryExtensionV1{
 					Flags: xdr.Uint32(row.Flags),
 				},
-			},
+			}
 		}
 		entry := xdr.LedgerEntry{
 			LastModifiedLedgerSeq: xdr.Uint32(row.LastModifiedLedger),

--- a/services/horizon/internal/ingest/verify_range_state_test.go
+++ b/services/horizon/internal/ingest/verify_range_state_test.go
@@ -311,6 +311,7 @@ func (s *VerifyRangeStateTestSuite) TestSuccessWithVerify() {
 			},
 		},
 		Sponsor: null.StringFrom("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+		Flags:   uint32(xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag),
 	}
 	claimableBalanceChange := ingest.Change{
 		Type: xdr.LedgerEntryTypeClaimableBalance,
@@ -331,6 +332,12 @@ func (s *VerifyRangeStateTestSuite) TestSuccessWithVerify() {
 					},
 					Asset:  claimableBalance.Asset,
 					Amount: claimableBalance.Amount,
+					Ext: xdr.ClaimableBalanceEntryExt{
+						V: 1,
+						V1: &xdr.ClaimableBalanceEntryExtensionV1{
+							Flags: xdr.Uint32(xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag),
+						},
+					},
 				},
 			},
 			LastModifiedLedgerSeq: xdr.Uint32(62),

--- a/services/horizon/internal/ingest/verify_test.go
+++ b/services/horizon/internal/ingest/verify_test.go
@@ -1,0 +1,75 @@
+package ingest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/go/xdr"
+)
+
+func TestTransformEntry_ClaimableBalance(t *testing.T) {
+
+	input := xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 20,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeClaimableBalance,
+			ClaimableBalance: &xdr.ClaimableBalanceEntry{
+				Claimants: []xdr.Claimant{
+					{
+						Type: xdr.ClaimantTypeClaimantTypeV0,
+						V0: &xdr.ClaimantV0{
+							Destination: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+						},
+					},
+					{
+						Type: xdr.ClaimantTypeClaimantTypeV0,
+						V0: &xdr.ClaimantV0{
+							Destination: xdr.MustAddress("GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A"),
+						},
+					},
+				},
+				Ext: xdr.ClaimableBalanceEntryExt{
+					V: 1,
+					V1: &xdr.ClaimableBalanceEntryExtensionV1{
+						Flags: 0,
+					},
+				},
+			},
+		},
+	}
+
+	expectedOutput := xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 20,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeClaimableBalance,
+			ClaimableBalance: &xdr.ClaimableBalanceEntry{
+				Claimants: []xdr.Claimant{
+					{
+						Type: xdr.ClaimantTypeClaimantTypeV0,
+						V0: &xdr.ClaimantV0{
+							Destination: xdr.MustAddress("GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A"),
+						},
+					},
+					{
+						Type: xdr.ClaimantTypeClaimantTypeV0,
+						V0: &xdr.ClaimantV0{
+							Destination: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+						},
+					},
+				},
+				Ext: xdr.ClaimableBalanceEntryExt{
+					V: 0,
+				},
+			},
+		},
+		Ext: xdr.LedgerEntryExt{
+			V:  1,
+			V1: &xdr.LedgerEntryExtensionV1{},
+		},
+	}
+	_, output := transformEntry(input)
+
+	assert.Equal(t, expectedOutput, output)
+
+}

--- a/services/horizon/internal/resourceadapter/claimable_balances.go
+++ b/services/horizon/internal/resourceadapter/claimable_balances.go
@@ -41,6 +41,10 @@ func PopulateClaimableBalance(
 		dest.LastModifiedTime = &ledger.ClosedAt
 	}
 
+	if xdr.ClaimableBalanceFlags(claimableBalance.Flags)&xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag != 0 {
+		dest.Flags.ClaimableBalanceClawbackEnabled = true
+	}
+
 	lb := hal.LinkBuilder{Base: horizonContext.BaseURL(ctx)}
 	self := fmt.Sprintf("/claimable_balances/%s", dest.BalanceID)
 	dest.Links.Self = lb.Link(self)

--- a/services/horizon/internal/resourceadapter/claimable_balances.go
+++ b/services/horizon/internal/resourceadapter/claimable_balances.go
@@ -41,8 +41,8 @@ func PopulateClaimableBalance(
 		dest.LastModifiedTime = &ledger.ClosedAt
 	}
 
-	if xdr.ClaimableBalanceFlags(claimableBalance.Flags)&xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag != 0 {
-		dest.Flags.ClaimableBalanceClawbackEnabled = true
+	if xdr.ClaimableBalanceFlags(claimableBalance.Flags).IsClawbackEnabled() {
+		dest.Flags.ClawbackEnabled = true
 	}
 
 	lb := hal.LinkBuilder{Base: horizonContext.BaseURL(ctx)}

--- a/services/horizon/internal/resourceadapter/claimable_balances.go
+++ b/services/horizon/internal/resourceadapter/claimable_balances.go
@@ -42,7 +42,7 @@ func PopulateClaimableBalance(
 	}
 
 	if xdr.ClaimableBalanceFlags(claimableBalance.Flags).IsClawbackEnabled() {
-		dest.Flags.ClawbackEnabled = true
+		dest.Flags.ClawbackEnabled = xdr.ClaimableBalanceFlags(claimableBalance.Flags).IsClawbackEnabled()
 	}
 
 	lb := hal.LinkBuilder{Base: horizonContext.BaseURL(ctx)}

--- a/services/horizon/internal/resourceadapter/claimable_balances_test.go
+++ b/services/horizon/internal/resourceadapter/claimable_balances_test.go
@@ -49,7 +49,7 @@ func TestPopulateClaimableBalance(t *testing.T) {
 	tt.Len(resource.Claimants, 1)
 	tt.Equal("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", resource.Claimants[0].Destination)
 	tt.Equal("123-000000000102030000000000000000000000000000000000000000000000000000000000", resource.PagingToken())
-	tt.True(resource.Flags.ClaimableBalanceClawbackEnabled)
+	tt.True(resource.Flags.ClawbackEnabled)
 
 	links, err := json.Marshal(resource.Links)
 	tt.NoError(err)

--- a/services/horizon/internal/resourceadapter/claimable_balances_test.go
+++ b/services/horizon/internal/resourceadapter/claimable_balances_test.go
@@ -35,6 +35,7 @@ func TestPopulateClaimableBalance(t *testing.T) {
 			},
 		},
 		LastModifiedLedger: 123,
+		Flags:              uint32(xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag),
 	}
 
 	err := PopulateClaimableBalance(ctx, &resource, claimableBalance, nil)
@@ -48,6 +49,7 @@ func TestPopulateClaimableBalance(t *testing.T) {
 	tt.Len(resource.Claimants, 1)
 	tt.Equal("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", resource.Claimants[0].Destination)
 	tt.Equal("123-000000000102030000000000000000000000000000000000000000000000000000000000", resource.PagingToken())
+	tt.True(resource.Flags.ClaimableBalanceClawbackEnabled)
 
 	links, err := json.Marshal(resource.Links)
 	tt.NoError(err)

--- a/xdr/account_flags.go
+++ b/xdr/account_flags.go
@@ -20,6 +20,6 @@ func (accountFlags AccountFlags) IsAuthImmutable() bool {
 
 // IsAuthClawbackEnabled returns true if the account has the "AUTH_CLAWBACK_ENABLED" option
 // turned on.
-func (accountFlags AccountFlags) IsClawbackEnabled() bool {
+func (accountFlags AccountFlags) IsAuthClawbackEnabled() bool {
 	return (accountFlags & AccountFlagsAuthClawbackEnabledFlag) != 0
 }

--- a/xdr/account_flags_test.go
+++ b/xdr/account_flags_test.go
@@ -56,18 +56,18 @@ func TestIsAuthImmutable(t *testing.T) {
 	tt.False(flag.IsAuthImmutable())
 }
 
-func TestIsClawbackEnabled(t *testing.T) {
+func TestIsAuthClawbackEnabled(t *testing.T) {
 	tt := assert.New(t)
 
 	flag := xdr.AccountFlags(8)
-	tt.True(flag.IsClawbackEnabled())
+	tt.True(flag.IsAuthClawbackEnabled())
 
 	flag = xdr.AccountFlags(0)
-	tt.False(flag.IsClawbackEnabled())
+	tt.False(flag.IsAuthClawbackEnabled())
 
 	flag = xdr.AccountFlags(1)
-	tt.False(flag.IsClawbackEnabled())
+	tt.False(flag.IsAuthClawbackEnabled())
 
 	flag = xdr.AccountFlags(2)
-	tt.False(flag.IsClawbackEnabled())
+	tt.False(flag.IsAuthClawbackEnabled())
 }

--- a/xdr/claimable_balance_entry.go
+++ b/xdr/claimable_balance_entry.go
@@ -1,9 +1,18 @@
 package xdr
 
-func (entry *ClaimableBalanceEntry) Flags() Uint32 {
+func (entry *ClaimableBalanceEntry) Flags() ClaimableBalanceFlags {
 	switch entry.Ext.V {
 	case 1:
-		return entry.Ext.V1.Flags
+		return ClaimableBalanceFlags(entry.Ext.V1.Flags)
 	}
 	return 0
+}
+
+func NormalizeClaimableBalanceExtension(ext ClaimableBalanceEntryExt) ClaimableBalanceEntryExt {
+	normalized := ext
+	if ext.V == 1 && ext.V1.Flags == 0 {
+		// If the flags equal 0 it is equivalent to Version 0
+		normalized = ClaimableBalanceEntryExt{V: 0}
+	}
+	return normalized
 }

--- a/xdr/claimable_balance_entry.go
+++ b/xdr/claimable_balance_entry.go
@@ -1,0 +1,9 @@
+package xdr
+
+func (entry *ClaimableBalanceEntry) Flags() Uint32 {
+	switch entry.Ext.V {
+	case 1:
+		return entry.Ext.V1.Flags
+	}
+	return 0
+}

--- a/xdr/claimable_balance_entry_test.go
+++ b/xdr/claimable_balance_entry_test.go
@@ -1,0 +1,30 @@
+package xdr_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/go/xdr"
+)
+
+func TestClaimableBalanceEntry_Flags(t *testing.T) {
+	entry := xdr.ClaimableBalanceEntry{
+		Ext: xdr.ClaimableBalanceEntryExt{
+			V: 0,
+		},
+	}
+
+	assert.Equal(t, xdr.ClaimableBalanceFlags(0), entry.Flags())
+
+	entry = xdr.ClaimableBalanceEntry{
+		Ext: xdr.ClaimableBalanceEntryExt{
+			V: 1,
+			V1: &xdr.ClaimableBalanceEntryExtensionV1{
+				Flags: xdr.Uint32(xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag),
+			},
+		},
+	}
+
+	assert.Equal(t, xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag, entry.Flags())
+}

--- a/xdr/claimable_balance_entry_test.go
+++ b/xdr/claimable_balance_entry_test.go
@@ -28,3 +28,16 @@ func TestClaimableBalanceEntry_Flags(t *testing.T) {
 
 	assert.Equal(t, xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag, entry.Flags())
 }
+
+func TestNormalizeClaimableBalanceExtension(t *testing.T) {
+	input := xdr.ClaimableBalanceEntryExt{
+		V: 1,
+		V1: &xdr.ClaimableBalanceEntryExtensionV1{
+			Flags: 0,
+		},
+	}
+
+	output := xdr.NormalizeClaimableBalanceExtension(input)
+
+	assert.Equal(t, xdr.ClaimableBalanceEntryExt{V: 0}, output)
+}

--- a/xdr/claimable_balance_flags.go
+++ b/xdr/claimable_balance_flags.go
@@ -1,0 +1,7 @@
+package xdr
+
+// IsClawbackEnabled returns true if the claimable balance has the "CLAWBACK_ENABLED" option
+// turned on.
+func (cbFlags ClaimableBalanceFlags) IsClawbackEnabled() bool {
+	return (cbFlags & ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag) != 0
+}

--- a/xdr/claimable_balance_flags_test.go
+++ b/xdr/claimable_balance_flags_test.go
@@ -1,0 +1,26 @@
+package xdr_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/go/xdr"
+)
+
+func TestIsClawbackEnabled(t *testing.T) {
+	tt := assert.New(t)
+
+	flag := xdr.ClaimableBalanceFlags(1)
+	tt.True(flag.IsClawbackEnabled())
+
+	flag = xdr.ClaimableBalanceFlags(0)
+	tt.False(flag.IsClawbackEnabled())
+
+	flag = xdr.ClaimableBalanceFlags(2)
+	tt.False(flag.IsClawbackEnabled())
+
+	flag = xdr.ClaimableBalanceFlags(4)
+	tt.False(flag.IsClawbackEnabled())
+
+}


### PR DESCRIPTION
* ALTER the claimable_balances SQL table to add a flags column
* Add ingestion support for for the new flag (including verification)
* Add support to the Horizon Go client
* Extend Claimable balance effects to include the flag

Part of #3348 