### PR TITLE
txnbuild: remove error from return values of AddSignatureDecorated

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -6,6 +6,8 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Removed error return value from AddDecoratedSignature. (#3779)
+
 ## [v7.1.1](https://github.com/stellar/go/releases/tag/horizonclient-v7.1.1) - 2021-06-25
 
 ### Bug Fixes

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -6,7 +6,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-* Removed error return value from AddDecoratedSignature. ([#3779](https://github.com/stellar/go/pull/3779))
+* Removed error return value from AddSignatureDecorated. ([#3779](https://github.com/stellar/go/pull/3779))
 
 ## [v7.1.1](https://github.com/stellar/go/releases/tag/horizonclient-v7.1.1) - 2021-06-25
 

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -6,7 +6,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-* Removed error return value from AddDecoratedSignature. (#3779)
+* Removed error return value from AddDecoratedSignature. ([#3779](https://github.com/stellar/go/pull/3779))
 
 ## [v7.1.1](https://github.com/stellar/go/releases/tag/horizonclient-v7.1.1) - 2021-06-25
 

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -76,11 +76,11 @@ func concatSignatures(
 	return extended, nil
 }
 
-func concatSignatureDecorated(e xdr.TransactionEnvelope, signatures []xdr.DecoratedSignature, newSignatures []xdr.DecoratedSignature) ([]xdr.DecoratedSignature, error) {
+func concatSignatureDecorated(e xdr.TransactionEnvelope, signatures []xdr.DecoratedSignature, newSignatures []xdr.DecoratedSignature) []xdr.DecoratedSignature {
 	extended := make([]xdr.DecoratedSignature, len(signatures)+len(newSignatures))
 	copy(extended, signatures)
 	copy(extended[len(signatures):], newSignatures)
-	return extended, nil
+	return extended
 }
 
 func concatSignatureBase64(e xdr.TransactionEnvelope, signatures []xdr.DecoratedSignature, networkStr, publicKey, signature string) ([]xdr.DecoratedSignature, error) {
@@ -314,13 +314,9 @@ func (t *Transaction) SignHashX(preimage []byte) (*Transaction, error) {
 
 // AddSignatureDecorated returns a new Transaction instance which extends the current instance
 // with an additional decorated signature(s).
-func (t *Transaction) AddSignatureDecorated(signature ...xdr.DecoratedSignature) (*Transaction, error) {
-	extendedSignatures, err := concatSignatureDecorated(t.envelope, t.Signatures(), signature)
-	if err != nil {
-		return nil, err
-	}
-
-	return t.clone(extendedSignatures), nil
+func (t *Transaction) AddSignatureDecorated(signature ...xdr.DecoratedSignature) *Transaction {
+	extendedSignatures := concatSignatureDecorated(t.envelope, t.Signatures(), signature)
+	return t.clone(extendedSignatures)
 }
 
 // AddSignatureBase64 returns a new Transaction instance which extends the current instance

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1615,7 +1615,7 @@ func TestAddSignatureDecorated(t *testing.T) {
 	// Same if signatures added separately.
 	{
 		var tx1sigs1 *Transaction
-		tx1sigs1, err = tx1.AddSignatureDecorated(
+		tx1sigs1 = tx1.AddSignatureDecorated(
 			xdr.DecoratedSignature{
 				Hint: kp0.Hint(),
 				Signature: func() xdr.Signature {
@@ -1628,8 +1628,7 @@ func TestAddSignatureDecorated(t *testing.T) {
 				}(),
 			},
 		)
-		assert.NoError(t, err)
-		tx1sigs1, err = tx1sigs1.AddSignatureDecorated(
+		tx1sigs1 = tx1sigs1.AddSignatureDecorated(
 			xdr.DecoratedSignature{
 				Hint: kp1.Hint(),
 				Signature: func() xdr.Signature {
@@ -1642,7 +1641,6 @@ func TestAddSignatureDecorated(t *testing.T) {
 				}(),
 			},
 		)
-		assert.NoError(t, err)
 		var actual string
 		actual, err = tx1sigs1.Base64()
 		assert.NoError(t, err)
@@ -1652,7 +1650,7 @@ func TestAddSignatureDecorated(t *testing.T) {
 	// Same if signatures added together.
 	{
 		var tx1sigs2 *Transaction
-		tx1sigs2, err = tx1.AddSignatureDecorated(
+		tx1sigs2 = tx1.AddSignatureDecorated(
 			xdr.DecoratedSignature{
 				Hint: kp0.Hint(),
 				Signature: func() xdr.Signature {
@@ -1676,7 +1674,6 @@ func TestAddSignatureDecorated(t *testing.T) {
 				}(),
 			},
 		)
-		assert.NoError(t, err)
 		var actual string
 		actual, err = tx1sigs2.Base64()
 		assert.NoError(t, err)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove the error from the return values of Transaction.AddSignatureDecorated.

### Why

The error value isn't used, the function never returns an error. Using the SDK becomes extra and unnecessarily verbose if callers must handle errors that will never occur.

### Known limitations

N/A

### Merging

This PR is currently targeting master, but this is a breaking change and should target the next major version of txnbuild, whenever that is planned.