### PR TITLE
services/horizon: Add muxed details to transactions

### DIFF
--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -2,8 +2,9 @@ package effects
 
 import (
 	"encoding/json"
-	"github.com/stellar/go/xdr"
 	"time"
+
+	"github.com/stellar/go/xdr"
 
 	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stellar/go/support/render/hal"
@@ -249,6 +250,8 @@ type Base struct {
 	ID              string    `json:"id"`
 	PT              string    `json:"paging_token"`
 	Account         string    `json:"account"`
+	AccountMuxed    string    `json:"account_muxed,omitempty"`
+	AccountMuxedID  uint64    `json:"account_muxed_id,omitempty"`
 	Type            string    `json:"type"`
 	TypeI           int32     `json:"type_i"`
 	LedgerCloseTime time.Time `json:"created_at"`
@@ -382,6 +385,8 @@ type TrustlineDeauthorized struct {
 type Trade struct {
 	Base
 	Seller            string `json:"seller"`
+	SellerMuxed       string `json:"seller_muxed,omitempty"`
+	SellerMuxedID     uint64 `json:"seller_muxed_id,omitempty"`
 	OfferID           int64  `json:"offer_id,string"`
 	SoldAmount        string `json:"sold_amount"`
 	SoldAssetType     string `json:"sold_asset_type"`

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -458,6 +458,8 @@ type Transaction struct {
 	AccountMuxedID     uint64              `json:"source_account_muxed_id,omitempty"`
 	AccountSequence    string              `json:"source_account_sequence"`
 	FeeAccount         string              `json:"fee_account"`
+	FeeAccountMuxed    string              `json:"fee_account_muxed,omitempty"`
+	FeeAccountMuxedID  uint64              `json:"fee_account_muxed_id,omitempty"`
 	FeeCharged         int64               `json:"fee_charged,string"`
 	MaxFee             int64               `json:"max_fee,string"`
 	OperationCount     int32               `json:"operation_count"`

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -454,6 +454,8 @@ type Transaction struct {
 	Ledger             int32               `json:"ledger"`
 	LedgerCloseTime    time.Time           `json:"created_at"`
 	Account            string              `json:"source_account"`
+	AccountMuxed       string              `json:"source_account_muxed,omitempty"`
+	AccountMuxedID     uint64              `json:"source_account_muxed_id,omitempty"`
 	AccountSequence    string              `json:"source_account_sequence"`
 	FeeAccount         string              `json:"fee_account"`
 	FeeCharged         int64               `json:"fee_charged,string"`

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -427,6 +427,8 @@ type Effect struct {
 // when the effect type is trade
 type TradeEffectDetails struct {
 	Seller            string `json:"seller"`
+	SellerMuxed       string `json:"seller_muxed,omitempty"`
+	SellerMuxedID     uint64 `json:"seller_muxed_id,omitempty"`
 	OfferID           int64  `json:"offer_id"`
 	SoldAmount        string `json:"sold_amount"`
 	SoldAssetType     string `json:"sold_asset_type"`

--- a/services/horizon/internal/ingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/ingest/processors/effects_processor_test.go
@@ -946,10 +946,12 @@ func TestOperationEffects(t *testing.T) {
 				{
 					address: "GDEOVUDLCYTO46D6GD6WH7BFESPBV5RACC6F6NUFCIRU7PL2XONQHVGJ",
 					details: map[string]interface{}{
-						"amount":       "1.0000000",
-						"asset_code":   "ARS",
-						"asset_type":   "credit_alphanum4",
-						"asset_issuer": "GCXI6Q73J7F6EUSBZTPW4G4OUGVDHABPYF2U4KO7MVEX52OH5VMVUCRF",
+						"account_muxed":    "MDEOVUDLCYTO46D6GD6WH7BFESPBV5RACC6F6NUFCIRU7PL2XONQGAAAAAAMV7V2X24II",
+						"account_muxed_id": uint64(0xcafebabe),
+						"amount":           "1.0000000",
+						"asset_code":       "ARS",
+						"asset_type":       "credit_alphanum4",
+						"asset_issuer":     "GCXI6Q73J7F6EUSBZTPW4G4OUGVDHABPYF2U4KO7MVEX52OH5VMVUCRF",
 					},
 					effectType:  history.EffectAccountCredited,
 					operationID: int64(85899350017),
@@ -958,10 +960,12 @@ func TestOperationEffects(t *testing.T) {
 				{
 					address: "GD3MMHD2YZWL5RAUWG6O3RMA5HTZYM7S3JLSZ2Z35JNJAWTDIKXY737V",
 					details: map[string]interface{}{
-						"amount":       "0.0300000",
-						"asset_code":   "BRL",
-						"asset_type":   "credit_alphanum4",
-						"asset_issuer": "GCXI6Q73J7F6EUSBZTPW4G4OUGVDHABPYF2U4KO7MVEX52OH5VMVUCRF",
+						"account_muxed":    "MD3MMHD2YZWL5RAUWG6O3RMA5HTZYM7S3JLSZ2Z35JNJAWTDIKXY6AAAAAAMV7V2XZY4C",
+						"account_muxed_id": uint64(0xcafebabe),
+						"amount":           "0.0300000",
+						"asset_code":       "BRL",
+						"asset_type":       "credit_alphanum4",
+						"asset_issuer":     "GCXI6Q73J7F6EUSBZTPW4G4OUGVDHABPYF2U4KO7MVEX52OH5VMVUCRF",
 					},
 					effectType:  history.EffectAccountDebited,
 					operationID: int64(85899350017),
@@ -970,6 +974,8 @@ func TestOperationEffects(t *testing.T) {
 				{
 					address: "GD3MMHD2YZWL5RAUWG6O3RMA5HTZYM7S3JLSZ2Z35JNJAWTDIKXY737V",
 					details: map[string]interface{}{
+						"account_muxed":       "MD3MMHD2YZWL5RAUWG6O3RMA5HTZYM7S3JLSZ2Z35JNJAWTDIKXY6AAAAAAMV7V2XZY4C",
+						"account_muxed_id":    uint64(0xcafebabe),
 						"seller":              "GDEOVUDLCYTO46D6GD6WH7BFESPBV5RACC6F6NUFCIRU7PL2XONQHVGJ",
 						"offer_id":            xdr.Int64(10072128),
 						"sold_amount":         "0.0300000",
@@ -989,6 +995,8 @@ func TestOperationEffects(t *testing.T) {
 					address: "GDEOVUDLCYTO46D6GD6WH7BFESPBV5RACC6F6NUFCIRU7PL2XONQHVGJ",
 					details: map[string]interface{}{
 						"seller":              "GD3MMHD2YZWL5RAUWG6O3RMA5HTZYM7S3JLSZ2Z35JNJAWTDIKXY737V",
+						"seller_muxed":        "MD3MMHD2YZWL5RAUWG6O3RMA5HTZYM7S3JLSZ2Z35JNJAWTDIKXY6AAAAAAMV7V2XZY4C",
+						"seller_muxed_id":     uint64(0xcafebabe),
 						"offer_id":            xdr.Int64(10072128),
 						"sold_amount":         "1.0000000",
 						"bought_amount":       "0.0300000",

--- a/services/horizon/internal/resourceadapter/effects.go
+++ b/services/horizon/internal/resourceadapter/effects.go
@@ -59,6 +59,11 @@ var EffectTypeNames = map[history.EffectType]string{
 	history.EffectClaimableBalanceClawedBack:         "claimable_balance_clawed_back",
 }
 
+type muxedAccount struct {
+	AccountMuxed   string `json:"account_muxed"`
+	AccountMuxedID uint64 `json:"account_muxed_id"`
+}
+
 // NewEffect creates a new effect resource from the provided database representation
 // of the effect.
 func NewEffect(
@@ -68,7 +73,12 @@ func NewEffect(
 ) (result hal.Pageable, err error) {
 
 	basev := effects.Base{}
-	PopulateBaseEffect(ctx, &basev, row, ledger)
+	var mAccount muxedAccount
+	// We abuse the details to inject muxed-account information without changing the DB schema
+	if err = row.UnmarshalDetails(&mAccount); err != nil {
+		return
+	}
+	PopulateBaseEffect(ctx, &basev, mAccount, row, ledger)
 
 	switch row.Type {
 	case history.EffectAccountCreated:
@@ -141,6 +151,8 @@ func NewEffect(
 		err = row.UnmarshalDetails(&tradeDetails)
 		if err == nil {
 			e.Seller = tradeDetails.Seller
+			e.SellerMuxed = tradeDetails.SellerMuxed
+			e.SellerMuxedID = tradeDetails.SellerMuxedID
 			e.OfferID = tradeDetails.OfferID
 			e.SoldAmount = tradeDetails.SoldAmount
 			e.SoldAssetType = tradeDetails.SoldAssetType
@@ -269,10 +281,12 @@ func NewEffect(
 }
 
 // Populate loads this resource from `row`
-func PopulateBaseEffect(ctx context.Context, this *effects.Base, row history.Effect, ledger history.Ledger) {
+func PopulateBaseEffect(ctx context.Context, this *effects.Base, account muxedAccount, row history.Effect, ledger history.Ledger) {
 	this.ID = row.ID()
 	this.PT = row.PagingToken()
 	this.Account = row.Account
+	this.AccountMuxed = account.AccountMuxed
+	this.AccountMuxedID = account.AccountMuxedID
 	populateEffectType(this, row)
 	this.LedgerCloseTime = ledger.ClosedAt
 

--- a/services/horizon/internal/resourceadapter/effects_test.go
+++ b/services/horizon/internal/resourceadapter/effects_test.go
@@ -88,3 +88,46 @@ func TestNewEffect_EffectTrustlineAuthorizedToMaintainLiabilities(t *testing.T) 
 	tt.Len(page.Embedded.Records, 1)
 	tt.Equal(effect, page.Embedded.Records[0].(effects.TrustlineAuthorizedToMaintainLiabilities))
 }
+
+func TestNewEffect_EffectTrade_Muxed(t *testing.T) {
+	tt := assert.New(t)
+	ctx, _ := test.ContextWithLogBuffer()
+
+	details := `{
+	"seller": "GAQAA5L65LSYH7CQ3VTJ7F3HHLGCL3DSLAR2Y47263D56MNNGHSQSTVY",
+	"seller_muxed": "MAQAA5L65LSYH7CQ3VTJ7F3HHLGCL3DSLAR2Y47263D56MNNGHSQSAAAAAAAAAAE2LP26",
+    "seller_muxed_id": 1234,
+	"account_muxed": "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ"
+	}`
+
+	hEffect := history.Effect{
+		Account:            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
+		HistoryOperationID: 1,
+		Order:              1,
+		Type:               history.EffectTrade,
+		DetailsString:      null.StringFrom(details),
+	}
+	resource, err := NewEffect(ctx, hEffect, history.Ledger{})
+	tt.NoError(err)
+
+	var resourcePage hal.Page
+	resourcePage.Add(resource)
+
+	effect, ok := resource.(effects.Trade)
+	tt.True(ok)
+	tt.Equal("trade", effect.Type)
+
+	binary, err := json.Marshal(resourcePage)
+	tt.NoError(err)
+
+	var page effects.EffectsPage
+	tt.NoError(json.Unmarshal(binary, &page))
+	tt.Len(page.Embedded.Records, 1)
+	tt.Equal(effect, page.Embedded.Records[0].(effects.Trade))
+	tt.Equal("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ", effect.Account)
+	tt.Equal("MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ", effect.AccountMuxed)
+	tt.Equal(uint64(0), effect.AccountMuxedID)
+	tt.Equal("GAQAA5L65LSYH7CQ3VTJ7F3HHLGCL3DSLAR2Y47263D56MNNGHSQSTVY", effect.Seller)
+	tt.Equal("MAQAA5L65LSYH7CQ3VTJ7F3HHLGCL3DSLAR2Y47263D56MNNGHSQSAAAAAAAAAAE2LP26", effect.SellerMuxed)
+	tt.Equal(uint64(1234), effect.SellerMuxedID)
+}

--- a/services/horizon/internal/resourceadapter/transaction.go
+++ b/services/horizon/internal/resourceadapter/transaction.go
@@ -30,6 +30,16 @@ func PopulateTransaction(
 	dest.Ledger = row.LedgerSequence
 	dest.LedgerCloseTime = row.LedgerCloseTime
 	dest.Account = row.Account
+	var env xdr.TransactionEnvelope
+	if err := xdr.SafeUnmarshalBase64(row.TxEnvelope, &env); err != nil {
+		return err
+
+	}
+	source := env.SourceAccount()
+	if source.Type == xdr.CryptoKeyTypeKeyTypeMuxedEd25519 {
+		dest.AccountMuxed = source.Address()
+		dest.AccountMuxedID = uint64(source.Med25519.Id)
+	}
 	dest.AccountSequence = row.AccountSequence
 
 	dest.FeeCharged = row.FeeCharged

--- a/services/horizon/internal/resourceadapter/transaction.go
+++ b/services/horizon/internal/resourceadapter/transaction.go
@@ -66,6 +66,13 @@ func PopulateTransaction(
 
 	if row.InnerTransactionHash.Valid {
 		dest.FeeAccount = row.FeeAccount.String
+		if env.IsFeeBump() {
+			feeAccount := env.FeeBumpAccount()
+			if feeAccount.Type == xdr.CryptoKeyTypeKeyTypeMuxedEd25519 {
+				dest.FeeAccountMuxed = feeAccount.Address()
+				dest.FeeAccountMuxedID = uint64(feeAccount.Med25519.Id)
+			}
+		}
 		dest.MaxFee = row.NewMaxFee.Int64
 		dest.FeeBumpTransaction = &protocol.FeeBumpTransaction{
 			Hash:       row.TransactionHash,
@@ -80,7 +87,81 @@ func PopulateTransaction(
 			dest.Signatures = dest.InnerTransaction.Signatures
 		}
 	} else {
-		dest.FeeAccount = row.Account
+		dest.FeeAccount = dest.Account
+		dest.FeeAccountMuxed = dest.AccountMuxed
+		dest.FeeAccountMuxedID = dest.AccountMuxedID
+		dest.MaxFee = row.MaxFee
+	}
+
+	lb := hal.LinkBuilder{Base: horizonContext.BaseURL(ctx)}
+	dest.Links.Account = lb.Link("/accounts", dest.Account)
+	dest.Links.Ledger = lb.Link("/ledgers", fmt.Sprintf("%d", dest.Ledger))
+	dest.Links.Operations = lb.PagedLink("/transactions", dest.ID, "operations")
+	dest.Links.Effects = lb.PagedLink("/transactions", dest.ID, "effects")
+	dest.Links.Self = lb.Link("/transactions", dest.ID)
+	dest.Links.Transaction = dest.Links.Self
+	dest.Links.Succeeds = lb.Linkf("/transactions?order=desc&cursor=%s", dest.PT)
+	dest.Links.Precedes = lb.Linkf("/transactions?order=asc&cursor=%s", dest.PT)
+
+	return nil
+}
+
+func PopulateTransactionNotMuxed(
+	ctx context.Context,
+	transactionHash string,
+	dest *protocol.Transaction,
+	row history.Transaction,
+) error {
+	dest.ID = transactionHash
+	dest.PT = row.PagingToken()
+	dest.Successful = row.Successful
+	dest.Hash = transactionHash
+	dest.Ledger = row.LedgerSequence
+	dest.LedgerCloseTime = row.LedgerCloseTime
+	dest.Account = row.Account
+	dest.AccountSequence = row.AccountSequence
+
+	dest.FeeCharged = row.FeeCharged
+
+	dest.OperationCount = row.OperationCount
+	dest.EnvelopeXdr = row.TxEnvelope
+	dest.ResultXdr = row.TxResult
+	dest.ResultMetaXdr = row.TxMeta
+	dest.FeeMetaXdr = row.TxFeeMeta
+	dest.MemoType = row.MemoType
+	dest.Memo = row.Memo.String
+	if row.MemoType == "text" {
+		if memoBytes, err := memoBytes(row.TxEnvelope); err != nil {
+			return err
+		} else {
+			dest.MemoBytes = memoBytes
+		}
+	}
+	dest.Signatures = row.Signatures
+	if !row.TimeBounds.Null {
+		dest.ValidBefore = timeString(dest, row.TimeBounds.Upper)
+		dest.ValidAfter = timeString(dest, row.TimeBounds.Lower)
+	}
+
+	if row.InnerTransactionHash.Valid {
+		dest.FeeAccount = row.FeeAccount.String
+		dest.MaxFee = row.NewMaxFee.Int64
+		dest.FeeBumpTransaction = &protocol.FeeBumpTransaction{
+			Hash:       row.TransactionHash,
+			Signatures: dest.Signatures,
+		}
+		dest.InnerTransaction = &protocol.InnerTransaction{
+			Hash:       row.InnerTransactionHash.String,
+			MaxFee:     row.MaxFee,
+			Signatures: row.InnerSignatures,
+		}
+		if transactionHash != row.TransactionHash {
+			dest.Signatures = dest.InnerTransaction.Signatures
+		}
+	} else {
+		dest.FeeAccount = dest.Account
+		dest.FeeAccountMuxed = dest.AccountMuxed
+		dest.FeeAccountMuxedID = dest.AccountMuxedID
 		dest.MaxFee = row.MaxFee
 	}
 


### PR DESCRIPTION
Addresses part of #3591 

Depends (until merged) on #3610 

This PR extracts the source muxed accounts of a transaction by decoding its XDR on the fly. The reason for doing this being that the Muxed Accounts are not accesible directly from the DB.

```
pkg: github.com/stellar/go/services/horizon/internal/resourceadapter
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkNewTransactionNotMuxed
BenchmarkNewTransactionNotMuxed-8   	 1020502	      1257 ns/op
PASS
```

```
pkg: github.com/stellar/go/services/horizon/internal/resourceadapter
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkNewTransactionMuxed
BenchmarkNewTransactionMuxed-8   	   25114	     45686 ns/op
PASS
```

(with a 6-operation transaction it's 4x slower)

Alternatively we can:
* Try to only decode the relevant parts of the XDR (I am not sure that's possible)
* Add two new columns to the `history_transactions` table (one for `fee_account_muxed` and `account_muxed`)


TODO:
- [ ] Add tests