### PR TITLE
services/horizon: Add Stellar protocol version metrics

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -78,6 +78,7 @@ type App struct {
 	historyElderLedgerCounter         prometheus.CounterFunc
 	coreLatestLedgerCounter           prometheus.CounterFunc
 	coreSynced                        prometheus.GaugeFunc
+	coreSupportedProtocolVersion      prometheus.GaugeFunc
 }
 
 func (a *App) GetCoreSettings() actions.CoreSettings {

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -217,6 +217,17 @@ func initDbMetrics(app *App) {
 	)
 	app.prometheusRegistry.MustRegister(app.coreSynced)
 
+	app.coreSupportedProtocolVersion = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: "horizon", Subsystem: "stellar_core", Name: "supported_protocol_version",
+			Help: "determines the supported version of the protocol by Stellar-Core defined by --stellar-core-url",
+		},
+		func() float64 {
+			return float64(app.coreSettings.CoreSupportedProtocolVersion)
+		},
+	)
+	app.prometheusRegistry.MustRegister(app.coreSupportedProtocolVersion)
+
 	app.prometheusRegistry.MustRegister(app.orderBookStream.LatestLedgerGauge)
 }
 
@@ -243,6 +254,7 @@ func initIngestMetrics(app *App) {
 	}
 
 	app.ingestingGauge.Inc()
+	app.prometheusRegistry.MustRegister(app.ingester.Metrics().MaxSupportedProtocolVersion)
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().LocalLatestLedger)
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().LedgerIngestionDuration)
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().StateVerifyDuration)
@@ -250,6 +262,7 @@ func initIngestMetrics(app *App) {
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().LedgerStatsCounter)
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().ProcessorsRunDuration)
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().CaptiveStellarCoreSynced)
+	app.prometheusRegistry.MustRegister(app.ingester.Metrics().CaptiveCoreSupportedProtocolVersion)
 }
 
 func initTxSubMetrics(app *App) {

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -208,7 +208,7 @@ func initDbMetrics(app *App) {
 			Help: "determines if Stellar-Core defined by --stellar-core-url is synced with the network",
 		},
 		func() float64 {
-			if app.coreSettings.Synced {
+			if app.coreSettings.get().Synced {
 				return 1
 			} else {
 				return 0
@@ -223,7 +223,7 @@ func initDbMetrics(app *App) {
 			Help: "determines the supported version of the protocol by Stellar-Core defined by --stellar-core-url",
 		},
 		func() float64 {
-			return float64(app.coreSettings.CoreSupportedProtocolVersion)
+			return float64(app.coreSettings.get().CoreSupportedProtocolVersion)
 		},
 	)
 	app.prometheusRegistry.MustRegister(app.coreSupportedProtocolVersion)

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -223,7 +223,7 @@ func initDbMetrics(app *App) {
 			Help: "determines the supported version of the protocol by Stellar-Core defined by --stellar-core-url",
 		},
 		func() float64 {
-			return float64(app.coreSettings.get().CoreSupportedProtocolVersion)
+			return float64(app.coreState.Get().CoreSupportedProtocolVersion)
 		},
 	)
 	app.prometheusRegistry.MustRegister(app.coreSupportedProtocolVersion)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Adds metrics exposing supported protocol version of Horizon, Stellar-Core and Captive Stellar-Core.

### Why

New metrics will allow tracking if Horizon and Stellar-Core are using compatible versions.