### PR TITLE
all: Update Horizon-related Stellar-Core references to use v17.1.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,7 +446,6 @@ jobs:
       - run:
           name: Run Horizon integration tests <<#parameters.enable-captive-core>>(With captive core)<</parameters.enable-captive-core>>
           # Currently all integration tests are in a single directory.
-          # Pulling the image helps with test running time
           command: |
             cd ~/go/src/github.com/stellar/go
             go test -timeout 25m -v ./services/horizon/internal/integration/...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ commands:
     parameters:
       core-version:
         type: string
-        default: "17.0.0-568.ea5878e.xenial~buildtests"
+        default: "17.1.0-584.fbc0325.xenial"
     steps:
       - run:
           name: Install Stellar Core <<#parameters.core-version>> (version <<parameters.core-version>>)<</parameters.core-version>>

--- a/services/horizon/docker/Dockerfile.dev
+++ b/services/horizon/docker/Dockerfile.dev
@@ -9,7 +9,7 @@ RUN go install github.com/stellar/go/exp/services/captivecore
 
 FROM ubuntu:20.04
 
-ENV STELLAR_CORE_VERSION 17.0.0-568.ea5878e.focal
+ENV STELLAR_CORE_VERSION 17.1.0-584.fbc0325.focal
 ENV STELLAR_CORE_BINARY_PATH /usr/bin/stellar-core
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/services/horizon/docker/core-start.sh
+++ b/services/horizon/docker/core-start.sh
@@ -15,7 +15,7 @@ if [ "$1" = "standalone" ]; then
   # start a network from scratch
   stellar-core force-scp
 
-  # initialze history archive for stand alone network
+  # initialize history archive for standalone network
   stellar-core new-hist vs
 
   # serve history archives to horizon on port 1570

--- a/services/horizon/docker/docker-compose.integration-tests.yml
+++ b/services/horizon/docker/docker-compose.integration-tests.yml
@@ -10,7 +10,7 @@ services:
       - "5641:5641"
     command: ["-p", "5641"]
   core:
-    image: ${CORE_IMAGE:-stellar/stellar-core:testing}
+    image: ${CORE_IMAGE:-stellar/stellar-core:v17.1.0}
     depends_on:
       - core-postgres
     restart: on-failure

--- a/services/horizon/docker/docker-compose.integration-tests.yml
+++ b/services/horizon/docker/docker-compose.integration-tests.yml
@@ -10,7 +10,7 @@ services:
       - "5641:5641"
     command: ["-p", "5641"]
   core:
-    image: ${CORE_IMAGE:-stellar/stellar-core:v17.0.0}
+    image: ${CORE_IMAGE:-stellar/stellar-core:testing}
     depends_on:
       - core-postgres
     restart: on-failure

--- a/services/horizon/docker/verify-range/Dockerfile
+++ b/services/horizon/docker/verify-range/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 
 MAINTAINER Bartek Nowotarski <bartek@stellar.org>
 
-ENV STELLAR_CORE_VERSION 16.0.0-529.0e35ac6.focal
+ENV STELLAR_CORE_VERSION 17.1.0-584.fbc0325.focal
 # to remove tzdata interactive flow
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
### What
Update references across the board to use the [latest stable](https://github.com/stellar/stellar-core/releases/tag/v17.1.0) Stellar-Core: `17.1.0-584.fbc0325`.

### Why
We need 17.1.0 to take advantage of #3670 (though Horizon will be backwards-compatible) and close #3631.