### PR TITLE
services/horizon: add option to submit without waiting for transaction final state

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -5,6 +5,7 @@ package horizon
 import (
 	"encoding/base64"
 	"encoding/json"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -471,6 +472,23 @@ type Transaction struct {
 	ValidBefore        string              `json:"valid_before,omitempty"`
 	FeeBumpTransaction *FeeBumpTransaction `json:"fee_bump_transaction,omitempty"`
 	InnerTransaction   *InnerTransaction   `json:"inner_transaction,omitempty"`
+}
+
+// PendingTransaction represents a pending transaction submitted asynchronously.
+type PendingTransaction struct {
+	Links struct {
+		Self hal.Link `json:"self"`
+	} `json:"_links"`
+	ID      string `json:"id"`
+	Hash    string `json:"hash"`
+	Pending bool   `json:"pending"`
+}
+
+// StatusCode returns the status code returned for the pending transaction,
+// which is always 202 Accepted, to indicate that the request has been accepted
+// but not processed.
+func (pt PendingTransaction) StatusCode() int {
+	return http.StatusAccepted
 }
 
 // FeeBumpTransaction contains information about a fee bump transaction

--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -146,6 +146,28 @@ func getString(r *http.Request, name string) (string, error) {
 	return value, nil
 }
 
+// getBool retrieves a bool value from the action parameter of the given name.
+// The default value is used if the parameter is not set in the request.
+// Populates err if the value is not a valid bool and the zero value for bool is
+// returned.
+func getBool(r *http.Request, name string, def bool) (bool, error) {
+	str, err := getString(r, name)
+	if err != nil {
+		return false, err
+	}
+
+	if str == "" {
+		return def, nil
+	}
+
+	asBool, err := strconv.ParseBool(str)
+	if err != nil {
+		return false, problem.MakeInvalidFieldProblem(name, errors.New("unparseable value"))
+	}
+
+	return asBool, nil
+}
+
 // getLimit retrieves a uint64 limit from the action parameter of the given
 // name. Populates err if the value is not a valid limit.  Uses the provided
 // default value if the limit parameter is a blank string.

--- a/services/horizon/internal/httpx/handler.go
+++ b/services/horizon/internal/httpx/handler.go
@@ -41,8 +41,16 @@ func (handler ObjectActionHandler) ServeHTTP(
 			return
 		}
 
-		httpjson.Render(
+		// If the response provides a StatusCode() function use the status code
+		// returned by it, otherwise assume 200 status OK.
+		status := http.StatusOK
+		if statusCoder, ok := response.(interface{ StatusCode() int }); ok {
+			status = statusCoder.StatusCode()
+		}
+
+		httpjson.RenderStatus(
 			w,
+			status,
 			response,
 			httpjson.HALJSON,
 		)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add option to submit without waiting for transaction final state. Transactions submitted with the additional parameter `async=true` are submitted directly to the submitter (stellar-core) and a pending transaction response is returned with a HTTP status code 202 Accepted.

### Why

Applications do not always want to keep a http connection open for ~5 seconds to find out the final state of the submitted transaction. In some cases applications would prefer to submit and lookup the transaction later to see if it was successful, failed, or just not included.

Technically if an application was to cover all edge cases it would need to support that later lookup anyway, because it is possible for the Horizon to timeout, or the connection to be interrupted. It's also always possible for a submitted transaction to be scooped up by some other party if the transaction has been broadcasted or shared, and for that other party to resubmit the transaction during its time bound window of validity, even if Horizon fails the transaction immediately on the initial submit.

For applications that implement these edge cases already, submitting without waiting may be attractive.

### Known limitations

This PR includes no tests for the new behavior of the endpoint. I've been working on a test, but it's a work-in-progress, and I'm learning a bit about how action tests work so it's taking me a bit longer.
