### PR TITLE
 services/regulated-assets-approval-server: update README and refactor tx_approve.go file

### DIFF
--- a/services/regulated-assets-approval-server/README.md
+++ b/services/regulated-assets-approval-server/README.md
@@ -1,10 +1,13 @@
 # regulated-assets-approval-server
 
 ```sh
-Status: unreleased
+Status: supporting SEP-8 transactions revision with a simplified rule:
+- only revises payment type operations
+- payments with amount lower than or equal the configured threshold are revised successfully
+- payments with amount exceeding the threshold need further action
 ```
 
-This is a [SEP-8] Approval Server reference implementation based on SEP-8 v1.6.1
+This is a [SEP-8] Approval Server reference implementation based on SEP-8 v1.7.1
 intended for **testing only**. It is being conceived to:
 
 1. Be used as an example of how regulated assets transactions can be validated
@@ -64,7 +67,10 @@ Flags:
 
 #### Migration files
 
-regulated-assets-approval-server builds the migrations into the binary. If there are any changes to the db(adding, removing or updating tables) generate a new `internal/db/dbmigrate/dbmigrate_generated.go` using the `gogenerate.sh` script located at the root of the repo.
+This project builds the migrations into a binary and embeds it into the built
+project. If there are any changes to the db schema, generate a new version of
+`internal/db/dbmigrate/dbmigrate_generated.go` using the `gogenerate.sh` script
+located at the root of the repo.
 
 ```sh
 $ ./gogenerate.sh
@@ -81,32 +87,36 @@ Usage:
   regulated-assets-approval-server serve [flags]
 
 Flags:
-      --asset-code string              The code of the regulated asset (ASSET_CODE)
-      --database-url string            Database URL (DATABASE_URL) (default "postgres://localhost:5432/?sslmode=disable")
-      --friendbot-payment-amount int   The amount of regulated assets the friendbot will be distributing (FRIENDBOT_PAYMENT_AMOUNT) (default 10000)
-      --horizon-url string             Horizon URL used for looking up account details (HORIZON_URL) (default "https://horizon-testnet.stellar.org/")
-      --issuer-account-secret string   Secret key of the asset issuer's stellar account. (ISSUER_ACCOUNT_SECRET)
-      --network-passphrase string      Network passphrase of the Stellar network transactions should be signed for (NETWORK_PASSPHRASE) (default "Test SDF Network ; September 2015")
-      --port int                       Port to listen and serve on (PORT) (default 8000)
-      --base-url string                The base url address to this server(BASE_URL)
-      --kyc-required-payment-amount-threshold string The amount threshold when KYC is required, may contain decimals and is greater than 0 (KYC_REQUIRED_PAYMENT_AMOUNT_THRESHOLD)(default 500 units)
+      --asset-code string                              The code of the regulated asset (ASSET_CODE)
+      --base-url string                                The base url address to this server (BASE_URL)
+      --database-url string                            Database URL (DATABASE_URL) (default "postgres://localhost:5432/?sslmode=disable")
+      --friendbot-payment-amount int                   The amount of regulated assets the friendbot will be distributing (FRIENDBOT_PAYMENT_AMOUNT) (default 10000)
+      --horizon-url string                             Horizon URL used for looking up account details (HORIZON_URL) (default "https://horizon-testnet.stellar.org/")
+      --issuer-account-secret string                   Secret key of the issuer account. (ISSUER_ACCOUNT_SECRET)
+      --kyc-required-payment-amount-threshold string   The amount threshold when KYC is required, may contain decimals and is greater than 0 (KYC_REQUIRED_PAYMENT_AMOUNT_THRESHOLD) (default "500")
+      --network-passphrase string                      Network passphrase of the Stellar network transactions should be signed for (NETWORK_PASSPHRASE) (default "Test SDF Network ; September 2015")
+      --port int                                       Port to listen and serve on (PORT) (default 8000)
 ```
 
 ## Account Setup
 
 In order to properly use this server for regulated assets, the account whose
-secret was added in `--issuer-account-secret (ACCOUNT_ISSUER_SECRET)` needs to
+secret was added in `--issuer-account-secret (ISSUER_ACCOUNT_SECRET)` needs to
 be configured according with SEP-8 [authorization flags] by setting both
 `Authorization Required` and `Authorization Revocable` flags. This allows the
 issuer to grant and revoke authorization to transact the asset at will.
 
 You can use [this
 link](https://laboratory.stellar.org/#txbuilder?params=eyJhdHRyaWJ1dGVzIjp7ImZlZSI6IjEwMCIsImJhc2VGZWUiOiIxMDAiLCJtaW5GZWUiOiIxMDAifSwiZmVlQnVtcEF0dHJpYnV0ZXMiOnsibWF4RmVlIjoiMTAwIn0sIm9wZXJhdGlvbnMiOlt7ImlkIjowLCJhdHRyaWJ1dGVzIjp7InNldEZsYWdzIjozfSwibmFtZSI6InNldE9wdGlvbnMifV19)
-to set those flags. Just click the link, fulfill the account address, sequence
-number, then the account secret and submit the transaction.
+to set those flags in Stellar Laboratory. Just click the link, fill the account
+address and sequence number, then the account secret and submit the transaction.
 
-After setting up the issuer account you can fund a stellar account with an initial balance of the regulated asset with our internal `friendbot/?addr={stellar_address}` endpoint.
-This endpoint is not part of the official SEP-8 Approval Server spec, it's a debug feature to allow accounts to test sending transactions (payments with the issuer's regulated asset) to the server.
+After setting up the issuer account you can send some unities of the regulkated
+asset to a stellar account using our internal
+`friendbot/?addr={stellar_address}` endpoint. This endpoint is not part of the
+official SEP-8 Approval Server spec, it's a debug feature to allow accounts to
+test sending transactions (payments with the issuer's regulated asset) to the
+server.
 
 ### `GET /friendbot?addr={stellar_address}`
 
@@ -118,10 +128,13 @@ link](https://laboratory.stellar.org/#txbuilder?params=eyJhdHRyaWJ1dGVzIjp7ImZlZ
 to do that in Stellar Laboratory.
 
 ## API Spec
+
 ### `POST /tx-approve`
 
-This is the core [SEP-8] endpoint used to validate and process approval/revision/rejection of regulated assets transactions.
-Note: The example responses below have set their `base-url` env var to `"https://sep8-base-url.com"`.
+This is the core [SEP-8] endpoint used to validate and process
+approval/revision/rejection of regulated assets transactions. Note: The example
+responses below have set their `base-url` env var configured to
+`"https://sep8-base-url.com"`.
 
 **Request:**
 
@@ -133,7 +146,7 @@ Note: The example responses below have set their `base-url` env var to `"https:/
 
 **Responses:**
 
-_Revised:_ This response means the transaction was revised to be made compliant,
+_Revised:_ this response means the transaction was revised to be made compliant,
 and signed by the issuer. For more info read the SEP-8 [Revised] section.
 
 ```json
@@ -144,7 +157,7 @@ and signed by the issuer. For more info read the SEP-8 [Revised] section.
 }
 ```
 
-_Rejected:_ This response means the transaction is not and couldn't be made
+_Rejected:_ this response means the transaction is not and couldn't be made
 compliant. For more info read the SEP-8 [Rejected] section.
 
 ```json
@@ -154,8 +167,7 @@ compliant. For more info read the SEP-8 [Rejected] section.
 }
 ```
 
-_Action Required:_
-This response means the user must complete an action before this transaction can
+_Action Required:_ this response means the user must complete an action before this transaction can
 be approved. The approval server will provide a URL that facilitates the action.
 Upon completion, the user can resubmit the transaction. For more info read the
 SEP-8 [Action Required] section.
@@ -177,10 +189,12 @@ SEP-8 [Action Required] section.
 This endpoint is used for the extra action after `/tx-approve`, as described in
 the SEP-8 [Action Required] section.
 
-Currently an arbitrarily criteria is implemented, email addresses starting with "x" will have the KYC
-automatically denied while all other emails will be accepted.
+Currently an arbitrarily criteria is implemented: email addresses starting with
+"x" will have the KYC automatically denied while all other emails will be
+accepted.
 
-Note: Subsequent KYC attempts with new (valid)emails addresses will approve your account for KYC required transactions.
+_Note: you'll need to resubmit your transaction to
+[`/tx_approve`](#post-tx-approve) in order to verify if your KYC was approved._
 
 **Request:**
 
@@ -198,7 +212,8 @@ Note: Subsequent KYC attempts with new (valid)emails addresses will approve your
 }
 ```
 
-After the user has been approved or rejected they can POST their transaction to [`POST /tx-approve`](#post-tx-approve) for revision.
+After the user has been approved or rejected they can POST their transaction to
+[`POST /tx-approve`](#post-tx-approve) for revision.
 
 If their KYC was rejected they should see a rejection response.
 **Response (rejected for emails staring with "x"):**
@@ -214,9 +229,11 @@ If their KYC was rejected they should see a rejection response.
 
 Returns the detail of an account that requested KYC, as well some metadata about
 its status.
-Note: This functionality is for test/debugging purposes and it's not part of the [SEP-8] spec.
 
-**Response (No KYC Submitted):**
+_Note: This functionality is for test/debugging purposes and it's not
+part of the [SEP-8] spec._
+
+**Response (pending KYC submission):**
 
 ```json
 {
@@ -226,7 +243,7 @@ Note: This functionality is for test/debugging purposes and it's not part of the
 }
 ```
 
-**Response (Approved KYC):**
+**Response (approved KYC):**
 
 ```json
 {
@@ -239,7 +256,7 @@ Note: This functionality is for test/debugging purposes and it's not part of the
 }
 ```
 
-**Response (Rejected KYC):**
+**Response (rejected KYC):**
 
 ```json
 {
@@ -256,7 +273,9 @@ Note: This functionality is for test/debugging purposes and it's not part of the
 
 Deletes a stellar account from the list of KYCs. If the stellar address is not
 in the database to be deleted the server will return with a `404 - Not Found`.
-Note: This functionality is for test/debugging purposes and it's not part of the [SEP-8] spec.
+
+_Note: This functionality is for test/debugging purposes and it's not part of
+the [SEP-8] spec._
 
 **Response:**
 

--- a/services/regulated-assets-approval-server/README.md
+++ b/services/regulated-assets-approval-server/README.md
@@ -133,7 +133,8 @@ Note: The example responses below have set their `base-url` env var to `"https:/
 
 **Responses:**
 
-_Revised:_
+_Revised:_ This response means the transaction was revised to be made compliant,
+and signed by the issuer. For more info read the SEP-8 [Revised] section.
 
 ```json
 {
@@ -143,7 +144,8 @@ _Revised:_
 }
 ```
 
-_Rejected:_
+_Rejected:_ This response means the transaction is not and couldn't be made
+compliant. For more info read the SEP-8 [Rejected] section.
 
 ```json
 {
@@ -153,6 +155,10 @@ _Rejected:_
 ```
 
 _Action Required:_
+This response means the user must complete an action before this transaction can
+be approved. The approval server will provide a URL that facilitates the action.
+Upon completion, the user can resubmit the transaction. For more info read the
+SEP-8 [Action Required] section.
 
 ```json
 {
@@ -263,3 +269,5 @@ Note: This functionality is for test/debugging purposes and it's not part of the
 [SEP-8]: https://github.com/stellar/stellar-protocol/blob/7c795bb9abc606cd1e34764c4ba07900d58fe26e/ecosystem/sep-0008.md
 [authorization flags]: https://github.com/stellar/stellar-protocol/blob/7c795bb9abc606cd1e34764c4ba07900d58fe26e/ecosystem/sep-0008.md#authorization-flags
 [Action Required]: https://github.com/stellar/stellar-protocol/blob/7c795bb9abc606cd1e34764c4ba07900d58fe26e/ecosystem/sep-0008.md#action-required
+[Rejected]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md#rejected
+[Revised]:https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md#revised

--- a/services/regulated-assets-approval-server/README.md
+++ b/services/regulated-assets-approval-server/README.md
@@ -1,10 +1,12 @@
 # regulated-assets-approval-server
 
 ```sh
-Status: supporting SEP-8 transactions revision with a simplified rule:
-- only revises payment type operations
-- payments with amount lower than or equal the configured threshold are revised successfully
-- payments with amount exceeding the threshold need further action
+Status: supports SEP-8 transactions revision with a simplified rule:
+- only revises transactions containing a single operation of type payment.
+- payments whose amount does not meet the configured threshold are considered compliant and revised according to the SEP-8 specification.
+- payments with an amount exceeding the threshold need further action.
+
+It is important to notice the SEP-8 "success" response has not been implemented yet so even if the submitted transaction is compliant to be marked as successful according with SEP-8, the service will reject it.
 ```
 
 This is a [SEP-8] Approval Server reference implementation based on SEP-8 v1.7.1
@@ -216,7 +218,7 @@ After the user has been approved or rejected they can POST their transaction to
 [`POST /tx-approve`](#post-tx-approve) for revision.
 
 If their KYC was rejected they should see a rejection response.
-**Response (rejected for emails staring with "x"):**
+**Response (rejected for emails starting with "x"):**
 
 ```json
 {

--- a/services/regulated-assets-approval-server/README.md
+++ b/services/regulated-assets-approval-server/README.md
@@ -134,7 +134,7 @@ to do that in Stellar Laboratory.
 This is the core [SEP-8] endpoint used to validate and process
 approval/revision/rejection of regulated assets transactions. Note: The example
 responses below have set their `base-url` env var configured to
-`"https://sep8-base-url.com"`.
+`"https://example.com"`.
 
 **Request:**
 
@@ -176,7 +176,7 @@ SEP-8 [Action Required] section.
 {
   "status": "action_required",
   "message": "Payments exceeding 500.00 GOAT needs KYC approval. Please provide an email address.",
-  "action_url": "https://sep8-base-url.com/kyc-status/cf4fe081-5b38-48b6-86ed-1bcfb7171c7d",
+  "action_url": "https://example.com/kyc-status/cf4fe081-5b38-48b6-86ed-1bcfb7171c7d",
   "action_method": "POST",
   "action_fields": [
     "email_address"

--- a/services/regulated-assets-approval-server/README.md
+++ b/services/regulated-assets-approval-server/README.md
@@ -67,7 +67,7 @@ Flags:
 
 #### Migration files
 
-This project builds the migrations into a binary and embeds it into the built
+This project builds the migrations into the binary and embeds it into the built
 project. If there are any changes to the db schema, generate a new version of
 `internal/db/dbmigrate/dbmigrate_generated.go` using the `gogenerate.sh` script
 located at the root of the repo.
@@ -108,15 +108,15 @@ issuer to grant and revoke authorization to transact the asset at will.
 
 You can use [this
 link](https://laboratory.stellar.org/#txbuilder?params=eyJhdHRyaWJ1dGVzIjp7ImZlZSI6IjEwMCIsImJhc2VGZWUiOiIxMDAiLCJtaW5GZWUiOiIxMDAifSwiZmVlQnVtcEF0dHJpYnV0ZXMiOnsibWF4RmVlIjoiMTAwIn0sIm9wZXJhdGlvbnMiOlt7ImlkIjowLCJhdHRyaWJ1dGVzIjp7InNldEZsYWdzIjozfSwibmFtZSI6InNldE9wdGlvbnMifV19)
-to set those flags in Stellar Laboratory. Just click the link, fill the account
+to set those flags in Stellar Laboratory. Click the link, fill the account
 address and sequence number, then the account secret and submit the transaction.
 
-After setting up the issuer account you can send some unities of the regulkated
-asset to a stellar account using our internal
-`friendbot/?addr={stellar_address}` endpoint. This endpoint is not part of the
-official SEP-8 Approval Server spec, it's a debug feature to allow accounts to
-test sending transactions (payments with the issuer's regulated asset) to the
-server.
+After setting up the issuer account you can send some amount of the regulated
+asset to a stellar account using the servers friendbot
+`friendbot/?addr={stellar_address}` endpoint. The friendbot endpoint is not part
+of the SEP-8 Approval Server specification, it's a debug feature that allows
+accounts to test sending transactions containing payments with the issuer's
+regulated asset, to the server.
 
 ### `GET /friendbot?addr={stellar_address}`
 
@@ -189,7 +189,7 @@ SEP-8 [Action Required] section.
 This endpoint is used for the extra action after `/tx-approve`, as described in
 the SEP-8 [Action Required] section.
 
-Currently an arbitrarily criteria is implemented: email addresses starting with
+Currently an arbitrary criteria is implemented: email addresses starting with
 "x" will have the KYC automatically denied while all other emails will be
 accepted.
 

--- a/services/regulated-assets-approval-server/cmd/serve.go
+++ b/services/regulated-assets-approval-server/cmd/serve.go
@@ -17,7 +17,7 @@ func (c *ServeCommand) Command() *cobra.Command {
 	configOpts := config.ConfigOptions{
 		{
 			Name:      "issuer-account-secret",
-			Usage:     "Secret key of the asset issuer's stellar account.",
+			Usage:     "Secret key of the issuer account.",
 			OptType:   types.String,
 			ConfigKey: &opts.IssuerAccountSecret,
 			Required:  true,

--- a/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
@@ -213,7 +213,7 @@ func TestAPI_RejectedIntegration(t *testing.T) {
 
 	// TEST "rejected" response if the transaction sourceAccount the same as the server issuer account.
 	wantBody = `{
-		"status":"rejected", "error":"The source account is invalid."
+		"status":"rejected", "error":"Transaction source account is invalid."
 	}`
 	require.JSONEq(t, wantBody, string(body))
 
@@ -635,7 +635,7 @@ func TestAPI_KYCIntegration(t *testing.T) {
 	require.NoError(t, err)
 	wantTXApprovalResponse := txApprovalResponse{
 		Status:       sep8Status("action_required"),
-		Message:      `Payments exceeding 500.00 GOAT requires KYC approval. Please provide an email address.`,
+		Message:      `Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.`,
 		ActionURL:    txApprovePOSTResponse.ActionURL,
 		ActionMethod: "POST",
 		ActionFields: []string{"email_address"},

--- a/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
@@ -3,11 +3,9 @@ package serve
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -17,7 +15,6 @@ import (
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/protocols/horizon"
-	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stellar/go/services/regulated-assets-approval-server/internal/db/dbtest"
 	kycstatus "github.com/stellar/go/services/regulated-assets-approval-server/internal/serve/kyc-status"
 	"github.com/stellar/go/txnbuild"
@@ -25,53 +22,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAPI_RejectedIntegration(t *testing.T) {
+func TestAPI_txApprove_rejected(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
 	defer conn.Close()
 
-	// Perpare accounts on mock horizon.
-	issuerAccKeyPair := keypair.MustRandom()
-	assetGOAT := txnbuild.CreditAsset{
-		Code:   "GOAT",
-		Issuer: issuerAccKeyPair.Address(),
-	}
+	issuerKP := keypair.MustRandom()
 	horizonMock := horizonclient.MockClient{}
-	senderAccKP := keypair.MustRandom()
-	receiverAccKP := keypair.MustRandom()
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: issuerAccKeyPair.Address()}).
-		Return(horizon.Account{
-			AccountID: issuerAccKeyPair.Address(),
-			Sequence:  "1",
-			Balances: []horizon.Balance{
-				{
-					Asset:   base.Asset{Code: "ASSET", Issuer: issuerAccKeyPair.Address()},
-					Balance: "1",
-				},
-			},
-		}, nil)
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderAccKP.Address()}).
-		Return(horizon.Account{
-			AccountID: senderAccKP.Address(),
-			Sequence:  "2",
-		}, nil)
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: receiverAccKP.Address()}).
-		Return(horizon.Account{
-			AccountID: receiverAccKP.Address(),
-			Sequence:  "3",
-		}, nil)
-
-	// Create tx-approve/ txApproveHandler.
 	kycThresholdAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)
+
 	handler := txApproveHandler{
-		issuerKP:          issuerAccKeyPair,
-		assetCode:         assetGOAT.GetCode(),
+		issuerKP:          issuerKP,
+		assetCode:         "FOO",
 		horizonClient:     &horizonMock,
 		networkPassphrase: network.TestNetworkPassphrase,
 		db:                conn,
@@ -79,322 +44,28 @@ func TestAPI_RejectedIntegration(t *testing.T) {
 		baseURL:           "https://sep8-server.test",
 	}
 
-	// Prepare and send empty "tx" for "/tx-approve" POST request.
-	req := `{
-		"tx": ""
-	}`
+	// rejected if no transaction "tx"is submitted
 	m := chi.NewMux()
 	m.Post("/tx-approve", handler.ServeHTTP)
-	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	r := httptest.NewRequest("POST", "/tx-approve", nil)
 	r = r.WithContext(ctx)
 	w := httptest.NewRecorder()
 	m.ServeHTTP(w, r)
+
 	resp := w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	// TEST "rejected" response if no transaction is submitted.
 	wantBody := `{
-		"status":"rejected", "error":"Missing parameter \"tx\"."
-	}`
-	require.JSONEq(t, wantBody, string(body))
-
-	// Prepare and send malformed "tx" for "/tx-approve" POST request.
-	req = `{
-		"tx": "BADXDRTRANSACTIONENVELOPE"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "rejected" response if can't parse XDR.
-	wantBody = `{
-		"status":"rejected", "error":"Invalid parameter \"tx\"."
-	}`
-	require.JSONEq(t, wantBody, string(body))
-
-	// Prepare non generic transaction "tx".
-	senderAcc, err := handler.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: senderAccKP.Address()})
-	require.NoError(t, err)
-	tx, err := txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &senderAcc,
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					Destination: receiverAccKP.Address(),
-					Amount:      "1",
-					Asset:       assetGOAT,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	feeBumpTx, err := txnbuild.NewFeeBumpTransaction(
-		txnbuild.FeeBumpTransactionParams{
-			Inner:      tx,
-			FeeAccount: receiverAccKP.Address(),
-			BaseFee:    2 * txnbuild.MinBaseFee,
-		},
-	)
-	require.NoError(t, err)
-	feeBumpTxEnc, err := feeBumpTx.Base64()
-	require.NoError(t, err)
-
-	// Send invalid "tx" for "/tx-approve" POST request.
-	req = `{
-		"tx": "` + feeBumpTxEnc + `"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "rejected" response if  a non generic transaction fails, same result as malformed XDR.
-	wantBody = `{
-		"status":"rejected", "error":"Invalid parameter \"tx\"."
-	}`
-	require.JSONEq(t, wantBody, string(body))
-
-	// Prepare "tx" where transaction sourceAccount the same as the server issuer account.
-	issuerAcc, err := handler.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: issuerAccKeyPair.Address()})
-	require.NoError(t, err)
-	tx, err = txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &issuerAcc,
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					Destination: senderAccKP.Address(),
-					Amount:      "1",
-					Asset:       assetGOAT,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txEnc, err := tx.Base64()
-	require.NoError(t, err)
-
-	// Send "tx" where transaction sourceAccount the same as the server issuer account for "/tx-approve" POST request.
-	req = `{
-		"tx": "` + txEnc + `"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "rejected" response if the transaction sourceAccount the same as the server issuer account.
-	wantBody = `{
-		"status":"rejected", "error":"Transaction source account is invalid."
-	}`
-	require.JSONEq(t, wantBody, string(body))
-
-	// Prepare "tx" where transaction's operation sourceAccount the same as the server issuer account.
-	tx, err = txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &senderAcc,
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					SourceAccount: issuerAccKeyPair.Address(),
-					Destination:   senderAccKP.Address(),
-					Amount:        "1",
-					Asset:         assetGOAT,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txEnc, err = tx.Base64()
-	require.NoError(t, err)
-
-	// Send "tx" where transaction's operation sourceAccount the same as the server issuer account for "/tx-approve" POST request.
-	req = `{
-		"tx": "` + txEnc + `"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "rejected" response if the transaction's operation sourceAccount the same as the server issuer account.
-	wantBody = `{
-		"status":"rejected", "error":"There is one or more unauthorized operations in the provided transaction."
-	}`
-	require.JSONEq(t, wantBody, string(body))
-
-	// Prepare "tx" where transaction's operation is not a payment.
-	tx, err = txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &senderAcc,
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.AllowTrust{
-					Trustor:   receiverAccKP.Address(),
-					Type:      assetGOAT,
-					Authorize: true,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txEnc, err = tx.Base64()
-	require.NoError(t, err)
-
-	// Send "tx" where transaction's operation is not a payment for "/tx-approve" POST request.
-	req = `{
-		"tx": "` + txEnc + `"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "rejected" response if transaction's operation is not a payment.
-	wantBody = `{
-		"status":"rejected", "error":"There is one or more unauthorized operations in the provided transaction."
-	}`
-	require.JSONEq(t, wantBody, string(body))
-
-	// Prepare "tx" where theres more than one operation in transaction.
-	tx, err = txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &senderAcc,
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					SourceAccount: senderAccKP.Address(),
-					Destination:   receiverAccKP.Address(),
-					Amount:        "1",
-					Asset:         assetGOAT,
-				},
-				&txnbuild.Payment{
-					SourceAccount: senderAccKP.Address(),
-					Destination:   receiverAccKP.Address(),
-					Amount:        "2",
-					Asset:         assetGOAT,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txEnc, err = tx.Base64()
-	require.NoError(t, err)
-
-	// Send "tx" where theres more than one operation in transaction for "/tx-approve" POST request.
-	req = `{
-		"tx": "` + txEnc + `"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "rejected" response if more than one operation in transaction.
-	wantBody = `{
-		"status":"rejected", "error":"Please submit a transaction with exactly one operation of type payment."
-	}`
-	require.JSONEq(t, wantBody, string(body))
-
-	// Prepare "tx" where transaction's transaction source account seq num is not equal to account sequence+1.
-	tx, err = txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount: &horizon.Account{
-				AccountID: senderAccKP.Address(),
-				Sequence:  "50",
-			},
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					SourceAccount: senderAccKP.Address(),
-					Destination:   receiverAccKP.Address(),
-					Amount:        "1",
-					Asset:         assetGOAT,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txEnc, err = tx.Base64()
-	require.NoError(t, err)
-
-	// Send "tx" where transaction's transaction source account seq num is not equal to account sequence+1 for "/tx-approve" POST request.
-	req = `{
-		"tx": "` + txEnc + `"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "rejected" response if where transaction's transaction source account seq num is not equal to account sequence+1.
-	wantBody = `{
-		"status":"rejected", "error":"Invalid transaction sequence number."
+		"status": "rejected",
+		"error": "Missing parameter \"tx\"."
 	}`
 	require.JSONEq(t, wantBody, string(body))
 }
 
-func TestAPI_RevisedIntegration(t *testing.T) {
+func TestAPI_txApprove_revised(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)
 	defer db.Close()
@@ -402,42 +73,25 @@ func TestAPI_RevisedIntegration(t *testing.T) {
 	defer conn.Close()
 
 	// Perpare accounts on mock horizon.
-	issuerAccKeyPair := keypair.MustRandom()
-	senderAccKP := keypair.MustRandom()
-	receiverAccKP := keypair.MustRandom()
+	senderKP := keypair.MustRandom()
+	receiverKP := keypair.MustRandom()
+	issuerKP := keypair.MustRandom()
 	assetGOAT := txnbuild.CreditAsset{
 		Code:   "GOAT",
-		Issuer: issuerAccKeyPair.Address(),
+		Issuer: issuerKP.Address(),
 	}
 	horizonMock := horizonclient.MockClient{}
 	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: issuerAccKeyPair.Address()}).
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
 		Return(horizon.Account{
-			Balances: []horizon.Balance{
-				{
-					Asset:   base.Asset{Code: "ASSET", Issuer: issuerAccKeyPair.Address()},
-					Balance: "0",
-				},
-			},
-		}, nil)
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderAccKP.Address()}).
-		Return(horizon.Account{
-			AccountID: senderAccKP.Address(),
+			AccountID: senderKP.Address(),
 			Sequence:  "5",
 		}, nil)
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: receiverAccKP.Address()}).
-		Return(horizon.Account{
-			AccountID: receiverAccKP.Address(),
-			Sequence:  "0",
-		}, nil)
 
-	// Create tx-approve/ txApproveHandler.
 	kycThresholdAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)
 	handler := txApproveHandler{
-		issuerKP:          issuerAccKeyPair,
+		issuerKP:          issuerKP,
 		assetCode:         assetGOAT.GetCode(),
 		horizonClient:     &horizonMock,
 		networkPassphrase: network.TestNetworkPassphrase,
@@ -446,17 +100,17 @@ func TestAPI_RevisedIntegration(t *testing.T) {
 		baseURL:           "https://sep8-server.test",
 	}
 
-	// Prepare revisable "tx".
-	senderAcc, err := handler.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: senderAccKP.Address()})
-	require.NoError(t, err)
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
-			SourceAccount:        &senderAcc,
+			SourceAccount: &horizon.Account{
+				AccountID: senderKP.Address(),
+				Sequence:  "5",
+			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
 				&txnbuild.Payment{
-					SourceAccount: senderAccKP.Address(),
-					Destination:   receiverAccKP.Address(),
+					SourceAccount: senderKP.Address(),
+					Destination:   receiverKP.Address(),
 					Amount:        "1",
 					Asset:         assetGOAT,
 				},
@@ -466,121 +120,95 @@ func TestAPI_RevisedIntegration(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	txEnc, err := tx.Base64()
+	txe, err := tx.Base64()
 	require.NoError(t, err)
 
-	// Send revisable "tx" for "/tx-approve" POST request.
-	req := `{
-		"tx": "` + txEnc + `"
-		}`
 	m := chi.NewMux()
 	m.Post("/tx-approve", handler.ServeHTTP)
+	req := `{
+		"tx": "` + txe + `"
+	}`
 	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
 	r = r.WithContext(ctx)
 	w := httptest.NewRecorder()
 	m.ServeHTTP(w, r)
+
 	resp := w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	// TEST successful "revised" response.
-	var txApprovePOSTResponse txApprovalResponse
-	err = json.Unmarshal(body, &txApprovePOSTResponse)
+	var gotResponse txApprovalResponse
+	err = json.Unmarshal(body, &gotResponse)
 	require.NoError(t, err)
-	wantTXApprovalResponse := txApprovalResponse{
-		Status:  sep8Status("revised"),
-		Tx:      txApprovePOSTResponse.Tx,
-		Message: `Authorization and deauthorization operations were added.`,
-	}
-	assert.Equal(t, wantTXApprovalResponse, txApprovePOSTResponse)
+	require.Equal(t, sep8StatusRevised, gotResponse.Status)
+	require.Equal(t, "Authorization and deauthorization operations were added.", gotResponse.Message)
 
-	// Decode the request's transaction.
-	parsed, err := txnbuild.TransactionFromXDR(txApprovePOSTResponse.Tx)
+	gotGenericTx, err := txnbuild.TransactionFromXDR(gotResponse.Tx)
 	require.NoError(t, err)
-	tx, ok := parsed.Transaction()
+	gotTx, ok := gotGenericTx.Transaction()
 	require.True(t, ok)
 
-	// Check if revised transaction only has 5 operations.
-	require.Len(t, tx.Operations(), 5)
-	// Check Operation 1: AllowTrust op where issuer fully authorizes account A, asset X.
-	op1, ok := tx.Operations()[0].(*txnbuild.AllowTrust)
+	require.Len(t, gotTx.Operations(), 5)
+	// AllowTrust op where issuer fully authorizes account A, asset X
+	op0, ok := gotTx.Operations()[0].(*txnbuild.AllowTrust)
 	require.True(t, ok)
-	assert.Equal(t, op1.Trustor, senderAccKP.Address())
+	assert.Equal(t, op0.Trustor, senderKP.Address())
+	assert.Equal(t, op0.Type.GetCode(), assetGOAT.GetCode())
+	require.True(t, op0.Authorize)
+	// AllowTrust op where issuer fully authorizes account B, asset X
+	op1, ok := gotTx.Operations()[1].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op1.Trustor, receiverKP.Address())
 	assert.Equal(t, op1.Type.GetCode(), assetGOAT.GetCode())
 	require.True(t, op1.Authorize)
-	// Check  Operation 2: AllowTrust op where issuer fully authorizes account B, asset X.
-	op2, ok := tx.Operations()[1].(*txnbuild.AllowTrust)
+	// Payment from A to B
+	op2, ok := gotTx.Operations()[2].(*txnbuild.Payment)
 	require.True(t, ok)
-	assert.Equal(t, op2.Trustor, receiverAccKP.Address())
-	assert.Equal(t, op2.Type.GetCode(), assetGOAT.GetCode())
-	require.True(t, op2.Authorize)
-	// Check Operation 3: Payment from A to B.
-	op3, ok := tx.Operations()[2].(*txnbuild.Payment)
+	assert.Equal(t, op2.Destination, receiverKP.Address())
+	assert.Equal(t, op2.Asset, assetGOAT)
+	// AllowTrust op where issuer fully deauthorizes account B, asset X
+	op3, ok := gotTx.Operations()[3].(*txnbuild.AllowTrust)
 	require.True(t, ok)
-	assert.Equal(t, op3.SourceAccount, senderAccKP.Address())
-	assert.Equal(t, op3.Destination, receiverAccKP.Address())
-	assert.Equal(t, op3.Asset, assetGOAT)
-	// Check Operation 4: AllowTrust op where issuer fully deauthorizes account B, asset X.
-	op4, ok := tx.Operations()[3].(*txnbuild.AllowTrust)
+	assert.Equal(t, op3.Trustor, receiverKP.Address())
+	assert.Equal(t, op3.Type.GetCode(), assetGOAT.GetCode())
+	require.False(t, op3.Authorize)
+	// AllowTrust op where issuer fully deauthorizes account A, asset X
+	op4, ok := gotTx.Operations()[4].(*txnbuild.AllowTrust)
 	require.True(t, ok)
-	assert.Equal(t, op4.Trustor, receiverAccKP.Address())
+	assert.Equal(t, op4.Trustor, senderKP.Address())
 	assert.Equal(t, op4.Type.GetCode(), assetGOAT.GetCode())
 	require.False(t, op4.Authorize)
-	// Check Operation 5: AllowTrust op where issuer fully deauthorizes account A, asset X.
-	op5, ok := tx.Operations()[4].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op5.Trustor, senderAccKP.Address())
-	assert.Equal(t, op5.Type.GetCode(), assetGOAT.GetCode())
-	require.False(t, op5.Authorize)
 }
 
-func TestAPI_KYCIntegration(t *testing.T) {
+func TestAPI_txAprove_actionRequired(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
 	defer conn.Close()
 
-	// Perpare accounts on mock horizon.
-	issuerAccKeyPair := keypair.MustRandom()
-	senderAccKP := keypair.MustRandom()
-	receiverAccKP := keypair.MustRandom()
+	// prepare handler dependencies
+	senderKP := keypair.MustRandom()
+	receiverKP := keypair.MustRandom()
+	issuerKP := keypair.MustRandom()
 	assetGOAT := txnbuild.CreditAsset{
 		Code:   "GOAT",
-		Issuer: issuerAccKeyPair.Address(),
+		Issuer: issuerKP.Address(),
 	}
-	horizonMock := horizonclient.MockClient{}
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: issuerAccKeyPair.Address()}).
-		Return(horizon.Account{
-			Balances: []horizon.Balance{
-				{
-					Asset:   base.Asset{Code: "ASSET", Issuer: issuerAccKeyPair.Address()},
-					Balance: "0",
-				},
-			},
-		}, nil)
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderAccKP.Address()}).
-		Return(horizon.Account{
-			AccountID: senderAccKP.Address(),
-			Sequence:  "5",
-		}, nil)
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: receiverAccKP.Address()}).
-		Return(horizon.Account{
-			AccountID: receiverAccKP.Address(),
-			Sequence:  "0",
-		}, nil)
-
-	// Create tx-approve/ txApproveHandler.
 	kycThresholdAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)
+	horizonMock := horizonclient.MockClient{}
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
+		Return(horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "1",
+		}, nil)
+
 	handler := txApproveHandler{
-		issuerKP:          issuerAccKeyPair,
+		issuerKP:          issuerKP,
 		assetCode:         assetGOAT.GetCode(),
 		horizonClient:     &horizonMock,
 		networkPassphrase: network.TestNetworkPassphrase,
@@ -589,17 +217,23 @@ func TestAPI_KYCIntegration(t *testing.T) {
 		baseURL:           "https://sep8-server.test",
 	}
 
-	// Prepare transaction whose payment amount is <=500 GOATs for /tx-approve POST request.
-	senderAcc, err := handler.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: senderAccKP.Address()})
-	require.NoError(t, err)
+	// setup route handlers
+	m := chi.NewMux()
+	m.Post("/tx-approve", handler.ServeHTTP)
+	m.Post("/kyc-status/{callback_id}", kycstatus.PostHandler{DB: conn}.ServeHTTP)
+
+	// Step 1: Client sends payment with 500+ GOAT
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
-			SourceAccount:        &senderAcc,
+			SourceAccount: &horizon.Account{
+				AccountID: senderKP.Address(),
+				Sequence:  "1",
+			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
 				&txnbuild.Payment{
-					SourceAccount: senderAccKP.Address(),
-					Destination:   receiverAccKP.Address(),
+					SourceAccount: senderKP.Address(),
+					Destination:   receiverKP.Address(),
 					Amount:        "501",
 					Asset:         assetGOAT,
 				},
@@ -609,182 +243,192 @@ func TestAPI_KYCIntegration(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	txEnc, err := tx.Base64()
+	txe, err := tx.Base64()
 	require.NoError(t, err)
 
-	// Send /tx-approve POST request with transaction in request body.
-	req := `{
-		"tx": "` + txEnc + `"
-	}`
-	m := chi.NewMux()
-	m.Post("/tx-approve", handler.ServeHTTP)
-	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(`{"tx": "`+txe+`"}`))
 	r = r.WithContext(ctx)
 	w := httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp := w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	// TEST "action_required" response for sender account.
+	var callbackID string
+	q := `SELECT callback_id FROM accounts_kyc_status WHERE stellar_address = $1`
+	err = conn.QueryRowContext(ctx, q, senderKP.Address()).Scan(&callbackID)
+	require.NoError(t, err)
+
 	var txApprovePOSTResponse txApprovalResponse
 	err = json.Unmarshal(body, &txApprovePOSTResponse)
 	require.NoError(t, err)
 	wantTXApprovalResponse := txApprovalResponse{
 		Status:       sep8Status("action_required"),
-		Message:      `Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.`,
-		ActionURL:    txApprovePOSTResponse.ActionURL,
+		Message:      "Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.",
+		ActionURL:    "https://sep8-server.test/kyc-status/" + callbackID,
 		ActionMethod: "POST",
 		ActionFields: []string{"email_address"},
 	}
 	assert.Equal(t, wantTXApprovalResponse, txApprovePOSTResponse)
+}
 
-	// Setup /kyc-status route for subsequent integration steps.
-	m.Route("/kyc-status", func(mux chi.Router) {
-		mux.Post("/{callback_id}", kycstatus.PostHandler{
-			DB: conn,
-		}.ServeHTTP)
-	})
-	// RxUUID is a regex used to validate correct UUIDs, https://w.wiki/39fK
-	var RxUUID = regexp.MustCompile(
-		`[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}`)
-	// Grab callbackID
-	callbackID := RxUUID.FindAllString(txApprovePOSTResponse.ActionURL, 1)[0]
+func TestAPI_txAprove_actionRequiredFlow(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.Open(t)
+	defer db.Close()
+	conn := db.Open()
+	defer conn.Close()
 
-	// Verify the KYC entree was inserted in db.
-	const q = `
-		SELECT callback_id
-		FROM accounts_kyc_status
-		WHERE stellar_address = $1
-	`
-	var returnedCallbackID string
-	err = handler.db.QueryRowContext(ctx, q, senderAccKP.Address()).Scan(&returnedCallbackID)
+	// prepare handler dependencies
+	senderKP := keypair.MustRandom()
+	receiverKP := keypair.MustRandom()
+	issuerKP := keypair.MustRandom()
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerKP.Address(),
+	}
+	kycThresholdAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)
-	assert.Equal(t, callbackID, returnedCallbackID)
+	horizonMock := horizonclient.MockClient{}
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
+		Return(horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "1",
+		}, nil)
 
-	// Prepare and send /kyc-status/{callback_id} POST request; with an email_address that doesn't start with "x".
-	req = `{
-		"email_address": "TestEmail@email.com"
-	}`
-	r = httptest.NewRequest("POST", fmt.Sprintf("/kyc-status/%s", callbackID), strings.NewReader(req))
+	handler := txApproveHandler{
+		issuerKP:          issuerKP,
+		assetCode:         assetGOAT.GetCode(),
+		horizonClient:     &horizonMock,
+		networkPassphrase: network.TestNetworkPassphrase,
+		db:                conn,
+		kycThreshold:      kycThresholdAmount,
+		baseURL:           "https://sep8-server.test",
+	}
+
+	// setup route handlers
+	m := chi.NewMux()
+	m.Post("/tx-approve", handler.ServeHTTP)
+	m.Post("/kyc-status/{callback_id}", kycstatus.PostHandler{DB: conn}.ServeHTTP)
+
+	// Step 1: client sends payment with 500+ GOAT
+	tx, err := txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount: &horizon.Account{
+				AccountID: senderKP.Address(),
+				Sequence:  "1",
+			},
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.Payment{
+					SourceAccount: senderKP.Address(),
+					Destination:   receiverKP.Address(),
+					Amount:        "501",
+					Asset:         assetGOAT,
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	txe, err := tx.Base64()
+	require.NoError(t, err)
+
+	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(`{"tx": "`+txe+`"}`))
+	r = r.WithContext(ctx)
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var callbackID string
+	q := `SELECT callback_id FROM accounts_kyc_status WHERE stellar_address = $1`
+	err = conn.QueryRowContext(ctx, q, senderKP.Address()).Scan(&callbackID)
+	require.NoError(t, err)
+
+	var gotResponse txApprovalResponse
+	err = json.Unmarshal(body, &gotResponse)
+	require.NoError(t, err)
+	wantTXApprovalResponse := txApprovalResponse{
+		Status:       sep8Status("action_required"),
+		Message:      "Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.",
+		ActionURL:    "https://sep8-server.test/kyc-status/" + callbackID,
+		ActionMethod: "POST",
+		ActionFields: []string{"email_address"},
+	}
+	assert.Equal(t, wantTXApprovalResponse, gotResponse)
+
+	// Step 2: client follows up with action required. KYC should get approved for emails not starting with "x"
+	actionMethod := gotResponse.ActionMethod
+	actionURL := gotResponse.ActionURL
+	actionFields := strings.NewReader(`{"email_address": "test@email.com"}`)
+	r = httptest.NewRequest(actionMethod, actionURL, actionFields)
 	r = r.WithContext(ctx)
 	w = httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp = w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-
-	// TEST "no_further_action_required" response for approved account.
 	wantBody := `{"result": "no_further_action_required"}`
 	require.JSONEq(t, wantBody, string(body))
 
-	// Prepare and send /tx-approve POST request to be revised tx via a new /tx-approve POST.
-	req = `{
-		"tx": "` + txEnc + `"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	// Step 3: verify transactions with 500+ GOAT can now be revised
+	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(`{"tx": "`+txe+`"}`))
 	r = r.WithContext(ctx)
 	w = httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp = w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	// TEST "revised" response for approved account.
-	txApprovePOSTResponse = txApprovalResponse{}
-	assert.Empty(t, txApprovePOSTResponse)
-	err = json.Unmarshal(body, &txApprovePOSTResponse)
+	gotResponse = txApprovalResponse{}
+	err = json.Unmarshal(body, &gotResponse)
 	require.NoError(t, err)
-	wantTXApprovalResponse = txApprovalResponse{
-		Status:  sep8Status("revised"),
-		Tx:      txApprovePOSTResponse.Tx,
-		Message: `Authorization and deauthorization operations were added.`,
-	}
-	assert.Equal(t, wantTXApprovalResponse, txApprovePOSTResponse)
+	assert.Equal(t, sep8StatusRevised, gotResponse.Status)
+	assert.Equal(t, "Authorization and deauthorization operations were added.", gotResponse.Message)
+	require.NotEmpty(t, gotResponse.Tx)
 
-	// Decode the request's transaction.
-	parsed, err := txnbuild.TransactionFromXDR(txApprovePOSTResponse.Tx)
-	require.NoError(t, err)
-	tx, ok := parsed.Transaction()
-	require.True(t, ok)
-
-	// Check if revised transaction only has 5 operations.
-	require.Len(t, tx.Operations(), 5)
-	// Check Operation 1: AllowTrust op where issuer fully authorizes account A, asset X.
-	op1, ok := tx.Operations()[0].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op1.Trustor, senderAccKP.Address())
-	assert.Equal(t, op1.Type.GetCode(), assetGOAT.GetCode())
-	require.True(t, op1.Authorize)
-	// Check  Operation 2: AllowTrust op where issuer fully authorizes account B, asset X.
-	op2, ok := tx.Operations()[1].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op2.Trustor, receiverAccKP.Address())
-	assert.Equal(t, op2.Type.GetCode(), assetGOAT.GetCode())
-	require.True(t, op2.Authorize)
-	// Check Operation 3: Payment from A to B.
-	op3, ok := tx.Operations()[2].(*txnbuild.Payment)
-	require.True(t, ok)
-	assert.Equal(t, op3.SourceAccount, senderAccKP.Address())
-	assert.Equal(t, op3.Destination, receiverAccKP.Address())
-	assert.Equal(t, op3.Asset, assetGOAT)
-	// Check Operation 4: AllowTrust op where issuer fully deauthorizes account B, asset X.
-	op4, ok := tx.Operations()[3].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op4.Trustor, receiverAccKP.Address())
-	assert.Equal(t, op4.Type.GetCode(), assetGOAT.GetCode())
-	require.False(t, op4.Authorize)
-	// Check Operation 5: AllowTrust op where issuer fully deauthorizes account A, asset X.
-	op5, ok := tx.Operations()[4].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op5.Trustor, senderAccKP.Address())
-	assert.Equal(t, op5.Type.GetCode(), assetGOAT.GetCode())
-	require.False(t, op5.Authorize)
-
-	// Prepare and send /kyc-status/{callback_id} POST request; with an email_address that starts with "x".
-	req = `{
-		"email_address": "xTestEmail@email.com"
-	}`
-	r = httptest.NewRequest("POST", fmt.Sprintf("/kyc-status/%s", callbackID), strings.NewReader(req))
+	// Step 4: client follows up with action required. KYC should get rejected for emails starting with "x"
+	actionFields = strings.NewReader(`{"email_address": "xtest@email.com"}`)
+	r = httptest.NewRequest(actionMethod, actionURL, actionFields)
 	r = r.WithContext(ctx)
 	w = httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp = w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-
-	// TEST "no_further_action_required" response for approved account.
 	wantBody = `{"result": "no_further_action_required"}`
 	require.JSONEq(t, wantBody, string(body))
 
-	// Prepare and send /tx-approve POST request to be revised tx via a new /tx-approve POST.
-	req = `{
-		"tx": "` + txEnc + `"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	// Step 5: verify transactions with 500+ GOAT are rejected
+	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(`{"tx": "`+txe+`"}`))
 	r = r.WithContext(ctx)
 	w = httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-
-	// TEST "rejected" response for rejected KYC account.
 	wantBody = `{
-		"status":"rejected", "error":"Your KYC was rejected and you're not authorized for operations above 500.00 GOAT."
+		"status": "rejected",
+		"error": "Your KYC was rejected and you're not authorized for operations above 500.00 GOAT."
 	}`
 	require.JSONEq(t, wantBody, string(body))
 }

--- a/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
@@ -3,9 +3,11 @@ package serve
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -15,6 +17,7 @@ import (
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stellar/go/services/regulated-assets-approval-server/internal/db/dbtest"
 	kycstatus "github.com/stellar/go/services/regulated-assets-approval-server/internal/serve/kyc-status"
 	"github.com/stellar/go/txnbuild"
@@ -22,50 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAPI_txApprove_rejected(t *testing.T) {
-	ctx := context.Background()
-	db := dbtest.Open(t)
-	defer db.Close()
-	conn := db.Open()
-	defer conn.Close()
-
-	issuerKP := keypair.MustRandom()
-	horizonMock := horizonclient.MockClient{}
-	kycThresholdAmount, err := amount.ParseInt64("500")
-	require.NoError(t, err)
-
-	handler := txApproveHandler{
-		issuerKP:          issuerKP,
-		assetCode:         "FOO",
-		horizonClient:     &horizonMock,
-		networkPassphrase: network.TestNetworkPassphrase,
-		db:                conn,
-		kycThreshold:      kycThresholdAmount,
-		baseURL:           "https://sep8-server.test",
-	}
-
-	// rejected if no transaction "tx"is submitted
-	m := chi.NewMux()
-	m.Post("/tx-approve", handler.ServeHTTP)
-	r := httptest.NewRequest("POST", "/tx-approve", nil)
-	r = r.WithContext(ctx)
-	w := httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-
-	resp := w.Result()
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err := ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	wantBody := `{
-		"status": "rejected",
-		"error": "Missing parameter \"tx\"."
-	}`
-	require.JSONEq(t, wantBody, string(body))
-}
-
-func TestAPI_txApprove_revised(t *testing.T) {
+func TestAPI_RejectedIntegration(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)
 	defer db.Close()
@@ -73,25 +33,44 @@ func TestAPI_txApprove_revised(t *testing.T) {
 	defer conn.Close()
 
 	// Perpare accounts on mock horizon.
-	senderKP := keypair.MustRandom()
-	receiverKP := keypair.MustRandom()
-	issuerKP := keypair.MustRandom()
+	issuerAccKeyPair := keypair.MustRandom()
 	assetGOAT := txnbuild.CreditAsset{
 		Code:   "GOAT",
-		Issuer: issuerKP.Address(),
+		Issuer: issuerAccKeyPair.Address(),
 	}
 	horizonMock := horizonclient.MockClient{}
+	senderAccKP := keypair.MustRandom()
+	receiverAccKP := keypair.MustRandom()
 	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: issuerAccKeyPair.Address()}).
 		Return(horizon.Account{
-			AccountID: senderKP.Address(),
-			Sequence:  "5",
+			AccountID: issuerAccKeyPair.Address(),
+			Sequence:  "1",
+			Balances: []horizon.Balance{
+				{
+					Asset:   base.Asset{Code: "ASSET", Issuer: issuerAccKeyPair.Address()},
+					Balance: "1",
+				},
+			},
+		}, nil)
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderAccKP.Address()}).
+		Return(horizon.Account{
+			AccountID: senderAccKP.Address(),
+			Sequence:  "2",
+		}, nil)
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: receiverAccKP.Address()}).
+		Return(horizon.Account{
+			AccountID: receiverAccKP.Address(),
+			Sequence:  "3",
 		}, nil)
 
+	// Create tx-approve/ txApproveHandler.
 	kycThresholdAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)
 	handler := txApproveHandler{
-		issuerKP:          issuerKP,
+		issuerKP:          issuerAccKeyPair,
 		assetCode:         assetGOAT.GetCode(),
 		horizonClient:     &horizonMock,
 		networkPassphrase: network.TestNetworkPassphrase,
@@ -100,17 +79,153 @@ func TestAPI_txApprove_revised(t *testing.T) {
 		baseURL:           "https://sep8-server.test",
 	}
 
+	// Prepare and send empty "tx" for "/tx-approve" POST request.
+	req := `{
+		"tx": ""
+	}`
+	m := chi.NewMux()
+	m.Post("/tx-approve", handler.ServeHTTP)
+	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	r = r.WithContext(ctx)
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// TEST "rejected" response if no transaction is submitted.
+	wantBody := `{
+		"status":"rejected", "error":"Missing parameter \"tx\"."
+	}`
+	require.JSONEq(t, wantBody, string(body))
+
+	// Prepare and send malformed "tx" for "/tx-approve" POST request.
+	req = `{
+		"tx": "BADXDRTRANSACTIONENVELOPE"
+	}`
+	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	r = r.WithContext(ctx)
+	w = httptest.NewRecorder()
+	m.ServeHTTP(w, r)
+	resp = w.Result()
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// TEST "rejected" response if can't parse XDR.
+	wantBody = `{
+		"status":"rejected", "error":"Invalid parameter \"tx\"."
+	}`
+	require.JSONEq(t, wantBody, string(body))
+
+	// Prepare non generic transaction "tx".
+	senderAcc, err := handler.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: senderAccKP.Address()})
+	require.NoError(t, err)
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
-			SourceAccount: &horizon.Account{
-				AccountID: senderKP.Address(),
-				Sequence:  "5",
-			},
+			SourceAccount:        &senderAcc,
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
 				&txnbuild.Payment{
-					SourceAccount: senderKP.Address(),
-					Destination:   receiverKP.Address(),
+					Destination: receiverAccKP.Address(),
+					Amount:      "1",
+					Asset:       assetGOAT,
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	feeBumpTx, err := txnbuild.NewFeeBumpTransaction(
+		txnbuild.FeeBumpTransactionParams{
+			Inner:      tx,
+			FeeAccount: receiverAccKP.Address(),
+			BaseFee:    2 * txnbuild.MinBaseFee,
+		},
+	)
+	require.NoError(t, err)
+	feeBumpTxEnc, err := feeBumpTx.Base64()
+	require.NoError(t, err)
+
+	// Send invalid "tx" for "/tx-approve" POST request.
+	req = `{
+		"tx": "` + feeBumpTxEnc + `"
+	}`
+	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	r = r.WithContext(ctx)
+	w = httptest.NewRecorder()
+	m.ServeHTTP(w, r)
+	resp = w.Result()
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// TEST "rejected" response if  a non generic transaction fails, same result as malformed XDR.
+	wantBody = `{
+		"status":"rejected", "error":"Invalid parameter \"tx\"."
+	}`
+	require.JSONEq(t, wantBody, string(body))
+
+	// Prepare "tx" where transaction sourceAccount the same as the server issuer account.
+	issuerAcc, err := handler.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: issuerAccKeyPair.Address()})
+	require.NoError(t, err)
+	tx, err = txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount:        &issuerAcc,
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.Payment{
+					Destination: senderAccKP.Address(),
+					Amount:      "1",
+					Asset:       assetGOAT,
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	txEnc, err := tx.Base64()
+	require.NoError(t, err)
+
+	// Send "tx" where transaction sourceAccount the same as the server issuer account for "/tx-approve" POST request.
+	req = `{
+		"tx": "` + txEnc + `"
+	}`
+	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	r = r.WithContext(ctx)
+	w = httptest.NewRecorder()
+	m.ServeHTTP(w, r)
+	resp = w.Result()
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// TEST "rejected" response if the transaction sourceAccount the same as the server issuer account.
+	wantBody = `{
+		"status":"rejected", "error":"Transaction source account is invalid."
+	}`
+	require.JSONEq(t, wantBody, string(body))
+
+	// Prepare "tx" where transaction's operation sourceAccount the same as the server issuer account.
+	tx, err = txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount:        &senderAcc,
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.Payment{
+					SourceAccount: issuerAccKeyPair.Address(),
+					Destination:   senderAccKP.Address(),
 					Amount:        "1",
 					Asset:         assetGOAT,
 				},
@@ -120,95 +235,209 @@ func TestAPI_txApprove_revised(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	txe, err := tx.Base64()
+	txEnc, err = tx.Base64()
 	require.NoError(t, err)
 
-	m := chi.NewMux()
-	m.Post("/tx-approve", handler.ServeHTTP)
-	req := `{
-		"tx": "` + txe + `"
+	// Send "tx" where transaction's operation sourceAccount the same as the server issuer account for "/tx-approve" POST request.
+	req = `{
+		"tx": "` + txEnc + `"
 	}`
-	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
 	r = r.WithContext(ctx)
-	w := httptest.NewRecorder()
+	w = httptest.NewRecorder()
 	m.ServeHTTP(w, r)
-
-	resp := w.Result()
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp = w.Result()
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	var gotResponse txApprovalResponse
-	err = json.Unmarshal(body, &gotResponse)
-	require.NoError(t, err)
-	require.Equal(t, sep8StatusRevised, gotResponse.Status)
-	require.Equal(t, "Authorization and deauthorization operations were added.", gotResponse.Message)
+	// TEST "rejected" response if the transaction's operation sourceAccount the same as the server issuer account.
+	wantBody = `{
+		"status":"rejected", "error":"There is one or more unauthorized operations in the provided transaction."
+	}`
+	require.JSONEq(t, wantBody, string(body))
 
-	gotGenericTx, err := txnbuild.TransactionFromXDR(gotResponse.Tx)
+	// Prepare "tx" where transaction's operation is not a payment.
+	tx, err = txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount:        &senderAcc,
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.AllowTrust{
+					Trustor:   receiverAccKP.Address(),
+					Type:      assetGOAT,
+					Authorize: true,
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
 	require.NoError(t, err)
-	gotTx, ok := gotGenericTx.Transaction()
-	require.True(t, ok)
+	txEnc, err = tx.Base64()
+	require.NoError(t, err)
 
-	require.Len(t, gotTx.Operations(), 5)
-	// AllowTrust op where issuer fully authorizes account A, asset X
-	op0, ok := gotTx.Operations()[0].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op0.Trustor, senderKP.Address())
-	assert.Equal(t, op0.Type.GetCode(), assetGOAT.GetCode())
-	require.True(t, op0.Authorize)
-	// AllowTrust op where issuer fully authorizes account B, asset X
-	op1, ok := gotTx.Operations()[1].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op1.Trustor, receiverKP.Address())
-	assert.Equal(t, op1.Type.GetCode(), assetGOAT.GetCode())
-	require.True(t, op1.Authorize)
-	// Payment from A to B
-	op2, ok := gotTx.Operations()[2].(*txnbuild.Payment)
-	require.True(t, ok)
-	assert.Equal(t, op2.Destination, receiverKP.Address())
-	assert.Equal(t, op2.Asset, assetGOAT)
-	// AllowTrust op where issuer fully deauthorizes account B, asset X
-	op3, ok := gotTx.Operations()[3].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op3.Trustor, receiverKP.Address())
-	assert.Equal(t, op3.Type.GetCode(), assetGOAT.GetCode())
-	require.False(t, op3.Authorize)
-	// AllowTrust op where issuer fully deauthorizes account A, asset X
-	op4, ok := gotTx.Operations()[4].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op4.Trustor, senderKP.Address())
-	assert.Equal(t, op4.Type.GetCode(), assetGOAT.GetCode())
-	require.False(t, op4.Authorize)
+	// Send "tx" where transaction's operation is not a payment for "/tx-approve" POST request.
+	req = `{
+		"tx": "` + txEnc + `"
+	}`
+	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	r = r.WithContext(ctx)
+	w = httptest.NewRecorder()
+	m.ServeHTTP(w, r)
+	resp = w.Result()
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// TEST "rejected" response if transaction's operation is not a payment.
+	wantBody = `{
+		"status":"rejected", "error":"There is one or more unauthorized operations in the provided transaction."
+	}`
+	require.JSONEq(t, wantBody, string(body))
+
+	// Prepare "tx" where theres more than one operation in transaction.
+	tx, err = txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount:        &senderAcc,
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.Payment{
+					SourceAccount: senderAccKP.Address(),
+					Destination:   receiverAccKP.Address(),
+					Amount:        "1",
+					Asset:         assetGOAT,
+				},
+				&txnbuild.Payment{
+					SourceAccount: senderAccKP.Address(),
+					Destination:   receiverAccKP.Address(),
+					Amount:        "2",
+					Asset:         assetGOAT,
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	txEnc, err = tx.Base64()
+	require.NoError(t, err)
+
+	// Send "tx" where theres more than one operation in transaction for "/tx-approve" POST request.
+	req = `{
+		"tx": "` + txEnc + `"
+	}`
+	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	r = r.WithContext(ctx)
+	w = httptest.NewRecorder()
+	m.ServeHTTP(w, r)
+	resp = w.Result()
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// TEST "rejected" response if more than one operation in transaction.
+	wantBody = `{
+		"status":"rejected", "error":"Please submit a transaction with exactly one operation of type payment."
+	}`
+	require.JSONEq(t, wantBody, string(body))
+
+	// Prepare "tx" where transaction's transaction source account seq num is not equal to account sequence+1.
+	tx, err = txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount: &horizon.Account{
+				AccountID: senderAccKP.Address(),
+				Sequence:  "50",
+			},
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.Payment{
+					SourceAccount: senderAccKP.Address(),
+					Destination:   receiverAccKP.Address(),
+					Amount:        "1",
+					Asset:         assetGOAT,
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	txEnc, err = tx.Base64()
+	require.NoError(t, err)
+
+	// Send "tx" where transaction's transaction source account seq num is not equal to account sequence+1 for "/tx-approve" POST request.
+	req = `{
+		"tx": "` + txEnc + `"
+	}`
+	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	r = r.WithContext(ctx)
+	w = httptest.NewRecorder()
+	m.ServeHTTP(w, r)
+	resp = w.Result()
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// TEST "rejected" response if where transaction's transaction source account seq num is not equal to account sequence+1.
+	wantBody = `{
+		"status":"rejected", "error":"Invalid transaction sequence number."
+	}`
+	require.JSONEq(t, wantBody, string(body))
 }
 
-func TestAPI_txAprove_actionRequired(t *testing.T) {
+func TestAPI_RevisedIntegration(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
 	defer conn.Close()
 
-	// prepare handler dependencies
-	senderKP := keypair.MustRandom()
-	receiverKP := keypair.MustRandom()
-	issuerKP := keypair.MustRandom()
+	// Perpare accounts on mock horizon.
+	issuerAccKeyPair := keypair.MustRandom()
+	senderAccKP := keypair.MustRandom()
+	receiverAccKP := keypair.MustRandom()
 	assetGOAT := txnbuild.CreditAsset{
 		Code:   "GOAT",
-		Issuer: issuerKP.Address(),
+		Issuer: issuerAccKeyPair.Address(),
 	}
-	kycThresholdAmount, err := amount.ParseInt64("500")
-	require.NoError(t, err)
 	horizonMock := horizonclient.MockClient{}
 	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: issuerAccKeyPair.Address()}).
 		Return(horizon.Account{
-			AccountID: senderKP.Address(),
-			Sequence:  "1",
+			Balances: []horizon.Balance{
+				{
+					Asset:   base.Asset{Code: "ASSET", Issuer: issuerAccKeyPair.Address()},
+					Balance: "0",
+				},
+			},
+		}, nil)
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderAccKP.Address()}).
+		Return(horizon.Account{
+			AccountID: senderAccKP.Address(),
+			Sequence:  "5",
+		}, nil)
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: receiverAccKP.Address()}).
+		Return(horizon.Account{
+			AccountID: receiverAccKP.Address(),
+			Sequence:  "0",
 		}, nil)
 
+	// Create tx-approve/ txApproveHandler.
+	kycThresholdAmount, err := amount.ParseInt64("500")
+	require.NoError(t, err)
 	handler := txApproveHandler{
-		issuerKP:          issuerKP,
+		issuerKP:          issuerAccKeyPair,
 		assetCode:         assetGOAT.GetCode(),
 		horizonClient:     &horizonMock,
 		networkPassphrase: network.TestNetworkPassphrase,
@@ -217,23 +446,160 @@ func TestAPI_txAprove_actionRequired(t *testing.T) {
 		baseURL:           "https://sep8-server.test",
 	}
 
-	// setup route handlers
-	m := chi.NewMux()
-	m.Post("/tx-approve", handler.ServeHTTP)
-	m.Post("/kyc-status/{callback_id}", kycstatus.PostHandler{DB: conn}.ServeHTTP)
-
-	// Step 1: Client sends payment with 500+ GOAT
+	// Prepare revisable "tx".
+	senderAcc, err := handler.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: senderAccKP.Address()})
+	require.NoError(t, err)
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
-			SourceAccount: &horizon.Account{
-				AccountID: senderKP.Address(),
-				Sequence:  "1",
-			},
+			SourceAccount:        &senderAcc,
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
 				&txnbuild.Payment{
-					SourceAccount: senderKP.Address(),
-					Destination:   receiverKP.Address(),
+					SourceAccount: senderAccKP.Address(),
+					Destination:   receiverAccKP.Address(),
+					Amount:        "1",
+					Asset:         assetGOAT,
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	txEnc, err := tx.Base64()
+	require.NoError(t, err)
+
+	// Send revisable "tx" for "/tx-approve" POST request.
+	req := `{
+		"tx": "` + txEnc + `"
+		}`
+	m := chi.NewMux()
+	m.Post("/tx-approve", handler.ServeHTTP)
+	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	r = r.WithContext(ctx)
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// TEST successful "revised" response.
+	var txApprovePOSTResponse txApprovalResponse
+	err = json.Unmarshal(body, &txApprovePOSTResponse)
+	require.NoError(t, err)
+	wantTXApprovalResponse := txApprovalResponse{
+		Status:  sep8Status("revised"),
+		Tx:      txApprovePOSTResponse.Tx,
+		Message: `Authorization and deauthorization operations were added.`,
+	}
+	assert.Equal(t, wantTXApprovalResponse, txApprovePOSTResponse)
+
+	// Decode the request's transaction.
+	parsed, err := txnbuild.TransactionFromXDR(txApprovePOSTResponse.Tx)
+	require.NoError(t, err)
+	tx, ok := parsed.Transaction()
+	require.True(t, ok)
+
+	// Check if revised transaction only has 5 operations.
+	require.Len(t, tx.Operations(), 5)
+	// Check Operation 1: AllowTrust op where issuer fully authorizes account A, asset X.
+	op1, ok := tx.Operations()[0].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op1.Trustor, senderAccKP.Address())
+	assert.Equal(t, op1.Type.GetCode(), assetGOAT.GetCode())
+	require.True(t, op1.Authorize)
+	// Check  Operation 2: AllowTrust op where issuer fully authorizes account B, asset X.
+	op2, ok := tx.Operations()[1].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op2.Trustor, receiverAccKP.Address())
+	assert.Equal(t, op2.Type.GetCode(), assetGOAT.GetCode())
+	require.True(t, op2.Authorize)
+	// Check Operation 3: Payment from A to B.
+	op3, ok := tx.Operations()[2].(*txnbuild.Payment)
+	require.True(t, ok)
+	assert.Equal(t, op3.SourceAccount, senderAccKP.Address())
+	assert.Equal(t, op3.Destination, receiverAccKP.Address())
+	assert.Equal(t, op3.Asset, assetGOAT)
+	// Check Operation 4: AllowTrust op where issuer fully deauthorizes account B, asset X.
+	op4, ok := tx.Operations()[3].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op4.Trustor, receiverAccKP.Address())
+	assert.Equal(t, op4.Type.GetCode(), assetGOAT.GetCode())
+	require.False(t, op4.Authorize)
+	// Check Operation 5: AllowTrust op where issuer fully deauthorizes account A, asset X.
+	op5, ok := tx.Operations()[4].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op5.Trustor, senderAccKP.Address())
+	assert.Equal(t, op5.Type.GetCode(), assetGOAT.GetCode())
+	require.False(t, op5.Authorize)
+}
+
+func TestAPI_KYCIntegration(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.Open(t)
+	defer db.Close()
+	conn := db.Open()
+	defer conn.Close()
+
+	// Perpare accounts on mock horizon.
+	issuerAccKeyPair := keypair.MustRandom()
+	senderAccKP := keypair.MustRandom()
+	receiverAccKP := keypair.MustRandom()
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerAccKeyPair.Address(),
+	}
+	horizonMock := horizonclient.MockClient{}
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: issuerAccKeyPair.Address()}).
+		Return(horizon.Account{
+			Balances: []horizon.Balance{
+				{
+					Asset:   base.Asset{Code: "ASSET", Issuer: issuerAccKeyPair.Address()},
+					Balance: "0",
+				},
+			},
+		}, nil)
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderAccKP.Address()}).
+		Return(horizon.Account{
+			AccountID: senderAccKP.Address(),
+			Sequence:  "5",
+		}, nil)
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: receiverAccKP.Address()}).
+		Return(horizon.Account{
+			AccountID: receiverAccKP.Address(),
+			Sequence:  "0",
+		}, nil)
+
+	// Create tx-approve/ txApproveHandler.
+	kycThresholdAmount, err := amount.ParseInt64("500")
+	require.NoError(t, err)
+	handler := txApproveHandler{
+		issuerKP:          issuerAccKeyPair,
+		assetCode:         assetGOAT.GetCode(),
+		horizonClient:     &horizonMock,
+		networkPassphrase: network.TestNetworkPassphrase,
+		db:                conn,
+		kycThreshold:      kycThresholdAmount,
+		baseURL:           "https://sep8-server.test",
+	}
+
+	// Prepare transaction whose payment amount is <=500 GOATs for /tx-approve POST request.
+	senderAcc, err := handler.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: senderAccKP.Address()})
+	require.NoError(t, err)
+	tx, err := txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount:        &senderAcc,
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.Payment{
+					SourceAccount: senderAccKP.Address(),
+					Destination:   receiverAccKP.Address(),
 					Amount:        "501",
 					Asset:         assetGOAT,
 				},
@@ -243,192 +609,182 @@ func TestAPI_txAprove_actionRequired(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	txe, err := tx.Base64()
+	txEnc, err := tx.Base64()
 	require.NoError(t, err)
 
-	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(`{"tx": "`+txe+`"}`))
+	// Send /tx-approve POST request with transaction in request body.
+	req := `{
+		"tx": "` + txEnc + `"
+	}`
+	m := chi.NewMux()
+	m.Post("/tx-approve", handler.ServeHTTP)
+	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
 	r = r.WithContext(ctx)
 	w := httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp := w.Result()
+	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	var callbackID string
-	q := `SELECT callback_id FROM accounts_kyc_status WHERE stellar_address = $1`
-	err = conn.QueryRowContext(ctx, q, senderKP.Address()).Scan(&callbackID)
-	require.NoError(t, err)
-
+	// TEST "action_required" response for sender account.
 	var txApprovePOSTResponse txApprovalResponse
 	err = json.Unmarshal(body, &txApprovePOSTResponse)
 	require.NoError(t, err)
 	wantTXApprovalResponse := txApprovalResponse{
 		Status:       sep8Status("action_required"),
-		Message:      "Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.",
-		ActionURL:    "https://sep8-server.test/kyc-status/" + callbackID,
+		Message:      `Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.`,
+		ActionURL:    txApprovePOSTResponse.ActionURL,
 		ActionMethod: "POST",
 		ActionFields: []string{"email_address"},
 	}
 	assert.Equal(t, wantTXApprovalResponse, txApprovePOSTResponse)
-}
 
-func TestAPI_txAprove_actionRequiredFlow(t *testing.T) {
-	ctx := context.Background()
-	db := dbtest.Open(t)
-	defer db.Close()
-	conn := db.Open()
-	defer conn.Close()
+	// Setup /kyc-status route for subsequent integration steps.
+	m.Route("/kyc-status", func(mux chi.Router) {
+		mux.Post("/{callback_id}", kycstatus.PostHandler{
+			DB: conn,
+		}.ServeHTTP)
+	})
+	// RxUUID is a regex used to validate correct UUIDs, https://w.wiki/39fK
+	var RxUUID = regexp.MustCompile(
+		`[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}`)
+	// Grab callbackID
+	callbackID := RxUUID.FindAllString(txApprovePOSTResponse.ActionURL, 1)[0]
 
-	// prepare handler dependencies
-	senderKP := keypair.MustRandom()
-	receiverKP := keypair.MustRandom()
-	issuerKP := keypair.MustRandom()
-	assetGOAT := txnbuild.CreditAsset{
-		Code:   "GOAT",
-		Issuer: issuerKP.Address(),
-	}
-	kycThresholdAmount, err := amount.ParseInt64("500")
+	// Verify the KYC entree was inserted in db.
+	const q = `
+		SELECT callback_id
+		FROM accounts_kyc_status
+		WHERE stellar_address = $1
+	`
+	var returnedCallbackID string
+	err = handler.db.QueryRowContext(ctx, q, senderAccKP.Address()).Scan(&returnedCallbackID)
 	require.NoError(t, err)
-	horizonMock := horizonclient.MockClient{}
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
-		Return(horizon.Account{
-			AccountID: senderKP.Address(),
-			Sequence:  "1",
-		}, nil)
+	assert.Equal(t, callbackID, returnedCallbackID)
 
-	handler := txApproveHandler{
-		issuerKP:          issuerKP,
-		assetCode:         assetGOAT.GetCode(),
-		horizonClient:     &horizonMock,
-		networkPassphrase: network.TestNetworkPassphrase,
-		db:                conn,
-		kycThreshold:      kycThresholdAmount,
-		baseURL:           "https://sep8-server.test",
-	}
-
-	// setup route handlers
-	m := chi.NewMux()
-	m.Post("/tx-approve", handler.ServeHTTP)
-	m.Post("/kyc-status/{callback_id}", kycstatus.PostHandler{DB: conn}.ServeHTTP)
-
-	// Step 1: client sends payment with 500+ GOAT
-	tx, err := txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount: &horizon.Account{
-				AccountID: senderKP.Address(),
-				Sequence:  "1",
-			},
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					SourceAccount: senderKP.Address(),
-					Destination:   receiverKP.Address(),
-					Amount:        "501",
-					Asset:         assetGOAT,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txe, err := tx.Base64()
-	require.NoError(t, err)
-
-	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(`{"tx": "`+txe+`"}`))
-	r = r.WithContext(ctx)
-	w := httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp := w.Result()
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err := ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	var callbackID string
-	q := `SELECT callback_id FROM accounts_kyc_status WHERE stellar_address = $1`
-	err = conn.QueryRowContext(ctx, q, senderKP.Address()).Scan(&callbackID)
-	require.NoError(t, err)
-
-	var gotResponse txApprovalResponse
-	err = json.Unmarshal(body, &gotResponse)
-	require.NoError(t, err)
-	wantTXApprovalResponse := txApprovalResponse{
-		Status:       sep8Status("action_required"),
-		Message:      "Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.",
-		ActionURL:    "https://sep8-server.test/kyc-status/" + callbackID,
-		ActionMethod: "POST",
-		ActionFields: []string{"email_address"},
-	}
-	assert.Equal(t, wantTXApprovalResponse, gotResponse)
-
-	// Step 2: client follows up with action required. KYC should get approved for emails not starting with "x"
-	actionMethod := gotResponse.ActionMethod
-	actionURL := gotResponse.ActionURL
-	actionFields := strings.NewReader(`{"email_address": "test@email.com"}`)
-	r = httptest.NewRequest(actionMethod, actionURL, actionFields)
+	// Prepare and send /kyc-status/{callback_id} POST request; with an email_address that doesn't start with "x".
+	req = `{
+		"email_address": "TestEmail@email.com"
+	}`
+	r = httptest.NewRequest("POST", fmt.Sprintf("/kyc-status/%s", callbackID), strings.NewReader(req))
 	r = r.WithContext(ctx)
 	w = httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp = w.Result()
+	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
+
+	// TEST "no_further_action_required" response for approved account.
 	wantBody := `{"result": "no_further_action_required"}`
 	require.JSONEq(t, wantBody, string(body))
 
-	// Step 3: verify transactions with 500+ GOAT can now be revised
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(`{"tx": "`+txe+`"}`))
+	// Prepare and send /tx-approve POST request to be revised tx via a new /tx-approve POST.
+	req = `{
+		"tx": "` + txEnc + `"
+	}`
+	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
 	r = r.WithContext(ctx)
 	w = httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp = w.Result()
+	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	gotResponse = txApprovalResponse{}
-	err = json.Unmarshal(body, &gotResponse)
+	// TEST "revised" response for approved account.
+	txApprovePOSTResponse = txApprovalResponse{}
+	assert.Empty(t, txApprovePOSTResponse)
+	err = json.Unmarshal(body, &txApprovePOSTResponse)
 	require.NoError(t, err)
-	assert.Equal(t, sep8StatusRevised, gotResponse.Status)
-	assert.Equal(t, "Authorization and deauthorization operations were added.", gotResponse.Message)
-	require.NotEmpty(t, gotResponse.Tx)
+	wantTXApprovalResponse = txApprovalResponse{
+		Status:  sep8Status("revised"),
+		Tx:      txApprovePOSTResponse.Tx,
+		Message: `Authorization and deauthorization operations were added.`,
+	}
+	assert.Equal(t, wantTXApprovalResponse, txApprovePOSTResponse)
 
-	// Step 4: client follows up with action required. KYC should get rejected for emails starting with "x"
-	actionFields = strings.NewReader(`{"email_address": "xtest@email.com"}`)
-	r = httptest.NewRequest(actionMethod, actionURL, actionFields)
+	// Decode the request's transaction.
+	parsed, err := txnbuild.TransactionFromXDR(txApprovePOSTResponse.Tx)
+	require.NoError(t, err)
+	tx, ok := parsed.Transaction()
+	require.True(t, ok)
+
+	// Check if revised transaction only has 5 operations.
+	require.Len(t, tx.Operations(), 5)
+	// Check Operation 1: AllowTrust op where issuer fully authorizes account A, asset X.
+	op1, ok := tx.Operations()[0].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op1.Trustor, senderAccKP.Address())
+	assert.Equal(t, op1.Type.GetCode(), assetGOAT.GetCode())
+	require.True(t, op1.Authorize)
+	// Check  Operation 2: AllowTrust op where issuer fully authorizes account B, asset X.
+	op2, ok := tx.Operations()[1].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op2.Trustor, receiverAccKP.Address())
+	assert.Equal(t, op2.Type.GetCode(), assetGOAT.GetCode())
+	require.True(t, op2.Authorize)
+	// Check Operation 3: Payment from A to B.
+	op3, ok := tx.Operations()[2].(*txnbuild.Payment)
+	require.True(t, ok)
+	assert.Equal(t, op3.SourceAccount, senderAccKP.Address())
+	assert.Equal(t, op3.Destination, receiverAccKP.Address())
+	assert.Equal(t, op3.Asset, assetGOAT)
+	// Check Operation 4: AllowTrust op where issuer fully deauthorizes account B, asset X.
+	op4, ok := tx.Operations()[3].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op4.Trustor, receiverAccKP.Address())
+	assert.Equal(t, op4.Type.GetCode(), assetGOAT.GetCode())
+	require.False(t, op4.Authorize)
+	// Check Operation 5: AllowTrust op where issuer fully deauthorizes account A, asset X.
+	op5, ok := tx.Operations()[4].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op5.Trustor, senderAccKP.Address())
+	assert.Equal(t, op5.Type.GetCode(), assetGOAT.GetCode())
+	require.False(t, op5.Authorize)
+
+	// Prepare and send /kyc-status/{callback_id} POST request; with an email_address that starts with "x".
+	req = `{
+		"email_address": "xTestEmail@email.com"
+	}`
+	r = httptest.NewRequest("POST", fmt.Sprintf("/kyc-status/%s", callbackID), strings.NewReader(req))
 	r = r.WithContext(ctx)
 	w = httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp = w.Result()
+	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
+
+	// TEST "no_further_action_required" response for approved account.
 	wantBody = `{"result": "no_further_action_required"}`
 	require.JSONEq(t, wantBody, string(body))
 
-	// Step 5: verify transactions with 500+ GOAT are rejected
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(`{"tx": "`+txe+`"}`))
+	// Prepare and send /tx-approve POST request to be revised tx via a new /tx-approve POST.
+	req = `{
+		"tx": "` + txEnc + `"
+	}`
+	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
 	r = r.WithContext(ctx)
 	w = httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp = w.Result()
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
+
+	// TEST "rejected" response for rejected KYC account.
 	wantBody = `{
-		"status": "rejected",
-		"error": "Your KYC was rejected and you're not authorized for operations above 500.00 GOAT."
+		"status":"rejected", "error":"Your KYC was rejected and you're not authorized for operations above 500.00 GOAT."
 	}`
 	require.JSONEq(t, wantBody, string(body))
 }

--- a/services/regulated-assets-approval-server/internal/serve/kyc-status/delete_handler.go
+++ b/services/regulated-assets-approval-server/internal/serve/kyc-status/delete_handler.go
@@ -57,14 +57,7 @@ func (h DeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	httpjson.Render(w, httpjson.DefaultResponse, httpjson.JSON)
 }
 
-func (h DeleteHandler) handle(ctx context.Context, in deleteRequest) (err error) {
-	defer func() {
-		log.Ctx(ctx).Debug("==== will log responses ====")
-		log.Ctx(ctx).Debugf("req: %+v", in)
-		log.Ctx(ctx).Debugf("err: %+v", err)
-		log.Ctx(ctx).Debug("====  did log responses ====")
-	}()
-
+func (h DeleteHandler) handle(ctx context.Context, in deleteRequest) error {
 	// Check if deleteRequest StellarAddress value is present.
 	if in.StellarAddress == "" {
 		return httperror.NewHTTPError(http.StatusBadRequest, "Missing stellar address.")
@@ -80,7 +73,7 @@ func (h DeleteHandler) handle(ctx context.Context, in deleteRequest) (err error)
 			SELECT * FROM deleted_rows
 		)
 	`
-	err = h.DB.QueryRowContext(ctx, q, in.StellarAddress).Scan(&existed)
+	err := h.DB.QueryRowContext(ctx, q, in.StellarAddress).Scan(&existed)
 	if err != nil {
 		return errors.Wrap(err, "querying the database")
 	}

--- a/services/regulated-assets-approval-server/internal/serve/kyc-status/get_detail_handler.go
+++ b/services/regulated-assets-approval-server/internal/serve/kyc-status/get_detail_handler.go
@@ -73,15 +73,7 @@ func (h GetDetailHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	kycGetResponse.Render(w)
 }
 
-func (h GetDetailHandler) handle(ctx context.Context, in getDetailRequest) (resp *kycGetResponse, err error) {
-	defer func() {
-		log.Ctx(ctx).Debug("==== will log responses ====")
-		log.Ctx(ctx).Debugf("req: %+v", in)
-		log.Ctx(ctx).Debugf("resp: %+v", resp)
-		log.Ctx(ctx).Debugf("err: %+v", err)
-		log.Ctx(ctx).Debug("====  did log responses ====")
-	}()
-
+func (h GetDetailHandler) handle(ctx context.Context, in getDetailRequest) (*kycGetResponse, error) {
 	// Check if getDetailRequest StellarAddressOrCallbackID value is present.
 	if in.StellarAddressOrCallbackID == "" {
 		return nil, httperror.NewHTTPError(http.StatusBadRequest, "Missing stellar address or callbackID")
@@ -99,7 +91,7 @@ func (h GetDetailHandler) handle(ctx context.Context, in getDetailRequest) (resp
 		FROM accounts_kyc_status
 		WHERE stellar_address = $1 OR callback_id = $1
 	`
-	err = h.DB.QueryRowContext(ctx, q, in.StellarAddressOrCallbackID).Scan(&stellarAddress, &emailAddress, &createdAt, &kycSubmittedAt, &approvedAt, &rejectedAt, &callbackID)
+	err := h.DB.QueryRowContext(ctx, q, in.StellarAddressOrCallbackID).Scan(&stellarAddress, &emailAddress, &createdAt, &kycSubmittedAt, &approvedAt, &rejectedAt, &callbackID)
 	if err == sql.ErrNoRows {
 		return nil, httperror.NewHTTPError(http.StatusNotFound, "Not found.")
 	}

--- a/services/regulated-assets-approval-server/internal/serve/kyc-status/post_handler.go
+++ b/services/regulated-assets-approval-server/internal/serve/kyc-status/post_handler.go
@@ -79,15 +79,7 @@ func (h PostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	kycResponse.Render(w)
 }
 
-func (h PostHandler) handle(ctx context.Context, in kycPostRequest) (resp *kycPostResponse, err error) {
-	defer func() {
-		log.Ctx(ctx).Debug("==== will log responses ====")
-		log.Ctx(ctx).Debugf("req: %+v", in)
-		log.Ctx(ctx).Debugf("resp: %+v", resp)
-		log.Ctx(ctx).Debugf("err: %+v", err)
-		log.Ctx(ctx).Debug("====  did log responses ====")
-	}()
-
+func (h PostHandler) handle(ctx context.Context, in kycPostRequest) (*kycPostResponse, error) {
 	// Check if kycPostRequest values are present or not malformed.
 	if in.CallbackID == "" {
 		return nil, httperror.NewHTTPError(http.StatusBadRequest, "Missing callbackID.")
@@ -101,7 +93,7 @@ func (h PostHandler) handle(ctx context.Context, in kycPostRequest) (resp *kycPo
 
 	var exists bool
 	query, args := in.buildUpdateKYCQuery()
-	err = h.DB.QueryRowContext(ctx, query, args...).Scan(&exists)
+	err := h.DB.QueryRowContext(ctx, query, args...).Scan(&exists)
 	if err != nil {
 		return nil, errors.Wrap(err, "querying the database")
 	}

--- a/services/regulated-assets-approval-server/internal/serve/toml.go
+++ b/services/regulated-assets-approval-server/internal/serve/toml.go
@@ -57,7 +57,7 @@ func (h stellarTOMLHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	// Convert kycThreshold value to human readable string; from amount package's int64 5000000000 to 500.00.
-	kycThreshold, err := convertThresholdToReadableString(h.kycThreshold)
+	kycThreshold, err := convertAmountToReadableString(h.kycThreshold)
 	if err != nil {
 		log.Ctx(ctx).Error(errors.Wrap(err, "converting kycThreshold value to human readable string"))
 		httperror.InternalServer.Render(rw)

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve.go
@@ -59,15 +59,6 @@ func (h txApproveHandler) validate() error {
 	return nil
 }
 
-func convertAmountToReadableString(threshold int64) (string, error) {
-	amountStr := amount.StringFromInt64(threshold)
-	amountFloat, err := strconv.ParseFloat(amountStr, 64)
-	if err != nil {
-		return "", errors.Wrap(err, "converting threshold amount from string to float")
-	}
-	return fmt.Sprintf("%.2f", amountFloat), nil
-}
-
 func (h txApproveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	err := h.validate()
@@ -289,4 +280,13 @@ func (h txApproveHandler) handleActionRequiredResponseIfNeeded(ctx context.Conte
 		fmt.Sprintf("%s/kyc-status/%s", h.baseURL, callbackID),
 		[]string{"email_address"},
 	), nil
+}
+
+func convertAmountToReadableString(threshold int64) (string, error) {
+	amountStr := amount.StringFromInt64(threshold)
+	amountFloat, err := strconv.ParseFloat(amountStr, 64)
+	if err != nil {
+		return "", errors.Wrap(err, "converting threshold amount from string to float")
+	}
+	return fmt.Sprintf("%.2f", amountFloat), nil
 }

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve.go
@@ -95,9 +95,8 @@ func (h txApproveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	txApproveResp.Render(w)
 }
 
-// validateInput performs some validations on the provided transaction. It can
-// reject the transaction based on general criteria that would be applied in any
-// approval server.
+// validateInput validates if the input parameters contain a valid transaction
+// and if the source account is not set in a way that would harm the issuer.
 func (h txApproveHandler) validateInput(ctx context.Context, in txApproveRequest) (*txApprovalResponse, *txnbuild.Transaction) {
 	if in.Tx == "" {
 		log.Ctx(ctx).Error(`request is missing parameter "tx".`)
@@ -117,9 +116,7 @@ func (h txApproveHandler) validateInput(ctx context.Context, in txApproveRequest
 	}
 
 	if tx.SourceAccount().AccountID == h.issuerKP.Address() {
-		log.Ctx(ctx).Errorf("transaction %s sourceAccount is the same as the server issuer account %s",
-			in.Tx,
-			h.issuerKP.Address())
+		log.Ctx(ctx).Errorf("transaction %s sourceAccount is the same as the server issuer account %s", in.Tx, h.issuerKP.Address())
 		return NewRejectedTxApprovalResponse("Transaction source account is invalid."), nil
 	}
 

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve.go
@@ -59,13 +59,13 @@ func (h txApproveHandler) validate() error {
 	return nil
 }
 
-func convertThresholdToReadableString(threshold int64) (string, error) {
-	thresholdStr := amount.StringFromInt64(threshold)
-	res, err := strconv.ParseFloat(thresholdStr, 1)
+func convertAmountToReadableString(threshold int64) (string, error) {
+	amountStr := amount.StringFromInt64(threshold)
+	amountFloat, err := strconv.ParseFloat(amountStr, 64)
 	if err != nil {
 		return "", errors.Wrap(err, "converting threshold amount from string to float")
 	}
-	return fmt.Sprintf("%.2f", res), nil
+	return fmt.Sprintf("%.2f", amountFloat), nil
 }
 
 func (h txApproveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -278,7 +278,7 @@ func (h txApproveHandler) handleKYCRequiredOperationIfNeeded(ctx context.Context
 		return nil, nil
 	}
 	if rejectedAt.Valid {
-		kycThreshold, err := convertThresholdToReadableString(h.kycThreshold)
+		kycThreshold, err := convertAmountToReadableString(h.kycThreshold)
 		if err != nil {
 			return nil, errors.Wrap(err, "converting kycThreshold to human readable string")
 		}

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve.go
@@ -120,7 +120,7 @@ func (h txApproveHandler) validateInput(ctx context.Context, in txApproveRequest
 		log.Ctx(ctx).Errorf("transaction %s sourceAccount is the same as the server issuer account %s",
 			in.Tx,
 			h.issuerKP.Address())
-		return NewRejectedTxApprovalResponse("The source account is invalid."), nil
+		return NewRejectedTxApprovalResponse("Transaction source account is invalid."), nil
 	}
 
 	if len(tx.Operations()) != 1 {
@@ -300,11 +300,11 @@ func (h txApproveHandler) kycRequiredMessageIfNeeded(paymentOp *txnbuild.Payment
 		return "", errors.Wrap(err, "parsing account payment amount from string to Int64")
 	}
 	if paymentAmount > h.kycThreshold {
-		kycThreshold, err := convertThresholdToReadableString(h.kycThreshold)
+		kycThreshold, err := convertAmountToReadableString(h.kycThreshold)
 		if err != nil {
 			return "", errors.Wrap(err, "converting kycThreshold to human readable string")
 		}
-		return fmt.Sprintf(`Payments exceeding %s %s requires KYC approval. Please provide an email address.`, kycThreshold, h.assetCode), nil
+		return fmt.Sprintf(`Payments exceeding %s %s require KYC approval. Please provide an email address.`, kycThreshold, h.assetCode), nil
 	}
 	return "", nil
 }

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
@@ -112,25 +112,14 @@ func TestTxApproveHandlerValidate(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestConvertThresholdToReadableString(t *testing.T) {
-	// Prepare raw int64 amountValue.
-	// Context: stellar-core represents asset "amounts" as 64-bit so amounts shown as "500" is represented in stellar-core as 5000000000.
-	var amountValue int64 = 5000000000
-
-	// TEST if no error and if "500.00" returned
-	amountString, err := convertThresholdToReadableString(amountValue)
+func TestConvertAmountToReadableString(t *testing.T) {
+	parsedAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)
-	assert.Equal(t, "500.00", amountString)
+	assert.Equal(t, int64(5000000000), parsedAmount)
 
-	// Prepare amount parsed Int64 from string
-	// Context: env var KYCRequiredPaymentAmountThreshold is the token's unit quantity represented as string.
-	// This string is converted to int64 and passed to the txApproveHandler for payment evaluation.
-	parsedThresholdResult, err := amount.ParseInt64("500")
-
-	// TEST if no error and if "500.00" returned
-	amountString, err = convertThresholdToReadableString(parsedThresholdResult)
+	readableAmount, err := convertAmountToReadableString(parsedAmount)
 	require.NoError(t, err)
-	assert.Equal(t, "500.00", amountString)
+	assert.Equal(t, "500.00", readableAmount)
 }
 
 func TestTxApproveHandlerKYCRequiredMessageIfNeeded(t *testing.T) {

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
@@ -197,10 +197,10 @@ func TestTxApproveHandlerKYCRequiredMessageIfNeeded(t *testing.T) {
 	}
 
 	// TEST Successful KYC required response.
-	// actionRequiredMessage should return "Payments exceeding [kycThreshold] [assetCode] requires KYC approval..." message.
+	// actionRequiredMessage should return "Payments exceeding [kycThreshold] [assetCode] require KYC approval..." message.
 	actionRequiredMessage, err = h.kycRequiredMessageIfNeeded(&paymentOP)
 	require.NoError(t, err)
-	assert.Equal(t, `Payments exceeding 500.00 GOAT requires KYC approval. Please provide an email address.`, actionRequiredMessage)
+	assert.Equal(t, `Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.`, actionRequiredMessage)
 }
 
 func TestTxApproveHandlerHandleKYCRequiredOperationIfNeeded(t *testing.T) {
@@ -248,7 +248,7 @@ func TestTxApproveHandlerHandleKYCRequiredOperationIfNeeded(t *testing.T) {
 	require.NoError(t, err)
 	wantTXApprovalResponse := txApprovalResponse{
 		Status:       sep8Status("action_required"),
-		Message:      `Payments exceeding 500.00 GOAT requires KYC approval. Please provide an email address.`,
+		Message:      `Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.`,
 		StatusCode:   http.StatusOK,
 		ActionURL:    actionRequiredTxApprovalResponse.ActionURL,
 		ActionMethod: "POST",
@@ -416,7 +416,7 @@ func TestTxApproveHandlerTxApprove(t *testing.T) {
 	require.NoError(t, err)
 	wantRejectedResponse = txApprovalResponse{
 		Status:     "rejected",
-		Error:      "The source account is invalid.",
+		Error:      "Transaction source account is invalid.",
 		StatusCode: http.StatusBadRequest,
 	}
 	assert.Equal(t, &wantRejectedResponse, rejectedResponse)

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
@@ -511,6 +511,7 @@ func TestTxApproveHandlerTxApprove_actionRequired(t *testing.T) {
 	}
 	require.Equal(t, wantResp, txApprovalResp)
 }
+
 func TestTxApproveHandlerTxApprove_revised(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stellar/go/services/regulated-assets-approval-server/internal/db/dbtest"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stretchr/testify/assert"
@@ -17,7 +18,7 @@ import (
 )
 
 func TestTxApproveHandlerValidate(t *testing.T) {
-	// empty issuer KP.
+	// empty asset issuer KP.
 	h := txApproveHandler{}
 	err := h.validate()
 	require.EqualError(t, err, "issuer keypair cannot be nil")
@@ -111,109 +112,25 @@ func TestTxApproveHandlerValidate(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestTxApproveHandler_validateInput(t *testing.T) {
-	h := txApproveHandler{}
-	ctx := context.Background()
+func TestConvertAmountToReadableString(t *testing.T) {
+	// Prepare raw int64 amountValue.
+	// Context: stellar-core represents asset "amounts" as 64-bit so amounts shown as "500" is represented in stellar-core as 5000000000.
+	var amountValue int64 = 5000000000
 
-	// rejects if incoming tx is empty
-	in := txApproveRequest{}
-	txApprovalResp, gotTx := h.validateInput(ctx, in)
-	require.Equal(t, NewRejectedTxApprovalResponse("Missing parameter \"tx\"."), txApprovalResp)
-	require.Nil(t, gotTx)
-
-	// rejects if incoming tx is invalid
-	in = txApproveRequest{Tx: "foobar"}
-	txApprovalResp, gotTx = h.validateInput(ctx, in)
-	require.Equal(t, NewRejectedTxApprovalResponse("Invalid parameter \"tx\"."), txApprovalResp)
-	require.Nil(t, gotTx)
-
-	// rejects if incoming tx is a fee bump transaction
-	in = txApproveRequest{Tx: "AAAABQAAAAAo/cVyQxyGh7F/Vsj0BzfDYuOJvrwgfHGyqYFpHB5RCAAAAAAAAADIAAAAAgAAAAAo/cVyQxyGh7F/Vsj0BzfDYuOJvrwgfHGyqYFpHB5RCAAAAGQAEfDJAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAo/cVyQxyGh7F/Vsj0BzfDYuOJvrwgfHGyqYFpHB5RCAAAAAAAAAAAAJiWgAAAAAAAAAAAAAAAAAAAAAA="}
-	txApprovalResp, gotTx = h.validateInput(ctx, in)
-	require.Equal(t, NewRejectedTxApprovalResponse("Invalid parameter \"tx\"."), txApprovalResp)
-	require.Nil(t, gotTx)
-
-	// rejects if tx source account is the issuer
-	clientKP := keypair.MustRandom()
-	h.issuerKP = keypair.MustRandom()
-
-	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
-		SourceAccount: &horizon.Account{
-			AccountID: h.issuerKP.Address(),
-			Sequence:  "1",
-		},
-		IncrementSequenceNum: true,
-		Timebounds:           txnbuild.NewInfiniteTimeout(),
-		BaseFee:              300,
-		Operations: []txnbuild.Operation{
-			&txnbuild.Payment{
-				Destination: clientKP.Address(),
-				Amount:      "1",
-				Asset:       txnbuild.NativeAsset{},
-			},
-		},
-	})
+	// TEST if no error and if "500.00" returned
+	amountString, err := convertAmountToReadableString(amountValue)
 	require.NoError(t, err)
-	txe, err := tx.Base64()
-	require.NoError(t, err)
+	assert.Equal(t, "500.00", amountString)
 
-	in.Tx = txe
-	txApprovalResp, gotTx = h.validateInput(ctx, in)
-	require.Equal(t, NewRejectedTxApprovalResponse("Transaction source account is invalid."), txApprovalResp)
-	require.Nil(t, gotTx)
+	// Prepare amount parsed Int64 from string
+	// Context: env var KYCRequiredPaymentAmountThreshold is the token's unit quantity represented as string.
+	// This string is converted to int64 and passed to the txApproveHandler for payment evaluation.
+	parsedThresholdResult, err := amount.ParseInt64("500")
 
-	// rejects if tx contains more than one operation
-	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
-		SourceAccount: &horizon.Account{
-			AccountID: clientKP.Address(),
-			Sequence:  "1",
-		},
-		IncrementSequenceNum: true,
-		Timebounds:           txnbuild.NewInfiniteTimeout(),
-		BaseFee:              300,
-		Operations: []txnbuild.Operation{
-			&txnbuild.BumpSequence{},
-			&txnbuild.Payment{
-				Destination: clientKP.Address(),
-				Amount:      "1.0000000",
-				Asset:       txnbuild.NativeAsset{},
-			},
-		},
-	})
+	// TEST if no error and if "500.00" returned
+	amountString, err = convertAmountToReadableString(parsedThresholdResult)
 	require.NoError(t, err)
-	txe, err = tx.Base64()
-	require.NoError(t, err)
-
-	in.Tx = txe
-	txApprovalResp, gotTx = h.validateInput(ctx, in)
-	require.Equal(t, NewRejectedTxApprovalResponse("Please submit a transaction with exactly one operation of type payment."), txApprovalResp)
-	require.Nil(t, gotTx)
-
-	// success
-	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
-		SourceAccount: &horizon.Account{
-			AccountID: clientKP.Address(),
-			Sequence:  "1",
-		},
-		IncrementSequenceNum: true,
-		Timebounds:           txnbuild.NewInfiniteTimeout(),
-		BaseFee:              300,
-		Operations: []txnbuild.Operation{
-			&txnbuild.Payment{
-				Destination: clientKP.Address(),
-				Amount:      "1.0000000",
-				Asset:       txnbuild.NativeAsset{},
-			},
-		},
-	})
-	require.NoError(t, err)
-	txe, err = tx.Base64()
-	require.NoError(t, err)
-
-	in.Tx = txe
-	txApprovalResp, gotTx = h.validateInput(ctx, in)
-	require.Nil(t, txApprovalResp)
-	require.Equal(t, gotTx, tx)
+	assert.Equal(t, "500.00", amountString)
 }
 
 func TestTxApproveHandler_handleActionRequiredResponseIfNeeded(t *testing.T) {
@@ -223,103 +140,17 @@ func TestTxApproveHandler_handleActionRequiredResponseIfNeeded(t *testing.T) {
 	conn := db.Open()
 	defer conn.Close()
 
-	kycThreshold, err := amount.ParseInt64("500")
-	require.NoError(t, err)
-	h := txApproveHandler{
-		assetCode:    "FOO",
-		baseURL:      "https://sep8-server.test",
-		kycThreshold: kycThreshold,
-		db:           conn,
-	}
-
-	// payments smaller than or equal the threshold are not "action_required"
-	clientKP := keypair.MustRandom()
-	paymentOp := &txnbuild.Payment{
-		Amount: amount.StringFromInt64(kycThreshold),
-	}
-	txApprovalResp, err := h.handleActionRequiredResponseIfNeeded(ctx, clientKP.Address(), paymentOp)
-	require.NoError(t, err)
-	require.Nil(t, txApprovalResp)
-
-	// payments greater than the threshold are "action_required"
-	paymentOp = &txnbuild.Payment{
-		Amount: amount.StringFromInt64(kycThreshold + 1),
-	}
-	txApprovalResp, err = h.handleActionRequiredResponseIfNeeded(ctx, clientKP.Address(), paymentOp)
-	require.NoError(t, err)
-
-	var callbackID string
-	q := `SELECT callback_id FROM accounts_kyc_status WHERE stellar_address = $1`
-	err = conn.QueryRowContext(ctx, q, clientKP.Address()).Scan(&callbackID)
-	require.NoError(t, err)
-
-	wantResp := &txApprovalResponse{
-		Status:       sep8StatusActionRequired,
-		Message:      "Payments exceeding 500.00 FOO require KYC approval. Please provide an email address.",
-		ActionMethod: "POST",
-		StatusCode:   http.StatusOK,
-		ActionURL:    "https://sep8-server.test/kyc-status/" + callbackID,
-		ActionFields: []string{"email_address"},
-	}
-	require.Equal(t, wantResp, txApprovalResp)
-
-	// test addresses with approved KYC
-	q = `
-		UPDATE accounts_kyc_status
-		SET 
-			approved_at = NOW(),
-			rejected_at = NULL
-		WHERE stellar_address = $1
-	`
-	_, err = conn.ExecContext(ctx, q, clientKP.Address())
-	require.NoError(t, err)
-	txApprovalResp, err = h.handleActionRequiredResponseIfNeeded(ctx, clientKP.Address(), paymentOp)
-	require.NoError(t, err)
-	require.Nil(t, txApprovalResp)
-
-	// test addresses with rejected KYC
-	q = `
-		UPDATE accounts_kyc_status
-		SET 
-			approved_at = NULL,
-			rejected_at = NOW()
-		WHERE stellar_address = $1
-	`
-	_, err = conn.ExecContext(ctx, q, clientKP.Address())
-	require.NoError(t, err)
-	txApprovalResp, err = h.handleActionRequiredResponseIfNeeded(ctx, clientKP.Address(), paymentOp)
-	require.NoError(t, err)
-	require.Equal(t, NewRejectedTxApprovalResponse("Your KYC was rejected and you're not authorized for operations above 500.00 FOO."), txApprovalResp)
-}
-
-func TestTxApproveHandlerTxApprove_rejected(t *testing.T) {
-	ctx := context.Background()
-	db := dbtest.Open(t)
-	defer db.Close()
-	conn := db.Open()
-	defer conn.Close()
-
-	// prepare accounts on mock horizon
-	issuerKP := keypair.MustRandom()
-	senderKP := keypair.MustRandom()
-	receiverKP := keypair.MustRandom()
+	// Create tx-approve/ txApproveHandler.
+	issuerAccKeyPair := keypair.MustRandom()
 	horizonMock := horizonclient.MockClient{}
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
-		Return(horizon.Account{
-			AccountID: senderKP.Address(),
-			Sequence:  "2",
-		}, nil)
-
-	// prepare txApproveHandler
 	kycThresholdAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)
 	assetGOAT := txnbuild.CreditAsset{
 		Code:   "GOAT",
-		Issuer: issuerKP.Address(),
+		Issuer: issuerAccKeyPair.Address(),
 	}
-	handler := txApproveHandler{
-		issuerKP:          issuerKP,
+	h := txApproveHandler{
+		issuerKP:          issuerAccKeyPair,
 		assetCode:         assetGOAT.GetCode(),
 		horizonClient:     &horizonMock,
 		networkPassphrase: network.TestNetworkPassphrase,
@@ -328,8 +159,104 @@ func TestTxApproveHandlerTxApprove_rejected(t *testing.T) {
 		baseURL:           "https://sep8-server.test",
 	}
 
-	// "rejected" if tx is empty
-	rejectedResponse, err := handler.txApprove(ctx, txApproveRequest{})
+	// TEST if txApproveHandler is valid.
+	err = h.validate()
+	require.NoError(t, err)
+
+	// Prepare payment op whose amount is greater than 500 GOATs.
+	sourceKP := keypair.MustRandom()
+	destinationKP := keypair.MustRandom()
+	paymentOP := txnbuild.Payment{
+		SourceAccount: sourceKP.Address(),
+		Destination:   destinationKP.Address(),
+		Amount:        "501",
+		Asset:         assetGOAT,
+	}
+
+	// TEST successful "action_required" response.
+	actionRequiredTxApprovalResponse, err := h.handleActionRequiredResponseIfNeeded(ctx, sourceKP.Address(), &paymentOP)
+	require.NoError(t, err)
+	wantTXApprovalResponse := txApprovalResponse{
+		Status:       sep8Status("action_required"),
+		Message:      `Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.`,
+		StatusCode:   http.StatusOK,
+		ActionURL:    actionRequiredTxApprovalResponse.ActionURL,
+		ActionMethod: "POST",
+		ActionFields: []string{"email_address"},
+	}
+	assert.Equal(t, &wantTXApprovalResponse, actionRequiredTxApprovalResponse)
+
+	// TEST if the kyc attempt was logged in db's accounts_kyc_status table.
+	const q = `
+	SELECT stellar_address
+	FROM accounts_kyc_status
+	WHERE stellar_address = $1
+	`
+	var stellarAddress string
+	err = h.db.QueryRowContext(ctx, q, sourceKP.Address()).Scan(&stellarAddress)
+	require.NoError(t, err)
+	assert.Equal(t, sourceKP.Address(), stellarAddress)
+}
+
+func TestTxApproveHandlerTxApprove(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.Open(t)
+	defer db.Close()
+	conn := db.Open()
+	defer conn.Close()
+
+	// Perpare accounts on mock horizon.
+	issuerAccKeyPair := keypair.MustRandom()
+	senderAccKP := keypair.MustRandom()
+	receiverAccKP := keypair.MustRandom()
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerAccKeyPair.Address(),
+	}
+	horizonMock := horizonclient.MockClient{}
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: issuerAccKeyPair.Address()}).
+		Return(horizon.Account{
+			AccountID: issuerAccKeyPair.Address(),
+			Sequence:  "1",
+			Balances: []horizon.Balance{
+				{
+					Asset:   base.Asset{Code: "ASSET", Issuer: issuerAccKeyPair.Address()},
+					Balance: "0",
+				},
+			},
+		}, nil)
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderAccKP.Address()}).
+		Return(horizon.Account{
+			AccountID: senderAccKP.Address(),
+			Sequence:  "2",
+		}, nil)
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: receiverAccKP.Address()}).
+		Return(horizon.Account{
+			AccountID: receiverAccKP.Address(),
+			Sequence:  "3",
+		}, nil)
+
+	// Create tx-approve/ txApproveHandler.
+	kycThresholdAmount, err := amount.ParseInt64("500")
+	require.NoError(t, err)
+	handler := txApproveHandler{
+		issuerKP:          issuerAccKeyPair,
+		assetCode:         assetGOAT.GetCode(),
+		horizonClient:     &horizonMock,
+		networkPassphrase: network.TestNetworkPassphrase,
+		db:                conn,
+		kycThreshold:      kycThresholdAmount,
+		baseURL:           "https://sep8-server.test",
+	}
+
+	// TEST "rejected" response if no transaction is submitted; with empty "tx" for txApprove.
+	req := txApproveRequest{
+		Tx: "",
+	}
+	rejectedResponse, err := handler.txApprove(ctx, req)
 	require.NoError(t, err)
 	wantRejectedResponse := txApprovalResponse{
 		Status:     "rejected",
@@ -338,50 +265,136 @@ func TestTxApproveHandlerTxApprove_rejected(t *testing.T) {
 	}
 	assert.Equal(t, &wantRejectedResponse, rejectedResponse)
 
-	// rejected if the single operation is not a payment
+	// TEST "rejected" response if can't parse XDR; with malformed "tx" for txApprove.
+	req = txApproveRequest{
+		Tx: "BADXDRTRANSACTIONENVELOPE",
+	}
+	rejectedResponse, err = handler.txApprove(ctx, req)
+	require.NoError(t, err)
+	wantRejectedResponse = txApprovalResponse{
+		Status:     "rejected",
+		Error:      `Invalid parameter "tx".`,
+		StatusCode: http.StatusBadRequest,
+	}
+	assert.Equal(t, &wantRejectedResponse, rejectedResponse)
+
+	// Prepare invalid(non generic transaction) "tx" for txApprove.
+	senderAcc, err := handler.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: senderAccKP.Address()})
+	require.NoError(t, err)
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
-			SourceAccount: &horizon.Account{
-				AccountID: senderKP.Address(),
-				Sequence:  "2",
-			},
+			SourceAccount:        &senderAcc,
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
-				&txnbuild.BumpSequence{},
+				&txnbuild.Payment{
+					Destination: receiverAccKP.Address(),
+					Amount:      "1",
+					Asset:       assetGOAT,
+				},
 			},
 			BaseFee:    txnbuild.MinBaseFee,
 			Timebounds: txnbuild.NewInfiniteTimeout(),
 		},
 	)
 	require.NoError(t, err)
-	txe, err := tx.Base64()
+	feeBumpTx, err := txnbuild.NewFeeBumpTransaction(
+		txnbuild.FeeBumpTransactionParams{
+			Inner:      tx,
+			FeeAccount: receiverAccKP.Address(),
+			BaseFee:    2 * txnbuild.MinBaseFee,
+		},
+	)
+	require.NoError(t, err)
+	feeBumpTxEnc, err := feeBumpTx.Base64()
 	require.NoError(t, err)
 
-	txApprovalResp, err := handler.txApprove(ctx, txApproveRequest{Tx: txe})
+	// TEST "rejected" response if a non generic transaction fails, same result as malformed XDR.
+	req = txApproveRequest{
+		Tx: feeBumpTxEnc,
+	}
+	rejectedResponse, err = handler.txApprove(ctx, req)
 	require.NoError(t, err)
-	wantTxApprovalResp := &txApprovalResponse{
+	assert.Equal(t, &wantRejectedResponse, rejectedResponse) // wantRejectedResponse is identical to "if can't parse XDR".
+
+	// Prepare transaction sourceAccount the same as the server issuer account for txApprove.
+	issuerAcc, err := handler.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: issuerAccKeyPair.Address()})
+	require.NoError(t, err)
+	tx, err = txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount:        &issuerAcc,
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.Payment{
+					Destination: senderAccKP.Address(),
+					Amount:      "1",
+					Asset:       assetGOAT,
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	txEnc, err := tx.Base64()
+	require.NoError(t, err)
+
+	// TEST "rejected" response for sender account; transaction sourceAccount the same as the server issuer account.
+	req = txApproveRequest{
+		Tx: txEnc,
+	}
+	rejectedResponse, err = handler.txApprove(ctx, req)
+	require.NoError(t, err)
+	wantRejectedResponse = txApprovalResponse{
+		Status:     "rejected",
+		Error:      "Transaction source account is invalid.",
+		StatusCode: http.StatusBadRequest,
+	}
+	assert.Equal(t, &wantRejectedResponse, rejectedResponse)
+
+	// Prepare transaction where transaction's payment operation sourceAccount the same as the server issuer account.
+	tx, err = txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount:        &senderAcc,
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.Payment{
+					SourceAccount: issuerAccKeyPair.Address(),
+					Destination:   senderAccKP.Address(),
+					Amount:        "1",
+					Asset:         assetGOAT,
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	txEnc, err = tx.Base64()
+	require.NoError(t, err)
+
+	// TEST "rejected" response for sender account; payment operation sourceAccount the same as the server issuer account.
+	req = txApproveRequest{
+		Tx: txEnc,
+	}
+	rejectedResponse, err = handler.txApprove(ctx, req)
+	require.NoError(t, err)
+	wantRejectedResponse = txApprovalResponse{
 		Status:     "rejected",
 		Error:      "There is one or more unauthorized operations in the provided transaction.",
 		StatusCode: http.StatusBadRequest,
 	}
-	assert.Equal(t, wantTxApprovalResp, txApprovalResp)
+	assert.Equal(t, &wantRejectedResponse, rejectedResponse)
 
-	// rejected if payment asset is not supported
+	// Prepare transaction where operation is not a payment (in this case allowing trust for receiverAccKP).
 	tx, err = txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
-			SourceAccount: &horizon.Account{
-				AccountID: senderKP.Address(),
-				Sequence:  "2",
-			},
+			SourceAccount:        &senderAcc,
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					Destination: receiverKP.Address(),
-					Amount:      "1",
-					Asset: txnbuild.CreditAsset{
-						Code:   "FOO",
-						Issuer: keypair.MustRandom().Address(),
-					},
+				&txnbuild.AllowTrust{
+					Trustor:   receiverAccKP.Address(),
+					Type:      assetGOAT,
+					Authorize: true,
 				},
 			},
 			BaseFee:    txnbuild.MinBaseFee,
@@ -389,31 +402,38 @@ func TestTxApproveHandlerTxApprove_rejected(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	txe, err = tx.Base64()
-	require.NoError(t, err)
+	txEnc, err = tx.Base64()
 
-	txApprovalResp, err = handler.txApprove(ctx, txApproveRequest{Tx: txe})
+	// TEST "rejected" response if operation is not a payment (in this case allowing trust for receiverAccKP).
+	req = txApproveRequest{
+		Tx: txEnc,
+	}
+	rejectedResponse, err = handler.txApprove(ctx, req)
 	require.NoError(t, err)
-	wantTxApprovalResp = &txApprovalResponse{
+	wantRejectedResponse = txApprovalResponse{
 		Status:     "rejected",
-		Error:      "The payment asset is not supported by this issuer.",
+		Error:      "There is one or more unauthorized operations in the provided transaction.",
 		StatusCode: http.StatusBadRequest,
 	}
-	assert.Equal(t, wantTxApprovalResp, txApprovalResp)
+	assert.Equal(t, &wantRejectedResponse, rejectedResponse)
 
-	// rejected if sequence number is not incremental
+	// Prepare transaction with multiple operations.
 	tx, err = txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
-			SourceAccount: &horizon.Account{
-				AccountID: senderKP.Address(),
-				Sequence:  "20",
-			},
+			SourceAccount:        &senderAcc,
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
 				&txnbuild.Payment{
-					Destination: receiverKP.Address(),
-					Amount:      "1",
-					Asset:       assetGOAT,
+					SourceAccount: senderAccKP.Address(),
+					Destination:   receiverAccKP.Address(),
+					Amount:        "1",
+					Asset:         assetGOAT,
+				},
+				&txnbuild.Payment{
+					SourceAccount: senderAccKP.Address(),
+					Destination:   receiverAccKP.Address(),
+					Amount:        "2",
+					Asset:         assetGOAT,
 				},
 			},
 			BaseFee:    txnbuild.MinBaseFee,
@@ -421,207 +441,56 @@ func TestTxApproveHandlerTxApprove_rejected(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	txe, err = tx.Base64()
+	txEnc, err = tx.Base64()
 	require.NoError(t, err)
 
-	txApprovalResp, err = handler.txApprove(ctx, txApproveRequest{Tx: txe})
+	// TEST "rejected" response for sender account; transaction with multiple operations.
+	req = txApproveRequest{
+		Tx: txEnc,
+	}
+	rejectedResponse, err = handler.txApprove(ctx, req)
 	require.NoError(t, err)
-	wantTxApprovalResp = &txApprovalResponse{
+	wantRejectedResponse = txApprovalResponse{
+		Status:     "rejected",
+		Error:      "Please submit a transaction with exactly one operation of type payment.",
+		StatusCode: http.StatusBadRequest,
+	}
+	assert.Equal(t, &wantRejectedResponse, rejectedResponse)
+
+	// Prepare transaction where sourceAccount seq num too far in the future.
+	tx, err = txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount: &horizon.Account{
+				AccountID: senderAccKP.Address(),
+				Sequence:  "50",
+			},
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.Payment{
+					SourceAccount: senderAccKP.Address(),
+					Destination:   receiverAccKP.Address(),
+					Amount:        "1",
+					Asset:         assetGOAT,
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	txEnc, err = tx.Base64()
+	require.NoError(t, err)
+
+	// TEST "rejected" response if transaction source account seq num is not equal to account sequence+1.
+	req = txApproveRequest{
+		Tx: txEnc,
+	}
+	rejectedResponse, err = handler.txApprove(ctx, req)
+	require.NoError(t, err)
+	wantRejectedResponse = txApprovalResponse{
 		Status:     "rejected",
 		Error:      "Invalid transaction sequence number.",
 		StatusCode: http.StatusBadRequest,
 	}
-	assert.Equal(t, wantTxApprovalResp, txApprovalResp)
-}
-
-func TestTxApproveHandlerTxApprove_actionRequired(t *testing.T) {
-	ctx := context.Background()
-	db := dbtest.Open(t)
-	defer db.Close()
-	conn := db.Open()
-	defer conn.Close()
-
-	// prepare accounts on mock horizon
-	issuerKP := keypair.MustRandom()
-	senderKP := keypair.MustRandom()
-	receiverKP := keypair.MustRandom()
-	horizonMock := horizonclient.MockClient{}
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
-		Return(horizon.Account{
-			AccountID: senderKP.Address(),
-			Sequence:  "2",
-		}, nil)
-
-	// prepare txApproveHandler
-	kycThresholdAmount, err := amount.ParseInt64("500")
-	require.NoError(t, err)
-	assetGOAT := txnbuild.CreditAsset{
-		Code:   "GOAT",
-		Issuer: issuerKP.Address(),
-	}
-	handler := txApproveHandler{
-		issuerKP:          issuerKP,
-		assetCode:         assetGOAT.GetCode(),
-		horizonClient:     &horizonMock,
-		networkPassphrase: network.TestNetworkPassphrase,
-		db:                conn,
-		kycThreshold:      kycThresholdAmount,
-		baseURL:           "https://sep8-server.test",
-	}
-
-	// rejected if sequence number is not incremental
-	tx, err := txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount: &horizon.Account{
-				AccountID: senderKP.Address(),
-				Sequence:  "2",
-			},
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					Destination: receiverKP.Address(),
-					Amount:      "501",
-					Asset:       assetGOAT,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txe, err := tx.Base64()
-	require.NoError(t, err)
-
-	txApprovalResp, err := handler.txApprove(ctx, txApproveRequest{Tx: txe})
-	require.NoError(t, err)
-
-	var callbackID string
-	q := `SELECT callback_id FROM accounts_kyc_status WHERE stellar_address = $1`
-	err = conn.QueryRowContext(ctx, q, senderKP.Address()).Scan(&callbackID)
-	require.NoError(t, err)
-
-	wantResp := &txApprovalResponse{
-		Status:       sep8StatusActionRequired,
-		Message:      "Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.",
-		ActionMethod: "POST",
-		StatusCode:   http.StatusOK,
-		ActionURL:    "https://sep8-server.test/kyc-status/" + callbackID,
-		ActionFields: []string{"email_address"},
-	}
-	require.Equal(t, wantResp, txApprovalResp)
-}
-
-func TestTxApproveHandlerTxApprove_revised(t *testing.T) {
-	ctx := context.Background()
-	db := dbtest.Open(t)
-	defer db.Close()
-	conn := db.Open()
-	defer conn.Close()
-
-	// prepare accounts on mock horizon
-	issuerKP := keypair.MustRandom()
-	senderKP := keypair.MustRandom()
-	receiverKP := keypair.MustRandom()
-	horizonMock := horizonclient.MockClient{}
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
-		Return(horizon.Account{
-			AccountID: senderKP.Address(),
-			Sequence:  "2",
-		}, nil)
-
-	// prepare txApproveHandler
-	kycThresholdAmount, err := amount.ParseInt64("500")
-	require.NoError(t, err)
-	assetGOAT := txnbuild.CreditAsset{
-		Code:   "GOAT",
-		Issuer: issuerKP.Address(),
-	}
-	handler := txApproveHandler{
-		issuerKP:          issuerKP,
-		assetCode:         assetGOAT.GetCode(),
-		horizonClient:     &horizonMock,
-		networkPassphrase: network.TestNetworkPassphrase,
-		db:                conn,
-		kycThreshold:      kycThresholdAmount,
-		baseURL:           "https://sep8-server.test",
-	}
-
-	// rejected if sequence number is not incremental
-	tx, err := txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount: &horizon.Account{
-				AccountID: senderKP.Address(),
-				Sequence:  "2",
-			},
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					Destination: receiverKP.Address(),
-					Amount:      "500",
-					Asset:       assetGOAT,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txe, err := tx.Base64()
-	require.NoError(t, err)
-
-	txApprovalResp, err := handler.txApprove(ctx, txApproveRequest{Tx: txe})
-	require.NoError(t, err)
-	require.Equal(t, sep8StatusRevised, txApprovalResp.Status)
-	require.Equal(t, http.StatusOK, txApprovalResp.StatusCode)
-	require.Equal(t, "Authorization and deauthorization operations were added.", txApprovalResp.Message)
-
-	gotGenericTx, err := txnbuild.TransactionFromXDR(txApprovalResp.Tx)
-	require.NoError(t, err)
-	gotTx, ok := gotGenericTx.Transaction()
-	require.True(t, ok)
-	require.Equal(t, senderKP.Address(), gotTx.SourceAccount().AccountID)
-	require.Equal(t, int64(3), gotTx.SourceAccount().Sequence)
-
-	require.Len(t, gotTx.Operations(), 5)
-	// AllowTrust op where issuer fully authorizes account A, asset X
-	op0, ok := gotTx.Operations()[0].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op0.Trustor, senderKP.Address())
-	assert.Equal(t, op0.Type.GetCode(), assetGOAT.GetCode())
-	require.True(t, op0.Authorize)
-	// AllowTrust op where issuer fully authorizes account B, asset X
-	op1, ok := gotTx.Operations()[1].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op1.Trustor, receiverKP.Address())
-	assert.Equal(t, op1.Type.GetCode(), assetGOAT.GetCode())
-	require.True(t, op1.Authorize)
-	// Payment from A to B
-	op2, ok := gotTx.Operations()[2].(*txnbuild.Payment)
-	require.True(t, ok)
-	assert.Equal(t, op2.Destination, receiverKP.Address())
-	assert.Equal(t, op2.Asset, assetGOAT)
-	// AllowTrust op where issuer fully deauthorizes account B, asset X
-	op3, ok := gotTx.Operations()[3].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op3.Trustor, receiverKP.Address())
-	assert.Equal(t, op3.Type.GetCode(), assetGOAT.GetCode())
-	require.False(t, op3.Authorize)
-	// AllowTrust op where issuer fully deauthorizes account A, asset X
-	op4, ok := gotTx.Operations()[4].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op4.Trustor, senderKP.Address())
-	assert.Equal(t, op4.Type.GetCode(), assetGOAT.GetCode())
-	require.False(t, op4.Authorize)
-}
-
-func TestConvertAmountToReadableString(t *testing.T) {
-	parsedAmount, err := amount.ParseInt64("500")
-	require.NoError(t, err)
-	assert.Equal(t, int64(5000000000), parsedAmount)
-
-	readableAmount, err := convertAmountToReadableString(parsedAmount)
-	require.NoError(t, err)
-	assert.Equal(t, "500.00", readableAmount)
+	assert.Equal(t, &wantRejectedResponse, rejectedResponse)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Refactoring tx_approve.go file before we start supporting other SEP-8 responses.

Also, made some methods and variable names more consistent and removed an unneeded method

### Why

The structure of the tx_approve.go file needed some tidying before being expanded with more SEP-8 responses like "success" and "pending".

### Known limitations

N/A
