### PR TITLE
services/horizon:  Make LedgerTransaction's Meta a private field

### DIFF
--- a/ingest/ledger_transaction.go
+++ b/ingest/ledger_transaction.go
@@ -47,7 +47,14 @@ func (t *LedgerTransaction) GetChanges() ([]Change, error) {
 	// Transaction meta
 	switch t.meta.V {
 	case 0:
-		return changes, errors.New("TransactionMeta.V=0 not supported")
+		if t.meta.Operations != nil {
+			for _, operationMeta := range *t.meta.Operations {
+				opChanges := GetChangesFromLedgerEntryChanges(
+					operationMeta.Changes,
+				)
+				changes = append(changes, opChanges...)
+			}
+		}
 	case 1:
 		v1Meta := t.meta.MustV1()
 		txChanges := GetChangesFromLedgerEntryChanges(v1Meta.TxChanges)

--- a/ingest/ledger_transaction_reader.go
+++ b/ingest/ledger_transaction_reader.go
@@ -102,7 +102,7 @@ func (reader *LedgerTransactionReader) storeTransactions(lcm xdr.LedgerCloseMeta
 			Index:      uint32(i + 1), // Transactions start at '1'
 			Envelope:   envelope,
 			Result:     result,
-			Meta:       lcm.V0.TxProcessing[i].TxApplyProcessing,
+			meta:       lcm.V0.TxProcessing[i].TxApplyProcessing,
 			FeeChanges: lcm.V0.TxProcessing[i].FeeProcessing,
 		})
 	}

--- a/ingest/ledger_transaction_test.go
+++ b/ingest/ledger_transaction_test.go
@@ -331,17 +331,6 @@ func TestMetaV2Order(t *testing.T) {
 
 }
 
-func TestMetaV0(t *testing.T) {
-	tx := LedgerTransaction{
-		meta: xdr.TransactionMeta{
-			V: 0,
-		}}
-
-	_, err := tx.GetChanges()
-	assert.Error(t, err)
-	assert.EqualError(t, err, "TransactionMeta.V=0 not supported")
-}
-
 func TestChangeAccountChangedExceptSignersLastModifiedLedgerSeq(t *testing.T) {
 	change := Change{
 		Type: xdr.LedgerEntryTypeAccount,

--- a/ingest/ledger_transaction_test.go
+++ b/ingest/ledger_transaction_test.go
@@ -45,7 +45,7 @@ func TestFeeMetaAndOperationsChangesSeparate(t *testing.T) {
 				},
 			},
 		},
-		Meta: xdr.TransactionMeta{
+		meta: xdr.TransactionMeta{
 			V: 1,
 			V1: &xdr.TransactionMetaV1{
 				Operations: []xdr.OperationMeta{
@@ -146,11 +146,11 @@ func TestFailedTransactionOperationChangesMeta(t *testing.T) {
 						},
 					},
 				},
-				Meta: tc.meta,
+				meta: tc.meta,
 			}
 
 			operationChanges, err := tx.GetOperationChanges(0)
-			if tx.Meta.V == 0 {
+			if tx.meta.V == 0 {
 				assert.Error(t, err)
 				assert.EqualError(t, err, "TransactionMeta.V=0 not supported")
 			} else {
@@ -162,7 +162,7 @@ func TestFailedTransactionOperationChangesMeta(t *testing.T) {
 }
 func TestMetaV2Order(t *testing.T) {
 	tx := LedgerTransaction{
-		Meta: xdr.TransactionMeta{
+		meta: xdr.TransactionMeta{
 			V: 2,
 			V2: &xdr.TransactionMetaV2{
 				TxChangesBefore: xdr.LedgerEntryChanges{
@@ -333,7 +333,7 @@ func TestMetaV2Order(t *testing.T) {
 
 func TestMetaV0(t *testing.T) {
 	tx := LedgerTransaction{
-		Meta: xdr.TransactionMeta{
+		meta: xdr.TransactionMeta{
 			V: 0,
 		}}
 
@@ -449,7 +449,7 @@ func TestChangeAccountChangedExceptSignersSignerChange(t *testing.T) {
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
 							Weight: 1,
 						},
@@ -464,7 +464,7 @@ func TestChangeAccountChangedExceptSignersSignerChange(t *testing.T) {
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
 							Weight: 2,
 						},
@@ -497,7 +497,7 @@ func TestChangeAccountChangedExceptSignersNoChanges(t *testing.T) {
 					HomeDomain:    "stellar.org",
 					Thresholds:    [4]byte{1, 1, 1, 1},
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
 							Weight: 1,
 						},
@@ -528,7 +528,7 @@ func TestChangeAccountChangedExceptSignersNoChanges(t *testing.T) {
 					HomeDomain:    "stellar.org",
 					Thresholds:    [4]byte{1, 1, 1, 1},
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
 							Weight: 1,
 						},
@@ -708,7 +708,7 @@ func TestChangeAccountSignersChangedSignerAdded(t *testing.T) {
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
 							Weight: 1,
 						},
@@ -731,7 +731,7 @@ func TestChangeAccountSignersChangedSignerRemoved(t *testing.T) {
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
 							Weight: 1,
 						},
@@ -764,7 +764,7 @@ func TestChangeAccountSignersChangedSignerWeightChanged(t *testing.T) {
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
 							Weight: 1,
 						},
@@ -779,7 +779,7 @@ func TestChangeAccountSignersChangedSignerWeightChanged(t *testing.T) {
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
 							Weight: 2,
 						},

--- a/services/horizon/internal/db2/history/fee_bump_scenario.go
+++ b/services/horizon/internal/db2/history/fee_bump_scenario.go
@@ -57,7 +57,6 @@ func buildLedgerTransaction(t *testing.T, tx testTransaction) ingest.LedgerTrans
 		Envelope:   xdr.TransactionEnvelope{},
 		Result:     xdr.TransactionResultPair{},
 		FeeChanges: xdr.LedgerEntryChanges{},
-		Meta:       xdr.TransactionMeta{},
 	}
 
 	tt := assert.New(t)
@@ -66,7 +65,9 @@ func buildLedgerTransaction(t *testing.T, tx testTransaction) ingest.LedgerTrans
 	tt.NoError(err)
 	err = xdr.SafeUnmarshalBase64(tx.resultXDR, &transaction.Result.Result)
 	tt.NoError(err)
-	err = xdr.SafeUnmarshalBase64(tx.metaXDR, &transaction.Meta)
+	var meta xdr.TransactionMeta
+	err = xdr.SafeUnmarshalBase64(tx.metaXDR, &meta)
+	transaction.UnsafeSetMeta(meta)
 	tt.NoError(err)
 	err = xdr.SafeUnmarshalBase64(tx.feeChangesXDR, &transaction.FeeChanges)
 	tt.NoError(err)

--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
@@ -236,7 +236,7 @@ func transactionToRow(transaction ingest.LedgerTransaction, sequence uint32) (Tr
 	if err != nil {
 		return TransactionWithoutLedger{}, err
 	}
-	metaBase64, err := xdr.MarshalBase64(transaction.Meta)
+	metaBase64, err := xdr.MarshalBase64(transaction.UnsafeGetMeta())
 	if err != nil {
 		return TransactionWithoutLedger{}, err
 	}

--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder_test.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder_test.go
@@ -75,15 +75,15 @@ func TestTransactionToMap_muxed(t *testing.T) {
 				},
 			},
 		},
-		Meta: xdr.TransactionMeta{
-			V:          1,
-			Operations: &[]xdr.OperationMeta{},
-			V1: &xdr.TransactionMetaV1{
-				TxChanges:  []xdr.LedgerEntryChange{},
-				Operations: []xdr.OperationMeta{},
-			},
-		},
 	}
+	tx.UnsafeSetMeta(xdr.TransactionMeta{
+		V:          1,
+		Operations: &[]xdr.OperationMeta{},
+		V1: &xdr.TransactionMetaV1{
+			TxChanges:  []xdr.LedgerEntryChange{},
+			Operations: []xdr.OperationMeta{},
+		},
+	})
 	row, err := transactionToRow(tx, 20)
 	assert.NoError(t, err)
 

--- a/services/horizon/internal/ingest/processors/claimable_balances_transaction_processor_test.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_transaction_processor_test.go
@@ -67,23 +67,28 @@ func (s *ClaimableBalancesTransactionProcessorTestSuiteLedger) testOperationInse
 	internalID := int64(1234)
 	txn := createTransaction(true, 1)
 	txn.Envelope.Operations()[0].Body = body
-	txn.Meta.V = 2
-	txn.Meta.V2.Operations = []xdr.OperationMeta{
-		{Changes: xdr.LedgerEntryChanges{
-			{
-				Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-				State: &xdr.LedgerEntry{
-					Data: xdr.LedgerEntryData{
-						Type: xdr.LedgerEntryTypeClaimableBalance,
-						ClaimableBalance: &xdr.ClaimableBalanceEntry{
-							BalanceId: balanceID,
+	txn.UnsafeSetMeta(
+		xdr.TransactionMeta{
+			V: 2,
+			V2: &xdr.TransactionMetaV2{
+				Operations: []xdr.OperationMeta{
+					{Changes: xdr.LedgerEntryChanges{
+						{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+							State: &xdr.LedgerEntry{
+								Data: xdr.LedgerEntryData{
+									Type: xdr.LedgerEntryTypeClaimableBalance,
+									ClaimableBalance: &xdr.ClaimableBalanceEntry{
+										BalanceId: balanceID,
+									},
+								},
+							},
 						},
-					},
+						change,
+					}},
 				},
-			},
-			change,
-		}},
-	}
+			}},
+	)
 
 	if body.Type == xdr.OperationTypeCreateClaimableBalance {
 		// For insert test

--- a/services/horizon/internal/ingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/ingest/processors/effects_processor_test.go
@@ -1508,57 +1508,55 @@ func TestOperationEffects(t *testing.T) {
 
 func TestOperationEffectsSetOptionsSignersOrder(t *testing.T) {
 	tt := assert.New(t)
-	transaction := ingest.LedgerTransaction{
-		Meta: createTransactionMeta([]xdr.OperationMeta{
-			{
-				Changes: []xdr.LedgerEntryChange{
-					// State
-					{
-						Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-						State: &xdr.LedgerEntry{
-							Data: xdr.LedgerEntryData{
-								Type: xdr.LedgerEntryTypeAccount,
-								Account: &xdr.AccountEntry{
-									AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-									Signers: []xdr.Signer{
-										{
-											Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
-											Weight: 10,
-										},
-										{
-											Key:    xdr.MustSigner("GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS"),
-											Weight: 10,
-										},
+	meta := createTransactionMeta([]xdr.OperationMeta{
+		{
+			Changes: []xdr.LedgerEntryChange{
+				// State
+				{
+					Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+					State: &xdr.LedgerEntry{
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeAccount,
+							Account: &xdr.AccountEntry{
+								AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+								Signers: []xdr.Signer{
+									{
+										Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
+										Weight: 10,
+									},
+									{
+										Key:    xdr.MustSigner("GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS"),
+										Weight: 10,
 									},
 								},
 							},
 						},
 					},
-					// Updated
-					{
-						Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
-						Updated: &xdr.LedgerEntry{
-							Data: xdr.LedgerEntryData{
-								Type: xdr.LedgerEntryTypeAccount,
-								Account: &xdr.AccountEntry{
-									AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-									Signers: []xdr.Signer{
-										{
-											Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
-											Weight: 16,
-										},
-										{
-											Key:    xdr.MustSigner("GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS"),
-											Weight: 15,
-										},
-										{
-											Key:    xdr.MustSigner("GCR3TQ2TVH3QRI7GQMC3IJGUUBR32YQHWBIKIMTYRQ2YH4XUTDB75UKE"),
-											Weight: 14,
-										},
-										{
-											Key:    xdr.MustSigner("GA4O5DLUUTLCTMM2UOWOYPNIH2FTD4NLO6KDZOFQRUISQ3FYKABGJLPC"),
-											Weight: 17,
-										},
+				},
+				// Updated
+				{
+					Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
+					Updated: &xdr.LedgerEntry{
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeAccount,
+							Account: &xdr.AccountEntry{
+								AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+								Signers: []xdr.Signer{
+									{
+										Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
+										Weight: 16,
+									},
+									{
+										Key:    xdr.MustSigner("GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS"),
+										Weight: 15,
+									},
+									{
+										Key:    xdr.MustSigner("GCR3TQ2TVH3QRI7GQMC3IJGUUBR32YQHWBIKIMTYRQ2YH4XUTDB75UKE"),
+										Weight: 14,
+									},
+									{
+										Key:    xdr.MustSigner("GA4O5DLUUTLCTMM2UOWOYPNIH2FTD4NLO6KDZOFQRUISQ3FYKABGJLPC"),
+										Weight: 17,
 									},
 								},
 							},
@@ -1566,8 +1564,10 @@ func TestOperationEffectsSetOptionsSignersOrder(t *testing.T) {
 					},
 				},
 			},
-		}),
-	}
+		},
+	})
+	var transaction ingest.LedgerTransaction
+	transaction.UnsafeSetMeta(meta)
 	transaction.Index = 1
 	transaction.Envelope.Type = xdr.EnvelopeTypeEnvelopeTypeTx
 	aid := xdr.MustAddress("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV")
@@ -1639,57 +1639,55 @@ func TestOperationEffectsSetOptionsSignersOrder(t *testing.T) {
 // Regression for https://github.com/stellar/go/issues/2136
 func TestOperationEffectsSetOptionsSignersNoUpdated(t *testing.T) {
 	tt := assert.New(t)
-	transaction := ingest.LedgerTransaction{
-		Meta: createTransactionMeta([]xdr.OperationMeta{
-			{
-				Changes: []xdr.LedgerEntryChange{
-					// State
-					{
-						Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-						State: &xdr.LedgerEntry{
-							Data: xdr.LedgerEntryData{
-								Type: xdr.LedgerEntryTypeAccount,
-								Account: &xdr.AccountEntry{
-									AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-									Signers: []xdr.Signer{
-										{
-											Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
-											Weight: 10,
-										},
-										{
-											Key:    xdr.MustSigner("GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS"),
-											Weight: 10,
-										},
-										{
-											Key:    xdr.MustSigner("GA4O5DLUUTLCTMM2UOWOYPNIH2FTD4NLO6KDZOFQRUISQ3FYKABGJLPC"),
-											Weight: 17,
-										},
+	meta := createTransactionMeta([]xdr.OperationMeta{
+		{
+			Changes: []xdr.LedgerEntryChange{
+				// State
+				{
+					Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+					State: &xdr.LedgerEntry{
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeAccount,
+							Account: &xdr.AccountEntry{
+								AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+								Signers: []xdr.Signer{
+									{
+										Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
+										Weight: 10,
+									},
+									{
+										Key:    xdr.MustSigner("GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS"),
+										Weight: 10,
+									},
+									{
+										Key:    xdr.MustSigner("GA4O5DLUUTLCTMM2UOWOYPNIH2FTD4NLO6KDZOFQRUISQ3FYKABGJLPC"),
+										Weight: 17,
 									},
 								},
 							},
 						},
 					},
-					// Updated
-					{
-						Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
-						Updated: &xdr.LedgerEntry{
-							Data: xdr.LedgerEntryData{
-								Type: xdr.LedgerEntryTypeAccount,
-								Account: &xdr.AccountEntry{
-									AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-									Signers: []xdr.Signer{
-										{
-											Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
-											Weight: 16,
-										},
-										{
-											Key:    xdr.MustSigner("GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS"),
-											Weight: 10,
-										},
-										{
-											Key:    xdr.MustSigner("GCR3TQ2TVH3QRI7GQMC3IJGUUBR32YQHWBIKIMTYRQ2YH4XUTDB75UKE"),
-											Weight: 14,
-										},
+				},
+				// Updated
+				{
+					Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
+					Updated: &xdr.LedgerEntry{
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeAccount,
+							Account: &xdr.AccountEntry{
+								AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+								Signers: []xdr.Signer{
+									{
+										Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
+										Weight: 16,
+									},
+									{
+										Key:    xdr.MustSigner("GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS"),
+										Weight: 10,
+									},
+									{
+										Key:    xdr.MustSigner("GCR3TQ2TVH3QRI7GQMC3IJGUUBR32YQHWBIKIMTYRQ2YH4XUTDB75UKE"),
+										Weight: 14,
 									},
 								},
 							},
@@ -1697,8 +1695,10 @@ func TestOperationEffectsSetOptionsSignersNoUpdated(t *testing.T) {
 					},
 				},
 			},
-		}),
-	}
+		},
+	})
+	var transaction ingest.LedgerTransaction
+	transaction.UnsafeSetMeta(meta)
 	transaction.Index = 1
 	transaction.Envelope.Type = xdr.EnvelopeTypeEnvelopeTypeTx
 	aid := xdr.MustAddress("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV")
@@ -1760,9 +1760,9 @@ func TestOperationRegressionAccountTrustItself(t *testing.T) {
 	tt := assert.New(t)
 	// NOTE:  when an account trusts itself, the transaction is successful but
 	// no ledger entries are actually modified.
-	transaction := ingest.LedgerTransaction{
-		Meta: createTransactionMeta([]xdr.OperationMeta{}),
-	}
+	var transaction ingest.LedgerTransaction
+	meta := createTransactionMeta([]xdr.OperationMeta{})
+	transaction.UnsafeSetMeta(meta)
 	transaction.Index = 1
 	transaction.Envelope.Type = xdr.EnvelopeTypeEnvelopeTypeTx
 	aid := xdr.MustAddress("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV")
@@ -1809,15 +1809,14 @@ func TestOperationEffectsAllowTrustAuthorizedToMaintainLiabilities(t *testing.T)
 			},
 		},
 	}
-
+	var tx ingest.LedgerTransaction
+	tx.UnsafeSetMeta(xdr.TransactionMeta{
+		V:  2,
+		V2: &xdr.TransactionMetaV2{},
+	})
 	operation := transactionOperationWrapper{
-		index: 0,
-		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
-				V:  2,
-				V2: &xdr.TransactionMetaV2{},
-			},
-		},
+		index:          0,
+		transaction:    tx,
 		operation:      op,
 		ledgerSequence: 1,
 	}
@@ -1871,14 +1870,14 @@ func TestOperationEffectsClawback(t *testing.T) {
 		},
 	}
 
+	var tx ingest.LedgerTransaction
+	tx.UnsafeSetMeta(xdr.TransactionMeta{
+		V:  2,
+		V2: &xdr.TransactionMetaV2{},
+	})
 	operation := transactionOperationWrapper{
-		index: 0,
-		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
-				V:  2,
-				V2: &xdr.TransactionMetaV2{},
-			},
-		},
+		index:          0,
+		transaction:    tx,
 		operation:      op,
 		ledgerSequence: 1,
 	}
@@ -1931,14 +1930,14 @@ func TestOperationEffectsClawbackClaimableBalance(t *testing.T) {
 		},
 	}
 
+	var tx ingest.LedgerTransaction
+	tx.UnsafeSetMeta(xdr.TransactionMeta{
+		V:  2,
+		V2: &xdr.TransactionMetaV2{},
+	})
 	operation := transactionOperationWrapper{
-		index: 0,
-		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
-				V:  2,
-				V2: &xdr.TransactionMetaV2{},
-			},
-		},
+		index:          0,
+		transaction:    tx,
 		operation:      op,
 		ledgerSequence: 1,
 	}
@@ -1980,14 +1979,14 @@ func TestOperationEffectsSetTrustLineFlags(t *testing.T) {
 		},
 	}
 
+	var tx ingest.LedgerTransaction
+	tx.UnsafeSetMeta(xdr.TransactionMeta{
+		V:  2,
+		V2: &xdr.TransactionMetaV2{},
+	})
 	operation := transactionOperationWrapper{
-		index: 0,
-		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
-				V:  2,
-				V2: &xdr.TransactionMetaV2{},
-			},
-		},
+		index:          0,
+		transaction:    tx,
 		operation:      op,
 		ledgerSequence: 1,
 	}
@@ -2121,24 +2120,24 @@ func (s *CreateClaimableBalanceEffectsTestSuite) SetupTest() {
 			},
 		},
 		FeeChanges: xdr.LedgerEntryChanges{},
-		Meta: xdr.TransactionMeta{
-			V: 2,
-			V2: &xdr.TransactionMetaV2{
-				Operations: []xdr.OperationMeta{
-					{
-						Changes: []xdr.LedgerEntryChange{
-							{
-								Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
-								Created: &xdr.LedgerEntry{
-									Data: xdr.LedgerEntryData{
-										Type: xdr.LedgerEntryTypeClaimableBalance,
-										ClaimableBalance: &xdr.ClaimableBalanceEntry{
-											BalanceId: balanceIDOp1,
-											Ext: xdr.ClaimableBalanceEntryExt{
-												V: 1,
-												V1: &xdr.ClaimableBalanceEntryExtensionV1{
-													Flags: xdr.Uint32(xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag),
-												},
+	}
+	s.tx.UnsafeSetMeta(xdr.TransactionMeta{
+		V: 2,
+		V2: &xdr.TransactionMetaV2{
+			Operations: []xdr.OperationMeta{
+				{
+					Changes: []xdr.LedgerEntryChange{
+						{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+							Created: &xdr.LedgerEntry{
+								Data: xdr.LedgerEntryData{
+									Type: xdr.LedgerEntryTypeClaimableBalance,
+									ClaimableBalance: &xdr.ClaimableBalanceEntry{
+										BalanceId: balanceIDOp1,
+										Ext: xdr.ClaimableBalanceEntryExt{
+											V: 1,
+											V1: &xdr.ClaimableBalanceEntryExtensionV1{
+												Flags: xdr.Uint32(xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag),
 											},
 										},
 									},
@@ -2146,13 +2145,13 @@ func (s *CreateClaimableBalanceEffectsTestSuite) SetupTest() {
 							},
 						},
 					},
-					{
-						// Not used for the test
-					},
+				},
+				{
+					// Not used for the test
 				},
 			},
 		},
-	}
+	})
 }
 func (s *CreateClaimableBalanceEffectsTestSuite) TestEffects() {
 	testCases := []struct {
@@ -2349,84 +2348,84 @@ func (s *ClaimClaimableBalanceEffectsTestSuite) SetupTest() {
 			},
 		},
 		FeeChanges: xdr.LedgerEntryChanges{},
-		Meta: xdr.TransactionMeta{
-			V: 2,
-			V2: &xdr.TransactionMetaV2{
-				Operations: []xdr.OperationMeta{
-					// op1
-					{
-						Changes: xdr.LedgerEntryChanges{
-							xdr.LedgerEntryChange{
-								Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-								State: &xdr.LedgerEntry{
-									Data: xdr.LedgerEntryData{
-										Type: xdr.LedgerEntryTypeClaimableBalance,
-										ClaimableBalance: &xdr.ClaimableBalanceEntry{
-											BalanceId: balanceIDOp1Meta,
-											Amount:    xdr.Int64(100000000),
-											Asset:     xdr.MustNewNativeAsset(),
-											Claimants: []xdr.Claimant{
-												{
-													Type: xdr.ClaimantTypeClaimantTypeV0,
-													V0: &xdr.ClaimantV0{
-														Destination: xdr.MustAddress("GD5OVB6FKDV7P7SOJ5UB2BPLBL4XGSHPYHINR5355SY3RSXLT2BZWAKY"),
+	}
+	s.tx.UnsafeSetMeta(xdr.TransactionMeta{
+		V: 2,
+		V2: &xdr.TransactionMetaV2{
+			Operations: []xdr.OperationMeta{
+				// op1
+				{
+					Changes: xdr.LedgerEntryChanges{
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+							State: &xdr.LedgerEntry{
+								Data: xdr.LedgerEntryData{
+									Type: xdr.LedgerEntryTypeClaimableBalance,
+									ClaimableBalance: &xdr.ClaimableBalanceEntry{
+										BalanceId: balanceIDOp1Meta,
+										Amount:    xdr.Int64(100000000),
+										Asset:     xdr.MustNewNativeAsset(),
+										Claimants: []xdr.Claimant{
+											{
+												Type: xdr.ClaimantTypeClaimantTypeV0,
+												V0: &xdr.ClaimantV0{
+													Destination: xdr.MustAddress("GD5OVB6FKDV7P7SOJ5UB2BPLBL4XGSHPYHINR5355SY3RSXLT2BZWAKY"),
 
-														Predicate: xdr.ClaimPredicate{
-															Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
-														},
+													Predicate: xdr.ClaimPredicate{
+														Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
 													},
 												},
 											},
-											Ext: xdr.ClaimableBalanceEntryExt{
-												V: 1,
-												V1: &xdr.ClaimableBalanceEntryExtensionV1{
-													Flags: xdr.Uint32(xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag),
-												},
+										},
+										Ext: xdr.ClaimableBalanceEntryExt{
+											V: 1,
+											V1: &xdr.ClaimableBalanceEntryExtensionV1{
+												Flags: xdr.Uint32(xdr.ClaimableBalanceFlagsClaimableBalanceClawbackEnabledFlag),
 											},
 										},
-									},
-								},
-							},
-							xdr.LedgerEntryChange{
-								Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-								Removed: &xdr.LedgerKey{
-									Type: xdr.LedgerEntryTypeClaimableBalance,
-									ClaimableBalance: &xdr.LedgerKeyClaimableBalance{
-										BalanceId: balanceIDOp1Meta,
 									},
 								},
 							},
 						},
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+							Removed: &xdr.LedgerKey{
+								Type: xdr.LedgerEntryTypeClaimableBalance,
+								ClaimableBalance: &xdr.LedgerKeyClaimableBalance{
+									BalanceId: balanceIDOp1Meta,
+								},
+							},
+						},
 					},
-					// op2
-					{
-						Changes: xdr.LedgerEntryChanges{
-							xdr.LedgerEntryChange{
-								Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-								State: &xdr.LedgerEntry{
-									Data: xdr.LedgerEntryData{
-										Type: xdr.LedgerEntryTypeClaimableBalance,
-										ClaimableBalance: &xdr.ClaimableBalanceEntry{
-											BalanceId: balanceIDOp2Meta,
-											Amount:    xdr.Int64(200000000),
-											Asset:     xdr.MustNewCreditAsset("USD", "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
-											Claimants: []xdr.Claimant{
-												{
-													Type: xdr.ClaimantTypeClaimantTypeV0,
-													V0: &xdr.ClaimantV0{
-														Destination: xdr.MustAddress("GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2"),
-														Predicate: xdr.ClaimPredicate{
-															Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
-														},
+				},
+				// op2
+				{
+					Changes: xdr.LedgerEntryChanges{
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+							State: &xdr.LedgerEntry{
+								Data: xdr.LedgerEntryData{
+									Type: xdr.LedgerEntryTypeClaimableBalance,
+									ClaimableBalance: &xdr.ClaimableBalanceEntry{
+										BalanceId: balanceIDOp2Meta,
+										Amount:    xdr.Int64(200000000),
+										Asset:     xdr.MustNewCreditAsset("USD", "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD"),
+										Claimants: []xdr.Claimant{
+											{
+												Type: xdr.ClaimantTypeClaimantTypeV0,
+												V0: &xdr.ClaimantV0{
+													Destination: xdr.MustAddress("GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2"),
+													Predicate: xdr.ClaimPredicate{
+														Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
 													},
 												},
-												{
-													Type: xdr.ClaimantTypeClaimantTypeV0,
-													V0: &xdr.ClaimantV0{
-														Destination: xdr.MustAddress("GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3"),
-														Predicate: xdr.ClaimPredicate{
-															Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
-														},
+											},
+											{
+												Type: xdr.ClaimantTypeClaimantTypeV0,
+												V0: &xdr.ClaimantV0{
+													Destination: xdr.MustAddress("GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3"),
+													Predicate: xdr.ClaimPredicate{
+														Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
 													},
 												},
 											},
@@ -2434,13 +2433,13 @@ func (s *ClaimClaimableBalanceEffectsTestSuite) SetupTest() {
 									},
 								},
 							},
-							xdr.LedgerEntryChange{
-								Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
-								Removed: &xdr.LedgerKey{
-									Type: xdr.LedgerEntryTypeClaimableBalance,
-									ClaimableBalance: &xdr.LedgerKeyClaimableBalance{
-										BalanceId: balanceIDOp2Meta,
-									},
+						},
+						xdr.LedgerEntryChange{
+							Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+							Removed: &xdr.LedgerKey{
+								Type: xdr.LedgerEntryTypeClaimableBalance,
+								ClaimableBalance: &xdr.LedgerKeyClaimableBalance{
+									BalanceId: balanceIDOp2Meta,
 								},
 							},
 						},
@@ -2448,7 +2447,7 @@ func (s *ClaimClaimableBalanceEffectsTestSuite) SetupTest() {
 				},
 			},
 		},
-	}
+	})
 }
 func (s *ClaimClaimableBalanceEffectsTestSuite) TestEffects() {
 	testCases := []struct {

--- a/services/horizon/internal/ingest/processors/ledgers_processor_test.go
+++ b/services/horizon/internal/ingest/processors/ledgers_processor_test.go
@@ -48,7 +48,7 @@ func createTransaction(successful bool, numOps int) ingest.LedgerTransaction {
 		})
 	}
 	sourceAID := xdr.MustAddress("GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY")
-	return ingest.LedgerTransaction{
+	tx := ingest.LedgerTransaction{
 		Result: xdr.TransactionResultPair{
 			TransactionHash: xdr.Hash{},
 			Result: xdr.TransactionResult{
@@ -68,13 +68,14 @@ func createTransaction(successful bool, numOps int) ingest.LedgerTransaction {
 				},
 			},
 		},
-		Meta: xdr.TransactionMeta{
-			V: 2,
-			V2: &xdr.TransactionMetaV2{
-				Operations: make([]xdr.OperationMeta, numOps, numOps),
-			},
-		},
 	}
+	tx.UnsafeSetMeta(xdr.TransactionMeta{
+		V: 2,
+		V2: &xdr.TransactionMetaV2{
+			Operations: make([]xdr.OperationMeta, numOps, numOps),
+		},
+	})
+	return tx
 }
 
 func (s *LedgersProcessorTestSuiteLedger) SetupTest() {

--- a/services/horizon/internal/ingest/processors/participants_processor.go
+++ b/services/horizon/internal/ingest/processors/participants_processor.go
@@ -106,14 +106,6 @@ func participantsForLedgerEntry(le xdr.LedgerEntry) *xdr.AccountId {
 	return &aid
 }
 
-func participantsForLedgerKey(lk xdr.LedgerKey) *xdr.AccountId {
-	if lk.Type != xdr.LedgerEntryTypeAccount {
-		return nil
-	}
-	aid := lk.MustAccount().AccountId
-	return &aid
-}
-
 func participantsForTransaction(
 	sequence uint32,
 	transaction ingest.LedgerTransaction,

--- a/services/horizon/internal/ingest/processors/participants_test.go
+++ b/services/horizon/internal/ingest/processors/participants_test.go
@@ -34,22 +34,22 @@ func TestParticipantsForTransaction(t *testing.T) {
 			&feeChanges,
 		),
 	)
-
-	particpants, err := participantsForTransaction(
-		3,
-		ingest.LedgerTransaction{
-			Index:      1,
-			Envelope:   envelope,
-			FeeChanges: feeChanges,
-			Meta:       meta,
-			Result: xdr.TransactionResultPair{
-				Result: xdr.TransactionResult{
-					Result: xdr.TransactionResultResult{
-						Code: xdr.TransactionResultCodeTxSuccess,
-					},
+	tx := ingest.LedgerTransaction{
+		Index:      1,
+		Envelope:   envelope,
+		FeeChanges: feeChanges,
+		Result: xdr.TransactionResultPair{
+			Result: xdr.TransactionResult{
+				Result: xdr.TransactionResultResult{
+					Code: xdr.TransactionResultCodeTxSuccess,
 				},
 			},
 		},
+	}
+	tx.UnsafeSetMeta(meta)
+	particpants, err := participantsForTransaction(
+		3,
+		tx,
 	)
 	assert.NoError(t, err)
 	assert.Len(t, particpants, 2)

--- a/services/horizon/internal/ingest/processors/trades_processor_test.go
+++ b/services/horizon/internal/ingest/processors/trades_processor_test.go
@@ -440,20 +440,20 @@ func (s *TradeProcessorTestSuiteLedger) mockReadTradeTransactions(
 		},
 		Index:      1,
 		FeeChanges: []xdr.LedgerEntryChange{},
-		Meta: xdr.TransactionMeta{
-			V: 2,
-			V2: &xdr.TransactionMetaV2{
-				Operations: []xdr.OperationMeta{
-					{
-						Changes: xdr.LedgerEntryChanges{},
-					},
+	}
+	meta := xdr.TransactionMeta{
+		V: 2,
+		V2: &xdr.TransactionMetaV2{
+			Operations: []xdr.OperationMeta{
+				{
+					Changes: xdr.LedgerEntryChanges{},
 				},
 			},
 		},
 	}
 
 	for i, trade := range s.allTrades {
-		tx.Meta.V2.Operations = append(tx.Meta.V2.Operations, xdr.OperationMeta{
+		meta.V2.Operations = append(meta.V2.Operations, xdr.OperationMeta{
 			Changes: xdr.LedgerEntryChanges{
 				xdr.LedgerEntryChange{
 					Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
@@ -481,6 +481,8 @@ func (s *TradeProcessorTestSuiteLedger) mockReadTradeTransactions(
 			},
 		})
 	}
+
+	tx.UnsafeSetMeta(meta)
 
 	s.txs = []ingest.LedgerTransaction{
 		tx,

--- a/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
+++ b/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
@@ -1039,16 +1039,16 @@ func TestTransactionOperationAllowTrustDetails(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			operation := transactionOperationWrapper{
-				index: 0,
-				transaction: ingest.LedgerTransaction{
-					Meta: xdr.TransactionMeta{
-						V: 2,
-						V2: &xdr.TransactionMetaV2{
-							Operations: make([]xdr.OperationMeta, 1, 1),
-						},
-					},
+			var tx ingest.LedgerTransaction
+			tx.UnsafeSetMeta(xdr.TransactionMeta{
+				V: 2,
+				V2: &xdr.TransactionMetaV2{
+					Operations: make([]xdr.OperationMeta, 1, 1),
 				},
+			})
+			operation := transactionOperationWrapper{
+				index:          0,
+				transaction:    tx,
 				operation:      tc.op,
 				ledgerSequence: 1,
 			}
@@ -1169,16 +1169,16 @@ func (s *CreateClaimableBalanceOpTestSuite) TestDetails() {
 	}
 	for _, tc := range testCases {
 		s.T().Run(tc.desc, func(t *testing.T) {
-			operation := transactionOperationWrapper{
-				index: 0,
-				transaction: ingest.LedgerTransaction{
-					Meta: xdr.TransactionMeta{
-						V: 2,
-						V2: &xdr.TransactionMetaV2{
-							Operations: make([]xdr.OperationMeta, 1, 1),
-						},
-					},
+			var tx ingest.LedgerTransaction
+			tx.UnsafeSetMeta(xdr.TransactionMeta{
+				V: 2,
+				V2: &xdr.TransactionMetaV2{
+					Operations: make([]xdr.OperationMeta, 1, 1),
 				},
+			})
+			operation := transactionOperationWrapper{
+				index:          0,
+				transaction:    tx,
 				operation:      tc.op,
 				ledgerSequence: 1,
 			}
@@ -1216,14 +1216,16 @@ func (s *CreateClaimableBalanceOpTestSuite) TestParticipants() {
 	}
 	for _, tc := range testCases {
 		s.T().Run(tc.desc, func(t *testing.T) {
+			var tx ingest.LedgerTransaction
+			tx.UnsafeSetMeta(xdr.TransactionMeta{
+				V: 2,
+				V2: &xdr.TransactionMetaV2{
+					Operations: make([]xdr.OperationMeta, 1, 1),
+				},
+			})
 			operation := transactionOperationWrapper{
-				index: 0,
-				transaction: ingest.LedgerTransaction{Meta: xdr.TransactionMeta{
-					V: 2,
-					V2: &xdr.TransactionMetaV2{
-						Operations: make([]xdr.OperationMeta, 1, 1),
-					},
-				}},
+				index:          0,
+				transaction:    tx,
 				operation:      tc.op,
 				ledgerSequence: 1,
 			}
@@ -1266,15 +1268,16 @@ func (s *ClaimClaimableBalanceOpTestSuite) TestDetails() {
 		"balance_id": s.balanceID,
 	}
 
+	var tx ingest.LedgerTransaction
+	tx.UnsafeSetMeta(xdr.TransactionMeta{
+		V: 2,
+		V2: &xdr.TransactionMetaV2{
+			Operations: make([]xdr.OperationMeta, 1, 1),
+		},
+	})
 	operation := transactionOperationWrapper{
-		index: 0,
-		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
-				V: 2,
-				V2: &xdr.TransactionMetaV2{
-					Operations: make([]xdr.OperationMeta, 1, 1),
-				},
-			}},
+		index:          0,
+		transaction:    tx,
 		operation:      s.op,
 		ledgerSequence: 1,
 	}
@@ -1285,16 +1288,16 @@ func (s *ClaimClaimableBalanceOpTestSuite) TestDetails() {
 }
 
 func (s *ClaimClaimableBalanceOpTestSuite) TestParticipants() {
-	operation := transactionOperationWrapper{
-		index: 0,
-		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
-				V: 2,
-				V2: &xdr.TransactionMetaV2{
-					Operations: make([]xdr.OperationMeta, 1, 1),
-				},
-			},
+	var tx ingest.LedgerTransaction
+	tx.UnsafeSetMeta(xdr.TransactionMeta{
+		V: 2,
+		V2: &xdr.TransactionMetaV2{
+			Operations: make([]xdr.OperationMeta, 1, 1),
 		},
+	})
+	operation := transactionOperationWrapper{
+		index:          0,
+		transaction:    tx,
 		operation:      s.op,
 		ledgerSequence: 1,
 	}
@@ -1319,7 +1322,7 @@ func getSponsoredSandwichWrappers() []*transactionOperationWrapper {
 	const ledgerSeq = uint32(12345)
 	tx := createTransaction(true, 3)
 	tx.Index = 1
-	tx.Meta = xdr.TransactionMeta{
+	meta := xdr.TransactionMeta{
 		V: 2,
 		V2: &xdr.TransactionMetaV2{
 			Operations: make([]xdr.OperationMeta, 3, 3),
@@ -1358,7 +1361,7 @@ func getSponsoredSandwichWrappers() []*transactionOperationWrapper {
 	}
 	sponsoreeMuxed := sponsoree.ToMuxedAccount()
 	tx.Envelope.Operations()[1].SourceAccount = &sponsoreeMuxed
-	tx.Meta.V2.Operations[1] = xdr.OperationMeta{Changes: []xdr.LedgerEntryChange{
+	meta.V2.Operations[1] = xdr.OperationMeta{Changes: []xdr.LedgerEntryChange{
 		{
 			Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
 			Created: &xdr.LedgerEntry{
@@ -1372,6 +1375,7 @@ func getSponsoredSandwichWrappers() []*transactionOperationWrapper {
 			},
 		},
 	}}
+	tx.UnsafeSetMeta(meta)
 
 	// end sponsorship
 	tx.Envelope.Operations()[2].Body = xdr.OperationBody{
@@ -1481,16 +1485,16 @@ func (s *ClawbackTestSuite) TestDetails() {
 		"amount":       "0.0000020",
 		"from":         "GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
 	}
-
+	var tx ingest.LedgerTransaction
+	tx.UnsafeSetMeta(xdr.TransactionMeta{
+		V: 2,
+		V2: &xdr.TransactionMetaV2{
+			Operations: make([]xdr.OperationMeta, 1, 1),
+		},
+	})
 	operation := transactionOperationWrapper{
-		index: 0,
-		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
-				V: 2,
-				V2: &xdr.TransactionMetaV2{
-					Operations: make([]xdr.OperationMeta, 1, 1),
-				},
-			}},
+		index:          0,
+		transaction:    tx,
 		operation:      s.op,
 		ledgerSequence: 1,
 	}
@@ -1501,16 +1505,16 @@ func (s *ClawbackTestSuite) TestDetails() {
 }
 
 func (s *ClawbackTestSuite) TestParticipants() {
-	operation := transactionOperationWrapper{
-		index: 0,
-		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
-				V: 2,
-				V2: &xdr.TransactionMetaV2{
-					Operations: make([]xdr.OperationMeta, 1, 1),
-				},
-			},
+	var tx ingest.LedgerTransaction
+	tx.UnsafeSetMeta(xdr.TransactionMeta{
+		V: 2,
+		V2: &xdr.TransactionMetaV2{
+			Operations: make([]xdr.OperationMeta, 1, 1),
 		},
+	})
+	operation := transactionOperationWrapper{
+		index:          0,
+		transaction:    tx,
 		operation:      s.op,
 		ledgerSequence: 1,
 	}
@@ -1564,15 +1568,16 @@ func (s *SetTrustLineFlagsTestSuite) TestDetails() {
 		"trustor":       "GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
 	}
 
+	var tx ingest.LedgerTransaction
+	tx.UnsafeSetMeta(xdr.TransactionMeta{
+		V: 2,
+		V2: &xdr.TransactionMetaV2{
+			Operations: make([]xdr.OperationMeta, 1, 1),
+		},
+	})
 	operation := transactionOperationWrapper{
-		index: 0,
-		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
-				V: 2,
-				V2: &xdr.TransactionMetaV2{
-					Operations: make([]xdr.OperationMeta, 1, 1),
-				},
-			}},
+		index:          0,
+		transaction:    tx,
 		operation:      s.op,
 		ledgerSequence: 1,
 	}
@@ -1583,16 +1588,16 @@ func (s *SetTrustLineFlagsTestSuite) TestDetails() {
 }
 
 func (s *SetTrustLineFlagsTestSuite) TestParticipants() {
-	operation := transactionOperationWrapper{
-		index: 0,
-		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
-				V: 2,
-				V2: &xdr.TransactionMetaV2{
-					Operations: make([]xdr.OperationMeta, 1, 1),
-				},
-			},
+	var tx ingest.LedgerTransaction
+	tx.UnsafeSetMeta(xdr.TransactionMeta{
+		V: 2,
+		V2: &xdr.TransactionMetaV2{
+			Operations: make([]xdr.OperationMeta, 1, 1),
 		},
+	})
+	operation := transactionOperationWrapper{
+		index:          0,
+		transaction:    tx,
 		operation:      s.op,
 		ledgerSequence: 1,
 	}

--- a/services/horizon/internal/test/transactions/main.go
+++ b/services/horizon/internal/test/transactions/main.go
@@ -27,7 +27,6 @@ func BuildLedgerTransaction(t *testing.T, tx TestTransaction) ingest.LedgerTrans
 		Envelope:   xdr.TransactionEnvelope{},
 		Result:     xdr.TransactionResultPair{},
 		FeeChanges: xdr.LedgerEntryChanges{},
-		Meta:       xdr.TransactionMeta{},
 	}
 
 	tt := assert.New(t)
@@ -36,7 +35,9 @@ func BuildLedgerTransaction(t *testing.T, tx TestTransaction) ingest.LedgerTrans
 	tt.NoError(err)
 	err = xdr.SafeUnmarshalBase64(tx.ResultXDR, &transaction.Result.Result)
 	tt.NoError(err)
-	err = xdr.SafeUnmarshalBase64(tx.MetaXDR, &transaction.Meta)
+	var meta xdr.TransactionMeta
+	err = xdr.SafeUnmarshalBase64(tx.MetaXDR, &meta)
+	transaction.UnsafeSetMeta(meta)
 	tt.NoError(err)
 	err = xdr.SafeUnmarshalBase64(tx.FeeChangesXDR, &transaction.FeeChanges)
 	tt.NoError(err)


### PR DESCRIPTION
This change transforms 

```go
type LedgerTransaction struct {
	...
	Meta       xdr.TransactionMeta
}
```

into 

```go
type LedgerTransaction struct {
	...
	meta       xdr.TransactionMeta
}
```

Unfortunately I've had to add a getter and a setter:

1. `func (t *LedgerTransaction) UnsafeSetMeta(meta xdr.TransactionMeta)`, needed for test fixtures
2. `(t *LedgerTransaction) UnsafeGetMeta() xdr.TransactionMeta)`, needed for db ingestion (see `transactionToRow(transaction ingest.LedgerTransaction, sequence uint32)`).

As a result the participants processor (`participantsForTransaction()`) now uses `func (t *LedgerTransaction) GetChanges()` which constitutes a change of behavior (for the better, I believe, although new participants may be found).

To make sure `participantsForTransaction()`works with old transactions, `GetChanges()` now also returns the changes of Meta version `0`.

In addition, and for consistency, `participantsForTransaction()` now uses `GetFeeChanges()` instead of `LedgerTransaction`s `FeeChanges` field.

I think `FeeChanges` should probably be made private in the future.

Fixes #3491
