### PR TITLE
services/horizon: Add `horizon db detect-gaps` command

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -9,6 +9,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Fix bug in `horizon db reingest range` command, which would throw a duplicate entry conflict error from the DB. ([3661](https://github.com/stellar/go/pull/3661)).
 * Fix bug in DB metrics preventing Horizon from starting when read-only replica middleware is enabled. ([3668](https://github.com/stellar/go/pull/3668)).
+* Add new command `horizon db detect-gaps`, which detects ingestion gaps in the database. The command prints out the `db reingest` commands to run in order to fill the gaps found. 
 
 ## v2.4.0
 

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -323,7 +323,6 @@ var dbDetectGapsCmd = &cobra.Command{
 }
 
 func runDBDetectGaps(config horizon.Config) ([]history.LedgerGap, error) {
-	fmt.Println(config.DatabaseURL)
 	horizonSession, err := db.Open("postgres", config.DatabaseURL)
 	if err != nil {
 		return nil, err

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -295,6 +295,67 @@ func runDBReingestRange(from, to uint32, reingestForce bool, parallelWorkers uin
 	)
 }
 
+var dbDetectGapsCmd = &cobra.Command{
+	Use:   "detect-gaps",
+	Short: "detects ingestion gaps in Horizon's database",
+	Long:  "detects ingestion gaps in Horizon's database and prints a list of reingest commands needed to fill the gaps",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireAndSetFlag(horizon.DatabaseURLFlagName)
+		if len(args) != 0 {
+			cmd.Usage()
+			os.Exit(1)
+		}
+		gaps, err := runDBDetectGaps(*config)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if len(gaps) == 0 {
+			hlog.Info("No gaps found")
+			return
+		}
+		cmdname := os.Args[0]
+		for _, g := range gaps {
+			fmt.Printf("%s db reingest %d %d\n", cmdname, g.GapStartSequence, g.GapEndSequence)
+		}
+	},
+}
+
+type gap struct {
+	GapStartSequence uint32
+	GapEndSequence   uint32
+}
+
+func runDBDetectGaps(config horizon.Config) ([]gap, error) {
+	fmt.Println(config.DatabaseURL)
+	db, err := sql.Open("postgres", config.DatabaseURL)
+	if err != nil {
+		return nil, err
+	}
+	query := `SELECT sequence + 1 AS gap_start,
+		next_number - 1 AS gap_end
+	FROM (
+		SELECT sequence,
+		LEAD(sequence) OVER (ORDER BY sequence) AS next_number
+	FROM history_ledgers
+	) number
+	WHERE sequence + 1 <> next_number;`
+	var result []gap
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var g gap
+		err := rows.Scan(&g.GapStartSequence, &g.GapEndSequence)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, g)
+	}
+	return result, nil
+}
+
 func init() {
 	for _, co := range reingestRangeCmdOpts {
 		err := co.Init(dbReingestRangeCmd)
@@ -311,6 +372,7 @@ func init() {
 		dbMigrateCmd,
 		dbReapCmd,
 		dbReingestCmd,
+		dbDetectGapsCmd,
 	)
 	dbReingestCmd.AddCommand(dbReingestRangeCmd)
 }

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
 
 	horizon "github.com/stellar/go/services/horizon/internal"
 	"github.com/stellar/go/services/horizon/internal/db2/schema"
@@ -315,45 +316,19 @@ var dbDetectGapsCmd = &cobra.Command{
 		}
 		cmdname := os.Args[0]
 		for _, g := range gaps {
-			fmt.Printf("%s db reingest %d %d\n", cmdname, g.GapStartSequence, g.GapEndSequence)
+			fmt.Printf("%s db reingest %d %d\n", cmdname, g.StartSequence, g.EndSequence)
 		}
 	},
 }
 
-type gap struct {
-	GapStartSequence uint32
-	GapEndSequence   uint32
-}
-
-func runDBDetectGaps(config horizon.Config) ([]gap, error) {
+func runDBDetectGaps(config horizon.Config) ([]history.LedgerGap, error) {
 	fmt.Println(config.DatabaseURL)
-	db, err := sql.Open("postgres", config.DatabaseURL)
+	horizonSession, err := db.Open("postgres", config.DatabaseURL)
 	if err != nil {
 		return nil, err
 	}
-	query := `SELECT sequence + 1 AS gap_start,
-		next_number - 1 AS gap_end
-	FROM (
-		SELECT sequence,
-		LEAD(sequence) OVER (ORDER BY sequence) AS next_number
-	FROM history_ledgers
-	) number
-	WHERE sequence + 1 <> next_number;`
-	var result []gap
-	rows, err := db.Query(query)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var g gap
-		err := rows.Scan(&g.GapStartSequence, &g.GapEndSequence)
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, g)
-	}
-	return result, nil
+	q := &history.Q{horizonSession}
+	return q.GetLedgerGaps(context.Background())
 }
 
 func init() {

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -314,6 +314,7 @@ var dbDetectGapsCmd = &cobra.Command{
 			hlog.Info("No gaps found")
 			return
 		}
+		fmt.Println("Horizon commands to run in order to fill in the gaps:")
 		cmdname := os.Args[0]
 		for _, g := range gaps {
 			fmt.Printf("%s db reingest %d %d\n", cmdname, g.StartSequence, g.EndSequence)

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -537,6 +537,11 @@ type LedgerCache struct {
 	queued map[int32]struct{}
 }
 
+type LedgerGap struct {
+	StartSequence uint32 `db:"gap_start"`
+	EndSequence   uint32 `db:"gap_end"`
+}
+
 // LedgersQ is a helper struct to aid in configuring queries that loads
 // slices of Ledger structs.
 type LedgersQ struct {


### PR DESCRIPTION
Fixes #3530

This PR adds a new `horizon db detect-gaps` command