### PR TITLE
all: update all docker images to use Go 1.16.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,52 +244,11 @@ jobs:
       - staticcheck
       - build_packages
 
-  # test_code_1_14 performs all package tests using Go 1.14.
-  test_code_1_14:
-    working_directory: /go/src/github.com/stellar/go
-    docker:
-      - image: golang:1.14.15-stretch
-        environment:
-          GO111MODULE: "on"
-          PGHOST: localhost
-          PGPORT: 5432
-          PGUSER: circleci
-          PGDATABASE: circle_test
-          MYSQL_HOST: 127.0.0.1
-          MYSQL_PORT: 3306
-      - image: circleci/postgres:9.6.5-alpine-ram
-        environment:
-          POSTGRES_USER: circleci
-    steps:
-      - install_go_deps
-      - test_packages
-
-  # test_code_1_14_postgres10 performs all package tests using Go 1.14 and Postgres 10.
-  test_code_1_14_postgres10:
-    working_directory: /go/src/github.com/stellar/go
-    docker:
-      - image: golang:1.14.15-stretch
-        environment:
-          GO111MODULE: "on"
-          PGHOST: localhost
-          PGPORT: 5432
-          PGUSER: circleci
-          PGDATABASE: circle_test
-          MYSQL_HOST: 127.0.0.1
-          MYSQL_PORT: 3306
-      - image: circleci/postgres:10-alpine-ram
-        environment:
-          POSTGRES_USER: circleci
-      - image: circleci/redis:5.0-alpine
-    steps:
-      - install_go_deps
-      - test_packages
-
   # test_code_1_15 performs all package tests using Go 1.15.
   test_code_1_15:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.15.8
+      - image: golang:1.15.10
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -309,7 +268,7 @@ jobs:
   test_code_1_15_postgres10:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.15.8
+      - image: golang:1.15.10
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -331,7 +290,7 @@ jobs:
   test_code_1_16:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.16
+      - image: golang:1.16.2
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -351,7 +310,7 @@ jobs:
   test_code_1_16_postgres10:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.16
+      - image: golang:1.16.2
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -375,7 +334,7 @@ jobs:
   publish_artifacts:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.16
+      - image: golang:1.16.2
     steps:
       - check_deprecations
       - install_go_deps
@@ -518,8 +477,6 @@ workflows:
   check_code_and_test:
     jobs:
       - check_code_1_16
-      - test_code_1_14
-      - test_code_1_14_postgres10
       - test_code_1_15
       - test_code_1_15_postgres10
       - test_code_1_16

--- a/exp/services/recoverysigner/docker/Dockerfile
+++ b/exp/services/recoverysigner/docker/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.14-stretch as build
+FROM golang:1.16.2 as build
 
 ADD . /src/recoverysigner
 WORKDIR /src/recoverysigner
 RUN go build -o /bin/recoverysigner ./exp/services/recoverysigner
 
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 COPY --from=build /bin/recoverysigner /app/

--- a/exp/services/webauth/docker/Dockerfile
+++ b/exp/services/webauth/docker/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.14-stretch as build
+FROM golang:1.16.2 as build
 
 ADD . /src/webauth
 WORKDIR /src/webauth
 RUN go build -o /bin/webauth ./exp/services/webauth
 
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 COPY --from=build /bin/webauth /app/

--- a/exp/tools/dump-ledger-state/Dockerfile
+++ b/exp/tools/dump-ledger-state/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "host all all all trust" > /etc/postgresql/9.6/main/pg_hba.conf
 # And add `listen_addresses` to `/etc/postgresql/9.6/main/postgresql.conf`
 RUN echo "listen_addresses='*'" >> /etc/postgresql/9.6/main/postgresql.conf
 
-RUN curl -sL https://storage.googleapis.com/golang/go1.15.3.linux-amd64.tar.gz | tar -C /usr/local -xz
+RUN curl -sL https://storage.googleapis.com/golang/go1.16.2.linux-amd64.tar.gz | tar -C /usr/local -xz
 RUN ln -s  /usr/local/go/bin/go /usr/local/bin/go
 WORKDIR /go/src/github.com/stellar/go
 COPY go.mod go.sum ./

--- a/services/friendbot/docker/Dockerfile
+++ b/services/friendbot/docker/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.14-stretch as build
+FROM golang:1.16.2 as build
 
 ADD . /src/friendbot
 WORKDIR /src/friendbot
 RUN go build -o /bin/friendbot ./services/friendbot
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 COPY --from=build /bin/friendbot /app/

--- a/services/horizon/docker/Dockerfile.dev
+++ b/services/horizon/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.14-stretch AS builder
+FROM golang:1.16.2 AS builder
 
 WORKDIR /go/src/github.com/stellar/go
 COPY go.mod go.sum ./

--- a/services/horizon/internal/scripts/check_release_hash/Dockerfile
+++ b/services/horizon/internal/scripts/check_release_hash/Dockerfile
@@ -1,5 +1,5 @@
 # Change to Go version used in CI or rebuild with --build-arg.
-ARG GO_IMAGE=golang:1.16.2-stretch
+ARG GO_IMAGE=golang:1.16.2
 FROM $GO_IMAGE
 
 WORKDIR /go/src/github.com/stellar/go

--- a/services/horizon/internal/scripts/check_release_hash/Dockerfile
+++ b/services/horizon/internal/scripts/check_release_hash/Dockerfile
@@ -1,5 +1,5 @@
 # Change to Go version used in CI or rebuild with --build-arg.
-ARG GO_IMAGE=golang:1.14.15-stretch
+ARG GO_IMAGE=golang:1.16.2-stretch
 FROM $GO_IMAGE
 
 WORKDIR /go/src/github.com/stellar/go

--- a/services/keystore/docker/Dockerfile
+++ b/services/keystore/docker/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.14-stretch as build
+FROM golang:1.16.2 as build
 
 ADD . /src/keystore
 WORKDIR /src/keystore
 RUN go build -o /bin/keystored ./services/keystore/cmd/keystored
 
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 ADD ./services/keystore/migrations/ /app/migrations/

--- a/services/regulated-assets-approval-server/docker/Dockerfile
+++ b/services/regulated-assets-approval-server/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as build
+FROM golang:1.16.2 as build
 
 ADD . /src/regulated-assets-approval-server
 WORKDIR /src/regulated-assets-approval-server

--- a/services/ticker/docker/Dockerfile
+++ b/services/ticker/docker/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.14-stretch as build
+FROM golang:1.16.2 as build
 
 ADD . /src/ticker
 WORKDIR /src/ticker
 RUN go build -o /bin/ticker ./services/ticker
 
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 COPY --from=build /bin/ticker /app/

--- a/services/ticker/docker/Dockerfile-dev
+++ b/services/ticker/docker/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM golang:1.14-stretch as build
+FROM golang:1.16.2-stretch as build
 
 LABEL maintainer="Alex Cordeiro <alexc@stellar.org>"
 


### PR DESCRIPTION
### What

Update all docker images to use Go 1.16.2 and Ubuntu 18.04.

### Why

Go 1.14 is no longer supported or receiving security updates. Ubuntu needs upgrading to align the versions of Ubuntu in the runtime images with the build images.

### Known limitations

N/A

### Reviewing

If I have requested you review this PR it is because I believe you own or are the most knowledgeable person for a service impacted by this change. Please review the PR, and handle, or delegate someone else to handle, any deployment after merge for your respective service.

@accordeiro Ticker
@bartekn @ire-and-curses Horizon
@marcelosalloum Friendbot, Regulated Assets
@leighmcculloch Webauth, Recoverysigner, Keystore