### PR TITLE
services/horizon: Fix ledger sequence value in runTransactionProcessorsOnLedger

### DIFF
--- a/services/horizon/internal/ingest/fsm.go
+++ b/services/horizon/internal/ingest/fsm.go
@@ -611,7 +611,7 @@ func runTransactionProcessorsOnLedger(s *system, ledger xdr.LedgerCloseMeta) err
 	log.
 		WithFields(ledgerTransactionStats.Map()).
 		WithFields(logpkg.F{
-			"sequence": ledger,
+			"sequence": ledger.LedgerSequence(),
 			"duration": time.Since(startTime).Seconds(),
 			"state":    false,
 			"ledger":   true,


### PR DESCRIPTION
Display ledger sequence in the logs instead of `xdr.LedgerCloseMeta` object dump.