### PR TITLE
services/horizon: Fix remaining HTTP error logging

### DIFF
--- a/services/horizon/internal/httpx/server.go
+++ b/services/horizon/internal/httpx/server.go
@@ -58,6 +58,7 @@ func init() {
 	problem.RegisterError(context.Canceled, hProblem.ServiceUnavailable)
 	problem.RegisterError(db.ErrCancelled, hProblem.ServiceUnavailable)
 	problem.RegisterError(db.ErrConflictWithRecovery, hProblem.ServiceUnavailable)
+	problem.RegisterError(db.ErrBadConnection, hProblem.ServiceUnavailable)
 }
 
 func NewServer(serverConfig ServerConfig, routerConfig RouterConfig, ledgerState *ledger.State) (*Server, error) {

--- a/services/horizon/internal/txsub/system.go
+++ b/services/horizon/internal/txsub/system.go
@@ -320,7 +320,10 @@ func (sys *System) Tick(ctx context.Context) {
 		}
 
 		if err != ErrNoResults {
+			// Error in a DB transaction will likely not recover. If that happens/
+			// we return and Tick will try again in next run.
 			logger.WithStack(err).Error(err)
+			return
 		}
 	}
 

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -38,6 +38,9 @@ var (
 	// read replica cancels the query due to conflict with about-to-be-applied
 	// WAL entries (https://www.postgresql.org/docs/current/hot-standby.html).
 	ErrConflictWithRecovery = errors.New("canceling statement due to conflict with recovery")
+	// ErrBadConnection is an error returned when driver returns `bad connection`
+	// error.
+	ErrBadConnection = errors.New("bad connection")
 )
 
 // Conn represents a connection to a single database.

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -236,6 +236,8 @@ func (s *Session) replaceWithKnownError(err error) error {
 		return ErrCancelled
 	case strings.Contains(err.Error(), "pq: canceling statement due to conflict with recovery"):
 		return ErrConflictWithRecovery
+	case strings.Contains(err.Error(), "driver: bad connection"):
+		return ErrBadConnection
 	default:
 		return nil
 	}

--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -73,7 +73,8 @@ const (
 	// LogNoErrors indicates that the Problem instance should not log any errors
 	LogNoErrors = LogFilter(iota)
 	// LogUnknownErrors indicates that the Problem instance should only log errors
-	// which are not registered
+	// which are not registered with level=error but will also log known errors with
+	// level=warn.
 	LogUnknownErrors = LogFilter(iota)
 	// LogAllErrors indicates that the Problem instance should log all errors
 	LogAllErrors = LogFilter(iota)
@@ -187,6 +188,8 @@ func (ps *Problem) Render(ctx context.Context, w http.ResponseWriter, err error)
 				ps.reportFn(ctx, err)
 			}
 			problem = ServerError
+		} else if ps.filter == LogUnknownErrors {
+			ps.log.Ctx(ctx).WithStack(err).Warn(err)
 		}
 	}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

In https://github.com/stellar/go/pull/3674 I silenced `canceling statement due to conflict with recovery` so Horizon does not report expected errors with `level=error`. However, I missed `bad connection` errors that occur from time to time (around 0.001% of all requests in the last 24h in horizon.stellar.org likely after conflict with recovery error) but trigger alerts.