### PR TITLE
horizon: Fix circle ci jobs which publish docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,7 @@ jobs:
 
   publish_horizon_docker_image:
     docker:
-      - image: buildpack-deps:stretch
+      - image: circleci/buildpack-deps:stretch
     steps:
       - checkout
       - setup_remote_docker
@@ -439,7 +439,7 @@ jobs:
 
   publish_latest_horizon_docker_image:
     docker:
-      - image: buildpack-deps:stretch
+      - image: circleci/buildpack-deps:stretch
     steps:
       - checkout
       - setup_remote_docker
@@ -452,7 +452,7 @@ jobs:
 
   publish_commit_hash_horizon_docker_image:
     docker:
-      - image: buildpack-deps:stretch
+      - image: circleci/buildpack-deps:stretch
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
The circle ci jobs which build and publish docker images have been failing with the following error:

```
#!/bin/bash -eo pipefail
echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
TAG=$(git rev-parse --short HEAD)
docker build -f services/horizon/docker/Dockerfile -t stellar/horizon:$TAG .
docker push stellar/horizon:$TAG
/bin/bash: docker: command not found

Exited with code exit status 127
CircleCI received exit code 127
```

I believe the issue is that the `docker` client is not available in `buildpack-deps:stretch` so I have switched back to using `circleci/buildpack-deps:stretch`