### PR TITLE
Preprocess _muxed_id fields before unmarshalling from the DB

### DIFF
--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -88,7 +88,7 @@ type CreateAccount struct {
 	StartingBalance string `json:"starting_balance"`
 	Funder          string `json:"funder"`
 	FunderMuxed     string `json:"funder_muxed,omitempty"`
-	FunderMuxedID   uint64 `json:"funder_muxed_id,omitempty"`
+	FunderMuxedID   uint64 `json:"funder_muxed_id,omitempty,string"`
 	Account         string `json:"account"`
 }
 

--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -99,10 +99,10 @@ type Payment struct {
 	base.Asset
 	From        string `json:"from"`
 	FromMuxed   string `json:"from_muxed,omitempty"`
-	FromMuxedID uint64 `json:"from_muxed_id,omitempty"`
+	FromMuxedID uint64 `json:"from_muxed_id,omitempty,string"`
 	To          string `json:"to"`
 	ToMuxed     string `json:"to_muxed,omitempty"`
-	ToMuxedID   uint64 `json:"to_muxed_id,omitempty"`
+	ToMuxedID   uint64 `json:"to_muxed_id,omitempty,string"`
 	Amount      string `json:"amount"`
 }
 

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,7 +6,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-## v2.5.1
+## v2.5.2
 
 **Upgrading to this version from <= v2.1.1 will trigger a state rebuild. During this process (which can take up to 20 minutes), Horizon will not ingest new ledgers.**
 

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -10,6 +10,12 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 **Upgrading to this version from <= v2.1.1 will trigger a state rebuild. During this process (which can take up to 20 minutes), Horizon will not ingest new ledgers.**
 
+* Fix a bug in the method unmarshaling payment operation details. ([#3722](https://github.com/stellar/go/pull/3722))
+
+## v2.5.1
+
+**Upgrading to this version from <= v2.1.1 will trigger a state rebuild. During this process (which can take up to 20 minutes), Horizon will not ingest new ledgers.**
+
 * Fix for Stellar-Core 17.1.0 bug that can potentially corrupt Captive-Core storage dir.
 * All muxed ID fields are now represented as strings. This is to support JS that may not handle uint64 values in JSON responses properly.
 

--- a/services/horizon/internal/db2/history/operation.go
+++ b/services/horizon/internal/db2/history/operation.go
@@ -27,14 +27,14 @@ func (r *Operation) UnmarshalDetails(dest interface{}) error {
 	}
 	preprocessedDetails, err := preprocessDetails(r.DetailsString.String)
 	if err != nil {
-		err = errors.Wrap(err, "error in unmarshal")
+		return errors.Wrap(err, "error in unmarshal")
 	}
 	err = json.Unmarshal(preprocessedDetails, &dest)
 	if err != nil {
-		err = errors.Wrap(err, "error in unmarshal")
+		return errors.Wrap(err, "error in unmarshal")
 	}
 
-	return err
+	return nil
 }
 
 func preprocessDetails(details string) ([]byte, error) {

--- a/services/horizon/internal/ingest/processors/operations_processor.go
+++ b/services/horizon/internal/ingest/processors/operations_processor.go
@@ -216,6 +216,10 @@ func addAccountAndMuxedAccountDetails(result map[string]interface{}, a xdr.Muxed
 	result[prefix] = accid.Address()
 	if a.Type == xdr.CryptoKeyTypeKeyTypeMuxedEd25519 {
 		result[prefix+"_muxed"] = a.Address()
+		// _muxed_id fields should had ideally been stored in the DB as a string instead of uint64
+		// due to Javascript not being able to handle them, see https://github.com/stellar/go/issues/3714
+		// However, we released this code in the wild before correcting it. Thus, what we do is
+		// work around it (by preprocessing it into a string) in Operation.UnmarshalDetails()
 		result[prefix+"_muxed_id"] = uint64(a.Med25519.Id)
 	}
 }

--- a/services/horizon/internal/integration/muxed_account_details_test.go
+++ b/services/horizon/internal/integration/muxed_account_details_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stellar/go/clients/horizonclient"
@@ -35,7 +36,8 @@ func TestMuxedAccountDetails(t *testing.T) {
 	destination := xdr.MuxedAccount{
 		Type: xdr.CryptoKeyTypeKeyTypeMuxedEd25519,
 		Med25519: &xdr.MuxedAccountMed25519{
-			Id:      0xdeadbeefdeadbeef,
+			// Make sure we cover the full uint64 range
+			Id:      math.MaxUint64,
 			Ed25519: *destinationAcID.Ed25519,
 		},
 	}

--- a/services/horizon/internal/integration/muxed_account_details_test.go
+++ b/services/horizon/internal/integration/muxed_account_details_test.go
@@ -27,7 +27,7 @@ func TestMuxedAccountDetails(t *testing.T) {
 	source := xdr.MuxedAccount{
 		Type: xdr.CryptoKeyTypeKeyTypeMuxedEd25519,
 		Med25519: &xdr.MuxedAccountMed25519{
-			Id:      0xcafebabe,
+			Id:      0xcafebabecafebabe,
 			Ed25519: *masterAcID.Ed25519,
 		},
 	}
@@ -35,7 +35,7 @@ func TestMuxedAccountDetails(t *testing.T) {
 	destination := xdr.MuxedAccount{
 		Type: xdr.CryptoKeyTypeKeyTypeMuxedEd25519,
 		Med25519: &xdr.MuxedAccountMed25519{
-			Id:      0xdeadbeef,
+			Id:      0xdeadbeefdeadbeef,
 			Ed25519: *destinationAcID.Ed25519,
 		},
 	}

--- a/services/horizon/internal/integration/muxed_operations_test.go
+++ b/services/horizon/internal/integration/muxed_operations_test.go
@@ -73,15 +73,36 @@ func TestMuxedOperations(t *testing.T) {
 		&txnbuild.EndSponsoringFutureReserves{
 			SourceAccount: sponsored.Address(),
 		},
-		// This with:
-		// > Field: Destination, Error: invalid version byte
-		// > validation failed for *txnbuild.AccountMerge operation
-		// &txnbuild.AccountMerge{
-		// 	SourceAccount: sponsoredMuxed.Address(),
-		// 	Destination:   masterMuxed.Address(),
-		// },
 	}
 	txResp, err := itest.SubmitMultiSigOperations(itest.MasterAccount(), []*keypair.Full{master, sponsored}, ops...)
+	assert.NoError(t, err)
+	assert.True(t, txResp.Successful)
+
+	ops = []txnbuild.Operation{
+		// Remove subentries to be able to merge account
+		&txnbuild.ManageSellOffer{
+			SourceAccount: sponsoredMuxed.Address(),
+			Selling:       txnbuild.NativeAsset{},
+			Buying:        txnbuild.CreditAsset{"ABCD", master.Address()},
+			Amount:        "0",
+			Price:         "1",
+			OfferID:       1,
+		},
+		&txnbuild.ChangeTrust{
+			SourceAccount: sponsoredMuxed.Address(),
+			Line:          txnbuild.CreditAsset{"ABCD", master.Address()},
+			Limit:         "0",
+		},
+		&txnbuild.ManageData{
+			SourceAccount: sponsoredMuxed.Address(),
+			Name:          "test",
+		},
+		&txnbuild.AccountMerge{
+			SourceAccount: sponsoredMuxed.Address(),
+			Destination:   masterMuxed.Address(),
+		},
+	}
+	txResp, err = itest.SubmitMultiSigOperations(itest.MasterAccount(), []*keypair.Full{master, sponsored}, ops...)
 	assert.NoError(t, err)
 	assert.True(t, txResp.Successful)
 

--- a/services/horizon/internal/integration/muxed_operations_test.go
+++ b/services/horizon/internal/integration/muxed_operations_test.go
@@ -1,0 +1,98 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/services/horizon/internal/test/integration"
+	"github.com/stellar/go/txnbuild"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMuxedOperations(t *testing.T) {
+	itest := integration.NewTest(t, integration.Config{ProtocolVersion: 17})
+
+	sponsored := keypair.MustRandom()
+	// Is there an easier way?
+	sponsoredMuxed := xdr.MustMuxedAddress(sponsored.Address())
+	sponsoredMuxed.Type = xdr.CryptoKeyTypeKeyTypeMuxedEd25519
+	sponsoredMuxed.Med25519 = &xdr.MuxedAccountMed25519{
+		Ed25519: *sponsoredMuxed.Ed25519,
+		Id:      100,
+	}
+
+	master := itest.Master()
+	masterMuxed := xdr.MustMuxedAddress(master.Address())
+	masterMuxed.Type = xdr.CryptoKeyTypeKeyTypeMuxedEd25519
+	masterMuxed.Med25519 = &xdr.MuxedAccountMed25519{
+		Ed25519: *masterMuxed.Ed25519,
+		Id:      200,
+	}
+
+	ops := []txnbuild.Operation{
+		&txnbuild.BeginSponsoringFutureReserves{
+			SponsoredID: sponsored.Address(),
+		},
+		&txnbuild.CreateAccount{
+			Destination: sponsored.Address(),
+			Amount:      "100",
+		},
+		&txnbuild.ChangeTrust{
+			SourceAccount: sponsoredMuxed.Address(),
+			Line:          txnbuild.CreditAsset{"ABCD", master.Address()},
+			Limit:         txnbuild.MaxTrustlineLimit,
+		},
+		&txnbuild.ManageSellOffer{
+			SourceAccount: sponsoredMuxed.Address(),
+			Selling:       txnbuild.NativeAsset{},
+			Buying:        txnbuild.CreditAsset{"ABCD", master.Address()},
+			Amount:        "3",
+			Price:         "1",
+		},
+		&txnbuild.ManageData{
+			SourceAccount: sponsoredMuxed.Address(),
+			Name:          "test",
+			Value:         []byte("test"),
+		},
+		&txnbuild.Payment{
+			SourceAccount: sponsoredMuxed.Address(),
+			Destination:   master.Address(),
+			Amount:        "1",
+			Asset:         txnbuild.NativeAsset{},
+		},
+		&txnbuild.CreateClaimableBalance{
+			SourceAccount: sponsoredMuxed.Address(),
+			Amount:        "2",
+			Asset:         txnbuild.NativeAsset{},
+			Destinations: []txnbuild.Claimant{
+				txnbuild.NewClaimant(keypair.MustRandom().Address(), nil),
+			},
+		},
+		&txnbuild.EndSponsoringFutureReserves{
+			SourceAccount: sponsored.Address(),
+		},
+		// This with:
+		// > Field: Destination, Error: invalid version byte
+		// > validation failed for *txnbuild.AccountMerge operation
+		// &txnbuild.AccountMerge{
+		// 	SourceAccount: sponsoredMuxed.Address(),
+		// 	Destination:   masterMuxed.Address(),
+		// },
+	}
+	txResp, err := itest.SubmitMultiSigOperations(itest.MasterAccount(), []*keypair.Full{master, sponsored}, ops...)
+	assert.NoError(t, err)
+	assert.True(t, txResp.Successful)
+
+	// Check if no 5xx after processing the tx above
+	// TODO expand it to test actual muxed fields
+	_, err = itest.Client().Operations(horizonclient.OperationRequest{Limit: 200})
+	assert.NoError(t, err, "/operations failed")
+
+	_, err = itest.Client().Payments(horizonclient.OperationRequest{Limit: 200})
+	assert.NoError(t, err, "/payments failed")
+
+	_, err = itest.Client().Effects(horizonclient.EffectRequest{Limit: 200})
+	assert.NoError(t, err, "/effects failed")
+}

--- a/services/horizon/internal/integration/muxed_operations_test.go
+++ b/services/horizon/internal/integration/muxed_operations_test.go
@@ -51,6 +51,14 @@ func TestMuxedOperations(t *testing.T) {
 			Amount:        "3",
 			Price:         "1",
 		},
+		// This will generate a trade effect:
+		&txnbuild.ManageSellOffer{
+			SourceAccount: masterMuxed.Address(),
+			Selling:       txnbuild.CreditAsset{"ABCD", master.Address()},
+			Buying:        txnbuild.NativeAsset{},
+			Amount:        "3",
+			Price:         "1",
+		},
 		&txnbuild.ManageData{
 			SourceAccount: sponsoredMuxed.Address(),
 			Name:          "test",
@@ -80,13 +88,11 @@ func TestMuxedOperations(t *testing.T) {
 
 	ops = []txnbuild.Operation{
 		// Remove subentries to be able to merge account
-		&txnbuild.ManageSellOffer{
+		&txnbuild.Payment{
 			SourceAccount: sponsoredMuxed.Address(),
-			Selling:       txnbuild.NativeAsset{},
-			Buying:        txnbuild.CreditAsset{"ABCD", master.Address()},
-			Amount:        "0",
-			Price:         "1",
-			OfferID:       1,
+			Destination:   master.Address(),
+			Amount:        "3",
+			Asset:         txnbuild.CreditAsset{"ABCD", master.Address()},
 		},
 		&txnbuild.ChangeTrust{
 			SourceAccount: sponsoredMuxed.Address(),

--- a/txnbuild/account_merge.go
+++ b/txnbuild/account_merge.go
@@ -63,9 +63,9 @@ func (am *AccountMerge) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) err
 func (am *AccountMerge) Validate(withMuxedAccounts bool) error {
 	var err error
 	if withMuxedAccounts {
-		_, err = xdr.AddressToAccountId(am.Destination)
-	} else {
 		_, err = xdr.AddressToMuxedAccount(am.Destination)
+	} else {
+		_, err = xdr.AddressToAccountId(am.Destination)
 	}
 	if err != nil {
 		return NewValidationError("Destination", err.Error())

--- a/txnbuild/account_merge_test.go
+++ b/txnbuild/account_merge_test.go
@@ -23,7 +23,7 @@ func TestAccountMergeValidate(t *testing.T) {
 		},
 	)
 	if assert.Error(t, err) {
-		expected := "invalid address"
+		expected := "minimum valid length is 5"
 		assert.Contains(t, err.Error(), expected)
 	}
 }


### PR DESCRIPTION
Fixes #3714 . In particular it fixed the problem found at https://github.com/stellar/go/pull/3716#issuecomment-868358655