### PR TITLE
services/horizon: Update Docker Compose flow to work with latest stable Stellar-Core

### DIFF
--- a/services/horizon/docker/core-start.sh
+++ b/services/horizon/docker/core-start.sh
@@ -12,6 +12,9 @@ cat stellar-core.cfg
 stellar-core new-db
 
 if [ "$1" = "standalone" ]; then
+  # start a network from scratch
+  FLAGS="--wait-for-consensus"
+
   # initialize history archive for standalone network
   stellar-core new-hist vs
 
@@ -21,5 +24,4 @@ if [ "$1" = "standalone" ]; then
   popd
 fi
 
-# start a network from scratch
-exec stellar-core run --wait-for-consensus
+exec stellar-core run $FLAGS

--- a/services/horizon/docker/core-start.sh
+++ b/services/horizon/docker/core-start.sh
@@ -12,9 +12,6 @@ cat stellar-core.cfg
 stellar-core new-db
 
 if [ "$1" = "standalone" ]; then
-  # start a network from scratch
-  stellar-core force-scp
-
   # initialize history archive for standalone network
   stellar-core new-hist vs
 
@@ -24,4 +21,5 @@ if [ "$1" = "standalone" ]; then
   popd
 fi
 
-exec stellar-core run
+# start a network from scratch
+exec stellar-core run --wait-for-consensus

--- a/services/horizon/docker/docker-compose.standalone.yml
+++ b/services/horizon/docker/docker-compose.standalone.yml
@@ -16,7 +16,7 @@ services:
   core:
     # to use a specific version of stellar core
     # image: stellar/stellar-core:$VERSION
-    image: stellar/stellar-core
+    image: stellar/stellar-core:v17.1.0
     depends_on:
       - core-postgres
       - core-upgrade
@@ -40,11 +40,11 @@ services:
     volumes:
       - ./captive-core-standalone.cfg:/captive-core-standalone.cfg
 
-  # this container will invoke a request to upgrade stellar core to protocol 15 (by default)
+  # this container will invoke a request to upgrade stellar core to protocol 17 (by default)
   core-upgrade:
     restart: on-failure
     image: curlimages/curl:7.69.1
-    command: ["-v", "-f", "http://host.docker.internal:11626/upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z&protocolversion=${PROTOCOL_VERSION:-15}"]
+    command: ["-v", "-f", "http://host.docker.internal:11626/upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z&protocolversion=${PROTOCOL_VERSION:-17}"]
     network_mode: '${NETWORK_MODE:-bridge}'
 
 volumes:


### PR DESCRIPTION
### What
Updates the Docker-Compose YAML files to be compatible with the latest version of Stellar-Core.

### Why
Running Core+Horizon via the compose workflow will cause issues:
 - the core container will fail because `force scp` is deprecated
 - the upgrade container will use P15 which is outdated
 - [stellar/stellar-core:latest](https://hub.docker.com/layers/stellar/stellar-core/latest/images/sha256-d6b97102fe154afca3fb8e8e5d2f5976bc8c8a878f2d83905cbb577c3a75a96f?context=explore) defines an ENTRYPOINT which is incompatible with the compose `command`

### Known limitations
#3764 still applies.