### PR TITLE
Fallback to Origin header if Referer is not set

### DIFF
--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -154,6 +154,9 @@ func logEndOfRequest(ctx context.Context, r *http.Request, requestDurationSummar
 
 	referer := r.Referer()
 	if referer == "" {
+		referer = r.Header.Get("Origin")
+	}
+	if referer == "" {
 		referer = "undefined"
 	}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

If `Referer` is not set, log the `Origin` instead.

### Why

So we get more complete stats on inbound traffic sources. Browsers do not always set the `Referer` header, but do set `Origin` on all cross-origin requests (most of our requests).

### Known limitations

[TODO or N/A]
