### PR TITLE
all: update go versions to latest minor versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,8 +115,8 @@ commands:
           name: Download and install golang
           command: |
             sudo rm -rf /usr/local/go
-            wget https://dl.google.com/go/go1.14.6.linux-amd64.tar.gz
-            sudo tar -C /usr/local -xzf go1.14.6.linux-amd64.tar.gz
+            wget https://dl.google.com/go/go1.14.15.linux-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go1.14.15.linux-amd64.tar.gz
 
   # install_go_deps installs the go dependencies of the project.
   install_go_deps:
@@ -244,7 +244,7 @@ jobs:
   check_code_1_15:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.15.7
+      - image: golang:1.15.8
     steps:
       - install_go_deps
       - check_go_deps
@@ -258,7 +258,7 @@ jobs:
   test_code_1_14:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.14.14-stretch
+      - image: golang:1.14.15-stretch
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -278,7 +278,7 @@ jobs:
   test_code_1_14_postgres10:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.14.14-stretch
+      - image: golang:1.14.15-stretch
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -299,7 +299,7 @@ jobs:
   test_code_1_15:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.15.7
+      - image: golang:1.15.8
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -319,7 +319,7 @@ jobs:
   test_code_1_15_postgres10:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.15.7
+      - image: golang:1.15.8
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -388,7 +388,7 @@ jobs:
       # Artifacts are built on Go 1.14 because a Go 1.15 Docker image for
       # Debian Stretch is currently not available. See
       # https://github.com/docker-library/golang/issues/344.
-      - image: golang:1.14.14-stretch
+      - image: golang:1.14.15-stretch
     steps:
       - check_deprecations
       - install_go_deps


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Update go versions to latest minor versions

### Why

Go 1.14.15 and 1.15.8 were released yesterday.

Also it looks like we are using an older version of Go in one part of the build process.

### Known limitations

N/A
