### PR TITLE
ingest: Use a *random* history archive from the Captive Core configuration list

### DIFF
--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -420,12 +420,25 @@ func Connect(u string, opts ConnectOptions) (*Archive, error) {
 	return &arch, err
 }
 
+func MustConnect(u string, opts ConnectOptions) *Archive {
+	arch, err := Connect(u, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return arch
+}
+
 func ConnectAny(urls []string, opts ConnectOptions) (*Archive, error) {
+	if len(urls) == 0 {
+		return nil, errors.New("No history archives provided")
+	}
+
 	var outerErr error
 	for len(urls) > 0 {
 		i := rand.Intn(len(urls))
 		archive, err := Connect(urls[i], opts)
 		if err != nil {
+			// Drop the failed archive from the list and try again
 			urls = append(urls[:i], urls[i+1:]...)
 			outerErr = err
 			continue
@@ -435,12 +448,4 @@ func ConnectAny(urls []string, opts ConnectOptions) (*Archive, error) {
 	}
 
 	return nil, outerErr
-}
-
-func MustConnect(u string, opts ConnectOptions) *Archive {
-	arch, err := Connect(u, opts)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return arch
 }

--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"net/url"
 	"path"
 	"regexp"
@@ -417,6 +418,23 @@ func Connect(u string, opts ConnectOptions) (*Archive, error) {
 		err = errors.New("unknown URL scheme: '" + parsed.Scheme + "'")
 	}
 	return &arch, err
+}
+
+func ConnectAny(urls []string, opts ConnectOptions) (*Archive, error) {
+	var outerErr error
+	for len(urls) > 0 {
+		i := rand.Intn(len(urls))
+		archive, err := Connect(urls[i], opts)
+		if err != nil {
+			urls = append(urls[:i], urls[i+1:]...)
+			outerErr = err
+			continue
+		}
+
+		return archive, nil
+	}
+
+	return nil, outerErr
 }
 
 func MustConnect(u string, opts ConnectOptions) *Archive {

--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -433,13 +433,14 @@ func ConnectAny(urls []string, opts ConnectOptions) (*Archive, error) {
 		return nil, errors.New("No history archives provided")
 	}
 
+	urlsCopy := urls
 	var outerErr error
-	for len(urls) > 0 {
-		i := rand.Intn(len(urls))
-		archive, err := Connect(urls[i], opts)
+	for len(urlsCopy) > 0 {
+		i := rand.Intn(len(urlsCopy))
+		archive, err := Connect(urlsCopy[i], opts)
 		if err != nil {
 			// Drop the failed archive from the list and try again
-			urls = append(urls[:i], urls[i+1:]...)
+			urlsCopy = append(urlsCopy[:i], urlsCopy[i+1:]...)
 			outerErr = err
 			continue
 		}

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -146,14 +146,15 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	var cancel context.CancelFunc
 	config.Context, cancel = context.WithCancel(parentCtx)
 
-	archive, err := historyarchive.Connect(
-		config.HistoryArchiveURLs[0],
+	archive, err := historyarchive.ConnectAny(
+		config.HistoryArchiveURLs,
 		historyarchive.ConnectOptions{
 			NetworkPassphrase:   config.NetworkPassphrase,
 			CheckpointFrequency: config.CheckpointFrequency,
 			Context:             config.Context,
 		},
 	)
+
 	if err != nil {
 		cancel()
 		return nil, errors.Wrap(err, "error connecting to history archive")

--- a/ingest/tutorial/example_claimables.go
+++ b/ingest/tutorial/example_claimables.go
@@ -13,8 +13,8 @@ import (
 
 func claimables() {
 	// Open a history archive using our existing configuration details.
-	historyArchive, err := historyarchive.Connect(
-		config.HistoryArchiveURLs[0],
+	historyArchive, err := historyarchive.ConnectAny(
+		config.HistoryArchiveURLs,
 		historyarchive.ConnectOptions{
 			NetworkPassphrase: config.NetworkPassphrase,
 			S3Region:          "us-west-1",


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Introduces `historyarchive.ConnectAny`, which chooses a random history archive from a list of URLs until succeeding.

### Why
Previously, listing more than one history archive in the Captive Core configuration had no impact since the first was always used. This is (more or less) a preliminary effort into being smarter about the way we use history archives.

Moving forward, the goal may be to refactor the `historyarchive` library to use a random archive for every request for redundancy purposes, but this can be done in future PRs.

### Known limitations
I'd like to add a test.