### PR TITLE
keypair: add Equal func to KP, Full, FromAddress

### DIFF
--- a/keypair/from_address.go
+++ b/keypair/from_address.go
@@ -55,6 +55,19 @@ func (kp *FromAddress) SignDecorated(input []byte) (xdr.DecoratedSignature, erro
 	return xdr.DecoratedSignature{}, ErrCannotSign
 }
 
+func (kp *FromAddress) Equal(o KP) bool {
+	if a, ok := o.(*FromAddress); ok {
+		if kp == nil && a == nil {
+			return true
+		}
+		if kp == nil || a == nil {
+			return false
+		}
+		return kp.address == a.address
+	}
+	return false
+}
+
 func (kp *FromAddress) publicKey() ed25519.PublicKey {
 	return ed25519.PublicKey(strkey.MustDecode(strkey.VersionByteAccountID, kp.address))
 }

--- a/keypair/from_address_test.go
+++ b/keypair/from_address_test.go
@@ -1,11 +1,52 @@
 package keypair
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestFromAddress_Equal(t *testing.T) {
+	// A nil FromAddress.
+	var kp0 *FromAddress
+
+	// A FromAddress with a value.
+	kp1 := MustParseAddress("GAYUB4KATGTUZEGUMJEOZDPPWM4MQLHCIKC4T55YSXHN234WI6BJMIY2")
+
+	// A FromAddress and its corresponding Full.
+	kp2 := MustParseAddress("GD5II5W6KQTJPES32LL6VJK6PLOHMEKYUXJPLERXUKR3MCLM3TNFSIPW")
+	kp3 := MustParseFull("SBPBTSQAIEA5HLWLVWA4TJ7RBKHCEERE2W2DZLB6AUUCEUIYWLJF2EUS")
+
+	// A nil KP interface is not a From Address, so should not be equal to a
+	// From Address, even a nil From Address.
+	assert.False(t, kp0.Equal(nil))
+
+	// A nil FromAddress should be equal to a nil FromAddress.
+	assert.True(t, kp0.Equal((*FromAddress)(nil)))
+
+	// A non-nil FromAddress is not equal to a nil KP with no type.
+	assert.False(t, kp1.Equal(nil))
+
+	// A non-nil FromAddress is not equal to a nil FromAddress.
+	assert.False(t, kp1.Equal((*FromAddress)(nil)))
+
+	// A non-nil FromAddress is equal to itself.
+	assert.True(t, kp1.Equal(kp1))
+
+	// A non-nil FromAddress is equal to another FromAddress containing the same address.
+	assert.True(t, kp1.Equal(MustParseAddress(kp1.address)))
+
+	// A non-nil FromAddress is not equal a non-nil FromAddress of different value.
+	assert.False(t, kp1.Equal(kp2))
+	assert.False(t, kp2.Equal(kp1))
+
+	// A non-nil FromAddress should not equal its corresponding Full.
+	assert.False(t, kp2.Equal(kp3))
+}
 
 var _ = Describe("keypair.FromAddress", func() {
 	var subject KP
@@ -21,14 +62,12 @@ var _ = Describe("keypair.FromAddress", func() {
 			_, err := subject.Sign(message)
 			Expect(err).To(HaveOccurred())
 		})
-
 	})
 	Describe("SignBase64()", func() {
 		It("fails", func() {
 			_, err := subject.SignBase64(message)
 			Expect(err).To(HaveOccurred())
 		})
-
 	})
 	Describe("SignDecorated()", func() {
 		It("fails", func() {
@@ -107,5 +146,4 @@ var _ = Describe("keypair.FromAddress", func() {
 			}),
 		)
 	})
-
 })

--- a/keypair/from_address_test.go
+++ b/keypair/from_address_test.go
@@ -62,12 +62,14 @@ var _ = Describe("keypair.FromAddress", func() {
 			_, err := subject.Sign(message)
 			Expect(err).To(HaveOccurred())
 		})
+
 	})
 	Describe("SignBase64()", func() {
 		It("fails", func() {
 			_, err := subject.SignBase64(message)
 			Expect(err).To(HaveOccurred())
 		})
+
 	})
 	Describe("SignDecorated()", func() {
 		It("fails", func() {
@@ -146,4 +148,5 @@ var _ = Describe("keypair.FromAddress", func() {
 			}),
 		)
 	})
+
 })

--- a/keypair/full.go
+++ b/keypair/full.go
@@ -69,6 +69,19 @@ func (kp *Full) SignDecorated(input []byte) (xdr.DecoratedSignature, error) {
 	}, nil
 }
 
+func (kp *Full) Equal(o KP) bool {
+	if f, ok := o.(*Full); ok {
+		if kp == nil && f == nil {
+			return true
+		}
+		if kp == nil || f == nil {
+			return false
+		}
+		return kp.seed == f.seed
+	}
+	return false
+}
+
 func (kp *Full) publicKey() ed25519.PublicKey {
 	pub, _ := kp.keys()
 	return pub

--- a/keypair/full_test.go
+++ b/keypair/full_test.go
@@ -2,11 +2,51 @@ package keypair
 
 import (
 	"encoding/hex"
+	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestFull_Equal(t *testing.T) {
+	// A nil Full.
+	var kp0 *Full
+
+	// A Full with a value.
+	kp1 := MustParseFull("SBFGFF27Y64ZUGFAIG5AMJGQODZZKV2YQKAVUUN4HNE24XZXD2OEUVUP")
+
+	// A Full and its corresponding Full.
+	kp2 := MustParseFull("SBPBTSQAIEA5HLWLVWA4TJ7RBKHCEERE2W2DZLB6AUUCEUIYWLJF2EUS")
+	kp3 := MustParseAddress("GD5II5W6KQTJPES32LL6VJK6PLOHMEKYUXJPLERXUKR3MCLM3TNFSIPW")
+
+	// A nil KP interface is not a From Address, so should not be equal to a
+	// From Address, even a nil From Address.
+	assert.False(t, kp0.Equal(nil))
+
+	// A nil Full should be equal to a nil Full.
+	assert.True(t, kp0.Equal((*Full)(nil)))
+
+	// A non-nil Full is not equal to a nil KP with no type.
+	assert.False(t, kp1.Equal(nil))
+
+	// A non-nil Full is not equal to a nil Full.
+	assert.False(t, kp1.Equal((*Full)(nil)))
+
+	// A non-nil Full is equal to itself.
+	assert.True(t, kp1.Equal(kp1))
+
+	// A non-nil Full is equal to another Full containing the same address.
+	assert.True(t, kp1.Equal(MustParseFull(kp1.seed)))
+
+	// A non-nil Full is not equal a non-nil Full of different value.
+	assert.False(t, kp1.Equal(kp2))
+	assert.False(t, kp2.Equal(kp1))
+
+	// A non-nil Full should not equal its corresponding FromAddress.
+	assert.False(t, kp2.Equal(kp3))
+}
 
 var _ = Describe("keypair.Full", func() {
 	var subject KP
@@ -67,5 +107,4 @@ var _ = Describe("keypair.Full", func() {
 			Expect(sig.Signature).To(BeEquivalentTo(signature))
 		})
 	})
-
 })

--- a/keypair/full_test.go
+++ b/keypair/full_test.go
@@ -107,4 +107,5 @@ var _ = Describe("keypair.Full", func() {
 			Expect(sig.Signature).To(BeEquivalentTo(signature))
 		})
 	})
+
 })

--- a/keypair/main.go
+++ b/keypair/main.go
@@ -40,6 +40,7 @@ type KP interface {
 	Sign(input []byte) ([]byte, error)
 	SignBase64(input []byte) (string, error)
 	SignDecorated(input []byte) (xdr.DecoratedSignature, error)
+	Equal(kp KP) bool
 }
 
 // Random creates a random full keypair


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add an `Equal` function to `KP`, `Full`, `FromAddress`.

### Why

Keypairs are often passed around as pointers because that's how the package creates the types. This makes it inconvenient to do equality checks. Callers knowing the internals are comparable can do `*kp1 == *kp2` or `kp1.Address() == kp2.Address()`, but if either is `nil` this causes nil dereference panics. This is annoyingly more complicated to write in every case.

This also makes keypairs comparable with popular comparison modules like the [google/go-cmp] package.

[google/go-cmp]: https://github.com/google/go-cmp

### Known limitations

N/A
