### PR TITLE
clients/horizonclient: make errors easier to understand at a glance

### DIFF
--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+* Added transaction and operation result codes to the horizonclient.Error string for easy glancing at string only errors for underlying cause.
+
 ## [v7.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v7.0.0) - 2021-05-15
 
 None

--- a/clients/horizonclient/error.go
+++ b/clients/horizonclient/error.go
@@ -2,6 +2,7 @@ package horizonclient
 
 import (
 	"encoding/json"
+	"strings"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/errors"
@@ -9,7 +10,18 @@ import (
 )
 
 func (herr Error) Error() string {
-	return `horizon error: "` + herr.Problem.Title + `" - check horizon.Error.Problem for more information`
+	s := strings.Builder{}
+	s.WriteString(`horizon error: "`)
+	s.WriteString(herr.Problem.Title)
+	s.WriteString(`" `)
+	if rc, err := herr.ResultCodes(); err == nil {
+		s.WriteString(`(`)
+		resultCodes := append([]string{rc.TransactionCode}, rc.OperationCodes...)
+		s.WriteString(strings.Join(resultCodes, `, `))
+		s.WriteString(`) `)
+	}
+	s.WriteString(`- check horizon.Error.Problem for more information`)
+	return s.String()
 }
 
 // Envelope extracts the transaction envelope that triggered this error from the

--- a/clients/horizonclient/error_test.go
+++ b/clients/horizonclient/error_test.go
@@ -23,7 +23,7 @@ func TestError_Error(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, `horizon error: "Transaction Failed" - check horizon.Error.Problem for more information`, herr.Error())
+	assert.Equal(t, `horizon error: "Transaction Failed" (tx_failed, op_underfunded, op_already_exists) - check horizon.Error.Problem for more information`, herr.Error())
 
 	// transaction failed sad path: missing result_codes extra
 	herr = Error{

--- a/clients/horizonclient/error_test.go
+++ b/clients/horizonclient/error_test.go
@@ -3,8 +3,60 @@ package horizonclient
 import (
 	"testing"
 
+	"github.com/stellar/go/support/render/problem"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestError_Error(t *testing.T) {
+	var herr Error
+
+	// transaction failed happy path: with the appropriate extra fields
+	herr = Error{
+		Problem: problem.P{
+			Title: "Transaction Failed",
+			Type:  "transaction_failed",
+			Extras: map[string]interface{}{
+				"result_codes": map[string]interface{}{
+					"transaction": "tx_failed",
+					"operations":  []string{"op_underfunded", "op_already_exists"},
+				},
+			},
+		},
+	}
+	assert.Equal(t, `horizon error: "Transaction Failed" - check horizon.Error.Problem for more information`, herr.Error())
+
+	// transaction failed sad path: missing result_codes extra
+	herr = Error{
+		Problem: problem.P{
+			Title:  "Transaction Failed",
+			Type:   "transaction_failed",
+			Extras: map[string]interface{}{},
+		},
+	}
+	assert.Equal(t, `horizon error: "Transaction Failed" - check horizon.Error.Problem for more information`, herr.Error())
+
+	// transaction failed sad path: unparseable result_codes extra
+	herr = Error{
+		Problem: problem.P{
+			Title: "Transaction Failed",
+			Type:  "transaction_failed",
+			Extras: map[string]interface{}{
+				"result_codes": "kaboom",
+			},
+		},
+	}
+	assert.Equal(t, `horizon error: "Transaction Failed" - check horizon.Error.Problem for more information`, herr.Error())
+
+	// non-transaction errors
+	herr = Error{
+		Problem: problem.P{
+			Type:   "https://stellar.org/horizon-errors/not_found",
+			Title:  "Resource Missing",
+			Status: 404,
+		},
+	}
+	assert.Equal(t, `horizon error: "Resource Missing" - check horizon.Error.Problem for more information`, herr.Error())
+}
 
 func TestError_ResultCodes(t *testing.T) {
 	var herr Error

--- a/services/regulated-assets-approval-server/internal/serve/httperror/http_error_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/httperror/http_error_test.go
@@ -35,5 +35,5 @@ func TestParseHorizonError(t *testing.T) {
 		},
 	}
 	err = ParseHorizonError(horizonError)
-	require.EqualError(t, err, "error submitting transaction: problem: bad_request, &{TransactionCode:tx_code_here OperationCodes:[op_success op_bad_auth]}\n: horizon error: \"Bad Request\" - check horizon.Error.Problem for more information")
+	require.EqualError(t, err, "error submitting transaction: problem: bad_request, &{TransactionCode:tx_code_here OperationCodes:[op_success op_bad_auth]}\n: horizon error: \"Bad Request\" (tx_code_here, op_success, op_bad_auth) - check horizon.Error.Problem for more information")
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Include the transaction result codes in the horizonclient.Error string that is outputted when serializing the error to a string.

### Why

When developing the transaction failed error is very opaque, displaying only `"Transaction Failed"` in logs. This is fine for code that has been written well to unwrap the error using `horizonclient.GetError`, and that also uses `ResultsCodes()`. But developers, even experienced ones, don't often start out writing code that inspects errors perfectly. It's helpful to get succinct textual errors that are as meaningful as possible, and really pin point what happened. Including the result code in the string that is output will in most cases significantly increase the signal a developer gets on why a transaction failed.

This is a recurring pain point for me using the horizonclient package in applications.

This function was not tested, so I added tests first in the first commit and the second commit contains the changes to the test and the new functionality.

### Known limitations

N/A