### PR TITLE
services/horizon: Fixup db metrics

### DIFF
--- a/services/horizon/internal/db2/history/orderbook.go
+++ b/services/horizon/internal/db2/history/orderbook.go
@@ -102,6 +102,7 @@ func (q *Q) GetOrderBookSummary(ctx context.Context, sellingAsset, buyingAsset x
 			LIMIT $3
 		)
 	`
+	// Add explicit query type for prometheus metrics, since we use raw sql.
 	ctx = context.WithValue(ctx, &db.QueryTypeContextKey, db.SelectQueryType)
 	err = q.SelectRaw(ctx, &levels, selectPriceLevels, selling, buying, maxPriceLevels)
 	if err != nil {

--- a/services/horizon/internal/db2/history/orderbook.go
+++ b/services/horizon/internal/db2/history/orderbook.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/stellar/go/amount"
+	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -101,6 +102,7 @@ func (q *Q) GetOrderBookSummary(ctx context.Context, sellingAsset, buyingAsset x
 			LIMIT $3
 		)
 	`
+	ctx = context.WithValue(ctx, &db.QueryTypeContextKey, db.SelectQueryType)
 	err = q.SelectRaw(ctx, &levels, selectPriceLevels, selling, buying, maxPriceLevels)
 	if err != nil {
 		return result, errors.Wrap(err, "cannot select price levels")

--- a/services/horizon/internal/db2/history/trade.go
+++ b/services/horizon/internal/db2/history/trade.go
@@ -8,6 +8,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 
 	"github.com/stellar/go/services/horizon/internal/db2"
+	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -195,6 +196,7 @@ func (q *TradesQ) Select(ctx context.Context, dest interface{}) error {
 		return errors.New("TradesQ.Page call is required before calling Select")
 	}
 
+	ctx = context.WithValue(ctx, &db.QueryTypeContextKey, db.SelectQueryType)
 	if q.rawSQL != "" {
 		q.Err = q.parent.SelectRaw(ctx, dest, q.rawSQL, q.rawArgs...)
 	} else {

--- a/services/horizon/internal/db2/history/trade.go
+++ b/services/horizon/internal/db2/history/trade.go
@@ -196,6 +196,7 @@ func (q *TradesQ) Select(ctx context.Context, dest interface{}) error {
 		return errors.New("TradesQ.Page call is required before calling Select")
 	}
 
+	// Add explicit query type for prometheus metrics, since we use raw sql.
 	ctx = context.WithValue(ctx, &db.QueryTypeContextKey, db.SelectQueryType)
 	if q.rawSQL != "" {
 		q.Err = q.parent.SelectRaw(ctx, dest, q.rawSQL, q.rawArgs...)

--- a/support/db/metrics.go
+++ b/support/db/metrics.go
@@ -16,11 +16,11 @@ type CtxKey string
 var RouteContextKey = CtxKey("route")
 var QueryTypeContextKey = CtxKey("query_type")
 
-type Subsystem string
+type Subservice string
 
-var CoreSubsystem = Subsystem("core")
-var HistorySubsystem = Subsystem("history")
-var IngestSubsystem = Subsystem("ingest")
+var CoreSubservice = Subservice("core")
+var HistorySubservice = Subservice("history")
+var IngestSubservice = Subservice("ingest")
 
 type QueryType string
 
@@ -55,7 +55,7 @@ type SessionWithMetrics struct {
 	maxLifetimeClosedCounter prometheus.CounterFunc
 }
 
-func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *prometheus.Registry) SessionInterface {
+func RegisterMetrics(base *Session, namespace string, sub Subservice, registry *prometheus.Registry) SessionInterface {
 	s := &SessionWithMetrics{
 		SessionInterface: base,
 		registry:         registry,
@@ -66,7 +66,7 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 			Namespace:   namespace,
 			Subsystem:   "db",
 			Name:        "query_total",
-			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
+			ConstLabels: prometheus.Labels{"subservice": string(sub)},
 		},
 		[]string{"query_type", "error", "route"},
 	)
@@ -76,7 +76,7 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 		prometheus.SummaryOpts{
 			Namespace: namespace, Subsystem: "db",
 			Name:        "query_duration_seconds",
-			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
+			ConstLabels: prometheus.Labels{"subservice": string(sub)},
 		},
 		[]string{"query_type", "error", "route"},
 	)
@@ -100,7 +100,7 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 			Namespace:   namespace,
 			Subsystem:   "db",
 			Name:        "max_open_connections",
-			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
+			ConstLabels: prometheus.Labels{"subservice": string(sub)},
 		},
 		func() float64 {
 			// Right now MaxOpenConnections in Horizon is static however it's possible that
@@ -116,7 +116,7 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 			Namespace:   namespace,
 			Subsystem:   "db",
 			Name:        "open_connections",
-			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
+			ConstLabels: prometheus.Labels{"subservice": string(sub)},
 		},
 		func() float64 {
 			return float64(base.DB.Stats().OpenConnections)
@@ -129,7 +129,7 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 			Namespace:   namespace,
 			Subsystem:   "db",
 			Name:        "in_use_connections",
-			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
+			ConstLabels: prometheus.Labels{"subservice": string(sub)},
 		},
 		func() float64 {
 			return float64(base.DB.Stats().InUse)
@@ -142,7 +142,7 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 			Namespace:   namespace,
 			Subsystem:   "db",
 			Name:        "idle_connections",
-			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
+			ConstLabels: prometheus.Labels{"subservice": string(sub)},
 		},
 		func() float64 {
 			return float64(base.DB.Stats().Idle)
@@ -156,7 +156,7 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 			Subsystem:   "db",
 			Name:        "wait_count_total",
 			Help:        "total number of number of connections waited for",
-			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
+			ConstLabels: prometheus.Labels{"subservice": string(sub)},
 		},
 		func() float64 {
 			return float64(base.DB.Stats().WaitCount)
@@ -170,7 +170,7 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 			Subsystem:   "db",
 			Name:        "wait_duration_seconds_total",
 			Help:        "total time blocked waiting for a new connection",
-			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
+			ConstLabels: prometheus.Labels{"subservice": string(sub)},
 		},
 		func() float64 {
 			return base.DB.Stats().WaitDuration.Seconds()
@@ -184,7 +184,7 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 			Subsystem:   "db",
 			Name:        "max_idle_closed_total",
 			Help:        "total number of number of connections closed due to SetMaxIdleConns",
-			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
+			ConstLabels: prometheus.Labels{"subservice": string(sub)},
 		},
 		func() float64 {
 			return float64(base.DB.Stats().MaxIdleClosed)
@@ -198,7 +198,7 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 			Subsystem:   "db",
 			Name:        "max_idle_time_closed_total",
 			Help:        "total number of number of connections closed due to SetConnMaxIdleTime",
-			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
+			ConstLabels: prometheus.Labels{"subservice": string(sub)},
 		},
 		func() float64 {
 			return float64(base.DB.Stats().MaxIdleTimeClosed)
@@ -212,7 +212,7 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 			Subsystem:   "db",
 			Name:        "max_lifetime_closed_total",
 			Help:        "total number of number of connections closed due to SetConnMaxLifetime",
-			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
+			ConstLabels: prometheus.Labels{"subservice": string(sub)},
 		},
 		func() float64 {
 			return float64(base.DB.Stats().MaxLifetimeClosed)

--- a/support/db/metrics.go
+++ b/support/db/metrics.go
@@ -56,34 +56,39 @@ type SessionWithMetrics struct {
 }
 
 func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *prometheus.Registry) SessionInterface {
-	subsystem := fmt.Sprintf("db_%s", sub)
 	s := &SessionWithMetrics{
 		SessionInterface: base,
 		registry:         registry,
 	}
 
 	s.queryCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{Namespace: namespace, Subsystem: subsystem, Name: "query_total"},
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   "db",
+			Name:        "query_total",
+			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
+		},
 		[]string{"query_type", "error", "route"},
 	)
 	registry.MustRegister(s.queryCounter)
 
 	s.queryDurationSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
-			Namespace: namespace, Subsystem: subsystem,
-			Name: "query_duration_seconds",
+			Namespace: namespace, Subsystem: "db",
+			Name:        "query_duration_seconds",
+			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
 		},
 		[]string{"query_type", "error", "route"},
 	)
 	registry.MustRegister(s.queryDurationSummary)
 
 	// txnCounter: prometheus.NewCounter(
-	// 	prometheus.CounterOpts{Namespace: namespace, Subsystem: subsystem, Name: "transaction_total"},
+	// 	prometheus.CounterOpts{Namespace: namespace, Subsystem: "db", Name: "transaction_total"},
 	// ),
 	// registry.MustRegister(s.txnCounter)
 	// txnDuration: prometheus.NewHistogram(
 	// 	prometheus.HistogramOpts{
-	// 		Namespace: namespace, Subsystem: subsystem,
+	// 		Namespace: namespace, Subsystem: "db",
 	// 		Name:    "transaction_duration_seconds",
 	//		Buckets: prometheus.ExponentialBuckets(0.1, 3, 5),
 	// 	},
@@ -91,7 +96,12 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 	// registry.MustRegister(s.txnDuration)
 
 	s.maxOpenConnectionsGauge = prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{Namespace: namespace, Subsystem: subsystem, Name: "max_open_connections"},
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Subsystem:   "db",
+			Name:        "max_open_connections",
+			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
+		},
 		func() float64 {
 			// Right now MaxOpenConnections in Horizon is static however it's possible that
 			// it will change one day. In such case, using GaugeFunc is very cheap and will
@@ -102,7 +112,12 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 	registry.MustRegister(s.maxOpenConnectionsGauge)
 
 	s.openConnectionsGauge = prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{Namespace: namespace, Subsystem: subsystem, Name: "open_connections"},
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Subsystem:   "db",
+			Name:        "open_connections",
+			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
+		},
 		func() float64 {
 			return float64(base.DB.Stats().OpenConnections)
 		},
@@ -110,7 +125,12 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 	registry.MustRegister(s.openConnectionsGauge)
 
 	s.inUseConnectionsGauge = prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{Namespace: namespace, Subsystem: subsystem, Name: "in_use_connections"},
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Subsystem:   "db",
+			Name:        "in_use_connections",
+			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
+		},
 		func() float64 {
 			return float64(base.DB.Stats().InUse)
 		},
@@ -118,7 +138,12 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 	registry.MustRegister(s.inUseConnectionsGauge)
 
 	s.idleConnectionsGauge = prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{Namespace: namespace, Subsystem: subsystem, Name: "idle_connections"},
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Subsystem:   "db",
+			Name:        "idle_connections",
+			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
+		},
 		func() float64 {
 			return float64(base.DB.Stats().Idle)
 		},
@@ -127,8 +152,11 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 
 	s.waitCountCounter = prometheus.NewCounterFunc(
 		prometheus.CounterOpts{
-			Namespace: namespace, Subsystem: subsystem, Name: "wait_count_total",
-			Help: "total number of number of connections waited for",
+			Namespace:   namespace,
+			Subsystem:   "db",
+			Name:        "wait_count_total",
+			Help:        "total number of number of connections waited for",
+			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
 		},
 		func() float64 {
 			return float64(base.DB.Stats().WaitCount)
@@ -138,8 +166,11 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 
 	s.waitDurationCounter = prometheus.NewCounterFunc(
 		prometheus.CounterOpts{
-			Namespace: namespace, Subsystem: subsystem, Name: "wait_duration_seconds_total",
-			Help: "total time blocked waiting for a new connection",
+			Namespace:   namespace,
+			Subsystem:   "db",
+			Name:        "wait_duration_seconds_total",
+			Help:        "total time blocked waiting for a new connection",
+			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
 		},
 		func() float64 {
 			return base.DB.Stats().WaitDuration.Seconds()
@@ -149,8 +180,11 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 
 	s.maxIdleClosedCounter = prometheus.NewCounterFunc(
 		prometheus.CounterOpts{
-			Namespace: namespace, Subsystem: subsystem, Name: "max_idle_closed_total",
-			Help: "total number of number of connections closed due to SetMaxIdleConns",
+			Namespace:   namespace,
+			Subsystem:   "db",
+			Name:        "max_idle_closed_total",
+			Help:        "total number of number of connections closed due to SetMaxIdleConns",
+			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
 		},
 		func() float64 {
 			return float64(base.DB.Stats().MaxIdleClosed)
@@ -160,8 +194,11 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 
 	s.maxIdleTimeClosedCounter = prometheus.NewCounterFunc(
 		prometheus.CounterOpts{
-			Namespace: namespace, Subsystem: subsystem, Name: "max_idle_time_closed_total",
-			Help: "total number of number of connections closed due to SetConnMaxIdleTime",
+			Namespace:   namespace,
+			Subsystem:   "db",
+			Name:        "max_idle_time_closed_total",
+			Help:        "total number of number of connections closed due to SetConnMaxIdleTime",
+			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
 		},
 		func() float64 {
 			return float64(base.DB.Stats().MaxIdleTimeClosed)
@@ -171,8 +208,11 @@ func RegisterMetrics(base *Session, namespace string, sub Subsystem, registry *p
 
 	s.maxLifetimeClosedCounter = prometheus.NewCounterFunc(
 		prometheus.CounterOpts{
-			Namespace: namespace, Subsystem: subsystem, Name: "max_lifetime_closed_total",
-			Help: "total number of number of connections closed due to SetConnMaxLifetime",
+			Namespace:   namespace,
+			Subsystem:   "db",
+			Name:        "max_lifetime_closed_total",
+			Help:        "total number of number of connections closed due to SetConnMaxLifetime",
+			ConstLabels: prometheus.Labels{"subsystem": string(sub)},
 		},
 		func() float64 {
 			return float64(base.DB.Stats().MaxLifetimeClosed)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What/Why

- Change db metric subsystem (e.g. `ingest`, or `history`), to a label for easier aggregation.
- Add an explicit query type to a couple complex raw-sql queries so they don't show up as `undefined` in the metrics.

### Known limitations

[TODO or N/A]
