### PR TITLE
services/horizon/internal/: Fix logged message when horizon cannot open a db connection

### DIFF
--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -21,7 +21,7 @@ import (
 func mustNewDBSession(subservice db.Subservice, databaseURL string, maxIdle, maxOpen int, registry *prometheus.Registry) db.SessionInterface {
 	session, err := db.Open("postgres", databaseURL)
 	if err != nil {
-		log.Fatalf("cannot open Horizon DB: %v", err)
+		log.Fatalf("cannot open %v DB: %v", subservice, err)
 	}
 
 	session.DB.SetMaxIdleConns(maxIdle)


### PR DESCRIPTION
Horizon logs a "cannot open Horizon DB" message when it fails to establish a database connection.
The problem is that this message is also logged when failing to open a connection to the Stellar Core DB.
This commit fixes the error message by specifying which database incurred the failure.