### PR TITLE
services/horizon: Apply and check migrations on ingesting instances only

### DIFF
--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -74,9 +74,6 @@ type Config struct {
 	// ApplyMigrations will apply pending migrations to the horizon database
 	// before starting the horizon service
 	ApplyMigrations bool
-	// SkipMigrationsCheck will skip checking if there are any migrations
-	// required
-	SkipMigrationsCheck bool
 	// CheckpointFrequency establishes how many ledgers exist between checkpoints
 	CheckpointFrequency uint32
 	// BehindCloudflare determines if Horizon instance is behind Cloudflare. In


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit reverts https://github.com/stellar/go/commit/7c92b23f34181a00a510914d80fc458372aa13b0 and changes the DB migrations behaviour to only trigger on ingesting instances.

### Why

When checking if there are any migrations required Horizon calls `migrate.PlanMigration` which sends `CREATE TABLE gorp_migrations`. This write query is forbidden when using read only database (like replica).

The new flag in https://github.com/stellar/go/commit/7c92b23f34181a00a510914d80fc458372aa13b0 added unnecessary complexity. Ingesting instances are guaranteed to have write access to a DB.

Thanks @jacekn for the idea!

### Known limitations

[TODO or N/A]
