### PR TITLE
services/horizon: Install specific Debian package version in check_release_hash

### DIFF
--- a/services/horizon/internal/scripts/check_release_hash/README.md
+++ b/services/horizon/internal/scripts/check_release_hash/README.md
@@ -5,5 +5,5 @@ Docker image for comparing releases hash to a local builds hash.
 ## Usage
 
 1. Build the image. Optionally pass `--build-arg` with `golang` image you want to use for compilation. See `Dockerfile` for a default value.
-2. `docker run -e "TAG=horizon-vX.Y.Z" check_release_hash`
+2. `docker run -e "TAG=horizon-vX.Y.Z"  -e "PACKAGE_VERSION=X.Y.Z-BUILD_ID" check_release_hash`
 3. Compare the hashes in the output. `released` directory contains packages from GitHub, `dist` are the locally built packages.

--- a/services/horizon/internal/scripts/check_release_hash/check.sh
+++ b/services/horizon/internal/scripts/check_release_hash/check.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+set -e
+
+apt-get clean && apt-get update && apt-get install -y stellar-horizon=$PACKAGE_VERSION
+
 mkdir released
 cd released
 
@@ -20,8 +24,6 @@ git checkout $TAG
 CIRCLE_TAG=$TAG go run -v ./support/scripts/build_release_artifacts -keep
 
 suffixes=(darwin-amd64 linux-amd64 linux-arm windows-amd64)
-
-apt-get update && apt-get install -y stellar-horizon
 
 for S in "${suffixes[@]}"
 do


### PR DESCRIPTION
Update `check_release_hash` to check specific Debian package version. Also update the script to exit on errors.