### PR TITLE
clients/horizonclient: allow Fund on other networks and rely on server to indicate support

### DIFF
--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+* The restriction that `Fund` can only be called on the DefaultTestNetClient has
+been removed. Any horizonclient.Client may now call Fund. Horizon instances not
+supporting Fund will error with a resource not found error.
+
 ## [v7.1.1](https://github.com/stellar/go/releases/tag/horizonclient-v7.1.1) - 2021-06-25
 
 * Added transaction and operation result codes to the horizonclient.Error string for easy glancing at string only errors for underlying cause.

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -575,11 +575,11 @@ func (c *Client) Trades(request TradeRequest) (tds hProtocol.TradesPage, err err
 // Fund creates a new account funded from friendbot. It only works on test networks. See
 // https://www.stellar.org/developers/guides/get-started/create-account.html for more information.
 func (c *Client) Fund(addr string) (tx hProtocol.Transaction, err error) {
-	if !c.isTestNet {
-		return tx, errors.New("can't fund account from friendbot on production network")
-	}
 	friendbotURL := fmt.Sprintf("%sfriendbot?addr=%s", c.fixHorizonURL(), addr)
 	err = c.sendGetRequest(friendbotURL, &tx)
+	if IsNotFoundError(err) {
+		return tx, errors.Wrap(err, "funding is only available on test networks and may not supported by "+c.fixHorizonURL())
+	}
 	return
 }
 

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -578,7 +578,7 @@ func (c *Client) Fund(addr string) (tx hProtocol.Transaction, err error) {
 	friendbotURL := fmt.Sprintf("%sfriendbot?addr=%s", c.fixHorizonURL(), addr)
 	err = c.sendGetRequest(friendbotURL, &tx)
 	if IsNotFoundError(err) {
-		return tx, errors.Wrap(err, "funding is only available on test networks and may not supported by "+c.fixHorizonURL())
+		return tx, errors.Wrap(err, "funding is only available on test networks and may not be supported by "+c.fixHorizonURL())
 	}
 	return
 }

--- a/clients/horizonclient/client_fund_test.go
+++ b/clients/horizonclient/client_fund_test.go
@@ -25,7 +25,6 @@ func TestFund(t *testing.T) {
 	client := &Client{
 		HorizonURL: "https://localhost/",
 		HTTP:       hmock,
-		isTestNet:  true,
 	}
 
 	hmock.On(
@@ -36,4 +35,27 @@ func TestFund(t *testing.T) {
 	tx, err := client.Fund("GBLPP2W3X3PJQXYMC7EFWM5G2QCZL7HTCTFNMONS4ITGAYJ3GNNZIQ4V")
 	assert.NoError(t, err)
 	assert.Equal(t, int32(8269), tx.Ledger)
+}
+
+func TestFund_notSupported(t *testing.T) {
+	friendbotFundResponse := `{
+  "type": "https://stellar.org/horizon-errors/not_found",
+  "title": "Resource Missing",
+  "status": 404,
+  "detail": "The resource at the url requested was not found.  This usually occurs for one of two reasons:  The url requested is not valid, or no data in our database could be found with the parameters provided."
+}`
+
+	hmock := httptest.NewClient()
+	client := &Client{
+		HorizonURL: "https://localhost/",
+		HTTP:       hmock,
+	}
+
+	hmock.On(
+		"GET",
+		"https://localhost/friendbot?addr=GBLPP2W3X3PJQXYMC7EFWM5G2QCZL7HTCTFNMONS4ITGAYJ3GNNZIQ4V",
+	).ReturnString(404, friendbotFundResponse)
+
+	_, err := client.Fund("GBLPP2W3X3PJQXYMC7EFWM5G2QCZL7HTCTFNMONS4ITGAYJ3GNNZIQ4V")
+	assert.EqualError(t, err, "funding is only available on test networks and may not supported by https://localhost/: horizon error: \"Resource Missing\" - check horizon.Error.Problem for more information")
 }

--- a/clients/horizonclient/client_fund_test.go
+++ b/clients/horizonclient/client_fund_test.go
@@ -57,5 +57,5 @@ func TestFund_notSupported(t *testing.T) {
 	).ReturnString(404, friendbotFundResponse)
 
 	_, err := client.Fund("GBLPP2W3X3PJQXYMC7EFWM5G2QCZL7HTCTFNMONS4ITGAYJ3GNNZIQ4V")
-	assert.EqualError(t, err, "funding is only available on test networks and may not supported by https://localhost/: horizon error: \"Resource Missing\" - check horizon.Error.Problem for more information")
+	assert.EqualError(t, err, "funding is only available on test networks and may not be supported by https://localhost/: horizon error: \"Resource Missing\" - check horizon.Error.Problem for more information")
 }

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -141,7 +141,6 @@ type Client struct {
 	// AppVersion is the version of the application using the horizonclient package
 	AppVersion     string
 	horizonTimeout time.Duration
-	isTestNet      bool
 
 	// clock is a Clock returning the current time.
 	clock *clock.Clock
@@ -215,7 +214,6 @@ var DefaultTestNetClient = &Client{
 	HorizonURL:     "https://horizon-testnet.stellar.org/",
 	HTTP:           http.DefaultClient,
 	horizonTimeout: HorizonTimeout,
-	isTestNet:      true,
 }
 
 // DefaultPublicNetClient is a default client to connect to public network.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Allow the `Fund` function to submit a fund request to any horizon instance, not just the instance defined by `horizonclient.DefaultTestNetClient`, and rely on the horizon instance responding with a 404 as an indicator that funding is not supported.

### Why

The only way to construct a `horizonclient.Client` that supports the `Fund` operation is to use and mutate the `horizonclient.DefaultTestNetClient`. This is unnecessarily restrictive because a developer may wish to use the `Fund` operation with a non-default client that they have constructed themselves, or they may wish to use the `Fund` operation with their own private or standalone test network.

### Known limitations

N/A
