### PR TITLE
all: add ci job to close stale issues and prs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: 'Stale Issues'
+
+on:
+  schedule:
+    - cron: '0 18 * * *' # approx 9:30am daily
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          debug-only: false
+          days-before-stale: 30
+          days-before-close: 30
+          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 30 days unless the stale label is removed.'
+          stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. It will be closed in 30 days unless the stale label is removed.'
+          stale-issue-label: stale
+          stale-pr-label: stale
+          remove-stale-when-updated: true


### PR DESCRIPTION
### What

Add a CI job to comment on stale issues and pull requests after 30 days of inactivity and close them 30 days after that, so 60 days total.

### Why

There are a lot of stale issues. We've had success with using this same pattern to clean up the stellar-protocol repo.

I've noticed that @2opremio routinely checks in on long lived pull requests to see if they should be closed. We don't have a huge amount of open pull requests so there isn't as big of an issue with them as we have with issues, but checking in on long lived pull requests is something a bot can do rather than it being on a human on the team.


### Known limitations

In the stellar-protocol repo we had some labels that clearly signaled an issue shouldn't be closed, and so we configured the stale checker to ignore those issues. In this repo there is no clear label that signals that issue should stay around, so there are no issues/prs exempt from the check.
