### PR TITLE
all: remove lint messages from package doc

### DIFF
--- a/services/horizon/internal/ingest/build_state_test.go
+++ b/services/horizon/internal/ingest/build_state_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package ingest
 
 import (

--- a/services/horizon/internal/ingest/db_integration_test.go
+++ b/services/horizon/internal/ingest/db_integration_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package ingest
 
 import (

--- a/services/horizon/internal/ingest/group_processors_test.go
+++ b/services/horizon/internal/ingest/group_processors_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package ingest
 
 import (

--- a/services/horizon/internal/ingest/ingest_history_range_state_test.go
+++ b/services/horizon/internal/ingest/ingest_history_range_state_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package ingest
 
 import (

--- a/services/horizon/internal/ingest/init_state_test.go
+++ b/services/horizon/internal/ingest/init_state_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package ingest
 
 import (

--- a/services/horizon/internal/ingest/orderbook_test.go
+++ b/services/horizon/internal/ingest/orderbook_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package ingest
 
 import (

--- a/services/horizon/internal/ingest/processors/accounts_data_processor_test.go
+++ b/services/horizon/internal/ingest/processors/accounts_data_processor_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package processors
 
 import (

--- a/services/horizon/internal/ingest/processors/accounts_processor_test.go
+++ b/services/horizon/internal/ingest/processors/accounts_processor_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package processors
 
 import (

--- a/services/horizon/internal/ingest/processors/asset_stats_processor_test.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package processors
 
 import (

--- a/services/horizon/internal/ingest/processors/claimable_balances_processor_test.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_processor_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package processors
 
 import (

--- a/services/horizon/internal/ingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/ingest/processors/effects_processor_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package processors
 
 import (

--- a/services/horizon/internal/ingest/processors/ledgers_processor_test.go
+++ b/services/horizon/internal/ingest/processors/ledgers_processor_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package processors
 
 import (

--- a/services/horizon/internal/ingest/processors/offers_processor_test.go
+++ b/services/horizon/internal/ingest/processors/offers_processor_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package processors
 
 import (

--- a/services/horizon/internal/ingest/processors/operations_processor_test.go
+++ b/services/horizon/internal/ingest/processors/operations_processor_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package processors
 
 import (

--- a/services/horizon/internal/ingest/processors/participants_processor.go
+++ b/services/horizon/internal/ingest/processors/participants_processor.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package processors
 
 import (

--- a/services/horizon/internal/ingest/processors/participants_processor_test.go
+++ b/services/horizon/internal/ingest/processors/participants_processor_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package processors
 
 import (

--- a/services/horizon/internal/ingest/processors/signer_processor_test.go
+++ b/services/horizon/internal/ingest/processors/signer_processor_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package processors
 
 import (

--- a/services/horizon/internal/ingest/processors/trades_processor_test.go
+++ b/services/horizon/internal/ingest/processors/trades_processor_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package processors
 
 import (

--- a/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
+++ b/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package processors
 
 import (

--- a/services/horizon/internal/ingest/processors/transactions_processor_test.go
+++ b/services/horizon/internal/ingest/processors/transactions_processor_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package processors
 
 import (

--- a/services/horizon/internal/ingest/processors/trust_lines_processor_test.go
+++ b/services/horizon/internal/ingest/processors/trust_lines_processor_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package processors
 
 import (

--- a/services/horizon/internal/ingest/resume_state_test.go
+++ b/services/horizon/internal/ingest/resume_state_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package ingest
 
 import (

--- a/services/horizon/internal/ingest/stress_test.go
+++ b/services/horizon/internal/ingest/stress_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package ingest
 
 import (

--- a/services/horizon/internal/ingest/verify/main_test.go
+++ b/services/horizon/internal/ingest/verify/main_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package verify
 
 import (

--- a/services/horizon/internal/ingest/verify_range_state_test.go
+++ b/services/horizon/internal/ingest/verify_range_state_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package ingest
 
 import (

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package horizon
 
 import (

--- a/services/horizon/internal/render/sse/stream_test.go
+++ b/services/horizon/internal/render/sse/stream_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package sse
 
 import (

--- a/services/horizon/internal/txsub/open_submission_list_test.go
+++ b/services/horizon/internal/txsub/open_submission_list_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package txsub
 
 import (

--- a/services/horizon/internal/txsub/sequence/queue_test.go
+++ b/services/horizon/internal/txsub/sequence/queue_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package sequence
 
 import (

--- a/services/horizon/internal/txsub/system_test.go
+++ b/services/horizon/internal/txsub/system_test.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package txsub
 
 import (

--- a/txnbuild/begin_sponsoring_future_reserves.go
+++ b/txnbuild/begin_sponsoring_future_reserves.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package txnbuild
 
 import (

--- a/txnbuild/claim_claimable_balance.go
+++ b/txnbuild/claim_claimable_balance.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package txnbuild
 
 import (

--- a/txnbuild/create_claimable_balance.go
+++ b/txnbuild/create_claimable_balance.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package txnbuild
 
 import (

--- a/txnbuild/end_sponsoring_future_reserves.go
+++ b/txnbuild/end_sponsoring_future_reserves.go
@@ -1,4 +1,5 @@
 //lint:file-ignore U1001 Ignore all unused code, staticcheck doesn't understand testify/suite
+
 package txnbuild
 
 import (


### PR DESCRIPTION
### What
Remove the staticcheck lint comments from package docs.

### Why
At some point we added `//lint:file-ignore` comments to files in the repo. We added the comments to the top of the file on the line above the `package` declaration, which unfortunately godoc.org and other Go documentation tools interpret to mean it is documentation for the package. Comments that are intended to be file level but not package documentation need to have an empty line separating them from package documentation or the package declaration. This change adds those empty lines.

<img width="1420" alt="Screen Shot 2021-02-09 at 9 07 59 PM" src="https://user-images.githubusercontent.com/351529/107467528-11b07c80-6b1b-11eb-9533-5c8299237d6c.png">


### Known limitations

N/A