### PR TITLE
exp/services/recoverysigner: update usage in readme

### DIFF
--- a/exp/services/recoverysigner/README.md
+++ b/exp/services/recoverysigner/README.md
@@ -38,21 +38,23 @@ Use "recoverysigner [command] --help" for more information about a command.
 
 ```
 $ recoverysigner serve --help
-Run the SEP-30 Recover Signer server
+Run the SEP-30 Recovery Signer server
 
 Usage:
   recoverysigner serve [flags]
 
 Flags:
-      --admin-port int               Port to listen and serve admin functionality including metrics (ADMIN_PORT)
-      --db-url string                Database URL (DB_URL) (default "postgres://localhost:5432/?sslmode=disable")
-      --firebase-project-id string   Firebase project ID to use for validating Firebase JWTs (FIREBASE_PROJECT_ID)
-      --metrics-namespace string     Namespace to use for metric names prefixed to metrics reported (METRICS_NAMESPACE) (default "recoverysigner")
-      --network-passphrase string    Network passphrase of the Stellar network transactions should be signed for (NETWORK_PASSPHRASE) (default "Test SDF Network ; September 2015")
-      --port int                     Port to listen and serve on (PORT) (default 8000)
-      --sep10-jwks string            JSON Web Key Set (JWKS) containing one or more keys used to validate SEP-10 JWTs (if the key is an asymmetric key that has separate public and private key, the JWK need only contain the public key) (if multiple keys are provided they will all attempt verification the key ID will be ignored although logged) (SEP10_JWKS)
-      --sep10-jwt-issuer string      JWT issuer to verify if in the SEP-10 JWT iss field (not checked if empty) (SEP10_JWT_ISSUER)
-      --signing-key string           Stellar signing key(s) used for signing transactions comma separated (first key is preferred signer) (will be deprecated with per-account keys in the future) (SIGNING_KEY)
+      --admin-port int                   Port to listen and serve admin functionality including metrics (ADMIN_PORT)
+      --allowed-source-accounts string   Stellar account(s) allowed as source accounts in transactions signed for all users in addition to the registered account comma separated (important: these accounts must never be registered accounts and must never have the signer configured that is a signing key used by this server) (ALLOWED_SOURCE_ACCOUNTS)
+      --db-max-open-conns int            Database max open connections (DB_MAX_OPEN_CONNS) (default 20)
+      --db-url string                    Database URL (DB_URL) (default "postgres://localhost:5432/?sslmode=disable")
+      --firebase-project-id string       Firebase project ID to use for validating Firebase JWTs (FIREBASE_PROJECT_ID)
+      --metrics-namespace string         Namespace to use for metric names prefixed to metrics reported (METRICS_NAMESPACE) (default "recoverysigner")
+      --network-passphrase string        Network passphrase of the Stellar network transactions should be signed for (NETWORK_PASSPHRASE) (default "Test SDF Network ; September 2015")
+      --port int                         Port to listen and serve on (PORT) (default 8000)
+      --sep10-jwks string                JSON Web Key Set (JWKS) containing one or more keys used to validate SEP-10 JWTs (if the key is an asymmetric key that has separate public and private key, the JWK need only contain the public key) (if multiple keys are provided they will all attempt verification the key ID will be ignored although logged) (SEP10_JWKS)
+      --sep10-jwt-issuer string          JWT issuer to verify is in the SEP-10 JWT iss field (not checked if empty) (SEP10_JWT_ISSUER)
+      --signing-key string               Stellar signing key(s) used for signing transactions comma separated (first key is preferred signer) (will be deprecated with per-account keys in the future) (SIGNING_KEY)
 ```
 
 ## Usage: db


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Update the usage of recoverysigner in its readme.

### Why

It looks like it has become out of date. Notably the allowed source accounts option is not present.

### Known limitations

N/A