### PR TITLE
Fix transaction submission when handling large transaction payloads

### DIFF
--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -7,7 +7,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Added transaction and operation result codes to the horizonclient.Error string for easy glancing at string only errors for underlying cause.
 * Fix bug in the transaction submission where requests with large transaction payloads fail with an HTTP 414 URI Too Long error ([#3643](https://github.com/stellar/go/pull/3643)).
-* 
+
 ## [v7.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v7.0.0) - 2021-05-15
 
 None

--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -6,7 +6,8 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * Added transaction and operation result codes to the horizonclient.Error string for easy glancing at string only errors for underlying cause.
-* Fix bug in the transaction submission where requests with large transaction payloads fail with an HTTP 414 URI Too Long error.
+* Fix bug in the transaction submission where requests with large transaction payloads fail with an HTTP 414 URI Too Long error ([#3643](https://github.com/stellar/go/pull/3643)).
+* 
 ## [v7.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v7.0.0) - 2021-05-15
 
 None

--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -6,7 +6,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * Added transaction and operation result codes to the horizonclient.Error string for easy glancing at string only errors for underlying cause.
-
+* Fix bug in the transaction submission where requests with large transaction payloads fail with an HTTP 414 URI Too Long error.
 ## [v7.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v7.0.0) - 2021-05-15
 
 None

--- a/clients/horizonclient/account_request.go
+++ b/clients/horizonclient/account_request.go
@@ -2,6 +2,7 @@ package horizonclient
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/stellar/go/support/errors"
@@ -45,4 +46,14 @@ func (ar AccountRequest) BuildURL() (endpoint string, err error) {
 	}
 
 	return endpoint, err
+}
+
+// HTTPRequest returns the http request for the account endpoint
+func (ar AccountRequest) HTTPRequest(horizonURL string) (*http.Request, error) {
+	endpoint, err := ar.BuildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequest("GET", horizonURL+endpoint, nil)
 }

--- a/clients/horizonclient/accounts_request.go
+++ b/clients/horizonclient/accounts_request.go
@@ -2,6 +2,7 @@ package horizonclient
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/stellar/go/support/errors"
@@ -53,4 +54,14 @@ func (r AccountsRequest) BuildURL() (endpoint string, err error) {
 	}
 
 	return endpoint, err
+}
+
+// HTTPRequest returns the http request for the accounts endpoint
+func (r AccountsRequest) HTTPRequest(horizonURL string) (*http.Request, error) {
+	endpoint, err := r.BuildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequest("GET", horizonURL+endpoint, nil)
 }

--- a/clients/horizonclient/asset_request.go
+++ b/clients/horizonclient/asset_request.go
@@ -2,6 +2,7 @@ package horizonclient
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/stellar/go/support/errors"
@@ -26,4 +27,14 @@ func (ar AssetRequest) BuildURL() (endpoint string, err error) {
 	}
 
 	return endpoint, err
+}
+
+// HTTPRequest returns the http request for the assets endpoint
+func (ar AssetRequest) HTTPRequest(horizonURL string) (*http.Request, error) {
+	endpoint, err := ar.BuildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequest("GET", horizonURL+endpoint, nil)
 }

--- a/clients/horizonclient/claimable_balance_request.go
+++ b/clients/horizonclient/claimable_balance_request.go
@@ -2,6 +2,7 @@ package horizonclient
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/stellar/go/support/errors"
@@ -39,4 +40,14 @@ func (cbr ClaimableBalanceRequest) BuildURL() (endpoint string, err error) {
 	}
 
 	return endpoint, err
+}
+
+// HTTPRequest returns the http request for the claimable balances endpoint
+func (cbr ClaimableBalanceRequest) HTTPRequest(horizonURL string) (*http.Request, error) {
+	endpoint, err := cbr.BuildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequest("GET", horizonURL+endpoint, nil)
 }

--- a/clients/horizonclient/effect_request.go
+++ b/clients/horizonclient/effect_request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/stellar/go/protocols/horizon/effects"
@@ -79,4 +80,14 @@ func (er EffectRequest) StreamEffects(ctx context.Context, client *Client, handl
 		handler(effs)
 		return nil
 	})
+}
+
+// HTTPRequest returns the http request for the effects endpoint
+func (er EffectRequest) HTTPRequest(horizonURL string) (*http.Request, error) {
+	endpoint, err := er.BuildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequest("GET", horizonURL+endpoint, nil)
 }

--- a/clients/horizonclient/fee_stats_request.go
+++ b/clients/horizonclient/fee_stats_request.go
@@ -1,6 +1,9 @@
 package horizonclient
 
-import "github.com/stellar/go/support/errors"
+import (
+	"github.com/stellar/go/support/errors"
+	"net/http"
+)
 
 // BuildURL returns the url for getting fee stats about a running horizon instance
 func (fr feeStatsRequest) BuildURL() (endpoint string, err error) {
@@ -10,4 +13,14 @@ func (fr feeStatsRequest) BuildURL() (endpoint string, err error) {
 	}
 
 	return
+}
+
+// HTTPRequest returns the http request for the fee stats endpoint
+func (fr feeStatsRequest) HTTPRequest(horizonURL string) (*http.Request, error) {
+	endpoint, err := fr.BuildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequest("GET", horizonURL+endpoint, nil)
 }

--- a/clients/horizonclient/ledger_request.go
+++ b/clients/horizonclient/ledger_request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
@@ -38,6 +39,16 @@ func (lr LedgerRequest) BuildURL() (endpoint string, err error) {
 	}
 
 	return endpoint, err
+}
+
+// HTTPRequest returns the http request for the ledger endpoint
+func (lr LedgerRequest) HTTPRequest(horizonURL string) (*http.Request, error) {
+	endpoint, err := lr.BuildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequest("GET", horizonURL+endpoint, nil)
 }
 
 // LedgerHandler is a function that is called when a new ledger is received

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -225,6 +225,7 @@ var DefaultPublicNetClient = &Client{
 }
 
 // HorizonRequest contains methods implemented by request structs for horizon endpoints.
+// Action needed in release: horizonclient-v8.0.0: remove BuildURL()
 type HorizonRequest interface {
 	BuildURL() (string, error)
 	HTTPRequest(horizonURL string) (*http.Request, error)

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -227,6 +227,7 @@ var DefaultPublicNetClient = &Client{
 // HorizonRequest contains methods implemented by request structs for horizon endpoints.
 type HorizonRequest interface {
 	BuildURL() (string, error)
+	HTTPRequest(horizonURL string) (*http.Request, error)
 }
 
 // AccountsRequest struct contains data for making requests to the accounts endpoint of a horizon server.

--- a/clients/horizonclient/offer_request.go
+++ b/clients/horizonclient/offer_request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
@@ -48,6 +49,16 @@ func (or OfferRequest) BuildURL() (endpoint string, err error) {
 	}
 
 	return endpoint, err
+}
+
+// HTTPRequest returns the http request for the offers endpoint
+func (or OfferRequest) HTTPRequest(horizonURL string) (*http.Request, error) {
+	endpoint, err := or.BuildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequest("GET", horizonURL+endpoint, nil)
 }
 
 // OfferHandler is a function that is called when a new offer is received

--- a/clients/horizonclient/operation_request.go
+++ b/clients/horizonclient/operation_request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/stellar/go/protocols/horizon/operations"
@@ -52,6 +53,16 @@ func (op OperationRequest) BuildURL() (endpoint string, err error) {
 	}
 
 	return endpoint, err
+}
+
+// HTTPRequest returns the http request for the operations endpoint
+func (op OperationRequest) HTTPRequest(horizonURL string) (*http.Request, error) {
+	endpoint, err := op.BuildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequest("GET", horizonURL+endpoint, nil)
 }
 
 // setEndpoint sets the endpoint for the OperationRequest

--- a/clients/horizonclient/order_book_request.go
+++ b/clients/horizonclient/order_book_request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
@@ -35,6 +36,16 @@ func (obr OrderBookRequest) BuildURL() (endpoint string, err error) {
 	}
 
 	return endpoint, err
+}
+
+// HTTPRequest returns the http request for the order book endpoint
+func (obr OrderBookRequest) HTTPRequest(horizonURL string) (*http.Request, error) {
+	endpoint, err := obr.BuildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequest("GET", horizonURL+endpoint, nil)
 }
 
 // OrderBookHandler is a function that is called when a new order summary is received

--- a/clients/horizonclient/paths_request.go
+++ b/clients/horizonclient/paths_request.go
@@ -2,6 +2,7 @@ package horizonclient
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/stellar/go/support/errors"
@@ -33,4 +34,14 @@ func (pr PathsRequest) BuildURL() (endpoint string, err error) {
 	}
 
 	return endpoint, err
+}
+
+// HTTPRequest returns the http request for the path payment endpoint
+func (pr PathsRequest) HTTPRequest(horizonURL string) (*http.Request, error) {
+	endpoint, err := pr.BuildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequest("GET", horizonURL+endpoint, nil)
 }

--- a/clients/horizonclient/strict_send_paths_request.go
+++ b/clients/horizonclient/strict_send_paths_request.go
@@ -2,6 +2,7 @@ package horizonclient
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/stellar/go/support/errors"
@@ -32,4 +33,14 @@ func (pr StrictSendPathsRequest) BuildURL() (endpoint string, err error) {
 	}
 
 	return endpoint, err
+}
+
+// HTTPRequest returns the http request for the strict send path payment endpoint
+func (pr StrictSendPathsRequest) HTTPRequest(horizonURL string) (*http.Request, error) {
+	endpoint, err := pr.BuildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequest("GET", horizonURL+endpoint, nil)
 }

--- a/clients/horizonclient/submit_request.go
+++ b/clients/horizonclient/submit_request.go
@@ -2,7 +2,9 @@ package horizonclient
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/stellar/go/support/errors"
 )
@@ -18,4 +20,16 @@ func (sr submitRequest) BuildURL() (endpoint string, err error) {
 
 	endpoint = fmt.Sprintf("%s?%s", sr.endpoint, query.Encode())
 	return endpoint, err
+}
+
+// HTTPRequest returns the http request for submitting transactions to a running horizon instance
+func (sr submitRequest) HTTPRequest(horizonURL string) (*http.Request, error) {
+	form := url.Values{}
+	form.Set("tx", sr.transactionXdr)
+	request, err := http.NewRequest("POST", horizonURL+sr.endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	return request, nil
 }

--- a/clients/horizonclient/trade_aggregation_request.go
+++ b/clients/horizonclient/trade_aggregation_request.go
@@ -2,6 +2,7 @@ package horizonclient
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 
@@ -35,4 +36,14 @@ func (ta TradeAggregationRequest) BuildURL() (endpoint string, err error) {
 	}
 
 	return endpoint, err
+}
+
+// HTTPRequest returns the http request for the trade aggregations endpoint
+func (ta TradeAggregationRequest) HTTPRequest(horizonURL string) (*http.Request, error) {
+	endpoint, err := ta.BuildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequest("GET", horizonURL+endpoint, nil)
 }

--- a/clients/horizonclient/trade_request.go
+++ b/clients/horizonclient/trade_request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
@@ -60,6 +61,16 @@ func (tr TradeRequest) BuildURL() (endpoint string, err error) {
 	}
 
 	return endpoint, err
+}
+
+// HTTPRequest returns the http request for the trades endpoint
+func (tr TradeRequest) HTTPRequest(horizonURL string) (*http.Request, error) {
+	endpoint, err := tr.BuildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequest("GET", horizonURL+endpoint, nil)
 }
 
 // TradeHandler is a function that is called when a new trade is received

--- a/clients/horizonclient/transaction_request.go
+++ b/clients/horizonclient/transaction_request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
@@ -45,6 +46,16 @@ func (tr TransactionRequest) BuildURL() (endpoint string, err error) {
 	}
 
 	return endpoint, err
+}
+
+// HTTPRequest returns the http request for the transactions endpoint
+func (tr TransactionRequest) HTTPRequest(horizonURL string) (*http.Request, error) {
+	endpoint, err := tr.BuildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequest("GET", horizonURL+endpoint, nil)
 }
 
 // TransactionHandler is a function that is called when a new transaction is received


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Close https://github.com/stellar/go/issues/3621

The payload for the submit transaction endpoint is included as a query parameter in the horizon client. When a transaction has a lengthy XDR encoding, the request url can be too long which will cause the request to fail with a "HTTP 414 URI Too Long" error. To fix this issue I have moved the transaction payload into the POST body.