### PR TITLE
services/horizon: Move reap service outside global tick

### DIFF
--- a/services/horizon/internal/reap/system.go
+++ b/services/horizon/internal/reap/system.go
@@ -38,15 +38,21 @@ func (r *System) DeleteUnretainedHistory(ctx context.Context) error {
 	return nil
 }
 
-// Tick triggers the reaper system to update itself, deleted unretained history
+// Run triggers the reaper system to update itself, deleted unretained history
 // if it is the appropriate time.
-func (r *System) Tick(ctx context.Context) {
-	if time.Now().Before(r.nextRun) {
-		return
+func (r *System) Run() {
+	for {
+		select {
+		case <-time.After(1 * time.Hour):
+			r.runOnce(r.ctx)
+		case <-r.ctx.Done():
+			return
+		}
 	}
+}
 
-	r.runOnce(ctx)
-	r.nextRun = time.Now().Add(1 * time.Hour)
+func (r *System) Shutdown() {
+	r.cancel()
 }
 
 func (r *System) runOnce(ctx context.Context) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit moves ledger reaping service outside global `Tick()` method.

Close #3711. Close #3728. Part of #613.

### Why

After https://github.com/stellar/go/pull/3567 reap process was cancelled after 1s. However in some deployments removing older ledgers take more time. To prevent the process from being cancelled in `Tick` it was moved outside of this method to a separate service.

### Known limitations

N/A.
