### PR TITLE
[CAP 35] Replace AssetCode by Asset in new operations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ commands:
             sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
             sudo bash -c 'echo "deb https://apt.stellar.org xenial unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
             # TODO: replace by the stable version when ready
-            sudo apt-get update && sudo apt-get install -y stellar-core=15.2.0-441.620af1f.xenial~clawbackPR~buildtests
+            sudo apt-get update && sudo apt-get install -y stellar-core=11.4.0-467.e1dfff1.xenial~clawbackCompleteTest~buildtests
             echo "using stellar core version $(stellar-core version)"
             echo "export CAPTIVE_CORE_BIN=/usr/bin/stellar-core" >> $BASH_ENV
 

--- a/services/horizon/internal/ingest/processors/effects_processor.go
+++ b/services/horizon/internal/ingest/processors/effects_processor.go
@@ -692,7 +692,7 @@ func (e *effectsWrapper) addAllowTrustEffects() {
 		e.add(source.Address(), history.EffectTrustlineAuthorized, details)
 		// Forward compatibility
 		setFlags := xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag)
-		e.addTrustLineFlagsEffect(source, &op.Trustor, op.Asset, &setFlags, nil)
+		e.addTrustLineFlagsEffect(source, &op.Trustor, op.Asset.ToAsset(*source), &setFlags, nil)
 	case xdr.TrustLineFlags(op.Authorize).IsAuthorizedToMaintainLiabilitiesFlag():
 		e.add(
 			source.Address(),
@@ -701,12 +701,12 @@ func (e *effectsWrapper) addAllowTrustEffects() {
 		)
 		// Forward compatibility
 		setFlags := xdr.Uint32(xdr.TrustLineFlagsAuthorizedToMaintainLiabilitiesFlag)
-		e.addTrustLineFlagsEffect(source, &op.Trustor, op.Asset, &setFlags, nil)
+		e.addTrustLineFlagsEffect(source, &op.Trustor, op.Asset.ToAsset(*source), &setFlags, nil)
 	default:
 		e.add(source.Address(), history.EffectTrustlineDeauthorized, details)
 		// Forward compatibility, show both as cleared
 		clearFlags := xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag | xdr.TrustLineFlagsAuthorizedToMaintainLiabilitiesFlag)
-		e.addTrustLineFlagsEffect(source, &op.Trustor, op.Asset, nil, &clearFlags)
+		e.addTrustLineFlagsEffect(source, &op.Trustor, op.Asset.ToAsset(*source), nil, &clearFlags)
 	}
 }
 
@@ -955,7 +955,7 @@ func (e *effectsWrapper) addClawbackEffects() error {
 		"amount": amount.String(op.Amount),
 	}
 	source := e.operation.SourceAccount()
-	addAssetDetails(details, op.Asset.ToAsset(*source), "")
+	addAssetDetails(details, op.Asset, "")
 	e.add(
 		source.Address(),
 		history.EffectAccountCredited,
@@ -999,13 +999,13 @@ func (e *effectsWrapper) addSetTrustLineFlagsEffects() error {
 func (e *effectsWrapper) addTrustLineFlagsEffect(
 	account *xdr.AccountId,
 	trustor *xdr.AccountId,
-	assetCode xdr.AssetCode,
+	asset xdr.Asset,
 	setFlags *xdr.Uint32,
 	clearFlags *xdr.Uint32) {
 	details := map[string]interface{}{
 		"trustor": trustor.Address(),
 	}
-	addAssetDetails(details, assetCode.ToAsset(*account), "")
+	addAssetDetails(details, asset, "")
 
 	var flagDetailsAdded bool
 	if setFlags != nil {

--- a/services/horizon/internal/ingest/processors/effects_processor.go
+++ b/services/horizon/internal/ingest/processors/effects_processor.go
@@ -692,7 +692,7 @@ func (e *effectsWrapper) addAllowTrustEffects() {
 		e.add(source.Address(), history.EffectTrustlineAuthorized, details)
 		// Forward compatibility
 		setFlags := xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag)
-		e.addTrustLineFlagsEffect(source, &op.Trustor, op.Asset.ToAsset(*source), &setFlags, nil)
+		e.addTrustLineFlagsEffect(source, &op.Trustor, asset, &setFlags, nil)
 	case xdr.TrustLineFlags(op.Authorize).IsAuthorizedToMaintainLiabilitiesFlag():
 		e.add(
 			source.Address(),
@@ -701,12 +701,12 @@ func (e *effectsWrapper) addAllowTrustEffects() {
 		)
 		// Forward compatibility
 		setFlags := xdr.Uint32(xdr.TrustLineFlagsAuthorizedToMaintainLiabilitiesFlag)
-		e.addTrustLineFlagsEffect(source, &op.Trustor, op.Asset.ToAsset(*source), &setFlags, nil)
+		e.addTrustLineFlagsEffect(source, &op.Trustor, asset, &setFlags, nil)
 	default:
 		e.add(source.Address(), history.EffectTrustlineDeauthorized, details)
 		// Forward compatibility, show both as cleared
 		clearFlags := xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag | xdr.TrustLineFlagsAuthorizedToMaintainLiabilitiesFlag)
-		e.addTrustLineFlagsEffect(source, &op.Trustor, op.Asset.ToAsset(*source), nil, &clearFlags)
+		e.addTrustLineFlagsEffect(source, &op.Trustor, asset, nil, &clearFlags)
 	}
 }
 

--- a/services/horizon/internal/ingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/ingest/processors/effects_processor_test.go
@@ -1847,9 +1847,6 @@ func TestOperationEffectsAllowTrustAuthorizedToMaintainLiabilities(t *testing.T)
 
 func TestOperationEffectsClawback(t *testing.T) {
 	tt := assert.New(t)
-	asset := xdr.Asset{}
-	clawbackAsset, err := asset.ToAssetCode("COP")
-	tt.NoError(err)
 	aid := xdr.MustAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD")
 	source := aid.ToMuxedAccount()
 	op := xdr.Operation{
@@ -1857,7 +1854,7 @@ func TestOperationEffectsClawback(t *testing.T) {
 		Body: xdr.OperationBody{
 			Type: xdr.OperationTypeClawback,
 			ClawbackOp: &xdr.ClawbackOp{
-				Asset:  clawbackAsset,
+				Asset:  xdr.MustNewCreditAsset("COP", "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
 				From:   xdr.MustMuxedAddress("GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3"),
 				Amount: 34,
 			},
@@ -1966,7 +1963,7 @@ func TestOperationEffectsSetTrustLineFlags(t *testing.T) {
 			Type: xdr.OperationTypeSetTrustLineFlags,
 			SetTrustLineFlagsOp: &xdr.SetTrustLineFlagsOp{
 				Trustor:    trustor,
-				Asset:      xdr.MustNewAssetCodeFromString("USD"),
+				Asset:      xdr.MustNewCreditAsset("USD", "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
 				ClearFlags: &clearFlags,
 				SetFlags:   &setFlags,
 			},

--- a/services/horizon/internal/ingest/processors/operations_processor.go
+++ b/services/horizon/internal/ingest/processors/operations_processor.go
@@ -418,7 +418,7 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 		}
 	case xdr.OperationTypeClawback:
 		op := operation.operation.Body.MustClawbackOp()
-		addAssetDetails(details, op.Asset.ToAsset(*source), "")
+		addAssetDetails(details, op.Asset, "")
 		from := op.From.ToAccountId()
 		details["from"] = from.Address()
 		details["amount"] = amount.String(op.Amount)
@@ -432,7 +432,7 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 	case xdr.OperationTypeSetTrustLineFlags:
 		op := operation.operation.Body.MustSetTrustLineFlagsOp()
 		details["trustor"] = op.Trustor.Address()
-		addAssetDetails(details, op.Asset.ToAsset(*source), "")
+		addAssetDetails(details, op.Asset, "")
 		if op.SetFlags != nil && *op.SetFlags > 0 {
 			addTrustLineFlagDetails(details, xdr.TrustLineFlags(*op.SetFlags), "set")
 		}

--- a/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
+++ b/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
@@ -1486,7 +1486,7 @@ func (s *SetTrustLineFlagsTestSuite) SetupTest() {
 			Type: xdr.OperationTypeSetTrustLineFlags,
 			SetTrustLineFlagsOp: &xdr.SetTrustLineFlagsOp{
 				Trustor:    trustor,
-				Asset:      xdr.MustNewAssetCodeFromString("USD"),
+				Asset:      xdr.MustNewCreditAsset("USD", "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
 				ClearFlags: &clearFlags,
 				SetFlags:   &setFlags,
 			},

--- a/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
+++ b/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
@@ -600,22 +600,6 @@ func TestTransactionOperationDetails(t *testing.T) {
 			},
 		},
 		{
-			desc:          "clawback",
-			envelopeXDR:   "AAAAAgAAAADrAt1LkCV3iVpe6NkPVn9kb2Yh4hyn0m7QzbF5J9zTIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAATAAAAAVVTRAAAAAAAgHx5MrwKqyn+j+nUvuOra8GmzrRKvG8ew8JfchFfAvIAAAAAAAAAFAAAAAAAAAAA",
-			resultXDR:     "AAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-			metaXDR:       "AAAAAgAAAAAAAAABAAAAAAAAAAA=",
-			feeChangesXDR: "AAAAAA==",
-			hash:          "c8a8890d5cae9051ef692ed3e867687e1c3e9869995328698c60bdb237194e83",
-			index:         0,
-			expected: map[string]interface{}{
-				"amount":       "0.0000020",
-				"asset_code":   "USD",
-				"asset_issuer": "GDVQFXKLSASXPCK2L3UNSD2WP5SG6ZRB4IOKPUTO2DG3C6JH3TJSEA7R",
-				"asset_type":   "credit_alphanum4",
-				"from":         "GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS",
-			},
-		},
-		{
 			desc:          "clawbackClaimableBalance",
 			envelopeXDR:   "AAAAAgAAAADrAt1LkCV3iVpe6NkPVn9kb2Yh4hyn0m7QzbF5J9zTIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAUAAAAAMr+ur7erb7vAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
 			resultXDR:     "AAAAAAAAAAAAAAAAAAAAAAAAAAA=",
@@ -1466,6 +1450,81 @@ func TestSponsoredSandwichTransaction_Participants(t *testing.T) {
 		},
 		participants,
 	)
+}
+
+type ClawbackTestSuite struct {
+	suite.Suite
+	op        xdr.Operation
+	balanceID string
+}
+
+func (s *ClawbackTestSuite) SetupTest() {
+	aid := xdr.MustAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD")
+	source := aid.ToMuxedAccount()
+	s.op = xdr.Operation{
+		SourceAccount: &source,
+		Body: xdr.OperationBody{
+			Type: xdr.OperationTypeClawback,
+			ClawbackOp: &xdr.ClawbackOp{
+				Asset:  xdr.MustNewCreditAsset("USD", "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
+				From:   xdr.MustMuxedAddress("GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY"),
+				Amount: 20,
+			},
+		},
+	}
+}
+func (s *ClawbackTestSuite) TestDetails() {
+	expected := map[string]interface{}{
+		"asset_code":   "USD",
+		"asset_issuer": "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
+		"asset_type":   "credit_alphanum4",
+		"amount":       "0.0000020",
+		"from":         "GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+	}
+
+	operation := transactionOperationWrapper{
+		index: 0,
+		transaction: ingest.LedgerTransaction{
+			Meta: xdr.TransactionMeta{
+				V: 2,
+				V2: &xdr.TransactionMetaV2{
+					Operations: make([]xdr.OperationMeta, 1, 1),
+				},
+			}},
+		operation:      s.op,
+		ledgerSequence: 1,
+	}
+
+	details, err := operation.Details()
+	s.Assert().NoError(err)
+	s.Assert().Equal(expected, details)
+}
+
+func (s *ClawbackTestSuite) TestParticipants() {
+	operation := transactionOperationWrapper{
+		index: 0,
+		transaction: ingest.LedgerTransaction{
+			Meta: xdr.TransactionMeta{
+				V: 2,
+				V2: &xdr.TransactionMetaV2{
+					Operations: make([]xdr.OperationMeta, 1, 1),
+				},
+			},
+		},
+		operation:      s.op,
+		ledgerSequence: 1,
+	}
+
+	participants, err := operation.Participants()
+	s.Assert().NoError(err)
+	s.Assert().ElementsMatch([]xdr.AccountId{
+		xdr.MustAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
+		xdr.MustAddress("GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY"),
+	}, participants)
+}
+
+func TestClawbackTestSuite(t *testing.T) {
+	suite.Run(t, new(ClawbackTestSuite))
 }
 
 type SetTrustLineFlagsTestSuite struct {

--- a/txnbuild/clawback.go
+++ b/txnbuild/clawback.go
@@ -38,19 +38,16 @@ func (cb *Clawback) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to parse amount")
 	}
 
-	// Clawback uses an asset code, map to it
-	xdrAsset := xdr.Asset{}
-
-	assetCode, err := xdrAsset.ToAssetCode(cb.Asset.GetCode())
+	xdrAsset, err := cb.Asset.ToXDR()
 	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "can't convert asset to asset code")
+		return xdr.Operation{}, errors.Wrap(err, "can't convert asset to XDR")
 	}
 
 	opType := xdr.OperationTypeClawback
 	xdrOp := xdr.ClawbackOp{
 		From:   fromMuxedAccount,
 		Amount: xdrAmount,
-		Asset:  assetCode,
+		Asset:  xdrAsset,
 	}
 	body, err := xdr.NewOperationBody(opType, xdrOp)
 	if err != nil {
@@ -72,9 +69,9 @@ func (cb *Clawback) FromXDR(xdrOp xdr.Operation) error {
 	fromAID := result.From.ToAccountId()
 	cb.From = fromAID.Address()
 	cb.Amount = amount.String(result.Amount)
-	asset, err := assetCodeToCreditAsset(result.Asset)
+	asset, err := assetFromXDR(result.Asset)
 	if err != nil {
-		return errors.Wrap(err, "error parsing clawback operation from xdr")
+		return errors.Wrap(err, "error parsing clawback operation from XDR")
 	}
 	cb.Asset = asset
 

--- a/txnbuild/clawback_test.go
+++ b/txnbuild/clawback_test.go
@@ -85,7 +85,7 @@ func TestClawbackRoundTrip(t *testing.T) {
 	clawback := Clawback{
 		From:   "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
 		Amount: "10.0000000",
-		Asset:  CreditAsset{"USD", ""},
+		Asset:  CreditAsset{"USD", "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU"},
 	}
 
 	testOperationsMarshallingRoundtrip(t, []Operation{&clawback})

--- a/txnbuild/set_trust_line_flags.go
+++ b/txnbuild/set_trust_line_flags.go
@@ -43,10 +43,9 @@ func (stf *SetTrustLineFlags) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.New("trustline doesn't exist for a native (XLM) asset")
 	}
 
-	xdrAsset := xdr.Asset{}
-	xdrOp.Asset, err = xdrAsset.ToAssetCode(stf.Asset.GetCode())
+	xdrOp.Asset, err = stf.Asset.ToXDR()
 	if err != nil {
-		return xdr.Operation{}, errors.Wrap(err, "can't convert asset for trustline to allow trust asset type")
+		return xdr.Operation{}, errors.Wrap(err, "can't convert asset to XDR")
 	}
 
 	xdrOp.ClearFlags = trustLineFlagsToXDR(stf.ClearFlags)
@@ -82,9 +81,9 @@ func (stf *SetTrustLineFlags) FromXDR(xdrOp xdr.Operation) error {
 
 	stf.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	stf.Trustor = op.Trustor.Address()
-	asset, err := assetCodeToCreditAsset(op.Asset)
+	asset, err := assetFromXDR(op.Asset)
 	if err != nil {
-		return errors.Wrap(err, "error parsing allow_trust operation from xdr")
+		return errors.Wrap(err, "error parsing asset from xdr")
 	}
 	stf.Asset = asset
 	stf.ClearFlags = fromXDRTrustlineFlag(op.ClearFlags)

--- a/txnbuild/set_trustline_flags_test.go
+++ b/txnbuild/set_trustline_flags_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSetTrustLineFlags(t *testing.T) {
-	asset := CreditAsset{"ABCD", ""}
+	asset := CreditAsset{"ABCD", "GAEJJMDDCRYF752PKIJICUVL7MROJBNXDV2ZB455T7BAFHU2LCLSE2LW"}
 	source := &SimpleAccount{
 		AccountID: "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU",
 	}

--- a/xdr/Stellar-transaction.x
+++ b/xdr/Stellar-transaction.x
@@ -376,7 +376,7 @@ case REVOKE_SPONSORSHIP_SIGNER:
 */
 struct ClawbackOp
 {
-    AssetCode asset;
+    Asset asset;
     MuxedAccount from;
     int64 amount;
 };
@@ -404,7 +404,7 @@ struct ClawbackClaimableBalanceOp
 struct SetTrustLineFlagsOp
 {
     AccountID trustor;
-    AssetCode asset;
+    Asset asset;
 
     uint32* clearFlags; // which flags to clear
     uint32* setFlags;   // which flags to set

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -9406,13 +9406,13 @@ var (
 //
 //   struct ClawbackOp
 //    {
-//        AssetCode asset;
+//        Asset asset;
 //        MuxedAccount from;
 //        int64 amount;
 //    };
 //
 type ClawbackOp struct {
-	Asset  AssetCode
+	Asset  Asset
 	From   MuxedAccount
 	Amount Int64
 }
@@ -9469,7 +9469,7 @@ var (
 //   struct SetTrustLineFlagsOp
 //    {
 //        AccountID trustor;
-//        AssetCode asset;
+//        Asset asset;
 //
 //        uint32* clearFlags; // which flags to clear
 //        uint32* setFlags;   // which flags to set
@@ -9477,7 +9477,7 @@ var (
 //
 type SetTrustLineFlagsOp struct {
 	Trustor    AccountId
-	Asset      AssetCode
+	Asset      Asset
 	ClearFlags *Uint32
 	SetFlags   *Uint32
 }


### PR DESCRIPTION
This follows the latest XDR change from CAP35, which I somehow missed ( https://github.com/stellar/stellar-protocol/pull/852 )

Part of #3348 