### PR TITLE
Fix ingestion of fee_account_muxed{_id} fields

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,6 +6,8 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Fix a bug in `fee_account_muxed` and `fee_account_muxed_id` fields (the fields were incorrectly populated with the source account details). ([3735](https://github.com/stellar/go/pull/3735))
+
 ## v2.5.2
 
 **Upgrading to this version from <= v2.1.1 will trigger a state rebuild. During this process (which can take up to 20 minutes), Horizon will not ingest new ledgers.**

--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
@@ -283,7 +283,7 @@ func transactionToRow(transaction ingest.LedgerTransaction, sequence uint32) (Tr
 		feeAccount := feeBumpAccount.ToAccountId()
 		var feeAccountMuxed null.String
 		if source.Type == xdr.CryptoKeyTypeKeyTypeMuxedEd25519 {
-			feeAccountMuxed = null.StringFrom(source.Address())
+			feeAccountMuxed = null.StringFrom(feeBumpAccount.Address())
 		}
 		t.FeeAccount = null.StringFrom(feeAccount.Address())
 		t.FeeAccountMuxed = feeAccountMuxed

--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder_test.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder_test.go
@@ -90,4 +90,6 @@ func TestTransactionToMap_muxed(t *testing.T) {
 	assert.Equal(t, innerAccountID.Address(), row.Account)
 
 	assert.Equal(t, feeSourceAccountID.Address(), row.FeeAccount.String)
+
+	assert.Equal(t, feeSource.Address(), row.FeeAccountMuxed.String)
 }


### PR DESCRIPTION
Unfortunately this still requires a reingestion in order to fix it for
old ledgers.

Fixes #3733 