### PR TITLE
all: Update app.version string build flag

### DIFF
--- a/support/scripts/build_release_artifacts/main.go
+++ b/support/scripts/build_release_artifacts/main.go
@@ -86,7 +86,15 @@ func build(pkg, dest, version, buildOS, buildArch string) {
 	buildTime := time.Now().Format(time.RFC3339)
 
 	timeFlag := fmt.Sprintf("-X github.com/stellar/go/support/app.buildTime=%s", buildTime)
-	versionFlag := fmt.Sprintf("-X github.com/stellar/go/support/app.version=%s", version)
+
+	// Note: verison string should match other build pipelines to create
+	// reproducible builds for Horizon (and other projects in the future).
+	rev := runOutput("git", "rev-parse", "HEAD")
+	versionString := version[1:] // Remove letter `v`
+	versionFlag := fmt.Sprintf(
+		"-X github.com/stellar/go/support/app.version=%s-%s",
+		versionString, rev,
+	)
 
 	if buildOS == "windows" {
 		dest = dest + ".exe"


### PR DESCRIPTION
### What

Update app version string in `build_release_artifacts` script to match build other pipelines.

### Why

We want final binaries to be the same to allow reproducible builds.

### Known limitations

This will change the version string for other apps built by `build_release_artifacts`.
