### PR TITLE
 clients/horizonclient fix request timeout

### DIFF
--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -119,7 +119,7 @@ func (c *Client) sendRequestURL(requestURL string, method string, a interface{})
 	if c.horizonTimeout == 0 {
 		c.horizonTimeout = HorizonTimeout
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*c.horizonTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), c.horizonTimeout)
 	resp, err := c.HTTP.Do(req.WithContext(ctx))
 	if err != nil {
 		cancel()


### PR DESCRIPTION
Fix for  clients/horizonclient/client.go sendRequestURL method context timeout. 

Redundant multiply horizonTimeout on time.Second creates timeout equal to 10^18 nanoseconds (if horizonTimeout was set as 1 second (by default) )
