### PR TITLE
exp/services/recoverysigner: Fix TestOpen_openAndPingFails

### DIFF
--- a/exp/services/recoverysigner/internal/db/db_test.go
+++ b/exp/services/recoverysigner/internal/db/db_test.go
@@ -1,6 +1,9 @@
 package db
 
 import (
+	"fmt"
+	"net"
+	"regexp"
 	"testing"
 
 	"github.com/stellar/go/support/db/dbtest"
@@ -20,10 +23,25 @@ func TestOpen_openAndPingSucceeds(t *testing.T) {
 }
 
 func TestOpen_openAndPingFails(t *testing.T) {
-	sqlxDB, err := Open("postgres://localhost:0")
+	// Find an empty port
+	listener, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener.Close())
+	// Slight race here with other stuff on the system, which could claim this port.
+
+	sqlxDB, err := Open(fmt.Sprintf("postgres://localhost:%d", port))
 	require.NoError(t, err)
 	assert.Equal(t, "postgres", sqlxDB.DriverName())
 
 	err = sqlxDB.Ping()
-	require.EqualError(t, err, "dial tcp 127.0.0.1:0: connect: connection refused")
+	require.Error(t, err)
+	require.Regexp(
+		t,
+		regexp.MustCompile(
+			// regex to support both ipv4 and ipv6, on the port we found.
+			fmt.Sprintf("dial tcp (127\\.0\\.0\\.1|\\[::1\\]):%d: connect: connection refused", port),
+		),
+		err.Error(),
+	)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Extracted from https://github.com/stellar/go/pull/3545. I fixed `TestOpen_openAndPingFails`. The two issues were, Open on port 0, and sometimes the error would be different due to IPv6. Now it handles both ipv4 and ipv6, as well as finding a free port for the test to run on.

### Why

Because it was intermittently failing and being annoying.

### Known limitations

[TODO or N/A]
