### PR TITLE
Fix minor issues connected to reproducible builds

### DIFF
--- a/services/horizon/internal/scripts/check_release_hash/Dockerfile
+++ b/services/horizon/internal/scripts/check_release_hash/Dockerfile
@@ -1,5 +1,5 @@
 # Change to Go version used in CI or rebuild with --build-arg.
-ARG GO_IMAGE=golang:1.14.14-stretch
+ARG GO_IMAGE=golang:1.14.15-stretch
 FROM $GO_IMAGE
 
 WORKDIR /go/src/github.com/stellar/go

--- a/support/scripts/build_release_artifacts/main.go
+++ b/support/scripts/build_release_artifacts/main.go
@@ -86,7 +86,7 @@ func build(pkg, dest, version, buildOS, buildArch string) {
 	rev := runOutput("git", "rev-parse", "HEAD")
 	versionString := version[1:] // Remove letter `v`
 	versionFlag := fmt.Sprintf(
-		"-X github.com/stellar/go/support/app.version=%s-%s",
+		"-X=github.com/stellar/go/support/app.version=%s-%s",
 		versionString, rev,
 	)
 
@@ -97,7 +97,6 @@ func build(pkg, dest, version, buildOS, buildArch string) {
 	cmd := exec.Command("go", "build",
 		"-trimpath",
 		"-o", dest,
-		"-ldflags", versionFlag,
 		pkg,
 	)
 	cmd.Stderr = os.Stderr
@@ -106,6 +105,7 @@ func build(pkg, dest, version, buildOS, buildArch string) {
 	cmd.Env = append(
 		os.Environ(),
 		"CGO_ENABLED=0",
+		fmt.Sprintf("GOFLAGS=-ldflags=%s", versionFlag),
 		fmt.Sprintf("GOOS=%s", buildOS),
 		fmt.Sprintf("GOARCH=%s", buildArch),
 	)


### PR DESCRIPTION
I checked for the last time before releasing Horizon if the binaries' hashes match and they didn't. This commit fixes the issues:
* Updates `check_release_hash` to use Golang version we use in Circle.
* Move `-ldflags` from command arguments to env variable. This has the same effect but apparently the hash was different than the binary built by `stellar/packages`.