### PR TITLE
[CAP 35] Finish SDK support for CAP35

### DIFF
--- a/txnbuild/allow_trust.go
+++ b/txnbuild/allow_trust.go
@@ -102,7 +102,7 @@ func (at *AllowTrust) Validate() error {
 		return NewValidationError("Trustor", err.Error())
 	}
 
-	err = validateAllowTrustAsset(at.Type)
+	err = validateAssetCode(at.Type)
 	if err != nil {
 		return NewValidationError("Type", err.Error())
 	}

--- a/txnbuild/begin_sponsoring_future_reserves_test.go
+++ b/txnbuild/begin_sponsoring_future_reserves_test.go
@@ -1,44 +1,13 @@
 package txnbuild
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 )
-
-func roundTrip(t *testing.T, operations []Operation) {
-	kp1 := newKeypair1()
-	sourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
-
-	tx, err := NewTransaction(
-		TransactionParams{
-			SourceAccount: &sourceAccount,
-			Operations:    operations,
-			Timebounds:    NewInfiniteTimeout(),
-			BaseFee:       MinBaseFee,
-		},
-	)
-	assert.NoError(t, err)
-
-	var b64 string
-	b64, err = tx.Base64()
-	assert.NoError(t, err)
-
-	var parsedTx *GenericTransaction
-	parsedTx, err = TransactionFromXDR(b64)
-	assert.NoError(t, err)
-	var ok bool
-	tx, ok = parsedTx.Transaction()
-	assert.True(t, ok)
-
-	for i := 0; i < len(operations); i++ {
-		assert.Equal(t, operations[i], tx.Operations()[i])
-	}
-}
 
 func TestBeginSponsoringFutureReservesRoundTrip(t *testing.T) {
 	beginSponsoring := &BeginSponsoringFutureReserves{
 		SponsoredID: newKeypair1().Address(),
 	}
 
-	roundTrip(t, []Operation{beginSponsoring})
+	testOperationsMarshallingRoundtrip(t, []Operation{beginSponsoring})
 }

--- a/txnbuild/clawback.go
+++ b/txnbuild/clawback.go
@@ -94,7 +94,7 @@ func (cb *Clawback) Validate() error {
 		return NewValidationError("Amount", err.Error())
 	}
 
-	err = validateStellarAsset(cb.Asset)
+	err = validateAssetCode(cb.Asset)
 	if err != nil {
 		return NewValidationError("Asset", err.Error())
 	}

--- a/txnbuild/clawback_claimable_balance.go
+++ b/txnbuild/clawback_claimable_balance.go
@@ -1,0 +1,70 @@
+//lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+package txnbuild
+
+import (
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+// ClawbackClaimableBalance represents the Stellar clawback claimable balance operation. See
+// https://www.stellar.org/developers/guides/concepts/list-of-operations.html
+type ClawbackClaimableBalance struct {
+	BalanceID     string
+	SourceAccount Account
+}
+
+// BuildXDR for ClawbackClaimableBalance returns a fully configured XDR Operation.
+func (cb *ClawbackClaimableBalance) BuildXDR() (xdr.Operation, error) {
+	var xdrBalanceID xdr.ClaimableBalanceId
+	err := xdr.SafeUnmarshalHex(cb.BalanceID, &xdrBalanceID)
+	if err != nil {
+		return xdr.Operation{}, errors.Wrap(err, "failed to set XDR 'ClaimableBalanceId' field")
+	}
+	xdrOp := xdr.ClawbackClaimableBalanceOp{
+		BalanceId: xdrBalanceID,
+	}
+
+	opType := xdr.OperationTypeClawbackClaimableBalance
+	body, err := xdr.NewOperationBody(opType, xdrOp)
+	if err != nil {
+		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
+	}
+	op := xdr.Operation{Body: body}
+	SetOpSourceAccount(&op, cb.SourceAccount)
+	return op, nil
+}
+
+// FromXDR for ClawbackClaimableBalance initializes the txnbuild struct from the corresponding xdr Operation.
+func (cb *ClawbackClaimableBalance) FromXDR(xdrOp xdr.Operation) error {
+	result, ok := xdrOp.Body.GetClawbackClaimableBalanceOp()
+	if !ok {
+		return errors.New("error parsing clawback_claimable_balance operation from xdr")
+	}
+
+	cb.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	balanceID, err := xdr.MarshalHex(result.BalanceId)
+	if err != nil {
+		return errors.New("error parsing BalanceID in claim_claimable_balance operation from xdr")
+	}
+	cb.BalanceID = balanceID
+
+	return nil
+}
+
+// Validate for ClawbackClaimableBalance validates the required struct fields. It returns an error if any of the fields are
+// invalid. Otherwise, it returns nil.
+func (cb *ClawbackClaimableBalance) Validate() error {
+	var xdrBalanceID xdr.ClaimableBalanceId
+	err := xdr.SafeUnmarshalHex(cb.BalanceID, &xdrBalanceID)
+	if err != nil {
+		return NewValidationError("BalanceID", err.Error())
+	}
+
+	return nil
+}
+
+// GetSourceAccount returns the source account of the operation, or nil if not
+// set.
+func (cb *ClawbackClaimableBalance) GetSourceAccount() Account {
+	return cb.SourceAccount
+}

--- a/txnbuild/clawback_claimable_balance_test.go
+++ b/txnbuild/clawback_claimable_balance_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 )
 
-func TestClaimClaimableBalanceRoundTrip(t *testing.T) {
-	claimClaimableBalance := &ClaimClaimableBalance{
+func TestClawbackClaimableBalanceRoundTrip(t *testing.T) {
+	claimClaimableBalance := &ClawbackClaimableBalance{
 		BalanceID: "00000000929b20b72e5890ab51c24f1cc46fa01c4f318d8d33367d24dd614cfdf5491072",
 	}
 

--- a/txnbuild/clawback_test.go
+++ b/txnbuild/clawback_test.go
@@ -35,7 +35,7 @@ func TestClawbackValidateAmount(t *testing.T) {
 	kp0 := newKeypair0()
 	sourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
-	payment := Clawback{
+	clawback := Clawback{
 		From:   "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
 		Amount: "ten",
 		Asset:  CreditAsset{"", kp0.Address()},
@@ -45,7 +45,7 @@ func TestClawbackValidateAmount(t *testing.T) {
 		TransactionParams{
 			SourceAccount:        &sourceAccount,
 			IncrementSequenceNum: false,
-			Operations:           []Operation{&payment},
+			Operations:           []Operation{&clawback},
 			BaseFee:              MinBaseFee,
 			Timebounds:           NewInfiniteTimeout(),
 		},
@@ -60,7 +60,7 @@ func TestClawbackValidateAsset(t *testing.T) {
 	kp0 := newKeypair0()
 	sourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
-	payment := Clawback{
+	clawback := Clawback{
 		From:   "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
 		Amount: "10",
 		Asset:  CreditAsset{},
@@ -70,7 +70,7 @@ func TestClawbackValidateAsset(t *testing.T) {
 		TransactionParams{
 			SourceAccount:        &sourceAccount,
 			IncrementSequenceNum: false,
-			Operations:           []Operation{&payment},
+			Operations:           []Operation{&clawback},
 			BaseFee:              MinBaseFee,
 			Timebounds:           NewInfiniteTimeout(),
 		},
@@ -79,4 +79,14 @@ func TestClawbackValidateAsset(t *testing.T) {
 		expected := "validation failed for *txnbuild.Clawback operation: Field: Asset, Error: asset code length must be between 1 and 12 characters"
 		assert.Contains(t, err.Error(), expected)
 	}
+}
+
+func TestClawbackRoundTrip(t *testing.T) {
+	clawback := Clawback{
+		From:   "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
+		Amount: "10.0000000",
+		Asset:  CreditAsset{"USD", ""},
+	}
+
+	testOperationsMarshallingRoundtrip(t, []Operation{&clawback})
 }

--- a/txnbuild/create_claimable_balance_test.go
+++ b/txnbuild/create_claimable_balance_test.go
@@ -29,5 +29,5 @@ func TestCreateClaimableBalanceRoundTrip(t *testing.T) {
 		},
 	}
 
-	roundTrip(t, []Operation{createNativeBalance, createAssetBalance})
+	testOperationsMarshallingRoundtrip(t, []Operation{createNativeBalance, createAssetBalance})
 }

--- a/txnbuild/end_sponsoring_future_reserves_test.go
+++ b/txnbuild/end_sponsoring_future_reserves_test.go
@@ -3,5 +3,5 @@ package txnbuild
 import "testing"
 
 func TestEndSponsoringFutureReservesRoundTrip(t *testing.T) {
-	roundTrip(t, []Operation{&EndSponsoringFutureReserves{}})
+	testOperationsMarshallingRoundtrip(t, []Operation{&EndSponsoringFutureReserves{}})
 }

--- a/txnbuild/helpers.go
+++ b/txnbuild/helpers.go
@@ -84,10 +84,10 @@ func validateAmount(n interface{}) error {
 	return nil
 }
 
-// validateAllowTrustAsset checks if the provided asset is valid for use in AllowTrust operation.
+// validateAssetCode checks if the provided asset is valid as an asset code.
 // It returns an error if the asset is invalid.
 // The asset must be non native (XLM) with a valid asset code.
-func validateAllowTrustAsset(asset Asset) error {
+func validateAssetCode(asset Asset) error {
 	// Note: we are not using validateStellarAsset() function for AllowTrust operations because it requires the
 	//  following :
 	// - asset is non-native
@@ -117,7 +117,7 @@ func validateChangeTrustAsset(asset Asset) error {
 	// - asset is non-native
 	// - asset code is valid
 	// - asset issuer is valid
-	err := validateAllowTrustAsset(asset)
+	err := validateAssetCode(asset)
 	if err != nil {
 		return err
 	}

--- a/txnbuild/helpers_test.go
+++ b/txnbuild/helpers_test.go
@@ -206,19 +206,19 @@ func TestValidateAmountInvalidValue(t *testing.T) {
 }
 
 func TestValidateAllowTrustAsset(t *testing.T) {
-	err := validateAllowTrustAsset(nil)
+	err := validateAssetCode(nil)
 	assert.Error(t, err)
 	expectedErrMsg := "asset is undefined"
 	require.EqualError(t, err, expectedErrMsg, "An asset is required")
 
-	err = validateAllowTrustAsset(NativeAsset{})
+	err = validateAssetCode(NativeAsset{})
 	assert.Error(t, err)
 	expectedErrMsg = "native (XLM) asset type is not allowed"
 	require.EqualError(t, err, expectedErrMsg, "An asset is required")
 
 	// allow trust asset does not require asset issuer
 	atAsset := CreditAsset{Code: "ABCD"}
-	err = validateAllowTrustAsset(atAsset)
+	err = validateAssetCode(atAsset)
 	assert.NoError(t, err)
 }
 

--- a/txnbuild/operation.go
+++ b/txnbuild/operation.go
@@ -68,6 +68,8 @@ func operationFromXDR(xdrOp xdr.Operation) (Operation, error) {
 		newOp = &RevokeSponsorship{}
 	case xdr.OperationTypeClawback:
 		newOp = &Clawback{}
+	case xdr.OperationTypeClawbackClaimableBalance:
+		newOp = &ClawbackClaimableBalance{}
 	case xdr.OperationTypeSetTrustLineFlags:
 		newOp = &SetTrustLineFlags{}
 	default:

--- a/txnbuild/revoke_sponsorship_test.go
+++ b/txnbuild/revoke_sponsorship_test.go
@@ -102,7 +102,7 @@ func TestRevokeSponsorship(t *testing.T) {
 			var op2 RevokeSponsorship
 			assert.NoError(t, op2.FromXDR(xdrOp2))
 			assert.Equal(t, op, op2)
-			roundTrip(t, []Operation{&testcase.op})
+			testOperationsMarshallingRoundtrip(t, []Operation{&testcase.op})
 		})
 	}
 }

--- a/txnbuild/set_trust_line_flags.go
+++ b/txnbuild/set_trust_line_flags.go
@@ -119,7 +119,7 @@ func (stf *SetTrustLineFlags) Validate() error {
 		return NewValidationError("Trustor", err.Error())
 	}
 
-	err = validateAllowTrustAsset(stf.Asset)
+	err = validateAssetCode(stf.Asset)
 	if err != nil {
 		return NewValidationError("Asset", err.Error())
 	}

--- a/txnbuild/set_trustline_flags_test.go
+++ b/txnbuild/set_trustline_flags_test.go
@@ -90,7 +90,7 @@ func TestSetTrustLineFlags(t *testing.T) {
 			var op2 SetTrustLineFlags
 			assert.NoError(t, op2.FromXDR(xdrOp2))
 			assert.Equal(t, op, op2)
-			roundTrip(t, []Operation{&testcase.op})
+			testOperationsMarshallingRoundtrip(t, []Operation{&testcase.op})
 		})
 	}
 }


### PR DESCRIPTION
* Add support for the ClawbackClaimableBalance Operation
* Improve testing (and fix a bug) for the Clawback Operation
* Rename `validateAllowTrustAsset` to `validateAssetCode`
* Move the `roundTrip` testing function to a common file and give it the more descriptive name `testOperationsMarshallingRoundtrip`

Part of #3348 