### PR TITLE
go/support/http 3404 add x forwarded for header to log start of request

### DIFF
--- a/support/http/logging_middleware.go
+++ b/support/http/logging_middleware.go
@@ -50,12 +50,13 @@ func logStartOfRequest(
 	r *stdhttp.Request,
 ) {
 	l := log.Ctx(r.Context()).WithFields(log.F{
-		"subsys":    "http",
-		"path":      r.URL.String(),
-		"method":    r.Method,
-		"ip":        r.RemoteAddr,
-		"host":      r.Host,
-		"useragent": r.Header.Get("User-Agent"),
+		"subsys":          "http",
+		"path":            r.URL.String(),
+		"method":          r.Method,
+		"ip":              r.RemoteAddr,
+		"host":            r.Host,
+		"useragent":       r.Header.Get("User-Agent"),
+		"X-Forwarded-For": r.Header.Get("X-Forwarded-For"),
 	})
 	l.Info("starting request")
 }

--- a/support/http/logging_middleware_test.go
+++ b/support/http/logging_middleware_test.go
@@ -22,6 +22,7 @@ func TestHTTPMiddleware(t *testing.T) {
 	done := log.DefaultLogger.StartTest(log.InfoLevel)
 	mux := chi.NewMux()
 
+	mux.Use(setXFFMiddleWare)
 	mux.Use(middleware.RequestID)
 	mux.Use(LoggingMiddleware)
 
@@ -45,6 +46,7 @@ func TestHTTPMiddleware(t *testing.T) {
 		assert.NotEmpty(t, logged[0].Data["req"])
 		assert.Equal(t, "/path/1234", logged[0].Data["path"])
 		assert.Equal(t, "Go-http-client/1.1", logged[0].Data["useragent"])
+		assert.Equal(t, "4.1.1", logged[0].Data["X-Forwarded-For"])
 		req1 := logged[0].Data["req"]
 
 		assert.Equal(t, "handler log line", logged[1].Message)
@@ -63,6 +65,7 @@ func TestHTTPMiddleware(t *testing.T) {
 		assert.NotEmpty(t, logged[3].Data["req"])
 		assert.NotEmpty(t, logged[3].Data["path"])
 		assert.Equal(t, "Go-http-client/1.1", logged[3].Data["useragent"])
+		assert.Equal(t, "4.1.1", logged[3].Data["X-Forwarded-For"])
 		req2 := logged[3].Data["req"]
 
 		assert.Equal(t, "finished request", logged[4].Message)
@@ -78,6 +81,7 @@ func TestHTTPMiddleware(t *testing.T) {
 		assert.NotEmpty(t, logged[5].Data["req"])
 		assert.NotEmpty(t, logged[5].Data["path"])
 		assert.Equal(t, "Go-http-client/1.1", logged[5].Data["useragent"])
+		assert.Equal(t, "4.1.1", logged[5].Data["X-Forwarded-For"])
 		req3 := logged[5].Data["req"]
 
 		assert.Equal(t, "finished request", logged[6].Message)
@@ -161,6 +165,7 @@ func TestHTTPMiddlewareWithLoggerSet(t *testing.T) {
 	done := logger.StartTest(log.InfoLevel)
 	mux := chi.NewMux()
 
+	mux.Use(setXFFMiddleWare)
 	mux.Use(middleware.RequestID)
 	mux.Use(SetLoggerMiddleware(logger))
 	mux.Use(LoggingMiddleware)
@@ -185,6 +190,7 @@ func TestHTTPMiddlewareWithLoggerSet(t *testing.T) {
 		assert.NotEmpty(t, logged[0].Data["req"])
 		assert.Equal(t, "/path/1234", logged[0].Data["path"])
 		assert.Equal(t, "Go-http-client/1.1", logged[0].Data["useragent"])
+		assert.Equal(t, "4.1.1", logged[0].Data["X-Forwarded-For"])
 		req1 := logged[0].Data["req"]
 
 		assert.Equal(t, "handler log line", logged[1].Message)
@@ -203,6 +209,7 @@ func TestHTTPMiddlewareWithLoggerSet(t *testing.T) {
 		assert.NotEmpty(t, logged[3].Data["req"])
 		assert.NotEmpty(t, logged[3].Data["path"])
 		assert.Equal(t, "Go-http-client/1.1", logged[3].Data["useragent"])
+		assert.Equal(t, "4.1.1", logged[3].Data["X-Forwarded-For"])
 		req2 := logged[3].Data["req"]
 
 		assert.Equal(t, "finished request", logged[4].Message)
@@ -218,6 +225,7 @@ func TestHTTPMiddlewareWithLoggerSet(t *testing.T) {
 		assert.NotEmpty(t, logged[5].Data["req"])
 		assert.NotEmpty(t, logged[5].Data["path"])
 		assert.Equal(t, "Go-http-client/1.1", logged[5].Data["useragent"])
+		assert.Equal(t, "4.1.1", logged[5].Data["X-Forwarded-For"])
 		req3 := logged[5].Data["req"]
 
 		assert.Equal(t, "finished request", logged[6].Message)

--- a/support/http/logging_middleware_test.go
+++ b/support/http/logging_middleware_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"net/http"
 	stdhttp "net/http"
 	"testing"
 
@@ -11,6 +12,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func setXFFMiddleWare(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Header.Set("X-Forwarded-For", "4.1.1")
+		next.ServeHTTP(w, r)
+	})
+}
 func TestHTTPMiddleware(t *testing.T) {
 	done := log.DefaultLogger.StartTest(log.InfoLevel)
 	mux := chi.NewMux()


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [X] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [X] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [X] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [X] This PR adds tests for the most critical parts of the new functionality or fixes.

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add xff field to the http middleware logger.
Closes: #3404 


### Why

Logging the The X-Forwarded-For (XFF) header will help identify the originating IP address of a client . 

### Known limitations

N/A