### PR TITLE
Update docker image build timestamp format

### DIFF
--- a/exp/services/recoverysigner/Makefile
+++ b/exp/services/recoverysigner/Makefile
@@ -4,7 +4,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # If TAG is not provided set default value
 TAG ?= stellar/recoverysigner:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
+BUILD_DATE := $(shell date -u +%FT%TZ)
 
 docker-build:
 	cd ../../../ && \

--- a/exp/services/webauth/Makefile
+++ b/exp/services/webauth/Makefile
@@ -4,7 +4,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # If TAG is not provided set default value
 TAG ?= stellar/webauth:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
+BUILD_DATE := $(shell date -u +%FT%TZ)
 
 docker-build:
 	cd ../../../ && \

--- a/services/friendbot/Makefile
+++ b/services/friendbot/Makefile
@@ -4,7 +4,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # If TAG is not provided set default value
 TAG ?= stellar/friendbot:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
+BUILD_DATE := $(shell date -u  +%FT%TZ)
 
 docker-build:
 	cd ../../ && \

--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -1,7 +1,7 @@
 SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
+BUILD_DATE := $(shell date -u +%FT%TZ)
 
 TAG ?= stellar/stellar-horizon:$(VERSION)
 

--- a/services/keystore/Makefile
+++ b/services/keystore/Makefile
@@ -4,7 +4,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # If TAG is not provided set default value
 TAG ?= stellar/keystore:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
+BUILD_DATE := $(shell date -utc +%FT%TZ)
 
 docker-build:
 	cd ../../ && \

--- a/services/keystore/Makefile
+++ b/services/keystore/Makefile
@@ -4,7 +4,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # If TAG is not provided set default value
 TAG ?= stellar/keystore:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date -utc +%FT%TZ)
+BUILD_DATE := $(shell date -u +%FT%TZ)
 
 docker-build:
 	cd ../../ && \

--- a/services/regulated-assets-approval-server/Makefile
+++ b/services/regulated-assets-approval-server/Makefile
@@ -4,7 +4,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # If TAG is not provided set default value
 TAG ?= stellar/regulated-assets-approval-server:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
+BUILD_DATE := $(shell date -u +%FT%TZ)
 
 docker-build:
 	cd ../../ && \

--- a/services/ticker/Makefile
+++ b/services/ticker/Makefile
@@ -4,7 +4,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # If TAG is not provided set default value
 TAG ?= stellar/ticker:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
+BUILD_DATE := $(shell date -u +%FT%TZ)
 
 docker-build:
 	cd ../../ && \


### PR DESCRIPTION
Golang time parser is not compatible with format rendered by the GNU date,
even though both claim to be RFC3339. This change replaces space separator
between date and time with "T" which will allow golang to parse it.
It also switches from `--utc` to `-u` that's supported by both GNU and BSD
date commands.