### PR TITLE
historyarchive: Introduce a History Archive pool that's selected from for all calls

### DIFF
--- a/historyarchive/archive_pool.go
+++ b/historyarchive/archive_pool.go
@@ -15,16 +15,13 @@ import (
 // distribute requests fairly throughout the pool.
 type ArchivePool []ArchiveInterface
 
-// CreatePool tries connecting to each of the provided history archive URLs,
+// NewArchivePool tries connecting to each of the provided history archive URLs,
 // returning a pool of valid archives.
 //
 // If none of the archives work, this returns the error message of the last
 // failed archive. Note that the errors for each individual archive are hard to
 // track if there's success overall.
-//
-// Possible FIXME for the above limitation: return []error instead? but then
-// users need to check `len(pool) > 0` instead of `err == nil`.
-func CreatePool(archiveURLs []string, config ConnectOptions) (ArchivePool, error) {
+func NewArchivePool(archiveURLs []string, config ConnectOptions) (ArchivePool, error) {
 	if len(archiveURLs) <= 0 {
 		return nil, errors.New("No history archives provided")
 	}

--- a/historyarchive/pool.go
+++ b/historyarchive/pool.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-// A PooledArchive is just a collection of `ArchiveInterface`s so that we can
+// A ArchivePool is just a collection of `ArchiveInterface`s so that we can
 // distribute requests fairly throughout the pool.
-type PooledArchive []ArchiveInterface
+type ArchivePool []ArchiveInterface
 
 // CreatePool tries connecting to each of the provided history archive URLs,
 // returning a pool of valid archives.
@@ -24,7 +24,7 @@ type PooledArchive []ArchiveInterface
 //
 // Possible FIXME for the above limitation: return []error instead? but then
 // users need to check `len(pool) > 0` instead of `err == nil`.
-func CreatePool(archiveURLs []string, config ConnectOptions) (PooledArchive, error) {
+func CreatePool(archiveURLs []string, config ConnectOptions) (ArchivePool, error) {
 	if len(archiveURLs) <= 0 {
 		return nil, errors.New("No history archives provided")
 	}
@@ -32,7 +32,7 @@ func CreatePool(archiveURLs []string, config ConnectOptions) (PooledArchive, err
 	var lastErr error = nil
 
 	// Try connecting to all of the listed archives, but only store valid ones.
-	var validArchives PooledArchive
+	var validArchives ArchivePool
 	for _, url := range archiveURLs {
 		archive, err := Connect(
 			url,
@@ -59,78 +59,78 @@ func CreatePool(archiveURLs []string, config ConnectOptions) (PooledArchive, err
 }
 
 // Ensure the pool conforms to the ArchiveInterface
-var _ ArchiveInterface = PooledArchive{}
+var _ ArchiveInterface = ArchivePool{}
 
 // Below are the ArchiveInterface method implementations.
 
-func (pa PooledArchive) GetAnyArchive() ArchiveInterface {
+func (pa ArchivePool) GetAnyArchive() ArchiveInterface {
 	return pa[rand.Intn(len(pa))]
 }
 
-func (pa PooledArchive) GetPathHAS(path string) (HistoryArchiveState, error) {
+func (pa ArchivePool) GetPathHAS(path string) (HistoryArchiveState, error) {
 	return pa.GetAnyArchive().GetPathHAS(path)
 }
 
-func (pa PooledArchive) PutPathHAS(path string, has HistoryArchiveState, opts *CommandOptions) error {
+func (pa ArchivePool) PutPathHAS(path string, has HistoryArchiveState, opts *CommandOptions) error {
 	return pa.GetAnyArchive().PutPathHAS(path, has, opts)
 }
 
-func (pa PooledArchive) BucketExists(bucket Hash) (bool, error) {
+func (pa ArchivePool) BucketExists(bucket Hash) (bool, error) {
 	return pa.GetAnyArchive().BucketExists(bucket)
 }
 
-func (pa PooledArchive) CategoryCheckpointExists(cat string, chk uint32) (bool, error) {
+func (pa ArchivePool) CategoryCheckpointExists(cat string, chk uint32) (bool, error) {
 	return pa.GetAnyArchive().CategoryCheckpointExists(cat, chk)
 }
 
-func (pa PooledArchive) GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, error) {
+func (pa ArchivePool) GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, error) {
 	return pa.GetAnyArchive().GetLedgerHeader(chk)
 }
 
-func (pa PooledArchive) GetRootHAS() (HistoryArchiveState, error) {
+func (pa ArchivePool) GetRootHAS() (HistoryArchiveState, error) {
 	return pa.GetAnyArchive().GetRootHAS()
 }
 
-func (pa PooledArchive) GetLedgers(start, end uint32) (map[uint32]*Ledger, error) {
+func (pa ArchivePool) GetLedgers(start, end uint32) (map[uint32]*Ledger, error) {
 	return pa.GetAnyArchive().GetLedgers(start, end)
 }
 
-func (pa PooledArchive) GetCheckpointHAS(chk uint32) (HistoryArchiveState, error) {
+func (pa ArchivePool) GetCheckpointHAS(chk uint32) (HistoryArchiveState, error) {
 	return pa.GetAnyArchive().GetCheckpointHAS(chk)
 }
 
-func (pa PooledArchive) PutCheckpointHAS(chk uint32, has HistoryArchiveState, opts *CommandOptions) error {
+func (pa ArchivePool) PutCheckpointHAS(chk uint32, has HistoryArchiveState, opts *CommandOptions) error {
 	return pa.GetAnyArchive().PutCheckpointHAS(chk, has, opts)
 }
 
-func (pa PooledArchive) PutRootHAS(has HistoryArchiveState, opts *CommandOptions) error {
+func (pa ArchivePool) PutRootHAS(has HistoryArchiveState, opts *CommandOptions) error {
 	return pa.GetAnyArchive().PutRootHAS(has, opts)
 }
 
-func (pa PooledArchive) ListBucket(dp DirPrefix) (chan string, chan error) {
+func (pa ArchivePool) ListBucket(dp DirPrefix) (chan string, chan error) {
 	return pa.GetAnyArchive().ListBucket(dp)
 }
 
-func (pa PooledArchive) ListAllBuckets() (chan string, chan error) {
+func (pa ArchivePool) ListAllBuckets() (chan string, chan error) {
 	return pa.GetAnyArchive().ListAllBuckets()
 }
 
-func (pa PooledArchive) ListAllBucketHashes() (chan Hash, chan error) {
+func (pa ArchivePool) ListAllBucketHashes() (chan Hash, chan error) {
 	return pa.GetAnyArchive().ListAllBucketHashes()
 }
 
-func (pa PooledArchive) ListCategoryCheckpoints(cat string, pth string) (chan uint32, chan error) {
+func (pa ArchivePool) ListCategoryCheckpoints(cat string, pth string) (chan uint32, chan error) {
 	return pa.GetAnyArchive().ListCategoryCheckpoints(cat, pth)
 }
 
-func (pa PooledArchive) GetXdrStreamForHash(hash Hash) (*XdrStream, error) {
+func (pa ArchivePool) GetXdrStreamForHash(hash Hash) (*XdrStream, error) {
 	return pa.GetAnyArchive().GetXdrStreamForHash(hash)
 }
 
-func (pa PooledArchive) GetXdrStream(pth string) (*XdrStream, error) {
+func (pa ArchivePool) GetXdrStream(pth string) (*XdrStream, error) {
 	return pa.GetAnyArchive().GetXdrStream(pth)
 }
 
-func (pa PooledArchive) GetCheckpointManager() CheckpointManager {
+func (pa ArchivePool) GetCheckpointManager() CheckpointManager {
 	return pa.GetAnyArchive().GetCheckpointManager()
 }

--- a/historyarchive/pool.go
+++ b/historyarchive/pool.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Stellar Development Foundation and contributors. Licensed
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
@@ -8,90 +8,55 @@ import (
 	"math/rand"
 
 	"github.com/stellar/go/support/errors"
-	"github.com/stellar/go/xdr"
 )
 
-// Type PooledArchive forwards all API calls to a random ArchiveInterface within
-// its internal pool.
-type PooledArchive struct {
-	pool []ArchiveInterface
-}
+// A PooledArchive is just a collection of `ArchiveInterface`s so that we can
+// distribute requests fairly throughout the pool.
+type PooledArchive []ArchiveInterface
 
-var _ ArchiveInterface = &PooledArchive{}
-
-func CreatePool(archives ...ArchiveInterface) (*PooledArchive, error) {
-	if len(archives) <= 0 {
+// CreatePool tries connecting to each of the provided history archive URLs,
+// returning a pool of valid archives.
+//
+// If none of the archives work, this returns the error message of the last
+// failed archive. Note that the errors for each individual archive are hard to
+// track if there's success overall.
+//
+// Possible FIXME for the above limitation: return []error instead? but then
+// users need to check `len(pool) > 0` instead of `err == nil`.
+func CreatePool(archiveURLs []string, config ConnectOptions) (*PooledArchive, error) {
+	if len(archiveURLs) <= 0 {
 		return nil, errors.New("No history archives provided")
 	}
-	return &PooledArchive{pool: archives}, nil
+
+	var lastErr error = nil
+
+	// Try connecting to all of the listed archives, but only store valid ones.
+	var validArchives PooledArchive
+	for _, url := range archiveURLs {
+		archive, err := Connect(
+			url,
+			ConnectOptions{
+				NetworkPassphrase:   config.NetworkPassphrase,
+				CheckpointFrequency: config.CheckpointFrequency,
+				Context:             config.Context,
+			},
+		)
+
+		if err != nil {
+			lastErr = errors.Wrapf(err, "Error connecting to history archive (%s)", url)
+			continue
+		}
+
+		validArchives = append(validArchives, archive)
+	}
+
+	if len(validArchives) == 0 {
+		return nil, lastErr
+	}
+
+	return &validArchives, nil
 }
 
-func (pa *PooledArchive) GetAnyArchive() ArchiveInterface {
-	return pa.pool[rand.Intn(len(pa.pool))]
-}
-
-// Below are the ArchiveInterface method implementations.
-
-func (pa *PooledArchive) GetPathHAS(path string) (HistoryArchiveState, error) {
-	return pa.GetAnyArchive().GetPathHAS(path)
-}
-
-func (pa *PooledArchive) PutPathHAS(path string, has HistoryArchiveState, opts *CommandOptions) error {
-	return pa.GetAnyArchive().PutPathHAS(path, has, opts)
-}
-
-func (pa *PooledArchive) BucketExists(bucket Hash) (bool, error) {
-	return pa.GetAnyArchive().BucketExists(bucket)
-}
-
-func (pa *PooledArchive) CategoryCheckpointExists(cat string, chk uint32) (bool, error) {
-	return pa.GetAnyArchive().CategoryCheckpointExists(cat, chk)
-}
-
-func (pa *PooledArchive) GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, error) {
-	return pa.GetAnyArchive().GetLedgerHeader(chk)
-}
-
-func (pa *PooledArchive) GetRootHAS() (HistoryArchiveState, error) {
-	return pa.GetAnyArchive().GetRootHAS()
-}
-
-func (pa *PooledArchive) GetCheckpointHAS(chk uint32) (HistoryArchiveState, error) {
-	return pa.GetAnyArchive().GetCheckpointHAS(chk)
-}
-
-func (pa *PooledArchive) PutCheckpointHAS(chk uint32, has HistoryArchiveState, opts *CommandOptions) error {
-	return pa.GetAnyArchive().PutCheckpointHAS(chk, has, opts)
-}
-
-func (pa *PooledArchive) PutRootHAS(has HistoryArchiveState, opts *CommandOptions) error {
-	return pa.GetAnyArchive().PutRootHAS(has, opts)
-}
-
-func (pa *PooledArchive) ListBucket(dp DirPrefix) (chan string, chan error) {
-	return pa.GetAnyArchive().ListBucket(dp)
-}
-
-func (pa *PooledArchive) ListAllBuckets() (chan string, chan error) {
-	return pa.GetAnyArchive().ListAllBuckets()
-}
-
-func (pa *PooledArchive) ListAllBucketHashes() (chan Hash, chan error) {
-	return pa.GetAnyArchive().ListAllBucketHashes()
-}
-
-func (pa *PooledArchive) ListCategoryCheckpoints(cat string, pth string) (chan uint32, chan error) {
-	return pa.GetAnyArchive().ListCategoryCheckpoints(cat, pth)
-}
-
-func (pa *PooledArchive) GetXdrStreamForHash(hash Hash) (*XdrStream, error) {
-	return pa.GetAnyArchive().GetXdrStreamForHash(hash)
-}
-
-func (pa *PooledArchive) GetXdrStream(pth string) (*XdrStream, error) {
-	return pa.GetAnyArchive().GetXdrStream(pth)
-}
-
-func (pa *PooledArchive) GetCheckpointManager() CheckpointManager {
-	return pa.GetAnyArchive().GetCheckpointManager()
+func GetRandomArchive(pool PooledArchive) ArchiveInterface {
+	return pool[rand.Intn(len(pool))]
 }

--- a/historyarchive/pool.go
+++ b/historyarchive/pool.go
@@ -19,7 +19,7 @@ type PooledArchive struct {
 
 var _ ArchiveInterface = &PooledArchive{}
 
-func CreatePool(archives []ArchiveInterface) (*PooledArchive, error) {
+func CreatePool(archives ...ArchiveInterface) (*PooledArchive, error) {
 	if len(archives) <= 0 {
 		return nil, errors.New("No history archives provided")
 	}

--- a/historyarchive/pool.go
+++ b/historyarchive/pool.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 
 	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
 )
 
 // A PooledArchive is just a collection of `ArchiveInterface`s so that we can
@@ -23,7 +24,7 @@ type PooledArchive []ArchiveInterface
 //
 // Possible FIXME for the above limitation: return []error instead? but then
 // users need to check `len(pool) > 0` instead of `err == nil`.
-func CreatePool(archiveURLs []string, config ConnectOptions) (*PooledArchive, error) {
+func CreatePool(archiveURLs []string, config ConnectOptions) (PooledArchive, error) {
 	if len(archiveURLs) <= 0 {
 		return nil, errors.New("No history archives provided")
 	}
@@ -54,9 +55,82 @@ func CreatePool(archiveURLs []string, config ConnectOptions) (*PooledArchive, er
 		return nil, lastErr
 	}
 
-	return &validArchives, nil
+	return validArchives, nil
 }
 
-func GetRandomArchive(pool PooledArchive) ArchiveInterface {
-	return pool[rand.Intn(len(pool))]
+// Ensure the pool conforms to the ArchiveInterface
+var _ ArchiveInterface = PooledArchive{}
+
+// Below are the ArchiveInterface method implementations.
+
+func (pa PooledArchive) GetAnyArchive() ArchiveInterface {
+	return pa[rand.Intn(len(pa))]
+}
+
+func (pa PooledArchive) GetPathHAS(path string) (HistoryArchiveState, error) {
+	return pa.GetAnyArchive().GetPathHAS(path)
+}
+
+func (pa PooledArchive) PutPathHAS(path string, has HistoryArchiveState, opts *CommandOptions) error {
+	return pa.GetAnyArchive().PutPathHAS(path, has, opts)
+}
+
+func (pa PooledArchive) BucketExists(bucket Hash) (bool, error) {
+	return pa.GetAnyArchive().BucketExists(bucket)
+}
+
+func (pa PooledArchive) CategoryCheckpointExists(cat string, chk uint32) (bool, error) {
+	return pa.GetAnyArchive().CategoryCheckpointExists(cat, chk)
+}
+
+func (pa PooledArchive) GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, error) {
+	return pa.GetAnyArchive().GetLedgerHeader(chk)
+}
+
+func (pa PooledArchive) GetRootHAS() (HistoryArchiveState, error) {
+	return pa.GetAnyArchive().GetRootHAS()
+}
+
+func (pa PooledArchive) GetLedgers(start, end uint32) (map[uint32]*Ledger, error) {
+	return pa.GetAnyArchive().GetLedgers(start, end)
+}
+
+func (pa PooledArchive) GetCheckpointHAS(chk uint32) (HistoryArchiveState, error) {
+	return pa.GetAnyArchive().GetCheckpointHAS(chk)
+}
+
+func (pa PooledArchive) PutCheckpointHAS(chk uint32, has HistoryArchiveState, opts *CommandOptions) error {
+	return pa.GetAnyArchive().PutCheckpointHAS(chk, has, opts)
+}
+
+func (pa PooledArchive) PutRootHAS(has HistoryArchiveState, opts *CommandOptions) error {
+	return pa.GetAnyArchive().PutRootHAS(has, opts)
+}
+
+func (pa PooledArchive) ListBucket(dp DirPrefix) (chan string, chan error) {
+	return pa.GetAnyArchive().ListBucket(dp)
+}
+
+func (pa PooledArchive) ListAllBuckets() (chan string, chan error) {
+	return pa.GetAnyArchive().ListAllBuckets()
+}
+
+func (pa PooledArchive) ListAllBucketHashes() (chan Hash, chan error) {
+	return pa.GetAnyArchive().ListAllBucketHashes()
+}
+
+func (pa PooledArchive) ListCategoryCheckpoints(cat string, pth string) (chan uint32, chan error) {
+	return pa.GetAnyArchive().ListCategoryCheckpoints(cat, pth)
+}
+
+func (pa PooledArchive) GetXdrStreamForHash(hash Hash) (*XdrStream, error) {
+	return pa.GetAnyArchive().GetXdrStreamForHash(hash)
+}
+
+func (pa PooledArchive) GetXdrStream(pth string) (*XdrStream, error) {
+	return pa.GetAnyArchive().GetXdrStream(pth)
+}
+
+func (pa PooledArchive) GetCheckpointManager() CheckpointManager {
+	return pa.GetAnyArchive().GetCheckpointManager()
 }

--- a/historyarchive/pool.go
+++ b/historyarchive/pool.go
@@ -1,0 +1,97 @@
+// Copyright 2016 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+package historyarchive
+
+import (
+	"math/rand"
+
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/xdr"
+)
+
+// Type PooledArchive forwards all API calls to a random ArchiveInterface within
+// its internal pool.
+type PooledArchive struct {
+	pool []ArchiveInterface
+}
+
+var _ ArchiveInterface = &PooledArchive{}
+
+func CreatePool(archives []ArchiveInterface) (*PooledArchive, error) {
+	if len(archives) <= 0 {
+		return nil, errors.New("No history archives provided")
+	}
+	return &PooledArchive{pool: archives}, nil
+}
+
+func (pa *PooledArchive) GetAnyArchive() ArchiveInterface {
+	return pa.pool[rand.Intn(len(pa.pool))]
+}
+
+// Below are the ArchiveInterface method implementations.
+
+func (pa *PooledArchive) GetPathHAS(path string) (HistoryArchiveState, error) {
+	return pa.GetAnyArchive().GetPathHAS(path)
+}
+
+func (pa *PooledArchive) PutPathHAS(path string, has HistoryArchiveState, opts *CommandOptions) error {
+	return pa.GetAnyArchive().PutPathHAS(path, has, opts)
+}
+
+func (pa *PooledArchive) BucketExists(bucket Hash) (bool, error) {
+	return pa.GetAnyArchive().BucketExists(bucket)
+}
+
+func (pa *PooledArchive) CategoryCheckpointExists(cat string, chk uint32) (bool, error) {
+	return pa.GetAnyArchive().CategoryCheckpointExists(cat, chk)
+}
+
+func (pa *PooledArchive) GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, error) {
+	return pa.GetAnyArchive().GetLedgerHeader(chk)
+}
+
+func (pa *PooledArchive) GetRootHAS() (HistoryArchiveState, error) {
+	return pa.GetAnyArchive().GetRootHAS()
+}
+
+func (pa *PooledArchive) GetCheckpointHAS(chk uint32) (HistoryArchiveState, error) {
+	return pa.GetAnyArchive().GetCheckpointHAS(chk)
+}
+
+func (pa *PooledArchive) PutCheckpointHAS(chk uint32, has HistoryArchiveState, opts *CommandOptions) error {
+	return pa.GetAnyArchive().PutCheckpointHAS(chk, has, opts)
+}
+
+func (pa *PooledArchive) PutRootHAS(has HistoryArchiveState, opts *CommandOptions) error {
+	return pa.GetAnyArchive().PutRootHAS(has, opts)
+}
+
+func (pa *PooledArchive) ListBucket(dp DirPrefix) (chan string, chan error) {
+	return pa.GetAnyArchive().ListBucket(dp)
+}
+
+func (pa *PooledArchive) ListAllBuckets() (chan string, chan error) {
+	return pa.GetAnyArchive().ListAllBuckets()
+}
+
+func (pa *PooledArchive) ListAllBucketHashes() (chan Hash, chan error) {
+	return pa.GetAnyArchive().ListAllBucketHashes()
+}
+
+func (pa *PooledArchive) ListCategoryCheckpoints(cat string, pth string) (chan uint32, chan error) {
+	return pa.GetAnyArchive().ListCategoryCheckpoints(cat, pth)
+}
+
+func (pa *PooledArchive) GetXdrStreamForHash(hash Hash) (*XdrStream, error) {
+	return pa.GetAnyArchive().GetXdrStreamForHash(hash)
+}
+
+func (pa *PooledArchive) GetXdrStream(pth string) (*XdrStream, error) {
+	return pa.GetAnyArchive().GetXdrStream(pth)
+}
+
+func (pa *PooledArchive) GetCheckpointManager() CheckpointManager {
+	return pa.GetAnyArchive().GetCheckpointManager()
+}

--- a/historyarchive/pool.go
+++ b/historyarchive/pool.go
@@ -59,7 +59,7 @@ func CreatePool(archiveURLs []string, config ConnectOptions) (ArchivePool, error
 }
 
 // Ensure the pool conforms to the ArchiveInterface
-var _ ArchiveInterface = ArchivePool{}
+var _ ArchiveInterface = &ArchivePool{}
 
 // Below are the ArchiveInterface method implementations.
 
@@ -67,70 +67,70 @@ func (pa ArchivePool) GetAnyArchive() ArchiveInterface {
 	return pa[rand.Intn(len(pa))]
 }
 
-func (pa ArchivePool) GetPathHAS(path string) (HistoryArchiveState, error) {
+func (pa *ArchivePool) GetPathHAS(path string) (HistoryArchiveState, error) {
 	return pa.GetAnyArchive().GetPathHAS(path)
 }
 
-func (pa ArchivePool) PutPathHAS(path string, has HistoryArchiveState, opts *CommandOptions) error {
+func (pa *ArchivePool) PutPathHAS(path string, has HistoryArchiveState, opts *CommandOptions) error {
 	return pa.GetAnyArchive().PutPathHAS(path, has, opts)
 }
 
-func (pa ArchivePool) BucketExists(bucket Hash) (bool, error) {
+func (pa *ArchivePool) BucketExists(bucket Hash) (bool, error) {
 	return pa.GetAnyArchive().BucketExists(bucket)
 }
 
-func (pa ArchivePool) CategoryCheckpointExists(cat string, chk uint32) (bool, error) {
+func (pa *ArchivePool) CategoryCheckpointExists(cat string, chk uint32) (bool, error) {
 	return pa.GetAnyArchive().CategoryCheckpointExists(cat, chk)
 }
 
-func (pa ArchivePool) GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, error) {
+func (pa *ArchivePool) GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, error) {
 	return pa.GetAnyArchive().GetLedgerHeader(chk)
 }
 
-func (pa ArchivePool) GetRootHAS() (HistoryArchiveState, error) {
+func (pa *ArchivePool) GetRootHAS() (HistoryArchiveState, error) {
 	return pa.GetAnyArchive().GetRootHAS()
 }
 
-func (pa ArchivePool) GetLedgers(start, end uint32) (map[uint32]*Ledger, error) {
+func (pa *ArchivePool) GetLedgers(start, end uint32) (map[uint32]*Ledger, error) {
 	return pa.GetAnyArchive().GetLedgers(start, end)
 }
 
-func (pa ArchivePool) GetCheckpointHAS(chk uint32) (HistoryArchiveState, error) {
+func (pa *ArchivePool) GetCheckpointHAS(chk uint32) (HistoryArchiveState, error) {
 	return pa.GetAnyArchive().GetCheckpointHAS(chk)
 }
 
-func (pa ArchivePool) PutCheckpointHAS(chk uint32, has HistoryArchiveState, opts *CommandOptions) error {
+func (pa *ArchivePool) PutCheckpointHAS(chk uint32, has HistoryArchiveState, opts *CommandOptions) error {
 	return pa.GetAnyArchive().PutCheckpointHAS(chk, has, opts)
 }
 
-func (pa ArchivePool) PutRootHAS(has HistoryArchiveState, opts *CommandOptions) error {
+func (pa *ArchivePool) PutRootHAS(has HistoryArchiveState, opts *CommandOptions) error {
 	return pa.GetAnyArchive().PutRootHAS(has, opts)
 }
 
-func (pa ArchivePool) ListBucket(dp DirPrefix) (chan string, chan error) {
+func (pa *ArchivePool) ListBucket(dp DirPrefix) (chan string, chan error) {
 	return pa.GetAnyArchive().ListBucket(dp)
 }
 
-func (pa ArchivePool) ListAllBuckets() (chan string, chan error) {
+func (pa *ArchivePool) ListAllBuckets() (chan string, chan error) {
 	return pa.GetAnyArchive().ListAllBuckets()
 }
 
-func (pa ArchivePool) ListAllBucketHashes() (chan Hash, chan error) {
+func (pa *ArchivePool) ListAllBucketHashes() (chan Hash, chan error) {
 	return pa.GetAnyArchive().ListAllBucketHashes()
 }
 
-func (pa ArchivePool) ListCategoryCheckpoints(cat string, pth string) (chan uint32, chan error) {
+func (pa *ArchivePool) ListCategoryCheckpoints(cat string, pth string) (chan uint32, chan error) {
 	return pa.GetAnyArchive().ListCategoryCheckpoints(cat, pth)
 }
 
-func (pa ArchivePool) GetXdrStreamForHash(hash Hash) (*XdrStream, error) {
+func (pa *ArchivePool) GetXdrStreamForHash(hash Hash) (*XdrStream, error) {
 	return pa.GetAnyArchive().GetXdrStreamForHash(hash)
 }
 
-func (pa ArchivePool) GetXdrStream(pth string) (*XdrStream, error) {
+func (pa *ArchivePool) GetXdrStream(pth string) (*XdrStream, error) {
 	return pa.GetAnyArchive().GetXdrStream(pth)
 }
 
-func (pa ArchivePool) GetCheckpointManager() CheckpointManager {
+func (pa *ArchivePool) GetCheckpointManager() CheckpointManager {
 	return pa.GetAnyArchive().GetCheckpointManager()
 }

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -146,7 +146,7 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	var cancel context.CancelFunc
 	config.Context, cancel = context.WithCancel(parentCtx)
 
-	archivePool, err := historyarchive.CreatePool(
+	archivePool, err := historyarchive.NewArchivePool(
 		config.HistoryArchiveURLs,
 		historyarchive.ConnectOptions{
 			NetworkPassphrase:   config.NetworkPassphrase,

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -161,7 +161,7 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	}
 
 	c := &CaptiveStellarCore{
-		archive:           historyarchive.GetRandomArchive(*archivePool),
+		archive:           archivePool,
 		ledgerHashStore:   config.LedgerHashStore,
 		cancel:            cancel,
 		checkpointManager: historyarchive.NewCheckpointManager(config.CheckpointFrequency),

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -159,6 +159,7 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 		)
 
 		if err != nil {
+			config.Log.Warnf("Error connecting to history archive (%s): %s", url, err)
 			continue
 		}
 
@@ -168,6 +169,7 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	pool, err := historyarchive.CreatePool(validArchives...)
 	if err != nil {
 		cancel()
+		config.Log.Error("Error connecting to ALL history archives.")
 		return nil, err
 	}
 

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -146,21 +146,33 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	var cancel context.CancelFunc
 	config.Context, cancel = context.WithCancel(parentCtx)
 
-	archive, err := historyarchive.Connect(
-		config.HistoryArchiveURLs[0],
-		historyarchive.ConnectOptions{
-			NetworkPassphrase:   config.NetworkPassphrase,
-			CheckpointFrequency: config.CheckpointFrequency,
-			Context:             config.Context,
-		},
-	)
+	var validArchives []historyarchive.ArchiveInterface
+
+	for _, url := range config.HistoryArchiveURLs {
+		archive, err := historyarchive.Connect(
+			url,
+			historyarchive.ConnectOptions{
+				NetworkPassphrase:   config.NetworkPassphrase,
+				CheckpointFrequency: config.CheckpointFrequency,
+				Context:             config.Context,
+			},
+		)
+
+		if err != nil {
+			continue
+		}
+
+		validArchives = append(validArchives, archive)
+	}
+
+	pool, err := historyarchive.CreatePool(validArchives...)
 	if err != nil {
 		cancel()
-		return nil, errors.Wrap(err, "error connecting to history archive")
+		return nil, err
 	}
 
 	c := &CaptiveStellarCore{
-		archive:           archive,
+		archive:           pool,
 		ledgerHashStore:   config.LedgerHashStore,
 		cancel:            cancel,
 		checkpointManager: historyarchive.NewCheckpointManager(config.CheckpointFrequency),

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -146,35 +146,22 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	var cancel context.CancelFunc
 	config.Context, cancel = context.WithCancel(parentCtx)
 
-	var validArchives []historyarchive.ArchiveInterface
+	archivePool, err := historyarchive.CreatePool(
+		config.HistoryArchiveURLs,
+		historyarchive.ConnectOptions{
+			NetworkPassphrase:   config.NetworkPassphrase,
+			CheckpointFrequency: config.CheckpointFrequency,
+			Context:             config.Context,
+		},
+	)
 
-	for _, url := range config.HistoryArchiveURLs {
-		archive, err := historyarchive.Connect(
-			url,
-			historyarchive.ConnectOptions{
-				NetworkPassphrase:   config.NetworkPassphrase,
-				CheckpointFrequency: config.CheckpointFrequency,
-				Context:             config.Context,
-			},
-		)
-
-		if err != nil {
-			config.Log.Warnf("Error connecting to history archive (%s): %s", url, err)
-			continue
-		}
-
-		validArchives = append(validArchives, archive)
-	}
-
-	pool, err := historyarchive.CreatePool(validArchives...)
 	if err != nil {
 		cancel()
-		config.Log.Error("Error connecting to ALL history archives.")
-		return nil, err
+		return nil, errors.Wrap(err, "Error connecting to ALL history archives.")
 	}
 
 	c := &CaptiveStellarCore{
-		archive:           pool,
+		archive:           historyarchive.GetRandomArchive(*archivePool),
 		ledgerHashStore:   config.LedgerHashStore,
 		cancel:            cancel,
 		checkpointManager: historyarchive.NewCheckpointManager(config.CheckpointFrequency),

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -161,7 +161,7 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	}
 
 	c := &CaptiveStellarCore{
-		archive:           archivePool,
+		archive:           &archivePool,
 		ledgerHashStore:   config.LedgerHashStore,
 		cancel:            cancel,
 		checkpointManager: historyarchive.NewCheckpointManager(config.CheckpointFrequency),


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
This is an improvement over #3375 which just chooses a random URL from the list. Instead, we should actually create a pool of all history archive connections and cycle through them randomly for each HA-related operation we need.

### Why
With this change, we actually use the entire URL list in the configuration that the user provides. This adds resilience and redundancy. See stellar/horizon-internal#3 for more context.

### Known limitations
n/a