### PR TITLE
services/horizon: Fix standalone mode under Docker Compose flow.

### DIFF
--- a/services/horizon/docker/core-start.sh
+++ b/services/horizon/docker/core-start.sh
@@ -12,6 +12,9 @@ cat stellar-core.cfg
 stellar-core new-db
 
 if [ "$1" = "standalone" ]; then
+  # start a network from scratch
+  FLAGS="--wait-for-consensus"
+
   # initialize history archive for standalone network
   stellar-core new-hist vs
 
@@ -21,5 +24,4 @@ if [ "$1" = "standalone" ]; then
   popd
 fi
 
-# start a network from scratch
-exec stellar-core run --wait-for-consensus
+exec stellar-core run $FLAGS

--- a/services/horizon/docker/core-start.sh
+++ b/services/horizon/docker/core-start.sh
@@ -12,9 +12,6 @@ cat stellar-core.cfg
 stellar-core new-db
 
 if [ "$1" = "standalone" ]; then
-  # start a network from scratch
-  stellar-core force-scp
-
   # initialize history archive for standalone network
   stellar-core new-hist vs
 
@@ -24,4 +21,5 @@ if [ "$1" = "standalone" ]; then
   popd
 fi
 
-exec stellar-core run
+# start a network from scratch
+exec stellar-core run --wait-for-consensus

--- a/services/horizon/docker/core-start.sh
+++ b/services/horizon/docker/core-start.sh
@@ -12,9 +12,6 @@ cat stellar-core.cfg
 stellar-core new-db
 
 if [ "$1" = "standalone" ]; then
-  # start a network from scratch
-  FLAGS="--wait-for-consensus"
-
   # initialize history archive for standalone network
   stellar-core new-hist vs
 
@@ -24,4 +21,4 @@ if [ "$1" = "standalone" ]; then
   popd
 fi
 
-exec stellar-core run $FLAGS
+exec stellar-core run

--- a/services/horizon/docker/docker-compose.standalone.yml
+++ b/services/horizon/docker/docker-compose.standalone.yml
@@ -15,7 +15,7 @@ services:
   core:
     # to use a specific version of stellar core
     # image: stellar/stellar-core:$VERSION
-    image: stellar/stellar-core
+    image: stellar/stellar-core:v17.1.0
     depends_on:
       - core-postgres
       - core-upgrade
@@ -40,11 +40,11 @@ services:
     volumes:
       - ./captive-core-standalone.cfg:/captive-core-standalone.cfg
 
-  # this container will invoke a request to upgrade stellar core to protocol 15 (by default)
+  # this container will invoke a request to upgrade stellar core to protocol 17 (by default)
   core-upgrade:
     restart: on-failure
     image: curlimages/curl:7.69.1
-    command: ["-v", "-f", "http://host.docker.internal:11626/upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z&protocolversion=${PROTOCOL_VERSION:-15}"]
+    command: ["-v", "-f", "http://host.docker.internal:11626/upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z&protocolversion=${PROTOCOL_VERSION:-17}"]
     extra_hosts:
       - "host.docker.internal:host-gateway"
 

--- a/services/horizon/docker/docker-compose.standalone.yml
+++ b/services/horizon/docker/docker-compose.standalone.yml
@@ -13,9 +13,7 @@ services:
       - "core-db-data:/var/lib/postgresql/data"
 
   core:
-    # to use a specific version of stellar core
-    # image: stellar/stellar-core:$VERSION
-    image: stellar/stellar-core:v17.1.0
+    image: ${CORE_IMAGE:-stellar/stellar-core:v17.1.0}
     depends_on:
       - core-postgres
       - core-upgrade

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -125,9 +125,9 @@ func NewTest(t *testing.T, config Config) *Test {
 
 	// Only run Stellar Core container and its dependencies.
 	i.runComposeCommand("up", "--detach", "--quiet-pull", "--no-color", "core")
+	i.prepareShutdownHandlers()
 	i.coreClient = &stellarcore.Client{URL: "http://localhost:" + strconv.Itoa(stellarCorePort)}
 	i.waitForCore()
-	i.prepareShutdownHandlers()
 
 	if !config.SkipHorizonStart {
 		if innerErr := i.StartHorizon(); innerErr != nil {
@@ -200,13 +200,13 @@ func (i *Test) runComposeCommand(args ...string) {
 
 func (i *Test) prepareShutdownHandlers() {
 	i.shutdownCalls = append(i.shutdownCalls,
-		i.environment.Restore,
 		func() {
 			if i.app != nil {
 				i.app.Close()
 			}
 			i.runComposeCommand("down", "-v", "--remove-orphans")
 		},
+		i.environment.Restore,
 	)
 
 	// Register cleanup handlers (on panic and ctrl+c) so the containers are


### PR DESCRIPTION
This is a recreation of #3769:

### What
Updates the Docker-Compose YAML files to be compatible with the latest version of Stellar-Core.

### Why
Running Core+Horizon via the compose workflow will cause issues:
 - the core container will fail because `force scp` is deprecated
 - the upgrade container will use P15 which is outdated
 - [stellar/stellar-core:latest](https://hub.docker.com/layers/stellar/stellar-core/latest/images/sha256-d6b97102fe154afca3fb8e8e5d2f5976bc8c8a878f2d83905cbb577c3a75a96f?context=explore) defines an ENTRYPOINT which is incompatible with the compose `command`