### PR TITLE
`regulated-assets-approval-server/`: Copy migrations to image

### DIFF
--- a/services/regulated-assets-approval-server/docker/Dockerfile
+++ b/services/regulated-assets-approval-server/docker/Dockerfile
@@ -9,6 +9,7 @@ FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 COPY --from=build /bin/regulated-assets-approval-server /app/
+COPY --from=build /bin/regulated-assets-approval-server/internal/db/dbmigrate/migrations /app/internal/db/dbmigrate/migrations/
 EXPOSE 8000
 ENTRYPOINT ["/app/regulated-assets-approval-server"]
 CMD ["serve"]


### PR DESCRIPTION
### What

Include `/app/internal/db/dbmigrate/migrations/` and their files to docker image

### Why

The init deployed container is failing because the migration .sql files are not included in the image.
We need to copy them from the codebase into the image.
[Slack Thread](https://stellarfoundation.slack.com/archives/C02U19A2A/p1621380918020400) 