### PR TITLE
services/horizon: Omit asset details on failed liquidity pools operations

### DIFF
--- a/protocols/horizon/base/main.go
+++ b/protocols/horizon/base/main.go
@@ -12,7 +12,8 @@ type Asset struct {
 }
 
 type AssetAmount struct {
-	Asset  string `json:"asset"`
+	// Asset may be empty when unknown (e.g. when used in the representation of operations whose transaction failed)
+	Asset  string `json:"asset,omitempty"`
 	Amount string `json:"amount"`
 }
 

--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -331,7 +331,7 @@ type LiquidityPoolDeposit struct {
 	MaxPrice          string             `json:"max_price"`
 	MaxPriceR         base.Price         `json:"max_price_r"`
 	ReservesDeposited []base.AssetAmount `json:"reserves_deposited"`
-	SharesReceived    string             `json:"shares_received"`
+	SharesReceived    string             `json:"shares_received,omitempty"`
 }
 
 // LiquidityPoolWithdraw is the json resource representing a single operation whose type is

--- a/services/horizon/internal/ingest/processors/effects_processor.go
+++ b/services/horizon/internal/ingest/processors/effects_processor.go
@@ -1192,7 +1192,7 @@ func (e *effectsWrapper) addLiquidityPoolRevokedEffect() error {
 	source := e.operation.SourceAccount()
 	lp, delta, err := e.operation.getLiquidityPoolAndProductDelta(nil)
 	if err != nil {
-		if err == errLiquidtyPoolChangeNotFound {
+		if err == errLiquidityPoolChangeNotFound {
 			// no revocation happened
 			return nil
 		}
@@ -1295,14 +1295,14 @@ func liquidityPoolDetails(lp *xdr.LiquidityPoolEntry) map[string]interface{} {
 		"type":             "constant_product",
 		"total_trustlines": strconv.FormatInt(int64(lp.Body.ConstantProduct.PoolSharesTrustLineCount), 10),
 		"total_shares":     amount.String(lp.Body.ConstantProduct.TotalPoolShares),
-		"reserves": []map[string]string{
+		"reserves": []base.AssetAmount{
 			{
-				"asset":  lp.Body.ConstantProduct.Params.AssetA.StringCanonical(),
-				"amount": amount.String(lp.Body.ConstantProduct.ReserveA),
+				lp.Body.ConstantProduct.Params.AssetA.StringCanonical(),
+				amount.String(lp.Body.ConstantProduct.ReserveA),
 			},
 			{
-				"asset":  lp.Body.ConstantProduct.Params.AssetB.StringCanonical(),
-				"amount": amount.String(lp.Body.ConstantProduct.ReserveB),
+				lp.Body.ConstantProduct.Params.AssetB.StringCanonical(),
+				amount.String(lp.Body.ConstantProduct.ReserveB),
 			},
 		},
 	}
@@ -1316,14 +1316,14 @@ func (e *effectsWrapper) addLiquidityPoolDepositEffect() error {
 	}
 	details := map[string]interface{}{
 		"liquidity_pool": liquidityPoolDetails(lp),
-		"reserves_deposited": []map[string]string{
+		"reserves_deposited": []base.AssetAmount{
 			{
-				"asset":  lp.Body.ConstantProduct.Params.AssetA.StringCanonical(),
-				"amount": amount.String(delta.ReserveA),
+				lp.Body.ConstantProduct.Params.AssetA.StringCanonical(),
+				amount.String(delta.ReserveA),
 			},
 			{
-				"asset":  lp.Body.ConstantProduct.Params.AssetB.StringCanonical(),
-				"amount": amount.String(delta.ReserveB),
+				lp.Body.ConstantProduct.Params.AssetB.StringCanonical(),
+				amount.String(delta.ReserveB),
 			},
 		},
 		"shares_received": amount.String(delta.TotalPoolShares),
@@ -1340,14 +1340,14 @@ func (e *effectsWrapper) addLiquidityPoolWithdrawEffect() error {
 	}
 	details := map[string]interface{}{
 		"liquidity_pool": liquidityPoolDetails(lp),
-		"reserves_received": []map[string]string{
+		"reserves_received": []base.AssetAmount{
 			{
-				"asset":  lp.Body.ConstantProduct.Params.AssetA.StringCanonical(),
-				"amount": amount.String(-delta.ReserveA),
+				lp.Body.ConstantProduct.Params.AssetA.StringCanonical(),
+				amount.String(-delta.ReserveA),
 			},
 			{
-				"asset":  lp.Body.ConstantProduct.Params.AssetB.StringCanonical(),
-				"amount": amount.String(-delta.ReserveB),
+				lp.Body.ConstantProduct.Params.AssetB.StringCanonical(),
+				amount.String(-delta.ReserveB),
 			},
 		},
 		"shares_redeemed": amount.String(-delta.TotalPoolShares),

--- a/services/horizon/internal/ingest/processors/effects_processor.go
+++ b/services/horizon/internal/ingest/processors/effects_processor.go
@@ -1297,12 +1297,12 @@ func liquidityPoolDetails(lp *xdr.LiquidityPoolEntry) map[string]interface{} {
 		"total_shares":     amount.String(lp.Body.ConstantProduct.TotalPoolShares),
 		"reserves": []base.AssetAmount{
 			{
-				lp.Body.ConstantProduct.Params.AssetA.StringCanonical(),
-				amount.String(lp.Body.ConstantProduct.ReserveA),
+				Asset:  lp.Body.ConstantProduct.Params.AssetA.StringCanonical(),
+				Amount: amount.String(lp.Body.ConstantProduct.ReserveA),
 			},
 			{
-				lp.Body.ConstantProduct.Params.AssetB.StringCanonical(),
-				amount.String(lp.Body.ConstantProduct.ReserveB),
+				Asset:  lp.Body.ConstantProduct.Params.AssetB.StringCanonical(),
+				Amount: amount.String(lp.Body.ConstantProduct.ReserveB),
 			},
 		},
 	}
@@ -1318,12 +1318,12 @@ func (e *effectsWrapper) addLiquidityPoolDepositEffect() error {
 		"liquidity_pool": liquidityPoolDetails(lp),
 		"reserves_deposited": []base.AssetAmount{
 			{
-				lp.Body.ConstantProduct.Params.AssetA.StringCanonical(),
-				amount.String(delta.ReserveA),
+				Asset:  lp.Body.ConstantProduct.Params.AssetA.StringCanonical(),
+				Amount: amount.String(delta.ReserveA),
 			},
 			{
-				lp.Body.ConstantProduct.Params.AssetB.StringCanonical(),
-				amount.String(delta.ReserveB),
+				Asset:  lp.Body.ConstantProduct.Params.AssetB.StringCanonical(),
+				Amount: amount.String(delta.ReserveB),
 			},
 		},
 		"shares_received": amount.String(delta.TotalPoolShares),
@@ -1342,12 +1342,12 @@ func (e *effectsWrapper) addLiquidityPoolWithdrawEffect() error {
 		"liquidity_pool": liquidityPoolDetails(lp),
 		"reserves_received": []base.AssetAmount{
 			{
-				lp.Body.ConstantProduct.Params.AssetA.StringCanonical(),
-				amount.String(-delta.ReserveA),
+				Asset:  lp.Body.ConstantProduct.Params.AssetA.StringCanonical(),
+				Amount: amount.String(-delta.ReserveA),
 			},
 			{
-				lp.Body.ConstantProduct.Params.AssetB.StringCanonical(),
-				amount.String(-delta.ReserveB),
+				Asset:  lp.Body.ConstantProduct.Params.AssetB.StringCanonical(),
+				Amount: amount.String(-delta.ReserveB),
 			},
 		},
 		"shares_redeemed": amount.String(-delta.TotalPoolShares),

--- a/services/horizon/internal/ingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/ingest/processors/effects_processor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/guregu/null"
+	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -2937,14 +2938,14 @@ func TestLiquidityPoolEffects(t *testing.T) {
 						"liquidity_pool": map[string]interface{}{
 							"fee_bp": uint32(20),
 							"id":     poolIDStr,
-							"reserves": []map[string]string{
+							"reserves": []base.AssetAmount{
 								{
-									"amount": "0.0000100",
-									"asset":  "USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+									"USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+									"0.0000100",
 								},
 								{
-									"amount": "0.0000200",
-									"asset":  "native",
+									"native",
+									"0.0000200",
 								},
 							},
 							"total_shares":     "0.0001000",
@@ -2994,28 +2995,28 @@ func TestLiquidityPoolEffects(t *testing.T) {
 						"liquidity_pool": map[string]interface{}{
 							"fee_bp": uint32(20),
 							"id":     poolIDStr,
-							"reserves": []map[string]string{
+							"reserves": []base.AssetAmount{
 								{
-									"amount": "0.0000160",
-									"asset":  "USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+									"USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+									"0.0000160",
 								},
 								{
-									"amount": "0.0000250",
-									"asset":  "native",
+									"native",
+									"0.0000250",
 								},
 							},
 							"total_shares":     "0.0001010",
 							"total_trustlines": "10",
 							"type":             "constant_product",
 						},
-						"reserves_deposited": []map[string]string{
+						"reserves_deposited": []base.AssetAmount{
 							{
-								"amount": "0.0000060",
-								"asset":  "USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+								"USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+								"0.0000060",
 							},
 							{
-								"amount": "0.0000050",
-								"asset":  "native",
+								"native",
+								"0.0000050",
 							},
 						},
 						"shares_received": "0.0000010",
@@ -3055,28 +3056,28 @@ func TestLiquidityPoolEffects(t *testing.T) {
 						"liquidity_pool": map[string]interface{}{
 							"fee_bp": uint32(20),
 							"id":     poolIDStr,
-							"reserves": []map[string]string{
+							"reserves": []base.AssetAmount{
 								{
-									"amount": "0.0000094",
-									"asset":  "USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+									"USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+									"0.0000094",
 								},
 								{
-									"amount": "0.0000189",
-									"asset":  "native",
+									"native",
+									"0.0000189",
 								},
 							},
 							"total_shares":     "0.0000990",
 							"total_trustlines": "10",
 							"type":             "constant_product",
 						},
-						"reserves_received": []map[string]string{
+						"reserves_received": []base.AssetAmount{
 							{
-								"amount": "0.0000006",
-								"asset":  "USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+								"USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+								"0.0000006",
 							},
 							{
-								"amount": "0.0000011",
-								"asset":  "native",
+								"native",
+								"0.0000011",
 							},
 						},
 						"shares_redeemed": "0.0000010",
@@ -3172,14 +3173,14 @@ func TestLiquidityPoolEffects(t *testing.T) {
 						"liquidity_pool": map[string]interface{}{
 							"fee_bp": uint32(20),
 							"id":     poolIDStr,
-							"reserves": []map[string]string{
+							"reserves": []base.AssetAmount{
 								{
-									"amount": "0.0000094",
-									"asset":  "USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+									"USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+									"0.0000094",
 								},
 								{
-									"amount": "0.0000189",
-									"asset":  "native",
+									"native",
+									"0.0000189",
 								},
 							},
 							"total_shares":     "0.0000990",
@@ -3365,14 +3366,14 @@ func TestLiquidityPoolEffects(t *testing.T) {
 						"liquidity_pool": map[string]interface{}{
 							"fee_bp": uint32(20),
 							"id":     poolIDStr,
-							"reserves": []map[string]string{
+							"reserves": []base.AssetAmount{
 								{
-									"amount": "0.0000100",
-									"asset":  "USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+									"USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+									"0.0000100",
 								},
 								{
-									"amount": "0.0000200",
-									"asset":  "native",
+									"native",
+									"0.0000200",
 								},
 							},
 							"total_shares":     "0.0001000",

--- a/services/horizon/internal/ingest/processors/operations_processor.go
+++ b/services/horizon/internal/ingest/processors/operations_processor.go
@@ -540,8 +540,8 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 			sharesReceived = delta.TotalPoolShares
 		}
 		details["reserves_max"] = []base.AssetAmount{
-			{assetA, amount.String(op.MaxAmountA)},
-			{assetB, amount.String(op.MaxAmountB)},
+			{Asset: assetA, Amount: amount.String(op.MaxAmountA)},
+			{Asset: assetB, Amount: amount.String(op.MaxAmountB)},
 		}
 		details["min_price"] = op.MinPrice.String()
 		details["min_price_r"] = map[string]interface{}{
@@ -554,8 +554,8 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 			"d": op.MaxPrice.D,
 		}
 		details["reserves_deposited"] = []base.AssetAmount{
-			{assetA, amount.String(depositedA)},
-			{assetB, amount.String(depositedB)},
+			{Asset: assetA, Amount: amount.String(depositedA)},
+			{Asset: assetB, Amount: amount.String(depositedB)},
 		}
 		details["shares_received"] = amount.String(sharesReceived)
 	case xdr.OperationTypeLiquidityPoolWithdraw:
@@ -576,13 +576,13 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 			receivedA, receivedB = -delta.ReserveA, -delta.ReserveB
 		}
 		details["reserves_min"] = []base.AssetAmount{
-			{assetA, amount.String(op.MinAmountA)},
-			{assetB, amount.String(op.MinAmountB)},
+			{Asset: assetA, Amount: amount.String(op.MinAmountA)},
+			{Asset: assetB, Amount: amount.String(op.MinAmountB)},
 		}
 		details["shares"] = amount.String(op.Amount)
 		details["reserves_received"] = []base.AssetAmount{
-			{assetA, amount.String(receivedA)},
-			{assetB, amount.String(receivedB)},
+			{Asset: assetA, Amount: amount.String(receivedA)},
+			{Asset: assetB, Amount: amount.String(receivedB)},
 		}
 
 	default:

--- a/services/horizon/internal/ingest/processors/operations_processor.go
+++ b/services/horizon/internal/ingest/processors/operations_processor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/guregu/null"
 	"github.com/stellar/go/amount"
 	"github.com/stellar/go/ingest"
+	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/toid"
 	"github.com/stellar/go/support/errors"
@@ -189,7 +190,7 @@ type liquidityPoolDelta struct {
 	TotalPoolShares xdr.Int64
 }
 
-var errLiquidtyPoolChangeNotFound = errors.New("liquidity pool change not found")
+var errLiquidityPoolChangeNotFound = errors.New("liquidity pool change not found")
 
 func (operation *transactionOperationWrapper) getLiquidityPoolAndProductDelta(lpID *xdr.PoolId) (*xdr.LiquidityPoolEntry, *liquidityPoolDelta, error) {
 	changes, err := operation.transaction.GetOperationChanges(operation.index)
@@ -237,7 +238,7 @@ func (operation *transactionOperationWrapper) getLiquidityPoolAndProductDelta(lp
 		return lp, delta, nil
 	}
 
-	return nil, nil, errLiquidtyPoolChangeNotFound
+	return nil, nil, errLiquidityPoolChangeNotFound
 }
 
 // OperationResult returns the operation's result record
@@ -522,19 +523,25 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 	case xdr.OperationTypeLiquidityPoolDeposit:
 		op := operation.operation.Body.MustLiquidityPoolDepositOp()
 		details["liquidity_pool_id"] = PoolIDToString(op.LiquidityPoolId)
-		lp, delta, err := operation.getLiquidityPoolAndProductDelta(&op.LiquidityPoolId)
-		if err != nil {
-			// TODO - discuss
-			if err == errLiquidtyPoolChangeNotFound {
-				return nil, nil
+		var (
+			assetA, assetB         string
+			depositedA, depositedB xdr.Int64
+			sharesReceived         xdr.Int64
+		)
+		if operation.transaction.Result.Successful() {
+			// we will use the defaults (omitted asset and 0 amounts) if the transaction failed
+			lp, delta, err := operation.getLiquidityPoolAndProductDelta(&op.LiquidityPoolId)
+			if err != nil {
+				return nil, err
 			}
-			return nil, err
+			params := lp.Body.ConstantProduct.Params
+			assetA, assetB = params.AssetA.StringCanonical(), params.AssetB.StringCanonical()
+			depositedA, depositedB = delta.ReserveA, delta.ReserveB
+			sharesReceived = delta.TotalPoolShares
 		}
-		assetA := lp.Body.ConstantProduct.Params.AssetA
-		assetB := lp.Body.ConstantProduct.Params.AssetB
-		details["reserves_max"] = []map[string]string{
-			{"asset": assetA.StringCanonical(), "amount": amount.String(op.MaxAmountA)},
-			{"asset": assetB.StringCanonical(), "amount": amount.String(op.MaxAmountB)},
+		details["reserves_max"] = []base.AssetAmount{
+			{assetA, amount.String(op.MaxAmountA)},
+			{assetB, amount.String(op.MaxAmountB)},
 		}
 		details["min_price"] = op.MinPrice.String()
 		details["min_price_r"] = map[string]interface{}{
@@ -546,38 +553,36 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 			"n": op.MaxPrice.N,
 			"d": op.MaxPrice.D,
 		}
-		if err != nil {
-			return nil, err
+		details["reserves_deposited"] = []base.AssetAmount{
+			{assetA, amount.String(depositedA)},
+			{assetB, amount.String(depositedB)},
 		}
-		details["reserves_deposited"] = []map[string]string{
-			{"asset": assetA.StringCanonical(), "amount": amount.String(delta.ReserveA)},
-			{"asset": assetB.StringCanonical(), "amount": amount.String(delta.ReserveB)},
-		}
-		details["shares_received"] = amount.String(delta.TotalPoolShares)
+		details["shares_received"] = amount.String(sharesReceived)
 	case xdr.OperationTypeLiquidityPoolWithdraw:
 		op := operation.operation.Body.MustLiquidityPoolWithdrawOp()
 		details["liquidity_pool_id"] = PoolIDToString(op.LiquidityPoolId)
-		lp, delta, err := operation.getLiquidityPoolAndProductDelta(&op.LiquidityPoolId)
-		if err != nil {
-			// TODO - discuss
-			if err == errLiquidtyPoolChangeNotFound {
-				return nil, nil
+		var (
+			assetA, assetB       string
+			receivedA, receivedB xdr.Int64
+		)
+		if operation.transaction.Result.Successful() {
+			// we will use the defaults (omitted asset and 0 amounts) if the transaction failed
+			lp, delta, err := operation.getLiquidityPoolAndProductDelta(&op.LiquidityPoolId)
+			if err != nil {
+				return nil, err
 			}
-			return nil, err
+			params := lp.Body.ConstantProduct.Params
+			assetA, assetB = params.AssetA.StringCanonical(), params.AssetB.StringCanonical()
+			receivedA, receivedB = -delta.ReserveA, -delta.ReserveB
 		}
-		assetA := lp.Body.ConstantProduct.Params.AssetA
-		assetB := lp.Body.ConstantProduct.Params.AssetB
-		details["reserves_min"] = []map[string]string{
-			{"asset": assetA.StringCanonical(), "amount": amount.String(op.MinAmountA)},
-			{"asset": assetB.StringCanonical(), "amount": amount.String(op.MinAmountB)},
+		details["reserves_min"] = []base.AssetAmount{
+			{assetA, amount.String(op.MinAmountA)},
+			{assetB, amount.String(op.MinAmountB)},
 		}
 		details["shares"] = amount.String(op.Amount)
-		if err != nil {
-			return nil, err
-		}
-		details["reserves_received"] = []map[string]string{
-			{"asset": assetA.StringCanonical(), "amount": amount.String(-delta.ReserveA)},
-			{"asset": assetB.StringCanonical(), "amount": amount.String(-delta.ReserveB)},
+		details["reserves_received"] = []base.AssetAmount{
+			{assetA, amount.String(receivedA)},
+			{assetB, amount.String(receivedB)},
 		}
 
 	default:


### PR DESCRIPTION
When a liquidity pool operation belongs to a failed transaction we
cannot easily retreive the liquidity pool (on failure, the transaction
metadata won't include liquidity pool changes). In fact, we may not be
able to retreive the liquitity pool at all (e.g. if the liquidity pool
id of the operation is incorrect and the transaction failed for that
reason).

Thus, we make the asset optional in the /operation API responses.

When an operation belongs to a failed transaction we omit the asset.
Also, we set the amount in `reserves_received`, `reserves_deposited`
and `shares_received` to 0, which is consistent with a failure (in
that case no shares nor or reserves change).

Closes #3869 