### PR TITLE
Update missing CAP 38 XDR definitions

### DIFF
--- a/xdr/Stellar-ledger-entries.x
+++ b/xdr/Stellar-ledger-entries.x
@@ -391,13 +391,16 @@ case CLAIMANT_TYPE_V0:
 
 enum ClaimableBalanceIDType
 {
-    CLAIMABLE_BALANCE_ID_TYPE_V0 = 0
+    CLAIMABLE_BALANCE_ID_TYPE_V0 = 0,
+    CLAIMABLE_BALANCE_ID_TYPE_FROM_POOL_REVOKE = 1
 };
 
 union ClaimableBalanceID switch (ClaimableBalanceIDType type)
 {
 case CLAIMABLE_BALANCE_ID_TYPE_V0:
     Hash v0;
+case CLAIMABLE_BALANCE_ID_TYPE_FROM_POOL_REVOKE:
+    Hash fromPoolRevoke;
 };
 
 enum ClaimableBalanceFlags
@@ -570,6 +573,7 @@ enum EnvelopeType
     ENVELOPE_TYPE_AUTH = 3,
     ENVELOPE_TYPE_SCPVALUE = 4,
     ENVELOPE_TYPE_TX_FEE_BUMP = 5,
-    ENVELOPE_TYPE_OP_ID = 6
+    ENVELOPE_TYPE_OP_ID = 6,
+    ENVELOPE_TYPE_POOL_REVOKE_OP_ID = 7
 };
 }

--- a/xdr/Stellar-ledger.x
+++ b/xdr/Stellar-ledger.x
@@ -33,7 +33,7 @@ struct StellarValue
     // this is a vector of encoded 'LedgerUpgrade' so that nodes can drop
     // unknown steps during consensus if needed.
     // see notes below on 'LedgerUpgrade' for more detail
-    // max size is dictated by number of upgrade types (+ room for future)
+    // max size is dictated by number of upgrade types ( room for future)
     UpgradeType upgrades<6>;
 
     // reserved for future use
@@ -46,6 +46,29 @@ struct StellarValue
     }
     ext;
 };
+
+const MASK_LEDGERHEADER_FLAGS = 0x7;
+
+enum LedgerHeaderFlags
+{ // masks for each flag
+
+    DISABLE_LIQUIDITY_POOL_TRADING_FLAG = 0x1,
+    DISABLE_LIQUIDITY_POOL_DEPOSIT_FLAG = 0x2,
+    DISABLE_LIQUIDITY_POOL_WITHDRAWAL_FLAG = 0x4
+};
+
+struct LedgerHeaderExtensionV1
+{
+    uint32 flags; // UpgradeFlags
+
+    union switch (int v)
+    {
+    case 0:
+        void;
+    }
+    ext;
+};
+
 
 /* The LedgerHeader is the highest level structure representing the
  * state of a ledger, cryptographically linked to previous ledgers.
@@ -84,6 +107,8 @@ struct LedgerHeader
     {
     case 0:
         void;
+    case 1:
+        LedgerHeaderExtensionV1 v1;
     }
     ext;
 };
@@ -98,7 +123,8 @@ enum LedgerUpgradeType
     LEDGER_UPGRADE_VERSION = 1,
     LEDGER_UPGRADE_BASE_FEE = 2,
     LEDGER_UPGRADE_MAX_TX_SET_SIZE = 3,
-    LEDGER_UPGRADE_BASE_RESERVE = 4
+    LEDGER_UPGRADE_BASE_RESERVE = 4,
+    LEDGER_UPGRADE_FLAGS = 5
 };
 
 union LedgerUpgrade switch (LedgerUpgradeType type)
@@ -111,6 +137,8 @@ case LEDGER_UPGRADE_MAX_TX_SET_SIZE:
     uint32 newMaxTxSetSize; // update maxTxSetSize
 case LEDGER_UPGRADE_BASE_RESERVE:
     uint32 newBaseReserve; // update baseReserve
+case LEDGER_UPGRADE_FLAGS:
+    uint32 newFlags; // update flags
 };
 
 /* Entries used to define the bucket list */

--- a/xdr/Stellar-transaction.x
+++ b/xdr/Stellar-transaction.x
@@ -56,7 +56,8 @@ enum OperationType
     CLAWBACK = 19,
     CLAWBACK_CLAIMABLE_BALANCE = 20,
     SET_TRUST_LINE_FLAGS = 21,
-    LIQUIDITY_POOL_DEPOSIT = 22
+    LIQUIDITY_POOL_DEPOSIT = 22,
+    LIQUIDITY_POOL_WITHDRAW = 23
 };
 
 /* CreateAccount
@@ -450,6 +451,20 @@ struct LiquidityPoolDepositOp
     Price maxPrice;       // maximum depositA/depositB
 };
 
+/* Withdraw assets from a liquidity pool
+
+    Threshold: med
+
+    Result: LiquidityPoolWithdrawResult
+*/
+struct LiquidityPoolWithdrawOp
+{
+    PoolID liquidityPoolID;
+    int64 amount;         // amount of pool shares to withdraw
+    int64 minAmountA;     // minimum amount of first asset to withdraw
+    int64 minAmountB;     // minimum amount of second asset to withdraw
+};
+
 /* An operation is the lowest unit of work that a transaction does */
 struct Operation
 {
@@ -506,6 +521,8 @@ struct Operation
         SetTrustLineFlagsOp setTrustLineFlagsOp;
     case LIQUIDITY_POOL_DEPOSIT:
         LiquidityPoolDepositOp liquidityPoolDepositOp;
+    case LIQUIDITY_POOL_WITHDRAW:
+        LiquidityPoolWithdrawOp liquidityPoolWithdrawOp;
     }
     body;
 };
@@ -519,6 +536,15 @@ case ENVELOPE_TYPE_OP_ID:
         SequenceNumber seqNum;
         uint32 opNum;
     } id;
+case ENVELOPE_TYPE_POOL_REVOKE_OP_ID:
+    struct
+    {
+        AccountID sourceAccount;
+        SequenceNumber seqNum;
+        uint32 opNum;
+        PoolID liquidityPoolID;
+        Asset asset;
+    } revokeId;
 };
 
 enum MemoType
@@ -681,7 +707,8 @@ struct TransactionSignaturePayload
 enum ClaimAtomType
 {
     CLAIM_ATOM_TYPE_V0 = 0,
-    CLAIM_ATOM_TYPE_ORDER_BOOK = 1
+    CLAIM_ATOM_TYPE_ORDER_BOOK = 1,
+    CLAIM_ATOM_TYPE_LIQUIDITY_POOL = 2
 };
 
 // ClaimOfferAtomV0 is a ClaimOfferAtom with the AccountID discriminant stripped
@@ -719,6 +746,19 @@ struct ClaimOfferAtom
     int64 amountBought;
 };
 
+struct ClaimLiquidityAtom
+{
+    PoolID liquidityPoolID;
+
+    // amount and asset taken from the pool
+    Asset assetSold;
+    int64 amountSold;
+
+    // amount and asset sent to the pool
+    Asset assetBought;
+    int64 amountBought;
+};
+
 /* This result is used when offers are taken or liquidity is exchanged with a
    liquidity pool during an operation
 */
@@ -728,6 +768,8 @@ case CLAIM_ATOM_TYPE_V0:
     ClaimOfferAtomV0 v0;
 case CLAIM_ATOM_TYPE_ORDER_BOOK:
     ClaimOfferAtom orderBook;
+case CLAIM_ATOM_TYPE_LIQUIDITY_POOL:
+    ClaimLiquidityAtom liquidityPool;
 };
 
 /******* CreateAccount Result ********/
@@ -1038,7 +1080,9 @@ enum AllowTrustResultCode
                                     // source account does not require trust
     ALLOW_TRUST_TRUST_NOT_REQUIRED = -3,
     ALLOW_TRUST_CANT_REVOKE = -4,     // source account can't revoke trust,
-    ALLOW_TRUST_SELF_NOT_ALLOWED = -5 // trusting self is not allowed
+    ALLOW_TRUST_SELF_NOT_ALLOWED = -5, // trusting self is not allowed
+    ALLOW_TRUST_LOW_RESERVE = -6 // claimable balances can't be created
+                                 // on revoke due to low reserves 
 };
 
 union AllowTrustResult switch (AllowTrustResultCode code)
@@ -1301,7 +1345,9 @@ enum SetTrustLineFlagsResultCode
     SET_TRUST_LINE_FLAGS_MALFORMED = -1,
     SET_TRUST_LINE_FLAGS_NO_TRUST_LINE = -2,
     SET_TRUST_LINE_FLAGS_CANT_REVOKE = -3,
-    SET_TRUST_LINE_FLAGS_INVALID_STATE = -4
+    SET_TRUST_LINE_FLAGS_INVALID_STATE = -4,
+    SET_TRUST_LINE_FLAGS_LOW_RESERVE = -5 // claimable balances can't be created
+                                          // on revoke due to low reserves
 };
 
 union SetTrustLineFlagsResult switch (SetTrustLineFlagsResultCode code)
@@ -1341,6 +1387,34 @@ case LIQUIDITY_POOL_DEPOSIT_SUCCESS:
 default:
     void;
 };
+
+/******* LiquidityPoolWithdraw Result ********/
+
+enum LiquidityPoolWithdrawResultCode
+{
+    // codes considered as "success" for the operation
+    LIQUIDITY_POOL_WITHDRAW_SUCCESS = 0,
+
+    // codes considered as "failure" for the operation
+    LIQUIDITY_POOL_WITHDRAW_MALFORMED = -1,      // bad input
+    LIQUIDITY_POOL_WITHDRAW_NO_TRUST = -2,       // no trust line for one of the
+                                                 // assets
+    LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED = -3,    // not enough balance of the
+                                                 // pool share
+    LIQUIDITY_POOL_WITHDRAW_LINE_FULL = -4,      // would go above limit for one
+                                                 // of the assets
+    LIQUIDITY_POOL_WITHDRAW_UNDER_MINIMUM = -5   // didn't withdraw enough
+};
+
+union LiquidityPoolWithdrawResult switch (
+    LiquidityPoolWithdrawResultCode code)
+{
+case LIQUIDITY_POOL_WITHDRAW_SUCCESS:
+    void;
+default:
+    void;
+};
+
 
 /* High level Operation Result */
 enum OperationResultCode
@@ -1406,6 +1480,8 @@ case opINNER:
         SetTrustLineFlagsResult setTrustLineFlagsResult;
     case LIQUIDITY_POOL_DEPOSIT:
         LiquidityPoolDepositResult liquidityPoolDepositResult;
+    case LIQUIDITY_POOL_WITHDRAW:
+        LiquidityPoolWithdrawResult liquidityPoolWithdrawResult;
     }
     tr;
 default:


### PR DESCRIPTION
There were some definitions missing from https://github.com/stellar/go/pull/3811 because I pulled the xdr files from the stellar core repo. The stellar core repo does not have the full changes from https://github.com/stellar/stellar-protocol/blob/master/core/cap-0038.md


For this PR, I have taken the XDR definitions from cap 38 directly.

fixes https://github.com/stellar/go/issues/3807