### PR TITLE
services/horizon: Update TestProtocol14StateVerifier to test LiquidityPoolEntry

### DIFF
--- a/services/horizon/internal/integration/state_verifier_test.go
+++ b/services/horizon/internal/integration/state_verifier_test.go
@@ -11,13 +11,16 @@ import (
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/ingest"
 	"github.com/stellar/go/services/horizon/internal/test/integration"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestProtocol14StateVerifier(t *testing.T) {
-	itest := integration.NewTest(t, protocol15Config)
+func TestStateVerifier(t *testing.T) {
+	itest := integration.NewTest(t, integration.Config{
+		ProtocolVersion: ingest.MaxSupportedProtocolVersion,
+	})
 
 	sponsored := keypair.MustRandom()
 	sponsoredSource := &txnbuild.SimpleAccount{
@@ -44,6 +47,19 @@ func TestProtocol14StateVerifier(t *testing.T) {
 			SourceAccount: sponsoredSource.AccountID,
 			Line:          txnbuild.CreditAsset{"ABCD", master.Address()}.MustToChangeTrustAsset(),
 			Limit:         txnbuild.MaxTrustlineLimit,
+		},
+		&txnbuild.ChangeTrust{
+			Line: txnbuild.LiquidityPoolShareChangeTrustAsset{
+				LiquidityPoolParameters: txnbuild.LiquidityPoolParameters{
+					AssetA: txnbuild.NativeAsset{},
+					AssetB: txnbuild.CreditAsset{
+						Code:   "ABCD",
+						Issuer: master.Address(),
+					},
+					Fee: 30,
+				},
+			},
+			Limit: txnbuild.MaxTrustlineLimit,
 		},
 		&txnbuild.ManageSellOffer{
 			SourceAccount: sponsoredSource.AccountID,

--- a/services/horizon/internal/integration/trade_aggregations_test.go
+++ b/services/horizon/internal/integration/trade_aggregations_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/ingest"
 	"github.com/stellar/go/services/horizon/internal/test/integration"
 	strtime "github.com/stellar/go/support/time"
 	"github.com/stellar/go/xdr"
@@ -14,7 +15,7 @@ import (
 )
 
 func TestTradeAggregations(t *testing.T) {
-	itest := integration.NewTest(t, protocol15Config)
+	itest := integration.NewTest(t, integration.Config{ProtocolVersion: ingest.MaxSupportedProtocolVersion})
 	ctx := context.Background()
 	historyQ := itest.Horizon().HistoryQ()
 

--- a/services/horizon/internal/integration/txsub_test.go
+++ b/services/horizon/internal/integration/txsub_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stellar/go/services/horizon/internal/ingest"
 	"github.com/stellar/go/services/horizon/internal/test/integration"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stretchr/testify/assert"
@@ -12,7 +13,7 @@ import (
 
 func TestTxsub(t *testing.T) {
 	tt := assert.New(t)
-	itest := integration.NewTest(t, integration.Config{ProtocolVersion: 17})
+	itest := integration.NewTest(t, integration.Config{ProtocolVersion: ingest.MaxSupportedProtocolVersion})
 	master := itest.Master()
 
 	// Sanity check: create 20 accounts and submit 2 txs from each of them as

--- a/services/horizon/internal/resourceadapter/operations_test.go
+++ b/services/horizon/internal/resourceadapter/operations_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestNewOperationAllTypesCovered(t *testing.T) {
+	// TODO remove skip after amm ingestion is complete
+	t.Skip()
 	for typ, s := range xdr.OperationTypeToStringMap {
 		row := history.Operation{
 			Type: xdr.OperationType(typ),

--- a/services/horizon/internal/resourceadapter/operations_test.go
+++ b/services/horizon/internal/resourceadapter/operations_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestNewOperationAllTypesCovered(t *testing.T) {
-	// TODO remove skip after amm ingestion is complete
-	t.Skip()
 	for typ, s := range xdr.OperationTypeToStringMap {
 		row := history.Operation{
 			Type: xdr.OperationType(typ),

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -32,7 +32,6 @@ import (
 
 const (
 	StandaloneNetworkPassphrase = "Standalone Network ; February 2017"
-	LatestProtocolVersion       = int32(18)
 	stellarCorePostgresPassword = "mysecretpassword"
 	adminPort                   = 6060
 	stellarCorePort             = 11626

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -32,6 +32,7 @@ import (
 
 const (
 	StandaloneNetworkPassphrase = "Standalone Network ; February 2017"
+	LatestProtocolVersion       = int32(18)
 	stellarCorePostgresPassword = "mysecretpassword"
 	adminPort                   = 6060
 	stellarCorePort             = 11626
@@ -45,7 +46,7 @@ var (
 
 type Config struct {
 	PostgresURL           string
-	ProtocolVersion       int32
+	ProtocolVersion       uint32
 	SkipContainerCreation bool
 	CoreDockerImage       string
 
@@ -421,7 +422,7 @@ func (i *Test) WaitForHorizon() {
 			continue
 		}
 
-		if root.CurrentProtocolVersion == i.config.ProtocolVersion {
+		if uint32(root.CurrentProtocolVersion) == i.config.ProtocolVersion {
 			i.t.Logf("Horizon protocol version matches... %v", root)
 			return
 		}

--- a/xdr/ledger_key.go
+++ b/xdr/ledger_key.go
@@ -173,6 +173,12 @@ func (key LedgerKey) MarshalBinaryCompress() ([]byte, error) {
 			return nil, err
 		}
 		m = append(m, cBalance...)
+	case LedgerEntryTypeLiquidityPool:
+		cBalance, err := key.LiquidityPool.LiquidityPoolId.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		m = append(m, cBalance...)
 	default:
 		panic("Unknown type")
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

Update `TestProtocol14StateVerifier` with Liquidity Pool entry to ensure state verifier works correctly. Rename `TestProtocol14StateVerifier` to `TestStateVerifier` and use the latest supported protocol version instead of 15.

Close #3839.