### PR TITLE
services/horizon: Reap data in a DB transaction

### DIFF
--- a/services/horizon/internal/reap/main.go
+++ b/services/horizon/internal/reap/main.go
@@ -25,7 +25,7 @@ type System struct {
 // database for now ledgers and ingesting data into the horizon database.
 func New(retention uint, dbSession db.SessionInterface, ledgerState *ledger.State) *System {
 	r := &System{
-		HistoryQ:       &history.Q{dbSession},
+		HistoryQ:       &history.Q{dbSession.Clone()},
 		RetentionCount: retention,
 		ledgerState:    ledgerState,
 	}

--- a/services/horizon/internal/reap/system.go
+++ b/services/horizon/internal/reap/system.go
@@ -83,5 +83,10 @@ func (r *System) clearBefore(ctx context.Context, seq int32) error {
 		return errors.Wrap(err, "Error in DeleteRangeAll")
 	}
 
+	err = r.HistoryQ.Commit()
+	if err != nil {
+		return errors.Wrap(err, "Error in commit")
+	}
+
 	return nil
 }

--- a/services/horizon/internal/reap/system.go
+++ b/services/horizon/internal/reap/system.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/stellar/go/services/horizon/internal/errors"
 	"github.com/stellar/go/services/horizon/internal/toid"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
 )
 
@@ -71,9 +71,15 @@ func (r *System) clearBefore(ctx context.Context, seq int32) error {
 		return err
 	}
 
+	err = r.HistoryQ.Begin()
+	if err != nil {
+		return errors.Wrap(err, "Error in begin")
+	}
+	defer r.HistoryQ.Rollback()
+
 	err = r.HistoryQ.DeleteRangeAll(ctx, start, end)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Error in DeleteRangeAll")
 	}
 
 	return nil

--- a/services/horizon/internal/reap/system.go
+++ b/services/horizon/internal/reap/system.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	herrors "github.com/stellar/go/services/horizon/internal/errors"
 	"github.com/stellar/go/services/horizon/internal/toid"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
@@ -51,9 +52,9 @@ func (r *System) Tick(ctx context.Context) {
 func (r *System) runOnce(ctx context.Context) {
 	defer func() {
 		if rec := recover(); rec != nil {
-			err := errors.FromPanic(rec)
+			err := herrors.FromPanic(rec)
 			log.Errorf("reaper panicked: %s", err)
-			errors.ReportToSentry(err, nil)
+			herrors.ReportToSentry(err, nil)
 		}
 	}()
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Wrap reap processing in a DB transaction.

### Why

When checking https://github.com/stellar/go/issues/3711 I realized that since https://github.com/stellar/go/pull/3567 reap process can be stopped in a middle which can result in just a part of ledger data reaped causing issues like https://github.com/stellar/go/issues/3751.

### Known limitations

It's likely that reap won't finish because of https://github.com/stellar/go/pull/3567. We should probably move it outside of global `Tick` (https://github.com/stellar/go/issues/613).