### PR TITLE
services/horizon: Reap in batches of 100k ledgers per second, to play nicely with others

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -7,6 +7,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 * The `--ingest` flag is set by default. If `--captive-core-config-path` is not set, the config file is generated based on network passhprase. ([3783](https://github.com/stellar/go/pull/3783))
 * Add a feature flag `--captive-core-reuse-storage-path`/`CAPTIVE_CORE_REUSE_STORAGE_PATH` that will reuse Captive Core's storage path for bucket files when applicable for better performance ([3750](https://github.com/stellar/go/pull/3750)).
+* Limit reap to 100k ledgers/second, to prevent excess CPU usage ([3823](https://github.com/stellar/go/pull/3823)).
 
 ## v2.6.1
 

--- a/services/horizon/internal/reap/system.go
+++ b/services/horizon/internal/reap/system.go
@@ -70,28 +70,49 @@ func (r *System) runOnce(ctx context.Context) {
 	}
 }
 
+// Work backwards in 100k ledger blocks to prevent using all the CPU.
+//
+// This runs every hour, so we need to make sure it doesn't
+// run for longer than an hour.
+//
+// Current ledger at 2021-08-12 is 36,827,497, so 100k means 368 batches. At 1
+// batch/second, that seems like a reasonable balance between running well
+// under an hour, and slowing it down enough to leave some CPU for other
+// processes.
+var batchSize = int32(100_000)
+var sleep = 1 * time.Second
+
 func (r *System) clearBefore(ctx context.Context, seq int32) error {
 	log.WithField("new_elder", seq).Info("reaper: clearing")
 
-	start, end, err := toid.LedgerRangeInclusive(1, seq-1)
-	if err != nil {
-		return err
-	}
+	for endSeq := seq - 1; endSeq >= 1; endSeq -= batchSize {
+		startSeq := endSeq - batchSize
+		if startSeq < 1 {
+			startSeq = 1
+		}
 
-	err = r.HistoryQ.Begin()
-	if err != nil {
-		return errors.Wrap(err, "Error in begin")
-	}
-	defer r.HistoryQ.Rollback()
+		start, end, err := toid.LedgerRangeInclusive(startSeq, endSeq)
+		if err != nil {
+			return err
+		}
 
-	err = r.HistoryQ.DeleteRangeAll(ctx, start, end)
-	if err != nil {
-		return errors.Wrap(err, "Error in DeleteRangeAll")
-	}
+		err = r.HistoryQ.Begin()
+		if err != nil {
+			return errors.Wrap(err, "Error in begin")
+		}
+		defer r.HistoryQ.Rollback()
 
-	err = r.HistoryQ.Commit()
-	if err != nil {
-		return errors.Wrap(err, "Error in commit")
+		err = r.HistoryQ.DeleteRangeAll(ctx, start, end)
+		if err != nil {
+			return errors.Wrap(err, "Error in DeleteRangeAll")
+		}
+
+		err = r.HistoryQ.Commit()
+		if err != nil {
+			return errors.Wrap(err, "Error in commit")
+		}
+
+		time.Sleep(sleep)
 	}
 
 	return nil

--- a/services/horizon/internal/reap/system.go
+++ b/services/horizon/internal/reap/system.go
@@ -26,7 +26,7 @@ func (r *System) DeleteUnretainedHistory(ctx context.Context) error {
 		return nil
 	}
 
-	err := r.clearBefore(ctx, targetElder)
+	err := r.clearBefore(ctx, latest.HistoryElder, targetElder)
 	if err != nil {
 		return err
 	}
@@ -82,16 +82,15 @@ func (r *System) runOnce(ctx context.Context) {
 var batchSize = int32(100_000)
 var sleep = 1 * time.Second
 
-func (r *System) clearBefore(ctx context.Context, seq int32) error {
-	log.WithField("new_elder", seq).Info("reaper: clearing")
-
-	for endSeq := seq - 1; endSeq >= 1; endSeq -= batchSize {
-		startSeq := endSeq - batchSize
-		if startSeq < 1 {
-			startSeq = 1
+func (r *System) clearBefore(ctx context.Context, startSeq, endSeq int32) error {
+	for batchEndSeq := endSeq - 1; batchEndSeq >= startSeq; batchEndSeq -= batchSize {
+		batchStartSeq := batchEndSeq - batchSize
+		if batchStartSeq < startSeq {
+			batchStartSeq = startSeq
 		}
+		log.WithField("start_ledger", batchStartSeq).WithField("end_ledger", batchEndSeq).Info("reaper: clearing")
 
-		start, end, err := toid.LedgerRangeInclusive(startSeq, endSeq)
+		batchStart, batchEnd, err := toid.LedgerRangeInclusive(batchStartSeq, batchEndSeq)
 		if err != nil {
 			return err
 		}
@@ -102,7 +101,7 @@ func (r *System) clearBefore(ctx context.Context, seq int32) error {
 		}
 		defer r.HistoryQ.Rollback()
 
-		err = r.HistoryQ.DeleteRangeAll(ctx, start, end)
+		err = r.HistoryQ.DeleteRangeAll(ctx, batchStart, batchEnd)
 		if err != nil {
 			return errors.Wrap(err, "Error in DeleteRangeAll")
 		}

--- a/services/horizon/internal/reap/system_test.go
+++ b/services/horizon/internal/reap/system_test.go
@@ -17,6 +17,9 @@ func TestDeleteUnretainedHistory(t *testing.T) {
 
 	sys := New(0, db, ledgerState)
 
+	// Disable sleeps for this.
+	sleep = 0
+
 	var (
 		prev int
 		cur  int


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Limit reaper to 100k ledgers/second..

### Why

This should keep it running well under an hour (370seconds currently), but stop it from using all available CPU, starving other processes.

Fixes #3819 

### Known limitations

- [x] TODO: Actually launch it, and see it work now.
