### PR TITLE
txnbuild: implement encoding.Text{M,Unm}arshaler in Transaction, FeeBumpTransaction, GenericTransaction

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -7,7 +7,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * GenericTransaction, Transaction, and FeeBumpTransaction now implement
-* encoding.TextMarshaler and encoding.TextUnmarshaler.
+encoding.TextMarshaler and encoding.TextUnmarshaler.
 
 ## [v7.1.1](https://github.com/stellar/go/releases/tag/horizonclient-v7.1.1) - 2021-06-25
 

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -6,6 +6,9 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* GenericTransaction, Transaction, and FeeBumpTransaction now implement
+* encoding.TextMarshaler and encoding.TextUnmarshaler.
+
 ## [v7.1.1](https://github.com/stellar/go/releases/tag/horizonclient-v7.1.1) - 2021-06-25
 
 ### Bug Fixes

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -568,8 +568,8 @@ func (t *FeeBumpTransaction) Base64() (string, error) {
 	return marshallBase64(t.envelope, t.Signatures())
 }
 
-// NewGenericTransactionWithFeeBumpTransaction creates a GenericTransaction
-// containing the FeeBumpTransaction.
+// ToGenericTransaction creates a GenericTransaction containing the
+// FeeBumpTransaction.
 func (t *FeeBumpTransaction) ToGenericTransaction() *GenericTransaction {
 	return &GenericTransaction{feeBump: t}
 }

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -382,6 +382,11 @@ func (t *Transaction) Base64() (string, error) {
 	return marshallBase64(t.envelope, t.Signatures())
 }
 
+// ToGenericTransaction creates a GenericTransaction containing the Transaction.
+func (t *Transaction) ToGenericTransaction() *GenericTransaction {
+	return &GenericTransaction{simple: t}
+}
+
 // ClaimableBalanceID returns the claimable balance ID for the operation at the given index within the transaction.
 // given index (which should be a `CreateClaimableBalance` operation).
 func (t *Transaction) ClaimableBalanceID(operationIndex int) (string, error) {
@@ -563,6 +568,12 @@ func (t *FeeBumpTransaction) Base64() (string, error) {
 	return marshallBase64(t.envelope, t.Signatures())
 }
 
+// NewGenericTransactionWithFeeBumpTransaction creates a GenericTransaction
+// containing the FeeBumpTransaction.
+func (t *FeeBumpTransaction) ToGenericTransaction() *GenericTransaction {
+	return &GenericTransaction{feeBump: t}
+}
+
 // InnerTransaction returns the Transaction which is wrapped by
 // this FeeBumpTransaction instance.
 func (t *FeeBumpTransaction) InnerTransaction() *Transaction {
@@ -576,18 +587,6 @@ func (t *FeeBumpTransaction) InnerTransaction() *Transaction {
 type GenericTransaction struct {
 	simple  *Transaction
 	feeBump *FeeBumpTransaction
-}
-
-// NewGenericTransactionWithTransaction creates a GenericTransaction containing
-// the given Transaction.
-func NewGenericTransactionWithTransaction(tx *Transaction) *GenericTransaction {
-	return &GenericTransaction{simple: tx}
-}
-
-// NewGenericTransactionWithFeeBumpTransaction creates a GenericTransaction
-// containing the given FeeBumpTransaction.
-func NewGenericTransactionWithFeeBumpTransaction(fbtx *FeeBumpTransaction) *GenericTransaction {
-	return &GenericTransaction{feeBump: fbtx}
 }
 
 // Transaction unpacks the GenericTransaction instance into a Transaction.

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -189,6 +189,17 @@ func marshallBase64(e xdr.TransactionEnvelope, signatures []xdr.DecoratedSignatu
 	return base64.StdEncoding.EncodeToString(binary), nil
 }
 
+func marshallBase64Bytes(e xdr.TransactionEnvelope, signatures []xdr.DecoratedSignature) ([]byte, error) {
+	binary, err := marshallBinary(e, signatures)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get XDR bytestring")
+	}
+
+	encoded := make([]byte, base64.StdEncoding.EncodedLen(len(binary)))
+	base64.StdEncoding.Encode(encoded, binary)
+	return encoded, nil
+}
+
 // Transaction represents a Stellar transaction. See
 // https://www.stellar.org/developers/guides/concepts/transactions.html
 // A Transaction may be wrapped by a FeeBumpTransaction in which case
@@ -344,6 +355,26 @@ func (t *Transaction) ToXDR() xdr.TransactionEnvelope {
 // MarshalBinary returns the binary XDR representation of the transaction envelope.
 func (t *Transaction) MarshalBinary() ([]byte, error) {
 	return marshallBinary(t.envelope, t.Signatures())
+}
+
+// MarshalText returns the base64 XDR representation of the transaction envelope.
+func (t *Transaction) MarshalText() ([]byte, error) {
+	return marshallBase64Bytes(t.envelope, t.Signatures())
+}
+
+// UnmarshalText consumes into the value the base64 XDR representation of the
+// transaction envelope.
+func (t *Transaction) UnmarshalText(b []byte) error {
+	gtx, err := TransactionFromXDR(string(b))
+	if err != nil {
+		return err
+	}
+	tx, ok := gtx.Transaction()
+	if !ok {
+		return errors.New("transaction envelope unmarshaled into FeeBumpTransaction is not a fee bump transaction")
+	}
+	*t = *tx
+	return nil
 }
 
 // Base64 returns the base 64 XDR representation of the transaction envelope.
@@ -506,6 +537,27 @@ func (t *FeeBumpTransaction) MarshalBinary() ([]byte, error) {
 	return marshallBinary(t.envelope, t.Signatures())
 }
 
+// MarshalText returns the base64 XDR representation of the transaction
+// envelope.
+func (t *FeeBumpTransaction) MarshalText() ([]byte, error) {
+	return marshallBase64Bytes(t.envelope, t.Signatures())
+}
+
+// UnmarshalText consumes into the value the base64 XDR representation of the
+// transaction envelope.
+func (t *FeeBumpTransaction) UnmarshalText(b []byte) error {
+	gtx, err := TransactionFromXDR(string(b))
+	if err != nil {
+		return err
+	}
+	fbtx, ok := gtx.FeeBump()
+	if !ok {
+		return errors.New("transaction envelope unmarshaled into Transaction is not a transaction")
+	}
+	*t = *fbtx
+	return nil
+}
+
 // Base64 returns the base 64 XDR representation of the transaction envelope.
 func (t *FeeBumpTransaction) Base64() (string, error) {
 	return marshallBase64(t.envelope, t.Signatures())
@@ -526,6 +578,18 @@ type GenericTransaction struct {
 	feeBump *FeeBumpTransaction
 }
 
+// NewGenericTransactionWithTransaction creates a GenericTransaction containing
+// the given Transaction.
+func NewGenericTransactionWithTransaction(tx *Transaction) *GenericTransaction {
+	return &GenericTransaction{simple: tx}
+}
+
+// NewGenericTransactionWithFeeBumpTransaction creates a GenericTransaction
+// containing the given FeeBumpTransaction.
+func NewGenericTransactionWithFeeBumpTransaction(fbtx *FeeBumpTransaction) *GenericTransaction {
+	return &GenericTransaction{feeBump: fbtx}
+}
+
 // Transaction unpacks the GenericTransaction instance into a Transaction.
 // The function also returns a boolean which is true if the GenericTransaction can be
 // unpacked into a Transaction.
@@ -538,6 +602,29 @@ func (t GenericTransaction) Transaction() (*Transaction, bool) {
 // can be unpacked into a FeeBumpTransaction.
 func (t GenericTransaction) FeeBump() (*FeeBumpTransaction, bool) {
 	return t.feeBump, t.feeBump != nil
+}
+
+// MarshalText returns the base64 XDR representation of the transaction
+// envelope.
+func (t *GenericTransaction) MarshalText() ([]byte, error) {
+	if tx, ok := t.Transaction(); ok {
+		return tx.MarshalText()
+	}
+	if fbtx, ok := t.FeeBump(); ok {
+		return fbtx.MarshalText()
+	}
+	return nil, errors.New("unable to marshal empty GenericTransaction")
+}
+
+// UnmarshalText consumes into the value the base64 XDR representation of the
+// transaction envelope.
+func (t *GenericTransaction) UnmarshalText(b []byte) error {
+	gtx, err := TransactionFromXDR(string(b))
+	if err != nil {
+		return err
+	}
+	*t = *gtx
+	return nil
 }
 
 type TransactionFromXDROption int

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -4518,7 +4518,7 @@ func TestGenericTransaction_marshalUnmarshalText(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("tx base64:", txb64)
 
-	gtx = NewGenericTransactionWithTransaction(tx)
+	gtx = tx.ToGenericTransaction()
 	marshaled, err := gtx.MarshalText()
 	require.NoError(t, err)
 	t.Log("tx marshaled text:", string(marshaled))
@@ -4539,11 +4539,11 @@ func TestGenericTransaction_marshalUnmarshalText(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("fbtx base64:", fbtxb64)
 
-	fbgtx := NewGenericTransactionWithTransaction(tx)
+	fbgtx := fbtx.ToGenericTransaction()
 	marshaled, err = fbgtx.MarshalText()
 	require.NoError(t, err)
 	t.Log("fbtx marshaled text:", string(marshaled))
-	assert.Equal(t, txb64, string(marshaled))
+	assert.Equal(t, fbtxb64, string(marshaled))
 	fbgtx2 := &GenericTransaction{}
 	err = fbgtx2.UnmarshalText(marshaled)
 	require.NoError(t, err)

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -4417,3 +4417,135 @@ func TestClaimableBalanceIds(t *testing.T) {
 
 	assert.Equal(t, actualBalanceId, calculatedBalanceId)
 }
+
+func TestTransaction_marshalUnmarshalText(t *testing.T) {
+	k := keypair.MustRandom()
+
+	tx, err := NewTransaction(
+		TransactionParams{
+			SourceAccount:        &SimpleAccount{AccountID: k.Address(), Sequence: 1},
+			IncrementSequenceNum: false,
+			BaseFee:              MinBaseFee,
+			Timebounds:           NewInfiniteTimeout(),
+			Operations:           []Operation{&BumpSequence{BumpTo: 2}},
+		},
+	)
+	assert.NoError(t, err)
+	tx, err = tx.Sign(network.TestNetworkPassphrase, k)
+	assert.NoError(t, err)
+
+	b64, err := tx.Base64()
+	require.NoError(t, err)
+	t.Log("tx base64:", b64)
+
+	marshaled, err := tx.MarshalText()
+	require.NoError(t, err)
+	t.Log("tx marshaled text:", string(marshaled))
+	assert.Equal(t, b64, string(marshaled))
+
+	tx2 := &Transaction{}
+	err = tx2.UnmarshalText(marshaled)
+	require.NoError(t, err)
+	assert.Equal(t, tx, tx2)
+
+	err = (&FeeBumpTransaction{}).UnmarshalText(marshaled)
+	assert.EqualError(t, err, "transaction envelope unmarshaled into Transaction is not a transaction")
+}
+
+func TestFeeBumpTransaction_marshalUnmarshalText(t *testing.T) {
+	k := keypair.MustRandom()
+
+	tx, err := NewTransaction(
+		TransactionParams{
+			SourceAccount:        &SimpleAccount{AccountID: k.Address(), Sequence: 1},
+			IncrementSequenceNum: false,
+			BaseFee:              MinBaseFee,
+			Timebounds:           NewInfiniteTimeout(),
+			Operations:           []Operation{&BumpSequence{BumpTo: 2}},
+		},
+	)
+	require.NoError(t, err)
+	tx, err = tx.Sign(network.TestNetworkPassphrase, k)
+	require.NoError(t, err)
+
+	fbtx, err := NewFeeBumpTransaction(FeeBumpTransactionParams{
+		Inner:      tx,
+		FeeAccount: k.Address(),
+		BaseFee:    MinBaseFee,
+	})
+	require.NoError(t, err)
+
+	b64, err := fbtx.Base64()
+	require.NoError(t, err)
+	t.Log("tx base64:", b64)
+
+	marshaled, err := fbtx.MarshalText()
+	require.NoError(t, err)
+	t.Log("tx marshaled text:", string(marshaled))
+	assert.Equal(t, b64, string(marshaled))
+
+	fbtx2 := &FeeBumpTransaction{}
+	err = fbtx2.UnmarshalText(marshaled)
+	require.NoError(t, err)
+	assert.Equal(t, fbtx, fbtx2)
+
+	err = (&Transaction{}).UnmarshalText(marshaled)
+	assert.EqualError(t, err, "transaction envelope unmarshaled into FeeBumpTransaction is not a fee bump transaction")
+}
+
+func TestGenericTransaction_marshalUnmarshalText(t *testing.T) {
+	k := keypair.MustRandom()
+
+	// GenericTransaction containing nothing.
+	gtx := &GenericTransaction{}
+	_, err := gtx.MarshalText()
+	assert.EqualError(t, err, "unable to marshal empty GenericTransaction")
+
+	// GenericTransaction containing a Transaction.
+	tx, err := NewTransaction(
+		TransactionParams{
+			SourceAccount:        &SimpleAccount{AccountID: k.Address(), Sequence: 1},
+			IncrementSequenceNum: false,
+			BaseFee:              MinBaseFee,
+			Timebounds:           NewInfiniteTimeout(),
+			Operations:           []Operation{&BumpSequence{BumpTo: 2}},
+		},
+	)
+	require.NoError(t, err)
+	tx, err = tx.Sign(network.TestNetworkPassphrase, k)
+	require.NoError(t, err)
+	txb64, err := tx.Base64()
+	require.NoError(t, err)
+	t.Log("tx base64:", txb64)
+
+	gtx = NewGenericTransactionWithTransaction(tx)
+	marshaled, err := gtx.MarshalText()
+	require.NoError(t, err)
+	t.Log("tx marshaled text:", string(marshaled))
+	assert.Equal(t, txb64, string(marshaled))
+	gtx2 := &GenericTransaction{}
+	err = gtx2.UnmarshalText(marshaled)
+	require.NoError(t, err)
+	assert.Equal(t, gtx, gtx2)
+
+	// GenericTransaction containing a FeeBumpTransaction.
+	fbtx, err := NewFeeBumpTransaction(FeeBumpTransactionParams{
+		Inner:      tx,
+		FeeAccount: k.Address(),
+		BaseFee:    MinBaseFee,
+	})
+	require.NoError(t, err)
+	fbtxb64, err := fbtx.Base64()
+	require.NoError(t, err)
+	t.Log("fbtx base64:", fbtxb64)
+
+	fbgtx := NewGenericTransactionWithTransaction(tx)
+	marshaled, err = fbgtx.MarshalText()
+	require.NoError(t, err)
+	t.Log("fbtx marshaled text:", string(marshaled))
+	assert.Equal(t, txb64, string(marshaled))
+	fbgtx2 := &GenericTransaction{}
+	err = fbgtx2.UnmarshalText(marshaled)
+	require.NoError(t, err)
+	assert.Equal(t, fbgtx, fbgtx2)
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Implement `encoding.TextMarshaler` and `encoding.TextUnmarshaler` in `Transaction`, `FeeBumpTransaction`, `GenericTransaction`.

### Why

Transaction, FeeBumpTransaction, and GenericTransaction all have well defined formats for serialization as strings. It would be convenient if these types were automatically serializable via encoders such as the `encoding/json` package.

Constructors for GenericTransaction are added so that code building Transaction and FeeBumpTransaction can get a GenericTransaction for those built transactions, for setting in a field that can hold both, in a type supporting serialization.

### Known limitations

N/A