### PR TITLE
services/horizon: Improve Captive Stellar-Core validation

### DIFF
--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -29,6 +29,8 @@ const (
 	StellarCoreBinaryPathName = "stellar-core-binary-path"
 	// CaptiveCoreConfigAppendPathName is the command line flag for configuring the path to the captive core additional configuration
 	CaptiveCoreConfigAppendPathName = "captive-core-config-append-path"
+
+	captiveCoreMigrationHint = "If you are migrating from Horizon 1.x.y read the Migration Guide here: https://github.com/stellar/go/blob/master/services/horizon/internal/docs/captive_core.md"
 )
 
 // validateBothOrNeither ensures that both options are provided, if either is provided.
@@ -413,46 +415,56 @@ func ApplyFlags(config *Config, flags support.ConfigOptions) {
 	// Validate options that should be provided together
 	validateBothOrNeither("tls-cert", "tls-key")
 
-	// config.HistoryArchiveURLs contains a single empty value when empty so using
-	// viper.GetString is easier.
-	if config.Ingest && viper.GetString("history-archive-urls") == "" {
-		stdLog.Fatalf("--history-archive-urls must be set when --ingest is set")
-	}
-
-	if config.EnableCaptiveCoreIngestion {
-		binaryPath := viper.GetString(StellarCoreBinaryPathName)
-
-		// If the user didn't specify a Stellar Core binary, we can check the
-		// $PATH and possibly fill it in for them.
-		if binaryPath == "" {
-			if result, err := exec.LookPath("stellar-core"); err == nil {
-				binaryPath = result
-				viper.Set(StellarCoreBinaryPathName, binaryPath)
-				config.CaptiveCoreBinaryPath = binaryPath
-			}
-		}
-
-		remoteURL := viper.GetString("remote-captive-core-url")
-
-		// NOTE: If both of these are set (regardless of user- or PATH-supplied
-		//       defaults for the binary path), the Remote Captive Core URL
-		//       takes precedence.
-		if binaryPath == "" && remoteURL == "" {
-			stdLog.Fatalf("Invalid config: captive core requires that either --stellar-core-binary-path or --remote-captive-core-url is set. " +
-				"If you are migrating from Horizon 1.x.y read the Migration Guide here: https://github.com/stellar/go/blob/master/services/horizon/internal/docs/captive_core.md")
-		}
-
-		// If we don't supply an explicit core URL and we are running a local
-		// captive core process with the http port enabled, point to it.
-		if config.StellarCoreURL == "" && config.RemoteCaptiveCoreURL == "" && config.CaptiveCoreHTTPPort != 0 {
-			config.StellarCoreURL = fmt.Sprintf("http://localhost:%d", config.CaptiveCoreHTTPPort)
-			viper.Set(StellarCoreURLFlagName, config.StellarCoreURL)
-		}
-	}
-
 	if config.Ingest {
 		// When running live ingestion a config file is required too
 		validateBothOrNeither(StellarCoreBinaryPathName, CaptiveCoreConfigAppendPathName)
+
+		// config.HistoryArchiveURLs contains a single empty value when empty so using
+		// viper.GetString is easier.
+		if len(config.HistoryArchiveURLs) == 0 {
+			stdLog.Fatalf("--history-archive-urls must be set when --ingest is set")
+		}
+
+		if config.EnableCaptiveCoreIngestion {
+			binaryPath := viper.GetString(StellarCoreBinaryPathName)
+
+			// If the user didn't specify a Stellar Core binary, we can check the
+			// $PATH and possibly fill it in for them.
+			if binaryPath == "" {
+				if result, err := exec.LookPath("stellar-core"); err == nil {
+					binaryPath = result
+					viper.Set(StellarCoreBinaryPathName, binaryPath)
+					config.CaptiveCoreBinaryPath = binaryPath
+				}
+			}
+
+			// NOTE: If both of these are set (regardless of user- or PATH-supplied
+			//       defaults for the binary path), the Remote Captive Core URL
+			//       takes precedence.
+			if binaryPath == "" && config.RemoteCaptiveCoreURL == "" {
+				stdLog.Fatalf("Invalid config: captive core requires that either --stellar-core-binary-path or --remote-captive-core-url is set. " + captiveCoreMigrationHint)
+			}
+
+			if config.CaptiveCoreBinaryPath == "" || config.CaptiveCoreConfigAppendPath == "" {
+				stdLog.Fatalf("Invalid config: captive core requires that both --%s and --%s are set. "+captiveCoreMigrationHint,
+					StellarCoreBinaryPathName, CaptiveCoreConfigAppendPathName)
+			}
+
+			// If we don't supply an explicit core URL and we are running a local
+			// captive core process with the http port enabled, point to it.
+			if config.StellarCoreURL == "" && config.RemoteCaptiveCoreURL == "" && config.CaptiveCoreHTTPPort != 0 {
+				config.StellarCoreURL = fmt.Sprintf("http://localhost:%d", config.CaptiveCoreHTTPPort)
+				viper.Set(StellarCoreURLFlagName, config.StellarCoreURL)
+			}
+		}
+	} else {
+		if config.CaptiveCoreBinaryPath != "" || config.CaptiveCoreConfigAppendPath != "" {
+			stdLog.Fatalf("Invalid config: one or more captive core params passed (--%s or --%s) but --ingest not set. "+captiveCoreMigrationHint,
+				StellarCoreBinaryPathName, CaptiveCoreConfigAppendPathName)
+		}
+		if config.StellarCoreDatabaseURL != "" {
+			stdLog.Fatalf("Invalid config: --%s passed but --ingest not set. ", StellarCoreDBURLFlagName)
+		}
 	}
 
 	// Configure log file


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit improves Captive Stellar-Core flags validation:
* Passing ingestion flags (Captive Stellar-Core or Stellar-Core DB params) without enabling ingestion (`--ingest`) throws an error. Close #3473.
* Allow starting HTTP server without ingestion without having to set `ENABLE_CAPTIVE_CORE_INGESTION=false`. Close #3466.

### Why

Some users need hints how to configure Captive Stellar-Core.

### Known limitations

This change can break some scripts that pass extra config flags without setting `--ingest`.