### PR TITLE
services/horizon: Fix verify-range command toml crash

### DIFF
--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -100,13 +100,15 @@ var ingestVerifyRangeCmd = &cobra.Command{
 		}
 
 		ingestConfig := ingest.Config{
-			NetworkPassphrase:     config.NetworkPassphrase,
-			HistorySession:        horizonSession,
-			HistoryArchiveURL:     config.HistoryArchiveURLs[0],
-			EnableCaptiveCore:     config.EnableCaptiveCoreIngestion,
-			CaptiveCoreBinaryPath: config.CaptiveCoreBinaryPath,
-			RemoteCaptiveCoreURL:  config.RemoteCaptiveCoreURL,
-			CheckpointFrequency:   config.CheckpointFrequency,
+			NetworkPassphrase:      config.NetworkPassphrase,
+			HistorySession:         horizonSession,
+			HistoryArchiveURL:      config.HistoryArchiveURLs[0],
+			EnableCaptiveCore:      config.EnableCaptiveCoreIngestion,
+			CaptiveCoreBinaryPath:  config.CaptiveCoreBinaryPath,
+			RemoteCaptiveCoreURL:   config.RemoteCaptiveCoreURL,
+			CheckpointFrequency:    config.CheckpointFrequency,
+			CaptiveCoreToml:        config.CaptiveCoreToml,
+			CaptiveCoreStoragePath: config.CaptiveCoreStoragePath,
 		}
 
 		if !ingestConfig.EnableCaptiveCore {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add two missing params to `ingestVerifyRangeCmd` (probably missed in https://github.com/stellar/go/commit/4c983802b17b22efe4f968820847470e9e54fbc1).

### Why

Crash when used with Captive-Core:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x17ad39a]

goroutine 1 [running]:
github.com/stellar/go/ingest/ledgerbackend.(*CaptiveCoreToml).Marshal(0x0, 0x52, 0x1, 0xc0002beae0, 0x52, 0xc000016eb8)
	/go/src/github.com/stellar/go/ingest/ledgerbackend/toml.go:188 +0x19a
github.com/stellar/go/ingest/ledgerbackend.(*CaptiveCoreToml).clone(0x0, 0xc00022e870, 0x27, 0xc000016ef8)
	/go/src/github.com/stellar/go/ingest/ledgerbackend/toml.go:341 +0x2f
github.com/stellar/go/ingest/ledgerbackend.(*CaptiveCoreToml).CatchupToml(0x0, 0x17aa85f, 0xc00022e870, 0x27)
	/go/src/github.com/stellar/go/ingest/ledgerbackend/toml.go:356 +0x2f
github.com/stellar/go/ingest/ledgerbackend.generateConfig(0x0, 0x1, 0xc00023a160, 0xc0000ae820, 0xc0004fa480, 0x0, 0xc000016fa0)
	/go/src/github.com/stellar/go/ingest/ledgerbackend/stellar_core_runner.go:140 +0x19f
github.com/stellar/go/ingest/ledgerbackend.writeConf(0x0, 0x1, 0xc0002beae0, 0x52, 0x1, 0xc00022e840, 0x25, 0x40)
	/go/src/github.com/stellar/go/ingest/ledgerbackend/stellar_core_runner.go:129 +0x39
github.com/stellar/go/ingest/ledgerbackend.newStellarCoreRunner(0xc00003c0b9, 0x30, 0xc00003c063, 0x2e, 0xc000208120, 0x1, 0x1, 0x0, 0x40, 0x1d5a740, ...)
	/go/src/github.com/stellar/go/ingest/ledgerbackend/stellar_core_runner.go:119 +0x4b7
github.com/stellar/go/ingest/ledgerbackend.NewCaptive.func1(0x1, 0xc0022286ff, 0x0, 0x0, 0x1c03318)
	/go/src/github.com/stellar/go/ingest/ledgerbackend/captive_core_backend.go:168 +0x88
github.com/stellar/go/ingest/ledgerbackend.(*CaptiveStellarCore).openOfflineReplaySubprocess(0xc0000e8100, 0x9b83ff009b833f, 0x105ac01, 0x1074c00)
	/go/src/github.com/stellar/go/ingest/ledgerbackend/captive_core_backend.go:201 +0x9c
github.com/stellar/go/ingest/ledgerbackend.(*CaptiveStellarCore).startPreparingRange(0xc0000e8100, 0x1d63d50, 0xc000098100, 0x9b83ff009b833f, 0x2b66bb987d01, 0xc6d4200, 0x0, 0x0)
	/go/src/github.com/stellar/go/ingest/ledgerbackend/captive_core_backend.go:353 +0xf2
github.com/stellar/go/ingest/ledgerbackend.(*CaptiveStellarCore).PrepareRange(0xc0000e8100, 0x1d63d50, 0xc000098100, 0x9b83ff009b833f, 0x1, 0x0, 0x35fffff)
	/go/src/github.com/stellar/go/ingest/ledgerbackend/captive_core_backend.go:374 +0x6c
github.com/stellar/go/services/horizon/internal/ingest.verifyRangeState.run(0x9b83ff009b833f, 0x0, 0xc00000c1e0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/go/src/github.com/stellar/go/services/horizon/internal/ingest/fsm.go:819 +0x593
github.com/stellar/go/services/horizon/internal/ingest.(*system).runStateMachine(0xc00000c1e0, 0x1d5a880, 0xc0004ba600, 0x0, 0x0)
	/go/src/github.com/stellar/go/services/horizon/internal/ingest/main.go:486 +0x38d
github.com/stellar/go/services/horizon/internal/ingest.(*system).VerifyRange(0xc00000c1e0, 0x9b83ff009b833f, 0x0, 0x0, 0x0)
	/go/src/github.com/stellar/go/services/horizon/internal/ingest/main.go:433 +0x87
github.com/stellar/go/services/horizon/cmd.glob..func7(0x231f6a0, 0xc0004de340, 0x0, 0x4)
	/go/src/github.com/stellar/go/services/horizon/cmd/ingest.go:129 +0x404
github.com/spf13/cobra.(*Command).execute(0x231f6a0, 0xc0004de200, 0x4, 0x4, 0x231f6a0, 0xc0004de200)
	/go/pkg/mod/github.com/spf13/cobra@v0.0.0-20160830174925-9c28e4bbd74e/command.go:603 +0x24b
github.com/spf13/cobra.(*Command).ExecuteC(0x231ff20, 0xc000000180, 0x200000003, 0xc000000180)
	/go/pkg/mod/github.com/spf13/cobra@v0.0.0-20160830174925-9c28e4bbd74e/command.go:689 +0x2d0
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v0.0.0-20160830174925-9c28e4bbd74e/command.go:648
github.com/stellar/go/services/horizon/cmd.Execute()
	/go/src/github.com/stellar/go/services/horizon/cmd/root.go:33 +0x31
main.main()
	/go/src/github.com/stellar/go/services/horizon/main.go:6 +0x25
exit status 2
```

### Known limitations

[TODO or N/A]
