### PR TITLE
services/horizon: Return 503 error in POST /transactions if Stellar-Core not synced

### DIFF
--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -345,6 +345,10 @@ func getAsset(r *http.Request, prefix string) (xdr.Asset, error) {
 func getURLParam(r *http.Request, key string) (string, bool) {
 	rctx := chi.RouteContext(r.Context())
 
+	if rctx == nil {
+		return "", false
+	}
+
 	// Return immediately if keys does not match Values
 	// This can happen when a named param is not specified.
 	// This is a bug in chi: https://github.com/go-chi/chi/issues/426

--- a/services/horizon/internal/actions/root.go
+++ b/services/horizon/internal/actions/root.go
@@ -5,24 +5,18 @@ import (
 	"net/url"
 
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/corestate"
 	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/resourceadapter"
 )
 
-type CoreSettings struct {
-	Synced                       bool
-	CurrentProtocolVersion       int32
-	CoreSupportedProtocolVersion int32
-	CoreVersion                  string
-}
-
-type CoreSettingsGetter interface {
-	GetCoreSettings() CoreSettings
+type CoreStateGetter interface {
+	GetCoreState() corestate.State
 }
 
 type GetRootHandler struct {
 	LedgerState *ledger.State
-	CoreSettingsGetter
+	CoreStateGetter
 	NetworkPassphrase string
 	FriendbotURL      *url.URL
 	HorizonVersion    string
@@ -37,16 +31,16 @@ func (handler GetRootHandler) GetResource(w HeaderWriter, r *http.Request) (inte
 		"strictReceivePaths": StrictReceivePathsQuery{}.URITemplate(),
 		"strictSendPaths":    FindFixedPathsQuery{}.URITemplate(),
 	}
-	coreSettings := handler.GetCoreSettings()
+	coreState := handler.GetCoreState()
 	resourceadapter.PopulateRoot(
 		r.Context(),
 		&res,
 		handler.LedgerState.CurrentStatus(),
 		handler.HorizonVersion,
-		coreSettings.CoreVersion,
+		coreState.CoreVersion,
 		handler.NetworkPassphrase,
-		coreSettings.CurrentProtocolVersion,
-		coreSettings.CoreSupportedProtocolVersion,
+		coreState.CurrentProtocolVersion,
+		coreState.CoreSupportedProtocolVersion,
 		handler.FriendbotURL,
 		templates,
 	)

--- a/services/horizon/internal/actions/submit_transaction.go
+++ b/services/horizon/internal/actions/submit_transaction.go
@@ -19,6 +19,7 @@ import (
 type SubmitTransactionHandler struct {
 	Submitter         *txsub.System
 	NetworkPassphrase string
+	CoreStateGetter
 }
 
 type envelopeInfo struct {
@@ -134,6 +135,11 @@ func (handler SubmitTransactionHandler) GetResource(w HeaderWriter, r *http.Requ
 				"envelope_xdr": raw,
 			},
 		}
+	}
+
+	coreState := handler.GetCoreState()
+	if !coreState.Synced {
+		return nil, hProblem.StaleHistory
 	}
 
 	submission := handler.Submitter.Submit(

--- a/services/horizon/internal/actions_transaction_test.go
+++ b/services/horizon/internal/actions_transaction_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/corestate"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/ingest"
 	"github.com/stellar/go/services/horizon/internal/test"
@@ -249,7 +250,7 @@ func TestTransactionActions_Post(t *testing.T) {
 	defer ht.Finish()
 
 	// Pass Synced check
-	ht.App.coreState.Synced = true
+	ht.App.coreState.SetState(corestate.State{Synced: true})
 
 	tx := xdr.TransactionEnvelope{
 		Type: xdr.EnvelopeTypeEnvelopeTypeTxV0,
@@ -293,7 +294,7 @@ func TestTransactionActions_PostSuccessful(t *testing.T) {
 	defer ht.Finish()
 
 	// Pass Synced check
-	ht.App.coreState.Synced = true
+	ht.App.coreState.SetState(corestate.State{Synced: true})
 
 	destAID := xdr.MustAddress("GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON")
 	tx2 := xdr.TransactionEnvelope{
@@ -347,7 +348,7 @@ func TestTransactionActions_PostFailed(t *testing.T) {
 	defer ht.Finish()
 
 	// Pass Synced check
-	ht.App.coreState.Synced = true
+	ht.App.coreState.SetState(corestate.State{Synced: true})
 
 	// aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf
 	form := url.Values{"tx": []string{"AAAAAG5oJtVdnYOVdZqtXpTHBtbcY0mCmfcBIKEgWnlvFIhaAAAAZAAAAAIAAAACAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAO2C/AO45YBD3tHVFO1R3A0MekP8JR6nN1A9eWidyItUAAAABVVNEAAAAAACuo3ot45qCPExpQ/3oHN+z17Ryis1lfMFYmQWgruS+TAAAAAB3NZQAAAAAAAAAAAFvFIhaAAAAQKcGS9OsVnVHCVIH04C9ZKzzKYBRdCmy+Jwmzld7QcALOxZUcAgkuGfoSdvXpH38mNvrqQiaMsSNmTJWYRzHvgo="}}
@@ -363,7 +364,7 @@ func TestPostFeeBumpTransaction(t *testing.T) {
 	defer ht.Finish()
 
 	// Pass Synced check
-	ht.App.coreState.Synced = true
+	ht.App.coreState.SetState(corestate.State{Synced: true})
 
 	test.ResetHorizonDB(t, ht.HorizonDB)
 	q := &history.Q{ht.HorizonSession()}
@@ -402,7 +403,7 @@ func TestPostFailedFeeBumpTransaction(t *testing.T) {
 	defer ht.Finish()
 
 	// Pass Synced check
-	ht.App.coreState.Synced = true
+	ht.App.coreState.SetState(corestate.State{Synced: true})
 
 	test.ResetHorizonDB(t, ht.HorizonDB)
 	q := &history.Q{ht.HorizonSession()}

--- a/services/horizon/internal/actions_transaction_test.go
+++ b/services/horizon/internal/actions_transaction_test.go
@@ -248,6 +248,9 @@ func TestTransactionActions_Post(t *testing.T) {
 	ht := StartHTTPTest(t, "base")
 	defer ht.Finish()
 
+	// Pass Synced check
+	ht.App.coreState.Synced = true
+
 	tx := xdr.TransactionEnvelope{
 		Type: xdr.EnvelopeTypeEnvelopeTypeTxV0,
 		V0: &xdr.TransactionV0Envelope{
@@ -288,6 +291,9 @@ func TestTransactionActions_Post(t *testing.T) {
 func TestTransactionActions_PostSuccessful(t *testing.T) {
 	ht := StartHTTPTest(t, "failed_transactions")
 	defer ht.Finish()
+
+	// Pass Synced check
+	ht.App.coreState.Synced = true
 
 	destAID := xdr.MustAddress("GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON")
 	tx2 := xdr.TransactionEnvelope{
@@ -340,6 +346,9 @@ func TestTransactionActions_PostFailed(t *testing.T) {
 	ht := StartHTTPTest(t, "failed_transactions")
 	defer ht.Finish()
 
+	// Pass Synced check
+	ht.App.coreState.Synced = true
+
 	// aa168f12124b7c196c0adaee7c73a64d37f99428cacb59a91ff389626845e7cf
 	form := url.Values{"tx": []string{"AAAAAG5oJtVdnYOVdZqtXpTHBtbcY0mCmfcBIKEgWnlvFIhaAAAAZAAAAAIAAAACAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAO2C/AO45YBD3tHVFO1R3A0MekP8JR6nN1A9eWidyItUAAAABVVNEAAAAAACuo3ot45qCPExpQ/3oHN+z17Ryis1lfMFYmQWgruS+TAAAAAB3NZQAAAAAAAAAAAFvFIhaAAAAQKcGS9OsVnVHCVIH04C9ZKzzKYBRdCmy+Jwmzld7QcALOxZUcAgkuGfoSdvXpH38mNvrqQiaMsSNmTJWYRzHvgo="}}
 
@@ -352,6 +361,10 @@ func TestTransactionActions_PostFailed(t *testing.T) {
 func TestPostFeeBumpTransaction(t *testing.T) {
 	ht := StartHTTPTestWithoutScenario(t)
 	defer ht.Finish()
+
+	// Pass Synced check
+	ht.App.coreState.Synced = true
+
 	test.ResetHorizonDB(t, ht.HorizonDB)
 	q := &history.Q{ht.HorizonSession()}
 	fixture := history.FeeBumpScenario(ht.T, q, true)
@@ -387,6 +400,10 @@ func TestPostFeeBumpTransaction(t *testing.T) {
 func TestPostFailedFeeBumpTransaction(t *testing.T) {
 	ht := StartHTTPTestWithoutScenario(t)
 	defer ht.Finish()
+
+	// Pass Synced check
+	ht.App.coreState.Synced = true
+
 	test.ResetHorizonDB(t, ht.HorizonDB)
 	q := &history.Q{ht.HorizonSession()}
 	fixture := history.FeeBumpScenario(ht.T, q, false)

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -13,8 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stellar/go/clients/stellarcore"
-	proto "github.com/stellar/go/protocols/stellarcore"
-	"github.com/stellar/go/services/horizon/internal/actions"
+	"github.com/stellar/go/services/horizon/internal/corestate"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/httpx"
 	"github.com/stellar/go/services/horizon/internal/ingest"
@@ -30,26 +29,6 @@ import (
 	"github.com/stellar/go/support/log"
 )
 
-type coreSettingsStore struct {
-	sync.RWMutex
-	actions.CoreSettings
-}
-
-func (c *coreSettingsStore) set(resp *proto.InfoResponse) {
-	c.Lock()
-	defer c.Unlock()
-	c.Synced = resp.IsSynced()
-	c.CoreVersion = resp.Info.Build
-	c.CurrentProtocolVersion = int32(resp.Info.Ledger.Version)
-	c.CoreSupportedProtocolVersion = int32(resp.Info.ProtocolVersion)
-}
-
-func (c *coreSettingsStore) get() actions.CoreSettings {
-	c.RLock()
-	defer c.RUnlock()
-	return c.CoreSettings
-}
-
 // App represents the root of the state of a horizon instance.
 type App struct {
 	done            chan struct{}
@@ -60,7 +39,7 @@ type App struct {
 	ctx             context.Context
 	cancel          func()
 	horizonVersion  string
-	coreSettings    coreSettingsStore
+	coreState       corestate.Store
 	orderBookStream *ingest.OrderBookStream
 	submitter       *txsub.System
 	paths           paths.Finder
@@ -80,8 +59,8 @@ type App struct {
 	coreSynced                        prometheus.GaugeFunc
 }
 
-func (a *App) GetCoreSettings() actions.CoreSettings {
-	return a.coreSettings.get()
+func (a *App) GetCoreState() corestate.State {
+	return a.coreState.Get()
 }
 
 const tickerMaxFrequency = 1 * time.Second
@@ -390,7 +369,7 @@ func (a *App) UpdateStellarCoreInfo(ctx context.Context) {
 		os.Exit(1)
 	}
 
-	a.coreSettings.set(resp)
+	a.coreState.Set(resp)
 }
 
 // DeleteUnretainedHistory forwards to the app's reaper.  See

--- a/services/horizon/internal/corestate/main.go
+++ b/services/horizon/internal/corestate/main.go
@@ -15,20 +15,20 @@ type State struct {
 
 type Store struct {
 	sync.RWMutex
-	State
+	state State
 }
 
 func (c *Store) Set(resp *stellarcore.InfoResponse) {
 	c.Lock()
 	defer c.Unlock()
-	c.Synced = resp.IsSynced()
-	c.CoreVersion = resp.Info.Build
-	c.CurrentProtocolVersion = int32(resp.Info.Ledger.Version)
-	c.CoreSupportedProtocolVersion = int32(resp.Info.ProtocolVersion)
+	c.state.Synced = resp.IsSynced()
+	c.state.CoreVersion = resp.Info.Build
+	c.state.CurrentProtocolVersion = int32(resp.Info.Ledger.Version)
+	c.state.CoreSupportedProtocolVersion = int32(resp.Info.ProtocolVersion)
 }
 
 func (c *Store) Get() State {
 	c.RLock()
 	defer c.RUnlock()
-	return c.State
+	return c.state
 }

--- a/services/horizon/internal/corestate/main.go
+++ b/services/horizon/internal/corestate/main.go
@@ -27,6 +27,12 @@ func (c *Store) Set(resp *stellarcore.InfoResponse) {
 	c.state.CoreSupportedProtocolVersion = int32(resp.Info.ProtocolVersion)
 }
 
+func (c *Store) SetState(state State) {
+	c.Lock()
+	defer c.Unlock()
+	c.state = state
+}
+
 func (c *Store) Get() State {
 	c.RLock()
 	defer c.RUnlock()

--- a/services/horizon/internal/corestate/main.go
+++ b/services/horizon/internal/corestate/main.go
@@ -1,0 +1,34 @@
+package corestate
+
+import (
+	"sync"
+
+	"github.com/stellar/go/protocols/stellarcore"
+)
+
+type State struct {
+	Synced                       bool
+	CurrentProtocolVersion       int32
+	CoreSupportedProtocolVersion int32
+	CoreVersion                  string
+}
+
+type Store struct {
+	sync.RWMutex
+	State
+}
+
+func (c *Store) Set(resp *stellarcore.InfoResponse) {
+	c.Lock()
+	defer c.Unlock()
+	c.Synced = resp.IsSynced()
+	c.CoreVersion = resp.Info.Build
+	c.CurrentProtocolVersion = int32(resp.Info.Ledger.Version)
+	c.CoreSupportedProtocolVersion = int32(resp.Info.ProtocolVersion)
+}
+
+func (c *Store) Get() State {
+	c.RLock()
+	defer c.RUnlock()
+	return c.State
+}

--- a/services/horizon/internal/httpx/router.go
+++ b/services/horizon/internal/httpx/router.go
@@ -43,7 +43,7 @@ type RouterConfig struct {
 	MaxPathLength         uint
 	PathFinder            paths.Finder
 	PrometheusRegistry    *prometheus.Registry
-	CoreGetter            actions.CoreSettingsGetter
+	CoreGetter            actions.CoreStateGetter
 	HorizonVersion        string
 	FriendbotURL          *url.URL
 	HealthCheck           http.Handler
@@ -124,11 +124,11 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 	r.Method(http.MethodGet, "/health", config.HealthCheck)
 
 	r.Method(http.MethodGet, "/", ObjectActionHandler{Action: actions.GetRootHandler{
-		LedgerState:        ledgerState,
-		CoreSettingsGetter: config.CoreGetter,
-		NetworkPassphrase:  config.NetworkPassphrase,
-		FriendbotURL:       config.FriendbotURL,
-		HorizonVersion:     config.HorizonVersion,
+		LedgerState:       ledgerState,
+		CoreStateGetter:   config.CoreGetter,
+		NetworkPassphrase: config.NetworkPassphrase,
+		FriendbotURL:      config.FriendbotURL,
+		HorizonVersion:    config.HorizonVersion,
 	}})
 
 	streamHandler := sse.StreamHandler{
@@ -292,6 +292,7 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 	r.Method(http.MethodPost, "/transactions", ObjectActionHandler{actions.SubmitTransactionHandler{
 		Submitter:         config.TxSubmitter,
 		NetworkPassphrase: config.NetworkPassphrase,
+		CoreStateGetter:   config.CoreGetter,
 	}})
 
 	// Network state related endpoints

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -208,7 +208,7 @@ func initDbMetrics(app *App) {
 			Help: "determines if Stellar-Core defined by --stellar-core-url is synced with the network",
 		},
 		func() float64 {
-			if app.coreState.Synced {
+			if app.coreState.Get().Synced {
 				return 1
 			} else {
 				return 0

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -208,7 +208,7 @@ func initDbMetrics(app *App) {
 			Help: "determines if Stellar-Core defined by --stellar-core-url is synced with the network",
 		},
 		func() float64 {
-			if app.coreSettings.Synced {
+			if app.coreState.Synced {
 				return 1
 			} else {
 				return 0

--- a/services/horizon/internal/render/problem/problem.go
+++ b/services/horizon/internal/render/problem/problem.go
@@ -100,8 +100,8 @@ var (
 		Status: http.StatusServiceUnavailable,
 		Detail: "This horizon instance is configured to reject client requests " +
 			"when it can determine that the history database is lagging too far " +
-			"behind the connected instance of stellar-core or read replica. Please " +
-			"try again later.",
+			"behind the connected instance of Stellar-Core or read replica. It's " +
+			"also possible that Stellar-Core is out of sync. Please try again later.",
 	}
 
 	// StillIngesting is a well-known problem type.  Use it as a shortcut


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit changes `POST /transactions` behaviour to return `503 Service Unavailable` (`stale_history`) instead of `504 Gateway Timeout` (`timeout`) response if connected Stellar-Core is not synced.

Close #3550.

### Why

`timeout` error is confusing when the connected Stellar-Core is not synced because it means that the transaction has been broadcasted but there is no result yet. What actually happens is that the transaction is not broadcasted (and Horizon cannot ingest it) when Stellar-Core is not in synced. The new response is returned as soon as Horizon determines that the Stellar-Core status has changed.

### Known limitations

[TODO or N/A]
