### PR TITLE
xdr: Remove Price.Scan method

### DIFF
--- a/xdr/db.go
+++ b/xdr/db.go
@@ -5,8 +5,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-
-	"github.com/lib/pq"
 )
 
 // This file contains implementations of the sql.Scanner interface for stellar xdr types
@@ -73,24 +71,6 @@ func (t *Int64) Scan(src interface{}) error {
 	}
 
 	*t = Int64(val)
-	return nil
-}
-
-// Scan reads from a src into an xdr.Price
-func (t *Price) Scan(src interface{}) error {
-	// assuming the price is represented as a two-element array [n,d]
-	arr := pq.Int64Array{}
-	err := arr.Scan(src)
-
-	if err != nil {
-		return err
-	}
-
-	if len(arr) != 2 {
-		return errors.New("price array should have exactly 2 elements")
-	}
-
-	*t = Price{Int32(arr[0]), Int32(arr[1])}
 	return nil
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit removes `xdr.Price.Scan` method (implements [`Scanner`](https://golang.org/pkg/database/sql/#Scanner) interface) because it's no longer used in `stellar/go` (since https://github.com/stellar/go/commit/599673d1b9746ace4701bfe2668f224e80aabd0d).

Close #3152.

### Why

The method was dependant on `github.com/lib/pq` so everyone who pulled `xdr` package had to add it to their dependencies.

### Known limitations

Should be released in a major version because this can be a breaking change for some users.