### PR TITLE
services/horizon: Issue #3241, Include unauthorized assets on /assets

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -193,6 +193,18 @@ type AssetStatAccounts struct {
 	Unauthorized                    int32 `json:"unauthorized"`
 }
 
+func (a AssetStatAccounts) Add(b AssetStatAccounts) AssetStatAccounts {
+	return AssetStatAccounts{
+		Authorized:                      a.Authorized + b.Authorized,
+		AuthorizedToMaintainLiabilities: a.AuthorizedToMaintainLiabilities + b.AuthorizedToMaintainLiabilities,
+		Unauthorized:                    a.Unauthorized + b.Unauthorized,
+	}
+}
+
+func (a AssetStatAccounts) Sum() int32 {
+	return a.Authorized + a.AuthorizedToMaintainLiabilities + a.Unauthorized
+}
+
 // Balance represents an account's holdings for a single currency type
 type Balance struct {
 	Balance                           string `json:"balance"`

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -168,9 +168,9 @@ type AssetStat struct {
 	base.Asset
 	PT          string            `json:"paging_token"`
 	Accounts    AssetStatAccounts `json:"accounts"`
-	Amount      string            `json:"amount"`
+	Amount      string            `json:"amount"` // Deprecated
 	Balances    AssetStatBalances `json:"balances"`
-	NumAccounts int32             `json:"num_accounts"`
+	NumAccounts int32             `json:"num_accounts"` // Deprecated
 	Flags       AccountFlags      `json:"flags"`
 }
 

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -166,12 +166,14 @@ type AssetStat struct {
 	} `json:"_links"`
 
 	base.Asset
-	PT          string            `json:"paging_token"`
-	Accounts    AssetStatAccounts `json:"accounts"`
-	Amount      string            `json:"amount"` // Deprecated
-	Balances    AssetStatBalances `json:"balances"`
-	NumAccounts int32             `json:"num_accounts"` // Deprecated
-	Flags       AccountFlags      `json:"flags"`
+	PT       string            `json:"paging_token"`
+	Accounts AssetStatAccounts `json:"accounts"`
+	// Action needed in release: horizon-v3.0.0: deprecated field
+	Amount   string            `json:"amount"`
+	Balances AssetStatBalances `json:"balances"`
+	// Action needed in release: horizon-v3.0.0: deprecated field
+	NumAccounts int32        `json:"num_accounts"`
+	Flags       AccountFlags `json:"flags"`
 }
 
 // PagingToken implementation for hal.Pageable

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -193,18 +193,6 @@ type AssetStatAccounts struct {
 	Unauthorized                    int32 `json:"unauthorized"`
 }
 
-func (a AssetStatAccounts) Add(b AssetStatAccounts) AssetStatAccounts {
-	return AssetStatAccounts{
-		Authorized:                      a.Authorized + b.Authorized,
-		AuthorizedToMaintainLiabilities: a.AuthorizedToMaintainLiabilities + b.AuthorizedToMaintainLiabilities,
-		Unauthorized:                    a.Unauthorized + b.Unauthorized,
-	}
-}
-
-func (a AssetStatAccounts) Sum() int32 {
-	return a.Authorized + a.AuthorizedToMaintainLiabilities + a.Unauthorized
-}
-
 // Balance represents an account's holdings for a single currency type
 type Balance struct {
 	Balance                           string `json:"balance"`

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -166,15 +166,31 @@ type AssetStat struct {
 	} `json:"_links"`
 
 	base.Asset
-	PT          string       `json:"paging_token"`
-	Amount      string       `json:"amount"`
-	NumAccounts int32        `json:"num_accounts"`
-	Flags       AccountFlags `json:"flags"`
+	PT          string               `json:"paging_token"`
+	Accounts    AssetStatNumAccounts `json:"accounts"`
+	Amount      string               `json:"amount"`
+	Balances    AssetStatBalances    `json:"balances"`
+	NumAccounts int32                `json:"num_accounts"`
+	Flags       AccountFlags         `json:"flags"`
 }
 
 // PagingToken implementation for hal.Pageable
 func (res AssetStat) PagingToken() string {
 	return res.PT
+}
+
+// AssetStatBalances represents the summarized balances for a single Asset
+type AssetStatBalances struct {
+	Authorized                      string `json:"authorized"`
+	AuthorizedToMaintainLiabilities string `json:"authorized_to_maintain_liabilities"`
+	Unauthorized                    string `json:"unauthorized"`
+}
+
+// AssetStatNumAccounts represents the summarized acount numbers for a single Asset
+type AssetStatNumAccounts struct {
+	Authorized                      int32 `json:"authorized"`
+	AuthorizedToMaintainLiabilities int32 `json:"authorized_to_maintain_liabilities"`
+	Unauthorized                    int32 `json:"unauthorized"`
 }
 
 // Balance represents an account's holdings for a single currency type

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -166,12 +166,12 @@ type AssetStat struct {
 	} `json:"_links"`
 
 	base.Asset
-	PT          string               `json:"paging_token"`
-	Accounts    AssetStatNumAccounts `json:"accounts"`
-	Amount      string               `json:"amount"`
-	Balances    AssetStatBalances    `json:"balances"`
-	NumAccounts int32                `json:"num_accounts"`
-	Flags       AccountFlags         `json:"flags"`
+	PT          string            `json:"paging_token"`
+	Accounts    AssetStatAccounts `json:"accounts"`
+	Amount      string            `json:"amount"`
+	Balances    AssetStatBalances `json:"balances"`
+	NumAccounts int32             `json:"num_accounts"`
+	Flags       AccountFlags      `json:"flags"`
 }
 
 // PagingToken implementation for hal.Pageable
@@ -186,8 +186,8 @@ type AssetStatBalances struct {
 	Unauthorized                    string `json:"unauthorized"`
 }
 
-// AssetStatNumAccounts represents the summarized acount numbers for a single Asset
-type AssetStatNumAccounts struct {
+// AssetStatAccounts represents the summarized acount numbers for a single Asset
+type AssetStatAccounts struct {
 	Authorized                      int32 `json:"authorized"`
 	AuthorizedToMaintainLiabilities int32 `json:"authorized_to_maintain_liabilities"`
 	Unauthorized                    int32 `json:"unauthorized"`

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -7,6 +7,8 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Add an endpoint which determines if Horizon is healthy enough to receive traffic ([3435](https://github.com/stellar/go/pull/3435)).
 * Sanitize route regular expressions for Prometheus metrics ([3459](https://github.com/stellar/go/pull/3459)).
+* Add asset stat summaries per trust-line flag category ([3454](https://github.com/stellar/go/pull/3454)).
+  - The `amount`, and `num_accounts` fields in `/assets` endpoint are deprecated. Fields will be removed in Horizon 3.0. You can find the same data under `balances.authorized`, and `accounts.authorized`, respectively.
 
 ## v2.0.0
 

--- a/services/horizon/internal/actions/asset_test.go
+++ b/services/horizon/internal/actions/asset_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -311,23 +313,12 @@ func TestAssetStats(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			r := makeRequest(t, testCase.queryParams, map[string]string{}, q.Session)
 			results, err := handler.GetResourcePage(httptest.NewRecorder(), r)
-			if err != nil {
-				t.Fatalf("unexpected error %v", err)
-			}
+			assert.NoError(t, err)
 
-			if len(results) != len(testCase.expected) {
-				t.Fatalf(
-					"expectes results to have length %v but got %v",
-					len(results),
-					len(testCase.expected),
-				)
-			}
-
+			assert.Len(t, results, len(testCase.expected))
 			for i, item := range results {
 				assetStat := item.(horizon.AssetStat)
-				if assetStat != testCase.expected[i] {
-					t.Fatalf("expected %v but got %v", testCase.expected[i], assetStat)
-				}
+				assert.Equal(t, testCase.expected[i], assetStat)
 			}
 		})
 	}

--- a/services/horizon/internal/actions/asset_test.go
+++ b/services/horizon/internal/actions/asset_test.go
@@ -125,10 +125,30 @@ func TestAssetStats(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: issuer.AccountID,
 		AssetCode:   "USD",
+		Accounts: history.ExpAssetStatAccounts{
+			Authorized:                      2,
+			AuthorizedToMaintainLiabilities: 3,
+			Unauthorized:                    4,
+		},
+		Balances: history.ExpAssetStatBalances{
+			Authorized:                      "1",
+			AuthorizedToMaintainLiabilities: "2",
+			Unauthorized:                    "3",
+		},
 		Amount:      "1",
 		NumAccounts: 2,
 	}
 	usdAssetStatResponse := horizon.AssetStat{
+		Accounts: horizon.AssetStatAccounts{
+			Authorized:                      usdAssetStat.Accounts.Authorized,
+			AuthorizedToMaintainLiabilities: usdAssetStat.Accounts.AuthorizedToMaintainLiabilities,
+			Unauthorized:                    usdAssetStat.Accounts.Unauthorized,
+		},
+		Balances: horizon.AssetStatBalances{
+			Authorized:                      "0.0000001",
+			AuthorizedToMaintainLiabilities: "0.0000002",
+			Unauthorized:                    "0.0000003",
+		},
 		Amount:      "0.0000001",
 		NumAccounts: usdAssetStat.NumAccounts,
 		Asset: base.Asset{
@@ -144,10 +164,30 @@ func TestAssetStats(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: issuer.AccountID,
 		AssetCode:   "ETHER",
+		Accounts: history.ExpAssetStatAccounts{
+			Authorized:                      1,
+			AuthorizedToMaintainLiabilities: 2,
+			Unauthorized:                    3,
+		},
+		Balances: history.ExpAssetStatBalances{
+			Authorized:                      "23",
+			AuthorizedToMaintainLiabilities: "46",
+			Unauthorized:                    "92",
+		},
 		Amount:      "23",
 		NumAccounts: 1,
 	}
 	etherAssetStatResponse := horizon.AssetStat{
+		Accounts: horizon.AssetStatAccounts{
+			Authorized:                      etherAssetStat.Accounts.Authorized,
+			AuthorizedToMaintainLiabilities: etherAssetStat.Accounts.AuthorizedToMaintainLiabilities,
+			Unauthorized:                    etherAssetStat.Accounts.Unauthorized,
+		},
+		Balances: horizon.AssetStatBalances{
+			Authorized:                      "0.0000023",
+			AuthorizedToMaintainLiabilities: "0.0000046",
+			Unauthorized:                    "0.0000092",
+		},
 		Amount:      "0.0000023",
 		NumAccounts: etherAssetStat.NumAccounts,
 		Asset: base.Asset{
@@ -163,10 +203,30 @@ func TestAssetStats(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: otherIssuer.AccountID,
 		AssetCode:   "USD",
+		Accounts: history.ExpAssetStatAccounts{
+			Authorized:                      2,
+			AuthorizedToMaintainLiabilities: 3,
+			Unauthorized:                    4,
+		},
+		Balances: history.ExpAssetStatBalances{
+			Authorized:                      "1",
+			AuthorizedToMaintainLiabilities: "2",
+			Unauthorized:                    "3",
+		},
 		Amount:      "1",
 		NumAccounts: 2,
 	}
 	otherUSDAssetStatResponse := horizon.AssetStat{
+		Accounts: horizon.AssetStatAccounts{
+			Authorized:                      otherUSDAssetStat.Accounts.Authorized,
+			AuthorizedToMaintainLiabilities: otherUSDAssetStat.Accounts.AuthorizedToMaintainLiabilities,
+			Unauthorized:                    otherUSDAssetStat.Accounts.Unauthorized,
+		},
+		Balances: horizon.AssetStatBalances{
+			Authorized:                      "0.0000001",
+			AuthorizedToMaintainLiabilities: "0.0000002",
+			Unauthorized:                    "0.0000003",
+		},
 		Amount:      "0.0000001",
 		NumAccounts: otherUSDAssetStat.NumAccounts,
 		Asset: base.Asset{
@@ -184,10 +244,30 @@ func TestAssetStats(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: otherIssuer.AccountID,
 		AssetCode:   "EUR",
+		Accounts: history.ExpAssetStatAccounts{
+			Authorized:                      3,
+			AuthorizedToMaintainLiabilities: 4,
+			Unauthorized:                    5,
+		},
+		Balances: history.ExpAssetStatBalances{
+			Authorized:                      "111",
+			AuthorizedToMaintainLiabilities: "222",
+			Unauthorized:                    "333",
+		},
 		Amount:      "111",
 		NumAccounts: 3,
 	}
 	eurAssetStatResponse := horizon.AssetStat{
+		Accounts: horizon.AssetStatAccounts{
+			Authorized:                      eurAssetStat.Accounts.Authorized,
+			AuthorizedToMaintainLiabilities: eurAssetStat.Accounts.AuthorizedToMaintainLiabilities,
+			Unauthorized:                    eurAssetStat.Accounts.Unauthorized,
+		},
+		Balances: horizon.AssetStatBalances{
+			Authorized:                      "0.0000111",
+			AuthorizedToMaintainLiabilities: "0.0000222",
+			Unauthorized:                    "0.0000333",
+		},
 		Amount:      "0.0000111",
 		NumAccounts: eurAssetStat.NumAccounts,
 		Asset: base.Asset{
@@ -335,6 +415,16 @@ func TestAssetStatsIssuerDoesNotExist(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 		AssetCode:   "USD",
+		Accounts: history.ExpAssetStatAccounts{
+			Authorized:                      2,
+			AuthorizedToMaintainLiabilities: 3,
+			Unauthorized:                    4,
+		},
+		Balances: history.ExpAssetStatBalances{
+			Authorized:                      "1",
+			AuthorizedToMaintainLiabilities: "2",
+			Unauthorized:                    "3",
+		},
 		Amount:      "1",
 		NumAccounts: 2,
 	}
@@ -347,6 +437,16 @@ func TestAssetStatsIssuerDoesNotExist(t *testing.T) {
 	tt.Assert.NoError(err)
 
 	expectedAssetStatResponse := horizon.AssetStat{
+		Accounts: horizon.AssetStatAccounts{
+			Authorized:                      2,
+			AuthorizedToMaintainLiabilities: 3,
+			Unauthorized:                    4,
+		},
+		Balances: horizon.AssetStatBalances{
+			Authorized:                      "0.0000001",
+			AuthorizedToMaintainLiabilities: "0.0000002",
+			Unauthorized:                    "0.0000003",
+		},
 		Amount:      "0.0000001",
 		NumAccounts: usdAssetStat.NumAccounts,
 		Asset: base.Asset{

--- a/services/horizon/internal/db2/history/asset_stats.go
+++ b/services/horizon/internal/db2/history/asset_stats.go
@@ -16,6 +16,8 @@ func assetStatToMap(assetStat ExpAssetStat) map[string]interface{} {
 		"asset_type":   assetStat.AssetType,
 		"asset_code":   assetStat.AssetCode,
 		"asset_issuer": assetStat.AssetIssuer,
+		"accounts":     assetStat.Accounts,
+		"balances":     assetStat.Balances,
 		"amount":       assetStat.Amount,
 		"num_accounts": assetStat.NumAccounts,
 	}

--- a/services/horizon/internal/db2/history/asset_stats_test.go
+++ b/services/horizon/internal/db2/history/asset_stats_test.go
@@ -21,6 +21,16 @@ func TestInsertAssetStats(t *testing.T) {
 			AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 			AssetIssuer: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 			AssetCode:   "USD",
+			Accounts: ExpAssetStatAccounts{
+				Authorized:                      2,
+				AuthorizedToMaintainLiabilities: 3,
+				Unauthorized:                    4,
+			},
+			Balances: ExpAssetStatBalances{
+				Authorized:                      "1",
+				AuthorizedToMaintainLiabilities: "2",
+				Unauthorized:                    "3",
+			},
 			Amount:      "1",
 			NumAccounts: 2,
 		},
@@ -28,6 +38,16 @@ func TestInsertAssetStats(t *testing.T) {
 			AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum12,
 			AssetIssuer: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 			AssetCode:   "ETHER",
+			Accounts: ExpAssetStatAccounts{
+				Authorized:                      1,
+				AuthorizedToMaintainLiabilities: 3,
+				Unauthorized:                    4,
+			},
+			Balances: ExpAssetStatBalances{
+				Authorized:                      "23",
+				AuthorizedToMaintainLiabilities: "2",
+				Unauthorized:                    "3",
+			},
 			Amount:      "23",
 			NumAccounts: 1,
 		},
@@ -52,6 +72,16 @@ func TestInsertAssetStat(t *testing.T) {
 			AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 			AssetIssuer: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 			AssetCode:   "USD",
+			Accounts: ExpAssetStatAccounts{
+				Authorized:                      2,
+				AuthorizedToMaintainLiabilities: 3,
+				Unauthorized:                    4,
+			},
+			Balances: ExpAssetStatBalances{
+				Authorized:                      "1",
+				AuthorizedToMaintainLiabilities: "2",
+				Unauthorized:                    "3",
+			},
 			Amount:      "1",
 			NumAccounts: 2,
 		},
@@ -59,6 +89,16 @@ func TestInsertAssetStat(t *testing.T) {
 			AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum12,
 			AssetIssuer: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 			AssetCode:   "ETHER",
+			Accounts: ExpAssetStatAccounts{
+				Authorized:                      1,
+				AuthorizedToMaintainLiabilities: 3,
+				Unauthorized:                    4,
+			},
+			Balances: ExpAssetStatBalances{
+				Authorized:                      "23",
+				AuthorizedToMaintainLiabilities: "2",
+				Unauthorized:                    "3",
+			},
 			Amount:      "23",
 			NumAccounts: 1,
 		},
@@ -85,6 +125,16 @@ func TestInsertAssetStatAlreadyExistsError(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 		AssetCode:   "USD",
+		Accounts: ExpAssetStatAccounts{
+			Authorized:                      2,
+			AuthorizedToMaintainLiabilities: 3,
+			Unauthorized:                    4,
+		},
+		Balances: ExpAssetStatBalances{
+			Authorized:                      "1",
+			AuthorizedToMaintainLiabilities: "2",
+			Unauthorized:                    "3",
+		},
 		Amount:      "1",
 		NumAccounts: 2,
 	}
@@ -120,6 +170,16 @@ func TestUpdateAssetStatDoesNotExistsError(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 		AssetCode:   "USD",
+		Accounts: ExpAssetStatAccounts{
+			Authorized:                      2,
+			AuthorizedToMaintainLiabilities: 3,
+			Unauthorized:                    4,
+		},
+		Balances: ExpAssetStatBalances{
+			Authorized:                      "1",
+			AuthorizedToMaintainLiabilities: "2",
+			Unauthorized:                    "3",
+		},
 		Amount:      "1",
 		NumAccounts: 2,
 	}
@@ -143,6 +203,16 @@ func TestUpdateStat(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 		AssetCode:   "USD",
+		Accounts: ExpAssetStatAccounts{
+			Authorized:                      2,
+			AuthorizedToMaintainLiabilities: 3,
+			Unauthorized:                    4,
+		},
+		Balances: ExpAssetStatBalances{
+			Authorized:                      "1",
+			AuthorizedToMaintainLiabilities: "2",
+			Unauthorized:                    "3",
+		},
 		Amount:      "1",
 		NumAccounts: 2,
 	}
@@ -177,6 +247,16 @@ func TestGetAssetStatDoesNotExist(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 		AssetCode:   "USD",
+		Accounts: ExpAssetStatAccounts{
+			Authorized:                      2,
+			AuthorizedToMaintainLiabilities: 3,
+			Unauthorized:                    4,
+		},
+		Balances: ExpAssetStatBalances{
+			Authorized:                      "1",
+			AuthorizedToMaintainLiabilities: "2",
+			Unauthorized:                    "3",
+		},
 		Amount:      "1",
 		NumAccounts: 2,
 	}
@@ -196,6 +276,16 @@ func TestRemoveAssetStat(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 		AssetCode:   "USD",
+		Accounts: ExpAssetStatAccounts{
+			Authorized:                      2,
+			AuthorizedToMaintainLiabilities: 3,
+			Unauthorized:                    4,
+		},
+		Balances: ExpAssetStatBalances{
+			Authorized:                      "1",
+			AuthorizedToMaintainLiabilities: "2",
+			Unauthorized:                    "3",
+		},
 		Amount:      "1",
 		NumAccounts: 2,
 	}
@@ -320,6 +410,16 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 		AssetCode:   "USD",
+		Accounts: ExpAssetStatAccounts{
+			Authorized:                      2,
+			AuthorizedToMaintainLiabilities: 3,
+			Unauthorized:                    4,
+		},
+		Balances: ExpAssetStatBalances{
+			Authorized:                      "1",
+			AuthorizedToMaintainLiabilities: "2",
+			Unauthorized:                    "3",
+		},
 		Amount:      "1",
 		NumAccounts: 2,
 	}
@@ -327,6 +427,16 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum12,
 		AssetIssuer: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 		AssetCode:   "ETHER",
+		Accounts: ExpAssetStatAccounts{
+			Authorized:                      1,
+			AuthorizedToMaintainLiabilities: 3,
+			Unauthorized:                    4,
+		},
+		Balances: ExpAssetStatBalances{
+			Authorized:                      "23",
+			AuthorizedToMaintainLiabilities: "2",
+			Unauthorized:                    "3",
+		},
 		Amount:      "23",
 		NumAccounts: 1,
 	}
@@ -334,6 +444,16 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
 		AssetCode:   "USD",
+		Accounts: ExpAssetStatAccounts{
+			Authorized:                      2,
+			AuthorizedToMaintainLiabilities: 3,
+			Unauthorized:                    4,
+		},
+		Balances: ExpAssetStatBalances{
+			Authorized:                      "1",
+			AuthorizedToMaintainLiabilities: "2",
+			Unauthorized:                    "3",
+		},
 		Amount:      "1",
 		NumAccounts: 2,
 	}
@@ -341,6 +461,16 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
 		AssetCode:   "EUR",
+		Accounts: ExpAssetStatAccounts{
+			Authorized:                      3,
+			AuthorizedToMaintainLiabilities: 2,
+			Unauthorized:                    4,
+		},
+		Balances: ExpAssetStatBalances{
+			Authorized:                      "111",
+			AuthorizedToMaintainLiabilities: "2",
+			Unauthorized:                    "3",
+		},
 		Amount:      "111",
 		NumAccounts: 3,
 	}

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -4,6 +4,8 @@ package history
 
 import (
 	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -12,7 +14,6 @@ import (
 	"github.com/guregu/null"
 	"github.com/jmoiron/sqlx"
 
-	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
@@ -322,13 +323,13 @@ type Asset struct {
 
 // ExpAssetStat is a row in the exp_asset_stats table representing the stats per Asset
 type ExpAssetStat struct {
-	AssetType   xdr.AssetType             `db:"asset_type"`
-	AssetCode   string                    `db:"asset_code"`
-	AssetIssuer string                    `db:"asset_issuer"`
-	Accounts    horizon.AssetStatAccounts `db:"accounts"`
-	Balances    horizon.AssetStatBalances `db:"balances"`
-	Amount      string                    `db:"amount"`
-	NumAccounts int32                     `db:"num_accounts"`
+	AssetType   xdr.AssetType        `db:"asset_type"`
+	AssetCode   string               `db:"asset_code"`
+	AssetIssuer string               `db:"asset_issuer"`
+	Accounts    ExpAssetStatAccounts `db:"accounts"`
+	Balances    ExpAssetStatBalances `db:"balances"`
+	Amount      string               `db:"amount"`
+	NumAccounts int32                `db:"num_accounts"`
 }
 
 // PagingToken returns a cursor for this asset stat
@@ -339,6 +340,60 @@ func (e ExpAssetStat) PagingToken() string {
 		e.AssetIssuer,
 		xdr.AssetTypeToString[e.AssetType],
 	)
+}
+
+// ExpAssetStatAccounts represents the summarized acount numbers for a single Asset
+type ExpAssetStatAccounts struct {
+	Authorized                      int32 `json:"authorized"`
+	AuthorizedToMaintainLiabilities int32 `json:"authorized_to_maintain_liabilities"`
+	Unauthorized                    int32 `json:"unauthorized"`
+}
+
+func (e ExpAssetStatAccounts) Value() (driver.Value, error) {
+	j, err := json.Marshal(e)
+	return j, err
+}
+
+func (e *ExpAssetStatAccounts) Scan(src interface{}) error {
+	source, ok := src.([]byte)
+	if !ok {
+		return errors.New("Type assertion .([]byte) failed.")
+	}
+
+	return json.Unmarshal(source, &e)
+}
+
+func (a ExpAssetStatAccounts) Add(b ExpAssetStatAccounts) ExpAssetStatAccounts {
+	return ExpAssetStatAccounts{
+		Authorized:                      a.Authorized + b.Authorized,
+		AuthorizedToMaintainLiabilities: a.AuthorizedToMaintainLiabilities + b.AuthorizedToMaintainLiabilities,
+		Unauthorized:                    a.Unauthorized + b.Unauthorized,
+	}
+}
+
+func (a ExpAssetStatAccounts) Sum() int32 {
+	return a.Authorized + a.AuthorizedToMaintainLiabilities + a.Unauthorized
+}
+
+// ExpAssetStatBalances represents the summarized balances for a single Asset
+type ExpAssetStatBalances struct {
+	Authorized                      string `json:"authorized"`
+	AuthorizedToMaintainLiabilities string `json:"authorized_to_maintain_liabilities"`
+	Unauthorized                    string `json:"unauthorized"`
+}
+
+func (e ExpAssetStatBalances) Value() (driver.Value, error) {
+	j, err := json.Marshal(e)
+	return j, err
+}
+
+func (e *ExpAssetStatBalances) Scan(src interface{}) error {
+	source, ok := src.([]byte)
+	if !ok {
+		return errors.New("Type assertion .([]byte) failed.")
+	}
+
+	return json.Unmarshal(source, &e)
 }
 
 // QAssetStats defines exp_asset_stats related queries.

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -371,8 +371,8 @@ func (a ExpAssetStatAccounts) Add(b ExpAssetStatAccounts) ExpAssetStatAccounts {
 	}
 }
 
-func (a ExpAssetStatAccounts) Sum() int32 {
-	return a.Authorized + a.AuthorizedToMaintainLiabilities + a.Unauthorized
+func (a ExpAssetStatAccounts) IsZero() bool {
+	return a.Authorized == 0 && a.AuthorizedToMaintainLiabilities == 0 && a.Unauthorized == 0
 }
 
 // ExpAssetStatBalances represents the summarized balances for a single Asset

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -322,13 +322,13 @@ type Asset struct {
 
 // ExpAssetStat is a row in the exp_asset_stats table representing the stats per Asset
 type ExpAssetStat struct {
-	AssetType   xdr.AssetType                `db:"asset_type"`
-	AssetCode   string                       `db:"asset_code"`
-	AssetIssuer string                       `db:"asset_issuer"`
-	Accounts    horizon.AssetStatNumAccounts `db:"accounts"`
-	Balances    horizon.AssetStatBalances    `db:"balances"`
-	Amount      string                       `db:"amount"`
-	NumAccounts int32                        `db:"num_accounts"`
+	AssetType   xdr.AssetType             `db:"asset_type"`
+	AssetCode   string                    `db:"asset_code"`
+	AssetIssuer string                    `db:"asset_issuer"`
+	Accounts    horizon.AssetStatAccounts `db:"accounts"`
+	Balances    horizon.AssetStatBalances `db:"balances"`
+	Amount      string                    `db:"amount"`
+	NumAccounts int32                     `db:"num_accounts"`
 }
 
 // PagingToken returns a cursor for this asset stat

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/guregu/null"
 	"github.com/jmoiron/sqlx"
 
+	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
@@ -321,12 +322,13 @@ type Asset struct {
 
 // ExpAssetStat is a row in the exp_asset_stats table representing the stats per Asset
 type ExpAssetStat struct {
-	AssetType      xdr.AssetType      `db:"asset_type"`
-	AssetCode      string             `db:"asset_code"`
-	AssetIssuer    string             `db:"asset_issuer"`
-	Amount         string             `db:"amount"`
-	NumAccounts    int32              `db:"num_accounts"`
-	TrustLineFlags xdr.TrustLineFlags `db:"trust_line_flags"`
+	AssetType   xdr.AssetType                `db:"asset_type"`
+	AssetCode   string                       `db:"asset_code"`
+	AssetIssuer string                       `db:"asset_issuer"`
+	Accounts    horizon.AssetStatNumAccounts `db:"accounts"`
+	Balances    horizon.AssetStatBalances    `db:"balances"`
+	Amount      string                       `db:"amount"`
+	NumAccounts int32                        `db:"num_accounts"`
 }
 
 // PagingToken returns a cursor for this asset stat

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -350,8 +350,7 @@ type ExpAssetStatAccounts struct {
 }
 
 func (e ExpAssetStatAccounts) Value() (driver.Value, error) {
-	j, err := json.Marshal(e)
-	return j, err
+	return json.Marshal(e)
 }
 
 func (e *ExpAssetStatAccounts) Scan(src interface{}) error {
@@ -383,8 +382,7 @@ type ExpAssetStatBalances struct {
 }
 
 func (e ExpAssetStatBalances) Value() (driver.Value, error) {
-	j, err := json.Marshal(e)
-	return j, err
+	return json.Marshal(e)
 }
 
 func (e *ExpAssetStatBalances) Scan(src interface{}) error {

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -321,11 +321,12 @@ type Asset struct {
 
 // ExpAssetStat is a row in the exp_asset_stats table representing the stats per Asset
 type ExpAssetStat struct {
-	AssetType   xdr.AssetType `db:"asset_type"`
-	AssetCode   string        `db:"asset_code"`
-	AssetIssuer string        `db:"asset_issuer"`
-	Amount      string        `db:"amount"`
-	NumAccounts int32         `db:"num_accounts"`
+	AssetType      xdr.AssetType      `db:"asset_type"`
+	AssetCode      string             `db:"asset_code"`
+	AssetIssuer    string             `db:"asset_issuer"`
+	Amount         string             `db:"amount"`
+	NumAccounts    int32              `db:"num_accounts"`
+	TrustLineFlags xdr.TrustLineFlags `db:"trust_line_flags"`
 }
 
 // PagingToken returns a cursor for this asset stat

--- a/services/horizon/internal/db2/schema/bindata.go
+++ b/services/horizon/internal/db2/schema/bindata.go
@@ -38,6 +38,7 @@
 // migrations/41_add_sponsor_to_state_tables.sql (800B)
 // migrations/42_add_num_sponsored_and_num_sponsoring_to_accounts.sql (276B)
 // migrations/43_add_claimable_balances_flags.sql (145B)
+// migrations/44_asset_stat_accounts_and_balances.sql (439B)
 // migrations/4_add_protocol_version.sql (188B)
 // migrations/5_create_trades_table.sql (1.1kB)
 // migrations/6_create_assets_table.sql (366B)
@@ -873,6 +874,26 @@ func migrations43_add_claimable_balances_flagsSql() (*asset, error) {
 	return a, nil
 }
 
+var _migrations44_asset_stat_accounts_and_balancesSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x8c\x90\x4f\x4f\xc2\x30\x18\xc6\xef\xef\xa7\x78\x6e\x48\x2c\x9f\x60\xf1\x30\xec\x2e\xa6\x6e\x84\x75\xe7\xe6\x5d\x69\x74\x84\xb5\x84\xb6\xd1\xf8\xe9\x8d\x44\x70\x60\xa2\x5c\xfb\xfc\xf9\xf5\x79\x17\x0b\xdc\x8f\xc3\xcb\x81\x93\x43\xb7\x27\x2a\x95\xae\xd6\xd0\xe5\x52\x55\x70\xef\x7b\xc3\x31\xba\x64\x62\xe2\x14\xa9\x94\x12\x8f\x8d\xea\x9e\x6b\xb0\xb5\x21\xfb\x14\xf1\xd4\x36\xf5\x52\x4c\xa5\x9e\x77\xec\xad\xfb\x96\x0a\xea\x56\xb2\xd4\xbf\xcb\x80\xb6\xd2\x04\xe0\xa7\xeb\x01\xdb\x18\x7c\x6f\xfa\x3c\xec\x36\x26\xf4\x5b\x67\xd3\xdd\x8c\x73\x7a\x0d\x87\xe1\xc3\x6d\x66\x02\x3e\x8f\xe6\xe4\x9f\x8b\x63\xfc\xcc\xbb\x21\xce\xe3\x57\x72\x5e\xfc\xb3\xf3\xa8\x5d\x2f\x6d\x2b\x8d\xba\xd1\xa8\x3b\xa5\xc4\xa5\xe7\xfc\x85\xa9\xa7\x20\x9a\x1e\x57\x86\x37\xff\x37\x56\xae\x9b\xd5\x35\x55\x5c\xbc\x9e\x38\x05\x7d\x06\x00\x00\xff\xff\x9e\x44\x07\x8e\xb7\x01\x00\x00")
+
+func migrations44_asset_stat_accounts_and_balancesSqlBytes() ([]byte, error) {
+	return bindataRead(
+		_migrations44_asset_stat_accounts_and_balancesSql,
+		"migrations/44_asset_stat_accounts_and_balances.sql",
+	)
+}
+
+func migrations44_asset_stat_accounts_and_balancesSql() (*asset, error) {
+	bytes, err := migrations44_asset_stat_accounts_and_balancesSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "migrations/44_asset_stat_accounts_and_balances.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb0, 0x3b, 0xce, 0x82, 0x13, 0x91, 0xc0, 0xc2, 0x93, 0xb1, 0x17, 0xbc, 0x57, 0x34, 0xdd, 0x98, 0xc8, 0x36, 0xee, 0x29, 0xd, 0x1e, 0x69, 0xb, 0x3f, 0x31, 0xbc, 0x41, 0xd4, 0x7d, 0xa5, 0xfd}}
+	return a, nil
+}
+
 var _migrations4_add_protocol_versionSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x84\xcd\xb1\x0a\xc2\x30\x10\x06\xe0\x3d\x4f\xf1\xef\x52\x70\xef\x14\x4d\x9d\xce\x44\x4a\x32\x38\x15\xd1\xa3\x06\x6a\xae\x5c\x82\xe2\xdb\xbb\xba\x88\x4f\xf0\x75\x1d\x36\x8f\x3c\xeb\xa5\x31\xd2\x6a\x2c\xc5\x61\x44\xb4\x3b\x1a\x10\x3c\x9d\x71\xcf\xb5\x89\xbe\xa7\x85\x6f\x33\x6b\x85\x01\xac\x73\xd8\x07\x4a\x47\x8f\x55\xa5\xc9\x55\x96\xe9\xc9\x5a\xb3\x14\xe4\xd2\x78\x66\x85\x1b\x0e\x36\x51\xc4\x16\x3e\x44\xf8\x44\xd4\x1b\xf3\x6d\x39\x79\x95\xff\x9a\x1b\xc3\xe9\x97\xd5\x9b\x4f\x00\x00\x00\xff\xff\x83\xbb\x30\x2e\xbc\x00\x00\x00")
 
 func migrations4_add_protocol_versionSqlBytes() ([]byte, error) {
@@ -1142,6 +1163,7 @@ var _bindata = map[string]func() (*asset, error){
 	"migrations/41_add_sponsor_to_state_tables.sql":                      migrations41_add_sponsor_to_state_tablesSql,
 	"migrations/42_add_num_sponsored_and_num_sponsoring_to_accounts.sql": migrations42_add_num_sponsored_and_num_sponsoring_to_accountsSql,
 	"migrations/43_add_claimable_balances_flags.sql":                     migrations43_add_claimable_balances_flagsSql,
+	"migrations/44_asset_stat_accounts_and_balances.sql":                 migrations44_asset_stat_accounts_and_balancesSql,
 	"migrations/4_add_protocol_version.sql":                              migrations4_add_protocol_versionSql,
 	"migrations/5_create_trades_table.sql":                               migrations5_create_trades_tableSql,
 	"migrations/6_create_assets_table.sql":                               migrations6_create_assets_tableSql,
@@ -1231,6 +1253,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"41_add_sponsor_to_state_tables.sql":                      &bintree{migrations41_add_sponsor_to_state_tablesSql, map[string]*bintree{}},
 		"42_add_num_sponsored_and_num_sponsoring_to_accounts.sql": &bintree{migrations42_add_num_sponsored_and_num_sponsoring_to_accountsSql, map[string]*bintree{}},
 		"43_add_claimable_balances_flags.sql":                     &bintree{migrations43_add_claimable_balances_flagsSql, map[string]*bintree{}},
+		"44_asset_stat_accounts_and_balances.sql":                 &bintree{migrations44_asset_stat_accounts_and_balancesSql, map[string]*bintree{}},
 		"4_add_protocol_version.sql":                              &bintree{migrations4_add_protocol_versionSql, map[string]*bintree{}},
 		"5_create_trades_table.sql":                               &bintree{migrations5_create_trades_tableSql, map[string]*bintree{}},
 		"6_create_assets_table.sql":                               &bintree{migrations6_create_assets_tableSql, map[string]*bintree{}},

--- a/services/horizon/internal/db2/schema/migrations/43_asset_stat_trust_line_flags.sql
+++ b/services/horizon/internal/db2/schema/migrations/43_asset_stat_trust_line_flags.sql
@@ -1,11 +1,16 @@
 -- +migrate Up
 
 ALTER TABLE asset_stats
-ADD COLUMN trust_line_flags integer DEFAULT 0;
+ADD COLUMN accounts JSONB;
+ADD COLUMN balances JSONB;
 -- Previously, all the asset_stats we stored were authorized.
-UPDATE asset_stats SET trust_line_flags = 1;
+UPDATE asset_stats
+  SET
+    accounts = jsonb_build_object('authorized', num_accounts),
+    balances = jsonb_build_object('authorized', amount);
 
 -- +migrate Down
 
 ALTER TABLE asset_stats
-DROP COLUMN trust_line_flags;
+DROP COLUMN accounts;
+DROP COLUMN balances;

--- a/services/horizon/internal/db2/schema/migrations/43_asset_stat_trust_line_flags.sql
+++ b/services/horizon/internal/db2/schema/migrations/43_asset_stat_trust_line_flags.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+
+ALTER TABLE asset_stats
+ADD COLUMN trust_line_flags integer DEFAULT 0;
+-- Previously, all the asset_stats we stored were authorized.
+UPDATE asset_stats SET trust_line_flags = 1;
+
+-- +migrate Down
+
+ALTER TABLE asset_stats
+DROP COLUMN trust_line_flags;

--- a/services/horizon/internal/db2/schema/migrations/44_asset_stat_accounts_and_balances.sql
+++ b/services/horizon/internal/db2/schema/migrations/44_asset_stat_accounts_and_balances.sql
@@ -1,16 +1,16 @@
 -- +migrate Up
 
-ALTER TABLE asset_stats
+ALTER TABLE exp_asset_stats
 ADD COLUMN accounts JSONB;
 ADD COLUMN balances JSONB;
--- Previously, all the asset_stats we stored were authorized.
-UPDATE asset_stats
+-- Previously, all the exp_asset_stats we stored were authorized.
+UPDATE exp_asset_stats
   SET
     accounts = jsonb_build_object('authorized', num_accounts),
     balances = jsonb_build_object('authorized', amount);
 
 -- +migrate Down
 
-ALTER TABLE asset_stats
+ALTER TABLE exp_asset_stats
 DROP COLUMN accounts;
 DROP COLUMN balances;

--- a/services/horizon/internal/db2/schema/migrations/44_asset_stat_accounts_and_balances.sql
+++ b/services/horizon/internal/db2/schema/migrations/44_asset_stat_accounts_and_balances.sql
@@ -1,16 +1,19 @@
 -- +migrate Up
 
 ALTER TABLE exp_asset_stats
-ADD COLUMN accounts JSONB;
+ADD COLUMN accounts JSONB,
 ADD COLUMN balances JSONB;
--- Previously, all the exp_asset_stats we stored were authorized.
 UPDATE exp_asset_stats
   SET
     accounts = jsonb_build_object('authorized', num_accounts),
     balances = jsonb_build_object('authorized', amount);
 
+ALTER TABLE exp_asset_stats
+ALTER COLUMN accounts SET NOT NULL,
+ALTER COLUMN balances SET NOT NULL;
+
 -- +migrate Down
 
 ALTER TABLE exp_asset_stats
-DROP COLUMN accounts;
+DROP COLUMN accounts,
 DROP COLUMN balances;

--- a/services/horizon/internal/docs/reference/endpoints/assets-all.md
+++ b/services/horizon/internal/docs/reference/endpoints/assets-all.md
@@ -8,9 +8,6 @@ replacement: https://developers.stellar.org/api/resources/assets/
 This endpoint represents all [assets](../resources/asset.md).
 It will give you all the assets in the system along with various statistics about each.
 
-### Notes
-- The attribute `num_accounts` includes authorized trust lines only.
-
 ## Request
 
 ```
@@ -81,8 +78,16 @@ If called normally this endpoint responds with a [page](../resources/page.md) of
         "asset_code": "BANANA",
         "asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
         "paging_token": "BANANA_GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN_credit_alphanum4",
-        "amount": "10000.0000000",
-        "num_accounts": 2126,
+        "accounts": {
+          "authorized": 2126,
+          "authorized_to_maintain_liabilities": 32,
+          "unauthorized": 5
+        },
+        "balances": {
+          "authorized": "10000.0000000",
+          "authorized_to_maintain_liabilities": "3000.0000000",
+          "unauthorized": "4000.0000000"
+        },
         "flags": {
           "auth_required": true,
           "auth_revocable": false
@@ -98,8 +103,16 @@ If called normally this endpoint responds with a [page](../resources/page.md) of
         "asset_code": "BTC",
         "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG",
         "paging_token": "BTC_GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG_credit_alphanum4",
-        "amount": "5000.0000000",
-        "num_accounts": 32,
+        "accounts": {
+          "authorized": 32,
+          "authorized_to_maintain_liabilities": 124,
+          "unauthorized": 6
+        },
+        "balances": {
+          "authorized": "5000.0000000",
+          "authorized_to_maintain_liabilities": "8000.0000000",
+          "unauthorized": "2000.0000000"
+        },
         "flags": {
           "auth_required": false,
           "auth_revocable": false
@@ -115,8 +128,16 @@ If called normally this endpoint responds with a [page](../resources/page.md) of
         "asset_code": "USD",
         "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG",
         "paging_token": "USD_GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG_credit_alphanum4",
-        "amount": "1000000000.0000000",
-        "num_accounts": 91547871,
+        "accounts": {
+          "authorized": 91547871,
+          "authorized_to_maintain_liabilities": 45773935,
+          "unauthorized": 22886967
+        },
+        "balances": {
+          "authorized": "1000000000.0000000",
+          "authorized_to_maintain_liabilities": "500000000.0000000",
+          "unauthorized": "250000000.0000000"
+        },
         "flags": {
           "auth_required": false,
           "auth_revocable": false

--- a/services/horizon/internal/docs/reference/resources/asset.md
+++ b/services/horizon/internal/docs/reference/resources/asset.md
@@ -16,8 +16,8 @@ To learn more about the concept of assets in the Stellar network, take a look at
 | asset_type               | string | The type of this asset: "credit_alphanum4", or "credit_alphanum12". |
 | asset_code               | string | The code of this asset.   |
 | asset_issuer             | string | The issuer of this asset. |
-| amount                   | number | The number of units of credit issued. |
-| num_accounts             | number | The number of accounts that: 1) trust this asset and 2) where if the asset has the auth_required flag then the account is authorized to hold the asset. |
+| accounts                 | object | The number of accounts holding this asset, summarized by each state of the trust line flags. |
+| balances                 | object | The number of units of credit issued, summarized by each state of the trust line flags. |
 | flags                    | object | The flags denote the enabling/disabling of certain asset issuer privileges. |
 | paging_token             | string | A [paging token](./page.md) suitable for use as the `cursor` parameter to transaction collection resources.                   |
 
@@ -46,8 +46,16 @@ To learn more about the concept of assets in the Stellar network, take a look at
   "asset_code": "USD",
   "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG",
   "paging_token": "USD_GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG_credit_alphanum4",
-  "amount": "100.0000000",
-  "num_accounts": 91547871,
+  "accounts": {
+    "authorized": 91547871,
+    "authorized_to_maintain_liabilities": 45773935,
+    "unauthorized": 22886967
+  },
+  "balances": {
+    "authorized": "100.0000000",
+    "authorized_to_maintain_liabilities": "50.0000000",
+    "unauthorized": "25.0000000"
+  },
   "flags": {
     "auth_required": false,
     "auth_revocable": false

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -49,7 +49,8 @@ const (
 	// - 11: Protocol 14: CAP-23 and CAP-33.
 	// - 12: Trigger state rebuild due to `absTime` -> `abs_time` rename
 	//       in ClaimableBalances predicates.
-	CurrentVersion = 12
+	// - 13: Trigger state rebuild to include more than just authorized assets.
+	CurrentVersion = 13
 
 	// MaxDBConnections is the size of the postgres connection pool dedicated to Horizon ingestion:
 	//  * Ledger ingestion,

--- a/services/horizon/internal/ingest/processors/asset_stats_processor.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor.go
@@ -172,12 +172,13 @@ func (p *AssetStatsProcessor) Commit() error {
 			} else {
 				// Update
 				rowsAffected, err = p.assetStatsQ.UpdateAssetStat(history.ExpAssetStat{
-					AssetType:      delta.AssetType,
-					AssetCode:      delta.AssetCode,
-					AssetIssuer:    delta.AssetIssuer,
-					Amount:         statBalance.String(),
-					NumAccounts:    statAccounts,
-					TrustLineFlags: delta.TrustLineFlags,
+					AssetType:   delta.AssetType,
+					AssetCode:   delta.AssetCode,
+					AssetIssuer: delta.AssetIssuer,
+					Accounts:    statAccounts,
+					Balances:    statBalances,
+					Amount:      statBalances.Authorized.String(),
+					NumAccounts: statAccounts.Authorized,
 				})
 				if err != nil {
 					return errors.Wrap(err, "could not update asset stat")

--- a/services/horizon/internal/ingest/processors/asset_stats_processor.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor.go
@@ -2,7 +2,6 @@ package processors
 
 import (
 	"database/sql"
-	"math/big"
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -167,11 +166,9 @@ func (p *AssetStatsProcessor) Commit() error {
 			statBalances = statBalances.Add(deltaBalances)
 			statAccounts := stat.Accounts.Add(delta.Accounts)
 
-			// TODO: Sum is not really what we want here. We want to check they're
-			// all 0.
-			if statAccounts.Sum() == 0 {
+			if statAccounts.IsZero() {
 				// Remove stats
-				if statBalances.Sum().Cmp(big.NewInt(0)) != 0 {
+				if !statBalances.IsZero() {
 					return ingest.NewStateError(errors.Errorf(
 						"Removing asset stat by final amount non-zero for: %s %s %s",
 						delta.AssetType,

--- a/services/horizon/internal/ingest/processors/asset_stats_processor.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor.go
@@ -172,11 +172,12 @@ func (p *AssetStatsProcessor) Commit() error {
 			} else {
 				// Update
 				rowsAffected, err = p.assetStatsQ.UpdateAssetStat(history.ExpAssetStat{
-					AssetType:   delta.AssetType,
-					AssetCode:   delta.AssetCode,
-					AssetIssuer: delta.AssetIssuer,
-					Amount:      statBalance.String(),
-					NumAccounts: statAccounts,
+					AssetType:      delta.AssetType,
+					AssetCode:      delta.AssetCode,
+					AssetIssuer:    delta.AssetIssuer,
+					Amount:         statBalance.String(),
+					NumAccounts:    statAccounts,
+					TrustLineFlags: delta.TrustLineFlags,
 				})
 				if err != nil {
 					return errors.Wrap(err, "could not update asset stat")
@@ -206,46 +207,27 @@ func (p *AssetStatsProcessor) adjustAssetStat(
 	var deltaAccounts int32
 	var trustline xdr.TrustLineEntry
 
-	if preTrustline != nil && postTrustline == nil {
-		trustline = *preTrustline
-		// removing a trustline
-		if xdr.TrustLineFlags(preTrustline.Flags).IsAuthorized() {
-			deltaAccounts = -1
-			deltaBalance = -preTrustline.Balance
-		}
-	} else if preTrustline == nil && postTrustline != nil {
-		trustline = *postTrustline
+	switch {
+	case preTrustline == nil && postTrustline != nil:
 		// adding a trustline
-		if xdr.TrustLineFlags(postTrustline.Flags).IsAuthorized() {
-			deltaAccounts = 1
-			deltaBalance = postTrustline.Balance
-		}
-	} else if preTrustline != nil && postTrustline != nil {
 		trustline = *postTrustline
+		deltaAccounts = 1
+		deltaBalance = postTrustline.Balance
+	case preTrustline != nil && postTrustline != nil:
 		// updating a trustline
-		if xdr.TrustLineFlags(preTrustline.Flags).IsAuthorized() &&
-			xdr.TrustLineFlags(postTrustline.Flags).IsAuthorized() {
-			// trustline remains authorized
-			deltaAccounts = 0
-			deltaBalance = postTrustline.Balance - preTrustline.Balance
-		} else if xdr.TrustLineFlags(preTrustline.Flags).IsAuthorized() &&
-			!xdr.TrustLineFlags(postTrustline.Flags).IsAuthorized() {
-			// trustline was authorized and became unauthorized
-			deltaAccounts = -1
-			deltaBalance = -preTrustline.Balance
-		} else if !xdr.TrustLineFlags(preTrustline.Flags).IsAuthorized() &&
-			xdr.TrustLineFlags(postTrustline.Flags).IsAuthorized() {
-			// trustline was unauthorized and became authorized
-			deltaAccounts = 1
-			deltaBalance = postTrustline.Balance
-		}
-		// else, trustline was unauthorized and remains unauthorized
-		// so there is no change to accounts or balances
-	} else {
+		trustline = *postTrustline
+		deltaAccounts = 0
+		deltaBalance = postTrustline.Balance - preTrustline.Balance
+	case preTrustline != nil && postTrustline == nil:
+		// removing a trustline
+		trustline = *preTrustline
+		deltaAccounts = -1
+		deltaBalance = -preTrustline.Balance
+	default:
 		return ingest.NewStateError(errors.New("both pre and post trustlines cannot be nil"))
 	}
 
-	err := p.assetStatSet.AddDelta(trustline.Asset, int64(deltaBalance), deltaAccounts)
+	err := p.assetStatSet.AddDelta(trustline.Asset, int64(deltaBalance), deltaAccounts, xdr.TrustLineFlags(trustline.Flags))
 	if err != nil {
 		return errors.Wrap(err, "error running AssetStatSet.AddDelta")
 	}

--- a/services/horizon/internal/ingest/processors/asset_stats_processor.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor.go
@@ -221,32 +221,21 @@ func (p *AssetStatsProcessor) adjustAssetStat(
 ) error {
 	deltaAccounts := map[xdr.Uint32]int32{}
 	deltaBalances := map[xdr.Uint32]int64{}
-	var trustline xdr.TrustLineEntry
 
-	switch {
-	case preTrustline == nil && postTrustline != nil:
-		// adding a trustline
-		trustline = *postTrustline
-		deltaAccounts[trustline.Flags] = 1
-		deltaBalances[trustline.Flags] = int64(postTrustline.Balance)
-	case preTrustline != nil && postTrustline != nil:
-		// updating a trustline
-		trustline = *postTrustline
-		if preTrustline.Flags == postTrustline.Flags {
-			deltaBalances[trustline.Flags] = int64(postTrustline.Balance - preTrustline.Balance)
-		} else {
-			deltaAccounts[preTrustline.Flags] = -1
-			deltaBalances[preTrustline.Flags] = int64(-preTrustline.Balance)
-			deltaAccounts[postTrustline.Flags] = 1
-			deltaBalances[postTrustline.Flags] = int64(postTrustline.Balance)
-		}
-	case preTrustline != nil && postTrustline == nil:
-		// removing a trustline
-		trustline = *preTrustline
-		deltaAccounts[trustline.Flags] = -1
-		deltaBalances[trustline.Flags] = int64(-preTrustline.Balance)
-	default:
+	if preTrustline == nil && postTrustline == nil {
 		return ingest.NewStateError(errors.New("both pre and post trustlines cannot be nil"))
+	}
+
+	var trustline xdr.TrustLineEntry
+	if preTrustline != nil {
+		trustline = *preTrustline
+		deltaAccounts[preTrustline.Flags] -= 1
+		deltaBalances[preTrustline.Flags] -= int64(preTrustline.Balance)
+	}
+	if postTrustline != nil {
+		trustline = *postTrustline
+		deltaAccounts[postTrustline.Flags] += 1
+		deltaBalances[postTrustline.Flags] += int64(postTrustline.Balance)
 	}
 
 	err := p.assetStatSet.AddDelta(trustline.Asset, deltaBalances, deltaAccounts)

--- a/services/horizon/internal/ingest/processors/asset_stats_processor.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor.go
@@ -191,7 +191,7 @@ func (p *AssetStatsProcessor) Commit() error {
 					AssetCode:   delta.AssetCode,
 					AssetIssuer: delta.AssetIssuer,
 					Accounts:    statAccounts,
-					Balances:    statBalances.Finish(),
+					Balances:    statBalances.ConvertToHistoryObject(),
 					Amount:      statBalances.Authorized.String(),
 					NumAccounts: statAccounts.Authorized,
 				})

--- a/services/horizon/internal/ingest/processors/asset_stats_processor.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor.go
@@ -109,8 +109,10 @@ func (p *AssetStatsProcessor) Commit() error {
 	assetStatsDeltas := p.assetStatSet.All()
 	for _, delta := range assetStatsDeltas {
 		var rowsAffected int64
+		var stat history.ExpAssetStat
+		var err error
 
-		stat, err := p.assetStatsQ.GetAssetStat(
+		stat, err = p.assetStatsQ.GetAssetStat(
 			delta.AssetType,
 			delta.AssetCode,
 			delta.AssetIssuer,
@@ -153,12 +155,12 @@ func (p *AssetStatsProcessor) Commit() error {
 			}
 		} else {
 			var statBalances assetStatBalances
-			if err := statBalances.Parse(&stat.Balances); err != nil {
+			if err = statBalances.Parse(&stat.Balances); err != nil {
 				return errors.Wrap(err, "Error parsing balances")
 			}
 
 			var deltaBalances assetStatBalances
-			if err := deltaBalances.Parse(&delta.Balances); err != nil {
+			if err = deltaBalances.Parse(&delta.Balances); err != nil {
 				return errors.Wrap(err, "Error parsing balances")
 			}
 

--- a/services/horizon/internal/ingest/processors/asset_stats_processor.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor.go
@@ -121,39 +121,55 @@ func (p *AssetStatsProcessor) Commit() error {
 		}
 
 		if assetStatNotFound {
-			// Insert
-			if delta.NumAccounts < 0 {
+			// Safety checks
+			if delta.Accounts.Authorized < 0 {
 				return ingest.NewStateError(errors.Errorf(
-					"NumAccounts negative but DB entry does not exist for asset: %s %s %s",
+					"Authorized accounts negative but DB entry does not exist for asset: %s %s %s",
+					delta.AssetType,
+					delta.AssetCode,
+					delta.AssetIssuer,
+				))
+			} else if delta.Accounts.AuthorizedToMaintainLiabilities < 0 {
+				return ingest.NewStateError(errors.Errorf(
+					"AuthorizedToMaintainLiabilities accounts negative but DB entry does not exist for asset: %s %s %s",
+					delta.AssetType,
+					delta.AssetCode,
+					delta.AssetIssuer,
+				))
+			} else if delta.Accounts.Unauthorized < 0 {
+				return ingest.NewStateError(errors.Errorf(
+					"Unauthorized accounts negative but DB entry does not exist for asset: %s %s %s",
 					delta.AssetType,
 					delta.AssetCode,
 					delta.AssetIssuer,
 				))
 			}
 
+			// Insert
 			var errInsert error
 			rowsAffected, errInsert = p.assetStatsQ.InsertAssetStat(delta)
 			if errInsert != nil {
 				return errors.Wrap(errInsert, "could not insert asset stat")
 			}
 		} else {
-			statBalance, ok := new(big.Int).SetString(stat.Amount, 10)
-			if !ok {
-				return errors.New("Error parsing: " + stat.Amount)
+			var statBalances assetStatBalances
+			if err := statBalances.Parse(&stat.Balances); err != nil {
+				return errors.Wrap(err, "Error parsing balances")
 			}
 
-			deltaBalance, ok := new(big.Int).SetString(delta.Amount, 10)
-			if !ok {
-				return errors.New("Error parsing: " + stat.Amount)
+			var deltaBalances assetStatBalances
+			if err := deltaBalances.Parse(&delta.Balances); err != nil {
+				return errors.Wrap(err, "Error parsing balances")
 			}
 
-			// statBalance = statBalance + deltaBalance
-			statBalance.Add(statBalance, deltaBalance)
-			statAccounts := stat.NumAccounts + delta.NumAccounts
+			statBalances = statBalances.Add(deltaBalances)
+			statAccounts := stat.Accounts.Add(delta.Accounts)
 
-			if statAccounts == 0 {
+			// TODO: Sum is not really what we want here. We want to check they're
+			// all 0.
+			if statAccounts.Sum() == 0 {
 				// Remove stats
-				if statBalance.Cmp(big.NewInt(0)) != 0 {
+				if statBalances.Sum().Cmp(big.NewInt(0)) != 0 {
 					return ingest.NewStateError(errors.Errorf(
 						"Removing asset stat by final amount non-zero for: %s %s %s",
 						delta.AssetType,
@@ -176,7 +192,7 @@ func (p *AssetStatsProcessor) Commit() error {
 					AssetCode:   delta.AssetCode,
 					AssetIssuer: delta.AssetIssuer,
 					Accounts:    statAccounts,
-					Balances:    statBalances,
+					Balances:    statBalances.Finish(),
 					Amount:      statBalances.Authorized.String(),
 					NumAccounts: statAccounts.Authorized,
 				})
@@ -204,31 +220,37 @@ func (p *AssetStatsProcessor) adjustAssetStat(
 	preTrustline *xdr.TrustLineEntry,
 	postTrustline *xdr.TrustLineEntry,
 ) error {
-	var deltaBalance xdr.Int64
-	var deltaAccounts int32
+	deltaAccounts := map[xdr.Uint32]int32{}
+	deltaBalances := map[xdr.Uint32]int64{}
 	var trustline xdr.TrustLineEntry
 
 	switch {
 	case preTrustline == nil && postTrustline != nil:
 		// adding a trustline
 		trustline = *postTrustline
-		deltaAccounts = 1
-		deltaBalance = postTrustline.Balance
+		deltaAccounts[trustline.Flags] = 1
+		deltaBalances[trustline.Flags] = int64(postTrustline.Balance)
 	case preTrustline != nil && postTrustline != nil:
 		// updating a trustline
 		trustline = *postTrustline
-		deltaAccounts = 0
-		deltaBalance = postTrustline.Balance - preTrustline.Balance
+		if preTrustline.Flags == postTrustline.Flags {
+			deltaBalances[trustline.Flags] = int64(postTrustline.Balance - preTrustline.Balance)
+		} else {
+			deltaAccounts[preTrustline.Flags] = -1
+			deltaBalances[preTrustline.Flags] = int64(-preTrustline.Balance)
+			deltaAccounts[postTrustline.Flags] = 1
+			deltaBalances[postTrustline.Flags] = int64(postTrustline.Balance)
+		}
 	case preTrustline != nil && postTrustline == nil:
 		// removing a trustline
 		trustline = *preTrustline
-		deltaAccounts = -1
-		deltaBalance = -preTrustline.Balance
+		deltaAccounts[trustline.Flags] = -1
+		deltaBalances[trustline.Flags] = int64(-preTrustline.Balance)
 	default:
 		return ingest.NewStateError(errors.New("both pre and post trustlines cannot be nil"))
 	}
 
-	err := p.assetStatSet.AddDelta(trustline.Asset, int64(deltaBalance), deltaAccounts, xdr.TrustLineFlags(trustline.Flags))
+	err := p.assetStatSet.AddDelta(trustline.Asset, deltaBalances, deltaAccounts)
 	if err != nil {
 		return errors.Wrap(err, "error running AssetStatSet.AddDelta")
 	}

--- a/services/horizon/internal/ingest/processors/asset_stats_processor_test.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor_test.go
@@ -626,7 +626,7 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestRemoveTrustLine() {
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "USD",
 		Accounts: history.ExpAssetStatAccounts{
-			Authorized: 1,
+			Unauthorized: 1,
 		},
 		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "0",
@@ -634,7 +634,7 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestRemoveTrustLine() {
 			Unauthorized:                    "0",
 		},
 		Amount:      "0",
-		NumAccounts: 1,
+		NumAccounts: 0,
 	}, nil).Once()
 	s.mockQ.On("RemoveAssetStat",
 		xdr.AssetTypeAssetTypeCreditAlphanum4,

--- a/services/horizon/internal/ingest/processors/asset_stats_processor_test.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stellar/go/ingest"
-	protocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/suite"
@@ -59,8 +58,8 @@ func (s *AssetStatsProcessorTestSuiteState) TestCreateTrustLine() {
 			AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 			AssetIssuer: trustLineIssuer.Address(),
 			AssetCode:   "EUR",
-			Accounts:    protocol.AssetStatAccounts{Authorized: 1},
-			Balances: protocol.AssetStatBalances{
+			Accounts:    history.ExpAssetStatAccounts{Authorized: 1},
+			Balances: history.ExpAssetStatBalances{
 				Authorized:                      "0",
 				AuthorizedToMaintainLiabilities: "0",
 				Unauthorized:                    "0",
@@ -95,8 +94,8 @@ func (s *AssetStatsProcessorTestSuiteState) TestCreateTrustLineUnauthorized() {
 			AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 			AssetIssuer: trustLineIssuer.Address(),
 			AssetCode:   "EUR",
-			Accounts:    protocol.AssetStatAccounts{Unauthorized: 1},
-			Balances: protocol.AssetStatBalances{
+			Accounts:    history.ExpAssetStatAccounts{Unauthorized: 1},
+			Balances: history.ExpAssetStatBalances{
 				Authorized:                      "0",
 				AuthorizedToMaintainLiabilities: "0",
 				Unauthorized:                    "0",
@@ -243,10 +242,10 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestInsertTrustLine() {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "EUR",
-		Accounts: protocol.AssetStatAccounts{
+		Accounts: history.ExpAssetStatAccounts{
 			Authorized: 1,
 		},
-		Balances: protocol.AssetStatBalances{
+		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "10",
 			AuthorizedToMaintainLiabilities: "0",
 			Unauthorized:                    "0",
@@ -264,10 +263,10 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestInsertTrustLine() {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "USD",
-		Accounts: protocol.AssetStatAccounts{
+		Accounts: history.ExpAssetStatAccounts{
 			Unauthorized: 1,
 		},
-		Balances: protocol.AssetStatBalances{
+		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "0",
 			AuthorizedToMaintainLiabilities: "0",
 			Unauthorized:                    "10",
@@ -322,8 +321,8 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateTrustLine() {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "EUR",
-		Accounts:    protocol.AssetStatAccounts{Authorized: 1},
-		Balances: protocol.AssetStatBalances{
+		Accounts:    history.ExpAssetStatAccounts{Authorized: 1},
+		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "100",
 			AuthorizedToMaintainLiabilities: "0",
 			Unauthorized:                    "0",
@@ -335,8 +334,8 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateTrustLine() {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "EUR",
-		Accounts:    protocol.AssetStatAccounts{Authorized: 1},
-		Balances: protocol.AssetStatBalances{
+		Accounts:    history.ExpAssetStatAccounts{Authorized: 1},
+		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "110",
 			AuthorizedToMaintainLiabilities: "0",
 			Unauthorized:                    "0",
@@ -456,10 +455,10 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateTrustLineAuthorization() 
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "EUR",
-		Accounts: protocol.AssetStatAccounts{
+		Accounts: history.ExpAssetStatAccounts{
 			Unauthorized: 1,
 		},
-		Balances: protocol.AssetStatBalances{
+		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "0",
 			AuthorizedToMaintainLiabilities: "0",
 			Unauthorized:                    "100",
@@ -471,10 +470,10 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateTrustLineAuthorization() 
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "EUR",
-		Accounts: protocol.AssetStatAccounts{
+		Accounts: history.ExpAssetStatAccounts{
 			Authorized: 1,
 		},
-		Balances: protocol.AssetStatBalances{
+		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "10",
 			AuthorizedToMaintainLiabilities: "0",
 			Unauthorized:                    "0",
@@ -491,10 +490,10 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateTrustLineAuthorization() 
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "USD",
-		Accounts: protocol.AssetStatAccounts{
+		Accounts: history.ExpAssetStatAccounts{
 			Authorized: 1,
 		},
-		Balances: protocol.AssetStatBalances{
+		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "100",
 			AuthorizedToMaintainLiabilities: "0",
 			Unauthorized:                    "0",
@@ -506,10 +505,10 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateTrustLineAuthorization() 
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "USD",
-		Accounts: protocol.AssetStatAccounts{
+		Accounts: history.ExpAssetStatAccounts{
 			Unauthorized: 1,
 		},
-		Balances: protocol.AssetStatBalances{
+		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "0",
 			AuthorizedToMaintainLiabilities: "0",
 			Unauthorized:                    "10",
@@ -526,10 +525,10 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateTrustLineAuthorization() 
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "ETH",
-		Accounts: protocol.AssetStatAccounts{
+		Accounts: history.ExpAssetStatAccounts{
 			Authorized: 1,
 		},
-		Balances: protocol.AssetStatBalances{
+		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "100",
 			AuthorizedToMaintainLiabilities: "0",
 			Unauthorized:                    "0",
@@ -541,10 +540,10 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateTrustLineAuthorization() 
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "ETH",
-		Accounts: protocol.AssetStatAccounts{
+		Accounts: history.ExpAssetStatAccounts{
 			AuthorizedToMaintainLiabilities: 1,
 		},
-		Balances: protocol.AssetStatBalances{
+		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "0",
 			AuthorizedToMaintainLiabilities: "10",
 			Unauthorized:                    "0",
@@ -601,10 +600,10 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestRemoveTrustLine() {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "EUR",
-		Accounts: protocol.AssetStatAccounts{
+		Accounts: history.ExpAssetStatAccounts{
 			Authorized: 1,
 		},
-		Balances: protocol.AssetStatBalances{
+		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "0",
 			AuthorizedToMaintainLiabilities: "0",
 			Unauthorized:                    "0",
@@ -626,10 +625,10 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestRemoveTrustLine() {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "USD",
-		Accounts: protocol.AssetStatAccounts{
+		Accounts: history.ExpAssetStatAccounts{
 			Authorized: 1,
 		},
-		Balances: protocol.AssetStatBalances{
+		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "0",
 			AuthorizedToMaintainLiabilities: "0",
 			Unauthorized:                    "0",
@@ -703,10 +702,10 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestProcessUpgradeChange() {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "EUR",
-		Accounts: protocol.AssetStatAccounts{
+		Accounts: history.ExpAssetStatAccounts{
 			Authorized: 1,
 		},
-		Balances: protocol.AssetStatBalances{
+		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "10",
 			AuthorizedToMaintainLiabilities: "0",
 			Unauthorized:                    "0",

--- a/services/horizon/internal/ingest/processors/asset_stats_processor_test.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stellar/go/ingest"
+	protocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/suite"
@@ -58,6 +59,12 @@ func (s *AssetStatsProcessorTestSuiteState) TestCreateTrustLine() {
 			AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 			AssetIssuer: trustLineIssuer.Address(),
 			AssetCode:   "EUR",
+			Accounts:    protocol.AssetStatAccounts{Authorized: 1},
+			Balances: protocol.AssetStatBalances{
+				Authorized:                      "0",
+				AuthorizedToMaintainLiabilities: "0",
+				Unauthorized:                    "0",
+			},
 			Amount:      "0",
 			NumAccounts: 1,
 		},
@@ -83,8 +90,21 @@ func (s *AssetStatsProcessorTestSuiteState) TestCreateTrustLineUnauthorized() {
 	})
 	s.Assert().NoError(err)
 
-	s.mockQ.
-		On("InsertAssetStats", []history.ExpAssetStat{}, maxBatchSize).Return(nil).Once()
+	s.mockQ.On("InsertAssetStats", []history.ExpAssetStat{
+		{
+			AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
+			AssetIssuer: trustLineIssuer.Address(),
+			AssetCode:   "EUR",
+			Accounts:    protocol.AssetStatAccounts{Unauthorized: 1},
+			Balances: protocol.AssetStatBalances{
+				Authorized:                      "0",
+				AuthorizedToMaintainLiabilities: "0",
+				Unauthorized:                    "0",
+			},
+			Amount:      "0",
+			NumAccounts: 0,
+		},
+	}, maxBatchSize).Return(nil).Once()
 }
 
 func TestAssetStatsProcessorTestSuiteLedger(t *testing.T) {
@@ -223,8 +243,37 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestInsertTrustLine() {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "EUR",
+		Accounts: protocol.AssetStatAccounts{
+			Authorized: 1,
+		},
+		Balances: protocol.AssetStatBalances{
+			Authorized:                      "10",
+			AuthorizedToMaintainLiabilities: "0",
+			Unauthorized:                    "0",
+		},
 		Amount:      "10",
 		NumAccounts: 1,
+	}).Return(int64(1), nil).Once()
+
+	s.mockQ.On("GetAssetStat",
+		xdr.AssetTypeAssetTypeCreditAlphanum4,
+		"USD",
+		trustLineIssuer.Address(),
+	).Return(history.ExpAssetStat{}, sql.ErrNoRows).Once()
+	s.mockQ.On("InsertAssetStat", history.ExpAssetStat{
+		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AssetIssuer: trustLineIssuer.Address(),
+		AssetCode:   "USD",
+		Accounts: protocol.AssetStatAccounts{
+			Unauthorized: 1,
+		},
+		Balances: protocol.AssetStatBalances{
+			Authorized:                      "0",
+			AuthorizedToMaintainLiabilities: "0",
+			Unauthorized:                    "10",
+		},
+		Amount:      "0",
+		NumAccounts: 0,
 	}).Return(int64(1), nil).Once()
 
 	s.Assert().NoError(s.processor.Commit())
@@ -273,6 +322,12 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateTrustLine() {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "EUR",
+		Accounts:    protocol.AssetStatAccounts{Authorized: 1},
+		Balances: protocol.AssetStatBalances{
+			Authorized:                      "100",
+			AuthorizedToMaintainLiabilities: "0",
+			Unauthorized:                    "0",
+		},
 		Amount:      "100",
 		NumAccounts: 1,
 	}, nil).Once()
@@ -280,6 +335,12 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateTrustLine() {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "EUR",
+		Accounts:    protocol.AssetStatAccounts{Authorized: 1},
+		Balances: protocol.AssetStatBalances{
+			Authorized:                      "110",
+			AuthorizedToMaintainLiabilities: "0",
+			Unauthorized:                    "0",
+		},
 		Amount:      "110",
 		NumAccounts: 1,
 	}).Return(int64(1), nil).Once()
@@ -290,28 +351,44 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateTrustLine() {
 func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateTrustLineAuthorization() {
 	lastModifiedLedgerSeq := xdr.Uint32(1234)
 
-	trustLine := xdr.TrustLineEntry{
+	// EUR trustline: 100 unauthorized -> 10 authorized
+	eurTrustLine := xdr.TrustLineEntry{
 		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
 		Asset:     xdr.MustNewCreditAsset("EUR", trustLineIssuer.Address()),
 		Balance:   100,
 	}
-	updatedTrustLine := xdr.TrustLineEntry{
+	eurUpdatedTrustLine := xdr.TrustLineEntry{
 		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
 		Asset:     xdr.MustNewCreditAsset("EUR", trustLineIssuer.Address()),
 		Balance:   10,
 		Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag),
 	}
 
-	otherTrustLine := xdr.TrustLineEntry{
+	// USD trustline: 100 authorized -> 10 unauthorized
+	usdTrustLine := xdr.TrustLineEntry{
 		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
 		Asset:     xdr.MustNewCreditAsset("USD", trustLineIssuer.Address()),
 		Balance:   100,
 		Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag),
 	}
-	otherUpdatedTrustLine := xdr.TrustLineEntry{
+	usdUpdatedTrustLine := xdr.TrustLineEntry{
 		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
 		Asset:     xdr.MustNewCreditAsset("USD", trustLineIssuer.Address()),
 		Balance:   10,
+	}
+
+	// ETH trustline: 100 authorized -> 10 authorized_to_maintain_liabilities
+	ethTrustLine := xdr.TrustLineEntry{
+		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		Asset:     xdr.MustNewCreditAsset("ETH", trustLineIssuer.Address()),
+		Balance:   100,
+		Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag),
+	}
+	ethUpdatedTrustLine := xdr.TrustLineEntry{
+		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		Asset:     xdr.MustNewCreditAsset("ETH", trustLineIssuer.Address()),
+		Balance:   10,
+		Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedToMaintainLiabilitiesFlag),
 	}
 
 	err := s.processor.ProcessChange(ingest.Change{
@@ -320,14 +397,14 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateTrustLineAuthorization() 
 			LastModifiedLedgerSeq: lastModifiedLedgerSeq - 1,
 			Data: xdr.LedgerEntryData{
 				Type:      xdr.LedgerEntryTypeTrustline,
-				TrustLine: &trustLine,
+				TrustLine: &eurTrustLine,
 			},
 		},
 		Post: &xdr.LedgerEntry{
 			LastModifiedLedgerSeq: lastModifiedLedgerSeq,
 			Data: xdr.LedgerEntryData{
 				Type:      xdr.LedgerEntryTypeTrustline,
-				TrustLine: &updatedTrustLine,
+				TrustLine: &eurUpdatedTrustLine,
 			},
 		},
 	})
@@ -339,14 +416,33 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateTrustLineAuthorization() 
 			LastModifiedLedgerSeq: lastModifiedLedgerSeq - 1,
 			Data: xdr.LedgerEntryData{
 				Type:      xdr.LedgerEntryTypeTrustline,
-				TrustLine: &otherTrustLine,
+				TrustLine: &usdTrustLine,
 			},
 		},
 		Post: &xdr.LedgerEntry{
 			LastModifiedLedgerSeq: lastModifiedLedgerSeq,
 			Data: xdr.LedgerEntryData{
 				Type:      xdr.LedgerEntryTypeTrustline,
-				TrustLine: &otherUpdatedTrustLine,
+				TrustLine: &usdUpdatedTrustLine,
+			},
+		},
+	})
+	s.Assert().NoError(err)
+
+	err = s.processor.ProcessChange(ingest.Change{
+		Type: xdr.LedgerEntryTypeTrustline,
+		Pre: &xdr.LedgerEntry{
+			LastModifiedLedgerSeq: lastModifiedLedgerSeq - 1,
+			Data: xdr.LedgerEntryData{
+				Type:      xdr.LedgerEntryTypeTrustline,
+				TrustLine: &ethTrustLine,
+			},
+		},
+		Post: &xdr.LedgerEntry{
+			LastModifiedLedgerSeq: lastModifiedLedgerSeq,
+			Data: xdr.LedgerEntryData{
+				Type:      xdr.LedgerEntryTypeTrustline,
+				TrustLine: &ethUpdatedTrustLine,
 			},
 		},
 	})
@@ -356,11 +452,33 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateTrustLineAuthorization() 
 		xdr.AssetTypeAssetTypeCreditAlphanum4,
 		"EUR",
 		trustLineIssuer.Address(),
-	).Return(history.ExpAssetStat{}, sql.ErrNoRows).Once()
-	s.mockQ.On("InsertAssetStat", history.ExpAssetStat{
+	).Return(history.ExpAssetStat{
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "EUR",
+		Accounts: protocol.AssetStatAccounts{
+			Unauthorized: 1,
+		},
+		Balances: protocol.AssetStatBalances{
+			Authorized:                      "0",
+			AuthorizedToMaintainLiabilities: "0",
+			Unauthorized:                    "100",
+		},
+		Amount:      "0",
+		NumAccounts: 0,
+	}, nil).Once()
+	s.mockQ.On("UpdateAssetStat", history.ExpAssetStat{
+		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AssetIssuer: trustLineIssuer.Address(),
+		AssetCode:   "EUR",
+		Accounts: protocol.AssetStatAccounts{
+			Authorized: 1,
+		},
+		Balances: protocol.AssetStatBalances{
+			Authorized:                      "10",
+			AuthorizedToMaintainLiabilities: "0",
+			Unauthorized:                    "0",
+		},
 		Amount:      "10",
 		NumAccounts: 1,
 	}).Return(int64(1), nil).Once()
@@ -373,18 +491,78 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateTrustLineAuthorization() 
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "USD",
+		Accounts: protocol.AssetStatAccounts{
+			Authorized: 1,
+		},
+		Balances: protocol.AssetStatBalances{
+			Authorized:                      "100",
+			AuthorizedToMaintainLiabilities: "0",
+			Unauthorized:                    "0",
+		},
 		Amount:      "100",
 		NumAccounts: 1,
 	}, nil).Once()
-	s.mockQ.On("RemoveAssetStat",
+	s.mockQ.On("UpdateAssetStat", history.ExpAssetStat{
+		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AssetIssuer: trustLineIssuer.Address(),
+		AssetCode:   "USD",
+		Accounts: protocol.AssetStatAccounts{
+			Unauthorized: 1,
+		},
+		Balances: protocol.AssetStatBalances{
+			Authorized:                      "0",
+			AuthorizedToMaintainLiabilities: "0",
+			Unauthorized:                    "10",
+		},
+		Amount:      "0",
+		NumAccounts: 0,
+	}).Return(int64(1), nil).Once()
+
+	s.mockQ.On("GetAssetStat",
 		xdr.AssetTypeAssetTypeCreditAlphanum4,
-		"USD",
+		"ETH",
 		trustLineIssuer.Address(),
-	).Return(int64(1), nil).Once()
+	).Return(history.ExpAssetStat{
+		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AssetIssuer: trustLineIssuer.Address(),
+		AssetCode:   "ETH",
+		Accounts: protocol.AssetStatAccounts{
+			Authorized: 1,
+		},
+		Balances: protocol.AssetStatBalances{
+			Authorized:                      "100",
+			AuthorizedToMaintainLiabilities: "0",
+			Unauthorized:                    "0",
+		},
+		Amount:      "100",
+		NumAccounts: 1,
+	}, nil).Once()
+	s.mockQ.On("UpdateAssetStat", history.ExpAssetStat{
+		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AssetIssuer: trustLineIssuer.Address(),
+		AssetCode:   "ETH",
+		Accounts: protocol.AssetStatAccounts{
+			AuthorizedToMaintainLiabilities: 1,
+		},
+		Balances: protocol.AssetStatBalances{
+			Authorized:                      "0",
+			AuthorizedToMaintainLiabilities: "10",
+			Unauthorized:                    "0",
+		},
+		Amount:      "0",
+		NumAccounts: 0,
+	}).Return(int64(1), nil).Once()
+
 	s.Assert().NoError(s.processor.Commit())
 }
 
 func (s *AssetStatsProcessorTestSuiteLedger) TestRemoveTrustLine() {
+	authorizedTrustLine := xdr.TrustLineEntry{
+		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		Asset:     xdr.MustNewCreditAsset("EUR", trustLineIssuer.Address()),
+		Balance:   0,
+		Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag),
+	}
 	unauthorizedTrustLine := xdr.TrustLineEntry{
 		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
 		Asset:     xdr.MustNewCreditAsset("USD", trustLineIssuer.Address()),
@@ -395,13 +573,8 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestRemoveTrustLine() {
 		Type: xdr.LedgerEntryTypeTrustline,
 		Pre: &xdr.LedgerEntry{
 			Data: xdr.LedgerEntryData{
-				Type: xdr.LedgerEntryTypeTrustline,
-				TrustLine: &xdr.TrustLineEntry{
-					AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
-					Asset:     xdr.MustNewCreditAsset("EUR", trustLineIssuer.Address()),
-					Balance:   0,
-					Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag),
-				},
+				Type:      xdr.LedgerEntryTypeTrustline,
+				TrustLine: &authorizedTrustLine,
 			},
 		},
 		Post: nil,
@@ -428,6 +601,14 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestRemoveTrustLine() {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "EUR",
+		Accounts: protocol.AssetStatAccounts{
+			Authorized: 1,
+		},
+		Balances: protocol.AssetStatBalances{
+			Authorized:                      "0",
+			AuthorizedToMaintainLiabilities: "0",
+			Unauthorized:                    "0",
+		},
 		Amount:      "0",
 		NumAccounts: 1,
 	}, nil).Once()
@@ -436,6 +617,32 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestRemoveTrustLine() {
 		"EUR",
 		trustLineIssuer.Address(),
 	).Return(int64(1), nil).Once()
+
+	s.mockQ.On("GetAssetStat",
+		xdr.AssetTypeAssetTypeCreditAlphanum4,
+		"USD",
+		trustLineIssuer.Address(),
+	).Return(history.ExpAssetStat{
+		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AssetIssuer: trustLineIssuer.Address(),
+		AssetCode:   "USD",
+		Accounts: protocol.AssetStatAccounts{
+			Authorized: 1,
+		},
+		Balances: protocol.AssetStatBalances{
+			Authorized:                      "0",
+			AuthorizedToMaintainLiabilities: "0",
+			Unauthorized:                    "0",
+		},
+		Amount:      "0",
+		NumAccounts: 1,
+	}, nil).Once()
+	s.mockQ.On("RemoveAssetStat",
+		xdr.AssetTypeAssetTypeCreditAlphanum4,
+		"USD",
+		trustLineIssuer.Address(),
+	).Return(int64(1), nil).Once()
+
 	s.Assert().NoError(s.processor.Commit())
 }
 
@@ -496,6 +703,14 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestProcessUpgradeChange() {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetIssuer: trustLineIssuer.Address(),
 		AssetCode:   "EUR",
+		Accounts: protocol.AssetStatAccounts{
+			Authorized: 1,
+		},
+		Balances: protocol.AssetStatBalances{
+			Authorized:                      "10",
+			AuthorizedToMaintainLiabilities: "0",
+			Unauthorized:                    "0",
+		},
 		Amount:      "10",
 		NumAccounts: 1,
 	}).Return(int64(1), nil).Once()

--- a/services/horizon/internal/ingest/processors/asset_stats_set.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_set.go
@@ -56,12 +56,8 @@ func (a assetStatBalances) Add(b assetStatBalances) assetStatBalances {
 	}
 }
 
-func (a assetStatBalances) Sum() *big.Int {
-	sum := big.NewInt(0)
-	sum = sum.Add(sum, a.Authorized)
-	sum = sum.Add(sum, a.AuthorizedToMaintainLiabilities)
-	sum = sum.Add(sum, a.Unauthorized)
-	return sum
+func (a assetStatBalances) IsZero() bool {
+	return a.Authorized.Cmp(big.NewInt(0)) == 0 && a.AuthorizedToMaintainLiabilities.Cmp(big.NewInt(0)) == 0 && a.Unauthorized.Cmp(big.NewInt(0)) == 0
 }
 
 func (a assetStatBalances) Finish() history.ExpAssetStatBalances {
@@ -76,18 +72,6 @@ type assetStatAccounts struct {
 	Authorized                      int32
 	AuthorizedToMaintainLiabilities int32
 	Unauthorized                    int32
-}
-
-func (a assetStatAccounts) Add(b assetStatAccounts) assetStatAccounts {
-	return assetStatAccounts{
-		Authorized:                      a.Authorized + b.Authorized,
-		AuthorizedToMaintainLiabilities: a.AuthorizedToMaintainLiabilities + b.AuthorizedToMaintainLiabilities,
-		Unauthorized:                    a.Unauthorized + b.Unauthorized,
-	}
-}
-
-func (a assetStatAccounts) Sum() int32 {
-	return a.Authorized + a.AuthorizedToMaintainLiabilities + a.Unauthorized
 }
 
 func (value assetStatValue) Finish() history.ExpAssetStat {

--- a/services/horizon/internal/ingest/processors/asset_stats_set.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_set.go
@@ -60,7 +60,7 @@ func (a assetStatBalances) IsZero() bool {
 	return a.Authorized.Cmp(big.NewInt(0)) == 0 && a.AuthorizedToMaintainLiabilities.Cmp(big.NewInt(0)) == 0 && a.Unauthorized.Cmp(big.NewInt(0)) == 0
 }
 
-func (a assetStatBalances) Finish() history.ExpAssetStatBalances {
+func (a assetStatBalances) ConvertToHistoryObject() history.ExpAssetStatBalances {
 	return history.ExpAssetStatBalances{
 		Authorized:                      a.Authorized.String(),
 		AuthorizedToMaintainLiabilities: a.AuthorizedToMaintainLiabilities.String(),
@@ -74,8 +74,8 @@ type assetStatAccounts struct {
 	Unauthorized                    int32
 }
 
-func (value assetStatValue) Finish() history.ExpAssetStat {
-	balances := value.balances.Finish()
+func (value assetStatValue) ConvertToHistoryObject() history.ExpAssetStat {
+	balances := value.balances.ConvertToHistoryObject()
 	return history.ExpAssetStat{
 		AssetType:   value.assetType,
 		AssetCode:   value.assetCode,
@@ -184,14 +184,14 @@ func (s AssetStatSet) Remove(assetType xdr.AssetType, assetCode string, assetIss
 
 	delete(s, key)
 
-	return value.Finish(), true
+	return value.ConvertToHistoryObject(), true
 }
 
 // All returns a list of all `history.ExpAssetStat` contained within the set
 func (s AssetStatSet) All() []history.ExpAssetStat {
 	assetStats := make([]history.ExpAssetStat, 0, len(s))
 	for _, value := range s {
-		assetStats = append(assetStats, value.Finish())
+		assetStats = append(assetStats, value.ConvertToHistoryObject())
 	}
 	return assetStats
 }

--- a/services/horizon/internal/ingest/processors/asset_stats_set.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_set.go
@@ -3,7 +3,6 @@ package processors
 import (
 	"math/big"
 
-	protocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
@@ -18,15 +17,16 @@ type assetStatKey struct {
 type assetStatValue struct {
 	assetStatKey
 	balances assetStatBalances
-	accounts assetStatNumAccounts
+	accounts assetStatAccounts
 }
+
 type assetStatBalances struct {
 	Authorized                      *big.Int
 	AuthorizedToMaintainLiabilities *big.Int
 	Unauthorized                    *big.Int
 }
 
-func (a *assetStatBalances) Parse(b *protocol.AssetStatBalances) error {
+func (a *assetStatBalances) Parse(b *history.ExpAssetStatBalances) error {
 	authorized, ok := new(big.Int).SetString(b.Authorized, 10)
 	if !ok {
 		return errors.New("Error parsing: " + b.Authorized)
@@ -64,18 +64,30 @@ func (a assetStatBalances) Sum() *big.Int {
 	return sum
 }
 
-func (a assetStatBalances) Finish() protocol.AssetStatBalances {
-	return protocol.AssetStatBalances{
+func (a assetStatBalances) Finish() history.ExpAssetStatBalances {
+	return history.ExpAssetStatBalances{
 		Authorized:                      a.Authorized.String(),
 		AuthorizedToMaintainLiabilities: a.AuthorizedToMaintainLiabilities.String(),
 		Unauthorized:                    a.Unauthorized.String(),
 	}
 }
 
-type assetStatNumAccounts struct {
+type assetStatAccounts struct {
 	Authorized                      int32
 	AuthorizedToMaintainLiabilities int32
 	Unauthorized                    int32
+}
+
+func (a assetStatAccounts) Add(b assetStatAccounts) assetStatAccounts {
+	return assetStatAccounts{
+		Authorized:                      a.Authorized + b.Authorized,
+		AuthorizedToMaintainLiabilities: a.AuthorizedToMaintainLiabilities + b.AuthorizedToMaintainLiabilities,
+		Unauthorized:                    a.Unauthorized + b.Unauthorized,
+	}
+}
+
+func (a assetStatAccounts) Sum() int32 {
+	return a.Authorized + a.AuthorizedToMaintainLiabilities + a.Unauthorized
 }
 
 func (value assetStatValue) Finish() history.ExpAssetStat {
@@ -84,7 +96,7 @@ func (value assetStatValue) Finish() history.ExpAssetStat {
 		AssetType:   value.assetType,
 		AssetCode:   value.assetCode,
 		AssetIssuer: value.assetIssuer,
-		Accounts:    protocol.AssetStatAccounts(value.accounts),
+		Accounts:    history.ExpAssetStatAccounts(value.accounts),
 		Balances:    balances,
 		Amount:      balances.Authorized,
 		NumAccounts: value.accounts.Authorized,

--- a/services/horizon/internal/ingest/processors/asset_stats_set.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_set.go
@@ -14,8 +14,9 @@ type assetStatKey struct {
 	assetIssuer string
 }
 type assetStatValue struct {
-	amount      *big.Int
-	numAccounts int32
+	amount         *big.Int
+	numAccounts    int32
+	trustLineFlags xdr.TrustLineFlags
 }
 
 // AssetStatSet represents a collection of asset stats
@@ -24,15 +25,11 @@ type AssetStatSet map[assetStatKey]*assetStatValue
 // Add updates the set with a trustline entry from a history archive snapshot
 // if the trustline is authorized.
 func (s AssetStatSet) Add(trustLine xdr.TrustLineEntry) error {
-	if !xdr.TrustLineFlags(trustLine.Flags).IsAuthorized() {
-		return nil
-	}
-
-	return s.AddDelta(trustLine.Asset, int64(trustLine.Balance), 1)
+	return s.AddDelta(trustLine.Asset, int64(trustLine.Balance), 1, xdr.TrustLineFlags(trustLine.Flags))
 }
 
 // AddDelta adds a delta balance and delta accounts to a given asset.
-func (s AssetStatSet) AddDelta(asset xdr.Asset, deltaBalance int64, deltaAccounts int32) error {
+func (s AssetStatSet) AddDelta(asset xdr.Asset, deltaBalance int64, deltaAccounts int32, deltaTrustLineFlags xdr.TrustLineFlags) error {
 	if deltaBalance == 0 && deltaAccounts == 0 {
 		return nil
 	}
@@ -45,8 +42,9 @@ func (s AssetStatSet) AddDelta(asset xdr.Asset, deltaBalance int64, deltaAccount
 	current, ok := s[key]
 	if !ok {
 		s[key] = &assetStatValue{
-			amount:      big.NewInt(int64(deltaBalance)),
-			numAccounts: deltaAccounts,
+			amount:         big.NewInt(int64(deltaBalance)),
+			numAccounts:    deltaAccounts,
+			trustLineFlags: deltaTrustLineFlags,
 		}
 	} else {
 		current.amount.Add(current.amount, big.NewInt(int64(deltaBalance)))
@@ -74,11 +72,12 @@ func (s AssetStatSet) Remove(assetType xdr.AssetType, assetCode string, assetIss
 	delete(s, key)
 
 	return history.ExpAssetStat{
-		AssetType:   key.assetType,
-		AssetCode:   key.assetCode,
-		AssetIssuer: key.assetIssuer,
-		Amount:      value.amount.String(),
-		NumAccounts: value.numAccounts,
+		AssetType:      key.assetType,
+		AssetCode:      key.assetCode,
+		AssetIssuer:    key.assetIssuer,
+		Amount:         value.amount.String(),
+		NumAccounts:    value.numAccounts,
+		TrustLineFlags: value.trustLineFlags,
 	}, true
 }
 
@@ -87,11 +86,12 @@ func (s AssetStatSet) All() []history.ExpAssetStat {
 	assetStats := make([]history.ExpAssetStat, 0, len(s))
 	for key, value := range s {
 		assetStats = append(assetStats, history.ExpAssetStat{
-			AssetType:   key.assetType,
-			AssetCode:   key.assetCode,
-			AssetIssuer: key.assetIssuer,
-			Amount:      value.amount.String(),
-			NumAccounts: value.numAccounts,
+			AssetType:      key.assetType,
+			AssetCode:      key.assetCode,
+			AssetIssuer:    key.assetIssuer,
+			Amount:         value.amount.String(),
+			NumAccounts:    value.numAccounts,
+			TrustLineFlags: value.trustLineFlags,
 		})
 	}
 	return assetStats

--- a/services/horizon/internal/ingest/processors/asset_stats_set.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_set.go
@@ -3,6 +3,7 @@ package processors
 import (
 	"math/big"
 
+	protocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
@@ -13,10 +14,38 @@ type assetStatKey struct {
 	assetCode   string
 	assetIssuer string
 }
+
 type assetStatValue struct {
-	amount         *big.Int
-	numAccounts    int32
-	trustLineFlags xdr.TrustLineFlags
+	assetStatKey
+	balances assetStatBalances
+	accounts assetStatNumAccounts
+}
+type assetStatBalances struct {
+	Authorized                      *big.Int
+	AuthorizedToMaintainLiabilities *big.Int
+	Unauthorized                    *big.Int
+}
+type assetStatNumAccounts struct {
+	Authorized                      int32
+	AuthorizedToMaintainLiabilities int32
+	Unauthorized                    int32
+}
+
+func (value assetStatValue) Finish() history.ExpAssetStat {
+	balances := protocol.AssetStatBalances{
+		Authorized:                      value.balances.Authorized.String(),
+		AuthorizedToMaintainLiabilities: value.balances.AuthorizedToMaintainLiabilities.String(),
+		Unauthorized:                    value.balances.Unauthorized.String(),
+	}
+	return history.ExpAssetStat{
+		AssetType:   value.assetType,
+		AssetCode:   value.assetCode,
+		AssetIssuer: value.assetIssuer,
+		Accounts:    protocol.AssetStatNumAccounts(value.accounts),
+		Balances:    balances,
+		Amount:      balances.Authorized,
+		NumAccounts: value.accounts.Authorized,
+	}
 }
 
 // AssetStatSet represents a collection of asset stats
@@ -28,8 +57,8 @@ func (s AssetStatSet) Add(trustLine xdr.TrustLineEntry) error {
 	return s.AddDelta(trustLine.Asset, int64(trustLine.Balance), 1, xdr.TrustLineFlags(trustLine.Flags))
 }
 
-// AddDelta adds a delta balance and delta accounts to a given asset.
-func (s AssetStatSet) AddDelta(asset xdr.Asset, deltaBalance int64, deltaAccounts int32, deltaTrustLineFlags xdr.TrustLineFlags) error {
+// AddDelta adds a delta balance and delta accounts to a given asset trustline.
+func (s AssetStatSet) AddDelta(asset xdr.Asset, deltaBalance int64, deltaAccounts int32, flags xdr.TrustLineFlags) error {
 	if deltaBalance == 0 && deltaAccounts == 0 {
 		return nil
 	}
@@ -41,21 +70,33 @@ func (s AssetStatSet) AddDelta(asset xdr.Asset, deltaBalance int64, deltaAccount
 
 	current, ok := s[key]
 	if !ok {
-		s[key] = &assetStatValue{
-			amount:         big.NewInt(int64(deltaBalance)),
-			numAccounts:    deltaAccounts,
-			trustLineFlags: deltaTrustLineFlags,
-		}
+		current = &assetStatValue{assetStatKey: key}
+		s[key] = current
+	}
+
+	// TODO: Do we need to handle clawback authorized here?
+	if flags.IsAuthorized() {
+		current.balances.Authorized.Add(current.balances.Authorized, big.NewInt(int64(deltaBalance)))
+		current.accounts.Authorized += deltaAccounts
+	} else if flags.IsAuthorizedToMaintainLiabilitiesFlag() {
+		current.balances.AuthorizedToMaintainLiabilities.Add(current.balances.AuthorizedToMaintainLiabilities, big.NewInt(int64(deltaBalance)))
+		current.accounts.AuthorizedToMaintainLiabilities += deltaAccounts
 	} else {
-		current.amount.Add(current.amount, big.NewInt(int64(deltaBalance)))
-		current.numAccounts += deltaAccounts
-		// Note: it's possible that after operations above:
-		// numAccounts != 0 && amount == 0 (ex. two accounts send some of their assets to third account)
-		//  OR
-		// numAccounts == 0 && amount != 0 (ex. issuer issued an asset)
-		if current.numAccounts == 0 && current.amount.Cmp(big.NewInt(0)) == 0 {
-			delete(s, key)
-		}
+		current.balances.Unauthorized.Add(current.balances.Unauthorized, big.NewInt(int64(deltaBalance)))
+		current.accounts.Unauthorized += deltaAccounts
+	}
+
+	// Note: it's possible that after operations above:
+	// numAccounts != 0 && amount == 0 (ex. two accounts send some of their assets to third account)
+	//  OR
+	// numAccounts == 0 && amount != 0 (ex. issuer issued an asset)
+	if current.balances.Authorized.Cmp(big.NewInt(0)) == 0 &&
+		current.balances.AuthorizedToMaintainLiabilities.Cmp(big.NewInt(0)) == 0 &&
+		current.balances.Unauthorized.Cmp(big.NewInt(0)) == 0 &&
+		current.accounts.Authorized == 0 &&
+		current.accounts.AuthorizedToMaintainLiabilities == 0 &&
+		current.accounts.Unauthorized == 0 {
+		delete(s, key)
 	}
 
 	return nil
@@ -71,28 +112,14 @@ func (s AssetStatSet) Remove(assetType xdr.AssetType, assetCode string, assetIss
 
 	delete(s, key)
 
-	return history.ExpAssetStat{
-		AssetType:      key.assetType,
-		AssetCode:      key.assetCode,
-		AssetIssuer:    key.assetIssuer,
-		Amount:         value.amount.String(),
-		NumAccounts:    value.numAccounts,
-		TrustLineFlags: value.trustLineFlags,
-	}, true
+	return value.Finish(), true
 }
 
 // All returns a list of all `history.ExpAssetStat` contained within the set
 func (s AssetStatSet) All() []history.ExpAssetStat {
 	assetStats := make([]history.ExpAssetStat, 0, len(s))
-	for key, value := range s {
-		assetStats = append(assetStats, history.ExpAssetStat{
-			AssetType:      key.assetType,
-			AssetCode:      key.assetCode,
-			AssetIssuer:    key.assetIssuer,
-			Amount:         value.amount.String(),
-			NumAccounts:    value.numAccounts,
-			TrustLineFlags: value.trustLineFlags,
-		})
+	for _, value := range s {
+		assetStats = append(assetStats, value.Finish())
 	}
 	return assetStats
 }

--- a/services/horizon/internal/ingest/processors/asset_stats_set.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_set.go
@@ -41,7 +41,7 @@ func (value assetStatValue) Finish() history.ExpAssetStat {
 		AssetType:   value.assetType,
 		AssetCode:   value.assetCode,
 		AssetIssuer: value.assetIssuer,
-		Accounts:    protocol.AssetStatNumAccounts(value.accounts),
+		Accounts:    protocol.AssetStatAccounts(value.accounts),
 		Balances:    balances,
 		Amount:      balances.Authorized,
 		NumAccounts: value.accounts.Authorized,

--- a/services/horizon/internal/ingest/processors/asset_stats_set.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_set.go
@@ -25,6 +25,53 @@ type assetStatBalances struct {
 	AuthorizedToMaintainLiabilities *big.Int
 	Unauthorized                    *big.Int
 }
+
+func (a *assetStatBalances) Parse(b *protocol.AssetStatBalances) error {
+	authorized, ok := new(big.Int).SetString(b.Authorized, 10)
+	if !ok {
+		return errors.New("Error parsing: " + b.Authorized)
+	}
+	a.Authorized = authorized
+
+	authorizedToMaintainLiabilities, ok := new(big.Int).SetString(b.AuthorizedToMaintainLiabilities, 10)
+	if !ok {
+		return errors.New("Error parsing: " + b.AuthorizedToMaintainLiabilities)
+	}
+	a.AuthorizedToMaintainLiabilities = authorizedToMaintainLiabilities
+
+	unauthorized, ok := new(big.Int).SetString(b.Unauthorized, 10)
+	if !ok {
+		return errors.New("Error parsing: " + b.Unauthorized)
+	}
+	a.Unauthorized = unauthorized
+
+	return nil
+}
+
+func (a assetStatBalances) Add(b assetStatBalances) assetStatBalances {
+	return assetStatBalances{
+		Authorized:                      big.NewInt(0).Add(a.Authorized, b.Authorized),
+		AuthorizedToMaintainLiabilities: big.NewInt(0).Add(a.AuthorizedToMaintainLiabilities, b.AuthorizedToMaintainLiabilities),
+		Unauthorized:                    big.NewInt(0).Add(a.Unauthorized, b.Unauthorized),
+	}
+}
+
+func (a assetStatBalances) Sum() *big.Int {
+	sum := big.NewInt(0)
+	sum = sum.Add(sum, a.Authorized)
+	sum = sum.Add(sum, a.AuthorizedToMaintainLiabilities)
+	sum = sum.Add(sum, a.Unauthorized)
+	return sum
+}
+
+func (a assetStatBalances) Finish() protocol.AssetStatBalances {
+	return protocol.AssetStatBalances{
+		Authorized:                      a.Authorized.String(),
+		AuthorizedToMaintainLiabilities: a.AuthorizedToMaintainLiabilities.String(),
+		Unauthorized:                    a.Unauthorized.String(),
+	}
+}
+
 type assetStatNumAccounts struct {
 	Authorized                      int32
 	AuthorizedToMaintainLiabilities int32
@@ -32,11 +79,7 @@ type assetStatNumAccounts struct {
 }
 
 func (value assetStatValue) Finish() history.ExpAssetStat {
-	balances := protocol.AssetStatBalances{
-		Authorized:                      value.balances.Authorized.String(),
-		AuthorizedToMaintainLiabilities: value.balances.AuthorizedToMaintainLiabilities.String(),
-		Unauthorized:                    value.balances.Unauthorized.String(),
-	}
+	balances := value.balances.Finish()
 	return history.ExpAssetStat{
 		AssetType:   value.assetType,
 		AssetCode:   value.assetCode,
@@ -54,12 +97,31 @@ type AssetStatSet map[assetStatKey]*assetStatValue
 // Add updates the set with a trustline entry from a history archive snapshot
 // if the trustline is authorized.
 func (s AssetStatSet) Add(trustLine xdr.TrustLineEntry) error {
-	return s.AddDelta(trustLine.Asset, int64(trustLine.Balance), 1, xdr.TrustLineFlags(trustLine.Flags))
+	flags := trustLine.Flags
+	return s.AddDelta(
+		trustLine.Asset,
+		map[xdr.Uint32]int64{flags: int64(trustLine.Balance)},
+		map[xdr.Uint32]int32{flags: 1},
+	)
 }
 
 // AddDelta adds a delta balance and delta accounts to a given asset trustline.
-func (s AssetStatSet) AddDelta(asset xdr.Asset, deltaBalance int64, deltaAccounts int32, flags xdr.TrustLineFlags) error {
-	if deltaBalance == 0 && deltaAccounts == 0 {
+func (s AssetStatSet) AddDelta(asset xdr.Asset, deltaBalances map[xdr.Uint32]int64, deltaAccounts map[xdr.Uint32]int32) error {
+	accountsEmpty := true
+	for _, v := range deltaAccounts {
+		if v != 0 {
+			accountsEmpty = false
+			break
+		}
+	}
+	balancesEmpty := true
+	for _, v := range deltaBalances {
+		if v != 0 {
+			balancesEmpty = false
+			break
+		}
+	}
+	if accountsEmpty && balancesEmpty {
 		return nil
 	}
 
@@ -70,20 +132,37 @@ func (s AssetStatSet) AddDelta(asset xdr.Asset, deltaBalance int64, deltaAccount
 
 	current, ok := s[key]
 	if !ok {
-		current = &assetStatValue{assetStatKey: key}
+		current = &assetStatValue{assetStatKey: key, balances: assetStatBalances{
+			Authorized:                      big.NewInt(0),
+			AuthorizedToMaintainLiabilities: big.NewInt(0),
+			Unauthorized:                    big.NewInt(0),
+		}}
 		s[key] = current
 	}
 
 	// TODO: Do we need to handle clawback authorized here?
-	if flags.IsAuthorized() {
-		current.balances.Authorized.Add(current.balances.Authorized, big.NewInt(int64(deltaBalance)))
-		current.accounts.Authorized += deltaAccounts
-	} else if flags.IsAuthorizedToMaintainLiabilitiesFlag() {
-		current.balances.AuthorizedToMaintainLiabilities.Add(current.balances.AuthorizedToMaintainLiabilities, big.NewInt(int64(deltaBalance)))
-		current.accounts.AuthorizedToMaintainLiabilities += deltaAccounts
-	} else {
-		current.balances.Unauthorized.Add(current.balances.Unauthorized, big.NewInt(int64(deltaBalance)))
-		current.accounts.Unauthorized += deltaAccounts
+	for k, v := range deltaAccounts {
+		flags := xdr.TrustLineFlags(k)
+		if flags.IsAuthorized() {
+			current.accounts.Authorized += v
+		} else if flags.IsAuthorizedToMaintainLiabilitiesFlag() {
+			current.accounts.AuthorizedToMaintainLiabilities += v
+		} else {
+			current.accounts.Unauthorized += v
+		}
+	}
+
+	// TODO: Do we need to handle clawback authorized here?
+	for k, v := range deltaBalances {
+		flags := xdr.TrustLineFlags(k)
+		bigV := big.NewInt(v)
+		if flags.IsAuthorized() {
+			current.balances.Authorized.Add(current.balances.Authorized, bigV)
+		} else if flags.IsAuthorizedToMaintainLiabilitiesFlag() {
+			current.balances.AuthorizedToMaintainLiabilities.Add(current.balances.AuthorizedToMaintainLiabilities, bigV)
+		} else {
+			current.balances.Unauthorized.Add(current.balances.Unauthorized, bigV)
+		}
 	}
 
 	// Note: it's possible that after operations above:

--- a/services/horizon/internal/ingest/processors/asset_stats_set.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_set.go
@@ -17,7 +17,7 @@ type assetStatKey struct {
 type assetStatValue struct {
 	assetStatKey
 	balances assetStatBalances
-	accounts assetStatAccounts
+	accounts history.ExpAssetStatAccounts
 }
 
 type assetStatBalances struct {
@@ -68,19 +68,13 @@ func (a assetStatBalances) ConvertToHistoryObject() history.ExpAssetStatBalances
 	}
 }
 
-type assetStatAccounts struct {
-	Authorized                      int32
-	AuthorizedToMaintainLiabilities int32
-	Unauthorized                    int32
-}
-
 func (value assetStatValue) ConvertToHistoryObject() history.ExpAssetStat {
 	balances := value.balances.ConvertToHistoryObject()
 	return history.ExpAssetStat{
 		AssetType:   value.assetType,
 		AssetCode:   value.assetCode,
 		AssetIssuer: value.assetIssuer,
-		Accounts:    history.ExpAssetStatAccounts(value.accounts),
+		Accounts:    value.accounts,
 		Balances:    balances,
 		Amount:      balances.Authorized,
 		NumAccounts: value.accounts.Authorized,

--- a/services/horizon/internal/ingest/processors/asset_stats_set.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_set.go
@@ -90,8 +90,7 @@ func (value assetStatValue) Finish() history.ExpAssetStat {
 // AssetStatSet represents a collection of asset stats
 type AssetStatSet map[assetStatKey]*assetStatValue
 
-// Add updates the set with a trustline entry from a history archive snapshot
-// if the trustline is authorized.
+// Add updates the set with a trustline entry from a history archive snapshot.
 func (s AssetStatSet) Add(trustLine xdr.TrustLineEntry) error {
 	flags := trustLine.Flags
 	return s.AddDelta(

--- a/services/horizon/internal/ingest/processors/asset_stats_set.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_set.go
@@ -136,7 +136,6 @@ func (s AssetStatSet) AddDelta(asset xdr.Asset, deltaBalances map[xdr.Uint32]int
 		s[key] = current
 	}
 
-	// TODO: Do we need to handle clawback authorized here?
 	for k, v := range deltaAccounts {
 		flags := xdr.TrustLineFlags(k)
 		if flags.IsAuthorized() {
@@ -148,7 +147,6 @@ func (s AssetStatSet) AddDelta(asset xdr.Asset, deltaBalances map[xdr.Uint32]int
 		}
 	}
 
-	// TODO: Do we need to handle clawback authorized here?
 	for k, v := range deltaBalances {
 		flags := xdr.TrustLineFlags(k)
 		bigV := big.NewInt(v)

--- a/services/horizon/internal/ingest/processors/asset_stats_set_test.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_set_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"testing"
 
+	protocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/xdr"
 )
@@ -40,21 +41,6 @@ func assertAllEquals(t *testing.T, set AssetStatSet, expected []history.ExpAsset
 	}
 }
 
-func TestAssetStatSetIgnoresUnauthorizedTrustlines(t *testing.T) {
-	set := AssetStatSet{}
-	err := set.Add(xdr.TrustLineEntry{
-		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
-		Asset:     xdr.MustNewCreditAsset("EUR", trustLineIssuer.Address()),
-		Balance:   1,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-	if all := set.All(); len(all) != 0 {
-		t.Fatalf("expected empty list but got %v", all)
-	}
-}
-
 func TestAddAndRemoveAssetStats(t *testing.T) {
 	set := AssetStatSet{}
 	eur := "EUR"
@@ -62,6 +48,14 @@ func TestAddAndRemoveAssetStats(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetCode:   eur,
 		AssetIssuer: trustLineIssuer.Address(),
+		Accounts: protocol.AssetStatAccounts{
+			Authorized: 1,
+		},
+		Balances: protocol.AssetStatBalances{
+			Authorized:                      "1",
+			AuthorizedToMaintainLiabilities: "0",
+			Unauthorized:                    "0",
+		},
 		Amount:      "1",
 		NumAccounts: 1,
 	}
@@ -87,7 +81,9 @@ func TestAddAndRemoveAssetStats(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 
+	eurAssetStat.Balances.Authorized = "25"
 	eurAssetStat.Amount = "25"
+	eurAssetStat.Accounts.Authorized++
 	eurAssetStat.NumAccounts++
 	assertAllEquals(t, set, []history.ExpAssetStat{eurAssetStat})
 
@@ -113,19 +109,58 @@ func TestAddAndRemoveAssetStats(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 
+	// Add an authorized_to_maintain_liabilities trust line
+	err = set.Add(xdr.TrustLineEntry{
+		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		Asset:     xdr.MustNewCreditAsset(ether, trustLineIssuer.Address()),
+		Balance:   4,
+		Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedToMaintainLiabilitiesFlag),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	// Add an unauthorized trust line
+	err = set.Add(xdr.TrustLineEntry{
+		AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		Asset:     xdr.MustNewCreditAsset(ether, trustLineIssuer.Address()),
+		Balance:   5,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
 	expected := []history.ExpAssetStat{
-		history.ExpAssetStat{
+		{
 			AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum12,
 			AssetCode:   ether,
 			AssetIssuer: trustLineIssuer.Address(),
+			Accounts: protocol.AssetStatAccounts{
+				Authorized:                      1,
+				AuthorizedToMaintainLiabilities: 1,
+				Unauthorized:                    1,
+			},
+			Balances: protocol.AssetStatBalances{
+				Authorized:                      "3",
+				AuthorizedToMaintainLiabilities: "4",
+				Unauthorized:                    "5",
+			},
 			Amount:      "3",
 			NumAccounts: 1,
 		},
 		eurAssetStat,
-		history.ExpAssetStat{
+		{
 			AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 			AssetCode:   usd,
 			AssetIssuer: trustLineIssuer.Address(),
+			Accounts: protocol.AssetStatAccounts{
+				Authorized: 1,
+			},
+			Balances: protocol.AssetStatBalances{
+				Authorized:                      "10",
+				AuthorizedToMaintainLiabilities: "0",
+				Unauthorized:                    "0",
+			},
 			Amount:      "10",
 			NumAccounts: 1,
 		},
@@ -166,6 +201,14 @@ func TestOverflowAssetStatSet(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetCode:   eur,
 		AssetIssuer: trustLineIssuer.Address(),
+		Accounts: protocol.AssetStatAccounts{
+			Authorized: 1,
+		},
+		Balances: protocol.AssetStatBalances{
+			Authorized:                      "9223372036854775807",
+			AuthorizedToMaintainLiabilities: "0",
+			Unauthorized:                    "0",
+		},
 		Amount:      "9223372036854775807",
 		NumAccounts: 1,
 	}
@@ -191,6 +234,14 @@ func TestOverflowAssetStatSet(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetCode:   eur,
 		AssetIssuer: trustLineIssuer.Address(),
+		Accounts: protocol.AssetStatAccounts{
+			Authorized: 2,
+		},
+		Balances: protocol.AssetStatBalances{
+			Authorized:                      "18446744073709551614",
+			AuthorizedToMaintainLiabilities: "0",
+			Unauthorized:                    "0",
+		},
 		Amount:      "18446744073709551614",
 		NumAccounts: 2,
 	}

--- a/services/horizon/internal/ingest/processors/asset_stats_set_test.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_set_test.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"testing"
 
-	protocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/xdr"
 )
@@ -48,10 +47,10 @@ func TestAddAndRemoveAssetStats(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetCode:   eur,
 		AssetIssuer: trustLineIssuer.Address(),
-		Accounts: protocol.AssetStatAccounts{
+		Accounts: history.ExpAssetStatAccounts{
 			Authorized: 1,
 		},
-		Balances: protocol.AssetStatBalances{
+		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "1",
 			AuthorizedToMaintainLiabilities: "0",
 			Unauthorized:                    "0",
@@ -135,12 +134,12 @@ func TestAddAndRemoveAssetStats(t *testing.T) {
 			AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum12,
 			AssetCode:   ether,
 			AssetIssuer: trustLineIssuer.Address(),
-			Accounts: protocol.AssetStatAccounts{
+			Accounts: history.ExpAssetStatAccounts{
 				Authorized:                      1,
 				AuthorizedToMaintainLiabilities: 1,
 				Unauthorized:                    1,
 			},
-			Balances: protocol.AssetStatBalances{
+			Balances: history.ExpAssetStatBalances{
 				Authorized:                      "3",
 				AuthorizedToMaintainLiabilities: "4",
 				Unauthorized:                    "5",
@@ -153,10 +152,10 @@ func TestAddAndRemoveAssetStats(t *testing.T) {
 			AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 			AssetCode:   usd,
 			AssetIssuer: trustLineIssuer.Address(),
-			Accounts: protocol.AssetStatAccounts{
+			Accounts: history.ExpAssetStatAccounts{
 				Authorized: 1,
 			},
-			Balances: protocol.AssetStatBalances{
+			Balances: history.ExpAssetStatBalances{
 				Authorized:                      "10",
 				AuthorizedToMaintainLiabilities: "0",
 				Unauthorized:                    "0",
@@ -201,10 +200,10 @@ func TestOverflowAssetStatSet(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetCode:   eur,
 		AssetIssuer: trustLineIssuer.Address(),
-		Accounts: protocol.AssetStatAccounts{
+		Accounts: history.ExpAssetStatAccounts{
 			Authorized: 1,
 		},
-		Balances: protocol.AssetStatBalances{
+		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "9223372036854775807",
 			AuthorizedToMaintainLiabilities: "0",
 			Unauthorized:                    "0",
@@ -234,10 +233,10 @@ func TestOverflowAssetStatSet(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetCode:   eur,
 		AssetIssuer: trustLineIssuer.Address(),
-		Accounts: protocol.AssetStatAccounts{
+		Accounts: history.ExpAssetStatAccounts{
 			Authorized: 2,
 		},
-		Balances: protocol.AssetStatBalances{
+		Balances: history.ExpAssetStatBalances{
 			Authorized:                      "18446744073709551614",
 			AuthorizedToMaintainLiabilities: "0",
 			Unauthorized:                    "0",

--- a/services/horizon/internal/ingest/verify.go
+++ b/services/horizon/internal/ingest/verify.go
@@ -27,7 +27,7 @@ const assetStatsBatchSize = 500
 // check them.
 // There is a test that checks it, to fix it: update the actual `verifyState`
 // method instead of just updating this value!
-const stateVerifierExpectedIngestionVersion = 12
+const stateVerifierExpectedIngestionVersion = 13
 
 // verifyState is called as a go routine from pipeline post hook every 64
 // ledgers. It checks if the state is correct. If another go routine is already

--- a/services/horizon/internal/resourceadapter/asset_stat.go
+++ b/services/horizon/internal/resourceadapter/asset_stat.go
@@ -28,7 +28,10 @@ func PopulateAssetStat(
 	if err != nil {
 		return errors.Wrap(err, "Invalid amount in PopulateAssetStat")
 	}
-	res.Balances = protocol.AssetStatBalances(row.Balances)
+	err = populateAssetStatBalances(&res.Balances, row.Balances)
+	if err != nil {
+		return err
+	}
 	res.NumAccounts = row.NumAccounts
 	flags := int8(issuer.Flags)
 	res.Flags = protocol.AccountFlags{
@@ -46,4 +49,23 @@ func PopulateAssetStat(
 	}
 	res.Links.Toml = hal.NewLink(toml)
 	return
+}
+
+func populateAssetStatBalances(res *protocol.AssetStatBalances, row history.ExpAssetStatBalances) (err error) {
+	res.Authorized, err = amount.IntStringToAmount(row.Authorized)
+	if err != nil {
+		return errors.Wrapf(err, "Invalid amount in PopulateAssetStatBalances: %q", row.Authorized)
+	}
+
+	res.AuthorizedToMaintainLiabilities, err = amount.IntStringToAmount(row.AuthorizedToMaintainLiabilities)
+	if err != nil {
+		return errors.Wrapf(err, "Invalid amount in PopulateAssetStatBalances: %q", row.AuthorizedToMaintainLiabilities)
+	}
+
+	res.Unauthorized, err = amount.IntStringToAmount(row.Unauthorized)
+	if err != nil {
+		return errors.Wrapf(err, "Invalid amount in PopulateAssetStatBalances: %q", row.Unauthorized)
+	}
+
+	return nil
 }

--- a/services/horizon/internal/resourceadapter/asset_stat.go
+++ b/services/horizon/internal/resourceadapter/asset_stat.go
@@ -23,10 +23,12 @@ func PopulateAssetStat(
 	res.Asset.Type = xdr.AssetTypeToString[row.AssetType]
 	res.Asset.Code = row.AssetCode
 	res.Asset.Issuer = row.AssetIssuer
+	res.Accounts = protocol.AssetStatNumAccounts(row.Accounts)
 	res.Amount, err = amount.IntStringToAmount(row.Amount)
 	if err != nil {
 		return errors.Wrap(err, "Invalid amount in PopulateAssetStat")
 	}
+	res.Balances = protocol.AssetStatBalances(row.Balances)
 	res.NumAccounts = row.NumAccounts
 	flags := int8(issuer.Flags)
 	res.Flags = protocol.AccountFlags{

--- a/services/horizon/internal/resourceadapter/asset_stat.go
+++ b/services/horizon/internal/resourceadapter/asset_stat.go
@@ -23,7 +23,7 @@ func PopulateAssetStat(
 	res.Asset.Type = xdr.AssetTypeToString[row.AssetType]
 	res.Asset.Code = row.AssetCode
 	res.Asset.Issuer = row.AssetIssuer
-	res.Accounts = protocol.AssetStatNumAccounts(row.Accounts)
+	res.Accounts = protocol.AssetStatAccounts(row.Accounts)
 	res.Amount, err = amount.IntStringToAmount(row.Amount)
 	if err != nil {
 		return errors.Wrap(err, "Invalid amount in PopulateAssetStat")

--- a/services/horizon/internal/resourceadapter/asset_stat_test.go
+++ b/services/horizon/internal/resourceadapter/asset_stat_test.go
@@ -16,6 +16,16 @@ func TestPopulateExpAssetStat(t *testing.T) {
 		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AssetCode:   "XIM",
 		AssetIssuer: "GBZ35ZJRIKJGYH5PBKLKOZ5L6EXCNTO7BKIL7DAVVDFQ2ODJEEHHJXIM",
+		Accounts: history.ExpAssetStatAccounts{
+			Authorized:                      429,
+			AuthorizedToMaintainLiabilities: 214,
+			Unauthorized:                    107,
+		},
+		Balances: history.ExpAssetStatBalances{
+			Authorized:                      "100000000000000000000",
+			AuthorizedToMaintainLiabilities: "50000000000000000000",
+			Unauthorized:                    "2500000000000000000",
+		},
 		Amount:      "100000000000000000000", // 10T
 		NumAccounts: 429,
 	}
@@ -32,6 +42,12 @@ func TestPopulateExpAssetStat(t *testing.T) {
 	assert.Equal(t, "credit_alphanum4", res.Type)
 	assert.Equal(t, "XIM", res.Code)
 	assert.Equal(t, "GBZ35ZJRIKJGYH5PBKLKOZ5L6EXCNTO7BKIL7DAVVDFQ2ODJEEHHJXIM", res.Issuer)
+	assert.Equal(t, int32(429), res.Accounts.Authorized)
+	assert.Equal(t, int32(214), res.Accounts.AuthorizedToMaintainLiabilities)
+	assert.Equal(t, int32(107), res.Accounts.Unauthorized)
+	assert.Equal(t, "10000000000000.0000000", res.Balances.Authorized)
+	assert.Equal(t, "5000000000000.0000000", res.Balances.AuthorizedToMaintainLiabilities)
+	assert.Equal(t, "250000000000.0000000", res.Balances.Unauthorized)
 	assert.Equal(t, "10000000000000.0000000", res.Amount)
 	assert.Equal(t, int32(429), res.NumAccounts)
 	assert.Equal(t, horizon.AccountFlags{}, res.Flags)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Include unauthorized assets on the /assets endpoint, and expose the trustline flags.

### Why

As per issue #3241.

### Known limitations

[TODO or N/A]
