### PR TITLE
services/horizon: Revert "Use Core 17 for CI (and disable cap35-specific job) (#3585)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,6 +421,10 @@ jobs:
       enable-captive-core:
         type: boolean
         default: false
+      # TODO: remove once a stellar core version with cap-35 is released
+      enable-cap-35-tests:
+        type: boolean
+        default: false
     working_directory: ~/go/src/github.com/stellar/go
     machine:
       image: ubuntu-1604:202010-01
@@ -439,12 +443,28 @@ jobs:
       - when:
           condition: <<parameters.enable-captive-core>>
           steps:
-            - install_stellar_core
+            - unless:
+                condition: <<parameters.enable-cap-35-tests>>
+                steps:
+                  # Install the default version of stellar core
+                  - install_stellar_core
+            - when:
+                condition: <<parameters.enable-cap-35-tests>>
+                steps:
+                  # Install a Stellar Core version with CAP35 support
+                  - install_stellar_core:
+                      core-version: 15.3.0-498.7a7f18c.xenial~SetTrustlineFlagsPR~buildtests
             - run:
                 name: Setting Captive Core env variables
                 command: echo "export HORIZON_INTEGRATION_ENABLE_CAPTIVE_CORE=true" >> $BASH_ENV
+      - when:
+          condition: <<parameters.enable-cap-35-tests>>
+          steps:
+            - run:
+                name: Setting CAP35 env variables
+                command: echo "export HORIZON_INTEGRATION_ENABLE_CAP_35=true" >> $BASH_ENV
       - run:
-          name: Run Horizon integration tests <<#parameters.enable-captive-core>>(With captive core)<</parameters.enable-captive-core>>
+          name: Run Horizon integration tests <<#parameters.enable-captive-core>>(With captive core)<</parameters.enable-captive-core>> <<#parameters.enable-cap-35-tests>>(With CAP35)<</parameters.enable-cap-35-tests>>
           # Currently all integration tests are in a single directory.
           # Pulling the image helps with test running time
           command: |
@@ -472,6 +492,11 @@ workflows:
       - test_horizon_integration:
           name: test_horizon_integration_with_captive_core
           enable-captive-core: true
+      # ... and cap35 with captive core
+      - test_horizon_integration:
+          name: test_horizon_integration_cap35_with_captive_core
+          enable-captive-core: true
+          enable-cap-35-tests: true
       - test_verify_range_docker_image
       - publish_state_diff_docker_image:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,9 @@ commands:
     parameters:
       core-version:
         type: string
-        default: "" # latest version by default
+        # version which works with captive-core by default
+        # TODO: Set this to latest once core is fixed
+        default: "15.3.0-498.7a7f18c.xenial~SetTrustlineFlagsPR~buildtests"
     steps:
       - run:
           name: Install Stellar Core <<#parameters.core-version>> (version <<parameters.core-version>>)<</parameters.core-version>>

--- a/services/horizon/docker/Dockerfile.dev
+++ b/services/horizon/docker/Dockerfile.dev
@@ -9,7 +9,7 @@ RUN go install github.com/stellar/go/exp/services/captivecore
 
 FROM ubuntu:20.04
 
-ENV STELLAR_CORE_VERSION 17.0.0-557.096f6a7.focal
+ENV STELLAR_CORE_VERSION 15.0.0-40
 ENV STELLAR_CORE_BINARY_PATH /usr/bin/stellar-core
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/services/horizon/docker/core-start.sh
+++ b/services/horizon/docker/core-start.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-set -x
 
 source /etc/profile
 
@@ -24,4 +23,4 @@ if [ "$1" = "standalone" ]; then
   popd
 fi
 
-exec stellar-core run
+exec /init -- stellar-core run

--- a/services/horizon/docker/docker-compose.integration-tests.yml
+++ b/services/horizon/docker/docker-compose.integration-tests.yml
@@ -10,7 +10,7 @@ services:
       - "5641:5641"
     command: ["-p", "5641"]
   core:
-    image: ${CORE_IMAGE:-stellar/stellar-core:v17.0.0}
+    image: ${CORE_IMAGE:-stellar/stellar-core}
     depends_on:
       - core-postgres
     restart: on-failure

--- a/services/horizon/docker/docker-compose.integration-tests.yml
+++ b/services/horizon/docker/docker-compose.integration-tests.yml
@@ -10,7 +10,7 @@ services:
       - "5641:5641"
     command: ["-p", "5641"]
   core:
-    image: ${CORE_IMAGE:-stellar/stellar-core}
+    image: ${CORE_IMAGE:-stellar/stellar-core:15.3.0-1506-ff56e7f2}
     depends_on:
       - core-postgres
     restart: on-failure

--- a/services/horizon/internal/integration/protocol16_test.go
+++ b/services/horizon/internal/integration/protocol16_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,7 +18,14 @@ import (
 )
 
 func NewProtocol16Test(t *testing.T) *integration.Test {
-	config := integration.Config{ProtocolVersion: 17}
+	// TODO, this should be removed once a core version with CAP 35 is released
+	if os.Getenv("HORIZON_INTEGRATION_ENABLE_CAP_35") != "true" {
+		t.Skip("skipping CAP35 test, set HORIZON_INTEGRATION_ENABLE_CAP_35=true if you want to run it")
+	}
+	config := integration.Config{
+		ProtocolVersion: 16,
+		CoreDockerImage: "2opremio/stellar-core:cap35",
+	}
 	return integration.NewTest(t, config)
 }
 
@@ -29,8 +37,8 @@ func TestProtocol16Basics(t *testing.T) {
 	t.Run("Sanity", func(t *testing.T) {
 		root, err := itest.Client().Root()
 		tt.NoError(err)
-		tt.LessOrEqual(int32(17), root.CoreSupportedProtocolVersion)
-		tt.Equal(int32(17), root.CurrentProtocolVersion)
+		tt.LessOrEqual(int32(16), root.CoreSupportedProtocolVersion)
+		tt.Equal(int32(16), root.CurrentProtocolVersion)
 
 		// Submit a simple tx
 		op := txnbuild.Payment{


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This reverts commit 72c01edaa63e8c903e5e99666545e5fd8d59ae2b. (#3585)


### Why

It resulted in captive core crashing, and the integration tests hanging.

### Known limitations

- @2opremio wdyt?
