### PR TITLE
services/horizon/internal: Warn about change for ingest flag

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,7 +6,9 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 ## v2.7.0
 **Upgrading to this version from <= v2.1.1 will trigger a state rebuild. During this process (which will take at least 10 minutes), Horizon will not ingest new ledgers.**
 
-* The `--ingest` flag is set by default. If `--captive-core-config-path` is not set, the config file is generated based on network passhprase. ([3783](https://github.com/stellar/go/pull/3783))
+**In the 2.9.0 Horizon release, the `--ingest` flag will be set to `true` by default.**
+
+* If `--captive-core-config-path` is not set, the config file is generated based on network passhprase. ([3783](https://github.com/stellar/go/pull/3783))
 * Fix bug in horizon reap system (used by `horizon db reap` command and when horizon is configured with `--history-retention-count`) which could lead to partial deletions. ([3754](https://github.com/stellar/go/pull/3754))
 * Log debug messages from captive core at the appropriate log level. ([3746](https://github.com/stellar/go/pull/3746))
 * Add a feature flag `--captive-core-reuse-storage-path`/`CAPTIVE_CORE_REUSE_STORAGE_PATH` that will reuse Captive Core's storage path for bucket files when applicable for better performance. ([3750](https://github.com/stellar/go/pull/3750))

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -388,11 +388,19 @@ func Flags() (*Config, support.ConfigOptions) {
 			Usage:     "TLS private key file to use for securing connections to horizon",
 		},
 		&support.ConfigOption{
-			Name:        "ingest",
-			ConfigKey:   &config.Ingest,
-			OptType:     types.Bool,
-			FlagDefault: true,
-			Usage:       "causes this horizon process to ingest data from stellar-core into horizon's db",
+			Name:      "ingest",
+			ConfigKey: &config.Ingest,
+			OptType:   types.Bool,
+			// Action needed in release: horizon-v2.9.0: make --ingest default true
+			FlagDefault: false,
+			CustomSetValue: func(opt *support.ConfigOption) {
+				if support.IsExplicitlySet(opt) {
+					*opt.ConfigKey.(*bool) = viper.GetBool(opt.Name)
+				} else {
+					stdLog.Println("WARNING: in the 2.9.0 Horizon release the --ingest flag will default to true. Update your configuration so that --ingest is explicitly set to false.")
+				}
+			},
+			Usage: "causes this horizon process to ingest data from stellar-core into horizon's db",
 		},
 		&support.ConfigOption{
 			Name:        "cursor-name",

--- a/support/config/config_option.go
+++ b/support/config/config_option.go
@@ -168,7 +168,7 @@ func SetURL(co *ConfigOption) {
 // value indicates the flag was not explicitly set
 func SetOptionalUint(co *ConfigOption) {
 	key := co.ConfigKey.(**uint)
-	if isExplicitlySet(co) {
+	if IsExplicitlySet(co) {
 		*key = new(uint)
 		**key = uint(viper.GetInt(co.Name))
 	} else {
@@ -187,7 +187,9 @@ func parseEnvVars(entries []string) map[string]bool {
 
 var envVars = parseEnvVars(os.Environ())
 
-func isExplicitlySet(co *ConfigOption) bool {
+// IsExplicitlySet returns true if and only if the given config option was set explicitly either
+// via a command line argument or via an environment variable
+func IsExplicitlySet(co *ConfigOption) bool {
 	// co.flag.Changed is only set to true when the configuration is set via command line parameter.
 	// In the case where a variable is configured via environment variable we need to check envVars.
 	return co.flag.Changed || envVars[co.EnvVar]
@@ -197,7 +199,7 @@ func isExplicitlySet(co *ConfigOption) bool {
 // value indicates the flag was not explicitly set
 func SetOptionalString(co *ConfigOption) {
 	key := co.ConfigKey.(**string)
-	if isExplicitlySet(co) {
+	if IsExplicitlySet(co) {
 		*key = new(string)
 		**key = viper.GetString(co.Name)
 	} else {


### PR DESCRIPTION
@jacekn has advised that we warn about the new default for `--ingest` and give some time for horizon maintainers to update their configurations.

Depends on https://github.com/stellar/go/pull/3794