### PR TITLE
services/horizon: Fix data races found by integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,7 +448,7 @@ jobs:
           # Currently all integration tests are in a single directory.
           command: |
             cd ~/go/src/github.com/stellar/go
-            go test -timeout 25m -v ./services/horizon/internal/integration/...
+            go test -race -timeout 25m -v ./services/horizon/internal/integration/...
 
 #-------------------------------------------------------------------------#
 # Workflows orchestrate jobs and make sure they run in the right sequence #

--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -7,6 +7,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Added transaction and operation result codes to the horizonclient.Error string for easy glancing at string only errors for underlying cause.
 * Fix bug in the transaction submission where requests with large transaction payloads fail with an HTTP 414 URI Too Long error ([#3643](https://github.com/stellar/go/pull/3643)).
+* Fix a data race in `Client.fixHorizonURL`([#3690](https://github.com/stellar/go/pull/3690)).
 
 ## [v7.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v7.0.0) - 2021-05-15
 

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -26,8 +26,8 @@ import (
 
 // sendRequest builds the URL for the given horizon request and sends the url to a horizon server
 func (c *Client) sendRequest(hr HorizonRequest, resp interface{}) (err error) {
-	c.HorizonURL = c.fixHorizonURL()
-	req, err := hr.HTTPRequest(c.HorizonURL)
+	horizonURL := c.fixHorizonURL()
+	req, err := hr.HTTPRequest(horizonURL)
 	if err != nil {
 		return err
 	}

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -26,8 +26,7 @@ import (
 
 // sendRequest builds the URL for the given horizon request and sends the url to a horizon server
 func (c *Client) sendRequest(hr HorizonRequest, resp interface{}) (err error) {
-	horizonURL := c.fixHorizonURL()
-	req, err := hr.HTTPRequest(horizonURL)
+	req, err := hr.HTTPRequest(c.fixHorizonURL())
 	if err != nil {
 		return err
 	}
@@ -270,7 +269,10 @@ func (c *Client) setDefaultClient() {
 
 // fixHorizonURL strips all slashes(/) at the end of HorizonURL if any, then adds a single slash
 func (c *Client) fixHorizonURL() string {
-	return strings.TrimRight(c.HorizonURL, "/") + "/"
+	c.fixHorizonURLOnce.Do(func() {
+		c.HorizonURL = strings.TrimRight(c.HorizonURL, "/") + "/"
+	})
+	return c.HorizonURL
 }
 
 // SetHorizonTimeout allows users to set the timeout before a horizon request is cancelled.

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -129,7 +129,8 @@ type UniversalTimeHandler func() int64
 // Client struct contains data for creating a horizon client that connects to the stellar network.
 type Client struct {
 	// URL of Horizon server to connect
-	HorizonURL string
+	HorizonURL        string
+	fixHorizonURLOnce sync.Once
 
 	// HTTP client to make requests with
 	HTTP HTTP

--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -399,7 +399,6 @@ func getParams(dst interface{}, r *http.Request) error {
 		}
 	}
 
-	decoder.IgnoreUnknownKeys(true)
 	if err := decoder.Decode(dst, query); err != nil {
 		for k, e := range err.(schema.MultiError) {
 			return problem.NewProblemWithInvalidField(
@@ -608,4 +607,8 @@ func countNonEmpty(params ...interface{}) (int, error) {
 	}
 
 	return count, nil
+}
+
+func init() {
+	decoder.IgnoreUnknownKeys(true)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

This commit adds `-race` flag to Horizon integration tests and fixes two bugs found by race detector:
* `Client.sendRequest` overwriting `c.HorizonURL` when used in multiple go routines.
* `decoder.IgnoreUnknownKeys` overwriting `gorilla/schema.Decoder.ignoreUnknownKeys` when called from multiple go routines.