### PR TITLE
services/regulated-assets-approval-server: refactor tests targetting the "/kyc-status/*" endpoints

### DIFF
--- a/services/regulated-assets-approval-server/internal/serve/api_kyc_status_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/api_kyc_status_test.go
@@ -21,44 +21,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAPI_POSTKYCStatus(t *testing.T) {
+func TestAPI_postKYCStatus(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
 	defer conn.Close()
 
-	// Create kyc-status PostHandler.
-	postHandler := kycstatus.PostHandler{DB: conn}
+	handler := kycstatus.PostHandler{DB: conn}
+	m := chi.NewMux()
+	m.Post("/kyc-status/{callback_id}", handler.ServeHTTP)
 
-	// INSERT new unverified account in db's accounts_kyc_status table.
-	const insertNewAccountQuery = `
-	INSERT INTO accounts_kyc_status (stellar_address, callback_id)
-	VALUES ($1, $2)
+	q := `
+		INSERT INTO accounts_kyc_status (stellar_address, callback_id)
+		VALUES ($1, $2)
 	`
-	approveKP := keypair.MustRandom()
+	clientKP := keypair.MustRandom()
 	callbackID := uuid.New().String()
-	_, err := postHandler.DB.ExecContext(ctx, insertNewAccountQuery, approveKP.Address(), callbackID)
+	_, err := handler.DB.ExecContext(ctx, q, clientKP.Address(), callbackID)
 	require.NoError(t, err)
 
-	// Preparing and send /kyc-status/{callback_id} POST request.
-	m := chi.NewMux()
-	m.Post("/kyc-status/{callback_id}", postHandler.ServeHTTP)
-	reqBody := `{
-		"email_address": "TestEmail@email.com"
-	}`
-	r := httptest.NewRequest("POST", fmt.Sprintf("/kyc-status/%s", callbackID), strings.NewReader(reqBody))
+	r := httptest.NewRequest("POST", "/kyc-status/"+callbackID, strings.NewReader(`{"email_address": "email@test.com"}`))
 	r = r.WithContext(ctx)
 	w := httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp := w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-
-	// TEST "no_further_action_required" response for approved account.
 	type kycStatusPOSTResponse struct {
 		Result string `json:"result"`
 	}
@@ -70,455 +62,110 @@ func TestAPI_POSTKYCStatus(t *testing.T) {
 	}
 	assert.Equal(t, wantPostResponse, kycStatusPOSTResponseApprove)
 
-	// Query db's accounts_kyc_status table account after /kyc-status/{callback_id} POST request.
-	const selectAccountQuery = `
-	SELECT approved_at, rejected_at, pending_at
-	FROM accounts_kyc_status
-	WHERE callback_id = $1
+	q = `
+		SELECT rejected_at, pending_at, approved_at
+		FROM accounts_kyc_status
+		WHERE stellar_address = $1 AND callback_id = $2
 	`
-	var approvedAt, rejectedAt, pendingAt sql.NullTime
-	err = postHandler.DB.QueryRowContext(ctx, selectAccountQuery, callbackID).Scan(&approvedAt, &rejectedAt, &pendingAt)
+	var rejectedAt, pendingAt, approvedAt sql.NullTime
+	err = handler.DB.QueryRowContext(ctx, q, clientKP.Address(), callbackID).Scan(&rejectedAt, &pendingAt, &approvedAt)
 	require.NoError(t, err)
 
-	// TEST if account in db's accounts_kyc_status table was approved.
-	// sql.NullTime.Valid is true if Time is not NULL
 	assert.True(t, approvedAt.Valid)
 	assert.False(t, rejectedAt.Valid)
 	assert.False(t, pendingAt.Valid)
-
-	// INSERT new unverified account in db's accounts_kyc_status table.
-	rejectedKP := keypair.MustRandom()
-	callbackIDRejected := uuid.New().String()
-	_, err = postHandler.DB.ExecContext(ctx, insertNewAccountQuery, rejectedKP.Address(), callbackIDRejected)
-	require.NoError(t, err)
-
-	// Preparing and send /kyc-status/{callback_id} POST request.
-	reqBody = `{
-		"email_address": "xTestEmail@email.com"
-	}`
-	r = httptest.NewRequest("POST", fmt.Sprintf("/kyc-status/%s", callbackIDRejected), strings.NewReader(reqBody))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "no_further_action_required" response for rejected account.
-	var kycStatusPOSTResponseRejected kycStatusPOSTResponse
-	err = json.Unmarshal(body, &kycStatusPOSTResponseRejected)
-	require.NoError(t, err)
-	wantPostResponse = kycStatusPOSTResponse{
-		Result: "no_further_action_required",
-	}
-	assert.Equal(t, wantPostResponse, kycStatusPOSTResponseRejected)
-
-	// Query db's accounts_kyc_status table account after /kyc-status/{callback_id} POST request.
-	err = postHandler.DB.QueryRowContext(ctx, selectAccountQuery, callbackIDRejected).Scan(&approvedAt, &rejectedAt, &pendingAt)
-	require.NoError(t, err)
-
-	// TEST if account in db's accounts_kyc_status table was rejected.
-	// Should be rejected based on arbitrary rule where emails begin with "x".
-	// sql.NullTime.Valid is true if Time is not NULL
-	assert.True(t, rejectedAt.Valid)
-	assert.False(t, approvedAt.Valid)
-	assert.False(t, pendingAt.Valid)
-
-	// emails starting with "y" will be marked as "pending"
-	reqBody = `{
-		"email_address": "yTestEmailx@email.com"
-	}`
-	r = httptest.NewRequest("POST", "/kyc-status/"+callbackIDRejected, strings.NewReader(reqBody))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	var kycStatusResponse kycStatusPOSTResponse
-	err = json.Unmarshal(body, &kycStatusResponse)
-	require.NoError(t, err)
-	wantPostResponse = kycStatusPOSTResponse{
-		Result: "no_further_action_required",
-	}
-	assert.Equal(t, wantPostResponse, kycStatusResponse)
-
-	err = postHandler.DB.QueryRowContext(ctx, selectAccountQuery, callbackIDRejected).Scan(&approvedAt, &rejectedAt, &pendingAt)
-	require.NoError(t, err)
-	assert.False(t, approvedAt.Valid)
-	assert.False(t, rejectedAt.Valid)
-	assert.True(t, pendingAt.Valid)
-
-	// Preparing and send /kyc-status/{callback_id} POST request; using the rejected account's callback_ID.
-	reqBody = `{
-		"email_address": "TestEmailx@email.com"
-	}`
-	r = httptest.NewRequest("POST", fmt.Sprintf("/kyc-status/%s", callbackIDRejected), strings.NewReader(reqBody))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "no_further_action_required" response for repeated KYC request after REJECTED w/ new email.
-	var kycStatusPOSTResponseRejectedNewEmail kycStatusPOSTResponse
-	err = json.Unmarshal(body, &kycStatusPOSTResponseRejectedNewEmail)
-	require.NoError(t, err)
-	wantPostResponse = kycStatusPOSTResponse{
-		Result: "no_further_action_required",
-	}
-	assert.Equal(t, wantPostResponse, kycStatusPOSTResponseRejectedNewEmail)
-
-	// Query db's accounts_kyc_status table account after /kyc-status/{callback_id} POST request.
-	selectUpdatedAccountEmailQuery := `
-	SELECT approved_at, rejected_at, pending_at, email_address
-	FROM accounts_kyc_status
-	WHERE callback_id = $1
-	`
-	var updatedEmail string
-	err = postHandler.DB.QueryRowContext(ctx, selectUpdatedAccountEmailQuery, callbackIDRejected).Scan(&approvedAt, &rejectedAt, &pendingAt, &updatedEmail)
-	require.NoError(t, err)
-
-	// TEST if account in db's accounts_kyc_status table was approved, and email was overwritten.
-	// sql.NullTime.Valid is true if Time is not NULL
-	assert.True(t, approvedAt.Valid)
-	assert.False(t, rejectedAt.Valid)
-	assert.False(t, pendingAt.Valid)
-	assert.NotEqual(t, "xTestEmail@email.com", updatedEmail)
-
-	// Preparing and send /kyc-status/{callback_id} POST request; w/ empty email value.
-	noEmailKP := keypair.MustRandom()
-	callbackIDNoEmail := uuid.New().String()
-	_, err = postHandler.DB.ExecContext(ctx, insertNewAccountQuery, noEmailKP.Address(), callbackIDNoEmail)
-	require.NoError(t, err)
-	reqBody = `{
-		"email_address": ""
-	}`
-	r = httptest.NewRequest("POST", fmt.Sprintf("/kyc-status/%s", callbackIDNoEmail), strings.NewReader(reqBody))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "Missing email_address" error response.
-	wantPostResponseMissingEmail := `{
-		"error": "Missing email_address."
-	}`
-	require.JSONEq(t, wantPostResponseMissingEmail, string(body))
-
-	// Preparing and send /kyc-status/{callback_id} POST request; callback_id not registered.
-	callbackIDNotFound := uuid.New().String()
-	reqBody = `{
-		"email_address": "notFound@email.com"
-	}`
-	r = httptest.NewRequest("POST", fmt.Sprintf("/kyc-status/%s", callbackIDNotFound), strings.NewReader(reqBody))
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusNotFound, w.Code)
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "Not found." error response.
-	wantPostResponseNotFound := `{
-		"error": "Not found."
-	}`
-	require.JSONEq(t, wantPostResponseNotFound, string(body))
 }
 
-func TestAPI_GETKYCStatus(t *testing.T) {
+func TestAPI_getKYCStatus(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
 	defer conn.Close()
 
-	// Create kyc-status GetDetailHandler.
-	getHandler := kycstatus.GetDetailHandler{DB: conn}
+	handler := kycstatus.GetDetailHandler{DB: conn}
+	m := chi.NewMux()
+	m.Get("/kyc-status/{stellar_address_or_callback_id}", handler.ServeHTTP)
 
-	// INSERT new account in db's accounts_kyc_status table; new account was approved after submitting kyc.
-	insertNewApprovedAccountQuery := `
-	INSERT INTO accounts_kyc_status (stellar_address, callback_id, email_address, kyc_submitted_at, approved_at, rejected_at)
-	VALUES ($1, $2, $3, NOW(), NOW(), NULL)
+	const q = `
+		INSERT INTO accounts_kyc_status (stellar_address, callback_id, email_address, kyc_submitted_at, approved_at, rejected_at, pending_at, created_at)
+		VALUES ($1, $2, $3, $4::timestamptz, $4::timestamptz, NULL, NULL, $5::timestamptz)
 	`
-	approveKP := keypair.MustRandom()
-	approveCallbackID := uuid.New().String()
-	approveEmailAddress := "email@approved.com"
-	_, err := getHandler.DB.ExecContext(ctx, insertNewApprovedAccountQuery, approveKP.Address(), approveCallbackID, approveEmailAddress)
+	clientKP := keypair.MustRandom()
+	callbackID := uuid.New().String()
+	emailAddress := "email@test.com"
+	approvedAt := time.Now().UTC().Truncate(time.Second)
+	createdAt := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Second)
+	_, err := handler.DB.ExecContext(ctx, q, clientKP.Address(), callbackID, emailAddress, approvedAt.Format(time.RFC3339), createdAt.Format(time.RFC3339))
 	require.NoError(t, err)
 
 	// Prepare and send /kyc-status/{stellar_address_or_callback_id} GET request; for approved account in the accounts_kyc_status table.
-	m := chi.NewMux()
-	m.Get("/kyc-status/{stellar_address_or_callback_id}", getHandler.ServeHTTP)
-	r := httptest.NewRequest("GET", fmt.Sprintf("/kyc-status/%s", approveKP.Address()), nil)
+	r := httptest.NewRequest("GET", fmt.Sprintf("/kyc-status/%s", clientKP.Address()), nil)
 	r = r.WithContext(ctx)
 	w := httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp := w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-
-	// TEST kycGetResponse response for approved account.
-	type kycGETResponse struct {
-		StellarAddress string     `json:"stellar_address"`
-		CallbackID     string     `json:"callback_id"`
-		EmailAddress   string     `json:"email_address,omitempty"`
-		CreatedAt      *time.Time `json:"created_at"`
-		KYCSubmittedAt *time.Time `json:"kyc_submitted_at,omitempty"`
-		ApprovedAt     *time.Time `json:"approved_at,omitempty"`
-		RejectedAt     *time.Time `json:"rejected_at,omitempty"`
-	}
-	var kycStatusGETResponseApprove kycGETResponse
-	err = json.Unmarshal(body, &kycStatusGETResponseApprove)
-	require.NoError(t, err)
-	wantPostResponse := kycGETResponse{
-		StellarAddress: approveKP.Address(),
-		CallbackID:     approveCallbackID,
-		EmailAddress:   approveEmailAddress,
-		CreatedAt:      kycStatusGETResponseApprove.CreatedAt,
-		KYCSubmittedAt: kycStatusGETResponseApprove.KYCSubmittedAt,
-		ApprovedAt:     kycStatusGETResponseApprove.ApprovedAt,
-		RejectedAt:     kycStatusGETResponseApprove.RejectedAt,
-	}
-	assert.Equal(t, wantPostResponse, kycStatusGETResponseApprove)
-
-	// TEST if response timestamps are present or null.
-	require.NotNil(t, kycStatusGETResponseApprove.CreatedAt)
-	require.NotNil(t, kycStatusGETResponseApprove.KYCSubmittedAt)
-	require.NotNil(t, kycStatusGETResponseApprove.ApprovedAt)
-	require.Nil(t, kycStatusGETResponseApprove.RejectedAt)
-
-	// INSERT new account in db's accounts_kyc_status table; new account was pending after submiting kyc.
-	insertNewPendingAccountQuery := `
-	INSERT INTO accounts_kyc_status (stellar_address, callback_id, email_address, kyc_submitted_at, approved_at, rejected_at, pending_at)
-	VALUES ($1, $2, $3, NOW(), NULL, NULL, NOW())
-	`
-	pendingKP := keypair.MustRandom()
-	pendingCallbackID := uuid.New().String()
-	pendingEmailAddress := "yemail@rejected.com"
-	_, err = getHandler.DB.ExecContext(ctx, insertNewPendingAccountQuery, pendingKP.Address(), pendingCallbackID, pendingEmailAddress)
-	require.NoError(t, err)
-
-	// Prepare and send /kyc-status/{stellar_address_or_callback_id} GET request; for rejected account in the accounts_kyc_status table.
-	r = httptest.NewRequest("GET", "/kyc-status/"+pendingKP.Address(), nil)
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	var kycStatusGETResponsePending kycGETResponse
-	err = json.Unmarshal(body, &kycStatusGETResponsePending)
-	require.NoError(t, err)
-	wantPostResponse = kycGETResponse{
-		StellarAddress: pendingKP.Address(),
-		CallbackID:     pendingCallbackID,
-		EmailAddress:   pendingEmailAddress,
-		CreatedAt:      kycStatusGETResponsePending.CreatedAt,
-		KYCSubmittedAt: kycStatusGETResponsePending.KYCSubmittedAt,
-		ApprovedAt:     kycStatusGETResponsePending.ApprovedAt,
-		RejectedAt:     kycStatusGETResponsePending.RejectedAt,
-	}
-	assert.Equal(t, wantPostResponse, kycStatusGETResponsePending)
-
-	// INSERT new account in db's accounts_kyc_status table; new account was rejected after submiting kyc.
-	insertNewRejectedAccountQuery := `
-	INSERT INTO accounts_kyc_status (stellar_address, callback_id, email_address, kyc_submitted_at, approved_at, rejected_at)
-	VALUES ($1, $2, $3, NOW(), NULL, NOW())
-	`
-	rejectKP := keypair.MustRandom()
-	rejectCallbackID := uuid.New().String()
-	rejectEmailAddress := "xemail@rejected.com"
-	_, err = getHandler.DB.ExecContext(ctx, insertNewRejectedAccountQuery, rejectKP.Address(), rejectCallbackID, rejectEmailAddress)
-	require.NoError(t, err)
-
-	// Prepare and send /kyc-status/{stellar_address_or_callback_id} GET request; for rejected account in the accounts_kyc_status table.
-	r = httptest.NewRequest("GET", fmt.Sprintf("/kyc-status/%s", rejectKP.Address()), nil)
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST kycGetResponse response for rejected account.
-	var kycStatusGETResponseReject kycGETResponse
-	err = json.Unmarshal(body, &kycStatusGETResponseReject)
-	require.NoError(t, err)
-	wantPostResponse = kycGETResponse{
-		StellarAddress: rejectKP.Address(),
-		CallbackID:     rejectCallbackID,
-		EmailAddress:   rejectEmailAddress,
-		CreatedAt:      kycStatusGETResponseReject.CreatedAt,
-		KYCSubmittedAt: kycStatusGETResponseReject.KYCSubmittedAt,
-		ApprovedAt:     kycStatusGETResponseReject.ApprovedAt,
-		RejectedAt:     kycStatusGETResponseReject.RejectedAt,
-	}
-	assert.Equal(t, wantPostResponse, kycStatusGETResponseReject)
-
-	// TEST if response timestamps are present or null.
-	require.NotNil(t, kycStatusGETResponseReject.CreatedAt)
-	require.NotNil(t, kycStatusGETResponseReject.KYCSubmittedAt)
-	require.NotNil(t, kycStatusGETResponseReject.RejectedAt)
-	require.Nil(t, kycStatusGETResponseReject.ApprovedAt)
-
-	// INSERT new account in db's accounts_kyc_status table; new account hasn't submitted kyc.
-	insertNewAccountNoKycQuery := `
-		INSERT INTO accounts_kyc_status (stellar_address, callback_id, email_address, kyc_submitted_at, approved_at, rejected_at)
-		VALUES ($1, $2, NULL, NULL, NULL, NULL)
-	`
-	noKycAccountKP := keypair.MustRandom()
-	noKycCallbackID := uuid.New().String()
-	_, err = getHandler.DB.ExecContext(ctx, insertNewAccountNoKycQuery, noKycAccountKP.Address(), noKycCallbackID)
-	require.NoError(t, err)
-
-	// Prepare and send /kyc-status/{stellar_address_or_callback_id} GET request; for no KYC account in the accounts_kyc_status table (this time using their callbackID).
-	r = httptest.NewRequest("GET", fmt.Sprintf("/kyc-status/%s", noKycCallbackID), nil)
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST kycGetResponse response for account that hasn't submitted kyc.
-	var kycStatusGETResponseNoKyc kycGETResponse
-	err = json.Unmarshal(body, &kycStatusGETResponseNoKyc)
-	require.NoError(t, err)
-	wantPostResponse = kycGETResponse{
-		StellarAddress: noKycAccountKP.Address(),
-		CallbackID:     noKycCallbackID,
-		EmailAddress:   "",
-		CreatedAt:      kycStatusGETResponseNoKyc.CreatedAt,
-		KYCSubmittedAt: kycStatusGETResponseNoKyc.KYCSubmittedAt,
-		ApprovedAt:     kycStatusGETResponseNoKyc.ApprovedAt,
-		RejectedAt:     kycStatusGETResponseNoKyc.RejectedAt,
-	}
-	assert.Equal(t, wantPostResponse, kycStatusGETResponseNoKyc)
-
-	// TEST if response timestamps are present or null.
-	require.NotNil(t, kycStatusGETResponseNoKyc.CreatedAt)
-	require.Nil(t, kycStatusGETResponseNoKyc.KYCSubmittedAt)
-	require.Nil(t, kycStatusGETResponseNoKyc.RejectedAt)
-	require.Nil(t, kycStatusGETResponseNoKyc.ApprovedAt)
-
-	// Prepare and send /kyc-status/{stellar_address_or_callback_id} GET request; for an account that isn't in the accounts_kyc_status table.
-	notPresentKP := keypair.MustRandom()
-	r = httptest.NewRequest("GET", fmt.Sprintf("/kyc-status/%s", notPresentKP.Address()), nil)
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusNotFound, w.Code)
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST "Not found." error response.
-	wantGetResponseNotFound := `{
-		"error": "Not found."
-	}`
-	require.JSONEq(t, wantGetResponseNotFound, string(body))
+	wantBody := fmt.Sprintf(`{
+		"stellar_address": "%s",
+		"callback_id": "%s",
+		"email_address": "%s",
+		"created_at": "%s",
+		"kyc_submitted_at": "%s",
+		"approved_at": "%s"
+	}`, clientKP.Address(), callbackID, emailAddress, createdAt.Format(time.RFC3339), approvedAt.Format(time.RFC3339), approvedAt.Format(time.RFC3339))
+	require.JSONEq(t, wantBody, string(body))
 }
 
-func TestAPI_DELETEKYCStatus(t *testing.T) {
+func TestAPI_deleteKYCStatus(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
 	defer conn.Close()
 
-	// Create kyc-status DeleteHandler.
-	deleteHandler := kycstatus.DeleteHandler{DB: conn}
+	handler := kycstatus.DeleteHandler{DB: conn}
+	m := chi.NewMux()
+	m.Delete("/kyc-status/{stellar_address}", handler.ServeHTTP)
 
-	// INSERT new account in db's accounts_kyc_status table; new account was approved after submitting kyc.
-	insertNewApprovedAccountQuery := `
-	INSERT INTO accounts_kyc_status (stellar_address, callback_id, email_address, kyc_submitted_at, approved_at, rejected_at)
-	VALUES ($1, $2, $3, NOW(), NOW(), NULL)
+	q := `
+		INSERT INTO accounts_kyc_status (stellar_address, callback_id, email_address, kyc_submitted_at, approved_at, rejected_at, pending_at)
+		VALUES ($1, $2, $3, NOW(), NOW(), NULL, NULL)
 	`
 	approveKP := keypair.MustRandom()
 	approveCallbackID := uuid.New().String()
-	approveEmailAddress := "email@approved.com"
-	_, err := deleteHandler.DB.ExecContext(ctx, insertNewApprovedAccountQuery, approveKP.Address(), approveCallbackID, approveEmailAddress)
+	approveEmailAddress := "email@test.com"
+	_, err := handler.DB.ExecContext(ctx, q, approveKP.Address(), approveCallbackID, approveEmailAddress)
 	require.NoError(t, err)
 
-	// Prepare and send /kyc-status/{stellar_address} DELETE request; for approved account in the accounts_kyc_status table.
-	m := chi.NewMux()
-	m.Delete("/kyc-status/{stellar_address}", deleteHandler.ServeHTTP)
 	r := httptest.NewRequest("DELETE", fmt.Sprintf("/kyc-status/%s", approveKP.Address()), nil)
 	r = r.WithContext(ctx)
 	w := httptest.NewRecorder()
 	m.ServeHTTP(w, r)
 	resp := w.Result()
-	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-
-	// TEST ok response for deleteing account's kyc record from db's accounts_kyc_status table.
 	wantBody := `{
 		"message":"ok"
 	}`
 	require.JSONEq(t, wantBody, string(body))
 
-	// Prepare and execute SELECT query for account that was deleted, TEST if the the account doesn't exist in the db.
-	existQuery := `
-	SELECT EXISTS(
-		SELECT stellar_address
-		FROM accounts_kyc_status
-		WHERE stellar_address = $1
-	)`
+	q = `
+		SELECT EXISTS(
+			SELECT stellar_address
+			FROM accounts_kyc_status
+			WHERE stellar_address = $1
+		)
+	`
 	var exists bool
-	err = deleteHandler.DB.QueryRowContext(ctx, existQuery, approveKP.Address()).Scan(&exists)
+	err = handler.DB.QueryRowContext(ctx, q, approveKP.Address()).Scan(&exists)
 	require.NoError(t, err)
-	assert.False(t, exists)
-
-	// Prepare and send /kyc-status/{stellar_address} DELETE request; for account that isn't in the accounts_kyc_status table.
-	r = httptest.NewRequest("DELETE", fmt.Sprintf("/kyc-status/%s", approveKP.Address()), nil)
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	m.ServeHTTP(w, r)
-	resp = w.Result()
-	assert.Equal(t, http.StatusNotFound, w.Code)
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// TEST error "Not found." response for attempting to delete an account that isn't in the accounts_kyc_status table.
-	wantDeleteResponseNotFound := `{
-		"error": "Not found."
-	}`
-	require.JSONEq(t, wantDeleteResponseNotFound, string(body))
+	require.False(t, exists)
 }

--- a/services/regulated-assets-approval-server/internal/serve/kycstatus/delete_handler_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/kycstatus/delete_handler_test.go
@@ -2,21 +2,24 @@ package kycstatus
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/services/regulated-assets-approval-server/internal/db/dbtest"
+	"github.com/stellar/go/services/regulated-assets-approval-server/internal/serve/httperror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeleteHandlerValidate(t *testing.T) {
-	// Test no db.
+func TestDeleteHandler_validate(t *testing.T) {
+	// database is nil
 	h := DeleteHandler{}
 	err := h.validate()
 	require.EqualError(t, err, "database cannot be nil")
-	// Success.
+
+	// success
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
@@ -26,52 +29,60 @@ func TestDeleteHandlerValidate(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDeleteHandlerHandle(t *testing.T) {
-	ctx := context.Background()
-
-	// Prepare and validate DeleteHandler.
+func TestDeleteHandler_handle_errors(t *testing.T) {
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
 	defer conn.Close()
+	ctx := context.Background()
+
 	h := DeleteHandler{DB: conn}
-	err := h.validate()
-	require.NoError(t, err)
 
-	// Prepare and send empty deleteRequest. TEST error "Missing stellar address."
+	// returns "400 - Missing stellar address." if no stellar address is provided
 	in := deleteRequest{}
-	err = h.handle(ctx, in)
-	require.EqualError(t, err, "Missing stellar address.")
+	err := h.handle(ctx, in)
+	require.Equal(t, httperror.NewHTTPError(http.StatusBadRequest, "Missing stellar address."), err)
 
-	// Prepare and send deleteRequest to an account not in the db. TEST error "Not found.".
+	// returns "404 - Not found." if the provided address could not be found
 	accountKP := keypair.MustRandom()
 	in = deleteRequest{StellarAddress: accountKP.Address()}
 	err = h.handle(ctx, in)
-	require.EqualError(t, err, "Not found.")
+	require.Equal(t, httperror.NewHTTPError(http.StatusNotFound, "Not found."), err)
+}
 
-	// INSERT new account in db's accounts_kyc_status table; new account was approved after submitting kyc.
-	insertNewAccountQuery := `
-	INSERT INTO accounts_kyc_status (stellar_address, callback_id, email_address, kyc_submitted_at, approved_at, rejected_at)
-	VALUES ($1, $2, $3, NOW(), NOW(), NULL)
+func TestDeleteHandler_handle_success(t *testing.T) {
+	db := dbtest.Open(t)
+	defer db.Close()
+	conn := db.Open()
+	defer conn.Close()
+	ctx := context.Background()
+
+	h := DeleteHandler{DB: conn}
+
+	// tests if the delete handler is really deleting a row from the database
+	q := `
+		INSERT INTO accounts_kyc_status (stellar_address, callback_id, email_address, kyc_submitted_at, approved_at, rejected_at, pending_at)
+		VALUES ($1, $2, $3, NOW(), NOW(), NULL, NULL)
 	`
+	accountKP := keypair.MustRandom()
 	callbackID := uuid.New().String()
 	emailAddress := "email@approved.com"
-	_, err = h.DB.ExecContext(ctx, insertNewAccountQuery, accountKP.Address(), callbackID, emailAddress)
+	_, err := h.DB.ExecContext(ctx, q, accountKP.Address(), callbackID, emailAddress)
 	require.NoError(t, err)
 
-	// Send deleteRequest to an account in the db. TEST if nil error returned (success).
+	in := deleteRequest{StellarAddress: accountKP.Address()}
 	err = h.handle(ctx, in)
 	require.NoError(t, err)
 
-	// Prepare and execute SELECT query for account that was deleted; ensure its no longer in db
-	existQuery := `
+	q = `
 		SELECT EXISTS(
 			SELECT stellar_address
 			FROM accounts_kyc_status
 			WHERE stellar_address = $1
-		)`
+		)
+	`
 	var exists bool
-	err = h.DB.QueryRowContext(ctx, existQuery, accountKP.Address()).Scan(&exists)
+	err = h.DB.QueryRowContext(ctx, q, accountKP.Address()).Scan(&exists)
 	require.NoError(t, err)
 	assert.False(t, exists)
 }

--- a/services/regulated-assets-approval-server/internal/serve/kycstatus/get_detail_handler.go
+++ b/services/regulated-assets-approval-server/internal/serve/kycstatus/get_detail_handler.go
@@ -77,7 +77,7 @@ func (h GetDetailHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h GetDetailHandler) handle(ctx context.Context, in getDetailRequest) (*kycGetResponse, error) {
 	// Check if getDetailRequest StellarAddressOrCallbackID value is present.
 	if in.StellarAddressOrCallbackID == "" {
-		return nil, httperror.NewHTTPError(http.StatusBadRequest, "Missing stellar address or callbackID")
+		return nil, httperror.NewHTTPError(http.StatusBadRequest, "Missing stellar address or callbackID.")
 	}
 
 	// Prepare SELECT query return values.

--- a/services/regulated-assets-approval-server/internal/serve/kycstatus/get_detail_handler_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/kycstatus/get_detail_handler_test.go
@@ -3,22 +3,23 @@ package kycstatus
 import (
 	"context"
 	"database/sql"
+	"net/http"
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
-	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/services/regulated-assets-approval-server/internal/db/dbtest"
+	"github.com/stellar/go/services/regulated-assets-approval-server/internal/serve/httperror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetDetailHandlerValidate(t *testing.T) {
-	// Test no db.
+func TestGetDetailHandler_validate(t *testing.T) {
+	// database is nil
 	h := GetDetailHandler{}
 	err := h.validate()
 	require.EqualError(t, err, "database cannot be nil")
-	// Success.
+
+	// success
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
@@ -29,98 +30,130 @@ func TestGetDetailHandlerValidate(t *testing.T) {
 }
 
 func TestTimePointerIfValid(t *testing.T) {
-	// Prepare NULL nullTimePtr.
-	var nullTimePtr sql.NullTime
-
-	// Send a NullTime Pointer to timePointerIfValid.
-	// TEST if timePointer is null; timePointerIfValid will return nil in this case.
-	timePointer := timePointerIfValid(nullTimePtr)
+	// invalid sql.NullTime should return nil
+	sqlNullTime := sql.NullTime{}
+	timePointer := timePointerIfValid(sqlNullTime)
 	require.Nil(t, timePointer)
 
-	// Prepare a valid nullTimePtr with a time set.
-	nullTimePtr.Valid = true
-	timeNow := time.Now()
-	nullTimePtr.Time = timeNow
-
-	// Send a valid Pointer to timePointerIfValid.
-	// TEST if timePointer is valid and if return a time.Time pointer equals the time.Now().
-	timePointer = timePointerIfValid(nullTimePtr)
-	require.NotNil(t, timePointer)
-	assert.Equal(t, &timeNow, timePointer)
+	// a valid sql.NullTime should return a time.Time pointer
+	desiredTime := time.Now()
+	sqlNullTime = sql.NullTime{
+		Valid: true,
+		Time:  desiredTime,
+	}
+	timePointer = timePointerIfValid(sqlNullTime)
+	require.Equal(t, &desiredTime, timePointer)
 }
 
-func TestGetDetailHandlerHandle(t *testing.T) {
-	ctx := context.Background()
-
-	// Prepare and validate GetDetailHandler.
+func TestGetDetailHandler_handle_error(t *testing.T) {
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
 	defer conn.Close()
-	h := GetDetailHandler{DB: conn}
-	err := h.validate()
-	require.NoError(t, err)
+	ctx := context.Background()
 
-	// Prepare and send empty getDetailRequest. TEST error "Missing stellar address or callbackID"
+	handler := GetDetailHandler{DB: conn}
+
+	// empty parameter will trigger a "400 - Missing stellar address or callbackID."
 	in := getDetailRequest{}
-	kycGetResp, err := h.handle(ctx, in)
-	require.Nil(t, kycGetResp)
-	require.EqualError(t, err, "Missing stellar address or callbackID")
+	kycGetResp, err := handler.handle(ctx, in)
+	assert.Nil(t, kycGetResp)
+	require.Equal(t, httperror.NewHTTPError(http.StatusBadRequest, "Missing stellar address or callbackID."), err)
 
-	// Prepare and send getDetailRequest to an account not in the db. TEST error "Not found.".
-	accountKP := keypair.MustRandom()
-	in = getDetailRequest{StellarAddressOrCallbackID: accountKP.Address()}
-	kycGetResp, err = h.handle(ctx, in)
-	require.Nil(t, kycGetResp)
+	// unexistent row will trigger a "404 - Not found.".
+	in = getDetailRequest{StellarAddressOrCallbackID: "unexistent"}
+	kycGetResp, err = handler.handle(ctx, in)
+	assert.Nil(t, kycGetResp)
 	require.EqualError(t, err, "Not found.")
+}
 
-	// Prepare and send getDetailRequest to a callbackID not in the db. TEST error "Not found.".
-	callbackID := uuid.New().String()
-	in = getDetailRequest{StellarAddressOrCallbackID: callbackID}
-	kycGetResp, err = h.handle(ctx, in)
-	require.Nil(t, kycGetResp)
-	require.EqualError(t, err, "Not found.")
+func TestGetDetailHandler_handle_success(t *testing.T) {
+	db := dbtest.Open(t)
+	defer db.Close()
+	conn := db.Open()
+	defer conn.Close()
+	ctx := context.Background()
 
-	// INSERT new account in db's accounts_kyc_status table; new account was approved after submitting kyc.
-	insertNewAccountQuery := `
-	INSERT INTO accounts_kyc_status (stellar_address, callback_id, email_address, kyc_submitted_at, approved_at, pending_at, rejected_at)
-	VALUES ($1, $2, $3, NOW(), NOW(), NOW(), NULL)
+	handler := GetDetailHandler{DB: conn}
+
+	// step 1: insert test data into database
+	const q = `
+		INSERT INTO accounts_kyc_status (stellar_address, callback_id, email_address, kyc_submitted_at, approved_at, pending_at, rejected_at, created_at)
+		VALUES
+			('rejected-address', 'rejected-callback-id', 'xrejected@test.com', $1::timestamptz, NULL, NULL, $1::timestamptz, $4::timestamptz),
+			('pending-address', 'pending-callback-id', 'ypending@test.com', $2::timestamptz, NULL, $2::timestamptz, NULL, $4::timestamptz),
+			('approved-address', 'approved-callback-id', 'approved@test.com', $3::timestamptz, $3::timestamptz, NULL, NULL, $4::timestamptz)
 	`
-	emailAddress := "email@approved.com"
-	_, err = h.DB.ExecContext(ctx, insertNewAccountQuery, accountKP.Address(), callbackID, emailAddress)
+	rejectedAt := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	pendingAt := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Second)
+	approvedAt := time.Now().UTC().Truncate(time.Second)
+	createdAt := time.Now().UTC().Truncate(time.Second)
+	_, err := handler.DB.ExecContext(ctx, q, rejectedAt.Format(time.RFC3339), pendingAt.Format(time.RFC3339), approvedAt.Format(time.RFC3339), createdAt.Format(time.RFC3339))
 	require.NoError(t, err)
 
-	// Prepare and send getDetailRequest to an account in the db; using stellar address. TEST if response returns with account that was inserted in db; using stellar address.
-	in = getDetailRequest{StellarAddressOrCallbackID: accountKP.Address()}
-	kycGetResp, err = h.handle(ctx, in)
+	// step 2.1: retrieve "rejected" entry with stellar address
+	in := getDetailRequest{StellarAddressOrCallbackID: "rejected-address"}
+	kycGetResp, err := handler.handle(ctx, in)
 	require.NoError(t, err)
 	wantKycGetResponse := kycGetResponse{
-		StellarAddress: accountKP.Address(),
-		CallbackID:     callbackID,
-		EmailAddress:   emailAddress,
-		CreatedAt:      kycGetResp.CreatedAt,
-		KYCSubmittedAt: kycGetResp.KYCSubmittedAt,
-		ApprovedAt:     kycGetResp.ApprovedAt,
-		RejectedAt:     kycGetResp.RejectedAt,
-		PendingAt:      kycGetResp.PendingAt,
+		StellarAddress: "rejected-address",
+		CallbackID:     "rejected-callback-id",
+		EmailAddress:   "xrejected@test.com",
+		CreatedAt:      &createdAt,
+		KYCSubmittedAt: &rejectedAt,
+		RejectedAt:     &rejectedAt,
+		PendingAt:      nil,
+		ApprovedAt:     nil,
 	}
 	assert.Equal(t, &wantKycGetResponse, kycGetResp)
 
-	// TEST if response timestamps are present or null.
-	require.NotNil(t, kycGetResp.CreatedAt)
-	require.NotNil(t, kycGetResp.KYCSubmittedAt)
-	require.NotNil(t, kycGetResp.ApprovedAt)
-	require.Nil(t, kycGetResp.RejectedAt)
-
-	/// Prepare and send getDetailRequest to an account in the db; using callbackID. TEST if response returns with account that was inserted in db; using callbackID.
-	in = getDetailRequest{StellarAddressOrCallbackID: callbackID}
-	kycGetResp, err = h.handle(ctx, in)
+	// step 2.2: retrieve "rejected" entry with callbackID
+	in = getDetailRequest{StellarAddressOrCallbackID: "rejected-callback-id"}
+	kycGetResp, err = handler.handle(ctx, in)
 	require.NoError(t, err)
 	assert.Equal(t, &wantKycGetResponse, kycGetResp)
 
-	// TEST if response timestamps are present or null.
-	require.NotNil(t, kycGetResp.CreatedAt)
-	require.NotNil(t, kycGetResp.KYCSubmittedAt)
-	require.NotNil(t, kycGetResp.ApprovedAt)
-	require.Nil(t, kycGetResp.RejectedAt)
+	// step 3.1: retrieve "pending" entry with stellar address
+	in = getDetailRequest{StellarAddressOrCallbackID: "pending-address"}
+	kycGetResp, err = handler.handle(ctx, in)
+	require.NoError(t, err)
+	wantKycGetResponse = kycGetResponse{
+		StellarAddress: "pending-address",
+		CallbackID:     "pending-callback-id",
+		EmailAddress:   "ypending@test.com",
+		CreatedAt:      &createdAt,
+		KYCSubmittedAt: &pendingAt,
+		RejectedAt:     nil,
+		PendingAt:      &pendingAt,
+		ApprovedAt:     nil,
+	}
+	assert.Equal(t, &wantKycGetResponse, kycGetResp)
+
+	// step 3.2: retrieve "pending" entry with callbackID
+	in = getDetailRequest{StellarAddressOrCallbackID: "pending-callback-id"}
+	kycGetResp, err = handler.handle(ctx, in)
+	require.NoError(t, err)
+	assert.Equal(t, &wantKycGetResponse, kycGetResp)
+
+	// step 4.1: retrieve "approved" entry with stellar address
+	in = getDetailRequest{StellarAddressOrCallbackID: "approved-address"}
+	kycGetResp, err = handler.handle(ctx, in)
+	require.NoError(t, err)
+	wantKycGetResponse = kycGetResponse{
+		StellarAddress: "approved-address",
+		CallbackID:     "approved-callback-id",
+		EmailAddress:   "approved@test.com",
+		CreatedAt:      &createdAt,
+		KYCSubmittedAt: &approvedAt,
+		RejectedAt:     nil,
+		PendingAt:      nil,
+		ApprovedAt:     &approvedAt,
+	}
+	assert.Equal(t, &wantKycGetResponse, kycGetResp)
+
+	// step 4.2: retrieve "approved" entry with callbackID
+	in = getDetailRequest{StellarAddressOrCallbackID: "approved-callback-id"}
+	kycGetResp, err = handler.handle(ctx, in)
+	require.NoError(t, err)
+	assert.Equal(t, &wantKycGetResponse, kycGetResp)
 }

--- a/services/regulated-assets-approval-server/internal/serve/kycstatus/post_handler_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/kycstatus/post_handler_test.go
@@ -1,19 +1,24 @@
 package kycstatus
 
 import (
+	"context"
+	"database/sql"
+	"net/http"
 	"testing"
 
 	"github.com/stellar/go/services/regulated-assets-approval-server/internal/db/dbtest"
+	"github.com/stellar/go/services/regulated-assets-approval-server/internal/serve/httperror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestPostHandlerValidate(t *testing.T) {
-	// Test no db.
+func TestPostHandler_validate(t *testing.T) {
+	// database is nil
 	h := PostHandler{}
 	err := h.validate()
 	require.EqualError(t, err, "database cannot be nil")
-	// Success.
+
+	// success
 	db := dbtest.Open(t)
 	defer db.Close()
 	conn := db.Open()
@@ -88,6 +93,124 @@ func TestBuildUpdateKYCQuery(t *testing.T) {
 	expectedArgs = []interface{}{in.EmailAddress, in.CallbackID}
 	require.Equal(t, expectedQuery, query)
 	require.Equal(t, expectedArgs, args)
+}
+
+func TestPostHandler_handle_error(t *testing.T) {
+	db := dbtest.Open(t)
+	defer db.Close()
+	conn := db.Open()
+	defer conn.Close()
+	ctx := context.Background()
+
+	handler := PostHandler{DB: conn}
+
+	// missing callbackID
+	in := kycPostRequest{}
+	kycPostResp, err := handler.handle(ctx, in)
+	require.Nil(t, kycPostResp)
+	require.Equal(t, httperror.NewHTTPError(http.StatusBadRequest, "Missing callbackID."), err)
+
+	// missing email_address
+	in = kycPostRequest{
+		CallbackID: "random-callback-id",
+	}
+	kycPostResp, err = handler.handle(ctx, in)
+	require.Nil(t, kycPostResp)
+	require.Equal(t, httperror.NewHTTPError(http.StatusBadRequest, "Missing email_address."), err)
+
+	// invalid email_address
+	in = kycPostRequest{
+		CallbackID:   "random-callback-id",
+		EmailAddress: "invalidemail",
+	}
+	kycPostResp, err = handler.handle(ctx, in)
+	require.Nil(t, kycPostResp)
+	require.Equal(t, httperror.NewHTTPError(http.StatusBadRequest, "The provided email_address is invalid."), err)
+
+	// callbackID not found
+	in = kycPostRequest{
+		CallbackID:   "random-callback-id",
+		EmailAddress: "email@test.com",
+	}
+	kycPostResp, err = handler.handle(ctx, in)
+	require.Nil(t, kycPostResp)
+	require.Equal(t, httperror.NewHTTPError(http.StatusNotFound, "Not found."), err)
+}
+
+func TestPostHandler_handle_success(t *testing.T) {
+	db := dbtest.Open(t)
+	defer db.Close()
+	conn := db.Open()
+	defer conn.Close()
+	ctx := context.Background()
+
+	handler := PostHandler{DB: conn}
+
+	rejectedCallbackID := "rejected-callback-id"
+	pendingCallbackID := "pending-callback-id"
+	approvedCallbackID := "approved-callback-id"
+	q := `
+		INSERT INTO accounts_kyc_status (stellar_address, callback_id)
+		VALUES 
+			('rejected-address', $1),
+			('pending-address', $2),
+			('approved-address', $3)
+	`
+
+	_, err := conn.DB.ExecContext(ctx, q, rejectedCallbackID, pendingCallbackID, approvedCallbackID)
+	require.NoError(t, err)
+
+	// should be rejected as email starts with "x"
+	in := kycPostRequest{
+		CallbackID:   rejectedCallbackID,
+		EmailAddress: "xemail@test.com",
+	}
+	kycPostResp, err := handler.handle(ctx, in)
+	assert.NoError(t, err)
+	require.Equal(t, NewKYCStatusPostResponse(), kycPostResp)
+
+	var rejectedAt, pendingAt, approvedAt sql.NullTime
+	q = `
+		SELECT rejected_at, pending_at, approved_at
+		FROM accounts_kyc_status
+		WHERE callback_id = $1
+	`
+	err = conn.DB.QueryRowContext(ctx, q, rejectedCallbackID).Scan(&rejectedAt, &pendingAt, &approvedAt)
+	require.NoError(t, err)
+
+	require.True(t, rejectedAt.Valid)
+	require.False(t, pendingAt.Valid)
+	require.False(t, approvedAt.Valid)
+
+	// should be marked as pending as email starts with "y"
+	in = kycPostRequest{
+		CallbackID:   pendingCallbackID,
+		EmailAddress: "yemail@test.com",
+	}
+	kycPostResp, err = handler.handle(ctx, in)
+	assert.NoError(t, err)
+	require.Equal(t, NewKYCStatusPostResponse(), kycPostResp)
+
+	err = conn.DB.QueryRowContext(ctx, q, pendingCallbackID).Scan(&rejectedAt, &pendingAt, &approvedAt)
+	require.NoError(t, err)
+	require.False(t, rejectedAt.Valid)
+	require.True(t, pendingAt.Valid)
+	require.False(t, approvedAt.Valid)
+
+	// should be approved as email doesn't start with "x" nor "y"
+	in = kycPostRequest{
+		CallbackID:   pendingCallbackID,
+		EmailAddress: "email@test.com",
+	}
+	kycPostResp, err = handler.handle(ctx, in)
+	assert.NoError(t, err)
+	require.Equal(t, NewKYCStatusPostResponse(), kycPostResp)
+
+	err = conn.DB.QueryRowContext(ctx, q, pendingCallbackID).Scan(&rejectedAt, &pendingAt, &approvedAt)
+	require.NoError(t, err)
+	require.False(t, rejectedAt.Valid)
+	require.False(t, pendingAt.Valid)
+	require.True(t, approvedAt.Valid)
 }
 
 func TestRxEmail(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Refactor tests targetting the `/kyc-status/*` endpoints. Now the unit tests are covering not only the happy path but also all edge cases from the transaction approval logic. On the other hand, the API tests were reduced to cover the happy path only, so they become easier to maintain and we don't repeat ourselves (DRY).

### Why

There was confusion between unit tests and API tests in this service so the package was not properly tested in terms of unit tests and a lot of the edge cases were being validated only in the API tests. That setup makes the code and tests harder to maintain as a developer would need to maintain package-related tests outside the package.

### Known limitations

N/A
