### PR TITLE
historyarchive: Fix ArchivePool functions

### DIFF
--- a/historyarchive/archive_pool.go
+++ b/historyarchive/archive_pool.go
@@ -56,7 +56,7 @@ func NewArchivePool(archiveURLs []string, config ConnectOptions) (ArchivePool, e
 }
 
 // Ensure the pool conforms to the ArchiveInterface
-var _ ArchiveInterface = &ArchivePool{}
+var _ ArchiveInterface = ArchivePool{}
 
 // Below are the ArchiveInterface method implementations.
 
@@ -64,70 +64,70 @@ func (pa ArchivePool) GetAnyArchive() ArchiveInterface {
 	return pa[rand.Intn(len(pa))]
 }
 
-func (pa *ArchivePool) GetPathHAS(path string) (HistoryArchiveState, error) {
+func (pa ArchivePool) GetPathHAS(path string) (HistoryArchiveState, error) {
 	return pa.GetAnyArchive().GetPathHAS(path)
 }
 
-func (pa *ArchivePool) PutPathHAS(path string, has HistoryArchiveState, opts *CommandOptions) error {
+func (pa ArchivePool) PutPathHAS(path string, has HistoryArchiveState, opts *CommandOptions) error {
 	return pa.GetAnyArchive().PutPathHAS(path, has, opts)
 }
 
-func (pa *ArchivePool) BucketExists(bucket Hash) (bool, error) {
+func (pa ArchivePool) BucketExists(bucket Hash) (bool, error) {
 	return pa.GetAnyArchive().BucketExists(bucket)
 }
 
-func (pa *ArchivePool) CategoryCheckpointExists(cat string, chk uint32) (bool, error) {
+func (pa ArchivePool) CategoryCheckpointExists(cat string, chk uint32) (bool, error) {
 	return pa.GetAnyArchive().CategoryCheckpointExists(cat, chk)
 }
 
-func (pa *ArchivePool) GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, error) {
+func (pa ArchivePool) GetLedgerHeader(chk uint32) (xdr.LedgerHeaderHistoryEntry, error) {
 	return pa.GetAnyArchive().GetLedgerHeader(chk)
 }
 
-func (pa *ArchivePool) GetRootHAS() (HistoryArchiveState, error) {
+func (pa ArchivePool) GetRootHAS() (HistoryArchiveState, error) {
 	return pa.GetAnyArchive().GetRootHAS()
 }
 
-func (pa *ArchivePool) GetLedgers(start, end uint32) (map[uint32]*Ledger, error) {
+func (pa ArchivePool) GetLedgers(start, end uint32) (map[uint32]*Ledger, error) {
 	return pa.GetAnyArchive().GetLedgers(start, end)
 }
 
-func (pa *ArchivePool) GetCheckpointHAS(chk uint32) (HistoryArchiveState, error) {
+func (pa ArchivePool) GetCheckpointHAS(chk uint32) (HistoryArchiveState, error) {
 	return pa.GetAnyArchive().GetCheckpointHAS(chk)
 }
 
-func (pa *ArchivePool) PutCheckpointHAS(chk uint32, has HistoryArchiveState, opts *CommandOptions) error {
+func (pa ArchivePool) PutCheckpointHAS(chk uint32, has HistoryArchiveState, opts *CommandOptions) error {
 	return pa.GetAnyArchive().PutCheckpointHAS(chk, has, opts)
 }
 
-func (pa *ArchivePool) PutRootHAS(has HistoryArchiveState, opts *CommandOptions) error {
+func (pa ArchivePool) PutRootHAS(has HistoryArchiveState, opts *CommandOptions) error {
 	return pa.GetAnyArchive().PutRootHAS(has, opts)
 }
 
-func (pa *ArchivePool) ListBucket(dp DirPrefix) (chan string, chan error) {
+func (pa ArchivePool) ListBucket(dp DirPrefix) (chan string, chan error) {
 	return pa.GetAnyArchive().ListBucket(dp)
 }
 
-func (pa *ArchivePool) ListAllBuckets() (chan string, chan error) {
+func (pa ArchivePool) ListAllBuckets() (chan string, chan error) {
 	return pa.GetAnyArchive().ListAllBuckets()
 }
 
-func (pa *ArchivePool) ListAllBucketHashes() (chan Hash, chan error) {
+func (pa ArchivePool) ListAllBucketHashes() (chan Hash, chan error) {
 	return pa.GetAnyArchive().ListAllBucketHashes()
 }
 
-func (pa *ArchivePool) ListCategoryCheckpoints(cat string, pth string) (chan uint32, chan error) {
+func (pa ArchivePool) ListCategoryCheckpoints(cat string, pth string) (chan uint32, chan error) {
 	return pa.GetAnyArchive().ListCategoryCheckpoints(cat, pth)
 }
 
-func (pa *ArchivePool) GetXdrStreamForHash(hash Hash) (*XdrStream, error) {
+func (pa ArchivePool) GetXdrStreamForHash(hash Hash) (*XdrStream, error) {
 	return pa.GetAnyArchive().GetXdrStreamForHash(hash)
 }
 
-func (pa *ArchivePool) GetXdrStream(pth string) (*XdrStream, error) {
+func (pa ArchivePool) GetXdrStream(pth string) (*XdrStream, error) {
 	return pa.GetAnyArchive().GetXdrStream(pth)
 }
 
-func (pa *ArchivePool) GetCheckpointManager() CheckpointManager {
+func (pa ArchivePool) GetCheckpointManager() CheckpointManager {
 	return pa.GetAnyArchive().GetCheckpointManager()
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

`NewArchivePool() ` returns a `ArchivePool` instance which I expected to conform to `ArchiveInterface`. 

However, it turns out that `ArchivePool` does not conform to the interface because all of its functions are defined on pointer receivers. Since `ArchivePool` is defined to be a slice we should rarely (if ever) need to create a pointer to an `ArchivePool` instance. Therefore it would be better if all of the functions acted on `ArchivePool` instances instead of `ArchivePool` pointers.