### PR TITLE
services/horizon: Find the stellar-core binary in the PATH earlier, if possible

### DIFF
--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -422,6 +422,18 @@ func ApplyFlags(config *Config, flags support.ConfigOptions) {
 	validateBothOrNeither("tls-cert", "tls-key")
 
 	if config.Ingest {
+		binaryPath := viper.GetString(StellarCoreBinaryPathName)
+
+		// If the user didn't specify a Stellar Core binary, we can check the
+		// $PATH and possibly fill it in for them.
+		if binaryPath == "" {
+			if result, err := exec.LookPath("stellar-core"); err == nil {
+				binaryPath = result
+				viper.Set(StellarCoreBinaryPathName, binaryPath)
+				config.CaptiveCoreBinaryPath = binaryPath
+			}
+		}
+
 		// When running live ingestion a config file is required too
 		validateBothOrNeither(StellarCoreBinaryPathName, CaptiveCoreConfigAppendPathName)
 
@@ -432,28 +444,17 @@ func ApplyFlags(config *Config, flags support.ConfigOptions) {
 		}
 
 		if config.EnableCaptiveCoreIngestion {
-			binaryPath := viper.GetString(StellarCoreBinaryPathName)
-
-			// If the user didn't specify a Stellar Core binary, we can check the
-			// $PATH and possibly fill it in for them.
-			if binaryPath == "" {
-				if result, err := exec.LookPath("stellar-core"); err == nil {
-					binaryPath = result
-					viper.Set(StellarCoreBinaryPathName, binaryPath)
-					config.CaptiveCoreBinaryPath = binaryPath
-				}
-			}
-
 			// NOTE: If both of these are set (regardless of user- or PATH-supplied
 			//       defaults for the binary path), the Remote Captive Core URL
 			//       takes precedence.
 			if binaryPath == "" && config.RemoteCaptiveCoreURL == "" {
-				stdLog.Fatalf("Invalid config: captive core requires that either --stellar-core-binary-path or --remote-captive-core-url is set. " + captiveCoreMigrationHint)
+				stdLog.Fatalf("Invalid config: captive core requires that either --%s or --remote-captive-core-url is set. %s",
+					StellarCoreBinaryPathName, captiveCoreMigrationHint)
 			}
 
-			if config.CaptiveCoreBinaryPath == "" || config.CaptiveCoreConfigAppendPath == "" {
-				stdLog.Fatalf("Invalid config: captive core requires that both --%s and --%s are set. "+captiveCoreMigrationHint,
-					StellarCoreBinaryPathName, CaptiveCoreConfigAppendPathName)
+			if binaryPath == "" || config.CaptiveCoreConfigAppendPath == "" {
+				stdLog.Fatalf("Invalid config: captive core requires that both --%s and --%s are set. %s",
+					StellarCoreBinaryPathName, CaptiveCoreConfigAppendPathName, captiveCoreMigrationHint)
 			}
 
 			// If we don't supply an explicit core URL and we are running a local


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Checks the PATH for `stellar-core` earlier.

### Why
After #3477, it's no longer possible to run Captive Core without setting the Core binary path. Demo:

```bash
export DATABASE_URL='postgres://postgres@localhost:5432/horizon?sslmode=disable'
export NETWORK_PASSPHRASE='Test SDF Network ; September 2015'
export HISTORY_ARCHIVE_URLS='http://history.stellar.org/prd/core-testnet/core_testnet_001/'
export CAPTIVE_CORE_CONFIG_APPEND_PATH=./docker/captive-core-testnet.cfg
export INGEST=true

horizon
```

Result:
```
Invalid config: captive-core-config-append-path = ..., but corresponding option stellar-core-binary-path is not configured
```

### Known limitations
n/a