### PR TITLE
Add function to fetch ledgers from history archive

### DIFF
--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -71,7 +71,7 @@ type ArchiveInterface interface {
 	CategoryCheckpointExists(cat string, chk uint32) (bool, error)
 	GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, error)
 	GetRootHAS() (HistoryArchiveState, error)
-	GetLedgers(start, end uint32) (map[uint32]Ledger, error)
+	GetLedgers(start, end uint32) (map[uint32]*Ledger, error)
 	GetCheckpointHAS(chk uint32) (HistoryArchiveState, error)
 	PutCheckpointHAS(chk uint32, has HistoryArchiveState, opts *CommandOptions) error
 	PutRootHAS(has HistoryArchiveState, opts *CommandOptions) error
@@ -202,12 +202,12 @@ func (a *Archive) GetRootHAS() (HistoryArchiveState, error) {
 	return a.GetPathHAS(rootHASPath)
 }
 
-func (a *Archive) GetLedgers(start, end uint32) (map[uint32]Ledger, error) {
+func (a *Archive) GetLedgers(start, end uint32) (map[uint32]*Ledger, error) {
 	if start > end {
 		return nil, errors.Errorf("range is invalid, start: %d end: %d", start, end)
 	}
 	checkpointRange := a.GetCheckpointManager().MakeRange(start, end)
-	cache := map[uint32]Ledger{}
+	cache := map[uint32]*Ledger{}
 	for cur := checkpointRange.Low; cur <= checkpointRange.High; cur = a.GetCheckpointManager().NextCheckpoint(cur) {
 		for _, category := range []string{"ledgers", "transactions", "results"} {
 			if exists, err := a.CategoryCheckpointExists(category, cur); err != nil {
@@ -225,7 +225,7 @@ func (a *Archive) GetLedgers(start, end uint32) (map[uint32]Ledger, error) {
 	return cache, nil
 }
 
-func (a *Archive) fetchCategory(cache map[uint32]Ledger, category string, checkpointSequence uint32) error {
+func (a *Archive) fetchCategory(cache map[uint32]*Ledger, category string, checkpointSequence uint32) error {
 	checkpointPath := CategoryCheckpointPath(category, checkpointSequence)
 	xdrStream, err := a.GetXdrStream(checkpointPath)
 	if err != nil {
@@ -239,6 +239,9 @@ func (a *Archive) fetchCategory(cache map[uint32]Ledger, category string, checkp
 			var object xdr.LedgerHeaderHistoryEntry
 			if err = xdrStream.ReadOne(&object); err != nil {
 				entry := cache[uint32(object.Header.LedgerSeq)]
+				if entry == nil {
+					entry = &Ledger{}
+				}
 				entry.Header = object
 				cache[uint32(object.Header.LedgerSeq)] = entry
 			}
@@ -246,6 +249,9 @@ func (a *Archive) fetchCategory(cache map[uint32]Ledger, category string, checkp
 			var object xdr.TransactionHistoryEntry
 			if err = xdrStream.ReadOne(&object); err != nil {
 				entry := cache[uint32(object.LedgerSeq)]
+				if entry == nil {
+					entry = &Ledger{}
+				}
 				entry.Transaction = object
 				cache[uint32(object.LedgerSeq)] = entry
 			}
@@ -253,6 +259,9 @@ func (a *Archive) fetchCategory(cache map[uint32]Ledger, category string, checkp
 			var object xdr.TransactionHistoryResultEntry
 			if err = xdrStream.ReadOne(&object); err != nil {
 				entry := cache[uint32(object.LedgerSeq)]
+				if entry == nil {
+					entry = &Ledger{}
+				}
 				entry.TransactionResult = object
 				cache[uint32(object.LedgerSeq)] = entry
 			}

--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -65,6 +65,7 @@ type ArchiveInterface interface {
 	CategoryCheckpointExists(cat string, chk uint32) (bool, error)
 	GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, error)
 	GetRootHAS() (HistoryArchiveState, error)
+	GetLedgers(start, end uint32) (map[uint32]*xdr.LedgerCloseMeta, error)
 	GetCheckpointHAS(chk uint32) (HistoryArchiveState, error)
 	PutCheckpointHAS(chk uint32, has HistoryArchiveState, opts *CommandOptions) error
 	PutRootHAS(has HistoryArchiveState, opts *CommandOptions) error
@@ -193,6 +194,75 @@ func (a *Archive) GetLedgerHeader(ledger uint32) (xdr.LedgerHeaderHistoryEntry, 
 
 func (a *Archive) GetRootHAS() (HistoryArchiveState, error) {
 	return a.GetPathHAS(rootHASPath)
+}
+
+func (a *Archive) GetLedgers(start, end uint32) (map[uint32]*xdr.LedgerCloseMeta, error) {
+	if start > end {
+		return nil, errors.Errorf("range is invalid, start: %d end: %d", start, end)
+	}
+	checkpointRange := a.GetCheckpointManager().MakeRange(start, end)
+	cache := map[uint32]*xdr.LedgerCloseMeta{}
+	for cur := checkpointRange.Low; cur <= checkpointRange.High; cur = a.GetCheckpointManager().NextCheckpoint(cur) {
+		// ledger must be fetched first because it initializes LedgerCloseMeta for
+		// a given sequence.
+		for _, category := range []string{"ledgers", "transactions", "results"} {
+			if exists, err := a.CategoryCheckpointExists(category, cur); err != nil {
+				return nil, errors.Wrap(err, "could not check if category checkpoint exists")
+			} else if !exists {
+				return nil, errors.Errorf("checkpoint %d is not published", cur)
+			}
+
+			if err := a.fetchCategory(cache, category, cur); err != nil {
+				return nil, errors.Wrap(err, "could not fetch category checkpoint")
+			}
+		}
+	}
+
+	return cache, nil
+}
+
+func (a *Archive) fetchCategory(cache map[uint32]*xdr.LedgerCloseMeta, category string, checkpointSequence uint32) error {
+	checkpointPath := CategoryCheckpointPath(category, checkpointSequence)
+	xdrStream, err := a.GetXdrStream(checkpointPath)
+	if err != nil {
+		return errors.Wrapf(err, "error opening %s stream", category)
+	}
+	defer xdrStream.Close()
+
+	for {
+		switch category {
+		case "ledger":
+			var object xdr.LedgerHeaderHistoryEntry
+			err = xdrStream.ReadOne(&object)
+			cache[uint32(object.Header.LedgerSeq)] = &xdr.LedgerCloseMeta{
+				V: 0,
+				V0: &xdr.LedgerCloseMetaV0{
+					LedgerHeader: object,
+				},
+			}
+		case "transactions":
+			var object xdr.TransactionHistoryEntry
+			err = xdrStream.ReadOne(&object)
+			cache[uint32(object.LedgerSeq)].V0.TxSet = object.TxSet
+		case "results":
+			var object xdr.TransactionHistoryResultEntry
+			err = xdrStream.ReadOne(&object)
+			cache[uint32(object.LedgerSeq)].V0.TxProcessing = make([]xdr.TransactionResultMeta, len(object.TxResultSet.Results))
+			for i := range object.TxResultSet.Results {
+				cache[uint32(object.LedgerSeq)].V0.TxProcessing[i].Result = object.TxResultSet.Results[i]
+			}
+		default:
+			panic("unknown category")
+		}
+
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return errors.Wrapf(err, "error reading from %s stream", category)
+		}
+	}
+
+	return nil
 }
 
 func (a *Archive) GetCheckpointHAS(chk uint32) (HistoryArchiveState, error) {

--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -49,6 +49,12 @@ type ConnectOptions struct {
 	CheckpointFrequency uint32
 }
 
+type Ledger struct {
+	Header            xdr.LedgerHeaderHistoryEntry
+	Transaction       xdr.TransactionHistoryEntry
+	TransactionResult xdr.TransactionHistoryResultEntry
+}
+
 type ArchiveBackend interface {
 	Exists(path string) (bool, error)
 	Size(path string) (int64, error)
@@ -65,7 +71,7 @@ type ArchiveInterface interface {
 	CategoryCheckpointExists(cat string, chk uint32) (bool, error)
 	GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, error)
 	GetRootHAS() (HistoryArchiveState, error)
-	GetLedgers(start, end uint32) (map[uint32]*xdr.LedgerCloseMeta, error)
+	GetLedgers(start, end uint32) (map[uint32]Ledger, error)
 	GetCheckpointHAS(chk uint32) (HistoryArchiveState, error)
 	PutCheckpointHAS(chk uint32, has HistoryArchiveState, opts *CommandOptions) error
 	PutRootHAS(has HistoryArchiveState, opts *CommandOptions) error
@@ -196,15 +202,13 @@ func (a *Archive) GetRootHAS() (HistoryArchiveState, error) {
 	return a.GetPathHAS(rootHASPath)
 }
 
-func (a *Archive) GetLedgers(start, end uint32) (map[uint32]*xdr.LedgerCloseMeta, error) {
+func (a *Archive) GetLedgers(start, end uint32) (map[uint32]Ledger, error) {
 	if start > end {
 		return nil, errors.Errorf("range is invalid, start: %d end: %d", start, end)
 	}
 	checkpointRange := a.GetCheckpointManager().MakeRange(start, end)
-	cache := map[uint32]*xdr.LedgerCloseMeta{}
+	cache := map[uint32]Ledger{}
 	for cur := checkpointRange.Low; cur <= checkpointRange.High; cur = a.GetCheckpointManager().NextCheckpoint(cur) {
-		// ledger must be fetched first because it initializes LedgerCloseMeta for
-		// a given sequence.
 		for _, category := range []string{"ledgers", "transactions", "results"} {
 			if exists, err := a.CategoryCheckpointExists(category, cur); err != nil {
 				return nil, errors.Wrap(err, "could not check if category checkpoint exists")
@@ -221,7 +225,7 @@ func (a *Archive) GetLedgers(start, end uint32) (map[uint32]*xdr.LedgerCloseMeta
 	return cache, nil
 }
 
-func (a *Archive) fetchCategory(cache map[uint32]*xdr.LedgerCloseMeta, category string, checkpointSequence uint32) error {
+func (a *Archive) fetchCategory(cache map[uint32]Ledger, category string, checkpointSequence uint32) error {
 	checkpointPath := CategoryCheckpointPath(category, checkpointSequence)
 	xdrStream, err := a.GetXdrStream(checkpointPath)
 	if err != nil {
@@ -233,23 +237,24 @@ func (a *Archive) fetchCategory(cache map[uint32]*xdr.LedgerCloseMeta, category 
 		switch category {
 		case "ledger":
 			var object xdr.LedgerHeaderHistoryEntry
-			err = xdrStream.ReadOne(&object)
-			cache[uint32(object.Header.LedgerSeq)] = &xdr.LedgerCloseMeta{
-				V: 0,
-				V0: &xdr.LedgerCloseMetaV0{
-					LedgerHeader: object,
-				},
+			if err = xdrStream.ReadOne(&object); err != nil {
+				entry := cache[uint32(object.Header.LedgerSeq)]
+				entry.Header = object
+				cache[uint32(object.Header.LedgerSeq)] = entry
 			}
 		case "transactions":
 			var object xdr.TransactionHistoryEntry
-			err = xdrStream.ReadOne(&object)
-			cache[uint32(object.LedgerSeq)].V0.TxSet = object.TxSet
+			if err = xdrStream.ReadOne(&object); err != nil {
+				entry := cache[uint32(object.LedgerSeq)]
+				entry.Transaction = object
+				cache[uint32(object.LedgerSeq)] = entry
+			}
 		case "results":
 			var object xdr.TransactionHistoryResultEntry
-			err = xdrStream.ReadOne(&object)
-			cache[uint32(object.LedgerSeq)].V0.TxProcessing = make([]xdr.TransactionResultMeta, len(object.TxResultSet.Results))
-			for i := range object.TxResultSet.Results {
-				cache[uint32(object.LedgerSeq)].V0.TxProcessing[i].Result = object.TxResultSet.Results[i]
+			if err = xdrStream.ReadOne(&object); err != nil {
+				entry := cache[uint32(object.LedgerSeq)]
+				entry.TransactionResult = object
+				cache[uint32(object.LedgerSeq)] = entry
 			}
 		default:
 			panic("unknown category")

--- a/historyarchive/mocks.go
+++ b/historyarchive/mocks.go
@@ -40,6 +40,11 @@ func (m *MockArchive) GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry,
 	return a.Get(0).(xdr.LedgerHeaderHistoryEntry), a.Error(1)
 }
 
+func (m *MockArchive) GetLedgers(start, end uint32) (map[uint32]*xdr.LedgerCloseMeta, error) {
+	a := m.Called(start, end)
+	return a.Get(0).(map[uint32]*xdr.LedgerCloseMeta), a.Error(1)
+}
+
 func (m *MockArchive) GetRootHAS() (HistoryArchiveState, error) {
 	a := m.Called()
 	return a.Get(0).(HistoryArchiveState), a.Error(1)

--- a/historyarchive/mocks.go
+++ b/historyarchive/mocks.go
@@ -40,9 +40,9 @@ func (m *MockArchive) GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry,
 	return a.Get(0).(xdr.LedgerHeaderHistoryEntry), a.Error(1)
 }
 
-func (m *MockArchive) GetLedgers(start, end uint32) (map[uint32]*xdr.LedgerCloseMeta, error) {
+func (m *MockArchive) GetLedgers(start, end uint32) (map[uint32]Ledger, error) {
 	a := m.Called(start, end)
-	return a.Get(0).(map[uint32]*xdr.LedgerCloseMeta), a.Error(1)
+	return a.Get(0).(map[uint32]Ledger), a.Error(1)
 }
 
 func (m *MockArchive) GetRootHAS() (HistoryArchiveState, error) {

--- a/historyarchive/mocks.go
+++ b/historyarchive/mocks.go
@@ -40,9 +40,9 @@ func (m *MockArchive) GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry,
 	return a.Get(0).(xdr.LedgerHeaderHistoryEntry), a.Error(1)
 }
 
-func (m *MockArchive) GetLedgers(start, end uint32) (map[uint32]Ledger, error) {
+func (m *MockArchive) GetLedgers(start, end uint32) (map[uint32]*Ledger, error) {
 	a := m.Called(start, end)
-	return a.Get(0).(map[uint32]Ledger), a.Error(1)
+	return a.Get(0).(map[uint32]*Ledger), a.Error(1)
 }
 
 func (m *MockArchive) GetRootHAS() (HistoryArchiveState, error) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Close https://github.com/stellar/go/issues/3340

Previously, we had a HistoryArchiveBackend implementation which used the history archives to fetch transactions belonging to a specific ledger. We decided to remove the implementation in #3321 because the transactions did not contain tx meta and that resulted in some inconsistencies with other ingest.LedgerBackend implementations.

However, the code to extract transactions from the history archives could be useful so we should add that functionality to the history archive client.

### Known limitations

[N/A]
