### PR TITLE
services/horizon: Allow filtering accounts by liquidity pool participation.

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -197,9 +197,11 @@ type AssetStatAccounts struct {
 	Unauthorized                    int32 `json:"unauthorized"`
 }
 
-// Balance represents an account's holdings for a single currency type
+// Balance represents an account's holdings for either a single currency type or
+// shares in a liquidity pool.
 type Balance struct {
 	Balance                           string `json:"balance"`
+	LiquidityPoolId                   string `json:"liquidity_pool_id,omitempty"`
 	Limit                             string `json:"limit,omitempty"`
 	BuyingLiabilities                 string `json:"buying_liabilities,omitempty"`
 	SellingLiabilities                string `json:"selling_liabilities,omitempty"`

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -11,8 +11,10 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 ### Add
 * Add a feature flag `--captive-core-reuse-storage-path`/`CAPTIVE_CORE_REUSE_STORAGE_PATH` that will reuse Captive Core's storage path for bucket files when applicable for better performance ([3750](https://github.com/stellar/go/pull/3750)).
 
-* Add the ability to filter accounts by their participation in a particular liquidity pool ([TODO](https://github.com/stellar/go/pull/TODO)).
+* Add the ability to filter accounts by their participation in a particular liquidity pool ([3873](https://github.com/stellar/go/pull/3873)).
 
+### Update
+* Include pool shares in account balances ([3873](https://github.com/stellar/go/pull/3873)).
 
 ## v2.6.1
 

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -5,8 +5,14 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-* The `--ingest` flag is set by default. If `--captive-core-config-path` is not set, the config file is generated based on network passhprase. ([3783](https://github.com/stellar/go/pull/3783))
+### Breaking
+* The `--ingest` flag is set by default. If `--captive-core-config-path` is not set, the config file is generated based on network passhprase ([3783](https://github.com/stellar/go/pull/3783)).
+
+### Add
 * Add a feature flag `--captive-core-reuse-storage-path`/`CAPTIVE_CORE_REUSE_STORAGE_PATH` that will reuse Captive Core's storage path for bucket files when applicable for better performance ([3750](https://github.com/stellar/go/pull/3750)).
+
+* Add the ability to filter accounts by their participation in a particular liquidity pool ([TODO](https://github.com/stellar/go/pull/TODO)).
+
 
 ## v2.6.1
 

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -84,7 +84,7 @@ var invalidAccountsParams = problem.P{
 	Type:   "invalid_accounts_params",
 	Title:  "Invalid Accounts Parameters",
 	Status: http.StatusBadRequest,
-	Detail: "Exactly one filter is required. Please ensure that you are including a signer, a sponsor, an asset, or a liquidity pool filter.",
+	Detail: "Exactly one filter is required. Please ensure that you are including a signer, sponsor, asset, or liquidity pool filter.",
 }
 
 // Validate runs custom validations.

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -69,9 +69,10 @@ func AccountInfo(ctx context.Context, hq *history.Q, addr string) (*protocol.Acc
 
 // AccountsQuery query struct for accounts end-point
 type AccountsQuery struct {
-	Signer      string `schema:"signer" valid:"accountID,optional"`
-	Sponsor     string `schema:"sponsor" valid:"accountID,optional"`
-	AssetFilter string `schema:"asset" valid:"asset,optional"`
+	Signer        string `schema:"signer" valid:"accountID,optional"`
+	Sponsor       string `schema:"sponsor" valid:"accountID,optional"`
+	AssetFilter   string `schema:"asset" valid:"asset,optional"`
+	LiquidityPool string `schema:"liquidity_pool" valid:"liquidity_pool,optional"`
 }
 
 // URITemplate returns a rfc6570 URI template the query struct
@@ -83,7 +84,7 @@ var invalidAccountsParams = problem.P{
 	Type:   "invalid_accounts_params",
 	Title:  "Invalid Accounts Parameters",
 	Status: http.StatusBadRequest,
-	Detail: "Exactly one filter is required. Please ensure that you are including a signer, an asset, or a sponsor filter.",
+	Detail: "Exactly one filter is required. Please ensure that you are including a signer, a sponsor, an asset, or a liquidity pool filter.",
 }
 
 // Validate runs custom validations.
@@ -155,6 +156,11 @@ func (handler GetAccountsHandler) GetResourcePage(
 		}
 	} else if len(qp.Signer) > 0 {
 		records, err = historyQ.AccountEntriesForSigner(ctx, qp.Signer, pq)
+		if err != nil {
+			return nil, errors.Wrap(err, "loading account records")
+		}
+	} else if len(qp.LiquidityPool) > 0 {
+		records, err = historyQ.AccountEntriesForLiquidityPool(ctx, qp.LiquidityPool, pq)
 		if err != nil {
 			return nil, errors.Wrap(err, "loading account records")
 		}

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -72,7 +72,7 @@ type AccountsQuery struct {
 	Signer        string `schema:"signer" valid:"accountID,optional"`
 	Sponsor       string `schema:"sponsor" valid:"accountID,optional"`
 	AssetFilter   string `schema:"asset" valid:"asset,optional"`
-	LiquidityPool string `schema:"liquidity_pool" valid:"liquidity_pool,optional"`
+	LiquidityPool string `schema:"liquidity_pool" valid:"sha256,optional"`
 }
 
 // URITemplate returns a rfc6570 URI template the query struct
@@ -161,7 +161,7 @@ func (handler GetAccountsHandler) GetResourcePage(
 			return nil, errors.Wrap(err, "loading account records")
 		}
 	} else if len(qp.LiquidityPool) > 0 {
-		records, err = historyQ.AccountEntriesForLiquidityPool(ctx, qp.LiquidityPool, pq)
+		records, err = historyQ.AccountsForLiquidityPool(ctx, qp.LiquidityPool, pq)
 		if err != nil {
 			return nil, errors.Wrap(err, "loading account records")
 		}

--- a/services/horizon/internal/actions/account.go
+++ b/services/horizon/internal/actions/account.go
@@ -125,7 +125,8 @@ type GetAccountsHandler struct {
 }
 
 // GetResourcePage returns a page containing the account records that have
-// `signer` as a signer or have a trustline to the given asset.
+// `signer` as a signer, `sponsor` as a sponsor, a trustline to the given
+// `asset`, or participate in a particular `liquidity_pool`.
 func (handler GetAccountsHandler) GetResourcePage(
 	w HeaderWriter,
 	r *http.Request,

--- a/services/horizon/internal/actions/account_test.go
+++ b/services/horizon/internal/actions/account_test.go
@@ -1,10 +1,11 @@
 package actions
 
 import (
-	"github.com/guregu/null"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/guregu/null"
 
 	"github.com/stretchr/testify/assert"
 
@@ -622,7 +623,7 @@ func TestGetAccountsHandlerInvalidParams(t *testing.T) {
 
 func TestAccountQueryURLTemplate(t *testing.T) {
 	tt := assert.New(t)
-	expected := "/accounts{?signer,sponsor,asset,cursor,limit,order}"
+	expected := "/accounts{?signer,sponsor,asset,liquidity_pool,cursor,limit,order}"
 	accountsQuery := AccountsQuery{}
 	tt.Equal(expected, accountsQuery.URITemplate())
 }

--- a/services/horizon/internal/actions_root_test.go
+++ b/services/horizon/internal/actions_root_test.go
@@ -47,7 +47,7 @@ func TestRootAction(t *testing.T) {
 		err = json.Unmarshal(w.Body.Bytes(), &actual)
 		ht.Require.NoError(err)
 		ht.Assert.Equal(
-			"http://localhost/accounts{?signer,sponsor,asset,cursor,limit,order}",
+			"http://localhost/accounts{?signer,sponsor,asset,liquidity_pool,cursor,limit,order}",
 			actual.Links.Accounts.Href,
 		)
 		ht.Assert.Equal(

--- a/services/horizon/internal/assets/main.go
+++ b/services/horizon/internal/assets/main.go
@@ -15,10 +15,9 @@ var ErrInvalidValue = errors.New("unknown asset type, cannot convert to string")
 // AssetTypeMap is the read-only (i.e. don't modify it) map from string names to
 // xdr.AssetType values
 var AssetTypeMap = map[string]xdr.AssetType{
-	"native":                xdr.AssetTypeAssetTypeNative,
-	"credit_alphanum4":      xdr.AssetTypeAssetTypeCreditAlphanum4,
-	"credit_alphanum12":     xdr.AssetTypeAssetTypeCreditAlphanum12,
-	"liquidity_pool_shares": xdr.AssetTypeAssetTypePoolShare,
+	"native":            xdr.AssetTypeAssetTypeNative,
+	"credit_alphanum4":  xdr.AssetTypeAssetTypeCreditAlphanum4,
+	"credit_alphanum12": xdr.AssetTypeAssetTypeCreditAlphanum12,
 }
 
 //Parse creates an asset from the provided strings.  See AssetTypeMap for valid strings for aType.

--- a/services/horizon/internal/assets/main.go
+++ b/services/horizon/internal/assets/main.go
@@ -7,17 +7,18 @@ import (
 )
 
 // ErrInvalidString gets returns when the string form of the asset type is invalid
-var ErrInvalidString = errors.New("invalid asset type: was not one of 'native', 'credit_alphanum4', 'credit_alphanum12'")
+var ErrInvalidString = errors.New("invalid asset type: was not one of 'native', 'credit_alphanum4', 'credit_alphanum12', 'liquidity_pool_shares'")
 
 //ErrInvalidValue gets returned when the xdr.AssetType int value is not one of the valid enum values
 var ErrInvalidValue = errors.New("unknown asset type, cannot convert to string")
 
-// AssetTypeMap is the read-only (i.e. don't modify it) map from string names to xdr.AssetType
-// values
+// AssetTypeMap is the read-only (i.e. don't modify it) map from string names to
+// xdr.AssetType values
 var AssetTypeMap = map[string]xdr.AssetType{
-	"native":            xdr.AssetTypeAssetTypeNative,
-	"credit_alphanum4":  xdr.AssetTypeAssetTypeCreditAlphanum4,
-	"credit_alphanum12": xdr.AssetTypeAssetTypeCreditAlphanum12,
+	"native":                xdr.AssetTypeAssetTypeNative,
+	"credit_alphanum4":      xdr.AssetTypeAssetTypeCreditAlphanum4,
+	"credit_alphanum12":     xdr.AssetTypeAssetTypeCreditAlphanum12,
+	"liquidity_pool_shares": xdr.AssetTypeAssetTypePoolShare,
 }
 
 //Parse creates an asset from the provided strings.  See AssetTypeMap for valid strings for aType.

--- a/services/horizon/internal/db2/history/accounts.go
+++ b/services/horizon/internal/db2/history/accounts.go
@@ -366,6 +366,11 @@ func (q *Q) AccountEntriesForSigner(ctx context.Context, signer string, page db2
 	return results, nil
 }
 
+// AccountEntriesForLiquidityPool returns a list of `AccountEntry` rows for a given liquidity pool ID.
+func (q *Q) AccountEntriesForLiquidityPool(ctx context.Context, poolId string, page db2.PageQuery) ([]AccountEntry, error) {
+	return nil, errors.New("filtering by liquidity pool is not implemented")
+}
+
 var selectAccounts = sq.Select(`
 	account_id,
 	balance,

--- a/services/horizon/internal/db2/history/accounts.go
+++ b/services/horizon/internal/db2/history/accounts.go
@@ -366,32 +366,6 @@ func (q *Q) AccountEntriesForSigner(ctx context.Context, signer string, page db2
 	return results, nil
 }
 
-// AccountEntriesForLiquidityPool returns a list of `AccountEntry` rows that
-// have trustlines established with a given liquidity pool ID.
-func (q *Q) AccountEntriesForLiquidityPool(ctx context.Context, poolId string, page db2.PageQuery) ([]AccountEntry, error) {
-	return nil, errors.New("filtering by liquidity pool is not implemented")
-
-	sql := sq.
-		Select("accounts.*").
-		From("accounts").
-		Join("trust_lines ON accounts.account_id = trust_lines.account_id").
-		Where(map[string]interface{}{
-			"trust_lines.liquidity_pool_id": poolId,
-		})
-
-	sql, err := page.ApplyToUsingCursor(sql, "trust_lines.liquidity_pool_id", page.Cursor)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not apply query to page")
-	}
-
-	var results []AccountEntry
-	if err := q.Select(ctx, &results, sql); err != nil {
-		return nil, errors.Wrap(err, "could not run select query")
-	}
-
-	return results, nil
-}
-
 var selectAccounts = sq.Select(`
 	account_id,
 	balance,

--- a/services/horizon/internal/resourceadapter/account_entry.go
+++ b/services/horizon/internal/resourceadapter/account_entry.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	protocol "github.com/stellar/go/protocols/horizon"
-	"github.com/stellar/go/services/horizon/internal/assets"
 	horizonContext "github.com/stellar/go/services/horizon/internal/context"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/errors"
@@ -51,19 +50,10 @@ func PopulateAccountEntry(
 		var err error
 
 		switch tl.AssetType {
-		case xdr.AssetTypeAssetTypeCreditAlphanum4:
-			fallthrough
-		case xdr.AssetTypeAssetTypeCreditAlphanum12:
-			err = PopulateAssetBalance(&dest.Balances[i], tl)
 		case xdr.AssetTypeAssetTypePoolShare:
 			err = PopulatePoolShareBalance(&dest.Balances[i], tl)
 		default:
-			assetType, innerErr := assets.String(tl.AssetType)
-			if innerErr != nil {
-				err = innerErr
-			} else {
-				err = errors.New("unknown asset in balance:" + assetType)
-			}
+			err = PopulateAssetBalance(&dest.Balances[i], tl)
 		}
 
 		if err != nil {

--- a/services/horizon/internal/resourceadapter/account_entry_test.go
+++ b/services/horizon/internal/resourceadapter/account_entry_test.go
@@ -3,10 +3,11 @@ package resourceadapter
 import (
 	"encoding/base64"
 	"encoding/json"
-	"github.com/guregu/null"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/guregu/null"
 
 	"github.com/stellar/go/amount"
 	. "github.com/stellar/go/protocols/horizon"
@@ -75,7 +76,7 @@ var (
 			AccountID:          accountID.Address(),
 			AssetCode:          "EUR",
 			AssetIssuer:        trustLineIssuer.Address(),
-			AssetType:          1,
+			AssetType:          xdr.AssetTypeAssetTypeCreditAlphanum4,
 			Balance:            20000,
 			Limit:              223456789,
 			Flags:              1,
@@ -85,14 +86,22 @@ var (
 		},
 		{
 			AccountID:          accountID.Address(),
-			AssetCode:          "USD",
+			AssetCode:          "USDDDDDDDDDD",
 			AssetIssuer:        trustLineIssuer.Address(),
-			AssetType:          1,
+			AssetType:          xdr.AssetTypeAssetTypeCreditAlphanum12,
 			Balance:            10000,
 			Limit:              123456789,
 			Flags:              0,
 			SellingLiabilities: 2,
 			BuyingLiabilities:  1,
+			LastModifiedLedger: 900,
+		},
+		{
+			AccountID:          accountID.Address(),
+			AssetType:          xdr.AssetTypeAssetTypePoolShare,
+			Balance:            10000,
+			Limit:              123456789,
+			Flags:              0,
 			LastModifiedLedger: 900,
 		},
 	}
@@ -166,7 +175,7 @@ func TestPopulateAccountEntry(t *testing.T) {
 		tt.Equal(d.Value, history.AccountDataValue(want))
 	}
 
-	tt.Len(hAccount.Balances, 3)
+	tt.Len(hAccount.Balances, 4)
 
 	for i, t := range trustLines {
 		ht := hAccount.Balances[i]

--- a/services/horizon/internal/resourceadapter/account_entry_test.go
+++ b/services/horizon/internal/resourceadapter/account_entry_test.go
@@ -181,8 +181,14 @@ func TestPopulateAccountEntry(t *testing.T) {
 		ht := hAccount.Balances[i]
 		tt.Equal(t.AssetIssuer, ht.Issuer)
 		tt.Equal(t.AssetCode, ht.Code)
-		wantType, e := assets.String(t.AssetType)
-		tt.NoError(e)
+		var wantType string
+		if t.AssetType == xdr.AssetTypeAssetTypePoolShare {
+			wantType = "liquidity_pool_shares"
+		} else {
+			var err error
+			wantType, err = assets.String(t.AssetType)
+			tt.NoError(err)
+		}
 		tt.Equal(wantType, ht.Type)
 
 		tt.Equal(amount.StringFromInt64(t.Balance), ht.Balance)

--- a/services/horizon/internal/resourceadapter/account_entry_test.go
+++ b/services/horizon/internal/resourceadapter/account_entry_test.go
@@ -185,7 +185,6 @@ func TestPopulateAccountEntry(t *testing.T) {
 		if t.AssetType == xdr.AssetTypeAssetTypePoolShare {
 			wantType = "liquidity_pool_shares"
 		} else {
-			var err error
 			wantType, err = assets.String(t.AssetType)
 			tt.NoError(err)
 		}

--- a/services/horizon/internal/resourceadapter/account_entry_test.go
+++ b/services/horizon/internal/resourceadapter/account_entry_test.go
@@ -186,8 +186,16 @@ func TestPopulateAccountEntry(t *testing.T) {
 		tt.Equal(wantType, ht.Type)
 
 		tt.Equal(amount.StringFromInt64(t.Balance), ht.Balance)
-		tt.Equal(amount.StringFromInt64(t.BuyingLiabilities), ht.BuyingLiabilities)
-		tt.Equal(amount.StringFromInt64(t.SellingLiabilities), ht.SellingLiabilities)
+		if t.BuyingLiabilities != 0 {
+			tt.Equal(amount.StringFromInt64(t.BuyingLiabilities), ht.BuyingLiabilities)
+		} else {
+			tt.Equal("", ht.BuyingLiabilities)
+		}
+		if t.SellingLiabilities != 0 {
+			tt.Equal(amount.StringFromInt64(t.SellingLiabilities), ht.SellingLiabilities)
+		} else {
+			tt.Equal("", ht.SellingLiabilities)
+		}
 		tt.Equal(amount.StringFromInt64(t.Limit), ht.Limit)
 		tt.Equal(t.LastModifiedLedger, ht.LastModifiedLedger)
 		tt.Equal(t.IsAuthorized(), *ht.IsAuthorized)

--- a/services/horizon/internal/resourceadapter/account_entry_test.go
+++ b/services/horizon/internal/resourceadapter/account_entry_test.go
@@ -186,16 +186,19 @@ func TestPopulateAccountEntry(t *testing.T) {
 		tt.Equal(wantType, ht.Type)
 
 		tt.Equal(amount.StringFromInt64(t.Balance), ht.Balance)
+
+		wantBuy := ""
 		if t.BuyingLiabilities != 0 {
-			tt.Equal(amount.StringFromInt64(t.BuyingLiabilities), ht.BuyingLiabilities)
-		} else {
-			tt.Equal("", ht.BuyingLiabilities)
+			wantBuy = amount.StringFromInt64(t.BuyingLiabilities)
 		}
+		tt.Equal(wantBuy, ht.BuyingLiabilities)
+
+		wantSell := ""
 		if t.SellingLiabilities != 0 {
-			tt.Equal(amount.StringFromInt64(t.SellingLiabilities), ht.SellingLiabilities)
-		} else {
-			tt.Equal("", ht.SellingLiabilities)
+			wantSell = amount.StringFromInt64(t.SellingLiabilities)
 		}
+		tt.Equal(wantSell, ht.SellingLiabilities)
+
 		tt.Equal(amount.StringFromInt64(t.Limit), ht.Limit)
 		tt.Equal(t.LastModifiedLedger, ht.LastModifiedLedger)
 		tt.Equal(t.IsAuthorized(), *ht.IsAuthorized)

--- a/services/horizon/internal/resourceadapter/balance.go
+++ b/services/horizon/internal/resourceadapter/balance.go
@@ -10,12 +10,17 @@ import (
 )
 
 func PopulatePoolShareBalance(dest *protocol.Balance, row history.TrustLine) (err error) {
-	dest.Type, err = assets.String(row.AssetType)
-	if err != nil {
-		return err
-	}
-	if dest.Type != "liquidity_pool_shares" {
-		return PopulateAssetBalance(dest, row)
+	if row.AssetType == xdr.AssetTypeAssetTypePoolShare {
+		dest.Type = "liquidity_pool_shares"
+	} else {
+		dest.Type, err = assets.String(row.AssetType)
+		if err != nil {
+			return err
+		}
+
+		if dest.Type != "liquidity_pool_shares" {
+			return PopulateAssetBalance(dest, row)
+		}
 	}
 
 	dest.Balance = amount.StringFromInt64(row.Balance)

--- a/services/horizon/internal/resourceadapter/balance.go
+++ b/services/horizon/internal/resourceadapter/balance.go
@@ -69,11 +69,15 @@ func PopulateNativeBalance(dest *protocol.Balance, stroops, buyingLiabilities, s
 func fillAuthorizationFlags(dest *protocol.Balance, row history.TrustLine) {
 	isAuthorized := row.IsAuthorized()
 	dest.IsAuthorized = &isAuthorized
+
+	// After CAP-18, isAuth => isAuthToMaintain, so the following code does this
+	// in a backwards compatible manner.
 	dest.IsAuthorizedToMaintainLiabilities = &isAuthorized
 	isAuthorizedToMaintainLiabilities := row.IsAuthorizedToMaintainLiabilities()
 	if isAuthorizedToMaintainLiabilities {
 		dest.IsAuthorizedToMaintainLiabilities = &isAuthorizedToMaintainLiabilities
 	}
+
 	isClawbackEnabled := row.IsClawbackEnabled()
 	if isClawbackEnabled {
 		dest.IsClawbackEnabled = &isClawbackEnabled

--- a/services/horizon/internal/resourceadapter/balance.go
+++ b/services/horizon/internal/resourceadapter/balance.go
@@ -9,10 +9,27 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-func PopulateBalance(dest *protocol.Balance, row history.TrustLine) (err error) {
+func PopulatePoolShareBalance(dest *protocol.Balance, row history.TrustLine) (err error) {
 	dest.Type, err = assets.String(row.AssetType)
 	if err != nil {
-		return errors.Wrap(err, "getting the string representation from the provided xdr asset type")
+		return err
+	}
+	if dest.Type != "liquidity_pool_shares" {
+		return PopulateAssetBalance(dest, row)
+	}
+
+	dest.Balance = amount.StringFromInt64(row.Balance)
+	dest.Limit = amount.StringFromInt64(row.Limit)
+	dest.LastModifiedLedger = row.LastModifiedLedger
+	fillAuthorizationFlags(dest, row)
+
+	return
+}
+
+func PopulateAssetBalance(dest *protocol.Balance, row history.TrustLine) (err error) {
+	dest.Type, err = assets.String(row.AssetType)
+	if err != nil {
+		return err
 	}
 
 	dest.Balance = amount.StringFromInt64(row.Balance)
@@ -22,20 +39,11 @@ func PopulateBalance(dest *protocol.Balance, row history.TrustLine) (err error) 
 	dest.Issuer = row.AssetIssuer
 	dest.Code = row.AssetCode
 	dest.LastModifiedLedger = row.LastModifiedLedger
-	isAuthorized := row.IsAuthorized()
-	dest.IsAuthorized = &isAuthorized
-	dest.IsAuthorizedToMaintainLiabilities = &isAuthorized
-	isAuthorizedToMaintainLiabilities := row.IsAuthorizedToMaintainLiabilities()
-	if isAuthorizedToMaintainLiabilities {
-		dest.IsAuthorizedToMaintainLiabilities = &isAuthorizedToMaintainLiabilities
-	}
-	isClawbackEnabled := row.IsClawbackEnabled()
-	if isClawbackEnabled {
-		dest.IsClawbackEnabled = &isClawbackEnabled
-	}
+	fillAuthorizationFlags(dest, row)
 	if row.Sponsor.Valid {
 		dest.Sponsor = row.Sponsor.String
 	}
+
 	return
 }
 
@@ -54,5 +62,20 @@ func PopulateNativeBalance(dest *protocol.Balance, stroops, buyingLiabilities, s
 	dest.Code = ""
 	dest.IsAuthorized = nil
 	dest.IsAuthorizedToMaintainLiabilities = nil
+	dest.IsClawbackEnabled = nil
 	return
+}
+
+func fillAuthorizationFlags(dest *protocol.Balance, row history.TrustLine) {
+	isAuthorized := row.IsAuthorized()
+	dest.IsAuthorized = &isAuthorized
+	dest.IsAuthorizedToMaintainLiabilities = &isAuthorized
+	isAuthorizedToMaintainLiabilities := row.IsAuthorizedToMaintainLiabilities()
+	if isAuthorizedToMaintainLiabilities {
+		dest.IsAuthorizedToMaintainLiabilities = &isAuthorizedToMaintainLiabilities
+	}
+	isClawbackEnabled := row.IsClawbackEnabled()
+	if isClawbackEnabled {
+		dest.IsClawbackEnabled = &isClawbackEnabled
+	}
 }

--- a/services/horizon/internal/resourceadapter/balance_test.go
+++ b/services/horizon/internal/resourceadapter/balance_test.go
@@ -39,9 +39,16 @@ func TestPopulateBalance(t *testing.T) {
 		Balance:     10,
 		Flags:       0,
 	}
+	poolshareTrustline := history.TrustLine{
+		AccountID: "testID",
+		AssetType: xdr.AssetTypeAssetTypePoolShare,
+		Limit:     100,
+		Balance:   10,
+		Flags:     0,
+	}
 
 	want := Balance{}
-	err := PopulateBalance(&want, authorizedTrustline)
+	err := PopulateAssetBalance(&want, authorizedTrustline)
 	assert.NoError(t, err)
 	assert.Equal(t, "credit_alphanum12", want.Type)
 	assert.Equal(t, "0.0000010", want.Balance)
@@ -52,7 +59,7 @@ func TestPopulateBalance(t *testing.T) {
 	assert.Equal(t, true, *want.IsAuthorizedToMaintainLiabilities)
 
 	want = Balance{}
-	err = PopulateBalance(&want, authorizedToMaintainLiabilitiesTrustline)
+	err = PopulateAssetBalance(&want, authorizedToMaintainLiabilitiesTrustline)
 	assert.NoError(t, err)
 	assert.Equal(t, "credit_alphanum12", want.Type)
 	assert.Equal(t, "0.0000010", want.Balance)
@@ -63,13 +70,24 @@ func TestPopulateBalance(t *testing.T) {
 	assert.Equal(t, true, *want.IsAuthorizedToMaintainLiabilities)
 
 	want = Balance{}
-	err = PopulateBalance(&want, unauthorizedTrustline)
+	err = PopulateAssetBalance(&want, unauthorizedTrustline)
 	assert.NoError(t, err)
 	assert.Equal(t, "credit_alphanum12", want.Type)
 	assert.Equal(t, "0.0000010", want.Balance)
 	assert.Equal(t, "0.0000100", want.Limit)
 	assert.Equal(t, "", want.Issuer)
 	assert.Equal(t, testAssetCode2, want.Code)
+	assert.Equal(t, false, *want.IsAuthorized)
+	assert.Equal(t, false, *want.IsAuthorizedToMaintainLiabilities)
+
+	want = Balance{}
+	err = PopulatePoolShareBalance(&want, poolshareTrustline)
+	assert.NoError(t, err)
+	assert.Equal(t, "liquidity_pool_shares", want.Type)
+	assert.Equal(t, "0.0000010", want.Balance)
+	assert.Equal(t, "0.0000100", want.Limit)
+	assert.Equal(t, "", want.Issuer)
+	assert.Equal(t, "", want.Code)
 	assert.Equal(t, false, *want.IsAuthorized)
 	assert.Equal(t, false, *want.IsAuthorizedToMaintainLiabilities)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
- Amends the API to include liquidity pool details in account balances.
- Allows only querying accounts participating in a particular liquidity pool (`GET /accounts?liquidity_pool=[...some id...]`).

### Why
Resolves #3832.

### Known limitations
Still needs to be tested, hence why it's in draft.
