### PR TITLE
.vscode: fix tasks file

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,9 +9,15 @@
     "options": {
         "cwd": "${workspaceRoot}"
     },
-    "tasks": [{
-        "taskName": "test all",
-        "isWatching": false,
-        "args": ["test", "./..."]
-    }]
+    "tasks": [
+        {
+            "label": "test all",
+            "type": "shell",
+            "args": [
+                "test",
+                "./..."
+            ],
+            "problemMatcher": []
+        }
+    ]
 }


### PR DESCRIPTION


### What

Format the VSCode tasks file.

### Why

When I open the stellar/go repo locally in the latest version of VSCode it displays a warning saying the file is "dirty". It appears the file is not formatted to how VSCode prefers it to be formatted. I don't really know what this file does or is for, but supposedly it was added because somebody uses it. This change resolves the warning.

### Known limitations

N/A