### PR TITLE
services/horizon: Add horizon_db_idle_closed_total metric

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -81,6 +81,7 @@ type App struct {
 	dbInUseConnectionsGauge           prometheus.GaugeFunc
 	dbWaitCountCounter                prometheus.CounterFunc
 	dbWaitDurationCounter             prometheus.CounterFunc
+	idleClosedCounter                 prometheus.CounterFunc
 	coreLatestLedgerCounter           prometheus.CounterFunc
 	coreSynced                        prometheus.GaugeFunc
 }

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -259,6 +259,17 @@ func initDbMetrics(app *App) {
 	)
 	app.prometheusRegistry.MustRegister(app.dbWaitDurationCounter)
 
+	app.idleClosedCounter = prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Namespace: "horizon", Subsystem: "db", Name: "idle_closed_total",
+			Help: "total number of connections closed due to SetMaxIdleConns",
+		},
+		func() float64 {
+			return float64(app.historyQ.Session.DB.Stats().MaxIdleClosed)
+		},
+	)
+	app.prometheusRegistry.MustRegister(app.idleClosedCounter)
+
 	app.prometheusRegistry.MustRegister(app.orderBookStream.LatestLedgerGauge)
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

[TODO: Short statement about what is changing.]

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
