### PR TITLE
all: Bump Golang minor versions in accordance with latest release.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,7 @@ jobs:
   check_code_1_16:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.16.5
+      - image: golang:1.16
     steps:
       - install_go_deps
       - check_go_deps
@@ -282,7 +282,7 @@ jobs:
   test_code_1_16:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.16.5
+      - image: golang:1.16
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -302,7 +302,7 @@ jobs:
   test_code_1_16_postgres10:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.16.5
+      - image: golang:1.16
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -325,7 +325,7 @@ jobs:
   publish_artifacts:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.16.5
+      - image: golang:1.16
     steps:
       - check_deprecations
       - install_go_deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ jobs:
   test_code_1_15:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.15.13
+      - image: golang:1.15
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -261,7 +261,7 @@ jobs:
   test_code_1_15_postgres10:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.15.13
+      - image: golang:1.15
         environment:
           GO111MODULE: "on"
           PGHOST: localhost

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,8 +115,8 @@ commands:
           name: Download and install golang
           command: |
             sudo rm -rf /usr/local/go
-            wget https://dl.google.com/go/go1.16.3.linux-amd64.tar.gz
-            sudo tar -C /usr/local -xzf go1.16.3.linux-amd64.tar.gz
+            wget https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
 
   # install_go_deps installs the go dependencies of the project.
   install_go_deps:
@@ -227,7 +227,7 @@ jobs:
   check_code_1_16:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.16
+      - image: golang:1.16.5
     steps:
       - install_go_deps
       - check_go_deps
@@ -241,7 +241,7 @@ jobs:
   test_code_1_15:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.15.11
+      - image: golang:1.15.13
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -261,7 +261,7 @@ jobs:
   test_code_1_15_postgres10:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.15.11
+      - image: golang:1.15.13
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -282,7 +282,7 @@ jobs:
   test_code_1_16:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.16.3
+      - image: golang:1.16.5
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -302,7 +302,7 @@ jobs:
   test_code_1_16_postgres10:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.16.3
+      - image: golang:1.16.5
         environment:
           GO111MODULE: "on"
           PGHOST: localhost
@@ -325,7 +325,7 @@ jobs:
   publish_artifacts:
     working_directory: /go/src/github.com/stellar/go
     docker:
-      - image: golang:1.16.3
+      - image: golang:1.16.5
     steps:
       - check_deprecations
       - install_go_deps

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.16.4]
+        go: [1.16.5]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.16.4, 1.15.11]
+        go: [1.16.5, 1.15.13]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.16.4, 1.15.11]
+        go: [1.16.5, 1.15.13]
         pg: [9.6.5, 10]
     runs-on: ${{ matrix.os }}
     services:

--- a/exp/services/recoverysigner/docker/Dockerfile
+++ b/exp/services/recoverysigner/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5 as build
+FROM golang:1.16 as build
 
 ADD . /src/recoverysigner
 WORKDIR /src/recoverysigner

--- a/exp/services/recoverysigner/docker/Dockerfile
+++ b/exp/services/recoverysigner/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3 as build
+FROM golang:1.16.5 as build
 
 ADD . /src/recoverysigner
 WORKDIR /src/recoverysigner

--- a/exp/services/webauth/docker/Dockerfile
+++ b/exp/services/webauth/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5 as build
+FROM golang:1.16 as build
 
 ADD . /src/webauth
 WORKDIR /src/webauth

--- a/exp/services/webauth/docker/Dockerfile
+++ b/exp/services/webauth/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3 as build
+FROM golang:1.16.5 as build
 
 ADD . /src/webauth
 WORKDIR /src/webauth

--- a/exp/tools/dump-ledger-state/Dockerfile
+++ b/exp/tools/dump-ledger-state/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "host all all all trust" > /etc/postgresql/9.6/main/pg_hba.conf
 # And add `listen_addresses` to `/etc/postgresql/9.6/main/postgresql.conf`
 RUN echo "listen_addresses='*'" >> /etc/postgresql/9.6/main/postgresql.conf
 
-RUN curl -sL https://storage.googleapis.com/golang/go1.16.3.linux-amd64.tar.gz | tar -C /usr/local -xz
+RUN curl -sL https://storage.googleapis.com/golang/go1.16.5.linux-amd64.tar.gz | tar -C /usr/local -xz
 RUN ln -s  /usr/local/go/bin/go /usr/local/bin/go
 WORKDIR /go/src/github.com/stellar/go
 COPY go.mod go.sum ./

--- a/services/friendbot/docker/Dockerfile
+++ b/services/friendbot/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3 as build
+FROM golang:1.16.5 as build
 
 ADD . /src/friendbot
 WORKDIR /src/friendbot

--- a/services/friendbot/docker/Dockerfile
+++ b/services/friendbot/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5 as build
+FROM golang:1.16 as build
 
 ADD . /src/friendbot
 WORKDIR /src/friendbot

--- a/services/horizon/docker/Dockerfile.dev
+++ b/services/horizon/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.16.5 AS builder
+FROM golang:1.16 AS builder
 
 WORKDIR /go/src/github.com/stellar/go
 COPY go.mod go.sum ./

--- a/services/horizon/docker/Dockerfile.dev
+++ b/services/horizon/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.16.3 AS builder
+FROM golang:1.16.5 AS builder
 
 WORKDIR /go/src/github.com/stellar/go
 COPY go.mod go.sum ./

--- a/services/horizon/docker/verify-range/dependencies
+++ b/services/horizon/docker/verify-range/dependencies
@@ -10,8 +10,8 @@ echo "deb https://apt.stellar.org $(lsb_release -cs) stable" | sudo tee -a /etc/
 apt-get update
 apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
 
-wget https://dl.google.com/go/go1.16.3.linux-amd64.tar.gz
-tar -C /usr/local -xzf go1.16.3.linux-amd64.tar.gz
+wget https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz
+tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
 
 # configure postgres
 service postgresql start

--- a/services/horizon/internal/scripts/check_release_hash/Dockerfile
+++ b/services/horizon/internal/scripts/check_release_hash/Dockerfile
@@ -1,5 +1,5 @@
 # Change to Go version used in CI or rebuild with --build-arg.
-ARG GO_IMAGE=golang:1.16.3
+ARG GO_IMAGE=golang:1.16.5
 FROM $GO_IMAGE
 
 WORKDIR /go/src/github.com/stellar/go

--- a/services/keystore/docker/Dockerfile
+++ b/services/keystore/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3 as build
+FROM golang:1.16.5 as build
 
 ADD . /src/keystore
 WORKDIR /src/keystore

--- a/services/regulated-assets-approval-server/docker/Dockerfile
+++ b/services/regulated-assets-approval-server/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3 as build
+FROM golang:1.16.5 as build
 
 ADD . /src/regulated-assets-approval-server
 WORKDIR /src/regulated-assets-approval-server

--- a/services/ticker/docker/Dockerfile
+++ b/services/ticker/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3 as build
+FROM golang:1.16.5 as build
 
 ADD . /src/ticker
 WORKDIR /src/ticker

--- a/services/ticker/docker/Dockerfile-dev
+++ b/services/ticker/docker/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM golang:1.16.3-stretch as build
+FROM golang:1.16.5-stretch as build
 
 LABEL maintainer="Alex Cordeiro <alexc@stellar.org>"
 


### PR DESCRIPTION
### What
Bumps from 1.16.3 -> 1.16.5 and 1.15.11 -> 1.15.13.

### Why
This bump includes security issues. Refer to the [release announcement](https://groups.google.com/g/golang-announce/c/RgCMkAEQjSI/m/r_EP-NlKBgAJ) for more.