### PR TITLE
services/horizon: Test full coverage of operation type switches

### DIFF
--- a/protocols/horizon/operations/main_test.go
+++ b/protocols/horizon/operations/main_test.go
@@ -1,0 +1,32 @@
+package operations
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/go/xdr"
+)
+
+func TestTypeNamesAllCovered(t *testing.T) {
+	for typ, s := range xdr.OperationTypeToStringMap {
+		_, ok := TypeNames[xdr.OperationType(typ)]
+		assert.True(t, ok, s)
+	}
+}
+
+func TestUnmarshalOperationAllCovered(t *testing.T) {
+	mistmatchErr := errors.New("Invalid operation format, unable to unmarshal json response")
+	for typ, s := range xdr.OperationTypeToStringMap {
+		_, err := UnmarshalOperation(typ, []byte{})
+		assert.Error(t, err, s)
+		// it shoudl be a parsing error, not the default branch
+		assert.NotEqual(t, mistmatchErr, err, s)
+	}
+
+	// make sure the check works for an unreasonable operation type
+	_, err := UnmarshalOperation(200000, []byte{})
+	assert.Error(t, err)
+	assert.Equal(t, mistmatchErr, err)
+}

--- a/protocols/horizon/operations/main_test.go
+++ b/protocols/horizon/operations/main_test.go
@@ -21,11 +21,11 @@ func TestUnmarshalOperationAllCovered(t *testing.T) {
 	for typ, s := range xdr.OperationTypeToStringMap {
 		_, err := UnmarshalOperation(typ, []byte{})
 		assert.Error(t, err, s)
-		// it shoudl be a parsing error, not the default branch
+		// it should be a parsing error, not the default branch
 		assert.NotEqual(t, mistmatchErr, err, s)
 	}
 
-	// make sure the check works for an unreasonable operation type
+	// make sure the check works for an unknown operation type
 	_, err := UnmarshalOperation(200000, []byte{})
 	assert.Error(t, err)
 	assert.Equal(t, mistmatchErr, err)

--- a/services/horizon/internal/codes/main_test.go
+++ b/services/horizon/internal/codes/main_test.go
@@ -7,6 +7,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestForOperationResultCoversForAllOpTypes(t *testing.T) {
+	for typ, s := range xdr.OperationTypeToStringMap {
+		result := xdr.OperationResult{
+			Code: xdr.OperationResultCodeOpInner,
+			Tr: &xdr.OperationResultTr{
+				Type: xdr.OperationType(typ),
+			},
+		}
+		f := func() {
+			ForOperationResult(result)
+		}
+		// it must panic because the operation restult is not set
+		assert.Panics(t, f, s)
+	}
+	// make sure the check works for an unknown operation type
+	result := xdr.OperationResult{
+		Code: xdr.OperationResultCodeOpInner,
+		Tr: &xdr.OperationResultTr{
+			Type: xdr.OperationType(200000),
+		},
+	}
+	f := func() {
+		ForOperationResult(result)
+	}
+	// it doesn'' panic because it doesn't branch out into the operation type
+	assert.NotPanics(t, f)
+}
+
 func TestString(t *testing.T) {
 	tests := []struct {
 		Input    interface{}

--- a/services/horizon/internal/codes/main_test.go
+++ b/services/horizon/internal/codes/main_test.go
@@ -18,7 +18,7 @@ func TestForOperationResultCoversForAllOpTypes(t *testing.T) {
 		f := func() {
 			ForOperationResult(result)
 		}
-		// it must panic because the operation restult is not set
+		// it must panic because the operation result is not set
 		assert.Panics(t, f, s)
 	}
 	// make sure the check works for an unknown operation type
@@ -31,7 +31,7 @@ func TestForOperationResultCoversForAllOpTypes(t *testing.T) {
 	f := func() {
 		ForOperationResult(result)
 	}
-	// it doesn'' panic because it doesn't branch out into the operation type
+	// it doesn't panic because it doesn't branch out into the operation type
 	assert.NotPanics(t, f)
 }
 

--- a/services/horizon/internal/ingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/ingest/processors/effects_processor_test.go
@@ -426,6 +426,61 @@ func getRevokeSponsorshipMeta(t *testing.T) (string, []effect) {
 	return b64, expectedEffects
 }
 
+func TestEffectsCoversAllOperationTypes(t *testing.T) {
+	for typ, s := range xdr.OperationTypeToStringMap {
+		op := xdr.Operation{
+			Body: xdr.OperationBody{
+				Type: xdr.OperationType(typ),
+			},
+		}
+		operation := transactionOperationWrapper{
+			index: 0,
+			transaction: ingest.LedgerTransaction{
+				Meta: xdr.TransactionMeta{
+					V:  2,
+					V2: &xdr.TransactionMetaV2{},
+				},
+			},
+			operation:      op,
+			ledgerSequence: 1,
+		}
+		// calling effects should either panic (because the operation field is set to nil)
+		// or not error
+		func() {
+			var err error
+			defer func() {
+				err2 := recover()
+				if err != nil {
+					assert.NotContains(t, err.Error(), "Unknown operation type")
+				}
+				assert.True(t, err2 != nil || err == nil, s)
+			}()
+			_, err = operation.effects()
+		}()
+	}
+
+	// make sure the check works for an unknown operation type
+	op := xdr.Operation{
+		Body: xdr.OperationBody{
+			Type: xdr.OperationType(20000),
+		},
+	}
+	operation := transactionOperationWrapper{
+		index: 0,
+		transaction: ingest.LedgerTransaction{
+			Meta: xdr.TransactionMeta{
+				V:  2,
+				V2: &xdr.TransactionMetaV2{},
+			},
+		},
+		operation:      op,
+		ledgerSequence: 1,
+	}
+	// calling effects should error due to the unknown operation
+	_, err := operation.effects()
+	assert.Contains(t, err.Error(), "Unknown operation type")
+}
+
 func TestOperationEffects(t *testing.T) {
 
 	sourceAID := xdr.MustAddress("GD3MMHD2YZWL5RAUWG6O3RMA5HTZYM7S3JLSZ2Z35JNJAWTDIKXY737V")

--- a/services/horizon/internal/ingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/ingest/processors/effects_processor_test.go
@@ -436,7 +436,7 @@ func TestEffectsCoversAllOperationTypes(t *testing.T) {
 		operation := transactionOperationWrapper{
 			index: 0,
 			transaction: ingest.LedgerTransaction{
-				Meta: xdr.TransactionMeta{
+				UnsafeMeta: xdr.TransactionMeta{
 					V:  2,
 					V2: &xdr.TransactionMetaV2{},
 				},
@@ -468,7 +468,7 @@ func TestEffectsCoversAllOperationTypes(t *testing.T) {
 	operation := transactionOperationWrapper{
 		index: 0,
 		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
+			UnsafeMeta: xdr.TransactionMeta{
 				V:  2,
 				V2: &xdr.TransactionMetaV2{},
 			},

--- a/services/horizon/internal/ingest/processors/stats_ledger_transaction_processor_test.go
+++ b/services/horizon/internal/ingest/processors/stats_ledger_transaction_processor_test.go
@@ -28,7 +28,7 @@ func TestStatsLedgerTransactionProcessoAllOpTypesCovered(t *testing.T) {
 		txTemplate.Envelope.V1.Tx.Operations[0].Body.Type = xdr.OperationType(typ)
 		f := func() {
 			var p StatsLedgerTransactionProcessor
-			p.ProcessTransaction(tx)
+			p.ProcessTransaction(context.Background(), tx)
 		}
 		assert.NotPanics(t, f, s)
 	}
@@ -38,7 +38,7 @@ func TestStatsLedgerTransactionProcessoAllOpTypesCovered(t *testing.T) {
 	txTemplate.Envelope.V1.Tx.Operations[0].Body.Type = 20000
 	f := func() {
 		var p StatsLedgerTransactionProcessor
-		p.ProcessTransaction(tx)
+		p.ProcessTransaction(context.Background(), tx)
 	}
 	assert.Panics(t, f)
 }

--- a/services/horizon/internal/ingest/processors/stats_ledger_transaction_processor_test.go
+++ b/services/horizon/internal/ingest/processors/stats_ledger_transaction_processor_test.go
@@ -10,6 +10,39 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
+func TestStatsLedgerTransactionProcessoAllOpTypesCovered(t *testing.T) {
+	txTemplate := ingest.LedgerTransaction{
+		Envelope: xdr.TransactionEnvelope{
+			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+			V1: &xdr.TransactionV1Envelope{
+				Tx: xdr.Transaction{
+					Operations: []xdr.Operation{
+						{Body: xdr.OperationBody{Type: 0}},
+					},
+				},
+			},
+		},
+	}
+	for typ, s := range xdr.OperationTypeToStringMap {
+		tx := txTemplate
+		txTemplate.Envelope.V1.Tx.Operations[0].Body.Type = xdr.OperationType(typ)
+		f := func() {
+			var p StatsLedgerTransactionProcessor
+			p.ProcessTransaction(tx)
+		}
+		assert.NotPanics(t, f, s)
+	}
+
+	// make sure the check works for an unreasonable operation type
+	tx := txTemplate
+	txTemplate.Envelope.V1.Tx.Operations[0].Body.Type = 20000
+	f := func() {
+		var p StatsLedgerTransactionProcessor
+		p.ProcessTransaction(tx)
+	}
+	assert.Panics(t, f)
+}
+
 func TestStatsLedgerTransactionProcessor(t *testing.T) {
 	processor := &StatsLedgerTransactionProcessor{}
 

--- a/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
+++ b/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
@@ -1608,3 +1608,123 @@ func (s *SetTrustLineFlagsTestSuite) TestParticipants() {
 func TestSetTrustLineFlagsTestSuite(t *testing.T) {
 	suite.Run(t, new(SetTrustLineFlagsTestSuite))
 }
+
+func TestParticipantsCoversAllOperationTypes(t *testing.T) {
+	source := xdr.MustMuxedAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD")
+	for typ, s := range xdr.OperationTypeToStringMap {
+		op := xdr.Operation{
+			SourceAccount: &source,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationType(typ),
+			},
+		}
+		operation := transactionOperationWrapper{
+			index: 0,
+			transaction: ingest.LedgerTransaction{
+				Meta: xdr.TransactionMeta{
+					V:  2,
+					V2: &xdr.TransactionMetaV2{},
+				},
+			},
+			operation:      op,
+			ledgerSequence: 1,
+		}
+		// calling Participants should either panic (because the operation field is set to nil)
+		// or not error
+		func() {
+			var err error
+			defer func() {
+				err2 := recover()
+				if err != nil {
+					assert.NotContains(t, err.Error(), "Unknown operation type")
+				}
+				assert.True(t, err2 != nil || err == nil, s)
+			}()
+			_, err = operation.Participants()
+		}()
+	}
+
+	// make sure the check works for an unknown operation type
+	op := xdr.Operation{
+		SourceAccount: &source,
+		Body: xdr.OperationBody{
+			Type: xdr.OperationType(20000),
+		},
+	}
+	operation := transactionOperationWrapper{
+		index: 0,
+		transaction: ingest.LedgerTransaction{
+			Meta: xdr.TransactionMeta{
+				V:  2,
+				V2: &xdr.TransactionMetaV2{},
+			},
+		},
+		operation:      op,
+		ledgerSequence: 1,
+	}
+	// calling Participants should error due to the unknown operation
+	_, err := operation.Participants()
+	assert.Contains(t, err.Error(), "Unknown operation type")
+}
+
+func TestDetailsCoversAllOperationTypes(t *testing.T) {
+	source := xdr.MustMuxedAddress("GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD")
+	for typ, s := range xdr.OperationTypeToStringMap {
+		op := xdr.Operation{
+			SourceAccount: &source,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationType(typ),
+			},
+		}
+		operation := transactionOperationWrapper{
+			index: 0,
+			transaction: ingest.LedgerTransaction{
+				Meta: xdr.TransactionMeta{
+					V:  2,
+					V2: &xdr.TransactionMetaV2{},
+				},
+			},
+			operation:      op,
+			ledgerSequence: 1,
+		}
+		// calling Details should either panic (because the operation field is set to nil)
+		// or not error
+		func() {
+			var err error
+			defer func() {
+				err2 := recover()
+				if err2 != nil {
+					if err3, ok := err2.(error); ok {
+						assert.NotContains(t, "Unknown operation type", err3.Error())
+					}
+				}
+				assert.True(t, err2 != nil || err == nil, s)
+			}()
+			_, err = operation.Details()
+		}()
+	}
+
+	// make sure the check works for an unknown operation type
+	op := xdr.Operation{
+		SourceAccount: &source,
+		Body: xdr.OperationBody{
+			Type: xdr.OperationType(20000),
+		},
+	}
+	operation := transactionOperationWrapper{
+		index: 0,
+		transaction: ingest.LedgerTransaction{
+			Meta: xdr.TransactionMeta{
+				V:  2,
+				V2: &xdr.TransactionMetaV2{},
+			},
+		},
+		operation:      op,
+		ledgerSequence: 1,
+	}
+	// calling Details should panic with unknown operation type
+	f := func() {
+		operation.Details()
+	}
+	assert.PanicsWithError(t, "Unknown operation type: ", f)
+}

--- a/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
+++ b/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
@@ -1621,7 +1621,7 @@ func TestParticipantsCoversAllOperationTypes(t *testing.T) {
 		operation := transactionOperationWrapper{
 			index: 0,
 			transaction: ingest.LedgerTransaction{
-				Meta: xdr.TransactionMeta{
+				UnsafeMeta: xdr.TransactionMeta{
 					V:  2,
 					V2: &xdr.TransactionMetaV2{},
 				},
@@ -1654,7 +1654,7 @@ func TestParticipantsCoversAllOperationTypes(t *testing.T) {
 	operation := transactionOperationWrapper{
 		index: 0,
 		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
+			UnsafeMeta: xdr.TransactionMeta{
 				V:  2,
 				V2: &xdr.TransactionMetaV2{},
 			},
@@ -1679,7 +1679,7 @@ func TestDetailsCoversAllOperationTypes(t *testing.T) {
 		operation := transactionOperationWrapper{
 			index: 0,
 			transaction: ingest.LedgerTransaction{
-				Meta: xdr.TransactionMeta{
+				UnsafeMeta: xdr.TransactionMeta{
 					V:  2,
 					V2: &xdr.TransactionMetaV2{},
 				},
@@ -1714,7 +1714,7 @@ func TestDetailsCoversAllOperationTypes(t *testing.T) {
 	operation := transactionOperationWrapper{
 		index: 0,
 		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
+			UnsafeMeta: xdr.TransactionMeta{
 				V:  2,
 				V2: &xdr.TransactionMetaV2{},
 			},

--- a/services/horizon/internal/resourceadapter/operations_test.go
+++ b/services/horizon/internal/resourceadapter/operations_test.go
@@ -1,6 +1,7 @@
 package resourceadapter
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -11,6 +12,29 @@ import (
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestNewOperationAllTypesCovered(t *testing.T) {
+	for typ, s := range xdr.OperationTypeToStringMap {
+		row := history.Operation{
+			Type: xdr.OperationType(typ),
+		}
+		op, err := NewOperation(context.Background(), row, "foo", &history.Transaction{}, history.Ledger{})
+		assert.NoError(t, err, s)
+		// if we got a base type, the operation is not covered
+		if _, ok := op.(operations.Base); ok {
+			assert.Fail(t, s)
+		}
+	}
+
+	// make sure the check works for an unreasonable operation type
+	row := history.Operation{
+		Type: xdr.OperationType(200000),
+	}
+	op, err := NewOperation(context.Background(), row, "foo", &history.Transaction{}, history.Ledger{})
+	assert.NoError(t, err)
+	assert.IsType(t, op, operations.Base{})
+
+}
 
 // TestPopulateOperation_Successful tests operation object population.
 func TestPopulateOperation_Successful(t *testing.T) {

--- a/xdr/main.go
+++ b/xdr/main.go
@@ -23,6 +23,8 @@ type Keyer interface {
 var _ = LedgerEntry{}
 var _ = LedgerKey{}
 
+var OperationTypeToStringMap = operationTypeMap
+
 func Uint32Ptr(val uint32) *Uint32 {
 	pval := Uint32(val)
 	return &pval


### PR DESCRIPTION
Part of #3430

I incorporated new tests, which use `xdr`'s  `operationTypeMap` (now  exported `OperationTypeToStringMap`) to go over all possible operations, even when we incorporate new ones.

The idea is that, from now on, every time we add a new XDR operation (i.e. through a CAP), the developer gets guided on what needs to be modified based on the failing tests.

The tests I added can be considered finicky, but it's hard to do it generically in a robust way.
