### PR TITLE
[CAP 35] Stop emitting an account_credited effect for Clawback

### DIFF
--- a/services/horizon/internal/ingest/processors/effects_processor.go
+++ b/services/horizon/internal/ingest/processors/effects_processor.go
@@ -947,11 +947,6 @@ func (e *effectsWrapper) addClawbackEffects() error {
 	}
 	source := e.operation.SourceAccount()
 	addAssetDetails(details, op.Asset.ToAsset(*source), "")
-	e.add(
-		source.Address(),
-		history.EffectAccountCredited,
-		details,
-	)
 
 	from := op.From.ToAccountId()
 	e.add(

--- a/services/horizon/internal/ingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/ingest/processors/effects_processor_test.go
@@ -1854,18 +1854,6 @@ func TestOperationEffectsClawback(t *testing.T) {
 
 	expected := []effect{
 		{
-			address:     "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
-			operationID: 4294967297,
-			details: map[string]interface{}{
-				"asset_code":   "COP",
-				"asset_issuer": "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
-				"asset_type":   "credit_alphanum4",
-				"amount":       "0.0000034",
-			},
-			effectType: history.EffectAccountCredited,
-			order:      uint32(1),
-		},
-		{
 			address:     "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3",
 			operationID: 4294967297,
 			details: map[string]interface{}{
@@ -1875,7 +1863,7 @@ func TestOperationEffectsClawback(t *testing.T) {
 				"amount":       "0.0000034",
 			},
 			effectType: history.EffectAccountDebited,
-			order:      uint32(2),
+			order:      uint32(1),
 		},
 	}
 	tt.Equal(expected, effects)


### PR DESCRIPTION
The clawed-back amount is just burned. No account is credited.
