### PR TITLE
services/horizon: Add prometheus metrics to database queries

### DIFF
--- a/ingest/ledgerbackend/database_backend.go
+++ b/ingest/ledgerbackend/database_backend.go
@@ -40,7 +40,7 @@ func NewDatabaseBackend(dataSourceName, networkPassphrase string) (*DatabaseBack
 	return NewDatabaseBackendFromSession(session, networkPassphrase)
 }
 
-func NewDatabaseBackendFromSession(session *db.Session, networkPassphrase string) (*DatabaseBackend, error) {
+func NewDatabaseBackendFromSession(session db.SessionInterface, networkPassphrase string) (*DatabaseBackend, error) {
 	return &DatabaseBackend{
 		session:           session,
 		networkPassphrase: networkPassphrase,

--- a/ingest/ledgerbackend/ledger_hash_store.go
+++ b/ingest/ledgerbackend/ledger_hash_store.go
@@ -20,11 +20,11 @@ type TrustedLedgerHashStore interface {
 
 // HorizonDBLedgerHashStore is a TrustedLedgerHashStore which uses horizon's db to look up ledger hashes
 type HorizonDBLedgerHashStore struct {
-	session *db.Session
+	session db.SessionInterface
 }
 
 // NewHorizonDBLedgerHashStore constructs a new TrustedLedgerHashStore backed by the horizon db
-func NewHorizonDBLedgerHashStore(session *db.Session) TrustedLedgerHashStore {
+func NewHorizonDBLedgerHashStore(session db.SessionInterface) TrustedLedgerHashStore {
 	return HorizonDBLedgerHashStore{session: session}
 }
 

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,6 +6,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * Refactor `ingest/ledgerbackend/LedgerBackend.GetLedger` method to always block, removing `ingest/ledgerbackend/LedgerBackend.GetLedgerBlocking`. Adds a first `context.Context` param to most `LedgerBackend` methods.
+* Add more in-depth Prometheus metrics (count & duration) for db queries.
 
 ## v2.2.0
 

--- a/services/horizon/internal/actions/account_test.go
+++ b/services/horizon/internal/actions/account_test.go
@@ -339,7 +339,7 @@ func TestGetAccountsHandlerPageNoResults(t *testing.T) {
 				"signer": signer,
 			},
 			map[string]string{},
-			q.Session,
+			q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -375,7 +375,7 @@ func TestGetAccountsHandlerPageResultsBySigner(t *testing.T) {
 				"signer": signer,
 			},
 			map[string]string{},
-			q.Session,
+			q,
 		),
 	)
 
@@ -405,7 +405,7 @@ func TestGetAccountsHandlerPageResultsBySigner(t *testing.T) {
 				"cursor": accountOne,
 			},
 			map[string]string{},
-			q.Session,
+			q,
 		),
 	)
 
@@ -455,7 +455,7 @@ func TestGetAccountsHandlerPageResultsBySponsor(t *testing.T) {
 				"sponsor": sponsor.Address(),
 			},
 			map[string]string{},
-			q.Session,
+			q,
 		),
 	)
 
@@ -511,7 +511,7 @@ func TestGetAccountsHandlerPageResultsByAsset(t *testing.T) {
 			t,
 			params,
 			map[string]string{},
-			q.Session,
+			q,
 		),
 	)
 
@@ -529,7 +529,7 @@ func TestGetAccountsHandlerPageResultsByAsset(t *testing.T) {
 			t,
 			params,
 			map[string]string{},
-			q.Session,
+			q,
 		),
 	)
 
@@ -613,7 +613,7 @@ func TestGetAccountsHandlerInvalidParams(t *testing.T) {
 					t,
 					tc.params,
 					map[string]string{},
-					q.Session,
+					q,
 				),
 			)
 			tt.Assert.Error(err)

--- a/services/horizon/internal/actions/asset_test.go
+++ b/services/horizon/internal/actions/asset_test.go
@@ -407,7 +407,7 @@ func TestAssetStats(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			r := makeRequest(t, testCase.queryParams, map[string]string{}, q.Session)
+			r := makeRequest(t, testCase.queryParams, map[string]string{}, q)
 			results, err := handler.GetResourcePage(httptest.NewRecorder(), r)
 			assert.NoError(t, err)
 
@@ -450,7 +450,7 @@ func TestAssetStatsIssuerDoesNotExist(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(numChanged, int64(1))
 
-	r := makeRequest(t, map[string]string{}, map[string]string{}, q.Session)
+	r := makeRequest(t, map[string]string{}, map[string]string{}, q)
 	results, err := handler.GetResourcePage(httptest.NewRecorder(), r)
 	tt.Assert.NoError(err)
 

--- a/services/horizon/internal/actions/claimable_balance_test.go
+++ b/services/horizon/internal/actions/claimable_balance_test.go
@@ -67,7 +67,7 @@ func TestGetClaimableBalanceByID(t *testing.T) {
 		t,
 		map[string]string{},
 		map[string]string{"id": id},
-		q.Session,
+		q,
 	))
 	tt.Assert.NoError(err)
 
@@ -85,7 +85,7 @@ func TestGetClaimableBalanceByID(t *testing.T) {
 		t,
 		map[string]string{},
 		map[string]string{"id": id},
-		q.Session,
+		q,
 	))
 	tt.Assert.Error(err)
 	tt.Assert.True(q.NoRows(errors.Cause(err)))
@@ -95,7 +95,7 @@ func TestGetClaimableBalanceByID(t *testing.T) {
 		t,
 		map[string]string{},
 		map[string]string{"id": "0000001112122"},
-		q.Session,
+		q,
 	))
 	tt.Assert.Error(err)
 	p := err.(*problem.P)
@@ -108,7 +108,7 @@ func TestGetClaimableBalanceByID(t *testing.T) {
 		t,
 		map[string]string{},
 		map[string]string{"id": ""},
-		q.Session,
+		q,
 	))
 	tt.Assert.Error(err)
 	p = err.(*problem.P)
@@ -212,7 +212,7 @@ func TestGetClaimableBalances(t *testing.T) {
 		t,
 		map[string]string{},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 	tt.Assert.NoError(err)
 	tt.Assert.Len(response, 4)
@@ -230,7 +230,7 @@ func TestGetClaimableBalances(t *testing.T) {
 			"cursor": response[3].(protocol.ClaimableBalance).PagingToken(),
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 	tt.Assert.NoError(err)
 	tt.Assert.Len(response, 0)
@@ -240,7 +240,7 @@ func TestGetClaimableBalances(t *testing.T) {
 		t,
 		map[string]string{"limit": "2"},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 	tt.Assert.NoError(err)
 	tt.Assert.Len(response, 2)
@@ -259,7 +259,7 @@ func TestGetClaimableBalances(t *testing.T) {
 			"cursor": response[1].(protocol.ClaimableBalance).PagingToken(),
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 
 	tt.Assert.NoError(err)
@@ -281,7 +281,7 @@ func TestGetClaimableBalances(t *testing.T) {
 			"cursor": lastIngestedCursor,
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 
 	tt.Assert.NoError(err)
@@ -329,7 +329,7 @@ func TestGetClaimableBalances(t *testing.T) {
 		t,
 		map[string]string{},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 
 	tt.Assert.NoError(err)
@@ -342,7 +342,7 @@ func TestGetClaimableBalances(t *testing.T) {
 			"cursor": lastIngestedCursor,
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 
 	tt.Assert.NoError(err)
@@ -361,7 +361,7 @@ func TestGetClaimableBalances(t *testing.T) {
 			"cursor": response[1].(protocol.ClaimableBalance).PagingToken(),
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 
 	tt.Assert.NoError(err)
@@ -378,7 +378,7 @@ func TestGetClaimableBalances(t *testing.T) {
 			"cursor": response[0].(protocol.ClaimableBalance).PagingToken(),
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 
 	tt.Assert.NoError(err)
@@ -392,7 +392,7 @@ func TestGetClaimableBalances(t *testing.T) {
 			"order": "desc",
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 
 	tt.Assert.NoError(err)
@@ -414,7 +414,7 @@ func TestGetClaimableBalances(t *testing.T) {
 			"cursor": response[1].(protocol.ClaimableBalance).PagingToken(),
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 
 	tt.Assert.NoError(err)
@@ -431,7 +431,7 @@ func TestGetClaimableBalances(t *testing.T) {
 			"asset": native.StringCanonical(),
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 
 	tt.Assert.NoError(err)
@@ -450,7 +450,7 @@ func TestGetClaimableBalances(t *testing.T) {
 			"asset": usd.StringCanonical(),
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 
 	tt.Assert.NoError(err)
@@ -469,7 +469,7 @@ func TestGetClaimableBalances(t *testing.T) {
 			"asset": euro.StringCanonical(),
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 
 	tt.Assert.NoError(err)
@@ -488,7 +488,7 @@ func TestGetClaimableBalances(t *testing.T) {
 			"sponsor": "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 
 	tt.Assert.NoError(err)
@@ -507,7 +507,7 @@ func TestGetClaimableBalances(t *testing.T) {
 			"claimant": "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 
 	tt.Assert.NoError(err)
@@ -519,7 +519,7 @@ func TestGetClaimableBalances(t *testing.T) {
 			"claimant": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 
 	tt.Assert.NoError(err)
@@ -539,7 +539,7 @@ func TestCursorAndOrderValidation(t *testing.T) {
 			"cursor": "-1-00000043d380c38a2f2cac46ab63674064c56fdce6b977fdef1a278ad50e1a7e6a5e18",
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 	p := err.(*problem.P)
 	tt.Assert.Equal("bad_request", p.Type)
@@ -552,7 +552,7 @@ func TestCursorAndOrderValidation(t *testing.T) {
 			"cursor": "1003529-00000043d380c38a2f2cac46ab63674064c56fdce6b977fdef1a278ad50e1a7e6a5e18",
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 	p = err.(*problem.P)
 	tt.Assert.Equal("bad_request", p.Type)
@@ -566,7 +566,7 @@ func TestCursorAndOrderValidation(t *testing.T) {
 			"cursor": "1003529-00000043d380c38a2f2cac46ab63674064c56fdce6b977fdef1a278ad50e1a7e6a5e18",
 		},
 		map[string]string{},
-		q.Session,
+		q,
 	))
 	p = err.(*problem.P)
 	tt.Assert.Equal("bad_request", p.Type)

--- a/services/horizon/internal/actions/helpers_test.go
+++ b/services/horizon/internal/actions/helpers_test.go
@@ -508,7 +508,7 @@ func makeRequest(
 	t *testing.T,
 	queryParams map[string]string,
 	routeParams map[string]string,
-	session *db.Session,
+	session db.SessionInterface,
 ) *http.Request {
 	request, err := http.NewRequest("GET", "/", nil)
 	if err != nil {

--- a/services/horizon/internal/actions/offer_test.go
+++ b/services/horizon/internal/actions/offer_test.go
@@ -105,7 +105,7 @@ func TestGetOfferByIDHandler(t *testing.T) {
 		{
 			"offer id is invalid",
 			makeRequest(
-				t, map[string]string{}, map[string]string{"offer_id": "invalid"}, q.Session,
+				t, map[string]string{}, map[string]string{"offer_id": "invalid"}, q,
 			),
 			func(err error) {
 				tt.Assert.Error(err)
@@ -121,7 +121,7 @@ func TestGetOfferByIDHandler(t *testing.T) {
 		{
 			"offer does not exist",
 			makeRequest(
-				t, map[string]string{}, map[string]string{"offer_id": "1234567"}, q.Session,
+				t, map[string]string{}, map[string]string{"offer_id": "1234567"}, q,
 			),
 			func(err error) {
 				tt.Assert.Equal(err, sql.ErrNoRows)
@@ -133,7 +133,7 @@ func TestGetOfferByIDHandler(t *testing.T) {
 		{
 			"offer with ledger close time",
 			makeRequest(
-				t, map[string]string{}, map[string]string{"offer_id": "4"}, q.Session,
+				t, map[string]string{}, map[string]string{"offer_id": "4"}, q,
 			),
 			func(err error) {
 				tt.Assert.NoError(err)
@@ -153,7 +153,7 @@ func TestGetOfferByIDHandler(t *testing.T) {
 		{
 			"offer without ledger close time",
 			makeRequest(
-				t, map[string]string{}, map[string]string{"offer_id": "6"}, q.Session,
+				t, map[string]string{}, map[string]string{"offer_id": "6"}, q,
 			),
 			func(err error) {
 				tt.Assert.NoError(err)
@@ -213,7 +213,7 @@ func TestGetOffersHandler(t *testing.T) {
 		records, err := handler.GetResourcePage(
 			httptest.NewRecorder(),
 			makeRequest(
-				t, map[string]string{}, map[string]string{}, q.Session,
+				t, map[string]string{}, map[string]string{}, q,
 			),
 		)
 		tt.Assert.NoError(err)
@@ -239,7 +239,7 @@ func TestGetOffersHandler(t *testing.T) {
 					"seller": issuer.Address(),
 				},
 				map[string]string{},
-				q.Session,
+				q,
 			),
 		)
 		tt.Assert.NoError(err)
@@ -258,7 +258,7 @@ func TestGetOffersHandler(t *testing.T) {
 					"seller": "GCXEWJ6U4KPGTNTBY5HX4WQ2EEVPWV2QKXEYIQ32IDYIX",
 				},
 				map[string]string{},
-				q.Session,
+				q,
 			),
 		)
 		tt.Assert.Error(err)
@@ -281,7 +281,7 @@ func TestGetOffersHandler(t *testing.T) {
 					"sponsor": sponsor.Address(),
 				},
 				map[string]string{},
-				q.Session,
+				q,
 			),
 		)
 		tt.Assert.NoError(err)
@@ -298,7 +298,7 @@ func TestGetOffersHandler(t *testing.T) {
 					"sponsor": "GCXEWJ6U4KPGTNTBY5HX4WQ2EEVPWV2QKXEYIQ32IDYIX",
 				},
 				map[string]string{},
-				q.Session,
+				q,
 			),
 		)
 		tt.Assert.Error(err)
@@ -323,7 +323,7 @@ func TestGetOffersHandler(t *testing.T) {
 					"selling_asset_type": asset.Type,
 				},
 				map[string]string{},
-				q.Session,
+				q,
 			),
 		)
 		tt.Assert.NoError(err)
@@ -347,7 +347,7 @@ func TestGetOffersHandler(t *testing.T) {
 					"selling_asset_issuer": asset.Issuer,
 				},
 				map[string]string{},
-				q.Session,
+				q,
 			),
 		)
 		tt.Assert.NoError(err)
@@ -364,7 +364,7 @@ func TestGetOffersHandler(t *testing.T) {
 					"selling": asset.Code + ":" + asset.Issuer,
 				},
 				map[string]string{},
-				q.Session,
+				q,
 			),
 		)
 		tt.Assert.NoError(err)
@@ -388,7 +388,7 @@ func TestGetOffersHandler(t *testing.T) {
 					"buying_asset_issuer": asset.Issuer,
 				},
 				map[string]string{},
-				q.Session,
+				q,
 			),
 		)
 		tt.Assert.NoError(err)
@@ -412,7 +412,7 @@ func TestGetOffersHandler(t *testing.T) {
 					"buying_asset_issuer": asset.Issuer,
 				},
 				map[string]string{},
-				q.Session,
+				q,
 			),
 		)
 		tt.Assert.NoError(err)
@@ -431,7 +431,7 @@ func TestGetOffersHandler(t *testing.T) {
 					"buying": asset.Code + ":" + asset.Issuer,
 				},
 				map[string]string{},
-				q.Session,
+				q,
 			),
 		)
 		tt.Assert.NoError(err)
@@ -455,7 +455,7 @@ func TestGetOffersHandler(t *testing.T) {
 					"buying": `native\\u0026cursor=\\u0026limit=10\\u0026order=asc\\u0026selling=BTC:GAEDZ7BHMDYEMU6IJT3CTTGDUSLZWS5CQWZHGP4XUOIDG5ISH3AFAEK2`,
 				},
 				map[string]string{},
-				q.Session,
+				q,
 			),
 		)
 		tt.Assert.Error(err)
@@ -491,7 +491,7 @@ func TestGetAccountOffersHandler(t *testing.T) {
 			t,
 			map[string]string{},
 			map[string]string{"account_id": issuer.Address()},
-			q.Session,
+			q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -509,7 +509,7 @@ func TestGetAccountOffersHandler(t *testing.T) {
 			t,
 			map[string]string{},
 			map[string]string{},
-			q.Session,
+			q,
 		),
 	)
 	tt.Assert.Error(err)

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -27,7 +27,7 @@ func TestGetOperationsWithoutFilter(t *testing.T) {
 	records, err := handler.GetResourcePage(
 		httptest.NewRecorder(),
 		makeRequest(
-			t, map[string]string{}, map[string]string{}, q.Session,
+			t, map[string]string{}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -73,7 +73,7 @@ func TestGetOperationsExclusiveFilters(t *testing.T) {
 			_, err := handler.GetResourcePage(
 				httptest.NewRecorder(),
 				makeRequest(
-					t, tc.query, map[string]string{}, q.Session,
+					t, tc.query, map[string]string{}, q,
 				),
 			)
 			tt.Assert.IsType(&supportProblem.P{}, err)
@@ -121,7 +121,7 @@ func TestGetOperationsFilterByAccountID(t *testing.T) {
 				makeRequest(
 					t, map[string]string{
 						"account_id": tc.accountID,
-					}, map[string]string{}, q.Session,
+					}, map[string]string{}, q,
 				),
 			)
 			tt.Assert.NoError(err)
@@ -179,7 +179,7 @@ func TestGetOperationsFilterByTxID(t *testing.T) {
 				makeRequest(
 					t, map[string]string{
 						"tx_id": tc.transactionID,
-					}, map[string]string{}, q.Session,
+					}, map[string]string{}, q,
 				),
 			)
 
@@ -217,7 +217,7 @@ func TestGetOperationsIncludeFailed(t *testing.T) {
 		makeRequest(
 			t, map[string]string{
 				"limit": "200",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -243,7 +243,7 @@ func TestGetOperationsIncludeFailed(t *testing.T) {
 			t, map[string]string{
 				"include_failed": "true",
 				"limit":          "200",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -268,7 +268,7 @@ func TestGetOperationsIncludeFailed(t *testing.T) {
 		makeRequest(
 			t, map[string]string{
 				"tx_id": "aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -283,7 +283,7 @@ func TestGetOperationsIncludeFailed(t *testing.T) {
 		makeRequest(
 			t, map[string]string{
 				"tx_id": "56e3216045d579bea40f2d35a09406de3a894ecb5be70dbda5ec9c0427a0d5a1",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -305,7 +305,7 @@ func TestGetOperationsIncludeFailed(t *testing.T) {
 		makeRequest(
 			t, map[string]string{
 				"tx_id": "56e3216045d579bea40f2d35a09406de3a894ecb5be70dbda5ec9c0427a0d5a1",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -320,7 +320,7 @@ func TestGetOperationsIncludeFailed(t *testing.T) {
 		makeRequest(
 			t, map[string]string{
 				"include_failed": "foo",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.Error(err)
@@ -381,7 +381,7 @@ func TestGetOperationsFilterByLedgerID(t *testing.T) {
 				makeRequest(
 					t, map[string]string{
 						"ledger_id": tc.ledgerID,
-					}, map[string]string{}, q.Session,
+					}, map[string]string{}, q,
 				),
 			)
 			if tc.expectedErr == "" {
@@ -418,7 +418,7 @@ func TestGetOperationsOnlyPayments(t *testing.T) {
 	records, err := handler.GetResourcePage(
 		httptest.NewRecorder(),
 		makeRequest(
-			t, map[string]string{}, map[string]string{}, q.Session,
+			t, map[string]string{}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -429,7 +429,7 @@ func TestGetOperationsOnlyPayments(t *testing.T) {
 		makeRequest(
 			t, map[string]string{
 				"ledger_id": "1",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -440,7 +440,7 @@ func TestGetOperationsOnlyPayments(t *testing.T) {
 		makeRequest(
 			t, map[string]string{
 				"ledger_id": "3",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -451,7 +451,7 @@ func TestGetOperationsOnlyPayments(t *testing.T) {
 		makeRequest(
 			t, map[string]string{
 				"account_id": "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -464,7 +464,7 @@ func TestGetOperationsOnlyPayments(t *testing.T) {
 		makeRequest(
 			t, map[string]string{
 				"tx_id": "b52f16ffb98c047e33b9c2ec30880330cde71f85b3443dae2c5cb86c7d4d8452",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -475,7 +475,7 @@ func TestGetOperationsOnlyPayments(t *testing.T) {
 		makeRequest(
 			t, map[string]string{
 				"tx_id": "1d2a4be72470658f68db50eef29ea0af3f985ce18b5c218f03461d40c47dc292",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -498,7 +498,7 @@ func TestOperation_CreatedAt(t *testing.T) {
 		makeRequest(
 			t, map[string]string{
 				"ledger_id": "3",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -526,7 +526,7 @@ func TestGetOperationsPagination(t *testing.T) {
 			t, map[string]string{
 				"order": "asc",
 				"limit": "1",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -538,7 +538,7 @@ func TestGetOperationsPagination(t *testing.T) {
 			t, map[string]string{
 				"limit": "1",
 				"order": "desc",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -550,7 +550,7 @@ func TestGetOperationsPagination(t *testing.T) {
 			t, map[string]string{
 				"order":  "desc",
 				"cursor": "12884905985",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -562,7 +562,7 @@ func TestGetOperationsPagination(t *testing.T) {
 			t, map[string]string{
 				"order":  "desc",
 				"cursor": "0",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.Error(err)
@@ -582,7 +582,7 @@ func TestGetOperations_IncludeTransactions(t *testing.T) {
 		makeRequest(
 			t, map[string]string{
 				"join": "accounts",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.Error(err)
@@ -601,7 +601,7 @@ func TestGetOperations_IncludeTransactions(t *testing.T) {
 			t, map[string]string{
 				"join":  "transactions",
 				"limit": "1",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -615,7 +615,7 @@ func TestGetOperations_IncludeTransactions(t *testing.T) {
 		makeRequest(
 			t, map[string]string{
 				"limit": "1",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)

--- a/services/horizon/internal/actions/orderbook_test.go
+++ b/services/horizon/internal/actions/orderbook_test.go
@@ -659,7 +659,7 @@ func TestOrderbookGetResource(t *testing.T) {
 					"limit":               strconv.Itoa(testCase.limit),
 				},
 				map[string]string{},
-				q.Session,
+				q,
 			)
 			w := httptest.NewRecorder()
 			response, err := handler.GetResource(w, r)

--- a/services/horizon/internal/actions/transaction_test.go
+++ b/services/horizon/internal/actions/transaction_test.go
@@ -25,7 +25,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 			t, map[string]string{
 				"account_id":     "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 				"include_failed": "true",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -37,7 +37,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 			t, map[string]string{
 				"account_id":     "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
 				"include_failed": "true",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -49,7 +49,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 			t, map[string]string{
 				"account_id":     "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
 				"include_failed": "true",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -62,7 +62,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 			t, map[string]string{
 				"ledger_id":      "1",
 				"include_failed": "true",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -74,7 +74,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 			t, map[string]string{
 				"ledger_id":      "2",
 				"include_failed": "true",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -86,7 +86,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 			t, map[string]string{
 				"ledger_id":      "3",
 				"include_failed": "true",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -99,7 +99,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 				"account_id":     "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 				"ledger_id":      "3",
 				"include_failed": "true",
-			}, map[string]string{}, q.Session,
+			}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.IsType(&supportProblem.P{}, err)
@@ -159,7 +159,7 @@ func TestFeeBumpTransactionPage(t *testing.T) {
 	records, err := handler.GetResourcePage(
 		httptest.NewRecorder(),
 		makeRequest(
-			t, map[string]string{}, map[string]string{}, q.Session,
+			t, map[string]string{}, map[string]string{}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -185,7 +185,7 @@ func TestFeeBumpTransactionResource(t *testing.T) {
 		makeRequest(
 			t, map[string]string{}, map[string]string{
 				"tx_id": fixture.OuterHash,
-			}, q.Session,
+			}, q,
 		),
 	)
 	tt.Assert.NoError(err)
@@ -197,7 +197,7 @@ func TestFeeBumpTransactionResource(t *testing.T) {
 		makeRequest(
 			t, map[string]string{}, map[string]string{
 				"tx_id": fixture.InnerHash,
-			}, q.Session,
+			}, q,
 		),
 	)
 	tt.Assert.NoError(err)

--- a/services/horizon/internal/actions_operation_test.go
+++ b/services/horizon/internal/actions_operation_test.go
@@ -279,7 +279,7 @@ func TestOperation_CreatedAt(t *testing.T) {
 	ht.UnmarshalPage(w.Body, &records)
 
 	l := history.Ledger{}
-	hq := history.Q{Session: ht.HorizonSession()}
+	hq := history.Q{SessionInterface: ht.HorizonSession()}
 	ht.Require.NoError(hq.LedgerBySequence(ht.Ctx, &l, 3))
 
 	ht.Assert.WithinDuration(l.ClosedAt, records[0].LedgerCloseTime, 1*time.Second)

--- a/services/horizon/internal/actions_payment_test.go
+++ b/services/horizon/internal/actions_payment_test.go
@@ -240,7 +240,7 @@ func TestPayment_CreatedAt(t *testing.T) {
 	ht.UnmarshalPage(w.Body, &records)
 
 	l := history.Ledger{}
-	hq := history.Q{Session: ht.HorizonSession()}
+	hq := history.Q{SessionInterface: ht.HorizonSession()}
 	ht.Require.NoError(hq.LedgerBySequence(ht.Ctx, &l, 3))
 
 	ht.Assert.WithinDuration(l.ClosedAt, records[0].LedgerCloseTime, 1*time.Second)

--- a/services/horizon/internal/actions_trade_test.go
+++ b/services/horizon/internal/actions_trade_test.go
@@ -35,7 +35,7 @@ func TestTradeActions_Index(t *testing.T) {
 
 		// 	ensure created_at is populated correctly
 		l := history.Ledger{}
-		hq := history.Q{Session: ht.HorizonSession()}
+		hq := history.Q{SessionInterface: ht.HorizonSession()}
 		ht.Require.NoError(hq.LedgerBySequence(ht.Ctx, &l, 9))
 
 		ht.Assert.WithinDuration(l.ClosedAt, records[0].LedgerCloseTime, 1*time.Second)

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -78,8 +78,12 @@ type App struct {
 	dbMaxOpenConnectionsGauge         prometheus.GaugeFunc
 	dbOpenConnectionsGauge            prometheus.GaugeFunc
 	dbInUseConnectionsGauge           prometheus.GaugeFunc
+	dbIdleConnectionsGauge            prometheus.GaugeFunc
 	dbWaitCountCounter                prometheus.CounterFunc
 	dbWaitDurationCounter             prometheus.CounterFunc
+	dbMaxIdleClosedCounter            prometheus.CounterFunc
+	dbMaxIdleTimeClosedCounter        prometheus.CounterFunc
+	dbMaxLifetimeClosedCounter        prometheus.CounterFunc
 	coreLatestLedgerCounter           prometheus.CounterFunc
 	coreSynced                        prometheus.GaugeFunc
 }

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -75,15 +75,6 @@ type App struct {
 	historyLatestLedgerCounter        prometheus.CounterFunc
 	historyLatestLedgerClosedAgoGauge prometheus.GaugeFunc
 	historyElderLedgerCounter         prometheus.CounterFunc
-	dbMaxOpenConnectionsGauge         prometheus.GaugeFunc
-	dbOpenConnectionsGauge            prometheus.GaugeFunc
-	dbInUseConnectionsGauge           prometheus.GaugeFunc
-	dbIdleConnectionsGauge            prometheus.GaugeFunc
-	dbWaitCountCounter                prometheus.CounterFunc
-	dbWaitDurationCounter             prometheus.CounterFunc
-	dbMaxIdleClosedCounter            prometheus.CounterFunc
-	dbMaxIdleTimeClosedCounter        prometheus.CounterFunc
-	dbMaxLifetimeClosedCounter        prometheus.CounterFunc
 	coreLatestLedgerCounter           prometheus.CounterFunc
 	coreSynced                        prometheus.GaugeFunc
 }
@@ -186,7 +177,7 @@ func (a *App) waitForDone() {
 // sure all requests are first properly finished to avoid "sql: database is
 // closed" errors.
 func (a *App) CloseDB() {
-	a.historyQ.Session.DB.Close()
+	a.historyQ.SessionInterface.Close()
 }
 
 // HistoryQ returns a helper object for performing sql queries against the
@@ -202,8 +193,8 @@ func (a *App) Ingestion() ingest.System {
 
 // HorizonSession returns a new session that loads data from the horizon
 // database.
-func (a *App) HorizonSession() *db.Session {
-	return &db.Session{DB: a.historyQ.Session.DB}
+func (a *App) HorizonSession() db.SessionInterface {
+	return a.historyQ.SessionInterface.Clone()
 }
 
 // UpdateLedgerState triggers a refresh of several metrics gauges, such as open
@@ -485,7 +476,7 @@ func (a *App) init() error {
 	initTxSubMetrics(a)
 
 	routerConfig := httpx.RouterConfig{
-		DBSession:             a.historyQ.Session,
+		DBSession:             a.historyQ.SessionInterface,
 		TxSubmitter:           a.submitter,
 		RateQuota:             a.config.RateQuota,
 		BehindCloudflare:      a.config.BehindCloudflare,
@@ -501,7 +492,7 @@ func (a *App) init() error {
 		HorizonVersion:        a.horizonVersion,
 		FriendbotURL:          a.config.FriendbotURL,
 		HealthCheck: healthCheck{
-			session: a.historyQ.Session,
+			session: a.historyQ.SessionInterface,
 			ctx:     a.ctx,
 			core: &stellarcore.Client{
 				HTTP: &http.Client{Timeout: infoRequestTimeout},

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -436,6 +436,12 @@ func (a *App) init() error {
 	// loggly
 	initLogglyLog(a)
 
+	// metrics and log.metrics
+	a.prometheusRegistry = prometheus.NewRegistry()
+	for _, meter := range *logmetrics.DefaultMetrics {
+		a.prometheusRegistry.MustRegister(meter)
+	}
+
 	// stellarCoreInfo
 	a.UpdateStellarCoreInfo(a.ctx)
 
@@ -453,12 +459,6 @@ func (a *App) init() error {
 
 	// reaper
 	a.reaper = reap.New(a.config.HistoryRetentionCount, a.HorizonSession(), a.ledgerState)
-
-	// metrics and log.metrics
-	a.prometheusRegistry = prometheus.NewRegistry()
-	for _, meter := range *logmetrics.DefaultMetrics {
-		a.prometheusRegistry.MustRegister(meter)
-	}
 
 	// go metrics
 	initGoMetrics(a)

--- a/services/horizon/internal/context/context.go
+++ b/services/horizon/internal/context/context.go
@@ -55,7 +55,7 @@ func BaseURL(ctx context.Context) *url.URL {
 
 func HistoryQFromRequest(request *http.Request) (*history.Q, error) {
 	ctx := request.Context()
-	session, ok := ctx.Value(&SessionContextKey).(*db.Session)
+	session, ok := ctx.Value(&SessionContextKey).(db.SessionInterface)
 	if !ok {
 		return nil, errors.New("missing session in request context")
 	}

--- a/services/horizon/internal/db2/assets/asset_stat_test.go
+++ b/services/horizon/internal/db2/assets/asset_stat_test.go
@@ -92,7 +92,7 @@ func TestAssetsStatsQExec(t *testing.T) {
 			tt.Require.NoError(err)
 
 			var results []AssetStatsR
-			err = history.Q{Session: tt.HorizonSession()}.Select(context.Background(), &results, sql)
+			err = history.Q{SessionInterface: tt.HorizonSession()}.Select(context.Background(), &results, sql)
 			tt.Require.NoError(err)
 			if !tt.Assert.Equal(3, len(results)) {
 				return

--- a/services/horizon/internal/db2/history/accounts.go
+++ b/services/horizon/internal/db2/history/accounts.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lib/pq"
 
 	"github.com/stellar/go/services/horizon/internal/db2"
+	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -190,7 +191,7 @@ func (q *Q) UpsertAccounts(ctx context.Context, accounts []xdr.LedgerEntry) erro
 		num_sponsoring = excluded.num_sponsoring`
 
 	_, err := q.ExecRaw(
-		ctx,
+		context.WithValue(ctx, &db.QueryTypeContextKey, "upsert"),
 		sql,
 		pq.Array(accountID),
 		pq.Array(balance),

--- a/services/horizon/internal/db2/history/accounts.go
+++ b/services/horizon/internal/db2/history/accounts.go
@@ -191,7 +191,7 @@ func (q *Q) UpsertAccounts(ctx context.Context, accounts []xdr.LedgerEntry) erro
 		num_sponsoring = excluded.num_sponsoring`
 
 	_, err := q.ExecRaw(
-		context.WithValue(ctx, &db.QueryTypeContextKey, "upsert"),
+		context.WithValue(ctx, &db.QueryTypeContextKey, db.UpsertQueryType),
 		sql,
 		pq.Array(accountID),
 		pq.Array(balance),

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -603,7 +603,7 @@ type OperationsQ struct {
 // Q is a helper struct on which to hang common_trades queries against a history
 // portion of the horizon database.
 type Q struct {
-	*db.Session
+	db.SessionInterface
 }
 
 // QSigners defines signer related queries.

--- a/services/horizon/internal/db2/history/trust_lines.go
+++ b/services/horizon/internal/db2/history/trust_lines.go
@@ -8,6 +8,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/guregu/null"
 	"github.com/lib/pq"
+	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -221,7 +222,9 @@ func (q *Q) UpsertTrustLines(ctx context.Context, trustLines []xdr.LedgerEntry) 
 		last_modified_ledger = excluded.last_modified_ledger,
 		sponsor = excluded.sponsor`
 
-	_, err := q.ExecRaw(ctx, sql,
+	_, err := q.ExecRaw(
+		context.WithValue(ctx, &db.QueryTypeContextKey, "upsert"),
+		sql,
 		pq.Array(ledgerKey),
 		pq.Array(accountID),
 		pq.Array(assetType),

--- a/services/horizon/internal/db2/history/trust_lines.go
+++ b/services/horizon/internal/db2/history/trust_lines.go
@@ -223,7 +223,7 @@ func (q *Q) UpsertTrustLines(ctx context.Context, trustLines []xdr.LedgerEntry) 
 		sponsor = excluded.sponsor`
 
 	_, err := q.ExecRaw(
-		context.WithValue(ctx, &db.QueryTypeContextKey, "upsert"),
+		context.WithValue(ctx, &db.QueryTypeContextKey, db.UpsertQueryType),
 		sql,
 		pq.Array(ledgerKey),
 		pq.Array(accountID),

--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -205,7 +205,7 @@ func recoverMiddleware(h http.Handler) http.Handler {
 // NewHistoryMiddleware adds session to the request context and ensures Horizon
 // is not in a stale state, which is when the difference between latest core
 // ledger and latest history ledger is higher than the given threshold
-func NewHistoryMiddleware(ledgerState *ledger.State, staleThreshold int32, session *db.Session) func(http.Handler) http.Handler {
+func NewHistoryMiddleware(ledgerState *ledger.State, staleThreshold int32, session db.SessionInterface) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -241,7 +241,7 @@ func NewHistoryMiddleware(ledgerState *ledger.State, staleThreshold int32, sessi
 // has been verified and is correct (Otherwise returns `500 Internal Server Error` to prevent
 // returning invalid data to the user)
 type StateMiddleware struct {
-	HorizonSession      *db.Session
+	HorizonSession      db.SessionInterface
 	NoStateVerification bool
 }
 

--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -141,16 +141,16 @@ func sanitizeMetricRoute(routePattern string) string {
 	route = strings.ReplaceAll(route, "\\", "\\\\")
 	route = strings.ReplaceAll(route, "\"", "\\\"")
 	route = strings.ReplaceAll(route, "\n", "\\n")
+	if route == "" {
+		// Can be empty when request did not reached the final route (ex. blocked by
+		// a middleware). More info: https://github.com/go-chi/chi/issues/270
+		return "undefined"
+	}
 	return route
 }
 
 func logEndOfRequest(ctx context.Context, r *http.Request, requestDurationSummary *prometheus.SummaryVec, duration time.Duration, mw middleware.WrapResponseWriter, streaming bool) {
 	route := sanitizeMetricRoute(chi.RouteContext(r.Context()).RoutePattern())
-	// Can be empty when request did not reached the final route (ex. blocked by
-	// a middleware). More info: https://github.com/go-chi/chi/issues/270
-	if route == "" {
-		route = "undefined"
-	}
 
 	referer := r.Referer()
 	if referer == "" {
@@ -209,6 +209,11 @@ func NewHistoryMiddleware(ledgerState *ledger.State, staleThreshold int32, sessi
 	return func(h http.Handler) http.Handler {
 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			chiRoute := chi.RouteContext(ctx)
+			if chiRoute != nil {
+				ctx = context.WithValue(ctx, &db.RouteContextKey, sanitizeMetricRoute(chiRoute.RoutePattern()))
+			}
 			if staleThreshold > 0 {
 				ls := ledgerState.CurrentStatus()
 				isStale := (ls.CoreLatest - ls.HistoryLatest) > int32(staleThreshold)
@@ -218,7 +223,7 @@ func NewHistoryMiddleware(ledgerState *ledger.State, staleThreshold int32, sessi
 						"history_latest_ledger": ls.HistoryLatest,
 						"core_latest_ledger":    ls.CoreLatest,
 					}
-					problem.Render(r.Context(), w, err)
+					problem.Render(ctx, w, err)
 					return
 				}
 			}
@@ -226,7 +231,7 @@ func NewHistoryMiddleware(ledgerState *ledger.State, staleThreshold int32, sessi
 			requestSession := session.Clone()
 			h.ServeHTTP(w, r.WithContext(
 				context.WithValue(
-					r.Context(),
+					ctx,
 					&horizonContext.SessionContextKey,
 					requestSession,
 				),
@@ -277,6 +282,10 @@ func ingestionStatus(ctx context.Context, q *history.Q) (uint32, bool, error) {
 func (m *StateMiddleware) WrapFunc(h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		chiRoute := chi.RouteContext(ctx)
+		if chiRoute != nil {
+			ctx = context.WithValue(ctx, &db.RouteContextKey, sanitizeMetricRoute(chiRoute.RoutePattern()))
+		}
 		session := m.HorizonSession.Clone()
 		q := &history.Q{session}
 		sseRequest := render.Negotiate(r) == render.MimeEventStream
@@ -292,7 +301,7 @@ func (m *StateMiddleware) WrapFunc(h http.HandlerFunc) http.HandlerFunc {
 		})
 		if err != nil {
 			err = supportErrors.Wrap(err, "Error starting ingestion read transaction")
-			problem.Render(r.Context(), w, err)
+			problem.Render(ctx, w, err)
 			return
 		}
 		defer session.Rollback(ctx)
@@ -301,22 +310,22 @@ func (m *StateMiddleware) WrapFunc(h http.HandlerFunc) http.HandlerFunc {
 			stateInvalid, invalidErr := q.GetExpStateInvalid(ctx)
 			if invalidErr != nil {
 				invalidErr = supportErrors.Wrap(invalidErr, "Error running GetExpStateInvalid")
-				problem.Render(r.Context(), w, invalidErr)
+				problem.Render(ctx, w, invalidErr)
 				return
 			}
 			if stateInvalid {
-				problem.Render(r.Context(), w, problem.ServerError)
+				problem.Render(ctx, w, problem.ServerError)
 				return
 			}
 		}
 
 		lastIngestedLedger, ready, err := ingestionStatus(ctx, q)
 		if err != nil {
-			problem.Render(r.Context(), w, err)
+			problem.Render(ctx, w, err)
 			return
 		}
 		if !m.NoStateVerification && !ready {
-			problem.Render(r.Context(), w, hProblem.StillIngesting)
+			problem.Render(ctx, w, hProblem.StillIngesting)
 			return
 		}
 
@@ -326,7 +335,7 @@ func (m *StateMiddleware) WrapFunc(h http.HandlerFunc) http.HandlerFunc {
 		if sseRequest {
 			if err = session.Rollback(ctx); err != nil {
 				problem.Render(
-					r.Context(),
+					ctx,
 					w,
 					supportErrors.Wrap(
 						err,
@@ -340,11 +349,7 @@ func (m *StateMiddleware) WrapFunc(h http.HandlerFunc) http.HandlerFunc {
 		}
 
 		h.ServeHTTP(w, r.WithContext(
-			context.WithValue(
-				r.Context(),
-				&horizonContext.SessionContextKey,
-				session,
-			),
+			context.WithValue(ctx, &horizonContext.SessionContextKey, session),
 		))
 	}
 }

--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -142,7 +142,7 @@ func sanitizeMetricRoute(routePattern string) string {
 	route = strings.ReplaceAll(route, "\"", "\\\"")
 	route = strings.ReplaceAll(route, "\n", "\\n")
 	if route == "" {
-		// Can be empty when request did not reached the final route (ex. blocked by
+		// Can be empty when request did not reach the final route (ex. blocked by
 		// a middleware). More info: https://github.com/go-chi/chi/issues/270
 		return "undefined"
 	}

--- a/services/horizon/internal/httpx/router.go
+++ b/services/horizon/internal/httpx/router.go
@@ -28,7 +28,7 @@ import (
 const maxAssetsForPathFinding = 15
 
 type RouterConfig struct {
-	DBSession   *db.Session
+	DBSession   db.SessionInterface
 	TxSubmitter *txsub.System
 	RateQuota   *throttled.RateQuota
 

--- a/services/horizon/internal/httpx/router.go
+++ b/services/horizon/internal/httpx/router.go
@@ -128,12 +128,10 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 	historyMiddleware := NewHistoryMiddleware(ledgerState, int32(config.StaleThreshold), config.DBSession)
 	// State endpoints behind stateMiddleware
 	r.Group(func(r chi.Router) {
-		r.Use(stateMiddleware.Wrap)
-
 		r.Route("/accounts", func(r chi.Router) {
-			r.Method(http.MethodGet, "/", restPageHandler(ledgerState, actions.GetAccountsHandler{LedgerState: ledgerState}))
+			r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/", restPageHandler(ledgerState, actions.GetAccountsHandler{LedgerState: ledgerState}))
 			r.Route("/{account_id}", func(r chi.Router) {
-				r.Method(
+				r.With(stateMiddleware.Wrap).Method(
 					http.MethodGet,
 					"/",
 					streamableObjectActionHandler{
@@ -142,25 +140,25 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 					},
 				)
 				accountData := actions.GetAccountDataHandler{}
-				r.Method(http.MethodGet, "/data/{key}", WrapRaw(
+				r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/data/{key}", WrapRaw(
 					streamableObjectActionHandler{streamHandler: streamHandler, action: accountData},
 					accountData,
 				))
-				r.Method(http.MethodGet, "/offers", streamableStatePageHandler(ledgerState, actions.GetAccountOffersHandler{LedgerState: ledgerState}, streamHandler))
+				r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/offers", streamableStatePageHandler(ledgerState, actions.GetAccountOffersHandler{LedgerState: ledgerState}, streamHandler))
 			})
 		})
 
 		r.Route("/claimable_balances", func(r chi.Router) {
-			r.Method(http.MethodGet, "/", restPageHandler(ledgerState, actions.GetClaimableBalancesHandler{LedgerState: ledgerState}))
-			r.Method(http.MethodGet, "/{id}", ObjectActionHandler{actions.GetClaimableBalanceByIDHandler{}})
+			r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/", restPageHandler(ledgerState, actions.GetClaimableBalancesHandler{LedgerState: ledgerState}))
+			r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/{id}", ObjectActionHandler{actions.GetClaimableBalanceByIDHandler{}})
 		})
 
 		r.Route("/offers", func(r chi.Router) {
-			r.Method(http.MethodGet, "/", restPageHandler(ledgerState, actions.GetOffersHandler{LedgerState: ledgerState}))
-			r.Method(http.MethodGet, "/{offer_id}", ObjectActionHandler{actions.GetOfferByID{}})
+			r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/", restPageHandler(ledgerState, actions.GetOffersHandler{LedgerState: ledgerState}))
+			r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/{offer_id}", ObjectActionHandler{actions.GetOfferByID{}})
 		})
 
-		r.Method(http.MethodGet, "/assets", restPageHandler(ledgerState, actions.AssetStatsHandler{LedgerState: ledgerState}))
+		r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/assets", restPageHandler(ledgerState, actions.AssetStatsHandler{LedgerState: ledgerState}))
 
 		findPaths := ObjectActionHandler{actions.FindPathsHandler{
 			StaleThreshold:       config.StaleThreshold,
@@ -176,11 +174,11 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 			PathFinder:           config.PathFinder,
 		}}
 
-		r.Method(http.MethodGet, "/paths", findPaths)
-		r.Method(http.MethodGet, "/paths/strict-receive", findPaths)
-		r.Method(http.MethodGet, "/paths/strict-send", findFixedPaths)
+		r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/paths", findPaths)
+		r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/paths/strict-receive", findPaths)
+		r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/paths/strict-send", findFixedPaths)
 
-		r.Method(
+		r.With(stateMiddleware.Wrap).Method(
 			http.MethodGet,
 			"/order_book",
 			streamableObjectActionHandler{
@@ -194,33 +192,31 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 	// need to use absolute routes here. Make sure we use regexp check here for
 	// emptiness. Without it, requesting `/accounts//payments` return all payments!
 	r.Group(func(r chi.Router) {
-		r.Use(historyMiddleware)
-		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/effects", streamableHistoryPageHandler(ledgerState, actions.GetEffectsHandler{LedgerState: ledgerState}, streamHandler))
-		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/operations", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+		r.With(historyMiddleware).Method(http.MethodGet, "/accounts/{account_id:\\w+}/effects", streamableHistoryPageHandler(ledgerState, actions.GetEffectsHandler{LedgerState: ledgerState}, streamHandler))
+		r.With(historyMiddleware).Method(http.MethodGet, "/accounts/{account_id:\\w+}/operations", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
 			LedgerState:  ledgerState,
 			OnlyPayments: false,
 		}, streamHandler))
-		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/payments", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+		r.With(historyMiddleware).Method(http.MethodGet, "/accounts/{account_id:\\w+}/payments", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
 			LedgerState:  ledgerState,
 			OnlyPayments: true,
 		}, streamHandler))
-		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/trades", streamableHistoryPageHandler(ledgerState, actions.GetTradesHandler{LedgerState: ledgerState}, streamHandler))
-		r.Method(http.MethodGet, "/accounts/{account_id:\\w+}/transactions", streamableHistoryPageHandler(ledgerState, actions.GetTransactionsHandler{LedgerState: ledgerState}, streamHandler))
+		r.With(historyMiddleware).Method(http.MethodGet, "/accounts/{account_id:\\w+}/trades", streamableHistoryPageHandler(ledgerState, actions.GetTradesHandler{LedgerState: ledgerState}, streamHandler))
+		r.With(historyMiddleware).Method(http.MethodGet, "/accounts/{account_id:\\w+}/transactions", streamableHistoryPageHandler(ledgerState, actions.GetTransactionsHandler{LedgerState: ledgerState}, streamHandler))
 	})
 	// ledger actions
 	r.Route("/ledgers", func(r chi.Router) {
-		r.Use(historyMiddleware)
-		r.Method(http.MethodGet, "/", streamableHistoryPageHandler(ledgerState, actions.GetLedgersHandler{LedgerState: ledgerState}, streamHandler))
+		r.With(historyMiddleware).Method(http.MethodGet, "/", streamableHistoryPageHandler(ledgerState, actions.GetLedgersHandler{LedgerState: ledgerState}, streamHandler))
 		r.Route("/{ledger_id}", func(r chi.Router) {
-			r.Method(http.MethodGet, "/", ObjectActionHandler{actions.GetLedgerByIDHandler{LedgerState: ledgerState}})
-			r.Method(http.MethodGet, "/transactions", streamableHistoryPageHandler(ledgerState, actions.GetTransactionsHandler{LedgerState: ledgerState}, streamHandler))
+			r.With(historyMiddleware).Method(http.MethodGet, "/", ObjectActionHandler{actions.GetLedgerByIDHandler{LedgerState: ledgerState}})
+			r.With(historyMiddleware).Method(http.MethodGet, "/transactions", streamableHistoryPageHandler(ledgerState, actions.GetTransactionsHandler{LedgerState: ledgerState}, streamHandler))
 			r.Group(func(r chi.Router) {
-				r.Method(http.MethodGet, "/effects", streamableHistoryPageHandler(ledgerState, actions.GetEffectsHandler{LedgerState: ledgerState}, streamHandler))
-				r.Method(http.MethodGet, "/operations", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+				r.With(historyMiddleware).Method(http.MethodGet, "/effects", streamableHistoryPageHandler(ledgerState, actions.GetEffectsHandler{LedgerState: ledgerState}, streamHandler))
+				r.With(historyMiddleware).Method(http.MethodGet, "/operations", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
 					LedgerState:  ledgerState,
 					OnlyPayments: false,
 				}, streamHandler))
-				r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+				r.With(historyMiddleware).Method(http.MethodGet, "/payments", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
 					LedgerState:  ledgerState,
 					OnlyPayments: true,
 				}, streamHandler))
@@ -229,26 +225,24 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 	})
 	// claimable balance actions
 	r.Group(func(r chi.Router) {
-		r.Use(historyMiddleware)
-		r.Method(http.MethodGet, "/claimable_balances/{claimable_balance_id:\\w+}/operations", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+		r.With(historyMiddleware).Method(http.MethodGet, "/claimable_balances/{claimable_balance_id:\\w+}/operations", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
 			LedgerState:  ledgerState,
 			OnlyPayments: false,
 		}, streamHandler))
-		r.Method(http.MethodGet, "/claimable_balances/{claimable_balance_id:\\w+}/transactions", streamableHistoryPageHandler(ledgerState, actions.GetTransactionsHandler{LedgerState: ledgerState}, streamHandler))
+		r.With(historyMiddleware).Method(http.MethodGet, "/claimable_balances/{claimable_balance_id:\\w+}/transactions", streamableHistoryPageHandler(ledgerState, actions.GetTransactionsHandler{LedgerState: ledgerState}, streamHandler))
 	})
 
 	// transaction history actions
 	r.Route("/transactions", func(r chi.Router) {
 		r.With(historyMiddleware).Method(http.MethodGet, "/", streamableHistoryPageHandler(ledgerState, actions.GetTransactionsHandler{LedgerState: ledgerState}, streamHandler))
 		r.Route("/{tx_id}", func(r chi.Router) {
-			r.Use(historyMiddleware)
-			r.Method(http.MethodGet, "/", ObjectActionHandler{actions.GetTransactionByHashHandler{}})
-			r.Method(http.MethodGet, "/effects", streamableHistoryPageHandler(ledgerState, actions.GetEffectsHandler{LedgerState: ledgerState}, streamHandler))
-			r.Method(http.MethodGet, "/operations", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+			r.With(historyMiddleware).Method(http.MethodGet, "/", ObjectActionHandler{actions.GetTransactionByHashHandler{}})
+			r.With(historyMiddleware).Method(http.MethodGet, "/effects", streamableHistoryPageHandler(ledgerState, actions.GetEffectsHandler{LedgerState: ledgerState}, streamHandler))
+			r.With(historyMiddleware).Method(http.MethodGet, "/operations", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
 				LedgerState:  ledgerState,
 				OnlyPayments: false,
 			}, streamHandler))
-			r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+			r.With(historyMiddleware).Method(http.MethodGet, "/payments", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
 				LedgerState:  ledgerState,
 				OnlyPayments: true,
 			}, streamHandler))
@@ -257,32 +251,30 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 
 	// operation actions
 	r.Route("/operations", func(r chi.Router) {
-		r.Use(historyMiddleware)
-		r.Method(http.MethodGet, "/", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+		r.With(historyMiddleware).Method(http.MethodGet, "/", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
 			LedgerState:  ledgerState,
 			OnlyPayments: false,
 		}, streamHandler))
-		r.Method(http.MethodGet, "/{id}", ObjectActionHandler{actions.GetOperationByIDHandler{LedgerState: ledgerState}})
-		r.Method(http.MethodGet, "/{op_id}/effects", streamableHistoryPageHandler(ledgerState, actions.GetEffectsHandler{LedgerState: ledgerState}, streamHandler))
+		r.With(historyMiddleware).Method(http.MethodGet, "/{id}", ObjectActionHandler{actions.GetOperationByIDHandler{LedgerState: ledgerState}})
+		r.With(historyMiddleware).Method(http.MethodGet, "/{op_id}/effects", streamableHistoryPageHandler(ledgerState, actions.GetEffectsHandler{LedgerState: ledgerState}, streamHandler))
 	})
 
 	r.Group(func(r chi.Router) {
-		r.Use(historyMiddleware)
 		// payment actions
-		r.Method(http.MethodGet, "/payments", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
+		r.With(historyMiddleware).Method(http.MethodGet, "/payments", streamableHistoryPageHandler(ledgerState, actions.GetOperationsHandler{
 			LedgerState:  ledgerState,
 			OnlyPayments: true,
 		}, streamHandler))
 
 		// effect actions
-		r.Method(http.MethodGet, "/effects", streamableHistoryPageHandler(ledgerState, actions.GetEffectsHandler{LedgerState: ledgerState}, streamHandler))
+		r.With(historyMiddleware).Method(http.MethodGet, "/effects", streamableHistoryPageHandler(ledgerState, actions.GetEffectsHandler{LedgerState: ledgerState}, streamHandler))
 
 		// trading related endpoints
-		r.Method(http.MethodGet, "/trades", streamableHistoryPageHandler(ledgerState, actions.GetTradesHandler{LedgerState: ledgerState}, streamHandler))
-		r.Method(http.MethodGet, "/trade_aggregations", ObjectActionHandler{actions.GetTradeAggregationsHandler{LedgerState: ledgerState}})
+		r.With(historyMiddleware).Method(http.MethodGet, "/trades", streamableHistoryPageHandler(ledgerState, actions.GetTradesHandler{LedgerState: ledgerState}, streamHandler))
+		r.With(historyMiddleware).Method(http.MethodGet, "/trade_aggregations", ObjectActionHandler{actions.GetTradeAggregationsHandler{LedgerState: ledgerState}})
 		// /offers/{offer_id} has been created above so we need to use absolute
 		// routes here.
-		r.Method(http.MethodGet, "/offers/{offer_id}/trades", streamableHistoryPageHandler(ledgerState, actions.GetTradesHandler{LedgerState: ledgerState}, streamHandler))
+		r.With(historyMiddleware).Method(http.MethodGet, "/offers/{offer_id}/trades", streamableHistoryPageHandler(ledgerState, actions.GetTradesHandler{LedgerState: ledgerState}, streamHandler))
 	})
 
 	// Transaction submission API

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -66,7 +66,7 @@ const (
 var log = logpkg.DefaultLogger.WithField("service", "ingest")
 
 type Config struct {
-	CoreSession                 *db.Session
+	CoreSession                 db.SessionInterface
 	StellarCoreURL              string
 	StellarCoreCursor           string
 	EnableCaptiveCore           bool
@@ -79,7 +79,7 @@ type Config struct {
 	RemoteCaptiveCoreURL        string
 	NetworkPassphrase           string
 
-	HistorySession           *db.Session
+	HistorySession           db.SessionInterface
 	HistoryArchiveURL        string
 	DisableStateVerification bool
 

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stellar/go/support/log"
 )
 
-func mustNewDBSession(databaseURL string, maxIdle, maxOpen int) *db.Session {
+func mustNewDBSession(subsystem string, databaseURL string, maxIdle, maxOpen int, registry *prometheus.Registry) db.SessionInterface {
 	session, err := db.Open("postgres", databaseURL)
 	if err != nil {
 		log.Fatalf("cannot open Horizon DB: %v", err)
@@ -26,7 +26,7 @@ func mustNewDBSession(databaseURL string, maxIdle, maxOpen int) *db.Session {
 
 	session.DB.SetMaxIdleConns(maxIdle)
 	session.DB.SetMaxOpenConns(maxOpen)
-	return session
+	return db.RegisterMetrics(session, "horizon", subsystem, registry)
 }
 
 func mustInitHorizonDB(app *App) {
@@ -44,9 +44,11 @@ func mustInitHorizonDB(app *App) {
 	}
 
 	app.historyQ = &history.Q{mustNewDBSession(
+		"history",
 		app.config.DatabaseURL,
 		maxIdle,
 		maxOpen,
+		app.prometheusRegistry,
 	)}
 }
 
@@ -54,12 +56,12 @@ func initIngester(app *App) {
 	var err error
 	var coreSession db.SessionInterface
 	if !app.config.EnableCaptiveCoreIngestion {
-		coreSession = mustNewDBSession(app.config.StellarCoreDatabaseURL, ingest.MaxDBConnections, ingest.MaxDBConnections)
+		coreSession = mustNewDBSession("core", app.config.StellarCoreDatabaseURL, ingest.MaxDBConnections, ingest.MaxDBConnections, app.prometheusRegistry)
 	}
 	app.ingester, err = ingest.NewSystem(ingest.Config{
 		CoreSession: coreSession,
 		HistorySession: mustNewDBSession(
-			app.config.DatabaseURL, ingest.MaxDBConnections, ingest.MaxDBConnections,
+			"ingest", app.config.DatabaseURL, ingest.MaxDBConnections, ingest.MaxDBConnections, app.prometheusRegistry,
 		),
 		NetworkPassphrase: app.config.NetworkPassphrase,
 		// TODO:

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -225,6 +225,14 @@ func initDbMetrics(app *App) {
 	)
 	app.prometheusRegistry.MustRegister(app.dbInUseConnectionsGauge)
 
+	app.dbIdleConnectionsGauge = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{Namespace: "horizon", Subsystem: "db", Name: "idle_connections"},
+		func() float64 {
+			return float64(app.historyQ.Session.DB.Stats().Idle)
+		},
+	)
+	app.prometheusRegistry.MustRegister(app.dbIdleConnectionsGauge)
+
 	app.dbWaitCountCounter = prometheus.NewCounterFunc(
 		prometheus.CounterOpts{
 			Namespace: "horizon", Subsystem: "db", Name: "wait_count_total",
@@ -246,6 +254,39 @@ func initDbMetrics(app *App) {
 		},
 	)
 	app.prometheusRegistry.MustRegister(app.dbWaitDurationCounter)
+
+	app.dbMaxIdleClosedCounter = prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Namespace: "horizon", Subsystem: "db", Name: "max_idle_closed_total",
+			Help: "total number of number of connections closed due to SetMaxIdleConns",
+		},
+		func() float64 {
+			return float64(app.historyQ.Session.DB.Stats().MaxIdleClosed)
+		},
+	)
+	app.prometheusRegistry.MustRegister(app.dbMaxIdleClosedCounter)
+
+	app.dbMaxIdleTimeClosedCounter = prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Namespace: "horizon", Subsystem: "db", Name: "max_idle_time_closed_total",
+			Help: "total number of number of connections closed due to SetConnMaxIdleTime",
+		},
+		func() float64 {
+			return float64(app.historyQ.Session.DB.Stats().MaxIdleTimeClosed)
+		},
+	)
+	app.prometheusRegistry.MustRegister(app.dbMaxIdleTimeClosedCounter)
+
+	app.dbMaxLifetimeClosedCounter = prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Namespace: "horizon", Subsystem: "db", Name: "max_lifetime_closed_total",
+			Help: "total number of number of connections closed due to SetConnMaxLifetime",
+		},
+		func() float64 {
+			return float64(app.historyQ.Session.DB.Stats().MaxLifetimeClosed)
+		},
+	)
+	app.prometheusRegistry.MustRegister(app.dbMaxLifetimeClosedCounter)
 
 	app.prometheusRegistry.MustRegister(app.orderBookStream.LatestLedgerGauge)
 }

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stellar/go/support/log"
 )
 
-func mustNewDBSession(subsystem string, databaseURL string, maxIdle, maxOpen int, registry *prometheus.Registry) db.SessionInterface {
+func mustNewDBSession(subsystem db.Subsystem, databaseURL string, maxIdle, maxOpen int, registry *prometheus.Registry) db.SessionInterface {
 	session, err := db.Open("postgres", databaseURL)
 	if err != nil {
 		log.Fatalf("cannot open Horizon DB: %v", err)
@@ -44,7 +44,7 @@ func mustInitHorizonDB(app *App) {
 	}
 
 	app.historyQ = &history.Q{mustNewDBSession(
-		"history",
+		db.HistorySubsystem,
 		app.config.DatabaseURL,
 		maxIdle,
 		maxOpen,
@@ -56,12 +56,13 @@ func initIngester(app *App) {
 	var err error
 	var coreSession db.SessionInterface
 	if !app.config.EnableCaptiveCoreIngestion {
-		coreSession = mustNewDBSession("core", app.config.StellarCoreDatabaseURL, ingest.MaxDBConnections, ingest.MaxDBConnections, app.prometheusRegistry)
+		coreSession = mustNewDBSession(
+			db.CoreSubsystem, app.config.StellarCoreDatabaseURL, ingest.MaxDBConnections, ingest.MaxDBConnections, app.prometheusRegistry)
 	}
 	app.ingester, err = ingest.NewSystem(ingest.Config{
 		CoreSession: coreSession,
 		HistorySession: mustNewDBSession(
-			"ingest", app.config.DatabaseURL, ingest.MaxDBConnections, ingest.MaxDBConnections, app.prometheusRegistry,
+			db.IngestSubsystem, app.config.DatabaseURL, ingest.MaxDBConnections, ingest.MaxDBConnections, app.prometheusRegistry,
 		),
 		NetworkPassphrase: app.config.NetworkPassphrase,
 		// TODO:

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -52,7 +52,7 @@ func mustInitHorizonDB(app *App) {
 
 func initIngester(app *App) {
 	var err error
-	var coreSession *db.Session
+	var coreSession db.SessionInterface
 	if !app.config.EnableCaptiveCoreIngestion {
 		coreSession = mustNewDBSession(app.config.StellarCoreDatabaseURL, ingest.MaxDBConnections, ingest.MaxDBConnections)
 	}
@@ -198,96 +198,6 @@ func initDbMetrics(app *App) {
 	)
 	app.prometheusRegistry.MustRegister(app.coreSynced)
 
-	app.dbMaxOpenConnectionsGauge = prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{Namespace: "horizon", Subsystem: "db", Name: "max_open_connections"},
-		func() float64 {
-			// Right now MaxOpenConnections in Horizon is static however it's possible that
-			// it will change one day. In such case, using GaugeFunc is very cheap and will
-			// prevent issues with this metric in the future.
-			return float64(app.historyQ.Session.DB.Stats().MaxOpenConnections)
-		},
-	)
-	app.prometheusRegistry.MustRegister(app.dbMaxOpenConnectionsGauge)
-
-	app.dbOpenConnectionsGauge = prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{Namespace: "horizon", Subsystem: "db", Name: "open_connections"},
-		func() float64 {
-			return float64(app.historyQ.Session.DB.Stats().OpenConnections)
-		},
-	)
-	app.prometheusRegistry.MustRegister(app.dbOpenConnectionsGauge)
-
-	app.dbInUseConnectionsGauge = prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{Namespace: "horizon", Subsystem: "db", Name: "in_use_connections"},
-		func() float64 {
-			return float64(app.historyQ.Session.DB.Stats().InUse)
-		},
-	)
-	app.prometheusRegistry.MustRegister(app.dbInUseConnectionsGauge)
-
-	app.dbIdleConnectionsGauge = prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{Namespace: "horizon", Subsystem: "db", Name: "idle_connections"},
-		func() float64 {
-			return float64(app.historyQ.Session.DB.Stats().Idle)
-		},
-	)
-	app.prometheusRegistry.MustRegister(app.dbIdleConnectionsGauge)
-
-	app.dbWaitCountCounter = prometheus.NewCounterFunc(
-		prometheus.CounterOpts{
-			Namespace: "horizon", Subsystem: "db", Name: "wait_count_total",
-			Help: "total number of number of connections waited for",
-		},
-		func() float64 {
-			return float64(app.historyQ.Session.DB.Stats().WaitCount)
-		},
-	)
-	app.prometheusRegistry.MustRegister(app.dbWaitCountCounter)
-
-	app.dbWaitDurationCounter = prometheus.NewCounterFunc(
-		prometheus.CounterOpts{
-			Namespace: "horizon", Subsystem: "db", Name: "wait_duration_seconds_total",
-			Help: "total time blocked waiting for a new connection",
-		},
-		func() float64 {
-			return app.historyQ.Session.DB.Stats().WaitDuration.Seconds()
-		},
-	)
-	app.prometheusRegistry.MustRegister(app.dbWaitDurationCounter)
-
-	app.dbMaxIdleClosedCounter = prometheus.NewCounterFunc(
-		prometheus.CounterOpts{
-			Namespace: "horizon", Subsystem: "db", Name: "max_idle_closed_total",
-			Help: "total number of number of connections closed due to SetMaxIdleConns",
-		},
-		func() float64 {
-			return float64(app.historyQ.Session.DB.Stats().MaxIdleClosed)
-		},
-	)
-	app.prometheusRegistry.MustRegister(app.dbMaxIdleClosedCounter)
-
-	app.dbMaxIdleTimeClosedCounter = prometheus.NewCounterFunc(
-		prometheus.CounterOpts{
-			Namespace: "horizon", Subsystem: "db", Name: "max_idle_time_closed_total",
-			Help: "total number of number of connections closed due to SetConnMaxIdleTime",
-		},
-		func() float64 {
-			return float64(app.historyQ.Session.DB.Stats().MaxIdleTimeClosed)
-		},
-	)
-	app.prometheusRegistry.MustRegister(app.dbMaxIdleTimeClosedCounter)
-
-	app.dbMaxLifetimeClosedCounter = prometheus.NewCounterFunc(
-		prometheus.CounterOpts{
-			Namespace: "horizon", Subsystem: "db", Name: "max_lifetime_closed_total",
-			Help: "total number of number of connections closed due to SetConnMaxLifetime",
-		},
-		func() float64 {
-			return float64(app.historyQ.Session.DB.Stats().MaxLifetimeClosed)
-		},
-	)
-	app.prometheusRegistry.MustRegister(app.dbMaxLifetimeClosedCounter)
-
 	app.prometheusRegistry.MustRegister(app.orderBookStream.LatestLedgerGauge)
 }
 
@@ -345,7 +255,7 @@ func initSubmissionSystem(app *App) {
 		Submitter:       txsub.NewDefaultSubmitter(http.DefaultClient, app.config.StellarCoreURL),
 		SubmissionQueue: sequence.NewManager(),
 		DB: func(ctx context.Context) txsub.HorizonDB {
-			return &history.Q{Session: app.HorizonSession()}
+			return &history.Q{SessionInterface: app.HorizonSession()}
 		},
 	}
 }

--- a/services/horizon/internal/reap/main.go
+++ b/services/horizon/internal/reap/main.go
@@ -23,7 +23,7 @@ type System struct {
 
 // New initializes the reaper, causing it to begin polling the stellar-core
 // database for now ledgers and ingesting data into the horizon database.
-func New(retention uint, dbSession *db.Session, ledgerState *ledger.State) *System {
+func New(retention uint, dbSession db.SessionInterface, ledgerState *ledger.State) *System {
 	r := &System{
 		HistoryQ:       &history.Q{dbSession},
 		RetentionCount: retention,

--- a/services/horizon/internal/txsub/results_test.go
+++ b/services/horizon/internal/txsub/results_test.go
@@ -11,7 +11,7 @@ func TestGetIngestedTx(t *testing.T) {
 	tt := test.Start(t)
 	tt.Scenario("base")
 	defer tt.Finish()
-	q := &history.Q{Session: tt.HorizonSession()}
+	q := &history.Q{SessionInterface: tt.HorizonSession()}
 	hash := "2374e99349b9ef7dba9a5db3339b78fda8f34777b1af33ba468ad5c0df946d4d"
 	tx, err := txResultByHash(tt.Ctx, q, hash)
 	tt.Assert.NoError(err)
@@ -22,7 +22,7 @@ func TestGetMissingTx(t *testing.T) {
 	tt := test.Start(t)
 	tt.Scenario("base")
 	defer tt.Finish()
-	q := &history.Q{Session: tt.HorizonSession()}
+	q := &history.Q{SessionInterface: tt.HorizonSession()}
 	hash := "adf1efb9fd253f53cbbe6230c131d2af19830328e52b610464652d67d2fb7195"
 
 	_, err := txResultByHash(tt.Ctx, q, hash)
@@ -33,7 +33,7 @@ func TestGetFailedTx(t *testing.T) {
 	tt := test.Start(t)
 	tt.Scenario("failed_transactions")
 	defer tt.Finish()
-	q := &history.Q{Session: tt.HorizonSession()}
+	q := &history.Q{SessionInterface: tt.HorizonSession()}
 	hash := "aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf"
 
 	_, err := txResultByHash(tt.Ctx, q, hash)

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -107,8 +107,11 @@ type SessionInterface interface {
 	BeginTx(ctx context.Context, opts *sql.TxOptions) error
 	Begin(ctx context.Context) error
 	Rollback(ctx context.Context) error
+	Commit(ctx context.Context) error
+	GetTx() *sqlx.Tx
+	GetTxOptions() *sql.TxOptions
 	TruncateTables(ctx context.Context, tables []string) error
-	Clone() *Session
+	Clone() SessionInterface
 	Close() error
 	Get(ctx context.Context, dest interface{}, query squirrel.Sqlizer) error
 	GetRaw(ctx context.Context, dest interface{}, query string, args ...interface{}) error
@@ -119,6 +122,12 @@ type SessionInterface interface {
 	ExecRaw(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 	NoRows(err error) bool
 	Ping(ctx context.Context, timeout time.Duration) error
+	DeleteRange(
+		ctx context.Context,
+		start, end int64,
+		table string,
+		idCol string,
+	) error
 }
 
 // Table helps to build sql queries against a given table.  It logically

--- a/support/db/metrics.go
+++ b/support/db/metrics.go
@@ -10,6 +10,18 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+type CtxKey string
+
+var RouteContextKey = CtxKey("route")
+
+// contextRoute returns a string representing the request endpoint, or "undefined" if it wasn't found
+func contextRoute(ctx context.Context) string {
+	if endpoint, ok := ctx.Value(&RouteContextKey).(string); ok {
+		return endpoint
+	}
+	return "undefined"
+}
+
 type SessionWithMetrics struct {
 	SessionInterface
 	registry                 *prometheus.Registry
@@ -35,7 +47,7 @@ func RegisterMetrics(base *Session, namespace, sub string, registry *prometheus.
 
 	s.queryCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{Namespace: namespace, Subsystem: subsystem, Name: "query_total"},
-		[]string{"query_type", "error"},
+		[]string{"query_type", "error", "route"},
 	)
 	registry.MustRegister(s.queryCounter)
 
@@ -45,7 +57,7 @@ func RegisterMetrics(base *Session, namespace, sub string, registry *prometheus.
 			Name:    "query_duration_seconds",
 			Buckets: prometheus.ExponentialBuckets(0.1, 2, 5),
 		},
-		[]string{"query_type", "error"},
+		[]string{"query_type", "error", "route"},
 	)
 	registry.MustRegister(s.queryDuration)
 
@@ -183,6 +195,7 @@ func (s *SessionWithMetrics) TruncateTables(ctx context.Context, tables []string
 		s.queryDuration.With(prometheus.Labels{
 			"query_type": "truncate_tables",
 			"error":      fmt.Sprint(err != nil),
+			"route":      contextRoute(ctx),
 		}).Observe(v)
 	}))
 	defer func() {
@@ -190,6 +203,7 @@ func (s *SessionWithMetrics) TruncateTables(ctx context.Context, tables []string
 		s.queryCounter.With(prometheus.Labels{
 			"query_type": "truncate_tables",
 			"error":      fmt.Sprint(err != nil),
+			"route":      contextRoute(ctx),
 		}).Inc()
 	}()
 
@@ -239,6 +253,7 @@ func (s *SessionWithMetrics) Get(ctx context.Context, dest interface{}, query sq
 		s.queryDuration.With(prometheus.Labels{
 			"query_type": queryType,
 			"error":      fmt.Sprint(err != nil),
+			"route":      contextRoute(ctx),
 		}).Observe(v)
 	}))
 	defer func() {
@@ -246,6 +261,7 @@ func (s *SessionWithMetrics) Get(ctx context.Context, dest interface{}, query sq
 		s.queryCounter.With(prometheus.Labels{
 			"query_type": queryType,
 			"error":      fmt.Sprint(err != nil),
+			"route":      contextRoute(ctx),
 		}).Inc()
 	}()
 
@@ -263,6 +279,7 @@ func (s *SessionWithMetrics) Select(ctx context.Context, dest interface{}, query
 		s.queryDuration.With(prometheus.Labels{
 			"query_type": queryType,
 			"error":      fmt.Sprint(err != nil),
+			"route":      contextRoute(ctx),
 		}).Observe(v)
 	}))
 	defer func() {
@@ -270,6 +287,7 @@ func (s *SessionWithMetrics) Select(ctx context.Context, dest interface{}, query
 		s.queryCounter.With(prometheus.Labels{
 			"query_type": queryType,
 			"error":      fmt.Sprint(err != nil),
+			"route":      contextRoute(ctx),
 		}).Inc()
 	}()
 
@@ -287,6 +305,7 @@ func (s *SessionWithMetrics) Exec(ctx context.Context, query squirrel.Sqlizer) (
 		s.queryDuration.With(prometheus.Labels{
 			"query_type": queryType,
 			"error":      fmt.Sprint(err != nil),
+			"route":      contextRoute(ctx),
 		}).Observe(v)
 	}))
 	defer func() {
@@ -294,6 +313,7 @@ func (s *SessionWithMetrics) Exec(ctx context.Context, query squirrel.Sqlizer) (
 		s.queryCounter.With(prometheus.Labels{
 			"query_type": queryType,
 			"error":      fmt.Sprint(err != nil),
+			"route":      contextRoute(ctx),
 		}).Inc()
 	}()
 
@@ -311,6 +331,7 @@ func (s *SessionWithMetrics) Ping(ctx context.Context, timeout time.Duration) (e
 		s.queryDuration.With(prometheus.Labels{
 			"query_type": queryType,
 			"error":      fmt.Sprint(err != nil),
+			"route":      contextRoute(ctx),
 		}).Observe(v)
 	}))
 	defer func() {
@@ -318,6 +339,7 @@ func (s *SessionWithMetrics) Ping(ctx context.Context, timeout time.Duration) (e
 		s.queryCounter.With(prometheus.Labels{
 			"query_type": queryType,
 			"error":      fmt.Sprint(err != nil),
+			"route":      contextRoute(ctx),
 		}).Inc()
 	}()
 
@@ -336,6 +358,7 @@ func (s *SessionWithMetrics) DeleteRange(
 		s.queryDuration.With(prometheus.Labels{
 			"query_type": queryType,
 			"error":      fmt.Sprint(err != nil),
+			"route":      contextRoute(ctx),
 		}).Observe(v)
 	}))
 	defer func() {
@@ -343,6 +366,7 @@ func (s *SessionWithMetrics) DeleteRange(
 		s.queryCounter.With(prometheus.Labels{
 			"query_type": queryType,
 			"error":      fmt.Sprint(err != nil),
+			"route":      contextRoute(ctx),
 		}).Inc()
 	}()
 

--- a/support/db/metrics.go
+++ b/support/db/metrics.go
@@ -16,6 +16,21 @@ type CtxKey string
 var RouteContextKey = CtxKey("route")
 var QueryTypeContextKey = CtxKey("query_type")
 
+type Subsystem string
+
+var CoreSubsystem = Subsystem("core")
+var HistorySubsystem = Subsystem("history")
+var IngestSubsystem = Subsystem("ingest")
+
+type QueryType string
+
+var DeleteQueryType = QueryType("delete")
+var InsertQueryType = QueryType("insert")
+var SelectQueryType = QueryType("select")
+var UndefinedQueryType = QueryType("undefined")
+var UpdateQueryType = QueryType("update")
+var UpsertQueryType = QueryType("upsert")
+
 // contextRoute returns a string representing the request endpoint, or "undefined" if it wasn't found
 func contextRoute(ctx context.Context) string {
 	if endpoint, ok := ctx.Value(&RouteContextKey).(string); ok {
@@ -40,7 +55,7 @@ type SessionWithMetrics struct {
 	maxLifetimeClosedCounter prometheus.CounterFunc
 }
 
-func RegisterMetrics(base *Session, namespace, sub string, registry *prometheus.Registry) SessionInterface {
+func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *prometheus.Registry) SessionInterface {
 	subsystem := fmt.Sprintf("db_%s", sub)
 	s := &SessionWithMetrics{
 		SessionInterface: base,
@@ -214,10 +229,10 @@ func (s *SessionWithMetrics) TruncateTables(ctx context.Context, tables []string
 
 func (s *SessionWithMetrics) Clone() SessionInterface {
 	return &SessionWithMetrics{
-		SessionInterface:         s.SessionInterface.Clone(),
-		registry:                 s.registry,
-		queryCounter:             s.queryCounter,
-		queryDurationSummary:     s.queryDurationSummary,
+		SessionInterface:     s.SessionInterface.Clone(),
+		registry:             s.registry,
+		queryCounter:         s.queryCounter,
+		queryDurationSummary: s.queryDurationSummary,
 		// txnCounter:               s.txnCounter,
 		// txnDurationSummary:       s.txnDurationSummary,
 		maxOpenConnectionsGauge:  s.maxOpenConnectionsGauge,
@@ -232,25 +247,25 @@ func (s *SessionWithMetrics) Clone() SessionInterface {
 	}
 }
 
-func getQueryType(ctx context.Context, query squirrel.Sqlizer) string {
+func getQueryType(ctx context.Context, query squirrel.Sqlizer) QueryType {
 	// Do we have an explicit query type set in the context? For raw execs, in
 	// lieu of better detection. e.g. "upsert"
-	if q, ok := ctx.Value(&QueryTypeContextKey).(string); ok {
+	if q, ok := ctx.Value(&QueryTypeContextKey).(QueryType); ok {
 		return q
 	}
 
 	// is it a squirrel builder?
 	if _, ok := query.(squirrel.DeleteBuilder); ok {
-		return "delete"
+		return DeleteQueryType
 	}
 	if _, ok := query.(squirrel.InsertBuilder); ok {
-		return "insert"
+		return InsertQueryType
 	}
 	if _, ok := query.(squirrel.SelectBuilder); ok {
-		return "select"
+		return SelectQueryType
 	}
 	if _, ok := query.(squirrel.UpdateBuilder); ok {
-		return "update"
+		return UpdateQueryType
 	}
 
 	// Try to guess based on the first word of the string.
@@ -262,17 +277,17 @@ func getQueryType(ctx context.Context, query squirrel.Sqlizer) string {
 		// complex query.
 		for _, word := range []string{"delete", "insert", "select", "update"} {
 			if word == words[0] {
-				return word
+				return QueryType(word)
 			}
 		}
 	}
 
 	// Fresh out of ideas.
-	return "undefined"
+	return UndefinedQueryType
 }
 
 func (s *SessionWithMetrics) Get(ctx context.Context, dest interface{}, query squirrel.Sqlizer) (err error) {
-	queryType := getQueryType(ctx, query)
+	queryType := string(getQueryType(ctx, query))
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
 		s.queryDurationSummary.With(prometheus.Labels{
 			"query_type": queryType,
@@ -298,7 +313,7 @@ func (s *SessionWithMetrics) GetRaw(ctx context.Context, dest interface{}, query
 }
 
 func (s *SessionWithMetrics) Select(ctx context.Context, dest interface{}, query squirrel.Sqlizer) (err error) {
-	queryType := getQueryType(ctx, query)
+	queryType := string(getQueryType(ctx, query))
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
 		s.queryDurationSummary.With(prometheus.Labels{
 			"query_type": queryType,
@@ -324,7 +339,7 @@ func (s *SessionWithMetrics) SelectRaw(ctx context.Context, dest interface{}, qu
 }
 
 func (s *SessionWithMetrics) Exec(ctx context.Context, query squirrel.Sqlizer) (result sql.Result, err error) {
-	queryType := getQueryType(ctx, query)
+	queryType := string(getQueryType(ctx, query))
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
 		s.queryDurationSummary.With(prometheus.Labels{
 			"query_type": queryType,

--- a/support/db/metrics.go
+++ b/support/db/metrics.go
@@ -1,0 +1,351 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type SessionWithMetrics struct {
+	SessionInterface
+	registry                 *prometheus.Registry
+	queryCounter             *prometheus.CounterVec
+	queryDuration            *prometheus.HistogramVec
+	maxOpenConnectionsGauge  prometheus.GaugeFunc
+	openConnectionsGauge     prometheus.GaugeFunc
+	inUseConnectionsGauge    prometheus.GaugeFunc
+	idleConnectionsGauge     prometheus.GaugeFunc
+	waitCountCounter         prometheus.CounterFunc
+	waitDurationCounter      prometheus.CounterFunc
+	maxIdleClosedCounter     prometheus.CounterFunc
+	maxIdleTimeClosedCounter prometheus.CounterFunc
+	maxLifetimeClosedCounter prometheus.CounterFunc
+}
+
+func RegisterMetrics(base *Session, namespace, sub string, registry *prometheus.Registry) SessionInterface {
+	subsystem := fmt.Sprintf("db_%s", sub)
+	s := &SessionWithMetrics{
+		SessionInterface: base,
+		registry:         registry,
+	}
+
+	s.queryCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Namespace: namespace, Subsystem: subsystem, Name: "query_total"},
+		[]string{"query_type", "error"},
+	)
+	registry.MustRegister(s.queryCounter)
+
+	s.queryDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace, Subsystem: subsystem,
+			Name:    "query_duration_seconds",
+			Buckets: prometheus.ExponentialBuckets(0.1, 2, 5),
+		},
+		[]string{"query_type", "error"},
+	)
+	registry.MustRegister(s.queryDuration)
+
+	// txnCounter: prometheus.NewCounter(
+	// 	prometheus.CounterOpts{Namespace: namespace, Subsystem: subsystem, Name: "transaction_total"},
+	// ),
+	// registry.MustRegister(s.txnCounter)
+	// txnDuration: prometheus.NewHistogram(
+	// 	prometheus.HistogramOpts{
+	// 		Namespace: namespace, Subsystem: subsystem,
+	// 		Name:    "transaction_duration_seconds",
+	//		Buckets: prometheus.ExponentialBuckets(0.1, 3, 5),
+	// 	},
+	// ),
+	// registry.MustRegister(s.txnDuration)
+
+	s.maxOpenConnectionsGauge = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{Namespace: namespace, Subsystem: subsystem, Name: "max_open_connections"},
+		func() float64 {
+			// Right now MaxOpenConnections in Horizon is static however it's possible that
+			// it will change one day. In such case, using GaugeFunc is very cheap and will
+			// prevent issues with this metric in the future.
+			return float64(base.DB.Stats().MaxOpenConnections)
+		},
+	)
+	registry.MustRegister(s.maxOpenConnectionsGauge)
+
+	s.openConnectionsGauge = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{Namespace: namespace, Subsystem: subsystem, Name: "open_connections"},
+		func() float64 {
+			return float64(base.DB.Stats().OpenConnections)
+		},
+	)
+	registry.MustRegister(s.openConnectionsGauge)
+
+	s.inUseConnectionsGauge = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{Namespace: namespace, Subsystem: subsystem, Name: "in_use_connections"},
+		func() float64 {
+			return float64(base.DB.Stats().InUse)
+		},
+	)
+	registry.MustRegister(s.inUseConnectionsGauge)
+
+	s.idleConnectionsGauge = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{Namespace: namespace, Subsystem: subsystem, Name: "idle_connections"},
+		func() float64 {
+			return float64(base.DB.Stats().Idle)
+		},
+	)
+	registry.MustRegister(s.idleConnectionsGauge)
+
+	s.waitCountCounter = prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Namespace: namespace, Subsystem: subsystem, Name: "wait_count_total",
+			Help: "total number of number of connections waited for",
+		},
+		func() float64 {
+			return float64(base.DB.Stats().WaitCount)
+		},
+	)
+	registry.MustRegister(s.waitCountCounter)
+
+	s.waitDurationCounter = prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Namespace: namespace, Subsystem: subsystem, Name: "wait_duration_seconds_total",
+			Help: "total time blocked waiting for a new connection",
+		},
+		func() float64 {
+			return base.DB.Stats().WaitDuration.Seconds()
+		},
+	)
+	registry.MustRegister(s.waitDurationCounter)
+
+	s.maxIdleClosedCounter = prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Namespace: namespace, Subsystem: subsystem, Name: "max_idle_closed_total",
+			Help: "total number of number of connections closed due to SetMaxIdleConns",
+		},
+		func() float64 {
+			return float64(base.DB.Stats().MaxIdleClosed)
+		},
+	)
+	registry.MustRegister(s.maxIdleClosedCounter)
+
+	s.maxIdleTimeClosedCounter = prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Namespace: namespace, Subsystem: subsystem, Name: "max_idle_time_closed_total",
+			Help: "total number of number of connections closed due to SetConnMaxIdleTime",
+		},
+		func() float64 {
+			return float64(base.DB.Stats().MaxIdleTimeClosed)
+		},
+	)
+	registry.MustRegister(s.maxIdleTimeClosedCounter)
+
+	s.maxLifetimeClosedCounter = prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Namespace: namespace, Subsystem: subsystem, Name: "max_lifetime_closed_total",
+			Help: "total number of number of connections closed due to SetConnMaxLifetime",
+		},
+		func() float64 {
+			return float64(base.DB.Stats().MaxLifetimeClosed)
+		},
+	)
+	registry.MustRegister(s.maxLifetimeClosedCounter)
+
+	return s
+}
+
+func (s *SessionWithMetrics) Close() error {
+	s.registry.Unregister(s.queryCounter)
+	s.registry.Unregister(s.queryDuration)
+	// s.registry.Unregister(s.txnCounter)
+	// s.registry.Unregister(s.txnDuration)
+	s.registry.Unregister(s.maxOpenConnectionsGauge)
+	s.registry.Unregister(s.openConnectionsGauge)
+	s.registry.Unregister(s.inUseConnectionsGauge)
+	s.registry.Unregister(s.idleConnectionsGauge)
+	s.registry.Unregister(s.waitCountCounter)
+	s.registry.Unregister(s.waitDurationCounter)
+	s.registry.Unregister(s.maxIdleClosedCounter)
+	s.registry.Unregister(s.maxIdleTimeClosedCounter)
+	s.registry.Unregister(s.maxLifetimeClosedCounter)
+	return s.SessionInterface.Close()
+}
+
+// TODO: Implement these
+// func (s *SessionWithMetrics) BeginTx(ctx context.Context, opts *sql.TxOptions) error {
+// func (s *SessionWithMetrics) Begin(ctx context.Context) error {
+// func (s *SessionWithMetrics) Commit(ctx context.Context) error
+// func (s *SessionWithMetrics) Rollback(ctx context.Context) error
+
+func (s *SessionWithMetrics) TruncateTables(ctx context.Context, tables []string) (err error) {
+	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
+		s.queryDuration.With(prometheus.Labels{
+			"query_type": "truncate_tables",
+			"error":      fmt.Sprint(err != nil),
+		}).Observe(v)
+	}))
+	defer func() {
+		timer.ObserveDuration()
+		s.queryCounter.With(prometheus.Labels{
+			"query_type": "truncate_tables",
+			"error":      fmt.Sprint(err != nil),
+		}).Inc()
+	}()
+
+	err = s.SessionInterface.TruncateTables(ctx, tables)
+	return err
+}
+
+func (s *SessionWithMetrics) Clone() SessionInterface {
+	return &SessionWithMetrics{
+		SessionInterface:         s.SessionInterface.Clone(),
+		registry:                 s.registry,
+		queryCounter:             s.queryCounter,
+		queryDuration:            s.queryDuration,
+		// txnCounter:               s.txnCounter,
+		// txnDuration:              s.txnDuration,
+		maxOpenConnectionsGauge:  s.maxOpenConnectionsGauge,
+		openConnectionsGauge:     s.openConnectionsGauge,
+		inUseConnectionsGauge:    s.inUseConnectionsGauge,
+		idleConnectionsGauge:     s.idleConnectionsGauge,
+		waitCountCounter:         s.waitCountCounter,
+		waitDurationCounter:      s.waitDurationCounter,
+		maxIdleClosedCounter:     s.maxIdleClosedCounter,
+		maxIdleTimeClosedCounter: s.maxIdleTimeClosedCounter,
+		maxLifetimeClosedCounter: s.maxLifetimeClosedCounter,
+	}
+}
+
+func getQueryType(query squirrel.Sqlizer) string {
+	if _, ok := query.(squirrel.DeleteBuilder); ok {
+		return "delete"
+	}
+	if _, ok := query.(squirrel.InsertBuilder); ok {
+		return "insert"
+	}
+	if _, ok := query.(squirrel.SelectBuilder); ok {
+		return "select"
+	}
+	if _, ok := query.(squirrel.UpdateBuilder); ok {
+		return "update"
+	}
+	return "undefined"
+}
+
+func (s *SessionWithMetrics) Get(ctx context.Context, dest interface{}, query squirrel.Sqlizer) (err error) {
+	queryType := getQueryType(query)
+	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
+		s.queryDuration.With(prometheus.Labels{
+			"query_type": queryType,
+			"error":      fmt.Sprint(err != nil),
+		}).Observe(v)
+	}))
+	defer func() {
+		timer.ObserveDuration()
+		s.queryCounter.With(prometheus.Labels{
+			"query_type": queryType,
+			"error":      fmt.Sprint(err != nil),
+		}).Inc()
+	}()
+
+	err = s.SessionInterface.Get(ctx, dest, query)
+	return err
+}
+
+func (s *SessionWithMetrics) GetRaw(ctx context.Context, dest interface{}, query string, args ...interface{}) (err error) {
+	return s.Get(ctx, dest, squirrel.Expr(query, args...))
+}
+
+func (s *SessionWithMetrics) Select(ctx context.Context, dest interface{}, query squirrel.Sqlizer) (err error) {
+	queryType := getQueryType(query)
+	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
+		s.queryDuration.With(prometheus.Labels{
+			"query_type": queryType,
+			"error":      fmt.Sprint(err != nil),
+		}).Observe(v)
+	}))
+	defer func() {
+		timer.ObserveDuration()
+		s.queryCounter.With(prometheus.Labels{
+			"query_type": queryType,
+			"error":      fmt.Sprint(err != nil),
+		}).Inc()
+	}()
+
+	err = s.SessionInterface.Select(ctx, dest, query)
+	return err
+}
+
+func (s *SessionWithMetrics) SelectRaw(ctx context.Context, dest interface{}, query string, args ...interface{}) (err error) {
+	return s.Select(ctx, dest, squirrel.Expr(query, args...))
+}
+
+func (s *SessionWithMetrics) Exec(ctx context.Context, query squirrel.Sqlizer) (result sql.Result, err error) {
+	queryType := getQueryType(query)
+	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
+		s.queryDuration.With(prometheus.Labels{
+			"query_type": queryType,
+			"error":      fmt.Sprint(err != nil),
+		}).Observe(v)
+	}))
+	defer func() {
+		timer.ObserveDuration()
+		s.queryCounter.With(prometheus.Labels{
+			"query_type": queryType,
+			"error":      fmt.Sprint(err != nil),
+		}).Inc()
+	}()
+
+	result, err = s.SessionInterface.Exec(ctx, query)
+	return result, err
+}
+
+func (s *SessionWithMetrics) ExecRaw(ctx context.Context, query string, args ...interface{}) (result sql.Result, err error) {
+	return s.Exec(ctx, squirrel.Expr(query, args...))
+}
+
+func (s *SessionWithMetrics) Ping(ctx context.Context, timeout time.Duration) (err error) {
+	queryType := "ping"
+	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
+		s.queryDuration.With(prometheus.Labels{
+			"query_type": queryType,
+			"error":      fmt.Sprint(err != nil),
+		}).Observe(v)
+	}))
+	defer func() {
+		timer.ObserveDuration()
+		s.queryCounter.With(prometheus.Labels{
+			"query_type": queryType,
+			"error":      fmt.Sprint(err != nil),
+		}).Inc()
+	}()
+
+	err = s.SessionInterface.Ping(ctx, timeout)
+	return err
+}
+
+func (s *SessionWithMetrics) DeleteRange(
+	ctx context.Context,
+	start, end int64,
+	table string,
+	idCol string,
+) (err error) {
+	queryType := "delete"
+	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
+		s.queryDuration.With(prometheus.Labels{
+			"query_type": queryType,
+			"error":      fmt.Sprint(err != nil),
+		}).Observe(v)
+	}))
+	defer func() {
+		timer.ObserveDuration()
+		s.queryCounter.With(prometheus.Labels{
+			"query_type": queryType,
+			"error":      fmt.Sprint(err != nil),
+		}).Inc()
+	}()
+
+	err = s.SessionInterface.DeleteRange(ctx, start, end, table, idCol)
+	return err
+}

--- a/support/db/metrics.go
+++ b/support/db/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/squirrel"
@@ -13,6 +14,7 @@ import (
 type CtxKey string
 
 var RouteContextKey = CtxKey("route")
+var QueryTypeContextKey = CtxKey("query_type")
 
 // contextRoute returns a string representing the request endpoint, or "undefined" if it wasn't found
 func contextRoute(ctx context.Context) string {
@@ -230,7 +232,14 @@ func (s *SessionWithMetrics) Clone() SessionInterface {
 	}
 }
 
-func getQueryType(query squirrel.Sqlizer) string {
+func getQueryType(ctx context.Context, query squirrel.Sqlizer) string {
+	// Do we have an explicit query type set in the context? For raw execs, in
+	// lieu of better detection. e.g. "upsert"
+	if q, ok := ctx.Value(&QueryTypeContextKey).(string); ok {
+		return q
+	}
+
+	// is it a squirrel builder?
 	if _, ok := query.(squirrel.DeleteBuilder); ok {
 		return "delete"
 	}
@@ -243,11 +252,27 @@ func getQueryType(query squirrel.Sqlizer) string {
 	if _, ok := query.(squirrel.UpdateBuilder); ok {
 		return "update"
 	}
+
+	// Try to guess based on the first word of the string.
+	// e.g. "SELECT * FROM table"
+	str, _, err := query.ToSql()
+	words := strings.Fields(strings.TrimSpace(strings.ToLower(str)))
+	if err == nil && len(words) > 0 {
+		// Make sure we don't only get known keywords here, incase it's a more
+		// complex query.
+		for _, word := range []string{"delete", "insert", "select", "update"} {
+			if word == words[0] {
+				return word
+			}
+		}
+	}
+
+	// Fresh out of ideas.
 	return "undefined"
 }
 
 func (s *SessionWithMetrics) Get(ctx context.Context, dest interface{}, query squirrel.Sqlizer) (err error) {
-	queryType := getQueryType(query)
+	queryType := getQueryType(ctx, query)
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
 		s.queryDurationSummary.With(prometheus.Labels{
 			"query_type": queryType,
@@ -273,7 +298,7 @@ func (s *SessionWithMetrics) GetRaw(ctx context.Context, dest interface{}, query
 }
 
 func (s *SessionWithMetrics) Select(ctx context.Context, dest interface{}, query squirrel.Sqlizer) (err error) {
-	queryType := getQueryType(query)
+	queryType := getQueryType(ctx, query)
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
 		s.queryDurationSummary.With(prometheus.Labels{
 			"query_type": queryType,
@@ -299,7 +324,7 @@ func (s *SessionWithMetrics) SelectRaw(ctx context.Context, dest interface{}, qu
 }
 
 func (s *SessionWithMetrics) Exec(ctx context.Context, query squirrel.Sqlizer) (result sql.Result, err error) {
-	queryType := getQueryType(query)
+	queryType := getQueryType(ctx, query)
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
 		s.queryDurationSummary.With(prometheus.Labels{
 			"query_type": queryType,

--- a/support/db/metrics.go
+++ b/support/db/metrics.go
@@ -26,7 +26,7 @@ type SessionWithMetrics struct {
 	SessionInterface
 	registry                 *prometheus.Registry
 	queryCounter             *prometheus.CounterVec
-	queryDuration            *prometheus.HistogramVec
+	queryDurationSummary     *prometheus.SummaryVec
 	maxOpenConnectionsGauge  prometheus.GaugeFunc
 	openConnectionsGauge     prometheus.GaugeFunc
 	inUseConnectionsGauge    prometheus.GaugeFunc
@@ -51,15 +51,14 @@ func RegisterMetrics(base *Session, namespace, sub string, registry *prometheus.
 	)
 	registry.MustRegister(s.queryCounter)
 
-	s.queryDuration = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
+	s.queryDurationSummary = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
 			Namespace: namespace, Subsystem: subsystem,
-			Name:    "query_duration_seconds",
-			Buckets: prometheus.ExponentialBuckets(0.1, 2, 5),
+			Name: "query_duration_seconds",
 		},
 		[]string{"query_type", "error", "route"},
 	)
-	registry.MustRegister(s.queryDuration)
+	registry.MustRegister(s.queryDurationSummary)
 
 	// txnCounter: prometheus.NewCounter(
 	// 	prometheus.CounterOpts{Namespace: namespace, Subsystem: subsystem, Name: "transaction_total"},
@@ -169,9 +168,9 @@ func RegisterMetrics(base *Session, namespace, sub string, registry *prometheus.
 
 func (s *SessionWithMetrics) Close() error {
 	s.registry.Unregister(s.queryCounter)
-	s.registry.Unregister(s.queryDuration)
+	s.registry.Unregister(s.queryDurationSummary)
 	// s.registry.Unregister(s.txnCounter)
-	// s.registry.Unregister(s.txnDuration)
+	// s.registry.Unregister(s.txnDurationSummary)
 	s.registry.Unregister(s.maxOpenConnectionsGauge)
 	s.registry.Unregister(s.openConnectionsGauge)
 	s.registry.Unregister(s.inUseConnectionsGauge)
@@ -192,7 +191,7 @@ func (s *SessionWithMetrics) Close() error {
 
 func (s *SessionWithMetrics) TruncateTables(ctx context.Context, tables []string) (err error) {
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-		s.queryDuration.With(prometheus.Labels{
+		s.queryDurationSummary.With(prometheus.Labels{
 			"query_type": "truncate_tables",
 			"error":      fmt.Sprint(err != nil),
 			"route":      contextRoute(ctx),
@@ -216,9 +215,9 @@ func (s *SessionWithMetrics) Clone() SessionInterface {
 		SessionInterface:         s.SessionInterface.Clone(),
 		registry:                 s.registry,
 		queryCounter:             s.queryCounter,
-		queryDuration:            s.queryDuration,
+		queryDurationSummary:     s.queryDurationSummary,
 		// txnCounter:               s.txnCounter,
-		// txnDuration:              s.txnDuration,
+		// txnDurationSummary:       s.txnDurationSummary,
 		maxOpenConnectionsGauge:  s.maxOpenConnectionsGauge,
 		openConnectionsGauge:     s.openConnectionsGauge,
 		inUseConnectionsGauge:    s.inUseConnectionsGauge,
@@ -250,7 +249,7 @@ func getQueryType(query squirrel.Sqlizer) string {
 func (s *SessionWithMetrics) Get(ctx context.Context, dest interface{}, query squirrel.Sqlizer) (err error) {
 	queryType := getQueryType(query)
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-		s.queryDuration.With(prometheus.Labels{
+		s.queryDurationSummary.With(prometheus.Labels{
 			"query_type": queryType,
 			"error":      fmt.Sprint(err != nil),
 			"route":      contextRoute(ctx),
@@ -276,7 +275,7 @@ func (s *SessionWithMetrics) GetRaw(ctx context.Context, dest interface{}, query
 func (s *SessionWithMetrics) Select(ctx context.Context, dest interface{}, query squirrel.Sqlizer) (err error) {
 	queryType := getQueryType(query)
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-		s.queryDuration.With(prometheus.Labels{
+		s.queryDurationSummary.With(prometheus.Labels{
 			"query_type": queryType,
 			"error":      fmt.Sprint(err != nil),
 			"route":      contextRoute(ctx),
@@ -302,7 +301,7 @@ func (s *SessionWithMetrics) SelectRaw(ctx context.Context, dest interface{}, qu
 func (s *SessionWithMetrics) Exec(ctx context.Context, query squirrel.Sqlizer) (result sql.Result, err error) {
 	queryType := getQueryType(query)
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-		s.queryDuration.With(prometheus.Labels{
+		s.queryDurationSummary.With(prometheus.Labels{
 			"query_type": queryType,
 			"error":      fmt.Sprint(err != nil),
 			"route":      contextRoute(ctx),
@@ -328,7 +327,7 @@ func (s *SessionWithMetrics) ExecRaw(ctx context.Context, query string, args ...
 func (s *SessionWithMetrics) Ping(ctx context.Context, timeout time.Duration) (err error) {
 	queryType := "ping"
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-		s.queryDuration.With(prometheus.Labels{
+		s.queryDurationSummary.With(prometheus.Labels{
 			"query_type": queryType,
 			"error":      fmt.Sprint(err != nil),
 			"route":      contextRoute(ctx),
@@ -355,7 +354,7 @@ func (s *SessionWithMetrics) DeleteRange(
 ) (err error) {
 	queryType := "delete"
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-		s.queryDuration.With(prometheus.Labels{
+		s.queryDurationSummary.With(prometheus.Labels{
 			"query_type": queryType,
 			"error":      fmt.Sprint(err != nil),
 			"route":      contextRoute(ctx),

--- a/support/db/mock_session.go
+++ b/support/db/mock_session.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Masterminds/squirrel"
 	sq "github.com/Masterminds/squirrel"
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -31,14 +32,29 @@ func (m *MockSession) Rollback(ctx context.Context) error {
 	return args.Error(0)
 }
 
+func (m *MockSession) Commit(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockSession) GetTx() *sqlx.Tx {
+	args := m.Called()
+	return args.Get(0).(*sqlx.Tx)
+}
+
+func (m *MockSession) GetTxOptions() *sql.TxOptions {
+	args := m.Called()
+	return args.Get(0).(*sql.TxOptions)
+}
+
 func (m *MockSession) TruncateTables(ctx context.Context, tables []string) error {
 	args := m.Called(ctx, tables)
 	return args.Error(0)
 }
 
-func (m *MockSession) Clone() *Session {
+func (m *MockSession) Clone() SessionInterface {
 	args := m.Called()
-	return args.Get(0).(*Session)
+	return args.Get(0).(SessionInterface)
 }
 
 func (m *MockSession) Close() error {
@@ -92,4 +108,13 @@ func (m *MockSession) NoRows(err error) bool {
 
 func (m *MockSession) Ping(ctx context.Context, timeout time.Duration) error {
 	return m.Called(ctx, timeout).Error(0)
+}
+
+func (m *MockSession) DeleteRange(
+	ctx context.Context,
+	start, end int64,
+	table string,
+	idCol string,
+) (err error) {
+	return m.Called(ctx, start, end, table, idCol).Error(0)
 }

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -68,7 +68,7 @@ func (s *Session) GetTxOptions() *sql.TxOptions {
 // Clone clones the receiver, returning a new instance backed by the same
 // context and db. The result will not be bound to any transaction that the
 // source is currently within.
-func (s *Session) Clone() *Session {
+func (s *Session) Clone() SessionInterface {
 	return &Session{
 		DB: s.DB,
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add prometheus metrics for query count and duration to horizon database calls. Turns out the metrics we had before were actually missing the ingest and core database clients as well, so I've added the same metrics to those too.

The big code changes here are:
- Actually use `db.SessionInterface`, instead of just using `*db.Session` everywhere. Nice cleanup anyway.
- Have to pass the `StateMiddleware` and `HistoryMiddleware` into each route individually, as they have to happen after routing. Big OOF.

### Why

So we can verify and really understand which endpoints are causing db load and why.

Fixes https://github.com/stellar/go/issues/3593

### Known limitations

- [x] TODO: Needs a bit more testing, like firing it up and seeing it work.
- I'm not sure if the register/unregister calls are in the right place. wdyt?
- @jacekn Do these metrics and labels look right?