### PR TITLE
horizenclient: add IsTimeoutError helper

### DIFF
--- a/clients/horizonclient/error_helpers.go
+++ b/clients/horizonclient/error_helpers.go
@@ -23,6 +23,26 @@ func IsNotFoundError(err error) bool {
 	return hErr.Problem.Type == "https://stellar.org/horizon-errors/not_found"
 }
 
+// IsTimeoutError returns true if the error is a horizonclient.Error with
+// a timeout problem indicating that Horizon timed out.
+func IsTimeoutError(err error) bool {
+	var hErr *Error
+
+	err = errors.Cause(err)
+	switch err := err.(type) {
+	case *Error:
+		hErr = err
+	case Error:
+		hErr = &err
+	}
+
+	if hErr == nil {
+		return false
+	}
+
+	return hErr.Problem.Type == "https://stellar.org/horizon-errors/timeout"
+}
+
 // GetError returns an error that can be interpreted as a horizon-specific
 // error. If err cannot be interpreted as a horizon-specific error, a nil error
 // is returned. The caller should still check whether err is nil.

--- a/clients/horizonclient/error_helpers_test.go
+++ b/clients/horizonclient/error_helpers_test.go
@@ -127,6 +127,125 @@ func TestIsNotFoundError(t *testing.T) {
 	}
 }
 
+func TestIsTimeoutError(t *testing.T) {
+	testCases := []struct {
+		desc string
+		err  error
+		is   bool
+	}{
+		{
+			desc: "nil error",
+			err:  nil,
+			is:   false,
+		},
+		{
+			desc: "another Go type of error",
+			err:  errors.New("error"),
+			is:   false,
+		},
+		{
+			desc: "timeout problem (pointer)",
+			err: &Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/timeout",
+					Title:  "Timeout",
+					Status: 504,
+				},
+			},
+			is: true,
+		},
+		{
+			desc: "wrapped timeout problem (pointer)",
+			err: errors.Wrap(&Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/timeout",
+					Title:  "Timeout",
+					Status: 504,
+				},
+			}, "wrap message"),
+			is: true,
+		},
+		{
+			desc: "timeout problem (not a pointer)",
+			err: Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/timeout",
+					Title:  "Timeout",
+					Status: 504,
+				},
+			},
+			is: true,
+		},
+		{
+			desc: "wrapped timout problem (not a pointer)",
+			err: errors.Wrap(Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/timeout",
+					Title:  "Timeout",
+					Status: 504,
+				},
+			}, "wrap message"),
+			is: true,
+		},
+		{
+			desc: "some other problem (pointer)",
+			err: &Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/server_error",
+					Title:  "Server Error",
+					Status: 500,
+				},
+			},
+			is: false,
+		},
+		{
+			desc: "wrapped some other problem (pointer)",
+			err: errors.Wrap(&Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/server_error",
+					Title:  "Server Error",
+					Status: 500,
+				},
+			}, "wrap message"),
+			is: false,
+		},
+		{
+			desc: "some other problem (not a pointer)",
+			err: Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/server_error",
+					Title:  "Server Error",
+					Status: 500,
+				},
+			},
+			is: false,
+		},
+		{
+			desc: "wrapped some other problem (not a pointer)",
+			err: errors.Wrap(Error{
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/server_error",
+					Title:  "Server Error",
+					Status: 500,
+				},
+			}, "wrap message"),
+			is: false,
+		},
+		{
+			desc: "a nil *horizonclient.Error",
+			err:  (*Error)(nil),
+			is:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			is := IsTimeoutError(tc.err)
+			assert.Equal(t, tc.is, is)
+		})
+	}
+}
+
 func TestGetError(t *testing.T) {
 	testCases := []struct {
 		desc    string


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR adds a new helper function `IsTimeoutError` to determine if an error returned by the Horizon client is 504 or not.

### Why

Applications that use Horizon client will want to handle 504s. Some applications might want to retry the same transaction, some applications might want to return a special error so that its client can retry or handle it in another graceful way.

### Known limitations

N/A
