### PR TITLE
services/horizon: Add 1s timeout to horizon.App.Tick

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -88,13 +88,15 @@ func (a *App) GetCoreSettings() actions.CoreSettings {
 	return a.coreSettings.get()
 }
 
+const tickerDuration = 1 * time.Second
+
 // NewApp constructs an new App instance from the provided config.
 func NewApp(config Config) (*App, error) {
 	a := &App{
 		config:         config,
 		ledgerState:    &ledger.State{},
 		horizonVersion: app.Version(),
-		ticks:          time.NewTicker(1 * time.Second),
+		ticks:          time.NewTicker(tickerDuration),
 		done:           make(chan struct{}),
 	}
 
@@ -402,22 +404,24 @@ func (a *App) DeleteUnretainedHistory(ctx context.Context) error {
 
 // Tick triggers horizon to update all of it's background processes such as
 // transaction submission, metrics, ingestion and reaping.
-func (a *App) Tick() {
+func (a *App) Tick(ctx context.Context) error {
 	var wg sync.WaitGroup
 	log.Debug("ticking app")
+
 	// update ledger state, operation fee state, and stellar-core info in parallel
 	wg.Add(3)
-	go func() { a.UpdateLedgerState(a.ctx); wg.Done() }()
-	go func() { a.UpdateFeeStatsState(a.ctx); wg.Done() }()
-	go func() { a.UpdateStellarCoreInfo(a.ctx); wg.Done() }()
+	go func() { a.UpdateLedgerState(ctx); wg.Done() }()
+	go func() { a.UpdateFeeStatsState(ctx); wg.Done() }()
+	go func() { a.UpdateStellarCoreInfo(ctx); wg.Done() }()
 	wg.Wait()
 
 	wg.Add(2)
-	go func() { a.reaper.Tick(a.ctx); wg.Done() }()
-	go func() { a.submitter.Tick(a.ctx); wg.Done() }()
+	go func() { a.reaper.Tick(ctx); wg.Done() }()
+	go func() { a.submitter.Tick(ctx); wg.Done() }()
 	wg.Wait()
 
 	log.Debug("finished ticking app")
+	return ctx.Err()
 }
 
 // Init initializes app, using the config to populate db connections and
@@ -530,7 +534,12 @@ func (a *App) run() {
 	for {
 		select {
 		case <-a.ticks.C:
-			a.Tick()
+			ctx, cancel := context.WithTimeout(a.ctx, tickerDuration)
+			err := a.Tick(ctx)
+			if err != nil {
+				log.Warnf("error ticking app: %s", err)
+			}
+			cancel() // Release timer
 		case <-a.ctx.Done():
 			log.Info("finished background ticker")
 			return

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -88,7 +88,8 @@ func (a *App) GetCoreSettings() actions.CoreSettings {
 	return a.coreSettings.get()
 }
 
-const tickerDuration = 1 * time.Second
+const tickerMaxFrequency = 1 * time.Second
+const tickerMaxDuration = 10 * time.Second
 
 // NewApp constructs an new App instance from the provided config.
 func NewApp(config Config) (*App, error) {
@@ -96,7 +97,7 @@ func NewApp(config Config) (*App, error) {
 		config:         config,
 		ledgerState:    &ledger.State{},
 		horizonVersion: app.Version(),
-		ticks:          time.NewTicker(tickerDuration),
+		ticks:          time.NewTicker(tickerMaxFrequency),
 		done:           make(chan struct{}),
 	}
 
@@ -534,7 +535,7 @@ func (a *App) run() {
 	for {
 		select {
 		case <-a.ticks.C:
-			ctx, cancel := context.WithTimeout(a.ctx, tickerDuration)
+			ctx, cancel := context.WithTimeout(a.ctx, tickerMaxDuration)
 			err := a.Tick(ctx)
 			if err != nil {
 				log.Warnf("error ticking app: %s", err)

--- a/services/horizon/internal/app_test.go
+++ b/services/horizon/internal/app_test.go
@@ -1,6 +1,7 @@
 package horizon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -36,6 +37,7 @@ func TestGenericHTTPFeatures(t *testing.T) {
 	w = ht.Get("/ledgers/")
 	ht.Assert.Equal(200, w.Code)
 }
+
 func TestMetrics(t *testing.T) {
 	ht := StartHTTPTest(t, "base")
 	defer ht.Finish()
@@ -53,6 +55,17 @@ func TestMetrics(t *testing.T) {
 	ht.Require.Less(float64(1000), getMetricValue(hlc).GetGauge().GetValue())
 	ht.Require.EqualValues(1, getMetricValue(he).GetCounter().GetValue())
 	ht.Require.EqualValues(64, getMetricValue(cl).GetCounter().GetValue())
+}
+
+func TestTick(t *testing.T) {
+	ht := StartHTTPTest(t, "base")
+	defer ht.Finish()
+
+	// Just sanity-check that we return the context error...
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := ht.App.Tick(ctx)
+	ht.Assert.EqualError(err, context.Canceled.Error())
 }
 
 func getMetricValue(metric prometheus.Metric) *dto.Metric {


### PR DESCRIPTION
Fixes #3344

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add 1s timeout to total runtime of `horizon.App.Tick`.

### Why

See https://github.com/stellar/go/issues/3344

### Known limitations

Just a single timeout, not per-item. But that seems to make sense given we want them all to complete within 1s total.
