### PR TITLE
doc: add examples for how to prefix commit titles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,11 @@ Check out the [Stellar Contribution Guide](https://github.com/stellar/docs/blob/
 
 ### Pull Requests
 
-* PR titles start with package name, ex. "horizon/ingest: fix...", or "all" when changes are broad, ex. "all: update...", or "doc" when changes are isolated to non-code documentation not limited to a single package.
+* PR titles start with:
+  * The package name most affected, ex. `services/horizon: fix...`.
+  * Or, multiple package names separated by a comma when the fix addresses multiple packages worth noting, ex. `services/horizon, services/friendbot: fix...`.
+  * Or, `all:` when changes are broad, ex. `all: update...`.
+  * Or, `doc:` when changes are isolated to non-code documentation not limited to a single package.
 * PRs must update the [CHANGELOG](CHANGELOG.md) with a small description of the change
 * PRs are merged into master or release branch using squash merge
 * Carefully think about where your PR fits according to [semver](https://semver.org). Target it at master if it’s only a patch change, otherwise if it contains breaking change or significant feature additions, set the base branch to the next major or minor release.


### PR DESCRIPTION
### What

Add examples for how to prefix multiple key packages, and make all examples for how to prefix package names clearer.

### Why

As an example for consistency based on what the Go project uses, which is the format our title lines are already based on.

### Known limitations

N/A
