### PR TITLE
services/horizon: Update asset error message to reflect the actual issue

### DIFF
--- a/services/horizon/internal/actions/asset.go
+++ b/services/horizon/internal/actions/asset.go
@@ -46,7 +46,7 @@ func (handler AssetStatsHandler) validateAssetParams(code, issuer string, pq db2
 		if len(parts) != 3 {
 			return problem.MakeInvalidFieldProblem(
 				"cursor",
-				errors.New("cursor must contain exactly one colon"),
+				errors.New("the cursor is not a valid paging_token"),
 			)
 		}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
The previous error message:

> cursor must contain exactly one colon

did not accurately reflect the actual problem which, according to the [relevant documentation](https://developers.stellar.org/api/resources/assets/list/), actually comes from not using a valid `paging_token` for the asset.

### Why
This closes #2368 (I should've done this months ago) and is coupled with stellar/new-docs#351.