### PR TITLE
Update golang to 1.14.14 and 1.15.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,7 +244,7 @@ jobs:
   check_code_1_15:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.15
+      - image: golang:1.15.7
     steps:
       - install_go_deps
       - check_go_deps
@@ -258,7 +258,7 @@ jobs:
   test_code_1_14:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.14-stretch
+      - image: golang:1.14.14-stretch
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -278,7 +278,7 @@ jobs:
   test_code_1_14_postgres10:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.14-stretch
+      - image: golang:1.14.14-stretch
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -299,7 +299,7 @@ jobs:
   test_code_1_15:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.15
+      - image: golang:1.15.7
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -319,7 +319,7 @@ jobs:
   test_code_1_15_postgres10:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.15
+      - image: golang:1.15.7
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -388,7 +388,7 @@ jobs:
       # Artifacts are built on Go 1.14 because a Go 1.15 Docker image for
       # Debian Stretch is currently not available. See
       # https://github.com/docker-library/golang/issues/344.
-      - image: golang:1.14-stretch
+      - image: golang:1.14.14-stretch
     steps:
       - check_deprecations
       - install_go_deps


### PR DESCRIPTION
Update golang to 1.14.14 and 1.15.7 because of CVE-2021-3115.

More information:
* https://groups.google.com/g/golang-announce/c/mperVMGa98w
* https://blog.golang.org/path-security