### PR TITLE
services/horizon: Drop YAML header from Captive Core doc

### DIFF
--- a/services/horizon/internal/docs/captive_core.md
+++ b/services/horizon/internal/docs/captive_core.md
@@ -1,8 +1,3 @@
----
-title: Using Captive Stellar-Core in Horizon
-replacement: https://developers.stellar.org/docs/horizon-captive-core/
----
-
 ## Using Captive Stellar-Core in Horizon
 
 ### Table of Contents


### PR DESCRIPTION
We don't need this table at the top of the file and it causes confusion due to the "fake" URL. We should put it back after the "Run an API Server" docs are updated with a Captive Core guide.