### PR TITLE
historyarchive: Archivist slow scan missing

### DIFF
--- a/historyarchive/scan.go
+++ b/historyarchive/scan.go
@@ -363,8 +363,8 @@ func (arch *Archive) CheckCheckpointFilesMissing(opts *CommandOptions) map[strin
 	for _, cat := range Categories() {
 		missing[cat] = make([]uint32, 0)
 		for ix := range opts.Range.GenerateCheckpoints(arch.checkpointManager) {
-			fileExists, mapEntryExists := arch.checkpointFiles[cat][ix]
-			if !fileExists || !mapEntryExists {
+			fileExists := arch.checkpointFiles[cat][ix]
+			if !fileExists {
 				missing[cat] = append(missing[cat], ix)
 			}
 		}

--- a/historyarchive/scan.go
+++ b/historyarchive/scan.go
@@ -348,8 +348,8 @@ func (arch *Archive) NoteExistingBucket(bucket Hash) {
 func (arch *Archive) NoteReferencedBucket(bucket Hash) bool {
 	arch.mutex.Lock()
 	defer arch.mutex.Unlock()
-	_, exists := arch.referencedBuckets[bucket]
-	if exists {
+	_, mapEntryExists := arch.referencedBuckets[bucket]
+	if mapEntryExists {
 		return false
 	}
 	arch.referencedBuckets[bucket] = true
@@ -377,8 +377,8 @@ func (arch *Archive) CheckBucketsMissing() map[Hash]bool {
 	defer arch.mutex.Unlock()
 	missing := make(map[Hash]bool)
 	for k := range arch.referencedBuckets {
-		_, ok := arch.allBuckets[k]
-		if !ok {
+		bucketExists, mapEntryExists := arch.allBuckets[k]
+		if !bucketExists || !mapEntryExists {
 			missing[k] = true
 		}
 	}

--- a/historyarchive/scan.go
+++ b/historyarchive/scan.go
@@ -377,8 +377,8 @@ func (arch *Archive) CheckBucketsMissing() map[Hash]bool {
 	defer arch.mutex.Unlock()
 	missing := make(map[Hash]bool)
 	for k := range arch.referencedBuckets {
-		bucketExists, mapEntryExists := arch.allBuckets[k]
-		if !bucketExists || !mapEntryExists {
+		bucketExists := arch.allBuckets[k]
+		if !bucketExists {
 			missing[k] = true
 		}
 	}

--- a/historyarchive/scan.go
+++ b/historyarchive/scan.go
@@ -363,8 +363,8 @@ func (arch *Archive) CheckCheckpointFilesMissing(opts *CommandOptions) map[strin
 	for _, cat := range Categories() {
 		missing[cat] = make([]uint32, 0)
 		for ix := range opts.Range.GenerateCheckpoints(arch.checkpointManager) {
-			_, ok := arch.checkpointFiles[cat][ix]
-			if !ok {
+			fileExists, mapEntryExists := arch.checkpointFiles[cat][ix]
+			if !fileExists || !mapEntryExists {
 				missing[cat] = append(missing[cat], ix)
 			}
 		}


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [X] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [X] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [X] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [X] This PR adds tests for the most critical parts of the new functionality or fixes.
* [X] (NA) I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [X] (NA) I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [X] (No) I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This change fixes a bug in archivist that causes it to mis-report archives as "not missing files" when they are, in fact, missing files. Fairly serious condition. It's caused on archives accessed through http -- which resorts to a slow-scan path that probes each file one by one using HEAD -- rather than archives like s3 that can be fast-scanned with a list command.

### Why

Existing behaviour is wrong. It treats "we got information about a file at all" as meaning "the file is there", even when the information we got is "the file is not there". Classic sort of 3-value-logic mistake on my part.

### Known limitations

None I'm aware of.