### PR TITLE
all: use official docker images for publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,7 +409,7 @@ jobs:
 
   publish_state_diff_docker_image:
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: docker:18.04
     steps:
       - checkout
       - setup_remote_docker
@@ -423,7 +423,7 @@ jobs:
 
   publish_horizon_docker_image:
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: docker:18.04
     steps:
       - checkout
       - setup_remote_docker
@@ -439,7 +439,7 @@ jobs:
 
   publish_latest_horizon_docker_image:
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: docker:18.04
     steps:
       - checkout
       - setup_remote_docker
@@ -452,7 +452,7 @@ jobs:
 
   publish_commit_hash_horizon_docker_image:
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: docker:18.04
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,7 +409,7 @@ jobs:
 
   publish_state_diff_docker_image:
     docker:
-      - image: docker:18.04
+      - image: docker:18.04-git
     steps:
       - checkout
       - setup_remote_docker
@@ -423,7 +423,7 @@ jobs:
 
   publish_horizon_docker_image:
     docker:
-      - image: docker:18.04
+      - image: docker:18.04-git
     steps:
       - checkout
       - setup_remote_docker
@@ -439,7 +439,7 @@ jobs:
 
   publish_latest_horizon_docker_image:
     docker:
-      - image: docker:18.04
+      - image: docker:18.04-git
     steps:
       - checkout
       - setup_remote_docker
@@ -452,7 +452,7 @@ jobs:
 
   publish_commit_hash_horizon_docker_image:
     docker:
-      - image: docker:18.04
+      - image: docker:18.04-git
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,10 +416,10 @@ jobs:
       - run:
           name: Build and Push Docker image
           command: |
-            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+            # echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
             docker build --no-cache -f exp/tools/dump-ledger-state/Dockerfile --build-arg GITCOMMIT=$CIRCLE_SHA1 -t stellar/ledger-state-diff:$CIRCLE_SHA1 -t stellar/ledger-state-diff:latest .
-            docker push stellar/ledger-state-diff:$CIRCLE_SHA1
-            docker push stellar/ledger-state-diff:latest
+            # docker push stellar/ledger-state-diff:$CIRCLE_SHA1
+            # docker push stellar/ledger-state-diff:latest
 
   publish_horizon_docker_image:
     docker:
@@ -430,12 +430,12 @@ jobs:
       - run:
           name: Build and Push Docker image
           command: |
-            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+            # echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
             # CIRCLE_TAG will be prefixed by "horizon-v", here we build the horizon docker image and tag it with stellar/horizon:$VERSION
             # where version is CIRCLE_TAG without the "horizon-v" prefix
             VERSION=${CIRCLE_TAG#horizon-v}
             docker build -f services/horizon/docker/Dockerfile -t stellar/horizon:$VERSION .
-            docker push stellar/horizon:$VERSION
+            # docker push stellar/horizon:$VERSION
 
   publish_latest_horizon_docker_image:
     docker:
@@ -446,9 +446,9 @@ jobs:
       - run:
           name: Build and Push Docker image
           command: |
-            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+            # echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
             docker build -f services/horizon/docker/Dockerfile -t stellar/horizon:latest .
-            docker push stellar/horizon:latest
+            # docker push stellar/horizon:latest
 
   publish_commit_hash_horizon_docker_image:
     docker:
@@ -459,10 +459,10 @@ jobs:
       - run:
           name: Build and Push Docker image
           command: |
-            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+            # echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
             TAG=$(git rev-parse --short HEAD)
             docker build -f services/horizon/docker/Dockerfile -t stellar/horizon:$TAG .
-            docker push stellar/horizon:$TAG
+            # docker push stellar/horizon:$TAG
 
   # test_horizon_integration performs Horizon integration tests, it's using
   # decicated vm machine to be able to start arbitrary docker containers.
@@ -518,6 +518,10 @@ workflows:
       # run the integration tests ...
       #   ... without captive core
       - test_horizon_integration
+      - publish_state_diff_docker_image
+      - publish_horizon_docker_image
+      - publish_latest_horizon_docker_image
+      - publish_commit_hash_horizon_docker_image
       #   ... and with captive core
       - test_horizon_integration:
           name: test_horizon_integration_with_captive_core

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,10 +416,10 @@ jobs:
       - run:
           name: Build and Push Docker image
           command: |
-            # echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
             docker build --no-cache -f exp/tools/dump-ledger-state/Dockerfile --build-arg GITCOMMIT=$CIRCLE_SHA1 -t stellar/ledger-state-diff:$CIRCLE_SHA1 -t stellar/ledger-state-diff:latest .
-            # docker push stellar/ledger-state-diff:$CIRCLE_SHA1
-            # docker push stellar/ledger-state-diff:latest
+            docker push stellar/ledger-state-diff:$CIRCLE_SHA1
+            docker push stellar/ledger-state-diff:latest
 
   publish_horizon_docker_image:
     docker:
@@ -430,12 +430,12 @@ jobs:
       - run:
           name: Build and Push Docker image
           command: |
-            # echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
             # CIRCLE_TAG will be prefixed by "horizon-v", here we build the horizon docker image and tag it with stellar/horizon:$VERSION
             # where version is CIRCLE_TAG without the "horizon-v" prefix
             VERSION=${CIRCLE_TAG#horizon-v}
             docker build -f services/horizon/docker/Dockerfile -t stellar/horizon:$VERSION .
-            # docker push stellar/horizon:$VERSION
+            docker push stellar/horizon:$VERSION
 
   publish_latest_horizon_docker_image:
     docker:
@@ -446,9 +446,9 @@ jobs:
       - run:
           name: Build and Push Docker image
           command: |
-            # echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
             docker build -f services/horizon/docker/Dockerfile -t stellar/horizon:latest .
-            # docker push stellar/horizon:latest
+            docker push stellar/horizon:latest
 
   publish_commit_hash_horizon_docker_image:
     docker:
@@ -459,10 +459,10 @@ jobs:
       - run:
           name: Build and Push Docker image
           command: |
-            # echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
             TAG=$(git rev-parse --short HEAD)
             docker build -f services/horizon/docker/Dockerfile -t stellar/horizon:$TAG .
-            # docker push stellar/horizon:$TAG
+            docker push stellar/horizon:$TAG
 
   # test_horizon_integration performs Horizon integration tests, it's using
   # decicated vm machine to be able to start arbitrary docker containers.
@@ -518,10 +518,6 @@ workflows:
       # run the integration tests ...
       #   ... without captive core
       - test_horizon_integration
-      - publish_state_diff_docker_image
-      - publish_horizon_docker_image
-      - publish_latest_horizon_docker_image
-      - publish_commit_hash_horizon_docker_image
       #   ... and with captive core
       - test_horizon_integration:
           name: test_horizon_integration_with_captive_core


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Use the official docker images for publishing Horizon to docker.

### Why

This is a follow up to #3367 that changed us back to using the CircleCI convenience images after I made change #3347. Instead of returning to use the buildpack-deps images I'm using the docker images because these tasks are building and pushing docker images, and so they should be perfect for this job.

### Known limitations

N/A
