### PR TITLE
services/horizon: Allow customization of the Captive Core log file.

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -111,6 +111,8 @@ type CaptiveCoreConfig struct {
 	NetworkPassphrase string
 	// HistoryArchiveURLs are a list of history archive urls
 	HistoryArchiveURLs []string
+	// LogPath is the path in which to store Core logs
+	LogPath string
 
 	// Optional fields
 

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -3,7 +3,6 @@ package ledgerbackend
 import (
 	"context"
 	"encoding/hex"
-	"io/ioutil"
 	"os"
 	"sync"
 
@@ -140,18 +139,11 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	// Here we set defaults in the config. Because config is not a pointer this code should
 	// not mutate the original CaptiveCoreConfig instance which was passed into NewCaptive()
 
-	// Create a default logging instance for Captive Core's output if no other
-	// logging configuration was specified.
+	// Log Captive Core straight to stdout by default
 	if config.Log == nil {
 		config.Log = log.New()
-		if config.LogPath != "" {
-			// We still create an empty logger instance so there's no nil
-			// pointer floating around beyond this call.
-			config.Log.Logger.SetOutput(ioutil.Discard)
-		} else {
-			config.Log.Logger.SetOutput(os.Stdout)
-			config.Log.SetLevel(logrus.InfoLevel)
-		}
+		config.Log.Logger.SetOutput(os.Stdout)
+		config.Log.SetLevel(logrus.InfoLevel)
 	}
 
 	parentCtx := config.Context

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -123,10 +123,9 @@ type CaptiveCoreConfig struct {
 	HTTPPort uint
 	// Log is an (optional) custom logger which will capture any output from the Stellar Core process.
 	// If Log is omitted then all output will be printed to stdout.
-	// However, if LogPath (optional, below) is set, no logging will be done to this.
 	Log *log.Entry
 	// LogPath is the (optional) path in which to store Core logs, passed along
-	// to Stellar-Core's LOG_FILE_PATH
+	// to Stellar Core's LOG_FILE_PATH
 	LogPath string
 	// Context is the (optional) context which controls the lifetime of a CaptiveStellarCore instance. Once the context is done
 	// the CaptiveStellarCore instance will not be able to stream ledgers from Stellar Core or spawn new

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -112,8 +112,6 @@ type CaptiveCoreConfig struct {
 	NetworkPassphrase string
 	// HistoryArchiveURLs are a list of history archive urls
 	HistoryArchiveURLs []string
-	// LogPath is the path in which to store Core logs
-	LogPath string
 
 	// Optional fields
 
@@ -126,7 +124,11 @@ type CaptiveCoreConfig struct {
 	HTTPPort uint
 	// Log is an (optional) custom logger which will capture any output from the Stellar Core process.
 	// If Log is omitted then all output will be printed to stdout.
+	// However, if LogPath (optional, below) is set, no logging will be done to this.
 	Log *log.Entry
+	// LogPath is the (optional) path in which to store Core logs, passed along
+	// to Stellar-Core's LOG_FILE_PATH
+	LogPath string
 	// Context is the (optional) context which controls the lifetime of a CaptiveStellarCore instance. Once the context is done
 	// the CaptiveStellarCore instance will not be able to stream ledgers from Stellar Core or spawn new
 	// instances of Stellar Core. If Context is omitted CaptiveStellarCore will default to using context.Background.

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -118,9 +118,8 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 		fmt.Sprintf(`NETWORK_PASSPHRASE="%s"`, r.networkPassphrase),
 		fmt.Sprintf(`BUCKET_DIR_PATH="%s"`, filepath.Join(r.tempDir, "buckets")),
 		fmt.Sprintf(`HTTP_PORT=%d`, r.httpPort),
+		fmt.Sprintf(`LOG_FILE_PATH="%s"`, r.logPath),
 	}
-
-	lines = append(lines, fmt.Sprintf(`LOG_FILE_PATH="%s"`, r.logPath))
 
 	if r.mode == stellarCoreRunnerModeOffline {
 		// In offline mode, there is no need to connect to peers

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -48,6 +48,7 @@ type pipe struct {
 }
 
 type stellarCoreRunner struct {
+	logPath           string
 	executablePath    string
 	configAppendPath  string
 	networkPassphrase string
@@ -82,6 +83,7 @@ func newStellarCoreRunner(config CaptiveCoreConfig, mode stellarCoreRunnerMode) 
 	ctx, cancel := context.WithCancel(config.Context)
 
 	runner := &stellarCoreRunner{
+		logPath:           config.LogPath,
 		executablePath:    config.BinaryPath,
 		configAppendPath:  config.ConfigAppendPath,
 		networkPassphrase: config.NetworkPassphrase,
@@ -116,8 +118,9 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 		fmt.Sprintf(`NETWORK_PASSPHRASE="%s"`, r.networkPassphrase),
 		fmt.Sprintf(`BUCKET_DIR_PATH="%s"`, filepath.Join(r.tempDir, "buckets")),
 		fmt.Sprintf(`HTTP_PORT=%d`, r.httpPort),
-		`LOG_FILE_PATH=""`,
 	}
+
+	lines = append(lines, fmt.Sprintf(`LOG_FILE_PATH="%s"`, r.logPath))
 
 	if r.mode == stellarCoreRunnerModeOffline {
 		// In offline mode, there is no need to connect to peers

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	CaptiveCoreConfigAppendPath string
 	RemoteCaptiveCoreURL        string
 	CaptiveCoreHTTPPort         uint
+	CaptiveCoreLogPath          string
 
 	StellarCoreDatabaseURL string
 	StellarCoreURL         string

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -256,6 +256,12 @@ func Flags() (*Config, support.ConfigOptions) {
 			Usage:     "name of the file where logs will be saved (leave empty to send logs to stdout)",
 		},
 		&support.ConfigOption{
+			Name:      "captive-core-log-path",
+			ConfigKey: &config.CaptiveCoreLogPath,
+			OptType:   types.String,
+			Usage:     "name of the path for Core logs (leave empty to log w/ Horizon)",
+		},
+		&support.ConfigOption{
 			Name:        "max-path-length",
 			ConfigKey:   &config.MaxPathLength,
 			OptType:     types.Uint,

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -259,7 +259,7 @@ func Flags() (*Config, support.ConfigOptions) {
 			Name:      "captive-core-log-path",
 			ConfigKey: &config.CaptiveCoreLogPath,
 			OptType:   types.String,
-			Usage:     "name of the path for Core logs (leave empty to log w/ Horizon)",
+			Usage:     "name of the path for Core logs (leave empty to log w/ Horizon only)",
 		},
 		&support.ConfigOption{
 			Name:        "max-path-length",

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -190,16 +190,7 @@ func NewSystem(config Config) (System, error) {
 				return nil, errors.Wrap(err, "error creating captive core backend")
 			}
 		} else {
-			// If the user wants a custom logging location for Captive Core (set
-			// via Core's LOG_FILE_PATH), it takes priority over Horizon's
-			// internal logging.
-			//
-			// https://github.com/stellar/go/issues/3438#issuecomment-797690998
-			var logger *logpkg.Entry = nil
-			if config.CaptiveCoreLogPath == "" {
-				logger = log.WithField("subservice", "stellar-core")
-			}
-
+			logger := log.WithField("subservice", "stellar-core")
 			ledgerBackend, err = ledgerbackend.NewCaptive(
 				ledgerbackend.CaptiveCoreConfig{
 					LogPath:             config.CaptiveCoreLogPath,

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -72,6 +72,7 @@ func initIngester(app *App) {
 		CaptiveCoreBinaryPath:       app.config.CaptiveCoreBinaryPath,
 		CaptiveCoreConfigAppendPath: app.config.CaptiveCoreConfigAppendPath,
 		CaptiveCoreHTTPPort:         app.config.CaptiveCoreHTTPPort,
+		CaptiveCoreLogPath:          app.config.CaptiveCoreLogPath,
 		RemoteCaptiveCoreURL:        app.config.RemoteCaptiveCoreURL,
 		EnableCaptiveCore:           app.config.EnableCaptiveCoreIngestion,
 		DisableStateVerification:    app.config.IngestDisableStateVerification,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
This introduces the `--captive-core-log-path` parameter, which sets Stellar Core's `LOG_FILE_PATH` in the auto-generated configuration accordingly. If it's not set, Horizon will continue to log Captive Core's output to its log path with `subservice=stellar-core`.

### Why
Closes #3438

### Known limitations
n/a