### PR TITLE
Fix configuration via environment variables for optional parameters

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -20,7 +20,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 * Fix bug in `horizon db reingest range` command, which would throw a duplicate entry conflict error from the DB. ([3661](https://github.com/stellar/go/pull/3661)).
 * Fix bug in DB metrics preventing Horizon from starting when read-only replica middleware is enabled. ([3668](https://github.com/stellar/go/pull/3668)).
 * Fix bug in the value of `route` in the logs for rate-limited requests (previously it was set to `undefined`). ([3658](https://github.com/stellar/go/pull/3658)).
-
+* Fix bug where the configuration for `CAPTIVE_CORE_LOG_PATH`, `CAPTIVE_CORE_PEER_PORT`, and `CAPTIVE_CORE_HTTP_PORT` were ignored if they were configured via environment variables instead of command line arguments. ([3702](https://github.com/stellar/go/pull/3702)).
 
 ## v2.4.0
 

--- a/support/config/config_option_test.go
+++ b/support/config/config_option_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -68,6 +69,59 @@ func TestConfigOption_optionalFlags_set(t *testing.T) {
 	cmd.SetArgs([]string{"--uint", "6", "--string", "test-string"})
 	cmd.Execute()
 	assert.Equal(t, "test-string", *optString)
+	assert.Equal(t, uint(6), *optUint)
+}
+
+// Test that optional flags are set to non nil values when they are configured explicitly.
+func TestConfigOption_optionalFlags_env_set_empty(t *testing.T) {
+	var optUint *uint
+	var optString *string
+	configOpts := ConfigOptions{
+		{Name: "uint", OptType: types.Uint, ConfigKey: &optUint, CustomSetValue: SetOptionalUint, FlagDefault: uint(0)},
+		{Name: "string", OptType: types.String, ConfigKey: &optString, CustomSetValue: SetOptionalString},
+	}
+	cmd := &cobra.Command{
+		Use: "doathing",
+		Run: func(_ *cobra.Command, _ []string) {
+			configOpts.Require()
+			configOpts.SetValues()
+		},
+	}
+	configOpts.Init(cmd)
+
+	envVars = map[string]bool{
+		"STRING": true,
+	}
+	cmd.Execute()
+	assert.Equal(t, "", *optString)
+	assert.Equal(t, (*uint)(nil), optUint)
+}
+
+// Test that optional flags are set to non nil values when they are configured explicitly.
+func TestConfigOption_optionalFlags_env_set(t *testing.T) {
+	var optUint *uint
+	var optString *string
+	configOpts := ConfigOptions{
+		{Name: "uint", OptType: types.Uint, ConfigKey: &optUint, CustomSetValue: SetOptionalUint, FlagDefault: uint(0)},
+		{Name: "string", OptType: types.String, ConfigKey: &optString, CustomSetValue: SetOptionalString},
+	}
+	cmd := &cobra.Command{
+		Use: "doathing",
+		Run: func(_ *cobra.Command, _ []string) {
+			configOpts.Require()
+			configOpts.SetValues()
+		},
+	}
+	configOpts.Init(cmd)
+
+	envVars = map[string]bool{
+		"STRING": true,
+		"UINT":   true,
+	}
+	viper.Set("STRING", "str")
+	viper.Set("UINT", 6)
+	cmd.Execute()
+	assert.Equal(t, "str", *optString)
 	assert.Equal(t, uint(6), *optUint)
 }
 

--- a/support/config/config_option_test.go
+++ b/support/config/config_option_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -89,9 +88,14 @@ func TestConfigOption_optionalFlags_env_set_empty(t *testing.T) {
 	}
 	configOpts.Init(cmd)
 
+	prev := envVars
 	envVars = map[string]bool{
 		"STRING": true,
 	}
+	defer func() {
+		envVars = prev
+	}()
+
 	cmd.Execute()
 	assert.Equal(t, "", *optString)
 	assert.Equal(t, (*uint)(nil), optUint)
@@ -114,12 +118,20 @@ func TestConfigOption_optionalFlags_env_set(t *testing.T) {
 	}
 	configOpts.Init(cmd)
 
+	prev := envVars
 	envVars = map[string]bool{
 		"STRING": true,
 		"UINT":   true,
 	}
-	viper.Set("STRING", "str")
-	viper.Set("UINT", 6)
+	defer func() {
+		envVars = prev
+	}()
+
+	defer os.Setenv("STRING", os.Getenv("STRING"))
+	defer os.Setenv("UINT", os.Getenv("UINT"))
+	os.Setenv("STRING", "str")
+	os.Setenv("UINT", "6")
+
 	cmd.Execute()
 	assert.Equal(t, "str", *optString)
 	assert.Equal(t, uint(6), *optUint)


### PR DESCRIPTION
Fixes https://github.com/stellar/go/issues/3696

This PR fixes a bug where the configuration variables listed below were ignored if they were configured via environment variables instead of command line arguments:

```
CAPTIVE_CORE_LOG_PATH
CAPTIVE_CORE_PEER_PORT
CAPTIVE_CORE_HTTP_PORT
```