### PR TITLE
regulated-assets-approval-server/internal/serve/kyc-status/get_detail_handler.go: BUGFIX get request render json

### DIFF
--- a/services/regulated-assets-approval-server/internal/serve/kyc-status/get_detail_handler.go
+++ b/services/regulated-assets-approval-server/internal/serve/kyc-status/get_detail_handler.go
@@ -22,11 +22,10 @@ type kycGetResponse struct {
 	KYCSubmittedAt *time.Time `json:"kyc_submitted_at,omitempty"`
 	ApprovedAt     *time.Time `json:"approved_at,omitempty"`
 	RejectedAt     *time.Time `json:"rejected_at,omitempty"`
-	StatusCode     int        `json:"-"`
 }
 
 func (k *kycGetResponse) Render(w http.ResponseWriter) {
-	httpjson.RenderStatus(w, k.StatusCode, k, httpjson.JSON)
+	httpjson.Render(w, k, httpjson.JSON)
 }
 
 type GetDetailHandler struct {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Properly render kyc-status GET response

### Why

kyc-status GET response was failing to render due to the use of `httpjson.RenderStatus` without populating the status code.
Thus resulting in a 502 error

### Known limitations
N/A
