### PR TITLE
services/regulated-assets-approval-server: implement SEP-8 "success" response

### DIFF
--- a/services/regulated-assets-approval-server/README.md
+++ b/services/regulated-assets-approval-server/README.md
@@ -6,6 +6,8 @@ Status: supports SEP-8 transactions revision with a simplified rule:
 - payments whose amount does not meet the configured threshold are considered compliant and revised according to the SEP-8 specification.
 - payments with an amount exceeding the threshold need further action.
 - transactions already compliant with SEP-8 that don't need to be revised will be signed and returned with the "success" SEP-8 status.
+
+Note: SEP-8 states the service should be able to handle offers in addition to payments, but we're not supporting that at the moment.
 ```
 
 This is a [SEP-8] Approval Server reference implementation based on SEP-8 v1.7.1

--- a/services/regulated-assets-approval-server/README.md
+++ b/services/regulated-assets-approval-server/README.md
@@ -5,8 +5,7 @@ Status: supports SEP-8 transactions revision with a simplified rule:
 - only revises transactions containing a single operation of type payment.
 - payments whose amount does not meet the configured threshold are considered compliant and revised according to the SEP-8 specification.
 - payments with an amount exceeding the threshold need further action.
-
-It is important to notice the SEP-8 "success" response has not been implemented yet so even if the submitted transaction is compliant to be marked as successful according with SEP-8, this service will reject it.
+- transactions already compliant with SEP-8 that don't need to be revised will be signed and returned with the "success" SEP-8 status.
 ```
 
 This is a [SEP-8] Approval Server reference implementation based on SEP-8 v1.7.1
@@ -134,8 +133,8 @@ to do that in Stellar Laboratory.
 ### `POST /tx-approve`
 
 This is the core [SEP-8] endpoint used to validate and process regulated assets
-transactions. Responds with one of the following statuses: [Success], [Revised],
-[Action Required], or [Rejected].
+transactions. Its response will contain one of the following statuses:
+[Success], [Revised], [Action Required], or [Rejected].
 
 Note: The example responses below have set their `base-url` env var configured
 to `"https://example.com"`.

--- a/services/regulated-assets-approval-server/README.md
+++ b/services/regulated-assets-approval-server/README.md
@@ -133,10 +133,12 @@ to do that in Stellar Laboratory.
 
 ### `POST /tx-approve`
 
-This is the core [SEP-8] endpoint used to validate and process
-approval/revision/rejection of regulated assets transactions. Note: The example
-responses below have set their `base-url` env var configured to
-`"https://example.com"`.
+This is the core [SEP-8] endpoint used to validate and process regulated assets
+transactions. Responds with one of the following statuses: [Success], [Revised],
+[Action Required], or [Rejected].
+
+Note: The example responses below have set their `base-url` env var configured
+to `"https://example.com"`.
 
 **Request:**
 
@@ -147,6 +149,17 @@ responses below have set their `base-url` env var configured to
 ```
 
 **Responses:**
+
+_Success:_ means the transaction has been approved and signed by the issuer
+without being revised. For more info read the SEP-8 [Success] section.
+
+```json
+{
+  "status": "success",
+  "message": "Transaction is compliant and signed by the issuer.",
+  "tx": "AAAAAgAAAAA0Nk3++mfFw4Is6OaUJTKe71XNtxdktcjGrPildK84xAAABdwAAJ3YAAAABwAAAAEAAAAAAAAAAAAAAABgXdapAAAAAAAAAAUAAAABAAAAAKo3U5g57mZuGKyGd8EFZlV5lkjDuHS5OXTj81I1g7yIAAAABwAAAAA0Nk3++mfFw4Is6OaUJTKe71XNtxdktcjGrPildK84xAAAAAJNWVVTRAAAAAAAAAAAAAABAAAAAQAAAACqN1OYOe5mbhishnfBBWZVeZZIw7h0uTl04/NSNYO8iAAAAAcAAAAAEZZVb/iufEW8M3P9k4tSLIrCwtN7nTSW5UMdrDy3w8oAAAACTVlVU0QAAAAAAAAAAAAAAQAAAAAAAAABAAAAABGWVW/4rnxFvDNz/ZOLUiyKwsLTe500luVDHaw8t8PKAAAAAk1ZVVNEAAAAAAAAAAAAAACqN1OYOe5mbhishnfBBWZVeZZIw7h0uTl04/NSNYO8iAAAAAEqnoiAAAAAAQAAAACqN1OYOe5mbhishnfBBWZVeZZIw7h0uTl04/NSNYO8iAAAAAcAAAAAEZZVb/iufEW8M3P9k4tSLIrCwtN7nTSW5UMdrDy3w8oAAAACTVlVU0QAAAAAAAAAAAAAAAAAAAEAAAAAqjdTmDnuZm4YrIZ3wQVmVXmWSMO4dLk5dOPzUjWDvIgAAAAHAAAAADQ2Tf76Z8XDgizo5pQlMp7vVc23F2S1yMas+KV0rzjEAAAAAk1ZVVNEAAAAAAAAAAAAAAAAAAAAAAAAATWDvIgAAABAxXindTDbKTpw9B+1aUdTOTE6CUF610A0ZL+ofBVSlcvHYadc3LfO/L4/V22h2FyHNt2ALwncmlEq+3hpojZDDQ=="
+}
+```
 
 _Revised:_ this response means the transaction was revised to be made compliant,
 and signed by the issuer. For more info read the SEP-8 [Revised] section.
@@ -292,3 +305,4 @@ the [SEP-8] spec._
 [Action Required]: https://github.com/stellar/stellar-protocol/blob/7c795bb9abc606cd1e34764c4ba07900d58fe26e/ecosystem/sep-0008.md#action-required
 [Rejected]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md#rejected
 [Revised]:https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md#revised
+[Success]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md#success

--- a/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
@@ -429,3 +429,152 @@ func TestAPI_txAprove_actionRequiredFlow(t *testing.T) {
 	}`
 	require.JSONEq(t, wantBody, string(body))
 }
+
+func TestAPI_txApprove_success(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.Open(t)
+	defer db.Close()
+	conn := db.Open()
+	defer conn.Close()
+
+	senderKP := keypair.MustRandom()
+	receiverKP := keypair.MustRandom()
+	issuerKP := keypair.MustRandom()
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerKP.Address(),
+	}
+	kycThresholdAmount, err := amount.ParseInt64("500")
+	require.NoError(t, err)
+
+	horizonMock := horizonclient.MockClient{}
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
+		Return(horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "5",
+		}, nil)
+
+	handler := txApproveHandler{
+		issuerKP:          issuerKP,
+		assetCode:         assetGOAT.GetCode(),
+		horizonClient:     &horizonMock,
+		networkPassphrase: network.TestNetworkPassphrase,
+		db:                conn,
+		kycThreshold:      kycThresholdAmount,
+		baseURL:           "https://example.com",
+	}
+	m := chi.NewMux()
+	m.Post("/tx-approve", handler.ServeHTTP)
+
+	// prepare SEP-8 compliant transaction
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "5",
+		},
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.AllowTrust{
+				Trustor:       senderKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     true,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       receiverKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     true,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.Payment{
+				SourceAccount: senderKP.Address(),
+				Destination:   receiverKP.Address(),
+				Amount:        "1",
+				Asset:         assetGOAT,
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       receiverKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     false,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       senderKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     false,
+				SourceAccount: issuerKP.Address(),
+			},
+		},
+		BaseFee:    300,
+		Timebounds: txnbuild.NewTimeout(300),
+	})
+	require.NoError(t, err)
+	txEnc, err := tx.Base64()
+	require.NoError(t, err)
+
+	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(`{"tx": "`+txEnc+`"}`))
+	r = r.WithContext(ctx)
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, r)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var gotSuccessResponse txApprovalResponse
+	err = json.Unmarshal(body, &gotSuccessResponse)
+	require.NoError(t, err)
+	wantSuccessResponse := txApprovalResponse{
+		Status:  sep8Status("success"),
+		Tx:      gotSuccessResponse.Tx,
+		Message: "Transaction is compliant and signed by the issuer.",
+	}
+	assert.Equal(t, wantSuccessResponse, gotSuccessResponse)
+
+	genericTx, err := txnbuild.TransactionFromXDR(gotSuccessResponse.Tx)
+	require.NoError(t, err)
+	tx, ok := genericTx.Transaction()
+	require.True(t, ok)
+
+	// Check if revised transaction only has 5 operations.
+	require.Len(t, tx.Operations(), 5)
+	// AllowTrust op where issuer fully authorizes sender, asset GOAT
+	op1, ok := tx.Operations()[0].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op1.Trustor, senderKP.Address())
+	assert.Equal(t, op1.Type.GetCode(), assetGOAT.GetCode())
+	require.True(t, op1.Authorize)
+	// AllowTrust op where issuer fully authorizes receiver, asset GOAT
+	op2, ok := tx.Operations()[1].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op2.Trustor, receiverKP.Address())
+	assert.Equal(t, op2.Type.GetCode(), assetGOAT.GetCode())
+	require.True(t, op2.Authorize)
+	// Payment from sender to receiver
+	op3, ok := tx.Operations()[2].(*txnbuild.Payment)
+	require.True(t, ok)
+	assert.Equal(t, op3.SourceAccount, senderKP.Address())
+	assert.Equal(t, op3.Destination, receiverKP.Address())
+	assert.Equal(t, op3.Asset, assetGOAT)
+	// AllowTrust op where issuer fully deauthorizes receiver, asset GOAT
+	op4, ok := tx.Operations()[3].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op4.Trustor, receiverKP.Address())
+	assert.Equal(t, op4.Type.GetCode(), assetGOAT.GetCode())
+	require.False(t, op4.Authorize)
+	// AllowTrust op where issuer fully deauthorizes sender, asset GOAT
+	op5, ok := tx.Operations()[4].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op5.Trustor, senderKP.Address())
+	assert.Equal(t, op5.Type.GetCode(), assetGOAT.GetCode())
+	require.False(t, op5.Authorize)
+
+	// check if issuer's signature is present
+	txHash, err := tx.Hash(handler.networkPassphrase)
+	require.NoError(t, err)
+	err = handler.issuerKP.Verify(txHash[:], tx.Signatures()[0].Signature)
+	require.NoError(t, err)
+}

--- a/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
@@ -488,10 +488,9 @@ func TestAPI_txApprove_success(t *testing.T) {
 				SourceAccount: issuerKP.Address(),
 			},
 			&txnbuild.Payment{
-				SourceAccount: senderKP.Address(),
-				Destination:   receiverKP.Address(),
-				Amount:        "1",
-				Asset:         assetGOAT,
+				Destination: receiverKP.Address(),
+				Amount:      "1",
+				Asset:       assetGOAT,
 			},
 			&txnbuild.AllowTrust{
 				Trustor:       receiverKP.Address(),
@@ -510,10 +509,10 @@ func TestAPI_txApprove_success(t *testing.T) {
 		Timebounds: txnbuild.NewTimeout(300),
 	})
 	require.NoError(t, err)
-	txEnc, err := tx.Base64()
+	txe, err := tx.Base64()
 	require.NoError(t, err)
 
-	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(`{"tx": "`+txEnc+`"}`))
+	r := httptest.NewRequest("POST", "/tx-approve", strings.NewReader(`{"tx": "`+txe+`"}`))
 	r = r.WithContext(ctx)
 	w := httptest.NewRecorder()
 	m.ServeHTTP(w, r)
@@ -538,41 +537,40 @@ func TestAPI_txApprove_success(t *testing.T) {
 	require.NoError(t, err)
 	tx, ok := genericTx.Transaction()
 	require.True(t, ok)
+	require.Equal(t, senderKP.Address(), tx.SourceAccount().AccountID)
 
-	// Check if revised transaction only has 5 operations.
 	require.Len(t, tx.Operations(), 5)
 	// AllowTrust op where issuer fully authorizes sender, asset GOAT
-	op1, ok := tx.Operations()[0].(*txnbuild.AllowTrust)
+	op0, ok := tx.Operations()[0].(*txnbuild.AllowTrust)
 	require.True(t, ok)
-	assert.Equal(t, op1.Trustor, senderKP.Address())
+	assert.Equal(t, op0.Trustor, senderKP.Address())
+	assert.Equal(t, op0.Type.GetCode(), assetGOAT.GetCode())
+	require.True(t, op0.Authorize)
+	// AllowTrust op where issuer fully authorizes receiver, asset GOAT
+	op1, ok := tx.Operations()[1].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op1.Trustor, receiverKP.Address())
 	assert.Equal(t, op1.Type.GetCode(), assetGOAT.GetCode())
 	require.True(t, op1.Authorize)
-	// AllowTrust op where issuer fully authorizes receiver, asset GOAT
-	op2, ok := tx.Operations()[1].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op2.Trustor, receiverKP.Address())
-	assert.Equal(t, op2.Type.GetCode(), assetGOAT.GetCode())
-	require.True(t, op2.Authorize)
 	// Payment from sender to receiver
-	op3, ok := tx.Operations()[2].(*txnbuild.Payment)
+	op2, ok := tx.Operations()[2].(*txnbuild.Payment)
 	require.True(t, ok)
-	assert.Equal(t, op3.SourceAccount, senderKP.Address())
-	assert.Equal(t, op3.Destination, receiverKP.Address())
-	assert.Equal(t, op3.Asset, assetGOAT)
+	assert.Equal(t, op2.Destination, receiverKP.Address())
+	assert.Equal(t, op2.Asset, assetGOAT)
 	// AllowTrust op where issuer fully deauthorizes receiver, asset GOAT
-	op4, ok := tx.Operations()[3].(*txnbuild.AllowTrust)
+	op3, ok := tx.Operations()[3].(*txnbuild.AllowTrust)
 	require.True(t, ok)
-	assert.Equal(t, op4.Trustor, receiverKP.Address())
+	assert.Equal(t, op3.Trustor, receiverKP.Address())
+	assert.Equal(t, op3.Type.GetCode(), assetGOAT.GetCode())
+	require.False(t, op3.Authorize)
+	// AllowTrust op where issuer fully deauthorizes sender, asset GOAT
+	op4, ok := tx.Operations()[4].(*txnbuild.AllowTrust)
+	require.True(t, ok)
+	assert.Equal(t, op4.Trustor, senderKP.Address())
 	assert.Equal(t, op4.Type.GetCode(), assetGOAT.GetCode())
 	require.False(t, op4.Authorize)
-	// AllowTrust op where issuer fully deauthorizes sender, asset GOAT
-	op5, ok := tx.Operations()[4].(*txnbuild.AllowTrust)
-	require.True(t, ok)
-	assert.Equal(t, op5.Trustor, senderKP.Address())
-	assert.Equal(t, op5.Type.GetCode(), assetGOAT.GetCode())
-	require.False(t, op5.Authorize)
 
-	// check if issuer's signature is present
+	// check if the transaction contains the issuer's signature
 	txHash, err := tx.Hash(handler.networkPassphrase)
 	require.NoError(t, err)
 	err = handler.issuerKP.Verify(txHash[:], tx.Signatures()[0].Signature)

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve.go
@@ -111,6 +111,7 @@ func (h txApproveHandler) validateInput(ctx context.Context, in txApproveRequest
 		return NewRejectedTxApprovalResponse("Transaction source account is invalid."), nil
 	}
 
+	// only AllowTrust operations can have the issuer as their source account
 	for _, op := range tx.Operations() {
 		if _, ok := op.(*txnbuild.AllowTrust); ok {
 			continue
@@ -148,7 +149,7 @@ func (h txApproveHandler) txApprove(ctx context.Context, in txApproveRequest) (r
 		return txSuccessResp, nil
 	}
 
-	// Validate the revisable transaction has one operation.
+	// validate the revisable transaction has one operation.
 	if len(tx.Operations()) != 1 {
 		return NewRejectedTxApprovalResponse("Please submit a transaction with exactly one operation of type payment."), nil
 	}
@@ -342,7 +343,7 @@ func (h txApproveHandler) handleSuccessResponseIfNeeded(ctx context.Context, tx 
 		return nil, errors.Wrap(err, "encoding revised transaction")
 	}
 
-	return NewSuccessTxApprovalResponse(txe, "Transaction is compliant and signed by the issuer."), err
+	return NewSuccessTxApprovalResponse(txe, "Transaction is compliant and signed by the issuer."), nil
 }
 
 // validateTransactionOperationsForSuccess checks if the incoming transaction

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve.go
@@ -107,7 +107,7 @@ func (h txApproveHandler) validateInput(ctx context.Context, in txApproveRequest
 	}
 
 	if tx.SourceAccount().AccountID == h.issuerKP.Address() {
-		log.Ctx(ctx).Errorf("transaction %s sourceAccount is the same as the server issuer account %s", in.Tx, h.issuerKP.Address())
+		log.Ctx(ctx).Errorf("transaction sourceAccount is the same as the server issuer account %s", h.issuerKP.Address())
 		return NewRejectedTxApprovalResponse("Transaction source account is invalid."), nil
 	}
 
@@ -229,7 +229,8 @@ func (h txApproveHandler) txApprove(ctx context.Context, in txApproveRequest) (r
 	return NewRevisedTxApprovalResponse(txe), nil
 }
 
-// handleActionRequiredResponseIfNeeded validates and returns an action_required response if the payment requires KYC.
+// handleActionRequiredResponseIfNeeded validates and returns an action_required
+// response if the payment requires KYC.
 func (h txApproveHandler) handleActionRequiredResponseIfNeeded(ctx context.Context, stellarAddress string, paymentOp *txnbuild.Payment) (*txApprovalResponse, error) {
 	paymentAmount, err := amount.ParseInt64(paymentOp.Amount)
 	if err != nil {
@@ -280,6 +281,77 @@ func (h txApproveHandler) handleActionRequiredResponseIfNeeded(ctx context.Conte
 		fmt.Sprintf("%s/kyc-status/%s", h.baseURL, callbackID),
 		[]string{"email_address"},
 	), nil
+}
+
+// validateTransactionOperationsForSuccess checks if the incoming transaction
+// operations are compliant with the anchor's SEP-8 policy.
+func validateTransactionOperationsForSuccess(ctx context.Context, tx *txnbuild.Transaction, issuerAddress string) (resp *txApprovalResponse, paymentOp *txnbuild.Payment, paymentSource string) {
+	if len(tx.Operations()) != 5 {
+		return NewRejectedTxApprovalResponse("Unsupported number of operations."), nil, ""
+	}
+
+	// extract the payment operation and payment source account.
+	paymentOp, ok := tx.Operations()[2].(*txnbuild.Payment)
+	if !ok {
+		log.Ctx(ctx).Error(`third operation is not of type payment`)
+		return NewRejectedTxApprovalResponse("There are one or more unexpected operations in the provided transaction."), nil, ""
+	}
+	paymentSource = paymentOp.SourceAccount
+	if paymentSource == "" {
+		paymentSource = tx.SourceAccount().AccountID
+	}
+
+	assetCode := paymentOp.Asset.GetCode()
+
+	operationsValid := func() bool {
+		op0, ok := tx.Operations()[0].(*txnbuild.AllowTrust)
+		if !ok ||
+			op0.Trustor != paymentSource ||
+			op0.Type.GetCode() != assetCode ||
+			!op0.Authorize ||
+			op0.SourceAccount != issuerAddress {
+			return false
+		}
+
+		op1, ok := tx.Operations()[1].(*txnbuild.AllowTrust)
+		if !ok ||
+			op1.Trustor != paymentOp.Destination ||
+			op1.Type.GetCode() != assetCode ||
+			!op1.Authorize ||
+			op1.SourceAccount != issuerAddress {
+			return false
+		}
+
+		op2, ok := tx.Operations()[2].(*txnbuild.Payment)
+		if !ok || op2 != paymentOp {
+			return false
+		}
+
+		op3, ok := tx.Operations()[3].(*txnbuild.AllowTrust)
+		if !ok ||
+			op3.Trustor != paymentOp.Destination ||
+			op3.Type.GetCode() != assetCode ||
+			op3.Authorize ||
+			op3.SourceAccount != issuerAddress {
+			return false
+		}
+
+		op4, ok := tx.Operations()[4].(*txnbuild.AllowTrust)
+		if !ok ||
+			op4.Trustor != paymentSource ||
+			op4.Type.GetCode() != assetCode ||
+			op4.Authorize ||
+			op4.SourceAccount != issuerAddress {
+			return false
+		}
+
+		return true
+	}()
+	if !operationsValid {
+		return NewRejectedTxApprovalResponse("There are one or more unexpected operations in the provided transaction."), nil, ""
+	}
+
+	return nil, paymentOp, paymentSource
 }
 
 func convertAmountToReadableString(threshold int64) (string, error) {

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve.go
@@ -111,13 +111,15 @@ func (h txApproveHandler) validateInput(ctx context.Context, in txApproveRequest
 		return NewRejectedTxApprovalResponse("Transaction source account is invalid."), nil
 	}
 
-	if len(tx.Operations()) != 1 {
-		return NewRejectedTxApprovalResponse("Please submit a transaction with exactly one operation of type payment."), nil
-	}
+	for _, op := range tx.Operations() {
+		if _, ok := op.(*txnbuild.AllowTrust); ok {
+			continue
+		}
 
-	if tx.Operations()[0].GetSourceAccount() == h.issuerKP.Address() {
-		log.Ctx(ctx).Error(`transaction contains one or more operations where sourceAccount is issuer account.`)
-		return NewRejectedTxApprovalResponse("There is one or more unauthorized operations in the provided transaction."), nil
+		if op.GetSourceAccount() == h.issuerKP.Address() {
+			log.Ctx(ctx).Error("transaction contains one or more unauthorized operations where source account is the issuer account")
+			return NewRejectedTxApprovalResponse("There are one or more unauthorized operations in the provided transaction."), nil
+		}
 	}
 
 	return nil, tx
@@ -138,9 +140,22 @@ func (h txApproveHandler) txApprove(ctx context.Context, in txApproveRequest) (r
 		return rejectedResponse, nil
 	}
 
+	txSuccessResp, err := h.handleSuccessResponseIfNeeded(ctx, tx)
+	if err != nil {
+		return nil, errors.Wrap(err, "checking if transaction in request was compliant")
+	}
+	if txSuccessResp != nil {
+		return txSuccessResp, nil
+	}
+
+	// Validate the revisable transaction has one operation.
+	if len(tx.Operations()) != 1 {
+		return NewRejectedTxApprovalResponse("Please submit a transaction with exactly one operation of type payment."), nil
+	}
+
 	paymentOp, ok := tx.Operations()[0].(*txnbuild.Payment)
 	if !ok {
-		log.Ctx(ctx).Error(`transaction contains one or more operations is not of type payment`)
+		log.Ctx(ctx).Error("transaction does not contain a payment operation")
 		return NewRejectedTxApprovalResponse("There is one or more unauthorized operations in the provided transaction."), nil
 	}
 	paymentSource := paymentOp.SourceAccount
@@ -157,7 +172,7 @@ func (h txApproveHandler) txApprove(ctx context.Context, in txApproveRequest) (r
 
 	acc, err := h.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: paymentSource})
 	if err != nil {
-		return nil, errors.Wrapf(err, "getting detail for payment source account %s", issuerAddress)
+		return nil, errors.Wrapf(err, "getting detail for payment source account %s", paymentSource)
 	}
 
 	// validate the sequence number

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve.go
@@ -283,6 +283,53 @@ func (h txApproveHandler) handleActionRequiredResponseIfNeeded(ctx context.Conte
 	), nil
 }
 
+// handleSuccessResponseIfNeeded inspects the incoming transaction and returns a
+// "success" response if it's already compliant with the SEP-8 authorization spec.
+func (h txApproveHandler) handleSuccessResponseIfNeeded(ctx context.Context, tx *txnbuild.Transaction) (*txApprovalResponse, error) {
+	if len(tx.Operations()) != 5 {
+		return nil, nil
+	}
+
+	rejectedResp, paymentOp, paymentSource := validateTransactionOperationsForSuccess(ctx, tx, h.issuerKP.Address())
+	if rejectedResp != nil {
+		return rejectedResp, nil
+	}
+
+	// pull current account details from the network then validate the tx sequence number
+	acc, err := h.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: paymentSource})
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting detail for payment source account %s", paymentSource)
+	}
+	accountSequence, err := strconv.ParseInt(acc.Sequence, 10, 64)
+	if err != nil {
+		return nil, errors.Wrapf(err, "parsing account sequence number %q from string to int64", acc.Sequence)
+	}
+	if tx.SourceAccount().Sequence != accountSequence+1 {
+		log.Ctx(ctx).Errorf(`invalid transaction sequence number tx.SourceAccount().Sequence: %d, accountSequence+1: %d`, tx.SourceAccount().Sequence, accountSequence+1)
+		return NewRejectedTxApprovalResponse("Invalid transaction sequence number."), nil
+	}
+
+	kycRequiredResponse, err := h.handleActionRequiredResponseIfNeeded(ctx, paymentSource, paymentOp)
+	if err != nil {
+		return nil, errors.Wrap(err, "handling KYC required payment")
+	}
+	if kycRequiredResponse != nil {
+		return kycRequiredResponse, nil
+	}
+
+	// sign transaction with issuer's signature and encode it
+	tx, err = tx.Sign(h.networkPassphrase, h.issuerKP)
+	if err != nil {
+		return nil, errors.Wrap(err, "signing transaction")
+	}
+	txe, err := tx.Base64()
+	if err != nil {
+		return nil, errors.Wrap(err, "encoding revised transaction")
+	}
+
+	return NewSuccessTxApprovalResponse(txe, "Transaction is compliant and signed by the issuer."), err
+}
+
 // validateTransactionOperationsForSuccess checks if the incoming transaction
 // operations are compliant with the anchor's SEP-8 policy.
 func validateTransactionOperationsForSuccess(ctx context.Context, tx *txnbuild.Transaction, issuerAddress string) (resp *txApprovalResponse, paymentOp *txnbuild.Payment, paymentSource string) {

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_response.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_response.go
@@ -49,10 +49,20 @@ func NewActionRequiredTxApprovalResponse(message, actionURL string, actionFields
 	}
 }
 
+func NewSuccessTxApprovalResponse(tx, message string) *txApprovalResponse {
+	return &txApprovalResponse{
+		Status:     sep8StatusSuccess,
+		Tx:         tx,
+		Message:    message,
+		StatusCode: http.StatusOK,
+	}
+}
+
 type sep8Status string
 
 const (
 	sep8StatusRejected       sep8Status = "rejected"
 	sep8StatusRevised        sep8Status = "revised"
 	sep8StatusActionRequired sep8Status = "action_required"
+	sep8StatusSuccess        sep8Status = "success"
 )

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
@@ -771,7 +771,7 @@ func TestValidateTransactionOperationsForSuccess(t *testing.T) {
 	assert.Nil(t, paymentOp)
 	assert.Empty(t, paymentSource)
 
-	// rejected if the operations don't match the expected format of AllowTrust, AllowTrust, Payment, AllowTrust, AllowTrust
+	// rejected if the operations list don't match the expected format [AllowTrust, AllowTrust, Payment, AllowTrust, AllowTrust]
 	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: senderKP.Address(),
@@ -1297,7 +1297,7 @@ func TestTxApproveHandler_handleSuccessResponseIfNeeded_success(t *testing.T) {
 	resp, _, _ := validateTransactionOperationsForSuccess(ctx, gotTx, issuerKP.Address())
 	assert.Nil(t, resp)
 
-	// check if issuer's signature is present
+	// check if the transaction contains the issuer's signature
 	gotTxHash, err := gotTx.Hash(handler.networkPassphrase)
 	require.NoError(t, err)
 	err = handler.issuerKP.Verify(gotTxHash[:], gotTx.Signatures()[0].Signature)

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
@@ -162,7 +162,7 @@ func TestTxApproveHandler_validateInput(t *testing.T) {
 	require.Equal(t, NewRejectedTxApprovalResponse("Transaction source account is invalid."), txApprovalResp)
 	require.Nil(t, gotTx)
 
-	// rejects if tx contains more than one operation
+	// rejects if there are any operations other than Allowtrust where the source account is the issuer
 	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: clientKP.Address(),
@@ -174,9 +174,10 @@ func TestTxApproveHandler_validateInput(t *testing.T) {
 		Operations: []txnbuild.Operation{
 			&txnbuild.BumpSequence{},
 			&txnbuild.Payment{
-				Destination: clientKP.Address(),
-				Amount:      "1.0000000",
-				Asset:       txnbuild.NativeAsset{},
+				Destination:   clientKP.Address(),
+				Amount:        "1.0000000",
+				Asset:         txnbuild.NativeAsset{},
+				SourceAccount: h.issuerKP.Address(),
 			},
 		},
 	})
@@ -186,7 +187,7 @@ func TestTxApproveHandler_validateInput(t *testing.T) {
 
 	in.Tx = txe
 	txApprovalResp, gotTx = h.validateInput(ctx, in)
-	require.Equal(t, NewRejectedTxApprovalResponse("Please submit a transaction with exactly one operation of type payment."), txApprovalResp)
+	require.Equal(t, NewRejectedTxApprovalResponse("There are one or more unauthorized operations in the provided transaction."), txApprovalResp)
 	require.Nil(t, gotTx)
 
 	// validation success
@@ -337,8 +338,36 @@ func TestTxApproveHandler_txApprove_rejected(t *testing.T) {
 	}
 	assert.Equal(t, &wantRejectedResponse, rejectedResponse)
 
-	// rejected if the single operation is not a payment
+	// rejected if contains more than one operation
 	tx, err := txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount: &horizon.Account{
+				AccountID: senderKP.Address(),
+				Sequence:  "2",
+			},
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.BumpSequence{},
+				&txnbuild.Payment{
+					Destination: receiverKP.Address(),
+					Amount:      "1",
+					Asset:       assetGOAT,
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	txe, err := tx.Base64()
+	require.NoError(t, err)
+
+	txApprovalResp, err := handler.txApprove(ctx, txApproveRequest{Tx: txe})
+	require.NoError(t, err)
+	assert.Equal(t, NewRejectedTxApprovalResponse("Please submit a transaction with exactly one operation of type payment."), txApprovalResp)
+
+	// rejected if the single operation is not a payment
+	tx, err = txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
 			SourceAccount: &horizon.Account{
 				AccountID: senderKP.Address(),
@@ -353,17 +382,12 @@ func TestTxApproveHandler_txApprove_rejected(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	txe, err := tx.Base64()
+	txe, err = tx.Base64()
 	require.NoError(t, err)
 
-	txApprovalResp, err := handler.txApprove(ctx, txApproveRequest{Tx: txe})
+	txApprovalResp, err = handler.txApprove(ctx, txApproveRequest{Tx: txe})
 	require.NoError(t, err)
-	wantTxApprovalResp := &txApprovalResponse{
-		Status:     "rejected",
-		Error:      "There is one or more unauthorized operations in the provided transaction.",
-		StatusCode: http.StatusBadRequest,
-	}
-	assert.Equal(t, wantTxApprovalResp, txApprovalResp)
+	assert.Equal(t, NewRejectedTxApprovalResponse("There is one or more unauthorized operations in the provided transaction."), txApprovalResp)
 
 	// rejected if payment asset is not supported
 	tx, err = txnbuild.NewTransaction(
@@ -393,12 +417,7 @@ func TestTxApproveHandler_txApprove_rejected(t *testing.T) {
 
 	txApprovalResp, err = handler.txApprove(ctx, txApproveRequest{Tx: txe})
 	require.NoError(t, err)
-	wantTxApprovalResp = &txApprovalResponse{
-		Status:     "rejected",
-		Error:      "The payment asset is not supported by this issuer.",
-		StatusCode: http.StatusBadRequest,
-	}
-	assert.Equal(t, wantTxApprovalResp, txApprovalResp)
+	assert.Equal(t, NewRejectedTxApprovalResponse("The payment asset is not supported by this issuer."), txApprovalResp)
 
 	// rejected if sequence number is not incremental
 	tx, err = txnbuild.NewTransaction(
@@ -425,12 +444,7 @@ func TestTxApproveHandler_txApprove_rejected(t *testing.T) {
 
 	txApprovalResp, err = handler.txApprove(ctx, txApproveRequest{Tx: txe})
 	require.NoError(t, err)
-	wantTxApprovalResp = &txApprovalResponse{
-		Status:     "rejected",
-		Error:      "Invalid transaction sequence number.",
-		StatusCode: http.StatusBadRequest,
-	}
-	assert.Equal(t, wantTxApprovalResp, txApprovalResp)
+	assert.Equal(t, NewRejectedTxApprovalResponse("Invalid transaction sequence number."), txApprovalResp)
 }
 
 func TestTxApproveHandler_txApprove_actionRequired(t *testing.T) {

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
@@ -611,6 +611,199 @@ func TestTxApproveHandler_txApprove_revised(t *testing.T) {
 	require.False(t, op4.Authorize)
 }
 
+func TestValidateTransactionOperationsForSuccess(t *testing.T) {
+	ctx := context.Background()
+	senderKP := keypair.MustRandom()
+	receiverKP := keypair.MustRandom()
+	issuerKP := keypair.MustRandom()
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerKP.Address(),
+	}
+
+	// rejected if number of operations is unsupported
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "5",
+		},
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.Payment{
+				SourceAccount: senderKP.Address(),
+				Destination:   receiverKP.Address(),
+				Amount:        "1",
+				Asset:         assetGOAT,
+			},
+		},
+		BaseFee:    300,
+		Timebounds: txnbuild.NewTimeout(300),
+	})
+	require.NoError(t, err)
+
+	txApprovalResp, paymentOp, paymentSource := validateTransactionOperationsForSuccess(ctx, tx, issuerKP.Address())
+	assert.Equal(t, NewRejectedTxApprovalResponse("Unsupported number of operations."), txApprovalResp)
+	assert.Nil(t, paymentOp)
+	assert.Empty(t, paymentSource)
+
+	// rejected if operation at index "2" is not a payment
+	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "5",
+		},
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.BumpSequence{},
+			&txnbuild.BumpSequence{},
+			&txnbuild.BumpSequence{},
+			&txnbuild.BumpSequence{},
+			&txnbuild.BumpSequence{},
+		},
+		BaseFee:    300,
+		Timebounds: txnbuild.NewTimeout(300),
+	})
+	require.NoError(t, err)
+
+	txApprovalResp, paymentOp, paymentSource = validateTransactionOperationsForSuccess(ctx, tx, issuerKP.Address())
+	assert.Equal(t, NewRejectedTxApprovalResponse("There are one or more unexpected operations in the provided transaction."), txApprovalResp)
+	assert.Nil(t, paymentOp)
+	assert.Empty(t, paymentSource)
+
+	// rejected if the operations don't match the expected format of AllowTrust, AllowTrust, Payment, AllowTrust, AllowTrust
+	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "5",
+		},
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.BumpSequence{},
+			&txnbuild.BumpSequence{},
+			&txnbuild.Payment{
+				SourceAccount: senderKP.Address(),
+				Destination:   receiverKP.Address(),
+				Amount:        "1",
+				Asset:         assetGOAT,
+			},
+			&txnbuild.BumpSequence{},
+			&txnbuild.BumpSequence{},
+		},
+		BaseFee:    300,
+		Timebounds: txnbuild.NewTimeout(300),
+	})
+	require.NoError(t, err)
+
+	txApprovalResp, paymentOp, paymentSource = validateTransactionOperationsForSuccess(ctx, tx, issuerKP.Address())
+	assert.Equal(t, NewRejectedTxApprovalResponse("There are one or more unexpected operations in the provided transaction."), txApprovalResp)
+	assert.Nil(t, paymentOp)
+	assert.Empty(t, paymentSource)
+
+	// rejected if the values inside the operations list don't match the expected format
+	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "5",
+		},
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.AllowTrust{
+				Trustor:       senderKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     true,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       receiverKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     true,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.Payment{
+				SourceAccount: senderKP.Address(),
+				Destination:   receiverKP.Address(),
+				Amount:        "1",
+				Asset:         assetGOAT,
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       receiverKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     false,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       senderKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     true, // <--- this flag is the only wrong value in this transaction
+				SourceAccount: issuerKP.Address(),
+			},
+		},
+		BaseFee:    300,
+		Timebounds: txnbuild.NewTimeout(300),
+	})
+	require.NoError(t, err)
+
+	txApprovalResp, paymentOp, paymentSource = validateTransactionOperationsForSuccess(ctx, tx, issuerKP.Address())
+	assert.Equal(t, NewRejectedTxApprovalResponse("There are one or more unexpected operations in the provided transaction."), txApprovalResp)
+	assert.Nil(t, paymentOp)
+	assert.Empty(t, paymentSource)
+
+	// success
+	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "5",
+		},
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.AllowTrust{
+				Trustor:       senderKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     true,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       receiverKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     true,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.Payment{
+				SourceAccount: senderKP.Address(),
+				Destination:   receiverKP.Address(),
+				Amount:        "1",
+				Asset:         assetGOAT,
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       receiverKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     false,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       senderKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     false,
+				SourceAccount: issuerKP.Address(),
+			},
+		},
+		BaseFee:    300,
+		Timebounds: txnbuild.NewTimeout(300),
+	})
+	require.NoError(t, err)
+
+	txApprovalResp, paymentOp, paymentSource = validateTransactionOperationsForSuccess(ctx, tx, issuerKP.Address())
+	assert.Nil(t, txApprovalResp)
+	assert.Equal(t, senderKP.Address(), paymentSource)
+	wantPaymentOp := &txnbuild.Payment{
+		SourceAccount: senderKP.Address(),
+		Destination:   receiverKP.Address(),
+		Amount:        "1",
+		Asset:         assetGOAT,
+	}
+	assert.Equal(t, wantPaymentOp, paymentOp)
+}
+
 func TestConvertAmountToReadableString(t *testing.T) {
 	parsedAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
@@ -804,6 +804,405 @@ func TestValidateTransactionOperationsForSuccess(t *testing.T) {
 	assert.Equal(t, wantPaymentOp, paymentOp)
 }
 
+func TestTxApproveHandler_handleSuccessResponseIfNeeded_revisable(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.Open(t)
+	defer db.Close()
+	conn := db.Open()
+	defer conn.Close()
+
+	senderKP := keypair.MustRandom()
+	receiverKP := keypair.MustRandom()
+	issuerKP := keypair.MustRandom()
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerKP.Address(),
+	}
+	kycThresholdAmount, err := amount.ParseInt64("500")
+	require.NoError(t, err)
+
+	horizonMock := horizonclient.MockClient{}
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
+		Return(horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "2",
+		}, nil)
+
+	handler := txApproveHandler{
+		issuerKP:          issuerKP,
+		assetCode:         assetGOAT.GetCode(),
+		horizonClient:     &horizonMock,
+		networkPassphrase: network.TestNetworkPassphrase,
+		db:                conn,
+		kycThreshold:      kycThresholdAmount,
+		baseURL:           "https://example.com",
+	}
+
+	revisableTx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "2",
+		},
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.Payment{
+				SourceAccount: senderKP.Address(),
+				Destination:   receiverKP.Address(),
+				Amount:        "1",
+				Asset:         assetGOAT,
+			},
+		},
+		BaseFee:    300,
+		Timebounds: txnbuild.NewTimeout(300),
+	})
+	require.NoError(t, err)
+
+	txSuccessResponse, err := handler.handleSuccessResponseIfNeeded(ctx, revisableTx)
+	require.NoError(t, err)
+	assert.Nil(t, txSuccessResponse)
+}
+
+func TestTxApproveHandler_handleSuccessResponseIfNeeded_rejected(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.Open(t)
+	defer db.Close()
+	conn := db.Open()
+	defer conn.Close()
+
+	senderKP := keypair.MustRandom()
+	receiverKP := keypair.MustRandom()
+	issuerKP := keypair.MustRandom()
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerKP.Address(),
+	}
+	kycThresholdAmount, err := amount.ParseInt64("500")
+	require.NoError(t, err)
+
+	horizonMock := horizonclient.MockClient{}
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
+		Return(horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "2",
+		}, nil)
+
+	handler := txApproveHandler{
+		issuerKP:          issuerKP,
+		assetCode:         assetGOAT.GetCode(),
+		horizonClient:     &horizonMock,
+		networkPassphrase: network.TestNetworkPassphrase,
+		db:                conn,
+		kycThreshold:      kycThresholdAmount,
+		baseURL:           "https://example.com",
+	}
+
+	// rejected if operations don't match the expected format
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "2",
+		},
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.BumpSequence{},
+			&txnbuild.BumpSequence{},
+			&txnbuild.Payment{
+				SourceAccount: senderKP.Address(),
+				Destination:   receiverKP.Address(),
+				Amount:        "1",
+				Asset:         assetGOAT,
+			},
+			&txnbuild.BumpSequence{},
+			&txnbuild.BumpSequence{},
+		},
+		BaseFee:    300,
+		Timebounds: txnbuild.NewTimeout(300),
+	})
+	require.NoError(t, err)
+
+	txApprovalResp, err := handler.handleSuccessResponseIfNeeded(ctx, tx)
+	require.NoError(t, err)
+	assert.Equal(t, NewRejectedTxApprovalResponse("There are one or more unexpected operations in the provided transaction."), txApprovalResp)
+
+	// rejected if sequence number is not incremental
+	compliantOps := []txnbuild.Operation{
+		&txnbuild.AllowTrust{
+			Trustor:       senderKP.Address(),
+			Type:          assetGOAT,
+			Authorize:     true,
+			SourceAccount: issuerKP.Address(),
+		},
+		&txnbuild.AllowTrust{
+			Trustor:       receiverKP.Address(),
+			Type:          assetGOAT,
+			Authorize:     true,
+			SourceAccount: issuerKP.Address(),
+		},
+		&txnbuild.Payment{
+			SourceAccount: senderKP.Address(),
+			Destination:   receiverKP.Address(),
+			Amount:        "1",
+			Asset:         assetGOAT,
+		},
+		&txnbuild.AllowTrust{
+			Trustor:       receiverKP.Address(),
+			Type:          assetGOAT,
+			Authorize:     false,
+			SourceAccount: issuerKP.Address(),
+		},
+		&txnbuild.AllowTrust{
+			Trustor:       senderKP.Address(),
+			Type:          assetGOAT,
+			Authorize:     false,
+			SourceAccount: issuerKP.Address(),
+		},
+	}
+	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "3",
+		},
+		IncrementSequenceNum: true,
+		Operations:           compliantOps,
+		BaseFee:              300,
+		Timebounds:           txnbuild.NewTimeout(300),
+	})
+	require.NoError(t, err)
+
+	txApprovalResp, err = handler.handleSuccessResponseIfNeeded(ctx, tx)
+	require.NoError(t, err)
+	assert.Equal(t, NewRejectedTxApprovalResponse("Invalid transaction sequence number."), txApprovalResp)
+}
+
+func TestTxApproveHandler_handleSuccessResponseIfNeeded_actionRequired(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.Open(t)
+	defer db.Close()
+	conn := db.Open()
+	defer conn.Close()
+
+	senderKP := keypair.MustRandom()
+	receiverKP := keypair.MustRandom()
+	issuerKP := keypair.MustRandom()
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerKP.Address(),
+	}
+	kycThresholdAmount, err := amount.ParseInt64("500")
+	require.NoError(t, err)
+
+	horizonMock := horizonclient.MockClient{}
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
+		Return(horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "2",
+		}, nil)
+
+	handler := txApproveHandler{
+		issuerKP:          issuerKP,
+		assetCode:         assetGOAT.GetCode(),
+		horizonClient:     &horizonMock,
+		networkPassphrase: network.TestNetworkPassphrase,
+		db:                conn,
+		kycThreshold:      kycThresholdAmount,
+		baseURL:           "https://example.com",
+	}
+
+	// compliant operations with a payment above threshold will return "action_required" if the user hasn't gone through KYC yet
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "2",
+		},
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.AllowTrust{
+				Trustor:       senderKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     true,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       receiverKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     true,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.Payment{
+				SourceAccount: senderKP.Address(),
+				Destination:   receiverKP.Address(),
+				Amount:        "501",
+				Asset:         assetGOAT,
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       receiverKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     false,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       senderKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     false,
+				SourceAccount: issuerKP.Address(),
+			},
+		},
+		BaseFee:    300,
+		Timebounds: txnbuild.NewTimeout(300),
+	})
+	require.NoError(t, err)
+
+	txApprovalResponse, err := handler.handleSuccessResponseIfNeeded(ctx, tx)
+	require.NoError(t, err)
+
+	var callbackID string
+	q := `SELECT callback_id FROM accounts_kyc_status WHERE stellar_address = $1`
+	err = conn.QueryRowContext(ctx, q, senderKP.Address()).Scan(&callbackID)
+	require.NoError(t, err)
+
+	wantTxApprovalResponse := NewActionRequiredTxApprovalResponse(
+		"Payments exceeding 500.00 GOAT require KYC approval. Please provide an email address.",
+		"https://example.com/kyc-status/"+callbackID,
+		[]string{"email_address"},
+	)
+	assert.Equal(t, wantTxApprovalResponse, txApprovalResponse)
+
+	// compliant operations with a payment above threshold will return "rejected" if the user's KYC was rejected
+	query := `
+		UPDATE accounts_kyc_status
+		SET
+			approved_at = NULL,
+			rejected_at = NOW()
+		WHERE stellar_address = $1
+	`
+	_, err = handler.db.ExecContext(ctx, query, senderKP.Address())
+	require.NoError(t, err)
+	txApprovalResponse, err = handler.handleSuccessResponseIfNeeded(ctx, tx)
+	require.NoError(t, err)
+	assert.Equal(t, NewRejectedTxApprovalResponse("Your KYC was rejected and you're not authorized for operations above 500.00 GOAT."), txApprovalResponse)
+
+	// compliant operations with a payment above threshold will return "success" if the user's KYC was approved
+	query = `
+		UPDATE accounts_kyc_status
+		SET
+			approved_at = NOW(),
+			rejected_at = NULL
+		WHERE stellar_address = $1
+	`
+	_, err = handler.db.ExecContext(ctx, query, senderKP.Address())
+	require.NoError(t, err)
+	txApprovalResponse, err = handler.handleSuccessResponseIfNeeded(ctx, tx)
+	require.NoError(t, err)
+	assert.Equal(t, NewSuccessTxApprovalResponse(txApprovalResponse.Tx, "Transaction is compliant and signed by the issuer."), txApprovalResponse)
+}
+
+func TestTxApproveHandler_handleSuccessResponseIfNeeded_success(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.Open(t)
+	defer db.Close()
+	conn := db.Open()
+	defer conn.Close()
+
+	senderKP := keypair.MustRandom()
+	receiverKP := keypair.MustRandom()
+	issuerKP := keypair.MustRandom()
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerKP.Address(),
+	}
+	kycThresholdAmount, err := amount.ParseInt64("500")
+	require.NoError(t, err)
+
+	horizonMock := horizonclient.MockClient{}
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
+		Return(horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "2",
+		}, nil)
+
+	handler := txApproveHandler{
+		issuerKP:          issuerKP,
+		assetCode:         assetGOAT.GetCode(),
+		horizonClient:     &horizonMock,
+		networkPassphrase: network.TestNetworkPassphrase,
+		db:                conn,
+		kycThreshold:      kycThresholdAmount,
+		baseURL:           "https://example.com",
+	}
+
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "2",
+		},
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.AllowTrust{
+				Trustor:       senderKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     true,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       receiverKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     true,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.Payment{
+				SourceAccount: senderKP.Address(),
+				Destination:   receiverKP.Address(),
+				Amount:        "1",
+				Asset:         assetGOAT,
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       receiverKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     false,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       senderKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     false,
+				SourceAccount: issuerKP.Address(),
+			},
+		},
+		BaseFee:    300,
+		Timebounds: txnbuild.NewTimeout(300),
+	})
+	require.NoError(t, err)
+
+	txApprovalResponse, err := handler.handleSuccessResponseIfNeeded(ctx, tx)
+	require.NoError(t, err)
+	require.Equal(t, NewSuccessTxApprovalResponse(txApprovalResponse.Tx, "Transaction is compliant and signed by the issuer."), txApprovalResponse)
+
+	gotGenericTx, err := txnbuild.TransactionFromXDR(txApprovalResponse.Tx)
+	require.NoError(t, err)
+	gotTx, ok := gotGenericTx.Transaction()
+	require.True(t, ok)
+
+	// test transaction params
+	assert.Equal(t, tx.SourceAccount(), gotTx.SourceAccount())
+	assert.Equal(t, tx.BaseFee(), gotTx.BaseFee())
+	assert.Equal(t, tx.Timebounds(), gotTx.Timebounds())
+	assert.Equal(t, tx.SequenceNumber(), gotTx.SequenceNumber())
+
+	// test if the operations are as expected
+	resp, _, _ := validateTransactionOperationsForSuccess(ctx, gotTx, issuerKP.Address())
+	assert.Nil(t, resp)
+
+	// check if issuer's signature is present
+	gotTxHash, err := gotTx.Hash(handler.networkPassphrase)
+	require.NoError(t, err)
+	err = handler.issuerKP.Verify(gotTxHash[:], gotTx.Signatures()[0].Signature)
+	require.NoError(t, err)
+}
+
 func TestConvertAmountToReadableString(t *testing.T) {
 	parsedAmount, err := amount.ParseInt64("500")
 	require.NoError(t, err)

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
@@ -447,6 +447,93 @@ func TestTxApproveHandler_txApprove_rejected(t *testing.T) {
 	assert.Equal(t, NewRejectedTxApprovalResponse("Invalid transaction sequence number."), txApprovalResp)
 }
 
+func TestTxApproveHandler_txApprove_success(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.Open(t)
+	defer db.Close()
+	conn := db.Open()
+	defer conn.Close()
+
+	senderKP := keypair.MustRandom()
+	receiverKP := keypair.MustRandom()
+	issuerKP := keypair.MustRandom()
+	assetGOAT := txnbuild.CreditAsset{
+		Code:   "GOAT",
+		Issuer: issuerKP.Address(),
+	}
+	kycThresholdAmount, err := amount.ParseInt64("500")
+	require.NoError(t, err)
+
+	horizonMock := horizonclient.MockClient{}
+	horizonMock.
+		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
+		Return(horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "2",
+		}, nil)
+
+	handler := txApproveHandler{
+		issuerKP:          issuerKP,
+		assetCode:         assetGOAT.GetCode(),
+		horizonClient:     &horizonMock,
+		networkPassphrase: network.TestNetworkPassphrase,
+		db:                conn,
+		kycThreshold:      kycThresholdAmount,
+		baseURL:           "https://example.com",
+	}
+
+	tx, err := txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount: &horizon.Account{
+				AccountID: senderKP.Address(),
+				Sequence:  "2",
+			},
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.AllowTrust{
+					Trustor:       senderKP.Address(),
+					Type:          assetGOAT,
+					Authorize:     true,
+					SourceAccount: issuerKP.Address(),
+				},
+				&txnbuild.AllowTrust{
+					Trustor:       receiverKP.Address(),
+					Type:          assetGOAT,
+					Authorize:     true,
+					SourceAccount: issuerKP.Address(),
+				},
+				&txnbuild.Payment{
+					SourceAccount: senderKP.Address(),
+					Destination:   receiverKP.Address(),
+					Amount:        "1",
+					Asset:         assetGOAT,
+				},
+				&txnbuild.AllowTrust{
+					Trustor:       receiverKP.Address(),
+					Type:          assetGOAT,
+					Authorize:     false,
+					SourceAccount: issuerKP.Address(),
+				},
+				&txnbuild.AllowTrust{
+					Trustor:       senderKP.Address(),
+					Type:          assetGOAT,
+					Authorize:     false,
+					SourceAccount: issuerKP.Address(),
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	txe, err := tx.Base64()
+	require.NoError(t, err)
+
+	txApprovalResp, err := handler.txApprove(ctx, txApproveRequest{Tx: txe})
+	require.NoError(t, err)
+	require.Equal(t, NewSuccessTxApprovalResponse(txApprovalResp.Tx, "Transaction is compliant and signed by the issuer."), txApprovalResp)
+}
+
 func TestTxApproveHandler_txApprove_actionRequired(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Support SEP-8 [success](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md#success) response.

### Why

According to SEP-8, if a client submits a transaction in a format already compliant with SEP-8 the server should be able to identify that case and sign the submitted transaction without revising it.

### Known limitations

N/A
