### PR TITLE
services/horizon: Add docker image for checking reproducible builds

### DIFF
--- a/services/horizon/internal/scripts/check_release_hash/Dockerfile
+++ b/services/horizon/internal/scripts/check_release_hash/Dockerfile
@@ -1,0 +1,19 @@
+# Change to Go version used in CI or rebuild with --build-arg.
+ARG GO_IMAGE=golang:1.14.14-stretch
+FROM $GO_IMAGE
+
+WORKDIR /go/src/github.com/stellar/go
+
+ENV DEBIAN_FRONTEND=noninteractive
+# ca-certificates are required to make tls connections
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl wget gnupg apt-utils git zip unzip
+RUN wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true apt-key add -
+RUN echo "deb https://apt.stellar.org xenial stable" >/etc/apt/sources.list.d/SDF.list
+
+RUN git clone https://github.com/stellar/go.git /go/src/github.com/stellar/go
+# Fetch dependencies and prebuild binaries. Not necessary but will make check faster.
+RUN go run -v ./support/scripts/build_release_artifacts
+
+COPY check.sh .
+RUN chmod +x check.sh
+ENTRYPOINT ["./check.sh"]

--- a/services/horizon/internal/scripts/check_release_hash/Dockerfile
+++ b/services/horizon/internal/scripts/check_release_hash/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/stellar/go
 
 ENV DEBIAN_FRONTEND=noninteractive
 # ca-certificates are required to make tls connections
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl wget gnupg apt-utils git zip unzip
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl wget gnupg apt-utils git zip unzip apt-transport-https ca-certificates
 RUN wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true apt-key add -
 RUN echo "deb https://apt.stellar.org xenial stable" >/etc/apt/sources.list.d/SDF.list
 

--- a/services/horizon/internal/scripts/check_release_hash/README.md
+++ b/services/horizon/internal/scripts/check_release_hash/README.md
@@ -1,0 +1,9 @@
+# check_release_hash
+
+Docker image for comparing releases hash to a local builds hash.
+
+## Usage
+
+1. Build the image. Optionally pass `--build-arg` with `golang` image you want to use for compilation. See `Dockerfile` for a default value.
+2. `docker run -e "TAG=horizon-vX.Y.Z" check_release_hash`
+3. Compare the hashes in the output. `released` directory contains packages from GitHub, `dist` are the locally built packages.

--- a/services/horizon/internal/scripts/check_release_hash/check.sh
+++ b/services/horizon/internal/scripts/check_release_hash/check.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-# apt-get update && apt-get install -y stellar-horizon
-
 mkdir released
 cd released
 
@@ -28,3 +26,6 @@ do
     shasum -a 256 ./released/$TAG-$S
     shasum -a 256 ./dist/$TAG-$S
 done
+
+apt-get update && apt-get install -y stellar-horizon
+shasum -a 256 $(which stellar-core)

--- a/services/horizon/internal/scripts/check_release_hash/check.sh
+++ b/services/horizon/internal/scripts/check_release_hash/check.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# apt-get update && apt-get install -y stellar-horizon
+
+mkdir released
+cd released
+
+wget https://github.com/stellar/go/releases/download/$TAG/$TAG-darwin-amd64.tar.gz
+wget https://github.com/stellar/go/releases/download/$TAG/$TAG-linux-amd64.tar.gz
+wget https://github.com/stellar/go/releases/download/$TAG/$TAG-linux-arm.tar.gz
+wget https://github.com/stellar/go/releases/download/$TAG/$TAG-windows-amd64.zip
+
+tar -xvf $TAG-darwin-amd64.tar.gz
+tar -xvf $TAG-linux-amd64.tar.gz
+tar -xvf $TAG-linux-arm.tar.gz
+unzip $TAG-windows-amd64.zip
+
+cd -
+
+git pull origin --tags
+git checkout $TAG
+CIRCLE_TAG=$TAG go run -v ./support/scripts/build_release_artifacts
+
+suffixes=(darwin-amd64.tar.gz linux-amd64.tar.gz linux-arm.tar.gz windows-amd64.zip)
+
+for S in "${suffixes[@]}"
+do
+	echo $TAG-$S
+    shasum -a 256 ./released/$TAG-$S
+    shasum -a 256 ./dist/$TAG-$S
+done

--- a/services/horizon/internal/scripts/check_release_hash/check.sh
+++ b/services/horizon/internal/scripts/check_release_hash/check.sh
@@ -16,16 +16,35 @@ cd -
 
 git pull origin --tags
 git checkout $TAG
-CIRCLE_TAG=$TAG go run -v ./support/scripts/build_release_artifacts
+# -keep: artifact directories are not removed after packaging
+CIRCLE_TAG=$TAG go run -v ./support/scripts/build_release_artifacts -keep
 
-suffixes=(darwin-amd64.tar.gz linux-amd64.tar.gz linux-arm.tar.gz windows-amd64.zip)
+suffixes=(darwin-amd64 linux-amd64 linux-arm windows-amd64)
+
+apt-get update && apt-get install -y stellar-horizon
 
 for S in "${suffixes[@]}"
 do
 	echo $TAG-$S
-    shasum -a 256 ./released/$TAG-$S
-    shasum -a 256 ./dist/$TAG-$S
+    
+    if [ -f "./released/$TAG-$S.tar.gz" ]; then
+        shasum -a 256 ./released/$TAG-$S.tar.gz
+        shasum -a 256 ./released/$TAG-$S/horizon
+    else
+        # windows
+        shasum -a 256 ./released/$TAG-$S.zip
+        shasum -a 256 ./released/$TAG-$S/horizon.exe
+    fi
+
+    if [ -f "./dist/$TAG-$S.tar.gz" ]; then
+        shasum -a 256 ./dist/$TAG-$S.tar.gz
+        shasum -a 256 ./dist/$TAG-$S/horizon
+    else
+        # windows
+        shasum -a 256 ./dist/$TAG-$S.zip
+        shasum -a 256 ./dist/$TAG-$S/horizon.exe
+    fi
 done
 
-apt-get update && apt-get install -y stellar-horizon
+echo "debian package"
 shasum -a 256 $(which stellar-horizon)

--- a/services/horizon/internal/scripts/check_release_hash/check.sh
+++ b/services/horizon/internal/scripts/check_release_hash/check.sh
@@ -28,4 +28,4 @@ do
 done
 
 apt-get update && apt-get install -y stellar-horizon
-shasum -a 256 $(which stellar-core)
+shasum -a 256 $(which stellar-horizon)

--- a/support/scripts/build_release_artifacts/main.go
+++ b/support/scripts/build_release_artifacts/main.go
@@ -90,7 +90,7 @@ func build(pkg, dest, version, buildOS, buildArch string) {
 	cmd := exec.Command("go", "build",
 		"-trimpath",
 		"-o", dest,
-		"-ldflags", fmt.Sprintf("%s", versionFlag),
+		"-ldflags", versionFlag,
 		pkg,
 	)
 	cmd.Stderr = os.Stderr

--- a/support/scripts/build_release_artifacts/main.go
+++ b/support/scripts/build_release_artifacts/main.go
@@ -12,8 +12,6 @@ import (
 	"regexp"
 	"strings"
 
-	"time"
-
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
 )
@@ -83,9 +81,6 @@ func binNamesForDir(dir string) []string {
 }
 
 func build(pkg, dest, version, buildOS, buildArch string) {
-	buildTime := time.Now().Format(time.RFC3339)
-
-	timeFlag := fmt.Sprintf("-X github.com/stellar/go/support/app.buildTime=%s", buildTime)
 	versionFlag := fmt.Sprintf("-X github.com/stellar/go/support/app.version=%s", version)
 
 	if buildOS == "windows" {
@@ -93,8 +88,9 @@ func build(pkg, dest, version, buildOS, buildArch string) {
 	}
 
 	cmd := exec.Command("go", "build",
+		"-trimpath",
 		"-o", dest,
-		"-ldflags", fmt.Sprintf("%s %s", timeFlag, versionFlag),
+		"-ldflags", fmt.Sprintf("%s", versionFlag),
 		pkg,
 	)
 	cmd.Stderr = os.Stderr
@@ -102,6 +98,7 @@ func build(pkg, dest, version, buildOS, buildArch string) {
 
 	cmd.Env = append(
 		os.Environ(),
+		"CGO_ENABLED=0",
 		fmt.Sprintf("GOOS=%s", buildOS),
 		fmt.Sprintf("GOARCH=%s", buildArch),
 	)


### PR DESCRIPTION
### What

Adds a docker image to allow comparing hashes of GitHub builds and local builds. Remove `buildTime` flag from build tags in `build_release_artifacts` to make the builds reproducible.

### Why

Creating reproducible builds and checking them will make our release process more secure.

### Known limitations

It doesn't check Debian packages yet. Will add this in a separate PR.