### PR TITLE
services/horizon/cmd: Fix prepare range bug

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -9,6 +9,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Add more in-depth Prometheus metrics (count & duration) for db queries.
 
+* Fix bug in `horizon db reingest range` command which required the `--ingest` flag to be set [3625](https://github.com/stellar/go/pull/3625)).
 
 ## v2.3.0
 

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -210,8 +210,8 @@ var dbReingestRangeCmd = &cobra.Command{
 			argsUInt32[i] = uint32(seq)
 		}
 
-		horizon.ApplyFlags(config, flags)
-		err := RunDBReingestRange(argsUInt32[0], argsUInt32[1], reingestForce, parallelWorkers, *config)
+		horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true})
+		err := runDBReingestRange(argsUInt32[0], argsUInt32[1], reingestForce, parallelWorkers, *config)
 		if err != nil {
 			if errors.Cause(err) == ingest.ErrReingestRangeConflict {
 				message := `
@@ -232,7 +232,7 @@ var dbReingestRangeCmd = &cobra.Command{
 	},
 }
 
-func RunDBReingestRange(from, to uint32, reingestForce bool, parallelWorkers uint, config horizon.Config) error {
+func runDBReingestRange(from, to uint32, reingestForce bool, parallelWorkers uint, config horizon.Config) error {
 	if reingestForce && parallelWorkers > 1 {
 		return errors.New("--force is incompatible with --parallel-workers > 1")
 	}
@@ -303,7 +303,7 @@ func init() {
 
 	viper.BindPFlags(dbReingestRangeCmd.PersistentFlags())
 
-	rootCmd.AddCommand(dbCmd)
+	RootCmd.AddCommand(dbCmd)
 	dbCmd.AddCommand(
 		dbInitCmd,
 		dbMigrateCmd,

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -202,12 +202,14 @@ var dbReingestRangeCmd = &cobra.Command{
 
 		argsUInt32 := make([]uint32, 2)
 		for i, arg := range args {
-			seq, err := strconv.Atoi(arg)
-			if err != nil {
+			if seq, err := strconv.Atoi(arg); err != nil {
 				cmd.Usage()
 				log.Fatalf(`Invalid sequence number "%s"`, arg)
+			} else if seq < 0 {
+				log.Fatalf("sequence number %s cannot be negative", arg)
+			} else {
+				argsUInt32[i] = uint32(seq)
 			}
-			argsUInt32[i] = uint32(seq)
 		}
 
 		horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true})

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -71,7 +71,7 @@ var ingestVerifyRangeCmd = &cobra.Command{
 			co.SetValue()
 		}
 
-		horizon.ApplyFlags(config, flags)
+		horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true})
 
 		if ingestVerifyDebugServerPort != 0 {
 			go func() {
@@ -170,7 +170,7 @@ var ingestStressTestCmd = &cobra.Command{
 			co.SetValue()
 		}
 
-		horizon.ApplyFlags(config, flags)
+		horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true})
 
 		horizonSession, err := db.Open("postgres", config.DatabaseURL)
 		if err != nil {
@@ -229,7 +229,7 @@ var ingestTriggerStateRebuildCmd = &cobra.Command{
 	Short: "updates a database to trigger state rebuild, state will be rebuilt by a running Horizon instance, DO NOT RUN production DB, some endpoints will be unavailable until state is rebuilt",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		horizon.ApplyFlags(config, flags)
+		horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true})
 
 		horizonSession, err := db.Open("postgres", config.DatabaseURL)
 		if err != nil {
@@ -251,7 +251,7 @@ var ingestInitGenesisStateCmd = &cobra.Command{
 	Short: "ingests genesis state (ledger 1)",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		horizon.ApplyFlags(config, flags)
+		horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true})
 
 		horizonSession, err := db.Open("postgres", config.DatabaseURL)
 		if err != nil {
@@ -322,7 +322,7 @@ func init() {
 
 	viper.BindPFlags(ingestVerifyRangeCmd.PersistentFlags())
 
-	rootCmd.AddCommand(ingestCmd)
+	RootCmd.AddCommand(ingestCmd)
 	ingestCmd.AddCommand(
 		ingestVerifyRangeCmd,
 		ingestStressTestCmd,

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -12,7 +12,7 @@ import (
 var (
 	config, flags = horizon.Flags()
 
-	rootCmd = &cobra.Command{
+	RootCmd = &cobra.Command{
 		Use:   "horizon",
 		Short: "client-facing api server for the Stellar network",
 		Long:  "Client-facing API server for the Stellar network. It acts as the interface between Stellar Core and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.",
@@ -23,14 +23,14 @@ var (
 )
 
 func init() {
-	err := flags.Init(rootCmd)
+	err := flags.Init(RootCmd)
 	if err != nil {
 		stdLog.Fatal(err.Error())
 	}
 }
 
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/services/horizon/cmd/serve.go
+++ b/services/horizon/cmd/serve.go
@@ -15,5 +15,5 @@ var serveCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(serveCmd)
+	RootCmd.AddCommand(serveCmd)
 }

--- a/services/horizon/cmd/version.go
+++ b/services/horizon/cmd/version.go
@@ -19,5 +19,5 @@ var versionCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(versionCmd)
+	RootCmd.AddCommand(versionCmd)
 }

--- a/services/horizon/internal/integration/db_test.go
+++ b/services/horizon/internal/integration/db_test.go
@@ -1,7 +1,9 @@
 package integration
 
 import (
+	"fmt"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -85,9 +87,34 @@ func TestReingestDB(t *testing.T) {
 		filepath.Dir(horizonConfig.CaptiveCoreConfigPath),
 		"captive-core-reingest-range-integration-tests.cfg",
 	)
+	horizoncmd.RootCmd.SetArgs([]string{
+		"--stellar-core-url",
+		horizonConfig.StellarCoreURL,
+		"--history-archive-urls",
+		horizonConfig.HistoryArchiveURLs[0],
+		"--db-url",
+		horizonConfig.DatabaseURL,
+		"--stellar-core-db-url",
+		horizonConfig.StellarCoreDatabaseURL,
+		"--stellar-core-binary-path",
+		horizonConfig.CaptiveCoreBinaryPath,
+		"--captive-core-config-append-path",
+		horizonConfig.CaptiveCoreConfigPath,
+		"--enable-captive-core-ingestion=" + strconv.FormatBool(horizonConfig.EnableCaptiveCoreIngestion),
+		"--network-passphrase",
+		horizonConfig.NetworkPassphrase,
+		// due to ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING
+		"--checkpoint-frequency",
+		"8",
+		"db",
+		"reingest",
+		"range",
+		"1",
+		fmt.Sprintf("%d", toLedger),
+	})
 
+	err = horizoncmd.RootCmd.Execute()
 	// Reingest into the DB
-	err = horizoncmd.RunDBReingestRange(1, toLedger, false, 1, horizonConfig)
 	tt.NoError(err)
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Fixes https://github.com/stellar/go/issues/3580

The `horizon db reingest range` command failed because it requires that the top level horizon ingest flag to be true.
In other words, `horizon --ingest db reingest range` works but `horizon db reingest range` responds with the following error:
```
2021/05/03 12:49:43 Invalid config: one or more captive core params passed (--stellar-core-binary-path or --captive-core-config-append-path) but --ingest not set. 
```

This PR fixes this bug by making all ingestion subcommands set ingest to true implicitly.

This PR also fixes the captive core config validation by only requiring the config file to be present when ingesting in online mode. It is not necessary to have a captive core config file when ingesting bounded ledger ranges.
