### PR TITLE
services/horizon: Remove level=warn logs for known errors

### DIFF
--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -73,8 +73,7 @@ const (
 	// LogNoErrors indicates that the Problem instance should not log any errors
 	LogNoErrors = LogFilter(iota)
 	// LogUnknownErrors indicates that the Problem instance should only log errors
-	// which are not registered with level=error but will also log known errors with
-	// level=warn.
+	// which are not registered
 	LogUnknownErrors = LogFilter(iota)
 	// LogAllErrors indicates that the Problem instance should log all errors
 	LogAllErrors = LogFilter(iota)
@@ -188,8 +187,6 @@ func (ps *Problem) Render(ctx context.Context, w http.ResponseWriter, err error)
 				ps.reportFn(ctx, err)
 			}
 			problem = ServerError
-		} else if ps.filter == LogUnknownErrors {
-			ps.log.Ctx(ctx).WithStack(err).Warn(err)
 		}
 	}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit remove some logging changes introduced in https://github.com/stellar/go/pull/3730.

### Why

I was hoping to still be able to see `bad connection` errors in the logs but with `warn` level however that are many other known errors which are propagated down to `render` package causing extensive `warn` logging.
