### PR TITLE
txnbuild: Remove TxEnvelope() functions from txnbuild

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Breaking changes
+
+* Remove `TxEnvelope()` functions from `Transaction` and `FeeBumpTransaction` to simplify the API. `ToXDR()` should be used instead of `TxEnvelope()`  ([#3377](https://github.com/stellar/go/pull/3377))
+
 ## [v5.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v5.0.0) - 2020-11-12
 
 ### Breaking changes

--- a/txnbuild/fee_bump_test.go
+++ b/txnbuild/fee_bump_test.go
@@ -387,7 +387,7 @@ func TestFeeBumpRoundTrip(t *testing.T) {
 	outerHash, err := feeBumpTx.HashHex(network.TestNetworkPassphrase)
 	assert.NoError(t, err)
 
-	env, err := feeBumpTx.TxEnvelope()
+	env := feeBumpTx.ToXDR()
 	assert.NoError(t, err)
 	assert.Equal(t, xdr.EnvelopeTypeEnvelopeTypeTxFeeBump, env.Type)
 	assert.Equal(t, xdr.MustAddress(kp1.Address()), env.FeeBumpAccount().ToAccountId())

--- a/txnbuild/helpers_test.go
+++ b/txnbuild/helpers_test.go
@@ -103,6 +103,7 @@ func newSignedFeeBumpTransaction(
 }
 
 func convertToV0(tx *Transaction) {
+	signatures := tx.Signatures()
 	tx.envelope.V0 = &xdr.TransactionV0Envelope{
 		Tx: xdr.TransactionV0{
 			SourceAccountEd25519: *tx.envelope.SourceAccount().Ed25519,
@@ -112,6 +113,7 @@ func convertToV0(tx *Transaction) {
 			Memo:                 tx.envelope.Memo(),
 			Operations:           tx.envelope.Operations(),
 		},
+		Signatures: signatures,
 	}
 	tx.envelope.V1 = nil
 	tx.envelope.Type = xdr.EnvelopeTypeEnvelopeTypeTxV0

--- a/txnbuild/manage_data_test.go
+++ b/txnbuild/manage_data_test.go
@@ -93,7 +93,7 @@ func TestManageDataRoundTrip(t *testing.T) {
 			)
 			assert.NoError(t, err)
 
-			envelope, err := tx.TxEnvelope()
+			envelope := tx.ToXDR()
 			assert.NoError(t, err)
 			assert.Len(t, envelope.Operations(), 1)
 			assert.Equal(t, xdr.String64(manageData.Name), envelope.Operations()[0].Body.ManageDataOp.DataName)

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -195,7 +195,6 @@ type Transaction struct {
 	operations    []Operation
 	memo          Memo
 	timebounds    Timebounds
-	signatures    []xdr.DecoratedSignature
 }
 
 // BaseFee returns the per operation fee for this transaction.
@@ -232,7 +231,7 @@ func (t *Transaction) Operations() []Operation {
 // Signatures returns the list of signatures attached to this transaction.
 // The contents of the returned slice should not be modified.
 func (t *Transaction) Signatures() []xdr.DecoratedSignature {
-	return t.signatures
+	return t.envelope.Signatures()
 }
 
 // Hash returns the network specific hash of this transaction
@@ -247,18 +246,36 @@ func (t *Transaction) HashHex(network string) (string, error) {
 	return hashHex(t.envelope, network)
 }
 
+func (t *Transaction) clone(signatures []xdr.DecoratedSignature) *Transaction {
+	newTx := new(Transaction)
+	*newTx = *t
+	newTx.envelope = t.envelope
+
+	switch newTx.envelope.Type {
+	case xdr.EnvelopeTypeEnvelopeTypeTx:
+		newTx.envelope.V1 = new(xdr.TransactionV1Envelope)
+		*newTx.envelope.V1 = *t.envelope.V1
+		newTx.envelope.V1.Signatures = signatures
+	case xdr.EnvelopeTypeEnvelopeTypeTxV0:
+		newTx.envelope.V0 = new(xdr.TransactionV0Envelope)
+		*newTx.envelope.V0 = *t.envelope.V0
+		newTx.envelope.V0.Signatures = signatures
+	default:
+		panic("invalid transaction type: " + newTx.envelope.Type.String())
+	}
+
+	return newTx
+}
+
 // Sign returns a new Transaction instance which extends the current instance
 // with additional signatures derived from the given list of keypair instances.
 func (t *Transaction) Sign(network string, kps ...*keypair.Full) (*Transaction, error) {
-	extendedSignatures, err := concatSignatures(t.envelope, network, t.signatures, kps...)
+	extendedSignatures, err := concatSignatures(t.envelope, network, t.Signatures(), kps...)
 	if err != nil {
 		return nil, err
 	}
 
-	newTx := new(Transaction)
-	*newTx = *t
-	newTx.signatures = extendedSignatures
-	return newTx, nil
+	return t.clone(extendedSignatures), nil
 }
 
 // SignWithKeyString returns a new Transaction instance which extends the current instance
@@ -275,60 +292,40 @@ func (t *Transaction) SignWithKeyString(network string, keys ...string) (*Transa
 // with HashX signature type.
 // See description here: https://www.stellar.org/developers/guides/concepts/multi-sig.html#hashx.
 func (t *Transaction) SignHashX(preimage []byte) (*Transaction, error) {
-	extendedSignatures, err := concatHashX(t.signatures, preimage)
+	extendedSignatures, err := concatHashX(t.Signatures(), preimage)
 	if err != nil {
 		return nil, err
 	}
 
-	newTx := new(Transaction)
-	*newTx = *t
-	newTx.signatures = extendedSignatures
-	return newTx, nil
+	return t.clone(extendedSignatures), nil
 }
 
 // AddSignatureBase64 returns a new Transaction instance which extends the current instance
 // with an additional signature derived from the given base64-encoded signature.
 func (t *Transaction) AddSignatureBase64(network, publicKey, signature string) (*Transaction, error) {
-	extendedSignatures, err := concatSignatureBase64(t.envelope, t.signatures, network, publicKey, signature)
+	extendedSignatures, err := concatSignatureBase64(t.envelope, t.Signatures(), network, publicKey, signature)
 	if err != nil {
 		return nil, err
 	}
 
-	newTx := new(Transaction)
-	*newTx = *t
-	newTx.signatures = extendedSignatures
-	return newTx, nil
+	return t.clone(extendedSignatures), nil
 }
 
 // ToXDR returns the a xdr.TransactionEnvelope which is equivalent to this transaction.
 // The envelope should not be modified because any changes applied may
 // affect the internals of the Transaction instance.
 func (t *Transaction) ToXDR() xdr.TransactionEnvelope {
-	env := t.envelope
-	switch env.Type {
-	case xdr.EnvelopeTypeEnvelopeTypeTx:
-		env.V1 = new(xdr.TransactionV1Envelope)
-		*env.V1 = *t.envelope.V1
-		env.V1.Signatures = t.signatures
-	case xdr.EnvelopeTypeEnvelopeTypeTxV0:
-		env.V0 = new(xdr.TransactionV0Envelope)
-		*env.V0 = *t.envelope.V0
-		env.V0.Signatures = t.signatures
-	default:
-		panic("invalid transaction type: " + env.Type.String())
-	}
-
-	return env
+	return t.envelope
 }
 
 // MarshalBinary returns the binary XDR representation of the transaction envelope.
 func (t *Transaction) MarshalBinary() ([]byte, error) {
-	return marshallBinary(t.envelope, t.signatures)
+	return marshallBinary(t.envelope, t.Signatures())
 }
 
 // Base64 returns the base 64 XDR representation of the transaction envelope.
 func (t *Transaction) Base64() (string, error) {
-	return marshallBase64(t.envelope, t.signatures)
+	return marshallBase64(t.envelope, t.Signatures())
 }
 
 // ClaimableBalanceID returns the claimable balance ID for the operation at the given index within the transaction.
@@ -395,7 +392,6 @@ type FeeBumpTransaction struct {
 	maxFee     int64
 	feeAccount string
 	inner      *Transaction
-	signatures []xdr.DecoratedSignature
 }
 
 // BaseFee returns the per operation fee for this transaction.
@@ -416,7 +412,7 @@ func (t *FeeBumpTransaction) FeeAccount() string {
 // Signatures returns the list of signatures attached to this transaction.
 // The contents of the returned slice should not be modified.
 func (t *FeeBumpTransaction) Signatures() []xdr.DecoratedSignature {
-	return t.signatures
+	return t.envelope.FeeBumpSignatures()
 }
 
 // Hash returns the network specific hash of this transaction
@@ -431,18 +427,24 @@ func (t *FeeBumpTransaction) HashHex(network string) (string, error) {
 	return hashHex(t.envelope, network)
 }
 
+func (t *FeeBumpTransaction) clone(signatures []xdr.DecoratedSignature) *FeeBumpTransaction {
+	newTx := new(FeeBumpTransaction)
+	*newTx = *t
+	newTx.envelope.FeeBump = new(xdr.FeeBumpTransactionEnvelope)
+	*newTx.envelope.FeeBump = *t.envelope.FeeBump
+	newTx.envelope.FeeBump.Signatures = signatures
+	return newTx
+}
+
 // Sign returns a new FeeBumpTransaction instance which extends the current instance
 // with additional signatures derived from the given list of keypair instances.
 func (t *FeeBumpTransaction) Sign(network string, kps ...*keypair.Full) (*FeeBumpTransaction, error) {
-	extendedSignatures, err := concatSignatures(t.envelope, network, t.signatures, kps...)
+	extendedSignatures, err := concatSignatures(t.envelope, network, t.Signatures(), kps...)
 	if err != nil {
 		return nil, err
 	}
 
-	newTx := new(FeeBumpTransaction)
-	*newTx = *t
-	newTx.signatures = extendedSignatures
-	return newTx, nil
+	return t.clone(extendedSignatures), nil
 }
 
 // SignWithKeyString returns a new FeeBumpTransaction instance which extends the current instance
@@ -459,56 +461,40 @@ func (t *FeeBumpTransaction) SignWithKeyString(network string, keys ...string) (
 // with HashX signature type.
 // See description here: https://www.stellar.org/developers/guides/concepts/multi-sig.html#hashx.
 func (t *FeeBumpTransaction) SignHashX(preimage []byte) (*FeeBumpTransaction, error) {
-	extendedSignatures, err := concatHashX(t.signatures, preimage)
+	extendedSignatures, err := concatHashX(t.Signatures(), preimage)
 	if err != nil {
 		return nil, err
 	}
 
-	newTx := new(FeeBumpTransaction)
-	*newTx = *t
-	newTx.signatures = extendedSignatures
-	return newTx, nil
+	return t.clone(extendedSignatures), nil
 }
 
 // AddSignatureBase64 returns a new FeeBumpTransaction instance which extends the current instance
 // with an additional signature derived from the given base64-encoded signature.
 func (t *FeeBumpTransaction) AddSignatureBase64(network, publicKey, signature string) (*FeeBumpTransaction, error) {
-	extendedSignatures, err := concatSignatureBase64(t.envelope, t.signatures, network, publicKey, signature)
+	extendedSignatures, err := concatSignatureBase64(t.envelope, t.Signatures(), network, publicKey, signature)
 	if err != nil {
 		return nil, err
 	}
 
-	newTx := new(FeeBumpTransaction)
-	*newTx = *t
-	newTx.signatures = extendedSignatures
-	return newTx, nil
+	return t.clone(extendedSignatures), nil
 }
 
 // ToXDR returns the a xdr.TransactionEnvelope which is equivalent to this transaction.
 // The envelope should not be modified because any changes applied may
 // affect the internals of the FeeBumpTransaction instance.
 func (t *FeeBumpTransaction) ToXDR() xdr.TransactionEnvelope {
-	env := t.envelope
-	switch env.Type {
-	case xdr.EnvelopeTypeEnvelopeTypeTxFeeBump:
-		env.FeeBump = new(xdr.FeeBumpTransactionEnvelope)
-		*env.FeeBump = *t.envelope.FeeBump
-		env.FeeBump.Signatures = t.signatures
-	default:
-		panic("invalid transaction type: " + env.Type.String())
-	}
-
-	return env
+	return t.envelope
 }
 
 // MarshalBinary returns the binary XDR representation of the transaction envelope.
 func (t *FeeBumpTransaction) MarshalBinary() ([]byte, error) {
-	return marshallBinary(t.envelope, t.signatures)
+	return marshallBinary(t.envelope, t.Signatures())
 }
 
 // Base64 returns the base 64 XDR representation of the transaction envelope.
 func (t *FeeBumpTransaction) Base64() (string, error) {
-	return marshallBase64(t.envelope, t.signatures)
+	return marshallBase64(t.envelope, t.Signatures())
 }
 
 // InnerTransaction returns the Transaction which is wrapped by
@@ -575,7 +561,6 @@ func transactionFromParsedXDR(xdrEnv xdr.TransactionEnvelope) (*GenericTransacti
 			maxFee:     xdrEnv.FeeBumpFee(),
 			inner:      innerTx.simple,
 			feeAccount: feeBumpAccount.Address(),
-			signatures: xdrEnv.FeeBumpSignatures(),
 		}
 		return newTx, nil
 	}
@@ -599,7 +584,6 @@ func transactionFromParsedXDR(xdrEnv xdr.TransactionEnvelope) (*GenericTransacti
 		operations: nil,
 		memo:       nil,
 		timebounds: Timebounds{},
-		signatures: xdrEnv.Signatures(),
 	}
 
 	if timeBounds := xdrEnv.TimeBounds(); timeBounds != nil {
@@ -661,7 +645,6 @@ func NewTransaction(params TransactionParams) (*Transaction, error) {
 		operations: params.Operations,
 		memo:       params.Memo,
 		timebounds: params.Timebounds,
-		signatures: nil,
 	}
 
 	accountID, err := xdr.AddressToAccountId(tx.sourceAccount.AccountID)
@@ -757,7 +740,7 @@ func convertToV1(tx *Transaction) (*Transaction, error) {
 	if err != nil {
 		return tx, err
 	}
-	tx.signatures = signatures
+	tx.envelope.V1.Signatures = signatures
 	return tx, nil
 }
 

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -182,19 +182,6 @@ func marshallBase64(e xdr.TransactionEnvelope, signatures []xdr.DecoratedSignatu
 	return base64.StdEncoding.EncodeToString(binary), nil
 }
 
-func cloneEnvelope(e xdr.TransactionEnvelope, signatures []xdr.DecoratedSignature) (xdr.TransactionEnvelope, error) {
-	var clone xdr.TransactionEnvelope
-	binary, err := marshallBinary(e, signatures)
-	if err != nil {
-		return clone, errors.Wrap(err, "could not marshall envelope")
-	}
-
-	if err = xdr.SafeUnmarshal(binary, &clone); err != nil {
-		return clone, errors.Wrap(err, "could not unmarshall envelope")
-	}
-	return clone, nil
-}
-
 // Transaction represents a Stellar transaction. See
 // https://www.stellar.org/developers/guides/concepts/transactions.html
 // A Transaction may be wrapped by a FeeBumpTransaction in which case
@@ -313,21 +300,19 @@ func (t *Transaction) AddSignatureBase64(network, publicKey, signature string) (
 	return newTx, nil
 }
 
-// TxEnvelope returns the a xdr.TransactionEnvelope instance which is
-// equivalent to this transaction.
-func (t *Transaction) TxEnvelope() (xdr.TransactionEnvelope, error) {
-	return cloneEnvelope(t.envelope, t.signatures)
-}
-
-// ToXDR is like TxEnvelope except that the transaction envelope returned by ToXDR
-// should not be modified because any changes applied to the transaction envelope may
+// ToXDR returns the a xdr.TransactionEnvelope which is equivalent to this transaction.
+// The envelope should not be modified because any changes applied may
 // affect the internals of the Transaction instance.
 func (t *Transaction) ToXDR() xdr.TransactionEnvelope {
 	env := t.envelope
 	switch env.Type {
 	case xdr.EnvelopeTypeEnvelopeTypeTx:
+		env.V1 = new(xdr.TransactionV1Envelope)
+		*env.V1 = *t.envelope.V1
 		env.V1.Signatures = t.signatures
 	case xdr.EnvelopeTypeEnvelopeTypeTxV0:
+		env.V0 = new(xdr.TransactionV0Envelope)
+		*env.V0 = *t.envelope.V0
 		env.V0.Signatures = t.signatures
 	default:
 		panic("invalid transaction type: " + env.Type.String())
@@ -499,19 +484,15 @@ func (t *FeeBumpTransaction) AddSignatureBase64(network, publicKey, signature st
 	return newTx, nil
 }
 
-// TxEnvelope returns the a xdr.TransactionEnvelope instance which is
-// equivalent to this transaction.
-func (t *FeeBumpTransaction) TxEnvelope() (xdr.TransactionEnvelope, error) {
-	return cloneEnvelope(t.envelope, t.signatures)
-}
-
-// ToXDR is like TxEnvelope except that the transaction envelope returned by ToXDR
-// should not be modified because any changes applied to the transaction envelope may
+// ToXDR returns the a xdr.TransactionEnvelope which is equivalent to this transaction.
+// The envelope should not be modified because any changes applied may
 // affect the internals of the FeeBumpTransaction instance.
 func (t *FeeBumpTransaction) ToXDR() xdr.TransactionEnvelope {
 	env := t.envelope
 	switch env.Type {
 	case xdr.EnvelopeTypeEnvelopeTypeTxFeeBump:
+		env.FeeBump = new(xdr.FeeBumpTransactionEnvelope)
+		*env.FeeBump = *t.envelope.FeeBump
 		env.FeeBump.Signatures = t.signatures
 	default:
 		panic("invalid transaction type: " + env.Type.String())
@@ -786,11 +767,15 @@ func NewFeeBumpTransaction(params FeeBumpTransactionParams) (*FeeBumpTransaction
 	if inner == nil {
 		return nil, errors.New("inner transaction is missing")
 	}
-	innerEnv, err := inner.TxEnvelope()
-	if err != nil {
-		return nil, errors.Wrap(err, "inner transaction envelope not found")
+	switch inner.envelope.Type {
+	case xdr.EnvelopeTypeEnvelopeTypeTx, xdr.EnvelopeTypeEnvelopeTypeTxV0:
+	default:
+		return nil, errors.Errorf("%s transactions cannot be fee bumped", inner.envelope.Type)
 	}
+
+	innerEnv := inner.ToXDR()
 	if innerEnv.Type == xdr.EnvelopeTypeEnvelopeTypeTxV0 {
+		var err error
 		inner, err = convertToV1(inner)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not upgrade transaction from v0 to v1")

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1053,7 +1053,7 @@ func TestHashHex(t *testing.T) {
 	expected = "1b3905ba8c3c0ecc68ae812f2d77f27c697195e8daf568740fc0f5662f65f759"
 	assert.Equal(t, expected, hashHex, "hex encoded hash should match")
 
-	txEnv, err := tx.TxEnvelope()
+	txEnv := tx.ToXDR()
 	assert.NoError(t, err)
 	assert.NotNil(t, txEnv, "transaction xdr envelope should not be nil")
 	sourceAccountFromEnv := txEnv.SourceAccount().ToAccountId()
@@ -1983,7 +1983,7 @@ func TestReadChallengeTx_forbidsMuxedAccounts(t *testing.T) {
 		time.Hour,
 	)
 
-	env, err := tx.TxEnvelope()
+	env := tx.ToXDR()
 	assert.NoError(t, err)
 	aid := xdr.MustAddress(kp0.Address())
 	muxedAccount := xdr.MuxedAccount{


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove `TxEnvelope()` from `Transaction` and `FeeBumpTransaction`. Now `ToXDR()` is the only function which produces XDR transaction envelopes.

### Why

It simplifies the API to just have one function which produces an XDR transaction envelope. Although it would be nice to have immutable transaction envelopes, the inconvenience of checking the error result might outweigh the benefit. Given that the `Signatures()` and `Operations()` functions assume the caller will not modify the returned slice, I think it is ok for us to be consistent and hold the same assumption in `ToXDR()`.

### Known limitations

[N/A]
