### PR TITLE
services/horizon: Check for overlap error before preparing range in reingestion

### DIFF
--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -297,7 +297,7 @@ var dbReingestRangeCmd = &cobra.Command{
 		horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true})
 		err := runDBReingestRange(argsUInt32[0], argsUInt32[1], reingestForce, parallelWorkers, *config)
 		if err != nil {
-			if errors.Cause(err) == ingest.ErrReingestRangeConflict {
+			if _, ok := errors.Cause(err).(ingest.ErrReingestRangeConflict); ok {
 				message := `
 			The range you have provided overlaps with Horizon's most recently ingested ledger.
 			It is not possible to run the reingest command on this range in parallel with

--- a/services/horizon/internal/ingest/fsm.go
+++ b/services/horizon/internal/ingest/fsm.go
@@ -754,7 +754,8 @@ func (h reingestHistoryRangeState) run(s *system) (transition, error) {
 		}
 
 		// Only prepare the range after checking the bounds to enable an early error return
-		if t, err := prepareRange(); err != nil {
+		var t transition
+		if t, err = prepareRange(); err != nil {
 			return t, err
 		}
 

--- a/services/horizon/internal/ingest/ingest_history_range_state_test.go
+++ b/services/horizon/internal/ingest/ingest_history_range_state_test.go
@@ -353,7 +353,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeOverlaps() {
 	s.historyQ.On("GetLastLedgerIngestNonBlocking", s.ctx).Return(uint32(190), nil).Once()
 
 	err := s.system.ReingestRange(100, 200, false)
-	s.Assert().Equal(err, ErrReingestRangeConflict)
+	s.Assert().Equal(ErrReingestRangeConflict{190}, err)
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeOverlapsAtEnd() {
@@ -363,7 +363,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeOverlapsAtEnd() {
 	s.historyQ.On("GetLastLedgerIngestNonBlocking", s.ctx).Return(uint32(200), nil).Once()
 
 	err := s.system.ReingestRange(100, 200, false)
-	s.Assert().Equal(err, ErrReingestRangeConflict)
+	s.Assert().Equal(ErrReingestRangeConflict{200}, err)
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TestClearHistoryFails() {


### PR DESCRIPTION
Fixes #3638