### PR TITLE
all: Refactor db.Session to take ctx into each call, instead of storing it on the session level

### DIFF
--- a/exp/services/captivecore/internal/api.go
+++ b/exp/services/captivecore/internal/api.go
@@ -63,7 +63,7 @@ func (c *CaptiveCoreAPI) Shutdown() {
 	c.core.Close()
 }
 
-func (c *CaptiveCoreAPI) startPrepareRange(ledgerRange ledgerbackend.Range) {
+func (c *CaptiveCoreAPI) startPrepareRange(ctx context.Context, ledgerRange ledgerbackend.Range) {
 	defer c.wg.Done()
 
 	err := c.core.PrepareRange(ledgerRange)
@@ -100,7 +100,7 @@ func (c *CaptiveCoreAPI) startPrepareRange(ledgerRange ledgerbackend.Range) {
 }
 
 // PrepareRange executes the PrepareRange operation on the captive core instance.
-func (c *CaptiveCoreAPI) PrepareRange(ledgerRange ledgerbackend.Range) (ledgerbackend.PrepareRangeResponse, error) {
+func (c *CaptiveCoreAPI) PrepareRange(ctx context.Context, ledgerRange ledgerbackend.Range) (ledgerbackend.PrepareRangeResponse, error) {
 	c.activeRequest.Lock()
 	defer c.activeRequest.Unlock()
 	if c.ctx.Err() != nil {
@@ -121,7 +121,7 @@ func (c *CaptiveCoreAPI) PrepareRange(ledgerRange ledgerbackend.Range) (ledgerba
 		c.activeRequest.valid = true
 
 		c.wg.Add(1)
-		go c.startPrepareRange(ledgerRange)
+		go c.startPrepareRange(ctx, ledgerRange)
 
 		return ledgerbackend.PrepareRangeResponse{
 			LedgerRange:   ledgerRange,
@@ -140,7 +140,7 @@ func (c *CaptiveCoreAPI) PrepareRange(ledgerRange ledgerbackend.Range) (ledgerba
 }
 
 // GetLatestLedgerSequence determines the latest ledger sequence available on the captive core instance.
-func (c *CaptiveCoreAPI) GetLatestLedgerSequence() (ledgerbackend.LatestLedgerSequenceResponse, error) {
+func (c *CaptiveCoreAPI) GetLatestLedgerSequence(ctx context.Context) (ledgerbackend.LatestLedgerSequenceResponse, error) {
 	c.activeRequest.Lock()
 	defer c.activeRequest.Unlock()
 
@@ -159,7 +159,7 @@ func (c *CaptiveCoreAPI) GetLatestLedgerSequence() (ledgerbackend.LatestLedgerSe
 }
 
 // GetLedger fetches the ledger with the given sequence number from the captive core instance.
-func (c *CaptiveCoreAPI) GetLedger(sequence uint32) (ledgerbackend.LedgerResponse, error) {
+func (c *CaptiveCoreAPI) GetLedger(ctx context.Context, sequence uint32) (ledgerbackend.LedgerResponse, error) {
 	c.activeRequest.Lock()
 	defer c.activeRequest.Unlock()
 

--- a/exp/services/captivecore/internal/api.go
+++ b/exp/services/captivecore/internal/api.go
@@ -63,7 +63,7 @@ func (c *CaptiveCoreAPI) Shutdown() {
 	c.core.Close()
 }
 
-func (c *CaptiveCoreAPI) startPrepareRange(ctx context.Context, ledgerRange ledgerbackend.Range) {
+func (c *CaptiveCoreAPI) startPrepareRange(ledgerRange ledgerbackend.Range) {
 	defer c.wg.Done()
 
 	err := c.core.PrepareRange(ledgerRange)
@@ -100,7 +100,7 @@ func (c *CaptiveCoreAPI) startPrepareRange(ctx context.Context, ledgerRange ledg
 }
 
 // PrepareRange executes the PrepareRange operation on the captive core instance.
-func (c *CaptiveCoreAPI) PrepareRange(ctx context.Context, ledgerRange ledgerbackend.Range) (ledgerbackend.PrepareRangeResponse, error) {
+func (c *CaptiveCoreAPI) PrepareRange(ledgerRange ledgerbackend.Range) (ledgerbackend.PrepareRangeResponse, error) {
 	c.activeRequest.Lock()
 	defer c.activeRequest.Unlock()
 	if c.ctx.Err() != nil {
@@ -121,7 +121,7 @@ func (c *CaptiveCoreAPI) PrepareRange(ctx context.Context, ledgerRange ledgerbac
 		c.activeRequest.valid = true
 
 		c.wg.Add(1)
-		go c.startPrepareRange(ctx, ledgerRange)
+		go c.startPrepareRange(ledgerRange)
 
 		return ledgerbackend.PrepareRangeResponse{
 			LedgerRange:   ledgerRange,
@@ -140,7 +140,7 @@ func (c *CaptiveCoreAPI) PrepareRange(ctx context.Context, ledgerRange ledgerbac
 }
 
 // GetLatestLedgerSequence determines the latest ledger sequence available on the captive core instance.
-func (c *CaptiveCoreAPI) GetLatestLedgerSequence(ctx context.Context) (ledgerbackend.LatestLedgerSequenceResponse, error) {
+func (c *CaptiveCoreAPI) GetLatestLedgerSequence() (ledgerbackend.LatestLedgerSequenceResponse, error) {
 	c.activeRequest.Lock()
 	defer c.activeRequest.Unlock()
 
@@ -159,7 +159,7 @@ func (c *CaptiveCoreAPI) GetLatestLedgerSequence(ctx context.Context) (ledgerbac
 }
 
 // GetLedger fetches the ledger with the given sequence number from the captive core instance.
-func (c *CaptiveCoreAPI) GetLedger(ctx context.Context, sequence uint32) (ledgerbackend.LedgerResponse, error) {
+func (c *CaptiveCoreAPI) GetLedger(sequence uint32) (ledgerbackend.LedgerResponse, error) {
 	c.activeRequest.Lock()
 	defer c.activeRequest.Unlock()
 

--- a/exp/services/captivecore/internal/api_test.go
+++ b/exp/services/captivecore/internal/api_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -19,13 +18,11 @@ func TestAPITestSuite(t *testing.T) {
 
 type APITestSuite struct {
 	suite.Suite
-	ctx           context.Context
 	ledgerBackend *ledgerbackend.MockDatabaseBackend
 	api           CaptiveCoreAPI
 }
 
 func (s *APITestSuite) SetupTest() {
-	s.ctx = context.Background()
 	s.ledgerBackend = &ledgerbackend.MockDatabaseBackend{}
 	s.api = NewCaptiveCoreAPI(s.ledgerBackend, log.New())
 }
@@ -35,12 +32,12 @@ func (s *APITestSuite) TearDownTest() {
 }
 
 func (s *APITestSuite) TestLatestSeqActiveRequestInvalid() {
-	_, err := s.api.GetLatestLedgerSequence(s.ctx)
+	_, err := s.api.GetLatestLedgerSequence()
 	s.Assert().Equal(err, ErrMissingPrepareRange)
 }
 
 func (s *APITestSuite) TestGetLedgerActiveRequestInvalid() {
-	_, err := s.api.GetLedger(s.ctx, 64)
+	_, err := s.api.GetLedger(64)
 	s.Assert().Equal(err, ErrMissingPrepareRange)
 }
 
@@ -51,7 +48,7 @@ func (s *APITestSuite) runBeforeReady(prepareRangeErr error, f func()) {
 		WaitUntil(waitChan).
 		Return(prepareRangeErr).Once()
 
-	response, err := s.api.PrepareRange(s.ctx, ledgerRange)
+	response, err := s.api.PrepareRange(ledgerRange)
 	s.Assert().NoError(err)
 	s.Assert().False(response.Ready)
 	s.Assert().Equal(response.LedgerRange, ledgerRange)
@@ -64,14 +61,14 @@ func (s *APITestSuite) runBeforeReady(prepareRangeErr error, f func()) {
 
 func (s *APITestSuite) TestLatestSeqActiveRequestNotReady() {
 	s.runBeforeReady(nil, func() {
-		_, err := s.api.GetLatestLedgerSequence(s.ctx)
+		_, err := s.api.GetLatestLedgerSequence()
 		s.Assert().Equal(err, ErrPrepareRangeNotReady)
 	})
 }
 
 func (s *APITestSuite) TestGetLedgerNotReady() {
 	s.runBeforeReady(nil, func() {
-		_, err := s.api.GetLedger(s.ctx, 64)
+		_, err := s.api.GetLedger(64)
 		s.Assert().Equal(err, ErrPrepareRangeNotReady)
 	})
 }
@@ -80,7 +77,7 @@ func (s *APITestSuite) waitUntilReady(ledgerRange ledgerbackend.Range) {
 	s.ledgerBackend.On("PrepareRange", ledgerRange).
 		Return(nil).Once()
 
-	response, err := s.api.PrepareRange(s.ctx, ledgerRange)
+	response, err := s.api.PrepareRange(ledgerRange)
 	s.Assert().NoError(err)
 	s.Assert().False(response.Ready)
 	s.Assert().Equal(response.LedgerRange, ledgerRange)
@@ -94,7 +91,7 @@ func (s *APITestSuite) TestLatestSeqError() {
 	expectedErr := fmt.Errorf("test error")
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(uint32(0), expectedErr).Once()
 
-	_, err := s.api.GetLatestLedgerSequence(s.ctx)
+	_, err := s.api.GetLatestLedgerSequence()
 	s.Assert().Equal(err, expectedErr)
 }
 
@@ -105,7 +102,7 @@ func (s *APITestSuite) TestGetLedgerError() {
 	s.ledgerBackend.On("GetLedger", uint32(64)).
 		Return(false, xdr.LedgerCloseMeta{}, expectedErr).Once()
 
-	_, err := s.api.GetLedger(s.ctx, 64)
+	_, err := s.api.GetLedger(64)
 	s.Assert().Equal(err, expectedErr)
 }
 
@@ -114,7 +111,7 @@ func (s *APITestSuite) TestLatestSeqSucceeds() {
 
 	expectedSeq := uint32(100)
 	s.ledgerBackend.On("GetLatestLedgerSequence").Return(expectedSeq, nil).Once()
-	seq, err := s.api.GetLatestLedgerSequence(s.ctx)
+	seq, err := s.api.GetLatestLedgerSequence()
 	s.Assert().NoError(err)
 	s.Assert().Equal(seq, ledgerbackend.LatestLedgerSequenceResponse{Sequence: expectedSeq})
 }
@@ -133,7 +130,7 @@ func (s *APITestSuite) TestGetLedgerSucceeds() {
 	}
 	s.ledgerBackend.On("GetLedger", uint32(64)).
 		Return(true, expectedLedger, nil).Once()
-	seq, err := s.api.GetLedger(s.ctx, 64)
+	seq, err := s.api.GetLedger(64)
 
 	s.Assert().NoError(err)
 	s.Assert().Equal(seq, ledgerbackend.LedgerResponse{
@@ -145,7 +142,7 @@ func (s *APITestSuite) TestGetLedgerSucceeds() {
 func (s *APITestSuite) TestShutDownBeforePrepareRange() {
 	s.ledgerBackend.On("Close").Return(nil).Once()
 	s.api.Shutdown()
-	_, err := s.api.PrepareRange(s.ctx, ledgerbackend.UnboundedRange(63))
+	_, err := s.api.PrepareRange(ledgerbackend.UnboundedRange(63))
 	s.Assert().EqualError(err, "Cannot prepare range when shut down")
 }
 
@@ -229,7 +226,7 @@ func (s *APITestSuite) TestRangeAlreadyPrepared() {
 		ledgerbackend.UnboundedRange(100),
 		ledgerbackend.BoundedRange(63, 70),
 	} {
-		response, err := s.api.PrepareRange(s.ctx, ledgerRange)
+		response, err := s.api.PrepareRange(ledgerRange)
 		s.Assert().NoError(err)
 		s.Assert().True(response.Ready)
 		s.Assert().Equal(superSetRange, response.LedgerRange)

--- a/exp/services/captivecore/internal/server.go
+++ b/exp/services/captivecore/internal/server.go
@@ -39,7 +39,7 @@ func Handler(api CaptiveCoreAPI) http.Handler {
 	mux := supporthttp.NewMux(api.log)
 
 	mux.Get("/latest-sequence", func(w http.ResponseWriter, r *http.Request) {
-		response, err := api.GetLatestLedgerSequence()
+		response, err := api.GetLatestLedgerSequence(r.Context())
 		serializeResponse(api.log, w, r, response, err)
 	})
 
@@ -51,7 +51,7 @@ func Handler(api CaptiveCoreAPI) http.Handler {
 			return
 		}
 
-		response, err := api.GetLedger(req.Sequence)
+		response, err := api.GetLedger(r.Context(), req.Sequence)
 		serializeResponse(api.log, w, r, response, err)
 	})
 
@@ -63,7 +63,7 @@ func Handler(api CaptiveCoreAPI) http.Handler {
 			return
 		}
 
-		response, err := api.PrepareRange(ledgerRange)
+		response, err := api.PrepareRange(r.Context(), ledgerRange)
 		serializeResponse(api.log, w, r, response, err)
 	})
 

--- a/exp/services/captivecore/internal/server.go
+++ b/exp/services/captivecore/internal/server.go
@@ -39,7 +39,7 @@ func Handler(api CaptiveCoreAPI) http.Handler {
 	mux := supporthttp.NewMux(api.log)
 
 	mux.Get("/latest-sequence", func(w http.ResponseWriter, r *http.Request) {
-		response, err := api.GetLatestLedgerSequence(r.Context())
+		response, err := api.GetLatestLedgerSequence()
 		serializeResponse(api.log, w, r, response, err)
 	})
 
@@ -51,7 +51,7 @@ func Handler(api CaptiveCoreAPI) http.Handler {
 			return
 		}
 
-		response, err := api.GetLedger(r.Context(), req.Sequence)
+		response, err := api.GetLedger(req.Sequence)
 		serializeResponse(api.log, w, r, response, err)
 	})
 
@@ -63,7 +63,7 @@ func Handler(api CaptiveCoreAPI) http.Handler {
 			return
 		}
 
-		response, err := api.PrepareRange(r.Context(), ledgerRange)
+		response, err := api.PrepareRange(ledgerRange)
 		serializeResponse(api.log, w, r, response, err)
 	})
 

--- a/exp/services/captivecore/internal/server_test.go
+++ b/exp/services/captivecore/internal/server_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -35,6 +36,7 @@ func (s *ServerTestSuite) SetupTest() {
 	s.server = httptest.NewServer(s.handler)
 	var err error
 	s.client, err = ledgerbackend.NewRemoteCaptive(
+		context.Background(),
 		s.server.URL,
 		ledgerbackend.PrepareRangePollInterval(time.Millisecond),
 	)

--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"go/types"
 	"strings"
@@ -138,7 +139,7 @@ func main() {
 				if err != nil {
 					logger.WithError(err).Fatal("Could not create db connection instance")
 				}
-				captiveConfig.LedgerHashStore = ledgerbackend.NewHorizonDBLedgerHashStore(dbConn)
+				captiveConfig.LedgerHashStore = ledgerbackend.NewHorizonDBLedgerHashStore(context.Background(), dbConn)
 			}
 
 			core, err := ledgerbackend.NewCaptive(captiveConfig)

--- a/exp/tools/dump-ledger-state/main.go
+++ b/exp/tools/dump-ledger-state/main.go
@@ -78,7 +78,7 @@ func (processor csvProcessor) ProcessChange(change ingest.Change) error {
 	if !ok {
 		return nil
 	}
-	if err := processor.changeStats.ProcessChange(change); err != nil {
+	if err := processor.changeStats.ProcessChange(context.Background(), change); err != nil {
 		return err
 	}
 

--- a/handlers/federation/handler.go
+++ b/handlers/federation/handler.go
@@ -26,9 +26,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch typ {
 	case "name":
-		h.lookupByName(w, q)
+		h.lookupByName(w, r, q)
 	case "id":
-		h.lookupByID(w, q)
+		h.lookupByID(w, r, q)
 	case "forward":
 		h.lookupByForward(w, r.URL.Query())
 	case "txid":
@@ -55,7 +55,7 @@ func (h *Handler) failNotImplemented(w http.ResponseWriter, msg string) {
 	}, http.StatusNotImplemented)
 }
 
-func (h *Handler) lookupByID(w http.ResponseWriter, q string) {
+func (h *Handler) lookupByID(w http.ResponseWriter, r *http.Request, q string) {
 	rd, ok := h.Driver.(ReverseDriver)
 
 	if !ok {
@@ -65,7 +65,7 @@ func (h *Handler) lookupByID(w http.ResponseWriter, q string) {
 
 	// TODO: validate that `q` is a strkey encoded address
 
-	rec, err := rd.LookupReverseRecord(q)
+	rec, err := rd.LookupReverseRecord(r.Context(), q)
 	if err != nil {
 		h.writeError(w, errors.Wrap(err, "lookup record"))
 		return
@@ -81,7 +81,7 @@ func (h *Handler) lookupByID(w http.ResponseWriter, q string) {
 	}, http.StatusOK)
 }
 
-func (h *Handler) lookupByName(w http.ResponseWriter, q string) {
+func (h *Handler) lookupByName(w http.ResponseWriter, r *http.Request, q string) {
 	name, domain, err := address.Split(q)
 	if err != nil {
 		h.writeJSON(w, ErrorResponse{
@@ -91,7 +91,7 @@ func (h *Handler) lookupByName(w http.ResponseWriter, q string) {
 		return
 	}
 
-	rec, err := h.Driver.LookupRecord(name, domain)
+	rec, err := h.Driver.LookupRecord(r.Context(), name, domain)
 	if err != nil {
 		h.writeError(w, errors.Wrap(err, "lookupByName"))
 		return

--- a/handlers/federation/handler_test.go
+++ b/handlers/federation/handler_test.go
@@ -1,6 +1,7 @@
 package federation
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"testing"
@@ -200,7 +201,7 @@ func (fd ForwardTestDriver) LookupForwardingRecord(query url.Values) (*Record, e
 	}
 }
 
-func (fd ForwardTestDriver) LookupRecord(name string, domain string) (*Record, error) {
+func (fd ForwardTestDriver) LookupRecord(ctx context.Context, name string, domain string) (*Record, error) {
 	return nil, nil
 }
 

--- a/handlers/federation/main.go
+++ b/handlers/federation/main.go
@@ -11,6 +11,7 @@
 package federation
 
 import (
+	"context"
 	"database/sql"
 	"net/url"
 	"sync"
@@ -25,7 +26,7 @@ type Driver interface {
 	// federation request to lookup a `Record` using the provided stellar address.
 	// An implementation should return a nil `*Record` value if the lookup
 	// successfully executed but no result was found.
-	LookupRecord(name string, domain string) (*Record, error)
+	LookupRecord(ctx context.Context, name, domain string) (*Record, error)
 }
 
 // ErrorResponse represents the JSON response sent to a client when the request
@@ -65,7 +66,7 @@ type ReverseDriver interface {
 	// federation request to lookup a `ReverseRecord` using the provided strkey
 	// encoded accountID. An implementation should return a nil `*ReverseRecord`
 	// value if the lookup successfully executed but no result was found.
-	LookupReverseRecord(accountID string) (*ReverseRecord, error)
+	LookupReverseRecord(ctx context.Context, accountID string) (*ReverseRecord, error)
 }
 
 // ForwardDriver represents a data source against which forward queries can

--- a/handlers/federation/reverse_sql_driver.go
+++ b/handlers/federation/reverse_sql_driver.go
@@ -1,16 +1,21 @@
 package federation
 
-import "github.com/stellar/go/support/errors"
+import (
+	"context"
+
+	"github.com/stellar/go/support/errors"
+)
 
 // LookupReverseRecord implements `ReverseDriver` by performing
 // `drv.LookupReverseRecordQuery` against `drv.DB` using the provided parameter
 func (drv *ReverseSQLDriver) LookupReverseRecord(
+	ctx context.Context,
 	accountid string,
 ) (*ReverseRecord, error) {
 	drv.initDB()
 	var result ReverseRecord
 
-	err := drv.db.GetRaw(&result, drv.LookupReverseRecordQuery, accountid)
+	err := drv.db.GetRaw(ctx, &result, drv.LookupReverseRecordQuery, accountid)
 
 	if drv.db.NoRows(err) {
 		return nil, nil

--- a/handlers/federation/sql_driver.go
+++ b/handlers/federation/sql_driver.go
@@ -1,15 +1,19 @@
 package federation
 
-import "github.com/stellar/go/support/db"
-import "github.com/stellar/go/support/errors"
+import (
+	"context"
+
+	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/support/errors"
+)
 
 // LookupRecord implements `Driver` by performing `drv.LookupRecordQuery`
 // against `drv.DB` using the provided parameters
-func (drv *SQLDriver) LookupRecord(name, domain string) (*Record, error) {
+func (drv *SQLDriver) LookupRecord(ctx context.Context, name, domain string) (*Record, error) {
 	drv.initDB()
 	var result Record
 
-	err := drv.db.GetRaw(&result, drv.LookupRecordQuery, name, domain)
+	err := drv.db.GetRaw(ctx, &result, drv.LookupRecordQuery, name, domain)
 
 	if drv.db.NoRows(err) {
 		return nil, nil

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -650,8 +650,15 @@ func (c *CaptiveStellarCore) Close() error {
 	// after the CaptiveStellarCore context is canceled all subsequent calls to PrepareRange() will fail
 	c.cancel()
 
+	// TODO: Sucks to ignore the error here, but no worse than it was before,
+	// so...
+	if c.ledgerHashStore != nil {
+		c.ledgerHashStore.Close()
+	}
+
 	if c.stellarCoreRunner != nil {
 		return c.stellarCoreRunner.close()
 	}
+
 	return nil
 }

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -241,7 +241,7 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 	return nil
 }
 
-func (c *CaptiveStellarCore) openOnlineReplaySubprocess(ctx context.Context, from uint32) error {
+func (c *CaptiveStellarCore) openOnlineReplaySubprocess(from uint32) error {
 	latestCheckpointSequence, err := c.getLatestCheckpointSequence()
 	if err != nil {
 		return errors.Wrap(err, "error getting latest checkpoint sequence")
@@ -269,7 +269,7 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(ctx context.Context, fro
 		c.stellarCoreRunner = runner
 	}
 
-	runFrom, ledgerHash, nextLedger, err := c.runFromParams(ctx, from)
+	runFrom, ledgerHash, nextLedger, err := c.runFromParams(from)
 	if err != nil {
 		return errors.Wrap(err, "error calculating ledger and hash for stelar-core run")
 	}
@@ -300,7 +300,7 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(ctx context.Context, fro
 }
 
 // runFromParams receives a ledger sequence and calculates the required values to call stellar-core run with --start-ledger and --start-hash
-func (c *CaptiveStellarCore) runFromParams(ctx context.Context, from uint32) (runFrom uint32, ledgerHash string, nextLedger uint32, err error) {
+func (c *CaptiveStellarCore) runFromParams(from uint32) (runFrom uint32, ledgerHash string, nextLedger uint32, err error) {
 	if from == 1 {
 		// Trying to start-from 1 results in an error from Stellar-Core:
 		// Target ledger 1 is not newer than last closed ledger 1 - nothing to do
@@ -357,7 +357,7 @@ func (c *CaptiveStellarCore) runFromParams(ctx context.Context, from uint32) (ru
 	return
 }
 
-func (c *CaptiveStellarCore) startPreparingRange(ctx context.Context, ledgerRange Range) (bool, error) {
+func (c *CaptiveStellarCore) startPreparingRange(ledgerRange Range) (bool, error) {
 	c.stellarCoreLock.Lock()
 	defer c.stellarCoreLock.Unlock()
 
@@ -375,7 +375,7 @@ func (c *CaptiveStellarCore) startPreparingRange(ctx context.Context, ledgerRang
 	if ledgerRange.bounded {
 		err = c.openOfflineReplaySubprocess(ledgerRange.from, ledgerRange.to)
 	} else {
-		err = c.openOnlineReplaySubprocess(ctx, ledgerRange.from)
+		err = c.openOnlineReplaySubprocess(ledgerRange.from)
 	}
 	if err != nil {
 		return false, errors.Wrap(err, "opening subprocess")
@@ -394,8 +394,7 @@ func (c *CaptiveStellarCore) startPreparingRange(ctx context.Context, ledgerRang
 // Please note that using a BoundedRange, currently, requires a full-trust on
 // history archive. This issue is being fixed in Stellar-Core.
 func (c *CaptiveStellarCore) PrepareRange(ledgerRange Range) error {
-	ctx := context.TODO()
-	if alreadyPrepared, err := c.startPreparingRange(ctx, ledgerRange); err != nil {
+	if alreadyPrepared, err := c.startPreparingRange(ledgerRange); err != nil {
 		return errors.Wrap(err, "error starting prepare range")
 	} else if alreadyPrepared {
 		return nil

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -162,10 +162,11 @@ func TestCaptivePrepareRange(t *testing.T) {
 		}
 	}
 
+	ctx := context.Background()
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(100), uint32(200)).Return(nil).Once()
 	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
-	mockRunner.On("context").Return(context.Background())
+	mockRunner.On("context").Return(ctx)
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -199,12 +200,13 @@ func TestCaptivePrepareRange(t *testing.T) {
 func TestCaptivePrepareRangeCrash(t *testing.T) {
 	metaChan := make(chan metaResult)
 	close(metaChan)
+	ctx := context.Background()
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(100), uint32(200)).Return(nil).Once()
 	mockRunner.On("getProcessExitError").Return(true, errors.New("exit code -1"))
 	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
 	mockRunner.On("close").Return(nil).Once()
-	mockRunner.On("context").Return(context.Background())
+	mockRunner.On("context").Return(ctx)
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -239,10 +241,11 @@ func TestCaptivePrepareRangeTerminated(t *testing.T) {
 		}
 	}
 	close(metaChan)
+	ctx := context.Background()
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(100), uint32(200)).Return(nil).Once()
 	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
-	mockRunner.On("context").Return(context.Background())
+	mockRunner.On("context").Return(ctx)
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -266,9 +269,10 @@ func TestCaptivePrepareRangeTerminated(t *testing.T) {
 }
 
 func TestCaptivePrepareRange_ErrClosingSession(t *testing.T) {
+	ctx := context.Background()
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("close").Return(fmt.Errorf("transient error"))
-	mockRunner.On("context").Return(context.Background())
+	mockRunner.On("context").Return(ctx)
 
 	captiveBackend := CaptiveStellarCore{
 		nextLedger:        300,
@@ -336,10 +340,11 @@ func TestCaptivePrepareRange_ToIsAheadOfRootHAS(t *testing.T) {
 		}
 	}
 
+	ctx := context.Background()
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(100), uint32(192)).Return(nil).Once()
 	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
-	mockRunner.On("context").Return(context.Background())
+	mockRunner.On("context").Return(ctx)
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -448,10 +453,11 @@ func TestCaptivePrepareRangeUnboundedRange_ReuseSession(t *testing.T) {
 		}
 	}
 
+	ctx := context.Background()
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("runFrom", uint32(62), "0000000000000000000000000000000000000000000000000000000000000000").Return(nil).Once()
 	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
-	mockRunner.On("context").Return(context.Background())
+	mockRunner.On("context").Return(ctx)
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -494,10 +500,11 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 		}
 	}
 
+	ctx := context.Background()
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("runFrom", uint32(62), "0000000000000000000000000000000000000000000000000000000000000000").Return(nil).Once()
 	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
-	mockRunner.On("context").Return(context.Background())
+	mockRunner.On("context").Return(ctx)
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -540,7 +547,8 @@ func TestCaptiveGetLedger(t *testing.T) {
 		}
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(65), uint32(66)).Return(nil)
 	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
@@ -685,10 +693,11 @@ func TestCaptiveGetLedger_NextLedgerIsDifferentToLedgerFromBuffer(t *testing.T) 
 		}
 	}
 
+	ctx := context.Background()
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(65), uint32(66)).Return(nil)
 	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
-	mockRunner.On("context").Return(context.Background())
+	mockRunner.On("context").Return(ctx)
 	mockRunner.On("close").Return(nil)
 
 	mockArchive := &historyarchive.MockArchive{}
@@ -769,10 +778,11 @@ func TestCaptiveGetLedger_ErrReadingMetaResult(t *testing.T) {
 		err: fmt.Errorf("unmarshalling error"),
 	}
 
+	ctx := context.Background()
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(65), uint32(66)).Return(nil)
 	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	mockRunner.On("context").Return(ctx)
 	mockRunner.On("getProcessExitError").Return(false, nil)
 	mockRunner.On("close").Return(nil).Run(func(args mock.Arguments) {
@@ -825,10 +835,11 @@ func TestCaptiveGetLedger_ErrClosingAfterLastLedger(t *testing.T) {
 		}
 	}
 
+	ctx := context.Background()
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(65), uint32(66)).Return(nil)
 	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
-	mockRunner.On("context").Return(context.Background())
+	mockRunner.On("context").Return(ctx)
 	mockRunner.On("close").Return(fmt.Errorf("transient error")).Once()
 
 	mockArchive := &historyarchive.MockArchive{}
@@ -920,10 +931,11 @@ func TestGetLedgerBoundsCheck(t *testing.T) {
 		}
 	}
 
+	ctx := context.Background()
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("catchup", uint32(128), uint32(130)).Return(nil).Once()
 	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
-	mockRunner.On("context").Return(context.Background())
+	mockRunner.On("context").Return(ctx)
 
 	mockArchive := &historyarchive.MockArchive{}
 	mockArchive.
@@ -1021,10 +1033,11 @@ func TestCaptiveGetLedgerTerminatedUnexpectedly(t *testing.T) {
 			}
 			close(metaChan)
 
+			ctx := testCase.ctx
 			mockRunner := &stellarCoreRunnerMock{}
 			mockRunner.On("catchup", uint32(64), uint32(100)).Return(nil).Once()
 			mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
-			mockRunner.On("context").Return(context.Background())
+			mockRunner.On("context").Return(ctx)
 			mockRunner.On("getProcessExitError").Return(testCase.processExited, testCase.processExitedError)
 			mockRunner.On("close").Return(nil).Once()
 
@@ -1070,6 +1083,7 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 			},
 		}, nil)
 
+	ctx := context.Background()
 	mockLedgerHashStore := &MockLedgerHashStore{}
 	mockLedgerHashStore.On("GetLedgerHash", uint32(1022)).
 		Return("", false, fmt.Errorf("transient error")).Once()
@@ -1088,28 +1102,28 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
-	runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(24)
+	runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(ctx, 24)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(2), runFrom)
 	assert.Equal(t, "mnb", ledgerHash)
 	assert.Equal(t, uint32(2), nextLedger)
 
-	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(86)
+	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(ctx, 86)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(62), runFrom)
 	assert.Equal(t, "cde", ledgerHash)
 	assert.Equal(t, uint32(2), nextLedger)
 
-	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(128)
+	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(ctx, 128)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(126), runFrom)
 	assert.Equal(t, "ghi", ledgerHash)
 	assert.Equal(t, uint32(64), nextLedger)
 
-	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(1050)
+	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(ctx, 1050)
 	assert.EqualError(t, err, "error trying to read ledger hash 1022: transient error")
 
-	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(300)
+	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(ctx, 300)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(254), runFrom, "runFrom")
 	assert.Equal(t, "0101010100000000000000000000000000000000000000000000000000000000", ledgerHash)
@@ -1149,6 +1163,7 @@ func TestCaptiveRunFromParams(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("from_%d", tc.from), func(t *testing.T) {
 			tt := assert.New(t)
+			ctx := context.Background()
 			mockArchive := &historyarchive.MockArchive{}
 			mockArchive.
 				On("GetLedgerHeader", uint32(tc.ledgerArchives)).
@@ -1163,7 +1178,7 @@ func TestCaptiveRunFromParams(t *testing.T) {
 				checkpointManager: historyarchive.NewCheckpointManager(64),
 			}
 
-			runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(tc.from)
+			runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(ctx, tc.from)
 			tt.NoError(err)
 			tt.Equal(tc.runFrom, runFrom, "runFrom")
 			tt.Equal("0101010100000000000000000000000000000000000000000000000000000000", ledgerHash)
@@ -1249,10 +1264,11 @@ func TestCaptivePreviousLedgerCheck(t *testing.T) {
 
 	}
 
+	ctx := context.Background()
 	mockRunner := &stellarCoreRunnerMock{}
 	mockRunner.On("runFrom", uint32(254), "0101010100000000000000000000000000000000000000000000000000000000").Return(nil).Once()
 	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
-	mockRunner.On("context").Return(context.Background())
+	mockRunner.On("context").Return(ctx)
 	mockRunner.On("close").Return(nil).Once()
 
 	mockArchive := &historyarchive.MockArchive{}

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -1083,7 +1083,6 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 			},
 		}, nil)
 
-	ctx := context.Background()
 	mockLedgerHashStore := &MockLedgerHashStore{}
 	mockLedgerHashStore.On("GetLedgerHash", uint32(1022)).
 		Return("", false, fmt.Errorf("transient error")).Once()
@@ -1102,28 +1101,28 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 		checkpointManager: historyarchive.NewCheckpointManager(64),
 	}
 
-	runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(ctx, 24)
+	runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(24)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(2), runFrom)
 	assert.Equal(t, "mnb", ledgerHash)
 	assert.Equal(t, uint32(2), nextLedger)
 
-	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(ctx, 86)
+	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(86)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(62), runFrom)
 	assert.Equal(t, "cde", ledgerHash)
 	assert.Equal(t, uint32(2), nextLedger)
 
-	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(ctx, 128)
+	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(128)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(126), runFrom)
 	assert.Equal(t, "ghi", ledgerHash)
 	assert.Equal(t, uint32(64), nextLedger)
 
-	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(ctx, 1050)
+	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(1050)
 	assert.EqualError(t, err, "error trying to read ledger hash 1022: transient error")
 
-	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(ctx, 300)
+	runFrom, ledgerHash, nextLedger, err = captiveBackend.runFromParams(300)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(254), runFrom, "runFrom")
 	assert.Equal(t, "0101010100000000000000000000000000000000000000000000000000000000", ledgerHash)
@@ -1163,7 +1162,6 @@ func TestCaptiveRunFromParams(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("from_%d", tc.from), func(t *testing.T) {
 			tt := assert.New(t)
-			ctx := context.Background()
 			mockArchive := &historyarchive.MockArchive{}
 			mockArchive.
 				On("GetLedgerHeader", uint32(tc.ledgerArchives)).
@@ -1178,7 +1176,7 @@ func TestCaptiveRunFromParams(t *testing.T) {
 				checkpointManager: historyarchive.NewCheckpointManager(64),
 			}
 
-			runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(ctx, tc.from)
+			runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(tc.from)
 			tt.NoError(err)
 			tt.Equal(tc.runFrom, runFrom, "runFrom")
 			tt.Equal("0101010100000000000000000000000000000000000000000000000000000000", ledgerHash)

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -1095,10 +1095,14 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 	mockLedgerHashStore.On("GetLedgerHash", uint32(2)).
 		Return("mnb", true, nil).Once()
 
+	cancelCalled := false
 	captiveBackend := CaptiveStellarCore{
 		archive:           mockArchive,
 		ledgerHashStore:   mockLedgerHashStore,
 		checkpointManager: historyarchive.NewCheckpointManager(64),
+		cancel: context.CancelFunc(func() {
+			cancelCalled = true
+		}),
 	}
 
 	runFrom, ledgerHash, nextLedger, err := captiveBackend.runFromParams(24)
@@ -1128,6 +1132,10 @@ func TestCaptiveUseOfLedgerHashStore(t *testing.T) {
 	assert.Equal(t, "0101010100000000000000000000000000000000000000000000000000000000", ledgerHash)
 	assert.Equal(t, uint32(192), nextLedger, "nextLedger")
 
+	mockLedgerHashStore.On("Close").Return(nil).Once()
+	err = captiveBackend.Close()
+	assert.NoError(t, err)
+	assert.True(t, cancelCalled)
 	mockLedgerHashStore.AssertExpectations(t)
 	mockArchive.AssertExpectations(t)
 }

--- a/ingest/ledgerbackend/database_backend.go
+++ b/ingest/ledgerbackend/database_backend.go
@@ -1,6 +1,7 @@
 package ledgerbackend
 
 import (
+	"context"
 	"database/sql"
 	"sort"
 	"time"
@@ -74,8 +75,9 @@ func (*DatabaseBackend) IsPrepared(ledgerRange Range) (bool, error) {
 
 // GetLatestLedgerSequence returns the most recent ledger sequence number present in the database.
 func (dbb *DatabaseBackend) GetLatestLedgerSequence() (uint32, error) {
+	ctx := context.TODO()
 	var ledger []ledgerHeader
-	err := dbb.session.SelectRaw(&ledger, latestLedgerSeqQuery)
+	err := dbb.session.SelectRaw(ctx, &ledger, latestLedgerSeqQuery)
 	if err != nil {
 		return 0, errors.Wrap(err, "couldn't select ledger sequence")
 	}
@@ -140,6 +142,7 @@ func (dbb *DatabaseBackend) GetLedgerBlocking(sequence uint32) (xdr.LedgerCloseM
 // GetLedger returns the LedgerCloseMeta for the given ledger sequence number.
 // The first returned value is false when the ledger does not exist in the database.
 func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMeta, error) {
+	ctx := context.TODO()
 	lcm := xdr.LedgerCloseMeta{
 		V0: &xdr.LedgerCloseMetaV0{},
 	}
@@ -147,7 +150,7 @@ func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMet
 	// Query - ledgerheader
 	var lRow ledgerHeaderHistory
 
-	err := dbb.session.GetRaw(&lRow, ledgerHeaderQuery, sequence)
+	err := dbb.session.GetRaw(ctx, &lRow, ledgerHeaderQuery, sequence)
 	// Return errors...
 	if err != nil {
 		switch err {
@@ -168,7 +171,7 @@ func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMet
 
 	// Query - txhistory
 	var txhRows []txHistory
-	err = dbb.session.SelectRaw(&txhRows, txHistoryQuery+orderBy, sequence)
+	err = dbb.session.SelectRaw(ctx, &txhRows, txHistoryQuery+orderBy, sequence)
 	// Return errors...
 	if err != nil {
 		return false, lcm, errors.Wrap(err, "Error getting txHistory")
@@ -194,7 +197,7 @@ func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMet
 
 	// Query - txfeehistory
 	var txfhRows []txFeeHistory
-	err = dbb.session.SelectRaw(&txfhRows, txFeeHistoryQuery+orderBy, sequence)
+	err = dbb.session.SelectRaw(ctx, &txfhRows, txFeeHistoryQuery+orderBy, sequence)
 	// Return errors...
 	if err != nil {
 		return false, lcm, errors.Wrap(err, "Error getting txFeeHistory")
@@ -211,7 +214,7 @@ func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMet
 
 	// Query - upgradehistory
 	var upgradeHistoryRows []upgradeHistory
-	err = dbb.session.SelectRaw(&upgradeHistoryRows, upgradeHistoryQuery, sequence)
+	err = dbb.session.SelectRaw(ctx, &upgradeHistoryRows, upgradeHistoryQuery, sequence)
 	// Return errors...
 	if err != nil {
 		return false, lcm, errors.Wrap(err, "Error getting upgradeHistoryRows")

--- a/ingest/ledgerbackend/database_backend.go
+++ b/ingest/ledgerbackend/database_backend.go
@@ -33,19 +33,19 @@ type DatabaseBackend struct {
 	session           session
 }
 
-func NewDatabaseBackend(dataSourceName, networkPassphrase string) (*DatabaseBackend, error) {
+func NewDatabaseBackend(ctx context.Context, dataSourceName, networkPassphrase string) (*DatabaseBackend, error) {
 	session, err := createSession(dataSourceName)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewDatabaseBackendFromSession(session, networkPassphrase)
+	return NewDatabaseBackendFromSession(ctx, session, networkPassphrase)
 }
 
-func NewDatabaseBackendFromSession(session *db.Session, networkPassphrase string) (*DatabaseBackend, error) {
+func NewDatabaseBackendFromSession(ctx context.Context, session *db.Session, networkPassphrase string) (*DatabaseBackend, error) {
 	// TODO: To avoid changing the LedgerBackend interface in this call we create
 	// a context once for this, so that Close() can cancel any in-progress method-calls.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 
 	return &DatabaseBackend{
 		cancel:            cancel,

--- a/ingest/ledgerbackend/database_backend.go
+++ b/ingest/ledgerbackend/database_backend.go
@@ -27,6 +27,8 @@ var _ LedgerBackend = (*DatabaseBackend)(nil)
 
 // DatabaseBackend implements a database data store.
 type DatabaseBackend struct {
+	cancel            context.CancelFunc
+	ctx               context.Context
 	networkPassphrase string
 	session           session
 }
@@ -37,11 +39,20 @@ func NewDatabaseBackend(dataSourceName, networkPassphrase string) (*DatabaseBack
 		return nil, err
 	}
 
-	return &DatabaseBackend{session: session, networkPassphrase: networkPassphrase}, nil
+	return NewDatabaseBackendFromSession(session, networkPassphrase)
 }
 
 func NewDatabaseBackendFromSession(session *db.Session, networkPassphrase string) (*DatabaseBackend, error) {
-	return &DatabaseBackend{session: session, networkPassphrase: networkPassphrase}, nil
+	// TODO: To avoid changing the LedgerBackend interface in this call we create
+	// a context once for this, so that Close() can cancel any in-progress method-calls.
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &DatabaseBackend{
+		cancel:            cancel,
+		ctx:               ctx,
+		session:           session,
+		networkPassphrase: networkPassphrase,
+	}, nil
 }
 
 func (dbb *DatabaseBackend) PrepareRange(ledgerRange Range) error {
@@ -75,9 +86,8 @@ func (*DatabaseBackend) IsPrepared(ledgerRange Range) (bool, error) {
 
 // GetLatestLedgerSequence returns the most recent ledger sequence number present in the database.
 func (dbb *DatabaseBackend) GetLatestLedgerSequence() (uint32, error) {
-	ctx := context.TODO()
 	var ledger []ledgerHeader
-	err := dbb.session.SelectRaw(ctx, &ledger, latestLedgerSeqQuery)
+	err := dbb.session.SelectRaw(dbb.ctx, &ledger, latestLedgerSeqQuery)
 	if err != nil {
 		return 0, errors.Wrap(err, "couldn't select ledger sequence")
 	}
@@ -142,7 +152,6 @@ func (dbb *DatabaseBackend) GetLedgerBlocking(sequence uint32) (xdr.LedgerCloseM
 // GetLedger returns the LedgerCloseMeta for the given ledger sequence number.
 // The first returned value is false when the ledger does not exist in the database.
 func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMeta, error) {
-	ctx := context.TODO()
 	lcm := xdr.LedgerCloseMeta{
 		V0: &xdr.LedgerCloseMetaV0{},
 	}
@@ -150,7 +159,7 @@ func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMet
 	// Query - ledgerheader
 	var lRow ledgerHeaderHistory
 
-	err := dbb.session.GetRaw(ctx, &lRow, ledgerHeaderQuery, sequence)
+	err := dbb.session.GetRaw(dbb.ctx, &lRow, ledgerHeaderQuery, sequence)
 	// Return errors...
 	if err != nil {
 		switch err {
@@ -171,7 +180,7 @@ func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMet
 
 	// Query - txhistory
 	var txhRows []txHistory
-	err = dbb.session.SelectRaw(ctx, &txhRows, txHistoryQuery+orderBy, sequence)
+	err = dbb.session.SelectRaw(dbb.ctx, &txhRows, txHistoryQuery+orderBy, sequence)
 	// Return errors...
 	if err != nil {
 		return false, lcm, errors.Wrap(err, "Error getting txHistory")
@@ -197,7 +206,7 @@ func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMet
 
 	// Query - txfeehistory
 	var txfhRows []txFeeHistory
-	err = dbb.session.SelectRaw(ctx, &txfhRows, txFeeHistoryQuery+orderBy, sequence)
+	err = dbb.session.SelectRaw(dbb.ctx, &txfhRows, txFeeHistoryQuery+orderBy, sequence)
 	// Return errors...
 	if err != nil {
 		return false, lcm, errors.Wrap(err, "Error getting txFeeHistory")
@@ -214,7 +223,7 @@ func (dbb *DatabaseBackend) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMet
 
 	// Query - upgradehistory
 	var upgradeHistoryRows []upgradeHistory
-	err = dbb.session.SelectRaw(ctx, &upgradeHistoryRows, upgradeHistoryQuery, sequence)
+	err = dbb.session.SelectRaw(dbb.ctx, &upgradeHistoryRows, upgradeHistoryQuery, sequence)
 	// Return errors...
 	if err != nil {
 		return false, lcm, errors.Wrap(err, "Error getting upgradeHistoryRows")
@@ -243,5 +252,6 @@ func createSession(dataSourceName string) (*db.Session, error) {
 
 // Close disconnects an active database session.
 func (dbb *DatabaseBackend) Close() error {
+	dbb.cancel()
 	return dbb.session.Close()
 }

--- a/ingest/ledgerbackend/ledger_backend.go
+++ b/ingest/ledgerbackend/ledger_backend.go
@@ -1,6 +1,8 @@
 package ledgerbackend
 
 import (
+	"context"
+
 	"github.com/stellar/go/xdr"
 )
 
@@ -25,8 +27,8 @@ type LedgerBackend interface {
 // session is the interface needed to access a persistent database session.
 // TODO can't use this until we add Close() to the existing db.Session object
 type session interface {
-	GetRaw(dest interface{}, query string, args ...interface{}) error
-	SelectRaw(dest interface{}, query string, args ...interface{}) error
+	GetRaw(ctx context.Context, dest interface{}, query string, args ...interface{}) error
+	SelectRaw(ctx context.Context, dest interface{}, query string, args ...interface{}) error
 	Close() error
 }
 

--- a/ingest/ledgerbackend/ledger_hash_store.go
+++ b/ingest/ledgerbackend/ledger_hash_store.go
@@ -1,6 +1,8 @@
 package ledgerbackend
 
 import (
+	"context"
+
 	sq "github.com/Masterminds/squirrel"
 	"github.com/stretchr/testify/mock"
 
@@ -27,11 +29,12 @@ func NewHorizonDBLedgerHashStore(session *db.Session) TrustedLedgerHashStore {
 
 // GetLedgerHash returns the ledger hash for the given sequence number
 func (h HorizonDBLedgerHashStore) GetLedgerHash(seq uint32) (string, bool, error) {
+	ctx := context.TODO()
 	sql := sq.Select("hl.ledger_hash").From("history_ledgers hl").
 		Limit(1).Where("sequence = ?", seq)
 
 	var hash string
-	err := h.session.Get(&hash, sql)
+	err := h.session.Get(ctx, &hash, sql)
 	if h.session.NoRows(err) {
 		return hash, false, nil
 	}

--- a/ingest/ledgerbackend/ledger_hash_store.go
+++ b/ingest/ledgerbackend/ledger_hash_store.go
@@ -15,30 +15,42 @@ import (
 type TrustedLedgerHashStore interface {
 	// GetLedgerHash returns the ledger hash for the given sequence number
 	GetLedgerHash(seq uint32) (string, bool, error)
+	Close() error
 }
 
 // HorizonDBLedgerHashStore is a TrustedLedgerHashStore which uses horizon's db to look up ledger hashes
 type HorizonDBLedgerHashStore struct {
+	cancel  context.CancelFunc
+	ctx     context.Context
 	session *db.Session
 }
 
 // NewHorizonDBLedgerHashStore constructs a new TrustedLedgerHashStore backed by the horizon db
 func NewHorizonDBLedgerHashStore(session *db.Session) TrustedLedgerHashStore {
-	return HorizonDBLedgerHashStore{session: session}
+	ctx, cancel := context.WithCancel(context.Background())
+	return HorizonDBLedgerHashStore{
+		cancel:  cancel,
+		ctx:     ctx,
+		session: session,
+	}
 }
 
 // GetLedgerHash returns the ledger hash for the given sequence number
 func (h HorizonDBLedgerHashStore) GetLedgerHash(seq uint32) (string, bool, error) {
-	ctx := context.TODO()
 	sql := sq.Select("hl.ledger_hash").From("history_ledgers hl").
 		Limit(1).Where("sequence = ?", seq)
 
 	var hash string
-	err := h.session.Get(ctx, &hash, sql)
+	err := h.session.Get(h.ctx, &hash, sql)
 	if h.session.NoRows(err) {
 		return hash, false, nil
 	}
 	return hash, true, err
+}
+
+func (h HorizonDBLedgerHashStore) Close() error {
+	h.cancel()
+	return h.session.Close()
 }
 
 // MockLedgerHashStore is a mock implementation of TrustedLedgerHashStore
@@ -50,4 +62,9 @@ type MockLedgerHashStore struct {
 func (m *MockLedgerHashStore) GetLedgerHash(seq uint32) (string, bool, error) {
 	args := m.Called(seq)
 	return args.Get(0).(string), args.Get(1).(bool), args.Error(2)
+}
+
+func (m *MockLedgerHashStore) Close() error {
+	args := m.Called()
+	return args.Error(0)
 }

--- a/ingest/ledgerbackend/ledger_hash_store.go
+++ b/ingest/ledgerbackend/ledger_hash_store.go
@@ -26,8 +26,8 @@ type HorizonDBLedgerHashStore struct {
 }
 
 // NewHorizonDBLedgerHashStore constructs a new TrustedLedgerHashStore backed by the horizon db
-func NewHorizonDBLedgerHashStore(session *db.Session) TrustedLedgerHashStore {
-	ctx, cancel := context.WithCancel(context.Background())
+func NewHorizonDBLedgerHashStore(ctx context.Context, session *db.Session) TrustedLedgerHashStore {
+	ctx, cancel := context.WithCancel(ctx)
 	return HorizonDBLedgerHashStore{
 		cancel:  cancel,
 		ctx:     ctx,

--- a/ingest/ledgerbackend/mock_database_backend.go
+++ b/ingest/ledgerbackend/mock_database_backend.go
@@ -1,8 +1,9 @@
 package ledgerbackend
 
 import (
-	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/stellar/go/xdr"
 )
 
 var _ LedgerBackend = (*MockDatabaseBackend)(nil)

--- a/ingest/ledgerbackend/remote_captive_core.go
+++ b/ingest/ledgerbackend/remote_captive_core.go
@@ -67,6 +67,7 @@ type RemoteCaptiveStellarCore struct {
 	client                   *http.Client
 	lock                     *sync.Mutex
 	cancel                   context.CancelFunc
+	parentCtx                context.Context
 	prepareRangePollInterval time.Duration
 }
 
@@ -84,7 +85,7 @@ func PrepareRangePollInterval(d time.Duration) RemoteCaptiveOption {
 // NewRemoteCaptive returns a new RemoteCaptiveStellarCore instance.
 //
 // Only the captiveCoreURL parameter is required.
-func NewRemoteCaptive(captiveCoreURL string, options ...RemoteCaptiveOption) (RemoteCaptiveStellarCore, error) {
+func NewRemoteCaptive(ctx context.Context, captiveCoreURL string, options ...RemoteCaptiveOption) (RemoteCaptiveStellarCore, error) {
 	u, err := url.Parse(captiveCoreURL)
 	if err != nil {
 		return RemoteCaptiveStellarCore{}, errors.Wrap(err, "unparseable url")
@@ -95,6 +96,7 @@ func NewRemoteCaptive(captiveCoreURL string, options ...RemoteCaptiveOption) (Re
 		url:                      u,
 		client:                   &http.Client{Timeout: 5 * time.Second},
 		lock:                     &sync.Mutex{},
+		parentCtx:                ctx,
 	}
 	for _, option := range options {
 		option(&client)
@@ -160,11 +162,13 @@ func (c RemoteCaptiveStellarCore) createContext() context.Context {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
+	// Cancel any outstanding PrepareRange request
 	if c.cancel != nil {
 		c.cancel()
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	// Make a new context for this new request.
+	ctx, cancel := context.WithCancel(c.parentCtx)
 	c.cancel = cancel
 	return ctx
 }

--- a/ingest/ledgerbackend/remote_captive_core.go
+++ b/ingest/ledgerbackend/remote_captive_core.go
@@ -128,17 +128,12 @@ func decodeResponse(response *http.Response, payload interface{}) error {
 // the latest sequence closed by the network. It's always the last value available
 // in the backend.
 func (c RemoteCaptiveStellarCore) GetLatestLedgerSequence() (sequence uint32, err error) {
-	// TODO: Should we use c.createContext here?
-	ctx := context.TODO()
+	// TODO: Have a context on this request so we can cancel all outstanding
+	// requests, not just PrepareRange.
 	u := *c.url
 	u.Path = path.Join(u.Path, "latest-sequence")
 
-	request, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to build request")
-	}
-
-	response, err := c.client.Do(request)
+	response, err := c.client.Get(u.String())
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to execute request")
 	}
@@ -161,7 +156,7 @@ func (c RemoteCaptiveStellarCore) Close() error {
 	return nil
 }
 
-func (c RemoteCaptiveStellarCore) createContext(background context.Context) context.Context {
+func (c RemoteCaptiveStellarCore) createContext() context.Context {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -169,7 +164,7 @@ func (c RemoteCaptiveStellarCore) createContext(background context.Context) cont
 		c.cancel()
 	}
 
-	ctx, cancel := context.WithCancel(background)
+	ctx, cancel := context.WithCancel(context.Background())
 	c.cancel = cancel
 	return ctx
 }
@@ -184,7 +179,7 @@ func (c RemoteCaptiveStellarCore) createContext(background context.Context) cont
 // Please note that using a BoundedRange, currently, requires a full-trust on
 // history archive. This issue is being fixed in Stellar-Core.
 func (c RemoteCaptiveStellarCore) PrepareRange(ledgerRange Range) error {
-	ctx := c.createContext(context.TODO())
+	ctx := c.createContext()
 	u := *c.url
 	u.Path = path.Join(u.Path, "prepare-range")
 	rangeBytes, err := json.Marshal(ledgerRange)
@@ -227,8 +222,8 @@ func (c RemoteCaptiveStellarCore) PrepareRange(ledgerRange Range) error {
 
 // IsPrepared returns true if a given ledgerRange is prepared.
 func (c RemoteCaptiveStellarCore) IsPrepared(ledgerRange Range) (bool, error) {
-	ctx := c.createContext(context.TODO())
-
+	// TODO: Have a context on this request so we can cancel all outstanding
+	// requests, not just PrepareRange.
 	u := *c.url
 	u.Path = path.Join(u.Path, "prepare-range")
 	rangeBytes, err := json.Marshal(ledgerRange)
@@ -236,14 +231,9 @@ func (c RemoteCaptiveStellarCore) IsPrepared(ledgerRange Range) (bool, error) {
 		return false, errors.Wrap(err, "cannot serialize range")
 	}
 	body := bytes.NewReader(rangeBytes)
-	req, err := http.NewRequestWithContext(ctx, "POST", u.String(), body)
-	if err != nil {
-		return false, errors.Wrap(err, "failed to build request")
-	}
-	req.Header.Add("Content-Type", "application/json; charset=utf-8")
 
 	var response *http.Response
-	response, err = c.client.Do(req)
+	response, err = c.client.Post(u.String(), "application/json; charset=utf-8", body)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to execute request")
 	}
@@ -274,16 +264,12 @@ func (c RemoteCaptiveStellarCore) IsPrepared(ledgerRange Range) (bool, error) {
 //     the first argument equal false.
 // This is done to provide maximum performance when streaming old ledgers.
 func (c RemoteCaptiveStellarCore) GetLedger(sequence uint32) (bool, xdr.LedgerCloseMeta, error) {
-	ctx := c.createContext(context.TODO())
-
+	// TODO: Have a context on this request so we can cancel all outstanding
+	// requests, not just PrepareRange.
 	u := *c.url
 	u.Path = path.Join(u.Path, "ledger", strconv.FormatUint(uint64(sequence), 10))
-	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
-	if err != nil {
-		return false, xdr.LedgerCloseMeta{}, errors.Wrap(err, "failed to build request")
-	}
 
-	response, err := c.client.Do(req)
+	response, err := c.client.Get(u.String())
 	if err != nil {
 		return false, xdr.LedgerCloseMeta{}, errors.Wrap(err, "failed to execute request")
 	}

--- a/ingest/stats_change_processor.go
+++ b/ingest/stats_change_processor.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"context"
 	"github.com/stellar/go/xdr"
 )
 
@@ -33,7 +34,7 @@ type StatsChangeProcessorResults struct {
 	TrustLinesRemoved int64
 }
 
-func (p *StatsChangeProcessor) ProcessChange(change Change) error {
+func (p *StatsChangeProcessor) ProcessChange(ctx context.Context, change Change) error {
 	switch change.Type {
 	case xdr.LedgerEntryTypeAccount:
 		switch change.LedgerEntryChangeType() {

--- a/ingest/stats_change_processor_test.go
+++ b/ingest/stats_change_processor_test.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stellar/go/xdr"
@@ -8,96 +9,97 @@ import (
 )
 
 func TestStatsChangeProcessor(t *testing.T) {
+	ctx := context.Background()
 	processor := &StatsChangeProcessor{}
 
 	// Created
-	assert.NoError(t, processor.ProcessChange(Change{
+	assert.NoError(t, processor.ProcessChange(ctx, Change{
 		Type: xdr.LedgerEntryTypeAccount,
 		Pre:  nil,
 		Post: &xdr.LedgerEntry{},
 	}))
 
-	assert.NoError(t, processor.ProcessChange(Change{
+	assert.NoError(t, processor.ProcessChange(ctx, Change{
 		Type: xdr.LedgerEntryTypeClaimableBalance,
 		Pre:  nil,
 		Post: &xdr.LedgerEntry{},
 	}))
 
-	assert.NoError(t, processor.ProcessChange(Change{
+	assert.NoError(t, processor.ProcessChange(ctx, Change{
 		Type: xdr.LedgerEntryTypeData,
 		Pre:  nil,
 		Post: &xdr.LedgerEntry{},
 	}))
 
-	assert.NoError(t, processor.ProcessChange(Change{
+	assert.NoError(t, processor.ProcessChange(ctx, Change{
 		Type: xdr.LedgerEntryTypeOffer,
 		Pre:  nil,
 		Post: &xdr.LedgerEntry{},
 	}))
 
-	assert.NoError(t, processor.ProcessChange(Change{
+	assert.NoError(t, processor.ProcessChange(ctx, Change{
 		Type: xdr.LedgerEntryTypeTrustline,
 		Pre:  nil,
 		Post: &xdr.LedgerEntry{},
 	}))
 
 	// Updated
-	assert.NoError(t, processor.ProcessChange(Change{
+	assert.NoError(t, processor.ProcessChange(ctx, Change{
 		Type: xdr.LedgerEntryTypeAccount,
 		Pre:  &xdr.LedgerEntry{},
 		Post: &xdr.LedgerEntry{},
 	}))
 
-	assert.NoError(t, processor.ProcessChange(Change{
+	assert.NoError(t, processor.ProcessChange(ctx, Change{
 		Type: xdr.LedgerEntryTypeClaimableBalance,
 		Pre:  &xdr.LedgerEntry{},
 		Post: &xdr.LedgerEntry{},
 	}))
 
-	assert.NoError(t, processor.ProcessChange(Change{
+	assert.NoError(t, processor.ProcessChange(ctx, Change{
 		Type: xdr.LedgerEntryTypeData,
 		Pre:  &xdr.LedgerEntry{},
 		Post: &xdr.LedgerEntry{},
 	}))
 
-	assert.NoError(t, processor.ProcessChange(Change{
+	assert.NoError(t, processor.ProcessChange(ctx, Change{
 		Type: xdr.LedgerEntryTypeOffer,
 		Pre:  &xdr.LedgerEntry{},
 		Post: &xdr.LedgerEntry{},
 	}))
 
-	assert.NoError(t, processor.ProcessChange(Change{
+	assert.NoError(t, processor.ProcessChange(ctx, Change{
 		Type: xdr.LedgerEntryTypeTrustline,
 		Pre:  &xdr.LedgerEntry{},
 		Post: &xdr.LedgerEntry{},
 	}))
 
 	// Removed
-	assert.NoError(t, processor.ProcessChange(Change{
+	assert.NoError(t, processor.ProcessChange(ctx, Change{
 		Type: xdr.LedgerEntryTypeAccount,
 		Pre:  &xdr.LedgerEntry{},
 		Post: nil,
 	}))
 
-	assert.NoError(t, processor.ProcessChange(Change{
+	assert.NoError(t, processor.ProcessChange(ctx, Change{
 		Type: xdr.LedgerEntryTypeClaimableBalance,
 		Pre:  &xdr.LedgerEntry{},
 		Post: nil,
 	}))
 
-	assert.NoError(t, processor.ProcessChange(Change{
+	assert.NoError(t, processor.ProcessChange(ctx, Change{
 		Type: xdr.LedgerEntryTypeData,
 		Pre:  &xdr.LedgerEntry{},
 		Post: nil,
 	}))
 
-	assert.NoError(t, processor.ProcessChange(Change{
+	assert.NoError(t, processor.ProcessChange(ctx, Change{
 		Type: xdr.LedgerEntryTypeOffer,
 		Pre:  &xdr.LedgerEntry{},
 		Post: nil,
 	}))
 
-	assert.NoError(t, processor.ProcessChange(Change{
+	assert.NoError(t, processor.ProcessChange(ctx, Change{
 		Type: xdr.LedgerEntryTypeTrustline,
 		Pre:  &xdr.LedgerEntry{},
 		Post: nil,

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"go/types"
@@ -113,8 +114,9 @@ var dbReapCmd = &cobra.Command{
 	Long:  "reap removes any historical data that is earlier than the configured retention cutoff",
 	Run: func(cmd *cobra.Command, args []string) {
 		app := horizon.NewAppFromFlags(config, flags)
-		app.UpdateLedgerState()
-		err := app.DeleteUnretainedHistory()
+		ctx := context.Background()
+		app.UpdateLedgerState(ctx)
+		err := app.DeleteUnretainedHistory(ctx)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"go/types"
 	"net/http"
@@ -227,6 +228,7 @@ var ingestTriggerStateRebuildCmd = &cobra.Command{
 	Use:   "trigger-state-rebuild",
 	Short: "updates a database to trigger state rebuild, state will be rebuilt by a running Horizon instance, DO NOT RUN production DB, some endpoints will be unavailable until state is rebuilt",
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
 		horizon.ApplyFlags(config, flags)
 
 		horizonSession, err := db.Open("postgres", config.DatabaseURL)
@@ -235,7 +237,7 @@ var ingestTriggerStateRebuildCmd = &cobra.Command{
 		}
 
 		historyQ := &history.Q{horizonSession}
-		err = historyQ.UpdateIngestVersion(0)
+		err = historyQ.UpdateIngestVersion(ctx, 0)
 		if err != nil {
 			log.Fatalf("cannot trigger state rebuild: %v", err)
 		}
@@ -248,6 +250,7 @@ var ingestInitGenesisStateCmd = &cobra.Command{
 	Use:   "init-genesis-state",
 	Short: "ingests genesis state (ledger 1)",
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
 		horizon.ApplyFlags(config, flags)
 
 		horizonSession, err := db.Open("postgres", config.DatabaseURL)
@@ -257,7 +260,7 @@ var ingestInitGenesisStateCmd = &cobra.Command{
 
 		historyQ := &history.Q{horizonSession}
 
-		lastIngestedLedger, err := historyQ.GetLastLedgerIngestNonBlocking()
+		lastIngestedLedger, err := historyQ.GetLastLedgerIngestNonBlocking(ctx)
 		if err != nil {
 			log.Fatalf("cannot get last ledger value: %v", err)
 		}

--- a/services/horizon/internal/action_offers_test.go
+++ b/services/horizon/internal/action_offers_test.go
@@ -1,6 +1,7 @@
 package horizon
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -15,14 +16,15 @@ func TestOfferActions_Show(t *testing.T) {
 	ht := StartHTTPTestWithoutScenario(t)
 	defer ht.Finish()
 	q := &history.Q{ht.HorizonSession()}
+	ctx := context.Background()
 
-	err := q.UpdateLastLedgerIngest(100)
+	err := q.UpdateLastLedgerIngest(ctx, 100)
 	ht.Assert.NoError(err)
-	err = q.UpdateIngestVersion(ingest.CurrentVersion)
+	err = q.UpdateIngestVersion(ctx, ingest.CurrentVersion)
 	ht.Assert.NoError(err)
 
 	ledgerCloseTime := time.Now().Unix()
-	_, err = q.InsertLedger(xdr.LedgerHeaderHistoryEntry{
+	_, err = q.InsertLedger(ctx, xdr.LedgerHeaderHistoryEntry{
 		Header: xdr.LedgerHeader{
 			LedgerSeq: 100,
 			ScpValue: xdr.StellarValue{
@@ -67,11 +69,11 @@ func TestOfferActions_Show(t *testing.T) {
 	}
 
 	batch := q.NewOffersBatchInsertBuilder(3)
-	err = batch.Add(eurOffer)
+	err = batch.Add(ctx, eurOffer)
 	ht.Assert.NoError(err)
-	err = batch.Add(usdOffer)
+	err = batch.Add(ctx, usdOffer)
 	ht.Assert.NoError(err)
-	ht.Assert.NoError(batch.Exec())
+	ht.Assert.NoError(batch.Exec(ctx))
 
 	w := ht.Get("/offers")
 	if ht.Assert.Equal(200, w.Code) {

--- a/services/horizon/internal/actions/account_data.go
+++ b/services/horizon/internal/actions/account_data.go
@@ -60,7 +60,7 @@ func loadAccountData(r *http.Request) (history.Data, error) {
 	if err != nil {
 		return history.Data{}, err
 	}
-	data, err := historyQ.GetAccountDataByName(qp.AccountID, qp.Key)
+	data, err := historyQ.GetAccountDataByName(r.Context(), qp.AccountID, qp.Key)
 	if err != nil {
 		return history.Data{}, err
 	}

--- a/services/horizon/internal/actions/account_test.go
+++ b/services/horizon/internal/actions/account_test.go
@@ -240,13 +240,13 @@ func TestAccountInfo(t *testing.T) {
 		},
 	}
 	batch := q.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(accountEntry)
+	err := batch.Add(tt.Ctx, accountEntry)
 	assert.NoError(t, err)
-	assert.NoError(t, batch.Exec())
+	assert.NoError(t, batch.Exec(tt.Ctx))
 
 	tt.Assert.NoError(err)
 
-	_, err = q.InsertTrustLine(xdr.LedgerEntry{
+	_, err = q.InsertTrustLine(tt.Ctx, xdr.LedgerEntry{
 		LastModifiedLedgerSeq: 6,
 		Data: xdr.LedgerEntryData{
 			Type: xdr.LedgerEntryTypeTrustline,
@@ -264,7 +264,7 @@ func TestAccountInfo(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	_, err = q.InsertTrustLine(xdr.LedgerEntry{
+	_, err = q.InsertTrustLine(tt.Ctx, xdr.LedgerEntry{
 		LastModifiedLedgerSeq: 1234,
 		Data: xdr.LedgerEntryData{
 			Type: xdr.LedgerEntryTypeTrustline,
@@ -283,7 +283,7 @@ func TestAccountInfo(t *testing.T) {
 	assert.NoError(t, err)
 
 	ledgerFourCloseTime := time.Now().Unix()
-	_, err = q.InsertLedger(xdr.LedgerHeaderHistoryEntry{
+	_, err = q.InsertLedger(tt.Ctx, xdr.LedgerHeaderHistoryEntry{
 		Header: xdr.LedgerHeader{
 			LedgerSeq: 4,
 			ScpValue: xdr.StellarValue{
@@ -355,16 +355,16 @@ func TestGetAccountsHandlerPageResultsBySigner(t *testing.T) {
 	handler := &GetAccountsHandler{}
 
 	batch := q.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(account1)
+	err := batch.Add(tt.Ctx, account1)
 	assert.NoError(t, err)
-	err = batch.Add(account2)
+	err = batch.Add(tt.Ctx, account2)
 	assert.NoError(t, err)
-	err = batch.Add(account3)
+	err = batch.Add(tt.Ctx, account3)
 	assert.NoError(t, err)
-	assert.NoError(t, batch.Exec())
+	assert.NoError(t, batch.Exec(tt.Ctx))
 
 	for _, row := range accountSigners {
-		q.CreateAccountSigner(row.Account, row.Signer, row.Weight, nil)
+		q.CreateAccountSigner(tt.Ctx, row.Account, row.Signer, row.Weight, nil)
 	}
 
 	records, err := handler.GetResourcePage(
@@ -435,16 +435,16 @@ func TestGetAccountsHandlerPageResultsBySponsor(t *testing.T) {
 	handler := &GetAccountsHandler{}
 
 	batch := q.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(account1)
+	err := batch.Add(tt.Ctx, account1)
 	assert.NoError(t, err)
-	err = batch.Add(account2)
+	err = batch.Add(tt.Ctx, account2)
 	assert.NoError(t, err)
-	err = batch.Add(account3)
+	err = batch.Add(tt.Ctx, account3)
 	assert.NoError(t, err)
-	assert.NoError(t, batch.Exec())
+	assert.NoError(t, batch.Exec(tt.Ctx))
 
 	for _, row := range accountSigners {
-		q.CreateAccountSigner(row.Account, row.Signer, row.Weight, nil)
+		q.CreateAccountSigner(tt.Ctx, row.Account, row.Signer, row.Weight, nil)
 	}
 
 	records, err := handler.GetResourcePage(
@@ -473,13 +473,13 @@ func TestGetAccountsHandlerPageResultsByAsset(t *testing.T) {
 	handler := &GetAccountsHandler{}
 
 	batch := q.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(account1)
+	err := batch.Add(tt.Ctx, account1)
 	assert.NoError(t, err)
-	err = batch.Add(account2)
+	err = batch.Add(tt.Ctx, account2)
 	assert.NoError(t, err)
-	assert.NoError(t, batch.Exec())
+	assert.NoError(t, batch.Exec(tt.Ctx))
 	ledgerCloseTime := time.Now().Unix()
-	_, err = q.InsertLedger(xdr.LedgerHeaderHistoryEntry{
+	_, err = q.InsertLedger(tt.Ctx, xdr.LedgerHeaderHistoryEntry{
 		Header: xdr.LedgerHeader{
 			LedgerSeq: 1234,
 			ScpValue: xdr.StellarValue{
@@ -490,13 +490,13 @@ func TestGetAccountsHandlerPageResultsByAsset(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, row := range accountSigners {
-		_, err = q.CreateAccountSigner(row.Account, row.Signer, row.Weight, nil)
+		_, err = q.CreateAccountSigner(tt.Ctx, row.Account, row.Signer, row.Weight, nil)
 		tt.Assert.NoError(err)
 	}
 
-	_, err = q.InsertAccountData(data1)
+	_, err = q.InsertAccountData(tt.Ctx, data1)
 	assert.NoError(t, err)
-	_, err = q.InsertAccountData(data2)
+	_, err = q.InsertAccountData(tt.Ctx, data2)
 	assert.NoError(t, err)
 
 	var assetType, code, issuer string
@@ -518,9 +518,9 @@ func TestGetAccountsHandlerPageResultsByAsset(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(0, len(records))
 
-	_, err = q.InsertTrustLine(eurTrustLine)
+	_, err = q.InsertTrustLine(tt.Ctx, eurTrustLine)
 	assert.NoError(t, err)
-	_, err = q.InsertTrustLine(usdTrustLine)
+	_, err = q.InsertTrustLine(tt.Ctx, usdTrustLine)
 	assert.NoError(t, err)
 
 	records, err = handler.GetResourcePage(

--- a/services/horizon/internal/actions/asset.go
+++ b/services/horizon/internal/actions/asset.go
@@ -1,12 +1,13 @@
 package actions
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/stellar/go/protocols/horizon"
-	"github.com/stellar/go/services/horizon/internal/context"
+	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/ledger"
@@ -78,6 +79,7 @@ func (handler AssetStatsHandler) validateAssetParams(code, issuer string, pq db2
 }
 
 func (handler AssetStatsHandler) findIssuersForAssets(
+	ctx context.Context,
 	historyQ *history.Q,
 	assetStats []history.ExpAssetStat,
 ) (map[string]history.AccountEntry, error) {
@@ -92,7 +94,7 @@ func (handler AssetStatsHandler) findIssuersForAssets(
 	}
 
 	accountsByID := map[string]history.AccountEntry{}
-	accounts, err := historyQ.GetAccountsByIDs(issuers)
+	accounts, err := historyQ.GetAccountsByIDs(ctx, issuers)
 	if err != nil {
 		return nil, err
 	}
@@ -134,17 +136,17 @@ func (handler AssetStatsHandler) GetResourcePage(
 		return nil, err
 	}
 
-	historyQ, err := context.HistoryQFromRequest(r)
+	historyQ, err := horizonContext.HistoryQFromRequest(r)
 	if err != nil {
 		return nil, err
 	}
 
-	assetStats, err := historyQ.GetAssetStats(code, issuer, pq)
+	assetStats, err := historyQ.GetAssetStats(ctx, code, issuer, pq)
 	if err != nil {
 		return nil, err
 	}
 
-	issuerAccounts, err := handler.findIssuersForAssets(historyQ, assetStats)
+	issuerAccounts, err := handler.findIssuersForAssets(ctx, historyQ, assetStats)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/asset_test.go
+++ b/services/horizon/internal/actions/asset_test.go
@@ -303,7 +303,7 @@ func TestAssetStats(t *testing.T) {
 		otherUSDAssetStat,
 		usdAssetStat,
 	} {
-		numChanged, err := q.InsertAssetStat(assetStat)
+		numChanged, err := q.InsertAssetStat(tt.Ctx, assetStat)
 		tt.Assert.NoError(err)
 		tt.Assert.Equal(numChanged, int64(1))
 	}
@@ -326,9 +326,9 @@ func TestAssetStats(t *testing.T) {
 			t.Fatalf("unexpected error %v", err)
 		}
 		batch := q.NewAccountsBatchInsertBuilder(0)
-		err := batch.Add(accountEntry)
+		err := batch.Add(tt.Ctx, accountEntry)
 		tt.Assert.NoError(err)
-		tt.Assert.NoError(batch.Exec())
+		tt.Assert.NoError(batch.Exec(tt.Ctx))
 	}
 
 	for _, testCase := range []struct {
@@ -446,7 +446,7 @@ func TestAssetStatsIssuerDoesNotExist(t *testing.T) {
 		Amount:      "1",
 		NumAccounts: 2,
 	}
-	numChanged, err := q.InsertAssetStat(usdAssetStat)
+	numChanged, err := q.InsertAssetStat(tt.Ctx, usdAssetStat)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(numChanged, int64(1))
 

--- a/services/horizon/internal/actions/claimable_balance.go
+++ b/services/horizon/internal/actions/claimable_balance.go
@@ -64,12 +64,12 @@ func (handler GetClaimableBalanceByIDHandler) GetResource(w HeaderWriter, r *htt
 	if err != nil {
 		return nil, err
 	}
-	cb, err := historyQ.FindClaimableBalanceByID(balanceID)
+	cb, err := historyQ.FindClaimableBalanceByID(ctx, balanceID)
 	if err != nil {
 		return nil, err
 	}
 	ledger := &history.Ledger{}
-	err = historyQ.LedgerBySequence(
+	err = historyQ.LedgerBySequence(ctx,
 		ledger,
 		int32(cb.LastModifiedLedger),
 	)
@@ -179,7 +179,7 @@ func (handler GetClaimableBalancesHandler) GetResourcePage(
 }
 
 func getClaimableBalancesPage(ctx context.Context, historyQ *history.Q, query history.ClaimableBalancesQuery) ([]hal.Pageable, error) {
-	records, err := historyQ.GetClaimableBalances(query)
+	records, err := historyQ.GetClaimableBalances(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func getClaimableBalancesPage(ctx context.Context, historyQ *history.Q, query hi
 	for _, record := range records {
 		ledgerCache.Queue(int32(record.LastModifiedLedger))
 	}
-	if err := ledgerCache.Load(historyQ); err != nil {
+	if err := ledgerCache.Load(ctx, historyQ); err != nil {
 		return nil, errors.Wrap(err, "failed to load ledger batch")
 	}
 

--- a/services/horizon/internal/actions/claimable_balance_test.go
+++ b/services/horizon/internal/actions/claimable_balance_test.go
@@ -52,10 +52,10 @@ func TestGetClaimableBalanceByID(t *testing.T) {
 
 	builder := q.NewClaimableBalancesBatchInsertBuilder(2)
 
-	err := builder.Add(&entry)
+	err := builder.Add(tt.Ctx, &entry)
 	tt.Assert.NoError(err)
 
-	err = builder.Exec()
+	err = builder.Exec(tt.Ctx)
 	tt.Assert.NoError(err)
 
 	tt.Assert.NoError(err)
@@ -200,11 +200,11 @@ func TestGetClaimableBalances(t *testing.T) {
 	for _, e := range entriesMeta {
 		entry := buildClaimableBalance(e.id, e.accountID, e.ledger, e.asset)
 		entries = append(entries, entry)
-		err := builder.Add(&entry)
+		err := builder.Add(tt.Ctx, &entry)
 		tt.Assert.NoError(err)
 	}
 
-	err := builder.Exec()
+	err := builder.Exec(tt.Ctx)
 	tt.Assert.NoError(err)
 
 	handler := GetClaimableBalancesHandler{}
@@ -293,7 +293,7 @@ func TestGetClaimableBalances(t *testing.T) {
 		SponsoringId: xdr.MustAddressPtr("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 	}
 	entryToBeUpdated.LastModifiedLedgerSeq = xdr.Uint32(1238)
-	q.UpdateClaimableBalance(entryToBeUpdated)
+	q.UpdateClaimableBalance(tt.Ctx, entryToBeUpdated)
 
 	entriesMeta = []struct {
 		id        xdr.Hash
@@ -319,10 +319,10 @@ func TestGetClaimableBalances(t *testing.T) {
 	for _, e := range entriesMeta {
 		entry := buildClaimableBalance(e.id, e.accountID, e.ledger, e.asset)
 		entries = append(entries, entry)
-		tt.Assert.NoError(builder.Add(&entry))
+		tt.Assert.NoError(builder.Add(tt.Ctx, &entry))
 	}
 
-	err = builder.Exec()
+	err = builder.Exec(tt.Ctx)
 	tt.Assert.NoError(err)
 
 	response, err = handler.GetResourcePage(httptest.NewRecorder(), makeRequest(

--- a/services/horizon/internal/actions/ledger.go
+++ b/services/horizon/internal/actions/ledger.go
@@ -33,7 +33,7 @@ func (handler GetLedgersHandler) GetResourcePage(w HeaderWriter, r *http.Request
 	}
 
 	var records []history.Ledger
-	if err = historyQ.Ledgers().Page(pq).Select(&records); err != nil {
+	if err = historyQ.Ledgers().Page(pq).Select(r.Context(), &records); err != nil {
 		return nil, err
 	}
 
@@ -73,7 +73,7 @@ func (handler GetLedgerByIDHandler) GetResource(w HeaderWriter, r *http.Request)
 		return nil, err
 	}
 	var ledger history.Ledger
-	err = historyQ.LedgerBySequence(&ledger, int32(qp.LedgerID))
+	err = historyQ.LedgerBySequence(r.Context(), &ledger, int32(qp.LedgerID))
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/offer.go
+++ b/services/horizon/internal/actions/offer.go
@@ -35,13 +35,14 @@ func (handler GetOfferByID) GetResource(w HeaderWriter, r *http.Request) (interf
 		return nil, err
 	}
 
-	record, err := historyQ.GetOfferByID(int64(qp.OfferID))
+	record, err := historyQ.GetOfferByID(r.Context(), int64(qp.OfferID))
 	if err != nil {
 		return nil, err
 	}
 
 	ledger := &history.Ledger{}
 	err = historyQ.LedgerBySequence(
+		r.Context(),
 		ledger,
 		int32(record.LastModifiedLedger),
 	)
@@ -181,7 +182,7 @@ func (handler GetAccountOffersHandler) GetResourcePage(
 }
 
 func getOffersPage(ctx context.Context, historyQ *history.Q, query history.OffersQuery) ([]hal.Pageable, error) {
-	records, err := historyQ.GetOffers(query)
+	records, err := historyQ.GetOffers(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +192,7 @@ func getOffersPage(ctx context.Context, historyQ *history.Q, query history.Offer
 		ledgerCache.Queue(int32(record.LastModifiedLedger))
 	}
 
-	if err := ledgerCache.Load(historyQ); err != nil {
+	if err := ledgerCache.Load(ctx, historyQ); err != nil {
 		return nil, errors.Wrap(err, "failed to load ledger batch")
 	}
 

--- a/services/horizon/internal/actions/offer_test.go
+++ b/services/horizon/internal/actions/offer_test.go
@@ -79,7 +79,7 @@ func TestGetOfferByIDHandler(t *testing.T) {
 	handler := GetOfferByID{}
 
 	ledgerCloseTime := time.Now().Unix()
-	_, err := q.InsertLedger(xdr.LedgerHeaderHistoryEntry{
+	_, err := q.InsertLedger(tt.Ctx, xdr.LedgerHeaderHistoryEntry{
 		Header: xdr.LedgerHeader{
 			LedgerSeq: 3,
 			ScpValue: xdr.StellarValue{
@@ -90,11 +90,11 @@ func TestGetOfferByIDHandler(t *testing.T) {
 	tt.Assert.NoError(err)
 
 	batch := q.NewOffersBatchInsertBuilder(0)
-	err = batch.Add(eurOffer)
+	err = batch.Add(tt.Ctx, eurOffer)
 	tt.Assert.NoError(err)
-	err = batch.Add(usdOffer)
+	err = batch.Add(tt.Ctx, usdOffer)
 	tt.Assert.NoError(err)
-	tt.Assert.NoError(batch.Exec())
+	tt.Assert.NoError(batch.Exec(tt.Ctx))
 
 	for _, testCase := range []struct {
 		name          string
@@ -190,7 +190,7 @@ func TestGetOffersHandler(t *testing.T) {
 	handler := GetOffersHandler{}
 
 	ledgerCloseTime := time.Now().Unix()
-	_, err := q.InsertLedger(xdr.LedgerHeaderHistoryEntry{
+	_, err := q.InsertLedger(tt.Ctx, xdr.LedgerHeaderHistoryEntry{
 		Header: xdr.LedgerHeader{
 			LedgerSeq: 3,
 			ScpValue: xdr.StellarValue{
@@ -201,13 +201,13 @@ func TestGetOffersHandler(t *testing.T) {
 	tt.Assert.NoError(err)
 
 	batch := q.NewOffersBatchInsertBuilder(0)
-	err = batch.Add(eurOffer)
+	err = batch.Add(tt.Ctx, eurOffer)
 	tt.Assert.NoError(err)
-	err = batch.Add(twoEurOffer)
+	err = batch.Add(tt.Ctx, twoEurOffer)
 	tt.Assert.NoError(err)
-	err = batch.Add(usdOffer)
+	err = batch.Add(tt.Ctx, usdOffer)
 	tt.Assert.NoError(err)
-	tt.Assert.NoError(batch.Exec())
+	tt.Assert.NoError(batch.Exec(tt.Ctx))
 
 	t.Run("No filter", func(t *testing.T) {
 		records, err := handler.GetResourcePage(
@@ -478,12 +478,12 @@ func TestGetAccountOffersHandler(t *testing.T) {
 	handler := GetAccountOffersHandler{}
 
 	batch := q.NewOffersBatchInsertBuilder(0)
-	err := batch.Add(eurOffer)
-	err = batch.Add(twoEurOffer)
+	err := batch.Add(tt.Ctx, eurOffer)
+	err = batch.Add(tt.Ctx, twoEurOffer)
 	tt.Assert.NoError(err)
-	err = batch.Add(usdOffer)
+	err = batch.Add(tt.Ctx, usdOffer)
 	tt.Assert.NoError(err)
-	tt.Assert.NoError(batch.Exec())
+	tt.Assert.NoError(batch.Exec(tt.Ctx))
 
 	records, err := handler.GetResourcePage(
 		httptest.NewRecorder(),

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -294,7 +294,7 @@ func TestGetOperationsIncludeFailed(t *testing.T) {
 	}
 
 	// NULL value
-	_, err = tt.HorizonSession().ExecRaw(
+	_, err = tt.HorizonSession().ExecRaw(tt.Ctx,
 		`UPDATE history_transactions SET successful = NULL WHERE transaction_hash = ?`,
 		"56e3216045d579bea40f2d35a09406de3a894ecb5be70dbda5ec9c0427a0d5a1",
 	)
@@ -504,7 +504,7 @@ func TestOperation_CreatedAt(t *testing.T) {
 	tt.Assert.NoError(err)
 
 	l := history.Ledger{}
-	tt.Assert.NoError(q.LedgerBySequence(&l, 3))
+	tt.Assert.NoError(q.LedgerBySequence(tt.Ctx, &l, 3))
 
 	record := records[0].(operations.Payment)
 

--- a/services/horizon/internal/actions/orderbook.go
+++ b/services/horizon/internal/actions/orderbook.go
@@ -100,7 +100,7 @@ func (handler GetOrderbookHandler) GetResource(w HeaderWriter, r *http.Request) 
 		return nil, err
 	}
 
-	summary, err := historyQ.GetOrderBookSummary(selling, buying, int(limit))
+	summary, err := historyQ.GetOrderBookSummary(r.Context(), selling, buying, int(limit))
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/orderbook_test.go
+++ b/services/horizon/internal/actions/orderbook_test.go
@@ -574,19 +574,19 @@ func TestOrderbookGetResource(t *testing.T) {
 		otherSellEurOffer,
 	}
 
-	assert.NoError(t, q.TruncateTables([]string{"offers"}))
+	assert.NoError(t, q.TruncateTables(tt.Ctx, []string{"offers"}))
 
 	batch := q.NewOffersBatchInsertBuilder(0)
 	for _, offer := range offers {
-		assert.NoError(t, batch.Add(offer))
+		assert.NoError(t, batch.Add(tt.Ctx, offer))
 	}
-	assert.NoError(t, batch.Exec())
+	assert.NoError(t, batch.Exec(tt.Ctx))
 
-	assert.NoError(t, q.BeginTx(&sql.TxOptions{
+	assert.NoError(t, q.BeginTx(tt.Ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	}))
-	defer q.Rollback()
+	defer q.Rollback(tt.Ctx)
 
 	fullResponse := empty
 	fullResponse.Asks = []protocol.PriceLevel{

--- a/services/horizon/internal/actions/path.go
+++ b/services/horizon/internal/actions/path.go
@@ -334,5 +334,5 @@ func assetsForAddress(r *http.Request, addy string) ([]xdr.Asset, []xdr.Int64, e
 	if err != nil {
 		return nil, nil, err
 	}
-	return historyQ.AssetsForAddress(addy)
+	return historyQ.AssetsForAddress(r.Context(), addy)
 }

--- a/services/horizon/internal/actions_account_test.go
+++ b/services/horizon/internal/actions_account_test.go
@@ -14,11 +14,11 @@ func TestAccountActions_InvalidID(t *testing.T) {
 
 	// Makes StateMiddleware happy
 	q := history.Q{ht.HorizonSession()}
-	err := q.UpdateLastLedgerIngest(100)
+	err := q.UpdateLastLedgerIngest(ht.Ctx, 100)
 	ht.Assert.NoError(err)
-	err = q.UpdateIngestVersion(ingest.CurrentVersion)
+	err = q.UpdateIngestVersion(ht.Ctx, ingest.CurrentVersion)
 	ht.Assert.NoError(err)
-	_, err = q.InsertLedger(xdr.LedgerHeaderHistoryEntry{
+	_, err = q.InsertLedger(ht.Ctx, xdr.LedgerHeaderHistoryEntry{
 		Header: xdr.LedgerHeader{
 			LedgerSeq: 100,
 		},

--- a/services/horizon/internal/actions_data_test.go
+++ b/services/horizon/internal/actions_data_test.go
@@ -53,22 +53,22 @@ func TestDataActions_Show(t *testing.T) {
 	q := &history.Q{ht.HorizonSession()}
 
 	// Makes StateMiddleware happy
-	err := q.UpdateLastLedgerIngest(100)
+	err := q.UpdateLastLedgerIngest(ht.Ctx, 100)
 	ht.Assert.NoError(err)
-	err = q.UpdateIngestVersion(ingest.CurrentVersion)
+	err = q.UpdateIngestVersion(ht.Ctx, ingest.CurrentVersion)
 	ht.Assert.NoError(err)
-	_, err = q.InsertLedger(xdr.LedgerHeaderHistoryEntry{
+	_, err = q.InsertLedger(ht.Ctx, xdr.LedgerHeaderHistoryEntry{
 		Header: xdr.LedgerHeader{
 			LedgerSeq: 100,
 		},
 	}, 0, 0, 0, 0, 0)
 	ht.Assert.NoError(err)
 
-	rows, err := q.InsertAccountData(data1)
+	rows, err := q.InsertAccountData(ht.Ctx, data1)
 	assert.NoError(t, err)
 	ht.Assert.Equal(int64(1), rows)
 
-	rows, err = q.InsertAccountData(data2)
+	rows, err = q.InsertAccountData(ht.Ctx, data2)
 	assert.NoError(t, err)
 	ht.Assert.Equal(int64(1), rows)
 

--- a/services/horizon/internal/actions_effects_test.go
+++ b/services/horizon/internal/actions_effects_test.go
@@ -43,9 +43,9 @@ func TestEffectActions_Index(t *testing.T) {
 
 		// Makes StateMiddleware happy
 		q := history.Q{ht.HorizonSession()}
-		err := q.UpdateLastLedgerIngest(3)
+		err := q.UpdateLastLedgerIngest(ht.Ctx, 3)
 		ht.Assert.NoError(err)
-		err = q.UpdateIngestVersion(ingest.CurrentVersion)
+		err = q.UpdateIngestVersion(ht.Ctx, ingest.CurrentVersion)
 		ht.Assert.NoError(err)
 
 		// checks if empty param returns 404 instead of all payments

--- a/services/horizon/internal/actions_operation_fee_stats_test.go
+++ b/services/horizon/internal/actions_operation_fee_stats_test.go
@@ -151,10 +151,10 @@ func TestOperationFeeTestsActions_Show(t *testing.T) {
 			defer ht.Finish()
 
 			// Update max_tx_set_size on ledgers
-			_, err := ht.HorizonSession().ExecRaw("UPDATE history_ledgers SET max_tx_set_size = 50")
+			_, err := ht.HorizonSession().ExecRaw(ht.Ctx, "UPDATE history_ledgers SET max_tx_set_size = 50")
 			ht.Require.NoError(err)
 
-			ht.App.UpdateFeeStatsState()
+			ht.App.UpdateFeeStatsState(ht.Ctx)
 
 			w := ht.Get("/fee_stats")
 
@@ -205,14 +205,14 @@ func TestOperationFeeTestsActions_ShowMultiOp(t *testing.T) {
 	defer ht.Finish()
 
 	// Update max_tx_set_size on ledgers
-	_, err := ht.HorizonSession().ExecRaw("UPDATE history_ledgers SET max_tx_set_size = 50")
+	_, err := ht.HorizonSession().ExecRaw(ht.Ctx, "UPDATE history_ledgers SET max_tx_set_size = 50")
 	ht.Require.NoError(err)
 
 	// Update number of ops on each transaction
-	_, err = ht.HorizonSession().ExecRaw("UPDATE history_transactions SET operation_count = operation_count * 2")
+	_, err = ht.HorizonSession().ExecRaw(ht.Ctx, "UPDATE history_transactions SET operation_count = operation_count * 2")
 	ht.Require.NoError(err)
 
-	ht.App.UpdateFeeStatsState()
+	ht.App.UpdateFeeStatsState(ht.Ctx)
 
 	w := ht.Get("/fee_stats")
 
@@ -271,14 +271,14 @@ func TestOperationFeeTestsActions_NotInterpolating(t *testing.T) {
 	defer ht.Finish()
 
 	// Update max_tx_set_size on ledgers
-	_, err := ht.HorizonSession().ExecRaw("UPDATE history_ledgers SET max_tx_set_size = 50")
+	_, err := ht.HorizonSession().ExecRaw(ht.Ctx, "UPDATE history_ledgers SET max_tx_set_size = 50")
 	ht.Require.NoError(err)
 
 	// Update one tx to a huge fee
-	_, err = ht.HorizonSession().ExecRaw("UPDATE history_transactions SET max_fee = 256000, operation_count = 16 WHERE transaction_hash = '6a349e7331e93a251367287e274fb1699abaf723bde37aebe96248c76fd3071a'")
+	_, err = ht.HorizonSession().ExecRaw(ht.Ctx, "UPDATE history_transactions SET max_fee = 256000, operation_count = 16 WHERE transaction_hash = '6a349e7331e93a251367287e274fb1699abaf723bde37aebe96248c76fd3071a'")
 	ht.Require.NoError(err)
 
-	ht.App.UpdateFeeStatsState()
+	ht.App.UpdateFeeStatsState(ht.Ctx)
 
 	w := ht.Get("/fee_stats")
 
@@ -326,13 +326,13 @@ func TestOperationFeeTestsActions_FeeBump(t *testing.T) {
 	defer ht.Finish()
 
 	// Update one tx to be a fee bump
-	result, err := ht.HorizonSession().ExecRaw("UPDATE history_transactions SET max_fee = 10, new_max_fee = 1000, fee_charged = 200 WHERE transaction_hash = '6a349e7331e93a251367287e274fb1699abaf723bde37aebe96248c76fd3071a'")
+	result, err := ht.HorizonSession().ExecRaw(ht.Ctx, "UPDATE history_transactions SET max_fee = 10, new_max_fee = 1000, fee_charged = 200 WHERE transaction_hash = '6a349e7331e93a251367287e274fb1699abaf723bde37aebe96248c76fd3071a'")
 	ht.Require.NoError(err)
 	rowsAffected, err := result.RowsAffected()
 	ht.Require.NoError(err)
 	ht.Require.Equal(int64(1), rowsAffected)
 
-	ht.App.UpdateFeeStatsState()
+	ht.App.UpdateFeeStatsState(ht.Ctx)
 
 	w := ht.Get("/fee_stats")
 

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -169,7 +169,7 @@ func TestOperationActions_Show_Failed(t *testing.T) {
 	}
 
 	// NULL value
-	_, err := ht.HorizonSession().ExecRaw(
+	_, err := ht.HorizonSession().ExecRaw(ht.Ctx,
 		`UPDATE history_transactions SET successful = NULL WHERE transaction_hash = ?`,
 		"56e3216045d579bea40f2d35a09406de3a894ecb5be70dbda5ec9c0427a0d5a1",
 	)
@@ -280,7 +280,7 @@ func TestOperation_CreatedAt(t *testing.T) {
 
 	l := history.Ledger{}
 	hq := history.Q{Session: ht.HorizonSession()}
-	ht.Require.NoError(hq.LedgerBySequence(&l, 3))
+	ht.Require.NoError(hq.LedgerBySequence(ht.Ctx, &l, 3))
 
 	ht.Assert.WithinDuration(l.ClosedAt, records[0].LedgerCloseTime, 1*time.Second)
 }

--- a/services/horizon/internal/actions_path_test.go
+++ b/services/horizon/internal/actions_path_test.go
@@ -50,11 +50,11 @@ func mockPathFindingClient(
 	router.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			s := session.Clone()
-			s.BeginTx(&sql.TxOptions{
+			s.BeginTx(tt.Ctx, &sql.TxOptions{
 				Isolation: sql.LevelRepeatableRead,
 				ReadOnly:  true,
 			})
-			defer s.Rollback()
+			defer s.Rollback(tt.Ctx)
 
 			ctx := context.WithValue(
 				r.Context(),
@@ -168,9 +168,9 @@ func TestPathActionsStrictReceive(t *testing.T) {
 	}
 
 	batch := q.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(account)
+	err := batch.Add(tt.Ctx, account)
 	assert.NoError(t, err)
-	err = batch.Exec()
+	err = batch.Exec(tt.Ctx)
 	assert.NoError(t, err)
 
 	assetsByKeys := map[string]xdr.Asset{}
@@ -204,7 +204,7 @@ func TestPathActionsStrictReceive(t *testing.T) {
 			},
 		}
 
-		rows, err1 := q.InsertTrustLine(trustline)
+		rows, err1 := q.InsertTrustLine(tt.Ctx, trustline)
 		assert.NoError(t, err1)
 		assert.Equal(t, int64(1), rows)
 	}
@@ -526,9 +526,9 @@ func TestPathActionsStrictSend(t *testing.T) {
 	}
 
 	batch := historyQ.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(account)
+	err := batch.Add(tt.Ctx, account)
 	assert.NoError(t, err)
-	err = batch.Exec()
+	err = batch.Exec(tt.Ctx)
 	assert.NoError(t, err)
 
 	assetsByKeys := map[string]xdr.Asset{}
@@ -562,7 +562,7 @@ func TestPathActionsStrictSend(t *testing.T) {
 			},
 		}
 
-		rows, err := historyQ.InsertTrustLine(trustline)
+		rows, err := historyQ.InsertTrustLine(tt.Ctx, trustline)
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1), rows)
 	}

--- a/services/horizon/internal/actions_payment_test.go
+++ b/services/horizon/internal/actions_payment_test.go
@@ -35,9 +35,9 @@ func TestPaymentActions(t *testing.T) {
 	// Makes StateMiddleware happy
 	initializeStateMiddleware := func() {
 		q := history.Q{ht.HorizonSession()}
-		err := q.UpdateLastLedgerIngest(3)
+		err := q.UpdateLastLedgerIngest(ht.Ctx, 3)
 		ht.Assert.NoError(err)
-		err = q.UpdateIngestVersion(ingest.CurrentVersion)
+		err = q.UpdateIngestVersion(ht.Ctx, ingest.CurrentVersion)
 		ht.Assert.NoError(err)
 	}
 	initializeStateMiddleware()
@@ -212,7 +212,7 @@ func TestPaymentActions_Show_Failed(t *testing.T) {
 	}
 
 	// NULL value
-	_, err := ht.HorizonSession().ExecRaw(
+	_, err := ht.HorizonSession().ExecRaw(ht.Ctx,
 		`UPDATE history_transactions SET successful = NULL WHERE transaction_hash = ?`,
 		"56e3216045d579bea40f2d35a09406de3a894ecb5be70dbda5ec9c0427a0d5a1",
 	)
@@ -241,7 +241,7 @@ func TestPayment_CreatedAt(t *testing.T) {
 
 	l := history.Ledger{}
 	hq := history.Q{Session: ht.HorizonSession()}
-	ht.Require.NoError(hq.LedgerBySequence(&l, 3))
+	ht.Require.NoError(hq.LedgerBySequence(ht.Ctx, &l, 3))
 
 	ht.Assert.WithinDuration(l.ClosedAt, records[0].LedgerCloseTime, 1*time.Second)
 }

--- a/services/horizon/internal/actions_root_test.go
+++ b/services/horizon/internal/actions_root_test.go
@@ -28,8 +28,8 @@ func TestRootAction(t *testing.T) {
 
 	ht.App.config.StellarCoreURL = server.URL
 	ht.App.config.NetworkPassphrase = "test"
-	ht.App.UpdateStellarCoreInfo()
-	ht.App.UpdateLedgerState()
+	ht.App.UpdateStellarCoreInfo(ht.Ctx)
+	ht.App.UpdateLedgerState(ht.Ctx)
 
 	w := ht.Get("/")
 
@@ -94,7 +94,7 @@ func TestRootCoreClientInfoErrored(t *testing.T) {
 	defer server.Close()
 
 	ht.App.config.StellarCoreURL = server.URL
-	ht.App.UpdateLedgerState()
+	ht.App.UpdateLedgerState(ht.Ctx)
 
 	w := ht.Get("/")
 

--- a/services/horizon/internal/actions_trade_test.go
+++ b/services/horizon/internal/actions_trade_test.go
@@ -36,7 +36,7 @@ func TestTradeActions_Index(t *testing.T) {
 		// 	ensure created_at is populated correctly
 		l := history.Ledger{}
 		hq := history.Q{Session: ht.HorizonSession()}
-		ht.Require.NoError(hq.LedgerBySequence(&l, 9))
+		ht.Require.NoError(hq.LedgerBySequence(ht.Ctx, &l, 9))
 
 		ht.Assert.WithinDuration(l.ClosedAt, records[0].LedgerCloseTime, 1*time.Second)
 	}

--- a/services/horizon/internal/actions_transaction_test.go
+++ b/services/horizon/internal/actions_transaction_test.go
@@ -145,7 +145,7 @@ func TestTransactionActions_Show_Failed(t *testing.T) {
 	}
 
 	// NULL value
-	_, err := ht.HorizonSession().ExecRaw(
+	_, err := ht.HorizonSession().ExecRaw(ht.Ctx,
 		`UPDATE history_transactions SET successful = NULL WHERE transaction_hash = ?`,
 		"56e3216045d579bea40f2d35a09406de3a894ecb5be70dbda5ec9c0427a0d5a1",
 	)
@@ -193,9 +193,9 @@ func TestTransactionActions_Index(t *testing.T) {
 
 	// Makes StateMiddleware happy
 	q := history.Q{ht.HorizonSession()}
-	err := q.UpdateLastLedgerIngest(100)
+	err := q.UpdateLastLedgerIngest(ht.Ctx, 100)
 	ht.Assert.NoError(err)
-	err = q.UpdateIngestVersion(ingest.CurrentVersion)
+	err = q.UpdateIngestVersion(ht.Ctx, ingest.CurrentVersion)
 	ht.Assert.NoError(err)
 
 	// checks if empty param returns 404 instead of all payments

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -194,14 +194,14 @@ func (a *App) Ingestion() ingest.System {
 }
 
 // HorizonSession returns a new session that loads data from the horizon
-// database. The returned session is bound to `ctx`.
-func (a *App) HorizonSession(ctx context.Context) *db.Session {
-	return &db.Session{DB: a.historyQ.Session.DB, Ctx: ctx}
+// database.
+func (a *App) HorizonSession() *db.Session {
+	return &db.Session{DB: a.historyQ.Session.DB}
 }
 
 // UpdateLedgerState triggers a refresh of several metrics gauges, such as open
 // db connections and ledger state
-func (a *App) UpdateLedgerState() {
+func (a *App) UpdateLedgerState(ctx context.Context) {
 	var next ledger.Status
 
 	logErr := func(err error, msg string) {
@@ -221,19 +221,19 @@ func (a *App) UpdateLedgerState() {
 	next.CoreLatest = int32(coreInfo.Info.Ledger.Num)
 
 	next.HistoryLatest, next.HistoryLatestClosedAt, err =
-		a.HistoryQ().LatestLedgerSequenceClosedAt()
+		a.HistoryQ().LatestLedgerSequenceClosedAt(ctx)
 	if err != nil {
 		logErr(err, "failed to load the latest known ledger state from history DB")
 		return
 	}
 
-	err = a.HistoryQ().ElderLedger(&next.HistoryElder)
+	err = a.HistoryQ().ElderLedger(ctx, &next.HistoryElder)
 	if err != nil {
 		logErr(err, "failed to load the oldest known ledger state from history DB")
 		return
 	}
 
-	next.ExpHistoryLatest, err = a.HistoryQ().GetLastLedgerIngestNonBlocking()
+	next.ExpHistoryLatest, err = a.HistoryQ().GetLastLedgerIngestNonBlocking(ctx)
 	if err != nil {
 		logErr(err, "failed to load the oldest known exp ledger state from history DB")
 		return
@@ -243,7 +243,7 @@ func (a *App) UpdateLedgerState() {
 }
 
 // UpdateFeeStatsState triggers a refresh of several operation fee metrics.
-func (a *App) UpdateFeeStatsState() {
+func (a *App) UpdateFeeStatsState(ctx context.Context) {
 	var (
 		next          operationfeestats.State
 		latest        history.LatestLedger
@@ -262,7 +262,7 @@ func (a *App) UpdateFeeStatsState() {
 
 	cur, ok := operationfeestats.CurrentState()
 
-	err := a.HistoryQ().LatestLedgerBaseFeeAndSequence(&latest)
+	err := a.HistoryQ().LatestLedgerBaseFeeAndSequence(ctx, &latest)
 	if err != nil {
 		logErr(err, "failed to load the latest known ledger's base fee and sequence number")
 		return
@@ -276,13 +276,13 @@ func (a *App) UpdateFeeStatsState() {
 	next.LastBaseFee = int64(latest.BaseFee)
 	next.LastLedger = uint32(latest.Sequence)
 
-	err = a.HistoryQ().FeeStats(latest.Sequence, &feeStats)
+	err = a.HistoryQ().FeeStats(ctx, latest.Sequence, &feeStats)
 	if err != nil {
 		logErr(err, "failed to load operation fee stats")
 		return
 	}
 
-	err = a.HistoryQ().LedgerCapacityUsageStats(latest.Sequence, &capacityStats)
+	err = a.HistoryQ().LedgerCapacityUsageStats(ctx, latest.Sequence, &capacityStats)
 	if err != nil {
 		logErr(err, "failed to load ledger capacity usage stats")
 		return
@@ -365,7 +365,7 @@ func (a *App) UpdateFeeStatsState() {
 // UpdateStellarCoreInfo updates the value of CoreVersion,
 // CurrentProtocolVersion, and CoreSupportedProtocolVersion from the Stellar
 // core API.
-func (a *App) UpdateStellarCoreInfo() {
+func (a *App) UpdateStellarCoreInfo(ctx context.Context) {
 	if a.config.StellarCoreURL == "" {
 		return
 	}
@@ -374,7 +374,7 @@ func (a *App) UpdateStellarCoreInfo() {
 		URL: a.config.StellarCoreURL,
 	}
 
-	resp, err := core.Info(context.Background())
+	resp, err := core.Info(ctx)
 	if err != nil {
 		log.Warnf("could not load stellar-core info: %s", err)
 		return
@@ -396,8 +396,8 @@ func (a *App) UpdateStellarCoreInfo() {
 
 // DeleteUnretainedHistory forwards to the app's reaper.  See
 // `reap.DeleteUnretainedHistory` for details
-func (a *App) DeleteUnretainedHistory() error {
-	return a.reaper.DeleteUnretainedHistory()
+func (a *App) DeleteUnretainedHistory(ctx context.Context) error {
+	return a.reaper.DeleteUnretainedHistory(ctx)
 }
 
 // Tick triggers horizon to update all of it's background processes such as
@@ -407,13 +407,13 @@ func (a *App) Tick() {
 	log.Debug("ticking app")
 	// update ledger state, operation fee state, and stellar-core info in parallel
 	wg.Add(3)
-	go func() { a.UpdateLedgerState(); wg.Done() }()
-	go func() { a.UpdateFeeStatsState(); wg.Done() }()
-	go func() { a.UpdateStellarCoreInfo(); wg.Done() }()
+	go func() { a.UpdateLedgerState(a.ctx); wg.Done() }()
+	go func() { a.UpdateFeeStatsState(a.ctx); wg.Done() }()
+	go func() { a.UpdateStellarCoreInfo(a.ctx); wg.Done() }()
 	wg.Wait()
 
 	wg.Add(2)
-	go func() { a.reaper.Tick(); wg.Done() }()
+	go func() { a.reaper.Tick(a.ctx); wg.Done() }()
 	go func() { a.submitter.Tick(a.ctx); wg.Done() }()
 	wg.Wait()
 
@@ -437,7 +437,7 @@ func (a *App) init() error {
 	initLogglyLog(a)
 
 	// stellarCoreInfo
-	a.UpdateStellarCoreInfo()
+	a.UpdateStellarCoreInfo(a.ctx)
 
 	// horizon-db and core-db
 	mustInitHorizonDB(a)
@@ -452,7 +452,7 @@ func (a *App) init() error {
 	initSubmissionSystem(a)
 
 	// reaper
-	a.reaper = reap.New(a.config.HistoryRetentionCount, a.HorizonSession(context.Background()), a.ledgerState)
+	a.reaper = reap.New(a.config.HistoryRetentionCount, a.HorizonSession(), a.ledgerState)
 
 	// metrics and log.metrics
 	a.prometheusRegistry = prometheus.NewRegistry()

--- a/services/horizon/internal/db2/assets/asset_stat_test.go
+++ b/services/horizon/internal/db2/assets/asset_stat_test.go
@@ -1,6 +1,7 @@
 package assets
 
 import (
+	"context"
 	"strconv"
 	"testing"
 
@@ -91,7 +92,7 @@ func TestAssetsStatsQExec(t *testing.T) {
 			tt.Require.NoError(err)
 
 			var results []AssetStatsR
-			err = history.Q{Session: tt.HorizonSession()}.Select(&results, sql)
+			err = history.Q{Session: tt.HorizonSession()}.Select(context.Background(), &results, sql)
 			tt.Require.NoError(err)
 			if !tt.Assert.Equal(3, len(results)) {
 				return

--- a/services/horizon/internal/db2/history/account_data_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/account_data_batch_insert_builder.go
@@ -1,11 +1,13 @@
 package history
 
 import (
+	"context"
+
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 
-func (i *accountDataBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
+func (i *accountDataBatchInsertBuilder) Add(ctx context.Context, entry xdr.LedgerEntry) error {
 	data := entry.Data.MustData()
 	// Add ledger_key only when inserting rows
 	key, err := dataEntryToLedgerKeyString(entry)
@@ -13,7 +15,7 @@ func (i *accountDataBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
 		return errors.Wrap(err, "Error running dataEntryToLedgerKeyString")
 	}
 
-	return i.builder.Row(map[string]interface{}{
+	return i.builder.Row(ctx, map[string]interface{}{
 		"ledger_key":           key,
 		"account_id":           data.AccountId.Address(),
 		"name":                 data.DataName,
@@ -23,6 +25,6 @@ func (i *accountDataBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
 	})
 }
 
-func (i *accountDataBatchInsertBuilder) Exec() error {
-	return i.builder.Exec()
+func (i *accountDataBatchInsertBuilder) Exec(ctx context.Context) error {
+	return i.builder.Exec(ctx)
 }

--- a/services/horizon/internal/db2/history/account_data_batch_insert_builder_test.go
+++ b/services/horizon/internal/db2/history/account_data_batch_insert_builder_test.go
@@ -35,13 +35,13 @@ func TestDataBatchInsertBuilderAdd(t *testing.T) {
 
 	builder := q.NewAccountDataBatchInsertBuilder(2)
 
-	err := builder.Add(entry)
+	err := builder.Add(tt.Ctx, entry)
 	tt.Assert.NoError(err)
 
-	err = builder.Exec()
+	err = builder.Exec(tt.Ctx)
 	tt.Assert.NoError(err)
 
-	record, err := q.GetAccountDataByName(accountID.Address(), "foo")
+	record, err := q.GetAccountDataByName(tt.Ctx, accountID.Address(), "foo")
 	tt.Assert.NoError(err)
 
 	tt.Assert.Equal(data.DataName, xdr.String64(record.Name))

--- a/services/horizon/internal/db2/history/account_data_test.go
+++ b/services/horizon/internal/db2/history/account_data_test.go
@@ -47,11 +47,11 @@ func TestInsertAccountData(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	rows, err := q.InsertAccountData(data1)
+	rows, err := q.InsertAccountData(tt.Ctx, data1)
 	assert.NoError(t, err)
 	tt.Assert.Equal(int64(1), rows)
 
-	rows, err = q.InsertAccountData(data2)
+	rows, err = q.InsertAccountData(tt.Ctx, data2)
 	assert.NoError(t, err)
 	tt.Assert.Equal(int64(1), rows)
 
@@ -60,7 +60,7 @@ func TestInsertAccountData(t *testing.T) {
 		{AccountId: data2.Data.Data.AccountId, DataName: data2.Data.Data.DataName},
 	}
 
-	datas, err := q.GetAccountDataByKeys(keys)
+	datas, err := q.GetAccountDataByKeys(tt.Ctx, keys)
 	assert.NoError(t, err)
 	assert.Len(t, datas, 2)
 
@@ -79,21 +79,21 @@ func TestUpdateAccountData(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	rows, err := q.InsertAccountData(data1)
+	rows, err := q.InsertAccountData(tt.Ctx, data1)
 	assert.NoError(t, err)
 	tt.Assert.Equal(int64(1), rows)
 
 	modifiedData := data1
 	modifiedData.Data.Data.DataValue[0] = 1
 
-	rows, err = q.UpdateAccountData(modifiedData)
+	rows, err = q.UpdateAccountData(tt.Ctx, modifiedData)
 	assert.NoError(t, err)
 	tt.Assert.Equal(int64(1), rows)
 
 	keys := []xdr.LedgerKeyData{
 		{AccountId: data1.Data.Data.AccountId, DataName: data1.Data.Data.DataName},
 	}
-	datas, err := q.GetAccountDataByKeys(keys)
+	datas, err := q.GetAccountDataByKeys(tt.Ctx, keys)
 	assert.NoError(t, err)
 	assert.Len(t, datas, 1)
 
@@ -108,21 +108,21 @@ func TestRemoveAccountData(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	rows, err := q.InsertAccountData(data1)
+	rows, err := q.InsertAccountData(tt.Ctx, data1)
 	assert.NoError(t, err)
 	tt.Assert.Equal(int64(1), rows)
 
 	key := xdr.LedgerKeyData{AccountId: data1.Data.Data.AccountId, DataName: data1.Data.Data.DataName}
-	rows, err = q.RemoveAccountData(key)
+	rows, err = q.RemoveAccountData(tt.Ctx, key)
 	assert.NoError(t, err)
 	tt.Assert.Equal(int64(1), rows)
 
-	datas, err := q.GetAccountDataByKeys([]xdr.LedgerKeyData{key})
+	datas, err := q.GetAccountDataByKeys(tt.Ctx, []xdr.LedgerKeyData{key})
 	assert.NoError(t, err)
 	assert.Len(t, datas, 0)
 
 	// Doesn't exist anymore
-	rows, err = q.RemoveAccountData(key)
+	rows, err = q.RemoveAccountData(tt.Ctx, key)
 	assert.NoError(t, err)
 	tt.Assert.Equal(int64(0), rows)
 }
@@ -133,16 +133,16 @@ func TestGetAccountDataByAccountsID(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	_, err := q.InsertAccountData(data1)
+	_, err := q.InsertAccountData(tt.Ctx, data1)
 	assert.NoError(t, err)
-	_, err = q.InsertAccountData(data2)
+	_, err = q.InsertAccountData(tt.Ctx, data2)
 	assert.NoError(t, err)
 
 	ids := []string{
 		data1.Data.Data.AccountId.Address(),
 		data2.Data.Data.AccountId.Address(),
 	}
-	datas, err := q.GetAccountDataByAccountsID(ids)
+	datas, err := q.GetAccountDataByAccountsID(tt.Ctx, ids)
 	assert.NoError(t, err)
 	assert.Len(t, datas, 2)
 
@@ -159,12 +159,12 @@ func TestGetAccountDataByAccountID(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	_, err := q.InsertAccountData(data1)
+	_, err := q.InsertAccountData(tt.Ctx, data1)
 	assert.NoError(t, err)
-	_, err = q.InsertAccountData(data2)
+	_, err = q.InsertAccountData(tt.Ctx, data2)
 	assert.NoError(t, err)
 
-	records, err := q.GetAccountDataByAccountID(data1.Data.Data.AccountId.Address())
+	records, err := q.GetAccountDataByAccountID(tt.Ctx, data1.Data.Data.AccountId.Address())
 	assert.NoError(t, err)
 	assert.Len(t, records, 2)
 
@@ -181,17 +181,17 @@ func TestGetAccountDataByName(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	_, err := q.InsertAccountData(data1)
+	_, err := q.InsertAccountData(tt.Ctx, data1)
 	assert.NoError(t, err)
-	_, err = q.InsertAccountData(data2)
+	_, err = q.InsertAccountData(tt.Ctx, data2)
 	assert.NoError(t, err)
 
-	record, err := q.GetAccountDataByName(data1.Data.Data.AccountId.Address(), string(data1.Data.Data.DataName))
+	record, err := q.GetAccountDataByName(tt.Ctx, data1.Data.Data.AccountId.Address(), string(data1.Data.Data.DataName))
 	assert.NoError(t, err)
 	tt.Assert.Equal(data1.Data.Data.DataName, xdr.String64(record.Name))
 	tt.Assert.Equal([]byte(data1.Data.Data.DataValue), []byte(record.Value))
 
-	record, err = q.GetAccountDataByName(data1.Data.Data.AccountId.Address(), string(data2.Data.Data.DataName))
+	record, err = q.GetAccountDataByName(tt.Ctx, data1.Data.Data.AccountId.Address(), string(data2.Data.Data.DataName))
 	assert.NoError(t, err)
 	tt.Assert.Equal(data2.Data.Data.DataName, xdr.String64(record.Name))
 	tt.Assert.Equal([]byte(data2.Data.Data.DataValue), []byte(record.Value))

--- a/services/horizon/internal/db2/history/account_signers.go
+++ b/services/horizon/internal/db2/history/account_signers.go
@@ -1,31 +1,33 @@
 package history
 
 import (
+	"context"
+
 	sq "github.com/Masterminds/squirrel"
 
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/support/errors"
 )
 
-func (q *Q) GetAccountSignersByAccountID(id string) ([]AccountSigner, error) {
+func (q *Q) GetAccountSignersByAccountID(ctx context.Context, id string) ([]AccountSigner, error) {
 	sql := selectAccountSigners.
 		Where(sq.Eq{"accounts_signers.account_id": id}).
 		OrderBy("accounts_signers.signer asc")
 
 	var results []AccountSigner
-	if err := q.Select(&results, sql); err != nil {
+	if err := q.Select(ctx, &results, sql); err != nil {
 		return nil, errors.Wrap(err, "could not run select query")
 	}
 
 	return results, nil
 }
 
-func (q *Q) SignersForAccounts(accounts []string) ([]AccountSigner, error) {
+func (q *Q) SignersForAccounts(ctx context.Context, accounts []string) ([]AccountSigner, error) {
 	sql := selectAccountSigners.
 		Where(map[string]interface{}{"accounts_signers.account_id": accounts})
 
 	var results []AccountSigner
-	if err := q.Select(&results, sql); err != nil {
+	if err := q.Select(ctx, &results, sql); err != nil {
 		return nil, errors.Wrap(err, "could not run select query")
 	}
 
@@ -33,7 +35,7 @@ func (q *Q) SignersForAccounts(accounts []string) ([]AccountSigner, error) {
 }
 
 // AccountsForSigner returns a list of `AccountSigner` rows for a given signer
-func (q *Q) AccountsForSigner(signer string, page db2.PageQuery) ([]AccountSigner, error) {
+func (q *Q) AccountsForSigner(ctx context.Context, signer string, page db2.PageQuery) ([]AccountSigner, error) {
 	sql := selectAccountSigners.Where("accounts_signers.signer = ?", signer)
 	sql, err := page.ApplyToUsingCursor(sql, "accounts_signers.account_id", page.Cursor)
 	if err != nil {
@@ -41,7 +43,7 @@ func (q *Q) AccountsForSigner(signer string, page db2.PageQuery) ([]AccountSigne
 	}
 
 	var results []AccountSigner
-	if err := q.Select(&results, sql); err != nil {
+	if err := q.Select(ctx, &results, sql); err != nil {
 		return nil, errors.Wrap(err, "could not run select query")
 	}
 
@@ -50,12 +52,12 @@ func (q *Q) AccountsForSigner(signer string, page db2.PageQuery) ([]AccountSigne
 
 // CreateAccountSigner creates a row in the accounts_signers table.
 // Returns number of rows affected and error.
-func (q *Q) CreateAccountSigner(account, signer string, weight int32, sponsor *string) (int64, error) {
+func (q *Q) CreateAccountSigner(ctx context.Context, account, signer string, weight int32, sponsor *string) (int64, error) {
 	sql := sq.Insert("accounts_signers").
 		Columns("account_id", "signer", "weight", "sponsor").
 		Values(account, signer, weight, sponsor)
 
-	result, err := q.Exec(sql)
+	result, err := q.Exec(ctx, sql)
 	if err != nil {
 		return 0, err
 	}
@@ -65,13 +67,13 @@ func (q *Q) CreateAccountSigner(account, signer string, weight int32, sponsor *s
 
 // RemoveAccountSigner deletes a row in the accounts_signers table.
 // Returns number of rows affected and error.
-func (q *Q) RemoveAccountSigner(account, signer string) (int64, error) {
+func (q *Q) RemoveAccountSigner(ctx context.Context, account, signer string) (int64, error) {
 	sql := sq.Delete("accounts_signers").Where(sq.Eq{
 		"account_id": account,
 		"signer":     signer,
 	})
 
-	result, err := q.Exec(sql)
+	result, err := q.Exec(ctx, sql)
 	if err != nil {
 		return 0, err
 	}

--- a/services/horizon/internal/db2/history/account_signers_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/account_signers_batch_insert_builder.go
@@ -1,7 +1,11 @@
 package history
 
-func (i *accountSignersBatchInsertBuilder) Add(signer AccountSigner) error {
-	return i.builder.Row(map[string]interface{}{
+import (
+	"context"
+)
+
+func (i *accountSignersBatchInsertBuilder) Add(ctx context.Context, signer AccountSigner) error {
+	return i.builder.Row(ctx, map[string]interface{}{
 		"account_id": signer.Account,
 		"signer":     signer.Signer,
 		"weight":     signer.Weight,
@@ -9,6 +13,6 @@ func (i *accountSignersBatchInsertBuilder) Add(signer AccountSigner) error {
 	})
 }
 
-func (i *accountSignersBatchInsertBuilder) Exec() error {
-	return i.builder.Exec()
+func (i *accountSignersBatchInsertBuilder) Exec(ctx context.Context) error {
+	return i.builder.Exec(ctx)
 }

--- a/services/horizon/internal/db2/history/account_signers_test.go
+++ b/services/horizon/internal/db2/history/account_signers_test.go
@@ -15,7 +15,7 @@ func TestQueryEmptyAccountSigners(t *testing.T) {
 	q := &Q{tt.HorizonSession()}
 
 	signer := "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO0"
-	results, err := q.AccountsForSigner(signer, db2.PageQuery{Order: "asc", Limit: 10})
+	results, err := q.AccountsForSigner(tt.Ctx, signer, db2.PageQuery{Order: "asc", Limit: 10})
 	tt.Assert.NoError(err)
 	tt.Assert.Len(results, 0)
 }
@@ -29,7 +29,7 @@ func TestInsertAccountSigner(t *testing.T) {
 	account := "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2"
 	signer := "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4"
 	weight := int32(123)
-	rowsAffected, err := q.CreateAccountSigner(account, signer, weight, nil)
+	rowsAffected, err := q.CreateAccountSigner(tt.Ctx, account, signer, weight, nil)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(int64(1), rowsAffected)
 
@@ -38,13 +38,13 @@ func TestInsertAccountSigner(t *testing.T) {
 		Signer:  signer,
 		Weight:  weight,
 	}
-	results, err := q.AccountsForSigner(signer, db2.PageQuery{Order: "asc", Limit: 10})
+	results, err := q.AccountsForSigner(tt.Ctx, signer, db2.PageQuery{Order: "asc", Limit: 10})
 	tt.Assert.NoError(err)
 	tt.Assert.Len(results, 1)
 	tt.Assert.Equal(expected, results[0])
 
 	weight = 321
-	_, err = q.CreateAccountSigner(account, signer, weight, nil)
+	_, err = q.CreateAccountSigner(tt.Ctx, account, signer, weight, nil)
 	tt.Assert.Error(err)
 	tt.Assert.EqualError(err, `exec failed: pq: duplicate key value violates unique constraint "accounts_signers_pkey"`)
 }
@@ -59,7 +59,7 @@ func TestInsertAccountSignerSponsor(t *testing.T) {
 	signer := "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4"
 	weight := int32(123)
 	sponsor := "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
-	rowsAffected, err := q.CreateAccountSigner(account, signer, weight, &sponsor)
+	rowsAffected, err := q.CreateAccountSigner(tt.Ctx, account, signer, weight, &sponsor)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(int64(1), rowsAffected)
 
@@ -69,7 +69,7 @@ func TestInsertAccountSignerSponsor(t *testing.T) {
 		Weight:  weight,
 		Sponsor: null.StringFrom(sponsor),
 	}
-	results, err := q.AccountsForSigner(signer, db2.PageQuery{Order: "asc", Limit: 10})
+	results, err := q.AccountsForSigner(tt.Ctx, signer, db2.PageQuery{Order: "asc", Limit: 10})
 	tt.Assert.NoError(err)
 	tt.Assert.Len(results, 1)
 	tt.Assert.Equal(expected, results[0])
@@ -84,13 +84,13 @@ func TestMultipleAccountsForSigner(t *testing.T) {
 	account := "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH1"
 	signer := "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO2"
 	weight := int32(123)
-	rowsAffected, err := q.CreateAccountSigner(account, signer, weight, nil)
+	rowsAffected, err := q.CreateAccountSigner(tt.Ctx, account, signer, weight, nil)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(int64(1), rowsAffected)
 
 	anotherAccount := "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
 	anotherWeight := int32(321)
-	rowsAffected, err = q.CreateAccountSigner(anotherAccount, signer, anotherWeight, nil)
+	rowsAffected, err = q.CreateAccountSigner(tt.Ctx, anotherAccount, signer, anotherWeight, nil)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(int64(1), rowsAffected)
 
@@ -106,7 +106,7 @@ func TestMultipleAccountsForSigner(t *testing.T) {
 			Weight:  anotherWeight,
 		},
 	}
-	results, err := q.AccountsForSigner(signer, db2.PageQuery{Order: "asc", Limit: 10})
+	results, err := q.AccountsForSigner(tt.Ctx, signer, db2.PageQuery{Order: "asc", Limit: 10})
 	tt.Assert.NoError(err)
 	tt.Assert.Len(results, 2)
 	tt.Assert.Equal(expected, results)
@@ -120,7 +120,7 @@ func TestRemoveNonExistantAccountSigner(t *testing.T) {
 
 	account := "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH3"
 	signer := "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO5"
-	rowsAffected, err := q.RemoveAccountSigner(account, signer)
+	rowsAffected, err := q.RemoveAccountSigner(tt.Ctx, account, signer)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(int64(0), rowsAffected)
 }
@@ -134,7 +134,7 @@ func TestRemoveAccountSigner(t *testing.T) {
 	account := "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH6"
 	signer := "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO7"
 	weight := int32(123)
-	_, err := q.CreateAccountSigner(account, signer, weight, nil)
+	_, err := q.CreateAccountSigner(tt.Ctx, account, signer, weight, nil)
 	tt.Assert.NoError(err)
 
 	expected := AccountSigner{
@@ -142,16 +142,16 @@ func TestRemoveAccountSigner(t *testing.T) {
 		Signer:  signer,
 		Weight:  weight,
 	}
-	results, err := q.AccountsForSigner(signer, db2.PageQuery{Order: "asc", Limit: 10})
+	results, err := q.AccountsForSigner(tt.Ctx, signer, db2.PageQuery{Order: "asc", Limit: 10})
 	tt.Assert.NoError(err)
 	tt.Assert.Len(results, 1)
 	tt.Assert.Equal(expected, results[0])
 
-	rowsAffected, err := q.RemoveAccountSigner(account, signer)
+	rowsAffected, err := q.RemoveAccountSigner(tt.Ctx, account, signer)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(int64(1), rowsAffected)
 
-	results, err = q.AccountsForSigner(signer, db2.PageQuery{Order: "asc", Limit: 10})
+	results, err = q.AccountsForSigner(tt.Ctx, signer, db2.PageQuery{Order: "asc", Limit: 10})
 	tt.Assert.NoError(err)
 	tt.Assert.Len(results, 0)
 }
@@ -165,13 +165,13 @@ func TestGetAccountSignersByAccountID(t *testing.T) {
 	account := "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH6"
 	signer := "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO7"
 	weight := int32(123)
-	_, err := q.CreateAccountSigner(account, signer, weight, nil)
+	_, err := q.CreateAccountSigner(tt.Ctx, account, signer, weight, nil)
 	tt.Assert.NoError(err)
 
 	signer2 := "GC2WJF6YWMAEHGGAK2UOMZCIOMH4RU7KY2CQEWZQJV2ZQJVXJ335ZSXG"
 	weight2 := int32(100)
 	sponsor := "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
-	_, err = q.CreateAccountSigner(account, signer2, weight2, &sponsor)
+	_, err = q.CreateAccountSigner(tt.Ctx, account, signer2, weight2, &sponsor)
 	tt.Assert.NoError(err)
 
 	expected := []AccountSigner{
@@ -187,7 +187,7 @@ func TestGetAccountSignersByAccountID(t *testing.T) {
 			Sponsor: null.StringFrom(sponsor),
 		},
 	}
-	results, err := q.GetAccountSignersByAccountID(account)
+	results, err := q.GetAccountSignersByAccountID(tt.Ctx, account)
 	tt.Assert.NoError(err)
 	tt.Assert.Len(results, 2)
 	tt.Assert.Equal(expected, results)

--- a/services/horizon/internal/db2/history/account_test.go
+++ b/services/horizon/internal/db2/history/account_test.go
@@ -60,7 +60,7 @@ func TestCreateAccountsSortedOrder(t *testing.T) {
 		"GBYSBDAJZMHL5AMD7QXQ3JEP3Q4GLKADWIJURAAHQALNAWD6Z5XF2RAC",
 		"GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB",
 	}
-	accounts, err := q.CreateAccounts(addresses, 1)
+	accounts, err := q.CreateAccounts(tt.Ctx, addresses, 1)
 	tt.Assert.NoError(err)
 
 	idToAddress := map[int64]string{}
@@ -93,12 +93,12 @@ func TestCreateAccounts(t *testing.T) {
 		"GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB",
 		"GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 	}
-	accounts, err := q.CreateAccounts(addresses, 1)
+	accounts, err := q.CreateAccounts(tt.Ctx, addresses, 1)
 	tt.Assert.NoError(err)
 	tt.Assert.Len(accounts, 2)
 	assertAccountsContainAddresses(tt, accounts, addresses)
 
-	dupAccounts, err := q.CreateAccounts([]string{
+	dupAccounts, err := q.CreateAccounts(tt.Ctx, []string{
 		"GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB",
 		"GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 	}, 2)
@@ -111,7 +111,7 @@ func TestCreateAccounts(t *testing.T) {
 		"GCYVFGI3SEQJGBNQQG7YCMFWEYOHK3XPVOVPA6C566PXWN4SN7LILZSM",
 		"GBYSBDAJZMHL5AMD7QXQ3JEP3Q4GLKADWIJURAAHQALNAWD6Z5XF2RAC",
 	}
-	accounts, err = q.CreateAccounts(addresses, 1)
+	accounts, err = q.CreateAccounts(tt.Ctx, addresses, 1)
 	tt.Assert.NoError(err)
 	assertAccountsContainAddresses(tt, accounts, addresses)
 	for address, accountID := range dupAccounts {

--- a/services/horizon/internal/db2/history/accounts_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/accounts_batch_insert_builder.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"context"
+
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/xdr"
 )
@@ -10,10 +12,10 @@ type accountsBatchInsertBuilder struct {
 	builder db.BatchInsertBuilder
 }
 
-func (i *accountsBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
-	return i.builder.Row(accountToMap(entry))
+func (i *accountsBatchInsertBuilder) Add(ctx context.Context, entry xdr.LedgerEntry) error {
+	return i.builder.Row(ctx, accountToMap(entry))
 }
 
-func (i *accountsBatchInsertBuilder) Exec() error {
-	return i.builder.Exec()
+func (i *accountsBatchInsertBuilder) Exec(ctx context.Context) error {
+	return i.builder.Exec(ctx)
 }

--- a/services/horizon/internal/db2/history/asset_stats_test.go
+++ b/services/horizon/internal/db2/history/asset_stats_test.go
@@ -14,7 +14,7 @@ func TestInsertAssetStats(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
-	tt.Assert.NoError(q.InsertAssetStats([]ExpAssetStat{}, 1))
+	tt.Assert.NoError(q.InsertAssetStats(tt.Ctx, []ExpAssetStat{}, 1))
 
 	assetStats := []ExpAssetStat{
 		{
@@ -52,10 +52,10 @@ func TestInsertAssetStats(t *testing.T) {
 			NumAccounts: 1,
 		},
 	}
-	tt.Assert.NoError(q.InsertAssetStats(assetStats, 1))
+	tt.Assert.NoError(q.InsertAssetStats(tt.Ctx, assetStats, 1))
 
 	for _, assetStat := range assetStats {
-		got, err := q.GetAssetStat(assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
+		got, err := q.GetAssetStat(tt.Ctx, assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
 		tt.Assert.NoError(err)
 		tt.Assert.Equal(got, assetStat)
 	}
@@ -105,11 +105,11 @@ func TestInsertAssetStat(t *testing.T) {
 	}
 
 	for _, assetStat := range assetStats {
-		numChanged, err := q.InsertAssetStat(assetStat)
+		numChanged, err := q.InsertAssetStat(tt.Ctx, assetStat)
 		tt.Assert.NoError(err)
 		tt.Assert.Equal(numChanged, int64(1))
 
-		got, err := q.GetAssetStat(assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
+		got, err := q.GetAssetStat(tt.Ctx, assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
 		tt.Assert.NoError(err)
 		tt.Assert.Equal(got, assetStat)
 	}
@@ -139,23 +139,23 @@ func TestInsertAssetStatAlreadyExistsError(t *testing.T) {
 		NumAccounts: 2,
 	}
 
-	numChanged, err := q.InsertAssetStat(assetStat)
+	numChanged, err := q.InsertAssetStat(tt.Ctx, assetStat)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(numChanged, int64(1))
 
-	numChanged, err = q.InsertAssetStat(assetStat)
+	numChanged, err = q.InsertAssetStat(tt.Ctx, assetStat)
 	tt.Assert.Error(err)
 	tt.Assert.Equal(numChanged, int64(0))
 
 	assetStat.NumAccounts = 4
 	assetStat.Amount = "3"
-	numChanged, err = q.InsertAssetStat(assetStat)
+	numChanged, err = q.InsertAssetStat(tt.Ctx, assetStat)
 	tt.Assert.Error(err)
 	tt.Assert.Equal(numChanged, int64(0))
 
 	assetStat.NumAccounts = 2
 	assetStat.Amount = "1"
-	got, err := q.GetAssetStat(assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
+	got, err := q.GetAssetStat(tt.Ctx, assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(got, assetStat)
 }
@@ -184,11 +184,11 @@ func TestUpdateAssetStatDoesNotExistsError(t *testing.T) {
 		NumAccounts: 2,
 	}
 
-	numChanged, err := q.UpdateAssetStat(assetStat)
+	numChanged, err := q.UpdateAssetStat(tt.Ctx, assetStat)
 	tt.Assert.Nil(err)
 	tt.Assert.Equal(numChanged, int64(0))
 
-	_, err = q.GetAssetStat(assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
+	_, err = q.GetAssetStat(tt.Ctx, assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
 	tt.Assert.Equal(err, sql.ErrNoRows)
 }
 
@@ -217,22 +217,22 @@ func TestUpdateStat(t *testing.T) {
 		NumAccounts: 2,
 	}
 
-	numChanged, err := q.InsertAssetStat(assetStat)
+	numChanged, err := q.InsertAssetStat(tt.Ctx, assetStat)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(numChanged, int64(1))
 
-	got, err := q.GetAssetStat(assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
+	got, err := q.GetAssetStat(tt.Ctx, assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(got, assetStat)
 
 	assetStat.NumAccounts = 50
 	assetStat.Amount = "23"
 
-	numChanged, err = q.UpdateAssetStat(assetStat)
+	numChanged, err = q.UpdateAssetStat(tt.Ctx, assetStat)
 	tt.Assert.Nil(err)
 	tt.Assert.Equal(numChanged, int64(1))
 
-	got, err = q.GetAssetStat(assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
+	got, err = q.GetAssetStat(tt.Ctx, assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(got, assetStat)
 }
@@ -261,7 +261,7 @@ func TestGetAssetStatDoesNotExist(t *testing.T) {
 		NumAccounts: 2,
 	}
 
-	_, err := q.GetAssetStat(assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
+	_, err := q.GetAssetStat(tt.Ctx, assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
 	tt.Assert.Equal(err, sql.ErrNoRows)
 }
 
@@ -290,7 +290,7 @@ func TestRemoveAssetStat(t *testing.T) {
 		NumAccounts: 2,
 	}
 
-	numChanged, err := q.RemoveAssetStat(
+	numChanged, err := q.RemoveAssetStat(tt.Ctx,
 		assetStat.AssetType,
 		assetStat.AssetCode,
 		assetStat.AssetIssuer,
@@ -298,15 +298,15 @@ func TestRemoveAssetStat(t *testing.T) {
 	tt.Assert.Nil(err)
 	tt.Assert.Equal(numChanged, int64(0))
 
-	numChanged, err = q.InsertAssetStat(assetStat)
+	numChanged, err = q.InsertAssetStat(tt.Ctx, assetStat)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(numChanged, int64(1))
 
-	got, err := q.GetAssetStat(assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
+	got, err := q.GetAssetStat(tt.Ctx, assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(got, assetStat)
 
-	numChanged, err = q.RemoveAssetStat(
+	numChanged, err = q.RemoveAssetStat(tt.Ctx,
 		assetStat.AssetType,
 		assetStat.AssetCode,
 		assetStat.AssetIssuer,
@@ -314,7 +314,7 @@ func TestRemoveAssetStat(t *testing.T) {
 	tt.Assert.Nil(err)
 	tt.Assert.Equal(numChanged, int64(1))
 
-	_, err = q.GetAssetStat(assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
+	_, err = q.GetAssetStat(tt.Ctx, assetStat.AssetType, assetStat.AssetCode, assetStat.AssetIssuer)
 	tt.Assert.Equal(err, sql.ErrNoRows)
 }
 
@@ -367,7 +367,7 @@ func TestGetAssetStatsCursorValidation(t *testing.T) {
 				Order:  "asc",
 				Limit:  5,
 			}
-			results, err := q.GetAssetStats("", "", page)
+			results, err := q.GetAssetStats(tt.Ctx, "", "", page)
 			tt.Assert.Empty(results)
 			tt.Assert.NotNil(err)
 			tt.Assert.Contains(err.Error(), testCase.expectedError)
@@ -386,7 +386,7 @@ func TestGetAssetStatsOrderValidation(t *testing.T) {
 		Order: "invalid",
 		Limit: 5,
 	}
-	results, err := q.GetAssetStats("", "", page)
+	results, err := q.GetAssetStats(tt.Ctx, "", "", page)
 	tt.Assert.Empty(results)
 	tt.Assert.NotNil(err)
 	tt.Assert.Contains(err.Error(), "invalid page order")
@@ -481,7 +481,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 		usdAssetStat,
 	}
 	for _, assetStat := range assetStats {
-		numChanged, err := q.InsertAssetStat(assetStat)
+		numChanged, err := q.InsertAssetStat(tt.Ctx, assetStat)
 		tt.Assert.NoError(err)
 		tt.Assert.Equal(numChanged, int64(1))
 	}
@@ -721,12 +721,12 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 				Cursor: testCase.cursor,
 				Limit:  5,
 			}
-			results, err := q.GetAssetStats(testCase.assetCode, testCase.assetIssuer, page)
+			results, err := q.GetAssetStats(tt.Ctx, testCase.assetCode, testCase.assetIssuer, page)
 			tt.Assert.NoError(err)
 			tt.Assert.Equal(testCase.expected, results)
 
 			page.Limit = 1
-			results, err = q.GetAssetStats(testCase.assetCode, testCase.assetIssuer, page)
+			results, err = q.GetAssetStats(tt.Ctx, testCase.assetCode, testCase.assetIssuer, page)
 			tt.Assert.NoError(err)
 			if len(testCase.expected) == 0 {
 				tt.Assert.Equal(testCase.expected, results)
@@ -738,7 +738,7 @@ func TestGetAssetStatsFiltersAndCursor(t *testing.T) {
 				page = page.Invert()
 				page.Limit = 5
 
-				results, err = q.GetAssetStats(testCase.assetCode, testCase.assetIssuer, page)
+				results, err = q.GetAssetStats(tt.Ctx, testCase.assetCode, testCase.assetIssuer, page)
 				tt.Assert.NoError(err)
 				reverseAssetStats(results)
 				tt.Assert.Equal(testCase.expected, results)

--- a/services/horizon/internal/db2/history/asset_test.go
+++ b/services/horizon/internal/db2/history/asset_test.go
@@ -18,7 +18,7 @@ func TestCreateAssetsSortedOrder(t *testing.T) {
 		usdAsset, nativeAsset, eurAsset,
 		xdr.MustNewCreditAsset("CNY", issuer.Address()),
 	}
-	assetMap, err := q.CreateAssets(
+	assetMap, err := q.CreateAssets(tt.Ctx,
 		assets,
 		2,
 	)
@@ -61,7 +61,7 @@ func TestCreateAssets(t *testing.T) {
 	assets := []xdr.Asset{
 		nativeAsset, eurAsset,
 	}
-	assetMap, err := q.CreateAssets(assets, 1)
+	assetMap, err := q.CreateAssets(tt.Ctx, assets, 1)
 	tt.Assert.NoError(err)
 	tt.Assert.Len(assetMap, len(assets))
 
@@ -81,7 +81,7 @@ func TestCreateAssets(t *testing.T) {
 	}
 
 	// CreateAssets handles duplicates
-	assetMap, err = q.CreateAssets(
+	assetMap, err = q.CreateAssets(tt.Ctx,
 		[]xdr.Asset{
 			nativeAsset, nativeAsset, eurAsset, eurAsset,
 			nativeAsset, nativeAsset, eurAsset, eurAsset,
@@ -106,7 +106,7 @@ func TestCreateAssets(t *testing.T) {
 
 	// CreateAssets handles duplicates and new rows
 	assets = append(assets, usdAsset)
-	assetMap, err = q.CreateAssets(assets, 2)
+	assetMap, err = q.CreateAssets(tt.Ctx, assets, 2)
 	tt.Assert.NoError(err)
 	tt.Assert.Len(assetMap, len(assets))
 

--- a/services/horizon/internal/db2/history/claimable_balances_batch_insert_builder_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_batch_insert_builder_test.go
@@ -59,14 +59,14 @@ func TestAddClaimableBalance(t *testing.T) {
 
 	builder := q.NewClaimableBalancesBatchInsertBuilder(2)
 
-	err := builder.Add(&entry)
+	err := builder.Add(tt.Ctx, &entry)
 	tt.Assert.NoError(err)
 
-	err = builder.Exec()
+	err = builder.Exec(tt.Ctx)
 	tt.Assert.NoError(err)
 
 	cbs := []ClaimableBalance{}
-	err = q.Select(&cbs, selectClaimableBalances)
+	err = q.Select(tt.Ctx, &cbs, selectClaimableBalances)
 
 	if tt.Assert.NoError(err) {
 		tt.Assert.Len(cbs, 1)

--- a/services/horizon/internal/db2/history/claimable_balances_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_test.go
@@ -47,22 +47,22 @@ func TestRemoveClaimableBalance(t *testing.T) {
 
 	builder := q.NewClaimableBalancesBatchInsertBuilder(2)
 
-	err := builder.Add(&entry)
+	err := builder.Add(tt.Ctx, &entry)
 	tt.Assert.NoError(err)
 
-	err = builder.Exec()
+	err = builder.Exec(tt.Ctx)
 	tt.Assert.NoError(err)
 
-	r, err := q.FindClaimableBalanceByID(cBalance.BalanceId)
+	r, err := q.FindClaimableBalanceByID(tt.Ctx, cBalance.BalanceId)
 	tt.Assert.NoError(err)
 	tt.Assert.NotNil(r)
 
-	removed, err := q.RemoveClaimableBalance(cBalance)
+	removed, err := q.RemoveClaimableBalance(tt.Ctx, cBalance)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(int64(1), removed)
 
 	cbs := []ClaimableBalance{}
-	err = q.Select(&cbs, selectClaimableBalances)
+	err = q.Select(tt.Ctx, &cbs, selectClaimableBalances)
 
 	if tt.Assert.NoError(err) {
 		tt.Assert.Len(cbs, 0)
@@ -110,7 +110,7 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 
 	builder := q.NewClaimableBalancesBatchInsertBuilder(2)
 
-	err := builder.Add(&entry)
+	err := builder.Add(tt.Ctx, &entry)
 	tt.Assert.NoError(err)
 
 	balanceID = xdr.ClaimableBalanceId{
@@ -150,10 +150,10 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 		LastModifiedLedgerSeq: lastModifiedLedgerSeq,
 	}
 
-	err = builder.Add(&entry)
+	err = builder.Add(tt.Ctx, &entry)
 	tt.Assert.NoError(err)
 
-	err = builder.Exec()
+	err = builder.Exec(tt.Ctx)
 	tt.Assert.NoError(err)
 
 	query := ClaimableBalancesQuery{
@@ -161,7 +161,7 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 		Claimant:  xdr.MustAddressPtr(dest1),
 	}
 
-	cbs, err := q.GetClaimableBalances(query)
+	cbs, err := q.GetClaimableBalances(tt.Ctx, query)
 	tt.Assert.NoError(err)
 	tt.Assert.Len(cbs, 2)
 
@@ -170,7 +170,7 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 	}
 
 	query.Claimant = xdr.MustAddressPtr(dest2)
-	cbs, err = q.GetClaimableBalances(query)
+	cbs, err = q.GetClaimableBalances(tt.Ctx, query)
 	tt.Assert.NoError(err)
 	tt.Assert.Len(cbs, 1)
 	tt.Assert.Equal(dest2, cbs[0].Claimants[1].Destination)
@@ -215,10 +215,10 @@ func TestUpdateClaimableBalance(t *testing.T) {
 
 	builder := q.NewClaimableBalancesBatchInsertBuilder(1)
 
-	err := builder.Add(&entry)
+	err := builder.Add(tt.Ctx, &entry)
 	tt.Assert.NoError(err)
 
-	err = builder.Exec()
+	err = builder.Exec(tt.Ctx)
 	tt.Assert.NoError(err)
 
 	entry = xdr.LedgerEntry{
@@ -235,12 +235,12 @@ func TestUpdateClaimableBalance(t *testing.T) {
 		},
 	}
 
-	updated, err := q.UpdateClaimableBalance(entry)
+	updated, err := q.UpdateClaimableBalance(tt.Ctx, entry)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(int64(1), updated)
 
 	cbs := []ClaimableBalance{}
-	err = q.Select(&cbs, selectClaimableBalances)
+	err = q.Select(tt.Ctx, &cbs, selectClaimableBalances)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", cbs[0].Sponsor.String)
 	tt.Assert.Equal(uint32(lastModifiedLedgerSeq+1), cbs[0].LastModifiedLedger)
@@ -285,13 +285,13 @@ func TestFindClaimableBalance(t *testing.T) {
 
 	builder := q.NewClaimableBalancesBatchInsertBuilder(2)
 
-	err := builder.Add(&entry)
+	err := builder.Add(tt.Ctx, &entry)
 	tt.Assert.NoError(err)
 
-	err = builder.Exec()
+	err = builder.Exec(tt.Ctx)
 	tt.Assert.NoError(err)
 
-	cb, err := q.FindClaimableBalanceByID(cBalance.BalanceId)
+	cb, err := q.FindClaimableBalanceByID(tt.Ctx, cBalance.BalanceId)
 	tt.Assert.NoError(err)
 
 	tt.Assert.Equal(cBalance.BalanceId, cb.BalanceID)
@@ -344,21 +344,21 @@ func TestGetClaimableBalancesByID(t *testing.T) {
 
 	builder := q.NewClaimableBalancesBatchInsertBuilder(2)
 
-	err := builder.Add(&entry)
+	err := builder.Add(tt.Ctx, &entry)
 	tt.Assert.NoError(err)
 
-	err = builder.Exec()
+	err = builder.Exec(tt.Ctx)
 	tt.Assert.NoError(err)
 
-	r, err := q.GetClaimableBalancesByID([]xdr.ClaimableBalanceId{cBalance.BalanceId})
+	r, err := q.GetClaimableBalancesByID(tt.Ctx, []xdr.ClaimableBalanceId{cBalance.BalanceId})
 	tt.Assert.NoError(err)
 	tt.Assert.Len(r, 1)
 
-	removed, err := q.RemoveClaimableBalance(cBalance)
+	removed, err := q.RemoveClaimableBalance(tt.Ctx, cBalance)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(int64(1), removed)
 
-	r, err = q.GetClaimableBalancesByID([]xdr.ClaimableBalanceId{cBalance.BalanceId})
+	r, err = q.GetClaimableBalancesByID(tt.Ctx, []xdr.ClaimableBalanceId{cBalance.BalanceId})
 	tt.Assert.NoError(err)
 	tt.Assert.Len(r, 0)
 }

--- a/services/horizon/internal/db2/history/effect.go
+++ b/services/horizon/internal/db2/history/effect.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -48,9 +49,9 @@ func (q *Q) Effects() *EffectsQ {
 }
 
 // ForAccount filters the operations collection to a specific account
-func (q *EffectsQ) ForAccount(aid string) *EffectsQ {
+func (q *EffectsQ) ForAccount(ctx context.Context, aid string) *EffectsQ {
 	var account Account
-	q.Err = q.parent.AccountByAddress(&account, aid)
+	q.Err = q.parent.AccountByAddress(ctx, &account, aid)
 	if q.Err != nil {
 		return q
 	}
@@ -62,9 +63,9 @@ func (q *EffectsQ) ForAccount(aid string) *EffectsQ {
 
 // ForLedger filters the query to only effects in a specific ledger,
 // specified by its sequence.
-func (q *EffectsQ) ForLedger(seq int32) *EffectsQ {
+func (q *EffectsQ) ForLedger(ctx context.Context, seq int32) *EffectsQ {
 	var ledger Ledger
-	q.Err = q.parent.LedgerBySequence(&ledger, seq)
+	q.Err = q.parent.LedgerBySequence(ctx, &ledger, seq)
 	if q.Err != nil {
 		return q
 	}
@@ -97,9 +98,9 @@ func (q *EffectsQ) ForOperation(id int64) *EffectsQ {
 
 // ForTransaction filters the query to only effects in a specific
 // transaction, specified by the transactions's hex-encoded hash.
-func (q *EffectsQ) ForTransaction(hash string) *EffectsQ {
+func (q *EffectsQ) ForTransaction(ctx context.Context, hash string) *EffectsQ {
 	var tx Transaction
-	q.Err = q.parent.TransactionByHash(&tx, hash)
+	q.Err = q.parent.TransactionByHash(ctx, &tx, hash)
 	if q.Err != nil {
 		return q
 	}
@@ -162,12 +163,12 @@ func (q *EffectsQ) Page(page db2.PageQuery) *EffectsQ {
 }
 
 // Select loads the results of the query specified by `q` into `dest`.
-func (q *EffectsQ) Select(dest interface{}) error {
+func (q *EffectsQ) Select(ctx context.Context, dest interface{}) error {
 	if q.Err != nil {
 		return q.Err
 	}
 
-	q.Err = q.parent.Select(dest, q.sql)
+	q.Err = q.parent.Select(ctx, dest, q.sql)
 	return q.Err
 }
 

--- a/services/horizon/internal/db2/history/effect_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/effect_batch_insert_builder.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"context"
+
 	"github.com/stellar/go/support/db"
 )
 
@@ -8,13 +10,14 @@ import (
 // history_effects table
 type EffectBatchInsertBuilder interface {
 	Add(
+		ctx context.Context,
 		accountID int64,
 		operationID int64,
 		order uint32,
 		effectType EffectType,
 		details []byte,
 	) error
-	Exec() error
+	Exec(ctx context.Context) error
 }
 
 // effectBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
@@ -34,13 +37,14 @@ func (q *Q) NewEffectBatchInsertBuilder(maxBatchSize int) EffectBatchInsertBuild
 
 // Add adds a effect to the batch
 func (i *effectBatchInsertBuilder) Add(
+	ctx context.Context,
 	accountID int64,
 	operationID int64,
 	order uint32,
 	effectType EffectType,
 	details []byte,
 ) error {
-	return i.builder.Row(map[string]interface{}{
+	return i.builder.Row(ctx, map[string]interface{}{
 		"history_account_id":   accountID,
 		"history_operation_id": operationID,
 		"\"order\"":            order,
@@ -49,6 +53,6 @@ func (i *effectBatchInsertBuilder) Add(
 	})
 }
 
-func (i *effectBatchInsertBuilder) Exec() error {
-	return i.builder.Exec()
+func (i *effectBatchInsertBuilder) Exec(ctx context.Context) error {
+	return i.builder.Exec(ctx)
 }

--- a/services/horizon/internal/db2/history/effect_batch_insert_builder_test.go
+++ b/services/horizon/internal/db2/history/effect_batch_insert_builder_test.go
@@ -15,7 +15,7 @@ func TestAddEffect(t *testing.T) {
 	q := &Q{tt.HorizonSession()}
 
 	address := "GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON"
-	accounIDs, err := q.CreateAccounts([]string{address}, 1)
+	accounIDs, err := q.CreateAccounts(tt.Ctx, []string{address}, 1)
 	tt.Assert.NoError(err)
 
 	builder := q.NewEffectBatchInsertBuilder(2)
@@ -25,7 +25,7 @@ func TestAddEffect(t *testing.T) {
 		"asset_type": "native",
 	})
 
-	err = builder.Add(
+	err = builder.Add(tt.Ctx,
 		accounIDs[address],
 		toid.New(sequence, 1, 1).ToInt64(),
 		1,
@@ -34,11 +34,11 @@ func TestAddEffect(t *testing.T) {
 	)
 	tt.Assert.NoError(err)
 
-	err = builder.Exec()
+	err = builder.Exec(tt.Ctx)
 	tt.Assert.NoError(err)
 
 	effects := []Effect{}
-	tt.Assert.NoError(q.Effects().Select(&effects))
+	tt.Assert.NoError(q.Effects().Select(tt.Ctx, &effects))
 	tt.Assert.Len(effects, 1)
 
 	effect := effects[0]

--- a/services/horizon/internal/db2/history/fee_bump_scenario.go
+++ b/services/horizon/internal/db2/history/fee_bump_scenario.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"testing"
@@ -113,7 +114,7 @@ func FeeBumpScenario(tt *test.T, q *Q, successful bool) FeeBumpFixture {
 	}
 	*fixture.Ledger.SuccessfulTransactionCount = 1
 	*fixture.Ledger.FailedTransactionCount = 0
-	_, err := q.Exec(sq.Insert("history_ledgers").SetMap(ledgerToMap(fixture.Ledger)))
+	_, err := q.Exec(context.Background(), sq.Insert("history_ledgers").SetMap(ledgerToMap(fixture.Ledger)))
 	tt.Assert.NoError(err)
 
 	fixture.Envelope = xdr.TransactionEnvelope{
@@ -242,12 +243,13 @@ func FeeBumpScenario(tt *test.T, q *Q, successful bool) FeeBumpFixture {
 		metaXDR:       "AAAAAQAAAAAAAAAA",
 		hash:          "edba3051b2f2d9b713e8a08709d631eccb72c59864ff3c564c68792271bb24a7",
 	})
+	ctx := context.Background()
 	insertBuilder := q.NewTransactionBatchInsertBuilder(2)
 	// include both fee bump and normal transaction in the same batch
 	// to make sure both kinds of transactions can be inserted using a single exec statement
-	tt.Assert.NoError(insertBuilder.Add(feeBumpTransaction, sequence))
-	tt.Assert.NoError(insertBuilder.Add(normalTransaction, sequence))
-	tt.Assert.NoError(insertBuilder.Exec())
+	tt.Assert.NoError(insertBuilder.Add(ctx, feeBumpTransaction, sequence))
+	tt.Assert.NoError(insertBuilder.Add(ctx, normalTransaction, sequence))
+	tt.Assert.NoError(insertBuilder.Exec(ctx))
 
 	account := fixture.Envelope.SourceAccount().ToAccountId()
 	feeBumpAccount := fixture.Envelope.FeeBumpAccount().ToAccountId()
@@ -259,6 +261,7 @@ func FeeBumpScenario(tt *test.T, q *Q, successful bool) FeeBumpFixture {
 	tt.Assert.NoError(err)
 
 	tt.Assert.NoError(opBuilder.Add(
+		ctx,
 		toid.New(fixture.Ledger.Sequence, 1, 1).ToInt64(),
 		toid.New(fixture.Ledger.Sequence, 1, 0).ToInt64(),
 		1,
@@ -266,16 +269,17 @@ func FeeBumpScenario(tt *test.T, q *Q, successful bool) FeeBumpFixture {
 		details,
 		account.Address(),
 	))
-	tt.Assert.NoError(opBuilder.Exec())
+	tt.Assert.NoError(opBuilder.Exec(ctx))
 
 	effectBuilder := q.NewEffectBatchInsertBuilder(2)
 	details, err = json.Marshal(map[string]interface{}{"new_seq": 98})
 	tt.Assert.NoError(err)
 
-	accounIDs, err := q.CreateAccounts([]string{account.Address()}, 1)
+	accounIDs, err := q.CreateAccounts(ctx, []string{account.Address()}, 1)
 	tt.Assert.NoError(err)
 
 	err = effectBuilder.Add(
+		ctx,
 		accounIDs[account.Address()],
 		toid.New(fixture.Ledger.Sequence, 1, 1).ToInt64(),
 		1,
@@ -283,7 +287,7 @@ func FeeBumpScenario(tt *test.T, q *Q, successful bool) FeeBumpFixture {
 		details,
 	)
 	tt.Assert.NoError(err)
-	tt.Assert.NoError(effectBuilder.Exec())
+	tt.Assert.NoError(effectBuilder.Exec(ctx))
 
 	fixture.Transaction = Transaction{
 		TransactionWithoutLedger: TransactionWithoutLedger{
@@ -333,7 +337,7 @@ func FeeBumpScenario(tt *test.T, q *Q, successful bool) FeeBumpFixture {
 		},
 	}
 
-	results, err := q.TransactionsByIDs(fixture.Transaction.ID, fixture.NormalTransaction.ID)
+	results, err := q.TransactionsByIDs(ctx, fixture.Transaction.ID, fixture.NormalTransaction.ID)
 	tt.Assert.NoError(err)
 
 	fixture.Transaction.CreatedAt = results[fixture.Transaction.ID].CreatedAt

--- a/services/horizon/internal/db2/history/ingestion.go
+++ b/services/horizon/internal/db2/history/ingestion.go
@@ -1,12 +1,16 @@
 package history
 
+import (
+	"context"
+)
+
 // TruncateIngestStateTables clears out ingestion state tables.
 // Ingestion state tables are horizon database tables populated by
 // the ingestion system using history archive snapshots.
 // Any horizon database tables which cannot be populated using
 // history archive snapshots will not be truncated.
-func (q *Q) TruncateIngestStateTables() error {
-	return q.TruncateTables([]string{
+func (q *Q) TruncateIngestStateTables(ctx context.Context) error {
+	return q.TruncateTables(ctx, []string{
 		"accounts",
 		"accounts_data",
 		"accounts_signers",

--- a/services/horizon/internal/db2/history/ledger_cache.go
+++ b/services/horizon/internal/db2/history/ledger_cache.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"context"
+
 	"github.com/stellar/go/support/errors"
 )
 
@@ -18,7 +20,7 @@ func (lc *LedgerCache) Queue(seq int32) {
 
 // Load loads a batch of ledgers identified by `sequences`, using `q`,
 // and populates the cache with the results
-func (lc *LedgerCache) Load(q *Q) error {
+func (lc *LedgerCache) Load(ctx context.Context, q *Q) error {
 	lc.lock.Lock()
 	defer lc.lock.Unlock()
 
@@ -32,7 +34,7 @@ func (lc *LedgerCache) Load(q *Q) error {
 	}
 
 	var ledgers []Ledger
-	err := q.LedgersBySequence(&ledgers, sequences...)
+	err := q.LedgersBySequence(ctx, &ledgers, sequences...)
 	if err != nil {
 		return errors.Wrap(err, "failed to load ledger batch")
 	}

--- a/services/horizon/internal/db2/history/ledger_cache_test.go
+++ b/services/horizon/internal/db2/history/ledger_cache_test.go
@@ -16,7 +16,7 @@ func TestLedgerCache(t *testing.T) {
 	lc.Queue(2)
 	lc.Queue(3)
 
-	err := lc.Load(q)
+	err := lc.Load(tt.Ctx, q)
 
 	if tt.Assert.NoError(err) {
 		tt.Assert.Contains(lc.Records, int32(2))

--- a/services/horizon/internal/db2/history/ledger_test.go
+++ b/services/horizon/internal/db2/history/ledger_test.go
@@ -21,22 +21,22 @@ func TestLedgerQueries(t *testing.T) {
 
 	// Test LedgerBySequence
 	var l Ledger
-	err := q.LedgerBySequence(&l, 3)
+	err := q.LedgerBySequence(tt.Ctx, &l, 3)
 	tt.Assert.NoError(err)
 
-	err = q.LedgerBySequence(&l, 100000)
+	err = q.LedgerBySequence(tt.Ctx, &l, 100000)
 	tt.Assert.Equal(err, sql.ErrNoRows)
 
 	// Test Ledgers()
 	ls := []Ledger{}
-	err = q.Ledgers().Select(&ls)
+	err = q.Ledgers().Select(tt.Ctx, &ls)
 
 	if tt.Assert.NoError(err) {
 		tt.Assert.Len(ls, 3)
 	}
 
 	// LedgersBySequence
-	err = q.LedgersBySequence(&ls, 1, 2, 3)
+	err = q.LedgersBySequence(tt.Ctx, &ls, 1, 2, 3)
 
 	if tt.Assert.NoError(err) {
 		tt.Assert.Len(ls, 3)
@@ -116,7 +116,7 @@ func TestInsertLedger(t *testing.T) {
 	tt.Assert.NoError(err)
 	expectedLedger.LedgerHeaderXDR = null.NewString(ledgerHeaderBase64, true)
 
-	rowsAffected, err := q.InsertLedger(
+	rowsAffected, err := q.InsertLedger(tt.Ctx,
 		ledgerEntry,
 		12,
 		3,
@@ -128,7 +128,7 @@ func TestInsertLedger(t *testing.T) {
 	tt.Assert.Equal(rowsAffected, int64(1))
 
 	var ledgerFromDB Ledger
-	err = q.LedgerBySequence(&ledgerFromDB, 69859)
+	err = q.LedgerBySequence(tt.Ctx, &ledgerFromDB, 69859)
 	tt.Assert.NoError(err)
 
 	expectedLedger.CreatedAt = ledgerFromDB.CreatedAt

--- a/services/horizon/internal/db2/history/ledger_test.go
+++ b/services/horizon/internal/db2/history/ledger_test.go
@@ -58,7 +58,7 @@ func TestInsertLedger(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	ledgerHashStore := ledgerbackend.NewHorizonDBLedgerHashStore(tt.HorizonSession())
+	ledgerHashStore := ledgerbackend.NewHorizonDBLedgerHashStore(tt.Ctx, tt.HorizonSession())
 	_, exists, err := ledgerHashStore.GetLedgerHash(100)
 	tt.Assert.NoError(err)
 	tt.Assert.False(exists)

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -3,6 +3,7 @@
 package history
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
@@ -215,8 +216,8 @@ type AccountEntry struct {
 }
 
 type AccountsBatchInsertBuilder interface {
-	Add(entry xdr.LedgerEntry) error
-	Exec() error
+	Add(ctx context.Context, entry xdr.LedgerEntry) error
+	Exec(ctx context.Context) error
 }
 
 type IngestionQ interface {
@@ -237,32 +238,32 @@ type IngestionQ interface {
 	QSigners
 	//QTrades
 	NewTradeBatchInsertBuilder(maxBatchSize int) TradeBatchInsertBuilder
-	CreateAssets(assets []xdr.Asset, batchSize int) (map[string]Asset, error)
+	CreateAssets(ctx context.Context, assets []xdr.Asset, batchSize int) (map[string]Asset, error)
 	QTransactions
 	QTrustLines
 
-	Begin() error
-	BeginTx(*sql.TxOptions) error
-	Commit() error
+	Begin(context.Context) error
+	BeginTx(context.Context, *sql.TxOptions) error
+	Commit(context.Context) error
 	CloneIngestionQ() IngestionQ
-	Rollback() error
+	Rollback(context.Context) error
 	GetTx() *sqlx.Tx
-	GetIngestVersion() (int, error)
-	UpdateExpStateInvalid(bool) error
-	UpdateIngestVersion(int) error
-	GetExpStateInvalid() (bool, error)
-	GetLatestHistoryLedger() (uint32, error)
-	GetOfferCompactionSequence() (uint32, error)
-	TruncateIngestStateTables() error
-	DeleteRangeAll(start, end int64) error
+	GetIngestVersion(context.Context) (int, error)
+	UpdateExpStateInvalid(context.Context, bool) error
+	UpdateIngestVersion(context.Context, int) error
+	GetExpStateInvalid(context.Context) (bool, error)
+	GetLatestHistoryLedger(context.Context) (uint32, error)
+	GetOfferCompactionSequence(context.Context) (uint32, error)
+	TruncateIngestStateTables(context.Context) error
+	DeleteRangeAll(ctx context.Context, start, end int64) error
 }
 
 // QAccounts defines account related queries.
 type QAccounts interface {
 	NewAccountsBatchInsertBuilder(maxBatchSize int) AccountsBatchInsertBuilder
-	GetAccountsByIDs(ids []string) ([]AccountEntry, error)
-	UpsertAccounts(accounts []xdr.LedgerEntry) error
-	RemoveAccount(accountID string) (int64, error)
+	GetAccountsByIDs(ctx context.Context, ids []string) ([]AccountEntry, error)
+	UpsertAccounts(ctx context.Context, accounts []xdr.LedgerEntry) error
+	RemoveAccount(ctx context.Context, accountID string) (int64, error)
 }
 
 // AccountSigner is a row of data from the `accounts_signers` table
@@ -274,8 +275,8 @@ type AccountSigner struct {
 }
 
 type AccountSignersBatchInsertBuilder interface {
-	Add(signer AccountSigner) error
-	Exec() error
+	Add(ctx context.Context, signer AccountSigner) error
+	Exec(ctx context.Context) error
 }
 
 // accountSignersBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
@@ -295,8 +296,8 @@ type Data struct {
 type AccountDataValue []byte
 
 type AccountDataBatchInsertBuilder interface {
-	Add(entry xdr.LedgerEntry) error
-	Exec() error
+	Add(ctx context.Context, entry xdr.LedgerEntry) error
+	Exec(ctx context.Context) error
 }
 
 // accountDataBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
@@ -307,11 +308,11 @@ type accountDataBatchInsertBuilder struct {
 // QData defines account data related queries.
 type QData interface {
 	NewAccountDataBatchInsertBuilder(maxBatchSize int) AccountDataBatchInsertBuilder
-	CountAccountsData() (int, error)
-	GetAccountDataByKeys(keys []xdr.LedgerKeyData) ([]Data, error)
-	InsertAccountData(entry xdr.LedgerEntry) (int64, error)
-	UpdateAccountData(entry xdr.LedgerEntry) (int64, error)
-	RemoveAccountData(key xdr.LedgerKeyData) (int64, error)
+	CountAccountsData(ctx context.Context) (int, error)
+	GetAccountDataByKeys(ctx context.Context, keys []xdr.LedgerKeyData) ([]Data, error)
+	InsertAccountData(ctx context.Context, entry xdr.LedgerEntry) (int64, error)
+	UpdateAccountData(ctx context.Context, entry xdr.LedgerEntry) (int64, error)
+	RemoveAccountData(ctx context.Context, key xdr.LedgerKeyData) (int64, error)
 }
 
 // Asset is a row of data from the `history_assets` table
@@ -400,17 +401,17 @@ func (e *ExpAssetStatBalances) Scan(src interface{}) error {
 
 // QAssetStats defines exp_asset_stats related queries.
 type QAssetStats interface {
-	InsertAssetStats(stats []ExpAssetStat, batchSize int) error
-	InsertAssetStat(stat ExpAssetStat) (int64, error)
-	UpdateAssetStat(stat ExpAssetStat) (int64, error)
-	GetAssetStat(assetType xdr.AssetType, assetCode, assetIssuer string) (ExpAssetStat, error)
-	RemoveAssetStat(assetType xdr.AssetType, assetCode, assetIssuer string) (int64, error)
-	GetAssetStats(assetCode, assetIssuer string, page db2.PageQuery) ([]ExpAssetStat, error)
-	CountTrustLines() (int, error)
+	InsertAssetStats(ctx context.Context, stats []ExpAssetStat, batchSize int) error
+	InsertAssetStat(ctx context.Context, stat ExpAssetStat) (int64, error)
+	UpdateAssetStat(ctx context.Context, stat ExpAssetStat) (int64, error)
+	GetAssetStat(ctx context.Context, assetType xdr.AssetType, assetCode, assetIssuer string) (ExpAssetStat, error)
+	RemoveAssetStat(ctx context.Context, assetType xdr.AssetType, assetCode, assetIssuer string) (int64, error)
+	GetAssetStats(ctx context.Context, assetCode, assetIssuer string, page db2.PageQuery) ([]ExpAssetStat, error)
+	CountTrustLines(ctx context.Context) (int, error)
 }
 
 type QCreateAccountsHistory interface {
-	CreateAccounts(addresses []string, maxBatchSize int) (map[string]int64, error)
+	CreateAccounts(ctx context.Context, addresses []string, maxBatchSize int) (map[string]int64, error)
 }
 
 // Effect is a row of data from the `history_effects` table
@@ -580,8 +581,8 @@ type Offer struct {
 }
 
 type OffersBatchInsertBuilder interface {
-	Add(offer Offer) error
-	Exec() error
+	Add(ctx context.Context, offer Offer) error
+	Exec(ctx context.Context) error
 }
 
 // offersBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
@@ -608,15 +609,15 @@ type Q struct {
 
 // QSigners defines signer related queries.
 type QSigners interface {
-	GetLastLedgerIngestNonBlocking() (uint32, error)
-	GetLastLedgerIngest() (uint32, error)
-	UpdateLastLedgerIngest(ledgerSequence uint32) error
-	AccountsForSigner(signer string, page db2.PageQuery) ([]AccountSigner, error)
+	GetLastLedgerIngestNonBlocking(ctx context.Context) (uint32, error)
+	GetLastLedgerIngest(ctx context.Context) (uint32, error)
+	UpdateLastLedgerIngest(ctx context.Context, ledgerSequence uint32) error
+	AccountsForSigner(ctx context.Context, signer string, page db2.PageQuery) ([]AccountSigner, error)
 	NewAccountSignersBatchInsertBuilder(maxBatchSize int) AccountSignersBatchInsertBuilder
-	CreateAccountSigner(account, signer string, weight int32, sponsor *string) (int64, error)
-	RemoveAccountSigner(account, signer string) (int64, error)
-	SignersForAccounts(accounts []string) ([]AccountSigner, error)
-	CountAccounts() (int, error)
+	CreateAccountSigner(ctx context.Context, account, signer string, weight int32, sponsor *string) (int64, error)
+	RemoveAccountSigner(ctx context.Context, account, signer string) (int64, error)
+	SignersForAccounts(ctx context.Context, accounts []string) ([]AccountSigner, error)
+	CountAccounts(ctx context.Context) (int, error)
 }
 
 // OffersQuery is a helper struct to configure queries to offers
@@ -709,16 +710,16 @@ type TrustLine struct {
 // QTrustLines defines trust lines related queries.
 type QTrustLines interface {
 	NewTrustLinesBatchInsertBuilder(maxBatchSize int) TrustLinesBatchInsertBuilder
-	GetTrustLinesByKeys(keys []xdr.LedgerKeyTrustLine) ([]TrustLine, error)
-	InsertTrustLine(entry xdr.LedgerEntry) (int64, error)
-	UpdateTrustLine(entry xdr.LedgerEntry) (int64, error)
-	UpsertTrustLines(entries []xdr.LedgerEntry) error
-	RemoveTrustLine(key xdr.LedgerKeyTrustLine) (int64, error)
+	GetTrustLinesByKeys(ctx context.Context, keys []xdr.LedgerKeyTrustLine) ([]TrustLine, error)
+	InsertTrustLine(ctx context.Context, entry xdr.LedgerEntry) (int64, error)
+	UpdateTrustLine(ctx context.Context, entry xdr.LedgerEntry) (int64, error)
+	UpsertTrustLines(ctx context.Context, entries []xdr.LedgerEntry) error
+	RemoveTrustLine(ctx context.Context, key xdr.LedgerKeyTrustLine) (int64, error)
 }
 
 type TrustLinesBatchInsertBuilder interface {
-	Add(entry xdr.LedgerEntry) error
-	Exec() error
+	Add(ctx context.Context, entry xdr.LedgerEntry) error
+	Exec(ctx context.Context) error
 }
 
 // trustLinesBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
@@ -772,31 +773,31 @@ func (q *Q) NewTrustLinesBatchInsertBuilder(maxBatchSize int) TrustLinesBatchIns
 }
 
 // ElderLedger loads the oldest ledger known to the history database
-func (q *Q) ElderLedger(dest interface{}) error {
-	return q.GetRaw(dest, `SELECT COALESCE(MIN(sequence), 0) FROM history_ledgers`)
+func (q *Q) ElderLedger(ctx context.Context, dest interface{}) error {
+	return q.GetRaw(ctx, dest, `SELECT COALESCE(MIN(sequence), 0) FROM history_ledgers`)
 }
 
 // GetLatestHistoryLedger loads the latest known ledger. Returns 0 if no ledgers in
 // `history_ledgers` table.
-func (q *Q) GetLatestHistoryLedger() (uint32, error) {
+func (q *Q) GetLatestHistoryLedger(ctx context.Context) (uint32, error) {
 	var value uint32
-	err := q.LatestLedger(&value)
+	err := q.LatestLedger(ctx, &value)
 	return value, err
 }
 
 // LatestLedger loads the latest known ledger
-func (q *Q) LatestLedger(dest interface{}) error {
-	return q.GetRaw(dest, `SELECT COALESCE(MAX(sequence), 0) FROM history_ledgers`)
+func (q *Q) LatestLedger(ctx context.Context, dest interface{}) error {
+	return q.GetRaw(ctx, dest, `SELECT COALESCE(MAX(sequence), 0) FROM history_ledgers`)
 }
 
 // LatestLedgerSequenceClosedAt loads the latest known ledger sequence and close time,
 // returns empty values if no ledgers in a DB.
-func (q *Q) LatestLedgerSequenceClosedAt() (int32, time.Time, error) {
+func (q *Q) LatestLedgerSequenceClosedAt(ctx context.Context) (int32, time.Time, error) {
 	ledger := struct {
 		Sequence int32     `db:"sequence"`
 		ClosedAt time.Time `db:"closed_at"`
 	}{}
-	err := q.GetRaw(&ledger, `SELECT sequence, closed_at FROM history_ledgers ORDER BY sequence DESC LIMIT 1`)
+	err := q.GetRaw(ctx, &ledger, `SELECT sequence, closed_at FROM history_ledgers ORDER BY sequence DESC LIMIT 1`)
 	if err == sql.ErrNoRows {
 		// Will return empty values
 		return ledger.Sequence, ledger.ClosedAt, nil
@@ -806,8 +807,8 @@ func (q *Q) LatestLedgerSequenceClosedAt() (int32, time.Time, error) {
 
 // LatestLedgerBaseFeeAndSequence loads the latest known ledger's base fee and
 // sequence number.
-func (q *Q) LatestLedgerBaseFeeAndSequence(dest interface{}) error {
-	return q.GetRaw(dest, `
+func (q *Q) LatestLedgerBaseFeeAndSequence(ctx context.Context, dest interface{}) error {
+	return q.GetRaw(ctx, dest, `
 		SELECT base_fee, sequence
 		FROM history_ledgers
 		WHERE sequence = (SELECT COALESCE(MAX(sequence), 0) FROM history_ledgers)
@@ -821,32 +822,32 @@ func (q *Q) CloneIngestionQ() IngestionQ {
 
 // DeleteRangeAll deletes a range of rows from all history tables between
 // `start` and `end` (exclusive).
-func (q *Q) DeleteRangeAll(start, end int64) error {
-	err := q.DeleteRange(start, end, "history_effects", "history_operation_id")
+func (q *Q) DeleteRangeAll(ctx context.Context, start, end int64) error {
+	err := q.DeleteRange(ctx, start, end, "history_effects", "history_operation_id")
 	if err != nil {
 		return errors.Wrap(err, "Error clearing history_effects")
 	}
-	err = q.DeleteRange(start, end, "history_operation_participants", "history_operation_id")
+	err = q.DeleteRange(ctx, start, end, "history_operation_participants", "history_operation_id")
 	if err != nil {
 		return errors.Wrap(err, "Error clearing history_operation_participants")
 	}
-	err = q.DeleteRange(start, end, "history_operations", "id")
+	err = q.DeleteRange(ctx, start, end, "history_operations", "id")
 	if err != nil {
 		return errors.Wrap(err, "Error clearing history_operations")
 	}
-	err = q.DeleteRange(start, end, "history_transaction_participants", "history_transaction_id")
+	err = q.DeleteRange(ctx, start, end, "history_transaction_participants", "history_transaction_id")
 	if err != nil {
 		return errors.Wrap(err, "Error clearing history_transaction_participants")
 	}
-	err = q.DeleteRange(start, end, "history_transactions", "id")
+	err = q.DeleteRange(ctx, start, end, "history_transactions", "id")
 	if err != nil {
 		return errors.Wrap(err, "Error clearing history_transactions")
 	}
-	err = q.DeleteRange(start, end, "history_ledgers", "id")
+	err = q.DeleteRange(ctx, start, end, "history_ledgers", "id")
 	if err != nil {
 		return errors.Wrap(err, "Error clearing history_ledgers")
 	}
-	err = q.DeleteRange(start, end, "history_trades", "history_operation_id")
+	err = q.DeleteRange(ctx, start, end, "history_trades", "history_operation_id")
 	if err != nil {
 		return errors.Wrap(err, "Error clearing history_trades")
 	}

--- a/services/horizon/internal/db2/history/main_test.go
+++ b/services/horizon/internal/db2/history/main_test.go
@@ -14,7 +14,7 @@ func TestLatestLedger(t *testing.T) {
 	q := &Q{tt.HorizonSession()}
 
 	var seq int
-	err := q.LatestLedger(&seq)
+	err := q.LatestLedger(tt.Ctx, &seq)
 
 	if tt.Assert.NoError(err) {
 		tt.Assert.Equal(3, seq)
@@ -27,7 +27,7 @@ func TestLatestLedgerSequenceClosedAt(t *testing.T) {
 	defer tt.Finish()
 	q := &Q{tt.HorizonSession()}
 
-	sequence, closedAt, err := q.LatestLedgerSequenceClosedAt()
+	sequence, closedAt, err := q.LatestLedgerSequenceClosedAt(tt.Ctx)
 	if tt.Assert.NoError(err) {
 		tt.Assert.Equal(int32(3), sequence)
 		tt.Assert.Equal("2019-10-31T13:19:46Z", closedAt.Format(time.RFC3339))
@@ -35,7 +35,7 @@ func TestLatestLedgerSequenceClosedAt(t *testing.T) {
 
 	test.ResetHorizonDB(t, tt.HorizonDB)
 
-	sequence, closedAt, err = q.LatestLedgerSequenceClosedAt()
+	sequence, closedAt, err = q.LatestLedgerSequenceClosedAt(tt.Ctx)
 	if tt.Assert.NoError(err) {
 		tt.Assert.Equal(int32(0), sequence)
 		tt.Assert.Equal("0001-01-01T00:00:00Z", closedAt.Format(time.RFC3339))
@@ -48,7 +48,7 @@ func TestGetLatestHistoryLedgerEmptyDB(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	value, err := q.GetLatestHistoryLedger()
+	value, err := q.GetLatestHistoryLedger(tt.Ctx)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(uint32(0), value)
 }
@@ -60,7 +60,7 @@ func TestElderLedger(t *testing.T) {
 	q := &Q{tt.HorizonSession()}
 
 	var seq int
-	err := q.ElderLedger(&seq)
+	err := q.ElderLedger(tt.Ctx, &seq)
 
 	if tt.Assert.NoError(err) {
 		tt.Assert.Equal(1, seq)

--- a/services/horizon/internal/db2/history/mock_account_data_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_account_data_batch_insert_builder.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"context"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/mock"
 )
@@ -9,12 +10,12 @@ type MockAccountDataBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockAccountDataBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
-	a := m.Called(entry)
+func (m *MockAccountDataBatchInsertBuilder) Add(ctx context.Context, entry xdr.LedgerEntry) error {
+	a := m.Called(ctx, entry)
 	return a.Error(0)
 }
 
-func (m *MockAccountDataBatchInsertBuilder) Exec() error {
-	a := m.Called()
+func (m *MockAccountDataBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
 	return a.Error(0)
 }

--- a/services/horizon/internal/db2/history/mock_account_signers_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_account_signers_batch_insert_builder.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"context"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -8,12 +9,12 @@ type MockAccountSignersBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockAccountSignersBatchInsertBuilder) Add(signer AccountSigner) error {
-	a := m.Called(signer)
+func (m *MockAccountSignersBatchInsertBuilder) Add(ctx context.Context, signer AccountSigner) error {
+	a := m.Called(ctx, signer)
 	return a.Error(0)
 }
 
-func (m *MockAccountSignersBatchInsertBuilder) Exec() error {
-	a := m.Called()
+func (m *MockAccountSignersBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
 	return a.Error(0)
 }

--- a/services/horizon/internal/db2/history/mock_effect_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_effect_batch_insert_builder.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"context"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -10,14 +11,14 @@ type MockEffectBatchInsertBuilder struct {
 }
 
 // Add mock
-func (m *MockEffectBatchInsertBuilder) Add(
+func (m *MockEffectBatchInsertBuilder) Add(ctx context.Context,
 	accountID int64,
 	operationID int64,
 	order uint32,
 	effectType EffectType,
 	details []byte,
 ) error {
-	a := m.Called(
+	a := m.Called(ctx,
 		accountID,
 		operationID,
 		order,
@@ -28,7 +29,7 @@ func (m *MockEffectBatchInsertBuilder) Add(
 }
 
 // Exec mock
-func (m *MockEffectBatchInsertBuilder) Exec() error {
-	a := m.Called()
+func (m *MockEffectBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
 	return a.Error(0)
 }

--- a/services/horizon/internal/db2/history/mock_offers_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_offers_batch_insert_builder.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"context"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -8,12 +9,12 @@ type MockOffersBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockOffersBatchInsertBuilder) Add(row Offer) error {
-	a := m.Called(row)
+func (m *MockOffersBatchInsertBuilder) Add(ctx context.Context, row Offer) error {
+	a := m.Called(ctx, row)
 	return a.Error(0)
 }
 
-func (m *MockOffersBatchInsertBuilder) Exec() error {
-	a := m.Called()
+func (m *MockOffersBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
 	return a.Error(0)
 }

--- a/services/horizon/internal/db2/history/mock_operation_participant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_operation_participant_batch_insert_builder.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"context"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -10,13 +11,13 @@ type MockOperationParticipantBatchInsertBuilder struct {
 }
 
 // Add mock
-func (m *MockOperationParticipantBatchInsertBuilder) Add(operationID int64, accountID int64) error {
-	a := m.Called(operationID, accountID)
+func (m *MockOperationParticipantBatchInsertBuilder) Add(ctx context.Context, operationID int64, accountID int64) error {
+	a := m.Called(ctx, operationID, accountID)
 	return a.Error(0)
 }
 
 // Exec mock
-func (m *MockOperationParticipantBatchInsertBuilder) Exec() error {
-	a := m.Called()
+func (m *MockOperationParticipantBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
 	return a.Error(0)
 }

--- a/services/horizon/internal/db2/history/mock_operations_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_operations_batch_insert_builder.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"context"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/mock"
 )
@@ -11,7 +12,7 @@ type MockOperationsBatchInsertBuilder struct {
 }
 
 // Add mock
-func (m *MockOperationsBatchInsertBuilder) Add(
+func (m *MockOperationsBatchInsertBuilder) Add(ctx context.Context,
 	id int64,
 	transactionID int64,
 	applicationOrder uint32,
@@ -19,7 +20,7 @@ func (m *MockOperationsBatchInsertBuilder) Add(
 	details []byte,
 	sourceAccount string,
 ) error {
-	a := m.Called(
+	a := m.Called(ctx,
 		id,
 		transactionID,
 		applicationOrder,
@@ -31,7 +32,7 @@ func (m *MockOperationsBatchInsertBuilder) Add(
 }
 
 // Exec mock
-func (m *MockOperationsBatchInsertBuilder) Exec() error {
-	a := m.Called()
+func (m *MockOperationsBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
 	return a.Error(0)
 }

--- a/services/horizon/internal/db2/history/mock_q_accounts.go
+++ b/services/horizon/internal/db2/history/mock_q_accounts.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"context"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/stellar/go/xdr"
@@ -11,8 +12,8 @@ type MockQAccounts struct {
 	mock.Mock
 }
 
-func (m *MockQAccounts) GetAccountsByIDs(ids []string) ([]AccountEntry, error) {
-	a := m.Called(ids)
+func (m *MockQAccounts) GetAccountsByIDs(ctx context.Context, ids []string) ([]AccountEntry, error) {
+	a := m.Called(ctx, ids)
 	return a.Get(0).([]AccountEntry), a.Error(1)
 }
 
@@ -21,12 +22,12 @@ func (m *MockQAccounts) NewAccountsBatchInsertBuilder(maxBatchSize int) Accounts
 	return a.Get(0).(AccountsBatchInsertBuilder)
 }
 
-func (m *MockQAccounts) UpsertAccounts(accounts []xdr.LedgerEntry) error {
-	a := m.Called(accounts)
+func (m *MockQAccounts) UpsertAccounts(ctx context.Context, accounts []xdr.LedgerEntry) error {
+	a := m.Called(ctx, accounts)
 	return a.Error(0)
 }
 
-func (m *MockQAccounts) RemoveAccount(accountID string) (int64, error) {
-	a := m.Called(accountID)
+func (m *MockQAccounts) RemoveAccount(ctx context.Context, accountID string) (int64, error) {
+	a := m.Called(ctx, accountID)
 	return a.Get(0).(int64), a.Error(1)
 }

--- a/services/horizon/internal/db2/history/mock_q_asset_stats.go
+++ b/services/horizon/internal/db2/history/mock_q_asset_stats.go
@@ -1,9 +1,12 @@
 package history
 
 import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/xdr"
-	"github.com/stretchr/testify/mock"
 )
 
 // MockQAssetStats is a mock implementation of the QAssetStats interface
@@ -11,37 +14,37 @@ type MockQAssetStats struct {
 	mock.Mock
 }
 
-func (m *MockQAssetStats) InsertAssetStats(assetStats []ExpAssetStat, batchSize int) error {
-	a := m.Called(assetStats, batchSize)
+func (m *MockQAssetStats) InsertAssetStats(ctx context.Context, assetStats []ExpAssetStat, batchSize int) error {
+	a := m.Called(ctx, assetStats, batchSize)
 	return a.Error(0)
 }
 
-func (m *MockQAssetStats) InsertAssetStat(assetStat ExpAssetStat) (int64, error) {
-	a := m.Called(assetStat)
+func (m *MockQAssetStats) InsertAssetStat(ctx context.Context, assetStat ExpAssetStat) (int64, error) {
+	a := m.Called(ctx, assetStat)
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQAssetStats) UpdateAssetStat(assetStat ExpAssetStat) (int64, error) {
-	a := m.Called(assetStat)
+func (m *MockQAssetStats) UpdateAssetStat(ctx context.Context, assetStat ExpAssetStat) (int64, error) {
+	a := m.Called(ctx, assetStat)
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQAssetStats) GetAssetStat(assetType xdr.AssetType, assetCode, assetIssuer string) (ExpAssetStat, error) {
-	a := m.Called(assetType, assetCode, assetIssuer)
+func (m *MockQAssetStats) GetAssetStat(ctx context.Context, assetType xdr.AssetType, assetCode, assetIssuer string) (ExpAssetStat, error) {
+	a := m.Called(ctx, assetType, assetCode, assetIssuer)
 	return a.Get(0).(ExpAssetStat), a.Error(1)
 }
 
-func (m *MockQAssetStats) RemoveAssetStat(assetType xdr.AssetType, assetCode, assetIssuer string) (int64, error) {
-	a := m.Called(assetType, assetCode, assetIssuer)
+func (m *MockQAssetStats) RemoveAssetStat(ctx context.Context, assetType xdr.AssetType, assetCode, assetIssuer string) (int64, error) {
+	a := m.Called(ctx, assetType, assetCode, assetIssuer)
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQAssetStats) GetAssetStats(assetCode, assetIssuer string, page db2.PageQuery) ([]ExpAssetStat, error) {
-	a := m.Called(assetCode, assetIssuer, page)
+func (m *MockQAssetStats) GetAssetStats(ctx context.Context, assetCode, assetIssuer string, page db2.PageQuery) ([]ExpAssetStat, error) {
+	a := m.Called(ctx, assetCode, assetIssuer, page)
 	return a.Get(0).([]ExpAssetStat), a.Error(1)
 }
 
-func (m *MockQAssetStats) CountTrustLines() (int, error) {
-	a := m.Called()
+func (m *MockQAssetStats) CountTrustLines(ctx context.Context) (int, error) {
+	a := m.Called(ctx)
 	return a.Get(0).(int), a.Error(1)
 }

--- a/services/horizon/internal/db2/history/mock_q_claimable_balances.go
+++ b/services/horizon/internal/db2/history/mock_q_claimable_balances.go
@@ -1,8 +1,11 @@
 package history
 
 import (
-	"github.com/stellar/go/xdr"
+	"context"
+
 	"github.com/stretchr/testify/mock"
+
+	"github.com/stellar/go/xdr"
 )
 
 // MockQClaimableBalances is a mock implementation of the QAccounts interface
@@ -15,23 +18,23 @@ func (m *MockQClaimableBalances) NewClaimableBalancesBatchInsertBuilder(maxBatch
 	return a.Get(0).(ClaimableBalancesBatchInsertBuilder)
 }
 
-func (m *MockQClaimableBalances) CountClaimableBalances() (int, error) {
-	a := m.Called()
+func (m *MockQClaimableBalances) CountClaimableBalances(ctx context.Context) (int, error) {
+	a := m.Called(ctx)
 	return a.Get(0).(int), a.Error(1)
 }
 
-func (m *MockQClaimableBalances) GetClaimableBalancesByID(ids []xdr.ClaimableBalanceId) ([]ClaimableBalance, error) {
-	a := m.Called(ids)
+func (m *MockQClaimableBalances) GetClaimableBalancesByID(ctx context.Context, ids []xdr.ClaimableBalanceId) ([]ClaimableBalance, error) {
+	a := m.Called(ctx, ids)
 	return a.Get(0).([]ClaimableBalance), a.Error(1)
 }
 
-func (m *MockQClaimableBalances) UpdateClaimableBalance(entry xdr.LedgerEntry) (int64, error) {
-	a := m.Called(entry)
+func (m *MockQClaimableBalances) UpdateClaimableBalance(ctx context.Context, entry xdr.LedgerEntry) (int64, error) {
+	a := m.Called(ctx, entry)
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQClaimableBalances) RemoveClaimableBalance(cBalance xdr.ClaimableBalanceEntry) (int64, error) {
-	a := m.Called(cBalance)
+func (m *MockQClaimableBalances) RemoveClaimableBalance(ctx context.Context, cBalance xdr.ClaimableBalanceEntry) (int64, error) {
+	a := m.Called(ctx, cBalance)
 	return a.Get(0).(int64), a.Error(1)
 }
 
@@ -39,12 +42,12 @@ type MockClaimableBalancesBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockClaimableBalancesBatchInsertBuilder) Add(entry *xdr.LedgerEntry) error {
-	a := m.Called(entry)
+func (m *MockClaimableBalancesBatchInsertBuilder) Add(ctx context.Context, entry *xdr.LedgerEntry) error {
+	a := m.Called(ctx, entry)
 	return a.Error(0)
 }
 
-func (m *MockClaimableBalancesBatchInsertBuilder) Exec() error {
-	a := m.Called()
+func (m *MockClaimableBalancesBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
 	return a.Error(0)
 }

--- a/services/horizon/internal/db2/history/mock_q_data.go
+++ b/services/horizon/internal/db2/history/mock_q_data.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"context"
+
 	"github.com/stretchr/testify/mock"
 
 	"github.com/stellar/go/xdr"
@@ -11,13 +13,13 @@ type MockQData struct {
 	mock.Mock
 }
 
-func (m *MockQData) GetAccountDataByKeys(keys []xdr.LedgerKeyData) ([]Data, error) {
-	a := m.Called()
+func (m *MockQData) GetAccountDataByKeys(ctx context.Context, keys []xdr.LedgerKeyData) ([]Data, error) {
+	a := m.Called(ctx)
 	return a.Get(0).([]Data), a.Error(1)
 }
 
-func (m *MockQData) CountAccountsData() (int, error) {
-	a := m.Called()
+func (m *MockQData) CountAccountsData(ctx context.Context) (int, error) {
+	a := m.Called(ctx)
 	return a.Get(0).(int), a.Error(1)
 }
 
@@ -26,17 +28,17 @@ func (m *MockQData) NewAccountDataBatchInsertBuilder(maxBatchSize int) AccountDa
 	return a.Get(0).(AccountDataBatchInsertBuilder)
 }
 
-func (m *MockQData) InsertAccountData(entry xdr.LedgerEntry) (int64, error) {
-	a := m.Called(entry)
+func (m *MockQData) InsertAccountData(ctx context.Context, entry xdr.LedgerEntry) (int64, error) {
+	a := m.Called(ctx, entry)
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQData) UpdateAccountData(entry xdr.LedgerEntry) (int64, error) {
-	a := m.Called(entry)
+func (m *MockQData) UpdateAccountData(ctx context.Context, entry xdr.LedgerEntry) (int64, error) {
+	a := m.Called(ctx, entry)
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQData) RemoveAccountData(key xdr.LedgerKeyData) (int64, error) {
-	a := m.Called(key)
+func (m *MockQData) RemoveAccountData(ctx context.Context, key xdr.LedgerKeyData) (int64, error) {
+	a := m.Called(ctx, key)
 	return a.Get(0).(int64), a.Error(1)
 }

--- a/services/horizon/internal/db2/history/mock_q_effects.go
+++ b/services/horizon/internal/db2/history/mock_q_effects.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"context"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -14,7 +15,7 @@ func (m *MockQEffects) NewEffectBatchInsertBuilder(maxBatchSize int) EffectBatch
 	return a.Get(0).(EffectBatchInsertBuilder)
 }
 
-func (m *MockQEffects) CreateAccounts(addresses []string, maxBatchSize int) (map[string]int64, error) {
-	a := m.Called(addresses, maxBatchSize)
+func (m *MockQEffects) CreateAccounts(ctx context.Context, addresses []string, maxBatchSize int) (map[string]int64, error) {
+	a := m.Called(ctx, addresses, maxBatchSize)
 	return a.Get(0).(map[string]int64), a.Error(1)
 }

--- a/services/horizon/internal/db2/history/mock_q_history_claimable_balances.go
+++ b/services/horizon/internal/db2/history/mock_q_history_claimable_balances.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"context"
 	"github.com/stellar/go/xdr"
 
 	"github.com/stretchr/testify/mock"
@@ -11,8 +12,8 @@ type MockQHistoryClaimableBalances struct {
 	mock.Mock
 }
 
-func (m *MockQHistoryClaimableBalances) CreateHistoryClaimableBalances(ids []xdr.ClaimableBalanceId, maxBatchSize int) (map[string]int64, error) {
-	a := m.Called(ids, maxBatchSize)
+func (m *MockQHistoryClaimableBalances) CreateHistoryClaimableBalances(ctx context.Context, ids []xdr.ClaimableBalanceId, maxBatchSize int) (map[string]int64, error) {
+	a := m.Called(ctx, ids, maxBatchSize)
 	return a.Get(0).(map[string]int64), a.Error(1)
 }
 
@@ -27,13 +28,13 @@ type MockTransactionClaimableBalanceBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockTransactionClaimableBalanceBatchInsertBuilder) Add(transactionID, accountID int64) error {
-	a := m.Called(transactionID, accountID)
+func (m *MockTransactionClaimableBalanceBatchInsertBuilder) Add(ctx context.Context, transactionID, accountID int64) error {
+	a := m.Called(ctx, transactionID, accountID)
 	return a.Error(0)
 }
 
-func (m *MockTransactionClaimableBalanceBatchInsertBuilder) Exec() error {
-	a := m.Called()
+func (m *MockTransactionClaimableBalanceBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
 	return a.Error(0)
 }
 
@@ -49,12 +50,12 @@ type MockOperationClaimableBalanceBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockOperationClaimableBalanceBatchInsertBuilder) Add(transactionID, accountID int64) error {
-	a := m.Called(transactionID, accountID)
+func (m *MockOperationClaimableBalanceBatchInsertBuilder) Add(ctx context.Context, transactionID, accountID int64) error {
+	a := m.Called(ctx, transactionID, accountID)
 	return a.Error(0)
 }
 
-func (m *MockOperationClaimableBalanceBatchInsertBuilder) Exec() error {
-	a := m.Called()
+func (m *MockOperationClaimableBalanceBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
 	return a.Error(0)
 }

--- a/services/horizon/internal/db2/history/mock_q_ledgers.go
+++ b/services/horizon/internal/db2/history/mock_q_ledgers.go
@@ -1,15 +1,18 @@
 package history
 
 import (
-	"github.com/stellar/go/xdr"
+	"context"
+
 	"github.com/stretchr/testify/mock"
+
+	"github.com/stellar/go/xdr"
 )
 
 type MockQLedgers struct {
 	mock.Mock
 }
 
-func (m *MockQLedgers) InsertLedger(
+func (m *MockQLedgers) InsertLedger(ctx context.Context,
 	ledger xdr.LedgerHeaderHistoryEntry,
 	successTxsCount int,
 	failedTxsCount int,
@@ -17,6 +20,6 @@ func (m *MockQLedgers) InsertLedger(
 	txSetOpCount int,
 	ingestVersion int,
 ) (int64, error) {
-	a := m.Called(ledger, successTxsCount, failedTxsCount, opCount, txSetOpCount, ingestVersion)
+	a := m.Called(ctx, ledger, successTxsCount, failedTxsCount, opCount, txSetOpCount, ingestVersion)
 	return a.Get(0).(int64), a.Error(1)
 }

--- a/services/horizon/internal/db2/history/mock_q_offers.go
+++ b/services/horizon/internal/db2/history/mock_q_offers.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"context"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -9,23 +10,23 @@ type MockQOffers struct {
 	mock.Mock
 }
 
-func (m *MockQOffers) GetAllOffers() ([]Offer, error) {
-	a := m.Called()
+func (m *MockQOffers) GetAllOffers(ctx context.Context) ([]Offer, error) {
+	a := m.Called(ctx)
 	return a.Get(0).([]Offer), a.Error(1)
 }
 
-func (m *MockQOffers) GetOffersByIDs(ids []int64) ([]Offer, error) {
-	a := m.Called(ids)
+func (m *MockQOffers) GetOffersByIDs(ctx context.Context, ids []int64) ([]Offer, error) {
+	a := m.Called(ctx, ids)
 	return a.Get(0).([]Offer), a.Error(1)
 }
 
-func (m *MockQOffers) GetUpdatedOffers(newerThanSequence uint32) ([]Offer, error) {
-	a := m.Called(newerThanSequence)
+func (m *MockQOffers) GetUpdatedOffers(ctx context.Context, newerThanSequence uint32) ([]Offer, error) {
+	a := m.Called(ctx, newerThanSequence)
 	return a.Get(0).([]Offer), a.Error(1)
 }
 
-func (m *MockQOffers) CountOffers() (int, error) {
-	a := m.Called()
+func (m *MockQOffers) CountOffers(ctx context.Context) (int, error) {
+	a := m.Called(ctx)
 	return a.Get(0).(int), a.Error(1)
 }
 
@@ -34,17 +35,17 @@ func (m *MockQOffers) NewOffersBatchInsertBuilder(maxBatchSize int) OffersBatchI
 	return a.Get(0).(OffersBatchInsertBuilder)
 }
 
-func (m *MockQOffers) UpdateOffer(row Offer) (int64, error) {
-	a := m.Called(row)
+func (m *MockQOffers) UpdateOffer(ctx context.Context, row Offer) (int64, error) {
+	a := m.Called(ctx, row)
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQOffers) RemoveOffers(offerIDs []int64, lastModifiedLedger uint32) (int64, error) {
-	a := m.Called(offerIDs, lastModifiedLedger)
+func (m *MockQOffers) RemoveOffers(ctx context.Context, offerIDs []int64, lastModifiedLedger uint32) (int64, error) {
+	a := m.Called(ctx, offerIDs, lastModifiedLedger)
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQOffers) CompactOffers(cutOffSequence uint32) (int64, error) {
-	a := m.Called(cutOffSequence)
+func (m *MockQOffers) CompactOffers(ctx context.Context, cutOffSequence uint32) (int64, error) {
+	a := m.Called(ctx, cutOffSequence)
 	return a.Get(0).(int64), a.Error(1)
 }

--- a/services/horizon/internal/db2/history/mock_q_participants.go
+++ b/services/horizon/internal/db2/history/mock_q_participants.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"context"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -9,8 +10,8 @@ type MockQParticipants struct {
 	mock.Mock
 }
 
-func (m *MockQParticipants) CreateAccounts(addresses []string, maxBatchSize int) (map[string]int64, error) {
-	a := m.Called(addresses, maxBatchSize)
+func (m *MockQParticipants) CreateAccounts(ctx context.Context, addresses []string, maxBatchSize int) (map[string]int64, error) {
+	a := m.Called(ctx, addresses, maxBatchSize)
 	return a.Get(0).(map[string]int64), a.Error(1)
 }
 
@@ -25,13 +26,13 @@ type MockTransactionParticipantsBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockTransactionParticipantsBatchInsertBuilder) Add(transactionID, accountID int64) error {
-	a := m.Called(transactionID, accountID)
+func (m *MockTransactionParticipantsBatchInsertBuilder) Add(ctx context.Context, transactionID, accountID int64) error {
+	a := m.Called(ctx, transactionID, accountID)
 	return a.Error(0)
 }
 
-func (m *MockTransactionParticipantsBatchInsertBuilder) Exec() error {
-	a := m.Called()
+func (m *MockTransactionParticipantsBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
 	return a.Error(0)
 }
 

--- a/services/horizon/internal/db2/history/mock_q_signers.go
+++ b/services/horizon/internal/db2/history/mock_q_signers.go
@@ -1,31 +1,34 @@
 package history
 
 import (
-	"github.com/stellar/go/services/horizon/internal/db2"
+	"context"
+
 	"github.com/stretchr/testify/mock"
+
+	"github.com/stellar/go/services/horizon/internal/db2"
 )
 
 type MockQSigners struct {
 	mock.Mock
 }
 
-func (m *MockQSigners) GetLastLedgerIngestNonBlocking() (uint32, error) {
-	a := m.Called()
+func (m *MockQSigners) GetLastLedgerIngestNonBlocking(ctx context.Context) (uint32, error) {
+	a := m.Called(ctx)
 	return a.Get(0).(uint32), a.Error(1)
 }
 
-func (m *MockQSigners) GetLastLedgerIngest() (uint32, error) {
-	a := m.Called()
+func (m *MockQSigners) GetLastLedgerIngest(ctx context.Context) (uint32, error) {
+	a := m.Called(ctx)
 	return a.Get(0).(uint32), a.Error(1)
 }
 
-func (m *MockQSigners) UpdateLastLedgerIngest(ledgerSequence uint32) error {
-	a := m.Called(ledgerSequence)
+func (m *MockQSigners) UpdateLastLedgerIngest(ctx context.Context, ledgerSequence uint32) error {
+	a := m.Called(ctx, ledgerSequence)
 	return a.Error(0)
 }
 
-func (m *MockQSigners) AccountsForSigner(signer string, page db2.PageQuery) ([]AccountSigner, error) {
-	a := m.Called(signer, page)
+func (m *MockQSigners) AccountsForSigner(ctx context.Context, signer string, page db2.PageQuery) ([]AccountSigner, error) {
+	a := m.Called(ctx, signer, page)
 	return a.Get(0).([]AccountSigner), a.Error(1)
 }
 
@@ -34,22 +37,22 @@ func (m *MockQSigners) NewAccountSignersBatchInsertBuilder(maxBatchSize int) Acc
 	return a.Get(0).(AccountSignersBatchInsertBuilder)
 }
 
-func (m *MockQSigners) CreateAccountSigner(account, signer string, weight int32, sponsor *string) (int64, error) {
-	a := m.Called(account, signer, weight, sponsor)
+func (m *MockQSigners) CreateAccountSigner(ctx context.Context, account, signer string, weight int32, sponsor *string) (int64, error) {
+	a := m.Called(ctx, account, signer, weight, sponsor)
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQSigners) RemoveAccountSigner(account, signer string) (int64, error) {
-	a := m.Called(account, signer)
+func (m *MockQSigners) RemoveAccountSigner(ctx context.Context, account, signer string) (int64, error) {
+	a := m.Called(ctx, account, signer)
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQSigners) SignersForAccounts(accounts []string) ([]AccountSigner, error) {
-	a := m.Called(accounts)
+func (m *MockQSigners) SignersForAccounts(ctx context.Context, accounts []string) ([]AccountSigner, error) {
+	a := m.Called(ctx, accounts)
 	return a.Get(0).([]AccountSigner), a.Error(1)
 }
 
-func (m *MockQSigners) CountAccounts() (int, error) {
-	a := m.Called()
+func (m *MockQSigners) CountAccounts(ctx context.Context) (int, error) {
+	a := m.Called(ctx)
 	return a.Get(0).(int), a.Error(1)
 }

--- a/services/horizon/internal/db2/history/mock_q_trades.go
+++ b/services/horizon/internal/db2/history/mock_q_trades.go
@@ -1,7 +1,10 @@
 package history
 
 import (
+	"context"
+
 	"github.com/stellar/go/xdr"
+
 	"github.com/stretchr/testify/mock"
 )
 
@@ -9,13 +12,13 @@ type MockQTrades struct {
 	mock.Mock
 }
 
-func (m *MockQTrades) CreateAccounts(addresses []string, maxBatchSize int) (map[string]int64, error) {
-	a := m.Called(addresses, maxBatchSize)
+func (m *MockQTrades) CreateAccounts(ctx context.Context, addresses []string, maxBatchSize int) (map[string]int64, error) {
+	a := m.Called(ctx, addresses, maxBatchSize)
 	return a.Get(0).(map[string]int64), a.Error(1)
 }
 
-func (m *MockQTrades) CreateAssets(assets []xdr.Asset, maxBatchSize int) (map[string]Asset, error) {
-	a := m.Called(assets, maxBatchSize)
+func (m *MockQTrades) CreateAssets(ctx context.Context, assets []xdr.Asset, maxBatchSize int) (map[string]Asset, error) {
+	a := m.Called(ctx, assets, maxBatchSize)
 	return a.Get(0).(map[string]Asset), a.Error(1)
 }
 
@@ -28,12 +31,12 @@ type MockTradeBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockTradeBatchInsertBuilder) Add(entries ...InsertTrade) error {
-	a := m.Called(entries)
+func (m *MockTradeBatchInsertBuilder) Add(ctx context.Context, entries ...InsertTrade) error {
+	a := m.Called(ctx, entries)
 	return a.Error(0)
 }
 
-func (m *MockTradeBatchInsertBuilder) Exec() error {
-	a := m.Called()
+func (m *MockTradeBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
 	return a.Error(0)
 }

--- a/services/horizon/internal/db2/history/mock_q_trust_lines.go
+++ b/services/horizon/internal/db2/history/mock_q_trust_lines.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"context"
+
 	"github.com/stretchr/testify/mock"
 
 	"github.com/stellar/go/xdr"
@@ -16,27 +18,27 @@ func (m *MockQTrustLines) NewTrustLinesBatchInsertBuilder(maxBatchSize int) Trus
 	return a.Get(0).(TrustLinesBatchInsertBuilder)
 }
 
-func (m *MockQTrustLines) GetTrustLinesByKeys(keys []xdr.LedgerKeyTrustLine) ([]TrustLine, error) {
-	a := m.Called(keys)
+func (m *MockQTrustLines) GetTrustLinesByKeys(ctx context.Context, keys []xdr.LedgerKeyTrustLine) ([]TrustLine, error) {
+	a := m.Called(ctx, keys)
 	return a.Get(0).([]TrustLine), a.Error(1)
 }
 
-func (m *MockQTrustLines) InsertTrustLine(entry xdr.LedgerEntry) (int64, error) {
-	a := m.Called(entry)
+func (m *MockQTrustLines) InsertTrustLine(ctx context.Context, entry xdr.LedgerEntry) (int64, error) {
+	a := m.Called(ctx, entry)
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQTrustLines) UpdateTrustLine(entry xdr.LedgerEntry) (int64, error) {
-	a := m.Called(entry)
+func (m *MockQTrustLines) UpdateTrustLine(ctx context.Context, entry xdr.LedgerEntry) (int64, error) {
+	a := m.Called(ctx, entry)
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQTrustLines) UpsertTrustLines(trustLines []xdr.LedgerEntry) error {
-	a := m.Called(trustLines)
+func (m *MockQTrustLines) UpsertTrustLines(ctx context.Context, trustLines []xdr.LedgerEntry) error {
+	a := m.Called(ctx, trustLines)
 	return a.Error(0)
 }
 
-func (m *MockQTrustLines) RemoveTrustLine(key xdr.LedgerKeyTrustLine) (int64, error) {
-	a := m.Called(key)
+func (m *MockQTrustLines) RemoveTrustLine(ctx context.Context, key xdr.LedgerKeyTrustLine) (int64, error) {
+	a := m.Called(ctx, key)
 	return a.Get(0).(int64), a.Error(1)
 }

--- a/services/horizon/internal/db2/history/mock_transactions_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_transactions_batch_insert_builder.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"context"
+
 	"github.com/stretchr/testify/mock"
 
 	"github.com/stellar/go/ingest"
@@ -10,12 +12,12 @@ type MockTransactionsBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockTransactionsBatchInsertBuilder) Add(transaction ingest.LedgerTransaction, sequence uint32) error {
-	a := m.Called(transaction, sequence)
+func (m *MockTransactionsBatchInsertBuilder) Add(ctx context.Context, transaction ingest.LedgerTransaction, sequence uint32) error {
+	a := m.Called(ctx, transaction, sequence)
 	return a.Error(0)
 }
 
-func (m *MockTransactionsBatchInsertBuilder) Exec() error {
-	a := m.Called()
+func (m *MockTransactionsBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
 	return a.Error(0)
 }

--- a/services/horizon/internal/db2/history/offers_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/offers_batch_insert_builder.go
@@ -1,10 +1,14 @@
 package history
 
+import (
+	"context"
+)
+
 // Add adds a new offer entry to the batch.
-func (i *offersBatchInsertBuilder) Add(offer Offer) error {
-	return i.builder.RowStruct(offer)
+func (i *offersBatchInsertBuilder) Add(ctx context.Context, offer Offer) error {
+	return i.builder.RowStruct(ctx, offer)
 }
 
-func (i *offersBatchInsertBuilder) Exec() error {
-	return i.builder.Exec()
+func (i *offersBatchInsertBuilder) Exec(ctx context.Context) error {
+	return i.builder.Exec(ctx)
 }

--- a/services/horizon/internal/db2/history/operation_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/operation_batch_insert_builder.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"context"
+
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/xdr"
 )
@@ -9,6 +11,7 @@ import (
 // history_operations table
 type OperationBatchInsertBuilder interface {
 	Add(
+		ctx context.Context,
 		id int64,
 		transactionID int64,
 		applicationOrder uint32,
@@ -16,7 +19,7 @@ type OperationBatchInsertBuilder interface {
 		details []byte,
 		sourceAccount string,
 	) error
-	Exec() error
+	Exec(ctx context.Context) error
 }
 
 // operationBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
@@ -36,6 +39,7 @@ func (q *Q) NewOperationBatchInsertBuilder(maxBatchSize int) OperationBatchInser
 
 // Add adds a transaction's operations to the batch
 func (i *operationBatchInsertBuilder) Add(
+	ctx context.Context,
 	id int64,
 	transactionID int64,
 	applicationOrder uint32,
@@ -43,7 +47,7 @@ func (i *operationBatchInsertBuilder) Add(
 	details []byte,
 	sourceAccount string,
 ) error {
-	return i.builder.Row(map[string]interface{}{
+	return i.builder.Row(ctx, map[string]interface{}{
 		"id":                id,
 		"transaction_id":    transactionID,
 		"application_order": applicationOrder,
@@ -54,6 +58,6 @@ func (i *operationBatchInsertBuilder) Add(
 
 }
 
-func (i *operationBatchInsertBuilder) Exec() error {
-	return i.builder.Exec()
+func (i *operationBatchInsertBuilder) Exec(ctx context.Context) error {
+	return i.builder.Exec(ctx)
 }

--- a/services/horizon/internal/db2/history/operation_batch_insert_builder_test.go
+++ b/services/horizon/internal/db2/history/operation_batch_insert_builder_test.go
@@ -34,8 +34,8 @@ func TestAddOperation(t *testing.T) {
 	)
 
 	sequence := int32(56)
-	tt.Assert.NoError(txBatch.Add(transaction, uint32(sequence)))
-	tt.Assert.NoError(txBatch.Exec())
+	tt.Assert.NoError(txBatch.Add(tt.Ctx, transaction, uint32(sequence)))
+	tt.Assert.NoError(txBatch.Exec(tt.Ctx))
 
 	details, err := json.Marshal(map[string]string{
 		"to":         "GANFZDRBCNTUXIODCJEYMACPMCSZEVE4WZGZ3CZDZ3P2SXK4KH75IK6Y",
@@ -45,7 +45,7 @@ func TestAddOperation(t *testing.T) {
 	})
 	tt.Assert.NoError(err)
 
-	err = builder.Add(
+	err = builder.Add(tt.Ctx,
 		toid.New(sequence, 1, 1).ToInt64(),
 		toid.New(sequence, 1, 0).ToInt64(),
 		1,
@@ -55,11 +55,11 @@ func TestAddOperation(t *testing.T) {
 	)
 	tt.Assert.NoError(err)
 
-	err = builder.Exec()
+	err = builder.Exec(tt.Ctx)
 	tt.Assert.NoError(err)
 
 	ops := []Operation{}
-	err = q.Select(&ops, selectOperation)
+	err = q.Select(tt.Ctx, &ops, selectOperation)
 
 	if tt.Assert.NoError(err) {
 		tt.Assert.Len(ops, 1)

--- a/services/horizon/internal/db2/history/operation_participant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/operation_participant_batch_insert_builder.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"context"
+
 	"github.com/stellar/go/support/db"
 )
 
@@ -8,10 +10,11 @@ import (
 // history_operations table
 type OperationParticipantBatchInsertBuilder interface {
 	Add(
+		ctx context.Context,
 		operationID int64,
 		accountID int64,
 	) error
-	Exec() error
+	Exec(ctx context.Context) error
 }
 
 // operationParticipantBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
@@ -31,15 +34,16 @@ func (q *Q) NewOperationParticipantBatchInsertBuilder(maxBatchSize int) Operatio
 
 // Add adds an operation participant to the batch
 func (i *operationParticipantBatchInsertBuilder) Add(
+	ctx context.Context,
 	operationID int64,
 	accountID int64,
 ) error {
-	return i.builder.Row(map[string]interface{}{
+	return i.builder.Row(ctx, map[string]interface{}{
 		"history_operation_id": operationID,
 		"history_account_id":   accountID,
 	})
 }
 
-func (i *operationParticipantBatchInsertBuilder) Exec() error {
-	return i.builder.Exec()
+func (i *operationParticipantBatchInsertBuilder) Exec(ctx context.Context) error {
+	return i.builder.Exec(ctx)
 }

--- a/services/horizon/internal/db2/history/operation_participant_batch_insert_builder_test.go
+++ b/services/horizon/internal/db2/history/operation_participant_batch_insert_builder_test.go
@@ -14,10 +14,10 @@ func TestAddOperationParticipants(t *testing.T) {
 	q := &Q{tt.HorizonSession()}
 
 	builder := q.NewOperationParticipantBatchInsertBuilder(1)
-	err := builder.Add(240518172673, 1)
+	err := builder.Add(tt.Ctx, 240518172673, 1)
 	tt.Assert.NoError(err)
 
-	err = builder.Exec()
+	err = builder.Exec(tt.Ctx)
 	tt.Assert.NoError(err)
 
 	type hop struct {
@@ -26,7 +26,7 @@ func TestAddOperationParticipants(t *testing.T) {
 	}
 
 	ops := []hop{}
-	err = q.Select(&ops, sq.Select(
+	err = q.Select(tt.Ctx, &ops, sq.Select(
 		"hopp.history_operation_id, "+
 			"hopp.history_account_id").
 		From("history_operation_participants hopp"),

--- a/services/horizon/internal/db2/history/orderbook.go
+++ b/services/horizon/internal/db2/history/orderbook.go
@@ -1,10 +1,11 @@
 package history
 
 import (
+	"context"
 	"database/sql"
-	"github.com/stellar/go/amount"
 	"math/big"
 
+	"github.com/stellar/go/amount"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -40,7 +41,7 @@ type OrderBookSummary struct {
 
 // GetOrderBookSummary returns an OrderBookSummary for a given trading pair.
 // GetOrderBookSummary should only be called in a repeatable read transaction.
-func (q *Q) GetOrderBookSummary(sellingAsset, buyingAsset xdr.Asset, maxPriceLevels int) (OrderBookSummary, error) {
+func (q *Q) GetOrderBookSummary(ctx context.Context, sellingAsset, buyingAsset xdr.Asset, maxPriceLevels int) (OrderBookSummary, error) {
 	var result OrderBookSummary
 
 	if tx := q.GetTx(); tx == nil {
@@ -100,12 +101,12 @@ func (q *Q) GetOrderBookSummary(sellingAsset, buyingAsset xdr.Asset, maxPriceLev
 			LIMIT $3
 		)
 	`
-	err = q.SelectRaw(&levels, selectPriceLevels, selling, buying, maxPriceLevels)
+	err = q.SelectRaw(ctx, &levels, selectPriceLevels, selling, buying, maxPriceLevels)
 	if err != nil {
 		return result, errors.Wrap(err, "cannot select price levels")
 	}
 
-	err = q.SelectRaw(&offers, selectOfferSummaries, selling, buying, maxPriceLevels)
+	err = q.SelectRaw(ctx, &offers, selectOfferSummaries, selling, buying, maxPriceLevels)
 	if err != nil {
 		return result, errors.Wrap(err, "cannot select offer summaries")
 	}

--- a/services/horizon/internal/db2/history/participants.go
+++ b/services/horizon/internal/db2/history/participants.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"context"
+
 	"github.com/stellar/go/support/db"
 )
 
@@ -14,8 +16,8 @@ type QParticipants interface {
 // TransactionParticipantsBatchInsertBuilder is used to insert transaction participants into the
 // history_transaction_participants table
 type TransactionParticipantsBatchInsertBuilder interface {
-	Add(transactionID, accountID int64) error
-	Exec() error
+	Add(ctx context.Context, transactionID, accountID int64) error
+	Exec(ctx context.Context) error
 }
 
 type transactionParticipantsBatchInsertBuilder struct {
@@ -33,14 +35,14 @@ func (q *Q) NewTransactionParticipantsBatchInsertBuilder(maxBatchSize int) Trans
 }
 
 // Add adds a new transaction participant to the batch
-func (i *transactionParticipantsBatchInsertBuilder) Add(transactionID, accountID int64) error {
-	return i.builder.Row(map[string]interface{}{
+func (i *transactionParticipantsBatchInsertBuilder) Add(ctx context.Context, transactionID, accountID int64) error {
+	return i.builder.Row(ctx, map[string]interface{}{
 		"history_transaction_id": transactionID,
 		"history_account_id":     accountID,
 	})
 }
 
 // Exec flushes all pending transaction participants to the db
-func (i *transactionParticipantsBatchInsertBuilder) Exec() error {
-	return i.builder.Exec()
+func (i *transactionParticipantsBatchInsertBuilder) Exec(ctx context.Context) error {
+	return i.builder.Exec(ctx)
 }

--- a/services/horizon/internal/db2/history/participants_test.go
+++ b/services/horizon/internal/db2/history/participants_test.go
@@ -18,7 +18,7 @@ func getTransactionParticipants(tt *test.T, q *Q) []transactionParticipant {
 		From("history_transaction_participants").
 		OrderBy("(history_transaction_id, history_account_id) asc")
 
-	err := q.Select(&participants, sql)
+	err := q.Select(tt.Ctx, &participants, sql)
 	if err != nil {
 		tt.T.Fatal(err)
 	}
@@ -39,11 +39,11 @@ func TestTransactionParticipantsBatch(t *testing.T) {
 	accountID := int64(100)
 
 	for i := int64(0); i < 3; i++ {
-		tt.Assert.NoError(batch.Add(transactionID, accountID+i))
+		tt.Assert.NoError(batch.Add(tt.Ctx, transactionID, accountID+i))
 	}
 
-	tt.Assert.NoError(batch.Add(otherTransactionID, accountID))
-	tt.Assert.NoError(batch.Exec())
+	tt.Assert.NoError(batch.Add(tt.Ctx, otherTransactionID, accountID))
+	tt.Assert.NoError(batch.Exec(tt.Ctx))
 
 	participants := getTransactionParticipants(tt, q)
 	tt.Assert.Equal(

--- a/services/horizon/internal/db2/history/sequence_provider.go
+++ b/services/horizon/internal/db2/history/sequence_provider.go
@@ -1,16 +1,18 @@
 package history
 
 import (
+	"context"
+
 	sq "github.com/Masterminds/squirrel"
 
 	"github.com/stellar/go/support/errors"
 )
 
-func (q *Q) GetSequenceNumbers(addresses []string) (map[string]uint64, error) {
+func (q *Q) GetSequenceNumbers(ctx context.Context, addresses []string) (map[string]uint64, error) {
 	var accounts []AccountEntry
 	sql := sq.Select("account_id, sequence_number").From("accounts").
 		Where(map[string]interface{}{"accounts.account_id": addresses})
-	if err := q.Select(&accounts, sql); err != nil {
+	if err := q.Select(ctx, &accounts, sql); err != nil {
 		return nil, errors.Wrap(err, "could not query accounts")
 	}
 

--- a/services/horizon/internal/db2/history/sequence_provider_test.go
+++ b/services/horizon/internal/db2/history/sequence_provider_test.go
@@ -17,7 +17,7 @@ func TestSequenceProviderEmptyDB(t *testing.T) {
 		"GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB",
 		"GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 	}
-	results, err := q.GetSequenceNumbers(addresses)
+	results, err := q.GetSequenceNumbers(tt.Ctx, addresses)
 	assert.NoError(t, err)
 	assert.Len(t, results, 0)
 }
@@ -29,13 +29,13 @@ func TestSequenceProviderGet(t *testing.T) {
 	q := &Q{tt.HorizonSession()}
 
 	batch := q.NewAccountsBatchInsertBuilder(0)
-	err := batch.Add(account1)
+	err := batch.Add(tt.Ctx, account1)
 	assert.NoError(t, err)
-	err = batch.Add(account2)
+	err = batch.Add(tt.Ctx, account2)
 	assert.NoError(t, err)
-	assert.NoError(t, batch.Exec())
+	assert.NoError(t, batch.Exec(tt.Ctx))
 
-	results, err := q.GetSequenceNumbers([]string{
+	results, err := q.GetSequenceNumbers(tt.Ctx, []string{
 		"GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB",
 		"GCT2NQM5KJJEF55NPMY444C6M6CA7T33HRNCMA6ZFBIIXKNCRO6J25K7",
 		"GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",

--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"context"
 	"database/sql/driver"
 	"encoding/base64"
 	"encoding/hex"
@@ -24,8 +25,8 @@ import (
 // TransactionBatchInsertBuilder is used to insert transactions into the
 // history_transactions table
 type TransactionBatchInsertBuilder interface {
-	Add(transaction ingest.LedgerTransaction, sequence uint32) error
-	Exec() error
+	Add(ctx context.Context, transaction ingest.LedgerTransaction, sequence uint32) error
+	Exec(ctx context.Context) error
 }
 
 // transactionBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
@@ -44,17 +45,17 @@ func (q *Q) NewTransactionBatchInsertBuilder(maxBatchSize int) TransactionBatchI
 }
 
 // Add adds a new transaction to the batch
-func (i *transactionBatchInsertBuilder) Add(transaction ingest.LedgerTransaction, sequence uint32) error {
+func (i *transactionBatchInsertBuilder) Add(ctx context.Context, transaction ingest.LedgerTransaction, sequence uint32) error {
 	row, err := transactionToRow(transaction, sequence)
 	if err != nil {
 		return err
 	}
 
-	return i.builder.RowStruct(row)
+	return i.builder.RowStruct(ctx, row)
 }
 
-func (i *transactionBatchInsertBuilder) Exec() error {
-	return i.builder.Exec()
+func (i *transactionBatchInsertBuilder) Exec(ctx context.Context) error {
+	return i.builder.Exec(ctx)
 }
 
 // TimeBounds represents the time bounds of a Stellar transaction

--- a/services/horizon/internal/db2/history/trust_lines_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/trust_lines_batch_insert_builder.go
@@ -1,13 +1,15 @@
 package history
 
 import (
+	"context"
+
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 
 // Add adds a new trust line entry to the batch. `lastModifiedLedger` is another
 // parameter because `xdr.TrustLineEntry` does not have a field to hold this value.
-func (i *trustLinesBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
+func (i *trustLinesBatchInsertBuilder) Add(ctx context.Context, entry xdr.LedgerEntry) error {
 	m := trustLineToMap(entry)
 
 	// Add lkey only when inserting rows
@@ -17,9 +19,9 @@ func (i *trustLinesBatchInsertBuilder) Add(entry xdr.LedgerEntry) error {
 	}
 	m["ledger_key"] = key
 
-	return i.builder.Row(m)
+	return i.builder.Row(ctx, m)
 }
 
-func (i *trustLinesBatchInsertBuilder) Exec() error {
-	return i.builder.Exec()
+func (i *trustLinesBatchInsertBuilder) Exec(ctx context.Context) error {
+	return i.builder.Exec(ctx)
 }

--- a/services/horizon/internal/db2/history/trust_lines_test.go
+++ b/services/horizon/internal/db2/history/trust_lines_test.go
@@ -108,11 +108,11 @@ func TestInsertTrustLine(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	rows, err := q.InsertTrustLine(eurTrustLine)
+	rows, err := q.InsertTrustLine(tt.Ctx, eurTrustLine)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), rows)
 
-	rows, err = q.InsertTrustLine(usdTrustLine)
+	rows, err = q.InsertTrustLine(tt.Ctx, usdTrustLine)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), rows)
 
@@ -121,7 +121,7 @@ func TestInsertTrustLine(t *testing.T) {
 		{Asset: usdTrustLine.Data.TrustLine.Asset, AccountId: usdTrustLine.Data.TrustLine.AccountId},
 	}
 
-	lines, err := q.GetTrustLinesByKeys(keys)
+	lines, err := q.GetTrustLinesByKeys(tt.Ctx, keys)
 	assert.NoError(t, err)
 	assert.Len(t, lines, 2)
 
@@ -134,7 +134,7 @@ func TestUpdateTrustLine(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	rows, err := q.InsertTrustLine(eurTrustLine)
+	rows, err := q.InsertTrustLine(tt.Ctx, eurTrustLine)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), rows)
 
@@ -145,14 +145,14 @@ func TestUpdateTrustLine(t *testing.T) {
 	modifiedTrustLine.Ext.V1 = &v1Copy
 	modifiedTrustLine.Data.TrustLine.Balance = 30000
 
-	rows, err = q.UpdateTrustLine(modifiedTrustLine)
+	rows, err = q.UpdateTrustLine(tt.Ctx, modifiedTrustLine)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), rows)
 
 	keys := []xdr.LedgerKeyTrustLine{
 		{Asset: eurTrustLine.Data.TrustLine.Asset, AccountId: eurTrustLine.Data.TrustLine.AccountId},
 	}
-	lines, err := q.GetTrustLinesByKeys(keys)
+	lines, err := q.GetTrustLinesByKeys(tt.Ctx, keys)
 	assert.NoError(t, err)
 	assert.Len(t, lines, 1)
 
@@ -189,25 +189,25 @@ func TestUpsertTrustLines(t *testing.T) {
 	q := &Q{tt.HorizonSession()}
 
 	// Upserting nothing is no op
-	err := q.UpsertTrustLines([]xdr.LedgerEntry{})
+	err := q.UpsertTrustLines(tt.Ctx, []xdr.LedgerEntry{})
 	assert.NoError(t, err)
 
 	ledgerEntries := []xdr.LedgerEntry{eurTrustLine, usdTrustLine}
 
-	err = q.UpsertTrustLines(ledgerEntries)
+	err = q.UpsertTrustLines(tt.Ctx, ledgerEntries)
 	assert.NoError(t, err)
 
 	keys := []xdr.LedgerKeyTrustLine{
 		{Asset: eurTrustLine.Data.TrustLine.Asset, AccountId: eurTrustLine.Data.TrustLine.AccountId},
 	}
-	lines, err := q.GetTrustLinesByKeys(keys)
+	lines, err := q.GetTrustLinesByKeys(tt.Ctx, keys)
 	assert.NoError(t, err)
 	assert.Len(t, lines, 1)
 
 	keys = []xdr.LedgerKeyTrustLine{
 		{Asset: usdTrustLine.Data.TrustLine.Asset, AccountId: usdTrustLine.Data.TrustLine.AccountId},
 	}
-	lines, err = q.GetTrustLinesByKeys(keys)
+	lines, err = q.GetTrustLinesByKeys(tt.Ctx, keys)
 	assert.NoError(t, err)
 	assert.Len(t, lines, 1)
 
@@ -216,13 +216,13 @@ func TestUpsertTrustLines(t *testing.T) {
 
 	ledgerEntries = []xdr.LedgerEntry{modifiedTrustLine}
 
-	err = q.UpsertTrustLines(ledgerEntries)
+	err = q.UpsertTrustLines(tt.Ctx, ledgerEntries)
 	assert.NoError(t, err)
 
 	keys = []xdr.LedgerKeyTrustLine{
 		{Asset: eurTrustLine.Data.TrustLine.Asset, AccountId: eurTrustLine.Data.TrustLine.AccountId},
 	}
-	lines, err = q.GetTrustLinesByKeys(keys)
+	lines, err = q.GetTrustLinesByKeys(tt.Ctx, keys)
 	assert.NoError(t, err)
 	assert.Len(t, lines, 1)
 
@@ -267,7 +267,7 @@ func TestUpsertTrustLines(t *testing.T) {
 	keys = []xdr.LedgerKeyTrustLine{
 		{Asset: usdTrustLine.Data.TrustLine.Asset, AccountId: usdTrustLine.Data.TrustLine.AccountId},
 	}
-	lines, err = q.GetTrustLinesByKeys(keys)
+	lines, err = q.GetTrustLinesByKeys(tt.Ctx, keys)
 	assert.NoError(t, err)
 	assert.Len(t, lines, 1)
 
@@ -309,21 +309,21 @@ func TestRemoveTrustLine(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	rows, err := q.InsertTrustLine(eurTrustLine)
+	rows, err := q.InsertTrustLine(tt.Ctx, eurTrustLine)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), rows)
 
 	key := xdr.LedgerKeyTrustLine{Asset: eurTrustLine.Data.TrustLine.Asset, AccountId: eurTrustLine.Data.TrustLine.AccountId}
-	rows, err = q.RemoveTrustLine(key)
+	rows, err = q.RemoveTrustLine(tt.Ctx, key)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), rows)
 
-	lines, err := q.GetTrustLinesByKeys([]xdr.LedgerKeyTrustLine{key})
+	lines, err := q.GetTrustLinesByKeys(tt.Ctx, []xdr.LedgerKeyTrustLine{key})
 	assert.NoError(t, err)
 	assert.Len(t, lines, 0)
 
 	// Doesn't exist anymore
-	rows, err = q.RemoveTrustLine(key)
+	rows, err = q.RemoveTrustLine(tt.Ctx, key)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(0), rows)
 }
@@ -333,11 +333,11 @@ func TestGetSortedTrustLinesByAccountsID(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	_, err := q.InsertTrustLine(eurTrustLine)
+	_, err := q.InsertTrustLine(tt.Ctx, eurTrustLine)
 	tt.Assert.NoError(err)
-	_, err = q.InsertTrustLine(usdTrustLine)
+	_, err = q.InsertTrustLine(tt.Ctx, usdTrustLine)
 	tt.Assert.NoError(err)
-	_, err = q.InsertTrustLine(usdTrustLine2)
+	_, err = q.InsertTrustLine(tt.Ctx, usdTrustLine2)
 	tt.Assert.NoError(err)
 
 	ids := []string{
@@ -345,7 +345,7 @@ func TestGetSortedTrustLinesByAccountsID(t *testing.T) {
 		usdTrustLine.Data.TrustLine.AccountId.Address(),
 	}
 
-	records, err := q.GetSortedTrustLinesByAccountIDs(ids)
+	records, err := q.GetSortedTrustLinesByAccountIDs(tt.Ctx, ids)
 	tt.Assert.NoError(err)
 	tt.Assert.Len(records, 2)
 
@@ -378,10 +378,10 @@ func TestGetTrustLinesByAccountID(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	_, err := q.InsertTrustLine(eurTrustLine)
+	_, err := q.InsertTrustLine(tt.Ctx, eurTrustLine)
 	tt.Assert.NoError(err)
 
-	record, err := q.GetSortedTrustLinesByAccountID(eurTrustLine.Data.TrustLine.AccountId.Address())
+	record, err := q.GetSortedTrustLinesByAccountID(tt.Ctx, eurTrustLine.Data.TrustLine.AccountId.Address())
 	tt.Assert.NoError(err)
 
 	asset := xdr.MustNewCreditAsset(record[0].AssetCode, record[0].AssetIssuer)
@@ -401,13 +401,13 @@ func TestAssetsForAddressRequiresTransaction(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	_, _, err := q.AssetsForAddress(eurTrustLine.Data.TrustLine.AccountId.Address())
+	_, _, err := q.AssetsForAddress(tt.Ctx, eurTrustLine.Data.TrustLine.AccountId.Address())
 	assert.EqualError(t, err, "cannot be called outside of a transaction")
 
-	assert.NoError(t, q.Begin())
-	defer q.Rollback()
+	assert.NoError(t, q.Begin(tt.Ctx))
+	defer q.Rollback(tt.Ctx)
 
-	_, _, err = q.AssetsForAddress(eurTrustLine.Data.TrustLine.AccountId.Address())
+	_, _, err = q.AssetsForAddress(tt.Ctx, eurTrustLine.Data.TrustLine.AccountId.Address())
 	assert.EqualError(t, err, "should only be called in a repeatable read transaction")
 }
 
@@ -419,10 +419,10 @@ func TestAssetsForAddress(t *testing.T) {
 
 	ledgerEntries := []xdr.LedgerEntry{account1}
 
-	err := q.UpsertAccounts(ledgerEntries)
+	err := q.UpsertAccounts(tt.Ctx, ledgerEntries)
 	assert.NoError(t, err)
 
-	_, err = q.InsertTrustLine(eurTrustLine)
+	_, err = q.InsertTrustLine(tt.Ctx, eurTrustLine)
 	tt.Assert.NoError(err)
 
 	brlTrustLine := xdr.LedgerEntry{
@@ -448,22 +448,22 @@ func TestAssetsForAddress(t *testing.T) {
 		},
 	}
 
-	_, err = q.InsertTrustLine(brlTrustLine)
+	_, err = q.InsertTrustLine(tt.Ctx, brlTrustLine)
 	tt.Assert.NoError(err)
 
-	err = q.BeginTx(&sql.TxOptions{
+	err = q.BeginTx(tt.Ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	})
 	assert.NoError(t, err)
-	defer q.Rollback()
+	defer q.Rollback(tt.Ctx)
 
-	assets, balances, err := q.AssetsForAddress(usdTrustLine.Data.TrustLine.AccountId.Address())
+	assets, balances, err := q.AssetsForAddress(tt.Ctx, usdTrustLine.Data.TrustLine.AccountId.Address())
 	tt.Assert.NoError(err)
 	tt.Assert.Empty(assets)
 	tt.Assert.Empty(balances)
 
-	assets, balances, err = q.AssetsForAddress(account1.Data.Account.AccountId.Address())
+	assets, balances, err = q.AssetsForAddress(tt.Ctx, account1.Data.Account.AccountId.Address())
 	tt.Assert.NoError(err)
 
 	assetsToBalance := map[string]xdr.Int64{}

--- a/services/horizon/internal/health.go
+++ b/services/horizon/internal/health.go
@@ -68,7 +68,7 @@ func (h healthCheck) runCheck() healthResponse {
 		CoreUp:            true,
 		CoreSynced:        true,
 	}
-	if err := h.session.Ping(dbPingTimeout); err != nil {
+	if err := h.session.Ping(h.ctx, dbPingTimeout); err != nil {
 		healthLogger.Warnf("could not ping db: %s", err)
 		response.DatabaseConnected = false
 	}

--- a/services/horizon/internal/health_test.go
+++ b/services/horizon/internal/health_test.go
@@ -118,9 +118,9 @@ func TestHealthCheck(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			session := &db.MockSession{}
-			session.On("Ping", dbPingTimeout).Return(tc.pingErr).Once()
 			ctx := context.Background()
+			session := &db.MockSession{}
+			session.On("Ping", ctx, dbPingTimeout).Return(tc.pingErr).Once()
 			core := &mockStellarCore{}
 			core.On("Info", ctx).Return(tc.coreResponse, tc.coreErr).Once()
 
@@ -180,8 +180,9 @@ func TestHealthCheckCache(t *testing.T) {
 		assert.True(t, h.cache.lastUpdate.Equal(time.Unix(0, 0)))
 	}
 
+	ctx := context.Background()
 	session := &db.MockSession{}
-	session.On("Ping", dbPingTimeout).Return(nil).Once()
+	session.On("Ping", ctx, dbPingTimeout).Return(nil).Once()
 	core := &mockStellarCore{}
 	core.On("Info", h.ctx).Return(&stellarcore.InfoResponse{}, fmt.Errorf("core err")).Once()
 	h.session = session

--- a/services/horizon/internal/httpt_test.go
+++ b/services/horizon/internal/httpt_test.go
@@ -1,6 +1,7 @@
 package horizon
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -41,7 +42,7 @@ func startHTTPTest(t *testing.T, scenario string) *HTTPT {
 	}`)
 
 	ret.App.config.StellarCoreURL = ret.coreServer.URL
-	ret.App.UpdateLedgerState()
+	ret.App.UpdateLedgerState(context.Background())
 
 	return ret
 }
@@ -98,7 +99,7 @@ func (ht *HTTPT) Post(
 // setting the retention count to the provided number.
 func (ht *HTTPT) ReapHistory(retention uint) {
 	ht.App.reaper.RetentionCount = retention
-	err := ht.App.DeleteUnretainedHistory()
+	err := ht.App.DeleteUnretainedHistory(context.Background())
 	ht.Require.NoError(err)
-	ht.App.UpdateLedgerState()
+	ht.App.UpdateLedgerState(context.Background())
 }

--- a/services/horizon/internal/httpx/handler.go
+++ b/services/horizon/internal/httpx/handler.go
@@ -104,14 +104,14 @@ func repeatableReadStream(
 
 	return func() ([]sse.Event, error) {
 		if session != nil {
-			err := session.BeginTx(&sql.TxOptions{
+			err := session.BeginTx(r.Context(), &sql.TxOptions{
 				Isolation: sql.LevelRepeatableRead,
 				ReadOnly:  true,
 			})
 			if err != nil {
 				return nil, errors.Wrap(err, "Error starting repeatable read transaction")
 			}
-			defer session.Rollback()
+			defer session.Rollback(r.Context())
 		}
 
 		return generateEvents()

--- a/services/horizon/internal/httpx/stream_handler_test.go
+++ b/services/horizon/internal/httpx/stream_handler_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/stellar/go/services/horizon/internal/actions"
 	horizonContext "github.com/stellar/go/services/horizon/internal/context"
@@ -477,17 +478,17 @@ func TestRepeatableReadStream(t *testing.T) {
 		}
 
 		session := &db.MockSession{}
-		session.On("BeginTx", &sql.TxOptions{
+		session.On("BeginTx", mock.Anything, &sql.TxOptions{
 			Isolation: sql.LevelRepeatableRead,
 			ReadOnly:  true,
 		}).Return(nil).Once()
-		session.On("Rollback").Return(nil).Once()
+		session.On("Rollback", mock.Anything).Return(nil).Once()
 
-		session.On("BeginTx", &sql.TxOptions{
+		session.On("BeginTx", mock.Anything, &sql.TxOptions{
 			Isolation: sql.LevelRepeatableRead,
 			ReadOnly:  true,
 		}).Return(nil).Once()
-		session.On("Rollback").Return(nil).Once()
+		session.On("Rollback", mock.Anything).Return(nil).Once()
 
 		request := streamRequest(t, "limit=2")
 		request = request.WithContext(context.WithValue(
@@ -516,17 +517,17 @@ func TestRepeatableReadStream(t *testing.T) {
 		}
 
 		session := &db.MockSession{}
-		session.On("BeginTx", &sql.TxOptions{
+		session.On("BeginTx", mock.Anything, &sql.TxOptions{
 			Isolation: sql.LevelRepeatableRead,
 			ReadOnly:  true,
 		}).Return(nil).Once()
-		session.On("Rollback").Return(nil).Once()
+		session.On("Rollback", mock.Anything).Return(nil).Once()
 
-		session.On("BeginTx", &sql.TxOptions{
+		session.On("BeginTx", mock.Anything, &sql.TxOptions{
 			Isolation: sql.LevelRepeatableRead,
 			ReadOnly:  true,
 		}).Return(nil).Once()
-		session.On("Rollback").Return(nil).Once()
+		session.On("Rollback", mock.Anything).Return(nil).Once()
 
 		request := streamRequest(t, "")
 		request = request.WithContext(context.WithValue(

--- a/services/horizon/internal/ingest/database_backend_test.go
+++ b/services/horizon/internal/ingest/database_backend_test.go
@@ -13,7 +13,7 @@ func TestGetLatestLedger(t *testing.T) {
 	tt.ScenarioWithoutHorizon("base")
 	defer tt.Finish()
 
-	backend, err := ledgerbackend.NewDatabaseBackendFromSession(tt.CoreSession(), network.TestNetworkPassphrase)
+	backend, err := ledgerbackend.NewDatabaseBackendFromSession(tt.Ctx, tt.CoreSession(), network.TestNetworkPassphrase)
 	tt.Assert.NoError(err)
 	seq, err := backend.GetLatestLedgerSequence()
 	tt.Assert.NoError(err)
@@ -28,7 +28,7 @@ func TestGetLatestLedgerNotFound(t *testing.T) {
 	_, err := tt.CoreDB.Exec(`DELETE FROM ledgerheaders`)
 	tt.Assert.NoError(err, "failed to remove ledgerheaders")
 
-	backend, err := ledgerbackend.NewDatabaseBackendFromSession(tt.CoreSession(), network.TestNetworkPassphrase)
+	backend, err := ledgerbackend.NewDatabaseBackendFromSession(tt.Ctx, tt.CoreSession(), network.TestNetworkPassphrase)
 	tt.Assert.NoError(err)
 	_, err = backend.GetLatestLedgerSequence()
 	tt.Assert.EqualError(err, "no ledgers exist in ledgerheaders table")

--- a/services/horizon/internal/ingest/group_processors.go
+++ b/services/horizon/internal/ingest/group_processors.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -26,10 +27,10 @@ func newGroupChangeProcessors(processors []horizonChangeProcessor) *groupChangeP
 	}
 }
 
-func (g groupChangeProcessors) ProcessChange(change ingest.Change) error {
+func (g groupChangeProcessors) ProcessChange(ctx context.Context, change ingest.Change) error {
 	for _, p := range g.processors {
 		startTime := time.Now()
-		if err := p.ProcessChange(change); err != nil {
+		if err := p.ProcessChange(ctx, change); err != nil {
 			return errors.Wrapf(err, "error in %T.ProcessChange", p)
 		}
 		g.AddRunDuration(fmt.Sprintf("%T", p), startTime)
@@ -37,10 +38,10 @@ func (g groupChangeProcessors) ProcessChange(change ingest.Change) error {
 	return nil
 }
 
-func (g groupChangeProcessors) Commit() error {
+func (g groupChangeProcessors) Commit(ctx context.Context) error {
 	for _, p := range g.processors {
 		startTime := time.Now()
-		if err := p.Commit(); err != nil {
+		if err := p.Commit(ctx); err != nil {
 			return errors.Wrapf(err, "error in %T.Commit", p)
 		}
 		g.AddRunDuration(fmt.Sprintf("%T", p), startTime)
@@ -60,10 +61,10 @@ func newGroupTransactionProcessors(processors []horizonTransactionProcessor) *gr
 	}
 }
 
-func (g groupTransactionProcessors) ProcessTransaction(tx ingest.LedgerTransaction) error {
+func (g groupTransactionProcessors) ProcessTransaction(ctx context.Context, tx ingest.LedgerTransaction) error {
 	for _, p := range g.processors {
 		startTime := time.Now()
-		if err := p.ProcessTransaction(tx); err != nil {
+		if err := p.ProcessTransaction(ctx, tx); err != nil {
 			return errors.Wrapf(err, "error in %T.ProcessTransaction", p)
 		}
 		g.AddRunDuration(fmt.Sprintf("%T", p), startTime)
@@ -71,10 +72,10 @@ func (g groupTransactionProcessors) ProcessTransaction(tx ingest.LedgerTransacti
 	return nil
 }
 
-func (g groupTransactionProcessors) Commit() error {
+func (g groupTransactionProcessors) Commit(ctx context.Context) error {
 	for _, p := range g.processors {
 		startTime := time.Now()
-		if err := p.Commit(); err != nil {
+		if err := p.Commit(ctx); err != nil {
 			return errors.Wrapf(err, "error in %T.Commit", p)
 		}
 		g.AddRunDuration(fmt.Sprintf("%T", p), startTime)

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -218,7 +218,6 @@ func NewSystem(config Config) (System, error) {
 		}
 	} else {
 		coreSession := config.CoreSession.Clone()
-		coreSession.Ctx = ctx
 		ledgerBackend, err = ledgerbackend.NewDatabaseBackendFromSession(coreSession, config.NetworkPassphrase)
 		if err != nil {
 			cancel()
@@ -227,7 +226,6 @@ func NewSystem(config Config) (System, error) {
 	}
 
 	historyQ := &history.Q{config.HistorySession.Clone()}
-	historyQ.Ctx = ctx
 
 	historyAdapter := newHistoryArchiveAdapter(archive)
 
@@ -279,7 +277,7 @@ func (s *system) initMetrics() {
 			Help: "equals 1 if state invalid, 0 otherwise",
 		},
 		func() float64 {
-			invalid, err := s.historyQ.CloneIngestionQ().GetExpStateInvalid()
+			invalid, err := s.historyQ.CloneIngestionQ().GetExpStateInvalid(s.ctx)
 			if err != nil {
 				log.WithError(err).Error("Error in initMetrics/GetExpStateInvalid")
 				return 0
@@ -487,7 +485,7 @@ func (s *system) runStateMachine(cur stateMachineNode) error {
 }
 
 func (s *system) maybeVerifyState(lastIngestedLedger uint32) {
-	stateInvalid, err := s.historyQ.GetExpStateInvalid()
+	stateInvalid, err := s.historyQ.GetExpStateInvalid(s.ctx)
 	if err != nil && !isCancelledError(err) {
 		log.WithField("err", err).Error("Error getting state invalid value")
 	}
@@ -509,7 +507,7 @@ func (s *system) maybeVerifyState(lastIngestedLedger uint32) {
 				errorCount := s.incrementStateVerificationErrors()
 				switch errors.Cause(err).(type) {
 				case ingest.StateError:
-					markStateInvalid(s.historyQ, err)
+					markStateInvalid(s.ctx, s.historyQ, err)
 				default:
 					logger := log.WithField("err", err).Warn
 					if errorCount >= stateVerificationErrorThreshold {
@@ -572,10 +570,10 @@ func (s *system) Shutdown() {
 	}
 }
 
-func markStateInvalid(historyQ history.IngestionQ, err error) {
+func markStateInvalid(ctx context.Context, historyQ history.IngestionQ, err error) {
 	log.WithField("err", err).Error("STATE IS INVALID!")
 	q := historyQ.CloneIngestionQ()
-	if err := q.UpdateExpStateInvalid(true); err != nil {
+	if err := q.UpdateExpStateInvalid(ctx, true); err != nil {
 		log.WithField("err", err).Error(updateExpStateInvalidErrMsg)
 	}
 }

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -188,7 +188,7 @@ func NewSystem(config Config) (System, error) {
 	var ledgerBackend ledgerbackend.LedgerBackend
 	if config.EnableCaptiveCore {
 		if len(config.RemoteCaptiveCoreURL) > 0 {
-			ledgerBackend, err = ledgerbackend.NewRemoteCaptive(config.RemoteCaptiveCoreURL)
+			ledgerBackend, err = ledgerbackend.NewRemoteCaptive(ctx, config.RemoteCaptiveCoreURL)
 			if err != nil {
 				cancel()
 				return nil, errors.Wrap(err, "error creating captive core backend")
@@ -206,7 +206,7 @@ func NewSystem(config Config) (System, error) {
 					NetworkPassphrase:   config.NetworkPassphrase,
 					HistoryArchiveURLs:  []string{config.HistoryArchiveURL},
 					CheckpointFrequency: config.CheckpointFrequency,
-					LedgerHashStore:     ledgerbackend.NewHorizonDBLedgerHashStore(config.HistorySession),
+					LedgerHashStore:     ledgerbackend.NewHorizonDBLedgerHashStore(ctx, config.HistorySession),
 					Log:                 logger,
 					Context:             ctx,
 				},
@@ -218,7 +218,7 @@ func NewSystem(config Config) (System, error) {
 		}
 	} else {
 		coreSession := config.CoreSession.Clone()
-		ledgerBackend, err = ledgerbackend.NewDatabaseBackendFromSession(coreSession, config.NetworkPassphrase)
+		ledgerBackend, err = ledgerbackend.NewDatabaseBackendFromSession(ctx, coreSession, config.NetworkPassphrase)
 		if err != nil {
 			cancel()
 			return nil, errors.Wrap(err, "error creating ledger backend")

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
+	ctx := context.Background()
 	maxBatchSize := 100000
 
 	q := &mockDBQ{}
@@ -25,23 +26,23 @@ func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
 	// Batches
 	mockOffersBatchInsertBuilder := &history.MockOffersBatchInsertBuilder{}
 	defer mock.AssertExpectationsForObjects(t, mockOffersBatchInsertBuilder)
-	mockOffersBatchInsertBuilder.On("Exec").Return(nil).Once()
+	mockOffersBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	q.MockQOffers.On("NewOffersBatchInsertBuilder", maxBatchSize).
 		Return(mockOffersBatchInsertBuilder).Once()
 
 	mockAccountDataBatchInsertBuilder := &history.MockAccountDataBatchInsertBuilder{}
 	defer mock.AssertExpectationsForObjects(t, mockAccountDataBatchInsertBuilder)
-	mockAccountDataBatchInsertBuilder.On("Exec").Return(nil).Once()
+	mockAccountDataBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	q.MockQData.On("NewAccountDataBatchInsertBuilder", maxBatchSize).
 		Return(mockAccountDataBatchInsertBuilder).Once()
 
 	mockClaimableBalancesBatchInsertBuilder := &history.MockClaimableBalancesBatchInsertBuilder{}
 	defer mock.AssertExpectationsForObjects(t, mockClaimableBalancesBatchInsertBuilder)
-	mockClaimableBalancesBatchInsertBuilder.On("Exec").Return(nil).Once()
+	mockClaimableBalancesBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	q.MockQClaimableBalances.On("NewClaimableBalancesBatchInsertBuilder", maxBatchSize).
 		Return(mockClaimableBalancesBatchInsertBuilder).Once()
 
-	q.MockQAccounts.On("UpsertAccounts", []xdr.LedgerEntry{
+	q.MockQAccounts.On("UpsertAccounts", ctx, []xdr.LedgerEntry{
 		{
 			LastModifiedLedgerSeq: 1,
 			Data: xdr.LedgerEntryData{
@@ -58,20 +59,21 @@ func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
 
 	mockAccountSignersBatchInsertBuilder := &history.MockAccountSignersBatchInsertBuilder{}
 	defer mock.AssertExpectationsForObjects(t, mockAccountSignersBatchInsertBuilder)
-	mockAccountSignersBatchInsertBuilder.On("Add", history.AccountSigner{
+	mockAccountSignersBatchInsertBuilder.On("Add", ctx, history.AccountSigner{
 		Account: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
 		Signer:  "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
 		Weight:  1,
 		Sponsor: null.String{},
 	}).Return(nil).Once()
-	mockAccountSignersBatchInsertBuilder.On("Exec").Return(nil).Once()
+	mockAccountSignersBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
 		Return(mockAccountSignersBatchInsertBuilder).Once()
 
-	q.MockQAssetStats.On("InsertAssetStats", []history.ExpAssetStat{}, 100000).
+	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)
 
 	runner := ProcessorRunner{
+		ctx: ctx,
 		config: Config{
 			NetworkPassphrase: network.PublicNetworkPassphrase,
 		},
@@ -83,6 +85,7 @@ func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
 }
 
 func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
+	ctx := context.Background()
 	maxBatchSize := 100000
 
 	config := Config{
@@ -103,11 +106,7 @@ func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
 	m.On("Close").Return(nil).Once()
 
 	historyAdapter.
-		On(
-			"GetState",
-			mock.AnythingOfType("*context.emptyCtx"),
-			uint32(63),
-		).
+		On("GetState", ctx, uint32(63)).
 		Return(
 			m,
 			nil,
@@ -116,23 +115,23 @@ func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
 	// Batches
 	mockOffersBatchInsertBuilder := &history.MockOffersBatchInsertBuilder{}
 	defer mock.AssertExpectationsForObjects(t, mockOffersBatchInsertBuilder)
-	mockOffersBatchInsertBuilder.On("Exec").Return(nil).Once()
+	mockOffersBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	q.MockQOffers.On("NewOffersBatchInsertBuilder", maxBatchSize).
 		Return(mockOffersBatchInsertBuilder).Once()
 
 	mockAccountDataBatchInsertBuilder := &history.MockAccountDataBatchInsertBuilder{}
 	defer mock.AssertExpectationsForObjects(t, mockAccountDataBatchInsertBuilder)
-	mockAccountDataBatchInsertBuilder.On("Exec").Return(nil).Once()
+	mockAccountDataBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	q.MockQData.On("NewAccountDataBatchInsertBuilder", maxBatchSize).
 		Return(mockAccountDataBatchInsertBuilder).Once()
 
 	mockClaimableBalancesBatchInsertBuilder := &history.MockClaimableBalancesBatchInsertBuilder{}
 	defer mock.AssertExpectationsForObjects(t, mockClaimableBalancesBatchInsertBuilder)
-	mockClaimableBalancesBatchInsertBuilder.On("Exec").Return(nil).Once()
+	mockClaimableBalancesBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	q.MockQClaimableBalances.On("NewClaimableBalancesBatchInsertBuilder", maxBatchSize).
 		Return(mockClaimableBalancesBatchInsertBuilder).Once()
 
-	q.MockQAccounts.On("UpsertAccounts", []xdr.LedgerEntry{
+	q.MockQAccounts.On("UpsertAccounts", ctx, []xdr.LedgerEntry{
 		{
 			LastModifiedLedgerSeq: 1,
 			Data: xdr.LedgerEntryData{
@@ -149,20 +148,20 @@ func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
 
 	mockAccountSignersBatchInsertBuilder := &history.MockAccountSignersBatchInsertBuilder{}
 	defer mock.AssertExpectationsForObjects(t, mockAccountSignersBatchInsertBuilder)
-	mockAccountSignersBatchInsertBuilder.On("Add", history.AccountSigner{
+	mockAccountSignersBatchInsertBuilder.On("Add", ctx, history.AccountSigner{
 		Account: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
 		Signer:  "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
 		Weight:  1,
 	}).Return(nil).Once()
-	mockAccountSignersBatchInsertBuilder.On("Exec").Return(nil).Once()
+	mockAccountSignersBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
 		Return(mockAccountSignersBatchInsertBuilder).Once()
 
-	q.MockQAssetStats.On("InsertAssetStats", []history.ExpAssetStat{}, 100000).
+	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)
 
 	runner := ProcessorRunner{
-		ctx:            context.Background(),
+		ctx:            ctx,
 		config:         config,
 		historyQ:       q,
 		historyAdapter: historyAdapter,
@@ -173,6 +172,7 @@ func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
 }
 
 func TestProcessorRunnerRunHistoryArchiveIngestionProtocolVersionNotSupported(t *testing.T) {
+	ctx := context.Background()
 	maxBatchSize := 100000
 
 	config := Config{
@@ -205,11 +205,11 @@ func TestProcessorRunnerRunHistoryArchiveIngestionProtocolVersionNotSupported(t 
 	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
 		Return(mockAccountSignersBatchInsertBuilder).Once()
 
-	q.MockQAssetStats.On("InsertAssetStats", []history.ExpAssetStat{}, 100000).
+	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)
 
 	runner := ProcessorRunner{
-		ctx:            context.Background(),
+		ctx:            ctx,
 		config:         config,
 		historyQ:       q,
 		historyAdapter: historyAdapter,
@@ -220,6 +220,7 @@ func TestProcessorRunnerRunHistoryArchiveIngestionProtocolVersionNotSupported(t 
 }
 
 func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
+	ctx := context.Background()
 	maxBatchSize := 100000
 
 	q := &mockDBQ{}
@@ -234,6 +235,7 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 		Return(&history.MockAccountSignersBatchInsertBuilder{}).Twice()
 
 	runner := ProcessorRunner{
+		ctx:      ctx,
 		historyQ: q,
 	}
 
@@ -254,6 +256,7 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 	assert.IsType(t, &processors.TrustLinesProcessor{}, processor.processors[6])
 
 	runner = ProcessorRunner{
+		ctx:      ctx,
 		historyQ: q,
 	}
 
@@ -274,6 +277,7 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 }
 
 func TestProcessorRunnerBuildTransactionProcessor(t *testing.T) {
+	ctx := context.Background()
 	maxBatchSize := 100000
 
 	q := &mockDBQ{}
@@ -285,6 +289,7 @@ func TestProcessorRunnerBuildTransactionProcessor(t *testing.T) {
 		Return(&history.MockTransactionsBatchInsertBuilder{}).Twice()
 
 	runner := ProcessorRunner{
+		ctx:      ctx,
 		config:   Config{},
 		historyQ: q,
 	}
@@ -304,6 +309,7 @@ func TestProcessorRunnerBuildTransactionProcessor(t *testing.T) {
 }
 
 func TestProcessorRunnerRunAllProcessorsOnLedger(t *testing.T) {
+	ctx := context.Background()
 	maxBatchSize := 100000
 
 	config := Config{
@@ -326,13 +332,13 @@ func TestProcessorRunnerRunAllProcessorsOnLedger(t *testing.T) {
 	// Batches
 	mockOffersBatchInsertBuilder := &history.MockOffersBatchInsertBuilder{}
 	defer mock.AssertExpectationsForObjects(t, mockOffersBatchInsertBuilder)
-	mockOffersBatchInsertBuilder.On("Exec").Return(nil).Once()
+	mockOffersBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	q.MockQOffers.On("NewOffersBatchInsertBuilder", maxBatchSize).
 		Return(mockOffersBatchInsertBuilder).Once()
 
 	mockAccountDataBatchInsertBuilder := &history.MockAccountDataBatchInsertBuilder{}
 	defer mock.AssertExpectationsForObjects(t, mockAccountDataBatchInsertBuilder)
-	mockAccountDataBatchInsertBuilder.On("Exec").Return(nil).Once()
+	mockAccountDataBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	q.MockQData.On("NewAccountDataBatchInsertBuilder", maxBatchSize).
 		Return(mockAccountDataBatchInsertBuilder).Once()
 
@@ -343,27 +349,27 @@ func TestProcessorRunnerRunAllProcessorsOnLedger(t *testing.T) {
 
 	mockOperationsBatchInsertBuilder := &history.MockOperationsBatchInsertBuilder{}
 	defer mock.AssertExpectationsForObjects(t, mockOperationsBatchInsertBuilder)
-	mockOperationsBatchInsertBuilder.On("Exec").Return(nil).Once()
+	mockOperationsBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	q.MockQOperations.On("NewOperationBatchInsertBuilder", maxBatchSize).
 		Return(mockOperationsBatchInsertBuilder).Twice()
 
 	mockTransactionsBatchInsertBuilder := &history.MockTransactionsBatchInsertBuilder{}
 	defer mock.AssertExpectationsForObjects(t, mockTransactionsBatchInsertBuilder)
-	mockTransactionsBatchInsertBuilder.On("Exec").Return(nil).Once()
+	mockTransactionsBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	q.MockQTransactions.On("NewTransactionBatchInsertBuilder", maxBatchSize).
 		Return(mockTransactionsBatchInsertBuilder).Twice()
 
 	mockClaimableBalancesBatchInsertBuilder := &history.MockClaimableBalancesBatchInsertBuilder{}
 	defer mock.AssertExpectationsForObjects(t, mockClaimableBalancesBatchInsertBuilder)
-	mockClaimableBalancesBatchInsertBuilder.On("Exec").Return(nil).Once()
+	mockClaimableBalancesBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	q.MockQClaimableBalances.On("NewClaimableBalancesBatchInsertBuilder", maxBatchSize).
 		Return(mockClaimableBalancesBatchInsertBuilder).Once()
 
-	q.MockQLedgers.On("InsertLedger", ledger.V0.LedgerHeader, 0, 0, 0, 0, CurrentVersion).
+	q.MockQLedgers.On("InsertLedger", ctx, ledger.V0.LedgerHeader, 0, 0, 0, 0, CurrentVersion).
 		Return(int64(1), nil).Once()
 
 	runner := ProcessorRunner{
-		ctx:      context.Background(),
+		ctx:      ctx,
 		config:   config,
 		historyQ: q,
 	}
@@ -373,6 +379,7 @@ func TestProcessorRunnerRunAllProcessorsOnLedger(t *testing.T) {
 }
 
 func TestProcessorRunnerRunAllProcessorsOnLedgerProtocolVersionNotSupported(t *testing.T) {
+	ctx := context.Background()
 	maxBatchSize := 100000
 
 	config := Config{
@@ -424,7 +431,7 @@ func TestProcessorRunnerRunAllProcessorsOnLedgerProtocolVersionNotSupported(t *t
 		Return(mockClaimableBalancesBatchInsertBuilder).Once()
 
 	runner := ProcessorRunner{
-		ctx:      context.Background(),
+		ctx:      ctx,
 		config:   config,
 		historyQ: q,
 	}

--- a/services/horizon/internal/ingest/processors/change_processors.go
+++ b/services/horizon/internal/ingest/processors/change_processors.go
@@ -1,6 +1,7 @@
 package processors
 
 import (
+	"context"
 	"io"
 
 	"github.com/stellar/go/ingest"
@@ -8,14 +9,15 @@ import (
 )
 
 type ChangeProcessor interface {
-	ProcessChange(change ingest.Change) error
+	ProcessChange(ctx context.Context, change ingest.Change) error
 }
 
 type LedgerTransactionProcessor interface {
-	ProcessTransaction(transaction ingest.LedgerTransaction) error
+	ProcessTransaction(ctx context.Context, transaction ingest.LedgerTransaction) error
 }
 
 func StreamLedgerTransactions(
+	ctx context.Context,
 	txProcessor LedgerTransactionProcessor,
 	reader *ingest.LedgerTransactionReader,
 ) error {
@@ -27,7 +29,7 @@ func StreamLedgerTransactions(
 		if err != nil {
 			return errors.Wrap(err, "could not read transaction")
 		}
-		if err = txProcessor.ProcessTransaction(tx); err != nil {
+		if err = txProcessor.ProcessTransaction(ctx, tx); err != nil {
 			return errors.Wrapf(
 				err,
 				"could not process transaction %v",
@@ -38,6 +40,7 @@ func StreamLedgerTransactions(
 }
 
 func StreamChanges(
+	ctx context.Context,
 	changeProcessor ChangeProcessor,
 	reader ingest.ChangeReader,
 ) error {
@@ -50,7 +53,7 @@ func StreamChanges(
 			return errors.Wrap(err, "could not read transaction")
 		}
 
-		if err = changeProcessor.ProcessChange(change); err != nil {
+		if err = changeProcessor.ProcessChange(ctx, change); err != nil {
 			return errors.Wrap(
 				err,
 				"could not process change",

--- a/services/horizon/internal/ingest/processors/change_processors_test.go
+++ b/services/horizon/internal/ingest/processors/change_processors_test.go
@@ -1,6 +1,7 @@
 package processors
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 
 func TestStreamReaderError(t *testing.T) {
 	tt := assert.New(t)
+	ctx := context.Background()
 
 	mockChangeReader := &ingest.MockChangeReader{}
 	mockChangeReader.
@@ -18,12 +20,13 @@ func TestStreamReaderError(t *testing.T) {
 		Return(ingest.Change{}, errors.New("transient error")).Once()
 	mockChangeProcessor := &MockChangeProcessor{}
 
-	err := StreamChanges(mockChangeProcessor, mockChangeReader)
+	err := StreamChanges(ctx, mockChangeProcessor, mockChangeReader)
 	tt.EqualError(err, "could not read transaction: transient error")
 }
 
 func TestStreamChangeProcessorError(t *testing.T) {
 	tt := assert.New(t)
+	ctx := context.Background()
 
 	change := ingest.Change{}
 	mockChangeReader := &ingest.MockChangeReader{}
@@ -34,11 +37,11 @@ func TestStreamChangeProcessorError(t *testing.T) {
 	mockChangeProcessor := &MockChangeProcessor{}
 	mockChangeProcessor.
 		On(
-			"ProcessChange",
+			"ProcessChange", ctx,
 			change,
 		).
 		Return(errors.New("transient error")).Once()
 
-	err := StreamChanges(mockChangeProcessor, mockChangeReader)
+	err := StreamChanges(ctx, mockChangeProcessor, mockChangeReader)
 	tt.EqualError(err, "could not process change: transient error")
 }

--- a/services/horizon/internal/ingest/processors/claimable_balances_transaction_processor_test.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_transaction_processor_test.go
@@ -3,6 +3,7 @@
 package processors
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -15,6 +16,7 @@ import (
 
 type ClaimableBalancesTransactionProcessorTestSuiteLedger struct {
 	suite.Suite
+	ctx                               context.Context
 	processor                         *ClaimableBalancesTransactionProcessor
 	mockQ                             *history.MockQHistoryClaimableBalances
 	mockTransactionBatchInsertBuilder *history.MockTransactionClaimableBalanceBatchInsertBuilder
@@ -28,6 +30,7 @@ func TestClaimableBalancesTransactionProcessorTestSuiteLedger(t *testing.T) {
 }
 
 func (s *ClaimableBalancesTransactionProcessorTestSuiteLedger) SetupTest() {
+	s.ctx = context.Background()
 	s.mockQ = &history.MockQHistoryClaimableBalances{}
 	s.mockTransactionBatchInsertBuilder = &history.MockTransactionClaimableBalanceBatchInsertBuilder{}
 	s.mockOperationBatchInsertBuilder = &history.MockOperationClaimableBalanceBatchInsertBuilder{}
@@ -46,16 +49,16 @@ func (s *ClaimableBalancesTransactionProcessorTestSuiteLedger) TearDownTest() {
 }
 
 func (s *ClaimableBalancesTransactionProcessorTestSuiteLedger) mockTransactionBatchAdd(transactionID, internalID int64, err error) {
-	s.mockTransactionBatchInsertBuilder.On("Add", transactionID, internalID).Return(err).Once()
+	s.mockTransactionBatchInsertBuilder.On("Add", s.ctx, transactionID, internalID).Return(err).Once()
 }
 
 func (s *ClaimableBalancesTransactionProcessorTestSuiteLedger) mockOperationBatchAdd(operationID, internalID int64, err error) {
-	s.mockOperationBatchInsertBuilder.On("Add", operationID, internalID).Return(err).Once()
+	s.mockOperationBatchInsertBuilder.On("Add", s.ctx, operationID, internalID).Return(err).Once()
 }
 
 func (s *ClaimableBalancesTransactionProcessorTestSuiteLedger) TestEmptyClaimableBalances() {
 	// What is this expecting? Doesn't seem to assert anything meaningful...
-	err := s.processor.Commit()
+	err := s.processor.Commit(context.Background())
 	s.Assert().NoError(err)
 }
 
@@ -109,9 +112,9 @@ func (s *ClaimableBalancesTransactionProcessorTestSuiteLedger) testOperationInse
 	hexID, _ := xdr.MarshalHex(balanceID)
 
 	// Setup a q
-	s.mockQ.On("CreateHistoryClaimableBalances", mock.AnythingOfType("[]xdr.ClaimableBalanceId"), maxBatchSize).
+	s.mockQ.On("CreateHistoryClaimableBalances", s.ctx, mock.AnythingOfType("[]xdr.ClaimableBalanceId"), maxBatchSize).
 		Run(func(args mock.Arguments) {
-			arg := args.Get(0).([]xdr.ClaimableBalanceId)
+			arg := args.Get(1).([]xdr.ClaimableBalanceId)
 			s.Assert().ElementsMatch(
 				[]xdr.ClaimableBalanceId{
 					balanceID,
@@ -126,18 +129,18 @@ func (s *ClaimableBalancesTransactionProcessorTestSuiteLedger) testOperationInse
 	s.mockQ.On("NewTransactionClaimableBalanceBatchInsertBuilder", maxBatchSize).
 		Return(s.mockTransactionBatchInsertBuilder).Once()
 	s.mockTransactionBatchAdd(txnID, internalID, nil)
-	s.mockTransactionBatchInsertBuilder.On("Exec").Return(nil).Once()
+	s.mockTransactionBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
 
 	// Prepare to process operations successfully
 	s.mockQ.On("NewOperationClaimableBalanceBatchInsertBuilder", maxBatchSize).
 		Return(s.mockOperationBatchInsertBuilder).Once()
 	s.mockOperationBatchAdd(opID, internalID, nil)
-	s.mockOperationBatchInsertBuilder.On("Exec").Return(nil).Once()
+	s.mockOperationBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
 
 	// Process the transaction
-	err := s.processor.ProcessTransaction(txn)
+	err := s.processor.ProcessTransaction(s.ctx, txn)
 	s.Assert().NoError(err)
-	err = s.processor.Commit()
+	err = s.processor.Commit(s.ctx)
 	s.Assert().NoError(err)
 }
 

--- a/services/horizon/internal/ingest/processors/ledgers_processor.go
+++ b/services/horizon/internal/ingest/processors/ledgers_processor.go
@@ -1,6 +1,8 @@
 package processors
 
 import (
+	"context"
+
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/errors"
@@ -29,7 +31,7 @@ func NewLedgerProcessor(
 	}
 }
 
-func (p *LedgersProcessor) ProcessTransaction(transaction ingest.LedgerTransaction) (err error) {
+func (p *LedgersProcessor) ProcessTransaction(ctx context.Context, transaction ingest.LedgerTransaction) (err error) {
 	opCount := len(transaction.Envelope.Operations())
 	p.txSetOpCount += opCount
 	if transaction.Result.Successful() {
@@ -42,8 +44,8 @@ func (p *LedgersProcessor) ProcessTransaction(transaction ingest.LedgerTransacti
 	return nil
 }
 
-func (p *LedgersProcessor) Commit() error {
-	rowsAffected, err := p.ledgersQ.InsertLedger(
+func (p *LedgersProcessor) Commit(ctx context.Context) error {
+	rowsAffected, err := p.ledgersQ.InsertLedger(ctx,
 		p.ledger,
 		p.successTxCount,
 		p.failedTxCount,

--- a/services/horizon/internal/ingest/processors/ledgers_processor_test.go
+++ b/services/horizon/internal/ingest/processors/ledgers_processor_test.go
@@ -3,6 +3,7 @@
 package processors
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stellar/go/ingest"
@@ -107,8 +108,10 @@ func (s *LedgersProcessorTestSuiteLedger) TearDownTest() {
 }
 
 func (s *LedgersProcessorTestSuiteLedger) TestInsertLedgerSucceeds() {
+	ctx := context.Background()
 	s.mockQ.On(
 		"InsertLedger",
+		ctx,
 		s.header,
 		s.successCount,
 		s.failedCount,
@@ -118,17 +121,19 @@ func (s *LedgersProcessorTestSuiteLedger) TestInsertLedgerSucceeds() {
 	).Return(int64(1), nil)
 
 	for _, tx := range s.txs {
-		err := s.processor.ProcessTransaction(tx)
+		err := s.processor.ProcessTransaction(ctx, tx)
 		s.Assert().NoError(err)
 	}
 
-	err := s.processor.Commit()
+	err := s.processor.Commit(ctx)
 	s.Assert().NoError(err)
 }
 
 func (s *LedgersProcessorTestSuiteLedger) TestInsertLedgerReturnsError() {
+	ctx := context.Background()
 	s.mockQ.On(
 		"InsertLedger",
+		ctx,
 		mock.Anything,
 		mock.Anything,
 		mock.Anything,
@@ -137,14 +142,16 @@ func (s *LedgersProcessorTestSuiteLedger) TestInsertLedgerReturnsError() {
 		mock.Anything,
 	).Return(int64(0), errors.New("transient error"))
 
-	err := s.processor.Commit()
+	err := s.processor.Commit(ctx)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "Could not insert ledger: transient error")
 }
 
 func (s *LedgersProcessorTestSuiteLedger) TestInsertLedgerNoRowsAffected() {
+	ctx := context.Background()
 	s.mockQ.On(
 		"InsertLedger",
+		ctx,
 		mock.Anything,
 		mock.Anything,
 		mock.Anything,
@@ -153,7 +160,7 @@ func (s *LedgersProcessorTestSuiteLedger) TestInsertLedgerNoRowsAffected() {
 		mock.Anything,
 	).Return(int64(0), nil)
 
-	err := s.processor.Commit()
+	err := s.processor.Commit(ctx)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "0 rows affected when ingesting new ledger: 20")
 }

--- a/services/horizon/internal/ingest/processors/mock_change_processor.go
+++ b/services/horizon/internal/ingest/processors/mock_change_processor.go
@@ -1,6 +1,8 @@
 package processors
 
 import (
+	"context"
+
 	"github.com/stretchr/testify/mock"
 
 	"github.com/stellar/go/ingest"
@@ -12,7 +14,7 @@ type MockChangeProcessor struct {
 	mock.Mock
 }
 
-func (m *MockChangeProcessor) ProcessChange(change ingest.Change) error {
-	args := m.Called(change)
+func (m *MockChangeProcessor) ProcessChange(ctx context.Context, change ingest.Change) error {
+	args := m.Called(ctx, change)
 	return args.Error(0)
 }

--- a/services/horizon/internal/ingest/processors/operations_processor.go
+++ b/services/horizon/internal/ingest/processors/operations_processor.go
@@ -1,6 +1,7 @@
 package processors
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -30,7 +31,7 @@ func NewOperationProcessor(operationsQ history.QOperations, sequence uint32) *Op
 }
 
 // ProcessTransaction process the given transaction
-func (p *OperationProcessor) ProcessTransaction(transaction ingest.LedgerTransaction) error {
+func (p *OperationProcessor) ProcessTransaction(ctx context.Context, transaction ingest.LedgerTransaction) error {
 	for i, op := range transaction.Envelope.Operations() {
 		operation := transactionOperationWrapper{
 			index:          uint32(i),
@@ -48,7 +49,7 @@ func (p *OperationProcessor) ProcessTransaction(transaction ingest.LedgerTransac
 			return errors.Wrapf(err, "Error marshaling details for operation %v", operation.ID())
 		}
 
-		if err := p.batch.Add(
+		if err := p.batch.Add(ctx,
 			operation.ID(),
 			operation.TransactionID(),
 			operation.Order(),
@@ -63,8 +64,8 @@ func (p *OperationProcessor) ProcessTransaction(transaction ingest.LedgerTransac
 	return nil
 }
 
-func (p *OperationProcessor) Commit() error {
-	return p.batch.Exec()
+func (p *OperationProcessor) Commit(ctx context.Context) error {
+	return p.batch.Exec(ctx)
 }
 
 // transactionOperationWrapper represents the data for a single operation within a transaction

--- a/services/horizon/internal/ingest/processors/operations_processor_test.go
+++ b/services/horizon/internal/ingest/processors/operations_processor_test.go
@@ -3,6 +3,7 @@
 package processors
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -17,6 +18,7 @@ import (
 
 type OperationsProcessorTestSuiteLedger struct {
 	suite.Suite
+	ctx                    context.Context
 	processor              *OperationProcessor
 	mockQ                  *history.MockQOperations
 	mockBatchInsertBuilder *history.MockOperationsBatchInsertBuilder
@@ -27,6 +29,7 @@ func TestOperationProcessorTestSuiteLedger(t *testing.T) {
 }
 
 func (s *OperationsProcessorTestSuiteLedger) SetupTest() {
+	s.ctx = context.Background()
 	s.mockQ = &history.MockQOperations{}
 	s.mockBatchInsertBuilder = &history.MockOperationsBatchInsertBuilder{}
 	s.mockQ.
@@ -64,6 +67,7 @@ func (s *OperationsProcessorTestSuiteLedger) mockBatchInsertAdds(txs []ingest.Le
 
 			s.mockBatchInsertBuilder.On(
 				"Add",
+				s.ctx,
 				expected.ID(),
 				expected.TransactionID(),
 				expected.Order(),
@@ -110,11 +114,11 @@ func (s *OperationsProcessorTestSuiteLedger) TestAddOperationSucceeds() {
 
 	err = s.mockBatchInsertAdds(txs, uint32(56))
 	s.Assert().NoError(err)
-	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
-	s.Assert().NoError(s.processor.Commit())
+	s.mockBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
+	s.Assert().NoError(s.processor.Commit(s.ctx))
 
 	for _, tx := range txs {
-		err = s.processor.ProcessTransaction(tx)
+		err = s.processor.ProcessTransaction(s.ctx, tx)
 		s.Assert().NoError(err)
 	}
 }
@@ -124,7 +128,7 @@ func (s *OperationsProcessorTestSuiteLedger) TestAddOperationFails() {
 
 	s.mockBatchInsertBuilder.
 		On(
-			"Add",
+			"Add", s.ctx,
 			mock.Anything,
 			mock.Anything,
 			mock.Anything,
@@ -133,14 +137,14 @@ func (s *OperationsProcessorTestSuiteLedger) TestAddOperationFails() {
 			mock.Anything,
 		).Return(errors.New("transient error")).Once()
 
-	err := s.processor.ProcessTransaction(tx)
+	err := s.processor.ProcessTransaction(s.ctx, tx)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "Error batch inserting operation rows: transient error")
 }
 
 func (s *OperationsProcessorTestSuiteLedger) TestExecFails() {
-	s.mockBatchInsertBuilder.On("Exec").Return(errors.New("transient error")).Once()
-	err := s.processor.Commit()
+	s.mockBatchInsertBuilder.On("Exec", s.ctx).Return(errors.New("transient error")).Once()
+	err := s.processor.Commit(s.ctx)
 	s.Assert().Error(err)
 	s.Assert().EqualError(err, "transient error")
 }

--- a/services/horizon/internal/ingest/processors/participants_processor.go
+++ b/services/horizon/internal/ingest/processors/participants_processor.go
@@ -3,6 +3,7 @@
 package processors
 
 import (
+	"context"
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/toid"
@@ -46,13 +47,13 @@ func (p *participant) addOperationID(id int64) {
 	p.operationSet[id] = struct{}{}
 }
 
-func (p *ParticipantsProcessor) loadAccountIDs(participantSet map[string]participant) error {
+func (p *ParticipantsProcessor) loadAccountIDs(ctx context.Context, participantSet map[string]participant) error {
 	addresses := make([]string, 0, len(participantSet))
 	for address := range participantSet {
 		addresses = append(addresses, address)
 	}
 
-	addressToID, err := p.participantsQ.CreateAccounts(addresses, maxBatchSize)
+	addressToID, err := p.participantsQ.CreateAccounts(ctx, addresses, maxBatchSize)
 	if err != nil {
 		return errors.Wrap(err, "Could not create account ids")
 	}
@@ -226,41 +227,41 @@ func (p *ParticipantsProcessor) addOperationsParticipants(
 	return nil
 }
 
-func (p *ParticipantsProcessor) insertDBTransactionParticipants(participantSet map[string]participant) error {
+func (p *ParticipantsProcessor) insertDBTransactionParticipants(ctx context.Context, participantSet map[string]participant) error {
 	batch := p.participantsQ.NewTransactionParticipantsBatchInsertBuilder(maxBatchSize)
 
 	for _, entry := range participantSet {
 		for transactionID := range entry.transactionSet {
-			if err := batch.Add(transactionID, entry.accountID); err != nil {
+			if err := batch.Add(ctx, transactionID, entry.accountID); err != nil {
 				return errors.Wrap(err, "Could not insert transaction participant in db")
 			}
 		}
 	}
 
-	if err := batch.Exec(); err != nil {
+	if err := batch.Exec(ctx); err != nil {
 		return errors.Wrap(err, "Could not flush transaction participants to db")
 	}
 	return nil
 }
 
-func (p *ParticipantsProcessor) insertDBOperationsParticipants(participantSet map[string]participant) error {
+func (p *ParticipantsProcessor) insertDBOperationsParticipants(ctx context.Context, participantSet map[string]participant) error {
 	batch := p.participantsQ.NewOperationParticipantBatchInsertBuilder(maxBatchSize)
 
 	for _, entry := range participantSet {
 		for operationID := range entry.operationSet {
-			if err := batch.Add(operationID, entry.accountID); err != nil {
+			if err := batch.Add(ctx, operationID, entry.accountID); err != nil {
 				return errors.Wrap(err, "could not insert operation participant in db")
 			}
 		}
 	}
 
-	if err := batch.Exec(); err != nil {
+	if err := batch.Exec(ctx); err != nil {
 		return errors.Wrap(err, "could not flush operation participants to db")
 	}
 	return nil
 }
 
-func (p *ParticipantsProcessor) ProcessTransaction(transaction ingest.LedgerTransaction) (err error) {
+func (p *ParticipantsProcessor) ProcessTransaction(ctx context.Context, transaction ingest.LedgerTransaction) (err error) {
 	err = p.addTransactionParticipants(p.participantSet, p.sequence, transaction)
 	if err != nil {
 		return err
@@ -274,17 +275,17 @@ func (p *ParticipantsProcessor) ProcessTransaction(transaction ingest.LedgerTran
 	return nil
 }
 
-func (p *ParticipantsProcessor) Commit() (err error) {
+func (p *ParticipantsProcessor) Commit(ctx context.Context) (err error) {
 	if len(p.participantSet) > 0 {
-		if err = p.loadAccountIDs(p.participantSet); err != nil {
+		if err = p.loadAccountIDs(ctx, p.participantSet); err != nil {
 			return err
 		}
 
-		if err = p.insertDBTransactionParticipants(p.participantSet); err != nil {
+		if err = p.insertDBTransactionParticipants(ctx, p.participantSet); err != nil {
 			return err
 		}
 
-		if err = p.insertDBOperationsParticipants(p.participantSet); err != nil {
+		if err = p.insertDBOperationsParticipants(ctx, p.participantSet); err != nil {
 			return err
 		}
 	}

--- a/services/horizon/internal/ingest/processors/stats_ledger_transaction_processor.go
+++ b/services/horizon/internal/ingest/processors/stats_ledger_transaction_processor.go
@@ -1,6 +1,7 @@
 package processors
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/stellar/go/ingest"
@@ -47,7 +48,7 @@ type StatsLedgerTransactionProcessorResults struct {
 	OperationsSetTrustLineFlags             int64
 }
 
-func (p *StatsLedgerTransactionProcessor) ProcessTransaction(transaction ingest.LedgerTransaction) error {
+func (p *StatsLedgerTransactionProcessor) ProcessTransaction(ctx context.Context, transaction ingest.LedgerTransaction) error {
 	p.results.Transactions++
 	ops := int64(len(transaction.Envelope.Operations()))
 	p.results.Operations += ops

--- a/services/horizon/internal/ingest/processors/stats_ledger_transaction_processor_test.go
+++ b/services/horizon/internal/ingest/processors/stats_ledger_transaction_processor_test.go
@@ -1,6 +1,7 @@
 package processors
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +14,7 @@ func TestStatsLedgerTransactionProcessor(t *testing.T) {
 	processor := &StatsLedgerTransactionProcessor{}
 
 	// Successful
-	assert.NoError(t, processor.ProcessTransaction(ingest.LedgerTransaction{
+	assert.NoError(t, processor.ProcessTransaction(context.Background(), ingest.LedgerTransaction{
 		Result: xdr.TransactionResultPair{
 			Result: xdr.TransactionResult{
 				Result: xdr.TransactionResultResult{
@@ -54,7 +55,7 @@ func TestStatsLedgerTransactionProcessor(t *testing.T) {
 	}))
 
 	// Failed
-	assert.NoError(t, processor.ProcessTransaction(ingest.LedgerTransaction{
+	assert.NoError(t, processor.ProcessTransaction(context.Background(), ingest.LedgerTransaction{
 		Result: xdr.TransactionResultPair{
 			Result: xdr.TransactionResult{
 				Result: xdr.TransactionResultResult{

--- a/services/horizon/internal/ingest/processors/trades_processor_test.go
+++ b/services/horizon/internal/ingest/processors/trades_processor_test.go
@@ -3,6 +3,7 @@
 package processors
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -156,10 +157,11 @@ func (s *TradeProcessorTestSuiteLedger) TearDownTest() {
 }
 
 func (s *TradeProcessorTestSuiteLedger) TestIgnoreFailedTransactions() {
-	err := s.processor.ProcessTransaction(createTransaction(false, 1))
+	ctx := context.Background()
+	err := s.processor.ProcessTransaction(ctx, createTransaction(false, 1))
 	s.Assert().NoError(err)
 
-	err = s.processor.Commit()
+	err = s.processor.Commit(ctx)
 	s.Assert().NoError(err)
 }
 
@@ -491,20 +493,21 @@ func (s *TradeProcessorTestSuiteLedger) mockReadTradeTransactions(
 }
 
 func (s *TradeProcessorTestSuiteLedger) TestIngestTradesSucceeds() {
+	ctx := context.Background()
 	inserts := s.mockReadTradeTransactions(s.processor.ledger)
 
-	s.mockQ.On("CreateAccounts", mock.AnythingOfType("[]string"), maxBatchSize).
+	s.mockQ.On("CreateAccounts", ctx, mock.AnythingOfType("[]string"), maxBatchSize).
 		Run(func(args mock.Arguments) {
-			arg := args.Get(0).([]string)
+			arg := args.Get(1).([]string)
 			s.Assert().ElementsMatch(
 				mapKeysToList(s.unmuxedAccountToID),
 				arg,
 			)
 		}).Return(s.unmuxedAccountToID, nil).Once()
 
-	s.mockQ.On("CreateAssets", mock.AnythingOfType("[]xdr.Asset"), maxBatchSize).
+	s.mockQ.On("CreateAssets", ctx, mock.AnythingOfType("[]xdr.Asset"), maxBatchSize).
 		Run(func(args mock.Arguments) {
-			arg := args.Get(0).([]xdr.Asset)
+			arg := args.Get(1).([]xdr.Asset)
 			s.Assert().ElementsMatch(
 				s.assets,
 				arg,
@@ -512,28 +515,29 @@ func (s *TradeProcessorTestSuiteLedger) TestIngestTradesSucceeds() {
 		}).Return(s.assetToID, nil).Once()
 
 	for _, insert := range inserts {
-		s.mockBatchInsertBuilder.On("Add", []history.InsertTrade{
+		s.mockBatchInsertBuilder.On("Add", ctx, []history.InsertTrade{
 			insert,
 		}).Return(nil).Once()
 	}
 
-	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
+	s.mockBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 
 	for _, tx := range s.txs {
-		err := s.processor.ProcessTransaction(tx)
+		err := s.processor.ProcessTransaction(ctx, tx)
 		s.Assert().NoError(err)
 	}
 
-	err := s.processor.Commit()
+	err := s.processor.Commit(ctx)
 	s.Assert().NoError(err)
 }
 
 func (s *TradeProcessorTestSuiteLedger) TestCreateAccountsError() {
+	ctx := context.Background()
 	s.mockReadTradeTransactions(s.processor.ledger)
 
-	s.mockQ.On("CreateAccounts", mock.AnythingOfType("[]string"), maxBatchSize).
+	s.mockQ.On("CreateAccounts", ctx, mock.AnythingOfType("[]string"), maxBatchSize).
 		Run(func(args mock.Arguments) {
-			arg := args.Get(0).([]string)
+			arg := args.Get(1).([]string)
 			s.Assert().ElementsMatch(
 				mapKeysToList(s.unmuxedAccountToID),
 				arg,
@@ -541,30 +545,31 @@ func (s *TradeProcessorTestSuiteLedger) TestCreateAccountsError() {
 		}).Return(map[string]int64{}, fmt.Errorf("create accounts error")).Once()
 
 	for _, tx := range s.txs {
-		err := s.processor.ProcessTransaction(tx)
+		err := s.processor.ProcessTransaction(ctx, tx)
 		s.Assert().NoError(err)
 	}
 
-	err := s.processor.Commit()
+	err := s.processor.Commit(ctx)
 
 	s.Assert().EqualError(err, "Error creating account ids: create accounts error")
 }
 
 func (s *TradeProcessorTestSuiteLedger) TestCreateAssetsError() {
+	ctx := context.Background()
 	s.mockReadTradeTransactions(s.processor.ledger)
 
-	s.mockQ.On("CreateAccounts", mock.AnythingOfType("[]string"), maxBatchSize).
+	s.mockQ.On("CreateAccounts", ctx, mock.AnythingOfType("[]string"), maxBatchSize).
 		Run(func(args mock.Arguments) {
-			arg := args.Get(0).([]string)
+			arg := args.Get(1).([]string)
 			s.Assert().ElementsMatch(
 				mapKeysToList(s.unmuxedAccountToID),
 				arg,
 			)
 		}).Return(s.unmuxedAccountToID, nil).Once()
 
-	s.mockQ.On("CreateAssets", mock.AnythingOfType("[]xdr.Asset"), maxBatchSize).
+	s.mockQ.On("CreateAssets", ctx, mock.AnythingOfType("[]xdr.Asset"), maxBatchSize).
 		Run(func(args mock.Arguments) {
-			arg := args.Get(0).([]xdr.Asset)
+			arg := args.Get(1).([]xdr.Asset)
 			s.Assert().ElementsMatch(
 				s.assets,
 				arg,
@@ -572,111 +577,114 @@ func (s *TradeProcessorTestSuiteLedger) TestCreateAssetsError() {
 		}).Return(s.assetToID, fmt.Errorf("create assets error")).Once()
 
 	for _, tx := range s.txs {
-		err := s.processor.ProcessTransaction(tx)
+		err := s.processor.ProcessTransaction(ctx, tx)
 		s.Assert().NoError(err)
 	}
 
-	err := s.processor.Commit()
+	err := s.processor.Commit(ctx)
 	s.Assert().EqualError(err, "Error creating asset ids: create assets error")
 }
 
 func (s *TradeProcessorTestSuiteLedger) TestBatchAddError() {
+	ctx := context.Background()
 	s.mockReadTradeTransactions(s.processor.ledger)
 
-	s.mockQ.On("CreateAccounts", mock.AnythingOfType("[]string"), maxBatchSize).
+	s.mockQ.On("CreateAccounts", ctx, mock.AnythingOfType("[]string"), maxBatchSize).
 		Run(func(args mock.Arguments) {
-			arg := args.Get(0).([]string)
+			arg := args.Get(1).([]string)
 			s.Assert().ElementsMatch(
 				mapKeysToList(s.unmuxedAccountToID),
 				arg,
 			)
 		}).Return(s.unmuxedAccountToID, nil).Once()
 
-	s.mockQ.On("CreateAssets", mock.AnythingOfType("[]xdr.Asset"), maxBatchSize).
+	s.mockQ.On("CreateAssets", ctx, mock.AnythingOfType("[]xdr.Asset"), maxBatchSize).
 		Run(func(args mock.Arguments) {
-			arg := args.Get(0).([]xdr.Asset)
+			arg := args.Get(1).([]xdr.Asset)
 			s.Assert().ElementsMatch(
 				s.assets,
 				arg,
 			)
 		}).Return(s.assetToID, nil).Once()
 
-	s.mockBatchInsertBuilder.On("Add", mock.AnythingOfType("[]history.InsertTrade")).
+	s.mockBatchInsertBuilder.On("Add", ctx, mock.AnythingOfType("[]history.InsertTrade")).
 		Return(fmt.Errorf("batch add error")).Once()
 
 	for _, tx := range s.txs {
-		err := s.processor.ProcessTransaction(tx)
+		err := s.processor.ProcessTransaction(ctx, tx)
 		s.Assert().NoError(err)
 	}
 
-	err := s.processor.Commit()
+	err := s.processor.Commit(ctx)
 	s.Assert().EqualError(err, "Error adding trade to batch: batch add error")
 }
 
 func (s *TradeProcessorTestSuiteLedger) TestBatchExecError() {
+	ctx := context.Background()
 	insert := s.mockReadTradeTransactions(s.processor.ledger)
 
-	s.mockQ.On("CreateAccounts", mock.AnythingOfType("[]string"), maxBatchSize).
+	s.mockQ.On("CreateAccounts", ctx, mock.AnythingOfType("[]string"), maxBatchSize).
 		Run(func(args mock.Arguments) {
-			arg := args.Get(0).([]string)
+			arg := args.Get(1).([]string)
 			s.Assert().ElementsMatch(
 				mapKeysToList(s.unmuxedAccountToID),
 				arg,
 			)
 		}).Return(s.unmuxedAccountToID, nil).Once()
 
-	s.mockQ.On("CreateAssets", mock.AnythingOfType("[]xdr.Asset"), maxBatchSize).
+	s.mockQ.On("CreateAssets", ctx, mock.AnythingOfType("[]xdr.Asset"), maxBatchSize).
 		Run(func(args mock.Arguments) {
-			arg := args.Get(0).([]xdr.Asset)
+			arg := args.Get(1).([]xdr.Asset)
 			s.Assert().ElementsMatch(
 				s.assets,
 				arg,
 			)
 		}).Return(s.assetToID, nil).Once()
 
-	s.mockBatchInsertBuilder.On("Add", mock.AnythingOfType("[]history.InsertTrade")).
+	s.mockBatchInsertBuilder.On("Add", ctx, mock.AnythingOfType("[]history.InsertTrade")).
 		Return(nil).Times(len(insert))
-	s.mockBatchInsertBuilder.On("Exec").Return(fmt.Errorf("exec error")).Once()
+	s.mockBatchInsertBuilder.On("Exec", ctx).Return(fmt.Errorf("exec error")).Once()
 	for _, tx := range s.txs {
-		err := s.processor.ProcessTransaction(tx)
+		err := s.processor.ProcessTransaction(ctx, tx)
 		s.Assert().NoError(err)
 	}
 
-	err := s.processor.Commit()
+	err := s.processor.Commit(ctx)
 	s.Assert().EqualError(err, "Error flushing operation batch: exec error")
 }
 
 func (s *TradeProcessorTestSuiteLedger) TestIgnoreCheckIfSmallLedger() {
+	ctx := context.Background()
 	insert := s.mockReadTradeTransactions(s.processor.ledger)
 
-	s.mockQ.On("CreateAccounts", mock.AnythingOfType("[]string"), maxBatchSize).
+	s.mockQ.On("CreateAccounts", ctx, mock.AnythingOfType("[]string"), maxBatchSize).
 		Run(func(args mock.Arguments) {
-			arg := args.Get(0).([]string)
+			arg := args.Get(1).([]string)
 			s.Assert().ElementsMatch(
 				mapKeysToList(s.unmuxedAccountToID),
 				arg,
 			)
 		}).Return(s.unmuxedAccountToID, nil).Once()
 
-	s.mockQ.On("CreateAssets", mock.AnythingOfType("[]xdr.Asset"), maxBatchSize).
+	s.mockQ.On("CreateAssets", ctx, mock.AnythingOfType("[]xdr.Asset"), maxBatchSize).
 		Run(func(args mock.Arguments) {
-			arg := args.Get(0).([]xdr.Asset)
+			arg := args.Get(1).([]xdr.Asset)
 			s.Assert().ElementsMatch(
 				s.assets,
 				arg,
 			)
 		}).Return(s.assetToID, nil).Once()
 
-	s.mockBatchInsertBuilder.On("Add", mock.AnythingOfType("[]history.InsertTrade")).
+	s.mockBatchInsertBuilder.On("Add", ctx, mock.AnythingOfType("[]history.InsertTrade")).
 		Return(nil).Times(len(insert))
-	s.mockBatchInsertBuilder.On("Exec").Return(nil).Once()
+	s.mockBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 
 	for _, tx := range s.txs {
-		err := s.processor.ProcessTransaction(tx)
+		err := s.processor.ProcessTransaction(ctx, tx)
 		s.Assert().NoError(err)
 	}
 
-	err := s.processor.Commit()
+	err := s.processor.Commit(ctx)
 	s.Assert().NoError(err)
 }
 

--- a/services/horizon/internal/ingest/processors/transactions_processor.go
+++ b/services/horizon/internal/ingest/processors/transactions_processor.go
@@ -1,6 +1,7 @@
 package processors
 
 import (
+	"context"
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/errors"
@@ -20,16 +21,16 @@ func NewTransactionProcessor(transactionsQ history.QTransactions, sequence uint3
 	}
 }
 
-func (p *TransactionProcessor) ProcessTransaction(transaction ingest.LedgerTransaction) error {
-	if err := p.batch.Add(transaction, p.sequence); err != nil {
+func (p *TransactionProcessor) ProcessTransaction(ctx context.Context, transaction ingest.LedgerTransaction) error {
+	if err := p.batch.Add(ctx, transaction, p.sequence); err != nil {
 		return errors.Wrap(err, "Error batch inserting transaction rows")
 	}
 
 	return nil
 }
 
-func (p *TransactionProcessor) Commit() error {
-	if err := p.batch.Exec(); err != nil {
+func (p *TransactionProcessor) Commit(ctx context.Context) error {
+	if err := p.batch.Exec(ctx); err != nil {
 		return errors.Wrap(err, "Error flushing transaction batch")
 	}
 

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -88,7 +88,7 @@ func initIngester(app *App) {
 func initPathFinder(app *App) {
 	orderBookGraph := orderbook.NewOrderBookGraph()
 	app.orderBookStream = ingest.NewOrderBookStream(
-		&history.Q{app.HorizonSession(app.ctx)},
+		&history.Q{app.HorizonSession()},
 		orderBookGraph,
 	)
 
@@ -304,7 +304,7 @@ func initSubmissionSystem(app *App) {
 		Submitter:       txsub.NewDefaultSubmitter(http.DefaultClient, app.config.StellarCoreURL),
 		SubmissionQueue: sequence.NewManager(),
 		DB: func(ctx context.Context) txsub.HorizonDB {
-			return &history.Q{Session: app.HorizonSession(ctx)}
+			return &history.Q{Session: app.HorizonSession()}
 		},
 	}
 }

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -3,6 +3,7 @@
 package horizon
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -270,8 +271,8 @@ func TestStateMiddleware(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			stateMiddleware.NoStateVerification = testCase.noStateVerification
-			tt.Assert.NoError(q.UpdateExpStateInvalid(testCase.stateInvalid))
-			_, err = q.InsertLedger(xdr.LedgerHeaderHistoryEntry{
+			tt.Assert.NoError(q.UpdateExpStateInvalid(context.Background(), testCase.stateInvalid))
+			_, err = q.InsertLedger(context.Background(), xdr.LedgerHeaderHistoryEntry{
 				Hash: xdr.Hash{byte(i)},
 				Header: xdr.LedgerHeader{
 					LedgerSeq:          testCase.latestHistoryLedger,
@@ -279,8 +280,8 @@ func TestStateMiddleware(t *testing.T) {
 				},
 			}, 0, 0, 0, 0, 0)
 			tt.Assert.NoError(err)
-			tt.Assert.NoError(q.UpdateLastLedgerIngest(testCase.lastIngestedLedger))
-			tt.Assert.NoError(q.UpdateIngestVersion(testCase.ingestionVersion))
+			tt.Assert.NoError(q.UpdateLastLedgerIngest(context.Background(), testCase.lastIngestedLedger))
+			tt.Assert.NoError(q.UpdateIngestVersion(context.Background(), testCase.ingestionVersion))
 
 			if testCase.sseRequest {
 				request.Header.Set("Accept", "text/event-stream")

--- a/services/horizon/internal/reap/system_test.go
+++ b/services/horizon/internal/reap/system_test.go
@@ -21,30 +21,30 @@ func TestDeleteUnretainedHistory(t *testing.T) {
 		prev int
 		cur  int
 	)
-	err := db.GetRaw(&prev, `SELECT COUNT(*) FROM history_ledgers`)
+	err := db.GetRaw(tt.Ctx, &prev, `SELECT COUNT(*) FROM history_ledgers`)
 	tt.Require.NoError(err)
 
-	err = sys.DeleteUnretainedHistory()
+	err = sys.DeleteUnretainedHistory(tt.Ctx)
 	if tt.Assert.NoError(err) {
-		err = db.GetRaw(&cur, `SELECT COUNT(*) FROM history_ledgers`)
+		err = db.GetRaw(tt.Ctx, &cur, `SELECT COUNT(*) FROM history_ledgers`)
 		tt.Require.NoError(err)
 		tt.Assert.Equal(prev, cur, "Ledgers deleted when RetentionCount == 0")
 	}
 
 	ledgerState.SetStatus(tt.LoadLedgerStatus())
 	sys.RetentionCount = 10
-	err = sys.DeleteUnretainedHistory()
+	err = sys.DeleteUnretainedHistory(tt.Ctx)
 	if tt.Assert.NoError(err) {
-		err = db.GetRaw(&cur, `SELECT COUNT(*) FROM history_ledgers`)
+		err = db.GetRaw(tt.Ctx, &cur, `SELECT COUNT(*) FROM history_ledgers`)
 		tt.Require.NoError(err)
 		tt.Assert.Equal(10, cur)
 	}
 
 	ledgerState.SetStatus(tt.LoadLedgerStatus())
 	sys.RetentionCount = 1
-	err = sys.DeleteUnretainedHistory()
+	err = sys.DeleteUnretainedHistory(tt.Ctx)
 	if tt.Assert.NoError(err) {
-		err = db.GetRaw(&cur, `SELECT COUNT(*) FROM history_ledgers`)
+		err = db.GetRaw(tt.Ctx, &cur, `SELECT COUNT(*) FROM history_ledgers`)
 		tt.Require.NoError(err)
 		tt.Assert.Equal(1, cur)
 	}

--- a/services/horizon/internal/test/t.go
+++ b/services/horizon/internal/test/t.go
@@ -18,8 +18,7 @@ import (
 // CoreSession returns a db.Session instance pointing at the stellar core test database
 func (t *T) CoreSession() *db.Session {
 	return &db.Session{
-		DB:  t.CoreDB,
-		Ctx: t.Ctx,
+		DB: t.CoreDB,
 	}
 }
 
@@ -38,8 +37,7 @@ func (t *T) Finish() {
 // database
 func (t *T) HorizonSession() *db.Session {
 	return &db.Session{
-		DB:  t.HorizonDB,
-		Ctx: t.Ctx,
+		DB: t.HorizonDB,
 	}
 }
 
@@ -137,7 +135,7 @@ func (t *T) UnmarshalExtras(r io.Reader) map[string]string {
 func (t *T) LoadLedgerStatus() ledger.Status {
 	var next ledger.Status
 
-	err := t.CoreSession().GetRaw(&next, `
+	err := t.CoreSession().GetRaw(t.Ctx, &next, `
 		SELECT
 			COALESCE(MAX(ledgerseq), 0) as core_latest
 		FROM ledgerheaders
@@ -147,7 +145,7 @@ func (t *T) LoadLedgerStatus() ledger.Status {
 		panic(err)
 	}
 
-	err = t.HorizonSession().GetRaw(&next, `
+	err = t.HorizonSession().GetRaw(t.Ctx, &next, `
 			SELECT
 				COALESCE(MIN(sequence), 0) as history_elder,
 				COALESCE(MAX(sequence), 0) as history_latest

--- a/services/horizon/internal/test/trades/main.go
+++ b/services/horizon/internal/test/trades/main.go
@@ -2,6 +2,8 @@
 package trades
 
 import (
+	"context"
+
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/time"
@@ -49,17 +51,18 @@ func IngestTestTrade(
 		D: xdr.Int32(amountSold),
 	}
 
-	accounts, err := q.CreateAccounts([]string{seller.Address(), buyer.Address()}, 2)
+	ctx := context.Background()
+	accounts, err := q.CreateAccounts(ctx, []string{seller.Address(), buyer.Address()}, 2)
 	if err != nil {
 		return err
 	}
-	assets, err := q.CreateAssets([]xdr.Asset{assetBought, assetSold}, 2)
+	assets, err := q.CreateAssets(ctx, []xdr.Asset{assetBought, assetSold}, 2)
 	if err != nil {
 		return err
 	}
 
 	batch := q.NewTradeBatchInsertBuilder(0)
-	batch.Add(history.InsertTrade{
+	batch.Add(ctx, history.InsertTrade{
 		HistoryOperationID: opCounter,
 		Order:              0,
 		BuyOfferExists:     false,
@@ -72,7 +75,7 @@ func IngestTestTrade(
 		BuyerAccountID:     accounts[buyer.Address()],
 		SellerAccountID:    accounts[seller.Address()],
 	})
-	return batch.Exec()
+	return batch.Exec(ctx)
 }
 
 //PopulateTestTrades generates and ingests trades between two assets according to given parameters

--- a/services/horizon/internal/txsub/helpers_test.go
+++ b/services/horizon/internal/txsub/helpers_test.go
@@ -28,13 +28,13 @@ type mockDBQ struct {
 	mock.Mock
 }
 
-func (m *mockDBQ) BeginTx(txOpts *sql.TxOptions) error {
-	args := m.Called(txOpts)
+func (m *mockDBQ) BeginTx(ctx context.Context, txOpts *sql.TxOptions) error {
+	args := m.Called(ctx, txOpts)
 	return args.Error(0)
 }
 
-func (m *mockDBQ) Rollback() error {
-	args := m.Called()
+func (m *mockDBQ) Rollback(ctx context.Context) error {
+	args := m.Called(ctx)
 	return args.Error(0)
 }
 
@@ -43,12 +43,12 @@ func (m *mockDBQ) NoRows(err error) bool {
 	return args.Bool(0)
 }
 
-func (m *mockDBQ) GetSequenceNumbers(addresses []string) (map[string]uint64, error) {
-	args := m.Called(addresses)
+func (m *mockDBQ) GetSequenceNumbers(ctx context.Context, addresses []string) (map[string]uint64, error) {
+	args := m.Called(ctx, addresses)
 	return args.Get(0).(map[string]uint64), args.Error(1)
 }
 
-func (m *mockDBQ) TransactionByHash(dest interface{}, hash string) error {
-	args := m.Called(dest, hash)
+func (m *mockDBQ) TransactionByHash(ctx context.Context, dest interface{}, hash string) error {
+	args := m.Called(ctx, dest, hash)
 	return args.Error(0)
 }

--- a/services/horizon/internal/txsub/results_test.go
+++ b/services/horizon/internal/txsub/results_test.go
@@ -13,7 +13,7 @@ func TestGetIngestedTx(t *testing.T) {
 	defer tt.Finish()
 	q := &history.Q{Session: tt.HorizonSession()}
 	hash := "2374e99349b9ef7dba9a5db3339b78fda8f34777b1af33ba468ad5c0df946d4d"
-	tx, err := txResultByHash(q, hash)
+	tx, err := txResultByHash(tt.Ctx, q, hash)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(hash, tx.TransactionHash)
 }
@@ -25,7 +25,7 @@ func TestGetMissingTx(t *testing.T) {
 	q := &history.Q{Session: tt.HorizonSession()}
 	hash := "adf1efb9fd253f53cbbe6230c131d2af19830328e52b610464652d67d2fb7195"
 
-	_, err := txResultByHash(q, hash)
+	_, err := txResultByHash(tt.Ctx, q, hash)
 	tt.Assert.Equal(ErrNoResults, err)
 }
 
@@ -36,6 +36,6 @@ func TestGetFailedTx(t *testing.T) {
 	q := &history.Q{Session: tt.HorizonSession()}
 	hash := "aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf"
 
-	_, err := txResultByHash(q, hash)
+	_, err := txResultByHash(tt.Ctx, q, hash)
 	tt.Assert.Equal("AAAAAAAAAGT/////AAAAAQAAAAAAAAAB/////gAAAAA=", err.(*FailedTransactionError).ResultXDR)
 }

--- a/services/ticker/cmd/clean.go
+++ b/services/ticker/cmd/clean.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"time"
 
 	"github.com/lib/pq"
@@ -45,7 +46,7 @@ var cmdCleanTrades = &cobra.Command{
 		now := time.Now()
 		minDate := now.AddDate(0, 0, -DaysToKeep)
 		Logger.Infof("Deleting trade entries older than %d days", DaysToKeep)
-		err = session.DeleteOldTrades(minDate)
+		err = session.DeleteOldTrades(context.Background(), minDate)
 		if err != nil {
 			Logger.Fatal("could not delete trade entries:", err)
 		}

--- a/services/ticker/cmd/generate.go
+++ b/services/ticker/cmd/generate.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"github.com/lib/pq"
 	"github.com/spf13/cobra"
 	ticker "github.com/stellar/go/services/ticker/internal"
@@ -74,7 +75,7 @@ var cmdGenerateAssetData = &cobra.Command{
 		}
 
 		Logger.Infof("Starting asset data generation, outputting to: %s\n", AssetsOutFile)
-		err = ticker.GenerateAssetsFile(&session, Logger, AssetsOutFile)
+		err = ticker.GenerateAssetsFile(context.Background(), &session, Logger, AssetsOutFile)
 		if err != nil {
 			Logger.Fatal("could not generate asset data:", err)
 		}

--- a/services/ticker/cmd/ingest.go
+++ b/services/ticker/cmd/ingest.go
@@ -54,7 +54,8 @@ var cmdIngestAssets = &cobra.Command{
 		}
 		defer session.DB.Close()
 
-		err = ticker.RefreshAssets(&session, Client, Logger)
+		ctx := context.Background()
+		err = ticker.RefreshAssets(ctx, &session, Client, Logger)
 		if err != nil {
 			Logger.Fatal("could not refresh asset database:", err)
 		}
@@ -76,20 +77,20 @@ var cmdIngestTrades = &cobra.Command{
 		}
 		defer session.DB.Close()
 
+		ctx := context.Background()
 		numDays := float32(BackfillHours) / 24.0
 		Logger.Infof(
 			"Backfilling Trade data for the past %d hour(s) [%.2f days]\n",
 			BackfillHours,
 			numDays,
 		)
-		err = ticker.BackfillTrades(&session, Client, Logger, BackfillHours, 0)
+		err = ticker.BackfillTrades(ctx, &session, Client, Logger, BackfillHours, 0)
 		if err != nil {
 			Logger.Fatal("could not refresh trade database:", err)
 		}
 
 		if ShouldStream {
 			Logger.Info("Streaming new data (this is a continuous process)")
-			ctx := context.Background()
 			err = ticker.StreamTrades(ctx, &session, Client, Logger)
 			if err != nil {
 				Logger.Fatal("could not refresh trade database:", err)

--- a/services/ticker/internal/actions_asset.go
+++ b/services/ticker/internal/actions_asset.go
@@ -1,6 +1,7 @@
 package ticker
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"time"
@@ -13,7 +14,7 @@ import (
 )
 
 // RefreshAssets scrapes the most recent asset list and ingests then into the db.
-func RefreshAssets(s *tickerdb.TickerSession, c *horizonclient.Client, l *hlog.Entry) (err error) {
+func RefreshAssets(ctx context.Context, s *tickerdb.TickerSession, c *horizonclient.Client, l *hlog.Entry) (err error) {
 	sc := scraper.ScraperConfig{
 		Client: c,
 		Logger: l,
@@ -28,14 +29,14 @@ func RefreshAssets(s *tickerdb.TickerSession, c *horizonclient.Client, l *hlog.E
 		if dbIssuer.PublicKey == "" {
 			dbIssuer.PublicKey = finalAsset.Issuer
 		}
-		issuerID, err := s.InsertOrUpdateIssuer(&dbIssuer, []string{"public_key"})
+		issuerID, err := s.InsertOrUpdateIssuer(ctx, &dbIssuer, []string{"public_key"})
 		if err != nil {
 			l.Error("Error inserting issuer:", dbIssuer, err)
 			continue
 		}
 
 		dbAsset := finalAssetToDBAsset(finalAsset, issuerID)
-		err = s.InsertOrUpdateAsset(&dbAsset, []string{"code", "issuer_account", "issuer_id"})
+		err = s.InsertOrUpdateAsset(ctx, &dbAsset, []string{"code", "issuer_account", "issuer_id"})
 		if err != nil {
 			l.Error("Error inserting asset:", dbAsset, err)
 		}
@@ -45,10 +46,10 @@ func RefreshAssets(s *tickerdb.TickerSession, c *horizonclient.Client, l *hlog.E
 }
 
 // GenerateAssetsFile generates a file with the info about all valid scraped Assets
-func GenerateAssetsFile(s *tickerdb.TickerSession, l *hlog.Entry, filename string) error {
+func GenerateAssetsFile(ctx context.Context, s *tickerdb.TickerSession, l *hlog.Entry, filename string) error {
 	l.Infoln("Retrieving asset data from db...")
 	var assets []Asset
-	validAssets, err := s.GetAssetsWithNestedIssuer()
+	validAssets, err := s.GetAssetsWithNestedIssuer(ctx)
 	if err != nil {
 		return err
 	}

--- a/services/ticker/internal/actions_market.go
+++ b/services/ticker/internal/actions_market.go
@@ -1,6 +1,7 @@
 package ticker
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -40,8 +41,9 @@ func GenerateMarketSummary(s *tickerdb.TickerSession) (ms MarketSummary, err err
 	now := time.Now()
 	nowMillis := utils.TimeToUnixEpoch(now)
 	nowRFC339 := utils.TimeToRFC3339(now)
+	ctx := context.Background()
 
-	dbMarkets, err := s.RetrieveMarketData()
+	dbMarkets, err := s.RetrieveMarketData(ctx)
 	if err != nil {
 		return
 	}

--- a/services/ticker/internal/actions_orderbook.go
+++ b/services/ticker/internal/actions_orderbook.go
@@ -1,6 +1,7 @@
 package ticker
 
 import (
+	"context"
 	"time"
 
 	horizonclient "github.com/stellar/go/clients/horizonclient"
@@ -17,9 +18,10 @@ func RefreshOrderbookEntries(s *tickerdb.TickerSession, c *horizonclient.Client,
 		Client: c,
 		Logger: l,
 	}
+	ctx := context.Background()
 
 	// Retrieve relevant markets for the past 7 days (168 hours):
-	mkts, err := s.Retrieve7DRelevantMarkets()
+	mkts, err := s.Retrieve7DRelevantMarkets(ctx)
 	if err != nil {
 		return errors.Wrap(err, "could not retrieve partial markets")
 	}
@@ -39,7 +41,7 @@ func RefreshOrderbookEntries(s *tickerdb.TickerSession, c *horizonclient.Client,
 		}
 
 		dbOS := orderbookStatsToDBOrderbookStats(ob, mkt.BaseAssetID, mkt.CounterAssetID)
-		err = s.InsertOrUpdateOrderbookStats(&dbOS, []string{"base_asset_id", "counter_asset_id"})
+		err = s.InsertOrUpdateOrderbookStats(ctx, &dbOS, []string{"base_asset_id", "counter_asset_id"})
 		if err != nil {
 			l.Error(errors.Wrap(err, "could not insert orderbook stats into db"))
 			continue
@@ -60,7 +62,7 @@ func RefreshOrderbookEntries(s *tickerdb.TickerSession, c *horizonclient.Client,
 		}
 
 		dbIOS := orderbookStatsToDBOrderbookStats(iob, mkt.CounterAssetID, mkt.BaseAssetID)
-		err = s.InsertOrUpdateOrderbookStats(&dbIOS, []string{"base_asset_id", "counter_asset_id"})
+		err = s.InsertOrUpdateOrderbookStats(ctx, &dbIOS, []string{"base_asset_id", "counter_asset_id"})
 		if err != nil {
 			l.Error(errors.Wrap(err, "could not insert reverse orderbook stats into db"))
 		}

--- a/services/ticker/internal/gql/resolvers_asset.go
+++ b/services/ticker/internal/gql/resolvers_asset.go
@@ -1,14 +1,15 @@
 package gql
 
 import (
+	"context"
 	"errors"
 
 	"github.com/stellar/go/services/ticker/internal/tickerdb"
 )
 
 // Assets resolves the assets() GraphQL query.
-func (r *resolver) Assets() (assets []*asset, err error) {
-	dbAssets, err := r.db.GetAllValidAssets()
+func (r *resolver) Assets(ctx context.Context) (assets []*asset, err error) {
+	dbAssets, err := r.db.GetAllValidAssets(ctx)
 	if err != nil {
 		// obfuscating sql errors to avoid exposing underlying
 		// implementation

--- a/services/ticker/internal/gql/resolvers_issuer.go
+++ b/services/ticker/internal/gql/resolvers_issuer.go
@@ -1,14 +1,15 @@
 package gql
 
 import (
+	"context"
 	"errors"
 
 	"github.com/stellar/go/services/ticker/internal/tickerdb"
 )
 
 // Issuers resolves the issuers() GraphQL query.
-func (r *resolver) Issuers() (issuers []*tickerdb.Issuer, err error) {
-	dbIssuers, err := r.db.GetAllIssuers()
+func (r *resolver) Issuers(ctx context.Context) (issuers []*tickerdb.Issuer, err error) {
+	dbIssuers, err := r.db.GetAllIssuers(ctx)
 	if err != nil {
 		// obfuscating sql errors to avoid exposing underlying
 		// implementation

--- a/services/ticker/internal/gql/resolvers_market.go
+++ b/services/ticker/internal/gql/resolvers_market.go
@@ -1,6 +1,7 @@
 package gql
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -11,7 +12,7 @@ import (
 )
 
 // Markets resolves the markets() GraphQL query.
-func (r *resolver) Markets(args struct {
+func (r *resolver) Markets(ctx context.Context, args struct {
 	BaseAssetCode      *string
 	BaseAssetIssuer    *string
 	CounterAssetCode   *string
@@ -28,7 +29,7 @@ func (r *resolver) Markets(args struct {
 		pairName = fmt.Sprintf("%s:%s / %s:%s", *args.BaseAssetCode, *args.BaseAssetIssuer, *args.CounterAssetCode, *args.CounterAssetIssuer)
 	}
 
-	dbMarkets, err := r.db.RetrievePartialMarkets(
+	dbMarkets, err := r.db.RetrievePartialMarkets(ctx,
 		args.BaseAssetCode,
 		args.BaseAssetIssuer,
 		args.CounterAssetCode,
@@ -57,7 +58,7 @@ func (r *resolver) Markets(args struct {
 }
 
 // Ticker resolves the ticker() GraphQL query (TODO)
-func (r *resolver) Ticker(
+func (r *resolver) Ticker(ctx context.Context,
 	args struct {
 		Code        *string
 		PairNames   *[]*string
@@ -74,7 +75,7 @@ func (r *resolver) Ticker(
 		return
 	}
 
-	dbMarkets, err := r.db.RetrievePartialAggMarkets(args.Code, args.PairNames, numHours)
+	dbMarkets, err := r.db.RetrievePartialAggMarkets(ctx, args.Code, args.PairNames, numHours)
 	if err != nil {
 		// obfuscating sql errors to avoid exposing underlying
 		// implementation

--- a/services/ticker/internal/tickerdb/helpers.go
+++ b/services/ticker/internal/tickerdb/helpers.go
@@ -1,6 +1,7 @@
 package tickerdb
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -172,7 +173,7 @@ func orderBaseAndCounter(
 // performUpsertQuery introspects a dbStruct interface{} and performs an insert query
 // (if the conflictConstraint isn't broken), otherwise it updates the instance on the
 // db, preserving the old values for the fields in preserveFields
-func (s *TickerSession) performUpsertQuery(dbStruct interface{}, tableName string, conflictConstraint string, preserveFields []string) error {
+func (s *TickerSession) performUpsertQuery(ctx context.Context, dbStruct interface{}, tableName string, conflictConstraint string, preserveFields []string) error {
 	dbFields := getDBFieldTags(dbStruct, true)
 	dbFieldsString := strings.Join(dbFields, ", ")
 	dbValues := getDBFieldValues(dbStruct, true)
@@ -183,6 +184,6 @@ func (s *TickerSession) performUpsertQuery(dbStruct interface{}, tableName strin
 	qs := fmt.Sprintf("INSERT INTO %s (", tableName) + dbFieldsString + ")"
 	qs += " VALUES (" + generatePlaceholders(dbValues) + ")"
 	qs += " " + createOnConflictFragment(conflictConstraint, toUpdateFields) + ";"
-	_, err := s.ExecRaw(qs, dbValues...)
+	_, err := s.ExecRaw(ctx, qs, dbValues...)
 	return err
 }

--- a/services/ticker/internal/tickerdb/main.go
+++ b/services/ticker/internal/tickerdb/main.go
@@ -1,7 +1,6 @@
 package tickerdb
 
 import (
-	"context"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -175,7 +174,6 @@ func CreateSession(driverName, dataSourceName string) (session TickerSession, er
 	}
 
 	session.DB = dbconn
-	session.Ctx = context.Background()
 	return
 }
 

--- a/services/ticker/internal/tickerdb/queries_issuer.go
+++ b/services/ticker/internal/tickerdb/queries_issuer.go
@@ -1,6 +1,7 @@
 package tickerdb
 
 import (
+	"context"
 	"strings"
 
 	"github.com/stellar/go/services/ticker/internal/utils"
@@ -8,7 +9,7 @@ import (
 
 // InsertOrUpdateIssuer inserts an Issuer on the database (if new),
 // or updates an existing one
-func (s *TickerSession) InsertOrUpdateIssuer(issuer *Issuer, preserveFields []string) (id int32, err error) {
+func (s *TickerSession) InsertOrUpdateIssuer(ctx context.Context, issuer *Issuer, preserveFields []string) (id int32, err error) {
 	dbFields := getDBFieldTags(*issuer, true)
 	dbFieldsString := strings.Join(dbFields, ", ")
 	dbValues := getDBFieldValues(*issuer, true)
@@ -21,7 +22,7 @@ func (s *TickerSession) InsertOrUpdateIssuer(issuer *Issuer, preserveFields []st
 	qs += " " + createOnConflictFragment("public_key_unique", toUpdateFields)
 	qs += " RETURNING id;"
 
-	rows, err := s.QueryRaw(qs, dbValues...)
+	rows, err := s.QueryRaw(ctx, qs, dbValues...)
 	if err != nil {
 		return
 	}
@@ -33,7 +34,7 @@ func (s *TickerSession) InsertOrUpdateIssuer(issuer *Issuer, preserveFields []st
 }
 
 // GetAllIssuers returns a slice with all issuers in the database
-func (s *TickerSession) GetAllIssuers() (issuers []Issuer, err error) {
-	err = s.SelectRaw(&issuers, "SELECT * FROM issuers")
+func (s *TickerSession) GetAllIssuers(ctx context.Context) (issuers []Issuer, err error) {
+	err = s.SelectRaw(ctx, &issuers, "SELECT * FROM issuers")
 	return
 }

--- a/services/ticker/internal/tickerdb/queries_orderbook.go
+++ b/services/ticker/internal/tickerdb/queries_orderbook.go
@@ -1,7 +1,11 @@
 package tickerdb
 
+import (
+	"context"
+)
+
 // InsertOrUpdateOrderbookStats inserts an OrdebookStats entry on the database (if new),
 // or updates an existing one
-func (s *TickerSession) InsertOrUpdateOrderbookStats(o *OrderbookStats, preserveFields []string) (err error) {
-	return s.performUpsertQuery(*o, "orderbook_stats", "orderbook_stats_base_counter_asset_key", preserveFields)
+func (s *TickerSession) InsertOrUpdateOrderbookStats(ctx context.Context, o *OrderbookStats, preserveFields []string) (err error) {
+	return s.performUpsertQuery(ctx, *o, "orderbook_stats", "orderbook_stats_base_counter_asset_key", preserveFields)
 }

--- a/services/ticker/internal/tickerdb/tickerdb_test/queries_asset_test.go
+++ b/services/ticker/internal/tickerdb/tickerdb_test/queries_asset_test.go
@@ -19,8 +19,8 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 
 	var session tickerdb.TickerSession
 	session.DB = db.Open()
-	session.Ctx = context.Background()
 	defer session.DB.Close()
+	ctx := context.Background()
 
 	// Run migrations to make sure the tests are run
 	// on the most updated schema version
@@ -41,10 +41,10 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 		Name:      name,
 	}
 	tbl := session.GetTable("issuers")
-	_, err = tbl.Insert(issuer).IgnoreCols("id").Exec()
+	_, err = tbl.Insert(issuer).IgnoreCols("id").Exec(ctx)
 	require.NoError(t, err)
 	var dbIssuer tickerdb.Issuer
-	err = session.GetRaw(&dbIssuer, `
+	err = session.GetRaw(ctx, &dbIssuer, `
 		SELECT *
 		FROM issuers
 		ORDER BY id DESC
@@ -62,11 +62,11 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 		LastValid:     firstTime,
 		LastChecked:   firstTime,
 	}
-	err = session.InsertOrUpdateAsset(&a, []string{"code", "issuer_account", "issuer_id"})
+	err = session.InsertOrUpdateAsset(ctx, &a, []string{"code", "issuer_account", "issuer_id"})
 	require.NoError(t, err)
 
 	var dbAsset1 tickerdb.Asset
-	err = session.GetRaw(&dbAsset1, `
+	err = session.GetRaw(ctx, &dbAsset1, `
 		SELECT *
 		FROM assets
 		ORDER BY id DESC
@@ -93,11 +93,11 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 	t.Log("secondTime:", secondTime)
 	a.LastValid = secondTime
 	a.LastChecked = secondTime
-	err = session.InsertOrUpdateAsset(&a, []string{"code", "issuer_account", "issuer_id"})
+	err = session.InsertOrUpdateAsset(ctx, &a, []string{"code", "issuer_account", "issuer_id"})
 	require.NoError(t, err)
 
 	var dbAsset2 tickerdb.Asset
-	err = session.GetRaw(&dbAsset2, `
+	err = session.GetRaw(ctx, &dbAsset2, `
 		SELECT *
 		FROM assets
 		ORDER BY id DESC
@@ -128,10 +128,10 @@ func TestInsertOrUpdateAsset(t *testing.T) {
 	t.Log("thirdTime:", thirdTime)
 	a.LastValid = thirdTime
 	a.LastChecked = thirdTime
-	err = session.InsertOrUpdateAsset(&a, []string{"code", "issuer_id", "last_valid", "last_checked", "issuer_account"})
+	err = session.InsertOrUpdateAsset(ctx, &a, []string{"code", "issuer_id", "last_valid", "last_checked", "issuer_account"})
 	require.NoError(t, err)
 	var dbAsset3 tickerdb.Asset
-	err = session.GetRaw(&dbAsset3, `
+	err = session.GetRaw(ctx, &dbAsset3, `
 		SELECT *
 		FROM assets
 		ORDER BY id DESC
@@ -163,8 +163,8 @@ func TestGetAssetByCodeAndIssuerAccount(t *testing.T) {
 
 	var session tickerdb.TickerSession
 	session.DB = db.Open()
-	session.Ctx = context.Background()
 	defer session.DB.Close()
+	ctx := context.Background()
 
 	// Run migrations to make sure the tests are run
 	// on the most updated schema version
@@ -185,10 +185,10 @@ func TestGetAssetByCodeAndIssuerAccount(t *testing.T) {
 		Name:      name,
 	}
 	tbl := session.GetTable("issuers")
-	_, err = tbl.Insert(issuer).IgnoreCols("id").Exec()
+	_, err = tbl.Insert(issuer).IgnoreCols("id").Exec(ctx)
 	require.NoError(t, err)
 	var dbIssuer tickerdb.Issuer
-	err = session.GetRaw(&dbIssuer, `
+	err = session.GetRaw(ctx, &dbIssuer, `
 		SELECT *
 		FROM issuers
 		ORDER BY id DESC
@@ -205,11 +205,11 @@ func TestGetAssetByCodeAndIssuerAccount(t *testing.T) {
 		LastValid:     firstTime,
 		LastChecked:   firstTime,
 	}
-	err = session.InsertOrUpdateAsset(&a, []string{"code", "issuer_account", "issuer_id"})
+	err = session.InsertOrUpdateAsset(ctx, &a, []string{"code", "issuer_account", "issuer_id"})
 	require.NoError(t, err)
 
 	var dbAsset tickerdb.Asset
-	err = session.GetRaw(&dbAsset, `
+	err = session.GetRaw(ctx, &dbAsset, `
 		SELECT *
 		FROM assets
 		ORDER BY id DESC
@@ -218,13 +218,13 @@ func TestGetAssetByCodeAndIssuerAccount(t *testing.T) {
 	require.NoError(t, err)
 
 	// Searching for an asset that exists:
-	found, id, err := session.GetAssetByCodeAndIssuerAccount(code, issuerAccount)
+	found, id, err := session.GetAssetByCodeAndIssuerAccount(ctx, code, issuerAccount)
 	require.NoError(t, err)
 	assert.Equal(t, dbAsset.ID, id)
 	assert.True(t, found)
 
 	// Now searching for an asset that does not exist:
-	found, _, err = session.GetAssetByCodeAndIssuerAccount(
+	found, _, err = session.GetAssetByCodeAndIssuerAccount(ctx,
 		"NONEXISTENT CODE",
 		issuerAccount,
 	)

--- a/services/ticker/internal/tickerdb/tickerdb_test/queries_issuer_test.go
+++ b/services/ticker/internal/tickerdb/tickerdb_test/queries_issuer_test.go
@@ -18,8 +18,8 @@ func TestInsertOrUpdateIssuer(t *testing.T) {
 
 	var session tickerdb.TickerSession
 	session.DB = db.Open()
-	session.Ctx = context.Background()
 	defer session.DB.Close()
+	ctx := context.Background()
 
 	// Run migrations to make sure the tests are run
 	// on the most updated schema version
@@ -37,11 +37,11 @@ func TestInsertOrUpdateIssuer(t *testing.T) {
 		PublicKey: publicKey,
 		Name:      name,
 	}
-	id, err := session.InsertOrUpdateIssuer(&issuer, []string{"public_key"})
+	id, err := session.InsertOrUpdateIssuer(ctx, &issuer, []string{"public_key"})
 
 	require.NoError(t, err)
 	var dbIssuer tickerdb.Issuer
-	err = session.GetRaw(&dbIssuer, `
+	err = session.GetRaw(ctx, &dbIssuer, `
 		SELECT *
 		FROM issuers
 		ORDER BY id DESC
@@ -57,11 +57,11 @@ func TestInsertOrUpdateIssuer(t *testing.T) {
 		PublicKey: "ANOTHERKEY",
 		Name:      "Hello from the other side",
 	}
-	id2, err := session.InsertOrUpdateIssuer(&issuer2, []string{"public_key"})
+	id2, err := session.InsertOrUpdateIssuer(ctx, &issuer2, []string{"public_key"})
 
 	require.NoError(t, err)
 	var dbIssuer2 tickerdb.Issuer
-	err = session.GetRaw(&dbIssuer2, `
+	err = session.GetRaw(ctx, &dbIssuer2, `
 		SELECT *
 		FROM issuers
 		ORDER BY id DESC
@@ -79,11 +79,11 @@ func TestInsertOrUpdateIssuer(t *testing.T) {
 		PublicKey: publicKey,
 		Name:      name3,
 	}
-	id, err = session.InsertOrUpdateIssuer(&issuer3, []string{"public_key"})
+	id, err = session.InsertOrUpdateIssuer(ctx, &issuer3, []string{"public_key"})
 	require.NoError(t, err)
 
 	var dbIssuer3 tickerdb.Issuer
-	err = session.GetRaw(
+	err = session.GetRaw(ctx,
 		&dbIssuer3,
 		"SELECT * FROM issuers WHERE id=?",
 		id,

--- a/services/ticker/internal/tickerdb/tickerdb_test/queries_orderbook_test.go
+++ b/services/ticker/internal/tickerdb/tickerdb_test/queries_orderbook_test.go
@@ -18,8 +18,8 @@ func TestInsertOrUpdateOrderbokStats(t *testing.T) {
 
 	var session tickerdb.TickerSession
 	session.DB = db.Open()
-	session.Ctx = context.Background()
 	defer session.DB.Close()
+	ctx := context.Background()
 
 	// Run migrations to make sure the tests are run
 	// on the most updated schema version
@@ -40,10 +40,10 @@ func TestInsertOrUpdateOrderbokStats(t *testing.T) {
 		Name:      name,
 	}
 	tbl := session.GetTable("issuers")
-	_, err = tbl.Insert(issuer).IgnoreCols("id").Exec()
+	_, err = tbl.Insert(issuer).IgnoreCols("id").Exec(ctx)
 	require.NoError(t, err)
 	var dbIssuer tickerdb.Issuer
-	err = session.GetRaw(&dbIssuer, `
+	err = session.GetRaw(ctx, &dbIssuer, `
 		SELECT *
 		FROM issuers
 		ORDER BY id DESC
@@ -60,11 +60,11 @@ func TestInsertOrUpdateOrderbokStats(t *testing.T) {
 		LastValid:     firstTime,
 		LastChecked:   firstTime,
 	}
-	err = session.InsertOrUpdateAsset(&a, []string{"code", "issuer_account", "issuer_id"})
+	err = session.InsertOrUpdateAsset(ctx, &a, []string{"code", "issuer_account", "issuer_id"})
 	require.NoError(t, err)
 
 	var dbAsset1 tickerdb.Asset
-	err = session.GetRaw(&dbAsset1, `
+	err = session.GetRaw(ctx, &dbAsset1, `
 		SELECT *
 		FROM assets
 		ORDER BY id DESC
@@ -82,11 +82,11 @@ func TestInsertOrUpdateOrderbokStats(t *testing.T) {
 	secondTime := time.Now()
 	a.LastValid = secondTime
 	a.LastChecked = secondTime
-	err = session.InsertOrUpdateAsset(&a, []string{"code", "issuer_account", "issuer_id"})
+	err = session.InsertOrUpdateAsset(ctx, &a, []string{"code", "issuer_account", "issuer_id"})
 	require.NoError(t, err)
 
 	var dbAsset2 tickerdb.Asset
-	err = session.GetRaw(&dbAsset2, `
+	err = session.GetRaw(ctx, &dbAsset2, `
 		SELECT *
 		FROM assets
 		ORDER BY id DESC
@@ -109,14 +109,14 @@ func TestInsertOrUpdateOrderbokStats(t *testing.T) {
 		SpreadMidPoint: 0.35,
 		UpdatedAt:      obTime,
 	}
-	err = session.InsertOrUpdateOrderbookStats(
+	err = session.InsertOrUpdateOrderbookStats(ctx,
 		&orderbookStats,
 		[]string{"base_asset_id", "counter_asset_id"},
 	)
 	require.NoError(t, err)
 
 	var dbOS tickerdb.OrderbookStats
-	err = session.GetRaw(&dbOS, `
+	err = session.GetRaw(ctx, &dbOS, `
 		SELECT *
 		FROM orderbook_stats
 		ORDER BY id DESC
@@ -151,14 +151,14 @@ func TestInsertOrUpdateOrderbokStats(t *testing.T) {
 		SpreadMidPoint: 0.7,
 		UpdatedAt:      obTime2,
 	}
-	err = session.InsertOrUpdateOrderbookStats(
+	err = session.InsertOrUpdateOrderbookStats(ctx,
 		&orderbookStats2,
 		[]string{"base_asset_id", "counter_asset_id", "lowest_ask"},
 	)
 	require.NoError(t, err)
 
 	var dbOS2 tickerdb.OrderbookStats
-	err = session.GetRaw(&dbOS2, `
+	err = session.GetRaw(ctx, &dbOS2, `
 		SELECT *
 		FROM orderbook_stats
 		ORDER BY id DESC

--- a/services/ticker/internal/tickerdb/tickerdb_test/queries_trade_test.go
+++ b/services/ticker/internal/tickerdb/tickerdb_test/queries_trade_test.go
@@ -20,8 +20,8 @@ func TestBulkInsertTrades(t *testing.T) {
 
 	var session tickerdb.TickerSession
 	session.DB = db.Open()
-	session.Ctx = context.Background()
 	defer session.DB.Close()
+	ctx := context.Background()
 
 	// Run migrations to make sure the tests are run
 	// on the most updated schema version
@@ -36,10 +36,10 @@ func TestBulkInsertTrades(t *testing.T) {
 	_, err = tbl.Insert(tickerdb.Issuer{
 		PublicKey: "GCF3TQXKZJNFJK7HCMNE2O2CUNKCJH2Y2ROISTBPLC7C5EIA5NNG2XZB",
 		Name:      "FOO BAR",
-	}).IgnoreCols("id").Exec()
+	}).IgnoreCols("id").Exec(ctx)
 	require.NoError(t, err)
 	var issuer tickerdb.Issuer
-	err = session.GetRaw(&issuer, `
+	err = session.GetRaw(ctx, &issuer, `
 		SELECT *
 		FROM issuers
 		ORDER BY id DESC
@@ -48,13 +48,13 @@ func TestBulkInsertTrades(t *testing.T) {
 	require.NoError(t, err)
 
 	// Adding a seed asset to be used later:
-	err = session.InsertOrUpdateAsset(&tickerdb.Asset{
+	err = session.InsertOrUpdateAsset(ctx, &tickerdb.Asset{
 		Code:     "XLM",
 		IssuerID: issuer.ID,
 	}, []string{"code", "issuer_id"})
 	require.NoError(t, err)
 	var asset1 tickerdb.Asset
-	err = session.GetRaw(&asset1, `
+	err = session.GetRaw(ctx, &asset1, `
 		SELECT *
 		FROM assets
 		ORDER BY id DESC
@@ -63,13 +63,13 @@ func TestBulkInsertTrades(t *testing.T) {
 	require.NoError(t, err)
 
 	// Adding another asset to be used later:
-	err = session.InsertOrUpdateAsset(&tickerdb.Asset{
+	err = session.InsertOrUpdateAsset(ctx, &tickerdb.Asset{
 		Code:     "BTC",
 		IssuerID: issuer.ID,
 	}, []string{"code", "issuer_id"})
 	require.NoError(t, err)
 	var asset2 tickerdb.Asset
-	err = session.GetRaw(&asset2, `
+	err = session.GetRaw(ctx, &asset2, `
 		SELECT *
 		FROM assets
 		ORDER BY id DESC
@@ -95,11 +95,11 @@ func TestBulkInsertTrades(t *testing.T) {
 			LedgerCloseTime: time.Now(),
 		},
 	}
-	err = session.BulkInsertTrades(trades)
+	err = session.BulkInsertTrades(ctx, trades)
 	require.NoError(t, err)
 
 	// Ensure only two were created:
-	rows, err := session.QueryRaw("SELECT * FROM trades")
+	rows, err := session.QueryRaw(ctx, "SELECT * FROM trades")
 	require.NoError(t, err)
 	rowsCount := 0
 	for rows.Next() {
@@ -108,10 +108,10 @@ func TestBulkInsertTrades(t *testing.T) {
 	assert.Equal(t, 2, rowsCount)
 
 	// Re-insert the same trades and check if count remains = 2:
-	err = session.BulkInsertTrades(trades)
+	err = session.BulkInsertTrades(ctx, trades)
 	require.NoError(t, err)
 
-	rows, err = session.QueryRaw("SELECT * FROM trades")
+	rows, err = session.QueryRaw(ctx, "SELECT * FROM trades")
 	require.NoError(t, err)
 	rowsCount2 := 0
 	for rows.Next() {
@@ -126,8 +126,8 @@ func TestGetLastTrade(t *testing.T) {
 
 	var session tickerdb.TickerSession
 	session.DB = db.Open()
-	session.Ctx = context.Background()
 	defer session.DB.Close()
+	ctx := context.Background()
 
 	// Run migrations to make sure the tests are run
 	// on the most updated schema version
@@ -138,7 +138,7 @@ func TestGetLastTrade(t *testing.T) {
 	require.NoError(t, err)
 
 	// Sanity Check (there are no trades in the database)
-	_, err = session.GetLastTrade()
+	_, err = session.GetLastTrade(ctx)
 	require.Error(t, err)
 
 	// Adding a seed issuer to be used later:
@@ -146,10 +146,10 @@ func TestGetLastTrade(t *testing.T) {
 	_, err = tbl.Insert(tickerdb.Issuer{
 		PublicKey: "GCF3TQXKZJNFJK7HCMNE2O2CUNKCJH2Y2ROISTBPLC7C5EIA5NNG2XZB",
 		Name:      "FOO BAR",
-	}).IgnoreCols("id").Exec()
+	}).IgnoreCols("id").Exec(ctx)
 	require.NoError(t, err)
 	var issuer tickerdb.Issuer
-	err = session.GetRaw(&issuer, `
+	err = session.GetRaw(ctx, &issuer, `
 		SELECT *
 		FROM issuers
 		ORDER BY id DESC
@@ -158,13 +158,13 @@ func TestGetLastTrade(t *testing.T) {
 	require.NoError(t, err)
 
 	// Adding a seed asset to be used later:
-	err = session.InsertOrUpdateAsset(&tickerdb.Asset{
+	err = session.InsertOrUpdateAsset(ctx, &tickerdb.Asset{
 		Code:     "XLM",
 		IssuerID: issuer.ID,
 	}, []string{"code", "issuer_id"})
 	require.NoError(t, err)
 	var asset1 tickerdb.Asset
-	err = session.GetRaw(&asset1, `
+	err = session.GetRaw(ctx, &asset1, `
 		SELECT *
 		FROM assets
 		ORDER BY id DESC
@@ -173,13 +173,13 @@ func TestGetLastTrade(t *testing.T) {
 	require.NoError(t, err)
 
 	// Adding another asset to be used later:
-	err = session.InsertOrUpdateAsset(&tickerdb.Asset{
+	err = session.InsertOrUpdateAsset(ctx, &tickerdb.Asset{
 		Code:     "BTC",
 		IssuerID: issuer.ID,
 	}, []string{"code", "issuer_id"})
 	require.NoError(t, err)
 	var asset2 tickerdb.Asset
-	err = session.GetRaw(&asset2, `
+	err = session.GetRaw(ctx, &asset2, `
 		SELECT *
 		FROM assets
 		ORDER BY id DESC
@@ -216,10 +216,10 @@ func TestGetLastTrade(t *testing.T) {
 	}
 
 	// Re-insert the same trades and check if count remains = 2:
-	err = session.BulkInsertTrades(trades)
+	err = session.BulkInsertTrades(ctx, trades)
 	require.NoError(t, err)
 
-	lastTrade, err := session.GetLastTrade()
+	lastTrade, err := session.GetLastTrade(ctx)
 	require.NoError(t, err)
 	assert.WithinDuration(t, now.Local(), lastTrade.LedgerCloseTime.Local(), 10*time.Millisecond)
 }
@@ -230,8 +230,8 @@ func TestDeleteOldTrades(t *testing.T) {
 
 	var session tickerdb.TickerSession
 	session.DB = db.Open()
-	session.Ctx = context.Background()
 	defer session.DB.Close()
+	ctx := context.Background()
 
 	// Run migrations to make sure the tests are run
 	// on the most updated schema version
@@ -246,10 +246,10 @@ func TestDeleteOldTrades(t *testing.T) {
 	_, err = tbl.Insert(tickerdb.Issuer{
 		PublicKey: "GCF3TQXKZJNFJK7HCMNE2O2CUNKCJH2Y2ROISTBPLC7C5EIA5NNG2XZB",
 		Name:      "FOO BAR",
-	}).IgnoreCols("id").Exec()
+	}).IgnoreCols("id").Exec(ctx)
 	require.NoError(t, err)
 	var issuer tickerdb.Issuer
-	err = session.GetRaw(&issuer, `
+	err = session.GetRaw(ctx, &issuer, `
 		SELECT *
 		FROM issuers
 		ORDER BY id DESC
@@ -258,13 +258,13 @@ func TestDeleteOldTrades(t *testing.T) {
 	require.NoError(t, err)
 
 	// Adding a seed asset to be used later:
-	err = session.InsertOrUpdateAsset(&tickerdb.Asset{
+	err = session.InsertOrUpdateAsset(ctx, &tickerdb.Asset{
 		Code:     "XLM",
 		IssuerID: issuer.ID,
 	}, []string{"code", "issuer_id"})
 	require.NoError(t, err)
 	var asset1 tickerdb.Asset
-	err = session.GetRaw(&asset1, `
+	err = session.GetRaw(ctx, &asset1, `
 		SELECT *
 		FROM assets
 		ORDER BY id DESC
@@ -273,13 +273,13 @@ func TestDeleteOldTrades(t *testing.T) {
 	require.NoError(t, err)
 
 	// Adding another asset to be used later:
-	err = session.InsertOrUpdateAsset(&tickerdb.Asset{
+	err = session.InsertOrUpdateAsset(ctx, &tickerdb.Asset{
 		Code:     "BTC",
 		IssuerID: issuer.ID,
 	}, []string{"code", "issuer_id"})
 	require.NoError(t, err)
 	var asset2 tickerdb.Asset
-	err = session.GetRaw(&asset2, `
+	err = session.GetRaw(ctx, &asset2, `
 		SELECT *
 		FROM assets
 		ORDER BY id DESC
@@ -323,16 +323,16 @@ func TestDeleteOldTrades(t *testing.T) {
 			LedgerCloseTime: oneYearAgo,
 		},
 	}
-	err = session.BulkInsertTrades(trades)
+	err = session.BulkInsertTrades(ctx, trades)
 	require.NoError(t, err)
 
 	// Deleting trades older than 1 day ago:
-	err = session.DeleteOldTrades(oneDayAgo)
+	err = session.DeleteOldTrades(ctx, oneDayAgo)
 	require.NoError(t, err)
 
 	var dbTrades []tickerdb.Trade
 	var trade1, trade2 tickerdb.Trade
-	err = session.SelectRaw(&dbTrades, "SELECT * FROM trades")
+	err = session.SelectRaw(ctx, &dbTrades, "SELECT * FROM trades")
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(dbTrades))
 

--- a/support/db/delete_builder.go
+++ b/support/db/delete_builder.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/pkg/errors"
@@ -8,8 +9,8 @@ import (
 
 // Exec executes the query represented by the builder, deleting any rows that
 // match the queries where clauses.
-func (delb *DeleteBuilder) Exec() (sql.Result, error) {
-	r, err := delb.Table.Session.Exec(delb.sql)
+func (delb *DeleteBuilder) Exec(ctx context.Context) (sql.Result, error) {
+	r, err := delb.Table.Session.Exec(ctx, delb.sql)
 	if err != nil {
 		return nil, errors.Wrap(err, "delete failed")
 	}

--- a/support/db/delete_builder_test.go
+++ b/support/db/delete_builder_test.go
@@ -12,11 +12,12 @@ import (
 func TestDeleteBuilder_Exec(t *testing.T) {
 	db := dbtest.Postgres(t).Load(testSchema)
 	defer db.Close()
-	sess := &Session{DB: db.Open(), Ctx: context.Background()}
+	sess := &Session{DB: db.Open()}
 	defer sess.DB.Close()
 
+	ctx := context.Background()
 	tbl := sess.GetTable("people")
-	r, err := tbl.Delete("name = ?", "scott").Exec()
+	r, err := tbl.Delete("name = ?", "scott").Exec(ctx)
 
 	if assert.NoError(t, err, "query error") {
 		actual, err := r.RowsAffected()
@@ -24,7 +25,7 @@ func TestDeleteBuilder_Exec(t *testing.T) {
 		assert.Equal(t, int64(1), actual)
 
 		var found int
-		err = sess.GetRaw(&found, "SELECT COUNT(*) FROM people WHERE name = ?", "scott")
+		err = sess.GetRaw(ctx, &found, "SELECT COUNT(*) FROM people WHERE name = ?", "scott")
 		require.NoError(t, err)
 		assert.Equal(t, 0, found)
 	}

--- a/support/db/get_builder.go
+++ b/support/db/get_builder.go
@@ -1,14 +1,15 @@
 package db
 
 import (
+	"context"
 	"github.com/stellar/go/support/errors"
 )
 
 // Exec executes the query represented by the builder, populating the
 // destination with the results returned by running the query against the
 // current database session.
-func (gb *GetBuilder) Exec() error {
-	err := gb.Table.Session.Get(gb.dest, gb.sql)
+func (gb *GetBuilder) Exec(ctx context.Context) error {
+	err := gb.Table.Session.Get(ctx, gb.dest, gb.sql)
 	if err != nil {
 		return errors.Wrap(err, "get failed")
 	}

--- a/support/db/get_builder_test.go
+++ b/support/db/get_builder_test.go
@@ -11,13 +11,13 @@ import (
 func TestGetBuilder_Exec(t *testing.T) {
 	db := dbtest.Postgres(t).Load(testSchema)
 	defer db.Close()
-	sess := &Session{DB: db.Open(), Ctx: context.Background()}
+	sess := &Session{DB: db.Open()}
 	defer sess.DB.Close()
 
 	var found person
 
 	tbl := sess.GetTable("people")
-	err := tbl.Get(&found, "name = ?", "scott").Exec()
+	err := tbl.Get(&found, "name = ?", "scott").Exec(context.Background())
 
 	if assert.NoError(t, err, "query error") {
 		assert.Equal(t, "scott", found.Name)

--- a/support/db/insert_builder.go
+++ b/support/db/insert_builder.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"reflect"
 
@@ -9,7 +10,7 @@ import (
 
 // Exec executes the query represented by the builder, inserting each val
 // provided to the builder into the database.
-func (ib *InsertBuilder) Exec() (sql.Result, error) {
+func (ib *InsertBuilder) Exec(ctx context.Context) (sql.Result, error) {
 	if len(ib.rows) == 0 {
 		return nil, &NoRowsError{}
 	}
@@ -49,7 +50,7 @@ func (ib *InsertBuilder) Exec() (sql.Result, error) {
 
 	// TODO: support return inserted id
 
-	r, err := ib.Table.Session.Exec(sql)
+	r, err := ib.Table.Session.Exec(ctx, sql)
 	if err != nil {
 		return nil, errors.Wrap(err, "insert failed")
 	}

--- a/support/db/insert_builder_test.go
+++ b/support/db/insert_builder_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 func TestInsertBuilder_Exec(t *testing.T) {
+	ctx := context.Background()
 	db := dbtest.Postgres(t).Load(testSchema)
 	defer db.Close()
-	sess := &Session{DB: db.Open(), Ctx: context.Background()}
+	sess := &Session{DB: db.Open()}
 	defer sess.DB.Close()
 
 	tbl := sess.GetTable("people")
@@ -20,11 +21,11 @@ func TestInsertBuilder_Exec(t *testing.T) {
 	_, err := tbl.Insert(person{
 		Name:        "bubba",
 		HungerLevel: "120",
-	}).Exec()
+	}).Exec(ctx)
 
 	if assert.NoError(t, err) {
 		var found []person
-		err = sess.SelectRaw(
+		err = sess.SelectRaw(ctx,
 			&found,
 			"SELECT * FROM people WHERE name = ?",
 			"bubba",
@@ -39,7 +40,7 @@ func TestInsertBuilder_Exec(t *testing.T) {
 	}
 
 	// no rows
-	_, err = tbl.Insert().Exec()
+	_, err = tbl.Insert().Exec(ctx)
 	if assert.Error(t, err) {
 		assert.IsType(t, &NoRowsError{}, err)
 		assert.EqualError(t, err, "no rows provided to insert")
@@ -52,7 +53,7 @@ func TestInsertBuilder_Exec(t *testing.T) {
 	}, person{
 		Name:        "bubba3",
 		HungerLevel: "120",
-	}).Exec()
+	}).Exec(ctx)
 
 	if assert.NoError(t, err) {
 		count, err2 := r.RowsAffected()
@@ -69,7 +70,7 @@ func TestInsertBuilder_Exec(t *testing.T) {
 		Name:        "bubba2",
 		HungerLevel: "120",
 		NotAColumn:  3,
-	}).Exec()
+	}).Exec(ctx)
 
 	assert.Error(t, err)
 }

--- a/support/db/main_test.go
+++ b/support/db/main_test.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stellar/go/support/db/dbtest"
@@ -18,7 +17,7 @@ type person struct {
 func TestGetTable(t *testing.T) {
 	db := dbtest.Postgres(t).Load(testSchema)
 	defer db.Close()
-	sess := &Session{DB: db.Open(), Ctx: context.Background()}
+	sess := &Session{DB: db.Open()}
 	defer sess.DB.Close()
 
 	tbl := sess.GetTable("users")

--- a/support/db/mock_session.go
+++ b/support/db/mock_session.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"time"
 
@@ -15,23 +16,23 @@ type MockSession struct {
 	mock.Mock
 }
 
-func (m *MockSession) Begin() error {
-	args := m.Called()
+func (m *MockSession) Begin(ctx context.Context) error {
+	args := m.Called(ctx)
 	return args.Error(0)
 }
 
-func (m *MockSession) BeginTx(opts *sql.TxOptions) error {
-	args := m.Called(opts)
+func (m *MockSession) BeginTx(ctx context.Context, opts *sql.TxOptions) error {
+	args := m.Called(ctx, opts)
 	return args.Error(0)
 }
 
-func (m *MockSession) Rollback() error {
-	args := m.Called()
+func (m *MockSession) Rollback(ctx context.Context) error {
+	args := m.Called(ctx)
 	return args.Error(0)
 }
 
-func (m *MockSession) TruncateTables(tables []string) error {
-	args := m.Called(tables)
+func (m *MockSession) TruncateTables(ctx context.Context, tables []string) error {
+	args := m.Called(ctx, tables)
 	return args.Error(0)
 }
 
@@ -45,27 +46,27 @@ func (m *MockSession) Close() error {
 	return args.Error(0)
 }
 
-func (m *MockSession) Get(dest interface{}, query sq.Sqlizer) error {
-	args := m.Called(dest, query)
+func (m *MockSession) Get(ctx context.Context, dest interface{}, query sq.Sqlizer) error {
+	args := m.Called(ctx, dest, query)
 	return args.Error(0)
 }
 
-func (m *MockSession) GetRaw(dest interface{}, query string, args ...interface{}) error {
-	argss := m.Called(dest, query, args)
+func (m *MockSession) GetRaw(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+	argss := m.Called(ctx, dest, query, args)
 	return argss.Error(0)
 }
 
-func (m *MockSession) Select(dest interface{}, query squirrel.Sqlizer) error {
-	argss := m.Called(dest, query)
+func (m *MockSession) Select(ctx context.Context, dest interface{}, query squirrel.Sqlizer) error {
+	argss := m.Called(ctx, dest, query)
 	return argss.Error(0)
 }
 
-func (m *MockSession) SelectRaw(
+func (m *MockSession) SelectRaw(ctx context.Context,
 	dest interface{},
 	query string,
 	args ...interface{},
 ) error {
-	argss := m.Called(dest, query, args)
+	argss := m.Called(ctx, dest, query, args)
 	return argss.Error(0)
 }
 
@@ -74,13 +75,13 @@ func (m *MockSession) GetTable(name string) *Table {
 	return args.Get(0).(*Table)
 }
 
-func (m *MockSession) Exec(query squirrel.Sqlizer) (sql.Result, error) {
-	args := m.Called(query)
+func (m *MockSession) Exec(ctx context.Context, query squirrel.Sqlizer) (sql.Result, error) {
+	args := m.Called(ctx, query)
 	return args.Get(0).(sql.Result), args.Error(1)
 }
 
-func (m *MockSession) ExecRaw(query string, args ...interface{}) (sql.Result, error) {
-	argss := m.Called(query, args)
+func (m *MockSession) ExecRaw(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	argss := m.Called(ctx, query, args)
 	return argss.Get(0).(sql.Result), argss.Error(1)
 }
 
@@ -89,6 +90,6 @@ func (m *MockSession) NoRows(err error) bool {
 	return args.Get(0).(bool)
 }
 
-func (m *MockSession) Ping(timeout time.Duration) error {
-	return m.Called(timeout).Error(0)
+func (m *MockSession) Ping(ctx context.Context, timeout time.Duration) error {
+	return m.Called(ctx, timeout).Error(0)
 }

--- a/support/db/schema/main.go
+++ b/support/db/schema/main.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 
@@ -21,8 +22,8 @@ const (
 )
 
 // Init installs the latest schema into db after clearing it first
-func Init(db *db.Session, latest []byte) error {
-	return db.ExecAll(string(latest))
+func Init(ctx context.Context, db *db.Session, latest []byte) error {
+	return db.ExecAll(ctx, string(latest))
 }
 
 // Migrate performs schema migration.  Migrations can occur in one of three

--- a/support/db/select_builder.go
+++ b/support/db/select_builder.go
@@ -1,14 +1,15 @@
 package db
 
 import (
+	"context"
 	"github.com/stellar/go/support/errors"
 )
 
 // Exec executes the query represented by the builder, populating the
 // destination with the results returned by running the query against the
 // current database session.
-func (sb *SelectBuilder) Exec() error {
-	err := sb.Table.Session.Select(sb.dest, sb.sql)
+func (sb *SelectBuilder) Exec(ctx context.Context) error {
+	err := sb.Table.Session.Select(ctx, sb.dest, sb.sql)
 	if err != nil {
 		return errors.Wrap(err, "select failed")
 	}

--- a/support/db/select_builder_test.go
+++ b/support/db/select_builder_test.go
@@ -12,7 +12,7 @@ import (
 func TestSelectBuilder_Exec(t *testing.T) {
 	db := dbtest.Postgres(t).Load(testSchema)
 	defer db.Close()
-	sess := &Session{DB: db.Open(), Ctx: context.Background()}
+	sess := &Session{DB: db.Open()}
 	defer sess.DB.Close()
 
 	var results []person
@@ -30,7 +30,7 @@ func TestSelectBuilder_Exec(t *testing.T) {
 		assert.Equal(t, "scott", args[0])
 	}
 
-	err = sb.Exec()
+	err = sb.Exec(context.Background())
 
 	if assert.NoError(t, err, "query error") {
 		if assert.Len(t, results, 1) {

--- a/support/db/session_test.go
+++ b/support/db/session_test.go
@@ -13,24 +13,25 @@ func TestSession(t *testing.T) {
 	db := dbtest.Postgres(t).Load(testSchema)
 	defer db.Close()
 
+	ctx := context.Background()
 	assert := assert.New(t)
 	require := require.New(t)
-	sess := &Session{DB: db.Open(), Ctx: context.Background()}
+	sess := &Session{DB: db.Open()}
 	defer sess.DB.Close()
 
 	assert.Equal("postgres", sess.Dialect())
 
 	var count int
-	err := sess.GetRaw(&count, "SELECT COUNT(*) FROM people")
+	err := sess.GetRaw(ctx, &count, "SELECT COUNT(*) FROM people")
 	assert.NoError(err)
 	assert.Equal(3, count)
 
 	var names []string
-	err = sess.SelectRaw(&names, "SELECT name FROM people")
+	err = sess.SelectRaw(ctx, &names, "SELECT name FROM people")
 	assert.NoError(err)
 	assert.Len(names, 3)
 
-	ret, err := sess.ExecRaw("DELETE FROM people")
+	ret, err := sess.ExecRaw(ctx, "DELETE FROM people")
 	assert.NoError(err)
 	deleted, err := ret.RowsAffected()
 	assert.NoError(err)
@@ -40,7 +41,7 @@ func TestSession(t *testing.T) {
 	// during execution)
 	db.Load(testSchema)
 	var name string
-	err = sess.GetRaw(
+	err = sess.GetRaw(ctx,
 		&name,
 		"SELECT name FROM people WHERE hunger_level = ? AND name != '??'",
 		1000000,
@@ -49,7 +50,7 @@ func TestSession(t *testing.T) {
 	assert.Equal("scott", name)
 
 	// Test NoRows
-	err = sess.GetRaw(
+	err = sess.GetRaw(ctx,
 		&name,
 		"SELECT name FROM people WHERE hunger_level = ?",
 		1234,
@@ -58,29 +59,29 @@ func TestSession(t *testing.T) {
 
 	// Test transactions
 	db.Load(testSchema)
-	require.NoError(sess.Begin(), "begin failed")
-	err = sess.GetRaw(&count, "SELECT COUNT(*) FROM people")
+	require.NoError(sess.Begin(ctx), "begin failed")
+	err = sess.GetRaw(ctx, &count, "SELECT COUNT(*) FROM people")
 	assert.NoError(err)
 	assert.Equal(3, count)
-	_, err = sess.ExecRaw("DELETE FROM people")
+	_, err = sess.ExecRaw(ctx, "DELETE FROM people")
 	assert.NoError(err)
-	err = sess.GetRaw(&count, "SELECT COUNT(*) FROM people")
+	err = sess.GetRaw(ctx, &count, "SELECT COUNT(*) FROM people")
 	assert.NoError(err)
 	assert.Equal(0, count, "people did not appear deleted inside transaction")
-	assert.NoError(sess.Rollback(), "rollback failed")
+	assert.NoError(sess.Rollback(ctx), "rollback failed")
 
 	// Ensure commit works
-	require.NoError(sess.Begin(), "begin failed")
-	sess.ExecRaw("DELETE FROM people")
-	assert.NoError(sess.Commit(), "commit failed")
-	err = sess.GetRaw(&count, "SELECT COUNT(*) FROM people")
+	require.NoError(sess.Begin(ctx), "begin failed")
+	sess.ExecRaw(ctx, "DELETE FROM people")
+	assert.NoError(sess.Commit(ctx), "commit failed")
+	err = sess.GetRaw(ctx, &count, "SELECT COUNT(*) FROM people")
 	assert.NoError(err)
 	assert.Equal(0, count)
 
 	// ensure that selecting into a populated slice clears the slice first
 	db.Load(testSchema)
 	require.Len(names, 3, "ids slice was not preloaded with data")
-	err = sess.SelectRaw(&names, "SELECT name FROM people limit 2")
+	err = sess.SelectRaw(ctx, &names, "SELECT name FROM people limit 2")
 	assert.NoError(err)
 	assert.Len(names, 2)
 

--- a/support/db/update_builder.go
+++ b/support/db/update_builder.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"reflect"
 
@@ -9,8 +10,8 @@ import (
 
 // Exec executes the query that has been previously configured on the
 // UpdateBuilder.
-func (ub *UpdateBuilder) Exec() (sql.Result, error) {
-	r, err := ub.Table.Session.Exec(ub.sql)
+func (ub *UpdateBuilder) Exec(ctx context.Context) (sql.Result, error) {
+	r, err := ub.Table.Session.Exec(ctx, ub.sql)
 	if err != nil {
 		return nil, errors.Wrap(err, "select failed")
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The root change is:
```diff
 package db

 type Session struct {
        // DB is the database connection that queries should be executed against.
        DB *sqlx.DB

-       // Ctx is the context in which the repo is operating under.
-       Ctx context.Context
-
        tx        *sqlx.Tx
        txOptions *sql.TxOptions
 }
```
And changing all the `db.Session` methods (where needed) to take a `ctx context.Context` params. Then passing that through all the places to get it there.

### Why

For https://github.com/stellar/go/issues/3344, we want to pass different timeouts in different contexts. This change makes that easier, and generally follows the go norms of passing the context late into the method.

### Known limitations

It's big. Will be difficult to review and merge. Most of the param passing is pretty mechanical. The interesting parts are around where we create the contexts initially. But, most of that is in tests.

### Questions

- [ ] RemoteCaptiveStellarCore.createContext and cancellation semantics. Should we do it everywhere? Only for PrepareRange?
  - Ignored this, keeping the existing semantics, for now. But seems like we should cancel all outstanding requests, not just PrepareRange.
- [ ] OrderBookStream.Run, should we make a new timeout ctx each tick?


### Bonus

~~I also fixed `TestOpen_openAndPingFails`, because it was intermittently failing and being annoying.~~
