### PR TITLE
ingest: Finish renaming LedgerEntryChangeCache to ChangeCompactor.

### DIFF
--- a/ingest/change_compactor.go
+++ b/ingest/change_compactor.go
@@ -52,8 +52,8 @@ type ChangeCompactor struct {
 	mutex sync.Mutex
 }
 
-// NewLedgerEntryChangeCache returns a new ChangeCompactor.
-func NewLedgerEntryChangeCache() *ChangeCompactor {
+// NewChangeCompactor returns a new ChangeCompactor.
+func NewChangeCompactor() *ChangeCompactor {
 	return &ChangeCompactor{
 		cache: make(map[string]Change),
 	}

--- a/ingest/change_compactor_test.go
+++ b/ingest/change_compactor_test.go
@@ -8,19 +8,19 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestLedgerEntryChangeCacheExistingCreated(t *testing.T) {
-	suite.Run(t, new(TestLedgerEntryChangeCacheExistingCreatedSuite))
+func TestChangeCompactorExistingCreated(t *testing.T) {
+	suite.Run(t, new(TestChangeCompactorExistingCreatedSuite))
 }
 
-// TestLedgerEntryChangeCacheExistingCreatedSuite tests transitions from
+// TestChangeCompactorExistingCreatedSuite tests transitions from
 // existing CREATED state in the cache.
-type TestLedgerEntryChangeCacheExistingCreatedSuite struct {
+type TestChangeCompactorExistingCreatedSuite struct {
 	suite.Suite
 	cache *ChangeCompactor
 }
 
-func (s *TestLedgerEntryChangeCacheExistingCreatedSuite) SetupTest() {
-	s.cache = NewLedgerEntryChangeCache()
+func (s *TestChangeCompactorExistingCreatedSuite) SetupTest() {
+	s.cache = NewChangeCompactor()
 
 	change := Change{
 		Type: xdr.LedgerEntryTypeAccount,
@@ -41,7 +41,7 @@ func (s *TestLedgerEntryChangeCacheExistingCreatedSuite) SetupTest() {
 	s.Assert().Equal(changes[0].LedgerEntryChangeType(), xdr.LedgerEntryChangeTypeLedgerEntryCreated)
 }
 
-func (s *TestLedgerEntryChangeCacheExistingCreatedSuite) TestChangeCreated() {
+func (s *TestChangeCompactorExistingCreatedSuite) TestChangeCreated() {
 	change := Change{
 		Type: xdr.LedgerEntryTypeAccount,
 		Pre:  nil,
@@ -61,7 +61,7 @@ func (s *TestLedgerEntryChangeCacheExistingCreatedSuite) TestChangeCreated() {
 	)
 }
 
-func (s *TestLedgerEntryChangeCacheExistingCreatedSuite) TestChangeUpdated() {
+func (s *TestChangeCompactorExistingCreatedSuite) TestChangeUpdated() {
 	change := Change{
 		Type: xdr.LedgerEntryTypeAccount,
 		Pre: &xdr.LedgerEntry{
@@ -89,7 +89,7 @@ func (s *TestLedgerEntryChangeCacheExistingCreatedSuite) TestChangeUpdated() {
 	s.Assert().Equal(changes[0].LedgerEntryChangeType(), xdr.LedgerEntryChangeTypeLedgerEntryCreated)
 }
 
-func (s *TestLedgerEntryChangeCacheExistingCreatedSuite) TestChangeRemoved() {
+func (s *TestChangeCompactorExistingCreatedSuite) TestChangeRemoved() {
 	change := Change{
 		Type: xdr.LedgerEntryTypeAccount,
 		Pre: &xdr.LedgerEntry{
@@ -109,18 +109,18 @@ func (s *TestLedgerEntryChangeCacheExistingCreatedSuite) TestChangeRemoved() {
 }
 
 func TestLedgerEntryChangeCacheExistingUpdated(t *testing.T) {
-	suite.Run(t, new(TestLedgerEntryChangeCacheExistingUpdatedSuite))
+	suite.Run(t, new(TestChangeCompactorExistingUpdatedSuite))
 }
 
-// TestLedgerEntryChangeCacheExistingUpdatedSuite tests transitions from
-// existing UPDATED state in the cache.
-type TestLedgerEntryChangeCacheExistingUpdatedSuite struct {
+// TestChangeCompactorExistingUpdatedSuite tests transitions from existing
+// UPDATED state in the cache.
+type TestChangeCompactorExistingUpdatedSuite struct {
 	suite.Suite
 	cache *ChangeCompactor
 }
 
-func (s *TestLedgerEntryChangeCacheExistingUpdatedSuite) SetupTest() {
-	s.cache = NewLedgerEntryChangeCache()
+func (s *TestChangeCompactorExistingUpdatedSuite) SetupTest() {
+	s.cache = NewChangeCompactor()
 
 	change := Change{
 		Type: xdr.LedgerEntryTypeAccount,
@@ -149,7 +149,7 @@ func (s *TestLedgerEntryChangeCacheExistingUpdatedSuite) SetupTest() {
 	s.Assert().Equal(changes[0].LedgerEntryChangeType(), xdr.LedgerEntryChangeTypeLedgerEntryUpdated)
 }
 
-func (s *TestLedgerEntryChangeCacheExistingUpdatedSuite) TestChangeCreated() {
+func (s *TestChangeCompactorExistingUpdatedSuite) TestChangeCreated() {
 	change := Change{
 		Type: xdr.LedgerEntryTypeAccount,
 		Pre:  nil,
@@ -169,7 +169,7 @@ func (s *TestLedgerEntryChangeCacheExistingUpdatedSuite) TestChangeCreated() {
 	)
 }
 
-func (s *TestLedgerEntryChangeCacheExistingUpdatedSuite) TestChangeUpdated() {
+func (s *TestChangeCompactorExistingUpdatedSuite) TestChangeUpdated() {
 	change := Change{
 		Type: xdr.LedgerEntryTypeAccount,
 		Pre: &xdr.LedgerEntry{
@@ -198,7 +198,7 @@ func (s *TestLedgerEntryChangeCacheExistingUpdatedSuite) TestChangeUpdated() {
 	s.Assert().Equal(changes[0].Post.LastModifiedLedgerSeq, xdr.Uint32(12))
 }
 
-func (s *TestLedgerEntryChangeCacheExistingUpdatedSuite) TestChangeRemoved() {
+func (s *TestChangeCompactorExistingUpdatedSuite) TestChangeRemoved() {
 	change := Change{
 		Type: xdr.LedgerEntryTypeAccount,
 		Pre: &xdr.LedgerEntry{
@@ -218,19 +218,19 @@ func (s *TestLedgerEntryChangeCacheExistingUpdatedSuite) TestChangeRemoved() {
 	s.Assert().Equal(changes[0].LedgerEntryChangeType(), xdr.LedgerEntryChangeTypeLedgerEntryRemoved)
 }
 
-func TestLedgerEntryChangeCacheExistingRemoved(t *testing.T) {
-	suite.Run(t, new(TestLedgerEntryChangeCacheExistingRemovedSuite))
+func TestChangeCompactorExistingRemoved(t *testing.T) {
+	suite.Run(t, new(TestChangeCompactorExistingRemovedSuite))
 }
 
-// TestLedgerEntryChangeCacheExistingRemovedSuite tests transitions from
-// existing REMOVED state in the cache.
-type TestLedgerEntryChangeCacheExistingRemovedSuite struct {
+// TestChangeCompactorExistingRemovedSuite tests transitions from existing
+// REMOVED state in the cache.
+type TestChangeCompactorExistingRemovedSuite struct {
 	suite.Suite
 	cache *ChangeCompactor
 }
 
-func (s *TestLedgerEntryChangeCacheExistingRemovedSuite) SetupTest() {
-	s.cache = NewLedgerEntryChangeCache()
+func (s *TestChangeCompactorExistingRemovedSuite) SetupTest() {
+	s.cache = NewChangeCompactor()
 
 	change := Change{
 		Type: xdr.LedgerEntryTypeAccount,
@@ -251,7 +251,7 @@ func (s *TestLedgerEntryChangeCacheExistingRemovedSuite) SetupTest() {
 	s.Assert().Equal(changes[0].LedgerEntryChangeType(), xdr.LedgerEntryChangeTypeLedgerEntryRemoved)
 }
 
-func (s *TestLedgerEntryChangeCacheExistingRemovedSuite) TestChangeCreated() {
+func (s *TestChangeCompactorExistingRemovedSuite) TestChangeCreated() {
 	change := Change{
 		Type: xdr.LedgerEntryTypeAccount,
 		Pre:  nil,
@@ -272,7 +272,7 @@ func (s *TestLedgerEntryChangeCacheExistingRemovedSuite) TestChangeCreated() {
 	s.Assert().Equal(changes[0].Post.LastModifiedLedgerSeq, xdr.Uint32(12))
 }
 
-func (s *TestLedgerEntryChangeCacheExistingRemovedSuite) TestChangeUpdated() {
+func (s *TestChangeCompactorExistingRemovedSuite) TestChangeUpdated() {
 	change := Change{
 		Type: xdr.LedgerEntryTypeAccount,
 		Pre: &xdr.LedgerEntry{
@@ -300,7 +300,7 @@ func (s *TestLedgerEntryChangeCacheExistingRemovedSuite) TestChangeUpdated() {
 	)
 }
 
-func (s *TestLedgerEntryChangeCacheExistingRemovedSuite) TestChangeRemoved() {
+func (s *TestChangeCompactorExistingRemovedSuite) TestChangeRemoved() {
 	change := Change{
 		Type: xdr.LedgerEntryTypeAccount,
 		Pre: &xdr.LedgerEntry{
@@ -320,13 +320,14 @@ func (s *TestLedgerEntryChangeCacheExistingRemovedSuite) TestChangeRemoved() {
 	)
 }
 
-// TestLedgerEntryChangeCacheSquashMultiplePayments simulates sending multiple
-// payments between two accounts. Ledger cache should squash multiple changes
-// into just two.
+// TestChangeCompactorSquashMultiplePayments simulates sending multiple payments
+// between two accounts. Ledger cache should squash multiple changes into just
+// two.
+//
 // GAJ2T6NQ6TDZRVRSNWM3JC7L3TG4H7UBCVK3GUHKP3TQ5NQ3LM4JGBTJ sends money
 // GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML receives money
-func TestLedgerEntryChangeCacheSquashMultiplePayments(t *testing.T) {
-	cache := NewLedgerEntryChangeCache()
+func TestChangeCompactorSquashMultiplePayments(t *testing.T) {
+	cache := NewChangeCompactor()
 
 	for i := 1; i <= 1000; i++ {
 		change := Change{

--- a/services/horizon/internal/ingest/processors/account_data_processor.go
+++ b/services/horizon/internal/ingest/processors/account_data_processor.go
@@ -20,7 +20,7 @@ func NewAccountDataProcessor(dataQ history.QData) *AccountDataProcessor {
 }
 
 func (p *AccountDataProcessor) reset() {
-	p.cache = ingest.NewLedgerEntryChangeCache()
+	p.cache = ingest.NewChangeCompactor()
 }
 
 func (p *AccountDataProcessor) ProcessChange(change ingest.Change) error {

--- a/services/horizon/internal/ingest/processors/accounts_processor.go
+++ b/services/horizon/internal/ingest/processors/accounts_processor.go
@@ -20,7 +20,7 @@ func NewAccountsProcessor(accountsQ history.QAccounts) *AccountsProcessor {
 }
 
 func (p *AccountsProcessor) reset() {
-	p.cache = ingest.NewLedgerEntryChangeCache()
+	p.cache = ingest.NewChangeCompactor()
 }
 
 func (p *AccountsProcessor) ProcessChange(change ingest.Change) error {

--- a/services/horizon/internal/ingest/processors/asset_stats_processor.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor.go
@@ -36,7 +36,7 @@ func NewAssetStatsProcessor(
 }
 
 func (p *AssetStatsProcessor) reset() {
-	p.cache = ingest.NewLedgerEntryChangeCache()
+	p.cache = ingest.NewChangeCompactor()
 	p.assetStatSet = AssetStatSet{}
 }
 

--- a/services/horizon/internal/ingest/processors/claimable_balances_processor.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_processor.go
@@ -19,7 +19,7 @@ func NewClaimableBalancesProcessor(Q history.QClaimableBalances) *ClaimableBalan
 }
 
 func (p *ClaimableBalancesProcessor) reset() {
-	p.cache = ingest.NewLedgerEntryChangeCache()
+	p.cache = ingest.NewChangeCompactor()
 }
 
 func (p *ClaimableBalancesProcessor) ProcessChange(change ingest.Change) error {

--- a/services/horizon/internal/ingest/processors/offers_processor.go
+++ b/services/horizon/internal/ingest/processors/offers_processor.go
@@ -27,7 +27,7 @@ func NewOffersProcessor(offersQ history.QOffers, sequence uint32) *OffersProcess
 }
 
 func (p *OffersProcessor) reset() {
-	p.cache = ingest.NewLedgerEntryChangeCache()
+	p.cache = ingest.NewChangeCompactor()
 	p.insertBatch = p.offersQ.NewOffersBatchInsertBuilder(maxBatchSize)
 	p.removeBatch = []int64{}
 }

--- a/services/horizon/internal/ingest/processors/signers_processor.go
+++ b/services/horizon/internal/ingest/processors/signers_processor.go
@@ -30,7 +30,7 @@ func NewSignersProcessor(
 
 func (p *SignersProcessor) reset() {
 	p.batch = p.signersQ.NewAccountSignersBatchInsertBuilder(maxBatchSize)
-	p.cache = ingest.NewLedgerEntryChangeCache()
+	p.cache = ingest.NewChangeCompactor()
 }
 
 func (p *SignersProcessor) ProcessChange(change ingest.Change) error {

--- a/services/horizon/internal/ingest/processors/trust_lines_processor.go
+++ b/services/horizon/internal/ingest/processors/trust_lines_processor.go
@@ -20,7 +20,7 @@ func NewTrustLinesProcessor(trustLinesQ history.QTrustLines) *TrustLinesProcesso
 }
 
 func (p *TrustLinesProcessor) reset() {
-	p.cache = ingest.NewLedgerEntryChangeCache()
+	p.cache = ingest.NewChangeCompactor()
 }
 
 func (p *TrustLinesProcessor) ProcessChange(change ingest.Change) error {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Renames `NewLedgerEntryChangeCache` to `NewChangeCompactor` within the library, its test suite, and all uses within horizon/internal/ingest.

### Why
#3332 started this process but left the constructor unchanged. This completes the rename so readers will not be confused by the two divergent naming conventions.

### Known limitations
This is technically an API change so it may need a proper version bump if `ingest` is "released."
