### PR TITLE
ingest: Properly parse and emit debug-level tags from Captive Core.

### DIFF
--- a/ingest/CHANGELOG.md
+++ b/ingest/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file. This projec
 ### New Features
 * **Performance improvement**: the Captive Core backend now reuses bucket files whenever it finds existing ones in the corresponding `--captive-core-storage-path` (introduced in [v2.0](#v2.0.0)) rather than generating a one-time temporary sub-directory ([#3670](https://github.com/stellar/go/pull/3670)). Note that taking advantage of this feature requires [Stellar-Core v17.1.0](https://github.com/stellar/stellar-core/releases/tag/v17.1.0) or later.
 
+### Bug Fixes
+* The Stellar Core runner now parses logs from its underlying subprocess better [#3746](https://github.com/stellar/go/pull/3746).
+
 
 ## v2.0.0
 

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -221,11 +221,11 @@ func (r *stellarCoreRunner) getLogLineWriter() io.Writer {
 					"DEBUG":   r.log.Debugf,
 				}
 
-				if writer, ok := levelMapping[strings.ToUpper(level)]; ok {
-					writer("%s: %s", category, line)
-				} else {
-					r.log.Infof("%s: %s", category, line)
+				writer := r.log.Infof
+				if f, ok := levelMapping[strings.ToUpper(level)]; ok {
+					writer = f
 				}
+				writer("%s: %s", category, line)
 			} else {
 				r.log.Info(line)
 			}

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -218,12 +218,13 @@ func (r *stellarCoreRunner) getLogLineWriter() io.Writer {
 					"ERROR":   r.log.Errorf,
 					"WARNING": r.log.Warnf,
 					"INFO":    r.log.Infof,
+					"DEBUG":   r.log.Debugf,
 				}
 
 				if writer, ok := levelMapping[strings.ToUpper(level)]; ok {
 					writer("%s: %s", category, line)
 				} else {
-					r.log.Info(line)
+					r.log.Infof("%s: %s", category, line)
 				}
 			} else {
 				r.log.Info(line)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Logs better in cases where the line can't be parsed, and properly parses `debug`-level logs, as well.

### Why
Logs that are marked with `DEBUG` were treated as un-parseable by the Captive Core runner, which incorrectly truncated the log category. Closes #3692.