### PR TITLE
Switch to ubuntu 20.04 base image

### DIFF
--- a/services/ticker/Makefile
+++ b/services/ticker/Makefile
@@ -3,14 +3,17 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 
 # If TAG is not provided set default value
 TAG ?= stellar/ticker:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
 
 docker-build:
 	cd ../../ && \
-	$(SUDO) docker build -f services/ticker/docker/Dockerfile -t $(TAG) .
+	$(SUDO) docker build --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	-f services/ticker/docker/Dockerfile -t $(TAG) .
 
 docker-push:
 	cd ../../ && \
 	$(SUDO) docker push $(TAG)
 
 docker-build-dev:
-	$(SUDO) docker build -f docker/Dockerfile-dev -t $(TAG) .
+	$(SUDO) docker build --pull -f docker/Dockerfile-dev -t $(TAG) .

--- a/services/ticker/docker/Dockerfile
+++ b/services/ticker/docker/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /src/ticker
 RUN go build -o /bin/ticker ./services/ticker
 
 
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates
 COPY --from=build /bin/ticker /app/
 EXPOSE 8000
 ENTRYPOINT ["/app/ticker"]


### PR DESCRIPTION
### What

* switch to ubuntu 20.04 base image
* add --pull to the Makefile to ensure we always use latest images
* add image.created label

### Why

Ubuntu 16.04 is nearly EOL. Other changes improve consistency