### PR TITLE
services/horizon: Add --skip-migrations-check flag

### DIFF
--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -74,6 +74,9 @@ type Config struct {
 	// ApplyMigrations will apply pending migrations to the horizon database
 	// before starting the horizon service
 	ApplyMigrations bool
+	// SkipMigrationsCheck will skip checking if there are any migrations
+	// required
+	SkipMigrationsCheck bool
 	// CheckpointFrequency establishes how many ledgers exist between checkpoints
 	CheckpointFrequency uint32
 	// BehindCloudflare determines if Horizon instance is behind Cloudflare. In

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -387,6 +387,14 @@ func Flags() (*Config, support.ConfigOptions) {
 			Usage:       "applies pending migrations before starting horizon",
 		},
 		&support.ConfigOption{
+			Name:        "skip-migrations-check",
+			ConfigKey:   &config.SkipMigrationsCheck,
+			OptType:     types.Bool,
+			FlagDefault: false,
+			Required:    false,
+			Usage:       "skips checking if there are migrations required",
+		},
+		&support.ConfigOption{
 			Name:        "checkpoint-frequency",
 			ConfigKey:   &config.CheckpointFrequency,
 			OptType:     types.Uint32,
@@ -443,7 +451,9 @@ func ApplyFlags(config *Config, flags support.ConfigOptions) {
 	}
 
 	// Migrations should be checked as early as possible
-	checkMigrations(*config)
+	if !config.SkipMigrationsCheck {
+		checkMigrations(*config)
+	}
 
 	// Validate options that should be provided together
 	validateBothOrNeither("tls-cert", "tls-key")


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit adds `--skip-migrations-check` flag that, when set, will skip checking if there are any migrations required to start Horizon.

### Why

When checking if there are any migrations required Horizon calls `migrate.PlanMigration` which sends `CREATE TABLE gorp_migrations`. This query is forbidden when using read only database (like replica).

### Known limitations

No tests, will be added in #3193.