### PR TITLE
services/horizon: Rename LedgerTransaction's Meta to UnsafeMeta

### DIFF
--- a/ingest/ledger_transaction_reader.go
+++ b/ingest/ledger_transaction_reader.go
@@ -102,7 +102,7 @@ func (reader *LedgerTransactionReader) storeTransactions(lcm xdr.LedgerCloseMeta
 			Index:      uint32(i + 1), // Transactions start at '1'
 			Envelope:   envelope,
 			Result:     result,
-			Meta:       lcm.V0.TxProcessing[i].TxApplyProcessing,
+			UnsafeMeta: lcm.V0.TxProcessing[i].TxApplyProcessing,
 			FeeChanges: lcm.V0.TxProcessing[i].FeeProcessing,
 		})
 	}

--- a/ingest/ledger_transaction_test.go
+++ b/ingest/ledger_transaction_test.go
@@ -45,7 +45,7 @@ func TestFeeMetaAndOperationsChangesSeparate(t *testing.T) {
 				},
 			},
 		},
-		Meta: xdr.TransactionMeta{
+		UnsafeMeta: xdr.TransactionMeta{
 			V: 1,
 			V1: &xdr.TransactionMetaV1{
 				Operations: []xdr.OperationMeta{
@@ -146,11 +146,11 @@ func TestFailedTransactionOperationChangesMeta(t *testing.T) {
 						},
 					},
 				},
-				Meta: tc.meta,
+				UnsafeMeta: tc.meta,
 			}
 
 			operationChanges, err := tx.GetOperationChanges(0)
-			if tx.Meta.V == 0 {
+			if tx.UnsafeMeta.V == 0 {
 				assert.Error(t, err)
 				assert.EqualError(t, err, "TransactionMeta.V=0 not supported")
 			} else {
@@ -162,7 +162,7 @@ func TestFailedTransactionOperationChangesMeta(t *testing.T) {
 }
 func TestMetaV2Order(t *testing.T) {
 	tx := LedgerTransaction{
-		Meta: xdr.TransactionMeta{
+		UnsafeMeta: xdr.TransactionMeta{
 			V: 2,
 			V2: &xdr.TransactionMetaV2{
 				TxChangesBefore: xdr.LedgerEntryChanges{
@@ -333,7 +333,7 @@ func TestMetaV2Order(t *testing.T) {
 
 func TestMetaV0(t *testing.T) {
 	tx := LedgerTransaction{
-		Meta: xdr.TransactionMeta{
+		UnsafeMeta: xdr.TransactionMeta{
 			V: 0,
 		}}
 
@@ -449,7 +449,7 @@ func TestChangeAccountChangedExceptSignersSignerChange(t *testing.T) {
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
 							Weight: 1,
 						},
@@ -464,7 +464,7 @@ func TestChangeAccountChangedExceptSignersSignerChange(t *testing.T) {
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
 							Weight: 2,
 						},
@@ -497,7 +497,7 @@ func TestChangeAccountChangedExceptSignersNoChanges(t *testing.T) {
 					HomeDomain:    "stellar.org",
 					Thresholds:    [4]byte{1, 1, 1, 1},
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
 							Weight: 1,
 						},
@@ -528,7 +528,7 @@ func TestChangeAccountChangedExceptSignersNoChanges(t *testing.T) {
 					HomeDomain:    "stellar.org",
 					Thresholds:    [4]byte{1, 1, 1, 1},
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
 							Weight: 1,
 						},
@@ -708,7 +708,7 @@ func TestChangeAccountSignersChangedSignerAdded(t *testing.T) {
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
 							Weight: 1,
 						},
@@ -731,7 +731,7 @@ func TestChangeAccountSignersChangedSignerRemoved(t *testing.T) {
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
 							Weight: 1,
 						},
@@ -764,7 +764,7 @@ func TestChangeAccountSignersChangedSignerWeightChanged(t *testing.T) {
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
 							Weight: 1,
 						},
@@ -779,7 +779,7 @@ func TestChangeAccountSignersChangedSignerWeightChanged(t *testing.T) {
 				Account: &xdr.AccountEntry{
 					AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 					Signers: []xdr.Signer{
-						xdr.Signer{
+						{
 							Key:    xdr.MustSigner("GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX"),
 							Weight: 2,
 						},

--- a/services/horizon/internal/db2/history/fee_bump_scenario.go
+++ b/services/horizon/internal/db2/history/fee_bump_scenario.go
@@ -57,7 +57,7 @@ func buildLedgerTransaction(t *testing.T, tx testTransaction) ingest.LedgerTrans
 		Envelope:   xdr.TransactionEnvelope{},
 		Result:     xdr.TransactionResultPair{},
 		FeeChanges: xdr.LedgerEntryChanges{},
-		Meta:       xdr.TransactionMeta{},
+		UnsafeMeta: xdr.TransactionMeta{},
 	}
 
 	tt := assert.New(t)
@@ -66,7 +66,7 @@ func buildLedgerTransaction(t *testing.T, tx testTransaction) ingest.LedgerTrans
 	tt.NoError(err)
 	err = xdr.SafeUnmarshalBase64(tx.resultXDR, &transaction.Result.Result)
 	tt.NoError(err)
-	err = xdr.SafeUnmarshalBase64(tx.metaXDR, &transaction.Meta)
+	err = xdr.SafeUnmarshalBase64(tx.metaXDR, &transaction.UnsafeMeta)
 	tt.NoError(err)
 	err = xdr.SafeUnmarshalBase64(tx.feeChangesXDR, &transaction.FeeChanges)
 	tt.NoError(err)

--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
@@ -236,7 +236,7 @@ func transactionToRow(transaction ingest.LedgerTransaction, sequence uint32) (Tr
 	if err != nil {
 		return TransactionWithoutLedger{}, err
 	}
-	metaBase64, err := xdr.MarshalBase64(transaction.Meta)
+	metaBase64, err := xdr.MarshalBase64(transaction.UnsafeMeta)
 	if err != nil {
 		return TransactionWithoutLedger{}, err
 	}

--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder_test.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder_test.go
@@ -75,7 +75,7 @@ func TestTransactionToMap_muxed(t *testing.T) {
 				},
 			},
 		},
-		Meta: xdr.TransactionMeta{
+		UnsafeMeta: xdr.TransactionMeta{
 			V:          1,
 			Operations: &[]xdr.OperationMeta{},
 			V1: &xdr.TransactionMetaV1{

--- a/services/horizon/internal/ingest/processors/claimable_balances_transaction_processor_test.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_transaction_processor_test.go
@@ -67,8 +67,8 @@ func (s *ClaimableBalancesTransactionProcessorTestSuiteLedger) testOperationInse
 	internalID := int64(1234)
 	txn := createTransaction(true, 1)
 	txn.Envelope.Operations()[0].Body = body
-	txn.Meta.V = 2
-	txn.Meta.V2.Operations = []xdr.OperationMeta{
+	txn.UnsafeMeta.V = 2
+	txn.UnsafeMeta.V2.Operations = []xdr.OperationMeta{
 		{Changes: xdr.LedgerEntryChanges{
 			{
 				Type: xdr.LedgerEntryChangeTypeLedgerEntryState,

--- a/services/horizon/internal/ingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/ingest/processors/effects_processor_test.go
@@ -1509,7 +1509,7 @@ func TestOperationEffects(t *testing.T) {
 func TestOperationEffectsSetOptionsSignersOrder(t *testing.T) {
 	tt := assert.New(t)
 	transaction := ingest.LedgerTransaction{
-		Meta: createTransactionMeta([]xdr.OperationMeta{
+		UnsafeMeta: createTransactionMeta([]xdr.OperationMeta{
 			{
 				Changes: []xdr.LedgerEntryChange{
 					// State
@@ -1640,7 +1640,7 @@ func TestOperationEffectsSetOptionsSignersOrder(t *testing.T) {
 func TestOperationEffectsSetOptionsSignersNoUpdated(t *testing.T) {
 	tt := assert.New(t)
 	transaction := ingest.LedgerTransaction{
-		Meta: createTransactionMeta([]xdr.OperationMeta{
+		UnsafeMeta: createTransactionMeta([]xdr.OperationMeta{
 			{
 				Changes: []xdr.LedgerEntryChange{
 					// State
@@ -1761,7 +1761,7 @@ func TestOperationRegressionAccountTrustItself(t *testing.T) {
 	// NOTE:  when an account trusts itself, the transaction is successful but
 	// no ledger entries are actually modified.
 	transaction := ingest.LedgerTransaction{
-		Meta: createTransactionMeta([]xdr.OperationMeta{}),
+		UnsafeMeta: createTransactionMeta([]xdr.OperationMeta{}),
 	}
 	transaction.Index = 1
 	transaction.Envelope.Type = xdr.EnvelopeTypeEnvelopeTypeTx
@@ -1813,7 +1813,7 @@ func TestOperationEffectsAllowTrustAuthorizedToMaintainLiabilities(t *testing.T)
 	operation := transactionOperationWrapper{
 		index: 0,
 		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
+			UnsafeMeta: xdr.TransactionMeta{
 				V:  2,
 				V2: &xdr.TransactionMetaV2{},
 			},
@@ -1874,7 +1874,7 @@ func TestOperationEffectsClawback(t *testing.T) {
 	operation := transactionOperationWrapper{
 		index: 0,
 		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
+			UnsafeMeta: xdr.TransactionMeta{
 				V:  2,
 				V2: &xdr.TransactionMetaV2{},
 			},
@@ -1934,7 +1934,7 @@ func TestOperationEffectsClawbackClaimableBalance(t *testing.T) {
 	operation := transactionOperationWrapper{
 		index: 0,
 		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
+			UnsafeMeta: xdr.TransactionMeta{
 				V:  2,
 				V2: &xdr.TransactionMetaV2{},
 			},
@@ -1983,7 +1983,7 @@ func TestOperationEffectsSetTrustLineFlags(t *testing.T) {
 	operation := transactionOperationWrapper{
 		index: 0,
 		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
+			UnsafeMeta: xdr.TransactionMeta{
 				V:  2,
 				V2: &xdr.TransactionMetaV2{},
 			},
@@ -2121,7 +2121,7 @@ func (s *CreateClaimableBalanceEffectsTestSuite) SetupTest() {
 			},
 		},
 		FeeChanges: xdr.LedgerEntryChanges{},
-		Meta: xdr.TransactionMeta{
+		UnsafeMeta: xdr.TransactionMeta{
 			V: 2,
 			V2: &xdr.TransactionMetaV2{
 				Operations: []xdr.OperationMeta{
@@ -2349,7 +2349,7 @@ func (s *ClaimClaimableBalanceEffectsTestSuite) SetupTest() {
 			},
 		},
 		FeeChanges: xdr.LedgerEntryChanges{},
-		Meta: xdr.TransactionMeta{
+		UnsafeMeta: xdr.TransactionMeta{
 			V: 2,
 			V2: &xdr.TransactionMetaV2{
 				Operations: []xdr.OperationMeta{

--- a/services/horizon/internal/ingest/processors/ledgers_processor_test.go
+++ b/services/horizon/internal/ingest/processors/ledgers_processor_test.go
@@ -68,7 +68,7 @@ func createTransaction(successful bool, numOps int) ingest.LedgerTransaction {
 				},
 			},
 		},
-		Meta: xdr.TransactionMeta{
+		UnsafeMeta: xdr.TransactionMeta{
 			V: 2,
 			V2: &xdr.TransactionMetaV2{
 				Operations: make([]xdr.OperationMeta, numOps, numOps),

--- a/services/horizon/internal/ingest/processors/participants_processor.go
+++ b/services/horizon/internal/ingest/processors/participants_processor.go
@@ -149,7 +149,7 @@ func participantsForTransaction(
 		participants = append(participants, transaction.Envelope.FeeBumpAccount().ToAccountId())
 	}
 
-	p, err := participantsForMeta(transaction.Meta)
+	p, err := participantsForMeta(transaction.UnsafeMeta)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/ingest/processors/participants_test.go
+++ b/services/horizon/internal/ingest/processors/participants_test.go
@@ -41,7 +41,7 @@ func TestParticipantsForTransaction(t *testing.T) {
 			Index:      1,
 			Envelope:   envelope,
 			FeeChanges: feeChanges,
-			Meta:       meta,
+			UnsafeMeta: meta,
 			Result: xdr.TransactionResultPair{
 				Result: xdr.TransactionResult{
 					Result: xdr.TransactionResultResult{

--- a/services/horizon/internal/ingest/processors/trades_processor_test.go
+++ b/services/horizon/internal/ingest/processors/trades_processor_test.go
@@ -440,7 +440,7 @@ func (s *TradeProcessorTestSuiteLedger) mockReadTradeTransactions(
 		},
 		Index:      1,
 		FeeChanges: []xdr.LedgerEntryChange{},
-		Meta: xdr.TransactionMeta{
+		UnsafeMeta: xdr.TransactionMeta{
 			V: 2,
 			V2: &xdr.TransactionMetaV2{
 				Operations: []xdr.OperationMeta{
@@ -453,7 +453,7 @@ func (s *TradeProcessorTestSuiteLedger) mockReadTradeTransactions(
 	}
 
 	for i, trade := range s.allTrades {
-		tx.Meta.V2.Operations = append(tx.Meta.V2.Operations, xdr.OperationMeta{
+		tx.UnsafeMeta.V2.Operations = append(tx.UnsafeMeta.V2.Operations, xdr.OperationMeta{
 			Changes: xdr.LedgerEntryChanges{
 				xdr.LedgerEntryChange{
 					Type: xdr.LedgerEntryChangeTypeLedgerEntryState,

--- a/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
+++ b/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
@@ -1042,7 +1042,7 @@ func TestTransactionOperationAllowTrustDetails(t *testing.T) {
 			operation := transactionOperationWrapper{
 				index: 0,
 				transaction: ingest.LedgerTransaction{
-					Meta: xdr.TransactionMeta{
+					UnsafeMeta: xdr.TransactionMeta{
 						V: 2,
 						V2: &xdr.TransactionMetaV2{
 							Operations: make([]xdr.OperationMeta, 1, 1),
@@ -1172,7 +1172,7 @@ func (s *CreateClaimableBalanceOpTestSuite) TestDetails() {
 			operation := transactionOperationWrapper{
 				index: 0,
 				transaction: ingest.LedgerTransaction{
-					Meta: xdr.TransactionMeta{
+					UnsafeMeta: xdr.TransactionMeta{
 						V: 2,
 						V2: &xdr.TransactionMetaV2{
 							Operations: make([]xdr.OperationMeta, 1, 1),
@@ -1218,7 +1218,7 @@ func (s *CreateClaimableBalanceOpTestSuite) TestParticipants() {
 		s.T().Run(tc.desc, func(t *testing.T) {
 			operation := transactionOperationWrapper{
 				index: 0,
-				transaction: ingest.LedgerTransaction{Meta: xdr.TransactionMeta{
+				transaction: ingest.LedgerTransaction{UnsafeMeta: xdr.TransactionMeta{
 					V: 2,
 					V2: &xdr.TransactionMetaV2{
 						Operations: make([]xdr.OperationMeta, 1, 1),
@@ -1269,7 +1269,7 @@ func (s *ClaimClaimableBalanceOpTestSuite) TestDetails() {
 	operation := transactionOperationWrapper{
 		index: 0,
 		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
+			UnsafeMeta: xdr.TransactionMeta{
 				V: 2,
 				V2: &xdr.TransactionMetaV2{
 					Operations: make([]xdr.OperationMeta, 1, 1),
@@ -1288,7 +1288,7 @@ func (s *ClaimClaimableBalanceOpTestSuite) TestParticipants() {
 	operation := transactionOperationWrapper{
 		index: 0,
 		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
+			UnsafeMeta: xdr.TransactionMeta{
 				V: 2,
 				V2: &xdr.TransactionMetaV2{
 					Operations: make([]xdr.OperationMeta, 1, 1),
@@ -1319,7 +1319,7 @@ func getSponsoredSandwichWrappers() []*transactionOperationWrapper {
 	const ledgerSeq = uint32(12345)
 	tx := createTransaction(true, 3)
 	tx.Index = 1
-	tx.Meta = xdr.TransactionMeta{
+	tx.UnsafeMeta = xdr.TransactionMeta{
 		V: 2,
 		V2: &xdr.TransactionMetaV2{
 			Operations: make([]xdr.OperationMeta, 3, 3),
@@ -1358,7 +1358,7 @@ func getSponsoredSandwichWrappers() []*transactionOperationWrapper {
 	}
 	sponsoreeMuxed := sponsoree.ToMuxedAccount()
 	tx.Envelope.Operations()[1].SourceAccount = &sponsoreeMuxed
-	tx.Meta.V2.Operations[1] = xdr.OperationMeta{Changes: []xdr.LedgerEntryChange{
+	tx.UnsafeMeta.V2.Operations[1] = xdr.OperationMeta{Changes: []xdr.LedgerEntryChange{
 		{
 			Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
 			Created: &xdr.LedgerEntry{
@@ -1485,7 +1485,7 @@ func (s *ClawbackTestSuite) TestDetails() {
 	operation := transactionOperationWrapper{
 		index: 0,
 		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
+			UnsafeMeta: xdr.TransactionMeta{
 				V: 2,
 				V2: &xdr.TransactionMetaV2{
 					Operations: make([]xdr.OperationMeta, 1, 1),
@@ -1504,7 +1504,7 @@ func (s *ClawbackTestSuite) TestParticipants() {
 	operation := transactionOperationWrapper{
 		index: 0,
 		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
+			UnsafeMeta: xdr.TransactionMeta{
 				V: 2,
 				V2: &xdr.TransactionMetaV2{
 					Operations: make([]xdr.OperationMeta, 1, 1),
@@ -1567,7 +1567,7 @@ func (s *SetTrustLineFlagsTestSuite) TestDetails() {
 	operation := transactionOperationWrapper{
 		index: 0,
 		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
+			UnsafeMeta: xdr.TransactionMeta{
 				V: 2,
 				V2: &xdr.TransactionMetaV2{
 					Operations: make([]xdr.OperationMeta, 1, 1),
@@ -1586,7 +1586,7 @@ func (s *SetTrustLineFlagsTestSuite) TestParticipants() {
 	operation := transactionOperationWrapper{
 		index: 0,
 		transaction: ingest.LedgerTransaction{
-			Meta: xdr.TransactionMeta{
+			UnsafeMeta: xdr.TransactionMeta{
 				V: 2,
 				V2: &xdr.TransactionMetaV2{
 					Operations: make([]xdr.OperationMeta, 1, 1),

--- a/services/horizon/internal/test/transactions/main.go
+++ b/services/horizon/internal/test/transactions/main.go
@@ -27,7 +27,7 @@ func BuildLedgerTransaction(t *testing.T, tx TestTransaction) ingest.LedgerTrans
 		Envelope:   xdr.TransactionEnvelope{},
 		Result:     xdr.TransactionResultPair{},
 		FeeChanges: xdr.LedgerEntryChanges{},
-		Meta:       xdr.TransactionMeta{},
+		UnsafeMeta: xdr.TransactionMeta{},
 	}
 
 	tt := assert.New(t)
@@ -36,7 +36,7 @@ func BuildLedgerTransaction(t *testing.T, tx TestTransaction) ingest.LedgerTrans
 	tt.NoError(err)
 	err = xdr.SafeUnmarshalBase64(tx.ResultXDR, &transaction.Result.Result)
 	tt.NoError(err)
-	err = xdr.SafeUnmarshalBase64(tx.MetaXDR, &transaction.Meta)
+	err = xdr.SafeUnmarshalBase64(tx.MetaXDR, &transaction.UnsafeMeta)
 	tt.NoError(err)
 	err = xdr.SafeUnmarshalBase64(tx.FeeChangesXDR, &transaction.FeeChanges)
 	tt.NoError(err)


### PR DESCRIPTION
Fixes #3491 

Alternative to #3555
