### PR TITLE
services/horizon: Add metric with local latest ledger

### DIFF
--- a/services/horizon/internal/ingest/fsm.go
+++ b/services/horizon/internal/ingest/fsm.go
@@ -362,6 +362,8 @@ func (r resumeState) run(s *system) (transition, error) {
 		return start(), errors.New("unexpected latestSuccessfullyProcessedLedger value")
 	}
 
+	s.metrics.LocalLatestLedger.Set(float64(r.latestSuccessfullyProcessedLedger))
+
 	if err := s.historyQ.Begin(); err != nil {
 		return retryResume(r),
 			errors.Wrap(err, "Error starting a transaction")

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -96,6 +96,9 @@ type stellarCoreClient interface {
 }
 
 type Metrics struct {
+	// LocalLedger exposes the last ingested ledger by this ingesting instance.
+	LocalLatestLedger prometheus.Gauge
+
 	// LedgerIngestionDuration exposes timing metrics about the rate and
 	// duration of ledger ingestion (including updating DB and graph).
 	LedgerIngestionDuration prometheus.Summary
@@ -241,6 +244,11 @@ func NewSystem(config Config) (System, error) {
 }
 
 func (s *system) initMetrics() {
+	s.metrics.LocalLatestLedger = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "horizon", Subsystem: "ingest", Name: "local_latest_ledger",
+		Help: "sequence number of the latest ledger ingested by this ingesting instance",
+	})
+
 	s.metrics.LedgerIngestionDuration = prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: "horizon", Subsystem: "ingest", Name: "ledger_ingestion_duration_seconds",
 		Help: "ledger ingestion durations, sliding window = 10m",

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -255,6 +255,7 @@ func initIngestMetrics(app *App) {
 	}
 
 	app.ingestingGauge.Inc()
+	app.prometheusRegistry.MustRegister(app.ingester.Metrics().LocalLatestLedger)
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().LedgerIngestionDuration)
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().StateVerifyDuration)
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().StateInvalidGauge)


### PR DESCRIPTION
### What

Adds a new metric: `horizon_ingest_local_latest_ledger` that exposes the local latest ledger sequence which is the last ledger ingested by this ingesting instance.

### Why

While checking metrics after Horizon 2.0.0 RC deployment I noticed that existing metric: `horizon_history_latest_ledger` can be confusing because it loads the ledger sequence from DB. However, it's possible that one of ingesting instances is out of sync and is waiting for Stellar-Core sync. It would be great to be able to measure the delay in ledgers and a new metric allows this.