### PR TITLE
services/regulated-assets-approval-server: make sure the SEP-8 "pending" response contains the "timeout" field

### DIFF
--- a/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
@@ -458,7 +458,7 @@ func TestAPI_txAprove_actionRequiredFlow(t *testing.T) {
 	wantBody = `{
 		"status": "pending",
 		"message": "Your account could not be verified as approved nor rejected and was marked as pending. You will need staff authorization for operations above 500.00 GOAT.",
-		"timestamp": 0
+		"timeout": 0
 	}`
 	require.JSONEq(t, wantBody, string(body))
 }

--- a/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
@@ -457,7 +457,8 @@ func TestAPI_txAprove_actionRequiredFlow(t *testing.T) {
 	require.NoError(t, err)
 	wantBody = `{
 		"status": "pending",
-		"message": "Your account could not be verified as approved nor rejected and was marked as pending. You will need staff authorization for operations above 500.00 GOAT."
+		"message": "Your account could not be verified as approved nor rejected and was marked as pending. You will need staff authorization for operations above 500.00 GOAT.",
+		"timestamp": 0
 	}`
 	require.JSONEq(t, wantBody, string(body))
 }

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_response.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_response.go
@@ -15,7 +15,7 @@ type txApprovalResponse struct {
 	ActionURL    string     `json:"action_url,omitempty"`
 	ActionMethod string     `json:"action_method,omitempty"`
 	ActionFields []string   `json:"action_fields,omitempty"`
-	Timestamp    *int64     `json:"timestamp,omitempty"`
+	Timeout      *int64     `json:"timeout,omitempty"`
 }
 
 func (t *txApprovalResponse) Render(w http.ResponseWriter) {
@@ -65,7 +65,7 @@ func NewPendingTxApprovalResponse(message string) *txApprovalResponse {
 		Status:     sep8StatusPending,
 		Message:    message,
 		StatusCode: http.StatusOK,
-		Timestamp:  &timestamp,
+		Timeout:    &timestamp,
 	}
 }
 

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_response.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_response.go
@@ -15,6 +15,7 @@ type txApprovalResponse struct {
 	ActionURL    string     `json:"action_url,omitempty"`
 	ActionMethod string     `json:"action_method,omitempty"`
 	ActionFields []string   `json:"action_fields,omitempty"`
+	Timestamp    *int64     `json:"timestamp,omitempty"`
 }
 
 func (t *txApprovalResponse) Render(w http.ResponseWriter) {
@@ -59,10 +60,12 @@ func NewSuccessTxApprovalResponse(tx, message string) *txApprovalResponse {
 }
 
 func NewPendingTxApprovalResponse(message string) *txApprovalResponse {
+	timestamp := int64(0)
 	return &txApprovalResponse{
 		Status:     sep8StatusPending,
 		Message:    message,
 		StatusCode: http.StatusOK,
+		Timestamp:  &timestamp,
 	}
 }
 

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_response.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_response.go
@@ -60,12 +60,12 @@ func NewSuccessTxApprovalResponse(tx, message string) *txApprovalResponse {
 }
 
 func NewPendingTxApprovalResponse(message string) *txApprovalResponse {
-	timestamp := int64(0)
+	timeout := int64(0)
 	return &txApprovalResponse{
 		Status:     sep8StatusPending,
 		Message:    message,
 		StatusCode: http.StatusOK,
-		Timeout:    &timestamp,
+		Timeout:    &timeout,
 	}
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Make sure the SEP-8 "pending" response contains the "timeout" field.

### Why

According to [SEP-8](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md#pending), the "timeout" field is mandatory and if no timestamp can be determined it should be set to "0":
> timeout is the (...) number of milliseconds to wait before submitting the same transaction again. Use `0` if the wait time cannot be determined.

### Known limitations

N/A
