### PR TITLE
services/horizon: Add missing tx result codes

### DIFF
--- a/services/horizon/internal/codes/main.go
+++ b/services/horizon/internal/codes/main.go
@@ -271,6 +271,10 @@ func String(code interface{}) (string, error) {
 			return "op_not_required", nil
 		case xdr.AllowTrustResultCodeAllowTrustCantRevoke:
 			return "op_cant_revoke", nil
+		case xdr.AllowTrustResultCodeAllowTrustSelfNotAllowed:
+			return "op_self_not_allowed", nil
+		case xdr.AllowTrustResultCodeAllowTrustLowReserve:
+			return OpLowReserve, nil
 		}
 	case xdr.AccountMergeResultCode:
 		switch code {
@@ -288,6 +292,8 @@ func String(code interface{}) (string, error) {
 			return "op_seq_num_too_far", nil
 		case xdr.AccountMergeResultCodeAccountMergeDestFull:
 			return "op_dest_full", nil
+		case xdr.AccountMergeResultCodeAccountMergeIsSponsor:
+			return "op_is_sponsor", nil
 		}
 	case xdr.InflationResultCode:
 		switch code {
@@ -305,7 +311,7 @@ func String(code interface{}) (string, error) {
 		case xdr.ManageDataResultCodeManageDataNameNotFound:
 			return "op_data_name_not_found", nil
 		case xdr.ManageDataResultCodeManageDataLowReserve:
-			return "op_low_reserve", nil
+			return OpLowReserve, nil
 		case xdr.ManageDataResultCodeManageDataInvalidName:
 			return "op_data_invalid_name", nil
 		}
@@ -405,6 +411,8 @@ func String(code interface{}) (string, error) {
 			return OpLowReserve, nil
 		case xdr.RevokeSponsorshipResultCodeRevokeSponsorshipOnlyTransferable:
 			return "op_only_transferable", nil
+		case xdr.RevokeSponsorshipResultCodeRevokeSponsorshipMalformed:
+			return OpMalformed, nil
 		}
 	case xdr.ClawbackResultCode:
 		switch code {
@@ -442,6 +450,42 @@ func String(code interface{}) (string, error) {
 			return "op_cant_revoke", nil
 		case xdr.SetTrustLineFlagsResultCodeSetTrustLineFlagsInvalidState:
 			return "op_invalid_state", nil
+		case xdr.SetTrustLineFlagsResultCodeSetTrustLineFlagsLowReserve:
+			return OpLowReserve, nil
+		}
+	case xdr.LiquidityPoolDepositResultCode:
+		switch code {
+		case xdr.LiquidityPoolDepositResultCodeLiquidityPoolDepositSuccess:
+			return OpSuccess, nil
+		case xdr.LiquidityPoolDepositResultCodeLiquidityPoolDepositMalformed:
+			return OpMalformed, nil
+		case xdr.LiquidityPoolDepositResultCodeLiquidityPoolDepositNoTrust:
+			return OpNoTrust, nil
+		case xdr.LiquidityPoolDepositResultCodeLiquidityPoolDepositNotAuthorized:
+			return OpNotAuthorized, nil
+		case xdr.LiquidityPoolDepositResultCodeLiquidityPoolDepositUnderfunded:
+			return OpUnderfunded, nil
+		case xdr.LiquidityPoolDepositResultCodeLiquidityPoolDepositLineFull:
+			return OpLineFull, nil
+		case xdr.LiquidityPoolDepositResultCodeLiquidityPoolDepositBadPrice:
+			return "op_bad_price", nil
+		case xdr.LiquidityPoolDepositResultCodeLiquidityPoolDepositPoolFull:
+			return "op_pool_full", nil
+		}
+	case xdr.LiquidityPoolWithdrawResultCode:
+		switch code {
+		case xdr.LiquidityPoolWithdrawResultCodeLiquidityPoolWithdrawSuccess:
+			return OpSuccess, nil
+		case xdr.LiquidityPoolWithdrawResultCodeLiquidityPoolWithdrawMalformed:
+			return OpMalformed, nil
+		case xdr.LiquidityPoolWithdrawResultCodeLiquidityPoolWithdrawNoTrust:
+			return OpNoTrust, nil
+		case xdr.LiquidityPoolWithdrawResultCodeLiquidityPoolWithdrawUnderfunded:
+			return OpUnderfunded, nil
+		case xdr.LiquidityPoolWithdrawResultCodeLiquidityPoolWithdrawLineFull:
+			return OpLineFull, nil
+		case xdr.LiquidityPoolWithdrawResultCodeLiquidityPoolWithdrawUnderMinimum:
+			return "op_under_minimum", nil
 		}
 	}
 
@@ -503,6 +547,10 @@ func ForOperationResult(opr xdr.OperationResult) (string, error) {
 		ic = ir.MustClawbackClaimableBalanceResult().Code
 	case xdr.OperationTypeSetTrustLineFlags:
 		ic = ir.MustSetTrustLineFlagsResult().Code
+	case xdr.OperationTypeLiquidityPoolDeposit:
+		ic = ir.MustLiquidityPoolDepositResult().Code
+	case xdr.OperationTypeLiquidityPoolWithdraw:
+		ic = ir.MustLiquidityPoolWithdrawResult().Code
 	}
 
 	return String(ic)

--- a/services/horizon/internal/codes/main_test.go
+++ b/services/horizon/internal/codes/main_test.go
@@ -1,6 +1,8 @@
 package codes
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/stellar/go/xdr"
@@ -8,8 +10,6 @@ import (
 )
 
 func TestForOperationResultCoversForAllOpTypes(t *testing.T) {
-	// TODO remove skip after amm ingestion is complete
-	t.Skip()
 	for typ, s := range xdr.OperationTypeToStringMap {
 		result := xdr.OperationResult{
 			Code: xdr.OperationResultCodeOpInner,
@@ -23,6 +23,67 @@ func TestForOperationResultCoversForAllOpTypes(t *testing.T) {
 		// it must panic because the operation result is not set
 		assert.Panics(t, f, s)
 	}
+
+	// Check if all operations' codes are covered
+	resultTypes := map[xdr.OperationType]reflect.Type{
+		xdr.OperationTypeCreateAccount:                 reflect.TypeOf(xdr.CreateAccountResultCode(0)),
+		xdr.OperationTypePayment:                       reflect.TypeOf(xdr.PaymentResultCode(0)),
+		xdr.OperationTypePathPaymentStrictReceive:      reflect.TypeOf(xdr.PathPaymentStrictReceiveResultCode(0)),
+		xdr.OperationTypeManageSellOffer:               reflect.TypeOf(xdr.ManageSellOfferResultCode(0)),
+		xdr.OperationTypeCreatePassiveSellOffer:        reflect.TypeOf(xdr.ManageSellOfferResultCode(0)),
+		xdr.OperationTypeSetOptions:                    reflect.TypeOf(xdr.SetOptionsResultCode(0)),
+		xdr.OperationTypeChangeTrust:                   reflect.TypeOf(xdr.ChangeTrustResultCode(0)),
+		xdr.OperationTypeAllowTrust:                    reflect.TypeOf(xdr.AllowTrustResultCode(0)),
+		xdr.OperationTypeAccountMerge:                  reflect.TypeOf(xdr.AccountMergeResultCode(0)),
+		xdr.OperationTypeInflation:                     reflect.TypeOf(xdr.InflationResultCode(0)),
+		xdr.OperationTypeManageData:                    reflect.TypeOf(xdr.ManageDataResultCode(0)),
+		xdr.OperationTypeBumpSequence:                  reflect.TypeOf(xdr.BumpSequenceResultCode(0)),
+		xdr.OperationTypeManageBuyOffer:                reflect.TypeOf(xdr.ManageBuyOfferResultCode(0)),
+		xdr.OperationTypePathPaymentStrictSend:         reflect.TypeOf(xdr.PathPaymentStrictSendResultCode(0)),
+		xdr.OperationTypeCreateClaimableBalance:        reflect.TypeOf(xdr.CreateClaimableBalanceResultCode(0)),
+		xdr.OperationTypeClaimClaimableBalance:         reflect.TypeOf(xdr.ClaimClaimableBalanceResultCode(0)),
+		xdr.OperationTypeBeginSponsoringFutureReserves: reflect.TypeOf(xdr.BeginSponsoringFutureReservesResultCode(0)),
+		xdr.OperationTypeEndSponsoringFutureReserves:   reflect.TypeOf(xdr.EndSponsoringFutureReservesResultCode(0)),
+		xdr.OperationTypeRevokeSponsorship:             reflect.TypeOf(xdr.RevokeSponsorshipResultCode(0)),
+		xdr.OperationTypeClawback:                      reflect.TypeOf(xdr.ClawbackResultCode(0)),
+		xdr.OperationTypeClawbackClaimableBalance:      reflect.TypeOf(xdr.ClawbackClaimableBalanceResultCode(0)),
+		xdr.OperationTypeSetTrustLineFlags:             reflect.TypeOf(xdr.SetTrustLineFlagsResultCode(0)),
+		xdr.OperationTypeLiquidityPoolDeposit:          reflect.TypeOf(xdr.LiquidityPoolDepositResultCode(0)),
+		xdr.OperationTypeLiquidityPoolWithdraw:         reflect.TypeOf(xdr.LiquidityPoolWithdrawResultCode(0)),
+	}
+	// If this is not equal it means one or more result struct is missing in resultTypes map.
+	assert.Equal(t, len(xdr.OperationTypeToStringMap), len(resultTypes))
+
+	type validEnum interface {
+		ValidEnum(v int32) bool
+	}
+
+	for _, resultCode := range resultTypes {
+		integerCode := int32(0)
+		for {
+			// Create a new variable of result code type and set it to the current
+			// integer Code.
+			val := reflect.New(resultCode).Elem()
+			val.SetInt(int64(integerCode))
+
+			// Then check if integer value of the code is valid. If it's not, break.
+			// We exploit the fact that the code's integer values are a sequence:
+			// [0, -1, -2, ...].
+			iValue := val.Interface()
+			valid := iValue.(validEnum).ValidEnum(integerCode)
+			if !valid {
+				break
+			}
+
+			res, err := String(iValue)
+			if assert.NoError(t, err, fmt.Sprintf("type=%T code=%d not implemented", iValue, iValue)) {
+				// Ensure value is not empty even when implemented
+				assert.NotEmpty(t, res, fmt.Sprintf("type=%T code=%d empty", iValue, iValue))
+			}
+			integerCode--
+		}
+	}
+
 	// make sure the check works for an unknown operation type
 	result := xdr.OperationResult{
 		Code: xdr.OperationResultCodeOpInner,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

Added a new Protocol 18 and missing codes from previous protocol upgrade. Added a test to ensure return codes of all specific operation types are implemented.

Close #3858.