### PR TITLE
services/horizon: Remove "Starting request" log entries

### DIFF
--- a/services/horizon/internal/docs/admin.md
+++ b/services/horizon/internal/docs/admin.md
@@ -216,30 +216,11 @@ Metrics are collected while a Horizon process is running and they are exposed at
 
 Below we present a few standard log entries with associated fields. You can use them to build metrics and alerts. We present below some examples. Please note that this represents Horizon app metrics only. You should also monitor your hardware metrics like CPU or RAM Utilization.
 
-### Starting HTTP request
-
-| Key              | Value                                                                                          |
-|------------------|------------------------------------------------------------------------------------------------|
-| **`msg`**        | **`Starting request`**                                                                         |
-| `client_name`    | Value of `X-Client-Name` HTTP header representing client name                                  |
-| `client_version` | Value of `X-Client-Version` HTTP header representing client version                            |
-| `app_name`       | Value of `X-App-Name` HTTP header representing app name                                        |
-| `app_version`    | Value of `X-App-Version` HTTP header representing app version                                  |
-| `forwarded_ip`   | First value of `X-Forwarded-For` header                                                        |
-| `host`           | Value of `Host` header                                                                         |
-| `ip`             | IP of a client sending HTTP request                                                            |
-| `ip_port`        | IP and port of a client sending HTTP request                                                   |
-| `method`         | HTTP method (`GET`, `POST`, ...)                                                               |
-| `path`           | Full request path, including query string (ex. `/transactions?order=desc`)                     |
-| `streaming`      | Boolean, `true` if request is a streaming request                                              |
-| `referer`        | Value of `Referer` header                                                                      |
-| `req`            | Random value that uniquely identifies a request, attached to all logs within this HTTP request |
-
 ### Finished HTTP request
 
 | Key              | Value                                                                                          |
 |------------------|------------------------------------------------------------------------------------------------|
-| **`msg`**        | **`Finished request`**                                                                         |
+| **`msg`**        | **`HTTP request`**                                                                             |
 | `bytes`          | Number of response bytes sent                                                                  |
 | `client_name`    | Value of `X-Client-Name` HTTP header representing client name                                  |
 | `client_version` | Value of `X-Client-Version` HTTP header representing client version                            |

--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -79,11 +79,8 @@ func loggerMiddleware(serverMetrics *ServerMetrics) func(next http.Handler) http
 			acceptHeader := r.Header.Get("Accept")
 			streaming := strings.Contains(acceptHeader, render.MimeEventStream)
 
-			logStartOfRequest(ctx, r, streaming)
 			then := time.Now()
-
 			next.ServeHTTP(mw, r.WithContext(ctx))
-
 			duration := time.Since(then)
 			logEndOfRequest(ctx, r, serverMetrics.RequestDurationSummary, duration, mw, streaming)
 		})
@@ -132,28 +129,6 @@ func getClientData(r *http.Request, headerName string) string {
 	return value
 }
 
-func logStartOfRequest(ctx context.Context, r *http.Request, streaming bool) {
-	referer := r.Referer()
-	if referer == "" {
-		referer = "undefined"
-	}
-
-	log.Ctx(ctx).WithFields(log.F{
-		"client_name":    getClientData(r, clientNameHeader),
-		"client_version": getClientData(r, clientVersionHeader),
-		"app_name":       getClientData(r, appNameHeader),
-		"app_version":    getClientData(r, appVersionHeader),
-		"forwarded_ip":   firstXForwardedFor(r),
-		"host":           r.Host,
-		"ip":             remoteAddrIP(r),
-		"ip_port":        r.RemoteAddr,
-		"method":         r.Method,
-		"path":           r.URL.String(),
-		"streaming":      streaming,
-		"referer":        referer,
-	}).Info("Starting request")
-}
-
 func logEndOfRequest(ctx context.Context, r *http.Request, requestDurationSummary *prometheus.SummaryVec, duration time.Duration, mw middleware.WrapResponseWriter, streaming bool) {
 	routePattern := chi.RouteContext(r.Context()).RoutePattern()
 	// Can be empty when request did not reached the final route (ex. blocked by
@@ -184,7 +159,7 @@ func logEndOfRequest(ctx context.Context, r *http.Request, requestDurationSummar
 		"status":         mw.Status(),
 		"streaming":      streaming,
 		"referer":        referer,
-	}).Info("Finished request")
+	}).Info("HTTP request")
 
 	requestDurationSummary.With(prometheus.Labels{
 		"status":    strconv.FormatInt(int64(mw.Status()), 10),

--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -159,7 +159,7 @@ func logEndOfRequest(ctx context.Context, r *http.Request, requestDurationSummar
 		"status":         mw.Status(),
 		"streaming":      streaming,
 		"referer":        referer,
-	}).Info("HTTP request")
+	}).Info("Finished request")
 
 	requestDurationSummary.With(prometheus.Labels{
 		"status":    strconv.FormatInt(int64(mw.Status()), 10),


### PR DESCRIPTION
### What

This commit removes `Starting request` log entries from Horizon. It also changes `Finished request` to `HTTP request`

### Why

`Finished request` contains exactly the same subset of fields as `Starting request`. This change will decrease number of log entries from HTTP request by around a half.

### Known limitations

N/A
