### PR TITLE
txnbuild: Use correct account in ClaimableBalanceID()

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v5.0.1](https://github.com/stellar/go/releases/tag/horizonclient-v5.0.1) - 2021-02-12
+
+* Fix a bug in `ClaimableBalanceID()` where the wrong account was used to derive the claimable balance id ([#3404](https://github.com/stellar/go/pull/3404))
+
 ## [v5.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v5.0.0) - 2020-11-12
 
 ### Breaking changes

--- a/txnbuild/create_claimable_balance_test.go
+++ b/txnbuild/create_claimable_balance_test.go
@@ -2,6 +2,11 @@ package txnbuild
 
 import (
 	"testing"
+	"time"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/network"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateClaimableBalanceRoundTrip(t *testing.T) {
@@ -30,4 +35,46 @@ func TestCreateClaimableBalanceRoundTrip(t *testing.T) {
 	}
 
 	roundTrip(t, []Operation{createNativeBalance, createAssetBalance})
+}
+
+func TestClaimableBalanceID(t *testing.T) {
+	A := "SCZANGBA5YHTNYVVV4C3U252E2B6P6F5T3U6MM63WBSBZATAQI3EBTQ4"
+	B := "GA2C5RFPE6GCKMY3US5PAB6UZLKIGSPIUKSLRB6Q723BM2OARMDUYEJ5"
+
+	aKeys := keypair.MustParseFull(A)
+	aAccount := SimpleAccount{AccountID: aKeys.Address(), Sequence: 123}
+
+	soon := time.Now().Add(time.Second * 60)
+	bCanClaim := BeforeRelativeTimePredicate(60)
+	aCanReclaim := NotPredicate(BeforeAbsoluteTimePredicate(soon.Unix()))
+
+	claimants := []Claimant{
+		NewClaimant(B, &bCanClaim),
+		NewClaimant(aKeys.Address(), &aCanReclaim),
+	}
+
+	claimableBalanceEntry := CreateClaimableBalance{
+		Destinations:  claimants,
+		Asset:         NativeAsset{},
+		Amount:        "420",
+		SourceAccount: &SimpleAccount{AccountID: "GB56OJGSA6VHEUFZDX6AL2YDVG2TS5JDZYQJHDYHBDH7PCD5NIQKLSDO"},
+	}
+
+	// Build and sign the transaction
+	tx, err := NewTransaction(
+		TransactionParams{
+			SourceAccount:        &aAccount,
+			IncrementSequenceNum: true,
+			BaseFee:              MinBaseFee,
+			Timebounds:           NewInfiniteTimeout(),
+			Operations:           []Operation{&claimableBalanceEntry},
+		},
+	)
+	assert.NoError(t, err)
+	tx, err = tx.Sign(network.TestNetworkPassphrase, aKeys)
+	assert.NoError(t, err)
+
+	balanceId, err := tx.ClaimableBalanceID(0)
+	assert.NoError(t, err)
+	assert.Equal(t, "0000000095001252ab3b4d16adbfa5364ce526dfcda03cb2258b827edbb2e0450087be51", balanceId)
 }

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -353,18 +353,12 @@ func (t *Transaction) ClaimableBalanceID(operationIndex int) (string, error) {
 		return "", errors.New("invalid operation index")
 	}
 
-	operation, ok := t.operations[operationIndex].(*CreateClaimableBalance)
+	_, ok := t.operations[operationIndex].(*CreateClaimableBalance)
 	if !ok {
 		return "", errors.New("operation is not CreateClaimableBalance")
 	}
 
-	// Use the operation's source account or the transaction's source if not.
-	var account Account = &t.sourceAccount
-	if operation.SourceAccount != nil {
-		account = operation.GetSourceAccount()
-	}
-
-	seq, err := account.GetSequenceNumber()
+	seq, err := t.sourceAccount.GetSequenceNumber()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to retrieve account sequence number")
 	}
@@ -374,7 +368,7 @@ func (t *Transaction) ClaimableBalanceID(operationIndex int) (string, error) {
 	operationId := xdr.OperationId{
 		Type: xdr.EnvelopeTypeEnvelopeTypeOpId,
 		Id: &xdr.OperationIdId{
-			SourceAccount: xdr.MustMuxedAddress(account.GetAccountID()),
+			SourceAccount: xdr.MustMuxedAddress(t.sourceAccount.GetAccountID()),
 			SeqNum:        xdr.SequenceNumber(seq),
 			OpNum:         xdr.Uint32(operationIndex),
 		},


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

ClaimableBalanceID() builds an xdr.OperationId using the operation source account and the sequence number of the operation source account. It seems like we should be using the transaction source account and the sequence number found in the transaction. That is my understanding based on https://github.com/stellar/stellar-core/blob/b0cc4a9b8c3423358d1881b991834cf658bc38f5/src/transactions/CreateClaimableBalanceOpFrame.cpp#L278[…]L288

This fix was actually included in the v6 release https://github.com/stellar/go/pull/3393 . However, @leighmcculloch and @marcelosalloum would like to create a patch release for just this fix instead of including it in a major version release.

### Known limitations

[N/A]
