### PR TITLE
services/horizon: Fix some bugs in db migrate commands

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this
 file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## v2.6.1
+
+**Upgrading to this version from <= v2.5.2 will trigger a state rebuild. During this process (which will take at least 10 minutes), Horizon will not ingest new ledgers.**
+
+* Fix bug introduced in v2.6.0 ([#3737](https://github.com/stellar/go/pull/3737)), preventing usage of `horizon db migrate up/down/redo` commands. ([#3762](https://github.com/stellar/go/pull/3762))
 
 ## v2.6.0
 

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -74,7 +74,7 @@ func migrate(dir schema.MigrateDir, count int) {
 		log.Fatal(err)
 	}
 
-	numMigrationsRun, err := schema.Migrate(dbConn.DB.DB, schema.MigrateRedo, count)
+	numMigrationsRun, err := schema.Migrate(dbConn.DB.DB, dir, count)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -99,7 +99,7 @@ var dbMigrateDownCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		count, err := strconv.Atoi(args[1])
+		count, err := strconv.Atoi(args[0])
 		if err != nil {
 			log.Println(err)
 			cmd.Usage()
@@ -123,7 +123,7 @@ var dbMigrateRedoCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		count, err := strconv.Atoi(args[1])
+		count, err := strconv.Atoi(args[0])
 		if err != nil {
 			log.Println(err)
 			cmd.Usage()


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fix some bugs introduced in https://github.com/stellar/go/pull/3737
- off-by-one on arg parsing
- not actually using the migration direction

### Why

- Without it migrations are totally broken.
  - How didn't we (myself mainly) catch this in testing? Primarily, as-noted in #3737, there aren't tests for the migrate commands. Because they're stateful, CLI commands modifying the database, they're not straightforward to test. We should have a find a way to test these.

### Known limitations

[TODO or N/A]
