### PR TITLE
SEP-8: prevent server from revising or approving a transaction if the destination account is the asset issuer

### DIFF
--- a/services/regulated-assets-approval-server/internal/serve/tx_approve.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve.go
@@ -164,6 +164,10 @@ func (h txApproveHandler) txApprove(ctx context.Context, in txApproveRequest) (r
 		paymentSource = tx.SourceAccount().AccountID
 	}
 
+	if paymentOp.Destination == h.issuerKP.Address() {
+		return NewRejectedTxApprovalResponse("Can't transfer asset to its issuer."), nil
+	}
+
 	// validate payment asset is the one supported by the issuer
 	issuerAddress := h.issuerKP.Address()
 	if paymentOp.Asset.GetCode() != h.assetCode || paymentOp.Asset.GetIssuer() != issuerAddress {
@@ -309,6 +313,10 @@ func (h txApproveHandler) handleSuccessResponseIfNeeded(ctx context.Context, tx 
 	rejectedResp, paymentOp, paymentSource := validateTransactionOperationsForSuccess(ctx, tx, h.issuerKP.Address())
 	if rejectedResp != nil {
 		return rejectedResp, nil
+	}
+
+	if paymentOp.Destination == h.issuerKP.Address() {
+		return NewRejectedTxApprovalResponse("Can't transfer asset to its issuer."), nil
 	}
 
 	// pull current account details from the network then validate the tx sequence number

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
@@ -389,6 +389,36 @@ func TestTxApproveHandler_txApprove_rejected(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, NewRejectedTxApprovalResponse("There is one or more unauthorized operations in the provided transaction."), txApprovalResp)
 
+	// rejected if attempting to transfer an asset to its own issuer
+	tx, err = txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount: &horizon.Account{
+				AccountID: senderKP.Address(),
+				Sequence:  "2",
+			},
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.Payment{
+					Destination: issuerKP.Address(),
+					Amount:      "1",
+					Asset: txnbuild.CreditAsset{
+						Code:   "FOO",
+						Issuer: keypair.MustRandom().Address(),
+					},
+				},
+			},
+			BaseFee:    txnbuild.MinBaseFee,
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	txe, err = tx.Base64()
+	require.NoError(t, err)
+
+	txApprovalResp, err = handler.txApprove(ctx, txApproveRequest{Tx: txe})
+	require.NoError(t, err)
+	assert.Equal(t, NewRejectedTxApprovalResponse("Can't transfer asset to its issuer."), txApprovalResp)
+
 	// rejected if payment asset is not supported
 	tx, err = txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
@@ -1026,6 +1056,54 @@ func TestTxApproveHandler_handleSuccessResponseIfNeeded_rejected(t *testing.T) {
 	txApprovalResp, err := handler.handleSuccessResponseIfNeeded(ctx, tx)
 	require.NoError(t, err)
 	assert.Equal(t, NewRejectedTxApprovalResponse("There are one or more unexpected operations in the provided transaction."), txApprovalResp)
+
+	// rejected if attempting to transfer an asset to its own issuer
+	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &horizon.Account{
+			AccountID: senderKP.Address(),
+			Sequence:  "2",
+		},
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.AllowTrust{
+				Trustor:       senderKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     true,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       issuerKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     true,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.Payment{
+				SourceAccount: senderKP.Address(),
+				Destination:   issuerKP.Address(),
+				Amount:        "1",
+				Asset:         assetGOAT,
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       issuerKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     false,
+				SourceAccount: issuerKP.Address(),
+			},
+			&txnbuild.AllowTrust{
+				Trustor:       senderKP.Address(),
+				Type:          assetGOAT,
+				Authorize:     false,
+				SourceAccount: issuerKP.Address(),
+			},
+		},
+		BaseFee:    300,
+		Timebounds: txnbuild.NewTimeout(300),
+	})
+	require.NoError(t, err)
+
+	txApprovalResp, err = handler.handleSuccessResponseIfNeeded(ctx, tx)
+	require.NoError(t, err)
+	assert.Equal(t, NewRejectedTxApprovalResponse("Can't transfer asset to its issuer."), txApprovalResp)
 
 	// rejected if sequence number is not incremental
 	compliantOps := []txnbuild.Operation{

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
@@ -399,7 +399,7 @@ func TestTxApproveHandler_txApprove_rejected(t *testing.T) {
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
 				&txnbuild.Payment{
-					Destination: issuerKP.Address(),
+					Destination: issuerKP.Address(), // <--- this will trigger the rejection
 					Amount:      "1",
 					Asset: txnbuild.CreditAsset{
 						Code:   "FOO",
@@ -1079,7 +1079,7 @@ func TestTxApproveHandler_handleSuccessResponseIfNeeded_rejected(t *testing.T) {
 			},
 			&txnbuild.Payment{
 				SourceAccount: senderKP.Address(),
-				Destination:   issuerKP.Address(),
+				Destination:   issuerKP.Address(), // <--- this will trigger the rejection
 				Amount:        "1",
 				Asset:         assetGOAT,
 			},


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Prevent server from revising or approving a transaction if the destination account is the asset issuer.

### Why

When you send a payment to the asset issuer those assets end up being burned and cease from existing. We don't want to allow that to happen in our SEP-8 server.

### Known limitations

N/A
