### PR TITLE
keypair: remove interface comparisons

### DIFF
--- a/keypair/from_address.go
+++ b/keypair/from_address.go
@@ -55,25 +55,24 @@ func (kp *FromAddress) SignDecorated(input []byte) (xdr.DecoratedSignature, erro
 	return xdr.DecoratedSignature{}, ErrCannotSign
 }
 
-func (kp *FromAddress) Equal(o KP) bool {
-	if a, ok := o.(*FromAddress); ok {
-		if kp == nil && a == nil {
-			return true
-		}
-		if kp == nil || a == nil {
-			return false
-		}
-		return kp.address == a.address
+func (kp *FromAddress) Equal(a *FromAddress) bool {
+	if kp == nil && a == nil {
+		return true
 	}
-	return false
+	if kp == nil || a == nil {
+		return false
+	}
+	return kp.address == a.address
 }
 
 func (kp *FromAddress) publicKey() ed25519.PublicKey {
 	return ed25519.PublicKey(strkey.MustDecode(strkey.VersionByteAccountID, kp.address))
 }
 
-var _ = encoding.TextMarshaler(&FromAddress{})
-var _ = encoding.TextUnmarshaler(&FromAddress{})
+var (
+	_ = encoding.TextMarshaler(&FromAddress{})
+	_ = encoding.TextUnmarshaler(&FromAddress{})
+)
 
 func (kp *FromAddress) UnmarshalText(text []byte) error {
 	textKP, err := ParseAddress(string(text))

--- a/keypair/from_address_test.go
+++ b/keypair/from_address_test.go
@@ -17,22 +17,17 @@ func TestFromAddress_Equal(t *testing.T) {
 	// A FromAddress with a value.
 	kp1 := MustParseAddress("GAYUB4KATGTUZEGUMJEOZDPPWM4MQLHCIKC4T55YSXHN234WI6BJMIY2")
 
-	// A FromAddress and its corresponding Full.
+	// Another FromAddress with a value.
 	kp2 := MustParseAddress("GD5II5W6KQTJPES32LL6VJK6PLOHMEKYUXJPLERXUKR3MCLM3TNFSIPW")
-	kp3 := MustParseFull("SBPBTSQAIEA5HLWLVWA4TJ7RBKHCEERE2W2DZLB6AUUCEUIYWLJF2EUS")
-
-	// A nil KP interface is not a From Address, so should not be equal to a
-	// From Address, even a nil From Address.
-	assert.False(t, kp0.Equal(nil))
 
 	// A nil FromAddress should be equal to a nil FromAddress.
-	assert.True(t, kp0.Equal((*FromAddress)(nil)))
+	assert.True(t, kp0.Equal(nil))
 
 	// A non-nil FromAddress is not equal to a nil KP with no type.
 	assert.False(t, kp1.Equal(nil))
 
 	// A non-nil FromAddress is not equal to a nil FromAddress.
-	assert.False(t, kp1.Equal((*FromAddress)(nil)))
+	assert.False(t, kp1.Equal(nil))
 
 	// A non-nil FromAddress is equal to itself.
 	assert.True(t, kp1.Equal(kp1))
@@ -43,9 +38,6 @@ func TestFromAddress_Equal(t *testing.T) {
 	// A non-nil FromAddress is not equal a non-nil FromAddress of different value.
 	assert.False(t, kp1.Equal(kp2))
 	assert.False(t, kp2.Equal(kp1))
-
-	// A non-nil FromAddress should not equal its corresponding Full.
-	assert.False(t, kp2.Equal(kp3))
 }
 
 var _ = Describe("keypair.FromAddress", func() {

--- a/keypair/full.go
+++ b/keypair/full.go
@@ -69,17 +69,14 @@ func (kp *Full) SignDecorated(input []byte) (xdr.DecoratedSignature, error) {
 	}, nil
 }
 
-func (kp *Full) Equal(o KP) bool {
-	if f, ok := o.(*Full); ok {
-		if kp == nil && f == nil {
-			return true
-		}
-		if kp == nil || f == nil {
-			return false
-		}
-		return kp.seed == f.seed
+func (kp *Full) Equal(f *Full) bool {
+	if kp == nil && f == nil {
+		return true
 	}
-	return false
+	if kp == nil || f == nil {
+		return false
+	}
+	return kp.seed == f.seed
 }
 
 func (kp *Full) publicKey() ed25519.PublicKey {

--- a/keypair/full_test.go
+++ b/keypair/full_test.go
@@ -17,22 +17,17 @@ func TestFull_Equal(t *testing.T) {
 	// A Full with a value.
 	kp1 := MustParseFull("SBFGFF27Y64ZUGFAIG5AMJGQODZZKV2YQKAVUUN4HNE24XZXD2OEUVUP")
 
-	// A Full and its corresponding Full.
+	// Another Full with a value.
 	kp2 := MustParseFull("SBPBTSQAIEA5HLWLVWA4TJ7RBKHCEERE2W2DZLB6AUUCEUIYWLJF2EUS")
-	kp3 := MustParseAddress("GD5II5W6KQTJPES32LL6VJK6PLOHMEKYUXJPLERXUKR3MCLM3TNFSIPW")
-
-	// A nil KP interface is not a From Address, so should not be equal to a
-	// From Address, even a nil From Address.
-	assert.False(t, kp0.Equal(nil))
 
 	// A nil Full should be equal to a nil Full.
-	assert.True(t, kp0.Equal((*Full)(nil)))
+	assert.True(t, kp0.Equal(nil))
 
 	// A non-nil Full is not equal to a nil KP with no type.
 	assert.False(t, kp1.Equal(nil))
 
 	// A non-nil Full is not equal to a nil Full.
-	assert.False(t, kp1.Equal((*Full)(nil)))
+	assert.False(t, kp1.Equal(nil))
 
 	// A non-nil Full is equal to itself.
 	assert.True(t, kp1.Equal(kp1))
@@ -43,9 +38,6 @@ func TestFull_Equal(t *testing.T) {
 	// A non-nil Full is not equal a non-nil Full of different value.
 	assert.False(t, kp1.Equal(kp2))
 	assert.False(t, kp2.Equal(kp1))
-
-	// A non-nil Full should not equal its corresponding FromAddress.
-	assert.False(t, kp2.Equal(kp3))
 }
 
 var _ = Describe("keypair.Full", func() {

--- a/keypair/main.go
+++ b/keypair/main.go
@@ -40,7 +40,6 @@ type KP interface {
 	Sign(input []byte) ([]byte, error)
 	SignBase64(input []byte) (string, error)
 	SignDecorated(input []byte) (xdr.DecoratedSignature, error)
-	Equal(kp KP) bool
 }
 
 // Random creates a random full keypair


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Limit the keypair types to be comparable to themselves, so that a FromAddress is only comparable to a FromAddress and a Full is only comparable to a Full.

### Why

The functions don't actually provide this functionality even though they accept a `KP` interface type. In the case different types are passed in they return false, so it isn't useful that they accept the interface. The fact they accept the interface makes their use error prone. It's really easy to pass in a Full thinking it's a FromAddress, and it will compile but never return true. I ran into this problem myself and it took me a while to debug in a small sized application. Given that it never returns true we should just never support passing in the other types.

There could be some value in retaining that all `KP`s have an Equal that works with any `KP`, but I think the value delivered with that is small compared to the foot gun problem described above.

### Known limitations

This is a breaking change but it is a breaking change to functionality that only exists on master and is unreleased, so no compatibility promise implicit or explicit exists.
