### PR TITLE
[CAP35] Add support for SetTrustLineFlags operation

### DIFF
--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -86,6 +86,10 @@ const (
 	// to true and it authorizes another account's trustline to maintain liabilities
 	EffectTrustlineAuthorizedToMaintainLiabilities EffectType = 25 // from allow_trust
 
+	// EffectTrustlineFlagsUpdated effects occur when a TrustLine changes its
+	// flags, either clearing or setting.
+	EffectTrustlineFlagsUpdated EffectType = 26 // from set_trust_line flags
+
 	// trading effects
 
 	// EffectOfferCreated occurs when an account offers to trade an asset
@@ -178,10 +182,6 @@ const (
 	// EffectClaimableBalanceClawedBack occurs when a claimable balance is clawed back
 	EffectClaimableBalanceClawedBack EffectType = 80 // from clawback_claimable_balance
 
-	// EffectTrustlineFlagsUpdated effects occur when a TrustLine changes its
-	// flags, either clearing or setting.
-	EffectTrustlineFlagsUpdated EffectType = 81 // from set_trust_line flags
-
 )
 
 // Peter 30-04-2019: this is copied from the resourcadapter package
@@ -207,6 +207,7 @@ var EffectTypeNames = map[EffectType]string{
 	EffectTrustlineAuthorized:                      "trustline_authorized",
 	EffectTrustlineAuthorizedToMaintainLiabilities: "trustline_authorized_to_maintain_liabilities",
 	EffectTrustlineDeauthorized:                    "trustline_deauthorized",
+	EffectTrustlineFlagsUpdated:                    "trustline_flags_updated",
 	EffectOfferCreated:                             "offer_created",
 	EffectOfferRemoved:                             "offer_removed",
 	EffectOfferUpdated:                             "offer_updated",
@@ -234,7 +235,6 @@ var EffectTypeNames = map[EffectType]string{
 	EffectSignerSponsorshipUpdated:                 "signer_sponsorship_updated",
 	EffectSignerSponsorshipRemoved:                 "signer_sponsorship_removed",
 	EffectClaimableBalanceClawedBack:               "claimable_balance_clawed_back",
-	EffectTrustlineFlagsUpdated:                    "trustline_flags_updated",
 }
 
 // Base provides the common structure for any effect resource effect.
@@ -673,6 +673,12 @@ func UnmarshalEffect(effectType string, dataString []byte) (effects Effect, err 
 			return
 		}
 		effects = effect
+	case EffectTypeNames[EffectTrustlineFlagsUpdated]:
+		var effect TrustlineFlagsUpdated
+		if err = json.Unmarshal(dataString, &effect); err != nil {
+			return
+		}
+		effects = effect
 	case EffectTypeNames[EffectTrustlineRemoved]:
 		var effect TrustlineRemoved
 		if err = json.Unmarshal(dataString, &effect); err != nil {
@@ -819,12 +825,6 @@ func UnmarshalEffect(effectType string, dataString []byte) (effects Effect, err 
 		effects = effect
 	case EffectTypeNames[EffectClaimableBalanceClawedBack]:
 		var effect ClaimableBalanceClawedBack
-		if err = json.Unmarshal(dataString, &effect); err != nil {
-			return
-		}
-		effects = effect
-	case EffectTypeNames[EffectTrustlineFlagsUpdated]:
-		var effect TrustlineFlagsUpdated
 		if err = json.Unmarshal(dataString, &effect); err != nil {
 			return
 		}

--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -71,14 +71,17 @@ const (
 	// EffectTrustlineUpdated occurs when an account changes a trustline's limit
 	EffectTrustlineUpdated EffectType = 22 // from change_trust, allow_trust
 
+	// Deprecated: use EffectTrustlineFlagsUpdated instead
 	// EffectTrustlineAuthorized occurs when an anchor has AUTH_REQUIRED flag set
 	// to true and it authorizes another account's trustline
 	EffectTrustlineAuthorized EffectType = 23 // from allow_trust
 
+	// Deprecated: use EffectTrustlineFlagsUpdated instead
 	// EffectTrustlineDeauthorized occurs when an anchor revokes access to a asset
 	// it issues.
 	EffectTrustlineDeauthorized EffectType = 24 // from allow_trust
 
+	// Deprecated: use EffectTrustlineFlagsUpdated instead
 	// EffectTrustlineAuthorizedToMaintainLiabilities occurs when an anchor has AUTH_REQUIRED flag set
 	// to true and it authorizes another account's trustline to maintain liabilities
 	EffectTrustlineAuthorizedToMaintainLiabilities EffectType = 25 // from allow_trust
@@ -175,6 +178,10 @@ const (
 	// EffectClaimableBalanceClawedBack occurs when a claimable balance is clawed back
 	EffectClaimableBalanceClawedBack EffectType = 80 // from clawback_claimable_balance
 
+	// EffectTrustlineFlagsUpdated effects occur when a TrustLine changes its
+	// flags, either clearing or setting.
+	EffectTrustlineFlagsUpdated EffectType = 81 // from set_trust_line flags
+
 )
 
 // Peter 30-04-2019: this is copied from the resourcadapter package
@@ -227,6 +234,7 @@ var EffectTypeNames = map[EffectType]string{
 	EffectSignerSponsorshipUpdated:                 "signer_sponsorship_updated",
 	EffectSignerSponsorshipRemoved:                 "signer_sponsorship_removed",
 	EffectClaimableBalanceClawedBack:               "claimable_balance_clawed_back",
+	EffectTrustlineFlagsUpdated:                    "trustline_flags_updated",
 }
 
 // Base provides the common structure for any effect resource effect.
@@ -346,6 +354,7 @@ type TrustlineUpdated struct {
 	Limit string `json:"limit"`
 }
 
+// Deprecated: use TrustlineFlagsUpdated instead
 type TrustlineAuthorized struct {
 	Base
 	Trustor   string `json:"trustor"`
@@ -353,6 +362,7 @@ type TrustlineAuthorized struct {
 	AssetCode string `json:"asset_code,omitempty"`
 }
 
+// Deprecated: use TrustlineFlagsUpdated instead
 type TrustlineAuthorizedToMaintainLiabilities struct {
 	Base
 	Trustor   string `json:"trustor"`
@@ -360,6 +370,7 @@ type TrustlineAuthorizedToMaintainLiabilities struct {
 	AssetCode string `json:"asset_code,omitempty"`
 }
 
+// Deprecated: use TrustlineFlagsUpdated instead
 type TrustlineDeauthorized struct {
 	Base
 	Trustor   string `json:"trustor"`
@@ -498,6 +509,15 @@ type SignerSponsorshipRemoved struct {
 type ClaimableBalanceClawedBack struct {
 	Base
 	BalanceID string `json:"balance_id"`
+}
+
+type TrustlineFlagsUpdated struct {
+	Base
+	base.Asset
+	Trustor                         string `json:"trustor"`
+	Authorized                      *bool  `json:"authorized_flag,omitempty"`
+	AuthorizedToMaintainLiabilities *bool  `json:"authorized_to_maintain_liabilites_flag,omitempty"`
+	ClawbackEnabled                 *bool  `json:"claback_enabled_flag,omitempty"`
 }
 
 // Effect contains methods that are implemented by all effect types.
@@ -799,6 +819,12 @@ func UnmarshalEffect(effectType string, dataString []byte) (effects Effect, err 
 		effects = effect
 	case EffectTypeNames[EffectClaimableBalanceClawedBack]:
 		var effect ClaimableBalanceClawedBack
+		if err = json.Unmarshal(dataString, &effect); err != nil {
+			return
+		}
+		effects = effect
+	case EffectTypeNames[EffectTrustlineFlagsUpdated]:
+		var effect TrustlineFlagsUpdated
 		if err = json.Unmarshal(dataString, &effect); err != nil {
 			return
 		}

--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -194,6 +194,7 @@ type ChangeTrust struct {
 	Trustor string `json:"trustor"`
 }
 
+// Deprecated: use TrustlineFlagsUpdated instead.
 // AllowTrust is the json resource representing a single operation whose type is
 // AllowTrust.
 type AllowTrust struct {
@@ -274,11 +275,23 @@ type Clawback struct {
 	Amount string `json:"amount"`
 }
 
-// Clawback is the json resource representing a single operation whose type is
-// Clawback.
+// ClawbackClaimableBalance is the json resource representing a single operation whose type is
+// ClawbackClaimableBalance.
 type ClawbackClaimableBalance struct {
 	Base
 	ClaimableBalanceID *string `json:"balance_id,omitempty"`
+}
+
+// SetTrustLineFlags is the json resource representing a single operation whose type is
+// SetTrustLineFlags.
+type SetTrustLineFlags struct {
+	Base
+	base.Asset
+	Trustor     string   `json:"trustor"`
+	SetFlags    []int    `json:"set_flags,omitempty"`
+	SetFlagsS   []string `json:"set_flags_s,omitempty"`
+	ClearFlags  []int    `json:"clear_flags,omitempty"`
+	ClearFlagsS []string `json:"clear_flags_s,omitempty"`
 }
 
 // Operation interface contains methods implemented by the operation types
@@ -480,6 +493,12 @@ func UnmarshalOperation(operationTypeID int32, dataString []byte) (ops Operation
 		ops = op
 	case xdr.OperationTypeClawbackClaimableBalance:
 		var op ClawbackClaimableBalance
+		if err = json.Unmarshal(dataString, &op); err != nil {
+			return
+		}
+		ops = op
+	case xdr.OperationTypeSetTrustLineFlags:
+		var op SetTrustLineFlags
 		if err = json.Unmarshal(dataString, &op); err != nil {
 			return
 		}

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -88,6 +88,10 @@ const (
 	// to true and it authorizes another account's trustline to maintain liabilities
 	EffectTrustlineAuthorizedToMaintainLiabilities EffectType = 25 // from allow_trust
 
+	// EffectTrustlineFlagsUpdated effects occur when a TrustLine changes its
+	// flags, either clearing or setting.
+	EffectTrustlineFlagsUpdated EffectType = 26 // from set_trust_line flags
+
 	// trading effects
 
 	// EffectOfferCreated occurs when an account offers to trade an asset
@@ -179,10 +183,6 @@ const (
 
 	// EffectClaimableBalanceClawedBack occurs when a claimable balance is clawed back
 	EffectClaimableBalanceClawedBack EffectType = 80 // from clawback_claimable_balance
-
-	// EffectTrustlineFlagsUpdated effects occur when a TrustLine changes its
-	// flags, either clearing or setting.
-	EffectTrustlineFlagsUpdated EffectType = 81 // from set_trust_line flags
 )
 
 // Account is a row of data from the `history_accounts` table

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -73,21 +73,20 @@ const (
 	// EffectTrustlineUpdated occurs when an account changes a trustline's limit
 	EffectTrustlineUpdated EffectType = 22 // from change_trust, allow_trust
 
+	// Deprecated: use EffectTrustlineFlagsUpdated instead.
 	// EffectTrustlineAuthorized occurs when an anchor has AUTH_REQUIRED flag set
 	// to true and it authorizes another account's trustline
 	EffectTrustlineAuthorized EffectType = 23 // from allow_trust
 
+	// Deprecated: use EffectTrustlineFlagsUpdated instead.
 	// EffectTrustlineDeauthorized occurs when an anchor revokes access to a asset
 	// it issues.
 	EffectTrustlineDeauthorized EffectType = 24 // from allow_trust
 
+	// Deprecated: use EffectTrustlineFlagsUpdated instead.
 	// EffectTrustlineAuthorizedToMaintainLiabilities occurs when an anchor has AUTH_REQUIRED flag set
 	// to true and it authorizes another account's trustline to maintain liabilities
 	EffectTrustlineAuthorizedToMaintainLiabilities EffectType = 25 // from allow_trust
-
-	// EffectTrustlineClawbackEnabled occurs when an anchor has AUTH_CLAWBACK_ENABLED flag set
-	// to true and creates and asset
-	EffectTrustlineClawbackEnabled EffectType = 26 // from allow_trust
 
 	// trading effects
 
@@ -95,7 +94,7 @@ const (
 	EffectOfferCreated EffectType = 30 // from manage_offer, creat_passive_offer
 
 	// EffectOfferRemoved occurs when an account removes an offer
-	EffectOfferRemoved EffectType = 31 // from manage_offer, creat_passive_offer, path_payment
+	EffectOfferRemoved EffectType = 31 // from manage_offer, create_passive_offer, path_payment
 
 	// EffectOfferUpdated occurs when an offer is updated by the offering account.
 	EffectOfferUpdated EffectType = 32 // from manage_offer, creat_passive_offer, path_payment
@@ -180,6 +179,10 @@ const (
 
 	// EffectClaimableBalanceClawedBack occurs when a claimable balance is clawed back
 	EffectClaimableBalanceClawedBack EffectType = 80 // from clawback_claimable_balance
+
+	// EffectTrustlineFlagsUpdated effects occur when a TrustLine changes its
+	// flags, either clearing or setting.
+	EffectTrustlineFlagsUpdated EffectType = 81 // from set_trust_line flags
 )
 
 // Account is a row of data from the `history_accounts` table

--- a/services/horizon/internal/ingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/ingest/processors/effects_processor_test.go
@@ -1247,6 +1247,19 @@ func TestOperationEffects(t *testing.T) {
 						"asset_issuer": "GD4SMOE3VPSF7ZR3CTEQ3P5UNTBMEJDA2GLXTHR7MMARANKKJDZ7RPGF",
 					},
 				},
+				{
+					address:     "GD4SMOE3VPSF7ZR3CTEQ3P5UNTBMEJDA2GLXTHR7MMARANKKJDZ7RPGF",
+					effectType:  history.EffectTrustlineFlagsUpdated,
+					order:       uint32(2),
+					operationID: int64(176093663233),
+					details: map[string]interface{}{
+						"asset_code":      "USD",
+						"asset_issuer":    "GD4SMOE3VPSF7ZR3CTEQ3P5UNTBMEJDA2GLXTHR7MMARANKKJDZ7RPGF",
+						"asset_type":      "credit_alphanum4",
+						"authorized_flag": true,
+						"trustor":         "GCVW5LCRZFP7PENXTAGOVIQXADDNUXXZJCNKF4VQB2IK7W2LPJWF73UG",
+					},
+				},
 			},
 		},
 		{
@@ -1814,6 +1827,19 @@ func TestOperationEffectsAllowTrustAuthorizedToMaintainLiabilities(t *testing.T)
 			effectType: history.EffectTrustlineAuthorizedToMaintainLiabilities,
 			order:      uint32(1),
 		},
+		{
+			address:     "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+			operationID: int64(4294967297),
+			details: map[string]interface{}{
+				"asset_code":                        "COP",
+				"asset_issuer":                      "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+				"asset_type":                        "credit_alphanum4",
+				"authorized_to_maintain_liabilites": true,
+				"trustor":                           "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3",
+			},
+			effectType: history.EffectTrustlineFlagsUpdated,
+			order:      uint32(2),
+		},
 	}
 	tt.Equal(expected, effects)
 }
@@ -1920,6 +1946,61 @@ func TestOperationEffectsClawbackClaimableBalance(t *testing.T) {
 				"balance_id": "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
 			},
 			effectType: history.EffectClaimableBalanceClawedBack,
+			order:      uint32(1),
+		},
+	}
+	tt.Equal(expected, effects)
+}
+
+func TestOperationEffectsSetTrustLineFlags(t *testing.T) {
+	tt := assert.New(t)
+	aid := xdr.MustAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD")
+	source := aid.ToMuxedAccount()
+	trustor := xdr.MustAddress("GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY")
+	setFlags := xdr.Uint32(xdr.TrustLineFlagsAuthorizedToMaintainLiabilitiesFlag)
+	clearFlags := xdr.Uint32(xdr.TrustLineFlagsTrustlineClawbackEnabledFlag | xdr.TrustLineFlagsAuthorizedFlag)
+	op := xdr.Operation{
+		SourceAccount: &source,
+		Body: xdr.OperationBody{
+			Type: xdr.OperationTypeSetTrustLineFlags,
+			SetTrustLineFlagsOp: &xdr.SetTrustLineFlagsOp{
+				Trustor:    trustor,
+				Asset:      xdr.MustNewAssetCodeFromString("USD"),
+				ClearFlags: &clearFlags,
+				SetFlags:   &setFlags,
+			},
+		},
+	}
+
+	operation := transactionOperationWrapper{
+		index: 0,
+		transaction: ingest.LedgerTransaction{
+			Meta: xdr.TransactionMeta{
+				V:  2,
+				V2: &xdr.TransactionMetaV2{},
+			},
+		},
+		operation:      op,
+		ledgerSequence: 1,
+	}
+
+	effects, err := operation.effects()
+	tt.NoError(err)
+
+	expected := []effect{
+		{
+			address:     "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+			operationID: 4294967297,
+			details: map[string]interface{}{
+				"asset_code":                        "USD",
+				"asset_issuer":                      "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+				"asset_type":                        "credit_alphanum4",
+				"authorized_flag":                   false,
+				"authorized_to_maintain_liabilites": true,
+				"clawback_enabled_flag":             false,
+				"trustor":                           "GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+			},
+			effectType: history.EffectTrustlineFlagsUpdated,
 			order:      uint32(1),
 		},
 	}

--- a/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
+++ b/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
@@ -1316,7 +1316,7 @@ func (s *ClaimClaimableBalanceOpTestSuite) TestParticipants() {
 
 	participants, err := operation.Participants()
 	s.Assert().NoError(err)
-	s.Assert().Equal([]xdr.AccountId{
+	s.Assert().ElementsMatch([]xdr.AccountId{
 		xdr.MustAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
 	}, participants)
 }
@@ -1465,4 +1465,86 @@ func TestSponsoredSandwichTransaction_Participants(t *testing.T) {
 		},
 		participants,
 	)
+}
+
+type SetTrustLineFlagsTestSuite struct {
+	suite.Suite
+	op        xdr.Operation
+	balanceID string
+}
+
+func (s *SetTrustLineFlagsTestSuite) SetupTest() {
+	aid := xdr.MustAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD")
+	source := aid.ToMuxedAccount()
+	trustor := xdr.MustAddress("GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY")
+	setFlags := xdr.Uint32(xdr.TrustLineFlagsAuthorizedToMaintainLiabilitiesFlag)
+	clearFlags := xdr.Uint32(xdr.TrustLineFlagsTrustlineClawbackEnabledFlag | xdr.TrustLineFlagsAuthorizedFlag)
+	s.op = xdr.Operation{
+		SourceAccount: &source,
+		Body: xdr.OperationBody{
+			Type: xdr.OperationTypeSetTrustLineFlags,
+			SetTrustLineFlagsOp: &xdr.SetTrustLineFlagsOp{
+				Trustor:    trustor,
+				Asset:      xdr.MustNewAssetCodeFromString("USD"),
+				ClearFlags: &clearFlags,
+				SetFlags:   &setFlags,
+			},
+		},
+	}
+}
+func (s *SetTrustLineFlagsTestSuite) TestDetails() {
+	expected := map[string]interface{}{
+		"asset_code":    "USD",
+		"asset_issuer":  "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+		"asset_type":    "credit_alphanum4",
+		"clear_flags":   []int32{1, 4},
+		"clear_flags_s": []string{"authorized", "clawback_enabled"},
+		"set_flags":     []int32{2},
+		"set_flags_s":   []string{"authorized_to_maintain_liabilites"},
+		"trustor":       "GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+	}
+
+	operation := transactionOperationWrapper{
+		index: 0,
+		transaction: ingest.LedgerTransaction{
+			Meta: xdr.TransactionMeta{
+				V: 2,
+				V2: &xdr.TransactionMetaV2{
+					Operations: make([]xdr.OperationMeta, 1, 1),
+				},
+			}},
+		operation:      s.op,
+		ledgerSequence: 1,
+	}
+
+	details, err := operation.Details()
+	s.Assert().NoError(err)
+	s.Assert().Equal(expected, details)
+}
+
+func (s *SetTrustLineFlagsTestSuite) TestParticipants() {
+	operation := transactionOperationWrapper{
+		index: 0,
+		transaction: ingest.LedgerTransaction{
+			Meta: xdr.TransactionMeta{
+				V: 2,
+				V2: &xdr.TransactionMetaV2{
+					Operations: make([]xdr.OperationMeta, 1, 1),
+				},
+			},
+		},
+		operation:      s.op,
+		ledgerSequence: 1,
+	}
+
+	participants, err := operation.Participants()
+	s.Assert().NoError(err)
+	s.Assert().ElementsMatch([]xdr.AccountId{
+		xdr.MustAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
+		xdr.MustAddress("GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY"),
+	}, participants)
+}
+
+func TestSetTrustLineFlagsTestSuite(t *testing.T) {
+	suite.Run(t, new(SetTrustLineFlagsTestSuite))
 }

--- a/services/horizon/internal/resourceadapter/effects.go
+++ b/services/horizon/internal/resourceadapter/effects.go
@@ -55,6 +55,7 @@ var EffectTypeNames = map[history.EffectType]string{
 	history.EffectSignerSponsorshipUpdated:                 "signer_sponsorship_updated",
 	history.EffectSignerSponsorshipRemoved:                 "signer_sponsorship_removed",
 	history.EffectClaimableBalanceClawedBack:               "claimable_balance_clawed_back",
+	history.EffectTrustlineFlagsUpdated:                    "trustline_flags_updated",
 }
 
 // NewEffect creates a new effect resource from the provided database representation
@@ -240,6 +241,10 @@ func NewEffect(
 		result = e
 	case history.EffectClaimableBalanceClawedBack:
 		e := effects.ClaimableBalanceClawedBack{Base: basev}
+		err = row.UnmarshalDetails(&e)
+		result = e
+	case history.EffectTrustlineFlagsUpdated:
+		e := effects.TrustlineFlagsUpdated{Base: basev}
 		err = row.UnmarshalDetails(&e)
 		result = e
 	default:

--- a/services/horizon/internal/resourceadapter/effects.go
+++ b/services/horizon/internal/resourceadapter/effects.go
@@ -28,6 +28,7 @@ var EffectTypeNames = map[history.EffectType]string{
 	history.EffectTrustlineAuthorized:                      "trustline_authorized",
 	history.EffectTrustlineAuthorizedToMaintainLiabilities: "trustline_authorized_to_maintain_liabilities",
 	history.EffectTrustlineDeauthorized:                    "trustline_deauthorized",
+	history.EffectTrustlineFlagsUpdated:                    "trustline_flags_updated",
 	history.EffectOfferCreated:                             "offer_created",
 	history.EffectOfferRemoved:                             "offer_removed",
 	history.EffectOfferUpdated:                             "offer_updated",
@@ -55,7 +56,6 @@ var EffectTypeNames = map[history.EffectType]string{
 	history.EffectSignerSponsorshipUpdated:                 "signer_sponsorship_updated",
 	history.EffectSignerSponsorshipRemoved:                 "signer_sponsorship_removed",
 	history.EffectClaimableBalanceClawedBack:               "claimable_balance_clawed_back",
-	history.EffectTrustlineFlagsUpdated:                    "trustline_flags_updated",
 }
 
 // NewEffect creates a new effect resource from the provided database representation
@@ -128,6 +128,10 @@ func NewEffect(
 		result = e
 	case history.EffectTrustlineDeauthorized:
 		e := effects.TrustlineDeauthorized{Base: basev}
+		err = row.UnmarshalDetails(&e)
+		result = e
+	case history.EffectTrustlineFlagsUpdated:
+		e := effects.TrustlineFlagsUpdated{Base: basev}
 		err = row.UnmarshalDetails(&e)
 		result = e
 	case history.EffectTrade:
@@ -241,10 +245,6 @@ func NewEffect(
 		result = e
 	case history.EffectClaimableBalanceClawedBack:
 		e := effects.ClaimableBalanceClawedBack{Base: basev}
-		err = row.UnmarshalDetails(&e)
-		result = e
-	case history.EffectTrustlineFlagsUpdated:
-		e := effects.TrustlineFlagsUpdated{Base: basev}
 		err = row.UnmarshalDetails(&e)
 		result = e
 	default:

--- a/services/horizon/internal/resourceadapter/operations.go
+++ b/services/horizon/internal/resourceadapter/operations.go
@@ -136,6 +136,10 @@ func NewOperation(
 		e := operations.ClawbackClaimableBalance{Base: base}
 		err = operationRow.UnmarshalDetails(&e)
 		result = e
+	case xdr.OperationTypeSetTrustLineFlags:
+		e := operations.SetTrustLineFlags{Base: base}
+		err = operationRow.UnmarshalDetails(&e)
+		result = e
 	default:
 		result = base
 	}

--- a/txnbuild/allow_trust.go
+++ b/txnbuild/allow_trust.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
+// Deprecated: use SetTrustLineFlags instead.
 // AllowTrust represents the Stellar allow trust operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type AllowTrust struct {
@@ -15,7 +16,6 @@ type AllowTrust struct {
 	Type                           Asset
 	Authorize                      bool
 	AuthorizeToMaintainLiabilities bool
-	ClawbackEnabled                bool
 	SourceAccount                  Account
 }
 
@@ -47,9 +47,6 @@ func (at *AllowTrust) BuildXDR() (xdr.Operation, error) {
 		xdrOp.Authorize = xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag)
 	} else if at.AuthorizeToMaintainLiabilities {
 		xdrOp.Authorize = xdr.Uint32(xdr.TrustLineFlagsAuthorizedToMaintainLiabilitiesFlag)
-	}
-	if at.ClawbackEnabled {
-		xdrOp.Authorize |= xdr.Uint32(xdr.TrustLineFlagsTrustlineClawbackEnabledFlag)
 	}
 
 	opType := xdr.OperationTypeAllowTrust
@@ -88,7 +85,6 @@ func (at *AllowTrust) FromXDR(xdrOp xdr.Operation) error {
 	flag := xdr.TrustLineFlags(result.Authorize)
 	at.Authorize = flag.IsAuthorized()
 	at.AuthorizeToMaintainLiabilities = flag.IsAuthorizedToMaintainLiabilitiesFlag()
-	at.ClawbackEnabled = flag.IsClawbackEnabledFlag()
 	t, err := assetCodeToCreditAsset(result.Asset)
 	if err != nil {
 		return errors.Wrap(err, "error parsing allow_trust operation from xdr")

--- a/txnbuild/operation.go
+++ b/txnbuild/operation.go
@@ -1,6 +1,8 @@
 package txnbuild
 
 import (
+	"fmt"
+
 	"github.com/stellar/go/xdr"
 )
 
@@ -64,6 +66,12 @@ func operationFromXDR(xdrOp xdr.Operation) (Operation, error) {
 		newOp = &ClaimClaimableBalance{}
 	case xdr.OperationTypeRevokeSponsorship:
 		newOp = &RevokeSponsorship{}
+	case xdr.OperationTypeClawback:
+		newOp = &Clawback{}
+	case xdr.OperationTypeSetTrustLineFlags:
+		newOp = &SetTrustLineFlags{}
+	default:
+		return nil, fmt.Errorf("unknown operation type: %d", xdrOp.Body.Type)
 	}
 
 	err := newOp.FromXDR(xdrOp)

--- a/txnbuild/set_trustline_flags_test.go
+++ b/txnbuild/set_trustline_flags_test.go
@@ -1,0 +1,96 @@
+package txnbuild
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/go/xdr"
+)
+
+func TestSetTrustLineFlags(t *testing.T) {
+	asset := CreditAsset{"ABCD", ""}
+	source := &SimpleAccount{
+		AccountID: "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU",
+	}
+	trustor := "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z"
+	for _, testcase := range []struct {
+		name string
+		op   SetTrustLineFlags
+	}{
+		{
+			name: "Both set and clear",
+			op: SetTrustLineFlags{
+				Trustor:       trustor,
+				Asset:         asset,
+				SetFlags:      []TrustLineFlag{TrustLineClawbackEnabled},
+				ClearFlags:    []TrustLineFlag{TrustLineAuthorized, TrustLineAuthorizedToMaintainLiabilities},
+				SourceAccount: source,
+			},
+		},
+		{
+			name: "Both set and clear 2",
+			op: SetTrustLineFlags{
+				Trustor:       trustor,
+				Asset:         asset,
+				SetFlags:      []TrustLineFlag{TrustLineAuthorized, TrustLineAuthorizedToMaintainLiabilities},
+				ClearFlags:    []TrustLineFlag{TrustLineClawbackEnabled},
+				SourceAccount: source,
+			},
+		},
+		{
+			name: "Only set",
+			op: SetTrustLineFlags{
+				Trustor:       trustor,
+				Asset:         asset,
+				SetFlags:      []TrustLineFlag{TrustLineClawbackEnabled},
+				ClearFlags:    nil,
+				SourceAccount: source,
+			},
+		},
+		{
+			name: "Only clear",
+			op: SetTrustLineFlags{
+				Trustor:       trustor,
+				Asset:         asset,
+				SetFlags:      nil,
+				ClearFlags:    []TrustLineFlag{TrustLineClawbackEnabled},
+				SourceAccount: source,
+			},
+		},
+		{
+			name: "No set nor clear",
+			op: SetTrustLineFlags{
+				Trustor:       trustor,
+				Asset:         asset,
+				SetFlags:      nil,
+				ClearFlags:    nil,
+				SourceAccount: source,
+			},
+		},
+		{
+			name: "No source",
+			op: SetTrustLineFlags{
+				Trustor:    trustor,
+				Asset:      asset,
+				SetFlags:   []TrustLineFlag{TrustLineClawbackEnabled},
+				ClearFlags: []TrustLineFlag{TrustLineAuthorized, TrustLineAuthorizedToMaintainLiabilities},
+			},
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			op := testcase.op
+			assert.NoError(t, op.Validate())
+			xdrOp, err := op.BuildXDR()
+			assert.NoError(t, err)
+			xdrBin, err := xdrOp.MarshalBinary()
+			assert.NoError(t, err)
+			var xdrOp2 xdr.Operation
+			assert.NoError(t, xdr.SafeUnmarshal(xdrBin, &xdrOp2))
+			var op2 SetTrustLineFlags
+			assert.NoError(t, op2.FromXDR(xdrOp2))
+			assert.Equal(t, op, op2)
+			roundTrip(t, []Operation{&testcase.op})
+		})
+	}
+}

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -8574,13 +8574,14 @@ var (
 type OperationType int32
 
 const (
-	OperationTypeCreateAccount                 OperationType = 0
-	OperationTypePayment                       OperationType = 1
-	OperationTypePathPaymentStrictReceive      OperationType = 2
-	OperationTypeManageSellOffer               OperationType = 3
-	OperationTypeCreatePassiveSellOffer        OperationType = 4
-	OperationTypeSetOptions                    OperationType = 5
-	OperationTypeChangeTrust                   OperationType = 6
+	OperationTypeCreateAccount            OperationType = 0
+	OperationTypePayment                  OperationType = 1
+	OperationTypePathPaymentStrictReceive OperationType = 2
+	OperationTypeManageSellOffer          OperationType = 3
+	OperationTypeCreatePassiveSellOffer   OperationType = 4
+	OperationTypeSetOptions               OperationType = 5
+	OperationTypeChangeTrust              OperationType = 6
+	// Deprecated: use OperationTypeSetTrustLineFlags
 	OperationTypeAllowTrust                    OperationType = 7
 	OperationTypeAccountMerge                  OperationType = 8
 	OperationTypeInflation                     OperationType = 9
@@ -9003,6 +9004,7 @@ var (
 	_ encoding.BinaryUnmarshaler = (*ChangeTrustOp)(nil)
 )
 
+// Deprecated: use OperationTypeSetTrustLineFlags.
 // AllowTrustOp is an XDR Struct defines as:
 //
 //   struct AllowTrustOp


### PR DESCRIPTION
`SetTrustLineFlags` superseeds `AllowTrust` operation, which is now deprecated.

`SetTrustLineFlags` emits a new effect: `EffectTrustlineFlagsUpdated`, which is very similar to the
pre-existing `EffectAccountFlagsUpdated`.

The effects emitted by `AllowTrust` (`EffectTrustlineAuthorized`, `EffectTrustlineAuthorizedToMaintainLiabilities` and
`EffectTrustlineDeauthorized`) are now deprecated. `AllowTrust` will keep emitting them for now.

In addition`AllowTrust` will start emitting `EffectAccountFlagsUpdated`, so that users don't have to parse both sets of effects. Note that the contrary isn't true, `SetTrustLineFlags` won't emit `EffectTrustlineAuthorized`, `EffectTrustlineAuthorizedToMaintainLiabilities` nor `EffectTrustlineDeauthorized`.

Part of #3348 