### PR TITLE
txnbuild: add AddSignatureDecorated

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -8,6 +8,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ### New features
 
 * Add `SequenceNumber` function to `Transaction`.
+* Add `AddSignatureDecorated` function to `Transaction`.
 
 ### Bug Fix
 

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -76,6 +76,13 @@ func concatSignatures(
 	return extended, nil
 }
 
+func concatSignatureDecorated(e xdr.TransactionEnvelope, signatures []xdr.DecoratedSignature, newSignatures []xdr.DecoratedSignature) ([]xdr.DecoratedSignature, error) {
+	extended := make([]xdr.DecoratedSignature, len(signatures)+len(newSignatures))
+	copy(extended, signatures)
+	copy(extended[len(signatures):], newSignatures)
+	return extended, nil
+}
+
 func concatSignatureBase64(e xdr.TransactionEnvelope, signatures []xdr.DecoratedSignature, networkStr, publicKey, signature string) ([]xdr.DecoratedSignature, error) {
 	if signature == "" {
 		return nil, errors.New("signature not presented")
@@ -298,6 +305,17 @@ func (t *Transaction) SignWithKeyString(network string, keys ...string) (*Transa
 // See description here: https://www.stellar.org/developers/guides/concepts/multi-sig.html#hashx.
 func (t *Transaction) SignHashX(preimage []byte) (*Transaction, error) {
 	extendedSignatures, err := concatHashX(t.Signatures(), preimage)
+	if err != nil {
+		return nil, err
+	}
+
+	return t.clone(extendedSignatures), nil
+}
+
+// AddSignatureDecorated returns a new Transaction instance which extends the current instance
+// with an additional signature(s).
+func (t *Transaction) AddSignatureDecorated(signature ...xdr.DecoratedSignature) (*Transaction, error) {
+	extendedSignatures, err := concatSignatureDecorated(t.envelope, t.Signatures(), signature)
 	if err != nil {
 		return nil, err
 	}

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -313,7 +313,7 @@ func (t *Transaction) SignHashX(preimage []byte) (*Transaction, error) {
 }
 
 // AddSignatureDecorated returns a new Transaction instance which extends the current instance
-// with an additional signature(s).
+// with an additional decorated signature(s).
 func (t *Transaction) AddSignatureDecorated(signature ...xdr.DecoratedSignature) (*Transaction, error) {
 	extendedSignatures, err := concatSignatureDecorated(t.envelope, t.Signatures(), signature)
 	if err != nil {

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1577,6 +1577,105 @@ func TestSignWithSecretKey(t *testing.T) {
 	assert.Equal(t, expected, actual, "base64 xdr should match")
 }
 
+func TestAddSignatureDecorated(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+	txSource := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
+	tx1Source := NewSimpleAccount(kp0.Address(), int64(9605939170639897))
+	createAccount := CreateAccount{
+		Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
+		Amount:        "10",
+		SourceAccount: kp1.Address(),
+	}
+
+	expected, err := newSignedTransaction(
+		TransactionParams{
+			SourceAccount:        &txSource,
+			IncrementSequenceNum: true,
+			Operations:           []Operation{&createAccount},
+			BaseFee:              MinBaseFee,
+			Timebounds:           NewInfiniteTimeout(),
+		},
+		network.TestNetworkPassphrase,
+		kp0, kp1,
+	)
+	assert.NoError(t, err)
+
+	tx1, err := NewTransaction(
+		TransactionParams{
+			SourceAccount:        &tx1Source,
+			IncrementSequenceNum: true,
+			Operations:           []Operation{&createAccount},
+			BaseFee:              MinBaseFee,
+			Timebounds:           NewInfiniteTimeout(),
+		},
+	)
+	assert.NoError(t, err)
+
+	// Same if signatures added separately.
+	{
+		tx1sigs1, err := tx1.AddSignatureDecorated(
+			xdr.DecoratedSignature{
+				Hint: kp0.Hint(),
+				Signature: func() xdr.Signature {
+					sigBytes, err := base64.StdEncoding.DecodeString("TVogR6tbrWLnOc1BsP/j+Qrxpja2NWNgeRIwujECYscRdMG7AMtnb3dkCT7sqlbSM0TTzlRh7G+BcVocYBtqBw==")
+					if err != nil {
+						require.NoError(t, err)
+					}
+					return xdr.Signature(sigBytes)
+				}(),
+			},
+		)
+		assert.NoError(t, err)
+		tx1sigs1, err = tx1sigs1.AddSignatureDecorated(
+			xdr.DecoratedSignature{
+				Hint: kp1.Hint(),
+				Signature: func() xdr.Signature {
+					sigBytes, err := base64.StdEncoding.DecodeString("Iy77JteoW/FbeiuViZpgTyvrHP4BnBOeyVOjrdb5O/MpEMwcSlYXAkCBqPt4tBDil4jIcDDLhm7TsN6aUBkIBg==")
+					if err != nil {
+						require.NoError(t, err)
+					}
+					return xdr.Signature(sigBytes)
+				}(),
+			},
+		)
+		assert.NoError(t, err)
+		actual, err := tx1sigs1.Base64()
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual, "base64 xdr should match")
+	}
+
+	// Same if signatures added together.
+	{
+		tx1sigs2, err := tx1.AddSignatureDecorated(
+			xdr.DecoratedSignature{
+				Hint: kp0.Hint(),
+				Signature: func() xdr.Signature {
+					sigBytes, err := base64.StdEncoding.DecodeString("TVogR6tbrWLnOc1BsP/j+Qrxpja2NWNgeRIwujECYscRdMG7AMtnb3dkCT7sqlbSM0TTzlRh7G+BcVocYBtqBw==")
+					if err != nil {
+						require.NoError(t, err)
+					}
+					return xdr.Signature(sigBytes)
+				}(),
+			},
+			xdr.DecoratedSignature{
+				Hint: kp1.Hint(),
+				Signature: func() xdr.Signature {
+					sigBytes, err := base64.StdEncoding.DecodeString("Iy77JteoW/FbeiuViZpgTyvrHP4BnBOeyVOjrdb5O/MpEMwcSlYXAkCBqPt4tBDil4jIcDDLhm7TsN6aUBkIBg==")
+					if err != nil {
+						require.NoError(t, err)
+					}
+					return xdr.Signature(sigBytes)
+				}(),
+			},
+		)
+		assert.NoError(t, err)
+		actual, err := tx1sigs2.Base64()
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual, "base64 xdr should match")
+	}
+}
+
 func TestAddSignatureBase64(t *testing.T) {
 	kp0 := newKeypair0()
 	kp1 := newKeypair1()

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1619,7 +1619,8 @@ func TestAddSignatureDecorated(t *testing.T) {
 			xdr.DecoratedSignature{
 				Hint: kp0.Hint(),
 				Signature: func() xdr.Signature {
-					sigBytes, err := base64.StdEncoding.DecodeString("TVogR6tbrWLnOc1BsP/j+Qrxpja2NWNgeRIwujECYscRdMG7AMtnb3dkCT7sqlbSM0TTzlRh7G+BcVocYBtqBw==")
+					var sigBytes []byte
+					sigBytes, err = base64.StdEncoding.DecodeString("TVogR6tbrWLnOc1BsP/j+Qrxpja2NWNgeRIwujECYscRdMG7AMtnb3dkCT7sqlbSM0TTzlRh7G+BcVocYBtqBw==")
 					if err != nil {
 						require.NoError(t, err)
 					}
@@ -1632,7 +1633,8 @@ func TestAddSignatureDecorated(t *testing.T) {
 			xdr.DecoratedSignature{
 				Hint: kp1.Hint(),
 				Signature: func() xdr.Signature {
-					sigBytes, err := base64.StdEncoding.DecodeString("Iy77JteoW/FbeiuViZpgTyvrHP4BnBOeyVOjrdb5O/MpEMwcSlYXAkCBqPt4tBDil4jIcDDLhm7TsN6aUBkIBg==")
+					var sigBytes []byte
+					sigBytes, err = base64.StdEncoding.DecodeString("Iy77JteoW/FbeiuViZpgTyvrHP4BnBOeyVOjrdb5O/MpEMwcSlYXAkCBqPt4tBDil4jIcDDLhm7TsN6aUBkIBg==")
 					if err != nil {
 						require.NoError(t, err)
 					}
@@ -1641,7 +1643,8 @@ func TestAddSignatureDecorated(t *testing.T) {
 			},
 		)
 		assert.NoError(t, err)
-		actual, err := tx1sigs1.Base64()
+		var actual string
+		actual, err = tx1sigs1.Base64()
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual, "base64 xdr should match")
 	}
@@ -1653,7 +1656,8 @@ func TestAddSignatureDecorated(t *testing.T) {
 			xdr.DecoratedSignature{
 				Hint: kp0.Hint(),
 				Signature: func() xdr.Signature {
-					sigBytes, err := base64.StdEncoding.DecodeString("TVogR6tbrWLnOc1BsP/j+Qrxpja2NWNgeRIwujECYscRdMG7AMtnb3dkCT7sqlbSM0TTzlRh7G+BcVocYBtqBw==")
+					var sigBytes []byte
+					sigBytes, err = base64.StdEncoding.DecodeString("TVogR6tbrWLnOc1BsP/j+Qrxpja2NWNgeRIwujECYscRdMG7AMtnb3dkCT7sqlbSM0TTzlRh7G+BcVocYBtqBw==")
 					if err != nil {
 						require.NoError(t, err)
 					}
@@ -1663,7 +1667,8 @@ func TestAddSignatureDecorated(t *testing.T) {
 			xdr.DecoratedSignature{
 				Hint: kp1.Hint(),
 				Signature: func() xdr.Signature {
-					sigBytes, err := base64.StdEncoding.DecodeString("Iy77JteoW/FbeiuViZpgTyvrHP4BnBOeyVOjrdb5O/MpEMwcSlYXAkCBqPt4tBDil4jIcDDLhm7TsN6aUBkIBg==")
+					var sigBytes []byte
+					sigBytes, err = base64.StdEncoding.DecodeString("Iy77JteoW/FbeiuViZpgTyvrHP4BnBOeyVOjrdb5O/MpEMwcSlYXAkCBqPt4tBDil4jIcDDLhm7TsN6aUBkIBg==")
 					if err != nil {
 						require.NoError(t, err)
 					}
@@ -1672,7 +1677,8 @@ func TestAddSignatureDecorated(t *testing.T) {
 			},
 		)
 		assert.NoError(t, err)
-		actual, err := tx1sigs2.Base64()
+		var actual string
+		actual, err = tx1sigs2.Base64()
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual, "base64 xdr should match")
 	}

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1614,7 +1614,8 @@ func TestAddSignatureDecorated(t *testing.T) {
 
 	// Same if signatures added separately.
 	{
-		tx1sigs1, err := tx1.AddSignatureDecorated(
+		var tx1sigs1 *txnbuild.Transaction
+		tx1sigs1, err = tx1.AddSignatureDecorated(
 			xdr.DecoratedSignature{
 				Hint: kp0.Hint(),
 				Signature: func() xdr.Signature {
@@ -1647,7 +1648,8 @@ func TestAddSignatureDecorated(t *testing.T) {
 
 	// Same if signatures added together.
 	{
-		tx1sigs2, err := tx1.AddSignatureDecorated(
+		var tx1sigs2 *txnbuild.Transaction
+		tx1sigs2, err = tx1.AddSignatureDecorated(
 			xdr.DecoratedSignature{
 				Hint: kp0.Hint(),
 				Signature: func() xdr.Signature {

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1614,7 +1614,7 @@ func TestAddSignatureDecorated(t *testing.T) {
 
 	// Same if signatures added separately.
 	{
-		var tx1sigs1 *txnbuild.Transaction
+		var tx1sigs1 *Transaction
 		tx1sigs1, err = tx1.AddSignatureDecorated(
 			xdr.DecoratedSignature{
 				Hint: kp0.Hint(),
@@ -1648,7 +1648,7 @@ func TestAddSignatureDecorated(t *testing.T) {
 
 	// Same if signatures added together.
 	{
-		var tx1sigs2 *txnbuild.Transaction
+		var tx1sigs2 *Transaction
 		tx1sigs2, err = tx1.AddSignatureDecorated(
 			xdr.DecoratedSignature{
 				Hint: kp0.Hint(),


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add `AddSignatureDecorated` function to `Transaction`.

### Why

The `Transaction` type has a `AddSignatureBase64` which is helpful when working with some SEPs where signatures and full signers are passed around, but sometimes people are exchanging the briefer decorated signatures. In that case there is no convenient way to attach the decorated signature to an existing transaction. The only methods available is to convert the `Transaction` to a `xdr.TransactionEnvelope`. But in that case there is no way to go back to a `Transaction` without round-tripping through Base64.

### Known limitations

N/A