### PR TITLE
support/http: Add X-Forwarded-For middleware

### DIFF
--- a/support/http/xff_middleware.go
+++ b/support/http/xff_middleware.go
@@ -1,0 +1,55 @@
+package http
+
+import (
+	stdhttp "net/http"
+	"strings"
+)
+
+// XFFMiddlewareConfig provides a configuration for XFFMiddleware.
+type XFFMiddlewareConfig struct {
+	BehindCloudflare      bool
+	BehindAWSLoadBalancer bool
+}
+
+// XFFMiddleware is a middleware that replaces http.Request.RemoteAddr with a
+// visitor value based on a given config:
+//
+//   * If BehindCloudflare is true CF-Connecting-IP header is used.
+//   * If BehindAWSLoadBalancer is true the last value of X-Forwarded-For header
+//     is used.
+//   * If none of above is set the first value of X-Forwarded-For header is
+//     used. Note: it's easy to spoof the real IP address if the application is
+//     not behind a proxy that maintains a X-Forwarded-For header.
+//
+// Please note that the new RemoteAddr value may not contain the port part!
+func XFFMiddleware(config XFFMiddlewareConfig) func(next stdhttp.Handler) stdhttp.Handler {
+	if config.BehindCloudflare && config.BehindAWSLoadBalancer {
+		panic("Only one of BehindCloudflare and BehindAWSLoadBalancer options can be selected")
+	}
+
+	return func(next stdhttp.Handler) stdhttp.Handler {
+		fn := func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+			var newRemoteAddr string
+
+			if config.BehindCloudflare {
+				newRemoteAddr = r.Header.Get("CF-Connecting-IP")
+			} else {
+				ips := strings.Split(r.Header.Get("X-Forwarded-For"), ",")
+				if len(ips) > 0 {
+					if config.BehindAWSLoadBalancer {
+						newRemoteAddr = ips[len(ips)-1]
+					} else {
+						newRemoteAddr = ips[0]
+					}
+				}
+			}
+
+			newRemoteAddr = strings.TrimSpace(newRemoteAddr)
+			if newRemoteAddr != "" {
+				r.RemoteAddr = newRemoteAddr
+			}
+			next.ServeHTTP(w, r)
+		}
+		return stdhttp.HandlerFunc(fn)
+	}
+}

--- a/support/http/xff_middleware_test.go
+++ b/support/http/xff_middleware_test.go
@@ -1,0 +1,84 @@
+package http
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockHandler struct {
+	mock.Mock
+}
+
+func (m *MockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.Called(w, r)
+}
+
+func TestXFFMiddlewareWrongConfig(t *testing.T) {
+	assert.Panics(t, func() {
+		XFFMiddleware(XFFMiddlewareConfig{
+			BehindCloudflare:      true,
+			BehindAWSLoadBalancer: true,
+		})
+	})
+}
+
+func TestXFFMiddlewareCloudFlare(t *testing.T) {
+	xff := XFFMiddleware(XFFMiddlewareConfig{
+		BehindCloudflare: true,
+	})
+
+	mockHandler := &MockHandler{}
+	mockHandler.On("ServeHTTP", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			r := args.Get(1).(*http.Request)
+			assert.Equal(t, "2.2.2.2", r.RemoteAddr)
+		}).Once()
+	handler := xff(mockHandler)
+	handler.ServeHTTP(nil, &http.Request{
+		RemoteAddr: "127.0.0.1",
+		Header:     xffHeaders("CF-Connecting-IP", "2.2.2.2"),
+	})
+}
+
+func TestXFFMiddlewareAWS(t *testing.T) {
+	xff := XFFMiddleware(XFFMiddlewareConfig{
+		BehindAWSLoadBalancer: true,
+	})
+
+	mockHandler := &MockHandler{}
+	mockHandler.On("ServeHTTP", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			r := args.Get(1).(*http.Request)
+			assert.Equal(t, "2.2.2.2", r.RemoteAddr)
+		}).Once()
+	handler := xff(mockHandler)
+	handler.ServeHTTP(nil, &http.Request{
+		RemoteAddr: "127.0.0.1",
+		Header:     xffHeaders("X-Forwarded-For", "1.1.1.1,2.2.2.2"),
+	})
+}
+
+func TestXFFMiddlewareNormalProxy(t *testing.T) {
+	xff := XFFMiddleware(XFFMiddlewareConfig{})
+
+	mockHandler := &MockHandler{}
+	mockHandler.On("ServeHTTP", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			r := args.Get(1).(*http.Request)
+			assert.Equal(t, "1.1.1.1", r.RemoteAddr)
+		}).Once()
+	handler := xff(mockHandler)
+	handler.ServeHTTP(nil, &http.Request{
+		RemoteAddr: "127.0.0.1",
+		Header:     xffHeaders("X-Forwarded-For", "1.1.1.1,2.2.2.2"),
+	})
+}
+
+func xffHeaders(name, value string) http.Header {
+	headers := http.Header{}
+	headers.Add(name, value)
+	return headers
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit adds a new middleware: `XFFMiddleware` to `support/http` package.

### Why

The middleware we currently use in Horizon: `github.com/sebest/xff` does not have support for AWS in which the client header is [appended](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html#x-forwarded-for) to the list of IPs instead of being [prepended](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For). It also does not have a support for CloudFlare.

### Known limitations

Standard `RemoteAddr` value contains the port. Usually values obtained via headers do not.
