### PR TITLE
services/horizon: Fix verify-image issues

### DIFF
--- a/services/horizon/docker/verify-range/dependencies
+++ b/services/horizon/docker/verify-range/dependencies
@@ -10,8 +10,8 @@ echo "deb https://apt.stellar.org $(lsb_release -cs) stable" | sudo tee -a /etc/
 apt-get update
 apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
 
-wget https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz
-tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
+wget https://dl.google.com/go/go1.17.linux-amd64.tar.gz
+tar -C /usr/local -xzf go1.17.linux-amd64.tar.gz
 
 # configure postgres
 service postgresql start

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -67,7 +67,7 @@ git pull origin
 if [ ! -z "$BRANCH" ]; then
 	git checkout $BRANCH
 fi
-git log -1
+git log -1 --pretty=oneline
 
 function alter_tables_unlogged() {
 	# UNLOGGED for performance reasons (order is important because some tables reference others)


### PR DESCRIPTION
The commit message of https://github.com/stellar/go/commit/e011c915474e7d742c5840827eaee3c481f44adf was long enough to make `git log -1` command enable scrolling. This was causing `test_verify_range_docker_image` job failures because it got stuck at `git log -1` command waiting for user action.

I also noticed that the Golang version in the image does not match the one we use in other places. I changed it to Go 1.17.