### PR TITLE
services/horizon/docker: Remove NETWORK_MODE=host configuration for linux users

### DIFF
--- a/services/horizon/docker/README.md
+++ b/services/horizon/docker/README.md
@@ -20,21 +20,6 @@ The script takes one optional parameter which configures the Stellar network use
 
 `./start.sh standalone` will run the containers on a private standalone Stellar network.
 
-## Set up a .env file
-
-Mac OS X and Windows users should create an [`.env`](https://docs.docker.com/compose/environment-variables/#the-env_file-configuration-option) file which consists of:
-
-`NETWORK_MODE=bridge`
-
-Linux users should also create an `.env` file. However, the contents of the file should look like:
-
-`NETWORK_MODE=host`
-
-Additionally, you will need to add `127.0.0.1 host.docker.internal` to the `/etc/hosts` file on your linux machine.
-
-If https://github.com/docker/for-linux/issues/264 is ever fixed then it won't be necessary to alias `host.docker.internal` to localhost and there won't be any differences between the Linux and Mac OS X / Windows configurations.
-
-
 ## Run docker-compose
 
 Run the following command to start all the Stellar docker containers:

--- a/services/horizon/docker/docker-compose.standalone.yml
+++ b/services/horizon/docker/docker-compose.standalone.yml
@@ -11,7 +11,6 @@ services:
     command: ["-p", "5641"]
     volumes:
       - "core-db-data:/var/lib/postgresql/data"
-    network_mode: '${NETWORK_MODE:-bridge}'
 
   core:
     # to use a specific version of stellar core
@@ -30,7 +29,8 @@ services:
     volumes:
       - ./stellar-core-standalone.cfg:/stellar-core.cfg
       - ./core-start.sh:/start
-    network_mode: '${NETWORK_MODE:-bridge}'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   horizon:
     environment:
@@ -45,7 +45,8 @@ services:
     restart: on-failure
     image: curlimages/curl:7.69.1
     command: ["-v", "-f", "http://host.docker.internal:11626/upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z&protocolversion=${PROTOCOL_VERSION:-15}"]
-    network_mode: '${NETWORK_MODE:-bridge}'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
 volumes:
   core-db-data:

--- a/services/horizon/docker/docker-compose.yml
+++ b/services/horizon/docker/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - "5432:5432"
     volumes:
       - "horizon-db-data:/var/lib/postgresql/data"
-    network_mode: '${NETWORK_MODE:-bridge}'
 
   horizon:
     depends_on:
@@ -32,8 +31,9 @@ services:
       - PER_HOUR_RATE_LIMIT=0
     volumes:
       - ./captive-core-testnet.cfg:/captive-core-testnet.cfg
-    network_mode: '${NETWORK_MODE:-bridge}'
     command: ["--apply-migrations"]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
 volumes:
   horizon-db-data:

--- a/services/horizon/docker/start.sh
+++ b/services/horizon/docker/start.sh
@@ -25,19 +25,4 @@ case $NETWORK in
     ;;
 esac
 
-
-case $OSTYPE in
-linux-*)
-    if ! grep -E "^127.0.0.1 .*host\.docker\.internal.*$" /etc/hosts > /dev/null 2>&1; then
-        echo "Missing: \`127.0.0.1 host.docker.internal\` in /etc/hosts"
-        exit 1
-    fi
-
-    echo "NETWORK_MODE=host" > .env
-    ;;
-*)
-    echo "NETWORK_MODE=bridge" > .env
-    ;;
-esac
-
 docker-compose $DOCKER_FLAGS up --build -d


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes https://github.com/stellar/go/issues/3764

Docker for linux recently implemented a fix which allows a container to access the host machine by setting the `extra_hosts` property https://stackoverflow.com/questions/31324981/how-to-access-host-port-from-docker-container/61424570#61424570

With that fix we can get rid of the `network_mode=host` configuration
