### PR TITLE
[CAP 35] Separate CAP35 tests (so that we can merge cap35 to master)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,14 +144,17 @@ commands:
 
   # install_stellar_core installs the latest unstable version of stellar core.
   install_stellar_core:
+    parameters:
+      core-version:
+        type: string
+        default: 15.0.0-40
     steps:
       - run:
           name: Install latest version of Stellar Core
           command: |
             sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
             sudo bash -c 'echo "deb https://apt.stellar.org xenial unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
-            # TODO: replace by the stable version when ready
-            sudo apt-get update && sudo apt-get install -y stellar-core=11.4.0-472.84cd6a0.xenial~cap35FonsTest~buildtests
+            sudo apt-get update && sudo apt-get install -y stellar-core=<<parameters.core_version>>
             echo "using stellar core version $(stellar-core version)"
             echo "export CAPTIVE_CORE_BIN=/usr/bin/stellar-core" >> $BASH_ENV
 
@@ -455,6 +458,10 @@ jobs:
       enable-captive-core:
         type: boolean
         default: false
+      # TODO: remove once a stellar core version with cap-35 is released
+      enable-cap-35-tests:
+        type: boolean
+        default: false
     working_directory: ~/go/src/github.com/stellar/go
     machine:
       image: ubuntu-1604:202010-01
@@ -463,6 +470,11 @@ jobs:
       - run:
           name: Setting env variables
           command: echo "export HORIZON_INTEGRATION_TESTS=true" >> $BASH_ENV
+      - when:
+          condition: <<parameters.enable-captive-core>>
+          steps:
+            - install_stellar_core:
+                core-version: <<parameters.core_version>>
       - run:
           name: Pull latest Stellar Core image
           command: docker pull stellar/stellar-core
@@ -471,16 +483,35 @@ jobs:
           name: Start Horizon Postgres DB
           command: docker run -d --env POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 circleci/postgres:9.6.5-alpine
       - when:
-          condition: << parameters.enable-captive-core >>
+          condition: <<parameters.enable-captive-core>>
           steps:
-            - install_stellar_core
+            - unless:
+                condition: <<parameters.enable-cap-35-tests>>
+                steps:
+                  # Install the default version of stellar core
+                  - install_stellar_core
+            - when:
+                contition: <<parameters.enable-cap-35-tests>>
+                steps:
+                  # Install a Stellar Core version with CAP35 support
+                  - install_stellar_core:
+                      core_version: 11.4.0-472.84cd6a0.xenial~cap35FonsTest~buildtests
+            - run:
+                name: Setting Captive Core env variables
+                command: echo "export HORIZON_INTEGRATION_ENABLE_CAPTIVE_CORE=true" >> $BASH_ENV
+      - when:
+          condition: <<parameters.enable-cap-35-tests>>
+          steps:
+            - run:
+                name: Setting CAP35 env variables
+                command: echo "export HORIZON_INTEGRATION_ENABLE_CAP_35=true" >> $BASH_ENV
       - run:
-          name: Run Horizon integration tests <<# parameters.enable-captive-core >>(With captive core)<</ parameters.enable-captive-core >>
+          name: Run Horizon integration tests <<#parameters.enable-captive-core>>(With captive core)<</parameters.enable-captive-core>> <<#parameters.enable-cap-35-tests>>(With captive core)<</parameters.enable-cap-35-tests>>
           # Currently all integration tests are in a single directory.
           # Pulling the image helps with test running time
           command: |
             cd ~/go/src/github.com/stellar/go
-            <<# parameters.enable-captive-core >>HORIZON_INTEGRATION_ENABLE_CAPTIVE_CORE=true<</ parameters.enable-captive-core >> go test -timeout 25m -v ./services/horizon/internal/integration/...
+            go test -timeout 25m -v ./services/horizon/internal/integration/...
 
 #-------------------------------------------------------------------------#
 # Workflows orchestrate jobs and make sure they run in the right sequence #
@@ -505,6 +536,11 @@ workflows:
       - test_horizon_integration:
           name: test_horizon_integration_with_captive_core
           enable-captive-core: true
+      # ... and cap35 with captive core
+      - test_horizon_integration:
+          name: test_horizon_integration_cap35_with_captive_core
+          enable-captive-core: true
+          core_version: 11.4.0-472.84cd6a0.xenial~cap35FonsTest~buildtests
       - publish_state_diff_docker_image:
           filters:
               branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,14 +147,14 @@ commands:
     parameters:
       core-version:
         type: string
-        default: 15.0.0-40
+        default: ""
     steps:
       - run:
-          name: Install latest version of Stellar Core
+          name: Install Stellar core <<#parameters.core-version>> (version <<parameters.core-version>>)<</parameters.core-version>>
           command: |
             sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
             sudo bash -c 'echo "deb https://apt.stellar.org xenial unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
-            sudo apt-get update && sudo apt-get install -y stellar-core=<<parameters.core-version>>
+            sudo apt-get update && sudo apt-get install -y stellar-core<<#parameters.core-version>>=<<parameters.core-version>><</parameters.core-version>>
             echo "using stellar core version $(stellar-core version)"
             echo "export CAPTIVE_CORE_BIN=/usr/bin/stellar-core" >> $BASH_ENV
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ commands:
           command: |
             sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
             sudo bash -c 'echo "deb https://apt.stellar.org xenial unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
-            sudo apt-get update && sudo apt-get install -y stellar-core=<<parameters.core_version>>
+            sudo apt-get update && sudo apt-get install -y stellar-core=<<parameters.core-version>>
             echo "using stellar core version $(stellar-core version)"
             echo "export CAPTIVE_CORE_BIN=/usr/bin/stellar-core" >> $BASH_ENV
 
@@ -470,11 +470,6 @@ jobs:
       - run:
           name: Setting env variables
           command: echo "export HORIZON_INTEGRATION_TESTS=true" >> $BASH_ENV
-      - when:
-          condition: <<parameters.enable-captive-core>>
-          steps:
-            - install_stellar_core:
-                core-version: <<parameters.core_version>>
       - run:
           name: Pull latest Stellar Core image
           command: docker pull stellar/stellar-core
@@ -495,7 +490,7 @@ jobs:
                 steps:
                   # Install a Stellar Core version with CAP35 support
                   - install_stellar_core:
-                      core_version: 11.4.0-472.84cd6a0.xenial~cap35FonsTest~buildtests
+                      core-version: 11.4.0-472.84cd6a0.xenial~cap35FonsTest~buildtests
             - run:
                 name: Setting Captive Core env variables
                 command: echo "export HORIZON_INTEGRATION_ENABLE_CAPTIVE_CORE=true" >> $BASH_ENV
@@ -540,7 +535,7 @@ workflows:
       - test_horizon_integration:
           name: test_horizon_integration_cap35_with_captive_core
           enable-captive-core: true
-          core_version: 11.4.0-472.84cd6a0.xenial~cap35FonsTest~buildtests
+          enable-cap-35-tests: true
       - publish_state_diff_docker_image:
           filters:
               branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -491,7 +491,7 @@ jobs:
                   # Install the default version of stellar core
                   - install_stellar_core
             - when:
-                contition: <<parameters.enable-cap-35-tests>>
+                condition: <<parameters.enable-cap-35-tests>>
                 steps:
                   # Install a Stellar Core version with CAP35 support
                   - install_stellar_core:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ commands:
         default: ""
     steps:
       - run:
-          name: Install Stellar core <<#parameters.core-version>> (version <<parameters.core-version>>)<</parameters.core-version>>
+          name: Install Stellar Core <<#parameters.core-version>> (version <<parameters.core-version>>)<</parameters.core-version>>
           command: |
             sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
             sudo bash -c 'echo "deb https://apt.stellar.org xenial unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
@@ -501,7 +501,7 @@ jobs:
                 name: Setting CAP35 env variables
                 command: echo "export HORIZON_INTEGRATION_ENABLE_CAP_35=true" >> $BASH_ENV
       - run:
-          name: Run Horizon integration tests <<#parameters.enable-captive-core>>(With captive core)<</parameters.enable-captive-core>> <<#parameters.enable-cap-35-tests>>(With captive core)<</parameters.enable-cap-35-tests>>
+          name: Run Horizon integration tests <<#parameters.enable-captive-core>>(With captive core)<</parameters.enable-captive-core>> <<#parameters.enable-cap-35-tests>>(With CAP35)<</parameters.enable-cap-35-tests>>
           # Currently all integration tests are in a single directory.
           # Pulling the image helps with test running time
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ commands:
     parameters:
       core-version:
         type: string
-        default: ""
+        default: "" # latest version by default
     steps:
       - run:
           name: Install Stellar Core <<#parameters.core-version>> (version <<parameters.core-version>>)<</parameters.core-version>>

--- a/services/horizon/docker/Dockerfile.dev
+++ b/services/horizon/docker/Dockerfile.dev
@@ -9,8 +9,7 @@ RUN go install github.com/stellar/go/exp/services/captivecore
 
 FROM ubuntu:18.04
 
-# TODO: change to a stable version when available
-ENV STELLAR_CORE_VERSION 15.2.0-441.620af1f.xenial~clawbackPR~buildtests
+ENV STELLAR_CORE_VERSION 15.0.0-40
 ENV STELLAR_CORE_BINARY_PATH /usr/bin/stellar-core
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/services/horizon/docker/docker-compose.integration-tests.yml
+++ b/services/horizon/docker/docker-compose.integration-tests.yml
@@ -10,9 +10,7 @@ services:
       - "5641:5641"
     command: ["-p", "5641"]
   core:
-    # TODO: update to the official image when ready
-    # The sources to build this image are at https://github.com/2opremio/docker-stellar-core/tree/cap35
-    image: 2opremio/stellar-core:cap35
+    image: ${CORE_IMAGE:-stellar/stellar-core}
     depends_on:
       - core-postgres
     restart: on-failure

--- a/services/horizon/internal/integration/protocol16_test.go
+++ b/services/horizon/internal/integration/protocol16_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,11 +15,21 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-var protocol16Config = integration.Config{ProtocolVersion: 16}
+func NewProtocol16Test(t *testing.T) *integration.Test {
+	// TODO, this should be removed once a core version with CAP 35 is released
+	if os.Getenv("HORIZON_INTEGRATION_ENABLE_CAP_35") != "true" {
+		t.Skip("skipping CAP35 test, set HORIZON_INTEGRATION_ENABLE_CAP_35=true if you want to run it")
+	}
+	config := integration.Config{
+		ProtocolVersion: 16,
+		CoreDockerImage: "2opremio/stellar-core:cap35",
+	}
+	return integration.NewTest(t, config)
+}
 
 func TestProtocol16Basics(t *testing.T) {
 	tt := assert.New(t)
-	itest := integration.NewTest(t, protocol16Config)
+	itest := NewProtocol16Test(t)
 	master := itest.Master()
 
 	t.Run("Sanity", func(t *testing.T) {
@@ -42,7 +53,7 @@ func TestProtocol16Basics(t *testing.T) {
 
 func TestHappyClawback(t *testing.T) {
 	tt := assert.New(t)
-	itest := integration.NewTest(t, protocol16Config)
+	itest := NewProtocol16Test(t)
 	master := itest.Master()
 
 	// Give the master account the revocable flag (needed to set the clawback flag)
@@ -149,7 +160,7 @@ func TestHappyClawback(t *testing.T) {
 
 func TestHappyClawbackClaimableBalance(t *testing.T) {
 	tt := assert.New(t)
-	itest := integration.NewTest(t, protocol16Config)
+	itest := NewProtocol16Test(t)
 	master := itest.Master()
 
 	// Give the master account the revocable flag (needed to set the clawback flag)
@@ -250,7 +261,7 @@ func TestHappyClawbackClaimableBalance(t *testing.T) {
 
 func TestHappySetTrustLineFlags(t *testing.T) {
 	tt := assert.New(t)
-	itest := integration.NewTest(t, protocol16Config)
+	itest := NewProtocol16Test(t)
 	master := itest.Master()
 
 	// Give the master account the revocable flag (needed to set the clawback flag)

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -79,8 +79,12 @@ func NewTest(t *testing.T, config Config) *Test {
 		if config.CoreDockerImage != "" {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("CORE_IMAGE=%s", config.CoreDockerImage))
 		}
-		t.Log("Running", cmd.Env, cmdline)
-		_, innerErr := cmd.Output()
+		t.Log("Running", cmd.Env, cmd.Path, cmd.Args)
+		out, innerErr := cmd.Output()
+		if exitErr, ok := innerErr.(*exec.ExitError); ok {
+			fmt.Printf("stdout:\n%s\n", string(out))
+			fmt.Printf("stderr:\n%s\n", string(exitErr.Stderr))
+		}
 		fatalIf(t, innerErr)
 	}
 

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -75,11 +75,11 @@ func NewTest(t *testing.T, config Config) *Test {
 	// Runs a docker-compose command applied to the above configs
 	runComposeCommand := func(args ...string) {
 		cmdline := append([]string{"-f", integrationYaml}, args...)
-		t.Log("Running", cmdline)
 		cmd := exec.Command("docker-compose", cmdline...)
 		if config.CoreDockerImage != "" {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("CORE_IMAGE=%s", config.CoreDockerImage))
 		}
+		t.Log("Running", cmd.Env, cmdline)
 		_, innerErr := cmd.Output()
 		fatalIf(t, innerErr)
 	}

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -41,6 +41,7 @@ type Config struct {
 	PostgresURL           string
 	ProtocolVersion       int32
 	SkipContainerCreation bool
+	CoreDockerImage       string
 }
 
 type Test struct {
@@ -76,6 +77,9 @@ func NewTest(t *testing.T, config Config) *Test {
 		cmdline := append([]string{"-f", integrationYaml}, args...)
 		t.Log("Running", cmdline)
 		cmd := exec.Command("docker-compose", cmdline...)
+		if config.CoreDockerImage != "" {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("CORE_IMAGE=%s", config.CoreDockerImage))
+		}
 		_, innerErr := cmd.Output()
 		fatalIf(t, innerErr)
 	}

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -77,6 +77,7 @@ func NewTest(t *testing.T, config Config) *Test {
 		cmdline := append([]string{"-f", integrationYaml}, args...)
 		cmd := exec.Command("docker-compose", cmdline...)
 		if config.CoreDockerImage != "" {
+			cmd.Env = os.Environ()
 			cmd.Env = append(cmd.Env, fmt.Sprintf("CORE_IMAGE=%s", config.CoreDockerImage))
 		}
 		t.Log("Running", cmd.Env, cmd.Args)

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -79,7 +79,7 @@ func NewTest(t *testing.T, config Config) *Test {
 		if config.CoreDockerImage != "" {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("CORE_IMAGE=%s", config.CoreDockerImage))
 		}
-		t.Log("Running", cmd.Env, cmd.Path, cmd.Args)
+		t.Log("Running", cmd.Env, cmd.Args)
 		out, innerErr := cmd.Output()
 		if exitErr, ok := innerErr.(*exec.ExitError); ok {
 			fmt.Printf("stdout:\n%s\n", string(out))


### PR DESCRIPTION
The idea behind this is to separate cap35 tests (which require an unreleased Core version) so that we can merge the `cap35` branch into master without tainting the other tests before Core makes an official release with CAP35 support.

Part of #3348 