### PR TITLE
txnbuild: Use strings to represent accounts in txnbuild operations

### DIFF
--- a/exp/services/recoverysigner/internal/serve/account_sign.go
+++ b/exp/services/recoverysigner/internal/serve/account_sign.go
@@ -139,14 +139,14 @@ func (h accountSignHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, op := range tx.Operations() {
 		opSourceAccount := op.GetSourceAccount()
-		if opSourceAccount == nil {
+		if opSourceAccount == "" {
 			continue
 		}
 
-		if op.GetSourceAccount().GetAccountID() != req.Address.Address() {
+		if op.GetSourceAccount() != req.Address.Address() {
 			var opHasAllowedAccount bool
 			for _, sa := range h.AllowedSourceAccounts {
-				if sa.Address() == op.GetSourceAccount().GetAccountID() {
+				if sa.Address() == op.GetSourceAccount() {
 					opHasAllowedAccount = true
 					break
 				}

--- a/exp/services/recoverysigner/internal/serve/account_sign_signing_address_test.go
+++ b/exp/services/recoverysigner/internal/serve/account_sign_signing_address_test.go
@@ -537,7 +537,7 @@ func TestAccountSign_signingAddressAccountAuthenticatedTxAndOpSourceAccountValid
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
 				&txnbuild.SetOptions{
-					SourceAccount: &txnbuild.SimpleAccount{AccountID: "GA6HNE7O2N2IXIOBZNZ4IPTS2P6DSAJJF5GD5PDLH5GYOZ6WMPSKCXD4"},
+					SourceAccount: "GA6HNE7O2N2IXIOBZNZ4IPTS2P6DSAJJF5GD5PDLH5GYOZ6WMPSKCXD4",
 					Signer: &txnbuild.Signer{
 						Address: "GD7CGJSJ5OBOU5KOP2UQDH3MPY75UTEY27HVV5XPSL2X6DJ2VGTOSXEU",
 						Weight:  20,
@@ -603,7 +603,7 @@ func TestAccountSign_signingAddressAccountAuthenticatedTxSourceAccountInvalid(t 
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
 				&txnbuild.SetOptions{
-					SourceAccount: &txnbuild.SimpleAccount{AccountID: "GA6HNE7O2N2IXIOBZNZ4IPTS2P6DSAJJF5GD5PDLH5GYOZ6WMPSKCXD4"},
+					SourceAccount: "GA6HNE7O2N2IXIOBZNZ4IPTS2P6DSAJJF5GD5PDLH5GYOZ6WMPSKCXD4",
 					Signer: &txnbuild.Signer{
 						Address: "GD7CGJSJ5OBOU5KOP2UQDH3MPY75UTEY27HVV5XPSL2X6DJ2VGTOSXEU",
 						Weight:  20,
@@ -666,7 +666,7 @@ func TestAccountSign_signingAddressAccountAuthenticatedOpSourceAccountInvalid(t 
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
 				&txnbuild.SetOptions{
-					SourceAccount: &txnbuild.SimpleAccount{AccountID: "GA47G3ZQBUR5NF2ZECG774O3QGKFMAW75XLXSCDICFDDV5GKGRFGFSOI"},
+					SourceAccount: "GA47G3ZQBUR5NF2ZECG774O3QGKFMAW75XLXSCDICFDDV5GKGRFGFSOI",
 					Signer: &txnbuild.Signer{
 						Address: "GD7CGJSJ5OBOU5KOP2UQDH3MPY75UTEY27HVV5XPSL2X6DJ2VGTOSXEU",
 						Weight:  20,
@@ -730,7 +730,7 @@ func TestAccountSign_signingAddressAccountAuthenticatedTxAndOpSourceAccountInval
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
 				&txnbuild.SetOptions{
-					SourceAccount: &txnbuild.SimpleAccount{AccountID: "GA47G3ZQBUR5NF2ZECG774O3QGKFMAW75XLXSCDICFDDV5GKGRFGFSOI"},
+					SourceAccount: "GA47G3ZQBUR5NF2ZECG774O3QGKFMAW75XLXSCDICFDDV5GKGRFGFSOI",
 					Signer: &txnbuild.Signer{
 						Address: "GD7CGJSJ5OBOU5KOP2UQDH3MPY75UTEY27HVV5XPSL2X6DJ2VGTOSXEU",
 						Weight:  20,
@@ -1021,7 +1021,7 @@ func TestAccountSign_signingAddressEmailOwnerAuthenticatedOpSourceAccountIsAllow
 			Operations: []txnbuild.Operation{
 				&txnbuild.BeginSponsoringFutureReserves{
 					SponsoredID:   "GA6HNE7O2N2IXIOBZNZ4IPTS2P6DSAJJF5GD5PDLH5GYOZ6WMPSKCXD4",
-					SourceAccount: &txnbuild.SimpleAccount{AccountID: "GDR3RJVOHYR5A4RSLZ7D3GOSTPBGD2FY7KJD7ZB7363ROOQHWYDVVULS"},
+					SourceAccount: "GDR3RJVOHYR5A4RSLZ7D3GOSTPBGD2FY7KJD7ZB7363ROOQHWYDVVULS",
 				},
 				&txnbuild.SetOptions{
 					Signer: &txnbuild.Signer{
@@ -1098,7 +1098,7 @@ func TestAccountSign_signingAddressEmailOwnerAuthenticatedOpSourceAccountInvalid
 			Operations: []txnbuild.Operation{
 				&txnbuild.BeginSponsoringFutureReserves{
 					SponsoredID:   "GA6HNE7O2N2IXIOBZNZ4IPTS2P6DSAJJF5GD5PDLH5GYOZ6WMPSKCXD4",
-					SourceAccount: &txnbuild.SimpleAccount{AccountID: "GDR3RJVOHYR5A4RSLZ7D3GOSTPBGD2FY7KJD7ZB7363ROOQHWYDVVULS"},
+					SourceAccount: "GDR3RJVOHYR5A4RSLZ7D3GOSTPBGD2FY7KJD7ZB7363ROOQHWYDVVULS",
 				},
 				&txnbuild.SetOptions{
 					Signer: &txnbuild.Signer{

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -108,7 +108,7 @@ func (minion *Minion) checkHandleBadSequence(err *horizonclient.Error) {
 func (minion *Minion) makeTx(destAddress string) (string, error) {
 	createAccountOp := txnbuild.CreateAccount{
 		Destination:   destAddress,
-		SourceAccount: minion.BotAccount,
+		SourceAccount: minion.BotAccount.GetAccountID(),
 		Amount:        minion.StartingBalance,
 	}
 	tx, err := txnbuild.NewTransaction(

--- a/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
@@ -114,11 +114,11 @@ func TestSponsorships(t *testing.T) {
 		t.Logf("Revoking & replacing sponsorship")
 		ops = []txnbuild.Operation{
 			&txnbuild.BeginSponsoringFutureReserves{
-				SourceAccount: newSponsor,
+				SourceAccount: newSponsor.GetAccountID(),
 				SponsoredID:   sponsorPair.Address(),
 			},
 			&txnbuild.RevokeSponsorship{
-				SourceAccount:   sponsor,
+				SourceAccount:   sponsor.GetAccountID(),
 				SponsorshipType: txnbuild.RevokeSponsorshipTypeAccount,
 				Account:         &newAccountID,
 			},
@@ -192,7 +192,7 @@ func TestSponsorships(t *testing.T) {
 		signerKey := keypair.MustRandom().Address() // unspecified signer
 
 		ops := sponsorOperations(newAccountPair.Address(), &txnbuild.SetOptions{
-			SourceAccount: newAccount,
+			SourceAccount: newAccount.GetAccountID(),
 			Signer: &txnbuild.Signer{
 				Address: signerKey,
 				Weight:  1,
@@ -233,7 +233,7 @@ func TestSponsorships(t *testing.T) {
 		newSponsorPair, newSponsor := keys[2], accounts[2]
 		ops = []txnbuild.Operation{
 			&txnbuild.BeginSponsoringFutureReserves{
-				SourceAccount: newSponsor,
+				SourceAccount: newSponsor.GetAccountID(),
 				SponsoredID:   sponsorPair.Address(),
 			},
 			&txnbuild.RevokeSponsorship{
@@ -328,7 +328,7 @@ func TestSponsorships(t *testing.T) {
 		}
 		ops := sponsorOperations(newAccountPair.Address(),
 			&txnbuild.SetOptions{
-				SourceAccount: newAccount,
+				SourceAccount: newAccount.GetAccountID(),
 				Signer: &txnbuild.Signer{
 					Address: preAuthSignerKey.Address(),
 					Weight:  1,
@@ -402,7 +402,7 @@ func TestSponsorships(t *testing.T) {
 			&txnbuild.ManageData{
 				Name:          "SponsoredData",
 				Value:         []byte("SponsoredValue"),
-				SourceAccount: newAccount,
+				SourceAccount: newAccount.GetAccountID(),
 			})
 
 		signers := []*keypair.Full{sponsorPair, newAccountPair}
@@ -441,7 +441,7 @@ func TestSponsorships(t *testing.T) {
 		newSponsorPair, newSponsor := keys[2], accounts[2]
 		ops = []txnbuild.Operation{
 			&txnbuild.BeginSponsoringFutureReserves{
-				SourceAccount: newSponsor,
+				SourceAccount: newSponsor.GetAccountID(),
 				SponsoredID:   sponsorPair.Address(),
 			},
 			&txnbuild.RevokeSponsorship{
@@ -507,12 +507,12 @@ func TestSponsorships(t *testing.T) {
 
 		ops := sponsorOperations(newAccountPair.Address(),
 			&txnbuild.ChangeTrust{
-				SourceAccount: newAccount,
+				SourceAccount: newAccount.GetAccountID(),
 				Line:          asset,
 				Limit:         txnbuild.MaxTrustlineLimit,
 			},
 			&txnbuild.ManageSellOffer{
-				SourceAccount: newAccount,
+				SourceAccount: newAccount.GetAccountID(),
 				Selling:       txnbuild.NativeAsset{},
 				Buying:        asset,
 				Amount:        "3",
@@ -572,7 +572,7 @@ func TestSponsorships(t *testing.T) {
 
 		ops = []txnbuild.Operation{
 			&txnbuild.BeginSponsoringFutureReserves{
-				SourceAccount: newSponsor,
+				SourceAccount: newSponsor.GetAccountID(),
 				SponsoredID:   sponsorPair.Address(),
 			},
 			&txnbuild.RevokeSponsorship{
@@ -653,11 +653,11 @@ func TestSponsorships(t *testing.T) {
 
 		ops := []txnbuild.Operation{
 			&txnbuild.BeginSponsoringFutureReserves{
-				SourceAccount: sponsor,
+				SourceAccount: sponsor.GetAccountID(),
 				SponsoredID:   sponsoreePair.Address(),
 			},
 			&txnbuild.CreateClaimableBalance{
-				SourceAccount: sponsoree,
+				SourceAccount: sponsoree.GetAccountID(),
 				Destinations: []txnbuild.Claimant{
 					txnbuild.NewClaimant(sponsorPair.Address(), nil),
 					txnbuild.NewClaimant(sponsoreePair.Address(), nil),
@@ -747,7 +747,7 @@ func sponsorOperations(account string, ops ...txnbuild.Operation) []txnbuild.Ope
 		},
 		ops...),
 		&txnbuild.EndSponsoringFutureReserves{
-			SourceAccount: &txnbuild.SimpleAccount{AccountID: account},
+			SourceAccount: account,
 		},
 	)
 }

--- a/services/horizon/internal/integration/protocol14_state_verifier_test.go
+++ b/services/horizon/internal/integration/protocol14_state_verifier_test.go
@@ -39,24 +39,24 @@ func TestProtocol14StateVerifier(t *testing.T) {
 			Amount:      "100",
 		},
 		&txnbuild.ChangeTrust{
-			SourceAccount: sponsoredSource,
+			SourceAccount: sponsoredSource.AccountID,
 			Line:          txnbuild.CreditAsset{"ABCD", master.Address()},
 			Limit:         txnbuild.MaxTrustlineLimit,
 		},
 		&txnbuild.ManageSellOffer{
-			SourceAccount: sponsoredSource,
+			SourceAccount: sponsoredSource.AccountID,
 			Selling:       txnbuild.NativeAsset{},
 			Buying:        txnbuild.CreditAsset{"ABCD", master.Address()},
 			Amount:        "3",
 			Price:         "1",
 		},
 		&txnbuild.ManageData{
-			SourceAccount: sponsoredSource,
+			SourceAccount: sponsoredSource.AccountID,
 			Name:          "test",
 			Value:         []byte("test"),
 		},
 		&txnbuild.CreateClaimableBalance{
-			SourceAccount: sponsoredSource,
+			SourceAccount: sponsoredSource.AccountID,
 			Amount:        "2",
 			Asset:         txnbuild.NativeAsset{},
 			Destinations: []txnbuild.Claimant{
@@ -64,10 +64,10 @@ func TestProtocol14StateVerifier(t *testing.T) {
 			},
 		},
 		&txnbuild.EndSponsoringFutureReserves{
-			SourceAccount: sponsoredSource,
+			SourceAccount: sponsoredSource.AccountID,
 		},
 		&txnbuild.SetOptions{
-			SourceAccount: sponsoredSource,
+			SourceAccount: sponsoredSource.AccountID,
 			Signer: &txnbuild.Signer{
 				Address: signer1.Address(),
 				Weight:  3,
@@ -77,17 +77,17 @@ func TestProtocol14StateVerifier(t *testing.T) {
 			SponsoredID: sponsored.Address(),
 		},
 		&txnbuild.SetOptions{
-			SourceAccount: sponsoredSource,
+			SourceAccount: sponsoredSource.AccountID,
 			Signer: &txnbuild.Signer{
 				Address: signer2.Address(),
 				Weight:  3,
 			},
 		},
 		&txnbuild.EndSponsoringFutureReserves{
-			SourceAccount: sponsoredSource,
+			SourceAccount: sponsoredSource.AccountID,
 		},
 		&txnbuild.SetOptions{
-			SourceAccount: sponsoredSource,
+			SourceAccount: sponsoredSource.AccountID,
 			Signer: &txnbuild.Signer{
 				Address: signer3.Address(),
 				Weight:  3,

--- a/services/horizon/internal/integration/protocol14_test.go
+++ b/services/horizon/internal/integration/protocol14_test.go
@@ -381,7 +381,7 @@ func TestClaimableBalancePredicates(t *testing.T) {
 			t.Logf("  amount: %d, predicate: %+v", amount, predicate.Type)
 
 			createClaimOps[i] = &txnbuild.CreateClaimableBalance{
-				SourceAccount: accountA,
+				SourceAccount: accountA.GetAccountID(),
 				Destinations:  []txnbuild.Claimant{claimant},
 				Amount:        fmt.Sprintf("%d.0000000", amount),
 				Asset:         txnbuild.NativeAsset{},

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -391,7 +391,7 @@ func (i *Test) CreateAccounts(count int, initialBalance string) ([]*keypair.Full
 		pairs[i] = pair
 
 		ops[i] = &txnbuild.CreateAccount{
-			SourceAccount: &masterAccount,
+			SourceAccount: masterAccount.AccountID,
 			Destination:   pair.Address(),
 			Amount:        initialBalance,
 		}

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -5,9 +5,12 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Fix bug in `ClaimableBalanceID()` ([#3393](https://github.com/stellar/go/pull/3393))
+
 ### Breaking changes
 
-* Remove `TxEnvelope()` functions from `Transaction` and `FeeBumpTransaction` to simplify the API. `ToXDR()` should be used instead of `TxEnvelope()`  ([#3377](https://github.com/stellar/go/pull/3377))
+* Use strings to represent accounts in Operation structs ([#3393](https://github.com/stellar/go/pull/3393))
+* Remove `TxEnvelope()` functions from `Transaction` and `FeeBumpTransaction` to simplify the API. `ToXDR()` should be used instead of `TxEnvelope()` ([#3377](https://github.com/stellar/go/pull/3377))
 
 ## [v5.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v5.0.0) - 2020-11-12
 

--- a/txnbuild/account_merge.go
+++ b/txnbuild/account_merge.go
@@ -9,7 +9,7 @@ import (
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type AccountMerge struct {
 	Destination   string
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for AccountMerge returns a fully configured XDR Operation.
@@ -56,8 +56,8 @@ func (am *AccountMerge) Validate() error {
 	return nil
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (am *AccountMerge) GetSourceAccount() Account {
+func (am *AccountMerge) GetSourceAccount() string {
 	return am.SourceAccount
 }

--- a/txnbuild/allow_trust.go
+++ b/txnbuild/allow_trust.go
@@ -14,7 +14,7 @@ type AllowTrust struct {
 	Type                           Asset
 	Authorize                      bool
 	AuthorizeToMaintainLiabilities bool
-	SourceAccount                  Account
+	SourceAccount                  string
 }
 
 // BuildXDR for AllowTrust returns a fully configured XDR Operation.
@@ -97,8 +97,8 @@ func (at *AllowTrust) Validate() error {
 	return nil
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (at *AllowTrust) GetSourceAccount() Account {
+func (at *AllowTrust) GetSourceAccount() string {
 	return at.SourceAccount
 }

--- a/txnbuild/begin_sponsoring_future_reserves.go
+++ b/txnbuild/begin_sponsoring_future_reserves.go
@@ -10,7 +10,7 @@ import (
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type BeginSponsoringFutureReserves struct {
 	SponsoredID   string
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for BeginSponsoringFutureReserves returns a fully configured XDR Operation.
@@ -53,8 +53,8 @@ func (bs *BeginSponsoringFutureReserves) Validate() error {
 	return nil
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (bs *BeginSponsoringFutureReserves) GetSourceAccount() Account {
+func (bs *BeginSponsoringFutureReserves) GetSourceAccount() string {
 	return bs.SourceAccount
 }

--- a/txnbuild/bump_sequence.go
+++ b/txnbuild/bump_sequence.go
@@ -9,7 +9,7 @@ import (
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type BumpSequence struct {
 	BumpTo        int64
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for BumpSequence returns a fully configured XDR Operation.
@@ -47,8 +47,8 @@ func (bs *BumpSequence) Validate() error {
 	return nil
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (bs *BumpSequence) GetSourceAccount() Account {
+func (bs *BumpSequence) GetSourceAccount() string {
 	return bs.SourceAccount
 }

--- a/txnbuild/change_trust.go
+++ b/txnbuild/change_trust.go
@@ -14,7 +14,7 @@ import (
 type ChangeTrust struct {
 	Line          Asset
 	Limit         string
-	SourceAccount Account
+	SourceAccount string
 }
 
 // MaxTrustlineLimit represents the maximum value that can be set as a trustline limit.
@@ -97,8 +97,8 @@ func (ct *ChangeTrust) Validate() error {
 	return nil
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (ct *ChangeTrust) GetSourceAccount() Account {
+func (ct *ChangeTrust) GetSourceAccount() string {
 	return ct.SourceAccount
 }

--- a/txnbuild/claim_claimable_balance.go
+++ b/txnbuild/claim_claimable_balance.go
@@ -10,7 +10,7 @@ import (
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type ClaimClaimableBalance struct {
 	BalanceID     string
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for ClaimClaimableBalance returns a fully configured XDR Operation.
@@ -63,8 +63,8 @@ func (cb *ClaimClaimableBalance) Validate() error {
 	return nil
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (cb *ClaimClaimableBalance) GetSourceAccount() Account {
+func (cb *ClaimClaimableBalance) GetSourceAccount() string {
 	return cb.SourceAccount
 }

--- a/txnbuild/create_account.go
+++ b/txnbuild/create_account.go
@@ -11,7 +11,7 @@ import (
 type CreateAccount struct {
 	Destination   string
 	Amount        string
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for CreateAccount returns a fully configured XDR Operation.
@@ -68,8 +68,8 @@ func (ca *CreateAccount) Validate() error {
 	return nil
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (ca *CreateAccount) GetSourceAccount() Account {
+func (ca *CreateAccount) GetSourceAccount() string {
 	return ca.SourceAccount
 }

--- a/txnbuild/create_claimable_balance.go
+++ b/txnbuild/create_claimable_balance.go
@@ -13,7 +13,7 @@ type CreateClaimableBalance struct {
 	Amount        string
 	Asset         Asset
 	Destinations  []Claimant
-	SourceAccount Account
+	SourceAccount string
 }
 
 // Claimant represents a claimable balance claimant
@@ -186,8 +186,8 @@ func (cb *CreateClaimableBalance) Validate() error {
 	return nil
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (cb *CreateClaimableBalance) GetSourceAccount() Account {
+func (cb *CreateClaimableBalance) GetSourceAccount() string {
 	return cb.SourceAccount
 }

--- a/txnbuild/create_passive_offer.go
+++ b/txnbuild/create_passive_offer.go
@@ -14,7 +14,7 @@ type CreatePassiveSellOffer struct {
 	Amount        string
 	Price         string
 	price         price
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for CreatePassiveSellOffer returns a fully configured XDR Operation.
@@ -88,8 +88,8 @@ func (cpo *CreatePassiveSellOffer) Validate() error {
 	return validatePassiveOffer(cpo.Buying, cpo.Selling, cpo.Amount, cpo.Price)
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (cpo *CreatePassiveSellOffer) GetSourceAccount() Account {
+func (cpo *CreatePassiveSellOffer) GetSourceAccount() string {
 	return cpo.SourceAccount
 }

--- a/txnbuild/create_passive_offer_test.go
+++ b/txnbuild/create_passive_offer_test.go
@@ -116,14 +116,13 @@ func TestCreatePassiveSellOfferValidatePrice(t *testing.T) {
 
 func TestCreatePassiveSellOfferPrice(t *testing.T) {
 	kp0 := newKeypair0()
-	sourceAccount := NewSimpleAccount(kp0.Address(), int64(41137196761100))
 
 	offer := CreatePassiveSellOffer{
 		Selling:       CreditAsset{"ABCD", kp0.Address()},
 		Buying:        NativeAsset{},
 		Amount:        "1",
 		Price:         "0.000000001",
-		SourceAccount: &sourceAccount,
+		SourceAccount: kp0.Address(),
 	}
 
 	xdrOp, err := offer.BuildXDR()

--- a/txnbuild/end_sponsoring_future_reserves.go
+++ b/txnbuild/end_sponsoring_future_reserves.go
@@ -9,7 +9,7 @@ import (
 // EndSponsoringFutureReserves represents the Stellar begin sponsoring future reserves operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type EndSponsoringFutureReserves struct {
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for EndSponsoringFutureReserves returns a fully configured XDR Operation.
@@ -40,8 +40,8 @@ func (es *EndSponsoringFutureReserves) Validate() error {
 	return nil
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (es *EndSponsoringFutureReserves) GetSourceAccount() Account {
+func (es *EndSponsoringFutureReserves) GetSourceAccount() string {
 	return es.SourceAccount
 }

--- a/txnbuild/example_test.go
+++ b/txnbuild/example_test.go
@@ -873,7 +873,7 @@ func ExampleBeginSponsoringFutureReserves() {
 	sponsorTrustline := []Operation{
 		&BeginSponsoringFutureReserves{SponsoredID: test.A.Address()},
 		&ChangeTrust{
-			SourceAccount: &test.Aaccount,
+			SourceAccount: test.Aaccount.AccountID,
 			Line:          &test.Assets[0],
 			Limit:         MaxTrustlineLimit,
 		},
@@ -905,7 +905,7 @@ func ExampleBeginSponsoringFutureReserves_transfer() {
 
 	transferOps := []Operation{
 		&BeginSponsoringFutureReserves{
-			SourceAccount: &test.S2account,
+			SourceAccount: test.S2account.AccountID,
 			SponsoredID:   test.S1.Address(),
 		},
 		&RevokeSponsorship{

--- a/txnbuild/fee_bump_test.go
+++ b/txnbuild/fee_bump_test.go
@@ -287,11 +287,10 @@ func TestFeeBumpAddSignatureBase64(t *testing.T) {
 	kp1 := newKeypair1()
 	kp2 := newKeypair2()
 	txSource := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
-	opSource := NewSimpleAccount(kp1.Address(), 0)
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:        "10",
-		SourceAccount: &opSource,
+		SourceAccount: kp1.Address(),
 	}
 
 	inner, err := NewTransaction(

--- a/txnbuild/inflation.go
+++ b/txnbuild/inflation.go
@@ -8,7 +8,7 @@ import (
 // Inflation represents the Stellar inflation operation. See
 // https://www.stellar.org/developers/guides/concepts/list-of-operations.html
 type Inflation struct {
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for Inflation returns a fully configured XDR Operation.
@@ -39,8 +39,8 @@ func (inf *Inflation) Validate() error {
 	return nil
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (inf *Inflation) GetSourceAccount() Account {
+func (inf *Inflation) GetSourceAccount() string {
 	return inf.SourceAccount
 }

--- a/txnbuild/manage_buy_offer.go
+++ b/txnbuild/manage_buy_offer.go
@@ -15,7 +15,7 @@ type ManageBuyOffer struct {
 	Price         string
 	price         price
 	OfferID       int64
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for ManageBuyOffer returns a fully configured XDR Operation.
@@ -91,8 +91,8 @@ func (mo *ManageBuyOffer) Validate() error {
 	return validateOffer(mo.Buying, mo.Selling, mo.Amount, mo.Price, mo.OfferID)
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (mo *ManageBuyOffer) GetSourceAccount() Account {
+func (mo *ManageBuyOffer) GetSourceAccount() string {
 	return mo.SourceAccount
 }

--- a/txnbuild/manage_data.go
+++ b/txnbuild/manage_data.go
@@ -10,7 +10,7 @@ import (
 type ManageData struct {
 	Name          string
 	Value         []byte
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for ManageData returns a fully configured XDR Operation.
@@ -65,8 +65,8 @@ func (md *ManageData) Validate() error {
 	return nil
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (md *ManageData) GetSourceAccount() Account {
+func (md *ManageData) GetSourceAccount() string {
 	return md.SourceAccount
 }

--- a/txnbuild/manage_offer.go
+++ b/txnbuild/manage_offer.go
@@ -9,7 +9,7 @@ import (
 //CreateOfferOp returns a ManageSellOffer operation to create a new offer, by
 // setting the OfferID to "0". The sourceAccount is optional, and if not provided,
 // will be that of the surrounding transaction.
-func CreateOfferOp(selling, buying Asset, amount, price string, sourceAccount ...Account) (ManageSellOffer, error) {
+func CreateOfferOp(selling, buying Asset, amount, price string, sourceAccount ...string) (ManageSellOffer, error) {
 	if len(sourceAccount) > 1 {
 		return ManageSellOffer{}, errors.New("offer can't have multiple source accounts")
 	}
@@ -29,7 +29,7 @@ func CreateOfferOp(selling, buying Asset, amount, price string, sourceAccount ..
 // UpdateOfferOp returns a ManageSellOffer operation to update an offer.
 // The sourceAccount is optional, and if not provided, will be that of
 // the surrounding transaction.
-func UpdateOfferOp(selling, buying Asset, amount, price string, offerID int64, sourceAccount ...Account) (ManageSellOffer, error) {
+func UpdateOfferOp(selling, buying Asset, amount, price string, offerID int64, sourceAccount ...string) (ManageSellOffer, error) {
 	if len(sourceAccount) > 1 {
 		return ManageSellOffer{}, errors.New("offer can't have multiple source accounts")
 	}
@@ -49,7 +49,7 @@ func UpdateOfferOp(selling, buying Asset, amount, price string, offerID int64, s
 //DeleteOfferOp returns a ManageSellOffer operation to delete an offer, by
 // setting the Amount to "0". The sourceAccount is optional, and if not provided,
 // will be that of the surrounding transaction.
-func DeleteOfferOp(offerID int64, sourceAccount ...Account) (ManageSellOffer, error) {
+func DeleteOfferOp(offerID int64, sourceAccount ...string) (ManageSellOffer, error) {
 	// It turns out Stellar core doesn't care about any of these fields except the amount.
 	// However, Horizon will reject ManageSellOffer if it is missing fields.
 	// Horizon will also reject if Buying == Selling.
@@ -79,7 +79,7 @@ type ManageSellOffer struct {
 	Price         string
 	price         price
 	OfferID       int64
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for ManageSellOffer returns a fully configured XDR Operation.
@@ -157,6 +157,6 @@ func (mo *ManageSellOffer) Validate() error {
 
 // GetSourceAccount returns the source account of the operation, or nil if not
 // set.
-func (mo *ManageSellOffer) GetSourceAccount() Account {
+func (mo *ManageSellOffer) GetSourceAccount() string {
 	return mo.SourceAccount
 }

--- a/txnbuild/operation.go
+++ b/txnbuild/operation.go
@@ -9,16 +9,16 @@ type Operation interface {
 	BuildXDR() (xdr.Operation, error)
 	FromXDR(xdrOp xdr.Operation) error
 	Validate() error
-	GetSourceAccount() Account
+	GetSourceAccount() string
 }
 
 // SetOpSourceAccount sets the source account ID on an Operation.
-func SetOpSourceAccount(op *xdr.Operation, sourceAccount Account) {
-	if sourceAccount == nil {
+func SetOpSourceAccount(op *xdr.Operation, sourceAccount string) {
+	if sourceAccount == "" {
 		return
 	}
 	var opSourceAccountID xdr.MuxedAccount
-	opSourceAccountID.SetAddress(sourceAccount.GetAccountID())
+	opSourceAccountID.SetAddress(sourceAccount)
 	op.SourceAccount = &opSourceAccountID
 }
 
@@ -70,11 +70,10 @@ func operationFromXDR(xdrOp xdr.Operation) (Operation, error) {
 	return newOp, err
 }
 
-// accountFromXDR returns a txnbuild Account from a XDR Account.
-func accountFromXDR(account *xdr.MuxedAccount) Account {
+func accountFromXDR(account *xdr.MuxedAccount) string {
 	if account != nil {
 		aid := account.ToAccountId()
-		return &SimpleAccount{AccountID: aid.Address()}
+		return aid.Address()
 	}
-	return nil
+	return ""
 }

--- a/txnbuild/operation_test.go
+++ b/txnbuild/operation_test.go
@@ -17,7 +17,7 @@ func TestCreateAccountFromXDR(t *testing.T) {
 		var ca CreateAccount
 		err = ca.FromXDR(xdrEnv.Operations()[0])
 		if assert.NoError(t, err) {
-			assert.Equal(t, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR", ca.SourceAccount.GetAccountID(), "source accounts should match")
+			assert.Equal(t, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR", ca.SourceAccount, "source accounts should match")
 			assert.Equal(t, "GCPHE7DYMAUAY4UWA6OIYDFGLKRXGLLEMT6MVETC36L7LW4Z3A37EJW5", ca.Destination, "destination should match")
 			assert.Equal(t, "10000.0000000", ca.Amount, "starting balance should match")
 		}
@@ -29,7 +29,7 @@ func TestCreateAccountFromXDR(t *testing.T) {
 		var ca CreateAccount
 		err = ca.FromXDR(xdrEnv.Operations()[0])
 		if assert.NoError(t, err) {
-			assert.Equal(t, nil, ca.SourceAccount, "source accounts should match")
+			assert.Equal(t, "", ca.SourceAccount, "source accounts should match")
 			assert.Equal(t, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR", ca.Destination, "destination should match")
 			assert.Equal(t, "198.0000000", ca.Amount, "starting balance should match")
 		}
@@ -45,7 +45,7 @@ func TestZeroBalanceAccount(t *testing.T) {
 			Amount:      "0",
 		},
 		&EndSponsoringFutureReserves{
-			SourceAccount: &SimpleAccount{AccountID: sponsee.Address()},
+			SourceAccount: sponsee.Address(),
 		},
 	}
 
@@ -71,7 +71,7 @@ func TestPaymentFromXDR(t *testing.T) {
 		var p Payment
 		err = p.FromXDR(xdrEnv.Operations()[0])
 		if assert.NoError(t, err) {
-			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", p.SourceAccount.GetAccountID(), "source accounts should match")
+			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", p.SourceAccount, "source accounts should match")
 			assert.Equal(t, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR", p.Destination, "destination should match")
 			assert.Equal(t, "10.0000000", p.Amount, "amount should match")
 			assert.Equal(t, true, p.Asset.IsNative(), "Asset should be native")
@@ -79,7 +79,7 @@ func TestPaymentFromXDR(t *testing.T) {
 
 		err = p.FromXDR(xdrEnv.Operations()[1])
 		if assert.NoError(t, err) {
-			assert.Equal(t, nil, p.SourceAccount, "source accounts should match")
+			assert.Equal(t, "", p.SourceAccount, "source accounts should match")
 			assert.Equal(t, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR", p.Destination, "destination should match")
 			assert.Equal(t, "134.0000000", p.Amount, "amount should match")
 			assetType, e := p.Asset.GetType()
@@ -99,7 +99,7 @@ func TestPathPaymentFromXDR(t *testing.T) {
 		var pp PathPayment
 		err = pp.FromXDR(xdrEnv.Operations()[0])
 		if assert.NoError(t, err) {
-			assert.Equal(t, nil, pp.SourceAccount, "source accounts should match")
+			assert.Equal(t, "", pp.SourceAccount, "source accounts should match")
 			assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", pp.Destination, "destination should match")
 			assert.Equal(t, "1.0000000", pp.DestAmount, "DestAmount should match")
 			assert.Equal(t, "10.0000000", pp.SendMax, "SendMax should match")
@@ -122,7 +122,7 @@ func TestManageSellOfferFromXDR(t *testing.T) {
 		var mso ManageSellOffer
 		err = mso.FromXDR(xdrEnv.Operations()[0])
 		if assert.NoError(t, err) {
-			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", mso.SourceAccount.GetAccountID(), "source accounts should match")
+			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", mso.SourceAccount, "source accounts should match")
 			assert.Equal(t, int64(0), mso.OfferID, "OfferID should match")
 			assert.Equal(t, "300.0000000", mso.Amount, "Amount should match")
 			assert.Equal(t, "5", mso.Price, "Price should match")
@@ -136,7 +136,7 @@ func TestManageSellOfferFromXDR(t *testing.T) {
 
 		err = mso.FromXDR(xdrEnv.Operations()[1])
 		if assert.NoError(t, err) {
-			assert.Equal(t, nil, mso.SourceAccount, "source accounts should match")
+			assert.Equal(t, "", mso.SourceAccount, "source accounts should match")
 			assert.Equal(t, int64(0), mso.OfferID, "OfferID should match")
 			assert.Equal(t, "400.0000000", mso.Amount, "Amount should match")
 			assert.Equal(t, "5", mso.Price, "Price should match")
@@ -159,7 +159,7 @@ func TestManageBuyOfferFromXDR(t *testing.T) {
 		var mbo ManageBuyOffer
 		err = mbo.FromXDR(xdrEnv.Operations()[0])
 		if assert.NoError(t, err) {
-			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", mbo.SourceAccount.GetAccountID(), "source accounts should match")
+			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", mbo.SourceAccount, "source accounts should match")
 			assert.Equal(t, int64(0), mbo.OfferID, "OfferID should match")
 			assert.Equal(t, "100.0000000", mbo.Amount, "Amount should match")
 			assert.Equal(t, "0.5", mbo.Price, "Price should match")
@@ -173,7 +173,7 @@ func TestManageBuyOfferFromXDR(t *testing.T) {
 
 		err = mbo.FromXDR(xdrEnv.Operations()[1])
 		if assert.NoError(t, err) {
-			assert.Equal(t, nil, mbo.SourceAccount, "source accounts should match")
+			assert.Equal(t, "", mbo.SourceAccount, "source accounts should match")
 			assert.Equal(t, int64(0), mbo.OfferID, "OfferID should match")
 			assert.Equal(t, "300.0000000", mbo.Amount, "Amount should match")
 			assert.Equal(t, "0.6", mbo.Price, "Price should match")
@@ -196,7 +196,7 @@ func TestCreatePassiveSellOfferFromXDR(t *testing.T) {
 		var cpo CreatePassiveSellOffer
 		err = cpo.FromXDR(xdrEnv.Operations()[0])
 		if assert.NoError(t, err) {
-			assert.Equal(t, nil, cpo.SourceAccount, "source accounts should match")
+			assert.Equal(t, "", cpo.SourceAccount, "source accounts should match")
 			assert.Equal(t, "10.0000000", cpo.Amount, "Amount should match")
 			assert.Equal(t, "1", cpo.Price, "Price should match")
 			assert.Equal(t, true, cpo.Selling.IsNative(), "Selling should be native")
@@ -253,7 +253,7 @@ func TestSetOptionsFromXDR(t *testing.T) {
 	var so SetOptions
 	err = so.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", so.SourceAccount.GetAccountID(), "source accounts should match")
+		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", so.SourceAccount, "source accounts should match")
 		assert.Equal(t, Threshold(7), *so.MasterWeight, "master weight should match")
 		assert.Equal(t, Threshold(2), *so.LowThreshold, "low threshold should match")
 		assert.Equal(t, Threshold(4), *so.MediumThreshold, "medium threshold should match")
@@ -295,7 +295,7 @@ func TestChangeTrustFromXDR(t *testing.T) {
 	var ct ChangeTrust
 	err = ct.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", ct.SourceAccount.GetAccountID(), "source accounts should match")
+		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", ct.SourceAccount, "source accounts should match")
 		assetType, e := ct.Line.GetType()
 		assert.NoError(t, e)
 
@@ -336,7 +336,7 @@ func TestAllowTrustFromXDR(t *testing.T) {
 	var at AllowTrust
 	err = at.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", at.SourceAccount.GetAccountID(), "source accounts should match")
+		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", at.SourceAccount, "source accounts should match")
 
 		assetType, e := at.Type.GetType()
 		assert.NoError(t, e)
@@ -367,7 +367,7 @@ func TestAccountMergeFromXDR(t *testing.T) {
 	var am AccountMerge
 	err = am.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", am.SourceAccount.GetAccountID(), "source accounts should match")
+		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", am.SourceAccount, "source accounts should match")
 		assert.Equal(t, "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3", am.Destination, "destination accounts should match")
 	}
 }
@@ -385,7 +385,7 @@ func TestInflationFromXDR(t *testing.T) {
 	var inf Inflation
 	err = inf.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", inf.SourceAccount.GetAccountID(), "source accounts should match")
+		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", inf.SourceAccount, "source accounts should match")
 	}
 }
 
@@ -412,7 +412,7 @@ func TestManageDataFromXDR(t *testing.T) {
 	var md ManageData
 	err = md.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", md.SourceAccount.GetAccountID(), "source accounts should match")
+		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", md.SourceAccount, "source accounts should match")
 		assert.Equal(t, "data", md.Name, "Name should match")
 		assert.Equal(t, "value", string(md.Value), "Value should match")
 	}
@@ -438,7 +438,7 @@ func TestBumpSequenceFromXDR(t *testing.T) {
 	var bs BumpSequence
 	err = bs.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", bs.SourceAccount.GetAccountID(), "source accounts should match")
+		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", bs.SourceAccount, "source accounts should match")
 		assert.Equal(t, int64(45), bs.BumpTo, "BumpTo should match")
 	}
 }

--- a/txnbuild/path_payment.go
+++ b/txnbuild/path_payment.go
@@ -21,7 +21,7 @@ type PathPaymentStrictReceive struct {
 	DestAsset     Asset
 	DestAmount    string
 	Path          []Asset
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for PathPaymentStrictReceive returns a fully configured XDR Operation.
@@ -160,8 +160,8 @@ func (pp *PathPaymentStrictReceive) Validate() error {
 	return nil
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (pp *PathPaymentStrictReceive) GetSourceAccount() Account {
+func (pp *PathPaymentStrictReceive) GetSourceAccount() string {
 	return pp.SourceAccount
 }

--- a/txnbuild/path_payment_strict_send.go
+++ b/txnbuild/path_payment_strict_send.go
@@ -15,7 +15,7 @@ type PathPaymentStrictSend struct {
 	DestAsset     Asset
 	DestMin       string
 	Path          []Asset
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for Payment returns a fully configured XDR Operation.
@@ -154,8 +154,8 @@ func (pp *PathPaymentStrictSend) Validate() error {
 	return nil
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (pp *PathPaymentStrictSend) GetSourceAccount() Account {
+func (pp *PathPaymentStrictSend) GetSourceAccount() string {
 	return pp.SourceAccount
 }

--- a/txnbuild/payment.go
+++ b/txnbuild/payment.go
@@ -12,7 +12,7 @@ type Payment struct {
 	Destination   string
 	Amount        string
 	Asset         Asset
-	SourceAccount Account
+	SourceAccount string
 }
 
 // BuildXDR for Payment returns a fully configured XDR Operation.
@@ -94,8 +94,8 @@ func (p *Payment) Validate() error {
 	return nil
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (p *Payment) GetSourceAccount() Account {
+func (p *Payment) GetSourceAccount() string {
 	return p.SourceAccount
 }

--- a/txnbuild/revoke_sponsorship.go
+++ b/txnbuild/revoke_sponsorship.go
@@ -23,7 +23,7 @@ const (
 // SponsorshipType stablishes which sponsorship is being revoked.
 // The other fields should be ignored.
 type RevokeSponsorship struct {
-	SourceAccount   Account
+	SourceAccount   string
 	SponsorshipType RevokeSponsorshipType
 	// Account ID (strkey)
 	Account   *string
@@ -278,6 +278,6 @@ func (r *RevokeSponsorship) Validate() error {
 	return nil
 }
 
-func (r *RevokeSponsorship) GetSourceAccount() Account {
+func (r *RevokeSponsorship) GetSourceAccount() string {
 	return r.SourceAccount
 }

--- a/txnbuild/revoke_sponsorship_test.go
+++ b/txnbuild/revoke_sponsorship_test.go
@@ -32,11 +32,7 @@ func TestRevokeSponsorship(t *testing.T) {
 			op: RevokeSponsorship{
 				SponsorshipType: RevokeSponsorshipTypeAccount,
 				Account:         &accountAddress,
-				SourceAccount: &SimpleAccount{
-					AccountID: accountAddress2,
-					// We intentionally don't set the sequence, since it isn't directly expressed in the XDR
-					// Sequence:  1,
-				},
+				SourceAccount:   accountAddress2,
 			},
 		},
 		{

--- a/txnbuild/set_options.go
+++ b/txnbuild/set_options.go
@@ -60,7 +60,7 @@ type SetOptions struct {
 	HomeDomain           *string
 	Signer               *Signer
 	xdrOp                xdr.SetOptionsOp
-	SourceAccount        Account
+	SourceAccount        string
 }
 
 // BuildXDR for SetOptions returns a fully configured XDR Operation.
@@ -318,8 +318,8 @@ func (so *SetOptions) Validate() error {
 	return nil
 }
 
-// GetSourceAccount returns the source account of the operation, or nil if not
+// GetSourceAccount returns the source account of the operation, or the empty string if not
 // set.
-func (so *SetOptions) GetSourceAccount() Account {
+func (so *SetOptions) GetSourceAccount() string {
 	return so.SourceAccount
 }

--- a/txnbuild/signers_test.go
+++ b/txnbuild/signers_test.go
@@ -14,11 +14,10 @@ func TestAccountMergeMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	accountMerge := AccountMerge{
 		Destination:   "GAS4V4O2B7DW5T7IQRPEEVCRXMDZESKISR7DVIGKZQYYV3OSQ5SH5LVP",
-		SourceAccount: &opSourceAccount,
+		SourceAccount: kp1.Address(),
 	}
 
 	received, err := newSignedTransaction(
@@ -40,7 +39,6 @@ func TestAccountMergeMultSigners(t *testing.T) {
 
 func TestAllowTrustMultSigners(t *testing.T) {
 	kp0 := newKeypair0()
-	opSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
 	txSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
@@ -50,7 +48,7 @@ func TestAllowTrustMultSigners(t *testing.T) {
 		Trustor:       kp1.Address(),
 		Type:          issuedAsset,
 		Authorize:     true,
-		SourceAccount: &opSourceAccount,
+		SourceAccount: kp0.Address(),
 	}
 
 	received, err := newSignedTransaction(
@@ -75,11 +73,10 @@ func TestBumpSequenceMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	bumpSequence := BumpSequence{
 		BumpTo:        9606132444168300,
-		SourceAccount: &opSourceAccount,
+		SourceAccount: kp1.Address(),
 	}
 
 	received, err := newSignedTransaction(
@@ -104,12 +101,11 @@ func TestChangeTrustMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	changeTrust := ChangeTrust{
 		Line:          CreditAsset{"ABCD", kp0.Address()},
 		Limit:         "10",
-		SourceAccount: &opSourceAccount,
+		SourceAccount: kp1.Address(),
 	}
 
 	received, err := newSignedTransaction(
@@ -134,12 +130,11 @@ func TestCreateAccountMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:        "10",
-		SourceAccount: &opSourceAccount,
+		SourceAccount: kp1.Address(),
 	}
 
 	received, err := newSignedTransaction(
@@ -164,14 +159,13 @@ func TestCreatePassiveSellOfferMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	createPassiveOffer := CreatePassiveSellOffer{
 		Selling:       NativeAsset{},
 		Buying:        CreditAsset{"ABCD", kp0.Address()},
 		Amount:        "10",
 		Price:         "1.0",
-		SourceAccount: &opSourceAccount,
+		SourceAccount: kp1.Address(),
 	}
 
 	received, err := newSignedTransaction(
@@ -196,10 +190,9 @@ func TestInflationMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	inflation := Inflation{
-		SourceAccount: &opSourceAccount,
+		SourceAccount: kp1.Address(),
 	}
 
 	received, err := newSignedTransaction(
@@ -224,12 +217,11 @@ func TestManageDataMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	manageData := ManageData{
 		Name:          "Fruit preference",
 		Value:         []byte("Apple"),
-		SourceAccount: &opSourceAccount,
+		SourceAccount: kp1.Address(),
 	}
 
 	received, err := newSignedTransaction(
@@ -254,13 +246,12 @@ func TestManageOfferCreateMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	selling := NativeAsset{}
 	buying := CreditAsset{"ABCD", kp0.Address()}
 	sellAmount := "100"
 	price := "0.01"
-	createOffer, err := CreateOfferOp(selling, buying, sellAmount, price, &opSourceAccount)
+	createOffer, err := CreateOfferOp(selling, buying, sellAmount, price, kp1.Address())
 	check(err)
 
 	received, err := newSignedTransaction(
@@ -285,10 +276,9 @@ func TestManageOfferDeleteMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	offerID := int64(2921622)
-	deleteOffer, err := DeleteOfferOp(offerID, &opSourceAccount)
+	deleteOffer, err := DeleteOfferOp(offerID, kp1.Address())
 	check(err)
 
 	received, err := newSignedTransaction(
@@ -313,14 +303,13 @@ func TestManageOfferUpdateMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	selling := NativeAsset{}
 	buying := CreditAsset{"ABCD", kp0.Address()}
 	sellAmount := "50"
 	price := "0.02"
 	offerID := int64(2497628)
-	updateOffer, err := UpdateOfferOp(selling, buying, sellAmount, price, offerID, &opSourceAccount)
+	updateOffer, err := UpdateOfferOp(selling, buying, sellAmount, price, offerID, kp1.Address())
 	check(err)
 
 	received, err := newSignedTransaction(
@@ -345,7 +334,6 @@ func TestPathPaymentMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	abcdAsset := CreditAsset{"ABCD", kp0.Address()}
 	pathPayment := PathPayment{
@@ -355,7 +343,7 @@ func TestPathPaymentMultSigners(t *testing.T) {
 		DestAsset:     NativeAsset{},
 		DestAmount:    "1",
 		Path:          []Asset{abcdAsset},
-		SourceAccount: &opSourceAccount,
+		SourceAccount: kp1.Address(),
 	}
 
 	received, err := newSignedTransaction(
@@ -381,13 +369,12 @@ func TestPaymentMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	payment := Payment{
 		Destination:   "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
 		Amount:        "10",
 		Asset:         NativeAsset{},
-		SourceAccount: &opSourceAccount,
+		SourceAccount: kp1.Address(),
 	}
 
 	received, err := newSignedTransaction(
@@ -412,11 +399,10 @@ func TestSetOptionsMultSigners(t *testing.T) {
 	txSourceAccount := NewSimpleAccount(kp0.Address(), int64(9605939170639898))
 
 	kp1 := newKeypair1()
-	opSourceAccount := NewSimpleAccount(kp1.Address(), int64(9606132444168199))
 
 	setOptions := SetOptions{
 		SetFlags:      []AccountFlag{AuthRequired, AuthRevocable},
-		SourceAccount: &opSourceAccount,
+		SourceAccount: kp1.Address(),
 	}
 
 	received, err := newSignedTransaction(

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -335,6 +335,10 @@ func (t *Transaction) ClaimableBalanceID(operationIndex int) (string, error) {
 		return "", errors.New("invalid operation index")
 	}
 
+	if _, ok := t.operations[operationIndex].(*CreateClaimableBalance); !ok {
+		return "", errors.New("operation is not CreateClaimableBalance")
+	}
+
 	// We mimic the relevant code from Stellar Core
 	// https://github.com/stellar/stellar-core/blob/9f3cc04e6ec02c38974c42545a86cdc79809252b/src/test/TestAccount.cpp#L285
 	operationId := xdr.OperationId{

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -335,29 +335,13 @@ func (t *Transaction) ClaimableBalanceID(operationIndex int) (string, error) {
 		return "", errors.New("invalid operation index")
 	}
 
-	operation, ok := t.operations[operationIndex].(*CreateClaimableBalance)
-	if !ok {
-		return "", errors.New("operation is not CreateClaimableBalance")
-	}
-
-	// Use the operation's source account or the transaction's source if not.
-	var account Account = &t.sourceAccount
-	if operation.SourceAccount != nil {
-		account = operation.GetSourceAccount()
-	}
-
-	seq, err := account.GetSequenceNumber()
-	if err != nil {
-		return "", errors.Wrap(err, "failed to retrieve account sequence number")
-	}
-
 	// We mimic the relevant code from Stellar Core
 	// https://github.com/stellar/stellar-core/blob/9f3cc04e6ec02c38974c42545a86cdc79809252b/src/test/TestAccount.cpp#L285
 	operationId := xdr.OperationId{
 		Type: xdr.EnvelopeTypeEnvelopeTypeOpId,
 		Id: &xdr.OperationIdId{
-			SourceAccount: xdr.MustMuxedAddress(account.GetAccountID()),
-			SeqNum:        xdr.SequenceNumber(seq),
+			SourceAccount: xdr.MustMuxedAddress(t.sourceAccount.AccountID),
+			SeqNum:        xdr.SequenceNumber(t.sourceAccount.Sequence),
 			OpNum:         xdr.Uint32(operationIndex),
 		},
 	}
@@ -850,11 +834,6 @@ func BuildChallengeTx(serverSignerSecret, clientAccountID, homeDomain, network s
 		Sequence:  0,
 	}
 
-	// represent client account as SimpleAccount
-	ca := SimpleAccount{
-		AccountID: clientAccountID,
-	}
-
 	currentTime := time.Now().UTC()
 	maxTime := currentTime.Add(timebound)
 
@@ -866,7 +845,7 @@ func BuildChallengeTx(serverSignerSecret, clientAccountID, homeDomain, network s
 			IncrementSequenceNum: false,
 			Operations: []Operation{
 				&ManageData{
-					SourceAccount: &ca,
+					SourceAccount: clientAccountID,
 					Name:          homeDomain + " auth",
 					Value:         []byte(randomNonceToString),
 				},
@@ -966,7 +945,7 @@ func ReadChallengeTx(challengeTx, serverAccountID, network string, homeDomains [
 	if !ok {
 		return tx, clientAccountID, matchedHomeDomain, errors.New("operation type should be manage_data")
 	}
-	if op.SourceAccount == nil {
+	if op.SourceAccount == "" {
 		return tx, clientAccountID, matchedHomeDomain, errors.New("operation should have a source account")
 	}
 	for _, homeDomain := range homeDomains {
@@ -979,7 +958,7 @@ func ReadChallengeTx(challengeTx, serverAccountID, network string, homeDomains [
 		return tx, clientAccountID, matchedHomeDomain, errors.Errorf("operation key does not match any homeDomains passed (key=%q, homeDomains=%v)", op.Name, homeDomains)
 	}
 
-	clientAccountID = op.SourceAccount.GetAccountID()
+	clientAccountID = op.SourceAccount
 	rawOperations := tx.envelope.Operations()
 	if len(rawOperations) > 0 && rawOperations[0].SourceAccount.Type == xdr.CryptoKeyTypeKeyTypeMuxedEd25519 {
 		err = errors.New("invalid operation source account: only valid Ed25519 accounts are allowed in challenge transactions")
@@ -1005,10 +984,10 @@ func ReadChallengeTx(challengeTx, serverAccountID, network string, homeDomains [
 		if !ok {
 			return tx, clientAccountID, matchedHomeDomain, errors.New("operation type should be manage_data")
 		}
-		if op.SourceAccount == nil {
+		if op.SourceAccount == "" {
 			return tx, clientAccountID, matchedHomeDomain, errors.New("operation should have a source account")
 		}
-		if op.SourceAccount.GetAccountID() != serverAccountID {
+		if op.SourceAccount != serverAccountID {
 			return tx, clientAccountID, matchedHomeDomain, errors.New("subsequent operations are unrecognized")
 		}
 	}

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1270,7 +1270,7 @@ func TestFromXDR(t *testing.T) {
 	assert.IsType(t, newTx.Operations()[0], &Payment{}, "Operation types should match")
 	paymentOp, ok1 := newTx.Operations()[0].(*Payment)
 	assert.Equal(t, true, ok1)
-	assert.Equal(t, "GATBMIXTHXYKSUZSZUEJKACZ2OS2IYUWP2AIF3CA32PIDLJ67CH6Y5UY", paymentOp.SourceAccount.GetAccountID(), "Operation source should match")
+	assert.Equal(t, "GATBMIXTHXYKSUZSZUEJKACZ2OS2IYUWP2AIF3CA32PIDLJ67CH6Y5UY", paymentOp.SourceAccount, "Operation source should match")
 	assert.Equal(t, "GDGEQS64ISS6Y2KDM5V67B6LXALJX4E7VE4MIA54NANSUX5MKGKBZM5G", paymentOp.Destination, "Operation destination should match")
 	assert.Equal(t, "874.0000000", paymentOp.Amount, "Operation amount should match")
 
@@ -1295,7 +1295,7 @@ func TestFromXDR(t *testing.T) {
 	assert.IsType(t, newTx2.Operations()[1], &ManageData{}, "Operation types should match")
 	op1, ok1 := newTx2.Operations()[0].(*ChangeTrust)
 	assert.Equal(t, true, ok1)
-	assert.Equal(t, "GD4Q3HT4IMFTIYLYRPTJQ7XLKROGGEUV74WTL26KPEWUTF72AJKGSJS7", op1.SourceAccount.GetAccountID(), "Operation source should match")
+	assert.Equal(t, "GD4Q3HT4IMFTIYLYRPTJQ7XLKROGGEUV74WTL26KPEWUTF72AJKGSJS7", op1.SourceAccount, "Operation source should match")
 	assetType, err := op1.Line.GetType()
 	assert.NoError(t, err)
 
@@ -1306,7 +1306,7 @@ func TestFromXDR(t *testing.T) {
 
 	op2, ok2 := newTx2.Operations()[1].(*ManageData)
 	assert.Equal(t, true, ok2)
-	assert.Equal(t, nil, op2.SourceAccount, "Operation source should match")
+	assert.Equal(t, "", op2.SourceAccount, "Operation source should match")
 	assert.Equal(t, "test", op2.Name, "Name should match")
 	assert.Equal(t, "value", string(op2.Value), "Value should match")
 }
@@ -1399,11 +1399,10 @@ func TestSignWithSecretKey(t *testing.T) {
 	kp1 := newKeypair1()
 	txSource := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
 	tx1Source := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
-	opSource := NewSimpleAccount(kp1.Address(), 0)
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:        "10",
-		SourceAccount: &opSource,
+		SourceAccount: kp1.Address(),
 	}
 
 	expected, err := newSignedTransaction(
@@ -1447,11 +1446,10 @@ func TestAddSignatureBase64(t *testing.T) {
 	kp1 := newKeypair1()
 	txSource := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
 	tx1Source := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
-	opSource := NewSimpleAccount(kp1.Address(), 0)
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:        "10",
-		SourceAccount: &opSource,
+		SourceAccount: kp1.Address(),
 	}
 
 	expected, err := newSignedTransaction(
@@ -1500,9 +1498,8 @@ func TestReadChallengeTx_validSignedByServerAndClient(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -1532,9 +1529,8 @@ func TestReadChallengeTx_validSignedByServer(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -1563,9 +1559,8 @@ func TestReadChallengeTx_invalidNotSignedByServer(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -1592,9 +1587,8 @@ func TestReadChallengeTx_invalidCorrupted(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -1629,9 +1623,8 @@ func TestReadChallengeTx_invalidServerAccountIDMismatch(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(newKeypair2().Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -1660,9 +1653,8 @@ func TestReadChallengeTx_invalidSeqNoNotZero(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), 1234)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -1691,9 +1683,8 @@ func TestReadChallengeTx_invalidTimeboundsInfinite(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -1722,9 +1713,8 @@ func TestReadChallengeTx_invalidTimeboundsOutsideRange(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -1754,9 +1744,8 @@ func TestReadChallengeTx_invalidOperationWrongType(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := BumpSequence{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		BumpTo:        0,
 	}
 	tx, err := NewTransaction(
@@ -1810,9 +1799,8 @@ func TestReadChallengeTx_invalidDataValueWrongEncodedLength(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 45))),
 	}
@@ -1841,9 +1829,8 @@ func TestReadChallengeTx_invalidDataValueCorruptBase64(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA?AAAAAAAAAAAAAAAAAAAAAAAAAA"),
 	}
@@ -1872,9 +1859,8 @@ func TestReadChallengeTx_invalidDataValueWrongByteLength(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 47))),
 	}
@@ -2012,9 +1998,8 @@ func TestReadChallengeTx_doesVerifyHomeDomainFailure(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2041,9 +2026,8 @@ func TestReadChallengeTx_doesVerifyHomeDomainSuccess(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2070,14 +2054,13 @@ func TestReadChallengeTx_allowsAdditionalManageDataOpsWithSourceAccountSetToServ
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op1 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := ManageData{
-		SourceAccount: &txSource,
+		SourceAccount: txSource.AccountID,
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte("a value"),
 	}
@@ -2106,14 +2089,13 @@ func TestReadChallengeTx_disallowsAdditionalManageDataOpsWithoutSourceAccountSet
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op1 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "a key",
 		Value:         []byte("a value"),
 	}
@@ -2140,14 +2122,13 @@ func TestReadChallengeTx_disallowsAdditionalOpsOfOtherTypes(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op1 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := BumpSequence{
-		SourceAccount: &txSource,
+		SourceAccount: txSource.AccountID,
 		BumpTo:        0,
 	}
 	tx, err := NewTransaction(
@@ -2175,9 +2156,8 @@ func TestReadChallengeTx_matchesHomeDomain(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op1 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2204,9 +2184,8 @@ func TestReadChallengeTx_doesNotMatchHomeDomain(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op1 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2233,9 +2212,8 @@ func TestVerifyChallengeTxThreshold_invalidServer(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2266,9 +2244,8 @@ func TestVerifyChallengeTxThreshold_validServerAndClientKeyMeetingThreshold(t *t
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2303,9 +2280,8 @@ func TestVerifyChallengeTxThreshold_validServerAndMultipleClientKeyMeetingThresh
 	clientKP1 := newKeypair1()
 	clientKP2 := newKeypair2()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP1.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP1.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2343,9 +2319,8 @@ func TestVerifyChallengeTxThreshold_validServerAndMultipleClientKeyMeetingThresh
 	clientKP2 := newKeypair2()
 	clientKP3 := keypair.MustRandom()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP1.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP1.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2387,9 +2362,8 @@ func TestVerifyChallengeTxThreshold_validServerAndMultipleClientKeyMeetingThresh
 	xHash := "XDRPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD"
 	unknownSignerType := "?ARPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD"
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP1.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP1.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2431,9 +2405,8 @@ func TestVerifyChallengeTxThreshold_invalidServerAndMultipleClientKeyNotMeetingT
 	clientKP2 := newKeypair2()
 	clientKP3 := keypair.MustRandom()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP1.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP1.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2467,9 +2440,8 @@ func TestVerifyChallengeTxThreshold_invalidClientKeyUnrecognized(t *testing.T) {
 	clientKP2 := newKeypair2()
 	clientKP3 := keypair.MustRandom()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP1.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP1.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2502,9 +2474,8 @@ func TestVerifyChallengeTxThreshold_invalidNoSigners(t *testing.T) {
 	clientKP2 := newKeypair2()
 	clientKP3 := keypair.MustRandom()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP1.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP1.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2533,9 +2504,8 @@ func TestVerifyChallengeTxThreshold_weightsAddToMoreThan8Bits(t *testing.T) {
 	clientKP1 := newKeypair1()
 	clientKP2 := newKeypair2()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP1.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP1.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2571,9 +2541,8 @@ func TestVerifyChallengeTxThreshold_matchesHomeDomain(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op1 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2609,9 +2578,8 @@ func TestVerifyChallengeTxThreshold_doesNotMatchHomeDomain(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op1 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2643,9 +2611,8 @@ func TestVerifyChallengeTxThreshold_doesVerifyHomeDomainFailure(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "will fail auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2675,9 +2642,8 @@ func TestVerifyChallengeTxThreshold_doesVerifyHomeDomainSuccess(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2711,14 +2677,14 @@ func TestVerifyChallengeTxThreshold_allowsAdditionalManageDataOpsWithSourceAccou
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op1 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := ManageData{
-		SourceAccount: &txSource,
+		SourceAccount: txSource.AccountID,
 		Name:          "a key",
 		Value:         []byte("a value"),
 	}
@@ -2752,14 +2718,14 @@ func TestVerifyChallengeTxThreshold_disallowsAdditionalManageDataOpsWithoutSourc
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op1 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "a key",
 		Value:         []byte("a value"),
 	}
@@ -2790,14 +2756,14 @@ func TestVerifyChallengeTxThreshold_disallowsAdditionalOpsOfOtherTypes(t *testin
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op1 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := BumpSequence{
-		SourceAccount: &txSource,
+		SourceAccount: txSource.AccountID,
 		BumpTo:        0,
 	}
 	tx64, err := newSignedTransaction(
@@ -2827,9 +2793,9 @@ func TestVerifyChallengeTxSigners_invalidServer(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2855,9 +2821,9 @@ func TestVerifyChallengeTxSigners_validServerAndClientMasterKey(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2883,9 +2849,9 @@ func TestVerifyChallengeTxSigners_invalidServerAndNoClient(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2912,9 +2878,9 @@ func TestVerifyChallengeTxSigners_invalidServerAndUnrecognizedClient(t *testing.
 	clientKP := newKeypair1()
 	unrecognizedKP := newKeypair2()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2941,9 +2907,9 @@ func TestVerifyChallengeTxSigners_validServerAndMultipleClientSigners(t *testing
 	clientKP := newKeypair1()
 	clientKP2 := newKeypair2()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2970,9 +2936,9 @@ func TestVerifyChallengeTxSigners_validServerAndMultipleClientSignersReverseOrde
 	clientKP := newKeypair1()
 	clientKP2 := newKeypair2()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -2999,9 +2965,9 @@ func TestVerifyChallengeTxSigners_validServerAndClientSignersNotMasterKey(t *tes
 	clientKP := newKeypair1()
 	clientKP2 := newKeypair2()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -3028,9 +2994,9 @@ func TestVerifyChallengeTxSigners_validServerAndClientSignersIgnoresServerSigner
 	clientKP := newKeypair1()
 	clientKP2 := newKeypair2()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -3057,9 +3023,9 @@ func TestVerifyChallengeTxSigners_invalidServerNoClientSignersIgnoresServerSigne
 	clientKP := newKeypair1()
 	clientKP2 := newKeypair2()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -3086,9 +3052,9 @@ func TestVerifyChallengeTxSigners_validServerAndClientSignersIgnoresDuplicateSig
 	clientKP := newKeypair1()
 	clientKP2 := newKeypair2()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -3118,9 +3084,9 @@ func TestVerifyChallengeTxSigners_validIgnorePreauthTxHashAndXHash(t *testing.T)
 	xHash := "XDRPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD"
 	unknownSignerType := "?ARPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD"
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -3147,9 +3113,9 @@ func TestVerifyChallengeTxSigners_invalidServerAndClientSignersIgnoresDuplicateS
 	clientKP := newKeypair1()
 	clientKP2 := newKeypair2()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -3176,9 +3142,9 @@ func TestVerifyChallengeTxSigners_invalidServerAndClientSignersFailsDuplicateSig
 	clientKP := newKeypair1()
 	clientKP2 := newKeypair2()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -3205,9 +3171,9 @@ func TestVerifyChallengeTxSigners_invalidServerAndClientSignersFailsSignerSeed(t
 	clientKP := newKeypair1()
 	clientKP2 := newKeypair2()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -3233,9 +3199,9 @@ func TestVerifyChallengeTxSigners_invalidNoSigners(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -3260,9 +3226,9 @@ func TestVerifyChallengeTxSigners_doesVerifyHomeDomainFailure(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -3287,9 +3253,9 @@ func TestVerifyChallengeTxSigners_matchesHomeDomain(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op1 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -3321,9 +3287,9 @@ func TestVerifyChallengeTxSigners_doesNotMatchHomeDomain(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op1 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -3355,9 +3321,9 @@ func TestVerifyChallengeTxSigners_doesVerifyHomeDomainSuccess(t *testing.T) {
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
@@ -3382,14 +3348,14 @@ func TestVerifyChallengeTxSigners_allowsAdditionalManageDataOpsWithSourceAccount
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op1 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := ManageData{
-		SourceAccount: &txSource,
+		SourceAccount: txSource.AccountID,
 		Name:          "a key",
 		Value:         []byte("a value"),
 	}
@@ -3415,14 +3381,14 @@ func TestVerifyChallengeTxSigners_disallowsAdditionalManageDataOpsWithoutSourceA
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op1 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "a key",
 		Value:         []byte("a value"),
 	}
@@ -3448,14 +3414,14 @@ func TestVerifyChallengeTxSigners_disallowsAdditionalOpsOfOtherTypes(t *testing.
 	serverKP := newKeypair0()
 	clientKP := newKeypair1()
 	txSource := NewSimpleAccount(serverKP.Address(), -1)
-	opSource := NewSimpleAccount(clientKP.Address(), 0)
+
 	op1 := ManageData{
-		SourceAccount: &opSource,
+		SourceAccount: clientKP.Address(),
 		Name:          "testanchor.stellar.org auth",
 		Value:         []byte(base64.StdEncoding.EncodeToString(make([]byte, 48))),
 	}
 	op2 := BumpSequence{
-		SourceAccount: &txSource,
+		SourceAccount: txSource.AccountID,
 		BumpTo:        0,
 	}
 	tx64, err := newSignedTransaction(
@@ -3480,11 +3446,10 @@ func TestVerifyTxSignatureUnsignedTx(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
 	txSource := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
-	opSource := NewSimpleAccount(kp1.Address(), 0)
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:        "10",
-		SourceAccount: &opSource,
+		SourceAccount: kp1.Address(),
 	}
 	tx, err := NewTransaction(
 		TransactionParams{
@@ -3507,11 +3472,10 @@ func TestVerifyTxSignatureSingle(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
 	txSource := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
-	opSource := NewSimpleAccount(kp1.Address(), 0)
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:        "10",
-		SourceAccount: &opSource,
+		SourceAccount: kp1.Address(),
 	}
 	tx, err := NewTransaction(
 		TransactionParams{
@@ -3534,11 +3498,10 @@ func TestVerifyTxSignatureMultiple(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
 	txSource := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
-	opSource := NewSimpleAccount(kp1.Address(), 0)
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:        "10",
-		SourceAccount: &opSource,
+		SourceAccount: kp1.Address(),
 	}
 	tx, err := NewTransaction(
 		TransactionParams{
@@ -3563,11 +3526,10 @@ func TestVerifyTxSignatureInvalid(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()
 	txSource := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
-	opSource := NewSimpleAccount(kp1.Address(), 0)
 	createAccount := CreateAccount{
 		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
 		Amount:        "10",
-		SourceAccount: &opSource,
+		SourceAccount: kp1.Address(),
 	}
 	tx, err := NewTransaction(
 		TransactionParams{


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Close https://github.com/stellar/go/issues/2813

Use strings to represent accounts in txnbuild operations.

This PR also fixes a bug `ClaimableBalanceID()`. The function builds an `xdr.OperationId` using the **operation** source account and the sequence number of the **operation** source account. It seems like we should be using the **transaction** source account and the sequence number found in the **transaction**. That is my understanding based on https://github.com/stellar/stellar-core/blob/b0cc4a9b8c3423358d1881b991834cf658bc38f5/src/transactions/CreateClaimableBalanceOpFrame.cpp#L278[…]L288

### Why

We have an `Account` interface to represent Stellar accounts. The interface includes functions to get the account address and the account sequence number. This interface is useful for describing the source account of a Stellar transaction since we need to obtain the sequence number in order to define the transaction.

Many transaction operations also include `Account` fields. However, we never need the sequence number of an account to build an operation XDR. Instead of using the `Account` interface in operation structs, it would be more ergonomic to use strings since we only care about he account address when constructing operations.

### Known limitations

[N/A]
