### PR TITLE
txnbuild: fix bug where base fee is not allowed to be zero

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -7,8 +7,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Bug Fix
 
-* `BaseFee` in `TransactionParams` when calling `NewTransaction` is now allowed
-to be zero.
+* `BaseFee` in `TransactionParams` when calling `NewTransaction` is allowed to be zero because the fee can be paid by wrapping a `Transaction` in a `FeeBumpTransaction`. ([#3622](https://github.com/stellar/go/pull/3622))
 
 ## [v7.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v7.0.0) - 2021-05-15
 

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -5,6 +5,11 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Bug Fix
+
+* `BaseFee` in `TransactionParams` when calling `NewTransaction` is now allowed
+to be zero.
+
 ## [v7.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v7.0.0) - 2021-05-15
 
 ### Breaking changes

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -678,10 +678,8 @@ func NewTransaction(params TransactionParams) (*Transaction, error) {
 		sourceAccount = accountID.ToMuxedAccount()
 	}
 
-	if tx.baseFee < MinBaseFee {
-		return nil, errors.Errorf(
-			"base fee cannot be lower than network minimum of %d", MinBaseFee,
-		)
+	if tx.baseFee < 0 {
+		return nil, errors.Errorf("base fee cannot be negative")
 	}
 
 	if len(tx.operations) == 0 {

--- a/txnbuild/transaction_fee_test.go
+++ b/txnbuild/transaction_fee_test.go
@@ -7,7 +7,41 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMinBaseFee(t *testing.T) {
+func TestBaseFeeCanBeZero(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), 1)
+
+	tx, err := NewTransaction(
+		TransactionParams{
+			SourceAccount: &sourceAccount,
+			Operations:    []Operation{&Inflation{}},
+			BaseFee:       0,
+			Timebounds:    NewInfiniteTimeout(),
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), tx.baseFee)
+}
+
+func TestBaseFeeCanBePositive(t *testing.T) {
+	kp0 := newKeypair0()
+	sourceAccount := NewSimpleAccount(kp0.Address(), 1)
+
+	tx, err := NewTransaction(
+		TransactionParams{
+			SourceAccount: &sourceAccount,
+			Operations:    []Operation{&Inflation{}},
+			BaseFee:       MinBaseFee,
+			Timebounds:    NewInfiniteTimeout(),
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(MinBaseFee), tx.baseFee)
+}
+
+func TestBaseFeeCannotBeNegative(t *testing.T) {
 	kp0 := newKeypair0()
 	sourceAccount := NewSimpleAccount(kp0.Address(), 1)
 
@@ -15,12 +49,12 @@ func TestMinBaseFee(t *testing.T) {
 		TransactionParams{
 			SourceAccount: &sourceAccount,
 			Operations:    []Operation{&Inflation{}},
-			BaseFee:       MinBaseFee - 1,
+			BaseFee:       -1,
 			Timebounds:    NewInfiniteTimeout(),
 		},
 	)
 
-	assert.EqualError(t, err, "base fee cannot be lower than network minimum of 100")
+	assert.EqualError(t, err, "base fee cannot be negative")
 }
 
 func TestFeeBumpMinBaseFee(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Allow the base fee to be zero when building transactions.

### Why

The `txnbuild.NewTransaction` function errors when creating a transaction with a base fee of zero.

This is a bug.

Transactions with a zero base fee are accepted to the Stellar network when they are wrapped in a fee bump transaction envelope that pays the fee of the transaction. Applications use a zero base fee on the inner transaction to support fee sponsorship by an account that isn't the transaction source account.

This is required for payment channels, wallets like Vibrant, and other uses.

### Known limitations

N/A
