### PR TITLE
services/horizon: Add middleware for checking read-replica lag

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -56,6 +56,7 @@ type App struct {
 	config          Config
 	webServer       *httpx.Server
 	historyQ        *history.Q
+	primaryHistoryQ *history.Q
 	ctx             context.Context
 	cancel          func()
 	horizonVersion  string
@@ -500,6 +501,10 @@ func (a *App) init() error {
 			},
 			cache: newHealthCache(healthCacheTTL),
 		},
+	}
+
+	if a.primaryHistoryQ != nil {
+		routerConfig.PrimaryDBSession = a.primaryHistoryQ.Session
 	}
 
 	var err error

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -12,6 +12,7 @@ import (
 // app's main function and is provided to NewApp.
 type Config struct {
 	DatabaseURL        string
+	RoDatabaseURL      string
 	HistoryArchiveURLs []string
 	Port               uint
 	AdminPort          uint

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -94,6 +94,13 @@ func Flags() (*Config, support.ConfigOptions) {
 			Usage:     "horizon postgres database to connect with",
 		},
 		&support.ConfigOption{
+			Name:      "ro-database-url",
+			ConfigKey: &config.RoDatabaseURL,
+			OptType:   types.String,
+			Required:  false,
+			Usage:     "horizon postgres read-replica to connect with, when set it will return stale history error when replica is behind primary",
+		},
+		&support.ConfigOption{
 			Name:        StellarCoreBinaryPathName,
 			OptType:     types.String,
 			FlagDefault: "",

--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -354,3 +354,51 @@ func (m *StateMiddleware) WrapFunc(h http.HandlerFunc) http.HandlerFunc {
 func (m *StateMiddleware) Wrap(h http.Handler) http.Handler {
 	return m.WrapFunc(h.ServeHTTP)
 }
+
+type ReplicaSyncCheckMiddleware struct {
+	PrimaryHistoryQ *history.Q
+	ReplicaHistoryQ *history.Q
+	ServerMetrics   *ServerMetrics
+}
+
+// WrapFunc executes the middleware on a given HTTP handler function
+func (m *ReplicaSyncCheckMiddleware) WrapFunc(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		for attempt := 1; attempt <= 4; attempt++ {
+			primaryIngestLedger, err := m.PrimaryHistoryQ.GetLastLedgerIngestNonBlocking()
+			if err != nil {
+				problem.Render(r.Context(), w, err)
+				return
+			}
+
+			replicaIngestLedger, err := m.ReplicaHistoryQ.GetLastLedgerIngestNonBlocking()
+			if err != nil {
+				problem.Render(r.Context(), w, err)
+				return
+			}
+
+			if replicaIngestLedger >= primaryIngestLedger {
+				break
+			}
+
+			switch attempt {
+			case 1:
+				time.Sleep(20 * time.Millisecond)
+			case 2:
+				time.Sleep(40 * time.Millisecond)
+			case 3:
+				time.Sleep(80 * time.Millisecond)
+			case 4:
+				problem.Render(r.Context(), w, hProblem.StaleHistory)
+				m.ServerMetrics.ReplicaLagErrorsCounter.Inc()
+				return
+			}
+		}
+
+		h.ServeHTTP(w, r)
+	}
+}
+
+func (m *ReplicaSyncCheckMiddleware) Wrap(h http.Handler) http.Handler {
+	return m.WrapFunc(h.ServeHTTP)
+}

--- a/services/horizon/internal/httpx/server.go
+++ b/services/horizon/internal/httpx/server.go
@@ -22,7 +22,8 @@ import (
 )
 
 type ServerMetrics struct {
-	RequestDurationSummary *prometheus.SummaryVec
+	RequestDurationSummary  *prometheus.SummaryVec
+	ReplicaLagErrorsCounter prometheus.Counter
 }
 
 type TLSConfig struct {
@@ -66,6 +67,12 @@ func NewServer(serverConfig ServerConfig, routerConfig RouterConfig, ledgerState
 				Help: "HTTP requests durations, sliding window = 10m",
 			},
 			[]string{"status", "route", "streaming", "method"},
+		),
+		ReplicaLagErrorsCounter: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: "horizon", Subsystem: "http", Name: "replica_lag_errors_count",
+				Help: "Count of HTTP errors returned due to replica lag",
+			},
 		),
 	}
 	router, err := NewRouter(&routerConfig, sm, ledgerState)

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -43,11 +43,26 @@ func mustInitHorizonDB(app *App) {
 		}
 	}
 
-	app.historyQ = &history.Q{mustNewDBSession(
-		app.config.DatabaseURL,
-		maxIdle,
-		maxOpen,
-	)}
+	if app.config.RoDatabaseURL == "" {
+		app.historyQ = &history.Q{mustNewDBSession(
+			app.config.DatabaseURL,
+			maxIdle,
+			maxOpen,
+		)}
+	} else {
+		// If RO set, use it for all DB queries
+		app.historyQ = &history.Q{mustNewDBSession(
+			app.config.RoDatabaseURL,
+			maxIdle,
+			maxOpen,
+		)}
+
+		app.primaryHistoryQ = &history.Q{mustNewDBSession(
+			app.config.DatabaseURL,
+			maxIdle,
+			maxOpen,
+		)}
+	}
 }
 
 func initIngester(app *App) {
@@ -296,6 +311,7 @@ func initTxSubMetrics(app *App) {
 
 func initWebMetrics(app *App) {
 	app.prometheusRegistry.MustRegister(app.webServer.Metrics.RequestDurationSummary)
+	app.prometheusRegistry.MustRegister(app.webServer.Metrics.ReplicaLagErrorsCounter)
 }
 
 func initSubmissionSystem(app *App) {

--- a/services/horizon/internal/render/problem/problem.go
+++ b/services/horizon/internal/render/problem/problem.go
@@ -100,8 +100,8 @@ var (
 		Status: http.StatusServiceUnavailable,
 		Detail: "This horizon instance is configured to reject client requests " +
 			"when it can determine that the history database is lagging too far " +
-			"behind the connected instance of stellar-core.  If you operate this " +
-			"server, please ensure that the ingestion system is properly running.",
+			"behind the connected instance of stellar-core or read replica. Please " +
+			"try again later.",
 	}
 
 	// StillIngesting is a well-known problem type.  Use it as a shortcut


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

* Adds a new `RO_DATABASE_URL` that allows setting a connection to a read-replica DB.
* When the flag is set:
  * A new middleware checking if the read-replica is behind a primary DB will be enabled. If such check fails three times, the `stale_history` error will be returned. The middleware will sleep 20ms and 40ms on the first and second failure.
  * All DB queries will be sent to read-replica (except the one that checks the primary sequence number in the middleware above).
* Adds a new `horizon_http_replica_lag_errors_count` metric to be able to track number of error responses due to replica lag.

### Why

Horizon should provide clients with strongly consistent responses when using read-replicas. Specifically, for consecutive HTTP requests: A and B, response for B must always return data at ledger sequence higher or equal to the response for A.

### Known limitations

In case of a higher replica lag, the middleware may increase HTTP error rate.