### PR TITLE
services/horizon: Purging log.Fatal, to make horizon CLI easier to test.

### DIFF
--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -66,11 +66,12 @@ func main() {
 			OptType:     types.String,
 			Required:    true,
 			FlagDefault: "",
-			CustomSetValue: func(co *config.ConfigOption) {
+			CustomSetValue: func(co *config.ConfigOption) error {
 				stringOfUrls := viper.GetString(co.Name)
 				urlStrings := strings.Split(stringOfUrls, ",")
 
 				*(co.ConfigKey.(*[]string)) = urlStrings
+				return nil
 			},
 			Usage: "comma-separated list of stellar history archives to connect with",
 		},
@@ -79,12 +80,13 @@ func main() {
 			ConfigKey:   &logLevel,
 			OptType:     types.String,
 			FlagDefault: "info",
-			CustomSetValue: func(co *config.ConfigOption) {
+			CustomSetValue: func(co *config.ConfigOption) error {
 				ll, err := logrus.ParseLevel(viper.GetString(co.Name))
 				if err != nil {
-					logger.Fatalf("Could not parse log-level: %v", viper.GetString(co.Name))
+					return fmt.Errorf("Could not parse log-level: %v", viper.GetString(co.Name))
 				}
 				*(co.ConfigKey.(*logrus.Level)) = ll
+				return nil
 			},
 			Usage: "minimum log severity (debug, info, warn, error) to log",
 		},

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -32,32 +32,34 @@ var dbMigrateCmd = &cobra.Command{
 	Short: "commands to run schema migrations on horizon's postgres db",
 }
 
-func requireAndSetFlag(name string) {
+func requireAndSetFlag(name string) error {
 	for _, flag := range flags {
 		if flag.Name == name {
 			flag.Require()
 			flag.SetValue()
-			return
+			return nil
 		}
 	}
-	log.Fatalf("could not find %s flag", name)
+	return fmt.Errorf("could not find %s flag", name)
 }
 
 var dbInitCmd = &cobra.Command{
 	Use:   "init",
 	Short: "install schema",
 	Long:  "init initializes the postgres database used by horizon.",
-	Run: func(cmd *cobra.Command, args []string) {
-		requireAndSetFlag(horizon.DatabaseURLFlagName)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAndSetFlag(horizon.DatabaseURLFlagName); err != nil {
+			return err
+		}
 
 		db, err := sql.Open("postgres", config.DatabaseURL)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		numMigrationsRun, err := schema.Migrate(db, schema.MigrateUp, 0)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		if numMigrationsRun == 0 {
@@ -65,18 +67,19 @@ var dbInitCmd = &cobra.Command{
 		} else {
 			log.Printf("Successfully applied %d migrations.\n", numMigrationsRun)
 		}
+		return nil
 	},
 }
 
-func migrate(dir schema.MigrateDir, count int) {
+func migrate(dir schema.MigrateDir, count int) error {
 	dbConn, err := db.Open("postgres", config.DatabaseURL)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	numMigrationsRun, err := schema.Migrate(dbConn.DB.DB, dir, count)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	if numMigrationsRun == 0 {
@@ -84,29 +87,32 @@ func migrate(dir schema.MigrateDir, count int) {
 	} else {
 		log.Printf("Successfully applied %d migrations.\n", numMigrationsRun)
 	}
+	return nil
 }
 
 var dbMigrateDownCmd = &cobra.Command{
 	Use:   "down COUNT",
 	Short: "run upwards db schema migrations",
 	Long:  "performs a downards schema migration command",
-	Run: func(cmd *cobra.Command, args []string) {
-		requireAndSetFlag(horizon.DatabaseURLFlagName)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAndSetFlag(horizon.DatabaseURLFlagName); err != nil {
+			return err
+		}
 
 		// Only allow invokations with 1 args.
 		if len(args) != 1 {
 			cmd.Usage()
-			os.Exit(1)
+			return ErrUsage
 		}
 
 		count, err := strconv.Atoi(args[0])
 		if err != nil {
 			log.Println(err)
 			cmd.Usage()
-			os.Exit(1)
+			return ErrUsage
 		}
 
-		migrate(schema.MigrateDown, count)
+		return migrate(schema.MigrateDown, count)
 	},
 }
 
@@ -114,23 +120,25 @@ var dbMigrateRedoCmd = &cobra.Command{
 	Use:   "redo COUNT",
 	Short: "redo db schema migrations",
 	Long:  "performs a redo schema migration command",
-	Run: func(cmd *cobra.Command, args []string) {
-		requireAndSetFlag(horizon.DatabaseURLFlagName)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAndSetFlag(horizon.DatabaseURLFlagName); err != nil {
+			return err
+		}
 
 		// Only allow invokations with 1 args.
 		if len(args) != 1 {
 			cmd.Usage()
-			os.Exit(1)
+			return ErrUsage
 		}
 
 		count, err := strconv.Atoi(args[0])
 		if err != nil {
 			log.Println(err)
 			cmd.Usage()
-			os.Exit(1)
+			return ErrUsage
 		}
 
-		migrate(schema.MigrateRedo, count)
+		return migrate(schema.MigrateRedo, count)
 	},
 }
 
@@ -138,27 +146,30 @@ var dbMigrateStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "print current database migration status",
 	Long:  "print current database migration status",
-	Run: func(cmd *cobra.Command, args []string) {
-		requireAndSetFlag(horizon.DatabaseURLFlagName)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAndSetFlag(horizon.DatabaseURLFlagName); err != nil {
+			return err
+		}
 
 		// Only allow invokations with 0 args.
 		if len(args) != 0 {
 			fmt.Println(args)
 			cmd.Usage()
-			os.Exit(1)
+			return ErrUsage
 		}
 
 		dbConn, err := db.Open("postgres", config.DatabaseURL)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		status, err := schema.Status(dbConn.DB.DB)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		fmt.Println(status)
+		return nil
 	},
 }
 
@@ -166,13 +177,15 @@ var dbMigrateUpCmd = &cobra.Command{
 	Use:   "up [COUNT]",
 	Short: "run upwards db schema migrations",
 	Long:  "performs an upwards schema migration command",
-	Run: func(cmd *cobra.Command, args []string) {
-		requireAndSetFlag(horizon.DatabaseURLFlagName)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAndSetFlag(horizon.DatabaseURLFlagName); err != nil {
+			return err
+		}
 
 		// Only allow invokations with 0-1 args.
 		if len(args) > 1 {
 			cmd.Usage()
-			os.Exit(1)
+			return ErrUsage
 		}
 
 		count := 0
@@ -182,11 +195,11 @@ var dbMigrateUpCmd = &cobra.Command{
 			if err != nil {
 				log.Println(err)
 				cmd.Usage()
-				os.Exit(1)
+				return ErrUsage
 			}
 		}
 
-		migrate(schema.MigrateUp, count)
+		return migrate(schema.MigrateUp, count)
 	},
 }
 
@@ -194,14 +207,14 @@ var dbReapCmd = &cobra.Command{
 	Use:   "reap",
 	Short: "reaps (i.e. removes) any reapable history data",
 	Long:  "reap removes any historical data that is earlier than the configured retention cutoff",
-	Run: func(cmd *cobra.Command, args []string) {
-		app := horizon.NewAppFromFlags(config, flags)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		app, err := horizon.NewAppFromFlags(config, flags)
+		if err != nil {
+			return err
+		}
 		ctx := context.Background()
 		app.UpdateLedgerState(ctx)
-		err := app.DeleteUnretainedHistory(ctx)
-		if err != nil {
-			log.Fatal(err)
-		}
+		return app.DeleteUnretainedHistory(ctx)
 	},
 }
 
@@ -209,10 +222,10 @@ var dbReingestCmd = &cobra.Command{
 	Use:   "reingest",
 	Short: "reingest commands",
 	Long:  "reingest ingests historical data for every ledger or ledgers specified by subcommand",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println("Use one of the subcomands...")
 		cmd.Usage()
-		os.Exit(1)
+		return ErrUsage
 	},
 }
 
@@ -271,24 +284,26 @@ var dbReingestRangeCmd = &cobra.Command{
 	Use:   "range [Start sequence number] [End sequence number]",
 	Short: "reingests ledgers within a range",
 	Long:  "reingests ledgers between X and Y sequence number (closed intervals)",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, co := range reingestRangeCmdOpts {
-			co.Require()
+			if err := co.RequireE(); err != nil {
+				return err
+			}
 			co.SetValue()
 		}
 
 		if len(args) != 2 {
 			cmd.Usage()
-			os.Exit(1)
+			return ErrUsage
 		}
 
 		argsUInt32 := make([]uint32, 2)
 		for i, arg := range args {
 			if seq, err := strconv.Atoi(arg); err != nil {
 				cmd.Usage()
-				log.Fatalf(`Invalid sequence number "%s"`, arg)
+				return fmt.Errorf(`Invalid sequence number "%s"`, arg)
 			} else if seq < 0 {
-				log.Fatalf("sequence number %s cannot be negative", arg)
+				return fmt.Errorf("sequence number %s cannot be negative", arg)
 			} else {
 				argsUInt32[i] = uint32(seq)
 			}
@@ -298,21 +313,21 @@ var dbReingestRangeCmd = &cobra.Command{
 		err := runDBReingestRange(argsUInt32[0], argsUInt32[1], reingestForce, parallelWorkers, *config)
 		if err != nil {
 			if _, ok := errors.Cause(err).(ingest.ErrReingestRangeConflict); ok {
-				message := `
+				return fmt.Errorf(`
 			The range you have provided overlaps with Horizon's most recently ingested ledger.
 			It is not possible to run the reingest command on this range in parallel with
 			Horizon's ingestion system.
 			Either reduce the range so that it doesn't overlap with Horizon's ingestion system,
 			or, use the force flag to ensure that Horizon's ingestion system is blocked until
 			the reingest command completes.
-			`
-				log.Fatal(message)
+			`)
 			}
 
-			log.Fatal(err)
+			return err
 		}
 
 		hlog.Info("Range run successfully!")
+		return nil
 	},
 }
 
@@ -381,25 +396,29 @@ var dbDetectGapsCmd = &cobra.Command{
 	Use:   "detect-gaps",
 	Short: "detects ingestion gaps in Horizon's database",
 	Long:  "detects ingestion gaps in Horizon's database and prints a list of reingest commands needed to fill the gaps",
-	Run: func(cmd *cobra.Command, args []string) {
-		requireAndSetFlag(horizon.DatabaseURLFlagName)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAndSetFlag(horizon.DatabaseURLFlagName); err != nil {
+			return err
+		}
+
 		if len(args) != 0 {
 			cmd.Usage()
-			os.Exit(1)
+			return ErrUsage
 		}
 		gaps, err := runDBDetectGaps(*config)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		if len(gaps) == 0 {
 			hlog.Info("No gaps found")
-			return
+			return nil
 		}
 		fmt.Println("Horizon commands to run in order to fill in the gaps:")
 		cmdname := os.Args[0]
 		for _, g := range gaps {
 			fmt.Printf("%s db reingest %d %d\n", cmdname, g.StartSequence, g.EndSequence)
 		}
+		return nil
 	},
 }
 

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -313,14 +313,12 @@ var dbReingestRangeCmd = &cobra.Command{
 		err := runDBReingestRange(argsUInt32[0], argsUInt32[1], reingestForce, parallelWorkers, *config)
 		if err != nil {
 			if _, ok := errors.Cause(err).(ingest.ErrReingestRangeConflict); ok {
-				return fmt.Errorf(`
-			The range you have provided overlaps with Horizon's most recently ingested ledger.
-			It is not possible to run the reingest command on this range in parallel with
-			Horizon's ingestion system.
-			Either reduce the range so that it doesn't overlap with Horizon's ingestion system,
-			or, use the force flag to ensure that Horizon's ingestion system is blocked until
-			the reingest command completes.
-			`)
+				return fmt.Errorf(`The range you have provided overlaps with Horizon's most recently ingested ledger.
+It is not possible to run the reingest command on this range in parallel with
+Horizon's ingestion system.
+Either reduce the range so that it doesn't overlap with Horizon's ingestion system,
+or, use the force flag to ensure that Horizon's ingestion system is blocked until
+the reingest command completes.`)
 			}
 
 			return err

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -101,15 +101,13 @@ var dbMigrateDownCmd = &cobra.Command{
 
 		// Only allow invokations with 1 args.
 		if len(args) != 1 {
-			cmd.Usage()
-			return ErrUsage
+			return ErrUsage{cmd}
 		}
 
 		count, err := strconv.Atoi(args[0])
 		if err != nil {
 			log.Println(err)
-			cmd.Usage()
-			return ErrUsage
+			return ErrUsage{cmd}
 		}
 
 		return migrate(schema.MigrateDown, count)
@@ -127,15 +125,13 @@ var dbMigrateRedoCmd = &cobra.Command{
 
 		// Only allow invokations with 1 args.
 		if len(args) != 1 {
-			cmd.Usage()
-			return ErrUsage
+			return ErrUsage{cmd}
 		}
 
 		count, err := strconv.Atoi(args[0])
 		if err != nil {
 			log.Println(err)
-			cmd.Usage()
-			return ErrUsage
+			return ErrUsage{cmd}
 		}
 
 		return migrate(schema.MigrateRedo, count)
@@ -154,8 +150,7 @@ var dbMigrateStatusCmd = &cobra.Command{
 		// Only allow invokations with 0 args.
 		if len(args) != 0 {
 			fmt.Println(args)
-			cmd.Usage()
-			return ErrUsage
+			return ErrUsage{cmd}
 		}
 
 		dbConn, err := db.Open("postgres", config.DatabaseURL)
@@ -184,8 +179,7 @@ var dbMigrateUpCmd = &cobra.Command{
 
 		// Only allow invokations with 0-1 args.
 		if len(args) > 1 {
-			cmd.Usage()
-			return ErrUsage
+			return ErrUsage{cmd}
 		}
 
 		count := 0
@@ -194,8 +188,7 @@ var dbMigrateUpCmd = &cobra.Command{
 			count, err = strconv.Atoi(args[0])
 			if err != nil {
 				log.Println(err)
-				cmd.Usage()
-				return ErrUsage
+				return ErrUsage{cmd}
 			}
 		}
 
@@ -224,8 +217,7 @@ var dbReingestCmd = &cobra.Command{
 	Long:  "reingest ingests historical data for every ledger or ledgers specified by subcommand",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println("Use one of the subcomands...")
-		cmd.Usage()
-		return ErrUsage
+		return ErrUsage{cmd}
 	},
 }
 
@@ -293,8 +285,7 @@ var dbReingestRangeCmd = &cobra.Command{
 		}
 
 		if len(args) != 2 {
-			cmd.Usage()
-			return ErrUsage
+			return ErrUsage{cmd}
 		}
 
 		argsUInt32 := make([]uint32, 2)
@@ -400,8 +391,7 @@ var dbDetectGapsCmd = &cobra.Command{
 		}
 
 		if len(args) != 0 {
-			cmd.Usage()
-			return ErrUsage
+			return ErrUsage{cmd}
 		}
 		gaps, err := runDBDetectGaps(*config)
 		if err != nil {

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -65,13 +65,17 @@ var ingestVerifyRangeCmd = &cobra.Command{
 	Use:   "verify-range",
 	Short: "runs ingestion pipeline within a range. warning! requires clean DB.",
 	Long:  "runs ingestion pipeline between X and Y sequence number (inclusive)",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, co := range ingestVerifyRangeCmdOpts {
-			co.Require()
+			if err := co.RequireE(); err != nil {
+				return err
+			}
 			co.SetValue()
 		}
 
-		horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true})
+		if err := horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true}); err != nil {
+			return err
+		}
 
 		if ingestVerifyDebugServerPort != 0 {
 			go func() {
@@ -88,15 +92,15 @@ var ingestVerifyRangeCmd = &cobra.Command{
 
 		horizonSession, err := db.Open("postgres", config.DatabaseURL)
 		if err != nil {
-			log.Fatalf("cannot open Horizon DB: %v", err)
+			return fmt.Errorf("cannot open Horizon DB: %v", err)
 		}
 		mngr := historyarchive.NewCheckpointManager(config.CheckpointFrequency)
 		if !mngr.IsCheckpoint(ingestVerifyFrom) && ingestVerifyFrom != 1 {
-			log.Fatal("`--from` must be a checkpoint ledger")
+			return fmt.Errorf("`--from` must be a checkpoint ledger")
 		}
 
 		if ingestVerifyState && !mngr.IsCheckpoint(ingestVerifyTo) {
-			log.Fatal("`--to` must be a checkpoint ledger when `--verify-state` is set.")
+			return fmt.Errorf("`--to` must be a checkpoint ledger when `--verify-state` is set.")
 		}
 
 		ingestConfig := ingest.Config{
@@ -113,19 +117,19 @@ var ingestVerifyRangeCmd = &cobra.Command{
 
 		if !ingestConfig.EnableCaptiveCore {
 			if config.StellarCoreDatabaseURL == "" {
-				log.Fatalf("flag --%s cannot be empty", horizon.StellarCoreDBURLFlagName)
+				return fmt.Errorf("flag --%s cannot be empty", horizon.StellarCoreDBURLFlagName)
 			}
 
 			coreSession, dbErr := db.Open("postgres", config.StellarCoreDatabaseURL)
 			if dbErr != nil {
-				log.Fatalf("cannot open Core DB: %v", dbErr)
+				return fmt.Errorf("cannot open Core DB: %v", dbErr)
 			}
 			ingestConfig.CoreSession = coreSession
 		}
 
 		system, err := ingest.NewSystem(ingestConfig)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		err = system.VerifyRange(
@@ -134,10 +138,11 @@ var ingestVerifyRangeCmd = &cobra.Command{
 			ingestVerifyState,
 		)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		log.Info("Range run successfully!")
+		return nil
 	},
 }
 
@@ -166,25 +171,29 @@ var ingestStressTestCmd = &cobra.Command{
 	Use:   "stress-test",
 	Short: "runs ingestion pipeline on a ledger with many changes. warning! requires clean DB.",
 	Long:  "runs ingestion pipeline on a ledger with many changes. warning! requires clean DB.",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, co := range stressTestCmdOpts {
-			co.Require()
+			if err := co.RequireE(); err != nil {
+				return err
+			}
 			co.SetValue()
 		}
 
-		horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true})
+		if err := horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true}); err != nil {
+			return err
+		}
 
 		horizonSession, err := db.Open("postgres", config.DatabaseURL)
 		if err != nil {
-			log.Fatalf("cannot open Horizon DB: %v", err)
+			return fmt.Errorf("cannot open Horizon DB: %v", err)
 		}
 
 		if stressTestNumTransactions <= 0 {
-			log.Fatal("`--transactions` must be positive")
+			return fmt.Errorf("`--transactions` must be positive")
 		}
 
 		if stressTestChangesPerTransaction <= 0 {
-			log.Fatal("`--changes` must be positive")
+			return fmt.Errorf("`--changes` must be positive")
 		}
 
 		ingestConfig := ingest.Config{
@@ -199,19 +208,19 @@ var ingestStressTestCmd = &cobra.Command{
 			ingestConfig.RemoteCaptiveCoreURL = config.RemoteCaptiveCoreURL
 		} else {
 			if config.StellarCoreDatabaseURL == "" {
-				log.Fatalf("flag --%s cannot be empty", horizon.StellarCoreDBURLFlagName)
+				return fmt.Errorf("flag --%s cannot be empty", horizon.StellarCoreDBURLFlagName)
 			}
 
 			coreSession, dbErr := db.Open("postgres", config.StellarCoreDatabaseURL)
 			if dbErr != nil {
-				log.Fatalf("cannot open Core DB: %v", dbErr)
+				return fmt.Errorf("cannot open Core DB: %v", dbErr)
 			}
 			ingestConfig.CoreSession = coreSession
 		}
 
 		system, err := ingest.NewSystem(ingestConfig)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		err = system.StressTest(
@@ -219,56 +228,61 @@ var ingestStressTestCmd = &cobra.Command{
 			stressTestChangesPerTransaction,
 		)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		log.Info("Stress test completed successfully!")
+		return nil
 	},
 }
 
 var ingestTriggerStateRebuildCmd = &cobra.Command{
 	Use:   "trigger-state-rebuild",
 	Short: "updates a database to trigger state rebuild, state will be rebuilt by a running Horizon instance, DO NOT RUN production DB, some endpoints will be unavailable until state is rebuilt",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
-		horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true})
+		if err := horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true}); err != nil {
+			return err
+		}
 
 		horizonSession, err := db.Open("postgres", config.DatabaseURL)
 		if err != nil {
-			log.Fatalf("cannot open Horizon DB: %v", err)
+			return fmt.Errorf("cannot open Horizon DB: %v", err)
 		}
 
 		historyQ := &history.Q{horizonSession}
-		err = historyQ.UpdateIngestVersion(ctx, 0)
-		if err != nil {
-			log.Fatalf("cannot trigger state rebuild: %v", err)
+		if err := historyQ.UpdateIngestVersion(ctx, 0); err != nil {
+			return fmt.Errorf("cannot trigger state rebuild: %v", err)
 		}
 
 		log.Info("Triggered state rebuild")
+		return nil
 	},
 }
 
 var ingestInitGenesisStateCmd = &cobra.Command{
 	Use:   "init-genesis-state",
 	Short: "ingests genesis state (ledger 1)",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
-		horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true})
+		if err := horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true}); err != nil {
+			return err
+		}
 
 		horizonSession, err := db.Open("postgres", config.DatabaseURL)
 		if err != nil {
-			log.Fatalf("cannot open Horizon DB: %v", err)
+			return fmt.Errorf("cannot open Horizon DB: %v", err)
 		}
 
 		historyQ := &history.Q{horizonSession}
 
 		lastIngestedLedger, err := historyQ.GetLastLedgerIngestNonBlocking(ctx)
 		if err != nil {
-			log.Fatalf("cannot get last ledger value: %v", err)
+			return fmt.Errorf("cannot get last ledger value: %v", err)
 		}
 
 		if lastIngestedLedger != 0 {
-			log.Fatalf("cannot run on non-empty DB")
+			return fmt.Errorf("cannot run on non-empty DB")
 		}
 
 		ingestConfig := ingest.Config{
@@ -283,27 +297,28 @@ var ingestInitGenesisStateCmd = &cobra.Command{
 			ingestConfig.CaptiveCoreBinaryPath = config.CaptiveCoreBinaryPath
 		} else {
 			if config.StellarCoreDatabaseURL == "" {
-				log.Fatalf("flag --%s cannot be empty", horizon.StellarCoreDBURLFlagName)
+				return fmt.Errorf("flag --%s cannot be empty", horizon.StellarCoreDBURLFlagName)
 			}
 
 			coreSession, dbErr := db.Open("postgres", config.StellarCoreDatabaseURL)
 			if dbErr != nil {
-				log.Fatalf("cannot open Core DB: %v", dbErr)
+				return fmt.Errorf("cannot open Core DB: %v", dbErr)
 			}
 			ingestConfig.CoreSession = coreSession
 		}
 
 		system, err := ingest.NewSystem(ingestConfig)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		err = system.BuildGenesisState()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		log.Info("Genesis ledger stat successfully ingested!")
+		return nil
 	},
 }
 

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	stdLog "log"
-	"os"
 
 	"github.com/spf13/cobra"
 	horizon "github.com/stellar/go/services/horizon/internal"
@@ -16,11 +15,25 @@ var (
 		Use:   "horizon",
 		Short: "client-facing api server for the Stellar network",
 		Long:  "Client-facing API server for the Stellar network. It acts as the interface between Stellar Core and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.",
-		Run: func(cmd *cobra.Command, args []string) {
-			horizon.NewAppFromFlags(config, flags).Serve()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app, err := horizon.NewAppFromFlags(config, flags)
+			if err != nil {
+				return err
+			}
+			return app.Serve()
 		},
 	}
+
+	// ErrUsage indicates we printed the usage string, so just exit with code 1
+	ErrUsage = ErrExitCode(1)
 )
+
+// Indicates we want to exit with a specific error code without printing an error.
+type ErrExitCode int
+
+func (e ErrExitCode) Error() string {
+	return fmt.Sprintf("exit code: %d", e)
+}
 
 func init() {
 	err := flags.Init(RootCmd)
@@ -29,9 +42,6 @@ func init() {
 	}
 }
 
-func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+func Execute() error {
+	return RootCmd.Execute()
 }

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -12,9 +12,11 @@ var (
 	config, flags = horizon.Flags()
 
 	RootCmd = &cobra.Command{
-		Use:   "horizon",
-		Short: "client-facing api server for the Stellar network",
-		Long:  "Client-facing API server for the Stellar network. It acts as the interface between Stellar Core and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.",
+		Use:           "horizon",
+		Short:         "client-facing api server for the Stellar network",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		Long:          "Client-facing API server for the Stellar network. It acts as the interface between Stellar Core and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app, err := horizon.NewAppFromFlags(config, flags)
 			if err != nil {
@@ -23,10 +25,16 @@ var (
 			return app.Serve()
 		},
 	}
-
-	// ErrUsage indicates we printed the usage string, so just exit with code 1
-	ErrUsage = ErrExitCode(1)
 )
+
+// ErrUsage indicates we should print the usage string and exit with code 1
+type ErrUsage struct {
+	cmd *cobra.Command
+}
+
+func (e ErrUsage) Error() string {
+	return e.cmd.UsageString()
+}
 
 // Indicates we want to exit with a specific error code without printing an error.
 type ErrExitCode int

--- a/services/horizon/cmd/serve.go
+++ b/services/horizon/cmd/serve.go
@@ -9,8 +9,12 @@ var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "run horizon server",
 	Long:  "serve initializes then starts the horizon HTTP server",
-	Run: func(cmd *cobra.Command, args []string) {
-		horizon.NewAppFromFlags(config, flags).Serve()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		app, err := horizon.NewAppFromFlags(config, flags)
+		if err != nil {
+			return err
+		}
+		return app.Serve()
 	},
 }
 

--- a/services/horizon/cmd/version.go
+++ b/services/horizon/cmd/version.go
@@ -12,9 +12,10 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "print horizon and Golang runtime version",
 	Long:  "",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println(apkg.Version())
 		fmt.Println(runtime.Version())
+		return nil
 	},
 }
 

--- a/services/horizon/internal/actions_root_test.go
+++ b/services/horizon/internal/actions_root_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRootAction(t *testing.T) {
@@ -28,7 +29,7 @@ func TestRootAction(t *testing.T) {
 
 	ht.App.config.StellarCoreURL = server.URL
 	ht.App.config.NetworkPassphrase = "test"
-	ht.App.UpdateStellarCoreInfo(ht.Ctx)
+	assert.NoError(t, ht.App.UpdateStellarCoreInfo(ht.Ctx))
 	ht.App.UpdateLedgerState(ht.Ctx)
 
 	w := ht.Get("/")

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -374,6 +374,9 @@ func (a *App) UpdateFeeStatsState(ctx context.Context) {
 // UpdateStellarCoreInfo updates the value of CoreVersion,
 // CurrentProtocolVersion, and CoreSupportedProtocolVersion from the Stellar
 // core API.
+//
+// Warning: This method should only return an error if it is fatal. See usage
+// in `App.Tick`
 func (a *App) UpdateStellarCoreInfo(ctx context.Context) error {
 	if a.config.StellarCoreURL == "" {
 		return nil

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -3,6 +3,7 @@ package horizon
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/stellar/go/clients/stellarcore"
 	"github.com/stellar/go/services/horizon/internal/corestate"
@@ -85,7 +87,7 @@ func NewApp(config Config) (*App, error) {
 
 // Serve starts the horizon web server, binding it to a socket, setting up
 // the shutdown signals.
-func (a *App) Serve() {
+func (a *App) Serve() error {
 
 	log.Infof("Starting horizon on :%d (ingest: %v)", a.config.Port, a.config.Ingest)
 
@@ -153,13 +155,14 @@ func (a *App) Serve() {
 
 	err := a.webServer.Serve()
 	if err != nil && err != http.ErrServerClosed {
-		log.Fatal(err)
+		return err
 	}
 
 	wg.Wait()
 	a.CloseDB()
 
 	log.Info("stopped")
+	return nil
 }
 
 // Close cancels the app. It does not close DB connections - use App.CloseDB().
@@ -372,9 +375,9 @@ func (a *App) UpdateFeeStatsState(ctx context.Context) {
 // UpdateStellarCoreInfo updates the value of CoreVersion,
 // CurrentProtocolVersion, and CoreSupportedProtocolVersion from the Stellar
 // core API.
-func (a *App) UpdateStellarCoreInfo(ctx context.Context) {
+func (a *App) UpdateStellarCoreInfo(ctx context.Context) error {
 	if a.config.StellarCoreURL == "" {
-		return
+		return nil
 	}
 
 	core := &stellarcore.Client{
@@ -384,21 +387,21 @@ func (a *App) UpdateStellarCoreInfo(ctx context.Context) {
 	resp, err := core.Info(ctx)
 	if err != nil {
 		log.Warnf("could not load stellar-core info: %s", err)
-		return
+		return nil
 	}
 
 	// Check if NetworkPassphrase is different, if so exit Horizon as it can break the
 	// state of the application.
 	if resp.Info.Network != a.config.NetworkPassphrase {
-		log.Errorf(
+		return fmt.Errorf(
 			"Network passphrase of stellar-core (%s) does not match Horizon configuration (%s). Exiting...",
 			resp.Info.Network,
 			a.config.NetworkPassphrase,
 		)
-		os.Exit(1)
 	}
 
 	a.coreState.Set(resp)
+	return nil
 }
 
 // DeleteUnretainedHistory forwards to the app's reaper.  See
@@ -410,19 +413,22 @@ func (a *App) DeleteUnretainedHistory(ctx context.Context) error {
 // Tick triggers horizon to update all of it's background processes such as
 // transaction submission, metrics, ingestion and reaping.
 func (a *App) Tick(ctx context.Context) error {
-	var wg sync.WaitGroup
+	wg, ctx := errgroup.WithContext(ctx)
 	log.Debug("ticking app")
 
 	// update ledger state, operation fee state, and stellar-core info in parallel
-	wg.Add(3)
-	go func() { a.UpdateLedgerState(ctx); wg.Done() }()
-	go func() { a.UpdateFeeStatsState(ctx); wg.Done() }()
-	go func() { a.UpdateStellarCoreInfo(ctx); wg.Done() }()
-	wg.Wait()
+	wg.Go(func() error { a.UpdateLedgerState(ctx); return nil })
+	wg.Go(func() error { a.UpdateFeeStatsState(ctx); return nil })
+	wg.Go(func() error { return a.UpdateStellarCoreInfo(ctx) })
+	if err := wg.Wait(); err != nil {
+		return err
+	}
+	if ctx.Err() != nil {
+		// Failure to launch
+		return ctx.Err()
+	}
 
-	wg.Add(1)
-	go func() { a.submitter.Tick(ctx); wg.Done() }()
-	wg.Wait()
+	a.submitter.Tick(ctx)
 
 	log.Debug("finished ticking app")
 	return ctx.Err()

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/stellar/go/clients/stellarcore"
 	"github.com/stellar/go/services/horizon/internal/corestate"
@@ -413,22 +412,23 @@ func (a *App) DeleteUnretainedHistory(ctx context.Context) error {
 // Tick triggers horizon to update all of it's background processes such as
 // transaction submission, metrics, ingestion and reaping.
 func (a *App) Tick(ctx context.Context) error {
-	wg, ctx := errgroup.WithContext(ctx)
+	var wg sync.WaitGroup
 	log.Debug("ticking app")
 
 	// update ledger state, operation fee state, and stellar-core info in parallel
-	wg.Go(func() error { a.UpdateLedgerState(ctx); return nil })
-	wg.Go(func() error { a.UpdateFeeStatsState(ctx); return nil })
-	wg.Go(func() error { return a.UpdateStellarCoreInfo(ctx) })
-	if err := wg.Wait(); err != nil {
+	wg.Add(3)
+	var err error
+	go func() { a.UpdateLedgerState(ctx); wg.Done() }()
+	go func() { a.UpdateFeeStatsState(ctx); wg.Done() }()
+	go func() { err = a.UpdateStellarCoreInfo(ctx); wg.Done() }()
+	wg.Wait()
+	if err != nil {
 		return err
 	}
-	if ctx.Err() != nil {
-		// Failure to launch
-		return ctx.Err()
-	}
 
-	a.submitter.Tick(ctx)
+	wg.Add(1)
+	go func() { a.submitter.Tick(ctx); wg.Done() }()
+	wg.Wait()
 
 	log.Debug("finished ticking app")
 	return ctx.Err()

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -73,11 +73,10 @@ func applyMigrations(config Config) error {
 func checkMigrations(config Config) error {
 	migrationsToApplyUp := schema.GetMigrationsUp(config.DatabaseURL)
 	if len(migrationsToApplyUp) > 0 {
-		return fmt.Errorf(`
-		There are %v migrations to apply in the "up" direction.
-		The necessary migrations are: %v
-		A database migration is required to run this version (%v) of Horizon. Run "horizon db migrate up" to update your DB. Consult the Changelog (https://github.com/stellar/go/blob/master/services/horizon/CHANGELOG.md) for more information.
-			`,
+		return fmt.Errorf(
+			`There are %v migrations to apply in the "up" direction.
+The necessary migrations are: %v
+A database migration is required to run this version (%v) of Horizon. Run "horizon db migrate up" to update your DB. Consult the Changelog (https://github.com/stellar/go/blob/master/services/horizon/CHANGELOG.md) for more information.`,
 			len(migrationsToApplyUp),
 			migrationsToApplyUp,
 			apkg.Version(),
@@ -86,10 +85,9 @@ func checkMigrations(config Config) error {
 
 	nMigrationsDown := schema.GetNumMigrationsDown(config.DatabaseURL)
 	if nMigrationsDown > 0 {
-		return fmt.Errorf(`
-		A database migration DOWN to an earlier version of the schema is required to run this version (%v) of Horizon. Consult the Changelog (https://github.com/stellar/go/blob/master/services/horizon/CHANGELOG.md) for more information.
-		In order to migrate the database DOWN, using the HIGHEST version number of Horizon you have installed (not this binary), run "horizon db migrate down %v".
-			`,
+		return fmt.Errorf(
+			`A database migration DOWN to an earlier version of the schema is required to run this version (%v) of Horizon. Consult the Changelog (https://github.com/stellar/go/blob/master/services/horizon/CHANGELOG.md) for more information.
+In order to migrate the database DOWN, using the HIGHEST version number of Horizon you have installed (not this binary), run "horizon db migrate down %v".`,
 			apkg.Version(),
 			nMigrationsDown,
 		)

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -486,7 +486,10 @@ func Flags() (*Config, support.ConfigOptions) {
 
 // NewAppFromFlags constructs a new Horizon App from the given command line flags
 func NewAppFromFlags(config *Config, flags support.ConfigOptions) (*App, error) {
-	ApplyFlags(config, flags, ApplyOptions{RequireCaptiveCoreConfig: true, AlwaysIngest: false})
+	err := ApplyFlags(config, flags, ApplyOptions{RequireCaptiveCoreConfig: true, AlwaysIngest: false})
+	if err != nil {
+		return nil, err
+	}
 	// Validate app-specific arguments
 	if config.StellarCoreURL == "" {
 		return nil, fmt.Errorf("flag --%s cannot be empty", StellarCoreURLFlagName)
@@ -512,7 +515,9 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 	if err := flags.RequireE(); err != nil {
 		return err
 	}
-	flags.SetValues()
+	if err := flags.SetValues(); err != nil {
+		return err
+	}
 
 	// Validate options that should be provided together
 	if err := validateBothOrNeither("tls-cert", "tls-key"); err != nil {

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -41,48 +41,60 @@ const (
 )
 
 // validateBothOrNeither ensures that both options are provided, if either is provided.
-func validateBothOrNeither(option1, option2 string) {
+func validateBothOrNeither(option1, option2 string) error {
 	arg1, arg2 := viper.GetString(option1), viper.GetString(option2)
 	if arg1 != "" && arg2 == "" {
-		stdLog.Fatalf("Invalid config: %s = %s, but corresponding option %s is not configured", option1, arg1, option2)
+		return fmt.Errorf("Invalid config: %s = %s, but corresponding option %s is not configured", option1, arg1, option2)
 	}
 	if arg1 == "" && arg2 != "" {
-		stdLog.Fatalf("Invalid config: %s = %s, but corresponding option %s is not configured", option2, arg2, option1)
+		return fmt.Errorf("Invalid config: %s = %s, but corresponding option %s is not configured", option2, arg2, option1)
 	}
+	return nil
 }
 
-func applyMigrations(config Config) {
+func applyMigrations(config Config) error {
 	dbConn, err := db.Open("postgres", config.DatabaseURL)
 	if err != nil {
-		stdLog.Fatalf("could not connect to horizon db: %v", err)
+		return fmt.Errorf("could not connect to horizon db: %v", err)
 	}
 	defer dbConn.Close()
 
 	numMigrations, err := schema.Migrate(dbConn.DB.DB, schema.MigrateUp, 0)
 	if err != nil {
-		stdLog.Fatalf("could not apply migrations: %v", err)
+		return fmt.Errorf("could not apply migrations: %v", err)
 	}
 	if numMigrations > 0 {
 		stdLog.Printf("successfully applied %v horizon migrations\n", numMigrations)
 	}
+	return nil
 }
 
 // checkMigrations looks for necessary database migrations and fails with a descriptive error if migrations are needed.
-func checkMigrations(config Config) {
+func checkMigrations(config Config) error {
 	migrationsToApplyUp := schema.GetMigrationsUp(config.DatabaseURL)
 	if len(migrationsToApplyUp) > 0 {
-		stdLog.Printf(`There are %v migrations to apply in the "up" direction.`, len(migrationsToApplyUp))
-		stdLog.Printf("The necessary migrations are: %v", migrationsToApplyUp)
-		stdLog.Printf("A database migration is required to run this version (%v) of Horizon. Run \"horizon db migrate up\" to update your DB. Consult the Changelog (https://github.com/stellar/go/blob/master/services/horizon/CHANGELOG.md) for more information.", apkg.Version())
-		os.Exit(1)
+		return fmt.Errorf(`
+		There are %v migrations to apply in the "up" direction.
+		The necessary migrations are: %v
+		A database migration is required to run this version (%v) of Horizon. Run "horizon db migrate up" to update your DB. Consult the Changelog (https://github.com/stellar/go/blob/master/services/horizon/CHANGELOG.md) for more information.
+			`,
+			len(migrationsToApplyUp),
+			migrationsToApplyUp,
+			apkg.Version(),
+		)
 	}
 
 	nMigrationsDown := schema.GetNumMigrationsDown(config.DatabaseURL)
 	if nMigrationsDown > 0 {
-		stdLog.Printf("A database migration DOWN to an earlier version of the schema is required to run this version (%v) of Horizon. Consult the Changelog (https://github.com/stellar/go/blob/master/services/horizon/CHANGELOG.md) for more information.", apkg.Version())
-		stdLog.Printf("In order to migrate the database DOWN, using the HIGHEST version number of Horizon you have installed (not this binary), run \"horizon db migrate down %v\".", nMigrationsDown)
-		os.Exit(1)
+		return fmt.Errorf(`
+		A database migration DOWN to an earlier version of the schema is required to run this version (%v) of Horizon. Consult the Changelog (https://github.com/stellar/go/blob/master/services/horizon/CHANGELOG.md) for more information.
+		In order to migrate the database DOWN, using the HIGHEST version number of Horizon you have installed (not this binary), run "horizon db migrate down %v".
+			`,
+			apkg.Version(),
+			nMigrationsDown,
+		)
 	}
+	return nil
 }
 
 // Flags returns a Config instance and a list of commandline flags which modify the Config instance
@@ -129,7 +141,7 @@ func Flags() (*Config, support.ConfigOptions) {
 			FlagDefault: "",
 			Required:    false,
 			Usage:       "DEPRECATED in favor of " + CaptiveCoreConfigPathName,
-			CustomSetValue: func(opt *support.ConfigOption) {
+			CustomSetValue: func(opt *support.ConfigOption) error {
 				if val := viper.GetString(opt.Name); val != "" {
 					if viper.GetString(CaptiveCoreConfigPathName) != "" {
 						stdLog.Printf(
@@ -143,6 +155,7 @@ func Flags() (*Config, support.ConfigOptions) {
 						config.CaptiveCoreConfigPath = val
 					}
 				}
+				return nil
 			},
 		},
 		&support.ConfigOption{
@@ -151,11 +164,12 @@ func Flags() (*Config, support.ConfigOptions) {
 			FlagDefault: "",
 			Required:    false,
 			Usage:       "path to the configuration file used by captive core. It must, at least, include enough details to define a quorum set. Any fields in the configuration file which are not supported by captive core will be rejected.",
-			CustomSetValue: func(opt *support.ConfigOption) {
+			CustomSetValue: func(opt *support.ConfigOption) error {
 				if val := viper.GetString(opt.Name); val != "" {
 					config.CaptiveCoreConfigPath = val
 					config.CaptiveCoreTomlParams.Strict = true
 				}
+				return nil
 			},
 		},
 		&support.ConfigOption{
@@ -178,16 +192,17 @@ func Flags() (*Config, support.ConfigOptions) {
 		&support.ConfigOption{
 			Name:    "captive-core-storage-path",
 			OptType: types.String,
-			CustomSetValue: func(opt *support.ConfigOption) {
+			CustomSetValue: func(opt *support.ConfigOption) error {
 				existingValue := viper.GetString(opt.Name)
 				if existingValue == "" || existingValue == "." {
 					cwd, err := os.Getwd()
 					if err != nil {
-						stdLog.Fatalf("Unable to determine the current directory: %s", err)
+						return fmt.Errorf("Unable to determine the current directory: %s", err)
 					}
 					existingValue = cwd
 				}
 				*opt.ConfigKey.(*string) = existingValue
+				return nil
 			},
 			Required:  false,
 			Usage:     "Storage location for Captive Core bucket data",
@@ -230,11 +245,11 @@ func Flags() (*Config, support.ConfigOptions) {
 			OptType:     types.String,
 			Required:    false,
 			FlagDefault: "",
-			CustomSetValue: func(co *support.ConfigOption) {
+			CustomSetValue: func(co *support.ConfigOption) error {
 				stringOfUrls := viper.GetString(co.Name)
 				urlStrings := strings.Split(stringOfUrls, ",")
-
 				*(co.ConfigKey.(*[]string)) = urlStrings
+				return nil
 			},
 			Usage: "comma-separated list of stellar history archives to connect with",
 		},
@@ -294,7 +309,7 @@ func Flags() (*Config, support.ConfigOptions) {
 			ConfigKey:   &config.RateQuota,
 			OptType:     types.Int,
 			FlagDefault: 3600,
-			CustomSetValue: func(co *support.ConfigOption) {
+			CustomSetValue: func(co *support.ConfigOption) error {
 				var rateLimit *throttled.RateQuota = nil
 				perHourRateLimit := viper.GetInt(co.Name)
 				if perHourRateLimit != 0 {
@@ -304,6 +319,7 @@ func Flags() (*Config, support.ConfigOptions) {
 					}
 					*(co.ConfigKey.(**throttled.RateQuota)) = rateLimit
 				}
+				return nil
 			},
 			Usage: "max count of requests allowed in a one hour period, by remote ip address",
 		},
@@ -319,12 +335,13 @@ func Flags() (*Config, support.ConfigOptions) {
 			ConfigKey:   &config.LogLevel,
 			OptType:     types.String,
 			FlagDefault: "info",
-			CustomSetValue: func(co *support.ConfigOption) {
+			CustomSetValue: func(co *support.ConfigOption) error {
 				ll, err := logrus.ParseLevel(viper.GetString(co.Name))
 				if err != nil {
-					stdLog.Fatalf("Could not parse log-level: %v", viper.GetString(co.Name))
+					return fmt.Errorf("Could not parse log-level: %v", viper.GetString(co.Name))
 				}
 				*(co.ConfigKey.(*logrus.Level)) = ll
+				return nil
 			},
 			Usage: "minimum log severity (debug, info, warn, error) to log",
 		},
@@ -468,20 +485,20 @@ func Flags() (*Config, support.ConfigOptions) {
 }
 
 // NewAppFromFlags constructs a new Horizon App from the given command line flags
-func NewAppFromFlags(config *Config, flags support.ConfigOptions) *App {
+func NewAppFromFlags(config *Config, flags support.ConfigOptions) (*App, error) {
 	ApplyFlags(config, flags, ApplyOptions{RequireCaptiveCoreConfig: true, AlwaysIngest: false})
 	// Validate app-specific arguments
 	if config.StellarCoreURL == "" {
-		log.Fatalf("flag --%s cannot be empty", StellarCoreURLFlagName)
+		return nil, fmt.Errorf("flag --%s cannot be empty", StellarCoreURLFlagName)
 	}
 	if config.Ingest && !config.EnableCaptiveCoreIngestion && config.StellarCoreDatabaseURL == "" {
-		log.Fatalf("flag --%s cannot be empty", StellarCoreDBURLFlagName)
+		return nil, fmt.Errorf("flag --%s cannot be empty", StellarCoreDBURLFlagName)
 	}
 	app, err := NewApp(*config)
 	if err != nil {
-		log.Fatalf("cannot initialize app: %s", err)
+		return nil, fmt.Errorf("cannot initialize app: %s", err)
 	}
-	return app
+	return app, nil
 }
 
 type ApplyOptions struct {
@@ -490,13 +507,17 @@ type ApplyOptions struct {
 }
 
 // ApplyFlags applies the command line flags on the given Config instance
-func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOptions) {
+func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOptions) error {
 	// Verify required options and load the config struct
-	flags.Require()
+	if err := flags.RequireE(); err != nil {
+		return err
+	}
 	flags.SetValues()
 
 	// Validate options that should be provided together
-	validateBothOrNeither("tls-cert", "tls-key")
+	if err := validateBothOrNeither("tls-cert", "tls-key"); err != nil {
+		return err
+	}
 
 	if options.AlwaysIngest {
 		config.Ingest = true
@@ -507,14 +528,18 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 		// only on ingesting instances which are required to have write-access
 		// to the DB.
 		if config.ApplyMigrations {
-			applyMigrations(*config)
+			if err := applyMigrations(*config); err != nil {
+				return err
+			}
 		}
-		checkMigrations(*config)
+		if err := checkMigrations(*config); err != nil {
+			return err
+		}
 
 		// config.HistoryArchiveURLs contains a single empty value when empty so using
 		// viper.GetString is easier.
 		if len(config.HistoryArchiveURLs) == 0 {
-			stdLog.Fatalf("--history-archive-urls must be set when --ingest is set")
+			return fmt.Errorf("--history-archive-urls must be set when --ingest is set")
 		}
 
 		if config.EnableCaptiveCoreIngestion {
@@ -534,14 +559,14 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 			//       defaults for the binary path), the Remote Captive Core URL
 			//       takes precedence.
 			if binaryPath == "" && config.RemoteCaptiveCoreURL == "" {
-				stdLog.Fatalf("Invalid config: captive core requires that either --%s or --remote-captive-core-url is set. %s",
+				return fmt.Errorf("Invalid config: captive core requires that either --%s or --remote-captive-core-url is set. %s",
 					StellarCoreBinaryPathName, captiveCoreMigrationHint)
 			}
 
 			if config.RemoteCaptiveCoreURL == "" && (binaryPath == "" || config.CaptiveCoreConfigPath == "") {
 				if options.RequireCaptiveCoreConfig {
 					var err error
-					errorMessage := fmt.Sprintf(
+					errorMessage := fmt.Errorf(
 						"Invalid config: captive core requires that both --%s and --%s are set. %s",
 						StellarCoreBinaryPathName, CaptiveCoreConfigPathName, captiveCoreMigrationHint,
 					)
@@ -557,23 +582,23 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 						config.HistoryArchiveURLs = []string{"https://history.stellar.org/prd/core-live/core_live_001/"}
 						config.UsingDefaultPubnetConfig = true
 					default:
-						stdLog.Fatal(errorMessage)
+						return errorMessage
 					}
 
 					executablePath, err := os.Executable()
 					if err != nil {
-						stdLog.Fatal(errorMessage)
+						return errorMessage
 					}
 
 					config.CaptiveCoreConfigPath = filepath.Join(filepath.Dir(executablePath), configFileName)
 					if _, err = os.Stat(config.CaptiveCoreConfigPath); os.IsNotExist(err) {
-						stdLog.Fatal(errorMessage)
+						return errorMessage
 					}
 
 					config.CaptiveCoreTomlParams.NetworkPassphrase = config.NetworkPassphrase
 					config.CaptiveCoreToml, err = ledgerbackend.NewCaptiveCoreTomlFromFile(config.CaptiveCoreConfigPath, config.CaptiveCoreTomlParams)
 					if err != nil {
-						stdLog.Fatalf("Invalid captive core toml file %v", err)
+						return fmt.Errorf("Invalid captive core toml file %v", err)
 					}
 				} else {
 					var err error
@@ -581,7 +606,7 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 					config.CaptiveCoreTomlParams.NetworkPassphrase = config.NetworkPassphrase
 					config.CaptiveCoreToml, err = ledgerbackend.NewCaptiveCoreToml(config.CaptiveCoreTomlParams)
 					if err != nil {
-						stdLog.Fatalf("Invalid captive core toml file %v", err)
+						return fmt.Errorf("Invalid captive core toml file %v", err)
 					}
 				}
 			} else if config.RemoteCaptiveCoreURL == "" {
@@ -590,7 +615,7 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 				config.CaptiveCoreTomlParams.NetworkPassphrase = config.NetworkPassphrase
 				config.CaptiveCoreToml, err = ledgerbackend.NewCaptiveCoreTomlFromFile(config.CaptiveCoreConfigPath, config.CaptiveCoreTomlParams)
 				if err != nil {
-					stdLog.Fatalf("Invalid captive core toml file %v", err)
+					return fmt.Errorf("Invalid captive core toml file %v", err)
 				}
 			}
 
@@ -607,11 +632,11 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 			if viper.GetString(CaptiveCoreConfigPathName) != "" {
 				captiveCoreConfigFlag = CaptiveCoreConfigPathName
 			}
-			stdLog.Fatalf("Invalid config: one or more captive core params passed (--%s or --%s) but --ingest not set. "+captiveCoreMigrationHint,
+			return fmt.Errorf("Invalid config: one or more captive core params passed (--%s or --%s) but --ingest not set. "+captiveCoreMigrationHint,
 				StellarCoreBinaryPathName, captiveCoreConfigFlag)
 		}
 		if config.StellarCoreDatabaseURL != "" {
-			stdLog.Fatalf("Invalid config: --%s passed but --ingest not set. ", StellarCoreDBURLFlagName)
+			return fmt.Errorf("Invalid config: --%s passed but --ingest not set. ", StellarCoreDBURLFlagName)
 		}
 	}
 
@@ -621,7 +646,7 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 		if err == nil {
 			log.DefaultLogger.Logger.Out = logFile
 		} else {
-			stdLog.Fatalf("Failed to open file to log: %s", err)
+			return fmt.Errorf("Failed to open file to log: %s", err)
 		}
 	}
 
@@ -636,6 +661,8 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 	}
 
 	if config.BehindCloudflare && config.BehindAWSLoadBalancer {
-		stdLog.Fatal("Invalid config: Only one option of --behind-cloudflare and --behind-aws-load-balancer is allowed. If Horizon is behind both, use --behind-cloudflare only.")
+		return fmt.Errorf("Invalid config: Only one option of --behind-cloudflare and --behind-aws-load-balancer is allowed. If Horizon is behind both, use --behind-cloudflare only.")
 	}
+
+	return nil
 }

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -268,10 +268,14 @@ func (i *Test) StartHorizon() error {
 		Use:   "horizon",
 		Short: "Client-facing API server for the Stellar network",
 		Long:  "Client-facing API server for the Stellar network.",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			var err error
 			i.app, err = horizon.NewAppFromFlags(config, configOpts)
-			return err
+			if err != nil {
+				// Explicitly exit here as that's how these tests are structured for now.
+				fmt.Println(err)
+				os.Exit(1)
+			}
 		},
 	}
 

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -268,8 +268,10 @@ func (i *Test) StartHorizon() error {
 		Use:   "horizon",
 		Short: "Client-facing API server for the Stellar network",
 		Long:  "Client-facing API server for the Stellar network.",
-		Run: func(cmd *cobra.Command, args []string) {
-			i.app = horizon.NewAppFromFlags(config, configOpts)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			i.app, err = horizon.NewAppFromFlags(config, configOpts)
+			return err
 		},
 	}
 

--- a/services/horizon/main.go
+++ b/services/horizon/main.go
@@ -1,7 +1,18 @@
 package main
 
-import "github.com/stellar/go/services/horizon/cmd"
+import (
+	"fmt"
+	"os"
+
+	"github.com/stellar/go/services/horizon/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	err := cmd.Execute()
+	if e, ok := err.(cmd.ErrExitCode); ok {
+		os.Exit(int(e))
+	} else if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve.go
@@ -186,7 +186,7 @@ func (h txApproveHandler) txApprove(ctx context.Context, in txApproveRequest) (r
 		return nil, errors.Wrapf(err, "parsing account sequence number %q from string to int64", acc.Sequence)
 	}
 	if tx.SourceAccount().Sequence != accountSequence+1 {
-		log.Ctx(ctx).Errorf(`invalid transaction sequence number tx.SourceAccount().Sequence: %d, accountSequence+1:%d`, tx.SourceAccount().Sequence, accountSequence+1)
+		log.Ctx(ctx).Errorf(`invalid transaction sequence number tx.SourceAccount().Sequence: %d, accountSequence+1: %d`, tx.SourceAccount().Sequence, accountSequence+1)
 		return NewRejectedTxApprovalResponse("Invalid transaction sequence number."), nil
 	}
 

--- a/support/config/config_option.go
+++ b/support/config/config_option.go
@@ -38,24 +38,37 @@ func (cos ConfigOptions) Require() {
 	}
 }
 
-// SetValues calls SetValue on each ConfigOption.
-func (cos ConfigOptions) SetValues() {
+// RequireE is like Require, but returns the error instead of Fatal
+func (cos ConfigOptions) RequireE() error {
 	for _, co := range cos {
-		co.SetValue()
+		if err := co.RequireE(); err != nil {
+			return err
+		}
 	}
+	return nil
+}
+
+// SetValues calls SetValue on each ConfigOption.
+func (cos ConfigOptions) SetValues() error {
+	for _, co := range cos {
+		if err := co.SetValue(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ConfigOption is a complete description of the configuration of a command line option
 type ConfigOption struct {
-	Name           string              // e.g. "db-url"
-	EnvVar         string              // e.g. "DATABASE_URL". Defaults to uppercase/underscore representation of name
-	OptType        types.BasicKind     // The type of this option, e.g. types.Bool
-	FlagDefault    interface{}         // A default if no option is provided. Omit or set to `nil` if no default
-	Required       bool                // Whether this option must be set for Horizon to run
-	Usage          string              // Help text
-	CustomSetValue func(*ConfigOption) // Optional function for custom validation/transformation
-	ConfigKey      interface{}         // Pointer to the final key in the linked Config struct
-	flag           *pflag.Flag         // The persistent flag that the config option is attached to
+	Name           string                    // e.g. "db-url"
+	EnvVar         string                    // e.g. "DATABASE_URL". Defaults to uppercase/underscore representation of name
+	OptType        types.BasicKind           // The type of this option, e.g. types.Bool
+	FlagDefault    interface{}               // A default if no option is provided. Omit or set to `nil` if no default
+	Required       bool                      // Whether this option must be set for Horizon to run
+	Usage          string                    // Help text
+	CustomSetValue func(*ConfigOption) error // Optional function for custom validation/transformation
+	ConfigKey      interface{}               // Pointer to the final key in the linked Config struct
+	flag           *pflag.Flag               // The persistent flag that the config option is attached to
 }
 
 // Init handles initialisation steps, including configuring and binding the env variable name.
@@ -77,23 +90,34 @@ func (co *ConfigOption) Bind() {
 
 // Require checks that a required string configuration option is not empty, raising a user error if it is.
 func (co *ConfigOption) Require() {
-	co.Bind()
-	if co.Required && viper.GetString(co.Name) == "" {
-		stdLog.Fatalf("Invalid config: %s is blank. Please specify --%s on the command line or set the %s environment variable.", co.Name, co.Name, co.EnvVar)
+	if err := co.RequireE(); err != nil {
+		stdLog.Fatal(err.Error())
 	}
 }
 
+// RequireE is like Require, but returns the error instead of Fatal
+func (co *ConfigOption) RequireE() error {
+	co.Bind()
+	if co.Required && viper.GetString(co.Name) == "" {
+		return fmt.Errorf("Invalid config: %s is blank. Please specify --%s on the command line or set the %s environment variable.", co.Name, co.Name, co.EnvVar)
+	}
+	return nil
+}
+
 // SetValue sets a value in the global config, using a custom function, if one was provided.
-func (co *ConfigOption) SetValue() {
+func (co *ConfigOption) SetValue() error {
 	co.Bind()
 
 	// Use a custom setting function, if one is provided
 	if co.CustomSetValue != nil {
-		co.CustomSetValue(co)
+		if err := co.CustomSetValue(co); err != nil {
+			return err
+		}
 		// Otherwise, just set the provided arg directly
 	} else if co.ConfigKey != nil {
 		co.setSimpleValue()
 	}
+	return nil
 }
 
 // UsageText returns the string to use for the usage text of the option. The
@@ -148,25 +172,27 @@ func (co *ConfigOption) setFlag(cmd *cobra.Command) error {
 }
 
 // SetDuration converts a command line int to a duration, and stores it in the final config.
-func SetDuration(co *ConfigOption) {
+func SetDuration(co *ConfigOption) error {
 	*(co.ConfigKey.(*time.Duration)) = time.Duration(viper.GetInt(co.Name)) * time.Second
+	return nil
 }
 
 // SetURL converts a command line string to a URL, and stores it in the final config.
-func SetURL(co *ConfigOption) {
+func SetURL(co *ConfigOption) error {
 	urlString := viper.GetString(co.Name)
 	if urlString != "" {
 		urlType, err := url.Parse(urlString)
 		if err != nil {
-			stdLog.Fatalf("Unable to parse URL: %s/%v", urlString, err)
+			return fmt.Errorf("Unable to parse URL: %s/%v", urlString, err)
 		}
 		*(co.ConfigKey.(**url.URL)) = urlType
 	}
+	return nil
 }
 
 // SetOptionalUint converts a command line uint to a *uint where the nil
 // value indicates the flag was not explicitly set
-func SetOptionalUint(co *ConfigOption) {
+func SetOptionalUint(co *ConfigOption) error {
 	key := co.ConfigKey.(**uint)
 	if isExplicitlySet(co) {
 		*key = new(uint)
@@ -174,6 +200,7 @@ func SetOptionalUint(co *ConfigOption) {
 	} else {
 		*key = nil
 	}
+	return nil
 }
 
 func parseEnvVars(entries []string) map[string]bool {
@@ -195,7 +222,7 @@ func isExplicitlySet(co *ConfigOption) bool {
 
 // SetOptionalString converts a command line uint to a *string where the nil
 // value indicates the flag was not explicitly set
-func SetOptionalString(co *ConfigOption) {
+func SetOptionalString(co *ConfigOption) error {
 	key := co.ConfigKey.(**string)
 	if isExplicitlySet(co) {
 		*key = new(string)
@@ -203,4 +230,5 @@ func SetOptionalString(co *ConfigOption) {
 	} else {
 		*key = nil
 	}
+	return nil
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove `log.Fatal` and `os.Exit` calls from Horizon.
- `log.Fatal` and `os.Exit` should only be called in `func main()`, and `func init()`.
- Everything else which could fail returns an `error`, which propagates up to `func main()`

### Why

As discussed in https://github.com/stellar/go/pull/3741#discussion_r668142648, using `log.Fatal` and `os.Exit` make integration testing Horizon harder. They force you to launch it as a subprocess and faff around with managing that. Removing these *should* make it simpler.

Reducing friction for CLI-type tests would have helped catch https://github.com/stellar/go/pull/3762 type bugs sooner/easier.

### Known limitations

`[WIP]` at this point, as I want to get people's opinions, and if there are any gotchas to watch out for here before spending more time on this. If we're happy with the approach we should merge https://github.com/stellar/go/pull/3741 as-is, then use this to simplify it, and add a few more cli tests.

The one big outstanding thing here re: testing are the places we use `os.Getenv`. But.. One thing at a time.
