### PR TITLE
ingest/ledgerbackend: Reject bounded ledger ranges that have ledgers after latest checkpoint

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -192,14 +192,18 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 
 	if from > latestCheckpointSequence {
 		return errors.Errorf(
-			"sequence: %d is greater than max available in history archives: %d",
+			"from sequence: %d is greater than max available in history archives: %d",
 			from,
 			latestCheckpointSequence,
 		)
 	}
 
 	if to > latestCheckpointSequence {
-		to = latestCheckpointSequence
+		return errors.Errorf(
+			"to sequence: %d is greater than max available in history archives: %d",
+			to,
+			latestCheckpointSequence,
+		)
 	}
 
 	var runner stellarCoreRunnerInterface

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -7,6 +7,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * Fix a bug in `fee_account_muxed` and `fee_account_muxed_id` fields (the fields were incorrectly populated with the source account details). ([3735](https://github.com/stellar/go/pull/3735))
+* Validate ledger range when calling `horizon db reingest range` so that we respond with an error when attempting to ingest ledgers which are not available in the history archives. ([3738](https://github.com/stellar/go/pull/3738))
 
 ## v2.5.2
 


### PR DESCRIPTION
Fixes https://github.com/stellar/go/issues/3726