### PR TITLE
services/horizon: Add txsub integration test

### DIFF
--- a/services/horizon/internal/actions/submit_transaction_test.go
+++ b/services/horizon/internal/actions/submit_transaction_test.go
@@ -1,0 +1,66 @@
+package actions
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/services/horizon/internal/corestate"
+	"github.com/stellar/go/support/render/problem"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStellarCoreMalformedTx(t *testing.T) {
+	handler := SubmitTransactionHandler{}
+
+	r := httptest.NewRequest("POST", "https://horizon.stellar.org/transactions", nil)
+	w := httptest.NewRecorder()
+	_, err := handler.GetResource(w, r)
+	assert.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, err.(*problem.P).Status)
+	assert.Equal(t, "Transaction Malformed", err.(*problem.P).Title)
+}
+
+type coreStateGetterMock struct {
+	mock.Mock
+}
+
+func (m *coreStateGetterMock) GetCoreState() corestate.State {
+	a := m.Called()
+	return a.Get(0).(corestate.State)
+}
+
+func TestStellarCoreNotSynced(t *testing.T) {
+	mock := &coreStateGetterMock{}
+	mock.On("GetCoreState").Return(corestate.State{
+		Synced: false,
+	})
+
+	handler := SubmitTransactionHandler{
+		NetworkPassphrase: network.PublicNetworkPassphrase,
+		CoreStateGetter:   mock,
+	}
+
+	form := url.Values{}
+	form.Set("tx", "AAAAAAGUcmKO5465JxTSLQOQljwk2SfqAJmZSG6JH6wtqpwhAAABLAAAAAAAAAABAAAAAAAAAAEAAAALaGVsbG8gd29ybGQAAAAAAwAAAAAAAAAAAAAAABbxCy3mLg3hiTqX4VUEEp60pFOrJNxYM1JtxXTwXhY2AAAAAAvrwgAAAAAAAAAAAQAAAAAW8Qst5i4N4Yk6l+FVBBKetKRTqyTcWDNSbcV08F4WNgAAAAAN4Lazj4x61AAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABLaqcIQAAAEBKwqWy3TaOxoGnfm9eUjfTRBvPf34dvDA0Nf+B8z4zBob90UXtuCqmQqwMCyH+okOI3c05br3khkH0yP4kCwcE")
+
+	request, err := http.NewRequest(
+		"POST",
+		"https://horizon.stellar.org/transactions",
+		strings.NewReader(form.Encode()),
+	)
+	require.NoError(t, err)
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	w := httptest.NewRecorder()
+	_, err = handler.GetResource(w, request)
+	assert.Error(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, err.(problem.P).Status)
+	assert.Equal(t, "stale_history", err.(problem.P).Type)
+	assert.Equal(t, "Historical DB Is Too Stale", err.(problem.P).Title)
+}

--- a/services/horizon/internal/integration/txsub_test.go
+++ b/services/horizon/internal/integration/txsub_test.go
@@ -1,0 +1,69 @@
+package integration
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stellar/go/services/horizon/internal/test/integration"
+	"github.com/stellar/go/txnbuild"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTxsub(t *testing.T) {
+	tt := assert.New(t)
+	itest := integration.NewTest(t, integration.Config{ProtocolVersion: 17})
+	master := itest.Master()
+
+	// Sanity check: create 20 accounts and submit 2 txs from each of them as
+	// a source at the same time. Then check if the results are correct.
+	t.Run("Sanity", func(t *testing.T) {
+		testAccounts := 20
+		subsPerAccont := 2
+		keys, accounts := itest.CreateAccounts(testAccounts, "1000")
+
+		var wg sync.WaitGroup
+
+		for i := 0; i < testAccounts; i++ {
+			for j := 0; j < subsPerAccont; j++ {
+				wg.Add(1)
+
+				seq, err := accounts[i].GetSequenceNumber()
+				assert.NoError(t, err)
+
+				var account txnbuild.SimpleAccount
+				if j == 0 {
+					account = txnbuild.SimpleAccount{
+						AccountID: keys[i].Address(),
+						Sequence:  seq,
+					}
+				} else {
+					account = txnbuild.SimpleAccount{
+						AccountID: keys[i].Address(),
+						Sequence:  seq + 1,
+					}
+				}
+
+				go func(i int, j int, account txnbuild.SimpleAccount) {
+					defer wg.Done()
+
+					op := txnbuild.Payment{
+						Destination: master.Address(),
+						Amount:      "10",
+						Asset:       txnbuild.NativeAsset{},
+					}
+
+					txResp := itest.MustSubmitOperations(&account, keys[i], &op)
+
+					tt.Equal(accounts[i].GetAccountID(), txResp.Account)
+					seq, err := account.GetSequenceNumber()
+					assert.NoError(t, err)
+					tt.Equal(strconv.FormatInt(seq, 10), txResp.AccountSequence)
+					t.Logf("%d/%d done", i, j)
+				}(i, j, account)
+			}
+		}
+
+		wg.Wait()
+	})
+}

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -226,6 +226,10 @@ of accounts, subscribe to event streams, and more.`,
 		// due to ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING
 		"--checkpoint-frequency",
 		"8",
+
+		// disable rate limiting
+		"--per-hour-rate-limit",
+		"0",
 	}
 
 	// initialize core arguments


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Adds sanity integration test for txsub. Add a test (`submit_transaction_test.go`) I forgot to include in https://github.com/stellar/go/pull/3653.

### Why

While we have some unit tests for txsub we don't test the transaction submission endpoint during mirroring test. A simple integration test should at least catch the most obvious bugs.

### Known limitations

[TODO or N/A]
