### PR TITLE
services/horizon: Add feature flag to reuse Captive-Core storage dir

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -123,6 +123,10 @@ type CaptiveCoreConfig struct {
 	// stored. We always append /captive-core to this directory, since we clean
 	// it up entirely on shutdown.
 	StoragePath string
+	// ReuseStorageDir determines if the storage dir in StoragePath should
+	// be reused between Stellar-Core executions. Defaults to false because of
+	// Stellar-Core 17.1.0 issue.
+	ReuseStorageDir bool
 }
 
 // NewCaptive returns a new CaptiveStellarCore instance.

--- a/ingest/ledgerbackend/stellar_core_runner_test.go
+++ b/ingest/ledgerbackend/stellar_core_runner_test.go
@@ -47,6 +47,7 @@ func TestCloseBeforeStartOnline(t *testing.T) {
 		Log:                log.New(),
 		Context:            context.Background(),
 		Toml:               captiveCoreToml,
+		ReuseStorageDir:    true,
 	}, stellarCoreRunnerModeOnline)
 	assert.NoError(t, err)
 
@@ -60,6 +61,32 @@ func TestCloseBeforeStartOnline(t *testing.T) {
 	// Directory no longer cleaned up on shutdown (perf. bump in v2.5.0)
 	_, err = os.Stat(tempDir)
 	assert.NoError(t, err)
+}
+
+func TestCloseBeforeStartOnlineReuseFlagFalse(t *testing.T) {
+	captiveCoreToml, err := NewCaptiveCoreToml(CaptiveCoreTomlParams{})
+	assert.NoError(t, err)
+
+	captiveCoreToml.AddExamplePubnetValidators()
+
+	runner, err := newStellarCoreRunner(CaptiveCoreConfig{
+		HistoryArchiveURLs: []string{"http://localhost"},
+		Log:                log.New(),
+		Context:            context.Background(),
+		Toml:               captiveCoreToml,
+		ReuseStorageDir:    false,
+	}, stellarCoreRunnerModeOnline)
+	assert.NoError(t, err)
+
+	tempDir := runner.storagePath
+	info, err := os.Stat(tempDir)
+	assert.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	assert.NoError(t, runner.close())
+
+	_, err = os.Stat(tempDir)
+	assert.Error(t, err)
 }
 
 func TestCloseBeforeStartOnlineWithError(t *testing.T) {

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,6 +6,12 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## v2.5.1
+
+**Upgrading to this version from <= v2.1.1 will trigger a state rebuild. During this process (which can take up to 20 minutes), Horizon will not ingest new ledgers.**
+
+* Fix for Stellar-Core 17.1.0 bug that can potentially corrupt Captive-Core storage dir.
+
 ## v2.5.0
 
 **Upgrading to this version from <= v2.1.1 will trigger a state rebuild. During this process (which can take up to 20 minutes), Horizon will not ingest new ledgers.**

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -1,9 +1,10 @@
 package horizon
 
 import (
-	"github.com/stellar/go/ingest/ledgerbackend"
 	"net/url"
 	"time"
+
+	"github.com/stellar/go/ingest/ledgerbackend"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stellar/throttled"
@@ -25,6 +26,7 @@ type Config struct {
 	CaptiveCoreTomlParams      ledgerbackend.CaptiveCoreTomlParams
 	CaptiveCoreToml            *ledgerbackend.CaptiveCoreToml
 	CaptiveCoreStoragePath     string
+	CaptiveCoreReuseStorageDir bool
 
 	StellarCoreDatabaseURL string
 	StellarCoreURL         string

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -2,12 +2,13 @@ package horizon
 
 import (
 	"fmt"
-	"github.com/stellar/go/ingest/ledgerbackend"
 	"go/types"
 	stdLog "log"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/stellar/go/ingest/ledgerbackend"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -189,6 +190,14 @@ func Flags() (*Config, support.ConfigOptions) {
 			Required:  false,
 			Usage:     "Storage location for Captive Core bucket data",
 			ConfigKey: &config.CaptiveCoreStoragePath,
+		},
+		&support.ConfigOption{
+			Name:        "captive-core-reuse-storage-dir",
+			OptType:     types.Bool,
+			Required:    false,
+			FlagDefault: false,
+			Usage:       "determines if storage-dir should be reused, disabled by default because of Stellar-Core 17.1.0 issue",
+			ConfigKey:   &config.CaptiveCoreStoragePath,
 		},
 		&support.ConfigOption{
 			Name:           "captive-core-peer-port",

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -197,7 +197,7 @@ func Flags() (*Config, support.ConfigOptions) {
 			Required:    false,
 			FlagDefault: false,
 			Usage:       "determines if storage-dir should be reused, disabled by default because of Stellar-Core 17.1.0 issue",
-			ConfigKey:   &config.CaptiveCoreStoragePath,
+			ConfigKey:   &config.CaptiveCoreReuseStorageDir,
 		},
 		&support.ConfigOption{
 			Name:           "captive-core-peer-port",

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -66,15 +66,16 @@ const (
 var log = logpkg.DefaultLogger.WithField("service", "ingest")
 
 type Config struct {
-	CoreSession            db.SessionInterface
-	StellarCoreURL         string
-	StellarCoreCursor      string
-	EnableCaptiveCore      bool
-	CaptiveCoreBinaryPath  string
-	CaptiveCoreStoragePath string
-	CaptiveCoreToml        *ledgerbackend.CaptiveCoreToml
-	RemoteCaptiveCoreURL   string
-	NetworkPassphrase      string
+	CoreSession                db.SessionInterface
+	StellarCoreURL             string
+	StellarCoreCursor          string
+	EnableCaptiveCore          bool
+	CaptiveCoreBinaryPath      string
+	CaptiveCoreStoragePath     string
+	CaptiveCoreReuseStorageDir bool
+	CaptiveCoreToml            *ledgerbackend.CaptiveCoreToml
+	RemoteCaptiveCoreURL       string
+	NetworkPassphrase          string
 
 	HistorySession           db.SessionInterface
 	HistoryArchiveURL        string

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -87,16 +87,17 @@ func initIngester(app *App) {
 		// TODO:
 		// Use the first archive for now. We don't have a mechanism to
 		// use multiple archives at the same time currently.
-		HistoryArchiveURL:        app.config.HistoryArchiveURLs[0],
-		CheckpointFrequency:      app.config.CheckpointFrequency,
-		StellarCoreURL:           app.config.StellarCoreURL,
-		StellarCoreCursor:        app.config.CursorName,
-		CaptiveCoreBinaryPath:    app.config.CaptiveCoreBinaryPath,
-		CaptiveCoreStoragePath:   app.config.CaptiveCoreStoragePath,
-		CaptiveCoreToml:          app.config.CaptiveCoreToml,
-		RemoteCaptiveCoreURL:     app.config.RemoteCaptiveCoreURL,
-		EnableCaptiveCore:        app.config.EnableCaptiveCoreIngestion,
-		DisableStateVerification: app.config.IngestDisableStateVerification,
+		HistoryArchiveURL:          app.config.HistoryArchiveURLs[0],
+		CheckpointFrequency:        app.config.CheckpointFrequency,
+		StellarCoreURL:             app.config.StellarCoreURL,
+		StellarCoreCursor:          app.config.CursorName,
+		CaptiveCoreBinaryPath:      app.config.CaptiveCoreBinaryPath,
+		CaptiveCoreStoragePath:     app.config.CaptiveCoreStoragePath,
+		CaptiveCoreReuseStorageDir: app.config.CaptiveCoreReuseStorageDir,
+		CaptiveCoreToml:            app.config.CaptiveCoreToml,
+		RemoteCaptiveCoreURL:       app.config.RemoteCaptiveCoreURL,
+		EnableCaptiveCore:          app.config.EnableCaptiveCoreIngestion,
+		DisableStateVerification:   app.config.IngestDisableStateVerification,
 	})
 
 	if err != nil {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Adds a new `--captive-core-reuse-storage-dir` flag to enable/disable Captive-Core storage dir reuse.

### Why

In Stellar-Core 17.1.0 there is a bug that can potentially corrupt storage dir: https://github.com/stellar/stellar-core/issues/3085. The feature flag can be enabled or removed when a fix is released.