### PR TITLE
services/horizon: Split App.UpdateLedgerState into Core and Horizon ledger update methods

### DIFF
--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -206,7 +206,7 @@ var dbReapCmd = &cobra.Command{
 			return err
 		}
 		ctx := context.Background()
-		app.UpdateLedgerState(ctx)
+		app.UpdateHorizonLedgerState(ctx)
 		return app.DeleteUnretainedHistory(ctx)
 	},
 }

--- a/services/horizon/internal/actions_root_test.go
+++ b/services/horizon/internal/actions_root_test.go
@@ -30,7 +30,8 @@ func TestRootAction(t *testing.T) {
 	ht.App.config.StellarCoreURL = server.URL
 	ht.App.config.NetworkPassphrase = "test"
 	assert.NoError(t, ht.App.UpdateStellarCoreInfo(ht.Ctx))
-	ht.App.UpdateLedgerState(ht.Ctx)
+	ht.App.UpdateCoreLedgerState(ht.Ctx)
+	ht.App.UpdateHorizonLedgerState(ht.Ctx)
 
 	w := ht.Get("/")
 
@@ -95,7 +96,7 @@ func TestRootCoreClientInfoErrored(t *testing.T) {
 	defer server.Close()
 
 	ht.App.config.StellarCoreURL = server.URL
-	ht.App.UpdateLedgerState(ht.Ctx)
+	ht.App.UpdateCoreLedgerState(ht.Ctx)
 
 	w := ht.Get("/")
 

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -66,7 +66,7 @@ func (a *App) GetCoreState() corestate.State {
 }
 
 const tickerMaxFrequency = 1 * time.Second
-const tickerMaxDuration = 10 * time.Second
+const tickerMaxDuration = 5 * time.Second
 
 // NewApp constructs an new App instance from the provided config.
 func NewApp(config Config) (*App, error) {
@@ -208,10 +208,11 @@ func (a *App) HorizonSession() db.SessionInterface {
 	return a.historyQ.SessionInterface.Clone()
 }
 
-// UpdateLedgerState triggers a refresh of several metrics gauges, such as open
-// db connections and ledger state
-func (a *App) UpdateLedgerState(ctx context.Context) {
-	var next ledger.Status
+// UpdateCoreLedgerState triggers a refresh of Stellar-Core ledger state.
+// This is done separately from Horizon ledger state update to prevent issues
+// in case Stellar-Core query timeout.
+func (a *App) UpdateCoreLedgerState(ctx context.Context) {
+	var next ledger.CoreStatus
 
 	logErr := func(err error, msg string) {
 		log.WithStack(err).WithField("err", err.Error()).Error(msg)
@@ -228,7 +229,20 @@ func (a *App) UpdateLedgerState(ctx context.Context) {
 		return
 	}
 	next.CoreLatest = int32(coreInfo.Info.Ledger.Num)
+	a.ledgerState.SetCoreStatus(next)
+}
 
+// UpdateHorizonLedgerState triggers a refresh of Horizon ledger state.
+// This is done separately from Core ledger state update to prevent issues
+// in case Stellar-Core query timeout.
+func (a *App) UpdateHorizonLedgerState(ctx context.Context) {
+	var next ledger.HorizonStatus
+
+	logErr := func(err error, msg string) {
+		log.WithStack(err).WithField("err", err.Error()).Error(msg)
+	}
+
+	var err error
 	next.HistoryLatest, next.HistoryLatestClosedAt, err =
 		a.HistoryQ().LatestLedgerSequenceClosedAt(ctx)
 	if err != nil {
@@ -248,7 +262,7 @@ func (a *App) UpdateLedgerState(ctx context.Context) {
 		return
 	}
 
-	a.ledgerState.SetStatus(next)
+	a.ledgerState.SetHorizonStatus(next)
 }
 
 // UpdateFeeStatsState triggers a refresh of several operation fee metrics.
@@ -419,9 +433,10 @@ func (a *App) Tick(ctx context.Context) error {
 	log.Debug("ticking app")
 
 	// update ledger state, operation fee state, and stellar-core info in parallel
-	wg.Add(3)
+	wg.Add(4)
 	var err error
-	go func() { a.UpdateLedgerState(ctx); wg.Done() }()
+	go func() { a.UpdateCoreLedgerState(ctx); wg.Done() }()
+	go func() { a.UpdateHorizonLedgerState(ctx); wg.Done() }()
 	go func() { a.UpdateFeeStatsState(ctx); wg.Done() }()
 	go func() { err = a.UpdateStellarCoreInfo(ctx); wg.Done() }()
 	wg.Wait()

--- a/services/horizon/internal/httpt_test.go
+++ b/services/horizon/internal/httpt_test.go
@@ -42,7 +42,8 @@ func startHTTPTest(t *testing.T, scenario string) *HTTPT {
 	}`)
 
 	ret.App.config.StellarCoreURL = ret.coreServer.URL
-	ret.App.UpdateLedgerState(context.Background())
+	ret.App.UpdateCoreLedgerState(context.Background())
+	ret.App.UpdateHorizonLedgerState(context.Background())
 
 	return ret
 }
@@ -101,5 +102,6 @@ func (ht *HTTPT) ReapHistory(retention uint) {
 	ht.App.reaper.RetentionCount = retention
 	err := ht.App.DeleteUnretainedHistory(context.Background())
 	ht.Require.NoError(err)
-	ht.App.UpdateLedgerState(context.Background())
+	ht.App.UpdateCoreLedgerState(context.Background())
+	ht.App.UpdateHorizonLedgerState(context.Background())
 }

--- a/services/horizon/internal/ledger/ledger_source_test.go
+++ b/services/horizon/internal/ledger/ledger_source_test.go
@@ -8,7 +8,11 @@ import (
 func Test_HistoryDBLedgerSourceCurrentLedger(t *testing.T) {
 	state := &State{
 		RWMutex: sync.RWMutex{},
-		current: Status{ExpHistoryLatest: 3},
+		current: Status{
+			HorizonStatus: HorizonStatus{
+				ExpHistoryLatest: 3,
+			},
+		},
 	}
 
 	ledgerSource := HistoryDBSource{
@@ -25,7 +29,11 @@ func Test_HistoryDBLedgerSourceCurrentLedger(t *testing.T) {
 func Test_HistoryDBLedgerSourceNextLedger(t *testing.T) {
 	state := &State{
 		RWMutex: sync.RWMutex{},
-		current: Status{ExpHistoryLatest: 3},
+		current: Status{
+			HorizonStatus: HorizonStatus{
+				ExpHistoryLatest: 3,
+			},
+		},
 	}
 
 	ledgerSource := HistoryDBSource{

--- a/services/horizon/internal/ledger/main.go
+++ b/services/horizon/internal/ledger/main.go
@@ -13,7 +13,15 @@ import (
 // Status represents a snapshot of both horizon's and stellar-core's view of the
 // ledger.
 type Status struct {
-	CoreLatest            int32     `db:"core_latest"`
+	CoreStatus
+	HorizonStatus
+}
+
+type CoreStatus struct {
+	CoreLatest int32 `db:"core_latest"`
+}
+
+type HorizonStatus struct {
 	HistoryLatest         int32     `db:"history_latest"`
 	HistoryLatestClosedAt time.Time `db:"history_latest_closed_at"`
 	HistoryElder          int32     `db:"history_elder"`
@@ -40,4 +48,18 @@ func (c *State) SetStatus(next Status) {
 	c.Lock()
 	defer c.Unlock()
 	c.current = next
+}
+
+// SetCoreStatus updates the cached snapshot of the ledger state of Stellar-Core
+func (c *State) SetCoreStatus(next CoreStatus) {
+	c.Lock()
+	defer c.Unlock()
+	c.current.CoreStatus = next
+}
+
+// SetHorizonStatus updates the cached snapshot of the ledger state of Horizon
+func (c *State) SetHorizonStatus(next HorizonStatus) {
+	c.Lock()
+	defer c.Unlock()
+	c.current.HorizonStatus = next
 }

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -347,8 +347,12 @@ func TestCheckHistoryStaleMiddleware(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			state := ledger.Status{
-				CoreLatest:    testCase.coreLatest,
-				HistoryLatest: testCase.historyLatest,
+				CoreStatus: ledger.CoreStatus{
+					CoreLatest: testCase.coreLatest,
+				},
+				HorizonStatus: ledger.HorizonStatus{
+					HistoryLatest: testCase.historyLatest,
+				},
 			}
 			ledgerState := &ledger.State{}
 			ledgerState.SetStatus(state)

--- a/services/horizon/internal/resourceadapter/root_test.go
+++ b/services/horizon/internal/resourceadapter/root_test.go
@@ -22,7 +22,14 @@ func TestPopulateRoot(t *testing.T) {
 
 	PopulateRoot(context.Background(),
 		res,
-		ledger.Status{CoreLatest: 1, HistoryLatest: 3, HistoryElder: 2},
+		ledger.Status{
+			CoreStatus: ledger.CoreStatus{
+				CoreLatest: 1,
+			},
+			HorizonStatus: ledger.HorizonStatus{
+				HistoryLatest: 3, HistoryElder: 2,
+			},
+		},
 		"hVersion",
 		"cVersion",
 		"passphrase",
@@ -44,7 +51,14 @@ func TestPopulateRoot(t *testing.T) {
 	res = &horizon.Root{}
 	PopulateRoot(context.Background(),
 		res,
-		ledger.Status{CoreLatest: 1, HistoryLatest: 3, HistoryElder: 2},
+		ledger.Status{
+			CoreStatus: ledger.CoreStatus{
+				CoreLatest: 1,
+			},
+			HorizonStatus: ledger.HorizonStatus{
+				HistoryLatest: 3, HistoryElder: 2,
+			},
+		},
 		"hVersion",
 		"cVersion",
 		"passphrase",
@@ -65,7 +79,14 @@ func TestPopulateRoot(t *testing.T) {
 	res = &horizon.Root{}
 	PopulateRoot(context.Background(),
 		res,
-		ledger.Status{CoreLatest: 1, HistoryLatest: 3, HistoryElder: 2},
+		ledger.Status{
+			CoreStatus: ledger.CoreStatus{
+				CoreLatest: 1,
+			},
+			HorizonStatus: ledger.HorizonStatus{
+				HistoryLatest: 3, HistoryElder: 2,
+			},
+		},
 		"hVersion",
 		"cVersion",
 		"passphrase",


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit splits `UpdateLedgerState` into `UpdateCoreLedgerState` and `UpdateHorizonLedgerState` which update Core and Horizon ledger state separately. It also changes `Tick` frequency to 5 seconds.

Close #3883.

### Why

If Stellar-Core is unresponsive the call to Stellar-Core `/info` endpoint  will be cancelled after 10 seconds but it will also return entire `UpdateLedgerState` method. This will make Horizon ledgers stats out of date which can affect streaming (because streams are updated only when Horizon ledger in `ledger.Status` is incremented.

### Known limitations

With this change it's possible that Horizon root can report Core ledger sequence behind Horizon.