### PR TITLE
services/horizon/docker/verify-range: Ignore EffectTrustlineFlagsUpdated effects

### DIFF
--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -36,7 +36,7 @@ echo "FROM: $FROM TO: $TO"
 
 dump_horizon_db() {
 	echo "dumping history_effects"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_effects.history_operation_id, history_effects.order, type, details, history_accounts.address from history_effects left join history_accounts on history_accounts.id = history_effects.history_account_id order by history_operation_id asc, \"order\" asc" > "${1}_effects"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_effects.history_operation_id, history_effects.order, type, details, history_accounts.address from history_effects left join history_accounts on history_accounts.id = history_effects.history_account_id where type != 26 order by history_operation_id asc, \"order\" asc" > "${1}_effects"
 	echo "dumping history_ledgers"
 	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select sequence, ledger_hash, previous_ledger_hash, transaction_count, operation_count, closed_at, id, total_coins, fee_pool, base_fee, base_reserve, max_tx_set_size, protocol_version, ledger_header, successful_transaction_count, failed_transaction_count from history_ledgers order by sequence asc" > "${1}_ledgers"
 	echo "dumping history_operations"

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -36,6 +36,7 @@ echo "FROM: $FROM TO: $TO"
 
 dump_horizon_db() {
 	echo "dumping history_effects"
+	# Remove "where type != 26" after Horizon 2.1.0 release!
 	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_effects.history_operation_id, history_effects.order, type, details, history_accounts.address from history_effects left join history_accounts on history_accounts.id = history_effects.history_account_id where type != 26 order by history_operation_id asc, \"order\" asc" > "${1}_effects"
 	echo "dumping history_ledgers"
 	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select sequence, ledger_hash, previous_ledger_hash, transaction_count, operation_count, closed_at, id, total_coins, fee_pool, base_fee, base_reserve, max_tx_set_size, protocol_version, ledger_header, successful_transaction_count, failed_transaction_count from history_ledgers order by sequence asc" > "${1}_ledgers"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

In https://github.com/stellar/go/commit/06190c5aa74be0d699800dd96ba870ee13a9917b we added a new effect: `EffectTrustlineFlagsUpdated` that breaks diff checks in `verify-range` image. This PR removes all `EffectTrustlineFlagsUpdated` effects from the checks to remove false positives. This is a temporary change and should be removed after 2.1.0 is released.
