### PR TITLE
Add --pull flag to docker builds

### DIFF
--- a/exp/services/recoverysigner/Makefile
+++ b/exp/services/recoverysigner/Makefile
@@ -8,7 +8,7 @@ BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
 
 docker-build:
 	cd ../../../ && \
-	$(SUDO) docker build --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	$(SUDO) docker build --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
 	-f exp/services/recoverysigner/docker/Dockerfile -t $(TAG) .
 
 docker-push:

--- a/exp/services/webauth/Makefile
+++ b/exp/services/webauth/Makefile
@@ -8,7 +8,7 @@ BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
 
 docker-build:
 	cd ../../../ && \
-	$(SUDO) docker build --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	$(SUDO) docker build --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
 	-f exp/services/webauth/docker/Dockerfile -t $(TAG) .
 
 docker-push:

--- a/services/friendbot/Makefile
+++ b/services/friendbot/Makefile
@@ -8,7 +8,7 @@ BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
 
 docker-build:
 	cd ../../ && \
-	$(SUDO) docker build --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	$(SUDO) docker build --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
 	-f services/friendbot/docker/Dockerfile -t $(TAG) .
 
 docker-push:

--- a/services/keystore/Makefile
+++ b/services/keystore/Makefile
@@ -8,7 +8,7 @@ BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
 
 docker-build:
 	cd ../../ && \
-	$(SUDO) docker build --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	$(SUDO) docker build --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
 	-f services/keystore/docker/Dockerfile -t $(TAG) .
 
 docker-push:

--- a/services/ticker/Makefile
+++ b/services/ticker/Makefile
@@ -8,7 +8,7 @@ BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
 
 docker-build:
 	cd ../../ && \
-	$(SUDO) docker build --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	$(SUDO) docker build --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
 	-f services/ticker/docker/Dockerfile -t $(TAG) .
 
 docker-push:
@@ -16,5 +16,5 @@ docker-push:
 	$(SUDO) docker push $(TAG)
 
 docker-build-dev:
-	$(SUDO) docker build --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	$(SUDO) docker build --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
 	-f docker/Dockerfile-dev -t $(TAG) .


### PR DESCRIPTION
### What

Add --pull flag to docker builds

### Why

By default if images exist locally they are used for builds.
This change will ensure we always pull latest versions which ensures we get all security patches.