### PR TITLE
Move recoverysigner docker image to 20.04 base

### DIFF
--- a/exp/services/recoverysigner/docker/Dockerfile
+++ b/exp/services/recoverysigner/docker/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /src/recoverysigner
 RUN go build -o /bin/recoverysigner ./exp/services/recoverysigner
 
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 COPY --from=build /bin/recoverysigner /app/


### PR DESCRIPTION
### What

Move recoverysigner docker image to 20.04 base

### Why

We're moving other images to 20.04 so this change improves consistency.
