### PR TITLE
services/regulated-assets-approval-server: refactor tests targeting the /tx-approve endpoint

### DIFF
--- a/services/regulated-assets-approval-server/README.md
+++ b/services/regulated-assets-approval-server/README.md
@@ -6,7 +6,7 @@ Status: supports SEP-8 transactions revision with a simplified rule:
 - payments whose amount does not meet the configured threshold are considered compliant and revised according to the SEP-8 specification.
 - payments with an amount exceeding the threshold need further action.
 
-It is important to notice the SEP-8 "success" response has not been implemented yet so even if the submitted transaction is compliant to be marked as successful according with SEP-8, the service will reject it.
+It is important to notice the SEP-8 "success" response has not been implemented yet so even if the submitted transaction is compliant to be marked as successful according with SEP-8, this service will reject it.
 ```
 
 This is a [SEP-8] Approval Server reference implementation based on SEP-8 v1.7.1

--- a/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
@@ -3,11 +3,9 @@ package serve
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -17,7 +15,6 @@ import (
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/protocols/horizon"
-	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stellar/go/services/regulated-assets-approval-server/internal/db/dbtest"
 	kycstatus "github.com/stellar/go/services/regulated-assets-approval-server/internal/serve/kyc-status"
 	"github.com/stellar/go/txnbuild"
@@ -25,53 +22,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAPI_RejectedIntegration(t *testing.T) {
+func TestAPI_txApprove_rejected(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
 	defer conn.Close()
 
-	// Perpare accounts on mock horizon.
-	issuerAccKeyPair := keypair.MustRandom()
-	assetGOAT := txnbuild.CreditAsset{
-		Code:   "GOAT",
-		Issuer: issuerAccKeyPair.Address(),
-	}
+	issuerKP := keypair.MustRandom()
 	horizonMock := horizonclient.MockClient{}
-	senderAccKP := keypair.MustRandom()
-	receiverAccKP := keypair.MustRandom()
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: issuerAccKeyPair.Address()}).
-		Return(horizon.Account{
-			AccountID: issuerAccKeyPair.Address(),
-			Sequence:  "1",
-			Balances: []horizon.Balance{
-				{
-					Asset:   base.Asset{Code: "ASSET", Issuer: issuerAccKeyPair.Address()},
-					Balance: "1",
-				},
-			},
-		}, nil)
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderAccKP.Address()}).
-		Return(horizon.Account{
-			AccountID: senderAccKP.Address(),
-			Sequence:  "2",
-		}, nil)
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: receiverAccKP.Address()}).
-		Return(horizon.Account{
-			AccountID: receiverAccKP.Address(),
-			Sequence:  "3",
-		}, nil)
-
-	// Create tx-approve/ txApproveHandler.
 	kycThresholdAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)
+
 	handler := txApproveHandler{
-		issuerKP:          issuerAccKeyPair,
-		assetCode:         assetGOAT.GetCode(),
+		issuerKP:          issuerKP,
+		assetCode:         "FOO",
 		horizonClient:     &horizonMock,
 		networkPassphrase: network.TestNetworkPassphrase,
 		db:                conn,
@@ -79,322 +44,28 @@ func TestAPI_RejectedIntegration(t *testing.T) {
 		baseURL:           "https://sep8-server.test",
 	}
 
-	// Prepare and send empty "tx" for "/tx-approve" POST request.
-	req := `{
-		"tx": ""
-	}`
+	// rejected if no transaction "tx"is submitted
 	m := chi.NewMux()
 	m.Post("/tx-approve", handler.ServeHTTP)
-	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	r := httptest.NewRequest("POST", "/tx-approve", nil)
 	r = r.WithContext(ctx)
 	w := httptest.NewRecorder()
 	m.ServeHTTP(w, r)
+
 	resp := w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	// TEST "rejected" response if no transaction is submitted.
 	wantBody := `{
-		"status":"rejected", "error":"Missing parameter \"tx\"."
-	}`
-	require.JSONEq(t, wantBody, string(body))
-
-	// Prepare and send malformed "tx" for "/tx-approve" POST request.
-	req = `{
-		"tx": "BADXDRTRANSACTIONENVELOPE"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "rejected" response if can't parse XDR.
-	wantBody = `{
-		"status":"rejected", "error":"Invalid parameter \"tx\"."
-	}`
-	require.JSONEq(t, wantBody, string(body))
-
-	// Prepare non generic transaction "tx".
-	senderAcc, err := handler.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: senderAccKP.Address()})
-	require.NoError(t, err)
-	tx, err := txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &senderAcc,
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					Destination: receiverAccKP.Address(),
-					Amount:      "1",
-					Asset:       assetGOAT,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	feeBumpTx, err := txnbuild.NewFeeBumpTransaction(
-		txnbuild.FeeBumpTransactionParams{
-			Inner:      tx,
-			FeeAccount: receiverAccKP.Address(),
-			BaseFee:    2 * txnbuild.MinBaseFee,
-		},
-	)
-	require.NoError(t, err)
-	feeBumpTxEnc, err := feeBumpTx.Base64()
-	require.NoError(t, err)
-
-	// Send invalid "tx" for "/tx-approve" POST request.
-	req = `{
-		"tx": "` + feeBumpTxEnc + `"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "rejected" response if  a non generic transaction fails, same result as malformed XDR.
-	wantBody = `{
-		"status":"rejected", "error":"Invalid parameter \"tx\"."
-	}`
-	require.JSONEq(t, wantBody, string(body))
-
-	// Prepare "tx" where transaction sourceAccount the same as the server issuer account.
-	issuerAcc, err := handler.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: issuerAccKeyPair.Address()})
-	require.NoError(t, err)
-	tx, err = txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &issuerAcc,
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					Destination: senderAccKP.Address(),
-					Amount:      "1",
-					Asset:       assetGOAT,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txEnc, err := tx.Base64()
-	require.NoError(t, err)
-
-	// Send "tx" where transaction sourceAccount the same as the server issuer account for "/tx-approve" POST request.
-	req = `{
-		"tx": "` + txEnc + `"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "rejected" response if the transaction sourceAccount the same as the server issuer account.
-	wantBody = `{
-		"status":"rejected", "error":"Transaction source account is invalid."
-	}`
-	require.JSONEq(t, wantBody, string(body))
-
-	// Prepare "tx" where transaction's operation sourceAccount the same as the server issuer account.
-	tx, err = txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &senderAcc,
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					SourceAccount: issuerAccKeyPair.Address(),
-					Destination:   senderAccKP.Address(),
-					Amount:        "1",
-					Asset:         assetGOAT,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txEnc, err = tx.Base64()
-	require.NoError(t, err)
-
-	// Send "tx" where transaction's operation sourceAccount the same as the server issuer account for "/tx-approve" POST request.
-	req = `{
-		"tx": "` + txEnc + `"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "rejected" response if the transaction's operation sourceAccount the same as the server issuer account.
-	wantBody = `{
-		"status":"rejected", "error":"There is one or more unauthorized operations in the provided transaction."
-	}`
-	require.JSONEq(t, wantBody, string(body))
-
-	// Prepare "tx" where transaction's operation is not a payment.
-	tx, err = txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &senderAcc,
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.AllowTrust{
-					Trustor:   receiverAccKP.Address(),
-					Type:      assetGOAT,
-					Authorize: true,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txEnc, err = tx.Base64()
-	require.NoError(t, err)
-
-	// Send "tx" where transaction's operation is not a payment for "/tx-approve" POST request.
-	req = `{
-		"tx": "` + txEnc + `"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "rejected" response if transaction's operation is not a payment.
-	wantBody = `{
-		"status":"rejected", "error":"There is one or more unauthorized operations in the provided transaction."
-	}`
-	require.JSONEq(t, wantBody, string(body))
-
-	// Prepare "tx" where theres more than one operation in transaction.
-	tx, err = txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &senderAcc,
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					SourceAccount: senderAccKP.Address(),
-					Destination:   receiverAccKP.Address(),
-					Amount:        "1",
-					Asset:         assetGOAT,
-				},
-				&txnbuild.Payment{
-					SourceAccount: senderAccKP.Address(),
-					Destination:   receiverAccKP.Address(),
-					Amount:        "2",
-					Asset:         assetGOAT,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txEnc, err = tx.Base64()
-	require.NoError(t, err)
-
-	// Send "tx" where theres more than one operation in transaction for "/tx-approve" POST request.
-	req = `{
-		"tx": "` + txEnc + `"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "rejected" response if more than one operation in transaction.
-	wantBody = `{
-		"status":"rejected", "error":"Please submit a transaction with exactly one operation of type payment."
-	}`
-	require.JSONEq(t, wantBody, string(body))
-
-	// Prepare "tx" where transaction's transaction source account seq num is not equal to account sequence+1.
-	tx, err = txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount: &horizon.Account{
-				AccountID: senderAccKP.Address(),
-				Sequence:  "50",
-			},
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					SourceAccount: senderAccKP.Address(),
-					Destination:   receiverAccKP.Address(),
-					Amount:        "1",
-					Asset:         assetGOAT,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txEnc, err = tx.Base64()
-	require.NoError(t, err)
-
-	// Send "tx" where transaction's transaction source account seq num is not equal to account sequence+1 for "/tx-approve" POST request.
-	req = `{
-		"tx": "` + txEnc + `"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "rejected" response if where transaction's transaction source account seq num is not equal to account sequence+1.
-	wantBody = `{
-		"status":"rejected", "error":"Invalid transaction sequence number."
+		"status": "rejected",
+		"error": "Missing parameter \"tx\"."
 	}`
 	require.JSONEq(t, wantBody, string(body))
 }
 
-func TestAPI_RevisedIntegration(t *testing.T) {
+func TestAPI_txApprove_revised(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)
 	defer db.Close()
@@ -402,42 +73,25 @@ func TestAPI_RevisedIntegration(t *testing.T) {
 	defer conn.Close()
 
 	// Perpare accounts on mock horizon.
-	issuerAccKeyPair := keypair.MustRandom()
-	senderAccKP := keypair.MustRandom()
-	receiverAccKP := keypair.MustRandom()
+	senderKP := keypair.MustRandom()
+	receiverKP := keypair.MustRandom()
+	issuerKP := keypair.MustRandom()
 	assetGOAT := txnbuild.CreditAsset{
 		Code:   "GOAT",
-		Issuer: issuerAccKeyPair.Address(),
+		Issuer: issuerKP.Address(),
 	}
 	horizonMock := horizonclient.MockClient{}
 	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: issuerAccKeyPair.Address()}).
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
 		Return(horizon.Account{
-			Balances: []horizon.Balance{
-				{
-					Asset:   base.Asset{Code: "ASSET", Issuer: issuerAccKeyPair.Address()},
-					Balance: "0",
-				},
-			},
-		}, nil)
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderAccKP.Address()}).
-		Return(horizon.Account{
-			AccountID: senderAccKP.Address(),
+			AccountID: senderKP.Address(),
 			Sequence:  "5",
 		}, nil)
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: receiverAccKP.Address()}).
-		Return(horizon.Account{
-			AccountID: receiverAccKP.Address(),
-			Sequence:  "0",
-		}, nil)
 
-	// Create tx-approve/ txApproveHandler.
 	kycThresholdAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)
 	handler := txApproveHandler{
-		issuerKP:          issuerAccKeyPair,
+		issuerKP:          issuerKP,
 		assetCode:         assetGOAT.GetCode(),
 		horizonClient:     &horizonMock,
 		networkPassphrase: network.TestNetworkPassphrase,
@@ -446,17 +100,17 @@ func TestAPI_RevisedIntegration(t *testing.T) {
 		baseURL:           "https://sep8-server.test",
 	}
 
-	// Prepare revisable "tx".
-	senderAcc, err := handler.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: senderAccKP.Address()})
-	require.NoError(t, err)
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
-			SourceAccount:        &senderAcc,
+			SourceAccount: &horizon.Account{
+				AccountID: senderKP.Address(),
+				Sequence:  "5",
+			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
 				&txnbuild.Payment{
-					SourceAccount: senderAccKP.Address(),
-					Destination:   receiverAccKP.Address(),
+					SourceAccount: senderKP.Address(),
+					Destination:   receiverKP.Address(),
 					Amount:        "1",
 					Asset:         assetGOAT,
 				},
@@ -466,121 +120,95 @@ func TestAPI_RevisedIntegration(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	txEnc, err := tx.Base64()
+	txe, err := tx.Base64()
 	require.NoError(t, err)
 
-	// Send revisable "tx" for "/tx-approve" POST request.
-	req := `{
-		"tx": "` + txEnc + `"
-		}`
 	m := chi.NewMux()
 	m.Post("/tx-approve", handler.ServeHTTP)
+	req := `{
+		"tx": "` + txe + `"
+	}`
 	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
 	r = r.WithContext(ctx)
 	w := httptest.NewRecorder()
 	m.ServeHTTP(w, r)
+
 	resp := w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	// TEST successful "revised" response.
-	var txApprovePOSTResponse txApprovalResponse
-	err = json.Unmarshal(body, &txApprovePOSTResponse)
+	var gotResponse txApprovalResponse
+	err = json.Unmarshal(body, &gotResponse)
 	require.NoError(t, err)
-	wantTXApprovalResponse := txApprovalResponse{
-		Status:  sep8Status("revised"),
-		Tx:      txApprovePOSTResponse.Tx,
-		Message: `Authorization and deauthorization operations were added.`,
-	}
-	assert.Equal(t, wantTXApprovalResponse, txApprovePOSTResponse)
+	require.Equal(t, sep8StatusRevised, gotResponse.Status)
+	require.Equal(t, "Authorization and deauthorization operations were added.", gotResponse.Message)
 
-	// Decode the request's transaction.
-	parsed, err := txnbuild.TransactionFromXDR(txApprovePOSTResponse.Tx)
+	gotGenericTx, err := txnbuild.TransactionFromXDR(gotResponse.Tx)
 	require.NoError(t, err)
-	tx, ok := parsed.Transaction()
+	gotTx, ok := gotGenericTx.Transaction()
 	require.True(t, ok)
 
-	// Check if revised transaction only has 5 operations.
-	require.Len(t, tx.Operations(), 5)
-	// Check Operation 1: AllowTrust op where issuer fully authorizes account A, asset X.
-	op1, ok := tx.Operations()[0].(*txnbuild.AllowTrust)
+	require.Len(t, gotTx.Operations(), 5)
+	// AllowTrust op where issuer fully authorizes account A, asset X
+	op0, ok := gotTx.Operations()[0].(*txnbuild.AllowTrust)
 	require.True(t, ok)
-	assert.Equal(t, op1.Trustor, senderAccKP.Address())
+	assert.Equal(t, op0.Trustor, senderKP.Address())
+	assert.Equal(t, op0.Type.GetCode(), assetGOAT.GetCode())
+	require.True(t, op0.Authorize)
+	// AllowTrust op where issuer fully authorizes account B, asset X
+	op1, ok := gotTx.Operations()[1].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op1.Trustor, receiverKP.Address())
 	assert.Equal(t, op1.Type.GetCode(), assetGOAT.GetCode())
 	require.True(t, op1.Authorize)
-	// Check  Operation 2: AllowTrust op where issuer fully authorizes account B, asset X.
-	op2, ok := tx.Operations()[1].(*txnbuild.AllowTrust)
+	// Payment from A to B
+	op2, ok := gotTx.Operations()[2].(*txnbuild.Payment)
 	require.True(t, ok)
-	assert.Equal(t, op2.Trustor, receiverAccKP.Address())
-	assert.Equal(t, op2.Type.GetCode(), assetGOAT.GetCode())
-	require.True(t, op2.Authorize)
-	// Check Operation 3: Payment from A to B.
-	op3, ok := tx.Operations()[2].(*txnbuild.Payment)
+	assert.Equal(t, op2.Destination, receiverKP.Address())
+	assert.Equal(t, op2.Asset, assetGOAT)
+	// AllowTrust op where issuer fully deauthorizes account B, asset X
+	op3, ok := gotTx.Operations()[3].(*txnbuild.AllowTrust)
 	require.True(t, ok)
-	assert.Equal(t, op3.SourceAccount, senderAccKP.Address())
-	assert.Equal(t, op3.Destination, receiverAccKP.Address())
-	assert.Equal(t, op3.Asset, assetGOAT)
-	// Check Operation 4: AllowTrust op where issuer fully deauthorizes account B, asset X.
-	op4, ok := tx.Operations()[3].(*txnbuild.AllowTrust)
+	assert.Equal(t, op3.Trustor, receiverKP.Address())
+	assert.Equal(t, op3.Type.GetCode(), assetGOAT.GetCode())
+	require.False(t, op3.Authorize)
+	// AllowTrust op where issuer fully deauthorizes account A, asset X
+	op4, ok := gotTx.Operations()[4].(*txnbuild.AllowTrust)
 	require.True(t, ok)
-	assert.Equal(t, op4.Trustor, receiverAccKP.Address())
+	assert.Equal(t, op4.Trustor, senderKP.Address())
 	assert.Equal(t, op4.Type.GetCode(), assetGOAT.GetCode())
 	require.False(t, op4.Authorize)
-	// Check Operation 5: AllowTrust op where issuer fully deauthorizes account A, asset X.
-	op5, ok := tx.Operations()[4].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op5.Trustor, senderAccKP.Address())
-	assert.Equal(t, op5.Type.GetCode(), assetGOAT.GetCode())
-	require.False(t, op5.Authorize)
 }
 
-func TestAPI_KYCIntegration(t *testing.T) {
+func TestAPI_txAprove_actionRequired(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
 	defer conn.Close()
 
-	// Perpare accounts on mock horizon.
-	issuerAccKeyPair := keypair.MustRandom()
-	senderAccKP := keypair.MustRandom()
-	receiverAccKP := keypair.MustRandom()
+	// prepare handler dependencies
+	senderKP := keypair.MustRandom()
+	receiverKP := keypair.MustRandom()
+	issuerKP := keypair.MustRandom()
 	assetGOAT := txnbuild.CreditAsset{
 		Code:   "GOAT",
-		Issuer: issuerAccKeyPair.Address(),
+		Issuer: issuerKP.Address(),
 	}
-	horizonMock := horizonclient.MockClient{}
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: issuerAccKeyPair.Address()}).
-		Return(horizon.Account{
-			Balances: []horizon.Balance{
-				{
-					Asset:   base.Asset{Code: "ASSET", Issuer: issuerAccKeyPair.Address()},
-					Balance: "0",
-				},
-			},
-		}, nil)
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderAccKP.Address()}).
-		Return(horizon.Account{
-			AccountID: senderAccKP.Address(),
-			Sequence:  "5",
-		}, nil)
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: receiverAccKP.Address()}).
-		Return(horizon.Account{
-			AccountID: receiverAccKP.Address(),
-			Sequence:  "0",
-		}, nil)
-
-	// Create tx-approve/ txApproveHandler.
 	kycThresholdAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)
+	horizonMock := horizonclient.MockClient{}
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
+		Return(horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "1",
+		}, nil)
+
 	handler := txApproveHandler{
-		issuerKP:          issuerAccKeyPair,
+		issuerKP:          issuerKP,
 		assetCode:         assetGOAT.GetCode(),
 		horizonClient:     &horizonMock,
 		networkPassphrase: network.TestNetworkPassphrase,
@@ -589,17 +217,23 @@ func TestAPI_KYCIntegration(t *testing.T) {
 		baseURL:           "https://sep8-server.test",
 	}
 
-	// Prepare transaction whose payment amount is <=500 GOATs for /tx-approve POST request.
-	senderAcc, err := handler.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: senderAccKP.Address()})
-	require.NoError(t, err)
+	// setup route handlers
+	m := chi.NewMux()
+	m.Post("/tx-approve", handler.ServeHTTP)
+	m.Post("/kyc-status/{callback_id}", kycstatus.PostHandler{DB: conn}.ServeHTTP)
+
+	// Step 1: Client sends payment with 500+ GOAT
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
-			SourceAccount:        &senderAcc,
+			SourceAccount: &horizon.Account{
+				AccountID: senderKP.Address(),
+				Sequence:  "1",
+			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
 				&txnbuild.Payment{
-					SourceAccount: senderAccKP.Address(),
-					Destination:   receiverAccKP.Address(),
+					SourceAccount: senderKP.Address(),
+					Destination:   receiverKP.Address(),
 					Amount:        "501",
 					Asset:         assetGOAT,
 				},
@@ -609,182 +243,192 @@ func TestAPI_KYCIntegration(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	txEnc, err := tx.Base64()
+	txe, err := tx.Base64()
 	require.NoError(t, err)
 
-	// Send /tx-approve POST request with transaction in request body.
-	req := `{
-		"tx": "` + txEnc + `"
-	}`
-	m := chi.NewMux()
-	m.Post("/tx-approve", handler.ServeHTTP)
-	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(`{"tx": "`+txe+`"}`))
 	r = r.WithContext(ctx)
 	w := httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp := w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	// TEST "action_required" response for sender account.
+	var callbackID string
+	q := `SELECT callback_id FROM accounts_kyc_status WHERE stellar_address = $1`
+	err = conn.QueryRowContext(ctx, q, senderKP.Address()).Scan(&callbackID)
+	require.NoError(t, err)
+
 	var txApprovePOSTResponse txApprovalResponse
 	err = json.Unmarshal(body, &txApprovePOSTResponse)
 	require.NoError(t, err)
 	wantTXApprovalResponse := txApprovalResponse{
 		Status:       sep8Status("action_required"),
-		Message:      `Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.`,
-		ActionURL:    txApprovePOSTResponse.ActionURL,
+		Message:      "Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.",
+		ActionURL:    "https://sep8-server.test/kyc-status/" + callbackID,
 		ActionMethod: "POST",
 		ActionFields: []string{"email_address"},
 	}
 	assert.Equal(t, wantTXApprovalResponse, txApprovePOSTResponse)
+}
 
-	// Setup /kyc-status route for subsequent integration steps.
-	m.Route("/kyc-status", func(mux chi.Router) {
-		mux.Post("/{callback_id}", kycstatus.PostHandler{
-			DB: conn,
-		}.ServeHTTP)
-	})
-	// RxUUID is a regex used to validate correct UUIDs, https://w.wiki/39fK
-	var RxUUID = regexp.MustCompile(
-		`[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}`)
-	// Grab callbackID
-	callbackID := RxUUID.FindAllString(txApprovePOSTResponse.ActionURL, 1)[0]
+func TestAPI_txAprove_actionRequiredFlow(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.Open(t)
+	defer db.Close()
+	conn := db.Open()
+	defer conn.Close()
 
-	// Verify the KYC entree was inserted in db.
-	const q = `
-		SELECT callback_id
-		FROM accounts_kyc_status
-		WHERE stellar_address = $1
-	`
-	var returnedCallbackID string
-	err = handler.db.QueryRowContext(ctx, q, senderAccKP.Address()).Scan(&returnedCallbackID)
+	// prepare handler dependencies
+	senderKP := keypair.MustRandom()
+	receiverKP := keypair.MustRandom()
+	issuerKP := keypair.MustRandom()
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerKP.Address(),
+	}
+	kycThresholdAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)
-	assert.Equal(t, callbackID, returnedCallbackID)
+	horizonMock := horizonclient.MockClient{}
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
+		Return(horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "1",
+		}, nil)
 
-	// Prepare and send /kyc-status/{callback_id} POST request; with an email_address that doesn't start with "x".
-	req = `{
-		"email_address": "TestEmail@email.com"
-	}`
-	r = httptest.NewRequest("POST", fmt.Sprintf("/kyc-status/%s", callbackID), strings.NewReader(req))
+	handler := txApproveHandler{
+		issuerKP:          issuerKP,
+		assetCode:         assetGOAT.GetCode(),
+		horizonClient:     &horizonMock,
+		networkPassphrase: network.TestNetworkPassphrase,
+		db:                conn,
+		kycThreshold:      kycThresholdAmount,
+		baseURL:           "https://sep8-server.test",
+	}
+
+	// setup route handlers
+	m := chi.NewMux()
+	m.Post("/tx-approve", handler.ServeHTTP)
+	m.Post("/kyc-status/{callback_id}", kycstatus.PostHandler{DB: conn}.ServeHTTP)
+
+	// Step 1: client sends payment with 500+ GOAT
+	tx, err := txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount: &horizon.Account{
+				AccountID: senderKP.Address(),
+				Sequence:  "1",
+			},
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.Payment{
+					SourceAccount: senderKP.Address(),
+					Destination:   receiverKP.Address(),
+					Amount:        "501",
+					Asset:         assetGOAT,
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	txe, err := tx.Base64()
+	require.NoError(t, err)
+
+	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(`{"tx": "`+txe+`"}`))
+	r = r.WithContext(ctx)
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, r)
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var callbackID string
+	q := `SELECT callback_id FROM accounts_kyc_status WHERE stellar_address = $1`
+	err = conn.QueryRowContext(ctx, q, senderKP.Address()).Scan(&callbackID)
+	require.NoError(t, err)
+
+	var gotResponse txApprovalResponse
+	err = json.Unmarshal(body, &gotResponse)
+	require.NoError(t, err)
+	wantTXApprovalResponse := txApprovalResponse{
+		Status:       sep8Status("action_required"),
+		Message:      "Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.",
+		ActionURL:    "https://sep8-server.test/kyc-status/" + callbackID,
+		ActionMethod: "POST",
+		ActionFields: []string{"email_address"},
+	}
+	assert.Equal(t, wantTXApprovalResponse, gotResponse)
+
+	// Step 2: client follows up with action required. KYC should get approved for emails not starting with "x"
+	actionMethod := gotResponse.ActionMethod
+	actionURL := gotResponse.ActionURL
+	actionFields := strings.NewReader(`{"email_address": "test@email.com"}`)
+	r = httptest.NewRequest(actionMethod, actionURL, actionFields)
 	r = r.WithContext(ctx)
 	w = httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp = w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-
-	// TEST "no_further_action_required" response for approved account.
 	wantBody := `{"result": "no_further_action_required"}`
 	require.JSONEq(t, wantBody, string(body))
 
-	// Prepare and send /tx-approve POST request to be revised tx via a new /tx-approve POST.
-	req = `{
-		"tx": "` + txEnc + `"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	// Step 3: verify transactions with 500+ GOAT can now be revised
+	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(`{"tx": "`+txe+`"}`))
 	r = r.WithContext(ctx)
 	w = httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp = w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	// TEST "revised" response for approved account.
-	txApprovePOSTResponse = txApprovalResponse{}
-	assert.Empty(t, txApprovePOSTResponse)
-	err = json.Unmarshal(body, &txApprovePOSTResponse)
+	gotResponse = txApprovalResponse{}
+	err = json.Unmarshal(body, &gotResponse)
 	require.NoError(t, err)
-	wantTXApprovalResponse = txApprovalResponse{
-		Status:  sep8Status("revised"),
-		Tx:      txApprovePOSTResponse.Tx,
-		Message: `Authorization and deauthorization operations were added.`,
-	}
-	assert.Equal(t, wantTXApprovalResponse, txApprovePOSTResponse)
+	assert.Equal(t, sep8StatusRevised, gotResponse.Status)
+	assert.Equal(t, "Authorization and deauthorization operations were added.", gotResponse.Message)
+	require.NotEmpty(t, gotResponse.Tx)
 
-	// Decode the request's transaction.
-	parsed, err := txnbuild.TransactionFromXDR(txApprovePOSTResponse.Tx)
-	require.NoError(t, err)
-	tx, ok := parsed.Transaction()
-	require.True(t, ok)
-
-	// Check if revised transaction only has 5 operations.
-	require.Len(t, tx.Operations(), 5)
-	// Check Operation 1: AllowTrust op where issuer fully authorizes account A, asset X.
-	op1, ok := tx.Operations()[0].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op1.Trustor, senderAccKP.Address())
-	assert.Equal(t, op1.Type.GetCode(), assetGOAT.GetCode())
-	require.True(t, op1.Authorize)
-	// Check  Operation 2: AllowTrust op where issuer fully authorizes account B, asset X.
-	op2, ok := tx.Operations()[1].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op2.Trustor, receiverAccKP.Address())
-	assert.Equal(t, op2.Type.GetCode(), assetGOAT.GetCode())
-	require.True(t, op2.Authorize)
-	// Check Operation 3: Payment from A to B.
-	op3, ok := tx.Operations()[2].(*txnbuild.Payment)
-	require.True(t, ok)
-	assert.Equal(t, op3.SourceAccount, senderAccKP.Address())
-	assert.Equal(t, op3.Destination, receiverAccKP.Address())
-	assert.Equal(t, op3.Asset, assetGOAT)
-	// Check Operation 4: AllowTrust op where issuer fully deauthorizes account B, asset X.
-	op4, ok := tx.Operations()[3].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op4.Trustor, receiverAccKP.Address())
-	assert.Equal(t, op4.Type.GetCode(), assetGOAT.GetCode())
-	require.False(t, op4.Authorize)
-	// Check Operation 5: AllowTrust op where issuer fully deauthorizes account A, asset X.
-	op5, ok := tx.Operations()[4].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op5.Trustor, senderAccKP.Address())
-	assert.Equal(t, op5.Type.GetCode(), assetGOAT.GetCode())
-	require.False(t, op5.Authorize)
-
-	// Prepare and send /kyc-status/{callback_id} POST request; with an email_address that starts with "x".
-	req = `{
-		"email_address": "xTestEmail@email.com"
-	}`
-	r = httptest.NewRequest("POST", fmt.Sprintf("/kyc-status/%s", callbackID), strings.NewReader(req))
+	// Step 4: client follows up with action required. KYC should get rejected for emails starting with "x"
+	actionFields = strings.NewReader(`{"email_address": "xtest@email.com"}`)
+	r = httptest.NewRequest(actionMethod, actionURL, actionFields)
 	r = r.WithContext(ctx)
 	w = httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp = w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-
-	// TEST "no_further_action_required" response for approved account.
 	wantBody = `{"result": "no_further_action_required"}`
 	require.JSONEq(t, wantBody, string(body))
 
-	// Prepare and send /tx-approve POST request to be revised tx via a new /tx-approve POST.
-	req = `{
-		"tx": "` + txEnc + `"
-	}`
-	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	// Step 5: verify transactions with 500+ GOAT are rejected
+	r = httptest.NewRequest("POST", "/tx-approve", strings.NewReader(`{"tx": "`+txe+`"}`))
 	r = r.WithContext(ctx)
 	w = httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-
-	// TEST "rejected" response for rejected KYC account.
 	wantBody = `{
-		"status":"rejected", "error":"Your KYC was rejected and you're not authorized for operations above 500.00 GOAT."
+		"status": "rejected",
+		"error": "Your KYC was rejected and you're not authorized for operations above 500.00 GOAT."
 	}`
 	require.JSONEq(t, wantBody, string(body))
 }

--- a/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
@@ -30,21 +30,20 @@ func TestAPI_txApprove_rejected(t *testing.T) {
 	defer conn.Close()
 
 	issuerKP := keypair.MustRandom()
-	horizonMock := horizonclient.MockClient{}
 	kycThresholdAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)
 
 	handler := txApproveHandler{
 		issuerKP:          issuerKP,
 		assetCode:         "FOO",
-		horizonClient:     &horizonMock,
+		horizonClient:     &horizonclient.MockClient{},
 		networkPassphrase: network.TestNetworkPassphrase,
 		db:                conn,
 		kycThreshold:      kycThresholdAmount,
 		baseURL:           "https://example.com",
 	}
 
-	// rejected if no transaction "tx"is submitted
+	// rejected if no transaction "tx" is submitted
 	m := chi.NewMux()
 	m.Post("/tx-approve", handler.ServeHTTP)
 	r := httptest.NewRequest("POST", "/tx-approve", nil)
@@ -72,7 +71,6 @@ func TestAPI_txApprove_revised(t *testing.T) {
 	conn := db.Open()
 	defer conn.Close()
 
-	// Perpare accounts on mock horizon.
 	senderKP := keypair.MustRandom()
 	receiverKP := keypair.MustRandom()
 	issuerKP := keypair.MustRandom()
@@ -80,6 +78,9 @@ func TestAPI_txApprove_revised(t *testing.T) {
 		Code:   "GOAT",
 		Issuer: issuerKP.Address(),
 	}
+	kycThresholdAmount, err := amount.ParseInt64("500")
+	require.NoError(t, err)
+
 	horizonMock := horizonclient.MockClient{}
 	horizonMock.
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
@@ -88,8 +89,6 @@ func TestAPI_txApprove_revised(t *testing.T) {
 			Sequence:  "5",
 		}, nil)
 
-	kycThresholdAmount, err := amount.ParseInt64("500")
-	require.NoError(t, err)
 	handler := txApproveHandler{
 		issuerKP:          issuerKP,
 		assetCode:         assetGOAT.GetCode(),
@@ -125,10 +124,7 @@ func TestAPI_txApprove_revised(t *testing.T) {
 
 	m := chi.NewMux()
 	m.Post("/tx-approve", handler.ServeHTTP)
-	req := `{
-		"tx": "` + txe + `"
-	}`
-	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(req))
+	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(`{"tx": "`+txe+`"}`))
 	r = r.WithContext(ctx)
 	w := httptest.NewRecorder()
 	m.ServeHTTP(w, r)
@@ -151,30 +147,30 @@ func TestAPI_txApprove_revised(t *testing.T) {
 	require.True(t, ok)
 
 	require.Len(t, gotTx.Operations(), 5)
-	// AllowTrust op where issuer fully authorizes account A, asset X
+	// AllowTrust op where issuer fully authorizes sender, asset GOAT
 	op0, ok := gotTx.Operations()[0].(*txnbuild.AllowTrust)
 	require.True(t, ok)
 	assert.Equal(t, op0.Trustor, senderKP.Address())
 	assert.Equal(t, op0.Type.GetCode(), assetGOAT.GetCode())
 	require.True(t, op0.Authorize)
-	// AllowTrust op where issuer fully authorizes account B, asset X
+	// AllowTrust op where issuer fully authorizes receiver, asset GOAT
 	op1, ok := gotTx.Operations()[1].(*txnbuild.AllowTrust)
 	require.True(t, ok)
 	assert.Equal(t, op1.Trustor, receiverKP.Address())
 	assert.Equal(t, op1.Type.GetCode(), assetGOAT.GetCode())
 	require.True(t, op1.Authorize)
-	// Payment from A to B
+	// Payment from sender to receiver
 	op2, ok := gotTx.Operations()[2].(*txnbuild.Payment)
 	require.True(t, ok)
 	assert.Equal(t, op2.Destination, receiverKP.Address())
 	assert.Equal(t, op2.Asset, assetGOAT)
-	// AllowTrust op where issuer fully deauthorizes account B, asset X
+	// AllowTrust op where issuer fully deauthorizes receiver, asset GOAT
 	op3, ok := gotTx.Operations()[3].(*txnbuild.AllowTrust)
 	require.True(t, ok)
 	assert.Equal(t, op3.Trustor, receiverKP.Address())
 	assert.Equal(t, op3.Type.GetCode(), assetGOAT.GetCode())
 	require.False(t, op3.Authorize)
-	// AllowTrust op where issuer fully deauthorizes account A, asset X
+	// AllowTrust op where issuer fully deauthorizes sender, asset GOAT
 	op4, ok := gotTx.Operations()[4].(*txnbuild.AllowTrust)
 	require.True(t, ok)
 	assert.Equal(t, op4.Trustor, senderKP.Address())
@@ -199,6 +195,7 @@ func TestAPI_txAprove_actionRequired(t *testing.T) {
 	}
 	kycThresholdAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)
+
 	horizonMock := horizonclient.MockClient{}
 	horizonMock.
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
@@ -222,7 +219,6 @@ func TestAPI_txAprove_actionRequired(t *testing.T) {
 	m.Post("/tx-approve", handler.ServeHTTP)
 	m.Post("/kyc-status/{callback_id}", kycstatus.PostHandler{DB: conn}.ServeHTTP)
 
-	// Step 1: Client sends payment with 500+ GOAT
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
 			SourceAccount: &horizon.Account{
@@ -261,17 +257,17 @@ func TestAPI_txAprove_actionRequired(t *testing.T) {
 	err = conn.QueryRowContext(ctx, q, senderKP.Address()).Scan(&callbackID)
 	require.NoError(t, err)
 
-	var txApprovePOSTResponse txApprovalResponse
-	err = json.Unmarshal(body, &txApprovePOSTResponse)
+	var gotTxApprovalResponse txApprovalResponse
+	err = json.Unmarshal(body, &gotTxApprovalResponse)
 	require.NoError(t, err)
-	wantTXApprovalResponse := txApprovalResponse{
+	wantTxApprovalResponse := txApprovalResponse{
 		Status:       sep8Status("action_required"),
 		Message:      "Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.",
 		ActionURL:    "https://example.com/kyc-status/" + callbackID,
 		ActionMethod: "POST",
 		ActionFields: []string{"email_address"},
 	}
-	assert.Equal(t, wantTXApprovalResponse, txApprovePOSTResponse)
+	assert.Equal(t, wantTxApprovalResponse, gotTxApprovalResponse)
 }
 
 func TestAPI_txAprove_actionRequiredFlow(t *testing.T) {
@@ -291,6 +287,7 @@ func TestAPI_txAprove_actionRequiredFlow(t *testing.T) {
 	}
 	kycThresholdAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)
+
 	horizonMock := horizonclient.MockClient{}
 	horizonMock.
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
@@ -353,21 +350,21 @@ func TestAPI_txAprove_actionRequiredFlow(t *testing.T) {
 	err = conn.QueryRowContext(ctx, q, senderKP.Address()).Scan(&callbackID)
 	require.NoError(t, err)
 
-	var gotResponse txApprovalResponse
-	err = json.Unmarshal(body, &gotResponse)
+	var gotTxApprovalResponse txApprovalResponse
+	err = json.Unmarshal(body, &gotTxApprovalResponse)
 	require.NoError(t, err)
-	wantTXApprovalResponse := txApprovalResponse{
+	wantTxApprovalResponse := txApprovalResponse{
 		Status:       sep8Status("action_required"),
 		Message:      "Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.",
 		ActionURL:    "https://example.com/kyc-status/" + callbackID,
 		ActionMethod: "POST",
 		ActionFields: []string{"email_address"},
 	}
-	assert.Equal(t, wantTXApprovalResponse, gotResponse)
+	assert.Equal(t, wantTxApprovalResponse, gotTxApprovalResponse)
 
 	// Step 2: client follows up with action required. KYC should get approved for emails not starting with "x"
-	actionMethod := gotResponse.ActionMethod
-	actionURL := gotResponse.ActionURL
+	actionMethod := gotTxApprovalResponse.ActionMethod
+	actionURL := gotTxApprovalResponse.ActionURL
 	actionFields := strings.NewReader(`{"email_address": "test@email.com"}`)
 	r = httptest.NewRequest(actionMethod, actionURL, actionFields)
 	r = r.WithContext(ctx)
@@ -393,14 +390,14 @@ func TestAPI_txAprove_actionRequiredFlow(t *testing.T) {
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	gotResponse = txApprovalResponse{}
-	err = json.Unmarshal(body, &gotResponse)
+	gotTxApprovalResponse = txApprovalResponse{}
+	err = json.Unmarshal(body, &gotTxApprovalResponse)
 	require.NoError(t, err)
-	assert.Equal(t, sep8StatusRevised, gotResponse.Status)
-	assert.Equal(t, "Authorization and deauthorization operations were added.", gotResponse.Message)
-	require.NotEmpty(t, gotResponse.Tx)
+	assert.Equal(t, sep8StatusRevised, gotTxApprovalResponse.Status)
+	assert.Equal(t, "Authorization and deauthorization operations were added.", gotTxApprovalResponse.Message)
+	require.NotEmpty(t, gotTxApprovalResponse.Tx)
 
-	// Step 4: client follows up with action required. KYC should get rejected for emails starting with "x"
+	// Step 4: client follows up with action required again. This time KYC will get rejected as the email starts with "x"
 	actionFields = strings.NewReader(`{"email_address": "xtest@email.com"}`)
 	r = httptest.NewRequest(actionMethod, actionURL, actionFields)
 	r = r.WithContext(ctx)

--- a/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
@@ -41,7 +41,7 @@ func TestAPI_txApprove_rejected(t *testing.T) {
 		networkPassphrase: network.TestNetworkPassphrase,
 		db:                conn,
 		kycThreshold:      kycThresholdAmount,
-		baseURL:           "https://sep8-server.test",
+		baseURL:           "https://example.com",
 	}
 
 	// rejected if no transaction "tx"is submitted
@@ -97,7 +97,7 @@ func TestAPI_txApprove_revised(t *testing.T) {
 		networkPassphrase: network.TestNetworkPassphrase,
 		db:                conn,
 		kycThreshold:      kycThresholdAmount,
-		baseURL:           "https://sep8-server.test",
+		baseURL:           "https://example.com",
 	}
 
 	tx, err := txnbuild.NewTransaction(
@@ -214,7 +214,7 @@ func TestAPI_txAprove_actionRequired(t *testing.T) {
 		networkPassphrase: network.TestNetworkPassphrase,
 		db:                conn,
 		kycThreshold:      kycThresholdAmount,
-		baseURL:           "https://sep8-server.test",
+		baseURL:           "https://example.com",
 	}
 
 	// setup route handlers
@@ -267,7 +267,7 @@ func TestAPI_txAprove_actionRequired(t *testing.T) {
 	wantTXApprovalResponse := txApprovalResponse{
 		Status:       sep8Status("action_required"),
 		Message:      "Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.",
-		ActionURL:    "https://sep8-server.test/kyc-status/" + callbackID,
+		ActionURL:    "https://example.com/kyc-status/" + callbackID,
 		ActionMethod: "POST",
 		ActionFields: []string{"email_address"},
 	}
@@ -306,7 +306,7 @@ func TestAPI_txAprove_actionRequiredFlow(t *testing.T) {
 		networkPassphrase: network.TestNetworkPassphrase,
 		db:                conn,
 		kycThreshold:      kycThresholdAmount,
-		baseURL:           "https://sep8-server.test",
+		baseURL:           "https://example.com",
 	}
 
 	// setup route handlers
@@ -359,7 +359,7 @@ func TestAPI_txAprove_actionRequiredFlow(t *testing.T) {
 	wantTXApprovalResponse := txApprovalResponse{
 		Status:       sep8Status("action_required"),
 		Message:      "Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.",
-		ActionURL:    "https://sep8-server.test/kyc-status/" + callbackID,
+		ActionURL:    "https://example.com/kyc-status/" + callbackID,
 		ActionMethod: "POST",
 		ActionFields: []string{"email_address"},
 	}

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
@@ -189,7 +189,7 @@ func TestTxApproveHandler_validateInput(t *testing.T) {
 	require.Equal(t, NewRejectedTxApprovalResponse("Please submit a transaction with exactly one operation of type payment."), txApprovalResp)
 	require.Nil(t, gotTx)
 
-	// success
+	// validation success
 	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: clientKP.Address(),
@@ -232,7 +232,7 @@ func TestTxApproveHandler_handleActionRequiredResponseIfNeeded(t *testing.T) {
 		db:           conn,
 	}
 
-	// payments smaller than or equal the threshold are not "action_required"
+	// payments up to the the threshold won't trigger "action_required"
 	clientKP := keypair.MustRandom()
 	paymentOp := &txnbuild.Payment{
 		Amount: amount.StringFromInt64(kycThreshold),
@@ -241,7 +241,7 @@ func TestTxApproveHandler_handleActionRequiredResponseIfNeeded(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, txApprovalResp)
 
-	// payments greater than the threshold are "action_required"
+	// payments greater than the threshold will trigger "action_required"
 	paymentOp = &txnbuild.Payment{
 		Amount: amount.StringFromInt64(kycThreshold + 1),
 	}
@@ -263,7 +263,7 @@ func TestTxApproveHandler_handleActionRequiredResponseIfNeeded(t *testing.T) {
 	}
 	require.Equal(t, wantResp, txApprovalResp)
 
-	// test addresses with approved KYC
+	// if KYC was previously approved, handleActionRequiredResponseIfNeeded will return nil
 	q = `
 		UPDATE accounts_kyc_status
 		SET 
@@ -277,7 +277,7 @@ func TestTxApproveHandler_handleActionRequiredResponseIfNeeded(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, txApprovalResp)
 
-	// test addresses with rejected KYC
+	// if KYC was previously rejected, handleActionRequiredResponseIfNeeded will return a "rejected" response
 	q = `
 		UPDATE accounts_kyc_status
 		SET 
@@ -292,17 +292,23 @@ func TestTxApproveHandler_handleActionRequiredResponseIfNeeded(t *testing.T) {
 	require.Equal(t, NewRejectedTxApprovalResponse("Your KYC was rejected and you're not authorized for operations above 500.00 FOO."), txApprovalResp)
 }
 
-func TestTxApproveHandlerTxApprove_rejected(t *testing.T) {
+func TestTxApproveHandler_txApprove_rejected(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
 	defer conn.Close()
 
-	// prepare accounts on mock horizon
-	issuerKP := keypair.MustRandom()
 	senderKP := keypair.MustRandom()
 	receiverKP := keypair.MustRandom()
+	issuerKP := keypair.MustRandom()
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerKP.Address(),
+	}
+	kycThresholdAmount, err := amount.ParseInt64("500")
+	require.NoError(t, err)
+
 	horizonMock := horizonclient.MockClient{}
 	horizonMock.
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
@@ -311,13 +317,6 @@ func TestTxApproveHandlerTxApprove_rejected(t *testing.T) {
 			Sequence:  "2",
 		}, nil)
 
-	// prepare txApproveHandler
-	kycThresholdAmount, err := amount.ParseInt64("500")
-	require.NoError(t, err)
-	assetGOAT := txnbuild.CreditAsset{
-		Code:   "GOAT",
-		Issuer: issuerKP.Address(),
-	}
 	handler := txApproveHandler{
 		issuerKP:          issuerKP,
 		assetCode:         assetGOAT.GetCode(),
@@ -434,17 +433,23 @@ func TestTxApproveHandlerTxApprove_rejected(t *testing.T) {
 	assert.Equal(t, wantTxApprovalResp, txApprovalResp)
 }
 
-func TestTxApproveHandlerTxApprove_actionRequired(t *testing.T) {
+func TestTxApproveHandler_txApprove_actionRequired(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
 	defer conn.Close()
 
-	// prepare accounts on mock horizon
-	issuerKP := keypair.MustRandom()
 	senderKP := keypair.MustRandom()
 	receiverKP := keypair.MustRandom()
+	issuerKP := keypair.MustRandom()
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerKP.Address(),
+	}
+	kycThresholdAmount, err := amount.ParseInt64("500")
+	require.NoError(t, err)
+
 	horizonMock := horizonclient.MockClient{}
 	horizonMock.
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
@@ -453,13 +458,6 @@ func TestTxApproveHandlerTxApprove_actionRequired(t *testing.T) {
 			Sequence:  "2",
 		}, nil)
 
-	// prepare txApproveHandler
-	kycThresholdAmount, err := amount.ParseInt64("500")
-	require.NoError(t, err)
-	assetGOAT := txnbuild.CreditAsset{
-		Code:   "GOAT",
-		Issuer: issuerKP.Address(),
-	}
 	handler := txApproveHandler{
 		issuerKP:          issuerKP,
 		assetCode:         assetGOAT.GetCode(),
@@ -470,7 +468,6 @@ func TestTxApproveHandlerTxApprove_actionRequired(t *testing.T) {
 		baseURL:           "https://example.com",
 	}
 
-	// rejected if sequence number is not incremental
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
 			SourceAccount: &horizon.Account{
@@ -512,17 +509,23 @@ func TestTxApproveHandlerTxApprove_actionRequired(t *testing.T) {
 	require.Equal(t, wantResp, txApprovalResp)
 }
 
-func TestTxApproveHandlerTxApprove_revised(t *testing.T) {
+func TestTxApproveHandler_txApprove_revised(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
 	defer conn.Close()
 
-	// prepare accounts on mock horizon
-	issuerKP := keypair.MustRandom()
 	senderKP := keypair.MustRandom()
 	receiverKP := keypair.MustRandom()
+	issuerKP := keypair.MustRandom()
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerKP.Address(),
+	}
+	kycThresholdAmount, err := amount.ParseInt64("500")
+	require.NoError(t, err)
+
 	horizonMock := horizonclient.MockClient{}
 	horizonMock.
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
@@ -531,13 +534,6 @@ func TestTxApproveHandlerTxApprove_revised(t *testing.T) {
 			Sequence:  "2",
 		}, nil)
 
-	// prepare txApproveHandler
-	kycThresholdAmount, err := amount.ParseInt64("500")
-	require.NoError(t, err)
-	assetGOAT := txnbuild.CreditAsset{
-		Code:   "GOAT",
-		Issuer: issuerKP.Address(),
-	}
 	handler := txApproveHandler{
 		issuerKP:          issuerKP,
 		assetCode:         assetGOAT.GetCode(),
@@ -548,7 +544,6 @@ func TestTxApproveHandlerTxApprove_revised(t *testing.T) {
 		baseURL:           "https://example.com",
 	}
 
-	// rejected if sequence number is not incremental
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
 			SourceAccount: &horizon.Account{
@@ -585,30 +580,30 @@ func TestTxApproveHandlerTxApprove_revised(t *testing.T) {
 	require.Equal(t, int64(3), gotTx.SourceAccount().Sequence)
 
 	require.Len(t, gotTx.Operations(), 5)
-	// AllowTrust op where issuer fully authorizes account A, asset X
+	// AllowTrust op where issuer fully authorizes sender, asset GOAT
 	op0, ok := gotTx.Operations()[0].(*txnbuild.AllowTrust)
 	require.True(t, ok)
 	assert.Equal(t, op0.Trustor, senderKP.Address())
 	assert.Equal(t, op0.Type.GetCode(), assetGOAT.GetCode())
 	require.True(t, op0.Authorize)
-	// AllowTrust op where issuer fully authorizes account B, asset X
+	// AllowTrust op where issuer fully authorizes receiver, asset GOAT
 	op1, ok := gotTx.Operations()[1].(*txnbuild.AllowTrust)
 	require.True(t, ok)
 	assert.Equal(t, op1.Trustor, receiverKP.Address())
 	assert.Equal(t, op1.Type.GetCode(), assetGOAT.GetCode())
 	require.True(t, op1.Authorize)
-	// Payment from A to B
+	// Payment from sender to receiver
 	op2, ok := gotTx.Operations()[2].(*txnbuild.Payment)
 	require.True(t, ok)
 	assert.Equal(t, op2.Destination, receiverKP.Address())
 	assert.Equal(t, op2.Asset, assetGOAT)
-	// AllowTrust op where issuer fully deauthorizes account B, asset X
+	// AllowTrust op where issuer fully deauthorizes receiver, asset GOAT
 	op3, ok := gotTx.Operations()[3].(*txnbuild.AllowTrust)
 	require.True(t, ok)
 	assert.Equal(t, op3.Trustor, receiverKP.Address())
 	assert.Equal(t, op3.Type.GetCode(), assetGOAT.GetCode())
 	require.False(t, op3.Authorize)
-	// AllowTrust op where issuer fully deauthorizes account A, asset X
+	// AllowTrust op where issuer fully deauthorizes sender, asset GOAT
 	op4, ok := gotTx.Operations()[4].(*txnbuild.AllowTrust)
 	require.True(t, ok)
 	assert.Equal(t, op4.Trustor, senderKP.Address())

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
@@ -105,7 +105,7 @@ func TestTxApproveHandlerValidate(t *testing.T) {
 		networkPassphrase: network.TestNetworkPassphrase,
 		db:                conn,
 		kycThreshold:      1,
-		baseURL:           "https://sep8-server.test",
+		baseURL:           "https://example.com",
 	}
 	err = h.validate()
 	require.NoError(t, err)
@@ -227,7 +227,7 @@ func TestTxApproveHandler_handleActionRequiredResponseIfNeeded(t *testing.T) {
 	require.NoError(t, err)
 	h := txApproveHandler{
 		assetCode:    "FOO",
-		baseURL:      "https://sep8-server.test",
+		baseURL:      "https://example.com",
 		kycThreshold: kycThreshold,
 		db:           conn,
 	}
@@ -258,7 +258,7 @@ func TestTxApproveHandler_handleActionRequiredResponseIfNeeded(t *testing.T) {
 		Message:      "Payments exceeding 500.00 FOO require KYC approval. Please provide an email address.",
 		ActionMethod: "POST",
 		StatusCode:   http.StatusOK,
-		ActionURL:    "https://sep8-server.test/kyc-status/" + callbackID,
+		ActionURL:    "https://example.com/kyc-status/" + callbackID,
 		ActionFields: []string{"email_address"},
 	}
 	require.Equal(t, wantResp, txApprovalResp)
@@ -325,7 +325,7 @@ func TestTxApproveHandlerTxApprove_rejected(t *testing.T) {
 		networkPassphrase: network.TestNetworkPassphrase,
 		db:                conn,
 		kycThreshold:      kycThresholdAmount,
-		baseURL:           "https://sep8-server.test",
+		baseURL:           "https://example.com",
 	}
 
 	// "rejected" if tx is empty
@@ -467,7 +467,7 @@ func TestTxApproveHandlerTxApprove_actionRequired(t *testing.T) {
 		networkPassphrase: network.TestNetworkPassphrase,
 		db:                conn,
 		kycThreshold:      kycThresholdAmount,
-		baseURL:           "https://sep8-server.test",
+		baseURL:           "https://example.com",
 	}
 
 	// rejected if sequence number is not incremental
@@ -506,7 +506,7 @@ func TestTxApproveHandlerTxApprove_actionRequired(t *testing.T) {
 		Message:      "Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.",
 		ActionMethod: "POST",
 		StatusCode:   http.StatusOK,
-		ActionURL:    "https://sep8-server.test/kyc-status/" + callbackID,
+		ActionURL:    "https://example.com/kyc-status/" + callbackID,
 		ActionFields: []string{"email_address"},
 	}
 	require.Equal(t, wantResp, txApprovalResp)
@@ -545,7 +545,7 @@ func TestTxApproveHandlerTxApprove_revised(t *testing.T) {
 		networkPassphrase: network.TestNetworkPassphrase,
 		db:                conn,
 		kycThreshold:      kycThresholdAmount,
-		baseURL:           "https://sep8-server.test",
+		baseURL:           "https://example.com",
 	}
 
 	// rejected if sequence number is not incremental

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/protocols/horizon"
-	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stellar/go/services/regulated-assets-approval-server/internal/db/dbtest"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +17,7 @@ import (
 )
 
 func TestTxApproveHandlerValidate(t *testing.T) {
-	// empty asset issuer KP.
+	// empty issuer KP.
 	h := txApproveHandler{}
 	err := h.validate()
 	require.EqualError(t, err, "issuer keypair cannot be nil")
@@ -112,25 +111,109 @@ func TestTxApproveHandlerValidate(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestConvertAmountToReadableString(t *testing.T) {
-	// Prepare raw int64 amountValue.
-	// Context: stellar-core represents asset "amounts" as 64-bit so amounts shown as "500" is represented in stellar-core as 5000000000.
-	var amountValue int64 = 5000000000
+func TestTxApproveHandler_validateInput(t *testing.T) {
+	h := txApproveHandler{}
+	ctx := context.Background()
 
-	// TEST if no error and if "500.00" returned
-	amountString, err := convertAmountToReadableString(amountValue)
+	// rejects if incoming tx is empty
+	in := txApproveRequest{}
+	txApprovalResp, gotTx := h.validateInput(ctx, in)
+	require.Equal(t, NewRejectedTxApprovalResponse("Missing parameter \"tx\"."), txApprovalResp)
+	require.Nil(t, gotTx)
+
+	// rejects if incoming tx is invalid
+	in = txApproveRequest{Tx: "foobar"}
+	txApprovalResp, gotTx = h.validateInput(ctx, in)
+	require.Equal(t, NewRejectedTxApprovalResponse("Invalid parameter \"tx\"."), txApprovalResp)
+	require.Nil(t, gotTx)
+
+	// rejects if incoming tx is a fee bump transaction
+	in = txApproveRequest{Tx: "AAAABQAAAAAo/cVyQxyGh7F/Vsj0BzfDYuOJvrwgfHGyqYFpHB5RCAAAAAAAAADIAAAAAgAAAAAo/cVyQxyGh7F/Vsj0BzfDYuOJvrwgfHGyqYFpHB5RCAAAAGQAEfDJAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAo/cVyQxyGh7F/Vsj0BzfDYuOJvrwgfHGyqYFpHB5RCAAAAAAAAAAAAJiWgAAAAAAAAAAAAAAAAAAAAAA="}
+	txApprovalResp, gotTx = h.validateInput(ctx, in)
+	require.Equal(t, NewRejectedTxApprovalResponse("Invalid parameter \"tx\"."), txApprovalResp)
+	require.Nil(t, gotTx)
+
+	// rejects if tx source account is the issuer
+	clientKP := keypair.MustRandom()
+	h.issuerKP = keypair.MustRandom()
+
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &horizon.Account{
+			AccountID: h.issuerKP.Address(),
+			Sequence:  "1",
+		},
+		IncrementSequenceNum: true,
+		Timebounds:           txnbuild.NewInfiniteTimeout(),
+		BaseFee:              300,
+		Operations: []txnbuild.Operation{
+			&txnbuild.Payment{
+				Destination: clientKP.Address(),
+				Amount:      "1",
+				Asset:       txnbuild.NativeAsset{},
+			},
+		},
+	})
 	require.NoError(t, err)
-	assert.Equal(t, "500.00", amountString)
-
-	// Prepare amount parsed Int64 from string
-	// Context: env var KYCRequiredPaymentAmountThreshold is the token's unit quantity represented as string.
-	// This string is converted to int64 and passed to the txApproveHandler for payment evaluation.
-	parsedThresholdResult, err := amount.ParseInt64("500")
-
-	// TEST if no error and if "500.00" returned
-	amountString, err = convertAmountToReadableString(parsedThresholdResult)
+	txe, err := tx.Base64()
 	require.NoError(t, err)
-	assert.Equal(t, "500.00", amountString)
+
+	in.Tx = txe
+	txApprovalResp, gotTx = h.validateInput(ctx, in)
+	require.Equal(t, NewRejectedTxApprovalResponse("Transaction source account is invalid."), txApprovalResp)
+	require.Nil(t, gotTx)
+
+	// rejects if tx contains more than one operation
+	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &horizon.Account{
+			AccountID: clientKP.Address(),
+			Sequence:  "1",
+		},
+		IncrementSequenceNum: true,
+		Timebounds:           txnbuild.NewInfiniteTimeout(),
+		BaseFee:              300,
+		Operations: []txnbuild.Operation{
+			&txnbuild.BumpSequence{},
+			&txnbuild.Payment{
+				Destination: clientKP.Address(),
+				Amount:      "1.0000000",
+				Asset:       txnbuild.NativeAsset{},
+			},
+		},
+	})
+	require.NoError(t, err)
+	txe, err = tx.Base64()
+	require.NoError(t, err)
+
+	in.Tx = txe
+	txApprovalResp, gotTx = h.validateInput(ctx, in)
+	require.Equal(t, NewRejectedTxApprovalResponse("Please submit a transaction with exactly one operation of type payment."), txApprovalResp)
+	require.Nil(t, gotTx)
+
+	// success
+	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &horizon.Account{
+			AccountID: clientKP.Address(),
+			Sequence:  "1",
+		},
+		IncrementSequenceNum: true,
+		Timebounds:           txnbuild.NewInfiniteTimeout(),
+		BaseFee:              300,
+		Operations: []txnbuild.Operation{
+			&txnbuild.Payment{
+				Destination: clientKP.Address(),
+				Amount:      "1.0000000",
+				Asset:       txnbuild.NativeAsset{},
+			},
+		},
+	})
+	require.NoError(t, err)
+	txe, err = tx.Base64()
+	require.NoError(t, err)
+
+	in.Tx = txe
+	txApprovalResp, gotTx = h.validateInput(ctx, in)
+	require.Nil(t, txApprovalResp)
+	require.Equal(t, gotTx, tx)
 }
 
 func TestTxApproveHandler_handleActionRequiredResponseIfNeeded(t *testing.T) {
@@ -140,110 +223,103 @@ func TestTxApproveHandler_handleActionRequiredResponseIfNeeded(t *testing.T) {
 	conn := db.Open()
 	defer conn.Close()
 
-	// Create tx-approve/ txApproveHandler.
-	issuerAccKeyPair := keypair.MustRandom()
-	horizonMock := horizonclient.MockClient{}
-	kycThresholdAmount, err := amount.ParseInt64("500")
+	kycThreshold, err := amount.ParseInt64("500")
 	require.NoError(t, err)
-	assetGOAT := txnbuild.CreditAsset{
-		Code:   "GOAT",
-		Issuer: issuerAccKeyPair.Address(),
-	}
 	h := txApproveHandler{
-		issuerKP:          issuerAccKeyPair,
-		assetCode:         assetGOAT.GetCode(),
-		horizonClient:     &horizonMock,
-		networkPassphrase: network.TestNetworkPassphrase,
-		db:                conn,
-		kycThreshold:      kycThresholdAmount,
-		baseURL:           "https://sep8-server.test",
+		assetCode:    "FOO",
+		baseURL:      "https://sep8-server.test",
+		kycThreshold: kycThreshold,
+		db:           conn,
 	}
 
-	// TEST if txApproveHandler is valid.
-	err = h.validate()
-	require.NoError(t, err)
-
-	// Prepare payment op whose amount is greater than 500 GOATs.
-	sourceKP := keypair.MustRandom()
-	destinationKP := keypair.MustRandom()
-	paymentOP := txnbuild.Payment{
-		SourceAccount: sourceKP.Address(),
-		Destination:   destinationKP.Address(),
-		Amount:        "501",
-		Asset:         assetGOAT,
+	// payments smaller than or equal the threshold are not "action_required"
+	clientKP := keypair.MustRandom()
+	paymentOp := &txnbuild.Payment{
+		Amount: amount.StringFromInt64(kycThreshold),
 	}
-
-	// TEST successful "action_required" response.
-	actionRequiredTxApprovalResponse, err := h.handleActionRequiredResponseIfNeeded(ctx, sourceKP.Address(), &paymentOP)
+	txApprovalResp, err := h.handleActionRequiredResponseIfNeeded(ctx, clientKP.Address(), paymentOp)
 	require.NoError(t, err)
-	wantTXApprovalResponse := txApprovalResponse{
-		Status:       sep8Status("action_required"),
-		Message:      `Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.`,
-		StatusCode:   http.StatusOK,
-		ActionURL:    actionRequiredTxApprovalResponse.ActionURL,
+	require.Nil(t, txApprovalResp)
+
+	// payments greater than the threshold are "action_required"
+	paymentOp = &txnbuild.Payment{
+		Amount: amount.StringFromInt64(kycThreshold + 1),
+	}
+	txApprovalResp, err = h.handleActionRequiredResponseIfNeeded(ctx, clientKP.Address(), paymentOp)
+	require.NoError(t, err)
+
+	var callbackID string
+	q := `SELECT callback_id FROM accounts_kyc_status WHERE stellar_address = $1`
+	err = conn.QueryRowContext(ctx, q, clientKP.Address()).Scan(&callbackID)
+	require.NoError(t, err)
+
+	wantResp := &txApprovalResponse{
+		Status:       sep8StatusActionRequired,
+		Message:      "Payments exceeding 500.00 FOO require KYC approval. Please provide an email address.",
 		ActionMethod: "POST",
+		StatusCode:   http.StatusOK,
+		ActionURL:    "https://sep8-server.test/kyc-status/" + callbackID,
 		ActionFields: []string{"email_address"},
 	}
-	assert.Equal(t, &wantTXApprovalResponse, actionRequiredTxApprovalResponse)
+	require.Equal(t, wantResp, txApprovalResp)
 
-	// TEST if the kyc attempt was logged in db's accounts_kyc_status table.
-	const q = `
-	SELECT stellar_address
-	FROM accounts_kyc_status
-	WHERE stellar_address = $1
+	// test addresses with approved KYC
+	q = `
+		UPDATE accounts_kyc_status
+		SET 
+			approved_at = NOW(),
+			rejected_at = NULL
+		WHERE stellar_address = $1
 	`
-	var stellarAddress string
-	err = h.db.QueryRowContext(ctx, q, sourceKP.Address()).Scan(&stellarAddress)
+	_, err = conn.ExecContext(ctx, q, clientKP.Address())
 	require.NoError(t, err)
-	assert.Equal(t, sourceKP.Address(), stellarAddress)
+	txApprovalResp, err = h.handleActionRequiredResponseIfNeeded(ctx, clientKP.Address(), paymentOp)
+	require.NoError(t, err)
+	require.Nil(t, txApprovalResp)
+
+	// test addresses with rejected KYC
+	q = `
+		UPDATE accounts_kyc_status
+		SET 
+			approved_at = NULL,
+			rejected_at = NOW()
+		WHERE stellar_address = $1
+	`
+	_, err = conn.ExecContext(ctx, q, clientKP.Address())
+	require.NoError(t, err)
+	txApprovalResp, err = h.handleActionRequiredResponseIfNeeded(ctx, clientKP.Address(), paymentOp)
+	require.NoError(t, err)
+	require.Equal(t, NewRejectedTxApprovalResponse("Your KYC was rejected and you're not authorized for operations above 500.00 FOO."), txApprovalResp)
 }
 
-func TestTxApproveHandlerTxApprove(t *testing.T) {
+func TestTxApproveHandlerTxApprove_rejected(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
 	defer conn.Close()
 
-	// Perpare accounts on mock horizon.
-	issuerAccKeyPair := keypair.MustRandom()
-	senderAccKP := keypair.MustRandom()
-	receiverAccKP := keypair.MustRandom()
-	assetGOAT := txnbuild.CreditAsset{
-		Code:   "GOAT",
-		Issuer: issuerAccKeyPair.Address(),
-	}
+	// prepare accounts on mock horizon
+	issuerKP := keypair.MustRandom()
+	senderKP := keypair.MustRandom()
+	receiverKP := keypair.MustRandom()
 	horizonMock := horizonclient.MockClient{}
 	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: issuerAccKeyPair.Address()}).
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
 		Return(horizon.Account{
-			AccountID: issuerAccKeyPair.Address(),
-			Sequence:  "1",
-			Balances: []horizon.Balance{
-				{
-					Asset:   base.Asset{Code: "ASSET", Issuer: issuerAccKeyPair.Address()},
-					Balance: "0",
-				},
-			},
-		}, nil)
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderAccKP.Address()}).
-		Return(horizon.Account{
-			AccountID: senderAccKP.Address(),
+			AccountID: senderKP.Address(),
 			Sequence:  "2",
 		}, nil)
-	horizonMock.
-		On("AccountDetail", horizonclient.AccountRequest{AccountID: receiverAccKP.Address()}).
-		Return(horizon.Account{
-			AccountID: receiverAccKP.Address(),
-			Sequence:  "3",
-		}, nil)
 
-	// Create tx-approve/ txApproveHandler.
+	// prepare txApproveHandler
 	kycThresholdAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerKP.Address(),
+	}
 	handler := txApproveHandler{
-		issuerKP:          issuerAccKeyPair,
+		issuerKP:          issuerKP,
 		assetCode:         assetGOAT.GetCode(),
 		horizonClient:     &horizonMock,
 		networkPassphrase: network.TestNetworkPassphrase,
@@ -252,11 +328,8 @@ func TestTxApproveHandlerTxApprove(t *testing.T) {
 		baseURL:           "https://sep8-server.test",
 	}
 
-	// TEST "rejected" response if no transaction is submitted; with empty "tx" for txApprove.
-	req := txApproveRequest{
-		Tx: "",
-	}
-	rejectedResponse, err := handler.txApprove(ctx, req)
+	// "rejected" if tx is empty
+	rejectedResponse, err := handler.txApprove(ctx, txApproveRequest{})
 	require.NoError(t, err)
 	wantRejectedResponse := txApprovalResponse{
 		Status:     "rejected",
@@ -265,212 +338,50 @@ func TestTxApproveHandlerTxApprove(t *testing.T) {
 	}
 	assert.Equal(t, &wantRejectedResponse, rejectedResponse)
 
-	// TEST "rejected" response if can't parse XDR; with malformed "tx" for txApprove.
-	req = txApproveRequest{
-		Tx: "BADXDRTRANSACTIONENVELOPE",
-	}
-	rejectedResponse, err = handler.txApprove(ctx, req)
-	require.NoError(t, err)
-	wantRejectedResponse = txApprovalResponse{
-		Status:     "rejected",
-		Error:      `Invalid parameter "tx".`,
-		StatusCode: http.StatusBadRequest,
-	}
-	assert.Equal(t, &wantRejectedResponse, rejectedResponse)
-
-	// Prepare invalid(non generic transaction) "tx" for txApprove.
-	senderAcc, err := handler.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: senderAccKP.Address()})
-	require.NoError(t, err)
+	// rejected if the single operation is not a payment
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
-			SourceAccount:        &senderAcc,
+			SourceAccount: &horizon.Account{
+				AccountID: senderKP.Address(),
+				Sequence:  "2",
+			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					Destination: receiverAccKP.Address(),
-					Amount:      "1",
-					Asset:       assetGOAT,
-				},
+				&txnbuild.BumpSequence{},
 			},
 			BaseFee:    txnbuild.MinBaseFee,
 			Timebounds: txnbuild.NewInfiniteTimeout(),
 		},
 	)
 	require.NoError(t, err)
-	feeBumpTx, err := txnbuild.NewFeeBumpTransaction(
-		txnbuild.FeeBumpTransactionParams{
-			Inner:      tx,
-			FeeAccount: receiverAccKP.Address(),
-			BaseFee:    2 * txnbuild.MinBaseFee,
-		},
-	)
-	require.NoError(t, err)
-	feeBumpTxEnc, err := feeBumpTx.Base64()
+	txe, err := tx.Base64()
 	require.NoError(t, err)
 
-	// TEST "rejected" response if a non generic transaction fails, same result as malformed XDR.
-	req = txApproveRequest{
-		Tx: feeBumpTxEnc,
-	}
-	rejectedResponse, err = handler.txApprove(ctx, req)
+	txApprovalResp, err := handler.txApprove(ctx, txApproveRequest{Tx: txe})
 	require.NoError(t, err)
-	assert.Equal(t, &wantRejectedResponse, rejectedResponse) // wantRejectedResponse is identical to "if can't parse XDR".
-
-	// Prepare transaction sourceAccount the same as the server issuer account for txApprove.
-	issuerAcc, err := handler.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: issuerAccKeyPair.Address()})
-	require.NoError(t, err)
-	tx, err = txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &issuerAcc,
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					Destination: senderAccKP.Address(),
-					Amount:      "1",
-					Asset:       assetGOAT,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txEnc, err := tx.Base64()
-	require.NoError(t, err)
-
-	// TEST "rejected" response for sender account; transaction sourceAccount the same as the server issuer account.
-	req = txApproveRequest{
-		Tx: txEnc,
-	}
-	rejectedResponse, err = handler.txApprove(ctx, req)
-	require.NoError(t, err)
-	wantRejectedResponse = txApprovalResponse{
-		Status:     "rejected",
-		Error:      "Transaction source account is invalid.",
-		StatusCode: http.StatusBadRequest,
-	}
-	assert.Equal(t, &wantRejectedResponse, rejectedResponse)
-
-	// Prepare transaction where transaction's payment operation sourceAccount the same as the server issuer account.
-	tx, err = txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &senderAcc,
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					SourceAccount: issuerAccKeyPair.Address(),
-					Destination:   senderAccKP.Address(),
-					Amount:        "1",
-					Asset:         assetGOAT,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txEnc, err = tx.Base64()
-	require.NoError(t, err)
-
-	// TEST "rejected" response for sender account; payment operation sourceAccount the same as the server issuer account.
-	req = txApproveRequest{
-		Tx: txEnc,
-	}
-	rejectedResponse, err = handler.txApprove(ctx, req)
-	require.NoError(t, err)
-	wantRejectedResponse = txApprovalResponse{
+	wantTxApprovalResp := &txApprovalResponse{
 		Status:     "rejected",
 		Error:      "There is one or more unauthorized operations in the provided transaction.",
 		StatusCode: http.StatusBadRequest,
 	}
-	assert.Equal(t, &wantRejectedResponse, rejectedResponse)
+	assert.Equal(t, wantTxApprovalResp, txApprovalResp)
 
-	// Prepare transaction where operation is not a payment (in this case allowing trust for receiverAccKP).
-	tx, err = txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &senderAcc,
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.AllowTrust{
-					Trustor:   receiverAccKP.Address(),
-					Type:      assetGOAT,
-					Authorize: true,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txEnc, err = tx.Base64()
-
-	// TEST "rejected" response if operation is not a payment (in this case allowing trust for receiverAccKP).
-	req = txApproveRequest{
-		Tx: txEnc,
-	}
-	rejectedResponse, err = handler.txApprove(ctx, req)
-	require.NoError(t, err)
-	wantRejectedResponse = txApprovalResponse{
-		Status:     "rejected",
-		Error:      "There is one or more unauthorized operations in the provided transaction.",
-		StatusCode: http.StatusBadRequest,
-	}
-	assert.Equal(t, &wantRejectedResponse, rejectedResponse)
-
-	// Prepare transaction with multiple operations.
-	tx, err = txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &senderAcc,
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					SourceAccount: senderAccKP.Address(),
-					Destination:   receiverAccKP.Address(),
-					Amount:        "1",
-					Asset:         assetGOAT,
-				},
-				&txnbuild.Payment{
-					SourceAccount: senderAccKP.Address(),
-					Destination:   receiverAccKP.Address(),
-					Amount:        "2",
-					Asset:         assetGOAT,
-				},
-			},
-			BaseFee:    txnbuild.MinBaseFee,
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-		},
-	)
-	require.NoError(t, err)
-	txEnc, err = tx.Base64()
-	require.NoError(t, err)
-
-	// TEST "rejected" response for sender account; transaction with multiple operations.
-	req = txApproveRequest{
-		Tx: txEnc,
-	}
-	rejectedResponse, err = handler.txApprove(ctx, req)
-	require.NoError(t, err)
-	wantRejectedResponse = txApprovalResponse{
-		Status:     "rejected",
-		Error:      "Please submit a transaction with exactly one operation of type payment.",
-		StatusCode: http.StatusBadRequest,
-	}
-	assert.Equal(t, &wantRejectedResponse, rejectedResponse)
-
-	// Prepare transaction where sourceAccount seq num too far in the future.
+	// rejected if payment asset is not supported
 	tx, err = txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
 			SourceAccount: &horizon.Account{
-				AccountID: senderAccKP.Address(),
-				Sequence:  "50",
+				AccountID: senderKP.Address(),
+				Sequence:  "2",
 			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
 				&txnbuild.Payment{
-					SourceAccount: senderAccKP.Address(),
-					Destination:   receiverAccKP.Address(),
-					Amount:        "1",
-					Asset:         assetGOAT,
+					Destination: receiverKP.Address(),
+					Amount:      "1",
+					Asset: txnbuild.CreditAsset{
+						Code:   "FOO",
+						Issuer: keypair.MustRandom().Address(),
+					},
 				},
 			},
 			BaseFee:    txnbuild.MinBaseFee,
@@ -478,19 +389,239 @@ func TestTxApproveHandlerTxApprove(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	txEnc, err = tx.Base64()
+	txe, err = tx.Base64()
 	require.NoError(t, err)
 
-	// TEST "rejected" response if transaction source account seq num is not equal to account sequence+1.
-	req = txApproveRequest{
-		Tx: txEnc,
-	}
-	rejectedResponse, err = handler.txApprove(ctx, req)
+	txApprovalResp, err = handler.txApprove(ctx, txApproveRequest{Tx: txe})
 	require.NoError(t, err)
-	wantRejectedResponse = txApprovalResponse{
+	wantTxApprovalResp = &txApprovalResponse{
+		Status:     "rejected",
+		Error:      "The payment asset is not supported by this issuer.",
+		StatusCode: http.StatusBadRequest,
+	}
+	assert.Equal(t, wantTxApprovalResp, txApprovalResp)
+
+	// rejected if sequence number is not incremental
+	tx, err = txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount: &horizon.Account{
+				AccountID: senderKP.Address(),
+				Sequence:  "20",
+			},
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.Payment{
+					Destination: receiverKP.Address(),
+					Amount:      "1",
+					Asset:       assetGOAT,
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	txe, err = tx.Base64()
+	require.NoError(t, err)
+
+	txApprovalResp, err = handler.txApprove(ctx, txApproveRequest{Tx: txe})
+	require.NoError(t, err)
+	wantTxApprovalResp = &txApprovalResponse{
 		Status:     "rejected",
 		Error:      "Invalid transaction sequence number.",
 		StatusCode: http.StatusBadRequest,
 	}
-	assert.Equal(t, &wantRejectedResponse, rejectedResponse)
+	assert.Equal(t, wantTxApprovalResp, txApprovalResp)
+}
+
+func TestTxApproveHandlerTxApprove_actionRequired(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.Open(t)
+	defer db.Close()
+	conn := db.Open()
+	defer conn.Close()
+
+	// prepare accounts on mock horizon
+	issuerKP := keypair.MustRandom()
+	senderKP := keypair.MustRandom()
+	receiverKP := keypair.MustRandom()
+	horizonMock := horizonclient.MockClient{}
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
+		Return(horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "2",
+		}, nil)
+
+	// prepare txApproveHandler
+	kycThresholdAmount, err := amount.ParseInt64("500")
+	require.NoError(t, err)
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerKP.Address(),
+	}
+	handler := txApproveHandler{
+		issuerKP:          issuerKP,
+		assetCode:         assetGOAT.GetCode(),
+		horizonClient:     &horizonMock,
+		networkPassphrase: network.TestNetworkPassphrase,
+		db:                conn,
+		kycThreshold:      kycThresholdAmount,
+		baseURL:           "https://sep8-server.test",
+	}
+
+	// rejected if sequence number is not incremental
+	tx, err := txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount: &horizon.Account{
+				AccountID: senderKP.Address(),
+				Sequence:  "2",
+			},
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.Payment{
+					Destination: receiverKP.Address(),
+					Amount:      "501",
+					Asset:       assetGOAT,
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	txe, err := tx.Base64()
+	require.NoError(t, err)
+
+	txApprovalResp, err := handler.txApprove(ctx, txApproveRequest{Tx: txe})
+	require.NoError(t, err)
+
+	var callbackID string
+	q := `SELECT callback_id FROM accounts_kyc_status WHERE stellar_address = $1`
+	err = conn.QueryRowContext(ctx, q, senderKP.Address()).Scan(&callbackID)
+	require.NoError(t, err)
+
+	wantResp := &txApprovalResponse{
+		Status:       sep8StatusActionRequired,
+		Message:      "Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.",
+		ActionMethod: "POST",
+		StatusCode:   http.StatusOK,
+		ActionURL:    "https://sep8-server.test/kyc-status/" + callbackID,
+		ActionFields: []string{"email_address"},
+	}
+	require.Equal(t, wantResp, txApprovalResp)
+}
+
+func TestTxApproveHandlerTxApprove_revised(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.Open(t)
+	defer db.Close()
+	conn := db.Open()
+	defer conn.Close()
+
+	// prepare accounts on mock horizon
+	issuerKP := keypair.MustRandom()
+	senderKP := keypair.MustRandom()
+	receiverKP := keypair.MustRandom()
+	horizonMock := horizonclient.MockClient{}
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
+		Return(horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "2",
+		}, nil)
+
+	// prepare txApproveHandler
+	kycThresholdAmount, err := amount.ParseInt64("500")
+	require.NoError(t, err)
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerKP.Address(),
+	}
+	handler := txApproveHandler{
+		issuerKP:          issuerKP,
+		assetCode:         assetGOAT.GetCode(),
+		horizonClient:     &horizonMock,
+		networkPassphrase: network.TestNetworkPassphrase,
+		db:                conn,
+		kycThreshold:      kycThresholdAmount,
+		baseURL:           "https://sep8-server.test",
+	}
+
+	// rejected if sequence number is not incremental
+	tx, err := txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount: &horizon.Account{
+				AccountID: senderKP.Address(),
+				Sequence:  "2",
+			},
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.Payment{
+					Destination: receiverKP.Address(),
+					Amount:      "500",
+					Asset:       assetGOAT,
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	txe, err := tx.Base64()
+	require.NoError(t, err)
+
+	txApprovalResp, err := handler.txApprove(ctx, txApproveRequest{Tx: txe})
+	require.NoError(t, err)
+	require.Equal(t, sep8StatusRevised, txApprovalResp.Status)
+	require.Equal(t, http.StatusOK, txApprovalResp.StatusCode)
+	require.Equal(t, "Authorization and deauthorization operations were added.", txApprovalResp.Message)
+
+	gotGenericTx, err := txnbuild.TransactionFromXDR(txApprovalResp.Tx)
+	require.NoError(t, err)
+	gotTx, ok := gotGenericTx.Transaction()
+	require.True(t, ok)
+	require.Equal(t, senderKP.Address(), gotTx.SourceAccount().AccountID)
+	require.Equal(t, int64(3), gotTx.SourceAccount().Sequence)
+
+	require.Len(t, gotTx.Operations(), 5)
+	// AllowTrust op where issuer fully authorizes account A, asset X
+	op0, ok := gotTx.Operations()[0].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op0.Trustor, senderKP.Address())
+	assert.Equal(t, op0.Type.GetCode(), assetGOAT.GetCode())
+	require.True(t, op0.Authorize)
+	// AllowTrust op where issuer fully authorizes account B, asset X
+	op1, ok := gotTx.Operations()[1].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op1.Trustor, receiverKP.Address())
+	assert.Equal(t, op1.Type.GetCode(), assetGOAT.GetCode())
+	require.True(t, op1.Authorize)
+	// Payment from A to B
+	op2, ok := gotTx.Operations()[2].(*txnbuild.Payment)
+	require.True(t, ok)
+	assert.Equal(t, op2.Destination, receiverKP.Address())
+	assert.Equal(t, op2.Asset, assetGOAT)
+	// AllowTrust op where issuer fully deauthorizes account B, asset X
+	op3, ok := gotTx.Operations()[3].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op3.Trustor, receiverKP.Address())
+	assert.Equal(t, op3.Type.GetCode(), assetGOAT.GetCode())
+	require.False(t, op3.Authorize)
+	// AllowTrust op where issuer fully deauthorizes account A, asset X
+	op4, ok := gotTx.Operations()[4].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op4.Trustor, senderKP.Address())
+	assert.Equal(t, op4.Type.GetCode(), assetGOAT.GetCode())
+	require.False(t, op4.Authorize)
+}
+
+func TestConvertAmountToReadableString(t *testing.T) {
+	parsedAmount, err := amount.ParseInt64("500")
+	require.NoError(t, err)
+	assert.Equal(t, int64(5000000000), parsedAmount)
+
+	readableAmount, err := convertAmountToReadableString(parsedAmount)
+	require.NoError(t, err)
+	assert.Equal(t, "500.00", readableAmount)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Refactor tests addressing the `/tx-approve` endpoint for revised/rejected/action_required responses.

Now the unit tests are covering not only the happy path but also all edge cases from the transaction approval logic. On the other hand, the API tests were reduced to cover the happy path only, so they become easier to maintain and we don't repeat ourselves (DRY).

Additionally, removed unnecessary setup in the tests where variables and mocked functions were being declared without need.

### Why

There was confusion between unit tests and API tests in this service so the package was not properly tested in terms of unit tests and a lot of the edge cases were being validated only in the API tests.

This makes the code and tests harder to maintain as a developer would need to maintain package-related tests outside the package.

### Known limitations

N/A