### PR TITLE
Switch friendbot to 20.04 image

### DIFF
--- a/services/friendbot/docker/Dockerfile
+++ b/services/friendbot/docker/Dockerfile
@@ -4,9 +4,9 @@ ADD . /src/friendbot
 WORKDIR /src/friendbot
 RUN go build -o /bin/friendbot ./services/friendbot
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates
 COPY --from=build /bin/friendbot /app/
 EXPOSE 8004
 ENTRYPOINT ["/app/friendbot"]


### PR DESCRIPTION
### What

Switch friendbot docker image to 20.04 base

### Why

We are migrating other images to 20.04, this change will keep friendbot consistent with other projects.

