### PR TITLE
support/db: Handle "conflict with recovery" errors gracefully

### DIFF
--- a/services/horizon/internal/httpx/server.go
+++ b/services/horizon/internal/httpx/server.go
@@ -57,6 +57,7 @@ func init() {
 	problem.RegisterError(context.DeadlineExceeded, hProblem.Timeout)
 	problem.RegisterError(context.Canceled, hProblem.ServiceUnavailable)
 	problem.RegisterError(db.ErrCancelled, hProblem.ServiceUnavailable)
+	problem.RegisterError(db.ErrConflictWithRecovery, hProblem.ServiceUnavailable)
 }
 
 func NewServer(serverConfig ServerConfig, routerConfig RouterConfig, ledgerState *ledger.State) (*Server, error) {

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -34,6 +34,10 @@ var (
 	// ErrCancelled is an error returned by Session methods when request has
 	// been cancelled (ex. context cancelled).
 	ErrCancelled = errors.New("canceling statement due to user request")
+	// ErrConflictWithRecovery is an error returned by Session methods when
+	// read replica cancels the query due to conflict with about-to-be-applied
+	// WAL entries (https://www.postgresql.org/docs/current/hot-standby.html).
+	ErrConflictWithRecovery = errors.New("canceling statement due to conflict with recovery")
 )
 
 // Conn represents a connection to a single database.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

This commit returns `ErrConflictWithRecovery` error in case of Postgres `canceling statement due to conflict with recovery` error and handles this error in Horizon.