### PR TITLE
`services/regulated-assets-approval-server/internal/db`: add a database support to the sep8 regulated assets server

### DIFF
--- a/services/regulated-assets-approval-server/README.md
+++ b/services/regulated-assets-approval-server/README.md
@@ -24,9 +24,24 @@ Usage:
   regulated-assets-approval-server [command]
 
 Available Commands:
+  migrate     Run migrations on the database
   serve       Serve the SEP-8 Approval Server
 
 Use "regulated-assets-approval-server [command] --help" for more information about a command.
+```
+
+### Usage: Migrate
+
+```sh
+$ go install
+$ regulated-assets-approval-server migrate --help
+Run migrations on the database
+
+Usage:
+  regulated-assets-approval-server migrate [up|down] [count] [flags]
+
+Flags:
+      --database-url string   Database URL (DATABASE_URL) (default "postgres://localhost:5432/sep8_regulated_assets?sslmode=disable")
 ```
 
 ### Usage: Serve

--- a/services/regulated-assets-approval-server/README.md
+++ b/services/regulated-assets-approval-server/README.md
@@ -56,7 +56,7 @@ Usage:
 
 Flags:
       --asset-code string              The code of the regulated asset (ASSET_CODE)
-      --database-url string            Database URL (DATABASE_URL) (default "postgres://localhost:5432/ppdemo?sslmode=disable")
+      --database-url string            Database URL (DATABASE_URL) (default "postgres://localhost:5432/sep8_regulated_assets?sslmode=disable")
       --friendbot-payment-amount int   The amount of regulated assets the friendbot will be distributing (FRIENDBOT_PAYMENT_AMOUNT) (default 10000)
       --horizon-url string             Horizon URL used for looking up account details (HORIZON_URL) (default "https://horizon-testnet.stellar.org/")
       --issuer-account-secret string   Secret key of the asset issuer's stellar account. (ISSUER_ACCOUNT_SECRET)

--- a/services/regulated-assets-approval-server/README.md
+++ b/services/regulated-assets-approval-server/README.md
@@ -41,7 +41,7 @@ Usage:
   regulated-assets-approval-server migrate [up|down] [count] [flags]
 
 Flags:
-      --database-url string   Database URL (DATABASE_URL) (default "postgres://localhost:5432/sep8_regulated_assets?sslmode=disable")
+      --database-url string   Database URL (DATABASE_URL) (default "postgres://localhost:5432/?sslmode=disable")
 ```
 
 ### Usage: Serve
@@ -56,7 +56,7 @@ Usage:
 
 Flags:
       --asset-code string              The code of the regulated asset (ASSET_CODE)
-      --database-url string            Database URL (DATABASE_URL) (default "postgres://localhost:5432/sep8_regulated_assets?sslmode=disable")
+      --database-url string            Database URL (DATABASE_URL) (default "postgres://localhost:5432/?sslmode=disable")
       --friendbot-payment-amount int   The amount of regulated assets the friendbot will be distributing (FRIENDBOT_PAYMENT_AMOUNT) (default 10000)
       --horizon-url string             Horizon URL used for looking up account details (HORIZON_URL) (default "https://horizon-testnet.stellar.org/")
       --issuer-account-secret string   Secret key of the asset issuer's stellar account. (ISSUER_ACCOUNT_SECRET)

--- a/services/regulated-assets-approval-server/README.md
+++ b/services/regulated-assets-approval-server/README.md
@@ -41,6 +41,7 @@ Usage:
 
 Flags:
       --asset-code string              The code of the regulated asset (ASSET_CODE)
+      --database-url string            Database URL (DATABASE_URL) (default "postgres://localhost:5432/ppdemo?sslmode=disable")
       --friendbot-payment-amount int   The amount of regulated assets the friendbot will be distributing (FRIENDBOT_PAYMENT_AMOUNT) (default 10000)
       --horizon-url string             Horizon URL used for looking up account details (HORIZON_URL) (default "https://horizon-testnet.stellar.org/")
       --issuer-account-secret string   Secret key of the asset issuer's stellar account. (ISSUER_ACCOUNT_SECRET)

--- a/services/regulated-assets-approval-server/cmd/migrate.go
+++ b/services/regulated-assets-approval-server/cmd/migrate.go
@@ -24,7 +24,7 @@ func (c *MigrateCommand) Command() *cobra.Command {
 			Usage:       "Database URL",
 			OptType:     types.String,
 			ConfigKey:   &c.DatabaseURL,
-			FlagDefault: "postgres://localhost:5432/sep8_regulated_assets?sslmode=disable",
+			FlagDefault: "postgres://localhost:5432/?sslmode=disable",
 			Required:    true,
 		},
 	}

--- a/services/regulated-assets-approval-server/cmd/migrate.go
+++ b/services/regulated-assets-approval-server/cmd/migrate.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"go/types"
+	"strconv"
+	"strings"
+
+	migrate "github.com/rubenv/sql-migrate"
+	"github.com/spf13/cobra"
+	"github.com/stellar/go/services/regulated-assets-approval-server/internal/db"
+	"github.com/stellar/go/services/regulated-assets-approval-server/internal/db/dbmigrate"
+	"github.com/stellar/go/support/config"
+	"github.com/stellar/go/support/log"
+)
+
+type MigrateCommand struct {
+	DatabaseURL string
+}
+
+func (c *MigrateCommand) Command() *cobra.Command {
+	configOpts := config.ConfigOptions{
+		{
+			Name:        "database-url",
+			Usage:       "Database URL",
+			OptType:     types.String,
+			ConfigKey:   &c.DatabaseURL,
+			FlagDefault: "postgres://localhost:5432/sep8_regulated_assets?sslmode=disable",
+			Required:    true,
+		},
+	}
+	cmd := &cobra.Command{
+		Use:   "migrate [up|down] [count]",
+		Short: "Run migrations on the database",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			configOpts.Require()
+			configOpts.SetValues()
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			c.Migrate(cmd, args)
+		},
+	}
+	configOpts.Init(cmd)
+
+	return cmd
+}
+
+func (c *MigrateCommand) Migrate(cmd *cobra.Command, args []string) {
+	db, err := db.Open(c.DatabaseURL)
+	if err != nil {
+		log.Errorf("Error opening database: %s", err.Error())
+		return
+	}
+
+	if len(args) < 1 {
+		cmd.Help()
+		return
+	}
+	dirStr := args[0]
+
+	var dir migrate.MigrationDirection
+	switch dirStr {
+	case "down":
+		dir = migrate.Down
+	case "up":
+		dir = migrate.Up
+	default:
+		log.Errorf("Invalid migration direction, must be 'up' or 'down'.")
+		return
+	}
+
+	var count int
+	if len(args) >= 2 {
+		count, err = strconv.Atoi(args[1])
+		if err != nil {
+			log.Errorf("Invalid migration count, must be a number.")
+			return
+		}
+		if count < 1 {
+			log.Errorf("Invalid migration count, must be a number greater than zero.")
+			return
+		}
+	}
+
+	migrations, err := dbmigrate.PlanMigration(db, dir, count)
+	if err != nil {
+		log.Errorf("Error planning migration: %s", err.Error())
+		return
+	}
+	if len(migrations) > 0 {
+		log.Infof("Migrations to apply %s: %s", dirStr, strings.Join(migrations, ", "))
+	}
+
+	n, err := dbmigrate.Migrate(db, dir, count)
+	if err != nil {
+		log.Errorf("Error applying migrations: %s", err.Error())
+		return
+	}
+	if n > 0 {
+		log.Infof("Successfully applied %d migrations %s.", n, dirStr)
+	} else {
+		log.Infof("No migrations applied %s.", dirStr)
+	}
+}

--- a/services/regulated-assets-approval-server/cmd/serve.go
+++ b/services/regulated-assets-approval-server/cmd/serve.go
@@ -34,7 +34,7 @@ func (c *ServeCommand) Command() *cobra.Command {
 			Usage:       "Database URL",
 			OptType:     types.String,
 			ConfigKey:   &opts.DatabaseURL,
-			FlagDefault: "postgres://localhost:5432/sep8_regulated_assets?sslmode=disable",
+			FlagDefault: "postgres://localhost:5432/?sslmode=disable",
 			Required:    true,
 		},
 		{

--- a/services/regulated-assets-approval-server/cmd/serve.go
+++ b/services/regulated-assets-approval-server/cmd/serve.go
@@ -30,6 +30,14 @@ func (c *ServeCommand) Command() *cobra.Command {
 			Required:  true,
 		},
 		{
+			Name:        "database-url",
+			Usage:       "Database URL",
+			OptType:     types.String,
+			ConfigKey:   &opts.DatabaseURL,
+			FlagDefault: "postgres://localhost:5432/sep8_regulated_assets?sslmode=disable",
+			Required:    true,
+		},
+		{
 			Name:        "friendbot-payment-amount",
 			Usage:       "The amount of regulated assets the friendbot will be distributing",
 			OptType:     types.Int,

--- a/services/regulated-assets-approval-server/internal/db/db.go
+++ b/services/regulated-assets-approval-server/internal/db/db.go
@@ -1,0 +1,9 @@
+package db
+
+import (
+	"github.com/jmoiron/sqlx"
+)
+
+func Open(dataSourceName string) (*sqlx.DB, error) {
+	return sqlx.Open("postgres", dataSourceName)
+}

--- a/services/regulated-assets-approval-server/internal/db/db_test.go
+++ b/services/regulated-assets-approval-server/internal/db/db_test.go
@@ -1,0 +1,30 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stellar/go/support/db/dbtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpen_openAndPingSucceeds(t *testing.T) {
+	db := dbtest.Postgres(t)
+
+	sqlxDB, err := Open(db.DSN)
+	require.NoError(t, err)
+	assert.Equal(t, "postgres", sqlxDB.DriverName())
+
+	err = sqlxDB.Ping()
+	require.NoError(t, err)
+}
+
+func TestOpen_openAndPingFails(t *testing.T) {
+	sqlxDB, err := Open("postgres://127.0.0.1:0")
+	require.NoError(t, err)
+	assert.Equal(t, "postgres", sqlxDB.DriverName())
+
+	err = sqlxDB.Ping()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dial tcp 127.0.0.1:0: connect:")
+}

--- a/services/regulated-assets-approval-server/internal/db/dbmigrate/dbmigrate.go
+++ b/services/regulated-assets-approval-server/internal/db/dbmigrate/dbmigrate.go
@@ -1,0 +1,31 @@
+package dbmigrate
+
+import (
+	"github.com/jmoiron/sqlx"
+	migrate "github.com/rubenv/sql-migrate"
+)
+
+var migrationSource = &migrate.FileMigrationSource{
+	Dir: "internal/db/dbmigrate/migrations",
+}
+
+// PlanMigration finds the migrations that would be applied if Migrate was to
+// be run now.
+func PlanMigration(db *sqlx.DB, dir migrate.MigrationDirection, count int) ([]string, error) {
+	migrations, _, err := migrate.PlanMigration(db.DB, db.DriverName(), migrationSource, dir, count)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(migrations))
+	for _, m := range migrations {
+		ids = append(ids, m.Id)
+	}
+	return ids, nil
+}
+
+// Migrate runs all the migrations to get the database to the state described
+// by the migration files in the direction specified. Count is the maximum
+// number of migrations to apply or rollback.
+func Migrate(db *sqlx.DB, dir migrate.MigrationDirection, count int) (int, error) {
+	return migrate.ExecMax(db.DB, db.DriverName(), migrationSource, dir, count)
+}

--- a/services/regulated-assets-approval-server/internal/db/dbmigrate/migrations/2021-05-05.0.initial.sql
+++ b/services/regulated-assets-approval-server/internal/db/dbmigrate/migrations/2021-05-05.0.initial.sql
@@ -1,0 +1,7 @@
+-- This migration file is intentionally empty and is a first starting point for
+-- our migrations before we yet have a schema.
+
+-- +migrate Up
+
+-- +migrate Down
+

--- a/services/regulated-assets-approval-server/internal/db/dbtest/dbtest.go
+++ b/services/regulated-assets-approval-server/internal/db/dbtest/dbtest.go
@@ -1,0 +1,34 @@
+package dbtest
+
+import (
+	"path"
+	"runtime"
+	"testing"
+
+	migrate "github.com/rubenv/sql-migrate"
+	"github.com/stellar/go/support/db/dbtest"
+)
+
+func Open(t *testing.T) *dbtest.DB {
+	db := dbtest.Postgres(t)
+
+	// Get the folder holding the migrations relative to this file. We cannot
+	// hardcode "../migrations" because Open is called from tests in multiple
+	// packages and tests are executed with the current working directory set
+	// to the package the test lives in.
+	_, filename, _, _ := runtime.Caller(0)
+	migrationsDir := path.Join(path.Dir(filename), "..", "dbmigrate", "migrations")
+
+	migrations := &migrate.FileMigrationSource{
+		Dir: migrationsDir,
+	}
+
+	conn := db.Open()
+	defer conn.Close()
+
+	_, err := migrate.Exec(conn.DB, "postgres", migrations, migrate.Up)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}

--- a/services/regulated-assets-approval-server/internal/db/dbtest/dbtest.go
+++ b/services/regulated-assets-approval-server/internal/db/dbtest/dbtest.go
@@ -13,9 +13,9 @@ func Open(t *testing.T) *dbtest.DB {
 	db := dbtest.Postgres(t)
 
 	// Get the folder holding the migrations relative to this file. We cannot
-	// hardcode "../migrations" because Open is called from tests in multiple
-	// packages and tests are executed with the current working directory set
-	// to the package the test lives in.
+	// hardcode "../dbmigrate/migrations" because Open is called from tests in
+	// multiple packages and tests are executed with the current working
+	// directory set to the package the test lives in.
 	_, filename, _, _ := runtime.Caller(0)
 	migrationsDir := path.Join(path.Dir(filename), "..", "dbmigrate", "migrations")
 

--- a/services/regulated-assets-approval-server/internal/db/dbtest/dbtest_test.go
+++ b/services/regulated-assets-approval-server/internal/db/dbtest/dbtest_test.go
@@ -1,0 +1,18 @@
+package dbtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpen(t *testing.T) {
+	db := Open(t)
+	session := db.Open()
+
+	count := 0
+	err := session.Get(&count, `SELECT COUNT(*) FROM gorp_migrations`)
+	require.NoError(t, err)
+	assert.Greater(t, count, 0)
+}

--- a/services/regulated-assets-approval-server/internal/serve/serve.go
+++ b/services/regulated-assets-approval-server/internal/serve/serve.go
@@ -18,6 +18,7 @@ import (
 type Options struct {
 	IssuerAccountSecret    string
 	AssetCode              string
+	DatabaseURL            string
 	FriendbotPaymentAmount int
 	HorizonURL             string
 	NetworkPassphrase      string

--- a/services/regulated-assets-approval-server/main.go
+++ b/services/regulated-assets-approval-server/main.go
@@ -19,6 +19,7 @@ func main() {
 		},
 	}
 
+	rootCmd.AddCommand((&cmd.MigrateCommand{}).Command())
 	rootCmd.AddCommand((&cmd.ServeCommand{}).Command())
 
 	err := rootCmd.Execute()


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add a database support to the sep8 regulated assets server.

### Why

To store the KYC statuses.

### Known limitations

N/A
