### PR TITLE
services/horizon: Add flag to choose a custom peering port for Captive Core

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -121,6 +121,10 @@ type CaptiveCoreConfig struct {
 	LedgerHashStore TrustedLedgerHashStore
 	// HTTPPort is the TCP port to listen for requests (defaults to 0, which disables the HTTP server)
 	HTTPPort uint
+	// PeerPort is the TCP port to bind to for connecting to the Stellar network
+	// (defaults to 11625). It may be useful for example when there's >1 Stellar-Core
+	// instance running on a machine.
+	PeerPort uint
 	// Log is an (optional) custom logger which will capture any output from the Stellar Core process.
 	// If Log is omitted then all output will be printed to stdout.
 	Log *log.Entry

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -54,6 +54,7 @@ type stellarCoreRunner struct {
 	networkPassphrase string
 	historyURLs       []string
 	httpPort          uint
+	peerPort          uint
 	mode              stellarCoreRunnerMode
 
 	started      bool
@@ -89,6 +90,7 @@ func newStellarCoreRunner(config CaptiveCoreConfig, mode stellarCoreRunnerMode) 
 		networkPassphrase: config.NetworkPassphrase,
 		historyURLs:       config.HistoryArchiveURLs,
 		httpPort:          config.HTTPPort,
+		peerPort:          config.PeerPort,
 		mode:              mode,
 		ctx:               ctx,
 		cancel:            cancel,
@@ -119,6 +121,10 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 		fmt.Sprintf(`BUCKET_DIR_PATH="%s"`, filepath.Join(r.tempDir, "buckets")),
 		fmt.Sprintf(`HTTP_PORT=%d`, r.httpPort),
 		fmt.Sprintf(`LOG_FILE_PATH="%s"`, r.logPath),
+	}
+
+	if r.peerPort > 0 {
+		lines = append(lines, fmt.Sprintf(`PEER_PORT=%d`, r.peerPort))
 	}
 
 	if r.mode == stellarCoreRunnerModeOffline {
@@ -152,6 +158,8 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 		lines = append(lines, fmt.Sprintf(`get="curl -sf %s/{0} -o {1}"`, val))
 	}
 	result += strings.Join(lines, "\n")
+
+	fmt.Println(result)
 
 	return result, nil
 }

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -159,8 +159,6 @@ func (r *stellarCoreRunner) generateConfig() (string, error) {
 	}
 	result += strings.Join(lines, "\n")
 
-	fmt.Println(result)
-
 	return result, nil
 }
 

--- a/ingest/ledgerbackend/stellar_core_runner_test.go
+++ b/ingest/ledgerbackend/stellar_core_runner_test.go
@@ -44,6 +44,7 @@ func TestGenerateConfig(t *testing.T) {
 				HistoryArchiveURLs: []string{"http://localhost:1170"},
 				Log:                log.New(),
 				ConfigAppendPath:   testCase.appendPath,
+				PeerPort:           12345,
 				Context:            context.Background(),
 				NetworkPassphrase:  "Public Global Stellar Network ; September 2015",
 			}, testCase.mode)

--- a/ingest/ledgerbackend/testdata/expected-offline-core.cfg
+++ b/ingest/ledgerbackend/testdata/expected-offline-core.cfg
@@ -5,6 +5,7 @@ NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 BUCKET_DIR_PATH="/test-temp-dir/buckets"
 HTTP_PORT=6789
 LOG_FILE_PATH=""
+PEER_PORT=12345
 RUN_STANDALONE=true
 UNSAFE_QUORUM=true
 [QUORUM_SET]

--- a/ingest/ledgerbackend/testdata/expected-offline-with-appendix-core.cfg
+++ b/ingest/ledgerbackend/testdata/expected-offline-with-appendix-core.cfg
@@ -5,6 +5,7 @@ NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 BUCKET_DIR_PATH="/test-temp-dir/buckets"
 HTTP_PORT=6789
 LOG_FILE_PATH=""
+PEER_PORT=12345
 RUN_STANDALONE=true
 UNSAFE_QUORUM=true
 

--- a/ingest/ledgerbackend/testdata/expected-online-core.cfg
+++ b/ingest/ledgerbackend/testdata/expected-online-core.cfg
@@ -5,6 +5,7 @@ NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 BUCKET_DIR_PATH="/test-temp-dir/buckets"
 HTTP_PORT=6789
 LOG_FILE_PATH=""
+PEER_PORT=12345
 
 [[HOME_DOMAINS]]
 HOME_DOMAIN="testnet.stellar.org"

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -9,6 +9,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 * Sanitize route regular expressions for Prometheus metrics ([3459](https://github.com/stellar/go/pull/3459)).
 * Add asset stat summaries per trust-line flag category ([3454](https://github.com/stellar/go/pull/3454)).
   - The `amount`, and `num_accounts` fields in `/assets` endpoint are deprecated. Fields will be removed in Horizon 3.0. You can find the same data under `balances.authorized`, and `accounts.authorized`, respectively.
+* Add a flag `--captive-core-peer-port`/`CAPTIVE_CORE_PEER_PORT` that allows users to control which port the Captive Core subprocess will bind to for connecting to the Stellar swarm. ([3483](https://github.com/stellar/go/pull/3484)). 
 
 ## v2.0.0
 

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	CaptiveCoreConfigAppendPath string
 	RemoteCaptiveCoreURL        string
 	CaptiveCoreHTTPPort         uint
+	CaptiveCorePeerPort         uint
 	CaptiveCoreLogPath          string
 
 	StellarCoreDatabaseURL string

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -136,9 +136,9 @@ func Flags() (*Config, support.ConfigOptions) {
 		&support.ConfigOption{
 			Name:        "captive-core-peer-port",
 			OptType:     types.Uint,
-			FlagDefault: uint(11625),
+			FlagDefault: uint(0),
 			Required:    false,
-			Usage:       "port for Captive Core to bind to for connecting to the Stellar swarm",
+			Usage:       "port for Captive Core to bind to for connecting to the Stellar swarm (0 uses Stellar Core's default)",
 			ConfigKey:   &config.CaptiveCorePeerPort,
 		},
 		&support.ConfigOption{

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -134,6 +134,14 @@ func Flags() (*Config, support.ConfigOptions) {
 			ConfigKey:   &config.CaptiveCoreHTTPPort,
 		},
 		&support.ConfigOption{
+			Name:        "captive-core-peer-port",
+			OptType:     types.Uint,
+			FlagDefault: uint(11625),
+			Required:    false,
+			Usage:       "port for Captive Core to bind to for connecting to the Stellar swarm",
+			ConfigKey:   &config.CaptiveCorePeerPort,
+		},
+		&support.ConfigOption{
 			Name:      StellarCoreDBURLFlagName,
 			EnvVar:    "STELLAR_CORE_DATABASE_URL",
 			ConfigKey: &config.StellarCoreDatabaseURL,

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -72,6 +72,7 @@ type Config struct {
 	CaptiveCoreBinaryPath       string
 	CaptiveCoreConfigAppendPath string
 	CaptiveCoreHTTPPort         uint
+	CaptiveCorePeerPort         uint
 	CaptiveCoreLogPath          string
 	RemoteCaptiveCoreURL        string
 	NetworkPassphrase           string
@@ -198,6 +199,7 @@ func NewSystem(config Config) (System, error) {
 					BinaryPath:          config.CaptiveCoreBinaryPath,
 					ConfigAppendPath:    config.CaptiveCoreConfigAppendPath,
 					HTTPPort:            config.CaptiveCoreHTTPPort,
+					PeerPort:            config.CaptiveCorePeerPort,
 					NetworkPassphrase:   config.NetworkPassphrase,
 					HistoryArchiveURLs:  []string{config.HistoryArchiveURL},
 					CheckpointFrequency: config.CheckpointFrequency,

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -72,6 +72,7 @@ func initIngester(app *App) {
 		CaptiveCoreBinaryPath:       app.config.CaptiveCoreBinaryPath,
 		CaptiveCoreConfigAppendPath: app.config.CaptiveCoreConfigAppendPath,
 		CaptiveCoreHTTPPort:         app.config.CaptiveCoreHTTPPort,
+		CaptiveCorePeerPort:         app.config.CaptiveCorePeerPort,
 		CaptiveCoreLogPath:          app.config.CaptiveCoreLogPath,
 		RemoteCaptiveCoreURL:        app.config.RemoteCaptiveCoreURL,
 		EnableCaptiveCore:           app.config.EnableCaptiveCoreIngestion,


### PR DESCRIPTION
### What
This introduces the `--captive-core-peer-port=11625` parameter, which allows users to control which port Captive Core binds to when joining the Stellar network swarm.

### Why
Closes #3441.

### Known limitations
No validation is done on the actual value passed in (aside from type == uint), so non-port values work. However, then Core will fail to start (with an appropriate error message, of course). We could try to "fail fast" instead, but we don't do this for the HTTP port either.